### PR TITLE
add arrival and departure info for wings, ships, and parse objects

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -152,7 +152,7 @@ p_object *Player_start_pobject;
 // name of all ships to use while parsing a mission (since a ship might be referenced by
 // something before that ship has even been loaded yet)
 char Parse_names[MAX_SHIPS + MAX_WINGS][NAME_LENGTH];
-int Num_parse_names;
+size_t Num_parse_names;
 
 SCP_vector<texture_replace> Fred_texture_replacements;
 
@@ -6207,7 +6207,7 @@ bool post_process_mission()
 
 	// convert all ship name indices to ship indices now that mission has been loaded
 	if (Fred_running) {
-		for (i=0; i<Num_parse_names; i++) {
+		for (i=0; i<(int)Num_parse_names; i++) {
 			indices[i] = ship_name_lookup(Parse_names[i], 1);
 			if (indices[i] < 0)
 				Warning(LOCATION, "Ship name \"%s\" referenced, but this ship doesn't exist", Parse_names[i]);
@@ -7896,7 +7896,7 @@ int get_parse_name_index(const char *name)
 {
 	int i;
 
-	for (i=0; i<Num_parse_names; i++)
+	for (i=0; i<(int)Num_parse_names; i++)
 		if (!stricmp(name, Parse_names[i]))
 			return i;
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -472,7 +472,7 @@ extern matrix Parse_viewer_orient;
 extern fix Mission_end_time;
 
 extern char Parse_names[MAX_SHIPS + MAX_WINGS][NAME_LENGTH];
-extern int Num_parse_names;
+extern size_t Num_parse_names;
 extern int Num_teams;
 
 extern char			Player_start_shipname[NAME_LENGTH];

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -244,7 +244,22 @@ extern void stuff_boolean(int *i, bool a_to_eol=true);
 extern void stuff_boolean(bool *b, bool a_to_eol=true);
 extern void stuff_boolean_flag(int *i, int flag, bool a_to_eol=true);
 
-int string_lookup(const char *str1, const char* const *strlist, size_t max, const char *description = NULL, bool say_errors = false);
+template <class T>
+int string_lookup(const char* str1, T strlist, size_t max, const char* description = nullptr, bool say_errors = false)
+{
+	for (size_t i=0; i<max; i++)
+	{
+		Assert(strlen(strlist[i]) != 0); //-V805
+
+		if (!stricmp(str1, strlist[i]))
+			return (int)i;
+	}
+
+	if (say_errors)
+		error_display(0, "Unable to find [%s] in %s list.\n", str1, description);
+
+	return -1;
+}
 
 template<class Flags, class Flagset>
 void stuff_boolean_flag(Flagset& destination, Flags flag, bool a_to_eol = true)

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20820,21 +20820,8 @@ void sexp_set_support_ship(int n)
 	}
 	else
 	{
-		// anchor must exist - look for it
-		temp_val = -1;
-		for (i = 0; i < Num_parse_names; i++)
-		{
-			if (!stricmp(CTEXT(n), Parse_names[i]))
-				temp_val = i;
-		}
-		// if not found, make a new entry
-		if (temp_val < 0)
-		{
-			strcpy_s(Parse_names[Num_parse_names], CTEXT(n));
-			temp_val = Num_parse_names;
-			Num_parse_names++;
-		}
-		The_mission.support_ships.arrival_anchor = temp_val;
+		// find or create the anchor
+		The_mission.support_ships.arrival_anchor = get_parse_name_index(CTEXT(n));
 	}
 
 	// get departure location
@@ -20861,21 +20848,8 @@ void sexp_set_support_ship(int n)
 	}
 	else
 	{
-		// anchor must exist - look for it
-		temp_val = -1;
-		for (i = 0; i < Num_parse_names; i++)
-		{
-			if (!stricmp(CTEXT(n), Parse_names[i]))
-				temp_val = i;
-		}
-		// if not found, make a new entry
-		if (temp_val < 0)
-		{
-			strcpy_s(Parse_names[Num_parse_names], CTEXT(n));
-			temp_val = Num_parse_names;
-			Num_parse_names++;
-		}
-		The_mission.support_ships.departure_anchor = temp_val;
+		// find or create the anchor
+		The_mission.support_ships.departure_anchor = get_parse_name_index(CTEXT(n));
 	}
 
 	// get ship class
@@ -20947,19 +20921,8 @@ void sexp_set_arrival_info(int node)
 	}
 	else
 	{
-		// anchor must exist - look for it
-		for (i=0; i<Num_parse_names; i++)
-		{
-			if (!stricmp(CTEXT(n), Parse_names[i]))
-				arrival_anchor = i;
-		}
-		// if not found, make a new entry
-		if (arrival_anchor < 0)
-		{
-			strcpy_s(Parse_names[Num_parse_names], CTEXT(n));
-			arrival_anchor = Num_parse_names;
-			Num_parse_names++;
-		}
+		// find or create the anchor
+		arrival_anchor = get_parse_name_index(CTEXT(n));
 	}
 	n = CDR(n);
 
@@ -21054,19 +21017,8 @@ void sexp_set_departure_info(int node)
 	}
 	else
 	{
-		// anchor must exist - look for it
-		for (i=0; i<Num_parse_names; i++)
-		{
-			if (!stricmp(CTEXT(n), Parse_names[i]))
-				departure_anchor = i;
-		}
-		// if not found, make a new entry
-		if (departure_anchor < 0)
-		{
-			strcpy_s(Parse_names[Num_parse_names], CTEXT(n));
-			departure_anchor = Num_parse_names;
-			Num_parse_names++;
-		}
+		// find or create the anchor
+		departure_anchor = get_parse_name_index(CTEXT(n));
 	}
 	n = CDR(n);
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -267,6 +267,32 @@ ADE_FUNC(getFlag, l_Ship, "string flag_name", "Checks whether one or more flags 
 	return ADE_RETURN_TRUE;
 }
 
+static int ship_getset_helper(lua_State* L, int ship::* field, bool canSet = false, bool canBeNegative = false)
+{
+	object_h* objh;
+	int value;
+	if (!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &value))
+		return ADE_RETURN_NIL;
+
+	if (!objh->IsValid())
+		return ADE_RETURN_NIL;
+
+	ship* shipp = &Ships[objh->objp->instance];
+
+	if (ADE_SETTING_VAR)
+	{
+		if (canSet)
+		{
+			if (canBeNegative || value >= 0)
+				shipp->*field = value;
+		}
+		else
+			LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "i", shipp->*field);
+}
+
 ADE_VIRTVAR(ShieldArmorClass, l_Ship, "string", "Current Armor class of the ships' shield", "string", "Armor class name, or empty string if none is set")
 {
 	object_h *objh;
@@ -1094,6 +1120,97 @@ ADE_VIRTVAR(WaypointSpeedCap, l_Ship, "number", "Waypoint speed cap", "number", 
 	}
 
 	return ade_set_args(L, "i", aip->waypoint_speed_cap);
+}
+
+static int ship_getset_location_helper(lua_State* L, int ship::* field, const char* location_type, const char** location_names, size_t location_names_size)
+{
+	object_h* objh;
+	const char* s = nullptr;
+	if (!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
+		return ADE_RETURN_NIL;
+
+	if (!objh->IsValid())
+		return ADE_RETURN_NIL;
+
+	ship* shipp = &Ships[objh->objp->instance];
+
+	if (ADE_SETTING_VAR && s != nullptr)
+	{
+		int location = string_lookup(s, location_names, location_names_size);
+		if (location < 0)
+		{
+			Warning(LOCATION, "%s location '%s' not found.", location_type, s);
+			return ADE_RETURN_NIL;
+		}
+		shipp->*field = location;
+	}
+
+	return ade_set_args(L, "s", location_names[shipp->*field]);
+}
+
+ADE_VIRTVAR(ArrivalLocation, l_Ship, "string", "The ship's arrival location", "string", "Arrival location, or nil if handle is invalid")
+{
+	return ship_getset_location_helper(L, &ship::arrival_location, "Arrival", Arrival_location_names, MAX_ARRIVAL_NAMES);
+}
+
+ADE_VIRTVAR(DepartureLocation, l_Ship, "string", "The ship's departure location", "string", "Departure location, or nil if handle is invalid")
+{
+	return ship_getset_location_helper(L, &ship::departure_location, "Departure", Departure_location_names, MAX_DEPARTURE_NAMES);
+}
+
+static int ship_getset_anchor_helper(lua_State* L, int ship::* field)
+{
+	object_h* objh;
+	const char* s = nullptr;
+	if (!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
+		return ADE_RETURN_NIL;
+
+	if (!objh->IsValid())
+		return ADE_RETURN_NIL;
+
+	ship* shipp = &Ships[objh->objp->instance];
+
+	if (ADE_SETTING_VAR && s != nullptr)
+	{
+		shipp->*field = (stricmp(s, "<no anchor>") == 0) ? -1 : get_parse_name_index(s);
+	}
+
+	return ade_set_args(L, "s", (shipp->*field >= 0) ? Parse_names[shipp->*field] : "<no anchor>");
+}
+
+ADE_VIRTVAR(ArrivalAnchor, l_Ship, "string", "The ship's arrival anchor", "string", "Arrival anchor, or nil if handle is invalid")
+{
+	return ship_getset_anchor_helper(L, &ship::arrival_anchor);
+}
+
+ADE_VIRTVAR(DepartureAnchor, l_Ship, "string", "The ship's departure anchor", "string", "Departure anchor, or nil if handle is invalid")
+{
+	return ship_getset_anchor_helper(L, &ship::departure_anchor);
+}
+
+ADE_VIRTVAR(ArrivalPathMask, l_Ship, "number", "The ship's arrival path mask", "number", "Arrival path mask, or nil if handle is invalid")
+{
+	return ship_getset_helper(L, &ship::arrival_path_mask, true);
+}
+
+ADE_VIRTVAR(DeparturePathMask, l_Ship, "number", "The ship's departure path mask", "number", "Departure path mask, or nil if handle is invalid")
+{
+	return ship_getset_helper(L, &ship::departure_path_mask, true);
+}
+
+ADE_VIRTVAR(ArrivalDelay, l_Ship, "number", "The ship's arrival delay", "number", "Arrival delay, or nil if handle is invalid")
+{
+	return ship_getset_helper(L, &ship::arrival_delay, true);
+}
+
+ADE_VIRTVAR(DepartureDelay, l_Ship, "number", "The ship's departure delay", "number", "Departure delay, or nil if handle is invalid")
+{
+	return ship_getset_helper(L, &ship::departure_delay, true);
+}
+
+ADE_VIRTVAR(ArrivalDistance, l_Ship, "number", "The ship's arrival distance", "number", "Arrival distance, or nil if handle is invalid")
+{
+	return ship_getset_helper(L, &ship::arrival_distance, true);
 }
 
 ADE_FUNC(turnTowardsPoint,


### PR DESCRIPTION
Virtual variables corresponding to the same fields as in `set-arrival-info` and `set-departure-info`.  Some refactoring as well.

~~In draft status pending tests and rebase.~~