### PR TITLE
fix erroneous position/angle modification

### DIFF
--- a/fred2/orienteditor.cpp
+++ b/fred2/orienteditor.cpp
@@ -186,7 +186,7 @@ BOOL orient_editor::OnInitDialog()
 /**
  * Checks whether the position value is close enough to the input string value that we can assume the input has not changed.
  */
-bool orient_editor::is_close(float val, const CString &input_str)
+bool orient_editor::is_close(float val, const CString &input_str) const
 {
 	val = perform_input_rounding(val);
 	float input_val = convert(input_str);
@@ -198,7 +198,7 @@ bool orient_editor::is_close(float val, const CString &input_str)
 /**
  * Checks whether the angle value is close enough to the input string value that we can assume the input has not changed.
  */
-bool orient_editor::is_angle_close(float rad, const CString &input_str)
+bool orient_editor::is_angle_close(float rad, const CString &input_str) const
 {
 	float deg = perform_input_rounding(to_degrees(rad));
 	float input_deg = normalize_degrees(convert(input_str));
@@ -391,7 +391,7 @@ float orient_editor::normalize_degrees(float deg)
 /**
  * Extract a float from the CString, being mindful of any comma separators.
  */
-float orient_editor::convert(const CString &str)
+float orient_editor::convert(const CString &str) const
 {
 	char buf[256];
 	size_t i, j, len;
@@ -411,7 +411,7 @@ float orient_editor::convert(const CString &str)
  * This accounts for not only decimal rounding to the precision of the input box, but also floating point rounding due to inexact fractions such as 1/10.
  * See also GitHub PR #4475.
  */
-float orient_editor::perform_input_rounding(float val)
+float orient_editor::perform_input_rounding(float val) const
 {
 	CString str;
 	str.Format(INPUT_FORMAT, val);

--- a/fred2/orienteditor.h
+++ b/fred2/orienteditor.h
@@ -70,11 +70,12 @@ protected:
 	DECLARE_MESSAGE_MAP()
 
 private:
-	float convert(const CString &str);
-	float perform_input_rounding(float val);
+	float convert(const CString &str) const;
+	float perform_input_rounding(float val) const;
 
-	bool is_close(float val, const CString &input_str);
-	bool is_angle_close(float rad, const CString &input_str);
+	bool is_close(float val, const CString &input_str) const;
+	bool is_angle_close(float rad, const CString &input_str) const;
+
 	int total;
 	int index[MAX_OBJECTS];
 	void actually_point_object(object *ptr);

--- a/fred2/orienteditor.h
+++ b/fred2/orienteditor.h
@@ -24,6 +24,7 @@ public:
 	orient_editor(CWnd* pParent = NULL);   // standard constructor
 
 	static float to_degrees(float radians);
+	static float normalize_degrees(float degrees);
 
 // Dialog Data
 	//{{AFX_DATA(orient_editor)
@@ -70,7 +71,8 @@ protected:
 
 private:
 	float convert(const CString &str);
-	bool close(float val, const CString &str);
+	bool close(float val, const CString &input_str);
+	bool angle_close(float rad, const CString &input_str);
 	int total;
 	int index[MAX_OBJECTS];
 	void actually_point_object(object *ptr);

--- a/fred2/orienteditor.h
+++ b/fred2/orienteditor.h
@@ -71,8 +71,10 @@ protected:
 
 private:
 	float convert(const CString &str);
-	bool close(float val, const CString &input_str);
-	bool angle_close(float rad, const CString &input_str);
+	float perform_input_rounding(float val);
+
+	bool is_close(float val, const CString &input_str);
+	bool is_angle_close(float rad, const CString &input_str);
 	int total;
 	int index[MAX_OBJECTS];
 	void actually_point_object(object *ptr);


### PR DESCRIPTION
Due to rounding and conversion approximations, it was possible for FRED to think the position and/or angle was modified when no such modification had occurred.  This could result in erroneous updates.  In the case of angles this could result in a group of ships being assigned the wrong orientation.

Follow-up to #2614.