### PR TITLE
address issues causing network connectivity failures on macOS

### DIFF
--- a/code/inetfile/cftp.cpp
+++ b/code/inetfile/cftp.cpp
@@ -372,7 +372,7 @@ bool CFtpGet::IssuePasv()
 		return false;
 	}
 
-	if ( connect(m_DataSock, reinterpret_cast<LPSOCKADDR>(&dataaddr), sizeof(dataaddr)) == SOCKET_ERROR ) {
+	if ( connect(m_DataSock, reinterpret_cast<LPSOCKADDR>(&dataaddr), psnet_get_sockaddr_len(&dataaddr)) == SOCKET_ERROR ) {
 		return false;
 	}
 
@@ -392,7 +392,7 @@ int CFtpGet::ConnectControlSocket()
 	}
 
 	// Now we will connect to the host
-	if ( connect(m_ControlSock, reinterpret_cast<LPSOCKADDR>(&m_ServerAddr), sizeof(m_ServerAddr)) ) {
+	if ( connect(m_ControlSock, reinterpret_cast<LPSOCKADDR>(&m_ServerAddr), psnet_get_sockaddr_len(&m_ServerAddr)) ) {
 		m_State = FTP_STATE_CANT_CONNECT;
 		return 0;
 	}

--- a/code/inetfile/chttpget.cpp
+++ b/code/inetfile/chttpget.cpp
@@ -331,7 +331,7 @@ int ChttpGet::ConnectSocket()
 	timeout.tv_sec = 0;
 	timeout.tv_usec = 0;
 
-	int serr = connect(m_DataSock, reinterpret_cast<LPSOCKADDR>(&hostaddr), sizeof(hostaddr));
+	int serr = connect(m_DataSock, reinterpret_cast<LPSOCKADDR>(&hostaddr), psnet_get_sockaddr_len(&hostaddr));
 	int cerr = WSAGetLastError();
 	if (serr) {
 		// fail after 20 seconds
@@ -360,7 +360,7 @@ int ChttpGet::ConnectSocket()
 			if (m_Aborting)
 				return 0;
 
-			serr = connect(m_DataSock, reinterpret_cast<LPSOCKADDR>(&hostaddr), sizeof(hostaddr));
+			serr = connect(m_DataSock, reinterpret_cast<LPSOCKADDR>(&hostaddr), psnet_get_sockaddr_len(&hostaddr));
 
 			if (serr == 0)
 				break;

--- a/code/network/chat_api.cpp
+++ b/code/network/chat_api.cpp
@@ -152,7 +152,7 @@ int ConnectToChatServer(char *serveraddr, char *nickname, char *trackerid)
 			return -1;
 		}
 		
-		if (SOCKET_ERROR==bind(Chatsock, reinterpret_cast<LPSOCKADDR>(&Chataddr), sizeof(Chataddr)))
+		if (SOCKET_ERROR==bind(Chatsock, reinterpret_cast<LPSOCKADDR>(&Chataddr), psnet_get_sockaddr_len(&Chataddr)))
 		{
 			return -1;
 		}
@@ -164,7 +164,7 @@ int ConnectToChatServer(char *serveraddr, char *nickname, char *trackerid)
 			return -2;
 		}
 
-		if(SOCKET_ERROR == connect(Chatsock, reinterpret_cast<LPSOCKADDR>(&Chataddr), sizeof(Chataddr)))
+		if(SOCKET_ERROR == connect(Chatsock, reinterpret_cast<LPSOCKADDR>(&Chataddr), psnet_get_sockaddr_len(&Chataddr)))
 		{
 			if(WSAEWOULDBLOCK == WSAGetLastError())
 			{

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -178,6 +178,9 @@ bool psnet_get_addr(const char *host, uint16_t port, SOCKADDR_STORAGE *addr, int
 #define ADDR_FLAG_NUMERIC_SERVICE	(1<<0)
 #define ADDR_FLAG_PREFER_IPV4		(1<<1)
 
+// get protocol struct length from generic storage struct
+SOCKLEN_T psnet_get_sockaddr_len(const SOCKADDR_STORAGE *addr);
+
 // map an IPv4 address to IPv6
 void psnet_map4to6(const in_addr *in4, in6_addr *in6);
 


### PR DESCRIPTION
Fixes network connectivity issues on macOS due to a mismatch of struct sizes, which macOS appears to be rather particular about. Successfully tested on macOS, Linux, and Windows.