### PR TITLE
only attenuate a persistent sound by engine strength if it's an engine sound

### DIFF
--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -461,10 +461,10 @@ void obj_snd_do_frame()
 	}
 
 	closest_dist = 1000000.0f;
-	closest_objp = NULL;
+	closest_objp = nullptr;
 
-	object *observer_obj = NULL;
-	if (Viewer_obj != NULL) {
+	object *observer_obj = nullptr;
+	if (Viewer_obj != nullptr) {
 		observer_obj = Viewer_obj;
 	} else if (Viewer_mode & VM_OTHER_SHIP && Player_ai->target_objnum != -1) {
 		// apparently Viewer_obj is still null when Viewing Other Ship externally
@@ -474,7 +474,7 @@ void obj_snd_do_frame()
 	}
 
 	for ( osp = GET_FIRST(&obj_snd_list); osp !=END_OF_LIST(&obj_snd_list); osp = GET_NEXT(osp) ) {
-		Assert(osp != NULL);
+		Assert(osp != nullptr);
 		objp = &Objects[osp->objnum];
 		if ((Player_obj == objp) && (observer_obj == Player_obj) && !(osp->flags & OS_PLAY_ON_PLAYER)) {
 			// we don't play sounds if the view is from the player
@@ -538,7 +538,7 @@ void obj_snd_do_frame()
 			}
 
 			// check conditions for subsystem sounds
-			if (osp->ss != NULL)
+			if (osp->ss != nullptr)
 			{
 				if (osp->flags & OS_TURRET_BASE_ROTATION)
 				{
@@ -618,7 +618,7 @@ void obj_snd_do_frame()
 						break;
 
 					default:
-						UNREACHABLE("Unhandled object type for persistent sound; get Alan");
+						UNREACHABLE("Unhandled object type %d for persistent sound; get a coder!", objp->type);
 						break;
 				} // end switch
 
@@ -658,7 +658,7 @@ void obj_snd_do_frame()
 		if (!osp->instance.isValid())
 			continue;
 
-		sp = NULL;
+		sp = nullptr;
 		if ( objp->type == OBJ_SHIP )
 			sp = &Ships[objp->instance];
 

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -16,14 +16,15 @@
 
 #define	OS_USED					(1<<0)
 #define OS_MAIN					(1<<1)		// "main" sound. attentuation does not apply until outside the radius of the object
-#define OS_TURRET_BASE_ROTATION	(1<<2)
-#define OS_TURRET_GUN_ROTATION	(1<<3)
-#define OS_SUBSYS_ALIVE			(1<<4)
-#define OS_SUBSYS_DEAD			(1<<5)
-#define OS_SUBSYS_DAMAGED		(1<<6)
-#define OS_SUBSYS_ROTATION		(1<<7)
-#define OS_PLAY_ON_PLAYER		(1<<8)
-#define OS_LOOPING_DISABLED		(1<<9)
+#define OS_ENGINE				(1<<2)		// the engine sound; only played when engines are on
+#define OS_TURRET_BASE_ROTATION	(1<<3)
+#define OS_TURRET_GUN_ROTATION	(1<<4)
+#define OS_SUBSYS_ALIVE			(1<<5)
+#define OS_SUBSYS_DEAD			(1<<6)
+#define OS_SUBSYS_DAMAGED		(1<<7)
+#define OS_SUBSYS_ROTATION		(1<<8)
+#define OS_PLAY_ON_PLAYER		(1<<9)
+#define OS_LOOPING_DISABLED		(1<<10)
 
 struct vec3d;
 class object;

--- a/code/scripting/api/objs/enums.cpp
+++ b/code/scripting/api/objs/enums.cpp
@@ -114,6 +114,7 @@ flag_def_list Enumerations[] = {
 	// the following OS_ definitions use bitfield values, not the indexes in enums.h
 	{"OS_NONE", 0, 0},
 	{"OS_MAIN", OS_MAIN, 0},
+	{"OS_ENGINE", OS_ENGINE, 0},
 	{"OS_TURRET_BASE_ROTATION", OS_TURRET_BASE_ROTATION, 0},
 	{"OS_TURRET_GUN_ROTATION", OS_TURRET_GUN_ROTATION, 0},
 	{"OS_SUBSYS_ALIVE", OS_SUBSYS_ALIVE, 0},

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14809,7 +14809,7 @@ void ship_assign_sound(ship *sp)
 			engine_pos = vmd_zero_vector;
 		}
 
-		obj_snd_assign(sp->objnum, sip->engine_snd, &engine_pos, OS_MAIN);
+		obj_snd_assign(sp->objnum, sip->engine_snd, &engine_pos, OS_MAIN | OS_ENGINE);
 	}
 }
 


### PR DESCRIPTION
Previously the persistent object sound management code would attenuate all script-assigned sounds by engine strength, and would not play them at all if the engine was off.  This fixes the code to only apply that logic if the sound is in fact and engine sound.

There is also a small amount of refactoring.