### PR TITLE
Fix setting of `$Shadow Quality Default:`

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -535,10 +535,10 @@ void parse_mod_table(const char *filename)
 		}
 
 		if (optional_string("$Shadow Quality Default:")) {
-			// only read this value if shadows are enabled and using default quality --wookieejedi
+			int quality;
+			stuff_int(&quality);
+			// only set values if shadows are enabled and using default quality --wookieejedi
 			if (Shadow_quality_uses_mod_option) {
-				int quality;
-				stuff_int(&quality);
 				switch (quality) {
 				case 0:
 					Shadow_quality = ShadowQuality::Disabled;


### PR DESCRIPTION
`$Shadow Quality Default:` allows mods to specify what the default shadow quality should be, given that `-enable_shadows` flag is used. If a mod used this game settings option but the player did not use the `-enable_shadows` flag, then a parsing error would show up.

This PR fixes that bug by reordering two lines. Tested and fix works as expected.