### PR TITLE
fix crash when removing form-on-wing

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1235,6 +1235,10 @@ int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp )
 		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
 		goalmode = AI_GOAL_IGNORE_NEW;
 		break;
+	case OP_AI_FORM_ON_WING:
+		priority = 99;
+		goalmode = AI_GOAL_FORM_ON_WING;
+		break;
 	default:
 		const ai_mode_lua* luaAIMode = ai_lua_find_mode(op);
 		if(luaAIMode != nullptr){
@@ -1251,7 +1255,7 @@ int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp )
 			priority = localnode >= 0 ? atoi( CTEXT(localnode) ) : -1;
 		}
 		else {
-			UNREACHABLE("Invalid SEXP-OP number %d for an AI goal!", op);
+			UNREACHABLE("Invalid SEXP-OP %s (number %d) for an AI goal!", Sexp_nodes[node].text, op);
 		}
 		break;
 	};


### PR DESCRIPTION
This goal was missed in `ai_remove_goal_sexp_sub`, so add handling for it.  Also make the error message clearer in case another goal is missed in the future.

~~In draft status until it can be tested by Durandal.~~  Tested and verified.