### PR TITLE
Fix RTT Cockpits Gauges with Change Ship Class

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -18045,7 +18045,10 @@ void sexp_change_ship_class(int n)
 			{
 				change_ship_type(ship_entry->objp->instance, class_num, 1);
 				if (ship_entry->shipp == Player_ship) {
+					// update hud and RTT cockpit HUD gauges if applicable
 					set_current_hud();
+					ship_clear_cockpit_displays();
+					ship_init_cockpit_displays(Player_ship);
 				}
 
 				if (MULTIPLAYER_MASTER) {
@@ -18075,7 +18078,10 @@ void multi_sexp_change_ship_class()
 			if ((class_num >= 0) && (ship_num >= 0)) {
 				change_ship_type(ship_num, class_num, 1);
 				if (&Ships[ship_num] == Player_ship) {
+					// update hud and RTT cockpit HUD gauges if applicable
 					set_current_hud();
+					ship_clear_cockpit_displays();
+					ship_init_cockpit_displays(Player_ship);
 				}
 			}
 		}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -18045,7 +18045,7 @@ void sexp_change_ship_class(int n)
 			{
 				change_ship_type(ship_entry->objp->instance, class_num, 1);
 				if (ship_entry->shipp == Player_ship) {
-					// update hud and RTT cockpit HUD gauges if applicable
+					// update HUD and RTT cockpit gauges if applicable
 					set_current_hud();
 					ship_clear_cockpit_displays();
 					ship_init_cockpit_displays(Player_ship);
@@ -18078,7 +18078,7 @@ void multi_sexp_change_ship_class()
 			if ((class_num >= 0) && (ship_num >= 0)) {
 				change_ship_type(ship_num, class_num, 1);
 				if (&Ships[ship_num] == Player_ship) {
-					// update hud and RTT cockpit HUD gauges if applicable
+					// update HUD and RTT cockpit gauges if applicable
 					set_current_hud();
 					ship_clear_cockpit_displays();
 					ship_init_cockpit_displays(Player_ship);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -332,7 +332,7 @@ ADE_VIRTVAR(Class, l_Ship, "shipclass", "Ship class", "shipclass", "Ship class, 
 	if(ADE_SETTING_VAR && idx > -1) {
 		change_ship_type(objh->objp->instance, idx, 1);
 		if (shipp == Player_ship) {
-			// update hud and RTT cockpit HUD gauges if applicable
+			// update HUD and RTT cockpit gauges if applicable
 			set_current_hud();
 			ship_clear_cockpit_displays();
 			ship_init_cockpit_displays(Player_ship);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -332,7 +332,10 @@ ADE_VIRTVAR(Class, l_Ship, "shipclass", "Ship class", "shipclass", "Ship class, 
 	if(ADE_SETTING_VAR && idx > -1) {
 		change_ship_type(objh->objp->instance, idx, 1);
 		if (shipp == Player_ship) {
+			// update hud and RTT cockpit HUD gauges if applicable
 			set_current_hud();
+			ship_clear_cockpit_displays();
+			ship_init_cockpit_displays(Player_ship);
 		}
 	}
 


### PR DESCRIPTION
Previously, using the `change-ship-class` sexp or scripting function did not update RTT cockpit gauges. This PR adds the cockpit code update functions to fix the issue. Tested and works as expected.