### PR TITLE
New options for lead indicators

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -3953,8 +3953,9 @@ void HudGaugeLeadIndicator::renderLeadCurrentTarget()
 	{
 		int bank = swp->current_secondary_bank;
 		tmp = &Weapon_info[swp->secondary_bank_weapons[bank]];
-		if ( !(tmp->is_homing()) && !(tmp->is_locked_homing() && Player->target_in_lock_cone) ) {
-			//The secondary lead indicator is handled farther below if it is a non-locking type
+		if ( tmp->wi_flags[Weapon::Info_Flags::Dont_merge_indicators] 
+		|| (!(tmp->is_homing()) && !(tmp->is_locked_homing() && Player->target_in_lock_cone) )) {
+			//The secondary lead indicator is handled farther below if it is a non-locking type, or if the Dont_merge_indicators flag is set for it.
 			srange = -1.0f;
 		}
 	}
@@ -4073,9 +4074,10 @@ void HudGaugeLeadIndicator::renderLeadCurrentTarget()
 	if((swp->current_secondary_bank>=0) && (swp->secondary_bank_weapons[swp->current_secondary_bank] >= 0)) {
 		int bank=swp->current_secondary_bank;
 		wip=&Weapon_info[swp->secondary_bank_weapons[bank]];
+		bool dontmerge = wip->wi_flags[Weapon::Info_Flags::Dont_merge_indicators];
 
 		//get out of here if the secondary weapon is a homer or if its out of range
-		if ( wip->is_homing() )
+		if ( wip->is_homing() && !wip->wi_flags[Weapon::Info_Flags::Dont_merge_indicators] )
 			return;
 
 		double max_dist = MIN((wip->lifetime * wip->max_speed), wip->weapon_range);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4025,9 +4025,7 @@ void HudGaugeLeadIndicator::renderLeadCurrentTarget()
 			renderIndicator(frame_offset, targetp, &lead_target_pos);
 		}
 	}
-
-	if ( bank_to_fire < 0 )
-		return;
+	else return;
 
 	//do dumbfire lead indicator - color is orange (255,128,0) - bright, (192,96,0) - dim
 	//phreak changed 9/01/02

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4074,7 +4074,6 @@ void HudGaugeLeadIndicator::renderLeadCurrentTarget()
 	if((swp->current_secondary_bank>=0) && (swp->secondary_bank_weapons[swp->current_secondary_bank] >= 0)) {
 		int bank=swp->current_secondary_bank;
 		wip=&Weapon_info[swp->secondary_bank_weapons[bank]];
-		bool dontmerge = wip->wi_flags[Weapon::Info_Flags::Dont_merge_indicators];
 
 		//get out of here if the secondary weapon is a homer or if its out of range
 		if ( wip->is_homing() && !wip->wi_flags[Weapon::Info_Flags::Dont_merge_indicators] )

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4019,7 +4019,7 @@ void HudGaugeLeadIndicator::renderLeadCurrentTarget()
 			}
 		}
 		if (Lead_indicator_behavior == leadIndicatorBehavior::AVERAGE) {
-			averaged_lead_pos = averaged_lead_pos/average_instances;
+			averaged_lead_pos = averaged_lead_pos/i2fl(average_instances);
 			renderIndicator(frame_offset, targetp, &averaged_lead_pos);
 		}
 	}

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -69,6 +69,12 @@ extern const char *Strafe_submode_text[];
 
 extern void hud_init_targeting_colors();
 
+enum leadIndicatorBehavior {
+    DEFAULT = 0,
+    MULTIPLE,
+    AVERAGE
+};
+
 /// \brief An abbreviation for "Evaluate Ship as Closest Target", defines a 
 ///        data structure used to hold the required arguments for evaluating 
 ///        a prospective closest target to an attacked object.

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -69,7 +69,7 @@ extern const char *Strafe_submode_text[];
 
 extern void hud_init_targeting_colors();
 
-enum leadIndicatorBehavior {
+enum class leadIndicatorBehavior {
     DEFAULT = 0,
     MULTIPLE,
     AVERAGE

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -103,6 +103,7 @@ bool Show_subtitle_uses_pixels;
 int Show_subtitle_screen_base_res[2];
 int Show_subtitle_screen_adjusted_res[2];
 bool Always_warn_player_about_unbound_keys;
+leadIndicatorBehavior Lead_indicator_behavior;
 shadow_disable_overrides Shadow_disable_overrides {false, false, false, false};
 float Thruster_easing;
 
@@ -933,6 +934,30 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Custom_briefing_icons_always_override_standard_icons);
 		}
 
+		if (optional_string("$Lead indicator behavior:")){
+			SCP_string temp;
+			stuff_string(temp, F_RAW);
+			SCP_tolower(temp);
+
+			if (temp == "default")
+			{
+				Lead_indicator_behavior = leadIndicatorBehavior::DEFAULT;
+			}
+			else if (temp == "multiple")
+			{
+				Lead_indicator_behavior = leadIndicatorBehavior::MULTIPLE;
+			}
+			else if (temp == "average")
+			{
+				Lead_indicator_behavior = leadIndicatorBehavior::AVERAGE;
+			}
+			else
+			{
+				Warning(LOCATION, "$Lead indicator behavior: Invalid selection. Must be default, multiple or average. Reverting to default.");
+				Lead_indicator_behavior = leadIndicatorBehavior::DEFAULT;
+			}
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -1064,6 +1089,7 @@ void mod_table_reset()
 	Show_subtitle_screen_adjusted_res[0] = -1;
 	Show_subtitle_screen_adjusted_res[1] = -1;
 	Always_warn_player_about_unbound_keys = false;
+	Lead_indicator_behavior = leadIndicatorBehavior::DEFAULT;
 	Thruster_easing = 0;
 }
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -12,6 +12,7 @@
 #include "globalincs/pstypes.h"
 #include "globalincs/systemvars.h"
 #include "graphics/2d.h"
+#include "hud/hudtarget.h"
 
 extern int Directive_wait_time;
 extern bool True_loop_argument_sexps;
@@ -92,6 +93,7 @@ extern bool Show_subtitle_uses_pixels;
 extern int Show_subtitle_screen_base_res[];
 extern int Show_subtitle_screen_adjusted_res[];
 extern bool Always_warn_player_about_unbound_keys;
+extern leadIndicatorBehavior Lead_indicator_behavior;
 extern struct shadow_disable_overrides {
 	bool disable_techroom, disable_mission_select_weapons, disable_mission_select_ships, disable_cockpit;
 } Shadow_disable_overrides;

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -90,6 +90,7 @@ namespace Weapon {
 		No_collide,
 		Multilock_target_dead_subsys,
 		No_evasion,							// AI will not attempt to dodge this weapon - Asteroth
+		Dont_merge_indicators,				// This secondary lead indicator won't be merged with the primary lead indicator even if this is a homing weapon.
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -194,6 +194,7 @@ flag_def_list_new<Weapon::Info_Flags> Weapon_Info_Flags[] = {
 	{ "no collide",						Weapon::Info_Flags::No_collide,						    true, false },
 	{ "multilock target dead subsys",   Weapon::Info_Flags::Multilock_target_dead_subsys,		true, false },
 	{ "no evasion",						Weapon::Info_Flags::No_evasion,						    true, false },
+	{ "don't merge lead indicators",	Weapon::Info_Flags::Dont_merge_indicators,			    true, false },
 };
 
 const size_t num_weapon_info_flags = sizeof(Weapon_Info_Flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);


### PR DESCRIPTION
Adds a new game_settings.tbl option: `$Lead indicator behavior`, which can be set to `default`, `multiple` or `average`. 
Also adds a new flag to weapons.tbl: `don't merge lead indicators`

When `$Lead indicator behavior` is set to `default` (or unset), lead indicators act just like in retail, meaning when you link them, only the indicator for the one with the farthest range will be drawn.
When set to `multiple`, a lead indicator is drawn for all primary weapons in range when you have them linked.  
When set to `average`, a single lead indicator is drawn in the average of the position where each of them would usually be drawn.  
Invalid selections will revert to default and give a warning.

When Weapon flag `don't merge lead indicators` is set for a homing secondary, its lead indicator will be drawn as if it was a dumbfire missile. 