### PR TITLE
add some logging to waitAsync

### DIFF
--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -29,7 +29,8 @@ static const char *FILTERS_ENABLED_BY_DEFAULT[] =
 {
 	"error",
 	"warning",
-	"general"
+	"general",
+	"scripting"
 };
 
 struct outwnd_filter_struct {

--- a/code/scripting/api/LuaPromise.cpp
+++ b/code/scripting/api/LuaPromise.cpp
@@ -92,7 +92,7 @@ LuaPromise::LuaPromise(const std::shared_ptr<resolve_context>& resolveContext) :
 {
 	m_state->state = State::Pending;
 
-	// This executes promises eagerly since registering the callback kicks of the async operation
+	// This executes promises eagerly since registering the callback kicks off the async operation
 	m_state->registerResolveCallback(resolveContext);
 }
 

--- a/code/scripting/api/libs/async.cpp
+++ b/code/scripting/api/libs/async.cpp
@@ -111,7 +111,7 @@ ADE_FUNC(promise,
 	"function(function(any resolveVal) => void resolve, function(any errorVal) => void reject) => void body",
 	"Creates a promise that resolves when the resolve function of the callback is called or errors if the reject "
 	"function is called. The function will be called "
-	"on it's own.",
+	"on its own.",
 	"promise",
 	"The promise or nil on error")
 {

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1732,7 +1732,7 @@ ADE_FUNC(waitAsync,
 		time_resolve_context(int timestamp) : m_timestamp(timestamp) {
 			static int unique_id_counter = 0;
 			m_unique_id = unique_id_counter++;
-			mprintf(("waitAsync: Creating asynchronous context %d.\n", m_unique_id));
+			nprintf(("scripting", "waitAsync: Creating asynchronous context %d.\n", m_unique_id));
 		}
 		void setResolver(Resolver resolver) override
 		{
@@ -1747,7 +1747,7 @@ ADE_FUNC(waitAsync,
 				}
 
 				if (timestamp_elapsed(m_timestamp)) {
-					mprintf(("waitAsync: Timestamp has elapsed for asynchronous context %d.\n", m_unique_id));
+					nprintf(("scripting", "waitAsync: Timestamp has elapsed for asynchronous context %d.\n", m_unique_id));
 					resolver(false, luacpp::LuaValueList());
 					return executor::Executor::CallbackResult::Done;
 				}


### PR DESCRIPTION
Log when the context is created, completes, and is aborted.  Adds insight for the situation described in #4432.