### PR TITLE
Disallow using Replace Container Data with special argument list

### DIFF
--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -1769,6 +1769,9 @@ void sexp_container_set_special_arg_status(int arg_handler_node, bool status)
 		"Attempt to set special argument status on invalid argument handler. Please report!");
 
 	for (int arg_node = CDR(arg_handler_node); arg_node != -1; arg_node = CDR(arg_node)) {
+		Assertion(Sexp_nodes[arg_node].subtype != SEXP_ATOM_CONTAINER_DATA,
+			"Attempt to use Replace Container Data as special argument option, which isn't supported. Please report!");
+
 		if (Sexp_nodes[arg_node].subtype == SEXP_ATOM_CONTAINER_NAME) {
 			const char *container_name = Sexp_nodes[arg_node].text;
 			auto *p_container = get_sexp_container(container_name);

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -902,7 +902,9 @@ void sexp_tree::right_clicked(int mode)
 
 							// Replace Container Data submenu
 							// disallowed on variable-type SEXP args, to prevent FSO/FRED crashes
-							if (op_type != OPF_VARIABLE_NAME) {
+							// also disallowed for special argument options (not supported for now)
+							if (op_type != OPF_VARIABLE_NAME && op_type != OPF_ANYTHING &&
+								op_type != OPF_DATA_OR_STR_CONTAINER) {
 								int container_data_index = 0;
 								for (const auto &container : get_all_sexp_containers()) {
 									UINT flags = MF_STRING | MF_GRAYED;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5494,7 +5494,8 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 
 				// Replace Container Data submenu
 				// disallowed on variable-type SEXP args, to prevent FSO/FRED crashes
-				if (op_type != OPF_VARIABLE_NAME) {
+				// also disallowed for special argument options (not supported for now)
+				if (op_type != OPF_VARIABLE_NAME && op_type != OPF_ANYTHING && op_type != OPF_DATA_OR_STR_CONTAINER) {
 					const auto &containers = get_all_sexp_containers();
 					for (int idx = 0; idx < (int)containers.size(); ++idx) {
 						const auto &container = containers[idx];


### PR DESCRIPTION
Given concerns about complications from concurrent modification, I think it's best to prohibit the use of Replace Container Data with special argument lists. This includes the special argument handler SEXPs that don't support containers, such as `random-of` and `in-sequence`.

This restriction applies *only to argument lists*; the condition and actions SEXPs can still use Replace Container Data.

We can always revisit this decision later.