### PR TITLE
Automatically calculate length of flag name lists.

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -33,8 +33,8 @@ typedef struct ai_flag_name {
 	char flag_name[TOKEN_LENGTH];
 } ai_flag_name;
 
-#define MAX_AI_FLAG_NAMES			2
 extern ai_flag_name Ai_flag_names[];
+extern const int Num_ai_flag_names;
 
 //	dock_orient_and_approach() modes.
 #define	DOA_APPROACH	1		//	Approach the current point on the path (aip->path_cur)

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -216,6 +216,8 @@ ai_flag_name Ai_flag_names[] = {
 	{AI::AI_Flags::Free_afterburner_use,	"free-afterburner-use",	},
 };
 
+extern const int Num_ai_flag_names = sizeof(Ai_flag_names) / sizeof(ai_flag_name);
+
 const char *Skill_level_names(int level, int translate)
 {
 	const char *str = NULL;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -115,6 +115,8 @@ obj_flag_name Object_flag_names[] = {
 	{ Object::Object_Flags::Attackable_if_no_collide, "ai-attackable-if-no-collide", 1,},
 };
 
+extern const int Num_object_flag_names = sizeof(Object_flag_names) / sizeof(obj_flag_name);
+
 #ifdef OBJECT_CHECK
 checkobject::checkobject() 
     : type(0), signature(0), parent_sig(0) 

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -110,8 +110,8 @@ typedef struct obj_flag_name {
 	int flag_list;
 } obj_flag_name;
 
-#define MAX_OBJECT_FLAG_NAMES			11
 extern obj_flag_name Object_flag_names[];
+extern const int Num_object_flag_names;
 
 struct dock_instance;
 class model_draw_list;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3266,7 +3266,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 			case OPF_SHIP_FLAG:
 				{
 				bool found = false;
-				for ( i = 0; i < MAX_OBJECT_FLAG_NAMES; i++) {
+				for ( i = 0; i < Num_object_flag_names; i++) {
 					if (!stricmp(Object_flag_names[i].flag_name, CTEXT(node))) {
 						found = true;
 						break;
@@ -3274,7 +3274,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				}
 
 				if (!found) {
-					for ( i = 0; i < MAX_SHIP_FLAG_NAMES; i++) {
+					for ( i = 0; i < Num_ship_flag_names; i++) {
 						if (!stricmp(Ship_flag_names[i].flag_name, CTEXT(node))) {
 							found = true;
 							break;
@@ -3283,7 +3283,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				}
 
 				if (!found) {
-					for ( i = 0; i < MAX_AI_FLAG_NAMES; i++) {
+					for ( i = 0; i < Num_ai_flag_names; i++) {
 						if (!stricmp(Ai_flag_names[i].flag_name, CTEXT(node))) {
 							found = true;
 							break;
@@ -15512,7 +15512,7 @@ bool sexp_check_flag_arrays(const char *flag_name, Object::Object_Flags &object_
 	int i;
 	bool send_multi = false;
 
-	for ( i = 0; i < MAX_OBJECT_FLAG_NAMES; i++) {
+	for ( i = 0; i < Num_object_flag_names; i++) {
 		if (!stricmp(Object_flag_names[i].flag_name, flag_name)) {
 			// make sure the list writes to the correct list of flags!
 			if (Object_flag_names[i].flag_list == 1) {
@@ -15522,7 +15522,7 @@ bool sexp_check_flag_arrays(const char *flag_name, Object::Object_Flags &object_
 		}
 	}
 
-	for ( i = 0; i < MAX_SHIP_FLAG_NAMES; i++) {
+	for ( i = 0; i < Num_ship_flag_names; i++) {
 		if (!stricmp(Ship_flag_names[i].flag_name, flag_name)) {
 			// make sure the list writes to the correct list of flags!
 			ship_flags = Ship_flag_names[i].flag;
@@ -15539,7 +15539,7 @@ bool sexp_check_flag_arrays(const char *flag_name, Object::Object_Flags &object_
 		}
 	}
 
-	for ( i = 0; i < MAX_AI_FLAG_NAMES; i++) {
+	for ( i = 0; i < Num_ai_flag_names; i++) {
 		if (!stricmp(Ai_flag_names[i].flag_name, flag_name)) {
 			ai_flag = Ai_flag_names[i].flag;
 			break;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -503,7 +503,6 @@ const int num_ai_tgt_weapon_info_flags = sizeof(ai_tgt_weapon_flags) / sizeof(fl
 SCP_vector <ai_target_priority> Ai_tp_list;
 
 //	Constant for flag,				Name of flag,				In flags or flags2
-//  When adding new flags remember to bump MAX_SHIP_FLAG_NAMES in ship.h
 ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::Vaporize,						"vaporize" },
 	{ Ship_Flags::Warp_broken,					"break-warp" },
@@ -529,6 +528,8 @@ ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::Fail_sound_locked_primary, 	"fail-sound-locked-primary"},
 	{ Ship_Flags::Fail_sound_locked_secondary, 	"fail-sound-locked-secondary"}
 };
+
+extern const int Num_ship_flag_names = sizeof(Ship_flag_names) / sizeof(ship_flag_name);
 
 static int Laser_energy_out_snd_timer;	// timer so we play out of laser sound effect periodically
 static int Missile_out_snd_timer;	// timer so we play out of laser sound effect periodically

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -449,8 +449,8 @@ typedef struct ship_flag_name {
 	char flag_name[TOKEN_LENGTH];		// the name written to the mission file for its corresponding parse_object flag
 } ship_flag_name;
 
-#define MAX_SHIP_FLAG_NAMES					23
 extern ship_flag_name Ship_flag_names[];
+extern const int Num_ship_flag_names;
 
 #define DEFAULT_SHIP_PRIMITIVE_SENSOR_RANGE		10000	// Goober5000
 

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -6975,15 +6975,15 @@ sexp_list_item *sexp_tree::get_listing_opf_ship_flags()
 	int i;
 	sexp_list_item head;
 	// object flags
-	for ( i = 0; i < MAX_OBJECT_FLAG_NAMES; i++) {
+	for ( i = 0; i < Num_object_flag_names; i++) {
 		head.add_data(Object_flag_names[i].flag_name);
 	}
 	// ship flags
-	for ( i = 0; i < MAX_SHIP_FLAG_NAMES; i++) {
+	for ( i = 0; i < Num_ship_flag_names; i++) {
 		head.add_data(Ship_flag_names[i].flag_name);
 	}
 	// ai flags
-	for ( i = 0; i < MAX_AI_FLAG_NAMES; i++) {
+	for ( i = 0; i < Num_ai_flag_names; i++) {
 		head.add_data(Ai_flag_names[i].flag_name);
 	}
 

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4777,15 +4777,15 @@ sexp_list_item* sexp_tree::get_listing_opf_ship_flags() {
 	int i;
 	sexp_list_item head;
 	// object flags
-	for (i = 0; i < MAX_OBJECT_FLAG_NAMES; i++) {
+	for (i = 0; i < Num_object_flag_names; i++) {
 		head.add_data(Object_flag_names[i].flag_name);
 	}
 	// ship flags
-	for (i = 0; i < MAX_SHIP_FLAG_NAMES; i++) {
+	for (i = 0; i < Num_ship_flag_names; i++) {
 		head.add_data(Ship_flag_names[i].flag_name);
 	}
 	// ai flags
-	for (i = 0; i < MAX_AI_FLAG_NAMES; i++) {
+	for (i = 0; i < Num_ai_flag_names; i++) {
 		head.add_data(Ai_flag_names[i].flag_name);
 	}
 


### PR DESCRIPTION
`Ai_flag_names[]`, `Object_flag_names[]`, and `Ship_flag_names[]` all had an associated `#define` containing their length that had to manually be incremented whenever new flag names were added to the list. This commit instead makes the number of flags in the list be computed by simple `sizeof` division, so now adding a new entry just requires adding the entry, rather than remembering to bump a `#define`. Tested in FRED to make sure populating `OPF_SHIP_FLAG` entries still works.