### PR TITLE
improve huge_fire_info lookup

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -179,6 +179,15 @@ SCP_vector<exited_ship> Ships_exited;
 SCP_vector<ship_registry_entry> Ship_registry;
 SCP_unordered_map<SCP_string, int, SCP_string_lcase_hash, SCP_string_lcase_equal_to> Ship_registry_map;
 
+int ship_registry_get_index(const char *name)
+{
+	auto ship_it = Ship_registry_map.find(name);
+	if (ship_it != Ship_registry_map.end())
+		return ship_it->second;
+
+	return -1;
+}
+
 const ship_registry_entry *ship_registry_get(const char *name)
 {
 	auto ship_it = Ship_registry_map.find(name);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -902,6 +902,7 @@ struct ship_registry_entry
 extern SCP_vector<ship_registry_entry> Ship_registry;
 extern SCP_unordered_map<SCP_string, int, SCP_string_lcase_hash, SCP_string_lcase_equal_to> Ship_registry_map;
 
+extern int ship_registry_get_index(const char *name);
 extern const ship_registry_entry *ship_registry_get(const char *name);
 
 #define REGULAR_WEAPON	(1<<0)


### PR DESCRIPTION
According to EatThePath's frame profiling, this one ship name lookup takes 2% of the frame time.  It can be easily optimized by making use of the ship registry.