### PR TITLE
Check string, not number in release version regex

### DIFF
--- a/ci/post/main.py
+++ b/ci/post/main.py
@@ -42,7 +42,7 @@ MAJOR_VERSION_PATTERN = re.compile("(?:set_if_not_defined|set)\(FSO_VERSION_MAJO
 MINOR_VERSION_PATTERN = re.compile("(?:set_if_not_defined|set)\(FSO_VERSION_MINOR (\d+)\)")
 BUILD_VERSION_PATTERN = re.compile("(?:set_if_not_defined|set)\(FSO_VERSION_BUILD (\d+)\)")
 REVISION_VERSION_PATTERN = re.compile("(?:set_if_not_defined|set)\(FSO_VERSION_REVISION (\d+)\)")
-REVISION_STR_VERSION_PATTERN = re.compile("(?:set_if_not_defined|set)\(FSO_VERSION_REVISION_STR (\d+)\)")
+REVISION_STR_VERSION_PATTERN = re.compile("(?:set_if_not_defined|set)\(FSO_VERSION_REVISION_STR (\w+)\)")
 
 LOG_FORMAT = """
 ------------------------------------------------------------------------%n


### PR DESCRIPTION
`REVISION_STR_VERSION_PATTERN` is not currently matching against a string, it is matching against a number