### PR TITLE
Script function for `turnTowardsOrientation`

### DIFF
--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1008,6 +1008,30 @@ ADE_FUNC(turnTowardsPoint,
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(turnTowardsOrientation,
+	l_Ship,
+	"orientation target, [boolean respectDifficulty = true, vector turnrateModifier /* 100% of tabled values in all rotation axes by default */]",
+	"turns the ship towards the specified orientation during this frame",
+	nullptr,
+	nullptr)
+{
+	object_h ship;
+	matrix_h* target;
+	bool diffTurn = true;
+	vec3d* modifier = nullptr;
+
+	int argnum = ade_get_args(L, "oo|bo", l_Ship.Get(&ship), l_Matrix.GetPtr(&target), &diffTurn, l_Vector.GetPtr(&modifier));
+	if (argnum == 0) {
+		return ADE_RETURN_NIL;
+	}
+
+	matrix* mat = target->GetMatrix();
+	vec3d targetVec = mat->vec.fvec + ship.objp->pos;
+
+	ai_turn_towards_vector(&targetVec, ship.objp, nullptr, nullptr, 0.0f, (diffTurn ? 0 : AITTV_FAST), &mat->vec.rvec, modifier);
+	return ADE_RETURN_NIL;
+}
+
 ADE_FUNC(getCenterPosition, l_Ship, nullptr, "Returns the position of the ship's physical center, which may not be the position of the origin of the model", "vector", "World position of the center of the ship, or nil if an error occurred")
 {
 	object_h *shiph;


### PR DESCRIPTION
A simple copy of the same function on `ai_helper`, now usable on plain ships too.