### PR TITLE
patch the freeing of SEXP nodes

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2170,7 +2170,10 @@ int parse_create_object_sub(p_object *p_objp)
 
 		// free the sexpression nodes only for non-wing ships.  wing code will handle its own case
 		if (p_objp->wingnum < 0)
+		{
 			free_sexp2(p_objp->ai_goals);	// free up sexp nodes for reuse, since they aren't needed anymore.
+			p_objp->ai_goals = -1;
+		}
 	}
 
 	Assert(sip->model_num != -1);
@@ -4335,7 +4338,10 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, int force, int spec
 					
 					// free up sexp nodes for reuse
 					if (p_objp->ai_goals != -1)
+					{
 						free_sexp2(p_objp->ai_goals);
+						p_objp->ai_goals = -1;
+					}
 				}
 			}
 		}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1384,7 +1384,8 @@ int free_sexp(int num, int calling_node)
 	Assert(Sexp_nodes[num].type != SEXP_NOT_USED);  // make sure it is actually used
 	Assert(!(Sexp_nodes[num].type & SEXP_FLAG_PERSISTENT));
 
-	if ((num == Locked_sexp_true) || (num == Locked_sexp_false))
+	// never free these nodes
+	if ((num == -1) || (num == Locked_sexp_true) || (num == Locked_sexp_false))
 		return 0;
 
 	Sexp_nodes[num].type = SEXP_NOT_USED;
@@ -1398,8 +1399,9 @@ int free_sexp(int num, int calling_node)
 	i = Sexp_nodes[num].first;
 	while (i != -1) 
 	{
+		rest = Sexp_nodes[i].rest;
 		count += free_sexp(i, num);
-		i = Sexp_nodes[i].rest;
+		i = rest;
 	}
 
 	rest = Sexp_nodes[num].rest;
@@ -1421,21 +1423,27 @@ int free_sexp(int num, int calling_node)
  * Because the root node is an operator, instead of a list, we can't simply call free_sexp().  
  * This function should only be called on the root node of an sexp, otherwise the linking will get screwed up.
  */
-int free_sexp2(int num)
+int free_sexp2(int num, int calling_node)
 {	
-	int i, count = 0;
+	int i, rest, count = 0;
 
+	Assert((num >= 0) && (num < Num_sexp_nodes));
+	Assert(Sexp_nodes[num].type != SEXP_NOT_USED);  // make sure it is actually used
+	Assert(!(Sexp_nodes[num].type & SEXP_FLAG_PERSISTENT));
+
+	// never free these nodes
 	if ((num == -1) || (num == Locked_sexp_true) || (num == Locked_sexp_false)){
 		return 0;
 	}
 
 	i = Sexp_nodes[num].rest;
 	while (i != -1) {
-		count += free_sexp(i);
-		i = Sexp_nodes[i].rest;
+		rest = Sexp_nodes[i].rest;
+		count += free_sexp(i, num);
+		i = rest;
 	}
 
-	count += free_sexp(num);
+	count += free_sexp(num, calling_node);
 	return count;
 }
 
@@ -3866,7 +3874,7 @@ int get_sexp()
 		if (n >= 0)
 		{
 			// free the entire rest of the argument list
-			free_sexp2(n);	
+			free_sexp2(n, CDR(start));
 		}
 	}
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1260,7 +1260,7 @@ extern int alloc_sexp(const char *text, int type, int subtype, int first, int re
 extern int find_free_sexp();
 extern int free_one_sexp(int num);
 extern int free_sexp(int num, int calling_node = -1);
-extern int free_sexp2(int num);
+extern int free_sexp2(int num, int calling_node = -1);
 extern int dup_sexp_chain(int node);
 extern int cmp_sexp_chains(int node1, int node2);
 extern int find_sexp_list(int num);

--- a/fred2/campaigntreeview.cpp
+++ b/fred2/campaigntreeview.cpp
@@ -273,7 +273,7 @@ void stuff_link_with_formula(int *link_idx, int formula, int mission_num)
 				} else
 					Int3();			// bogus operator in campaign file
 
-				free_sexp(CDR(node2));
+				free_sexp(Sexp_nodes[node2].rest, node2);
 				free_one_sexp(node);
 				node = CDR(node);
 			}


### PR DESCRIPTION
Followup to #4088.  A few calls of `free_sexp` (especially in `free_sexp2`) did not supply the calling node, which left inconsistent SEXP tree structures and caused a crash in TranscendE1M6.  This fixes the crash and fills in some of these places.