### PR TITLE
fix good-rearm-time bug

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -145,6 +145,7 @@ namespace AI {
 		Prevent_negative_turret_ammo,
 		Fix_keep_safe_distance,
 		Ignore_aspect_when_leading,
+		Fix_good_rearm_time_bug,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -600,6 +600,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$AI ignores aspect lock for leading:", AI::Profile_Flags::Ignore_aspect_when_leading);
 
+				set_flag(profile, "$fix good-rearm-time bug:", AI::Profile_Flags::Fix_good_rearm_time_bug);
+
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
@@ -767,5 +769,8 @@ void ai_profile_t::reset()
 		flags.set(AI::Profile_Flags::Fighterbay_arrivals_use_carrier_orient);
 		flags.set(AI::Profile_Flags::Prevent_negative_turret_ammo);
 		flags.set(AI::Profile_Flags::Fix_keep_safe_distance);
+	}
+	if (mod_supports_version(22, 4, 0)) {
+		flags.set(AI::Profile_Flags::Fix_good_rearm_time_bug);
 	}
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -314,7 +314,7 @@ void ai_set_rearm_status(int team, int time)
 {
 	Assert( time >= 0 );
 
-	Iff_info[team].ai_rearm_timestamp = timestamp(time * 1000);
+	Iff_info[team].ai_rearm_timestamp = _timestamp(time * MILLISECONDS_PER_SECOND);
 }
 
 /**
@@ -330,7 +330,10 @@ int ai_good_time_to_rearm(object *objp)
 	Assert(objp->type == OBJ_SHIP);
 	team = Ships[objp->instance].team;
 	
-	return timestamp_valid(Iff_info[team].ai_rearm_timestamp);
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_good_rearm_time_bug])
+		return Iff_info[team].ai_rearm_timestamp.isValid() && !timestamp_elapsed(Iff_info[team].ai_rearm_timestamp);
+	else
+		return Iff_info[team].ai_rearm_timestamp.isValid();
 }
 
 /**
@@ -883,7 +886,7 @@ void ai_level_init()
 	Ai_goal_signature = 0;
 
 	for (i = 0; i < (int) Iff_info.size(); i++)
-		Iff_info[i].ai_rearm_timestamp = timestamp(-1);
+		Iff_info[i].ai_rearm_timestamp = TIMESTAMP::invalid();
 
 	// clear out the stuff needed for AI firing powerful secondary weapons
 	ai_init_secondary_info();

--- a/code/iff_defs/iff_defs.cpp
+++ b/code/iff_defs/iff_defs.cpp
@@ -394,7 +394,7 @@ void iff_init()
             }
 
 			// this is cleared between each level but let's just set it here for thoroughness
-			iff->ai_rearm_timestamp = timestamp(-1);
+			iff->ai_rearm_timestamp = TIMESTAMP::invalid();
 		}
 
 		required_string("#End");

--- a/code/iff_defs/iff_defs.h
+++ b/code/iff_defs/iff_defs.h
@@ -49,7 +49,7 @@ typedef struct iff_info {
 	flagset<Mission::Parse_Object_Flags> default_parse_flags;
 
 	// used internally, not parsed
-	int ai_rearm_timestamp;
+	TIMESTAMP ai_rearm_timestamp;
 
 } iff_info;
 


### PR DESCRIPTION
The original implementation of `ai_good_time_to_rearm` did not revert to being a "bad" time to rearm when the time was up.  This fixes that and adds an AI profiles flag to toggle it.

Also converts `ai_rearm_timestamp` to use the new TIMESTAMP type.