### PR TITLE
even more fixes for the skip-training-mission crash

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -951,7 +951,7 @@ void mission_campaign_store_goals_and_events()
 	int cur, i;
 	cmission *mission_obj;
 
-	if (!(Game_mode & GM_CAMPAIGN_MODE))
+	if (!(Game_mode & GM_CAMPAIGN_MODE) || (Campaign.current_mission < 0))
 		return;
 
 	cur = Campaign.current_mission;
@@ -1030,7 +1030,7 @@ void mission_campaign_store_variables(int persistence_type, bool store_red_alert
 	int cur, i, j;
 	cmission *mission_obj;
 
-	if (!(Game_mode & GM_CAMPAIGN_MODE))
+	if (!(Game_mode & GM_CAMPAIGN_MODE) || (Campaign.current_mission < 0))
 		return;
 
 	cur = Campaign.current_mission;
@@ -1098,7 +1098,7 @@ void mission_campaign_store_variables(int persistence_type, bool store_red_alert
 // jg18 - adapted from mission_campaign_store_variables()
 void mission_campaign_store_containers(ContainerType persistence_type, bool store_red_alert)
 {
-	if (!(Game_mode & GM_CAMPAIGN_MODE))
+	if (!(Game_mode & GM_CAMPAIGN_MODE) || (Campaign.current_mission < 0))
 		return;
 
 	if (!sexp_container_has_persistent_non_eternal_containers()) {
@@ -1901,7 +1901,7 @@ void mission_campaign_save_on_close_variables()
 	int i;
 
 	// make sure we are actually playing a single-player campaign
-	if (!(Game_mode & GM_CAMPAIGN_MODE) || (Campaign.type != CAMPAIGN_TYPE_SINGLE))
+	if (!(Game_mode & GM_CAMPAIGN_MODE) || (Campaign.type != CAMPAIGN_TYPE_SINGLE) || (Campaign.current_mission < 0))
 		return;
 
 	// now save variables
@@ -1941,7 +1941,7 @@ void mission_campaign_save_on_close_variables()
 void mission_campaign_save_on_close_containers()
 {
 	// make sure we are actually playing a single-player campaign
-	if (!(Game_mode & GM_CAMPAIGN_MODE) || (Campaign.type != CAMPAIGN_TYPE_SINGLE))
+	if (!(Game_mode & GM_CAMPAIGN_MODE) || (Campaign.type != CAMPAIGN_TYPE_SINGLE) || (Campaign.current_mission < 0))
 		return;
 
 	// now save containers


### PR DESCRIPTION
As noted in #4412, it's possible for `Campaign.current_mission` to be -1 even in campaign mode.  This explictly checks for that.