### PR TITLE
Replace +Orders Accepted: Bitfield with flag list

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3347,6 +3347,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 
 	// check for the optional "orders accepted" string which contains the orders from the default
     // set that this ship will actually listen to
+	// Obsolete and only for backwards compatibility
     if (optional_string("+Orders Accepted:"))
     {
 		p_objp->orders_accepted.clear();
@@ -3363,6 +3364,24 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 			}
 		}
     }
+
+	if (optional_string("+Orders Accepted List:"))
+	{
+		p_objp->orders_accepted.clear();
+
+		SCP_vector<SCP_string> accepted_flags;
+		stuff_string_list(accepted_flags);
+
+		for (const SCP_string& accepted : accepted_flags) {
+			for (size_t j = 0; j < Player_orders.size(); j++) {
+				if (Player_orders[j].parse_name == accepted)
+					p_objp->orders_accepted.insert(j);
+			}
+		}
+
+		if (!p_objp->orders_accepted.empty())
+			p_objp->flags.set(Mission::Parse_Object_Flags::SF_Use_unique_orders);
+	}
 
 	p_objp->group = 0;
 	if (optional_string("+Group:"))

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3695,17 +3695,30 @@ int CFred_mission_save::save_objects()
 		// possibly write out the orders that this ship will accept.  We'll only do it if the orders
 		// are not the default set of orders
 		if (shipp->orders_accepted != ship_get_default_orders_accepted(&Ship_info[shipp->ship_info_index])) {
-			if (optional_string_fred("+Orders Accepted List:", "$Name:"))
-				parse_comments();
-			else
-				fout("\n+Orders Accepted List:");
+			if (Mission_save_format == FSO_FORMAT_RETAIL) {
+				if (optional_string_fred("+Orders Accepted:", "$Name:"))
+					parse_comments();
+				else 
+					fout("\n+Orders Accepted:");
 
-			fout(" (");
-			for (size_t order_id : shipp->orders_accepted) {
-				const auto& order = Player_orders[order_id];
-				fout(" \"%s\"", order.parse_name.c_str());
+				int bitfield = 0;
+				for (size_t order : shipp->orders_accepted)
+					bitfield |= Player_orders[order].id;
+				fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
 			}
-			fout(" )");
+			else {
+				if (optional_string_fred("+Orders Accepted List:", "$Name:"))
+					parse_comments();
+				else
+					fout("\n+Orders Accepted List:");
+
+				fout(" (");
+				for (size_t order_id : shipp->orders_accepted) {
+					const auto& order = Player_orders[order_id];
+					fout(" \"%s\"", order.parse_name.c_str());
+				}
+				fout(" )");
+			}
 		}
 
 		if (shipp->group >= 0) {

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3695,15 +3695,17 @@ int CFred_mission_save::save_objects()
 		// possibly write out the orders that this ship will accept.  We'll only do it if the orders
 		// are not the default set of orders
 		if (shipp->orders_accepted != ship_get_default_orders_accepted(&Ship_info[shipp->ship_info_index])) {
-			if (optional_string_fred("+Orders Accepted:", "$Name:"))
+			if (optional_string_fred("+Orders Accepted List:", "$Name:"))
 				parse_comments();
 			else
-				fout("\n+Orders Accepted:");
+				fout("\n+Orders Accepted List:");
 
-			int bitfield = 0;
-			for(size_t order : shipp->orders_accepted)
-				bitfield |= Player_orders[order].id;
-			fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
+			fout(" (");
+			for (size_t order_id : shipp->orders_accepted) {
+				const auto& order = Player_orders[order_id];
+				fout(" \"%s\"", order.parse_name.c_str());
+			}
+			fout(" )");
 		}
 
 		if (shipp->group >= 0) {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3489,16 +3489,18 @@ int CFred_mission_save::save_objects()
 		// possibly write out the orders that this ship will accept.  We'll only do it if the orders
 		// are not the default set of orders
 		if (shipp->orders_accepted != ship_get_default_orders_accepted(&Ship_info[shipp->ship_info_index])) {
-			if (optional_string_fred("+Orders Accepted:", "$Name:")) {
+			if (optional_string_fred("+Orders Accepted List:", "$Name:")) {
 				parse_comments();
 			} else {
-				fout("\n+Orders Accepted:");
+				fout("\n+Orders Accepted List:");
 			}
 
-			int bitfield = 0;
-			for(size_t order : shipp->orders_accepted)
-				bitfield |= Player_orders[order].id;
-			fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
+			fout(" (");
+			for (size_t order_id : shipp->orders_accepted) {
+				const auto& order = Player_orders[order_id];
+				fout(" \"%s\"", order.parse_name.c_str());
+			}
+			fout(" )");
 		}
 
 		if (shipp->group >= 0) {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3489,18 +3489,31 @@ int CFred_mission_save::save_objects()
 		// possibly write out the orders that this ship will accept.  We'll only do it if the orders
 		// are not the default set of orders
 		if (shipp->orders_accepted != ship_get_default_orders_accepted(&Ship_info[shipp->ship_info_index])) {
-			if (optional_string_fred("+Orders Accepted List:", "$Name:")) {
-				parse_comments();
-			} else {
-				fout("\n+Orders Accepted List:");
-			}
+			if (save_format == MissionFormat::RETAIL) {
+				if (optional_string_fred("+Orders Accepted:", "$Name:")) {
+					parse_comments();
+				} else {
+					fout("\n+Orders Accepted:");
+				}
 
-			fout(" (");
-			for (size_t order_id : shipp->orders_accepted) {
-				const auto& order = Player_orders[order_id];
-				fout(" \"%s\"", order.parse_name.c_str());
+				int bitfield = 0;
+				for (size_t order : shipp->orders_accepted)
+					bitfield |= Player_orders[order].id;
+				fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
+			} else {
+				if (optional_string_fred("+Orders Accepted List:", "$Name:")) {
+					parse_comments();
+				} else {
+					fout("\n+Orders Accepted List:");
+				}
+
+				fout(" (");
+				for (size_t order_id : shipp->orders_accepted) {
+					const auto& order = Player_orders[order_id];
+					fout(" \"%s\"", order.parse_name.c_str());
+				}
+				fout(" )");
 			}
-			fout(" )");
 		}
 
 		if (shipp->group >= 0) {


### PR DESCRIPTION
As detailed in the LuaAI PR (#4198), the orders a ship is allowed to follow in mission are currently saved as a bitfield. This bitfield is only accurate if the orders are always within the same order however. And since LuaAI allows adding such orders with modular tables, this is now very brittle and prone to failure and to breaking missions if AI stuff is tweaked by modders.
Hence this PR removes the bitfield and replaces it with a flagset where the parse names of all allowed orders are explicitly listed