### PR TITLE
Optional discord presence

### DIFF
--- a/code/libs/discord/discord.h
+++ b/code/libs/discord/discord.h
@@ -4,5 +4,6 @@ namespace libs {
 namespace discord {
 
 void init();
+void shutdown();
 }
 } // namespace libs

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -12,12 +12,14 @@
 #include "globalincs/version.h"
 #include "graphics/shadows.h"
 #include "localization/localize.h"
+#include "libs/discord/discord.h"
 #include "mission/missioncampaign.h"
 #include "mission/missionload.h"
 #include "mission/missionmessage.h"
 #include "missionui/fictionviewer.h"
 #include "nebula/neb.h"
 #include "mod_table/mod_table.h"
+#include "options/Option.h"
 #include "parse/parselo.h"
 #include "sound/sound.h"
 #include "starfield/supernova.h"
@@ -109,6 +111,30 @@ leadIndicatorBehavior Lead_indicator_behavior;
 shadow_disable_overrides Shadow_disable_overrides {false, false, false, false};
 float Thruster_easing;
 bool Always_use_distant_firepoints;
+bool Discord_presence;
+
+static auto DiscordOption = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
+							 .category("Other")
+							 .default_val(Discord_presence)
+							 .level(options::ExpertLevel::Advanced)
+							 .importance(55)
+		                     .change_listener([](bool val, bool) {
+									if(Discord_presence){
+										if (!val) {
+											Discord_presence = false;
+											libs::discord::shutdown();
+											return true;
+										}
+									} else {
+										if (val) {
+											Discord_presence = true;
+											libs::discord::init();
+											return true;
+										}
+									}
+									return false;
+								})
+							 .finish();
 
 void mod_table_set_version_flags();
 
@@ -972,6 +998,9 @@ void parse_mod_table(const char *filename)
 		if (optional_string("$Use distant firepoint for all turrets:")){
 			stuff_boolean(&Always_use_distant_firepoints);
 		}
+		if (optional_string("$Enable discord rich presence:")) {
+			stuff_boolean(&Discord_presence);
+		}
 
 		required_string("#END");
 	}
@@ -1109,6 +1138,7 @@ void mod_table_reset()
 	Lead_indicator_behavior = leadIndicatorBehavior::DEFAULT;
 	Thruster_easing = 0;
 	Always_use_distant_firepoints = false;
+	Discord_presence = true;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -101,6 +101,7 @@ extern struct shadow_disable_overrides {
 } Shadow_disable_overrides;
 extern float Thruster_easing;
 extern bool Always_use_distant_firepoints;
+extern bool Discord_presence;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2013,8 +2013,9 @@ void game_init()
 #ifdef WITH_FFMPEG
 		libs::ffmpeg::initialize();
 #endif
-
-		libs::discord::init();
+		if (Discord_presence) {
+			libs::discord::init();
+		}
 	}
 
 	mod_table_post_process();


### PR DESCRIPTION
Sets up discord presence to allow toggling. Adds a game_settings.tbl flag to enable or disable it (Could be command line, but leaning in to the load_last directory instead). Also adds a constructed built-in option to toggle it during a game instance if the active mod is using SCPUI. The built-in option toggle will override the game_settings.tbl flag.

Partially implements #4113 