### PR TITLE
Enable LuaAI to use more arguments

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -460,7 +460,7 @@ typedef struct ai_info {
 	int multilock_check_timestamp;		// when to check for multilock next
 	SCP_vector<std::pair<int, ship_subsys*>> ai_missile_locks_firing;  // a list of missile locks (locked objnum, locked subsys) the ai is currently firing
 	
-	object_ship_wing_point_team lua_ai_target;
+	ai_lua_parameters lua_ai_target;
 } ai_info;
 
 // Goober5000

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -170,7 +170,7 @@ void ai_goal_reset(ai_goal *aigp, bool adding_goal, int ai_mode, int ai_submode,
 	aigp->dockee.name = nullptr;
 
 	aigp->lua_ai_target.target.clear();
-	//aigp->lua_ai_target.arguments.clear();
+	aigp->lua_ai_target.arguments.clear();
 }
 
 void ai_maybe_add_form_goal(wing* wingp)

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1076,7 +1076,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, char
 
 			aigp->priority = atoi( CTEXT(localnode) );
 
-			aigp->lua_ai_target = { std::move(target), std::move(luaAIMode->sexp.getSEXPArgumentList(CDR(localnode))) };
+			aigp->lua_ai_target = { std::move(target), luaAIMode->sexp.getSEXPArgumentList(CDR(localnode)) };
 		}
 		else {
 			UNREACHABLE("Invalid SEXP-OP number %d for an AI goal!", op);

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -170,7 +170,7 @@ void ai_goal_reset(ai_goal *aigp, bool adding_goal, int ai_mode, int ai_submode,
 	aigp->dockee.name = nullptr;
 
 	aigp->lua_ai_target.target.clear();
-	aigp->lua_ai_target.arguments.clear();
+	//aigp->lua_ai_target.arguments.clear();
 }
 
 void ai_maybe_add_form_goal(wing* wingp)

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -101,8 +101,8 @@ struct ai_info;
 enum class ai_achievability { ACHIEVABLE, NOT_ACHIEVABLE, NOT_KNOWN, SATISFIED };
 
 struct ai_lua_parameters {
-	object_ship_wing_point_team target{};
-	luacpp::LuaValueList arguments{};
+	object_ship_wing_point_team target;
+	luacpp::LuaValueList arguments;
 };
 
 // structure for AI goals
@@ -175,8 +175,8 @@ extern int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp );
 extern void ai_remove_wing_goal_sexp( int sexp, wing *wingp );
 
 // adds goals to ships/sings through player orders
-extern void ai_add_ship_goal_player(int type, int mode, int submode, char* shipname, ai_info* aip, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), {} });
-extern void ai_add_wing_goal_player(int type, int mode, int submode, char* shipname, int wingnum, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), {} });
+extern void ai_add_ship_goal_player(int type, int mode, int submode, char* shipname, ai_info* aip, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), luacpp::LuaValueList{} });
+extern void ai_add_wing_goal_player(int type, int mode, int submode, char* shipname, int wingnum, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), luacpp::LuaValueList{} });
 
 extern void ai_remove_ship_goal( ai_info *aip, int index );
 extern void ai_clear_ship_goals( ai_info *aip );

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -101,8 +101,8 @@ struct ai_info;
 enum class ai_achievability { ACHIEVABLE, NOT_ACHIEVABLE, NOT_KNOWN, SATISFIED };
 
 struct ai_lua_parameters {
-	object_ship_wing_point_team target;
-	luacpp::LuaValueList arguments;
+	object_ship_wing_point_team target{};
+	luacpp::LuaValueList arguments{};
 };
 
 // structure for AI goals

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -16,6 +16,8 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 #include "parse/sexp.h"
+#include "scripting/lua/LuaTypes.h"
+#include "scripting/lua/LuaValue.h"
 
 struct wing;
 struct ai_info;
@@ -98,6 +100,10 @@ struct ai_info;
 
 enum class ai_achievability { ACHIEVABLE, NOT_ACHIEVABLE, NOT_KNOWN, SATISFIED };
 
+struct ai_lua_parameters {
+	object_ship_wing_point_team target;
+	luacpp::LuaValueList arguments;
+};
 
 // structure for AI goals
 typedef struct ai_goal {
@@ -132,7 +138,7 @@ typedef struct ai_goal {
 		int	index;
 	} dockee;
 
-	object_ship_wing_point_team lua_ai_target;
+	ai_lua_parameters lua_ai_target;
 
 } ai_goal;
 
@@ -169,8 +175,8 @@ extern int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp );
 extern void ai_remove_wing_goal_sexp( int sexp, wing *wingp );
 
 // adds goals to ships/sings through player orders
-extern void ai_add_ship_goal_player( int type, int mode, int submode, char *shipname, ai_info *aip, const object_ship_wing_point_team& lua_target = object_ship_wing_point_team());
-extern void ai_add_wing_goal_player( int type, int mode, int submode, char *shipname, int wingnum, const object_ship_wing_point_team& lua_target = object_ship_wing_point_team());
+extern void ai_add_ship_goal_player(int type, int mode, int submode, char* shipname, ai_info* aip, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), {} });
+extern void ai_add_wing_goal_player(int type, int mode, int submode, char* shipname, int wingnum, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), {} });
 
 extern void ai_remove_ship_goal( ai_info *aip, int index );
 extern void ai_clear_ship_goals( ai_info *aip );

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -58,7 +58,7 @@ void run_ai_lua_action(const luacpp::LuaFunction& action, const ai_mode_lua& lua
 	luacpp::LuaValueList luaParameters;
 	luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_AI_Helper.Set(object_h(&Objects[Ships[aip->shipnum].objnum]))));
 	if (lua_ai.needsTarget) {
-		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(aip->lua_ai_target)));
+		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(aip->lua_ai_target.target)));
 	}
 
 	auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);
@@ -74,14 +74,10 @@ void ai_lua(ai_info* aip){
 
 	const auto& lua_ai = Lua_ai_modes.at(aip->submode);
 	
-	auto dynamicSEXP = sexp::get_dynamic_sexp(aip->submode);
+	const auto& lua_ai_sexp = lua_ai.sexp;
+	const auto& action = lua_ai_sexp.getAction();
 
-	if (dynamicSEXP != nullptr && typeid(*dynamicSEXP) == typeid(sexp::LuaAISEXP)) {
-		auto lua_ai_sexp = static_cast<sexp::LuaAISEXP*>(dynamicSEXP);
-		const auto& action = lua_ai_sexp->getActionFrame();
-
-		run_ai_lua_action(action, lua_ai, aip);
-	}
+	run_ai_lua_action(action, lua_ai, aip);
 }
 
 void ai_lua_start(ai_goal* aigp, object* objp){
@@ -98,15 +94,10 @@ void ai_lua_start(ai_goal* aigp, object* objp){
 	
 	const auto& lua_ai = Lua_ai_modes.at(aigp->ai_submode);
 
-	auto dynamicSEXP = sexp::get_dynamic_sexp(aigp->ai_submode);
+	const auto& lua_ai_sexp = lua_ai.sexp;
+	const auto& action = lua_ai_sexp.getActionEnter();
 
-	if (dynamicSEXP != nullptr && typeid(*dynamicSEXP) == typeid(sexp::LuaAISEXP)) {
-		auto lua_ai_sexp = static_cast<sexp::LuaAISEXP*>(dynamicSEXP);
-		const auto& action = lua_ai_sexp->getActionEnter();
-
-		run_ai_lua_action(action, lua_ai, aip);
-	}
-	
+	run_ai_lua_action(action, lua_ai, aip);
 }
 
 bool ai_lua_is_valid_target_intrinsic(int sexp_op, int target_objnum, ship* self) {
@@ -140,29 +131,25 @@ bool ai_lua_is_valid_target_intrinsic(int sexp_op, int target_objnum, ship* self
 }
 
 bool ai_lua_is_valid_target_lua(const ai_mode_lua& mode, int sexp_op, int target_objnum, ship* self) {
-	auto dynamicSEXP = sexp::get_dynamic_sexp(sexp_op);
 
-	if (dynamicSEXP != nullptr && typeid(*dynamicSEXP) == typeid(sexp::LuaAISEXP)) {
-		auto lua_ai_sexp = static_cast<sexp::LuaAISEXP*>(dynamicSEXP);
-		const auto& action = lua_ai_sexp->getTargetRestrict();
+	const auto& action = mode.sexp.getTargetRestrict();
 
-		if (!action.isValid())
-			return true;
+	if (!action.isValid())
+		return true;
 
-		luacpp::LuaValueList luaParameters;
-		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_Ship.Set(object_h(&Objects[self->objnum]))));
-		if (mode.needsTarget) {
-			luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(object_ship_wing_point_team(&Ships[Objects[target_objnum].instance]))));
-		}
+	luacpp::LuaValueList luaParameters;
+	luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_Ship.Set(object_h(&Objects[self->objnum]))));
+	if (mode.needsTarget) {
+		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(object_ship_wing_point_team(&Ships[Objects[target_objnum].instance]))));
+	}
 
-		auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);
+	auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);
 
-		if (!retVals.empty() && retVals[0].getValueType() == luacpp::ValueType::BOOLEAN) {
-			return retVals[0].getValue<bool>();
-		}
-		else {
-			Error(LOCATION, "LuaAI target restriction function did not return a valid boolean!");
-		}
+	if (!retVals.empty() && retVals[0].getValueType() == luacpp::ValueType::BOOLEAN) {
+		return retVals[0].getValue<bool>();
+	}
+	else {
+		Error(LOCATION, "LuaAI target restriction function did not return a valid boolean!");
 	}
 
 	return true;
@@ -193,46 +180,41 @@ bool ai_lua_is_valid_target(int sexp_op, int target_objnum, ship* self) {
 ai_achievability ai_lua_is_achievable(const ai_goal* aigp, int objnum){
 	const auto& lua_ai = Lua_ai_modes.at(aigp->ai_submode);
 
-	auto dynamicSEXP = sexp::get_dynamic_sexp(aigp->ai_submode);
+	const auto& action = lua_ai.sexp.getAchievable();
 
-	if (dynamicSEXP != nullptr && typeid(*dynamicSEXP) == typeid(sexp::LuaAISEXP)) {
-		auto lua_ai_sexp = static_cast<sexp::LuaAISEXP*>(dynamicSEXP);
-		const auto& action = lua_ai_sexp->getAchievable();
+	if (!action.isValid())
+		return ai_achievability::ACHIEVABLE;
 
-		if (!action.isValid())
+	luacpp::LuaValueList luaParameters;
+	luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_Ship.Set(object_h(&Objects[objnum]))));
+	if (lua_ai.needsTarget) {
+		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(aigp->lua_ai_target.target)));
+	}
+
+	auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);
+
+	if (!retVals.empty() && retVals[0].getValueType() == luacpp::ValueType::USERDATA) {
+		scripting::api::enum_h enumData;
+		retVals[0].getValue(scripting::api::l_Enum.Get(&enumData));
+		if (!enumData.IsValid()) {
+			Error(LOCATION, "LuaAI SEXP achievability hook returned an invalid avilability enum.");
 			return ai_achievability::ACHIEVABLE;
-
-		luacpp::LuaValueList luaParameters;
-		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_Ship.Set(object_h(&Objects[objnum]))));
-		if (lua_ai.needsTarget) {
-			luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(aigp->lua_ai_target)));
 		}
 
-		auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);
-
-		if (!retVals.empty() && retVals[0].getValueType() == luacpp::ValueType::USERDATA) {
-			scripting::api::enum_h enumData;
-			retVals[0].getValue(scripting::api::l_Enum.Get(&enumData));
-			if (!enumData.IsValid()) {
-				Error(LOCATION, "LuaAI SEXP achievability hook returned an invalid avilability enum.");
-				return ai_achievability::ACHIEVABLE;
-			}
-
-			switch (enumData.index) {
-			case scripting::api::LE_LUAAI_ACHIEVABLE:
-				return ai_achievability::ACHIEVABLE;
-			case scripting::api::LE_LUAAI_NOT_YET_ACHIEVABLE:
-				return ai_achievability::NOT_KNOWN;
-			case scripting::api::LE_LUAAI_UNACHIEVABLE:
-				return ai_achievability::NOT_ACHIEVABLE;
-			default:
-				Error(LOCATION, "LuaAI SEXP achievability hook returned an invalid avilability enum.");
-				return ai_achievability::ACHIEVABLE;
-			}
+		switch (enumData.index) {
+		case scripting::api::LE_LUAAI_ACHIEVABLE:
+			return ai_achievability::ACHIEVABLE;
+		case scripting::api::LE_LUAAI_NOT_YET_ACHIEVABLE:
+			return ai_achievability::NOT_KNOWN;
+		case scripting::api::LE_LUAAI_UNACHIEVABLE:
+			return ai_achievability::NOT_ACHIEVABLE;
+		default:
+			Error(LOCATION, "LuaAI SEXP achievability hook returned an invalid avilability enum.");
+			return ai_achievability::ACHIEVABLE;
 		}
-		else {
-			Error(LOCATION, "LuaAI SEXP achievability hook did not return any avilability enum!");
-		}
+	}
+	else {
+		Error(LOCATION, "LuaAI SEXP achievability hook did not return any avilability enum!");
 	}
 
 	return ai_achievability::ACHIEVABLE;

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -133,7 +133,7 @@ bool ai_lua_is_valid_target_intrinsic(int sexp_op, int target_objnum, ship* self
 	return false;
 }
 
-bool ai_lua_is_valid_target_lua(const ai_mode_lua& mode, int sexp_op, int target_objnum, ship* self) {
+bool ai_lua_is_valid_target_lua(const ai_mode_lua& mode, int target_objnum, ship* self) {
 
 	const auto& action = mode.sexp.getTargetRestrict();
 
@@ -177,7 +177,7 @@ bool ai_lua_is_valid_target(int sexp_op, int target_objnum, ship* self) {
 	}
 
 	//If we haven't bailed yet, query the custom callback
-	return ai_lua_is_valid_target_lua(mode, sexp_op, target_objnum, self);
+	return ai_lua_is_valid_target_lua(mode, target_objnum, self);
 }
 
 ai_achievability ai_lua_is_achievable(const ai_goal* aigp, int objnum){

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -60,6 +60,9 @@ void run_ai_lua_action(const luacpp::LuaFunction& action, const ai_mode_lua& lua
 	if (lua_ai.needsTarget) {
 		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(aip->lua_ai_target.target)));
 	}
+	for (const auto& additionalParam : aip->lua_ai_target.arguments) {
+		luaParameters.push_back(additionalParam);
+	}
 
 	auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);
 
@@ -189,6 +192,9 @@ ai_achievability ai_lua_is_achievable(const ai_goal* aigp, int objnum){
 	luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_Ship.Set(object_h(&Objects[objnum]))));
 	if (lua_ai.needsTarget) {
 		luaParameters.push_back(luacpp::LuaValue::createValue(action.getLuaState(), scripting::api::l_OSWPT.Set(aigp->lua_ai_target.target)));
+	}
+	for (const auto& additionalParam : aigp->lua_ai_target.arguments) {
+		luaParameters.push_back(additionalParam);
 	}
 
 	auto retVals = action.call(Script_system.GetLuaSession(), luaParameters);

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -4,9 +4,13 @@
 #include "ai/aigoals.h"
 #include "mission/missionmessage.h"
 #include "ship/ship.h"
+#include "parse/sexp.h"
 #include "globalincs/globals.h"
 
+namespace sexp { class LuaAISEXP; }
+
 struct ai_mode_lua {
+	const sexp::LuaAISEXP& sexp;
 	bool needsTarget;
 	const char* hudText;
 };
@@ -17,6 +21,7 @@ struct player_order_lua {
 	SCP_string displayText = "";
 	enum class target_restrictions : int { TARGET_ALLIES, TARGET_ALL, TARGET_OWN, TARGET_ENEMIES, TARGET_SAME_WING, TARGET_PLAYER_WING, TARGET_ALL_CAPS, TARGET_ALLIED_CAPS, TARGET_ENEMY_CAPS, TARGET_NOT_SELF } targetRestrictions = target_restrictions::TARGET_ALL;
 };
+
 
 void ai_lua_add_mode(int sexp_op, const ai_mode_lua& mode);
 bool ai_lua_add_order(int sexp_op, player_order_lua order);

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -225,7 +225,7 @@ void insertion_sort(T* array_base, int array_size, int (*fncompare)(const T*, co
 
 	// allocate space for the element being moved
 	// (Taylor says that for optimization purposes malloc/free should be used rather than vm_malloc/vm_free here)
-	current_buf = (T*)malloc(sizeof(T));
+	current_buf = new T();
 	if (current_buf == nullptr)
 	{
 		UNREACHABLE("Malloc failed!");
@@ -264,7 +264,7 @@ void insertion_sort(T* array_base, int array_size, int (*fncompare)(const T*, co
 	}
 
 	// free the allocated space
-	free(current_buf);
+	delete current_buf;
 }
 
 #endif

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1007,7 +1007,7 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 	ai_info *ainfo;
 	int ai_mode, ai_submode;					// ai mode and submode needed for ship commands
 	char *target_shipname;						// ship number of possible targets
-	object_ship_wing_point_team lua_target;
+	ai_lua_parameters lua_target;
 	int message;
 	int target_team, ship_team;				// team id's for the ship getting message and any target the player has
 	ship *ordering_shipp;
@@ -1251,7 +1251,7 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 			auto lua_porder = ai_lua_find_player_order(Player_orders[command].lua_id);
 			message = lua_porder->ai_message;
 			if (ainfo->target_objnum != -1)
-				lua_target = object_ship_wing_point_team(&Ships[Objects[ainfo->target_objnum].instance]);
+				lua_target = { object_ship_wing_point_team(&Ships[Objects[ainfo->target_objnum].instance]), {} };
 			break;
 		}
 
@@ -1300,7 +1300,7 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 	ai_info *ainfo;
 	int ai_mode, ai_submode;					// ai mode and submode needed for ship commands
 	char *target_shipname;						// ship number of possible targets
-	object_ship_wing_point_team lua_target;
+	ai_lua_parameters lua_target;
 	int message_sent, message;
 	int target_team, wing_team;				// team for the wing and the player's target
 	ship *ordering_shipp;
@@ -1478,7 +1478,7 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 			auto lua_porder = ai_lua_find_player_order(Player_orders[command].lua_id);
 			message = lua_porder->ai_message;
 			if(ainfo->target_objnum != -1)
-				lua_target = object_ship_wing_point_team(&Ships[Objects[ainfo->target_objnum].instance]);
+				lua_target = { object_ship_wing_point_team(&Ships[Objects[ainfo->target_objnum].instance]), {} };
 			break;
 
 		}

--- a/code/parse/sexp/DynamicSEXP.h
+++ b/code/parse/sexp/DynamicSEXP.h
@@ -36,7 +36,7 @@ class DynamicSEXP {
 	 *
 	 * @return The minimum amount of arguments
 	 */
-	virtual int getMinimumArguments() = 0;
+	virtual int getMinimumArguments() const = 0;
 
 	/**
 	 * @brief Gets the maximum number of how many arguments this SEXP may be called with
@@ -45,7 +45,7 @@ class DynamicSEXP {
 	 *
 	 * @return The maximum amount of arguments for this SEXP
 	 */
-	virtual int getMaximumArguments() = 0;
+	virtual int getMaximumArguments() const = 0;
 
 	/**
 	 * @brief Retrieves the type of the specified argument (0-base)

--- a/code/parse/sexp/EngineSEXP.cpp
+++ b/code/parse/sexp/EngineSEXP.cpp
@@ -191,8 +191,8 @@ void EngineSEXP::initialize()
 		}
 	}
 }
-int EngineSEXP::getMinimumArguments() { return _minArgs; }
-int EngineSEXP::getMaximumArguments() { return _maxArgs; }
+int EngineSEXP::getMinimumArguments() const { return _minArgs; }
+int EngineSEXP::getMaximumArguments() const { return _maxArgs; }
 int EngineSEXP::getArgumentType(int argnum) const
 {
 	if (argnum >= static_cast<int>(_argumentTypes.size())) {

--- a/code/parse/sexp/EngineSEXP.h
+++ b/code/parse/sexp/EngineSEXP.h
@@ -151,8 +151,8 @@ class EngineSEXP : public DynamicSEXP {
 
   public:
 	void initialize() override;
-	int getMinimumArguments() override;
-	int getMaximumArguments() override;
+	int getMinimumArguments() const override;
+	int getMaximumArguments() const override;
 	int getArgumentType(int argnum) const override;
 	int execute(int node) override;
 	int getReturnType() override;

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -249,7 +249,7 @@ void LuaAISEXP::parseTable() {
 	}
 
 	if (!variable_arg_part) {
-		if (_max_args != INT_MAX && _max_args != _argument_types.size()) {
+		if (_max_args != INT_MAX && _max_args != (int)_argument_types.size()) {
 			error_display(1, "Maximum Additional Argument count does not match number of specified arguments!");
 		}
 		_max_args = (int)_argument_types.size();

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -59,7 +59,9 @@ bool LuaAISEXP::parseCheckEndOfDescription() {
 		"+HUD String:",
 		"$Target Parameter:",
 		"$Player Order:",
-
+		"$Additional Parameter:",
+		"$Minimum Additional Arguments:",
+		"$Maximum Additional Arguments:"
 	};
 
 	bool found = false;
@@ -125,6 +127,10 @@ void LuaAISEXP::parseTable() {
 		paramNum++;
 	}
 
+	help_text << "\t" << paramNum;
+	help_text << ": Goal priority (number between 0 and 200. Player orders have a priority of 90-100).\r\n";
+
+
 	if (optional_string("$Player Order:")) {
 		playerOrder = std::unique_ptr<player_order_lua>(new player_order_lua());
 		auto &order = *playerOrder;
@@ -175,8 +181,79 @@ void LuaAISEXP::parseTable() {
 
 	}
 
-	help_text << "\t" << paramNum;
-	help_text << ": Goal priority (number between 0 and 200. Player orders have a priority of 90-100).\r\n";
+	if (optional_string("$Minimum Additional Arguments:")) {
+		stuff_int(&_min_args);
+
+		if (_min_args < 0) {
+			error_display(0, "Minimum argument number must be at least 0! Got %d.", _min_args);
+			_min_args = 0;
+		}
+	}
+	else {
+		_min_args = 0;
+	}
+
+	if (optional_string("$Maximum Additional Arguments:")) {
+		stuff_int(&_max_args);
+
+		if (_max_args < _min_args) {
+			error_display(0, "Maximum argument number must be at least %d, the number of minimum arguments! Got %d.", _min_args, _max_args);
+			_max_args = _min_args;
+		}
+	}
+	else {
+		_max_args = INT_MAX;
+	}
+
+	bool variable_arg_part = false;
+	while (optional_string("$Additional Parameter:")) {
+		required_string("+Description:");
+
+		SCP_string param_desc;
+		stuff_string(param_desc, F_NAME);
+
+		if (variable_arg_part) {
+			help_text << "\t" << _varargs_type_pattern.size() + 1;
+		}
+		else {
+			help_text << "\t" << ++paramNum;
+		}
+		help_text << ": " << param_desc << "\r\n";
+
+		required_string("+Type:");
+		SCP_string type_str;
+		stuff_string(type_str, F_NAME);
+
+		auto type = get_parameter_type(type_str);
+		if (type.second < 0) {
+			error_display(0, "Unknown parameter type '%s'!", type_str.c_str());
+			type = get_parameter_type("string");
+		}
+
+		if (variable_arg_part) {
+			_varargs_type_pattern.push_back(type);
+		}
+		else {
+			_argument_types.push_back(type);
+		}
+
+		if (optional_string("$Repeat")) {
+			if (!variable_arg_part) {
+				help_text << "Rest: (The following pattern repeats)\r\n";
+				variable_arg_part = true;
+			}
+			else {
+				error_display(0, "A second $Repeat has been encountered! Only one may appear in the parameter list.");
+			}
+		}
+	}
+
+	if (!variable_arg_part) {
+		if (_max_args != INT_MAX && _max_args != _argument_types.size()) {
+			error_display(1, "Maximum Additional Argument count does not match number of specified arguments!");
+		}
+		_max_args = (int)_argument_types.size();
+	}
 
 	_help_text = help_text.str();
 	lcl_replace_stuff(_help_text, true);

--- a/code/parse/sexp/LuaAISEXP.h
+++ b/code/parse/sexp/LuaAISEXP.h
@@ -46,8 +46,6 @@ class LuaAISEXP : public LuaSEXP {
 	void setTargetRestrict(const luacpp::LuaFunction& action);
 	luacpp::LuaFunction getTargetRestrict() const;
 
-	luacpp::LuaValueList getSEXPArgumentList(int node) const;
-
 	void registerAIMode(int sexp_id) const;
 	void maybeRegisterPlayerOrder(int sexp_id) const;
 };

--- a/code/parse/sexp/LuaAISEXP.h
+++ b/code/parse/sexp/LuaAISEXP.h
@@ -2,7 +2,7 @@
 
 #include "ai/ailua.h"
 
-#include "parse/sexp/DynamicSEXP.h"
+#include "parse/sexp/LuaSEXP.h"
 
 #include "scripting/lua/LuaFunction.h"
 #include "scripting/lua/LuaTable.h"
@@ -11,14 +11,13 @@
 
 namespace sexp {
 
-class LuaAISEXP : public DynamicSEXP {
+class LuaAISEXP : public LuaSEXP {
 	
 	int _arg_type = -1;
 	bool needsTarget = false;
 	const char* hudText = nullptr;
 
 	luacpp::LuaFunction _actionEnter;
-	luacpp::LuaFunction _actionFrame;
 	luacpp::LuaFunction _achievable;
 	luacpp::LuaFunction _targetRestrict;
 
@@ -31,21 +30,15 @@ class LuaAISEXP : public DynamicSEXP {
 	explicit LuaAISEXP(const SCP_string& name);
 
 	void initialize() override;
-	int getMinimumArguments() override;
-	int getMaximumArguments() override;
+	int getMinimumArguments() const override;
+	int getMaximumArguments() const override;
 	int getArgumentType(int argnum) const override;
 	int execute(int node) override;
-	int getReturnType() override;
-	int getSubcategory() override;
-	int getCategory() override;
 
 	void parseTable();
 
 	void setActionEnter(const luacpp::LuaFunction& action);
 	luacpp::LuaFunction getActionEnter() const;
-
-	void setActionFrame(const luacpp::LuaFunction& action);
-	luacpp::LuaFunction getActionFrame() const;
 
 	void setAchievable(const luacpp::LuaFunction& action);
 	luacpp::LuaFunction getAchievable() const;
@@ -53,6 +46,7 @@ class LuaAISEXP : public DynamicSEXP {
 	void setTargetRestrict(const luacpp::LuaFunction& action);
 	luacpp::LuaFunction getTargetRestrict() const;
 
+	luacpp::LuaValueList getSEXPArgumentList(int node) const;
 
 	void registerAIMode(int sexp_id) const;
 	void maybeRegisterPlayerOrder(int sexp_id) const;

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -289,26 +289,22 @@ int LuaSEXP::getSexpReturnValue(const LuaValueList& retVals) const {
 		return SEXP_TRUE;
 	}
 }
-int LuaSEXP::execute(int node) {
-	if (!_action.isValid()) {
-		Error(LOCATION,
-			  "Lua SEXP called without a valid action function! A script probably failed to set the action for some reason.");
-		return SEXP_CANT_EVAL;
-	}
 
+luacpp::LuaValueList LuaSEXP::getSEXPArgumentList(int node) const {
 	LuaValueList luaParameters;
 
 	// We need to adapt how we handle parameters based on their type. We use this variable to keep track of which parameter
 	// we are currently looking at
 	int argnum = 0;
 	while (node != -1) {
-		if (argnum < (int) _argument_types.size()) {
+		if (argnum < (int)_argument_types.size()) {
 			// This is a parameter in the normal list so we add it to the normal parameter list
 			luaParameters.push_back(sexpToLua(node, argnum));
 
 			node = CDR(node);
 			++argnum;
-		} else {
+		}
+		else {
 			// The varargs part is handled in chunks so that scripts can use the data more easily
 			// Every repeat pattern instance is put into its own table
 			LuaTable varargs_part = LuaTable::create(_action.getLuaState());
@@ -326,6 +322,18 @@ int LuaSEXP::execute(int node) {
 			luaParameters.push_back(varargs_part);
 		}
 	}
+
+	return luaParameters;
+}
+
+int LuaSEXP::execute(int node) {
+	if (!_action.isValid()) {
+		Error(LOCATION,
+			  "Lua SEXP called without a valid action function! A script probably failed to set the action for some reason.");
+		return SEXP_CANT_EVAL;
+	}
+
+	LuaValueList luaParameters = getSEXPArgumentList(node);
 
 	// All parameters are now in LuaValues, time to call our function
 	try {

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -101,10 +101,10 @@ LuaSEXP::LuaSEXP(const SCP_string& name) : DynamicSEXP(name) {
 void LuaSEXP::initialize() {
 	// Nothing to do for this type
 }
-int LuaSEXP::getMinimumArguments() {
+int LuaSEXP::getMinimumArguments() const {
 	return _min_args;
 }
-int LuaSEXP::getMaximumArguments() {
+int LuaSEXP::getMaximumArguments() const {
 	return _max_args;
 }
 std::pair<SCP_string, int> LuaSEXP::getArgumentInternalType(int argnum) const {

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -60,6 +60,8 @@ protected:
 
 	luacpp::LuaFunction getAction() const;
 	int getSexpReturnValue(const luacpp::LuaValueList& retVals) const;
+
+	luacpp::LuaValueList getSEXPArgumentList(int node) const;
 };
 
 }

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -10,6 +10,7 @@
 namespace sexp {
 
 class LuaSEXP : public DynamicSEXP {
+protected:
 	luacpp::LuaFunction _action;
 
 	int _min_args;
@@ -39,9 +40,9 @@ class LuaSEXP : public DynamicSEXP {
 
 	void initialize() override;
 
-	int getMinimumArguments() override;
+	int getMinimumArguments() const override;
 
-	int getMaximumArguments() override;
+	int getMaximumArguments() const override;
 
 	int getArgumentType(int argnum) const override;
 

--- a/code/scripting/api/objs/luaaisexp.cpp
+++ b/code/scripting/api/objs/luaaisexp.cpp
@@ -54,7 +54,7 @@ ADE_VIRTVAR(ActionFrame,
 	"function(ai_helper helper, oswpt | nil arg) => boolean action",
 	"The action function or nil on error")
 {
-	return sexp_function_getset_helper(L, &sexp::LuaAISEXP::setActionFrame, &sexp::LuaAISEXP::getActionFrame);
+	return sexp_function_getset_helper(L, &sexp::LuaAISEXP::setAction, &sexp::LuaAISEXP::getAction);
 }
 
 ADE_VIRTVAR(Achievability,

--- a/code/scripting/api/objs/luaaisexp.cpp
+++ b/code/scripting/api/objs/luaaisexp.cpp
@@ -39,9 +39,10 @@ inline int sexp_function_getset_helper(lua_State* L, void (sexp::LuaAISEXP::*set
 
 ADE_VIRTVAR(ActionEnter,
 	l_LuaAISEXP,
-	"function(ai_helper helper, oswpt | nil arg) => boolean action",
+	"function(ai_helper helper, any... args) => boolean action"
+	"/* If a target parameter is specified, it will be the first object of args in form of an OSWPT type. The following arguments are the additional parameters. The additional parameters are nil if the order is given as a player order. */",
 	"The action of this AI SEXP to be executed once when the AI receives this order. Return true if the AI goal is complete.",
-	"function(ai_helper helper, oswpt | nil arg) => boolean action",
+	"function(ai_helper helper, any... args) => boolean action",
 	"The action function or nil on error")
 {
 	return sexp_function_getset_helper(L, &sexp::LuaAISEXP::setActionEnter, &sexp::LuaAISEXP::getActionEnter);
@@ -49,9 +50,10 @@ ADE_VIRTVAR(ActionEnter,
 
 ADE_VIRTVAR(ActionFrame,
 	l_LuaAISEXP,
-	"function(ai_helper helper, oswpt | nil arg) => boolean action",
+	"function(ai_helper helper, any... args) => boolean action"
+	"/* If a target parameter is specified, it will be the first object of args in form of an OSWPT type. The following arguments are the additional parameters. The additional parameters are nil if the order is given as a player order. */",
 	"The action of this AI SEXP to be executed each frame while active. Return true if the AI goal is complete.",
-	"function(ai_helper helper, oswpt | nil arg) => boolean action",
+	"function(ai_helper helper, any... args) => boolean action",
 	"The action function or nil on error")
 {
 	return sexp_function_getset_helper(L, &sexp::LuaAISEXP::setAction, &sexp::LuaAISEXP::getAction);
@@ -59,9 +61,10 @@ ADE_VIRTVAR(ActionFrame,
 
 ADE_VIRTVAR(Achievability,
 	l_LuaAISEXP,
-	"function(ship ship, oswpt | nil arg) => enumeration achievable",
+	"function(ship ship, any... args) => enumeration achievable"
+	"/* If a target parameter is specified, it will be the first object of args in form of an OSWPT type. The following arguments are the additional parameters. The additional parameters are nil if the order is given as a player order. */",
 	"An optional function that specifies whether the AI mode is achieveable. Return LUAAI_ACHIEVABLE if it can be achieved, LUAAI_NOT_YET_ACHIEVABLE if it can be achieved later and execution should be delayed, and LUAAI_UNACHIEVABLE if the AI mode will never be achievable and should be cancelled. Assumes LUAAI_ACHIEVABLE if not specified.",
-	"function(ship ship, oswpt | nil arg) => enumeration achievable",
+	"function(ship ship, any... args) => enumeration achievable",
 	"The achievability function or nil on error")
 {
 	return sexp_function_getset_helper(L, &sexp::LuaAISEXP::setAchievable, &sexp::LuaAISEXP::getAchievable);


### PR DESCRIPTION
Previously, LuaAI could only use _one_ singular target parameter that had to conform to the OSWPT type.
Now, LuaAI can take any number (including repetitive) of arguments, with the restrictions that all non-target-parameter arguments will be nil if called as a player order, and that they cannot be used within target validation for player orders.