### PR TITLE
Clamp values to their correct ranges when loading and saving pilot and campaign files

### DIFF
--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1209,23 +1209,35 @@ void pilotfile::csg_read_settings()
 void pilotfile::csg_write_settings()
 {
 	startSection(Section::Settings);
+	clamped_range_warnings.clear();
 
 	// sound/voice/music
+	clamp_value_with_warn(&Master_sound_volume, 0.f, 1.f, "Effects Volume");
 	cfwrite_float(Master_sound_volume, cfp);
+	clamp_value_with_warn(&Master_event_music_volume, 0.f, 1.f, "Music Volume");
 	cfwrite_float(Master_event_music_volume, cfp);
+	clamp_value_with_warn(&Master_voice_volume, 0.f, 1.f, "Voice Volume");
 	cfwrite_float(Master_voice_volume, cfp);
 
 	cfwrite_int(Briefing_voice_enabled ? 1 : 0, cfp);
 
 	// skill level
+	clamp_value_with_warn(&Game_skill_level, 0, 4, "Game Skill Level");
 	cfwrite_int(Game_skill_level, cfp);
 
 	// input options
 	cfwrite_int(Use_mouse_to_fly, cfp);
+	clamp_value_with_warn(&Mouse_sensitivity, 0, 9, "Mouse Sensitivity");
 	cfwrite_int(Mouse_sensitivity, cfp);
+	clamp_value_with_warn(&Joy_sensitivity, 0, 9, "Joystick Sensitivity");
 	cfwrite_int(Joy_sensitivity, cfp);
+	clamp_value_with_warn(&Joy_dead_zone_size, 0, 45, "Joystick Deadzone");
 	cfwrite_int(Joy_dead_zone_size, cfp);
 
+	if (!clamped_range_warnings.empty()) {
+		ReleaseWarning(LOCATION, "The following values were out of bounds when saving the campaign file and were automatically reset.\n%s\nThis shouldn't be possible, please contact the FreeSpace 2 Open Source Code Project!\n", clamped_range_warnings.c_str());
+		clamped_range_warnings.clear();
+	}
 	endSection();
 }
 

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1134,11 +1134,20 @@ void pilotfile::csg_write_variables()
 
 void pilotfile::csg_read_settings()
 {
+	clamped_range_warnings.clear();
 	// sound/voice/music
 	if (!Using_in_game_options) {
-		snd_set_effects_volume(cfread_float(cfp));
-		event_music_set_volume(cfread_float(cfp));
-		snd_set_voice_volume(cfread_float(cfp));
+		float temp_volume = cfread_float(cfp);
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "Effects Volume");
+		snd_set_effects_volume(temp_volume);
+
+		temp_volume = cfread_float(cfp);
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "Music Volume");
+		event_music_set_volume(temp_volume);
+
+		temp_volume = cfread_float(cfp);
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "Voice Volume");
+		snd_set_voice_volume(temp_volume);
 
 		Briefing_voice_enabled = cfread_int(cfp) != 0;
 	} else {
@@ -1154,13 +1163,20 @@ void pilotfile::csg_read_settings()
 
 	// skill level
 	Game_skill_level = cfread_int(cfp);
+	clamp_value_with_warn(&Game_skill_level, 0, 4, "Game Skill Level");
 
 	// input options
 	if (!Using_in_game_options) {
 		Use_mouse_to_fly   = cfread_int(cfp) != 0;
 		Mouse_sensitivity  = cfread_int(cfp);
+		clamp_value_with_warn(&Mouse_sensitivity, 0, 9, "Mouse Sensitivity");
+
 		Joy_sensitivity    = cfread_int(cfp);
+		clamp_value_with_warn(&Joy_sensitivity, 0, 9, "Joystick Sensitivity");
+
 		Joy_dead_zone_size = cfread_int(cfp);
+		clamp_value_with_warn(&Joy_dead_zone_size, 0, 45, "Joystick Deadzone");
+
 	} else {
 		// The values are set by the in-game menu but we still need to read the int from the file to maintain the correct offset
 		cfread_int(cfp);
@@ -1183,6 +1199,10 @@ void pilotfile::csg_read_settings()
 		dummy = cfread_int(cfp);
 		dummy = cfread_int(cfp);
 		dummy = cfread_int(cfp);
+	}
+	if (!clamped_range_warnings.empty()) {
+		ReleaseWarning(LOCATION, "The following values in the campaign save file were out of bounds and were automatically reset:\n%s\nPlease check your settings!\n", clamped_range_warnings.c_str());
+		clamped_range_warnings.clear();
 	}
 }
 

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -157,6 +157,17 @@ class pilotfile {
 		// file offset of the size value for the current section (set with startSection())
 		size_t m_size_offset;
 
+		SCP_string clamped_range_warnings = "";
+
+		template <typename T> void clamp_value_with_warn(T* value, T min, T max, const char* name) {
+			if (*value < min) {
+				clamped_range_warnings += SCP_string(name) + ": too low (" + std::to_string(*value) + "). Will reset to minimum (" + std::to_string(min) + ")\n";
+				*value = min;
+			} else if (*value > max) {
+				clamped_range_warnings += SCP_string(name) + ": too high (" + std::to_string(*value) + "). Will reset to maximum (" + std::to_string(max) + ")\n"; 
+				*value = max;
+			}
+		}
 
 		// --------------------------------------------------------------------
 		// PLR specific

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -855,11 +855,8 @@ void pilotfile::plr_read_settings()
 		Detail.lighting          = handler->readInt("lighting");
 		clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "Lighting");
 		Detail.targetview_model  = handler->readInt("targetview_model");
-		clamp_value_with_warn(&Detail.targetview_model, 0, MAX_DETAIL_LEVEL, "Target View Rendering");
 		Detail.planets_suns      = handler->readInt("planets_suns");
-		clamp_value_with_warn(&Detail.planets_suns, 0, MAX_DETAIL_LEVEL, "Planets/Backgrounds");
 		Detail.weapon_extras     = handler->readInt("weapon_extras");
-		clamp_value_with_warn(&Detail.weapon_extras, 0, MAX_DETAIL_LEVEL, "Weapon Extras");
 	} else {
 		// The values are set by the in-game menu but we still need to read the int from the file to maintain the correct offset
 		handler->readInt("use_mouse_to_fly");
@@ -933,11 +930,8 @@ void pilotfile::plr_write_settings()
 	handler->writeInt("shield_effects", Detail.shield_effects);
 	clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "Lighting");
 	handler->writeInt("lighting", Detail.lighting);
-	clamp_value_with_warn(&Detail.targetview_model, 0, MAX_DETAIL_LEVEL, "Target View Rendering");
 	handler->writeInt("targetview_model", Detail.targetview_model);
-	clamp_value_with_warn(&Detail.planets_suns, 0, MAX_DETAIL_LEVEL, "Planets/Backgrounds");
 	handler->writeInt("planets_suns", Detail.planets_suns);
-	clamp_value_with_warn(&Detail.weapon_extras, 0, MAX_DETAIL_LEVEL, "Weapon Extras");
 	handler->writeInt("weapon_extras", Detail.weapon_extras);
 
 	if (!clamped_range_warnings.empty()) {

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -795,11 +795,20 @@ void pilotfile::plr_write_controls()
 
 void pilotfile::plr_read_settings()
 {
+	clamped_range_warnings.clear();
 	// sound/voice/music
 	if (!Using_in_game_options) {
-		snd_set_effects_volume(handler->readFloat("master_sound_volume"));
-		event_music_set_volume(handler->readFloat("master_event_music_volume"));
-		snd_set_voice_volume(handler->readFloat("aster_voice_volume"));
+		float temp_volume = handler->readFloat("master_sound_volume");
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "master_sound_volume");
+		snd_set_effects_volume(temp_volume);
+
+		temp_volume = handler->readFloat("master_event_music_volume");
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "master_event_music_volume");
+		event_music_set_volume(temp_volume);
+
+		temp_volume = handler->readFloat("aster_voice_volume");
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "aster_voice_volume");
+		snd_set_voice_volume(temp_volume);
 
 		Briefing_voice_enabled = handler->readInt("briefing_voice_enabled") != 0;
 	} else {
@@ -814,27 +823,43 @@ void pilotfile::plr_read_settings()
 
 	// skill level
 	Game_skill_level = handler->readInt("game_skill_level");
+	clamp_value_with_warn(&Game_skill_level, 0, 4, "game_skill_level");
 
 	// input options
 	if (!Using_in_game_options) {
 		Use_mouse_to_fly   = handler->readInt("use_mouse_to_fly") != 0;
 		Mouse_sensitivity  = handler->readInt("mouse_sensitivity");
+		clamp_value_with_warn(&Mouse_sensitivity, 0, 9, "mouse_sensitivity");
 		Joy_sensitivity    = handler->readInt("joy_sensitivity");
+		clamp_value_with_warn(&Joy_sensitivity, 0, 9, "joy_sensitivity");
 		Joy_dead_zone_size = handler->readInt("joy_dead_zone_size");
+		clamp_value_with_warn(&Joy_dead_zone_size, 0, 45, "joy_dead_zone_size");
 
 		// detail
 		Detail.setting           = handler->readInt("setting");
+		clamp_value_with_warn(&Detail.setting, -1, NUM_DEFAULT_DETAIL_LEVELS - 1, "setting");
 		Detail.nebula_detail     = handler->readInt("nebula_detail");
+		clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_LEVEL, "nebula_detail");
 		Detail.detail_distance   = handler->readInt("detail_distance");
+		clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_LEVEL, "detail_distance");
 		Detail.hardware_textures = handler->readInt("hardware_textures");
+		clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_LEVEL, "hardware_textures");
 		Detail.num_small_debris  = handler->readInt("num_small_debris");
+		clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_LEVEL, "num_small_debris");
 		Detail.num_particles     = handler->readInt("num_particles");
+		clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_LEVEL, "num_particles");
 		Detail.num_stars         = handler->readInt("num_stars");
+		clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_LEVEL, "num_stars");
 		Detail.shield_effects    = handler->readInt("shield_effects");
+		clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_LEVEL, "shield_effects");
 		Detail.lighting          = handler->readInt("lighting");
+		clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "lighting");
 		Detail.targetview_model  = handler->readInt("targetview_model");
+		clamp_value_with_warn(&Detail.targetview_model, 0, MAX_DETAIL_LEVEL, "targetview_model");
 		Detail.planets_suns      = handler->readInt("planets_suns");
+		clamp_value_with_warn(&Detail.planets_suns, 0, MAX_DETAIL_LEVEL, "planets_suns");
 		Detail.weapon_extras     = handler->readInt("weapon_extras");
+		clamp_value_with_warn(&Detail.weapon_extras, 0, MAX_DETAIL_LEVEL, "weapon_extras");
 	} else {
 		// The values are set by the in-game menu but we still need to read the int from the file to maintain the correct offset
 		handler->readInt("use_mouse_to_fly");
@@ -855,6 +880,10 @@ void pilotfile::plr_read_settings()
 		handler->readInt("targetview_model");
 		handler->readInt("planets_suns");
 		handler->readInt("weapon_extras");
+	}
+	if (!clamped_range_warnings.empty()) {
+		ReleaseWarning(LOCATION, "The following values in the pilot file were out of bounds and were automatically reset:\n%s\nPlease check your settings!\n", clamped_range_warnings.c_str());
+		clamped_range_warnings.clear();
 	}
 }
 

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -799,15 +799,15 @@ void pilotfile::plr_read_settings()
 	// sound/voice/music
 	if (!Using_in_game_options) {
 		float temp_volume = handler->readFloat("master_sound_volume");
-		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "master_sound_volume");
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "Effects Volume");
 		snd_set_effects_volume(temp_volume);
 
 		temp_volume = handler->readFloat("master_event_music_volume");
-		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "master_event_music_volume");
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "Music Volume");
 		event_music_set_volume(temp_volume);
 
 		temp_volume = handler->readFloat("aster_voice_volume");
-		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "aster_voice_volume");
+		clamp_value_with_warn(&temp_volume, 0.f, 1.f, "Voice Volume");
 		snd_set_voice_volume(temp_volume);
 
 		Briefing_voice_enabled = handler->readInt("briefing_voice_enabled") != 0;
@@ -823,43 +823,43 @@ void pilotfile::plr_read_settings()
 
 	// skill level
 	Game_skill_level = handler->readInt("game_skill_level");
-	clamp_value_with_warn(&Game_skill_level, 0, 4, "game_skill_level");
+	clamp_value_with_warn(&Game_skill_level, 0, 4, "Skill Level");
 
 	// input options
 	if (!Using_in_game_options) {
 		Use_mouse_to_fly   = handler->readInt("use_mouse_to_fly") != 0;
 		Mouse_sensitivity  = handler->readInt("mouse_sensitivity");
-		clamp_value_with_warn(&Mouse_sensitivity, 0, 9, "mouse_sensitivity");
+		clamp_value_with_warn(&Mouse_sensitivity, 0, 9, "Mouse Sensitivity");
 		Joy_sensitivity    = handler->readInt("joy_sensitivity");
-		clamp_value_with_warn(&Joy_sensitivity, 0, 9, "joy_sensitivity");
+		clamp_value_with_warn(&Joy_sensitivity, 0, 9, "Joystick Sensitivity");
 		Joy_dead_zone_size = handler->readInt("joy_dead_zone_size");
-		clamp_value_with_warn(&Joy_dead_zone_size, 0, 45, "joy_dead_zone_size");
+		clamp_value_with_warn(&Joy_dead_zone_size, 0, 45, "Joystick Deadzone");
 
 		// detail
 		Detail.setting           = handler->readInt("setting");
-		clamp_value_with_warn(&Detail.setting, -1, NUM_DEFAULT_DETAIL_LEVELS - 1, "setting");
+		clamp_value_with_warn(&Detail.setting, -1, NUM_DEFAULT_DETAIL_LEVELS - 1, "Detail Level Preset");
 		Detail.nebula_detail     = handler->readInt("nebula_detail");
-		clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_LEVEL, "nebula_detail");
+		clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_LEVEL, "Nebula Detail");
 		Detail.detail_distance   = handler->readInt("detail_distance");
-		clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_LEVEL, "detail_distance");
+		clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_LEVEL, "Model Detail");
 		Detail.hardware_textures = handler->readInt("hardware_textures");
-		clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_LEVEL, "hardware_textures");
+		clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_LEVEL, "3D Hardware Textures");
 		Detail.num_small_debris  = handler->readInt("num_small_debris");
-		clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_LEVEL, "num_small_debris");
+		clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_LEVEL, "Impact Effects");
 		Detail.num_particles     = handler->readInt("num_particles");
-		clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_LEVEL, "num_particles");
+		clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_LEVEL, "Particles");
 		Detail.num_stars         = handler->readInt("num_stars");
-		clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_LEVEL, "num_stars");
+		clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_LEVEL, "Stars");
 		Detail.shield_effects    = handler->readInt("shield_effects");
-		clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_LEVEL, "shield_effects");
+		clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_LEVEL, "Shield Hit Effects");
 		Detail.lighting          = handler->readInt("lighting");
-		clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "lighting");
+		clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "Lighting");
 		Detail.targetview_model  = handler->readInt("targetview_model");
-		clamp_value_with_warn(&Detail.targetview_model, 0, MAX_DETAIL_LEVEL, "targetview_model");
+		clamp_value_with_warn(&Detail.targetview_model, 0, MAX_DETAIL_LEVEL, "Target View Rendering");
 		Detail.planets_suns      = handler->readInt("planets_suns");
-		clamp_value_with_warn(&Detail.planets_suns, 0, MAX_DETAIL_LEVEL, "planets_suns");
+		clamp_value_with_warn(&Detail.planets_suns, 0, MAX_DETAIL_LEVEL, "Planets/Backgrounds");
 		Detail.weapon_extras     = handler->readInt("weapon_extras");
-		clamp_value_with_warn(&Detail.weapon_extras, 0, MAX_DETAIL_LEVEL, "weapon_extras");
+		clamp_value_with_warn(&Detail.weapon_extras, 0, MAX_DETAIL_LEVEL, "Weapon Extras");
 	} else {
 		// The values are set by the in-game menu but we still need to read the int from the file to maintain the correct offset
 		handler->readInt("use_mouse_to_fly");
@@ -892,52 +892,52 @@ void pilotfile::plr_write_settings()
 	handler->startSectionWrite(Section::Settings);
 
 	// sound/voice/music
-	clamp_value_with_warn(&Master_sound_volume, 0.f, 1.f, "master_sound_volume");
+	clamp_value_with_warn(&Master_sound_volume, 0.f, 1.f, "Effects Volume");
 	handler->writeFloat("master_sound_volume", Master_sound_volume);
-	clamp_value_with_warn(&Master_event_music_volume, 0.f, 1.f, "master_event_music_volume");
+	clamp_value_with_warn(&Master_event_music_volume, 0.f, 1.f, "Music Volume");
 	handler->writeFloat("master_event_music_volume", Master_event_music_volume);
-	clamp_value_with_warn(&Master_voice_volume, 0.f, 1.f, "aster_voice_volume");
+	clamp_value_with_warn(&Master_voice_volume, 0.f, 1.f, "Voice Volume");
 	handler->writeFloat("aster_voice_volume", Master_voice_volume);
 
 	handler->writeInt("briefing_voice_enabled", Briefing_voice_enabled ? 1 : 0);
 
 	// skill level
-	clamp_value_with_warn(&Game_skill_level, 0, 4, "game_skill_level");
+	clamp_value_with_warn(&Game_skill_level, 0, 4, "Skill Level");
 	handler->writeInt("game_skill_level", Game_skill_level);
 
 	// input options
 	handler->writeInt("use_mouse_to_fly", Use_mouse_to_fly);
-	clamp_value_with_warn(&Mouse_sensitivity, 0, 9, "mouse_sensitivity");
+	clamp_value_with_warn(&Mouse_sensitivity, 0, 9, "Mouse Sensitivity");
 	handler->writeInt("mouse_sensitivity", Mouse_sensitivity);
-	clamp_value_with_warn(&Joy_sensitivity, 0, 9, "joy_sensitivity");
+	clamp_value_with_warn(&Joy_sensitivity, 0, 9, "Joystick Sensitivity");
 	handler->writeInt("joy_sensitivity", Joy_sensitivity);
-	clamp_value_with_warn(&Joy_dead_zone_size, 0, 45, "joy_dead_zone_size");
+	clamp_value_with_warn(&Joy_dead_zone_size, 0, 45, "Joystick Deadzone");
 	handler->writeInt("joy_dead_zone_size", Joy_dead_zone_size);
 
 	// detail
-	clamp_value_with_warn(&Detail.setting, -1, NUM_DEFAULT_DETAIL_LEVELS - 1, "setting");
+	clamp_value_with_warn(&Detail.setting, -1, NUM_DEFAULT_DETAIL_LEVELS - 1, "Detail Level Preset");
 	handler->writeInt("setting", Detail.setting);
-	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_LEVEL, "nebula_detail");
+	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_LEVEL, "Nebula Detail");
 	handler->writeInt("nebula_detail", Detail.nebula_detail);
-	clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_LEVEL, "detail_distance");
+	clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_LEVEL, "Model Detail");
 	handler->writeInt("detail_distance", Detail.detail_distance);
-	clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_LEVEL, "hardware_textures");
+	clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_LEVEL, "3D Hardware Textures");
 	handler->writeInt("hardware_textures", Detail.hardware_textures);
-	clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_LEVEL, "num_small_debris");
+	clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_LEVEL, "Impact Effects");
 	handler->writeInt("num_small_debris", Detail.num_small_debris);
-	clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_LEVEL, "num_particles");
+	clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_LEVEL, "Particles");
 	handler->writeInt("num_particles", Detail.num_particles);
-	clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_LEVEL, "num_stars");
+	clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_LEVEL, "Stars");
 	handler->writeInt("num_stars", Detail.num_stars);
-	clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_LEVEL, "shield_effects");
+	clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_LEVEL, "Shield Hit Effects");
 	handler->writeInt("shield_effects", Detail.shield_effects);
-	clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "lighting");
+	clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "Lighting");
 	handler->writeInt("lighting", Detail.lighting);
-	clamp_value_with_warn(&Detail.targetview_model, 0, MAX_DETAIL_LEVEL, "targetview_model");
+	clamp_value_with_warn(&Detail.targetview_model, 0, MAX_DETAIL_LEVEL, "Target View Rendering");
 	handler->writeInt("targetview_model", Detail.targetview_model);
-	clamp_value_with_warn(&Detail.planets_suns, 0, MAX_DETAIL_LEVEL, "planets_suns");
+	clamp_value_with_warn(&Detail.planets_suns, 0, MAX_DETAIL_LEVEL, "Planets/Backgrounds");
 	handler->writeInt("planets_suns", Detail.planets_suns);
-	clamp_value_with_warn(&Detail.weapon_extras, 0, MAX_DETAIL_LEVEL, "weapon_extras");
+	clamp_value_with_warn(&Detail.weapon_extras, 0, MAX_DETAIL_LEVEL, "Weapon Extras");
 	handler->writeInt("weapon_extras", Detail.weapon_extras);
 
 	if (!clamped_range_warnings.empty()) {

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -892,35 +892,58 @@ void pilotfile::plr_write_settings()
 	handler->startSectionWrite(Section::Settings);
 
 	// sound/voice/music
+	clamp_value_with_warn(&Master_sound_volume, 0.f, 1.f, "master_sound_volume");
 	handler->writeFloat("master_sound_volume", Master_sound_volume);
+	clamp_value_with_warn(&Master_event_music_volume, 0.f, 1.f, "master_event_music_volume");
 	handler->writeFloat("master_event_music_volume", Master_event_music_volume);
+	clamp_value_with_warn(&Master_voice_volume, 0.f, 1.f, "aster_voice_volume");
 	handler->writeFloat("aster_voice_volume", Master_voice_volume);
 
 	handler->writeInt("briefing_voice_enabled", Briefing_voice_enabled ? 1 : 0);
 
 	// skill level
+	clamp_value_with_warn(&Game_skill_level, 0, 4, "game_skill_level");
 	handler->writeInt("game_skill_level", Game_skill_level);
 
 	// input options
 	handler->writeInt("use_mouse_to_fly", Use_mouse_to_fly);
+	clamp_value_with_warn(&Mouse_sensitivity, 0, 9, "mouse_sensitivity");
 	handler->writeInt("mouse_sensitivity", Mouse_sensitivity);
+	clamp_value_with_warn(&Joy_sensitivity, 0, 9, "joy_sensitivity");
 	handler->writeInt("joy_sensitivity", Joy_sensitivity);
+	clamp_value_with_warn(&Joy_dead_zone_size, 0, 45, "joy_dead_zone_size");
 	handler->writeInt("joy_dead_zone_size", Joy_dead_zone_size);
 
 	// detail
+	clamp_value_with_warn(&Detail.setting, -1, NUM_DEFAULT_DETAIL_LEVELS - 1, "setting");
 	handler->writeInt("setting", Detail.setting);
+	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_LEVEL, "nebula_detail");
 	handler->writeInt("nebula_detail", Detail.nebula_detail);
+	clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_LEVEL, "detail_distance");
 	handler->writeInt("detail_distance", Detail.detail_distance);
+	clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_LEVEL, "hardware_textures");
 	handler->writeInt("hardware_textures", Detail.hardware_textures);
+	clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_LEVEL, "num_small_debris");
 	handler->writeInt("num_small_debris", Detail.num_small_debris);
+	clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_LEVEL, "num_particles");
 	handler->writeInt("num_particles", Detail.num_particles);
+	clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_LEVEL, "num_stars");
 	handler->writeInt("num_stars", Detail.num_stars);
+	clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_LEVEL, "shield_effects");
 	handler->writeInt("shield_effects", Detail.shield_effects);
+	clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "lighting");
 	handler->writeInt("lighting", Detail.lighting);
+	clamp_value_with_warn(&Detail.targetview_model, 0, MAX_DETAIL_LEVEL, "targetview_model");
 	handler->writeInt("targetview_model", Detail.targetview_model);
+	clamp_value_with_warn(&Detail.planets_suns, 0, MAX_DETAIL_LEVEL, "planets_suns");
 	handler->writeInt("planets_suns", Detail.planets_suns);
+	clamp_value_with_warn(&Detail.weapon_extras, 0, MAX_DETAIL_LEVEL, "weapon_extras");
 	handler->writeInt("weapon_extras", Detail.weapon_extras);
 
+	if (!clamped_range_warnings.empty()) {
+		ReleaseWarning(LOCATION, "The following values were out of bounds when saving the Pilot file and were automatically reset.\n%s\nThis shouldn't be possible, please contact the FreeSpace 2 Open Source Code Project!\n", clamped_range_warnings.c_str());
+		clamped_range_warnings.clear();
+	}
 	handler->endSectionWrite();
 }
 


### PR DESCRIPTION
Should fix #3321. Tested with the provided save files and the defective value was clamped as expected. 

Also tried forcing a few wrong values by manually editing a JSON pilot file and playing it in the RC, which saved the wrong values to the campaign file, and then loaded the same pilot/campaign in my dev build, resulting in the values being corrected.