### PR TITLE
Fix the cmd_briefing scripting API

### DIFF
--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -539,7 +539,7 @@ ADE_FUNC(getCmdBriefing,
 	"The briefing data")
 {
 	// The cmd briefing code has support for specifying the team but only sets the index to 0
-	return ade_set_args(L, "o", l_CmdBrief.Set(Cmd_briefs[0]));
+	return ade_set_args(L, "o", l_CmdBrief.Set(0));
 }
 
 //**********SUBLIBRARY: UserInterface/LoopBrief

--- a/code/scripting/api/objs/cmd_brief.cpp
+++ b/code/scripting/api/objs/cmd_brief.cpp
@@ -4,13 +4,25 @@
 namespace scripting {
 namespace api {
 
-//**********HANDLE: cmd_briefing
-ADE_OBJ(l_CmdBriefStage, cmd_brief_stage, "cmd_briefing_stage", "Command briefing stage handle");
+cmd_brief_stage_h::cmd_brief_stage_h() : cmd_brief(-1), cmd_stage(-1) { }
 
-ADE_VIRTVAR(Text, l_CmdBriefStage, nullptr, "The text of the stage", "cmd_briefing_stage", "The text")
+cmd_brief_stage_h::cmd_brief_stage_h(int brief, int stage) : cmd_brief(brief), cmd_stage(stage) { }
+
+bool cmd_brief_stage_h::IsValid() const {
+	return cmd_brief >= 0 && cmd_stage >= 0;
+}
+
+cmd_brief_stage* cmd_brief_stage_h::getStage() const {
+	return &Cmd_briefs[cmd_brief].stage[cmd_stage];
+}
+
+//**********HANDLE: cmd_briefing
+ADE_OBJ(l_CmdBriefStage, cmd_brief_stage_h, "cmd_briefing_stage", "Command briefing stage handle");
+
+ADE_VIRTVAR(Text, l_CmdBriefStage, nullptr, "The text of the stage", "string", "The text")
 {
-	cmd_brief_stage* stage = nullptr;
-	if (!ade_get_args(L, "o", l_CmdBriefStage.GetPtr(&stage))) {
+	cmd_brief_stage_h stage;
+	if (!ade_get_args(L, "o", l_CmdBriefStage.Get(&stage))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -18,18 +30,18 @@ ADE_VIRTVAR(Text, l_CmdBriefStage, nullptr, "The text of the stage", "cmd_briefi
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", stage->text);
+	return ade_set_args(L, "s", stage.getStage()->text);
 }
 
 ADE_VIRTVAR(AniFilename,
 	l_CmdBriefStage,
 	nullptr,
 	"The filename of the animation to play",
-	"cmd_briefing_stage",
+	"string",
 	"The file name")
 {
-	cmd_brief_stage* stage = nullptr;
-	if (!ade_get_args(L, "o", l_CmdBriefStage.GetPtr(&stage))) {
+	cmd_brief_stage_h stage;
+	if (!ade_get_args(L, "o", l_CmdBriefStage.Get(&stage))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -37,18 +49,18 @@ ADE_VIRTVAR(AniFilename,
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", stage->ani_filename);
+	return ade_set_args(L, "s", stage.getStage()->ani_filename);
 }
 
 ADE_VIRTVAR(AudioFilename,
 	l_CmdBriefStage,
 	nullptr,
 	"The filename of the audio file to play",
-	"cmd_briefing_stage",
+	"string",
 	"The file name")
 {
-	cmd_brief_stage* stage = nullptr;
-	if (!ade_get_args(L, "o", l_CmdBriefStage.GetPtr(&stage))) {
+	cmd_brief_stage_h stage;
+	if (!ade_get_args(L, "o", l_CmdBriefStage.Get(&stage))) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -56,11 +68,11 @@ ADE_VIRTVAR(AudioFilename,
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", stage->wave_filename);
+	return ade_set_args(L, "s", stage.getStage()->wave_filename);
 }
 
 //**********HANDLE: cmd_briefing
-ADE_OBJ(l_CmdBrief, cmd_brief, "cmd_briefing", "Command briefing handle");
+ADE_OBJ(l_CmdBrief, int, "cmd_briefing", "Command briefing handle");
 
 ADE_INDEXER(l_CmdBrief,
 	"number index",
@@ -68,11 +80,16 @@ ADE_INDEXER(l_CmdBrief,
 	"cmd_briefing_stage",
 	"The stage at the specified location.")
 {
-	cmd_brief* brief = nullptr;
+	int briefIdx;
 	int index        = -1;
-	if (!ade_get_args(L, "oi", l_CmdBrief.GetPtr(&brief), &index)) {
+	if (!ade_get_args(L, "oi", l_CmdBrief.Get(&briefIdx), &index)) {
 		return ADE_RETURN_NIL;
 	}
+
+	if (briefIdx < 0)
+		return ADE_RETURN_NIL;
+
+	cmd_brief* brief = &Cmd_briefs[briefIdx];
 
 	--index;
 
@@ -81,17 +98,20 @@ ADE_INDEXER(l_CmdBrief,
 		return ADE_RETURN_NIL;
 	}
 
-	return ade_set_args(L, "o", l_CmdBriefStage.Set(brief->stage[index]));
+	return ade_set_args(L, "o", l_CmdBriefStage.Set(cmd_brief_stage_h(briefIdx, index)));
 }
 
 ADE_FUNC(__len, l_CmdBrief, nullptr, "The number of stages in the command briefing", "number", "The number of stages.")
 {
-	cmd_brief* brief = nullptr;
-	if (!ade_get_args(L, "o", l_CmdBrief.GetPtr(&brief))) {
+	int brief;
+	if (!ade_get_args(L, "o", l_CmdBrief.Get(&brief))) {
 		return ADE_RETURN_NIL;
 	}
 
-	return ade_set_args(L, "i", brief->num_stages);
+	if (brief < 0)
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "i", Cmd_briefs[brief].num_stages);
 }
 
 } // namespace api

--- a/code/scripting/api/objs/cmd_brief.h
+++ b/code/scripting/api/objs/cmd_brief.h
@@ -6,9 +6,18 @@
 namespace scripting {
 namespace api {
 
-DECLARE_ADE_OBJ(l_CmdBriefStage, cmd_brief_stage);
+struct cmd_brief_stage_h {
+	int cmd_brief, cmd_stage;
 
-DECLARE_ADE_OBJ(l_CmdBrief, cmd_brief);
+	cmd_brief_stage_h();
+	explicit cmd_brief_stage_h(int brief, int stage);
+	bool IsValid() const;
+	cmd_brief_stage* getStage() const;
+};
+
+DECLARE_ADE_OBJ(l_CmdBriefStage, cmd_brief_stage_h);
+
+DECLARE_ADE_OBJ(l_CmdBrief, int);
 
 } // namespace api
 } // namespace scripting


### PR DESCRIPTION
The API previously had incorrect documentation, and was using a copy of the cmd_briefing object for the lua data, instead of a reference to the object. This is troublesome, since that implies that no changes can be propagated to and from FSO and can cause hard-to-find bugs if there is ever any API method that can modify the object