### PR TITLE
Allow changing Animation Instance speed

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -258,11 +258,12 @@ namespace animation {
 		animList.parentSet->initializeSubmodelBuffer(pmi, applyBuffer);
 
 		for (const auto& anim : animList.animationList) {
-			switch (anim->m_instances[pmi->id].state) {
+			const auto& instanceData = anim->m_instances[pmi->id];
+			switch (instanceData.state) {
 			case ModelAnimationState::RUNNING_FWD:
 			case ModelAnimationState::RUNNING_RWD:
 			case ModelAnimationState::NEED_RECALC:
-				anim->play(frametime, pmi, applyBuffer);
+				anim->play(frametime * instanceData.speed, pmi, applyBuffer);
 				break;
 			case ModelAnimationState::COMPLETED:
 			case ModelAnimationState::PAUSED:
@@ -787,6 +788,11 @@ namespace animation {
 		for (auto anim : animations)
 			anim->m_instances[pmi->id].instance_flags.set(flag, set);
 	}
+
+	void ModelAnimationSet::AnimationList::setSpeed(float speed) const {
+		for (auto anim : animations)
+			anim->m_instances[pmi->id].speed = speed;
+	};
 
 	ModelAnimationSet::AnimationList& ModelAnimationSet::AnimationList::operator+=(const AnimationList& rhs) {
 		Assertion(pmi == rhs.pmi, "Tried to concatenate two AnimationLists of different model instances!");

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -774,7 +774,7 @@ namespace animation {
 	int ModelAnimationSet::AnimationList::getTime() const {
 		float duration = 0.0f;
 
-		for (auto anim : animations) {
+		for (const auto& anim : animations) {
 			if (anim->m_instances[pmi->id].state == ModelAnimationState::UNTRIGGERED)
 				continue;
 			float localDur = anim->m_instances[pmi->id].duration;
@@ -785,12 +785,12 @@ namespace animation {
 	}
 
 	void ModelAnimationSet::AnimationList::setFlag(Animation_Instance_Flags flag, bool set) const {
-		for (auto anim : animations)
+		for (const auto& anim : animations)
 			anim->m_instances[pmi->id].instance_flags.set(flag, set);
 	}
 
 	void ModelAnimationSet::AnimationList::setSpeed(float speed) const {
-		for (auto anim : animations)
+		for (const auto& anim : animations)
 			anim->m_instances[pmi->id].speed = speed;
 	};
 

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -252,6 +252,7 @@ namespace animation {
 			float time = 0.0f;
 			float duration = 0.0f;
 			flagset<animation::Animation_Instance_Flags> instance_flags;
+			float speed = 1.0f;
 		};
 		//PMI ID -> Instance Data
 		std::map<int, instance_data> m_instances;
@@ -364,6 +365,7 @@ namespace animation {
 			bool start(ModelAnimationDirection direction, bool forced = false, bool instant = false, bool pause = false) const;
 			int getTime() const;
 			void setFlag(Animation_Instance_Flags flag, bool set = true) const;
+			void setSpeed(float speed = 1.0f) const;
 			AnimationList& operator+=(const AnimationList& rhs);
 			AnimationList operator+(const AnimationList& rhs);
 		};

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1668,7 +1668,7 @@ ADE_FUNC(setAnimationSpeed, l_Ship, "string type, string triggeredBy, [number sp
 
 	auto animtype = animation::anim_match_type(type);
 	if (animtype == animation::ModelAnimationTriggerType::None)
-		return ADE_RETURN_FALSE;
+		return ADE_RETURN_NIL;
 
 	ship* shipp = &Ships[objh->objp->instance];
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1673,6 +1673,8 @@ ADE_FUNC(setAnimationSpeed, l_Ship, "string type, string triggeredBy, [number sp
 	ship* shipp = &Ships[objh->objp->instance];
 
 	Ship_info[shipp->ship_info_index].animations.parseScripted(model_get_instance(shipp->model_instance_num), animtype, trigger).setSpeed(speed);
+
+	return ADE_RETURN_NIL;
 }
 
 ADE_FUNC(getSubmodelAnimationTime, l_Ship, "string type, string triggeredBy", "Gets time that animation will be done", "number", "Time (seconds), or 0 if ship handle is invalid")

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1649,6 +1649,32 @@ ADE_FUNC(triggerSubmodelAnimation, l_Ship, "string type, string triggeredBy, [bo
 	return Ship_info[shipp->ship_info_index].animations.parseScripted(model_get_instance(shipp->model_instance_num), animtype, trigger).start(forwards ? animation::ModelAnimationDirection::FWD : animation::ModelAnimationDirection::RWD, forced || instant, instant, pause) ? ADE_RETURN_TRUE : ADE_RETURN_FALSE;
 }
 
+ADE_FUNC(setAnimationSpeed, l_Ship, "string type, string triggeredBy, [number speedMultiplier = 1.0]",
+	"Sets the speed multiplier at which an animation runs. Anything other than 1 will not work in multiplayer. Type is the string name of the animation type, "
+	"triggeredBy is a closer specification which animation should trigger. See *-anim.tbm specifications.",
+	nullptr,
+	nullptr)
+{
+	object_h* objh;
+	const char* type = nullptr;
+	const char* trigger = nullptr;
+	float speed = 1.0f;
+
+	if (!ade_get_args(L, "oss|f", l_Ship.GetPtr(&objh), &type, &trigger, &speed))
+		return ADE_RETURN_NIL;
+
+	if (!objh->IsValid())
+		return ADE_RETURN_NIL;
+
+	auto animtype = animation::anim_match_type(type);
+	if (animtype == animation::ModelAnimationTriggerType::None)
+		return ADE_RETURN_FALSE;
+
+	ship* shipp = &Ships[objh->objp->instance];
+
+	Ship_info[shipp->ship_info_index].animations.parseScripted(model_get_instance(shipp->model_instance_num), animtype, trigger).setSpeed(speed);
+}
+
 ADE_FUNC(getSubmodelAnimationTime, l_Ship, "string type, string triggeredBy", "Gets time that animation will be done", "number", "Time (seconds), or 0 if ship handle is invalid")
 {
 	object_h* objh;


### PR DESCRIPTION
This enables scripting to change the speed multiplier of any animation. If it is not yet running, the speed change will also affect the animation once it is started.