### PR TITLE
upgrade controls code to use type-safe timestamps

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -567,7 +567,9 @@ public:
 	CC_type type;           //!< manner control should be checked in
 
 // Items used during gameplay
-	int  used;                  //!< has control been used yet in mission?  If so, this is the timestamp. For axes, this denotes the last frame's value
+	TIMESTAMP digital_used;     //!< has control been used yet in mission?  If so, this is the timestamp.
+	                            // Note this is not a UI timestamp because this is purely for mission timing purposes.
+	int  analog_value;          // For axes, this denotes the last frame's value
 	bool disabled = true;       //!< whether this action should be available at all
 	bool locked = false;		//!< whether this action will be triggered by the respectively bound key
 	bool scriptEnabledByDefault = false; //!< whether this binding will execute it's registered hooks if triggered. Resets each mission

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -738,7 +738,8 @@ void control_config_common_init()
 	}
 
 	for (int i = 0; i < Action::NUM_VALUES; i++) {
-		Control_config[i + JOY_AXIS_BEGIN].used = JOY_AXIS_CENTER;
+		Control_config[i + JOY_AXIS_BEGIN].analog_value = JOY_AXIS_CENTER;
+		Control_config[i + JOY_AXIS_BEGIN].digital_used = TIMESTAMP::invalid();
 	}
 	
 	// TODO It's not memory efficient to keep the presets loaded into memory all the time, but we do need to know which
@@ -2759,7 +2760,8 @@ CCI& CCI::operator=(const CCI& A) {
 	indexXSTR = A.indexXSTR;
 	text = A.text;
 	type = A.type;
-	used = A.used;
+	analog_value = A.analog_value;
+	digital_used = A.digital_used;
 	disabled = A.disabled;
 	locked = A.locked;
 	scriptEnabledByDefault = A.scriptEnabledByDefault;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17486,7 +17486,7 @@ int sexp_key_pressed(int node)
 		return SEXP_FALSE;
 	}
 
-	if (!Control_config[z].used){
+	if (!Control_config[z].digital_used.isValid()){
 		return SEXP_FALSE;
 	}
 
@@ -17500,7 +17500,7 @@ int sexp_key_pressed(int node)
 	if (is_nan_forever)
 		return SEXP_KNOWN_FALSE;
 
-	return timestamp_since(Control_config[z].used) >= t * MILLISECONDS_PER_SECOND;
+	return timestamp_since(Control_config[z].digital_used) >= t * MILLISECONDS_PER_SECOND;
 }
 
 void sexp_key_reset(int node)
@@ -17511,7 +17511,11 @@ void sexp_key_reset(int node)
 	{
 		z = translate_key_to_index(CTEXT(n), false);
 		if (z >= 0)
-			Control_config[z].used = 0;
+		{
+			// note: this is only for digital controls like button presses,
+			// so we don't need to clear the analog value
+			Control_config[z].digital_used = TIMESTAMP::invalid();
+		}
 	}
 }
 				

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -224,7 +224,8 @@ void game_unpause() {}
 //Time stuff
 bool Time_compression_locked;
 float flRealframetime;
-int Last_frame_timestamp = 0;
+TIMESTAMP Last_frame_timestamp = TIMESTAMP::invalid();
+UI_TIMESTAMP Last_frame_ui_timestamp = UI_TIMESTAMP::invalid();
 void lock_time_compression(bool is_locked){}
 void change_time_compression(float multiplier){}
 void set_time_compression(float multiplier, float change_time){}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4177,7 +4177,8 @@ void game_frame(bool paused)
 
 fix Last_time = 0;						// The absolute time of game at end of last frame (beginning of this frame)
 fix Last_delta_time = 0;				// While game is paused, this keeps track of how much elapsed in the frame before paused.
-int Last_frame_timestamp = 0;
+TIMESTAMP Last_frame_timestamp = TIMESTAMP::invalid();
+UI_TIMESTAMP Last_frame_ui_timestamp = UI_TIMESTAMP::invalid();
 static bool Time_paused = false;
 
 void game_time_level_init()
@@ -4328,8 +4329,8 @@ void game_set_frametime(int state)
 
 #ifndef NDEBUG
 	// If the frame took more than 5 seconds, assume we're tracing through a debugger.  If timestamps are running, correct the elapsed time.
-	if (!Cmdline_slow_frames_ok && !timestamp_is_paused() && (Last_frame_timestamp != 0)) {
-		auto delta_timestamp = timestamp() - Last_frame_timestamp;
+	if (!Cmdline_slow_frames_ok && !timestamp_is_paused() && (Last_frame_ui_timestamp.isValid())) {
+		auto delta_timestamp = ui_timestamp_since(Last_frame_ui_timestamp);
 		if (delta_timestamp > 5 * MILLISECONDS_PER_SECOND) {
 			delta_timestamp -= 20;	// suppose last frame was 50 FPS
 			mprintf(("Too much time passed between frames.  Adjusting timestamp by %i milliseconds to compensate\n", delta_timestamp));
@@ -4367,7 +4368,8 @@ void game_set_frametime(int state)
 	}
 
 	Last_time = thistime;
-	Last_frame_timestamp = timestamp();
+	Last_frame_timestamp = _timestamp();
+	Last_frame_ui_timestamp = ui_timestamp();
 
 	flFrametime = f2fl(Frametime);
 

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -35,8 +35,8 @@ extern fix Frametime;
 extern float flRealframetime;
 extern float flFrametime;
 extern fix Missiontime;
-extern TIMESTAMP Last_frame_timestamp;			// A timestamp for when the previous frame ended
-extern UI_TIMESTAMP Last_frame_ui_timestamp;	// Ditto
+extern TIMESTAMP Last_frame_timestamp;			// A timestamp for when the previous frame ended, in mission time
+extern UI_TIMESTAMP Last_frame_ui_timestamp;	// Ditto, in real time (independent of pause and time compression)
 extern fix Skybox_timestamp;	// A timestamp for animated skyboxes -MageKing17
 
 // 0 - 4

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -35,7 +35,8 @@ extern fix Frametime;
 extern float flRealframetime;
 extern float flFrametime;
 extern fix Missiontime;
-extern int Last_frame_timestamp; // A timestamp for when the previous frame ended
+extern TIMESTAMP Last_frame_timestamp;			// A timestamp for when the previous frame ended
+extern UI_TIMESTAMP Last_frame_ui_timestamp;	// Ditto
 extern fix Skybox_timestamp;	// A timestamp for animated skyboxes -MageKing17
 
 // 0 - 4

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -228,7 +228,8 @@ void game_unpause() {}
 //Time stuff
 bool Time_compression_locked;
 float flRealframetime;
-int Last_frame_timestamp = 0;
+TIMESTAMP Last_frame_timestamp = TIMESTAMP::invalid();
+UI_TIMESTAMP Last_frame_ui_timestamp = UI_TIMESTAMP::invalid();
 void lock_time_compression(bool  /*is_locked*/){}
 void change_time_compression(float  /*multiplier*/){}
 void set_time_compression(float  /*multiplier*/, float  /*change_time*/){}

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -232,7 +232,8 @@ void game_unpause() {}
 //Time stuff
 bool Time_compression_locked;
 float flRealframetime;
-int Last_frame_timestamp = 0;
+TIMESTAMP Last_frame_timestamp = TIMESTAMP::invalid();
+UI_TIMESTAMP Last_frame_ui_timestamp = UI_TIMESTAMP::invalid();
 void lock_time_compression(bool  /*is_locked*/){}
 void change_time_compression(float  /*multiplier*/){}
 void set_time_compression(float  /*multiplier*/, float  /*change_time*/){}


### PR DESCRIPTION
This requires splitting the `used` field into digital and analog components.  The digital field stores the last-used timestamp, whereas the analog field stores the last value.