### PR TITLE
Implemented a command line flag that forces a fixed RNG seed,

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -476,6 +476,8 @@ bool Cmdline_dump_packet_type = false;
 #ifdef WIN32
 bool Cmdline_alternate_registry_path = false;
 #endif
+uint Cmdline_randseed = 0;
+bool Cmdline_randfixed = false;
 
 // Developer/Testing related
 cmdline_parm start_mission_arg("-start_mission", "Skip mainhall and run this mission", AT_STRING);	// Cmdline_start_mission
@@ -507,6 +509,7 @@ cmdline_parm debug_window_arg("-debug_window", NULL, AT_NONE);	// Cmdline_debug_
 cmdline_parm graphics_debug_output_arg("-gr_debug", nullptr, AT_NONE); // Cmdline_graphics_debug_output
 cmdline_parm log_to_stdout_arg("-stdout_log", nullptr, AT_NONE); // Cmdline_log_to_stdout
 cmdline_parm slow_frames_ok_arg("-slow_frames_ok", nullptr, AT_NONE);	// Cmdline_slow_frames_ok
+cmdline_parm fixed_seed_rand("-seed", nullptr, AT_INT);	// Cmdline_randseed,Cmdline_randfixed;
 
 
 char *Cmdline_start_mission = NULL;
@@ -2234,6 +2237,11 @@ bool SetCmdlineParams()
  
 	if (log_multi_packet_arg.found()) {
 		Cmdline_dump_packet_type = true;
+	}
+
+	if (fixed_seed_rand.found()) {
+		Cmdline_randfixed = true;
+		Cmdline_randseed = abs((fixed_seed_rand.get_int()));
 	}
 
 	return true; 

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -22,6 +22,7 @@
 #include "network/multi_log.h"
 #include "options/OptionsManager.h"
 #include "osapi/osapi.h"
+#include "osapi/dialogs.h"
 #include "parse/sexp.h"
 #include "scripting/scripting.h"
 #include "sound/openal.h"
@@ -476,8 +477,8 @@ bool Cmdline_dump_packet_type = false;
 #ifdef WIN32
 bool Cmdline_alternate_registry_path = false;
 #endif
-uint Cmdline_randseed = 0;
-bool Cmdline_randfixed = false;
+uint Cmdline_rng_seed = 0;
+bool Cmdline_reuse_rng_seed = false;
 
 // Developer/Testing related
 cmdline_parm start_mission_arg("-start_mission", "Skip mainhall and run this mission", AT_STRING);	// Cmdline_start_mission
@@ -509,7 +510,7 @@ cmdline_parm debug_window_arg("-debug_window", NULL, AT_NONE);	// Cmdline_debug_
 cmdline_parm graphics_debug_output_arg("-gr_debug", nullptr, AT_NONE); // Cmdline_graphics_debug_output
 cmdline_parm log_to_stdout_arg("-stdout_log", nullptr, AT_NONE); // Cmdline_log_to_stdout
 cmdline_parm slow_frames_ok_arg("-slow_frames_ok", nullptr, AT_NONE);	// Cmdline_slow_frames_ok
-cmdline_parm fixed_seed_rand("-seed", nullptr, AT_INT);	// Cmdline_randseed,Cmdline_randfixed;
+cmdline_parm fixed_seed_rand("-seed", nullptr, AT_INT);	// Cmdline_rng_seed,Cmdline_reuse_rng_seed;
 
 
 char *Cmdline_start_mission = NULL;
@@ -2240,8 +2241,13 @@ bool SetCmdlineParams()
 	}
 
 	if (fixed_seed_rand.found()) {
-		Cmdline_randfixed = true;
-		Cmdline_randseed = abs((fixed_seed_rand.get_int()));
+		Cmdline_rng_seed = abs(fixed_seed_rand.get_int());
+		if (Cmdline_rng_seed>0) {
+			Cmdline_reuse_rng_seed = true;
+		}
+		else {
+			Warning(LOCATION,"-seed must be an integer greater than 0. Invalid input seed will be disregarded.");
+		}
 	}
 
 	return true; 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -944,7 +944,8 @@ void game_level_close()
 uint load_gl_init;
 uint load_mission_load;
 uint load_post_level_init;
-
+extern bool Cmdline_randfixed;
+extern uint Cmdline_randseed;
 /**
  * Intializes game stuff.  
  *
@@ -963,6 +964,8 @@ void game_level_init()
 
 		// semirand function needs to get re-initted every time in multiplayer
 		init_semirand();
+	} else if(Cmdline_randfixed) {
+		Random::seed( Cmdline_randseed );
 	}
 
 	Framecount = 0;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -944,8 +944,8 @@ void game_level_close()
 uint load_gl_init;
 uint load_mission_load;
 uint load_post_level_init;
-extern bool Cmdline_randfixed;
-extern uint Cmdline_randseed;
+extern bool Cmdline_reuse_rng_seed;
+extern uint Cmdline_rng_seed;
 /**
  * Intializes game stuff.  
  *
@@ -964,8 +964,8 @@ void game_level_init()
 
 		// semirand function needs to get re-initted every time in multiplayer
 		init_semirand();
-	} else if(Cmdline_randfixed) {
-		Random::seed( Cmdline_randseed );
+	} else if(Cmdline_reuse_rng_seed) {
+		Random::seed( Cmdline_rng_seed );
 	}
 
 	Framecount = 0;


### PR DESCRIPTION
Reseeds the rng every mission load, if not in MP.

~~In draft because I'm having compiler difficulties and haven't been able to test any.~~

Now tested and appears functional. Doesn't result in noticeable repeatability in chaotic cutscenes, the ultimate goal, but that's expected as this is only one small piece of the puzzle. 