### PR TITLE
improve SEXP syntax checking

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6252,8 +6252,15 @@ bool post_process_mission()
 			int result, bad_node, op;
 
 			op = get_operator_index(i);
-			Assert(op != -1);  // need to make sure it is an operator before we treat it like one..
-			result = check_sexp_syntax( i, query_operator_return_type(op), 1, &bad_node);
+
+			// need to make sure it is an operator before we treat it like one..
+			if (op < 0)
+			{
+				result = SEXP_CHECK_UNKNOWN_OP;
+				bad_node = i;
+			}
+			else
+				result = check_sexp_syntax(i, query_operator_return_type(op), 1, &bad_node);
 
 			// entering this if statement will result in program termination!!!!!
 			// print out an error based on the return value from check_sexp_syntax()

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1972,6 +1972,11 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 
 	Assert(node >= 0 && node < Num_sexp_nodes);
 	Assert(Sexp_nodes[node].type != SEXP_NOT_USED);
+
+	op_node = node;		// save the node of the operator since we need to get to other args.
+	if (bad_node)
+		*bad_node = op_node;
+
 	if (Sexp_nodes[node].subtype == SEXP_ATOM_NUMBER && return_type == OPR_BOOL) {
 		// special case Mark seems to want supported
 		Assert(Sexp_nodes[node].first == -1);  // only lists should have a first pointer
@@ -1980,10 +1985,6 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 
 		return 0;
 	}
-
-	op_node = node;		// save the node of the operator since we need to get to other args.
-	if (bad_node)
-		*bad_node = op_node;
 
 	if (Sexp_nodes[op_node].subtype != SEXP_ATOM_OPERATOR)
 		return SEXP_CHECK_OP_EXPECTED;  // not an operator, which it should always be


### PR DESCRIPTION
When the top-level operator of a SEXP is not found, flag the error instead of crashing.  This is helpful for missions that contain unsupported scripted SEXPs.