### PR TITLE
Prioritize players in object update

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -163,10 +163,6 @@ void multi_ship_record_rank_seq_num(object* objp, int seq_num);
 // recalculate how much time is between position packets
 float multi_oo_calc_pos_time_difference(int player_id, int net_sig_idx);
 
-
-// tolerance for bashing position
-#define OO_POS_UPDATE_TOLERANCE	150.0f
-
 // new improved - more compacted info type
 #define OO_POS_AND_ORIENT_NEW		(1<<0)		// To update position and orientation. Because getting accurate velocity requires orientation, and accurate orienation requires velocity
 #define OO_FULL_PHYSICS				(1<<1)		// Since AI don't use all phys_info values, we need a flag to confirm when all have been transmitted.


### PR DESCRIPTION
This makes servers update player ships more often, even when they are not front and center in front of the player.  This hopefully will cut down on some of the player jitteriness.  Because client player ships have extra latency in a server-based system, they should have been prioritized when the system was changed over between FS1 and FS2.

Testing has occurred, and it is definitely not making anything worse, although our multiplayer testing base is not as scientific these days. 