### PR TITLE
assign cues when a ship is ship-created

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6689,6 +6689,10 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 	shipp->warpin_params_index = sip->warpin_params_index;
 	shipp->warpout_params_index = sip->warpout_params_index;
 
+	// default cues, which will be changed later unless this is created in the lab or by ship-create
+	shipp->arrival_cue = Locked_sexp_true;
+	shipp->departure_cue = Locked_sexp_false;
+
 	if(pm != NULL && pm->n_view_positions > 0)
 		ship_set_eye(objp, 0);
 	else


### PR DESCRIPTION
Assign locked-* cues to ship-created ships so that their arrival and departure cues are not -1.  Supersedes PR #4248.

Fixes #4251.