### PR TITLE
Add local coordinate relations to allow restoring old absolute behaviour

### DIFF
--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -74,9 +74,11 @@ namespace animation {
 			}
 
 			/* fall-thru */
-		case ModelAnimationState::NEED_RECALC:
+		case ModelAnimationState::NEED_RECALC: {
+			ModelAnimationSubmodelBuffer currentAnimationDelta;
+			m_set->initializeSubmodelBuffer(pmi, currentAnimationDelta);
 			//Store the submodels current data as the base for this animation and calculate this animations parameters
-			m_animation->recalculate(applyBuffer, pmi);
+			m_animation->recalculate(applyBuffer, currentAnimationDelta, pmi);
 
 			instanceData.duration = m_animation->getDuration(pmi->id);
 			instanceData.state = ModelAnimationState::RUNNING_FWD;
@@ -87,8 +89,9 @@ namespace animation {
 				if (m_flags[Animation_Flags::Loop, Animation_Flags::Auto_Reverse] && !m_flags[Animation_Flags::Reset_at_completion] && util::Random::flip_coin()) {
 					instanceData.state = ModelAnimationState::RUNNING_RWD;
 					break; //In this case, we must delay for a frame
-				}		
+				}
 			}
+		}
 
 			/* fall-thru */
 		case ModelAnimationState::RUNNING_FWD:
@@ -1463,7 +1466,7 @@ namespace animation {
 			}
 			else {
 				auto subsys = sip->animations.getSubmodel(sp->subobj_name);
-				auto rot = std::shared_ptr<ModelAnimationSegmentSetOrientation>(new ModelAnimationSegmentSetOrientation(subsys, angle, isRelative));
+				auto rot = std::shared_ptr<ModelAnimationSegmentSetOrientation>(new ModelAnimationSegmentSetOrientation(subsys, angle, isRelative ? ModelAnimationCoordinateRelation::RELATIVE_COORDS : ModelAnimationCoordinateRelation::ABSOLUTE_COORDS));
 				anim->setAnimation(std::move(rot));
 			}
 
@@ -1533,7 +1536,7 @@ namespace animation {
 				//Hence, throw time away, and let the segment handle calculating how long it actually takes
 			}
 
-			auto rotation = std::shared_ptr<ModelAnimationSegmentRotation>(new ModelAnimationSegmentRotation(subsys, target, velocity, tl::nullopt, acceleration, absolute));
+			auto rotation = std::shared_ptr<ModelAnimationSegmentRotation>(new ModelAnimationSegmentRotation(subsys, target, velocity, tl::nullopt, acceleration, absolute ? ModelAnimationCoordinateRelation::ABSOLUTE_COORDS : ModelAnimationCoordinateRelation::RELATIVE_COORDS));
 
 			if (optional_string("$Sound:")) {
 				gamesnd_id start_sound;

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -1150,6 +1150,11 @@ namespace animation {
 
 	}
 
+	ModelAnimationCoordinateRelation ModelAnimationParseHelper::parseCoordinateRelation() {
+		int result = optional_string_one_of(3, "+Relative", "+Local", "+Absolute");
+		return static_cast<ModelAnimationCoordinateRelation>(result < 0 ? 0 : result);
+	}
+
 	void ModelAnimationParseHelper::parseSingleAnimation() {
 
 		ModelAnimationParseHelper helper;

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -391,6 +391,7 @@ namespace animation {
 		std::shared_ptr<ModelAnimationSubmodel> parentSubmodel = nullptr;
 
 		static std::shared_ptr<ModelAnimationSubmodel> parseSubmodel();
+		static ModelAnimationCoordinateRelation parseCoordinateRelation();
 
 		static void parseTables();
 		static void parseAnimsetInfo(ModelAnimationSet& set, ship_info* sip);

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -70,6 +70,8 @@ namespace animation {
 		NUM_VALUES
 	};
 
+	enum class ModelAnimationCoordinateRelation : int { RELATIVE_COORDS, LOCAL_ABSOLUTE, ABSOLUTE_COORDS };
+
 	template <bool is_optional = false>
 	struct ModelAnimationData {
 	private:

--- a/code/model/modelanimation.h
+++ b/code/model/modelanimation.h
@@ -193,7 +193,7 @@ namespace animation {
 		//This function needs to provide a deep copy operation that returns a copy of this segment, including with all potential child segments copied as well.
 		virtual ModelAnimationSegment* copy() const = 0;
 		//Will be called to give the animations an opportunity to recalculate based on current ship data, as well as animation data up to that point.
-		virtual void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) = 0;
+		virtual void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& currentAnimDelta, polymodel_instance* pmi) = 0;
 		//This function needs to contain anything that manipulates ModelAnimationData (such as any movement)
 		virtual void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const = 0;
 		//This function needs to contain any animation parts that do not change ModelAnimationData (such as sound or particles)

--- a/code/model/modelanimation_moveables.cpp
+++ b/code/model/modelanimation_moveables.cpp
@@ -34,7 +34,7 @@ namespace animation {
 
 		anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(false, false, true, parentSet));
 
-		anim->setAnimation(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(parentSet->getSubmodel(m_submodel), m_defaultPosOrient, true)));
+		anim->setAnimation(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(parentSet->getSubmodel(m_submodel), m_defaultPosOrient, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
 
 		anim->start(pmi,ModelAnimationDirection::FWD);
 	}
@@ -100,8 +100,8 @@ namespace animation {
 		auto submodel = parentSet->getSubmodel(m_submodel);
 		
 		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, orient, true)));
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentRotation(submodel, m_defaultPosOrient, m_velocity, tl::nullopt, m_acceleration, true)));
+		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, orient, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
+		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentRotation(submodel, m_defaultPosOrient, m_velocity, tl::nullopt, m_acceleration, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS)));
 		
 		anim->setAnimation(sequence);
 
@@ -186,7 +186,7 @@ namespace animation {
 		auto submodel = parentSet->getSubmodel(m_submodel);
 
 		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, vmd_identity_matrix, true)));
+		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, vmd_identity_matrix, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
 		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentAxisRotation(submodel, 0.0f, m_velocity, tl::nullopt, m_acceleration, m_axis)));
 
 		anim->setAnimation(sequence);
@@ -282,7 +282,7 @@ namespace animation {
 		auto parallelSetOrient = std::shared_ptr<ModelAnimationSegmentParallel>(new ModelAnimationSegmentParallel());
 		for(const auto& link : m_chain) {
 			auto submodel = parentSet->getSubmodel(link.submodel);
-			parallelSetOrient->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, vmd_identity_matrix, true)));
+			parallelSetOrient->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, vmd_identity_matrix, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
 		}
 		sequence->addSegment(parallelSetOrient);
 		
@@ -298,7 +298,7 @@ namespace animation {
 		
 		for(const auto& link : m_chain) {
 			auto submodel = parentSet->getSubmodel(link.submodel);
-			auto rotation = std::shared_ptr<ModelAnimationSegmentRotation>(new ModelAnimationSegmentRotation(submodel, tl::optional<angles>({0,0,0}), tl::nullopt, m_time, link.acceleration, true));
+			auto rotation = std::shared_ptr<ModelAnimationSegmentRotation>(new ModelAnimationSegmentRotation(submodel, tl::optional<angles>({0,0,0}), tl::nullopt, m_time, link.acceleration, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS));
 			parallelIK->addSegment(rotation);
 			segment->m_chain.push_back({submodel, link.constraint, rotation});
 		}

--- a/code/model/modelanimation_segments.cpp
+++ b/code/model/modelanimation_segments.cpp
@@ -226,8 +226,7 @@ namespace animation {
 
 		required_string("+Angle:");
 		stuff_angles_deg_phb(&angle);
-		int result = optional_string_one_of(3, "+Relative", "+Local", "+Absolute");
-		ModelAnimationCoordinateRelation isRelative = static_cast<ModelAnimationCoordinateRelation>(result < 0 ? 0 : result);
+		ModelAnimationCoordinateRelation isAbsolute = ModelAnimationParseHelper::parseCoordinateRelation();
 
 		auto submodel = ModelAnimationParseHelper::parseSubmodel();
 
@@ -238,7 +237,7 @@ namespace animation {
 				error_display(1, "Set Orientation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSetOrientation>(new ModelAnimationSegmentSetOrientation(submodel, angle, isRelative));
+		auto segment = std::shared_ptr<ModelAnimationSegmentSetOrientation>(new ModelAnimationSegmentSetOrientation(submodel, angle, isAbsolute));
 
 		return segment;
 	}
@@ -564,8 +563,7 @@ namespace animation {
 			angles parse;
 			stuff_angles_deg_phb(&parse);
 			angle = std::move(parse);
-			int result = optional_string_one_of(3, "+Relative", "+Local", "+Absolute");
-			isAbsolute = static_cast<ModelAnimationCoordinateRelation>(result < 0 ? 0 : result);
+			isAbsolute = ModelAnimationParseHelper::parseCoordinateRelation();
 		}
 
 		if (optional_string("+Velocity:")) {
@@ -1112,8 +1110,7 @@ namespace animation {
 			vec3d parse;
 			stuff_vec3d(&parse);
 			offset = std::move(parse);
-			int result = optional_string_one_of(3, "+Relative", "+Local", "+Absolute");
-			isAbsolute = static_cast<ModelAnimationCoordinateRelation>(result < 0 ? 0 : result);
+			isAbsolute = ModelAnimationParseHelper::parseCoordinateRelation();
 		}
 
 		if (optional_string("+Velocity:")) {

--- a/code/model/modelanimation_segments.h
+++ b/code/model/modelanimation_segments.h
@@ -5,8 +5,6 @@
 
 namespace animation {
 
-	enum class ModelAnimationCoordinateRelation { RELATIVE_COORDS, LOCAL_ABSOLUTE, ABSOLUTE_COORDS };
-
 	//This segment handles multiple generic segments chained after one another
 	class ModelAnimationSegmentSerial : public ModelAnimationSegment {
 		//configureables:
@@ -78,7 +76,7 @@ namespace animation {
 		std::shared_ptr<ModelAnimationSubmodel> m_submodel;
 		tl::optional<angles> m_targetAngle;
 		tl::optional<matrix> m_targetOrientation;
-		ModelAnimationCoordinateRelation m_isAngleRelative;
+		ModelAnimationCoordinateRelation m_relationType;
 
 	private:
 		ModelAnimationSegment* copy() const override;
@@ -89,8 +87,8 @@ namespace animation {
 
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
-		ModelAnimationSegmentSetOrientation(std::shared_ptr<ModelAnimationSubmodel> submodel, const angles& angle, ModelAnimationCoordinateRelation isAngleRelative);
-		ModelAnimationSegmentSetOrientation(std::shared_ptr<ModelAnimationSubmodel> submodel, const matrix& orientation, ModelAnimationCoordinateRelation isAngleRelative);
+		ModelAnimationSegmentSetOrientation(std::shared_ptr<ModelAnimationSubmodel> submodel, const angles& angle, ModelAnimationCoordinateRelation relationType);
+		ModelAnimationSegmentSetOrientation(std::shared_ptr<ModelAnimationSubmodel> submodel, const matrix& orientation, ModelAnimationCoordinateRelation relationType);
 	};
 
 	//This segment rotates a submodels orientation by a certain amount around its defined rotation axis
@@ -134,7 +132,7 @@ namespace animation {
 		tl::optional<angles> m_velocity;
 		tl::optional<float> m_time;
 		tl::optional<angles> m_acceleration;
-		ModelAnimationCoordinateRelation m_isAbsolute;
+		ModelAnimationCoordinateRelation m_relationType;
 
 	private:
 		ModelAnimationSegment* copy() const override;
@@ -145,7 +143,7 @@ namespace animation {
 
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
-		ModelAnimationSegmentRotation(std::shared_ptr<ModelAnimationSubmodel> submodel, tl::optional<angles> targetAngle, tl::optional<angles> velocity, tl::optional<float> time, tl::optional<angles> acceleration, ModelAnimationCoordinateRelation isAbsolute = ModelAnimationCoordinateRelation::RELATIVE_COORDS);
+		ModelAnimationSegmentRotation(std::shared_ptr<ModelAnimationSubmodel> submodel, tl::optional<angles> targetAngle, tl::optional<angles> velocity, tl::optional<float> time, tl::optional<angles> acceleration, ModelAnimationCoordinateRelation relationType = ModelAnimationCoordinateRelation::RELATIVE_COORDS);
 
 	};
 
@@ -206,7 +204,7 @@ namespace animation {
 		tl::optional<float> m_time;
 		tl::optional<vec3d> m_acceleration;
 		enum class CoordinateSystem { COORDS_PARENT, COORDS_LOCAL_AT_START, COORDS_LOCAL_CURRENT } m_coordType;
-		ModelAnimationCoordinateRelation m_isAbsolute;
+		ModelAnimationCoordinateRelation m_relationType;
 
 	private:
 
@@ -217,7 +215,7 @@ namespace animation {
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
-		ModelAnimationSegmentTranslation(std::shared_ptr<ModelAnimationSubmodel> submodel, tl::optional<vec3d> target, tl::optional<vec3d> velocity, tl::optional<float> time, tl::optional<vec3d> acceleration, CoordinateSystem coordType = CoordinateSystem::COORDS_PARENT, ModelAnimationCoordinateRelation isAbsolute = ModelAnimationCoordinateRelation::RELATIVE_COORDS);
+		ModelAnimationSegmentTranslation(std::shared_ptr<ModelAnimationSubmodel> submodel, tl::optional<vec3d> target, tl::optional<vec3d> velocity, tl::optional<float> time, tl::optional<vec3d> acceleration, CoordinateSystem coordType = CoordinateSystem::COORDS_PARENT, ModelAnimationCoordinateRelation relationType = ModelAnimationCoordinateRelation::RELATIVE_COORDS);
 
 	};
 

--- a/code/model/modelanimation_segments.h
+++ b/code/model/modelanimation_segments.h
@@ -5,6 +5,8 @@
 
 namespace animation {
 
+	enum class ModelAnimationCoordinateRelation { RELATIVE_COORDS, LOCAL_ABSOLUTE, ABSOLUTE_COORDS };
+
 	//This segment handles multiple generic segments chained after one another
 	class ModelAnimationSegmentSerial : public ModelAnimationSegment {
 		//configureables:
@@ -12,7 +14,7 @@ namespace animation {
 		std::vector<std::shared_ptr<ModelAnimationSegment>> m_segments;
 
 	private:
-		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& currentAnimDelta, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
@@ -31,7 +33,7 @@ namespace animation {
 		std::vector<std::shared_ptr<ModelAnimationSegment>> m_segments;
 
 	private:
-		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& currentAnimDelta, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
@@ -51,7 +53,7 @@ namespace animation {
 
 	private:
 		ModelAnimationSegment* copy() const override;
-		void recalculate(ModelAnimationSubmodelBuffer& /*base*/, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& /*base*/, ModelAnimationSubmodelBuffer& /*currentAnimDelta*/, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& /*base*/, float /*time*/, int /*pmi_id*/) const override { };
 		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
 		void exchangeSubmodelPointers(ModelAnimationSet& /*replaceWith*/) override { };
@@ -76,19 +78,19 @@ namespace animation {
 		std::shared_ptr<ModelAnimationSubmodel> m_submodel;
 		tl::optional<angles> m_targetAngle;
 		tl::optional<matrix> m_targetOrientation;
-		bool m_isAngleRelative;
+		ModelAnimationCoordinateRelation m_isAngleRelative;
 
 	private:
 		ModelAnimationSegment* copy() const override;
-		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& currentAnimDelta, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float /*time*/, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
 
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
-		ModelAnimationSegmentSetOrientation(std::shared_ptr<ModelAnimationSubmodel> submodel, const angles& angle, bool isAngleRelative);
-		ModelAnimationSegmentSetOrientation(std::shared_ptr<ModelAnimationSubmodel> submodel, const matrix& orientation, bool isAngleRelative);
+		ModelAnimationSegmentSetOrientation(std::shared_ptr<ModelAnimationSubmodel> submodel, const angles& angle, ModelAnimationCoordinateRelation isAngleRelative);
+		ModelAnimationSegmentSetOrientation(std::shared_ptr<ModelAnimationSubmodel> submodel, const matrix& orientation, ModelAnimationCoordinateRelation isAngleRelative);
 	};
 
 	//This segment rotates a submodels orientation by a certain amount around its defined rotation axis
@@ -101,7 +103,7 @@ namespace animation {
 
 	private:
 		ModelAnimationSegment* copy() const override;
-		void recalculate(ModelAnimationSubmodelBuffer& /*base*/, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& /*base*/, ModelAnimationSubmodelBuffer& /*currentAnimDelta*/, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float /*time*/, int /*pmi_id*/) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
@@ -132,18 +134,18 @@ namespace animation {
 		tl::optional<angles> m_velocity;
 		tl::optional<float> m_time;
 		tl::optional<angles> m_acceleration;
-		bool m_isAbsolute;
+		ModelAnimationCoordinateRelation m_isAbsolute;
 
 	private:
 		ModelAnimationSegment* copy() const override;
-		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& currentAnimDelta, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
 
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
-		ModelAnimationSegmentRotation(std::shared_ptr<ModelAnimationSubmodel> submodel, tl::optional<angles> targetAngle, tl::optional<angles> velocity, tl::optional<float> time, tl::optional<angles> acceleration, bool isAbsolute = false);
+		ModelAnimationSegmentRotation(std::shared_ptr<ModelAnimationSubmodel> submodel, tl::optional<angles> targetAngle, tl::optional<angles> velocity, tl::optional<float> time, tl::optional<angles> acceleration, ModelAnimationCoordinateRelation isAbsolute = ModelAnimationCoordinateRelation::RELATIVE_COORDS);
 
 	};
 
@@ -172,7 +174,7 @@ namespace animation {
 
 	private:
 		ModelAnimationSegment* copy() const override;
-		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& /*currentAnimDelta*/, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& /*base*/, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
@@ -204,18 +206,18 @@ namespace animation {
 		tl::optional<float> m_time;
 		tl::optional<vec3d> m_acceleration;
 		enum class CoordinateSystem { COORDS_PARENT, COORDS_LOCAL_AT_START, COORDS_LOCAL_CURRENT } m_coordType;
-		bool m_isAbsolute;
+		ModelAnimationCoordinateRelation m_isAbsolute;
 
 	private:
 
 		ModelAnimationSegment* copy() const override;
-		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& currentAnimDelta, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
 	public:
 		static std::shared_ptr<ModelAnimationSegment> parser(ModelAnimationParseHelper* data);
-		ModelAnimationSegmentTranslation(std::shared_ptr<ModelAnimationSubmodel> submodel, tl::optional<vec3d> target, tl::optional<vec3d> velocity, tl::optional<float> time, tl::optional<vec3d> acceleration, CoordinateSystem coordType = CoordinateSystem::COORDS_PARENT, bool isAbsolute = false);
+		ModelAnimationSegmentTranslation(std::shared_ptr<ModelAnimationSubmodel> submodel, tl::optional<vec3d> target, tl::optional<vec3d> velocity, tl::optional<float> time, tl::optional<vec3d> acceleration, CoordinateSystem coordType = CoordinateSystem::COORDS_PARENT, ModelAnimationCoordinateRelation isAbsolute = ModelAnimationCoordinateRelation::RELATIVE_COORDS);
 
 	};
 
@@ -242,7 +244,7 @@ namespace animation {
 		
 	private:
 		ModelAnimationSegment* copy() const override;
-		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& currentAnimDelta, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
@@ -278,7 +280,7 @@ namespace animation {
 		tl::optional<matrix> m_targetRotation;
 	private:
 		ModelAnimationSegment* copy() const override;
-		void recalculate(ModelAnimationSubmodelBuffer& base, polymodel_instance* pmi) override;
+		void recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& /*currentAnimDelta*/, polymodel_instance* pmi) override;
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& /*state*/, float /*timeboundLower*/, float /*timeboundUpper*/, ModelAnimationDirection /*direction*/, int /*pmi_id*/) override { };
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;


### PR DESCRIPTION
When fixing +Absolute in a previous PR, I was unknowingly removing a bug that has found use in some indev mods.
This adds a +Local mode, which works as the old, broken +Absolute.
+Relative is a movement in relative space. (i.e., 0,0,0 will be no change)
+Local is a movement to absolute coordinates local to this single animation. (i.e., 0,0,0 will be the state at the beginning of the animation)
+Absolute is a movement to absolute coordinates within the FoR of the parent, considering all other active animations. (i,e. 0,0,0 will be the actual absolute 0 coordinate of the parent FoR)