### PR TITLE
Add maneuvering thruster easing

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9523,7 +9523,7 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 
 	aip = &Ai_info[Ships[docker_objp->instance].ai_index];
 
-	docker_objp->phys_info.forward_thrust = 0.0f;		//	Kill thrust so we don't have a sputtering thruster.
+	docker_objp->phys_info.linear_thrust.xyz.z = 0.0f;		//	Kill thrust so we don't have a sputtering thruster.
 
 	// Goober5000 - moved out here to save calculations
 	if (dock_mode != DOA_DOCK_STAY)
@@ -13209,7 +13209,7 @@ int ai_acquire_emerge_path(object *pl_objp, int parent_objnum, int allowed_path_
 	pl_objp->phys_info.prev_ramp_vel.xyz.x = 0.0f;
 	pl_objp->phys_info.prev_ramp_vel.xyz.y = 0.0f;
 	pl_objp->phys_info.prev_ramp_vel.xyz.z = 0.0f;
-	pl_objp->phys_info.forward_thrust = 0.0f;		// How much the forward thruster is applied.  0-1.
+	pl_objp->phys_info.linear_thrust.xyz.z = 0.0f;		// How much the forward thruster is applied.  0-1.
 	pl_objp->pos = pos;
 
 	vec3d rvec;		vm_vec_zero(&rvec);
@@ -14936,8 +14936,6 @@ void init_ai_object(int objnum)
 
 	aip->attacker_objnum = -1;
 	aip->goal_signature = -1;
-
-	Objects[objnum].phys_info.prev_fvec = Objects[objnum].orient.vec.fvec;
 
 	aip->last_predicted_enemy_pos.xyz.x = 0.0f;	//	Says this value needs to be recomputed!
 	aip->time_enemy_in_range = 0.0f;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13231,7 +13231,7 @@ int ai_acquire_emerge_path(object *pl_objp, int parent_objnum, int allowed_path_
 	pl_objp->phys_info.prev_ramp_vel.xyz.x = 0.0f;
 	pl_objp->phys_info.prev_ramp_vel.xyz.y = 0.0f;
 	pl_objp->phys_info.prev_ramp_vel.xyz.z = 0.0f;
-	pl_objp->phys_info.linear_thrust.xyz.z = 0.0f;		// How much the forward thruster is applied.  0-1.
+	pl_objp->phys_info.linear_thrust.xyz.z = 0.0f;		// How much the forward thruster is applied.  -1 - 1.
 	pl_objp->pos = pos;
 
 	vec3d rvec;		vm_vec_zero(&rvec);

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1947,7 +1947,7 @@ void update_throttle_sound()
 		throttle_sound_check_id = timestamp(THROTTLE_SOUND_CHECK_INTERVAL);
 	
 		if ( object_get_gliding(Player_obj) ) {	// Backslash
-			percent_throttle = Player_obj->phys_info.forward_thrust;
+			percent_throttle = Player_obj->phys_info.linear_thrust.xyz.z;
 		} else {
 			percent_throttle = Player_obj->phys_info.fspeed / Ship_info[Ships[Player_obj->instance].ship_info_index].max_speed;
 		}

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -89,7 +89,7 @@ void LabRenderer::renderModel(float frametime) {
 		model_render_set_wireframe_color(&Color_white);
 
 	if (renderFlags[LabRenderFlag::ShowThrusters] || renderFlags[LabRenderFlag::ShowAfterburners]) {
-		obj->phys_info.forward_thrust = 1.0f;
+		obj->phys_info.linear_thrust.xyz.z = 1.0f;
 		if (obj->type == OBJ_SHIP) {
 			Ships[obj->instance].flags.remove(Ship::Ship_Flags::No_thrusters);
 		}
@@ -102,7 +102,7 @@ void LabRenderer::renderModel(float frametime) {
 			obj->phys_info.flags &= ~PF_AFTERBURNER_ON;
 	}
 	else {
-		obj->phys_info.forward_thrust = 0.0f;
+		obj->phys_info.linear_thrust.xyz.z = 0.0f;
 
 		if (obj->type == OBJ_SHIP)
 			Ships[obj->instance].flags.set(Ship::Ship_Flags::No_thrusters);

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -92,6 +92,7 @@ bool Show_subtitle_uses_pixels;
 int Show_subtitle_screen_base_res[2];
 int Show_subtitle_screen_adjusted_res[2];
 bool Always_warn_player_about_unbound_keys;
+float Thruster_easing;
 
 void mod_table_set_version_flags();
 
@@ -568,6 +569,14 @@ void parse_mod_table(const char *filename)
 			stuff_float(&Min_pixel_size_laser);
 		}
 
+		if (optional_string("$Thruster easing value:")) {
+			stuff_float(&Thruster_easing);
+			if (Thruster_easing <= 0.0f) {
+				Warning(LOCATION, "A \'Thruster easing value\' less than or equal to 0 will not be used.\n");
+			}
+
+		}
+
 		optional_string("#NETWORK SETTINGS");
 
 		if (optional_string("$FS2NetD port:")) {
@@ -921,6 +930,7 @@ void mod_table_reset()
 	Show_subtitle_screen_adjusted_res[0] = -1;
 	Show_subtitle_screen_adjusted_res[1] = -1;
 	Always_warn_player_about_unbound_keys = false;
+	Thruster_easing = 0;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -81,6 +81,7 @@ extern bool Show_subtitle_uses_pixels;
 extern int Show_subtitle_screen_base_res[];
 extern int Show_subtitle_screen_adjusted_res[];
 extern bool Always_warn_player_about_unbound_keys;
+extern float Thruster_easing;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/observer/observer.cpp
+++ b/code/observer/observer.cpp
@@ -69,9 +69,9 @@ int observer_create(matrix *orient, vec3d *pos)
 	vm_vec_zero(&pi->desired_rotvel);
 	vm_vec_zero(&pi->vel);
 	vm_vec_zero(&pi->rotvel);
-	vm_vec_zero(&pi->prev_fvec);
 	vm_set_identity(&pi->last_rotmat);
-	pi->forward_thrust = 0.0f;
+	vm_vec_zero(&pi->linear_thrust);
+	vm_vec_zero(&pi->rotational_thrust);
 	pi->speed = 0.0f;
 	pi->fspeed = 0.0f;
 	pi->heading = 0.0f;

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -68,9 +68,9 @@ void physics_init( physics_info * pi )
 	pi->slide_decel_time_const=pi->side_slip_time_const;	// slide using max_vel.xyz.x & .xyz.y
 
 	pi->afterburner_decay = 1;
-	pi->forward_thrust = 0.0f;
-	pi->vert_thrust = 0.0f;	//added these two in order to get side and forward thrusters
-	pi->side_thrust = 0.0f;	//to glow brighter when the ship is moving in the right direction -Bobboau
+
+	vm_vec_zero(&pi->linear_thrust);
+	vm_vec_zero(&pi->rotational_thrust);
 
 	pi->flags = 0;
 
@@ -516,9 +516,24 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 		pi->desired_rotvel.xyz.z = ci->bank * pi->max_rotvel.xyz.z + delta_bank;
 	}
 
-	pi->forward_thrust = ci->forward;
-	pi->vert_thrust = ci->vertical;	//added these two in order to get side and forward thrusters
-	pi->side_thrust = ci->sideways;	//to glow brighter when the ship is moving in the right direction -Bobboau
+	// update 'thrust values' (these are cosmetic and do not affect physical behavior)
+	if (Thruster_easing > 0.0f) {
+		pi->linear_thrust.xyz.z = ci->forward +  (pi->linear_thrust.xyz.z - ci->forward) *  exp2f(-Thruster_easing * sim_time);
+		pi->linear_thrust.xyz.y = ci->vertical + (pi->linear_thrust.xyz.y - ci->vertical) * exp2f(-Thruster_easing * sim_time);
+		pi->linear_thrust.xyz.x = ci->sideways + (pi->linear_thrust.xyz.x - ci->sideways) * exp2f(-Thruster_easing * sim_time);
+
+		pi->rotational_thrust.xyz.z = ci->bank +    (pi->rotational_thrust.xyz.z - ci->bank) *    exp2f(-Thruster_easing * sim_time);
+		pi->rotational_thrust.xyz.y = ci->heading + (pi->rotational_thrust.xyz.y - ci->heading) * exp2f(-Thruster_easing * sim_time);
+		pi->rotational_thrust.xyz.x = ci->pitch +   (pi->rotational_thrust.xyz.x - ci->pitch) *   exp2f(-Thruster_easing * sim_time);
+	} else {
+		pi->linear_thrust.xyz.z = ci->forward;
+		pi->linear_thrust.xyz.y = ci->vertical;
+		pi->linear_thrust.xyz.x = ci->sideways;
+
+		pi->rotational_thrust.xyz.z = ci->bank;
+		pi->rotational_thrust.xyz.y = ci->heading;
+		pi->rotational_thrust.xyz.x = ci->pitch;
+	}
 
 	if ( pi->flags & PF_AFTERBURNER_ON ) {
 		goal_vel.xyz.x = ci->sideways*pi->afterburner_max_vel.xyz.x;

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -74,9 +74,11 @@ typedef struct physics_info {
 	vec3d	desired_vel;				// in world coord, (possibly) damped by side_slip_time_const to get final vel
 	vec3d	desired_rotvel;				// in local coords, damped by rotdamp to get final rotvel
 										// With framerate_independent_turning, the AI are not damped, see physics_sim_rot
-	float		forward_thrust;			// How much the forward thruster is applied.  0-1.
-	float		side_thrust;			// How much the forward thruster is +x.  0-1.
-	float		vert_thrust;			// How much the forward thruster is +y.  0-1.
+
+	vec3d  linear_thrust;				// -1 through 1, how much thrust is being applied in the lateral directions
+										// COSMETIC ONLY, this should not be used for physical behavior
+	vec3d  rotational_thrust;			// -1 through 1, how much thrust is being applied in the rotationally
+										// COSMETIC ONLY, this should not be used for physical behavior
 		
 	// Data that changes each frame.  Physics fills these in each frame.
 	vec3d	vel;						// The current velocity vector of this object
@@ -84,7 +86,6 @@ typedef struct physics_info {
 	float		speed;					// Yes, this can be derived from velocity, but that's expensive!
 	float		fspeed;					//	Speed in the forward direction.
 	float		heading;
-	vec3d	prev_fvec;				//	Used in AI for momentum.
 	matrix	last_rotmat;			//	Used for moving two objects together and for editor.
 
 	int		afterburner_decay;	// timestamp used to control how long ship shakes after afterburner released

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -77,7 +77,7 @@ typedef struct physics_info {
 
 	vec3d  linear_thrust;				// -1 through 1, how much thrust is being applied in the lateral directions
 										// COSMETIC ONLY, this should not be used for physical behavior
-	vec3d  rotational_thrust;			// -1 through 1, how much thrust is being applied in the rotationally
+	vec3d  rotational_thrust;			// -1 through 1, how much thrust is being applied rotationally
 										// COSMETIC ONLY, this should not be used for physical behavior
 		
 	// Data that changes each frame.  Physics fills these in each frame.

--- a/code/scripting/api/objs/physics_info.cpp
+++ b/code/scripting/api/objs/physics_info.cpp
@@ -114,7 +114,7 @@ ADE_VIRTVAR(ForwardDecelerationTime, l_Physics, "number", "Forward deceleration 
 	return ade_set_args(L, "f", pih->pi->forward_decel_time_const);
 }
 
-ADE_VIRTVAR(ForwardThrust, l_Physics, "number", "Forward thrust amount (0-1), used primarily for thruster graphics", "number", "Forward thrust, or 0 if handle is invalid")
+ADE_VIRTVAR(ForwardThrust, l_Physics, "number", "Forward thrust amount (-1 - 1), used primarily for thruster graphics and does not affect any physical behavior", "number", "Forward thrust, or 0 if handle is invalid")
 {
 	physics_info_h *pih;
 	float f = 0.0f;
@@ -125,10 +125,10 @@ ADE_VIRTVAR(ForwardThrust, l_Physics, "number", "Forward thrust amount (0-1), us
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
-		pih->pi->forward_thrust = f;
+		pih->pi->linear_thrust.xyz.z = f;
 	}
 
-	return ade_set_args(L, "f", pih->pi->forward_thrust);
+	return ade_set_args(L, "f", pih->pi->linear_thrust.xyz.z);
 }
 
 ADE_VIRTVAR(Mass, l_Physics, "number", "Object mass", "number", "Object mass, or 0 if handle is invalid")
@@ -233,7 +233,7 @@ ADE_VIRTVAR(ShockwaveShakeAmplitude, l_Physics, "number", "How much shaking from
 	return ade_set_args(L, "f", pih->pi->shockwave_shake_amp);
 }
 
-ADE_VIRTVAR(SideThrust, l_Physics, "number", "Side thrust amount (0-1), used primarily for thruster graphics", "number", "Side thrust amount, or 0 if handle is invalid")
+ADE_VIRTVAR(SideThrust, l_Physics, "number", "Side thrust amount (-1 - 1), used primarily for thruster graphics and does not affect any physical behavior", "number", "Side thrust amount, or 0 if handle is invalid")
 {
 	physics_info_h *pih;
 	float f = 0.0f;
@@ -244,10 +244,10 @@ ADE_VIRTVAR(SideThrust, l_Physics, "number", "Side thrust amount (0-1), used pri
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
-		pih->pi->side_thrust = f;
+		pih->pi->linear_thrust.xyz.x = f;
 	}
 
-	return ade_set_args(L, "f", pih->pi->side_thrust);
+	return ade_set_args(L, "f", pih->pi->linear_thrust.xyz.x);
 }
 
 ADE_VIRTVAR(SlideAccelerationTime, l_Physics, "number", "Time to accelerate to maximum slide velocity", "number", "Sliding acceleration time, or 0 if handle is invalid")
@@ -352,7 +352,7 @@ ADE_VIRTVAR(VelocityMax, l_Physics, "vector", "Object max local velocity (Local 
 	return ade_set_args(L, "o", l_Vector.Set(pih->pi->max_vel));
 }
 
-ADE_VIRTVAR(VerticalThrust, l_Physics, "number", "Vertical thrust amount (0-1), used primarily for thruster graphics", "number", "Vertical thrust amount, or 0 if handle is invalid")
+ADE_VIRTVAR(VerticalThrust, l_Physics, "number", "Vertical thrust amount (-1 - 1), used primarily for thruster graphics and does not affect any physical behavior", "number", "Vertical thrust amount, or 0 if handle is invalid")
 {
 	physics_info_h *pih;
 	float f = 0.0f;
@@ -363,10 +363,10 @@ ADE_VIRTVAR(VerticalThrust, l_Physics, "number", "Vertical thrust amount (0-1), 
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
-		pih->pi->vert_thrust = f;
+		pih->pi->linear_thrust.xyz.y = f;
 	}
 
-	return ade_set_args(L, "f", pih->pi->vert_thrust);
+	return ade_set_args(L, "f", pih->pi->linear_thrust.xyz.y);
 }
 
 ADE_VIRTVAR(AfterburnerActive, l_Physics, "boolean", "Specifies if the afterburner is active or not", "boolean", "true if afterburner is active false otherwise")

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3534,7 +3534,7 @@ int WE_Default::warpStart()
 			objp->phys_info.prev_ramp_vel.xyz.x = 0.0f;
 			objp->phys_info.prev_ramp_vel.xyz.y = 0.0f;
 			objp->phys_info.prev_ramp_vel.xyz.z = warping_speed;
-			objp->phys_info.linear_thrust.xyz.z = 1.0f;		// How much the forward thruster is applied.  0-1.
+			objp->phys_info.linear_thrust.xyz.z = 1.0f;		// How much the forward thruster is applied.  -1 - 1.
 		}
 	}
 
@@ -3569,7 +3569,7 @@ int WE_Default::warpFrame(float frametime)
 			objp->phys_info.prev_ramp_vel.xyz.x = 0.0f;
 			objp->phys_info.prev_ramp_vel.xyz.y = 0.0f;
 			objp->phys_info.prev_ramp_vel.xyz.z = warping_speed;
-			objp->phys_info.linear_thrust.xyz.z = 0.0f;		// How much the forward thruster is applied.  0-1.
+			objp->phys_info.linear_thrust.xyz.z = 0.0f;		// How much the forward thruster is applied.  -1 - 1.
 
 			stage_time_end = timestamp(fl2i(warping_time*1000.0f));
 		}

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3535,7 +3535,7 @@ int WE_Default::warpStart()
 			objp->phys_info.prev_ramp_vel.xyz.x = 0.0f;
 			objp->phys_info.prev_ramp_vel.xyz.y = 0.0f;
 			objp->phys_info.prev_ramp_vel.xyz.z = warping_speed;
-			objp->phys_info.forward_thrust = 1.0f;		// How much the forward thruster is applied.  0-1.
+			objp->phys_info.linear_thrust.xyz.z = 1.0f;		// How much the forward thruster is applied.  0-1.
 		}
 	}
 
@@ -3570,7 +3570,7 @@ int WE_Default::warpFrame(float frametime)
 			objp->phys_info.prev_ramp_vel.xyz.x = 0.0f;
 			objp->phys_info.prev_ramp_vel.xyz.y = 0.0f;
 			objp->phys_info.prev_ramp_vel.xyz.z = warping_speed;
-			objp->phys_info.forward_thrust = 0.0f;		// How much the forward thruster is applied.  0-1.
+			objp->phys_info.linear_thrust.xyz.z = 0.0f;		// How much the forward thruster is applied.  0-1.
 
 			stage_time_end = timestamp(fl2i(warping_time*1000.0f));
 		}


### PR DESCRIPTION
After some double checking to make sure it was only cosmetic, the `phys_info` thrust values are now dedicated to being cosmetic only, this way they can be cosmetically altered via a new 'thruster easing' parameter. Helps make thruster activation less jittery when used by fighters.

Does some miscellaneous clean up putting all the thrust values into a single vector, and make a similarly cosmetic `rotational_thrust` vector, which takes the place of `desired_rotvel` for use in thrusters. 
Remove vestigal field `prev_fvec`.
Fixes several erroneous docs which says the values are 0-1 when they're really -1 - 1.