### PR TITLE
Remove unused and costly checksum during model read

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -73,8 +73,6 @@ static bool ss_warning_shown_null = false;		// have we shown the warning dialog 
 static bool ss_warning_shown_mismatch = false;	// ditto but for a different warning
 #endif
 
-static uint Global_checksum = 0;
-
 // Anything less than this is considered incompatible.
 #define PM_COMPATIBLE_VERSION 1900
 
@@ -1443,11 +1441,7 @@ int read_model_file(polymodel * pm, const char *filename, int n_subsystems, mode
 
 	TRACE_SCOPE(tracing::ReadModelFile);
 
-	// generate checksum for the POF
-	cfseek(fp, 0, SEEK_SET);	
-	cf_chksum_long(fp, &Global_checksum);
 	cfseek(fp, 0, SEEK_SET);
-
 
 	// code to get a filename to write out subsystem information for each model that
 	// is read.  This info is essentially debug stuff that is used to help get models


### PR DESCRIPTION
Profiling shows this taking about 10% of the total time in loading BP's Icarus mission, and the result isn't even read any more!