### PR TITLE
Properly set rotation data from LuaAI

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -586,6 +586,7 @@ extern void ai_do_default_behavior(object *obj);
 extern void ai_start_waypoints(object *objp, waypoint_list *wp_list, int wp_flags);
 extern void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal);
 extern void ai_ship_destroy(int shipnum);
+extern vec3d ai_get_acc_limit(vec3d* vel_limit, const object* objp);
 extern void ai_turn_towards_vector(vec3d *dest, object *objp, vec3d *slide_vec, vec3d *rel_pos, float bank_override, int flags, vec3d *rvec = nullptr, vec3d* turnrate_mod = nullptr);
 extern void init_ai_object(int objnum);
 extern void ai_init(void);				//	Call this one to parse ai.tbl.

--- a/code/scripting/api/objs/ai_helper.cpp
+++ b/code/scripting/api/objs/ai_helper.cpp
@@ -6,6 +6,8 @@
 #include "vecmath.h"
 
 #include "ai/ai.h"
+#include "mission/missionparse.h"
+#include "ship/ship.h"
 
 namespace scripting {
 namespace api {
@@ -39,19 +41,65 @@ inline int aici_getset_helper(lua_State* L, float control_info::* value) {
 	return ade_set_args(L, "f", AI_ci.*value);
 }
 
-ADE_VIRTVAR(Pitch, l_AI_Helper, "number", "The pitch rate for the ship this frame, -1 to 1", "number", "The pitch rate, or 0 if the handle is invalid")
-{
-	return aici_getset_helper(L, &control_info::pitch);
+inline int pi_rotation_getset_helper(lua_State* L, int axis) {
+	//Use with care! This works only if, as expected, the l_AI_Helper object is the one supplied to the luaai scripts this very frame
+	object_h ship;
+	float f = 0.0f;
+	if (!ade_get_args(L, "o|f", l_AI_Helper.Get(&ship), &f))
+		return ade_set_error(L, "f", 0.0f);
+
+	if (!ship.IsValid())
+		return ade_set_error(L, "f", 0.0f);
+
+	vec3d vel_limit;
+	// get the turn rate if we have Use_axial_turnrate_differences
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Use_axial_turnrate_differences]) {
+		vel_limit = Ship_info[Ships[ship.objp->instance].ship_info_index].max_rotvel;
+	}
+	else { // else get the turn time
+		float turn_time = Ship_info[Ships[ship.objp->instance].ship_info_index].srotation_time;
+
+		if (turn_time > 0.0f)
+		{
+			vel_limit.xyz.x = PI2 / turn_time;
+			vel_limit.xyz.y = PI2 / turn_time;
+			vel_limit.xyz.z = PI2 / turn_time;
+		}
+	}
+	vec3d acc_limit = ai_get_acc_limit(&vel_limit, ship.objp);
+
+	float currentThrustVel = ((ship.objp->phys_info.desired_rotvel.a1d[axis] - ship.objp->phys_info.rotvel.a1d[axis]) / AI_frametime) / acc_limit.a1d[axis];
+
+	if (ADE_SETTING_VAR) {
+		currentThrustVel = f;
+		float targetVel = currentThrustVel * acc_limit.a1d[axis] * AI_frametime + ship.objp->phys_info.rotvel.a1d[axis];
+		CLAMP(targetVel, -vel_limit.a1d[axis], vel_limit.a1d[axis]);
+		ship.objp->phys_info.desired_rotvel.a1d[axis] = targetVel;
+
+		vec3d rotstep = ship.objp->phys_info.desired_rotvel * AI_frametime;
+
+		matrix	rotmat;
+		angles rotangles{ rotstep.xyz.x, rotstep.xyz.z, rotstep.xyz.y };
+		vm_angles_2_matrix(&rotmat, &rotangles);
+		vm_matrix_x_matrix(&ship.objp->phys_info.ai_desired_orient, &ship.objp->orient, &rotmat);
+	}
+
+	return ade_set_args(L, "f", currentThrustVel);
 }
 
-ADE_VIRTVAR(Bank, l_AI_Helper, "number", "The bank rate for the ship this frame, -1 to 1", "number", "The bank rate, or 0 if the handle is invalid")
+ADE_VIRTVAR(Pitch, l_AI_Helper, "number", "The pitch thrust rate for the ship this frame, -1 to 1", "number", "The pitch rate, or 0 if the handle is invalid")
 {
-	return aici_getset_helper(L, &control_info::bank);
+	return pi_rotation_getset_helper(L, 0);
 }
 
-ADE_VIRTVAR(Heading, l_AI_Helper, "number", "The heading rate for the ship this frame, -1 to 1", "number", "The heading rate, or 0 if the handle is invalid")
+ADE_VIRTVAR(Bank, l_AI_Helper, "number", "The bank thrust rate for the ship this frame, -1 to 1", "number", "The bank rate, or 0 if the handle is invalid")
 {
-	return aici_getset_helper(L, &control_info::heading);
+	return pi_rotation_getset_helper(L, 2);
+}
+
+ADE_VIRTVAR(Heading, l_AI_Helper, "number", "The heading thrust rate for the ship this frame, -1 to 1", "number", "The heading rate, or 0 if the handle is invalid")
+{
+	return pi_rotation_getset_helper(L, 1);
 }
 
 ADE_VIRTVAR(ForwardThrust, l_AI_Helper, "number", "The forward thrust rate for the ship this frame, -1 to 1", "number", "The forward thrust rate, or 0 if the handle is invalid")

--- a/code/scripting/api/objs/ai_helper.cpp
+++ b/code/scripting/api/objs/ai_helper.cpp
@@ -68,11 +68,11 @@ inline int pi_rotation_getset_helper(lua_State* L, int axis) {
 	}
 	vec3d acc_limit = ai_get_acc_limit(&vel_limit, ship.objp);
 
-	float currentThrustVel = ((ship.objp->phys_info.desired_rotvel.a1d[axis] - ship.objp->phys_info.rotvel.a1d[axis]) / AI_frametime) / acc_limit.a1d[axis];
+	float currentThrustRate = ((ship.objp->phys_info.desired_rotvel.a1d[axis] - ship.objp->phys_info.rotvel.a1d[axis]) / AI_frametime) / acc_limit.a1d[axis];
 
 	if (ADE_SETTING_VAR) {
-		currentThrustVel = f;
-		float targetVel = currentThrustVel * acc_limit.a1d[axis] * AI_frametime + ship.objp->phys_info.rotvel.a1d[axis];
+		currentThrustRate = f;
+		float targetVel = currentThrustRate * acc_limit.a1d[axis] * AI_frametime + ship.objp->phys_info.rotvel.a1d[axis];
 		CLAMP(targetVel, -vel_limit.a1d[axis], vel_limit.a1d[axis]);
 		ship.objp->phys_info.desired_rotvel.a1d[axis] = targetVel;
 
@@ -84,7 +84,7 @@ inline int pi_rotation_getset_helper(lua_State* L, int axis) {
 		vm_matrix_x_matrix(&ship.objp->phys_info.ai_desired_orient, &ship.objp->orient, &rotmat);
 	}
 
-	return ade_set_args(L, "f", currentThrustVel);
+	return ade_set_args(L, "f", currentThrustRate);
 }
 
 ADE_VIRTVAR(Pitch, l_AI_Helper, "number", "The pitch thrust rate for the ship this frame, -1 to 1", "number", "The pitch rate, or 0 if the handle is invalid")


### PR DESCRIPTION
Previously, rotation data was just written to the AI_ci, which, for rotation, is reset _and_ ignored.
Now fixes this, and properly resembles thrust (as described), regarding tabled damping and turntime values, as well as properly interacting with other AI functions setting the rotation.