### PR TITLE
Add a ship flag to allow the firing fail sound to play with locked primaries

### DIFF
--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -103,6 +103,8 @@ namespace Mission {
 		SF_Same_arrival_warp_when_docked,
 		SF_Same_departure_warp_when_docked,
 		OF_Attackable_if_no_collide, // Cyborg - keeps turrets from ignoring ships that have no_collide set
+		SF_Fail_sound_locked_primary, 	// Kiloku - Plays fail sound when firing with locked weapons
+		SF_Fail_sound_locked_secondary,	// Kiloku - Plays fail sound when firing with locked weapons
 
 		NUM_VALUES
 	};

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -318,8 +318,8 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "same-arrival-warp-when-docked",		Mission::Parse_Object_Flags::SF_Same_arrival_warp_when_docked,		true, false },
     { "same-departure-warp-when-docked",	Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked,	true, false },
     { "ai-attackable-if-no-collide",		Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
-	{ "fail-sound-locked-primary", 			Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary, true, false },
-	{ "fail-sound-locked-secondary", 		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false }
+    { "fail-sound-locked-primary", 			Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary, true, false },
+    { "fail-sound-locked-secondary", 		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false }
 };
 
 const size_t num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -318,6 +318,8 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "same-arrival-warp-when-docked",		Mission::Parse_Object_Flags::SF_Same_arrival_warp_when_docked,		true, false },
     { "same-departure-warp-when-docked",	Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked,	true, false },
     { "ai-attackable-if-no-collide",		Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
+	{ "fail-sound-locked-primary", 			Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary, true, false },
+	{ "fail-sound-locked-secondary", 		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false }
 };
 
 const size_t num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -318,8 +318,8 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "same-arrival-warp-when-docked",		Mission::Parse_Object_Flags::SF_Same_arrival_warp_when_docked,		true, false },
     { "same-departure-warp-when-docked",	Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked,	true, false },
     { "ai-attackable-if-no-collide",		Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
-    { "fail-sound-locked-primary", 			Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary, true, false },
-    { "fail-sound-locked-secondary", 		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false }
+    { "fail-sound-locked-primary",			Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary, true, false },
+    { "fail-sound-locked-secondary",		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false }
 };
 
 const size_t num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -34096,6 +34096,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"no-dynamic - Will stop allowing the AI to pursue dynamic goals (e.g.: chasing ships it was not ordered to)\r\n"
 		"free-afterburner-use - Allows the ship to use afterburners to follow waypoints\r\n"
 		"ai-attackable-if-no-collide - AI will still attack this ship even if collisions are disabled\r\n"
+		"fail-sound-locked-primary - This ship will play a weapon failure sound if trying to shoot primaries when they're locked\r\n"
+		"fail-sound-locked-secondary - This ship will play a weapon failure sound if trying to shoot secondaries when they're locked\r\n"
 	},
 
 	{ OP_SHIP_VISIBLE, "ship-visible\r\n"

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12454,7 +12454,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 	}
 	swp->next_secondary_fire_stamp[bank] = timestamp((int)(t * 1000.0f));
 	swp->last_secondary_fire_stamp[bank] = timestamp();
-	
+
 	// Here is where we check if weapons subsystem is capable of firing the weapon.
 	// do only in single player or if I am the server of a multiplayer game
 	if ( !(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER ) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -525,7 +525,8 @@ ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::No_disabled_self_destruct,	"no-disabled-self-destruct" },
 	{ Ship_Flags::Hide_mission_log,				"hide-in-mission-log" },
 	{ Ship_Flags::No_passive_lightning,			"no-ship-passive-lightning" },
-	{ Ship_Flags::Fail_sound_locked_primary, 	"fail-sound-locked-primary"}
+	{ Ship_Flags::Fail_sound_locked_primary, 	"fail-sound-locked-primary"},
+	{ Ship_Flags::Fail_sound_locked_secondary, 	"fail-sound-locked-secondary"}
 };
 
 static int Laser_energy_out_snd_timer;	// timer so we play out of laser sound effect periodically
@@ -12267,7 +12268,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 	}
 
 	// If the secondaries have been locked, bail
-	if (shipp->flags[Ship_Flags::Secondaries_locked])
+	if (shipp->flags[Ship_Flags::Secondaries_locked] && !(obj == Player_obj && shipp->flags[Ship_Flags::Fail_sound_locked_secondary]))
 	{
 		return 0;
 	}
@@ -12453,7 +12454,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 	}
 	swp->next_secondary_fire_stamp[bank] = timestamp((int)(t * 1000.0f));
 	swp->last_secondary_fire_stamp[bank] = timestamp();
-
+	
 	// Here is where we check if weapons subsystem is capable of firing the weapon.
 	// do only in single player or if I am the server of a multiplayer game
 	if ( !(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER ) {
@@ -12462,6 +12463,10 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 				if ( ship_maybe_do_secondary_fail_sound_hud(wip, false) ) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Cannot fire %s due to weapons system damage", 489), Weapon_info[weapon_idx].get_display_name());
 				}
+			goto done_secondary;
+		}
+		if (shipp->flags[Ship_Flags::Secondaries_locked] && (obj == Player_obj && shipp->flags[Ship_Flags::Fail_sound_locked_secondary])) {
+			ship_maybe_do_secondary_fail_sound_hud(wip, false);
 			goto done_secondary;
 		}
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12459,15 +12459,15 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 	// Here is where we check if weapons subsystem is capable of firing the weapon.
 	// do only in single player or if I am the server of a multiplayer game
 	if ( !(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER ) {
+		if (shipp->flags[Ship_Flags::Secondaries_locked] && (obj == Player_obj && shipp->flags[Ship_Flags::Fail_sound_locked_secondary])) {
+			ship_maybe_do_secondary_fail_sound_hud(wip, false);
+			goto done_secondary;
+		}
 		if ( ship_weapon_maybe_fail(shipp) ) {
 			if ( obj == Player_obj ) 
 				if ( ship_maybe_do_secondary_fail_sound_hud(wip, false) ) {
 					HUD_sourced_printf(HUD_SOURCE_HIDDEN, XSTR( "Cannot fire %s due to weapons system damage", 489), Weapon_info[weapon_idx].get_display_name());
 				}
-			goto done_secondary;
-		}
-		if (shipp->flags[Ship_Flags::Secondaries_locked] && (obj == Player_obj && shipp->flags[Ship_Flags::Fail_sound_locked_secondary])) {
-			ship_maybe_do_secondary_fail_sound_hud(wip, false);
 			goto done_secondary;
 		}
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11529,6 +11529,15 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			swp->last_primary_fire_stamp[bank_to_fire] = timestamp();
 		}
 
+
+		// The player is trying to fire primaries which are locked. We've set the Fail_sound_locked_primaries flag, so it should make the fail sound.
+		if  (obj == Player_obj && shipp->flags[Ship_Flags::Primaries_locked] && shipp->flags[Ship_Flags::Fail_sound_locked_primary])
+		{					
+			ship_maybe_do_primary_fail_sound_hud(false);
+			ship_stop_fire_primary_bank(obj, bank_to_fire);
+			continue;
+		}
+
 		// Here is where we check if weapons subsystem is capable of firing the weapon.
 		// Note that we can have partial bank firing, if the weapons subsystem is partially
 		// functional, which should be cool.  		
@@ -11677,14 +11686,6 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				} else {
 					numtimes = winfo_p->shots;
 					points = num_slots;
-				}
-
-				// The player is trying to fire primaries which are locked. We've set the Fail_sound_locked_primaries flag, so it should make the fail sound.
-				if  (obj == Player_obj && shipp->flags[Ship_Flags::Primaries_locked] && shipp->flags[Ship_Flags::Fail_sound_locked_primary])
-				{					
-					ship_maybe_do_primary_fail_sound_hud(false);
-					ship_stop_fire_primary_bank(obj, bank_to_fire);
-					continue;
 				}
 
 				// The energy-consumption code executes even for ballistic primaries, because

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -448,7 +448,7 @@ typedef struct ship_flag_name {
 	char flag_name[TOKEN_LENGTH];		// the name written to the mission file for its corresponding parse_object flag
 } ship_flag_name;
 
-#define MAX_SHIP_FLAG_NAMES					21
+#define MAX_SHIP_FLAG_NAMES					22
 extern ship_flag_name Ship_flag_names[];
 
 #define DEFAULT_SHIP_PRIMITIVE_SENSOR_RANGE		10000	// Goober5000

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -448,7 +448,7 @@ typedef struct ship_flag_name {
 	char flag_name[TOKEN_LENGTH];		// the name written to the mission file for its corresponding parse_object flag
 } ship_flag_name;
 
-#define MAX_SHIP_FLAG_NAMES					22
+#define MAX_SHIP_FLAG_NAMES					23
 extern ship_flag_name Ship_flag_names[];
 
 #define DEFAULT_SHIP_PRIMITIVE_SENSOR_RANGE		10000	// Goober5000

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -130,6 +130,7 @@ namespace Ship {
 		No_passive_lightning,		// Asteroth - disables ship passive lightning
 		Same_arrival_warp_when_docked,		// Goober5000
 		Same_departure_warp_when_docked,	// Goober5000
+		Fail_sound_locked_primary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
 
 		NUM_VALUES
 

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -131,6 +131,7 @@ namespace Ship {
 		Same_arrival_warp_when_docked,		// Goober5000
 		Same_departure_warp_when_docked,	// Goober5000
 		Fail_sound_locked_primary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
+		Fail_sound_locked_secondary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
 
 		NUM_VALUES
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3461,6 +3461,10 @@ int CFred_mission_save::save_objects()
 				fout(" \"same-departure-warp-when-docked\"");
 			if (objp->flags[Object::Object_Flags::Attackable_if_no_collide])
 				fout(" \"ai-attackable-if-no-collide\"");
+			if (shipp->flags[Ship::Ship_Flags::Fail_sound_locked_primary])
+				fout(" \"fail-sound-locked-primary\"");
+			if (shipp->flags[Ship::Ship_Flags::Fail_sound_locked_secondary])
+				fout(" \"fail-sound-locked-secondary\"");
 			fout(" )");
 		}
 		// -----------------------------------------------------------

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3245,6 +3245,12 @@ int CFred_mission_save::save_objects()
 			if (objp->flags[Object::Object_Flags::Attackable_if_no_collide]) {
 				fout(" \"ai-attackable-if-no-collide\"");
 			}
+			if (shipp->flags[Ship::Ship_Flags::Fail_sound_locked_primary]) {
+				fout(" \"fail-sound-locked-primary\"");
+			}
+			if (shipp->flags[Ship::Ship_Flags::Fail_sound_locked_secondary]) {
+				fout(" \"fail-sound-locked-secondary\"");
+			}
 			fout(" )");
 		}
 		// -----------------------------------------------------------


### PR DESCRIPTION
This Ship flag (`Fail_sound_locked_primaries`) causes the game to call the firing fail sound (like when you're out of weapon energy) if the player tries to fire their primaries when they're under the effects of the `Primaries_locked` flag. 

Tested and worked fine.