### PR TITLE
Allow modifying map container data when the map is an argument

### DIFF
--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -1257,11 +1257,6 @@ void sexp_add_to_map(int node)
 		return;
 	}
 
-	if (container.is_being_used_in_special_arg()) {
-		report_container_used_in_special_arg("Add-to-map", container_name);
-		return;
-	}
-
 	node = CDR(node);
 	Assertion(node != -1, "Add-to-map wasn't given values to add. Please report!");
 
@@ -1276,6 +1271,15 @@ void sexp_add_to_map(int node)
 		}
 
 		const SCP_string key = CTEXT(node);
+
+		if (container.is_being_used_in_special_arg()) {
+			// modifying existing keys' data is ok, but adding new keys is not
+			if (container.map_data.find(key) == container.map_data.end()) {
+				report_container_used_in_special_arg("Add-to-map", container_name);
+				continue;
+			}
+		}
+
 		const SCP_string data = CTEXT(CDR(node));
 		add_to_map_internal(container, key, data);
 

--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -1276,6 +1276,7 @@ void sexp_add_to_map(int node)
 			// modifying existing keys' data is ok, but adding new keys is not
 			if (container.map_data.find(key) == container.map_data.end()) {
 				report_container_used_in_special_arg("Add-to-map", container_name);
+				node = CDDR(node); // skip to next key-data pair
 				continue;
 			}
 		}


### PR DESCRIPTION
Allow a map container's data for existing keys to be modified when the map container is used in the special argument list.

Adding or removing keys is still prohibited in this situation due to concurrent modification.