### PR TITLE
Modular medals

### DIFF
--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -29,6 +29,7 @@
 #include "network/multi_pmsg.h"
 #include "playerman/player.h"
 #include "pilotfile/pilotfile.h"
+#include "stats/medals.h"
 
 // -----------------------------------------------------------------------------------
 // FREESPACE MASTER TRACKER DEFINES/VARS
@@ -882,8 +883,8 @@ void multi_stats_fs_to_tracker(scoring_struct *fs, vmt_stats_struct *vmt, player
 	vmt->last_flown = static_cast<unsigned int>(fs->last_flown);
 
 	// medals and ship kills are stored in a single array, medals first
-	Assert(fs->medal_counts.size() >= static_cast<size_t>(Num_medals));
-	vmt->num_medals = static_cast<unsigned char>(Num_medals);
+	Assert(fs->medal_counts.size() >= Medals.size());
+	vmt->num_medals = static_cast<unsigned char>(Medals.size());
 
 	if (vmt->num_medals > MAX_FS2OPEN_COUNTS) {
 		vmt->num_medals = MAX_FS2OPEN_COUNTS;
@@ -948,7 +949,7 @@ void multi_stats_tracker_to_fs(vmt_stats_struct *vmt,scoring_struct *fs)
 
 	Assert(count <= MAX_FS2OPEN_COUNTS);
 
-	const size_t max_medals = std::max(static_cast<size_t>(Num_medals), static_cast<size_t>(vmt->num_medals));
+	const size_t max_medals = std::max(Medals.size(), static_cast<size_t>(vmt->num_medals));
 	fs->medal_counts.assign(max_medals, 0);
 
 	for (size_t idx = 0, idx2 = 0; idx < count; ++idx) {

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -49,6 +49,7 @@
 #include "network/multi_pmsg.h"
 #include "object/object.h"
 #include "object/objectshield.h"
+#include "stats/medals.h"
 #include "ship/ship.h"
 #include "weapon/weapon.h"
 #include "hud/hudreticle.h"
@@ -6572,11 +6573,11 @@ void send_player_stats_block_packet(net_player *pl, int stats_code, net_player *
 			idx += MAX_SHIPS_PER_PACKET;
 		}
 
-		Assert( (Num_medals >= 0) && (Num_medals < USHRT_MAX) );
-		ADD_USHORT( (ushort)Num_medals );
+		Assert( ((int)Medals.size() >= 0) && ((int)Medals.size() < USHRT_MAX) );
+		ADD_USHORT( (ushort)Medals.size() );
 
 		// medal information
-		for(idx=0;idx<Num_medals;idx++){
+		for(idx=0;idx<(int)Medals.size();idx++){
 			i_tmp = sc->medal_counts[idx];
 			ADD_INT(i_tmp);
 		}
@@ -6748,7 +6749,7 @@ void process_player_stats_block_packet(ubyte *data, header *hinfo)
 		for (idx = 0; idx < num_medals; idx++) {
 			GET_INT(i_tmp);
 
-			if (idx < Num_medals) {
+			if (idx < (int)Medals.size()) {
 				sc->medal_counts[idx] = i_tmp;
 			}
 		}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3485,12 +3485,12 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				if ( type2 != SEXP_ATOM_STRING)
 					return SEXP_CHECK_TYPE_MISMATCH;
 
-				for (i = 0; i < Num_medals; i++) {
+				for (i = 0; i < (int)Medals.size(); i++) {
 					if ( !stricmp(CTEXT(node), Medals[i].name) )
 						break;
 				}
 
-				if ( i == Num_medals )
+				if (i == (int)Medals.size())
 					return SEXP_CHECK_INVALID_MEDAL_NAME;
 				break;
 
@@ -9090,7 +9090,7 @@ int sexp_was_medal_granted(int n)
 
 	auto medal_name = CTEXT(n);
 
-	for (int i=0; i<Num_medals; ++i) {
+	for (int i = 0; i < (int)Medals.size(); ++i) {
 		if (!stricmp(medal_name, Medals[i].name)) {
 			if (Player->stats.m_medal_earned == i) {
 				return SEXP_TRUE;
@@ -15083,12 +15083,12 @@ void sexp_grant_medal(int n)
 		Warning(LOCATION, "Cannot grant more than one medal per mission!  New medal '%s' will replace old medal '%s'!", medal_name, Medals[Player->stats.m_medal_earned].name);
 	}
 
-	for (i = 0; i < Num_medals; i++ ) {
+	for (i = 0; i < (int)Medals.size(); i++) {
 		if ( !stricmp(medal_name, Medals[i].name) )
 			break;
 	}
 
-	if ( i < Num_medals ) {
+	if (i < (int)Medals.size()) {
 		Player->stats.m_medal_earned = i;
 
 		if ( Game_mode & GM_MULTIPLAYER ) {

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -215,9 +215,9 @@ void pilotfile::csg_write_info()
 	}
 
 	// medals list
-	cfwrite_int(Num_medals, cfp);
+	cfwrite_int((int)Medals.size(), cfp);
 
-	for (idx = 0; idx < Num_medals; idx++) {
+	for (idx = 0; idx < (int)Medals.size(); idx++) {
 		cfwrite_string_len(Medals[idx].name, cfp);
 	}
 
@@ -417,7 +417,7 @@ void pilotfile::csg_write_missions()
 			}
 
 			// medals earned (scoring)
-			for (j = 0; j < Num_medals; j++) {
+			for (j = 0; j < (int)Medals.size(); j++) {
 				cfwrite_int(missionp->stats.medal_counts[j], cfp);
 			}
 		}
@@ -799,7 +799,7 @@ void pilotfile::csg_write_stats()
 	}
 
 	// medals earned (scoring)
-	for (idx = 0; idx < Num_medals; idx++) {
+	for (idx = 0; idx < (int)Medals.size(); idx++) {
 		cfwrite_int(p->stats.medal_counts[idx], cfp);
 	}
 

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -204,7 +204,7 @@ void pilotfile_convert::csg_import_ships_weapons()
 	}
 
 	// create list of medals (since it's missing from the old files)
-	list_size = Num_medals;
+	list_size = (int)Medals.size();
 
 	for (idx = 0; idx < list_size; idx++) {
 		ilist.name = Medals[idx].name;

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -209,7 +209,7 @@ static medal_stuff* get_medal_pointer(char* medal_name)
 	return nullptr;
 }
 
-static int get_medal_position(char* medal_name)
+static int get_medal_position(const char* medal_name)
 {
 	for (int i = 0; i < (int)Medals.size(); i++) {
 		if (!stricmp(medal_name, Medals[i].name)) {

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -197,7 +197,7 @@ const char* medal_stuff::get_display_name() const {
 	}
 }
 
-static medal_stuff* get_medal_pointer(char* medal_name)
+static medal_stuff* get_medal_pointer(const char* medal_name)
 {
 	for (int i = 0; i < (int)Medals.size(); i++) {
 		if (!stricmp(medal_name, Medals[i].name)) {
@@ -340,7 +340,7 @@ void parse_medals_table(const char* filename)
 				display_p->coords[GR_640].y = Default_medal_coords[GR_640][Medals.size()][1];
 			}
 			else {
-				Warning(LOCATION, "No default GR_640 position for medal '%s'!", medal_p->name);
+				error_display(0, "No default GR_640 position for medal '%s'!", medal_p->name);
 				display_p->coords[GR_640].x = 0;
 				display_p->coords[GR_640].y = 0;
 			}
@@ -353,7 +353,7 @@ void parse_medals_table(const char* filename)
 				display_p->coords[GR_1024].y = Default_medal_coords[GR_1024][Medals.size()][1];
 			}
 			else {
-				Warning(LOCATION, "No default GR_1024 position for medal '%s'!", medal_p->name);
+				error_display(0, "No default GR_1024 position for medal '%s'!", medal_p->name);
 				display_p->coords[GR_1024].x = 0;
 				display_p->coords[GR_1024].y = 0;
 			}
@@ -371,7 +371,7 @@ void parse_medals_table(const char* filename)
 				strcpy_s(medal_p->debrief_bitmap, Default_debriefing_bitmaps[Medals.size()]);
 			}
 			else {
-				Warning(LOCATION, "No default debriefing bitmap for medal '%s'!", medal_p->name);
+				error_display(0, "No default debriefing bitmap for medal '%s'!", medal_p->name);
 				strcpy_s(medal_p->debrief_bitmap, "");
 			}
 
@@ -416,7 +416,7 @@ void parse_medals_table(const char* filename)
 					if (optional_string("+Persona:")) {
 						stuff_int(&persona);
 						if (persona < 0) {
-							Warning(LOCATION,
+							error_display(0,
 								"Debriefing text for %s is assigned to an invalid persona: %i (must be 0 or "
 								"greater).\n",
 								medal_p->name,
@@ -427,7 +427,7 @@ void parse_medals_table(const char* filename)
 					medal_p->promotion_text[persona] = SCP_string(buf);
 				}
 				if (medal_p->promotion_text.find(-1) == medal_p->promotion_text.end()) {
-					Warning(LOCATION, "%s medal is missing default debriefing text.\n", medal_p->name);
+					error_display(0, "%s medal is missing default debriefing text.\n", medal_p->name);
 					medal_p->promotion_text[-1] = "";
 				}
 			}

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -27,8 +27,6 @@
 #include "cmdline/cmdline.h"
 #endif
 
-int Num_medals = 0;
-
 // define for the medal information
 SCP_vector<medal_stuff> Medals;
 
@@ -484,8 +482,6 @@ void medals_init()
 	manage_badges();
 
 	Rank_medal_index = get_medal_position("Rank");
-	Num_medals = (int)Medals.size();
-	mprintf(("MEDALS count of num_medals is %i while push_back is %i\n", Num_medals, Medals.size()));
 
 	// be sure that we know where the rank is
 	if (Rank_medal_index < 0) {
@@ -512,7 +508,7 @@ DCF(medals, "Grant or revoke medals")
 	{
 		dc_printf("You have the following medals:\n");
 
-		for (i = 0; i < Num_medals; i++)
+		for (i = 0; i < (int)Medals.size(); i++)
 		{
 			if (Player->stats.medal_counts[i] > 0)
 				dc_printf("%d %s\n", Player->stats.medal_counts[i], Medals[i].name);
@@ -522,14 +518,14 @@ DCF(medals, "Grant or revoke medals")
 	}
 
 	if (dc_optional_string("all")) {
-		for (i = 0; i < Num_medals; i++) {
+		for (i = 0; i < (int)Medals.size(); i++) {
 			Player->stats.medal_counts[i]++;
 		}
 		dc_printf("Granted all medals\n");
 		return;
 
 	} else if (dc_optional_string("clear")) {
-		for (i = 0; i < Num_medals; i++) {
+		for (i = 0; i < (int)Medals.size(); i++) {
 			Player->stats.medal_counts[i] = 0;
 		}
 		dc_printf("Cleared all medals\n");
@@ -551,7 +547,7 @@ DCF(medals, "Grant or revoke medals")
 	}
 
 	if (dc_maybe_stuff_int(&idx)) {
-		if (idx < 0 || idx >= Num_medals)
+		if (idx < 0 || idx >= (int)Medals.size())
 		{
 			dc_printf("Medal index %d is out of range\n", idx);
 			return;
@@ -563,7 +559,7 @@ DCF(medals, "Grant or revoke medals")
 	}
 
 	dc_printf("The following medals are available:\n");
-	for (i = 0; i < Num_medals; i++) {
+	for (i = 0; i < (int)Medals.size(); i++) {
 		dc_printf("%d: %s\n", i, Medals[i].name);
 	}
 }
@@ -580,13 +576,13 @@ void medal_main_init(player *pl, int mode)
 
 #ifndef NDEBUG
 	if (Cmdline_gimme_all_medals){
-		for (idx=0; idx < Num_medals; idx++){
+		for (idx = 0; idx < (int)Medals.size(); idx++) {
 			Medals_player->stats.medal_counts[idx] = 1;
 		}
 	}
 #endif
 
-	for (idx=0; idx < Num_medals; idx++) {
+	for (idx = 0; idx < (int)Medals.size(); idx++) {
 		if ((Medals[idx].available_from_start) && (Medals_player->stats.medal_counts[idx] < 1)) {
 			Medals_player->stats.medal_counts[idx] = 1;
 		}
@@ -776,7 +772,12 @@ int medal_main_do()
 	blit_medals();
 	blit_callsign();
 
-	region = snazzy_menu_do((ubyte*)Medals_mask->data, Medals_mask_w, Medals_mask_h, Num_medals, Medal_regions, &selected);
+	region = snazzy_menu_do((ubyte*)Medals_mask->data,
+		Medals_mask_w,
+		Medals_mask_h,
+		(int)Medals.size(),
+		Medal_regions,
+		&selected);
 	if (region == Rank_medal_index)
 	{
 		blit_label(Ranks[Player_score->rank].name, 1);
@@ -847,7 +848,7 @@ void init_medal_bitmaps()
 	int idx;
 	Assert(Player_score);
 
-	for (idx=0; idx<Num_medals; idx++) {
+	for (idx = 0; idx < (int)Medals.size(); idx++) {
 		Medal_display_info[idx].bitmap = -1;
 
 		if (Player_score->medal_counts[idx] > 0) {
@@ -907,10 +908,10 @@ void init_snazzy_regions()
 
 	// well, we need regions in an array (versus a vector), so...
 	Assert(Medal_regions == NULL);
-	Medal_regions = new MENU_REGION[Num_medals];
+	Medal_regions = new MENU_REGION[(int)Medals.size()];
 
 	// snazzy regions for the medals/ranks, etc.
-	for (idx=0; idx<Num_medals; idx++) {
+	for (idx = 0; idx < (int)Medals.size(); idx++) {
 		snazzy_menu_add_region(&Medal_regions[idx], "", idx, 0);
 	}
 }
@@ -920,7 +921,7 @@ void blit_medals()
 {
 	int idx;
 
-	for (idx=0; idx<Num_medals; idx++) {
+	for (idx = 0; idx < (int)Medals.size(); idx++) {
 		if (idx != Rank_medal_index && Player_score->medal_counts[idx] > 0) {
 #ifndef NDEBUG
 			// this can happen if gimmemedals was used on the medal screen
@@ -944,7 +945,7 @@ int medals_info_lookup(const char *name)
 		return -1;
 	}
 
-	for (int i = 0; i < Num_medals; i++) {
+	for (int i = 0; i < (int)Medals.size(); i++) {
 		if ( !stricmp(name, Medals[i].name) ) {
 			return i;
 		}

--- a/code/stats/medals.h
+++ b/code/stats/medals.h
@@ -35,6 +35,7 @@ public:
 	bool version_starts_at_1;
 	bool available_from_start;
 	int	kills_needed;
+	int mask_index;
 
 	//If this is a badge (kills_needed > 0)
 	char voice_base[MAX_FILENAME_LEN];

--- a/code/stats/medals.h
+++ b/code/stats/medals.h
@@ -18,7 +18,6 @@
 class scoring_struct;
 class player;
 
-#define MAX_BADGES				3
 extern int Rank_medal_index;
 
 extern scoring_struct *Player_score;
@@ -48,7 +47,7 @@ public:
 
 extern SCP_vector<medal_stuff> Medals;
 
-extern void parse_medal_tbl();
+extern void medals_init();
 
 // modes for this screen
 #define MM_NORMAL				0		// normal - run through the state code

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -198,7 +198,7 @@ void scoring_struct::init()
 	score = 0;
 	rank = RANK_ENSIGN;
 
-	medal_counts.assign(Num_medals, 0);
+	medal_counts.assign((int)Medals.size(), 0);
 
 	memset(kills, 0, sizeof(kills));
 	assists = 0;
@@ -420,7 +420,7 @@ void scoring_eval_badges(scoring_struct *sc)
 	// total_kills should now reflect the number of kills on hostile fighters/bombers.  Check this number
 	// against badge kill numbers, and award the appropriate badges as neccessary.
 	int last_badge_kills = 0;
-	for (auto i = 0; i < Num_medals; i++ ) {
+	for (auto i = 0; i < (int)Medals.size(); i++) {
 		if ( total_kills >= Medals[i].kills_needed
 			&& Medals[i].kills_needed > last_badge_kills
 			&& Medals[i].kills_needed > 0 )

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -419,16 +419,19 @@ void scoring_eval_badges(scoring_struct *sc)
 
 	// total_kills should now reflect the number of kills on hostile fighters/bombers.  Check this number
 	// against badge kill numbers, and award the appropriate badges as neccessary.
+	// Now properly awards all appropriate badges regardless of their position in the medals vector,
+	// but keeps the highest award to show to the player - Mjn
 	int last_badge_kills = 0;
 	for (auto i = 0; i < (int)Medals.size(); i++) {
 		if ( total_kills >= Medals[i].kills_needed
-			&& Medals[i].kills_needed > last_badge_kills
 			&& Medals[i].kills_needed > 0 )
 		{
-			last_badge_kills = Medals[i].kills_needed;
 			if (sc->medal_counts[i] < 1) {
 				sc->medal_counts[i] = 1;
-				sc->m_badge_earned.push_back(i);
+				if (Medals[i].kills_needed > last_badge_kills) {
+					last_badge_kills = Medals[i].kills_needed;
+					sc->m_badge_earned.push_back(i);
+				}
 			}
 		}
 	}

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -23,7 +23,6 @@ class object;
 
 #define NUM_MEDALS_FS2		18
 #define NUM_MEDALS_FS1		16
-extern int Num_medals;
 
 #define NUM_RANKS				10
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -417,7 +417,7 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	ai_profiles_init();
 	armor_init();
 	weapon_init();
-	parse_medal_tbl();			// get medal names for sexpression usage
+	medals_init();			// get medal names for sexpression usage
 	glowpoint_init();
 	ship_init();
 	parse_init();

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -6718,7 +6718,7 @@ sexp_list_item *sexp_tree::get_listing_opf_medal_name()
 	int i;
 	sexp_list_item head;
 
-	for (i=0; i<Num_medals; i++)
+	for (i = 0; i < (int)Medals.size(); i++)
 	{
 		// don't add Rank or the Ace badges
 		if ((i == Rank_medal_index) || (Medals[i].kills_needed > 0))

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1905,7 +1905,7 @@ void game_init()
 
 	parse_rank_tbl();
 	parse_traitor_tbl();
-	parse_medal_tbl();
+	medals_init();
 
 	cutscene_init();
 	key_init();

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -195,7 +195,7 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	weapon_init();
 
 	listener(SubSystem::Medals);
-	parse_medal_tbl();            // get medal names for sexpression usage
+	medals_init();            // get medal names for sexpression usage
 
 	listener(SubSystem::Glowpoints);
 	glowpoint_init();

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4522,7 +4522,7 @@ sexp_list_item* sexp_tree::get_listing_opf_medal_name() {
 	int i;
 	sexp_list_item head;
 
-	for (i = 0; i < Num_medals; i++) {
+	for (i = 0; i < (int)Medals.size(); i++) {
 		// don't add Rank or the Ace badges
 		if ((i == Rank_medal_index) || (Medals[i].kills_needed > 0)) {
 			continue;


### PR DESCRIPTION
Makes medals.tbl extendable with -mdl.tbm. Ended up being a bigger PR than expected because it fixes a number of related issues to make it easier to deal with modular medals including better handling of kill count badge promotion to remove requiring badges be tabled in order of kill count, better handling of finding the Rank medal, adding the ability to specify a mask value for each medal, and entirely removing `Num_medals` in favor of `Medals.size()`.