### PR TITLE
fix use of default tech database flags

### DIFF
--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -760,7 +760,6 @@ void techroom_change_tab(int num)
 	switch (Tab) {
 		case SHIPS_DATA_TAB:
             si_mask.set(multi ? Ship::Info_Flags::In_tech_database_m : Ship::Info_Flags::In_tech_database);
-            si_mask.set(multi ? Ship::Info_Flags::Default_in_tech_database_m : Ship::Info_Flags::Default_in_tech_database);
 			
 			// load ship info if necessary
 			if ( !Ships_loaded ) {
@@ -809,7 +808,6 @@ void techroom_change_tab(int num)
 				Weapon_list.reserve(Weapon_info.size());
 
 				wi_mask.set(multi ? Weapon::Info_Flags::Player_allowed : Weapon::Info_Flags::In_tech_database);
-                wi_mask.set(Weapon::Info_Flags::Default_in_tech_database);
 
 				int i = 0;
 				tech_list_entry temp_entry;

--- a/code/menuui/techmenu.h
+++ b/code/menuui/techmenu.h
@@ -25,7 +25,7 @@ typedef struct {
 // flags by Goober5000
 #define IIF_DEFAULT_VALUE				0
 #define IIF_IN_TECH_DATABASE			(1 << 0)	// in tech database? - Goober5000
-#define IIF_DEFAULT_IN_TECH_DATABASE	(1 << 1)	// in tech database by default? - Goober5000
+#define IIF_DEFAULT_IN_TECH_DATABASE	(1 << 1)	// this entry's default tech database status, as specified in species.tbl; used when the tech db is "reset to default" - Goober5000
 
 extern int Techroom_overlay_id;
 

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -182,8 +182,8 @@ namespace Ship {
 		Awacs,							// ditto
 		Knossos_device,					// this is the knossos device
 		No_fred,						// not available in fred
-		Default_in_tech_database,		// default in tech database - Goober5000
-		Default_in_tech_database_m,		// ditto - Goober5000
+		Default_in_tech_database,		// this entry's default tech database status, as specified in ships.tbl; used when the tech db is "reset to default" - Goober5000
+		Default_in_tech_database_m,		// ditto for multiplayer - Goober5000
 		Flash,							// makes a flash when it explodes
 		Show_ship_model,				// Show ship model even in first person view
 		Surface_shields,				// _argv[-1], 16 Jan 2005: Enable surface shields for this ship.

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -40,7 +40,7 @@ namespace Weapon {
 		Lockarm,							// if the missile was fired without a lock, it does significanlty less damage on impact
 		Ballistic,							// ballistic primaries - Goober5000
 		Pierce_shields,						// shield pierceing -Bobboau
-		Default_in_tech_database,			// default in tech database - Goober5000
+		Default_in_tech_database,			// this entry's default tech database status, as specified in weapons.tbl; used when the tech db is "reset to default" - Goober5000
 		Local_ssm,							// localized ssm. ship that fires ssm is in mission.  ssms also warp back in during mission
 		Tagged_only,						// can only fire if target is tagged
 		Cycle,								// will only fire from (shots (defalts to 1)) points at a time


### PR DESCRIPTION
The "default" tech database flags indicate whether entries are in the tech room by default, that is, when the table is originally parsed and the campaign is started.  Flags may be changed later, so that when the tech database is "reset to default" the flags can be returned to the known state as specified in the tables.

A bug was introduced back in commit c924e3997a (!) based on a misinterpretation of what "default" meant.  This fixes the bug and clarifies the flags.

Fixes #4390.