### PR TITLE
Clearable Ship/Subsystem Targets via script

### DIFF
--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -781,6 +781,7 @@ ADE_VIRTVAR(Target, l_Ship, "object", "Target of ship. Value may also be a deriv
 			aip->target_objnum = OBJ_INDEX(newh->objp);
 			aip->target_signature = newh->sig;
 			aip->target_time = 0.0f;
+			set_targeted_subsys(aip, nullptr, -1);
 
 			if (aip == Player_ai)
 				hud_shield_hit_reset(newh->objp);
@@ -788,9 +789,8 @@ ADE_VIRTVAR(Target, l_Ship, "object", "Target of ship. Value may also be a deriv
 			aip->target_objnum = -1;
 			aip->target_signature = -1;
 			aip->target_time = 0.0f;
+			set_targeted_subsys(aip, nullptr, -1);
 		}
-
-		set_targeted_subsys(aip, NULL, -1);
 	}
 
 	return ade_set_object_with_breed(L, aip->target_objnum);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -775,28 +775,22 @@ ADE_VIRTVAR(Target, l_Ship, "object", "Target of ship. Value may also be a deriv
 	else
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(ADE_SETTING_VAR && newh)
-	{
-		if(aip->target_signature != newh->sig)
-		{
-			if(newh->IsValid())
-			{
-				aip->target_objnum = OBJ_INDEX(newh->objp);
-				aip->target_signature = newh->sig;
-				aip->target_time = 0.0f;
+	if(ADE_SETTING_VAR && !(newh && aip->target_signature == newh->sig)) {
+		// we have a different target, or are clearng the target
+		if(newh && newh->IsValid())	{
+			aip->target_objnum = OBJ_INDEX(newh->objp);
+			aip->target_signature = newh->sig;
+			aip->target_time = 0.0f;
 
-				if (aip == Player_ai)
-					hud_shield_hit_reset(newh->objp);
-			}
-			else
-			{
-				aip->target_objnum = -1;
-				aip->target_signature = -1;
-				aip->target_time = 0.0f;
-			}
-
-			set_targeted_subsys(aip, NULL, -1);
+			if (aip == Player_ai)
+				hud_shield_hit_reset(newh->objp);
+		} else if (lua_isnil(L, 2)) {
+			aip->target_objnum = -1;
+			aip->target_signature = -1;
+			aip->target_time = 0.0f;
 		}
+
+		set_targeted_subsys(aip, NULL, -1);
 	}
 
 	return ade_set_object_with_breed(L, aip->target_objnum);

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -422,7 +422,7 @@ ADE_VIRTVAR(SecondaryBanks, l_Subsystem, "weaponbanktype", "Array of secondary w
 }
 
 
-ADE_VIRTVAR(Target, l_Subsystem, "object", "Object targeted by this subsystem. If used to set a new target, AI targeting will be switched off.", "object", "Targeted object, or invalid object handle if subsystem handle is invalid")
+ADE_VIRTVAR(Target, l_Subsystem, "object", "Object targeted by this subsystem. If used to set a new target or clear it, AI targeting will be switched off.", "object", "Targeted object, or invalid object handle if subsystem handle is invalid")
 {
 	ship_subsys_h *sso;
 	object_h *objh = nullptr;
@@ -434,12 +434,18 @@ ADE_VIRTVAR(Target, l_Subsystem, "object", "Object targeted by this subsystem. I
 
 	ship_subsys *ss = sso->ss;
 
-	if(ADE_SETTING_VAR && objh && objh->IsValid())
-	{
-		ss->turret_enemy_objnum = OBJ_INDEX(objh->objp);
-		ss->turret_enemy_sig = objh->sig;
-		ss->targeted_subsys = NULL;
-		ss->scripting_target_override = true;
+	if(ADE_SETTING_VAR)	{
+		if (objh && objh->IsValid()) {
+			ss->turret_enemy_objnum = OBJ_INDEX(objh->objp);
+			ss->turret_enemy_sig = objh->sig;
+			ss->targeted_subsys = nullptr;
+			ss->scripting_target_override = true;
+		} else if (lua_isnil(L, 2)) {
+			ss->turret_enemy_objnum = -1;
+			ss->turret_enemy_sig = -1;
+			ss->targeted_subsys = nullptr;
+			ss->scripting_target_override = true;
+		}
 	}
 
 	return ade_set_object_with_breed(L, ss->turret_enemy_objnum);


### PR DESCRIPTION
Previously, setting `Target` for either would have been ignored entirely.