### PR TITLE
Some extra safety checks for fiction viewer scripts

### DIFF
--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -503,7 +503,11 @@ ADE_LIB_DERIV(l_UserInterface_FictionViewer,
 
 ADE_FUNC(getFiction, l_UserInterface_FictionViewer, nullptr, "Get the fiction.", "fiction_viewer_stage", "The fiction data")
 {
-	return ade_set_args(L, "o", l_FictionViewerStage.Set(Fiction_viewer_stages[Fiction_viewer_active_stage]));
+	if (Fiction_viewer_active_stage >= 0) {
+		return ade_set_args(L, "o", l_FictionViewerStage.Set(Fiction_viewer_stages[Fiction_viewer_active_stage]));
+	} else {
+		return ADE_RETURN_NIL;
+	}
 }
 
 ADE_FUNC(getFictionMusicName, l_UserInterface_FictionViewer, nullptr,

--- a/code/scripting/api/objs/fictionviewer.cpp
+++ b/code/scripting/api/objs/fictionviewer.cpp
@@ -13,6 +13,10 @@ ADE_VIRTVAR(TextFile, l_FictionViewerStage, nullptr, "The text file of the stage
 		return ADE_RETURN_NIL;
 	}
 
+	if (stage == nullptr) {
+		return ADE_RETURN_NIL;
+	}
+
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
 	}
@@ -27,6 +31,10 @@ ADE_VIRTVAR(FontFile, l_FictionViewerStage, nullptr, "The font file of the stage
 		return ADE_RETURN_NIL;
 	}
 
+	if (stage == nullptr) {
+		return ADE_RETURN_NIL;
+	}
+
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
 	}
@@ -38,6 +46,10 @@ ADE_VIRTVAR(VoiceFile, l_FictionViewerStage, nullptr, "The voice file of the sta
 {
 	fiction_viewer_stage* stage = nullptr;
 	if (!ade_get_args(L, "o", l_FictionViewerStage.GetPtr(&stage))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (stage == nullptr) {
 		return ADE_RETURN_NIL;
 	}
 


### PR DESCRIPTION
Protects `Fiction_viewer_active_stage` if it reads a stage of -1 (it would have thrown a vector access error because the index is out of range). Also, given a lot of other scripting functions have additional built in error checks, I just added those to the fiction viewer functions.