### PR TITLE
Allow tech-room to auto switch to single-player mode

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -30,6 +30,7 @@
 #include "menuui/playermenu.h"
 #include "menuui/snazzyui.h"
 #include "mission/missioncampaign.h"
+#include "mod_table/mod_table.h"
 #include "network/multi.h"
 #include "network/multi_voice.h"
 #include "network/multiui.h"
@@ -917,6 +918,12 @@ void main_hall_do(float frametime)
 
 				// clicked on the tech room region
 				case TECH_ROOM_REGION:
+					// Check if Techroom should auto-switch to singleplayer mode --wookieejedi
+					if (Techroom_autoswitches_to_singleplayer) {
+						Player->flags &= ~PLAYER_FLAGS_IS_MULTI;
+						Game_mode = GM_NORMAL;
+					}
+
 					gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 					gameseq_post_event(GS_EVENT_TECH_MENU);
 					break;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -95,6 +95,7 @@ int Show_subtitle_screen_base_res[2];
 int Show_subtitle_screen_adjusted_res[2];
 bool Always_warn_player_about_unbound_keys;
 shadow_disable_overrides Shadow_disable_overrides {false, false, false, false};
+bool Techroom_autoswitches_to_singleplayer;
 
 void mod_table_set_version_flags();
 
@@ -858,6 +859,10 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Custom_briefing_icons_always_override_standard_icons);
 		}
 
+		if (optional_string("$Techroom is always auto-switched to singleplayer mode:")) {
+			stuff_boolean(&Techroom_autoswitches_to_singleplayer);
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -980,6 +985,7 @@ void mod_table_reset()
 	Show_subtitle_screen_adjusted_res[0] = -1;
 	Show_subtitle_screen_adjusted_res[1] = -1;
 	Always_warn_player_about_unbound_keys = false;
+	Techroom_autoswitches_to_singleplayer = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -86,6 +86,7 @@ extern bool Always_warn_player_about_unbound_keys;
 extern struct shadow_disable_overrides {
 	bool disable_techroom, disable_mission_select_weapons, disable_mission_select_ships, disable_cockpit;
 } Shadow_disable_overrides;
+extern bool Techroom_autoswitches_to_singleplayer;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
Many buttons in the main menu auto switch to either multi-player mode or single-player mode. For example, the `Campaign` door always switches to single-player, while the `Multiplayer` door auto switches to multiplayer mode. This is very useful for mods, especially with new players who are not sure where and how to switch between multi and single player pilots.

This PR adds an option to allow mods to auto switch to single-player for the `Techroom`, which is especially useful for playing simulator missions. The method used here is the same method that the campaign door uses to auto switch to single-player.

Tested and works as expected.