### PR TITLE
isDisabled returns if the ship is used in the mission

### DIFF
--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -3093,6 +3093,7 @@ void ss_init_units()
 		for ( j = 0; j < ss_wing->num_slots; j++ ) {
 				
 			ss_slot = &ss_wing->ss_slots[j];
+			ss_slot->in_mission = true;
 
 			if ( ss_slot->sa_index == -1 ) {
 				ss_slot->original_ship_class = Ships[wp->ship_index[j]].ship_info_index;

--- a/code/missionui/missionshipchoice.h
+++ b/code/missionui/missionshipchoice.h
@@ -68,6 +68,7 @@ typedef struct ss_slot_info {
 	int status;   // slot status (WING_SLOT_DISABLED, etc)
 	int sa_index; // index into ship arrival list, -1 if ship is created
 	int original_ship_class;
+	bool in_mission = false;
 } ss_slot_info;
 
 typedef struct ss_wing_info {

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1201,7 +1201,7 @@ ADE_INDEXER(l_Loadout_Wings, //
 
 ADE_FUNC(__len, l_Loadout_Wings, nullptr, "The number of loadout wings", "number", "The number of loadout wings.")
 {
-	return ade_set_args(L, "i", Ss_wings->num_slots);
+	return ade_set_args(L, "i", MAX_STARTING_WINGS);
 }
 
 ADE_LIB_DERIV(l_Loadout_Ships, "Loadout_Ships", nullptr, nullptr, l_UserInterface_ShipWepSelect);

--- a/code/scripting/api/objs/shipwepselect.cpp
+++ b/code/scripting/api/objs/shipwepselect.cpp
@@ -77,7 +77,7 @@ ADE_VIRTVAR(isWeaponLocked,
 	l_Loadout_Wing_Slot,
 	nullptr,
 	"If the slot's weapons are locked",
-	"string",
+	"boolean",
 	"The slot weapon status")
 {
 	ss_slot_info_h current;
@@ -92,7 +92,7 @@ ADE_VIRTVAR(isWeaponLocked,
 	return ade_set_args(L, "b", (current.getSlot()->status & WING_SLOT_WEAPONS_DISABLED) != 0);
 }
 
-ADE_VIRTVAR(isDisabled, l_Loadout_Wing_Slot, nullptr, "If the slot is disabled", "string", "The slot disabled status")
+ADE_VIRTVAR(isDisabled, l_Loadout_Wing_Slot, nullptr, "If the slot is not used in the current mission", "boolean", "The slot disabled status")
 {
 	ss_slot_info_h current;
 	if (!ade_get_args(L, "o", l_Loadout_Wing_Slot.Get(&current))) {
@@ -103,16 +103,10 @@ ADE_VIRTVAR(isDisabled, l_Loadout_Wing_Slot, nullptr, "If the slot is disabled",
 		LuaError(L, "This property is read only.");
 	}
 
-	//Player ships are marked as disabled for some reason, but scpui needs to assume they aren't
-	bool result = false;
-	if (!((current.getSlot()->status & WING_SLOT_IS_PLAYER) != 0)) {
-		result = !((current.getSlot()->status & WING_SLOT_DISABLED) != 0);
-	};
-
-	return ade_set_args(L, "b", result);
+	return ade_set_args(L, "b", !current.getSlot()->in_mission);
 }
 
-ADE_VIRTVAR(isPlayer, l_Loadout_Wing_Slot, nullptr, "If the slot is a player ship", "string", "The slot player status")
+ADE_VIRTVAR(isPlayer, l_Loadout_Wing_Slot, nullptr, "If the slot is a player ship", "boolean", "The slot player status")
 {
 	ss_slot_info_h current;
 	if (!ade_get_args(L, "o", l_Loadout_Wing_Slot.Get(&current))) {


### PR DESCRIPTION
Changes isDisabled to return the value that was always intended; if the ship slot is used in the mission or not. Fix some documentation while I'm in there. Also changes #Loadout_Wings to always return MAX_STARTING_WINGS because Wss_slots can apparently store more wings than that, but they shouldn't ever be used.