### PR TITLE
Fix clear-container SEXP

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -746,7 +746,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "add-to-map",						OP_CONTAINER_ADD_TO_MAP,				3,	INT_MAX,	SEXP_ACTION_OPERATOR, },	// Karajorma
 	{ "remove-from-map",				OP_CONTAINER_REMOVE_FROM_MAP,			2,	INT_MAX,	SEXP_ACTION_OPERATOR, },	// Karajorma
 	{ "get-map-keys",					OP_CONTAINER_GET_MAP_KEYS,				2,	3,			SEXP_ACTION_OPERATOR, },	// Karajorma
-	{ "clear-container",				OP_CLEAR_CONTAINER,						1,	1,			SEXP_ACTION_OPERATOR, },	// Karajorma
+	{ "clear-container",				OP_CLEAR_CONTAINER,						1,	INT_MAX,	SEXP_ACTION_OPERATOR, },	// Karajorma
 
 	//Other Sub-Category
 	{ "damaged-escort-priority",		OP_DAMAGED_ESCORT_LIST,					3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	//phreak
@@ -28498,12 +28498,7 @@ int query_operator_argument_type(int op, int argnum)
 			}
 
 		case OP_CLEAR_CONTAINER:
-			if (argnum == 0) {
-				return OPF_CONTAINER_NAME;
-			} else {
-				// This shouldn't happen
-				return OPF_NONE;
-			}
+			return OPF_CONTAINER_NAME;
 
 		case OP_HAS_DOCKED:
 		case OP_HAS_UNDOCKED:
@@ -33485,10 +33480,10 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t3:\t(Optional) When true, the list container's current contents are deleted. When false, the keys are appended to the end of the list." },
 
 	// Karajorma/jg18
-	{ OP_CLEAR_CONTAINER, "add-to-map\r\n"
-		"\tDeletes the current contents of a container.\r\n\r\n"
-		"Takes 1 argument...\r\n"
-		"\t1:\tName of the container.\r\n" },
+	{ OP_CLEAR_CONTAINER, "clear-container\r\n"
+		"\tDeletes the current contents of one or more containers.\r\n\r\n"
+		"Takes 1 or more arguments...\r\n"
+		"\tAll:\tName of the container(s) to clear.\r\n" },
 
 	{ OP_PROTECT_SHIP, "Protect ship (Action operator)\r\n"
 		"\tProtects a ship from being attacked by any enemy ship.  Any ship "

--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -1288,22 +1288,26 @@ void sexp_get_map_keys(int node)
 
 void sexp_clear_container(int node)
 {
-	const char *container_name = CTEXT(node);
-	auto *p_container = get_sexp_container(container_name);
+	Assertion(node != -1, "Clear-container wasn't given any containers. Please report!");
 
-	if (!p_container) {
-		report_nonexistent_container("Clear-container", container_name);
-		return;
-	}
+	for (; node != -1; node = CDR(node)) {
+		const char *container_name = CTEXT(node);
+		auto *p_container = get_sexp_container(container_name);
 
-	auto &container = *p_container;
+		if (!p_container) {
+			report_nonexistent_container("Clear-container", container_name);
+			continue;
+		}
 
-	if (container.is_map()) {
-		container.map_data.clear();
-	} else if (container.is_list()) {
-		container.list_data.clear();
-	} else {
-		UNREACHABLE("Container %s has invalid type (%d). Please report!", container_name, (int)container.type);
+		auto &container = *p_container;
+
+		if (container.is_map()) {
+			container.map_data.clear();
+		} else if (container.is_list()) {
+			container.list_data.clear();
+		} else {
+			UNREACHABLE("Container %s has invalid type (%d). Please report!", container_name, (int)container.type);
+		}
 	}
 }
 


### PR DESCRIPTION
Follow up on PR #3862 to make two changes to the `clear-container` SEXP:
1. Fix SEXP help text
2. Allow for any number of arguments, rather than only one.