### PR TITLE
Fix Texture Replace and Team Colors with Ship Changes

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10094,18 +10094,18 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
  */
 static void ship_model_change(int n, int ship_type)
 {
-	int i;
-	ship_info* sip;
-	ship* sp;
-	polymodel* pm;
-	object* objp;
+	int			i;
+	ship_info	*sip;
+	ship			*sp;
+	polymodel * pm;
+	object *objp;
 
-	Assert(n >= 0 && n < MAX_SHIPS);
+	Assert( n >= 0 && n < MAX_SHIPS );
 	sp = &Ships[n];
 	sip = &(Ship_info[ship_type]);
 	objp = &Objects[sp->objnum];
 
-	// Stop Animation on the old model
+	//Stop Animation on the old model
 	animation::ModelAnimationSet::stopAnimations(model_get_instance(sp->model_instance_num));
 
 	// get new model
@@ -10113,8 +10113,8 @@ static void ship_model_change(int n, int ship_type)
 		sip->model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
 	}
 
-	if (sip->cockpit_model_num == -1) {
-		if (strlen(sip->cockpit_pof_file)) {
+	if ( sip->cockpit_model_num == -1 ) {
+		if ( strlen(sip->cockpit_pof_file) ) {
 			sip->cockpit_model_num = model_load(sip->cockpit_pof_file, 0, NULL);
 		}
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10124,7 +10124,7 @@ static void ship_model_change(int n, int ship_type)
 
 	// Goober5000 - deal with texture replacement by re-applying the same code we used during parsing
 	// wookieejedi - replacement textures are loaded in mission parse, so need to load any new textures here
-	if (sip->replacement_textures.size() > 0) {
+	if ( !sip->replacement_textures.empty() ) {
 
 		// clear and reset replacement textures because the new positions may be different
 		if (sp->ship_replacement_textures == nullptr)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6352,7 +6352,10 @@ void ship::clear()
 
 	primitive_sensor_range = DEFAULT_SHIP_PRIMITIVE_SENSOR_RANGE;
 
-	ship_replacement_textures = NULL;
+	if (ship_replacement_textures != nullptr) {
+		vm_free(ship_replacement_textures);
+	}
+	ship_replacement_textures = nullptr;
 
 	current_viewpoint = -1;
 
@@ -10148,6 +10151,12 @@ static void ship_model_change(int n, int ship_type)
 					}
 				}
 			}
+		}
+	} else {
+		// ensure that any texture replacements are cleared from old ship 
+		if (sp->ship_replacement_textures != nullptr) {
+			vm_free(sp->ship_replacement_textures);
+			sp->ship_replacement_textures = nullptr;
 		}
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10844,7 +10844,12 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 
 	if (sip->uses_team_colors)
 	{
-		sp->team_name = sip->default_team_name;
+		// wookieejedi - mantain team color setting if possible
+		if (!p_objp->team_color_setting.empty()) {
+			sp->team_name = p_objp->team_color_setting;
+		} else {
+			sp->team_name = sip->default_team_name;
+		}
 	}
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10123,10 +10123,10 @@ static void ship_model_change(int n, int ship_type)
 	Objects[sp->objnum].radius = model_get_radius(pm->id);
 
 	// Goober5000 - deal with texture replacement by re-applying the same code we used during parsing
-	// wookieejedi - replacement textures are loaded in mission parse, so need to load any new textures
+	// wookieejedi - replacement textures are loaded in mission parse, so need to load any new textures here
 	if (sip->replacement_textures.size() > 0) {
 
-		// clear and reset replace textures because the new positions may be different
+		// clear and reset replacement textures because the new positions may be different
 		if (sp->ship_replacement_textures == nullptr)
 			sp->ship_replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
 		for (auto k = 0; k < MAX_REPLACEMENT_TEXTURES; k++)
@@ -10844,7 +10844,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 
 	if (sip->uses_team_colors)
 	{
-		// wookieejedi - mantain team color setting if possible
+		// wookieejedi - maintain team color setting if possible
 		if (!p_objp->team_color_setting.empty()) {
 			sp->team_name = p_objp->team_color_setting;
 		} else {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10123,7 +10123,7 @@ static void ship_model_change(int n, int ship_type)
 	Objects[sp->objnum].radius = model_get_radius(pm->id);
 
 	// Goober5000 - deal with texture replacement by re-applying the same code we used during parsing
-	// wookieejedi - these replacement textures have not been loaded in, since ship texture replacement load only occurs
+	// wookieejedi - replacement textures are loaded in mission parse, so need to load any new textures
 	if (sip->replacement_textures.size() > 0) {
 
 		// clear and reset replace textures because the new positions may be different


### PR DESCRIPTION
Tabled `$Texture Replace` did not work on ships where the class is changed in the loadout or with the `change-ship-class` sexp. This was because the replacement textures only were loaded during mission parse, and the `change_ship_type` did not account for loading new textures from ship classes that were not in the initial mission parse. Part of the bug was also that the code that updates texture replacements was after the texture page-in section of `change_ship_type`.

This PR fixes that bug by properly loading the textures in when the ship class changes. It also moves the code to within the `ship_model_change` function (which is only used in the `change_ship_type` function) so that the texture loading happens correctly before texture page in. The updated code also fixes some other edge case bugs to ensure that texture replace happens even if the old ship type did not use texture replacement. 

PR also fixes bug where Team Color was not maintained between loadout changes with ships that all had team colors enabled. 