### PR TITLE
Add overload for timestamp_elapsed_safe

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -503,6 +503,17 @@ bool timestamp_elapsed_safe(int a, int b) {
 	return timestamp_ms() >= a || timestamp_ms() < (a - b + 100);
 }
 
+bool timestamp_elapsed_safe(TIMESTAMP a, int b) {
+	if (!a.isValid() || a.isNever()) {
+		return false;
+	}
+	if (a.isImmediate()) {
+		return true;
+	}
+
+	return timer_get_milliseconds() >= a.value() || timer_get_milliseconds() < (a.value() - b + 100);
+}
+
 bool ui_timestamp_elapsed_safe(UI_TIMESTAMP a, int b) {
 	if (!a.isValid() || a.isNever()) {
 		return false;

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -187,6 +187,7 @@ bool ui_timestamp_elapsed( UI_TIMESTAMP stamp );
 
 // safer version of timestamp
 bool timestamp_elapsed_safe(int a, int b);
+bool timestamp_elapsed_safe(TIMESTAMP a, int b);
 bool ui_timestamp_elapsed_safe(UI_TIMESTAMP a, int b);
 
 //=================================================================


### PR DESCRIPTION
Are we having fun yet?  A carbon copy of the new `ui_timestamp_elapsed_safe`