### PR TITLE
Allows default shadow quality to be per mod

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -2072,11 +2072,17 @@ bool SetCmdlineParams()
 
 	if( enable_shadows_arg.found() )
 	{
+		// if only using `enable_shadows` then default quality level can be overriden in mod_settings.tbl --wookieejedi
+		Shadow_quality_uses_mod_option = true;
+
 		Shadow_quality = ShadowQuality::Medium;
 	}
 
 	if( shadow_quality_arg.found() )
 	{
+		// set that we are not using default shadow quality level --wookieejedi
+		Shadow_quality_uses_mod_option = false; 
+
 		switch (shadow_quality_arg.get_int()) {
 		case 0:
 			Shadow_quality = ShadowQuality::Disabled;

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -31,6 +31,8 @@ light_frustum_info Shadow_frustums[MAX_SHADOW_CASCADES];
 
 ShadowQuality Shadow_quality = ShadowQuality::Disabled;
 
+bool Shadow_quality_uses_mod_option = false; 
+
 auto ShadowQualityOption =
     options::OptionBuilder<ShadowQuality>("Graphics.Shadows", "Shadow Quality", "The quality of the shadows")
         .values({{ShadowQuality::Disabled, "Disabled"},

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -29,6 +29,8 @@ enum class ShadowQuality { Disabled = 0, Low = 1, Medium = 2, High = 3, Ultra = 
 
 extern ShadowQuality Shadow_quality;
 
+extern bool Shadow_quality_uses_mod_option; 
+
 extern matrix4 Shadow_view_matrix;
 extern matrix4 Shadow_proj_matrix[MAX_SHADOW_CASCADES];
 extern float Shadow_cascade_distances[MAX_SHADOW_CASCADES];

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -10,6 +10,7 @@
 #include "gamesnd/eventmusic.h"
 #include "def_files/def_files.h"
 #include "globalincs/version.h"
+#include "graphics/shadows.h"
 #include "localization/localize.h"
 #include "mission/missioncampaign.h"
 #include "mission/missionload.h"
@@ -530,6 +531,35 @@ void parse_mod_table(const char *filename)
 
 			if (optional_string("+Scaled visibility factor:")) {
 				stuff_float(&Neb2_fog_visibility_fireball_scaled_factor);
+			}
+		}
+
+		if (optional_string("$Shadow Quality Default:")) {
+			// only read this value if shadows are enabled and using default quality --wookieejedi
+			if (Shadow_quality_uses_mod_option) {
+				int quality;
+				stuff_int(&quality);
+				switch (quality) {
+				case 0:
+					Shadow_quality = ShadowQuality::Disabled;
+					break;
+				case 1:
+					Shadow_quality = ShadowQuality::Low;
+					break;
+				case 2:
+					Shadow_quality = ShadowQuality::Medium;
+					break;
+				case 3:
+					Shadow_quality = ShadowQuality::High;
+					break;
+				case 4:
+					Shadow_quality = ShadowQuality::Ultra;
+					break;
+				default:
+					// Shadow_quality was already set in cmdline.cpp, so just keep that default --wookieejedi
+					mprintf(("Game Settings Table: '$Shadow Quality Default:' value for default shadow quality %d is invalid. Using default quality of %d...\n", quality, static_cast<int>(Shadow_quality)));
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR allows mods to set a default `Shadow_detail` level in `game_settings.tbl`. ATM, if the `enable_shadows` flag is set then the game will use the `Medium` level.

It is very useful for mods to be able to specify a default level. For example, with FotG we have noticed that if the `High` shadows level looks far, far better then the default of `Medium`, with getting no noticeable FSP difference on our testers range of dedicated graphics cards. Yes, using `shadow_quality` flag will work, but that's a tedious extra step, especially for our testers who are new to FSO. Plus, using a `shadow_qualilty` that overrides if `enable_shadows` is set or not is rather unintuitive for our players.

A boolean check is used because it's far easier to set and check in the mod table code, especially for default values of `false`.