### PR TITLE
Implement renderTechModel() and renderTechModel2() for weapons

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -14,6 +14,7 @@
 
 #include "globalincs/globals.h"
 #include "globalincs/systemvars.h"
+#include "globalincs/pstypes.h"
 
 #include "actions/Program.h"
 #include "decals/decals.h"
@@ -29,6 +30,8 @@
 #include "weapon/swarm.h"
 #include "weapon/trails.h"
 #include "weapon/weapon_flags.h"
+#include "model/modelrender.h"
+#include "render/3d.h"
 
 class object;
 class ship_subsys;


### PR DESCRIPTION
Since Tech model files are not required for weapons, this version exits early and returns false if Tech model does not exist. I partially implemented falling back to the regular POF file if it exists and tech model doesn't, but since in weapons the regular POF file do not have closeup_pos or closeup_zoom defined, it wasn't as good. Thought it was better to stick with just the tech model, which does get those properties defined, as that's what the method is called in the first place.

Resolves #4353 