### PR TITLE
Changelog.py improvements and post-release-build.yaml debugging

### DIFF
--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -37,6 +37,10 @@ jobs:
     name: Post builds on Nebula and the forums
     runs-on: ubuntu-latest
     steps:
+      - name: Caller
+        # Name of what called this yaml.  Used to debug auto/manual step being triggered
+        run: echo "github.event_name= ${{ github.event_name }}"
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/ci/post/changelog.py
+++ b/ci/post/changelog.py
@@ -43,7 +43,7 @@ def get_last_page(response: requests.Response) -> int:
     
 
 def main():
-    parser = argparse.ArgumentParser(description="Retrives a log of commit messages and attempts to pretty them into a human-readbile format")
+    parser = argparse.ArgumentParser(description="Retrieves a log of commit messages and attempts to pretty them into a human-readable format")
     parser.add_argument("start_date",
                         help="Day of the earliest commit to add to the log.")
     parser.add_argument("-u", "--user", nargs=2, metavar=("NAME", "TOKEN"), default=["", ""],

--- a/ci/post/changelog.py
+++ b/ci/post/changelog.py
@@ -86,7 +86,7 @@ def main():
     url = "https://api.github.com/repos/scp-fs2open/fs2open.github.com/pulls"
     page = 1
     last_page = MAX_PAGES
-    while page < last_page + 1:
+    while page <= last_page:
         # GET <url>?base=master&sort=updated&direction=desc&state=closed&page=1
         response = requests.get(url,
         auth=(args.user[0], args.user[1]),

--- a/ci/post/changelog.py
+++ b/ci/post/changelog.py
@@ -1,5 +1,6 @@
 # Retrives a log of commit messages and attempts to pretty them into a human-readbile format
 
+import argparse
 import os
 import re
 import requests
@@ -42,9 +43,16 @@ def get_last_page(response: requests.Response) -> int:
     
 
 def main():
+    parser = argparse.ArgumentParser(description="Retrives a log of commit messages and attempts to pretty them into a human-readbile format")
+    parser.add_argument("start_date",
+                        help="Day of the earliest commit to add to the log.")
+    parser.add_argument("-u", "--user", nargs=2, metavar=("NAME", "TOKEN"), default=["", ""],
+                        help="Github username and token/password")
+
+    args = parser.parse_args()
+
     os.chdir(os.path.dirname(__file__))	# Change working directory to this file's directory
-    
-    start_date = datetime.strptime(sys.argv[1], "%Y-%m-%d")
+    start_date = datetime.strptime(args.start_date, "%Y-%m-%d")
 
     print("start_date: {}".format(start_date))
 
@@ -76,10 +84,13 @@ def main():
 
     changelog = {}
     url = "https://api.github.com/repos/scp-fs2open/fs2open.github.com/pulls"
+    page = 1
     last_page = MAX_PAGES
-    for page in range(1, last_page + 1):
+    while page < last_page + 1:
         # GET <url>?base=master&sort=updated&direction=desc&state=closed&page=1
-        response = requests.get(url, params={
+        response = requests.get(url,
+        auth=(args.user[0], args.user[1]),
+        params={
             "base": "master",
             "direction": "desc",
             "page": page,
@@ -139,6 +150,8 @@ def main():
                 }
                 print("Added pull #{} ({})".format(pull['number'], merge_date))
             # Else, silently ignore duplicate (for now...)
+
+        page += 1 # iterate to next page
 
 
     # Write the changelog to file


### PR DESCRIPTION
This adds an `echo` to print out the `github.event_name` of the calling workflow, so that the Auto Trigger can be debugged. (For some reason it hasn't been firing when called by Release.yaml)

Fixes Changelog.py going into an infinite loop due to not breaking out when page = last_page + 1, issue turned out to be due to how `for .. in ..` loops differ from C++'s `for` loops.

Also makes some improvements to the Changelog.py to be more user friendly as well as allow authentication to get around the REST API HTTP requests limits.