### PR TITLE
Allow turrets to use their firepoints for target-leading calculations

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1364,7 +1364,7 @@ int aifft_rotate_turret(object *objp, ship *shipp, ship_subsys *ss, object *lep,
 			vm_vec_scale_sub2(&target_moving_direction, &objp->phys_info.vel, wip->vel_inherit_amount);
 		}
 
-		if (tp->flags[Model::Subsystem_Flags::Turret_distant_firepoint]) {
+		if (tp->flags[Model::Subsystem_Flags::Turret_distant_firepoint] || Always_use_distant_firepoints) {
 			//The firing point of this turret is so far away from the its center that we should consider this for firing calculations
 			//This will do the enemy position prediction based on their relative position and speed to the firing point, not the turret center.
 			vec3d fire_pos, fire_vec;
@@ -2349,7 +2349,7 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 
 		// If the barrel of this turret is long, we shouldn't try to fire if the enemy is under the gun.
 		// Note that this isn't the same thing as min_range, which is unrelated to barrel length.
-		if (tp->flags[Model::Subsystem_Flags::Turret_distant_firepoint]) {
+		if (tp->flags[Model::Subsystem_Flags::Turret_distant_firepoint] || Always_use_distant_firepoints) {
 			vec3d fpoint, fvec;
 			ship_get_global_turret_gun_info(objp, ss, &fpoint, &fvec, use_angles, &predicted_enemy_pos);
 			auto barrel_length = vm_vec_dist(&fpoint, &gpos);

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1367,8 +1367,8 @@ int aifft_rotate_turret(object *objp, ship *shipp, ship_subsys *ss, object *lep,
 		if (tp->flags[Model::Subsystem_Flags::Turret_distant_firepoint]) {
 			//The firing point of this turret is so far away from the its center that we should consider this for firing calculations
 			//This will do the enemy position prediction based on their relative position and speed to the firing point, not the turret center.
-			vec3d fire_pos;
-			ship_get_global_turret_gun_info(objp, ss, &fire_pos, nullptr, 1, nullptr);
+			vec3d fire_pos, fire_vec;
+			ship_get_global_turret_gun_info(objp, ss, &fire_pos, &fire_vec, 1, nullptr);
 			set_predicted_enemy_pos_turret(predicted_enemy_pos, &fire_pos, objp, &enemy_point, &target_moving_direction, wip->max_speed, ss->turret_time_enemy_in_range * (weapon_system_strength + 1.0f)/2.0f);
 		} else {
 			set_predicted_enemy_pos_turret(predicted_enemy_pos, &gun_pos, objp, &enemy_point, &target_moving_direction, wip->max_speed, ss->turret_time_enemy_in_range * (weapon_system_strength + 1.0f)/2.0f);
@@ -2350,8 +2350,8 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 		// If the barrel of this turret is long, we shouldn't try to fire if the enemy is under the gun.
 		// Note that this isn't the same thing as min_range, which is unrelated to barrel length.
 		if (tp->flags[Model::Subsystem_Flags::Turret_distant_firepoint]) {
-			vec3d fpoint;
-			ship_get_global_turret_gun_info(objp, ss, &fpoint, nullptr, use_angles, &predicted_enemy_pos);
+			vec3d fpoint, fvec;
+			ship_get_global_turret_gun_info(objp, ss, &fpoint, &fvec, use_angles, &predicted_enemy_pos);
 			auto barrel_length = vm_vec_dist(&fpoint, &gpos);
 			if (dist_to_enemy < barrel_length) continue;
 		}

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1364,7 +1364,15 @@ int aifft_rotate_turret(object *objp, ship *shipp, ship_subsys *ss, object *lep,
 			vm_vec_scale_sub2(&target_moving_direction, &objp->phys_info.vel, wip->vel_inherit_amount);
 		}
 
-		set_predicted_enemy_pos_turret(predicted_enemy_pos, &gun_pos, objp, &enemy_point, &target_moving_direction, wip->max_speed, ss->turret_time_enemy_in_range * (weapon_system_strength + 1.0f)/2.0f);
+		if (tp->flags[Model::Subsystem_Flags::Turret_distant_firepoint]) {
+			//The firing point of this turret is so far away from the its center that we should consider this for firing calculations
+			//This will do the enemy position prediction based on their relative position and speed to the firing point, not the turret center.
+			vec3d fire_pos;
+			ship_get_global_turret_gun_info(objp, ss, &fire_pos, nullptr, 1, nullptr);
+			set_predicted_enemy_pos_turret(predicted_enemy_pos, &fire_pos, objp, &enemy_point, &target_moving_direction, wip->max_speed, ss->turret_time_enemy_in_range * (weapon_system_strength + 1.0f)/2.0f);
+		} else {
+			set_predicted_enemy_pos_turret(predicted_enemy_pos, &gun_pos, objp, &enemy_point, &target_moving_direction, wip->max_speed, ss->turret_time_enemy_in_range * (weapon_system_strength + 1.0f)/2.0f);
+		}
 
 		//Mess with the turret's accuracy if the weapon system is damaged.
 		if (weapon_system_strength < Weapon_SS_Threshold_Turret_Inaccuracy) {
@@ -2337,6 +2345,15 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 					weapon_firing_range *= BEAM_NEBULA_RANGE_REDUCE_FACTOR;
 				}
 			}
+		}
+
+		// If the barrel of this turret is long, we shouldn't try to fire if the enemy is under the gun.
+		// Note that this isn't the same thing as min_range, which is unrelated to barrel length.
+		if (tp->flags[Model::Subsystem_Flags::Turret_distant_firepoint]) {
+			vec3d fpoint;
+			ship_get_global_turret_gun_info(objp, ss, &fpoint, nullptr, use_angles, &predicted_enemy_pos);
+			auto barrel_length = vm_vec_dist(&fpoint, &gpos);
+			if (dist_to_enemy < barrel_length) continue;
 		}
 
 		// Don't try to fire beyond weapon_limit_range (or within min range)

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -108,6 +108,7 @@ bool Always_warn_player_about_unbound_keys;
 leadIndicatorBehavior Lead_indicator_behavior;
 shadow_disable_overrides Shadow_disable_overrides {false, false, false, false};
 float Thruster_easing;
+bool Always_use_distant_firepoints;
 
 void mod_table_set_version_flags();
 
@@ -966,6 +967,10 @@ void parse_mod_table(const char *filename)
 				Warning(LOCATION, "$Lead indicator behavior: Invalid selection. Must be default, multiple or average. Reverting to default.");
 				Lead_indicator_behavior = leadIndicatorBehavior::DEFAULT;
 			}
+		}
+
+		if (optional_string("$Use distant firepoint for all turrets:")){
+			stuff_boolean(&Always_use_distant_firepoints);
 		}
 
 		required_string("#END");

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1108,6 +1108,7 @@ void mod_table_reset()
 	Always_warn_player_about_unbound_keys = false;
 	Lead_indicator_behavior = leadIndicatorBehavior::DEFAULT;
 	Thruster_easing = 0;
+	Always_use_distant_firepoints = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -100,6 +100,7 @@ extern struct shadow_disable_overrides {
 	bool disable_techroom, disable_mission_select_weapons, disable_mission_select_ships, disable_cockpit;
 } Shadow_disable_overrides;
 extern float Thruster_easing;
+extern bool Always_use_distant_firepoints;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -70,6 +70,7 @@ namespace Model {
         No_sparks,          // Subsystem does not generate sparks if hit - m!m
 		No_impact_debris,    // Don't spawn the small debris on impact - m!m
 		Hide_turret_from_loadout_stats, // Turret is not accounted for in auto-generated "Turrets" line in the ship loadout window --wookieejedi
+		Turret_distant_firepoint,	//Turret barrel is very long and should be taken into account when aiming -- Kiloku
 
         NUM_VALUES
 	};

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -278,6 +278,7 @@ flag_def_list_new<Model::Subsystem_Flags> Subsystem_flags[] = {
 	{ "no damage spew",             Model::Subsystem_Flags::No_sparks,                          true, false },
 	{ "no impact debris",           Model::Subsystem_Flags::No_impact_debris,                   true, false },
 	{ "hide turret from loadout stats", Model::Subsystem_Flags::Hide_turret_from_loadout_stats, true, false },
+	{ "turret has distant firepoint", Model::Subsystem_Flags::Turret_distant_firepoint,         true, false },
 };
 
 const size_t Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list_new<Model::Subsystem_Flags>);


### PR DESCRIPTION
Most turrets can lead just fine without this, but in use cases where the firepoint is far from the center of the turret's "body" (an extra long barrel, for example) this can cause the turret to not aim correctly.  

This PR adds a ship flag that can be added to turret subsystems to enable it for them directly, as well as a game settings option to enable it for all turrets. 

Resolves #4288 