### PR TITLE
allow borrowing flyby sounds from a previously parsed species

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -1189,8 +1189,6 @@ void parse_sound_environments()
 	required_string("#Sound Environments End");
 }
 
-static SCP_vector<species_info> missingFlybySounds;
-
 void parse_sound_table(const char* filename)
 {
 	try
@@ -1291,20 +1289,14 @@ void gamesnd_parse_soundstbl()
 
 	parse_modular_table("*-snd.tbm", parse_sound_table);
 
-	// if we are missing any species then report
-	if (!missingFlybySounds.empty())
-	{
-		SCP_string errorString;
-		for (size_t i = 0; i < missingFlybySounds.size(); i++)
-		{
-			errorString.append(missingFlybySounds[i].species_name);
-			errorString.append("\n");
+	//Set any flyby sounds for species that use the borrowed feature
+	for (size_t i = 0; i < Species_info.size(); i++) {
+		if (Species_info[i].borrows_flyby_sounds_species >= 0) {
+			int idx = Species_info[i].borrows_flyby_sounds_species;
+			Species_info[i].snd_flyby_fighter = Species_info[idx].snd_flyby_fighter;
+			Species_info[i].snd_flyby_bomber = Species_info[idx].snd_flyby_bomber;
 		}
-
-		Error(LOCATION, "The following species are missing flyby sounds in sounds.tbl:\n%s", errorString.c_str());
 	}
-
-	missingFlybySounds.clear();
 }
 
 /**

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -344,6 +344,18 @@ void parse_species_tbl(const char *filename)
 				}
 			}
 
+			if (optional_string("$Borrows Flyby Sounds from:")) {
+				char temp_name[NAME_LENGTH];
+				stuff_string(temp_name, F_NAME, NAME_LENGTH);
+				int idx = species_info_lookup(temp_name);
+				if (idx >= 0) {
+					species->borrows_flyby_sounds_species = idx;
+				} else {
+					Warning(LOCATION, "Species %s for '$Borrows Flyby Sounds from' in Species %s is either invalid or not yet parsed."
+									  "The Species doing the borrowing must be defined after the Species it is borrowing from\n", temp_name, species->species_name);
+				}
+			}
+
 			// don't add new entry if this is just a modified one
 			if (!no_create)
 				Species_info.push_back(new_species);

--- a/code/species_defs/species_defs.h
+++ b/code/species_defs/species_defs.h
@@ -68,6 +68,7 @@ public:
 
 	game_snd snd_flyby_fighter;
 	game_snd snd_flyby_bomber;
+	int borrows_flyby_sounds_species;
 
 	int bii_indices[MIN_BRIEF_ICONS];
 	int borrows_bii_index_species;   // species that this species borrows all of its briefing icons from, -1 if none
@@ -90,6 +91,7 @@ public:
 		support_ship_name[0] = '\0';
 		support_ship_index = -1;
 		borrows_bii_index_species = -1;
+		borrows_flyby_sounds_species = -1;
 	}
 };
 


### PR DESCRIPTION
Adds ability to borrow flyby sounds to species_defs.tbl and cleans out some old species flyby checking code that was no longer used.

Fixes #4520 