### PR TITLE
Adds a cache for modular POFs

### DIFF
--- a/code/globalincs/safe_strings.h
+++ b/code/globalincs/safe_strings.h
@@ -22,6 +22,7 @@
 /* errno_t, EINVAL, ERANGE, etc.. */
 #include <cerrno>
 #include <cstdlib> /* size_t */
+#include "globalincs/pstypes.h"
 
 /* Because errno_t is not (yet) standard, we define it here like this */
 typedef int errno_t;
@@ -57,6 +58,13 @@ errno_t scp_strcpy_s( const char* file, int line, char (&strDest)[ size ], const
 	return scp_strcpy_s( file, line, strDest, size, strSource );
 }
 
+template< size_t size>
+inline
+errno_t scp_strncpy_s(const char* file, int line, char(&strDest)[size], const char* strSource, size_t count)
+{
+	return scp_strcpy_s(file, line, strDest, MIN(size, count), strSource);
+}
+
 template< size_t size >
 inline
 errno_t scp_strcat_s( const char* file, int line, char (&strDest)[ size ], const char* strSource )
@@ -65,6 +73,7 @@ errno_t scp_strcat_s( const char* file, int line, char (&strDest)[ size ], const
 }
 
 #define strcpy_s( ... ) scp_strcpy_s( __FILE__, __LINE__, __VA_ARGS__ )
+#define strncpy_s( ... ) scp_strncpy_s( __FILE__, __LINE__, __VA_ARGS__ )
 #define strcat_s( ... ) scp_strcat_s( __FILE__, __LINE__, __VA_ARGS__ )
 
 #elif defined(_MSC_VER) && _MSC_VER < 1400 || defined(NO_SAFE_STRINGS)

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -894,12 +894,16 @@ struct model_read_deferred_tasks {
 
 	//Key: Subsystem Name
 	SCP_unordered_map<SCP_string, model_subsystem_parse, SCP_string_lcase_hash, SCP_string_lcase_equal_to> model_subsystems;
+	using model_subsystem_pair = decltype(model_subsystems)::value_type;
 	//Key: Subsystem Name
 	SCP_unordered_map<SCP_string, engine_subsystem_parse, SCP_string_lcase_hash, SCP_string_lcase_equal_to> engine_subsystems;
+	using engine_subsystem_pair = decltype(engine_subsystems)::value_type;
 	//Key: Parent Subobject Nr
 	SCP_unordered_map<int, weapon_subsystem_parse> weapons_subsystems;
+	using weapon_subsystem_pair = decltype(weapons_subsystems)::value_type;
 	//Key: Subobject Nr
 	SCP_unordered_map<int, texture_idx_replace> texture_replacements;
+	using texture_replacement_pair = decltype(texture_replacements)::value_type;
 };
 
 using model_parse_depth = SCP_unordered_map<SCP_string, int, SCP_string_lcase_hash, SCP_string_lcase_equal_to>;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -71,6 +71,8 @@ extern int model_render_flags_size;
 #define SUBSYSTEM_UNKNOWN			11
 #define SUBSYSTEM_MAX				12				//	maximum value for subsystem_xxx, for error checking
 
+enum class modelread_status { FAIL, SUCCESS_REAL, SUCCESS_VIRTUAL };
+
 // Goober5000
 extern const char *Subsystem_types[SUBSYSTEM_MAX];
 
@@ -914,8 +916,8 @@ using model_parse_depth = SCP_unordered_map<SCP_string, int, SCP_string_lcase_ha
 //
 // The "level" parameter indicates how deep the nesting level is, and the "isLeaf" parameter indicates whether the submodel is a leaf node.
 // To find the model's detail0 root node, use pm->submodel[pm->detail[0]].
-template <typename Func, typename... AdditionalParams>
-void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int level, AdditionalParams... params)
+template <typename pm_t, typename Func, typename... AdditionalParams>
+void model_iterate_submodel_tree(pm_t* pm, int submodel, Func func, int level, AdditionalParams... params)
 {
 	Assertion(pm != nullptr, "pm must not be null!");
 	Assertion(submodel >= 0 && submodel < pm->n_models, "submodel must be in range!");
@@ -932,8 +934,8 @@ void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func, int lev
 }
 
 //This wrapper function is needed due to a bug in clang versions before 11 which breaks default parameters before parameter packs
-template <typename Func>
-inline void model_iterate_submodel_tree(polymodel* pm, int submodel, Func func)
+template <typename pm_t, typename Func>
+inline void model_iterate_submodel_tree(pm_t* pm, int submodel, Func func)
 {
 	model_iterate_submodel_tree(pm, submodel, func, 0);
 }
@@ -959,7 +961,7 @@ void model_delete_instance(int model_instance_num);
 // Goober5000
 void model_load_texture(polymodel *pm, int i, char *file);
 
-SCP_set<int> model_get_textures_used(polymodel* pm, int submodel);
+SCP_set<int> model_get_textures_used(const polymodel* pm, int submodel);
 
 // Returns a pointer to the polymodel structure for model 'n'
 polymodel *model_get(int model_num);

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -3426,6 +3426,6 @@ void bsp_polygon_data::replace_textures_used(const SCP_map<int, int>& replacemen
 	}
 }
 
-SCP_set<int> model_get_textures_used(polymodel* pm, int submodel) {
+SCP_set<int> model_get_textures_used(const polymodel* pm, int submodel) {
 	return bsp_polygon_data{ pm->submodel[submodel].bsp_data }.get_textures_used();
 }

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -74,7 +74,7 @@ public:
 		auto it = cache.find(pof_name);
 		
 		//Don't load from cache if it's a virtual pof (always reload these) or we don't have it cached
-		if ((vp_it != virtual_pofs.end() && vp_it->second.size() > depth[pof_name]) || it == cache.end()) {
+		if ((vp_it != virtual_pofs.end() && (int)vp_it->second.size() > depth[pof_name]) || it == cache.end()) {
 			auto pmh = ::make_shared<polymodel_holder>(pof_name, depth);
 			if(pmh->needs_emplace)
 				cache.emplace(pof_name, pmh);

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -201,7 +201,7 @@ void virtual_pof_init() {
 #define CHANGE_HELPER(name, intype, argtype) template<typename map_t> static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value>::type name(intype& input, map_t replace); \
 template<typename map_t> inline static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value, intype>::type name(intype&& input, map_t replace){ \
 	name<map_t>(input, replace); \
-	return input; \
+	return std::move(input); \
 } \
 template<typename map_t> static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value>::type name(intype& input, map_t replace) {\
 	for (const auto& replacement : replace) { \

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -68,9 +68,13 @@ public:
 		inline void keepBSPData(int sm) { keepSM.emplace(sm); }
 	};
 
-	const std::shared_ptr<polymodel_holder> operator()(const SCP_string& pof_name, const model_parse_depth& depth) {
+	const std::shared_ptr<polymodel_holder> operator()(const SCP_string& pof_name, model_parse_depth& depth) {
+		auto vp_it = virtual_pofs.find(pof_name);
+
 		auto it = cache.find(pof_name);
-		if (it == cache.end()) {
+		
+		//Don't load from cache if it's a virtual pof (always reload these) or we don't have it cached
+		if ((vp_it != virtual_pofs.end() && vp_it->second.size() > depth[pof_name]) || it == cache.end()) {
 			auto pmh = ::make_shared<polymodel_holder>(pof_name, depth);
 			if(pmh->needs_emplace)
 				cache.emplace(pof_name, pmh);

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -190,9 +190,9 @@ void virtual_pof_init() {
 // Internal helper functions
 
 #define REPLACE_IF_EQ(data) if ((data) == source) (data) = dest;
-#define REPLACE_IF_STRIEQ(data) if (stricmp(data, source.c_str()) == 0) { strncpy(data, dest.c_str(), dest.size()); data[dest.size()] = '\0'; }
+#define REPLACE_IF_STRIEQ(data) if (stricmp(data, source.c_str()) == 0) { strncpy_s(data, dest.c_str(), dest.size()); data[MIN(dest.size(), sizeof(data) / sizeof(data[0]))] = '\0'; }
 
-//Generates one function for replacing data in a type, which is a map entry of which the key may be replaced. Takes an rvalue reference, used for making a copy and modifying the tempoary to then assign it somewhere
+//Generates one function for replacing data in a type, which is a map entry of which the key may be replaced. Takes an rvalue reference, used for making a copy and modifying the temporary to then assign it somewhere
 #define CHANGE_HELPER_MAP_KEY(name, intype, argtype) template<typename map_t> static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value, intype>::type name(intype&& pass, map_t replace){ \
 	const auto it = replace.find(pass.first); \
 	intype input = { (it == replace.end() ? pass.first : it->second), pass.second }; \
@@ -201,7 +201,7 @@ void virtual_pof_init() {
 		const argtype& dest = replacement.second;
 #define CHANGE_HELPER_MAP_KEY_END } return input; }
 
-//Generates two functions for replacing data in a type. One that takes an rvalue reference, used for making a copy and modifying the tempoary to then assign it somewhere, and one which takes an lvalue reference for modifying in-place
+//Generates two functions for replacing data in a type. One that takes an rvalue reference, used for making a copy and modifying the temporary to then assign it somewhere, and one which takes an lvalue reference for modifying in-place
 #define CHANGE_HELPER(name, intype, argtype) template<typename map_t> static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value>::type name(intype& input, map_t replace); \
 template<typename map_t> inline static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value, intype>::type name(intype&& input, map_t replace){ \
 	name<map_t>(input, replace); \

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -189,13 +189,13 @@ void virtual_pof_init() {
 #define REPLACE_IF_STRIEQ(data) if (stricmp(data, source.c_str()) == 0) { strncpy(data, dest.c_str(), dest.size()); data[dest.size()] = '\0'; }
 
 //Generates one function for replacing data in a type, which is a map entry of which the key may be replaced. Takes an rvalue reference, used for making a copy and modifying the tempoary to then assign it somewhere
-#define CHANGE_HELPER_MAP_KEY(name, intype, argtype) template<typename map_t> static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value, intype>::type name(intype&& input, map_t replace){ \
-	const auto it = replace.find(input.first); \
-	intype result = { (it == replace.end() ? input.first : it->second), input.second }; \
+#define CHANGE_HELPER_MAP_KEY(name, intype, argtype) template<typename map_t> static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value, intype>::type name(intype&& pass, map_t replace){ \
+	const auto it = replace.find(pass.first); \
+	intype input = { (it == replace.end() ? pass.first : it->second), pass.second }; \
 	for (const auto& replacement : replace) { \
 		const argtype& source = replacement.first; \
 		const argtype& dest = replacement.second;
-#define CHANGE_HELPER_MAP_KEY_END } return result; }
+#define CHANGE_HELPER_MAP_KEY_END } return input; }
 
 //Generates two functions for replacing data in a type. One that takes an rvalue reference, used for making a copy and modifying the tempoary to then assign it somewhere, and one which takes an lvalue reference for modifying in-place
 #define CHANGE_HELPER(name, intype, argtype) template<typename map_t> static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value>::type name(intype& input, map_t replace); \

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -49,7 +49,7 @@ public:
 		}
 
 		//Don't copy, just move
-		const polymodel_holder(const polymodel_holder&) = delete;
+		polymodel_holder(const polymodel_holder&) = delete;
 		polymodel_holder& operator=(const polymodel_holder&) = delete;
 
 		~polymodel_holder() {
@@ -73,7 +73,7 @@ public:
 		if (it == cache.end()) {
 			auto pmh = ::make_shared<polymodel_holder>(pof_name, depth);
 			if(pmh->needs_emplace)
-				virtual_pof_build_cache.cache.emplace(pof_name, pmh);
+				cache.emplace(pof_name, pmh);
 			return pmh;
 		}
 		return it->second;

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -43,6 +43,15 @@ public:
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 
+class VirtualPOFOperationAddTurret : public VirtualPOFOperation {
+	
+	static void addTurretToPM(polymodel* pm, model_read_deferred_tasks& deferredTasks, int turretSubobjFrom, const polymodel* toAppend, const model_read_deferred_tasks& toAppendTasks);
+	friend class VirtualPOFOperationAddSubmodel;
+public:
+	VirtualPOFOperationAddTurret();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
+};
+
 class VirtualPOFOperationChangeData : public VirtualPOFOperation {
 	SCP_string submodel;
 	tl::optional<vec3d> setOffset = tl::nullopt;

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -8,10 +8,11 @@
 #include <tl/optional.hpp>
 
 bool model_exists(const SCP_string& filename);
-
 bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, model_parse_depth depth, int ferror, model_read_deferred_tasks& deferredTasks);
+void virtual_pof_purge_cache();
 
 void virtual_pof_init();
+
 
 struct VirtualPOFDefinition;
 
@@ -27,7 +28,9 @@ struct VirtualPOFDefinition {
 };
 
 class VirtualPOFOperationRenameSubobjects : public VirtualPOFOperation {
-	SCP_unordered_map<SCP_string, SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to> replacements;
+	using replacement_map = SCP_unordered_map<SCP_string, SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to>;
+	replacement_map replacements;
+	friend class VirtualPOFOperationAddSubmodel;
 public:
 	VirtualPOFOperationRenameSubobjects();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -46,15 +46,6 @@ public:
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 
-class VirtualPOFOperationAddTurret : public VirtualPOFOperation {
-	
-	static void addTurretToPM(polymodel* pm, model_read_deferred_tasks& deferredTasks, int turretSubobjFrom, const polymodel* toAppend, const model_read_deferred_tasks& toAppendTasks);
-	friend class VirtualPOFOperationAddSubmodel;
-public:
-	VirtualPOFOperationAddTurret();
-	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
-};
-
 class VirtualPOFOperationChangeData : public VirtualPOFOperation {
 	SCP_string submodel;
 	tl::optional<vec3d> setOffset = tl::nullopt;

--- a/code/sound/speech.cpp
+++ b/code/sound/speech.cpp
@@ -27,10 +27,12 @@
 
 // Since we define these ourself we need to undefine them for the sapi header
 #pragma push_macro("strcpy_s")
+#pragma push_macro("strncpy_s")
 #pragma push_macro("strcat_s")
 #pragma push_macro("memset")
 #pragma push_macro("memcpy")
 #undef strcpy_s
+#undef strncpy_s
 #undef strcat_s
 #undef memset
 #undef memcpy
@@ -41,6 +43,7 @@
 	#include <sphelper.h>
 
 #pragma pushpop_macro("strcpy_s")
+#pragma pushpop_macro("strncpy_s")
 #pragma pushpop_macro("strcat_s")
 #pragma pushpop_macro("memset")
 #pragma pushpop_macro("memcpy")

--- a/code/sound/voicerec.cpp
+++ b/code/sound/voicerec.cpp
@@ -31,10 +31,12 @@
 
 // Since we define these ourself we need to undefine them for the sapi header
 #pragma push_macro("strcpy_s")
+#pragma push_macro("strncpy_s")
 #pragma push_macro("strcat_s")
 #pragma push_macro("memset")
 #pragma push_macro("memcpy")
 #undef strcpy_s
+#undef strncpy_s
 #undef strcat_s
 #undef memset
 #undef memcpy
@@ -42,6 +44,7 @@
 #include <sphelper.h>                           // Contains definitions of SAPI functions
 
 #pragma pushpop_macro("strcpy_s")
+#pragma pushpop_macro("strncpy_s")
 #pragma pushpop_macro("strcat_s")
 #pragma pushpop_macro("memset")
 #pragma pushpop_macro("memcpy")


### PR DESCRIPTION
Previously, all loads for modular pofs were continually repeated. This changes this to cache models loaded from disk.
Since such a cache implies that the base models loaded from disk are immutable and reusable, some access had to be refactored. This consists mostly of macroifying the change_submodule_number (and name) functions, so that they provide methods for both in-place editing (when they need to operate on the current, mutable base model) as well as for editing an rvalue temporary copy of the data from the cache to be put moved into the current virtual pof with minimal code repetition. The templates in the macro may look scary, but all they do is allow any kind of map-like for providing the replacement arguments over just one variety of SCP_map.
This PR is a requirement for the followup-additions of features for modular pofs, as the changed API access has significant impact on further code (hence I also added caching much earlier than anticipated; it'd just get very very hard to add it after the fact if none of the modules takes the immutability of data in the cache into account) 