### PR TITLE
Limit all MP client collisions to prevent bugs

### DIFF
--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -805,6 +805,15 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 		Assert( !vm_is_vec_nan(&direction_light) );
 		vm_vec_scale_add2(&heavy->pos, &direction_light,  0.2f * lighter->phys_info.mass / (heavy->phys_info.mass + lighter->phys_info.mass));
 		vm_vec_scale_add2(&heavy->pos, &ship_ship_hit_info->collision_normal, -0.1f * lighter->phys_info.mass / (heavy->phys_info.mass + lighter->phys_info.mass));
+
+		// while we are in a block that has already checked if we should collide, set the MP client timestamps
+		if (MULTIPLAYER_CLIENT){
+			if (lighter == Player_obj && heavy->type == OBJ_SHIP){
+				Ships[heavy->instance].multi_client_collision_timestamp = _timestamp( calculate_next_multiplayer_client_collision_time(impulse_mag) );
+			} else if (lighter->type == OBJ_SHIP) {
+				Ships[lighter->instance].multi_client_collision_timestamp = _timestamp( calculate_next_multiplayer_client_collision_time(impulse_mag) );
+			}
+		}
 	}
 	
 	//For landings, we want minimal movement on the light ship (just enough to keep the collision detection honest)
@@ -822,14 +831,6 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 			lighter->phys_info.mass = copy_mass;
 		} else {
 			heavy->phys_info.mass = copy_mass;
-		}
-	}
-
-	if (MULTIPLAYER_CLIENT && should_collide){
-		if (lighter == Player_obj && heavy->type == OBJ_SHIP){
-			Ships[heavy->instance].multi_client_collision_timestamp = _timestamp( calculate_next_multiplayer_client_collision_time(impulse_mag) );
-		} else if (lighter->type == OBJ_SHIP) {
-			Ships[lighter->instance].multi_client_collision_timestamp = _timestamp( calculate_next_multiplayer_client_collision_time(impulse_mag) );
 		}
 	}
 }

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -754,9 +754,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 		vm_vec_scale(&impulse, impulse_mag);
 		vm_vec_scale(&delta_rotvel_light, impulse_mag);	
 		physics_collide_whack(&impulse, &delta_rotvel_light, &lighter->phys_info, &lighter->orient, ship_ship_hit_info->is_landing);
-	}
 
-	if (should_collide) {
 		vm_vec_negate(&impulse);
 		vm_vec_scale(&delta_rotvel_heavy, -impulse_mag);
 		physics_collide_whack(&impulse, &delta_rotvel_heavy, &heavy->phys_info, &heavy->orient, true);

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -481,9 +481,9 @@ static int calculate_next_multiplayer_client_collision_time(float impulse_magnit
 	// Uses a continuous cubic rational function that allows us to space out collisions based on collision strength.
 	// based on some quick tests from Asteroth about how strong impuse is on average.
 	constexpr float IMPULSE_RANGE_FACTOR = 0.000000000001031f; 	// The inverse of the range of regular impulse values, 9900, to the third power
-	constexpr int MIN_IMPULSE = 100;							// The lowest values of collisions that we see.  Ignore if lower than this.
-	constexpr int LONGEST_COLLISION_INTERVAL = 175;				// 1/5th of a second is usually enough time to get an update from the server.
-	constexpr int MINIMUM_INTERVAL = 25;						// if there is sufficient impulse, don't go below this value.
+	constexpr float MIN_IMPULSE = 100.0f;							// The lowest values of collisions that we see.  Ignore if lower than this.
+	constexpr float LONGEST_COLLISION_INTERVAL = 175.0f;				// 1/5th of a second is usually enough time to get an update from the server.
+	constexpr float MINIMUM_INTERVAL = 25.0f;						// if there is sufficient impulse, don't go below this value.
 
 	impulse_magnitude -= MIN_IMPULSE;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6413,6 +6413,9 @@ void ship::clear()
 	team_change_time = 0;
 
 	autoaim_fov = 0.0f;
+
+	multi_client_collision_timestamp.immediate();
+
 	passive_arc_next_times.clear();
 }
 bool ship::has_display_name() const {
@@ -6696,6 +6699,9 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 	shipp->secondary_team_name = "none";
 
 	shipp->autoaim_fov = sip->autoaim_fov;
+
+	shipp->multi_client_collision_timestamp.immediate();
+
 	shipp->max_shield_regen_per_second = sip->max_shield_regen_per_second;
 	shipp->max_weapon_regen_per_second = sip->max_weapon_regen_per_second;
 	

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6414,7 +6414,7 @@ void ship::clear()
 
 	autoaim_fov = 0.0f;
 
-	multi_client_collision_timestamp.immediate();
+	multi_client_collision_timestamp = TIMESTAMP::immediate();
 
 	passive_arc_next_times.clear();
 }
@@ -6700,7 +6700,7 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 
 	shipp->autoaim_fov = sip->autoaim_fov;
 
-	shipp->multi_client_collision_timestamp.immediate();
+	shipp->multi_client_collision_timestamp = TIMESTAMP::immediate();
 
 	shipp->max_shield_regen_per_second = sip->max_shield_regen_per_second;
 	shipp->max_weapon_regen_per_second = sip->max_weapon_regen_per_second;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -797,6 +797,9 @@ public:
 
 	float autoaim_fov;
 
+	TIMESTAMP	multi_client_collision_timestamp;
+
+
 	enum warpstage {
 		STAGE1 = 0,
 		STAGE2,

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -799,7 +799,6 @@ public:
 
 	TIMESTAMP	multi_client_collision_timestamp;
 
-
 	enum warpstage {
 		STAGE1 = 0,
 		STAGE2,


### PR DESCRIPTION
Clients with bad pings can find themselves being thrown to the far corners of the map because multiple collisions can happen before an update can be received from the server, compounding the effects of collisions.  (And on the second collision, an interpolated ship can actually do the opposite of react properly to a collision impulse, especially if a brand new object update packet has just come in, making the subsequent collision even more powerful)

Client players are still affected by collisions on their local instance, but other ships will literally pass through each other until updated by the server (avoids other bugs with stationary ships).  A new timestamp controls the frequency of collisions with the player ship, so that the buggy secondary collisions do not happen.

Still needs to be tested, but ready to be reviewed.