### PR TITLE
Add options to selectively disable shadows

### DIFF
--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -516,3 +516,23 @@ void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos)
 	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
 	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 }
+
+static bool shadow_override_backup = false;
+static bool last_override = false;
+
+bool shadow_maybe_start_frame(const bool& override) {
+	last_override = override;
+	if (last_override) {
+		shadow_override_backup = Shadow_override;
+		Shadow_override = true;
+		return false;
+	}
+	return Shadow_quality != ShadowQuality::Disabled;
+}
+
+void shadow_end_frame() {
+	if (last_override) {
+		Shadow_override = shadow_override_backup;
+		last_override = false;
+	}
+}

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -40,4 +40,7 @@ void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos);
 matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist);
 void shadows_end_render();
 
+bool shadow_maybe_start_frame(const bool& override = false);
+void shadow_end_frame();
+
 #endif

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -40,7 +40,16 @@ void shadows_render_all(float fov, matrix *eye_orient, vec3d *eye_pos);
 matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, float fov, float aspect, float veryneardist, float neardist, float middist, float fardist);
 void shadows_end_render();
 
+/**
+* Function to call when evaluating whether a shadowmap should be drawn or not when starting a new frame that is rendered with shadows enabled.
+* A call of this function must always be followed up later with shadow_end_frame once the shadow map and the objects using the shadow map are rendered.
+* @params override If true, will override the shadow settings to prevent the following render calls from using shadows until the next shadow_end_frame.
+* @returns Whether a shadow map needs to be generated or not.
+*/
 bool shadow_maybe_start_frame(const bool& override = false);
+/**
+* The follow-up to shadow_maybe_start_frame, for cleaning up and preparing for the next frame. Always call after shadow_maybe_start_frame as soon as the shadow map and the objects using it are rendered.
+*/
 void shadow_end_frame();
 
 #endif

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -551,11 +551,7 @@ void techroom_ships_render(float frametime)
 		render_info.set_replacement_textures(Techroom_ship_modelnum, sip->replacement_textures);
 	}
 
-	bool shadow_override_backup = Shadow_override;
-	if (Shadow_disable_overrides.disable_techroom) {
-		Shadow_override = true;
-	}
-    else if(Shadow_quality != ShadowQuality::Disabled)
+    if(shadow_maybe_start_frame(Shadow_disable_overrides.disable_techroom))
     {
         gr_reset_clip();
 
@@ -586,9 +582,7 @@ void techroom_ships_render(float frametime)
 
 	batching_render_all();
 
-	if (Shadow_disable_overrides.disable_techroom) {
-		Shadow_override = shadow_override_backup;
-	}
+	shadow_end_frame();
 
 	gr_end_view_matrix();
 	gr_end_proj_matrix();

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -551,7 +551,11 @@ void techroom_ships_render(float frametime)
 		render_info.set_replacement_textures(Techroom_ship_modelnum, sip->replacement_textures);
 	}
 
-    if(Shadow_quality != ShadowQuality::Disabled)
+	bool shadow_override_backup = Shadow_override;
+	if (Shadow_disable_overrides.disable_techroom) {
+		Shadow_override = true;
+	}
+    else if(Shadow_quality != ShadowQuality::Disabled)
     {
         gr_reset_clip();
 
@@ -581,6 +585,10 @@ void techroom_ships_render(float frametime)
 	Glowpoint_use_depth_buffer = true;
 
 	batching_render_all();
+
+	if (Shadow_disable_overrides.disable_techroom) {
+		Shadow_override = shadow_override_backup;
+	}
 
 	gr_end_view_matrix();
 	gr_end_proj_matrix();

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1071,7 +1071,12 @@ void brief_render_closeup(int ship_class, float frametime)
 
 	model_render_params render_info;
 	render_info.set_detail_level_lock(0);
+	
+	bool shadow_override_backup = Shadow_override;
 
+	if (Shadow_disable_overrides.disable_mission_select_ships) {
+		Shadow_override = true;
+	}
 	if (Shadow_quality != ShadowQuality::Disabled)
 	{
 		auto pm = model_get(Closeup_icon->modelnum);
@@ -1101,6 +1106,10 @@ void brief_render_closeup(int ship_class, float frametime)
 
 	gr_end_view_matrix();
 	gr_end_proj_matrix();
+
+	if (Shadow_disable_overrides.disable_mission_select_ships) {
+		Shadow_override = shadow_override_backup;
+	}
 
 	g3_end_frame();
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1071,13 +1071,8 @@ void brief_render_closeup(int ship_class, float frametime)
 
 	model_render_params render_info;
 	render_info.set_detail_level_lock(0);
-	
-	bool shadow_override_backup = Shadow_override;
 
-	if (Shadow_disable_overrides.disable_mission_select_ships) {
-		Shadow_override = true;
-	}
-	if (Shadow_quality != ShadowQuality::Disabled)
+	if (shadow_maybe_start_frame(Shadow_disable_overrides.disable_mission_select_ships))
 	{
 		auto pm = model_get(Closeup_icon->modelnum);
 
@@ -1107,9 +1102,7 @@ void brief_render_closeup(int ship_class, float frametime)
 	gr_end_view_matrix();
 	gr_end_proj_matrix();
 
-	if (Shadow_disable_overrides.disable_mission_select_ships) {
-		Shadow_override = shadow_override_backup;
-	}
+	shadow_end_frame();
 
 	g3_end_frame();
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1653,7 +1653,6 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 	angles rot_angles, view_angles;
 	matrix model_orient;
 
-	bool shadow_override_backup = Shadow_override;
 	const bool& shadow_disable_override = flags & MR_IS_MISSILE ? Shadow_disable_overrides.disable_mission_select_weapons : Shadow_disable_overrides.disable_mission_select_ships;
 
 	if (effect == 2) {  // FS2 Effect; Phase 0 Expand scanline, Phase 1 scan the grid and wireframe, Phase 2 scan up and reveal the ship, Phase 3 tilt the camera, Phase 4 start rotating the ship
@@ -1786,10 +1785,8 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 			render_info->set_detail_level_lock(0);
 
 			gr_zbuffer_set(true);
-			if (shadow_disable_override) {
-				Shadow_override = true;
-			}
-			else if(Shadow_quality != ShadowQuality::Disabled)
+
+			if(shadow_maybe_start_frame(shadow_disable_override))
             {
 				gr_end_view_matrix();
 				gr_end_proj_matrix();
@@ -1903,10 +1900,7 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 
 		render_info->set_detail_level_lock(0);
 
-		if (shadow_disable_override) {
-			Shadow_override = true;
-		}
-		else if(Shadow_quality != ShadowQuality::Disabled)
+		if(shadow_maybe_start_frame(shadow_disable_override))
 		{
 			if ( flags & MR_IS_MISSILE )  {
 				shadows_start_render(&Eye_matrix, &Eye_position, Proj_fov, gr_screen.clip_aspect, -closeup_pos->xyz.z + pm->rad, -closeup_pos->xyz.z + pm->rad + 20.0f, -closeup_pos->xyz.z + pm->rad + 200.0f, -closeup_pos->xyz.z + pm->rad + 1000.0f);
@@ -1947,9 +1941,7 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 		gr_reset_clip();
 	}
 
-	if (shadow_disable_override) {
-		Shadow_override = shadow_override_backup;
-	}
+	shadow_end_frame();
 }
 
 // NEWSTUFF END

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1653,6 +1653,9 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 	angles rot_angles, view_angles;
 	matrix model_orient;
 
+	bool shadow_override_backup = Shadow_override;
+	const bool& shadow_disable_override = flags & MR_IS_MISSILE ? Shadow_disable_overrides.disable_mission_select_weapons : Shadow_disable_overrides.disable_mission_select_ships;
+
 	if (effect == 2) {  // FS2 Effect; Phase 0 Expand scanline, Phase 1 scan the grid and wireframe, Phase 2 scan up and reveal the ship, Phase 3 tilt the camera, Phase 4 start rotating the ship
 		// rotate the ship as much as required for this frame
 		if (time >= 3.6f) // Phase 4
@@ -1783,7 +1786,10 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 			render_info->set_detail_level_lock(0);
 
 			gr_zbuffer_set(true);
-			if(Shadow_quality != ShadowQuality::Disabled)
+			if (shadow_disable_override) {
+				Shadow_override = true;
+			}
+			else if(Shadow_quality != ShadowQuality::Disabled)
             {
 				gr_end_view_matrix();
 				gr_end_proj_matrix();
@@ -1897,7 +1903,10 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 
 		render_info->set_detail_level_lock(0);
 
-		if(Shadow_quality != ShadowQuality::Disabled)
+		if (shadow_disable_override) {
+			Shadow_override = true;
+		}
+		else if(Shadow_quality != ShadowQuality::Disabled)
 		{
 			if ( flags & MR_IS_MISSILE )  {
 				shadows_start_render(&Eye_matrix, &Eye_position, Proj_fov, gr_screen.clip_aspect, -closeup_pos->xyz.z + pm->rad, -closeup_pos->xyz.z + pm->rad + 20.0f, -closeup_pos->xyz.z + pm->rad + 200.0f, -closeup_pos->xyz.z + pm->rad + 1000.0f);
@@ -1936,6 +1945,10 @@ void draw_model_rotating(model_render_params *render_info, int model_id, int x1,
 		gr_end_proj_matrix();
 		g3_end_frame();
 		gr_reset_clip();
+	}
+
+	if (shadow_disable_override) {
+		Shadow_override = shadow_override_backup;
 	}
 }
 

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -908,12 +908,7 @@ void wl_render_overhead_view(float frametime)
 				render_info.set_replacement_textures(wl_ship->model_num, sip->replacement_textures);
 			}
 
-			bool shadow_override_backup = Shadow_override;
-
-			if (Shadow_disable_overrides.disable_mission_select_weapons) {
-				Shadow_override = true;
-			}
-			else if (Shadow_quality != ShadowQuality::Disabled)
+			if (shadow_maybe_start_frame(Shadow_disable_overrides.disable_mission_select_weapons))
 			{
 				gr_reset_clip();
 				shadows_start_render(&Eye_matrix, &Eye_position, Proj_fov, gr_screen.clip_aspect, -sip->closeup_pos.xyz.z + pm->rad, 
@@ -937,9 +932,7 @@ void wl_render_overhead_view(float frametime)
             
 			batching_render_all();
 
-			if (Shadow_disable_overrides.disable_mission_select_weapons) {
-				Shadow_override = shadow_override_backup;
-			}
+			shadow_end_frame();
 
 			//NOW render the lines for weapons
 			gr_reset_clip();

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -908,7 +908,12 @@ void wl_render_overhead_view(float frametime)
 				render_info.set_replacement_textures(wl_ship->model_num, sip->replacement_textures);
 			}
 
-			if(Shadow_quality != ShadowQuality::Disabled)
+			bool shadow_override_backup = Shadow_override;
+
+			if (Shadow_disable_overrides.disable_mission_select_weapons) {
+				Shadow_override = true;
+			}
+			else if (Shadow_quality != ShadowQuality::Disabled)
 			{
 				gr_reset_clip();
 				shadows_start_render(&Eye_matrix, &Eye_position, Proj_fov, gr_screen.clip_aspect, -sip->closeup_pos.xyz.z + pm->rad, 
@@ -931,6 +936,10 @@ void wl_render_overhead_view(float frametime)
             Glowpoint_use_depth_buffer = true;
             
 			batching_render_all();
+
+			if (Shadow_disable_overrides.disable_mission_select_weapons) {
+				Shadow_override = shadow_override_backup;
+			}
 
 			//NOW render the lines for weapons
 			gr_reset_clip();

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -92,6 +92,7 @@ bool Show_subtitle_uses_pixels;
 int Show_subtitle_screen_base_res[2];
 int Show_subtitle_screen_adjusted_res[2];
 bool Always_warn_player_about_unbound_keys;
+shadow_disable_overrides Shadow_disable_overrides {false, false, false, false};
 
 void mod_table_set_version_flags();
 
@@ -550,6 +551,22 @@ void parse_mod_table(const char *filename)
 			else {
 				error_display(0, "$Shadow Cascade Distances Cockpit are %f, %f, %f, %f. One or more are < 0, and/or values are not increasing. Assuming default distances.", dis[0], dis[1], dis[2], dis[3]);
 			}
+		}
+
+		if (optional_string("$Shadow Disable Techroom:")) {
+			stuff_boolean(&Shadow_disable_overrides.disable_techroom);
+		}
+
+		if (optional_string("$Shadow Disable Cockpit:")) {
+			stuff_boolean(&Shadow_disable_overrides.disable_cockpit);
+		}
+
+		if (optional_string("$Shadow Disable Mission Brief Weapons:")) {
+			stuff_boolean(&Shadow_disable_overrides.disable_mission_select_weapons);
+		}
+
+		if (optional_string("$Shadow Disable Mission Brief Ships:")) {
+			stuff_boolean(&Shadow_disable_overrides.disable_mission_select_ships);
 		}
 
 		if (optional_string("$Minimum Pixel Size Thrusters:")) {

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Created by Hassan "Karajorma" Kazmi for the FreeSpace2 Source Code Project.
  * You may not sell or otherwise commercially exploit the source or things you
@@ -81,6 +82,9 @@ extern bool Show_subtitle_uses_pixels;
 extern int Show_subtitle_screen_base_res[];
 extern int Show_subtitle_screen_adjusted_res[];
 extern bool Always_warn_player_about_unbound_keys;
+extern struct shadow_disable_overrides {
+	bool disable_techroom, disable_mission_select_weapons, disable_mission_select_ships, disable_cockpit;
+} Shadow_disable_overrides;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7356,7 +7356,7 @@ void ship_render_cockpit(object *objp)
 
 	//Deal with the model
 	model_clear_instance(sip->cockpit_model_num);
-	if (Shadow_quality != ShadowQuality::Disabled) {
+	if (Shadow_quality != ShadowQuality::Disabled && !Shadow_disable_overrides.disable_cockpit) {
 		gr_reset_clip();
 		Shadow_override = false;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7349,14 +7349,13 @@ void ship_render_cockpit(object *objp)
 
 	vm_vec_unrotate(&pos, &sip->cockpit_offset, &eye_ori);
 
-	bool shadow_override_backup = Shadow_override;
 	float fov_backup = Proj_fov;
 
 	g3_set_fov(Sexp_fov <= 0.0f ? COCKPIT_ZOOM_DEFAULT : Sexp_fov);
 
 	//Deal with the model
 	model_clear_instance(sip->cockpit_model_num);
-	if (Shadow_quality != ShadowQuality::Disabled && !Shadow_disable_overrides.disable_cockpit) {
+	if (shadow_maybe_start_frame(Shadow_disable_overrides.disable_cockpit)) {
 		gr_reset_clip();
 		Shadow_override = false;
 
@@ -7396,8 +7395,7 @@ void ship_render_cockpit(object *objp)
 	hud_save_restore_camera_data(0);
 
 	//Restore the Shadow_override
-	if (Shadow_quality != ShadowQuality::Disabled)
-		Shadow_override = shadow_override_backup;
+	shadow_end_frame();
 }
 
 void ship_render_show_ship_cockpit(object *objp)


### PR DESCRIPTION
Some mods can contain models for which having shadows in the techroom / mission select screen is a problem. This allows to bulk-disable rendering of shadows for some of these categories, such as shadows for weapon selection during the mission briefing.