### PR TITLE
Allow an unlimited number of ship flags to be parsed at once.

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3727,9 +3727,8 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 	if (optional_string("$Flags:"))
 	{
-		// we'll assume the list will contain no more than 20 distinct tokens
-		char ship_strings[20][NAME_LENGTH];
-		int num_strings = (int)stuff_string_list(ship_strings, 20);
+		SCP_vector<SCP_string> ship_strings;
+		stuff_string_list(ship_strings);
 
 		int ship_type_index = -1;
 
@@ -3745,14 +3744,14 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			sip->flags.set(Ship::Info_Flags::Has_display_name, has_display_name);
 		}
 
-		for (auto i = 0; i < num_strings; i++)
+		for (const auto &flag : ship_strings)
 		{
 			// get ship type from ship flags
-			const char *ship_type = ship_strings[i];
+			const char *cur_flag = flag.c_str();
 			bool flag_found = false;
 
 			// look it up in the object types table
-			ship_type_index = ship_type_name_lookup(ship_type);
+			ship_type_index = ship_type_name_lookup(cur_flag);
 
 			// set ship class type
 			if ((ship_type_index >= 0) && (sip->class_type < 0))
@@ -3760,7 +3759,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 			// check various ship flags
 			for (size_t idx = 0; idx < Num_ship_flags; idx++) {
-				if ( !stricmp(Ship_flags[idx].name, ship_strings[i]) ) {
+				if ( !stricmp(Ship_flags[idx].name, cur_flag) ) {
 					flag_found = true;
 
 					if (!Ship_flags[idx].in_use)
@@ -3773,25 +3772,25 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			}
 
 			// catch typos or deprecations
-			if (!stricmp(ship_strings[i], "no-collide") || !stricmp(ship_strings[i], "no_collide")) {
+			if (!stricmp(cur_flag, "no-collide") || !stricmp(cur_flag, "no_collide")) {
 				flag_found = true;
 				sip->flags.set(Ship::Info_Flags::No_collide);
 			}
-			if (!stricmp(ship_strings[i], "dont collide invisible")) {
+			if (!stricmp(cur_flag, "dont collide invisible")) {
 				flag_found = true;
 				sip->flags.set(Ship::Info_Flags::Ship_class_dont_collide_invis);
 			}
-			if (!stricmp(ship_strings[i], "dont bank when turning")) {
+			if (!stricmp(cur_flag, "dont bank when turning")) {
 				flag_found = true;
 				sip->flags.set(Ship::Info_Flags::Dont_bank_when_turning);
 			}
-			if (!stricmp(ship_strings[i], "dont clamp max velocity")) {
+			if (!stricmp(cur_flag, "dont clamp max velocity")) {
 				flag_found = true;
 				sip->flags.set(Ship::Info_Flags::Dont_clamp_max_velocity);
 			}
 
 			if ( !flag_found && (ship_type_index < 0) )
-				Warning(LOCATION, "Bogus string in ship flags: %s\n", ship_strings[i]);
+				Warning(LOCATION, "Bogus string in ship flags: %s\n", cur_flag);
 		}
 
 		// set original status of tech database flags - Goober5000


### PR DESCRIPTION
For some reason, ship flag parsing was still using a fixed-size array instead of a vector, limiting it to 20 flags parsed in a single entry. Since there wasn't really a reason to do that (it was basically parsing to a vector anyway, then resizing it down to the limit, then stuffing the C-strings into the array), I changed it to a vector.