### PR TITLE
Allow Weapon To Override Turret Name

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1566,16 +1566,30 @@ void get_turret_subsys_name(ship_weapon *swp, char *outstr)
 
 	//WMC - find the first weapon, if there is one
 	if (swp->num_primary_banks || swp->num_secondary_banks) {
-		int weaponid;
+		bool done = false;
 		if (swp->num_primary_banks) {
-			weaponid = swp->primary_bank_weapons[0];
+			for (auto weapon : swp->primary_bank_weapons) {
+				if (weapon >= 0) {
+					if (strlen(Weapon_info[weapon].altSubsysName) != 0) {
+						sprintf(outstr, "%s", Weapon_info[weapon].altSubsysName);
+						done = true;
+						break;
+					}
+				}
+			}
+		} 
+		if ((swp->num_secondary_banks) && !done) {
+			for (auto weapon : swp->secondary_bank_weapons) {
+				if (weapon >= 0) {
+					if (strlen(Weapon_info[weapon].altSubsysName) != 0) {
+						sprintf(outstr, "%s", Weapon_info[weapon].altSubsysName);
+						done = true;
+						break;
+					}
+				}
+			}
 		}
-		else {
-			weaponid = swp->secondary_bank_weapons[0];
-		}
-		if (strlen(Weapon_info[weaponid].altSubsysName) != 0) {
-			sprintf(outstr, "%s", Weapon_info[weaponid].altSubsysName);
-		} else {
+		if (!done) {
 
 			auto flags = turret_weapon_aggregate_flags(swp);
 

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1566,43 +1566,51 @@ void get_turret_subsys_name(ship_weapon *swp, char *outstr)
 
 	//WMC - find the first weapon, if there is one
 	if (swp->num_primary_banks || swp->num_secondary_banks) {
-		auto flags = turret_weapon_aggregate_flags(swp);
-
-		// check if beam or flak using weapon flags
-		if (flags[Weapon::Info_Flags::Beam]) {
-			sprintf(outstr, "%s", XSTR("Beam turret", 1567));
-		} else if (flags[Weapon::Info_Flags::Flak]) {
-			sprintf(outstr, "%s", XSTR("Flak turret", 1566));
+		int weaponid;
+		if (swp->num_primary_banks) {
+			weaponid = swp->primary_bank_weapons[0];
+		}
+		else {
+			weaponid = swp->secondary_bank_weapons[0];
+		}
+		if (strlen(Weapon_info[weaponid].altSubsysName) != 0) {
+			sprintf(outstr, "%s", Weapon_info[weaponid].altSubsysName);
 		} else {
-			if (turret_weapon_has_subtype(swp, WP_MISSILE)) {
-				sprintf(outstr, "%s", XSTR("Missile lnchr", 1569));
-			} else if (turret_weapon_has_subtype(swp, WP_LASER)) {
-				// ballistic too! - Goober5000
-				if (flags[Weapon::Info_Flags::Ballistic])
-				{
-					sprintf(outstr, "%s", XSTR("Turret", 1487));
-				}
-				// the TVWP has some primaries flagged as bombs
-				else if (flags[Weapon::Info_Flags::Bomb])
-				{
-					sprintf(outstr, "%s", XSTR("Missile lnchr", 1569));
-				}
-				else
-				{
-					sprintf(outstr, "%s", XSTR("Laser turret", 1568));
-				}
+
+			auto flags = turret_weapon_aggregate_flags(swp);
+
+			// check if beam or flak using weapon flags
+			if (flags[Weapon::Info_Flags::Beam]) {
+				sprintf(outstr, "%s", XSTR("Beam turret", 1567));
+			} else if (flags[Weapon::Info_Flags::Flak]) {
+				sprintf(outstr, "%s", XSTR("Flak turret", 1566));
 			} else {
-				// Mantis #2226: find out if there are any weapons here at all
-				if (flags.none_set()) {
-					sprintf(outstr, "%s", NOX("Unused"));
-				} else {
-					// Illegal subtype
-					static bool Turret_illegal_subtype_warned = false;
-					if (!Turret_illegal_subtype_warned) {
-						Turret_illegal_subtype_warned = true;
-						Warning(LOCATION, "This turret has an illegal subtype!  Trace out and fix!");
+				if (turret_weapon_has_subtype(swp, WP_MISSILE)) {
+					sprintf(outstr, "%s", XSTR("Missile lnchr", 1569));
+				} else if (turret_weapon_has_subtype(swp, WP_LASER)) {
+					// ballistic too! - Goober5000
+					if (flags[Weapon::Info_Flags::Ballistic]) {
+						sprintf(outstr, "%s", XSTR("Turret", 1487));
 					}
-					sprintf(outstr, "%s", XSTR("Turret", 1487));
+					// the TVWP has some primaries flagged as bombs
+					else if (flags[Weapon::Info_Flags::Bomb]) {
+						sprintf(outstr, "%s", XSTR("Missile lnchr", 1569));
+					} else {
+						sprintf(outstr, "%s", XSTR("Laser turret", 1568));
+					}
+				} else {
+					// Mantis #2226: find out if there are any weapons here at all
+					if (flags.none_set()) {
+						sprintf(outstr, "%s", NOX("Unused"));
+					} else {
+						// Illegal subtype
+						static bool Turret_illegal_subtype_warned = false;
+						if (!Turret_illegal_subtype_warned) {
+							Turret_illegal_subtype_warned = true;
+							Warning(LOCATION, "This turret has an illegal subtype!  Trace out and fix!");
+						}
+						sprintf(outstr, "%s", XSTR("Turret", 1487));
+					}
 				}
 			}
 		}

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1568,10 +1568,10 @@ void get_turret_subsys_name(ship_weapon *swp, char *outstr)
 	if (swp->num_primary_banks || swp->num_secondary_banks) {
 		bool done = false;
 		if (swp->num_primary_banks) {
-			for (auto weapon : swp->primary_bank_weapons) {
-				if (weapon >= 0) {
-					if (strlen(Weapon_info[weapon].altSubsysName) != 0) {
-						sprintf(outstr, "%s", Weapon_info[weapon].altSubsysName);
+			for (auto weaponid : swp->primary_bank_weapons) {
+				if (weaponid >= 0) {
+					if (strlen(Weapon_info[weaponid].altSubsysName) != 0) {
+						sprintf(outstr, "%s", Weapon_info[weaponid].altSubsysName);
 						done = true;
 						break;
 					}
@@ -1579,10 +1579,10 @@ void get_turret_subsys_name(ship_weapon *swp, char *outstr)
 			}
 		} 
 		if ((swp->num_secondary_banks) && !done) {
-			for (auto weapon : swp->secondary_bank_weapons) {
-				if (weapon >= 0) {
-					if (strlen(Weapon_info[weapon].altSubsysName) != 0) {
-						sprintf(outstr, "%s", Weapon_info[weapon].altSubsysName);
+			for (auto weaponid : swp->secondary_bank_weapons) {
+				if (weaponid >= 0) {
+					if (strlen(Weapon_info[weaponid].altSubsysName) != 0) {
+						sprintf(outstr, "%s", Weapon_info[weaponid].altSubsysName);
 						done = true;
 						break;
 					}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -318,6 +318,7 @@ struct weapon_info
 	char	display_name[NAME_LENGTH];		// display name of this weapon
 	char	title[WEAPON_TITLE_LEN];		// official title of weapon (used by tooltips)
 	char	*desc;								// weapon's description (used by tooltips)
+	char	altSubsysName[NAME_LENGTH];        // rename turret to this if this is the turrets first weapon
 
 	char	pofbitmap_name[MAX_FILENAME_LEN];	// Name of the pof representing this if POF, or bitmap filename if bitmap
 	int		model_num;							// modelnum of weapon -- -1 if no model

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -999,6 +999,10 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		stuff_malloc_string(&wip->tech_desc, F_MULTITEXT);
 	}
 
+	if (optional_string("$Turret Name:")) {
+		stuff_string(wip->altSubsysName, F_NAME, NAME_LENGTH);
+	}
+
 	if (optional_string("$Tech Model:")) {
 		stuff_string(wip->tech_model, F_NAME, MAX_FILENAME_LEN);
 
@@ -8666,6 +8670,7 @@ void weapon_info::reset()
 	memset(this->display_name, 0, sizeof(this->display_name));
 	memset(this->title, 0, sizeof(this->title));
 	this->desc = nullptr;
+	memset(this->altSubsysName, 0, sizeof(this->altSubsysName));
 
 	memset(this->pofbitmap_name, 0, sizeof(this->pofbitmap_name));
 	this->model_num = -1;


### PR DESCRIPTION
Done following a discussion in #Freespace a week or so ago. Allows a weapon to override a turrets name if it is the first weapon in a turret. Does not override a Subsystems Alt name if specified in ships.tbl