### PR TITLE
Always record primary bank ammo capacity during ship creation.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9634,9 +9634,9 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 				swp->primary_bank_ammo[i] = (int)std::lround(capacity / size);
 				swp->primary_bank_start_ammo[i] = swp->primary_bank_ammo[i];
 			}
-
-			swp->primary_bank_capacity[i] = sip->primary_bank_ammo_capacity[i];
 		}
+
+		swp->primary_bank_capacity[i] = sip->primary_bank_ammo_capacity[i];
 	}
 
 	swp->num_secondary_banks = sip->num_secondary_banks;


### PR DESCRIPTION
`ship_set_default_weapons()` (which is called by `ship_create()`) was only setting `swp->primary_bank_capacity` for a bank if the default weapon for that bank was ballistic; if the ship was then equipped with an ammo-using primary and the `set-primary-ammo` SEXP was used on it, it would think the bank had a capacity of zero, resulting in 0 ammo.

This commit simply moves the assignment outside of the conditional, so that primary bank capacities are always recorded in the `ship_weapon` class.