### PR TITLE
Scripting functions required for SCPUI conversion of all four Tech Room UIs

### DIFF
--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -218,7 +218,7 @@ static float Credits_scroll_rate			= 15.0f;
 static float Credits_artwork_display_time	= 9.0f;
 static float Credits_artwork_fade_time		= 1.0f;
 
-static SCP_vector<SCP_string> Credit_text_parts;
+credits_info Credits_Info;
 
 static bool Credits_parsed;
 
@@ -258,6 +258,20 @@ void credits_start_music()
 	} else {
 		nprintf(("Warning", "Cannot play credits music\n"));
 	}
+}
+
+char* credits_get_music_filename(const char* music)
+{
+	int credits_spooled_music_index = event_music_get_spooled_music_index(music);
+	if (credits_spooled_music_index != -1) {
+		char* credits_wavfile_name = Spooled_music[credits_spooled_music_index].filename;
+		if (credits_wavfile_name != NULL) {
+			credits_load_music(credits_wavfile_name);
+			return credits_wavfile_name;
+		}
+		return nullptr;
+	}
+	return nullptr;
 }
 
 int credits_screen_button_pressed(int n)
@@ -304,8 +318,11 @@ void credits_parse_table(const char* filename)
 		{
 			int temp;
 			stuff_int(&temp);
-			if (temp > 0)
+			if (temp > 0) {
 				Credits_num_images = temp;
+			}
+
+			Credits_Info.num_images = Credits_num_images;
 		}
 		if (optional_string("$Start Image Index:"))
 		{
@@ -320,24 +337,31 @@ void credits_parse_table(const char* filename)
 			{
 				Credits_artwork_index = Credits_num_images - 1;
 			}
+			Credits_Info.start_index = Credits_artwork_index;
 		}
 		if (optional_string("$Text scroll rate:"))
 		{
 			stuff_float(&Credits_scroll_rate);
-			if (Credits_scroll_rate < 0.01f)
+			if (Credits_scroll_rate < 0.01f) {
 				Credits_scroll_rate = 0.01f;
+			}
+			Credits_Info.scroll_rate = Credits_scroll_rate;
 		}
 		if (optional_string("$Artworks display time:"))
 		{
 			stuff_float(&Credits_artwork_display_time);
-			if (Credits_artwork_display_time < 0.01f)
+			if (Credits_artwork_display_time < 0.01f) {
 				Credits_artwork_display_time = 0.01f;
+			}
+			Credits_Info.art_display_time = Credits_artwork_display_time;
 		}
 		if (optional_string("$Artworks fade time:"))
 		{
 			stuff_float(&Credits_artwork_fade_time);
-			if (Credits_artwork_fade_time < 0.01f)
+			if (Credits_artwork_fade_time < 0.01f){
 				Credits_artwork_fade_time = 0.01f;
+			}
+			Credits_Info.art_fade_time = Credits_artwork_fade_time;
 		}
 		if (optional_string("$SCP Credits position:"))
 		{
@@ -374,6 +398,7 @@ void credits_parse_table(const char* filename)
 			if (first_run && !Credits_parsed && line == mod_check)
 			{
 				credits_text.append(unmodified_credits);
+				Credits_Info.credit_parts.push_back(unmodified_credits);
 			}
 
 			first_run = false;
@@ -382,6 +407,7 @@ void credits_parse_table(const char* filename)
 			{
 				// If the line is empty then just append a newline, don't bother with splitting it first
 				credits_text.append("\n");
+				Credits_Info.credit_parts.push_back("\n");
 			}
 			else
 			{
@@ -403,6 +429,8 @@ void credits_parse_table(const char* filename)
 				{
 					credits_text.append(SCP_string(lines[i], charNum[i]));
 					credits_text.append("\n");
+					Credits_Info.credit_parts.push_back(SCP_string(lines[i], charNum[i]));
+					Credits_Info.credit_parts.push_back("\n");
 				}
 			}
 		}
@@ -418,8 +446,37 @@ void credits_parse_table(const char* filename)
 	}
 }
 
+void credits_scp_position()
+{
+	switch (SCP_credits_position) {
+	case START:
+		Credit_text_parts.insert(Credit_text_parts.begin(), fs2_open_credit_text);
+		Credits_Info.credit_parts.insert(Credits_Info.credit_parts.begin(), fs2_open_credit_text);
+		break;
+
+	case END:
+		Credit_text_parts.push_back(fs2_open_credit_text);
+		Credits_Info.credit_parts.push_back(fs2_open_credit_text);
+		break;
+
+	default:
+		Error(LOCATION, "Unimplemented credits position %d. Get a coder!", (int)SCP_credits_position);
+		break;
+	}
+}
+
 void credits_parse()
 {
+	// Build the API credits defaults here
+	Credits_Info.music = "Cinema";
+	Credits_Info.num_images = 46;
+	Credits_Info.start_index = Random::next(46);
+	Credits_Info.scroll_rate = 15.0f;
+	Credits_Info.art_display_time = 9.0f;
+	Credits_Info.art_fade_time = 1.0f;
+	Credits_Info.credit_parts.clear();
+	Credits_Info.credits_complete.clear();
+
 	// Parse main table
 	credits_parse_table("credits.tbl");
 
@@ -449,13 +506,7 @@ void credits_init()
 		Credits_artwork_index = Random::next(Credits_num_images);
 	}
 
-	int credits_spooled_music_index = event_music_get_spooled_music_index(Credits_music_name);	
-	if(credits_spooled_music_index != -1){
-		char *credits_wavfile_name = Spooled_music[credits_spooled_music_index].filename;		
-		if(credits_wavfile_name != NULL){
-			credits_load_music(credits_wavfile_name);
-		}
-	}
+	credits_get_music_filename(Credits_music_name);
 
 	// Use this id to trigger the start of music playing on the briefing screen
 	Credits_music_begin_timestamp = ui_timestamp(Credits_music_delay);
@@ -469,20 +520,7 @@ void credits_init()
 	}
 	else
 	{
-		switch (SCP_credits_position)
-		{
-			case START:
-				Credit_text_parts.insert(Credit_text_parts.begin(), fs2_open_credit_text);
-				break;
-
-			case END:
-				Credit_text_parts.push_back(fs2_open_credit_text);
-				break;
-
-			default:
-				Error(LOCATION, "Unimplemented credits position %d. Get a coder!", (int) SCP_credits_position);
-				break;
-		}
+		credits_scp_position();
 	}
 
 	int ch;

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -198,7 +198,7 @@ static credits_screen_buttons Buttons[NUM_BUTTONS][GR_NUM_RESOLUTIONS] = {
 //XSTR:ON
 };
 
-static char Credits_music_name[NAME_LENGTH];
+char Credits_music_name[NAME_LENGTH];
 static int	Credits_music_handle = -1;
 static UI_TIMESTAMP	Credits_music_begin_timestamp;
 
@@ -206,19 +206,21 @@ static int	Credits_frametime;		// frametime of credits_do_frame() loop in ms
 static int	Credits_last_time;		// timestamp used to calc frametime (in ms)
 static float Credits_counter;
 
-static int Credits_num_images;
-static int Credits_artwork_index;
+int Credits_num_images;
+int Credits_artwork_index;
 static SCP_vector<int> Credits_bmps;
 
 // Positions for credits...
 float Credit_start_pos, Credit_stop_pos, Credit_position = 0.0f;
 
 static int Credits_music_delay				= 2000;
-static float Credits_scroll_rate			= 15.0f;
-static float Credits_artwork_display_time	= 9.0f;
-static float Credits_artwork_fade_time		= 1.0f;
+float Credits_scroll_rate					= 15.0f;
+float Credits_artwork_display_time			= 9.0f;
+float Credits_artwork_fade_time				= 1.0f;
 
-credits_info Credits_Info;
+SCP_string credits_complete;
+
+SCP_vector<SCP_string> Credit_text_parts;
 
 static bool Credits_parsed;
 
@@ -260,7 +262,7 @@ void credits_start_music()
 	}
 }
 
-char* credits_get_music_filename(const char* music)
+const char* credits_get_music_filename(const char* music)
 {
 	int credits_spooled_music_index = event_music_get_spooled_music_index(music);
 	if (credits_spooled_music_index != -1) {
@@ -318,11 +320,8 @@ void credits_parse_table(const char* filename)
 		{
 			int temp;
 			stuff_int(&temp);
-			if (temp > 0) {
+			if (temp > 0) 
 				Credits_num_images = temp;
-			}
-
-			Credits_Info.num_images = Credits_num_images;
 		}
 		if (optional_string("$Start Image Index:"))
 		{
@@ -337,15 +336,12 @@ void credits_parse_table(const char* filename)
 			{
 				Credits_artwork_index = Credits_num_images - 1;
 			}
-			Credits_Info.start_index = Credits_artwork_index;
 		}
 		if (optional_string("$Text scroll rate:"))
 		{
 			stuff_float(&Credits_scroll_rate);
-			if (Credits_scroll_rate < 0.01f) {
+			if (Credits_scroll_rate < 0.01f)
 				Credits_scroll_rate = 0.01f;
-			}
-			Credits_Info.scroll_rate = Credits_scroll_rate;
 		}
 		if (optional_string("$Artworks display time:"))
 		{
@@ -353,15 +349,12 @@ void credits_parse_table(const char* filename)
 			if (Credits_artwork_display_time < 0.01f) {
 				Credits_artwork_display_time = 0.01f;
 			}
-			Credits_Info.art_display_time = Credits_artwork_display_time;
 		}
 		if (optional_string("$Artworks fade time:"))
 		{
 			stuff_float(&Credits_artwork_fade_time);
-			if (Credits_artwork_fade_time < 0.01f){
+			if (Credits_artwork_fade_time < 0.01f)
 				Credits_artwork_fade_time = 0.01f;
-			}
-			Credits_Info.art_fade_time = Credits_artwork_fade_time;
 		}
 		if (optional_string("$SCP Credits position:"))
 		{
@@ -398,7 +391,6 @@ void credits_parse_table(const char* filename)
 			if (first_run && !Credits_parsed && line == mod_check)
 			{
 				credits_text.append(unmodified_credits);
-				Credits_Info.credit_parts.push_back(unmodified_credits);
 			}
 
 			first_run = false;
@@ -407,7 +399,6 @@ void credits_parse_table(const char* filename)
 			{
 				// If the line is empty then just append a newline, don't bother with splitting it first
 				credits_text.append("\n");
-				Credits_Info.credit_parts.push_back("\n");
 			}
 			else
 			{
@@ -429,8 +420,6 @@ void credits_parse_table(const char* filename)
 				{
 					credits_text.append(SCP_string(lines[i], charNum[i]));
 					credits_text.append("\n");
-					Credits_Info.credit_parts.push_back(SCP_string(lines[i], charNum[i]));
-					Credits_Info.credit_parts.push_back("\n");
 				}
 			}
 		}
@@ -451,12 +440,10 @@ void credits_scp_position()
 	switch (SCP_credits_position) {
 	case START:
 		Credit_text_parts.insert(Credit_text_parts.begin(), fs2_open_credit_text);
-		Credits_Info.credit_parts.insert(Credits_Info.credit_parts.begin(), fs2_open_credit_text);
 		break;
 
 	case END:
 		Credit_text_parts.push_back(fs2_open_credit_text);
-		Credits_Info.credit_parts.push_back(fs2_open_credit_text);
 		break;
 
 	default:
@@ -467,15 +454,6 @@ void credits_scp_position()
 
 void credits_parse()
 {
-	// Build the API credits defaults here
-	Credits_Info.music = "Cinema";
-	Credits_Info.num_images = 46;
-	Credits_Info.start_index = Random::next(46);
-	Credits_Info.scroll_rate = 15.0f;
-	Credits_Info.art_display_time = 9.0f;
-	Credits_Info.art_fade_time = 1.0f;
-	Credits_Info.credit_parts.clear();
-	Credits_Info.credits_complete.clear();
 
 	// Parse main table
 	credits_parse_table("credits.tbl");

--- a/code/menuui/credits.h
+++ b/code/menuui/credits.h
@@ -12,9 +12,27 @@
 #ifndef __CREDITS_H__
 #define __CREDITS_H__
 
+struct credits_info {
+	SCP_string music;						// the mission name
+	int num_images;							// the mission filename
+	int start_index;						// the mission description
+	float scroll_rate;						// the mission designer
+	float art_display_time;					// the mission designer
+	float art_fade_time;					// the mission designer
+	SCP_vector<SCP_string> credit_parts;	// the lines of credits
+	SCP_string credits_complete;			// the lines of credits
+};
+
+extern credits_info Credits_Info;
+
 void credits_init();
 void credits_do_frame(float frametime);
 void credits_close();
+
+void credits_parse();
+void credits_scp_position();
+char* credits_get_music_filename(const char* music);
+static SCP_vector<SCP_string> Credit_text_parts;
 
 void credits_stop_music(bool fade);
 

--- a/code/menuui/credits.h
+++ b/code/menuui/credits.h
@@ -12,18 +12,15 @@
 #ifndef __CREDITS_H__
 #define __CREDITS_H__
 
-struct credits_info {
-	SCP_string music;						// the mission name
-	int num_images;							// the mission filename
-	int start_index;						// the mission description
-	float scroll_rate;						// the mission designer
-	float art_display_time;					// the mission designer
-	float art_fade_time;					// the mission designer
-	SCP_vector<SCP_string> credit_parts;	// the lines of credits
-	SCP_string credits_complete;			// the lines of credits
-};
+extern char Credits_music_name[NAME_LENGTH];
+extern int Credits_num_images;
+extern int Credits_artwork_index;
+extern float Credits_scroll_rate;
+extern float Credits_artwork_display_time;
+extern float Credits_artwork_fade_time;
 
-extern credits_info Credits_Info;
+//This is used to store the entire credits string for the SCPUI API
+extern SCP_string credits_complete;
 
 void credits_init();
 void credits_do_frame(float frametime);
@@ -31,8 +28,8 @@ void credits_close();
 
 void credits_parse();
 void credits_scp_position();
-char* credits_get_music_filename(const char* music);
-static SCP_vector<SCP_string> Credit_text_parts;
+const char* credits_get_music_filename(const char* music);
+extern SCP_vector<SCP_string> Credit_text_parts;
 
 void credits_stop_music(bool fade);
 

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -133,6 +133,11 @@ static sim_room_buttons Buttons[GR_NUM_RESOLUTIONS][NUM_BUTTONS] = {
 //XSTR:ON
 };
 
+SCP_vector<sim_mission> Sim_Missions;
+SCP_vector<sim_mission> Sim_CMissions;
+
+bool API_Access = false;
+
 const char* Sim_filename[GR_NUM_RESOLUTIONS] = {
 	"LoadMission",
 	"2_LoadMission"
@@ -499,6 +504,17 @@ int build_standalone_mission_list_do_frame()
 				Standalone_mission_flags[Num_standalone_missions_with_info] = The_mission.game_type;
 				int y = Num_lines * (font_height + 2);
 
+				//Add mission data to the API
+				if (API_Access) {
+					sim_mission mission;
+					mission.name = The_mission.name;
+					mission.filename = filename;
+					mission.mission_desc = The_mission.mission_desc;
+					mission.author = The_mission.author;
+
+					Sim_Missions.push_back(mission);
+				}
+
 				// determine some extra information
 				int flags = 0;
 				fs_builtin_mission *fb = game_find_builtin_mission(filename);				
@@ -531,6 +547,7 @@ int build_campaign_mission_list_do_frame()
 {
 	int font_height = gr_get_font_height();
 	char str[256];
+	char filename[MAX_FILENAME_LEN];
 	static int valid_missions_with_info = 0; // we use this to avoid blank entries in the mission list
 
 	// When no campaign files in data directory
@@ -549,14 +566,28 @@ int build_campaign_mission_list_do_frame()
 	Campaign_mission_flags[Num_campaign_missions_with_info] = 0;
 
 	// Only allow missions already completed
-	if (Campaign.missions[Num_campaign_missions_with_info].completed || Simroom_show_all) 
+	if (Campaign.missions[Num_campaign_missions_with_info].completed || (Simroom_show_all || API_Access)) 
 	{
 		if (!get_mission_info(Campaign.missions[Num_campaign_missions_with_info].name)) 
 		{
+			strcpy_s(filename, Campaign.missions[Num_campaign_missions_with_info].name);
+			
 			// add to list
 			Campaign_mission_names[Num_campaign_missions_with_info] = vm_strdup(The_mission.name);
 			Campaign_mission_flags[Num_campaign_missions_with_info] = The_mission.game_type;
 			int y = valid_missions_with_info * (font_height + 2);
+
+			// Add mission data to the API
+			if (API_Access) {
+				sim_mission mission;
+				mission.name = The_mission.name;
+				mission.filename = filename;
+				mission.mission_desc = The_mission.mission_desc;
+				mission.author = The_mission.author;
+				mission.visible = Campaign.missions[Num_campaign_missions_with_info].completed;
+
+				Sim_CMissions.push_back(mission);
+			}
 
 			// determine some extra information
 			int flags = 0;
@@ -1197,6 +1228,78 @@ void sim_room_close()
 
 	// unload special mission icons
 	sim_room_unload_mission_icons();
+}
+
+//The mission list for the tech room is built each time the game state is entered
+//so this method provides a way to do the exact same thing from scripting.
+//It has some duplication of code but seemed the easiest way to provide similar
+//functionality without a complete refactor.
+void api_sim_room_build_mission_list()
+{
+	char wild_card[256];
+
+	Num_campaign_missions = 0;
+	Get_file_list_filter = sim_room_campaign_mission_filter;
+
+	mission_campaign_build_list(false, false);
+
+	Hash_table_inited = 0;
+	if (build_campaign_mission_filename_hash_table()) {
+		Hash_table_inited = 1;
+	}
+
+	Get_file_list_filter = sim_room_standalone_mission_filter;
+	memset(wild_card, 0, 256);
+	strcpy_s(wild_card, NOX("*"));
+	strcat_s(wild_card, FS_MISSION_FILE_EXT);
+
+	Num_standalone_missions =
+		cf_get_file_list(MAX_MISSIONS, Mission_filenames, CF_TYPE_MISSIONS, wild_card, CF_SORT_NAME);
+
+	while (!build_standalone_mission_list_do_frame()) {
+	}
+	while (!build_campaign_mission_list_do_frame()) {
+	}
+
+	Num_campaign_missions_with_info = Num_standalone_missions_with_info = Standalone_mission_names_inited =
+		Campaign_mission_names_inited = 0;
+
+	int i;
+	for (i = 0; i < Num_campaign_missions; i++) {
+		if (Campaign_missions[i]) {
+			vm_free(Campaign_missions[i]);
+			Campaign_missions[i] = NULL;
+		}
+	}
+
+	if (Standalone_mission_names_inited) {
+		for (i = 0; i < Num_standalone_missions; i++) {
+			if (Standalone_mission_names[i] != NULL) {
+				vm_free(Standalone_mission_names[i]);
+				Standalone_mission_names[i] = NULL;
+			}
+			Standalone_mission_flags[i] = 0;
+		}
+	}
+
+	if (Campaign_mission_names_inited) {
+		for (i = 0; i < Campaign.num_missions; i++) {
+			if (Campaign_mission_names[i]) {
+				vm_free(Campaign_mission_names[i]);
+				Campaign_mission_names[i] = NULL;
+			}
+		}
+	}
+
+	for (i = 0; i < Num_standalone_missions; i++) {
+		vm_free(Mission_filenames[i]);
+		Mission_filenames[i] = NULL;
+	}
+
+	// free global Campaign_* list stuff
+	mission_campaign_free_list();
+
+	campaign_mission_hash_table_delete();
 }
 
 // ---------------------------------------------------------------------

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -506,13 +506,13 @@ int build_standalone_mission_list_do_frame()
 
 				//Add mission data to the API
 				if (API_Access) {
-					sim_mission mission;
-					mission.name = The_mission.name;
-					mission.filename = filename;
-					mission.mission_desc = The_mission.mission_desc;
-					mission.author = The_mission.author;
+					sim_mission api_mission;
+					api_mission.name = The_mission.name;
+					api_mission.filename = filename;
+					api_mission.mission_desc = The_mission.mission_desc;
+					api_mission.author = The_mission.author;
 
-					Sim_Missions.push_back(mission);
+					Sim_Missions.push_back(api_mission);
 				}
 
 				// determine some extra information
@@ -579,14 +579,14 @@ int build_campaign_mission_list_do_frame()
 
 			// Add mission data to the API
 			if (API_Access) {
-				sim_mission mission;
-				mission.name = The_mission.name;
-				mission.filename = filename;
-				mission.mission_desc = The_mission.mission_desc;
-				mission.author = The_mission.author;
-				mission.visible = Campaign.missions[Num_campaign_missions_with_info].completed;
+				sim_mission api_mission;
+				api_mission.name = The_mission.name;
+				api_mission.filename = filename;
+				api_mission.mission_desc = The_mission.mission_desc;
+				api_mission.author = The_mission.author;
+				api_mission.visible = Campaign.missions[Num_campaign_missions_with_info].completed;
 
-				Sim_CMissions.push_back(mission);
+				Sim_CMissions.push_back(api_mission);
 			}
 
 			// determine some extra information

--- a/code/menuui/readyroom.h
+++ b/code/menuui/readyroom.h
@@ -14,12 +14,27 @@
 #include "globalincs/pstypes.h"
 #include "scripting/hook_api.h"
 
+struct sim_mission {
+	SCP_string name;					// the mission name
+	SCP_string filename;  // the mission filename
+	SCP_string mission_desc; // the mission description
+	SCP_string author;               // the mission designer
+	int visible;							// if the mission is visible by default
+};
+
+extern SCP_vector<sim_mission> Sim_Missions;
+extern SCP_vector<sim_mission> Sim_CMissions;
+
+extern bool API_Access;
+
 extern int Sim_room_overlay_id;
 extern int Campaign_room_overlay_id;
 
 void sim_room_init();
 void sim_room_close();
 void sim_room_do_frame(float frametime);
+
+void api_sim_room_build_mission_list();
 
 // called by main menu to continue on with current campaign (if there is one).
 int readyroom_continue_campaign();

--- a/code/menuui/readyroom.h
+++ b/code/menuui/readyroom.h
@@ -25,8 +25,6 @@ struct sim_mission {
 extern SCP_vector<sim_mission> Sim_Missions;
 extern SCP_vector<sim_mission> Sim_CMissions;
 
-extern bool API_Access;
-
 extern int Sim_room_overlay_id;
 extern int Campaign_room_overlay_id;
 
@@ -34,7 +32,7 @@ void sim_room_init();
 void sim_room_close();
 void sim_room_do_frame(float frametime);
 
-void api_sim_room_build_mission_list();
+void api_sim_room_build_mission_list(bool API_Access);
 
 // called by main menu to continue on with current campaign (if there is one).
 int readyroom_continue_campaign();

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -414,6 +414,19 @@ void common_maybe_play_cutscene(int movie_type, bool restart_music, int music)
 	}
 }
 
+void common_play_cutscene(const char* filename, bool restart_music, int music)
+{
+	bool music_off = false;
+
+	common_music_close();
+	music_off = true;
+	movie::play(filename); // Play the movie!
+
+	if (music_off && restart_music) {
+		common_music_init(music);
+	}
+};
+
 // function that sets the current palette to the interface palette.  This function
 // needs to be followed by common_free_interface_palette() to restore the game palette.
 void common_set_interface_palette(const char *filename)

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -115,6 +115,7 @@ void common_music_close();
 
 int common_num_cutscenes_valid(int movie_type);
 void common_maybe_play_cutscene(int movie_type, bool restart_music = false, int music = 0);
+void common_play_cutscene(const char* filename, bool restart_music = false, int music = 0);
 
 int common_scroll_down_pressed(int *start, int size, int max_show);
 int common_scroll_up_pressed(int *start, int size, int max_show);

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1180,7 +1180,7 @@ ADE_FUNC(startMission,
 		// if mission is not running
 	} else {
 		// due safety checks of the game_start_mission() function allow only main menu for now.
-		if (gameseq_get_state(gameseq_get_depth()) == GS_STATE_MAIN_MENU || GS_STATE_SIMULATOR_ROOM) {
+		if ((gameseq_get_state(gameseq_get_depth()) == GS_STATE_MAIN_MENU) || (gameseq_get_state(gameseq_get_depth()) == GS_STATE_SIMULATOR_ROOM)) {
 			strcpy_s(Game_current_mission_filename, name_copy);
 			if (b == true) {
 				// start mission - go via briefing screen

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1180,7 +1180,7 @@ ADE_FUNC(startMission,
 		// if mission is not running
 	} else {
 		// due safety checks of the game_start_mission() function allow only main menu for now.
-		if (gameseq_get_state(gameseq_get_depth()) == GS_STATE_MAIN_MENU) {
+		if (gameseq_get_state(gameseq_get_depth()) == GS_STATE_MAIN_MENU || GS_STATE_SIMULATOR_ROOM) {
 			strcpy_s(Game_current_mission_filename, name_copy);
 			if (b == true) {
 				// start mission - go via briefing screen

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -731,7 +731,7 @@ ADE_INDEXER(l_UserInterface_SingleMissions, "number Index", "Array of simulator 
 	if (!ade_get_args(L, "*i", &idx))
 		return ade_set_error(L, "s", "");
 	
-	return ade_set_args(L, "o", l_TechRoomMission.Set(Sim_Missions[idx]));
+	return ade_set_args(L, "o", l_TechRoomMission.Set(sim_mission_h(idx, false)));
 }
 
 ADE_FUNC(__len, l_UserInterface_SingleMissions, nullptr, "The number of single missions", "number", "The number of single missions")
@@ -746,7 +746,7 @@ ADE_INDEXER(l_UserInterface_CampaignMissions, "number Index", "Array of campaign
 	if (!ade_get_args(L, "*i", &idx))
 		return ade_set_error(L, "s", "");
 	
-	return ade_set_args(L, "o", l_TechRoomMission.Set(Sim_CMissions[idx]));
+	return ade_set_args(L, "o", l_TechRoomMission.Set(sim_mission_h(idx, true)));
 }
 
 ADE_FUNC(__len, l_UserInterface_CampaignMissions, nullptr, "The number of campaign missions", "number", "The number of campaign missions")
@@ -765,7 +765,7 @@ ADE_INDEXER(l_UserInterface_Cutscenes,
 	if (!ade_get_args(L, "*i", &idx))
 		return ade_set_error(L, "s", "");
 
-	return ade_set_args(L, "o", l_TechRoomCutscene.Set(Cutscenes[idx]));
+	return ade_set_args(L, "o", l_TechRoomCutscene.Set(cutscene_info_h(idx)));
 }
 
 ADE_FUNC(__len, l_UserInterface_Cutscenes, nullptr, "The number of cutscenes", "number", "The number of cutscenes")

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -5,6 +5,7 @@
 #include "globalincs/alphacolors.h"
 
 #include "cmdline/cmdline.h"
+#include "cutscene/cutscenes.h"
 #include "gamesnd/eventmusic.h"
 #include "gamesequence/gamesequence.h"
 #include "menuui/barracks.h"
@@ -208,6 +209,19 @@ ADE_FUNC(maybePlayCutscene, l_UserInterface, "enumeration MovieType, boolean Res
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(playCutscene, l_UserInterface, "string Filename, boolean RestartMusic, number ScoreIndex", "Plays a cutscene.  If RestartMusic is true, then the music score at ScoreIndex will be started after the cutscene plays.", nullptr, "Returns nothing")
+{
+	const char* filename;
+	bool restart_music = false;
+	int score_index = 0;
+
+	if (!ade_get_args(L, "sbi", &filename, &restart_music, &score_index))
+		return ADE_RETURN_NIL;
+
+	common_play_cutscene(filename, restart_music, score_index);
+	return ADE_RETURN_NIL;
+}
+
 //**********SUBLIBRARY: UserInterface/PilotSelect
 ADE_LIB_DERIV(l_UserInterface_PilotSelect, "PilotSelect", nullptr,
               "API for accessing values specific to the pilot select screen.<br><b>Warning:</b> This is an internal "
@@ -341,6 +355,20 @@ ADE_FUNC(startAmbientSound, l_UserInterface_MainHall, nullptr, "Starts the ambie
 {
 	(void)L;
 	main_hall_start_ambient();
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(stopAmbientSound, l_UserInterface_MainHall, nullptr, "Stops the ambient mainhall sound.", nullptr, "nothing")
+{
+	(void)L;
+	main_hall_stop_ambient();
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(startMusic, l_UserInterface_MainHall, nullptr, "Starts the mainhall music.", nullptr, "nothing")
+{
+	(void)L;
+	main_hall_start_music();
 	return ADE_RETURN_NIL;
 }
 
@@ -689,6 +717,20 @@ ADE_INDEXER(l_UserInterface_CampaignMissions, "number Index", "Array of campaign
 		return ade_set_error(L, "s", "");
 	
 	return ade_set_args(L, "o", l_TechRoomMission.Set(Sim_CMissions[idx]));
+}
+
+ADE_LIB_DERIV(l_UserInterface_Cutscenes, "Cutscenes", nullptr, nullptr, l_UserInterface_TechRoom);
+ADE_INDEXER(l_UserInterface_Cutscenes,
+	"number Index",
+	"Array of cutscenes",
+	"custscene_info",
+	"Cutscene handle, or invalid handle if index is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "*i", &idx))
+		return ade_set_error(L, "s", "");
+
+	return ade_set_args(L, "o", l_TechRoomCutscene.Set(Cutscenes[idx]));
 }
 
 } // namespace api

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -21,6 +21,7 @@
 #include "playerman/managepilot.h"
 #include "scpui/SoundPlugin.h"
 #include "scpui/rocket_ui.h"
+#include "scripting/api/objs/techroom.h"
 #include "scripting/api/objs/loop_brief.h"
 #include "scripting/api/objs/redalert.h"
 #include "scripting/api/objs/fictionviewer.h"
@@ -641,6 +642,53 @@ ADE_FUNC(getFictionMusicName, l_UserInterface_FictionViewer, nullptr,
 	"The file name or empty if no music")
 {
 	return ade_set_args(L, "s", common_music_get_filename(SCORE_FICTION_VIEWER).c_str());
+}
+
+//**********SUBLIBRARY: UserInterface/TechRoom
+ADE_LIB_DERIV(l_UserInterface_TechRoom,
+	"TechRoom",
+	nullptr,
+	"API for accessing data related to the tech room UI.<br><b>Warning:</b> This is an internal "
+	"API for the new UI system. This should not be used by other code and may be removed in the future!",
+	l_UserInterface);
+
+ADE_FUNC(buildMissionList,
+	l_UserInterface_TechRoom,
+	nullptr,
+	"Builds the mission list for display. Must be called before the sim_mission handle will have data",
+	"number",
+	"Returns 1 when completed")
+{
+	API_Access = true;
+
+	Sim_Missions.clear();
+	Sim_CMissions.clear();
+
+	api_sim_room_build_mission_list();
+
+	mprintf(("Building mission lists for scripting API is complete!\n"));
+	API_Access = false;
+	return ade_set_args(L, "i", 1);
+}
+
+ADE_LIB_DERIV(l_UserInterface_SingleMissions, "SingleMissions", nullptr, nullptr, l_UserInterface_TechRoom);
+ADE_INDEXER(l_UserInterface_SingleMissions, "number Index", "Array of simulator missions", "sim_mission", "Mission handle, or invalid handle if index is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "*i", &idx))
+		return ade_set_error(L, "s", "");
+	
+	return ade_set_args(L, "o", l_TechRoomMission.Set(Sim_Missions[idx]));
+}
+
+ADE_LIB_DERIV(l_UserInterface_CampaignMissions, "CampaignMissions", nullptr, nullptr, l_UserInterface_TechRoom);
+ADE_INDEXER(l_UserInterface_CampaignMissions, "number Index", "Array of campaign missions", "sim_mission", "Mission handle, or invalid handle if index is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "*i", &idx))
+		return ade_set_error(L, "s", "");
+	
+	return ade_set_args(L, "o", l_TechRoomMission.Set(Sim_CMissions[idx]));
 }
 
 } // namespace api

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -9,6 +9,7 @@
 #include "gamesnd/eventmusic.h"
 #include "gamesequence/gamesequence.h"
 #include "menuui/barracks.h"
+#include "menuui/credits.h"
 #include "menuui/mainhallmenu.h"
 #include "menuui/optionsmenu.h"
 #include "menuui/playermenu.h"
@@ -699,6 +700,32 @@ ADE_FUNC(buildMissionList,
 	return ade_set_args(L, "i", 1);
 }
 
+ADE_FUNC(buildCredits,
+	l_UserInterface_TechRoom,
+	nullptr,
+	"Builds the credits for display. Must be called before the credits_info handle will have data",
+	"number",
+	"Returns 1 when completed")
+{
+
+	credits_parse();
+	credits_scp_position();
+
+	size_t count = Credits_Info.credit_parts.size();
+	mprintf(("CREDITS number of parts is %i\n", count));
+
+	for (int i = 0; i < count; i++) {
+		Credits_Info.credits_complete.append(Credits_Info.credit_parts[i]);
+	}
+
+	//Make sure we clean up after ourselves
+	Credit_text_parts.clear();
+
+	mprintf(("Building credits for scripting API is complete!\n"));
+
+	return ade_set_args(L, "i", 1);
+}
+
 ADE_LIB_DERIV(l_UserInterface_SingleMissions, "SingleMissions", nullptr, nullptr, l_UserInterface_TechRoom);
 ADE_INDEXER(l_UserInterface_SingleMissions, "number Index", "Array of simulator missions", "sim_mission", "Mission handle, or invalid handle if index is invalid")
 {
@@ -731,6 +758,77 @@ ADE_INDEXER(l_UserInterface_Cutscenes,
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "o", l_TechRoomCutscene.Set(Cutscenes[idx]));
+}
+
+ADE_LIB_DERIV(l_UserInterface_Credits, "Credits", nullptr, nullptr, l_UserInterface_TechRoom);
+ADE_VIRTVAR(Music, l_UserInterface_Credits, nullptr, "The credits music filename", "string", "The music filename")
+{
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", credits_get_music_filename(Credits_Info.music.c_str()));
+}
+
+ADE_VIRTVAR(NumImages, l_UserInterface_Credits, nullptr, "The total number of credits images", "number", "The number of images")
+{
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "i", Credits_Info.num_images);
+}
+
+ADE_VIRTVAR(StartIndex, l_UserInterface_Credits, nullptr, "The image index to begin with", "number", "The index")
+{
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "i", Credits_Info.start_index);
+}
+
+ADE_VIRTVAR(DisplayTime, l_UserInterface_Credits, nullptr, "The display time for each image", "number", "The display time")
+{
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "f", Credits_Info.art_display_time);
+}
+
+ADE_VIRTVAR(FadeTime, l_UserInterface_Credits, nullptr, "The crossfade time for each image", "number", "The fade time")
+{
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "f", Credits_Info.art_fade_time);
+}
+
+ADE_VIRTVAR(ScrollRate, l_UserInterface_Credits, nullptr, "The scroll rate of the text", "number", "The scroll rate")
+{
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "f", Credits_Info.scroll_rate);
+}
+
+ADE_VIRTVAR(Complete, l_UserInterface_Credits, nullptr, "The complete credits string", "string", "The credits")
+{
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", Credits_Info.credits_complete);
 }
 
 } // namespace api

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -688,15 +688,14 @@ ADE_FUNC(buildMissionList,
 	"number",
 	"Returns 1 when completed")
 {
-	API_Access = true;
 
 	Sim_Missions.clear();
 	Sim_CMissions.clear();
 
-	api_sim_room_build_mission_list();
+	api_sim_room_build_mission_list(true);
 
 	mprintf(("Building mission lists for scripting API is complete!\n"));
-	API_Access = false;
+
 	return ade_set_args(L, "i", 1);
 }
 
@@ -711,10 +710,10 @@ ADE_FUNC(buildCredits,
 	credits_parse();
 	credits_scp_position();
 
-	size_t count = Credits_Info.credit_parts.size();
+	size_t count = Credit_text_parts.size();
 
 	for (size_t i = 0; i < count; i++) {
-		Credits_Info.credits_complete.append(Credits_Info.credit_parts[i]);
+		credits_complete.append(Credit_text_parts[i]);
 	}
 
 	//Make sure we clean up after ourselves
@@ -782,7 +781,7 @@ ADE_VIRTVAR(Music, l_UserInterface_Credits, nullptr, "The credits music filename
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", credits_get_music_filename(Credits_Info.music.c_str()));
+	return ade_set_args(L, "s", credits_get_music_filename(Credits_music_name));
 }
 
 ADE_VIRTVAR(NumImages, l_UserInterface_Credits, nullptr, "The total number of credits images", "number", "The number of images")
@@ -792,7 +791,7 @@ ADE_VIRTVAR(NumImages, l_UserInterface_Credits, nullptr, "The total number of cr
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "i", Credits_Info.num_images);
+	return ade_set_args(L, "i", Credits_num_images);
 }
 
 ADE_VIRTVAR(StartIndex, l_UserInterface_Credits, nullptr, "The image index to begin with", "number", "The index")
@@ -802,7 +801,7 @@ ADE_VIRTVAR(StartIndex, l_UserInterface_Credits, nullptr, "The image index to be
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "i", Credits_Info.start_index);
+	return ade_set_args(L, "i", Credits_artwork_index);
 }
 
 ADE_VIRTVAR(DisplayTime, l_UserInterface_Credits, nullptr, "The display time for each image", "number", "The display time")
@@ -812,7 +811,7 @@ ADE_VIRTVAR(DisplayTime, l_UserInterface_Credits, nullptr, "The display time for
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "f", Credits_Info.art_display_time);
+	return ade_set_args(L, "f", Credits_artwork_display_time);
 }
 
 ADE_VIRTVAR(FadeTime, l_UserInterface_Credits, nullptr, "The crossfade time for each image", "number", "The fade time")
@@ -822,7 +821,7 @@ ADE_VIRTVAR(FadeTime, l_UserInterface_Credits, nullptr, "The crossfade time for 
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "f", Credits_Info.art_fade_time);
+	return ade_set_args(L, "f", Credits_artwork_fade_time);
 }
 
 ADE_VIRTVAR(ScrollRate, l_UserInterface_Credits, nullptr, "The scroll rate of the text", "number", "The scroll rate")
@@ -832,7 +831,7 @@ ADE_VIRTVAR(ScrollRate, l_UserInterface_Credits, nullptr, "The scroll rate of th
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "f", Credits_Info.scroll_rate);
+	return ade_set_args(L, "f", Credits_scroll_rate);
 }
 
 ADE_VIRTVAR(Complete, l_UserInterface_Credits, nullptr, "The complete credits string", "string", "The credits")
@@ -842,7 +841,7 @@ ADE_VIRTVAR(Complete, l_UserInterface_Credits, nullptr, "The complete credits st
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", Credits_Info.credits_complete);
+	return ade_set_args(L, "s", credits_complete);
 }
 
 } // namespace api

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -712,9 +712,8 @@ ADE_FUNC(buildCredits,
 	credits_scp_position();
 
 	size_t count = Credits_Info.credit_parts.size();
-	mprintf(("CREDITS number of parts is %i\n", count));
 
-	for (int i = 0; i < count; i++) {
+	for (size_t i = 0; i < count; i++) {
 		Credits_Info.credits_complete.append(Credits_Info.credit_parts[i]);
 	}
 
@@ -736,6 +735,11 @@ ADE_INDEXER(l_UserInterface_SingleMissions, "number Index", "Array of simulator 
 	return ade_set_args(L, "o", l_TechRoomMission.Set(Sim_Missions[idx]));
 }
 
+ADE_FUNC(__len, l_UserInterface_SingleMissions, nullptr, "The number of single missions", "number", "The number of single missions")
+{
+	return ade_set_args(L, "i", Sim_Missions.size());
+}
+
 ADE_LIB_DERIV(l_UserInterface_CampaignMissions, "CampaignMissions", nullptr, nullptr, l_UserInterface_TechRoom);
 ADE_INDEXER(l_UserInterface_CampaignMissions, "number Index", "Array of campaign missions", "sim_mission", "Mission handle, or invalid handle if index is invalid")
 {
@@ -744,6 +748,11 @@ ADE_INDEXER(l_UserInterface_CampaignMissions, "number Index", "Array of campaign
 		return ade_set_error(L, "s", "");
 	
 	return ade_set_args(L, "o", l_TechRoomMission.Set(Sim_CMissions[idx]));
+}
+
+ADE_FUNC(__len, l_UserInterface_CampaignMissions, nullptr, "The number of campaign missions", "number", "The number of campaign missions")
+{
+	return ade_set_args(L, "i", Sim_CMissions.size());
 }
 
 ADE_LIB_DERIV(l_UserInterface_Cutscenes, "Cutscenes", nullptr, nullptr, l_UserInterface_TechRoom);
@@ -758,6 +767,11 @@ ADE_INDEXER(l_UserInterface_Cutscenes,
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "o", l_TechRoomCutscene.Set(Cutscenes[idx]));
+}
+
+ADE_FUNC(__len, l_UserInterface_Cutscenes, nullptr, "The number of cutscenes", "number", "The number of cutscenes")
+{
+	return ade_set_args(L, "i", Cutscenes.size());
 }
 
 ADE_LIB_DERIV(l_UserInterface_Credits, "Credits", nullptr, nullptr, l_UserInterface_TechRoom);

--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -6,7 +6,7 @@ namespace api {
 //**********HANDLE: tech missions
 ADE_OBJ(l_TechRoomMission, sim_mission, "sim_mission", "Tech Room mission handle");
 
-ADE_VIRTVAR(Name, l_TechRoomMission, nullptr, "The name of the mission", "sim_mission", "The name")
+ADE_VIRTVAR(Name, l_TechRoomMission, nullptr, "The name of the mission", "string", "The name")
 {
 	sim_mission* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
@@ -20,7 +20,7 @@ ADE_VIRTVAR(Name, l_TechRoomMission, nullptr, "The name of the mission", "sim_mi
 	return ade_set_args(L, "s", current->name);
 }
 
-ADE_VIRTVAR(Filename, l_TechRoomMission, nullptr, "The filename of the mission", "sim_mission", "The filename")
+ADE_VIRTVAR(Filename, l_TechRoomMission, nullptr, "The filename of the mission", "string", "The filename")
 {
 	sim_mission* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
@@ -34,7 +34,7 @@ ADE_VIRTVAR(Filename, l_TechRoomMission, nullptr, "The filename of the mission",
 	return ade_set_args(L, "s", current->filename);
 }
 
-ADE_VIRTVAR(Description, l_TechRoomMission, nullptr, "The mission description", "sim_mission", "The description")
+ADE_VIRTVAR(Description, l_TechRoomMission, nullptr, "The mission description", "string", "The description")
 {
 	sim_mission* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
@@ -48,7 +48,7 @@ ADE_VIRTVAR(Description, l_TechRoomMission, nullptr, "The mission description", 
 	return ade_set_args(L, "s", current->mission_desc);
 }
 
-ADE_VIRTVAR(Author, l_TechRoomMission, nullptr, "The mission author", "sim_mission", "The author")
+ADE_VIRTVAR(Author, l_TechRoomMission, nullptr, "The mission author", "string", "The author")
 {
 	sim_mission* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
@@ -62,7 +62,7 @@ ADE_VIRTVAR(Author, l_TechRoomMission, nullptr, "The mission author", "sim_missi
 	return ade_set_args(L, "s", current->author);
 }
 
-ADE_VIRTVAR(Visibility, l_TechRoomMission, nullptr, "If the mission should be visible by default", "sim_mission", "1 if visible, 0 if not visible, returns nil if not a campaign mission")
+ADE_VIRTVAR(isVisible, l_TechRoomMission, nullptr, "If the mission should be visible by default", "boolean", "true if visible, false if not visible")
 {
 	sim_mission* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
@@ -73,13 +73,13 @@ ADE_VIRTVAR(Visibility, l_TechRoomMission, nullptr, "If the mission should be vi
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "i", current->visible);
+	return ade_set_args(L, "b", !(current->visible == 0));
 }
 
 //**********HANDLE: tech cutscenes
 ADE_OBJ(l_TechRoomCutscene, cutscene_info, "custscene_info", "Tech Room cutscene handle");
 
-ADE_VIRTVAR(Name, l_TechRoomCutscene, nullptr, "The name of the cutscene", "custscene_info", "The cutscene name")
+ADE_VIRTVAR(Name, l_TechRoomCutscene, nullptr, "The name of the cutscene", "string", "The cutscene name")
 {
 	cutscene_info* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
@@ -93,7 +93,7 @@ ADE_VIRTVAR(Name, l_TechRoomCutscene, nullptr, "The name of the cutscene", "cust
 	return ade_set_args(L, "s", current->name);
 }
 
-ADE_VIRTVAR(Filename, l_TechRoomCutscene, nullptr, "The filename of the cutscene", "custscene_info", "The cutscene filename")
+ADE_VIRTVAR(Filename, l_TechRoomCutscene, nullptr, "The filename of the cutscene", "string", "The cutscene filename")
 {
 	cutscene_info* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
@@ -107,7 +107,7 @@ ADE_VIRTVAR(Filename, l_TechRoomCutscene, nullptr, "The filename of the cutscene
 	return ade_set_args(L, "s", current->filename);
 }
 
-ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description", "custscene_info", "The cutscene description")
+ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description", "string", "The cutscene description")
 {
 	cutscene_info* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
@@ -121,12 +121,12 @@ ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description"
 	return ade_set_args(L, "s", current->description);
 }
 
-ADE_VIRTVAR(Visibility,
+ADE_VIRTVAR(isVisible,
 	l_TechRoomCutscene,
 	nullptr,
 	"If the cutscene should be visible by default",
-	"custscene_info",
-	"1 if visible, 0 if not visible")
+	"boolean",
+	"true if visible, false if not visible")
 {
 	cutscene_info* current = nullptr;
 	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
@@ -139,9 +139,9 @@ ADE_VIRTVAR(Visibility,
 	if (current->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] &&
 		!current->flags[Cutscene::Cutscene_Flags::Never_viewable]) 
 	{
-		return ade_set_args(L, "i", 1);
+		return ade_set_args(L, "b", false);
 	} else {
-		return ade_set_args(L, "i", 0);
+		return ade_set_args(L, "b", true);
 	}
 
 }

--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -105,6 +105,20 @@ ADE_VIRTVAR(isVisible, l_TechRoomMission, nullptr, "If the mission should be vis
 	return ade_set_args(L, "b", !(current.getStage()->visible == 0));
 }
 
+ADE_VIRTVAR(isCampaignMission, l_TechRoomMission, nullptr, "If the mission is campaign or single", "boolean", "true if campaign, false if single")
+{
+	sim_mission_h current;
+	if (!ade_get_args(L, "o", l_TechRoomMission.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "b", current.isCMission);
+}
+
 //**********HANDLE: tech cutscenes
 ADE_OBJ(l_TechRoomCutscene, cutscene_info_h, "custscene_info", "Tech Room cutscene handle");
 

--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -3,7 +3,7 @@
 namespace scripting {
 namespace api {
 
-//**********HANDLE: loop_briefing
+//**********HANDLE: tech missions
 ADE_OBJ(l_TechRoomMission, sim_mission, "sim_mission", "Tech Room mission handle");
 
 ADE_VIRTVAR(Name, l_TechRoomMission, nullptr, "The name of the mission", "sim_mission", "The name")
@@ -74,6 +74,76 @@ ADE_VIRTVAR(Visibility, l_TechRoomMission, nullptr, "If the mission should be vi
 	}
 
 	return ade_set_args(L, "i", current->visible);
+}
+
+//**********HANDLE: tech cutscenes
+ADE_OBJ(l_TechRoomCutscene, cutscene_info, "custscene_info", "Tech Room cutscene handle");
+
+ADE_VIRTVAR(Name, l_TechRoomCutscene, nullptr, "The name of the cutscene", "custscene_info", "The cutscene name")
+{
+	cutscene_info* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current->name);
+}
+
+ADE_VIRTVAR(Filename, l_TechRoomCutscene, nullptr, "The filename of the cutscene", "custscene_info", "The cutscene filename")
+{
+	cutscene_info* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current->filename);
+}
+
+ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description", "custscene_info", "The cutscene description")
+{
+	cutscene_info* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current->description);
+}
+
+ADE_VIRTVAR(Visibility,
+	l_TechRoomCutscene,
+	nullptr,
+	"If the cutscene should be visible by default",
+	"custscene_info",
+	"1 if visible, 0 if not visible")
+{
+	cutscene_info* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+	if (current->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] &&
+		!current->flags[Cutscene::Cutscene_Flags::Never_viewable]) 
+	{
+		return ade_set_args(L, "i", 1);
+	} else {
+		return ade_set_args(L, "i", 0);
+	}
+
 }
 
 } // namespace api

--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -1,0 +1,80 @@
+#include "techroom.h"
+
+namespace scripting {
+namespace api {
+
+//**********HANDLE: loop_briefing
+ADE_OBJ(l_TechRoomMission, sim_mission, "sim_mission", "Tech Room mission handle");
+
+ADE_VIRTVAR(Name, l_TechRoomMission, nullptr, "The name of the mission", "sim_mission", "The name")
+{
+	sim_mission* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current->name);
+}
+
+ADE_VIRTVAR(Filename, l_TechRoomMission, nullptr, "The filename of the mission", "sim_mission", "The filename")
+{
+	sim_mission* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current->filename);
+}
+
+ADE_VIRTVAR(Description, l_TechRoomMission, nullptr, "The mission description", "sim_mission", "The description")
+{
+	sim_mission* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current->mission_desc);
+}
+
+ADE_VIRTVAR(Author, l_TechRoomMission, nullptr, "The mission author", "sim_mission", "The author")
+{
+	sim_mission* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current->author);
+}
+
+ADE_VIRTVAR(Visibility, l_TechRoomMission, nullptr, "If the mission should be visible by default", "sim_mission", "1 if visible, 0 if not visible, returns nil if not a campaign mission")
+{
+	sim_mission* current = nullptr;
+	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "i", current->visible);
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -3,13 +3,42 @@
 namespace scripting {
 namespace api {
 
+sim_mission_h::sim_mission_h() : missionIdx(-1), isCMission(false) {}
+sim_mission_h::sim_mission_h(int index, bool cmission) : missionIdx(index), isCMission(cmission) {}
+
+bool sim_mission_h::IsValid() const
+{
+	return missionIdx >= 0;
+}
+
+sim_mission* sim_mission_h::getStage() const
+{
+	if (isCMission)
+		return &Sim_CMissions[missionIdx];
+	else
+		return &Sim_Missions[missionIdx];
+};
+
+cutscene_info_h::cutscene_info_h() : cutscene(-1) {}
+cutscene_info_h::cutscene_info_h(int scene) : cutscene(scene) {}
+
+bool cutscene_info_h::IsValid() const
+{
+	return cutscene >= 0;
+}
+
+cutscene_info* cutscene_info_h::getStage() const
+{
+	return &Cutscenes[cutscene];
+}
+
 //**********HANDLE: tech missions
-ADE_OBJ(l_TechRoomMission, sim_mission, "sim_mission", "Tech Room mission handle");
+ADE_OBJ(l_TechRoomMission, sim_mission_h, "sim_mission", "Tech Room mission handle");
 
 ADE_VIRTVAR(Name, l_TechRoomMission, nullptr, "The name of the mission", "string", "The name")
 {
-	sim_mission* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+	sim_mission_h current;
+	if (!ade_get_args(L, "o", l_TechRoomMission.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -17,13 +46,13 @@ ADE_VIRTVAR(Name, l_TechRoomMission, nullptr, "The name of the mission", "string
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current->name);
+	return ade_set_args(L, "s", current.getStage()->name);
 }
 
 ADE_VIRTVAR(Filename, l_TechRoomMission, nullptr, "The filename of the mission", "string", "The filename")
 {
-	sim_mission* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+	sim_mission_h current;
+	if (!ade_get_args(L, "o", l_TechRoomMission.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -31,13 +60,13 @@ ADE_VIRTVAR(Filename, l_TechRoomMission, nullptr, "The filename of the mission",
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current->filename);
+	return ade_set_args(L, "s", current.getStage()->filename);
 }
 
 ADE_VIRTVAR(Description, l_TechRoomMission, nullptr, "The mission description", "string", "The description")
 {
-	sim_mission* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+	sim_mission_h current;
+	if (!ade_get_args(L, "o", l_TechRoomMission.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -45,13 +74,13 @@ ADE_VIRTVAR(Description, l_TechRoomMission, nullptr, "The mission description", 
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current->mission_desc);
+	return ade_set_args(L, "s", current.getStage()->mission_desc);
 }
 
 ADE_VIRTVAR(Author, l_TechRoomMission, nullptr, "The mission author", "string", "The author")
 {
-	sim_mission* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+	sim_mission_h current;
+	if (!ade_get_args(L, "o", l_TechRoomMission.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -59,13 +88,13 @@ ADE_VIRTVAR(Author, l_TechRoomMission, nullptr, "The mission author", "string", 
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current->author);
+	return ade_set_args(L, "s", current.getStage()->author);
 }
 
 ADE_VIRTVAR(isVisible, l_TechRoomMission, nullptr, "If the mission should be visible by default", "boolean", "true if visible, false if not visible")
 {
-	sim_mission* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomMission.GetPtr(&current))) {
+	sim_mission_h current;
+	if (!ade_get_args(L, "o", l_TechRoomMission.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -73,16 +102,16 @@ ADE_VIRTVAR(isVisible, l_TechRoomMission, nullptr, "If the mission should be vis
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "b", !(current->visible == 0));
+	return ade_set_args(L, "b", !(current.getStage()->visible == 0));
 }
 
 //**********HANDLE: tech cutscenes
-ADE_OBJ(l_TechRoomCutscene, cutscene_info, "custscene_info", "Tech Room cutscene handle");
+ADE_OBJ(l_TechRoomCutscene, cutscene_info_h, "custscene_info", "Tech Room cutscene handle");
 
 ADE_VIRTVAR(Name, l_TechRoomCutscene, nullptr, "The name of the cutscene", "string", "The cutscene name")
 {
-	cutscene_info* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
+	cutscene_info_h current;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -90,13 +119,13 @@ ADE_VIRTVAR(Name, l_TechRoomCutscene, nullptr, "The name of the cutscene", "stri
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current->name);
+	return ade_set_args(L, "s", current.getStage()->name);
 }
 
 ADE_VIRTVAR(Filename, l_TechRoomCutscene, nullptr, "The filename of the cutscene", "string", "The cutscene filename")
 {
-	cutscene_info* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
+	cutscene_info_h current;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -104,13 +133,13 @@ ADE_VIRTVAR(Filename, l_TechRoomCutscene, nullptr, "The filename of the cutscene
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current->filename);
+	return ade_set_args(L, "s", current.getStage()->filename);
 }
 
 ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description", "string", "The cutscene description")
 {
-	cutscene_info* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
+	cutscene_info_h current;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -118,7 +147,7 @@ ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description"
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current->description);
+	return ade_set_args(L, "s", current.getStage()->description);
 }
 
 ADE_VIRTVAR(isVisible,
@@ -128,16 +157,16 @@ ADE_VIRTVAR(isVisible,
 	"boolean",
 	"true if visible, false if not visible")
 {
-	cutscene_info* current = nullptr;
-	if (!ade_get_args(L, "o", l_TechRoomCutscene.GetPtr(&current))) {
+	cutscene_info_h current;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
 	}
-	if (current->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] &&
-		!current->flags[Cutscene::Cutscene_Flags::Never_viewable]) 
+	if (current.getStage()->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] &&
+		!current.getStage()->flags[Cutscene::Cutscene_Flags::Never_viewable]) 
 	{
 		return ade_set_args(L, "b", false);
 	} else {

--- a/code/scripting/api/objs/techroom.h
+++ b/code/scripting/api/objs/techroom.h
@@ -7,8 +7,25 @@
 namespace scripting {
 namespace api {
 
-DECLARE_ADE_OBJ(l_TechRoomMission, sim_mission);
-DECLARE_ADE_OBJ(l_TechRoomCutscene, cutscene_info);
+struct sim_mission_h {
+	int missionIdx;
+	bool isCMission;
+	sim_mission_h();
+	explicit sim_mission_h(int index, bool cmission);
+	bool IsValid() const;
+	sim_mission* getStage() const;
+};
+
+struct cutscene_info_h {
+	int cutscene;
+	cutscene_info_h();
+	explicit cutscene_info_h(int scene);
+	bool IsValid() const;
+	cutscene_info* getStage() const;
+};
+
+DECLARE_ADE_OBJ(l_TechRoomMission, sim_mission_h);
+DECLARE_ADE_OBJ(l_TechRoomCutscene, cutscene_info_h);
 
 } // namespace api
 } // namespace scripting

--- a/code/scripting/api/objs/techroom.h
+++ b/code/scripting/api/objs/techroom.h
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "menuui/readyroom.h"
+#include "cutscene/cutscenes.h"
 #include "scripting/ade_api.h"
 
 namespace scripting {
 namespace api {
 
 DECLARE_ADE_OBJ(l_TechRoomMission, sim_mission);
+DECLARE_ADE_OBJ(l_TechRoomCutscene, cutscene_info);
 
 } // namespace api
 } // namespace scripting

--- a/code/scripting/api/objs/techroom.h
+++ b/code/scripting/api/objs/techroom.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "menuui/readyroom.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+DECLARE_ADE_OBJ(l_TechRoomMission, sim_mission);
+
+} // namespace api
+} // namespace scripting

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1400,6 +1400,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/subsystem.h
 	scripting/api/objs/team.cpp
 	scripting/api/objs/team.h
+	scripting/api/objs/techroom.cpp
+	scripting/api/objs/techroom.h
 	scripting/api/objs/texture.cpp
 	scripting/api/objs/texture.h
 	scripting/api/objs/texturemap.cpp


### PR DESCRIPTION
This adds an ScpUi API for access to the many tech room related bits including the simulator room, cutscenes viewer, and credits screen. I think I covered everything. Anything missed will be in a later PR.

Some files, notably readyroom.cpp and credits.cpp needed some slight rearranging because the mission list and credits data are not created/parsed until that UI is actually loaded. The restructure allows for the API to call those methods and then access the data without loading the rest of the retail UI elements. While a larger restructure could have made the files more efficient overall, I felt this was the best way to accomplish what was needed while keeping the impact to the affected files as minimal as possible. That said, I'm open to instruction how this could be improved if necessary.