### PR TITLE
Convert some Lua hooks to the new style to add documentation

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -32,7 +32,7 @@
 #include "object/objcollide.h"
 #include "object/object.h"
 #include "parse/parselo.h"
-#include "scripting/scripting.h"
+#include "scripting/global_hooks.h"
 #include "particle/particle.h"
 #include "render/3d.h"
 #include "ship/ship.h"
@@ -1511,11 +1511,12 @@ static void asteroid_maybe_break_up(object *pasteroid_obj)
 	if ( timestamp_elapsed(asp->final_death_time) ) {
 		vec3d	relvec, vfh, tvec;
 		bool skip = false;
-		bool hooked = Script_system.IsActiveAction(CHA_DEATH);
+		bool hooked = scripting::hooks::OnDeath->isActive();
 
 		if (hooked) {
-			Script_system.SetHookObject("Self", pasteroid_obj);
-			skip = Script_system.IsConditionOverride(CHA_DEATH, pasteroid_obj);
+			skip = scripting::hooks::OnDeath->isOverride(
+				scripting::hook_param_list(scripting::hook_param("Self", 'o', pasteroid_obj)),
+				pasteroid_obj);
 		}
 		if (!skip)
 		{
@@ -1623,8 +1624,9 @@ static void asteroid_maybe_break_up(object *pasteroid_obj)
 			asp->final_death_time = timestamp(-1);
 		}
 		if (hooked) {
-			Script_system.RunCondition(CHA_DEATH, pasteroid_obj);
-			Script_system.RemHookVar("Self");
+			scripting::hooks::OnDeath->run(
+				scripting::hook_param_list(scripting::hook_param("Self", 'o', pasteroid_obj)),
+				pasteroid_obj);
 		}
 	}
 }

--- a/code/object/collidedebrisship.cpp
+++ b/code/object/collidedebrisship.cpp
@@ -15,6 +15,7 @@
 #include "io/timer.h"
 #include "object/objcollide.h"
 #include "object/object.h"
+#include "scripting/global_hooks.h"
 #include "scripting/scripting.h"
 #include "scripting/api/objs/vecmath.h"
 #include "playerman/player.h"
@@ -80,11 +81,14 @@ int collide_debris_ship( obj_pair * pair )
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 			}
 
-			if (Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
-				Script_system.SetHookObjects(4, "Self", debris_objp, "Object", ship_objp, "Ship", ship_objp, "Debris", debris_objp);
-				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				debris_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, debris_objp, ship_objp);
-				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
+			if (scripting::hooks::OnShipCollision->isActive()) {
+				debris_override = scripting::hooks::OnShipCollision->isOverride(
+					scripting::hook_param_list(scripting::hook_param("Self", 'o', debris_objp),
+						scripting::hook_param("Object", 'o', ship_objp),
+						scripting::hook_param("Ship", 'o', ship_objp),
+						scripting::hook_param("Debris", 'o', debris_objp),
+						scripting::hook_param("Hitpos", 'o', hitpos)),
+					debris_objp, ship_objp);
 			}
 
 			if(!ship_override && !debris_override)
@@ -158,12 +162,15 @@ int collide_debris_ship( obj_pair * pair )
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
 			}
 
-			if (Script_system.IsActiveAction(CHA_COLLIDESHIP) && ((debris_override && !ship_override) || (!debris_override && !ship_override)))
+			if (scripting::hooks::OnShipCollision->isActive() && ((debris_override && !ship_override) || (!debris_override && !ship_override)))
 			{
-				Script_system.SetHookObjects(4, "Self", debris_objp, "Object", ship_objp, "Ship", ship_objp, "Debris", debris_objp);
-				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, debris_objp, ship_objp);
-				Script_system.RemHookVars({ "Self", "Object", "Ship", "Debris", "Hitpos" });
+				scripting::hooks::OnShipCollision->run(
+					scripting::hook_param_list(scripting::hook_param("Self", 'o', debris_objp),
+						scripting::hook_param("Object", 'o', ship_objp),
+						scripting::hook_param("Ship", 'o', ship_objp),
+						scripting::hook_param("Debris", 'o', debris_objp),
+						scripting::hook_param("Hitpos", 'o', hitpos)),
+					debris_objp, ship_objp);
 			}
 
 			return 0;
@@ -252,11 +259,14 @@ int collide_asteroid_ship( obj_pair * pair )
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 			}
 
-			if (Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
-				Script_system.SetHookObjects(4, "Self", asteroid_objp, "Object", ship_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
-				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				asteroid_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, asteroid_objp, ship_objp);
-				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
+			if (scripting::hooks::OnShipCollision->isActive()) {
+				asteroid_override = scripting::hooks::OnShipCollision->isOverride(
+					scripting::hook_param_list(scripting::hook_param("Self", 'o', asteroid_objp),
+						scripting::hook_param("Object", 'o', ship_objp),
+						scripting::hook_param("Ship", 'o', ship_objp),
+						scripting::hook_param("Asteroid", 'o', asteroid_objp),
+						scripting::hook_param("Hitpos", 'o', hitpos)),
+					asteroid_objp, ship_objp);
 			}
 
 			if(!ship_override && !asteroid_override)
@@ -334,12 +344,15 @@ int collide_asteroid_ship( obj_pair * pair )
 				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
 			}
 
-			if (Script_system.IsActiveAction(CHA_COLLIDESHIP) && ((asteroid_override && !ship_override) || (!asteroid_override && !ship_override)))
+			if (scripting::hooks::OnShipCollision->isActive() && ((asteroid_override && !ship_override) || (!asteroid_override && !ship_override)))
 			{
-				Script_system.SetHookObjects(4, "Self", asteroid_objp, "Object", ship_objp, "Ship", ship_objp, "Asteroid", asteroid_objp);
-				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(hitpos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, asteroid_objp, ship_objp);
-				Script_system.RemHookVars({ "Self", "Object", "Ship", "Asteroid", "Hitpos" });
+				scripting::hooks::OnShipCollision->run(
+					scripting::hook_param_list(scripting::hook_param("Self", 'o', asteroid_objp),
+						scripting::hook_param("Object", 'o', ship_objp),
+						scripting::hook_param("Ship", 'o', ship_objp),
+						scripting::hook_param("Asteroid", 'o', asteroid_objp),
+						scripting::hook_param("Hitpos", 'o', hitpos)),
+					asteroid_objp, ship_objp);
 			}
 
 			return 0;

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -24,8 +24,7 @@
 #include "object/object.h"
 #include "object/objectdock.h"
 #include "object/objectshield.h"
-#include "scripting/scripting.h"
-#include "scripting/api/objs/vecmath.h"
+#include "scripting/global_hooks.h"
 #include "playerman/player.h"
 #include "render/3d.h"			// needed for View_position, which is used when playing 3d sound
 #include "ship/ship.h"
@@ -1195,17 +1194,23 @@ int collide_ship_ship( obj_pair * pair )
 		{
 			bool a_override = false, b_override = false;
 
-			if (Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
-				Script_system.SetHookObjects(4, "Self", A, "Object", B, "Ship", A, "ShipB", B);
-				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(world_hit_pos));
-				a_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, A, B);
-				Script_system.RemHookVars({ "Self", "Object", "Ship", "ShipB", "Hitpos" });
+			if (scripting::hooks::OnShipCollision->isActive()) {
+				a_override = scripting::hooks::OnShipCollision->isOverride(
+					scripting::hook_param_list(scripting::hook_param("Self", 'o', A),
+						scripting::hook_param("Object", 'o', B),
+						scripting::hook_param("Ship", 'o', A),
+						scripting::hook_param("ShipB", 'o', B),
+						scripting::hook_param("Hitpos", 'o', world_hit_pos)),
+					A, B);
 
 				// Yes, this should be reversed.
-				Script_system.SetHookObjects(4, "Self", B, "Object", A, "Ship", B, "ShipB", A);
-				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(world_hit_pos));
-				b_override = Script_system.IsConditionOverride(CHA_COLLIDESHIP, B, A);
-				Script_system.RemHookVars({ "Self", "Object", "Ship", "ShipB", "Hitpos" });
+				b_override = scripting::hooks::OnShipCollision->isOverride(
+					scripting::hook_param_list(scripting::hook_param("Self", 'o', B),
+						scripting::hook_param("Object", 'o', A),
+						scripting::hook_param("Ship", 'o', B),
+						scripting::hook_param("ShipB", 'o', A),
+						scripting::hook_param("Hitpos", 'o', world_hit_pos)),
+					B, A);
 			}
 
 			if(!a_override && !b_override)
@@ -1447,24 +1452,28 @@ int collide_ship_ship( obj_pair * pair )
 				}
 			}
 
-			if (!Script_system.IsActiveAction(CHA_COLLIDESHIP)) {
+			if (!scripting::hooks::OnShipCollision->isActive()) {
 				return 0;
 			}
 
 			if(!(b_override && !a_override))
 			{
-				Script_system.SetHookObjects(4, "Self", A, "Object", B, "Ship", A, "ShipB", B);
-				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(world_hit_pos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, A, B);
-				Script_system.RemHookVars({ "Self", "Object", "Ship", "ShipB", "Hitpos" });
+				scripting::hooks::OnShipCollision->run(scripting::hook_param_list(scripting::hook_param("Self", 'o', A),
+														   scripting::hook_param("Object", 'o', B),
+														   scripting::hook_param("Ship", 'o', A),
+														   scripting::hook_param("ShipB", 'o', B),
+														   scripting::hook_param("Hitpos", 'o', world_hit_pos)),
+					A, B);
 			}
 			if((b_override && !a_override) || (!b_override && !a_override))
 			{
 				// Yes, this should be reversed.
-				Script_system.SetHookObjects(4, "Self", B, "Object", A, "Ship", B, "ShipB", A);
-				Script_system.SetHookVar("Hitpos", 'o', scripting::api::l_Vector.Set(world_hit_pos));
-				Script_system.RunCondition(CHA_COLLIDESHIP, B, A);
-				Script_system.RemHookVars({ "Self", "Object", "Ship", "ShipB", "Hitpos" });
+				scripting::hooks::OnShipCollision->run(scripting::hook_param_list(scripting::hook_param("Self", 'o', B),
+														   scripting::hook_param("Object", 'o', A),
+														   scripting::hook_param("Ship", 'o', B),
+														   scripting::hook_param("ShipB", 'o', A),
+														   scripting::hook_param("Hitpos", 'o', world_hit_pos)),
+					B, A);
 			}
 
 			return 0;

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -1,0 +1,40 @@
+
+#include "global_hooks.h"
+
+namespace scripting {
+namespace hooks {
+
+std::shared_ptr<scripting::Hook> OnGameInit = scripting::Hook::Factory("On Game Init",
+	"Executed at the start of the engine after all game data has been loaded.",
+	{},
+	CHA_GAMEINIT);
+
+std::shared_ptr<OverridableHook> OnDeath = OverridableHook::Factory("On Death",
+	"Invoked when an object (ship or asteroid) has been destroyed.",
+	{
+		{"Self", "object", "The object that was killed"},
+		{"Ship", "ship", "The ship that was destroyed (only set for ships)"},
+		{"Killer", "object", "The object that caused the death (only set for ships)"},
+		{"Hitpos",
+			"vector",
+			"The position of the hit that caused the death (only set for ships and only if available)"},
+	});
+
+std::shared_ptr<OverridableHook> OnShipCollision = OverridableHook::Factory("On Ship Collision",
+	"Invoked when a ship collides with another object. Note: When two ships collide this will be called twice, once "
+	"with each ship object as the \"Ship\" parameter.",
+	{{"Self", "object", "The \"other\" object that collided with the ship."},
+		{"Object",
+			"ship",
+			"The ship object with which the \"other\" object collided with. Provided for consistency with other "
+			"collision hooks."},
+		{"Ship", "ship", "Same as \"Object\""},
+		{"Hitpos", "vector", "The world position where the colission was detected"},
+		{"Debris", "object", "The debris object with which the ship collided (only set for debris collisions)"},
+		{"Asteroid", "object", "The asteroid object with which the ship collided (only set for asteroid collisions)"},
+		{"ShipB", "ship", "For ship on ship collisions, the \"other\" ship."},
+		{"Weapon", "weapon", "The weapon object with which the ship collided (only set for weapon collisions)"},
+		{"Beam", "weapon", "The beam object with which the ship collided (only set for beam collisions)"}});
+
+} // namespace hooks
+} // namespace scripting

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -1,0 +1,14 @@
+
+#include "hook_api.h"
+
+namespace scripting {
+namespace hooks {
+
+extern std::shared_ptr<scripting::Hook> OnGameInit;
+
+extern std::shared_ptr<OverridableHook> OnDeath;
+
+extern std::shared_ptr<OverridableHook> OnShipCollision;
+
+}
+} // namespace scripting

--- a/code/scripting/hook_api.cpp
+++ b/code/scripting/hook_api.cpp
@@ -2,7 +2,7 @@
 
 #include "globalincs/pstypes.h"
 
-#include <utility>
+#include "scripting/api/objs/vecmath.h"
 
 namespace scripting {
 
@@ -55,6 +55,10 @@ ade_odata_setter<object_h> convert_arg_type(object* objp)
 {
 	return ade_object_to_odata(objp != nullptr ? OBJ_INDEX(objp) : -1);
 }
+ade_odata_setter<vec3d> convert_arg_type(vec3d vec)
+{
+	return scripting::api::l_Vector.Set(vec);
+}
 } // namespace detail
 
 HookVariableDocumentation::HookVariableDocumentation(const char* name_, ade_type_info type_, const char* description_)
@@ -102,6 +106,11 @@ Hook::Hook(SCP_string hookName,
 {
 }
 Hook::~Hook() = default;
+
+bool Hook::isActive() const
+{
+	return Script_system.IsActiveAction(_hookId);
+}
 
 bool Hook::isOverridable() const { return false; }
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -1197,25 +1197,21 @@ void script_state::AddGameInitFunction(script_function func) { GameInitFunctions
 // This allows us to avoid significant overhead from checking everything at the potential hook sites, but you must call
 // AssayActions() after modifying ConditionalHooks before returning to normal operation of the scripting system!
 void script_state::AssayActions() {
-	for (bool &i : ActiveActions) {
-		i = false;
-	}
+	ActiveActions.clear();
 
 	for (const auto &hook : ConditionalHooks) {
 		for (const auto &action : hook.Actions) {
-			if (action.action_type >= -1 && action.action_type <= CHA_LAST) {
-				ActiveActions[action.action_type] = true;
-			}
+			ActiveActions[action.action_type] = true;
 		}
 	}
 }
 
-bool script_state::IsActiveAction(ConditionalActions action_id) {
-	return ActiveActions[action_id];
-}
-
-bool script_state::IsActiveAction(int hookId) {
-	// TODO
+bool script_state::IsActiveAction(int action_id) {
+	auto entry = ActiveActions.find(action_id);
+	if (entry != ActiveActions.end())
+		return entry->second;
+	else
+		return false;
 }
 
 //*************************CLASS: script_state*************************

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -56,13 +56,17 @@ class BuiltinHook : public scripting::HookBase {
 	}
 	~BuiltinHook() override = default;
 
+	bool isActive() const override
+	{
+		return Script_system.IsActiveAction(_hookId);
+	}
+
 	bool isOverridable() const override { return true; }
 };
 
 // clang-format off
 static USED_VARIABLE SCP_vector<std::shared_ptr<BuiltinHook>> Script_actions
 {
-	std::make_shared<BuiltinHook>("On Game Init",			CHA_GAMEINIT ),
 	std::make_shared<BuiltinHook>("On Splash Screen",		CHA_SPLASHSCREEN ),
 	std::make_shared<BuiltinHook>("On State Start",			CHA_ONSTATESTART ),
 	std::make_shared<BuiltinHook>("On Action",				CHA_ONACTION ),
@@ -74,12 +78,10 @@ static USED_VARIABLE SCP_vector<std::shared_ptr<BuiltinHook>> Script_actions
 	std::make_shared<BuiltinHook>("On Mouse Released",		CHA_MOUSERELEASED ),
 	std::make_shared<BuiltinHook>("On Mission Start",		CHA_MISSIONSTART ),
 	std::make_shared<BuiltinHook>("On HUD Draw",			CHA_HUDDRAW ),
-	std::make_shared<BuiltinHook>("On Ship Collision",		CHA_COLLIDESHIP ),
 	std::make_shared<BuiltinHook>("On Weapon Collision",	CHA_COLLIDEWEAPON ),
 	std::make_shared<BuiltinHook>("On Debris Collision",	CHA_COLLIDEDEBRIS ),
 	std::make_shared<BuiltinHook>("On Asteroid Collision",	CHA_COLLIDEASTEROID ),
 	std::make_shared<BuiltinHook>("On Object Render",		CHA_OBJECTRENDER ),
-	std::make_shared<BuiltinHook>("On Death",				CHA_DEATH ),
 	std::make_shared<BuiltinHook>("On Weapon Delete",		CHA_ONWEAPONDELETE ),
 	std::make_shared<BuiltinHook>("On Weapon Equipped",		CHA_ONWPEQUIPPED ),
 	std::make_shared<BuiltinHook>("On Weapon Fired",		CHA_ONWPFIRED ),
@@ -1210,6 +1212,10 @@ void script_state::AssayActions() {
 
 bool script_state::IsActiveAction(ConditionalActions action_id) {
 	return ActiveActions[action_id];
+}
+
+bool script_state::IsActiveAction(int hookId) {
+	// TODO
 }
 
 //*************************CLASS: script_state*************************

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -18,6 +18,7 @@
 
 namespace scripting {
 struct ScriptingDocumentation;
+class Hook;
 }
 
 struct image_desc
@@ -67,9 +68,7 @@ enum ConditionalType {
 //Actions
 enum ConditionalActions : int32_t {
 	CHA_NONE    = -1,
-	CHA_DEATH,
 	CHA_ONFRAME,
-	CHA_COLLIDESHIP,
 	CHA_COLLIDEWEAPON,
 	CHA_COLLIDEDEBRIS,
 	CHA_COLLIDEASTEROID,
@@ -245,6 +244,7 @@ public:
 	void AddConditionedHook(ConditionedHook hook);
 	void AssayActions();
 	bool IsActiveAction(ConditionalActions action_id);
+	bool IsActiveAction(int hookId);
 
 	void AddGameInitFunction(script_function func);
 

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -181,9 +181,10 @@ class script_state
 	// values are a vector to provide a stack of values. This is necessary to ensure consistent behavior if a scripting
 	// hook is called from within another script (e.g. calls to createShip)
 	SCP_unordered_map<SCP_string, SCP_vector<luacpp::LuaReference>> HookVariableValues;
+
 	// ActiveActions lets code that might run scripting hooks know whether any scripts are even registered for it.
 	// AssayActions is responsible for keeping it up to date.
-	bool ActiveActions[ConditionalActions::CHA_LAST+1];
+	SCP_unordered_map<int, bool> ActiveActions;
 
 	void ParseChunkSub(script_function& out_func, const char* debug_str=NULL);
 
@@ -243,7 +244,6 @@ public:
 	bool ParseCondition(const char *filename="<Unknown>");
 	void AddConditionedHook(ConditionedHook hook);
 	void AssayActions();
-	bool IsActiveAction(ConditionalActions action_id);
 	bool IsActiveAction(int hookId);
 
 	void AddGameInitFunction(script_function func);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -67,7 +67,7 @@
 #include "object/waypoint.h"
 #include "parse/parselo.h"
 #include "scripting/hook_api.h"
-#include "scripting/scripting.h"
+#include "scripting/global_hooks.h"
 #include "particle/particle.h"
 #include "playerman/player.h"
 #include "radar/radar.h"
@@ -7879,10 +7879,10 @@ void ship_destroy_instantly(object *ship_objp, bool with_debris)
 	mission_log_add_entry(LOG_SELF_DESTRUCTED, Ships[ship_objp->instance].ship_name, NULL );
 	
 	// scripting stuff
-	if (Script_system.IsActiveAction(CHA_DEATH)) {
-		Script_system.SetHookObjects(2, "Self", ship_objp, "Ship", ship_objp);
-		Script_system.RunCondition(CHA_DEATH, ship_objp);
-		Script_system.RemHookVars({"Self", "Ship"});
+	if (scripting::hooks::OnDeath->isActive()) {
+		scripting::hooks::OnDeath->run(scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
+			scripting::hook_param("Ship", 'o', ship_objp)),
+			ship_objp);
 	}
 
 	ship_objp->flags.set(Object::Object_Flags::Should_be_dead);

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1214,6 +1214,8 @@ add_file_folder("Scripting"
 	scripting/doc_json.h
 	scripting/doc_parser.cpp
 	scripting/doc_parser.h
+	scripting/global_hooks.cpp
+	scripting/global_hooks.h
 	scripting/hook_api.cpp
 	scripting/hook_api.h
 	scripting/lua.cpp

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -67,6 +67,7 @@
 #include "mod_table/mod_table.h"
 #include "libs/ffmpeg/FFmpeg.h"
 #include "scripting/scripting.h"
+#include "scripting/global_hooks.h"
 #include "utils/Random.h"
 
 #include <direct.h>
@@ -469,7 +470,7 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	Fred_main_wnd -> init_tools();
 
 	Script_system.RunInitFunctions();
-	Script_system.RunCondition(CHA_GAMEINIT);
+	scripting::hooks::OnGameInit->run();
 
 	return true;
 }

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -163,6 +163,7 @@
 #include "render/batching.h"
 #include "scpui/rocket_ui.h"
 #include "scripting/api/objs/gamestate.h"
+#include "scripting/global_hooks.h"
 #include "scripting/hook_api.h"
 #include "scripting/scripting.h"
 #include "ship/afterburner.h"
@@ -1986,7 +1987,7 @@ void game_init()
 	scpui::initialize();
 
 	Script_system.RunInitFunctions();
-	Script_system.RunCondition(CHA_GAMEINIT);
+	scripting::hooks::OnGameInit->run();
 
 	game_title_screen_close();
 

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -15,6 +15,7 @@
 #include <sound/audiostr.h>
 #include <project.h>
 #include <scripting/scripting.h>
+#include <scripting/global_hooks.h>
 #include <hud/hudsquadmsg.h>
 #include <globalincs/alphacolors.h>
 
@@ -257,7 +258,7 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 
 	listener(SubSystem::ScriptingInitHook);
 	Script_system.RunInitFunctions();
-	Script_system.RunCondition(CHA_GAMEINIT);
+	scripting::hooks::OnGameInit->run();
 
 	return true;
 }


### PR DESCRIPTION
This takes a few of the existing hooks and converts them to the new style of hook definition which can include more extensive documentation and enumeration of supported hook variables.

This is an updated version of #3151 to work with the latest codebase.

NOTE: Before this can be integrated into the codebase, it needs an implementation for `bool script_state::IsActiveAction(int hookId)` which apparently only has support for old-style script hooks.