### PR TITLE
Beam light cleanup

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1851,6 +1851,14 @@ bool beam_light_sanity_and_setup(beam const* bm, object const* objp, weapon_info
 	return true;
 }
 
+float beam_light_noise(beam const* bm, beam_weapon_info const* bwi)
+{
+	if ((bm->warmup_stamp < 0) && (bm->warmdown_stamp < 0)) // disable noise when warming up or down
+		return frand_range(1.0f - bwi->sections[0].flicker, 1.0f + bwi->sections[0].flicker);
+	else
+		return 1.0f;
+}
+
 // call to add a light source to a small object
 void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 {
@@ -1862,12 +1870,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 
 	Assert(pt != nullptr);
 
-	float noise;
-	// some noise
-	if ( (bm->warmup_stamp < 0) && (bm->warmdown_stamp < 0) ) // disable noise when warming up or down
-		noise = frand_range(1.0f - bwi->sections[0].flicker, 1.0f + bwi->sections[0].flicker);
-	else
-		noise = 1.0f;
+	float noise = beam_light_noise(bm,bwi);
 
 	// get the width of the beam
 	float light_rad = beam_current_light_radius(bm,bwi,noise);
@@ -1903,9 +1906,7 @@ void beam_add_light_large(beam *bm, object *objp, vec3d *pt0, vec3d *pt1)
 	if (!beam_light_sanity_and_setup(bm, objp, &wip, &bwi))
 		return;
 
-	float noise;
-	// some noise
-	noise = frand_range(1.0f - bwi->sections[0].flicker, 1.0f + bwi->sections[0].flicker);
+	float noise = beam_light_noise(bm, bwi);
 
 	// width of the beam
 	float light_rad = beam_current_light_radius(bm,bwi,noise);

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1821,7 +1821,7 @@ DCF(blight, "Sets the beam light scale factor (Default is 25.5f)")
 	dc_stuff_float(&blight);
 }
 
-float beam_current_light_radius(beam* bm, beam_weapon_info* bwi, float noise)
+float beam_current_light_radius(beam* bm, float noise)
 {
 	return bm->beam_light_width * bm->current_width_factor * blight * noise;
 }
@@ -1873,7 +1873,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 	float noise = beam_light_noise(bm,bwi);
 
 	// get the width of the beam
-	float light_rad = beam_current_light_radius(bm,bwi,noise);
+	float light_rad = beam_current_light_radius(bm,noise);
 
 	// average rgb of the beam	
 	float fr = (float)wip->laser_color_1.red / 255.0f;
@@ -1909,7 +1909,7 @@ void beam_add_light_large(beam *bm, object *objp, vec3d *pt0, vec3d *pt1)
 	float noise = beam_light_noise(bm, bwi);
 
 	// width of the beam
-	float light_rad = beam_current_light_radius(bm,bwi,noise);
+	float light_rad = beam_current_light_radius(bm,noise);
 
 	// average rgb of the beam	
 	float fr = (float)wip->laser_color_1.red / 255.0f;

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1821,6 +1821,11 @@ DCF(blight, "Sets the beam light scale factor (Default is 25.5f)")
 	dc_stuff_float(&blight);
 }
 
+float beam_current_light_radius(beam* bm, beam_weapon_info* bwi, float noise)
+{
+	return bm->beam_light_width * bm->current_width_factor * blight * noise;
+}
+
 // call to add a light source to a small object
 void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 {
@@ -1853,7 +1858,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 		noise = 1.0f;
 
 	// get the width of the beam
-	float light_rad = bm->beam_light_width * bm->current_width_factor * blight * noise;
+	float light_rad = beam_current_light_radius(bm,bwi,noise);
 
 	// average rgb of the beam	
 	float fr = (float)wip->laser_color_1.red / 255.0f;
@@ -1906,7 +1911,7 @@ void beam_add_light_large(beam *bm, object *objp, vec3d *pt0, vec3d *pt1)
 	noise = frand_range(1.0f - bwi->sections[0].flicker, 1.0f + bwi->sections[0].flicker);
 
 	// width of the beam
-	float light_rad = bm->beam_light_width * bm->current_width_factor * blight * noise;
+	float light_rad = beam_current_light_radius(bm,bwi,noise);
 
 	// average rgb of the beam	
 	float fr = (float)wip->laser_color_1.red / 255.0f;

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1822,7 +1822,7 @@ DCF(blight, "Sets the beam light scale factor (Default is 25.5f)")
 }
 
 // call to add a light source to a small object
-void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
+void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 {
 	weapon_info *wip;
 	beam_weapon_info *bwi;
@@ -1845,7 +1845,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 	Assert(bm->weapon_info_index >= 0);
 	wip = &Weapon_info[bm->weapon_info_index];
 	bwi = &wip->b_info;
-
+	Assert(pt!= nullptr);
 	// some noise
 	if ( (bm->warmup_stamp < 0) && (bm->warmdown_stamp < 0) ) // disable noise when warming up or down
 		noise = frand_range(1.0f - bwi->sections[0].flicker, 1.0f + bwi->sections[0].flicker);
@@ -1853,19 +1853,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 		noise = 1.0f;
 
 	// get the width of the beam
-	float light_rad = bm->beam_light_width * bm->current_width_factor * blight * noise;	
-
-	// nearest point on the beam, and its distance to the ship
-	vec3d near_pt;
-	if(pt_override == NULL){
-		float dist;
-		vm_vec_dist_to_line(&objp->pos, &bm->last_start, &bm->last_shot, &near_pt, &dist);
-		if(dist > light_rad){
-			return;
-		}
-	} else {
-		near_pt = *pt_override;
-	}
+	float light_rad = bm->beam_light_width * bm->current_width_factor * blight * noise;
 
 	// average rgb of the beam	
 	float fr = (float)wip->laser_color_1.red / 255.0f;
@@ -1886,7 +1874,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt_override = NULL)
 		pct = 1.0f;
 	}
 	// add a light
-	light_add_point(&near_pt, light_rad * 0.0001f, light_rad, pct, fr, fg, fb);
+	light_add_point(pt, light_rad * 0.0001f, light_rad, pct, fr, fg, fb);
 }
 
 // call to add a light source to a large object


### PR DESCRIPTION
`beam_add_light_small()` and `beam_add_light_large()` duplicate a lot of logic, and in working on #4208 I found this to be an obstacle to making any changes to them and my attempts to work around that are significant enough to deserve individual scrutiny in my mind. I've moved what are to me logically discrete steps of that shared logic into functions, and eliminated some logically unreachable code as well.