### PR TITLE
fix popups with inputboxes cancelling text input

### DIFF
--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -3875,7 +3875,10 @@ int Multi_pxo_searching = 0;
 void multi_pxo_com_init(int input_len)
 {
 	int idx;
-	
+
+	// drop focus from main window
+	Multi_pxo_window.clear_focus();
+
 	// create the interface window
 	Multi_pxo_com_window.create(0, 0, gr_screen.max_w_unscaled,gr_screen.max_h_unscaled, 0);
 	Multi_pxo_com_window.set_mask_bmap(Multi_pxo_com_mask_fname[gr_screen.res]);	
@@ -3917,6 +3920,9 @@ void multi_pxo_com_close()
 {
 	// destroy the UI_WINDOW
 	Multi_pxo_com_window.destroy();
+
+	// back on main window, set focus on chat input
+	Multi_pxo_chat_input.set_focus();
 }
 
 /**

--- a/code/ui/gadget.cpp
+++ b/code/ui/gadget.cpp
@@ -172,6 +172,10 @@ void UI_GADGET::destroy()
 		}
 	}
 
+	if (has_focus()) {
+		clear_focus();
+	}
+
 	if (children) {
 		cur = children;
 		do {
@@ -321,6 +325,10 @@ UI_GADGET *UI_GADGET::get_prev()
 void UI_GADGET::set_focus()
 {
 	my_wnd->selected_gadget = this;
+
+	if (kind == UI_KIND_INPUTBOX) {
+		SDL_StartTextInput();
+	}
 }
 
 // Make no gadget have focus in the UI window.
@@ -328,6 +336,10 @@ void UI_GADGET::set_focus()
 void UI_GADGET::clear_focus()
 {
 	my_wnd->selected_gadget = NULL;
+
+	if (kind == UI_KIND_INPUTBOX) {
+		SDL_StopTextInput();
+	}
 }
 
 // Return true or false if this gadget currently has the focus

--- a/code/ui/inputbox.cpp
+++ b/code/ui/inputbox.cpp
@@ -81,7 +81,6 @@ void UI_INPUTBOX::init_cursor()
 void UI_INPUTBOX::create(UI_WINDOW *wnd, int _x, int _y, int _w, int _text_len, const char *_text, int _flags, int pixel_lim, color *clr)
 {
 	textListener = os::events::addEventListener(SDL_TEXTINPUT, 10000, std::bind(&UI_INPUTBOX::handle_textInputEvent, this, std::placeholders::_1));
-	SDL_StartTextInput();
 
 	int tw, th;
 
@@ -156,8 +155,6 @@ void UI_INPUTBOX::set_invalid_chars(const char *ichars)
 
 void UI_INPUTBOX::destroy()
 {
-
-	SDL_StopTextInput();
 	os::events::removeEventListener(textListener);
 
 	if (text) {

--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -743,6 +743,7 @@ public:
 	void set_ignore_gadgets(int state);
 	void add_XSTR(const char *string, int _xstr_id, int _x, int _y, UI_GADGET *_assoc, int _color_type, int _font_id = -1);
 	void add_XSTR(UI_XSTR *xstr);
+	void clear_focus();
 
 	const char *(*tooltip_handler)(const char *text);
 	int last_keypress;		// filled in each frame

--- a/code/ui/window.cpp
+++ b/code/ui/window.cpp
@@ -470,6 +470,13 @@ void UI_WINDOW::set_ignore_gadgets(int state)
 	ignore_gadgets = state;
 }
 
+void UI_WINDOW::clear_focus()
+{
+	if (selected_gadget) {
+		selected_gadget->clear_focus();
+	}
+}
+
 void UI_WINDOW::add_XSTR(const char *string, int _xstr_id, int _x, int _y, UI_GADGET *_assoc, int _color_type, int _font_id)
 {
 	int idx;


### PR DESCRIPTION
Text input is enabled when an inputbox is created and disabled when it's destroyed. If a screen has an inputbox and can trigger a popup that also has an inputbox, then text input is disabled when the popup is closed thereby preventing the original screen's inputbox from working.