### PR TITLE
convert strncpy to strncpy_s

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -607,8 +607,7 @@ void parse_ai_profiles_tbl(const char *filename)
 				if (saved_Mp && (saved_Mp == Mp))
 				{
 					char tmp[60];
-					memset(tmp, 0, 60);
-					strncpy(tmp, Mp, 59);
+					strncpy_s(tmp, Mp, 59);
 					mprintf(("WARNING: Unrecognized parameter in ai_profiles: %s\n", tmp));
 
 					Mp++;

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1137,8 +1137,7 @@ int bm_load(const char *real_filename, int dir_type) {
 		return -1;
 
 	// make sure no one passed an extension
-	memset(filename, 0, MAX_FILENAME_LEN);
-	strncpy(filename, real_filename, MAX_FILENAME_LEN - 1);
+	strncpy_s(filename, real_filename, MAX_FILENAME_LEN - 1);
 	char *p = strrchr(filename, '.');
 	if (p) {
 		mprintf(("Someone passed an extension to bm_load for file '%s'\n", real_filename));
@@ -1452,8 +1451,7 @@ int bm_load_animation(const char *real_filename, int *nframes, int *fps, int *ke
 	if (total_time != nullptr)
 		*total_time = 0.0f;
 
-	memset(filename, 0, MAX_FILENAME_LEN);
-	strncpy(filename, real_filename, MAX_FILENAME_LEN - 1);
+	strncpy_s(filename, real_filename, MAX_FILENAME_LEN - 1);
 	char *p = strchr(filename, '.');
 	if (p) {
 		mprintf(("Someone passed an extension to bm_load_animation for file '%s'\n", real_filename));

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -101,7 +101,7 @@ void camera::reset()
 void camera::set_name(const char *in_name)
 {
 	if(in_name != NULL)
-		strncpy(name, in_name, NAME_LENGTH-1);
+		strncpy_s(name, in_name, NAME_LENGTH-1);
 }
 
 void camera::set_fov(float in_fov, float in_fov_time, float in_fov_acceleration_time, float in_fov_deceleration_time)
@@ -700,7 +700,7 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 		image_id = bm_load(in_imageanim);
 
 		if (image_id >= 0)
-			strncpy(imageanim, in_imageanim, sizeof(imageanim) - 1);
+			strncpy_s(imageanim, in_imageanim, MAX_FILENAME_LEN - 1);
 	}
 
 	//Setup pos
@@ -1032,11 +1032,11 @@ camid cam_create(const char *n_name, vec3d *n_pos, matrix *n_ori, object *n_obje
 	int sig = cam_get_next_sig();
 
 	//Get name
-	char buf[NAME_LENGTH] = {'\0'};
+	char buf[NAME_LENGTH];
 	if(n_name == NULL)
 		sprintf(buf, "Camera %d", cid.getSignature());
 	else
-		strncpy(buf, n_name, NAME_LENGTH-1);
+		strncpy_s(buf, n_name, NAME_LENGTH-1);
 
 	//Find a free slot
 	cam = new camera(buf, sig);

--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -198,9 +198,7 @@ int cfile_init(const char *exe_dir, const char *cdrom_dir)
 	}
 
 	char buf[CFILE_ROOT_DIRECTORY_LEN];
-
-	strncpy(buf, exe_dir, CFILE_ROOT_DIRECTORY_LEN - 1);
-	buf[CFILE_ROOT_DIRECTORY_LEN - 1] = '\0';
+	strncpy_s(buf, exe_dir, CFILE_ROOT_DIRECTORY_LEN - 1);
 
 	// are we in a root directory?		
 	if(cfile_in_root_dir(buf)){

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -1940,7 +1940,7 @@ int cf_get_file_list_preallocated(int max, char arr[][MAX_FILENAME_LEN], char** 
 
 				//mprintf(( "Found '%s' in root %d path %d\n", f->name_ext, f->root_index, f->pathtype_index ));
 
-				strncpy(arr[num_files], f->name_ext.c_str(), MAX_FILENAME_LEN - 1 );
+				strncpy_s(arr[num_files], f->name_ext.c_str(), MAX_FILENAME_LEN - 1);
 				char *ptr = strrchr(arr[num_files], '.');
 				if ( ptr ) {
 					*ptr = 0;

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2334,8 +2334,8 @@ void control_config_do_frame(float frametime)
 		}
 
 		// setup the conflict string
-		char conflict_str[512] = "";
-		strncpy(conflict_str, XSTR("Conflict!", 205), 511);
+		char conflict_str[64] = "";
+		strncpy_s(conflict_str, XSTR("Conflict!", 205), 63);
 		int sw, sh;
 		gr_get_string_size(&sw, &sh, conflict_str);
 

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -112,7 +112,7 @@ void fireball_play_warphole_close_sound(fireball *fb)
 	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius); // play warp sound effect
 }
 
-static void fireball_generate_unique_id(char *unique_id, int buffer_len, int fireball_index)
+static void fireball_generate_unique_id(char *unique_id, int buffer_size, int fireball_index)
 {
 	Assert((fireball_index >= 0) && (fireball_index < MAX_FIREBALL_TYPES));
 
@@ -120,37 +120,34 @@ static void fireball_generate_unique_id(char *unique_id, int buffer_len, int fir
 	{
 		// use sensible names for the fireball.tbl default entries
 		case FIREBALL_EXPLOSION_MEDIUM:
-			strncpy(unique_id, "Medium Explosion", buffer_len);
+			strncpy_s(unique_id, buffer_size, "Medium Explosion", buffer_size - 1);
 			break;
 
 		case FIREBALL_WARP:
-			strncpy(unique_id, "Warp Effect", buffer_len);
+			strncpy_s(unique_id, buffer_size, "Warp Effect", buffer_size - 1);
 			break;
 
 		case FIREBALL_KNOSSOS:
-			strncpy(unique_id, "Knossos Effect", buffer_len);
+			strncpy_s(unique_id, buffer_size, "Knossos Effect", buffer_size - 1);
 			break;
 
 		case FIREBALL_ASTEROID:
-			strncpy(unique_id, "Asteroid Explosion", buffer_len);
+			strncpy_s(unique_id, buffer_size, "Asteroid Explosion", buffer_size - 1);
 			break;
 
 		case FIREBALL_EXPLOSION_LARGE1:
-			strncpy(unique_id, "Large Explosion 1", buffer_len);
+			strncpy_s(unique_id, buffer_size, "Large Explosion 1", buffer_size - 1);
 			break;
 
 		case FIREBALL_EXPLOSION_LARGE2:
-			strncpy(unique_id, "Large Explosion 2", buffer_len);
+			strncpy_s(unique_id, buffer_size, "Large Explosion 2", buffer_size - 1);
 			break;
 
 		// base the id on the index
 		default:
-			snprintf(unique_id, buffer_len, "Custom Fireball %d", fireball_index - NUM_DEFAULT_FIREBALLS + 1);
+			snprintf(unique_id, buffer_size, "Custom Fireball %d", fireball_index - NUM_DEFAULT_FIREBALLS + 1);
 			break;
 	}
-
-	// null-terminate
-	unique_id[buffer_len - 1] = '\0';
 }
 
 /**

--- a/code/globalincs/safe_strings.h
+++ b/code/globalincs/safe_strings.h
@@ -51,18 +51,24 @@ typedef int errno_t;
 extern errno_t scp_strcpy_s( const char* file, int line, char* strDest, size_t sizeInBytes, const char* strSource );
 extern errno_t scp_strcat_s( const char* file, int line, char* strDest, size_t sizeInBytes, const char* strSource );
 
-template< size_t size>
+template< size_t size >
 inline
 errno_t scp_strcpy_s( const char* file, int line, char (&strDest)[ size ], const char* strSource )
 {
 	return scp_strcpy_s( file, line, strDest, size, strSource );
 }
 
-template< size_t size>
+template< size_t size >
 inline
-errno_t scp_strncpy_s(const char* file, int line, char(&strDest)[size], const char* strSource, size_t count)
+errno_t scp_strncpy_s( const char* file, int line, char(&strDest)[size], const char* strSource, size_t count )
 {
-	return scp_strcpy_s(file, line, strDest, MIN(size, count), strSource);
+	return scp_strcpy_s( file, line, strDest, MIN(size, count), strSource );
+}
+
+inline
+errno_t scp_strncpy_s( const char* file, int line, char* strDest, size_t size, const char* strSource, size_t count )
+{
+	return scp_strcpy_s( file, line, strDest, MIN(size, count), strSource );
 }
 
 template< size_t size >
@@ -81,8 +87,15 @@ errno_t scp_strcat_s( const char* file, int line, char (&strDest)[ size ], const
 #pragma message("safe_strings disabled - this is not good!")
 
 inline errno_t strcpy_s( char* strDest, size_t sizeInBytes, const char* strSource )
-{ 
+{
 	strcpy( strDest, strSource ); 
+	return 0;
+}
+
+inline errno_t strncpy_s( char* strDest, size_t sizeInBytes, const char* strSource, size_t count )
+{
+	strncpy( strDest, strSource, count );
+	strDest[count] = '\0';
 	return 0;
 }
 
@@ -93,13 +106,13 @@ inline errno_t strcat_s( char* strDest, size_t sizeInBytes, const char* strSourc
 }
 
 inline errno_t strcpy_s( char* strDest, const char* strSource )
-{ 
+{
 	strcpy( strDest, strSource );
 	return 0;
 }
 
 inline errno_t strcat_s( char* strDest, const char* strSource )
-{ 
+{
 	strcat( strDest, strSource ); 
 	return 0;
 }

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -126,7 +126,7 @@ void generic_bitmap_init(generic_bitmap *gb, const char *filename)
 	if (filename == NULL) {
 		gb->filename[0] = '\0';
 	} else {
-		strncpy(gb->filename, filename, MAX_FILENAME_LEN - 1);
+		strncpy_s(gb->filename, filename, MAX_FILENAME_LEN - 1);
 	}
 
 	gb->bitmap_id = -1;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2480,7 +2480,7 @@ void hud_start_text_flash(const char *txt, int t, int interval)
 		if(!stricmp(Hud_text_flash, XSTR("Emp", 1670)) || !stricmp(txt, XSTR("Launch", 1507)))
 			return;
 
-	strncpy(Hud_text_flash, txt, 500);
+	strncpy_s(Hud_text_flash, txt, 511);
 	Hud_text_flash_timer = timestamp(t);
 	Hud_text_flash_interval = interval;
 }

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -1253,14 +1253,14 @@ int player_select_pilot_file_filter(const char *filename)
 void player_select_set_bottom_text(const char *txt)
 {
 	if (txt) {
-		strncpy(Player_select_bottom_text, txt, 149);
+		strncpy_s(Player_select_bottom_text, txt, 149);
 	}
 }
 
 void player_select_set_middle_text(const char *txt)
 {
 	if (txt) {
-		strncpy(Player_select_middle_text, txt, 149);
+		strncpy_s(Player_select_middle_text, txt, 149);
 	}
 }
 

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -822,7 +822,7 @@ void techroom_change_tab(int num)
 						temp_entry.desc = wi.tech_desc;
 						temp_entry.name = wi.tech_title[0] ? wi.tech_title : wi.get_display_name();
 						// copy the weapon animation filename
-						strncpy(temp_entry.tech_anim_filename, wi.tech_anim_filename, MAX_FILENAME_LEN - 1);
+						strncpy_s(temp_entry.tech_anim_filename, wi.tech_anim_filename, MAX_FILENAME_LEN - 1);
 						
 						Weapon_list.push_back(temp_entry);
 					}
@@ -865,7 +865,7 @@ void techroom_change_tab(int num)
 						} else {
 							// try and load as an animation
 							temp_entry.bitmap = -1;
-							strncpy(temp_entry.tech_anim_filename, ii.anim_filename, NAME_LENGTH - 1);
+							strncpy_s(temp_entry.tech_anim_filename, ii.anim_filename, NAME_LENGTH - 1);
 						}
 
 						temp_entry.desc = ii.desc.c_str();

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -106,7 +106,7 @@ int mission_campaign_get_info(const char *filename, char *name, int *type, int *
 	Assert( name != NULL );
 	Assert( type != NULL );
 
-	strncpy(fname, filename, MAX_FILENAME_LEN - 1);
+	strncpy_s(fname, filename, MAX_FILENAME_LEN - 1);
 	auto fname_len = strlen(fname);
 	if ((fname_len < 4) || stricmp(fname + fname_len - 4, FS_CAMPAIGN_FILE_EXT) != 0){
 		strcat_s(fname, FS_CAMPAIGN_FILE_EXT);

--- a/code/mission/missionload.cpp
+++ b/code/mission/missionload.cpp
@@ -104,7 +104,7 @@ bool mission_load(const char* filename_ext)
 	char filename[MAX_PATH_LEN], *ext;
 
 	if ( (filename_ext != NULL) && (Game_current_mission_filename != filename_ext) )
-		strncpy(Game_current_mission_filename, filename_ext, MAX_FILENAME_LEN-1);
+		strncpy_s(Game_current_mission_filename, filename_ext, MAX_FILENAME_LEN-1);
 
 	mprintf(("MISSION LOAD: '%s'\n", filename_ext));
 	events::GameMissionLoad(filename_ext);
@@ -340,12 +340,12 @@ void mission_load_menu_do()
 		}
 	}
 
-	char mission_name_final[512] = "";
+	char mission_name_final[MAX_FILENAME_LEN];
 
 	if ( selected > -1  )	{
 		Campaign.current_mission = -1;
 		if ( use_recent_flag ) {
-			strncpy( mission_name_final, recent_missions[selected], MAX_FILENAME_LEN );
+			strncpy_s( mission_name_final, recent_missions[selected], MAX_FILENAME_LEN-1 );
 		} else {
 			char mission_name[NAME_LENGTH];
 			if ( Campaign_filter_index == 0 )	{
@@ -355,7 +355,7 @@ void mission_load_menu_do()
 			} else {
 				strcpy_s(mission_name, Campaign_missions[selected]);
 			}
-			strncpy( mission_name_final, mission_name, MAX_FILENAME_LEN );
+			strncpy_s( mission_name_final, mission_name, MAX_FILENAME_LEN-1 );
 		}
 
 		// go

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -858,7 +858,7 @@ void message_log_init_scrollback(int pw)
 				Assert(!(entry->index & CARGO_NO_DEPLETE));
 
 				message_log_add_segs(XSTR( "Cargo revealed: ", 418), LOG_COLOR_NORMAL);
-				strncpy(text, Cargo_names[entry->index], sizeof(text) - 1);
+				strncpy_s(text, Cargo_names[entry->index], 255);
 				message_log_add_segs( text, LOG_COLOR_BRIGHT );
 				break;
 
@@ -868,7 +868,7 @@ void message_log_init_scrollback(int pw)
 
 				message_log_add_segs(entry->sname_display.c_str(), LOG_COLOR_NORMAL);
 				message_log_add_segs(XSTR( " subsystem cargo revealed: ", 1488), LOG_COLOR_NORMAL);
-				strncpy(text, Cargo_names[entry->index], sizeof(text) - 1);
+				strncpy_s(text, Cargo_names[entry->index], 255);
 				message_log_add_segs( text, LOG_COLOR_BRIGHT );
 				break;
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6389,10 +6389,8 @@ bool post_process_mission()
 
 int get_mission_info(const char *filename, mission *mission_p, bool basic)
 {
-	char real_fname[MAX_FILENAME_LEN];
-	
-	strncpy(real_fname, filename, MAX_FILENAME_LEN-1);
-	real_fname[sizeof(real_fname)-1] = '\0';
+	char real_fname[MAX_FILENAME_LEN];	
+	strncpy_s(real_fname, filename, MAX_FILENAME_LEN-1);
 	
 	char *p = strrchr(real_fname, '.');
 	if (p) *p = 0; // remove any extension

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1242,9 +1242,9 @@ void brief_render(float frametime)
 	gr_set_color_fast(&Color_bright_white);
 
 	if (Game_mode & GM_MULTIPLAYER) {
-		char buf[256];
-		strncpy(buf, The_mission.name, 256);
-		font::force_fit_string(buf, 255, Title_coords_multi[gr_screen.res][2]);
+		char buf[NAME_LENGTH];
+		strcpy_s(buf, The_mission.name);
+		font::force_fit_string(buf, NAME_LENGTH - 1, Title_coords_multi[gr_screen.res][2]);
 		gr_string(Title_coords_multi[gr_screen.res][0], Title_coords_multi[gr_screen.res][1], buf, GR_RESIZE_MENU);
 	} else {
 		gr_get_string_size(&w, NULL, The_mission.name);

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -939,16 +939,14 @@ void debrief_choose_voice(char *voice_dest, size_t buf_size, char *voice_base, i
 	// use the base file; don't prepend anything to it
 	if (default_to_base)
 	{
-		strncpy(voice_dest, voice_base, buf_size);
+		strcpy_s(voice_dest, buf_size, voice_base);
 	}
 	// default to Petrarch
 	else
 	{
-		strncpy(voice_dest, "9_", buf_size);
-		strncat(voice_dest, voice_base, buf_size-2);
+		strcpy_s(voice_dest, buf_size, "9_");
+		strcat_s(voice_dest, buf_size-2, voice_base);
 	}
-	// Ensure null terminator
-	voice_dest[buf_size-1] = '\0';
 }
 
 void debrief_choose_medal_variant(char *buf, int medal_earned, int zero_based_version_index)

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -1102,7 +1102,7 @@ namespace animation {
 
 	SCP_string anim_name_from_subsys(model_subsystem* ss) {
 		char namelower[MAX_NAME_LEN];
-		strncpy(namelower, ss->subobj_name, MAX_NAME_LEN);
+		strncpy_s(namelower, ss->subobj_name, MAX_NAME_LEN-1);
 		strlwr(namelower);
 		return namelower;
 	}
@@ -1444,8 +1444,9 @@ namespace animation {
 			auto anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(true));
 
 			char namelower[MAX_NAME_LEN];
-			strncpy(namelower, sp->subobj_name, MAX_NAME_LEN);
+			strncpy_s(namelower, sp->subobj_name, MAX_NAME_LEN-1);
 			strlwr(namelower);
+
 			//since sp->type is not set without reading the pof, we need to infer it by subsystem name (which works, since the same name is used to match the submodels name, which is used to match the type in pof parsing)
 			//sadly, we also need to check for engine and radar, since these take precedent (as in, an engineturret is an engine before a turret type)
 			if (!strstr(namelower, "engine") && !strstr(namelower, "radar") && strstr(namelower, "turret")) {

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5697,7 +5697,7 @@ void parse_glowpoint_table(const char *filename)
 					}
 
 					char glow_texture_neb_name[256];
-					strncpy(glow_texture_neb_name, glow_texture_name, 256);
+					strncpy_s(glow_texture_neb_name, glow_texture_name, 255);
 					strcat(glow_texture_neb_name, "-neb");
 					gpo.glow_neb_bitmap = bm_load(glow_texture_neb_name);
 

--- a/code/network/chat_api.cpp
+++ b/code/network/chat_api.cpp
@@ -39,7 +39,7 @@ SOCKET Chatsock = INVALID_SOCKET;
 static SOCKADDR_STORAGE Chataddr;
 int Socket_connecting = 0;
 char Nick_name[33];
-char Orignial_nick_name[33];
+char Original_nick_name[33];
 int Nick_variety = 0;
 char szChat_channel[33] = "";
 char Input_chat_buffer[MAXCHATBUFFER] = "";
@@ -68,7 +68,7 @@ void ChatInit(void)
 {
 	Socket_connecting = 0;
 	memset(Nick_name, 0, sizeof(Nick_name));
-	memset(Orignial_nick_name, 0, sizeof(Orignial_nick_name));
+	memset(Original_nick_name, 0, sizeof(Original_nick_name));
 	Nick_variety = 0;
 	memset(szChat_channel, 0, sizeof(szChat_channel));
 	memset(Input_chat_buffer, 0, sizeof(Input_chat_buffer));
@@ -111,9 +111,9 @@ int ConnectToChatServer(char *serveraddr, char *nickname, char *trackerid)
 
 	if(!Socket_connecting)
 	{
-		strncpy(Nick_name, nickname, sizeof(Nick_name)-1);
-		strncpy(Orignial_nick_name, nickname, sizeof(Orignial_nick_name)-1);
-		strncpy(Chat_tracker_id, trackerid, sizeof(Chat_tracker_id)-1);
+		strncpy_s(Nick_name, nickname, sizeof(Nick_name)-1);
+		strncpy_s(Original_nick_name, nickname, sizeof(Original_nick_name)-1);
+		strncpy_s(Chat_tracker_id, trackerid, sizeof(Chat_tracker_id)-1);
 		
 		Firstuser = NULL;
 		Firstcommand = NULL;
@@ -127,9 +127,7 @@ int ConnectToChatServer(char *serveraddr, char *nickname, char *trackerid)
 			return -1;
 		}
 
-		memset(chat_server, 0, sizeof(chat_server));
-		strncpy(chat_server,serveraddr,(p-serveraddr));
-		chat_server[p-serveraddr] = '\0';
+		strncpy_s(chat_server,serveraddr,(p-serveraddr));
 		chat_port = static_cast<uint16_t>(atoi(p+1));
 		if(0==chat_port)
 		{
@@ -308,17 +306,13 @@ const char * SendChatString(const char *line,int raw)
 	char szTarget[50];
 	if(!Socket_connected) return NULL;
 
-	szCmd[sizeof(szCmd)-1] = '\0';
-	szTarget[sizeof(szTarget)-1] = '\0';
-
 	if(line[0]=='/')
 	{
-		
 		//Start off by getting the command
-		strncpy(szCmd, GetWordNum(0, line+1), sizeof(szCmd)-1);
+		strncpy_s(szCmd, GetWordNum(0, line+1), sizeof(szCmd)-1);
 		if(stricmp(szCmd,NOX("msg"))==0)
 		{
-			strncpy(szTarget, GetWordNum(1, line+1), sizeof(szTarget)-1);
+			strncpy_s(szTarget, GetWordNum(1, line+1), sizeof(szTarget)-1);
 			sprintf_safe(szCmd, NOX("PRIVMSG %s :%s\n\r"), szTarget, line+strlen(NOX("/msg "))+strlen(szTarget)+1);
 			send(Chatsock,szCmd,(int)strlen(szCmd),0);
 			szCmd[strlen(szCmd)-2] = '\0';
@@ -456,7 +450,7 @@ int SetNewChatChannel(char *channel)
 			sprintf_safe(partstr, NOX("/PART %s"), szChat_channel);
 			SendChatString(partstr,1);
 		}
-		strncpy(szChat_channel, channel, sizeof(szChat_channel)-1);
+		strncpy_s(szChat_channel, channel, sizeof(szChat_channel)-1);
 		sprintf_safe(partstr, NOX("/JOIN %s"), szChat_channel);
 		SendChatString(partstr,1);
 		Joining_channel = 1;
@@ -496,7 +490,7 @@ char *ChatGetString(void)
 					//Blank line, ignore it
 					return NULL;
 				}
-				strncpy(return_string, Input_chat_buffer, sizeof(return_string)-1);
+				strncpy_s(return_string, Input_chat_buffer, sizeof(return_string)-1);
 				Input_chat_buffer[0] = '\0';
 				
 				p = ParseIRCMessage(return_string,MSG_REMOTE);
@@ -525,12 +519,9 @@ const char * GetWordNum(int num, const char * l_String)
 	char seps[10] = NOX(" \n\r\t");
 	char *token,*strstart;
 
-	strreturn[sizeof(strreturn)-1] = '\0';
-	ptokstr[sizeof(ptokstr)-1] = '\0';
-
 	strstart = ptokstr;
 
-	strncpy(ptokstr, l_String, sizeof(ptokstr)-1);
+	strncpy_s(ptokstr, l_String, sizeof(ptokstr)-1);
 
 	token=strtok(ptokstr,seps);
 
@@ -540,7 +531,7 @@ const char * GetWordNum(int num, const char * l_String)
 	}
 	if(token)
 	{
-		strncpy(strreturn, token, sizeof(strreturn)-1);
+		strncpy_s(strreturn, token, sizeof(strreturn)-1);
 	}
 	else
 	{
@@ -550,7 +541,7 @@ const char * GetWordNum(int num, const char * l_String)
 	if(token[0]==':')
 	{
 		//Its not pretty, but it works, return the rest of the string
-		strncpy(strreturn, l_String+((token-strstart)+1), sizeof(strreturn)-1);
+		strncpy_s(strreturn, l_String+((token-strstart)+1), sizeof(strreturn)-1);
 	}
 
 	//return the appropriate response.
@@ -571,7 +562,7 @@ int AddChatUser(const char *nickname)
 	{
 		Firstuser = (Chat_user *)vm_malloc(sizeof(Chat_user));
 		Assert(Firstuser);
-		strncpy(Firstuser->nick_name, nickname, sizeof(Firstuser->nick_name)-1);
+		strncpy_s(Firstuser->nick_name, nickname, sizeof(Firstuser->nick_name)-1);
 		Firstuser->next = NULL;
 		AddChatCommandToQueue(CC_USER_JOINING,nickname,strlen(nickname)+1);
 		return 1;
@@ -585,7 +576,7 @@ int AddChatUser(const char *nickname)
 		Curruser->next = (Chat_user *)vm_malloc(sizeof(Chat_user));
 		Curruser = Curruser->next;
 		Assert(Curruser);
-		strncpy(Curruser->nick_name, nickname, sizeof(Curruser->nick_name)-1);
+		strncpy_s(Curruser->nick_name, nickname, sizeof(Curruser->nick_name)-1);
 		Curruser->next = NULL;
 		AddChatCommandToQueue(CC_USER_JOINING,nickname,strlen(nickname)+1);
 		return 1;
@@ -652,16 +643,6 @@ char * ParseIRCMessage(char *Line, int iMode)
 
 	ptrdiff_t iPrefixLen = 0;	// JAS: Get rid of optimized warning
 
-	szRemLine[MAXLOCALSTRING-1] = '\0';
-	szPrefix[MAXLOCALSTRING-1] = '\0';
-	szHackPrefix[MAXLOCALSTRING-1] = '\0';
-	szTarget[MAXLOCALSTRING-1] = '\0';
-	szNick[MAXLOCALSTRING-1] = '\0';
-	szCmd[MAXLOCALSTRING-1] = '\0';
-	szCTCPCmd[MAXLOCALSTRING-1] = '\0';
-
-	szResponse[MAXLOCALSTRING-1] = '\0';
-
 	if(strlen(Line)>=MAXLOCALSTRING)
 	{
 		return NULL; 
@@ -669,41 +650,40 @@ char * ParseIRCMessage(char *Line, int iMode)
 	//Nick included....
 	if(iMode==MSG_REMOTE)
 	{
-		strncpy(szRemLine, Line, sizeof(szRemLine)-1);
+		strncpy_s(szRemLine, Line, sizeof(szRemLine)-1);
 		//Start by getting the prefix
 		if(Line[0]==':')
 		{
 			//
 			pszTempStr=GetWordNum(0,Line+1);
-			strncpy(szPrefix, pszTempStr, sizeof(szPrefix)-1);
-			strncpy(szHackPrefix, pszTempStr, sizeof(szHackPrefix)-1);
-			strncpy(szRemLine, Line+1+strlen(szPrefix), sizeof(szRemLine)-1);
+			strncpy_s(szPrefix, pszTempStr, sizeof(szPrefix)-1);
+			strncpy_s(szHackPrefix, pszTempStr, sizeof(szHackPrefix)-1);
+			strncpy_s(szRemLine, Line+1+strlen(szPrefix), sizeof(szRemLine)-1);
 		}
 		//Next, get the Nick
 		pszTempStr=strtok(szHackPrefix,"!");
 		if(pszTempStr)
 		{
-			strncpy(szNick, pszTempStr, sizeof(szNick)-1);
+			strncpy_s(szNick, pszTempStr, sizeof(szNick)-1);
 		}
 		else
 		{
-			strncpy(szNick,szPrefix,31);
-         szNick[31]=0;
+			strncpy_s(szNick,szPrefix,31);
 		}
 		iPrefixLen=strlen(szPrefix);
 	}
 	else if(iMode==MSG_LOCAL)
 	{
-		strncpy(szRemLine, Line, sizeof(szRemLine)-1);
-		strncpy(szNick, Nick_name, sizeof(szNick)-1);
-		strncpy(szPrefix, Nick_name, sizeof(szPrefix)-1);
+		strncpy_s(szRemLine, Line, sizeof(szRemLine)-1);
+		strncpy_s(szNick, Nick_name, sizeof(szNick)-1);
+		strncpy_s(szPrefix, Nick_name, sizeof(szPrefix)-1);
 		iPrefixLen=-2;
 	}
 	//Next is the command
 	pszTempStr=GetWordNum(0,szRemLine);
 	if(pszTempStr[0])
 	{
-		strncpy(szCmd, pszTempStr, sizeof(szCmd)-1);
+		strncpy_s(szCmd, pszTempStr, sizeof(szCmd)-1);
 	}
 	else
 	{
@@ -712,28 +692,28 @@ char * ParseIRCMessage(char *Line, int iMode)
 	}
 
 	//Move the szRemLine string up
-	strncpy(szRemLine, Line+iPrefixLen+strlen(szCmd)+2, sizeof(szRemLine)-1);
+	strncpy_s(szRemLine, Line+iPrefixLen+strlen(szCmd)+2, sizeof(szRemLine)-1);
 	//Now parse the commands!
 	if(stricmp(szCmd,NOX("PRIVMSG"))==0)
 	{
 		pszTempStr=GetWordNum(0,szRemLine);
-		strncpy(szTarget, pszTempStr, sizeof(szTarget)-1);
-		strncpy(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4, sizeof(szRemLine)-1);
+		strncpy_s(szTarget, pszTempStr, sizeof(szTarget)-1);
+		strncpy_s(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4, sizeof(szRemLine)-1);
 		if(szRemLine[0]==':')
 		{
-			strncpy(szCTCPCmd, GetWordNum(0,szRemLine+1), sizeof(szCTCPCmd)-1);
+			strncpy_s(szCTCPCmd, GetWordNum(0,szRemLine+1), sizeof(szCTCPCmd)-1);
 			if(szCTCPCmd[strlen(szCTCPCmd)-1]==0x01) szCTCPCmd[strlen(szCTCPCmd)-1]=0x00;
 
 		}
 		else
 		{
-			strncpy(szCTCPCmd, GetWordNum(0,szRemLine), sizeof(szCTCPCmd)-1);
+			strncpy_s(szCTCPCmd, GetWordNum(0,szRemLine), sizeof(szCTCPCmd)-1);
 			if(szCTCPCmd[strlen(szCTCPCmd)-1]==0x01) szCTCPCmd[strlen(szCTCPCmd)-1]=0x00;
 		}
 		if(szCTCPCmd[0]==0x01)
 		{
 			//Handle ctcp message
-			strncpy(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+strlen(szCTCPCmd)+6, sizeof(szRemLine)-1);
+			strncpy_s(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+strlen(szCTCPCmd)+6, sizeof(szRemLine)-1);
 			szRemLine[strlen(szRemLine)-1] = '\0';//null out the ending 0x01
 			if(stricmp(szCTCPCmd+1,NOX("ACTION"))==0)
 			{
@@ -743,7 +723,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 			}
 			if(iMode==MSG_LOCAL)
 			{
-				strncpy(szHackPrefix, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4, sizeof(szHackPrefix)-1);
+				strncpy_s(szHackPrefix, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4, sizeof(szHackPrefix)-1);
 				szRemLine[strlen(szRemLine)-1] = '\0';
 				sprintf_safe(szResponse, NOX("** CTCP %s %s %s"), szTarget, szCTCPCmd+1, szRemLine);
 				return szResponse;
@@ -758,7 +738,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 			{
 				return NULL;
 			}
-			strncpy(szRemLine, 1 + GetWordNum(0,Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4), sizeof(szRemLine)-1);
+			strncpy_s(szRemLine, 1 + GetWordNum(0,Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4), sizeof(szRemLine)-1);
 			szRemLine[strlen(szRemLine)-1] = '\0';
 			sprintf_safe(szResponse, NOX("** CTCP Message from %s (%s)"), szNick, szRemLine);
 			return szResponse;
@@ -804,26 +784,23 @@ char * ParseIRCMessage(char *Line, int iMode)
 
 	if(stricmp(szCmd,NOX("NOTICE"))==0)
 	{
-		
-
 		pszTempStr=GetWordNum(0,szRemLine);
-		strncpy(szTarget, pszTempStr, sizeof(szTarget)-1);
-		strncpy(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4, sizeof(szRemLine)-1);
+		strncpy_s(szTarget, pszTempStr, sizeof(szTarget)-1);
+		strncpy_s(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4, sizeof(szRemLine)-1);
 		if(szRemLine[0]==':')
 		{
-			strncpy(szCTCPCmd, GetWordNum(0,szRemLine+1), sizeof(szCTCPCmd)-1);
+			strncpy_s(szCTCPCmd, GetWordNum(0,szRemLine+1), sizeof(szCTCPCmd)-1);
 			if(szCTCPCmd[strlen(szCTCPCmd)-1]==0x01) szCTCPCmd[strlen(szCTCPCmd)-1]=0x00;
-
 		}
 		else
 		{
-			strncpy(szCTCPCmd, GetWordNum(0,szRemLine), sizeof(szCTCPCmd)-1);
+			strncpy_s(szCTCPCmd, GetWordNum(0,szRemLine), sizeof(szCTCPCmd)-1);
 			if(szCTCPCmd[strlen(szCTCPCmd)-1]==0x01) szCTCPCmd[strlen(szCTCPCmd)-1]=0x00;
 		}
 		if(szCTCPCmd[0]==0x01)
 		{
 			//Handle ctcp message
-			strncpy(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+strlen(szCTCPCmd)+6, sizeof(szRemLine)-1);
+			strncpy_s(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+strlen(szCTCPCmd)+6, sizeof(szRemLine)-1);
 			szRemLine[strlen(szRemLine)-1] = '\0';//null out the ending 0x01
 			if(stricmp(szCTCPCmd+1,NOX("PING"))==0)
 			{
@@ -831,7 +808,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 			}
 			
 			//Default message
-			strncpy(szRemLine, 1 + GetWordNum(0,Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4), sizeof(szRemLine)-1);
+			strncpy_s(szRemLine, 1 + GetWordNum(0,Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+4), sizeof(szRemLine)-1);
 			szRemLine[strlen(szRemLine)-1] = '\0';
 			sprintf_safe(szResponse, XSTR("** CTCP Message from %s (%s)", 635), szNick, szRemLine);
 			return szResponse;
@@ -848,14 +825,14 @@ char * ParseIRCMessage(char *Line, int iMode)
 			Joined_channel = 1;
 			if(stricmp(szChat_channel,NOX("#autoselect"))==0)
 			{
-				strncpy(szChat_channel, GetWordNum(0,szRemLine), sizeof(szChat_channel)-1);
+				strncpy_s(szChat_channel, GetWordNum(0,szRemLine), sizeof(szChat_channel)-1);
 				AddChatCommandToQueue(CC_YOURCHANNEL,szChat_channel,strlen(szChat_channel)+1);
 
 			}
 		}
 		
 		pszTempStr=GetWordNum(0,szRemLine);
-		strncpy(szTarget, pszTempStr, sizeof(szTarget)-1);
+		strncpy_s(szTarget, pszTempStr, sizeof(szTarget)-1);
 
 		AddChatUser(szNick);
 		sprintf_safe(szResponse, XSTR("** %s has joined %s", 636), szNick, szTarget);
@@ -865,8 +842,8 @@ char * ParseIRCMessage(char *Line, int iMode)
 	if(stricmp(szCmd,NOX("PART"))==0)
 	{
 		pszTempStr=GetWordNum(0,szRemLine);
-		strncpy(szTarget, pszTempStr, sizeof(szTarget)-1);
-		strncpy(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+3, sizeof(szRemLine)-1);
+		strncpy_s(szTarget, pszTempStr, sizeof(szTarget)-1);
+		strncpy_s(szRemLine, Line+iPrefixLen+strlen(szCmd)+strlen(szTarget)+3, sizeof(szRemLine)-1);
 		//see if it is me!
 		if(stricmp(Nick_name,szNick)==0)
 		{
@@ -880,9 +857,9 @@ char * ParseIRCMessage(char *Line, int iMode)
 	if(stricmp(szCmd,NOX("KICK"))==0)
 	{
 		pszTempStr=GetWordNum(0,szRemLine);
-		strncpy(szTarget, pszTempStr, sizeof(szTarget)-1);
+		strncpy_s(szTarget, pszTempStr, sizeof(szTarget)-1);
 		pszTempStr=GetWordNum(1,szRemLine);
-		strncpy(szHackPrefix, pszTempStr, sizeof(szHackPrefix)-1);
+		strncpy_s(szHackPrefix, pszTempStr, sizeof(szHackPrefix)-1);
 		pszTempStr=GetWordNum(2,szRemLine);
 		//see if it is me!
 		if(stricmp(Nick_name,GetWordNum(1,szRemLine))==0)
@@ -904,7 +881,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 		if(stricmp(Nick_name,szNick)==0)
 		{
 			//Yup, it's me!
-			strncpy(Nick_name, GetWordNum(0,szRemLine), sizeof(Nick_name)-1);
+			strncpy_s(Nick_name, GetWordNum(0,szRemLine), sizeof(Nick_name)-1);
 		}
 		char nicks[70];
 		sprintf_safe(nicks, "%s %s", szNick, GetWordNum(0, szRemLine));
@@ -939,8 +916,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 	{
 		//This is whois user info, we can get their tracker info from here.  -5
 		char szWhoisUser[33];
-		memset(szWhoisUser, 0, sizeof(szWhoisUser));
-		strncpy(szWhoisUser, GetWordNum(1,szRemLine), sizeof(szWhoisUser)-1);
+		strncpy_s(szWhoisUser, GetWordNum(1,szRemLine), sizeof(szWhoisUser)-1);
 		Getting_user_tracker_error = 1;			
 		Getting_user_channel_error = 1;
 
@@ -951,19 +927,17 @@ char * ParseIRCMessage(char *Line, int iMode)
 	if(stricmp(szCmd,"311")==0)
 	{
 		char szWhoisUser[33];
-		memset(szWhoisUser, 0, sizeof(szWhoisUser));
-		strncpy(szWhoisUser, GetWordNum(1,szRemLine), sizeof(szWhoisUser)-1);
+		strncpy_s(szWhoisUser, GetWordNum(1,szRemLine), sizeof(szWhoisUser)-1);
 		//This is whois user info, we can get their tracker info from here.  -5
-		strncpy(User_req_tracker_id, GetWordNum(5,szRemLine), sizeof(User_req_tracker_id)-1);
+		strncpy_s(User_req_tracker_id, GetWordNum(5,szRemLine), sizeof(User_req_tracker_id)-1);
 		return NULL;
 	}
 	if(stricmp(szCmd,"319")==0)
 	{
 		char szWhoisUser[33];
-		memset(szWhoisUser, 0, sizeof(szWhoisUser));
-		strncpy(szWhoisUser, GetWordNum(1,szRemLine), sizeof(szWhoisUser)-1);
+		strncpy_s(szWhoisUser, GetWordNum(1,szRemLine), sizeof(szWhoisUser)-1);
 		//This is whois channel info -- what channel they are on		-2
-		strncpy(User_req_channel, GetWordNum(2,szRemLine), sizeof(User_req_channel)-1);
+		strncpy_s(User_req_channel, GetWordNum(2,szRemLine), sizeof(User_req_channel)-1);
 		return NULL;
 	}
 	
@@ -991,10 +965,8 @@ char * ParseIRCMessage(char *Line, int iMode)
 		{
 			char channel_list_name[33];
 			char sztopic[200];
-			memset(channel_list_name, 0, sizeof(channel_list_name));
-			memset(sztopic, 0, sizeof(sztopic));
-			strncpy(sztopic, GetWordNum(3,szRemLine), sizeof(sztopic)-1);
-			strncpy(channel_list_name, GetWordNum(1,szRemLine), sizeof(channel_list_name)-1);
+			strncpy_s(sztopic, GetWordNum(3,szRemLine), sizeof(sztopic)-1);
+			strncpy_s(channel_list_name, GetWordNum(1,szRemLine), sizeof(channel_list_name)-1);
 			AddChannel(channel_list_name,(short)atoi(GetWordNum(2,szRemLine)),sztopic);
 		}
 		return NULL;
@@ -1016,7 +988,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 		//Channel Topic, update status bar.
 		if(stricmp(szChat_channel,szTarget)==0)
 		{
-			//strncpy(szChanTopic,GetWordNum(2,szRemLine),70);
+			//strncpy_s(szChanTopic,GetWordNum(2,szRemLine),70);
 		}
 		//sprintf(NewMsg.Message,"*** %s has changed the topic to: %s",szNick,GetWordNum(2,szRemLine));
 
@@ -1027,7 +999,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 		//Channel Topic, update status bar.
 		if(stricmp(szChat_channel,szTarget)==0)
 		{
-			//strncpy(szChanTopic,GetWordNum(1,szRemLine),70);
+			//strncpy_s(szChanTopic,GetWordNum(1,szRemLine),70);
 		}
 		//sprintf(NewMsg.Message,"*** %s has changed the topic to: %s",szNick,GetWordNum(1,szRemLine));
 		return NULL;
@@ -1048,7 +1020,7 @@ char * ParseIRCMessage(char *Line, int iMode)
 		}
 
 		// end of motd
-		strncpy(szResponse, PXO_CHAT_END_OF_MOTD_PREFIX, sizeof(szResponse)-1);
+		strncpy_s(szResponse, PXO_CHAT_END_OF_MOTD_PREFIX, sizeof(szResponse)-1);
 		return szResponse;
 	}
 	if((stricmp(szCmd,"377")==0)||
@@ -1069,10 +1041,9 @@ char * ParseIRCMessage(char *Line, int iMode)
 	}
 	if(stricmp(szCmd,"353")==0)
 	{
-
 		//Names in the channel.
 		pszTempStr = GetWordNum(3,Line+iPrefixLen+strlen(szCmd)+2);
-		strncpy(szRemLine, pszTempStr, sizeof(szRemLine)-1);
+		strncpy_s(szRemLine, pszTempStr, sizeof(szRemLine)-1);
 		pszTempStr = strtok(szRemLine," ");
 
 		while(pszTempStr)
@@ -1119,17 +1090,16 @@ char * ParseIRCMessage(char *Line, int iMode)
 	{
 		//Channel Mode info
 		char new_nick[33];
-		sprintf_safe(new_nick, "%s%d", Orignial_nick_name, Nick_variety);
-		strncpy(Nick_name, new_nick, sizeof(Nick_name)-1);
+		sprintf_safe(new_nick, "%s%d", Original_nick_name, Nick_variety);
+		strncpy_s(Nick_name, new_nick, sizeof(Nick_name)-1);
 		Nick_variety++;
 		sprintf_safe(szResponse, NOX("/NICK %s"), new_nick);
 		SendChatString(szResponse,1);
 		return NULL;
 	}
 	//Default print
-	strncpy(szResponse, Line, sizeof(szResponse)-1);
+	strncpy_s(szResponse, Line, sizeof(szResponse)-1);
 	return NULL;
-
 }
 
 
@@ -1249,8 +1219,8 @@ void AddChannel(char *channel,unsigned short numusers,char *topic)
 	{
 		Firstchannel = (Chat_channel *)vm_malloc(sizeof(Chat_channel));
 		Assert(Firstchannel);
-		strncpy(Firstchannel->channel_name, channel, sizeof(Firstchannel->channel_name)-1);
-		strncpy(Firstchannel->topic, topic, sizeof(Firstchannel->topic)-1);
+		strncpy_s(Firstchannel->channel_name, channel, sizeof(Firstchannel->channel_name)-1);
+		strncpy_s(Firstchannel->topic, topic, sizeof(Firstchannel->topic)-1);
 		Firstchannel->users = numusers;
 		Firstchannel->next = NULL;
 		Currchannel = Firstchannel;
@@ -1264,8 +1234,8 @@ void AddChannel(char *channel,unsigned short numusers,char *topic)
 		Currchannel->next = (Chat_channel *)vm_malloc(sizeof(Chat_channel));
 		Assert(Currchannel->next);
 		Currchannel = Currchannel->next;
-		strncpy(Currchannel->channel_name, channel, sizeof(Currchannel->channel_name)-1);
-		strncpy(Currchannel->topic, topic, sizeof(Currchannel->topic)-1);
+		strncpy_s(Currchannel->channel_name, channel, sizeof(Currchannel->channel_name)-1);
+		strncpy_s(Currchannel->topic, topic, sizeof(Currchannel->topic)-1);
 		Currchannel->users = numusers;
 	}
 	Currchannel->next = NULL;
@@ -1276,7 +1246,6 @@ void AddChannel(char *channel,unsigned short numusers,char *topic)
 char *GetTrackerIdByUser(char *nickname)
 {
 	char szWhoisCmd[100];
-
 	
 	if(GettingUserTID)
 	{
@@ -1296,7 +1265,7 @@ char *GetTrackerIdByUser(char *nickname)
 	}
 	else
 	{
-		strncpy(Getting_user_tracker_info_for, nickname, sizeof(Getting_user_tracker_info_for)-1);
+		strncpy_s(Getting_user_tracker_info_for, nickname, sizeof(Getting_user_tracker_info_for)-1);
 		sprintf_safe(szWhoisCmd, NOX("/WHOIS %s"), nickname);
 		User_req_tracker_id[0] = '\0';
 		SendChatString(szWhoisCmd,1);		
@@ -1326,7 +1295,7 @@ char *GetChannelByUser(char *nickname)
 	}
 	else
 	{
-		strncpy(Getting_user_channel_info_for, nickname, sizeof(Getting_user_channel_info_for)-1);
+		strncpy_s(Getting_user_channel_info_for, nickname, sizeof(Getting_user_channel_info_for)-1);
 		User_req_channel[0] = '\0';
 		sprintf_safe(szWhoisCmd, NOX("/WHOIS %s"), nickname);
 		SendChatString(szWhoisCmd,1);

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -106,14 +106,14 @@ void multi_options_read_config()
 					Multi_options_g.protocol = NET_TCP;
 					NEXT_TOKEN();
 					if (tok != NULL) {
-						strncpy(Multi_fs_tracker_channel, tok, MAX_PATH-1);
+						strncpy_s(Multi_fs_tracker_channel, tok, MAX_PATH-1);
 					}
 				} else
 				// set the standalone server's permanent name
 				if	( SETTING("+name") ) {
 					NEXT_TOKEN();
 					if (tok != NULL) {
-						strncpy(Multi_options_g.std_pname, tok, STD_NAME_LEN);
+						strncpy_s(Multi_options_g.std_pname, tok, STD_NAME_LEN);
 					}
 				} else
 				// standalone won't allow voice transmission
@@ -140,7 +140,7 @@ void multi_options_read_config()
 				if ( SETTING("+passwd") ) {
 					NEXT_TOKEN();
 					if (tok != NULL) {
-						strncpy(Multi_options_g.std_passwd, tok, STD_PASSWD_LEN);
+						strncpy_s(Multi_options_g.std_passwd, tok, STD_PASSWD_LEN);
 #ifdef _WIN32
 						// yuck
 						extern HWND Multi_std_host_passwd;

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2282,8 +2282,7 @@ void multi_pxo_channel_count_update(char *name, int count)
 void multi_pxo_set_status_text(const char *txt)
 {
 	// copy in the text
-	memset(Multi_pxo_status_text, 0, MAX_PXO_TEXT_LEN);
-	strncpy(Multi_pxo_status_text, txt, MAX_PXO_TEXT_LEN-1);
+	strncpy_s(Multi_pxo_status_text, txt, MAX_PXO_TEXT_LEN-1);
 
 	// make sure it fits properly
 	font::force_fit_string(Multi_pxo_status_text, MAX_PXO_TEXT_LEN-1, Multi_pxo_status_coords[gr_screen.res][2]);
@@ -2439,10 +2438,11 @@ pxo_channel *multi_pxo_add_channel(char *name,pxo_channel **list)
 	if ( new_channel == NULL ) {
 		nprintf(("Network", "Cannot allocate space for new pxo_channel structure\n"));
 		return NULL;
-	}	
+	}
 	memset(new_channel,0,sizeof(pxo_channel));
+
 	// try and allocate a string for the channel name
-	strncpy(new_channel->name,name,MAX_CHANNEL_NAME_LEN);	
+	strncpy_s(new_channel->name,name,MAX_CHANNEL_NAME_LEN);	
 
 	// insert it on the list
 	if ( *list != NULL ) {
@@ -2870,9 +2870,11 @@ player_list *multi_pxo_add_player(char *name)
 	if ( new_player == NULL ) {
 		nprintf(("Network", "Cannot allocate space for new player_list structure\n"));
 		return NULL;
-	}	
+	}
+	memset(new_player, 0, sizeof(player_list));
+
 	// try and allocate a string for the channel name
-	strncpy(new_player->name, name, MAX_PLAYER_NAME_LEN);	
+	strncpy_s(new_player->name, name, MAX_PLAYER_NAME_LEN);	
 
 	// insert it on the list
 	if ( Multi_pxo_players != NULL ) {
@@ -3223,7 +3225,7 @@ void multi_pxo_chat_add_line(const char *txt, int mode)
 	
 	// copy in the text
 	Assert(Multi_pxo_chat_add != NULL);
-	strncpy(Multi_pxo_chat_add->text, txt, MAX_CHAT_LINE_LEN);
+	strncpy_s(Multi_pxo_chat_add->text, txt, MAX_CHAT_LINE_LEN);
 	Multi_pxo_chat_add->mode = mode;
 
 	// if we're at the end of the list, move the front item down

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -3694,8 +3694,8 @@ void multi_create_game_do()
 			netgame_info *ng; 
 			ng = &Netgame;
 
-			char almissionname[256]; // needed, for the strncpy below
-			strncpy(almissionname, Cmdline_almission,MAX_FILENAME_LEN); //DTP; copying name from cmd_almission line
+			char almissionname[MAX_FILENAME_LEN]; // needed, for the strncpy below
+			strncpy_s(almissionname, Cmdline_almission, MAX_FILENAME_LEN-1); //DTP; copying name from cmd_almission line
 
 			Netgame.options.respawn = 99; //override anything //for debugging, i often forget this.
 			ng->respawn = Netgame.options.respawn;

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -680,14 +680,14 @@ int psnet_get_network_status()
 /**
  * Convert a ::net_addr to a string
  */
-const char *psnet_addr_to_string(const net_addr *address, char *text, size_t max_len)
+const char *psnet_addr_to_string(const net_addr *address, char *text, size_t max_size)
 {
 	in6_addr addr6;
 
 	memcpy(&addr6, &address->addr, sizeof(addr6));
 
-	if ( inet_ntop(AF_INET6, &addr6, text, static_cast<socklen_t>(max_len)) == nullptr ) {
-		strncpy(text, "", max_len);
+	if ( inet_ntop(AF_INET6, &addr6, text, static_cast<socklen_t>(max_size)) == nullptr ) {
+		strncpy_s(text, max_size, "", max_size-1);
 	}
 
 	return text;

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -144,7 +144,7 @@ void psnet_close();
 int psnet_get_network_status();
 
 // convert a net_addr to a string
-const char *psnet_addr_to_string(const net_addr *address, char *text, size_t max_len);
+const char *psnet_addr_to_string(const net_addr *address, char *text, size_t max_size);
 
 // convert a string to a net addr
 bool psnet_string_to_addr(const char *text, net_addr *address);

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -409,10 +409,10 @@ void std_connect_handle_name_change()
 		SendMessage(Multi_std_name,EM_GETLINE,(WPARAM)0,(LPARAM)(LPCSTR)buf);
 
 		// just copy it over for now. we may want to process this more later on
-		strncpy(Netgame.name, buf, sizeof(Netgame.name));
+		strncpy_s(Netgame.name, buf, sizeof(Netgame.name)-1);
 
 		// copy it to the permanent name
-		strncpy(Multi_options_g.std_pname, buf, sizeof(Multi_options_g.std_pname));
+		strncpy_s(Multi_options_g.std_pname, buf, sizeof(Multi_options_g.std_pname)-1);
 
 		// update systray icon
 		standalone_do_systray(ST_MODE_UPDATE);
@@ -432,7 +432,7 @@ void std_connect_handle_passwd_change()
 	SendMessage(Multi_std_host_passwd,EM_GETLINE,(WPARAM)0,(LPARAM)(LPCSTR)buf);
 
 	// just copy it over for now. we may want to process this more later on
-	strncpy(Multi_options_g.std_passwd, buf, sizeof(Multi_options_g.std_passwd));
+	strncpy_s(Multi_options_g.std_passwd, buf, sizeof(Multi_options_g.std_passwd)-1);
 }
 
 // convert the index of an item in the list box into an index into the net players array
@@ -2285,7 +2285,7 @@ static void standalone_do_systray(int mode)
 	nid.uID = 999;
 	nid.uCallbackMessage = MSG_SYSTRAYICON;
 	nid.hIcon = LoadIcon( GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_APP_ICON) );
-	strncpy(nid.szTip, Netgame.name, sizeof(nid.szTip));
+	strncpy_s(nid.szTip, Netgame.name, sizeof(nid.szTip)-1);
 	nid.uFlags = (NIF_MESSAGE | NIF_ICON | NIF_TIP);
 
 	if (mode == ST_MODE_CREATE) {

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -899,7 +899,7 @@ const char *os_config_read_string(const char *section, const char *name, const c
 	char *ptr = profile_get_value(Osreg_profile, section, name);
 
 	if (ptr != NULL) {
-		strncpy(tmp_string_data, ptr, 1023);
+		strncpy_s(tmp_string_data, ptr, 1023);
 		default_value = tmp_string_data;
 	}
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -1172,18 +1172,17 @@ void get_string(SCP_string &str)
 //	Stuff a string into a string buffer.
 //	Supports various FreeSpace primitive types.  If 'len' is supplied, it will override
 // the default string length if using the F_NAME case.
-void stuff_string(char *outstr, int type, int len, const char *terminators)
+void stuff_string(char *outstr, int type, int stuff_size, const char *terminators)
 {
 	char read_str[PARSE_BUF_SIZE] = "";
-	int read_len = PARSE_BUF_SIZE;
-	int final_len = len - 1;
+	int final_len = stuff_size - 1;
 	int tag_id;
 
 	// make sure we have enough room
 	Assert( final_len > 0 );
 
 	// make sure it's zero'd out
-	memset( outstr, 0, len );
+	memset( outstr, 0, stuff_size );
 
 	switch (type) {
 		case F_RAW:
@@ -1194,14 +1193,14 @@ void stuff_string(char *outstr, int type, int len, const char *terminators)
 		case F_PATHNAME:
 		case F_MESSAGE:
 			ignore_gray_space();
-			copy_to_eoln(read_str, terminators, Mp, read_len);
+			copy_to_eoln(read_str, terminators, Mp, PARSE_BUF_SIZE);
 			drop_trailing_white_space(read_str);
 			advance_to_eoln(terminators);
 			break;
 
 		case F_NOTES:
 			ignore_white_space();
-			copy_text_until(read_str, Mp, "$End Notes:", read_len);
+			copy_text_until(read_str, Mp, "$End Notes:", PARSE_BUF_SIZE);
 			Mp += strlen(read_str);
 			required_string("$End Notes:");
 			break;
@@ -1211,14 +1210,14 @@ void stuff_string(char *outstr, int type, int len, const char *terminators)
 
 		case F_MULTITEXTOLD:
 			ignore_white_space();
-			copy_text_until(read_str, Mp, "$End Briefing Text:", read_len);
+			copy_text_until(read_str, Mp, "$End Briefing Text:", PARSE_BUF_SIZE);
 			Mp += strlen(read_str);
 			required_string("$End Briefing Text:");
 			break;
 
 		case F_MULTITEXT:
 			ignore_white_space();
-			copy_text_until(read_str, Mp, "$end_multi_text", read_len);
+			copy_text_until(read_str, Mp, "$end_multi_text", PARSE_BUF_SIZE);
 			Mp += strlen(read_str);
 			drop_trailing_white_space(read_str);
 			required_string("$end_multi_text");
@@ -1252,6 +1251,7 @@ void stuff_string(char *outstr, int type, int len, const char *terminators)
 			error_display(0, "Token too long: [%s].  Length = " SIZE_T_ARG ".  Max is %i.\n", read_str, strlen(read_str), final_len);
 
 		strncpy(outstr, read_str, final_len);
+		outstr[final_len] = 0;
 	}
 
 	diag_printf("Stuffed string = [%.30s]\n", outstr);
@@ -2261,14 +2261,14 @@ void read_raw_file_text(const char *filename, int mode, char *raw_text)
 				}
 
 				if (success) {
-					strncpy(Parse_text_raw, buffer.c_str(), buffer.length());
+					strncpy_s(Parse_text_raw, file_len+1, buffer.c_str(), buffer.length());
 				}
 				else {
 					Warning(LOCATION, "File reencoding failed!\n"
 						"You will probably encounter encoding issues.");
 
-					// Copy the original data back to the mission text pointer so that we don't loose any data here
-					strcpy(Parse_text_raw, input_str.c_str());
+					// Copy the original data back to the mission text pointer so that we don't lose any data here
+					strcpy_s(Parse_text_raw, file_len+1, input_str.c_str());
 				}
 			} else {
 				Warning(LOCATION, "Found invalid UTF-8 encoding in file %s at position " PTRDIFF_T_ARG "!\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -22456,7 +22456,7 @@ void sexp_string_get_substring(int node)
 
 		auto byte_diff = end_ptr - start_ptr;
 
-		strncpy(new_text, start_ptr, byte_diff);
+		strncpy_s(new_text, start_ptr, byte_diff);
 	}
 
 	// assign to variable
@@ -27756,7 +27756,7 @@ int get_sexp_main()
 	if (*Mp != '(')
 	{
 		char buf[512];
-		strncpy(buf, Mp, 512);
+		strncpy(buf, Mp, 511);
 		if (buf[511] != '\0')
 			strcpy(&buf[506], "[...]");
 
@@ -31890,8 +31890,7 @@ void sexp_modify_variable(const char *text, int index, bool sexp_callback)
 			Warning(LOCATION, "String too long.  Only " SIZE_T_ARG " characters will be assigned to %s.\n\nOriginal string:\n%s", maxCopyLen, Sexp_variables[index].variable_name, text);
 
 		// no variables, so no substitution
-		strncpy(Sexp_variables[index].text, text, maxCopyLen);
-		Sexp_variables[index].text[maxCopyLen] = 0;
+		strncpy_s(Sexp_variables[index].text, text, maxCopyLen);
 	}
 	Sexp_variables[index].type |= SEXP_VARIABLE_MODIFIED;
 
@@ -32390,8 +32389,7 @@ bool sexp_replace_variable_names_with_values(char *text, int max_len)
 			{
 				// get the replacement string ($variable)
 				char what_to_replace[TOKEN_LENGTH+1];
-				memset(what_to_replace, 0, TOKEN_LENGTH+1);
-				strncpy(what_to_replace, pos, strlen(Sexp_variables[var_index].variable_name) + 1);
+				strncpy_s(what_to_replace, pos, strlen(Sexp_variables[var_index].variable_name) + 1);
 
 				// replace it
 				auto diff = replace_one(text, what_to_replace, Sexp_variables[var_index].text, max_len);

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -386,7 +386,7 @@ void player_set_squad_bitmap(player *p, const char *fname, bool ismulti)
 
 	// try and set the new one
 	if (fname != squad_pic_p) {
-		strncpy(squad_pic_p, fname, MAX_FILENAME_LEN);
+		strncpy_s(squad_pic_p, MAX_FILENAME_LEN+1, fname, MAX_FILENAME_LEN);
 	}
 
 	if (squad_pic_p[0] != '\0') {

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1345,8 +1345,7 @@ static int drawString_sub(lua_State *L, bool use_resize_arg)
 			//Contrary to WMC's previous comment, let's make a new string each line
 			int len = linelengths[i];
 			char *buf = new char[len+1];
-			strncpy(buf, linestarts[i], len);
-			buf[len] = '\0';
+			strncpy_s(buf, len+1, linestarts[i], len);
 
 			//Draw the string
 			gr_string(x,curr_y,buf,resize_mode);

--- a/code/scripting/api/objs/event.cpp
+++ b/code/scripting/api/objs/event.cpp
@@ -23,9 +23,8 @@ ADE_VIRTVAR(Name, l_Event, "string", "Mission event name", "string", NULL)
 	mission_event *mep = &Mission_events[idx];
 
 	if (ADE_SETTING_VAR) {
-		auto len = sizeof(mep->name);
-		strncpy(mep->name, s, len);
-		mep->name[len - 1] = 0;
+		auto size = sizeof(mep->name);
+		strncpy_s(mep->name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", mep->name);

--- a/code/scripting/api/objs/intelentry.cpp
+++ b/code/scripting/api/objs/intelentry.cpp
@@ -50,9 +50,8 @@ ADE_VIRTVAR(Name, l_Intelentry, "string", "Intel entry name", "string", "Intel e
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(Intel_info[idx].name);
-		strncpy(Intel_info[idx].name, s, len);
-		Intel_info[idx].name[len - 1] = 0;
+		auto size = sizeof(Intel_info[idx].name);
+		strncpy_s(Intel_info[idx].name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Intel_info[idx].name);
@@ -91,9 +90,8 @@ ADE_VIRTVAR(AnimFilename, l_Intelentry, "string", "Intel entry animation filenam
 
 	if(ADE_SETTING_VAR) {
 		if(s != nullptr) {
-			auto len = sizeof(Intel_info[idx].anim_filename);
-			strncpy(Intel_info[idx].anim_filename, s, len);
-			Intel_info[idx].anim_filename[len - 1] = 0;
+			auto size = sizeof(Intel_info[idx].anim_filename);
+			strncpy_s(Intel_info[idx].anim_filename, s, size-1);
 		} else {
 			strcpy_s(Intel_info[idx].anim_filename, "");
 		}

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -212,9 +212,8 @@ ADE_VIRTVAR(Filename, l_Model, "string", "Model filename", "string", "Model file
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR) {
-		auto len = sizeof(pm->filename);
-		strncpy(pm->filename, s, len);
-		pm->filename[len - 1] = 0;
+		auto size = sizeof(pm->filename);
+		strncpy_s(pm->filename, s, size-1);
 	}
 
 	return ade_set_args(L, "s", pm->filename);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -338,9 +338,8 @@ ADE_VIRTVAR(Name, l_Ship, "string", "Ship name. This is the actual name of the s
 	ship *shipp = &Ships[objh->objp->instance];
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(shipp->ship_name);
-		strncpy(shipp->ship_name, s, len);
-		shipp->ship_name[len - 1] = 0;
+		auto size = sizeof(shipp->ship_name);
+		strncpy_s(shipp->ship_name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", shipp->ship_name);

--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -59,9 +59,8 @@ ADE_VIRTVAR(Name, l_Shipclass, "string", "Ship class name", "string", "Ship clas
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
-		auto len = sizeof(Ship_info[idx].name);
-		strncpy(Ship_info[idx].name, s, len);
-		Ship_info[idx].name[len - 1] = 0;
+		auto size = sizeof(Ship_info[idx].name);
+		strncpy_s(Ship_info[idx].name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Ship_info[idx].name);
@@ -78,9 +77,8 @@ ADE_VIRTVAR(ShortName, l_Shipclass, "string", "Ship class short name", "string",
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
-		auto len = sizeof(Ship_info[idx].short_name);
-		strncpy(Ship_info[idx].short_name, s, len);
-		Ship_info[idx].short_name[len - 1] = 0;
+		auto size = sizeof(Ship_info[idx].short_name);
+		strncpy_s(Ship_info[idx].short_name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Ship_info[idx].short_name);

--- a/code/scripting/api/objs/shiptype.cpp
+++ b/code/scripting/api/objs/shiptype.cpp
@@ -26,9 +26,8 @@ ADE_VIRTVAR(Name, l_Shiptype, "string", "Ship type name", "string", "Ship type n
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
-		auto len = sizeof(Ship_types[idx].name);
-		strncpy(Ship_types[idx].name, s, len);
-		Ship_types[idx].name[len - 1] = 0;
+		auto size = sizeof(Ship_types[idx].name);
+		strncpy_s(Ship_types[idx].name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Ship_types[idx].name);

--- a/code/scripting/api/objs/species.cpp
+++ b/code/scripting/api/objs/species.cpp
@@ -26,9 +26,8 @@ ADE_VIRTVAR(Name, l_Species, "string", "Species name", "string", "Species name, 
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(Species_info[idx].species_name);
-		strncpy(Species_info[idx].species_name, s, len);
-		Species_info[idx].species_name[len - 1] = 0;
+		auto size = sizeof(Species_info[idx].species_name);
+		strncpy_s(Species_info[idx].species_name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Species_info[idx].species_name);

--- a/code/scripting/api/objs/team.cpp
+++ b/code/scripting/api/objs/team.cpp
@@ -31,9 +31,8 @@ ADE_VIRTVAR(Name, l_Team, "string", "Team name", "string", "Team name, or empty 
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(Iff_info[tdx].iff_name);
-		strncpy(Iff_info[tdx].iff_name, s, len);
-		Iff_info[tdx].iff_name[len - 1] = 0;
+		auto size = sizeof(Iff_info[tdx].iff_name);
+		strncpy_s(Iff_info[tdx].iff_name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Iff_info[tdx].iff_name);

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -53,9 +53,8 @@ ADE_VIRTVAR(Name, l_Weaponclass, "string", "Weapon class name. This is the possi
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(Weapon_info[idx].name);
-		strncpy(Weapon_info[idx].name, s, len);
-		Weapon_info[idx].name[len - 1] = 0;
+		auto size = sizeof(Weapon_info[idx].name);
+		strncpy_s(Weapon_info[idx].name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Weapon_info[idx].name);
@@ -72,9 +71,8 @@ ADE_VIRTVAR(AltName, l_Weaponclass, "string", "The alternate weapon class name."
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(Weapon_info[idx].display_name);
-		strncpy(Weapon_info[idx].display_name, s, len);
-		Weapon_info[idx].display_name[len - 1] = 0;
+		auto size = sizeof(Weapon_info[idx].display_name);
+		strncpy_s(Weapon_info[idx].display_name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Weapon_info[idx].display_name);
@@ -91,9 +89,8 @@ ADE_VIRTVAR(Title, l_Weaponclass, "string", "Weapon class title", "string", "Wea
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(Weapon_info[idx].title);
-		strncpy(Weapon_info[idx].title, s, len);
-		Weapon_info[idx].title[len - 1] = 0;
+		auto size = sizeof(Weapon_info[idx].title);
+		strncpy_s(Weapon_info[idx].title, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Weapon_info[idx].title);
@@ -138,9 +135,8 @@ ADE_VIRTVAR(TechTitle, l_Weaponclass, "string", "Weapon class tech title", "stri
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(Weapon_info[idx].tech_title);
-		strncpy(Weapon_info[idx].tech_title, s, len);
-		Weapon_info[idx].tech_title[len - 1] = 0;
+		auto size = sizeof(Weapon_info[idx].tech_title);
+		strncpy_s(Weapon_info[idx].tech_title, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Weapon_info[idx].tech_title);
@@ -157,9 +153,8 @@ ADE_VIRTVAR(TechAnimationFilename, l_Weaponclass, "string", "Weapon class animat
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
-		auto len = sizeof(Weapon_info[idx].tech_anim_filename);
-		strncpy(Weapon_info[idx].tech_anim_filename, s, len);
-		Weapon_info[idx].tech_anim_filename[len - 1] = 0;
+		auto size = sizeof(Weapon_info[idx].tech_anim_filename);
+		strncpy_s(Weapon_info[idx].tech_anim_filename, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Weapon_info[idx].tech_anim_filename);

--- a/code/scripting/api/objs/wing.cpp
+++ b/code/scripting/api/objs/wing.cpp
@@ -51,9 +51,8 @@ ADE_VIRTVAR(Name, l_Wing, "string", "Name of Wing", "string", "Wing name, or emp
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL) {
-		auto len = sizeof(Wings[wdx].name);
-		strncpy(Wings[wdx].name, s, len);
-		Wings[wdx].name[len - 1] = 0;
+		auto size = sizeof(Wings[wdx].name);
+		strncpy_s(Wings[wdx].name, s, size-1);
 	}
 
 	return ade_set_args(L, "s", Wings[wdx].name);

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -879,9 +879,8 @@ void script_state::Clear()
 
 script_state::script_state(const char *name)
 {
-	auto len = sizeof(StateName);
-	strncpy(StateName, name, len);
-	StateName[len - 1] = 0;
+	auto size = sizeof(StateName);
+	strncpy_s(StateName, name, size-1);
 
 	Langs = 0;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15692,7 +15692,10 @@ bool ship_subsys_has_instance_name(ship_subsys *ss)
 		return false;
 }
 
-void ship_subsys_set_name(ship_subsys* ss, const char* n_name) { strncpy(ss->sub_name, n_name, NAME_LENGTH - 1); }
+void ship_subsys_set_name(ship_subsys* ss, const char* n_name)
+{
+	strncpy_s(ss->sub_name, n_name, NAME_LENGTH - 1);
+}
 
 /**
  * Return the shield strength of the specified quadrant on hit_objp
@@ -18604,7 +18607,7 @@ int damage_type_add(const char *name)
 
 	DamageTypeStruct dts;
 
-	strncpy(dts.name, name, NAME_LENGTH-1);
+	strncpy_s(dts.name, name, NAME_LENGTH-1);
 
 	if(strlen(name) > NAME_LENGTH - 1)
 	{
@@ -19039,7 +19042,7 @@ ArmorType::ArmorType(const char* in_name)
 		Warning(LOCATION, "Armor name %s is " SIZE_T_ARG " characters too long, and will be truncated", in_name, len - NAME_LENGTH);
 	}
 	
-	strncpy(Name, in_name, NAME_LENGTH-1);
+	strncpy_s(Name, in_name, NAME_LENGTH-1);
 }
 
 void ArmorType::ParseData()

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2883,7 +2883,7 @@ public:
 	//Returns handle, or < 0 on failure/wrong type
 	gamesnd_id getSound();
 	//Returns 1 if buffer was successfully written to
-	int getString(char *output, size_t output_max);
+	int getString(char *output, size_t output_len);
 
 	//Returns true if TYPE_NONE
 	bool isEmpty();
@@ -3022,25 +3022,25 @@ gamesnd_id CombinedVariable::getSound()
 	else
 		return {};
 }
-int CombinedVariable::getString(char *output, size_t output_max)
+int CombinedVariable::getString(char *output, size_t output_len)
 {
-	if(output == NULL || output_max == 0)
+	if(output == NULL || output_len == 0)
 		return 0;
 
 	if(Type == TYPE_FLOAT)
 	{
-		snprintf(output, output_max, "%f", su_Float);
+		snprintf(output, output_len, "%f", su_Float);
 		return 1;
 	}
 	if(Type == TYPE_IMAGE)
 	{
 		if(bm_is_valid(su_Image))
-			snprintf(output, output_max, "%s", bm_get_filename(su_Image));
+			snprintf(output, output_len, "%s", bm_get_filename(su_Image));
 		return 1;
 	}
 	if(Type == TYPE_INT)
 	{
-		snprintf(output, output_max, "%i", su_Int);
+		snprintf(output, output_len, "%i", su_Int);
 		return 1;
 	}
 	if(Type == TYPE_SOUND)
@@ -3052,7 +3052,7 @@ int CombinedVariable::getString(char *output, size_t output_max)
 	}
 	if(Type == TYPE_STRING)
 	{
-		strncpy(output, su_String, output_max);
+		strncpy(output, su_String, output_len);
 		return 1;
 	}
 	return 0;

--- a/code/ui/window.cpp
+++ b/code/ui/window.cpp
@@ -632,7 +632,7 @@ void UI_WINDOW::draw_one_xstr(UI_XSTR *xs, int frame)
 
 	// print this puppy out	
 	int xoffset = lcl_get_xstr_offset(xs->xstr_id, gr_screen.res);
-	strncpy(str, XSTR(xs->xstr, xs->xstr_id), 254);
+	strncpy_s(str, XSTR(xs->xstr, xs->xstr_id), 254);
 	if(str[0] == '&'){
 		if(strlen(str) > 1){			
 			gr_string((xs->x) + xoffset, xs->y, str + 1, GR_RESIZE_MENU);

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -192,8 +192,7 @@ void convert_multiline_string(CString &dest, const char *src)
 void deconvert_multiline_string(char *dest, const CString &str, size_t max_len)
 {
 	// leave room for the null terminator
-	memset(dest, 0, max_len + 1);
-	strncpy(dest, (LPCTSTR) str, max_len);
+	strncpy_s(dest, max_len+1, (LPCTSTR) str, max_len);
 
 	replace_all(dest, "\r\n", "\n", max_len);
 }
@@ -890,8 +889,7 @@ void clear_mission()
 
 	t = CTime::GetCurrentTime();
 	strcpy_s(The_mission.name, "Untitled");
-	strncpy(The_mission.author, str, NAME_LENGTH - 1);
-	The_mission.author[NAME_LENGTH - 1] = 0;
+	strncpy_s(The_mission.author, str, NAME_LENGTH - 1);
 	strcpy_s(The_mission.created, t.Format("%x at %X"));
 	strcpy_s(The_mission.modified, The_mission.created);
 	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.\n");

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -4829,12 +4829,8 @@ void sexp_tree::update_help(HTREEITEM h)
 					loc2 = strpbrk(loc, "\r\n");
 					if(loc2 != NULL)
 					{
-						size_t size = loc2-loc;
-						strncpy(buffer, loc, size);
-						if(size < sizeof(buffer))
-						{
-							buffer[size] = '\0';
-						}
+						size_t len = loc2-loc;
+						strncpy_s(buffer, loc, len);
 						display_number = false;
 					}
 					else

--- a/fred2/voiceactingmanager.cpp
+++ b/fred2/voiceactingmanager.cpp
@@ -549,14 +549,12 @@ void VoiceActingManager::get_valid_sender(char *sender, size_t sender_size, cons
 	Assert( sender != NULL );
 	Assert( message != NULL );
 
-	memset(sender, 0, sender_size);
-	strncpy(sender, get_message_sender(message), sender_size - 1);
+	strncpy_s(sender, sender_size, get_message_sender(message), sender_size - 1);
 
 	// check if we're overriding #Command
 	if (The_mission.flags[Mission::Mission_Flags::Override_hashcommand] && !strcmp("#Command", sender))
 	{
-		memset(sender, 0, sender_size);
-		strncpy(sender, The_mission.command_sender, sender_size - 1);
+		strncpy_s(sender, sender_size, The_mission.command_sender, sender_size - 1);
 	}
 
 	// strip hash if present
@@ -591,8 +589,7 @@ void VoiceActingManager::get_valid_sender(char *sender, size_t sender_size, cons
 		// use the regular sender display name
 		else
 		{
-			memset(sender, 0, sender_size);
-			strncpy(sender, shipp->get_display_name(), sender_size - 1);
+			strncpy_s(sender, sender_size, shipp->get_display_name(), sender_size - 1);
 		}
 	}
 }

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -114,20 +114,20 @@ bool MissionSpecDialogModel::apply() {
 	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
 	Editor::pad_with_newline(_m_mission_notes, NOTES_LENGTH - 1);
 
-	strncpy(The_mission.name, _m_mission_title.c_str(), NAME_LENGTH-1);
-	strncpy(The_mission.author, _m_designer_name.c_str(), NAME_LENGTH-1);
-	strncpy(The_mission.loading_screen[GR_640], _m_loading_640.c_str(), NAME_LENGTH-1);
-	strncpy(The_mission.loading_screen[GR_1024], _m_loading_1024.c_str(), NAME_LENGTH-1);
-	strncpy(The_mission.notes, _m_mission_notes.c_str(), NOTES_LENGTH);
-	strncpy(The_mission.mission_desc, _m_mission_desc.c_str(), MISSION_DESC_LENGTH);
+	strncpy_s(The_mission.name, _m_mission_title.c_str(), NAME_LENGTH-1);
+	strncpy_s(The_mission.author, _m_designer_name.c_str(), NAME_LENGTH-1);
+	strncpy_s(The_mission.loading_screen[GR_640], _m_loading_640.c_str(), NAME_LENGTH-1);
+	strncpy_s(The_mission.loading_screen[GR_1024], _m_loading_1024.c_str(), NAME_LENGTH-1);
+	strncpy_s(The_mission.notes, _m_mission_notes.c_str(), NOTES_LENGTH-1);
+	strncpy_s(The_mission.mission_desc, _m_mission_desc.c_str(), MISSION_DESC_LENGTH-1);
 
 	// copy squad stuff
 	if (_m_squad_name == NO_SQUAD) {
 		strcpy_s(The_mission.squad_name, "");
 		strcpy_s(The_mission.squad_filename, "");
 	} else {
-		strncpy(The_mission.squad_name, _m_squad_name.c_str(), NAME_LENGTH);
-		strncpy(The_mission.squad_filename, _m_squad_filename.c_str(), MAX_FILENAME_LEN);
+		strncpy_s(The_mission.squad_name, _m_squad_name.c_str(), NAME_LENGTH-1);
+		strncpy_s(The_mission.squad_filename, _m_squad_filename.c_str(), MAX_FILENAME_LEN-1);
 	}
 
 	The_mission.ai_profile = &Ai_profiles[_m_ai_profile];

--- a/qtfred/src/ui/dialogs/EventEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/EventEditorDialog.cpp
@@ -245,7 +245,7 @@ void EventEditorDialog::initMessageWidgets() {
 		}
 
 		if (!conflict) {  // update name if no conflicts, otherwise keep old name
-			strncpy(m_messages[m_cur_msg].name, text.toUtf8().constData(), NAME_LENGTH - 1);
+			strncpy_s(m_messages[m_cur_msg].name, text.toUtf8().constData(), NAME_LENGTH - 1);
 
 			auto item = ui->messageList->item(m_cur_msg);
 			item->setText(text);
@@ -258,7 +258,7 @@ void EventEditorDialog::initMessageWidgets() {
 
 		auto msg = ui->messageContent->toPlainText();
 
-		strncpy(m_messages[m_cur_msg].message, msg.toUtf8().constData(), MESSAGE_LENGTH - 1);
+		strncpy_s(m_messages[m_cur_msg].message, msg.toUtf8().constData(), MESSAGE_LENGTH - 1);
 		lcl_fred_replace_stuff(m_messages[m_cur_msg].message, MESSAGE_LENGTH - 1);
 	});
 	connect(ui->messageTeamCombo, QOverload<int>::of(&QComboBox::activated), this, [this](int id) {

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -2794,11 +2794,8 @@ void sexp_tree::update_help(QTreeWidgetItem* h) {
 					//Find EOL
 					loc2 = strpbrk(loc, "\r\n");
 					if (loc2 != NULL) {
-						size_t size = loc2 - loc;
-						strncpy(buffer, loc, size);
-						if (size < sizeof(buffer)) {
-							buffer[size] = '\0';
-						}
+						size_t len = loc2 - loc;
+						strncpy_s(buffer, loc, len);
 						display_number = false;
 					} else {
 						strcpy_s(buffer, loc);


### PR DESCRIPTION
I have gone through the codebase and replaced most instances of `strncpy` with `strncpy_s` which always adds a null-terminator and includes some extra error checking.  Quite a few of these places did not use the length properly and have been fixed.

This is based on #4321 but without the safe_strings removal.