### PR TITLE
Update scpui documentation

### DIFF
--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1155,7 +1155,7 @@ ADE_FUNC(initSelect,
 	nullptr,
 	"Initializes selection data including wing slots, ship and weapon pool, and loadout information. "
 	"Must be called before every mission regardless if ship or weapon select is actually used! "
-	"Should also be called on initialization of revelant briefing UIs such as briefing and red alert "
+	"Should also be called on initialization of relevant briefing UIs such as briefing and red alert "
 	"to ensure that the ships and weapons are properly set for the current mission.",
 	nullptr,
 	nullptr)


### PR DESCRIPTION
This fixes #4800 by clearing up the intended and _required_ use of `ui.ShipWepSelect.initSelect`. Rest of the "fix" is done in the scripts by calling this function upon initialization of relevant UIs.