### PR TITLE
1 Line fix for player view render check

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3439,7 +3439,7 @@ void game_render_frame( camid cid )
 
 	//Draw the viewer 'cause we didn't before.
 	//This is currently seperate to facilitate deferred rendering on different view/proj matrices and with different settings
-	if (Viewer_obj && Viewer_obj->type == OBJ_SHIP && Viewer_obj->instance > 0) {
+	if (Viewer_obj && Viewer_obj->type == OBJ_SHIP && Viewer_obj->instance >= 0) {
 		gr_end_proj_matrix();
 		gr_end_view_matrix();
 


### PR DESCRIPTION
Fix for recent updates to cockpit rendering check, which was false if the player was the only ship in a mission. `instance >0` was used but it is supposed to be `instance >= 0` (The object index is valid if larger or equal to 0, while the signature is only valid equal or larger to 1.) Tested and fix works as expected.