### PR TITLE
Prevent closed thread from Video Player from re-closing

### DIFF
--- a/code/cutscene/player.cpp
+++ b/code/cutscene/player.cpp
@@ -355,7 +355,8 @@ void Player::stopPlayback() {
 	audioPlaybackClose(&m_state);
 	videoPlaybackClose(&m_state);
 
-	m_decoderThread->join();
+	if(m_decoderThread->joinable())
+		m_decoderThread->join();
 }
 
 void Player::decoderThread() {


### PR DESCRIPTION
The Video Player keeps a thread for decoding. When you tell the player to close, all of its data is deallocated, and the decoding thread is closed. While deallocating the data is secured against deleting it multiple times, closing the thread is not. We should check if the thread is still joinable before we just blindly call join on it to prevent crashes. If it's not joinable, we can pretty much just ignore it at that state