### PR TITLE
asteroid field fix/refactor

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2145,6 +2145,7 @@ void asteroid_frame()
 		return;
 	}
 
+	// If there are no explicit targets, fall back to default retail targeting behavior
 	if (Asteroid_field.target_names.empty()) {
 		int objnum = set_asteroid_throw_objnum();
 		if (Asteroid_targets.empty() || Asteroid_targets[0].objnum != objnum) {

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -639,7 +639,7 @@ void asteroid_level_init()
 	vm_vec_make(&Asteroid_field.max_bound, 1000.0f, 1000.0f, 1000.0f);
 	vm_vec_make(&Asteroid_field.inner_min_bound, -500.0f, -500.0f, -500.0f);
 	vm_vec_make(&Asteroid_field.inner_max_bound, 500.0f, 500.0f, 500.0f);
-	Asteroid_field.has_inner_bound = 0;
+	Asteroid_field.has_inner_bound = false;
 	Asteroid_field.field_type = FT_ACTIVE;
 	Asteroid_field.debris_genre = DG_ASTEROID;
 	Asteroid_field.field_debris_type[0] = -1;

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -36,12 +36,6 @@ class model_draw_list;
 // Goober5000 - currently same as MAX_SHIP_DETAIL_LEVELS (put here to avoid an #include)
 #define MAX_ASTEROID_DETAIL_LEVELS	5
 
-// whether to do retail behavior, just throw at the first big ship in the field
-// must be explicitly opted out of by the mission
-extern bool Default_asteroid_throwing_behavior;
-
-extern SCP_vector<SCP_string> Asteroid_target_ships;
-
 // Data structure to track the active asteroids
 typedef struct asteroid_obj {
 	asteroid_obj *next, *prev;
@@ -134,7 +128,7 @@ typedef	struct asteroid_field {
 	vec3d	min_bound;					// Minimum range of field.
 	vec3d	max_bound;					// Maximum range of field.
 	float	bound_rad;
-	int		has_inner_bound;
+	bool	has_inner_bound;
 	vec3d	inner_min_bound;
 	vec3d	inner_max_bound;
 	vec3d	vel;						// Average asteroid moves at this velocity.
@@ -144,6 +138,8 @@ typedef	struct asteroid_field {
 	debris_genre_t	debris_genre;		// type of debris (ship or asteroid)  [generic type]
 	int				field_debris_type[MAX_ACTIVE_DEBRIS_TYPES];	// one of the debris type defines above
 	int				num_used_field_debris_types;	// how many of the above are used
+
+	SCP_vector<SCP_string> target_names;	// default retail behavior is to just throw at the first big ship in the field
 } asteroid_field;
 
 extern SCP_vector< asteroid_info > Asteroid_info;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2476,7 +2476,7 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 	}
 
 	// if this is an asteroid target, add it to the list
-	for (SCP_string& name : Asteroid_target_ships) {
+	for (SCP_string& name : Asteroid_field.target_names) {
 		if (stricmp(name.c_str(), shipp->ship_name) == 0) {
 			asteroid_add_target(&Objects[objnum]);
 			break;
@@ -5807,7 +5807,7 @@ void parse_asteroid_fields(mission *pm)
 		Asteroid_field.bound_rad = MAX(3000.0f, b_rad);
 
 		if (optional_string("+Inner Bound:")) {
-			Asteroid_field.has_inner_bound = 1;
+			Asteroid_field.has_inner_bound = true;
 
 			required_string("$Minimum:");
 			stuff_vec3d(&Asteroid_field.inner_min_bound);
@@ -5815,12 +5815,11 @@ void parse_asteroid_fields(mission *pm)
 			required_string("$Maximum:");
 			stuff_vec3d(&Asteroid_field.inner_max_bound);
 		} else {
-			Asteroid_field.has_inner_bound = 0;
+			Asteroid_field.has_inner_bound = false;
 		}
 
 		if (optional_string("$Asteroid Targets:")) {
-			stuff_string_list(Asteroid_target_ships);
-			Default_asteroid_throwing_behavior = false;
+			stuff_string_list(Asteroid_field.target_names);
 		}
 		i++;
 	}

--- a/fred2/asteroideditordlg.cpp
+++ b/fred2/asteroideditordlg.cpp
@@ -64,8 +64,6 @@ asteroid_editor::asteroid_editor(CWnd* pParent /*=NULL*/)
 	i=0;
 //	for (i=0; i<MAX_ASTEROID_FIELDS; i++)
 		a_field[i] = Asteroid_field;	//	Only supporting one field per mission.
-
-	m_field_targets = Asteroid_target_ships;
 }
 
 void asteroid_editor::DoDataExchange(CDataExchange* pDX)
@@ -193,6 +191,8 @@ int asteroid_editor::query_modified()
 				return 1;
 		}
 
+		if (a_field[i].target_names != Asteroid_field.target_names)
+			return 1;
 	}
 
 	return 0;
@@ -307,9 +307,6 @@ void asteroid_editor::OnOK()
 	for (i=0; i<1 /*MAX_ASTEROID_FIELDS*/; i++)
 		Asteroid_field = a_field[i];
 
-	// asteroid field targets are handled separately
-	Asteroid_target_ships = m_field_targets;
-
 	update_map_window();
 	theApp.record_window_data(&Asteroid_wnd_data, this);
 	CDialog::OnOK();
@@ -403,7 +400,7 @@ void asteroid_editor::update_init()
 			MODIFY(a_field[cur_field].field_debris_type[2], cur_choice);
 		}
 
-		MODIFY(a_field[last_field].has_inner_bound, m_enable_inner_bounds);
+		MODIFY(a_field[last_field].has_inner_bound, (bool)m_enable_inner_bounds);
 
 		MODIFY(a_field[last_field].inner_min_bound.xyz.x, (float) atof(m_box_min_x));
 		MODIFY(a_field[last_field].inner_min_bound.xyz.y, (float) atof(m_box_min_y));
@@ -412,14 +409,7 @@ void asteroid_editor::update_init()
 		MODIFY(a_field[last_field].inner_max_bound.xyz.y, (float) atof(m_box_max_y));
 		MODIFY(a_field[last_field].inner_max_bound.xyz.z, (float) atof(m_box_max_z));
 
-		// store current targets
-		auto targetList = ((CListBox*)GetDlgItem(IDC_FIELD_TARGET_LIST));
-		m_field_targets.clear();
-		for (int i = 0; i < targetList->GetCount(); ++i)
-		{
-			targetList->GetText(i, str);
-			m_field_targets.push_back((LPCSTR)str);
-		}
+		MODIFY(a_field[last_field].target_names, m_field_targets);
 	}
 
 	Assert(cur_field >= 0);
@@ -449,6 +439,8 @@ void asteroid_editor::update_init()
 	m_box_max_x.Format("%.1f", a_field[cur_field].inner_max_bound.xyz.x);
 	m_box_max_y.Format("%.1f", a_field[cur_field].inner_max_bound.xyz.y);
 	m_box_max_z.Format("%.1f", a_field[cur_field].inner_max_bound.xyz.z);
+
+	m_field_targets = a_field[cur_field].target_names;
 
 	// set up combo boxes
 	uint i;

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -3078,9 +3078,9 @@ int CFREDView::global_error_check()
 	}*/
 
 	// do error checking for asteroid targets
-	for (const auto& target_ship : Asteroid_target_ships) {
-		if (ship_name_lookup(target_ship.c_str(), 1) < 0) {
-			if (error("Asteroid target '%s' is not a valid ship", target_ship.c_str())) {
+	for (const auto& name : Asteroid_field.target_names) {
+		if (ship_name_lookup(name.c_str(), 1) < 0) {
+			if (error("Asteroid target '%s' is not a valid ship", name.c_str())) {
 				return 1;
 			}
 		}

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -834,18 +834,7 @@ void clear_mission()
 	cmd_brief_reset();
 	mission_event_shutdown();
 
-	Asteroid_field.num_initial_asteroids = 0;  // disable asteroid field by default.
-	Asteroid_field.speed = 0.0f;
-	vm_vec_make(&Asteroid_field.min_bound, -1000.0f, -1000.0f, -1000.0f);
-	vm_vec_make(&Asteroid_field.max_bound,  1000.0f,  1000.0f,  1000.0f);
-	vm_vec_make(&Asteroid_field.inner_min_bound, -500.0f, -500.0f, -500.0f);
-	vm_vec_make(&Asteroid_field.inner_max_bound,  500.0f,  500.0f,  500.0f);
-	Asteroid_field.has_inner_bound = 0;
-	Asteroid_field.field_type = FT_ACTIVE;
-	Asteroid_field.debris_genre = DG_ASTEROID;
-	Asteroid_field.field_debris_type[0] = -1;
-	Asteroid_field.field_debris_type[1] = -1;
-	Asteroid_field.field_debris_type[2] = -1;
+	asteroid_level_init();
 
 	strcpy_s(Mission_parse_storm_name, "none");
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -762,7 +762,7 @@ int CFred_mission_save::save_asteroid_fields()
 		parse_comments();
 		save_vector(Asteroid_field.max_bound);
 
-		if (Asteroid_field.has_inner_bound == 1) {
+		if (Asteroid_field.has_inner_bound) {
 			if (optional_string_fred("+Inner Bound:")) {
 				parse_comments();
 			} else {

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -778,7 +778,7 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
-		if (!Asteroid_target_ships.empty()) {
+		if (!Asteroid_field.target_names.empty()) {
 			fso_comment_push(";;FSO 22.0.0;;");
 			if (optional_string_fred("$Asteroid Targets:")) {
 				parse_comments();
@@ -787,7 +787,7 @@ int CFred_mission_save::save_asteroid_fields()
 				fout_version("\n$Asteroid Targets: (");
 			}
 
-			for (SCP_string& name : Asteroid_target_ships) {				
+			for (SCP_string& name : Asteroid_field.target_names) {
 				fout(" \"%s\"", name.c_str());
 			}
 

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -375,18 +375,7 @@ void Editor::clearMission() {
 	cmd_brief_reset();
 	mission_event_shutdown();
 
-	Asteroid_field.num_initial_asteroids = 0;  // disable asteroid field by default.
-	Asteroid_field.speed = 0.0f;
-	vm_vec_make(&Asteroid_field.min_bound, -1000.0f, -1000.0f, -1000.0f);
-	vm_vec_make(&Asteroid_field.max_bound, 1000.0f, 1000.0f, 1000.0f);
-	vm_vec_make(&Asteroid_field.inner_min_bound, -500.0f, -500.0f, -500.0f);
-	vm_vec_make(&Asteroid_field.inner_max_bound, 500.0f, 500.0f, 500.0f);
-	Asteroid_field.has_inner_bound = 0;
-	Asteroid_field.field_type = FT_ACTIVE;
-	Asteroid_field.debris_genre = DG_ASTEROID;
-	Asteroid_field.field_debris_type[0] = -1;
-	Asteroid_field.field_debris_type[1] = -1;
-	Asteroid_field.field_debris_type[2] = -1;
+	asteroid_level_init();
 
 	strcpy_s(Mission_parse_storm_name, "none");
 

--- a/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
@@ -387,12 +387,12 @@ void AsteroidEditorDialogModel::update_init()
 			modify(_a_field.field_debris_type[_AST_ORANGE], getAsteroidEnabled(_AST_ORANGE) == true ? 1 : -1);
 		}
 
-		modify(_a_field.has_inner_bound, static_cast<int>(_enable_inner_bounds));
+		modify(_a_field.has_inner_bound, _enable_inner_bounds);
 	}
 
 	// get from temp asteroid field into class
 	_enable_asteroids = _a_field.num_initial_asteroids ? true : false;
-	_enable_inner_bounds = _a_field.has_inner_bound ? true : false;
+	_enable_inner_bounds = _a_field.has_inner_bound;
 	_num_asteroids = _a_field.num_initial_asteroids;
 	if (!_enable_asteroids) {
 		_num_asteroids = 10;

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -792,7 +792,7 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
-		if (!Asteroid_target_ships.empty()) {
+		if (!Asteroid_field.target_names.empty()) {
 			fso_comment_push(";;FSO 22.0.0;;");
 			if (optional_string_fred("$Asteroid Targets:")) {
 				parse_comments();
@@ -801,7 +801,7 @@ int CFred_mission_save::save_asteroid_fields()
 				fout_version("\n$Asteroid Targets: (");
 			}
 
-			for (SCP_string& name : Asteroid_target_ships) {				
+			for (SCP_string& name : Asteroid_field.target_names) {
 				fout(" \"%s\"", name.c_str());
 			}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -776,7 +776,7 @@ int CFred_mission_save::save_asteroid_fields()
 		parse_comments();
 		save_vector(Asteroid_field.max_bound);
 
-		if (Asteroid_field.has_inner_bound == 1) {
+		if (Asteroid_field.has_inner_bound) {
 			if (optional_string_fred("+Inner Bound:")) {
 				parse_comments();
 			} else {


### PR DESCRIPTION
Some refactoring with asteroid fields:
1. Moves asteroid throwing targets into the Asteroid_field struct, in anticipation of potentially multiple fields in the future
2. Moves some initialization code into `asteroid_level_init`
3. Calls `asteroid_level_init` when a mission is cleared
4. Loads asteroid targets as part of the asteroid field update/init logic.  This fixes a FRED bug reported in Discord where asteroid targets stay in the dialog when a new mission is loaded
5. Remove `Default_asteroid_throwing_behavior` flag as it is equivalent to checking that the target list is empty