### PR TITLE
Allow API to optionally not start the next mission.

### DIFF
--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -885,7 +885,7 @@ ADE_FUNC(canSkip,
 
 ADE_FUNC(replayMission,
 	l_UserInterface_Debrief,
-	"[boolean restart = false]",
+	"[boolean restart = true]",
 	"Resets the mission outcome, and optionally restarts the mission at the briefing; "
 	"true to restart the mission, false to stay at current UI. Defaults to true.",
 	nullptr,
@@ -912,7 +912,7 @@ ADE_FUNC(replayMission,
 
 ADE_FUNC(acceptMission,
 	l_UserInterface_Debrief,
-	"[boolean start = false]",
+	"[boolean start = true]",
 	"Accepts the mission outcome, saves the stats, and optionally begins the next mission if in campaign; "
 	"true to start the next mission, false to stay at current UI. Defaults to true.",
 	nullptr,

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -885,40 +885,57 @@ ADE_FUNC(canSkip,
 
 ADE_FUNC(replayMission,
 	l_UserInterface_Debrief,
+	"[boolean restart = false]",
+	"Resets the mission outcome, and optionally restarts the mission at the briefing; "
+	"true to restart the mission, false to stay at current UI. Defaults to true.",
 	nullptr,
-	"Resets the mission outcome and begins the current mission again",
-	"number",
-	"Returns true when completed")
+	nullptr)
 {
+
+	bool restart = true;
+
+	ade_get_args(L, "|b", &restart);
+
 	// This is used to skip some UI preloading in debrief init
 	API_Access = true;
 
 	debrief_close();
 
-	gameseq_post_event(GS_EVENT_START_GAME);
+	if (restart) {
+		gameseq_post_event(GS_EVENT_START_GAME);
+	}
 
 	API_Access = false;
 
-	return ade_set_args(L, "b", true);
+	return ADE_RETURN_NIL;
 }
 
 ADE_FUNC(acceptMission,
 	l_UserInterface_Debrief,
+	"[boolean start = false]",
+	"Accepts the mission outcome, saves the stats, and optionally begins the next mission if in campaign; "
+	"true to start the next mission, false to stay at current UI. Defaults to true.",
 	nullptr,
-	"Accepts the mission outcome, saves the stats, and begins the next mission if in campaign",
-	"number",
-	"Returns true when completed")
+	nullptr)
 {
+	bool start = true;
+
+	ade_get_args(L, "|b", &start);
+
 	// This is used to skip some UI preloading in debrief init
 	API_Access = true;
 
-	debrief_accept();
+	if (start) {
+		debrief_accept(1);
+	} else {
+		debrief_accept(0);
+	};
 
 	debrief_close();
 
 	API_Access = false;
 
-	return ade_set_args(L, "b", true);
+	return ADE_RETURN_NIL;
 }
 
 //**********SUBLIBRARY: UserInterface/LoopBrief


### PR DESCRIPTION
Changes these two methods to allow the API to specify whether to go straight to the next (or current) mission briefing. This allows implementation of the debriefing ESC popup menu as well as skipping to the next mission. The latter requires closing out the debriefing with one of these two options so that we avoid an assert upon entering the next debriefing.

Also removes the return value because it was meaningless.