### PR TITLE
Fix 4276

### DIFF
--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -31,23 +31,23 @@
 #define	GM_CAMPAIGN_MODE				(1 << 10)			// are we currently in a campaign.
 #define GM_LAB							(1 << 11)			// We are currently in the F3 lab
 
-#define	VM_EXTERNAL						(1 << 0)				//	Set if not viewing from player position.
-#define	VM_TRACK						(1 << 1)				//	Set if viewer is tracking target.
-#define	VM_DEAD_VIEW					(1 << 2)				//	Set if viewer is watching from dead view.
-#define	VM_CHASE							(1 << 3)				//	Chase view.
-#define	VM_OTHER_SHIP					(1 << 4)				//	View from another ship.
-#define	VM_CAMERA_LOCKED			(1 << 5)				// Set if player does not have control of the camera
-#define	VM_WARP_CHASE					(1	<< 6)				// View while warping out (form normal view mode)
-#define	VM_PADLOCK_UP					(1 << 7)
-#define	VM_PADLOCK_REAR				(1 << 8)
-#define	VM_PADLOCK_LEFT				(1 << 9)
-#define	VM_PADLOCK_RIGHT				(1 << 10)
-#define	VM_WARPIN_ANCHOR				(1 << 11)			// special warpin camera mode
-#define VM_TOPDOWN					(1 << 12)				//Camera is looking down on ship
-#define VM_FREECAMERA				(1 << 13)				//Camera is not attached to any particular object, probably under SEXP control
-#define VM_CENTERING				(1 << 14)				// View is springing to center
+#define VM_EXTERNAL         (1 <<  0)   // Set if not viewing from player position.
+#define VM_TRACK            (1 <<  1)   // Set if viewer is tracking target.
+#define VM_DEAD_VIEW        (1 <<  2)   // Set if viewer is watching from dead view.
+#define VM_CHASE            (1 <<  3)   // Chase view.
+#define VM_OTHER_SHIP       (1 <<  4)   // View from another ship.
+#define VM_CAMERA_LOCKED    (1 <<  5)   // Set if player does not have control of the camera
+#define VM_WARP_CHASE       (1 <<  6)   // View while warping out (form normal view mode)
+#define VM_PADLOCK_UP       (1 <<  7)   // Set when player is looking up
+#define VM_PADLOCK_REAR     (1 <<  8)   // Set when player is looking behind
+#define VM_PADLOCK_LEFT     (1 <<  9)   // Set when player is looking left
+#define VM_PADLOCK_RIGHT    (1 << 10)   // Set when player is looking right
+#define VM_WARPIN_ANCHOR    (1 << 11)   // special warpin camera mode
+#define VM_TOPDOWN          (1 << 12)   // Camera is looking down on ship
+#define VM_FREECAMERA       (1 << 13)   // Camera is not attached to any particular object, probably under SEXP control
+#define VM_CENTERING        (1 << 14)   // View is springing to center
 
-#define	VM_PADLOCK_ANY (VM_PADLOCK_UP|VM_PADLOCK_REAR|VM_PADLOCK_LEFT|VM_PADLOCK_RIGHT)
+#define VM_PADLOCK_ANY (VM_PADLOCK_UP | VM_PADLOCK_REAR | VM_PADLOCK_LEFT | VM_PADLOCK_RIGHT)
 
 //-----Cutscene stuff
 //No bars

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -511,16 +511,6 @@ void do_view_external()
 }
 
 /**
- * Separate out the reading of thrust keys, so we can call this from external view as well as from normal view
- */
-void do_thrust_keys(control_info *ci)
-{
-	ci->forward = check_control_timef(FORWARD_THRUST) - check_control_timef(REVERSE_THRUST);
-	ci->sideways = (check_control_timef(RIGHT_SLIDE_THRUST) - check_control_timef(LEFT_SLIDE_THRUST));//for slideing-Bobboau
-	ci->vertical = (check_control_timef(UP_SLIDE_THRUST) - check_control_timef(DOWN_SLIDE_THRUST));//for slideing-Bobboau
-}
-
-/**
  * Called by single and multiplayer modes to reset information inside of control info structure
  */
 void player_control_reset_ci( control_info *ci )
@@ -552,12 +542,12 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 
 	// Camera & View controls
 	if ( Viewer_mode & VM_EXTERNAL ) {
+		// External mode
 		control_used(VIEW_EXTERNAL);
-
 		do_view_external();
-		do_thrust_keys(ci);
 
 	} else if ( Viewer_mode & VM_CHASE ) {
+		// Chase mode
 		do_view_chase();
 
 	} else {
@@ -570,7 +560,6 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 	// Ship controls
 	if (Viewer_mode & VM_CAMERA_LOCKED) {
 		// From keyboard...
-		do_thrust_keys(ci);
 		if ( check_control(BANK_WHEN_PRESSED) ) {
 			ci->bank = check_control_timef(BANK_LEFT) + check_control_timef(YAW_LEFT) - check_control_timef(YAW_RIGHT) - check_control_timef(BANK_RIGHT);
 			ci->heading = 0.0f;
@@ -609,6 +598,12 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 	}
 
 	if (!(Game_mode & GM_DEAD)) {
+		// Thrust controls
+		ci->forward = check_control_timef(FORWARD_THRUST) - check_control_timef(REVERSE_THRUST);
+		ci->sideways = (check_control_timef(RIGHT_SLIDE_THRUST) - check_control_timef(LEFT_SLIDE_THRUST)); // for slideing-Bobboau
+		ci->vertical = (check_control_timef(UP_SLIDE_THRUST) - check_control_timef(DOWN_SLIDE_THRUST)); // for slideing-Bobboau
+
+		// Throttle controls
 		if ( button_info_query(&Player->bi, ONE_THIRD_THROTTLE) ) {
 			control_used(ONE_THIRD_THROTTLE);
 			player_clear_speed_matching();


### PR DESCRIPTION
Move processing of thrust keys to be within the same block as the throttle keys

* Remove do_thrust_keys() function
* Clean up documentation of Viewer_mode flags
Fixes #4276 