### PR TITLE
end the campaign properly when a mission is skipped

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1822,7 +1822,12 @@ void mission_campaign_exit_loop()
 
 	// set things up for next mission
 	mission_campaign_next_mission();
-	gameseq_post_event(GS_EVENT_START_GAME);
+
+	if ( Campaign.next_mission == -1 || (The_mission.flags[Mission::Mission_Flags::End_to_mainhall]) ) {
+		gameseq_post_event( GS_EVENT_MAIN_MENU );
+	} else {
+		gameseq_post_event( GS_EVENT_START_GAME );
+	}
 }
 
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -351,7 +351,7 @@ void brief_skip_training_pressed()
 	mission_campaign_eval_next_mission();
 	mission_campaign_mission_over();	
 
-	if ( The_mission.flags[Mission::Mission_Flags::End_to_mainhall] ) {
+	if ( Campaign.next_mission == -1 || (The_mission.flags[Mission::Mission_Flags::End_to_mainhall]) ) {
 		gameseq_post_event( GS_EVENT_MAIN_MENU );
 	} else {
 		gameseq_post_event( GS_EVENT_START_GAME );


### PR DESCRIPTION
The "skip training" button and the "exit loop" button should both check whether the campaign is actually over before attempting to load the next mission.  The fix is simple - just use the same logic as in `mission_campaign_skip_to_next`.

Fixes #4412.