### PR TITLE
Ignore Wshadow warnings in stale librocket headers

### DIFF
--- a/code/scpui/IncludeNodeHandler.h
+++ b/code/scpui/IncludeNodeHandler.h
@@ -4,7 +4,12 @@
 #pragma push_macro("Assert")
 #undef Assert
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 #include <Rocket/Core/XMLNodeHandler.h>
+
+#pragma GCC diagnostic pop
 
 #pragma pop_macro("Assert")
 

--- a/code/scpui/SoundPlugin.h
+++ b/code/scpui/SoundPlugin.h
@@ -6,8 +6,13 @@
 #pragma push_macro("Assert")
 #undef Assert
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 #include <Rocket/Core.h>
 #include <Rocket/Core/Plugin.h>
+
+#pragma GCC diagnostic pop
 
 #pragma pop_macro("Assert")
 

--- a/code/scpui/elements/AnimationElement.cpp
+++ b/code/scpui/elements/AnimationElement.cpp
@@ -7,11 +7,16 @@
 #pragma push_macro("Assert")
 #undef Assert
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 #include <Rocket/Core.h>
 #include <Rocket/Core/ElementDocument.h>
 #include <Rocket/Core/GeometryUtilities.h>
 #include <Rocket/Core/String.h>
 #include <scpui/RocketRenderingInterface.h>
+
+#pragma GCC diagnostic pop
 
 #pragma pop_macro("Assert")
 

--- a/code/scpui/elements/AnimationElement.h
+++ b/code/scpui/elements/AnimationElement.h
@@ -4,9 +4,14 @@
 #pragma push_macro("Assert")
 #undef Assert
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Geometry.h>
 #include <Rocket/Core/Texture.h>
+
+#pragma GCC diagnostic pop
 
 #pragma pop_macro("Assert")
 

--- a/code/scpui/elements/ScrollingTextElement.cpp
+++ b/code/scpui/elements/ScrollingTextElement.cpp
@@ -10,7 +10,12 @@
 #pragma push_macro("Assert")
 #undef Assert
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 #include <Rocket/Core.h>
+
+#pragma GCC diagnostic pop
 
 #pragma pop_macro("Assert")
 

--- a/code/scpui/elements/ScrollingTextElement.h
+++ b/code/scpui/elements/ScrollingTextElement.h
@@ -4,9 +4,14 @@
 #pragma push_macro("Assert")
 #undef Assert
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+
 #include <Rocket/Core/Element.h>
 #include <Rocket/Core/Geometry.h>
 #include <Rocket/Core/Texture.h>
+
+#pragma GCC diagnostic pop
 
 #pragma pop_macro("Assert")
 


### PR DESCRIPTION
GCC 11 raises a warning due to a parameter "word" shadowing a typedef "word". I made a PR correcting
that to the upstream repo some time ago, which is still ignored. This is the last remaining issue with GCC 11.