### PR TITLE
Hopefully fix the post-build-release yaml

### DIFF
--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -30,7 +30,6 @@ env:
   NEBULA_PASSWORD: ${{ secrets.NEBULA_PASSWORD }}
   HLP_API: ${{ secrets.HLP_API }}
   HLP_KEY: ${{ secrets.HLP_KEY }}
-  RELEASE_TAG: ${{ github.event.inputs.releaseTag }}
 
 jobs:
   post_builds:
@@ -41,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-          ref: RELEASE_TAG
+          ref: ${{ github.event.inputs.releaseTag }}
 
       - name: Install Python dependencies
         run: pip install -r ci/post/requirements.txt


### PR DESCRIPTION
* Directly use inputs for actions/checkout

Issue was the the post-build-release yaml was hanging up on the step which invoked actions/checkout.  

`ref` was passed an environment variable, but was only interpreting it as a string.  Since the environment variable was using the {{ }} syntax and since the github.inputs context should be visible to actions/checkout, just use that directly instead of making the RELEASE_TAG env.