### PR TITLE
Auto-accept completed campaign mission before exiting game from debriefing screen

### DIFF
--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -709,7 +709,7 @@ void options_button_pressed(int n)
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			choice = popup( PF_NO_NETWORKING | PF_BODY_BIG, 2, POPUP_NO, POPUP_YES, XSTR( "Exit Game?", 374));
 			if ( choice == 1 ) {
-				if (gameseq_get_state() == GS_STATE_DEBRIEF && (Game_mode & GM_CAMPAIGN_MODE)) {
+				if (gameseq_get_state(1) == GS_STATE_DEBRIEF && (Game_mode & GM_CAMPAIGN_MODE)) {
 					// auto-accept mission outcome before quitting
 					debrief_maybe_auto_accept();
 				}

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -25,6 +25,7 @@
 #include "menuui/optionsmenu.h"
 #include "menuui/optionsmenumulti.h"
 #include "mission/missionbriefcommon.h"
+#include "missionui/missiondebrief.h"
 #include "missionui/missionscreencommon.h"
 #include "nebula/neb.h"
 #include "network/multi.h"
@@ -707,8 +708,13 @@ void options_button_pressed(int n)
 		case ABORT_GAME_BUTTON:
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			choice = popup( PF_NO_NETWORKING | PF_BODY_BIG, 2, POPUP_NO, POPUP_YES, XSTR( "Exit Game?", 374));
-			if ( choice == 1 )
+			if ( choice == 1 ) {
+				if (gameseq_get_state() == GS_STATE_DEBRIEF && (Game_mode & GM_CAMPAIGN_MODE)) {
+					// auto-accept mission outcome before quitting
+					debrief_maybe_auto_accept();
+				}
 				gameseq_post_event(GS_EVENT_QUIT_GAME);
+			}
 			break;
 
 		case CONTROL_CONFIG_BUTTON:

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -378,6 +378,7 @@ int Debrief_should_show_popup = 1;
 static int Debrief_skip_popup_already_shown = 0;
 
 void debrief_text_init();
+bool debrief_can_accept();
 void debrief_accept(int ok_to_post_start_game_event = 1);
 void debrief_kick_selected_player();
 
@@ -1268,12 +1269,17 @@ void debrief_assemble_optional_mission_popup_text(char *buffer, char *mission_lo
 	strcat(buffer, XSTR("\n\n\nDo you want to play the optional mission?", 1491));
 }
 
+bool debrief_can_accept()
+{
+	return !(/*Cheats_enabled ||*/ Turned_traitor || Must_replay_mission);
+}
+
 // what to do when the accept button is hit
 void debrief_accept(int ok_to_post_start_game_event)
 {
 	int go_loop = 0;
 
-	if ( (/*Cheats_enabled ||*/ Turned_traitor || Must_replay_mission) && (Game_mode & GM_CAMPAIGN_MODE) ) {
+	if ( !debrief_can_accept() && (Game_mode & GM_CAMPAIGN_MODE) ) {
 		const char *str;
 		int z;
 
@@ -2554,6 +2560,13 @@ void debrief_rebuild_player_list()
 void debrief_handle_player_drop()
 {
 	debrief_rebuild_player_list();
+}
+
+void debrief_maybe_auto_accept()
+{
+	if (debrief_can_accept()) {
+		debrief_accept(0);
+	}
 }
 
 void debrief_disable_accept()

--- a/code/missionui/missiondebrief.h
+++ b/code/missionui/missiondebrief.h
@@ -25,6 +25,7 @@ void debrief_close();
 void debrief_rebuild_player_list();
 void debrief_handle_player_drop();
 
+void debrief_maybe_auto_accept();
 void debrief_disable_accept();
 void debrief_assemble_optional_mission_popup_text(char *buffer, char *mission_loop_desc);
 


### PR DESCRIPTION
If the player exits the game from the options menu while at the debriefing screen after completing a mission during a campaign, then auto-accept the mission outcome.

Has not yet been scrutinized/tested.

Should fix Issue #4309.