### PR TITLE
Crossing the specular rubicon

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -318,17 +318,12 @@ cmdline_parm clip_dist_arg("-clipdist", "Changes the distance from the viewpoint
 cmdline_parm ambient_power_arg("-ambient", "Multiplies the brightness of all ambient light", AT_FLOAT);
 cmdline_parm light_power_arg("-light", "Multiplies the brightness of all light", AT_FLOAT);
 cmdline_parm emissive_power_arg("-emissive", "Multiplies the brightness of all ambient light", AT_FLOAT);
-
-cmdline_parm spec_static_arg("-spec_static", "Adjusts suns contribution to specular highlights", AT_FLOAT); //TODO: move to deprecated
-cmdline_parm spec_point_arg("-spec_point", "Adjusts laser weapons contribution to specular highlights", AT_FLOAT); //TODO: move to deprecated
-cmdline_parm spec_tube_arg("-spec_tube", "Adjusts beam weapons contribution to specular highlights", AT_FLOAT); //TODO: move to deprecated
-cmdline_parm ambient_factor_arg("-ambient_factor", "Adjusts ambient light applied to all parts of a ship", AT_INT);		// Cmdline_ambient_factor TODO: move to deprecated
+cmdline_parm emissive_arg("-emissive_light", "Enable emissive light from ships", AT_NONE);		// semi-deprecated but still functional
 cmdline_parm env("-noenv", NULL, AT_NONE);								// Cmdline_env
 cmdline_parm glow_arg("-noglow", NULL, AT_NONE); 						// Cmdline_glow  -- use Bobs glow code
 cmdline_parm nomotiondebris_arg("-nomotiondebris", NULL, AT_NONE);		// Cmdline_nomotiondebris  -- Removes those ugly floating rocks -C
 cmdline_parm noscalevid_arg("-noscalevid", NULL, AT_NONE);				// Cmdline_noscalevid  -- disable video scaling that fits to window
 cmdline_parm spec_arg("-nospec", NULL, AT_NONE);			// Cmdline_spec  --
-cmdline_parm emissive_arg("-emissive_light", "Enable emissive light from ships", AT_NONE);		// Cmdline_no_emissive  -- don't use emissive light in OGL //TODO: move to deprecated
 cmdline_parm normal_arg("-nonormal", NULL, AT_NONE);						// Cmdline_normal  -- disable normal mapping
 cmdline_parm height_arg("-noheight", NULL, AT_NONE);						// Cmdline_height  -- enable support for parallax mapping
 cmdline_parm enable_3d_shockwave_arg("-3dshockwave", NULL, AT_NONE);
@@ -350,7 +345,6 @@ cmdline_parm no_deferred_lighting_arg("-no_deferred", NULL, AT_NONE);	// Cmdline
 cmdline_parm anisotropy_level_arg("-anisotropic_filter", NULL, AT_INT);
 
 float Cmdline_clip_dist = Default_min_draw_distance;
-int Cmdline_ambient_factor = 128;
 float Cmdline_ambient_power = 1.0f;
 float Cmdline_emissive_power = 0.0f;
 float Cmdline_light_power = 1.0f;
@@ -565,6 +559,10 @@ cmdline_parm deprecated_missile_lighting_arg("-missile_lighting", "Deprecated", 
 cmdline_parm deprecated_cache_bitmaps_arg("-cache_bitmaps", "Deprecated", AT_NONE);
 cmdline_parm deprecated_no_emissive_arg("-no_emissive_light", "Deprecated", AT_NONE);
 cmdline_parm deprecated_postprocess_arg("-post_process", "Deprecated", AT_NONE);
+cmdline_parm deprecated_spec_static_arg("-spec_static", "Deprecated", AT_NONE);
+cmdline_parm deprecated_spec_point_arg("-spec_point", "Deprecated", AT_NONE);
+cmdline_parm deprecated_spec_tube_arg("-spec_tube", "Deprecated", AT_NONE);
+cmdline_parm deprecated_ambient_factor_arg("-ambient_factor", "Deprecated", AT_NONE);	//
 
 #ifndef NDEBUG
 // NOTE: this assumes that os_init() has already been called but isn't a fatal error if it hasn't
@@ -1843,32 +1841,17 @@ bool SetCmdlineParams()
 	if ( ambient_power_arg.found() )
 		Cmdline_ambient_power = ambient_power_arg.get_float();
 
-	if ( emissive_power_arg.found() ){
-		//for legacy support no parm defaults to the old emissive value
-		if(emissive_power_arg.has_param())
-			Cmdline_emissive_power = emissive_power_arg.get_float();
-		else
-			Cmdline_emissive_power = 0.09f;
+	if (emissive_power_arg.found() && emissive_power_arg.has_param()) {
+		Cmdline_emissive_power = emissive_power_arg.get_float();
+	} else if (emissive_arg.found() || emissive_power_arg.found()) {
+		// for legacy support no parm defaults to the old emissive value
+		Cmdline_emissive_power = 0.30f;
 	}
 
-	if ( light_power_arg.found() )
+	if (light_power_arg.found())
 		Cmdline_light_power = light_power_arg.get_float();
 
-	// specular comand lines TODO: dumpster
-	if ( spec_point_arg.found() ) {
-		//static_point_factor = spec_point_arg.get_float();
-	}
-
-	if ( spec_static_arg.found() ) {
-		//static_light_factor = spec_static_arg.get_float();
-	}
-
-	if ( spec_tube_arg.found() ) {
-		//static_tube_factor = spec_tube_arg.get_float();
-	}
-
-	if ( spec_arg.found() )
-	{
+	if (spec_arg.found()) {
 		Cmdline_spec = 0;
 	}
 
@@ -1935,9 +1918,6 @@ bool SetCmdlineParams()
 	if ( start_mission_arg.found() ) {
 		Cmdline_start_mission = start_mission_arg.str();
 	}
-
-	if ( ambient_factor_arg.found() )
-		Cmdline_ambient_factor = ambient_factor_arg.get_int();
 
 	if ( output_scripting_arg.found() )
 		Output_scripting_meta = true;
@@ -2019,7 +1999,7 @@ bool SetCmdlineParams()
 	}
 
 	if ( emissive_arg.found() && !emissive_power_arg.found()){
-		Cmdline_emissive_power = 0.09f;
+		Cmdline_emissive_power = 0.30f;
 	}
 
 	if ( rearm_timer_arg.found() )

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1844,7 +1844,7 @@ bool SetCmdlineParams()
 	if (emissive_power_arg.found() && emissive_power_arg.has_param()) {
 		Cmdline_emissive_power = emissive_power_arg.get_float();
 	} else if (emissive_arg.found() || emissive_power_arg.found()) {
-		// for legacy support no parm defaults to the old emissive value
+		// for legacy support no argument param defaults to the old emissive value
 		Cmdline_emissive_power = 0.30f;
 	}
 
@@ -1996,10 +1996,6 @@ bool SetCmdlineParams()
 
 	if ( no_fbo_arg.found() ) {
 		Cmdline_no_fbo = 1;
-	}
-
-	if ( emissive_arg.found() && !emissive_power_arg.found()){
-		Cmdline_emissive_power = 0.30f;
 	}
 
 	if ( rearm_timer_arg.found() )

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -315,16 +315,20 @@ int Cmdline_use_last_pilot = 0;
 cmdline_parm fov_arg("-fov", "Vertical field-of-view factor", AT_FLOAT);					// Cmdline_fov  -- comand line FOV -Bobboau
 cmdline_parm fov_cockpit_arg("-fov_cockpit", "Vertical field-of-view factor for Cockpits", AT_FLOAT);
 cmdline_parm clip_dist_arg("-clipdist", "Changes the distance from the viewpoint for the near-clipping plane", AT_FLOAT);		// Cmdline_clip_dist
-cmdline_parm spec_static_arg("-spec_static", "Adjusts suns contribution to specular highlights", AT_FLOAT);
-cmdline_parm spec_point_arg("-spec_point", "Adjusts laser weapons contribution to specular highlights", AT_FLOAT);
-cmdline_parm spec_tube_arg("-spec_tube", "Adjusts beam weapons contribution to specular highlights", AT_FLOAT);
-cmdline_parm ambient_factor_arg("-ambient_factor", "Adjusts ambient light applied to all parts of a ship", AT_INT);		// Cmdline_ambient_factor
+cmdline_parm ambient_power_arg("-ambient", "Multiplies the brightness of all ambient light", AT_FLOAT);
+cmdline_parm light_power_arg("-light", "Multiplies the brightness of all light", AT_FLOAT);
+cmdline_parm emissive_power_arg("-emissive", "Multiplies the brightness of all ambient light", AT_FLOAT);
+
+cmdline_parm spec_static_arg("-spec_static", "Adjusts suns contribution to specular highlights", AT_FLOAT); //TODO: move to deprecated
+cmdline_parm spec_point_arg("-spec_point", "Adjusts laser weapons contribution to specular highlights", AT_FLOAT); //TODO: move to deprecated
+cmdline_parm spec_tube_arg("-spec_tube", "Adjusts beam weapons contribution to specular highlights", AT_FLOAT); //TODO: move to deprecated
+cmdline_parm ambient_factor_arg("-ambient_factor", "Adjusts ambient light applied to all parts of a ship", AT_INT);		// Cmdline_ambient_factor TODO: move to deprecated
 cmdline_parm env("-noenv", NULL, AT_NONE);								// Cmdline_env
 cmdline_parm glow_arg("-noglow", NULL, AT_NONE); 						// Cmdline_glow  -- use Bobs glow code
 cmdline_parm nomotiondebris_arg("-nomotiondebris", NULL, AT_NONE);		// Cmdline_nomotiondebris  -- Removes those ugly floating rocks -C
 cmdline_parm noscalevid_arg("-noscalevid", NULL, AT_NONE);				// Cmdline_noscalevid  -- disable video scaling that fits to window
 cmdline_parm spec_arg("-nospec", NULL, AT_NONE);			// Cmdline_spec  --
-cmdline_parm emissive_arg("-emissive_light", "Enable emissive light from ships", AT_NONE);		// Cmdline_no_emissive  -- don't use emissive light in OGL
+cmdline_parm emissive_arg("-emissive_light", "Enable emissive light from ships", AT_NONE);		// Cmdline_no_emissive  -- don't use emissive light in OGL //TODO: move to deprecated
 cmdline_parm normal_arg("-nonormal", NULL, AT_NONE);						// Cmdline_normal  -- disable normal mapping
 cmdline_parm height_arg("-noheight", NULL, AT_NONE);						// Cmdline_height  -- enable support for parallax mapping
 cmdline_parm enable_3d_shockwave_arg("-3dshockwave", NULL, AT_NONE);
@@ -347,6 +351,9 @@ cmdline_parm anisotropy_level_arg("-anisotropic_filter", NULL, AT_INT);
 
 float Cmdline_clip_dist = Default_min_draw_distance;
 int Cmdline_ambient_factor = 128;
+float Cmdline_ambient_power = 1.0f;
+float Cmdline_emissive_power = 0.0f;
+float Cmdline_light_power = 1.0f;
 int Cmdline_env = 1;
 int Cmdline_mipmap = 0;
 int Cmdline_glow = 1;
@@ -1832,18 +1839,27 @@ bool SetCmdlineParams()
 	if ( stretch_menu.found() )	{
 		Cmdline_stretch_menu = 1;
 	}
+	// new lighting lines
+	if ( ambient_power_arg.found() )
+		Cmdline_ambient_power = ambient_power_arg.get_float();
 
-	// specular comand lines
+	if ( emissive_power_arg.found() )
+		Cmdline_emissive_power = emissive_power_arg.get_float();
+
+	if ( light_power_arg.found() )
+		Cmdline_light_power = light_power_arg.get_float();
+
+	// specular comand lines TODO: dumpster
 	if ( spec_point_arg.found() ) {
-		static_point_factor = spec_point_arg.get_float();
+		//static_point_factor = spec_point_arg.get_float();
 	}
 
 	if ( spec_static_arg.found() ) {
-		static_light_factor = spec_static_arg.get_float();
+		//static_light_factor = spec_static_arg.get_float();
 	}
 
 	if ( spec_tube_arg.found() ) {
-		static_tube_factor = spec_tube_arg.get_float();
+		//static_tube_factor = spec_tube_arg.get_float();
 	}
 
 	if ( spec_arg.found() )

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1843,8 +1843,13 @@ bool SetCmdlineParams()
 	if ( ambient_power_arg.found() )
 		Cmdline_ambient_power = ambient_power_arg.get_float();
 
-	if ( emissive_power_arg.found() )
-		Cmdline_emissive_power = emissive_power_arg.get_float();
+	if ( emissive_power_arg.found() ){
+		//for legacy support no parm defaults to the old emissive value
+		if(emissive_power_arg.has_param())
+			Cmdline_emissive_power = emissive_power_arg.get_float();
+		else
+			Cmdline_emissive_power = 0.09f;
+	}
 
 	if ( light_power_arg.found() )
 		Cmdline_light_power = light_power_arg.get_float();
@@ -2013,8 +2018,8 @@ bool SetCmdlineParams()
 		Cmdline_no_fbo = 1;
 	}
 
-	if ( emissive_arg.found() ) {
-		Cmdline_emissive = 1;
+	if ( emissive_arg.found() && !emissive_power_arg.found()){
+		Cmdline_emissive_power = 0.09f;
 	}
 
 	if ( rearm_timer_arg.found() )

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -53,9 +53,12 @@ extern char *Cmdline_center_res;
 
 // Graphics related
 extern float Cmdline_clip_dist;
-extern float static_light_factor;
-extern float static_point_factor;
-extern float static_tube_factor;
+extern float Cmdline_ambient_power;
+extern float Cmdline_emissive_power;
+extern float Cmdline_light_power;
+//extern float static_light_factor;
+//extern float static_point_factor;
+//extern float static_tube_factor;
 extern int Cmdline_ambient_factor;
 extern int Cmdline_env;
 extern int Cmdline_glow;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -56,10 +56,6 @@ extern float Cmdline_clip_dist;
 extern float Cmdline_ambient_power;
 extern float Cmdline_emissive_power;
 extern float Cmdline_light_power;
-//extern float static_light_factor;
-//extern float static_point_factor;
-//extern float static_tube_factor;
-extern int Cmdline_ambient_factor;
 extern int Cmdline_env;
 extern int Cmdline_glow;
 extern int Cmdline_noscalevid;	// disables fit-to-window for movies - taylor

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -32,7 +32,7 @@ layout (std140) uniform lightData {
 	vec3 diffuseLightColor;
 	float coneAngle;
 
-	vec3 specLightColor;
+	vec3 lightDir;
 	float coneInnerAngle;
 
 	vec3 coneDir;
@@ -41,9 +41,7 @@ layout (std140) uniform lightData {
 	vec3 scale;
 	float lightRadius;
 
-	vec3 lightDir;
 	int lightType;
-
 	bool enable_shadows;
 };
 
@@ -140,6 +138,6 @@ void main()
 	vec3 halfVec = normalize(lightDir + eyeDir);
 	float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(color * (diffuseLightColor * NdotL * attenuation), 1.0);
-	fragmentColor.rgb += computeLighting(specColor.rgb, lightDir, normal.xyz, halfVec, eyeDir, gloss, fresnel, NdotL).rgb * specLightColor * attenuation;
+	fragmentColor.rgb += computeLighting(specColor.rgb, lightDir, normal.xyz, halfVec, eyeDir, gloss, fresnel, NdotL).rgb * diffuseLightColor * attenuation;
 	fragOut0 = max(fragmentColor, vec4(0.0));
 }

--- a/code/def_files/data/effects/deferred-v.sdr
+++ b/code/def_files/data/effects/deferred-v.sdr
@@ -12,7 +12,7 @@ layout (std140) uniform lightData {
 	vec3 diffuseLightColor;
 	float coneAngle;
 
-	vec3 specLightColor;
+	vec3 lightDir;
 	float coneInnerAngle;
 
 	vec3 coneDir;
@@ -21,7 +21,6 @@ layout (std140) uniform lightData {
 	vec3 scale;
 	float lightRadius;
 
-	vec3 lightDir;
 	int lightType;
 
 	bool enable_shadows;

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -13,10 +13,9 @@ struct model_light {
 	vec3 diffuse_color;
 	int light_type;
 
-	vec3 spec_color;
+	vec3 direction;
 	float attenuation;
 
-	vec3 direction;
 };
 
 layout (std140) uniform modelData {
@@ -205,7 +204,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		float NdotL = clamp(dot(normal, lightDir), 0.0f, 1.0f);
 		// Ambient, Diffuse, and Specular
 		lightDiffuse += (lights[i].diffuse_color.rgb * diffuseFactor * NdotL * attenuation) * shadow;
-		lightSpecular += lights[i].spec_color * computeLighting(specularMaterial, lightDir, normal, halfVec, eyeDir, gloss, fresnel, NdotL) * attenuation * shadow;
+		lightSpecular += lights[i].diffuse_color * computeLighting(specularMaterial, lightDir, normal, halfVec, eyeDir, gloss, fresnel, NdotL) * attenuation * shadow;
 	}
 	return diffuseMaterial * (lightAmbient + lightDiffuse) + lightSpecular;
 }

--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -22,10 +22,9 @@ struct model_light {
 	vec3 diffuse_color;
 	int light_type;
 
-	vec3 spec_color;
+	vec3 direction;
 	float attenuation;
 
-	vec3 direction;
 };
 
 layout (std140) uniform modelData {

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -16,10 +16,9 @@ struct model_light {
 	vec3 diffuse_color;
 	int light_type;
 
-	vec3 spec_color;
+	vec3 direction;
 	float attenuation;
 
-	vec3 direction;
 };
 
 layout (std140) uniform modelData {

--- a/code/graphics/decal_draw_list.cpp
+++ b/code/graphics/decal_draw_list.cpp
@@ -114,13 +114,7 @@ decal_draw_list::decal_draw_list(size_t num_decals)
 	header->viewportSize.x = (float) gr_screen.max_w;
 	header->viewportSize.y = (float) gr_screen.max_h;
 
-	header->ambientLight.xyz.x = gr_light_ambient[0] + gr_user_ambient;
-	header->ambientLight.xyz.y = gr_light_ambient[1] + gr_user_ambient;
-	header->ambientLight.xyz.z = gr_light_ambient[2] + gr_user_ambient;
-
-	CLAMP(header->ambientLight.xyz.x, 0.02f, 1.0f);
-	CLAMP(header->ambientLight.xyz.y, 0.02f, 1.0f);
-	CLAMP(header->ambientLight.xyz.z, 0.02f, 1.0f);
+	gr_get_ambient_light(&header->ambientLight);
 
 	// Square the ambient part of the light to match the formula used in the main model shader
 	header->ambientLight.xyz.x *= header->ambientLight.xyz.x;

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -154,7 +154,7 @@ static void set_light(int light_num, gr_light* ltp) {
 
 	gr_light_uniforms[light_num].diffuse_color = vm_vec4_to_vec3(ltp->Diffuse);
 
-	gr_light_uniforms[light_num].spec_color = vm_vec4_to_vec3(ltp->Specular);
+	gr_light_uniforms[light_num].spec_color = vm_vec4_to_vec3(ltp->Diffuse);
 
 	gr_light_uniforms[light_num].light_type = ltp->type;
 

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -327,9 +327,10 @@ void gr_set_ambient_light(int red, int green, int blue) {
 }
 void gr_get_ambient_light(vec3d* light_vector) {
 	auto abv = lighting_profile::current()->ambient_light_brightness;
-	light_vector->xyz.x = abv.handle(gr_light_ambient[0]);
-	light_vector->xyz.y = abv.handle(gr_light_ambient[1]);
-	light_vector->xyz.z = abv.handle(gr_light_ambient[2]);
+	auto over = lighting_profile::current()->overall_brightness;
+	light_vector->xyz.x = over.handle(abv.handle(gr_light_ambient[0]));
+	light_vector->xyz.y = over.handle(abv.handle(gr_light_ambient[1]));
+	light_vector->xyz.z = over.handle(abv.handle(gr_light_ambient[2]));
 }
 
 void gr_lighting_fill_uniforms(void* data_out, size_t buffer_size) {

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -267,10 +267,6 @@ void gr_reset_lighting() {
 	Num_active_gr_lights = 0;
 }
 
-void gr_calculate_ambient(const vec3d& color_xyz){
-	auto lp = lighting_profile::current();
-}
-
 void gr_light_shutdown() {
 	gr_lights.clear();
 }

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -26,7 +26,6 @@ struct gr_light
 {
 	vec4 Ambient;
 	vec4 Diffuse;
-	vec4 Specular;
 
 	// light position
 	vec4 Position;
@@ -63,8 +62,6 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 	GLLight->Diffuse.xyzw.y = FSLight->g * FSLight->intensity;
 	GLLight->Diffuse.xyzw.z = FSLight->b * FSLight->intensity;
 	GLLight->Diffuse.xyzw.w = 1.0f;
-
-	GLLight->Specular =GLLight->Diffuse;
 
 	GLLight->type = static_cast<int>(FSLight->type);
 
@@ -226,11 +223,6 @@ void gr_set_center_alpha(int type) {
 		glight.Ambient.xyzw.z = 0.0f;
 	}
 	glight.type = type;
-
-	glight.Specular.xyzw.x = 0.0f;
-	glight.Specular.xyzw.y = 0.0f;
-	glight.Specular.xyzw.z = 0.0f;
-	glight.Specular.xyzw.w = 0.0f;
 
 	glight.Ambient.xyzw.w = 1.0f;
 	glight.Diffuse.xyzw.w = 1.0f;

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -142,8 +142,6 @@ static void set_light(int light_num, gr_light* ltp) {
 
 	gr_light_uniforms[light_num].diffuse_color = vm_vec4_to_vec3(ltp->Diffuse);
 
-	gr_light_uniforms[light_num].spec_color = vm_vec4_to_vec3(ltp->Diffuse);
-
 	gr_light_uniforms[light_num].light_type = ltp->type;
 
 	gr_light_uniforms[light_num].attenuation = ltp->LinearAtten;

--- a/code/graphics/light.h
+++ b/code/graphics/light.h
@@ -12,7 +12,6 @@ extern const float gr_light_color[4];
 extern const float gr_light_zero[4];
 extern const float gr_light_emission[4];
 extern float gr_light_ambient[4];
-extern float gr_user_ambient;
 
 //Functions
 void gr_set_light(light *fs_light);
@@ -20,8 +19,7 @@ void gr_reset_lighting();
 void gr_set_lighting();
 void gr_set_center_alpha(int type);
 void gr_set_ambient_light(int red, int green, int blue);
-
-void gr_calculate_ambient_factor(int ambient_factor = Cmdline_ambient_factor);
+void gr_get_ambient_light(vec3d* light_vector);
 
 void gr_lighting_fill_uniforms(void* data_out, size_t buffer_size);
 

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -161,13 +161,11 @@ void gr_opengl_deferred_lighting_finish()
 			auto light_data = uniformAligner.addTypedElement<deferred_light_data>();
 
 			light_data->lightType = static_cast<int>(l.type);
-			auto ltp = lighting_profile::current();
-			auto i = ltp->overall_brightness.handle(l.intensity);
 
 			vec3d diffuse;
-			diffuse.xyz.x = l.r * i;
-			diffuse.xyz.y = l.g * i;
-			diffuse.xyz.z = l.b * i;
+			diffuse.xyz.x = l.r * l.intensity;
+			diffuse.xyz.y = l.g * l.intensity;
+			diffuse.xyz.z = l.b * l.intensity;
 
 			light_data->diffuseLightColor = diffuse;
 

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -170,7 +170,6 @@ void gr_opengl_deferred_lighting_finish()
 			diffuse.xyz.z = l.b * i;
 
 			light_data->diffuseLightColor = diffuse;
-			light_data->specLightColor = diffuse;
 
 			// Set a default value for all lights. Only the first directional light will change this.
 			light_data->enable_shadows = false;

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -92,9 +92,6 @@ void gr_opengl_deferred_lighting_end()
 
 extern SCP_vector<light> Lights;
 extern int Num_lights;
-extern float static_point_factor;
-extern float static_light_factor;
-extern float static_tube_factor;
 
 void gr_opengl_deferred_lighting_finish()
 {

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -81,13 +81,7 @@ void convert_model_material(model_uniform_data* data_out,
 		data_out->diffuseFactor.xyz.x = gr_light_color[0] * light_factor;
 		data_out->diffuseFactor.xyz.y = gr_light_color[1] * light_factor;
 		data_out->diffuseFactor.xyz.z = gr_light_color[2] * light_factor;
-		data_out->ambientFactor.xyz.x = gr_light_ambient[0] + gr_user_ambient;
-		data_out->ambientFactor.xyz.y = gr_light_ambient[1] + gr_user_ambient;
-		data_out->ambientFactor.xyz.z = gr_light_ambient[2] + gr_user_ambient;
-
-		CLAMP(data_out->ambientFactor.xyz.x, 0.02f, 1.0f);
-		CLAMP(data_out->ambientFactor.xyz.y, 0.02f, 1.0f);
-		CLAMP(data_out->ambientFactor.xyz.z, 0.02f, 1.0f);
+		gr_get_ambient_light(&data_out->ambientFactor);
 
 		if (material.get_light_factor() > 0.25f && Cmdline_emissive) {
 			data_out->emissionFactor.xyz.x = gr_light_emission[0];

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -40,7 +40,7 @@ struct deferred_light_data {
 	vec3d diffuseLightColor;
 	float coneAngle;
 
-	vec3d specLightColor;
+	vec3d lightDir;
 	float coneInnerAngle;
 
 	vec3d coneDir;
@@ -49,23 +49,18 @@ struct deferred_light_data {
 	vec3d scale;
 	float lightRadius;
 
-	vec3d lightDir;
 	int lightType;
-
 	int enable_shadows;
 
-	float pad0[3]; // Struct size must be 16-bytes aligned because we use vec3s
+	float pad0[2]; // Struct size must be 16-bytes aligned because we use vec3s
 };
 
 struct model_light {
 	vec4 position;
 	vec3d diffuse_color;
 	int light_type;
-	vec3d spec_color;
-	float attenuation;
 	vec3d direction;
-
-	float pad;
+	float attenuation;
 };
 
 const size_t MAX_UNIFORM_LIGHTS = 8;

--- a/code/lab/dialogs/render_options.cpp
+++ b/code/lab/dialogs/render_options.cpp
@@ -139,13 +139,18 @@ void set_emissive_flag(Checkbox* caller) {
 void set_ambient_factor(Slider* caller) {
 	auto value = caller->GetSliderValue();
 
-	getLabManager()->Renderer->setAmbientFactor(fl2i(value));
+	getLabManager()->Renderer->setAmbientFactor(value);
 }
 
-void set_static_light_factor(Slider* caller) {
+void set_light_factor(Slider* caller) {
 	auto value = caller->GetSliderValue();
 
-	getLabManager()->Renderer->setDirectionalFactor(value);
+	getLabManager()->Renderer->setLightFactor(value);
+}
+void set_emissive(Slider* caller) {
+	auto value = caller->GetSliderValue();
+
+	getLabManager()->Renderer->setEmissiveFactor(value);
 }
 
 void set_bloom(Slider* caller) {
@@ -289,15 +294,20 @@ void RenderOptions::open(Button* /*caller*/) {
 	cbp = (Checkbox*)dialogWindow->AddChild(new Checkbox("Render with emissive lighting", 2, y, set_emissive_flag));
 	y += cbp->GetHeight() + 2;
 
-	auto ambient_sldr = new Slider("Ambient Factor", 0, 128, 0, y + 2, set_ambient_factor, dialogWindow->GetWidth());
-	ambient_sldr->SetSliderValue((float)Cmdline_ambient_factor);
+	auto light_sldr = new Slider("Light Brightness", 0.0f, 10.0f, 0, y + 2, set_light_factor, dialogWindow->GetWidth());
+	light_sldr->SetSliderValue(lighting_profile::lab_get_light());
+	dialogWindow->AddChild(light_sldr);
+	y += light_sldr->GetHeight() + 2;
+
+	auto ambient_sldr = new Slider("Ambient Factor", 0.0f, 10.0f, 0, y + 2, set_ambient_factor, dialogWindow->GetWidth());
+	ambient_sldr->SetSliderValue(lighting_profile::lab_get_ambient());
 	dialogWindow->AddChild(ambient_sldr);
 	y += ambient_sldr->GetHeight() + 2;
 
-	auto direct_sldr = new Slider("Direct. Lights", 0.0f, 2.0f, 0, y + 2, set_static_light_factor, dialogWindow->GetWidth());
-	//direct_sldr->SetSliderValue(static_light_factor);
-	dialogWindow->AddChild(direct_sldr);
-	y += direct_sldr->GetHeight() + 2;
+	auto emissive_sldr = new Slider("Emissive Amount", 0, 10.0f, 0, y + 2, set_emissive, dialogWindow->GetWidth());
+	emissive_sldr->SetSliderValue(lighting_profile::lab_get_emissive());
+	dialogWindow->AddChild(emissive_sldr);
+	y += emissive_sldr->GetHeight() + 2;
 
 	auto bloom_sldr = new Slider("Bloom", 0, 200, 0, y + 2, set_bloom, dialogWindow->GetWidth());
 	bloom_sldr->SetSliderValue((float)gr_bloom_intensity());

--- a/code/lab/dialogs/render_options.cpp
+++ b/code/lab/dialogs/render_options.cpp
@@ -295,7 +295,7 @@ void RenderOptions::open(Button* /*caller*/) {
 	y += ambient_sldr->GetHeight() + 2;
 
 	auto direct_sldr = new Slider("Direct. Lights", 0.0f, 2.0f, 0, y + 2, set_static_light_factor, dialogWindow->GetWidth());
-	direct_sldr->SetSliderValue(static_light_factor);
+	//direct_sldr->SetSliderValue(static_light_factor);
 	dialogWindow->AddChild(direct_sldr);
 	y += direct_sldr->GetHeight() + 2;
 

--- a/code/lab/renderer/lab_renderer.h
+++ b/code/lab/renderer/lab_renderer.h
@@ -71,8 +71,8 @@ class LabRenderer {
 public:
 	LabRenderer() {
 		bloomLevel = gr_bloom_intensity();
-		ambientFactor = Cmdline_ambient_factor;
-		directionalFactor = static_light_factor;
+		ambientFactor = 1;// Cmdline_ambient_factor;
+		directionalFactor = 1;// static_light_factor;
 		textureQuality = TextureQuality::Maximum;
 		cameraDistance = 100.0f;
 		currentTeamColor = "<none>";
@@ -141,15 +141,14 @@ public:
 
 	int setAmbientFactor(int factor) { 
 		ambientFactor = factor; 
-		Cmdline_ambient_factor = factor;
-		gr_calculate_ambient_factor();
+		//TODO: make this work with the lighting profile
 
 		return factor; 
 	}
 
 	float setDirectionalFactor(float factor) { 
 		directionalFactor = factor; 
-		static_light_factor = factor;
+		//TODO: make this work with the lighting profile
 		return factor; 
 	}
 

--- a/code/lab/renderer/lab_renderer.h
+++ b/code/lab/renderer/lab_renderer.h
@@ -137,17 +137,17 @@ public:
 
 	void setRenderFlag(LabRenderFlag flag, bool value) { renderFlags.set(flag, value); }
 
-	float setAmbientFactor(float factor) { 
+	static float setAmbientFactor(float factor) { 
 		lighting_profile::lab_set_ambient(factor);
 		return factor; 
 	}
 
-	float setLightFactor(float factor) {
+	static float setLightFactor(float factor) {
 		lighting_profile::lab_set_light(factor);
 		return factor; 
 	}
 
-	float setEmissiveFactor(float factor) { 
+	static float setEmissiveFactor(float factor) { 
 		lighting_profile::lab_set_emissive(factor);
 		return factor; 
 	}

--- a/code/lab/renderer/lab_renderer.h
+++ b/code/lab/renderer/lab_renderer.h
@@ -71,8 +71,6 @@ class LabRenderer {
 public:
 	LabRenderer() {
 		bloomLevel = gr_bloom_intensity();
-		ambientFactor = 1;// Cmdline_ambient_factor;
-		directionalFactor = 1;// static_light_factor;
 		textureQuality = TextureQuality::Maximum;
 		cameraDistance = 100.0f;
 		currentTeamColor = "<none>";
@@ -139,16 +137,18 @@ public:
 
 	void setRenderFlag(LabRenderFlag flag, bool value) { renderFlags.set(flag, value); }
 
-	int setAmbientFactor(int factor) { 
-		ambientFactor = factor; 
-		//TODO: make this work with the lighting profile
-
+	float setAmbientFactor(float factor) { 
+		lighting_profile::lab_set_ambient(factor);
 		return factor; 
 	}
 
-	float setDirectionalFactor(float factor) { 
-		directionalFactor = factor; 
-		//TODO: make this work with the lighting profile
+	float setLightFactor(float factor) {
+		lighting_profile::lab_set_light(factor);
+		return factor; 
+	}
+
+	float setEmissiveFactor(float factor) { 
+		lighting_profile::lab_set_emissive(factor);
 		return factor; 
 	}
 
@@ -179,8 +179,6 @@ public:
 
 private:
 	flagset<LabRenderFlag> renderFlags;
-	int ambientFactor;
-	float directionalFactor;
 	int bloomLevel;
 	float exposureLevel;
 	TextureQuality textureQuality;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -172,10 +172,9 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 	l.g = g;
 	l.b = b;
 
-	//Direcional lights not yet switched to use lighting profiles multipliers as that's part of a seperate project
+	//configurable global tuning of light qualities
 	auto lp = lighting_profile::current();
-	l.intensity = lp->directional_light_brightness.handle(intensity);
-	l.intensity = lp->overall_brightness.handle(l.intensity);
+	l.intensity = lp->overall_brightness.handle(lp->directional_light_brightness.handle(intensity));
 	l.rada = 0.0f;
 	l.radb = 0.0f;
 	l.rada_squared = l.rada*l.rada;
@@ -213,8 +212,7 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 
 	//configurable global tuning of light qualities
 	auto lp = lighting_profile::current();
-	l.intensity = lp->point_light_brightness.handle(intensity);
-	l.intensity = lp->overall_brightness.handle(l.intensity);
+	l.intensity = lp->overall_brightness.handle(lp->point_light_brightness.handle(intensity));
 	l.rada = lp->point_light_radius.handle(r1);
 	l.radb = lp->point_light_radius.handle(r2);
 	l.rada_squared = l.rada*l.rada;
@@ -252,8 +250,7 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 
 	//configurable global tuning of light qualities
 	auto lp = lighting_profile::current();
-	l.intensity = lp->tube_light_brightness.handle(intensity);
-	l.intensity = lp->overall_brightness.handle(l.intensity);
+	l.intensity = lp->overall_brightness.handle(lp->tube_light_brightness.handle(intensity));
 	l.rada = lp->tube_light_radius.handle(r1);
 	l.radb = lp->tube_light_radius.handle(r2);
 	l.rada_squared = l.rada*l.rada;
@@ -457,8 +454,7 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 	l.b = b;
 
 	auto lp = lighting_profile::current();
-	l.intensity = lp->cone_light_brightness.handle(intensity);
-	l.intensity = lp->overall_brightness.handle(l.intensity);
+	l.intensity = lp->overall_brightness.handle(lp->cone_light_brightness.handle(intensity));
 	l.rada = lp->cone_light_radius.handle(r1);
 	l.radb = lp->cone_light_radius.handle(r2);
 	l.rada_squared = l.rada*l.rada;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -175,6 +175,7 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 	//Direcional lights not yet switched to use lighting profiles multipliers as that's part of a seperate project
 	auto lp = lighting_profile::current();
 	l.intensity = lp->directional_light_brightness.handle(intensity);
+	l.intensity = lp->overall_brightness.handle(l.intensity);
 	l.rada = 0.0f;
 	l.radb = 0.0f;
 	l.rada_squared = l.rada*l.rada;
@@ -213,6 +214,7 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 	//configurable global tuning of light qualities
 	auto lp = lighting_profile::current();
 	l.intensity = lp->point_light_brightness.handle(intensity);
+	l.intensity = lp->overall_brightness.handle(l.intensity);
 	l.rada = lp->point_light_radius.handle(r1);
 	l.radb = lp->point_light_radius.handle(r2);
 	l.rada_squared = l.rada*l.rada;
@@ -251,6 +253,7 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 	//configurable global tuning of light qualities
 	auto lp = lighting_profile::current();
 	l.intensity = lp->tube_light_brightness.handle(intensity);
+	l.intensity = lp->overall_brightness.handle(l.intensity);
 	l.rada = lp->tube_light_radius.handle(r1);
 	l.radb = lp->tube_light_radius.handle(r2);
 	l.rada_squared = l.rada*l.rada;
@@ -455,6 +458,7 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 
 	auto lp = lighting_profile::current();
 	l.intensity = lp->cone_light_brightness.handle(intensity);
+	l.intensity = lp->overall_brightness.handle(l.intensity);
 	l.rada = lp->cone_light_radius.handle(r1);
 	l.radb = lp->cone_light_radius.handle(r2);
 	l.rada_squared = l.rada*l.rada;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -181,8 +181,9 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 	l.spec_g = spec_g;
 	l.spec_b = spec_b;
 
-	//Direcional lights not yet switched to use lighting profiles multipliers as that's part of a seperate project.
-	l.intensity = intensity;
+	//Direcional lights not yet switched to use lighting profiles multipliers as that's part of a seperate project
+	auto lp = lighting_profile::current();
+	l.intensity = lp->directional_light_brightness.handle(intensity);
 	l.rada = 0.0f;
 	l.radb = 0.0f;
 	l.rada_squared = l.rada*l.rada;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -156,15 +156,9 @@ void light_add_directional(const vec3d* dir, const hdr_color* new_color)
 	light_add_directional(dir, new_color->i(), new_color->r(), new_color->g(), new_color->b());
 }
 
-void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
+void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b)
 {
 	if (Lighting_off) return;
-
-	if(!specular){
-		spec_r = r;
-		spec_g = g;
-		spec_b = b;
-	}
 
 	Num_lights++;
 
@@ -177,9 +171,6 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 	l.r = r;
 	l.g = g;
 	l.b = b;
-	l.spec_r = spec_r;
-	l.spec_g = spec_g;
-	l.spec_b = spec_b;
 
 	//Direcional lights not yet switched to use lighting profiles multipliers as that's part of a seperate project
 	auto lp = lighting_profile::current();
@@ -201,7 +192,7 @@ void light_add_point(const vec3d* pos, float r1, float r2, const hdr_color* new_
 	light_add_point(pos, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b());
 }
 
-void light_add_point(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
+void light_add_point(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b)
 {
 	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
 	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
@@ -210,23 +201,14 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 
 	if (!Lighting_flag) return;
 
-	if(!specular){
-		spec_r = r;
-		spec_g = g;
-		spec_b = b;
-	}
-
 	light l;
-	
+
 	Num_lights++;
 	l.type = Light_Type::Point;
 	l.vec = *pos;
 	l.r = r;
 	l.g = g;
 	l.b = b;
-	l.spec_r = spec_r;
-	l.spec_g = spec_g;
-	l.spec_b = spec_b;
 
 	//configurable global tuning of light qualities
 	auto lp = lighting_profile::current();
@@ -246,7 +228,7 @@ void light_add_tube(const vec3d* p0, const vec3d* p1, float r1, float r2, const 
 	light_add_tube(p0, p1, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b());
 }
 
-void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
+void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b)
 {
 	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
 	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
@@ -254,12 +236,6 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 	if (Lighting_off) return;
 
 	if (!Lighting_flag) return;
-
-	if(!specular){
-		spec_r = r;
-		spec_g = g;
-		spec_b = b;
-	}
 
 	light l;
 
@@ -271,9 +247,6 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 	l.r = r;
 	l.g = g;
 	l.b = b;
-	l.spec_r = spec_r;
-	l.spec_g = spec_g;
-	l.spec_b = spec_b;
 
 	//configurable global tuning of light qualities
 	auto lp = lighting_profile::current();
@@ -457,16 +430,10 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 	light_add_cone(pos, dir, angle, inner_angle, dual_cone, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b());
 }
 
-void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, float spec_r, float spec_g, float spec_b, bool specular)
+void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b)
 {
 	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
 	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
-
-	if(!specular){
-		spec_r = r;
-		spec_g = g;
-		spec_b = b;
-	}
 
 	if ( Lighting_off ) return;
 
@@ -485,9 +452,6 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 	l.r = r;
 	l.g = g;
 	l.b = b;
-	l.spec_r = spec_r;
-	l.spec_g = spec_g;
-	l.spec_b = spec_b;
 
 	auto lp = lighting_profile::current();
 	l.intensity = lp->cone_light_brightness.handle(intensity);

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -325,10 +325,6 @@ int light_get_global_dir(vec3d *pos, int n)
 	return 1;
 }
 
-float static_light_factor = 1.0f;
-float static_tube_factor = 1.0f;
-float static_point_factor = 1.0f;
-
 void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, const vec3d *pos, const vec3d *norm, float static_light_level )
 {
 	int idx;

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -45,7 +45,6 @@ typedef struct light {
 	float	rada, rada_squared;				// How big of an area a point light affect.  Is equal to l->intensity / MIN_LIGHT;
 	float	radb, radb_squared;				// How big of an area a point light affect.  Is equal to l->intensity / MIN_LIGHT;
 	float	r,g,b;							// The color components of the light
-	float	spec_r,spec_g,spec_b;			// The specular color components of the light
 	float	cone_angle;						// angle for cone lights
 	float	cone_inner_angle;				// the inner angle for calculating falloff
 	bool	dual_cone;						// should the cone be shining in both directions?
@@ -89,13 +88,13 @@ extern void light_reset();
 //Intensity in lighting inputs multiplies the base colors.
 
 extern void light_add_directional(const vec3d *dir, const hdr_color *new_color);
-extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b);
 extern void light_add_point(const vec3d * pos, float r1, float r2, const hdr_color *new_color);
-extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b,float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b);
 extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, const hdr_color *new_color);
-extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b);
 extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, const hdr_color *new_color);
-extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, float spec_r = 0.0f, float spec_g = 0.0f, float spec_b = 0.0f, bool specular = false);
+extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b);
 
 
 extern void light_rotate_all();

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -328,8 +328,9 @@ void lighting_profile::parse_default_section(const char *filename)
 		if(lighting_profile_value::parse(filename,"$Ambient light brightness:",profile_name, &default_profile.ambient_light_brightness))
 		{
 			parsed = true;
-			default_profile.overall_brightness.stack_multiplier(Cmdline_ambient_power);
-			default_profile.overall_brightness.stack_minimum(Cmdline_emissive_power);
+			default_profile.ambient_light_brightness.stack_multiplier(Cmdline_ambient_power);
+			default_profile.ambient_light_brightness.stack_multiplier(Cmdline_light_power);
+			default_profile.ambient_light_brightness.stack_minimum(Cmdline_emissive_power);
 		}
 
 		if(lighting_profile_value::parse(filename,"$Overall brightness:",profile_name, &default_profile.overall_brightness))

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -436,3 +436,22 @@ void lighting_profile::lab_set_ppc(piecewise_power_curve_values ppcin ){
 piecewise_power_curve_values lighting_profile::lab_get_ppc(){
 	return default_profile.ppc_values;
 }
+
+float lighting_profile::lab_get_light(){
+	return default_profile.overall_brightness.handle(1.0f);
+}
+float lighting_profile::lab_get_ambient(){
+	return default_profile.ambient_light_brightness.handle(1.0f);
+}
+float lighting_profile::lab_get_emissive(){
+	return default_profile.ambient_light_brightness.handle(0.0f);
+}
+void lighting_profile::lab_set_light(float in){
+	default_profile.overall_brightness.set_multiplier(in);
+}
+void lighting_profile::lab_set_ambient(float in){
+	default_profile.ambient_light_brightness.set_multiplier(in);
+}
+void lighting_profile::lab_set_emissive(float in){
+	default_profile.ambient_light_brightness.set_minimum(MAX(0.0f,in));
+}

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -91,6 +91,11 @@ void lighting_profile_value::stack_minimum(float in)
 		has_minimum = true;
 	}
 }
+bool lighting_profile_value::read_adjust(float *out) const
+{
+	*out = adjust;
+	return has_adjust;
+}
 /**
  * @brief for use during the parsing of a light profile to attempt to read in an LPV
  *
@@ -205,7 +210,7 @@ void lighting_profile::reset()
 	directional_light_brightness.reset();
 	ambient_light_brightness.reset();
 	ambient_light_brightness.set_multiplier(Cmdline_ambient_power);
-	ambient_light_brightness.set_minimum(MAX(0.0f,Cmdline_emissive_power));
+	ambient_light_brightness.set_adjust(MAX(0.0f,Cmdline_emissive_power));
 
 	overall_brightness.reset();
 	overall_brightness.set_multiplier(Cmdline_light_power); 
@@ -444,7 +449,10 @@ float lighting_profile::lab_get_ambient(){
 	return default_profile.ambient_light_brightness.handle(1.0f);
 }
 float lighting_profile::lab_get_emissive(){
-	return default_profile.ambient_light_brightness.handle(0.0f);
+	float r;
+	default_profile.ambient_light_brightness.read_adjust(&r);
+
+	return r;
 }
 void lighting_profile::lab_set_light(float in){
 	default_profile.overall_brightness.set_multiplier(in);
@@ -453,5 +461,5 @@ void lighting_profile::lab_set_ambient(float in){
 	default_profile.ambient_light_brightness.set_multiplier(in);
 }
 void lighting_profile::lab_set_emissive(float in){
-	default_profile.ambient_light_brightness.set_minimum(MAX(0.0f,in));
+	default_profile.ambient_light_brightness.set_adjust(MAX(0.0f,in));
 }

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -177,6 +177,10 @@ void lighting_profile::reset()
 
 	directional_light_brightness.reset();
 	ambient_light_brightness.reset();
+	ambient_light_brightness.set_minimum(0.0f);
+
+	overall_brightness.reset();
+	overall_brightness.set_minimum(0.0f);
 }
 
 TonemapperAlgorithm lighting_profile::name_to_tonemapper(SCP_string &name)
@@ -290,7 +294,8 @@ void lighting_profile::parse_default_section(const char *filename)
 		parsed |= lighting_profile_value::parse(filename,"$Ambient light brightness:",profile_name,
 										&default_profile.ambient_light_brightness);
 
-
+		parsed |= lighting_profile_value::parse(filename,"$Overall brightness:","Default profile",
+										&default_profile.overall_brightness);
 		parsed |= parse_optional_float_into("$Exposure:",&default_profile.exposure);
 		if(!parsed){
 			stuff_string(buffer,F_RAW);

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -85,7 +85,12 @@ public:
 	static void lab_set_tonemapper(TonemapperAlgorithm tnin);
 	static void lab_set_ppc(piecewise_power_curve_values ppcin );
 	static piecewise_power_curve_values lab_get_ppc();
-
+	static float lab_get_light();
+	static void lab_set_light(float in);
+	static float lab_get_ambient();
+	static void lab_set_ambient(float in);
+	static float lab_get_emissive();
+	static void lab_set_emissive(float in);
 
 	SCP_string name;
     TonemapperAlgorithm tonemapper;

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -104,7 +104,8 @@ public:
 	lighting_profile_value cone_light_radius;
 	lighting_profile_value directional_light_brightness;
 	lighting_profile_value ambient_light_brightness;
-
+	//Strictly speaking this should be handled by postproc but we need something for the non-postproc people.
+	lighting_profile_value overall_brightness;
 
     void reset();
 

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -59,6 +59,7 @@ struct lighting_profile_value{
 	void stack_minimum(const float in);
 
 	static bool parse(const char *filename, const char * valuename, const SCP_string &profile_name, lighting_profile_value* value_target, bool required=false);
+	bool read_adjust(float *out) const;
 
 private:
 	bool has_adjust = false;

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -51,10 +51,12 @@ struct lighting_profile_value{
 
 	float handle(float input);
 	void reset();
-	void set_adjust(float in);
-	void set_multiplier(float in);
-	void set_maximum(float in);
-	void set_minimum(float in);
+	void set_adjust(const float in);
+	void set_multiplier(const float in);
+	void stack_multiplier(const float in);
+	void set_maximum(const float in);
+	void set_minimum(const float in);
+	void stack_minimum(const float in);
 
 	static bool parse(const char *filename, const char * valuename, const SCP_string &profile_name, lighting_profile_value* value_target, bool required=false);
 

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -530,16 +530,8 @@ void techroom_ships_render(float frametime)
 	g3_start_frame(1);
 	g3_set_view_matrix(&sip->closeup_pos, &vmd_identity_matrix, sip->closeup_zoom * 1.3f);
 
-	
-
-	// lighting for techroom
-	light_reset();
-	vec3d light_dir = vmd_zero_vector;
-	light_dir.xyz.y = 1.0f;	
-	light_dir.xyz.x = 0.0000001f;	
-	light_add_directional(&light_dir, 0.85f, 1.0f, 1.0f, 1.0f);
-	light_rotate_all();
-	// lighting for techroom
+	//setup lights
+	common_setup_room_lights();
 
 	Glowpoint_use_depth_buffer = false;
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1051,15 +1051,10 @@ void brief_render_closeup(int ship_class, float frametime)
 
 	g3_start_frame(1);
 	g3_set_view_matrix(&Closeup_cam_pos, &view_orient, Closeup_zoom);
-	
-	// the following is copied from menuui/techmenu.cpp ... it works heehee :D  - delt.
-	// lighting for techroom
-	light_reset();
-	vec3d light_dir = vmd_zero_vector;
-	light_dir.xyz.y = 1.0f;
-	light_add_directional(&light_dir, 0.85f, 1.0f, 1.0f, 1.0f);
-	light_rotate_all();
-	// lighting for techroom
+
+	//setup lights
+	common_setup_room_lights();
+
 	Glowpoint_use_depth_buffer = false;
 
 	model_clear_instance( Closeup_icon->modelnum );

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -22,7 +22,9 @@
 #include "gamesnd/eventmusic.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
+#include "globalincs/vmallocator.h"
 #include "graphics/2d.h"
+#include "graphics/color.h"
 #include "graphics/matrix.h"
 #include "graphics/shadows.h"
 #include "hud/hudwingmanstatus.h"
@@ -1614,13 +1616,8 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 
 	if(!(flags & MR_NO_LIGHTING))
 	{
-		light_reset();
-		vec3d light_dir = vmd_zero_vector;
-		light_dir.xyz.x = -0.5;
-		light_dir.xyz.y = 2.0f;
-		light_dir.xyz.z = -2.0f;	
-		light_add_directional(&light_dir, 0.65f, 1.0f, 1.0f, 1.0f);
-		light_rotate_all();
+		//setup lights
+		common_setup_room_lights();
 	}
 
 	if (sip != NULL && sip->replacement_textures.size() > 0) 
@@ -1769,14 +1766,8 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 
 			g3_done_instance(true);
 
-			// lighting for techroom
-			light_reset();
-			vec3d light_dir = vmd_zero_vector;
-			light_dir.xyz.y = 1.0f;
-			light_dir.xyz.x = 0.0000001f;
-			light_add_directional(&light_dir, 0.65f, 1.0f, 1.0f, 1.0f);
-			light_rotate_all();
-			// lighting for techroom
+			//setup lights
+			common_setup_room_lights();
 
 			// render the ships
 			model_clear_instance(model_id);
@@ -1885,13 +1876,8 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 			g3_set_view_matrix(&pos, &vmd_identity_matrix, closeup_zoom);
 		}
 
-		// lighting for techroom
-		light_reset();
-		vec3d light_dir = vmd_zero_vector;
-		light_dir.xyz.y = 1.0f;
-		light_add_directional(&light_dir, 0.65f, 1.0f, 1.0f, 1.0f);
-		light_rotate_all();
-		// lighting for techroom
+		//setup lights
+		common_setup_room_lights();
 
 		model_clear_instance(model_id);
 
@@ -1937,6 +1923,24 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 		g3_end_frame();
 		gr_reset_clip();
 	}
+}
+
+/**
+ * @brief add and rotate lights for all the non-gameplay ship rendering instances
+ */
+void common_setup_room_lights()
+{
+	light_reset();
+	auto tempv = vm_vec_new(-1.0f,0.3f,-1.0f);
+	auto tempc = hdr_color(1.0f,0.95f,0.9f, 0.0f, 1.5f);//use 3 for qaz shaders
+	light_add_directional(&tempv,&tempc);
+	tempv.xyz={-0.4f,0.4f,1.1f};
+	tempc = hdr_color(0.788f,0.886f,1.0f,0.0f,1.5f);//use 3 for qaz shaders
+	light_add_directional(&tempv,&tempc);
+	tempv.xyz={0.4f,0.1f,0.4f};
+	tempc = hdr_color(1.0f,1.0f,1.0f,0.0f,0.4f);//use 0.8 for qaz shaders
+	light_add_directional(&tempv,&tempc);
+	light_rotate_all();
 }
 
 // NEWSTUFF END

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -88,6 +88,7 @@ void	common_reset_buttons();
 void	common_redraw_pressed_buttons();
 void  common_maybe_clear_focus();
 void ship_select_common_init();
+void common_setup_room_lights();
 
 int mission_ui_background_load(const char *custom_background, const char *single_background, const char *multi_background = NULL);
 

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -889,14 +889,8 @@ void wl_render_overhead_view(float frametime)
 			g3_set_view_matrix( &sip->closeup_pos, &Eye_matrix, zoom);
 			render_info.set_detail_level_lock(0);
 			
-
-			light_reset();
-			vec3d light_dir = vmd_zero_vector;
-			light_dir.xyz.x = 0.5;
-			light_dir.xyz.y = 2.0f;
-			light_dir.xyz.z = -2.0f;	
-			light_add_directional(&light_dir, 0.65f, 1.0f, 1.0f, 1.0f);
-			light_rotate_all();
+			//setup lights
+			common_setup_room_lights();
 
             Glowpoint_use_depth_buffer = false;
             

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -56,7 +56,6 @@ extern fix game_get_overall_frametime();	// for texture animation
 
 typedef struct model_light {
 	ubyte r, g, b;
-	ubyte spec_r, spec_g, spec_b;
 } model_light;
 
 // a lighting object

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1872,9 +1872,9 @@ void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient,
 			cone_dir_screen.xyz.z = -cone_dir_screen.xyz.z;
 			light_add_cone(
 				&world_pnt, &cone_dir_screen, gpo->cone_angle, gpo->cone_inner_angle, gpo->dualcone, 1.0f, light_radius, 1,
-				lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z,-1);
+				lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z);
 		} else {
-			light_add_point(&world_pnt, 1.0f, light_radius, 1,	lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z, -1);
+			light_add_point(&world_pnt, 1.0f, light_radius, 1,	lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z);
 		}
 	}
 }

--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -10,6 +10,7 @@
 #include "ship/ship.h"
 #include "playerman/player.h"
 #include "graphics/matrix.h"
+#include "missionui/missionscreencommon.h"
 
 namespace scripting {
 namespace api {
@@ -632,12 +633,8 @@ ADE_FUNC(renderTechModel,
 	gr_set_proj_matrix( Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
 	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
-	//Handle light
-	light_reset();
-	vec3d light_dir = vmd_zero_vector;
-	light_dir.xyz.y = 1.0f;
-	light_add_directional(&light_dir, 0.65f, 1.0f, 1.0f, 1.0f);
-	light_rotate_all();
+	//setup lights
+	common_setup_room_lights();
 
 	//Draw the ship!!
 	model_clear_instance(sip->model_num);
@@ -705,12 +702,8 @@ ADE_FUNC(renderTechModel2, l_Shipclass, "number X1, number Y1, number X2, number
 	gr_set_proj_matrix( Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
 	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
-	//Handle light
-	light_reset();
-	vec3d light_dir = vmd_zero_vector;
-	light_dir.xyz.y = 1.0f;
-	light_add_directional(&light_dir, 0.65f, 1.0f, 1.0f, 1.0f);
-	light_rotate_all();
+	//setup lights
+	common_setup_room_lights();
 
 	//Draw the ship!!
 	model_clear_instance(sip->model_num);

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -9,7 +9,9 @@
 
 
 
+#include "globalincs/pstypes.h"
 #include <climits>
+#include <string>
 
 #include "freespace.h"
 #include "cmdline/cmdline.h"
@@ -25,6 +27,7 @@
 #include "model/modelrender.h"
 #include "nebula/neb.h"
 #include "options/Option.h"
+#include "osapi/dialogs.h"
 #include "parse/parselo.h"
 #include "render/3d.h"
 #include "render/batching.h"
@@ -87,7 +90,7 @@ typedef struct starfield_bitmap {
 	int glow_n_frames;
 	int glow_fps;
 	int xparent;
-	float r, g, b, i, spec_r, spec_g, spec_b;		// only for suns
+	float r, g, b, i;		// only for suns
 	int glare;										// only for suns
 	int flare;										// Is there a lens-flare for this sun?
 	flare_info flare_infos[MAX_FLARE_COUNT];		// each flare can use a texture in flare_bmp, with different scale
@@ -468,16 +471,8 @@ void parse_startbl(const char *filename)
 				stuff_float(&sbm.b);
 				stuff_float(&sbm.i);
 
-				if (optional_string("$SunSpecularRGB:")) {
-					stuff_float(&sbm.spec_r);
-					stuff_float(&sbm.spec_g);
-					stuff_float(&sbm.spec_b);
-				}
-				else {
-					sbm.spec_r = sbm.r;
-					sbm.spec_g = sbm.g;
-					sbm.spec_b = sbm.b;
-				}
+				if (optional_string("$SunSpecularRGB:"))
+					Warning(LOCATION, "Sun %s tried to set SunSpecularRGB. This feature has been deprecated and will be ignored.", sbm.filename);
 
 				// lens flare stuff
 				if (optional_string("$Flare:")) {
@@ -1183,7 +1178,7 @@ void stars_draw_sun(int show_sun)
 
 		// add the light source corresponding to the sun, except when rendering to an envmap
 		if ( !Rendering_to_env )
-			light_add_directional(&sun_dir, bm->i, bm->r, bm->g, bm->b, bm->spec_r, bm->spec_g, bm->spec_b, true);
+			light_add_directional(&sun_dir, bm->i, bm->r, bm->g, bm->b);
 
 		// if supernova
 		if ( supernova_active() && (idx == 0) )


### PR DESCRIPTION
as discussed in https://www.hard-light.net/forums/index.php?topic=98195.0 this PR replaces the command line args that scale lighting with whole-light controls, with controls in the lighting profiles to globally tune light types taking over for mods.

Effectively feature complete now but submitted in draft as there's a lot of cleanup and documentation I need to do still.

Includes changes from #4208, will have a history cleanup once that's merged in.