### PR TITLE
Reset loadout to default and handle commit mission error returns

### DIFF
--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -70,6 +70,8 @@ extern int Flash_bright;			// state of button to flash
 
 void common_button_do(int i);
 
+enum class commit_pressed_status { SUCCESS, GENERAL_FAIL, PLAYER_NO_WEAPONS,  NO_REQUIRED_WEAPON, NO_REQUIRED_WEAPON_MULTIPLE, BANK_GAP_ERROR};
+
 // common_select_init() performs initialization common to the briefing/ship select/weapon select
 // screens.  This includes loading/setting the palette, loading the background animation, loading
 // the screen switching animations, loading the button animation frames
@@ -79,7 +81,7 @@ void	common_select_close();
 void	common_draw_buttons();
 void	common_check_buttons();
 void	common_check_keys(int k);
-int 	commit_pressed(int API_Access = 0);
+commit_pressed_status commit_pressed(bool API_Access = false);
 void	common_render(float frametime);
 void	common_buttons_init(UI_WINDOW *ui_window);
 void	common_buttons_maybe_reload(UI_WINDOW *ui_window);

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -70,6 +70,7 @@ extern int Flash_bright;			// state of button to flash
 
 void common_button_do(int i);
 
+//If new enums are added here be sure to also update the description for the API version in scripting\api\libs\ui.cpp - Mjn
 enum class commit_pressed_status { SUCCESS, GENERAL_FAIL, PLAYER_NO_WEAPONS,  NO_REQUIRED_WEAPON, NO_REQUIRED_WEAPON_MULTIPLE, BANK_GAP_ERROR};
 
 // common_select_init() performs initialization common to the briefing/ship select/weapon select

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -79,7 +79,7 @@ void	common_select_close();
 void	common_draw_buttons();
 void	common_check_buttons();
 void	common_check_keys(int k);
-void	commit_pressed();
+int 	commit_pressed(int API_Access = 0);
 void	common_render(float frametime);
 void	common_buttons_init(UI_WINDOW *ui_window);
 void	common_buttons_maybe_reload(UI_WINDOW *ui_window);

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1887,7 +1887,7 @@ bool check_for_gaps_in_weapon_slots()
 // ------------------------------------------------------------------------
 // commit_pressed() is called when the commit button from any of the briefing/ship select/ weapon
 // select screens is pressed.  The ship selected is created, and the interface music is stopped.
-void commit_pressed()
+int commit_pressed(int API_Access)
 {
 	int j, player_ship_info_index;
 	
@@ -1897,7 +1897,7 @@ void commit_pressed()
 			rc = create_wings();
 			if (rc != 0) {
 				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
-				return;
+				return 1;
 			}
 		}
 	}
@@ -1913,8 +1913,10 @@ void commit_pressed()
 
 		update_player_ship( player_ship_info_index );
 		if ( wl_update_ship_weapons(Ships[Player_obj->instance].objnum, &Wss_slots[0]) == -1 ) {
-			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "Player ship has no weapons", 461));
-			return;
+			if (!API_Access) {
+				popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Player ship has no weapons", 461));
+			}
+			return 2;
 		}
 	}
 
@@ -1941,13 +1943,27 @@ void commit_pressed()
 	{
 		if (num_required_weapons == 1)
 		{
-			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("The %s is required for this mission, but it has not been added to any ship loadout.", 1624), weapon_list.c_str());
-			return;
+			if (!API_Access) {
+				popup(PF_USE_AFFIRMATIVE_ICON,
+					1,
+					POPUP_OK,
+					XSTR("The %s is required for this mission, but it has not been added to any ship loadout.", 1624),
+					weapon_list.c_str());
+			} 
+			return 3;
 		}
 		else if (num_required_weapons > 1)
 		{
-			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("The following weapons are required for this mission, but at least one of them has not been added to any ship loadout:\n\n%s", 1625), weapon_list.c_str());
-			return;
+			if (!API_Access) {
+				popup(PF_USE_AFFIRMATIVE_ICON,
+					1,
+					POPUP_OK,
+					XSTR("The following weapons are required for this mission, but at least one of them has not been "
+						 "added to any ship loadout:\n\n%s",
+						1625),
+					weapon_list.c_str());
+			} 
+			return 4;
 		}
 	}
 
@@ -1957,8 +1973,16 @@ void commit_pressed()
 	// Note2: don't check missions without briefings either
 	if (check_for_gaps_in_weapon_slots() && !(The_mission.game_type & MISSION_TYPE_TRAINING) && !The_mission.flags[Mission::Mission_Flags::Scramble, Mission::Mission_Flags::Red_alert, Mission::Mission_Flags::No_briefing])
 	{
-		popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("At least one ship has an empty weapon bank before a full weapon bank.\n\nAll weapon banks must have weapons assigned, or if there are any gaps, they must be at the bottom of the set of banks.", 1642), weapon_list.c_str());
-		return;
+		if (!API_Access) {
+			popup(PF_USE_AFFIRMATIVE_ICON,
+				1,
+				POPUP_OK,
+				XSTR("At least one ship has an empty weapon bank before a full weapon bank.\n\nAll weapon banks must "
+					 "have weapons assigned, or if there are any gaps, they must be at the bottom of the set of banks.",
+					1642),
+				weapon_list.c_str());
+		} 
+		return 5;
 	}
 
 	// Check to ensure that the hotkeys are still pointing to valid objects.  It is possible
@@ -2008,6 +2032,8 @@ void commit_pressed()
 		Pilot.save_savefile();
 		gameseq_post_event(GS_EVENT_ENTER_GAME);
 	}
+
+	return 0;
 }
 
 // ------------------------------------------------------------------------

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1887,7 +1887,7 @@ bool check_for_gaps_in_weapon_slots()
 // ------------------------------------------------------------------------
 // commit_pressed() is called when the commit button from any of the briefing/ship select/ weapon
 // select screens is pressed.  The ship selected is created, and the interface music is stopped.
-int commit_pressed(int API_Access)
+commit_pressed_status commit_pressed(bool API_Access)
 {
 	int j, player_ship_info_index;
 	
@@ -1897,7 +1897,7 @@ int commit_pressed(int API_Access)
 			rc = create_wings();
 			if (rc != 0) {
 				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
-				return 1;
+				return commit_pressed_status::GENERAL_FAIL;
 			}
 		}
 	}
@@ -1916,7 +1916,7 @@ int commit_pressed(int API_Access)
 			if (!API_Access) {
 				popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Player ship has no weapons", 461));
 			}
-			return 2;
+			return commit_pressed_status::PLAYER_NO_WEAPONS;
 		}
 	}
 
@@ -1950,7 +1950,7 @@ int commit_pressed(int API_Access)
 					XSTR("The %s is required for this mission, but it has not been added to any ship loadout.", 1624),
 					weapon_list.c_str());
 			} 
-			return 3;
+			return commit_pressed_status::NO_REQUIRED_WEAPON;
 		}
 		else if (num_required_weapons > 1)
 		{
@@ -1963,7 +1963,7 @@ int commit_pressed(int API_Access)
 						1625),
 					weapon_list.c_str());
 			} 
-			return 4;
+			return commit_pressed_status::NO_REQUIRED_WEAPON_MULTIPLE;
 		}
 	}
 
@@ -1982,7 +1982,7 @@ int commit_pressed(int API_Access)
 					1642),
 				weapon_list.c_str());
 		} 
-		return 5;
+		return commit_pressed_status::BANK_GAP_ERROR;
 	}
 
 	// Check to ensure that the hotkeys are still pointing to valid objects.  It is possible
@@ -2033,7 +2033,7 @@ int commit_pressed(int API_Access)
 		gameseq_post_event(GS_EVENT_ENTER_GAME);
 	}
 
-	return 0;
+	return commit_pressed_status::SUCCESS;
 }
 
 // ------------------------------------------------------------------------

--- a/code/missionui/missionshipchoice.h
+++ b/code/missionui/missionshipchoice.h
@@ -14,6 +14,7 @@
 
 #include "gamesnd/gamesnd.h"
 #include "missionui/missionscreencommon.h"
+#include "mission/missionparse.h"
 
 class p_object;
 
@@ -89,6 +90,9 @@ void ship_select_common_init();
 void ship_select_common_close();
 int ss_get_ship_class(int ship_entry_index);
 int ss_get_selected_ship();
+
+void ss_init_pool(team_data *pteam);
+void ss_init_units();
 
 void ss_blit_ship_icon(int x,int y,int ship_class,int bmap_num);
 

--- a/code/missionui/missionweaponchoice.h
+++ b/code/missionui/missionweaponchoice.h
@@ -52,6 +52,7 @@ void	wl_bash_ship_weapons(ship_weapon *swp, wss_unit *slot);
 
 void wl_set_default_weapons(int index, int ship_class);
 void wl_reset_to_defaults();
+void wl_fill_slots();
 
 // Set selected slot to first placed ship
 void wl_reset_selected_slot();

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -2642,7 +2642,6 @@ void multi_ts_commit_pressed()
 	switch(multi_ts_ok_to_commit()){
 	// yes, it _is_ ok to commit
 	case 0:
-		extern void commit_pressed();
 		commit_pressed();
 		break;
 

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -685,13 +685,14 @@ ADE_FUNC(skipTraining,
 ADE_FUNC(commitToMission,
 	l_UserInterface_Brief,
 	nullptr,
-	"Commits to the current mission with current loadout data, and starts the mission. WIP, do not use!",
-	nullptr,
-	nullptr)
+	"Commits to the current mission with current loadout data, and starts the mission. Returns an integer to represent "
+	"built-in errors or 0 if successful. 1 = general error, 2 = player ship has no weapons, 3 = the required weapon was not found "
+	"loaded on a ship, 4 = 2 or more required weapons were not found loaded on a ship, 5 = a gap in a ship's weapon banks was discovered "
+	"and all empty banks must be at the bottom of the list.",
+	"number error",
+	"the error value")
 {
-	SCP_UNUSED(L);
-	commit_pressed();
-	return ADE_RETURN_NIL;
+	return ade_set_args(L, "i", commit_pressed(1));
 }
 
 ADE_FUNC(drawBriefingMap,
@@ -1254,6 +1255,28 @@ ADE_FUNC(__len,
 	l_Weapon_Pool, nullptr, "The number of weapon classes in the pool", "number", "The number of weapon classes.")
 {
 	return ade_set_args(L, "i", weapon_info_size());
+}
+
+ADE_FUNC(resetSelect,
+	l_UserInterface_ShipWepSelect,
+	nullptr,
+	"Resets selection data to mission defaults including wing slots, ship and weapon pool, and loadout information",
+	nullptr,
+	nullptr)
+{
+	// Note this does all the things from ss_reset_to_default() in missionshipchoice.cpp except
+	// resetting UI elements - Mjn
+
+	SCP_UNUSED(L); // unused parameter
+
+	ss_init_pool(&Team_data[Common_team]);
+	ss_init_units();
+
+	if (!(Game_mode & GM_MULTIPLAYER)) {
+		wl_fill_slots();
+	}
+
+	return ADE_RETURN_NIL;
 }
 
 ADE_LIB_DERIV(l_Loadout_Wings, "Loadout_Wings", nullptr, nullptr, l_UserInterface_ShipWepSelect);

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -692,7 +692,7 @@ ADE_FUNC(commitToMission,
 	"number error",
 	"the error value")
 {
-	return ade_set_args(L, "i", commit_pressed(1));
+	return ade_set_args(L, "i", static_cast<int>(commit_pressed(true)));
 }
 
 ADE_FUNC(drawBriefingMap,


### PR DESCRIPTION
Changes `commit_pressed()` from a void to an int and introduces return values based on the built-in errors. Also adds an API_Access parameter to suppress popups if true so that scpui can handle them with it's own dialog prompts.

Also adds resetSelect() which resets Wss_slots, Ss_pool, and Wl_pool to the mission's default loadout.

Tests of both are working as intended to both scpui Commit presses and retail Commit presses.