### PR TITLE
Add maximum self repair percentages for health and subsystems

### DIFF
--- a/code/lab/dialogs/class_variables.cpp
+++ b/code/lab/dialogs/class_variables.cpp
@@ -48,7 +48,9 @@ void Variables::update(LabMode newLabMode, int classIndex) {
 			addVariable(&y, "Shields", sip->max_shield_strength);
 			addVariable(&y, "Hull", sip->max_hull_strength);
 			addVariable(&y, "Subsys repair rate", sip->subsys_repair_rate);
+			addVariable(&y, "Subsys repair max", sip->subsys_repair_max);
 			addVariable(&y, "Hull repair rate", sip->hull_repair_rate);
+			addVariable(&y, "Hull repair max", sip->hull_repair_max);
 			addVariable(&y, "Countermeasures", sip->cmeasure_max);
 			addVariable(&y, "HUD Icon", sip->shield_icon_index);
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1255,8 +1255,10 @@ public:
 
 	float	max_shield_recharge;
 
-	float	hull_repair_rate;				//How much of the hull is repaired every second
-	float	subsys_repair_rate;		//How fast 
+	float	hull_repair_rate;				// How much of the hull is repaired every second
+	float	subsys_repair_rate;				// How much of the subsystem is repaired every second
+	float   hull_repair_max;                // Maximum percent that hull can self repair --wookieejedi
+	float   subsys_repair_max;              // Maximum percent that subsystems can self repair --wookieejedi
 
 	float	sup_hull_repair_rate;
 	float	sup_shield_repair_rate;


### PR DESCRIPTION
Adds two new options to help with the automatic self repairs for hull and subsystems: `$Hull Self Repair Maximum:` and `$Subsystem Self Repair Maximum:`. These values allow mods to specify how much a ship's hull or subsystem can self repair to, which is very useful to have some auto repair but not enough to make the hull or subsystem 100%.

Also cleans up the `ship_auto_repair_frame` function with removing un-used define values, improving comments, and making formatting consistent. Also updates the parse sections of repair rate for hull and subsystems to print to the log if values are being clamped.

Probably easiest to review with hiding whitespace changes.