### PR TITLE
Fix conditional for `Always_warn_player_about_unbound_keys`

### DIFF
--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -659,7 +659,7 @@ SCP_string message_translate_tokens(const char *text)
 				if (ptr != nullptr) {  // was key translated properly?
 					if (!stricmp(ptr, NOX("none")) && (Training_bind_warning != Missiontime)) {
 						// check if a warning message should be displayed if the key is unbound
-						if ( (The_mission.game_type & MISSION_TYPE_TRAINING) || (Always_warn_player_about_unbound_keys & MISSION_TYPE_SINGLE) ) {
+						if ( (The_mission.game_type & MISSION_TYPE_TRAINING) || (Always_warn_player_about_unbound_keys && (The_mission.game_type & MISSION_TYPE_SINGLE)) ) {
 							r = popup(PF_TITLE_BIG | PF_TITLE_RED, 2, XSTR( "&Bind Control", 424), XSTR( "&Abort mission", 425),
 								XSTR( "Warning\nYou have no control bound to the action \"%s\".  You must do so before you can continue with your training.", 426),
 								XSTR(Control_config[Failed_key_index].text.c_str(), CONTROL_CONFIG_XSTR + Failed_key_index));


### PR DESCRIPTION
Properly check if mission is singleplayer for the `Always_warn_player_about_unbound_keys` game option.