### PR TITLE
fix subtitle clipping

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -831,7 +831,10 @@ void subtitle::do_frame(float frametime)
 
 	auto sizing_mode = do_screen_scaling ? GR_RESIZE_FULL : GR_RESIZE_NONE;
 	if (do_screen_scaling)
+	{
 		gr_set_screen_scale(Show_subtitle_screen_adjusted_res[0], Show_subtitle_screen_adjusted_res[1]);
+		gr_set_clip(0, 0, Show_subtitle_screen_adjusted_res[0], Show_subtitle_screen_adjusted_res[1]);
+	}
 
 	// do the actual drawing ---------------------
 
@@ -879,7 +882,10 @@ void subtitle::do_frame(float frametime)
 	// finished the actual drawing ---------------
 
 	if (do_screen_scaling)
+	{
 		gr_reset_screen_scale();
+		gr_reset_clip();
+	}
 
 	// restore old font
 	if (old_fontnum >= 0)


### PR DESCRIPTION
For subtitles drawn using the `$Show-subtitle base resolution:` feature, text near the side of the screen would get clipped off mysteriously:

![screen0261](https://user-images.githubusercontent.com/1878523/188551787-1f8952a4-7ebb-4226-aa87-ab6ee611cc61.png)

The clipping corresponded precisely to the edge of a 4:3 boundary:

![4_3_box](https://user-images.githubusercontent.com/1878523/188551809-c216839e-9f8d-4be8-abe1-117dd03c00eb.jpg)

This led me to discover that `gr_screen.clip_right_unscaled` was still set for a 4:3 box, rather than a 16:10 box as was expected.  Explicitly setting the clip boundary when setting the screen scale fixes the issue:

![screen0262](https://user-images.githubusercontent.com/1878523/188552086-e22614b3-e234-44e4-b541-ac166563603b.png)

For any graphics coders in the know, is this actually the proper fix?