### PR TITLE
De-Bitfield-y Player Orders

### DIFF
--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -17,11 +17,7 @@ void ai_lua_add_mode(int sexp_op, const ai_mode_lua& mode) {
 }
 
 bool ai_lua_add_order(int sexp_op, player_order_lua order) {
-	if (current_new_player_order_type == MAX_ENGINE_PLAYER_ORDER)
-		return false;
-
-	current_new_player_order_type = current_new_player_order_type >> 1;
-	Player_orders.emplace_back(vm_strdup(order.parseText.c_str()), vm_strdup(order.displayText.c_str()), -1, current_new_player_order_type, sexp_op);
+	Player_orders.emplace_back(vm_strdup(order.parseText.c_str()), vm_strdup(order.displayText.c_str()), -1, sexp_op);
 	Player_orders.back().localize();
 
 	Lua_player_orders.emplace(sexp_op, std::move(order));

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -216,7 +216,7 @@ void hud_init_comm_orders()
 // Text to display on the messaging menu when using the shortcut keys
 const char *comm_order_get_text(int item)
 {
-	Assertion(item <= (int)Player_orders.size(), "Did not find order with index %d!", item);
+	Assertion(item < (int)Player_orders.size(), "Did not find order with index %d!", item);
 	
 	return Player_orders[item].localized_name.c_str();
 }

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -157,22 +157,22 @@ int keys_used[] = {	KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_
 SCP_string  Comm_order_types[NUM_COMM_ORDER_TYPES];
 
 std::vector<player_order> Player_orders = {
-	player_order("attack ship",   "Destroy my target",  299),
-	player_order("disable ship",  "Disable my target",	300 ),
-	player_order("disarm ship",	  "Disarm my target",	301 ),
-	player_order("disable subsys","Destroy subsystem",	302 ),
-	player_order("guard ship",	  "Protect my target",	303 ),
-	player_order("ignore ship",   "Ignore my target",	304 ),
-	player_order("form on wing","Form on my wing",	305 ),
-	player_order("cover me",	"Cover me",			306 ),
-	player_order("attack any",	"Engage enemy",		307 ),
-	player_order("dock", "Capture my target",	308),
-	player_order("rearm me", "Rearm me",			309),
-	player_order("abort rearm", "Abort rearm",		310),
-	player_order("depart", "Depart",				311),
-	player_order("stay near me", "Stay near me",		-1),
-	player_order("stay near ship", "Stay near my target",-1),
-	player_order("keep safe dist", "Keep safe distance", -1)
+	player_order("attack ship",   "Destroy my target",  299, -1, ATTACK_TARGET_ITEM),
+	player_order("disable ship",  "Disable my target",	300, -1, DISABLE_TARGET_ITEM),
+	player_order("disarm ship",	  "Disarm my target",	301, -1, DISARM_TARGET_ITEM),
+	player_order("disable subsys","Destroy subsystem",	302, -1, DISABLE_SUBSYSTEM_ITEM),
+	player_order("guard ship",	  "Protect my target",	303, -1, PROTECT_TARGET_ITEM),
+	player_order("ignore ship",   "Ignore my target",	304, -1, IGNORE_TARGET_ITEM),
+	player_order("form on wing","Form on my wing",	305, -1, FORMATION_ITEM),
+	player_order("cover me",	"Cover me",			306, -1, COVER_ME_ITEM),
+	player_order("attack any",	"Engage enemy",		307, -1, ENGAGE_ENEMY_ITEM),
+	player_order("dock", "Capture my target",	308, -1, CAPTURE_TARGET_ITEM),
+	player_order("rearm me", "Rearm me",			309, -1, REARM_REPAIR_ME_ITEM),
+	player_order("abort rearm", "Abort rearm",		310, -1, ABORT_REARM_REPAIR_ITEM),
+	player_order("depart", "Depart",				311, -1, DEPART_ITEM),
+	player_order("stay near me", "Stay near me",		-1, -1, STAY_NEAR_ME_ITEM),
+	player_order("stay near ship", "Stay near my target",-1, -1, STAY_NEAR_TARGET_ITEM),
+	player_order("keep safe dist", "Keep safe distance", -1, -1, KEEP_SAFE_DIST_ITEM)
 };
 
 const std::set<size_t> default_messages{ ATTACK_TARGET_ITEM , DISABLE_TARGET_ITEM , DISARM_TARGET_ITEM , PROTECT_TARGET_ITEM , IGNORE_TARGET_ITEM , FORMATION_ITEM , COVER_ME_ITEM , ENGAGE_ENEMY_ITEM , DEPART_ITEM , DISABLE_SUBSYSTEM_ITEM };
@@ -206,6 +206,11 @@ void hud_init_comm_orders()
 
 	for (auto& order : Player_orders)
 		order.localize();
+
+	std::sort(Player_orders.begin(), Player_orders.end(), [](const player_order& o1, const player_order& o2) {
+		return o1.legacy_id < o2.legacy_id;
+	});
+
 }
 
 // Text to display on the messaging menu when using the shortcut keys

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1954,7 +1954,7 @@ void hud_squadmsg_ship_command()
 
 		// do some other checks to possibly gray out other items.
 		// if no target, remove any items which are associated with the players target
-		if (!hud_squadmsg_is_target_order_valid(order_id, 0))
+		if (!hud_squadmsg_is_target_order_valid(order_id, nullptr))
 			MsgItems[Num_menu_items].active = 0;
 
 		// if messaging all fighters, see if we should gray out the order if no one will accept it,

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -157,6 +157,7 @@ int keys_used[] = {	KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_
 SCP_string  Comm_order_types[NUM_COMM_ORDER_TYPES];
 
 std::vector<player_order> Player_orders = {
+	player_order("no order",   "No Order",  -1, -1, NO_ORDER_ITEM), //Required to keep defines in sync with array indices
 	player_order("attack ship",   "Destroy my target",  299, -1, ATTACK_TARGET_ITEM),
 	player_order("disable ship",  "Disable my target",	300, -1, DISABLE_TARGET_ITEM),
 	player_order("disarm ship",	  "Disarm my target",	301, -1, DISARM_TARGET_ITEM),

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1236,7 +1236,7 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 			break;
 		
 		default: {
-			Assert(command < Player_orders.size()); // get Allender -- illegal message
+			Assert(command < (int) Player_orders.size()); // get Allender -- illegal message
 			
 			ai_mode = AI_GOAL_LUA;
 			ai_submode = Player_orders[command].lua_id;
@@ -1463,7 +1463,7 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 			return 0;
 
 		default: {
-			Assert(command < Player_orders.size()); // get Allender -- illegal message
+			Assert(command < (int) Player_orders.size()); // get Allender -- illegal message
 
 			ai_mode = AI_GOAL_LUA;
 			ai_submode = Player_orders[command].lua_id;

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -157,25 +157,33 @@ int keys_used[] = {	KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_
 SCP_string  Comm_order_types[NUM_COMM_ORDER_TYPES];
 
 std::vector<player_order> Player_orders = {
-	player_order("attack ship",   "Destroy my target",  299, ATTACK_TARGET_ITEM),
-	player_order("disable ship",  "Disable my target",	300, DISABLE_TARGET_ITEM ),
-	player_order("disarm ship",	  "Disarm my target",	301, DISARM_TARGET_ITEM ),
-	player_order("disable subsys","Destroy subsystem",	302, DISABLE_SUBSYSTEM_ITEM ),
-	player_order("guard ship",	  "Protect my target",	303, PROTECT_TARGET_ITEM ),
-	player_order("ignore ship",   "Ignore my target",	304, IGNORE_TARGET_ITEM ),
-	player_order("form on wing","Form on my wing",	305, FORMATION_ITEM ),
-	player_order("cover me",	"Cover me",			306, COVER_ME_ITEM ),
-	player_order("attack any",	"Engage enemy",		307, ENGAGE_ENEMY_ITEM ),
-	player_order("dock", "Capture my target",	308, CAPTURE_TARGET_ITEM),
-	player_order("rearm me", "Rearm me",			309, REARM_REPAIR_ME_ITEM),
-	player_order("abort rearm", "Abort rearm",		310, ABORT_REARM_REPAIR_ITEM),
-	player_order("depart", "Depart",				311, DEPART_ITEM),
-	player_order("stay near me", "Stay near me",		-1, STAY_NEAR_ME_ITEM),
-	player_order("stay near ship", "Stay near my target",-1, STAY_NEAR_TARGET_ITEM),
-	player_order("keep safe dist", "Keep safe distance", -1, KEEP_SAFE_DIST_ITEM)
+	player_order("attack ship",   "Destroy my target",  299),
+	player_order("disable ship",  "Disable my target",	300 ),
+	player_order("disarm ship",	  "Disarm my target",	301 ),
+	player_order("disable subsys","Destroy subsystem",	302 ),
+	player_order("guard ship",	  "Protect my target",	303 ),
+	player_order("ignore ship",   "Ignore my target",	304 ),
+	player_order("form on wing","Form on my wing",	305 ),
+	player_order("cover me",	"Cover me",			306 ),
+	player_order("attack any",	"Engage enemy",		307 ),
+	player_order("dock", "Capture my target",	308),
+	player_order("rearm me", "Rearm me",			309),
+	player_order("abort rearm", "Abort rearm",		310),
+	player_order("depart", "Depart",				311),
+	player_order("stay near me", "Stay near me",		-1),
+	player_order("stay near ship", "Stay near my target",-1),
+	player_order("keep safe dist", "Keep safe distance", -1)
 };
 
-int current_new_player_order_type = (1 << 31);
+const std::set<size_t> default_messages{ ATTACK_TARGET_ITEM , DISABLE_TARGET_ITEM , DISARM_TARGET_ITEM , PROTECT_TARGET_ITEM , IGNORE_TARGET_ITEM , FORMATION_ITEM , COVER_ME_ITEM , ENGAGE_ENEMY_ITEM , DEPART_ITEM , DISABLE_SUBSYSTEM_ITEM };
+const std::set<size_t> enemy_target_messages{ ATTACK_TARGET_ITEM , DISABLE_TARGET_ITEM , DISARM_TARGET_ITEM , IGNORE_TARGET_ITEM , STAY_NEAR_TARGET_ITEM , CAPTURE_TARGET_ITEM , DISABLE_SUBSYSTEM_ITEM };
+const std::set<size_t> friendly_target_messages{ PROTECT_TARGET_ITEM };
+const std::set<size_t> target_messages = []() {
+	std::set<size_t> setunion;
+	std::set_union(enemy_target_messages.cbegin(), enemy_target_messages.cend(), friendly_target_messages.cbegin(), friendly_target_messages.cend(), std::inserter(setunion, setunion.end()));
+	return setunion;
+}();
+
 
 void hud_init_comm_orders()
 {
@@ -203,14 +211,9 @@ void hud_init_comm_orders()
 // Text to display on the messaging menu when using the shortcut keys
 const char *comm_order_get_text(int item)
 {
-	for(const auto& order : Player_orders){
-		if(order.id == item)
-			return order.localized_name.c_str();
-	}
+	Assertion(item <= (int)Player_orders.size(), "Did not find order with index %d!", item);
 	
-	UNREACHABLE("Did not find order with id %d!", item);
-	
-	return nullptr;
+	return Player_orders[item].localized_name.c_str();
 }
 
 SCP_vector<squadmsg_history> Squadmsg_history; 
@@ -218,7 +221,7 @@ SCP_vector<squadmsg_history> Squadmsg_history;
 // forward declarations
 void hud_add_issued_order(const char *name, int order);
 void hud_update_last_order(const char *target, int order_source, int special_index);
-bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip = nullptr);
+bool hud_squadmsg_is_target_order_valid(size_t order, ai_info *aip = nullptr);
 bool hud_squadmsg_ship_valid(ship *shipp, object *objp = nullptr);
 bool hud_squadmsg_ship_order_valid( int shipnum, int order );
 
@@ -333,10 +336,7 @@ bool hud_squadmsg_ship_valid(ship *shipp, object *objp)
 
 	// if a messaging shortcut, be sure this ship can process the order
 	if ( Msg_shortcut_command != -1 ) {
-		bool accepts_any = false;
-		for(size_t order : shipp->orders_accepted)
-			accepts_any |= (bool)(Player_orders[order].id & Msg_shortcut_command);
-		if ( !accepts_any )
+		if (shipp->orders_accepted.count((size_t) Msg_shortcut_command) == 0)
 			return false;
 		
 		else if ( !hud_squadmsg_ship_order_valid(objp->instance, Msg_shortcut_command) )
@@ -726,7 +726,7 @@ bool hud_squadmsg_ship_order_valid( int shipnum, int order )
 	Assert( shipnum >= 0 && shipnum < MAX_SHIPS );
 	ship *shipp = &Ships[shipnum];
 
-	switch ( order  )
+	switch ( order )
 	{
 		case DEPART_ITEM:
 			// disabled ships can't depart.
@@ -748,25 +748,14 @@ bool hud_squadmsg_ship_order_valid( int shipnum, int order )
 // returns true or false if the Players target is valid for the given order
 // find_order is true when we need to search the comm_orders array for the order entry.  We have
 // to do this action in some cases since all we know is the actual "value" of the order
-bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip )
+bool hud_squadmsg_is_target_order_valid(size_t order, ai_info *aip )
 {
 	int target_objnum;
-	size_t i;
 	ship *shipp, *ordering_shipp;
 	object *objp;
 
 	if ( aip == NULL )
 		aip = Player_ai;
-
-	// find the comm_menu item for this command
-	if ( find_order ) {
-		for (i = 0; i < Player_orders.size(); i++ ) {
-			if ( Player_orders[i].id == order )
-				break;
-		}
-		Assert( i < Player_orders.size() );
-		order = (int)i;
-	}
 
 	target_objnum = aip->target_objnum;
 	ordering_shipp = &Ships[aip->shipnum];
@@ -777,7 +766,7 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 	}
 
 	// orders which don't operate on targets are always valid
-	if ( !(Player_orders[order].id & TARGET_MESSAGES) )
+	if ( target_messages.count(order) == 0 )
 		return true;
 
 
@@ -802,7 +791,7 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 			return false;
 		}
 		
-		if ( (Player_orders[order].id == ATTACK_TARGET_ITEM )
+		if ( order == ATTACK_TARGET_ITEM
 			&& ((Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Bomb]) || (Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Fighter_Interceptable]))
 			&& (Weapons[objp->instance].team != ordering_shipp->team) ) {
 			return true;
@@ -826,24 +815,24 @@ bool hud_squadmsg_is_target_order_valid(int order, int find_order, ai_info *aip 
 	}
 
 	// if the order is a disable order or depart, and the ship is disabled, order isn't active
-	if ( (Player_orders[order].id == DISABLE_TARGET_ITEM) && (shipp->flags[Ship::Ship_Flags::Disabled]) ){
+	if ( (order == DISABLE_TARGET_ITEM) && (shipp->flags[Ship::Ship_Flags::Disabled]) ){
 		return false;
 	}
 
 	// same as above except for disarmed.
-	if ( (Player_orders[order].id == DISARM_TARGET_ITEM) && ((shipp->subsys_info[SUBSYSTEM_TURRET].type_count == 0) || (shipp->subsys_info[SUBSYSTEM_TURRET].aggregate_current_hits <= 0.0f)) ){
+	if ( (order == DISARM_TARGET_ITEM) && ((shipp->subsys_info[SUBSYSTEM_TURRET].type_count == 0) || (shipp->subsys_info[SUBSYSTEM_TURRET].aggregate_current_hits <= 0.0f)) ){
 		return false;
 	}
 
 	// if order is disable subsystem, and no subsystem targeted or no hits, then order not valid
-	if ( (Player_orders[order].id == DISABLE_SUBSYSTEM_ITEM) && ((aip->targeted_subsys == nullptr) || (aip->targeted_subsys->current_hits <= 0.0f)) ){
+	if ( (order == DISABLE_SUBSYSTEM_ITEM) && ((aip->targeted_subsys == nullptr) || (aip->targeted_subsys->current_hits <= 0.0f)) ){
 		return false;
 	}
 
 	// check based on target's and player's team
-	if ( (shipp->team == ordering_shipp->team) && (FRIENDLY_TARGET_MESSAGES & Player_orders[order].id) ){
+	if ( (shipp->team == ordering_shipp->team) && (friendly_target_messages.count(order) > 0) ){
 		return true;
-	} else if ( (shipp->team != ordering_shipp->team) && (ENEMY_TARGET_MESSAGES & Player_orders[order].id) ){
+	} else if ( (shipp->team != ordering_shipp->team) && (enemy_target_messages.count(order) > 0) ){
 		return true;
 	} else {
 		return false;
@@ -920,11 +909,7 @@ void hud_squadmsg_send_to_all_fighters( int command, int player_num )
 
 		// don't send the command if the "wing" won't accept the command.  We do this by looking at
 		// the set of orders accepted for the wing leader
-		bool accepts_current = false;
-		for(size_t order : shipp->orders_accepted)
-			accepts_current |= (bool)(Player_orders[order].id & command);
-		
-		if ( !accepts_current )
+		if (shipp->orders_accepted.count((size_t)command) == 0)
 			continue;
 
 		// send the command to the wing
@@ -960,11 +945,7 @@ void hud_squadmsg_send_to_all_fighters( int command, int player_num )
 			continue;
 
 		// don't send command if ship won't accept if
-		bool accepts_current = false;
-		for(size_t order : shipp->orders_accepted)
-			accepts_current |= (bool)(Player_orders[order].id & command);
-
-		if ( !accepts_current )
+		if (shipp->orders_accepted.count((size_t)command) == 0)
 			continue;
 
 		if (send_message) {
@@ -1055,10 +1036,10 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 	// a shortcut to save on repetitive coding.  If the order is a 'target' order, make the default
 	// mesage be "no target"
 	message = MESSAGE_NOSIR;
-	if ( (command & TARGET_MESSAGES) && (ainfo->target_objnum == -1) )
+	if ( target_messages.count((size_t)command) > 0 && (ainfo->target_objnum == -1) )
 		message = MESSAGE_NO_TARGET;
 
-	if ( hud_squadmsg_is_target_order_valid(command, 1, ainfo) ) {
+	if ( hud_squadmsg_is_target_order_valid((size_t) command, ainfo) ) {
 
 		target_shipname = NULL;
 		target_team = -1;
@@ -1255,16 +1236,11 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 			break;
 		
 		default: {
-			size_t i;
-			for (i = 0; i < Player_orders.size(); i++) {
-				if (Player_orders[i].id == command)
-					break;
-			}
-			Assert(i < Player_orders.size()); // get Allender -- illegal message
+			Assert(command < Player_orders.size()); // get Allender -- illegal message
 			
 			ai_mode = AI_GOAL_LUA;
-			ai_submode = Player_orders[i].lua_id;
-			auto lua_porder = ai_lua_find_player_order(Player_orders[i].lua_id);
+			ai_submode = Player_orders[command].lua_id;
+			auto lua_porder = ai_lua_find_player_order(Player_orders[command].lua_id);
 			message = lua_porder->ai_message;
 			if (ainfo->target_objnum != -1)
 				lua_target = object_ship_wing_point_team(&Ships[Objects[ainfo->target_objnum].instance]);
@@ -1355,10 +1331,10 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 
 	// a shortcut to save on repetative coding
 	message = MESSAGE_NOSIR;
-	if ( (command & TARGET_MESSAGES) && (ainfo->target_objnum == -1) )
+	if ( (target_messages.count((size_t)command) > 0) && (ainfo->target_objnum == -1) )
 		message = MESSAGE_NO_TARGET;
 
-	if ( hud_squadmsg_is_target_order_valid(command, 1, ainfo) ) {
+	if ( hud_squadmsg_is_target_order_valid((size_t)command, ainfo) ) {
 
 		target_shipname = NULL;
 		target_team = -1;
@@ -1487,16 +1463,11 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 			return 0;
 
 		default: {
-			size_t i;
-			for (i = 0; i < Player_orders.size(); i++) {
-				if (Player_orders[i].id == command)
-					break;
-			}
-			Assert(i < Player_orders.size()); // get Allender -- illegal message
+			Assert(command < Player_orders.size()); // get Allender -- illegal message
 
 			ai_mode = AI_GOAL_LUA;
-			ai_submode = Player_orders[i].lua_id;
-			auto lua_porder = ai_lua_find_player_order(Player_orders[i].lua_id);
+			ai_submode = Player_orders[command].lua_id;
+			auto lua_porder = ai_lua_find_player_order(Player_orders[command].lua_id);
 			message = lua_porder->ai_message;
 			if(ainfo->target_objnum != -1)
 				lua_target = object_ship_wing_point_team(&Ships[Objects[ainfo->target_objnum].instance]);
@@ -1963,18 +1934,14 @@ void hud_squadmsg_ship_command()
 		orders = Ships[Msg_instance].orders_accepted;
 		default_orders = ship_get_default_orders_accepted( &Ship_info[Ships[Msg_instance].ship_info_index] );
 	} else {
-		for(size_t i = 0; i < Player_orders.size(); i++){
-			if(Player_orders[i].id & DEFAULT_MESSAGES)
-				default_orders.insert(i);
-		}
-		orders = default_orders;
+		orders = default_orders = default_messages;
 	}
 
 	Num_menu_items = 0;
 	for(size_t order_id : default_orders) {
 		Assert (Num_menu_items < MAX_MENU_ITEMS);
 		MsgItems[Num_menu_items].text = Player_orders[order_id].localized_name;
-		MsgItems[Num_menu_items].instance = Player_orders[order_id].id;
+		MsgItems[Num_menu_items].instance = (int)order_id;
 		MsgItems[Num_menu_items].active = 0;
 
 		// check the bit to see if the command is active
@@ -1982,12 +1949,12 @@ void hud_squadmsg_ship_command()
 			MsgItems[Num_menu_items].active = 1;
 
 		// if the order cannot be carried out by the ship, then item should be inactive
-		if ((Msg_instance != MESSAGE_ALL_FIGHTERS) && !hud_squadmsg_ship_order_valid(Msg_instance, Player_orders[order_id].id))
+		if ((Msg_instance != MESSAGE_ALL_FIGHTERS) && !hud_squadmsg_ship_order_valid(Msg_instance, (int)order_id))
 			MsgItems[Num_menu_items].active = 0;
 
 		// do some other checks to possibly gray out other items.
 		// if no target, remove any items which are associated with the players target
-		if (!hud_squadmsg_is_target_order_valid((int)order_id, 0))
+		if (!hud_squadmsg_is_target_order_valid(order_id, 0))
 			MsgItems[Num_menu_items].active = 0;
 
 		// if messaging all fighters, see if we should gray out the order if no one will accept it,
@@ -1995,10 +1962,10 @@ void hud_squadmsg_ship_command()
 		if (Msg_instance == MESSAGE_ALL_FIGHTERS) {
 			ship_obj* so;
 			ship* shipp;
-			int partial_accept, all_accept;            // value which tells us what to do with menu item
+			bool partial_accept, all_accept;            // value which tells us what to do with menu item
 
-			all_accept = Player_orders[order_id].id;
-			partial_accept = 0;
+			all_accept = true;
+			partial_accept = false;
 			for (so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so)) {
 
 				// don't send messge to ships not on player's team, or that are in a wing.
@@ -2010,11 +1977,9 @@ void hud_squadmsg_ship_command()
 				if (!(Ship_info[shipp->ship_info_index].is_fighter_bomber()))
 					continue;
 
-				int local_accepted = 0;
-				for(size_t accepted_order : shipp->orders_accepted)
-					local_accepted |= Player_orders[accepted_order].id;
+				bool local_accepted = shipp->orders_accepted.count(order_id) > 0;
 				all_accept &= local_accepted;        // 'and'ing will either keep this bit set or zero it properly
-				partial_accept |= (local_accepted & Player_orders[order_id].id);    // 'or'ing will tell us if at least one accepts
+				partial_accept |= local_accepted;    // 'or'ing will tell us if at least one accepts
 			}
 
 			if (!all_accept) {
@@ -2069,10 +2034,7 @@ void hud_squadmsg_wing_command()
 		default_orders.insert(setAdd.begin(), setAdd.end());
 	}
 	
-	for(size_t i = 0; i < Player_orders.size(); i++){
-		if (Player_orders[i].id & CAPTURE_TARGET_ITEM) // we cannot capture any target with a wing.
-			default_orders.erase(i);
-	}
+	default_orders.erase(CAPTURE_TARGET_ITEM); // we cannot capture any target with a wing.
 
 	Num_menu_items = 0;
 	shipnum = wingp->ship_index[wingp->special_ship];
@@ -2084,7 +2046,7 @@ void hud_squadmsg_wing_command()
 		// to be available in the wing.
 		Assert ( Num_menu_items < MAX_MENU_ITEMS );
 		MsgItems[Num_menu_items].text = Player_orders[order_id].localized_name;
-		MsgItems[Num_menu_items].instance = Player_orders[order_id].id;
+		MsgItems[Num_menu_items].instance = (int)order_id;
 		MsgItems[Num_menu_items].active = 0;
 
 		// possibly grey out the menu item depending on whether or not the "wing" will accept this order
@@ -2277,11 +2239,7 @@ int hud_squadmsg_hotkey_select( int k )
 			continue;
 
 		// be sure that this ship can accept this command
-		bool accepts_current = false;
-		for(size_t order : Ships[objp->instance].orders_accepted)
-			accepts_current |= (bool)(Player_orders[order].id & Msg_shortcut_command);
-
-		if ( !accepts_current )
+		if ( Ships[objp->instance].orders_accepted.count(Msg_shortcut_command) == 0)
 			continue;
 
 		hud_squadmsg_send_ship_command( objp->instance, Msg_shortcut_command, send_message, SQUADMSG_HISTORY_ADD_ENTRY );
@@ -2447,16 +2405,17 @@ int hud_query_order_issued(const char *to, const char *order_name, const char *t
 
 	
 	for (i = 0; i < (int) Player_orders.size(); i++)
-		if (!stricmp(order_name, Player_orders[i].hud_name.c_str()))
-			order = Player_orders[i].id;
+		if (!stricmp(order_name, Player_orders[i].hud_name.c_str())) {
+			order = i;
+			break;
+		}
 
 	// Goober5000 - if not found, check compatibility
 	if (order == -1)
 	{
 		if (!stricmp(order_name, "Attack my target"))
 		{
-			i = 0;	// it maps to option 0, "Destroy my target"
-			order = Player_orders[i].id;
+			order = ATTACK_TARGET_ITEM;
 		}
 	}
 

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -30,56 +30,51 @@
 
 class object;
 
-// defines for messages that can be sent from the player.  Defined at bitfields so that we can enable
-// and disable messages on a message by message basis
+// defines for messages that can be sent from the player.  Indexes into Player_orders
 
-#define ATTACK_TARGET_ITEM			(1<<0)
-#define DISABLE_TARGET_ITEM			(1<<1)
-#define DISARM_TARGET_ITEM			(1<<2)
-#define PROTECT_TARGET_ITEM			(1<<3)
-#define IGNORE_TARGET_ITEM			(1<<4)
-#define FORMATION_ITEM				(1<<5)
-#define COVER_ME_ITEM				(1<<6)
-#define ENGAGE_ENEMY_ITEM			(1<<7)
-#define CAPTURE_TARGET_ITEM			(1<<8)
+#define ATTACK_TARGET_ITEM			0
+#define DISABLE_TARGET_ITEM			1
+#define DISARM_TARGET_ITEM			2
+#define PROTECT_TARGET_ITEM			3
+#define IGNORE_TARGET_ITEM			4
+#define FORMATION_ITEM				5
+#define COVER_ME_ITEM				6
+#define ENGAGE_ENEMY_ITEM			7
+#define CAPTURE_TARGET_ITEM			8
 
 // the next are for the support ship only
-#define REARM_REPAIR_ME_ITEM		(1<<9)
-#define ABORT_REARM_REPAIR_ITEM		(1<<10)
-#define STAY_NEAR_ME_ITEM			(1<<11)
-#define STAY_NEAR_TARGET_ITEM		(1<<12)
-#define KEEP_SAFE_DIST_ITEM			(1<<13)
+#define REARM_REPAIR_ME_ITEM		9
+#define ABORT_REARM_REPAIR_ITEM		10
+#define STAY_NEAR_ME_ITEM			11
+#define STAY_NEAR_TARGET_ITEM		12
+#define KEEP_SAFE_DIST_ITEM			13
 
 // next item for all ships again -- to try to preserve relative order within the message menu
-#define DEPART_ITEM					(1<<14)
+#define DEPART_ITEM					14
 
 // out of order, but it was this way in the original source
-#define DISABLE_SUBSYSTEM_ITEM		(1<<15)
-
-#define MAX_ENGINE_PLAYER_ORDER		DISABLE_SUBSYSTEM_ITEM
+#define DISABLE_SUBSYSTEM_ITEM		15
 
 // used for Message box gauge
 #define NUM_MBOX_FRAMES		3
 
 typedef struct player_order {
+public:
 	SCP_string parse_name;
 	SCP_string hud_name;
 	int hud_xstr;
-	int id;
 	SCP_string localized_name;
 	int lua_id;
-	player_order(SCP_string parsename, SCP_string hudname, int hudxstr, int orderid = 0, int luaid = -1) : parse_name(std::move(parsename)), hud_name(std::move(hudname)), hud_xstr(hudxstr), id(orderid), localized_name(""), lua_id(luaid) { }
+	player_order(SCP_string parsename, SCP_string hudname, int hudxstr, int luaid = -1) : parse_name(std::move(parsename)), hud_name(std::move(hudname)), hud_xstr(hudxstr), localized_name(""), lua_id(luaid) { }
 	inline void localize() { localized_name = XSTR(hud_name.c_str(), hud_xstr); }
 } player_order;
 
 extern std::vector<player_order> Player_orders;
-extern int current_new_player_order_type;
 
 // following defines are the set of possible commands that can be given to a ship.  A mission designer
 // might not allow some messages
 
 //WMC - Formerly FIGHTER_MESSAGES
-#define DEFAULT_MESSAGES	(ATTACK_TARGET_ITEM | DISABLE_TARGET_ITEM | DISARM_TARGET_ITEM | PROTECT_TARGET_ITEM | IGNORE_TARGET_ITEM | FORMATION_ITEM | COVER_ME_ITEM | ENGAGE_ENEMY_ITEM | DEPART_ITEM | DISABLE_SUBSYSTEM_ITEM)
 /*
 #define BOMBER_MESSAGES		FIGHTER_MESSAGES			// bombers can do the same things as fighters
 
@@ -97,10 +92,6 @@ extern int current_new_player_order_type;
 // these messages require an active target.  They are also the set of messages
 // which cannot be given to a ship when the target is on the same team, or the target
 // is not a ship.
-#define ENEMY_TARGET_MESSAGES		(ATTACK_TARGET_ITEM | DISABLE_TARGET_ITEM | DISARM_TARGET_ITEM | IGNORE_TARGET_ITEM | STAY_NEAR_TARGET_ITEM | CAPTURE_TARGET_ITEM | DISABLE_SUBSYSTEM_ITEM )
-#define FRIENDLY_TARGET_MESSAGES	(PROTECT_TARGET_ITEM)
-
-#define TARGET_MESSAGES	(ENEMY_TARGET_MESSAGES | FRIENDLY_TARGET_MESSAGES)
 
 
 

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -32,28 +32,30 @@ class object;
 
 // defines for messages that can be sent from the player.  Indexes into Player_orders
 
-#define ATTACK_TARGET_ITEM			0
-#define DISABLE_TARGET_ITEM			1
-#define DISARM_TARGET_ITEM			2
-#define PROTECT_TARGET_ITEM			3
-#define IGNORE_TARGET_ITEM			4
-#define FORMATION_ITEM				5
-#define COVER_ME_ITEM				6
-#define ENGAGE_ENEMY_ITEM			7
-#define CAPTURE_TARGET_ITEM			8
+#define NO_ORDER_ITEM				0
+
+#define ATTACK_TARGET_ITEM			1
+#define DISABLE_TARGET_ITEM			2
+#define DISARM_TARGET_ITEM			3
+#define PROTECT_TARGET_ITEM			4
+#define IGNORE_TARGET_ITEM			5
+#define FORMATION_ITEM				6
+#define COVER_ME_ITEM				7
+#define ENGAGE_ENEMY_ITEM			8
+#define CAPTURE_TARGET_ITEM			9
 
 // the next are for the support ship only
-#define REARM_REPAIR_ME_ITEM		9
-#define ABORT_REARM_REPAIR_ITEM		10
-#define STAY_NEAR_ME_ITEM			11
-#define STAY_NEAR_TARGET_ITEM		12
-#define KEEP_SAFE_DIST_ITEM			13
+#define REARM_REPAIR_ME_ITEM		10
+#define ABORT_REARM_REPAIR_ITEM		11
+#define STAY_NEAR_ME_ITEM			12
+#define STAY_NEAR_TARGET_ITEM		13
+#define KEEP_SAFE_DIST_ITEM			14
 
 // next item for all ships again -- to try to preserve relative order within the message menu
-#define DEPART_ITEM					14
+#define DEPART_ITEM					15
 
 // out of order, but it was this way in the original source
-#define DISABLE_SUBSYSTEM_ITEM		15
+#define DISABLE_SUBSYSTEM_ITEM		16
 
 // used for Message box gauge
 #define NUM_MBOX_FRAMES		3

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -59,12 +59,17 @@ class object;
 #define NUM_MBOX_FRAMES		3
 
 typedef struct player_order {
+private:
+	//Used to ensure that built-in order indexing is always correct
+	int legacy_id;
+	friend void hud_init_comm_orders();
+public:
 	SCP_string parse_name;
 	SCP_string hud_name;
 	int hud_xstr;
 	SCP_string localized_name;
 	int lua_id;
-	player_order(SCP_string parsename, SCP_string hudname, int hudxstr, int luaid = -1) : parse_name(std::move(parsename)), hud_name(std::move(hudname)), hud_xstr(hudxstr), localized_name(""), lua_id(luaid) { }
+	player_order(SCP_string parsename, SCP_string hudname, int hudxstr, int luaid = -1, int legacyid = 999999) : legacy_id(legacyid), parse_name(std::move(parsename)), hud_name(std::move(hudname)), hud_xstr(hudxstr), localized_name(""), lua_id(luaid) { }
 	inline void localize() { localized_name = XSTR(hud_name.c_str(), hud_xstr); }
 } player_order;
 

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -59,7 +59,6 @@ class object;
 #define NUM_MBOX_FRAMES		3
 
 typedef struct player_order {
-public:
 	SCP_string parse_name;
 	SCP_string hud_name;
 	int hud_xstr;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3359,7 +3359,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 			p_objp->flags.set(Mission::Parse_Object_Flags::SF_Use_unique_orders);
 
 			for(size_t j = 0; j < Player_orders.size(); j++){
-				if(Player_orders[j].id & tmp_orders)
+				if((1 << j) & tmp_orders)
 					p_objp->orders_accepted.insert(j);
 			}
 		}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3358,7 +3358,8 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
         if (tmp_orders != -1) {
 			p_objp->flags.set(Mission::Parse_Object_Flags::SF_Use_unique_orders);
 
-			for(size_t j = 0; j < Player_orders.size(); j++){
+			//Iterate over all player orders for the bitfield, but restrict to those that the integer could actually provide
+			for(size_t j = 0; j < Player_orders.size() && j < std::numeric_limits<decltype(tmp_orders)>::digits; j++) {
 				if((1 << j) & tmp_orders)
 					p_objp->orders_accepted.insert(j);
 			}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3361,7 +3361,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 			//Iterate over all player orders for the bitfield, but restrict to those that the integer could actually provide
 			for(size_t j = 0; j < Player_orders.size() && j < std::numeric_limits<decltype(tmp_orders)>::digits; j++) {
 				if((1 << j) & tmp_orders)
-					p_objp->orders_accepted.insert(j);
+					p_objp->orders_accepted.insert(j + 1); //The first "true" order starts at idx 1, since 0 can be "no order"
 			}
 		}
     }

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -70,6 +70,7 @@ class player;
 // version 54 - 3/20/2021 - Fixes for FSO 21_2 especially better net_sig calc, better missile intercept
 // version 55 - 8/28/2021 Adding multi-compatible animations
 // version 56 - 8/28/2021 Fix animations for 22_0 release
+// version 57 - 5/25/2022 Replace squadmessage bitfield with player order index
 // STANDALONE_ONLY
 
 #define MULTI_FS_SERVER_VERSION							56

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -70,10 +70,9 @@ class player;
 // version 54 - 3/20/2021 - Fixes for FSO 21_2 especially better net_sig calc, better missile intercept
 // version 55 - 8/28/2021 Adding multi-compatible animations
 // version 56 - 8/28/2021 Fix animations for 22_0 release
-// version 57 - 5/25/2022 Replace squadmessage bitfield with player order index
 // STANDALONE_ONLY
 
-#define MULTI_FS_SERVER_VERSION							57
+#define MULTI_FS_SERVER_VERSION							56
 
 #define MULTI_FS_SERVER_COMPATIBLE_VERSION			MULTI_FS_SERVER_VERSION
 

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -73,7 +73,7 @@ class player;
 // version 57 - 5/25/2022 Replace squadmessage bitfield with player order index
 // STANDALONE_ONLY
 
-#define MULTI_FS_SERVER_VERSION							56
+#define MULTI_FS_SERVER_VERSION							57
 
 #define MULTI_FS_SERVER_COMPATIBLE_VERSION			MULTI_FS_SERVER_VERSION
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -584,11 +584,7 @@ int create_ship(matrix *orient, vec3d *pos, int ship_type)
 			if (!(sip->is_small_ship()))
 			{
 				shipp->orders_accepted = ship_get_default_orders_accepted( sip );
-
-				for(size_t i = 0; i < Player_orders.size(); i++) {
-					if (Player_orders[i].id & DEPART_ITEM)
-						shipp->orders_accepted.erase(i);
-				}
+				shipp->orders_accepted.erase(DEPART_ITEM);
 			}
 		}
 		else

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3704,7 +3704,7 @@ int CFred_mission_save::save_objects()
 				int bitfield = 0;
 				for (size_t order : shipp->orders_accepted) {
 					if(order < 32)
-						bitfield |= (1 << order);				
+						bitfield |= (1 << (order - 1)); //The first "true" order starts at idx 1, since 0 can be "no order"				
 				}
 				fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
 			}

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3702,8 +3702,10 @@ int CFred_mission_save::save_objects()
 					fout("\n+Orders Accepted:");
 
 				int bitfield = 0;
-				for (size_t order : shipp->orders_accepted)
-					bitfield |= Player_orders[order].id;
+				for (size_t order : shipp->orders_accepted) {
+					if(order < 32)
+						bitfield |= (1 << order);				
+				}
 				fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
 			}
 			else {

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -736,11 +736,7 @@ int Editor::create_ship(matrix* orient, vec3d* pos, int ship_type) {
 			// the depart item
 			if (!(sip->is_small_ship())) {
 				shipp->orders_accepted = ship_get_default_orders_accepted(sip);
-
-				for(size_t i = 0; i < Player_orders.size(); i++) {
-					if (Player_orders[i].id & DEPART_ITEM)
-						shipp->orders_accepted.erase(i);
-				}
+				shipp->orders_accepted.erase(DEPART_ITEM);
 			}
 		} else {
 			shipp->orders_accepted.clear();

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3499,7 +3499,7 @@ int CFred_mission_save::save_objects()
 				int bitfield = 0;
 				for (size_t order : shipp->orders_accepted) {
 					if (order < 32)
-						bitfield |= (1 << order);
+						bitfield |= (1 << (order - 1)); //The first "true" order starts at idx 1, since 0 can be "no order"
 				}
 				fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
 			} else {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3497,8 +3497,10 @@ int CFred_mission_save::save_objects()
 				}
 
 				int bitfield = 0;
-				for (size_t order : shipp->orders_accepted)
-					bitfield |= Player_orders[order].id;
+				for (size_t order : shipp->orders_accepted) {
+					if (order < 32)
+						bitfield |= (1 << order);
+				}
 				fout(" %d\t\t;! note that this is a bitfield!!!", bitfield);
 			} else {
 				if (optional_string_fred("+Orders Accepted List:", "$Name:")) {


### PR DESCRIPTION
This allows for a nearly unlimited number of player orders as opposed to the 32 before.
Previously, orders were sometimes stored and passed as bitfields, and sometimes as indices into the player_orders array.
This PR tidies that up and replaces it to _always_ be an index into the player_orders array. 
As these bitfields were also sent to multi, replacing them with indices is a multi version bump.

As this is a deep rooted change, the following things need to be tested exhaustively before this can be merged:
- [x] Issuing player orders still works
- [x] player orders still have correct behaviour for determining valid targets
- [x] player orders still work with LuaAI
- [x] Using controls-bound shortcuts for player orders still works
- [x] player orders still work in multi
- [x] player orders issue correct hud displays in multi