### PR TITLE
Enable hud rearm timer in hud_gauges.tbl

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -380,7 +380,7 @@ int Cmdline_no_vsync = 0;
 cmdline_parm ballistic_gauge("-ballistic_gauge", NULL, AT_NONE);	// Cmdline_ballistic_gauge
 cmdline_parm dualscanlines_arg("-dualscanlines", NULL, AT_NONE); // Cmdline_dualscanlines  -- Change to phreaks options including new targeting code; semi-deprecated but still functional
 cmdline_parm orb_radar("-orbradar", NULL, AT_NONE);			// Cmdline_orb_radar
-cmdline_parm rearm_timer_arg("-rearm_timer", NULL, AT_NONE);	// Cmdline_rearm_timer
+cmdline_parm rearm_timer_arg("-rearm_timer", NULL, AT_NONE);	// Cmdline_rearm_timer; semi-deprecated but still functional-Mjn
 cmdline_parm targetinfo_arg("-targetinfo", NULL, AT_NONE);	// Cmdline_targetinfo  -- Adds ship name/class to right of target box -C; semi-deprecated but still functional-Mjn
 
 int Cmdline_ballistic_gauge = 0;	// WMCoolmon's gauge thingy

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2936,6 +2936,11 @@ void HudGaugeSupport::initTextDockValueOffsetX(int x)
 	text_dock_val_offset_x = x;
 }
 
+void HudGaugeSupport::initRearmTimer(bool choice)
+{
+	enable_rearm_timer = choice;
+}
+
 void HudGaugeSupport::initBitmaps(const char *fname)
 {
 	background.first_frame = bm_load_animation(fname, &background.num_frames);
@@ -2994,7 +2999,7 @@ void HudGaugeSupport::render(float  /*frametime*/)
 	if (Player_ai->ai_flags[AI::AI_Flags::Being_repaired]) {
 		Assert(Player_ship->ship_max_hull_strength > 0);
 		
-		if (!Cmdline_rearm_timer)
+		if (!enable_rearm_timer)
 		{
 			int i;
 			bool repairing = false;

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -517,6 +517,7 @@ protected:
 	int text_val_offset_y;
 	int text_dock_offset_x;
 	int text_dock_val_offset_x;
+	bool enable_rearm_timer;
 public:
 	HudGaugeSupport();
 	void initBitmaps(const char *fname);
@@ -524,6 +525,7 @@ public:
 	void initTextValueOffsetY(int y);
 	void initTextDockOffsetX(int x);
 	void initTextDockValueOffsetX(int x);
+	void initRearmTimer(bool choice);
 	void render(float frametime) override;
 	void pageIn() override;
 };

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -4191,6 +4191,7 @@ void load_gauge_support(gauge_settings* settings)
 	int text_val_offset_y;
 	int text_dock_offset_x;
 	int text_dock_val_offset_x;
+	bool rearm_timer_choice = Cmdline_rearm_timer;
 	char fname[MAX_FILENAME_LEN] = "support1";
 	
 	settings->origin[0] = 0.5f;
@@ -4233,12 +4234,16 @@ void load_gauge_support(gauge_settings* settings)
 	if(optional_string("Dock Time X-offset:")) {
 		stuff_int(&text_dock_val_offset_x);
 	}
+	if (optional_string("Enable Rearm Timer:")) {
+		stuff_boolean(&rearm_timer_choice);
+	}
 
 	hud_gauge->initBitmaps(fname);
 	hud_gauge->initHeaderOffsets(header_offsets[0], header_offsets[1]);
 	hud_gauge->initTextDockOffsetX(text_dock_offset_x);
 	hud_gauge->initTextDockValueOffsetX(text_dock_val_offset_x);
 	hud_gauge->initTextValueOffsetY(text_val_offset_y);
+	hud_gauge->initRearmTimer(rearm_timer_choice);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }


### PR DESCRIPTION
Adds a way to enable the support rearm timer from hud_gauges.tbl. Does not deprecate the commandline but the table setting, if parsed, will take precedence