### PR TITLE
don't prune HUD gauges by resolution in FRED

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -306,8 +306,8 @@ void parse_hud_gauges_tbl(const char *filename)
 		if (optional_string("$Reticle Style:")) {
 			int temp = required_string_either("FS1", "FS2");
 
-			// using require_string_either won't advance the Mp pointer to the next token so force it instead
-			skip_to_start_of_string("#Gauge Config");
+			// using require_string_either won't advance the Mp pointer to the next token
+			Mp += 3;
 
 			if (temp < 0)
 				Warning(LOCATION, "Undefined reticle style in hud_gauges.tbl!");
@@ -445,20 +445,17 @@ void parse_hud_gauges_tbl(const char *filename)
 			}
 
 			// Pruning time. Let's see if the current resolution defined by the user matches the conditions set by this entry
+			bool prune_config = false;
 			if (optional_string("$Required Aspect:")) {
 				// filter aspect ratio.
 				if (optional_string("Full Screen")) {
-					if( (float)gr_screen.center_w / (float)gr_screen.center_h > 1.5) {
-						skip_to_start_of_string("#Gauge Config");
-						//skip_to_start_of_string_either("#Gauge Config", "#End");
-						continue;
+					if ((float)gr_screen.center_w / (float)gr_screen.center_h > 1.5f) {
+						prune_config = true;
 					}
 				}
 				else if (optional_string("Wide Screen")) {
-					if( (float)gr_screen.center_w / (float)gr_screen.center_h <= 1.5) {
-						skip_to_start_of_string("#Gauge Config");
-						//skip_to_start_of_string_either("#Gauge Config", "#End");
-						continue;
+					if ((float)gr_screen.center_w / (float)gr_screen.center_h <= 1.5f) {
+						prune_config = true;
 					}
 				}
 			}
@@ -469,13 +466,11 @@ void parse_hud_gauges_tbl(const char *filename)
 				stuff_int_list(min_res, 2, RAW_INTEGER_TYPE);
 
 				if (min_res[0] > gr_screen.max_w) {
-					skip_to_start_of_string("#Gauge Config");
-					continue;
+					prune_config = true;
 				}
 				else if (min_res[0] == gr_screen.center_w) {
 					if (min_res[1] > gr_screen.center_h) {
-						skip_to_start_of_string("#Gauge Config");
-						continue;
+						prune_config = true;
 					}
 				}
 			}
@@ -486,15 +481,19 @@ void parse_hud_gauges_tbl(const char *filename)
 				stuff_int_list(max_res, 2, RAW_INTEGER_TYPE);
 
 				if (max_res[0] < gr_screen.max_w) {
-					skip_to_start_of_string("#Gauge Config");
-					continue;
+					prune_config = true;
 				}
 				else if (max_res[0] == gr_screen.center_w) {
 					if (max_res[1] < gr_screen.center_h) {
-						skip_to_start_of_string("#Gauge Config");
-						continue;
+						prune_config = true;
 					}
 				}
+			}
+
+			// don't prune resolutions in FRED
+			if (!Fred_running && prune_config) {
+				skip_to_start_of_string("#Gauge Config");
+				continue;
 			}
 
 			// let's start parsing for gauges.

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -6372,23 +6372,28 @@ sexp_list_item *sexp_tree::get_listing_opf_builtin_hud_gauge()
 sexp_list_item *sexp_tree::get_listing_opf_custom_hud_gauge()
 {
 	sexp_list_item head;
-	SCP_unordered_set<SCP_string> all_gauges;
+	// prevent duplicate names, comparing case-insensitively
+	SCP_unordered_set<SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to> all_gauges;
 
 	for (auto &gauge : default_hud_gauges)
 	{
-		all_gauges.insert(gauge->getCustomGaugeName());
-		head.add_data(gauge->getCustomGaugeName());
+		SCP_string name = gauge->getCustomGaugeName();
+		if (!name.empty() && all_gauges.count(name) == 0)
+		{
+			head.add_data(name.c_str());
+			all_gauges.insert(std::move(name));
+		}
 	}
 
 	for (auto &si : Ship_info)
 	{
 		for (auto &gauge : si.hud_gauges)
 		{
-			// avoid duplicating any HUD gauges
-			if (all_gauges.count(gauge->getCustomGaugeName()) == 0)
+			SCP_string name = gauge->getCustomGaugeName();
+			if (!name.empty() && all_gauges.count(name) == 0)
 			{
-				all_gauges.insert(gauge->getCustomGaugeName());
-				head.add_data(gauge->getCustomGaugeName());
+				head.add_data(name.c_str());
+				all_gauges.insert(std::move(name));
 			}
 		}
 	}


### PR DESCRIPTION
FRED needs to work with any HUD gauge in the table, so don't prune any based on resolution.  Fixes #4517.

This also improves checking for duplicate names in the FRED gauge list.