### PR TITLE
Allow option to choose to render with no lighting

### DIFF
--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -996,8 +996,8 @@ ADE_FUNC(isInTechroom, l_Shipclass, NULL, "Gets whether or not the ship class is
 ADE_FUNC(renderTechModel,
 	l_Shipclass,
 	"number X1, number Y1, number X2, number Y2, [number RotationPercent =0, number PitchPercent =0, number "
-	"BankPercent=40, number Zoom=1.3]",
-	"Draws ship model as if in techroom",
+	"BankPercent=40, number Zoom=1.3, number Lighting=0]",
+	"Draws ship model as if in techroom. 0 for regular lighting 1 for flat lighting.",
 	"boolean",
 	"Whether ship was rendered")
 {
@@ -1005,7 +1005,8 @@ ADE_FUNC(renderTechModel,
 	angles rot_angles = {0.0f, 0.0f, 40.0f};
 	int idx;
 	float zoom = 1.3f;
-	if(!ade_get_args(L, "oiiii|ffff", l_Shipclass.Get(&idx), &x1, &y1, &x2, &y2, &rot_angles.h, &rot_angles.p, &rot_angles.b, &zoom))
+	int lighting = 0;
+	if(!ade_get_args(L, "oiiii|ffffi", l_Shipclass.Get(&idx), &x1, &y1, &x2, &y2, &rot_angles.h, &rot_angles.p, &rot_angles.b, &zoom, &lighting))
 		return ade_set_error(L, "b", false);
 
 	if(idx < 0 || idx >= ship_info_size())
@@ -1060,7 +1061,7 @@ ADE_FUNC(renderTechModel,
 
 	uint render_flags = MR_AUTOCENTER | MR_NO_FOGGING;
 
-	if(sip->flags[Ship::Info_Flags::No_lighting])
+	if((lighting > 0) || (sip->flags[Ship::Info_Flags::No_lighting]))
 		render_flags |= MR_NO_LIGHTING;
 
 	render_info.set_flags(render_flags);

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -592,8 +592,8 @@ ADE_FUNC(isValid, l_Weaponclass, NULL, "Detects whether handle is valid", "boole
 ADE_FUNC(renderTechModel,
 	l_Weaponclass,
 	"number X1, number Y1, number X2, number Y2, [number RotationPercent =0, number PitchPercent =0, number "
-	"BankPercent=40, number Zoom=1.3]",
-	"Draws weapon tech model",
+	"BankPercent=40, number Zoom=1.3, number Lighting=0]",
+	"Draws weapon tech model. 0 for regular lighting 1 for flat lighting.",
 	"boolean",
 	"Whether weapon was rendered")
 {
@@ -601,8 +601,9 @@ ADE_FUNC(renderTechModel,
 	angles rot_angles = {0.0f, 0.0f, 40.0f};
 	int idx;
 	float zoom = 1.3f;
+	int lighting = 0;
 	if (!ade_get_args(L,
-			"oiiii|ffff",
+			"oiiii|ffffi",
 			l_Weaponclass.Get(&idx),
 			&x1,
 			&y1,
@@ -611,7 +612,8 @@ ADE_FUNC(renderTechModel,
 			&rot_angles.h,
 			&rot_angles.p,
 			&rot_angles.b,
-			&zoom))
+			&zoom,
+			&lighting))
 		return ade_set_error(L, "b", false);
 
 	if (idx < 0 || idx >= weapon_info_size())
@@ -671,7 +673,7 @@ ADE_FUNC(renderTechModel,
 
 	uint render_flags = MR_AUTOCENTER | MR_NO_FOGGING;
 
-	if (wip->wi_flags[Weapon::Info_Flags::Mr_no_lighting])
+	if ((lighting > 0) || (wip->wi_flags[Weapon::Info_Flags::Mr_no_lighting]))
 		render_flags |= MR_NO_LIGHTING;
 
 	render_info.set_flags(render_flags);


### PR DESCRIPTION
Adds option to renderTechModel() to render with flat lighting. This is especially useful for scpui to generate the ship and weapon icons more closely to the original FSO feature.