### PR TITLE
Add AI flag to support ai bay arrivals > 10 seconds

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -148,6 +148,7 @@ namespace AI {
 		Fix_good_rearm_time_bug,
 		No_continuous_turn_on_attack,
 		Fixed_removing_play_dead_order,
+		Disable_bay_emerge_timeout,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -606,6 +606,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$remove-goal properly removes play-dead order:", AI::Profile_Flags::Fixed_removing_play_dead_order);
 
+				set_flag(profile, "$bay arrivials not time limited:", AI::Profile_Flags::Disable_bay_emerge_timeout);
+
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -606,7 +606,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$remove-goal properly removes play-dead order:", AI::Profile_Flags::Fixed_removing_play_dead_order);
 
-				set_flag(profile, "$bay arrivials not time limited:", AI::Profile_Flags::Disable_bay_emerge_timeout);
+				set_flag(profile, "$bay arrivals not time limited:", AI::Profile_Flags::Disable_bay_emerge_timeout);
 
 
 				// if we've been through once already and are at the same place, force a move

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13320,7 +13320,10 @@ void ai_bay_emerge()
 	ai_path();
 
 	// New test: must have been in AI_EMERGE mode for at least 10 seconds, and be a minimum distance from the start point
-	if ( ( (Missiontime - aip->submode_start_time) > 10*F1_0 ) && (vm_vec_dist_quick(&Pl_objp->pos, &Objects[aip->goal_objnum].pos) > 0.75f * Objects[aip->goal_objnum].radius)) {
+	// This timeout results in AI not completing bay paths that take longer than 10 seconds, so disable with a flag with mods that need it --wookieejedi
+	if ( !(aip->ai_profile_flags[AI::Profile_Flags::Disable_bay_emerge_timeout]) &&
+		( (Missiontime - aip->submode_start_time) > 10 * F1_0) &&
+		( (vm_vec_dist_quick(&Pl_objp->pos, &Objects[aip->goal_objnum].pos) > 0.75f * Objects[aip->goal_objnum].radius) ) ) {
 		// erase path
 		ai_emerge_bay_path_cleanup(aip);
 		// deal with model animations


### PR DESCRIPTION
Currently, if an AI ship is emerging from a bay path, the AI will stop following that path after only 10 seconds (and some distance away from the starting point). This results in AI breaking off a path early if a bay arrival path is long and/or uses a slow bay arrive multipliers. For bays that require the ship to follow the exact path this results in AI that then run into the parent ship and each other.

This PR adds a flag which disables that 10 second timeout. Also, in my tests having a flag to disable works best, as opposed to setting a max time (which is hard to calculate with varying ship speeds and varying bay path lengths).

PR is tested and works as expected.