### PR TITLE
add missing hud_gauges.tbl options

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -4578,6 +4578,12 @@ void load_gauge_lock(gauge_settings* settings)
 		Lockspin_half_w = temp[0];
 		Lockspin_half_h = temp[1];
 	}
+	if(optional_string("Loop Locked Animation:")) {
+		stuff_boolean(&loop_locked_anim);
+	}
+	if(optional_string("Blink Locked Animation:")) {
+		stuff_boolean(&loop_locked_anim);
+	}
 
 	hud_gauge->initBitmaps(fname_lock, fname_spin);
 	hud_gauge->initLoopLockedAnim(loop_locked_anim);


### PR DESCRIPTION
These options for controlling the locking animation are toggled by `$Reticle Style:` but were otherwise not available to HUD gauges.