### PR TITLE
Add release CI config for Mac

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -310,11 +310,104 @@ jobs:
             ${{ steps.generate_package.outputs.package_path }}
             ${{ steps.generate_package.outputs.debug_path }}
 
+  build_mac:
+    strategy:
+      matrix:
+        configuration: [FastDebug, Release]
+        compiler: [clang]
+        arch: [x86_64]
+    name: Mac
+    needs: create_release
+    runs-on: macos-latest
+    steps:
+      - name: Cache Qt
+        id: cache-qt-mac
+        uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/../Qt
+          key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2
+        with:
+          version: ${{ env.QT_VERSION }}
+          dir: ${{ github.workspace }}/..
+          cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
+          setup-python: 'false'
+          aqtversion: ==1.1.3
+
+      - uses: actions/checkout@v1
+        name: Checkout
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Configure CMake
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          COMPILER: ${{ matrix.compiler }}
+          ARCHITECTURE: ${{ matrix.arch }}
+          JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
+        run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
+      - name: Compile
+        working-directory: ./build
+        run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja all
+      - name: Run Tests
+        working-directory: ./build
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          XDG_RUNTIME_DIR: /root
+        run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
+      - name: Package build result
+        working-directory: ./build
+        run: cd bin && tar -cvzf macos-build.tar *.app
+      - name: Upload build result
+        uses: actions/upload-artifact@v2
+        with:
+          name: mac-${{ matrix.configuration }}
+          path: ${{ github.workspace }}/build/bin/macos-build.tar
+  mac_zip:
+    name: Build Mac distribution zip
+    needs: build_mac
+    runs-on: ubuntu-latest
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout
+        with:
+          submodules: true
+          fetch-depth: '0'
+          ref: '${{ github.ref }}'
+      - name: Download Release builds
+        uses: actions/download-artifact@v2
+        with:
+          name: mac-Release
+          path: builds
+      - name: Download FastDebug builds
+        uses: actions/download-artifact@v2
+        with:
+          name: mac-FastDebug
+          path: builds
+      - name: Create Distribution package
+        id: generate_package
+        working-directory: ./builds
+        run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac
+      - name: Upload result package
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.generate_package.outputs.package_name }}
+          path: ${{ steps.generate_package.outputs.package_path }}
+      - name: Publish result package
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: ${{ steps.generate_package.outputs.package_path }}
+
   post_build:
     name: Post builds to Nebula and Forum
-    needs: [linux_zip, windows_zip]
+    needs: [linux_zip, windows_zip, mac_zip]
     uses: ./.github/workflows/post-build-release.yaml
     with:
       linux_result: ${{ needs.linux_zip.result }}
       windows_result: ${{ needs.windows_zip.result }}
+      mac_result: ${{ needs.mac_zip.result }}
       releaseTag: ${{ github.ref_name }}

--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -10,6 +10,9 @@ on:
       windows_result: # job.result
         required: true
         type: string
+      mac_result: # job.result
+        required: true
+        type: string
       releaseTag:
         required: true
         type: string
@@ -55,6 +58,7 @@ jobs:
         env:
           LINUX_RESULT: ${{ inputs.linux_result }}
           WINDOWS_RESULT: ${{ inputs.windows_result }}
+          MAC_RESULT: ${{ inputs.mac_result }}
         run: python ci/post/main.py release
 
       - name: Post Builds (Manual trigger)
@@ -63,6 +67,7 @@ jobs:
         env:
           LINUX_RESULT: success
           WINDOWS_RESULT: success
+          MAC_RESULT: success
         run: |
           echo "releaseTag= ${{ env.RELEASE_TAG }}"
           echo "repository= ${{ github.repository }}"


### PR DESCRIPTION
Adds release CI config for Mac. Note: this only adds enough to build and upload Mac artifacts to the Github release, but it doesn't change anything in the Python scripts that upload to Nebula and forums. That'd be a separate PR, also I'm not familiar with all that code so far.