### PR TITLE
Fix Mac builds by overriding py7zr version

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -234,6 +234,7 @@ jobs:
           cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
           setup-python: 'false'
           aqtversion: ==1.1.3
+          py7zrversion: '==0.19.*'
 
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -248,6 +248,7 @@ jobs:
           cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
           setup-python: 'false'
           aqtversion: ==1.1.3
+          py7zrversion: '==0.19.*'
 
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -181,6 +181,7 @@ jobs:
           cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
           setup-python: 'false'
           aqtversion: ==1.1.3
+          py7zrversion: '==0.19.*'
 
       - uses: actions/checkout@v1
         name: Checkout


### PR DESCRIPTION
Looks like the base GH Actions image got updated (newer Python?) and it now fails to install the older version of py7zr.