### PR TITLE
Add yaml file defining build options for vscode cmake tools users.

### DIFF
--- a/cmake-variants.yaml
+++ b/cmake-variants.yaml
@@ -1,0 +1,16 @@
+buildType:
+  default: release
+  description: R
+  choices:
+    release:
+      short: Release
+      long: Release builds
+      buildType: Release
+    fastDebug:
+      short: FastDebug
+      long: Debug with optimizations
+      buildType: FastDebug
+    debug:
+      short: Debug
+      long: Debug without optimizations
+      buildType: Debug


### PR DESCRIPTION
When using visual studio code to build the game, the cmake extension provides a list of build flavors to choose from but can't pick up on the SCP's custom defined builds and only uses a default list. This file is read by it to get around it.

  If keeping it in the root is undesirable it could be shifted to a `.vscode/` location instead.