### PR TITLE
Flag to turn off continuous turn when attacking

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -146,6 +146,7 @@ namespace AI {
 		Fix_keep_safe_distance,
 		Ignore_aspect_when_leading,
 		Fix_good_rearm_time_bug,
+		No_continuous_turn_on_attack,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -602,6 +602,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix good-rearm-time bug:", AI::Profile_Flags::Fix_good_rearm_time_bug);
 
+				set_flag(profile, "$no continuous turn on attack:", AI::Profile_Flags::No_continuous_turn_on_attack);
+
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
@@ -772,5 +774,6 @@ void ai_profile_t::reset()
 	}
 	if (mod_supports_version(22, 4, 0)) {
 		flags.set(AI::Profile_Flags::Fix_good_rearm_time_bug);
+		flags.set(AI::Profile_Flags::No_continuous_turn_on_attack);
 	}
 }

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1110,7 +1110,7 @@ void ai_big_chase()
 			}
 		}
 
-		if (aip->target_time < 2.0f)
+		if (!aip->ai_profile_flags[AI::Profile_Flags::No_continuous_turn_on_attack] && aip->target_time < 2.0f)
 			if ((dot_to_enemy < 0.9f) || (dist_to_enemy > 300.0f)) {
 				aip->submode = SM_CONTINUOUS_TURN;
 				aip->submode_start_time = Missiontime - fl2f(2.75f);	//	This backdated start time allows immediate switchout.


### PR DESCRIPTION
When fightercraft are ordered to attack big ships (if they pass some very modest conditions) they will enter this submode, which has them do nothing but turn in place for a second or two. I have no idea what the intention of this was, and it frustrates modders attempts to understand wtf the AI is doing, in addition to looking bizarre. This submode is used in other contexts, which this flag does not touch.