### PR TITLE
add improvements to aid in multi troubleshooting

### DIFF
--- a/code/network/multi_log.cpp
+++ b/code/network/multi_log.cpp
@@ -15,6 +15,10 @@
 #include "parse/generic_log.h"
 #include "cfile/cfile.h"
 #include "parse/parselo.h"
+#include "globalincs/version.h"
+#include "network/multi_options.h"
+#include "network/multi_fstracker.h"
+#include "network/multi.h"
 
 
 
@@ -77,11 +81,36 @@ void multi_log_write_update()
 	ml_printf("Server has been active for %d hours, %d minutes, and %d seconds", hours, mins, seconds);
 }
 
+// write out some info helpful for debugging
+static void multi_log_write_info()
+{
+	extern bool Multi_cfg_missing;
+
+	if (Multi_cfg_missing) {
+		ml_string("**  multi.cfg is missing!  **");
+	}
+
+	ml_printf("FreeSpace 2 Open version: %s", FS_VERSION_FULL);
+	ml_printf("Multi version: %d", MULTI_FS_SERVER_VERSION);
+
+	extern void cmdline_print_cmdline_multi();
+	cmdline_print_cmdline_multi();
+
+	if (Is_standalone) {
+		ml_printf("PXO: %s", Multi_options_g.pxo ? "Enabled" : "Disabled");
+
+		if (Multi_options_g.pxo) {
+			ml_printf("PXO Channel: %s", Multi_fs_tracker_channel);
+		}
+	}
+}
+
 // initialize the multi logfile
 void multi_log_init()
 {
 	if (logfile_init(LOGFILE_MULTI_LOG)) {
 		multi_log_write_header();
+		multi_log_write_info();
 
 		// initialize our timer info
 		Multi_log_open_systime = (int) time(NULL);

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -48,6 +48,7 @@ multi_global_options Multi_options_g;
 
 char Multi_options_proxy[512] = "";
 ushort Multi_options_proxy_port = 0;
+bool Multi_cfg_missing = true;
 
 // ----------------------------------------------------------------------------------
 // MULTI OPTIONS FUNCTIONS
@@ -76,6 +77,8 @@ void multi_options_read_config()
 	if (in == NULL) {
 		nprintf(("Network","Failed to open network config file, using default settings\n"));		
 	} else {
+		Multi_cfg_missing = false;
+
 		while ( !cfeof(in) ) {
 			// read in the game info
 			memset(str, 0, 512);

--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -205,13 +205,13 @@ namespace os
 
 			mprintf(("Lua Error: %s\n", msgStream.str().c_str()));
 
+			if (running_unittests) {
+				throw LuaErrorException(msgStream.str());
+			}
+
 			if (Cmdline_noninteractive) {
 				abort();
 				return;
-			}
-
-			if (running_unittests) {
-				throw LuaErrorException(msgStream.str());
 			}
 
 			set_clipboard_text(msgStream.str().c_str());
@@ -289,13 +289,13 @@ namespace os
 		{
 			mprintf(("\n%s\n", text));
 
+			if (running_unittests) {
+				throw ErrorException(text);
+			}
+
 			if (Cmdline_noninteractive) {
 				abort();
 				return;
-			}
-
-			if (running_unittests) {
-				throw ErrorException(text);
 			}
 
 			SCP_stringstream messageStream;
@@ -355,13 +355,13 @@ namespace os
 			// output to the debug log before anything else (so that we have a complete record)
 			mprintf(("WARNING: \"%s\" at %s:%d\n", text.c_str(), filename, line));
 
+			if (running_unittests) {
+				throw WarningException(text);
+			}
+
 			// now go for the additional popup window, if we want it ...
 			if (Cmdline_noninteractive) {
 				return;
-			}
-
-			if (running_unittests) {
-				throw WarningException(text);
 			}
 
 			SCP_stringstream boxMsgStream;


### PR DESCRIPTION
 - report when multi.cfg is missing
 - add game version, multi version, cmdline, and PXO status
   to multi.log
 - use non-interactive mode by default on standalone and
   enable it as soon as possible