### PR TITLE
several minor HUD enhancements

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -439,13 +439,13 @@ const char* HudGauge::getCustomGaugeText()
 	return custom_text.c_str();
 }
 
-void HudGauge::updateGaugeCoords(int _x, int _y)
+void HudGauge::setGaugeCoords(int _x, int _y)
 {
 	position[0] = _x;
 	position[1] = _y;
 }
 
-void HudGauge::updateGaugeFrame(int frame_offset)
+void HudGauge::setGaugeFrame(int frame_offset)
 {
 	if (frame_offset < 0 ||frame_offset > custom_frame.num_frames) {
 		return;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -439,22 +439,14 @@ const char* HudGauge::getCustomGaugeText()
 	return custom_text.c_str();
 }
 
-void HudGauge::updateCustomGaugeCoords(int _x, int _y)
+void HudGauge::updateGaugeCoords(int _x, int _y)
 {
-	if(!custom_gauge) {
-		return;
-	}
-
 	position[0] = _x;
 	position[1] = _y;
 }
 
-void HudGauge::updateCustomGaugeFrame(int frame_offset)
+void HudGauge::updateGaugeFrame(int frame_offset)
 {
-	if(!custom_gauge) {
-		return;
-	}
-	
 	if (frame_offset < 0 ||frame_offset > custom_frame.num_frames) {
 		return;
 	}
@@ -3981,6 +3973,18 @@ int hud_get_default_gauge_index(const char *name)
 	}
 
 	return -1;
+}
+
+HudGauge *hud_get_gauge(const char *name)
+{
+	auto gauge = hud_get_custom_gauge(name);
+	if (gauge == nullptr)
+	{
+		int idx = hud_get_default_gauge_index(name);
+		if (idx >= 0 && idx < (int)default_hud_gauges.size())
+			gauge = default_hud_gauges[idx].get();
+	}
+	return gauge;
 }
 
 HudGaugeMultiMsg::HudGaugeMultiMsg():

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -313,8 +313,8 @@ public:
 
 	// For updating custom gauges
 	const char* getCustomGaugeName();
-	void updateCustomGaugeCoords(int _x, int _y);
-	void updateCustomGaugeFrame(int frame_offset);
+	void updateGaugeCoords(int _x, int _y);
+	void updateGaugeFrame(int frame_offset);
 	void updateCustomGaugeText(const char* txt);
 	void updateCustomGaugeText(const SCP_string& txt);
 	const char* getCustomGaugeText();
@@ -570,8 +570,9 @@ public:
 	void render(float frametime) override;
 };
 
-HudGauge* hud_get_custom_gauge(const char* name, bool check_all_gauges = false);
-int hud_get_default_gauge_index(const char* name);
+HudGauge *hud_get_custom_gauge(const char *name, bool check_all_gauges = false);
+int hud_get_default_gauge_index(const char *name);
+HudGauge *hud_get_gauge(const char *name);
 
 extern SCP_vector<std::unique_ptr<HudGauge>> default_hud_gauges;
 

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -313,8 +313,6 @@ public:
 
 	// For updating custom gauges
 	const char* getCustomGaugeName();
-	void updateGaugeCoords(int _x, int _y);
-	void updateGaugeFrame(int frame_offset);
 	void updateCustomGaugeText(const char* txt);
 	void updateCustomGaugeText(const SCP_string& txt);
 	const char* getCustomGaugeText();
@@ -335,7 +333,9 @@ public:
 	
 	void setFont();
 	void setGaugeColor(int bright_index = HUD_C_NONE);
-	
+	void setGaugeCoords(int _x, int _y);
+	void setGaugeFrame(int frame_offset);
+
 	// rendering functions
 	void renderBitmap(int x, int y);
 	void renderBitmap(int frame, int x, int y);

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -100,15 +100,14 @@ int Training_obj_window_coords[GR_NUM_RESOLUTIONS][2] = {
 
 
 // training objectives global vars.
-int Training_obj_num_lines;
+int Training_obj_num_lines = 0;
+int Training_obj_num_display_lines = 0;
 int Training_obj_lines[TRAINING_OBJ_LINES];
 training_message_mods Training_message_mods[MAX_TRAINING_MESSAGE_MODS];
 
 // local module prototypes
 void training_process_message();
 
-
-static int Directive_frames_loaded = 0;
 
 HudGaugeDirectives::HudGaugeDirectives():
 HudGauge(HUD_OBJECT_DIRECTIVES, HUD_DIRECTIVES_VIEW, false, true, (VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY | VM_OTHER_SHIP), 255, 255, 255)
@@ -216,8 +215,10 @@ void HudGaugeDirectives::pageIn()
 void HudGaugeDirectives::render(float  /*frametime*/)
 {
 	char buf[256], *second_line;
-	int i, t, x, y, z, end, offset, bx, by, y_count;
+	int i, t, x, y, z, end, offset, bx, by;
 	color *c;
+
+	Training_obj_num_display_lines = 0;
 
 	if (!Training_obj_num_lines){
 		return;
@@ -241,10 +242,9 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 	bx = position[0];
 	by = position[1] + middle_frame_offset_y;
 
-	y_count = 0;
 	for (i=0; i<end; i++) {
 		x = position[0] + text_start_offsets[0];
-		y = position[1] + text_start_offsets[1] + y_count * text_h;
+		y = position[1] + text_start_offsets[1] + Training_obj_num_display_lines * text_h;
 		z = TRAINING_OBJ_LINES_MASK(i + offset);
 
 		c = &Color_normal;
@@ -315,14 +315,14 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 		
 		renderString(x, y, EG_OBJ1 + i, buf);
 		
-		y_count++;
+		Training_obj_num_display_lines++;
 
 		if ( second_line ) {
-			y = position[1] + text_start_offsets[1] + y_count * text_h;
+			y = position[1] + text_start_offsets[1] + Training_obj_num_display_lines * text_h;
 			
 			renderString(x+12, y, EG_OBJ1 + i + 1, second_line);
 			
-			y_count++;
+			Training_obj_num_display_lines++;
 		}
 	}
 
@@ -353,9 +353,6 @@ void training_mission_init()
 	for (i = 0; i < TRAINING_MESSAGE_QUEUE_MAX; i++)
 		Training_message_queue[i].special_message = NULL;
 
-	// The E: This is now handled by the new HUD code. No need to check here.
-	Directive_frames_loaded = 1;
-	
 	// only clear player flags if this is actually a training mission
 	if ( The_mission.game_type & MISSION_TYPE_TRAINING ) {
 		Player->flags &= ~(PLAYER_FLAGS_MATCH_TARGET | PLAYER_FLAGS_MSG_MODE | PLAYER_FLAGS_AUTO_TARGETING | PLAYER_FLAGS_AUTO_MATCH_SPEED | PLAYER_FLAGS_LINK_PRIMARY | PLAYER_FLAGS_LINK_SECONDARY );

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3389,7 +3389,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 					return SEXP_CHECK_TYPE_MISMATCH;
 				}
 
-				if (hud_get_custom_gauge(CTEXT(node), true) == nullptr) {
+				if (hud_get_gauge(CTEXT(node), true) == nullptr) {
 					return SEXP_CHECK_INVALID_CUSTOM_HUD_GAUGE;
 				}
 
@@ -11934,7 +11934,7 @@ void sexp_hud_set_text_num(int n)
 	auto gaugename = CTEXT(n);
 	char tmp[16] = "";
 
-	HudGauge* cg = hud_get_custom_gauge(gaugename);
+	HudGauge* cg = hud_get_gauge(gaugename);
 	if (cg) {
 		int num = eval_num(CDR(n), is_nan, is_nan_forever);
 		if (is_nan || is_nan_forever) {
@@ -11954,7 +11954,7 @@ void sexp_hud_set_text(int n)
 	auto gaugename = CTEXT(n);
 	auto text = CTEXT(CDR(n));
 
-	HudGauge* cg = hud_get_custom_gauge(gaugename);
+	HudGauge* cg = hud_get_gauge(gaugename);
 	if (cg) {
 		cg->updateCustomGaugeText(text);
 	} else {
@@ -11975,7 +11975,7 @@ void sexp_hud_set_message(int n)
 			sexp_replace_variable_names_with_values(message);
 			sexp_container_replace_refs_with_values(message);
 
-			HudGauge* cg = hud_get_custom_gauge(gaugename);
+			HudGauge* cg = hud_get_gauge(gaugename);
 			if (cg) {
 				cg->updateCustomGaugeText(message);
 			} else {
@@ -11999,7 +11999,7 @@ void sexp_hud_set_directive(int n)
 		return;
 	}
 
-	HudGauge* cg = hud_get_custom_gauge(gaugename);
+	HudGauge* cg = hud_get_gauge(gaugename);
 	if (cg) {
 		cg->updateCustomGaugeText(message);
 	} else {
@@ -12042,7 +12042,7 @@ void sexp_hud_set_coords(int n)
 	if (is_nan || is_nan_forever)
 		return;
 
-	HudGauge* cg = hud_get_custom_gauge(gaugename);
+	HudGauge* cg = hud_get_gauge(gaugename);
 	if (cg) {
 		cg->updateCustomGaugeCoords(coord_x, coord_y);
 	} else {
@@ -12059,7 +12059,7 @@ void sexp_hud_set_frame(int n)
 	if (is_nan || is_nan_forever)
 		return;
 
-	HudGauge* cg = hud_get_custom_gauge(gaugename);
+	HudGauge* cg = hud_get_gauge(gaugename);
 	if (cg) {
 		cg->updateCustomGaugeFrame(frame_num);
 	} else {
@@ -12081,7 +12081,7 @@ void sexp_hud_set_color(int n)
 	if (is_nan || is_nan_forever)
 		return;
 
-	HudGauge* cg = hud_get_custom_gauge(gaugename);
+	HudGauge* cg = hud_get_gauge(gaugename);
 	if (cg) {
 		cg->sexpLockConfigColor(false);
 		cg->updateColor((ubyte)rgb[0], (ubyte)rgb[1], (ubyte)rgb[2], (HUD_color_alpha + 1) * 16);
@@ -12141,7 +12141,7 @@ void sexp_hud_gauge_set_active(int n)
 	auto gaugename = CTEXT(n);
 	bool active = is_sexp_true(CDR(n));
 
-	hg = hud_get_custom_gauge(gaugename);
+	hg = hud_get_gauge(gaugename);
 	if (hg) {
 		hg->updateActive(active);
 	} else {
@@ -12157,7 +12157,7 @@ void sexp_hud_set_custom_gauge_active(int node)
 	for(; node >= 0; node = CDR(node)) {
 
 		auto gaugename = CTEXT(node);
-		hg = hud_get_custom_gauge(gaugename);
+		hg = hud_get_gauge(gaugename);
 
 		if (hg) {
 			hg->updateActive(activate);
@@ -31302,7 +31302,7 @@ bool sexp_recoverable_error(int num)
 		case SEXP_CHECK_AMBIGUOUS_GOAL_NAME:
 
 		// Having an invalid gauge in FSO won't hurt,
-		// as all places which call hud_get_custom_gauge() check its return value for NULL.
+		// as all places which call hud_get_gauge() check its return value for NULL.
 		case SEXP_CHECK_INVALID_CUSTOM_HUD_GAUGE:
 			return true;
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -12055,7 +12055,7 @@ void sexp_hud_set_coords(int n)
 
 	HudGauge* hg = hud_get_gauge(gaugename);
 	if (hg) {
-		hg->updateGaugeCoords(coord_x, coord_y);
+		hg->setGaugeCoords(coord_x, coord_y);
 	} else {
 		WarningEx(LOCATION, "Could not find a hud gauge named %s\n", gaugename);
 	}
@@ -12072,7 +12072,7 @@ void sexp_hud_set_frame(int n)
 
 	HudGauge* hg = hud_get_gauge(gaugename);
 	if (hg) {
-		hg->updateGaugeFrame(frame_num);
+		hg->setGaugeFrame(frame_num);
 	} else {
 		WarningEx(LOCATION, "Could not find a hud gauge named %s\n", gaugename);
 	}

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -128,6 +128,7 @@ struct ship_obj;
 #define OPF_CONTAINER_VALUE		97		// jg18 - Container data and map container keys
 #define OPF_DATA_OR_STR_CONTAINER	98	// jg18 - any data, or a container that is accessed via strings
 #define OPF_TRANSLATING_SUBSYSTEM	99	// Goober5000 - a translating subsystem
+#define OPF_ANY_HUD_GAUGE		100		// Goober5000 - both custom and builtin
 
 // Operand return types
 #define	OPR_NUMBER				1	// returns number
@@ -1131,6 +1132,7 @@ const char *CTEXT(int n);
 #define SEXP_CHECK_INVALID_AWACS_SUBSYS			-174
 #define SEXP_CHECK_INVALID_ROTATING_SUBSYS		-175
 #define SEXP_CHECK_INVALID_TRANSLATING_SUBSYS	-176
+#define SEXP_CHECK_INVALID_ANY_HUD_GAUGE		-177
 
 
 #define TRAINING_CONTEXT_SPEED		(1<<0)

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -185,13 +185,6 @@ ADE_FUNC(getHUDGaugeHandle, l_HUD, "string Name", "Returns a handle to a specifi
 
 	gauge = hud_get_gauge(name);
 	if (gauge == nullptr)
-	{
-		int idx = hud_get_default_gauge_index(name);
-		if (idx >= 0 && idx < (int)default_hud_gauges.size())
-			gauge = default_hud_gauges[idx].get();
-	}
-
-	if (gauge == nullptr)
 		return ADE_RETURN_NIL;
 	else
 		return ade_set_args(L, "o", l_HudGauge.Set(gauge));

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -12,6 +12,8 @@
 #include "hud/hudtargetbox.h"
 #include "hud/hudtarget.h"
 
+extern int Training_obj_num_display_lines;
+
 namespace scripting {
 namespace api {
 
@@ -264,6 +266,11 @@ ADE_FUNC(getTargetDistance, l_HUD, "object targetee, [vector targeter_position]"
 
 	auto dist = hud_find_target_distance(targetee_h->objp, targeter_pos);
 	return ade_set_args(L, "f", dist);
+}
+
+ADE_FUNC(getDirectiveLines, l_HUD, nullptr, "Returns the number of lines displayed by the currently active directives", "number", "The number of lines")
+{
+	return ade_set_args(L, "i", Training_obj_num_display_lines);
 }
 
 

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -183,7 +183,7 @@ ADE_FUNC(getHUDGaugeHandle, l_HUD, "string Name", "Returns a handle to a specifi
 		return ADE_RETURN_NIL;
 	HudGauge* gauge = nullptr;
 
-	gauge = hud_get_custom_gauge(name);
+	gauge = hud_get_gauge(name);
 	if (gauge == nullptr)
 	{
 		int idx = hud_get_default_gauge_index(name);

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -95,7 +95,7 @@ ADE_FUNC(setPosition, l_HudGauge, "number, number", "Sets the position of the sp
 	if (!ade_get_args(L, "oii", l_HudGauge.Get(&gauge), &x, &y))
 		return ADE_RETURN_NIL;
 
-	gauge->updateGaugeCoords(x, y);
+	gauge->setGaugeCoords(x, y);
 	return ADE_RETURN_NIL;
 }
 

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -95,7 +95,7 @@ ADE_FUNC(setPosition, l_HudGauge, "number, number", "Sets the position of the sp
 	if (!ade_get_args(L, "oii", l_HudGauge.Get(&gauge), &x, &y))
 		return ADE_RETURN_NIL;
 
-	gauge->initPosition(x, y);
+	gauge->updateGaugeCoords(x, y);
 	return ADE_RETURN_NIL;
 }
 

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -31,6 +31,9 @@ ADE_VIRTVAR(Name, l_HudGauge, "string", "Custom HUD Gauge name", "string", "Cust
 	if (gauge->getObjectType() != HUD_OBJECT_CUSTOM)
 		return ADE_RETURN_NIL;
 
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting the hud gauge name is not supported");
+
 	return ade_set_args(L, "s", gauge->getCustomGaugeName());
 }
 
@@ -83,6 +86,17 @@ ADE_FUNC(getPosition, l_HudGauge, nullptr, "Returns the position of the specifie
 	int x, y;
 	gauge->getPosition(&x, &y);
 	return ade_set_args(L, "ii", x, y);
+}
+
+ADE_FUNC(setPosition, l_HudGauge, "number, number", "Sets the position of the specified HUD gauge.", nullptr, nullptr)
+{
+	HudGauge* gauge;
+	int x, y;
+	if (!ade_get_args(L, "oii", l_HudGauge.Get(&gauge), &x, &y))
+		return ADE_RETURN_NIL;
+
+	gauge->initPosition(x, y);
+	return ADE_RETURN_NIL;
 }
 
 ADE_FUNC(getFont, l_HudGauge, nullptr, "Returns the font used by the specified HUD gauge.",

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -3253,6 +3253,10 @@ int sexp_tree::get_default_value(sexp_list_item *item, char *text_buf, int op, i
 			str = "<Custom hud gauge>";
 			break;
 
+		case OPF_ANY_HUD_GAUGE:
+			str = "<Custom or builtin hud gauge>";
+			break;
+
 		case OPF_ANIMATION_NAME:
 			str = "<Animation trigger name>";
 			break;			
@@ -3353,6 +3357,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_MESSAGE_OR_STRING:
 		case OPF_BUILTIN_HUD_GAUGE:
 		case OPF_CUSTOM_HUD_GAUGE:
+		case OPF_ANY_HUD_GAUGE:
 		case OPF_SHIP_EFFECT:
 		case OPF_ANIMATION_TYPE:
 		case OPF_SHIP_FLAG:
@@ -5329,6 +5334,10 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_custom_hud_gauge();
 			break;
 
+		case OPF_ANY_HUD_GAUGE:
+			list = get_listing_opf_any_hud_gauge();
+			break;
+
 		case OPF_SHIP_EFFECT:
 			list = get_listing_opf_ship_effect();
 			break;
@@ -6417,6 +6426,16 @@ sexp_list_item *sexp_tree::get_listing_opf_custom_hud_gauge()
 			}
 		}
 	}
+
+	return head.next;
+}
+
+sexp_list_item *sexp_tree::get_listing_opf_any_hud_gauge()
+{
+	sexp_list_item head;
+
+	head.add_list(get_listing_opf_builtin_hud_gauge());
+	head.add_list(get_listing_opf_custom_hud_gauge());
 
 	return head.next;
 }

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -287,6 +287,7 @@ public:
 	sexp_list_item *get_listing_opf_weapon_banks();
 	sexp_list_item *get_listing_opf_builtin_hud_gauge();
 	sexp_list_item *get_listing_opf_custom_hud_gauge();
+	sexp_list_item *get_listing_opf_any_hud_gauge();
 	sexp_list_item *get_listing_opf_ship_effect();
 	sexp_list_item *get_listing_opf_animation_type();
 	sexp_list_item *get_listing_opf_mission_moods();

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1421,6 +1421,10 @@ int sexp_tree::get_default_value(sexp_list_item* item, char* text_buf, int op, i
 		str = "<Custom hud gauge>";
 		break;
 
+	case OPF_ANY_HUD_GAUGE:
+		str = "<Custom or builtin hud gauge>";
+		break;
+
 	case OPF_ANIMATION_NAME:
 		str = "<Animation trigger name>";
 		break;
@@ -1520,6 +1524,7 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 	case OPF_MESSAGE_OR_STRING:
 	case OPF_BUILTIN_HUD_GAUGE:
 	case OPF_CUSTOM_HUD_GAUGE:
+	case OPF_ANY_HUD_GAUGE:
 	case OPF_SHIP_EFFECT:
 	case OPF_ANIMATION_TYPE:
 	case OPF_SHIP_FLAG:
@@ -3226,6 +3231,10 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 		list = get_listing_opf_custom_hud_gauge();
 		break;
 
+	case OPF_ANY_HUD_GAUGE:
+		list = get_listing_opf_any_hud_gauge();
+		break;
+
 	case OPF_SHIP_EFFECT:
 		list = get_listing_opf_ship_effect();
 		break;
@@ -4204,6 +4213,16 @@ sexp_list_item *sexp_tree::get_listing_opf_custom_hud_gauge()
 			}
 		}
 	}
+
+	return head.next;
+}
+
+sexp_list_item *sexp_tree::get_listing_opf_any_hud_gauge()
+{
+	sexp_list_item head;
+
+	head.add_list(get_listing_opf_builtin_hud_gauge());
+	head.add_list(get_listing_opf_custom_hud_gauge());
 
 	return head.next;
 }

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -334,6 +334,7 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_weapon_banks();
 	sexp_list_item* get_listing_opf_builtin_hud_gauge();
 	sexp_list_item* get_listing_opf_custom_hud_gauge();
+	sexp_list_item* get_listing_opf_any_hud_gauge();
 	sexp_list_item* get_listing_opf_ship_effect();
 	sexp_list_item* get_listing_opf_animation_type();
 	sexp_list_item* get_listing_opf_mission_moods();


### PR DESCRIPTION
add `getDirectiveLines` and `setPosition` script functions properly error if trying to set a HUD gauge name
remove the unneeded `Directive_frames_loaded` variable improve accuracy of SEXP help for HUD gauge operators