### PR TITLE
add new hooks for each object type

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1628,6 +1628,13 @@ static void asteroid_maybe_break_up(object *pasteroid_obj)
 				scripting::hook_param_list(scripting::hook_param("Self", 'o', pasteroid_obj)),
 				pasteroid_obj);
 		}
+		if (scripting::hooks::OnAsteroidDeath->isActive()) {
+			scripting::hooks::OnAsteroidDeath->run(
+				scripting::hook_param_list(
+					scripting::hook_param("Asteroid", 'o', pasteroid_obj),
+					scripting::hook_param("Hitpos", 'o', asp->death_hit_pos)),
+				pasteroid_obj);
+		}
 	}
 }
 

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -4,23 +4,20 @@
 namespace scripting {
 namespace hooks {
 
-std::shared_ptr<scripting::Hook> OnGameInit = scripting::Hook::Factory("On Game Init",
+const std::shared_ptr<Hook> OnGameInit = Hook::Factory("On Game Init",
 	"Executed at the start of the engine after all game data has been loaded.",
 	{},
 	CHA_GAMEINIT);
 
-std::shared_ptr<OverridableHook> OnDeath = OverridableHook::Factory("On Death",
-	"Invoked when an object (ship or asteroid) has been destroyed.",
+const std::shared_ptr<Hook> OnDebrisCreated = Hook::Factory(
+	"On Debris Created",
+	"Invoked when a piece of debris is created.",
 	{
-		{"Self", "object", "The object that was killed"},
-		{"Ship", "ship", "The ship that was destroyed (only set for ships)"},
-		{"Killer", "object", "The object that caused the death (only set for ships)"},
-		{"Hitpos",
-			"vector",
-			"The position of the hit that caused the death (only set for ships and only if available)"},
+		{"Debris", "debris", "The newly created debris object"},
+		{"Source", "object", "The object (probably a ship) from which this debris piece was spawned."},
 	});
 
-std::shared_ptr<OverridableHook> OnShipCollision = OverridableHook::Factory("On Ship Collision",
+const std::shared_ptr<OverridableHook> OnShipCollision = OverridableHook::Factory("On Ship Collision",
 	"Invoked when a ship collides with another object. Note: When two ships collide this will be called twice, once "
 	"with each ship object as the \"Ship\" parameter.",
 	{{"Self", "object", "The \"other\" object that collided with the ship."},
@@ -35,6 +32,63 @@ std::shared_ptr<OverridableHook> OnShipCollision = OverridableHook::Factory("On 
 		{"ShipB", "ship", "For ship on ship collisions, the \"other\" ship."},
 		{"Weapon", "weapon", "The weapon object with which the ship collided (only set for weapon collisions)"},
 		{"Beam", "weapon", "The beam object with which the ship collided (only set for beam collisions)"}});
+
+const std::shared_ptr<Hook> OnShipDeathStarted = Hook::Factory(
+	"On Ship Death Started", "Called when a ship starts the death process.",
+	{
+		{"Ship", "ship", "The ship that has begun the death process."},
+		{"Killer", "object", "The object responsible for killing the ship.  Always set but could be invalid if there is no killer."},
+		{"Hitpos", "vector", "The world coordinates of the killing blow.  Could be nil."},
+	});
+
+const std::shared_ptr<Hook> OnShipDeath = Hook::Factory(
+	"On Ship Death", "Called when a ship has been destroyed.  Supersedes On Death for ships.",
+	{
+		{"Ship", "ship", "The ship that was destroyed."},
+		{"Killer", "object", "The object responsible for killing the ship.  Always set but could be invalid if there is no killer."},
+		{"Hitpos", "vector", "The world coordinates of the killing blow.  Could be nil."},
+	});
+
+const std::shared_ptr<Hook> OnMissileDeathStarted = Hook::Factory(
+	"On Missile Death Started", "Called when a missile is about to be destroyed (whether by impact, interception, or expiration).",
+	{
+		{"Weapon", "weapon", "The weapon that was destroyed."},
+		{"Object", "object", "The object that the weapon hit - a ship, asteroid, or piece of debris.  Always set but could be invalid if there is no other object.  If this missile was destroyed by another weapon, the 'other object' will be invalid but the DestroyedByWeapon flag will be set."},
+	});
+
+const std::shared_ptr<Hook> OnMissileDeath = Hook::Factory(
+	"On Missile Death", "Called when a missile has been destroyed (whether by impact, interception, or expiration).",
+	{
+		{"Weapon", "weapon", "The weapon that was destroyed."},
+		{"Object", "object", "The object that the weapon hit - a ship, asteroid, or piece of debris.  Always set but could be invalid if there is no other object.  If this missile was destroyed by another weapon, the 'other object' will be invalid but the DestroyedByWeapon flag will be set."},
+	});
+
+const std::shared_ptr<Hook> OnAsteroidDeath = Hook::Factory(
+	"On Asteroid Death", "Called when an asteroid has been destroyed.  Supersedes On Death for asteroids.",
+	{
+		{"Asteroid", "asteroid", "The asteroid that was destroyed."},
+		{"Hitpos", "vector", "The world coordinates of the killing blow."},
+	});
+
+const std::shared_ptr<Hook> OnDebrisDeath = Hook::Factory(
+	"On Debris Death", "Called when a piece of debris has been destroyed.",
+	{
+		{"Debris", "debris", "The piece of debris that was destroyed."},
+		{"Hitpos", "vector", "The world coordinates of the killing blow.  Could be nil."},
+	});
+
+// ========== DEPRECATED ==========
+
+const std::shared_ptr<OverridableHook> OnDeath = OverridableHook::Factory("On Death",
+	"Invoked when an object (ship or asteroid) has been destroyed.  Deprecated in favor of On Ship Destroyed and On Asteroid Destroyed.",
+	{
+		{"Self", "object", "The object that was killed"},
+		{"Ship", "ship", "The ship that was destroyed (only set for ships)"},
+		{"Killer", "object", "The object that caused the death (only set for ships)"},
+		{"Hitpos",
+			"vector",
+			"The position of the hit that caused the death (only set for ships and only if available)"},
+	});
 
 } // namespace hooks
 } // namespace scripting

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -41,7 +41,7 @@ const std::shared_ptr<Hook> OnShipDeathStarted = Hook::Factory(
 		{"Hitpos", "vector", "The world coordinates of the killing blow.  Could be nil."},
 	});
 
-const std::shared_ptr<Hook> OnShipDeath = Hook::Factory(
+const std::shared_ptr<OverridableHook> OnShipDeath = OverridableHook::Factory(
 	"On Ship Death", "Called when a ship has been destroyed.  Supersedes On Death for ships.",
 	{
 		{"Ship", "ship", "The ship that was destroyed."},

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -4,11 +4,21 @@
 namespace scripting {
 namespace hooks {
 
-extern std::shared_ptr<scripting::Hook> OnGameInit;
+extern const std::shared_ptr<Hook>            OnGameInit;
 
-extern std::shared_ptr<OverridableHook> OnDeath;
+extern const std::shared_ptr<Hook>            OnDebrisCreated;
 
-extern std::shared_ptr<OverridableHook> OnShipCollision;
+extern const std::shared_ptr<OverridableHook> OnShipCollision;
+
+extern const std::shared_ptr<Hook>            OnShipDeathStarted;
+extern const std::shared_ptr<Hook>            OnShipDeath;
+extern const std::shared_ptr<Hook>            OnMissileDeathStarted;
+extern const std::shared_ptr<Hook>            OnMissileDeath;
+extern const std::shared_ptr<Hook>            OnAsteroidDeath;
+extern const std::shared_ptr<Hook>            OnDebrisDeath;
+
+// deprecated
+extern const std::shared_ptr<OverridableHook> OnDeath;
 
 }
 } // namespace scripting

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -11,7 +11,7 @@ extern const std::shared_ptr<Hook>            OnDebrisCreated;
 extern const std::shared_ptr<OverridableHook> OnShipCollision;
 
 extern const std::shared_ptr<Hook>            OnShipDeathStarted;
-extern const std::shared_ptr<Hook>            OnShipDeath;
+extern const std::shared_ptr<OverridableHook> OnShipDeath;
 extern const std::shared_ptr<Hook>            OnMissileDeathStarted;
 extern const std::shared_ptr<Hook>            OnMissileDeath;
 extern const std::shared_ptr<Hook>            OnAsteroidDeath;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7886,11 +7886,11 @@ void ship_destroy_instantly(object *ship_objp, bool with_debris)
 	Assert(ship_objp->type == OBJ_SHIP);
 	Assert(!(ship_objp == Player_obj));
 
-	if (OnShipDeathStartedHook->isActive()) {
+	if (scripting::hooks::OnShipDeathStarted->isActive()) {
 		// add scripting hook for 'On Ship Death Started' -- Goober5000
 		// hook is placed at the beginning of this function to allow the scripter to
 		// actually have access to the ship before any death routines (such as mission logging) are executed
-		OnShipDeathStartedHook->run(scripting::hook_param_list(scripting::hook_param("Ship", 'o', ship_objp)));
+		scripting::hooks::OnShipDeathStarted->run(scripting::hook_param_list(scripting::hook_param("Ship", 'o', ship_objp)));
 	}
 
 	// undocking and death preparation
@@ -7905,6 +7905,11 @@ void ship_destroy_instantly(object *ship_objp, bool with_debris)
 	// scripting stuff
 	if (scripting::hooks::OnDeath->isActive()) {
 		scripting::hooks::OnDeath->run(scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
+			scripting::hook_param("Ship", 'o', ship_objp)),
+			ship_objp);
+	}
+	if (scripting::hooks::OnShipDeath->isActive()) {
+		scripting::hooks::OnShipDeath->run(scripting::hook_param_list(
 			scripting::hook_param("Ship", 'o', ship_objp)),
 			ship_objp);
 	}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1621,8 +1621,6 @@ extern void ship_cleanup(int shipnum, int cleanup_mode);
 extern void ship_destroy_instantly(object *ship_obj, bool with_debris = false);
 extern void ship_actually_depart(int shipnum, int method = SHIP_DEPARTED_WARP);
 
-extern const std::shared_ptr<scripting::Hook> OnShipDeathStartedHook;
-
 extern bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj);
 extern int ship_stop_fire_primary(object * obj);
 extern int ship_fire_primary(object * objp, int force = 0, bool rollback_shot = false);

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1800,6 +1800,7 @@ void ship_hit_kill(object *ship_objp, object *other_obj, vec3d *hitpos, float pe
 				hitpos != nullptr)));
 	}
 
+	// if the OnDeath override is enabled, run the hook and then exit
 	if (scripting::hooks::OnDeath->isActive())
 	{
 		auto onDeathParamList = scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
@@ -1812,6 +1813,23 @@ void ship_hit_kill(object *ship_objp, object *other_obj, vec3d *hitpos, float pe
 
 		if (scripting::hooks::OnDeath->isOverride(onDeathParamList, ship_objp)) {
 			scripting::hooks::OnDeath->run(onDeathParamList, ship_objp);
+			return;
+		}
+	}
+
+	// if the OnShipDeath override is enabled, run the hook and then exit
+	if (scripting::hooks::OnShipDeath->isActive())
+	{
+		auto onDeathParamList = scripting::hook_param_list(
+			scripting::hook_param("Ship", 'o', ship_objp),
+			scripting::hook_param("Killer", 'o', other_obj),
+			scripting::hook_param("Hitpos",
+				'o',
+				scripting::api::l_Vector.Set(hitpos ? *hitpos : vmd_zero_vector),
+				hitpos != nullptr));
+
+		if (scripting::hooks::OnShipDeath->isOverride(onDeathParamList, ship_objp)) {
+			scripting::hooks::OnShipDeath->run(onDeathParamList, ship_objp);
 			return;
 		}
 	}

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -80,14 +80,6 @@ const std::shared_ptr<scripting::Hook> OnPainFlashHook = scripting::Hook::Factor
 		{"Pain_Type", "number", "The type of pain flash displayed: shield = 0 and hull = 1."},
 	});
 
-const std::shared_ptr<scripting::Hook> OnShipDeathStartedHook = scripting::Hook::Factory(
-	"On Ship Death Started", "Called when a ship starts the death process.",
-	{
-		{"Ship", "ship", "The ship that has begun the death process."},
-		{"Killer", "object", "The object responsible for killing the ship.  Could be null."},
-		{"Hitpos", "vector", "The world coordinates of the killing blow.  Could be null."},
-	});
-
 
 //WMC - Camera rough draft stuff
 /*
@@ -1794,18 +1786,21 @@ void ship_hit_kill(object *ship_objp, object *other_obj, vec3d *hitpos, float pe
 {
 	Assert(ship_objp);	// Goober5000 - but not other_obj, not only for sexp but also for self-destruct
 
-	if (OnShipDeathStartedHook->isActive())
+	if (scripting::hooks::OnShipDeathStarted->isActive())
 	{
 		// add scripting hook for 'On Ship Death Started' -- Goober5000
 		// hook is placed at the beginning of this function to allow the scripter to
 		// actually have access to the ship before any death routines (such as mission logging) are executed
-		if (hitpos)
-			OnShipDeathStartedHook->run(scripting::hook_param_list(scripting::hook_param("Ship", 'o', ship_objp), scripting::hook_param("Killer", 'o', other_obj), scripting::hook_param("Hitpos", 'o', scripting::api::l_Vector.Set(*hitpos))));
-		else
-			OnShipDeathStartedHook->run(scripting::hook_param_list(scripting::hook_param("Ship", 'o', ship_objp), scripting::hook_param("Killer", 'o', other_obj)));
+		scripting::hooks::OnShipDeathStarted->run(scripting::hook_param_list(
+			scripting::hook_param("Ship", 'o', ship_objp),
+			scripting::hook_param("Killer", 'o', other_obj),
+			scripting::hook_param("Hitpos",
+				'o',
+				scripting::api::l_Vector.Set(hitpos ? *hitpos : vmd_zero_vector),
+				hitpos != nullptr)));
 	}
 
-	if(scripting::hooks::OnDeath->isActive())
+	if (scripting::hooks::OnDeath->isActive())
 	{
 		auto onDeathParamList = scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
 			scripting::hook_param("Ship", 'o', ship_objp),
@@ -1816,7 +1811,6 @@ void ship_hit_kill(object *ship_objp, object *other_obj, vec3d *hitpos, float pe
 				hitpos != nullptr));
 
 		if (scripting::hooks::OnDeath->isOverride(onDeathParamList, ship_objp)) {
-			//WMC - Do scripting stuff
 			scripting::hooks::OnDeath->run(onDeathParamList, ship_objp);
 			return;
 		}
@@ -1981,6 +1975,17 @@ void ship_hit_kill(object *ship_objp, object *other_obj, vec3d *hitpos, float pe
 				hitpos != nullptr));
 
 		scripting::hooks::OnDeath->run(onDeathParamList, ship_objp);
+	}
+	if (scripting::hooks::OnShipDeath->isActive()) {
+		auto onDeathParamList = scripting::hook_param_list(
+			scripting::hook_param("Ship", 'o', ship_objp),
+			scripting::hook_param("Killer", 'o', other_obj),
+			scripting::hook_param("Hitpos",
+				'o',
+				scripting::api::l_Vector.Set(hitpos ? *hitpos : vmd_zero_vector),
+				hitpos != nullptr));
+
+		scripting::hooks::OnShipDeath->run(onDeathParamList, ship_objp);
 	}
 }
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -39,7 +39,7 @@
 #include "object/objectsnd.h"
 #include "parse/parsehi.h"
 #include "parse/parselo.h"
-#include "scripting/scripting.h"
+#include "scripting/global_hooks.h"
 #include "particle/particle.h"
 #include "playerman/player.h"
 #include "radar/radar.h"
@@ -7015,7 +7015,7 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 //
 //	Call to figure out if a weapon is armed or not
 //
-//Weapon is armed when...
+//Weapon is unarmed when...
 //1: Weapon is shot down by weapon
 //OR
 //1: weapon is destroyed before arm time
@@ -7083,8 +7083,6 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 	weapon *wp;
 	bool		hit_target = false;
 
-	object      *other_objp;
-	ship_obj	*so;
 	ship		*shipp;
 	int         objnum;
 
@@ -7095,6 +7093,14 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 	wp = &Weapons[weapon_obj->instance];
 	wip = &Weapon_info[weapon_type];
 	objnum = wp->objnum;
+
+	if (scripting::hooks::OnMissileDeathStarted->isActive() && wip->subtype == WP_MISSILE) {
+		// analagous to On Ship Death Started
+		scripting::hooks::OnMissileDeathStarted->run(scripting::hook_param_list(
+			scripting::hook_param("Weapon", 'o', weapon_obj),
+			scripting::hook_param("Object", 'o', other_obj)),
+			weapon_obj);
+	}
 
 	// check if the weapon actually hit the intended target
 	if (weapon_has_homing_object(wp))
@@ -7245,11 +7251,11 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 		return;
 
 	// For all objects that had this weapon as a target, wipe it out, forcing find of a new enemy
-	for ( so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so) ) {
-		other_objp = &Objects[so->objnum];
-		Assert(other_objp->instance != -1);
+	for ( auto so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so) ) {
+		auto ship_objp = &Objects[so->objnum];
+		Assert(ship_objp->instance != -1);
         
-		shipp = &Ships[other_objp->instance];
+		shipp = &Ships[ship_objp->instance];
 		Assert(shipp->ai_index != -1);
         
 		ai_info	*aip = &Ai_info[shipp->ai_index];
@@ -7274,6 +7280,13 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 		if (aip->hitter_objnum == objnum) {
 			aip->hitter_objnum = -1;
         }
+	}
+
+	if (scripting::hooks::OnMissileDeath->isActive() && wip->subtype == WP_MISSILE) {
+		scripting::hooks::OnMissileDeath->run(scripting::hook_param_list(
+			scripting::hook_param("Weapon", 'o', weapon_obj),
+			scripting::hook_param("Object", 'o', other_obj)),
+			weapon_obj);
 	}
 
     weapon_obj->flags.set(Object::Object_Flags::Should_be_dead);


### PR DESCRIPTION
Splits the existing On Death hook into independent hooks for each relevant type.  Adds On Ship Death, On Missile Death, etc.  Also adds On Missile Death Started to complement On Ship Death Started.

Partial fix for #4394; the remainder of the fix will need to be done in the MediaVPs.