### PR TITLE
More old dead shader override code that isn't hooked to anything anymore

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -54,20 +54,20 @@ layout (std140) uniform modelData {
 	int blend_alpha;
 
 	vec3 emissionFactor;
-	bool overrideDiffuse;
+	bool overrideDiffuse_;
 
-	vec3 diffuseClr;
-	bool overrideGlow;
+	vec3 diffuseClr_;
+	bool overrideGlow_;
 
-	vec3 glowClr;
-	bool overrideSpec;
+	vec3 glowClr_;
+	bool overrideSpec_;
 
-	vec3 specClr;
+	vec3 specClr_;
 	bool alphaGloss;
 
 	bool gammaSpec;
 	bool envGloss;
-	bool alpha_spec;
+	bool alpha_spec_;
 	int effect_num;
 
 	vec4 fogColor;
@@ -88,7 +88,7 @@ layout (std140) uniform modelData {
 	float middist;
 	float fardist;
 
-	vec2 normalAlphaMinMax;
+	vec2 normalAlphaMinMax_;
 	int sBasemapIndex;
 	int sGlowmapIndex;
 
@@ -273,7 +273,6 @@ void main()
 	// premultiply alpha if blend_alpha is 1. assume that our blend function is srcColor + (1-Alpha)*destColor.
 	// if blend_alpha is 2, assume blend func is additive and don't modify color
 	if(blend_alpha == 1) baseColor.rgb = baseColor.rgb * baseColor.a;
-	if(overrideDiffuse) baseColor.rgb = diffuseClr;
 #endif
 	specColor = vec4(baseColor.rgb * SPEC_FACTOR_NO_SPEC_MAP, glossData);
 #ifdef FLAG_HDR
@@ -282,10 +281,6 @@ void main()
 #ifdef FLAG_SPEC_MAP
 	specColor = texture(sSpecmap, vec3(texCoord, float(sSpecmapIndex)));
 	if(alphaGloss) glossData = specColor.a;
-	if(overrideSpec) {
-		specColor.rgb = specClr;
-		fresnelFactor = 1.0;
-	}
 	if(gammaSpec) {
 		specColor.rgb = max(specColor.rgb, vec3(0.03f)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
 		fresnelFactor = 1.0;
@@ -408,7 +403,6 @@ void main()
 #endif
 #ifdef FLAG_GLOW_MAP
 	vec3 glowColor = texture(sGlowmap, vec3(texCoord, float(sGlowmapIndex))).rgb;
-	if(overrideGlow) glowColor = glowClr;
  #ifdef FLAG_HDR
 	glowColor = srgb_to_linear(glowColor) * GLOW_MAP_SRGB_MULTIPLIER;
  #endif

--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -61,20 +61,20 @@ layout (std140) uniform modelData {
 	int blend_alpha;
 
 	vec3 emissionFactor;
-	bool overrideDiffuse;
+	bool overrideDiffuse_;
 
-	vec3 diffuseClr;
-	bool overrideGlow;
+	vec3 diffuseClr_;
+	bool overrideGlow_;
 
-	vec3 glowClr;
-	bool overrideSpec;
+	vec3 glowClr_;
+	bool overrideSpec_;
 
-	vec3 specClr;
+	vec3 specClr_;
 	bool alphaGloss;
 
 	bool gammaSpec;
 	bool envGloss;
-	bool alpha_spec;
+	bool alpha_spec_;
 	int effect_num;
 
 	vec4 fogColor;
@@ -95,7 +95,7 @@ layout (std140) uniform modelData {
 	float middist;
 	float fardist;
 
-	vec2 normalAlphaMinMax;
+	vec2 normalAlphaMinMax_;
 	int sBasemapIndex;
 	int sGlowmapIndex;
 

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -56,20 +56,20 @@ layout (std140) uniform modelData {
 	int blend_alpha;
 
 	vec3 emissionFactor;
-	bool overrideDiffuse;
+	bool overrideDiffuse_;
 
-	vec3 diffuseClr;
-	bool overrideGlow;
+	vec3 diffuseClr_;
+	bool overrideGlow_;
 
-	vec3 glowClr;
-	bool overrideSpec;
+	vec3 glowClr_;
+	bool overrideSpec_;
 
-	vec3 specClr;
+	vec3 specClr_;
 	bool alphaGloss;
 
 	bool gammaSpec;
 	bool envGloss;
-	bool alpha_spec;
+	bool alpha_spec_;
 	int effect_num;
 
 	vec4 fogColor;
@@ -90,7 +90,7 @@ layout (std140) uniform modelData {
 	float middist;
 	float fardist;
 
-	vec2 normalAlphaMinMax;
+	vec2 normalAlphaMinMax_;
 	int sBasemapIndex;
 	int sGlowmapIndex;
 

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -72,15 +72,6 @@ bool PostProcessing_override = false;
 bool Shadow_override = false;
 bool Trail_render_override = false;
 
-bool Basemap_color_override_set = false;
-float Basemap_color_override[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-
-bool Glowmap_color_override_set = false;
-float Glowmap_color_override[3] = {0.0f, 0.0f, 0.0f};
-
-bool Specmap_color_override_set = false;
-float Specmap_color_override[3] = {0.0f, 0.0f, 0.0f};
-
 // Values used for noise for thruster animations
 float Noise[NOISE_NUM_FRAMES] = { 
 	0.468225f,

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -144,16 +144,7 @@ extern bool PostProcessing_override;
 extern bool Shadow_override;
 extern bool Trail_render_override;
 
-extern bool Basemap_color_override_set;
-extern float Basemap_color_override[4];
-
-extern bool Glowmap_color_override_set;
-extern float Glowmap_color_override[3];
-
-extern bool Specmap_color_override_set;
-extern float Specmap_color_override[3];
-
-// game skill levels 
+// game skill levels
 #define	NUM_SKILL_LEVELS	5
 
 //====================================================================================

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -103,14 +103,6 @@ void convert_model_material(model_uniform_data* data_out,
 			data_out->desaturate = 0;
 		}
 
-		if (Basemap_color_override_set) {
-			data_out->overrideDiffuse = 1;
-			data_out->diffuseClr.xyz.x = Basemap_color_override[0];
-			data_out->diffuseClr.xyz.y = Basemap_color_override[1];
-			data_out->diffuseClr.xyz.z = Basemap_color_override[2];
-		} else {
-			data_out->overrideDiffuse = 0;
-		}
 
 		switch (material.get_blend_mode()) {
 		case ALPHA_BLEND_PREMULTIPLIED:
@@ -128,26 +120,10 @@ void convert_model_material(model_uniform_data* data_out,
 	}
 
 	if (shader_flags & SDR_FLAG_MODEL_GLOW_MAP) {
-		if (Glowmap_color_override_set) {
-			data_out->overrideGlow = 1;
-			data_out->glowClr.xyz.x = Glowmap_color_override[0];
-			data_out->glowClr.xyz.y = Glowmap_color_override[1];
-			data_out->glowClr.xyz.z = Glowmap_color_override[2];
-		} else {
-			data_out->overrideGlow = 0;
-		}
 		data_out->sGlowmapIndex = bm_get_array_index(material.get_texture_map(TM_GLOW_TYPE));
 	}
 
 	if (shader_flags & SDR_FLAG_MODEL_SPEC_MAP) {
-		if (Specmap_color_override_set) {
-			data_out->overrideSpec = 1;
-			data_out->specClr.xyz.x = Specmap_color_override[0];
-			data_out->specClr.xyz.y = Specmap_color_override[1];
-			data_out->specClr.xyz.z = Specmap_color_override[2];
-		} else {
-			data_out->overrideSpec = 0;
-		}
 
 		if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) {
 			data_out->sSpecmapIndex = bm_get_array_index(material.get_texture_map(TM_SPEC_GLOSS_TYPE));

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -104,20 +104,20 @@ struct model_uniform_data {
 	int blend_alpha;
 
 	vec3d emissionFactor;
-	int overrideDiffuse;
+	int overrideDiffuse_; //Unused, to be removed.
 
-	vec3d diffuseClr;
-	int overrideGlow;
+	vec3d diffuseClr_; //Unused, to be removed.
+	int overrideGlow_; //Unused, to be removed.
 
-	vec3d glowClr;
-	int overrideSpec;
+	vec3d glowClr_; //Unused, to be removed.
+	int overrideSpec_; //Unused, to be removed.
 
-	vec3d specClr;
+	vec3d specClr_; //Unused, to be removed.
 	int alphaGloss;
 
 	int gammaSpec;
 	int envGloss;
-	int alpha_spec;
+	int alpha_spec_; //Unused, to be removed.
 	int effect_num;
 
 	vec4 fogColor;
@@ -138,7 +138,7 @@ struct model_uniform_data {
 	float middist;
 	float fardist;
 
-	vec2d normalAlphaMinMax;
+	vec2d normalAlphaMinMax_;
 	int sBasemapIndex;
 	int sGlowmapIndex;
 


### PR DESCRIPTION
effectively a followup to #4823, working along similar lines but hitting a few things that were a tad less evident on my last sweep.

After this there are several elements of the model data shader uniform that are unused. Altering shader uniforms is something that can easily go wrong, and I'm not quite done with them yet, so for the moment I've marked all the dead ones' names to make them stick out and intend to do a followup very soon. 