### PR TITLE
Ensure sufficient stack size for Lua values

### DIFF
--- a/code/scripting/lua/LuaFunction.cpp
+++ b/code/scripting/lua/LuaFunction.cpp
@@ -172,12 +172,15 @@ LuaValueList LuaFunction::call(lua_State* L, const LuaValueList& args) const {
 		stackTop = lua_gettop(L);
 	}
 
+	if(!lua_checkstack(L, args.size() + 1))
+		throw LuaException("Lua Stack Overflow!");
+
 	// Push the function onto the stack
-	this->pushValue(L);
+	this->pushValue(L, true);
 
 	// Push the arguments onto the stack
 	for (const auto& arg : args) {
-		arg.pushValue(L);
+		arg.pushValue(L, true);
 	}
 
 	// actually call the function now!

--- a/code/scripting/lua/LuaFunction.cpp
+++ b/code/scripting/lua/LuaFunction.cpp
@@ -172,7 +172,7 @@ LuaValueList LuaFunction::call(lua_State* L, const LuaValueList& args) const {
 		stackTop = lua_gettop(L);
 	}
 
-	if(!lua_checkstack(L, args.size() + 1))
+	if(!lua_checkstack(L, (int)args.size() + 1))
 		throw LuaException("Lua Stack Overflow!");
 
 	// Push the function onto the stack

--- a/code/scripting/lua/LuaReference.cpp
+++ b/code/scripting/lua/LuaReference.cpp
@@ -80,9 +80,12 @@ bool UniqueLuaReference::isValid() const {
 	return true;
 }
 
-void UniqueLuaReference::pushValue(lua_State* thread) const
+void UniqueLuaReference::pushValue(lua_State* thread, bool guaranteeStack) const
 {
 	Assertion(thread != nullptr, "Valid thread state must be specified!");
+
+	if(!guaranteeStack)
+		lua_checkstack(thread, 1);
 
 	if (this->isValid()) {
 		lua_rawgeti(thread, LUA_REGISTRYINDEX, this->getReference());

--- a/code/scripting/lua/LuaReference.cpp
+++ b/code/scripting/lua/LuaReference.cpp
@@ -84,8 +84,9 @@ void UniqueLuaReference::pushValue(lua_State* thread, bool guaranteeStack) const
 {
 	Assertion(thread != nullptr, "Valid thread state must be specified!");
 
-	if(!guaranteeStack)
+	if (!guaranteeStack) {
 		lua_checkstack(thread, 1);
+	}
 
 	if (this->isValid()) {
 		lua_rawgeti(thread, LUA_REGISTRYINDEX, this->getReference());

--- a/code/scripting/lua/LuaReference.cpp
+++ b/code/scripting/lua/LuaReference.cpp
@@ -80,11 +80,11 @@ bool UniqueLuaReference::isValid() const {
 	return true;
 }
 
-void UniqueLuaReference::pushValue(lua_State* thread, bool guaranteeStack) const
+void UniqueLuaReference::pushValue(lua_State* thread, bool manualStackAllocation) const
 {
 	Assertion(thread != nullptr, "Valid thread state must be specified!");
 
-	if (!guaranteeStack) {
+	if (!manualStackAllocation) {
 		lua_checkstack(thread, 1);
 	}
 

--- a/code/scripting/lua/LuaReference.h
+++ b/code/scripting/lua/LuaReference.h
@@ -100,8 +100,9 @@ class UniqueLuaReference {
 	/**
     * @brief Pushes the referenced value onto the stack.
     * @param thread A specific thread state to push the value to. nullptr for the default state of this reference
+	* @param manualStackAllocation Set to true if you manually allocate sufficient stack size before calling this function. Keep false unless you know what you are doing.
     */
-	void pushValue(lua_State* thread, bool guaranteeStack = false) const;
+	void pushValue(lua_State* thread, bool manualStackAllocation = false) const;
 };
 }
 

--- a/code/scripting/lua/LuaReference.h
+++ b/code/scripting/lua/LuaReference.h
@@ -101,7 +101,7 @@ class UniqueLuaReference {
     * @brief Pushes the referenced value onto the stack.
     * @param thread A specific thread state to push the value to. nullptr for the default state of this reference
     */
-	void pushValue(lua_State* thread) const;
+	void pushValue(lua_State* thread, bool guaranteeStack = false) const;
 };
 }
 

--- a/code/scripting/lua/LuaValue.cpp
+++ b/code/scripting/lua/LuaValue.cpp
@@ -88,10 +88,10 @@ bool LuaValue::isValid() const {
 	return _reference && _reference->isValid();
 }
 
-bool LuaValue::pushValue(lua_State* thread, bool guaranteeStack) const
+bool LuaValue::pushValue(lua_State* thread, bool manualStackAllocation) const
 {
 	if (this->_reference->isValid()) {
-		this->_reference->pushValue(thread, guaranteeStack);
+		this->_reference->pushValue(thread, manualStackAllocation);
 		return true;
 	} else {
 		return false;

--- a/code/scripting/lua/LuaValue.cpp
+++ b/code/scripting/lua/LuaValue.cpp
@@ -88,10 +88,10 @@ bool LuaValue::isValid() const {
 	return _reference && _reference->isValid();
 }
 
-bool LuaValue::pushValue(lua_State* thread) const
+bool LuaValue::pushValue(lua_State* thread, bool guaranteeStack) const
 {
 	if (this->_reference->isValid()) {
-		this->_reference->pushValue(thread);
+		this->_reference->pushValue(thread, guaranteeStack);
 		return true;
 	} else {
 		return false;

--- a/code/scripting/lua/LuaValue.h
+++ b/code/scripting/lua/LuaValue.h
@@ -185,8 +185,9 @@ class LuaValue {
 	 * @brief Pushes this lua value onto the stack.
 	 * @param thread The thread stack onto which this value should be pushed. May be nullptr for the default state of
 	 * this value
+	 * @param manualStackAllocation Set to true if you manually allocate sufficient stack size before calling this function. Keep false unless you know what you are doing.
 	 */
-	bool pushValue(lua_State* thread, bool guaranteeStack = false) const;
+	bool pushValue(lua_State* thread, bool manualStackAllocation = false) const;
 
 	lua_State* getLuaState() const;
 

--- a/code/scripting/lua/LuaValue.h
+++ b/code/scripting/lua/LuaValue.h
@@ -186,7 +186,7 @@ class LuaValue {
 	 * @param thread The thread stack onto which this value should be pushed. May be nullptr for the default state of
 	 * this value
 	 */
-	bool pushValue(lua_State* thread) const;
+	bool pushValue(lua_State* thread, bool guaranteeStack = false) const;
 
 	lua_State* getLuaState() const;
 


### PR DESCRIPTION
Fixes #4287.
Until now, when we pushed values to the Lua stack from C, we _never_ checked that the stack allocated by the lua interpreter had space available, let alone reserve new space.
This PR now adds checks on each push to the stack. While this might slightly degrade performance, it is a necessary check.
To avoid unnecessary checks, there is infrastructure in place to pre-reserve multiple stack spaces and pass the information about guaranteed sufficient stack pre-allocation to the value push, enabling omission of the check in these instances.