### PR TITLE
Small fix for music initialization

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -660,6 +660,18 @@ void event_music_first_pattern()
 // this yields a relative start time of 1 second.  Mission start will now use relative rather than absolute delay.
 void event_music_set_start_delay()
 {
+	if (Event_music_inited == FALSE) {
+		return;
+	}
+
+	if (Event_music_enabled == FALSE) {
+		return;
+	}
+
+	if (Event_music_level_inited == FALSE) {
+		return;
+	}
+
 	Pattern_timer_id = timestamp(1000);
 }
 


### PR DESCRIPTION
Follow-up for #3879 particularly this commit 0dc3c914d920c11852000ff7a392f2a203e52579. Simply re-adds the various checks that the delay time had to go through before being set. This fixes a bug where music would not play on a mission where a mission without music was played previously. The logic causing that exact symptom gets kind of convoluted, but the basic cause is not checking the same conditions before setting the timestamp.

Unfortunately, I don't think this is the cause of a related bug where all music stops in a long play session. This one "fixes itself" after a single bugged music mission.