### PR TITLE
Moved lab access to light multipliers to cleaner path

### DIFF
--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -96,6 +96,11 @@ bool lighting_profile_value::read_adjust(float *out) const
 	*out = adjust;
 	return has_adjust;
 }
+bool lighting_profile_value::read_multiplier(float *out) const
+{
+	*out = multipier;
+	return has_multiplier;
+}
 /**
  * @brief for use during the parsing of a light profile to attempt to read in an LPV
  *
@@ -457,10 +462,16 @@ piecewise_power_curve_values lighting_profile::lab_get_ppc(){
 }
 
 float lighting_profile::lab_get_light(){
-	return default_profile.overall_brightness.handle(1.0f);
+	float r;
+	default_profile.overall_brightness.read_multiplier(&r);
+
+	return r;
 }
 float lighting_profile::lab_get_ambient(){
-	return default_profile.ambient_light_brightness.handle(1.0f);
+	float r;
+	default_profile.ambient_light_brightness.read_multiplier(&r);
+
+	return r;
 }
 float lighting_profile::lab_get_emissive(){
 	float r;

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -59,6 +59,7 @@ struct lighting_profile_value{
 	void stack_minimum(const float in);
 
 	static bool parse(const char *filename, const char * valuename, const SCP_string &profile_name, lighting_profile_value* value_target, bool required=false);
+	bool read_multiplier(float *out) const;
 	bool read_adjust(float *out) const;
 
 private:


### PR DESCRIPTION
The new lighting controls in the lab were implemented poorly, this makes them accurate to what is actually in the tables and prevents some potential side effects in the old handling.