### PR TITLE
Fix Orders Accepted List properly

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3378,6 +3378,8 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 					p_objp->orders_accepted.insert(j);
 			}
 		}
+
+		p_objp->flags.set(Mission::Parse_Object_Flags::SF_Use_unique_orders);
 	}
 
 	p_objp->group = 0;


### PR DESCRIPTION
Followup to #4310.
Evidently the fix has to be to _always_ add that flag, even with an empty list, and not never.
