### PR TITLE
Avoid setting .rest for Locked_sexp_true/false with malformed SEXPs.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3665,7 +3665,7 @@ void localize_sexp(int text_node, int id_node)
  */
 int get_sexp()
 {
-	int start, node, last, op, count;
+	int start, node, last, op;
 	char token[TOKEN_LENGTH];
 	char variable_text[TOKEN_LENGTH];
 
@@ -3845,6 +3845,11 @@ int get_sexp()
 			start = node;
 		} else {
 			Assert(last != -1);
+			// Locked_sexp_true and Locked_sexp_false are only meant to represent operator
+			// nodes with no arguments, i.e. (true) and (false). If they appear as "bare"
+			// arguments to another operator, or have arguments of their own, the global
+			// SEXP node structure can become corrupted; we hack around this by always
+			// wrapping them in their own list in these cases and warning the user.
 			if (last == start && (start == Locked_sexp_false || start == Locked_sexp_true)) {
 				Warning(LOCATION, "Found true or false operator at the start of a list, likely in a handwritten SEXP.");
 				start = alloc_sexp("", SEXP_LIST, SEXP_ATOM_LIST, start, -1);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3673,12 +3673,10 @@ int get_sexp()
 
 	// start - the node allocated in first instance of function
 	// node - the node allocated in current instance of function
-	// count - number of nodes allocated this instance of function [do we set last.rest or .first]
 	// variable - whether string or number is a variable referencing Sexp_variables
 
 	// initialization
 	start = last = -1;
-	count = 0;
 
 	ignore_white_space();
 	while (*Mp != ')') {
@@ -3843,11 +3841,20 @@ int get_sexp()
 		}
 
 		// update links
-		if (count++) {
-			Assert(last != -1);
-			Sexp_nodes[last].rest = node;
-		} else {
+		if (start == -1) {
 			start = node;
+		} else {
+			Assert(last != -1);
+			if (last == start && (start == Locked_sexp_false || start == Locked_sexp_true)) {
+				Warning(LOCATION, "Found true or false operator at the start of a list, likely in a handwritten SEXP.");
+				start = alloc_sexp("", SEXP_LIST, SEXP_ATOM_LIST, start, -1);
+				last = start;
+			}
+			if (node == Locked_sexp_false || node == Locked_sexp_true) {
+				Warning(LOCATION, "Found true or false operator in non-operator position, likely in a handwritten SEXP.");
+				node = alloc_sexp("", SEXP_LIST, SEXP_ATOM_LIST, node, -1);
+			}
+			Sexp_nodes[last].rest = node;
 		}
 
 		Assert(node != -1);  // ran out of nodes.  Time to raise the MAX!


### PR DESCRIPTION
When FRED puts a `true` in the middle of a list of arguments, it wraps it in a nested list as `(true)`, because it's technically an operator; however, if someone writes a SEXP by hand, they could easily forget to do this, and in such cases, this causes `Locked_sexp_true` to be inserted into the middle of the list. If it's not the last element of the list, it will then have its `.rest` attribute set to the next node in the list. If this is a temporary SEXP (i.e. from Lua's `runSEXP()` function), this used to be a temporary problem, but PR #4088 changed the global search for any node with `.rest` set to the node being freed to require an explicit parent node. This means that `Locked_sexp_true.rest` remains set to a freed node, which can cause further issues. If such a malformed SEXP *isn't* temporary it can cause even more issues, even pre-#4088.

This commit changes `get_sexp()` so that if it detects `true` or `false` in the middle of a list (and not a single-element list), it will put it into a single-element sub-list, hopefully preventing any modification of `Locked_sexp_true` or `Locked_sexp_false`, as giving a `Warning`. This should cause it to behave as though `true` or `false` was actually `(true)` or `(false)`, respectively, and therefore run as expected.

One thing I'm unsure about: I also do the "wrap in a list" functionality if `true` or `false` is at the start of a list (because not doing so would still set `.rest` on a locked node, and avoiding that is the whole point of this PR), but `((true) 1 2 3)` is arguably malformed itself; another suggestion was to instead discard any tokens after the first, but that would require slightly more effort (to consume tokens without allocating nodes), and I *think* `((true) 1 2 3)` would be handled as though it were the same as `(true)`. Which is to say, `eval_sexp()` would delegate to the nested `(true)` and then consider the value of that to be its own value. So it should be fine.