### PR TITLE
Modular rank table

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -676,7 +676,7 @@ void lcl_replace_stuff(SCP_string &text, bool force)
 	if (!Fred_running && Player != nullptr)
 	{
 		replace_all(text, "$callsign", Player->callsign);
-		replace_all(text, "$rank", Ranks[Player->stats.rank].name);
+		replace_all(text, "$rank", Ranks[verify_rank(Player->stats.rank)].name);
 	}
 
 	replace_all(text, "$quote", "\"");

--- a/code/network/multi_pinfo.cpp
+++ b/code/network/multi_pinfo.cpp
@@ -683,7 +683,7 @@ void multi_pinfo_build_stats()
 	}	
 
 	// rank
-	strcpy_s(Multi_pinfo_stats_vals[MPI_RANK],Ranks[sc->rank].name);
+	strcpy_s(Multi_pinfo_stats_vals[MPI_RANK], Ranks[verify_rank(sc->rank)].name);
 
 	// primary shots fired
 	sprintf(Multi_pinfo_stats_vals[MPI_PSHOTS_FIRED],"%u",sc->p_shots_fired);

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -4584,7 +4584,7 @@ void multi_pxo_pinfo_build_vals()
 
 	// rank
 	memset(Multi_pxo_pinfo_vals[1], 0, 50);	
-	multi_sg_rank_build_name(Ranks[fs->stats.rank].name, Multi_pxo_pinfo_vals[1]);	
+	multi_sg_rank_build_name(Ranks[verify_rank(fs->stats.rank)].name, Multi_pxo_pinfo_vals[1]);	
 	font::force_fit_string(Multi_pxo_pinfo_vals[1], 49, Multi_pxo_pinfo_coords[gr_screen.res][2] - (Multi_pxo_pinfo_val_x[gr_screen.res] - Multi_pxo_pinfo_coords[gr_screen.res][0]));
 
 	// kills

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -2305,7 +2305,7 @@ void multi_sg_select_rank_default();
 int multi_start_game_rank_from_name( char *rank ) {
 	int i;
 
-	for ( i = 0; i <= MAX_FREESPACE2_RANK; i++ ) {
+	for ( i = 0; i <= ((int)Ranks.size() - 1); i++ ) {
 		if ( !stricmp(Ranks[i].name, rank) ) {
 			return i;
 		}
@@ -2731,7 +2731,7 @@ void multi_sg_init_gamenet()
 
 	Multi_sg_netgame->security = Random::next(1, 32766);			// get some random security number	
 	Multi_sg_netgame->mode = NG_MODE_OPEN;
-	Multi_sg_netgame->rank_base = RANK_ENSIGN;
+	Multi_sg_netgame->rank_base = 0;
 	if(Multi_sg_netgame->security < 16){
 		Multi_sg_netgame->security += 16;
 	}
@@ -2860,7 +2860,7 @@ void multi_sg_rank_scroll_down()
 		return;
 	}
 	
-	if((NUM_RANKS - Multi_sg_rank_start) > Multi_sg_rank_max_display[gr_screen.res]){
+	if(((int)Ranks.size() - Multi_sg_rank_start) > Multi_sg_rank_max_display[gr_screen.res]){
 		Multi_sg_rank_start++;
 		gamesnd_play_iface(InterfaceSounds::SCROLL);
 	} else {
@@ -2883,7 +2883,7 @@ void multi_sg_rank_display_stuff()
 	line_height = gr_get_font_height() + 1;
 	idx = Multi_sg_rank_start;
 	count = 0;
-	while((count < NUM_RANKS) && (count < Multi_sg_rank_max_display[gr_screen.res]) && (idx < NUM_RANKS)){	
+	while ((count < (int)Ranks.size()) && (count < Multi_sg_rank_max_display[gr_screen.res]) && (idx < (int)Ranks.size())) {	
 		// if its the selected item, then color it differently
 		if(idx == Multi_sg_rank_select){
 			gr_set_color_fast(&Color_text_selected);
@@ -2924,7 +2924,7 @@ void multi_sg_rank_process_select()
 		Multi_sg_rank_button.get_mouse_pos(NULL,&y);
 		item = y / (gr_get_font_height() + 1);
 		
-		if(item + Multi_sg_rank_start < NUM_RANKS){		
+		if (item + Multi_sg_rank_start < (int)Ranks.size()) {		
 			// evaluate whether this rank is valid for the guy to pick		
 			if(multi_sg_rank_select_valid(item + Multi_sg_rank_start)){
 				gamesnd_play_iface(InterfaceSounds::USER_SELECT);
@@ -2937,7 +2937,7 @@ void multi_sg_rank_process_select()
 				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 
 				memset(string,0,255);
-				sprintf(string,XSTR("Illegal value for a host of your rank (%s)\n",784),Ranks[Net_player->m_player->stats.rank].name);
+				sprintf(string,XSTR("Illegal value for a host of your rank (%s)\n",784),Ranks[verify_rank(Net_player->m_player->stats.rank)].name);
 				multi_common_add_notify(string);
 			}
 		}		

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -2305,7 +2305,7 @@ void multi_sg_select_rank_default();
 int multi_start_game_rank_from_name( char *rank ) {
 	int i;
 
-	for ( i = 0; i <= ((int)Ranks.size() - 1); i++ ) {
+	for ( i = 0; i < ((int)Ranks.size()); i++ ) {
 		if ( !stricmp(Ranks[i].name, rank) ) {
 			return i;
 		}

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -245,7 +245,7 @@ void pilotfile::update_stats_backout(scoring_struct *stats, bool training)
 
 	if (stats->m_promotion_earned >= 0) {
 		// deal with a multi-rank promotion mission
-		for (i = 0; i < MAX_FREESPACE2_RANK; ++i) {
+		for (i = 0; i < ((int)Ranks.size() - 1); ++i) {
 			if (p_stats->score >= Ranks[i].points) {
 				p_stats->rank = i;
 			}

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -245,7 +245,7 @@ void pilotfile::update_stats_backout(scoring_struct *stats, bool training)
 
 	if (stats->m_promotion_earned >= 0) {
 		// deal with a multi-rank promotion mission
-		for (i = 0; i < ((int)Ranks.size() - 1); ++i) {
+		for (i = 0; i < ((int)Ranks.size()); ++i) {
 			if (p_stats->score >= Ranks[i].points) {
 				p_stats->rank = i;
 			}

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -48,7 +48,7 @@ typedef struct index_list_t {
 // special stats struct, since our use here is not content specific
 typedef struct scoring_special_t {
 	int score{ 0 };
-	int rank{ RANK_ENSIGN };
+	int rank{ 0 };
 	int assists{ 0 };
 	int kill_count{ 0 };
 	int kill_count_ok{ 0 };

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -143,7 +143,7 @@ void init_new_pilot(player *p, int reset)
 	Pilot.reset_stats();
 	
 	p->stats.score = 0;
-	p->stats.rank = RANK_ENSIGN;	
+	p->stats.rank = 0;	
 
 	p->tips = 1;
 

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -435,7 +435,7 @@ DCF(medals, "Grant or revoke medals")
 			if (Player->stats.medal_counts[i] > 0)
 				dc_printf("%d %s\n", Player->stats.medal_counts[i], Medals[i].name);
 		}
-		dc_printf("%s\n", Ranks[Player->stats.rank].name);
+		dc_printf("%s\n", Ranks[verify_rank(Player->stats.rank)].name);
 		return;
 	}
 
@@ -454,17 +454,17 @@ DCF(medals, "Grant or revoke medals")
 		return;
 
 	} else if (dc_optional_string("promote")) {
-		if (Player->stats.rank < MAX_FREESPACE2_RANK) {
+		if (Player->stats.rank < ((int)Ranks.size() - 1)) {
 			Player->stats.rank++;
 		}
-		dc_printf("Promoted to %s\n", Ranks[Player->stats.rank].name);
+		dc_printf("Promoted to %s\n", Ranks[verify_rank(Player->stats.rank)].name);
 		return;
 
 	} else if (dc_optional_string("demote")) {
 		if (Player->stats.rank > 0) {
 			Player->stats.rank--;
 		}
-		dc_printf("Demoted to %s\n", Ranks[Player->stats.rank].name);
+		dc_printf("Demoted to %s\n", Ranks[verify_rank(Player->stats.rank)].name);
 		return;
 	}
 
@@ -697,7 +697,7 @@ int medal_main_do()
 	region = snazzy_menu_do((ubyte*)Medals_mask->data, Medals_mask_w, Medals_mask_h, Num_medals, Medal_regions, &selected);
 	if (region == Rank_medal_index)
 	{
-		blit_label(Ranks[Player_score->rank].name, 1);
+		blit_label(Ranks[verify_rank(Player_score->rank)].name, 1);
 	}
 	else switch (region)
 	{
@@ -809,13 +809,13 @@ void init_medal_bitmaps()
 	// load up rank insignia
 	if (gr_screen.res == GR_1024) {
 		char filename[NAME_LENGTH];
-		if (snprintf(filename, NAME_LENGTH, "2_%s", Ranks[Player_score->rank].bitmap) >= NAME_LENGTH) {
+		if (snprintf(filename, NAME_LENGTH, "2_%s", Ranks[verify_rank(Player_score->rank)].bitmap) >= NAME_LENGTH) {
 			// Make sure the string is null terminated
 			filename[NAME_LENGTH - 1] = '\0';
 		}
 		Rank_bm = bm_load(filename);
 	} else {
-		Rank_bm = bm_load(Ranks[Player_score->rank].bitmap);
+		Rank_bm = bm_load(Ranks[verify_rank((int)Player_score->rank)].bitmap);
 	}
 }
 

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -46,7 +46,7 @@ extern debriefing Traitor_debriefing;
 traitor_stuff Traitor;
 
 // these tables are overwritten with the values from rank.tbl
-rank_stuff Ranks[NUM_RANKS];
+SCP_vector<rank_stuff> Ranks;
 
 // scoring scale factors by skill level
 float Scoring_scale_factors[NUM_SKILL_LEVELS] = {
@@ -57,32 +57,66 @@ float Scoring_scale_factors[NUM_SKILL_LEVELS] = {
 	1.25f					// insane
 };
 
-void parse_rank_tbl()
+static void rank_stuff_init(rank_stuff* ranki)
+{
+	ranki->name[0] = '\0';
+	ranki->promotion_text = {};
+	ranki->points = 1;
+	ranki->bitmap[0] = '\0';
+	ranki->promotion_voice_base[0] = '\0';
+}
+
+void parse_rank_table(const char* filename)
 {
 	try
 	{
-		read_file_text("rank.tbl", CF_TYPE_TABLES);
+		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
 
 		// parse in all the rank names
-		int idx = 0;
-		skip_to_string("[RANK NAMES]");
+
+		//Retail compatibility
+		if (check_for_string("[RANK NAMES]")) {
+			skip_to_string("[RANK NAMES]");
+		}
+		if (check_for_string("#Ranks")) {
+			skip_to_string("#Ranks");
+		}
+		
 		ignore_white_space();
 		while (required_string_either("#End", "$Name:"))
 		{
-			Assert(idx < NUM_RANKS);
+			//Assert(idx < NUM_RANKS);
+
+			rank_stuff rank_t;
+			rank_stuff_init(&rank_t);
+
+			//rank_stuff* rank_p;
+			// bool create_if_not_found = true;
 
 			required_string("$Name:");
-			stuff_string(Ranks[idx].name, F_NAME, NAME_LENGTH);
+			stuff_string(rank_t.name, F_NAME, NAME_LENGTH);
 
-			required_string("$Points:");
-			stuff_int(&Ranks[idx].points);
+			if (optional_string("$Points:")) {
+				stuff_int(&rank_t.points);
+			} else {
+				rank_t.points = ((int)Ranks.size() + 1);
+			}
 
-			required_string("$Bitmap:");
-			stuff_string(Ranks[idx].bitmap, F_NAME, MAX_FILENAME_LEN);
+			if (optional_string("$Bitmap:")) {
+				stuff_string(rank_t.bitmap, F_NAME, MAX_FILENAME_LEN);
+			}
 
-			required_string("$Promotion Voice Base:");
-			stuff_string(Ranks[idx].promotion_voice_base, F_NAME, MAX_FILENAME_LEN);
+			// Check here that the rank has a bitmap. If not, then error out
+			if (!stricmp(rank_t.bitmap, "")) {
+				error_display(1, "Missing valid bitmap file for rank %s", rank_t.name);
+			}
+
+			if (optional_string("$Promotion Voice Base:")) {
+				stuff_string(rank_t.promotion_voice_base, F_NAME, MAX_FILENAME_LEN);
+			} else {
+				strcpy(rank_t.promotion_voice_base, rank_t.name);
+			}
 
 			while (check_for_string("$Promotion Text:"))
 			{
@@ -99,35 +133,104 @@ void parse_rank_tbl()
 					stuff_int(&persona);
 					if (persona < 0)
 					{
-						Warning(LOCATION, "Debriefing text for %s rank is assigned to an invalid persona: %i (must be 0 or greater).\n", Ranks[idx].name, persona);
+						Warning(LOCATION,
+							"Debriefing text for %s rank is assigned to an invalid persona: %i (must be 0 or "
+							"greater).\n",
+							rank_t.name,
+							persona);
 						continue;
 					}
 				}
-				Ranks[idx].promotion_text[persona] = buf;
+				rank_t.promotion_text[persona] = buf;
 			}
 
-			if (Ranks[idx].promotion_text.find(-1) == Ranks[idx].promotion_text.end())
+			if (rank_t.promotion_text.find(-1) == rank_t.promotion_text.end())
 			{
-				Warning(LOCATION, "%s rank is missing default debriefing text.\n", Ranks[idx].name);
-				Ranks[idx].promotion_text[-1] = "";
+				Warning(LOCATION, "%s rank is missing default debriefing text.\n", rank_t.name);
+				rank_t.promotion_text[-1] = "";
 			}
 
-			idx++;
+			Ranks.push_back(rank_t);
+
 		}
 
 		required_string("#End");
 
-		// be sure that all rank points are in order
-		for (idx = 0; idx < NUM_RANKS - 1; idx++) {
-			if (Ranks[idx].points >= Ranks[idx + 1].points)
-				Warning(LOCATION, "Rank #%d (%s) has a higher \"$Points:\" value (%d) than the following rank (%s, %d points). This shouldn't actually crash FSO, but it might result in unexpected or incorrect behavior.\n", idx + 1, Ranks[idx].name, Ranks[idx].points, Ranks[idx+1].name, Ranks[idx+1].points);
-		}
 	}
 	catch (const parse::ParseException& e)
 	{
 		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", "rank.tbl", e.what()));
 		return;
 	}
+}
+
+void sort_ranks()
+{
+	bool shouldSort = false;
+
+	// be sure no ranks have equal point values
+	for (int i = 0; i < (int)Ranks.size(); i++) {
+		for (int j = (i + 1); j < (int)Ranks.size(); j++) {
+			if (Ranks[i].points == Ranks[j].points) {
+				Ranks[j].points++;
+				shouldSort = true;
+				mprintf(("Rank %s and %s are equal! Increasing %s to %i\n",
+					Ranks[i].name,
+					Ranks[j].name,
+					Ranks[j].name,
+					Ranks[j].points));
+			}
+		}
+	}
+
+	// be sure that all rank points are in order
+	for (int idx = 0; idx < (int)Ranks.size() - 1; idx++) {
+		if (Ranks[idx].points >= Ranks[idx + 1].points) {
+			shouldSort = true;
+		}
+	}
+
+	if (shouldSort) {
+		Warning(LOCATION,"Ranks were not ordered by points or had equal values adjusted. Sorting the ranks by point values!\n");
+
+		sort(Ranks.begin(), Ranks.end(), [](const rank_stuff& lhs, const rank_stuff& rhs) {
+			return lhs.points < rhs.points;
+		});
+
+		for (int i = 0; i < (int)Ranks.size(); i++) {
+			mprintf(("Rank %s is now in position %i\n", Ranks[i].name, i));
+		}
+	}
+}
+
+void rank_init()
+{
+
+	// first parse the default table
+	parse_rank_table("rank.tbl");
+
+	// parse any modular tables
+	//parse_modular_table("*-rnk.tbm", parse_rank_table);
+
+	if ((int)Ranks.size() <= 0) {
+		error_display(1, "No ranks have been defined in ranks.tbl. Must define at least one rank!");
+	}
+
+	sort_ranks();
+}
+
+//Provided as a way to prevent crashes due to ranks differing across mods-Mjn
+//If player rank is > max rank, returns max rank index, returns 0 if player rank < 0
+//else it returns player rank index
+int verify_rank(int ranki)
+{
+	if (ranki > ((int)Ranks.size() - 1)) {
+		return ((int)Ranks.size() - 1);
+	} else if (ranki < 0) {
+		return 0;
+	}
+
+	return ranki;
 }
 
 void parse_traitor_tbl()
@@ -196,7 +299,7 @@ void scoring_struct::init()
 {
 	flags = 0;
 	score = 0;
-	rank = RANK_ENSIGN;
+	rank = 0;
 
 	medal_counts.assign(Num_medals, 0);
 
@@ -376,7 +479,7 @@ void scoring_eval_rank( scoring_struct *sc )
 	
 		// if the player does indeed get promoted, we should change his mission score
 		// to reflect the difference between all time and new rank score
-		if ( old_rank < MAX_FREESPACE2_RANK ) {
+		if (old_rank < (Ranks.size() -1)) {
 			new_rank++;
 			if ( (sc->m_score + sc->score) < Ranks[new_rank].points )
 				sc->m_score = (Ranks[new_rank].points - sc->score);
@@ -386,7 +489,7 @@ void scoring_eval_rank( scoring_struct *sc )
 		// it is possible to get a negative mission score but that will
 		// never result in a degradation
 		score = sc->m_score + sc->score;
-		for (i=old_rank + 1; i<NUM_RANKS; i++) {
+		for (i=old_rank + 1; i<(int)Ranks.size(); i++) {
 			if ( score >= Ranks[i].points )
 				new_rank = i;
 		}
@@ -1362,7 +1465,7 @@ float scoring_get_scale_factor()
 void scoring_bash_rank(player *pl,int rank)
 {	
 	// if this is an invalid rank, do nothing
-	if((rank < RANK_ENSIGN) || (rank > RANK_ADMIRAL)){
+	if((rank < 0) || (rank > Ranks.size())){
 		nprintf(("General","Could not bash player rank - invalid value!!!\n"));
 		return;
 	}
@@ -1412,7 +1515,7 @@ DCF(rank, "changes player rank")
 
 void scoring_close()
 {
-	for(int i = 0; i<NUM_RANKS; i++) {
+	for (int i = 0; i < (int)Ranks.size(); i++) {
 		Ranks[i].promotion_text.clear();
 	}
 

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -73,7 +73,7 @@ static void rank_stuff_init(rank_stuff* ranki)
 {
 	ranki->name[0] = '\0';
 	ranki->promotion_text = {};
-	ranki->points = 1;
+	ranki->points = -1;
 	ranki->bitmap[0] = '\0';
 	ranki->promotion_voice_base[0] = '\0';
 }
@@ -138,7 +138,10 @@ void parse_rank_table(const char* filename)
 
 			if (optional_string("$Points:")) {
 				stuff_int(&rank_p->points);
-			} else {
+			} 
+			
+			// If points are not set then set it to index position + 1
+			if (rank_p->points == -1) {
 				rank_p->points = ((int)Ranks.size() + 1);
 			}
 
@@ -153,7 +156,10 @@ void parse_rank_table(const char* filename)
 
 			if (optional_string("$Promotion Voice Base:")) {
 				stuff_string(rank_p->promotion_voice_base, F_NAME, MAX_FILENAME_LEN);
-			} else {
+			} 
+
+			// If voice base is not set then set it to the rank name
+			if (rank_p->promotion_voice_base[0] == '\0') {
 				strcpy(rank_p->promotion_voice_base, rank_p->name);
 			}
 

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -516,7 +516,7 @@ void scoring_eval_rank( scoring_struct *sc )
 	
 		// if the player does indeed get promoted, we should change his mission score
 		// to reflect the difference between all time and new rank score
-		if (old_rank < (Ranks.size() -1)) {
+		if (old_rank < ((int)Ranks.size() -1)) {
 			new_rank++;
 			if ( (sc->m_score + sc->score) < Ranks[new_rank].points )
 				sc->m_score = (Ranks[new_rank].points - sc->score);
@@ -1502,7 +1502,7 @@ float scoring_get_scale_factor()
 void scoring_bash_rank(player *pl,int rank)
 {	
 	// if this is an invalid rank, do nothing
-	if((rank < 0) || (rank > Ranks.size())){
+	if((rank < 0) || (rank > (int)Ranks.size())){
 		nprintf(("General","Could not bash player rank - invalid value!!!\n"));
 		return;
 	}

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -57,7 +57,7 @@ float Scoring_scale_factors[NUM_SKILL_LEVELS] = {
 	1.25f					// insane
 };
 
-static rank_stuff* get_rank_pointer(char* rank_name)
+static rank_stuff* get_rank_pointer(const char* rank_name)
 {
 	for (int i = 0; i < (int)Ranks.size(); i++) {
 		if (!stricmp(rank_name, Ranks[i].name)) {
@@ -133,7 +133,7 @@ void parse_rank_table(const char* filename)
 					continue;
 				}
 				Ranks.push_back(rank_t);
-				rank_p = &Ranks[Ranks.size() - 1];
+				rank_p = &Ranks.back();
 			}
 
 			if (optional_string("$Points:")) {
@@ -215,13 +215,10 @@ void sort_ranks()
 	for (int i = 0; i < (int)Ranks.size(); i++) {
 		for (int j = (i + 1); j < (int)Ranks.size(); j++) {
 			if (Ranks[i].points == Ranks[j].points) {
-				Ranks[j].points++;
-				shouldSort = true;
-				mprintf(("Rank %s and %s are equal! Increasing %s to %i\n",
+				Error(LOCATION,
+					"Rank %s and %s have equal point values! This is not allowed.",
 					Ranks[i].name,
-					Ranks[j].name,
-					Ranks[j].name,
-					Ranks[j].points));
+					Ranks[j].name);
 			}
 		}
 	}

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -1505,7 +1505,7 @@ float scoring_get_scale_factor()
 void scoring_bash_rank(player *pl,int rank)
 {	
 	// if this is an invalid rank, do nothing
-	if((rank < 0) || (rank > (int)Ranks.size())){
+	if((rank < 0) || (rank >= (int)Ranks.size())){
 		nprintf(("General","Could not bash player rank - invalid value!!!\n"));
 		return;
 	}

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -25,19 +25,20 @@ class object;
 #define NUM_MEDALS_FS1		16
 extern int Num_medals;
 
-#define RANK_ENSIGN				0
-#define RANK_LT_JUNIOR			1
-#define RANK_LT					2
-#define RANK_LT_CMDR				3
-#define RANK_CMDR					4
-#define RANK_CAPTAIN				5
-#define RANK_COMMODORE			6
-#define RANK_REAR_ADMIRAL		7
-#define RANK_VICE_ADMIRAL		8
-#define RANK_ADMIRAL  			9
+//Ranks are no longer limited to the retail 10 and checks are against index position rather than arbitrary title - Mjn
+//#define RANK_ENSIGN				0
+//#define RANK_LT_JUNIOR			1
+//#define RANK_LT					2
+//#define RANK_LT_CMDR				3
+//#define RANK_CMDR					4
+//#define RANK_CAPTAIN				5
+//#define RANK_COMMODORE			6
+//#define RANK_REAR_ADMIRAL			7
+//#define RANK_VICE_ADMIRAL			8
+//#define RANK_ADMIRAL  			9
 
-#define MAX_FREESPACE1_RANK	RANK_COMMODORE
-#define MAX_FREESPACE2_RANK	RANK_ADMIRAL
+//#define MAX_FREESPACE1_RANK	RANK_COMMODORE
+//#define MAX_FREESPACE2_RANK	RANK_ADMIRAL
 
 
 /*

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -25,8 +25,6 @@ class object;
 #define NUM_MEDALS_FS1		16
 extern int Num_medals;
 
-#define NUM_RANKS				10
-
 #define RANK_ENSIGN				0
 #define RANK_LT_JUNIOR			1
 #define RANK_LT					2
@@ -142,10 +140,12 @@ public:
 	bool operator!=(const scoring_struct& rhs) const;
 };
 
-extern rank_stuff Ranks[NUM_RANKS];
+extern SCP_vector<rank_stuff> Ranks;
 extern traitor_stuff Traitor;
 
-void parse_rank_tbl();
+int verify_rank(int rank);
+
+void rank_init();
 void parse_traitor_tbl();
 void scoring_close();
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1903,7 +1903,7 @@ void game_init()
 
 	control_config_common_init();				// sets up localization stuff in the control config
 
-	parse_rank_tbl();
+	rank_init();
 	parse_traitor_tbl();
 	parse_medal_tbl();
 


### PR DESCRIPTION
Free Ranks from their retail shackles. Vectorizes Ranks and adds bounds checks to places where it's accessed. Removes the limit of 10 and assumptions that ranks will match retail's 10. UI elements that display rank will check if the player rank > than the current max. If so, display the max without changing player rank. Adds modular -rnk.tbm parsing with +nocreate support. 

Disallows Ranks to have equal values and will automatically increment one of them by 1 point if detected and log the change. Will then auto sort ranks after all parsing is done if Ranks is not ordered by point values or Rank equality is detected. Will warn if auto sorting is done and log the changes.