### PR TITLE
Add `isMultipart` and `getModelFlag` functions on subsystems

### DIFF
--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -629,7 +629,7 @@ ADE_FUNC(targetingOverride, l_Subsystem, "boolean", "If set to true, AI targetin
 ADE_FUNC(getModelFlag, 
 	l_Subsystem, 
 	"string flag_name", 
-	"Checks whether one or more model subsystem flags  <a href=\"https://www.w3schools.com/\">Visit W3Schools.com!</a>  are set - this function can accept an arbitrary number of flag arguments.  The flag names can be any string that the alter-ship-flag SEXP operator supports.", 
+	"Checks whether one or more <a href=\"https://wiki.hard-light.net/index.php/Subsystem#.24Flags:\">model subsystem flags</a> are set - this function can accept an arbitrary number of flag arguments.  The flag names can be any string that the alter-ship-flag SEXP operator supports.", 
 	"boolean", 
 	"Returns whether all flags are set, or nil if the subsystem is not valid")
 {

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -650,6 +650,9 @@ ADE_FUNC(getModelFlag,
 		if (subsys_flag == Model::Subsystem_Flags::NUM_VALUES) {
 			Warning(LOCATION, "Subsystem flag '%s' not found!", flag_name);
 			return ADE_RETURN_FALSE;
+		} else {
+			if (!(sso->ss->system_info->flags[subsys_flag]))
+				return ADE_RETURN_FALSE;
 		}
 
 		// read the next flag

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -689,6 +689,18 @@ ADE_FUNC(isTurret, l_Subsystem, NULL, "Determines if this subsystem is a turret"
 	return ade_set_args(L, "b", sso->ss->system_info->type == SUBSYSTEM_TURRET);
 }
 
+ADE_FUNC(isMultipartTurret, l_Subsystem, NULL, "Determines if this subsystem is a multi-part turret", "boolean", "true if subsystem is multi-part turret, false otherwise or nil on error")
+{
+	ship_subsys_h* sso;
+	if (!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
+		return ADE_RETURN_NIL;
+
+	if (!sso->isSubsystemValid())
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", sso->ss->system_info->type == SUBSYSTEM_TURRET && sso->ss->system_info->turret_gun_sobj != sso->ss->system_info->subobj_num);
+}
+
 ADE_FUNC(isTargetInFOV, l_Subsystem, "object Target", "Determines if the object is in the turrets FOV", "boolean", "true if in FOV, false if not, nil on error or if subsystem is not a turret ")
 {
 	ship_subsys_h *sso;

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -620,6 +620,46 @@ ADE_FUNC(targetingOverride, l_Subsystem, "boolean", "If set to true, AI targetin
 	return ADE_RETURN_TRUE;
 }
 
+ADE_FUNC(getModelFlag, 
+	l_Subsystem, 
+	"string flag_name", 
+	"Checks whether one or more model subsystem flags  <a href=\"https://www.w3schools.com/\">Visit W3Schools.com!</a>  are set - this function can accept an arbitrary number of flag arguments.  The flag names can be any string that the alter-ship-flag SEXP operator supports.", 
+	"boolean", 
+	"Returns whether all flags are set, or nil if the subsystem is not valid")
+{
+	ship_subsys_h* sso;
+	const char* flag_name;
+
+	if (!ade_get_args(L, "os", l_Subsystem.GetPtr(&sso), &flag_name))
+		return ADE_RETURN_NIL;
+	int skip_args = 1;	// not 2 because there will be one more below
+
+	if (!sso->IsValid())
+		return ADE_RETURN_NIL;
+
+	do {
+		auto subsys_flag = Model::Subsystem_Flags::NUM_VALUES;
+
+		for (size_t i = 0; i < (size_t)Num_subsystem_flags; i++) {
+			if (!stricmp(Subsystem_flags[i].name, flag_name)) {
+				subsys_flag = Subsystem_flags[i].def;
+				break;
+			}
+		}
+
+		if (subsys_flag == Model::Subsystem_Flags::NUM_VALUES) {
+			Warning(LOCATION, "Subsystem flag '%s' not found!", flag_name);
+			return ADE_RETURN_FALSE;
+		}
+
+		// read the next flag
+		internal::Ade_get_args_skip = ++skip_args;
+	} while (ade_get_args(L, "|s", &flag_name) > 0);
+
+	// if we're still here, all the flags we were looking for were present
+	return ADE_RETURN_TRUE;
+}
+
 ADE_FUNC(hasFired, l_Subsystem, NULL, "Determine if a subsystem has fired", "boolean", "true if if fired, false if not fired, or nil if invalid. resets fired flag when called.")
 {
 	ship_subsys_h *sso;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1464,6 +1464,9 @@ private:
 extern flag_def_list_new<Ship::Info_Flags> Ship_flags[];
 extern const size_t Num_ship_flags;
 
+extern flag_def_list_new<Model::Subsystem_Flags> Subsystem_flags[];
+extern const size_t Num_subsystem_flags;
+
 extern int Num_wings;
 extern ship Ships[MAX_SHIPS];
 extern ship	*Player_ship;


### PR DESCRIPTION
`getModelFlag` following the  same general API as `get/setFlag` on ships.