### PR TITLE
Prevent accidental skip cutscene at loading screen

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -716,8 +716,7 @@ namespace os
 void os_ignore_events() {
 	SDL_Event event;
 	while (SDL_PollEvent(&event)) {
-		// Add event to buffer
-		buffered_events.push_back(event);
+		// ignore event
 	}
 }
 


### PR DESCRIPTION
os_ignore_events() was buffering events instead of ignoring them. This
caused any skip-cutscene key to be buffered during the loading screen,
which would later be handled during the cutscene. From the player's
perspective, there was no cutscene.

This changes os_ignore_events() to ignore events.

Fixes #4419.