### PR TITLE
Fix lighting flickering on specmap-less models

### DIFF
--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -169,18 +169,18 @@ void convert_model_material(model_uniform_data* data_out,
 			data_out->gammaSpec = 0;
 			data_out->alphaGloss = 0;
 		}
-
-		if (shader_flags & SDR_FLAG_MODEL_ENV_MAP) {
-			if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0 || Gloss_override_set) {
-				data_out->envGloss = 1;
-			} else {
-				data_out->envGloss = 0;
-			}
-
-			data_out->envMatrix = gr_env_texture_matrix;
-		}
 	}
 
+	if (shader_flags & SDR_FLAG_MODEL_ENV_MAP) {
+		if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0 || Gloss_override_set) {
+			data_out->envGloss = 1;
+		} else {
+			data_out->envGloss = 0;
+		}
+
+		data_out->envMatrix = gr_env_texture_matrix;
+	}
+	
 	if ( shader_flags & SDR_FLAG_MODEL_NORMAL_MAP ) {
 		data_out->sNormalmapIndex = bm_get_array_index(material.get_texture_map(TM_NORMAL_TYPE));
 	}


### PR DESCRIPTION
Big shader PR #4652 made models always receive image based lighting (bar command line options) - even those without specular maps. However, the associated shader_flags logic wasn't updated. this meant that ships without specular maps would render environment lighting with uninitialized data describing its orientation. This resulted in flickering as the data would differ frame-to-frame. 

This PR moves the logic outside of the "if has specular map" conditional, making sure the data is initialised if environment map rendering is happening 