### PR TITLE
fix a bunch of graphics functions to respect GR_STUB

### DIFF
--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -293,6 +293,11 @@ float smoothstep(float edge0, float edge1, float x) {
 namespace decals {
 
 void initialize() {
+	if (gr_screen.mode == GR_STUB) {
+		Decal_system_active = false;
+		return;
+	}
+
 	DecalDefinitions.clear();
 	graphics::decal_draw_list::globalInit();
 

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -205,6 +205,10 @@ static void pre_render_init_lights() {
 }
 
 void gr_set_light(light* fs_light) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	// init the light
 	gr_light grl;
 	FSLight2GLLight(fs_light, &grl);
@@ -213,6 +217,10 @@ void gr_set_light(light* fs_light) {
 }
 
 void gr_set_center_alpha(int type) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if (!type) {
 		return;
 	}
@@ -275,11 +283,19 @@ void gr_set_center_alpha(int type) {
 }
 
 void gr_reset_lighting() {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	gr_lights.clear();
 	Num_active_gr_lights = 0;
 }
 
 void gr_calculate_ambient_factor(int ambient_factor) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	gr_user_ambient = (float) ((ambient_factor * 2) - 255) / 255.0f;
 }
 
@@ -288,6 +304,10 @@ void gr_light_shutdown() {
 }
 
 void gr_light_init() {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	gr_calculate_ambient_factor();
 
 	// allocate memory for enabled lights
@@ -295,6 +315,9 @@ void gr_light_init() {
 }
 
 void gr_set_lighting() {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
 
 	//Valathil: Sort lights by priority
 	extern bool Deferred_lighting;
@@ -326,6 +349,10 @@ void gr_set_lighting() {
 }
 
 void gr_set_ambient_light(int red, int green, int blue) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	gr_light_ambient[0] = i2fl(red) / 255.0f;
 	gr_light_ambient[1] = i2fl(green) / 255.0f;
 	gr_light_ambient[2] = i2fl(blue) / 255.0f;
@@ -335,6 +362,10 @@ void gr_set_ambient_light(int red, int green, int blue) {
 }
 
 void gr_lighting_fill_uniforms(void* data_out, size_t buffer_size) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	Assertion(sizeof(gr_light_uniforms) <= buffer_size, "Insufficient buffer supplied.");
 
 	memcpy(reinterpret_cast<graphics::model_light*>(data_out), gr_light_uniforms, sizeof(gr_light_uniforms));

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -209,6 +209,10 @@ void PostProcessingManager::setBloomShadersOk(bool ok)
 
 bool gr_lightshafts_enabled()
 {
+	if (gr_screen.mode == GR_STUB) {
+		return false;
+	}
+
 	// supernova glare should disable lightshafts
 	if (supernova_stage() >= SUPERNOVA_STAGE::CLOSE) {
 		return false;
@@ -227,6 +231,10 @@ bool gr_lightshafts_enabled()
 
 int gr_bloom_intensity()
 {
+	if (gr_screen.mode == GR_STUB) {
+		return 0;
+	}
+
 	if (graphics::Post_processing_manager == nullptr || !graphics::Post_processing_manager->bloomShadersOk()) {
 		return 0;
 	}
@@ -240,6 +248,10 @@ int gr_bloom_intensity()
 
 void gr_set_bloom_intensity(int intensity)
 {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if (Using_in_game_options) {
 		graphics::Post_processing_bloom_intensity = intensity;
 	} else {

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -708,11 +708,11 @@ static void gr_string_old(float sx,
 namespace {
 bool buffering_nanovg = false; //!< flag for when NanoVG buffering is enabled
 
-static void setupDrawingState(graphics::paths::PathRenderer* path) {
+void setupDrawingState(graphics::paths::PathRenderer* path) {
 	path->resetState();
 }
 
-static void setupTransforms(graphics::paths::PathRenderer* path, int resize_mode) {
+void setupTransforms(graphics::paths::PathRenderer* path, int resize_mode) {
 	float x = 0.0f;
 	float y = 0.0f;
 	float w = 1.0f;
@@ -739,7 +739,7 @@ static void setupTransforms(graphics::paths::PathRenderer* path, int resize_mode
 	path->scissor(0.0f, 0.0f, i2fl(clip_width), i2fl(clip_height));
 }
 
-static graphics::paths::PathRenderer* beginDrawing(int resize_mode) {
+graphics::paths::PathRenderer* beginDrawing(int resize_mode) {
 	auto path = graphics::paths::PathRenderer::instance();
 
 	path->saveState();
@@ -758,7 +758,7 @@ static graphics::paths::PathRenderer* beginDrawing(int resize_mode) {
 	return path;
 }
 
-static void endDrawing(graphics::paths::PathRenderer* path) {
+void endDrawing(graphics::paths::PathRenderer* path) {
 	if (!buffering_nanovg) {
 		// If buffering is enabled then this will be called later
 		path->endFrame();

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -46,6 +46,10 @@ static void gr_flash_internal(int r, int g, int b, int a, bool alpha_flash)
 }
 
 void gr_flash(int r, int g, int b) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if (!(r || g || b)) {
 		return;
 	}
@@ -54,6 +58,10 @@ void gr_flash(int r, int g, int b) {
 }
 
 void gr_flash_alpha(int r, int g, int b, int a) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if (!(r || g || b || a)) {
 		return;
 	}
@@ -152,6 +160,10 @@ static void bitmap_ex_internal(int x,
 }
 
 void gr_aabitmap(int x, int y, int resize_mode, bool mirror) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	GR_DEBUG_SCOPE("Draw AA-bitmap");
 
 	int w, h, do_resize;
@@ -222,6 +234,10 @@ void gr_aabitmap(int x, int y, int resize_mode, bool mirror) {
 					   &gr_screen.current_color);
 }
 void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode, bool mirror) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 
 	int reclip;
 #ifndef NDEBUG
@@ -349,6 +365,10 @@ void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode,
 }
 //these are penguins bitmap functions
 void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	int reclip;
 #ifndef NDEBUG
 	int count = 0;
@@ -688,11 +708,11 @@ static void gr_string_old(float sx,
 namespace {
 bool buffering_nanovg = false; //!< flag for when NanoVG buffering is enabled
 
-void setupDrawingState(graphics::paths::PathRenderer* path) {
+static void setupDrawingState(graphics::paths::PathRenderer* path) {
 	path->resetState();
 }
 
-void setupTransforms(graphics::paths::PathRenderer* path, int resize_mode) {
+static void setupTransforms(graphics::paths::PathRenderer* path, int resize_mode) {
 	float x = 0.0f;
 	float y = 0.0f;
 	float w = 1.0f;
@@ -719,7 +739,7 @@ void setupTransforms(graphics::paths::PathRenderer* path, int resize_mode) {
 	path->scissor(0.0f, 0.0f, i2fl(clip_width), i2fl(clip_height));
 }
 
-graphics::paths::PathRenderer* beginDrawing(int resize_mode) {
+static graphics::paths::PathRenderer* beginDrawing(int resize_mode) {
 	auto path = graphics::paths::PathRenderer::instance();
 
 	path->saveState();
@@ -738,7 +758,7 @@ graphics::paths::PathRenderer* beginDrawing(int resize_mode) {
 	return path;
 }
 
-void endDrawing(graphics::paths::PathRenderer* path) {
+static void endDrawing(graphics::paths::PathRenderer* path) {
 	if (!buffering_nanovg) {
 		// If buffering is enabled then this will be called later
 		path->endFrame();
@@ -748,6 +768,10 @@ void endDrawing(graphics::paths::PathRenderer* path) {
 }
 
 void gr_string(float sx, float sy, const char* s, int resize_mode, int in_length) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	GR_DEBUG_SCOPE("Render string");
 
 	using namespace font;
@@ -917,10 +941,18 @@ static void gr_line(float x1, float y1, float x2, float y2, int resize_mode) {
 }
 
 void gr_line(int x1, int y1, int x2, int y2, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	gr_line(i2fl(x1), i2fl(y1), i2fl(x2), i2fl(y2), resize_mode);
 }
 
 void gr_aaline(vertex* v1, vertex* v2) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	float x1 = v1->screen.xyw.x;
 	float y1 = v1->screen.xyw.y;
 	float x2 = v2->screen.xyw.x;
@@ -931,6 +963,10 @@ void gr_aaline(vertex* v1, vertex* v2) {
 }
 
 void gr_gradient(int x1, int y1, int x2, int y2, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if (!gr_screen.current_color.is_alphacolor) {
 		gr_line(x1, y1, x2, y2, resize_mode);
 		return;
@@ -953,10 +989,18 @@ void gr_gradient(int x1, int y1, int x2, int y2, int resize_mode) {
 	endDrawing(path);
 }
 void gr_pixel(int x, int y, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	gr_line(x, y, x, y, resize_mode);
 }
 
 void gr_circle(int xc, int yc, int d, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	auto path = beginDrawing(resize_mode);
 
 	path->circle(i2fl(xc), i2fl(yc), d / 2.0f);
@@ -966,6 +1010,10 @@ void gr_circle(int xc, int yc, int d, int resize_mode) {
 	endDrawing(path);
 }
 void gr_unfilled_circle(int xc, int yc, int d, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	auto path = beginDrawing(resize_mode);
 
 	path->circle(i2fl(xc), i2fl(yc), d / 2.0f);
@@ -975,6 +1023,10 @@ void gr_unfilled_circle(int xc, int yc, int d, int resize_mode) {
 	endDrawing(path);
 }
 void gr_arc(int xc, int yc, float r, float angle_start, float angle_end, bool fill, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	// Ensure that angle_start < angle_end
 	if (angle_end < angle_start) {
 		float temp = angle_start;
@@ -1001,6 +1053,10 @@ void gr_arc(int xc, int yc, float r, float angle_start, float angle_end, bool fi
 	endDrawing(path);
 }
 void gr_curve(int xc, int yc, int r, int direction, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	using namespace graphics::paths;
 
 	auto path = beginDrawing(resize_mode);
@@ -1048,6 +1104,10 @@ void gr_curve(int xc, int yc, int r, int direction, int resize_mode) {
 }
 
 void gr_rect(int x, int y, int w, int h, int resize_mode, float angle) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	auto path = beginDrawing(resize_mode);
 	if (angle != 0) {
 		// If we don't do this translation before and after rotating, the rotation will use 0,0 as the pivot, flinging the rectangle far away. 
@@ -1065,6 +1125,10 @@ void gr_rect(int x, int y, int w, int h, int resize_mode, float angle) {
 }
 
 void gr_shade(int x, int y, int w, int h, int resize_mode) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	auto r = (int) gr_screen.current_shader.r;
 	auto g = (int) gr_screen.current_shader.g;
 	auto b = (int) gr_screen.current_shader.b;
@@ -1083,6 +1147,10 @@ void gr_shade(int x, int y, int w, int h, int resize_mode) {
 }
 
 void gr_2d_start_buffer() {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	Assertion(!buffering_nanovg, "Tried to enable 2D buffering but it was already enabled!");
 
 	buffering_nanovg = true;
@@ -1092,6 +1160,10 @@ void gr_2d_start_buffer() {
 }
 
 void gr_2d_stop_buffer() {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	Assertion(buffering_nanovg, "Tried to stop 2D buffering but it was not enabled!");
 
 	buffering_nanovg = false;
@@ -1106,6 +1178,10 @@ static size_t immediate_buffer_size = 0;
 static const int IMMEDIATE_BUFFER_RESIZE_BLOCK_SIZE = 2048;
 
 size_t gr_add_to_immediate_buffer(size_t size, void* data) {
+	if (gr_screen.mode == GR_STUB) {
+		return 0;
+	}
+
 	GR_DEBUG_SCOPE("Add data to immediate buffer");
 
 	if (!gr_immediate_buffer_handle.isValid()) {
@@ -1132,6 +1208,10 @@ size_t gr_add_to_immediate_buffer(size_t size, void* data) {
 	return old_offset;
 }
 void gr_reset_immediate_buffer() {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if (!gr_immediate_buffer_handle.isValid()) {
 		// we haven't used the immediate buffer yet
 		return;
@@ -1150,6 +1230,10 @@ void gr_render_primitives_immediate(material* material_info,
 									int n_verts,
 									void* data,
 									size_t size) {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	auto offset = gr_add_to_immediate_buffer(size, data);
 
 	gr_render_primitives(material_info, prim_type, layout, 0, n_verts, gr_immediate_buffer_handle, offset);
@@ -1162,6 +1246,10 @@ void gr_render_primitives_2d_immediate(material* material_info,
 	void* data,
 	size_t size)
 {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	gr_set_2d_matrix();
 
 	gr_render_primitives_immediate(material_info, prim_type, layout, n_verts, data, size);
@@ -1315,6 +1403,10 @@ static void draw_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode, 
 
 void gr_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode, float angle)
 {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	material mat_params;
 	material_set_interface(&mat_params,
 		gr_screen.current_bitmap,
@@ -1326,6 +1418,10 @@ void gr_bitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode, float ang
 
 void gr_aabitmap_list(bitmap_rect_list* list, int n_bm, int resize_mode, float angle)
 {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	material render_mat;
 	render_mat.set_blend_mode(ALPHA_BLEND_ALPHA_BLEND_ALPHA);
 	render_mat.set_depth_mode(ZBUFFER_TYPE_NONE);

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -418,6 +418,10 @@ void shadows_end_render()
 
 void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos)
 {
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	GR_DEBUG_SCOPE("Render shadows");
 	TRACE_SCOPE(tracing::BuildShadowMap);
 

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -833,6 +833,10 @@ void stars_post_level_init()
 	float dist, dist_max;
 	ubyte red,green,blue,alpha;
 
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	// in FRED, make sure we always have at least one background
 	if (Fred_running)
 	{
@@ -1149,6 +1153,10 @@ void stars_draw_sun(int show_sun)
 	starfield_bitmap *bm;
 	float local_scale;
 
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	// should we even be here?
 	if (!show_sun)
 		return;
@@ -1233,6 +1241,10 @@ void stars_draw_lens_flare(vertex *sun_vex, int sun_n)
 	float dx,dy;
 	vertex flare_vex = *sun_vex; //copy over to flare_vex to get all sorts of properties
 
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	Assert( sun_n < (int)Suns.size() );
 
 	if ( (sun_n >= (int)Suns.size()) || (sun_n < 0) ) {
@@ -1284,6 +1296,10 @@ void stars_draw_sun_glow(int sun_n)
 	vec3d sun_pos, sun_dir;
 	vertex sun_vex;	
 	float local_scale;
+
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
 
 	// sanity
 	//WMC - Dunno why this is getting hit...
@@ -1357,6 +1373,10 @@ void stars_draw_bitmaps(int show_bitmaps)
 
 	int idx;
 	int star_index;
+
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
 
 	// should we even be here?
 	if ( !show_bitmaps )
@@ -1483,6 +1503,10 @@ DCF(subspace_set,"Set parameters for subspace effect")
 void subspace_render()
 {
 	int framenum = 0;
+
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
 
 	if ( Subspace_model_inner < 0 )	{
 		Subspace_model_inner = model_load( "subspace_small.pof", 0, nullptr );
@@ -1622,6 +1646,10 @@ void stars_draw_stars()
 	vertex p1, p2;
 	int can_draw = 1;
 
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if ( !last_stars_filled ) {
 		for (i = 0; i < Num_stars; i++) {
 			g3_rotate_faraway_vertex(&p2, &Stars[i].pos);
@@ -1721,6 +1749,10 @@ void stars_draw_motion_debris()
 	GR_DEBUG_SCOPE("Draw motion debris");
 	TRACE_SCOPE(tracing::DrawMotionDebris);
 
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if (Motion_debris_override)
 		return;
 
@@ -1779,6 +1811,10 @@ void stars_draw(int show_stars, int show_suns, int  /*show_nebulas*/, int show_s
 {
 	GR_DEBUG_SCOPE("Draw Stars");
 	TRACE_SCOPE(tracing::DrawStars);
+
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
 
 	int gr_zbuffering_save = gr_zbuffer_get();
 	gr_zbuffer_set(GR_ZBUFF_NONE);
@@ -1902,6 +1938,10 @@ void stars_page_in()
 	int idx, i;
 	starfield_bitmap_instance *sbi;
 	starfield_bitmap *sb;
+
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
 
 	// Initialize the subspace stuff
 
@@ -2151,6 +2191,10 @@ void stars_draw_background()
 	GR_DEBUG_SCOPE("Draw Background");
 	TRACE_SCOPE(tracing::DrawBackground);
 
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
+
 	if (Nmodel_num < 0)
 		return;
 
@@ -2172,6 +2216,10 @@ void stars_set_background_model(const char *model_name, const char *texture_name
 {
 	int new_model = -1;
 	int new_bitmap = -1;
+
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
 
 	if (model_name != nullptr && *model_name != '\0') {
 		new_model = model_load(model_name, 0, nullptr, -1);
@@ -2870,6 +2918,10 @@ void stars_setup_environment_mapping(camid cid) {
 	extern float View_zoom;
 	float old_zoom = View_zoom, new_zoom = 1.0f;//0.925f;
 	int i = 0;
+
+	if (gr_screen.mode == GR_STUB) {
+		return;
+	}
 
 	if(!cid.isValid())
 		return;


### PR DESCRIPTION
More work trying to make all of the newer graphics code play nice with stub graphics used by the standalone server. This is part one of the changes, which should address all of the weird graphics related crashes we've found so far while testing standalones.