### PR TITLE
Prevent dangling threads from crashing FSO on close

### DIFF
--- a/code/scripting/lua/LuaTable.cpp
+++ b/code/scripting/lua/LuaTable.cpp
@@ -17,9 +17,6 @@ LuaTable LuaTable::create(lua_State* state) {
 LuaTable::LuaTable() : LuaValue() {
 }
 
-LuaTable::LuaTable(const LuaTable& other) : LuaValue(other) {
-}
-
 LuaTable::~LuaTable() {
 }
 

--- a/code/scripting/lua/LuaTable.h
+++ b/code/scripting/lua/LuaTable.h
@@ -100,12 +100,6 @@ class LuaTable: public LuaValue {
 	LuaTable();
 
 	/**
-     * @brief Copy-constructor
-     * @param other The other table.
-     */
-	LuaTable(const LuaTable& other);
-
-	/**
      * Dereferences the stored reference to the table if it exists.
      */
 	~LuaTable() override;

--- a/code/scripting/lua/LuaThread.cpp
+++ b/code/scripting/lua/LuaThread.cpp
@@ -21,7 +21,7 @@ LuaThread LuaThread::create(lua_State* L, const LuaFunction& func)
 	int stack = lua_gettop(L);
 
 	//Make sure to create the function that clears the LuaThread reference BEFORE creating the userdata value, otherwise the function will be garbage-collected itself before it's called.
-	thread.deleterFunc = LuaFunction::createFromStdFunction(L, [threadRef](lua_State* L, const LuaValueList& params) -> LuaValueList {
+	thread.deleterFunc = LuaFunction::createFromStdFunction(L, [threadRef](lua_State*, const LuaValueList&) -> LuaValueList {
 		if(!threadRef.expired())
 			threadRef.lock()->removeReference();
 		return {};
@@ -53,8 +53,8 @@ LuaThread LuaThread::create(lua_State* L, const LuaFunction& func)
 LuaThread::LuaThread() = default;
 LuaThread::LuaThread(lua_State* luaState, lua_State* thread) : LuaValue(luaState), _thread(thread) {}
 
-LuaThread::LuaThread(LuaThread&& other) noexcept = default;
-LuaThread& LuaThread::operator=(LuaThread&& other) noexcept = default;
+LuaThread::LuaThread(LuaThread&&) = default;
+LuaThread& LuaThread::operator=(LuaThread&&) = default;
 
 LuaThread::~LuaThread() = default;
 

--- a/code/scripting/lua/LuaThread.cpp
+++ b/code/scripting/lua/LuaThread.cpp
@@ -5,14 +5,13 @@
 #include <utility>
 
 namespace luacpp {
-
 LuaThread LuaThread::create(lua_State* L, const LuaFunction& func)
 {
 	auto luaThread = lua_newthread(L);
 
 	LuaThread thread(L, luaThread);
-
 	thread.setReference(UniqueLuaReference::create(L));
+
 	lua_pop(L, 1);
 
 	//Make sure that the C++-side reference of the LuaThread is cleared when its parents references are auto-garbage collected by lua for whatever reason (usually due to the parent thread dying).
@@ -52,18 +51,10 @@ LuaThread LuaThread::create(lua_State* L, const LuaFunction& func)
 }
 
 LuaThread::LuaThread() = default;
-LuaThread::LuaThread(lua_State* luaState, lua_State* thread) : LuaValue(luaState), _thread(thread) { }
+LuaThread::LuaThread(lua_State* luaState, lua_State* thread) : LuaValue(luaState), _thread(thread) {}
 
-LuaThread::LuaThread(LuaThread&& other) noexcept : LuaValue(other) {
-	*this = std::move(other);
-}
-
-LuaThread& LuaThread::operator=(LuaThread&& other) noexcept {
-	LuaValue::operator=(other);
-	std::swap(_errorCallback, other._errorCallback);
-	std::swap(_thread, other._thread);
-	return *this;
-}
+LuaThread::LuaThread(LuaThread&& other) noexcept = default;
+LuaThread& LuaThread::operator=(LuaThread&& other) noexcept = default;
 
 LuaThread::~LuaThread() = default;
 

--- a/code/scripting/lua/LuaThread.cpp
+++ b/code/scripting/lua/LuaThread.cpp
@@ -10,7 +10,7 @@ namespace luacpp {
 
 SCP_unordered_set<LuaThread*> LuaThread::threads;
 SCP_unordered_set<LuaThread*>& LuaThread::registerThreadList(lua_State* mainThread) {
-	script_state::GetScriptState(mainThread)->OnStateDestroy.add([](lua_State* L) {
+	script_state::GetScriptState(mainThread)->OnStateDestroy.add([](lua_State*) {
 		for (LuaThread* thread : threads)
 			thread->getReference()->removeReference();
 		threads.clear();

--- a/code/scripting/lua/LuaThread.cpp
+++ b/code/scripting/lua/LuaThread.cpp
@@ -4,46 +4,55 @@
 
 #include <utility>
 
-#include "scripting/scripting.h"
-
 namespace luacpp {
-
-SCP_unordered_map<lua_State*, SCP_unordered_set<LuaThread*>> LuaThread::threads;
-SCP_unordered_set<LuaThread*>& LuaThread::registerThreadList(lua_State* mainThread) {
-	auto it = threads.find(mainThread);
-	if (it != threads.end())
-		return it->second;
-
-	script_state::GetScriptState(mainThread)->OnStateDestroy.add([](lua_State* L) {
-		for (LuaThread* thread : threads.at(L))
-			thread->getReference()->removeReference();
-
-		threads.erase(L);
-		});
-
-	return threads.emplace(mainThread, SCP_unordered_set<LuaThread*>{}).first->second;
-}
 
 LuaThread LuaThread::create(lua_State* L, const LuaFunction& func)
 {
 	auto luaThread = lua_newthread(L);
 
+	LuaThread thread(L, luaThread);
+
+	thread.setReference(UniqueLuaReference::create(L));
+	lua_pop(L, 1);
+
+	//Make sure that the C++-side reference of the LuaThread is cleared when its parents references are auto-garbage collected by lua for whatever reason (usually due to the parent thread dying).
+	//To do this, register an object with a __gc method in the thread (usually we'd want to directly attach it to the thread, but only userdata will have __gc methods called).
+	//Usually we'd want to do this when the childs references are GC'd, but creating tables on child threads from C causes tests to fail for some reason.
+	auto threadRef = std::weak_ptr<UniqueLuaReference>(thread.getReference());
+	int stack = lua_gettop(L);
+
+	//Make sure to create the function that clears the LuaThread reference BEFORE creating the userdata value, otherwise the function will be garbage-collected itself before it's called.
+	thread.deleterFunc = LuaFunction::createFromStdFunction(L, [threadRef](lua_State* L, const LuaValueList& params) -> LuaValueList {
+		if(!threadRef.expired())
+			threadRef.lock()->removeReference();
+		return {};
+		});
+
+	//NOW, create the dummy userdata, and its metatable
+	lua_newuserdata(L, sizeof(bool));
+	thread.deleterUserdata = UniqueLuaReference::create(L);
+	thread.deleterTable = LuaTable::create(L);
+
+	//Since we hold references to all we need, tidy up the stack.
+	lua_settop(L, stack);
+
+	//Push the values in the correct order for assembly. Userdata, then table, then func
+	thread.deleterUserdata->pushValue(L);
+	thread.deleterTable.pushValue(L);
+	thread.deleterFunc.pushValue(L);
+	lua_setfield(L, -2, "__gc"); //Takes the top value (func) and assigns it to the second to last one (table) as __gc, and pops the top value
+	lua_setmetatable(L, -2); //Takes the top value (table) and assigns it as the metadata table of the second to last one (userdata), and pops the last value
+	lua_pop(L, 1); //Pop the userdata
+
 	func.pushValue(L);
 	// Move the main function to the thread (I have no idea what this actually does but the Lua code does the same...)
 	lua_xmove(L, luaThread, 1);
-
-	LuaThread thread(L, luaThread);
-	thread.setReference(UniqueLuaReference::create(L));
-
-	lua_pop(L, 1);
 
 	return thread;
 }
 
 LuaThread::LuaThread() = default;
-LuaThread::LuaThread(lua_State* luaState, lua_State* thread) : LuaValue(luaState), _thread(thread) {
-	registerThreadList(luaState).emplace(this);
-}
+LuaThread::LuaThread(lua_State* luaState, lua_State* thread) : LuaValue(luaState), _thread(thread) { }
 
 LuaThread::LuaThread(LuaThread&& other) noexcept : LuaValue(other) {
 	*this = std::move(other);
@@ -53,19 +62,10 @@ LuaThread& LuaThread::operator=(LuaThread&& other) noexcept {
 	LuaValue::operator=(other);
 	std::swap(_errorCallback, other._errorCallback);
 	std::swap(_thread, other._thread);
-	threads.at(_luaState).emplace(this);
 	return *this;
 }
 
-LuaThread::~LuaThread() {
-	//Safety check since erasing from the half-dead threads set is gonna cause segfaults when the whole program deallocates, as dangling threads outlive the static threads map
-	if (!threads.empty()) {
-		auto it = threads.find(_luaState);
-
-		if (it != threads.end())
-			it->second.erase(this);
-	}
-}
+LuaThread::~LuaThread() = default;
 
 void LuaThread::setReference(const LuaReference& ref)
 {

--- a/code/scripting/lua/LuaThread.cpp
+++ b/code/scripting/lua/LuaThread.cpp
@@ -17,6 +17,7 @@ SCP_unordered_set<LuaThread*>& LuaThread::registerThreadList(lua_State* mainThre
 	script_state::GetScriptState(mainThread)->OnStateDestroy.add([](lua_State* L) {
 		for (LuaThread* thread : threads.at(L))
 			thread->getReference()->removeReference();
+
 		threads.erase(L);
 		});
 
@@ -61,11 +62,8 @@ LuaThread::~LuaThread() {
 	if (!threads.empty()) {
 		auto it = threads.find(_luaState);
 
-		if (it != threads.end()) {
+		if (it != threads.end())
 			it->second.erase(this);
-			if (it->second.empty())
-				threads.erase(it);
-		}
 	}
 }
 

--- a/code/scripting/lua/LuaThread.h
+++ b/code/scripting/lua/LuaThread.h
@@ -20,8 +20,9 @@ namespace luacpp {
  */
 class LuaThread : public LuaValue {
 
-	static SCP_unordered_map<lua_State*, SCP_unordered_set<LuaThread*>> threads;
-	static SCP_unordered_set<LuaThread*>& registerThreadList(lua_State* mainThread);
+	LuaReference deleterUserdata;
+	LuaTable deleterTable;
+	LuaFunction deleterFunc;
   public:
 	using ErrorCallback = std::function<bool(lua_State* mainState, lua_State* thread)>;
 	struct ResumeState

--- a/code/scripting/lua/LuaThread.h
+++ b/code/scripting/lua/LuaThread.h
@@ -5,6 +5,8 @@
 #include "LuaValue.h"
 #include "LuaFunction.h"
 
+#include "globalincs/vmallocator.h"
+
 #include <iterator>
 
 namespace luacpp {
@@ -17,6 +19,9 @@ namespace luacpp {
  * @see LuaConvert
  */
 class LuaThread : public LuaValue {
+
+	static SCP_unordered_set<LuaThread*> threads;
+	static SCP_unordered_set<LuaThread*>& registerThreadList(lua_State* mainThread);
   public:
 	using ErrorCallback = std::function<bool(lua_State* mainState, lua_State* thread)>;
 	struct ResumeState
@@ -35,16 +40,12 @@ class LuaThread : public LuaValue {
 	 */
 	LuaThread();
 
-	/**
-	 * @brief Copy-constructor
-	 * @param other The other thread.
-	 */
-	LuaThread(const LuaThread&);
-	LuaThread& operator=(const LuaThread&);
+	//Copying threads is VERY illegal
+	LuaThread(const LuaThread&) = delete;
+	LuaThread& operator=(const LuaThread&) = delete;
 
-	// These should be noexcept but Visual Studio doesn't like that yet in a recent enough version
-	LuaThread(LuaThread&&); // NOLINT(performance-noexcept-move-constructor)
-	LuaThread& operator=(LuaThread&&); // NOLINT(performance-noexcept-move-constructor)
+	LuaThread(LuaThread&&) noexcept; 
+	LuaThread& operator=(LuaThread&&) noexcept;
 
 	~LuaThread() override;
 

--- a/code/scripting/lua/LuaThread.h
+++ b/code/scripting/lua/LuaThread.h
@@ -20,7 +20,7 @@ namespace luacpp {
  */
 class LuaThread : public LuaValue {
 
-	static SCP_unordered_set<LuaThread*> threads;
+	static SCP_unordered_map<lua_State*, SCP_unordered_set<LuaThread*>> threads;
 	static SCP_unordered_set<LuaThread*>& registerThreadList(lua_State* mainThread);
   public:
 	using ErrorCallback = std::function<bool(lua_State* mainState, lua_State* thread)>;

--- a/code/scripting/lua/LuaThread.h
+++ b/code/scripting/lua/LuaThread.h
@@ -43,8 +43,8 @@ class LuaThread : public LuaValue {
 	LuaThread(const LuaThread&) = delete;
 	LuaThread& operator=(const LuaThread&) = delete;
 
-	LuaThread(LuaThread&&) = default; 
-	LuaThread& operator=(LuaThread&&) = default;
+	LuaThread(LuaThread&&); 
+	LuaThread& operator=(LuaThread&&);
 
 	~LuaThread() override;
 

--- a/code/scripting/lua/LuaThread.h
+++ b/code/scripting/lua/LuaThread.h
@@ -43,8 +43,8 @@ class LuaThread : public LuaValue {
 	LuaThread(const LuaThread&) = delete;
 	LuaThread& operator=(const LuaThread&) = delete;
 
-	LuaThread(LuaThread&&) noexcept; 
-	LuaThread& operator=(LuaThread&&) noexcept;
+	LuaThread(LuaThread&&) = default; 
+	LuaThread& operator=(LuaThread&&) = default;
 
 	~LuaThread() override;
 

--- a/code/scripting/lua/LuaThread.h
+++ b/code/scripting/lua/LuaThread.h
@@ -5,8 +5,6 @@
 #include "LuaValue.h"
 #include "LuaFunction.h"
 
-#include "globalincs/vmallocator.h"
-
 #include <iterator>
 
 namespace luacpp {

--- a/test/src/scripting/lua/Thread.cpp
+++ b/test/src/scripting/lua/Thread.cpp
@@ -4,13 +4,20 @@
 #include "scripting/lua/LuaFunction.h"
 #include "scripting/lua/LuaThread.h"
 
+#include "scripting/ScriptingTestFixture.h"
+
 using namespace luacpp;
 
-class LuaThreadTest : public LuaStateTest {
+//LuaThreads are no longer valid without a full script_state, as cleanup isn't possible for pure lua
+//hence, this is now a full scriptingtestfixture and not just a Lua Test
+class LuaThreadTest : public test::scripting::ScriptingTestFixture {
+public:
+	LuaThreadTest() : test::scripting::ScriptingTestFixture(INIT_CFILE) {}
 };
 
 TEST_F(LuaThreadTest, CreateYieldFinish)
 {
+	lua_State* L = _state->GetLuaSession();
 	ScopedLuaStackTest stackTest(L);
 
 	const auto mainFunc = LuaFunction::createFromCode(L, R"(
@@ -38,6 +45,7 @@ return yield_val
 
 TEST_F(LuaThreadTest, OnErrorCallbackIsCalled)
 {
+	lua_State* L = _state->GetLuaSession();
 	ScopedLuaStackTest stackTest(L);
 
 	const auto mainFunc = LuaFunction::createFromCode(L, R"(

--- a/test/src/scripting/lua/Thread.cpp
+++ b/test/src/scripting/lua/Thread.cpp
@@ -4,20 +4,13 @@
 #include "scripting/lua/LuaFunction.h"
 #include "scripting/lua/LuaThread.h"
 
-#include "scripting/ScriptingTestFixture.h"
-
 using namespace luacpp;
 
-//LuaThreads are no longer valid without a full script_state, as cleanup isn't possible for pure lua
-//hence, this is now a full scriptingtestfixture and not just a Lua Test
-class LuaThreadTest : public test::scripting::ScriptingTestFixture {
-public:
-	LuaThreadTest() : test::scripting::ScriptingTestFixture(INIT_CFILE) {}
+class LuaThreadTest : public LuaStateTest {
 };
 
 TEST_F(LuaThreadTest, CreateYieldFinish)
 {
-	lua_State* L = _state->GetLuaSession();
 	ScopedLuaStackTest stackTest(L);
 
 	const auto mainFunc = LuaFunction::createFromCode(L, R"(
@@ -45,7 +38,6 @@ return yield_val
 
 TEST_F(LuaThreadTest, OnErrorCallbackIsCalled)
 {
-	lua_State* L = _state->GetLuaSession();
 	ScopedLuaStackTest stackTest(L);
 
 	const auto mainFunc = LuaFunction::createFromCode(L, R"(


### PR DESCRIPTION
If we open a thread with async.run, we lose complete control over it.
This means, that when closing the scripting state, we don't actually take the thread with us.
To prevent the C++ side of things to try to push the thread off of the lua state way after the state is already dead, we remember all threads, and once the state gets destroyed, we forcibly push every thread handle off the stack. This has twofold effects: One, the C-Side of the handle gets invalidated, causing the destruction of the Thread object to not try to modify the lua stack, and two, cause the thread to be properly garbage collected on the lua side of things during deallocation.

As a sidenote, there is no built in way to stop threads in lua. They are an object like any other, and will be GC'd once they have no references left. I'm not entirely sure what the interpreter does with the _actual_ system thread it started, and when it'll be closed. But the final lua_close of the main thread should kill it at the latest.

This is very much not a pretty way of doing things, but unless we have other ways of pinging each thread object and invalidating the UniqueLuaReference they hold, we will keep crashing if a rouge thread survives the scripting environment.
The other alternative is to hard-disallow infinite loops in async runs, and then wait for each open thread on close of the script environment.