### PR TITLE
Actually grab the object's type when doing type checks.

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -10022,11 +10022,11 @@ void guard_object_was_hit(object *guard_objp, object *hitter_objp)
 
 			// This just checks to see that the target was a valid type. If it is not one of these, something really
 			// could be drastically wrong in the engine.
-			Assertion(aip->target_objnum == OBJ_SHIP || aip->target_objnum == OBJ_WEAPON || aip->target_objnum == OBJ_DEBRIS || aip->target_objnum == OBJ_ASTEROID || aip->target_objnum == OBJ_WAYPOINT,
+			Assertion(Objects[aip->target_objnum].type == OBJ_SHIP || Objects[aip->target_objnum].type == OBJ_WEAPON || Objects[aip->target_objnum].type == OBJ_DEBRIS || Objects[aip->target_objnum].type == OBJ_ASTEROID || Objects[aip->target_objnum].type == OBJ_WAYPOINT,
 				"This function just discovered that %s has an invalid target object type of %d. This is bad. Please report!", 
 				Ships[aip->shipnum].ship_name, Objects[aip->target_objnum].type);
 
-			if (!(aip->target_objnum == OBJ_SHIP || aip->target_objnum == OBJ_WEAPON || aip->target_objnum == OBJ_ASTEROID || aip->target_objnum == OBJ_DEBRIS)){
+			if (!(Objects[aip->target_objnum].type == OBJ_SHIP || Objects[aip->target_objnum].type == OBJ_WEAPON || Objects[aip->target_objnum].type == OBJ_ASTEROID || Objects[aip->target_objnum].type == OBJ_DEBRIS)){
 				// it's probably a valid target, but retail would not count those cases, so just return.
 				return;
 			} 


### PR DESCRIPTION
PR #4500 added some checks, but accidentally compared `aip->target_objnum` to an object type (although the assertion message correctly retrieved the object type, leading to the bizarre assertion that `OBJ_SHIP`, i.e. 1, was an invalid target object type). This commit makes them all access the `Objects[]` array and retrieve the `.type`, just as the assertion message does (and the pre-#4500 conditional did).

Related to #4504, in that it's the source of the failed assertions, although I can't be sure it was the cause of the crashes without testing.