### PR TITLE
Prevent subsystem `fireWeapon` scripting function from triggering an assert

### DIFF
--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -625,6 +625,12 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRan
 
 	wnum--;	//Lua->FS2
 
+	if (wnum < 0 || wnum >= MAX_SHIP_WEAPONS)
+	{
+		LuaError(L, "Weapon Number (%i) is invalid! Minimum is 1, maximum is %i", wnum+1, MAX_SHIP_WEAPONS+1);
+		return ADE_RETURN_NIL;
+	}
+
 	//Get default turret info
 	vec3d gpos, gvec;
 

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -627,7 +627,7 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRan
 
 	if (wnum < 0 || wnum >= MAX_SHIP_WEAPONS)
 	{
-		LuaError(L, "Weapon Number (%i) is invalid! Minimum is 1, maximum is %i", wnum+1, MAX_SHIP_WEAPONS+1);
+		LuaError(L, "TurretWeaponIndex (%i) is invalid! Minimum is 1, maximum is %i", wnum+1, MAX_SHIP_WEAPONS+1);
 		return ADE_RETURN_NIL;
 	}
 


### PR DESCRIPTION
It is possible for a script to call the `fireWeapon` subsystem function passing `wnum` as any integer. 
Down the line, `wnum` ends up passed to `ai_turret::get_turret_weapon_wip`, and could trigger either of those asserts:  
```C++
Assert(weapon_num < MAX_SHIP_WEAPONS);
Assert(weapon_num >= 0);
```

This PR prevents that by giving an error and returning early.