### PR TITLE
Bugfix for salvo mode and forced target

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2526,7 +2526,7 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 	bool in_fov = turret_fov_test(ss, &gvec, &v2e);
 	bool something_was_ok_to_fire = false;
 
-	if (in_fov) {
+	if (in_fov && num_valid) {
 
 		// Do salvo thing separately - to prevent messing up things
 		int number_of_firings;


### PR DESCRIPTION
Fixes an assert that could be caused with salvo mode turrets having an out-of-range target while using forced targets on that turret. Range is not a `tentative_return` so often turrets will discard the target when normally picking a new one (which also early returns if successful), but if they have a forced target they will not, and even then the `number_of_firings` will be set to the number of valid weapons, in normal cases simply 0, but with salvo mode, it's the number of firepoints. Resulting in an invalid access in `get_turret_weapon_wip()` later.

If the turret has gotten this far, there is no point in continuing if `num_valid` is 0.