### PR TITLE
Enable PNG blobs in LibRocket

### DIFF
--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -86,6 +86,65 @@ static void png_warning_fn(png_structp png_ptr, png_const_charp message)
 	}
 }
 
+
+static int png_read_header_data(int* w, int* h, int* bpp, png_voidp status, png_error_ptr error, png_error_ptr warning, png_rw_ptr readFunc, std::function<void()> onClose)
+{
+	png_infop info_ptr;
+	png_structp png_ptr;
+
+	/* Create and initialize the png_struct with the desired error handler
+	* functions.  If you want to use the default stderr and longjump method,
+	* you can supply NULL for the last three parameters.  We also supply the
+	* the compiler header file version, so that we know if the application
+	* was compiled with a compatible version of the library.  REQUIRED
+	*/
+	png_ptr = png_create_read_struct_2(PNG_LIBPNG_VER_STRING, status, error, warning, status, png_malloc_fn, png_free_fn);
+
+	if (png_ptr == nullptr)
+	{
+		mprintf(("png_read_header: error creating read struct\n"));
+		onClose();
+		return PNG_ERROR_READING;
+	}
+
+	/* Allocate/initialize the memory for image information.  REQUIRED. */
+	info_ptr = png_create_info_struct(png_ptr);
+	if (info_ptr == NULL)
+	{
+		mprintf(("png_read_header: error creating info struct\n"));
+		onClose();
+		png_destroy_read_struct(&png_ptr, nullptr, nullptr);
+		return PNG_ERROR_READING;
+	}
+
+	if (setjmp(png_jmpbuf(png_ptr)))
+	{
+		mprintf(("png_read_header: something went wrong\n"));
+		/* Free all of the memory associated with the png_ptr and info_ptr */
+		png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+		onClose();
+		/* If we get here, we had a problem reading the file */
+		return PNG_ERROR_READING;
+	}
+
+	png_set_read_fn(png_ptr, status, readFunc);
+
+	png_read_info(png_ptr, info_ptr);
+
+	if (w) *w = png_get_image_width(png_ptr, info_ptr);
+	if (h) *h = png_get_image_height(png_ptr, info_ptr);
+	// this turns out to be near useless, but meh
+	if (bpp) {
+		// bit depth can also be 16 bit we tell libpng to reduce that to 8 bits so we also need to tell our caller about that
+		auto bits = std::min(8, (int)png_get_bit_depth(png_ptr, info_ptr));
+		*bpp = (png_get_channels(png_ptr, info_ptr) * bits);
+	}
+
+	png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+
+	return PNG_ERROR_NONE;
+}
+
 /*
  * @brief Reads header information from the PNG file into the bitmap pointer
  *
@@ -100,14 +159,12 @@ static void png_warning_fn(png_structp png_ptr, png_const_charp message)
 int png_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, int *bpp, ubyte * /*palette*/)
 {
 	char filename[MAX_FILENAME_LEN];
-	png_infop info_ptr;
-	png_structp png_ptr;
 
 	png_status status;
 	status.reading_header = true;
 	status.filename = real_filename;
 
-	if (img_cfp == NULL) {
+	if (img_cfp == nullptr) {
 		strcpy_s( filename, real_filename );
 
 		char *p = strchr( filename, '.' );
@@ -125,101 +182,60 @@ int png_read_header(const char *real_filename, CFILE *img_cfp, int *w, int *h, i
 		status.cfp = img_cfp;
 	}
 
-	Assert( status.cfp != NULL );
+	Assert( status.cfp != nullptr);
 
-	if (status.cfp == NULL)
+	if (status.cfp == nullptr)
 		return PNG_ERROR_READING;
 
-	/* Create and initialize the png_struct with the desired error handler
-	* functions.  If you want to use the default stderr and longjump method,
-	* you can supply NULL for the last three parameters.  We also supply the
-	* the compiler header file version, so that we know if the application
-	* was compiled with a compatible version of the library.  REQUIRED
-	*/
-	png_ptr = png_create_read_struct_2(PNG_LIBPNG_VER_STRING, &status, png_error_fn, png_warning_fn, &status, png_malloc_fn, png_free_fn);
+	int result = png_read_header_data(w, h, bpp, &status, png_error_fn, png_warning_fn, png_scp_read_data, [&status]() {cfclose(status.cfp); });
 
-	if (png_ptr == NULL)
-	{
-		mprintf(("png_read_header: error creating read struct\n"));
+	if (img_cfp == nullptr) {
 		cfclose(status.cfp);
-		return PNG_ERROR_READING;
+		status.cfp = nullptr;
 	}
 
-	/* Allocate/initialize the memory for image information.  REQUIRED. */
-	info_ptr = png_create_info_struct(png_ptr);
-	if (info_ptr == NULL)
-	{
-		mprintf(("png_read_header: error creating info struct\n"));
-		cfclose(status.cfp);
-		png_destroy_read_struct(&png_ptr, NULL, NULL);
-		return PNG_ERROR_READING;
-	}
+	return result;
+}
 
-	if (setjmp(png_jmpbuf(png_ptr)))
-	{
-		mprintf(("png_read_header: something went wrong\n"));
-		/* Free all of the memory associated with the png_ptr and info_ptr */
-		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
-		cfclose(status.cfp);
-		/* If we get here, we had a problem reading the file */
-		return PNG_ERROR_READING;
-	}
+int png_read_header(const SCP_string& b64, int* w, int* h, int* bpp, ubyte* /*palette*/)
+{
+	struct b64_dec_buffer {
+		SCP_string decoded;
+		size_t pos;
+	} buffer{ base64_decode(b64), 0 };
 
-	png_set_read_fn(png_ptr, &status, png_scp_read_data);
+	return png_read_header_data(w, h, bpp, &buffer,
+		[](png_structp png_ptr, png_const_charp msg) {
+			mprintf(("PNG error while parsing base64 PNG: %s\n", msg));
+			longjmp(png_jmpbuf(png_ptr), 1);
+		},
+		[](png_structp, png_const_charp msg) {
+			mprintf(("PNG warning while parsing base64 PNG: %s\n", msg));
+		},
+			[](png_structp png_ptr, png_bytep datap, png_size_t length) {
+			b64_dec_buffer& buf = *static_cast<b64_dec_buffer*>(png_get_io_ptr(png_ptr));
 
-	png_read_info(png_ptr, info_ptr);
-
-	if (w) *w = png_get_image_width(png_ptr, info_ptr);
-	if (h) *h = png_get_image_height(png_ptr, info_ptr);
-	// this turns out to be near useless, but meh
-	if (bpp) {
-		// bit depth can also be 16 bit we tell libpng to reduce that to 8 bits so we also need to tell our caller about that
-		auto bits = std::min(8, (int)png_get_bit_depth(png_ptr, info_ptr));
-		*bpp = (png_get_channels(png_ptr, info_ptr) * bits);
-	}
-
-	if (img_cfp == NULL) {
-		cfclose(status.cfp);
-		status.cfp = NULL;
-	}
-
-	png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
-
-	return PNG_ERROR_NONE;
+			for (size_t finalPos = buf.pos + length; buf.pos < finalPos; buf.pos++) {
+				*(datap++) = buf.decoded.at(buf.pos);
+			}
+		}, []() {});
 }
 
 /*
  * Loads a PNG image
  *
- * @param [in]  real_filename  name of the png file to load
  * @param [out] image_data     allocated storage for the bitmap
  * @param [in]  bpp
  * @param [in]  dest_size
- * @param [in]  cf_type
  *
  * @retval true if succesful, false otherwise
  */
-int png_read_bitmap(const char *real_filename, ubyte *image_data, int *bpp, int  /*dest_size*/, int cf_type)
+static int png_read_bitmap_data(ubyte *image_data, int *bpp, png_voidp status, png_error_ptr error, png_error_ptr warning, png_rw_ptr readFunc, std::function<void()> onClose)
 {
-	char filename[MAX_FILENAME_LEN];
 	png_infop info_ptr;
 	png_structp png_ptr;
 	png_bytepp row_pointers;
 	unsigned int i;
-
-	png_status status;
-	status.reading_header = false;
-	status.filename = real_filename;
-
-	strcpy_s( filename, real_filename );
-	char *p = strchr( filename, '.' );
-	if ( p ) *p = 0;
-	strcat_s( filename, ".png" );
-
-	status.cfp = cfopen(filename, "rb", CFILE_NORMAL, cf_type);
-
-	if (status.cfp == NULL)
-		return PNG_ERROR_READING;
 
 	/* Create and initialize the png_struct with the desired error handler
 	* functions.  If you want to use the default stderr and longjump method,
@@ -227,22 +243,22 @@ int png_read_bitmap(const char *real_filename, ubyte *image_data, int *bpp, int 
 	* the compiler header file version, so that we know if the application
 	* was compiled with a compatible version of the library.  REQUIRED
 	*/
-	png_ptr = png_create_read_struct_2(PNG_LIBPNG_VER_STRING, &status, png_error_fn, png_warning_fn, NULL, NULL, NULL);
+	png_ptr = png_create_read_struct_2(PNG_LIBPNG_VER_STRING, status, error, warning, nullptr, nullptr, nullptr);
 
-	if (png_ptr == NULL)
+	if (png_ptr == nullptr)
 	{
 		mprintf(("png_read_bitmap: png_ptr went wrong\n"));
-		cfclose(status.cfp);
+		onClose();
 		return PNG_ERROR_READING;
 	}
 
 	/* Allocate/initialize the memory for image information.  REQUIRED. */
 	info_ptr = png_create_info_struct(png_ptr);
-	if (info_ptr == NULL)
+	if (info_ptr == nullptr)
 	{
 		mprintf(("png_read_bitmap: info_ptr went wrong\n"));
-		cfclose(status.cfp);
-		png_destroy_read_struct(&png_ptr, NULL, NULL);
+		onClose();
+		png_destroy_read_struct(&png_ptr, nullptr, nullptr);
 		return PNG_ERROR_READING;
 	}
 
@@ -250,13 +266,13 @@ int png_read_bitmap(const char *real_filename, ubyte *image_data, int *bpp, int 
 	{
 		mprintf(("png_read_bitmap: something went wrong\n"));
 		/* Free all of the memory associated with the png_ptr and info_ptr */
-		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
-		cfclose(status.cfp);
+		png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
+		onClose();
 		/* If we get here, we had a problem reading the file */
 		return PNG_ERROR_READING;
 	}
 
-	png_set_read_fn(png_ptr, &status, png_scp_read_data);
+	png_set_read_fn(png_ptr, status, readFunc);
 
 	png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_BGR | PNG_TRANSFORM_EXPAND | PNG_TRANSFORM_STRIP_16, NULL);
 	auto len = png_get_rowbytes(png_ptr, info_ptr);
@@ -273,9 +289,65 @@ int png_read_bitmap(const char *real_filename, ubyte *image_data, int *bpp, int 
 	}
 
 	png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
-	cfclose(status.cfp);
+	onClose();
 
 	return PNG_ERROR_NONE;
+}
+
+/*
+ * Loads a PNG image
+ *
+ * @param [in]  real_filename  name of the png file to load
+ * @param [out] image_data     allocated storage for the bitmap
+ * @param [in]  bpp
+ * @param [in]  dest_size
+ * @param [in]  cf_type
+ *
+ * @retval true if succesful, false otherwise
+ */
+int png_read_bitmap(const char* real_filename, ubyte* image_data, int* bpp, int  /*dest_size*/, int cf_type)
+{
+	char filename[MAX_FILENAME_LEN];
+
+	png_status status;
+	status.reading_header = false;
+	status.filename = real_filename;
+
+	strcpy_s(filename, real_filename);
+	char* p = strchr(filename, '.');
+	if (p) *p = 0;
+	strcat_s(filename, ".png");
+
+	status.cfp = cfopen(filename, "rb", CFILE_NORMAL, cf_type);
+
+	if (status.cfp == NULL)
+		return PNG_ERROR_READING;
+
+	return png_read_bitmap_data(image_data, bpp, &status, png_error_fn, png_warning_fn, png_scp_read_data, [&status]() {cfclose(status.cfp); });
+}
+
+int png_read_bitmap(const SCP_string& b64, ubyte* image_data, int* bpp)
+{
+	struct b64_dec_buffer {
+		SCP_string decoded;
+		size_t pos;
+	} buffer{ base64_decode(b64), 0 };
+
+	return png_read_bitmap_data(image_data, bpp, &buffer,
+		[](png_structp png_ptr, png_const_charp msg) {
+			mprintf(("PNG error while parsing base64 PNG: %s\n", msg));
+			longjmp(png_jmpbuf(png_ptr), 1);
+		},
+		[](png_structp, png_const_charp msg) {
+			mprintf(("PNG warning while parsing base64 PNG: %s\n", msg));
+		}, 
+		[](png_structp png_ptr, png_bytep datap, png_size_t length) {
+			b64_dec_buffer& buf = *static_cast<b64_dec_buffer*>(png_get_io_ptr(png_ptr));
+
+			for (size_t finalPos = buf.pos + length; buf.pos < finalPos; buf.pos++) {
+				*(datap++) = buf.decoded.at(buf.pos);
+			}
+		}, []() {});
 }
 
 static bool png_write_bitmap_data(size_t width, size_t height, bool y_flip, const uint8_t* data, png_voidp status, png_error_ptr error, png_error_ptr warning, png_rw_ptr writeFunc, png_flush_ptr flushFnc) {
@@ -324,7 +396,7 @@ bool png_write_bitmap(const char* filename, size_t width, size_t height, bool y_
 }
 
 SCP_string png_b64_bitmap(size_t width, size_t height, bool y_flip, const uint8_t* data) {
-	struct b64_buffer {
+	struct b64_enc_buffer {
 		size_t i = 0;
 		std::array<png_byte, 3> buffer;
 		std::stringstream b64;
@@ -340,7 +412,7 @@ SCP_string png_b64_bitmap(size_t width, size_t height, bool y_flip, const uint8_
 			mprintf(("PNG warning while generating base64: %s\n", msg));
 		}, 
 		[](png_structp png_ptr, png_bytep datap, png_size_t length) {
-			auto& buf = *static_cast<b64_buffer*>(png_get_io_ptr(png_ptr));
+			auto& buf = *static_cast<b64_enc_buffer*>(png_get_io_ptr(png_ptr));
 
 			while (buf.i != 0 && length != 0) {
 				length--;
@@ -365,7 +437,7 @@ SCP_string png_b64_bitmap(size_t width, size_t height, bool y_flip, const uint8_
 			}
 		},
 		[](png_structp png_ptr) {
-			auto& buf = *static_cast<b64_buffer*>(png_get_io_ptr(png_ptr));
+			auto& buf = *static_cast<b64_enc_buffer*>(png_get_io_ptr(png_ptr));
 
 			if (buf.i != 0) {
 				base64_encode(buf.b64, buf.buffer.data(), (unsigned int) buf.i);

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -344,7 +344,7 @@ int png_read_bitmap(const SCP_string& b64, ubyte* image_data, int* bpp)
 		[](png_structp png_ptr, png_bytep datap, png_size_t length) {
 			b64_dec_buffer& buf = *static_cast<b64_dec_buffer*>(png_get_io_ptr(png_ptr));
 
-			for (size_t finalPos = buf.pos + length; buf.pos < finalPos; buf.pos++) {
+			for (size_t finalPos = std::min(buf.pos + length, buf.decoded.size()); buf.pos < finalPos; buf.pos++) {
 				*(datap++) = buf.decoded.at(buf.pos);
 			}
 		}, []() {});
@@ -443,6 +443,9 @@ SCP_string png_b64_bitmap(size_t width, size_t height, bool y_flip, const uint8_
 				base64_encode(buf.b64, buf.buffer.data(), (unsigned int) buf.i);
 			}
 		});
+
+	if (buffer.i != 0)
+		base64_encode(buffer.b64, buffer.buffer.data(), (unsigned int)buffer.i);
 
 	return buffer.b64.str();
 }

--- a/code/pngutils/pngutils.h
+++ b/code/pngutils/pngutils.h
@@ -16,7 +16,9 @@
 
 // reading
 extern int png_read_header(const char *real_filename, CFILE *img_cfp = NULL, int *w = nullptr, int *h = nullptr, int *bpp = nullptr, ubyte *palette = nullptr);
+extern int png_read_header(const SCP_string& b64, int* w, int* h, int* bpp, ubyte *palette = nullptr);
 extern int png_read_bitmap(const char *real_filename, ubyte *image_data, int *bpp, int dest_size, int cf_type = CF_TYPE_ANY);
+extern int png_read_bitmap(const SCP_string& b64, ubyte* image_data, int* bpp);
 
 extern bool png_write_bitmap(const char* filename, size_t width, size_t height, bool y_flip, const uint8_t* data);
 extern SCP_string png_b64_bitmap(size_t width, size_t height, bool y_flip, const uint8_t* data);

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -155,9 +155,11 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 			memset(rawdata, 0, w * h * d_size);
 			png_read_bitmap(data, rawdata, &bpp);
 
+			bool success = RocketRenderingInterface::GenerateTexture(texture_handle, rawdata, { w, h });
+			
 			delete[] rawdata;
 
-			return RocketRenderingInterface::GenerateTexture(texture_handle, rawdata, { w, h });
+			return success;
 		}
 		else {
 			return false;

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -155,7 +155,8 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 			memset(rawdata, 0, w * h * d_size);
 			png_read_bitmap(data, rawdata, &bpp);
 
-			bool success = RocketRenderingInterface::GenerateTexture(texture_handle, rawdata, { w, h });
+			texture_dimensions = { w, h };
+			bool success = RocketRenderingInterface::GenerateTexture(texture_handle, rawdata, texture_dimensions);
 			
 			delete[] rawdata;
 

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -148,11 +148,11 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 			int d_size = bpp >> 3;
 
 			//we waste memory if it turns out to be 24-bit, but the way this whole thing works is dodgy anyway
-			ubyte* rawdata = new ubyte[w * h * (bpp >> 3)];
+			ubyte* rawdata = new ubyte[w * h * d_size];
 			if (rawdata == nullptr)
 				return false;
 
-			memset(rawdata, 0, w * h * (bpp >> 3));
+			memset(rawdata, 0, w * h * d_size);
 			png_read_bitmap(data, rawdata, &bpp);
 
 			delete[] rawdata;

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -148,12 +148,14 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 			int d_size = bpp >> 3;
 
 			//we waste memory if it turns out to be 24-bit, but the way this whole thing works is dodgy anyway
-			ubyte* rawdata = (ubyte*)vm_malloc(w * h * (bpp >> 3));
+			ubyte* rawdata = new ubyte[w * h * (bpp >> 3)];
 			if (rawdata == nullptr)
 				return false;
 
 			memset(rawdata, 0, w * h * (bpp >> 3));
 			png_read_bitmap(data, rawdata, &bpp);
+
+			delete[] rawdata;
 
 			return RocketRenderingInterface::GenerateTexture(texture_handle, rawdata, { w, h });
 		}

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -130,6 +130,38 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 {
 	TRACE_SCOPE(tracing::RocketLoadTexture);
 	GR_DEBUG_SCOPE("libRocket::LoadTexture");
+
+	if (source.Find("data:image/") == 0) {
+		//Special mode to catch blob textures
+		String submode = source.Substring(11);
+
+		if (submode.Find("png;base64,") == 0) {
+			SCP_string data = submode.Substring(11).CString();
+
+			int w, h, bpp;
+			png_read_header(data, &w, &h, &bpp);
+			if (w * h < 0)
+				return false;
+
+			//if it's not 32-bit, we expand when we read it
+			bpp = 32;
+			int d_size = bpp >> 3;
+
+			//we waste memory if it turns out to be 24-bit, but the way this whole thing works is dodgy anyway
+			ubyte* rawdata = (ubyte*)vm_malloc(w * h * (bpp >> 3));
+			if (rawdata == nullptr)
+				return false;
+
+			memset(rawdata, 0, w * h * (bpp >> 3));
+			png_read_bitmap(data, rawdata, &bpp);
+
+			return RocketRenderingInterface::GenerateTexture(texture_handle, rawdata, { w, h });
+		}
+		else {
+			return false;
+		}
+	}
+
 	SCP_string filename;
 	int dir_type;
 	if (!RocketFileInterface::getCFilePath(source, filename, dir_type)) {


### PR DESCRIPTION
This PR adds PNG decoding from base64 strings, as well as adds "file path" handling to librockets image backend, which allows to catch ``data:image/png;base64,``-prefixed png's and properly decode them.