### PR TITLE
Fix issue with new pilots getting demoted too fast

### DIFF
--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -246,9 +246,8 @@ void pilotfile::update_stats_backout(scoring_struct *stats, bool training)
 	if (stats->m_promotion_earned >= 0) {
 		// deal with a multi-rank promotion mission
 		for (i = 0; i < MAX_FREESPACE2_RANK; ++i) {
-			if (p_stats->score <= Ranks[i].points) {
-				p_stats->rank = i-1;
-				break;
+			if (p_stats->score >= Ranks[i].points) {
+				p_stats->rank = i;
 			}
 		}
 		Assertion (p_stats->rank >= 0, "Rank became negative.");


### PR DESCRIPTION
If a new pilot manages to gain a rank during the first mission and then decides to replay that mission, the check to reset the rank was accidentally demoting the pilot by two ranks instead of one. Inverting the check and just iterating through the ranks table until the fitting rank can be found fixes this.

This fixes #4614 