### PR TITLE
add some UX guards to the briefing editor icons

### DIFF
--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -643,14 +643,9 @@ void brief_init_colors()
 {
 }
 
-briefing_icon_info *brief_get_icon_info(brief_icon *bi)
+bool brief_special_closeup(int briefing_icon_type)
 {
-	if (bi->ship_class < 0)
-		return NULL;
-	ship_info *sip = &Ship_info[bi->ship_class];
-
-	bool allow_override = true;
-	switch (bi->type)
+	switch (briefing_icon_type)
 	{
 		case ICON_PLANET:
 		case ICON_ASTEROID_FIELD:
@@ -658,12 +653,19 @@ briefing_icon_info *brief_get_icon_info(brief_icon *bi)
 		case ICON_UNKNOWN:
 		case ICON_UNKNOWN_WING:
 		case ICON_JUMP_NODE:
-			allow_override = false;
-			break;
+			return true;
 	}
+	return false;
+}
+
+briefing_icon_info *brief_get_icon_info(brief_icon *bi)
+{
+	if (bi->ship_class < 0)
+		return nullptr;
+	ship_info *sip = &Ship_info[bi->ship_class];
 
 	// ship info might override the usual briefing icon
-	if ((allow_override || Custom_briefing_icons_always_override_standard_icons) && sip->bii_index_ship >= 0)
+	if ((!brief_special_closeup(bi->type) || Custom_briefing_icons_always_override_standard_icons) && sip->bii_index_ship >= 0)
 	{
 		if (bi->flags & BI_USE_WING_ICON)
 		{

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -67,13 +67,14 @@ typedef struct briefing_icon_info {
 	generic_anim	regular;
 	hud_anim		fade;
 	hud_anim		highlight;
-} briefing_icon_type;
+} briefing_icon_info;
 
 extern SCP_vector<briefing_icon_info> Briefing_icon_info;
 
 struct brief_icon;
 extern briefing_icon_info *brief_get_icon_info(brief_icon *bi);
 
+extern bool brief_special_closeup(int briefing_icon_type);
 
 
 // Moving out of missionbriefcommon.cpp so it can be referenced elsewhere -MageKing17

--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -329,6 +329,27 @@ void briefing_editor_dlg::restore_editor_state()
 	m_cur_icon = icon_saved;
 }
 
+int briefing_editor_dlg::get_first_ship_with_no_custom_icon()
+{
+	if (first_ship_with_no_custom_icon < 0)
+	{
+		for (int i = 0; i < ship_info_size(); ++i)
+		{
+			if (Ship_info[i].bii_index_ship < 0)
+			{
+				first_ship_with_no_custom_icon = i;
+				break;
+			}
+		}
+
+		// sanity check
+		if (first_ship_with_no_custom_icon < 0)
+			first_ship_with_no_custom_icon = 0;
+	}
+
+	return first_ship_with_no_custom_icon;
+}
+
 void briefing_editor_dlg::update_data(int update)
 {
 	char buf[MAX_LABEL_LEN];
@@ -500,6 +521,11 @@ void briefing_editor_dlg::update_data(int update)
 			}
 			ptr->icons[m_last_icon].type = m_icon_image;
 
+			// if this icon has a special closeup image (like a jump node)
+			// then make sure the ship class doesn't have a special icon
+			if (brief_special_closeup(m_icon_image))
+				m_ship_type = get_first_ship_with_no_custom_icon();
+
 			if ((ptr->icons[m_last_icon].team != m_icon_team) && !m_change_local) {
 				set_modified();
 				reset_icon_loop(m_last_stage);
@@ -619,7 +645,7 @@ void briefing_editor_dlg::update_data(int update)
 	GetDlgItem(IDC_ICON_CLOSEUP_LABEL) -> EnableWindow(enable);
 	GetDlgItem(IDC_ICON_LABEL) -> EnableWindow(enable);
 	GetDlgItem(IDC_ICON_IMAGE) -> EnableWindow(enable && (sip_bii_ship < 0));
-	GetDlgItem(IDC_SHIP_TYPE) -> EnableWindow(enable);
+	GetDlgItem(IDC_SHIP_TYPE) -> EnableWindow(enable && !brief_special_closeup(m_icon_image));
 	GetDlgItem(IDC_HILIGHT) -> EnableWindow(enable);
 	GetDlgItem(IDC_FLIP_ICON) -> EnableWindow(enable);
 	GetDlgItem(IDC_USE_WING_ICON) -> EnableWindow(enable);

--- a/fred2/briefingeditordlg.h
+++ b/fred2/briefingeditordlg.h
@@ -114,6 +114,9 @@ protected:
 	virtual BOOL OnInitDialog();
 	BOOL PreTranslateMessage(MSG * pMsg);
 
+	int first_ship_with_no_custom_icon = -1;
+	int get_first_ship_with_no_custom_icon();
+
 	// Generated message map functions
 	//{{AFX_MSG(briefing_editor_dlg)
 	afx_msg void OnClose();


### PR DESCRIPTION
1) Prevent the ship class from being changed if the icon image has a special closeup (like a jump node)
2) If the icon image is changed to a special closeup, automatically choose a ship class that doesn't have a custom icon

Fixes #3860