### PR TITLE
Update `$POF file Techroom:` Usage

### DIFF
--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -330,13 +330,7 @@ void techroom_select_new_entry()
 			i++;
 		}
 
-		if (sip->pof_file_tech[0] != '\0') {
-			// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to the
-			// techroom model, which is decidedly wrong for the mission itself.
-			Techroom_ship_modelnum = model_load(sip->pof_file_tech, 0, nullptr);
-		} else {
-			Techroom_ship_modelnum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-		}
+		Techroom_ship_modelnum = model_load(sip, true);
 
 		if (Techroom_ship_model_instance >= 0) {
 			model_delete_instance(Techroom_ship_model_instance);

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -330,7 +330,13 @@ void techroom_select_new_entry()
 			i++;
 		}
 
-		Techroom_ship_modelnum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+		if (sip->pof_file_tech[0] != '\0') {
+			// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to the
+			// techroom model, which is decidedly wrong for the mission itself.
+			Techroom_ship_modelnum = model_load(sip->pof_file_tech, 0, nullptr);
+		} else {
+			Techroom_ship_modelnum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+		}
 
 		if (Techroom_ship_model_instance >= 0) {
 			model_delete_instance(Techroom_ship_model_instance);

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1373,13 +1373,7 @@ int brief_setup_closeup(brief_icon *bi)
 		if ( sip == nullptr ) {
 			Closeup_icon->modelnum = model_load(pof_filename, 0, nullptr);
 		} else {
-			if (sip->pof_file_tech[0] != '\0') {
-				// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to the
-				// techroom model, which is decidedly wrong for the mission itself.
-				Closeup_icon->modelnum = model_load(sip->pof_file_tech, 0, nullptr);
-			} else {
-				Closeup_icon->modelnum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-			}
+			Closeup_icon->modelnum = model_load(sip, true);
 			Closeup_icon->model_instance_num = model_create_instance(-1, Closeup_icon->modelnum);
 			model_set_up_techroom_instance(sip, Closeup_icon->model_instance_num);
 		}
@@ -1604,13 +1598,7 @@ void brief_do_frame(float frametime)
 
 					ship_info *sip = &Ship_info[Closeup_icon->ship_class];
 					if (sip->model_num < 0) {
-						if (sip->pof_file_tech[0] != '\0') {
-							// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
-							// the techroom model, which is decidedly wrong for the mission itself.
-							sip->model_num = model_load(sip->pof_file_tech, 0, nullptr);
-						} else {
-							sip->model_num = model_load(sip->pof_file, 0, nullptr);
-						}
+						sip->model_num = model_load(sip, true);
 					}
 
 					mprintf(("Shiptype = %d (%s)\n", Closeup_icon->ship_class, sip->name));
@@ -1627,13 +1615,7 @@ void brief_do_frame(float frametime)
 
 					ship_info *sip = &Ship_info[Closeup_icon->ship_class];
 					if (sip->model_num < 0) {
-						if (sip->pof_file_tech[0] != '\0') {
-							// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
-							// the techroom model, which is decidedly wrong for the mission itself.
-							sip->model_num = model_load(sip->pof_file_tech, 0, nullptr);
-						} else {
-							sip->model_num = model_load(sip->pof_file, 0, nullptr);
-						}
+						sip->model_num = model_load(sip, true);
 					}
 
 					mprintf(("Shiptype = %d (%s)\n", Closeup_icon->ship_class, sip->name));

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1370,10 +1370,16 @@ int brief_setup_closeup(brief_icon *bi)
 	}
 	
 	if ( Closeup_icon->modelnum < 0 ) {
-		if ( sip == NULL ) {
-			Closeup_icon->modelnum = model_load(pof_filename, 0, NULL);
+		if ( sip == nullptr ) {
+			Closeup_icon->modelnum = model_load(pof_filename, 0, nullptr);
 		} else {
-			Closeup_icon->modelnum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+			if (sip->pof_file_tech[0] != '\0') {
+				// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to the
+				// techroom model, which is decidedly wrong for the mission itself.
+				Closeup_icon->modelnum = model_load(sip->pof_file_tech, 0, nullptr);
+			} else {
+				Closeup_icon->modelnum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+			}
 			Closeup_icon->model_instance_num = model_create_instance(-1, Closeup_icon->modelnum);
 			model_set_up_techroom_instance(sip, Closeup_icon->model_instance_num);
 		}
@@ -1597,8 +1603,15 @@ void brief_do_frame(float frametime)
 					Closeup_icon->ship_class--;
 
 					ship_info *sip = &Ship_info[Closeup_icon->ship_class];
-					if (sip->model_num < 0)
-						sip->model_num = model_load(sip->pof_file, 0, NULL);
+					if (sip->model_num < 0) {
+						if (sip->pof_file_tech[0] != '\0') {
+							// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
+							// the techroom model, which is decidedly wrong for the mission itself.
+							sip->model_num = model_load(sip->pof_file_tech, 0, nullptr);
+						} else {
+							sip->model_num = model_load(sip->pof_file, 0, nullptr);
+						}
+					}
 
 					mprintf(("Shiptype = %d (%s)\n", Closeup_icon->ship_class, sip->name));
 					mprintf(("Modelnum = %d (%s)\n", sip->model_num, sip->pof_file));
@@ -1613,8 +1626,15 @@ void brief_do_frame(float frametime)
 					Closeup_icon->ship_class++;
 
 					ship_info *sip = &Ship_info[Closeup_icon->ship_class];
-					if (sip->model_num < 0)
-						sip->model_num = model_load(sip->pof_file, 0, NULL);
+					if (sip->model_num < 0) {
+						if (sip->pof_file_tech[0] != '\0') {
+							// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
+							// the techroom model, which is decidedly wrong for the mission itself.
+							sip->model_num = model_load(sip->pof_file_tech, 0, nullptr);
+						} else {
+							sip->model_num = model_load(sip->pof_file, 0, nullptr);
+						}
+					}
 
 					mprintf(("Shiptype = %d (%s)\n", Closeup_icon->ship_class, sip->name));
 					mprintf(("Modelnum = %d (%s)\n", sip->model_num, sip->pof_file));

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1495,7 +1495,15 @@ void ship_select_do(float frametime)
 		{
 			ship_info *sip = &Ship_info[Carried_ss_icon.ship_class];
 			if(Ss_icons[Carried_ss_icon.ship_class].model_index == -1) {
-				Ss_icons[Carried_ss_icon.ship_class].model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+
+				if (sip->pof_file_tech[0] != '\0') {
+					// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
+					// the techroom model, which is decidedly wrong for the mission itself.
+					Ss_icons[Carried_ss_icon.ship_class].model_index = model_load(sip->pof_file_tech, 0, nullptr);
+				} else {
+					Ss_icons[Carried_ss_icon.ship_class].model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+				}
+
 				mprintf(("SL WARNING: Had to attempt to page in model for %s paged in manually! Result: %d\n", sip->name, Ss_icons[Carried_ss_icon.ship_class].model_index));
 			}
 			gr_set_color_fast(&Icon_colors[ICON_FRAME_SELECTED]);
@@ -1688,7 +1696,15 @@ void draw_ship_icon_with_number(int screen_offset, int ship_class)
 	{
 		ship_info *sip = &Ship_info[ship_class];
 		if(ss_icon->model_index == -1) {
-			ss_icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+
+			if (sip->pof_file_tech[0] != '\0') {
+				// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
+				// the techroom model, which is decidedly wrong for the mission itself.
+				ss_icon->model_index = model_load(sip->pof_file_tech, 0, nullptr);
+			} else {
+				ss_icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+			}
+
 			mprintf(("SL WARNING: Had to attempt to page in model for %s paged in manually! Result: %d\n", sip->name, ss_icon->model_index));
 		}
 		gr_set_color_fast(color_to_draw);
@@ -1744,7 +1760,13 @@ void start_ship_animation(int ship_class, int  /*play_sound*/)
 		}
 
 		// Load the necessary model file
-		ShipSelectModelNum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+		if (sip->pof_file_tech[0] != '\0') {
+			// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
+			// the techroom model, which is decidedly wrong for the mission itself.
+			ShipSelectModelNum = model_load(sip->pof_file_tech, 0, nullptr);
+		} else {
+			ShipSelectModelNum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+		}
 		
 		// page in ship textures properly (takes care of nondimming pixels)
 		model_page_in_textures(ShipSelectModelNum, ship_class);
@@ -2381,7 +2403,15 @@ void ss_blit_ship_icon(int x,int y,int ship_class,int bmap_num)
 		{
 			ship_info *sip = &Ship_info[ship_class];
 			if(icon->model_index == -1) {
-				icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+
+				if (sip->pof_file_tech[0] != '\0') {
+					// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
+					// the techroom model, which is decidedly wrong for the mission itself.
+					icon->model_index = model_load(sip->pof_file_tech, 0, nullptr);
+				} else {
+					icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+				}
+
 				mprintf(("SL WARNING: Had to attempt to page in model for %s paged in manually! Result: %d\n", sip->name, icon->model_index));
 			}
 			if(icon->model_index != -1)
@@ -2929,7 +2959,14 @@ void ss_load_icons(int ship_class)
 	}
 	else
 	{
-		icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+		if (sip->pof_file_tech[0] != '\0') {
+			// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
+			// the techroom model, which is decidedly wrong for the mission itself.
+			icon->model_index = model_load(sip->pof_file_tech, 0, nullptr);
+		} else {
+			icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+		}
+
 		model_page_in_textures(icon->model_index, ship_class);
 	}
 }

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1495,15 +1495,7 @@ void ship_select_do(float frametime)
 		{
 			ship_info *sip = &Ship_info[Carried_ss_icon.ship_class];
 			if(Ss_icons[Carried_ss_icon.ship_class].model_index == -1) {
-
-				if (sip->pof_file_tech[0] != '\0') {
-					// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
-					// the techroom model, which is decidedly wrong for the mission itself.
-					Ss_icons[Carried_ss_icon.ship_class].model_index = model_load(sip->pof_file_tech, 0, nullptr);
-				} else {
-					Ss_icons[Carried_ss_icon.ship_class].model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-				}
-
+				Ss_icons[Carried_ss_icon.ship_class].model_index = model_load(sip, true);
 				mprintf(("SL WARNING: Had to attempt to page in model for %s paged in manually! Result: %d\n", sip->name, Ss_icons[Carried_ss_icon.ship_class].model_index));
 			}
 			gr_set_color_fast(&Icon_colors[ICON_FRAME_SELECTED]);
@@ -1696,15 +1688,7 @@ void draw_ship_icon_with_number(int screen_offset, int ship_class)
 	{
 		ship_info *sip = &Ship_info[ship_class];
 		if(ss_icon->model_index == -1) {
-
-			if (sip->pof_file_tech[0] != '\0') {
-				// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
-				// the techroom model, which is decidedly wrong for the mission itself.
-				ss_icon->model_index = model_load(sip->pof_file_tech, 0, nullptr);
-			} else {
-				ss_icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-			}
-
+			ss_icon->model_index = model_load(sip, true);
 			mprintf(("SL WARNING: Had to attempt to page in model for %s paged in manually! Result: %d\n", sip->name, ss_icon->model_index));
 		}
 		gr_set_color_fast(color_to_draw);
@@ -1760,13 +1744,7 @@ void start_ship_animation(int ship_class, int  /*play_sound*/)
 		}
 
 		// Load the necessary model file
-		if (sip->pof_file_tech[0] != '\0') {
-			// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
-			// the techroom model, which is decidedly wrong for the mission itself.
-			ShipSelectModelNum = model_load(sip->pof_file_tech, 0, nullptr);
-		} else {
-			ShipSelectModelNum = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-		}
+		ShipSelectModelNum = model_load(sip, true);
 		
 		// page in ship textures properly (takes care of nondimming pixels)
 		model_page_in_textures(ShipSelectModelNum, ship_class);
@@ -2403,15 +2381,7 @@ void ss_blit_ship_icon(int x,int y,int ship_class,int bmap_num)
 		{
 			ship_info *sip = &Ship_info[ship_class];
 			if(icon->model_index == -1) {
-
-				if (sip->pof_file_tech[0] != '\0') {
-					// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
-					// the techroom model, which is decidedly wrong for the mission itself.
-					icon->model_index = model_load(sip->pof_file_tech, 0, nullptr);
-				} else {
-					icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-				}
-
+				icon->model_index = model_load(sip, true);
 				mprintf(("SL WARNING: Had to attempt to page in model for %s paged in manually! Result: %d\n", sip->name, icon->model_index));
 			}
 			if(icon->model_index != -1)
@@ -2959,14 +2929,7 @@ void ss_load_icons(int ship_class)
 	}
 	else
 	{
-		if (sip->pof_file_tech[0] != '\0') {
-			// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to
-			// the techroom model, which is decidedly wrong for the mission itself.
-			icon->model_index = model_load(sip->pof_file_tech, 0, nullptr);
-		} else {
-			icon->model_index = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-		}
-
+		icon->model_index = model_load(sip, true);
 		model_page_in_textures(icon->model_index, ship_class);
 	}
 }

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1045,13 +1045,7 @@ void wl_render_overhead_view(float frametime)
 		{
 			if (wl_ship->model_num < 0)
 			{
-				if (sip->pof_file_tech[0] != '\0') {
-					//This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to the techroom model, which is decidedly wrong for the mission itself.
-					wl_ship->model_num = model_load(sip->pof_file_tech, 0, nullptr);
-				}
-				else {
-					wl_ship->model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
-				}
+				wl_ship->model_num = model_load(sip, true);
 				model_page_in_textures(wl_ship->model_num, ship_class);
 			}
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -952,6 +952,9 @@ void model_free(polymodel* pm);
 void model_free_all();
 void model_instance_free_all();
 
+// Alias to model_looad, checks if a pof tech model exists and loads it if specified, otherwise loads the default pof. --wookieejedi
+int model_load(ship_info* sip, bool prefer_tech_model);
+
 // Loads a model from disk and returns the model number it loaded into.
 int model_load(const char *filename, int n_subsystems, model_subsystem *subsystems, int ferror = 1, int duplicate = 0);
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -952,7 +952,7 @@ void model_free(polymodel* pm);
 void model_free_all();
 void model_instance_free_all();
 
-// Alias to model_looad, checks if a pof tech model exists and loads it if specified, otherwise loads the default pof. --wookieejedi
+// Alias to model_load, checks if a pof tech model exists and loads it if specified, otherwise loads the default pof. --wookieejedi
 int model_load(ship_info* sip, bool prefer_tech_model);
 
 // Loads a model from disk and returns the model number it loaded into.

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3186,6 +3186,18 @@ void model_load_texture(polymodel *pm, int i, char *file)
 	gr_maybe_create_shader(SDR_TYPE_MODEL, shader_flags | SDR_FLAG_MODEL_LIGHT | SDR_FLAG_MODEL_FOG);
 }
 
+//returns the number of the pof tech model if specified, otherwise number of pof model
+int model_load(ship_info* sip, bool prefer_tech_model)
+{
+	if (prefer_tech_model && sip->pof_file_tech[0] != '\0') {
+		// This cannot load into sip->subsystems, as this will overwrite the subsystems model_num to the
+		// techroom model, which is decidedly wrong for the mission itself.
+		return model_load(sip->pof_file_tech, 0, nullptr);
+	} else {
+		return model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0]);
+	}
+}
+
 //returns the number of this model
 int model_load(const  char* filename, int n_subsystems, model_subsystem* subsystems, int ferror, int duplicate)
 {


### PR DESCRIPTION
Currently `$POF file Techroom:` is only used in the weapons loadout screen (despite having techroom in the name). This PR expands the use of the `$POF file Techroom:` to shiploadout select and the actual techroom.

If it is desired, I can put it behind a game settings flag, but IMO it would make the most sense for modders to have this just work as the actual name implies.

Tested and works as expected. 