### PR TITLE
Flag for seamless animations with startup period

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -12,12 +12,15 @@ extern float flFrametime;
 
 namespace animation {
 
-	flag_def_list_new<animation::Animation_Flags> Animation_flags[] = {
-		{ "auto reverse",				animation::Animation_Flags::Auto_Reverse,						true, false },
-		{ "reset at completion",		animation::Animation_Flags::Reset_at_completion,		        true, false },
-		{ "loop",						animation::Animation_Flags::Loop,						        true, false },
-		{ "random starting phase",		animation::Animation_Flags::Random_starting_phase,				true, false },
-		{ "pause on reverse",			animation::Animation_Flags::Pause_on_reverse,					true, false },
+	special_flag_def_list_new<animation::Animation_Flags, ModelAnimation&> Animation_flags[] = {
+		{ "auto reverse",				animation::Animation_Flags::Auto_Reverse,						true },
+		{ "reset at completion",		animation::Animation_Flags::Reset_at_completion,		        true },
+		{ "loop",						animation::Animation_Flags::Loop,						        true },
+		{ "random starting phase",		animation::Animation_Flags::Random_starting_phase,				true },
+		{ "pause on reverse",			animation::Animation_Flags::Pause_on_reverse,					true },
+		{ "seamless with startup",		animation::Animation_Flags::Seamless_with_startup,				true, [](const SCP_string& from, ModelAnimation& anim) {
+			anim.m_flagData.loopsFrom = std::atof(from.c_str());
+		}}
 	};
 
 	const size_t Num_animation_flags = sizeof(Animation_flags) / sizeof(flag_def_list_new<animation::Animation_Flags>);
@@ -1194,7 +1197,10 @@ namespace animation {
 
 		if (optional_string("$Flags:")) {
 			SCP_vector<SCP_string> unparsed;
-			parse_string_flag_list(animation->m_flags, Animation_flags, Num_animation_flags, &unparsed);
+			parse_string_flag_list_special(animation->m_flags, Animation_flags, &unparsed, *animation);
+			for (const auto& flag : unparsed) {
+				error_display(0, "Unknown flag %s in flag list!", flag.c_str());
+			}
 		}
 
 		if (Animation_types.find(type)->second.second) {

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -28,8 +28,6 @@ namespace animation {
 		}}
 	};
 
-	const size_t Num_animation_flags = sizeof(Animation_flags) / sizeof(flag_def_list_new<animation::Animation_Flags>);
-
 	std::map<int, ModelAnimationSet::RunningAnimationList> ModelAnimationSet::s_runningAnimations;
 	std::map<unsigned int, std::shared_ptr<ModelAnimation>> ModelAnimationSet::s_animationById;
 

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -21,6 +21,9 @@ namespace animation {
 		{ "seamless with startup",		animation::Animation_Flags::Seamless_with_startup,				true, [](const SCP_string& from, ModelAnimation& anim) {
 			anim.m_flagData.loopsFrom = static_cast<float>(std::atof(from.c_str()));
 			anim.m_flags.set(animation::Animation_Flags::Loop);
+
+			//While this flag implies Reset_at_completion semantically, it's implemented in a conflicting manner. Hence, make sure that seamless will take priority, and force-disable reset at completion if set
+			anim.m_flags.set(animation::Animation_Flags::Reset_at_completion, false);
 		}}
 	};
 

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -21,6 +21,7 @@ namespace animation {
 		{ "seamless with startup",		animation::Animation_Flags::Seamless_with_startup,				true, [](const SCP_string& from, ModelAnimation& anim) {
 			anim.m_flagData.loopsFrom = static_cast<float>(std::atof(from.c_str()));
 			anim.m_flags.set(animation::Animation_Flags::Loop);
+			anim.m_flags.set(animation::Animation_Flags::Seamless_with_startup);
 
 			//While this flag implies Reset_at_completion semantically, it's implemented in a conflicting manner. Hence, make sure that seamless will take priority, and force-disable reset at completion if set
 			anim.m_flags.set(animation::Animation_Flags::Reset_at_completion, false);

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -60,6 +60,7 @@ namespace animation {
 		Loop,					//Will automatically loop the animation once it completes. Is compatible with Reset_at_completion to loop back from the start instead of reversing. Incompatible with Auto_reverse
 		Random_starting_phase,  //When an animation is started from an untriggered state, will randomize its time to any possible time of the animation + possibly on the reverse, if the animation would automatically enter that
 		Pause_on_reverse,		//Will cause any start in RWD direction to behave as a call to pause the animation. Required (and also only really useful) when a looping animation is supposed to be triggered by an internal engine trigger
+		Seamless_with_startup,	//Provides autoamtic handling of animations that loop with an initialization part (effectively looping from a specific time)
 		NUM_VALUES
 	};
 
@@ -222,6 +223,13 @@ namespace animation {
 
 		flagset<animation::Animation_Flags>	m_flags;
 
+	public:
+		struct {
+			//Seamless_with_startup
+			float loopsFrom = 0.0f;
+		} m_flagData;
+
+	private:
 		ModelAnimationState play(float frametime, polymodel_instance* pmi, ModelAnimationSubmodelBuffer& applyBuffer, bool applyOnly = false);
 
 		friend class ModelAnimationSet;

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -66,6 +66,7 @@ namespace animation {
 
 	FLAG_LIST(Animation_Instance_Flags) {
 		Stop_after_next_loop,	//Once a looping animation would start the next loop, stop the animation instead. Only valid for looping animations
+		Seamless_loop_shutdown, //Set whenever a seamlessly looping animation is in its final shutdown phase
 		NUM_VALUES
 	};
 
@@ -221,9 +222,8 @@ namespace animation {
 		//True if the animation can externally have its state changed. Needs special handling
 		bool m_canChangeState;
 
-		flagset<animation::Animation_Flags>	m_flags;
-
 	public:
+		flagset<animation::Animation_Flags>	m_flags;
 		struct {
 			//Seamless_with_startup
 			float loopsFrom = 0.0f;

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -60,7 +60,7 @@ namespace animation {
 		Loop,					//Will automatically loop the animation once it completes. Is compatible with Reset_at_completion to loop back from the start instead of reversing. Incompatible with Auto_reverse
 		Random_starting_phase,  //When an animation is started from an untriggered state, will randomize its time to any possible time of the animation + possibly on the reverse, if the animation would automatically enter that
 		Pause_on_reverse,		//Will cause any start in RWD direction to behave as a call to pause the animation. Required (and also only really useful) when a looping animation is supposed to be triggered by an internal engine trigger
-		Seamless_with_startup,	//Provides autoamtic handling of animations that loop with an initialization part (effectively looping from a specific time)
+		Seamless_with_startup,	//Provides automatic handling of animations that loop with an initialization part (effectively looping from a specific time)
 		NUM_VALUES
 	};
 


### PR DESCRIPTION
This is a rather specific flag for a certain but common type of animation, namely seamlessly looping animations which have an initial startup from a different rest state to their seamless loop.
This flag acts as a loop + reset on startup flag combination which, instead of skipping back to the end, skips back to the part where the seamless loop begins, both in forwards and backwards direction. Once the loop is stopped, the animation will run until the next loop would begin, and then play the startup sequence in reverse.