### PR TITLE
Merge Show Ship and Cockpit Renderpasses

### DIFF
--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -41,6 +41,8 @@ static float Reflective_light = REFLECTIVE_LIGHT_DEFAULT;
 int Lighting_flag = 1;
 int Num_lights = 0;
 
+lighting_mode Lighting_mode = lighting_mode::NORMAL;
+
 DCF(light,"Changes lighting parameters")
 {
 	SCP_string arg_str;

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -84,6 +84,9 @@ public:
 	light_indexing_info bufferLights();
 };
 
+enum class lighting_mode { NORMAL, COCKPIT };
+extern lighting_mode Lighting_mode;
+
 extern void light_reset();
 
 //Intensity in lighting inputs multiplies the base colors.

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -221,6 +221,9 @@ void lighting_profile::reset()
 	ambient_light_brightness.set_multiplier(0.286f); 
 	ambient_light_brightness.stack_multiplier(Cmdline_ambient_power);
 	ambient_light_brightness.set_adjust(MAX(0.0f,Cmdline_emissive_power));
+
+	cockpit_light_radius_modifier.reset();
+	cockpit_light_radius_modifier.set_multiplier(1.0f);
 }
 
 TonemapperAlgorithm lighting_profile::name_to_tonemapper(SCP_string &name)
@@ -346,6 +349,10 @@ void lighting_profile::parse_default_section(const char *filename)
 		}
 
 		parsed |= parse_optional_float_into("$Exposure:",&default_profile.exposure);
+
+		parsed |= lighting_profile_value::parse(filename, "$Cockpit light radius modifier:", profile_name,
+			&default_profile.cockpit_light_radius_modifier);
+
 		if(!parsed){
 			stuff_string(buffer,F_RAW);
 			Warning(LOCATION,"Unhandled line in lighting profile\n\t%s",buffer.c_str());

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -114,6 +114,7 @@ public:
 	lighting_profile_value ambient_light_brightness;
 	//Strictly speaking this should be handled by postproc but we need something for the non-postproc people.
 	lighting_profile_value overall_brightness;
+	lighting_profile_value cockpit_light_radius_modifier;
 
     void reset();
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -92,6 +92,7 @@ bool Neb_affects_particles;
 bool Neb_affects_fireballs;
 std::tuple<float, float, float, float> Shadow_distances;
 std::tuple<float, float, float, float> Shadow_distances_cockpit;
+bool Show_ship_casts_shadow;
 bool Cockpit_shares_coordinate_space;
 bool Custom_briefing_icons_always_override_standard_icons;
 float Min_pixel_size_thruster;
@@ -646,6 +647,10 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Shadow_disable_overrides.disable_mission_select_ships);
 		}
 
+		if (optional_string("$Show Ship Casts Shadow:")) {
+			stuff_boolean(&Show_ship_casts_shadow);
+		}
+
 		if (optional_string("$Cockpit Shares Coordinate Space:")) {
 			stuff_boolean(&Cockpit_shares_coordinate_space);
 		}
@@ -1081,6 +1086,7 @@ void mod_table_reset()
 	Neb_affects_fireballs = false;
 	Shadow_distances = std::make_tuple(200.0f, 600.0f, 2500.0f, 8000.0f); // Default values tuned by Swifty and added here by wookieejedi
 	Shadow_distances_cockpit = std::make_tuple(0.25f, 0.75f, 1.5f, 3.0f); // Default values tuned by wookieejedi and added here by Lafiel
+	Show_ship_casts_shadow = false;
 	Cockpit_shares_coordinate_space = false;
 	Custom_briefing_icons_always_override_standard_icons = false;
 	Min_pixel_size_thruster = 0.0f;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -646,7 +646,7 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Shadow_disable_overrides.disable_mission_select_ships);
 		}
 
-		if (optional_string("$Enable 'show ship' Deferred Render, Cockpit Shares Coordinate Space:")) {
+		if (optional_string("$Cockpit Shares Coordinate Space:")) {
 			stuff_boolean(&Cockpit_shares_coordinate_space);
 		}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -92,6 +92,7 @@ bool Neb_affects_particles;
 bool Neb_affects_fireballs;
 std::tuple<float, float, float, float> Shadow_distances;
 std::tuple<float, float, float, float> Shadow_distances_cockpit;
+bool Cockpit_shares_coordinate_space;
 bool Custom_briefing_icons_always_override_standard_icons;
 float Min_pixel_size_thruster;
 float Min_pixel_size_beam;
@@ -645,6 +646,10 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Shadow_disable_overrides.disable_mission_select_ships);
 		}
 
+		if (optional_string("$Enable 'show ship' Deferred Render, Cockpit Shares Coordinate Space:")) {
+			stuff_boolean(&Cockpit_shares_coordinate_space);
+		}
+
 		if (optional_string("$Minimum Pixel Size Thrusters:")) {
 			stuff_float(&Min_pixel_size_thruster);
 		}
@@ -1076,6 +1081,7 @@ void mod_table_reset()
 	Neb_affects_fireballs = false;
 	Shadow_distances = std::make_tuple(200.0f, 600.0f, 2500.0f, 8000.0f); // Default values tuned by Swifty and added here by wookieejedi
 	Shadow_distances_cockpit = std::make_tuple(0.25f, 0.75f, 1.5f, 3.0f); // Default values tuned by wookieejedi and added here by Lafiel
+	Cockpit_shares_coordinate_space = false;
 	Custom_briefing_icons_always_override_standard_icons = false;
 	Min_pixel_size_thruster = 0.0f;
 	Min_pixel_size_beam = 0.0f;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -651,7 +651,7 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Show_ship_casts_shadow);
 		}
 
-		if (optional_string("$Cockpit Shares Coordinate Space:")) {
+		if (optional_string("$Ship Model And Cockpit Share Coordinate Space:")) {
 			stuff_boolean(&Cockpit_shares_coordinate_space);
 		}
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -82,6 +82,7 @@ extern bool Neb_affects_particles;
 extern bool Neb_affects_fireballs;
 extern std::tuple<float, float, float, float> Shadow_distances;
 extern std::tuple<float, float, float, float> Shadow_distances_cockpit;
+extern bool Cockpit_shares_coordinate_space;
 extern bool Custom_briefing_icons_always_override_standard_icons;
 extern float Min_pixel_size_thruster;
 extern float Min_pixel_size_beam;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -82,6 +82,7 @@ extern bool Neb_affects_particles;
 extern bool Neb_affects_fireballs;
 extern std::tuple<float, float, float, float> Shadow_distances;
 extern std::tuple<float, float, float, float> Shadow_distances_cockpit;
+extern bool Show_ship_casts_shadow;
 extern bool Cockpit_shares_coordinate_space;
 extern bool Custom_briefing_icons_always_override_standard_icons;
 extern float Min_pixel_size_thruster;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7436,6 +7436,8 @@ void ship_render_player_ship(object* objp) {
 		return;
 	}
 
+	Lighting_mode = lighting_mode::COCKPIT;
+
 	gr_reset_clip();
 
 	//Deal with the model
@@ -7525,6 +7527,8 @@ void ship_render_player_ship(object* objp) {
 		gr_reset_lighting();
 		gr_set_lighting();
 	}
+
+	Lighting_mode = lighting_mode::NORMAL;
 
 	gr_end_view_matrix();
 	gr_end_proj_matrix();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7451,12 +7451,12 @@ void ship_render_player_ship(object* objp) {
 
 		shadows_start_render(&eye_orient, &leaning_position, Proj_fov, gr_screen.clip_aspect, std::get<0>(Shadow_distances_cockpit), std::get<1>(Shadow_distances_cockpit), std::get<2>(Shadow_distances_cockpit), std::get<3>(Shadow_distances_cockpit));
 
-		if (deferredRenderShipModel) {
+		if (deferredRenderShipModel && Show_ship_casts_shadow) {
 			model_render_params shadow_render_info;
 			shadow_render_info.set_detail_level_lock(0);
 			shadow_render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING);
 			shadow_render_info.set_object_number(OBJ_INDEX(objp));
-			//model_render_immediate(&shadow_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset);
+			model_render_immediate(&shadow_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset);
 		}
 		if (renderCockpitModel) {
 			model_render_params shadow_render_info;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7380,7 +7380,7 @@ void ship_render_player_ship(object* objp) {
 	ship* shipp = &Ships[objp->instance];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
 
-	const bool hasCockpitModel = sip->cockpit_model_num > 0;
+	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
 
 	const bool renderCockpitModel = Viewer_mode != VM_TOPDOWN && hasCockpitModel;
 	const bool renderShipModel = (sip->flags[Ship::Info_Flags::Show_ship_model])

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7451,10 +7451,11 @@ void ship_render_player_ship(object* objp) {
 
 		shadows_start_render(&eye_orient, &leaning_position, Proj_fov, gr_screen.clip_aspect, std::get<0>(Shadow_distances_cockpit), std::get<1>(Shadow_distances_cockpit), std::get<2>(Shadow_distances_cockpit), std::get<3>(Shadow_distances_cockpit));
 
-		if (deferredRenderShipModel && Show_ship_casts_shadow) {
+		if (deferredRenderShipModel) {
 			model_render_params shadow_render_info;
 			shadow_render_info.set_detail_level_lock(0);
-			shadow_render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING);
+			//If we just want to recieve, we still have to write to the color buffer but not to the zbuffer, otherwise shadow recieving breaks
+			shadow_render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING | (Show_ship_casts_shadow ? 0 : MR_NO_ZBUFFER));
 			shadow_render_info.set_object_number(OBJ_INDEX(objp));
 			model_render_immediate(&shadow_render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset);
 		}
@@ -7462,6 +7463,7 @@ void ship_render_player_ship(object* objp) {
 			model_render_params shadow_render_info;
 			shadow_render_info.set_detail_level_lock(0);
 			shadow_render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING);
+			shadow_render_info.set_object_number(OBJ_INDEX(objp));
 			vec3d offset = sip->cockpit_offset;
 			vm_vec_unrotate(&offset, &offset, &objp->orient);
 			model_render_immediate(&shadow_render_info, sip->cockpit_model_num, &objp->orient, &offset);
@@ -7497,6 +7499,7 @@ void ship_render_player_ship(object* objp) {
 			render_info.set_team_color(shipp->team_name, shipp->secondary_team_name, 0, 0);
 
 		model_render_immediate(&render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset);
+		gr_zbuffer_clear(true);
 	}
 	if (renderCockpitModel) {
 		model_render_params render_info;
@@ -7505,7 +7508,6 @@ void ship_render_player_ship(object* objp) {
 		render_info.set_replacement_textures(Player_cockpit_textures);
 		vec3d offset = sip->cockpit_offset;
 		vm_vec_unrotate(&offset, &offset, &objp->orient);
-
 		model_render_immediate(&render_info, sip->cockpit_model_num, &objp->orient, &offset);
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7391,7 +7391,9 @@ void ship_render_player_ship(object* objp) {
 	if (!(renderCockpitModel || renderShipModel))
 		return;
 
-	//If we aren't sure whether cockpits and external models can share the same worldspace, we need to pre-render the external ship hull without shadows / deferred and give the cockpit precedence, unless this ship has no cockpit at all
+	//If we aren't sure whether cockpits and external models can share the same worldspace,
+	//we need to pre-render the external ship hull without shadows / deferred and give the cockpit precedence,
+	//unless this ship has no cockpit at all
 	const bool prerenderShipModel = renderShipModel && hasCockpitModel && !Cockpit_shares_coordinate_space;
 	const bool deferredRenderShipModel = renderShipModel && !prerenderShipModel;
 
@@ -7429,8 +7431,9 @@ void ship_render_player_ship(object* objp) {
 		gr_post_process_restore_zbuffer();
 	}
 
-	//We only needed to prerender the ship model. This can occur if the cockpit isn't rendered for some reason but a model exists.
-	//In this case, we still want to not render the ship model with deferred rendering to keep visuals constant for the ship
+	//We only needed to prerender the ship model. This can occur if the cockpit isn't
+	//rendered for some reason but a model exists. In this case, we still want to not
+	//render the ship model with deferred rendering to keep visuals constant for the ship
 	if (!renderCockpitModel && !deferredRenderShipModel) {
 		Proj_fov = fov_backup;
 		return;
@@ -7451,7 +7454,11 @@ void ship_render_player_ship(object* objp) {
 		gr_reset_clip();
 		Shadow_override = false;
 
-		shadows_start_render(&eye_orient, &leaning_position, Proj_fov, gr_screen.clip_aspect, std::get<0>(Shadow_distances_cockpit), std::get<1>(Shadow_distances_cockpit), std::get<2>(Shadow_distances_cockpit), std::get<3>(Shadow_distances_cockpit));
+		shadows_start_render(&eye_orient, &leaning_position, Proj_fov, gr_screen.clip_aspect,
+			std::get<0>(Shadow_distances_cockpit),
+			std::get<1>(Shadow_distances_cockpit),
+			std::get<2>(Shadow_distances_cockpit),
+			std::get<3>(Shadow_distances_cockpit));
 
 		if (deferredRenderShipModel) {
 			model_render_params shadow_render_info;
@@ -13949,8 +13956,8 @@ void ship_get_eye_local(vec3d* eye_pos, matrix* eye_orient, object* obj, bool do
 		return;
 	}
 
-	// eye points are stored in an array -- the normal viewing position for a ship is the current_eye_index
-	// element.
+	// eye points are stored in an array -- the normal viewing position for a ship is
+	// the current_eye_index element.
 	eye* ep = &(pm->view_positions[shipp->current_viewpoint]);
 
 	if (ep->parent >= 0 && pm->submodel[ep->parent].flags[Model::Submodel_flags::Can_move]) {
@@ -13961,7 +13968,7 @@ void ship_get_eye_local(vec3d* eye_pos, matrix* eye_orient, object* obj, bool do
 		*eye_orient = obj->orient;
 	}
 
-	//	Modify the orientation based on head orientation.
+	// Modify the orientation based on head orientation.
 	if (Viewer_obj == obj && do_slew) {
 		// Add the cockpit leaning translation offset
 		vm_vec_add2(eye_pos, &leaning_position);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1590,8 +1590,6 @@ extern void change_ship_type(int n, int ship_type, int by_sexp = 0);
 extern void ship_process_pre( object * objp, float frametime );
 extern void ship_process_post( object * objp, float frametime );
 extern void ship_render( object * obj, model_draw_list * scene );
-extern void ship_render_cockpit( object * objp);
-extern void ship_render_show_ship_cockpit( object * objp);
 extern void ship_render_player_ship( object * objp);
 extern void ship_delete( object * objp );
 extern int ship_check_collision_fast( object * obj, object * other_obj, vec3d * hitpos );

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1592,6 +1592,7 @@ extern void ship_process_post( object * objp, float frametime );
 extern void ship_render( object * obj, model_draw_list * scene );
 extern void ship_render_cockpit( object * objp);
 extern void ship_render_show_ship_cockpit( object * objp);
+extern void ship_render_player_ship( object * objp);
 extern void ship_delete( object * objp );
 extern int ship_check_collision_fast( object * obj, object * other_obj, vec3d * hitpos );
 extern int ship_get_num_ships();
@@ -1706,6 +1707,7 @@ extern int ship_find_num_turrets(object *objp);
 
 extern void compute_slew_matrix(matrix *orient, angles *a);
 extern void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew = true, bool from_origin = false);		// returns in eye the correct viewing position for the given object
+extern void ship_get_eye_local(vec3d* eye_pos, matrix* eye_orient, object* obj, bool do_slew = true);		// returns the eye data, local to the ship
 
 extern ship_subsys *ship_find_first_subsys(ship *sp, int subsys_type, vec3d *attacker_pos = nullptr);
 extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns index'th subsystem of this ship


### PR DESCRIPTION
The first followup to #3445.
This removes the two different functions for external ship model and cockpit rendering, and instead fuses them into one function.
Apart from the evidently higher maintainability, this has a few advantages:
1. Due to the shipmodel now being in the deferred cockpit pass, ship model and cockpit can shadow one another
2. The external ship model is now also rendered deferred at no additional cost.
3. The external ship model is rendered, like the cockpit, with a 0,0,0 view matrix which avoids the stuttering issues observed for close models like show ship / cockpit when far from the origin.
4. It allows for finer control over the relation between cockpit and show ship model as well as their render settings