### PR TITLE
fix parsing issues with hud color presets

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1613,6 +1613,7 @@ void hud_config_color_load(const char *name)
 	int idx;
 	char str[1024];
 	char *fname;
+	ubyte r, g, b, a;
 
 	fname = cf_add_ext(name, ".hcf");
 
@@ -1630,13 +1631,18 @@ void hud_config_color_load(const char *name)
 		while (optional_string("+Gauge:")) {
 			stuff_string(str, F_NAME, sizeof(str));
 
+			required_string("+RGBA:");
+			stuff_ubyte(&r);
+			stuff_ubyte(&g);
+			stuff_ubyte(&b);
+			stuff_ubyte(&a);
+
 			for (idx = 0; idx < NUM_HUD_GAUGES; idx++) {
-				if (!stricmp(str, Hud_Gauge_Names[idx])) {
-					required_string("+RGBA:");
-					stuff_ubyte(&HUD_config.clr[idx].red);
-					stuff_ubyte(&HUD_config.clr[idx].green);
-					stuff_ubyte(&HUD_config.clr[idx].blue);
-					stuff_ubyte(&HUD_config.clr[idx].alpha);
+				if (!stricmp(str, HC_gauge_descriptions(idx))) {
+					HUD_config.clr[idx].red = r;
+					HUD_config.clr[idx].green = g;
+					HUD_config.clr[idx].blue = b;
+					HUD_config.clr[idx].alpha = a;
 					break;
 				}
 			}


### PR DESCRIPTION
The first issue is that if a gauge isn't found it will fail to parse any remaining gauges in the file. The second issue is that when saving the preset the game uses translated strings for the gauge name but when loading the preset it uses untranslated strings.

This should address both issues while keeping the original purpose of the changes as well as not breaking existing presets or requiring any mod changes.

Ref: http://scp.indiegames.us/mantis/view.php?id=3099