### PR TITLE
return the actual number of starting wings

### DIFF
--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -3008,6 +3008,7 @@ void ss_clear_slots()
 			slot->status = WING_SLOT_LOCKED;
 			slot->sa_index = -1;
 			slot->original_ship_class = -1;
+			slot->in_mission = false;
 		}
 	}
 }

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1295,7 +1295,14 @@ ADE_INDEXER(l_Loadout_Wings,
 
 ADE_FUNC(__len, l_Loadout_Wings, nullptr, "The number of loadout wings", "number", "The number of loadout wings.")
 {
-	return ade_set_args(L, "i", MAX_STARTING_WINGS);
+	int count = 0;
+
+	for (int i = 0; i < MAX_STARTING_WINGS; i++) {
+		if (Ss_wings[i].ss_slots[0].in_mission)
+			count++;
+	};
+
+	return ade_set_args(L, "i", count);
 }
 
 ADE_LIB_DERIV(l_Loadout_Ships, "Loadout_Ships", nullptr, nullptr, l_UserInterface_ShipWepSelect);


### PR DESCRIPTION
Instead of always returning 3, this now checks that a wing has a ship actually used in the mission and will return 0-3 properly. Also makes sure to clear `in_mission` in all the slots when appropriate so that the count is, indeed, accurate.