### PR TITLE
enhanced control for the global ship shudder

### DIFF
--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -69,6 +69,12 @@
 
 extern bool Ships_inited;
 
+extern bool Game_shudder_perpetual;
+extern bool Game_shudder_everywhere;
+extern TIMESTAMP Game_shudder_time;
+extern int Game_shudder_total;
+extern float Game_shudder_intensity;
+
 namespace scripting {
 namespace api {
 
@@ -1258,25 +1264,107 @@ ADE_FUNC(renderFrame, l_Mission, NULL, "Renders mission frame, but does not move
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(applyShudder, l_Mission, "number time, number intesity", "Applies a shudder effects to the camera. Time is in seconds. Intensity specifies the shudder effect strength, the Maxim has a value of 1440.", "boolean", "true if successfull, false otherwise")
+ADE_FUNC(applyShudder, l_Mission, "number time, number intensity, [boolean perpetual, boolean everywhere]", "Applies a shudder effect to the camera. Time is in seconds. Intensity specifies the shudder effect strength; the Maxim has a value of 1440. If perpetual is true, the shudder does not decay. If everywhere is true, the shudder is applied regardless of view.", "boolean", "true if successful, false otherwise")
 {
 	float time = -1.0f;
 	float intensity = -1.0f;
+	bool perpetual = false;
+	bool everywhere = false;
 
-	if (!ade_get_args(L, "ff", &time, &intensity))
+	if (!ade_get_args(L, "ff|bb", &time, &intensity, &perpetual, &everywhere))
 		return ADE_RETURN_FALSE;
 
 	if (time < 0.0f || intensity < 0.0f)
 	{
-		LuaError(L, "Illegal shudder values given. Must be bigger than zero, got time of %f and intensity of %f.", time, intensity);
+		LuaError(L, "Illegal shudder values given. Must be bigger than zero; got time of %f and intensity of %f.", time, intensity);
 		return ADE_RETURN_FALSE;
 	}
 
 	int int_time = fl2i(time * 1000.0f);
 
-	game_shudder_apply(int_time, intensity * 0.01f);
+	game_shudder_apply(int_time, intensity * 0.01f, perpetual, everywhere);
 
 	return ADE_RETURN_TRUE;
+}
+
+ADE_VIRTVAR(ShudderPerpetual, l_Mission, "boolean", "Gets or sets whether the shudder is perpetual, i.e. with a constant intensity that does not decay.", "boolean", "the shudder perpetual flag")
+{
+	bool perpetual = Game_shudder_perpetual;
+
+	if (ADE_SETTING_VAR && ade_get_args(L, "*b", &perpetual))
+	{
+		Game_shudder_perpetual = perpetual;
+	}
+
+	return ade_set_args(L, "b", perpetual);
+}
+
+ADE_VIRTVAR(ShudderEverywhere, l_Mission, "boolean", "Gets or sets whether the shudder is applied everywhere regardless of camera view.", "boolean", "the shudder everywhere flag")
+{
+	bool everywhere = Game_shudder_everywhere;
+
+	if (ADE_SETTING_VAR && ade_get_args(L, "*b", &everywhere))
+	{
+		Game_shudder_everywhere = everywhere;
+	}
+
+	return ade_set_args(L, "b", everywhere);
+}
+
+ADE_VIRTVAR(ShudderTimeLeft, l_Mission, "number", "Gets or sets the number of seconds until the shudder stops.  This is independent of the decay time.", "number", "the shudder time left variable")
+{
+	float time_left = Game_shudder_time.isValid()
+		? timestamp_until(Game_shudder_time) / static_cast<float>(MILLISECONDS_PER_SECOND)
+		: 0.0f;
+
+	if (ADE_SETTING_VAR && ade_get_args(L, "*f", &time_left))
+	{
+		if (time_left < 0.0f)
+		{
+			LuaError(L, "Illegal shudder time left.  Must be bigger than zero; got %f.", time_left);
+			time_left = 0.0f;
+		}
+
+		Game_shudder_time = _timestamp(static_cast<int>(time_left * MILLISECONDS_PER_SECOND));
+	}
+
+	return ade_set_args(L, "f", time_left);
+}
+
+ADE_VIRTVAR(ShudderDecayTime, l_Mission, "number", "Gets or sets the shudder decay time in seconds.  This can be zero in which case the shudder will not decay.", "number", "the shudder decay time variable")
+{
+	float total = Game_shudder_total / static_cast<float>(MILLISECONDS_PER_SECOND);
+
+	if (ADE_SETTING_VAR && ade_get_args(L, "*f", &total))
+	{
+		if (total < 0.0f)
+		{
+			LuaError(L, "Illegal shudder decay time.  Must be bigger than zero; got %f.", total);
+			total = 0.0f;
+		}
+
+		Game_shudder_total = static_cast<int>(total * MILLISECONDS_PER_SECOND);
+	}
+
+	return ade_set_args(L, "f", total);
+}
+
+ADE_VIRTVAR(ShudderIntensity, l_Mission, "number", "Gets or sets the shudder intensity variable.  For comparison, the Maxim has a value of 1440.", "number", "the shudder intensity variable")
+{
+	float intensity = Game_shudder_intensity * 100.0f;
+
+	if (ADE_SETTING_VAR && ade_get_args(L, "*f", &intensity))
+	{
+		if (intensity < 0.0f)
+		{
+			LuaError(L, "Illegal shudder intensity.  Must be bigger than zero; got %f.", intensity);
+			intensity = 0.0f;
+		}
+
+		Game_shudder_intensity = intensity * 0.01f;
+	}
+
+	return ade_set_args(L, "f", intensity);
 }
 
 ADE_FUNC(isInCampaign, l_Mission, NULL, "Get whether or not the current mission being played in a campaign (as opposed to the tech room's simulator)", "boolean", "true if in campaign, false if not")

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -198,7 +198,14 @@ struct fs_builtin_mission *game_find_builtin_mission(char*){return NULL;}
 void game_format_time(fix, char*){}
 void game_do_state(int){}
 void game_process_event(int, int){}
-void game_shudder_apply(int, float){}
+
+bool Game_shudder_perpetual;
+bool Game_shudder_everywhere;
+TIMESTAMP Game_shudder_time;
+int Game_shudder_total;
+float Game_shudder_intensity;
+void game_shudder_apply(int, float, bool, bool){}
+
 int game_hacked_data(){return 0;}
 int game_single_step;
 int last_single_step;

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -178,7 +178,7 @@ void game_whack_reset();
 void game_whack_apply( float x, float y );
 
 // call to apply a "shudder"
-void game_shudder_apply(int time, float intensity);
+void game_shudder_apply(int time, float intensity, bool perpetual = false, bool everywhere = false);
 
 //===================================================================
 

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -202,7 +202,14 @@ struct fs_builtin_mission *game_find_builtin_mission(char*){return NULL;}
 void game_format_time(fix, char*){}
 void game_do_state(int){}
 void game_process_event(int, int){}
-void game_shudder_apply(int, float){}
+
+bool Game_shudder_perpetual;
+bool Game_shudder_everywhere;
+TIMESTAMP Game_shudder_time;
+int Game_shudder_total;
+float Game_shudder_intensity;
+void game_shudder_apply(int, float, bool, bool){}
+
 int game_hacked_data(){return 0;}
 int game_single_step;
 int last_single_step;

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -206,7 +206,14 @@ struct fs_builtin_mission *game_find_builtin_mission(char*){return NULL;}
 void game_format_time(fix, char*){}
 void game_do_state(int){}
 void game_process_event(int, int){}
-void game_shudder_apply(int, float){}
+
+bool Game_shudder_perpetual;
+bool Game_shudder_everywhere;
+TIMESTAMP Game_shudder_time;
+int Game_shudder_total;
+float Game_shudder_intensity;
+void game_shudder_apply(int, float, bool, bool){}
+
 int game_hacked_data(){return 0;}
 int game_single_step;
 int last_single_step;


### PR DESCRIPTION
Allow the variables controlling ship shudder to be independently set using scripting.  Also add new flags to apply the shudder without decay and apply the shudder regardless of camera.

Also change the shudder timestamp to the new style.