### PR TITLE
fix two bugs associated with custom tech databases

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1548,20 +1548,29 @@ void campaign_room_scroll_info_down()
 		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
-void campaign_reset(const SCP_string& campaign_file) {
+void campaign_reset(const SCP_string& campaign_file)
+{
 	auto filename = campaign_file + FS_CAMPAIGN_FILE_EXT;
 
 	mission_campaign_savefile_delete(filename.c_str());
-	mission_campaign_load(filename.c_str(), nullptr, 1 , false); // retail doesn't reset stats when resetting the campaign
-	mission_campaign_next_mission();
 
-	// Goober5000 - reinitialize tech database if needed
-	if ((Campaign.flags & CF_CUSTOM_TECH_DATABASE) || !stricmp(Campaign.filename, "freespace2")) {
-		// reset tech database to what's in the tables
-		tech_reset_to_default();
+	const int load_status = mission_campaign_load(filename.c_str(), nullptr, 1 , false);	// retail doesn't reset stats when resetting the campaign
+
+	// see if we successfully loaded this campaign
+	if (load_status == 0) {
+		// Goober5000 - reinitialize tech database if needed
+		if ((Campaign.flags & CF_CUSTOM_TECH_DATABASE) || !stricmp(Campaign.filename, "freespace2")) {
+			// reset tech database to what's in the tables
+			tech_reset_to_default();
+
+			// write the savefile so that we don't later load a stale techroom
+			Pilot.save_savefile();
+		}
+
+		OnCampaignBeginHook->run(scripting::hook_param_list(scripting::hook_param("Campaign", 's', Campaign.filename)));
 	}
 
-	OnCampaignBeginHook->run(scripting::hook_param_list(scripting::hook_param("Campaign", 's', Campaign.filename)));
+	mission_campaign_next_mission();
 }
 
 // returns: 0 = success, !0 = aborted or failed
@@ -1664,7 +1673,7 @@ void campaign_select_campaign(const SCP_string& campaign_file)
 		strcpy_s(Player->current_campaign, campaign_file.c_str()); // track new campaign for player
 
 		// attempt to load the campaign
-		int load_status = mission_campaign_load(campaign_file.c_str());
+		const int load_status = mission_campaign_load(campaign_file.c_str());
 
 		// see if we successfully loaded this campaign and it's at the beginning
 		if (load_status == 0 && Campaign.prev_mission < 0) {
@@ -1672,6 +1681,9 @@ void campaign_select_campaign(const SCP_string& campaign_file)
 			if ((Campaign.flags & CF_CUSTOM_TECH_DATABASE) || !stricmp(Campaign.filename, "freespace2")) {
 				// reset tech database to what's in the tables
 				tech_reset_to_default();
+
+				// write the savefile so that we don't later load a stale techroom
+				Pilot.save_savefile();
 			}
 
 			OnCampaignBeginHook->run(scripting::hook_param_list(scripting::hook_param("Campaign", 's', Campaign.filename)));

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -1377,24 +1377,16 @@ int intel_info_lookup(const char *name)
 void tech_reset_to_default()
 {
 	// ships
-    for (auto &si : Ship_info)
-    {
-        if (si.flags[Ship::Info_Flags::Default_in_tech_database])
-            si.flags.set(Ship::Info_Flags::In_tech_database);
-        else
-            si.flags.remove(Ship::Info_Flags::Default_in_tech_database);
-
-        if (si.flags[Ship::Info_Flags::Default_in_tech_database_m])
-            si.flags.set(Ship::Info_Flags::In_tech_database_m);
-        else
-            si.flags.remove(Ship::Info_Flags::Default_in_tech_database_m);
-    }
-
+	for (auto& si : Ship_info)
+	{
+		si.flags.set(Ship::Info_Flags::In_tech_database, si.flags[Ship::Info_Flags::Default_in_tech_database]);
+		si.flags.set(Ship::Info_Flags::In_tech_database_m, si.flags[Ship::Info_Flags::Default_in_tech_database_m]);
+	}
 
 	// weapons
-	for (auto &wi : Weapon_info)
+	for (auto& wi : Weapon_info)
 	{
-        wi.wi_flags.set(Weapon::Info_Flags::In_tech_database, wi.wi_flags[Weapon::Info_Flags::Default_in_tech_database]);
+		wi.wi_flags.set(Weapon::Info_Flags::In_tech_database, wi.wi_flags[Weapon::Info_Flags::Default_in_tech_database]);
 	}
 
 	// intelligence

--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -314,7 +314,7 @@ ADE_FUNC(loadCampaign, l_Player, "string campaign", "Loads the specified campaig
 	strcpy_s(pl->current_campaign, filename); // track new campaign for player
 
 	// attempt to load the campaign
-	int load_status = mission_campaign_load(filename, pl);
+	const int load_status = mission_campaign_load(filename, pl);
 
 	// see if we successfully loaded this campaign and it's at the beginning
 	if (load_status == 0 && Campaign.prev_mission < 0) {
@@ -322,6 +322,9 @@ ADE_FUNC(loadCampaign, l_Player, "string campaign", "Loads the specified campaig
 		if ((Campaign.flags & CF_CUSTOM_TECH_DATABASE) || !stricmp(Campaign.filename, "freespace2")) {
 			// reset tech database to what's in the tables
 			tech_reset_to_default();
+
+			// write the savefile so that we don't later load a stale techroom
+			Pilot.save_savefile();
 		}
 
 		OnCampaignBeginHook->run(scripting::hook_param_list(scripting::hook_param("Campaign", 's', Campaign.filename)));


### PR DESCRIPTION
1) In commit 770fce8de5dc3ab4fd1db0e4d74724664dd60047, a flag was incorrectly ported from a bit to a flagset, which caused ships not in the tech db to not be removed.
2) Perhaps due to the pilot file upgrade, campaigns which had their tech databases reset would immediately load stale techroom data from the savefile.  This change writes the savefile after the reset so that subsequent reloads will load the correct data.