### PR TITLE
Allow adding custom head anis to the list in FRED

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -45,6 +45,7 @@ int FS2NetD_port;
 int Default_multi_object_update_level;
 float Briefing_window_FOV;
 bool Disable_hc_message_ani;
+SCP_vector<SCP_string> Custom_head_anis;
 bool Red_alert_applies_to_delayed_ships;
 bool Beams_use_damage_factors;
 float Generic_pain_flash_factor;
@@ -740,6 +741,20 @@ void parse_mod_table(const char *filename)
 			else {
 				mprintf(("Game Settings Table: FRED - Using Hard Coded Message Ani Files\n"));
 
+			}
+		}
+
+		if (optional_string("$Add Message Head Ani Files:")) {
+			SCP_string head_name;
+			while (optional_string("+Head:")) {
+				stuff_string(head_name, F_NAME);
+
+				// remove extension?
+				if (drop_extension(head_name)) {
+					mprintf(("Game Settings Table: Removed extension on head ani file name %s\n", head_name.c_str()));
+				}
+
+				Custom_head_anis.push_back(head_name);
 			}
 		}
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -36,6 +36,7 @@ extern int FS2NetD_port;
 extern int Default_multi_object_update_level;
 extern float Briefing_window_FOV;
 extern bool Disable_hc_message_ani;
+extern SCP_vector<SCP_string> Custom_head_anis;
 extern bool Red_alert_applies_to_delayed_ships;
 extern bool Beams_use_damage_factors;
 extern float Generic_pain_flash_factor;

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -172,7 +172,7 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // event_editor message handlers
 
-void maybe_add_head(CComboBox *box, char* name)
+void maybe_add_head(CComboBox *box, const char* name)
 {
 	if (box->FindStringExact(-1, name) == CB_ERR) {
 		box->AddString(name);
@@ -274,6 +274,10 @@ BOOL event_editor::OnInitDialog()
 		maybe_add_head(box, "Head-CM5");
 		maybe_add_head(box, "Head-BSH");
 		
+	}
+
+	for (auto &thisHead : Custom_head_anis) {
+		maybe_add_head(box, thisHead.c_str());
 	}
 
 /*


### PR DESCRIPTION
Implements the ability to define a custom list of Head Anis in game_settings.tbl and uses that to populate the list in the FRED Events Editor. Fixes #3875