### PR TITLE
fix supercap immediate warpout

### DIFF
--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3462,6 +3462,11 @@ int WE_Default::warpStart()
 	{
 		compute_warpout_stuff(&effect_time, &pos);
 		effect_time += SHIPFX_WARP_DELAY;
+
+		if (sip->flags[Ship::Info_Flags::Supercap]) {
+			// turn off warpin physics in case we're jumping out immediately
+			objp->phys_info.flags &= ~PF_SPECIAL_WARP_IN;
+		}
 	}
 
 	radius = shipfx_calculate_effect_radius(objp, direction);


### PR DESCRIPTION
Supercaps have a special physics flag applied when they warp in so that they slow down quickly.  However, if a supercap immediately warps out again - as in Deus Ex Machina and DEM: Interlude - this physics flag will interfere with the process so that the ship doesn't accelerate immediately even though the warpout portal is opening.  This will cause the ship to miss the portal and clip off a section.  The solution is to clear the flag once the warpout process starts.