### PR TITLE
enable target info in hud_gauges.tbl

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2155,7 +2155,7 @@ void asteroid_init()
 	asteroid_parse_tbl();
 }
 
-extern int Cmdline_targetinfo;
+extern bool Extra_target_info;
 
 /**
  * Draw brackets around on-screen asteroids that are about to collide, otherwise draw an offscreen indicator
@@ -2191,7 +2191,7 @@ void asteroid_show_brackets()
 		g3_rotate_vertex(&asteroid_vertex,&asteroid_objp->pos);
 		g3_project_vertex(&asteroid_vertex);
 
-		if ( Cmdline_targetinfo ) {
+		if ( Extra_target_info ) {
 			hud_target_add_display_list(asteroid_objp, &asteroid_vertex, &asteroid_objp->pos, 0, NULL, NULL, TARGET_DISPLAY_DIST | TARGET_DISPLAY_LEAD);
 		} else {
 			hud_target_add_display_list(asteroid_objp, &asteroid_vertex, &asteroid_objp->pos, 0, NULL, NULL, TARGET_DISPLAY_DIST);

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -381,7 +381,7 @@ cmdline_parm ballistic_gauge("-ballistic_gauge", NULL, AT_NONE);	// Cmdline_ball
 cmdline_parm dualscanlines_arg("-dualscanlines", NULL, AT_NONE); // Cmdline_dualscanlines  -- Change to phreaks options including new targeting code; semi-deprecated but still functional
 cmdline_parm orb_radar("-orbradar", NULL, AT_NONE);			// Cmdline_orb_radar
 cmdline_parm rearm_timer_arg("-rearm_timer", NULL, AT_NONE);	// Cmdline_rearm_timer
-cmdline_parm targetinfo_arg("-targetinfo", NULL, AT_NONE);	// Cmdline_targetinfo  -- Adds ship name/class to right of target box -C
+cmdline_parm targetinfo_arg("-targetinfo", NULL, AT_NONE);	// Cmdline_targetinfo  -- Adds ship name/class to right of target box -C; semi-deprecated but still functional-Mjn
 
 int Cmdline_ballistic_gauge = 0;	// WMCoolmon's gauge thingy
 int Cmdline_dualscanlines = 0;

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -387,7 +387,6 @@ int Cmdline_ballistic_gauge = 0;	// WMCoolmon's gauge thingy
 int Cmdline_dualscanlines = 0;
 int Cmdline_orb_radar = 0;
 int Cmdline_rearm_timer = 0;
-int Cmdline_targetinfo = 0;
 
 // Gameplay related
 cmdline_parm use_3dwarp("-3dwarp", nullptr, AT_NONE);			// Is now Fireball_use_3d_warp
@@ -1731,7 +1730,7 @@ bool SetCmdlineParams()
 
 	if(targetinfo_arg.found())
 	{
-		Cmdline_targetinfo = 1;
+		Extra_target_info = true;
 	}
 
 	if(nomovies_arg.found() ) {

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -80,7 +80,6 @@ extern int Cmdline_ballistic_gauge;
 extern int Cmdline_dualscanlines;
 extern int Cmdline_orb_radar;
 extern int Cmdline_rearm_timer;
-extern int Cmdline_targetinfo;
 
 // Gameplay related
 extern int Cmdline_ship_choice_3d;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -182,6 +182,7 @@ static int					Pl_hud_is_bright;
 #define SUBSYS_DAMAGE_FLASH_INTERVAL	100
 
 float Player_rearm_eta = 0;
+bool Extra_target_info = false;
 
 // forward declarations
 void update_throttle_sound();

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -581,5 +581,7 @@ extern SCP_vector<std::unique_ptr<HudGauge>> default_hud_gauges;
 extern flag_def_list Hud_gauge_types[];
 extern int Num_hud_gauge_types;
 
+extern bool Extra_target_info;
+
 #endif	/* __HUD_H__ */
 

--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -185,7 +185,7 @@ void draw_brackets_diamond_quick(graphics::line_draw_list* draw_list, int x1, in
 
 extern int HUD_drew_selection_bracket_on_target;
 //Do we want to show the ship & class name?
-extern int Cmdline_targetinfo;
+extern bool Extra_target_info;
 
 // Display the current target distance, right justified at (x,y)
 void hud_target_show_dist_on_bracket(int x, int y, float distance, int font_num)

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -4710,6 +4710,9 @@ void load_gauge_brackets(gauge_settings* settings)
 	if(optional_string("Dot Filename:")) {
 		stuff_string(fname, F_NAME, MAX_FILENAME_LEN);
 	}
+	if (optional_string("Enable Target Info:")) {
+		stuff_boolean(&Extra_target_info);
+	}
 
 	hud_gauge->initBitmaps(fname);
 	hud_gauge->initMinSubTargetBoxSizes(min_subtarget_box[0], min_subtarget_box[1]);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -3408,7 +3408,7 @@ void hud_show_selection_set()
 			if ( OBJ_INDEX(targetp) == Player_ai->target_objnum ) {
 				hud_target_add_display_list(targetp, &target_point, &targetp->pos, 5, iff_get_color(IFF_COLOR_SELECTION, 1), NULL, 0);
 				HUD_drew_selection_bracket_on_target = 1;
-			} else if ( Cmdline_targetinfo ) {		//Backslash -- show the distance and a lead indicator
+			} else if ( Extra_target_info ) {		//Backslash -- show the distance and a lead indicator
 				hud_target_add_display_list(targetp, &target_point, &targetp->pos, 5, iff_get_color(IFF_COLOR_SELECTION, 1), NULL, TARGET_DISPLAY_DIST | TARGET_DISPLAY_LEAD);
 			} else {
 				hud_target_add_display_list(targetp, &target_point, &targetp->pos, 5, iff_get_color(IFF_COLOR_SELECTION, 1), NULL, 0);
@@ -3471,7 +3471,7 @@ void hud_show_targeting_gauges(float frametime)
 		if (target_point.codes == 0) { // target center is not on screen
 			int target_display_flags;
 
-			if(Cmdline_targetinfo) {
+			if(Extra_target_info) {
 				target_display_flags = TARGET_DISPLAY_DIST | TARGET_DISPLAY_DOTS | TARGET_DISPLAY_SUBSYS | TARGET_DISPLAY_NAME | TARGET_DISPLAY_CLASS;
 			} else {
 				target_display_flags = TARGET_DISPLAY_DIST | TARGET_DISPLAY_DOTS | TARGET_DISPLAY_SUBSYS;


### PR DESCRIPTION
Adds a way to enable extra target info from hud_gauges.tbl. Does not deprecate the commandline but the table setting, if parsed, will take precedence