### PR TITLE
miscellaneous fixes related to old Coverity fixes

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6347,11 +6347,6 @@ int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int second
 			}
 		}
 	}
-	else
-	{
-		// We have no valid target object, we should not fire at it...
-		return 0;
-	}
 
 	return 1;
 }

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1782,6 +1782,8 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 #endif
 
 	if (check_ok_to_fire(parent_objnum, turret->turret_enemy_objnum, wip, -1, turret)) {
+		auto turret_enemy_objp = (turret->turret_enemy_objnum >= 0) ? &Objects[turret->turret_enemy_objnum] : nullptr;
+
 		ship_weapon* swp = &turret->weapons;
 		turret->turret_last_fire_direction = *firing_vec;
 
@@ -1818,13 +1820,13 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 			memset(&fire_info, 0, sizeof(beam_fire_info));
 			fire_info.accuracy = 1.0f;
 			fire_info.beam_info_index = turret_weapon_class;
-			fire_info.beam_info_override = NULL;
+			fire_info.beam_info_override = nullptr;
 			fire_info.shooter = &Objects[parent_objnum];
-			fire_info.target = &Objects[turret->turret_enemy_objnum];
+			fire_info.target = turret_enemy_objp;
 			if (wip->wi_flags[Weapon::Info_Flags::Antisubsysbeam])
 				fire_info.target_subsys = turret->targeted_subsys;
 			else
-				fire_info.target_subsys = NULL;
+				fire_info.target_subsys = nullptr;
 			fire_info.turret = turret;
 			fire_info.burst_seed = old_burst_seed;
 			fire_info.fire_method = BFM_TURRET_FIRED;
@@ -1841,7 +1843,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 				turret->last_fired_weapon_info_index = turret_weapon_class;
 
 				if (Script_system.IsActiveAction(CHA_ONTURRETFIRED)) {
-					Script_system.SetHookObjects(4, "Ship", &Objects[parent_objnum], "Weapon", nullptr, "Beam", objp, "Target", &Objects[turret->turret_enemy_objnum]);
+					Script_system.SetHookObjects(4, "Ship", &Objects[parent_objnum], "Weapon", nullptr, "Beam", objp, "Target", turret_enemy_objp);
 					Script_system.RunCondition(CHA_ONTURRETFIRED, &Objects[parent_objnum], objp);
 					Script_system.RemHookVars({"Ship", "Weapon", "Beam", "Target"});
 				}
@@ -1984,7 +1986,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 					wp->turret_subsys = turret;	
 
 					if (Script_system.IsActiveAction(CHA_ONTURRETFIRED)) {
-						Script_system.SetHookObjects(4, "Ship", &Objects[parent_objnum], "Weapon", objp, "Beam", nullptr, "Target", &Objects[turret->turret_enemy_objnum]);
+						Script_system.SetHookObjects(4, "Ship", &Objects[parent_objnum], "Weapon", objp, "Beam", nullptr, "Target", turret_enemy_objp);
 						Script_system.RunCondition(CHA_ONTURRETFIRED, &Objects[parent_objnum], objp);
 						Script_system.RemHookVars({"Ship", "Weapon", "Beam", "Target"});
 					}

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -702,7 +702,7 @@ int obj_snd_assign(int objnum, gamesnd_id sndnum, const vec3d *pos, int flags, c
 {
 	Assertion(pos != nullptr, "Sound position must not be null!");
 
-	if(objnum < 0 || objnum > MAX_OBJECTS)
+	if(objnum < 0 || objnum >= MAX_OBJECTS)
 		return -1;
 
 	if(!sndnum.isValid())

--- a/code/scripting/api/objs/cockpit_display.cpp
+++ b/code/scripting/api/objs/cockpit_display.cpp
@@ -204,7 +204,7 @@ size_t cockpit_display_h::GetId() {
 	return m_display_num;
 }
 bool cockpit_display_h::isValid() {
-	if (obj_num < 0 || obj_num > MAX_OBJECTS)
+	if (obj_num < 0 || obj_num >= MAX_OBJECTS)
 	{
 		return false;
 	}

--- a/code/scripting/doc_html.cpp
+++ b/code/scripting/doc_html.cpp
@@ -398,7 +398,6 @@ void OutputElement(FILE* fp,
 			if (!propEl->description.empty())
 				fprintf(fp, "<dd>%s</dd>\n", propEl->description.c_str());
 
-			//***Also settable with: Arguments
 			if (!propEl->returnDocumentation.empty())
 				fprintf(fp, "<dd><b>Value:</b> %s</b></dd>\n", propEl->returnDocumentation.c_str());
 			break;


### PR DESCRIPTION
1) Remove the extra branch in `check_ok_to_fire` that was added in SVN revision 10392, or commit 0d54630e83419f53ede08056bac3b26928d059cb.  If there was an actual Coverity error, this does not fix it at the proper location.  More importantly, this breaks certain turret firing behavior.
2) Fix a couple of bounds checks.
3) Remove an incorrect stale comment.

This fixes the broken turret swarm weapons that were uncovered by the fixes in #2959.