### PR TITLE
prevent too many dynamic SEXPs from breaking the SEXP system

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -32319,6 +32319,21 @@ int get_category(int sexp_id)
 }
 
 // Goober5000
+const char *get_category_name(int category_id)
+{
+	if (category_id == OP_CATEGORY_CHANGE2)
+		category_id = OP_CATEGORY_CHANGE;
+
+	for (auto &category : op_menu)
+	{
+		if (category.id == category_id)
+			return category.name.c_str();
+	}
+
+	return "<unknown>";
+}
+
+// Goober5000
 int category_of_subcategory(int subcategory_id)
 {
 	int category = (subcategory_id & OP_CATEGORY_MASK);

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1359,6 +1359,7 @@ void set_turret_secondary_ammo(ship_subsys *turret, int requested_bank, int requ
 extern int get_category(int sexp_id);
 extern int category_of_subcategory(int subcategory_id);
 extern int get_subcategory(int sexp_id);
+extern const char *get_category_name(int category_id);
 
 // Goober5000
 extern void sexp_music_close();

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -125,8 +125,10 @@ void parse_sexp_table(const char* filename) {
 				luaSexp->parseTable();
 
 				int op = add_dynamic_sexp(std::move(instance), SEXP_GOAL_OPERATOR);
-				luaSexp->registerAIMode(op);
-				luaSexp->maybeRegisterPlayerOrder(op);
+				if (op >= 0) {
+					luaSexp->registerAIMode(op);
+					luaSexp->maybeRegisterPlayerOrder(op);
+				}
 			}
 			required_string("#End");
 		}
@@ -177,8 +179,19 @@ int add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp, int type)
 	new_op.min = sexp->getMinimumArguments();
 	new_op.max = sexp->getMaximumArguments();
 
+	int free_op_index = get_next_free_operator(sexp->getCategory());
+	if (free_op_index >= 256) {
+		Warning(LOCATION, "There are too many SEXPs in the category %d.  The %s SEXP will not be added.", sexp->getCategory(), sexp->getName().c_str());
+		return -1;
+	}
+
+	if (Operators.size() >= FIRST_OP) {
+		Warning(LOCATION, "There are too many total SEXPs.  The %s SEXP will not be added.", sexp->getName().c_str());
+		return -1;
+	}
+
 	// For now, all dynamic SEXPS are only valid in missions
-	new_op.value = get_next_free_operator(sexp->getCategory()) | sexp->getCategory() | OP_NONCAMPAIGN_FLAG;
+	new_op.value = free_op_index | sexp->getCategory() | OP_NONCAMPAIGN_FLAG;
 	new_op.type = type;
 
 	global.operator_const_mapping.insert(std::make_pair(new_op.value, std::move(sexp)));

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -181,12 +181,12 @@ int add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp, int type)
 
 	int free_op_index = get_next_free_operator(sexp->getCategory());
 	if (free_op_index >= 256) {
-		Warning(LOCATION, "There are too many SEXPs in the category %d.  The %s SEXP will not be added.", sexp->getCategory(), sexp->getName().c_str());
+		Warning(LOCATION, "There are too many SEXPs in the %s category.  The SEXP %s will not be added.", get_category_name(sexp->getCategory()), sexp->getName().c_str());
 		return -1;
 	}
 
 	if (Operators.size() >= FIRST_OP) {
-		Warning(LOCATION, "There are too many total SEXPs.  The %s SEXP will not be added.", sexp->getName().c_str());
+		Warning(LOCATION, "There are too many total SEXPs.  The SEXP %s will not be added.", sexp->getName().c_str());
 		return -1;
 	}
 


### PR DESCRIPTION
SEXP categories will not support more than 256 SEXPs; this is why the CHANGE2 category had to be created when CHANGE got full.  Unfortunately, dynamic SEXPs will count toward this limit, so mysterious errors will occur for the ones whose category indexes roll over.  The problem is not easily fixable, but at least the engine can detect the situation, warn about it, and refrain from adding any problematic SEXPs.

Since too many *total* SEXPs would cause a similar problem, this adds a warning for that case too.