### PR TITLE
Add optional Drop Shadows to HUD

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -284,17 +284,17 @@ enum IoActionId : int {
 	CUSTOM_CONTROL_4								= 122,
 	CUSTOM_CONTROL_5								= 123,
 
-	TOGGLE_HUD_SHADOWS								= 124,
 	//!< @n
 	//!< Analog controls
 	//!<-----------------------------
 	//!< All axis actions must be kept together
-	JOY_HEADING_AXIS								= 125,
-	JOY_PITCH_AXIS									= 126,
-	JOY_BANK_AXIS									= 127,
-	JOY_ABS_THROTTLE_AXIS							= 128,
-	JOY_REL_THROTTLE_AXIS							= 129,
+	JOY_HEADING_AXIS								= 124,
+	JOY_PITCH_AXIS									= 125,
+	JOY_BANK_AXIS									= 126,
+	JOY_ABS_THROTTLE_AXIS							= 127,
+	JOY_REL_THROTTLE_AXIS							= 128,
 
+	TOGGLE_HUD_SHADOWS,
 
 	/*!
 	 * This must always be below the last defined item

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -284,15 +284,17 @@ enum IoActionId : int {
 	CUSTOM_CONTROL_4								= 122,
 	CUSTOM_CONTROL_5								= 123,
 
+	TOGGLE_HUD_SHADOWS								= 124,
 	//!< @n
 	//!< Analog controls
 	//!<-----------------------------
 	//!< All axis actions must be kept together
-	JOY_HEADING_AXIS								= 124,
-	JOY_PITCH_AXIS									= 125,
-	JOY_BANK_AXIS									= 126,
-	JOY_ABS_THROTTLE_AXIS							= 127,
-	JOY_REL_THROTTLE_AXIS							= 128,
+	JOY_HEADING_AXIS								= 125,
+	JOY_PITCH_AXIS									= 126,
+	JOY_BANK_AXIS									= 127,
+	JOY_ABS_THROTTLE_AXIS							= 128,
+	JOY_REL_THROTTLE_AXIS							= 129,
+
 
 	/*!
 	 * This must always be below the last defined item

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -258,6 +258,7 @@ void control_config_common_init_bindings() {
 	// HUD
 	(TOGGLE_HUD,                                    KEY_SHIFTED | KEY_O, -1, COMPUTER_TAB, 1, "Toggle HUD",                       CC_TYPE_TRIGGER)
 	(TOGGLE_HUD_CONTRAST,                                         KEY_L, -1, COMPUTER_TAB, 1, "Toggle High HUD Contrast",         CC_TYPE_TRIGGER)
+	(TOGGLE_HUD_SHADOWS,                              KEY_ALTED | KEY_L, -1, COMPUTER_TAB, 0, "Toggle HUD Drop Shadows",          CC_TYPE_TRIGGER)
 	(HUD_TARGETBOX_TOGGLE_WIREFRAME,    KEY_ALTED | KEY_SHIFTED | KEY_Q, -1, COMPUTER_TAB, 1, "Toggle HUD Wireframe Target View", CC_TYPE_TRIGGER)
 
 	// Custom Controls
@@ -409,6 +410,7 @@ SCP_unordered_map<SCP_string, IoActionId> old_text = {
 	{"Increase Time Compression",               TIME_SPEED_UP},
 	{"Decrease Time Compression",               TIME_SLOW_DOWN},
 	{"Toggle High HUD Contrast",                TOGGLE_HUD_CONTRAST},
+	{"Toggle HUD Drop Shadows",                 TOGGLE_HUD_SHADOWS},
 	{"(Multiplayer) Toggle Network Info",       MULTI_TOGGLE_NETINFO},
 	{"(Multiplayer) Self Destruct",             MULTI_SELF_DESTRUCT},
 
@@ -1122,6 +1124,7 @@ void LoadEnumsIntoActionMap() {
 	ADD_ENUM_TO_ACTION_MAP(TIME_SLOW_DOWN)
 
 	ADD_ENUM_TO_ACTION_MAP(TOGGLE_HUD_CONTRAST)
+	ADD_ENUM_TO_ACTION_MAP(TOGGLE_HUD_SHADOWS)
 
 	ADD_ENUM_TO_ACTION_MAP(MULTI_TOGGLE_NETINFO)
 

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3881,6 +3881,11 @@ void hud_toggle_contrast()
 	HUD_contrast = !HUD_contrast;
 }
 
+void hud_toggle_shadows()
+{
+	HUD_shadows = !HUD_shadows;
+}
+
 void hud_set_contrast(int high)
 {
 	HUD_contrast = high;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -755,10 +755,9 @@ void HudGauge::renderString(int x, int y, const char *str)
 	}
 
 	if (HUD_shadows) {
-		auto temp = gr_screen.current_color;
 		gr_set_color_fast(&Color_black);
 		gr_string(x + nx + 1, y + ny + 1, str);
-		gr_set_color_fast(&temp);
+		gr_set_color_fast(&gauge_color);
 	}
 
 	gr_string(x + nx, y + ny, str);
@@ -784,20 +783,19 @@ void HudGauge::renderString(int x, int y, int gauge_id, const char *str)
 		}
 	}
 
-	auto temp = gr_screen.current_color;
 
 	if ( gauge_id > -2 ) {
 		if (HUD_shadows) {
 			gr_set_color_fast(&Color_black);
 			emp_hud_string(x + nx + 1, y + ny + 1, gauge_id, str, GR_RESIZE_FULL);
-			gr_set_color_fast(&temp);
+			gr_set_color_fast(&gauge_color);
 		}
 		emp_hud_string(x + nx, y + ny, gauge_id, str, GR_RESIZE_FULL);
 	} else {
 		if (HUD_shadows) {
 			gr_set_color_fast(&Color_black);
 			gr_string(x + nx + 1, y + ny + 1, str);
-			gr_set_color_fast(&temp);
+			gr_set_color_fast(&gauge_color);
 		}
 		gr_string(x + nx, y + ny, str);
 	}

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -81,6 +81,7 @@ int HUD_color_alpha = HUD_COLOR_ALPHA_DEFAULT;		// 1 -> HUD_COLOR_ALPHA_USER_MAX
 
 int HUD_draw     = 1;
 int HUD_contrast = 0;										// high or lo contrast (for nebula, etc)
+bool HUD_shadows = true;
 
 // Goober5000
 int HUD_disable_except_messages = 0;
@@ -753,6 +754,13 @@ void HudGauge::renderString(int x, int y, const char *str)
 		}
 	}
 
+	if (HUD_shadows) {
+		auto temp = gr_screen.current_color;
+		gr_set_color_fast(&Color_black);
+		gr_string(x + nx + 1, y + ny + 1, str);
+		gr_set_color_fast(&temp);
+	}
+
 	gr_string(x + nx, y + ny, str);
 	gr_reset_screen_scale();
 }
@@ -776,9 +784,21 @@ void HudGauge::renderString(int x, int y, int gauge_id, const char *str)
 		}
 	}
 
+	auto temp = gr_screen.current_color;
+
 	if ( gauge_id > -2 ) {
+		if (HUD_shadows) {
+			gr_set_color_fast(&Color_black);
+			emp_hud_string(x + nx + 1, y + ny + 1, gauge_id, str, GR_RESIZE_FULL);
+			gr_set_color_fast(&temp);
+		}
 		emp_hud_string(x + nx, y + ny, gauge_id, str, GR_RESIZE_FULL);
 	} else {
+		if (HUD_shadows) {
+			gr_set_color_fast(&Color_black);
+			gr_string(x + nx + 1, y + ny + 1, str);
+			gr_set_color_fast(&temp);
+		}
 		gr_string(x + nx, y + ny, str);
 	}
 

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -81,7 +81,7 @@ int HUD_color_alpha = HUD_COLOR_ALPHA_DEFAULT;		// 1 -> HUD_COLOR_ALPHA_USER_MAX
 
 int HUD_draw     = 1;
 int HUD_contrast = 0;										// high or lo contrast (for nebula, etc)
-bool HUD_shadows = true;
+bool HUD_shadows = false;
 
 // Goober5000
 int HUD_disable_except_messages = 0;
@@ -3879,14 +3879,14 @@ void hud_toggle_contrast()
 	HUD_contrast = !HUD_contrast;
 }
 
-void hud_toggle_shadows()
-{
-	HUD_shadows = !HUD_shadows;
-}
-
 void hud_set_contrast(int high)
 {
 	HUD_contrast = high;
+}
+
+void hud_toggle_shadows()
+{
+	HUD_shadows = !HUD_shadows;
 }
 
 // Paging functions for the rest of the HUD code

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -208,8 +208,8 @@ int hud_disabled_except_messages();
 
 // contrast stuff
 void hud_toggle_contrast();
-void hud_toggle_shadows();
 void hud_set_contrast(int high);
+void hud_toggle_shadows();
 
 class HudGauge 
 {

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -70,6 +70,7 @@ enum class HudAlignment
 
 extern int HUD_draw;
 extern int HUD_contrast;
+extern bool HUD_shadows;
 
 #define HUD_NUM_COLOR_LEVELS	16
 extern color HUD_color_defaults[HUD_NUM_COLOR_LEVELS];

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -208,6 +208,7 @@ int hud_disabled_except_messages();
 
 // contrast stuff
 void hud_toggle_contrast();
+void hud_toggle_shadows();
 void hud_set_contrast(int high);
 
 class HudGauge 

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -23,6 +23,7 @@
 #include "ship/subsysdamage.h"
 #include "weapon/emp.h"
 #include "weapon/weapon.h"
+#include "globalincs/alphacolors.h"
 
 float Energy_levels[NUM_ENERGY_LEVELS] = {0.0f,  0.0833f, 0.167f, 0.25f, 0.333f, 0.417f, 0.5f, 0.583f, 0.667f, 0.75f, 0.833f, 0.9167f, 1.0f};
 bool Weapon_energy_cheat = false;
@@ -871,6 +872,24 @@ void HudGaugeEts::blitGauge(int index)
 	clip_h = fl2i( (1 - Energy_levels[index]) * ETS_bar_h );
 
 	bm_get_info(Ets_bar.first_frame,&w,&h);
+
+	if (HUD_shadows) {
+		// These act more as a backing black layer.
+
+		gr_set_color_fast(&Color_black);
+		// draw the top portion
+		x = position[0] + Top_offsets[0];
+		y = position[1] + Top_offsets[1];
+		
+		renderBitmapEx(Ets_bar.first_frame,x,y,w,ETS_bar_h,0,0);
+
+		// draw the bottom portion
+		x = position[0] + Bottom_offsets[0];
+		y = position[1] + Bottom_offsets[1];
+
+		renderBitmapEx(Ets_bar.first_frame, x, y, w, y + ETS_bar_h, 0, 0);
+		gr_set_color_fast(&gauge_color);
+	}
 
 	if ( index < NUM_ENERGY_LEVELS-1 ) {
 		// some portion of dark needs to be drawn

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -279,6 +279,19 @@ ship_info *sip = &Ship_info[Player_ship->ship_info_index];
 
 	setGaugeColor(HUD_C_BRIGHT);
 
+	if (HUD_shadows){
+		auto temp = gr_screen.current_color;
+		gr_set_color_fast(&Color_black);
+
+		if (has_autoaim_lock)
+			renderBitmap(crosshair.first_frame + autoaim_frame_offset, position[0] + 1, position[1] + 1);
+		else
+			renderBitmap(crosshair.first_frame, position[0] + 1, position[1] + 1);
+
+		gr_set_color_fast(&temp);
+
+	}
+
 	if (has_autoaim_lock)
 		renderBitmap(crosshair.first_frame + autoaim_frame_offset, position[0], position[1]);
 	else

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -280,7 +280,6 @@ ship_info *sip = &Ship_info[Player_ship->ship_info_index];
 	setGaugeColor(HUD_C_BRIGHT);
 
 	if (HUD_shadows){
-		auto temp = gr_screen.current_color;
 		gr_set_color_fast(&Color_black);
 
 		if (has_autoaim_lock)
@@ -295,8 +294,7 @@ ship_info *sip = &Ship_info[Player_ship->ship_info_index];
 			renderBitmap(crosshair.first_frame, position[0] + 1, position[1] + 1);
 			renderBitmap(crosshair.first_frame, position[0] + 1, position[1] + 1);
 		}
-		gr_set_color_fast(&temp);
-
+		gr_set_color_fast(&gauge_color);
 	}
 
 	if (has_autoaim_lock)

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -284,10 +284,17 @@ ship_info *sip = &Ship_info[Player_ship->ship_info_index];
 		gr_set_color_fast(&Color_black);
 
 		if (has_autoaim_lock)
+		{
+			// Render the shadow twice to increase visibility
 			renderBitmap(crosshair.first_frame + autoaim_frame_offset, position[0] + 1, position[1] + 1);
+			renderBitmap(crosshair.first_frame + autoaim_frame_offset, position[0] + 1, position[1] + 1);
+		}
 		else
+		{
+			// Render the shadow twice to increase visibility
 			renderBitmap(crosshair.first_frame, position[0] + 1, position[1] + 1);
-
+			renderBitmap(crosshair.first_frame, position[0] + 1, position[1] + 1);
+		}
 		gr_set_color_fast(&temp);
 
 	}

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -320,6 +320,7 @@ int Normal_key_set[] = {
 	TIME_SLOW_DOWN,
 
 	TOGGLE_HUD_CONTRAST,
+	TOGGLE_HUD_SHADOWS,
 
 	MULTI_TOGGLE_NETINFO,
 	MULTI_SELF_DESTRUCT,
@@ -461,6 +462,7 @@ int Non_critical_key_set[] = {
 	MULTI_MESSAGE_TARGET,
 	MULTI_OBSERVER_ZOOM_TO,
 	TOGGLE_HUD_CONTRAST,
+	TOGGLE_HUD_SHADOWS,
 
 	MULTI_TOGGLE_NETINFO,
 	MULTI_SELF_DESTRUCT,
@@ -2558,6 +2560,11 @@ int button_function(int n)
 		case TOGGLE_HUD_CONTRAST:
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			hud_toggle_contrast();
+			break;
+
+		case TOGGLE_HUD_SHADOWS:
+			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
+			hud_toggle_shadows();
 			break;
 
 		// toggle network info

--- a/code/scripting/api/objs/control_info.cpp
+++ b/code/scripting/api/objs/control_info.cpp
@@ -112,6 +112,7 @@ flag_def_list plr_commands[] = {
 	{	"TIME_SPEED_UP",						TIME_SPEED_UP,							3	},
 	{	"TIME_SLOW_DOWN",						TIME_SLOW_DOWN,							3	},
 	{	"TOGGLE_HUD_CONTRAST",					TOGGLE_HUD_CONTRAST,					3	},
+	{	"TOGGLE_HUD_SHADOWS",					TOGGLE_HUD_SHADOWS,						3	},
 	{	"MULTI_TOGGLE_NETINFO",					MULTI_TOGGLE_NETINFO,					3	},
 	{	"MULTI_SELF_DESTRUCT",					MULTI_SELF_DESTRUCT,					3	},
 	{	"TOGGLE_HUD",							TOGGLE_HUD,								3	},


### PR DESCRIPTION
This PR adds a new control (By default Alt+L, but it will be unset for existing pilots) which lets the player enable or disable Drop Shadows on the HUD, affecting Text, the main targeting reticle and the background of the ETS gauges. 

<details><summary><b>Click here to see comparison screenshots</b></summary>

Low contrast, no shadows
![locontrast](https://user-images.githubusercontent.com/4577144/184679495-7f7db0fe-cb5d-4cc7-9c8e-02d041f8dc27.png)

High contrast, no shadows
![hicontrast](https://user-images.githubusercontent.com/4577144/184679536-9dc600c7-23d9-4013-adcb-6184ea3f2b46.png)

Low contrast, with shadows
![locontrast_shadowed](https://user-images.githubusercontent.com/4577144/184679573-d74b4a3a-494f-41d6-a8de-c28373a05c59.png)

High contrast, with shadows
![hicontrast_shadowed](https://user-images.githubusercontent.com/4577144/184679591-2c555c25-fb50-4329-bf10-13bc8d4348ab.png)
</details>

Related: #3712. I'm not sure if we could consider that it closes that FR. IMO there are other possible ways to improve HUD contrast that would be nice to have: 
 * Allow HUD elements to be fully opaque (currently even with alpha at 255, they'll be slightly transparent due to how `aabitmap`s work
 * Use outlines instead of shadows (This would probably require a specific shader) 
 * Allow HUD elements to dynamically change color depending on the colors of what's behind it