### PR TITLE
Model code cleanup #1

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -235,9 +235,38 @@ typedef struct model_special {
 
 #define MAX_LIVE_DEBRIS	7
 
+// Byte offsets for TMAPPOLY/TMAP2POLY
+// An offset of +0 corresponds to the ID of the chunk
+#define TMAP_SIZE			4
+#define TMAP_NORMAL			8
+#define TMAP_CENTER			20
+#define TMAP_RADIUS			32
+#define TMAP_NVERTS			36
+#define TMAP_TEXNUM			40
+#define TMAP_VERTS			44
+
+#define TMAP2_BBOX_MIN		8
+#define TMAP2_BBOX_MAX		20
+#define TMAP2_NORMAL		32
+#define TMAP2_TEXNUM		44
+#define TMAP2_NVERTS		48
+#define TMAP2_VERTS			52
+
+/**
+ * @struct model_tmap_vert_old
+ * @brief Struct to hold vertex information for a polygon (TMAPPOLY)
+ *
+ */
+typedef struct model_tmap_vert_old {
+	uint vertnum; //!< Vertex index into a subobject vertex buffer.
+	uint normnum; //!< Normal index into a subobject normal buffer.
+	float u;      //!< Horizontal texture coordinate for the vertex.
+	float v;      //!< Vertical texture coordinate for the vertex.
+} model_tmap_vert_old;
+
 /**
 * @struct model_tmap_vert
-* @brief Struct to hold vertex information for a polygon
+* @brief Struct to hold vertex information for a polygon (TMAP2POLY)
 * 
 */
 typedef struct model_tmap_vert {
@@ -245,6 +274,21 @@ typedef struct model_tmap_vert {
 	uint normnum;	//!< Normal index into a subobject normal buffer.
 	float u;        //!< Horizontal texture coordinate for the vertex.
 	float v;		//!< Vertical texture coordinate for the vertex.
+
+	/**
+	 * @brief Default constructor for model_tmap_vert
+	 *
+	 */
+	model_tmap_vert() : vertnum(0), normnum(0), u(0.0f), v(0.0f) {}
+
+	/**
+	 * @brief Initializes a model_tmap_vert from a model_tmap_vert_old.
+	 *
+	 * @param tmap_vert A TMAPPOLY vertex object.
+	 */
+	model_tmap_vert(const model_tmap_vert_old& tmap_vert)
+		: vertnum(tmap_vert.vertnum), normnum(tmap_vert.normnum), u(tmap_vert.u), v(tmap_vert.v)
+	{}
 } model_tmap_vert;
 
 /*

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -258,8 +258,8 @@ typedef struct model_special {
  *
  */
 typedef struct model_tmap_vert_old {
-	uint vertnum; //!< Vertex index into a subobject vertex buffer.
-	uint normnum; //!< Normal index into a subobject normal buffer.
+	ushort vertnum; //!< Vertex index into a subobject vertex buffer.
+	ushort normnum; //!< Normal index into a subobject normal buffer.
 	float u;      //!< Horizontal texture coordinate for the vertex.
 	float v;      //!< Vertical texture coordinate for the vertex.
 } model_tmap_vert_old;
@@ -290,17 +290,6 @@ typedef struct model_tmap_vert {
 		: vertnum(tmap_vert.vertnum), normnum(tmap_vert.normnum), u(tmap_vert.u), v(tmap_vert.v)
 	{}
 } model_tmap_vert;
-
-/*
- * @brief Helper function to correctly convert the chunk data from TMAPPOLY to 
- *		  model_tmap_vert.
- * 
- * @param[in] vs Vertex data for the parsed TMAP
- * @param[out] verts Converted vertex data
- * @param n_vert Number of vertices in the chunk
- * 
-**/
-void unpack_tmap_verts(const ubyte* vs, model_tmap_vert* verts, uint n_vert);
 
 struct bsp_collision_node {
 	vec3d min;

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -464,7 +464,7 @@ void model_collide_parse_bsp_tmappoly(bsp_collision_leaf *leaf, SCP_vector<model
 	verts = new model_tmap_vert[nv];
 	auto vs = reinterpret_cast<model_tmap_vert_old*>(&p[44]);
 
-	for (uint i = 0; i < nv; i++) {
+	for (i = 0; i < nv; i++) {
 		verts[i] = model_tmap_vert(vs[i]);
 	}
 
@@ -512,7 +512,7 @@ void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<mode
 		return;
 	}
 
-	verts = (model_tmap_vert*)(p + 52);
+	verts = reinterpret_cast<model_tmap_vert*>(p + 52);
 
 	leaf->tmap_num = (ubyte)tmap_num;
 	leaf->num_verts = (ubyte)nv;

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -512,13 +512,13 @@ void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<mode
 		return;
 	}
 
-	verts = reinterpret_cast<model_tmap_vert*>(p + 52);
+	verts = reinterpret_cast<model_tmap_vert*>(p + TMAP2_VERTS);
 
 	leaf->tmap_num = (ubyte)tmap_num;
 	leaf->num_verts = (ubyte)nv;
 	leaf->vert_start = (int)vert_buffer->size();
 
-	plane_norm = vp(p + 32);
+	plane_norm = vp(p + TMAP2_NORMAL);
 
 	leaf->plane_norm = *plane_norm;
 

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -462,9 +462,11 @@ void model_collide_parse_bsp_tmappoly(bsp_collision_leaf *leaf, SCP_vector<model
 	Assert(tmap_num >= 0 && tmap_num < MAX_MODEL_TEXTURES);
 
 	verts = new model_tmap_vert[nv];
+	auto vs = reinterpret_cast<model_tmap_vert_old*>(&p[44]);
 
-	// Copy the verts manually since they aren't aligned with the struct
-	unpack_tmap_verts(&p[44], verts, nv);
+	for (uint i = 0; i < nv; i++) {
+		verts[i] = model_tmap_vert(vs[i]);
+	}
 
 	leaf->tmap_num = (ubyte)tmap_num;
 	leaf->num_verts = (ubyte)nv;
@@ -496,14 +498,14 @@ void model_collide_parse_bsp_tmap2poly(bsp_collision_leaf* leaf, SCP_vector<mode
 	vec3d* plane_norm;
 	model_tmap_vert* verts;
 
-	nv = uw(p + 48);
+	nv = uw(p + TMAP2_NVERTS);
 
 	if (nv > TMAP_MAX_VERTS) {
 		Error(LOCATION,"Model contains TMAP2 chunk with more than %d vertices!", TMAP_MAX_VERTS);
 		return;
 	}
 
-	tmap_num = w(p + 44);
+	tmap_num = w(p + TMAP2_TEXNUM);
 
 	if (tmap_num < 0 || tmap_num >= MAX_MODEL_TEXTURES) {
 		Error(LOCATION, "Model contains TMAP2 chunk with invalid texture id (%d)!", tmap_num);

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1709,18 +1709,6 @@ int check_values(vec3d *N)
 	return 0;
 }
 
-// Unpacks verts from TMAPPOLY since it's no longer direct memory mapped with model_tmap_vert
-void unpack_tmap_verts(const ubyte* vs, model_tmap_vert* verts, uint n_vert) {
-	// Copy the verts manually since they aren't aligned with the struct
-	for (uint i = 0; i < n_vert; i++) {
-		verts[i].vertnum = us(vs);
-		verts[i].normnum = us(vs + 2);
-		verts[i].u = fl(vs + 4);
-		verts[i].v = fl(vs + 8);
-		vs += 12;
-	}
-}
-
 int Parse_normal_problem_count = 0;
 
 void parse_tmap(int offset, ubyte *bsp_data)
@@ -1819,7 +1807,7 @@ void parse_tmap2(int offset, ubyte* bsp_data)
 
 	int problem_count = 0;
 
-	tverts = (model_tmap_vert*)&bsp_data[offset + TMAP2_VERTS];
+	tverts = reinterpret_cast<model_tmap_vert*>(&bsp_data[offset + TMAP2_VERTS]);
 
 	for (uint i = 1; i < (n_vert - 1); i++) {
 		V = &polygon_list[pof_tex].vert[(polygon_list[pof_tex].n_verts)];
@@ -1967,8 +1955,8 @@ void parse_bsp(int offset, ubyte *bsp_data)
 
 void find_tmap(int offset, const ubyte *bsp_data, int id)
 {
-	int pof_tex = w(bsp_data+offset+(id == OP_TMAP2POLY ? TMAP2_TEXNUM : TMAP_TEXNUM));
-	uint n_vert = uw(bsp_data+offset+ (id == OP_TMAP2POLY ? TMAP2_NVERTS : TMAP_NVERTS));
+	int pof_tex = cw(bsp_data+offset+(id == OP_TMAP2POLY ? TMAP2_TEXNUM : TMAP_TEXNUM));
+	uint n_vert = cuw(bsp_data+offset+ (id == OP_TMAP2POLY ? TMAP2_NVERTS : TMAP_NVERTS));
 
 	tri_count[pof_tex] += n_vert-2;	
 }
@@ -3231,7 +3219,7 @@ void bsp_polygon_data::process_tmap2(int offset, ubyte* bsp_data)
 		return;
 	}
 
-	tverts = (model_tmap_vert*)&bsp_data[offset + TMAP2_VERTS];
+	tverts = reinterpret_cast<model_tmap_vert*>(&bsp_data[offset + TMAP2_VERTS]);
 
 	// make a polygon
 	polygon.Start_index = (uint)Polygon_vertices.size();

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1725,14 +1725,15 @@ int Parse_normal_problem_count = 0;
 
 void parse_tmap(int offset, ubyte *bsp_data)
 {
-	int pof_tex = w(bsp_data+offset+40);
-	uint n_vert = uw(bsp_data+offset+36);
-	
-	ubyte *p = &bsp_data[offset+8];
+	int pof_tex = w(bsp_data+offset+TMAP_TEXNUM);
+	uint n_vert = uw(bsp_data+offset+TMAP_NVERTS);
+	ubyte *p = &bsp_data[offset+TMAP_NORMAL];
+	auto vs = reinterpret_cast<model_tmap_vert_old*>(&bsp_data[offset + TMAP_VERTS]);
 	auto tverts = new model_tmap_vert[n_vert];
 
-	// Copy the verts manually since they aren't aligned with the struct
-	unpack_tmap_verts(&bsp_data[offset + 44], tverts, n_vert);
+	for (uint i = 0; i < n_vert; i++) {
+		tverts[i] = model_tmap_vert(vs[i]);
+	}
 
 	vertex *V;
 	vec3d *v;
@@ -1806,10 +1807,10 @@ void parse_tmap(int offset, ubyte *bsp_data)
 */
 void parse_tmap2(int offset, ubyte* bsp_data)
 {
-	int pof_tex = w(bsp_data + offset + 44);
-	uint n_vert = uw(bsp_data + offset + 48);
+	int pof_tex = w(bsp_data + offset + TMAP2_TEXNUM);
+	uint n_vert = uw(bsp_data + offset + TMAP2_NVERTS);
 
-	ubyte* p = &bsp_data[offset + 32];
+	ubyte* p = &bsp_data[offset + TMAP2_NORMAL];
 	model_tmap_vert* tverts;
 
 	vertex* V;
@@ -1818,7 +1819,7 @@ void parse_tmap2(int offset, ubyte* bsp_data)
 
 	int problem_count = 0;
 
-	tverts = (model_tmap_vert*)&bsp_data[offset + 52];
+	tverts = (model_tmap_vert*)&bsp_data[offset + TMAP2_VERTS];
 
 	for (uint i = 1; i < (n_vert - 1); i++) {
 		V = &polygon_list[pof_tex].vert[(polygon_list[pof_tex].n_verts)];
@@ -1966,8 +1967,8 @@ void parse_bsp(int offset, ubyte *bsp_data)
 
 void find_tmap(int offset, const ubyte *bsp_data, int id)
 {
-	int pof_tex = w(bsp_data+offset+(id == OP_TMAP2POLY ? 44 : 40));
-	uint n_vert = uw(bsp_data+offset+ (id == OP_TMAP2POLY ? 48 : 36));
+	int pof_tex = w(bsp_data+offset+(id == OP_TMAP2POLY ? TMAP2_TEXNUM : TMAP_TEXNUM));
+	uint n_vert = uw(bsp_data+offset+ (id == OP_TMAP2POLY ? TMAP2_NVERTS : TMAP_NVERTS));
 
 	tri_count[pof_tex] += n_vert-2;	
 }
@@ -3150,19 +3151,26 @@ void bsp_polygon_data::process_sortnorm(int offset, ubyte* bsp_data)
 
 void bsp_polygon_data::process_tmap(int offset, ubyte* bsp_data)
 {
-	int pof_tex = w(bsp_data + offset + 40);
-	uint n_vert = uw(bsp_data + offset + 36);
+	int pof_tex = w(bsp_data + offset + TMAP_TEXNUM);
+	uint n_vert = uw(bsp_data + offset + TMAP_NVERTS);
+	ubyte* p;
+	model_tmap_vert* tverts;
 
 	if ( n_vert < 3 ) {
 		// don't parse degenerate polygons
 		return;
 	}
 
-	ubyte *p = &bsp_data[offset + 8];
-	auto tverts = new model_tmap_vert[n_vert];
+	p = &bsp_data[offset + TMAP_NORMAL];
+
+	auto vs = reinterpret_cast<model_tmap_vert_old*>(&bsp_data[offset + TMAP_VERTS]);
+	tverts = new model_tmap_vert[n_vert];
+	for (uint i = 0; i < n_vert; i++) {
+		tverts[i] = model_tmap_vert(vs[i]);
+	}
 
 	// Copy the verts manually since they aren't aligned with the struct
-	unpack_tmap_verts(&bsp_data[offset + 44], tverts, n_vert);
+	//unpack_tmap_verts(&bsp_data[offset + 44], tverts, n_vert);
 
 	int problem_count = 0;
 
@@ -3212,8 +3220,8 @@ void bsp_polygon_data::process_tmap(int offset, ubyte* bsp_data)
 */
 void bsp_polygon_data::process_tmap2(int offset, ubyte* bsp_data)
 {
-	int pof_tex = w(bsp_data + offset + 44);
-	uint n_vert = uw(bsp_data + offset + 48);
+	int pof_tex = w(bsp_data + offset + TMAP2_TEXNUM);
+	uint n_vert = uw(bsp_data + offset + TMAP2_NVERTS);
 	model_tmap_vert* tverts;
 	int problem_count = 0;
 	bsp_polygon polygon;
@@ -3223,7 +3231,7 @@ void bsp_polygon_data::process_tmap2(int offset, ubyte* bsp_data)
 		return;
 	}
 
-	tverts = (model_tmap_vert*)&bsp_data[offset + 52];
+	tverts = (model_tmap_vert*)&bsp_data[offset + TMAP2_VERTS];
 
 	// make a polygon
 	polygon.Start_index = (uint)Polygon_vertices.size();

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -128,7 +128,7 @@ void moff_defpoints(ubyte * p, int just_count)
 // +32     float      radius
 // +36     int         nverts
 // +40     int         tmap_num
-// +44     nverts*(model_tmap_vert-4) vertlist (n,u,v)
+// +44     nverts*(model_tmap_vert_old) vertlist (n,u,v)
 void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count )
 {
 	uint i, nv;
@@ -137,9 +137,11 @@ void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count
 	nv = uw(p+36);
 
 	verts = new model_tmap_vert[nv];
+	auto vs = reinterpret_cast<model_tmap_vert_old*>(&p[44]);
 
-	// Copy the verts manually since they aren't aligned with the struct
-	unpack_tmap_verts(&p[44], verts, nv);
+	for (uint i = 0; i < nv; i++) {
+		verts[i] = model_tmap_vert(vs[i]);
+	}
 
 	if ( (pm->version < 2003) && !just_count )	{
 		// Set the "normal_point" part of field to be the center of the polygon
@@ -196,9 +198,9 @@ void moff_tmap2poly(ubyte* p, polymodel* pm, model_octant* oct, int just_count)
 	uint i, nv;
 	model_tmap_vert* verts;
 
-	nv = uw(p + 48);
+	nv = uw(p + TMAP2_NVERTS);
 
-	verts = (model_tmap_vert*)(p + 52);
+	verts = (model_tmap_vert*)(p + TMAP2_VERTS);
 
 	vec3d center_point;
 	vm_vec_zero(&center_point);

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -139,7 +139,7 @@ void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count
 	verts = new model_tmap_vert[nv];
 	auto vs = reinterpret_cast<model_tmap_vert_old*>(&p[44]);
 
-	for (uint i = 0; i < nv; i++) {
+	for (i = 0; i < nv; i++) {
 		verts[i] = model_tmap_vert(vs[i]);
 	}
 
@@ -200,7 +200,7 @@ void moff_tmap2poly(ubyte* p, polymodel* pm, model_octant* oct, int just_count)
 
 	nv = uw(p + TMAP2_NVERTS);
 
-	verts = (model_tmap_vert*)(p + TMAP2_VERTS);
+	verts = reinterpret_cast<model_tmap_vert*>(p + TMAP2_VERTS);
 
 	vec3d center_point;
 	vm_vec_zero(&center_point);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4976,13 +4976,13 @@ void swap_bsp_tmap2poly(polymodel* pm, ubyte* p)
 	uint i, nv;
 	model_tmap_vert* verts;
 
-	nv = INTEL_INT(uw(p + 48)); // tigital
-	uw(p + 48) = nv;
+	nv = INTEL_INT(uw(p + TMAP2_NVERTS)); // tigital
+	uw(p + TMAP2_NVERTS) = nv;
 
-	int tmap_num = INTEL_INT(w(p + 44)); // tigital
-	w(p + 44) = tmap_num;
+	int tmap_num = INTEL_INT(w(p + TMAP2_TEXNUM)); // tigital
+	w(p + TMAP2_TEXNUM) = tmap_num;
 
-	verts = (model_tmap_vert*)(p + 52);
+	verts = (model_tmap_vert*)(p + TMAP2_VERTS);
 	for (i = 0; i < nv; i++) {
 		verts[i].vertnum = INTEL_SHORT(verts[i].vertnum);
 		verts[i].normnum = INTEL_SHORT(verts[i].normnum);

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -68,12 +68,16 @@ class polymodel;
 #define ID_SLDC 0x43444c53				// CDLS (SLDC): Shield Collision Tree
 #define ID_SLC2 0x32434c53				// 2CLS (SLC2): Shield Collision Tree with ints instead of char - ShivanSpS
 
-#define us(p)	(*((ushort *) (p)))
-#define uw(p)	(*((uint *) (p)))
-#define w(p)	(*((int *) (p)))
-#define wp(p)	((int *) (p))
-#define vp(p)	((vec3d *) (p))
-#define fl(p)	(*((float *) (p)))
+#define us(p)	(*reinterpret_cast<ushort*>(p))
+#define cus(p)  (*reinterpret_cast<const ushort*>(p))
+#define uw(p)	(*reinterpret_cast<uint*>(p))
+#define cuw(p)  (*reinterpret_cast<const uint*>(p))
+#define w(p)	(*reinterpret_cast<int*>(p))
+#define cw(p)   (*reinterpret_cast<const int*>(p))
+#define wp(p)	(reinterpret_cast<int*>(p)
+#define vp(p)	(reinterpret_cast<vec3d*>(p))
+#define fl(p)	(*reinterpret_cast<float*>(p))
+#define cfl(p)  (*reinterpret_cast<const float*>(p))
 
 // Creates the octants for a given polygon model
 void model_octant_create( polymodel * pm );


### PR DESCRIPTION
This is some much needed cleanup of the model code related to parsing some of the bsp data structure. There are some updates to macros, swapping out a function for some safe typecasting, and the addition of a new struct to make parsing TMAPPOLY less ugly. Also removed some magic numbers.