### PR TITLE
Add corrections in multi ship record

### DIFF
--- a/code/network/multi_interpolate.cpp
+++ b/code/network/multi_interpolate.cpp
@@ -2,6 +2,7 @@
 #include "globalincs/pstypes.h"
 #include "freespace.h"
 
+extern void multi_ship_record_signal_update(int objnum, TIMESTAMP lower_time_limit, TIMESTAMP upper_time_limit, int prev_packet_index, int current_packet_index);
 ///////////////////////////////////////////
 // interpolation info management functions
 
@@ -38,7 +39,7 @@ void interpolation_manager::reassess_packet_index(vec3d* pos, matrix* ori, physi
 }
 
 // the meat and potatoes.  Basically, this figures out if we should interpolate, and then interpolates or sims
-void interpolation_manager::interpolate(vec3d* pos, matrix* ori, physics_info* pip, vec3d* last_pos, matrix* last_orient, bool player_ship)
+void interpolation_manager::interpolate_main(vec3d* pos, matrix* ori, physics_info* pip, vec3d* last_pos, matrix* last_orient, bool player_ship)
 {
 	// make sure its a valid ship and valid mode
 	Assert(Game_mode & GM_MULTIPLAYER);
@@ -89,14 +90,19 @@ void interpolation_manager::interpolate(vec3d* pos, matrix* ori, physics_info* p
 		vm_vec_scale_add(last_pos, pos, &pip->vel, -flFrametime);
 
 		// Asteroth's method for last orient.
-		vec3d normalized_rotvel;
-		float mag = vm_vec_copy_normalize(&normalized_rotvel, &pip->rotvel);
+		if (!IS_VEC_NULL(&pip->rotvel)) {
 
-		matrix rotate_to_previous;
+			vec3d normalized_rotvel;
+			float mag = vm_vec_copy_normalize(&normalized_rotvel, &pip->rotvel);
 
-		vm_quaternion_rotate(&rotate_to_previous, -mag * flFrametime, &normalized_rotvel);
-		vm_matrix_x_matrix(last_orient, &rotate_to_previous, ori);
+			matrix rotate_to_previous;
 
+			vm_quaternion_rotate(&rotate_to_previous, -mag * flFrametime, &normalized_rotvel);
+			vm_matrix_x_matrix(last_orient, &rotate_to_previous, ori);
+		} else {
+			*last_orient = *ori;
+		}
+		
 		// duplicate the rest of the physics engine's calls here to make the simulation more exact.
 		pip->speed = vm_vec_mag(&pip->vel);
 		pip->fspeed = vm_vec_dot(&ori->vec.fvec, &pip->vel);
@@ -152,21 +158,55 @@ void interpolation_manager::interpolate(vec3d* pos, matrix* ori, physics_info* p
 	vm_interpolate_matrices(ori, &_packets[_prev_packet_index].orientation, &_packets[_upcoming_packet_index].orientation, scale);
 
 	// a quick calculation for the last orientation, courtesy Asteroth
-	vec3d normalized_rotvel;
-	float mag = vm_vec_copy_normalize(&normalized_rotvel, &pip->rotvel);
+	if (!IS_VEC_NULL(&pip->rotvel)) {
 
-	matrix rotate_to_previous;
+		vec3d normalized_rotvel;
+		float mag = vm_vec_copy_normalize(&normalized_rotvel, &pip->rotvel);
 
-	vm_quaternion_rotate(&rotate_to_previous, -mag * flFrametime, &normalized_rotvel);
-	vm_matrix_x_matrix(last_orient, &rotate_to_previous, ori);
+		matrix rotate_to_previous;
+
+		vm_quaternion_rotate(&rotate_to_previous, -mag * flFrametime, &normalized_rotvel);
+		vm_matrix_x_matrix(last_orient, &rotate_to_previous, ori);
+	} else {
+		*last_orient = *ori;
+	}
 
 	// duplicate the rest of the physics engine's calls here to make the simulation more exact.
 	pip->speed = vm_vec_mag(&pip->vel);
 	pip->fspeed = vm_vec_dot(&ori->vec.fvec, &pip->vel);
 }
 
+// correct the ship record for player ships when an up to date packet comes in.
+void interpolation_manager::reinterpolate_previous(TIMESTAMP stamp, int prev_packet_index, int next_packet_index,  vec3d* position, matrix* orientation, vec3d* velocity, vec3d* rotational_velocity)
+{
+	// calc what the current timing should be.
+	float numerator = static_cast<float>(_packets[_upcoming_packet_index].remote_missiontime) - static_cast<float>(stamp.value());
+	float denominator = static_cast<float>(_packets[_upcoming_packet_index].remote_missiontime) - static_cast<float>(_packets[_prev_packet_index].remote_missiontime);
+
+	denominator = (denominator > 0.05f) ? denominator : 0.05f;
+	
+	float scale = numerator / denominator;
+
+	// protect against bad floating point arithmetic making orientation or position look off
+	CLAMP(scale, 0.001f, 0.999f);
+
+	// calc the corrected physics data
+	vec3d temp_vector;
+
+	vm_vec_sub(&temp_vector, &_packets[next_packet_index].position, &_packets[prev_packet_index].position);
+	vm_vec_scale_add(position, &_packets[prev_packet_index].position, &temp_vector, scale);
+
+	vm_vec_sub(&temp_vector, &_packets[next_packet_index].velocity, &_packets[prev_packet_index].velocity);
+	vm_vec_scale_add(velocity, &_packets[prev_packet_index].velocity, &temp_vector, scale);
+
+	vm_vec_sub(&temp_vector, &_packets[next_packet_index].rotational_velocity, &_packets[prev_packet_index].rotational_velocity);
+	vm_vec_scale_add(rotational_velocity, &_packets[prev_packet_index].rotational_velocity, &temp_vector, scale);
+
+	vm_interpolate_matrices(orientation, &_packets[prev_packet_index].orientation, &_packets[next_packet_index].orientation, scale);
+}
+
 // add a packet to the vector, remove the last one if necessary.
-void interpolation_manager::add_packet(int frame, int packet_timestamp, vec3d* position, vec3d* velocity, vec3d* rotational_velocity, vec3d* desired_velocity, vec3d* desired_rotational_velocity, angles* angles, int player_index) 
+void interpolation_manager::add_packet(int objnum, int frame, int packet_timestamp, vec3d* position, vec3d* velocity, vec3d* rotational_velocity, vec3d* desired_velocity, vec3d* desired_rotational_velocity, angles* angles, int player_index) 
 {
 	if (_packets.empty()) {
 		_packets.push_back(packet_info(frame, packet_timestamp, position, velocity, rotational_velocity, desired_velocity, desired_rotational_velocity, angles));
@@ -204,11 +244,23 @@ void interpolation_manager::add_packet(int frame, int packet_timestamp, vec3d* p
 				_packets.pop_back();
 			}
 
+			// whenenver the server gets a player packet, we need to update the ship record, since the old info is now stale
+			if (Objects[objnum].flags[Object::Object_Flags::Player_ship]){
+
+				int start_time = Multi_Timing_Info.get_mission_start_time();
+
+				multi_ship_record_signal_update(objnum, TIMESTAMP(start_time + _packets[_prev_packet_index].remote_missiontime), TIMESTAMP(start_time + _packets[_upcoming_packet_index].remote_missiontime), _prev_packet_index, _upcoming_packet_index);
+
+				// if it's not the front packet, we need to update more info past the current packet, as well.  
+				// Should be rare though as it is a contingency for out of order packets.
+				if (_upcoming_packet_index != 0){
+					multi_ship_record_signal_update(objnum, TIMESTAMP(start_time + _packets[_upcoming_packet_index].remote_missiontime), TIMESTAMP(start_time + _packets[_upcoming_packet_index - 1].remote_missiontime), _upcoming_packet_index, _upcoming_packet_index - 1);
+				}
+			}
+
 			return;
 		}
 	}
-
-
 }
 
 // basically, copy the state from the object that had been simulated up to that point and treat it as the "old packet".

--- a/code/network/multi_interpolate.h
+++ b/code/network/multi_interpolate.h
@@ -58,8 +58,9 @@ private:
 public:
 
 	// adds a new packet, whilst also manually sorting the relevant entries
-	void add_packet(int frame, int time_delta, vec3d* position, vec3d* velocity, vec3d* rotational_velocity, vec3d* desired_velocity, vec3d* desired_rotational_velocity, angles* angles, int player_index);
-	void interpolate(vec3d* pos, matrix* ori, physics_info* pip, vec3d* last_pos, matrix* last_orient, bool player_ship);
+	void add_packet(int objnum, int frame, int time_delta, vec3d* position, vec3d* velocity, vec3d* rotational_velocity, vec3d* desired_velocity, vec3d* desired_rotational_velocity, angles* angles, int player_index);
+	void interpolate_main(vec3d* pos, matrix* ori, physics_info* pip, vec3d* last_pos, matrix* last_orient, bool player_ship);
+	void reinterpolate_previous(TIMESTAMP stamp, int prev_packet_index, int next_packet_index,  vec3d* position, matrix* orientation, vec3d* velocity, vec3d* rotational_velocity);
 
 	int get_hull_comparison_frame() { return _hull_comparison_frame; }
 	int get_shields_comparison_frame() { return _shields_comparison_frame; }

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -24,7 +24,7 @@ struct net_player;
 class ship;
 struct physics_info;
 struct weapon;
-
+class TIMESTAMP;
 
 // client button info flags
 #define OOC_FIRE_CONTROL_PRESSED	(1<<0)
@@ -96,6 +96,9 @@ void multi_ship_record_add_rollback_wep(int wep_objnum);
 
 // Manage rollback for a frame
 void multi_ship_record_do_rollback();
+
+// Tell the ship record code that it needs to request corrected data
+void multi_ship_record_signal_update(int objnum, TIMESTAMP lower_time_limit, TIMESTAMP higher_time_limit, int prev_packet_index, int current_packet_index);
 
 // ---------------------------------------------------------------------------------------------------
 // Client side frame tracking, for now used only to help lookup info from packets to improve client accuracy.

--- a/code/network/multi_time_manager.h
+++ b/code/network/multi_time_manager.h
@@ -29,6 +29,10 @@ public:
 	// aka reset the class. Needs to be called every time the mission starts.
 	void set_mission_start_time();
 
+	// this was not part of the original design, but is useful when matching up 
+	// timestamps to what is kept internally in this class.
+	int get_mission_start_time() { return _start_time.value(); }
+
 	void update_current_time();
 
 	int get_current_time() { return _current_time; }

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1524,7 +1524,7 @@ void obj_move_all(float frametime)
 		if (!(objp->flags[Object::Object_Flags::Immobile] && objp->hull_strength > 0.0f)) {
 			// if this is an object which should be interpolated in multiplayer, do so
 			if (interpolation_object) {
-				objp->interp_info.interpolate(&objp->pos, &objp->orient, &objp->phys_info, &objp->last_pos, &objp->last_orient, objp->flags[Object::Object_Flags::Player_ship]);
+				objp->interp_info.interpolate_main(&objp->pos, &objp->orient, &objp->phys_info, &objp->last_pos, &objp->last_orient, objp->flags[Object::Object_Flags::Player_ship]);
 			} else {
 				// physics
 				obj_move_call_physics(objp, frametime);


### PR DESCRIPTION
The ship record for player ships is not always accurate.  This corrects entries in the ship record as valid packets are received, removing data recorded from guesses while interpolating ship info.

Also, remove a case where null vectors were being passed to the physics engine.

Waiting on some final testing.

Could not have finished this if not for @wookieejedi who has been performing testing and linting until I get a regular setup again.
