### PR TITLE
Fix False Null MOI warnings

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2800,7 +2800,7 @@ bool turret_adv_fov_test(ship_subsys *ss, vec3d *gvec, vec3d *v2e, float size_mo
 			return true; 
 		else {
 			of_dst.xyz.y = 0;
-			if (!IS_VEC_NULL(&of_dst)) {
+			if (!IS_VEC_NULL_SQ_SAFE(&of_dst)) {
 				vm_vec_normalize(&of_dst);
 				// now we have 2d vector with lenght of 1 that points at the targets direction after being rotated to turrets FOR
 				if ((of_dst.xyz.z + size_mod) >= tp->turret_base_fov)

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1640,7 +1640,7 @@ static void asteroid_test_collide(object *pasteroid_obj, object *pship_obj, mc_i
 	asteroid_ray_dist = vm_vec_mag_quick(&pasteroid_obj->phys_info.desired_vel) * ASTEROID_MIN_COLLIDE_TIME;
 	asteroid_fvec = pasteroid_obj->phys_info.desired_vel;
 
-	if(IS_VEC_NULL(&asteroid_fvec)){
+	if(IS_VEC_NULL_SQ_SAFE(&asteroid_fvec)){
 		terminus = pasteroid_obj->pos;
 	} else {
 		vm_vec_normalize(&asteroid_fvec);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1033,7 +1033,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 		speed = vm_vec_mag(&target_objp->phys_info.vel);
 
 		// do the extra math only if it won't lead to null vec issues
-		if(!(IS_VEC_NULL(&target_objp->phys_info.vel))){
+		if(!(IS_VEC_NULL_SQ_SAFE(&target_objp->phys_info.vel))){
 			vec3d unit_vec, component_vec;
 
 			// in other words substract the magnitude of the target's velocity vectors parallel component from the speed of the weapon

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -96,7 +96,7 @@ float fl_isqrt( float x )
 } 
 */
 
-// sees if a floating point number is within the minimum tolerance of zero
+// sees if a floating point number is within a certain threshold (by default, epsilon) of zero
 inline bool fl_near_zero(float a, float e = std::numeric_limits<float>::epsilon())
 {
 	return a < e && a > -e;

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -97,10 +97,9 @@ float fl_isqrt( float x )
 */
 
 // sees if a floating point number is within the minimum tolerance of zero
-inline bool fl_near_zero(float a)
+inline bool fl_near_zero(float a, float e = std::numeric_limits<float>::epsilon())
 {
-	return a < std::numeric_limits<float>::epsilon()
-		&& a > -std::numeric_limits<float>::epsilon();
+	return a < e && a > -e;
 }
 
 // sees if two floating point numbers are within the minimum tolerance

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1118,7 +1118,7 @@ float find_nearest_point_on_line(vec3d *nearest_point, const vec3d *p0, const ve
 	vm_vec_sub(&norm, p1, p0);
 	vm_vec_sub(&xlated_int_pnt, int_pnt, p0);
 
-	if (IS_VEC_NULL(&norm)) {
+	if (IS_VEC_NULL_SQ_SAFE(&norm)) {
 		*nearest_point = *int_pnt;
 		return 9999.9f;
 	}
@@ -1345,7 +1345,7 @@ void vm_vec_rand_vec(vec3d *rvec)
 	rvec->xyz.y = (frand() - 0.5f) * 2;
 	rvec->xyz.z = (frand() - 0.5f) * 2;
 
-	if (IS_VEC_NULL(rvec))
+	if (IS_VEC_NULL_SQ_SAFE(rvec))
 		rvec->xyz.x = 1.0f;
 
 	vm_vec_normalize(rvec);
@@ -1565,7 +1565,7 @@ void vm_matrix_to_rot_axis_and_angle(const matrix *m, float *theta, vec3d *rot_a
 		rot_axis->xyz.x = (m->vec.uvec.xyz.z - m->vec.fvec.xyz.y);
 		rot_axis->xyz.y = (m->vec.fvec.xyz.x - m->vec.rvec.xyz.z);
 		rot_axis->xyz.z = (m->vec.rvec.xyz.y - m->vec.uvec.xyz.x);
-		if (IS_VEC_NULL(rot_axis)) {
+		if (IS_VEC_NULL_SQ_SAFE(rot_axis)) {
 			vm_vec_make(rot_axis, 1.0f, 0.0f, 0.0f);
 		} else {
 			vm_vec_normalize(rot_axis);

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -20,14 +20,15 @@
 #define vm_is_vec_nan(v) (fl_is_nan((v)->xyz.x) || fl_is_nan((v)->xyz.y) || fl_is_nan((v)->xyz.z))
 
 //Macros/functions to fill in fields of structures
+//VEC_NULL macros split into two functions in 2009 with commit 75a514b
 
-//macro to check if vector is zero, uses 1e-16 as a minimum tolerance
+//macro to check if vector is close to zero or would be close to zero after squaring
 #define IS_VEC_NULL_SQ_SAFE(v) \
 		(fl_near_zero((v)->xyz.x, (float) 1e-16) && \
 		fl_near_zero((v)->xyz.y, (float) 1e-16) && \
 		fl_near_zero((v)->xyz.z, (float) 1e-16))
 
-// macro to check if vector is zero, uses 1e-36 as a minimum tolerance
+//macro to check if vector is close to zero
 #define IS_VEC_NULL(v) \
 		(fl_near_zero((v)->xyz.x, (float) 1e-36) && \
 		fl_near_zero((v)->xyz.y, (float) 1e-36) && \

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -22,9 +22,15 @@
 //Macros/functions to fill in fields of structures
 
 //macro to check if vector is zero
-#define IS_VEC_NULL(v) (fl_near_zero((v)->xyz.x) && \
-						fl_near_zero((v)->xyz.y) && \
-						fl_near_zero((v)->xyz.z))
+#define IS_VEC_NULL_SQ_SAFE(v) \
+		(fl_near_zero((v)->xyz.x, 1e-16) && \
+		fl_near_zero((v)->xyz.y, 1e-16) && \
+		fl_near_zero((v)->xyz.z, 1e-16))
+
+#define IS_VEC_NULL(v) \
+		(fl_near_zero((v)->xyz.x, 1e-36) && \
+		fl_near_zero((v)->xyz.y, 1e-36) && \
+		fl_near_zero((v)->xyz.z, 1e-36))
 
 #define IS_MAT_NULL(v) (IS_VEC_NULL(&(v)->vec.fvec) && IS_VEC_NULL(&(v)->vec.uvec) && IS_VEC_NULL(&(v)->vec.rvec))
 

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -21,16 +21,17 @@
 
 //Macros/functions to fill in fields of structures
 
-//macro to check if vector is zero
+//macro to check if vector is zero, uses 1e-16 as a minimum tolerance
 #define IS_VEC_NULL_SQ_SAFE(v) \
-		(fl_near_zero((v)->xyz.x, 1e-16) && \
-		fl_near_zero((v)->xyz.y, 1e-16) && \
-		fl_near_zero((v)->xyz.z, 1e-16))
+		(fl_near_zero((v)->xyz.x, (float) 1e-16) && \
+		fl_near_zero((v)->xyz.y, (float) 1e-16) && \
+		fl_near_zero((v)->xyz.z, (float) 1e-16))
 
+// macro to check if vector is zero, uses 1e-36 as a minimum tolerance
 #define IS_VEC_NULL(v) \
-		(fl_near_zero((v)->xyz.x, 1e-36) && \
-		fl_near_zero((v)->xyz.y, 1e-36) && \
-		fl_near_zero((v)->xyz.z, 1e-36))
+		(fl_near_zero((v)->xyz.x, (float) 1e-36) && \
+		fl_near_zero((v)->xyz.y, (float) 1e-36) && \
+		fl_near_zero((v)->xyz.z, (float) 1e-36))
 
 #define IS_MAT_NULL(v) (IS_VEC_NULL(&(v)->vec.fvec) && IS_VEC_NULL(&(v)->vec.uvec) && IS_VEC_NULL(&(v)->vec.rvec))
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1512,7 +1512,7 @@ void brief_set_camera_target(vec3d *pos, matrix *orient, int time)
 	// calculate camera velocity
 	vm_vec_sub(&Cam_vel, pos, &Current_cam_pos);
 	
-	if ( !IS_VEC_NULL(&Cam_vel) ) {
+	if ( !IS_VEC_NULL_SQ_SAFE(&Cam_vel) ) {
 		vm_vec_normalize(&Cam_vel);
 	}
 
@@ -1803,7 +1803,7 @@ int brief_set_move_list(int new_stage, int current_stage, float time)
 					imi->direction = zero_v;
 
 					vm_vec_sub(&imi->direction, &imi->finish, &imi->start);
-					if ( !IS_VEC_NULL(&imi->direction) ) {
+					if ( !IS_VEC_NULL_SQ_SAFE(&imi->direction) ) {
 						vm_vec_normalize(&imi->direction);
 					}
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2314,7 +2314,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 
 						cfread_vector(&(p->pnt), fp);
 						cfread_vector( &temp_vec, fp );
-						if (!IS_VEC_NULL(&temp_vec))
+						if (!IS_VEC_NULL_SQ_SAFE(&temp_vec))
 							vm_vec_normalize(&temp_vec);
 						else
 							vm_vec_zero(&temp_vec);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2273,7 +2273,7 @@ void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, in
 			vec3d scale_vec = { { { 1.0f, 0.0f, 0.0f } } };
 
 			// normalize banks, in case of incredibly big normals
-			if ( !IS_VEC_NULL(&world_norm) )
+			if ( !IS_VEC_NULL_SQ_SAFE(&world_norm) )
 				vm_vec_copy_normalize(&scale_vec, &world_norm);
 
 			// adjust for thrust

--- a/code/nebula/neblightning.cpp
+++ b/code/nebula/neblightning.cpp
@@ -509,7 +509,7 @@ void nebl_process()
 			} while (vm_vec_dist(&strike, &Eye_position) > 200.0f && vm_vec_dist(&start, &strike) > 200.0f);
 
 			// add some flavor to the bolt. mmmmmmmm, lightning
-			if(!IS_VEC_NULL(&Storm->flavor)){
+			if(!IS_VEC_NULL_SQ_SAFE(&Storm->flavor)){
 				// start with your basic hot sauce. measure how much you have			
 				vec3d your_basic_hot_sauce;
 				vm_vec_sub(&your_basic_hot_sauce, &strike, &start);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8545,7 +8545,7 @@ void sexp_set_orient_sub(matrix *orient_to_set, vec3d *pos, vec3d *location, int
 
 	vm_vec_sub(&v_orient, location, pos);
 
-	if (IS_VEC_NULL(&v_orient))
+	if (IS_VEC_NULL_SQ_SAFE(&v_orient))
 	{
 		Warning(LOCATION, "error in sexp setting ship orientation: can't point to self; quitting...\n");
 		return;
@@ -13160,7 +13160,7 @@ void sexp_explosion_effect(int n)
 						ship_apply_global_damage( objp, nullptr, &origin, t_damage, -1 );
 						vec3d force, vec_ship_to_impact;
 						vm_vec_sub( &vec_ship_to_impact, &objp->pos, &origin );
-						if (!IS_VEC_NULL( &vec_ship_to_impact )) {
+						if (!IS_VEC_NULL_SQ_SAFE( &vec_ship_to_impact )) {
 							vm_vec_copy_normalize( &force, &vec_ship_to_impact );
 							vm_vec_scale( &force, (float)max_blast );
 							ship_apply_whack( &force, &origin, objp );
@@ -13322,7 +13322,7 @@ void sexp_warp_effect(int n)
 
 	vm_vec_sub(&v_orient, &location, &origin);
 
-	if (IS_VEC_NULL(&v_orient))
+	if (IS_VEC_NULL_SQ_SAFE(&v_orient))
 	{
 		Warning(LOCATION, "error in warp-effect: warp can't point to itself; quitting the warp...\n");
 		return;

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -985,7 +985,7 @@ void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi,
 	pi->flags |= PF_IN_SHOCKWAVE;
 
 	// safety dance
-	if (!(IS_VEC_NULL(&torque))) {
+	if (!(IS_VEC_NULL_SQ_SAFE(&torque))) {
 		vec3d delta_rotvel;
 		vm_vec_rotate( &local_torque, &torque, orient );
 		vm_vec_copy_normalize(&delta_rotvel, &local_torque);

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -95,7 +95,7 @@ void HudGaugeRadarOrb::plotBlip(blip *b, vec3d *scaled_pos)
 {
 	*scaled_pos = b->position;
 	
-	if (IS_VEC_NULL(scaled_pos)) {
+	if (IS_VEC_NULL_SQ_SAFE(scaled_pos)) {
 		vm_vec_make(scaled_pos, 1.0f, 0.0f, 0.0f);
 	} else {
 		vm_vec_normalize(scaled_pos);

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1059,7 +1059,7 @@ ADE_FUNC(createWarpeffect,
 
 	vm_vec_sub(&v_orient, &point_to, &pos);
 
-	if (IS_VEC_NULL(&v_orient))
+	if (IS_VEC_NULL_SQ_SAFE(&v_orient))
 	{
 		//error in warp-effect: warp can't point to itself
 		LuaError(L, "The warp effect cannot be pointing at itself");


### PR DESCRIPTION
In #4443, `fl_near_zero` was set to use default epsilon values in the `IS_VEC_NULL` check. In this comparison, epsilon is the wrong threshold because it used to have a much smaller threshold. The fix restores the previous definitions of `IS_VEC_NULL` and `IS_VEC_NULL_SQ_SAFE` by exposing the epsilon value as an optional parameter (similar to how `IS_NEAR_ZERO` used to work. This PR also restores `IS_VEC_NULL_SQ_SAFE` where it was replaced by `IS_VEC_NULL.`

Fixes #4534.