### PR TITLE
Modular POF Features

### DIFF
--- a/code/globalincs/safe_strings.cpp
+++ b/code/globalincs/safe_strings.cpp
@@ -61,6 +61,51 @@ errno_t scp_strcpy_s( const char* file, int line, char* strDest, size_t sizeInBy
 	return 0;
 }
 
+errno_t scp_strncpy_s(const char* file, int line, char* strDest, size_t sizeInBytes, const char* strSource, size_t inputSizeInBytes) {
+	char* pDest;
+	const char* pSource;
+	size_t bufferLeft = sizeInBytes;
+
+	if (!strDest || !strSource)
+	{
+		if (strDest)
+			*strDest = '\0';
+		__safe_strings_error_handler(EINVAL);
+		return EINVAL;
+	}
+
+	if (sizeInBytes == 0)
+	{
+		*strDest = '\0';
+		__safe_strings_error_handler(ERANGE);
+		return ERANGE;
+	}
+
+	if (inputSizeInBytes == 0)
+	{
+		*strDest = '\0';
+		return 0;
+	}
+
+	pDest = strDest;
+	pSource = strSource;
+
+	while ((*pDest++ = *pSource++) != 0 && (--inputSizeInBytes > 0) && --bufferLeft > 0);
+
+	if (bufferLeft == 0 || (inputSizeInBytes == 0 && bufferLeft <= 1))
+	{
+		*strDest = '\0';
+		__safe_strings_error_handler(ERANGE);
+		return ERANGE;
+	}
+
+	if (inputSizeInBytes == 0) {
+		*pDest = '\0';
+	}
+
+	return 0;
+}
+
 errno_t scp_strcat_s( const char* file, int line, char* strDest, size_t sizeInBytes, const char* strSource )
 {
 	char* pDest;

--- a/code/globalincs/safe_strings.h
+++ b/code/globalincs/safe_strings.h
@@ -62,7 +62,8 @@ template< size_t size>
 inline
 errno_t scp_strncpy_s(const char* file, int line, char(&strDest)[size], const char* strSource, size_t count)
 {
-	return scp_strcpy_s(file, line, strDest, MIN(size, count), strSource);
+	//+ 1 to allow for null terminator after source. Still hardlimit by size
+	return scp_strcpy_s(file, line, strDest, MIN(size, count + 1), strSource);
 }
 
 template< size_t size >

--- a/code/globalincs/safe_strings.h
+++ b/code/globalincs/safe_strings.h
@@ -49,6 +49,7 @@ typedef int errno_t;
 #endif
 
 extern errno_t scp_strcpy_s( const char* file, int line, char* strDest, size_t sizeInBytes, const char* strSource );
+extern errno_t scp_strncpy_s( const char* file, int line, char* strDest, size_t sizeInBytes, const char* strSource, size_t inputSizeInBytes );
 extern errno_t scp_strcat_s( const char* file, int line, char* strDest, size_t sizeInBytes, const char* strSource );
 
 template< size_t size>
@@ -62,8 +63,7 @@ template< size_t size>
 inline
 errno_t scp_strncpy_s(const char* file, int line, char(&strDest)[size], const char* strSource, size_t count)
 {
-	//+ 1 to allow for null terminator after source. Still hardlimit by size
-	return scp_strcpy_s(file, line, strDest, MIN(size, count + 1), strSource);
+	return scp_strncpy_s(file, line, strDest, size, strSource, count);
 }
 
 template< size_t size >

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -879,7 +879,7 @@ struct model_read_deferred_tasks {
 	};
 
 	struct engine_subsystem_parse {
-		int thruster_nr;
+		SCP_string subsystem_name;
 	};
 
 	struct weapon_subsystem_parse {
@@ -897,8 +897,8 @@ struct model_read_deferred_tasks {
 	//Key: Subsystem Name
 	SCP_unordered_map<SCP_string, model_subsystem_parse, SCP_string_lcase_hash, SCP_string_lcase_equal_to> model_subsystems;
 	using model_subsystem_pair = decltype(model_subsystems)::value_type;
-	//Key: Subsystem Name
-	SCP_unordered_map<SCP_string, engine_subsystem_parse, SCP_string_lcase_hash, SCP_string_lcase_equal_to> engine_subsystems;
+	//Key: Engine Nr
+	SCP_unordered_map<int, engine_subsystem_parse> engine_subsystems;
 	using engine_subsystem_pair = decltype(engine_subsystems)::value_type;
 	//Key: Parent Subobject Nr
 	SCP_unordered_map<int, weapon_subsystem_parse> weapons_subsystems;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2517,7 +2517,7 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 
 									nprintf(("wash", "Ship %s with engine wash associated with subsys %s\n", filename, engine_subsys_name));
 
-									subsystemParseList.engine_subsystems.emplace(engine_subsys_name, model_read_deferred_tasks::engine_subsystem_parse{ i });
+									subsystemParseList.engine_subsystems.emplace(i, model_read_deferred_tasks::engine_subsystem_parse{ engine_subsys_name });
 								}
 							}
 						}
@@ -2936,10 +2936,10 @@ modelread_status read_and_process_model_file(polymodel* pm, const char* filename
 	for (const auto& subsystem : deferredTasks.engine_subsystems) {
 		// start off assuming the subsys is invalid
 		int table_error = 1;
-		auto bank = &pm->thrusters[subsystem.second.thruster_nr];
+		auto bank = &pm->thrusters[subsystem.first];
 
 		for (int k = 0; k < n_subsystems; k++) {
-			if (!subsystem_stricmp(subsystems[k].subobj_name, subsystem.first.c_str())) {
+			if (!subsystem_stricmp(subsystems[k].subobj_name, subsystem.second.subsystem_name.c_str())) {
 				bank->submodel_num = subsystems[k].subobj_num;
 
 				bank->wash_info_pointer = subsystems[k].engine_wash_pointer;

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -641,7 +641,7 @@ VirtualPOFOperationAddGlowpoint::VirtualPOFOperationAddGlowpoint() {
 	stuff_string(renameSubmodel, F_NAME);
 }
 
-void VirtualPOFOperationAddGlowpoint::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
+void VirtualPOFOperationAddGlowpoint::process(polymodel* pm, model_read_deferred_tasks& /*deferredTasks*/, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
 	auto appendingPM = virtual_pof_build_cache(appendingPOF, depth);
 
 	int dest_subobj_no = model_find_submodel_index(pm, renameSubmodel.c_str());
@@ -678,7 +678,7 @@ VirtualPOFOperationAddSpecialSubsystem::VirtualPOFOperationAddSpecialSubsystem()
 	}
 }
 
-void VirtualPOFOperationAddSpecialSubsystem::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
+void VirtualPOFOperationAddSpecialSubsystem::process(polymodel* /*pm*/, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
 	auto appendingPM = virtual_pof_build_cache(appendingPOF, depth);
 	const auto& subsystems = appendingPM->deferred().model_subsystems;
 

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -409,7 +409,7 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 					if (std::find(to_copy_submodels.begin(), to_copy_submodels.end(), turretSubsys.first) == to_copy_submodels.end())
 						continue;
 
-					if (turretSubsys.second.gun_subobj_nr != -1 && std::find(to_copy_submodels.begin(), to_copy_submodels.end(), turretSubsys.second.gun_subobj_nr) == to_copy_submodels.end())
+					if (turretSubsys.second.gun_subobj_nr != turretSubsys.first && std::find(to_copy_submodels.begin(), to_copy_submodels.end(), turretSubsys.second.gun_subobj_nr) == to_copy_submodels.end())
 						continue;
 
 					deferredTasks.weapons_subsystems.emplace(change_submodel_numbers(model_read_deferred_tasks::weapon_subsystem_pair(turretSubsys), replaceSubobjNo));
@@ -496,7 +496,7 @@ void VirtualPOFOperationAddTurret::process(polymodel* pm, model_read_deferred_ta
 		return;
 	}
 
-	if (it->second.gun_subobj_nr != -1) {
+	if (it->second.gun_subobj_nr != base_src_subobj_no) {
 		int gun_dest_subobj_no = -1;
 		if (barrelNameDest) {
 			gun_dest_subobj_no = model_find_submodel_index(pm, barrelNameDest->c_str());

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -655,6 +655,8 @@ void VirtualPOFOperationAddGlowpoint::process(polymodel* pm, model_read_deferred
 	pm->glow_point_banks[newGPNumber] = object_copy_including_array_member(appendingPM->pm()->glow_point_banks[sourceId], &glow_point_bank::points, &glow_point_bank::num_points);
 	pm->glow_point_banks[newGPNumber].submodel_parent = dest_subobj_no;
 
+	appendingPM->keepGlowbank(sourceId);
+
 	if (moveGlowpoint) {
 		const vec3d& offset = *moveGlowpoint;
 		for (int i = 0; i < pm->glow_point_banks[newGPNumber].num_points; i++)

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -13,6 +13,7 @@
 static SCP_unordered_map<SCP_string, std::vector<VirtualPOFDefinition>, SCP_string_lcase_hash, SCP_string_lcase_equal_to> virtual_pofs;
 static SCP_unordered_map<SCP_string, std::function<std::unique_ptr<VirtualPOFOperation>()>> virtual_pof_operations = {
 	{"$Add Subobject:", &make_unique<VirtualPOFOperationAddSubmodel> },
+	{"$Add Turret:", &make_unique<VirtualPOFOperationAddTurret> },
 	{"$Rename Subobjects:", &make_unique<VirtualPOFOperationRenameSubobjects> },
 	{"$Set Subobject Data:", &make_unique<VirtualPOFOperationChangeData> },
 	{"$Set Header Data:", &make_unique<VirtualPOFOperationHeaderData> }

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include <tl/optional.hpp>
+#include <mpark/variant.hpp>
 
 bool model_exists(const SCP_string& filename);
 bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, model_parse_depth depth, int ferror, model_read_deferred_tasks& deferredTasks);
@@ -55,6 +56,16 @@ class VirtualPOFOperationAddTurret : public VirtualPOFOperation {
 	std::unique_ptr<VirtualPOFOperationRenameSubobjects> rename = nullptr;
 public:
 	VirtualPOFOperationAddTurret();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
+};
+
+class VirtualPOFOperationAddEngine : public VirtualPOFOperation {
+	mpark::variant<SCP_string, int> sourceId;
+	tl::optional<SCP_string> renameSubsystem;
+	tl::optional<vec3d> moveEngine;
+	SCP_string appendingPOF;
+public:
+	VirtualPOFOperationAddEngine();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -41,8 +41,18 @@ class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
 	SCP_string appendingPOF;
 	std::unique_ptr<VirtualPOFOperationRenameSubobjects> rename = nullptr;
 	bool copyChildren = true;
+	bool copyTurrets = false;
 public:
 	VirtualPOFOperationAddSubmodel();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
+};
+
+class VirtualPOFOperationAddTurret : public VirtualPOFOperation {
+	SCP_string baseNameSrc, baseNameDest;
+	tl::optional<SCP_string> barrelNameDest;
+	SCP_string appendingPOF;
+public:
+	VirtualPOFOperationAddTurret();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -28,9 +28,10 @@ struct VirtualPOFDefinition {
 	SCP_vector<std::unique_ptr<VirtualPOFOperation>> operationList;
 };
 
+using VirtualPOFNameReplacementMap = SCP_unordered_map<SCP_string, SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to>;
+
 class VirtualPOFOperationRenameSubobjects : public VirtualPOFOperation {
-	using replacement_map = SCP_unordered_map<SCP_string, SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to>;
-	replacement_map replacements;
+	VirtualPOFNameReplacementMap replacements;
 	friend class VirtualPOFOperationAddSubmodel;
 	friend class VirtualPOFOperationAddTurret;
 public:
@@ -44,6 +45,7 @@ class VirtualPOFOperationAddSubmodel : public VirtualPOFOperation {
 	std::unique_ptr<VirtualPOFOperationRenameSubobjects> rename = nullptr;
 	bool copyChildren = true;
 	bool copyTurrets = false;
+	bool copyGlowpoints = false;
 public:
 	VirtualPOFOperationAddSubmodel();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
@@ -66,6 +68,25 @@ class VirtualPOFOperationAddEngine : public VirtualPOFOperation {
 	SCP_string appendingPOF;
 public:
 	VirtualPOFOperationAddEngine();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
+};
+
+class VirtualPOFOperationAddGlowpoint : public VirtualPOFOperation {
+	int sourceId;
+	SCP_string renameSubmodel;
+	tl::optional<vec3d> moveGlowpoint;
+	SCP_string appendingPOF;
+public:
+	VirtualPOFOperationAddGlowpoint();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
+};
+
+class VirtualPOFOperationAddSpecialSubsystem : public VirtualPOFOperation {
+	SCP_string sourceSubsystem;
+	tl::optional<SCP_string> renameSubsystem;
+	SCP_string appendingPOF;
+public:
+	VirtualPOFOperationAddSpecialSubsystem();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -31,6 +31,7 @@ class VirtualPOFOperationRenameSubobjects : public VirtualPOFOperation {
 	using replacement_map = SCP_unordered_map<SCP_string, SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to>;
 	replacement_map replacements;
 	friend class VirtualPOFOperationAddSubmodel;
+	friend class VirtualPOFOperationAddTurret;
 public:
 	VirtualPOFOperationRenameSubobjects();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
@@ -51,6 +52,7 @@ class VirtualPOFOperationAddTurret : public VirtualPOFOperation {
 	SCP_string baseNameSrc, baseNameDest;
 	tl::optional<SCP_string> barrelNameDest;
 	SCP_string appendingPOF;
+	std::unique_ptr<VirtualPOFOperationRenameSubobjects> rename = nullptr;
 public:
 	VirtualPOFOperationAddTurret();
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;


### PR DESCRIPTION
The first big set of features for Virtual / Modular POFs (#4590)

Adds:
1. Copying Turrets
2. Copying Glowpoints
3. Copying Engines
4. Copying Special-Point Subsystems
5. Automatic handling of attached Glowpoints and Turrets when a Submodel Tree is copied

While not the proposed solution, this implements #3935 

