### PR TITLE
additional checks for FS1 message conversion

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1046,6 +1046,13 @@ bool message_filename_has_fs1_wingman_prefix(const char *filename)
 		&& filename[2] != '\0');
 }
 
+void message_filename_convert_to_command(char *buf, const char *filename)
+{
+	// prepend the command name, and then the rest of the filename.
+	strcpy(buf, COMMAND_WAVE_PREFIX);
+	strcat(buf, &filename[2]);
+}
+
 // Play wave file associated with message
 // input: m		=>		pointer to message description
 //
@@ -1070,13 +1077,10 @@ bool message_play_wave( message_q *q )
 		// Look for "[1-6]_" at the front of the message.  If found, then convert to TC_*
 		if ( q->flags & MQF_CONVERT_TO_COMMAND && message_filename_has_fs1_wingman_prefix(filename) ) {
 			char temp[MAX_FILENAME_LEN];
+			message_filename_convert_to_command(temp, filename);
+			strcpy_s(filename, temp);
 
 			Message_waves[index].num = sound_load_id::invalid(); // forces us to reload the message
-
-			// prepend the command name, and then the rest of the filename.
-			strcpy_s( temp, COMMAND_WAVE_PREFIX );
-			strcat_s( temp, &filename[2] );
-			strcpy_s( filename, temp );
 		}
 
 		// load the sound file into memory
@@ -1714,12 +1718,29 @@ void message_queue_message( int message_num, int priority, int timing, const cha
 
 	// wingman personas have their alive status checked
 	if ( (m_persona != -1) && (Personas[m_persona].flags & PERSONA_FLAG_WINGMAN) ) {
+		bool convert_to_command = false;
+
 		// SPECIAL HACK -- if the who_from is terran command, and there is a wingman persona attached
 		// to this message, then set a bit to tell the wave/anim playing code to play the command version
 		// of the wave and head
 		// ADDENDUM -- Since the special hack is specifically for mission-unique messages, don't
 		// convert built-in messages to Command
 		if ( builtin_type < 0 && !stricmp(who_from, The_mission.command_sender) ) {
+			// ADDENDUM 2 -- perform an additional check: only convert this message if a WAV exists for it
+			auto m = &Messages[message_num];
+			if (m->wave_info.index >= 0) {
+				auto filename = Message_waves[m->wave_info.index].name;
+				if (message_filename_has_fs1_wingman_prefix(filename)) {
+					char converted[MAX_FILENAME_LEN];
+					message_filename_convert_to_command(converted, filename);
+					if (cf_exists_full(converted, CF_TYPE_VOICE_SPECIAL)) {
+						convert_to_command = true;
+					}
+				}
+			}
+		}
+
+		if (convert_to_command) {
 			MessageQ[i].flags |= MQF_CONVERT_TO_COMMAND;
 			MessageQ[i].source = HUD_SOURCE_TERRAN_CMD;
 		} else {


### PR DESCRIPTION
Before setting the `MQF_CONVERT_TO_COMMAND` flag, check to make sure the conversion will succeed.

This should ensure proper behavior for any case where command-conversion is needed.  I've tested it with both a message that should not be converted and a message that should, and both behave as expected.

Follow-up to #4150 and #4078.  Fixes #4356.