### PR TITLE
model.Submodels fix

### DIFF
--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -441,6 +441,9 @@ ADE_INDEXER(l_ModelSubmodels, "submodel", "number|string IndexOrName", "submodel
 		index = model_find_submodel_index(msh->GetID(), name);
 	}
 
+	if (!msh->IsValid())
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
 	polymodel *pm = msh->Get();
 
 	if (index < 0 || index >= pm->n_models)


### PR DESCRIPTION
Guard against the indexer being invalid, e.g. if the model isn't loaded yet.