### PR TITLE
save PXO stats to local pilot file

### DIFF
--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -28,6 +28,7 @@
 #include "network/stand_gui.h"
 #include "network/multi_pmsg.h"
 #include "playerman/player.h"
+#include "pilotfile/pilotfile.h"
 
 // -----------------------------------------------------------------------------------
 // FREESPACE MASTER TRACKER DEFINES/VARS
@@ -240,7 +241,8 @@ int multi_fs_tracker_validate(int show_error)
 			}
 
 			// copy my statistics into my pilot file
-			multi_stats_tracker_to_fs(&Multi_tracker_fs_pilot,&Player->stats);			
+			multi_stats_tracker_to_fs(&Multi_tracker_fs_pilot,&Player->stats);
+			Pilot.set_multi_stats(&Player->stats);
 
 			Multi_validate_mode = -1;
 
@@ -939,6 +941,8 @@ void multi_stats_tracker_to_fs(vmt_stats_struct *vmt,scoring_struct *fs)
 		fs->last_flown = 0;
 	}
 
+	fs->last_backup = fs->last_flown;
+
 	// medals and ship kills are stored in a single array, medals first
 	const size_t count = vmt->num_medals + vmt->num_ships;
 
@@ -949,7 +953,9 @@ void multi_stats_tracker_to_fs(vmt_stats_struct *vmt,scoring_struct *fs)
 
 	for (size_t idx = 0, idx2 = 0; idx < count; ++idx) {
 		if (idx < vmt->num_medals) {
-			fs->medal_counts[idx] = static_cast<int>(vmt->counts[idx]);
+			if (idx < max_medals) {
+				fs->medal_counts[idx] = static_cast<int>(vmt->counts[idx]);
+			}
 		} else {
 			fs->kills[idx2++] = static_cast<int>(vmt->counts[idx]);
 		}

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -344,7 +344,7 @@ void pilotfile::set_multi_stats(const scoring_struct *stats)
 		}
 
 		ilist.name = Ship_info[idx].name;
-		ilist.index = idx;
+		ilist.index = static_cast<int>(idx);
 		ilist.val = stats->kills[idx];
 
 		multi_stats.ship_kills.push_back(ilist);
@@ -362,7 +362,7 @@ void pilotfile::set_multi_stats(const scoring_struct *stats)
 		}
 
 		ilist.name = Medals[idx].name;
-		ilist.index = idx;
+		ilist.index = static_cast<int>(idx);
 		ilist.val = stats->medal_counts[idx];
 
 		multi_stats.medals_earned.push_back(ilist);

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -300,6 +300,76 @@ void pilotfile::update_stats_backout(scoring_struct *stats, bool training)
 }
 
 /**
+ * @brief Clear and set multi stats from given scoring struct
+ * @note This is really just for use by PXO to set multi stats from tracker
+ * 
+ * @param stats 
+ */
+void pilotfile::set_multi_stats(const scoring_struct *stats)
+{
+	size_t idx;
+	index_list_t ilist;
+
+
+	multi_stats.score = stats->score;
+	multi_stats.rank = stats->rank;
+	multi_stats.assists = stats->assists;
+	multi_stats.kill_count = stats->kill_count;
+	multi_stats.kill_count_ok = stats->kill_count_ok;
+	multi_stats.bonehead_kills = stats->bonehead_kills;
+
+	multi_stats.p_shots_fired = stats->p_shots_fired;
+	multi_stats.p_shots_hit = stats->p_shots_hit;
+	multi_stats.p_bonehead_hits = stats->p_bonehead_hits;
+
+	multi_stats.s_shots_fired = stats->s_shots_fired;
+	multi_stats.s_shots_hit = stats->s_shots_hit;
+	multi_stats.s_bonehead_hits = stats->s_bonehead_hits;
+
+	multi_stats.flight_time = stats->flight_time;
+	multi_stats.missions_flown = stats->missions_flown;
+	multi_stats.last_flown = stats->last_flown;
+	multi_stats.last_backup = stats->last_backup;
+
+
+	// ship kills
+	multi_stats.ship_kills.clear();
+	multi_stats.ship_kills.shrink_to_fit();
+
+	auto kills_size = std::min(SDL_arraysize(stats->kills), Ship_info.size());
+
+	for (idx = 0; idx < kills_size; ++idx) {
+		if (stats->kills[idx] <= 0) {
+			continue;
+		}
+
+		ilist.name = Ship_info[idx].name;
+		ilist.index = idx;
+		ilist.val = stats->kills[idx];
+
+		multi_stats.ship_kills.push_back(ilist);
+	}
+
+	// medals
+	multi_stats.medals_earned.clear();
+	multi_stats.medals_earned.shrink_to_fit();
+
+	auto medals_size = std::min(stats->medal_counts.size(), Medals.size());
+
+	for (idx = 0; idx < medals_size; ++idx) {
+		if (stats->medal_counts[idx] <= 0) {
+			continue;
+		}
+
+		ilist.name = Medals[idx].name;
+		ilist.index = idx;
+		ilist.val = stats->medal_counts[idx];
+
+		multi_stats.medals_earned.push_back(ilist);
+	}
+}
+
+/**
  * Reset stats stored in the .plr file; all_time_stats & multi_stats
  */
 void pilotfile::reset_stats()

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -93,6 +93,7 @@ class pilotfile {
 		// updating stats, multi and/or all-time
 		void update_stats(scoring_struct *stats, bool training = false);
 		void update_stats_backout(scoring_struct *stats, bool training = false);
+		void set_multi_stats(const scoring_struct *stats);
 		void reset_stats();
 
 		/**


### PR DESCRIPTION
Retail saved tracker stats to the local pilot file after read, however the newer pilot file code doesn't work the same way. This adds the ability to properly update the pilot file with multiplayer stats from the tracker during login.

NOTE: This will always overwrite multi stats in the pilot file with the stats from the tracker!