### PR TITLE
Add option to expand warning on unbound keys

### DIFF
--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -658,7 +658,8 @@ SCP_string message_translate_tokens(const char *text)
 				ptr = translate_key(temp);  // try and translate key
 				if (ptr != nullptr) {  // was key translated properly?
 					if (!stricmp(ptr, NOX("none")) && (Training_bind_warning != Missiontime)) {
-						if ( The_mission.game_type & MISSION_TYPE_TRAINING ) {
+						// check if a warning message should be displayed if the key is unbound
+						if ( (The_mission.game_type & MISSION_TYPE_TRAINING) || (Always_warn_player_about_unbound_keys & MISSION_TYPE_SINGLE) ) {
 							r = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, XSTR( "&Bind Control", 424), XSTR( "&Abort mission", 425),
 								XSTR( "Warning\nYou have no control bound to the action \"%s\".  You must do so before you can continue with your training.", 426),
 								XSTR(Control_config[Failed_key_index].text.c_str(), CONTROL_CONFIG_XSTR + Failed_key_index));

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -91,6 +91,7 @@ bool Supernova_hits_at_zero;
 bool Show_subtitle_uses_pixels;
 int Show_subtitle_screen_base_res[2];
 int Show_subtitle_screen_adjusted_res[2];
+bool Always_warn_player_about_unbound_keys;
 
 void mod_table_set_version_flags();
 
@@ -266,6 +267,10 @@ void parse_mod_table(const char *filename)
 			} else {
 				mprintf(("Game Settings Table: HUD timer will reach %.2f when the supernova shockwave hits the player\n", SUPERNOVA_HIT_TIME));
 			}
+		}
+
+		if (optional_string("$Always warn player about unbound keys used in Directives Gauge:")) {
+			stuff_boolean(&Always_warn_player_about_unbound_keys);
 		}
 
 		optional_string("#SEXP SETTINGS");
@@ -915,6 +920,7 @@ void mod_table_reset()
 	Show_subtitle_screen_base_res[1] = -1;
 	Show_subtitle_screen_adjusted_res[0] = -1;
 	Show_subtitle_screen_adjusted_res[1] = -1;
+	Always_warn_player_about_unbound_keys = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -80,6 +80,7 @@ extern bool Supernova_hits_at_zero;
 extern bool Show_subtitle_uses_pixels;
 extern int Show_subtitle_screen_base_res[];
 extern int Show_subtitle_screen_adjusted_res[];
+extern bool Always_warn_player_about_unbound_keys;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
In Training missions, the game will check if keys used in directives are bound or unbound, and if unbound will display a message to the player to bind the key.

This is limited to only Training missions though, so this PR adds a `game_settings` option to allow modders to use that check in singleplayer mission types too, which is very useful for mods that rely on key presses in non-training missions. Also fixes #4340.