### PR TITLE
fix up conditions for script hooks

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -4721,7 +4721,7 @@ void ai_waypoints()
 					Script_system.SetHookObject("Ship", &Objects[Ships[Pl_objp->instance].objnum]);
 					Script_system.SetHookVar("Wing", 'o', scripting::api::l_Wing.Set(Ships[Pl_objp->instance].wingnum));
 					Script_system.SetHookVar("Waypointlist", 'o', scripting::api::l_WaypointList.Set(scripting::api::waypointlist_h(aip->wp_list)));
-					Script_system.RunCondition(CHA_ONWAYPOINTSDONE);
+					Script_system.RunCondition(CHA_ONWAYPOINTSDONE, Pl_objp);
 					Script_system.RemHookVars({"Ship", "Wing", "Waypointlist"});
 				}
 			}

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -306,7 +306,7 @@ void ai_clear_ship_goals( ai_info *aip )
 	// add scripting hook for 'On Goals Cleared' --wookieejedi
 	if (Script_system.IsActiveAction(CHA_ONGOALSCLEARED)) {
 		Script_system.SetHookObject("Ship", &Objects[Ships[aip->shipnum].objnum]);
-		Script_system.RunCondition(CHA_ONGOALSCLEARED);
+		Script_system.RunCondition(CHA_ONGOALSCLEARED, &Objects[Ships[aip->shipnum].objnum]);
 		Script_system.RemHookVars({"Ship"});
 	}
 }

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1842,7 +1842,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 
 				if (Script_system.IsActiveAction(CHA_ONTURRETFIRED)) {
 					Script_system.SetHookObjects(4, "Ship", &Objects[parent_objnum], "Weapon", nullptr, "Beam", objp, "Target", &Objects[turret->turret_enemy_objnum]);
-					Script_system.RunCondition(CHA_ONTURRETFIRED, &Objects[parent_objnum]);
+					Script_system.RunCondition(CHA_ONTURRETFIRED, &Objects[parent_objnum], objp);
 					Script_system.RemHookVars({"Ship", "Weapon", "Beam", "Target"});
 				}
 			}
@@ -1985,7 +1985,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 
 					if (Script_system.IsActiveAction(CHA_ONTURRETFIRED)) {
 						Script_system.SetHookObjects(4, "Ship", &Objects[parent_objnum], "Weapon", objp, "Beam", nullptr, "Target", &Objects[turret->turret_enemy_objnum]);
-						Script_system.RunCondition(CHA_ONTURRETFIRED, &Objects[parent_objnum]);
+						Script_system.RunCondition(CHA_ONTURRETFIRED, &Objects[parent_objnum], objp);
 						Script_system.RemHookVars({"Ship", "Weapon", "Beam", "Target"});
 					}
 
@@ -2103,7 +2103,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 
 		if (Script_system.IsActiveAction(CHA_ONTURRETFIRED)) {
 			Script_system.SetHookObjects(4, "Ship", &Objects[tsi->parent_objnum], "Weapon", &Objects[weapon_objnum], "Beam", nullptr, "Target", &Objects[tsi->turret->turret_enemy_objnum]);
-			Script_system.RunCondition(CHA_ONTURRETFIRED, &Objects[tsi->parent_objnum]);
+			Script_system.RunCondition(CHA_ONTURRETFIRED, &Objects[tsi->parent_objnum], &Objects[weapon_objnum]);
 			Script_system.RemHookVars({"Ship", "Weapon", "Beam", "Target"});
 		}
 

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2617,7 +2617,7 @@ int check_control(int id, int key)
 
 		if (Script_system.IsActiveAction(CHA_ONACTIONSTOPPED)) {
 			Script_system.SetHookVar("Action", 's', Control_config[id].text);
-			Script_system.RunCondition(CHA_ONACTIONSTOPPED, nullptr, id);
+			Script_system.RunCondition(CHA_ONACTIONSTOPPED, nullptr, nullptr, id);
 			Script_system.RemHookVar("Action");
 		}
 
@@ -2781,7 +2781,7 @@ void control_used(int id)
 	if (Control_config[id].used < Last_frame_timestamp) {
 		if (!Control_config[id].continuous_ongoing) {
 			Script_system.SetHookVar("Action", 's', Control_config[id].text);
-			Script_system.RunCondition(CHA_ONACTION, nullptr, id);
+			Script_system.RunCondition(CHA_ONACTION, nullptr, nullptr, id);
 			Script_system.RemHookVar("Action");
 
 			if (Control_config[id].type == CC_TYPE_CONTINUOUS)

--- a/code/object/collidedebrisship.cpp
+++ b/code/object/collidedebrisship.cpp
@@ -76,14 +76,14 @@ int collide_debris_ship( obj_pair * pair )
 			if (Script_system.IsActiveAction(CHA_COLLIDEDEBRIS)) {
 				Script_system.SetHookObjects(4, "Self", ship_objp, "Object", debris_objp, "Ship", ship_objp, "Debris", debris_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				ship_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, ship_objp);
+				ship_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, ship_objp, debris_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 			}
 
 			if (Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
 				Script_system.SetHookObjects(4, "Self", debris_objp, "Object", ship_objp, "Ship", ship_objp, "Debris", debris_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				debris_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, debris_objp);
+				debris_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, debris_objp, ship_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 			}
 
@@ -154,7 +154,7 @@ int collide_debris_ship( obj_pair * pair )
 			{
 				Script_system.SetHookObjects(4, "Self", ship_objp, "Object", debris_objp, "Ship", ship_objp, "Debris", debris_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDEDEBRIS, ship_objp);
+				Script_system.RunCondition(CHA_COLLIDEDEBRIS, ship_objp, debris_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 			}
 
@@ -162,7 +162,7 @@ int collide_debris_ship( obj_pair * pair )
 			{
 				Script_system.SetHookObjects(4, "Self", debris_objp, "Object", ship_objp, "Ship", ship_objp, "Debris", debris_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, debris_objp);
+				Script_system.RunCondition(CHA_COLLIDESHIP, debris_objp, ship_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 			}
 
@@ -248,14 +248,14 @@ int collide_asteroid_ship( obj_pair * pair )
 			if (Script_system.IsActiveAction(CHA_COLLIDEASTEROID)) {
 				Script_system.SetHookObjects(4, "Self", ship_objp, "Object", asteroid_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				ship_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, ship_objp);
+				ship_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, ship_objp, asteroid_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 			}
 
 			if (Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
 				Script_system.SetHookObjects(4, "Self", asteroid_objp, "Object", ship_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, asteroid_objp);
+				asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, asteroid_objp, ship_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 			}
 
@@ -330,7 +330,7 @@ int collide_asteroid_ship( obj_pair * pair )
 			{
 				Script_system.SetHookObjects(4, "Self", ship_objp, "Object", asteroid_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDEASTEROID, ship_objp);
+				Script_system.RunCondition(CHA_COLLIDEASTEROID, ship_objp, asteroid_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 			}
 
@@ -338,7 +338,7 @@ int collide_asteroid_ship( obj_pair * pair )
 			{
 				Script_system.SetHookObjects(4, "Self", asteroid_objp, "Object", ship_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, asteroid_objp);
+				Script_system.RunCondition(CHA_COLLIDESHIP, asteroid_objp, ship_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 			}
 

--- a/code/object/collidedebrisweapon.cpp
+++ b/code/object/collidedebrisweapon.cpp
@@ -50,14 +50,14 @@ int collide_debris_weapon( obj_pair * pair )
 		if (Script_system.IsActiveAction(CHA_COLLIDEDEBRIS)) {
 			Script_system.SetHookObjects(4, "Self", weapon_obj, "Object", pdebris, "Weapon", weapon_obj, "Debris", pdebris);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, weapon_obj);
+			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, weapon_obj, pdebris);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "Debris", "Hitpos" });
 		}
 
 		if (Script_system.IsActiveAction(CHA_COLLIDEWEAPON)) {
 			Script_system.SetHookObjects(4, "Self", pdebris, "Object", weapon_obj, "Weapon", weapon_obj, "Debris", pdebris);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			debris_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pdebris);
+			debris_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pdebris, weapon_obj);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "Debris", "Hitpos" });
 		}
 
@@ -71,7 +71,7 @@ int collide_debris_weapon( obj_pair * pair )
 		{
 			Script_system.SetHookObjects(4, "Self", weapon_obj, "Object", pdebris, "Weapon", weapon_obj, "Debris", pdebris);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			Script_system.RunCondition(CHA_COLLIDEDEBRIS, weapon_obj);
+			Script_system.RunCondition(CHA_COLLIDEDEBRIS, weapon_obj, pdebris);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "Debris", "Hitpos" });
 		}
 
@@ -79,7 +79,7 @@ int collide_debris_weapon( obj_pair * pair )
 		{
 			Script_system.SetHookObjects(4, "Self", pdebris, "Object", weapon_obj, "Weapon", weapon_obj, "Debris", pdebris);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			Script_system.RunCondition(CHA_COLLIDEWEAPON, pdebris, Weapons[weapon_obj->instance].weapon_info_index);
+			Script_system.RunCondition(CHA_COLLIDEWEAPON, pdebris, weapon_obj);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "Debris", "Hitpos" });
 		}
 
@@ -121,14 +121,14 @@ int collide_asteroid_weapon( obj_pair * pair )
 		if (Script_system.IsActiveAction(CHA_COLLIDEASTEROID)) {
 			Script_system.SetHookObjects(4, "Self", weapon_obj, "Object", pasteroid, "Weapon", weapon_obj, "Asteroid", pasteroid);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, weapon_obj);
+			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, weapon_obj, pasteroid);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "Asteroid", "Hitpos" });
 		}
 
 		if (Script_system.IsActiveAction(CHA_COLLIDEWEAPON)) {
 			Script_system.SetHookObjects(4, "Self", pasteroid, "Object", weapon_obj, "Weapon", weapon_obj, "Asteroid", pasteroid);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pasteroid);
+			asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pasteroid, weapon_obj);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "Asteroid", "Hitpos" });
 		}
 
@@ -142,7 +142,7 @@ int collide_asteroid_weapon( obj_pair * pair )
 		{
 			Script_system.SetHookObjects(4, "Self", weapon_obj, "Object", pasteroid, "Weapon", weapon_obj, "Asteroid", pasteroid);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			Script_system.RunCondition(CHA_COLLIDEASTEROID, weapon_obj);
+			Script_system.RunCondition(CHA_COLLIDEASTEROID, weapon_obj, pasteroid);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "Asteroid", "Hitpos" });
 		}
 
@@ -150,7 +150,7 @@ int collide_asteroid_weapon( obj_pair * pair )
 		{
 			Script_system.SetHookObjects(4, "Self", pasteroid, "Object", weapon_obj, "Weapon", weapon_obj, "Asteroid", pasteroid);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-			Script_system.RunCondition(CHA_COLLIDEWEAPON, pasteroid, Weapons[weapon_obj->instance].weapon_info_index);
+			Script_system.RunCondition(CHA_COLLIDEWEAPON, pasteroid, weapon_obj);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "Asteroid", "Hitpos" });
 		}
 

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1137,13 +1137,13 @@ int collide_ship_ship( obj_pair * pair )
 			if (Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
 				Script_system.SetHookObjects(4, "Self", A, "Object", B, "Ship", A, "ShipB", B);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(world_hit_pos));
-				a_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, A);
+				a_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, A, B);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "ShipB", "Hitpos" });
 
 				// Yes, this should be reversed.
 				Script_system.SetHookObjects(4, "Self", B, "Object", A, "Ship", B, "ShipB", A);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(world_hit_pos));
-				b_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, B);
+				b_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, B, A);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "ShipB", "Hitpos" });
 			}
 
@@ -1394,7 +1394,7 @@ int collide_ship_ship( obj_pair * pair )
 			{
 				Script_system.SetHookObjects(4, "Self", A, "Object", B, "Ship", A, "ShipB", B);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(world_hit_pos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, A);
+				Script_system.RunCondition(CHA_COLLIDESHIP, A, B);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "ShipB", "Hitpos" });
 			}
 			if((b_override && !a_override) || (!b_override && !a_override))
@@ -1402,7 +1402,7 @@ int collide_ship_ship( obj_pair * pair )
 				// Yes, this should be reversed.
 				Script_system.SetHookObjects(4, "Self", B, "Object", A, "Ship", B, "ShipB", A);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(world_hit_pos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, B);
+				Script_system.RunCondition(CHA_COLLIDESHIP, B, A);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "ShipB", "Hitpos" });
 			}
 

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -455,14 +455,14 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 		if (Script_system.IsActiveAction(CHA_COLLIDEWEAPON)) {
 			Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(mc.hit_point_world));
-			ship_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, ship_objp);
+			ship_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, ship_objp, weapon_objp);
 			Script_system.RemHookVars({ "Self", "Object", "Ship", "Weapon", "Hitpos" });
 		}
 
 		if (Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
 			Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(mc.hit_point_world));
-			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, weapon_objp);
+			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, weapon_objp, ship_objp);
 			Script_system.RemHookVars({ "Self", "Object", "Ship", "Weapon", "Hitpos" });
 		}
 
@@ -479,7 +479,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 		{
 			Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(mc.hit_point_world));
-			Script_system.RunCondition(CHA_COLLIDEWEAPON, ship_objp, wp->weapon_info_index);
+			Script_system.RunCondition(CHA_COLLIDEWEAPON, ship_objp, weapon_objp);
 			Script_system.RemHookVars({ "Self", "Object", "Ship", "Weapon", "Hitpos" });
 		}
 
@@ -487,7 +487,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 		{
 			Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Weapon", weapon_objp);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(mc.hit_point_world));
-			Script_system.RunCondition(CHA_COLLIDESHIP, weapon_objp);
+			Script_system.RunCondition(CHA_COLLIDESHIP, weapon_objp, ship_objp);
 			Script_system.RemHookVars({ "Self", "Object", "Ship", "Weapon", "Hitpos" });
 		}
 	}

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -88,13 +88,13 @@ int collide_weapon_weapon( obj_pair * pair )
 		if (Script_system.IsActiveAction(CHA_COLLIDEWEAPON)) {
 			Script_system.SetHookObjects(4, "Self", A, "Object", B, "Weapon", A, "WeaponB", B);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(B->pos));
-			a_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, A);
+			a_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, A, B);
 			Script_system.RemHookVars({"Self", "Object", "Weapon", "WeaponB", "Hitpos" });
 
 			// Yes, this should be reversed.
 			Script_system.SetHookObjects(4, "Self", B, "Object", A, "Weapon", B, "WeaponB", A);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(A->pos));
-			b_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, B);
+			b_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, B, A);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "WeaponB", "Hitpos" });
 		}
 
@@ -194,7 +194,7 @@ int collide_weapon_weapon( obj_pair * pair )
 		{
 			Script_system.SetHookObjects(4, "Self", A, "Object", B, "Weapon", A, "WeaponB", B);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(B->pos));
-			Script_system.RunCondition(CHA_COLLIDEWEAPON, A, wpA->weapon_info_index);
+			Script_system.RunCondition(CHA_COLLIDEWEAPON, A, B);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "WeaponB", "Hitpos" });
 		}
 		else
@@ -202,7 +202,7 @@ int collide_weapon_weapon( obj_pair * pair )
 			// Yes, this should be reversed.
 			Script_system.SetHookObjects(4, "Self", B, "Object", A, "Weapon", B, "WeaponB", A);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(A->pos));
-			Script_system.RunCondition(CHA_COLLIDEWEAPON, B, wpB->weapon_info_index);
+			Script_system.RunCondition(CHA_COLLIDEWEAPON, B, A);
 			Script_system.RemHookVars({ "Self", "Object", "Weapon", "WeaponB", "Hitpos" });
 		}
 

--- a/code/scripting/hook_api.h
+++ b/code/scripting/hook_api.h
@@ -132,8 +132,9 @@ class Hook : public HookBase {
 
 	template <typename... Args>
 	int run(detail::HookParameterInstanceList<Args...> argsList = hook_param_list<Args...>(),
-			object* objp                                        = nullptr,
-			int more_data                                       = 0) const
+			object* objp1                                       = nullptr,
+			object* objp2                                       = nullptr,
+			int more_data                                       = -1) const
 	{
 		SCP_vector<SCP_string> paramNames;
 		argsList.setHookVars(paramNames);
@@ -147,7 +148,7 @@ class Hook : public HookBase {
 		});
 #endif
 
-		const auto num_run = Script_system.RunCondition(_hookId, objp, more_data);
+		const auto num_run = Script_system.RunCondition(_hookId, objp1, objp2, more_data);
 
 		for (const auto& param : paramNames) {
 			Script_system.RemHookVar(param.c_str());

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -425,10 +425,20 @@ bool ConditionedHook::ConditionsValid(int action, object *objp1, object *objp2, 
 			{
 				for (auto objp : objp_array)
 				{
-					if (objp != nullptr && (objp->type == OBJ_WEAPON || objp->type == OBJ_BEAM))
+					if (objp == nullptr)
+						continue;
+
+					if (objp->type == OBJ_WEAPON)
 					{
 						// scp.condition_cached_value holds the weapon_info_index of the requested weapon class
 						if (Weapons[objp->instance].weapon_info_index != scp.condition_cached_value)
+							return false;
+						break;
+					}
+					else if (objp->type == OBJ_BEAM)
+					{
+						// scp.condition_cached_value holds the weapon_info_index of the requested weapon class
+						if (Beams[objp->instance].weapon_info_index != scp.condition_cached_value)
 							return false;
 						break;
 					}

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -328,15 +328,16 @@ bool ConditionedHook::AddAction(script_action *sa)
 	return true;
 }
 
-bool ConditionedHook::ConditionsValid(int action, object *objp, int more_data)
+bool ConditionedHook::ConditionsValid(int action, object *objp1, object *objp2, int more_data)
 {
+	object *objp_array[2];
+	objp_array[0] = objp1;
+	objp_array[1] = objp2;
 
 	//Return false if any conditions are not met
 	//Never return true inside the loop, or you will be potentially skipping other conditions on the hook.
-	ship_info *sip;
-	for(auto & scp : Conditions)
+	for (auto & scp : Conditions)
 	{
-		
 		switch(scp.condition_type)
 		{
 			case CHC_STATE:
@@ -345,249 +346,284 @@ bool ConditionedHook::ConditionsValid(int action, object *objp, int more_data)
 				if(gameseq_get_state() != scp.condition_cached_value)
 					return false;
 				break;
+
 			case CHC_SHIPTYPE:
-				if(objp == NULL || objp->type != OBJ_SHIP)
-					return false;
-				sip = &Ship_info[Ships[objp->instance].ship_info_index];
-				if(sip->class_type < 0)
-					return false;
-				if(stricmp(Ship_types[sip->class_type].name, scp.condition_string.c_str()) != 0)
-					return false;
+			{
+				for (auto objp : objp_array)
+				{
+					if (objp != nullptr && objp->type == OBJ_SHIP)
+					{
+						auto sip = &Ship_info[Ships[objp->instance].ship_info_index];
+						if (sip->class_type >= 0)
+						{
+							if (stricmp(Ship_types[sip->class_type].name, scp.condition_string.c_str()) != 0)
+								return false;
+						}
+						break;
+					}
+				}
 				break;
+			}
+
 			case CHC_SHIPCLASS:
-				//scp.condition_cached_value holds the weapon_info_index of the requested weapon class
-				if(objp == NULL || objp->type != OBJ_SHIP)
-					return false;
-				if(!(Ships[objp->instance].ship_info_index == scp.condition_cached_value))
-					return false;
+			{
+				for (auto objp : objp_array)
+				{
+					if (objp != nullptr && objp->type == OBJ_SHIP)
+					{
+						// scp.condition_cached_value holds the ship_info_index of the requested ship class
+						if (Ships[objp->instance].ship_info_index != scp.condition_cached_value)
+							return false;
+						break;
+					}
+				}
 				break;
+			}
+
 			case CHC_SHIP:
-				if(objp == NULL || objp->type != OBJ_SHIP)
-					return false;
-				if(stricmp(Ships[objp->instance].ship_name, scp.condition_string.c_str()) != 0)
-					return false;
+			{
+				for (auto objp : objp_array)
+				{
+					if (objp != nullptr && objp->type == OBJ_SHIP)
+					{
+						if (stricmp(Ships[objp->instance].ship_name, scp.condition_string.c_str()) != 0)
+							return false;
+						break;
+					}
+				}
 				break;
+			}
+
 			case CHC_MISSION:
-				{
-					//WMC - Get mission filename with Mission_filename
-					//I don't use Game_current_mission_filename, because
-					//Mission_filename is valid in both fs2_open and FRED
-					size_t len = strlen(Mission_filename);
-					if(!len)
-						return false;
-					if(len > 4 && !stricmp(&Mission_filename[len-4], ".fs2"))
-						len -= 4;
-					if(strnicmp(scp.condition_string.c_str(), Mission_filename, len) != 0)
-						return false;
-					break;
-				}
+			{
+				//WMC - Get mission filename with Mission_filename
+				//I don't use Game_current_mission_filename, because
+				//Mission_filename is valid in both fs2_open and FRED
+				size_t len = strlen(Mission_filename);
+				if(!len)
+					return false;
+				if(len > 4 && !stricmp(&Mission_filename[len-4], ".fs2"))
+					len -= 4;
+				if(strnicmp(scp.condition_string.c_str(), Mission_filename, len) != 0)
+					return false;
+				break;
+			}
+
 			case CHC_CAMPAIGN:
-				{
-					size_t len = strlen(Campaign.filename);
-					if(!len)
-						return false;
-					if(len > 4 && !stricmp(&Mission_filename[len-4], ".fc2"))
-						len -= 4;
-					if(strnicmp(scp.condition_string.c_str(), Mission_filename, len) != 0)
-						return false;
-					break;
-				}
+			{
+				size_t len = strlen(Campaign.filename);
+				if(!len)
+					return false;
+				if(len > 4 && !stricmp(&Mission_filename[len-4], ".fc2"))
+					len -= 4;
+				if(strnicmp(scp.condition_string.c_str(), Mission_filename, len) != 0)
+					return false;
+				break;
+			}
+
 			case CHC_WEAPONCLASS:
+			{
+				for (auto objp : objp_array)
 				{
-					//scp.condition_cached_value holds the weapon_info_index of the requested weapon class
-					if (action == CHA_COLLIDEWEAPON) {
-						return(more_data == scp.condition_cached_value);
-					} else if (!(action == CHA_ONWPSELECTED || action == CHA_ONWPDESELECTED || action == CHA_ONWPEQUIPPED || action == CHA_ONWPFIRED || action == CHA_ONTURRETFIRED )) {
-						if (objp == NULL || (objp->type != OBJ_WEAPON && objp->type != OBJ_BEAM))
+					if (objp != nullptr && (objp->type == OBJ_WEAPON || objp->type == OBJ_BEAM))
+					{
+						// scp.condition_cached_value holds the weapon_info_index of the requested weapon class
+						if (Weapons[objp->instance].weapon_info_index != scp.condition_cached_value)
 							return false;
-						else if (objp->type == OBJ_WEAPON && !(Weapons[objp->instance].weapon_info_index == scp.condition_cached_value))
-							return false;
-						else if (objp->type == OBJ_BEAM && !(Weapons[objp->instance].weapon_info_index == scp.condition_cached_value))
-							return false;
+						break;
 					}
-					else if (objp == NULL || objp->type != OBJ_SHIP) {
-						return false;
-					}
-					else if (action == CHA_ONWEAPONCREATED) {
-						if (objp == nullptr || objp->type != OBJ_WEAPON)
-							return false;
-					}
-					else {
+				}
 
-						// Okay, if we're still here, then objp is both valid and a ship
-						ship* shipp = &Ships[objp->instance];
-						bool primary = false, secondary = false, prev_primary = false, prev_secondary = false;
-						switch (action) {
-						case CHA_ONWPSELECTED: {
-							if (shipp->weapons.current_primary_bank >= 0) {
-								primary = shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank] == scp.condition_cached_value;
-							}
-							if (shipp->weapons.current_secondary_bank >= 0) {
-								secondary = shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank] == scp.condition_cached_value;
-							}
+				if (objp1 == nullptr || objp1->type != OBJ_SHIP)
+					break;
+				auto shipp = &Ships[objp1->instance];
+				bool primary = false, secondary = false, prev_primary = false, prev_secondary = false;
 
-							if (!(primary || secondary)) {
-								return false;
-							}
-
-							if ((shipp->flags[Ship::Ship_Flags::Primary_linked]) && primary && (Weapon_info[shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank]].wi_flags[Weapon::Info_Flags::Nolink])) {
-								return false;
-							}
-
-							break; }
-						case CHA_ONWPDESELECTED: {
-							if (shipp->weapons.current_primary_bank >= 0) {
-								primary = shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank] == scp.condition_cached_value;
-							}
-							if (shipp->weapons.previous_primary_bank >= 0) {
-								prev_primary = shipp->weapons.primary_bank_weapons[shipp->weapons.previous_primary_bank] == scp.condition_cached_value;
-							}
-							if (shipp->weapons.current_secondary_bank >= 0) {
-								secondary = shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank] == scp.condition_cached_value;
-							}
-							if (shipp->weapons.previous_secondary_bank >= 0) {
-								prev_secondary = shipp->weapons.secondary_bank_weapons[shipp->weapons.previous_secondary_bank] == scp.condition_cached_value;
-							}
-
-							if (!(
-									(shipp->flags[Ship::Ship_Flags::Primary_linked]) && prev_primary && 
-									(Weapon_info[shipp->weapons.primary_bank_weapons[shipp->weapons.previous_primary_bank]].wi_flags[Weapon::Info_Flags::Nolink])
-								)) {
-								return false;
-							}
-							if (!prev_secondary && !secondary && !prev_primary && !primary)
-								return false;
-
-							if ((!prev_secondary && !secondary) && (prev_primary && primary))
-								return false;
-
-							if ((!prev_secondary && !secondary) && (!prev_primary && primary))
-								return false;
-
-							if ((!prev_primary && !primary) && (prev_secondary && secondary))
-								return false;
-
-							if ((!prev_primary && !primary) && (!prev_secondary && secondary))
-								return false;
-
-							break; }
-						case CHA_ONWPEQUIPPED: {
-							bool equipped = false;
-							for (int j = 0; j < MAX_SHIP_PRIMARY_BANKS && !equipped; j++) {
-								if (shipp->weapons.primary_bank_weapons[j] > 0 && shipp->weapons.primary_bank_weapons[j] < weapon_info_size()) {
-									equipped = shipp->weapons.primary_bank_weapons[j] == scp.condition_cached_value;
-								}
-							}
-							for (int j = 0; j < MAX_SHIP_SECONDARY_BANKS && !equipped; j++) {
-								if (shipp->weapons.secondary_bank_weapons[j] >= 0 && (shipp->weapons.secondary_bank_weapons[j] < weapon_info_size()))
-								{
-									equipped = shipp->weapons.secondary_bank_weapons[j] == scp.condition_cached_value;
-								}
-
-							}
-
-							if (!equipped) {
-								return false;
-							}
-
-							break;
+				switch (action)
+				{
+					case CHA_ONWPSELECTED:
+					{
+						if (shipp->weapons.current_primary_bank >= 0) {
+							primary = shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank] == scp.condition_cached_value;
 						}
-						case CHA_ONWPFIRED: {
-							if (more_data == 1) {
-								primary = shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank] == scp.condition_cached_value;
-								secondary = false;
-							} else {
-								primary = false;
-								secondary = shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank] == scp.condition_cached_value;
-							}
+						if (shipp->weapons.current_secondary_bank >= 0) {
+							secondary = shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank] == scp.condition_cached_value;
+						}
 
-							if (
-								(shipp->flags[Ship::Ship_Flags::Primary_linked]) && primary && 
-								(Weapon_info[shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank]].wi_flags[Weapon::Info_Flags::Nolink]))
+						if (!(primary || secondary)) {
+							return false;
+						}
+
+						if ((shipp->flags[Ship::Ship_Flags::Primary_linked]) && primary && (Weapon_info[shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank]].wi_flags[Weapon::Info_Flags::Nolink])) {
+							return false;
+						}
+
+						break;
+					}
+
+					case CHA_ONWPDESELECTED:
+					{
+						if (shipp->weapons.current_primary_bank >= 0) {
+							primary = shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank] == scp.condition_cached_value;
+						}
+						if (shipp->weapons.previous_primary_bank >= 0) {
+							prev_primary = shipp->weapons.primary_bank_weapons[shipp->weapons.previous_primary_bank] == scp.condition_cached_value;
+						}
+						if (shipp->weapons.current_secondary_bank >= 0) {
+							secondary = shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank] == scp.condition_cached_value;
+						}
+						if (shipp->weapons.previous_secondary_bank >= 0) {
+							prev_secondary = shipp->weapons.secondary_bank_weapons[shipp->weapons.previous_secondary_bank] == scp.condition_cached_value;
+						}
+
+						if (!(
+								(shipp->flags[Ship::Ship_Flags::Primary_linked]) && prev_primary && 
+								(Weapon_info[shipp->weapons.primary_bank_weapons[shipp->weapons.previous_primary_bank]].wi_flags[Weapon::Info_Flags::Nolink])
+							)) {
+							return false;
+						}
+						if (!prev_secondary && !secondary && !prev_primary && !primary)
+							return false;
+
+						if ((!prev_secondary && !secondary) && (prev_primary && primary))
+							return false;
+
+						if ((!prev_secondary && !secondary) && (!prev_primary && primary))
+							return false;
+
+						if ((!prev_primary && !primary) && (prev_secondary && secondary))
+							return false;
+
+						if ((!prev_primary && !primary) && (!prev_secondary && secondary))
+							return false;
+
+						break;
+					}
+
+					case CHA_ONWPEQUIPPED:
+					{
+						bool equipped = false;
+						for (int j = 0; j < MAX_SHIP_PRIMARY_BANKS && !equipped; j++) {
+							if (shipp->weapons.primary_bank_weapons[j] > 0 && shipp->weapons.primary_bank_weapons[j] < weapon_info_size()) {
+								equipped = shipp->weapons.primary_bank_weapons[j] == scp.condition_cached_value;
+							}
+						}
+						for (int j = 0; j < MAX_SHIP_SECONDARY_BANKS && !equipped; j++) {
+							if (shipp->weapons.secondary_bank_weapons[j] >= 0 && (shipp->weapons.secondary_bank_weapons[j] < weapon_info_size()))
 							{
-								return false;
+								equipped = shipp->weapons.secondary_bank_weapons[j] == scp.condition_cached_value;
 							}
 
-							if (more_data == 1 && !primary) {
-								return false;
-							}
-							else if (more_data != 1 && !secondary) {
-								return false;
-							}
-							break;
 						}
-						case CHA_ONTURRETFIRED: {
-							if(shipp->last_fired_turret->last_fired_weapon_info_index != scp.condition_cached_value)
-								return false;
-							break;
+
+						if (!equipped) {
+							return false;
 						}
-						case CHA_PRIMARYFIRE: {
-							if (shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank] != scp.condition_cached_value)
-								return false;
-							break;
-						}
-						case CHA_SECONDARYFIRE: {
-							if(shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank] != scp.condition_cached_value)
-								return false;
-							break;
-						}
-						case CHA_BEAMFIRE: {
-							if(more_data != scp.condition_cached_value)
-								return false;
-							break;
-						}
-						default:
-							break;
+
+						break;
 					}
-				} // case CHC_WEAPONCLASS
-				break;
+
+					case CHA_ONWPFIRED:
+					{
+						if (more_data == 1) {
+							primary = shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank] == scp.condition_cached_value;
+							secondary = false;
+						} else {
+							primary = false;
+							secondary = shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank] == scp.condition_cached_value;
+						}
+
+						if (
+							(shipp->flags[Ship::Ship_Flags::Primary_linked]) && primary && 
+							(Weapon_info[shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank]].wi_flags[Weapon::Info_Flags::Nolink]))
+						{
+							return false;
+						}
+
+						if (more_data == 1 && !primary) {
+							return false;
+						}
+						else if (more_data != 1 && !secondary) {
+							return false;
+						}
+						break;
+					}
+
+					case CHA_ONTURRETFIRED: {
+						if(shipp->last_fired_turret->last_fired_weapon_info_index != scp.condition_cached_value)
+							return false;
+						break;
+					}
+					case CHA_PRIMARYFIRE: {
+						if (shipp->weapons.primary_bank_weapons[shipp->weapons.current_primary_bank] != scp.condition_cached_value)
+							return false;
+						break;
+					}
+					case CHA_SECONDARYFIRE: {
+						if(shipp->weapons.secondary_bank_weapons[shipp->weapons.current_secondary_bank] != scp.condition_cached_value)
+							return false;
+						break;
+					}
+					case CHA_BEAMFIRE: {
+						if(more_data != scp.condition_cached_value)
+							return false;
+						break;
+					}
+					default:
+						break;
 				}
+				break;
+			} // case CHC_WEAPONCLASS
+
 			case CHC_OBJECTTYPE:
-				if(objp == NULL)
-					return false;
-				if(objp->type != scp.condition_cached_value)
+				if (objp1 == nullptr || objp1->type != scp.condition_cached_value)
 					return false;
 				break;
+
 			case CHC_KEYPRESS:
-				{
-					extern int Current_key_down;
-					if(gameseq_get_depth() < 0)
-						return false;
-					if(Current_key_down == 0)
-						return false;
-					//WMC - could be more efficient, but whatever.
-					if(stricmp(textify_scancode(Current_key_down), scp.condition_string.c_str()) != 0)
-						return false;
-					break;
-				}
+			{
+				extern int Current_key_down;
+				if(gameseq_get_depth() < 0)
+					return false;
+				if(Current_key_down == 0)
+					return false;
+				//WMC - could be more efficient, but whatever.
+				if(stricmp(textify_scancode(Current_key_down), scp.condition_string.c_str()) != 0)
+					return false;
+				break;
+			}
+
 			case CHC_ACTION:
-				{
-					if(gameseq_get_depth() < 0)
-						return false;
+			{
+				if(gameseq_get_depth() < 0)
+					return false;
 
-					int action_index = more_data;
+				int action_index = more_data;
 
-					if (action_index <= 0 || stricmp(scp.condition_string.c_str(), Control_config[action_index].text.c_str()) != 0)
-						return false;
-					break;
-				}
+				if (action_index <= 0 || stricmp(scp.condition_string.c_str(), Control_config[action_index].text.c_str()) != 0)
+					return false;
+				break;
+			}
+
 			case CHC_VERSION:
+			{
+				//Already evaluated on script load, stored value is 1 if application matches condition, 0 if not.
+				if(scp.condition_cached_value == 0)
 				{
-					//Already evaluated on script load, stored value is 1 if application matches condition, 0 if not.
-					if(scp.condition_cached_value == 0)
-					{
-						return false;
-					}
-					break;
+					return false;
 				}
+				break;
+			}
+
 			case CHC_APPLICATION:
+			{
+				//Already evaluated on script load, stored value is 1 if application matches condition, 0 if not.
+				if(scp.condition_cached_value == 0)
 				{
-					//Already evaluated on script load, stored value is 1 if application matches condition, 0 if not.
-					if(scp.condition_cached_value == 0)
-					{
-						return false;
-					}
+					return false;
 				}
+			}
+
 			default:
 				break;
 		}
@@ -711,7 +747,7 @@ void script_state::UnloadImages()
 	ScriptImages.clear();
 }
 
-int script_state::RunCondition(int action, object* objp, int more_data)
+int script_state::RunCondition(int action, object *objp1, object *objp2, int more_data)
 {
 	TRACE_SCOPE(tracing::LuaHooks);
 	int num = 0;
@@ -722,7 +758,7 @@ int script_state::RunCondition(int action, object* objp, int more_data)
 
 	for(SCP_vector<ConditionedHook>::iterator chp = ConditionalHooks.begin(); chp != ConditionalHooks.end(); ++chp) 
 	{
-		if(chp->ConditionsValid(action, objp, more_data))
+		if(chp->ConditionsValid(action, objp1, objp2, more_data))
 		{
 			chp->Run(this, action);
 			num++;
@@ -731,12 +767,11 @@ int script_state::RunCondition(int action, object* objp, int more_data)
 	return num;
 }
 
-bool script_state::IsConditionOverride(int action, object *objp)
+bool script_state::IsConditionOverride(int action, object *objp1, object *objp2, int more_data)
 {
-	//bool b = false;
 	for(SCP_vector<ConditionedHook>::iterator chp = ConditionalHooks.begin(); chp != ConditionalHooks.end(); ++chp)
 	{
-		if(chp->ConditionsValid(action, objp))
+		if(chp->ConditionsValid(action, objp1, objp2, more_data))
 		{
 			if(chp->IsOverride(this, action))
 				return true;

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -156,7 +156,7 @@ public:
 	bool AddCondition(script_condition *sc);
 	bool AddAction(script_action *sa);
 
-	bool ConditionsValid(int action, class object *objp=NULL, int more_data = 0);
+	bool ConditionsValid(int action, class object *objp1 = nullptr, class object *objp2 = nullptr, int more_data = -1);
 	bool IsOverride(class script_state *sys, int action);
 	bool Run(class script_state* sys, int action);
 };
@@ -253,8 +253,8 @@ public:
 	int RunBytecode(script_function& hd, char format = '\0', T* data = nullptr);
 	int RunBytecode(script_function& hd);
 	bool IsOverride(script_hook &hd);
-	int RunCondition(int condition, object* objp = nullptr, int more_data = 0);
-	bool IsConditionOverride(int action, object *objp=NULL);
+	int RunCondition(int condition, object *objp1 = nullptr, object *objp2 = nullptr, int more_data = -1);
+	bool IsConditionOverride(int action, object *objp1 = nullptr, object *objp2 = nullptr, int more_data = -1);
 
 	void RunInitFunctions();
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7981,7 +7981,7 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 			Script_system.SetHookObject("Ship", objp);
 			Script_system.SetHookVar("Method", 's', departmethod);
 			Script_system.SetHookVar("JumpNode", 's', jumpnode_name);
-			Script_system.RunCondition(CHA_ONSHIPDEPART);
+			Script_system.RunCondition(CHA_ONSHIPDEPART, objp);
 			Script_system.RemHookVars({"Ship", "Method", "JumpNode"});
 		}
 	}
@@ -12085,8 +12085,8 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 		if (Script_system.IsActiveAction(CHA_ONWPFIRED) || Script_system.IsActiveAction(CHA_PRIMARYFIRE)) {
 			Script_system.SetHookObjects(2, "User", objp, "Target", target);
-			Script_system.RunCondition(CHA_ONWPFIRED, objp, 1);
-			Script_system.RunCondition(CHA_PRIMARYFIRE, objp);
+			Script_system.RunCondition(CHA_ONWPFIRED, objp, nullptr, 1);
+			Script_system.RunCondition(CHA_PRIMARYFIRE, objp, nullptr);
 			Script_system.RemHookVars({"User", "Target"});
 		}
 	}
@@ -12787,8 +12787,8 @@ done_secondary:
 
 		if (Script_system.IsActiveAction(CHA_ONWPFIRED) || Script_system.IsActiveAction(CHA_SECONDARYFIRE)) {
 			Script_system.SetHookObjects(2, "User", objp, "Target", target);
-			Script_system.RunCondition(CHA_ONWPFIRED, objp);
-			Script_system.RunCondition(CHA_SECONDARYFIRE, objp);
+			Script_system.RunCondition(CHA_ONWPFIRED, objp, nullptr, 2);
+			Script_system.RunCondition(CHA_SECONDARYFIRE, objp, nullptr);
 			Script_system.RemHookVars({"User", "Target"});
 		}
 	}
@@ -13049,8 +13049,8 @@ int ship_select_next_primary(object *objp, int direction)
 
 		if (Script_system.IsActiveAction(CHA_ONWPSELECTED) || Script_system.IsActiveAction(CHA_ONWPDESELECTED)) {
 			Script_system.SetHookObjects(2, "User", objp, "Target", target);
-			Script_system.RunCondition(CHA_ONWPSELECTED, objp);
-			Script_system.RunCondition(CHA_ONWPDESELECTED, objp);
+			Script_system.RunCondition(CHA_ONWPSELECTED, objp, nullptr, 1);
+			Script_system.RunCondition(CHA_ONWPDESELECTED, objp, nullptr, 1);
 			Script_system.RemHookVars({"User", "Target"});
 		}
 
@@ -13153,8 +13153,8 @@ int ship_select_next_secondary(object *objp)
 
 			if (Script_system.IsActiveAction(CHA_ONWPSELECTED) || Script_system.IsActiveAction(CHA_ONWPDESELECTED)) {
 				Script_system.SetHookObjects(2, "User", objp, "Target", target);
-				Script_system.RunCondition(CHA_ONWPSELECTED, objp);
-				Script_system.RunCondition(CHA_ONWPDESELECTED, objp);
+				Script_system.RunCondition(CHA_ONWPSELECTED, objp, nullptr, 2);
+				Script_system.RunCondition(CHA_ONWPDESELECTED, objp, nullptr, 2);
 				Script_system.RemHookVars({"User", "Target"});
 			}
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2147,7 +2147,7 @@ int beam_start_firing(beam *b)
 
 	if (Script_system.IsActiveAction(CHA_BEAMFIRE)) {
 		Script_system.SetHookObjects(3, "Beam", &Objects[b->objnum], "User", b->objp, "Target", b->target);
-		Script_system.RunCondition(CHA_BEAMFIRE, &Objects[b->objnum], b->weapon_info_index);
+		Script_system.RunCondition(CHA_BEAMFIRE, b->objp, &Objects[b->objnum]);
 		Script_system.RemHookVars({"Beam", "User", "Target"});
 	}
 
@@ -3070,14 +3070,14 @@ int beam_collide_ship(obj_pair *pair)
 			if (Script_system.IsActiveAction(CHA_COLLIDEBEAM)) {
 				Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Beam", weapon_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(mc_array[i]->hit_point_world));
-				ship_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, ship_objp);
+				ship_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, ship_objp, weapon_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Beam", "Hitpos" });
 			}
 
 			if (Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
 				Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Beam", weapon_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(mc_array[i]->hit_point_world));
-				weapon_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, weapon_objp);
+				weapon_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, weapon_objp, ship_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Beam", "Hitpos" });
 			}
 
@@ -3092,7 +3092,7 @@ int beam_collide_ship(obj_pair *pair)
 			{
 				Script_system.SetHookObjects(4, "Self", ship_objp, "Object", weapon_objp, "Ship", ship_objp, "Beam", weapon_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(mc_array[i]->hit_point_world));
-				Script_system.RunCondition(CHA_COLLIDEBEAM, ship_objp);
+				Script_system.RunCondition(CHA_COLLIDEBEAM, ship_objp, weapon_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Beam", "Hitpos" });
 			}
 
@@ -3100,7 +3100,7 @@ int beam_collide_ship(obj_pair *pair)
 			{
 				Script_system.SetHookObjects(4, "Self", weapon_objp, "Object", ship_objp, "Ship", ship_objp, "Beam", weapon_objp);
 				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(mc_array[i]->hit_point_world));
-				Script_system.RunCondition(CHA_COLLIDESHIP, weapon_objp);
+				Script_system.RunCondition(CHA_COLLIDESHIP, weapon_objp, ship_objp);
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Beam", "Hitpos" });
 			}
 		}
@@ -3179,14 +3179,14 @@ int beam_collide_asteroid(obj_pair *pair)
 		if (Script_system.IsActiveAction(CHA_COLLIDEASTEROID)) {
 			Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Asteroid", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, pair->a);
+			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEASTEROID, pair->a, pair->b);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Asteroid", "Hitpos" });
 		}
 
 		if (Script_system.IsActiveAction(CHA_COLLIDEBEAM)) {
 			Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Asteroid", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b);
+			asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b, pair->a);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Asteroid", "Hitpos" });
 		}
 
@@ -3199,7 +3199,7 @@ int beam_collide_asteroid(obj_pair *pair)
 		{
 			Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Asteroid", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			Script_system.RunCondition(CHA_COLLIDEASTEROID, pair->a);
+			Script_system.RunCondition(CHA_COLLIDEASTEROID, pair->a, pair->b);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Asteroid", "Hitpos" });
 		}
 
@@ -3207,7 +3207,7 @@ int beam_collide_asteroid(obj_pair *pair)
 		{
 			Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Asteroid", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b);
+			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b, pair->a);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Asteroid", "Hitpos" });
 		}
 
@@ -3284,7 +3284,7 @@ int beam_collide_missile(obj_pair *pair)
 		if (Script_system.IsActiveAction(CHA_COLLIDEWEAPON)) {
 			Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Weapon", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			a_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pair->a);
+			a_override = Script_system.IsConditionOverride(CHA_COLLIDEWEAPON, pair->a, pair->b);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Weapon", "Hitpos" });
 		}
 
@@ -3292,7 +3292,7 @@ int beam_collide_missile(obj_pair *pair)
 		if (Script_system.IsActiveAction(CHA_COLLIDEBEAM)) {
 			Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Weapon", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			b_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b);
+			b_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b, pair->a);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Weapon", "Hitpos" });
 		}
 
@@ -3305,7 +3305,7 @@ int beam_collide_missile(obj_pair *pair)
 		{
 			Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Weapon", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			Script_system.RunCondition(CHA_COLLIDEWEAPON, pair->a);
+			Script_system.RunCondition(CHA_COLLIDEWEAPON, pair->a, pair->b);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Weapon", "Hitpos" });
 		}
 
@@ -3314,7 +3314,7 @@ int beam_collide_missile(obj_pair *pair)
 			//Should be reversed
 			Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Weapon", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b);
+			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b, pair->a);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Weapon", "Hitpos" });
 		}
 	}
@@ -3391,14 +3391,14 @@ int beam_collide_debris(obj_pair *pair)
 		if (Script_system.IsActiveAction(CHA_COLLIDEDEBRIS)) {
 			Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Debris", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, pair->a);
+			weapon_override = Script_system.IsConditionOverride(CHA_COLLIDEDEBRIS, pair->a, pair->b);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Debris", "Hitpos" });
 		}
 
 		if (Script_system.IsActiveAction(CHA_COLLIDEBEAM)) {
 			Script_system.SetHookObjects(4, "Self", pair->b, "Object",  pair->a, "Beam", pair->a, "Debris", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			debris_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b);
+			debris_override = Script_system.IsConditionOverride(CHA_COLLIDEBEAM, pair->b, pair->a);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Debris", "Hitpos" });
 		}
 
@@ -3412,7 +3412,7 @@ int beam_collide_debris(obj_pair *pair)
 		{
 			Script_system.SetHookObjects(4, "Self", pair->a, "Object", pair->b, "Beam", pair->a, "Debris", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			Script_system.RunCondition(CHA_COLLIDEDEBRIS, pair->a);
+			Script_system.RunCondition(CHA_COLLIDEDEBRIS, pair->a, pair->b);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Debris", "Hitpos" });
 		}
 
@@ -3420,7 +3420,7 @@ int beam_collide_debris(obj_pair *pair)
 		{
 			Script_system.SetHookObjects(4, "Self", pair->b, "Object", pair->a, "Beam", pair->a, "Debris", pair->b);
 			Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(test_collide.hit_point_world));
-			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b);
+			Script_system.RunCondition(CHA_COLLIDEBEAM, pair->b, pair->a);
 			Script_system.RemHookVars({ "Self", "Object", "Beam", "Debris", "Hitpos" });
 		}
 	}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4378,7 +4378,7 @@ void weapon_delete(object *obj)
 
 	if (Script_system.IsActiveAction(CHA_ONWEAPONDELETE)) {
 		Script_system.SetHookObjects(2, "Weapon", obj, "Self", obj);
-		Script_system.RunCondition(CHA_ONWEAPONDELETE);
+		Script_system.RunCondition(CHA_ONWEAPONDELETE, obj);
 		Script_system.RemHookVars({"Weapon", "Self"});
 	}
 
@@ -6420,7 +6420,7 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 
 	if (Script_system.IsActiveAction(CHA_ONWEAPONCREATED)) {
 		Script_system.SetHookObject("Weapon", &Objects[objnum]);
-		Script_system.RunCondition(CHA_ONWEAPONCREATED);
+		Script_system.RunCondition(CHA_ONWEAPONCREATED, &Objects[objnum]);
 		Script_system.RemHookVar("Weapon");
 	}
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5524,8 +5524,8 @@ void game_enter_state( int old_state, int new_state )
 	Script_system.SetHookVar("OldState", 'o', l_GameState.Set(gamestate_h(old_state)));
 	Script_system.SetHookVar("NewState", 'o', l_GameState.Set(gamestate_h(new_state)));
 
-	if(Script_system.IsConditionOverride(CHA_ONSTATESTART)) {
-		Script_system.RunCondition(CHA_ONSTATESTART);
+	if(Script_system.IsConditionOverride(CHA_ONSTATESTART, nullptr, nullptr, old_state)) {
+		Script_system.RunCondition(CHA_ONSTATESTART, nullptr, nullptr, old_state);
 		Script_system.RemHookVars({"OldState", "NewState"});
 		return;
 	}
@@ -6048,7 +6048,7 @@ void mouse_force_pos(int x, int y);
 	} // end switch
 
 	//WMC - now do user scripting stuff
-	Script_system.RunCondition(CHA_ONSTATESTART);
+	Script_system.RunCondition(CHA_ONSTATESTART, nullptr, nullptr, old_state);
 	Script_system.RemHookVars({"OldState", "NewState"});
 }
 


### PR DESCRIPTION
For script hooks which use conditions, be more consistent about evaluating both objects involved, as well as evaluating the different types of objects.

Fixes #3874.