### PR TITLE
Provide a limited partial fix for FRED keyboard shortcuts

### DIFF
--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -445,7 +445,7 @@ IDR_MENU_EDIT_SEXP_TREE MENU
 BEGIN
     POPUP "Edit sexp tree"
     BEGIN
-        MENUITEM "&Delete Item\tDelete",        ID_DELETE
+        MENUITEM "&Delete Item",                ID_DELETE
         MENUITEM "&Edit Data\tSpace Bar",       ID_EDIT_TEXT
         MENUITEM "Expand All",                  ID_EXPAND_ALL
         MENUITEM SEPARATOR

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -2509,13 +2509,13 @@ void sexp_tree::NodeCopy()
 
 void sexp_tree::NodeReplacePaste()
 {
-	if (item_index < 0)
+	if (item_index < 0 || Sexp_clipboard < 0)
 		return;
 
 	int i;
 
 	// the following assumptions are made..
-	Assert((Sexp_clipboard > -1) && (Sexp_nodes[Sexp_clipboard].type != SEXP_NOT_USED));
+	Assert(Sexp_nodes[Sexp_clipboard].type != SEXP_NOT_USED);
 	Assert(Sexp_nodes[Sexp_clipboard].subtype != SEXP_ATOM_LIST);
 	Assertion(Sexp_nodes[Sexp_clipboard].subtype != SEXP_ATOM_CONTAINER_NAME,
 		"Attempt to use container name %s from SEXP clipboard. Please report!",
@@ -2587,13 +2587,13 @@ void sexp_tree::NodeReplacePaste()
 
 void sexp_tree::NodeAddPaste()
 {
-	if (item_index < 0)
+	if (item_index < 0 || Sexp_clipboard < 0)
 		return;
 
 	int i;
 
 	// the following assumptions are made..
-	Assert((Sexp_clipboard > -1) && (Sexp_nodes[Sexp_clipboard].type != SEXP_NOT_USED));
+	Assert(Sexp_nodes[Sexp_clipboard].type != SEXP_NOT_USED);
 	Assert(Sexp_nodes[Sexp_clipboard].subtype != SEXP_ATOM_LIST);
 	Assertion(Sexp_nodes[Sexp_clipboard].subtype != SEXP_ATOM_CONTAINER_NAME,
 		"Attempt to use container name %s from SEXP clipboard. Please report!",


### PR DESCRIPTION
Makes these changes in FRED's Events Editor:
1. Ensures the keyboard shortcuts for Paste/Add-Paste won't trigger a crash if the clipboard is empty.
2. Remove "Delete" from UI as a keyboard shortcut for "Delete Item". It never worked, and as explained in the related issue, it shouldn't be made to.

Intended as a very limited partial fix for Issue #4405 until someone can do a proper rewrite of `sexp_tree::right_clicked()`.