### PR TITLE
convert event-related timestamps to new system

### DIFF
--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -175,7 +175,7 @@ int Num_goals = 0;								// number of goals for this mission
 int Event_index = -1;  // used by sexp code to tell what event it came from
 bool Log_event = false;
 bool Snapshot_all_events = false;
-int Mission_goal_timestamp;
+TIMESTAMP Mission_goal_timestamp;
 
 mission_event Mission_events[MAX_MISSION_EVENTS];
 mission_goal Mission_goals[MAX_GOALS];		// structure for the goals of this mission
@@ -186,8 +186,8 @@ SCP_vector<event_annotation> Event_annotations;
 #define DIRECTIVE_SOUND_DELAY			500					// time directive success sound effect is delayed
 #define DIRECTIVE_SPECIAL_DELAY		7000					// mark special directives as true after 7 seconds
 
-static int Mission_directive_sound_timestamp;	// timestamp to control when directive succcess sound gets played
-static int Mission_directive_special_timestamp;	// used to specially mark a directive as true even though it's not
+static TIMESTAMP Mission_directive_sound_timestamp;		// timestamp to control when directive succcess sound gets played
+static TIMESTAMP Mission_directive_special_timestamp;	// used to specially mark a directive as true even though it's not
 
 const char *Goal_type_text(int n)
 {
@@ -378,11 +378,11 @@ void mission_init_goals()
 	Num_mission_events = 0;
 	for (i=0; i<MAX_MISSION_EVENTS; i++) {
 		Mission_events[i].result = 0;
-		Mission_events[i].timestamp = timestamp(-1);
+		Mission_events[i].timestamp = TIMESTAMP::invalid();
 		Mission_events[i].flags = 0;
 		Mission_events[i].count = 0;
-		Mission_events[i].satisfied_time = 0;
-		Mission_events[i].born_on_date = 0;
+		Mission_events[i].satisfied_time = TIMESTAMP::invalid();
+		Mission_events[i].born_on_date = TIMESTAMP::invalid();
 		Mission_events[i].team = -1;
 
 		Mission_events[i].mission_log_flags = 0;
@@ -394,9 +394,9 @@ void mission_init_goals()
 		Mission_events[i].previous_result = 0;
 	}
 
-	Mission_goal_timestamp = timestamp(GOAL_TIMESTAMP);
-	Mission_directive_sound_timestamp = 0;
-	Mission_directive_special_timestamp = timestamp(-1);		// need to make invalid right away
+	Mission_goal_timestamp = _timestamp(GOAL_TIMESTAMP);
+	Mission_directive_sound_timestamp = TIMESTAMP::invalid();
+	Mission_directive_special_timestamp = TIMESTAMP::invalid();		// need to make invalid right away
 }
 
 // called at the end of a mission for cleanup
@@ -834,14 +834,14 @@ int mission_get_event_status(int event)
 
 		// if the timestamp has elapsed, we can "mark" this directive as true although it's really not.
 		if ( timestamp_elapsed(Mission_directive_special_timestamp) ) {
-			Mission_events[event].satisfied_time = Missiontime;
+			Mission_events[event].satisfied_time = _timestamp();
 			Mission_events[event].flags |= MEF_DIRECTIVE_TEMP_TRUE;
 		}
 
 		return EVENT_CURRENT;
 	} else if (Mission_events[event].flags & MEF_CURRENT) {
-		if (!Mission_events[event].born_on_date){
-			Mission_events[event].born_on_date = timestamp();
+		if (!Mission_events[event].born_on_date.isValid()) {
+			Mission_events[event].born_on_date = _timestamp();
 		}
 
 		if (Mission_events[event].result) {
@@ -869,7 +869,7 @@ void mission_event_set_directive_special(int event)
 
 	// start from a known state
 	Mission_events[event].flags &= ~MEF_DIRECTIVE_TEMP_TRUE;
-	Mission_directive_special_timestamp = timestamp(DIRECTIVE_SPECIAL_DELAY);
+	Mission_directive_special_timestamp = _timestamp(DIRECTIVE_SPECIAL_DELAY);
 }
 
 void mission_event_unset_directive_special(int event)
@@ -885,13 +885,13 @@ void mission_event_unset_directive_special(int event)
 	if ( Mission_events[event].flags & MEF_DIRECTIVE_TEMP_TRUE ){
 		Mission_events[event].flags &= ~MEF_DIRECTIVE_TEMP_TRUE;
 	}
-	Mission_events[event].satisfied_time = 0;
-	Mission_directive_special_timestamp = timestamp(-1);
+	Mission_events[event].satisfied_time = TIMESTAMP::invalid();
+	Mission_directive_special_timestamp = TIMESTAMP::invalid();
 }
 
 void mission_event_set_completion_sound_timestamp()
 {
-	Mission_directive_sound_timestamp = timestamp(DIRECTIVE_SOUND_DELAY);
+	Mission_directive_sound_timestamp = _timestamp(DIRECTIVE_SOUND_DELAY);
 }
 
 // function which evaluates and processes the given event
@@ -913,26 +913,28 @@ void mission_process_event( int event )
 
 	// if chained, insure that previous event is true and next event is false
 	if (Mission_events[event].chain_delay >= 0) {  // this indicates it's chained
-		fix offset;
+		int offset;
 		if (Mission_events[event].flags & MEF_USE_MSECS) {
-			offset = fl2f(Mission_events[event].chain_delay * 0.001f);
+			offset = Mission_events[event].chain_delay;
 		} else {
-			offset = i2f(Mission_events[event].chain_delay);
+			offset = Mission_events[event].chain_delay * MILLISECONDS_PER_SECOND;
 		}
 
 		// What everyone expected the chaining behavior to be, as specified in Karajorma's original fix to Mantis #82
 		if (Alternate_chaining_behavior) {
 			if (event > 0){
-				if (!Mission_events[event - 1].result || ((fix) Mission_events[event - 1].satisfied_time + offset > Missiontime)){
-					sindex = -1;  // bypass evaluation
+				if (!Mission_events[event - 1].result ||
+					(Mission_events[event - 1].satisfied_time.isValid() && timestamp_since(Mission_events[event - 1].satisfied_time) < offset)) {
+						sindex = -1;  // bypass evaluation
 				}
 			}
 		}
 		// Volition's original chaining behavior as used in retail and demonstrated in e.g. btm-01.fsm (or btm-01.fs2 in the Port)
 		else {
 			if (event > 0){
-				if (!Mission_events[event - 1].result || ((fix) Mission_events[event - 1].timestamp + offset > Missiontime)){
-					sindex = -1;  // bypass evaluation
+				if (!Mission_events[event - 1].result ||
+					(Mission_events[event - 1].timestamp.isValid() && timestamp_since(Mission_events[event - 1].timestamp) < offset)) {
+						sindex = -1;  // bypass evaluation
 				}
 			}
 
@@ -986,8 +988,8 @@ void mission_process_event( int event )
 
 	// if the sexpression is known false, then no need to evaluate anymore
 	if ((sindex >= 0) && (Sexp_nodes[sindex].value == SEXP_KNOWN_FALSE)) {
-		Mission_events[event].timestamp = (int) Missiontime;
-		Mission_events[event].satisfied_time = Missiontime;
+		Mission_events[event].timestamp = _timestamp();
+		Mission_events[event].satisfied_time = _timestamp();
 		// _argv[-1] - repeat_count of -1 would mean repeat indefinitely, so set to 0 instead.
 		Mission_events[event].repeat_count = 0;
 		Mission_events[event].formula = -1;
@@ -999,8 +1001,8 @@ void mission_process_event( int event )
 		return;
 	}
 
-	if (result && !Mission_events[event].satisfied_time) {
-		Mission_events[event].satisfied_time = Missiontime;
+	if (result && !Mission_events[event].satisfied_time.isValid()) {
+		Mission_events[event].satisfied_time = _timestamp();
 		if ( Mission_events[event].objective_text ) {
 			mission_event_set_completion_sound_timestamp();
 		}
@@ -1019,12 +1021,12 @@ void mission_process_event( int event )
 	}
 
 	// decrement the repeat count.  When at 0, don't eval this function anymore
-	if ( result || timestamp_valid(Mission_events[event].timestamp) ) {
+	if ( result || Mission_events[event].timestamp.isValid() ) {
 		// _argv[-1] - negative repeat count means repeat indefinitely.
 		if ( Mission_events[event].repeat_count > 0 )
 			Mission_events[event].repeat_count--;
 		if ( Mission_events[event].repeat_count == 0 ) {
-			Mission_events[event].timestamp = (int)Missiontime;
+			Mission_events[event].timestamp = _timestamp();
 			Mission_events[event].formula = -1;
 
 			if(Game_mode & GM_MULTIPLAYER){
@@ -1044,7 +1046,7 @@ void mission_process_event( int event )
 				interval *= 1000;
 
 			// set the timestamp to time out 'interval' milliseconds in the future.
-			Mission_events[event].timestamp = timestamp( interval );
+			Mission_events[event].timestamp = _timestamp( interval );
 		}
 	}
 
@@ -1059,7 +1061,7 @@ void mission_process_event( int event )
 void mission_maybe_play_directive_success_sound()
 {
 	if ( timestamp_elapsed(Mission_directive_sound_timestamp) ) {
-		Mission_directive_sound_timestamp=0;
+		Mission_directive_sound_timestamp = TIMESTAMP::invalid();
 		snd_play( gamesnd_get_game_sound(GameSounds::DIRECTIVE_COMPLETE) );
 	}
 }
@@ -1073,7 +1075,7 @@ void mission_eval_goals()
 	// process any whose timestamp is valid and has expired.  This would catch repeating events only
 	for (i=0; i<Num_mission_events; i++) {
 		if (Mission_events[i].formula != -1) {
-			if ( !timestamp_valid(Mission_events[i].timestamp) || !timestamp_elapsed(Mission_events[i].timestamp) ){
+			if ( !Mission_events[i].timestamp.isValid() || !timestamp_elapsed(Mission_events[i].timestamp) ){
 				continue;
 			}
 
@@ -1113,7 +1115,7 @@ void mission_eval_goals()
 			// only evaluate this event if the timestamp is not valid.  We do this since
 			// we will evaluate repeatable events at the top of the file so we can get
 			// the exact interval that the designer asked for.
-			if ( !timestamp_valid( Mission_events[i].timestamp) ){
+			if ( !Mission_events[i].timestamp.isValid() ){
 				TRACE_SCOPE(tracing::NonrepeatingEvents);
 				mission_process_event( i );
 			}
@@ -1126,9 +1128,9 @@ void mission_eval_goals()
 	}
 
 	if (The_mission.game_type & MISSION_TYPE_TRAINING){
-		Mission_goal_timestamp = timestamp(GOAL_TIMESTAMP_TRAINING);
+		Mission_goal_timestamp = _timestamp(GOAL_TIMESTAMP_TRAINING);
 	} else {
-		Mission_goal_timestamp = timestamp(GOAL_TIMESTAMP);
+		Mission_goal_timestamp = _timestamp(GOAL_TIMESTAMP);
 	}
 
 	if ( !hud_disabled() && hud_gauge_active(HUD_DIRECTIVES_VIEW) ) {
@@ -1519,6 +1521,26 @@ int mission_event_find_sexp_tree(int root_node)
 {
 	for (int i = 0; i < Num_mission_events; ++i)
 		if (Mission_events[i].formula == root_node)
+			return i;
+	return -1;
+}
+
+int mission_goal_lookup(const char *name)
+{
+	Assertion(name != nullptr, "Goal name cannot be null!");
+
+	for (int i = 0; i < Num_goals; ++i)
+		if (!stricmp(Mission_goals[i].name, name))
+			return i;
+	return -1;
+}
+
+int mission_event_lookup(const char *name)
+{
+	Assertion(name != nullptr, "Event name cannot be null!");
+
+	for (int i = 0; i < Num_mission_events; ++i)
+		if (!stricmp(Mission_events[i].name, name))
 			return i;
 	return -1;
 }

--- a/code/mission/missiongoals.h
+++ b/code/mission/missiongoals.h
@@ -84,6 +84,7 @@ extern int	Num_goals;									// number of goals for this mission
 #define MEF_DIRECTIVE_TEMP_TRUE		(1 << 2)		// this directive is temporarily true.
 #define MEF_USING_TRIGGER_COUNT		(1 << 3)		// Karajorma - use trigger count as well as repeat count to determine how many repeats this event has
 #define MEF_USE_MSECS				(1 << 4)		// Goober5000 - interval and chain delay are in milliseconds, not seconds
+#define MEF_TIMESTAMP_HAS_INTERVAL	(1 << 5)		// Goober5000 - flag to simulate Volition's gloriously buggy hack
 
 #define MAX_MISSION_EVENT_LOG_FLAGS		9			// this must be changed if a mission log flag is added below
 
@@ -109,7 +110,7 @@ typedef struct mission_event {
 	TIMESTAMP	timestamp;		// set at 'interval' seconds when we start to eval.
 	int	score;					// score for this event
 	int	chain_delay;
-	int	flags;
+	int	flags;					// MEF_*
 	char	*objective_text;
 	char	*objective_key_text;
 	int	count;					// object count for directive display

--- a/code/mission/missiongoals.h
+++ b/code/mission/missiongoals.h
@@ -14,6 +14,7 @@
 
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
+#include "io/timer.h"
 
 struct ai_goal;
 struct ai_info;
@@ -105,15 +106,15 @@ typedef struct mission_event {
 	int	repeat_count;			// number of times to test this goal
 	int trigger_count;			// number of times to allow this goal to trigger
 	int	interval;				// interval (in seconds) at which an evaulation is repeated once true.
-	int	timestamp;				// set at 'interval' seconds when we start to eval.
+	TIMESTAMP	timestamp;		// set at 'interval' seconds when we start to eval.
 	int	score;					// score for this event
 	int	chain_delay;
 	int	flags;
 	char	*objective_text;
 	char	*objective_key_text;
 	int	count;					// object count for directive display
-	int	satisfied_time;			// this is used to temporarily mark the directive as satisfied when the event isn't (e.g. for a destroyed wave when there are more waves later)
-	int	born_on_date;			// timestamp at which event was born
+	TIMESTAMP	satisfied_time;	// this is used to temporarily mark the directive as satisfied when the event isn't (e.g. for a destroyed wave when there are more waves later)
+	TIMESTAMP	born_on_date;	// timestamp at which event was born
 	int	team;						// for multiplayer games
 
 	// event log stuff
@@ -129,7 +130,7 @@ typedef struct mission_event {
 
 extern int Num_mission_events;
 extern mission_event Mission_events[MAX_MISSION_EVENTS];
-extern int Mission_goal_timestamp;
+extern TIMESTAMP Mission_goal_timestamp;
 extern int Event_index;  // used by sexp code to tell what event it came from
 extern bool Log_event;
 extern bool Snapshot_all_events;
@@ -193,6 +194,9 @@ void mission_goal_exit();
 
 int mission_goal_find_sexp_tree(int root_node);
 int mission_event_find_sexp_tree(int root_node);
+
+int mission_goal_lookup(const char *name);
+int mission_event_lookup(const char *name);
 
 int ML_objectives_init(int x, int y, int w, int h);
 void ML_objectives_close();

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8527,8 +8527,8 @@ void process_event_update_packet(ubyte *data, header *hinfo)
 		mission_event_unset_directive_special(u_event);
 	}	
 
-	if (Mission_events[u_event].result && !Mission_events[u_event].satisfied_time) {
-		Mission_events[u_event].satisfied_time = Missiontime;
+	if (Mission_events[u_event].result && !Mission_events[u_event].satisfied_time.isValid()) {
+		Mission_events[u_event].satisfied_time = _timestamp();
 		if ( Mission_events[u_event].objective_text ) {
 			mission_event_set_completion_sound_timestamp();
 		}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -16385,39 +16385,29 @@ int sexp_event_status( int n, int want_true )
 int sexp_event_delay_status( int n, int want_true, bool use_msecs = false)
 {
 	bool is_nan, is_nan_forever;
-	fix delay;
+	int delay;
 	int rval = SEXP_FALSE;
 	bool use_as_directive = false;
 
 	auto name = CTEXT(n);
 
-	if (use_msecs) {
-		uint64_t tempDelay = eval_num(CDR(n), is_nan, is_nan_forever);
-		if (is_nan) {
-			return SEXP_FALSE;
-		}
-		else if (is_nan_forever) {
-			return SEXP_KNOWN_FALSE;
-		}
-
-		tempDelay = tempDelay << 16;
-		tempDelay = tempDelay / 1000;
-
-		delay = (fix) tempDelay;
-	} else {
-		delay = i2f(eval_num(CDR(n), is_nan, is_nan_forever));
-		if (is_nan) {
-			return SEXP_FALSE;
-		}
-		else if (is_nan_forever) {
-			return SEXP_KNOWN_FALSE;
-		}
+	delay = eval_num(CDR(n), is_nan, is_nan_forever);
+	if (is_nan) {
+		return SEXP_FALSE;
+	}
+	else if (is_nan_forever) {
+		return SEXP_KNOWN_FALSE;
+	}
+	if (!use_msecs) {
+		delay *= MILLISECONDS_PER_SECOND;
 	}
 
 	for (int i = 0; i < Num_mission_events; ++i) {
-		// look for the event name, check it's status.  If formula is gone, we know the state won't ever change.
+		// look for the event name; check its status.  If formula is gone, we know the state won't ever change.
 		if ( !stricmp(Mission_events[i].name, name) ) {
-			if ( (fix) Mission_events[i].timestamp + delay >= Missiontime ) {
+			// Previous implementations could skip this block if the timestamp wasn't valid yet.  This had no effect
+			// because result, checked below, was still 0; but let's be correct.
+			if ( !Mission_events[i].timestamp.isValid() || timestamp_since(Mission_events[i].timestamp) <= delay ) {
 				rval = SEXP_FALSE;
 				break;
 			}


### PR DESCRIPTION
This change covers just the timestamps associated with goals and events, for better review and isolation purposes.

Follow-up to #4569.