### PR TITLE
Steps towards properly batching draw calls for hud

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -7,6 +7,7 @@
  *
  */
 
+#include "graphics/render.h"
 #ifdef _WIN32
 #include <windows.h>
 #include <windowsx.h>
@@ -2559,7 +2560,9 @@ void gr_flip(bool execute_scripting)
 
 		// WMC - Do conditional hooks. Yippee!
 		if (OnFrameHook->isActive()) {
+			gr_2d_start_buffer(); 
 			OnFrameHook->run();
+			gr_2d_stop_buffer();
 		}
 	}
 

--- a/code/graphics/paths/NanoVGRenderer.h
+++ b/code/graphics/paths/NanoVGRenderer.h
@@ -87,6 +87,10 @@ class NanoVGRenderer {
 
 	std::vector<NVGvertex> _vertices;
 	std::vector<DrawCall> _drawCalls;
+	std::vector<DrawCall> _drawFillCalls;
+	std::vector<DrawCall> _drawConvexFillCalls;
+	std::vector<DrawCall> _drawStrokeCalls;
+	std::vector<DrawCall> _drawTriangleCalls;
 	std::vector<graphics::nanovg_draw_data> _uniformData;
 	std::vector<Path> _paths;
 
@@ -96,6 +100,7 @@ class NanoVGRenderer {
 	ivec2 _viewport;
 
 	DrawCall* addDrawCall();
+	DrawCall* addDrawCall(CallType t);
 	size_t addUniformData(size_t num);
 	size_t addVertices(const NVGvertex* vert, size_t num);
 
@@ -110,7 +115,7 @@ class NanoVGRenderer {
 					  float strokeThr);
 
 	Image* getTexture(int id);
-
+	void sortCalls(std::vector<DrawCall> calls);
 	void drawTriangles(const DrawCall& call);
 	void drawFill(const DrawCall& call);
 	void drawConvexFill(const DrawCall& call);

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -96,6 +96,11 @@ Category MainFrame("Main Frame", true);
 Category PageFlip("Page flip", true);
 
 Category NanoVGFlushFrame("NanoVG flush frame", true);
+Category NanoVGFlushAll("NanoVG misc flush", true);
+Category NanoVGFlushFill("NanoVG fill flush", true);
+Category NanoVGFlushConvex("NanoVG convex flush", true);
+Category NanoVGFlushPath("NanoVG path flush", true);
+Category NanoVGFlushTriangle("NanoVG triangle flush", true);
 Category NanoVGDrawFill("NanoVG Draw fill", true);
 Category NanoVGDrawConvexFill("NanoVG Draw convex fill", true);
 Category NanoVGDrawStroke("NanoVG Draw stroke", true);

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -109,6 +109,11 @@ extern Category MainFrame;
 extern Category PageFlip;
 
 extern Category NanoVGFlushFrame;
+extern Category NanoVGFlushAll;
+extern Category NanoVGFlushFill;
+extern Category NanoVGFlushConvex;
+extern Category NanoVGFlushPath;
+extern Category NanoVGFlushTriangle;
 extern Category NanoVGDrawFill;
 extern Category NanoVGDrawConvexFill;
 extern Category NanoVGDrawStroke;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -10,6 +10,7 @@
 
 
 
+#include "graphics/render.h"
 #ifdef _WIN32
  #include <winsock2.h>	// required to prevent winsock 1.1 being used
  #include <direct.h>
@@ -4068,6 +4069,7 @@ void game_frame(bool paused)
 				cid.getCamera()->get_info(&Net_player->s_info.eye_pos, &Net_player->s_info.eye_orient);
 			}
 
+			gr_2d_start_buffer();
 			Scripting_didnt_draw_hud = 1;
 			Script_system.SetHookObject("Self", Viewer_obj);
 			Script_system.SetHookObject("Player", Player_obj);
@@ -4093,6 +4095,7 @@ void game_frame(bool paused)
 
 				Script_system.RunCondition(CHA_HUDDRAW, Viewer_obj);
 			}
+			gr_2d_stop_buffer();
 			Script_system.RemHookVar("Self");
 			Script_system.RemHookVar("Player");
 			


### PR DESCRIPTION
There's a batching system in nanoVG, but we don't use it. Currently this PR activates that system to make a few batches depending on how much lua drawing there is. 
But the batching system doesn't actually reduce the draw calls or even the high level openGL calls any that I can see, so it's unlikely to have any performance benefit yet.
The PR thus also makes a few changes to get closer to being able to batch properly. The needed changes go a few levels deeper than I've gone so far, which is the biggest reason this is in draft atm