### PR TITLE
Early return instead of assert on 0 or less sized hud brackets

### DIFF
--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -57,9 +57,9 @@ void draw_brackets_square(graphics::line_draw_list* draw_list, int x1, int y1, i
 	}
 	
 	width = x2 - x1;
-	Assert( width > 0);
 	height = y2 - y1;
-	Assert( height > 0);
+	if (width < 1 || height < 1)
+		return;
 
 	// make the brackets extend 25% of the way along the width or height
 	int bracket_width = width/4;

--- a/code/hud/hudbrackets.h
+++ b/code/hud/hudbrackets.h
@@ -16,7 +16,10 @@
 #include "graphics/line_draw_list.h"
 
 void hud_init_brackets();
+
+// requires that x2 > x1 and y2 > y1
 void draw_brackets_square(graphics::line_draw_list* draw_list, int x1, int y1, int x2, int y2, int resize_mode = GR_RESIZE_FULL);
+
 void draw_brackets_square_quick(graphics::line_draw_list* draw_list, int x1, int y1, int x2, int y2, int thick=0);
 void draw_brackets_diamond_quick(graphics::line_draw_list* draw_list, int x1, int y1, int x2, int y2);
 


### PR DESCRIPTION
This is a relatively minor issue that ought not to bring everything to a screeching halt.

I'm not going to say this will fix (github pls) #4214 just yet. It's possible other engine code is doing something wonky that resulted in bad parameters that warrants a bit more investigation.