### PR TITLE
add -dualscanlines as a HUD config option

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -378,7 +378,7 @@ int Cmdline_no_vsync = 0;
 
 // HUD related
 cmdline_parm ballistic_gauge("-ballistic_gauge", NULL, AT_NONE);	// Cmdline_ballistic_gauge
-cmdline_parm dualscanlines_arg("-dualscanlines", NULL, AT_NONE); // Cmdline_dualscanlines  -- Change to phreaks options including new targeting code
+cmdline_parm dualscanlines_arg("-dualscanlines", NULL, AT_NONE); // Cmdline_dualscanlines  -- Change to phreaks options including new targeting code; semi-deprecated but still functional
 cmdline_parm orb_radar("-orbradar", NULL, AT_NONE);			// Cmdline_orb_radar
 cmdline_parm rearm_timer_arg("-rearm_timer", NULL, AT_NONE);	// Cmdline_rearm_timer
 cmdline_parm targetinfo_arg("-targetinfo", NULL, AT_NONE);	// Cmdline_targetinfo  -- Adds ship name/class to right of target box -C

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -3218,12 +3218,12 @@ void load_gauge_target_monitor(gauge_settings* settings)
 	}
 	if (optional_string("Cargo Scan Type:")) {
 		int type = required_string_one_of(3, "default", "dualscanlines", "discoscanlines");
-		if (type == 0) {
-			Cargo_scan_type = CargoScanType::DEFAULT;
-		} else if (type == 1) {
+		if (type == 1) {
 			Cargo_scan_type = CargoScanType::DUAL_SCAN_LINES;
-		} else {
+		} else if (type == 2) {
 			Cargo_scan_type = CargoScanType::DISCO_SCAN_LINES;
+		} else {
+			Cargo_scan_type = CargoScanType::DEFAULT;
 		}
 	}
 	if(optional_string("Cargo Scan Start Offsets:")) {

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -3217,11 +3217,13 @@ void load_gauge_target_monitor(gauge_settings* settings)
 		stuff_int_list(Cargo_string_offsets, 2);
 	}
 	if (optional_string("Cargo Scan Type:")) {
-		int type = required_string_one_of(2, "default", "dualscanlines");
+		int type = required_string_one_of(3, "default", "dualscanlines", "discoscanlines");
 		if (type == 0) {
 			Cargo_scan_type = CargoScanType::DEFAULT;
-		} else {
+		} else if (type == 1) {
 			Cargo_scan_type = CargoScanType::DUAL_SCAN_LINES;
+		} else {
+			Cargo_scan_type = CargoScanType::DISCO_SCAN_LINES;
 		}
 	}
 	if(optional_string("Cargo Scan Start Offsets:")) {

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -3109,6 +3109,7 @@ void load_gauge_target_monitor(gauge_settings* settings)
 	int Speed_offsets[2];
 	int Cargo_string_offsets[2];
 	int Hull_offsets[2];
+	CargoScanType Cargo_scan_type;
 	int Cargo_scan_start_offsets[2];
 	int Cargo_scan_size[2];
 
@@ -3165,6 +3166,7 @@ void load_gauge_target_monitor(gauge_settings* settings)
 	Hull_offsets[0] = 134;
 	Hull_offsets[1] = 42;
 
+	Cargo_scan_type = Cmdline_dualscanlines ? CargoScanType::DUAL_SCAN_LINES : CargoScanType::DEFAULT;
 	Cargo_scan_start_offsets[0] = 2;
 	Cargo_scan_start_offsets[1] = 45;
 	Cargo_scan_size[0] = 130;
@@ -3214,6 +3216,14 @@ void load_gauge_target_monitor(gauge_settings* settings)
 	if(optional_string("Cargo Contents Offsets:")) {
 		stuff_int_list(Cargo_string_offsets, 2);
 	}
+	if (optional_string("Cargo Scan Type:")) {
+		int type = required_string_one_of(2, "default", "dualscanlines");
+		if (type == 0) {
+			Cargo_scan_type = CargoScanType::DEFAULT;
+		} else {
+			Cargo_scan_type = CargoScanType::DUAL_SCAN_LINES;
+		}
+	}
 	if(optional_string("Cargo Scan Start Offsets:")) {
 		stuff_int_list(Cargo_scan_start_offsets, 2);
 	}
@@ -3247,6 +3257,7 @@ void load_gauge_target_monitor(gauge_settings* settings)
 	hud_gauge->initSpeedOffsets(Speed_offsets[0], Speed_offsets[1]);
 	hud_gauge->initCargoStringOffsets(Cargo_string_offsets[0], Cargo_string_offsets[1]);
 	hud_gauge->initHullOffsets(Hull_offsets[0], Hull_offsets[1]);
+	hud_gauge->initCargoScanType(Cargo_scan_type);
 	hud_gauge->initCargoScanStartOffsets(Cargo_scan_start_offsets[0], Cargo_scan_start_offsets[1]);
 	hud_gauge->initCargoScanSize(Cargo_scan_size[0], Cargo_scan_size[1]);
 	hud_gauge->initSubsysNameOffsets(Subsys_name_offsets[0], Subsys_name_offsets[1], Use_subsys_name_offsets);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1906,32 +1906,84 @@ void HudGaugeTargetBox::maybeRenderCargoScan(ship_info *target_sip, ship_subsys 
 
 	setGaugeColor(HUD_C_BRIGHT);
 
-	// draw horizontal scan line
-	x1 = position[0] + Cargo_scan_start_offsets[0]; // Cargo_scan_coords[gr_screen.res][0];
-	y1 = fl2i(0.5f + position[1] + Cargo_scan_start_offsets[1] + ( (i2fl(Player->cargo_inspect_time) / scan_time) * Cargo_scan_h ));
-	x2 = x1 + Cargo_scan_w;
+	int left = position[0] + Cargo_scan_start_offsets[0];
+	int right = left + Cargo_scan_w;
+	int top = position[1] + Cargo_scan_start_offsets[1];
+	int bot = top + Cargo_scan_h;
 
-	renderLine(x1, y1, x2, y1);
+	float t = i2fl(Player->cargo_inspect_time) / scan_time;
 
-	// RT Changed this to be optional
-	if(Cargo_scan_type == CargoScanType::DUAL_SCAN_LINES) {
-		// added 2nd horizontal scan line - phreak
-		y1 = fl2i(position[1] + Cargo_scan_start_offsets[1] + Cargo_scan_h - ( (i2fl(Player->cargo_inspect_time) / scan_time) * Cargo_scan_h ));
+	if (Cargo_scan_type == CargoScanType::DEFAULT || Cargo_scan_type == CargoScanType::DUAL_SCAN_LINES) {
+		// draw horizontal scan line
+		x1 = left;
+		y1 = fl2i(0.5f + top + (t * Cargo_scan_h));
+		x2 = x1 + Cargo_scan_w;
+
 		renderLine(x1, y1, x2, y1);
-	}
 
-	// draw vertical scan line
-	x1 = fl2i(0.5f + position[0] + Cargo_scan_start_offsets[0] + ( (i2fl(Player->cargo_inspect_time) / scan_time) * Cargo_scan_w ));
-	y1 = position[1] + Cargo_scan_start_offsets[1];
-	y2 = y1 + Cargo_scan_h;
+		// RT Changed this to be optional
+		if (Cargo_scan_type == CargoScanType::DUAL_SCAN_LINES) {
+			// added 2nd horizontal scan line - phreak
+			y1 = fl2i(bot - (t * Cargo_scan_h));
+			renderLine(x1, y1, x2, y1);
+		}
 
-	renderLine(x1, y1-3, x1, y2-1);
+		// draw vertical scan line
+		x1 = fl2i(0.5f + left + (t * Cargo_scan_w));
+		y1 = top;
+		y2 = bot;
 
-	// RT Changed this to be optional
-	if(Cargo_scan_type == CargoScanType::DUAL_SCAN_LINES) {
-		// added 2nd vertical scan line - phreak
-		x1 = fl2i(0.5f + Cargo_scan_w + position[0] + Cargo_scan_start_offsets[0] - ( (i2fl(Player->cargo_inspect_time) / scan_time) * Cargo_scan_w ));
-		renderLine(x1, y1-3, x1, y2-1);
+		renderLine(x1, y1 - 3, x1, y2 - 1);
+
+		// RT Changed this to be optional
+		if (Cargo_scan_type == CargoScanType::DUAL_SCAN_LINES) {
+			// added 2nd vertical scan line - phreak
+			x1 = fl2i(0.5f + right - (t * Cargo_scan_w));
+			renderLine(x1, y1 - 3, x1, y2 - 1);
+		}
+	} else if (Cargo_scan_type == CargoScanType::DISCO_SCAN_LINES) {	
+		// by popular demand, this, which was made as a joke, was added - Asteroth
+		for (int i = 0; i < 4; i++) {
+			float arr[2] = { 1 / 0.75f, 1 / 0.4f };
+			float tmod;
+			if (i < 2) {
+				tmod = powf(t, arr[i]);
+			} else {
+				tmod = 1 - powf(1 - t, arr[i - 2]);
+			}
+
+			if (tmod < 0.5f) {
+				y2 = fl2i(0.5f + bot - 2.f * tmod * Cargo_scan_h);
+				renderLine(left, bot, right, y2);
+			} else {
+				x2 = fl2i(0.5f + right - (2.f * tmod - 1) * Cargo_scan_w);
+				renderLine(left, bot, x2, top);
+			}
+
+			if (tmod < 0.5f) {
+				x2 = fl2i(0.5f + right - 2.f * tmod * Cargo_scan_w);
+				renderLine(right, bot, x2, top);
+			} else {
+				y2 = fl2i(0.5f + top + (2.f * tmod - 1) * Cargo_scan_h);
+				renderLine(right, bot, left, y2);
+			}
+
+			if (tmod < 0.5f) {
+				y2 = fl2i(0.5f + top + 2.f * tmod * Cargo_scan_h);
+				renderLine(right, top, left, y2);
+			} else {
+				x2 = fl2i(0.5f + left + (2.f * tmod - 1) * Cargo_scan_w);
+				renderLine(right, top, x2, bot);
+			}
+
+			if (tmod < 0.5f) {
+				x2 = fl2i(0.5f + left + 2.f * tmod * Cargo_scan_w);
+				renderLine(left, top, x2, bot);
+			} else {
+				y2 = fl2i(0.5f + bot - (2.f * tmod - 1) * Cargo_scan_h);
+				renderLine(left, top, right, y2);
+			}
+		}
 	}
 }
 

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -277,6 +277,11 @@ void HudGaugeTargetBox::initHullOffsets(int x, int y)
 	Hull_offsets[1] = y;
 }
 
+void HudGaugeTargetBox::initCargoScanType(CargoScanType scantype)
+{
+	Cargo_scan_type = scantype;
+}
+
 void HudGaugeTargetBox::initCargoScanStartOffsets(int x, int y)
 {
 	Cargo_scan_start_offsets[0] = x;
@@ -1909,7 +1914,7 @@ void HudGaugeTargetBox::maybeRenderCargoScan(ship_info *target_sip, ship_subsys 
 	renderLine(x1, y1, x2, y1);
 
 	// RT Changed this to be optional
-	if(Cmdline_dualscanlines) {
+	if(Cargo_scan_type == CargoScanType::DUAL_SCAN_LINES) {
 		// added 2nd horizontal scan line - phreak
 		y1 = fl2i(position[1] + Cargo_scan_start_offsets[1] + Cargo_scan_h - ( (i2fl(Player->cargo_inspect_time) / scan_time) * Cargo_scan_h ));
 		renderLine(x1, y1, x2, y1);
@@ -1923,7 +1928,7 @@ void HudGaugeTargetBox::maybeRenderCargoScan(ship_info *target_sip, ship_subsys 
 	renderLine(x1, y1-3, x1, y2-1);
 
 	// RT Changed this to be optional
-	if(Cmdline_dualscanlines) {
+	if(Cargo_scan_type == CargoScanType::DUAL_SCAN_LINES) {
 		// added 2nd vertical scan line - phreak
 		x1 = fl2i(0.5f + Cargo_scan_w + position[0] + Cargo_scan_start_offsets[0] - ( (i2fl(Player->cargo_inspect_time) / scan_time) * Cargo_scan_w ));
 		renderLine(x1, y1-3, x1, y2-1);

--- a/code/hud/hudtargetbox.h
+++ b/code/hud/hudtargetbox.h
@@ -40,6 +40,8 @@ extern int Targetbox_wire;
 extern int Targetbox_shader_effect;
 extern bool Lock_targetbox_mode;
 
+enum class CargoScanType { DEFAULT, DUAL_SCAN_LINES };
+
 class HudGaugeTargetBox: public HudGauge // HUD_TARGET_MONITOR
 {
 	hud_frames Monitor_frame;
@@ -66,6 +68,7 @@ class HudGaugeTargetBox: public HudGauge // HUD_TARGET_MONITOR
 	// remember, these coords describe the rightmost position of this element, not the leftmost like it usually does.
 	int Hull_offsets[2];
 
+	CargoScanType Cargo_scan_type;
 	int Cargo_scan_start_offsets[2];
 	int Cargo_scan_h;
 	int Cargo_scan_w;
@@ -100,6 +103,7 @@ public:
 	void initSpeedOffsets(int x, int y);
 	void initCargoStringOffsets(int x, int y);
 	void initHullOffsets(int x, int y);
+	void initCargoScanType(CargoScanType scantype);
 	void initCargoScanStartOffsets(int x, int y);
 	void initCargoScanSize(int w, int h);
 	void initSubsysNameOffsets(int x, int y, bool activate);

--- a/code/hud/hudtargetbox.h
+++ b/code/hud/hudtargetbox.h
@@ -40,7 +40,7 @@ extern int Targetbox_wire;
 extern int Targetbox_shader_effect;
 extern bool Lock_targetbox_mode;
 
-enum class CargoScanType { DEFAULT, DUAL_SCAN_LINES };
+enum class CargoScanType { DEFAULT, DUAL_SCAN_LINES, DISCO_SCAN_LINES };
 
 class HudGaugeTargetBox: public HudGauge // HUD_TARGET_MONITOR
 {


### PR DESCRIPTION
Allow different types of cargo scans, including the -dualscanline behavior, to be specified in the HUD gauges table.  Right now the options are "default" and "dualscanlines".