### PR TITLE
Fix AI Goal Display Strings

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15843,7 +15843,7 @@ SCP_string ship_return_orders(ship* sp)
 			outbuf += target_name;
 			outbuf += XSTR(" wing", 494);
 		} else {
-			sprintf(outbuf, "%s", XSTR("no orders", 495));
+			outbuf = XSTR("no orders", 495);
 		}
 		break;
 
@@ -15852,7 +15852,7 @@ SCP_string ship_return_orders(ship* sp)
 			outbuf += XSTR("any ", -1);
 			outbuf += target_name;
 		} else {
-			sprintf(outbuf, "%s", XSTR("no orders", 495));
+			outbuf = XSTR("no orders", 495);
 		}
 		break;
 
@@ -15868,7 +15868,7 @@ SCP_string ship_return_orders(ship* sp)
 		if (aigp->target_name) {
 			outbuf += target_name;
 		} else {
-			sprintf(outbuf, "%s", XSTR("no orders", 495));
+			outbuf = XSTR("no orders", 495);
 		}
 		break;
 
@@ -15879,7 +15879,7 @@ SCP_string ship_return_orders(ship* sp)
 			hud_targetbox_truncate_subsys_name(subsys_name);
 			sprintf(outbuf, XSTR("atk %s %s", 496), target_name, subsys_name);
 		} else {
-			sprintf(outbuf, "%s", XSTR("no orders", 495));
+			outbuf = XSTR("no orders", 495);
 		}
 		break;
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15843,7 +15843,7 @@ SCP_string ship_return_orders(ship* sp)
 			outbuf += target_name;
 			outbuf += XSTR(" wing", 494);
 		} else {
-			outbuf += XSTR("no orders", 495);
+			sprintf(outbuf, XSTR("no orders", 495));
 		}
 		break;
 
@@ -15852,7 +15852,7 @@ SCP_string ship_return_orders(ship* sp)
 			outbuf += XSTR("any ", -1);
 			outbuf += target_name;
 		} else {
-			outbuf += XSTR("no orders", 495);
+			sprintf(outbuf, XSTR("no orders", 495));
 		}
 		break;
 
@@ -15868,7 +15868,7 @@ SCP_string ship_return_orders(ship* sp)
 		if (aigp->target_name) {
 			outbuf += target_name;
 		} else {
-			outbuf += XSTR("no orders", 495);
+			sprintf(outbuf, XSTR("no orders", 495));
 		}
 		break;
 
@@ -15879,7 +15879,7 @@ SCP_string ship_return_orders(ship* sp)
 			hud_targetbox_truncate_subsys_name(subsys_name);
 			sprintf(outbuf, XSTR("atk %s %s", 496), target_name, subsys_name);
 		} else {
-			outbuf += XSTR("no orders", 495);
+			sprintf(outbuf, XSTR("no orders", 495));
 		}
 		break;
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15843,7 +15843,7 @@ SCP_string ship_return_orders(ship* sp)
 			outbuf += target_name;
 			outbuf += XSTR(" wing", 494);
 		} else {
-			sprintf(outbuf, XSTR("no orders", 495));
+			sprintf(outbuf, "%s", XSTR("no orders", 495));
 		}
 		break;
 
@@ -15852,7 +15852,7 @@ SCP_string ship_return_orders(ship* sp)
 			outbuf += XSTR("any ", -1);
 			outbuf += target_name;
 		} else {
-			sprintf(outbuf, XSTR("no orders", 495));
+			sprintf(outbuf, "%s", XSTR("no orders", 495));
 		}
 		break;
 
@@ -15868,7 +15868,7 @@ SCP_string ship_return_orders(ship* sp)
 		if (aigp->target_name) {
 			outbuf += target_name;
 		} else {
-			sprintf(outbuf, XSTR("no orders", 495));
+			sprintf(outbuf, "%s", XSTR("no orders", 495));
 		}
 		break;
 
@@ -15879,7 +15879,7 @@ SCP_string ship_return_orders(ship* sp)
 			hud_targetbox_truncate_subsys_name(subsys_name);
 			sprintf(outbuf, XSTR("atk %s %s", 496), target_name, subsys_name);
 		} else {
-			sprintf(outbuf, XSTR("no orders", 495));
+			sprintf(outbuf, "%s", XSTR("no orders", 495));
 		}
 		break;
 	}


### PR DESCRIPTION
Okay so previously, if a target goal was not valid the code was
`strcpy(outbuf, XSTR("no orders", 495)); `

but then it was changed to
`outbuf += XSTR("no orders", 495);`

So it would instead append the "no orders" instead of properly replace the whole string. Looks just like a copy and paster oversight, since all the other text appends the name of the target with the order.

This PR correctly replaces, rather than appends that text. Fixes #4345