### PR TITLE
Do our best to avoid invalid types in obj_team

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14487,6 +14487,10 @@ void ai_frame(int objnum)
 {
 	// Cyborg - can you believe this was added in *2022*??
 	Assertion (Objects[objnum].type == OBJ_SHIP, "Ai_frame was called for a non-ship of type %d. Please report!", Objects[objnum].type);
+	
+	if (Objects[objnum].type != OBJ_SHIP){
+		return;
+	}
 
 	ship		*shipp = &Ships[Objects[objnum].instance];
 	ai_info	*aip = &Ai_info[shipp->ai_index];

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15107,10 +15107,9 @@ void init_aip_from_class_and_profile(ai_info *aip, ai_class *aicp, ai_profile_t 
 
 void ai_do_default_behavior(object *obj)
 {
-    Assert(obj != nullptr);
-    Assert(obj->instance != -1);
-    Assert(obj->type == OBJ_SHIP);
-    Assert(Ships[obj->instance].ai_index != -1);
+    Assertion(obj != nullptr, "Ai_do_default_behavior() was given a bad information.  Specifically obj is a nullptr. This is a coder error, please report!");
+    Assertion((obj->type == OBJ_SHIP) && (obj->instance > -1) && (obj->instance < MAX_SHIPS), "This function that requires an object to be a ship was passed an invalid ship. Please report\n\nObject type: %d\nInstance #: %d", obj->type, obj->instance);
+    Assertion(Ships[obj->instance].ai_index > 0, "A ship has been found to have an invalid ai_index of %d. This should have been assigned and is coder mistake, please report!", Ships[obj->instance].ai_index);
 
     ai_info	*aip = &Ai_info[Ships[obj->instance].ai_index];
     ship_info* sip = &Ship_info[Ships[obj->instance].ship_info_index];

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -16155,7 +16155,7 @@ void maybe_cheat_fire_synaptic(object *objp)
 		ship	*shipp;
 		int	wing_index, time;
 
-		Assertion(objp->type == OBJ_SHIP, "maybe_cheat_fire_synaptic was called with a non-ship object type of %d. Please report!", objp->type);
+		Assertion(objp->type == OBJ_SHIP, "This ai function requires a ship, but was called with a non-ship object type of %d. Please report!", objp->type);
 
 		shipp = &Ships[objp->instance];
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15549,11 +15549,14 @@ void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal)
 			return;
 		
 		hitter_objnum = hit_objp->parent;
-		Assert((hitter_objnum >= 0) && (hitter_objnum < MAX_OBJECTS));
+		Assertion((hitter_objnum >= 0) && (hitter_objnum < MAX_OBJECTS), "hitter_objnum in this function is an invalid index of %d.  This can cause random behavior, and is a coder mistake.  Please report!", hitter_objnum);
 		objp_hitter = &Objects[hitter_objnum];
 
+		Assertion((objp_hitter->type == OBJ_SHIP) || (objp_hitter->type == OBJ_WEAPON) || (objp_hitter->type == OBJ_ASTEROID) || (objp_hitter->type == OBJ_BEAM) || (objp_hitter->type == OBJ_DEBRIS),
+		"The ai code is passing an invalid object type of %d to a function when trying to decide how to respond to something hitting it.  This is a bug in the code, please report!", objp_hitter->type);
+
 		// lets not check hits by ghosts any further either
-		if(objp_hitter->type != OBJ_SHIP && objp_hitter->type != OBJ_WEAPON && objp_hitter->type != OBJ_ASTEROID && objp_hitter->type != OBJ_BEAM)
+		if(objp_hitter->type != OBJ_SHIP && objp_hitter->type != OBJ_WEAPON && objp_hitter->type != OBJ_ASTEROID && objp_hitter->type != OBJ_BEAM && objp_hitter->type != OBJ_DEBRIS)
 			return;
 		
 		//	Hit by a protected ship, don't attack it.

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -16161,6 +16161,10 @@ void maybe_cheat_fire_synaptic(object *objp)
 
 		Assertion(objp->type == OBJ_SHIP, "This ai function requires a ship, but was called with a non-ship object type of %d. Please report!", objp->type);
 
+		if (objp->type != OBJ_SHIP) {
+			return;
+		}
+
 		shipp = &Ships[objp->instance];
 
 		if (!(strnicmp(shipp->ship_name, NOX("delta"), 5)))

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -10029,6 +10029,8 @@ void guard_object_was_hit(object *guard_objp, object *hitter_objp)
 					aip->active_goal = AI_ACTIVE_GOAL_DYNAMIC;
 				}
 			}
+		} else {
+			UNREACHABLE("The AI previously had a guard goal to guard something besides a ship, specifically an object of type %d. As we understand it, this should not happen. Please report!", Objects[aip->target_objnum].type);
 		}
 	}
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -15113,7 +15113,7 @@ void ai_do_default_behavior(object *obj)
 {
     Assertion(obj != nullptr, "Ai_do_default_behavior() was given a bad information.  Specifically obj is a nullptr. This is a coder error, please report!");
     Assertion((obj->type == OBJ_SHIP) && (obj->instance > -1) && (obj->instance < MAX_SHIPS), "This function that requires an object to be a ship was passed an invalid ship. Please report\n\nObject type: %d\nInstance #: %d", obj->type, obj->instance);
-    Assertion(Ships[obj->instance].ai_index > 0, "A ship has been found to have an invalid ai_index of %d. This should have been assigned and is coder mistake, please report!", Ships[obj->instance].ai_index);
+    Assertion(Ships[obj->instance].ai_index >= 0, "A ship has been found to have an invalid ai_index of %d. This should have been assigned and is coder mistake, please report!", Ships[obj->instance].ai_index);
 
     ai_info	*aip = &Ai_info[Ships[obj->instance].ai_index];
     ship_info* sip = &Ship_info[Ships[obj->instance].ship_info_index];

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -1530,6 +1530,8 @@ void hud_target_missile(object *source_obj, int next_flag)
 				continue;
 			}
 
+			Assertion(Objects[so->objnum].type == OBJ_SHIP, "hud_target_missile was about to call obj_team with a non-ship obejct with type %d. Please report!", Objects[so->objnum].type); 
+
 			// only allow targeting of hostile bombs
 			if (!iff_x_attacks_y(Player_ship->team, obj_team(A))) {
 				continue;

--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -1785,7 +1785,7 @@ void multi_ingame_send_ship_update(net_player *p)
 	// go through the list and send all ships which are mark as OF_COULD_BE_PLAYER
 	while(moveup!=END_OF_LIST(&Ship_obj_list)){
 		//Make sure the object can be a player and is on the same team as this guy
-		if(Objects[moveup->objnum].flags[Object::Object_Flags::Could_be_player] && obj_team(&Objects[moveup->objnum]) == p->p_info.team){
+		if(Objects[moveup->objnum].flags[Object::Object_Flags::Could_be_player] && Objects[moveup->objnum].type == OBJ_SHIP && obj_team(&Objects[moveup->objnum]) == p->p_info.team){
 			// send the update
 			send_ingame_ship_update_packet(p,&Ships[Objects[moveup->objnum].instance]);
 		}


### PR DESCRIPTION
An assert in `obj_team` is triggered very rarely, and we have yet to get a minidump or catch it in a debugger.  So I went through all the instances of `obj_team` and I tried to add checks or asserts that incoming objects were in fact what they should be (mostly ships).

There was one specific instance where already existing assertions should have been run before checking the object's team, on a code path having to do with friendly fire, which I hope is the cause.  Since I had to change that logic around, the indentations change and this PR looks a lot larger than it is.

In draft as it waits for testing, to make sure I didn't go too strict on the assertions.