### PR TITLE
Allow mods to change Emp flash color, intensity, and string

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2466,7 +2466,7 @@ void hud_start_text_flash(const char *txt, int t, int interval)
 	// HACK. don't override EMP if its still going    :)
 	// An additional hack: don't interrupt other warnings if this is a missile launch alert (Swifty)
 	if(!timestamp_elapsed(Hud_text_flash_timer))
-		if( !stricmp(Hud_text_flash, NOX("Emp")) || !stricmp(txt, NOX("Launch")) )
+		if(!stricmp(Hud_text_flash, XSTR("Emp", 1670)) || !stricmp(txt, XSTR("Launch", 1507)))
 			return;
 
 	strncpy(Hud_text_flash, txt, 500);

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -60,7 +60,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // add a new string to the code, you must assign it a new index.  Use the number below for
 // that index and increase the number below by one.
 // retail XSTR_SIZE = 1570
-#define XSTR_SIZE	1670
+#define XSTR_SIZE	1671
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -382,19 +382,19 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Generic Pain Flash Factor:")) {
 			stuff_float(&Generic_pain_flash_factor);
-			if (!fl_equal(Generic_pain_flash_factor, 1.0f))
+			if (Generic_pain_flash_factor > 0.0f)
 				mprintf(("Game Settings Table: Setting generic pain flash factor to %.2f\n", Generic_pain_flash_factor));
 		}
 
 		if (optional_string("$Shield Pain Flash Factor:")) {
 			stuff_float(&Shield_pain_flash_factor);
-			if (!fl_near_zero(Shield_pain_flash_factor, 0.01f))
+			if (Shield_pain_flash_factor > 0.0f)
 				 mprintf(("Game Settings Table: Setting shield pain flash factor to %.2f\n", Shield_pain_flash_factor));
 		}
 
 		if (optional_string("$EMP Pain Flash Factor:")) {
 			stuff_float(&Emp_pain_flash_factor);
-			if (!fl_near_zero(Emp_pain_flash_factor, 0.01f))
+			if (Emp_pain_flash_factor > 0.0f)
 				mprintf(("Game Settings Table: Setting EMP pain flash factor to %.2f\n", Emp_pain_flash_factor));
 		}
 
@@ -402,7 +402,7 @@ void parse_mod_table(const char *filename)
 			int rgb[3];
 			stuff_int_list(rgb, 3);
 			if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
-				Emp_pain_flash_color = std::make_tuple(static_cast<float>(rgb[0]/255), static_cast<float>(rgb[1]/255), static_cast<float>(rgb[2]/255));
+				Emp_pain_flash_color = std::make_tuple(static_cast<float>(rgb[0])/255, static_cast<float>(rgb[1])/255, static_cast<float>(rgb[2])/255);
 			} else {
 				error_display(0, "$EMP Pain Flash Color is %i, %i, %i. "
 					"One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -381,21 +381,30 @@ void parse_mod_table(const char *filename)
 		}
 
 		if (optional_string("$Generic Pain Flash Factor:")) {
-			stuff_float(&Generic_pain_flash_factor);
-			if (Generic_pain_flash_factor > 0.0f)
-				mprintf(("Game Settings Table: Setting generic pain flash factor to %.2f\n", Generic_pain_flash_factor));
+			float temp;
+			stuff_float(&temp);
+			if (temp >= 0.0f) {
+				mprintf(("Game Settings Table: Setting generic pain flash factor to %.2f\n", temp));
+				Generic_pain_flash_factor = temp;
+			}
 		}
 
 		if (optional_string("$Shield Pain Flash Factor:")) {
-			stuff_float(&Shield_pain_flash_factor);
-			if (Shield_pain_flash_factor > 0.0f)
-				 mprintf(("Game Settings Table: Setting shield pain flash factor to %.2f\n", Shield_pain_flash_factor));
+			float temp;
+			stuff_float(&temp);
+			if (temp >= 0.0f) {
+				mprintf(("Game Settings Table: Setting shield pain flash factor to %.2f\n", temp));
+				Shield_pain_flash_factor = temp;
+			}
 		}
 
 		if (optional_string("$EMP Pain Flash Factor:")) {
-			stuff_float(&Emp_pain_flash_factor);
-			if (Emp_pain_flash_factor > 0.0f)
-				mprintf(("Game Settings Table: Setting EMP pain flash factor to %.2f\n", Emp_pain_flash_factor));
+			float temp;
+			stuff_float(&temp);
+			if (temp >= 0.0f) {
+				mprintf(("Game Settings Table: Setting EMP pain flash factor to %.2f\n", temp));
+				Emp_pain_flash_factor = temp;
+			}
 		}
 
 		if (optional_string("$EMP Pain Flash Color:")) {

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -50,7 +50,7 @@ bool Beams_use_damage_factors;
 float Generic_pain_flash_factor;
 float Shield_pain_flash_factor;
 float Emp_pain_flash_factor;
-std::tuple<ubyte, ubyte, ubyte> Emp_pain_flash_color;
+std::tuple<float, float, float> Emp_pain_flash_color;
 gameversion::version Targeted_version; // Defaults to retail
 SCP_string Window_title;
 SCP_string Mod_title;
@@ -382,7 +382,7 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Generic Pain Flash Factor:")) {
 			stuff_float(&Generic_pain_flash_factor);
-			if (!fl_near_zero(Generic_pain_flash_factor, 0.01f))
+			if (!fl_equal(Generic_pain_flash_factor, 1.0f))
 				mprintf(("Game Settings Table: Setting generic pain flash factor to %.2f\n", Generic_pain_flash_factor));
 		}
 
@@ -402,7 +402,7 @@ void parse_mod_table(const char *filename)
 			int rgb[3];
 			stuff_int_list(rgb, 3);
 			if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
-				Emp_pain_flash_color = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
+				Emp_pain_flash_color = std::make_tuple(static_cast<float>(rgb[0]/255), static_cast<float>(rgb[1]/255), static_cast<float>(rgb[2]/255));
 			} else {
 				error_display(0, "$EMP Pain Flash Color is %i, %i, %i. "
 					"One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);
@@ -963,7 +963,7 @@ void mod_table_reset()
 	Generic_pain_flash_factor = 1.0f;
 	Shield_pain_flash_factor = 0.0f;
 	Emp_pain_flash_factor = 1.0f;
-	Emp_pain_flash_color = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(127));
+	Emp_pain_flash_color = std::make_tuple(1.0f, 1.0f, 0.5f);
 	Targeted_version = gameversion::version(2, 0, 0, 0); // Defaults to retail
 	Window_title = "";
 	Mod_title = "";

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -49,6 +49,8 @@ bool Red_alert_applies_to_delayed_ships;
 bool Beams_use_damage_factors;
 float Generic_pain_flash_factor;
 float Shield_pain_flash_factor;
+float Emp_pain_flash_factor;
+std::tuple<ubyte, ubyte, ubyte> Emp_pain_flash_color;
 gameversion::version Targeted_version; // Defaults to retail
 SCP_string Window_title;
 SCP_string Mod_title;
@@ -388,6 +390,23 @@ void parse_mod_table(const char *filename)
 			stuff_float(&Shield_pain_flash_factor);
 			if (Shield_pain_flash_factor != 0.0f)
 				 mprintf(("Game Settings Table: Setting shield pain flash factor to %.2f\n", Shield_pain_flash_factor));
+		}
+
+		if (optional_string("$EMP Pain Flash Factor:")) {
+			stuff_float(&Emp_pain_flash_factor);
+			if (Emp_pain_flash_factor != 0.0f)
+				mprintf(("Game Settings Table: Setting EMP pain flash factor to %.2f\n", Emp_pain_flash_factor));
+		}
+
+		if (optional_string("$EMP Pain Flash Color:")) {
+			int rgb[3];
+			stuff_int_list(rgb, 3);
+			if ((rgb[0] >= 0 && rgb[0] <= 255) && (rgb[1] >= 0 && rgb[1] <= 255) && (rgb[2] >= 0 && rgb[2] <= 255)) {
+				Emp_pain_flash_color = std::make_tuple(static_cast<ubyte>(rgb[0]), static_cast<ubyte>(rgb[1]), static_cast<ubyte>(rgb[2]));
+			} else {
+				error_display(0, "$EMP Pain Flash Color is %i, %i, %i. "
+					"One or more of these values is not within the range of 0-255. Assuming default color.", rgb[0], rgb[1], rgb[2]);
+			}
 		}
 
 		if (optional_string("$BMPMAN Slot Limit:")) {
@@ -943,6 +962,8 @@ void mod_table_reset()
 	Beams_use_damage_factors = false;
 	Generic_pain_flash_factor = 1.0f;
 	Shield_pain_flash_factor = 0.0f;
+	Emp_pain_flash_factor = 1.0f;
+	Emp_pain_flash_color = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(125));
 	Targeted_version = gameversion::version(2, 0, 0, 0); // Defaults to retail
 	Window_title = "";
 	Mod_title = "";

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -382,19 +382,19 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Generic Pain Flash Factor:")) {
 			stuff_float(&Generic_pain_flash_factor);
-			if (Generic_pain_flash_factor != 1.0f)
+			if (!fl_near_zero(Generic_pain_flash_factor, 0.01f))
 				mprintf(("Game Settings Table: Setting generic pain flash factor to %.2f\n", Generic_pain_flash_factor));
 		}
 
 		if (optional_string("$Shield Pain Flash Factor:")) {
 			stuff_float(&Shield_pain_flash_factor);
-			if (Shield_pain_flash_factor != 0.0f)
+			if (!fl_near_zero(Shield_pain_flash_factor, 0.01f))
 				 mprintf(("Game Settings Table: Setting shield pain flash factor to %.2f\n", Shield_pain_flash_factor));
 		}
 
 		if (optional_string("$EMP Pain Flash Factor:")) {
 			stuff_float(&Emp_pain_flash_factor);
-			if (Emp_pain_flash_factor != 0.0f)
+			if (!fl_near_zero(Emp_pain_flash_factor, 0.01f))
 				mprintf(("Game Settings Table: Setting EMP pain flash factor to %.2f\n", Emp_pain_flash_factor));
 		}
 
@@ -963,7 +963,7 @@ void mod_table_reset()
 	Generic_pain_flash_factor = 1.0f;
 	Shield_pain_flash_factor = 0.0f;
 	Emp_pain_flash_factor = 1.0f;
-	Emp_pain_flash_color = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(125));
+	Emp_pain_flash_color = std::make_tuple(static_cast<ubyte>(255), static_cast<ubyte>(255), static_cast<ubyte>(127));
 	Targeted_version = gameversion::version(2, 0, 0, 0); // Defaults to retail
 	Window_title = "";
 	Mod_title = "";

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -39,6 +39,8 @@ extern bool Red_alert_applies_to_delayed_ships;
 extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
+extern float Emp_pain_flash_factor;
+extern std::tuple<ubyte, ubyte, ubyte> Emp_pain_flash_color;
 extern SCP_string Window_title;
 extern SCP_string Mod_title;
 extern SCP_string Mod_version;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -40,7 +40,7 @@ extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
 extern float Emp_pain_flash_factor;
-extern std::tuple<ubyte, ubyte, ubyte> Emp_pain_flash_color;
+extern std::tuple<float, float, float> Emp_pain_flash_color;
 extern SCP_string Window_title;
 extern SCP_string Mod_title;
 extern SCP_string Mod_version;

--- a/code/weapon/emp.cpp
+++ b/code/weapon/emp.cpp
@@ -414,9 +414,9 @@ void emp_start_local(float intensity, float time)
 
 	// play a flash
 	game_flash(
-		std::get<0>(Emp_pain_flash_color) * Emp_pain_flash_factor,
-		std::get<1>(Emp_pain_flash_color) * Emp_pain_flash_factor,
-		std::get<2>(Emp_pain_flash_color) * Emp_pain_flash_factor
+		std::get<0>(Emp_pain_flash_color) * Emp_pain_flash_factor / 255,
+		std::get<1>(Emp_pain_flash_color) * Emp_pain_flash_factor / 255,
+		std::get<2>(Emp_pain_flash_color) * Emp_pain_flash_factor / 255
 	);
 }
 

--- a/code/weapon/emp.cpp
+++ b/code/weapon/emp.cpp
@@ -414,9 +414,9 @@ void emp_start_local(float intensity, float time)
 
 	// play a flash
 	game_flash(
-		std::get<0>(Emp_pain_flash_color) * Emp_pain_flash_factor / 255,
-		std::get<1>(Emp_pain_flash_color) * Emp_pain_flash_factor / 255,
-		std::get<2>(Emp_pain_flash_color) * Emp_pain_flash_factor / 255
+		std::get<0>(Emp_pain_flash_color) * Emp_pain_flash_factor,
+		std::get<1>(Emp_pain_flash_color) * Emp_pain_flash_factor,
+		std::get<2>(Emp_pain_flash_color) * Emp_pain_flash_factor
 	);
 }
 

--- a/code/weapon/emp.cpp
+++ b/code/weapon/emp.cpp
@@ -407,13 +407,17 @@ void emp_start_local(float intensity, float time)
 	}
 
 	// start the emp icon flashing
-	hud_start_text_flash(NOX("Emp"), 5000);
+	hud_start_text_flash(XSTR("Emp", 1670), 5000);
 
 	// determine how much we have to decrement the effect per second
 	Emp_decr = Emp_intensity / time;
 
 	// play a flash
-	game_flash( 1.0f, 1.0f, 0.5f );
+	game_flash(
+		std::get<0>(Emp_pain_flash_color) * Emp_pain_flash_factor,
+		std::get<1>(Emp_pain_flash_color) * Emp_pain_flash_factor,
+		std::get<2>(Emp_pain_flash_color) * Emp_pain_flash_factor
+	);
 }
 
 // stop the emp effect cold


### PR DESCRIPTION
EMP is the only text warning that does not use an entry in the strings table (and thus it's the only text warning gauge that mods cannot change and/or translate). This PR adds a string entry for it to allow mods to translate and change the string like all other HUD gauge text warnings.

Also, EMP flash has a hard coded color and strength factor for the flash, whereas generic pain and shield pain have a configurable flash strength factor (shield pain flash is based on shield color, while generic pain is based on damage dealt). This PR also allows modders to change the strength intensity and color following previously established methods.

This PR also fixes a case of "Launch" that fell through the cracks. The function is supplied the translated string, but within the function it does not check for the translation.

Everything is tested and works as expected.