### PR TITLE
Ensure that SEXP shudown is before script shutdown

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6683,15 +6683,14 @@ void game_shutdown(void)
 		gr_clear();
 		gr_flip();
 	}
-
+	
+	// Free SEXP resources
+	sexp_shutdown();
+	
 	// Free the scripting resources of the new UI first
 	scpui::shutdown_scripting();
 
-
-	// Free SEXP resources
-	sexp_shutdown();
-
-	// Everything after this should be done without scripting so we can free those resources here
+	// Everything after this should be done without scripting so we can free those resources here. By this point, all things that hold Lua References must be destroyed (such as Lua SEXPs)
 	Script_system.Clear();
 
 	// Deinitialize the new UI system, needs to be done after scripting shutdown to make sure the resources were

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6687,6 +6687,10 @@ void game_shutdown(void)
 	// Free the scripting resources of the new UI first
 	scpui::shutdown_scripting();
 
+
+	// Free SEXP resources
+	sexp_shutdown();
+
 	// Everything after this should be done without scripting so we can free those resources here
 	Script_system.Clear();
 
@@ -6729,8 +6733,6 @@ void game_shutdown(void)
 
 	scoring_close();
 
-	// Free SEXP resources
-	sexp_shutdown();
 
 	stars_close();			// clean out anything used by stars code
 


### PR DESCRIPTION
We must do sexp_shutdown() before we clear the scripting state. Otherwise FSO will try to destroy the LuaFunction references still held by the SEXP system, which will cause a crash as the lua state (and thus its function registry) is a nullptr / not allocated anymore by that point.