### PR TITLE
Delay processing "$Player Weapon Precedence:" until after parsing.

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1761,7 +1761,7 @@ void wl_remove_weps_from_pool(int *wep, int *wep_count, int ship_class)
 	
 					if ( (Wl_pool[wi_index] <= 0) || (wep_count[i] == 0) ) {
 						// fresh out of this weapon, pick an alternate pool weapon if we can
-						int wep_pool_index, wep_precedence_index, new_wi_index = -1;
+						int wep_pool_index, new_wi_index = -1;
 						for ( wep_pool_index = 0; wep_pool_index < weapon_info_size(); wep_pool_index++ ) {
 
 							if ( Wl_pool[wep_pool_index] <= 0 ) {
@@ -1777,8 +1777,8 @@ void wl_remove_weps_from_pool(int *wep, int *wep_count, int ship_class)
 								continue;
 							}
 
-							for ( wep_precedence_index = 0; wep_precedence_index < Num_player_weapon_precedence; wep_precedence_index++ ) {
-								if ( wep_pool_index == Player_weapon_precedence[wep_precedence_index] ) {
+							for ( const auto &precedence_index : Player_weapon_precedence ) {
+								if ( wep_pool_index == precedence_index ) {
 									new_wi_index = wep_pool_index;
 									break;
 								}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9548,7 +9548,7 @@ void ship_process_post(object * obj, float frametime)
  */
 static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 {
-	int			i, j;
+	int			i;
 	polymodel	*pm;
 	ship_weapon *swp = &shipp->weapons;
 	weapon_info *wip;
@@ -9574,9 +9574,7 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 		Error(LOCATION, "There are %d primary banks in the model file,\nbut only %d primary banks specified for %s.\nThis must be fixed, as it will cause crashes.\n", pm->n_guns, sip->num_primary_banks, sip->name);
 		for ( i = sip->num_primary_banks; i < pm->n_guns; i++ ) {
 			// Make unspecified weapon for bank be a laser
-			for ( j = 0; j < Num_player_weapon_precedence; j++ ) {
-				Assertion((Player_weapon_precedence[j] > 0), "Error reading player weapon precedence list. Check weapons.tbl for $Player Weapon Precedence entry, and correct as necessary.\n");
-				int weapon_id = Player_weapon_precedence[j];
+			for (const auto &weapon_id : Player_weapon_precedence) {
 				if ( (Weapon_info[weapon_id].subtype == WP_LASER) || (Weapon_info[weapon_id].subtype == WP_BEAM) ) {
 					swp->primary_bank_weapons[i] = weapon_id;
 					break;
@@ -9597,9 +9595,7 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 		Error(LOCATION, "There are %d secondary banks in the model file,\nbut only %d secondary banks specified for %s.\nThis must be fixed, as it will cause crashes.\n", pm->n_missiles, sip->num_secondary_banks, sip->name);
 		for ( i = sip->num_secondary_banks; i < pm->n_missiles; i++ ) {
 			// Make unspecified weapon for bank be a missile
-			for ( j = 0; j < Num_player_weapon_precedence; j++ ) {
-				Assertion((Player_weapon_precedence[j] > 0), "Error reading player weapon precedence list. Check weapons.tbl for $Player Weapon Precedence entry, and correct as necessary.\n");
-				int weapon_id = Player_weapon_precedence[j];
+			for (const auto &weapon_id : Player_weapon_precedence) {
 				if (Weapon_info[weapon_id].subtype == WP_MISSILE) {
 					swp->secondary_bank_weapons[i] = weapon_id;
 					break;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -662,8 +662,7 @@ extern int Num_weapons;
 extern int First_secondary_index;
 extern int Default_cmeasure_index;
 
-extern int Num_player_weapon_precedence;				// Number of weapon types in Player_weapon_precedence
-extern int Player_weapon_precedence[MAX_WEAPON_TYPES];	// Array of weapon types, precedence list for player weapon selection
+extern SCP_vector<int> Player_weapon_precedence;	// Vector of weapon types, precedence list for player weapon selection
 
 #define WEAPON_INDEX(wp)			(int)(wp-Weapons)
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -210,8 +210,10 @@ static int *used_weapons = NULL;
 int	Num_spawn_types = 0;
 char **Spawn_names = NULL;
 
-int Num_player_weapon_precedence;				// Number of weapon types in Player_weapon_precedence
-int Player_weapon_precedence[MAX_WEAPON_TYPES];	// Array of weapon types, precedence list for player weapon selection
+SCP_vector<int> Player_weapon_precedence;	// Vector of weapon types, precedence list for player weapon selection
+SCP_vector<SCP_string> Player_weapon_precedence_names;	// Vector of weapon names, gets turned into the above after parsing all modular tables and sorting the Weapon_info vector.
+SCP_string Player_weapon_precedence_file;	// If an invalid name is given, tell the user what file it was specified in.
+int Player_weapon_precedence_line;	// And this is the line the precedence list was given on.
 
 // Used to avoid playing too many impact sounds in too short a time interval.
 // This will elimate the odd "stereo" effect that occurs when two weapons impact at 
@@ -3588,7 +3590,9 @@ void parse_weaponstbl(const char *filename)
 		// during weapon selection.
 		if ((!Parsing_modular_table && required_string("$Player Weapon Precedence:")) || optional_string("$Player Weapon Precedence:"))
 		{
-			Num_player_weapon_precedence = (int)stuff_int_list(Player_weapon_precedence, MAX_WEAPON_TYPES, WEAPON_LIST_TYPE);
+			Player_weapon_precedence_file = filename;
+			Player_weapon_precedence_line = get_line_num();
+			stuff_string_list(Player_weapon_precedence_names);
 		}
 	}
 	catch (const parse::ParseException& e)
@@ -4144,6 +4148,22 @@ void weapon_generate_indexes_for_substitution() {
 	}
 }
 
+void weapon_generate_indexes_for_precedence()
+{
+	Player_weapon_precedence.clear();	// Make sure we're starting fresh.
+	for (const auto &name : Player_weapon_precedence_names) {
+		const char *cur_name = name.c_str();
+		const int cur_index = weapon_info_lookup(cur_name);
+		if (cur_index == -1) {
+			Warning(LOCATION, "Unknown weapon [%s] in player weapon precedence list (file %s, line %d).", cur_name, Player_weapon_precedence_file.c_str(), Player_weapon_precedence_line);
+		} else {
+			Player_weapon_precedence.push_back(cur_index);
+		}
+	}
+	Player_weapon_precedence_names = SCP_vector<SCP_string>();	// This is basically equivalent to .clear() and .shrink_to_fit() (it essentially swaps with the temporary vector, which then immediately deconstructs).
+	Player_weapon_precedence_file = "";	// Similar to the above, this would swap with an empty string, thereby being equivalent to .clear() and .shrink_to_fit().
+}
+
 void weapon_do_post_parse()
 {
 	weapon_info *wip;
@@ -4152,6 +4172,7 @@ void weapon_do_post_parse()
 	weapon_sort_by_type();	// NOTE: This has to be first thing!
 	weapon_clean_entries();
 	weapon_generate_indexes_for_substitution();
+	weapon_generate_indexes_for_precedence();
 
 	Default_cmeasure_index = -1;
 


### PR DESCRIPTION
The `stuff_int_list()` call converts the weapon names into the appropriate index into the `Weapon_info` array; however, in `weapon_do_post_parse()`, we call `weapon_sort_by_type()`, which reorders the array; this makes these indices potentially point to the wrong weapon. Additionally, there's no protection against someone `+remove`ing one of the weapons in the list in a later TBM.

This commit makes it so we instead store the names into a vector of strings, then convert them into indices after `weapon_sort_by_type()` has already been called. Additionally, `Player_weapon_precedence` is changed from a fixed-size array to a vector, since it's usually not as long as `MAX_WEAPON_TYPES`.

Fixes #4199.