### PR TITLE
Move of special parsing functions out of lighting_profiles into new file

### DIFF
--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -4,6 +4,7 @@
 #include "def_files/def_files.h"
 #include "lighting/lighting.h"
 #include "lighting/lighting_profiles.h"
+#include "parse/parsehi.h"
 #include "parse/parselo.h"
 
 //TODO: maybe a parsehi.cpp would be in order here?
@@ -99,12 +100,12 @@ void lighting_profile::parse_default_section()
 			default_profile.tonemapper = tn;
 			keep_going = true;
 		}
-		keep_going |= optional_parse_into_float("$PPC Toe Strength:",&default_profile.ppc_values.toe_strength);
-		keep_going |= optional_parse_into_float("$PPC Toe Length:",&default_profile.ppc_values.toe_length);
-		keep_going |= optional_parse_into_float("$PPC Shoulder Length:",&default_profile.ppc_values.shoulder_length);
-		keep_going |= optional_parse_into_float("$PPC Shoulder Strength:",&default_profile.ppc_values.shoulder_strength);
-		keep_going |= optional_parse_into_float("$PPC Shoulder Angle:",&default_profile.ppc_values.shoulder_angle);
-		keep_going |= optional_parse_into_float("$Exposure:",&default_profile.exposure);
+		keep_going |= parse_optional_float_into("$PPC Toe Strength:",&default_profile.ppc_values.toe_strength);
+		keep_going |= parse_optional_float_into("$PPC Toe Length:",&default_profile.ppc_values.toe_length);
+		keep_going |= parse_optional_float_into("$PPC Shoulder Length:",&default_profile.ppc_values.shoulder_length);
+		keep_going |= parse_optional_float_into("$PPC Shoulder Strength:",&default_profile.ppc_values.shoulder_strength);
+		keep_going |= parse_optional_float_into("$PPC Shoulder Angle:",&default_profile.ppc_values.shoulder_angle);
+		keep_going |= parse_optional_float_into("$Exposure:",&default_profile.exposure);
 		//TODO: Handle case when there's no line matched but we haven't hit an #end
 		Assert(keep_going);
 	}

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -7,16 +7,6 @@
 #include "parse/parsehi.h"
 #include "parse/parselo.h"
 
-//TODO: maybe a parsehi.cpp would be in order here?
-bool optional_parse_into_float(const SCP_string &fieldname, float* valuetarget)
-{
-	if(optional_string(fieldname.c_str())){
-		stuff_float(valuetarget);
-		return true;
-	}
-	return false;
-}
-
 void lighting_profile::reset()
 {
 	name = "";

--- a/code/parse/parsehi.cpp
+++ b/code/parse/parsehi.cpp
@@ -1,0 +1,19 @@
+#include "parsehi.h"
+#include "parselo.h"
+
+/**
+ * @brief Parses an optional table value into a field if the name is found
+ *
+ * @param field_name The name of the table field
+ * @param value_target Pointer to the variable to assign any parsed value to
+ *
+ * @return True if a value was parsed, false if not
+ */
+bool parse_optional_float_into(const SCP_string& field_name, float* value_target)
+{
+	if (optional_string(field_name.c_str())) {
+		stuff_float(value_target);
+		return true;
+	}
+	return false;
+}

--- a/code/parse/parsehi.h
+++ b/code/parse/parsehi.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "parse/parselo.h"
+
+//parsehi is intended for higher level, frequently used combinations of parselo functions
+//and also for collection of standardized parsing of complex types where appropriate
+
+extern bool parse_optional_float_into(const SCP_string& field_name, float* value_target);

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1026,6 +1026,8 @@ add_file_folder("Parse"
 	parse/encrypt.h
 	parse/generic_log.cpp
 	parse/generic_log.h
+	parse/parsehi.cpp
+	parse/parsehi.h
 	parse/parselo.cpp
 	parse/parselo.h
 	parse/sexp.cpp


### PR DESCRIPTION
This takes a little bit of tedium reduction I used in lighting profiles parsing and makes it more generally available.
I have done some work on applying this concept to all common table parsing constructs, but I would like to make use of this approach in other things long before I would ever get done doing that, so I'm PRing this as is with the intent of adding more capabilities as I actually need them.