### PR TITLE
Update max priority for scripting AIgoals

### DIFF
--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1278,8 +1278,8 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 	if(priority < 0.0f)
 		return ade_set_error(L, "b", false);
 
-	if(priority > 1.0f)
-		priority = 1.0f;
+	if(priority > 2.0f)
+		priority = 2.0f;
 
 	bool tgh_valid = tgh && tgh->IsValid();
 	bool tgsh_valid = tgsh && tgsh->isSubsystemValid();


### PR DESCRIPTION
Previously the scripting function `giveOrder` capped goals at priority 100, but the max is 200. This PR fixes that.