### PR TITLE
use queued rendering instead of immediate rendering for scripts

### DIFF
--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -35,6 +35,7 @@
 #include "object/objectshield.h"
 #include "object/objectsnd.h"
 #include "observer/observer.h"
+#include "scripting/api/libs/graphics.h"
 #include "scripting/scripting.h"
 #include "playerman/player.h"
 #include "radar/radar.h"
@@ -1679,11 +1680,18 @@ void obj_queue_render(object* obj, model_draw_list* scene)
 	if ( obj->flags[Object::Object_Flags::Should_be_dead] ) return;
 
 	if (Script_system.IsActiveAction(CHA_OBJECTRENDER)) {
+		// Set the render scene context
+		scripting::api::Current_scene = scene;
+
 		Script_system.SetHookObject("Self", obj);
 		bool skip_render = Script_system.IsConditionOverride(CHA_OBJECTRENDER, obj);
 		// Always execute the hook content
 		Script_system.RunCondition(CHA_OBJECTRENDER, obj);
 		Script_system.RemHookVar("Self");
+
+		// Clear the render scene context
+		scripting::api::Current_scene = nullptr;
+
 		if (skip_render) {
 			// Script said that it want's to skip rendering
 			return;

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -49,6 +49,7 @@ static bool WarnedBadThicknessLine = false;
 namespace scripting {
 namespace api {
 
+model_draw_list *Current_scene = nullptr;
 
 //**********LIBRARY: Graphics
 ADE_LIB(l_Graphics, "Graphics", "gr", "Graphics Library");
@@ -872,6 +873,10 @@ ADE_FUNC(drawModel, l_Graphics, "model model, vector position, orientation orien
 	if(model_num < 0)
 		return ade_set_args(L, "i", 3);
 
+	// Make sure we have a scene to use
+	if (!Current_scene)
+		return ade_set_args(L, "i", 4);
+
 	//Handle angles
 	matrix *orient = mh->GetMatrix();
 
@@ -909,7 +914,7 @@ ADE_FUNC(drawModel, l_Graphics, "model model, vector position, orientation orien
 
 	render_info.set_detail_level_lock(0);
 
-	model_render_immediate(&render_info, model_num, orient, v);
+	model_render_queue(&render_info, Current_scene, model_num, orient, v);
 
 	//OK we're done
 	gr_end_view_matrix();
@@ -948,6 +953,10 @@ ADE_FUNC(drawModelOOR, l_Graphics, "model Model, vector Position, orientation Or
 	if(model_num < 0)
 		return ade_set_args(L, "i", 3);
 
+	// Make sure we have a scene to use
+	if (!Current_scene)
+		return ade_set_args(L, "i", 4);
+
 	//Handle angles
 	matrix *orient = mh->GetMatrix();
 
@@ -957,7 +966,7 @@ ADE_FUNC(drawModelOOR, l_Graphics, "model Model, vector Position, orientation Or
 	model_render_params render_info;
 	render_info.set_flags(flags);
 
-	model_render_immediate(&render_info, model_num, orient, v);
+	model_render_queue(&render_info, Current_scene, model_num, orient, v);
 
 	return ade_set_args(L, "i", 0);
 }

--- a/code/scripting/api/libs/graphics.h
+++ b/code/scripting/api/libs/graphics.h
@@ -5,6 +5,8 @@
 namespace scripting {
 namespace api {
 
+extern model_draw_list *Current_scene;
+
 DECLARE_ADE_LIB(l_Graphics);
 
 }


### PR DESCRIPTION
Scripts that render models in the On Object Render hook were effectively doing immediate renders in the middle of queued renders.  This caused some data, such as model orientation, to 'leak' between renders.  It might also have something to do with why the bug in #4637 had the particular graphical side effects that it did.

Anyway, changing the immediate renders to queued renders fixes the leaky orientations, and is probably a good upgrade for other reasons as well.