### PR TITLE
Fix rollback primary collisions

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -56,7 +56,7 @@ struct oo_ship_position_records {
 
 // keeps track of what has been sent to each player, helps cut down on bandwidth, allowing only new information to be sent instead of old.
 struct oo_info_sent_to_players {	
-	int timestamp;					// The overall timestamp which is used to decide if a new packet should be sent to this player for this ship.
+	TIMESTAMP timestamp;					// The overall timestamp which is used to decide if a new packet should be sent to this player for this ship.
 
 	vec3d position;					// If they are stationary, there's no need to update their position.
 	float hull;						// no need to send hull if hull hasn't changed.
@@ -153,7 +153,7 @@ struct oo_unsimulated_shots {
 struct oo_general_info {
 	// info that helps us figure out what is the best reference object available when sending a rollback shot.
 	// We go by what is the most recent object update packet received, and then by distance.
-	int ref_timestamp;							// what time did we receive the reference object
+	int rollback_reference_timestamp;							// what time did we receive the reference object
 	ushort most_recent_updated_net_signature;	// what is the net signature of the reference object.
 	int most_recent_frame;					// what is the frame from the update of most recently updated object.
 
@@ -168,7 +168,7 @@ struct oo_general_info {
 	int number_of_frames;									// how many frames have we gone through, total.
 	ubyte cur_frame_index;									// the current frame index (to access the recorded info)
 
-	int timestamps[MAX_FRAMES_RECORDED];					// The timestamp for the recorded frame
+	TIMESTAMP timestamps[MAX_FRAMES_RECORDED];					// The timestamp for the recorded frame
 	SCP_vector<oo_ship_position_records> frame_info;		// Actually keeps track of ship physics info.  Uses net_signature as its index.
 	SCP_vector<oo_netplayer_records> player_frame_info;		// keeps track of player targets and what has been sent to each player. Uses player as the index
 
@@ -197,7 +197,7 @@ bool Afterburn_hack = false;			// HACK!!!
 int multi_find_prev_frame_idx();
 
 // quickly lookup how much time has passed since the given frame.
-uint multi_ship_record_get_time_elapsed(int original_frame, int new_frame);
+int multi_ship_record_get_time_elapsed(int original_frame, int new_frame);
 
 // fire the rollback weapons that are in the rollback struct
 void multi_oo_fire_rollback_shots(int frame_idx);
@@ -472,7 +472,7 @@ void multi_ship_record_increment_frame()
 		Oo_info.cur_frame_index = 0;
 	}
 
-	Oo_info.timestamps[Oo_info.cur_frame_index] = timestamp();
+	Oo_info.timestamps[Oo_info.cur_frame_index] = _timestamp();
 }
 
 // returns the last frame's index.
@@ -503,20 +503,43 @@ int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 
 	// Now we look for the frame that the client is saying to look for. 
 	// get the timestamp we are looking for.
-	int target_timestamp = Oo_info.timestamps[frame] + time_elapsed;
+	TIMESTAMP target_timestamp = timestamp_delta(Oo_info.timestamps[frame], time_elapsed);
+
+	// need to try to make rollback shot make some kind of sense if we have invalid timestamps,
+	// and print to debugif it is.
+	if (!target_timestamp.isValid() || target_timestamp.isNever()) {
+		mprintf(("Nonsense timestamp in multi_ship_record_find_frame of %s. Get ~~Allender~~ Cyborg!\n", (target_timestamp.isValid()) ? "isNever" : "NOT isValid"));
+		return frame;
+	};
 
 	for (int i = Oo_info.cur_frame_index - 2; i > -1; i--) {
 
+		// need to try to make rollback shot make some kind of sense if we have invalid timestamps,
+		// and print to debug if it is.	  No need to trigger the Assert in timestamp_in_between, as it is minor here. (i + 1 should be check on previous iteration, most of the time)
+		if (!Oo_info.timestamps[i].isValid() || Oo_info.timestamps[i].isNever()) {
+			mprintf(("timestamps[i] is %s, get ~~Allender~~ Cyborg!\n", (Oo_info.timestamps[i].isValid()) ? "isNever" : "invalid"));
+			return frame;
+		}
+
 		// Check to see if the client's timestamp matches the recorded frames.
-		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] >= target_timestamp)) {		
+		if (timestamp_in_between(target_timestamp, Oo_info.timestamps[i], Oo_info.timestamps[i + 1])) {		
 			return i;
 		}
 
 		// there is no need to check for an invalid frame here because, logically, the search cannot reach frame until the next section
 	}
 
+
+	// need to try to make rollback shot make some kind of sense if we have invalid timestamps,
+	// and print to debug if it is. No need to trigger the Assert in timestamp_in_between, as it is minor here.
+	if (!Oo_info.timestamps[MAX_FRAMES_RECORDED - 1].isValid() || Oo_info.timestamps[MAX_FRAMES_RECORDED - 1].isNever()) {
+			mprintf(("timestamps[MAX_FRAMES_FRAMES_RECORDED - 1] is %s, get ~~Allender~~ Cyborg!\n", (Oo_info.timestamps[MAX_FRAMES_RECORDED - 1].isValid()) ? "isNever" : "invalid"));
+			return frame;
+	}
+
+
 	// Check for an end of the wrap condition.
-	if ((Oo_info.timestamps[MAX_FRAMES_RECORDED - 1] <= target_timestamp) && (Oo_info.timestamps[0] >= target_timestamp)) {
+	if (timestamp_in_between(target_timestamp, Oo_info.timestamps[MAX_FRAMES_RECORDED - 1], Oo_info.timestamps[0])) {
 		return MAX_FRAMES_RECORDED - 1;
 	}
 
@@ -528,10 +551,16 @@ int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 
 	// Check the oldest frames.
 	for (int i = MAX_FRAMES_RECORDED - 2; i > Oo_info.cur_frame_index; i--) {
-		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] >= target_timestamp)) {
-			return i;
+		// need to try to make rollback shot make some kind of sense if we have invalid timestamps,
+		// and print to debug if it is. No need to trigger the Assert in timestamp_in_between, as it is minor here.
+		if (!Oo_info.timestamps[i].isValid() || Oo_info.timestamps[i].isNever()) {
+			mprintf(("timestamps[i] is %s, get ~~Allender~~ Cyborg!\n", (Oo_info.timestamps[i].isValid()) ? "isNever" : "invalid"));
+			return frame;
 		}
-		else if (i < frame) {
+
+		if (timestamp_in_between(target_timestamp, Oo_info.timestamps[i], Oo_info.timestamps[i + 1])) {
+			return i;
+		} else if (i < frame) {
 			return -1;
 		}
 	}
@@ -582,7 +611,7 @@ void multi_ship_record_add_timestamp(int pl_id, ubyte timestamp, int seq_num) {
 
 
 // quickly lookup how much time has passed between two frames.
-uint multi_ship_record_get_time_elapsed(int original_frame, int new_frame) 
+int multi_ship_record_get_time_elapsed(int original_frame, int new_frame) 
 {
 	// Bogus values
 	Assertion(original_frame <= MAX_FRAMES_RECORDED, "Function multi_ship_record_get_time_elapsed() got passed an invalid original frame, this is a code error, please report. ");
@@ -591,7 +620,7 @@ uint multi_ship_record_get_time_elapsed(int original_frame, int new_frame)
 		return 0;
 	}
 
-	return Oo_info.timestamps[new_frame] - Oo_info.timestamps[original_frame];
+	return timestamp_get_delta(Oo_info.timestamps[original_frame], Oo_info.timestamps[new_frame]);
 }
 
 // figures out how much time has passed bwetween the two frames.
@@ -599,7 +628,7 @@ int multi_ship_record_find_time_after_frame(int starting_frame, int ending_frame
 {
 	starting_frame = starting_frame % MAX_FRAMES_RECORDED;
 
-	int return_value = time_elapsed - (Oo_info.timestamps[ending_frame] - Oo_info.timestamps[starting_frame]);
+	int return_value = time_elapsed - (timestamp_get_delta(Oo_info.timestamps[ending_frame], Oo_info.timestamps[starting_frame]));
 	return return_value;
 }
 
@@ -738,7 +767,7 @@ void multi_ship_record_do_rollback()
 		multi_oo_restore_frame(frame_idx);
 
 		// push weapons forward for the frame (weapons do not get pushed forward for the first frame of their existence)
-		continue_rollback = (multi_oo_simulate_rollback_shots(frame_idx));
+		continue_rollback = multi_oo_simulate_rollback_shots(frame_idx);
 
 		// then fire all shots for the frame, primary and secondary, if there are any
 		multi_oo_fire_rollback_shots(frame_idx);
@@ -833,7 +862,7 @@ bool multi_oo_simulate_rollback_shots(int frame_idx)
 	}
 
 	// calculate the float version of the frametime.
-	float frametime = (float)multi_ship_record_get_time_elapsed(prev_frame, frame_idx) / (float)TIMESTAMP_FREQUENCY;
+	float frametime = static_cast<float>(multi_ship_record_get_time_elapsed(prev_frame, frame_idx)) / static_cast<float>(TIMESTAMP_FREQUENCY);
 
 	if (Oo_info.rollback_weapon_object_number.empty()) {
 		return true;
@@ -886,7 +915,7 @@ void multi_ship_record_rank_seq_num(object* objp, int seq_num)
 	if (seq_num > Oo_info.most_recent_frame || Oo_info.most_recent_updated_net_signature == 0) {
 		Oo_info.most_recent_updated_net_signature = objp->net_signature;
 		Oo_info.most_recent_frame = seq_num;
-		Oo_info.ref_timestamp = timestamp();
+		Oo_info.rollback_reference_timestamp = timestamp(); // these calls to _timestamp() will get fixed in interp overhaul 2
 
 	} // if this packet is from the same frame, the closer ship makes for a slightly more accurate reference point
 	else if (seq_num == Oo_info.most_recent_frame) {
@@ -895,7 +924,7 @@ void multi_ship_record_rank_seq_num(object* objp, int seq_num)
 		if ( (temp_reference_object == nullptr) || vm_vec_dist_squared(&temp_reference_object->pos, &Objects[Player->objnum].pos) > vm_vec_dist_squared(&objp->pos, &Objects[Player->objnum].pos) ) {
 			Oo_info.most_recent_updated_net_signature = objp->net_signature;
 			Oo_info.most_recent_frame = seq_num;
-			Oo_info.ref_timestamp = timestamp();
+			Oo_info.rollback_reference_timestamp = timestamp(); // these calls to _timestamp() will get fixed in interp overhaul 2
 		}
 	}
 }
@@ -915,7 +944,7 @@ int multi_client_lookup_frame_idx()
 // Quick lookup for the most recently received timestamp.
 int multi_client_lookup_frame_timestamp()
 {
-	return Oo_info.ref_timestamp;
+	return Oo_info.rollback_reference_timestamp;
 }
 
 // Resets what info we have sent and interpolation info for a respawn
@@ -929,7 +958,7 @@ void multi_oo_respawn_reset_info(ushort net_sig)
 
 	// When a player respawns, they keep their net signature, so clean up all the info that could mess things up in the future.
 	for (auto & player_record : Oo_info.player_frame_info) {
-		player_record.last_sent[net_sig].timestamp = -1;
+		player_record.last_sent[net_sig].timestamp = TIMESTAMP::immediate();
 		player_record.last_sent[net_sig].position = vmd_zero_vector;
 		player_record.last_sent[net_sig].hull = -1.0f;
 		player_record.last_sent[net_sig].ai_mode = -1;
@@ -2271,7 +2300,7 @@ void multi_oo_reset_timestamp(net_player *pl, object *objp, int range, int in_co
 
 	// reset the timestamp for this object
 	if(objp->type == OBJ_SHIP){
-		Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].timestamp = timestamp(stamp);
+		Oo_info.player_frame_info[pl->player_id].last_sent[objp->net_signature].timestamp = _timestamp(stamp);
 	} 
 }
 
@@ -2279,7 +2308,7 @@ void multi_oo_reset_timestamp(net_player *pl, object *objp, int range, int in_co
 int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 {
 	ushort oo_flags = 0;
-	int stamp;
+	TIMESTAMP stamp;
 	int player_index;
 	vec3d player_eye;
 	vec3d obj_dot;
@@ -2289,7 +2318,6 @@ int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 	ship *shipp;
 	ship_info *sip;
 
-	// if the timestamp has elapsed for this guy, send stuff
 	player_index = NET_PLAYER_INDEX(pl);
 	if(!(player_index >= 0) || !(player_index < MAX_PLAYERS)){
 		return 0;
@@ -2304,8 +2332,8 @@ int multi_oo_maybe_update(net_player *pl, object *obj, ubyte *data)
 		return 0;
 	}
 
-	// stamp hasn't popped yet
-	if((stamp != -1) && !timestamp_elapsed_safe(stamp, OO_MAX_TIMESTAMP)){
+	// if the timestamp hasn't elapsed for this guy return - This timestamp_elapsed
+	if(!(stamp.isNever()) && !(timestamp_elapsed_safe(stamp, OO_MAX_TIMESTAMP))){
 		return 0;
 	}
 	
@@ -2461,7 +2489,7 @@ void multi_oo_process_all(net_player *pl)
 	ADD_INT(Oo_info.number_of_frames);
 
 	// also the timestamp.
-	int temp_timestamp = (Oo_info.timestamps[Oo_info.cur_frame_index] - Oo_info.timestamps[multi_find_prev_frame_idx()]);
+	int temp_timestamp = timestamp_get_delta(Oo_info.timestamps[Oo_info.cur_frame_index], Oo_info.timestamps[multi_find_prev_frame_idx()]);
 
 	// only the very longest frames are going to have greater than 255 ms, so cap it at that.
 	if (temp_timestamp > 255) {
@@ -2631,7 +2659,7 @@ void multi_init_oo_and_ship_tracker()
 	// setup initial object update info	
 	// Part 1: Get the non-repeating parts of the struct set.
 
-	Oo_info.ref_timestamp = -1;
+	Oo_info.rollback_reference_timestamp = 0;
 	Oo_info.most_recent_updated_net_signature = 0;
 	Oo_info.most_recent_frame = 0;
 	for (int i = 0; i < MAX_PLAYERS; i++) { // NOLINT
@@ -2643,7 +2671,7 @@ void multi_init_oo_and_ship_tracker()
 	Oo_info.cur_frame_index = 0;
 
 	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) { // NOLINT
-		Oo_info.timestamps[i] = MAX_TIME; // This needs to be Max time (or at least some absurdly high number) for rollback to work correctly
+		Oo_info.timestamps[i] = _timestamp(); // as of Interpolate overhaul 2, this can be something besides infinite
 	}
 
 	Oo_info.rollback_mode = false;
@@ -2680,7 +2708,7 @@ void multi_init_oo_and_ship_tracker()
 	int cur = 0;
 	oo_info_sent_to_players temp_sent_to_player;
 
-	temp_sent_to_player.timestamp = timestamp(cur);
+	temp_sent_to_player.timestamp = _timestamp(cur);
 	temp_sent_to_player.position = vmd_zero_vector;
 	temp_sent_to_player.hull = 0.0f;
 	temp_sent_to_player.ai_mode = 0;
@@ -2776,7 +2804,7 @@ void multi_close_oo_and_ship_tracker()
 	}
 
 	// Part 1: Get the non-repeating parts of the struct set.
-	Oo_info.ref_timestamp = -1;
+	Oo_info.rollback_reference_timestamp = 0;
 	Oo_info.most_recent_updated_net_signature = 0;
 	Oo_info.most_recent_frame = 0;
 
@@ -2789,7 +2817,7 @@ void multi_close_oo_and_ship_tracker()
 	Oo_info.cur_frame_index = 0;
 
 	for (int i = 0; i < MAX_FRAMES_RECORDED; i++) { // NOLINT
-		Oo_info.timestamps[i] = MAX_TIME; // This needs to be Max time (or at least some absurdly high number) for rollback to work correctly
+		Oo_info.timestamps[i] = _timestamp(); // // as of Interpolate overhaul 2, this can be something besides infinite
 	}
 
 	Oo_info.rollback_mode = false;
@@ -2836,7 +2864,7 @@ void multi_oo_send_control_info()
 	ADD_INT(Oo_info.number_of_frames);
 
 	// also the timestamp.
-	int temp_timestamp = (Oo_info.timestamps[Oo_info.cur_frame_index] - Oo_info.timestamps[multi_find_prev_frame_idx()]);
+	int temp_timestamp = timestamp_get_delta(Oo_info.timestamps[Oo_info.cur_frame_index], Oo_info.timestamps[multi_find_prev_frame_idx()]);
 
 	// only the very longest frames are going to have greater than 255 ms, so cap it at that.
 	if (temp_timestamp > 255) {
@@ -2909,7 +2937,7 @@ void multi_oo_send_changed_object(object *changedobj)
 	ADD_INT(Oo_info.number_of_frames);
 
 	// also the timestamp.
-	int temp_timestamp = (Oo_info.timestamps[Oo_info.cur_frame_index] - Oo_info.timestamps[multi_find_prev_frame_idx()]);
+	int temp_timestamp = timestamp_get_delta(Oo_info.timestamps[Oo_info.cur_frame_index], Oo_info.timestamps[multi_find_prev_frame_idx()]);
 
 	// only the very longest frames are going to have greater than 255 ms, so cap it at that.
 	if (temp_timestamp > 255) {

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -489,7 +489,7 @@ int multi_find_prev_frame_idx()
 int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 {	
 	// frame coming in from the client is too old to be used. (The -1 prevents an edge case bug at very high pings)
-	if (Oo_info.cur_frame_index - client_frame >= MAX_FRAMES_RECORDED - 1) {
+	if (Oo_info.number_of_frames - client_frame >= MAX_FRAMES_RECORDED - 1) {
 		return -1;
 	}
 
@@ -511,9 +511,8 @@ int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] >= target_timestamp)) {		
 			return i;
 		}
-		else if (i < frame) {
-			return -1;
-		}
+
+		// there is no need to check for an invalid frame here because, logically, the search cannot reach frame until the next section
 	}
 
 	// Check for an end of the wrap condition.
@@ -840,7 +839,6 @@ bool multi_oo_simulate_rollback_shots(int frame_idx)
 		return true;
 	}
 
-	// initially set this to whether or not this is empty.  If it is, w
 	bool result = false;
 
 	// push the weapons forward.

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -508,25 +508,31 @@ int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 	for (int i = Oo_info.cur_frame_index - 2; i > -1; i--) {
 
 		// Check to see if the client's timestamp matches the recorded frames.
-		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] > target_timestamp)) {
+		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] >= target_timestamp)) {		
 			return i;
 		}
-		else if (i == frame) {
+		else if (i < frame) {
 			return -1;
 		}
 	}
 
 	// Check for an end of the wrap condition.
-	if ((Oo_info.timestamps[MAX_FRAMES_RECORDED - 1] <= target_timestamp) && (Oo_info.timestamps[0] > target_timestamp)) {
+	if ((Oo_info.timestamps[MAX_FRAMES_RECORDED - 1] <= target_timestamp) && (Oo_info.timestamps[0] >= target_timestamp)) {
 		return MAX_FRAMES_RECORDED - 1;
 	}
 
+	// Check for the received frame being passed
+	if (frame == 0){
+		return -1;
+	}
+
+
 	// Check the oldest frames.
 	for (int i = MAX_FRAMES_RECORDED - 2; i > Oo_info.cur_frame_index; i--) {
-		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] > target_timestamp)) {
+		if ((Oo_info.timestamps[i] <= target_timestamp) && (Oo_info.timestamps[i + 1] >= target_timestamp)) {
 			return i;
 		}
-		else if (i == frame) {
+		else if (i < frame) {
 			return -1;
 		}
 	}

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7842,7 +7842,7 @@ void send_non_homing_fired_packet(ship* shipp, int banks_or_number_of_missiles_f
 
 	// We need the time elpased, so send the last frame we got from the server and how much time has happened since then.
 	int last_received_frame = multi_client_lookup_frame_idx();
-	auto time_elapsed = (ushort)(timestamp() - multi_client_lookup_frame_timestamp());
+	auto time_elapsed = static_cast<ushort>(timestamp_since(multi_client_lookup_frame_timestamp()));
 
 	ADD_INT(last_received_frame);
 	ADD_USHORT(time_elapsed);
@@ -7950,11 +7950,11 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 	}
 
 	// figure out correct start frame
-	int frame = multi_ship_record_find_frame(client_frame, (int)time_elapsed);
+	int frame = multi_ship_record_find_frame(client_frame, static_cast<int>(time_elapsed));
 
 	if (frame > -1) {
 		// adjust time so that we can interpolate the position and orientation that was seen on the client.
-		int time_after_frame = multi_ship_record_find_time_after_frame(client_frame, frame, (int)time_elapsed);
+		int time_after_frame = multi_ship_record_find_time_after_frame(client_frame, frame, static_cast<int>(time_elapsed));
 		Assertion(time_after_frame >= 0, "Primary fire packet processor found an invalid time_after_frame of %d", time_after_frame);
 
 		vec3d new_tar_pos = multi_ship_record_lookup_position(objp_ref, frame);

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -7821,8 +7821,8 @@ void send_non_homing_fired_packet(ship* shipp, int banks_or_number_of_missiles_f
 	}
 
 	object* ref_objp = multi_get_network_object(multi_client_lookup_ref_obj_net_sig());
-	if (ref_objp == nullptr) {
-		mprintf(("Unable to get accurate reference object for non-homing packet.\n"));
+	if (ref_objp == nullptr || ref_objp->type != OBJ_SHIP) {
+		mprintf(("Unable to get accurate reference object for non-homing packet, because %s\n", (ref_objp == nullptr) ? "it was null." : "it was not a ship!"));
 		if (!secondary) {
 			send_NEW_primary_fired_packet(shipp, banks_or_number_of_missiles_fired);
 		}
@@ -7936,8 +7936,13 @@ void process_non_homing_fired_packet(ubyte* data, header* hinfo)
 
 	object* objp_ref = multi_get_network_object(target_ref);
 
-	if (objp_ref == nullptr) {
+	if (objp_ref == nullptr || objp_ref->type != OBJ_SHIP) {
 		// new way failed, use the old new way.
+
+		if (objp_ref != nullptr){
+			mprintf(("Rollback's reference object was not a ship! It was a %d. Get Cyborg!!!\n", objp_ref->type));
+		}
+
 		if (secondary) {
 			// if this is a rollback shot from a dumbfire secondary, we have to mark this as a 
 			// rollback shot so the client doesn't get an extra shot.


### PR DESCRIPTION
Taylor, Wookiejedi, and I have all been going back and forth heavily testing these fixes.  On stationary targets, we have 100% accuracy.  On moving targets, we have one more test pending, but results are promising so far, even at high pings.  This improvement works best with Interpolation Overhaul 2, but is independent of it.