### PR TITLE
Fix cfread string's handling of null terminated strings

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -1243,11 +1243,13 @@ void cfread_string_len(char *buf,int n, CFILE *file)
 {
 	int len;
 	len = cfread_int(file);
-	Assertion( (len < n), "len: %i, n: %i", len, n );
-	if (len)
+	Assertion( (len <= n), "String cannot fit in buffer, len: %i, buffer: %i", len, n );
+	if (len) {
 		cfread(buf, len, 1, file);
+		Assertion(len != n || buf[len - 1] == 0, "Unterminated string does not fit in buffer");
+	}
 
-	buf[len] = 0;
+	buf[MIN(len, n - 1)] = 0;
 }
 
 SCP_string cfread_string_len(CFILE *file)

--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -1239,17 +1239,17 @@ void cfread_string(char *buf, int n, CFILE *file)
 	} while (c != 0 );
 }
 
-void cfread_string_len(char *buf,int n, CFILE *file)
+void cfread_string_len(char *buf, int buffer_size, CFILE *file)
 {
 	int len;
 	len = cfread_int(file);
-	Assertion( (len <= n), "String cannot fit in buffer, len: %i, buffer: %i", len, n );
+	Assertion( (len <= buffer_size), "String cannot fit in buffer, len: %i, buffer: %i", len, buffer_size);
 	if (len) {
 		cfread(buf, len, 1, file);
-		Assertion(len != n || buf[len - 1] == 0, "Unterminated string does not fit in buffer");
+		Assertion(len != buffer_size || buf[len - 1] == 0, "Unterminated string does not fit in buffer");
 	}
 
-	buf[MIN(len, n - 1)] = 0;
+	buf[MIN(len, buffer_size - 1)] = 0;
 }
 
 SCP_string cfread_string_len(CFILE *file)

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -326,15 +326,17 @@ void cfread_vector(vec3d* vec, CFILE* file, vec3d* deflt = nullptr);
 // to n characters.
 void cfread_string(char *buf,int n, CFILE *file);
 /**
- * @brief Read a fixed length string that is not null-terminated, with the length stored in file
+ * @brief Read a fixed length string that is not null-terminated, with the length stored in file.
  *
+ * If it is not null-terminated, the length of the string *must* be less than the size of the buffer (to make room for one)
+ * 
  * @param buf Pre-allocated array to store string
- * @param n Size of pre-allocated array
+ * @param buffer_size Size of pre-allocated array
  * @param file File to read from
  *
  * @note Appends NULL character to string (buf)
  */
-void cfread_string_len(char *buf,int n, CFILE *file);
+void cfread_string_len(char *buf,int buffer_size, CFILE *file);
 
 /**
  * @brief Read a string from the file where the length is stored in the file

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2581,7 +2581,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 				memset( pm->paths, 0, sizeof(model_path) * pm->n_paths );
 					
 				for (i=0; i<pm->n_paths; i++ )	{
-					cfread_string_len(pm->paths[i].name, MAX_NAME_LEN-1, fp);
+					cfread_string_len(pm->paths[i].name, MAX_NAME_LEN, fp);
 
 					// check for reused path names... not fatal, but maybe problematic
 					for (j = 0; j < i; j++) {
@@ -2592,7 +2592,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 
 					if ( pm->version >= 2002 ) {
 						// store the sub_model name number of the parent
-						cfread_string_len(pm->paths[i].parent_name , MAX_NAME_LEN-1, fp);
+						cfread_string_len(pm->paths[i].parent_name , MAX_NAME_LEN, fp);
 						// get rid of leading '$' char in name
 						if ( pm->paths[i].parent_name[0] == '$' ) {
 							char tmpbuf[MAX_NAME_LEN];


### PR DESCRIPTION
This function stuffs a string from a file into a buffer and requires that the length of the string be strictly less than the size of the buffer it was going in, so that it could forcibly add a 0 after the end of the string and still fit in the buffer. This is a little more conservative than necessary, since it prevents properly null terminated strings of length, say, 32 from fitting in a 32 buffer, because it wants to add another at the end, and even more problematic if the file is trying to 4 byte align and has padded the string up to 32. 
Having a string equal to the size of the buffer is only a problem if it contains no terminator at all, which an assertion has been added for, and in which case it will simply overwrite the last character, otherwise, it is safe simply to add the terminator after the string within the buffer in case it didn't come with one.

Also fixes some mistaken BUFFER_SIZE - 1 arguments to this function, the argument should always match exactly the actual length of the buffer being used.