### PR TITLE
Fix Animation 3D Sound

### DIFF
--- a/code/model/modelanimation_segments.cpp
+++ b/code/model/modelanimation_segments.cpp
@@ -1233,7 +1233,7 @@ namespace animation {
 	}
 
 	sound_handle ModelAnimationSegmentSoundDuring::playSnd(polymodel_instance* pmi, const gamesnd_id& sound, bool loop) {
-		if (m_submodel != nullptr && pmi->objnum > 0) {
+		if (m_submodel != nullptr && pmi->objnum >= 0) {
 			auto submodel = m_submodel->findSubmodel(pmi);
 			if (submodel.first != nullptr) {
 				const object& obj = Objects[pmi->objnum];

--- a/code/model/modelanimation_segments.cpp
+++ b/code/model/modelanimation_segments.cpp
@@ -1190,7 +1190,7 @@ namespace animation {
 	}
 
 	void ModelAnimationSegmentSoundDuring::executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) {
-		polymodel_instance* pmi = model_get_instance(pmi->id);
+		polymodel_instance* pmi = model_get_instance(pmi_id);
 
 		if (timeboundLower <= 0.0f && 0.0f <= timeboundUpper) {
 			if (!m_flipIfReversed || direction == ModelAnimationDirection::FWD)

--- a/code/model/modelanimation_segments.h
+++ b/code/model/modelanimation_segments.h
@@ -228,8 +228,12 @@ namespace animation {
 		//PMI ID -> Instance Data
 		std::map<int, instance_data> m_instances;
 
+		std::shared_ptr<ModelAnimationSubmodel> m_submodel;
+		tl::optional<vec3d> m_position;
+
 		//configurables:
 	public:
+		float m_radius;
 		gamesnd_id m_start;
 		gamesnd_id m_end;
 		gamesnd_id m_during;
@@ -242,12 +246,13 @@ namespace animation {
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
 
-		void playStartSnd(int pmi_id);
-		void playEndSnd(int pmi_id);
+		sound_handle playSnd(polymodel_instance* pmi, const gamesnd_id& sound, bool loop);
+		void playStartSnd(polymodel_instance* pmi);
+		void playEndSnd(polymodel_instance* pmi);
 
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
-		ModelAnimationSegmentSoundDuring(std::shared_ptr<ModelAnimationSegment> segment, gamesnd_id start, gamesnd_id end, gamesnd_id during, bool flipIfReversed = false);
+		ModelAnimationSegmentSoundDuring(std::shared_ptr<ModelAnimationSegment> segment, gamesnd_id start, gamesnd_id end, gamesnd_id during, bool flipIfReversed = false, float radius = 0.0f, std::shared_ptr<ModelAnimationSubmodel> submodel = nullptr, tl::optional<vec3d> position = tl::nullopt);
 
 	};
 	


### PR DESCRIPTION
Previously, all animation sounds were played as 2D sounds.
Now, if they're properly attached to a parent submodel providing position (and they're on an actual object-model as opposed to stuff like skyboxes or cockpits without a position), the sound will play as a proper 3D sound