### PR TITLE
Fix the standalone ship being added to ship list

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1798,7 +1798,7 @@ void parse_dock_one_docked_object(p_object *pobjp, p_object *parent_pobjp)
 	ai_dock_with_object(objp, dockpoint, parent_objp, parent_dockpoint, AIDO_DOCK_NOW);
 }
 
-int parse_create_object_sub(p_object *objp);
+int parse_create_object_sub(p_object *objp, bool standalone_ship = false);
 
 // Goober5000
 void parse_create_docked_object_helper(p_object *pobjp, p_dock_function_info *infop)
@@ -1825,7 +1825,7 @@ void parse_create_docked_object_helper(p_object *pobjp, p_dock_function_info *in
  * This is a bit tricky because of the way initial docking is now handled.
  * Docking groups require special treatment.
  */
-int parse_create_object(p_object *pobjp)
+int parse_create_object(p_object *pobjp, bool standalone_ship)
 {
 	object *objp;
 
@@ -1841,7 +1841,7 @@ int parse_create_object(p_object *pobjp)
 		// if the leader will be destroyed before the mission starts, then *only* create the leader;
 		// don't create the rest of the group (this is what retail did)
 		if (pobjp->destroy_before_mission_time >= 0)
-			return parse_create_object_sub(pobjp);
+			return parse_create_object_sub(pobjp, standalone_ship);
 
 		// store the leader as a parameter
 		dfi.parameter_variables.objp_value = pobjp;
@@ -1861,7 +1861,7 @@ int parse_create_object(p_object *pobjp)
 	// create normally
 	else
 	{
-		parse_create_object_sub(pobjp);
+		parse_create_object_sub(pobjp, standalone_ship);
 	}
 
 	// get the main object
@@ -1894,7 +1894,7 @@ void parse_bring_in_docked_wing(p_object *p_objp, int wingnum, int shipnum);
  * Given a stuffed p_object struct, create an object and fill in the necessary fields.
  * @return object number.
  */
-int parse_create_object_sub(p_object *p_objp)
+int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 {
 	int	i, j, k, objnum, shipnum;
 	int anchor_objnum = -1;
@@ -1912,7 +1912,7 @@ int parse_create_object_sub(p_object *p_objp)
 	MONITOR_INC(NumShipArrivals, 1);
 
 	// base level creation - need ship name in case of duplicate textures
-	objnum = ship_create(&p_objp->orient, &p_objp->pos, p_objp->ship_class, p_objp->name);
+	objnum = ship_create(&p_objp->orient, &p_objp->pos, p_objp->ship_class, p_objp->name, standalone_ship);
 	Assert(objnum != -1);
 	shipnum = Objects[objnum].instance;
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1841,7 +1841,7 @@ int parse_create_object(p_object *pobjp, bool standalone_ship)
 		// if the leader will be destroyed before the mission starts, then *only* create the leader;
 		// don't create the rest of the group (this is what retail did)
 		if (pobjp->destroy_before_mission_time >= 0)
-			return parse_create_object_sub(pobjp, standalone_ship);
+			return parse_create_object_sub(pobjp);
 
 		// store the leader as a parameter
 		dfi.parameter_variables.objp_value = pobjp;

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -495,7 +495,7 @@ p_object *mission_parse_get_arrival_ship(const char *name);
 bool mission_check_ship_yet_to_arrive(const char *name);
 p_object *mission_parse_get_parse_object(ushort net_signature);
 p_object *mission_parse_get_parse_object(const char *name);
-int parse_create_object(p_object *objp);
+int parse_create_object(p_object *objp, bool standalone_ship = false);
 void resolve_parse_flags(object *objp, flagset<Mission::Parse_Object_Flags> &parse_flags);
 
 void mission_parse_close();

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -1564,7 +1564,7 @@ void multi_create_standalone_object()
 	Net_player->m_player->objnum = objnum;
 
 	// create the default player ship object and use that as my default virtual "ship", and make it "invisible"
-	pobj_num = parse_create_object(Player_start_pobject);
+	pobj_num = parse_create_object(Player_start_pobject, true);
 	Assert(pobj_num != -1);
     flagset<Object::Object_Flags> tmp_flags;
 	obj_set_flags(&Objects[pobj_num], tmp_flags + Object::Object_Flags::Player_ship);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -196,7 +196,7 @@ int	Player_ship_class;	// needs to be player specific, move to player structure
 #define		SHIP_OBJ_USED	(1<<0)				// flag used in ship_obj struct
 #define		MAX_SHIP_OBJS	MAX_SHIPS			// max number of ships tracked in ship list
 ship_obj		Ship_objs[MAX_SHIP_OBJS];		// array used to store ship object indexes
-ship_obj		Ship_obj_list;							// head of linked list of ship_obj structs
+ship_obj		Ship_obj_list;							// head of linked list of ship_obj structs, Standalone ship cannot be in this list or it will cause bugs.
 
 SCP_vector<ship_info>	Ship_info;
 reinforcements	Reinforcements[MAX_REINFORCEMENTS];
@@ -9882,7 +9882,7 @@ static void ship_init_afterburners(ship *shipp)
  * Returns object index of ship.
  * @return -1 means failed.
  */
-int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name)
+int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name, bool standalone_ship)
 {
 	int			i, n, objnum, j, k, t;
 	ship_info	*sip;
@@ -10074,8 +10074,10 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 
 	animation::anim_set_initial_states(shipp);
 
-	// Add this ship to Ship_obj_list
-	shipp->ship_list_index = ship_obj_list_add(objnum);
+	// Add this ship to Ship_obj_list, if it is *not* the standalone ship.  That can cause big time bugs.
+	if (!standalone_ship){
+		shipp->ship_list_index = ship_obj_list_add(objnum);
+	}
 
 	// Goober5000 - update the ship registry
 	// (since scripts and sexps can create ships, the entry may not yet exist)

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1584,7 +1584,7 @@ extern void ship_init();				// called once	at game start
 extern void ship_level_init();		// called before the start of each level
 
 //returns -1 if failed
-extern int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name = nullptr);
+extern int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name = nullptr, bool standalone_ship = false);
 extern void change_ship_type(int n, int ship_type, int by_sexp = 0);
 extern void ship_process_pre( object * objp, float frametime );
 extern void ship_process_post( object * objp, float frametime );


### PR DESCRIPTION
While it may seem counterintuitive, we have to keep the standalone bogus ship from being added to the ship object list so that we don't have to exclude it from all the places it could cause crashes or mysterious AI behaviors.  Both were being observed, and this should fix them.

I literally looked at every single place that the list is used, and most instances are potentially problematic, with other instances being benign, but none of them serving any practical use.