### PR TITLE
Add hook just before loadout parsing

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -421,6 +421,9 @@ const std::shared_ptr<scripting::Hook> OnDepartureStartedHook = scripting::Hook:
 		{"Ship", "ship", "The ship that has begun the departure process."},
 	});
 
+ const std::shared_ptr<scripting::Hook> OnLoadoutParseHook = scripting::Hook::Factory("On Loadout Parse",
+	"Called during mission load just before parsing the team loadout.",{});
+
 // Goober5000
 void parse_custom_bitmap(const char *expected_string_640, const char *expected_string_1024, char *string_field_640, char *string_field_1024)
 {
@@ -851,6 +854,10 @@ void parse_player_info2(mission *pm)
 	int nt, i;
 	SCP_vector<loadout_row> list, list2;
 	team_data *ptr;
+
+	if (OnLoadoutParseHook->isActive()) {
+		OnLoadoutParseHook->run();
+	}
 
 	// read in a ship/weapon pool for each team.
 	for ( nt = 0; nt < Num_teams; nt++ ) {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -421,7 +421,7 @@ const std::shared_ptr<scripting::Hook> OnDepartureStartedHook = scripting::Hook:
 		{"Ship", "ship", "The ship that has begun the departure process."},
 	});
 
- const std::shared_ptr<scripting::Hook> OnLoadoutParseHook = scripting::Hook::Factory("On Loadout Parse",
+ const std::shared_ptr<scripting::Hook> OnLoadoutAboutToParseHook = scripting::Hook::Factory("On Loadout About To Parse",
 	"Called during mission load just before parsing the team loadout.",{});
 
 // Goober5000
@@ -855,8 +855,8 @@ void parse_player_info2(mission *pm)
 	SCP_vector<loadout_row> list, list2;
 	team_data *ptr;
 
-	if (OnLoadoutParseHook->isActive()) {
-		OnLoadoutParseHook->run();
+	if (OnLoadoutAboutToParseHook->isActive()) {
+		OnLoadoutAboutToParseHook->run();
 	}
 
 	// read in a ship/weapon pool for each team.


### PR DESCRIPTION
Add On Loadout Parse hook that runs during mission parse but before loadouts are created. Resolves #4361 