### PR TITLE
disable compilation warnings in BitOp

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -106,3 +106,6 @@ set_target_properties(code PROPERTIES XCODE_ATTRIBUTE_GCC_GENERATE_DEBUGGING_SYM
 set_target_properties(code PROPERTIES XCODE_ATTRIBUTE_COPY_PHASE_STRIP[variant=Debug] "NO")
 set_target_properties(code PROPERTIES XCODE_ATTRIBUTE_STRIP_INSTALLED_PRODUCT[variant=Debug] "NO")
 set_target_properties(code PROPERTIES XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN[variant=Debug] "NO")
+
+# Prevent GCC warnings in third-party BitOp... see GitHub #4366
+suppress_file_warnings(scripting/lua/bitop/bit.c)


### PR DESCRIPTION
Since bit.c is a third-party file, we can't modify it, so let's instead disable the warnings for it.

Follow-up to #4274.  Fixes #4366.