### PR TITLE
Fix issues with loading of hud config presets

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -74,7 +74,7 @@ cf_pathtype Pathtypes[CF_MAX_PATH_TYPES]  = {
 	{ CF_TYPE_FONT,					"data" DIR_SEPARATOR_STR "fonts",											".vf .ttf .otf",						CF_TYPE_DATA	},
 	{ CF_TYPE_EFFECTS,				"data" DIR_SEPARATOR_STR "effects",											".ani .eff .pcx .neb .tga .jpg .png .dds .sdr",	CF_TYPE_DATA	},
 	{ CF_TYPE_HUD,					"data" DIR_SEPARATOR_STR "hud",												".pcx .ani .eff .tga .jpg .png .dds",	CF_TYPE_DATA	},
-	{ CF_TYPE_PLAYERS,				"data" DIR_SEPARATOR_STR "players",											".hcf",								CF_TYPE_DATA	},
+	{ CF_TYPE_PLAYERS,				"data" DIR_SEPARATOR_STR "players",											".hcf", /* DON'T add pilot files here!! */	CF_TYPE_DATA	},
 	{ CF_TYPE_PLAYER_IMAGES,		"data" DIR_SEPARATOR_STR "players" DIR_SEPARATOR_STR "images",				".pcx .png .dds",						CF_TYPE_PLAYERS	},
 	{ CF_TYPE_SQUAD_IMAGES,			"data" DIR_SEPARATOR_STR "players" DIR_SEPARATOR_STR "squads",				".pcx .png .dds",						CF_TYPE_PLAYERS	},
 	{ CF_TYPE_SINGLE_PLAYERS,		"data" DIR_SEPARATOR_STR "players" DIR_SEPARATOR_STR "single",				".pl2 .cs2 .plr .csg .css .json",	CF_TYPE_PLAYERS	},

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -1551,7 +1551,7 @@ int cf_get_file_list(SCP_vector<SCP_string>& list, int pathtype, const char* fil
 	}
 
 	bool skip_packfiles = false;
-	if ( (pathtype == CF_TYPE_PLAYERS) || (pathtype == CF_TYPE_SINGLE_PLAYERS) || (pathtype == CF_TYPE_MULTI_PLAYERS) ) {
+	if ( (pathtype == CF_TYPE_SINGLE_PLAYERS) || (pathtype == CF_TYPE_MULTI_PLAYERS) ) {
 		skip_packfiles = true;
 	} else if (Get_file_list_child != NULL) {
 		skip_packfiles = true;
@@ -1708,7 +1708,7 @@ int cf_get_file_list(int max, char** list, int pathtype, const char* filter, int
 	}
 
 	bool skip_packfiles = false;
-	if ((pathtype == CF_TYPE_PLAYERS) || (pathtype == CF_TYPE_SINGLE_PLAYERS) || (pathtype == CF_TYPE_MULTI_PLAYERS)) {
+	if ((pathtype == CF_TYPE_SINGLE_PLAYERS) || (pathtype == CF_TYPE_MULTI_PLAYERS)) {
 		skip_packfiles = true;
 	}
 	else if (Get_file_list_child != NULL) {
@@ -1887,7 +1887,7 @@ int cf_get_file_list_preallocated(int max, char arr[][MAX_FILENAME_LEN], char** 
 	}
 
 	bool skip_packfiles = false;
-	if ((pathtype == CF_TYPE_PLAYERS) || (pathtype == CF_TYPE_SINGLE_PLAYERS) || (pathtype == CF_TYPE_MULTI_PLAYERS)) {
+	if ((pathtype == CF_TYPE_SINGLE_PLAYERS) || (pathtype == CF_TYPE_MULTI_PLAYERS)) {
 		skip_packfiles = true;
 	}
 	else if (Get_file_list_child != NULL) {

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -1981,14 +1981,26 @@ int cf_get_file_list_preallocated(int max, char arr[][MAX_FILENAME_LEN], char** 
 // Output:  path      - Fully qualified pathname.
 //Returns 0 if the result would be too long (invalid result)
 int cf_create_default_path_string(char* path, uint path_max, int pathtype, const char* filename, bool localize,
-                                  uint32_t location_flags)
+                                  uint32_t _location_flags)
 {
+	uint32_t location_flags = _location_flags;
+
 	if ( filename && strchr(filename, DIR_SEPARATOR_CHAR) ) {
 		// Already has full path
 		strncpy( path, filename, path_max );
 
 	} else {
 		cf_root* root = nullptr;
+
+		// override location flags for path types which should always come from the root (NOT mod directories)
+		// NOTE: cache directories should NOT be added here to avoid possible mod breakage
+		switch(pathtype) {
+			case CF_TYPE_PLAYERS:
+			case CF_TYPE_MULTI_PLAYERS:
+			case CF_TYPE_SINGLE_PLAYERS:
+				location_flags = CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT;
+				break;
+		}
 
 		for (auto i = 0; i < Num_roots; ++i) {
 			auto current_root = cf_get_root(i);


### PR DESCRIPTION
This allows for retail hud config presets to once again show up in the list, as they were previously excluded from the file cache. Additionally it fixes newly created presets that were unable to be found without a restart when a mod is specified.