### PR TITLE
Only check that *ships* have left the mission

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9115,7 +9115,7 @@ static void ship_check_player_distance()
 		if (MULTIPLAYER_MASTER) {
 			// warn all players
 			for (idx=0; idx<MAX_PLAYERS; idx++) {
-				if (MULTI_CONNECTED(Net_players[idx]) && !MULTI_STANDALONE(Net_players[idx]) && !MULTI_OBSERVER(Net_players[idx]) && (Objects[Net_players[idx].m_player->objnum].type != OBJ_GHOST) ) {
+				if (MULTI_CONNECTED(Net_players[idx]) && !MULTI_STANDALONE(Net_players[idx]) && !MULTI_OBSERVER(Net_players[idx]) && (Objects[Net_players[idx].m_player->objnum].type == OBJ_SHIP) ) {
 					// if bad, blow him up
 					ship_check_player_distance_sub(Net_players[idx].m_player, idx);
 				}


### PR DESCRIPTION
Other types are possible here because multi deletes the ghost object, at least, that is what I understood from the code and comments two years ago, when I first started looking at respawn bugs.  So it is much better to just ensure that the object is a ship, instead of checking against what it shouldn't be before checking the distance.

Related, but not guaranteed to fix part of #4509.