### PR TITLE
revised disabling of Enter and Escape

### DIFF
--- a/fred2/addmodifycontainerdlg.cpp
+++ b/fred2/addmodifycontainerdlg.cpp
@@ -43,14 +43,14 @@ void CAddModifyContainerDlg::DoDataExchange(CDataExchange *pDX)
 // This is needed because despite the override of the normal OK and Cancel routes, Enter will still be recognized
 BOOL CAddModifyContainerDlg::PreTranslateMessage(MSG* pMsg)
 {
-	if (pMsg->hwnd == this->m_hWnd && pMsg->message == WM_KEYDOWN)
+	if (pMsg->message == WM_KEYDOWN)
 	{
 		if (pMsg->wParam == VK_RETURN || pMsg->wParam == VK_ESCAPE)
 		{
 			return TRUE;                // Do not process further
 		}
 	}
-	return CWnd::PreTranslateMessage(pMsg);
+	return CDialog::PreTranslateMessage(pMsg);
 }
 
 BEGIN_MESSAGE_MAP(CAddModifyContainerDlg, CDialog)


### PR DESCRIPTION
Turns out PR #4243 actually introduced a bug that appeared to implement the feature.  The previous implementation had the effect of intercepting all keypresses and routing them to the main window.  This fixes that bug by using `CDialog` instead of `CWnd`.  It also turns out that the `hWnd` window handle for some reason does not match the expected window, but fortunately, this implementation is only called in the correct window so the restriction is not needed.