### PR TITLE
Allow SCPUI to run `$On Briefing Stage:` hooks

### DIFF
--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -476,7 +476,8 @@ ADE_FUNC(runBriefingStageHook, l_UserInterface_CmdBrief, "number oldStage, numbe
 	int oldStage = -1, newStage = -1;
 	if (ade_get_args(L, "ii", &oldStage, &newStage) == 2)
 	{
-		common_fire_stage_script_hook(oldStage, newStage);
+		// Subtract 1 to convert from Lua conventions to C conventions
+		common_fire_stage_script_hook(oldStage -1, newStage -1);
 	}
 	else
 	{

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -471,5 +471,19 @@ ADE_FUNC(getBriefingMusicName, l_UserInterface_CmdBrief, nullptr, "Gets the file
 	return ade_set_args(L, "s", common_music_get_filename(SCORE_BRIEFING).c_str());
 }
 
+ADE_FUNC(runBriefingStageHook, l_UserInterface_CmdBrief, "number oldStage, number newStage", "Run $On Briefing Stage: hooks.", nullptr, nullptr)
+{
+	int oldStage = -1, newStage = -1;
+	if (ade_get_args(L, "ii", &oldStage, &newStage) == 2)
+	{
+		common_fire_stage_script_hook(oldStage, newStage);
+	}
+	else
+	{
+		LuaError(L, "Bad arguments given to ui.runBriefingStageHook!");
+	}
+	return ADE_RETURN_NIL;
+}
+
 } // namespace api
 } // namespace scripting


### PR DESCRIPTION
BTA added a script that listens for briefing stages. It works fine for regular briefings, but not for command briefings. Mjn realized that SCPUI (which we use for CBs, but not regular briefings) wasn't triggering the `$On Briefing Stage:` hooks. This adds a scripting function to trigger them.