### PR TITLE
Autotrigger on either workflow_call or push event.

### DIFF
--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -51,7 +51,7 @@ jobs:
         run: pip install -r ci/post/requirements.txt
 
       - name: Post Builds (Auto trigger)
-        if: ${{ github.event_name == 'workflow_call' }}
+        if: ${{ github.event_name == 'workflow_call' }} || ${{ github.event_name == 'push' }}
         env:
           LINUX_RESULT: ${{ github.event.inputs.linux_result }}
           WINDOWS_RESULT: ${{ github.event.inputs.windows_result }}


### PR DESCRIPTION
Auto-trigger in the Post-Build-Release workflow wasn't firing because the workflow inherited its caller's `github.event_name` of `push` instead of the expected `workflow_call`.  This changes it so that either event type will fire the auto-trigger in case github decides to change things.