### PR TITLE
Minor fix for 0 duration animated effects

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19951,22 +19951,26 @@ void ship_render_set_animated_effect(model_render_params *render_info, ship *shi
 	float timer;
 
 	ship_effect* sep = &Ship_effects[shipp->shader_effect_num];
+	int current_time = timer_get_milliseconds();
 	
-	if ( sep->invert_timer ) {
-		timer = 1.0f - ((timer_get_milliseconds() - shipp->shader_effect_start_time) / (float)shipp->shader_effect_duration);
-		timer = MAX(timer,0.0f);
-	} else {
-		timer = ((timer_get_milliseconds() - shipp->shader_effect_start_time) / (float)shipp->shader_effect_duration);
+	if (shipp->shader_effect_duration > 0) {
+		if (sep->invert_timer) {
+			timer = 1.0f - ((current_time - shipp->shader_effect_start_time) / (float)shipp->shader_effect_duration);
+			timer = MAX(timer, 0.0f);
+		}
+		else {
+			timer = ((current_time - shipp->shader_effect_start_time) / (float)shipp->shader_effect_duration);
+		}
+
+		render_info->set_animated_effect(sep->shader_effect, timer);
 	}
 
-	render_info->set_animated_effect(sep->shader_effect, timer);
-
-	if ( sep->disables_rendering && (timer_get_milliseconds() > shipp->shader_effect_start_time + shipp->shader_effect_duration) ) {
+	if ( sep->disables_rendering && (current_time >= shipp->shader_effect_start_time + shipp->shader_effect_duration) ) {
 		shipp->flags.set(Ship_Flags::Cloaked);
 		shipp->shader_effect_active = false;
 	} else {
 		shipp->flags.remove(Ship_Flags::Cloaked);
-		if (timer_get_milliseconds() > shipp->shader_effect_start_time + shipp->shader_effect_duration) {
+		if (current_time >= shipp->shader_effect_start_time + shipp->shader_effect_duration) {
 			shipp->shader_effect_active = false;
 		}
 	}


### PR DESCRIPTION
Using the `Cloak` or `Decloak` effect with 0 duration is a commonly accepted way to make a ship invisible/visible, however there is still a single frame of 'half-cloaked', due to the way it is handled. Firstly, only bother setting an animated effect if the effect actually has a duration (which also avoids division by 0 problems), and secondly use `>=` instead of `>` so we can take 'visibility' effect on the same frame.