### PR TITLE
Correctly set credits default even for scpui access

### DIFF
--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -198,7 +198,7 @@ static credits_screen_buttons Buttons[NUM_BUTTONS][GR_NUM_RESOLUTIONS] = {
 //XSTR:ON
 };
 
-char Credits_music_name[NAME_LENGTH];
+char Credits_music_name[NAME_LENGTH] = "Cinema";
 static int	Credits_music_handle = -1;
 static UI_TIMESTAMP	Credits_music_begin_timestamp;
 
@@ -470,9 +470,6 @@ void credits_init()
 	// pre-initialize
 	Credits_num_images = DEFAULT_NUM_IMAGES;
 	Credits_artwork_index = -1;
-
-	// this is moved up here so we can override it if desired
-	strcpy_s(Credits_music_name, "Cinema");
 
 	// parse credits early so as to set up any overrides (for music and such)
 	Credits_parsed = false;

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -207,7 +207,7 @@ static int	Credits_last_time;		// timestamp used to calc frametime (in ms)
 static float Credits_counter;
 
 int Credits_num_images = DEFAULT_NUM_IMAGES;
-int Credits_artwork_index = 0;
+int Credits_artwork_index = -1;
 static SCP_vector<int> Credits_bmps;
 
 // Positions for credits...

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -206,8 +206,8 @@ static int	Credits_frametime;		// frametime of credits_do_frame() loop in ms
 static int	Credits_last_time;		// timestamp used to calc frametime (in ms)
 static float Credits_counter;
 
-int Credits_num_images;
-int Credits_artwork_index;
+int Credits_num_images = DEFAULT_NUM_IMAGES;
+int Credits_artwork_index = 0;
 static SCP_vector<int> Credits_bmps;
 
 // Positions for credits...
@@ -466,10 +466,6 @@ void credits_init()
 {
 	int i;
 	credits_screen_buttons *b;
-
-	// pre-initialize
-	Credits_num_images = DEFAULT_NUM_IMAGES;
-	Credits_artwork_index = -1;
 
 	// parse credits early so as to set up any overrides (for music and such)
 	Credits_parsed = false;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1470,7 +1470,12 @@ ADE_VIRTVAR(StartIndex, l_UserInterface_Credits, nullptr, "The image index to be
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "i", Credits_artwork_index);
+	int retv = Credits_artwork_index;
+	if (retv < 0) {
+		retv = Random::next(Credits_num_images);
+	}
+
+	return ade_set_args(L, "i", retv);
 }
 
 ADE_VIRTVAR(DisplayTime, l_UserInterface_Credits, nullptr, "The display time for each image", "number", "The display time")


### PR DESCRIPTION
Sets the credits music default earlier so that SCPUI doesn't get nil data if no table explicitly sets the music.