### PR TITLE
A comprehensive fix for the `player.target_is_dying` variable.

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1515,6 +1515,7 @@ void hud_update_frame(float  /*frametime*/)
 	}
 
 	if (Player_ai->target_objnum == -1) {
+		Player->target_is_dying = -1; // according to comments elsewhere in the code, set to -1 when no target
 		hud_target_change_check();
 		return;
 	}

--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -395,7 +395,12 @@ void HudGaugeBrackets::renderObjectBrackets(object *targetp, color *clr, int w_c
 	int bound_rc;
 	SCP_list<CJumpNode>::iterator jnp;
 
-	if ( Player->target_is_dying <= 0 || (Player_ai->target_objnum >= 0 && targetp != &Objects[Player_ai->target_objnum])) {
+
+	bool not_player_target = (Player_ai->target_objnum < 0 || targetp != &Objects[Player_ai->target_objnum]);
+
+
+	// target_is_dying is set to zero when the target is not dying, -1 when no target. Only 1, aka "TRUE", is invalid.
+	if ( not_player_target || Player->target_is_dying <= 0) {
 		int modelnum;
 
 		switch ( targetp->type ) {
@@ -475,7 +480,13 @@ void HudGaugeBrackets::renderObjectBrackets(object *targetp, color *clr, int w_c
 			int target_objnum = -1;
 
 			if(flags & TARGET_DISPLAY_DIST) {
-				distance = Player_ai->current_target_distance;
+				// since we can have either the target, or rogue asteroids bracketed,
+				// check which case we are in, and then do the correct distance.
+				if (not_player_target) {
+					distance = hud_find_target_distance(targetp, &Player_obj->pos);
+				} else {
+					distance = Player_ai->current_target_distance;
+				}
 			}
 
 			if(flags & TARGET_DISPLAY_DOTS) {

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -194,7 +194,8 @@ void HudGaugeLock::renderOld(float frametime)
 		return;
 	}
 
-	if (Player->target_is_dying) {
+	// 1 is the only value for which your target is actually dying
+	if (Player->target_is_dying == 1) {
 		return;
 	}
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4523,6 +4523,7 @@ void HudGaugeTargetTriangle::render(float  /*frametime*/)
 	object *targetp = &Objects[Player_ai->target_objnum];
 
 	// draw the targeting triangle that orbits the outside of the outer circle of the reticle
+	// checking !target_is_dying is correct here, since you do not want -1 (no target) or 1(is actually dying)
 	if (!Player->target_is_dying && maybeFlashSexp() != 1) {
 
 		hud_set_iff_color(targetp, 1);

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1373,7 +1373,7 @@ void player_level_init()
 	Player->cargo_scan_loop    = sound_handle::invalid();
 	Player->cargo_inspect_time = 0;			// time that current target's cargo has been inspected for
 
-	Player->target_is_dying = -1;				// The player target is dying, set to -1 if no target
+	Player->target_is_dying = -1;				// Whether the player target is dying, -1 if no target
 	Player->current_target_sx = -1;			// Screen x-pos of current target (or subsystem if applicable)
 	Player->current_target_sy = -1;			// Screen y-pos of current target (or subsystem if applicable)
 	Player->target_in_lock_cone = -1;		// Is the current target in secondary weapon lock cone?


### PR DESCRIPTION
A comprehensive fix for the `target_is_dying` variable.

Retail expected this variable to be set to -1 when the player target had died, but that assignment was only on the player struct reset.  So this adds an assignment when it's been determined that there is no current valid target.  I also added comments and made sure the logic was consistent on all the checks.  There is a little bit of redundancy on the checks, but honestly that's probably better in c++.  But there is more than one way to fix this, so I'm open if anyone feels strongly that it should be done another way.

Tested and works as expected.
Closes #4393 
