### PR TITLE
Fix dangling pointer in hudparse.cpp

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -965,11 +965,6 @@ int parse_gauge_type()
 
 void load_gauge(int gauge, gauge_settings* settings)
 {
-	SCP_vector<int> ship_index;
-	ship_index.push_back(-1);
-	if (settings->ship_idx == NULL) {
-		settings->ship_idx = &ship_index;
-	}
 	switch(gauge) {
 	case HUD_OBJECT_CUSTOM:
 		load_gauge_custom(settings);
@@ -1365,7 +1360,7 @@ std::unique_ptr<T> gauge_load_common(gauge_settings* settings, T* preAllocated =
 
 template<typename T>
 void gauge_assign_common(const gauge_settings* settings, std::unique_ptr<T>&& hud_gauge) {
-	if(settings->ship_idx->at(0) >= 0) {
+	if(settings->ship_idx && settings->ship_idx->at(0) >= 0) {
 		for (auto ship_index = settings->ship_idx->begin(); ship_index != settings->ship_idx->end(); ++ship_index) {
 			std::unique_ptr<T> instance(new T());
 			*instance = *hud_gauge;
@@ -3007,7 +3002,7 @@ void load_gauge_radar_dradis(gauge_settings* settings)
 	if(optional_string("Unknown Contact Filename:")) {
 		stuff_string(unknown_fname, F_NAME, MAX_FILENAME_LEN);
 	}
-	if(optional_string("Cockpit Target:") && settings->ship_idx->at(0) >= 0) {
+	if(optional_string("Cockpit Target:") && settings->ship_idx && settings->ship_idx->at(0) >= 0) {
 		stuff_string(display_name, F_NAME, MAX_FILENAME_LEN);
 
 		if(optional_string("Canvas Size:")) {


### PR DESCRIPTION
Rather than try to put a sentinel value in *ship_idx if it's null, I've just left it null and put checks everywhere it's used. Nothing ever gets written through *ship_idx so this should have the same behaviour.