### PR TITLE
Remove pointless assertion in mission parsing.

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3163,7 +3163,6 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	p_objp->escort_priority = 0;
     if (optional_string("+Escort Priority:"))
     {
-        Assert(p_objp->flags[Mission::Parse_Object_Flags::SF_Escort]);
         stuff_int(&p_objp->escort_priority);
     }
 


### PR DESCRIPTION
When parsing escort priority, FSO asserts that the escort flag is set, but this assertion is only valid in missions output by FRED; it's fairly trivial to use notepad to remove the flag without removing escort priority, thereby triggering the assertion. Furthermore, there doesn't actually seem to be a problem if a parse object has an escort priority without the escort flag; the engine won't actually use the priority until/unless the ship is manually added to the escort list, and then it doesn't matter that one is set.