### PR TITLE
Dont add whitespace for no_fred ships in the main list

### DIFF
--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -1639,7 +1639,7 @@ BOOL CFREDView::OnCmdMsg(UINT nID, int nCode, void* pExtra, AFX_CMDHANDLERINFO* 
 	int id = (int) nID;
 
 	if (!pHandlerInfo) {
-		if ((id >= SHIP_TYPES) && (id < SHIP_TYPES + ship_type_combo_box_size + 3)) {
+		if ((id >= SHIP_TYPES) && (id < SHIP_TYPES + (int)ship_type_combo_box_size + 3)) {
 			if (nCode == CN_COMMAND) {
 				cur_model_index = id - SHIP_TYPES;
 				m_new_ship_type_combo_box.SetCurSelNEW(cur_model_index);

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -1639,7 +1639,7 @@ BOOL CFREDView::OnCmdMsg(UINT nID, int nCode, void* pExtra, AFX_CMDHANDLERINFO* 
 	int id = (int) nID;
 
 	if (!pHandlerInfo) {
-		if ((id >= SHIP_TYPES) && (id < SHIP_TYPES + num_ships_in_combo_box + 3)) {
+		if ((id >= SHIP_TYPES) && (id < SHIP_TYPES + ship_type_combo_box_size + 3)) {
 			if (nCode == CN_COMMAND) {
 				cur_model_index = id - SHIP_TYPES;
 				m_new_ship_type_combo_box.SetCurSelNEW(cur_model_index);

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -1639,7 +1639,7 @@ BOOL CFREDView::OnCmdMsg(UINT nID, int nCode, void* pExtra, AFX_CMDHANDLERINFO* 
 	int id = (int) nID;
 
 	if (!pHandlerInfo) {
-		if ((id >= SHIP_TYPES) && (id < SHIP_TYPES + ship_info_size() + 3)) {
+		if ((id >= SHIP_TYPES) && (id < SHIP_TYPES + num_ships_in_combo_box + 3)) {
 			if (nCode == CN_COMMAND) {
 				cur_model_index = id - SHIP_TYPES;
 				m_new_ship_type_combo_box.SetCurSelNEW(cur_model_index);

--- a/fred2/mainfrm.cpp
+++ b/fred2/mainfrm.cpp
@@ -420,7 +420,7 @@ void color_combo_box::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 
 		COLORREF newTextColor = RGB(0x80, 0x80, 0x80);  // light gray
 		if (!fDisabled) {
-			if (z >= ship_type_combo_box_size)
+			if (z >= (int)ship_type_combo_box_size)
 				newTextColor = RGB(0, 0, 0);
 			else {
 				species_info *sinfo = &Species_info[Ship_info[z].species];
@@ -473,7 +473,7 @@ int color_combo_box::GetCurSelNEW() {
 
 	// see if we have a special item (>= Ship_info.size())
 	cur_sel = GetCurSel();
-	if (cur_sel >= ship_type_combo_box_size) {
+	if (cur_sel >= (int)ship_type_combo_box_size) {
 		return cur_sel;
 	}
 
@@ -496,7 +496,7 @@ void color_combo_box::MeasureItem(LPMEASUREITEMSTRUCT) {
 }
 
 int color_combo_box::SetCurSelNEW(int model_index) {
-	if ((model_index < 0) || (model_index >= ship_type_combo_box_size)) {
+	if ((model_index < 0) || (model_index >= (int)ship_type_combo_box_size)) {
 		return SetCurSel(model_index);
 	}
 

--- a/fred2/mainfrm.cpp
+++ b/fred2/mainfrm.cpp
@@ -77,6 +77,7 @@ static UINT indicators[] =
 
 CMainFrame *Fred_main_wnd;
 color_combo_box m_new_ship_type_combo_box;
+size_t num_ships_in_combo_box = 0;
 int Toggle1_var = 0;
 CPoint Global_point2;
 
@@ -118,12 +119,17 @@ void CMainFrame::init_tools() {
     for (auto it = Ship_info.cbegin(); it != Ship_info.cend(); ++it) {
         // don't add the pirate ship
         if (it->flags[Ship::Info_Flags::No_fred]) {
-            m_new_ship_type_combo_box.AddString("");
+            //m_new_ship_type_combo_box.AddString("");
             continue;
-        }
-
-        m_new_ship_type_combo_box.AddString(it->name);
+		} else {
+			m_new_ship_type_combo_box.AddString(it->name);
+			num_ships_in_combo_box++;
+		}
     }
+
+	Id_select_type_start = (int)(num_ships_in_combo_box + 2);
+	Id_select_type_jump_node = (int)(num_ships_in_combo_box + 1);
+	Id_select_type_waypoint = (int)(num_ships_in_combo_box);
 
 	//	m_new_ship_type_combo_box.AddString("Player Start");		
 	m_new_ship_type_combo_box.AddString("Jump Node");
@@ -400,7 +406,7 @@ void color_combo_box::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	CDC* pDC = CDC::FromHandle(lpDrawItemStruct->hDC);
 
 	// I think we need to do a lookup by ship name here	
-	if (lpDrawItemStruct->itemID >= Ship_info.size()) {
+	if (lpDrawItemStruct->itemID >= num_ships_in_combo_box) {
 		z = lpDrawItemStruct->itemID;
 	} else {
 		memset(ship_name, 0, 256);
@@ -414,7 +420,7 @@ void color_combo_box::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 
 		COLORREF newTextColor = RGB(0x80, 0x80, 0x80);  // light gray
 		if (!fDisabled) {
-			if (z >= ship_info_size())
+			if (z >= num_ships_in_combo_box)
 				newTextColor = RGB(0, 0, 0);
 			else {
 				species_info *sinfo = &Species_info[Ship_info[z].species];
@@ -467,7 +473,7 @@ int color_combo_box::GetCurSelNEW() {
 
 	// see if we have a special item (>= Ship_info.size())
 	cur_sel = GetCurSel();
-	if (cur_sel >= ship_info_size()) {
+	if (cur_sel >= num_ships_in_combo_box) {
 		return cur_sel;
 	}
 
@@ -490,7 +496,7 @@ void color_combo_box::MeasureItem(LPMEASUREITEMSTRUCT) {
 }
 
 int color_combo_box::SetCurSelNEW(int model_index) {
-	if ((model_index < 0) || (model_index >= ship_info_size())) {
+	if ((model_index < 0) || (model_index >= num_ships_in_combo_box)) {
 		return SetCurSel(model_index);
 	}
 

--- a/fred2/mainfrm.cpp
+++ b/fred2/mainfrm.cpp
@@ -77,7 +77,7 @@ static UINT indicators[] =
 
 CMainFrame *Fred_main_wnd;
 color_combo_box m_new_ship_type_combo_box;
-size_t num_ships_in_combo_box = 0;
+size_t ship_type_combo_box_size = 0;
 int Toggle1_var = 0;
 CPoint Global_point2;
 
@@ -121,15 +121,15 @@ void CMainFrame::init_tools() {
         if (it->flags[Ship::Info_Flags::No_fred]) {
             //m_new_ship_type_combo_box.AddString("");
             continue;
-		} else {
-			m_new_ship_type_combo_box.AddString(it->name);
-			num_ships_in_combo_box++;
-		}
+        } else {
+            m_new_ship_type_combo_box.AddString(it->name);
+            ship_type_combo_box_size++;
+        }
     }
 
-	Id_select_type_start = (int)(num_ships_in_combo_box + 2);
-	Id_select_type_jump_node = (int)(num_ships_in_combo_box + 1);
-	Id_select_type_waypoint = (int)(num_ships_in_combo_box);
+	Id_select_type_start = (int)(ship_type_combo_box_size + 2);
+	Id_select_type_jump_node = (int)(ship_type_combo_box_size + 1);
+	Id_select_type_waypoint = (int)(ship_type_combo_box_size);
 
 	//	m_new_ship_type_combo_box.AddString("Player Start");		
 	m_new_ship_type_combo_box.AddString("Jump Node");
@@ -406,7 +406,7 @@ void color_combo_box::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	CDC* pDC = CDC::FromHandle(lpDrawItemStruct->hDC);
 
 	// I think we need to do a lookup by ship name here	
-	if (lpDrawItemStruct->itemID >= num_ships_in_combo_box) {
+	if (lpDrawItemStruct->itemID >= ship_type_combo_box_size) {
 		z = lpDrawItemStruct->itemID;
 	} else {
 		memset(ship_name, 0, 256);
@@ -420,7 +420,7 @@ void color_combo_box::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 
 		COLORREF newTextColor = RGB(0x80, 0x80, 0x80);  // light gray
 		if (!fDisabled) {
-			if (z >= num_ships_in_combo_box)
+			if (z >= ship_type_combo_box_size)
 				newTextColor = RGB(0, 0, 0);
 			else {
 				species_info *sinfo = &Species_info[Ship_info[z].species];
@@ -473,7 +473,7 @@ int color_combo_box::GetCurSelNEW() {
 
 	// see if we have a special item (>= Ship_info.size())
 	cur_sel = GetCurSel();
-	if (cur_sel >= num_ships_in_combo_box) {
+	if (cur_sel >= ship_type_combo_box_size) {
 		return cur_sel;
 	}
 
@@ -496,7 +496,7 @@ void color_combo_box::MeasureItem(LPMEASUREITEMSTRUCT) {
 }
 
 int color_combo_box::SetCurSelNEW(int model_index) {
-	if ((model_index < 0) || (model_index >= num_ships_in_combo_box)) {
+	if ((model_index < 0) || (model_index >= ship_type_combo_box_size)) {
 		return SetCurSel(model_index);
 	}
 

--- a/fred2/mainfrm.h
+++ b/fred2/mainfrm.h
@@ -218,5 +218,6 @@ protected:
 extern CMainFrame *Fred_main_wnd;   //!< The main FRED window
 
 extern color_combo_box m_new_ship_type_combo_box;  //!< The combo box
+extern size_t num_ships_in_combo_box;
 
 #endif // _MAINFRM_H

--- a/fred2/mainfrm.h
+++ b/fred2/mainfrm.h
@@ -218,6 +218,6 @@ protected:
 extern CMainFrame *Fred_main_wnd;   //!< The main FRED window
 
 extern color_combo_box m_new_ship_type_combo_box;  //!< The combo box
-extern size_t num_ships_in_combo_box;
+extern size_t ship_type_combo_box_size;
 
 #endif // _MAINFRM_H

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -466,9 +466,6 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	// Get the default player ship
 	Default_player_model = cur_model_index = get_default_player_ship_index();
 
-	Id_select_type_start = (int)(Ship_info.size() + 2);
-	Id_select_type_jump_node = (int)(Ship_info.size() + 1);
-	Id_select_type_waypoint = (int)(Ship_info.size());
 	Fred_main_wnd -> init_tools();
 
 	Script_system.RunInitFunctions();


### PR DESCRIPTION
Turns out this list already looks up objects by name with the exception of waypoints and jump nodes. So this modifies how we create the list slightly by adding a counter and doing checks against the counter total instead of `ship_info.size()` This allows to be able to not list white space in order to keep indices. This also moves where we set the expected index of waypoints and jump nodes to after the counter is complete. It changes them from `ship_info.size() + N` to counter total + N.

I spent a few hours FREDing on this build and didn't run into any bugs, but it is probably worth giving this PR just a little extra scrutiny to be sure. The FRED code isn't the most readable.

Fixes #3633