### PR TITLE
Correct sun position compensation math

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5477,7 +5477,7 @@ void parse_one_background(background_t *background)
 
 		// correct legacy bitmap angles which used incorrect math in older versions
 		if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
-			stars_correct_background_angles(&sle.ang);
+			stars_correct_background_sun_angles(&sle.ang);
 
 		// scale
 		required_string("+Scale:");
@@ -5506,7 +5506,7 @@ void parse_one_background(background_t *background)
 
 		// correct legacy bitmap angles which used incorrect math in older versions
 		if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
-			stars_correct_background_angles(&sle.ang);
+			stars_correct_background_bitmap_angles(&sle.ang);
 
 		// scale
 		if (optional_string("+Scale:"))

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14325,8 +14325,12 @@ void sexp_add_background_bitmap(int n, bool is_sun, bool uses_correct_angles)
 	eval_angles(&sle.ang, n, is_nan, is_nan_forever);
 	if (is_nan || is_nan_forever)
 		return;
-	if (!uses_correct_angles)
-		stars_correct_background_angles(&sle.ang);
+	if (!uses_correct_angles) {
+		if (is_sun)
+			stars_correct_background_sun_angles(&sle.ang);
+		else
+			stars_correct_background_bitmap_angles(&sle.ang);
+	}
 
 	if (is_sun)
 	{

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1335,7 +1335,7 @@ static int addBackgroundBitmap_sub(bool uses_correct_angles, lua_State* L)
 
 	sle.ang     = *orient.GetAngles();
 	if (!uses_correct_angles)
-		stars_correct_background_angles(&sle.ang);
+		stars_correct_background_bitmap_angles(&sle.ang);
 
 	sle.scale_x = scale_x;
 	sle.scale_y = scale_y;
@@ -1410,7 +1410,7 @@ static int addSunBitmap_sub(bool uses_correct_angles, lua_State* L)
 
 	sle.ang     = *orient.GetAngles();
 	if (!uses_correct_angles)
-		stars_correct_background_angles(&sle.ang);
+		stars_correct_background_sun_angles(&sle.ang);
 
 	sle.scale_x = scale_x;
 	sle.scale_y = scale_y;

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2425,7 +2425,21 @@ int stars_add_bitmap_entry(starfield_list_entry *sle)
 	return (int)(Starfield_bitmap_instances.size() - 1);
 }
 
-void stars_correct_background_angles(angles *angs_to_correct)
+void stars_correct_background_sun_angles(angles* angs_to_correct)
+{
+	matrix mat;
+	vm_angles_2_matrix(&mat, angs_to_correct);
+	vm_transpose(&mat);
+	vm_extract_angles_matrix(angs_to_correct, &mat);
+}
+
+void stars_uncorrect_background_sun_angles(angles* angs_to_uncorrect)
+{
+	// the actual operation is an inversion so 'correcting' and 'uncorrecting' are the same
+	stars_correct_background_sun_angles(angs_to_uncorrect);
+}
+
+void stars_correct_background_bitmap_angles(angles *angs_to_correct)
 {
 	matrix mat1, mat2;
 	angles ang1 = vm_angles_new(0.0, angs_to_correct->b, 0.0);
@@ -2440,7 +2454,7 @@ void stars_correct_background_angles(angles *angs_to_correct)
 	angs_to_correct->h = fmod(angs_to_correct->h + PI2, PI2);
 }
 
-void stars_uncorrect_background_angles(angles *angs_to_uncorrect)
+void stars_uncorrect_background_bitmap_angles(angles *angs_to_uncorrect)
 {
 	matrix mat;
 	vm_angles_2_matrix(&mat, angs_to_uncorrect);

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2431,6 +2431,9 @@ void stars_correct_background_sun_angles(angles* angs_to_correct)
 	vm_angles_2_matrix(&mat, angs_to_correct);
 	vm_transpose(&mat);
 	vm_extract_angles_matrix(angs_to_correct, &mat);
+	angs_to_correct->p = fmod(angs_to_correct->p + PI2, PI2);
+	angs_to_correct->b = fmod(angs_to_correct->b + PI2, PI2);
+	angs_to_correct->h = fmod(angs_to_correct->h + PI2, PI2);
 }
 
 void stars_uncorrect_background_sun_angles(angles* angs_to_uncorrect)

--- a/code/starfield/starfield.h
+++ b/code/starfield/starfield.h
@@ -67,10 +67,12 @@ int stars_add_sun_entry(starfield_list_entry *sun_ptr);
 int stars_add_bitmap_entry(starfield_list_entry *bitmap);
 
 // transform legacy angles, which used incorrect math in older versions, to correct angles
-void stars_correct_background_angles(angles *angs_to_correct);
+void stars_correct_background_bitmap_angles(angles *angs_to_correct);
+void stars_correct_background_sun_angles(angles* angs_to_correct);
 
 // transform correct angles to legacy angles
-void stars_uncorrect_background_angles(angles *angs_to_uncorrect);
+void stars_uncorrect_background_bitmap_angles(angles *angs_to_uncorrect);
+void stars_uncorrect_background_sun_angles(angles* angs_to_uncorrect);
 
 // get the number of entries that each vector contains
 // "is_a_sun" will get sun instance counts, otherwise it gets normal starfield bitmap instance counts

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -915,7 +915,7 @@ int CFred_mission_save::save_bitmaps()
 			parse_comments();
 			angles ang = sle->ang;
 			if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
-				stars_uncorrect_background_angles(&ang);
+				stars_uncorrect_background_sun_angles(&ang);
 			fout(" %f %f %f", ang.p, ang.b, ang.h);
 
 			// scale
@@ -938,7 +938,7 @@ int CFred_mission_save::save_bitmaps()
 			parse_comments();
 			angles ang = sle->ang;
 			if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
-				stars_uncorrect_background_angles(&ang);
+				stars_uncorrect_background_bitmap_angles(&ang);
 			fout(" %f %f %f", ang.p, ang.b, ang.h);
 
 			// scale

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -931,7 +931,7 @@ int CFred_mission_save::save_bitmaps()
 			parse_comments();
 			angles ang = sle->ang;
 			if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
-				stars_uncorrect_background_angles(&ang);
+				stars_uncorrect_background_sun_angles(&ang);
 			fout(" %f %f %f", ang.p, ang.b, ang.h);
 
 			// scale
@@ -954,7 +954,7 @@ int CFred_mission_save::save_bitmaps()
 			parse_comments();
 			angles ang = sle->ang;
 			if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
-				stars_uncorrect_background_angles(&ang);
+				stars_uncorrect_background_bitmap_angles(&ang);
 			fout(" %f %f %f", ang.p, ang.b, ang.h);
 
 			// scale


### PR DESCRIPTION
Due to extra 'bank' shenanigans background bitmaps have a more complicated conversion, but suns don't have this so their conversion is simpler (and also incorrect if you try to do the banking stuff). One result of this now is that 'banking' a sun bitmap in FRED will have no apparent effect, but given that sun bitmaps could never actually be banked anyway (it only affected it's 2d position before), this isn't really a loss.