### PR TITLE
removeSoundByIndex should be 1-based

### DIFF
--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -593,6 +593,7 @@ ADE_FUNC(removeSoundByIndex, l_Object, "number index", "Removes an assigned soun
 		return ADE_RETURN_NIL;
 
 	auto objp = objh->objp;
+	snd_idx--;	// Lua -> C++
 
 	if (snd_idx < 0 || snd_idx >= (int)objp->objsnd_num.size())
 	{


### PR DESCRIPTION
Looks like no mods use this script method, so this change should be safe.