### PR TITLE
Fix +Orders Accepted List: parse

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3378,9 +3378,6 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 					p_objp->orders_accepted.insert(j);
 			}
 		}
-
-		if (!p_objp->orders_accepted.empty())
-			p_objp->flags.set(Mission::Parse_Object_Flags::SF_Use_unique_orders);
 	}
 
 	p_objp->group = 0;


### PR DESCRIPTION
#4282 introduced a regression where an empty orders accepted list would cause the ship to accept the default orders, instead of no orders as would be correct.
This fixes this.