### PR TITLE
handle irc motd error to prevent connection hang

### DIFF
--- a/code/network/chat_api.cpp
+++ b/code/network/chat_api.cpp
@@ -1038,8 +1038,10 @@ char * ParseIRCMessage(char *Line, int iMode)
 		RemoveChatUser(szNick);
 		return NULL;
 	}
-	if(stricmp(szCmd,"376")==0) //end of motd, trigger autojoin...
+	if((stricmp(szCmd,"376")==0)||
+		(stricmp(szCmd,"422")==0))
 	{
+		//end of motd (or motd missing), trigger autojoin...
 		if (!Chat_server_connected)
 		{
 			Chat_server_connected=1;
@@ -1100,7 +1102,6 @@ char * ParseIRCMessage(char *Line, int iMode)
 	   (stricmp(szCmd,"254")==0)||
 	   (stricmp(szCmd,"255")==0)||
 	   (stricmp(szCmd,"265")==0)||
-	   (stricmp(szCmd,"372")==0)||
 	   (stricmp(szCmd,"375")==0)
 	   )
 	{


### PR DESCRIPTION
A MOTD missing (422) message is non-fatal and should be handled the same as a MOTD end (376) message to prevent the chat connection process from hanging.