### PR TITLE
Allow High Resolution Mode for SCPUI-only installations

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1553,7 +1553,8 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 	if (gr_get_resolution_class(width, height) != GR_640) {
 		// check for hi-res interface files so that we can verify our width/height is correct
 		// if we don't have it then fall back to 640x480 mode instead
-		if ( !cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY)) {
+		// Lafiel: BUT! Only do this if the "low res graphic" ACTUALLY exists. Using SCPUI, not having this file is not a sufficient indicator for being on forced low-res.
+		if ( !cf_exists_full("2_ChoosePilot-m.pcx", CF_TYPE_ANY) && cf_exists_full("ChoosePilot-m.pcx", CF_TYPE_ANY)) {
 			if ( (width == 1024) && (height == 768) ) {
 				width = 640;
 				height = 480;


### PR DESCRIPTION
This took _way_ too long to find.

With SCPUI on the horizon, we'll soon see TC's that don't need to ship with all retail graphics or replacements for these. While that already works in large parts, the game currently assumes we cannot support high resolutions when it cannot find some arbitrary high res retail file. This amends this check, so that it still triggers when retail is available, but only without the sparky_hi_fs2.vp package, so that we fall back to low res mode.
But in case that the low res file is also not available, assume that we are using SCPUI and do not want to do any falling back.