### PR TITLE
enhance ba.print and add ba.println

### DIFF
--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -62,6 +62,7 @@ ADE_FUNC(println, l_Base, "string Message", "Prints a string with a newline", nu
 
 ADE_FUNC(warning, l_Base, "string Message", "Displays a FreeSpace warning (debug build-only) message with the string provided", nullptr, nullptr)
 {
+#ifndef NDEBUG
 	auto str = ade_tostring(L, -1, false);
 
 	if (Cmdline_lua_devmode) {
@@ -69,6 +70,10 @@ ADE_FUNC(warning, l_Base, "string Message", "Displays a FreeSpace warning (debug
 	} else {
 		Warning(LOCATION, "%s", str.c_str());
 	}
+#else
+	SCP_UNUSED(L);
+	Global_warning_count++;
+#endif
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -26,38 +26,60 @@
 #include "utils/Random.h"
 #include "cmdline/cmdline.h"
 
+
 namespace scripting {
+extern SCP_string ade_tostring(lua_State* L, int argnum, bool add_typeinfo);
+	
 namespace api {
 using Random = ::util::Random;
 
 //**********LIBRARY: Base
 ADE_LIB(l_Base, "Base", "ba", "Base FreeSpace 2 functions");
 
-ADE_FUNC(print, l_Base, "string Message", "Prints a string", NULL, NULL)
+ADE_FUNC(print, l_Base, "string Message", "Prints a string", nullptr, nullptr)
 {
-	nprintf(("scripting","%s", lua_tostring(L, -1)));
+#ifndef NDEBUG
+	auto str = ade_tostring(L, -1, false);
+	nprintf(("scripting", "%s", str.c_str()));
+#else
+	SCP_UNUSED(L);
+#endif
 
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(warning, l_Base, "string Message", "Displays a FreeSpace warning (debug build-only) message with the string provided", NULL, NULL)
+ADE_FUNC(println, l_Base, "string Message", "Prints a string with a newline", nullptr, nullptr)
 {
+#ifndef NDEBUG
+	auto str = ade_tostring(L, -1, false);
+	nprintf(("scripting", "%s\n", str.c_str()));
+#else
+	SCP_UNUSED(L);
+#endif
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(warning, l_Base, "string Message", "Displays a FreeSpace warning (debug build-only) message with the string provided", nullptr, nullptr)
+{
+	auto str = ade_tostring(L, -1, false);
+
 	if (Cmdline_lua_devmode) {
-		nprintf(("scripting","WARNING: %s\n", lua_tostring(L, -1)));
-	}
-	else {
-		Warning(LOCATION, "%s", lua_tostring(L, -1));
+		nprintf(("scripting", "WARNING: %s\n", str.c_str()));
+	} else {
+		Warning(LOCATION, "%s", str.c_str());
 	}
 
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(error, l_Base, "string Message", "Displays a FreeSpace error message with the string provided", NULL, NULL)
+ADE_FUNC(error, l_Base, "string Message", "Displays a FreeSpace error message with the string provided", nullptr, nullptr)
 {
+	auto str = ade_tostring(L, -1, false);
+
 	if (Cmdline_lua_devmode) {
-		nprintf(("scripting","ERROR: %s\n", lua_tostring(L, -1)));
-	}
-	else {
+		nprintf(("scripting", "ERROR: %s\n", str.c_str()));
+	} else {
 		Error(LOCATION, "%s", lua_tostring(L, -1));
 	}
 


### PR DESCRIPTION
There was code that could interpret any Lua type as an argument for printing, so I adapted it to be used in `ba.print()`, `ba.warning()`, and `ba.error()`.  Also `ba.println()` seemed like a useful thing to add.

Viewing the diff without whitespace changes should cut down on clutter.

With this PR, the following test script...
```
ba.println(5)

local t = { 1, 2 }
ba.println(t)

ba.println("x")
```
...produces the following output...
```
5.000000
Table w/ no metatable
x
```