### PR TITLE
libRocket Texture Passthrough

### DIFF
--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -24,6 +24,8 @@
 #include "graphics/material.h"
 #include "tracing/categories.h"
 #include "tracing/tracing.h"
+#define BMPMAN_INTERNAL
+#include "bmpman/bm_internal.h"
 
 using namespace Rocket::Core;
 
@@ -161,6 +163,22 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 			delete[] rawdata;
 
 			return success;
+		}
+		else if (submode.Find("bmpman,") == 0) {
+			int handle = std::atoi(submode.Substring(7).CString());
+
+			auto* entry = bm_get_entry(handle);
+			if (entry->handle != handle)
+				return false;
+
+			entry->load_count++;
+
+			bm_get_info(handle, &texture_dimensions.x, &texture_dimensions.y);
+
+			std::unique_ptr<Texture> tex(new Texture());
+			tex->bm_handle = handle;
+			texture_handle = get_texture_handle(tex.release());
+			return true;
 		}
 		else {
 			return false;

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1519,8 +1519,8 @@ ADE_FUNC(createTexture, l_Graphics, "[number Width=512, number Height=512, enume
 	if(idx < 0)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	//Since creating a render target does not increase load count, we need to still do so even though we just created the texture
-	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx)));
+	//Since creating a render target does not increase load count, when creating the scripting texture object we need to pass true to the constructor so that the constructor will increase the load count for us.
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx, true)));
 }
 
 ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, boolean NoDropFrames]",
@@ -1549,7 +1549,7 @@ ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, bo
 	if(idx < 0)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 	
-	//Loading increases load count, so don't on texture init
+	//Loading increases load count, so we must pass false to the texture scripting object, so that the constructor doesn't increase the load count by itself again.
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx, false)));
 }
 

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1519,6 +1519,7 @@ ADE_FUNC(createTexture, l_Graphics, "[number Width=512, number Height=512, enume
 	if(idx < 0)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
+	//Since creating a render target does not increase load count, we need to still do so even though we just created the texture
 	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx)));
 }
 
@@ -1547,8 +1548,9 @@ ADE_FUNC(loadTexture, l_Graphics, "string Filename, [boolean LoadIfAnimation, bo
 
 	if(idx < 0)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
-
-	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx)));
+	
+	//Loading increases load count, so don't on texture init
+	return ade_set_args(L, "o", l_Texture.Set(texture_h(idx, false)));
 }
 
 ADE_FUNC(drawImage,

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -47,6 +47,7 @@
 #include "scripting/api/objs/color.h"
 #include "scripting/api/objs/enums.h"
 #include "scripting/api/objs/player.h"
+#include "scripting/api/objs/texture.h"
 #include "scripting/lua/LuaTable.h"
 #include "stats/medals.h"
 #include "stats/stats.h"
@@ -238,6 +239,19 @@ ADE_FUNC(playCutscene, l_UserInterface, "string Filename, boolean RestartMusic, 
 
 	common_play_cutscene(filename, restart_music, score_index);
 	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(linkTexture, l_UserInterface, "texture texture", "Links a texture directly to librocket.", "string", "The url string for librocket, or an empty string if invalid.")
+{
+	texture_h* tex;
+
+	if (!ade_get_args(L, "o", l_Texture.GetPtr(&tex)))
+		return ade_set_error(L, "s", "");
+
+	if(!tex->isValid())
+		return ade_set_error(L, "s", "");
+	
+	return ade_set_args(L, "s", "data:image/bmpman," + std::to_string(tex->handle));
 }
 
 //**********SUBLIBRARY: UserInterface/PilotSelect

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -248,7 +248,7 @@ ADE_FUNC(linkTexture, l_UserInterface, "texture texture", "Links a texture direc
 	if (!ade_get_args(L, "o", l_Texture.GetPtr(&tex)))
 		return ade_set_error(L, "s", "");
 
-	if(!tex->isValid())
+	if(tex == nullptr || !tex->isValid())
 		return ade_set_error(L, "s", "");
 	
 	return ade_set_args(L, "s", "data:image/bmpman," + std::to_string(tex->handle));

--- a/code/scripting/api/objs/texture.h
+++ b/code/scripting/api/objs/texture.h
@@ -11,7 +11,7 @@ struct texture_h {
 	int handle = -1;
 
 	texture_h();
-	explicit texture_h(int bm);
+	explicit texture_h(int bm, bool refcount = true);
 
 	~texture_h();
 


### PR DESCRIPTION
This allows to directly use a texture object for image sources in librocket over having to render on screen over librocket or to have to pass it as a blob, which is especially useful for rendering continually updating textures with librocket.
To make sure we don't run into problems with passing ownership and stuff, I had to redo the lock_count system for lua textures. This is a good thing anyways IMO, since we would have leaked textures which are created in lua, used / locked somewhere else, and then went out of scope in lua as it is now, whereas this new way will properly reference count them.
