### PR TITLE
Toggle cockpit

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -250,7 +250,7 @@ static int Damage_flash_timer;
 
 HudGauge::HudGauge():
 base_w(0), base_h(0), gauge_config(-1), font_num(font::FONT1), lock_color(false), sexp_lock_color(false), reticle_follow(false),
-active(false), off_by_default(false), sexp_override(false), pop_up(false), disabled_views(0), only_render_in_chase_view(false), custom_gauge(false),
+active(false), off_by_default(false), sexp_override(false), pop_up(false), disabled_views(0), only_render_in_chase_view(false), render_for_cockpit_toggle(0), custom_gauge(false),
 texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 {
 	position[0] = 0;
@@ -275,7 +275,7 @@ texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 HudGauge::HudGauge(int _gauge_object, int _gauge_config, bool _slew, bool _message, int _disabled_views, int r, int g, int b):
 base_w(0), base_h(0), gauge_config(_gauge_config), gauge_object(_gauge_object), font_num(font::FONT1), lock_color(false), sexp_lock_color(false),
 reticle_follow(_slew), active(false), off_by_default(false), sexp_override(false), pop_up(false), message_gauge(_message),
-disabled_views(_disabled_views), only_render_in_chase_view(false), custom_gauge(false), textoffset_x(0), textoffset_y(0), texture_target(-1),
+disabled_views(_disabled_views), only_render_in_chase_view(false), render_for_cockpit_toggle(0), custom_gauge(false), textoffset_x(0), textoffset_y(0), texture_target(-1),
 canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 {
 	Assert(gauge_config <= NUM_HUD_GAUGES && gauge_config >= 0);
@@ -311,7 +311,7 @@ canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 HudGauge::HudGauge(int _gauge_config, bool _slew, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y):
 base_w(0), base_h(0), gauge_config(_gauge_config), gauge_object(HUD_OBJECT_CUSTOM), font_num(font::FONT1), lock_color(false), sexp_lock_color(false),
 reticle_follow(_slew), active(false), off_by_default(false), sexp_override(false), pop_up(false), message_gauge(false),
-disabled_views(VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY), only_render_in_chase_view(false), custom_gauge(true), textoffset_x(txtoffset_x),
+disabled_views(VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY), only_render_in_chase_view(false), render_for_cockpit_toggle(0), custom_gauge(true), textoffset_x(txtoffset_x),
 textoffset_y(txtoffset_y), texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 {
 	position[0] = 0;
@@ -608,6 +608,11 @@ void HudGauge::initRenderStatus(bool do_render)
 void HudGauge::initChase_view_only(bool chase_view_only) 
 { 
 	only_render_in_chase_view = chase_view_only; 
+}
+
+void HudGauge::initCockpit_view_choice(int cockpit_view_choice)
+{
+	render_for_cockpit_toggle = cockpit_view_choice;
 }
 
 bool HudGauge::isOffbyDefault()
@@ -1169,6 +1174,14 @@ bool HudGauge::canRender()
 
 	if ((Viewer_mode & (VM_CHASE)) == 0 && only_render_in_chase_view) {
 		return false;
+	}
+	
+	if (render_for_cockpit_toggle > 0) {
+		if (cockpitActive && (render_for_cockpit_toggle == 2)) {
+			return false;
+		} else if (!cockpitActive && (render_for_cockpit_toggle == 1)) {
+			return false;
+		}
 	}
 
 	if(pop_up) {

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -244,6 +244,7 @@ protected:
 	int flash_next;
 	bool flash_status;
 	bool only_render_in_chase_view;
+	int render_for_cockpit_toggle;
 
 	// custom gauge specific stuff
 	bool custom_gauge;
@@ -303,6 +304,7 @@ public:
 	void updatePopUp(bool pop_up_flag);
 	void updateSexpOverride(bool sexp);
 	void initChase_view_only(bool chase_view_only);
+	void initCockpit_view_choice(int cockpit_view_choice);
 
 	// SEXP interfacing functions
 	// For flashing gauges in training missions

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -1329,12 +1329,19 @@ std::unique_ptr<T> gauge_load_common(gauge_settings* settings, T* preAllocated =
 	}
 
 	if (optional_string("Cockpit View Choice:")) {
-		int choice;
-		stuff_int(&choice);
-		if (choice < 0 || choice > 2) {
-			choice = 0;
+		char choice[NAME_LENGTH];
+		stuff_string(choice, F_NAME, NAME_LENGTH);
+
+		if (!stricmp(choice, "cockpitactive")) {
+			settings->cockpit_view_choice = 1;
+		} else if (!stricmp(choice, "cockpitinactive")) {
+			settings->cockpit_view_choice = 2;
+		} else {
+			if (stricmp(choice, "both")) {
+				Warning(LOCATION, "Unrecognized cockpit view choice: %s", choice);
+			}
+			settings->cockpit_view_choice = 0;
 		}
-		settings->cockpit_view_choice = choice;
 	}
 
 	if (settings->set_position) {
@@ -1486,12 +1493,19 @@ void load_gauge_custom(gauge_settings* settings)
 		}
 
 		if (optional_string("Cockpit View Choice:")) {
-			int choice;
-			stuff_int(&choice);
-			if (choice < 0 || choice > 2) {
-				choice = 0;
+			char choice[NAME_LENGTH];
+			stuff_string(choice, F_NAME, NAME_LENGTH);
+
+			if (!stricmp(choice, "cockpitactive")) {
+				settings->cockpit_view_choice = 1;
+			} else if (!stricmp(choice, "cockpitinactive")) {
+				settings->cockpit_view_choice = 2;
+			} else {
+				if (stricmp(choice, "both")) {
+					Warning(LOCATION, "Unrecognized cockpit view choice: %s", choice);
+				}
+				settings->cockpit_view_choice = 0;
 			}
-			settings->cockpit_view_choice = choice;
 		}
 
 		required_string("Name:");

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -220,6 +220,7 @@ void parse_hud_gauges_tbl(const char *filename)
 	color *ship_clr_p = NULL;
 	bool scale_gauge = true;
 	bool chase_view_only = false;
+	int cockpit_view_choice = 0;
 
 	try
 	{
@@ -508,6 +509,7 @@ void parse_hud_gauges_tbl(const char *filename)
 				settings.ship_idx = &ship_classes;
 				settings.use_clr = use_clr_p;
 				settings.chase_view_only = chase_view_only;
+				settings.cockpit_view_choice = cockpit_view_choice;
 
 				// if "default" is specified, then the base resolution is {-1, -1},
 				// indicating GR_640 or GR_1024 to the handlers. otherwise, change it
@@ -1326,6 +1328,15 @@ std::unique_ptr<T> gauge_load_common(gauge_settings* settings, T* preAllocated =
 		stuff_boolean(&settings->chase_view_only);
 	}
 
+	if (optional_string("Cockpit View Choice:")) {
+		int choice;
+		stuff_int(&choice);
+		if (choice < 0 || choice > 2) {
+			choice = 0;
+		}
+		settings->cockpit_view_choice = choice;
+	}
+
 	if (settings->set_position) {
 		if(optional_string("Slew:")) {
 			stuff_boolean(&settings->slew);
@@ -1345,6 +1356,7 @@ std::unique_ptr<T> gauge_load_common(gauge_settings* settings, T* preAllocated =
 	instance->initCoords(settings->use_coords, settings->coords[0], settings->coords[1]);
 
 	instance->initChase_view_only(settings->chase_view_only);
+	instance->initCockpit_view_choice(settings->cockpit_view_choice);
 	if (settings->set_position) {
 		instance->initPosition(settings->coords[0], settings->coords[1]);
 		instance->initSlew(settings->slew);
@@ -1473,6 +1485,15 @@ void load_gauge_custom(gauge_settings* settings)
 			stuff_boolean(&settings->chase_view_only);
 		}
 
+		if (optional_string("Cockpit View Choice:")) {
+			int choice;
+			stuff_int(&choice);
+			if (choice < 0 || choice > 2) {
+				choice = 0;
+			}
+			settings->cockpit_view_choice = choice;
+		}
+
 		required_string("Name:");
 		stuff_string(name, F_NAME, MAX_FILENAME_LEN);
 
@@ -1529,6 +1550,7 @@ void load_gauge_custom(gauge_settings* settings)
 	hud_gauge->lockConfigColor(lock_color);
 	hud_gauge->initCockpitTarget(display_name, display_offset[0], display_offset[1], display_size[0], display_size[1], canvas_size[0], canvas_size[1]);
 	hud_gauge->initChase_view_only(settings->chase_view_only);
+	hud_gauge->initCockpit_view_choice(settings->cockpit_view_choice);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }
@@ -3073,6 +3095,7 @@ void load_gauge_radar_dradis(gauge_settings* settings)
 	hud_gauge->initCockpitTarget(display_name, display_offset[0], display_offset[1], display_size[0], display_size[1], canvas_size[0], canvas_size[1]);
 	hud_gauge->initSound(loop_snd, loop_snd_volume, arrival_beep_snd, departure_beep_snd, stealth_arrival_snd, stealth_departure_snd, arrival_beep_delay, departure_beep_delay);
 	hud_gauge->initChase_view_only(settings->chase_view_only);
+	hud_gauge->initCockpit_view_choice(settings->cockpit_view_choice);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }

--- a/code/hud/hudparse.h
+++ b/code/hud/hudparse.h
@@ -41,8 +41,12 @@ typedef struct gauge_settings {
 	bool set_colour;
 	bool slew;
 	bool chase_view_only;
+	int cockpit_view_choice;
 
-	gauge_settings() : font_num(Hud_font), scale_gauge(Scale_retail_gauges), ship_idx(nullptr), use_clr(nullptr), use_coords(false), set_position(true), set_colour(true), slew(false), chase_view_only(Chase_view_only_ex) {
+	gauge_settings()
+		: font_num(Hud_font), scale_gauge(Scale_retail_gauges), ship_idx(nullptr), use_clr(nullptr), use_coords(false),
+		  set_position(true), set_colour(true), slew(false), chase_view_only(Chase_view_only_ex), cockpit_view_choice(0)
+	{
 		base_res[0] = -1;
 		base_res[1] = -1;
 		memcpy(force_scaling_above_res, Force_scaling_above_res_global, sizeof(force_scaling_above_res));

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -11,6 +11,7 @@
 #include "hud/hudconfig.h"
 #include "hud/hudtargetbox.h"
 #include "hud/hudtarget.h"
+#include "ship/ship.h"
 
 extern int Training_obj_num_display_lines;
 
@@ -264,6 +265,18 @@ ADE_FUNC(getTargetDistance, l_HUD, "object targetee, [vector targeter_position]"
 ADE_FUNC(getDirectiveLines, l_HUD, nullptr, "Returns the number of lines displayed by the currently active directives", "number", "The number of lines")
 {
 	return ade_set_args(L, "i", Training_obj_num_display_lines);
+}
+
+ADE_VIRTVAR(toggleCockpits, l_HUD, "boolean", "Gets or sets whether the the cockpit model will be rendered.", "boolean", "true if being rendered, false otherwise")
+{
+	bool choice = !disableCockpits;
+
+	if (ADE_SETTING_VAR && ade_get_args(L, "*b", &choice))
+	{
+		disableCockpits = !choice;
+	}
+
+	return ade_set_args(L, "b", choice);
 }
 
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -136,6 +136,7 @@ ship	*Player_ship;
 int		*Player_cockpit_textures;
 SCP_vector<cockpit_display> Player_displays;
 bool disableCockpits = false;
+bool cockpitActive = false;
 
 wing	Wings[MAX_WINGS];
 bool	Ships_inited = false;
@@ -7457,8 +7458,12 @@ void ship_render_player_ship(object* objp) {
 			|| !(Viewer_mode & VM_EXTERNAL));
 
 	//Nothing to do
-	if (!(renderCockpitModel || renderShipModel))
+	if (!(renderCockpitModel || renderShipModel)) {
+		cockpitActive = false;
 		return;
+	}
+
+	cockpitActive = true;
 
 	//If we aren't sure whether cockpits and external models can share the same worldspace,
 	//we need to pre-render the external ship hull without shadows / deferred and give the cockpit precedence,

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7451,7 +7451,7 @@ void ship_render_player_ship(object* objp) {
 
 	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
 
-	const bool renderCockpitModel = Viewer_mode != VM_TOPDOWN && hasCockpitModel;
+	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !disableCockpits;
 	const bool renderShipModel = (sip->flags[Ship::Info_Flags::Show_ship_model])
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK)
 			|| !(Viewer_mode & VM_EXTERNAL));
@@ -7463,7 +7463,8 @@ void ship_render_player_ship(object* objp) {
 	//If we aren't sure whether cockpits and external models can share the same worldspace,
 	//we need to pre-render the external ship hull without shadows / deferred and give the cockpit precedence,
 	//unless this ship has no cockpit at all
-	const bool prerenderShipModel = renderShipModel && hasCockpitModel && !Cockpit_shares_coordinate_space;
+	const bool prerenderShipModel =
+		renderShipModel && hasCockpitModel && !Cockpit_shares_coordinate_space && !disableCockpits;
 	const bool deferredRenderShipModel = renderShipModel && !prerenderShipModel;
 
 	gr_reset_clip();
@@ -7579,7 +7580,7 @@ void ship_render_player_ship(object* objp) {
 		model_render_immediate(&render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset);
 		gr_zbuffer_clear(true);
 	}
-	if (renderCockpitModel && !disableCockpits) {
+	if (renderCockpitModel) {
 		model_render_params render_info;
 		render_info.set_detail_level_lock(0);
 		render_info.set_flags(render_flags);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7456,20 +7456,17 @@ void ship_render_player_ship(object* objp) {
 	const bool renderShipModel = (sip->flags[Ship::Info_Flags::Show_ship_model])
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK)
 			|| !(Viewer_mode & VM_EXTERNAL));
+	cockpitActive = renderCockpitModel;
 
 	//Nothing to do
 	if (!(renderCockpitModel || renderShipModel)) {
-		cockpitActive = false;
 		return;
 	}
-
-	cockpitActive = true;
 
 	//If we aren't sure whether cockpits and external models can share the same worldspace,
 	//we need to pre-render the external ship hull without shadows / deferred and give the cockpit precedence,
 	//unless this ship has no cockpit at all
-	const bool prerenderShipModel =
-		renderShipModel && hasCockpitModel && !Cockpit_shares_coordinate_space && !disableCockpits;
+	const bool prerenderShipModel = renderShipModel && hasCockpitModel && !Cockpit_shares_coordinate_space;
 	const bool deferredRenderShipModel = renderShipModel && !prerenderShipModel;
 
 	gr_reset_clip();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -135,6 +135,7 @@ ship	Ships[MAX_SHIPS];
 ship	*Player_ship;
 int		*Player_cockpit_textures;
 SCP_vector<cockpit_display> Player_displays;
+bool disableCockpits = false;
 
 wing	Wings[MAX_WINGS];
 bool	Ships_inited = false;
@@ -7578,7 +7579,7 @@ void ship_render_player_ship(object* objp) {
 		model_render_immediate(&render_info, sip->model_num, shipp->model_instance_num, &objp->orient, &eye_offset);
 		gr_zbuffer_clear(true);
 	}
-	if (renderCockpitModel) {
+	if (renderCockpitModel && !disableCockpits) {
 		model_render_params render_info;
 		render_info.set_detail_level_lock(0);
 		render_info.set_flags(render_flags);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -287,6 +287,7 @@ typedef struct cockpit_display {
 } cockpit_display;
 
 extern bool disableCockpits;
+extern bool cockpitActive;
 
 extern SCP_vector<cockpit_display> Player_displays;
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -286,6 +286,8 @@ typedef struct cockpit_display {
 	char name[MAX_FILENAME_LEN];
 } cockpit_display;
 
+extern bool disableCockpits;
+
 extern SCP_vector<cockpit_display> Player_displays;
 
 typedef struct cockpit_display_info {


### PR DESCRIPTION
Makes cockpits toggle-able in mission and adds a new HUD gauge option to make a gauge render only when cockpits are active, only when cockpits are not active, or render for both (default). Also adds a Lua method to be able to toggle the cockpits.