### PR TITLE
Fix background sun positioning as well

### DIFF
--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -899,7 +899,7 @@ void stars_post_level_init()
 			starfield_bitmap_instance def_sun;
 
 			// stuff some values
-			def_sun.ang.h = fl_radians(60.0f);
+			def_sun.ang.h = fl_radians(-60.0f);
 
 			Suns.push_back(def_sun);
 		}
@@ -1133,7 +1133,7 @@ void stars_get_sun_pos(int sun_n, vec3d *pos)
 	
 	// rotation matrix
 	vm_angles_2_matrix(&rot, &Suns[sun_n].ang);
-	vm_vec_rotate(pos, &temp, &rot);
+	vm_vec_unrotate(pos, &temp, &rot);
 }
 
 // draw sun


### PR DESCRIPTION
Follow-up bugfix for #4186. Suns are getting their positions and everything stored and retrieved correctly, but the math that positions them was never corrected like bg bitmaps are now. The default sun position must be corrected as well, since that is entirely internal.