### PR TITLE
add ships.tbl override for turret fov

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2814,7 +2814,7 @@ bool turret_adv_fov_test(ship_subsys *ss, vec3d *gvec, vec3d *v2e, float size_mo
 bool turret_fov_test(ship_subsys *ss, vec3d *gvec, vec3d *v2e, float size_mod)
 {
 	bool in_fov = false;
-	if (ss->system_info->flags[Model::Subsystem_Flags::Turret_restricted_fov])
+	if (ss->system_info->flags[Model::Subsystem_Flags::Turret_base_restricted_fov])
 		in_fov = turret_adv_fov_test(ss, gvec, v2e, size_mod);
 	else
 		in_fov = turret_std_fov_test(ss, gvec, v2e, size_mod);

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -41,7 +41,8 @@ namespace Model {
 		Fire_on_target,		// prevents turret from firing unless it is pointing at the firingpoints are pointing at the target
 		No_ss_targeting,	// toggles the subsystem targeting for the turret
 		Turret_reset_idle,	// makes turret reset to their initial position if the target is out of field of view
-		Turret_restricted_fov,	// tells the game to use additional calculations should turret have a limited base fov or elevation
+		Turret_base_restricted_fov,	// tells the game to use additional calculations should turret have a limited base fov or elevation
+		Turret_barrel_override_fov,	// indicates the ships.tbl FOV should override the POF FOV
 		Carry_shockwave,	// subsystem - even with 'carry no damage' flag - will carry shockwave damage to the hull
 		Allow_landing,		// This subsystem can be landed on
 		Fov_edge_check,		// Tells the game to use better FOV edge checking with this turret

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -706,7 +706,11 @@ static void set_subsystem_info(int model_num, model_subsystem *subsystemp, char 
 		else
 			strcpy_s(buf,"180");
 		angle = fl_radians(atoi(buf))/2.0f;
-		subsystemp->turret_fov = cosf(angle);
+
+		// don't set the turret FOV if it has already been set (e.g. through ships.tbl)
+		if (!subsystemp->flags[Model::Subsystem_Flags::Turret_barrel_override_fov])
+			subsystemp->turret_fov = cosf(angle);
+
 		subsystemp->turret_num_firing_points = 0;
 
 		if (in(p, props, "$crewspot")) {
@@ -4039,7 +4043,7 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 		}
 	}
 
-	if (turret->flags[Model::Subsystem_Flags::Turret_restricted_fov])
+	if (turret->flags[Model::Subsystem_Flags::Turret_base_restricted_fov])
 		limited_base_rotation = true;
 
 	//------------

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4739,6 +4739,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			float	turning_rate;
 			float	percentage_of_hits;
 			bool turret_has_base_fov = false;
+			bool turret_has_barrel_fov = false;
 			model_subsystem *sp = NULL;			// to append on the ships list of subsystems
 			
 			int sfo_return;
@@ -4915,6 +4916,15 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				turret_has_base_fov = true;
 			}
 
+			if (optional_string("$Turret Barrel FOV:")) {
+				int value;
+				stuff_int(&value);
+				CAP(value, 0, 359);
+				float angle = fl_radians(value) / 2.0f;
+				sp->turret_fov = cosf(angle);
+				turret_has_barrel_fov = true;
+			}
+
 			if (optional_string("$Turret Reset Delay:"))
 				stuff_int(&sp->turret_reset_delay);
 
@@ -5010,7 +5020,9 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			}
 
             if (turret_has_base_fov)
-                sp->flags.set(Model::Subsystem_Flags::Turret_restricted_fov);
+                sp->flags.set(Model::Subsystem_Flags::Turret_base_restricted_fov);
+			if (turret_has_barrel_fov)
+				sp->flags.set(Model::Subsystem_Flags::Turret_barrel_override_fov);
 
 			if (optional_string("+non-targetable")) {
 				Warning(LOCATION, "Grammar error in table file.  Please change \"+non-targetable\" to \"+untargetable\".");

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -4018,7 +4018,7 @@ int beam_ok_to_fire(beam *b)
 
 			if (b->flags & BF_IS_FIGHTER_BEAM) {
 				turret_normal = b->objp->orient.vec.fvec;
-                b->subsys->system_info->flags.remove(Model::Subsystem_Flags::Turret_restricted_fov);
+                b->subsys->system_info->flags.remove(Model::Subsystem_Flags::Turret_base_restricted_fov);
 			} else {
 				model_instance_local_to_global_dir(&turret_normal, &b->subsys->system_info->turret_norm, Ships[b->objp->instance].model_instance_num, b->subsys->system_info->subobj_num, &b->objp->orient, true);
 			}


### PR DESCRIPTION
Add `$Turret Barrel FOV:` option for turrets in ships.tbl, as requested by CP5670.