### PR TITLE
fix makeShipArrive and makeWingArrive for reinforcements

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1774,13 +1774,18 @@ void hud_squadmsg_call_reinforcement(int reinforcement_num, int  /*player_num*/)
 
 	// safety net mainly for multiplayer servers in case some odd data desync occurs between 
 	// server and clients
-	if ( MULTIPLAYER_MASTER && (rp->num_uses == rp->uses) ) {
+	if ( MULTIPLAYER_MASTER && (rp->num_uses >= rp->uses) ) {
 		return;
 	}
 
 	// check to see if the reinforcement called was a wing.
 	for (i = 0; i < Num_wings; i++ ) {
 		if ( !stricmp(rp->name, Wings[i].name) ) {
+			// if the wing is currently present, skip this request so we don't waste a "use"
+			if (Wings[i].current_count > 0) {
+				return;
+			}
+
 			// found a wingname.  Call the parse function to create all the ships in this wing
 			// we must set the arrival cue of the wing to true, otherwise, this won't work!!
             Wings[i].flags.remove(Ship::Wing_Flags::Reinforcement);
@@ -1848,7 +1853,7 @@ void hud_squadmsg_reinforcement_select()
 			SCP_string rp_name = rp->name;
 
 			// don't put reinforcements onto the list that have already been used up.
-			if ( rp->num_uses == rp->uses ){
+			if ( rp->num_uses >= rp->uses ){
 				continue;
 			}
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -7194,7 +7194,19 @@ int mission_did_ship_arrive(p_object *objp, bool force_arrival)
 		if ( should_arrive ) {
 			mission_parse_mark_reinforcement_available(objp->name);
 		}
-		return -1;
+
+		// if we're forcing the arrival, then "use" the reinforcement; otherwise don't process anything else
+		if (force_arrival) {
+			for (int i = 0; i < Num_reinforcements; i++) {
+				auto rp = &Reinforcements[i];
+				if (!stricmp(rp->name, objp->name)) {
+					rp->num_uses++;
+					break;
+				}
+			}
+		} else {
+			return -1;
+		}
 	}
 
 	if ( should_arrive ) { 		// has the arrival criteria been met?
@@ -7447,8 +7459,19 @@ bool mission_maybe_make_wing_arrive(int wingnum, bool force_arrival)
 		if (force_arrival || eval_sexp(wingp->arrival_cue))
 			mission_parse_mark_reinforcement_available(wingp->name);
 
-		// reinforcement wings skip the rest of the function
-		return false;
+		// if we're forcing the arrival, then "use" the reinforcement; otherwise don't process anything else
+		if (force_arrival && wingp->current_count == 0) {
+			for (int i = 0; i < Num_reinforcements; i++) {
+				auto rp = &Reinforcements[i];
+				if (!stricmp(rp->name, wingp->name)) {
+					rp->num_uses++;
+					break;
+				}
+			}
+		} else {
+			// reinforcement wings skip the rest of the function
+			return false;
+		}
 	}
 		
 	// don't do evaluations for departing wings


### PR DESCRIPTION
The script functions should make the ships/wings arrive even if they are reinforcement, so this PR fixes that.  Also, this PR adds some additional verification of the `num_uses` of reinforcements, especially when the player calls for a wing that is already present but has more uses remaining.