### PR TITLE
Fix some bugs with maneuvers

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14763,20 +14763,16 @@ static void ai_control_info_apply(ai_info *aip)
 	if (aip->ai_override_flags.none_set())
 		return;
 
-	bool no_lat = false;
-	bool no_rot = false;
+	bool lateral_maneuver = false;
+	bool rotational_maneuver = false;
 
-	if (!aip->ai_override_flags[AI::Maneuver_Override_Flags::Lateral_never_expire] && timestamp_elapsed(aip->ai_override_lat_timestamp))
-		no_lat = true;
+	if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Lateral_never_expire] || !timestamp_elapsed(aip->ai_override_lat_timestamp))
+		lateral_maneuver = true;
 
-	if (!aip->ai_override_flags[AI::Maneuver_Override_Flags::Rotational_never_expire] && timestamp_elapsed(aip->ai_override_rot_timestamp))
-		no_rot = true;
+	if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Rotational_never_expire] || timestamp_elapsed(aip->ai_override_rot_timestamp))
+		rotational_maneuver = true;
 
-	if (no_rot && no_lat) {
-		aip->ai_override_flags.reset();
-	}
-	else
-	{
+	if (lateral_maneuver || rotational_maneuver) {
 		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Full_rot])
 		{
 			AI_ci.pitch = aip->ai_override_ci.pitch;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14710,7 +14710,8 @@ void ai_frame(int objnum)
 	}
 }
 
-static void ai_control_info_check(ai_info *aip, ship_info *sip, physics_info *pi)
+// set and removes any maneuver flags for ai maneuver overrides
+static void ai_control_info_flags_upkeep(ai_info* aip, ship_info* sip, physics_info* pi)
 {
 	if (aip->ai_override_flags.none_set())
 		return;
@@ -14741,6 +14742,41 @@ static void ai_control_info_check(ai_info *aip, ship_info *sip, physics_info *pi
 	}
 	else
 	{
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_bank_when_turning] || sip->flags[Ship::Info_Flags::Dont_bank_when_turning])
+			AI_ci.control_flags |= CIF_DONT_BANK_WHEN_TURNING;
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_clamp_max_velocity] || sip->flags[Ship::Info_Flags::Dont_clamp_max_velocity])
+			AI_ci.control_flags |= CIF_DONT_CLAMP_MAX_VELOCITY;
+		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Instantaneous_acceleration] || sip->flags[Ship::Info_Flags::Instantaneous_acceleration])
+			AI_ci.control_flags |= CIF_INSTANTANEOUS_ACCELERATION;
+	}
+
+	// set physics flag according to whether we are instantaneously accelerating
+	if (AI_ci.control_flags & CIF_INSTANTANEOUS_ACCELERATION)
+		pi->flags |= PF_MANEUVER_NO_DAMP;
+	else
+		pi->flags &= ~PF_MANEUVER_NO_DAMP;
+}
+
+// applies any rotational or lateral maneuver values to the AI's CI
+static void ai_control_info_apply(ai_info *aip)
+{
+	if (aip->ai_override_flags.none_set())
+		return;
+
+	bool no_lat = false;
+	bool no_rot = false;
+
+	if (!aip->ai_override_flags[AI::Maneuver_Override_Flags::Lateral_never_expire] && timestamp_elapsed(aip->ai_override_lat_timestamp))
+		no_lat = true;
+
+	if (!aip->ai_override_flags[AI::Maneuver_Override_Flags::Rotational_never_expire] && timestamp_elapsed(aip->ai_override_rot_timestamp))
+		no_rot = true;
+
+	if (no_rot && no_lat) {
+		aip->ai_override_flags.reset();
+	}
+	else
+	{
 		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Full_rot])
 		{
 			AI_ci.pitch = aip->ai_override_ci.pitch;
@@ -14750,17 +14786,11 @@ static void ai_control_info_check(ai_info *aip, ship_info *sip, physics_info *pi
 		else
 		{
 			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Pitch])
-			{
 				AI_ci.pitch = aip->ai_override_ci.pitch;
-			}
 			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Heading])
-			{
 				AI_ci.heading = aip->ai_override_ci.heading;
-			}
 			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Roll])
-			{
 				AI_ci.bank = aip->ai_override_ci.bank;
-			}
 		}
 
 		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Full_lat])
@@ -14772,32 +14802,13 @@ static void ai_control_info_check(ai_info *aip, ship_info *sip, physics_info *pi
 		else
 		{
 			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Up])
-			{
 				AI_ci.vertical = aip->ai_override_ci.vertical;
-			}
 			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Sideways])
-			{
 				AI_ci.sideways = aip->ai_override_ci.sideways;
-			}
 			if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Forward])
-			{
 				AI_ci.forward = aip->ai_override_ci.forward;
-			}
 		}
-
-		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_bank_when_turning] || sip->flags[Ship::Info_Flags::Dont_bank_when_turning])
-			AI_ci.control_flags |= CIF_DONT_BANK_WHEN_TURNING;
-		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Dont_clamp_max_velocity] || sip->flags[Ship::Info_Flags::Dont_clamp_max_velocity])
-			AI_ci.control_flags |= CIF_DONT_CLAMP_MAX_VELOCITY;
-		if (aip->ai_override_flags[AI::Maneuver_Override_Flags::Instantaneous_acceleration] || sip->flags[Ship::Info_Flags::Instantaneous_acceleration])
-			AI_ci.control_flags |= CIF_INSTANTANEOUS_ACCELERATION;
 	}
-
-	// set physics flag according to whether we are instantaneously accelerating
-	if (AI_ci.control_flags & CIF_INSTANTANEOUS_ACCELERATION)
-		pi->flags |= PF_NO_DAMP;
-	else
-		pi->flags &= ~PF_NO_DAMP;
 }
 
 int Last_ai_obj = -1;
@@ -14857,9 +14868,12 @@ void ai_process( object * obj, int ai_index, float frametime )
 	if (shipp->flags[Ship::Ship_Flags::Dying] && sip->flags[Ship::Info_Flags::Large_ship_deathroll])
 		rfc = false;
 
+	// regardless if we're acting on them, upkeep maneuver flags
+	ai_control_info_flags_upkeep(aip, sip, &obj->phys_info);
+
 	if (rfc) {
 		// Wanderer - sexp based override goes here - only if rfc is valid though
-		ai_control_info_check(aip, sip, &obj->phys_info);
+		ai_control_info_apply(aip);
 		physics_read_flying_controls( &obj->orient, &obj->phys_info, &AI_ci, frametime);
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -12208,6 +12208,11 @@ void multi_sexp_hud_display_gauge()
 void sexp_player_use_ai(int flag)
 {
 	Player_use_ai = flag ? 1 : 0;
+
+	if (!flag) {
+		Player_ai->ai_override_flags.reset();
+		Player_obj->phys_info.flags &= ~PF_MANEUVER_NO_DAMP;
+	}
 }
 
 // Karajorma

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -168,7 +168,7 @@ void physics_sim_rot(matrix * orient, physics_info * pi, float sim_time )
 			shock_amplitude = pi->shockwave_shake_amp * shock_fraction_time_left;
 		}
 	}
-	else if (pi->flags & PF_NO_DAMP) {
+	else if (pi->flags & PF_MANEUVER_NO_DAMP) {
 		rotdamp = 0.0f;
 	}
 	else {
@@ -305,7 +305,7 @@ void physics_sim_vel(vec3d * position, physics_info * pi, float sim_time, matrix
 		}
 	}
 	// no damping at all
-	else if (pi->flags & PF_NO_DAMP) {
+	else if (pi->flags & PF_MANEUVER_NO_DAMP) {
 		damp = vmd_zero_vector;
 	}
 	// newtonian

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -32,7 +32,7 @@
 #define PF_GLIDING				(1 << 14)
 #define PF_FORCE_GLIDE			(1 << 15)
 #define PF_NEWTONIAN_DAMP		(1 << 16)	// SUSHI: Whether or not to use newtonian dampening
-#define PF_NO_DAMP				(1 << 17)	// Goober5000 - don't damp velocity changes in physics; used for instantaneous acceleration
+#define PF_MANEUVER_NO_DAMP				(1 << 17)	// Goober5000 - don't damp velocity changes in physics; used for instantaneous acceleration
 
 //information for physics sim for an object
 typedef struct physics_info {


### PR DESCRIPTION
Two things: split `ai_control_info_check` into `ai_control_info_flags_upkeep`, which keeps track of the flags and sets or resets them accordingly and `ai_control_info_apply` which then uses those flags and sets the directional values. `ai_control_info_flags_upkeep` is then made unconditional, even if the AI mode dictates it should not act on maneuver overrides, keep track of the flags and ensure they set and reset properly. Additionally, `player-not-use-ai` completely resets maneuvers, preventing any accidental 'leakage' of its flags. Also makes clear that `PF_NO_DAMP` is only used for maneuvers. 

This is possibly, but not certainly, related to #2157