### PR TITLE
These old vars did something once, but not anymore

### DIFF
--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -66,11 +66,7 @@ char Processing_filename[MAX_PATH_LEN];
 #endif
 
 // override states to skip rendering of certain elements, but without disabling them completely
-bool Basemap_override = false;
 bool Envmap_override = false;
-bool Specmap_override = false;
-bool Normalmap_override = false;
-bool Heightmap_override = false;
 bool Glowpoint_override = false;
 bool Glowpoint_use_depth_buffer = true;
 bool PostProcessing_override = false;

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -138,14 +138,9 @@ extern float Noise[NOISE_NUM_FRAMES];
 
 
 // override states to skip rendering of certain elements, but without disabling them completely
-extern bool Basemap_override;
 extern bool Envmap_override;
-extern bool Specmap_override;
-extern bool Normalmap_override;
-extern bool Heightmap_override;
 extern bool Glowpoint_override;
 extern bool Glowpoint_use_depth_buffer;
-extern bool GLSL_override;
 extern bool PostProcessing_override;
 extern bool Shadow_override;
 extern bool Trail_render_override;

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -760,7 +760,7 @@ uint model_material::get_shader_flags() const
 		Shader_flags |= SDR_FLAG_MODEL_ANIMATED;
 	}
 
-	if ( get_texture_map(TM_BASE_TYPE) > 0 && !Basemap_override ) {
+	if ( get_texture_map(TM_BASE_TYPE) > 0) {
 		Shader_flags |= SDR_FLAG_MODEL_DIFFUSE_MAP;
 	}
 
@@ -768,18 +768,18 @@ uint model_material::get_shader_flags() const
 		Shader_flags |= SDR_FLAG_MODEL_GLOW_MAP;
 	}
 
-	if ( (get_texture_map(TM_SPECULAR_TYPE) > 0 || get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) && !Specmap_override ) {
+	if ( get_texture_map(TM_SPECULAR_TYPE) > 0 || get_texture_map(TM_SPEC_GLOSS_TYPE) > 0 ) {
 		Shader_flags |= SDR_FLAG_MODEL_SPEC_MAP;
 	}
 	if ( (ENVMAP > 0) && !Envmap_override ) {
 		Shader_flags |= SDR_FLAG_MODEL_ENV_MAP;
 	}
 
-	if ( (get_texture_map(TM_NORMAL_TYPE) > 0) && !Normalmap_override ) {
+	if ( get_texture_map(TM_NORMAL_TYPE) > 0 ) {
 		Shader_flags |= SDR_FLAG_MODEL_NORMAL_MAP;
 	}
 
-	if ( (get_texture_map(TM_HEIGHT_TYPE) > 0) && !Heightmap_override ) {
+	if ( get_texture_map(TM_HEIGHT_TYPE) > 0 ) {
 		Shader_flags |= SDR_FLAG_MODEL_HEIGHT_MAP;
 	}
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -49,11 +49,7 @@ extern int G3_user_clip;
 extern vec3d G3_user_clip_normal;
 extern vec3d G3_user_clip_point;
 
-extern bool Basemap_override;
 extern bool Envmap_override;
-extern bool Specmap_override;
-extern bool Normalmap_override;
-extern bool Heightmap_override;
 extern bool Shadow_override;
 
 size_t GL_vertex_data_in = 0;


### PR DESCRIPTION
As best I can tell these variables are remains of an older version of the lab or old implementations of command line flags, and are currently only ever a single value. To clean up, I removed them and the remaining checks on them.