### PR TITLE
Minor lighting shader fixes

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -197,6 +197,6 @@ void main()
 	vec3 halfVec = normalize(lightDir + eyeDir);
 	float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(1.0);
-	fragmentColor.rgb = computeLighting(specColor.rgb, diffColor, lightDir, normal.xyz, halfVec, eyeDir, alpha, area_normalisation, fresnel, NdotL).rgb * diffuseLightColor * attenuation;
+	fragmentColor.rgb = computeLighting(specColor.rgb, diffColor, lightDir, normal.xyz, halfVec, eyeDir, roughness, fresnel, NdotL).rgb * diffuseLightColor * attenuation * area_normalisation;
 	fragOut0 = max(fragmentColor, vec4(0.0));
 }

--- a/code/def_files/data/effects/lighting.sdr
+++ b/code/def_files/data/effects/lighting.sdr
@@ -24,9 +24,10 @@ float GeometrySchlickGGX(float dotAB, float k)
 {
     return dotAB / (dotAB * (1.0f - k) + k);
 }
-vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float alpha, float area_normalisation, float fresnelFactor, float dotNL)
+vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float roughness, float fresnelFactor, float dotNL)
 {
-
+	float alpha = roughness * roughness;
+	float alphaSqr = alpha * alpha;
 	float dotNH = clamp(dot(normal, halfVec), 0.0f, 1.0f);
 	float dotNV = clamp(dot(normal, view), 0.0f, 1.0f);
 
@@ -35,16 +36,16 @@ vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 ha
 	// Cook-Torrance BRDF Model (Specular Reflection) = Distibution * Fresnel * Geometry / (4*dotNV*dotNL)
 
 	// Distribution Term - Trowbridge-Reitz GGX
-	float alphaSqr = alpha * alpha;
-	float denom = dotNH * dotNH * (alphaSqr - 1.0f) + 1.001f; // Extra .001 to prevent div 0
+	
+	float denom = dotNH * dotNH * (alphaSqr - 1.0f) + 1.0001f; // Extra .0001 to prevent div 0
 	float distribution = alphaSqr / (PI * denom * denom);
 
 	// Fresnel Term - Fresnel-Schlick
 	vec3 fresnel = mix(specColor, FresnelSchlick(halfVec, view, specColor), fresnelFactor);
 
 	// Geometry Term - Schlick-GGX approximation
-	float alphaPrime = 2.0 - sqrt(alpha);
-	float k = alphaPrime * alphaPrime / 8.0f;
+	float r = roughness + 1.0;
+	float k = r * r / 8.0f;
 	// Smith's method: 
 	// Microsurfaces block light rays coming in from the light 
 	// AND block light rays reflecting to the camera.
@@ -65,12 +66,12 @@ vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 ha
 	return (specular + diffuse) * dotNL;
 }
 
-vec3 computeLighting(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float alpha, float area_normalisation, float fresnelFactor, float dotNL) 
+vec3 computeLighting(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float roughness, float fresnelFactor, float dotNL) 
 {
 	#ifdef FLAG_LIGHT_MODEL_BLINN_PHONG
 	return SpecularBlinnPhong(specColor, light, normal, halfVec, 32, fresnelFactor, dotNL);
 	#else
-	return ComputeGGX(specColor, diffColor, light, normal, halfVec, view, alpha, area_normalisation, fresnelFactor, dotNL);
+	return ComputeGGX(specColor, diffColor, light, normal, halfVec, view, roughness, fresnelFactor, dotNL);
 	#endif
 }
 

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -209,7 +209,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		float NdotL = clamp(dot(normal, lightDir), 0.0f, 1.0f);
 		// Ambient, Diffuse, and Specular
 		lightDiffuse += (lights[i].diffuse_color.rgb * diffuseFactor * NdotL * attenuation) * shadow;
-		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, alpha, 1.0, fresnel, NdotL) * attenuation * shadow;
+		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, roughness, fresnel, NdotL) * attenuation * shadow;
 	}
 	return diffuseMaterial * lightAmbient + lightSpecular;
 }


### PR DESCRIPTION
While working on shader culling, @EatThePath noticed some issues with rough dielectric surfaces being too shiny at sharp angles. Through a process of elimination he narrowed it down to the geometry term using the wrong equation for surface roughness. 

While fixing, I also noticed the `area_normalisation` term that stops wide beams from being too bright wasn't actually in use, so that's been applied to deferred lighting.

 To prevent further mistakes, there's some minor cleanup to make it more clear what we're doing. (This also gets rid of a sqrt() call, so hopefully there's some optimisation there)