### PR TITLE
Fix Remove-Order not working for Play Dead Orders

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -147,6 +147,7 @@ namespace AI {
 		Ignore_aspect_when_leading,
 		Fix_good_rearm_time_bug,
 		No_continuous_turn_on_attack,
+		Fixed_removing_play_dead_order,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -604,6 +604,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$no continuous turn on attack:", AI::Profile_Flags::No_continuous_turn_on_attack);
 
+				set_flag(profile, "$remove-goal properly removes play-dead order:", AI::Profile_Flags::Fixed_removing_play_dead_order);
+
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
@@ -775,5 +777,6 @@ void ai_profile_t::reset()
 	if (mod_supports_version(22, 4, 0)) {
 		flags.set(AI::Profile_Flags::Fix_good_rearm_time_bug);
 		flags.set(AI::Profile_Flags::No_continuous_turn_on_attack);
+		flags.set(AI::Profile_Flags::Fixed_removing_play_dead_order);
 	}
 }

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -311,7 +311,7 @@ void ai_remove_ship_goal( ai_info *aip, int index )
 		// wookieejedi - play dead needs some extra cleanup, too
 		// there is an early return for the mode AIM_PLAY_DEAD in AI frame, so it needs to be set back to AIM_NONE
 		if (aip->ai_profile_flags[AI::Profile_Flags::Fixed_removing_play_dead_order] && 
-			aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD || aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD_PERSISTENT) {
+			(aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD || aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD_PERSISTENT)) {
 			aip->mode = AIM_NONE;
 			aip->submode_start_time = Missiontime;
 		}

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -309,8 +309,9 @@ void ai_remove_ship_goal( ai_info *aip, int index )
 			ai_abort_rearm_request(&Objects[Ships[aip->shipnum].objnum]);
 
 		// wookieejedi - play dead needs some extra cleanup, too
-		// there is an early return for AIM_PLAY_DEAD in AI frame, so it needs to be removed
-		if (aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD || aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD_PERSISTENT) {
+		// there is an early return for the mode AIM_PLAY_DEAD in AI frame, so it needs to be set back to AIM_NONE
+		if (aip->ai_profile_flags[AI::Profile_Flags::Fixed_removing_play_dead_order] && 
+			aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD || aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD_PERSISTENT) {
 			aip->mode = AIM_NONE;
 			aip->submode_start_time = Missiontime;
 		}

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -308,6 +308,13 @@ void ai_remove_ship_goal( ai_info *aip, int index )
 		if (aip->goals[index].ai_mode == AI_GOAL_REARM_REPAIR)
 			ai_abort_rearm_request(&Objects[Ships[aip->shipnum].objnum]);
 
+		// wookieejedi - play dead needs some extra cleanup, too
+		// there is an early return for AIM_PLAY_DEAD in AI frame, so it needs to be removed
+		if (aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD || aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD_PERSISTENT) {
+			aip->mode = AIM_NONE;
+			aip->submode_start_time = Missiontime;
+		}
+
 		aip->active_goal = AI_GOAL_NONE;
 	}
 


### PR DESCRIPTION
Play-dead orders set a special case of the ai mode (`AIM_PLAY_DEAD`), which had special handling to return early in the AI frame function. Remove-order does not change the ai mode though, and thus even when a play-dead order was removed the `AIM_PLAY_DEAD` remained, which would continually trigger an early out in AI frame, which in turn would make turrets not fire on ships, even when the play-dead order was removed. No other orders had this early return, which is why remove order works for them.

This PR accounts for that special handling case. There also seemed to be an extra cleanup line for rearm and repair, so this was added right after that step.

Tested and works as expected.