### PR TITLE
-luadev flag and lua log filter

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -512,6 +512,7 @@ cmdline_parm graphics_debug_output_arg("-gr_debug", nullptr, AT_NONE); // Cmdlin
 cmdline_parm log_to_stdout_arg("-stdout_log", nullptr, AT_NONE); // Cmdline_log_to_stdout
 cmdline_parm slow_frames_ok_arg("-slow_frames_ok", nullptr, AT_NONE);	// Cmdline_slow_frames_ok
 cmdline_parm fixed_seed_rand("-seed", nullptr, AT_INT);	// Cmdline_rng_seed,Cmdline_reuse_rng_seed;
+cmdline_parm luadev_arg("-luadev", "nullptr", AT_NONE);	// Cmdline_slow_frames_ok
 
 
 char *Cmdline_start_mission = NULL;
@@ -545,6 +546,7 @@ bool Cmdline_debug_window = false;
 bool Cmdline_graphics_debug_output = false;
 bool Cmdline_log_to_stdout = false;
 bool Cmdline_slow_frames_ok = false;
+bool Cmdline_lua_devmode = false;
 
 // Other
 cmdline_parm get_flags_arg(GET_FLAGS_STRING, "Output the launcher flags file", AT_STRING);
@@ -2166,6 +2168,9 @@ bool SetCmdlineParams()
 
 	if (slow_frames_ok_arg.found()) {
 		Cmdline_slow_frames_ok = true;
+	}
+	if ( luadev_arg.found()) {
+		Cmdline_lua_devmode = true;
 	}
 
 	if (show_video_info.found())

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -512,7 +512,7 @@ cmdline_parm graphics_debug_output_arg("-gr_debug", nullptr, AT_NONE); // Cmdlin
 cmdline_parm log_to_stdout_arg("-stdout_log", nullptr, AT_NONE); // Cmdline_log_to_stdout
 cmdline_parm slow_frames_ok_arg("-slow_frames_ok", nullptr, AT_NONE);	// Cmdline_slow_frames_ok
 cmdline_parm fixed_seed_rand("-seed", nullptr, AT_INT);	// Cmdline_rng_seed,Cmdline_reuse_rng_seed;
-cmdline_parm luadev_arg("-luadev", "nullptr", AT_NONE);	// Cmdline_slow_frames_ok
+cmdline_parm luadev_arg("-luadev", "nullptr", AT_NONE);	// Cmdline_lua_devmode
 
 
 char *Cmdline_start_mission = NULL;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -154,6 +154,7 @@ extern bool Cmdline_debug_window;
 extern bool Cmdline_graphics_debug_output;
 extern bool Cmdline_log_to_stdout;
 extern bool Cmdline_slow_frames_ok;
+extern bool Cmdline_lua_devmode;
 
 enum class WeaponSpewType { NONE = 0, STANDARD, ALL };
 extern WeaponSpewType Cmdline_spew_weapon_stats;

--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -203,13 +203,18 @@ namespace os
 			msgStream << "\n";
 			msgStream << Separator;
 
-			mprintf(("Lua Error: %s\n", msgStream.str().c_str()));
+			nprintf(("lua","Lua Error: %s\n", msgStream.str().c_str()));
 
 			if (running_unittests) {
 				throw LuaErrorException(msgStream.str());
 			}
 
+			if (Cmdline_lua_devmode) {
+				return;
+			}
+
 			if (Cmdline_noninteractive) {
+				throw LuaErrorException(msgStream.str());
 				abort();
 				return;
 			}

--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -215,7 +215,6 @@ namespace os
 
 			if (Cmdline_noninteractive) {
 				throw LuaErrorException(msgStream.str());
-				abort();
 				return;
 			}
 

--- a/code/osapi/outwnd.cpp
+++ b/code/osapi/outwnd.cpp
@@ -205,8 +205,8 @@ void outwnd_print(const char *id, const char *tmp)
 		Outwnd_no_filter_file = 2;
 
 		outwnd_print("general", "==========================================================================\n");
-		outwnd_print("general", "DEBUG SPEW: No debug_filter.cfg found, so only general, error, and warning\n");
-		outwnd_print("general", "categories can be shown and no debug_filter.cfg info will be saved.\n");
+		outwnd_print("general", "DEBUG SPEW: No debug_filter.cfg found, so only general, error, warning and\n");
+		outwnd_print("general", "lua categories can be shown and no debug_filter.cfg info will be saved.\n");
 		outwnd_print("general", "==========================================================================\n");
 	}
 
@@ -222,7 +222,7 @@ void outwnd_print(const char *id, const char *tmp)
 		outwnd_filter_struct new_filter;
 
 		strcpy_s(new_filter.name, id);
-		new_filter.enabled = stricmp(new_filter.name, "general") == 0 || stricmp(new_filter.name, "error") == 0 || stricmp(new_filter.name, "warning") == 0;
+		new_filter.enabled = stricmp(new_filter.name, "general") == 0 || stricmp(new_filter.name, "error") == 0 || stricmp(new_filter.name, "warning") == 0 || stricmp(new_filter.name, "lua") == 0;
 
 		filter_vector().push_back( new_filter );
 		save_filter_info();

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -42,14 +42,24 @@ ADE_FUNC(print, l_Base, "string Message", "Prints a string", NULL, NULL)
 
 ADE_FUNC(warning, l_Base, "string Message", "Displays a FreeSpace warning (debug build-only) message with the string provided", NULL, NULL)
 {
-	Warning(LOCATION, "%s", lua_tostring(L, -1));
+	if (Cmdline_lua_devmode) {
+		nprintf(("lua","WARNING: %s", lua_tostring(L, -1)));
+	}
+	else {
+		Warning(LOCATION, "%s", lua_tostring(L, -1));
+	}
 
 	return ADE_RETURN_NIL;
 }
 
 ADE_FUNC(error, l_Base, "string Message", "Displays a FreeSpace error message with the string provided", NULL, NULL)
 {
-	Error(LOCATION, "%s", lua_tostring(L, -1));
+	if (Cmdline_lua_devmode) {
+		nprintf(("lua","ERROR: %s", lua_tostring(L, -1)));
+	}
+	else {
+		Error(LOCATION, "%s", lua_tostring(L, -1));
+	}
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -24,6 +24,7 @@
 #include "scripting/util/LuaValueDeserializer.h"
 #include "scripting/util/LuaValueSerializer.h"
 #include "utils/Random.h"
+#include "cmdline/cmdline.h"
 
 namespace scripting {
 namespace api {
@@ -34,7 +35,7 @@ ADE_LIB(l_Base, "Base", "ba", "Base FreeSpace 2 functions");
 
 ADE_FUNC(print, l_Base, "string Message", "Prints a string", NULL, NULL)
 {
-	mprintf(("%s", lua_tostring(L, -1)));
+	nprintf(("lua","%s", lua_tostring(L, -1)));
 
 	return ADE_RETURN_NIL;
 }


### PR DESCRIPTION
Adds new default 'lua' filter category for all lua errors and output and -luadev flag that currently only makes lua errors non-fatal.