### PR TITLE
partial revert of targeting distance ranking change

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -1305,9 +1305,7 @@ ship_obj *advance_ship(ship_obj *so, int next_flag)
 static object* select_next_target_by_distance(const bool targeting_from_closest_to_farthest, const int valid_team_mask, const int attacked_object_number = -1, flagset<Ship::Info_Flags>* target_filters = NULL) {
     object *minimum_object_ptr, *maximum_object_ptr, *nearest_object_ptr;
     minimum_object_ptr = maximum_object_ptr = nearest_object_ptr = NULL;
-    // we need to use the same distance method as evaluate_ship_as_closest_target
-    //float current_distance = hud_find_target_distance(&, Player_obj);
-    float current_distance = vm_vec_dist_quick(&Objects[Player_ai->target_objnum].pos, &Player_obj->pos);
+    float current_distance = hud_find_target_distance(&Objects[Player_ai->target_objnum], Player_obj);
     float minimum_distance = 1e20f;
     float maximum_distance = 0.0f;
     int player_object_index = OBJ_INDEX(Player_obj);
@@ -1362,9 +1360,7 @@ static object* select_next_target_by_distance(const bool targeting_from_closest_
                 continue;
             }
 
-            // we need to use the same distance method as evaluate_ship_as_closest_target
-            //new_distance = hud_find_target_distance(prospective_victim_ptr, Player_obj);
-            new_distance = vm_vec_dist_quick(&prospective_victim_ptr->pos, &Player_obj->pos);
+            new_distance = hud_find_target_distance(prospective_victim_ptr, Player_obj);
         }
         else {
             // Filter out any target that is not targeting the player  --Mastadon
@@ -4898,9 +4894,7 @@ int hud_target_closest_repair_ship(int goal_objnum)
 			}
 		}
 
-		// c.f. evaluate_ship_as_closest_target
-		//new_distance = hud_find_target_distance(A,Player_obj);
-		new_distance = vm_vec_dist_quick(&A->pos, &Player_obj->pos);
+		new_distance = hud_find_target_distance(A,Player_obj);
 
 		if (new_distance <= min_distance) {
 			min_distance=new_distance;
@@ -4963,9 +4957,7 @@ void hud_target_closest_uninspected_object()
 			continue;
 		}
 
-		// c.f. evaluate_ship_as_closest_target
-		//new_distance = hud_find_target_distance(A,Player_obj);
-		new_distance = vm_vec_dist_quick(&A->pos, &Player_obj->pos);
+		new_distance = hud_find_target_distance(A,Player_obj);
 
 		if (new_distance <= min_distance) {
 			min_distance=new_distance;
@@ -5000,9 +4992,7 @@ void hud_target_uninspected_object(int next_flag)
 
 	Target_next_uninspected_object_timestamp = timestamp(TL_RESET);
 
-	// c.f. evaluate_ship_as_closest_target
-	//cur_dist = hud_find_target_distance(&Objects[Player_ai->target_objnum], Player_obj);
-	cur_dist = vm_vec_dist_quick(&Objects[Player_ai->target_objnum].pos, &Player_obj->pos);
+	cur_dist = hud_find_target_distance(&Objects[Player_ai->target_objnum], Player_obj);
 
 	min_obj = max_obj = nearest_obj = NULL;
 	min_dist = 1e20f;
@@ -5034,9 +5024,7 @@ void hud_target_uninspected_object(int next_flag)
 			continue;
 		}
 
-		// c.f. evaluate_ship_as_closest_target
-		//new_dist = hud_find_target_distance(A, Player_obj);
-		new_dist = vm_vec_dist_quick(&A->pos, &Player_obj->pos);
+		new_dist = hud_find_target_distance(A, Player_obj);
 
 		if (new_dist <= min_dist) {
 			min_dist = new_dist;


### PR DESCRIPTION
Normally, when the player cycles through targets using (for example) the hostile targeting key, the targets will be shown in order of distance.  In PR #4121, this was changed from bounding-box distance to center-distance, which has very little noticeable effect on the cycle except that it now agrees with the AI strategy for measuring distance.

However, when the player targets a hostile for the first time, or when the cycle resets after 1.5 seconds have passed, the first ship targeted will be the closest ship *or* the ship with the closest turret.  And furthermore, when the target cycle continues, the next ship targeted will be the next ship farther away.  There can be a dramatic difference between a turret, which may be very close, and the center of the ship, which may be very far away.  The target cycle will continue with these far-away ships, and this has the effect of leapfrogging any ships that are closer that should be targeted first.

There isn't any easy way to tell that a ship has been targeted because of its turret, and not because of some other targeting key or because the cycle has restarted, but fortunately the bounding-box distance is a reasonable approximation because turrets tend to be on the bounding boxes.  So this commit simply restores the distance functions to what they were before.  The other fixes from #4121 are not related and remain in place.