### PR TITLE
Add new ship flag Aspect_immune

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -624,7 +624,7 @@ void hud_do_lock_indicator(float frametime)
 	if ( !(wip->is_locked_homing()) ) {
 		hud_lock_reset();
 		return;		
-	}
+	} 
 
 	// Allow locking on ships and bombs (only targeted weapon allowed is a bomb, so don't bother checking flags)
 	if ( (Objects[Player_ai->target_objnum].type != OBJ_SHIP) && (Objects[Player_ai->target_objnum].type != OBJ_WEAPON) ) {	
@@ -1021,7 +1021,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			ship_clear_lock(lock_slot);
 			return;
 		}
-
+		
 		if ( !weapon_target_satisfies_lock_restrictions(wip, lock_slot->obj) ) {
 			ship_clear_lock(lock_slot);
 			return;
@@ -1089,7 +1089,7 @@ void hud_lock_determine_lock_target(lock_info *lock_slot, weapon_info *wip)
 			ship_clear_lock(lock_slot);
 			return;
 		}
-
+		
 		if ( !weapon_target_satisfies_lock_restrictions(wip, lock_slot->obj) ) {
 			ship_clear_lock(lock_slot);
 			return;
@@ -1550,6 +1550,13 @@ void hud_do_lock_indicators(float frametime)
 			ship_clear_lock(lock_slot);
 			continue;
 		}
+
+		//Target ship is protected from Aspect Locks. Since this flag can be given mid mission, we need to cut short a lock attempt.
+		if ( wip->is_locked_homing() && lock_slot->obj->type == OBJ_SHIP && Ships[lock_slot->obj->instance].flags[Ship::Ship_Flags::Aspect_immune] ) {
+			ship_clear_lock(lock_slot);
+			continue;
+		}
+		
 
 		// unless they've flagged the weapon otherwise, discard locks on dead subsystems that aren't the primary target
 		if ( !wip->wi_flags[Weapon::Info_Flags::Multilock_target_dead_subsys] && lock_slot->subsys != nullptr && Player_ai->targeted_subsys != lock_slot->subsys 

--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -105,6 +105,7 @@ namespace Mission {
 		OF_Attackable_if_no_collide, // Cyborg - keeps turrets from ignoring ships that have no_collide set
 		SF_Fail_sound_locked_primary, 	// Kiloku - Plays fail sound when firing with locked weapons
 		SF_Fail_sound_locked_secondary,	// Kiloku - Plays fail sound when firing with locked weapons
+		SF_Aspect_immune,				//Kiloku - Ship cannot be locked onto by aspect seeking weapons
 
 		NUM_VALUES
 	};

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -319,7 +319,8 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "same-departure-warp-when-docked",	Mission::Parse_Object_Flags::SF_Same_departure_warp_when_docked,	true, false },
     { "ai-attackable-if-no-collide",		Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
     { "fail-sound-locked-primary",			Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary, true, false },
-    { "fail-sound-locked-secondary",		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false }
+    { "fail-sound-locked-secondary",		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false },
+    { "aspect-immune",						Mission::Parse_Object_Flags::SF_Aspect_immune, true, false }
 };
 
 const size_t num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -35040,6 +35040,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"ai-attackable-if-no-collide - AI will still attack this ship even if collisions are disabled\r\n"
 		"fail-sound-locked-primary - This ship will play a weapon failure sound if trying to shoot primaries when they're locked\r\n"
 		"fail-sound-locked-secondary - This ship will play a weapon failure sound if trying to shoot secondaries when they're locked\r\n"
+		"aspect-immune - This ship cannot be locked onto by aspect seeking weapons\r\n"
 	},
 
 	{ OP_CANCEL_FUTURE_WAVES, "cancel-future-waves\r\n"

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -527,7 +527,8 @@ ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::Hide_mission_log,				"hide-in-mission-log" },
 	{ Ship_Flags::No_passive_lightning,			"no-ship-passive-lightning" },
 	{ Ship_Flags::Fail_sound_locked_primary, 	"fail-sound-locked-primary"},
-	{ Ship_Flags::Fail_sound_locked_secondary, 	"fail-sound-locked-secondary"}
+	{ Ship_Flags::Fail_sound_locked_secondary, 	"fail-sound-locked-secondary"},
+	{ Ship_Flags::Aspect_immune, 				"aspect-immune"}
 };
 
 static int Laser_energy_out_snd_timer;	// timer so we play out of laser sound effect periodically
@@ -15693,7 +15694,7 @@ static int ship_is_getting_locked(ship *shipp)
 		aip = &Ai_info[Ships[objp->instance].ai_index];
 
 		if ( aip->target_objnum == shipp->objnum ) {
-			if ( aip->aspect_locked_time > 0.1f ) {
+			if ( aip->aspect_locked_time > 0.1f && !shipp->flags[Ship::Ship_Flags::Aspect_immune]) {
 				float dist, wep_range;
 				dist = vm_vec_dist_quick(&objp->pos, &Objects[shipp->objnum].pos);
 				wep_range = ship_get_secondary_weapon_range(&Ships[objp->instance]);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -448,7 +448,7 @@ typedef struct ship_flag_name {
 	char flag_name[TOKEN_LENGTH];		// the name written to the mission file for its corresponding parse_object flag
 } ship_flag_name;
 
-#define MAX_SHIP_FLAG_NAMES					23
+#define MAX_SHIP_FLAG_NAMES					24
 extern ship_flag_name Ship_flag_names[];
 
 #define DEFAULT_SHIP_PRIMITIVE_SENSOR_RANGE		10000	// Goober5000

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -132,7 +132,7 @@ namespace Ship {
 		Same_departure_warp_when_docked,	// Goober5000
 		Fail_sound_locked_primary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
 		Fail_sound_locked_secondary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
-
+		Aspect_immune,						//Kiloku -- Ship cannot be targeted by Aspect Seekers. 
 		NUM_VALUES
 
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -10,7 +10,6 @@
 
 
 #include <algorithm>
-#include <cstddef>
 
 #include "ai/aibig.h"
 #include "asteroid/asteroid.h"
@@ -21,7 +20,6 @@
 #include "freespace.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
-#include "graphics/color.h"
 #include "hud/hud.h"
 #include "hud/hudartillery.h"
 #include "iff_defs/iff_defs.h"
@@ -37,8 +35,6 @@
 #include "object/objcollide.h"
 #include "object/objectdock.h"
 #include "object/objectsnd.h"
-#include "parse/parsehi.h"
-#include "parse/parselo.h"
 #include "scripting/scripting.h"
 #include "particle/particle.h"
 #include "playerman/player.h"
@@ -1163,16 +1159,6 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if(optional_string("@Laser Tail Radius:")) {
 		stuff_float(&wip->laser_tail_radius );
 	}
-
-	if (parse_optional_color3i_into("$Light color:", &wip->light_color)) {
-		wip->light_color_set = true;
-	}
-
-	parse_optional_float_into("$Light radius:", &wip->light_radius);
-
-	float fbuffer;
-	if (parse_optional_float_into("$Light intensity:", &fbuffer))
-		wip->light_color.i(fbuffer);
 
 	if (optional_string("$Collision Radius Override:")) {
 		stuff_float(&wip->collision_radius_override);
@@ -2675,10 +2661,6 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 		if ( optional_string("+BeamWidth:") )
 			stuff_float(&wip->b_info.beam_width);
-
-		parse_optional_bool_into("+Beam Light Flickers:", &wip->b_info.beam_light_flicker);
-
-		parse_optional_bool_into("+Beam Width Multiplies Light Radius:", &wip->b_info.beam_light_as_multiplier);
 
 		if (optional_string("+Beam Flash Particle Effect:")) {
 			wip->flash_impact_weapon_expl_effect = particle::util::parseEffect(wip->name);
@@ -8727,10 +8709,6 @@ void weapon_info::reset()
 	this->laser_head_radius = 1.0f;
 	this->laser_tail_radius = 1.0f;
 
-	this->light_color_set = false;
-	this->light_color.reset();
-	this->light_radius = -1.0f; //Defaults handled at runtime via lighting profile if left negative
-
 	this->collision_radius_override = -1.0f;
 	this->max_speed = 10.0f;
 	this->acceleration_time = 0.0f;
@@ -8934,8 +8912,6 @@ void weapon_info::reset()
 	this->b_info.range = BEAM_FAR_LENGTH;
 	this->b_info.damage_threshold = 1.0f;
 	this->b_info.beam_width = -1.0f;
-	this->b_info.beam_light_flicker = true;
-	this->b_info.beam_light_as_multiplier = true;
 	this->b_info.flags.reset();
 
 	// type 5 beam stuff
@@ -9381,7 +9357,9 @@ bool weapon_target_satisfies_lock_restrictions(weapon_info* wip, object* target)
 {
 	if (target->type != OBJ_SHIP)
 		return true;
-
+	else if (wip->is_locked_homing() && Ships[target->instance].flags[Ship::Ship_Flags::Aspect_immune])
+		return false;
+	
 	auto& restrictions = wip->ship_restrict;
 	// if you didn't specify any restrictions, you can always lock
 	if (restrictions.empty()) return true;

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3490,6 +3490,8 @@ int CFred_mission_save::save_objects()
 				fout(" \"fail-sound-locked-primary\"");
 			if (shipp->flags[Ship::Ship_Flags::Fail_sound_locked_secondary])
 				fout(" \"fail-sound-locked-secondary\"");
+			if (shipp->flags[Ship::Ship_Flags::Aspect_immune])
+				fout(" \"aspect-immune\"");
 			fout(" )");
 		}
 		// -----------------------------------------------------------

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3277,6 +3277,9 @@ int CFred_mission_save::save_objects()
 			if (shipp->flags[Ship::Ship_Flags::Fail_sound_locked_secondary]) {
 				fout(" \"fail-sound-locked-secondary\"");
 			}
+			if (shipp->flags[Ship::Ship_Flags::Aspect_immune]) {
+				fout(" \"aspect-immune\"");
+			}
 			fout(" )");
 		}
 		// -----------------------------------------------------------


### PR DESCRIPTION
This is for #3812. 
I tested it by setting and unsetting the flag through `alter-ship-flag` on ships (both AI and the player). As far as I can tell, this works fine, doesn't interfere with the player's heatseekers, and doesn't stop the AI from fighting with their primaries. 

I couldn't test whether this interferes the AI's heatseekers due to qtFRED not having a loadout editor (as I don't have access to a Windows machine). 
It does successfully stop the AI fighter from using their aspect missiles (which are the default secondaries on the Maras which I used as the enemies in the test).
