### PR TITLE
Fix memory leak and use tmap verts directly

### DIFF
--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -448,36 +448,30 @@ void model_collide_parse_bsp_tmappoly(bsp_collision_leaf *leaf, SCP_vector<model
 
 	uint i;
 	uint nv;
-	model_tmap_vert *verts;
 
-	nv = uw(p+36);
+	nv = uw(p + TMAP_NVERTS);
 
 	if ( nv > TMAP_MAX_VERTS ) {
 		Int3();
 		return;
 	}
 
-	int tmap_num = w(p+40);
+	int tmap_num = w(p + TMAP_TEXNUM);
 
 	Assert(tmap_num >= 0 && tmap_num < MAX_MODEL_TEXTURES);
 
-	verts = new model_tmap_vert[nv];
-	auto vs = reinterpret_cast<model_tmap_vert_old*>(&p[44]);
-
-	for (i = 0; i < nv; i++) {
-		verts[i] = model_tmap_vert(vs[i]);
-	}
+	auto verts = reinterpret_cast<model_tmap_vert_old*>(&p[TMAP_VERTS]);
 
 	leaf->tmap_num = (ubyte)tmap_num;
 	leaf->num_verts = (ubyte)nv;
 	leaf->vert_start = (int)vert_buffer->size();
 
-	vec3d *plane_norm = vp(p+8);
+	vec3d *plane_norm = vp(p + TMAP_NORMAL);
 
 	leaf->plane_norm = *plane_norm;
 
 	for ( i = 0; i < nv; ++i ) {
-		vert_buffer->push_back(verts[i]);
+		vert_buffer->push_back(model_tmap_vert(verts[i]));
 	}
 }
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1716,12 +1716,7 @@ void parse_tmap(int offset, ubyte *bsp_data)
 	int pof_tex = w(bsp_data+offset+TMAP_TEXNUM);
 	uint n_vert = uw(bsp_data+offset+TMAP_NVERTS);
 	ubyte *p = &bsp_data[offset+TMAP_NORMAL];
-	auto vs = reinterpret_cast<model_tmap_vert_old*>(&bsp_data[offset + TMAP_VERTS]);
-	auto tverts = new model_tmap_vert[n_vert];
-
-	for (uint i = 0; i < n_vert; i++) {
-		tverts[i] = model_tmap_vert(vs[i]);
-	}
+	auto tverts = reinterpret_cast<model_tmap_vert_old*>(&bsp_data[offset + TMAP_VERTS]);
 
 	vertex *V;
 	vec3d *v;
@@ -1739,7 +1734,7 @@ void parse_tmap(int offset, ubyte *bsp_data)
 		V->texture_position.u = tverts[0].u;
 		V->texture_position.v = tverts[0].v;
 
-		*N = *Interp_norms[(int)tverts[0].normnum];
+		*N = *Interp_norms[tverts[0].normnum];
 
 		if ( IS_VEC_NULL(N) )
 			*N = *vp(p);
@@ -1756,7 +1751,7 @@ void parse_tmap(int offset, ubyte *bsp_data)
 		V->texture_position.u = tverts[i].u;
 		V->texture_position.v = tverts[i].v;
 
-		*N = *Interp_norms[(int)tverts[i].normnum];
+		*N = *Interp_norms[tverts[i].normnum];
 
 		if ( IS_VEC_NULL(N) )
 			*N = *vp(p);
@@ -3142,7 +3137,6 @@ void bsp_polygon_data::process_tmap(int offset, ubyte* bsp_data)
 	int pof_tex = w(bsp_data + offset + TMAP_TEXNUM);
 	uint n_vert = uw(bsp_data + offset + TMAP_NVERTS);
 	ubyte* p;
-	model_tmap_vert* tverts;
 
 	if ( n_vert < 3 ) {
 		// don't parse degenerate polygons
@@ -3151,11 +3145,7 @@ void bsp_polygon_data::process_tmap(int offset, ubyte* bsp_data)
 
 	p = &bsp_data[offset + TMAP_NORMAL];
 
-	auto vs = reinterpret_cast<model_tmap_vert_old*>(&bsp_data[offset + TMAP_VERTS]);
-	tverts = new model_tmap_vert[n_vert];
-	for (uint i = 0; i < n_vert; i++) {
-		tverts[i] = model_tmap_vert(vs[i]);
-	}
+	auto tverts = reinterpret_cast<model_tmap_vert_old*>(&bsp_data[offset + TMAP_VERTS]);
 
 	// Copy the verts manually since they aren't aligned with the struct
 	//unpack_tmap_verts(&bsp_data[offset + 44], tverts, n_vert);

--- a/code/model/modeloctant.cpp
+++ b/code/model/modeloctant.cpp
@@ -132,16 +132,10 @@ void moff_defpoints(ubyte * p, int just_count)
 void moff_tmappoly(ubyte * p, polymodel * pm, model_octant * oct, int just_count )
 {
 	uint i, nv;
-	model_tmap_vert *verts;
 
-	nv = uw(p+36);
+	nv = uw(p + TMAP_NVERTS);
 
-	verts = new model_tmap_vert[nv];
-	auto vs = reinterpret_cast<model_tmap_vert_old*>(&p[44]);
-
-	for (i = 0; i < nv; i++) {
-		verts[i] = model_tmap_vert(vs[i]);
-	}
+	auto verts = reinterpret_cast<model_tmap_vert_old*>(&p[TMAP_VERTS]);
 
 	if ( (pm->version < 2003) && !just_count )	{
 		// Set the "normal_point" part of field to be the center of the polygon

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4918,7 +4918,6 @@ void swap_bsp_defpoints(ubyte * p)
 void swap_bsp_tmappoly( polymodel * pm, ubyte * p )
 {
 	uint i, nv;
-	model_tmap_vert *verts;
 	vec3d * normal = vp(p+8);	//tigital
 	vec3d * center = vp(p+20);
 	float radius = INTEL_FLOAT( &fl(p+32) );
@@ -4938,36 +4937,12 @@ void swap_bsp_tmappoly( polymodel * pm, ubyte * p )
 	int tmap_num = INTEL_INT( w(p+40) );	//tigital
 		w(p+40) = tmap_num;
 
-	if ( nv < 0 ) return;
-
-	verts = new model_tmap_vert[n];
-
-	unpack_tmap_verts((p+44), verts, nv);
-
-	if ( pm->version < 2003 )	{
-		// Set the "normal_point" part of field to be the center of the polygon
-		vec3d center_point;
-		vm_vec_zero( &center_point );
-
-		for (i=0;i<nv;i++)	{
-			vm_vec_add2( &center_point, Interp_verts[verts[i].vertnum] );
-		}
-
-		center_point.xyz.x /= nv;
-		center_point.xyz.y /= nv;
-		center_point.xyz.z /= nv;
-
-		*vp(p+20) = center_point;
-
-		float rad = 0.0f;
-
-		for (i=0;i<nv;i++)	{
-			float dist = vm_vec_dist( &center_point, Interp_verts[verts[i].vertnum] );
-			if ( dist > rad )	{
-				rad = dist;
-			}
-		}
-		fl(p+32) = rad;
+	auto verts = reinterpret_cast<model_tmap_vert_old*>(&p[TMAP_VERTS]);
+	for (i = 0; i < nv; i++) {
+		verts[i].vertnum = INTEL_SHORT(verts[i].vertnum);	//tigital
+		verts[i].normnum = INTEL_SHORT(verts[i].normnum);	
+		verts[i].u = INTEL_FLOAT(&verts[i].u);
+		verts[i].v = INTEL_FLOAT(&verts[i].v);
 	}
 }
 
@@ -4984,8 +4959,8 @@ void swap_bsp_tmap2poly(polymodel* pm, ubyte* p)
 
 	verts = (model_tmap_vert*)(p + TMAP2_VERTS);
 	for (i = 0; i < nv; i++) {
-		verts[i].vertnum = INTEL_SHORT(verts[i].vertnum);
-		verts[i].normnum = INTEL_SHORT(verts[i].normnum);
+		verts[i].vertnum = INTEL_INT(verts[i].vertnum);
+		verts[i].normnum = INTEL_INT(verts[i].normnum);
 		verts[i].u = INTEL_FLOAT(&verts[i].u);
 		verts[i].v = INTEL_FLOAT(&verts[i].v);
 	}


### PR DESCRIPTION
There were several dynamic arrays `new`'d but not `delete[]`ed, however in this case they were largely unecessary. Instead of copying the `model_tmap_vert_old`s into `model_tmap_vert`s and using those, the `model_tmap_vert_old`s can be used directly. Also do some updating of the easily-missed-because-it-doesn't-get-compiled-on-my-machine swap bsp functions for big endian.

Should fix #4185