### PR TITLE
Enable client turrets to track targets

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2243,6 +2243,12 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 	// Rotate the turret even if time hasn't elapsed, since it needs to turn to face its target.
 	int use_angles = aifft_rotate_turret(objp, shipp, ss, lep, &predicted_enemy_pos, &gvec);
 
+	// Multiplayer clients are now able to try to track their targets and also reset to their idle positions.
+	// But everything after this point is turret firing, so we need to bail here.
+	if (MULTIPLAYER_CLIENT) {
+		return;
+	}
+
 	if ((tp->flags[Model::Subsystem_Flags::Fire_on_target]) && (ss->points_to_target >= 0.0f))
 	{
 		// value probably needs tweaking... could perhaps be made into table option?

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4403,9 +4403,22 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 	if (turret->flags[Model::Subsystem_Flags::Turret_base_restricted_fov])
 		limited_base_rotation = true;
 
+	// figure out how much time we need to account for.  This only varies in mulitplayer
+	// in singleplayer or multiplayer servers info_from_server_stamp will always be Timestamp::never()
+	float calc_time;
+
+	if ((Game_mode & GM_MULTIPLAYER) && !ss->info_from_server_stamp.isNever()){
+		calc_time = static_cast<float>(ss->info_from_server_stamp.value()) / MILLISECONDS_PER_SECOND;
+
+		// this timestamp will only be used once, so discard it.
+		ss->info_from_server_stamp = TIMESTAMP::never();
+	} else {
+		calc_time = flFrametime;
+	}
+
 	//------------
 	// Gradually turn the turret towards the desired angles
-	float step_size = turret->turret_turning_rate * flFrametime;
+	float step_size = turret->turret_turning_rate * calc_time;
 	float base_delta, gun_delta;
 
 	if (reset)

--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -50,6 +50,7 @@
 #include "network/multi_fstracker.h"
 #include "network/multi_sw.h"
 #include "network/multi_portfwd.h"
+#include "network/multi_turret_manager.h"
 #include "pilotfile/pilotfile.h"
 #include "debugconsole/console.h"
 #include "network/psnet2.h"
@@ -930,6 +931,10 @@ void process_packet_normal(ubyte* data, header *header_info)
 			process_sexp_packet(data, header_info);
 			break; 
 
+		case TURRET_TRACK:
+			process_turret_tracking_packet(data, header_info);
+			break;
+
 		default:
 			mprintf(("Received packet with unknown type %d\n", data[0] ));
 			header_info->bytes_processed = 10000;
@@ -1280,7 +1285,10 @@ void multi_do_frame()
 
 			// sending new objects from here is dependent on having objects only created after
 			// the game is done moving the objects.  I think that I can enforce this.				
-			multi_oo_process();			
+			multi_oo_process();
+
+			// send updates for turret tracking.
+			Multi_Turret_Manager.send_queued_packets();			
 
 			// evaluate whether the time limit has been reached or max kills has been reached
 			// Commented out by Sandeep 4/12/98, was causing problems with testing.

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -71,7 +71,7 @@ class player;
 // version 55 - 8/28/2021 - Adding multi-compatible animations
 // version 56 - 8/28/2021 - Fix animations for 22_0 release
 // version 57 - 6/5/2022 - Upgrade interpolation, fix multiplayer sexp handling, and enable player orders to exceed 16
-// Version 58 - ?/?/2022 - Enable turret movement on clients
+// Version 58 - 11/14/2022 - Enable turret movement on clients, and fix in-game joining
 // STANDALONE_ONLY
 
 #define MULTI_FS_SERVER_VERSION							58

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -71,10 +71,10 @@ class player;
 // version 55 - 8/28/2021 - Adding multi-compatible animations
 // version 56 - 8/28/2021 - Fix animations for 22_0 release
 // version 57 - 6/5/2022 - Upgrade interpolation, fix multiplayer sexp handling, and enable player orders to exceed 16
-// version 58 - ??/??/?? - Submodel translation and a fixed multi_pack_unpack_subsystem_list
+// Version 58 - ?/?/2022 - Enable turret movement on clients
 // STANDALONE_ONLY
 
-#define MULTI_FS_SERVER_VERSION							57
+#define MULTI_FS_SERVER_VERSION							58
 
 #define MULTI_FS_SERVER_COMPATIBLE_VERSION			MULTI_FS_SERVER_VERSION
 
@@ -217,6 +217,7 @@ class player;
 #define FLAK_FIRED					0xAA		// flak gun fired
 #define SELF_DESTRUCT				0xAB		// self destruct
 #define ANIMATION_TRIGGERED			0xAC		// Lafiel - Anytime an animation starts
+#define TURRET_TRACK				0xAD		// Cyborg - When a turret's target has changed.
 
 #define JOIN							0xB1		// a join request to a server
 #define ACCEPT							0xB2		// acceptance of a join packet

--- a/code/network/multi_turret_manager.cpp
+++ b/code/network/multi_turret_manager.cpp
@@ -1,0 +1,72 @@
+#include "network/multi_turret_manager.h"
+
+multiplayer_turret_manager Multi_Turret_Manager;
+
+bool multiplayer_turret_manager::get_latest_packet(ushort net_signature, int subsys_index, turret_packet* packet) 
+{
+    TIMESTAMP current_time = _timestamp(Multi_Timing_Info.get_current_time() + Multi_Timing_Info.get_mission_start_time());
+
+    auto it = _packets_in.find(turret_packet_address(net_signature, subsys_index));
+
+    // return if we have no packets for this turret and subsystem.
+    if (it == _packets_in.end() || it->second.empty()){
+        return false;
+    }
+
+    TIMESTAMP winning_time = TIMESTAMP::immediate();
+    int winning_index = -1;
+    
+    SCP_vector<turret_packet> retained;
+    
+    for (uint index = 0; index < it->second.size(); index++) {
+
+        // check that this packet has already elapsed.
+        if (timestamp_compare(current_time, it->second[index].time) > 0) {
+
+            // only the most recent packet for which time has elapsed matters.
+            if (timestamp_compare(it->second[index].time, winning_time) > 0){
+                winning_time = it->second[index].time;
+                winning_index = static_cast<int>(index);
+            }
+
+        } // retain packets that have not yet elapsed
+        else {
+            retained.push_back(it->second[index]);
+        }
+    }
+
+    // Sanity check. We were supposed to deal with an empty incoming vector above.
+    if (winning_index < 0 && retained.empty()) {
+        mprintf(("There seems to be a non-fatal mistake in multiplayer code.  Please report to Cyborg or check that multiplayer_turret_manager::find() has correct logic.\n"));
+        return false;
+
+    } else if (winning_index > -1) {
+        // we found an appropriate packet.
+        *packet = it->second[winning_index];
+
+        // restore only the elements that we need to keep around.
+        it->second = std::move(retained);
+        return true;
+
+    // here none of the received packets are yet available.
+    } else {
+        return false;
+    }
+}
+
+// clear things manually so that we don't rely on netsted containers emptying correctly automatically.
+void multiplayer_turret_manager::reset()
+{
+    for (auto& vec : _packets_in){
+        vec.second.clear();
+    }
+
+    _packets_in.clear();
+
+    for (auto& vec : _packets_out){
+        vec.second.clear();
+    }
+
+    _packets_out.clear();
+}
+

--- a/code/network/multi_turret_manager.h
+++ b/code/network/multi_turret_manager.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+#include "globalincs/systemvars.h"
+#include "network/multi_time_manager.h"
+#include "network/multiutil.h"
+#include "ship/ship.h"
+
+typedef std::pair<ushort,int> turret_packet_address;
+
+struct turret_packet {
+    TIMESTAMP time;
+    int target_objnum;
+    std::pair<bool, float> angle1;
+    std::pair<bool, float> angle2;
+
+    turret_packet() = default;
+    
+    turret_packet(int time_in, ushort target_netsig, std::pair<bool, float> ang1_in, std::pair<bool, float> ang2_in) 
+    {
+        time = _timestamp(time_in + Multi_Timing_Info.get_mission_start_time());
+
+        object* temp = (multi_get_network_object(target_netsig));
+        target_objnum = (temp != nullptr) ? OBJ_INDEX(temp) : -1;
+
+        angle1.first = ang1_in.first;
+
+        if (ang1_in.first){
+            angle1.second = ang1_in.second;
+        } else {
+            angle1.second = 0.0f;
+        }
+
+        angle2.first = ang2_in.first;
+
+        if (ang2_in.first){
+            angle2.second = ang2_in.second;
+        } else {
+            angle2.second = 0.0f;
+        }
+    }
+};
+
+// basic hash function to allow us to use turret_packet_address as a key for unordered map
+struct turret_packet_address_hash // <table_entry_option_address>
+{
+    std::size_t operator()(const turret_packet_address& k) const noexcept
+    {
+        // Compute individual hash values and combine them using XOR and bit shifting:
+        return ( (std::hash<int>{}(static_cast<int>(k.first)))
+            ^ (std::hash<int>{}(k.second) << 1));
+    }
+};
+
+class multiplayer_turret_manager {
+    SCP_unordered_map<turret_packet_address, SCP_vector<turret_packet>, turret_packet_address_hash> _packets_in;
+    SCP_unordered_map<ushort, SCP_vector<int>> _packets_out;
+
+public:
+    void add_incoming_packet(int time_in, int parent_ship, short subsys_index, ushort target_netsig, std::pair<bool, float> ang1_in, std::pair<bool, float> ang2_in) 
+    {
+        // if the data is nonsense, return
+        if (parent_ship < 0 || parent_ship > MAX_OBJECTS || Objects[parent_ship].net_signature == 0){
+            return;
+        }
+
+        _packets_in[turret_packet_address(Objects[parent_ship].net_signature, static_cast<int>(subsys_index))].emplace_back(time_in, target_netsig, ang1_in, ang2_in);
+    }
+
+    bool get_latest_packet(ushort net_signature, int subsys_index, turret_packet* packet);
+
+    void reset();
+
+    void add_packet_to_queue(ushort net_signature, int subsys_index) {
+
+        // if the subsysem actually can't be sent, don't queue it.
+        if (net_signature == 0  || subsys_index > INT16_MAX) {
+            nprintf(("network", "Trying to queue a turret tracking packet with unsendable info: net_signature %d and subsys_index %d.", net_signature, subsys_index));
+            return;
+        }
+        
+        // if this one was already added, there's no need to add it again.  
+        if (std::find(_packets_out[net_signature].begin(), _packets_out[net_signature].end(), subsys_index) != _packets_out[net_signature].end()){
+            return;
+        }
+
+        _packets_out[net_signature].push_back(subsys_index);
+    }
+
+    void send_queued_packets(){
+        for (auto& queued : _packets_out) {
+            if (!queued.second.empty()){
+                extern SCP_vector<int> send_turret_tracking_packet(ushort parent_sig, SCP_vector<int>& subsys_indexes);
+                queued.second = send_turret_tracking_packet(queued.first, queued.second);
+            }
+        }
+    };
+};
+
+extern multiplayer_turret_manager Multi_Turret_Manager;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -77,6 +77,7 @@
 #include "network/multi_mdns.h"
 #include "mission/missiongoals.h"
 #include "network/multi_interpolate.h"
+#include "network/multi_turret_manager.h"
 
 // #define _MULTI_SUPER_WACKY_COMPRESSION
 
@@ -9113,4 +9114,142 @@ void process_sexp_packet(ubyte *data, header *hinfo)
 	PACKET_SET_SIZE();
 
 	sexp_packet_received(received_packet, num_ubytes);
+}
+
+
+// sends as many turrets as possible, and returns those it can not yet send because of packet size.
+SCP_vector<int> send_turret_tracking_packet(ushort parent_sig, SCP_vector<int>& subsys_indexes) 
+{
+
+	Assertion(MULTIPLAYER_MASTER, "A non-server is trying to send a turret tracking packet. This is a coder mistake, please report!");
+
+	// Max size, minus some bytes for easy handling and safety.
+	constexpr int MAX_TURRET_PACKET_SIZE = MAX_PACKET_SIZE - 20;
+	SCP_vector<int> overflow_list;
+
+	Assertion (parent_sig != 0, "The turret tracking packet manager is trying to send a packet with a net signature of 0. This is nonsense and a coder mistake, please report!");
+
+	// somehow trying to send for an an invalid or non-network object
+	if (parent_sig == 0) {
+		// returning an empty list will signal the manager to clear its entries
+		return overflow_list;
+	}
+
+	auto temp = multi_get_network_object(parent_sig);
+
+	// this means that the ship may have been destroyed before being able to send the packet.  Ignore.
+	if (temp == nullptr){
+		// returning an empty list will signal the manager to clear its entries
+		return overflow_list;
+	}
+
+	ship* shipp = &Ships[temp->instance];
+
+	// Required for all send functions
+	ubyte data[MAX_PACKET_SIZE];
+	int packet_size = 0;
+
+	BUILD_HEADER(TURRET_TRACK);
+
+	ubyte last_index = 0;
+
+	// this is not usually done, but if the number of subsystems actually ends up being different than the expected,
+	// this ubyte in the packet will get overwritten at the end of this function.
+	ADD_DATA(last_index);
+
+	// send the time that this happened.
+	int time_out = Multi_Timing_Info.get_current_time();
+	ADD_INT(time_out);
+	ADD_USHORT(parent_sig);
+
+	ubyte count = 0;
+
+	// no, I don't expect to send UINT turrets, but I don't want to be stuck
+	// in an infinite loop with a smaller word size.
+	for (uint i = 0; i < subsys_indexes.size(); i++){
+
+		// pre count is now being switched to a limiter to ensure that we do not exceed MAX_TURRET_PACKET_SIZE
+		if (packet_size < MAX_TURRET_PACKET_SIZE) {
+			auto ssp = ship_get_indexed_subsys( shipp, subsys_indexes[i]);
+
+			// make sure the subsytem is valid.  If not, just continue.
+			if (ssp != nullptr){
+				// Add the data for the valid entry
+				ADD_SHORT( static_cast<short>(subsys_indexes[i]));
+
+				ushort target_netsig = (ssp->turret_enemy_objnum > -1) ? Objects[ssp->turret_enemy_objnum].net_signature : 0;
+				ADD_USHORT(target_netsig);
+
+				packet_size += multi_pack_turret_angles(data + packet_size, ssp);
+				++count;
+			} else {
+				// if we don't have a valid subsystem.
+				++last_index;
+			}
+
+		} else {
+			overflow_list.push_back(subsys_indexes[i]);
+		}
+	}
+
+	// nothing to send means that we should not send the packet, and just send back the overflow list.
+	if (count < 1) {
+		return overflow_list;
+	}
+
+	// and now, actually place the number of turrets we are updating
+	// this is a little hacky, but it's best to work through the serialization macros to rewrite the data.
+	int packet_size_record = packet_size;
+	packet_size = HEADER_LENGTH;
+	ADD_DATA(count);
+	packet_size = packet_size_record;
+
+	// The packet is now finished, so send.
+	multi_io_send_to_all(data, packet_size);
+
+	return overflow_list;
+}
+
+void process_turret_tracking_packet(ubyte *data, header *hinfo) 
+{
+	Assertion(MULTIPLAYER_CLIENT, "A non-client is receiving a turret tracking packet. This is a coder mistake, please report!");
+
+	int offset = HEADER_LENGTH;
+
+	int time_in;
+	ushort parent_netsig;
+	ubyte last_index;
+
+	GET_DATA(last_index);
+	GET_INT(time_in);
+	GET_USHORT(parent_netsig);
+
+	auto parent = multi_get_network_object(parent_netsig);
+
+	std::pair<bool, float> angle1;
+	std::pair<bool, float> angle2;
+
+	angle1.first = false;
+	angle1.second = 0.0f;
+	angle2.first = false;
+	angle2.second = 0.0f; 
+
+	for (ubyte index = 0; index < last_index; index++){
+		short subsystem_index;
+		ushort target_netsig;
+		GET_SHORT(subsystem_index);
+		GET_USHORT(target_netsig);
+
+		offset += multi_unpack_turret_angles(data + offset, angle1, angle2);
+
+		// even if the ship does not exist 
+		if (parent != nullptr){
+			Multi_Turret_Manager.add_incoming_packet(time_in, OBJ_INDEX(parent), subsystem_index, target_netsig, angle1, angle2);
+		}
+
+		angle1.first = false;
+		angle2.first = false;
+	}
+
+	PACKET_SET_SIZE();
 }

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -558,4 +558,8 @@ void process_self_destruct_packet(ubyte *data, header *hinfo);
 void send_sexp_packet(ubyte *sexp_packet, int num_ubytes);
 void process_sexp_packet(ubyte *data, header *hinfo);
 
+// Turret is tracking new object.
+void send_turret_tracking_packet(int ship_objnum, int subsys_index);
+void process_turret_tracking_packet(ubyte *data, header *hinfo);
+
 #endif

--- a/code/network/multiutil.h
+++ b/code/network/multiutil.h
@@ -27,6 +27,7 @@ class ship;
 struct server_item;
 class ship_info;
 class p_object;
+class ship_subsys;
 
 // two types of signatures that we can request,  permanent signatures are all below 5000.  non-permanent are above 5000
 #define MULTI_SIG_SHIP					1
@@ -202,6 +203,12 @@ int multi_pack_unpack_rotvel(int write, ubyte *data, physics_info *pi);
 
 // Cyborg17 - Packs/unpacks desired velocity and rotational velocity.
 int multi_pack_unpack_desired_vel_and_desired_rotvel(int write, bool full_physics, ubyte* data, physics_info* pi, vec3d* local_desired_vel);
+
+// pack cur_angle data from turrets
+int multi_pack_turret_angles(ubyte* data, ship_subsys* ssp);
+
+// unpack cur_angle data from turrets
+int multi_unpack_turret_angles(ubyte* data, std::pair<bool, float>& angle1, std::pair<bool, float>& angle2);
 
 // Cyborg17 - Compresses the list of subsystems, so that we don't have to mark each one with a ubyte
 int multi_pack_unpack_subsystem_list(bool write, ubyte* data, SCP_vector<ubyte>* flags, SCP_vector<float>* subsys_data);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -338,7 +338,7 @@ public:
 	model_subsystem *system_info;					// pointer to static data for this subsystem -- see model.h for definition
 
 	int			parent_objnum;						// objnum of the parent ship
-	int			parent_subsys_index;				// index of this subsystem in the parent ship's linked list
+	int			parent_subsys_index;				// index of this subsystem in the parent ship's linked list -- Do not access manually, use parent_subsys_index() as this may not yet be cached.
 
 	char		sub_name[NAME_LENGTH];					//WMC - Name that overrides name of original
 	float		current_hits;							// current number of hits this subsystem has left.
@@ -426,6 +426,9 @@ public:
 	//Per-turret ownage settings - SUSHI
 	int turret_max_bomb_ownage; 
 	int turret_max_target_ownage;
+
+	// multiplayer
+	TIMESTAMP info_from_server_stamp;
 
 	ship_subsys()
 		: next(NULL), prev(NULL)

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -941,6 +941,8 @@ add_file_folder("Network"
 	network/multi_sw.h
 	network/multi_team.cpp
 	network/multi_team.h
+	network/multi_turret_manager.cpp
+	network/multi_turret_manager.h
 	network/multi_time_manager.cpp
 	network/multi_time_manager.h
 	network/multi_update.cpp

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -132,6 +132,7 @@
 #include "network/multi_pxo.h"
 #include "network/multi_rate.h"
 #include "network/multi_respawn.h"
+#include "network/multi_turret_manager.h"
 #include "network/multi_voice.h"
 #include "network/multimsgs.h"
 #include "network/multiteamselect.h"
@@ -912,6 +913,7 @@ void game_level_close()
 		stars_level_close();
 
 		multi_close_oo_and_ship_tracker();
+		Multi_Turret_Manager.reset(); // Cyborg, this can safely be done after everything else.  At some point, I'll probably consolidate these.
 
 		Pilot.save_savefile();
 


### PR DESCRIPTION
This allows clients to user server data to move turrets according to the timing and target data on the server.  Uses a small packet to do so.