### PR TITLE
only display one popup when the player gets to the main hall

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -1059,6 +1059,7 @@ void main_hall_do(float frametime)
 
 	// see if we have a missing campaign and force the player to select a new campaign if so
 	extern bool Campaign_room_no_campaigns;
+	bool popup_shown = false;
 	if ( !(Player->flags & PLAYER_FLAGS_IS_MULTI) && Campaign_file_missing && !Campaign_room_no_campaigns ) {
 		int rc = popup(0, 3, XSTR("Go to Campaign Room", 1607), XSTR("Select another pilot", 1608), XSTR("Exit Game", 1609), XSTR("The currently active campaign cannot be found.  Please select another...", 1600));
 
@@ -1079,13 +1080,20 @@ void main_hall_do(float frametime)
 				gameseq_post_event(GS_EVENT_CAMPAIGN_ROOM);
 				break;
 		}
+
+		// since all paths in this code block will take us to a different state, don't display any more popups
+		popup_shown = true;
 	}
 
 	// Display a popup if playermenu loaded a player file with a different version than expected
-	player_tips_controls();
+	if (!popup_shown) {
+		popup_shown = player_tips_controls();
+	}
 
 	// maybe run the player tips popup
-	player_tips_popup();
+	if (!popup_shown) {
+		player_tips_popup();
+	}
 
 	// if we were supposed to skip a frame, then stop doing it after 1 frame
 	if (Main_hall_frame_skip) {

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -1459,7 +1459,10 @@ void player_tips_popup()
 	} while(ret > 0);
 }
 
-void player_tips_controls() {
+/**
+ * Displays a popup notification if the pilot was converted from pre-22.0 which might disrupt control settings.  Returns true if the popup was shown.
+ */
+bool player_tips_controls() {
 	if (Player->save_flags & PLAYER_FLAGS_PLR_VER_PRE_CONTROLS5) {
 		// Special case. Since the Controls5 PR is significantly different from retail, users must be informed
 		// of changes regarding their bindings
@@ -1476,7 +1479,11 @@ void player_tips_controls() {
 			Pilot.save_player(Player);
 			Pilot.save_savefile();
 		}
+
+		return true;
 	}
+
+	return false;
 }
 
 SCP_vector<SCP_string> player_select_enumerate_pilots() {

--- a/code/menuui/playermenu.h
+++ b/code/menuui/playermenu.h
@@ -41,7 +41,7 @@ int player_select_get_last_pilot();
 void player_tips_init();
 void player_tips_close();
 void player_tips_popup();
-void player_tips_controls();
+bool player_tips_controls();
 
 // quick check to make sure we always load default campaign savefile values when loading from the pilot
 // select screen but let us not overwrite current values with defaults when we aren't - taylor


### PR DESCRIPTION
There are three popups of decreasing priority that can appear in the main hall screen: campaign not found, pilot upgraded, and player tip.  Only one of these should actually be displayed -- the first popup will take the player to a different screen, rendering subsequent popups useless; and the second popup is more important than the third popup.  This PR prioritizes the popups accordingly.

Yes, this uses `goto`.  It's a succinct and clear way of implementing the necessary logic.  It works better than both a one-iteration loop and a cascading if() block.

Fixes #4418.