### PR TITLE
Improved beam, blob and warp lighting

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -48,6 +48,9 @@ layout (std140) uniform lightData {
 
 uniform float sourceRadius = 5.0; // This should be passed in part of lightData
 
+// Nearest point sphere and tube light calculations taken from 
+// "Real Shading in Unreal Engine 4" by Brian Karis, Epic Games
+// Part of SIGGRAPH 2013 Course: Physically Based Shading in Theory and Practice
 void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 lightDir, out float attenuation, out float area_normalisation)
 {
 	if (lightType == LT_DIRECTIONAL) {
@@ -61,17 +64,22 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			float dist = length(lightDir);
 
 			// this chunk is unneccessary if sourceRadius= 0.0, but let's avoid a branch.
+			// given a sphere of radius sourceRadius centered at lightDir,
+			// move lightDir towards the ray defined by reflectDir
 			vec3 centerToRay = dot(lightDir, reflectDir) * reflectDir - lightDir;
 			lightDir = lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
 			dist = length(lightDir);
+			// Energy conservation term
 			float alpha_adjust = clamp(alpha + (sourceRadius/(2*dist)), 0.0, 1.0);
 			area_normalisation = alpha/alpha_adjust;
 			area_normalisation *= area_normalisation;
+			//end chunk
 
-			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
+
 			if(dist > lightRadius) {
 				discard;
 			}
+			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 		} 
 		else if (lightType == LT_TUBE) {  // Tube light
 			float beamLength = length(beamVec);
@@ -84,30 +92,34 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			vec3 adjustedbeamVec = beamVec - 2.0 * lightRadius * beamDir;
 			//adjustments having been made, sourceDir needs recalculating
 			vec3 sourceDir = adjustedLightPos - position.xyz;
-			// Get nearest point on line
+			// Get nearest 
 			vec3 a_t = reflectDir;
 			vec3 b_t = beamDir;
 			vec3 b_0 = sourceDir;
 			vec3 c = cross(a_t, b_t);
 			vec3 d = b_0;
 			vec3 r = d - a_t * dot(d, a_t) - c * dot(d,c);
-			float neardist = -length(r)/dot(b_t, normalize(r));
-			// Somebody with a symbolic expression simplifier or a bigger brain than me should figure out how to optimise these calcs - qaz
-			// Move along the beam by the distance we calculated
+			float neardist = -dot(r, r)/dot(b_t, r);
 			lightDir = sourceDir + beamDir * neardist;
+			// Somebody with a symbolic expression simplifier or a bigger brain than me
+			// should figure out how to optimise these calcs - qaz
+			// Move along the beam by the distance we calculated
 			float dist = length(lightDir);
 
-			// this chunk is unneccessary if sourceRadius= 0.0, but let's avoid a branch.
+			// this chunk is unneccessary if sourceRadius = 0.0, but let's avoid a branch.
+			// Same principle as in LT_POINT, treat chosen location as a spherelight.
 			vec3 centerToRay = dot(lightDir, reflectDir) * reflectDir - lightDir;
 			lightDir = lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
 			dist = length(lightDir);
+			// Energy conservation term
 			float alpha_adjust = clamp(alpha + (sourceRadius/(2*dist)), 0.0, 1.0);
 			area_normalisation = alpha/alpha_adjust;
 			// don't need to square as it's a line rather than a sphere.
+			//end chunk
 
-			//if(dist > lightRadius) {
-			//	discard;
-			//}
+			if(dist > lightRadius) {
+				discard;
+			}
 			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 		} 
 		else if (lightType == LT_CONE) {

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -43,10 +43,9 @@ layout (std140) uniform lightData {
 
 	int lightType;
 	bool enable_shadows;
+
+	float sourceRadius;
 };
-
-
-uniform float sourceRadius = 5.0; // This should be passed in part of lightData
 
 // Nearest point sphere and tube light calculations taken from 
 // "Real Shading in Unreal Engine 4" by Brian Karis, Epic Games

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -50,6 +50,11 @@ layout (std140) uniform lightData {
 // Nearest point sphere and tube light calculations taken from 
 // "Real Shading in Unreal Engine 4" by Brian Karis, Epic Games
 // Part of SIGGRAPH 2013 Course: Physically Based Shading in Theory and Practice
+
+vec3 ExpandLightSize(in vec3 lightDir, in vec3 reflectDir) {
+	vec3 centerToRay = max(dot(lightDir, reflectDir),0) * reflectDir - lightDir;
+	return lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
+}
 void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 lightDir, out float attenuation, out float area_normalisation)
 {
 	if (lightType == LT_DIRECTIONAL) {
@@ -65,8 +70,7 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			// this chunk is unneccessary if sourceRadius= 0.0, but let's avoid a branch.
 			// given a sphere of radius sourceRadius centered at lightDir,
 			// move lightDir towards the ray defined by reflectDir
-			vec3 centerToRay = dot(lightDir, reflectDir) * reflectDir - lightDir;
-			lightDir = lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
+			lightDir = ExpandLightSize(lightDir, reflectDir);
 			dist = length(lightDir);
 			// Energy conservation term
 			float alpha_adjust = clamp(alpha + (sourceRadius/(2*dist)), 0.0, 1.0);
@@ -108,8 +112,7 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 
 			// this chunk is unneccessary if sourceRadius = 0.0, but let's avoid a branch.
 			// Same principle as in LT_POINT, treat chosen location as a spherelight.
-			vec3 centerToRay = dot(lightDir, reflectDir) * reflectDir - lightDir;
-			lightDir = lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
+			lightDir = ExpandLightSize(lightDir, reflectDir);
 			float dist = length(lightDir);
 			// Energy conservation term
 			float alpha_adjust = min(alpha + (sourceRadius/(2*dist)), 1.0);

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -81,37 +81,38 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 		} 
 		else if (lightType == LT_TUBE) {  // Tube light
-			float beamLength = length(beamVec);
-			vec3 beamDir = beamVec / beamLength;
+			
+			vec3 beamDir = normalize(beamVec);
 			//The actual 'lighting element' is shorter than the light volume cylinder
 			//To compensate the light is moved forward along the beam one radius and the length shortened
 			//this allows room for clean falloff of the light past the ends of beams.
 			vec3 adjustedLightPos = lightPosition - (beamDir * lightRadius);
-			beamLength = beamLength - (lightRadius * 2.0);
 			vec3 adjustedbeamVec = beamVec - 2.0 * lightRadius * beamDir;
+			float beamLength = length(adjustedbeamVec);
 			//adjustments having been made, sourceDir needs recalculating
 			vec3 sourceDir = adjustedLightPos - position.xyz;
-			// Get nearest 
+
+			// Get point on beam nearest to the reflection ray.
 			vec3 a_t = reflectDir;
 			vec3 b_t = beamDir;
 			vec3 b_0 = sourceDir;
 			vec3 c = cross(a_t, b_t);
 			vec3 d = b_0;
 			vec3 r = d - a_t * dot(d, a_t) - c * dot(d,c);
-			float neardist = -dot(r, r)/dot(b_t, r);
-			lightDir = sourceDir + beamDir * neardist;
-			// Somebody with a symbolic expression simplifier or a bigger brain than me
-			// should figure out how to optimise these calcs - qaz
+			float neardist = dot(r, r)/dot(b_t, r);
 			// Move along the beam by the distance we calculated
-			float dist = length(lightDir);
+			lightDir = sourceDir - beamDir * clamp(neardist, 0.0, beamLength);
+			// Somebody with a symbolic expression simplifier or a wrinklier brain than me
+			// should figure out how to optimise these calcs - qaz
+
 
 			// this chunk is unneccessary if sourceRadius = 0.0, but let's avoid a branch.
 			// Same principle as in LT_POINT, treat chosen location as a spherelight.
 			vec3 centerToRay = dot(lightDir, reflectDir) * reflectDir - lightDir;
 			lightDir = lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
-			dist = length(lightDir);
+			float dist = length(lightDir);
 			// Energy conservation term
-			float alpha_adjust = clamp(alpha + (sourceRadius/(2*dist)), 0.0, 1.0);
+			float alpha_adjust = min(alpha + (sourceRadius/(2*dist)), 1.0);
 			area_normalisation = alpha/alpha_adjust;
 			// don't need to square as it's a line rather than a sphere.
 			//end chunk

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -52,7 +52,15 @@ layout (std140) uniform lightData {
 // Part of SIGGRAPH 2013 Course: Physically Based Shading in Theory and Practice
 
 vec3 ExpandLightSize(in vec3 lightDir, in vec3 reflectDir) {
-	vec3 centerToRay = max(dot(lightDir, reflectDir),0) * reflectDir - lightDir;
+	// There's an extra max(...,sourceRadius) call here vs the version in the paper.
+	// This prevents the centerToRay calculation from choosing a point behind
+	// the reflection ray's origin (i.e. underneath the surface).
+	// this is necessary for situations where the fragment being shaded lies inside 
+	// the sourceRadius of the light.
+	// Instead, we choose a point suffciently far away from the reflection origin (hence max(...,sourceRadius))
+	// so that we have a gradual transition as the shaded fragments along the surface
+	// shift from being inside to outside the light.
+	vec3 centerToRay = max(dot(lightDir, reflectDir),sourceRadius) * reflectDir - lightDir;
 	return lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
 }
 void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 lightDir, out float attenuation, out float area_normalisation)

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -1,7 +1,7 @@
 //? #version 150
-#include "lighting.sdr"
+#include "lighting.sdr" //! #include "lighting.sdr"
 
-#include "shadows.sdr"
+#include "shadows.sdr" //! #include "shadows.sdr"
 
 in vec3 beamVec;
 in vec3 lightPosition;
@@ -45,22 +45,35 @@ layout (std140) uniform lightData {
 	bool enable_shadows;
 };
 
-void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
+
+uniform float sourceRadius = 5.0; // This should be passed in part of lightData
+
+void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 lightDir, out float attenuation, out float area_normalisation)
 {
 	if (lightType == LT_DIRECTIONAL) {
 		lightDir = normalize(lightPosition);
 		attenuation = 1.0;
+		area_normalisation = 1.0;
 	} else {
 		// Positional light source
-		lightDir = lightPosition - position.xyz;
-		float dist = length(lightDir);
-		attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
+		if (lightType == LT_POINT) {
+			lightDir = lightPosition - position.xyz;
+			float dist = length(lightDir);
 
-		if(dist > lightRadius && lightType != LT_TUBE) {
-			discard;
-		}
+			// this chunk is unneccessary if sourceRadius= 0.0, but let's avoid a branch.
+			vec3 centerToRay = dot(lightDir, reflectDir) * reflectDir - lightDir;
+			lightDir = lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
+			dist = length(lightDir);
+			float alpha_adjust = clamp(alpha + (sourceRadius/(2*dist)), 0.0, 1.0);
+			area_normalisation = alpha/alpha_adjust;
+			area_normalisation *= area_normalisation;
 
-		if (lightType == LT_TUBE) {  // Tube light
+			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
+			if(dist > lightRadius) {
+				discard;
+			}
+		} 
+		else if (lightType == LT_TUBE) {  // Tube light
 			float beamLength = length(beamVec);
 			vec3 beamDir = beamVec / beamLength;
 			//The actual 'lighting element' is shorter than the light volume cylinder
@@ -68,20 +81,40 @@ void GetLightInfo(vec3 position, out vec3 lightDir, out float attenuation)
 			//this allows room for clean falloff of the light past the ends of beams.
 			vec3 adjustedLightPos = lightPosition - (beamDir * lightRadius);
 			beamLength = beamLength - (lightRadius * 2.0);
-			//adjustments having been made, lightdir needs recalculating
-			lightDir = adjustedLightPos - position.xyz;
+			vec3 adjustedbeamVec = beamVec - 2.0 * lightRadius * beamDir;
+			//adjustments having been made, sourceDir needs recalculating
+			vec3 sourceDir = adjustedLightPos - position.xyz;
 			// Get nearest point on line
-			float neardist = clamp(dot(lightDir, beamDir), 0.0, beamLength);
-			// Move back from the endpoint of the beam along the beam by the distance we calculated
-			vec3 nearest = adjustedLightPos - beamDir * neardist;
-			lightDir = nearest - position.xyz;
+			vec3 a_t = reflectDir;
+			vec3 b_t = beamDir;
+			vec3 b_0 = sourceDir;
+			vec3 c = cross(a_t, b_t);
+			vec3 d = b_0;
+			vec3 r = d - a_t * dot(d, a_t) - c * dot(d,c);
+			float neardist = -length(r)/dot(b_t, normalize(r));
+			// Somebody with a symbolic expression simplifier or a bigger brain than me should figure out how to optimise these calcs - qaz
+			// Move along the beam by the distance we calculated
+			lightDir = sourceDir + beamDir * neardist;
+			float dist = length(lightDir);
+
+			// this chunk is unneccessary if sourceRadius= 0.0, but let's avoid a branch.
+			vec3 centerToRay = dot(lightDir, reflectDir) * reflectDir - lightDir;
+			lightDir = lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
 			dist = length(lightDir);
-			if(dist > lightRadius) {
-				discard;
-			}
+			float alpha_adjust = clamp(alpha + (sourceRadius/(2*dist)), 0.0, 1.0);
+			area_normalisation = alpha/alpha_adjust;
+			// don't need to square as it's a line rather than a sphere.
+
+			//if(dist > lightRadius) {
+			//	discard;
+			//}
 			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
-		} else if (lightType == LT_CONE) {
+		} 
+		else if (lightType == LT_CONE) {
+			lightDir = lightPosition - position.xyz;
 			float coneDot = dot(normalize(-lightDir), coneDir);
+			float dist = length(lightDir);
+			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 			if(dualCone) {
 				if(abs(coneDot) < coneAngle) {
 					discard;
@@ -115,13 +148,16 @@ void main()
 	// The vector in the normal buffer could be longer than the unit vector since decal rendering only adds to the normal buffer
 	vec3 normal = normalize(normalData.xyz);
 	float gloss = normalData.a;
+	float roughness = clamp(1.0f - gloss, 0.0f, 1.0f);
+	float alpha = roughness * roughness;
 	float fresnel = specColor.a;
 	vec3 eyeDir = normalize(-position);
 
 	vec3 lightDir;
 	float attenuation;
-
-	GetLightInfo(position, lightDir, attenuation);
+	float area_normalisation;
+	vec3 reflectDir = reflect(-eyeDir, normal);
+	GetLightInfo(position, alpha, reflectDir, lightDir, attenuation, area_normalisation);
 
 	if (enable_shadows) {
 		vec4 fragShadowPos = shadow_mv_matrix * inv_view_matrix * vec4(position, 1.0);
@@ -138,6 +174,6 @@ void main()
 	vec3 halfVec = normalize(lightDir + eyeDir);
 	float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(1.0);
-	fragmentColor.rgb = computeLighting(specColor.rgb, diffColor, lightDir, normal.xyz, halfVec, eyeDir, gloss, fresnel, NdotL).rgb * diffuseLightColor * attenuation;
+	fragmentColor.rgb = computeLighting(specColor.rgb, diffColor, lightDir, normal.xyz, halfVec, eyeDir, alpha, area_normalisation, fresnel, NdotL).rgb * diffuseLightColor * attenuation;
 	fragOut0 = max(fragmentColor, vec4(0.0));
 }

--- a/code/def_files/data/effects/deferred-v.sdr
+++ b/code/def_files/data/effects/deferred-v.sdr
@@ -22,8 +22,9 @@ layout (std140) uniform lightData {
 	float lightRadius;
 
 	int lightType;
-
 	bool enable_shadows;
+
+	float sourceRadius;
 };
 
 out vec3 lightPosition;

--- a/code/def_files/data/effects/lighting.sdr
+++ b/code/def_files/data/effects/lighting.sdr
@@ -24,10 +24,8 @@ float GeometrySchlickGGX(float dotAB, float k)
 {
     return dotAB / (dotAB * (1.0f - k) + k);
 }
-vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float gloss, float fresnelFactor, float dotNL)
+vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float alpha, float area_normalisation, float fresnelFactor, float dotNL)
 {
-	float roughness = clamp(1.0f - gloss, 0.0f, 1.0f);
-	float alpha = roughness * roughness;
 
 	float dotNH = clamp(dot(normal, halfVec), 0.0f, 1.0f);
 	float dotNV = clamp(dot(normal, view), 0.0f, 1.0f);
@@ -45,7 +43,7 @@ vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 ha
 	vec3 fresnel = mix(specColor, FresnelSchlick(halfVec, view, specColor), fresnelFactor);
 
 	// Geometry Term - Schlick-GGX approximation
-	float alphaPrime = roughness + 1.0f;
+	float alphaPrime = 2.0 - sqrt(alpha);
 	float k = alphaPrime * alphaPrime / 8.0f;
 	// Smith's method: 
 	// Microsurfaces block light rays coming in from the light 
@@ -59,7 +57,7 @@ vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 ha
 
 	vec3 specular = distribution * fresnel * geometry / (4*dotNV*dotNL + 0.0001);
 	
-	// Diffuse term - Lambertian 
+	// Diffuse term - Lambertian, kD represents energy lost to specular reflection.
 	vec3 kD = vec3(1.0)-fresnel;
 	kD *= (vec3(1.0) - specColor);
 	vec3 diffuse = kD * diffColor/PI;
@@ -67,12 +65,12 @@ vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 ha
 	return (specular + diffuse) * dotNL;
 }
 
-vec3 computeLighting(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float gloss, float fresnelFactor, float dotNL) 
+vec3 computeLighting(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float alpha, float area_normalisation, float fresnelFactor, float dotNL) 
 {
 	#ifdef FLAG_LIGHT_MODEL_BLINN_PHONG
 	return SpecularBlinnPhong(specColor, light, normal, halfVec, 32, fresnelFactor, dotNL);
 	#else
-	return ComputeGGX(specColor, diffColor, light, normal, halfVec, view, gloss, fresnelFactor, dotNL);
+	return ComputeGGX(specColor, diffColor, light, normal, halfVec, view, alpha, area_normalisation, fresnelFactor, dotNL);
 	#endif
 }
 

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -197,7 +197,8 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
         if(i > 0) {
             shadow = 1.0;
         }
-
+		float roughness = clamp(1.0f - gloss, 0.0f, 1.0f);
+		float alpha = roughness * roughness;
 		vec3 lightDir;
 		float attenuation;
 		// gather light params
@@ -206,7 +207,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		float NdotL = clamp(dot(normal, lightDir), 0.0f, 1.0f);
 		// Ambient, Diffuse, and Specular
 		lightDiffuse += (lights[i].diffuse_color.rgb * diffuseFactor * NdotL * attenuation) * shadow;
-		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, gloss, fresnel, NdotL) * attenuation * shadow;
+		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, alpha, 1.0, fresnel, NdotL) * attenuation * shadow;
 	}
 	return diffuseMaterial * lightAmbient + lightSpecular;
 }

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -17,6 +17,8 @@ struct model_light {
 	vec3 direction;
 	float attenuation;
 
+	float ml_sourceRadius;
+
 };
 
 layout (std140) uniform modelData {

--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -25,6 +25,7 @@ struct model_light {
 	vec3 direction;
 	float attenuation;
 
+	float ml_sourceRadius;
 };
 
 layout (std140) uniform modelData {

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -20,6 +20,7 @@ struct model_light {
 	vec3 direction;
 	float attenuation;
 
+	float ml_sourceRadius;
 };
 
 layout (std140) uniform modelData {

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -144,6 +144,7 @@ static void set_light(int light_num, gr_light* ltp) {
 	gr_light_uniforms[light_num].light_type = ltp->type;
 
 	gr_light_uniforms[light_num].attenuation = ltp->LinearAtten;
+	gr_light_uniforms[light_num].ml_sourceRadius = ltp->SourceRadius;
 }
 
 static bool sort_active_lights(const gr_light& la, const gr_light& lb) {

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -35,6 +35,7 @@ struct gr_light
 
 	float SpotCutOff;
 	float ConstantAtten, LinearAtten, QuadraticAtten;
+	float SourceRadius;
 
 	int type;
 };
@@ -81,6 +82,7 @@ void FSLight2GLLight(light* FSLight, gr_light* GLLight) {
 	GLLight->Position.xyzw.y = FSLight->vec.xyz.y;
 	GLLight->Position.xyzw.z = FSLight->vec.xyz.z; // flipped axis for FS2
 	GLLight->Position.xyzw.w = 1.0f;
+	GLLight->SourceRadius = FSLight->source_radius;
 
 
 	switch (FSLight->type) {

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -171,6 +171,7 @@ void gr_opengl_deferred_lighting_finish()
 
 			// Set a default value for all lights. Only the first directional light will change this.
 			light_data->enable_shadows = false;
+			light_data->sourceRadius = l.source_radius;
 
 			switch (l.type) {
 			case Light_Type::Directional:

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -51,8 +51,9 @@ struct deferred_light_data {
 
 	int lightType;
 	int enable_shadows;
+	float sourceRadius;
 
-	float pad0[2]; // Struct size must be 16-bytes aligned because we use vec3s
+	float pad0[1]; // Struct size must be 16-bytes aligned because we use vec3s
 };
 
 struct model_light {
@@ -61,6 +62,7 @@ struct model_light {
 	int light_type;
 	vec3d direction;
 	float attenuation;
+	float ml_sourceRadius;
 };
 
 const size_t MAX_UNIFORM_LIGHTS = 8;

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -58,11 +58,15 @@ struct deferred_light_data {
 
 struct model_light {
 	vec4 position;
+
 	vec3d diffuse_color;
 	int light_type;
+
 	vec3d direction;
 	float attenuation;
+
 	float ml_sourceRadius;
+	float pad0[3]; 
 };
 
 const size_t MAX_UNIFORM_LIGHTS = 8;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -150,13 +150,13 @@ static void light_rotate(light * l)
 	}
 }
 
-void light_add_directional(const vec3d* dir, const hdr_color* new_color)
+void light_add_directional(const vec3d* dir, const hdr_color* new_color, const float source_radius)
 {
 	Assert(new_color!= nullptr);
-	light_add_directional(dir, new_color->i(), new_color->r(), new_color->g(), new_color->b());
+	light_add_directional(dir, new_color->i(), new_color->r(), new_color->g(), new_color->b(), source_radius);
 }
 
-void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b)
+void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, const float source_radius)
 {
 	if (Lighting_off) return;
 
@@ -181,18 +181,23 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 	l.radb_squared = l.radb*l.radb;
 	l.instance = Num_lights-1;
 
+	if(source_radius>=0)
+		l.source_radius = source_radius;
+	else
+		l.source_radius = 1.0f;
+
 	Lights.push_back(l);
 	Static_light.push_back(l);
 }
 
 
-void light_add_point(const vec3d* pos, float r1, float r2, const hdr_color* new_color)
+void light_add_point(const vec3d* pos, float r1, float r2, const hdr_color* new_color, float source_radius)
 {
 	Assert(new_color!= nullptr);
-	light_add_point(pos, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b());
+	light_add_point(pos, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b(), source_radius);
 }
 
-void light_add_point(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b)
+void light_add_point(const vec3d *pos, float r1, float r2, float intensity, float r, float g, float b, const float source_radius)
 {
 	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
 	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
@@ -219,16 +224,21 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 	l.radb_squared = l.radb*l.radb;
 	l.instance = Num_lights-1;
 
+	if(source_radius>=0)
+		l.source_radius = source_radius;
+	else
+		l.source_radius = MAX(l.rada,l.radb) * 0.01f;
+
 	Lights.push_back(l);
 }
 
-void light_add_tube(const vec3d* p0, const vec3d* p1, float r1, float r2, const hdr_color* new_color)
+void light_add_tube(const vec3d* p0, const vec3d* p1, float r1, float r2, const hdr_color* new_color, const float source_radius)
 {
 	Assert(new_color!= nullptr);
-	light_add_tube(p0, p1, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b());
+	light_add_tube(p0, p1, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b(), source_radius);
 }
 
-void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b)
+void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, const float source_radius)
 {
 	Assertion(r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1);
 	Assertion(r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2);
@@ -256,6 +266,10 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 	l.rada_squared = l.rada*l.rada;
 	l.radb_squared = l.radb*l.radb;
 	l.instance = Num_lights-1;
+	if(source_radius>=0)
+		l.source_radius = source_radius;
+	else
+		l.source_radius = MAX(l.rada,l.radb) * 0.01f;
 
 	Lights.push_back(l);
 }
@@ -424,13 +438,13 @@ void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, const vec3
 }
 
 
-void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, const hdr_color* new_color)
+void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, const hdr_color* new_color, const float source_radius)
 {
 	Assert(new_color!= nullptr);
-	light_add_cone(pos, dir, angle, inner_angle, dual_cone, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b());
+	light_add_cone(pos, dir, angle, inner_angle, dual_cone, r1, r2, new_color->i(), new_color->r(), new_color->g(), new_color->b(), source_radius);
 }
 
-void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b)
+void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, const float source_radius )
 {
 	Assertion( r1 > 0.0f, "Invalid radius r1 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r1 );
 	Assertion( r2 > 0.0f, "Invalid radius r2 specified for light: %f. Radius must be > 0.0f. Examine stack trace to determine culprit.\n", r2 );
@@ -460,6 +474,11 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 	l.rada_squared = l.rada*l.rada;
 	l.radb_squared = l.radb*l.radb;
 	l.instance = Num_lights-1;
+
+	if(source_radius>=0)
+		l.source_radius = source_radius;
+	else
+		l.source_radius = MAX(l.rada,l.radb) * 0.01f;
 
 	Lights.push_back(l);
 }

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -181,10 +181,7 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 	l.radb_squared = l.radb*l.radb;
 	l.instance = Num_lights-1;
 
-	if(source_radius>=0)
-		l.source_radius = source_radius;
-	else
-		l.source_radius = 1.0f;
+	l.source_radius = MAX(0.0f,source_radius);
 
 	Lights.push_back(l);
 	Static_light.push_back(l);
@@ -224,10 +221,7 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 	l.radb_squared = l.radb*l.radb;
 	l.instance = Num_lights-1;
 
-	if(source_radius>=0)
-		l.source_radius = source_radius;
-	else
-		l.source_radius = MAX(l.rada,l.radb) * 0.01f;
+	l.source_radius = MAX(0.0f,source_radius);
 
 	Lights.push_back(l);
 }
@@ -266,10 +260,8 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 	l.rada_squared = l.rada*l.rada;
 	l.radb_squared = l.radb*l.radb;
 	l.instance = Num_lights-1;
-	if(source_radius>=0)
-		l.source_radius = source_radius;
-	else
-		l.source_radius = MAX(l.rada,l.radb) * 0.01f;
+
+	l.source_radius = MAX(0.0f,source_radius);
 
 	Lights.push_back(l);
 }
@@ -475,10 +467,7 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 	l.radb_squared = l.radb*l.radb;
 	l.instance = Num_lights-1;
 
-	if(source_radius>=0)
-		l.source_radius = source_radius;
-	else
-		l.source_radius = MAX(l.rada,l.radb) * 0.01f;
+	l.source_radius = MAX(0.0f,source_radius);
 
 	Lights.push_back(l);
 }

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -88,14 +88,14 @@ extern void light_reset();
 
 //Intensity in lighting inputs multiplies the base colors.
 
-extern void light_add_directional(const vec3d *dir, const hdr_color *new_color, const float source_radius = -1.0f );
-extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, const float source_radius = -1.0f);
-extern void light_add_point(const vec3d * pos, float r1, float r2, const hdr_color *new_color, const float source_radius = -1.0f);
-extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = -1.0f);
-extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, const hdr_color *new_color, const float source_radius = -1.0f);
-extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = -1.0f);
-extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, const hdr_color *new_color, const float source_radius = -1.0f);
-extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = -1.0f);
+extern void light_add_directional(const vec3d *dir, const hdr_color *new_color, const float source_radius = 0.0f );
+extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, const float source_radius = 0.0f);
+extern void light_add_point(const vec3d * pos, float r1, float r2, const hdr_color *new_color, const float source_radius = 0.0f);
+extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = 0.0f);
+extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, const hdr_color *new_color, const float source_radius = 0.0f);
+extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = 0.0f);
+extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, const hdr_color *new_color, const float source_radius = 0.0f);
+extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = 0.0f);
 
 
 extern void light_rotate_all();

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -48,6 +48,7 @@ typedef struct light {
 	float	cone_angle;						// angle for cone lights
 	float	cone_inner_angle;				// the inner angle for calculating falloff
 	bool	dual_cone;						// should the cone be shining in both directions?
+	float source_radius;					// The actual size of the object or volume emitting the light
 	int instance;
 } light;
 
@@ -87,14 +88,14 @@ extern void light_reset();
 
 //Intensity in lighting inputs multiplies the base colors.
 
-extern void light_add_directional(const vec3d *dir, const hdr_color *new_color);
-extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b);
-extern void light_add_point(const vec3d * pos, float r1, float r2, const hdr_color *new_color);
-extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b);
-extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, const hdr_color *new_color);
-extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b);
-extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, const hdr_color *new_color);
-extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b);
+extern void light_add_directional(const vec3d *dir, const hdr_color *new_color, const float source_radius = -1.0f );
+extern void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, const float source_radius = -1.0f);
+extern void light_add_point(const vec3d * pos, float r1, float r2, const hdr_color *new_color, const float source_radius = -1.0f);
+extern void light_add_point(const vec3d * pos, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = -1.0f);
+extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, const hdr_color *new_color, const float source_radius = -1.0f);
+extern void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = -1.0f);
+extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, const hdr_color *new_color, const float source_radius = -1.0f);
+extern void light_add_cone(const vec3d * pos, const vec3d * dir, float angle, float inner_angle, bool dual_cone, float r1, float r2, float intensity, float r, float g, float b, const float source_radius = -1.0f);
 
 
 extern void light_rotate_all();

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1873,9 +1873,9 @@ void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient,
 			cone_dir_screen.xyz.z = -cone_dir_screen.xyz.z;
 			light_add_cone(
 				&world_pnt, &cone_dir_screen, gpo->cone_angle, gpo->cone_inner_angle, gpo->dualcone, 1.0f, light_radius, 1,
-				lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z);
+				lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z, gpt->radius);
 		} else {
-			light_add_point(&world_pnt, 1.0f, light_radius, 1,	lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z);
+			light_add_point(&world_pnt, 1.0f, light_radius, 1,	lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z, gpt->radius);
 		}
 	}
 }

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1244,15 +1244,18 @@ void obj_move_all_post(object *objp, float frametime)
 					}
 					//handles both defaults and adjustments.
 					float r = wi->light_radius;
+					float source_radius = objp->radius;
 					if (wi->render_type == WRT_LASER) {
 						r = lp->laser_light_radius.handle(r);
 						light_color.i(lp->laser_light_brightness.handle(light_color.i()));
 					} else {
+						//Missiles should typically not be treated as lights for their whole radius. TODO: make configurable.
+						source_radius *= 0.05f;
 						r = lp->missile_light_radius.handle(r);
 						light_color.i(lp->missile_light_brightness.handle(light_color.i()));
 					}
 					if(r > 0.0f && light_color.i() > 0.0f)
-						light_add_point(&objp->pos, r, r, &light_color);
+						light_add_point(&objp->pos, r, r, &light_color,source_radius);
 				}
 			}
 
@@ -1345,7 +1348,7 @@ void obj_move_all_post(object *objp, float frametime)
 					// P goes from 0 to 1 to 0 over the life of the explosion
 					// Only do this if rad is > 0.0000001f
 					if (rad > 0.0001f)
-						light_add_point( &objp->pos, rad * 2.0f, rad * 5.0f, intensity, r, g, b);
+						light_add_point( &objp->pos, rad * 2.0f, rad * 5.0f, intensity, r, g, b,rad * 0.9f);
 				}
 			}
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1347,8 +1347,9 @@ void obj_move_all_post(object *objp, float frametime)
 					}
 					// P goes from 0 to 1 to 0 over the life of the explosion
 					// Only do this if rad is > 0.0000001f
+					// TODO: Make fireball source radius configurable, currently sized based on modern subspace portal textures as that will be a very prominent case of it
 					if (rad > 0.0001f)
-						light_add_point( &objp->pos, rad * 2.0f, rad * 5.0f, intensity, r, g, b,rad * 0.9f);
+						light_add_point( &objp->pos, rad * 2.0f, rad * 5.0f, intensity, r, g, b,rad * 0.3f);
 				}
 			}
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1927,7 +1927,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 
 	if (light_color.i() <= 0.0f || light_rad <= 0.0f)
 		return;
-	light_add_point(pt, light_rad * 0.0001f, light_rad, &light_color);
+	light_add_point(pt, light_rad * 0.0001f, light_rad, &light_color,bm->beam_light_width*pct*noise);
 }
 
 // call to add a light source to a large object
@@ -1955,7 +1955,7 @@ void beam_add_light_large(beam *bm, object *objp, vec3d *pt0, vec3d *pt1)
 	light_rad = lp->beam_light_radius.handle(light_rad);
 	if (light_color.i() <= 0.0f || light_rad <= 0.0f)
 		return;
-	light_add_tube(pt0, pt1, 1.0f, light_rad, &light_color);
+	light_add_tube(pt0, pt1, 1.0f, light_rad, &light_color,bm->beam_light_width*noise);
 }
 
 // mark an object as being lit

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1927,7 +1927,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 
 	if (light_color.i() <= 0.0f || light_rad <= 0.0f)
 		return;
-	light_add_point(pt, light_rad * 0.0001f, light_rad, &light_color,bm->beam_light_width*pct*noise);
+	light_add_point(pt, light_rad * 0.0001f, light_rad, &light_color,bm->beam_light_width*pct*noise/3.0f);
 }
 
 // call to add a light source to a large object
@@ -1955,7 +1955,7 @@ void beam_add_light_large(beam *bm, object *objp, vec3d *pt0, vec3d *pt1)
 	light_rad = lp->beam_light_radius.handle(light_rad);
 	if (light_color.i() <= 0.0f || light_rad <= 0.0f)
 		return;
-	light_add_tube(pt0, pt1, 1.0f, light_rad, &light_color,bm->beam_light_width*noise);
+	light_add_tube(pt0, pt1, 1.0f, light_rad, &light_color,bm->beam_light_width*noise/3.0f);
 }
 
 // mark an object as being lit


### PR DESCRIPTION
This was made in collaboration with @EatThePath, and focuses on improving the look of beams, weapons and warp lighting
This should be merged in after #4652 as it relies upon some of the changes made there.

Based off research by epic games, [Real Shading in Unreal Engine 4](https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf), the tube and point light lighting calculations have been modified. 

Firstly, the point-source approximation used by beams/tube lights has been changed. Instead of choosing the nearest point of the tube light to the shaded fragment, the eye direction and surface normal are taken into account. This improves the look of the reflections of beams (especially on curved surfaces)

Secondly, all beam and point lights now have a sourceRadius. This slightly modifies the lighting calculation, nudging the position of the point-source-approximation so that the specular reflections appear to have a physical size. This prevents glossy reflections of point sources from diminishing into a single point and gives weapon lighting true "thickness" 

22.2.0
![22.2.0](https://cdn.discordapp.com/attachments/223511363807346691/990748063024963594/unknown.png)

With improved lighting
![improved](https://cdn.discordapp.com/attachments/223511363807346691/990738626881134612/unknown.png)

This also improves the look of subspace portal lighting:
(from joe's warmachine stream)
![joe's warmachine stream](https://cdn.discordapp.com/attachments/849709471273058324/1008437332782874755/unknown.png)



Pics from ETP's work:
![ETP1](https://cdn.discordapp.com/attachments/222801080621203456/996454241784840352/screen0561.png)
![ETP2](https://cdn.discordapp.com/attachments/222801080621203456/996453381143003156/screen0558.png)

 