### PR TITLE
Add Subsystem Flag to Hide Turrets from Ship Loadout Stats

### DIFF
--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1147,7 +1147,7 @@ void ship_select_blit_ship_info()
 		int x;
 		for(x = 0; x < sip->n_subsystems; x++)
 		{
-			if ( (sip->subsystems[x].type == SUBSYSTEM_TURRET) && !(sip->subsystems[x].flags[Model::Subsystem_Flags::Hide_turrets_in_loadout_stats]) )
+			if ( (sip->subsystems[x].type == SUBSYSTEM_TURRET) && !(sip->subsystems[x].flags[Model::Subsystem_Flags::Hide_turret_from_loadout_stats]) )
 				num_turrets++;
 			/*
 			for(y = 0; y < MAX_SHIP_PRIMARY_BANKS || y < MAX_SHIP_SECONDARY_BANKS; y++)

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1147,7 +1147,7 @@ void ship_select_blit_ship_info()
 		int x;
 		for(x = 0; x < sip->n_subsystems; x++)
 		{
-			if(sip->subsystems[x].type == SUBSYSTEM_TURRET)
+			if ( (sip->subsystems[x].type == SUBSYSTEM_TURRET) && !(sip->subsystems[x].flags[Model::Subsystem_Flags::Hide_turrets_in_loadout_stats]) )
 				num_turrets++;
 			/*
 			for(y = 0; y < MAX_SHIP_PRIMARY_BANKS || y < MAX_SHIP_SECONDARY_BANKS; y++)

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -65,7 +65,7 @@ namespace Model {
         Share_fire_direction,		// (DahBlount) Whenever the turret fires, make all firing points fire in the same direction.
         No_sparks,          // Subsystem does not generate sparks if hit - m!m
 		No_impact_debris,    // Don't spawn the small debris on impact - m!m
-		Hide_turrets_in_loadout_stats, // Turret is not accounted for in auto-generated "Turrets" line in the ship loadout window --wookieejedi
+		Hide_turret_from_loadout_stats, // Turret is not accounted for in auto-generated "Turrets" line in the ship loadout window --wookieejedi
 
         NUM_VALUES
 	};

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -65,6 +65,7 @@ namespace Model {
         Share_fire_direction,		// (DahBlount) Whenever the turret fires, make all firing points fire in the same direction.
         No_sparks,          // Subsystem does not generate sparks if hit - m!m
 		No_impact_debris,    // Don't spawn the small debris on impact - m!m
+		Hide_turrets_in_loadout_stats, // Turret is not accounted for in auto-generated "Turrets" line in the ship loadout window --wookieejedi
 
         NUM_VALUES
 	};

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -265,7 +265,8 @@ flag_def_list_new<Model::Subsystem_Flags> Subsystem_flags[] = {
 	{ "don't autorepair if disabled", Model::Subsystem_Flags::No_autorepair_if_disabled,        true, false },
 	{ "share fire direction",       Model::Subsystem_Flags::Share_fire_direction,               true, false },
 	{ "no damage spew",             Model::Subsystem_Flags::No_sparks,                          true, false },
-	{ "no impact debris",           Model::Subsystem_Flags::No_impact_debris,                    true, false },
+	{ "no impact debris",           Model::Subsystem_Flags::No_impact_debris,                   true, false },
+	{ "hide turret from ship summary", Model::Subsystem_Flags::Hide_turrets_in_loadout_stats,   true, false },
 };
 
 const size_t Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list_new<Model::Subsystem_Flags>);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -266,7 +266,7 @@ flag_def_list_new<Model::Subsystem_Flags> Subsystem_flags[] = {
 	{ "share fire direction",       Model::Subsystem_Flags::Share_fire_direction,               true, false },
 	{ "no damage spew",             Model::Subsystem_Flags::No_sparks,                          true, false },
 	{ "no impact debris",           Model::Subsystem_Flags::No_impact_debris,                   true, false },
-	{ "hide turret from ship summary", Model::Subsystem_Flags::Hide_turrets_in_loadout_stats,   true, false },
+	{ "hide turret from loadout stats", Model::Subsystem_Flags::Hide_turret_from_loadout_stats, true, false },
 };
 
 const size_t Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list_new<Model::Subsystem_Flags>);


### PR DESCRIPTION
The statistics summary window in the ship loadout editor shows various aspects and stats of the selected ship. These can be toggled and customized through the ships table, but one line is actually autogenerated, `+Turrets`. This is unideal for certain ships, especially those which use turrets on ships in non-standard ways (for example having an AI controlled turret which shoots bombs). In these cases, the turrets are not actual turrets, and it is confusing for players seeing that there is a turret on the ship in the loadout editor. (I can give more detailed examples using FotG if needed).

This PR adds a subsystem flag which allows the modders to hide a turret subsystem so it is not counted in the auto generation of the `Turrets` summary line. (As a slight cleanup I also removed cleaned up the whitespace formatting on a nearby, but unrelated line).