### PR TITLE
cockpitinactive gauges should render in chase view

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1178,7 +1178,7 @@ bool HudGauge::canRender()
 	}
 	
 	if (render_for_cockpit_toggle > 0) {
-		if (((Viewer_mode & (VM_CHASE)) != 0) && (render_for_cockpit_toggle == 2)) {
+		if ((Viewer_mode & VM_CHASE) && (render_for_cockpit_toggle == 2)) {
 			return true;
 		} else if (cockpitActive && (render_for_cockpit_toggle == 2)) {
 			return false;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1178,7 +1178,9 @@ bool HudGauge::canRender()
 	}
 	
 	if (render_for_cockpit_toggle > 0) {
-		if (cockpitActive && (render_for_cockpit_toggle == 2)) {
+		if (((Viewer_mode & (VM_CHASE)) != 0) && (render_for_cockpit_toggle == 2)) {
+			return true;
+		} else if (cockpitActive && (render_for_cockpit_toggle == 2)) {
 			return false;
 		} else if (!cockpitActive && (render_for_cockpit_toggle == 1)) {
 			return false;


### PR DESCRIPTION
Gauges that are set to render if the cockpit is inactive should also render in chase view, even if the current ship has a cockpit and cockpits are enabled.