### PR TITLE
Implement ability to get and set a ship's persona index

### DIFF
--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -754,7 +754,7 @@ ADE_VIRTVAR(PersonaIndex, l_Ship, "number", "Persona index", "number", "The inde
 
 	ship *shipp = &Ships[objh->objp->instance];
 
-	if(ADE_SETTING_VAR && p_index >= 0)
+	if(ADE_SETTING_VAR && p_index > 0)
 		shipp->persona_index = p_index - 1;
 
 	return ade_set_args(L, "i", shipp->persona_index + 1);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -742,7 +742,7 @@ ADE_VIRTVAR(Team, l_Ship, "team", "Ship's team", "team", "Ship team, or invalid 
 	return ade_set_args(L, "o", l_Team.Set(shipp->team));
 }
 
-ADE_VIRTVAR(Persona, l_Ship, "number", "Persona index", "number", "The index of the persona from messages.tbl, -1 if no persona is set")
+ADE_VIRTVAR(PersonaIndex, l_Ship, "number", "Persona index", "number", "The index of the persona from messages.tbl, 0 if no persona is set")
 {
 	object_h *objh;
 	int p_index = -1;
@@ -755,9 +755,9 @@ ADE_VIRTVAR(Persona, l_Ship, "number", "Persona index", "number", "The index of 
 	ship *shipp = &Ships[objh->objp->instance];
 
 	if(ADE_SETTING_VAR && p_index >= 0)
-		shipp->persona_index = p_index;
+		shipp->persona_index = p_index - 1;
 
-	return ade_set_args(L, "i", shipp->persona_index);
+	return ade_set_args(L, "i", shipp->persona_index + 1);
 }
 
 ADE_VIRTVAR(Textures, l_Ship, "shiptextures", "Gets ship textures", "shiptextures", "Ship textures, or invalid shiptextures handle if ship handle is invalid")

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -742,6 +742,24 @@ ADE_VIRTVAR(Team, l_Ship, "team", "Ship's team", "team", "Ship team, or invalid 
 	return ade_set_args(L, "o", l_Team.Set(shipp->team));
 }
 
+ADE_VIRTVAR(Persona, l_Ship, "number", "Persona index", "number", "The index of the persona from messages.tbl, -1 if no persona is set")
+{
+	object_h *objh;
+	int p_index = -1;
+	if(!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &p_index))
+		return ade_set_error(L, "i", 0);
+
+	if(!objh->IsValid())
+		return ade_set_error(L, "i", 0);
+
+	ship *shipp = &Ships[objh->objp->instance];
+
+	if(ADE_SETTING_VAR && p_index >= 0)
+		shipp->persona_index = p_index;
+
+	return ade_set_args(L, "i", shipp->persona_index);
+}
+
 ADE_VIRTVAR(Textures, l_Ship, "shiptextures", "Gets ship textures", "shiptextures", "Ship textures, or invalid shiptextures handle if ship handle is invalid")
 {
 	object_h *sh = nullptr;


### PR DESCRIPTION
Implements #3070 . Allows getting and setting the ship's persona by index. Tested reading and writing with messages after writing and works as expected. Also testing writing an index that does not exist in messages.tbl. FSO does the same thing with that as it does if it gets an invalid persona from the mission file; it chooses a random persona instead.