### PR TITLE
floating-point followup

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -900,7 +900,7 @@ static void ai_big_maybe_fire_weapons(float dist_to_enemy, float dot_to_enemy)
 		
 		//	Chance of hitting ship is based on dot product of firing ship's forward vector with vector to ship
 		//	and also the size of the target relative to distance to target.
-		if (dot_to_enemy > MAX(0.5f, 0.90f + aip->ai_accuracy/10.0f - En_objp->radius/MAX(1.0f,dist_to_enemy))) {
+		if (dot_to_enemy > std::max(0.5f, 0.90f + aip->ai_accuracy / 10.0f - En_objp->radius / std::max(1.0f, dist_to_enemy))) {
 
 			ship *temp_shipp;
 			temp_shipp = &Ships[Pl_objp->instance];

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9167,7 +9167,7 @@ void ai_chase()
 			
 			//	Chance of hitting ship is based on dot product of firing ship's forward vector with vector to ship
 			//	and also the size of the target relative to distance to target.
-			if (dot_to_enemy > MAX(0.5f, 0.90f + aip->ai_accuracy/10.0f - En_objp->radius/MAX(1.0f,dist_to_enemy))) {
+			if (dot_to_enemy > std::max(0.5f, 0.90f + aip->ai_accuracy / 10.0f - En_objp->radius / std::max(1.0f, dist_to_enemy))) {
 
 				ship *temp_shipp;
 				ship_weapon *tswp;

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1658,7 +1658,7 @@ void hud_config_color_load(const char *name)
 void hud_config_alpha_slider_up()
 {	
 	int pos = HCS_CONV(HC_color_sliders[HCS_ALPHA].get_currentItem());
-	int max = MAX(MAX( HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()) ), HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()) );
+	int max = std::max({ HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()) });
 
 	// if this would put the brightest element past its limit, skip
 	if(max >= 255){

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -98,10 +98,13 @@ inline bool fl_near_zero(float a, float e = std::numeric_limits<float>::epsilon(
 	return a < e && a > -e;
 }
 
-// sees if two floating point numbers are within the minimum tolerance
+// sees if two floating point numbers are approximately equal, taking into account the argument magnitudes
+// see commit c62037
+// and see also this article, because fl_equal may need to be rewritten if it is recruited into more demanding situations:
+// https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
 inline bool fl_equal(float a, float b)
 {
-	return fl_near_zero(a - b);
+	return fl_abs(a - b) <= FLT_EPSILON * MAX(1.0f, MAX(fl_abs(a), fl_abs(b)));
 }
 
 // rounds off a floating point number to a multiple of some number

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -104,7 +104,7 @@ inline bool fl_near_zero(float a, float e = std::numeric_limits<float>::epsilon(
 // https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
 inline bool fl_equal(float a, float b)
 {
-	return fl_abs(a - b) <= FLT_EPSILON * MAX(1.0f, MAX(fl_abs(a), fl_abs(b)));
+	return fl_abs(a - b) <= FLT_EPSILON * std::max({ 1.0f, fl_abs(a), fl_abs(b) });
 }
 
 // rounds off a floating point number to a multiple of some number

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -41,11 +41,11 @@
 #define IS_VEC_NULL(v) IS_VEC_NULL_SQ_SAFE(v)
 
 // macro to check if moment-of-inertia vector is close to zero
-// (uses different thresholds since MOI values are really small)
+// (uses the previous 1e-36 threshold since MOI values are really small)
 #define IS_MOI_VEC_NULL(v) \
-		(fl_near_zero((v)->xyz.x, (float) 1e-20) && \
-		fl_near_zero((v)->xyz.y, (float) 1e-20) && \
-		fl_near_zero((v)->xyz.z, (float) 1e-20))
+		(fl_near_zero((v)->xyz.x, (float) 1e-36) && \
+		fl_near_zero((v)->xyz.y, (float) 1e-36) && \
+		fl_near_zero((v)->xyz.z, (float) 1e-36))
 
 // currently only used to check orientations
 #define IS_MAT_NULL(v) (IS_VEC_NULL(&(v)->vec.fvec) && IS_VEC_NULL(&(v)->vec.uvec) && IS_VEC_NULL(&(v)->vec.rvec))

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -22,18 +22,32 @@
 //Macros/functions to fill in fields of structures
 //VEC_NULL macros split into two functions in 2009 with commit 75a514b
 
-//macro to check if vector is close to zero or would be close to zero after squaring
+// Null vector checks are performed on the following types of vectors:
+// * orientation component vectors
+// * positions
+// * velocities
+// * normals
+// In each of these cases, FLT_EPSILON or 1.192092896e-07F is a reasonable threshold.
+
+// macro to check if vector is close to zero or would be close to zero after squaring
+// (uses FLT_EPSILON; original threshold was 1e-16 which can be tightened up a bit)
 #define IS_VEC_NULL_SQ_SAFE(v) \
-		(fl_near_zero((v)->xyz.x, (float) 1e-16) && \
-		fl_near_zero((v)->xyz.y, (float) 1e-16) && \
-		fl_near_zero((v)->xyz.z, (float) 1e-16))
+		(fl_near_zero((v)->xyz.x) && \
+		fl_near_zero((v)->xyz.y) && \
+		fl_near_zero((v)->xyz.z))
 
-//macro to check if vector is close to zero
-#define IS_VEC_NULL(v) \
-		(fl_near_zero((v)->xyz.x, (float) 1e-36) && \
-		fl_near_zero((v)->xyz.y, (float) 1e-36) && \
-		fl_near_zero((v)->xyz.z, (float) 1e-36))
+// macro to check if vector is close to zero
+// (original threshold was 1e-36 which was too small)
+#define IS_VEC_NULL(v) IS_VEC_NULL_SQ_SAFE(v)
 
+// macro to check if moment-of-inertia vector is close to zero
+// (uses different thresholds since MOI values are really small)
+#define IS_MOI_VEC_NULL(v) \
+		(fl_near_zero((v)->xyz.x, (float) 1e-20) && \
+		fl_near_zero((v)->xyz.y, (float) 1e-20) && \
+		fl_near_zero((v)->xyz.z, (float) 1e-20))
+
+// currently only used to check orientations
 #define IS_MAT_NULL(v) (IS_VEC_NULL(&(v)->vec.fvec) && IS_VEC_NULL(&(v)->vec.uvec) && IS_VEC_NULL(&(v)->vec.rvec))
 
 //macro to set a vector to zero.  we could do this with an in-line assembly

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -768,7 +768,7 @@ static void set_subsystem_info(int model_num, model_subsystem *subsystemp, char 
 		float turn_rate;
 		if (idx == 0 || idx == 2) {
 			float turn_time = static_cast<float>(atof(buf));
-			if (fl_near_zero(turn_time)) {
+			if (fl_near_zero(turn_time, 0.01f)) {
 				Warning(LOCATION, "Rotation has a turn time of 0 for subsystem '%s' on ship %s!", dname, modelp->filename);
 				turn_rate = 1.0f;
 			} else {
@@ -1286,7 +1286,7 @@ void determine_submodel_movement(bool is_rotation, const char *filename, bsp_inf
 			if (idx == 0)
 			{
 				auto turn_time = static_cast<float>(atof(buf));
-				if (fl_near_zero(turn_time))
+				if (fl_near_zero(turn_time, 0.01f))
 				{
 					Warning(LOCATION, "Dumb-Rotation has a turn time of 0 for subsystem '%s' on ship %s!", sm->name, filename);
 					turn_rate = 1.0f;
@@ -1620,9 +1620,9 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 					}
 
 					// a custom MOI is only used for ships, but we should probably log it anyway
-					if ( IS_VEC_NULL(&pm->moment_of_inertia.vec.rvec)
-						&& IS_VEC_NULL(&pm->moment_of_inertia.vec.uvec)
-						&& IS_VEC_NULL(&pm->moment_of_inertia.vec.fvec) )
+					if ( IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.rvec)
+						&& IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.uvec)
+						&& IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.fvec) )
 					{
 						mprintf(("Model %s has a null moment of inertia!  (This is only a problem if the model is a ship.)\n", filename));
 					}

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -655,7 +655,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 		}
 		else {
 			//Use the maximum value in X, Y, and Z (including overclocking)
-			dynamic_glide_cap_goal = MAX(MAX(pi->max_vel.xyz.x,pi->max_vel.xyz.y), pi->max_vel.xyz.z);
+			dynamic_glide_cap_goal = std::max({ pi->max_vel.xyz.x,pi->max_vel.xyz.y, pi->max_vel.xyz.z });
 		}
 		pi->cur_glide_cap = velocity_ramp(pi->cur_glide_cap, dynamic_glide_cap_goal, ramp_time_const, sim_time);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6037,9 +6037,9 @@ void physics_ship_init(object *objp)
 		pi->mass = pm->mass * sinfo->density;
 
 	// it was print-worthy back in read_model_file() in modelread.cpp, but now that its being used for an actual ship the user should be warned.
-	if (IS_VEC_NULL(&pm->moment_of_inertia.vec.fvec)
-		&& IS_VEC_NULL(&pm->moment_of_inertia.vec.uvec)
-		&& IS_VEC_NULL(&pm->moment_of_inertia.vec.rvec))
+	if (IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.fvec)
+		&& IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.uvec)
+		&& IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.rvec))
 		Warning(LOCATION, "%s (%s) has a null moment of inertia!", sinfo->name, sinfo->pof_file);
 
 	// if invalid they were already warned about this in read_model_file() in modelread.cpp, so now we just need to try and sweep it under the rug

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6079,10 +6079,10 @@ void physics_ship_init(object *objp)
 		pi->flags |= PF_SLIDE_ENABLED;
 
 	pi->cur_glide_cap = pi->max_vel.xyz.z; //Init dynamic glide cap stuff to the max vel.
-	if ( sinfo->glide_cap > 0.000001f || sinfo->glide_cap < -0.000001f )		//Backslash
+	if (sinfo->glide_cap > 0.000001f || sinfo->glide_cap < -0.000001f)		//Backslash
 		pi->glide_cap = sinfo->glide_cap;
 	else
-		pi->glide_cap = MAX(MAX(pi->max_vel.xyz.z, sinfo->max_overclocked_speed), pi->afterburner_max_vel.xyz.z);
+		pi->glide_cap = std::max({ pi->max_vel.xyz.z, sinfo->max_overclocked_speed, pi->afterburner_max_vel.xyz.z });
 	// If there's not a value for +Max Glide Speed set in the table, we want this cap to default to the fastest speed the ship can go.
 	// However, a negative value means we want no cap, thus allowing nearly infinite maximum gliding speeds.
 


### PR DESCRIPTION
Floating-point comparisons are tricky beasts.  See this article for a good summary of the issues involved:
https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/

This PR improves support somewhat, although there are obviously situations in the code (such as comparisons to 0) that should still be addressed.  This PR makes the following improvements:
1) Tightens the threshold on `IS_VEC_NULL` and `IS_VEC_NULL_SQ_SAFE` from 1e-16 and 1e-36 to FLT_EPSILON
2) Tightens the threshold for parsing `turn_time` in POFs
3) Restores the previous implementation of `fl_equal`
4) Adds a dedicated `IS_MOI_VEC_NULL` for moment of inertia values
5) Improves documentation

Follow-up to #4535 and #4443.