### PR TITLE
Make Wss_slots writable

### DIFF
--- a/code/missionui/missionweaponchoice.h
+++ b/code/missionui/missionweaponchoice.h
@@ -59,6 +59,8 @@ void wl_reset_selected_slot();
 void wl_remove_weps_from_pool(int *wep, int *wep_count, int ship_class);
 void wl_get_ship_class_weapons(int ship_class, int *wep, int *wep_count);
 void wl_get_default_weapons(int ship_class, int slot_num, int *wep, int *wep_count);
+int eval_weapon_flag_for_game_type(int weapon_flags);
+int wl_calc_missile_fit(int wi_index, int capacity);
 
 void wl_synch_interface();
 int wl_apply(int mode,int from_bank,int from_list,int to_bank,int to_list,int ship_slot,int player_index = -1, bool dont_play_sound = false);

--- a/code/scripting/api/objs/shipwepselect.cpp
+++ b/code/scripting/api/objs/shipwepselect.cpp
@@ -1,5 +1,7 @@
 #include "shipwepselect.h"
 #include "ship/ship.h"
+#include "weapon/weapon.h"
+#include "missionui/missionweaponchoice.h"
 
 namespace scripting {
 namespace api {
@@ -147,29 +149,44 @@ ADE_VIRTVAR(ShipClassIndex,
 ADE_OBJ(l_Loadout_Amount, wss_unit_count_h, "loadout_amount", "Loadout handle");
 
 ADE_INDEXER(l_Loadout_Amount,
-	"number idx",
+	"number bank, number amount",
 	"Array of ship bank weapons. 1-3 are Primary weapons. 4-7 are Secondary weapons. Note that banks "
-	"that do not exist on the ship class are still valid here but should hold nil data. Also note that "
-	"primary banks will also hold the value of 1 even if it is ballistic.",
+	"that do not exist on the ship class are still valid here as a loadout slot. Also note that "
+	"primary banks will hold the value of 1 even if it is ballistic. If the amount to set is greater than "
+	"the bank's capacity then it will be set to capacity. Set to -1 to empty the slot. Amounts less than -1 will be set to -1.",
 	"number",
 	"Amount of the currently loaded weapon, -1 if bank has no weapon, or nil if the ship or index is invalid")
 {
 	wss_unit_count_h current;
 	int idx = -1;
-	if (!ade_get_args(L, "oi", l_Loadout_Amount.Get(&current), &idx))
+	int amount;
+	if (!ade_get_args(L, "oi|i", l_Loadout_Amount.Get(&current), &idx, &amount))
 		return ADE_RETURN_NIL;
-
-	// Will eventually be writable so that Lua can manipulate the player loadout!
-	// Note may need to do some checking that the bank is valid for the current ship
-	// and that the amount-to-write is the correct size for the weapon/ship cargo size
-	if (ADE_SETTING_VAR) {
-		LuaError(L, "This property is read only.");
-	}
 
 	if (idx < 1 || idx > MAX_SHIP_WEAPONS) {
 		return ADE_RETURN_NIL;
 	};
-	idx--; // Convert to Lua's 1 based index system
+
+	idx--; // Convert from Lua
+	if (ADE_SETTING_VAR) {
+		ship_info* sip = &Ship_info[current.getBank()->ship_class];
+		weapon_info* wip = &Weapon_info[current.getBank()->wep[idx]];
+		int capacity = 0;
+		//Calculate max capacity of the weapon in the current bank
+		if (wip->subtype == WP_LASER) {
+			capacity = 1;
+		} else {
+			capacity = wl_calc_missile_fit(current.getBank()->wep[idx],
+				sip->secondary_bank_ammo_capacity[idx - MAX_SHIP_PRIMARY_BANKS]);
+		}
+		if (amount > capacity) {
+			amount = capacity;
+		} 
+		if (amount < -1){
+			amount = -1;
+		}
+		current.getBank()->wep_count[idx] = amount;
+	}
 
 	return ade_set_args(L, "i", current.getBank()->wep_count[idx]);
 }
@@ -183,29 +200,73 @@ ADE_FUNC(__len, l_Loadout_Amount, nullptr, "The number of weapon banks in the sl
 ADE_OBJ(l_Loadout_Weapon, wss_unit_wep_h, "loadout_weapon", "Loadout handle");
 
 ADE_INDEXER(l_Loadout_Weapon,
-	"number idx",
+	"number bank, number WeaponIndex",
 	"Array of ship bank weapons. 1-3 are Primary weapons. 4-7 are Secondary weapons. Note that banks "
-	"that do not exist on the ship class are still valid here as a loadout slot.",
+	"that do not exist on the ship class are still valid here as a loadout slot. When setting the weapon "
+	"it will be checked if it is valid for the ship and bank. If it is not then it will be set to -1 and the "
+	"amount will be set to -1. If it is valid for the ship then the amount is set to 0. Use .Amounts to set "
+	"the amount afterwards. Set to -1 to empty the slot.",
 	"number",
-	"index into Weapon Classes, 0 if bank is empty, or nil if the ship or index is invalid")
+	"index into Weapon Classes, 0 if bank is empty, -1 if the ship cannot carry the weapon, or nil if the ship or index is invalid")
 {
 	wss_unit_wep_h current;
-	int idx = -1;
-	if (!ade_get_args(L, "oi", l_Loadout_Weapon.Get(&current), &idx))
+	int bank = -1;
+	int wepIndex;
+	if (!ade_get_args(L, "oi|i", l_Loadout_Weapon.Get(&current), &bank, &wepIndex))
 		return ADE_RETURN_NIL;
 
-	// Will eventually be writable so that Lua can manipulate the player loadout!
-	// Note may need to do some checking that the bank is valid for the current ship
-	if (ADE_SETTING_VAR) {
-		LuaError(L, "This property is read only.");
-	}
-
-	if (idx < 1 || idx > MAX_SHIP_WEAPONS) {
+	if (bank < 1 || bank > MAX_SHIP_WEAPONS) {
 		return ADE_RETURN_NIL;
 	};
-	idx--; // Convert to Lua's 1 based index system
 
-	return ade_set_args(L, "i", current.getBank()->wep[idx] + 1);
+	ship_info* sip = &Ship_info[current.getBank()->ship_class];
+	int bankType = -1;
+	// Decide if we're setting a valid primary or secondary bank on the current ship class
+	if (bank <= sip->num_primary_banks) {
+		bankType = WP_LASER;
+	} else if (bank <= (sip->num_secondary_banks + MAX_SHIP_PRIMARY_BANKS)) {
+		bankType = WP_MISSILE;
+	}
+
+	wepIndex--; // Convert from Lua
+	bank--; //Convert from Lua
+	if (ADE_SETTING_VAR) {
+		if (bankType == -1 || wepIndex > weapon_info_size()) {
+			LuaError(L, "The provided bank or weapon index is invalid!");
+		} else {
+			bool valid = false;
+			//First we check that this is a valid bank for the ship and that the script is not trying to empty the bank
+			if (wepIndex > -1) {
+				// Next we check that this is a weapon the ship can carry
+				if (eval_weapon_flag_for_game_type(sip->restricted_loadout_flag[bank])) {
+					if (eval_weapon_flag_for_game_type(sip->allowed_bank_restricted_weapons[bank][wepIndex])) {
+						valid = true;
+					}
+				} else {
+					if (eval_weapon_flag_for_game_type(sip->allowed_weapons[wepIndex])) {
+						valid = true;
+					}
+				}
+			}
+			if (valid) {
+				//Now we double check that we're putting a primary in a primary slot or secondary in a secondary slot
+				weapon_info* wip = &Weapon_info[wepIndex];
+				if (wip->subtype == bankType) {
+					current.getBank()->wep[bank] = wepIndex;
+				} else {
+					LuaError(L, "Cannot put a primary in a secondary bank or a secondary in a primary bank!");
+				}
+				current.getBank()->wep_count[bank] = 0;
+			}
+			else {
+				//If the ship cannot carry this weapon in this bank then we set it to -1 and the amount to -1
+				current.getBank()->wep[bank] = -1;
+				current.getBank()->wep_count[bank] = -1;
+			}
+		}
+	}
+
+	return ade_set_args(L, "i", current.getBank()->wep[bank] + 1);
 }
 
 ADE_FUNC(__len, l_Loadout_Weapon, nullptr, "The number of weapon banks in the slot", "number", "The number of banks.")
@@ -218,19 +279,37 @@ ADE_OBJ(l_Loadout_Ship, int, "loadout_ship", "Loadout handle");
 
 ADE_VIRTVAR(ShipClassIndex,
 	l_Loadout_Ship,
-	nullptr,
-	"The index of the Ship Class",
+	"number",
+	"The index of the Ship Class. When setting the ship class this will also set the weapons to empty slots. Use "
+	".Weapons and .Amounts to set those afterwards. Set to -1 to empty the slot.",
 	"number",
 	"The index or nil if handle is invalid")
 {
 	int current;
-	if (!ade_get_args(L, "o", l_Loadout_Ship.Get(&current))) {
+	int shipIndex;
+	if (!ade_get_args(L, "o|i", l_Loadout_Ship.Get(&current), &shipIndex)) {
 		return ADE_RETURN_NIL;
 	}
 
-	// Will eventually be writable so that Lua can manipulate the player loadout!
+	shipIndex--; //Convert from Lua
+
 	if (ADE_SETTING_VAR) {
-		LuaError(L, "This property is read only.");
+		if (shipIndex > -1) {
+			// If we're not trying to empty the slot then make sure it's a valid ship index
+			if (shipIndex > ship_info_size()) {
+				LuaError(L, "The provided ship index is invalid!");
+			} else {
+				Wss_slots[current].ship_class = shipIndex;
+				//Reset all currently loaded weapons here
+				int i;
+				for (i = 0; i < MAX_SHIP_WEAPONS; i++) {
+					Wss_slots[current].wep[i] = -1;
+					Wss_slots[current].wep_count[i] = -1;
+				}
+			}
+		} else {
+			Wss_slots[current].ship_class = -1;
+		}
 	}
 
 	return ade_set_args(L, "i", (Wss_slots[current].ship_class + 1));


### PR DESCRIPTION
The next step for scpui loadout. This makes the loadout itself writable by Lua. It comes with checks in place to prevent setting weapon banks to invalid weapons for the current ship in the slot as well as preventing overloading the weapon amounts.