### PR TITLE
Modernise CFLAGS on Mac/Linux

### DIFF
--- a/cmake/toolchain-apple-clang.cmake
+++ b/cmake/toolchain-apple-clang.cmake
@@ -4,7 +4,7 @@ MESSAGE(STATUS "Doing configuration specific to Apple Clang...")
 # TODO: Actually add Mac specific flags here...
 
 # Suppress specific warning
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -funroll-loops -fsigned-char -Wno-unknown-pragmas")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char -Wno-unknown-pragmas")
 
 # Omit "conversion from string literal to 'char *' is deprecated" warnings.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings")

--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -33,7 +33,7 @@ set(COMPILER_FLAGS "")
 _enable_extra_compiler_warnings_flags()
 set(COMPILER_FLAGS "${COMPILER_FLAGS} ${_flags}")
 
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -funroll-loops -fsigned-char -Wno-unknown-pragmas")
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -fsigned-char -Wno-unknown-pragmas")
 
 # Omit "argument unused during compilation" when clang is used with ccache.
 if(${CMAKE_CXX_COMPILER} MATCHES "ccache")
@@ -85,7 +85,7 @@ endif()
 
 set(COMPILER_FLAGS_RELEASE "-O2 -Wno-unused-variable -Wno-unused-parameter")
 
-set(COMPILER_FLAGS_DEBUG "-O0 -g -Wshadow")
+set(COMPILER_FLAGS_DEBUG "-Og -g -Wshadow")
 
 # Always use the base flags and add our compiler flags at the bacl
 set(CMAKE_CXX_FLAGS "${CXX_BASE_FLAGS} ${COMPILER_FLAGS}")

--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -120,7 +120,7 @@ if (FSO_FATAL_WARNINGS)
 	target_compile_options(compiler INTERFACE "-Werror")
 endif()
 
-# Always define this to make sure that the fixed width format macros are available
+# Always define this to make sure that the fixed-width format macros are available
 target_compile_definitions(compiler INTERFACE __STDC_FORMAT_MACROS)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR MINGW)

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -45,7 +45,7 @@ endif()
 _enable_extra_compiler_warnings_flags()
 set(COMPILER_FLAGS "${COMPILER_FLAGS} ${_flags}")
 
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -funroll-loops -fsigned-char -Wno-unknown-pragmas")
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -fsigned-char -Wno-unknown-pragmas")
 
 if (NOT GCC_INCREMENTAL_LINKING)
 	# Place each function and data in its own section so the linker can
@@ -115,7 +115,7 @@ endif()
 
 set(COMPILER_FLAGS_RELEASE "-O2 -Wno-unused-variable -Wno-unused-but-set-variable -Wno-array-bounds -Wno-empty-body -Wno-clobbered  -Wno-unused-parameter")
 
-set(COMPILER_FLAGS_DEBUG "-O0 -g -Wshadow")
+set(COMPILER_FLAGS_DEBUG "-Og -g -Wshadow")
 
 # Always use the base flags and add our compiler flags at the back
 set(CMAKE_CXX_FLAGS "${CXX_BASE_FLAGS} ${COMPILER_FLAGS}")


### PR DESCRIPTION
Per GCC optimisation guide, which applies equally well to clang:
* -funroll-loops should not be used unless directed by profiling. The compiler will already unroll loops when it's a good idea.
* clang and gcc now have -Og optimisation levels designed to enable debugging with good performance.