### PR TITLE
Fix WeaponClass Script Condition

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -7,6 +7,7 @@
 #include "ade_args.h"
 #include "freespace.h"
 #include "hook_api.h"
+#include "global_hooks.h"
 
 #include "bmpman/bmpman.h"
 #include "controlconfig/controlsconfig.h"
@@ -439,6 +440,8 @@ bool ConditionedHook::ConditionsValid(int action, object *objp1, object *objp2, 
 
 			case CHC_WEAPONCLASS:
 			{
+				bool found_weapon = false;
+
 				for (auto objp : objp_array)
 				{
 					if (objp == nullptr)
@@ -449,6 +452,8 @@ bool ConditionedHook::ConditionsValid(int action, object *objp1, object *objp2, 
 						// scp.condition_cached_value holds the weapon_info_index of the requested weapon class
 						if (Weapons[objp->instance].weapon_info_index != scp.condition_cached_value)
 							return false;
+
+						found_weapon = true;
 						break;
 					}
 					else if (objp->type == OBJ_BEAM)
@@ -456,9 +461,15 @@ bool ConditionedHook::ConditionsValid(int action, object *objp1, object *objp2, 
 						// scp.condition_cached_value holds the weapon_info_index of the requested weapon class
 						if (Beams[objp->instance].weapon_info_index != scp.condition_cached_value)
 							return false;
+
+						found_weapon = true;
 						break;
 					}
 				}
+
+				//If a weaponclass is specified, but none of the objects was even any weapon, the hook must not evaluate.
+				if (!found_weapon)
+					return false;
 
 				if (objp1 == nullptr || objp1->type != OBJ_SHIP)
 					break;

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -7,7 +7,6 @@
 #include "ade_args.h"
 #include "freespace.h"
 #include "hook_api.h"
-#include "global_hooks.h"
 
 #include "bmpman/bmpman.h"
 #include "controlconfig/controlsconfig.h"


### PR DESCRIPTION
#4231 changed the WeaponClass hook in such a way, that if a Weapon Class was required, but the condition itself was called _with no weapon at all_, it'd still evaluate.
This breaks certain mods, such as JAD, which rely upon ``$On Ship Collision:`` with a Weapon class condition to catch and process hits of certain weapons on ships.