### PR TITLE
Make the "$Player Weapon Precedence:" list actually give precedence.

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1758,40 +1758,28 @@ void wl_remove_weps_from_pool(int *wep, int *wep_count, int ship_class)
 				if ( Wss_num_wings <= 0 ) {
 					wl_add_index_to_list(wi_index);
 				} else {
-	
+
 					if ( (Wl_pool[wi_index] <= 0) || (wep_count[i] == 0) ) {
 						// fresh out of this weapon, pick an alternate pool weapon if we can
-						int wep_pool_index, new_wi_index = -1;
-						for ( wep_pool_index = 0; wep_pool_index < weapon_info_size(); wep_pool_index++ ) {
+						for (const auto &new_index : Player_weapon_precedence) {
+							Assertion(new_index >= 0, "Somehow, a negative index (%d) got into Player_weapon_precedence; this should not happen. Get a coder!", new_index);
 
-							if ( Wl_pool[wep_pool_index] <= 0 ) {
+							if ( Wl_pool[new_index] <= 0 ) {
 								continue;
 							}
 
 							// AL 3-31-98: Only pick another primary if primary, etc
-							if ( Weapon_info[wi_index].subtype != Weapon_info[wep_pool_index].subtype ) {
+							if ( Weapon_info[wi_index].subtype != Weapon_info[new_index].subtype ) {
 								continue;
 							}
 
-							if ( !eval_weapon_flag_for_game_type(Ship_info[ship_class].allowed_weapons[wep_pool_index]) ) {
+							if ( !eval_weapon_flag_for_game_type(Ship_info[ship_class].allowed_weapons[new_index]) ) {
 								continue;
 							}
 
-							for ( const auto &precedence_index : Player_weapon_precedence ) {
-								if ( wep_pool_index == precedence_index ) {
-									new_wi_index = wep_pool_index;
-									break;
-								}
-							}
-
-							if ( new_wi_index >= 0 ) {
-								break;
-							}
-						}
-
-						if ( new_wi_index >= 0 ) {
-							wep[i] = new_wi_index;
-							wi_index = new_wi_index;
+							wep[i] = new_index;
+							wi_index = new_index;
+							break;
 						}
 					}
 


### PR DESCRIPTION
Theoretically, the list actually had precedence when a table entry had fewer banks than the model, which would fill the extra banks with the first applicable weapon in the precedence list... except the engine `Error`s before that can happen, so it didn't actually do that. When a mission's loadout doesn't include one or more of the weapons the ship thinks it should have (i.e. it's left to its default loadout and one or more of those are missing), the missing weapons are replaced from the `Player_weapon_precedence` list. However, it didn't actually check precedence: it just went through every weapon type in order, and picked the first applicable one that also happened to be on the `Player_weapon_precedence` list.

This commit makes it so that instead of iterating through every weapon ID, we just iterate through the ones in the `Player_weapon_precedence` list (which is now a vector, thanks to #4201). Not only does this mean that higher entries in the list will be chosen first (meaning actual precedence), but since the vector will often be much shorter than `Weapon_info`, it should also take fewer iterations to find a valid weapon (or decide none of them are valid). This is technically a backwards-incompatible change, but since it only affects missions where a ship on the loadout screen lacks a weapon in its assigned loadout, it should be a relatively minor break.