### PR TITLE
Cap bank velocity in AI turning

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2070,6 +2070,7 @@ void vm_angular_move_forward_vec(const vec3d* goal_f, const matrix* orient, cons
 
 	// handle bank separately, simpler, since its just a target velocity
 	{
+		CLAMP(bank_vel, -vel_limit->xyz.z, vel_limit->xyz.z);
 		float delta_bank_vel = bank_vel - w_in->xyz.z;
 		float delta_bank_accel = fl_abs(delta_bank_vel) / delta_t; // the accel required to reach the target vel this frame
 		float accel = (delta_bank_accel > acc_limit->xyz.z) ? acc_limit->xyz.z : delta_bank_accel;


### PR DESCRIPTION
An oversight from #4417. This will prevent ships from spinning themselves out of control under certain circumstances. That fact that ships are even *trying* to spin themselves out of control uncapped or otherwise is due to this dubious, but retail logic https://github.com/scp-fs2open/fs2open.github.com/blob/master/code/ai/aicode.cpp#L1300. I am confident this part could be re-written to something more sensical and less framerate sensitive, but that's technically a separate issue. It does at least seem to be behave like it did before the aforementioned PR.