### PR TITLE
Further limit what built-in UI elements can be setup when using SCPUI

### DIFF
--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1010,9 +1010,7 @@ void brief_api_init()
 	// init the scene-cut data
 	brief_transition_reset();
 
-	//This will need to be replaced with an API version in a later PR that deals with
-	//weapon and ship select APIs - Mjn
-	common_select_init();
+	common_select_init(true);
 
 	// init the briefing map
 	brief_init_map();

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -522,7 +522,7 @@ void common_reset_team_pointers()
 // is called.  This prevents multiple loadings of animations/bitmaps.
 //
 // This function also sets the palette based on the file palette01.pcx
-void common_select_init()
+void common_select_init(bool API_Access)
 {
 	if ( Common_select_inited ) {
 		nprintf(("Alan","common_select_init() returning without doing anything\n"));
@@ -560,9 +560,11 @@ void common_select_init()
 
 	common_set_team_pointers(Common_team);
 
-	ship_select_common_init();	
-	weapon_select_common_init();
-	common_flash_button_init();
+	ship_select_common_init(API_Access);	
+	weapon_select_common_init(API_Access);
+	if (!API_Access) {
+		common_flash_button_init();
+	}
 
 	if ( Game_mode & GM_MULTIPLAYER ) {
 		multi_ts_common_init();
@@ -577,25 +579,27 @@ void common_select_init()
 		}
 	}
 	
-	ss_reset_selected_ship();
+	if (!API_Access) {
+		ss_reset_selected_ship();
 
-	Drop_icon_mflag = 0;
-	Drop_on_wing_mflag = 0;
+		Drop_icon_mflag = 0;
+		Drop_on_wing_mflag = 0;
 
-	//init colors
-	gr_init_alphacolor(&Icon_colors[ICON_FRAME_NORMAL], 32, 128, 128, 255);
-	gr_init_alphacolor(&Icon_colors[ICON_FRAME_HOT], 48, 160, 160, 255);
-	gr_init_alphacolor(&Icon_colors[ICON_FRAME_SELECTED], 64, 192, 192, 255);
-	gr_init_alphacolor(&Icon_colors[ICON_FRAME_PLAYER], 192, 128, 64, 255);
-	gr_init_alphacolor(&Icon_colors[ICON_FRAME_DISABLED], 175, 175, 175, 255);
-	gr_init_alphacolor(&Icon_colors[ICON_FRAME_DISABLED_HIGH], 100, 100, 100, 255);
-	//init shaders
-	gr_create_shader(&Icon_shaders[ICON_FRAME_NORMAL], 32, 128, 128, 255);
-	gr_create_shader(&Icon_shaders[ICON_FRAME_HOT], 48, 160, 160, 255);
-	gr_create_shader(&Icon_shaders[ICON_FRAME_SELECTED], 64, 192, 192, 255);
-	gr_create_shader(&Icon_shaders[ICON_FRAME_PLAYER], 192, 128, 64, 255);
-	gr_create_shader(&Icon_shaders[ICON_FRAME_DISABLED], 175, 175, 175, 255);
-	gr_create_shader(&Icon_shaders[ICON_FRAME_DISABLED_HIGH], 100, 100, 100, 255);
+		// init colors
+		gr_init_alphacolor(&Icon_colors[ICON_FRAME_NORMAL], 32, 128, 128, 255);
+		gr_init_alphacolor(&Icon_colors[ICON_FRAME_HOT], 48, 160, 160, 255);
+		gr_init_alphacolor(&Icon_colors[ICON_FRAME_SELECTED], 64, 192, 192, 255);
+		gr_init_alphacolor(&Icon_colors[ICON_FRAME_PLAYER], 192, 128, 64, 255);
+		gr_init_alphacolor(&Icon_colors[ICON_FRAME_DISABLED], 175, 175, 175, 255);
+		gr_init_alphacolor(&Icon_colors[ICON_FRAME_DISABLED_HIGH], 100, 100, 100, 255);
+		// init shaders
+		gr_create_shader(&Icon_shaders[ICON_FRAME_NORMAL], 32, 128, 128, 255);
+		gr_create_shader(&Icon_shaders[ICON_FRAME_HOT], 48, 160, 160, 255);
+		gr_create_shader(&Icon_shaders[ICON_FRAME_SELECTED], 64, 192, 192, 255);
+		gr_create_shader(&Icon_shaders[ICON_FRAME_PLAYER], 192, 128, 64, 255);
+		gr_create_shader(&Icon_shaders[ICON_FRAME_DISABLED], 175, 175, 175, 255);
+		gr_create_shader(&Icon_shaders[ICON_FRAME_DISABLED_HIGH], 100, 100, 100, 255);
+	}
 }
 
 void common_reset_buttons()

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -78,7 +78,7 @@ enum class commit_pressed_status { SUCCESS, GENERAL_FAIL, PLAYER_NO_WEAPONS,  NO
 // common_select_init() performs initialization common to the briefing/ship select/weapon select
 // screens.  This includes loading/setting the palette, loading the background animation, loading
 // the screen switching animations, loading the button animation frames
-void	common_select_init();	
+void common_select_init(bool API_Access = false);
 int	common_select_do(float frametime);
 void	common_select_close();
 void	common_draw_buttons();
@@ -92,7 +92,7 @@ void 	common_render_selected_screen_button();
 void	common_reset_buttons();
 void	common_redraw_pressed_buttons();
 void  common_maybe_clear_focus();
-void ship_select_common_init();
+void ship_select_common_init(bool API_Access = false);
 void common_setup_room_lights();
 
 int mission_ui_background_load(const char *custom_background, const char *single_background, const char *multi_background = NULL);

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -311,7 +311,7 @@ void pick_from_wing(int wb_num, int ws_num);
 
 // ui related
 void ship_select_button_do(int i);
-void ship_select_common_init();
+void ship_select_common_init(bool API_Access);
 void ss_reset_selected_ship();
 void ss_restore_loadout();
 void maybe_change_selected_wing_ship(int wb_num, int ws_num);
@@ -3268,7 +3268,7 @@ void ship_select_init_team_data(int team_num)
 }
 
 // called when the briefing is entered
-void ship_select_common_init()
+void ship_select_common_init(bool API_Access)
 {		
 	// initialize team critical data for all teams
 	int idx;
@@ -3285,13 +3285,15 @@ void ship_select_common_init()
 		ship_select_init_team_data(Common_team);
 	}
 	
-	init_active_list();
+	if (!API_Access) {
+		init_active_list();
 
-	// load the necessary icons/animations
-	ss_load_all_icons();
+		// load the necessary icons/animations
+		ss_load_all_icons();
 
-	ss_reset_selected_ship();
-	ss_reset_carried_icon();
+		ss_reset_selected_ship();
+		ss_reset_carried_icon();
+	}
 }
 
 void ship_select_common_close()

--- a/code/missionui/missionshipchoice.h
+++ b/code/missionui/missionshipchoice.h
@@ -86,7 +86,7 @@ void draw_wing_block(int wb_num, int hot_slot, int selected_slot, int class_sele
 void ship_select_init();
 void ship_select_do(float frametime);
 void ship_select_close();
-void ship_select_common_init();
+void ship_select_common_init(bool API_Access);
 void ship_select_common_close();
 int ss_get_ship_class(int ship_entry_index);
 int ss_get_selected_ship();

--- a/code/missionui/missionshipchoice.h
+++ b/code/missionui/missionshipchoice.h
@@ -86,7 +86,6 @@ void draw_wing_block(int wb_num, int hot_slot, int selected_slot, int class_sele
 void ship_select_init();
 void ship_select_do(float frametime);
 void ship_select_close();
-void ship_select_common_init(bool API_Access);
 void ship_select_common_close();
 int ss_get_ship_class(int ship_entry_index);
 int ss_get_selected_ship();

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1988,7 +1988,7 @@ void weapon_select_close_team()
  * This init is called even before the weapons loadout screen is entered.  It is called when the
  * briefing state is entered.
  */
-void weapon_select_common_init()
+void weapon_select_common_init(bool API_Access)
 {
 	int idx;
 
@@ -2005,9 +2005,11 @@ void weapon_select_common_init()
 		weapon_select_init_team(Common_team);
 	}
 
-	wl_reset_selected_slot();
-	wl_reset_carried_icon();
-	wl_maybe_reset_selected_weapon_class();
+	if (!API_Access) {
+		wl_reset_selected_slot();
+		wl_reset_carried_icon();
+		wl_maybe_reset_selected_weapon_class();
+	}
 }
 
 /**

--- a/code/missionui/missionweaponchoice.h
+++ b/code/missionui/missionweaponchoice.h
@@ -41,7 +41,7 @@ class ship_weapon;
 extern int Weapon_select_overlay_id;
 
 void weapon_select_init();
-void weapon_select_common_init();
+void weapon_select_common_init(bool API_Access = false);
 void weapon_select_do(float frametime);
 void weapon_select_close();
 void weapon_select_close_team();

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1172,8 +1172,8 @@ ADE_FUNC(initSelect,
 
 	common_set_team_pointers(Common_team);
 
-	ship_select_common_init();
-	weapon_select_common_init();
+	ship_select_common_init(true);
+	weapon_select_common_init(true);
 
 	if ( Game_mode & GM_MULTIPLAYER ) {
 		multi_ts_common_init();


### PR DESCRIPTION
Partial fix for #4821. Stops SCPUI from being able to even get into functions that only handle retail UI elements.