### PR TITLE
fix stepped rotation

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3820,8 +3820,8 @@ void submodel_stepped_rotate(model_subsystem *psub, submodel_instance *smi)
 	// step_offset_time is TIME into current step
 	float step_offset_time = static_cast<float>(fmod(elapsed_time, step_time));
 
-	// get step we are on
-	int cur_step = static_cast<int>(elapsed_time / step_time + 0.5f);
+	// get step we are on (round down)
+	int cur_step = static_cast<int>(elapsed_time / step_time);
 
 	// get base angle
 	smi->cur_angle = (cur_step % psub->stepped_rotation->num_steps) * step_size;


### PR DESCRIPTION
As part of the cleanup in preparation for model translation, there was a bit of code review that was actually incorrect.  The calculation of the current step needs to be rounded down, because the step isn't actually complete until it fully reaches the next number.  Rounding the step causes the submodel to jump around in all sorts of weird ways.

Follow-up to #4443.