### PR TITLE
Cached subsystem indexing

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -7774,7 +7774,11 @@ int ai_set_attack_subsystem(object *objp, int subnum)
 	attacked_objp = &Objects[aip->target_objnum];
 	shipp = &Ships[attacked_objp->instance];		//  need to get our target's ship pointer!!!
 
-	ssp = ship_get_indexed_subsys(shipp, subnum, &objp->pos);
+	// When subnum is >= 0, it indicates a specific subsystem.  Otherwise it is a subsystem type.  See ai_submode
+	if (subnum >= 0)
+		ssp = ship_get_indexed_subsys(shipp, subnum);
+	else
+		ssp = ship_get_first_subsys(shipp, -subnum, &objp->pos);
 	if (ssp == NULL)
 		return 0;
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -7778,7 +7778,7 @@ int ai_set_attack_subsystem(object *objp, int subnum)
 	if (subnum >= 0)
 		ssp = ship_get_indexed_subsys(shipp, subnum);
 	else
-		ssp = ship_get_first_subsys(shipp, -subnum, &objp->pos);
+		ssp = ship_find_first_subsys(shipp, -subnum, &objp->pos);
 	if (ssp == NULL)
 		return 0;
 

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1858,7 +1858,7 @@ ai_achievability ai_mission_goal_achievable( int objnum, ai_goal *aigp )
 			sindex = ship_name_lookup( aigp->target_name );
 
 			if ( sindex != -1 ) {
-				aigp->ai_submode = ship_get_subsys_index( &Ships[sindex], aigp->docker.name );
+				aigp->ai_submode = ship_find_subsys( &Ships[sindex], aigp->docker.name );
 				aigp->flags.remove(AI::Goal_Flags::Subsys_needs_fixup);
 			} else {
 				Int3();

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2017,7 +2017,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 					if ( MULTIPLAYER_MASTER && (weapon_objnum != -1) ) {
 						int subsys_index;
 
-						subsys_index = ship_get_index_from_subsys(turret, parent_objnum );
+						subsys_index = ship_get_subsys_index(turret);
 						Assert( subsys_index != -1 );
 						if(wip->wi_flags[Weapon::Info_Flags::Flak]){			
 							send_flak_fired_packet( parent_objnum, subsys_index, weapon_objnum, flak_range );
@@ -2126,7 +2126,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 		if ( MULTIPLAYER_MASTER && (weapon_objnum != -1) ) {
 			int subsys_index;
 
-			subsys_index = ship_get_index_from_subsys(tsi->turret, tsi->parent_objnum );
+			subsys_index = ship_get_subsys_index(tsi->turret);
 			Assert( subsys_index != -1 );
 			send_turret_fired_packet( tsi->parent_objnum, subsys_index, weapon_objnum );
 		}

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1136,7 +1136,7 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 			}
 
 			ai_mode = AI_GOAL_DESTROY_SUBSYSTEM;
-			ai_submode = ship_get_subsys_index( &Ships[Objects[ainfo->target_objnum].instance], ainfo->targeted_subsys->system_info->subobj_name );
+			ai_submode = ship_find_subsys( &Ships[Objects[ainfo->target_objnum].instance], ainfo->targeted_subsys->system_info->subobj_name );
 			special_index = ai_submode; 
 			message = MESSAGE_ATTACK_TARGET;
 			break;
@@ -1423,7 +1423,7 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 			Assert( ainfo->targeted_subsys->current_hits > 0.0f);
 
 			ai_mode = AI_GOAL_DESTROY_SUBSYSTEM;
-			ai_submode = ship_get_subsys_index( &Ships[Objects[ainfo->target_objnum].instance], ainfo->targeted_subsys->system_info->subobj_name );
+			ai_submode = ship_find_subsys( &Ships[Objects[ainfo->target_objnum].instance], ainfo->targeted_subsys->system_info->subobj_name );
 			special_index = ai_submode; 
 			message = MESSAGE_ATTACK_TARGET;
 			break;
@@ -2485,7 +2485,7 @@ int hud_query_order_issued(const char *to, const char *order_name, const char *t
 								continue;
 							}
                             
-							int subsys_index = ship_get_subsys_index(&Ships[target_ship], special_argument); 
+							int subsys_index = ship_find_subsys(&Ships[target_ship], special_argument); 
 							// if the order is for s different subsystem
 							if (Squadmsg_history[i].special_index != subsys_index) {
 								continue;

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1096,12 +1096,12 @@ int multi_oo_pack_client_data(ubyte *data, ship* shipp)
 			
 		// targeted subsys index
 		if(Player_ai->targeted_subsys != nullptr){
-			t_subsys = (char)ship_get_index_from_subsys( Player_ai->targeted_subsys, Player_ai->target_objnum );
+			t_subsys = (char)ship_get_subsys_index( Player_ai->targeted_subsys );
 		}
 
 		// locked targeted subsys index
 		if(Player->locking_subsys != nullptr){
-			l_subsys = (char)ship_get_index_from_subsys( Player->locking_subsys, Player_ai->target_objnum );
+			l_subsys = (char)ship_get_subsys_index( Player->locking_subsys );
 		}
 	}
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3111,7 +3111,7 @@ void send_secondary_fired_packet( ship *shipp, ushort starting_sig, int  /*start
 	if ( aip->target_objnum != -1) {
 		target_net_signature = Objects[aip->target_objnum].net_signature;
 		if ( (Objects[aip->target_objnum].type == OBJ_SHIP) && (aip->targeted_subsys != NULL) ) {
-			s_index = ship_get_index_from_subsys( aip->targeted_subsys, aip->target_objnum );
+			s_index = ship_get_subsys_index( aip->targeted_subsys );
 		}
 
 		if ( Objects[aip->target_objnum].type == OBJ_WEAPON ) {
@@ -4437,7 +4437,7 @@ void send_player_order_packet(int type, int index, int cmd)
 	ADD_USHORT( target_net_signature );
 
 	if ( (Player_ai->target_objnum != -1) && (Player_ai->targeted_subsys != NULL) ) {
-		s_index = ship_get_index_from_subsys( Player_ai->targeted_subsys, Player_ai->target_objnum );
+		s_index = ship_get_subsys_index( Player_ai->targeted_subsys );
 	}
 
 	ADD_SHORT(static_cast<short>(s_index));
@@ -7522,7 +7522,7 @@ void send_homing_weapon_info( int weapon_num )
 
 		// get the subsystem index.
 		if ( (homing_object->type == OBJ_SHIP) && (wp->homing_subsys != NULL) ) {
-			s_index = ship_get_index_from_subsys( wp->homing_subsys, OBJ_INDEX(homing_object) );
+			s_index = ship_get_subsys_index( wp->homing_subsys );
 		}
 	}
 
@@ -8196,7 +8196,7 @@ void send_beam_fired_packet(const beam_fire_info *fire_info, const beam_info *ov
 			return;
 		}
 	} else if (fire_info->shooter && fire_info->turret) {
-		shooter_subsys_index = ship_get_index_from_subsys(fire_info->turret, OBJ_INDEX(fire_info->shooter));
+		shooter_subsys_index = ship_get_subsys_index(fire_info->turret);
 
 		Assertion(shooter_subsys_index >= 0, "BEAM fired from unknown subsystem!");
 		Assertion(shooter_subsys_index < SHRT_MAX, "BEAM fired from a subsystem beyond max limits!");
@@ -8210,7 +8210,7 @@ void send_beam_fired_packet(const beam_fire_info *fire_info, const beam_info *ov
 	target_sig = (fire_info->target) ? fire_info->target->net_signature : 0;
 
 	if (fire_info->target && fire_info->target_subsys) {
-		target_subsys_index = ship_get_index_from_subsys(fire_info->target_subsys, OBJ_INDEX(fire_info->target));
+		target_subsys_index = ship_get_subsys_index(fire_info->target_subsys);
 	}
 
 	u_beam_info = static_cast<short>(fire_info->beam_info_index);

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3351,7 +3351,7 @@ void send_turret_fired_packet( int ship_objnum, int subsys_index, int weapon_obj
 
 	pnet_signature = Objects[ship_objnum].net_signature;
 
-	ssp = ship_get_indexed_subsys( &Ships[Objects[ship_objnum].instance], subsys_index, NULL );
+	ssp = ship_get_indexed_subsys( &Ships[Objects[ship_objnum].instance], subsys_index );
 	if(ssp == NULL){
 		return;
 	}
@@ -3443,7 +3443,7 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	// find this turret, and set the position of the turret that just fired to be where it fired.  Quite a
 	// hack, but should be suitable.
 	shipp = &Ships[objp->instance];
-	ssp = ship_get_indexed_subsys( shipp, turret_index, NULL );
+	ssp = ship_get_indexed_subsys( shipp, turret_index );
 	if(ssp == NULL){
 		return;
 	}
@@ -8640,7 +8640,7 @@ void send_flak_fired_packet(int ship_objnum, int subsys_index, int weapon_objnum
 	Assert ( objp->type == OBJ_WEAPON );	
 	pnet_signature = Objects[ship_objnum].net_signature;
 
-	ssp = ship_get_indexed_subsys( &Ships[Objects[ship_objnum].instance], subsys_index, NULL );
+	ssp = ship_get_indexed_subsys( &Ships[Objects[ship_objnum].instance], subsys_index );
 	if(ssp == NULL){
 		return;
 	}
@@ -8724,7 +8724,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	// find this turret, and set the position of the turret that just fired to be where it fired.  Quite a
 	// hack, but should be suitable.
 	shipp = &Ships[objp->instance];
-	ssp = ship_get_indexed_subsys( shipp, turret_index, NULL );
+	ssp = ship_get_indexed_subsys( shipp, turret_index );
 	if(ssp == NULL){
 		return;
 	}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13659,6 +13659,7 @@ void sexp_sabotage_subsystem(int n)
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for sabotage subsystem\n", subsystem, shipp->ship_name));
 				continue;
 			}
+
 			// get the pointer to the subsystem.  Check it's current hits against it's max hits, and
 			// set the strength to the given percentage if current strength is > given percentage
 			ss = ship_get_indexed_subsys( shipp, index );
@@ -13777,6 +13778,7 @@ void sexp_repair_subsystem(int n)
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for repair subsystem\n", subsystem, shipp->ship_name));
 				continue;
 			}
+
 			// get the pointer to the subsystem.  Check it's current hits against it's max hits, and
 			// set the strength to the given percentage if current strength is < given percentage
 			ss = ship_get_indexed_subsys( shipp, index );
@@ -21644,7 +21646,7 @@ void sexp_subsys_set_random(int node)
 	for (idx=0; idx<Ship_info[shipp->ship_info_index].n_subsystems; idx++) {
 		if ( exclusion_list[idx] == 0 ) {
 			// get non excluded subsystem
-			subsys = ship_get_indexed_subsys(shipp, idx, nullptr);
+			subsys = ship_get_indexed_subsys(shipp, idx);
 			if (subsys == nullptr) {
 				nprintf(("Warning", "Nonexistent subsystem for index %d on ship %s for subsys set random\n", idx, shipp->ship_name));
 				continue;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13654,7 +13654,7 @@ void sexp_sabotage_subsystem(int n)
 		}
 		else {
 			do_loop = false;
-			index = ship_get_subsys_index(shipp, subsystem);
+			index = ship_find_subsys(shipp, subsystem);
 			if ( index == -1 ) {
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for sabotage subsystem\n", subsystem, shipp->ship_name));
 				continue;
@@ -13773,7 +13773,7 @@ void sexp_repair_subsystem(int n)
 		}
 		else {
 			do_loop = false;
-			index = ship_get_subsys_index(shipp, subsystem);
+			index = ship_find_subsys(shipp, subsystem);
 			if ( index == -1 ) {
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for repair subsystem\n", subsystem, shipp->ship_name));
 				continue;
@@ -13891,7 +13891,7 @@ void sexp_set_subsystem_strength(int n)
 		}
 		else {
 			do_loop = false;
-			index = ship_get_subsys_index(shipp, subsystem);
+			index = ship_find_subsys(shipp, subsystem);
 			if ( index == -1 ) {
 				nprintf(("Warning", "Couldn't find subsystem %s on ship %s for set subsystem strength\n", subsystem, shipp->ship_name));
 				continue;
@@ -21634,7 +21634,7 @@ void sexp_subsys_set_random(int node)
 
 	// get exclusion list
 	while( n != -1) {
-		int exclude_index = ship_get_subsys_index(shipp, CTEXT(n));
+		int exclude_index = ship_find_subsys(shipp, CTEXT(n));
 		if (exclude_index >= 0) {
 			exclusion_list[exclude_index] = 1;
 		}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13954,7 +13954,7 @@ void sexp_destroy_subsys_instantly(int n)
 
 					if (MULTIPLAYER_MASTER)
 					{
-						subsys_index = ship_get_subsys_index(shipp, ss);
+						subsys_index = ship_get_subsys_index(ss);
 						Assert(subsys_index >= 0);
 						Current_sexp_network_packet.send_int(subsys_index);
 					}
@@ -13977,7 +13977,7 @@ void sexp_destroy_subsys_instantly(int n)
 
 			if (MULTIPLAYER_MASTER)
 			{
-				subsys_index = ship_get_subsys_index(shipp, ss);
+				subsys_index = ship_get_subsys_index(ss);
 				Assert(subsys_index >= 0);
 				Current_sexp_network_packet.send_int(subsys_index);
 			}

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -344,7 +344,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Order, "subsystem", "Target subsystem of the orde
 					set_target_objnum(aip, OBJ_INDEX(objp));
 				}
 			}
-			ohp->aigp->ai_submode = ship_get_subsys_index( &Ships[objp->instance], newh->ss->system_info->subobj_name );
+			ohp->aigp->ai_submode = ship_find_subsys( &Ships[objp->instance], newh->ss->system_info->subobj_name );
 			if(ohp->odx == 0) {
 				set_targeted_subsys(aip, newh->ss, OBJ_INDEX(objp));
 			}

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1230,7 +1230,7 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 			{
 				ai_mode = AI_GOAL_DESTROY_SUBSYSTEM;
 				ai_shipname = Ships[tgh->objp->instance].ship_name;
-				ai_submode = ship_get_subsys_index( &Ships[tgsh->objp->instance], tgsh->ss->system_info->subobj_name );
+				ai_submode = ship_find_subsys( &Ships[tgsh->objp->instance], tgsh->ss->system_info->subobj_name );
 			}
 			else if(tgh_valid && tgh->objp->type == OBJ_WEAPON)
 			{

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13877,7 +13877,7 @@ ship_subsys *ship_get_best_subsys_to_attack(ship *sp, int subsys_type, vec3d *at
  *                 to select the best subsystem to attack of that type (using line-of-sight)
  *                 and based on the number of ships already attacking the subsystem
  */
-ship_subsys *ship_get_first_subsys(ship *sp, int subsys_type, vec3d *attacker_pos)
+ship_subsys *ship_find_first_subsys(ship *sp, int subsys_type, vec3d *attacker_pos)
 {
 	Assertion(subsys_type > SUBSYSTEM_NONE && subsys_type < SUBSYSTEM_MAX, "Subsys_type %d must refer to a valid subsystem type!", subsys_type);
 
@@ -13919,14 +13919,14 @@ void ship_index_subsystems(ship *shipp)
 		// normal indexing to valid subsystems
 		if (ss != END_OF_LIST(&shipp->subsys_list))
 		{
-			shipp->subsys_list_indexer.get()[index] = ss;
+			shipp->subsys_list_indexer[index] = ss;
 			ss->parent_subsys_index = index;
 			ss = GET_NEXT(ss);
 		}
 		// in the event we run out of subsystems (i.e. if not all subsystems were linked)
 		else
 		{
-			shipp->subsys_list_indexer.get()[index] = nullptr;
+			shipp->subsys_list_indexer[index] = nullptr;
 		}
 	}
 
@@ -13945,7 +13945,7 @@ ship_subsys *ship_get_indexed_subsys(ship *sp, int index)
 	if (!sp->flags[Ship::Ship_Flags::Subsystem_cache_valid])
 		ship_index_subsystems(sp);
 
-	return sp->subsys_list_indexer.get()[index];
+	return sp->subsys_list_indexer[index];
 }
 
 /**
@@ -13967,7 +13967,7 @@ int ship_get_subsys_index(ship_subsys *subsys)
 /**
  * Searches for the subsystem with the given name in the ship's linked list of subsystems, and returns its index or -1 if not found.
  */
-int ship_get_subsys_index(ship *sp, const char *ss_name)
+int ship_find_subsys(ship *sp, const char *ss_name)
 {
 	int count;
 	ship_subsys *ss;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13953,6 +13953,7 @@ ship_subsys *ship_get_indexed_subsys(ship *sp, int index)
 */
 int ship_get_subsys_index(ship_subsys *subsys)
 {
+	Assertion(subsys != nullptr, "ship_get_subsys_index was called with a null ship_subsys parameter!");
 	if (subsys == nullptr)
 		return -1;
 
@@ -13961,6 +13962,7 @@ int ship_get_subsys_index(ship_subsys *subsys)
 	if (!sp->flags[Ship::Ship_Flags::Subsystem_cache_valid])
 		ship_index_subsystems(sp);
 
+	Assertion(subsys->parent_subsys_index >= 0, "Somehow a subsystem could not be found in its parent ship %s's subsystem list!", sp->ship_name);
 	return subsys->parent_subsys_index;
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6973,6 +6973,7 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 	// for each subsystem, get a new ship_subsys instance and set up the pointers and other values
 	list_init ( &shipp->subsys_list );								// initialize the ship's list of subsystems
 	shipp->subsys_list_indexer.reset();
+	shipp->flags.remove(Ship::Ship_Flags::Subsystem_cache_valid);
 
 	// make sure to have allocated the number of subsystems we require
 	if (!ship_allocate_subsystems( sinfo->n_subsystems )) {
@@ -7670,6 +7671,7 @@ static void ship_subsystems_delete(ship *shipp)
 		}
 
 		shipp->subsys_list_indexer.reset();
+		shipp->flags.remove(Ship::Ship_Flags::Subsystem_cache_valid);
 	}
 }
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1707,11 +1707,12 @@ extern int ship_find_num_turrets(object *objp);
 
 extern void compute_slew_matrix(matrix *orient, angles *a);
 extern void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew = true, bool from_origin = false);		// returns in eye the correct viewing position for the given object
-//extern camid ship_get_followtarget_eye(object *obj);
+
 extern ship_subsys *ship_get_first_subsys(ship *sp, int subsys_type, vec3d *attacker_pos = nullptr);
 extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns index'th subsystem of this ship
 extern int ship_get_subsys_index(ship *sp, const char *ss_name);		// returns numerical index in linked list of subsystems
 extern int ship_get_subsys_index(ship_subsys *subsys);
+
 extern float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check = false );
 extern ship_subsys *ship_get_subsys(const ship *shipp, const char *subsys_name);
 extern int ship_get_num_subsys(ship *shipp);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -338,6 +338,7 @@ public:
 	model_subsystem *system_info;					// pointer to static data for this subsystem -- see model.h for definition
 
 	int			parent_objnum;						// objnum of the parent ship
+	int			parent_subsys_index;				// index of this subsystem in the parent ship's linked list
 
 	char		sub_name[NAME_LENGTH];					//WMC - Name that overrides name of original
 	float		current_hits;							// current number of hits this subsystem has left.
@@ -1709,9 +1710,8 @@ extern void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool 
 //extern camid ship_get_followtarget_eye(object *obj);
 extern ship_subsys *ship_get_first_subsys(ship *sp, int subsys_type, vec3d *attacker_pos = nullptr);
 extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns index'th subsystem of this ship
-extern int ship_get_index_from_subsys(ship_subsys *ssp, int objnum);
-extern int ship_get_subsys_index(ship *sp, const char* ss_name);		// returns numerical index in linked list of subsystems
-extern int ship_get_subsys_index(ship *shipp, ship_subsys *subsys);
+extern int ship_get_subsys_index(ship *sp, const char *ss_name);		// returns numerical index in linked list of subsystems
+extern int ship_get_subsys_index(ship_subsys *subsys);
 extern float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check = false );
 extern ship_subsys *ship_get_subsys(const ship *shipp, const char *subsys_name);
 extern int ship_get_num_subsys(ship *shipp);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -609,6 +609,7 @@ public:
 	// types of subsystems.  (i.e. the list might contain 3 engines.  There will be one subsys_info entry
 	// describing the state of all engines combined) -- MWA 4/1/97
 	ship_subsys	subsys_list;									//	linked list of subsystems for this ship.
+	std::unique_ptr<ship_subsys*> subsys_list_indexer;			//	provides random-access lookup to the linked list
 	ship_subsys	*last_targeted_subobject[MAX_PLAYERS];	// Last subobject that has been targeted.  NULL if none;(player specific)
 	ship_subsys_info	subsys_info[SUBSYSTEM_MAX];		// info on particular generic types of subsystems	
 
@@ -1706,7 +1707,8 @@ extern int ship_find_num_turrets(object *objp);
 extern void compute_slew_matrix(matrix *orient, angles *a);
 extern void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew = true, bool from_origin = false);		// returns in eye the correct viewing position for the given object
 //extern camid ship_get_followtarget_eye(object *obj);
-extern ship_subsys *ship_get_indexed_subsys( ship *sp, int index, vec3d *attacker_pos = NULL );	// returns index'th subsystem of this ship
+extern ship_subsys *ship_get_first_subsys(ship *sp, int subsys_type, vec3d *attacker_pos = nullptr);
+extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns index'th subsystem of this ship
 extern int ship_get_index_from_subsys(ship_subsys *ssp, int objnum);
 extern int ship_get_subsys_index(ship *sp, const char* ss_name);		// returns numerical index in linked list of subsystems
 extern int ship_get_subsys_index(ship *shipp, ship_subsys *subsys);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -610,7 +610,7 @@ public:
 	// types of subsystems.  (i.e. the list might contain 3 engines.  There will be one subsys_info entry
 	// describing the state of all engines combined) -- MWA 4/1/97
 	ship_subsys	subsys_list;									//	linked list of subsystems for this ship.
-	std::unique_ptr<ship_subsys*> subsys_list_indexer;			//	provides random-access lookup to the linked list
+	std::unique_ptr<ship_subsys*[]> subsys_list_indexer;		//	provides random-access lookup to the linked list
 	ship_subsys	*last_targeted_subobject[MAX_PLAYERS];	// Last subobject that has been targeted.  NULL if none;(player specific)
 	ship_subsys_info	subsys_info[SUBSYSTEM_MAX];		// info on particular generic types of subsystems	
 
@@ -1708,9 +1708,9 @@ extern int ship_find_num_turrets(object *objp);
 extern void compute_slew_matrix(matrix *orient, angles *a);
 extern void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew = true, bool from_origin = false);		// returns in eye the correct viewing position for the given object
 
-extern ship_subsys *ship_get_first_subsys(ship *sp, int subsys_type, vec3d *attacker_pos = nullptr);
+extern ship_subsys *ship_find_first_subsys(ship *sp, int subsys_type, vec3d *attacker_pos = nullptr);
 extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns index'th subsystem of this ship
-extern int ship_get_subsys_index(ship *sp, const char *ss_name);		// returns numerical index in linked list of subsystems
+extern int ship_find_subsys(ship *sp, const char *ss_name);		// returns numerical index in linked list of subsystems
 extern int ship_get_subsys_index(ship_subsys *subsys);
 
 extern float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check = false );

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -132,6 +132,7 @@ namespace Ship {
 		Same_departure_warp_when_docked,	// Goober5000
 		Fail_sound_locked_primary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
 		Fail_sound_locked_secondary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
+		Subsystem_cache_valid,		// Goober5000 - whether the subsystem list index caches can be used
 
 		NUM_VALUES
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -215,7 +215,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 	if ( MULTIPLAYER_MASTER ) {
 		int index;
 
-		index = ship_get_index_from_subsys(subsys, ship_p->objnum);
+		index = ship_get_subsys_index(subsys);
 		
 		vec3d hit;
 		if (hitpos) {

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -3579,7 +3579,7 @@ char *error_check_initial_orders(ai_goal *goals, int ship, int wing)
 		switch (goals[i].ai_mode) {
 			case AI_GOAL_DESTROY_SUBSYSTEM:
 				Assert(flag == 2 && inst >= 0);
-				if (ship_get_subsys_index(&Ships[inst], goals[i].docker.name) < 0)
+				if (ship_find_subsys(&Ships[inst], goals[i].docker.name) < 0)
 					return "Unknown subsystem type";
 
 				break;

--- a/fred2/shipgoalsdlg.cpp
+++ b/fred2/shipgoalsdlg.cpp
@@ -476,7 +476,7 @@ void ShipGoalsDlg::initialize(ai_goal *goals, int ship)
 			case AI_GOAL_DESTROY_SUBSYSTEM:
 				num = ship_name_lookup(goalp[item].target_name, 1);
 				if (num != -1)
-					m_subsys[item] = ship_get_subsys_index(&Ships[num], goalp[item].docker.name);
+					m_subsys[item] = ship_find_subsys(&Ships[num], goalp[item].docker.name);
 
 				break;
 

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -2770,7 +2770,7 @@ const char* Editor::error_check_initial_orders(ai_goal* goals, int ship, int win
 		switch (goals[i].ai_mode) {
 		case AI_GOAL_DESTROY_SUBSYSTEM:
 			Assert(flag == 2 && inst >= 0);
-			if (ship_get_subsys_index(&Ships[inst], goals[i].docker.name) < 0)
+			if (ship_find_subsys(&Ships[inst], goals[i].docker.name) < 0)
 				return "Unknown subsystem type";
 
 			break;

--- a/qtfred/src/mission/dialogs/ShipGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipGoalsDialogModel.cpp
@@ -442,7 +442,7 @@ namespace fso {
 					case AI_GOAL_DESTROY_SUBSYSTEM:
 						num = ship_name_lookup(goalp[item].target_name, 1);
 						if (num != -1)
-							m_subsys[item] = ship_get_subsys_index(&Ships[num], goalp[item].docker.name);
+							m_subsys[item] = ship_find_subsys(&Ships[num], goalp[item].docker.name);
 
 						break;
 


### PR DESCRIPTION
Add indexing caches to ships and subsystems, moving both subsystem-to-index and index-to-subsystem lookup from O(n) to O(1).  These lookups appear in many places and often run for multiple ships, multiple times per frame.  This should improve performance by a small but measurable amount, as @EatThePath said:
> I faintly recall seeing that function lurking not too far down the list in performance profiles, though not high enough to really be my focus
