### PR TITLE
make animated ship effects use the new timestamps

### DIFF
--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -253,7 +253,7 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 		}
 
 		if ( obj_render_is_model(obj) ) {
-			if( ((obj->type == OBJ_SHIP) && Ships[obj->instance].shader_effect_active) || (obj->type == OBJ_FIREBALL) )
+			if( ((obj->type == OBJ_SHIP) && Ships[obj->instance].shader_effect_timestamp.isValid()) || (obj->type == OBJ_FIREBALL) )
 				effect_ships.push_back(obj);
 			else 
 				render_function(obj);
@@ -328,7 +328,7 @@ void obj_render_queue_all()
 			}
 
 
-			if ( (objp->type == OBJ_SHIP) && Ships[objp->instance].shader_effect_active ) {
+			if ( (objp->type == OBJ_SHIP) && Ships[objp->instance].shader_effect_timestamp.isValid() ) {
 				effect_ships.push_back(objp);
 				continue;
 			}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -24608,10 +24608,9 @@ void sexp_ship_effect(int n)
 			case OSWPT_TYPE_SHIP:
 			{
 				auto sp = oswpt.ship_entry->shipp;
-				sp->shader_effect_active = true;
 				sp->shader_effect_num = effect_num;
 				sp->shader_effect_duration = effect_duration;
-				sp->shader_effect_start_time = timer_get_milliseconds();
+				sp->shader_effect_timestamp = _timestamp(effect_duration);
 				break;
 			}
 
@@ -24623,10 +24622,9 @@ void sexp_ship_effect(int n)
 					if (wp->ship_index[i] >= 0)
 					{
 						auto sp = &Ships[wp->ship_index[i]];
-						sp->shader_effect_active = true;
 						sp->shader_effect_num = effect_num;
 						sp->shader_effect_duration = effect_duration;
-						sp->shader_effect_start_time = timer_get_milliseconds();
+						sp->shader_effect_timestamp = _timestamp(effect_duration);
 					}
 				}
 				break;

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1220,10 +1220,9 @@ ADE_FUNC(addShipEffect, l_Ship, "string name, number durationMillis", "Activates
 
 	ship* shipp = &Ships[shiph->objp->instance];
 
-	shipp->shader_effect_active = true;
 	shipp->shader_effect_num = effect_num;
 	shipp->shader_effect_duration = duration;
-	shipp->shader_effect_start_time = timer_get_milliseconds();
+	shipp->shader_effect_timestamp = _timestamp(duration);
 
 	return ade_set_args(L, "b", true);
 }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -746,8 +746,7 @@ public:
 	//Animated Shader effects
 	int shader_effect_num;
 	int shader_effect_duration;
-	int shader_effect_start_time;
-	bool shader_effect_active;
+	TIMESTAMP shader_effect_timestamp;
 
 	float alpha_mult;
 


### PR DESCRIPTION
In addition to type-safety, this now adjusts ship effects properly for time compression and pausing.

Follow-up to #4716 