### PR TITLE
created new "load_last" universal mod directory

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -592,6 +592,7 @@ void cf_build_root_list(const char *cdrom_dir)
 	if ( !_getcwd(working_directory, CF_MAX_PATHNAME_LENGTH ) ) {
 		Error(LOCATION, "Can't get current working directory -- %d", errno );
 	}
+
 	if (Cmdline_override_data) {
 
 		//To allow user-override of mod files, this new root takes presecdence over all mod roots.
@@ -613,6 +614,7 @@ void cf_build_root_list(const char *cdrom_dir)
 
 		cf_build_pack_list(last);
 	}
+
 	//now that the _override root is finished(or not), handle all mods
 	cf_add_mod_roots(working_directory, CF_LOCATION_ROOT_GAME);
 

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -593,8 +593,29 @@ void cf_build_root_list(const char *cdrom_dir)
 		Error(LOCATION, "Can't get current working directory -- %d", errno );
 	}
 
+	//To allow user-override of mod files, this new root takes presecdence over all mod roots.
+	cf_root	*last = nullptr;
+	last = cf_create_root();
+
+	last->location_flags |= CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT | CF_LOCATION_TYPE_SECONDARY_MODS;
+
+	last->path = working_directory;
+	if (last->path.back() != DIR_SEPARATOR_CHAR) {
+		last->path += DIR_SEPARATOR_CHAR;
+	}
+	last->path += "load_last";
+	last->path += DIR_SEPARATOR_CHAR; 
+
+	last->roottype = CF_ROOTTYPE_PATH;
+
+	cf_init_root_pathtypes(last);
+
+	cf_build_pack_list(last);
+
+	//now that the load_last root is finished, handle all mods
 	cf_add_mod_roots(working_directory, CF_LOCATION_ROOT_GAME);
 
+	//finally, handle the default root.
 	root = cf_create_root();
 
 	root->location_flags |= CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT;

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -592,27 +592,28 @@ void cf_build_root_list(const char *cdrom_dir)
 	if ( !_getcwd(working_directory, CF_MAX_PATHNAME_LENGTH ) ) {
 		Error(LOCATION, "Can't get current working directory -- %d", errno );
 	}
+	if (Cmdline_override_data) {
 
-	//To allow user-override of mod files, this new root takes presecdence over all mod roots.
-	cf_root	*last = nullptr;
-	last = cf_create_root();
+		//To allow user-override of mod files, this new root takes presecdence over all mod roots.
+		cf_root	*last = nullptr;
+		last = cf_create_root();
 
-	last->location_flags |= CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT | CF_LOCATION_TYPE_SECONDARY_MODS;
+		last->location_flags |= CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT | CF_LOCATION_TYPE_SECONDARY_MODS;
 
-	last->path = working_directory;
-	if (last->path.back() != DIR_SEPARATOR_CHAR) {
-		last->path += DIR_SEPARATOR_CHAR;
+		last->path = working_directory;
+		if (last->path.back() != DIR_SEPARATOR_CHAR) {
+			last->path += DIR_SEPARATOR_CHAR;
+		}
+		last->path += "_override";
+		last->path += DIR_SEPARATOR_CHAR; 
+
+		last->roottype = CF_ROOTTYPE_PATH;
+
+		cf_init_root_pathtypes(last);
+
+		cf_build_pack_list(last);
 	}
-	last->path += "load_last";
-	last->path += DIR_SEPARATOR_CHAR; 
-
-	last->roottype = CF_ROOTTYPE_PATH;
-
-	cf_init_root_pathtypes(last);
-
-	cf_build_pack_list(last);
-
-	//now that the load_last root is finished, handle all mods
+	//now that the _override root is finished(or not), handle all mods
 	cf_add_mod_roots(working_directory, CF_LOCATION_ROOT_GAME);
 
 	//finally, handle the default root.

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -516,6 +516,7 @@ cmdline_parm log_to_stdout_arg("-stdout_log", nullptr, AT_NONE); // Cmdline_log_
 cmdline_parm slow_frames_ok_arg("-slow_frames_ok", nullptr, AT_NONE);	// Cmdline_slow_frames_ok
 cmdline_parm fixed_seed_rand("-seed", nullptr, AT_INT);	// Cmdline_rng_seed,Cmdline_reuse_rng_seed;
 cmdline_parm luadev_arg("-luadev", "nullptr", AT_NONE);	// Cmdline_lua_devmode
+cmdline_parm override_arg("-override", nullptr, AT_NONE);	// Cmdline_override_data
 
 
 char *Cmdline_start_mission = NULL;
@@ -550,6 +551,7 @@ bool Cmdline_graphics_debug_output = false;
 bool Cmdline_log_to_stdout = false;
 bool Cmdline_slow_frames_ok = false;
 bool Cmdline_lua_devmode = false;
+bool Cmdline_override_data = false;
 
 // Other
 cmdline_parm get_flags_arg(GET_FLAGS_STRING, "Output the launcher flags file", AT_STRING);
@@ -2179,6 +2181,10 @@ bool SetCmdlineParams()
 	}
 	if ( luadev_arg.found()) {
 		Cmdline_lua_devmode = true;
+	}
+
+	if ( override_arg.found()) {
+		Cmdline_override_data = true;
 	}
 
 	if (show_video_info.found())

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -516,7 +516,7 @@ cmdline_parm log_to_stdout_arg("-stdout_log", nullptr, AT_NONE); // Cmdline_log_
 cmdline_parm slow_frames_ok_arg("-slow_frames_ok", nullptr, AT_NONE);	// Cmdline_slow_frames_ok
 cmdline_parm fixed_seed_rand("-seed", nullptr, AT_INT);	// Cmdline_rng_seed,Cmdline_reuse_rng_seed;
 cmdline_parm luadev_arg("-luadev", "nullptr", AT_NONE);	// Cmdline_lua_devmode
-cmdline_parm override_arg("-override", nullptr, AT_NONE);	// Cmdline_override_data
+cmdline_parm override_arg("-override_data", nullptr, AT_NONE);	// Cmdline_override_data
 
 
 char *Cmdline_start_mission = NULL;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -156,6 +156,7 @@ extern bool Cmdline_graphics_debug_output;
 extern bool Cmdline_log_to_stdout;
 extern bool Cmdline_slow_frames_ok;
 extern bool Cmdline_lua_devmode;
+extern bool Cmdline_override_data;
 
 enum class WeaponSpewType { NONE = 0, STANDARD, ALL };
 extern WeaponSpewType Cmdline_spew_weapon_stats;


### PR DESCRIPTION
Implements #4113. In summary:
Conventional wisdom is that anything put in the fs2/data folder will override mod data but this is actually false, a file there will be shadowed or overridden by anything in mod files. It's possible that loose files in fs2/data override VP files, I haven't verified that for sure, but not all mods are distributed as such.
Clearly a community need/desire for something that overrides mod data exist, or there'd be no reason for that misconception to arise. So, this PR creates that capability.
This is implemented as effectively a 'built in' mod directory, named "load_last". Anything placed in fs2/load_last/data will be loaded after/above all roots in fs2/, though the appdata roots will still take priory.