### PR TITLE
always set the default gloss uniform since it is now always used

### DIFF
--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -93,8 +93,8 @@ void convert_model_material(model_uniform_data* data_out,
 			data_out->emissionFactor.xyz.z = gr_light_zero[2];
 		}
 
-		data_out->defaultGloss = 0.6f;
 	}
+	data_out->defaultGloss = 0.6f;
 
 	if (shader_flags & SDR_FLAG_MODEL_DIFFUSE_MAP) {
 		if (material.is_desaturated()) {


### PR DESCRIPTION
Fixes a regression from #4838. Leaving default gloss uninitialized for unlit models led to a flickering issue in some cases, such as loadout screens.