### PR TITLE
a few more script enhancements

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20068,7 +20068,7 @@ void sexp_turret_set_rate_of_fire(int node)
 		auto turret = ship_get_subsys(ship_entry->shipp, CTEXT(node));
 		if (turret != nullptr)
 		{
-			// set the range
+			// set the rate
 			if (rof < 0)
 				turret->rof_scaler = turret->system_info->turret_rof_scaler;
 			else
@@ -35453,6 +35453,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"hide-in-mission-log - Prevents events involving this ship from being viewable in the mission log\r\n"
 		"no-ship-passive-lightning - Turns off ship lightning that is unrelated to damage or EMP\r\n"
 		"glowmaps-disabled - Turns off glowmaps\r\n"
+		"no-thrusters - Turns off thrusters\r\n"
 		"fail-sound-locked-primary - This ship will play a weapon failure sound if trying to shoot primaries when they're locked\r\n"
 		"fail-sound-locked-secondary - This ship will play a weapon failure sound if trying to shoot secondaries when they're locked\r\n"
 		"aspect-immune - This ship cannot be locked onto by aspect seeking weapons\r\n"

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -822,7 +822,7 @@ ADE_VIRTVAR(Radius, l_Glowpoint, nullptr, "The radius of the glowpoint", "number
 	return ade_set_args(L, "f", radius);
 }
 
-ADE_FUNC(isValid, l_Glowpoint, NULL, "Returns wether this handle is valid or not", "boolean", "True if handle is valid, false otherwise")
+ADE_FUNC(isValid, l_Glowpoint, NULL, "Returns whether this handle is valid or not", "boolean", "True if handle is valid, false otherwise")
 {
 	glowpoint_h glh = NULL;
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -2146,6 +2146,45 @@ ADE_FUNC(vanish, l_Ship, nullptr, "Vanishes this ship from the mission. Works in
 	return ade_set_args(L, "b", true);
 }
 
+ADE_FUNC(setGlowPointBankActive, l_Ship, "boolean active, [number bank]", "Activates or deactivates one or more of a ship's glow point banks - this function can accept an arbitrary number of bank arguments.  Omit the bank number or specify -1 to activate or deactivate all banks.", nullptr, "Returns nothing")
+{
+	object_h* objh = nullptr;
+	bool active, at_least_one = false, do_all = false;
+	int bank_num;
+
+	if (!ade_get_args(L, "ob", l_Ship.GetPtr(&objh), &active))
+		return ADE_RETURN_NIL;
+	int skip_args = 1;	// not 2 because there will be one more before we read the first number
+
+	if (!objh->IsValid())
+		return ADE_RETURN_NIL;
+
+	auto shipp = &Ships[objh->objp->instance];
+
+	// read as many bank numbers as we have
+	while (internal::Ade_get_args_skip = ++skip_args, ade_get_args(L, "|i", &bank_num) > 0)
+	{
+		if (bank_num < 0)
+		{
+			do_all = true;
+			break;
+		}
+		at_least_one = true;
+
+		if (static_cast<size_t>(bank_num) < shipp->glow_point_bank_active.size())
+			shipp->glow_point_bank_active[bank_num] = active;
+	}
+
+	// set all banks
+	if (!at_least_one || do_all)
+	{
+		for (size_t i = 0; i < shipp->glow_point_bank_active.size(); ++i)
+			shipp->glow_point_bank_active[i] = active;
+	}
+
+	return ADE_RETURN_NIL;
+}
+
 
 }
 }

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -326,6 +326,28 @@ ADE_VIRTVAR(NumFirePoints, l_Subsystem, "number", "Number of firepoints", "numbe
 	return ade_set_args(L, "i", sso->ss->system_info->turret_num_firing_points);
 }
 
+ADE_VIRTVAR(FireRateMultiplier, l_Subsystem, "number", "Factor by which turret's rate of fire is multiplied.  This can also be set with the turret-set-rate-of-fire SEXP.  As with the SEXP, assigning a negative value will cause this to be reset to default.", "number", "Firing rate multiplier, or 0 if handle is invalid")
+{
+	ship_subsys_h* sso;
+	float multiplier;
+	if (!ade_get_args(L, "o|f", l_Subsystem.GetPtr(&sso), &multiplier))
+		return ade_set_error(L, "f", 0.0f);
+
+	if (!sso->isSubsystemValid())
+		return ade_set_error(L, "f", 0.0f);
+
+	if (ADE_SETTING_VAR)
+	{
+		// set the rate
+		if (multiplier < 0.0f)
+			sso->ss->rof_scaler = sso->ss->system_info->turret_rof_scaler;
+		else
+			sso->ss->rof_scaler = multiplier;
+	}
+
+	return ade_set_args(L, "f", sso->ss->rof_scaler);
+}
+
 ADE_FUNC(getModelName, l_Subsystem, NULL, "Returns the original name of the subsystem in the model file", "string", "name or empty string on error")
 {
 	ship_subsys_h *sso;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -537,6 +537,7 @@ ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::Hide_mission_log,				"hide-in-mission-log" },
 	{ Ship_Flags::No_passive_lightning,			"no-ship-passive-lightning" },
 	{ Ship_Flags::Glowmaps_disabled,			"glowmaps-disabled" },
+	{ Ship_Flags::No_thrusters,					"no-thrusters" },
 	{ Ship_Flags::Fail_sound_locked_primary, 	"fail-sound-locked-primary"},
 	{ Ship_Flags::Fail_sound_locked_secondary, 	"fail-sound-locked-secondary"},
 	{ Ship_Flags::Aspect_immune, 				"aspect-immune"}


### PR DESCRIPTION
1) Add the "no-thrusters" ship flag to the list of flag that can be used by alter-ship-flag or the ship's setFlag function
2) Add a `FireRateMultiplier` virtvar to control the firing rate of turrets (fulfills #4300)
3) Add a `setGlowPointBankActive` function to do the same thing as `activate-glow-point-bank`/`deactivate-glow-point-bank`

~~In draft status pending tests.~~