### PR TITLE
Small fix for `turret_next_fire_pos` in beam-fire

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -19551,6 +19551,7 @@ void sexp_beam_fire(int node, bool at_coords)
 		fire_info.fire_method = BFM_TURRET_FORCE_FIRED;
 
 		beam_fire(&fire_info);
+		fire_info.turret->turret_next_fire_pos++;
 	} else {
 		// it would appear the turret doesn't have any beam weapons
 		Warning(LOCATION, "Couldn't fire turret on ship %s; subsystem %s has no beam weapons", CTEXT(node), CTEXT(CDR(node)));


### PR DESCRIPTION
This ensures that when using beam-fire SEXPs the turrets will properly increment `turret_next_fire_pos` and cycle through its fire points. `beam_fire()` does not handle this, and it must be handled by the caller.