### PR TITLE
check all possible extensions for audio files

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -1294,7 +1294,7 @@ void parse_soundtrack()
 			continue;
 
 		// check for file
-		if (!cf_exists_full(Soundtracks[strack_idx].patterns[i].fname, CF_TYPE_MUSIC))
+		if (!cf_exists_full_ext(Soundtracks[strack_idx].patterns[i].fname, CF_TYPE_MUSIC, NUM_AUDIO_EXT, audio_ext_list))
 			return;
 	}
 

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -34,6 +34,7 @@
 #include "scripting/scripting.h"
 #include "ship/ship.h"
 #include "ship/subsysdamage.h"
+#include "sound/audiostr.h"
 #include "sound/fsspeech.h"
 #include "species_defs/species_defs.h"
 #include "utils/Random.h"
@@ -1735,7 +1736,7 @@ void message_queue_message( int message_num, int priority, int timing, const cha
 				if (message_filename_has_fs1_wingman_prefix(filename)) {
 					char converted[MAX_FILENAME_LEN];
 					message_filename_convert_to_command(converted, filename);
-					if (cf_exists_full(converted, CF_TYPE_VOICE_SPECIAL)) {
+					if (cf_exists_full_ext(converted, CF_TYPE_VOICE_SPECIAL, NUM_AUDIO_EXT, audio_ext_list)) {
 						convert_to_command = true;
 					}
 				}

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -926,7 +926,7 @@ void debrief_choose_voice(char *voice_dest, size_t buf_size, char *voice_base, i
 		if (snprintf(voice_dest, buf_size, NOX("%d_%s"), persona_index, voice_base) < static_cast<int>(buf_size))
 		{
 			// if it exists, we're done
-			if (cf_exists_full(voice_dest, CF_TYPE_VOICE_DEBRIEFINGS))
+			if (cf_exists_full_ext(voice_dest, CF_TYPE_VOICE_DEBRIEFINGS, NUM_AUDIO_EXT, audio_ext_list))
 				return;
 		}
 


### PR DESCRIPTION
When the code checks for the existence of an audio file, be sure to check all relevant extensions.

This fixes #4495.  Tested with both ST:R personas as well as the Vasudan persona.