### PR TITLE
Clean up the lua stack after EvalStringWithReturn's function creation

### DIFF
--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -337,13 +337,19 @@ bool script_state::EvalStringWithReturn(const char* string, const char* format, 
 				scripting::ade_get_args(LuaState, format, rtn);
 			}
 		} catch (const LuaException&) {
+			lua_pop(LuaState, 1);
+
 			return false;
 		}
 	} catch (const LuaException& e) {
 		LuaError(GetLuaSession(), "%s", e.what());
 
+		lua_pop(LuaState, 1);
+
 		return false;
 	}
+
+	lua_pop(LuaState, 1);
 
 	return true;
 }


### PR DESCRIPTION
fixes #4504. Hopefully. I'll freely admit my understanding of this area of the engine is spotty, but debug monitoring of the stack allocation showed this to be a source of leaks and the crashing missions are stable now as far as I've tested. More testing of script-eval-num and script-eval-bool heavy missions may be warranted. 