### PR TITLE
Use a local int for model storage in renderTechModel

### DIFF
--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -630,7 +630,7 @@ ADE_FUNC(renderTechModel,
 	int modelNum;
 	//Load the model if it exists or exit early
 	if (VALID_FNAME(wip->tech_model)) {
-		modelNum = model_load(wip->tech_model, 0, NULL, 0);
+		modelNum = model_load(wip->tech_model, 0, nullptr, 0);
 	} else {
 		return ade_set_args(L, "b", false);
 	}
@@ -700,7 +700,7 @@ ADE_FUNC(renderTechModel2,
 	int x1, y1, x2, y2;
 	int idx;
 	float zoom = 1.3f;
-	matrix_h* mh = NULL;
+	matrix_h* mh = nullptr;
 	if (!ade_get_args(L, "oiiiio|f", l_Weaponclass.Get(&idx), &x1, &y1, &x2, &y2, l_Matrix.GetPtr(&mh), &zoom))
 		return ade_set_error(L, "b", false);
 
@@ -716,7 +716,7 @@ ADE_FUNC(renderTechModel2,
 	int modelNum;
 	// Load the model if it exists or exit early
 	if (VALID_FNAME(wip->tech_model)) {
-		modelNum = model_load(wip->tech_model, 0, NULL, 0);
+		modelNum = model_load(wip->tech_model, 0, nullptr, 0);
 	} else {
 		return ade_set_args(L, "b", false);
 	}

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -627,14 +627,15 @@ ADE_FUNC(renderTechModel,
 	weapon_info* wip = &Weapon_info[idx];
 	model_render_params render_info;
 
+	int modelNum;
 	//Load the model if it exists or exit early
 	if (VALID_FNAME(wip->tech_model)) {
-		wip->model_num = model_load(wip->tech_model, 0, NULL, 0);
+		modelNum = model_load(wip->tech_model, 0, NULL, 0);
 	} else {
 		return ade_set_args(L, "b", false);
 	}
 
-	if (wip->model_num < 0)
+	if (modelNum < 0)
 		return ade_set_args(L, "b", false);
 
 	// Handle angles
@@ -665,7 +666,7 @@ ADE_FUNC(renderTechModel,
 	light_rotate_all();
 
 	// Draw the ship!!
-	model_clear_instance(wip->model_num);
+	model_clear_instance(modelNum);
 	render_info.set_detail_level_lock(0);
 
 	uint render_flags = MR_AUTOCENTER | MR_NO_FOGGING;
@@ -675,7 +676,7 @@ ADE_FUNC(renderTechModel,
 
 	render_info.set_flags(render_flags);
 
-	model_render_immediate(&render_info, wip->model_num, &orient, &vmd_zero_vector);
+	model_render_immediate(&render_info, modelNum, &orient, &vmd_zero_vector);
 
 	// OK we're done
 	gr_end_view_matrix();
@@ -712,14 +713,15 @@ ADE_FUNC(renderTechModel2,
 	weapon_info* wip = &Weapon_info[idx];
 	model_render_params render_info;
 
+	int modelNum;
 	// Load the model if it exists or exit early
 	if (VALID_FNAME(wip->tech_model)) {
-		wip->model_num = model_load(wip->tech_model, 0, NULL, 0);
+		modelNum = model_load(wip->tech_model, 0, NULL, 0);
 	} else {
 		return ade_set_args(L, "b", false);
 	}
 
-	if (wip->model_num < 0)
+	if (modelNum < 0)
 		return ade_set_args(L, "b", false);
 
 	// Handle angles
@@ -743,7 +745,7 @@ ADE_FUNC(renderTechModel2,
 	light_rotate_all();
 
 	// Draw the ship!!
-	model_clear_instance(wip->model_num);
+	model_clear_instance(modelNum);
 	render_info.set_detail_level_lock(0);
 
 	uint render_flags = MR_AUTOCENTER | MR_NO_FOGGING;
@@ -753,7 +755,7 @@ ADE_FUNC(renderTechModel2,
 
 	render_info.set_flags(render_flags);
 
-	model_render_immediate(&render_info, wip->model_num, orient, &vmd_zero_vector);
+	model_render_immediate(&render_info, modelNum, orient, &vmd_zero_vector);
 
 	// OK we're done
 	gr_end_view_matrix();


### PR DESCRIPTION
This fixes an issue where if renderTechModel was used it would load the tech model into `wip->model_num` causing the weapon in-game to subsequently not load in the desired low detail or bullet POF and instead use the tech model.