### PR TITLE
Fix FRED Crash with Team Colors

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10878,7 +10878,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	if (sip->uses_team_colors)
 	{
 		// wookieejedi - maintain team color setting if possible
-		if (!p_objp->team_color_setting.empty()) {
+		if (!Fred_running && !p_objp->team_color_setting.empty()) {
 			sp->team_name = p_objp->team_color_setting;
 		} else {
 			sp->team_name = sip->default_team_name;


### PR DESCRIPTION
`p_objp` cannot be used if FRED is running, and this PR adds that check to the updated team color fixes from #4207.

Fixes #4374