### PR TITLE
Add cockpit FoV

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -14,6 +14,7 @@
 
 //*************************IMPORTANT GLOBALS*************************
 float VIEWER_ZOOM_DEFAULT = 0.75f;			//	Default viewer zoom, 0.625 as per multi-lateral agreement on 3/24/97
+float COCKPIT_ZOOM_DEFAULT = 0.75f;
 float Sexp_fov = 0.0f;
 warp_camera Warp_camera;
 

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -156,6 +156,7 @@ public:
 //Some global stuff
 extern SCP_vector<subtitle> Subtitles;
 extern float VIEWER_ZOOM_DEFAULT;
+extern float COCKPIT_ZOOM_DEFAULT;
 extern float Sexp_fov;
 
 //Helpful functions

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -311,6 +311,7 @@ int Cmdline_use_last_pilot = 0;
 
 // Graphics related
 cmdline_parm fov_arg("-fov", "Vertical field-of-view factor", AT_FLOAT);					// Cmdline_fov  -- comand line FOV -Bobboau
+cmdline_parm fov_cockpit_arg("-fov_cockpit", "Vertical field-of-view factor for Cockpits", AT_FLOAT);
 cmdline_parm clip_dist_arg("-clipdist", "Changes the distance from the viewpoint for the near-clipping plane", AT_FLOAT);		// Cmdline_clip_dist
 cmdline_parm spec_static_arg("-spec_static", "Adjusts suns contribution to specular highlights", AT_FLOAT);
 cmdline_parm spec_point_arg("-spec_point", "Adjusts laser weapons contribution to specular highlights", AT_FLOAT);
@@ -1813,6 +1814,16 @@ bool SetCmdlineParams()
 			VIEWER_ZOOM_DEFAULT = val;
 		} else {
 			VIEWER_ZOOM_DEFAULT = 0.75f;
+		}
+	}
+
+	if ( fov_cockpit_arg.found() ) {
+		auto val = fov_cockpit_arg.get_float();
+		if (val > 0.1) {
+			COCKPIT_ZOOM_DEFAULT = val;
+		}
+		else {
+			COCKPIT_ZOOM_DEFAULT = VIEWER_ZOOM_DEFAULT;
 		}
 	}
 

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -54,6 +54,12 @@ extern void g3_end_frame_func(const char *filename, int lineno);
  */
 extern int g3_in_frame();
 
+
+/**
+ * Sets the Proj_fov from the specified zoom value
+ */
+void g3_set_fov(float zoom);
+
 /**
  * Set view from camera
  */

--- a/code/render/3dsetup.cpp
+++ b/code/render/3dsetup.cpp
@@ -124,6 +124,10 @@ void g3_end_frame_func(const char * /*filename*/, int  /*lineno*/)
 
 void scale_matrix(void);
 
+void g3_set_fov(float zoom) {
+	Proj_fov = 1.39626348f * zoom;
+}
+
 void g3_set_view(camera *cam)
 {
 	vec3d pos;
@@ -148,7 +152,7 @@ void g3_set_view_matrix(const vec3d *view_pos, const matrix *view_matrix, float 
 
 	View_matrix = *view_matrix;
 
-	Proj_fov = 1.39626348f * View_zoom;
+	g3_set_fov(View_zoom);
 
 	Eye_matrix = View_matrix;
 	Eye_position = *view_pos;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7332,6 +7332,9 @@ void ship_render_cockpit(object *objp)
 	vm_vec_unrotate(&pos, &sip->cockpit_offset, &eye_ori);
 
 	bool shadow_override_backup = Shadow_override;
+	float fov_backup = Proj_fov;
+
+	g3_set_fov(Sexp_fov <= 0.0f ? COCKPIT_ZOOM_DEFAULT : Sexp_fov);
 
 	//Deal with the model
 	model_clear_instance(sip->cockpit_model_num);
@@ -7366,6 +7369,8 @@ void ship_render_cockpit(object *objp)
 	render_info.set_replacement_textures(Player_cockpit_textures);
 
 	model_render_immediate(&render_info, sip->cockpit_model_num, &eye_ori, &pos);
+
+	Proj_fov = fov_backup;
 
 	gr_end_view_matrix();
 	gr_end_proj_matrix();


### PR DESCRIPTION
Implements / fixes #4219.
With this PR, SEXP'd FoV has precedence over the -fov_cockpit cmdline parameter, which has precedence over the -fov cmdline parameter which has precedence over the default 0.75 FoV.