### PR TITLE
Scpui api briefing map

### DIFF
--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1082,7 +1082,7 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 				//hud_set_iff_color(bi->team);
 				brief_set_icon_color(bi->team);
 
-				hud_anim_render(ha, frametime, 1, 0, 1, 0, GR_RESIZE_MENU, mirror_icon);
+				hud_anim_render(ha, frametime, 1, 0, 1, 0, bscreen.resize, mirror_icon);
 
 				if (!Brief_stage_highlight_sound_handle.isValid()) {
 					if ( !Fred_running) {
@@ -1100,7 +1100,7 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 				ha->sy = by;
 				brief_set_icon_color(bi->team);
 
-				if ( hud_anim_render(ha, frametime, 1, 0, 0, 1, GR_RESIZE_MENU, mirror_icon) == 0 ) {
+				if (hud_anim_render(ha, frametime, 1, 0, 0, 1, bscreen.resize, mirror_icon) == 0) {
 					bi->flags &= ~BI_FADEIN;
 				}
 			} else {
@@ -1110,12 +1110,12 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 
 		if ( !(bi->flags & BI_FADEIN) ) {
 			gr_set_bitmap(icon_bitmap);
-			gr_aabitmap(bx, by, GR_RESIZE_MENU,mirror_icon);
+			gr_aabitmap(bx, by, bscreen.resize, mirror_icon);
 
 			// draw text centered over the icon (make text darker)
 			if ( bi->type == ICON_FIGHTER_PLAYER || bi->type == ICON_BOMBER_PLAYER ) {
 				gr_get_string_size(&w,&h,Players[Player_num].callsign);
-				gr_string(bc - fl2i(w/2.0f), by - h, Players[Player_num].callsign, GR_RESIZE_MENU);
+				gr_string(bc - fl2i(w / 2.0f), by - h, Players[Player_num].callsign, bscreen.resize);
 			}
 			else {
 				if (Lcl_gr && !Disable_built_in_translations) {
@@ -1123,16 +1123,16 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 					strcpy_s(buf, bi->label);
 					lcl_translate_brief_icon_name_gr(buf);
 					gr_get_string_size(&w, &h, buf);
-					gr_string(bc - fl2i(w/2.0f), by - h, buf, GR_RESIZE_MENU);
+					gr_string(bc - fl2i(w / 2.0f), by - h, buf, bscreen.resize);
 				} else if (Lcl_pl && !Disable_built_in_translations) {
 					char buf[128];
 					strcpy_s(buf, bi->label);
 					lcl_translate_brief_icon_name_pl(buf);
 					gr_get_string_size(&w, &h, buf);
-					gr_string(bc - fl2i(w/2.0f), by - h, buf, GR_RESIZE_MENU);
+					gr_string(bc - fl2i(w / 2.0f), by - h, buf, bscreen.resize);
 				} else {
 					gr_get_string_size(&w,&h,bi->label);
-					gr_string(bc - fl2i(w/2.0f), by - h, bi->label, GR_RESIZE_MENU);
+					gr_string(bc - fl2i(w / 2.0f), by - h, bi->label, bscreen.resize);
 				}
 			}
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -633,6 +633,7 @@ void brief_init_screen(int  /*multiplayer_flag*/)
 	bscreen.map_x2			= Brief_grid_coords[gr_screen.res][0] + Brief_grid_coords[gr_screen.res][2];
 	bscreen.map_y1			= Brief_grid_coords[gr_screen.res][1];
 	bscreen.map_y2			= Brief_grid_coords[gr_screen.res][1] + Brief_grid_coords[gr_screen.res][3];
+	bscreen.resize          = GR_RESIZE_MENU;
 }
 
 // --------------------------------------------------------------------------------------
@@ -1217,7 +1218,7 @@ void brief_start_highlight_anims(int stage_num)
 //
 void brief_render_map(int stage_num, float frametime)
 {
-	gr_set_clip(bscreen.map_x1 + 1, bscreen.map_y1 + 1, bscreen.map_x2 - bscreen.map_x1 - 1, bscreen.map_y2 - bscreen.map_y1 - 2, GR_RESIZE_MENU);
+	gr_set_clip(bscreen.map_x1 + 1, bscreen.map_y1 + 1, bscreen.map_x2 - bscreen.map_x1 - 1, bscreen.map_y2 - bscreen.map_y1 - 2, bscreen.resize);
 
     if (stage_num >= Briefing->num_stages) {
 		gr_reset_clip();

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -262,7 +262,7 @@ extern int Brief_static_coords[GR_NUM_RESOLUTIONS][2];
 
 typedef struct brief_screen
 {
-	int map_x1, map_x2, map_y1, map_y2;
+	int map_x1, map_x2, map_y1, map_y2, resize;
 /*	int btext_x1, btext_x2, btext_y1, btext_y2;
 	int cup_x1, cup_x2, cup_y1, cup_y2;
 	int cupinfo_x1, cupinfo_x2, cupinfo_y1, cupinfo_y2;*/

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1948,6 +1948,7 @@ void brief_api_do_frame(float frametime)
 				time,
 				Current_brief_stage);
 
+			//A few items commented out, but keeping a record for closeup icon fixing in a later PR - Mjn
 			// Brief_playing_fade_sound = 0;
 			Last_brief_stage = Current_brief_stage;
 			// brief_reset_icons(Current_brief_stage);
@@ -2051,7 +2052,7 @@ void brief_close()
 void brief_api_close()
 {
 	if (Brief_inited == FALSE) {
-		nprintf(("Warning", "brief_close() returning without doing anything\n"));
+		nprintf(("Warning", "brief_api_close() returning without doing anything\n"));
 		return;
 	}
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1018,6 +1018,7 @@ void brief_api_init()
 	hud_anim_init(&Fade_anim, bstat_x, bstat_y, Brief_static_name[gr_screen.res]);
 	hud_anim_load(&Fade_anim);
 
+	//This will need to be replaced with an API version in a later PR - Mjn
 	common_select_init();
 
 	// This loads the static bitmap for stage cuts - Mjn

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1028,7 +1028,7 @@ void brief_api_init()
 
 	Brief_mouse_up_flag = 0;
 	Closeup_font_height = gr_get_font_height();
-	Closeup_icon = NULL;
+	Closeup_icon = nullptr;
 	Brief_inited = TRUE;
 }
 

--- a/code/missionui/missionbrief.h
+++ b/code/missionui/missionbrief.h
@@ -38,6 +38,11 @@ extern int	Brief_multitext_bitmap;	// bitmap for multiplayer chat window
 extern int	Brief_background_bitmap;
 extern UI_INPUTBOX	Common_multi_text_inputbox[3];
 
+// These are used to allow the API to define the coords for brief map static effect
+extern int bstat_x;
+extern int bstat_y;
+extern int brief_api;
+
 // Sounds
 #define		BRIEFING_MUSIC_DELAY	2500		// 650 ms delay before briefing music starts
 extern int	Briefing_music_handle;
@@ -48,6 +53,14 @@ extern int Briefing_overlay_id;
 extern int Briefing_paused;	// for stopping audio and stage progression
 
 struct brief_icon;
+
+void brief_api_init();
+void brief_api_do_frame(float frametime);
+void brief_do_next_pressed(int play_sound);
+void brief_do_prev_pressed();
+void brief_do_start_pressed();
+void brief_do_end_pressed();
+void brief_api_close();
 
 void brief_init();
 void brief_close();

--- a/code/missionui/missionbrief.h
+++ b/code/missionui/missionbrief.h
@@ -38,11 +38,6 @@ extern int	Brief_multitext_bitmap;	// bitmap for multiplayer chat window
 extern int	Brief_background_bitmap;
 extern UI_INPUTBOX	Common_multi_text_inputbox[3];
 
-// These are used to allow the API to define the coords for brief map static effect
-extern int bstat_x;
-extern int bstat_y;
-extern int brief_api;
-
 // Sounds
 #define		BRIEFING_MUSIC_DELAY	2500		// 650 ms delay before briefing music starts
 extern int	Briefing_music_handle;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -714,7 +714,7 @@ ADE_FUNC(startBriefingMap,
 ADE_FUNC(closeBriefingMap,
 	l_UserInterface_Brief,
 	nullptr,
-	"Closes the briefing map. Required after drawing!",
+	"Closes the briefing map. Required when done drawing!",
 	nullptr,
 	"nothing")
 {
@@ -726,7 +726,7 @@ ADE_FUNC(closeBriefingMap,
 ADE_FUNC(drawBriefingMap,
 	l_UserInterface_Brief,
 	nullptr,
-	"Draws the briefing map for the current mission.",
+	"Draws the briefing map for the current mission. Must be called On Frame.",
 	nullptr,
 	"nothing")
 {

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -562,14 +562,27 @@ ADE_FUNC(runBriefingStageHook,
 ADE_FUNC(initBriefing,
 	l_UserInterface_Brief,
 	nullptr,
-	"Initializes the briefing.  Handles various non-UI housekeeping tasks and compacts the stages to remove those that should not be shown.",
+	"Initializes the briefing and prepares the map for drawing.  Also handles various non-UI housekeeping tasks "
+	"and compacts the stages to remove those that should not be shown.",
 	nullptr,
 	"nothing")
 {
 	SCP_UNUSED(L);
 
-	// TODO: probably call brief_api_init()
+	brief_api_init();
 
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(closeBriefing,
+	l_UserInterface_Brief,
+	nullptr,
+	"Closes the briefing and pauses the map. Required after using the briefing API!",
+	nullptr,
+	nullptr)
+{
+	SCP_UNUSED(L);
+	brief_api_close();
 	return ADE_RETURN_NIL;
 }
 
@@ -657,25 +670,26 @@ ADE_FUNC(skipTraining,
 
 // For now any loadout error checking needs to happen in the script to prevent FSO from
 // generating a popup that will not be interactible from Librocket. A later update to this
-// method will introduce return values instead of generating pops and those return values
+// method will introduce return values instead of generating popups and those return values
 // can be used to handle loadout popups on the script side
 ADE_FUNC(commitToMission,
 	l_UserInterface_Brief,
 	nullptr,
-	"Commits to the current mission with current loadout data, and starts the mission.",
+	"Commits to the current mission with current loadout data, and starts the mission. WIP, do not use!",
 	nullptr,
 	"nothing")
 {
-	(void)L;
+	SCP_UNUSED(L);
 	commit_pressed();
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(startBriefingMap,
+ADE_FUNC(drawBriefingMap,
 	l_UserInterface_Brief,
-	"number x1, number y1, [number x2 = 888, number y2 = 235]",
-	"Starts the briefing map for the current mission. This also inits the current mission's loadout information "
-	"for maninipulation by Lua.",
+	"number x, number y, [number width = 888, number height = 371]",
+	"Draws the briefing map for the current mission at the specified coordinates. Note that the "
+	"width and height must be a specific aspect ratio to match retail. If changed then some icons "
+	"may be clipped from view unexpectedly. Must be called On Frame.",
 	nullptr,
 	nullptr)
 {
@@ -699,32 +713,9 @@ ADE_FUNC(startBriefingMap,
 	bscreen.map_y1 = y1;
 	bscreen.map_y2 = y1 + y2;
 	bscreen.resize = GR_RESIZE_NONE;
-	brief_api_init();
 
-	return ADE_RETURN_NIL;
-}
-
-ADE_FUNC(closeBriefingMap,
-	l_UserInterface_Brief,
-	nullptr,
-	"Closes the briefing map. Required when done drawing!",
-	nullptr,
-	nullptr)
-{
-	(void)L;
-	brief_api_close();
-	return ADE_RETURN_NIL;
-}
-
-ADE_FUNC(drawBriefingMap,
-	l_UserInterface_Brief,
-	nullptr,
-	"Draws the briefing map for the current mission. Must be called On Frame.",
-	nullptr,
-	nullptr)
-{
-	(void)L;
 	brief_api_do_frame(flRealframetime);
+
 	return ADE_RETURN_NIL;
 }
 
@@ -735,7 +726,7 @@ ADE_FUNC(callNextMapStage,
 	nullptr,
 	"nothing")
 {
-	(void)L;
+	SCP_UNUSED(L);
 	brief_do_next_pressed(0);
 	return ADE_RETURN_NIL;
 }
@@ -747,7 +738,7 @@ ADE_FUNC(callPrevMapStage,
 	nullptr,
 	nullptr)
 {
-	(void)L;
+	SCP_UNUSED(L);
 	brief_do_prev_pressed();
 	return ADE_RETURN_NIL;
 }
@@ -759,7 +750,7 @@ ADE_FUNC(callFirstMapStage,
 	nullptr,
 	"nothing")
 {
-	(void)L;
+	SCP_UNUSED(L);
 	brief_do_start_pressed();
 	return ADE_RETURN_NIL;
 }
@@ -772,7 +763,6 @@ ADE_FUNC(callLastMapStage,
 	nullptr)
 {
 	SCP_UNUSED(L);
-	(void)L;
 	brief_do_end_pressed();
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -700,12 +700,7 @@ ADE_FUNC(startBriefingMap,
 	bscreen.map_x2 = x1 + x2;
 	bscreen.map_y1 = y1;
 	bscreen.map_y2 = y1 + y2;
-
-	bstat_x = x1 + stat_x;
-	bstat_y = y1 + stat_y;
-
-	brief_api = 1;
-
+	bscreen.resize = GR_RESIZE_NONE;
 	brief_api_init();
 
 	return ADE_RETURN_NIL;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -673,21 +673,19 @@ ADE_FUNC(commitToMission,
 
 ADE_FUNC(startBriefingMap,
 	l_UserInterface_Brief,
-	"number x1, number y1, [number x2 = 888, number y2 = 235, number static offset x, number static offset y]",
+	"number x1, number y1, [number x2 = 888, number y2 = 235]",
 	"Starts the briefing map for the current mission. This also inits the current mission's loadout information "
 	"for maninipulation by Lua.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 
 	int x1;
 	int y1;
 	int x2 = 888;
 	int y2 = 371;
-	int stat_x;
-	int stat_y;
 
-	if (!ade_get_args(L, "ii|iiii", &x1, &y1, &x2, &y2, &stat_x, &stat_y)) {
+	if (!ade_get_args(L, "ii|ii", &x1, &y1, &x2, &y2)) {
 		LuaError(L, "X and Y coordinates not provided!");
 		return ADE_RETURN_NIL;
 	}
@@ -711,7 +709,7 @@ ADE_FUNC(closeBriefingMap,
 	nullptr,
 	"Closes the briefing map. Required when done drawing!",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	(void)L;
 	brief_api_close();
@@ -723,7 +721,7 @@ ADE_FUNC(drawBriefingMap,
 	nullptr,
 	"Draws the briefing map for the current mission. Must be called On Frame.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	(void)L;
 	brief_api_do_frame(flRealframetime);
@@ -747,7 +745,7 @@ ADE_FUNC(callPrevMapStage,
 	nullptr,
 	"Sends the briefing map to the previous stage.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	(void)L;
 	brief_do_prev_pressed();
@@ -771,7 +769,7 @@ ADE_FUNC(callLastMapStage,
 	nullptr,
 	"Sends the briefing map to the last stage.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	SCP_UNUSED(L);
 	(void)L;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -565,7 +565,7 @@ ADE_FUNC(initBriefing,
 	"Initializes the briefing and prepares the map for drawing.  Also handles various non-UI housekeeping tasks "
 	"and compacts the stages to remove those that should not be shown.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	SCP_UNUSED(L);
 
@@ -607,7 +607,7 @@ ADE_FUNC(exitLoop,
 	nullptr,
 	"Skips the current mission, exits the campaign loop, and loads the next non-loop mission in a campaign. Returns to the main hall if the player is not in a campaign.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	SCP_UNUSED(L);
 
@@ -625,7 +625,7 @@ ADE_FUNC(skipMission,
 	nullptr,
 	"Skips the current mission, and loads the next mission in a campaign. Returns to the main hall if the player is not in a campaign.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	SCP_UNUSED(L);
 
@@ -643,7 +643,7 @@ ADE_FUNC(skipTraining,
 	nullptr,
 	"Skips the current training mission, and loads the next mission in a campaign. Returns to the main hall if the player is not in a campaign.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	SCP_UNUSED(L);
 
@@ -677,7 +677,7 @@ ADE_FUNC(commitToMission,
 	nullptr,
 	"Commits to the current mission with current loadout data, and starts the mission. WIP, do not use!",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	SCP_UNUSED(L);
 	commit_pressed();
@@ -724,7 +724,7 @@ ADE_FUNC(callNextMapStage,
 	nullptr,
 	"Sends the briefing map to the next stage.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	SCP_UNUSED(L);
 	brief_do_next_pressed(0);
@@ -748,7 +748,7 @@ ADE_FUNC(callFirstMapStage,
 	nullptr,
 	"Sends the briefing map to the first stage.",
 	nullptr,
-	"nothing")
+	nullptr)
 {
 	SCP_UNUSED(L);
 	brief_do_start_pressed();

--- a/code/scripting/api/objs/briefing.cpp
+++ b/code/scripting/api/objs/briefing.cpp
@@ -59,8 +59,8 @@ ADE_VIRTVAR(hasForwardCut,
 	l_BriefStage,
 	nullptr,
 	"The result of the stage formula",
-	"briefing_stage",
-	"true if the stage should be displayed, false otherwise")
+	"boolean",
+	"true if the stage is set to cut to the next stage, false otherwise")
 {
 	brief_stage_h stage;
 	if (!ade_get_args(L, "o", l_BriefStage.Get(&stage))) {
@@ -82,8 +82,8 @@ ADE_VIRTVAR(hasBackwardCut,
 	l_BriefStage,
 	nullptr,
 	"The result of the stage formula",
-	"briefing_stage",
-	"true if the stage should be displayed, false otherwise")
+	"boolean",
+	"true if the stage is set to cut to the previous stage, false otherwise")
 {
 	brief_stage_h stage;
 	if (!ade_get_args(L, "o", l_BriefStage.Get(&stage))) {

--- a/code/scripting/api/objs/briefing.cpp
+++ b/code/scripting/api/objs/briefing.cpp
@@ -58,7 +58,7 @@ ADE_VIRTVAR(AudioFilename,
 ADE_VIRTVAR(hasForwardCut,
 	l_BriefStage,
 	nullptr,
-	"The result of the stage formula",
+	"If the stage has a forward cut flag",
 	"boolean",
 	"true if the stage is set to cut to the next stage, false otherwise")
 {
@@ -81,7 +81,7 @@ ADE_VIRTVAR(hasForwardCut,
 ADE_VIRTVAR(hasBackwardCut,
 	l_BriefStage,
 	nullptr,
-	"The result of the stage formula",
+	"If the stage has a backward cut flag",
 	"boolean",
 	"true if the stage is set to cut to the previous stage, false otherwise")
 {

--- a/code/scripting/api/objs/briefing.cpp
+++ b/code/scripting/api/objs/briefing.cpp
@@ -55,6 +55,52 @@ ADE_VIRTVAR(AudioFilename,
 	return ade_set_args(L, "s", stage.getStage()->voice);
 }
 
+ADE_VIRTVAR(hasForwardCut,
+	l_BriefStage,
+	nullptr,
+	"The result of the stage formula",
+	"briefing_stage",
+	"true if the stage should be displayed, false otherwise")
+{
+	brief_stage_h stage;
+	if (!ade_get_args(L, "o", l_BriefStage.Get(&stage))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	if (stage.getStage()->flags & BS_FORWARD_CUT) {
+		return ADE_RETURN_TRUE;
+	} else {
+		return ADE_RETURN_FALSE;
+	}
+}
+
+ADE_VIRTVAR(hasBackwardCut,
+	l_BriefStage,
+	nullptr,
+	"The result of the stage formula",
+	"briefing_stage",
+	"true if the stage should be displayed, false otherwise")
+{
+	brief_stage_h stage;
+	if (!ade_get_args(L, "o", l_BriefStage.Get(&stage))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	if (stage.getStage()->flags & BS_BACKWARD_CUT) {
+		return ADE_RETURN_TRUE;
+	} else {
+		return ADE_RETURN_FALSE;
+	}
+}
+
 //**********HANDLE: briefing
 ADE_OBJ(l_Brief, int, "briefing", "Briefing handle");
 


### PR DESCRIPTION
Creates an API that allows drawing the currently loaded mission's briefing icon map and ability to manipulate what stage it is on.

Note that because of how retail rendered the cut-to-stage static, rendering of that has been removed from the API to be handled by the scripts so that it can be properly sized dynamically.

Also note that clicking on the icons of the map rendered through the API is not currently possible. That will take further investigation to sort out and allow. There are several bits of code that are commented out, but kept to make that later PR easier.