### PR TITLE
lighting followup

### DIFF
--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -472,8 +472,20 @@ void parse_startbl(const char *filename)
 				stuff_float(&sbm.b);
 				stuff_float(&sbm.i);
 
-				if (optional_string("$SunSpecularRGB:"))
-					mprintf(("Sun %s tried to set SunSpecularRGB. This feature has been deprecated and will be ignored.\n", sbm.filename));
+				if (optional_string("$SunSpecularRGB:")) {
+					SCP_string warning;
+					sprintf(warning, "Sun %s tried to set SunSpecularRGB. This feature has been deprecated and will be ignored.", sbm.filename);
+
+					float spec_r, spec_g, spec_b;
+					stuff_float(&spec_r);
+					stuff_float(&spec_g);
+					stuff_float(&spec_b);
+
+					if (fl_equal(sbm.r, spec_r) && fl_equal(sbm.g, spec_g) && fl_equal(sbm.b, spec_b))
+						mprintf(("%s\n", warning.c_str()));				// default case is not significant
+					else
+						Warning(LOCATION, "%s", warning.c_str());		// customized case is significant
+				}
 
 				// lens flare stuff
 				if (optional_string("$Flare:")) {


### PR DESCRIPTION
Two small fixes to follow up the lighting PRs

1) Change the mprintf to a Warning, both to be consistent with other deprecation warnings and to notify modders that they might need to accommodate the new lighting system
2) Parse any leftover data so that legacy tables don't cause FSO to choke on parsing