### PR TITLE
Fix/post build release autotrigger01

### DIFF
--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -51,7 +51,7 @@ jobs:
         run: pip install -r ci/post/requirements.txt
 
       - name: Post Builds (Auto trigger)
-        if: ${{ github.event_name == 'workflow_call' }} || ${{ github.event_name == 'push' }}
+        if: ${{ (github.event_name == 'workflow_call') || (github.event_name == 'push') }}
         env:
           LINUX_RESULT: ${{ inputs.linux_result }}
           WINDOWS_RESULT: ${{ inputs.windows_result }}

--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -30,7 +30,7 @@ env:
   NEBULA_PASSWORD: ${{ secrets.NEBULA_PASSWORD }}
   HLP_API: ${{ secrets.HLP_API }}
   HLP_KEY: ${{ secrets.HLP_KEY }}
-  RELEASE_TAG: ${{ github.event.inputs.releaseTag }}
+  RELEASE_TAG: ${{ inputs.releaseTag }}
 
 jobs:
   post_builds:
@@ -53,8 +53,8 @@ jobs:
       - name: Post Builds (Auto trigger)
         if: ${{ github.event_name == 'workflow_call' }} || ${{ github.event_name == 'push' }}
         env:
-          LINUX_RESULT: ${{ github.event.inputs.linux_result }}
-          WINDOWS_RESULT: ${{ github.event.inputs.windows_result }}
+          LINUX_RESULT: ${{ inputs.linux_result }}
+          WINDOWS_RESULT: ${{ inputs.windows_result }}
         run: python ci/post/main.py release
 
       - name: Post Builds (Manual trigger)


### PR DESCRIPTION
Use correct contexts when trying to pass job results to workflow_dispatch workflows.

Autotrigger correctly gets the inputs now.

Autotrigger was grabbing the workflow_dispatch meant for manual trigger due to a logical weirdness with github's `${{ }}` syntax.  Moving the logical OR to be within the brackets resolves the issue of it being evaluated as always true.