### PR TITLE
Virtual / Modular POFs

### DIFF
--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -16,24 +16,24 @@
 #include <unordered_set>
 #include <vector>
 
-template< typename T >
-using SCP_vector = std::vector< T, std::allocator< T > >;
+template <typename T>
+using SCP_vector = std::vector<T, std::allocator<T>>;
 
-template< typename T >
+template <typename T>
 bool SCP_vector_contains(SCP_vector<T>& vector, T item) {
 	return std::find(vector.begin(), vector.end(), item) != vector.end();
 }
 
-template< typename T >
-using SCP_list = std::list< T, std::allocator< T > >;
+template <typename T>
+using SCP_list = std::list<T, std::allocator<T>>;
 
 
 extern std::locale SCP_default_locale;
 
-template< class charT >
+template <class charT>
 charT SCP_toupper(charT ch) { return std::toupper(ch, SCP_default_locale); }
 
-template< class charT >
+template <class charT>
 charT SCP_tolower(charT ch) { return std::tolower(ch, SCP_default_locale); }
 
 typedef std::basic_string<char, std::char_traits<char>, std::allocator<char> > SCP_string;
@@ -52,23 +52,23 @@ extern void SCP_tolower(char *str);
 extern void SCP_toupper(char *str);
 
 
-template< typename T, typename U >
-using SCP_map = std::map<T, U, std::less<T>, std::allocator<std::pair<const T, U> > >;
+template <typename T, typename U>
+using SCP_map = std::map<T, U, std::less<T>, std::allocator<std::pair<const T, U>>>;
 
-template< typename T, typename U >
-using SCP_multimap = std::multimap<T, U, std::less<T>, std::allocator<std::pair<const T, U> > >;
+template <typename T, typename U>
+using SCP_multimap = std::multimap<T, U, std::less<T>, std::allocator<std::pair<const T, U>>>;
 
-template< typename T >
-using SCP_queue = std::queue< T, std::deque< T, std::allocator< T > > >;
+template <typename T>
+using SCP_queue = std::queue<T, std::deque<T, std::allocator<T>>>;
 
-template< typename T >
-using SCP_deque = std::deque< T, std::allocator< T > >;
+template <typename T>
+using SCP_deque = std::deque<T, std::allocator<T>>;
 
 template <typename T>
 using SCP_set = std::set<T, std::less<T>, std::allocator<T>>;
 
 #if __cplusplus < 201402L
-template <class T, bool>
+template<class T, bool>
 struct enum_hasher_util {
 	inline size_t operator()(const T& elem) { return std::hash<T>()(elem); }
 };

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <locale>
 #include <map>
+#include <memory>
 #include <queue>
 #include <sstream>
 #include <string>
@@ -154,5 +155,15 @@ using SCP_unordered_map = std::unordered_map<Key, T, Hash, KeyEqual, std::alloca
 
 template <typename Key, typename Hash = SCP_hash<Key>, typename KeyEqual = std::equal_to<Key>>
 using SCP_unordered_set = std::unordered_set<Key, Hash, KeyEqual, std::allocator<Key>>;
+
+template <typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args) {
+	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template <typename T, typename... Args>
+std::shared_ptr<T> make_shared(Args&&... args) {
+	return std::shared_ptr<T>(new T(std::forward<Args>(args)...));
+}
 
 #endif // _VMALLOCATOR_H_INCLUDED_

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -157,13 +157,21 @@ template <typename Key, typename Hash = SCP_hash<Key>, typename KeyEqual = std::
 using SCP_unordered_set = std::unordered_set<Key, Hash, KeyEqual, std::allocator<Key>>;
 
 template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args) {
+typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type make_unique(Args&&... args) {
 	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+template <typename T, typename... Args>
+typename std::enable_if<std::is_array<T>::value, std::unique_ptr<T>>::type make_unique(std::size_t n) {
+	return std::unique_ptr<T>(new typename std::remove_extent<T>::type[n]());
 }
 
 template <typename T, typename... Args>
-std::shared_ptr<T> make_shared(Args&&... args) {
+typename std::enable_if<!std::is_array<T>::value, std::shared_ptr<T>>::type make_shared(Args&&... args) {
 	return std::shared_ptr<T>(new T(std::forward<Args>(args)...));
+}
+template <typename T, typename... Args>
+typename std::enable_if<std::is_array<T>::value, std::shared_ptr<T>>::type make_shared(std::size_t n) {
+	return std::shared_ptr<T>(new typename std::remove_extent<T>::type[n]());
 }
 
 #endif // _VMALLOCATOR_H_INCLUDED_

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <queue>
+#include <set>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -62,6 +63,9 @@ using SCP_queue = std::queue< T, std::deque< T, std::allocator< T > > >;
 
 template< typename T >
 using SCP_deque = std::deque< T, std::allocator< T > >;
+
+template <typename T>
+using SCP_set = std::set<T, std::less<T>, std::allocator<T>>;
 
 #if __cplusplus < 201402L
 template <class T, bool>

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -887,31 +887,27 @@ struct model_read_deferred_tasks {
 		int gun_subobj_nr;
 		vec3d turretNorm;
 		int n_slots;
-		std::vector<vec3d> firingpoints;
+		SCP_vector<vec3d> firingpoints;
 	};
 
 	struct texture_idx_replace {
-		std::map<int, int> replacementIds;
+		SCP_map<int, int> replacementIds;
 	};
 
 	//Key: Subsystem Name
-	std::unordered_map<SCP_string, model_subsystem_parse> model_subsystems;
+	SCP_unordered_map<SCP_string, model_subsystem_parse, SCP_string_lcase_hash, SCP_string_lcase_equal_to> model_subsystems;
 	//Key: Subsystem Name
-	std::unordered_map<SCP_string, engine_subsystem_parse> engine_subsystems;
+	SCP_unordered_map<SCP_string, engine_subsystem_parse, SCP_string_lcase_hash, SCP_string_lcase_equal_to> engine_subsystems;
 	//Key: Parent Subobject Nr
-	std::unordered_map<int, weapon_subsystem_parse> weapons_subsystems;
+	SCP_unordered_map<int, weapon_subsystem_parse> weapons_subsystems;
 	//Key: Subobject Nr
-	std::unordered_map<int, texture_idx_replace> texture_replacements;
+	SCP_unordered_map<int, texture_idx_replace> texture_replacements;
 };
 
 class model_parse_depth {
-	std::unordered_map<SCP_string, int> depth{};
+	SCP_unordered_map<SCP_string, int, SCP_string_lcase_hash, SCP_string_lcase_equal_to> depth{};
 public:
-	model_parse_depth() = default;
-	model_parse_depth(const model_parse_depth&) = default;
-	model_parse_depth& operator=(const model_parse_depth&) = default;
-	inline int& operator[](SCP_string name) {
-		SCP_tolower(name);
+	inline int& operator[](const SCP_string& name) {
 		return depth[name];
 	}
 };
@@ -967,7 +963,7 @@ void model_delete_instance(int model_instance_num);
 // Goober5000
 void model_load_texture(polymodel *pm, int i, char *file);
 
-std::set<int> model_get_textures_used(polymodel* pm, int submodel);
+SCP_set<int> model_get_textures_used(polymodel* pm, int submodel);
 
 // Returns a pointer to the polymodel structure for model 'n'
 polymodel *model_get(int model_num);
@@ -1441,7 +1437,7 @@ void model_page_in_textures(int modelnum, int ship_info_index = -1);
 // given a model, unload all of its textures
 void model_page_out_textures(int model_num, bool release = false);
 // given a model, without respect to usage state of the polymodel
-void model_page_out_textures(polymodel* pm, bool release = false, const std::set<int>& skipTextures = {}, const std::set<int>& skipGlowBanks = {});
+void model_page_out_textures(polymodel* pm, bool release = false, const SCP_set<int>& skipTextures = {}, const SCP_set<int>& skipGlowBanks = {});
 
 void model_do_intrinsic_motions(object *objp);
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1176,7 +1176,7 @@ void submodel_get_cross_sectional_avg_pos(int model_num, int submodel_num, float
 void submodel_get_cross_sectional_random_pos(int model_num, int submodel_num, float z_slice_pos, vec3d* pos);
   
 extern int model_find_submodel_index(int modelnum, const char *name);
-extern int model_find_submodel_index(const polymodel& pm, const char* name);
+extern int model_find_submodel_index(const polymodel* pm, const char* name);
 
 // gets the index into the docking_bays array of the specified type of docking point
 // Returns the index.  second functions returns the index of the docking bay with

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -909,7 +909,7 @@ void model_free_all();
 void model_instance_free_all();
 
 // Loads a model from disk and returns the model number it loaded into.
-int model_load(const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0);
+int model_load(const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0, int depth = 0);
 
 int model_create_instance(int objnum, int model_num);
 void model_delete_instance(int model_instance_num);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -868,6 +868,13 @@ public:
 	vertex_buffer detail_buffers[MAX_MODEL_DETAIL_LEVELS];
 };
 
+struct model_subsystem_parse {
+	int subobj_nr;
+	float rad;
+	vec3d pnt;
+	SCP_string props;
+};
+
 // Iterate over a submodel tree, starting at the given submodel root node, and running the given function for each node.  The function's signature should be:
 //
 // void func(int submodel, int level, bool isLeaf);
@@ -909,7 +916,7 @@ void model_free_all();
 void model_instance_free_all();
 
 // Loads a model from disk and returns the model number it loaded into.
-int model_load(const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0, int depth = 0);
+int model_load(const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0);
 
 int model_create_instance(int objnum, int model_num);
 void model_delete_instance(int model_instance_num);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -868,11 +868,32 @@ public:
 	vertex_buffer detail_buffers[MAX_MODEL_DETAIL_LEVELS];
 };
 
-struct model_subsystem_parse {
-	int subobj_nr;
-	float rad;
-	vec3d pnt;
-	SCP_string props;
+struct subsystem_parse_list {
+	struct model_subsystem_parse {
+		int subobj_nr;
+		float rad;
+		vec3d pnt;
+		SCP_string props;
+	};
+
+	struct engine_subsystem_parse {
+		int thruster_nr;
+	};
+
+	struct weapon_subsystem_parse {
+		int turret_nr;
+		int gun_subobj_nr;
+		vec3d turretNorm;
+		int n_slots;
+		std::vector<vec3d> firingpoints;
+	};
+
+	//Key: Subsystem Name
+	std::unordered_map<SCP_string, model_subsystem_parse> model_subsystems;
+	//Key: Subsystem Name
+	std::unordered_map<SCP_string, engine_subsystem_parse> engine_subsystems;
+	//Key: Parent Subobject Nr
+	std::unordered_map<int, weapon_subsystem_parse> weapons_subsystems;
 };
 
 // Iterate over a submodel tree, starting at the given submodel root node, and running the given function for each node.  The function's signature should be:

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -902,13 +902,7 @@ struct model_read_deferred_tasks {
 	SCP_unordered_map<int, texture_idx_replace> texture_replacements;
 };
 
-class model_parse_depth {
-	SCP_unordered_map<SCP_string, int, SCP_string_lcase_hash, SCP_string_lcase_equal_to> depth{};
-public:
-	inline int& operator[](const SCP_string& name) {
-		return depth[name];
-	}
-};
+using model_parse_depth = SCP_unordered_map<SCP_string, int, SCP_string_lcase_hash, SCP_string_lcase_equal_to>;
 
 // Iterate over a submodel tree, starting at the given submodel root node, and running the given function for each node.  The function's signature should be:
 //
@@ -1182,6 +1176,7 @@ void submodel_get_cross_sectional_avg_pos(int model_num, int submodel_num, float
 void submodel_get_cross_sectional_random_pos(int model_num, int submodel_num, float z_slice_pos, vec3d* pos);
   
 extern int model_find_submodel_index(int modelnum, const char *name);
+extern int model_find_submodel_index(const polymodel& pm, const char* name);
 
 // gets the index into the docking_bays array of the specified type of docking point
 // Returns the index.  second functions returns the index of the docking bay with

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -23,6 +23,8 @@
 #include "object/object.h"
 #include "ship/ship_flags.h"
 
+#include <set>
+
 class object;
 class ship_info;
 class model_render_params;
@@ -931,6 +933,8 @@ void model_init();
 
 // call to unload a model (works like bm_unload()), "force" SHOULD NEVER BE SET outside of modelread.cpp!!!!
 void model_unload(int modelnum, int force = 0);
+// Directly frees polymodel data, regardless of state and usage in ship classes. Use with caution. Will not clear textures
+void model_free(polymodel* pm);
 
 // Call to free all existing models
 void model_free_all();
@@ -944,6 +948,8 @@ void model_delete_instance(int model_instance_num);
 
 // Goober5000
 void model_load_texture(polymodel *pm, int i, char *file);
+
+std::set<int> model_get_textures_used(polymodel* pm, int submodel);
 
 // Returns a pointer to the polymodel structure for model 'n'
 polymodel *model_get(int model_num);
@@ -1416,6 +1422,8 @@ void model_page_in_textures(int modelnum, int ship_info_index = -1);
 
 // given a model, unload all of its textures
 void model_page_out_textures(int model_num, bool release = false);
+// given a model, without respect to usage state of the polymodel
+void model_page_out_textures(polymodel* pm, bool release = false, const std::set<int>& skipTextures = {}, const std::set<int>& skipGlowBanks = {});
 
 void model_do_intrinsic_motions(object *objp);
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -23,8 +23,6 @@
 #include "object/object.h"
 #include "ship/ship_flags.h"
 
-#include <set>
-
 class object;
 class ship_info;
 class model_render_params;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -870,7 +870,7 @@ public:
 	vertex_buffer detail_buffers[MAX_MODEL_DETAIL_LEVELS];
 };
 
-struct subsystem_parse_list {
+struct model_read_deferred_tasks {
 	struct model_subsystem_parse {
 		int subobj_nr;
 		float rad;
@@ -890,12 +890,18 @@ struct subsystem_parse_list {
 		std::vector<vec3d> firingpoints;
 	};
 
+	struct texture_idx_replace {
+		std::map<int, int> replacementIds;
+	};
+
 	//Key: Subsystem Name
 	std::unordered_map<SCP_string, model_subsystem_parse> model_subsystems;
 	//Key: Subsystem Name
 	std::unordered_map<SCP_string, engine_subsystem_parse> engine_subsystems;
 	//Key: Parent Subobject Nr
 	std::unordered_map<int, weapon_subsystem_parse> weapons_subsystems;
+	//Key: Subobject Nr
+	std::unordered_map<int, texture_idx_replace> texture_replacements;
 };
 
 // Iterate over a submodel tree, starting at the given submodel root node, and running the given function for each node.  The function's signature should be:

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -904,6 +904,18 @@ struct model_read_deferred_tasks {
 	std::unordered_map<int, texture_idx_replace> texture_replacements;
 };
 
+class model_parse_depth {
+	std::unordered_map<SCP_string, int> depth{};
+public:
+	model_parse_depth() = default;
+	model_parse_depth(const model_parse_depth&) = default;
+	model_parse_depth& operator=(const model_parse_depth&) = default;
+	inline int& operator[](SCP_string name) {
+		SCP_tolower(name);
+		return depth[name];
+	}
+};
+
 // Iterate over a submodel tree, starting at the given submodel root node, and running the given function for each node.  The function's signature should be:
 //
 // void func(int submodel, int level, bool isLeaf);

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -3428,6 +3428,6 @@ void bsp_polygon_data::replace_textures_used(const std::map<int, int>& replaceme
 }
 
 std::set<int> model_get_textures_used(polymodel* pm, int submodel) {
-	auto polies = std::make_unique<const bsp_polygon_data>(pm->submodel[submodel].bsp_data);
+	auto polies = make_unique<const bsp_polygon_data>(pm->submodel[submodel].bsp_data);
 	return polies->get_textures_used();
 }

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1635,7 +1635,7 @@ void model_page_out_textures(int model_num, bool release)
 	model_page_out_textures(pm, release);
 }
 
-void model_page_out_textures(polymodel* pm, bool release, const std::set<int>& skipTextures, const std::set<int>& skipGlowBanks)
+void model_page_out_textures(polymodel* pm, bool release, const SCP_set<int>& skipTextures, const SCP_set<int>& skipGlowBanks)
 {
 	int i, j;
 	for (i = 0; i < pm->n_textures; i++) {

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -116,8 +116,8 @@ public:
 	void generate_triangles(int texture, vertex *vert_ptr, vec3d* norm_ptr);
 	void generate_lines(int texture, vertex *vert_ptr);
 
-	std::set<int> get_textures_used() const;
-	void replace_textures_used(const std::map<int, int>& replacementMap);
+	SCP_set<int> get_textures_used() const;
+	void replace_textures_used(const SCP_map<int, int>& replacementMap);
 };
 
 /**
@@ -3407,14 +3407,14 @@ void bsp_polygon_data::generate_lines(int texture, vertex *vert_ptr)
 	}
 }
 
-std::set<int> bsp_polygon_data::get_textures_used() const {
-	std::set<int> textures;
+SCP_set<int> bsp_polygon_data::get_textures_used() const {
+	SCP_set<int> textures;
 	for (const auto& poly : Polygons)
 		textures.emplace(poly.texture);
 	return textures;
 }
 
-void bsp_polygon_data::replace_textures_used(const std::map<int, int>& replacementMap) {
+void bsp_polygon_data::replace_textures_used(const SCP_map<int, int>& replacementMap) {
 	for (auto& poly : Polygons) {
 		auto it = replacementMap.find(poly.texture);
 		if (it != replacementMap.end()) {
@@ -3427,7 +3427,7 @@ void bsp_polygon_data::replace_textures_used(const std::map<int, int>& replaceme
 	}
 }
 
-std::set<int> model_get_textures_used(polymodel* pm, int submodel) {
+SCP_set<int> model_get_textures_used(polymodel* pm, int submodel) {
 	auto polies = make_unique<const bsp_polygon_data>(pm->submodel[submodel].bsp_data);
 	return polies->get_textures_used();
 }

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1651,21 +1651,21 @@ void model_page_out_textures(polymodel* pm, bool release, const SCP_set<int>& sk
 		glow_point_bank* bank = &pm->glow_point_banks[j];
 
 		if (bank->glow_bitmap >= 0) {
-			//	if (release) {
-			//		bm_release(bank->glow_bitmap);
-			//		bank->glow_bitmap = -1;
-			//	} else {
-			bm_unload(bank->glow_bitmap);
-			//	}
+		//	if (release) {
+		//		bm_release(bank->glow_bitmap);
+		//		bank->glow_bitmap = -1;
+		//	} else {
+				bm_unload(bank->glow_bitmap);
+		//	}
 		}
 
 		if (bank->glow_neb_bitmap >= 0) {
-			//	if (release) {
-			//		bm_release(bank->glow_neb_bitmap);
-			//		bank->glow_neb_bitmap = -1;
-			//	} else {
-			bm_unload(bank->glow_neb_bitmap);
-			//	}
+		//	if (release) {
+		//		bm_release(bank->glow_neb_bitmap);
+		//		bank->glow_neb_bitmap = -1;
+		//	} else {
+				bm_unload(bank->glow_neb_bitmap);
+		//	}
 		}
 	}
 }
@@ -3428,6 +3428,5 @@ void bsp_polygon_data::replace_textures_used(const SCP_map<int, int>& replacemen
 }
 
 SCP_set<int> model_get_textures_used(polymodel* pm, int submodel) {
-	auto polies = make_unique<const bsp_polygon_data>(pm->submodel[submodel].bsp_data);
-	return polies->get_textures_used();
+	return bsp_polygon_data{ pm->submodel[submodel].bsp_data }.get_textures_used();
 }

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1546,9 +1546,7 @@ void resolve_submodel_index(const polymodel *pm, const char *requester, const ch
 	submodel_index = -1;
 }
 
-
-//reads a binary file containing a 3d model
-int read_model_file(polymodel * pm, const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror, const SCP_string& searchname)
+int read_model_file_no_subsys(polymodel * pm, const char* filename, int n_subsystems, model_subsystem * subsystems, int ferror, const SCP_string & searchname)
 {
 	CFILE *fp;
 	int version;
@@ -2957,6 +2955,13 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 	return 1;
 }
 
+//reads a binary file containing a 3d model
+int read_model_file(polymodel* pm, const char* filename, int n_subsystems, model_subsystem* subsystems, int ferror, const SCP_string& searchname)
+{
+	return read_model_file_no_subsys(pm, filename, n_subsystems, subsystems, ferror, searchname);
+}
+
+
 //Goober
 void model_load_texture(polymodel *pm, int i, char *file)
 {
@@ -3139,7 +3144,7 @@ void model_load_texture(polymodel *pm, int i, char *file)
 }
 
 //returns the number of this model
-int model_load(const  char *filename, int n_subsystems, model_subsystem *subsystems, int ferror, int duplicate, int depth)
+int model_load(const  char* filename, int n_subsystems, model_subsystem* subsystems, int ferror, int duplicate, int depth)
 {
 	int i, num;
 	polymodel *pm = NULL;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -681,7 +681,7 @@ void model_copy_subsystems( int n_subsystems, model_subsystem *d_sp, model_subsy
 }
 
 // routine to get/set subsystem information
-static void set_subsystem_info(int model_num, model_subsystem *subsystemp, char *props, char *dname)
+void set_subsystem_info(int model_num, model_subsystem *subsystemp, char *props, char *dname)
 {
 	char *p;
 	char buf[64];

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5048,17 +5048,21 @@ void model_instance_add_arc(polymodel *pm, polymodel_instance *pmi, int sub_mode
 	}
 }
 
-int model_find_submodel_index(int modelnum, const char *name)
-{
-	auto pm = model_get(modelnum);
-
-	for (int i = 0; i < pm->n_models; i++)
+int model_find_submodel_index(const polymodel& pm, const char* name) {
+	for (int i = 0; i < pm.n_models; i++)
 	{
-		if (!stricmp(pm->submodel[i].name, name))
+		if (!stricmp(pm.submodel[i].name, name))
 			return i;
 	}
 
 	return -1;
+}
+
+int model_find_submodel_index(int modelnum, const char *name)
+{
+	auto pm = model_get(modelnum);
+
+	return model_find_submodel_index(*pm, name);
 }
 
 // function to return an index into the docking_bays array which matches the criteria passed

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5048,10 +5048,10 @@ void model_instance_add_arc(polymodel *pm, polymodel_instance *pmi, int sub_mode
 	}
 }
 
-int model_find_submodel_index(const polymodel& pm, const char* name) {
-	for (int i = 0; i < pm.n_models; i++)
+int model_find_submodel_index(const polymodel* pm, const char* name) {
+	for (int i = 0; i < pm->n_models; i++)
 	{
-		if (!stricmp(pm.submodel[i].name, name))
+		if (!stricmp(pm->submodel[i].name, name))
 			return i;
 	}
 
@@ -5062,7 +5062,7 @@ int model_find_submodel_index(int modelnum, const char *name)
 {
 	auto pm = model_get(modelnum);
 
-	return model_find_submodel_index(*pm, name);
+	return model_find_submodel_index(pm, name);
 }
 
 // function to return an index into the docking_bays array which matches the criteria passed

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2938,7 +2938,7 @@ int read_and_process_model_file(polymodel* pm, const char* filename, int n_subsy
 	int status = read_model_file(pm, filename, ferror, deferredTasks);
 
 	for (const auto& subsystem : deferredTasks.model_subsystems) {
-		auto propBuffer = std::make_unique<char[]>(subsystem.second.props.size() + 1);
+		auto propBuffer = make_unique<char[]>(subsystem.second.props.size() + 1);
 		strncpy(propBuffer.get(), subsystem.second.props.c_str(), subsystem.second.props.size() + 1);
 
 		do_new_subsystem(n_subsystems, subsystems, subsystem.second.subobj_nr, subsystem.second.rad, &subsystem.second.pnt, propBuffer.get(), subsystem.first.c_str(), pm->id);		
@@ -3006,7 +3006,7 @@ int read_and_process_model_file(polymodel* pm, const char* filename, int n_subsy
 					break;
 				}
 			}
-			if ((snum == n_subsystems)) {
+			if (snum == n_subsystems) {
 				nprintf(("Warning", "Turret submodel %i not found for turret %i in model %s\n", subsystem.first, subsystem.second.turret_nr, pm->filename));
 			}
 		}

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2917,7 +2917,7 @@ int read_model_file_no_subsys(polymodel * pm, const char* filename, int ferror, 
 	return 1;
 }
 
-int read_model_file(polymodel* pm, const char* filename, int ferror, model_read_deferred_tasks& deferredTasks, int depth = 0)
+int read_model_file(polymodel* pm, const char* filename, int ferror, model_read_deferred_tasks& deferredTasks, model_parse_depth depth = {})
 {
 	int status = 0;
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1918,9 +1918,7 @@ int read_model_file_no_subsys(polymodel * pm, const char* filename, int ferror, 
 
 					get_user_prop_value(p+9, type);
 					if ( !stricmp(type, "subsystem") ) {	// if we have a subsystem, put it into the list!
-						SCP_string name = sm->name;
-						SCP_tolower(name);
-						subsystemParseList.model_subsystems.emplace(name, model_read_deferred_tasks::model_subsystem_parse{ n, sm->rad, sm->offset, props });
+						subsystemParseList.model_subsystems.emplace(sm->name, model_read_deferred_tasks::model_subsystem_parse{ n, sm->rad, sm->offset, props });
 					} else {
 						if ( !stricmp(type, "no_rotate") || !stricmp(type, "no_movement") ) {
 							// mark those submodels which should not move - i.e., those with no subsystem
@@ -2529,9 +2527,7 @@ int read_model_file_no_subsys(polymodel * pm, const char* filename, int ferror, 
 
 									nprintf(("wash", "Ship %s with engine wash associated with subsys %s\n", filename, engine_subsys_name));
 
-									SCP_string name = engine_subsys_name;
-									SCP_tolower(name);
-									subsystemParseList.engine_subsystems.emplace(name, model_read_deferred_tasks::engine_subsystem_parse{ i });
+									subsystemParseList.engine_subsystems.emplace(engine_subsys_name, model_read_deferred_tasks::engine_subsystem_parse{ i });
 								}
 							}
 						}
@@ -2621,17 +2617,13 @@ int read_model_file_no_subsys(polymodel * pm, const char* filename, int ferror, 
 
 						get_user_prop_value(p+9, type);
 						if ( !stricmp(type, "subsystem") ) {	// if we have a subsystem, put it into the list!
-							SCP_string namelower = &name[1];
-							SCP_tolower(namelower);
-							subsystemParseList.model_subsystems.emplace(namelower, model_read_deferred_tasks::model_subsystem_parse{ -1, radius, pnt, props_spcl }); // skip the first '$' character of the name
+							subsystemParseList.model_subsystems.emplace(&name[1], model_read_deferred_tasks::model_subsystem_parse{ -1, radius, pnt, props_spcl }); // skip the first '$' character of the name
 						} else if ( !stricmp(type, "shieldpoint") ) {
 							pm->shield_points.push_back(pnt);
 						}
 					} else if (in(name, "$enginelarge") || in(name, "$enginehuge")) 
 					{
-						SCP_string namelower = &name[1];
-						SCP_tolower(namelower);
-						subsystemParseList.model_subsystems.emplace(namelower, model_read_deferred_tasks::model_subsystem_parse{ -1, radius, pnt, props_spcl }); // skip the first '$' character of the name	
+						subsystemParseList.model_subsystems.emplace(&name[1], model_read_deferred_tasks::model_subsystem_parse{ -1, radius, pnt, props_spcl }); // skip the first '$' character of the name	
 					} else {
 						nprintf(("Warning", "Unknown special object type %s while reading model %s\n", name, pm->filename));
 					}					

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1918,7 +1918,9 @@ int read_model_file_no_subsys(polymodel * pm, const char* filename, int ferror, 
 
 					get_user_prop_value(p+9, type);
 					if ( !stricmp(type, "subsystem") ) {	// if we have a subsystem, put it into the list!
-						subsystemParseList.model_subsystems.emplace(sm->name, model_read_deferred_tasks::model_subsystem_parse{ n, sm->rad, sm->offset, props });
+						SCP_string name = sm->name;
+						SCP_tolower(name);
+						subsystemParseList.model_subsystems.emplace(name, model_read_deferred_tasks::model_subsystem_parse{ n, sm->rad, sm->offset, props });
 					} else {
 						if ( !stricmp(type, "no_rotate") || !stricmp(type, "no_movement") ) {
 							// mark those submodels which should not move - i.e., those with no subsystem
@@ -2527,7 +2529,9 @@ int read_model_file_no_subsys(polymodel * pm, const char* filename, int ferror, 
 
 									nprintf(("wash", "Ship %s with engine wash associated with subsys %s\n", filename, engine_subsys_name));
 
-									subsystemParseList.engine_subsystems.emplace(engine_subsys_name, model_read_deferred_tasks::engine_subsystem_parse{ i });
+									SCP_string name = engine_subsys_name;
+									SCP_tolower(name);
+									subsystemParseList.engine_subsystems.emplace(name, model_read_deferred_tasks::engine_subsystem_parse{ i });
 								}
 							}
 						}
@@ -2617,12 +2621,17 @@ int read_model_file_no_subsys(polymodel * pm, const char* filename, int ferror, 
 
 						get_user_prop_value(p+9, type);
 						if ( !stricmp(type, "subsystem") ) {	// if we have a subsystem, put it into the list!
-							subsystemParseList.model_subsystems.emplace(&name[1], model_read_deferred_tasks::model_subsystem_parse{ -1, radius, pnt, props_spcl }); // skip the first '$' character of the name
+							SCP_string namelower = &name[1];
+							SCP_tolower(namelower);
+							subsystemParseList.model_subsystems.emplace(namelower, model_read_deferred_tasks::model_subsystem_parse{ -1, radius, pnt, props_spcl }); // skip the first '$' character of the name
 						} else if ( !stricmp(type, "shieldpoint") ) {
 							pm->shield_points.push_back(pnt);
 						}
-					} else if (in(name, "$enginelarge") || in(name, "$enginehuge")) {
-						subsystemParseList.model_subsystems.emplace(&name[1], model_read_deferred_tasks::model_subsystem_parse{ -1, radius, pnt, props_spcl }); // skip the first '$' character of the name	
+					} else if (in(name, "$enginelarge") || in(name, "$enginehuge")) 
+					{
+						SCP_string namelower = &name[1];
+						SCP_tolower(namelower);
+						subsystemParseList.model_subsystems.emplace(namelower, model_read_deferred_tasks::model_subsystem_parse{ -1, radius, pnt, props_spcl }); // skip the first '$' character of the name	
 					} else {
 						nprintf(("Warning", "Unknown special object type %s while reading model %s\n", name, pm->filename));
 					}					

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2570,7 +2570,7 @@ int read_model_file_no_subsys(polymodel * pm, const char* filename, int ferror, 
 					cfread_vector(&temp_vec, fp);
 					vm_vec_normalize_safe(&temp_vec);
 					n_slots = cfread_int(fp);
-					std::vector<vec3d> firingpoints;
+					SCP_vector<vec3d> firingpoints;
 					for (j = 0; j < n_slots; j++) {
 						if (j < MAX_TFP) {
 							vec3d firepoint;

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -15,7 +15,7 @@ static std::unordered_map<SCP_string, std::function<std::unique_ptr<VirtualPOFOp
 /*
 * forward declares for internal modelread functions
 */
-extern void set_subsystem_info(int model_num, model_subsystem* subsystemp, char* props, char* dname);
+extern void set_subsystem_info(int model_num, model_subsystem* subsystemp, const char* props, const char* dname);
 
 
 
@@ -29,7 +29,7 @@ bool model_exists(const SCP_string& filename) {
 	return cf_exists_full(filename.c_str(), CF_TYPE_MODELS);
 }
 
-bool model_load_virtual(polymodel* pm, const SCP_string& filename, int depth) {
+bool model_read_virtual(polymodel* pm, const SCP_string& filename, int depth) {
 	return false;
 }
 

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -1,0 +1,49 @@
+#include "modelreplace.h"
+
+#include "cfile/cfile.h"
+
+#include <map>
+#include <vector>
+
+
+std::unordered_map<SCP_string, std::vector<VirtualPOFDefinition>> virtual_pofs;
+
+bool model_exists(const SCP_string& filename) {
+	auto it = virtual_pofs.find(filename);
+	if (it != virtual_pofs.end() && !it->second.empty()) {
+		return true;
+	}
+
+	return cf_exists_full(filename.c_str(), CF_TYPE_MODELS);
+}
+
+bool model_load_virtual(polymodel* pm, const SCP_string& filename, int depth) {
+	return false;
+}
+
+void parse_virtual_pof_table(const char* filename) {
+	try
+	{
+		read_file_text(filename, CF_TYPE_TABLES);
+		reset_parse();
+
+		
+	}
+	catch (const parse::ParseException& e)
+	{
+		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", filename, e.what()));
+		return;
+	}
+}
+
+void virtual_pof_init() {
+	if (cf_exists_full("virtual_pofs.tbl", CF_TYPE_TABLES))
+		parse_virtual_pof_table("virtual_pofs.tbl");
+
+	parse_modular_table(NOX("*-pof.tbm"), parse_virtual_pof_table);
+}
+
+
+void VirtualPOFOperationReplaceProps::process(polymodel* pm) const {
+
+}

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -170,8 +170,8 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 	SCP_set<int> keepTextures;
 	read_model_file(appendingPM, appendingPOF.c_str(), 0, appendingSubsys, depth);
 
-	int src_subobj_no = model_find_submodel_index(*appendingPM, subobjNameSrc.c_str());
-	int dest_subobj_no = model_find_submodel_index(*appendingPM, subobjNameDest.c_str());
+	int src_subobj_no = model_find_submodel_index(appendingPM, subobjNameSrc.c_str());
+	int dest_subobj_no = model_find_submodel_index(appendingPM, subobjNameDest.c_str());
 
 	if (src_subobj_no >= 0 && dest_subobj_no >= 0) {
 		create_family_tree(pm);
@@ -185,13 +185,13 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 		if (copyChildren) {
 			model_iterate_submodel_tree(appendingPM, src_subobj_no, [&to_copy_submodels, &has_name_collision, pm, appendingPM](int submodel, int /*level*/, bool /*isLeaf*/) {
 				to_copy_submodels.emplace_back(submodel);
-				if(model_find_submodel_index(*pm, appendingPM->submodel[submodel].name) != -1)
+				if(model_find_submodel_index(pm, appendingPM->submodel[submodel].name) != -1)
 					has_name_collision = true;
 				});
 		}
 		else {
 			to_copy_submodels.emplace_back(src_subobj_no);
-			if (model_find_submodel_index(*pm, appendingPM->submodel[src_subobj_no].name) != -1)
+			if (model_find_submodel_index(pm, appendingPM->submodel[src_subobj_no].name) != -1)
 				has_name_collision = true;
 		}
 
@@ -352,7 +352,7 @@ VirtualPOFOperationChangeData::VirtualPOFOperationChangeData() {
 }
 
 void VirtualPOFOperationChangeData::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth /*depth*/) const {
-	int subobj_no = model_find_submodel_index(*pm, submodel.c_str());
+	int subobj_no = model_find_submodel_index(pm, submodel.c_str());
 
 	if (subobj_no == -1) {
 		Warning(LOCATION, "Failed to find submodel to change data of. Returning original POF");

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -129,15 +129,15 @@ static void change_submodel_numbers(polymodel* pm, int source, int dest) {
 	for (int i = 0; i < pm->n_models; i++) {
 		auto& submodel = pm->submodel[i];
 		for (auto& detail : submodel.details)
-			REPLACE_IF_EQ(detail, source, dest);
-		REPLACE_IF_EQ(submodel.first_child, source, dest);
-		REPLACE_IF_EQ(submodel.i_replace, source, dest);
+			REPLACE_IF_EQ(detail);
+		REPLACE_IF_EQ(submodel.first_child);
+		REPLACE_IF_EQ(submodel.i_replace);
 		for (auto& debris : submodel.live_debris)
-			REPLACE_IF_EQ(debris, source, dest);
-		REPLACE_IF_EQ(submodel.look_at_submodel, source, dest);
-		REPLACE_IF_EQ(submodel.my_replacement, source, dest);
-		REPLACE_IF_EQ(submodel.next_sibling, source, dest);
-		REPLACE_IF_EQ(submodel.parent, source, dest);
+			REPLACE_IF_EQ(debris);
+		REPLACE_IF_EQ(submodel.look_at_submodel);
+		REPLACE_IF_EQ(submodel.my_replacement);
+		REPLACE_IF_EQ(submodel.next_sibling);
+		REPLACE_IF_EQ(submodel.parent);
 	}
 }
 

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -157,7 +157,7 @@ VirtualPOFOperationAddSubmodel::VirtualPOFOperationAddSubmodel() {
 	stuff_string(subobjNameSrc, F_NAME);
 
 	if (optional_string("+Copy Children:")) {
-		stuff_boolean(&copyChildred);
+		stuff_boolean(&copyChildren);
 	}
 
 	if (optional_string("$Rename Subobjects:")) {
@@ -195,7 +195,7 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 
 		std::vector<int> to_copy_submodels;
 		bool has_name_collision = false;
-		if (copyChildred) {
+		if (copyChildren) {
 			model_iterate_submodel_tree(appendingPM, src_subobj_no, [&to_copy_submodels, &has_name_collision, pm, appendingPM](int submodel, int /*level*/, bool /*isLeaf*/) {
 				to_copy_submodels.emplace_back(submodel);
 				for (int i = 0; i < pm->n_models; i++) {
@@ -287,7 +287,7 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 			pm->submodel[old_n_submodel].next_sibling = -1; //Our old submodel might've had a sibling. Not anymore.
 			pm->submodel[old_n_submodel].parent = dest_subobj_no;
 
-			if (!copyChildred) {
+			if (!copyChildren) {
 				//Clear children if needed
 				pm->submodel[old_n_submodel].num_children = 0;
 				pm->submodel[old_n_submodel].first_child = -1;
@@ -324,16 +324,12 @@ VirtualPOFOperationRenameSubobjects::VirtualPOFOperationRenameSubobjects() {
 
 void VirtualPOFOperationRenameSubobjects::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth /*depth*/) const {
 	for (int i = 0; i < pm->n_models; i++) {
-		SCP_string name = pm->submodel[i].name;
-		SCP_tolower(name);
-		auto it = replacements.find(name);
+		auto it = replacements.find(pm->submodel[i].name);
 		if (it != replacements.end()) {
 			strncpy(pm->submodel[i].name, it->second.c_str(), it->second.size());
 			pm->submodel[i].name[it->second.size()] = '\0';
 		}
-		name = pm->submodel[i].lod_name;
-		SCP_tolower(name);
-		it = replacements.find(name);
+		it = replacements.find(pm->submodel[i].lod_name);
 		if (it != replacements.end()) {
 			strncpy(pm->submodel[i].lod_name, it->second.c_str(), it->second.size());
 			pm->submodel[i].lod_name[it->second.size()] = '\0';

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -92,7 +92,7 @@ static void parse_virtual_pof() {
 			skip_to_start_of_string_either("$POF:", "#End");
 			return;
 		}
-	} while (!optional_string_either("$POF:", "#End"));
+	} while (optional_string_either("$POF:", "#End") == -1);
 	Mp -= 5;
 }
 
@@ -315,8 +315,8 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 VirtualPOFOperationRenameSubobjects::VirtualPOFOperationRenameSubobjects() {
 	while (optional_string("+Replace:")) {
 		SCP_string replace;
-		SCP_tolower(replace);
 		stuff_string(replace, F_NAME);
+		SCP_tolower(replace);
 		required_string("+With:");
 		stuff_string(replacements[replace], F_NAME);
 	}

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -2,11 +2,23 @@
 
 #include "cfile/cfile.h"
 
+#include <functional>
 #include <map>
+#include <memory>
 #include <vector>
 
+static std::unordered_map<SCP_string, std::vector<VirtualPOFDefinition>> virtual_pofs;
+static std::unordered_map<SCP_string, std::function<std::unique_ptr<VirtualPOFOperation>()>> virtual_pof_operations = { 
+	{"$Replace Props:", &std::make_unique<VirtualPOFOperationReplaceProps> }
+};
 
-std::unordered_map<SCP_string, std::vector<VirtualPOFDefinition>> virtual_pofs;
+/*
+* forward declares for internal modelread functions
+*/
+extern void set_subsystem_info(int model_num, model_subsystem* subsystemp, char* props, char* dname);
+
+
+
 
 bool model_exists(const SCP_string& filename) {
 	auto it = virtual_pofs.find(filename);
@@ -21,13 +33,22 @@ bool model_load_virtual(polymodel* pm, const SCP_string& filename, int depth) {
 	return false;
 }
 
+void parse_virtual_pof() {
+
+}
+
 void parse_virtual_pof_table(const char* filename) {
 	try
 	{
 		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
 
-		
+		required_string("#Virtual POFs");
+
+		while (optional_string("$POF:"))
+			parse_virtual_pof();
+
+		required_string("#End");
 	}
 	catch (const parse::ParseException& e)
 	{
@@ -44,6 +65,10 @@ void virtual_pof_init() {
 }
 
 
-void VirtualPOFOperationReplaceProps::process(polymodel* pm) const {
+VirtualPOFOperationReplaceProps::VirtualPOFOperationReplaceProps() {
 
+}
+
+void VirtualPOFOperationReplaceProps::process(polymodel* pm) const {
+	int submodel = model_find_submodel_index(pm->id, subobjName.c_str());
 }

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -15,7 +15,7 @@ static std::unordered_map<SCP_string, std::function<std::unique_ptr<VirtualPOFOp
 /*
 * forward declares for internal modelread functions
 */
-extern void set_subsystem_info(int model_num, model_subsystem* subsystemp, const char* props, const char* dname);
+extern int read_model_file(polymodel* pm, const char* filename, int ferror, subsystem_parse_list& subsystemParseList, int depth = 0);
 
 
 
@@ -29,7 +29,7 @@ bool model_exists(const SCP_string& filename) {
 	return cf_exists_full(filename.c_str(), CF_TYPE_MODELS);
 }
 
-bool model_read_virtual(polymodel* pm, const SCP_string& filename, int depth) {
+bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, int depth) {
 	return false;
 }
 

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -48,7 +48,7 @@ bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, model_pa
 	//We have one, but we're already past it and are processing whatever it overwrote
 	int& depthLocal = depth[filename];
 
-	if (virtual_pof_it->second.size() <= depthLocal)
+	if ((int)virtual_pof_it->second.size() <= depthLocal)
 		return false;
 
 	const auto& virtual_pof = virtual_pof_it->second[depthLocal];
@@ -229,7 +229,7 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 			//Modify new data to correct submodel indices. First move all indices to a safe spot where there can be no overlaps, then to the correct spot
 			for (const auto& id : to_copy_submodels)
 				change_submodel_numbers(appendingPM, id, id + pm->n_models);
-			for (int i = 0; i < to_copy_submodels.size(); i++) {
+			for (int i = 0; i < (int)to_copy_submodels.size(); i++) {
 				change_submodel_numbers(appendingPM, to_copy_submodels[i] + pm->n_models, i + old_n_submodel);
 				auto it = appendingSubsys.model_subsystems.find(appendingPM->submodel[to_copy_submodels[i]].name);
 				if (it != appendingSubsys.model_subsystems.end()) {
@@ -243,7 +243,7 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 			std::map<int, int> textureIDReplace;
 
 			//Copy over new data. This one needs to be fully free'd afterwards, so make sure to nullptr the respective pointers before freeing later
-			for (int i = 0; i < to_copy_submodels.size(); i++) {
+			for (int i = 0; i < (int)to_copy_submodels.size(); i++) {
 				auto& newSubmodel = pm->submodel[i + old_n_submodel];
 				newSubmodel = appendingPM->submodel[to_copy_submodels[i]];
 
@@ -322,20 +322,20 @@ VirtualPOFOperationRenameSubobjects::VirtualPOFOperationRenameSubobjects() {
 	}
 }
 
-void VirtualPOFOperationRenameSubobjects::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const {
+void VirtualPOFOperationRenameSubobjects::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth /*depth*/) const {
 	for (int i = 0; i < pm->n_models; i++) {
 		SCP_string name = pm->submodel[i].name;
 		SCP_tolower(name);
 		auto it = replacements.find(name);
 		if (it != replacements.end()) {
-			strncpy_s(pm->submodel[i].name, it->second.c_str(), it->second.size());
+			strncpy(pm->submodel[i].name, it->second.c_str(), it->second.size());
 			pm->submodel[i].name[it->second.size()] = '\0';
 		}
 		name = pm->submodel[i].lod_name;
 		SCP_tolower(name);
 		it = replacements.find(name);
 		if (it != replacements.end()) {
-			strncpy_s(pm->submodel[i].lod_name, it->second.c_str(), it->second.size());
+			strncpy(pm->submodel[i].lod_name, it->second.c_str(), it->second.size());
 			pm->submodel[i].lod_name[it->second.size()] = '\0';
 		}
 	}
@@ -395,7 +395,7 @@ VirtualPOFOperationHeaderData::VirtualPOFOperationHeaderData() {
 	}
 
 	if (optional_string("$Set Bounding Box:")) {
-		boundingbox = std::make_unique<std::pair<vec3d, vec3d>>();
+		boundingbox = make_unique<std::pair<vec3d, vec3d>>();
 		required_string("+Minimum:");
 		stuff_vec3d(&boundingbox->first);
 		required_string("+Maximum:");
@@ -406,7 +406,6 @@ VirtualPOFOperationHeaderData::VirtualPOFOperationHeaderData() {
 void VirtualPOFOperationHeaderData::process(polymodel* pm, model_read_deferred_tasks& /*deferredTasks*/, model_parse_depth /*depth*/) const {
 	if (radius != nullptr) {
 		pm->rad = pm->core_radius = *radius;
-		pm->bounding_box;
 	}
 
 	if (boundingbox != nullptr) {

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -1,15 +1,18 @@
 #include "modelreplace.h"
 
+#include "model.h"
+
 #include "cfile/cfile.h"
 
 #include <functional>
 #include <map>
 #include <memory>
+#include <set>
 #include <vector>
 
 static std::unordered_map<SCP_string, std::vector<VirtualPOFDefinition>> virtual_pofs;
 static std::unordered_map<SCP_string, std::function<std::unique_ptr<VirtualPOFOperation>()>> virtual_pof_operations = { 
-	{"$Replace Props:", &std::make_unique<VirtualPOFOperationReplaceProps> }
+	{"$Replace Props:", &std::make_unique<VirtualPOFOperationAddSubmodel> }
 };
 
 /*
@@ -18,7 +21,7 @@ static std::unordered_map<SCP_string, std::function<std::unique_ptr<VirtualPOFOp
 extern int read_model_file(polymodel* pm, const char* filename, int ferror, subsystem_parse_list& subsystemParseList, int depth = 0);
 
 
-
+// General Functions and external code paths
 
 bool model_exists(const SCP_string& filename) {
 	auto it = virtual_pofs.find(filename);
@@ -31,13 +34,17 @@ bool model_exists(const SCP_string& filename) {
 
 bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, int depth) {
 	return false;
+
+	//if return true, increment depth
 }
 
-void parse_virtual_pof() {
+// Parsing function
+
+static void parse_virtual_pof() {
 
 }
 
-void parse_virtual_pof_table(const char* filename) {
+static void parse_virtual_pof_table(const char* filename) {
 	try
 	{
 		read_file_text(filename, CF_TYPE_TABLES);
@@ -64,11 +71,122 @@ void virtual_pof_init() {
 	parse_modular_table(NOX("*-pof.tbm"), parse_virtual_pof_table);
 }
 
+// Internal helper functions
 
-VirtualPOFOperationReplaceProps::VirtualPOFOperationReplaceProps() {
+#define REPLACE_IF_EQ(data, source, dest) if ((data) == source) (data) = dest;
+
+void change_submodel_numbers(polymodel* pm, int source, int dest) {
+	//For now only in the subobject data...
+	for (int i = 0; i < pm->n_models; i++) {
+		auto& submodel = pm->submodel[i];
+		for (auto& detail : submodel.details)
+			REPLACE_IF_EQ(detail, source, dest);
+		REPLACE_IF_EQ(submodel.first_child, source, dest);
+		REPLACE_IF_EQ(submodel.i_replace, source, dest);
+		for (auto& debris : submodel.live_debris)
+			REPLACE_IF_EQ(debris, source, dest);
+		REPLACE_IF_EQ(submodel.look_at_submodel, source, dest);
+		REPLACE_IF_EQ(submodel.my_replacement, source, dest);
+		REPLACE_IF_EQ(submodel.next_sibling, source, dest);
+		REPLACE_IF_EQ(submodel.parent, source, dest);
+	}
+}
+
+// Actual replacement operations
+
+VirtualPOFOperationAddSubmodel::VirtualPOFOperationAddSubmodel() {
 
 }
 
-void VirtualPOFOperationReplaceProps::process(polymodel* pm) const {
-	int submodel = model_find_submodel_index(pm->id, subobjName.c_str());
+void VirtualPOFOperationAddSubmodel::process(polymodel* pm, subsystem_parse_list& subsysList, int depth) const {
+	polymodel* appendingPM = new polymodel();
+	subsystem_parse_list appendingSubsys;
+	std::set<int> keepTextures;
+	read_model_file(appendingPM, appendingPOF.c_str(), 0, appendingSubsys, depth);
+
+	int src_subobj_no = -1;
+	for (int i = 0; i < appendingPM->n_models; i++) {
+		if (!stricmp(appendingPM->submodel[i].name, subobjNameSrc.c_str()))
+			src_subobj_no = i;
+	}
+
+	int dest_subobj_no = -1;
+	for (int i = 0; i < pm->n_models; i++) {
+		if (!stricmp(pm->submodel[i].name, subobjNameDest.c_str()))
+			src_subobj_no = i;
+	}
+
+	if (src_subobj_no >= 0 && dest_subobj_no >= 0) {
+		std::vector<int> to_copy_submodels;
+		bool has_name_collision = false;
+		model_iterate_submodel_tree(appendingPM, src_subobj_no, [&to_copy_submodels, &has_name_collision, pm, appendingPM](int submodel, int /*level*/, bool /*isLeaf*/) {
+			to_copy_submodels.emplace_back(submodel);
+			for (int i = 0; i < pm->n_models; i++) {
+				if (!stricmp(pm->submodel[i].name, appendingPM->submodel[submodel].name))
+					has_name_collision = true;
+			}
+			});
+
+		if (!has_name_collision) {
+			//Make sure to keep old data
+			bsp_info* oldSubmodels = pm->submodel;
+			int old_n_submodel = pm->n_models;
+
+			//Realloc new submodel array of proper size
+			pm->n_models += (int)to_copy_submodels.size();
+			pm->submodel = new bsp_info[pm->n_models];
+
+			//Copy over old data. Pointers in the struct can still point to old members, we will just delete the outer bsp_info array
+			memcpy_s(&pm->submodel, pm->n_models, oldSubmodels, old_n_submodel);
+			delete[] oldSubmodels;
+
+			//Modify new data to correct submodel indices. First move all indices to a safe spot where there can be no overlaps, then to the correct spot
+			for (const auto& id : to_copy_submodels)
+				change_submodel_numbers(appendingPM, id, id + pm->n_models);
+			for (int i = 0; i < to_copy_submodels.size(); i++) {
+				change_submodel_numbers(appendingPM, to_copy_submodels[i] + pm->n_models, i + old_n_submodel);
+				auto it = appendingSubsys.model_subsystems.find(appendingPM->submodel[to_copy_submodels[i]].name);
+				if (it != appendingSubsys.model_subsystems.end()) {
+					it->second.subobj_nr = i + old_n_submodel;
+					subsysList.model_subsystems.emplace(*it);
+				}
+			}
+			
+			int deltaDepth = (pm->submodel[dest_subobj_no].depth + 1) - appendingPM->submodel[src_subobj_no].depth;
+
+			//Copy over new data. This one needs to be fully free'd afterwards, so make sure to nullptr the respective pointers before freeing later
+			for (int i = 0; i < to_copy_submodels.size(); i++) {
+				auto& newSubmodel = pm->submodel[i + old_n_submodel];
+				newSubmodel = appendingPM->submodel[to_copy_submodels[i]];
+
+				//Set new Depth
+				newSubmodel.depth += deltaDepth;
+
+				//Store texture replacement indices
+				//TODO
+
+				//Clear old pointer to data
+				appendingPM->submodel[i].bsp_data = nullptr;
+			}
+
+			//Register as next child to our destination
+			pm->submodel[dest_subobj_no].num_children++;
+			int last_sibling = pm->submodel[dest_subobj_no].first_child;
+			while (last_sibling >= 0)
+				last_sibling = pm->submodel[last_sibling].next_sibling;
+
+			pm->submodel[last_sibling].next_sibling = old_n_submodel; //The selected submodel will always be first, and thus get the first id
+			pm->submodel[old_n_submodel].next_sibling = -1; //Our old submodel might've had a sibling. Not anymore.
+		}
+		else {
+			Warning(LOCATION, "Failed to add submodel to virtual POF, original POF already has a subsystem with the same name as was supposed to be added."); //TODO automatic submodel renaming
+		}
+	}
+	else {
+		Warning(LOCATION, "Failed to add submodel to virtual POF, specified subobject was not found. Returning original POF");
+	}
+
+	
+	model_page_out_textures(appendingPM, true);
+	model_free(appendingPM);
 }

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -7,14 +7,14 @@
 
 bool model_exists(const SCP_string& filename);
 
-bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, int depth, int ferror, model_read_deferred_tasks& deferredTasks);
+bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, model_parse_depth depth, int ferror, model_read_deferred_tasks& deferredTasks);
 
 void virtual_pof_init();
 
 class VirtualPOFOperation {
 public:
 	virtual ~VirtualPOFOperation() = default;
-	virtual void process(polymodel*, model_read_deferred_tasks& subsysList, int depth) const = 0;
+	virtual void process(polymodel*, model_read_deferred_tasks& subsysList, model_parse_depth depth) const = 0;
 };
 
 struct VirtualPOFDefinition {
@@ -26,7 +26,7 @@ class VirtualPOFOperationRenameSubobjects : public VirtualPOFOperation {
 	std::unordered_map<SCP_string, SCP_string> replacements;
 public:
 	VirtualPOFOperationRenameSubobjects();
-	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, int depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
 };
 
 class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
@@ -36,7 +36,7 @@ class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
 	bool copyChildred = true;
 public:
 	VirtualPOFOperationAddSubmodel();
-	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, int depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
 };
 
 class VirtualPOFOperationChangeData : public VirtualPOFOperation {
@@ -45,5 +45,5 @@ class VirtualPOFOperationChangeData : public VirtualPOFOperation {
 	std::unique_ptr<vec3d> setOffset = nullptr;
 public:
 	VirtualPOFOperationChangeData();
-	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, int depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
 };

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -19,11 +19,11 @@ public:
 
 struct VirtualPOFDefinition {
 	SCP_string name, basePOF;
-	std::vector<std::unique_ptr<VirtualPOFOperation>> operationList;
+	SCP_vector<std::unique_ptr<VirtualPOFOperation>> operationList;
 };
 
 class VirtualPOFOperationRenameSubobjects : public VirtualPOFOperation {
-	std::unordered_map<SCP_string, SCP_string> replacements;
+	SCP_unordered_map<SCP_string, SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to> replacements;
 public:
 	VirtualPOFOperationRenameSubobjects();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
@@ -33,7 +33,7 @@ class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
 	SCP_string subobjNameSrc, subobjNameDest;
 	SCP_string appendingPOF;
 	std::unique_ptr<VirtualPOFOperationRenameSubobjects> rename = nullptr;
-	bool copyChildred = true;
+	bool copyChildren = true;
 public:
 	VirtualPOFOperationAddSubmodel();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -11,10 +11,12 @@ bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, model_pa
 
 void virtual_pof_init();
 
+struct VirtualPOFDefinition;
+
 class VirtualPOFOperation {
 public:
 	virtual ~VirtualPOFOperation() = default;
-	virtual void process(polymodel*, model_read_deferred_tasks& subsysList, model_parse_depth depth) const = 0;
+	virtual void process(polymodel* pm, model_read_deferred_tasks& subsysList, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const = 0;
 };
 
 struct VirtualPOFDefinition {
@@ -26,7 +28,7 @@ class VirtualPOFOperationRenameSubobjects : public VirtualPOFOperation {
 	SCP_unordered_map<SCP_string, SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to> replacements;
 public:
 	VirtualPOFOperationRenameSubobjects();
-	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 
 class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
@@ -36,7 +38,7 @@ class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
 	bool copyChildren = true;
 public:
 	VirtualPOFOperationAddSubmodel();
-	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 
 class VirtualPOFOperationChangeData : public VirtualPOFOperation {
@@ -45,7 +47,7 @@ class VirtualPOFOperationChangeData : public VirtualPOFOperation {
 	std::unique_ptr<vec3d> setOffset = nullptr;
 public:
 	VirtualPOFOperationChangeData();
-	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 
 class VirtualPOFOperationHeaderData : public VirtualPOFOperation {
@@ -54,5 +56,5 @@ class VirtualPOFOperationHeaderData : public VirtualPOFOperation {
 	std::unique_ptr<std::pair<vec3d, vec3d>> boundingbox = nullptr;
 public:
 	VirtualPOFOperationHeaderData();
-	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -5,19 +5,19 @@
 
 bool model_exists(const SCP_string& filename);
 
-bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, int depth);
+bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, int depth, int ferror, model_read_deferred_tasks& deferredTasks);
 
 void virtual_pof_init();
-
-class VirtualPOFDefinition {
-
-};
-
 
 class VirtualPOFOperation {
 public:
 	virtual ~VirtualPOFOperation() = default;
-	virtual void process(polymodel*, subsystem_parse_list& subsysList, int depth) const = 0;
+	virtual void process(polymodel*, model_read_deferred_tasks& subsysList, int depth) const = 0;
+};
+
+struct VirtualPOFDefinition {
+	SCP_string name, basePOF;
+	std::vector<std::unique_ptr<VirtualPOFOperation>> operationList;
 };
 
 class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
@@ -25,5 +25,5 @@ class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
 	SCP_string appendingPOF;
 public:
 	VirtualPOFOperationAddSubmodel();
-	void process(polymodel* pm, subsystem_parse_list& subsysList, int depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& subsysList, int depth) const override;
 };

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -5,7 +5,7 @@
 
 bool model_exists(const SCP_string& filename);
 
-bool model_read_virtual(polymodel* pm, const SCP_string& filename, int depth);
+bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, int depth);
 
 void virtual_pof_init();
 

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "globalincs/vmallocator.h"
+#include "model/model.h"
+
+bool model_exists(const SCP_string& filename);
+
+bool model_load_virtual(polymodel* pm, const SCP_string& filename, int depth);
+
+void virtual_pof_init();
+
+class VirtualPOFDefinition {
+
+};
+
+
+class VirtualPOFOperation {
+public:
+	virtual void process(polymodel*) const = 0;
+};
+
+class VirtualPOFOperationReplaceProps : public VirtualPOFOperation {
+public:
+	void process(polymodel* pm) const override;
+};

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -3,6 +3,8 @@
 #include "globalincs/vmallocator.h"
 #include "model/model.h"
 
+#include <memory>
+
 bool model_exists(const SCP_string& filename);
 
 bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, int depth, int ferror, model_read_deferred_tasks& deferredTasks);
@@ -20,10 +22,18 @@ struct VirtualPOFDefinition {
 	std::vector<std::unique_ptr<VirtualPOFOperation>> operationList;
 };
 
+class VirtualPOFOperationRenameSubobjects : public VirtualPOFOperation {
+	std::unordered_map<SCP_string, SCP_string> replacements;
+public:
+	VirtualPOFOperationRenameSubobjects();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, int depth) const override;
+};
+
 class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
 	SCP_string subobjNameSrc, subobjNameDest;
 	SCP_string appendingPOF;
+	std::unique_ptr<VirtualPOFOperationRenameSubobjects> rename = nullptr;
 public:
 	VirtualPOFOperationAddSubmodel();
-	void process(polymodel* pm, model_read_deferred_tasks& subsysList, int depth) const override;
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, int depth) const override;
 };

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -16,10 +16,14 @@ class VirtualPOFDefinition {
 
 class VirtualPOFOperation {
 public:
+	virtual ~VirtualPOFOperation() = default;
 	virtual void process(polymodel*) const = 0;
 };
 
 class VirtualPOFOperationReplaceProps : public VirtualPOFOperation {
+	SCP_string subobjName;
+	SCP_string replaceWith;
 public:
+	VirtualPOFOperationReplaceProps();
 	void process(polymodel* pm) const override;
 };

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -17,13 +17,13 @@ class VirtualPOFDefinition {
 class VirtualPOFOperation {
 public:
 	virtual ~VirtualPOFOperation() = default;
-	virtual void process(polymodel*) const = 0;
+	virtual void process(polymodel*, subsystem_parse_list& subsysList, int depth) const = 0;
 };
 
-class VirtualPOFOperationReplaceProps : public VirtualPOFOperation {
-	SCP_string subobjName;
-	SCP_string replaceWith;
+class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
+	SCP_string subobjNameSrc, subobjNameDest;
+	SCP_string appendingPOF;
 public:
-	VirtualPOFOperationReplaceProps();
-	void process(polymodel* pm) const override;
+	VirtualPOFOperationAddSubmodel();
+	void process(polymodel* pm, subsystem_parse_list& subsysList, int depth) const override;
 };

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -5,7 +5,7 @@
 
 bool model_exists(const SCP_string& filename);
 
-bool model_load_virtual(polymodel* pm, const SCP_string& filename, int depth);
+bool model_read_virtual(polymodel* pm, const SCP_string& filename, int depth);
 
 void virtual_pof_init();
 

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -33,7 +33,17 @@ class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
 	SCP_string subobjNameSrc, subobjNameDest;
 	SCP_string appendingPOF;
 	std::unique_ptr<VirtualPOFOperationRenameSubobjects> rename = nullptr;
+	bool copyChildred = true;
 public:
 	VirtualPOFOperationAddSubmodel();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, int depth) const override;
+};
+
+class VirtualPOFOperationChangeData : public VirtualPOFOperation {
+	SCP_string submodel;
+	//TODO Refactor into proper optional when available
+	std::unique_ptr<vec3d> setOffset = nullptr;
+public:
+	VirtualPOFOperationChangeData();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, int depth) const override;
 };

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -47,3 +47,12 @@ public:
 	VirtualPOFOperationChangeData();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
 };
+
+class VirtualPOFOperationHeaderData : public VirtualPOFOperation {
+	//TODO Refactor into proper optional when available
+	std::unique_ptr<float> radius = nullptr;
+	std::unique_ptr<std::pair<vec3d, vec3d>> boundingbox = nullptr;
+public:
+	VirtualPOFOperationHeaderData();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth) const override;
+};

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -27,6 +27,7 @@
 #include "network/multi_ingame.h"
 #include "popup/popup.h"
 #include "missionui/chatbox.h"
+#include "model/modelreplace.h"
 #include "network/multiteamselect.h"
 #include "network/multi_data.h"
 #include "network/multi_kick.h"
@@ -1571,6 +1572,7 @@ void standalone_main_init()
 	animation::ModelAnimationParseHelper::parseTables();
 	psnet_flush();
 	game_flush();
+	virtual_pof_init();
 	ship_init();
 
 	// setup port forwarding

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -547,15 +547,17 @@ int optional_string(const char *pstr)
 	return 0;
 }
 
-int optional_string_either(const char *str1, const char *str2)
+int optional_string_either(const char *str1, const char *str2, bool advance)
 {
 	ignore_white_space();
 
 	if ( !strnicmp(str1, Mp, strlen(str1)) ) {
-		Mp += strlen(str1);
+		if(advance)
+			Mp += strlen(str1);
 		return 0;
 	} else if ( !strnicmp(str2, Mp, strlen(str2)) ) {
-		Mp += strlen(str2);
+		if (advance)
+			Mp += strlen(str2);
 		return 1;
 	}
 

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -112,7 +112,7 @@ extern void skip_token();
 
 // optional
 extern int optional_string(const char *pstr);
-extern int optional_string_either(const char *str1, const char *str2);
+extern int optional_string_either(const char *str1, const char *str2, bool advance = true);
 extern int optional_string_one_of(int arg_count, ...);
 
 // required

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6037,13 +6037,13 @@ void physics_ship_init(object *objp)
 	else 
 		pi->mass = pm->mass * sinfo->density;
 
-	// it was print-worthy back in read_model_file() in modelread.cpp, but now that its being used for an actual ship the user should be warned.
+	// it was print-worthy back in read_and_process_model_file() in modelread.cpp, but now that its being used for an actual ship the user should be warned.
 	if (IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.fvec)
 		&& IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.uvec)
 		&& IS_MOI_VEC_NULL(&pm->moment_of_inertia.vec.rvec))
 		Warning(LOCATION, "%s (%s) has a null moment of inertia!", sinfo->name, sinfo->pof_file);
 
-	// if invalid they were already warned about this in read_model_file() in modelread.cpp, so now we just need to try and sweep it under the rug
+	// if invalid they were already warned about this in read_and_process_model_file() in modelread.cpp, so now we just need to try and sweep it under the rug
 	if (!is_valid_matrix(&pm->moment_of_inertia))
 	{
 		// TODO: generate MOI properly

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -55,6 +55,7 @@
 #include "mod_table/mod_table.h"
 #include "model/model.h"
 #include "model/modelrender.h"
+#include "model/modelreplace.h"
 #include "nebula/neb.h"
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
@@ -2751,7 +2752,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		// Goober5000 - if this is a modular table, and we're replacing an existing file name, and the file doesn't exist, don't replace it
 		if (replace)
 			if (sip->cockpit_pof_file[0] != '\0')
-				if (!cf_exists_full(temp, CF_TYPE_MODELS))
+				if (!model_exists(temp))
 					valid = false;
 
 		if (valid)
@@ -2818,7 +2819,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		// Goober5000 - if this is a modular table, and we're replacing an existing file name, and the file doesn't exist, don't replace it
 		if (replace)
 			if (sip->pof_file[0] != '\0')
-				if (!cf_exists_full(temp, CF_TYPE_MODELS))
+				if (!model_exists(temp))
 					valid = false;
 
 		if (valid)

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -870,6 +870,8 @@ add_file_folder("Model"
 	model/modelread.cpp
 	model/modelrender.h
 	model/modelrender.cpp
+	model/modelreplace.h
+	model/modelreplace.cpp
 	model/modelsinc.h
 	model/model_flags.h
 )

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -25,6 +25,7 @@
 #include "mission/missionmessage.h"
 #include "mission/missiongoals.h"
 #include "mission/missionbriefcommon.h"
+#include "model/modelreplace.h"
 #include "Management.h"
 #include "cfile/cfile.h"
 #include "graphics/2d.h"
@@ -411,6 +412,7 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	animation::ModelAnimationParseHelper::parseTables();
 	obj_init();
 	model_free_all();				// Free all existing models
+	virtual_pof_init();
 	ai_init();
 	ai_profiles_init();
 	armor_init();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -119,6 +119,7 @@
 #include "missionui/missionweaponchoice.h"
 #include "missionui/redalert.h"
 #include "mod_table/mod_table.h"
+#include "model/modelreplace.h"
 #include "nebula/neb.h"
 #include "nebula/neblightning.h"
 #include "network/multi.h"
@@ -1934,6 +1935,7 @@ void game_init()
 	sexp::dynamic_sexp_init();
 
 	obj_init();	
+	virtual_pof_init();
 	mflash_game_init();	
 	armor_init();
 	ai_init();

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -10,6 +10,7 @@
 #include <iff_defs/iff_defs.h>
 #include <weapon/weapon.h>
 #include <stats/medals.h>
+#include <model/modelreplace.h>
 #include <nebula/neb.h>
 #include <starfield/starfield.h>
 #include <sound/audiostr.h>
@@ -179,6 +180,7 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	listener(SubSystem::Models);
 	model_init();
 	model_free_all();                // Free all existing models
+	virtual_pof_init();
 
 	listener(SubSystem::AI);
 	ai_init();


### PR DESCRIPTION
This PR adds the basic framework to handle table-defined virtual POFs. These allow modular manipulation and combination of models during FSO runtime.
Right now, only the very basic features (copying submodel model data, renaming submodels, moving submodels, editing some POF header data) are supported, basically only allowing some dynamic kitbashing.
Due to the already large size of the PR, the following planned features will be deferred to a later PR:

- Replacing Submodels
- Processing more than just model data when copying / replacing
    - Allow to manipulate turret data
    - Allow to manipulate weapon fire point data
    - Allow to manipulate glowpoint data
    - Allow to manipulate dockbay paths and data
- Allow copying / replacement of said data individually, without needing to copy parent submodels to the target ship
- Enable shield modification and replacement
- Enable debris copying and replacement
- Enable eye point and more POF header data manipulation
- Automatize some processes currently manual
    - Enable the system to automatically rename submodels with conflicting names
    - Enable automatic bounding box / radius recalculation to fit new / changed submodels into the POF
- Optimization
    - Caching. Right now, Virtual POFs will only cache the end product. If a model is required multiple times for generating the final virtual POF, it will be loaded anew each time it is referenced.
- Likely more I've forgotten at the moment.