### PR TITLE
Make sure immobile objects always have 0 velocity

### DIFF
--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -789,7 +789,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	// We will try not to worry about the left over time in the frame
 	// heavy's position unchanged by collision
 	// light's position is heavy's position plus relative position from heavy
-	if (should_collide){
+	if (should_collide && !lighter->flags[Object::Object_Flags::Immobile]){
 		vm_vec_add(&lighter->pos, &heavy->pos, &ship_ship_hit_info->light_collision_cm_pos);
 	}
 
@@ -801,9 +801,11 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 
 	if (should_collide){
 
-		Assert( !vm_is_vec_nan(&direction_light) );
-		vm_vec_scale_add2(&heavy->pos, &direction_light,  0.2f * lighter->phys_info.mass / (heavy->phys_info.mass + lighter->phys_info.mass));
-		vm_vec_scale_add2(&heavy->pos, &ship_ship_hit_info->collision_normal, -0.1f * lighter->phys_info.mass / (heavy->phys_info.mass + lighter->phys_info.mass));
+		if (!heavy->flags[Object::Object_Flags::Immobile]) {
+			Assert(!vm_is_vec_nan(&direction_light));
+			vm_vec_scale_add2(&heavy->pos, &direction_light, 0.2f * lighter->phys_info.mass / (heavy->phys_info.mass + lighter->phys_info.mass));
+			vm_vec_scale_add2(&heavy->pos, &ship_ship_hit_info->collision_normal, -0.1f * lighter->phys_info.mass / (heavy->phys_info.mass + lighter->phys_info.mass));
+		}
 
 		// while we are in a block that has already checked if we should collide, set the MP client timestamps
 		if (MULTIPLAYER_CLIENT){
@@ -819,7 +821,7 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	if (ship_ship_hit_info->is_landing) {
 		vm_vec_scale_add2(&lighter->pos, &ship_ship_hit_info->collision_normal, LANDING_POS_OFFSET);
 	}
-	else {
+	else if (!lighter->flags[Object::Object_Flags::Immobile]) {
 		vm_vec_scale_add2(&lighter->pos, &direction_light, -0.2f * heavy->phys_info.mass / (heavy->phys_info.mass + lighter->phys_info.mass));
 		vm_vec_scale_add2(&lighter->pos, &ship_ship_hit_info->collision_normal,  0.1f * heavy->phys_info.mass / (heavy->phys_info.mass + lighter->phys_info.mass));
 	}

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1530,6 +1530,12 @@ void obj_move_all(float frametime)
 				// physics
 				obj_move_call_physics(objp, frametime);
 			}
+		} else if (objp->flags[Object::Object_Flags::Immobile]) {
+			// make sure velocity is always 0 for immobile things!
+			vm_vec_zero(&objp->phys_info.vel);
+			vm_vec_zero(&objp->phys_info.desired_vel);
+			vm_vec_zero(&objp->phys_info.rotvel);
+			vm_vec_zero(&objp->phys_info.desired_rotvel);
 		}
 
 		// Submodel movement now happens here, right after physics movement.  It's not excluded by the "immobile" flag.

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1530,7 +1530,7 @@ void obj_move_all(float frametime)
 				// physics
 				obj_move_call_physics(objp, frametime);
 			}
-		} else if (objp->flags[Object::Object_Flags::Immobile]) {
+		} else {
 			// make sure velocity is always 0 for immobile things!
 			vm_vec_zero(&objp->phys_info.vel);
 			vm_vec_zero(&objp->phys_info.desired_vel);


### PR DESCRIPTION
Collisions with immobile objects... are fundamentally broken, obviously as a physics concept it is nonsensical, and if the non-immobile object has enough mass it can just burrow straight through immobile objects. I'm not going to tackle that right now, but we can at least make sure things don't blow up too badly when it happens. Physics impacts will currently update the speed of an immobile object, but it still won't move, giving it 'phantom' speed, which causes 'phantom collisions' and screws up a bunch of stuff. Rather than hunt all that down, I think its best to just always re-affirm every frame that immobile objects have 0 velocity, just in case it comes from weird places.

Position modification is much rarer, so I did go in and explicitly add checks for the few times the physics tries to 'nudge' things outside of regular physics movement.