### PR TITLE
remove misplaced int3() and allow the game to continue with -1

### DIFF
--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -2776,23 +2776,24 @@ void ss_reset_selected_ship()
 	for ( i = 0; i < MAX_WSS_SLOTS; i++ ) {
 		if ( Wss_slots[i].ship_class >= 0 ) {
 			Selected_ss_class = Wss_slots[i].ship_class;
-			break;
+			return;
 		}
 	}
 
-	if ( Selected_ss_class == -1 ) {
-		Int3();
-		for ( i = 0; i < ship_info_size(); i++ ) {
-			if ( Ss_pool[i] > 0 ) {
-				Selected_ss_class = i;
-			}
+	// get the first ship class found in the pool
+	for ( i = 0; i < ship_info_size(); i++ ) {
+		if ( Ss_pool[i] > 0 ) {
+			Selected_ss_class = i;
+			return;
 		}
 	}
 
-	if ( Selected_ss_class == -1 ) {
+	// If we still haven't found a ship to display, then leave it as -1. This results in no ship info
+	// being displayed in the UI, but is not a game breaking issue. -Mjn
+	/*if ( Selected_ss_class == -1 ) {
 		Int3();
 		return;
-	}
+	}*/
 }
 
 // There may be ships that are in wings but not in Team_data[0].  Since we still want to show those


### PR DESCRIPTION
This makes `ss_reset_selected_ship() `mirror its sister function `wl_maybe_reset_selected_weapon_class()`. Removes an erroneous int3() which prevented checking the ship pool for a valid ship class if none was found in the loadout slots. Returns instead of breaks when a valid value is found. Finally, it allows the game to continue with a value of -1.

Research and testing shows that the Ship Select UI will handle a -1 correctly by not loading an animation or ship data. In other cases where a value is needed, error checking already exists there. That said, in the retail UI it seems to be impossible to force a value of -1 due to other error checking in the mission files themselves during load. (IE: You cannot have a ship without a player ship and having a player ship forces the pool to have at least one ship in it.)

In summary, a -1 here should be non-fatal and, using the sister function as a guide, I feel it's not even worth logging.

Fixes #4821 