### PR TITLE
Allow `test_line_of_sight` to return intersecting object signature

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -637,6 +637,6 @@ void do_random_sidethrust(ai_info *aip, ship_info *sip);
 void ai_formation_object_recalculate_slotnums(int form_objnum, int exiting_objnum = -1);
 
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, object*& first_intersect_obj = nullptr);
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, object** first_intersect_obj = nullptr);
 
 #endif

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -637,6 +637,6 @@ void do_random_sidethrust(ai_info *aip, ship_info *sip);
 void ai_formation_object_recalculate_slotnums(int form_objnum, int exiting_objnum = -1);
 
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, int* first_intersect_signature = nullptr);
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, object* first_intersect_obj = nullptr);
 
 #endif

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -637,6 +637,6 @@ void do_random_sidethrust(ai_info *aip, ship_info *sip);
 void ai_formation_object_recalculate_slotnums(int form_objnum, int exiting_objnum = -1);
 
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, object* first_intersect_obj = nullptr);
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, object*& first_intersect_obj = nullptr);
 
 #endif

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -637,6 +637,6 @@ void do_random_sidethrust(ai_info *aip, ship_info *sip);
 void ai_formation_object_recalculate_slotnums(int form_objnum, int exiting_objnum = -1);
 
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr);
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, int* first_intersect_signature = nullptr);
 
 #endif

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -16228,7 +16228,7 @@ void maybe_cheat_fire_synaptic(object *objp)
 	}
 }
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, object* first_intersect_obj) {
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, object*& first_intersect_obj) {
 	bool collides = false;
 
 	for (object* objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -16228,7 +16228,7 @@ void maybe_cheat_fire_synaptic(object *objp)
 	}
 }
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, int* first_intersect_signature) {
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, object* first_intersect_obj) {
 	bool collides = false;
 
 	for (object* objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
@@ -16306,7 +16306,7 @@ bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*
 					//If we need to find the first intersect distance, we need to keep searching if there might be an intersect earlier. Also, always record the first dist found
 					if (!collides || *first_intersect_dist > dist) {
 						*first_intersect_dist = dist;
-						*first_intersect_signature = objp->signature;
+						first_intersect_obj = objp;
 					}
 					collides = true;
 				}
@@ -16325,7 +16325,7 @@ bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*
 					//If we need to find the first intersect distance, we need to keep searching if there might be an intersect earlier
 					if (!collides || *first_intersect_dist > dist) {
 						*first_intersect_dist = dist;
-						*first_intersect_signature = objp->signature;
+						first_intersect_obj = objp;
 					}
 					collides = true;
 				}

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -16228,7 +16228,7 @@ void maybe_cheat_fire_synaptic(object *objp)
 	}
 }
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, object*& first_intersect_obj) {
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, object** first_intersect_obj) {
 	bool collides = false;
 
 	for (object* objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
@@ -16306,7 +16306,8 @@ bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*
 					//If we need to find the first intersect distance, we need to keep searching if there might be an intersect earlier. Also, always record the first dist found
 					if (!collides || *first_intersect_dist > dist) {
 						*first_intersect_dist = dist;
-						first_intersect_obj = objp;
+						if (first_intersect_obj != nullptr)
+							*first_intersect_obj = objp;
 					}
 					collides = true;
 				}
@@ -16325,7 +16326,8 @@ bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*
 					//If we need to find the first intersect distance, we need to keep searching if there might be an intersect earlier
 					if (!collides || *first_intersect_dist > dist) {
 						*first_intersect_dist = dist;
-						first_intersect_obj = objp;
+						if (first_intersect_obj != nullptr)
+							*first_intersect_obj = objp;
 					}
 					collides = true;
 				}

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -16228,7 +16228,7 @@ void maybe_cheat_fire_synaptic(object *objp)
 	}
 }
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist) {
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, int* first_intersect_signature) {
 	bool collides = false;
 
 	for (object* objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
@@ -16304,8 +16304,10 @@ bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*
 				}
 				else {
 					//If we need to find the first intersect distance, we need to keep searching if there might be an intersect earlier. Also, always record the first dist found
-					if (!collides || *first_intersect_dist > dist)
+					if (!collides || *first_intersect_dist > dist) {
 						*first_intersect_dist = dist;
+						*first_intersect_signature = objp->signature;
+					}
 					collides = true;
 				}
 			}
@@ -16321,8 +16323,10 @@ bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*
 				}
 				else {
 					//If we need to find the first intersect distance, we need to keep searching if there might be an intersect earlier
-					if (!collides || *first_intersect_dist > dist)
+					if (!collides || *first_intersect_dist > dist) {
 						*first_intersect_dist = dist;
+						*first_intersect_signature = objp->signature;
+					}
 					collides = true;
 				}
 			}

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1571,7 +1571,7 @@ ADE_FUNC(hasLineOfSight, l_Mission, "vector from, vector to, [table excludedObje
 	return testLineOfSight_internal(L, false);
 }
 
-ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [table excludedObjects /* expects list of objects, empty by default */, boolean testForShields = false, boolean testForHull = true, number threshold = 10.0]", "Checks whether the to-position is in line of sight from the from-position and returns the distance and object signature to the first interruption of the line of sight, disregarding specific excluded objects and objects with a radius of less then threshold.", "boolean, number", "true and zero and nil if there is line of sight, false and the distance and Signature otherwise.")
+ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [table excludedObjects /* expects list of objects, empty by default */, boolean testForShields = false, boolean testForHull = true, number threshold = 10.0]", "Checks whether the to-position is in line of sight from the from-position and returns the distance and object signature to the first interruption of the line of sight, disregarding specific excluded objects and objects with a radius of less then threshold.", "boolean, number", "number", "true and zero and -1 if there is line of sight, false and the distance and Signature otherwise.")
 {
 	return testLineOfSight_internal(L, true);
 }

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1571,7 +1571,7 @@ ADE_FUNC(hasLineOfSight, l_Mission, "vector from, vector to, [table excludedObje
 	return testLineOfSight_internal(L, false);
 }
 
-ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [table excludedObjects /* expects list of objects, empty by default */, boolean testForShields = false, boolean testForHull = true, number threshold = 10.0]", "Checks whether the to-position is in line of sight from the from-position and returns the distance and object signature to the first interruption of the line of sight, disregarding specific excluded objects and objects with a radius of less then threshold.", "boolean, number", "number", "true and zero and -1 if there is line of sight, false and the distance and Signature otherwise.")
+ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [table excludedObjects /* expects list of objects, empty by default */, boolean testForShields = false, boolean testForHull = true, number threshold = 10.0]", "Checks whether the to-position is in line of sight from the from-position and returns the distance and object signature to the first interruption of the line of sight, disregarding specific excluded objects and objects with a radius of less then threshold.", "boolean, number, number", "true and zero and -1 if there is line of sight, false and the distance and Signature otherwise.")
 {
 	return testLineOfSight_internal(L, true);
 }

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1513,14 +1513,14 @@ ADE_FUNC(hasCommandBriefing,
 	return ade_set_args(L, "b", mission_has_cmd_brief() != 0);
 }
 
-int testLineOfSight_internal(lua_State* L, bool returnDist_and_Sig) {
+int testLineOfSight_internal(lua_State* L, bool returnDist_and_Obj) {
 	vec3d from, to;
 	luacpp::LuaTable excludedObjects;
 	bool testForShields = false, testForHull = true;
 	float threshold = 10.0f;
 
 	float distStore = 0.0f;
-	float* dist = returnDist_and_Sig ? &distStore : nullptr;
+	float* dist = returnDist_and_Obj ? &distStore : nullptr;
 	object* intersecting_obj = nullptr;
 
 	if (!ade_get_args(L, "oo|tbbf", l_Vector.Get(&from), l_Vector.Get(&to), &excludedObjects, &testForShields, &testForHull, &threshold)) {
@@ -1559,7 +1559,7 @@ int testLineOfSight_internal(lua_State* L, bool returnDist_and_Sig) {
 
 	bool hasLoS = test_line_of_sight(&from, &to, std::move(excludedObjectIDs), threshold, testForShields, testForHull, dist, &intersecting_obj);
 
-	if (returnDist_and_Sig)
+	if (returnDist_and_Obj)
 		return ade_set_args(L, "bfo", hasLoS, *dist, l_Object.Set(object_h(intersecting_obj)));
 	else
 		return ade_set_args(L, "b", hasLoS);
@@ -1570,7 +1570,7 @@ ADE_FUNC(hasLineOfSight, l_Mission, "vector from, vector to, [table excludedObje
 	return testLineOfSight_internal(L, false);
 }
 
-ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [table excludedObjects /* expects list of objects, empty by default */, boolean testForShields = false, boolean testForHull = true, number threshold = 10.0]", "Checks whether the to-position is in line of sight from the from-position and returns the distance and object signature to the first interruption of the line of sight, disregarding specific excluded objects and objects with a radius of less then threshold.", "boolean, number, object", "true and zero and nil if there is line of sight, false and the distance and intersecting object otherwise.")
+ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [table excludedObjects /* expects list of objects, empty by default */, boolean testForShields = false, boolean testForHull = true, number threshold = 10.0]", "Checks whether the to-position is in line of sight from the from-position and returns the distance and intersecting object to the first interruption of the line of sight, disregarding specific excluded objects and objects with a radius of less then threshold.", "boolean, number, object", "true and zero and nil if there is line of sight, false and the distance and intersecting object otherwise.")
 {
 	return testLineOfSight_internal(L, true);
 }

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1557,7 +1557,7 @@ int testLineOfSight_internal(lua_State* L, bool returnDist_and_Sig) {
 		}
 	}
 
-	bool hasLoS = test_line_of_sight(&from, &to, std::move(excludedObjectIDs), threshold, testForShields, testForHull, dist, intersecting_obj);
+	bool hasLoS = test_line_of_sight(&from, &to, std::move(excludedObjectIDs), threshold, testForShields, testForHull, dist, &intersecting_obj);
 
 	if (returnDist_and_Sig)
 		return ade_set_args(L, "bfo", hasLoS, *dist, l_Object.Set(object_h(intersecting_obj)));

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1521,8 +1521,7 @@ int testLineOfSight_internal(lua_State* L, bool returnDist_and_Sig) {
 
 	float distStore = 0.0f;
 	float* dist = returnDist_and_Sig ? &distStore : nullptr;
-	int intersecting_obj_sig_Store = -1;
-	int* intersecting_obj_sig = returnDist_and_Sig ? &intersecting_obj_sig_Store : nullptr;
+	object* intersecting_obj = nullptr;
 
 	if (!ade_get_args(L, "oo|tbbf", l_Vector.Get(&from), l_Vector.Get(&to), &excludedObjects, &testForShields, &testForHull, &threshold)) {
 		return ADE_RETURN_FALSE;
@@ -1558,10 +1557,10 @@ int testLineOfSight_internal(lua_State* L, bool returnDist_and_Sig) {
 		}
 	}
 
-	bool hasLoS = test_line_of_sight(&from, &to, std::move(excludedObjectIDs), threshold, testForShields, testForHull, dist, intersecting_obj_sig);
+	bool hasLoS = test_line_of_sight(&from, &to, std::move(excludedObjectIDs), threshold, testForShields, testForHull, dist, intersecting_obj);
 
 	if (returnDist_and_Sig)
-		return ade_set_args(L, "bfi", hasLoS, *dist, *intersecting_obj_sig);
+		return ade_set_args(L, "bfo", hasLoS, *dist, l_Object.Set(object_h(intersecting_obj)));
 	else
 		return ade_set_args(L, "b", hasLoS);
 }
@@ -1571,7 +1570,7 @@ ADE_FUNC(hasLineOfSight, l_Mission, "vector from, vector to, [table excludedObje
 	return testLineOfSight_internal(L, false);
 }
 
-ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [table excludedObjects /* expects list of objects, empty by default */, boolean testForShields = false, boolean testForHull = true, number threshold = 10.0]", "Checks whether the to-position is in line of sight from the from-position and returns the distance and object signature to the first interruption of the line of sight, disregarding specific excluded objects and objects with a radius of less then threshold.", "boolean, number, number", "true and zero and -1 if there is line of sight, false and the distance and Signature otherwise.")
+ADE_FUNC(getLineOfSightFirstIntersect, l_Mission, "vector from, vector to, [table excludedObjects /* expects list of objects, empty by default */, boolean testForShields = false, boolean testForHull = true, number threshold = 10.0]", "Checks whether the to-position is in line of sight from the from-position and returns the distance and object signature to the first interruption of the line of sight, disregarding specific excluded objects and objects with a radius of less then threshold.", "boolean, number, object", "true and zero and nil if there is line of sight, false and the distance and intersecting object otherwise.")
 {
 	return testLineOfSight_internal(L, true);
 }


### PR DESCRIPTION
The `test_line_of_sight` can currently provide the closest intersecting distance, but it would be very useful, especially for AI scripting, if this function could also return the signature of the intersecting object. This PR adds that functionality.

Tested and works as expected. Happy to discuss strategies for changing implementation, too. The extra, third return value for object signature was added to `getLineOfSightFirstIntersect` function because that function already returns 2 values. Thus, it will remain compatible with older scripts which only save the first 2 returned values.