### PR TITLE
LuaAI

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -547,6 +547,8 @@ extern int Ai_firing_enabled;
 extern const char *Skill_level_names(int skill_level, int translate = 1);
 extern int Ai_goal_signature;
 
+extern control_info AI_ci;
+
 // need access to following data in AiBig.cpp
 extern object	*Pl_objp;
 extern object	*En_objp;

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -17,6 +17,7 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/systemvars.h"
 #include "object/waypoint.h"
+#include "parse/sexp.h"
 #include "physics/physics.h"
 #include "ship/ship_flags.h"
 
@@ -103,6 +104,8 @@ typedef struct ai_goal {
 		int	index;
 	} dockee;
 
+	object_ship_wing_point_team lua_ai_target;
+
 } ai_goal;
 
 #define	AIM_CHASE				0
@@ -127,8 +130,9 @@ typedef struct ai_goal {
 #define	AIM_SENTRYGUN			19		//  AI mode for sentry guns only (floating turrets)
 #define	AIM_WARP_OUT			20		//	Commence warp out sequence.  Point in legal direction.  Then call John's code.
 #define AIM_FLY_TO_SHIP			21		//  [Kazan] Fly to a ship, doesn't matter if it's hostile or friendly -- for Autopilot usage
+#define AIM_LUA					22		//  Generic Lua-based AI mode
 
-#define	MAX_AI_BEHAVIORS		22		//	Number of AIM_xxxx types
+#define	MAX_AI_BEHAVIORS		23		//	Number of AIM_xxxx types
 
 #define	MAX_WAYPOINTS_PER_LIST	20
 #define	MAX_ENEMY_DISTANCE	2500.0f		//	Maximum distance from which a ship will pursue an enemy.
@@ -498,6 +502,8 @@ typedef struct ai_info {
 
 	int multilock_check_timestamp;		// when to check for multilock next
 	SCP_vector<std::pair<int, ship_subsys*>> ai_missile_locks_firing;  // a list of missile locks (locked objnum, locked subsys) the ai is currently firing
+	
+	object_ship_wing_point_team lua_ai_target;
 } ai_info;
 
 // Goober5000

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12905,7 +12905,7 @@ void ai_maybe_evade_locked_missile(object *objp, ai_info *aip)
 				case AIM_WARP_OUT:
 					break;
 				default:
-					UNREACHABLE("Unknown AI Mode! Get a coder!");
+					UNREACHABLE("Unknown AI Mode %d! Get a coder!", aip->mode);
 					break;
 				}
 			}
@@ -12966,7 +12966,7 @@ void maybe_evade_dumbfire_weapon(ai_info *aip)
 	case AIM_LUA:
 		return;
 	default:
-		UNREACHABLE("Unknown AI Mode! Get a coder!");
+		UNREACHABLE("Unknown AI Mode %d! Get a coder!", aip->mode);
 		return;
 	}
 
@@ -13035,7 +13035,7 @@ void maybe_evade_dumbfire_weapon(ai_info *aip)
 		case AIM_LUA:
 			break;
 		default:
-			UNREACHABLE("Unknown AI Mode! Get a coder!");
+			UNREACHABLE("Unknown AI Mode %d! Get a coder!", aip->mode);
 		}
 	}
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15704,6 +15704,8 @@ void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal)
 	case AIM_WARP_OUT:
 		return;
 		break;
+	case AIM_LUA:
+		return;
 	default:
 		Int3();	//	Bogus mode!
 	}

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12900,11 +12900,12 @@ void ai_maybe_evade_locked_missile(object *objp, ai_info *aip)
 				case AIM_PLAY_DEAD:
 				case AIM_BAY_DEPART:
 				case AIM_SENTRYGUN:
+				case AIM_LUA:
 					break;
 				case AIM_WARP_OUT:
 					break;
 				default:
-					Int3();			//	Hey, what mode is it?
+					UNREACHABLE("Unknown AI Mode! Get a coder!");
 					break;
 				}
 			}
@@ -12965,7 +12966,7 @@ void maybe_evade_dumbfire_weapon(ai_info *aip)
 	case AIM_LUA:
 		return;
 	default:
-		Int3();	//	Bogus mode!
+		UNREACHABLE("Unknown AI Mode! Get a coder!");
 		return;
 	}
 
@@ -13034,7 +13035,7 @@ void maybe_evade_dumbfire_weapon(ai_info *aip)
 		case AIM_LUA:
 			break;
 		default:
-			Int3();	//	Bogus mode!
+			UNREACHABLE("Unknown AI Mode! Get a coder!");
 		}
 	}
 }
@@ -13621,7 +13622,7 @@ void ai_execute_behavior(ai_info *aip)
 		ai_lua(&Ships[Pl_objp->instance]);
 		break;
 	default:
-		Int3();		//	This should never happen -- MK, 5/12/97	
+		UNREACHABLE("Unknown AI Mode! Get a coder!");
 		break;
 	}
 
@@ -15707,7 +15708,7 @@ void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal)
 	case AIM_LUA:
 		return;
 	default:
-		Int3();	//	Bogus mode!
+		UNREACHABLE("Unknown AI Mode! Get a coder!");
 	}
 
 	if (timestamp_elapsed(aip->ok_to_target_timestamp)) {

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13619,7 +13619,7 @@ void ai_execute_behavior(ai_info *aip)
 		// properly until after 3.6.7 just to avoid delaying release or breaking something - taylor
 		break;
 	case AIM_LUA:
-		ai_lua(&Ships[Pl_objp->instance]);
+		ai_lua(aip);
 		break;
 	default:
 		UNREACHABLE("Unknown AI Mode! Get a coder!");

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -22,6 +22,7 @@
 #include "ai/aibig.h"
 #include "ai/aigoals.h"
 #include "ai/aiinternal.h"
+#include "ai/ailua.h"
 #include "asteroid/asteroid.h"
 #include "autopilot/autopilot.h"
 #include "cmeasure/cmeasure.h"
@@ -133,6 +134,8 @@ const char *Mode_text[MAX_AI_BEHAVIORS] = {
 	"BAY_DEPART",
 	"SENTRYGUN",
 	"WARP_OUT",
+	"FLY_TO_SHIP",
+	"LUA_AI"
 };
 
 //	Submode text is only valid for CHASE mode.
@@ -12959,6 +12962,7 @@ void maybe_evade_dumbfire_weapon(ai_info *aip)
 	case AIM_SENTRYGUN:
 	case AIM_WARP_OUT:
 	case AIM_FLY_TO_SHIP:
+	case AIM_LUA:
 		return;
 	default:
 		Int3();	//	Bogus mode!
@@ -13027,6 +13031,7 @@ void maybe_evade_dumbfire_weapon(ai_info *aip)
 		case AIM_BAY_EMERGE:
 		case AIM_BAY_DEPART:
 		case AIM_SENTRYGUN:
+		case AIM_LUA:
 			break;
 		default:
 			Int3();	//	Bogus mode!
@@ -13611,6 +13616,9 @@ void ai_execute_behavior(ai_info *aip)
 	case AIM_GET_BEHIND:
 		// FIXME: got this from TBP and added it here to skip the Int3() but don't really want to handle it
 		// properly until after 3.6.7 just to avoid delaying release or breaking something - taylor
+		break;
+	case AIM_LUA:
+		ai_lua(&Ships[Pl_objp->instance]);
 		break;
 	default:
 		Int3();		//	This should never happen -- MK, 5/12/97	

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -665,7 +665,7 @@ void ai_goal_fixup_dockpoints(ai_info *aip, ai_goal *aigp)
 // from the mission goals (i.e. those goals which come from events) in that we don't
 // use sexpressions for goals from the player...so we enumerate all the parameters
 
-void ai_add_goal_sub_player(int type, int mode, int submode, char *target_name, ai_goal *aigp, object_ship_wing_point_team lua_target )
+void ai_add_goal_sub_player(int type, int mode, int submode, char *target_name, ai_goal *aigp, const object_ship_wing_point_team& lua_target )
 {
 	Assert ( (type == AIG_TYPE_PLAYER_WING) || (type == AIG_TYPE_PLAYER_SHIP) );
 
@@ -673,7 +673,7 @@ void ai_add_goal_sub_player(int type, int mode, int submode, char *target_name, 
 	aigp->type = type;										// from player for sure -- could be to ship or to wing
 	aigp->ai_mode = mode;									// major mode for this goal
 	aigp->ai_submode = submode;								// could mean different things depending on mode
-	aigp->lua_ai_target = std::move(lua_target);
+	aigp->lua_ai_target = lua_target;
 
 	if ( mode == AI_GOAL_WARP ) {
 		if (submode >= 0) {
@@ -819,7 +819,7 @@ void ai_add_ship_goal_scripting(int mode, int submode, int priority, char *shipn
 // is issued to ship or wing (from player),  mode is AI_GOAL_*. submode is the submode the
 // ship should go into.  shipname is the object of the action.  aip is the ai_info pointer
 // of the ship receiving the order
-void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, ai_info *aip, object_ship_wing_point_team lua_target)
+void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, ai_info *aip, const object_ship_wing_point_team& lua_target)
 {
 	int empty_index;
 	ai_goal *aigp;
@@ -845,7 +845,7 @@ void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, a
 
 // adds a goal from the player to the given wing (which in turn will add it to the proper
 // ships in the wing
-void ai_add_wing_goal_player( int type, int mode, int submode, char *shipname, int wingnum, object_ship_wing_point_team lua_target)
+void ai_add_wing_goal_player( int type, int mode, int submode, char *shipname, int wingnum, const object_ship_wing_point_team& lua_target)
 {
 	int i, empty_index;
 	wing *wingp = &Wings[wingnum];

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -59,6 +59,7 @@ struct ai_goal;
 #define AI_GOAL_IGNORE_NEW				(1<<24)	// 0x01000000
 #define AI_GOAL_CHASE_SHIP_CLASS		(1<<25)	// 0x02000000
 #define AI_GOAL_PLAY_DEAD_PERSISTENT	(1<<26)	// 0x03000000
+#define AI_GOAL_LUA						(1<<27) // 0x04000000
 
 // now the masks for ship types
 

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -111,8 +111,8 @@ extern int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp );
 extern void ai_remove_wing_goal_sexp( int sexp, wing *wingp );
 
 // adds goals to ships/sings through player orders
-extern void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, ai_info *aip, object_ship_wing_point_team lua_target = object_ship_wing_point_team());
-extern void ai_add_wing_goal_player( int type, int mode, int submode, char *shipname, int wingnum, object_ship_wing_point_team lua_target = object_ship_wing_point_team());
+extern void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, ai_info *aip, const object_ship_wing_point_team& lua_target = object_ship_wing_point_team());
+extern void ai_add_wing_goal_player( int type, int mode, int submode, char *shipname, int wingnum, const object_ship_wing_point_team& lua_target = object_ship_wing_point_team());
 
 extern void ai_remove_ship_goal( ai_info *aip, int index );
 extern void ai_clear_ship_goals( ai_info *aip );

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -14,6 +14,7 @@
 
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
+#include "parse/sexp.h"
 
 struct wing;
 struct ai_info;
@@ -91,7 +92,7 @@ extern int Num_ai_goals;
 extern int Num_ai_dock_names;
 extern char Ai_dock_names[MAX_AI_DOCK_NAMES][NAME_LENGTH];
 
-extern const char *Ai_goal_text(int goal);
+extern const char *Ai_goal_text(int goal, int submode);
 
 // extern function definitions
 extern void ai_post_process_mission();
@@ -104,14 +105,14 @@ extern int ai_goal_num(ai_goal *goals);
 extern void ai_add_ship_goal_scripting(int mode, int submode, int priority, char *shipname, ai_info *aip);
 extern void ai_add_ship_goal_sexp( int sexp, int type, ai_info *aip );
 extern void ai_add_wing_goal_sexp( int sexp, int type, wing *wingp );
-extern void ai_add_goal_sub_sexp( int sexp, int type, ai_goal *aigp, char *actor_name );
+extern void ai_add_goal_sub_sexp( int sexp, int type, ai_goal *aigp, char *actor_name);
 
 extern int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp );
 extern void ai_remove_wing_goal_sexp( int sexp, wing *wingp );
 
 // adds goals to ships/sings through player orders
-extern void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, ai_info *aip );
-extern void ai_add_wing_goal_player( int type, int mode, int submode, char *shipname, int wingnum );
+extern void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, ai_info *aip, object_ship_wing_point_team lua_target = object_ship_wing_point_team());
+extern void ai_add_wing_goal_player( int type, int mode, int submode, char *shipname, int wingnum, object_ship_wing_point_team lua_target = object_ship_wing_point_team());
 
 extern void ai_remove_ship_goal( ai_info *aip, int index );
 extern void ai_clear_ship_goals( ai_info *aip );

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -87,27 +87,27 @@ void ai_lua(ai_info* aip){
 	}
 }
 
-void ai_lua_start(ai_goal* aip, object* objp){
+void ai_lua_start(ai_goal* aigp, object* objp){
 
 	Assert(objp->type == OBJ_SHIP);
 	Assert((objp->instance >= 0) && (objp->instance < MAX_SHIPS));
 
-	ai_info *aiip = &Ai_info[Ships[objp->instance].ai_index];
+	ai_info *aip = &Ai_info[Ships[objp->instance].ai_index];
 
-	aiip->mode = AIM_LUA;
-	aiip->submode = aip->ai_submode;
-	aiip->lua_ai_target = aip->lua_ai_target;
-	aiip->submode_start_time = Missiontime;
+	aip->mode = AIM_LUA;
+	aip->submode = aigp->ai_submode;
+	aip->lua_ai_target = aigp->lua_ai_target;
+	aip->submode_start_time = Missiontime;
 	
-	const auto& lua_ai = Lua_ai_modes.at(aip->ai_submode);
+	const auto& lua_ai = Lua_ai_modes.at(aigp->ai_submode);
 
-	auto dynamicSEXP = sexp::get_dynamic_sexp(aip->ai_submode);
+	auto dynamicSEXP = sexp::get_dynamic_sexp(aigp->ai_submode);
 
 	if (dynamicSEXP != nullptr && typeid(*dynamicSEXP) == typeid(sexp::LuaAISEXP)) {
 		auto lua_ai_sexp = static_cast<sexp::LuaAISEXP*>(dynamicSEXP);
 		const auto& action = lua_ai_sexp->getActionEnter();
 
-		run_ai_lua_action(action, lua_ai, aiip);
+		run_ai_lua_action(action, lua_ai, aip);
 	}
 	
 }

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -17,11 +17,11 @@ void ai_lua_add_mode(int sexp_op, const ai_mode_lua& mode) {
 }
 
 bool ai_lua_add_order(int sexp_op, player_order_lua order) {
-	if (current_highest_player_order_type == max_highest_player_order_type)
+	if (current_new_player_order_type == MAX_ENGINE_PLAYER_ORDER)
 		return false;
 
-	current_highest_player_order_type = current_highest_player_order_type << 1;
-	Player_orders.emplace_back(vm_strdup(order.parseText.c_str()), vm_strdup(order.displayText.c_str()), -1, current_highest_player_order_type, sexp_op);
+	current_new_player_order_type = current_new_player_order_type >> 1;
+	Player_orders.emplace_back(vm_strdup(order.parseText.c_str()), vm_strdup(order.displayText.c_str()), -1, current_new_player_order_type, sexp_op);
 	Player_orders.back().localize();
 
 	Lua_player_orders.emplace(sexp_op, std::move(order));
@@ -72,10 +72,7 @@ void run_ai_lua_action(const luacpp::LuaFunction& action, const ai_mode_lua& lua
 	}
 }
 
-void ai_lua(ship* shipp){
-	
-	ai_info	*aip = &Ai_info[shipp->ai_index];
-
+void ai_lua(ai_info* aip){
 	Assertion(aip->mode == AIM_LUA, "Tried to invoke LuaAI on a ship not in LuaAI-Mode");
 
 	const auto& lua_ai = Lua_ai_modes.at(aip->submode);

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -5,6 +5,7 @@
 #include "iff_defs/iff_defs.h"
 #include "parse/sexp/sexp_lookup.h"
 #include "parse/sexp/LuaAISEXP.h"
+#include "scripting/api/objs/ai_helper.h"
 #include "scripting/api/objs/oswpt.h"
 #include "scripting/scripting.h"
 
@@ -58,6 +59,7 @@ void run_ai_lua_action(const luacpp::LuaFunction& action, const ai_mode_lua& lua
 	}
 
 	luacpp::LuaValueList luaParameters;
+	luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_AI_Helper.Set(object_h(&Objects[Ships[aip->shipnum].objnum]))));
 	if (lua_ai.needsTarget) {
 		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(aip->lua_ai_target)));
 	}

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -1,0 +1,90 @@
+#include "ai/ailua.h"
+
+#include "ai/aigoals.h"
+#include "parse/sexp/sexp_lookup.h"
+#include "parse/sexp/LuaAISEXP.h"
+#include "scripting/api/objs/oswpt.h"
+#include "scripting/scripting.h"
+
+static std::map<int, ai_mode_lua> Lua_ai_modes;
+static std::map<int, player_order_lua> Lua_player_orders;
+
+void ai_lua_add_mode(int sexp_op, ai_mode_lua mode) {
+	Lua_ai_modes.emplace(sexp_op, std::move(mode));
+}
+
+bool ai_lua_has_mode(int sexp_op){
+	return Lua_ai_modes.count(sexp_op) > 0;
+}
+
+const ai_mode_lua* ai_lua_find_mode(int sexp_op){
+	auto aiLuaMode = Lua_ai_modes.find(sexp_op);
+	
+	if(aiLuaMode == Lua_ai_modes.end())
+		return nullptr;
+	else
+		return &aiLuaMode->second;
+}
+
+void run_ai_lua_action(const luacpp::LuaFunction& action, const ai_mode_lua& lua_ai, ai_info* aip) {
+	if (!action.isValid()) {
+		Error(LOCATION,
+			"Lua AI SEXP called without a valid action function! A script probably failed to set the action for some reason.");
+		return;
+	}
+
+	luacpp::LuaValueList luaParameters;
+	if (lua_ai.needsTarget) {
+		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(aip->lua_ai_target)));
+	}
+
+	auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);
+
+	if (retVals.size() > 0 && retVals[0].getValueType() == luacpp::ValueType::BOOLEAN) {
+		if (retVals[0].getValue<bool>())
+			ai_mission_goal_complete(aip);
+	}
+}
+
+void ai_lua(ship* shipp){
+	
+	ai_info	*aip = &Ai_info[shipp->ai_index];
+
+	Assertion(aip->mode == AIM_LUA, "Tried to invoke LuaAI on a ship not in LuaAI-Mode");
+
+	const auto& lua_ai = Lua_ai_modes.at(aip->submode);
+	
+	auto dynamicSEXP = sexp::get_dynamic_sexp(aip->submode);
+
+	if (dynamicSEXP != nullptr && typeid(*dynamicSEXP) == typeid(sexp::LuaAISEXP)) {
+		auto lua_ai_sexp = static_cast<sexp::LuaAISEXP*>(dynamicSEXP);
+		const auto& action = lua_ai_sexp->getActionFrame();
+
+		run_ai_lua_action(action, lua_ai, aip);
+	}
+}
+
+void ai_lua_start(ai_goal* aip, object* objp){
+
+	Assert(objp->type == OBJ_SHIP);
+	Assert((objp->instance >= 0) && (objp->instance < MAX_SHIPS));
+
+	ai_info *aiip = &Ai_info[Ships[objp->instance].ai_index];
+
+	aiip->mode = AIM_LUA;
+	aiip->submode = aip->ai_submode;
+	aiip->lua_ai_target = aip->lua_ai_target;
+	aiip->submode_start_time = Missiontime;
+	
+	const auto& lua_ai = Lua_ai_modes.at(aip->ai_submode);
+
+	auto dynamicSEXP = sexp::get_dynamic_sexp(aip->ai_submode);
+
+	if (dynamicSEXP != nullptr && typeid(*dynamicSEXP) == typeid(sexp::LuaAISEXP)) {
+		auto lua_ai_sexp = static_cast<sexp::LuaAISEXP*>(dynamicSEXP);
+		const auto& action = lua_ai_sexp->getActionEnter();
+
+		run_ai_lua_action(action, lua_ai, aiip);
+	}
+	
+}

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -12,8 +12,8 @@
 static std::unordered_map<int, ai_mode_lua> Lua_ai_modes;
 static std::unordered_map<int, player_order_lua> Lua_player_orders;
 
-void ai_lua_add_mode(int sexp_op, ai_mode_lua mode) {
-	Lua_ai_modes.emplace(sexp_op, std::move(mode));
+void ai_lua_add_mode(int sexp_op, const ai_mode_lua& mode) {
+	Lua_ai_modes.emplace(sexp_op, mode);
 }
 
 bool ai_lua_add_order(int sexp_op, player_order_lua order) {
@@ -66,7 +66,7 @@ void run_ai_lua_action(const luacpp::LuaFunction& action, const ai_mode_lua& lua
 
 	auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);
 
-	if (retVals.size() > 0 && retVals[0].getValueType() == luacpp::ValueType::BOOLEAN) {
+	if (!retVals.empty() && retVals[0].getValueType() == luacpp::ValueType::BOOLEAN) {
 		if (retVals[0].getValue<bool>())
 			ai_mission_goal_complete(aip);
 	}

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -17,7 +17,7 @@ struct player_order_lua {
 	enum class target_restrictions : int { TARGET_ALLIES, TARGET_ALL, TARGET_OWN, TARGET_ENEMIES, TARGET_SAME_WING, TARGET_PLAYER_WING, TARGET_ALL_CAPS, TARGET_ALLIED_CAPS, TARGET_ENEMY_CAPS } targetRestrictions = target_restrictions::TARGET_ALL;
 };
 
-void ai_lua_add_mode(int sexp_op, ai_mode_lua mode);
+void ai_lua_add_mode(int sexp_op, const ai_mode_lua& mode);
 bool ai_lua_add_order(int sexp_op, player_order_lua order);
 bool ai_lua_has_mode(int sexp_op);
 const ai_mode_lua* ai_lua_find_mode(int sexp_op);

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ai/ai.h"
+#include "ship/ship.h"
+
+struct ai_mode_lua {
+	bool needsTarget;
+};
+
+struct player_order_lua {
+	int ai_submode;
+};
+
+void ai_lua_add_mode(int sexp_op, ai_mode_lua mode);
+bool ai_lua_has_mode(int sexp_op);
+const ai_mode_lua* ai_lua_find_mode(int sexp_op);
+void ai_lua(ship* shipp);
+void ai_lua_start(ai_goal* aip, object* objp);

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -22,6 +22,6 @@ bool ai_lua_add_order(int sexp_op, player_order_lua order);
 bool ai_lua_has_mode(int sexp_op);
 const ai_mode_lua* ai_lua_find_mode(int sexp_op);
 const player_order_lua* ai_lua_find_player_order(int sexp_op);
-void ai_lua(ai_info* shipp);
+void ai_lua(ai_info* aip);
 void ai_lua_start(ai_goal* aip, object* objp);
 bool ai_lua_is_valid_target(int sexp_op, int target_objnum, ship* self);

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -14,7 +14,7 @@ struct player_order_lua {
 	int ai_message = MESSAGE_YESSIR;
 	SCP_string parseText = "";
 	SCP_string displayText = "";
-	enum class target_restrictions : int { TARGET_ALL, TARGET_OWN, TARGET_ALLIES, TARGET_ENEMIES, TARGET_PLAYER_WING, TARGET_ALL_CAPS, TARGET_ALLIED_CAPS, TARGET_ENEMY_CAPS } targetRestrictions = target_restrictions::TARGET_ALL;
+	enum class target_restrictions : int { TARGET_ALLIES, TARGET_ALL, TARGET_OWN, TARGET_ENEMIES, TARGET_SAME_WING, TARGET_PLAYER_WING, TARGET_ALL_CAPS, TARGET_ALLIED_CAPS, TARGET_ENEMY_CAPS } targetRestrictions = target_restrictions::TARGET_ALL;
 };
 
 void ai_lua_add_mode(int sexp_op, ai_mode_lua mode);
@@ -24,4 +24,4 @@ const ai_mode_lua* ai_lua_find_mode(int sexp_op);
 const player_order_lua* ai_lua_find_player_order(int sexp_op);
 void ai_lua(ship* shipp);
 void ai_lua_start(ai_goal* aip, object* objp);
-bool ai_lua_is_valid_target(int sexp_op, int target_objnum);
+bool ai_lua_is_valid_target(int sexp_op, int target_objnum, ship* self);

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -7,7 +7,7 @@
 
 struct ai_mode_lua {
 	bool needsTarget;
-	const char* hudText = nullptr;
+	const char* hudText;
 };
 
 struct player_order_lua {

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -22,6 +22,6 @@ bool ai_lua_add_order(int sexp_op, player_order_lua order);
 bool ai_lua_has_mode(int sexp_op);
 const ai_mode_lua* ai_lua_find_mode(int sexp_op);
 const player_order_lua* ai_lua_find_player_order(int sexp_op);
-void ai_lua(ship* shipp);
+void ai_lua(ai_info* shipp);
 void ai_lua_start(ai_goal* aip, object* objp);
 bool ai_lua_is_valid_target(int sexp_op, int target_objnum, ship* self);

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -23,5 +23,5 @@ bool ai_lua_has_mode(int sexp_op);
 const ai_mode_lua* ai_lua_find_mode(int sexp_op);
 const player_order_lua* ai_lua_find_player_order(int sexp_op);
 void ai_lua(ai_info* aip);
-void ai_lua_start(ai_goal* aip, object* objp);
+void ai_lua_start(ai_goal* aigp, object* objp);
 bool ai_lua_is_valid_target(int sexp_op, int target_objnum, ship* self);

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -1,18 +1,27 @@
 #pragma once
 
 #include "ai/ai.h"
+#include "mission/missionmessage.h"
 #include "ship/ship.h"
+#include "globalincs/globals.h"
 
 struct ai_mode_lua {
 	bool needsTarget;
+	const char* hudText = nullptr;
 };
 
 struct player_order_lua {
-	int ai_submode;
+	int ai_message = MESSAGE_YESSIR;
+	SCP_string parseText = "";
+	SCP_string displayText = "";
+	enum class target_restrictions : int { TARGET_ALL, TARGET_OWN, TARGET_ALLIES, TARGET_ENEMIES, TARGET_PLAYER_WING, TARGET_ALL_CAPS, TARGET_ALLIED_CAPS, TARGET_ENEMY_CAPS } targetRestrictions = target_restrictions::TARGET_ALL;
 };
 
 void ai_lua_add_mode(int sexp_op, ai_mode_lua mode);
+bool ai_lua_add_order(int sexp_op, player_order_lua order);
 bool ai_lua_has_mode(int sexp_op);
 const ai_mode_lua* ai_lua_find_mode(int sexp_op);
+const player_order_lua* ai_lua_find_player_order(int sexp_op);
 void ai_lua(ship* shipp);
 void ai_lua_start(ai_goal* aip, object* objp);
+bool ai_lua_is_valid_target(int sexp_op, int target_objnum);

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1253,7 +1253,7 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 			break;
 		
 		default: {
-			int i;
+			size_t i;
 			for (i = 0; i < Player_orders.size(); i++) {
 				if (Player_orders[i].id == command)
 					break;
@@ -1485,7 +1485,7 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 			return 0;
 
 		default: {
-			int i;
+			size_t i;
 			for (i = 0; i < Player_orders.size(); i++) {
 				if (Player_orders[i].id == command)
 					break;

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -175,7 +175,7 @@ std::vector<player_order> Player_orders = {
 	player_order("keep safe dist", "Keep safe distance", -1, KEEP_SAFE_DIST_ITEM)
 };
 
-int current_highest_player_order_type = MAX_ENGINE_PLAYER_ORDER;
+int current_new_player_order_type = (1 << 31);
 
 void hud_init_comm_orders()
 {

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -767,10 +767,11 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 	}
 
 	target_objnum = aip->target_objnum;
+	ordering_shipp = &Ships[aip->shipnum];
 
 	//If it's a lua order, defer to luaai
 	if (Player_orders[order].lua_id != -1) {
-		return ai_lua_is_valid_target(Player_orders[order].lua_id, target_objnum);
+		return ai_lua_is_valid_target(Player_orders[order].lua_id, target_objnum, ordering_shipp);
 	}
 
 	// orders which don't operate on targets are always valid
@@ -785,7 +786,6 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 
 	objp = &Objects[target_objnum];
 
-	ordering_shipp = &Ships[aip->shipnum];
 
 	// target isn't a ship, then return false
 	if ( (objp->type != OBJ_SHIP) && (objp->type != OBJ_WEAPON) )

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -12,6 +12,7 @@
 
 
 #include "ai/aigoals.h"
+#include "ai/ailua.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
 #include "hud/hudmessage.h"
@@ -32,7 +33,6 @@
 #include "ship/subsysdamage.h"
 #include "weapon/emp.h"
 #include "weapon/weapon.h"
-
 
 // defines for different modes in the squad messaging system
 
@@ -175,6 +175,8 @@ std::vector<player_order> Player_orders = {
 	player_order("keep safe dist", "Keep safe distance", -1, KEEP_SAFE_DIST_ITEM)
 };
 
+int current_highest_player_order_type = MAX_ENGINE_PLAYER_ORDER;
+
 void hud_init_comm_orders()
 {
 	int i;
@@ -194,9 +196,8 @@ void hud_init_comm_orders()
 		Comm_order_types[i] = temp_comm_order_types[i];
 	}
 
-	for(auto& order : Player_orders) {
-		order.localized_name = XSTR(order.hud_name.c_str(), order.hud_xstr);
-	}
+	for (auto& order : Player_orders)
+		order.localize();
 }
 
 // Text to display on the messaging menu when using the shortcut keys
@@ -765,11 +766,17 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 		order = (int)i;
 	}
 
+	target_objnum = aip->target_objnum;
+
+	//If it's a lua order, defer to luaai
+	if (Player_orders[order].lua_id != -1) {
+		return ai_lua_is_valid_target(Player_orders[order].lua_id, target_objnum);
+	}
+
 	// orders which don't operate on targets are always valid
 	if ( !(Player_orders[order].id & TARGET_MESSAGES) )
 		return true;
 
-	target_objnum = aip->target_objnum;
 
 	// order isn't valid if there is no player target
 	if ( target_objnum == -1 ) {
@@ -1009,6 +1016,7 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 	ai_info *ainfo;
 	int ai_mode, ai_submode;					// ai mode and submode needed for ship commands
 	char *target_shipname;						// ship number of possible targets
+	object_ship_wing_point_team lua_target;
 	int message;
 	int target_team, ship_team;				// team id's for the ship getting message and any target the player has
 	ship *ordering_shipp;
@@ -1244,16 +1252,29 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 			message = MESSAGE_YESSIR;
 			break;
 		
-		default:
-			Int3();										// get Allender -- illegal message
+		default: {
+			int i;
+			for (i = 0; i < Player_orders.size(); i++) {
+				if (Player_orders[i].id == command)
+					break;
+			}
+			Assert(i < Player_orders.size()); // get Allender -- illegal message
+			
+			ai_mode = AI_GOAL_LUA;
+			ai_submode = Player_orders[i].lua_id;
+			auto lua_porder = ai_lua_find_player_order(Player_orders[i].lua_id);
+			message = lua_porder->ai_message;
+			if (ainfo->target_objnum != -1)
+				lua_target = object_ship_wing_point_team(&Ships[Objects[ainfo->target_objnum].instance]);
 			break;
+		}
 
 		}
 
 		// handle case of messaging one ship.  Deal with messaging all fighters next.
 		if ( ai_mode != AI_GOAL_NONE ) {
 			Assert(ai_submode != -1234567);
-			ai_add_ship_goal_player( AIG_TYPE_PLAYER_SHIP, ai_mode, ai_submode, target_shipname, &Ai_info[Ships[shipnum].ai_index] );
+			ai_add_ship_goal_player( AIG_TYPE_PLAYER_SHIP, ai_mode, ai_submode, target_shipname, &Ai_info[Ships[shipnum].ai_index], lua_target );
 			if( update_history == SQUADMSG_HISTORY_ADD_ENTRY ) {
 				hud_add_issued_order(Ships[shipnum].ship_name, command);
 				hud_update_last_order(target_shipname, player_num, special_index); 
@@ -1293,6 +1314,7 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 	ai_info *ainfo;
 	int ai_mode, ai_submode;					// ai mode and submode needed for ship commands
 	char *target_shipname;						// ship number of possible targets
+	object_ship_wing_point_team lua_target;
 	int message_sent, message;
 	int target_team, wing_team;				// team for the wing and the player's target
 	ship *ordering_shipp;
@@ -1462,15 +1484,28 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 		case KEEP_SAFE_DIST_ITEM:
 			return 0;
 
-		default:
-			Int3();										// get Allender -- illegal message
+		default: {
+			int i;
+			for (i = 0; i < Player_orders.size(); i++) {
+				if (Player_orders[i].id == command)
+					break;
+			}
+			Assert(i < Player_orders.size()); // get Allender -- illegal message
+
+			ai_mode = AI_GOAL_LUA;
+			ai_submode = Player_orders[i].lua_id;
+			auto lua_porder = ai_lua_find_player_order(Player_orders[i].lua_id);
+			message = lua_porder->ai_message;
+			if(ainfo->target_objnum != -1)
+				lua_target = object_ship_wing_point_team(&Ships[Objects[ainfo->target_objnum].instance]);
 			break;
 
+		}
 		}
 
 		if ( ai_mode != AI_GOAL_NONE ) {
 			Assert(ai_submode != -1234567);
-			ai_add_wing_goal_player( AIG_TYPE_PLAYER_WING, ai_mode, ai_submode, target_shipname, wingnum );
+			ai_add_wing_goal_player( AIG_TYPE_PLAYER_WING, ai_mode, ai_submode, target_shipname, wingnum, lua_target );
 
 			if( update_history == SQUADMSG_HISTORY_ADD_ENTRY ) {				
 				hud_add_issued_order(Wings[wingnum].name, command);

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -73,8 +73,7 @@ typedef struct player_order {
 } player_order;
 
 extern std::vector<player_order> Player_orders;
-constexpr int max_highest_player_order_type = (1 << 31);
-extern int current_highest_player_order_type;
+extern int current_new_player_order_type;
 
 // following defines are the set of possible commands that can be given to a ship.  A mission designer
 // might not allow some messages

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -56,6 +56,8 @@ class object;
 // out of order, but it was this way in the original source
 #define DISABLE_SUBSYSTEM_ITEM		(1<<15)
 
+#define MAX_ENGINE_PLAYER_ORDER		DISABLE_SUBSYSTEM_ITEM
+
 // used for Message box gauge
 #define NUM_MBOX_FRAMES		3
 
@@ -65,10 +67,14 @@ typedef struct player_order {
 	int hud_xstr;
 	int id;
 	SCP_string localized_name;
-	player_order(SCP_string parsename, SCP_string hudname, int hudxstr, int orderid = 0) : parse_name(std::move(parsename)), hud_name(std::move(hudname)), hud_xstr(hudxstr), id(orderid), localized_name("") { }
+	int lua_id;
+	player_order(SCP_string parsename, SCP_string hudname, int hudxstr, int orderid = 0, int luaid = -1) : parse_name(std::move(parsename)), hud_name(std::move(hudname)), hud_xstr(hudxstr), id(orderid), localized_name(""), lua_id(luaid) { }
+	inline void localize() { localized_name = XSTR(hud_name.c_str(), hud_xstr); }
 } player_order;
 
 extern std::vector<player_order> Player_orders;
+constexpr int max_highest_player_order_type = (1 << 31);
+extern int current_highest_player_order_type;
 
 // following defines are the set of possible commands that can be given to a ship.  A mission designer
 // might not allow some messages

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 
 #include "ai/aigoals.h"
+#include "ai/ailua.h"
 #include "asteroid/asteroid.h"
 #include "autopilot/autopilot.h"
 #include "camera/camera.h"
@@ -30664,7 +30665,14 @@ int query_sexp_ai_goal_valid(int sexp_ai_goal, int ship_num)
 		if (Sexp_ai_goal_links[i].op_code == sexp_ai_goal)
 			break;
 
-	Assert(i < Num_sexp_ai_goal_links);
+	if (i >= Num_sexp_ai_goal_links) {
+		//is a luaAI?
+		Assert(ai_lua_has_mode(sexp_ai_goal));
+
+		return true;
+	}
+
+
 	return ai_query_goal_valid(ship_num, Sexp_ai_goal_links[i].ai_goal);
 }
 

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -22,7 +22,7 @@ int LuaAISEXP::getMaximumArguments() {	return getMinimumArguments();};
 
 int LuaAISEXP::getArgumentType(int argnum) const {	return argnum == 0 && _arg_type != -1 ? _arg_type : OPF_POSITIVE;};
 
-int LuaAISEXP::execute(int node) {
+int LuaAISEXP::execute(int /*node*/) {
 	UNREACHABLE("Tried to execute AI Lua SEXP %s! AI-Goal SEXPs should never be run.", _name.c_str());
 	return SEXP_CANT_EVAL;
 }
@@ -138,7 +138,7 @@ luacpp::LuaFunction LuaAISEXP::getActionFrame() const {
 }
 
 void LuaAISEXP::registerAIMode(int sexp_id) const {
-	ai_lua_add_mode(sexp_id, { needsTarget, hudText });
+	ai_lua_add_mode(sexp_id, ai_mode_lua{ needsTarget, hudText });
 }
 
 void LuaAISEXP::maybeRegisterPlayerOrder(int sexp_id) const {

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -1,0 +1,97 @@
+//
+//
+#include "LuaAISEXP.h"
+
+#include "localization/localize.h"
+#include "parse/parselo.h"
+#include "parse/sexp/LuaSEXP.h"
+
+using namespace luacpp;
+
+namespace sexp {
+static const SCP_unordered_set<int> allowed_oswpt_parameters{ OPF_SHIP, OPF_WING, OPF_SHIP_POINT, OPF_SHIP_WING, OPF_SHIP_WING_WHOLETEAM, OPF_SHIP_WING_SHIPONTEAM_POINT, OPF_SHIP_WING_POINT, OPF_SHIP_WING_POINT_OR_NONE };
+
+LuaAISEXP::LuaAISEXP(const SCP_string& name) : DynamicSEXP(name) {
+}
+
+void LuaAISEXP::initialize() {};
+
+int LuaAISEXP::getMinimumArguments() {	return _arg_type == -1 ? 1 : 2;};
+
+int LuaAISEXP::getMaximumArguments() {	return getMinimumArguments();};
+
+int LuaAISEXP::getArgumentType(int argnum) const {	return argnum == 0 && _arg_type != -1 ? _arg_type : OPF_POSITIVE;};
+
+int LuaAISEXP::execute(int node) {
+	UNREACHABLE("Tried to execute AI Lua SEXP %s! AI-Goal SEXPs should never be run.", _name.c_str());
+	return SEXP_CANT_EVAL;
+}
+
+int LuaAISEXP::getReturnType() {	return OPR_AI_GOAL;};
+
+int LuaAISEXP::getSubcategory() {	return getCategory();};
+
+int LuaAISEXP::getCategory() {	return OP_CATEGORY_AI;};
+
+void LuaAISEXP::parseTable() {
+	SCP_stringstream help_text;
+	help_text << _name << "\r\n";
+
+	required_string("$Description:");
+
+	SCP_string description;
+	stuff_string(description, F_NAME);
+
+	help_text << "\t" << description << "\r\n";
+
+	int paramNum = 1;
+	if (optional_string("$Target Parameter:")) {
+		needsTarget = true;
+		required_string("+Description:");
+
+		SCP_string param_desc;
+		stuff_string(param_desc, F_NAME);
+
+		help_text << "\t1";
+		help_text << ": " << param_desc << "\r\n";
+
+		required_string("+Type:");
+		SCP_string type_str;
+		stuff_string(type_str, F_NAME);
+
+		auto type = LuaSEXP::get_parameter_type(type_str);
+		if (type.second < 0 || allowed_oswpt_parameters.count(type.second) <= 0) {
+			error_display(0, "Parameter type '%s' is not an valid target type!", type_str.c_str());
+			type = LuaSEXP::get_parameter_type("ship");
+		}
+
+		_arg_type = type.second;
+
+		paramNum++;
+	}
+
+	help_text << "\t" << paramNum;
+	help_text << ": Goal priority (number between 0 and 200. Player orders have a priority of 90-100).\r\n";
+
+	_help_text = help_text.str();
+	lcl_replace_stuff(_help_text, true);
+}
+
+void LuaAISEXP::setActionEnter(const luacpp::LuaFunction& action) {
+	_actionEnter = action;
+}
+luacpp::LuaFunction LuaAISEXP::getActionEnter() const {
+	return _actionEnter;
+}
+
+void LuaAISEXP::setActionFrame(const luacpp::LuaFunction& action) {
+	_actionFrame = action;
+}
+luacpp::LuaFunction LuaAISEXP::getActionFrame() const {
+	return _actionFrame;
+}
+bool LuaAISEXP::hasTarget() const {
+	return needsTarget;
+}
+
+}

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -29,7 +29,7 @@ int LuaAISEXP::execute(int node) {
 
 int LuaAISEXP::getReturnType() {	return OPR_AI_GOAL;};
 
-int LuaAISEXP::getSubcategory() {	return getCategory();};
+int LuaAISEXP::getSubcategory() {	return -1;};
 
 int LuaAISEXP::getCategory() {	return OP_CATEGORY_AI;};
 

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -92,7 +92,7 @@ void LuaAISEXP::parseTable() {
 		}
 
 		if (optional_string("+Target Restrictions:")) {
-			int result = optional_string_one_of(8, "All", "Own Team", "Allies", "Hostiles", "Player Wing", "Capitals", "Allied Capitals", "Enemy Capitals");
+			int result = optional_string_one_of(8, "Allies", "All", "Own Team", "Hostiles", "Same Wing", "Player Wing", "Capitals", "Allied Capitals", "Enemy Capitals");
 			if (result == -1) {
 				error_display(0, "Unknown target restriction for player order %s. Assuming \"All\".", order.displayText.c_str());
 				order.targetRestrictions = player_order_lua::target_restrictions::TARGET_ALL;

--- a/code/parse/sexp/LuaAISEXP.h
+++ b/code/parse/sexp/LuaAISEXP.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ai/ailua.h"
+
 #include "parse/sexp/DynamicSEXP.h"
 
 #include "scripting/lua/LuaFunction.h"
@@ -13,9 +15,13 @@ class LuaAISEXP : public DynamicSEXP {
 	
 	int _arg_type = -1;
 	bool needsTarget = false;
+	const char* hudText = nullptr;
 
 	luacpp::LuaFunction _actionEnter;
 	luacpp::LuaFunction _actionFrame;
+
+	std::unique_ptr<player_order_lua> playerOrder = nullptr;
+
  public:
 	explicit LuaAISEXP(const SCP_string& name);
 
@@ -27,7 +33,6 @@ class LuaAISEXP : public DynamicSEXP {
 	int getReturnType() override;
 	int getSubcategory() override;
 	int getCategory() override;
-	bool hasTarget() const;
 
 	void parseTable();
 
@@ -36,6 +41,9 @@ class LuaAISEXP : public DynamicSEXP {
 
 	void setActionFrame(const luacpp::LuaFunction& action);
 	luacpp::LuaFunction getActionFrame() const;
+
+	void registerAIMode(int sexp_id) const;
+	void maybeRegisterPlayerOrder(int sexp_id) const;
 };
 
 }

--- a/code/parse/sexp/LuaAISEXP.h
+++ b/code/parse/sexp/LuaAISEXP.h
@@ -22,6 +22,9 @@ class LuaAISEXP : public DynamicSEXP {
 
 	std::unique_ptr<player_order_lua> playerOrder = nullptr;
 
+	// just a helper for parseTable
+	static bool parseCheckEndOfDescription();
+
  public:
 	explicit LuaAISEXP(const SCP_string& name);
 

--- a/code/parse/sexp/LuaAISEXP.h
+++ b/code/parse/sexp/LuaAISEXP.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "parse/sexp/DynamicSEXP.h"
+
+#include "scripting/lua/LuaFunction.h"
+#include "scripting/lua/LuaTable.h"
+
+#include "parse/sexp.h"
+
+namespace sexp {
+
+class LuaAISEXP : public DynamicSEXP {
+	
+	int _arg_type = -1;
+	bool needsTarget = false;
+
+	luacpp::LuaFunction _actionEnter;
+	luacpp::LuaFunction _actionFrame;
+ public:
+	explicit LuaAISEXP(const SCP_string& name);
+
+	void initialize() override;
+	int getMinimumArguments() override;
+	int getMaximumArguments() override;
+	int getArgumentType(int argnum) const override;
+	int execute(int node) override;
+	int getReturnType() override;
+	int getSubcategory() override;
+	int getCategory() override;
+	bool hasTarget() const;
+
+	void parseTable();
+
+	void setActionEnter(const luacpp::LuaFunction& action);
+	luacpp::LuaFunction getActionEnter() const;
+
+	void setActionFrame(const luacpp::LuaFunction& action);
+	luacpp::LuaFunction getActionFrame() const;
+};
+
+}
+

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -25,9 +25,9 @@
 
 using namespace luacpp;
 
-namespace {
+namespace sexp {
 
-SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_BOOL },
+static SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_BOOL },
 														  { "number",       OPF_NUMBER },
 														  { "ship",         OPF_SHIP },
 														  { "shipname",     OPF_SHIP },
@@ -47,7 +47,7 @@ SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",      OPF_
 														  { "ship+wing+waypoint",   OPF_SHIP_WING_POINT },
 														  { "ship+wing+waypoint+none",   OPF_SHIP_WING_POINT_OR_NONE }, };
 
-std::pair<SCP_string, int> get_parameter_type(const SCP_string& name)
+std::pair<SCP_string, int> LuaSEXP::get_parameter_type(const SCP_string& name)
 {
 	SCP_string copy = name;
 	SCP_tolower(copy);
@@ -60,10 +60,10 @@ std::pair<SCP_string, int> get_parameter_type(const SCP_string& name)
 	}
 }
 
-SCP_unordered_map<SCP_string, int> return_type_mapping{{ "number",  OPR_NUMBER },
+static SCP_unordered_map<SCP_string, int> return_type_mapping{{ "number",  OPR_NUMBER },
 													   { "boolean", OPR_BOOL },
 													   { "nothing", OPR_NULL }, };
-int get_return_type(const SCP_string& name)
+int LuaSEXP::get_return_type(const SCP_string& name)
 {
 	SCP_string copy = name;
 	SCP_tolower(copy);
@@ -76,7 +76,7 @@ int get_return_type(const SCP_string& name)
 	}
 }
 
-int get_category(const SCP_string& name) {
+int LuaSEXP::get_category(const SCP_string& name) {
 	for (auto& subcat : op_menu) {
 		if (subcat.name == name) {
 			return subcat.id;
@@ -86,7 +86,7 @@ int get_category(const SCP_string& name) {
 	return -1;
 }
 
-int get_subcategory(const SCP_string& name, int category) {
+int LuaSEXP::get_subcategory(const SCP_string& name, int category) {
 	for (auto& subcat : op_submenu) {
 		if (subcat.name == name && (subcat.id & OP_CATEGORY_MASK) == category) {
 			return subcat.id;
@@ -95,10 +95,6 @@ int get_subcategory(const SCP_string& name, int category) {
 
 	return -1;
 }
-
-}
-
-namespace sexp {
 
 LuaSEXP::LuaSEXP(const SCP_string& name) : DynamicSEXP(name) {
 }

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -30,6 +30,11 @@ class LuaSEXP : public DynamicSEXP {
 	static bool parseCheckEndOfDescription();
 
  public:
+	static std::pair<SCP_string, int> get_parameter_type(const SCP_string& name);
+	static int get_return_type(const SCP_string& name);
+	static int LuaSEXP::get_category(const SCP_string& name);
+	static int LuaSEXP::get_subcategory(const SCP_string& name, int category);
+
 	explicit LuaSEXP(const SCP_string& name);
 
 	void initialize() override;

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -32,8 +32,8 @@ class LuaSEXP : public DynamicSEXP {
  public:
 	static std::pair<SCP_string, int> get_parameter_type(const SCP_string& name);
 	static int get_return_type(const SCP_string& name);
-	static int LuaSEXP::get_category(const SCP_string& name);
-	static int LuaSEXP::get_subcategory(const SCP_string& name, int category);
+	static int get_category(const SCP_string& name);
+	static int get_subcategory(const SCP_string& name, int category);
 
 	explicit LuaSEXP(const SCP_string& name);
 

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -1,9 +1,12 @@
 
+#include "ai/ailua.h"
+
 #include "parse/sexp/sexp_lookup.h"
 
 #include "parse/parselo.h"
 #include "parse/sexp.h"
 #include "parse/sexp/LuaSEXP.h"
+#include "parse/sexp/LuaAISEXP.h"
 #include "scripting/scripting.h"
 
 #include <memory>
@@ -65,38 +68,68 @@ void parse_sexp_table(const char* filename) {
 		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
 
-		required_string("#Lua SEXPs");
-
 		// These characters may not appear in a SEXP name
-		const char* INVALID_CHARS = "()\"'\t ";
+		constexpr char* INVALID_CHARS = "()\"'\t ";
+		if (optional_string("#Lua SEXPs")) {
 
-		while (optional_string("$Operator:")) {
-			SCP_string name;
-			stuff_string(name, F_NAME);
+			while (optional_string("$Operator:")) {
+				SCP_string name;
+				stuff_string(name, F_NAME);
 
-			if (std::strpbrk(name.c_str(), INVALID_CHARS) != nullptr) {
-				error_display(0, "Found invalid SEXP name '%s'!", name.c_str());
+				if (std::strpbrk(name.c_str(), INVALID_CHARS) != nullptr) {
+					error_display(0, "Found invalid SEXP name '%s'!", name.c_str());
 
-				// Skip the invalid entry
-				skip_to_start_of_string_either("$Operator:", "#End");
-				continue;
+					// Skip the invalid entry
+					skip_to_start_of_string_either("$Operator:", "#End");
+					continue;
+				}
+				if (get_operator_index(name.c_str()) >= 0) {
+					error_display(0, "The SEXP '%s' is already defined!", name.c_str());
+
+					// Skip the invalid entry
+					skip_to_start_of_string_either("$Operator:", "#End");
+					continue;
+				}
+
+				std::unique_ptr<DynamicSEXP> instance(new LuaSEXP(name));
+				auto luaSexp = static_cast<LuaSEXP*>(instance.get());
+				luaSexp->parseTable();
+
+				add_dynamic_sexp(std::move(instance));
 			}
-			if (get_operator_index(name.c_str()) >= 0) {
-				error_display(0, "The SEXP '%s' is already defined!", name.c_str());
-
-				// Skip the invalid entry
-				skip_to_start_of_string_either("$Operator:", "#End");
-				continue;
-			}
-
-			std::unique_ptr<DynamicSEXP> instance(new LuaSEXP(name));
-			auto luaSexp = static_cast<LuaSEXP*>(instance.get());
-			luaSexp->parseTable();
-
-			add_dynamic_sexp(std::move(instance));
+			required_string("#End");
 		}
 
-		required_string("#End");
+		if (optional_string("#Lua AI")) {
+			while (optional_string("$Operator:")) {
+				SCP_string name;
+				stuff_string(name, F_NAME);
+
+				if (std::strpbrk(name.c_str(), INVALID_CHARS) != nullptr) {
+					error_display(0, "Found invalid AI-SEXP name '%s'!", name.c_str());
+
+					// Skip the invalid entry
+					skip_to_start_of_string_either("$Operator:", "#End");
+					continue;
+				}
+				if (get_operator_index(name.c_str()) >= 0) {
+					error_display(0, "The AI-SEXP '%s' is already defined!", name.c_str());
+
+					// Skip the invalid entry
+					skip_to_start_of_string_either("$Operator:", "#End");
+					continue;
+				}
+
+				std::unique_ptr<DynamicSEXP> instance(new LuaAISEXP(name));
+				auto luaSexp = static_cast<LuaAISEXP*>(instance.get());
+				luaSexp->parseTable();
+
+				int op = add_dynamic_sexp(std::move(instance), SEXP_GOAL_OPERATOR);
+				ai_lua_add_mode(op, { luaSexp->hasTarget() });
+			}
+			required_string("#End");
+		}
+
 	} catch (const parse::ParseException& e) {
 		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", filename, e.what()));
 		return;
@@ -123,14 +156,14 @@ void free_lua_sexps(lua_State* /*L*/)
 
 namespace sexp {
 
-void add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp)
+int add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp, int type)
 {
 	auto& global = globals();
 
 	if (!global.initialized) {
 		// Do nothing now and delay this until we know that we are properly initialized
 		global.pending_sexps.emplace_back(std::move(sexp));
-		return;
+		return -1;
 	}
 
 	sexp->initialize();
@@ -145,7 +178,7 @@ void add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp)
 
 	// For now, all dynamic SEXPS are only valid in missions
 	new_op.value = get_next_free_operator(sexp->getCategory()) | sexp->getCategory() | OP_NONCAMPAIGN_FLAG;
-	new_op.type = SEXP_ACTION_OPERATOR;
+	new_op.type = type;
 
 	global.operator_const_mapping.insert(std::make_pair(new_op.value, std::move(sexp)));
 
@@ -156,6 +189,8 @@ void add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp)
 	new_help.id = new_op.value;
 	new_help.help = help_text;
 	Sexp_help.push_back(new_help);
+
+	return new_op.value;
 }
 DynamicSEXP* get_dynamic_sexp(int operator_const)
 {

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -125,7 +125,8 @@ void parse_sexp_table(const char* filename) {
 				luaSexp->parseTable();
 
 				int op = add_dynamic_sexp(std::move(instance), SEXP_GOAL_OPERATOR);
-				ai_lua_add_mode(op, { luaSexp->hasTarget() });
+				luaSexp->registerAIMode(op);
+				luaSexp->maybeRegisterPlayerOrder(op);
 			}
 			required_string("#End");
 		}

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -69,7 +69,7 @@ void parse_sexp_table(const char* filename) {
 		reset_parse();
 
 		// These characters may not appear in a SEXP name
-		constexpr char* INVALID_CHARS = "()\"'\t ";
+		constexpr const char* INVALID_CHARS = "()\"'\t ";
 		if (optional_string("#Lua SEXPs")) {
 
 			while (optional_string("$Operator:")) {

--- a/code/parse/sexp/sexp_lookup.h
+++ b/code/parse/sexp/sexp_lookup.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "parse/sexp/DynamicSEXP.h"
+#include "parse/sexp.h"
 
 namespace sexp {
 
@@ -13,8 +14,11 @@ namespace sexp {
  * usable!
  *
  * @param sexp The sexp to add
+ * @param type The type of the SEXP
+ * 
+ * @return The operator id of the SEXP
  */
-void add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp);
+int add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp, int type = SEXP_ACTION_OPERATOR);
 
 /**
  * @brief Given an operator constant, return the associated dynamic SEXP

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -28,9 +28,11 @@
 #include "parse/sexp.h"
 #include "parse/sexp/DynamicSEXP.h"
 #include "parse/sexp/LuaSEXP.h"
+#include "parse/sexp/LuaAISEXP.h"
 #include "parse/sexp/sexp_lookup.h"
 #include "scripting/api/LuaPromise.h"
 #include "scripting/api/objs/LuaSEXP.h"
+#include "scripting/api/objs/luaaisexp.h"
 #include "scripting/api/objs/asteroid.h"
 #include "scripting/api/objs/background_element.h"
 #include "scripting/api/objs/beam.h"
@@ -1556,6 +1558,44 @@ ADE_INDEXER(l_Mission_LuaSEXPs, "string Name", "Gets a handle of a Lua SEXP", "L
 	}
 
 	return ade_set_args(L, "o", l_LuaSEXP.Set(lua_sexp_h(static_cast<sexp::LuaSEXP*>(dynamicSEXP))));
+}
+
+ADE_LIB_DERIV(l_Mission_LuaAISEXPs, "LuaAISEXPs", NULL, "Lua AI SEXPs", l_Mission);
+
+ADE_INDEXER(l_Mission_LuaAISEXPs, "string Name", "Gets a handle of a Lua SEXP", "LuaAISEXP", "Lua AI SEXP handle or invalid handle on error")
+{
+	const char* name = nullptr;
+	if (!ade_get_args(L, "*s", &name)) {
+		return ade_set_error(L, "o", l_LuaAISEXP.Set(lua_ai_sexp_h()));
+	}
+
+	if (name == nullptr) {
+		return ade_set_error(L, "o", l_LuaAISEXP.Set(lua_ai_sexp_h()));
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "Setting of Lua AI SEXPs is not supported!");
+	}
+
+	auto op = get_operator_const(name);
+
+	if (op == 0) {
+		LuaError(L, "SEXP '%s' is not known to the SEXP system!", name);
+		return ade_set_args(L, "o", l_LuaAISEXP.Set(lua_ai_sexp_h()));
+	}
+
+	auto dynamicSEXP = sexp::get_dynamic_sexp(op);
+
+	if (dynamicSEXP == nullptr) {
+		return ade_set_args(L, "o", l_LuaAISEXP.Set(lua_ai_sexp_h()));
+	}
+
+	if (typeid(*dynamicSEXP) != typeid(sexp::LuaAISEXP)) {
+		LuaError(L, "Specified dynamic SEXP name does not refer to a Lua SEXP!");
+		return ade_set_error(L, "o", l_LuaAISEXP.Set(lua_ai_sexp_h()));
+	}
+
+	return ade_set_args(L, "o", l_LuaAISEXP.Set(lua_ai_sexp_h(static_cast<sexp::LuaAISEXP*>(dynamicSEXP))));
 }
 
 static int arrivalListIter(lua_State* L)

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1522,7 +1522,7 @@ ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [tabl
 	return testLineOfSight_internal(L, true);
 }
 
-ADE_LIB_DERIV(l_Mission_LuaSEXPs, "LuaSEXPs", NULL, "Lua SEXPs", l_Mission);
+ADE_LIB_DERIV(l_Mission_LuaSEXPs, "LuaSEXPs", nullptr, "Lua SEXPs", l_Mission);
 
 ADE_INDEXER(l_Mission_LuaSEXPs, "string Name", "Gets a handle of a Lua SEXP", "LuaSEXP", "Lua SEXP handle or invalid handle on error")
 {

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1560,7 +1560,7 @@ ADE_INDEXER(l_Mission_LuaSEXPs, "string Name", "Gets a handle of a Lua SEXP", "L
 	return ade_set_args(L, "o", l_LuaSEXP.Set(lua_sexp_h(static_cast<sexp::LuaSEXP*>(dynamicSEXP))));
 }
 
-ADE_LIB_DERIV(l_Mission_LuaAISEXPs, "LuaAISEXPs", NULL, "Lua AI SEXPs", l_Mission);
+ADE_LIB_DERIV(l_Mission_LuaAISEXPs, "LuaAISEXPs", nullptr, "Lua AI SEXPs", l_Mission);
 
 ADE_INDEXER(l_Mission_LuaAISEXPs, "string Name", "Gets a handle of a Lua SEXP", "LuaAISEXP", "Lua AI SEXP handle or invalid handle on error")
 {

--- a/code/scripting/api/objs/ai_helper.cpp
+++ b/code/scripting/api/objs/ai_helper.cpp
@@ -1,0 +1,91 @@
+
+#include "ai_helper.h"
+
+#include "object.h"
+#include "ship.h"
+#include "vecmath.h"
+
+#include "ai/ai.h"
+
+namespace scripting {
+namespace api {
+
+//**********HANDLE: AI Helper
+ADE_OBJ(l_AI_Helper, object_h, "ai_helper", "A helper object to access functions for ship manipulation during AI phase");
+
+ADE_VIRTVAR(Ship, l_AI_Helper, nullptr, "The ship this AI runs for", "ship", "The ship, or invalid ship if the handle is invalid")
+{
+	object_h ship;
+	if (!ade_get_args(L, "o", l_AI_Helper.Get(&ship)))
+		return ade_set_error(L, "o", l_Ship.Set(object_h()));
+
+	return ade_set_args(L, "o", l_Ship.Set(ship));
+}
+
+inline int aici_getset_helper(lua_State* L, float control_info::* value) {
+	object_h ship;
+	float f = 0.0f;
+	if (!ade_get_args(L, "o|f", l_AI_Helper.Get(&ship), &f))
+		return ade_set_error(L, "f", 0.0f);
+
+	if (!ship.IsValid())
+		return ade_set_error(L, "f", 0.0f);
+
+	if (ADE_SETTING_VAR) {
+		AI_ci.*value = f;
+	}
+
+	return ade_set_args(L, "f", AI_ci.*value);
+}
+
+ADE_VIRTVAR(Pitch, l_AI_Helper, "number", "The pitch rate for the ship this frame, -1 to 1", "number", "The pitch rate, or 0 if the handle is invalid")
+{
+	return aici_getset_helper(L, &control_info::pitch);
+}
+
+ADE_VIRTVAR(Bank, l_AI_Helper, "number", "The bank rate for the ship this frame, -1 to 1", "number", "The bank rate, or 0 if the handle is invalid")
+{
+	return aici_getset_helper(L, &control_info::bank);
+}
+
+ADE_VIRTVAR(Heading, l_AI_Helper, "number", "The heading rate for the ship this frame, -1 to 1", "number", "The heading rate, or 0 if the handle is invalid")
+{
+	return aici_getset_helper(L, &control_info::heading);
+}
+
+ADE_VIRTVAR(ForwardThrust, l_AI_Helper, "number", "The forward thrust rate for the ship this frame, -1 to 1", "number", "The forward thrust rate, or 0 if the handle is invalid")
+{
+	return aici_getset_helper(L, &control_info::forward);
+}
+
+ADE_VIRTVAR(VerticalThrust, l_AI_Helper, "number", "The vertical thrust rate for the ship this frame, -1 to 1", "number", "The vertical thrust rate, or 0 if the handle is invalid")
+{
+	return aici_getset_helper(L, &control_info::vertical);
+}
+
+ADE_VIRTVAR(SidewaysThrust, l_AI_Helper, "number", "The sideways thrust rate for the ship this frame, -1 to 1", "number", "The sideways thrust rate, or 0 if the handle is invalid")
+{
+	return aici_getset_helper(L, &control_info::sideways);
+}
+
+ADE_FUNC(turnTowardsPoint,
+	l_AI_Helper,
+	"vector target, [boolean respectDifficulty = true, vector turnrateModifier (100% of tabled values in all rotation axes by default)]",
+	"turns the ship towards the specified point during this frame",
+	nullptr,
+	nullptr)
+{
+	object_h ship;
+	vec3d* target;
+	bool diffTurn = true;
+	vec3d* modifier = nullptr;
+	if (!ade_get_args(L, "oo|bo", l_AI_Helper.Get(&ship), l_Vector.GetPtr(&target), &diffTurn, l_Vector.GetPtr(&modifier))) {
+		return ADE_RETURN_NIL;
+	}
+
+	ai_turn_towards_vector(target, ship.objp, nullptr, nullptr, 0.0f, diffTurn ? 0 : AITTV_FAST, nullptr, modifier);
+	return ADE_RETURN_NIL;
+}
+
+}
+}

--- a/code/scripting/api/objs/ai_helper.cpp
+++ b/code/scripting/api/objs/ai_helper.cpp
@@ -23,6 +23,7 @@ ADE_VIRTVAR(Ship, l_AI_Helper, nullptr, "The ship this AI runs for", "ship", "Th
 }
 
 inline int aici_getset_helper(lua_State* L, float control_info::* value) {
+	//Use with care! This works only if, as expected, the l_AI_Helper object is the one supplied to the luaai scripts this very frame
 	object_h ship;
 	float f = 0.0f;
 	if (!ade_get_args(L, "o|f", l_AI_Helper.Get(&ship), &f))

--- a/code/scripting/api/objs/ai_helper.cpp
+++ b/code/scripting/api/objs/ai_helper.cpp
@@ -71,7 +71,7 @@ ADE_VIRTVAR(SidewaysThrust, l_AI_Helper, "number", "The sideways thrust rate for
 
 ADE_FUNC(turnTowardsPoint,
 	l_AI_Helper,
-	"vector target, [boolean respectDifficulty = true, vector turnrateModifier (100% of tabled values in all rotation axes by default)]",
+	"vector target, [boolean respectDifficulty = true, vector turnrateModifier /* 100% of tabled values in all rotation axes by default */]",
 	"turns the ship towards the specified point during this frame",
 	nullptr,
 	nullptr)

--- a/code/scripting/api/objs/ai_helper.h
+++ b/code/scripting/api/objs/ai_helper.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "scripting/ade_api.h"
+#include "object/object.h"
+
+namespace scripting {
+	namespace api {
+		DECLARE_ADE_OBJ(l_AI_Helper, object_h);
+	}
+}

--- a/code/scripting/api/objs/luaaisexp.cpp
+++ b/code/scripting/api/objs/luaaisexp.cpp
@@ -1,0 +1,75 @@
+//
+//
+
+#include "luaaisexp.h"
+
+namespace scripting {
+namespace api {
+
+lua_ai_sexp_h::lua_ai_sexp_h(sexp::LuaAISEXP* handle) : sexp_handle(handle) {
+}
+lua_ai_sexp_h::lua_ai_sexp_h() : sexp_handle(nullptr) {
+}
+bool lua_ai_sexp_h::isValid() {
+	return sexp_handle != nullptr;
+}
+
+ADE_OBJ(l_LuaAISEXP, lua_ai_sexp_h, "LuaAISEXP", "Lua AI SEXP handle");
+
+ADE_VIRTVAR(ActionEnter,
+	l_LuaAISEXP,
+	"function(oswpt | nil arg) => bool action",
+	"The action of this AI SEXP to be executed once when the AI recieves this order. Return true if the AI goal is complete.",
+	"function(oswpt | nil arg) => bool action",
+	"The action function or nil on error")
+{
+	lua_ai_sexp_h lua_sexp;
+	luacpp::LuaFunction action_arg;
+	if (!ade_get_args(L, "o|u", l_LuaAISEXP.Get(&lua_sexp), &action_arg)) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (!lua_sexp.isValid()) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		Assertion(action_arg.isValid(), "Action function reference must be valid!");
+
+		lua_sexp.sexp_handle->setActionEnter(action_arg);
+	}
+
+	auto action = lua_sexp.sexp_handle->getActionEnter();
+	return ade_set_args(L, "u", &action);
+}
+
+ADE_VIRTVAR(ActionFrame,
+	l_LuaAISEXP,
+	"function(oswpt | nil arg) => bool action",
+	"The action of this AI SEXP to be executed each frame while active. Return true if the AI goal is complete.",
+	"function(oswpt | nil arg) => bool action",
+	"The action function or nil on error")
+{
+	lua_ai_sexp_h lua_sexp;
+	luacpp::LuaFunction action_arg;
+	if (!ade_get_args(L, "o|u", l_LuaAISEXP.Get(&lua_sexp), &action_arg)) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (!lua_sexp.isValid()) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		Assertion(action_arg.isValid(), "Action function reference must be valid!");
+
+		lua_sexp.sexp_handle->setActionFrame(action_arg);
+	}
+
+	auto action = lua_sexp.sexp_handle->getActionFrame();
+	return ade_set_args(L, "u", &action);
+}
+
+}
+}
+

--- a/code/scripting/api/objs/luaaisexp.cpp
+++ b/code/scripting/api/objs/luaaisexp.cpp
@@ -18,9 +18,9 @@ ADE_OBJ(l_LuaAISEXP, lua_ai_sexp_h, "LuaAISEXP", "Lua AI SEXP handle");
 
 ADE_VIRTVAR(ActionEnter,
 	l_LuaAISEXP,
-	"function(ai_helper helper, oswpt | nil arg) => bool action",
+	"function(ai_helper helper, oswpt | nil arg) => boolean action",
 	"The action of this AI SEXP to be executed once when the AI recieves this order. Return true if the AI goal is complete.",
-	"function(ai_helper helper, oswpt | nil arg) => bool action",
+	"function(ai_helper helper, oswpt | nil arg) => boolean action",
 	"The action function or nil on error")
 {
 	lua_ai_sexp_h lua_sexp;
@@ -45,9 +45,9 @@ ADE_VIRTVAR(ActionEnter,
 
 ADE_VIRTVAR(ActionFrame,
 	l_LuaAISEXP,
-	"function(ai_helper helper, oswpt | nil arg) => bool action",
+	"function(ai_helper helper, oswpt | nil arg) => boolean action",
 	"The action of this AI SEXP to be executed each frame while active. Return true if the AI goal is complete.",
-	"function(ai_helper helper, oswpt | nil arg) => bool action",
+	"function(ai_helper helper, oswpt | nil arg) => boolean action",
 	"The action function or nil on error")
 {
 	lua_ai_sexp_h lua_sexp;

--- a/code/scripting/api/objs/luaaisexp.cpp
+++ b/code/scripting/api/objs/luaaisexp.cpp
@@ -19,7 +19,7 @@ ADE_OBJ(l_LuaAISEXP, lua_ai_sexp_h, "LuaAISEXP", "Lua AI SEXP handle");
 ADE_VIRTVAR(ActionEnter,
 	l_LuaAISEXP,
 	"function(ai_helper helper, oswpt | nil arg) => boolean action",
-	"The action of this AI SEXP to be executed once when the AI recieves this order. Return true if the AI goal is complete.",
+	"The action of this AI SEXP to be executed once when the AI receives this order. Return true if the AI goal is complete.",
 	"function(ai_helper helper, oswpt | nil arg) => boolean action",
 	"The action function or nil on error")
 {

--- a/code/scripting/api/objs/luaaisexp.cpp
+++ b/code/scripting/api/objs/luaaisexp.cpp
@@ -18,9 +18,9 @@ ADE_OBJ(l_LuaAISEXP, lua_ai_sexp_h, "LuaAISEXP", "Lua AI SEXP handle");
 
 ADE_VIRTVAR(ActionEnter,
 	l_LuaAISEXP,
-	"function(oswpt | nil arg) => bool action",
+	"function(ai_helper helper, oswpt | nil arg) => bool action",
 	"The action of this AI SEXP to be executed once when the AI recieves this order. Return true if the AI goal is complete.",
-	"function(oswpt | nil arg) => bool action",
+	"function(ai_helper helper, oswpt | nil arg) => bool action",
 	"The action function or nil on error")
 {
 	lua_ai_sexp_h lua_sexp;
@@ -45,9 +45,9 @@ ADE_VIRTVAR(ActionEnter,
 
 ADE_VIRTVAR(ActionFrame,
 	l_LuaAISEXP,
-	"function(oswpt | nil arg) => bool action",
+	"function(ai_helper helper, oswpt | nil arg) => bool action",
 	"The action of this AI SEXP to be executed each frame while active. Return true if the AI goal is complete.",
-	"function(oswpt | nil arg) => bool action",
+	"function(ai_helper helper, oswpt | nil arg) => bool action",
 	"The action function or nil on error")
 {
 	lua_ai_sexp_h lua_sexp;

--- a/code/scripting/api/objs/luaaisexp.h
+++ b/code/scripting/api/objs/luaaisexp.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "scripting/ade_api.h"
+#include "parse/sexp/LuaAISEXP.h"
+
+namespace scripting {
+namespace api {
+
+struct lua_ai_sexp_h {
+	sexp::LuaAISEXP* sexp_handle;
+
+	lua_ai_sexp_h(sexp::LuaAISEXP* sexp_handle);
+	lua_ai_sexp_h();
+
+	bool isValid();
+};
+
+DECLARE_ADE_OBJ(l_LuaAISEXP, lua_ai_sexp_h);
+
+}
+}
+

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15791,7 +15791,7 @@ SCP_string ship_return_orders(ship* sp)
 	if (aigp->ai_mode < 0)
 		return SCP_string();
 
-	auto order_text = Ai_goal_text(aigp->ai_mode);
+	auto order_text = Ai_goal_text(aigp->ai_mode, aigp->ai_submode);
 	if (order_text == nullptr)
 		return SCP_string();
 
@@ -15855,6 +15855,7 @@ SCP_string ship_return_orders(ship* sp)
 
 	case AI_GOAL_WAYPOINTS:
 	case AI_GOAL_WAYPOINTS_ONCE:
+	case AI_GOAL_LUA:
 		// don't do anything, all info is in order_text
 		break;
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -79,6 +79,8 @@ add_file_folder("AI"
 	ai/aigoals.cpp
 	ai/aigoals.h
 	ai/aiinternal.h
+	ai/ailua.cpp
+	ai/ailua.h
 	ai/aiturret.cpp
 )
 
@@ -1043,6 +1045,8 @@ add_file_folder("Parse\\\\SEXP"
 	parse/sexp/EngineSEXP.h
 	parse/sexp/LuaSEXP.cpp
 	parse/sexp/LuaSEXP.h
+	parse/sexp/LuaAISEXP.cpp
+	parse/sexp/LuaAISEXP.h
 	parse/sexp/sexp_lookup.cpp
 	parse/sexp/sexp_lookup.h
 	parse/sexp/SEXPParameterExtractor.cpp
@@ -1319,6 +1323,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/intelentry.h
 	scripting/api/objs/LuaSEXP.cpp
 	scripting/api/objs/LuaSEXP.h
+	scripting/api/objs/luaaisexp.cpp
+	scripting/api/objs/luaaisexp.h
 	scripting/api/objs/mc_info.cpp
 	scripting/api/objs/mc_info.h
 	scripting/api/objs/message.cpp

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1269,6 +1269,8 @@ add_file_folder("Scripting\\\\Api\\\\Libs"
 )
 
 add_file_folder("Scripting\\\\Api\\\\Objs"
+	scripting/api/objs/ai_helper.cpp
+	scripting/api/objs/ai_helper.h
 	scripting/api/objs/asteroid.cpp
 	scripting/api/objs/asteroid.h
 	scripting/api/objs/audio_stream.cpp

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -404,6 +404,8 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	gamesnd_parse_soundstbl();		// needs to be loaded after species stuff but before interface/weapon/ship stuff - taylor
 	mission_brief_common_init();	
 
+	sexp::dynamic_sexp_init(); // Must happen before ship init for LuaAI
+
 	animation::ModelAnimationParseHelper::parseTables();
 	obj_init();
 	model_free_all();				// Free all existing models
@@ -446,7 +448,6 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 
 	libs::ffmpeg::initialize();
 
-	sexp::dynamic_sexp_init();
 
 	// wookieejedi
 	// load in the controls and defaults including the controlconfigdefault.tbl

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1920,6 +1920,9 @@ void game_init()
 
 	animation::ModelAnimationParseHelper::parseTables();
 
+	// Initialize dynamic SEXPs. Must happen before ship init for LuaAI
+	sexp::dynamic_sexp_init();
+
 	obj_init();	
 	mflash_game_init();	
 	armor_init();
@@ -1969,8 +1972,6 @@ void game_init()
 	}
 
 	script_init();			//WMC
-	// Initialize dynamic SEXPs
-	sexp::dynamic_sexp_init();
 
 	// This needs to be done after the dynamic SEXP init so that our documentation contains the dynamic sexps
 	if (Cmdline_output_sexp_info) {

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -168,6 +168,10 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	listener(SubSystem::MissionBrief);
 	mission_brief_common_init();
 
+	// Initialize dynamic SEXPs. Must happen before ship init for LuaAI
+	listener(SubSystem::DynamicSEXPs);
+	sexp::dynamic_sexp_init();
+
 	listener(SubSystem::Objects);
 	obj_init();
 
@@ -244,9 +248,6 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 
 	listener(SubSystem::FFmpeg);
 	libs::ffmpeg::initialize();
-
-	listener(SubSystem::DynamicSEXPs);
-	sexp::dynamic_sexp_init();
 
 	// wookieejedi
 	// load in the controls and defaults including the controlconfigdefault.tbl


### PR DESCRIPTION
This PR adds the ability to add AI modes backed by scripting, similar to scripted SEXPs.
Additionally, these AI goals can be (in a limited fashion) registered to work as player orders (given through the comms menu).

An example of how this works is attached to the PR [here](https://github.com/scp-fs2open/fs2open.github.com/files/8535404/LuaAI.zip).

There are currently a few limitations and caveats to this.

General limits of the system with no improvement planned:
- Lua AI is limited to one target argument at most
- When a Lua AI goal is registered as a player order, it can only accept no targets or a ship as a target, not any oswpt type

Limits of the system that _could_ be improved or fixed, but with no immediate plans to do so:
- Since player orders themselves are limited to 32, Lua AI can only register about 16 more (possibly less in the future. SEXP-only AI modes, however, are unlimited) 
- Lua AI cannot be used for initially set goals of ships. They must be added by SEXP or by player order

Limits of the system that have soon-ish followup improvements already planned
- FRED saves allowed orders as a bitfield. This makes them susceptible to table loading order. In the future, this will be changed to an order-independent flagset. As that is a fairly large change however, it is deferred into a future PR
- Lua AI will play the Yessir message when recieving a new player order. Making that configurable is halfway implemented, but needs deliberation as to how to expose these messages to the table format
- FSO and FRED currently do not play nice with having more than 10 valid player orders for any objecttype. This limit will be removed in a future PR
- _Edit:_ Currently, scripting goals are always valid. Allowing the user to optionally define a function that tests whether the goal is currently valid for execution is planned for a future PR

Caveats that a user might stumble over if not aware of:
- The AI mode itself will be valid for all object types by default. If registered as a player order however, it needs to be added to the allowed player orders in the ``+Player Orders:	`` field of the objecttypes.tbl of the specific objecttype
- Lua AI will not take care of implausible orders for the scripter. If, for example, the target dies while the AI mode is active, it is the responsibility of the scripter to check for this and abort the AI mode if needed.