### PR TITLE
some fixes for playing movies via script

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -642,3 +642,8 @@ fix timestamp_get_mission_time()
 
 	return static_cast<fix>(time / MICROSECONDS_PER_SECOND);
 }
+
+uint64_t timestamp_get_mission_time_in_microseconds()
+{
+	return timestamp_get_microseconds() - Timestamp_microseconds_at_mission_start;
+}

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -106,6 +106,7 @@ extern int timer_get_seconds();				// seconds since program started... not accur
 constexpr int MILLISECONDS_PER_SECOND = 1000;
 constexpr uint64_t MICROSECONDS_PER_SECOND = 1000000;
 constexpr uint64_t NANOSECONDS_PER_SECOND = 1000000000;
+constexpr uint64_t NANOSECONDS_PER_MICROSECOND = 1000;
 
 // use this call to get the current counter value (which represents the time at the time
 // this function is called).  I.e. it doesn't return a count that would be in the future,
@@ -225,5 +226,6 @@ void timestamp_start_mission();
 
 // Calculate the current mission time using the timestamps
 fix timestamp_get_mission_time();
+uint64_t timestamp_get_mission_time_in_microseconds();
 
 #endif

--- a/code/scripting/api/libs/time_lib.cpp
+++ b/code/scripting/api/libs/time_lib.cpp
@@ -10,12 +10,12 @@ namespace api {
 
 ADE_LIB(l_Time, "Time", "time", "Real-Time library");
 
-ADE_FUNC(getCurrentTime, l_Time, nullptr, "Gets the current real-time timestamp.", "timestamp", "The current time")
+ADE_FUNC(getCurrentTime, l_Time, nullptr, "Gets the current real-time timestamp, i.e. the actual elapsed time, regardless of whether the game has changed time compression or been paused.", "timestamp", "The current time")
 {
 	return ade_set_args(L, "o", l_Timestamp.Set(timer_get_nanoseconds()));
 }
 
-ADE_FUNC(getCurrentMissionTime, l_Time, nullptr, "Gets the current mission-time timestamp.", "timestamp", "The current mission time")
+ADE_FUNC(getCurrentMissionTime, l_Time, nullptr, "Gets the current mission-time timestamp, which can be affected by time compression and paused.", "timestamp", "The current mission time")
 {
 	return ade_set_args(L, "o", l_Timestamp.Set(timestamp_get_mission_time_in_microseconds() * NANOSECONDS_PER_MICROSECOND));
 }

--- a/code/scripting/api/libs/time_lib.cpp
+++ b/code/scripting/api/libs/time_lib.cpp
@@ -15,5 +15,10 @@ ADE_FUNC(getCurrentTime, l_Time, nullptr, "Gets the current real-time timestamp.
 	return ade_set_args(L, "o", l_Timestamp.Set(timer_get_nanoseconds()));
 }
 
+ADE_FUNC(getCurrentMissionTime, l_Time, nullptr, "Gets the current mission-time timestamp.", "timestamp", "The current mission time")
+{
+	return ade_set_args(L, "o", l_Timestamp.Set(timestamp_get_mission_time_in_microseconds() * NANOSECONDS_PER_MICROSECOND));
+}
+
 } // namespace api
 } // namespace scripting

--- a/code/scripting/api/objs/movie_player.cpp
+++ b/code/scripting/api/objs/movie_player.cpp
@@ -63,7 +63,7 @@ ADE_VIRTVAR(FPS, l_MoviePlayer, "number", "Determines the frames per second of t
 		LuaError(L, "Tried to modify read-only member!");
 	}
 
-	return ade_set_args(L, "f", (int)ph->player()->getMovieProperties().fps);
+	return ade_set_args(L, "f", ph->player()->getMovieProperties().fps);
 }
 
 ADE_FUNC(update, l_MoviePlayer, "timespan step_time",

--- a/code/scripting/api/objs/time_obj.cpp
+++ b/code/scripting/api/objs/time_obj.cpp
@@ -31,7 +31,7 @@ ADE_FUNC(getSeconds, l_TimeSpan, nullptr, "Gets the value of this timestamp in s
 	}
 
 	// Timestamps and spans are stored in nanoseconds
-	return ade_set_args(L, "f", (float)value / 1000000000.f);
+	return ade_set_args(L, "f", (float)((long double)value / (long double)NANOSECONDS_PER_SECOND));
 }
 
 } // namespace api


### PR DESCRIPTION
The movie player code was missing some important functionality, in particular:
1) There was only one timing method to get real-time elapsed time, which was not suitable for pausing or time compression
2) There was an improper cast for the FPS property, causing a script error
3) The `getSeconds` method lost precision during casting

This patches those deficiencies.