### PR TITLE
Shaders flag slaughter

### DIFF
--- a/cmake-variants.yaml
+++ b/cmake-variants.yaml
@@ -1,0 +1,16 @@
+buildType:
+  default: release
+  description: R
+  choices:
+    release:
+      short: Release
+      long: Release builds
+      buildType: Release
+    fastDebug:
+      short: FastDebug
+      long: Debug with optimizations
+      buildType: FastDebug
+    debug:
+      short: Debug
+      long: Debug without optimizations
+      buildType: Debug

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1339,12 +1339,12 @@ static int bm_load_image_data(int handle, int bpp, ushort flags, bool nodebug)
 
 		if (be->type != BM_TYPE_USER && !nodebug) {
 			if (bmp->data == 0)
-				nprintf(("BmpMan", "Loading %s for the first time.\n", be->filename));
+				nprintf(("BmpMan", "Handle %i bm_load_image_data() Loading %s for the first time\n", handle, be->filename ));
 		}
 
 		if (!Bm_paging) {
 			if (be->type != BM_TYPE_USER && !nodebug)
-				nprintf(("Paging", "Loading %s (%dx%dx%d)\n", be->filename, bmp->w, bmp->h, true_bpp));
+				nprintf(("Paging", "Handle %i bm_load_image_data() Loading %s (%dx%dx%d)\n", handle, be->filename, bmp->w, bmp->h, true_bpp));
 		}
 
 		// select proper format
@@ -2767,13 +2767,13 @@ int bm_release(int handle, int clear_render_targets) {
 	Assertion(be->handle == handle, "Invalid bitmap handle number %d (expected %d) for %s passed to bm_release()\n", be->handle, handle, be->filename);
 
 	if (!clear_render_targets && ((be->type == BM_TYPE_RENDER_TARGET_STATIC) || (be->type == BM_TYPE_RENDER_TARGET_DYNAMIC))) {
-		nprintf(("BmpMan", "Tried to release a render target!\n"));
+		nprintf(("BmpMan", "Handle %i bm_release() Tried to release a render target!\n", handle));
 		return 0;
 	}
 
 	// If it is locked, cannot free it.
 	if (be->ref_count != 0) {
-		nprintf(("BmpMan", "Tried to release %s that has a lock count of %d.. not releasing\n", be->filename, be->ref_count));
+		nprintf(("BmpMan", "Handle %i bm_release() Tried to release %s that has a lock count of %d.. not releasing\n", handle, be->filename, be->ref_count));
 		return 0;
 	}
 
@@ -2784,13 +2784,12 @@ int bm_release(int handle, int clear_render_targets) {
 		be->load_count--;
 
 	if (be->load_count != 0) {
-		nprintf(("BmpMan", "Tried to release %s that has a load count of %d.. not releasing\n", be->filename, be->load_count + 1));
+		nprintf(("BmpMan", "Handle %i bm_release() Tried to release %s that had a load count of %d.. not releasing, reducing load count. \n", handle, be->filename, be->load_count + 1));
 		return 0;
 	}
 
-	if (be->type != BM_TYPE_USER) {
-		nprintf(("BmpMan", "Releasing bitmap %s with handle %i\n", be->filename, handle));
-	}
+
+	nprintf(("BmpMan", "Handle %i bm_release() Releasing bitmap %s\n", handle, be->filename));
 
 	// be sure that all frames of an ani are unloaded - taylor
 	if (bm_is_anim(be)) {
@@ -2868,7 +2867,7 @@ bool bm_release_rendertarget(int handle) {
 	Assertion(!bm_is_anim(be), "Cannot release a render target of an animation (bitmap handle number %d for %s)!\n", be->handle, be->filename);
 
 	if (!((be->type == BM_TYPE_RENDER_TARGET_STATIC) || (be->type == BM_TYPE_RENDER_TARGET_DYNAMIC))) {
-		nprintf(("BmpMan", "Tried to release a render target of a non-rendered bitmap!\n"));
+		nprintf(("BmpMan", "Handle %i bm_release_rendertarget() Tried to release a render target of a non-rendered bitmap!\n", handle ));
 		return false;
 	}
 
@@ -2890,7 +2889,7 @@ int bm_reload(int bitmap_handle, const char* filename) {
 		return -1;
 
 	if (entry->ref_count) {
-		nprintf(("BmpMan", "Trying to reload a bitmap that is still locked. Filename: %s, ref_count: %d", entry->filename, entry->ref_count));
+		nprintf(("BmpMan", "Handle %i bm_reload() Trying to reload a bitmap that is still locked. Filename: %s, ref_count: %d", bitmap_handle, entry->filename, entry->ref_count));
 		return -1;
 	}
 
@@ -3061,7 +3060,7 @@ int bm_unload(int handle, int clear_render_targets, bool nodebug) {
 
 	// If it is locked, cannot free it.
 	if (be->ref_count != 0 && !nodebug) {
-		nprintf(("BmpMan", "Tried to unload %s that has a lock count of %d.. not unloading\n", be->filename, be->ref_count));
+		nprintf(("BmpMan", "Handle %i bm_unload() Tried to unload %s that has a lock count of %d.. not unloading\n", handle, be->filename, be->ref_count));
 		return 0;
 	}
 
@@ -3073,7 +3072,7 @@ int bm_unload(int handle, int clear_render_targets, bool nodebug) {
 			be->load_count--;
 
 		if (be->load_count != 0 && !nodebug) {
-			nprintf(("BmpMan", "Tried to unload %s that has a load count of %d.. not unloading\n", be->filename, be->load_count + 1));
+			nprintf(("BmpMan", "Handle %i bm_unload() Tried to unload %s that had a load count of %d.. not unloading, decrementing load count\n", handle, be->filename, be->load_count + 1));
 			return 0;
 		}
 	}
@@ -3091,12 +3090,12 @@ int bm_unload(int handle, int clear_render_targets, bool nodebug) {
 
 		for (i = 0; i < first_entry->info.ani.num_frames; i++) {
 			if (!nodebug)
-				nprintf(("BmpMan", "Unloading %s frame %d.  %dx%dx%d\n", be->filename, i, bmp->w, bmp->h, bmp->bpp));
+				nprintf(("BmpMan", "Handle %i bm_unload() Unloading %s frame %d.  %dx%dx%d\n", handle, be->filename, i, bmp->w, bmp->h, bmp->bpp));
 			bm_free_data(bm_get_slot(first + i));		// clears flags, bbp, data, etc
 		}
 	} else {
 		if (!nodebug)
-			nprintf(("BmpMan", "Unloading %s.  %dx%dx%d\n", be->filename, bmp->w, bmp->h, bmp->bpp));
+			nprintf(("BmpMan", "Handle %i bm_unload() Unloading %s.  %dx%dx%d\n",handle, be->filename, bmp->w, bmp->h, bmp->bpp));
 		bm_free_data(bm_get_slot(handle));		// clears flags, bbp, data, etc
 	}
 
@@ -3141,14 +3140,14 @@ int bm_unload_fast(int handle, int clear_render_targets) {
 
 	// If it is locked, cannot free it.
 	if (be->ref_count != 0) {
-		nprintf(("BmpMan", "Tried to unload_fast %s that has a lock count of %d.. not unloading\n", be->filename, be->ref_count));
+		nprintf(("BmpMan", "Handle %i bm_unload_fast() Tried to unload_fast %s that has a lock count of %d.. not unloading\n", handle, be->filename, be->ref_count));
 		return 0;
 	}
 
 	Assert(be->handle == handle);		// INVALID BITMAP HANDLE!
 
 	// unlike bm_unload(), we handle each frame of an animation separately, for safer use in the graphics API
-	nprintf(("BmpMan", "Fast-unloading %s.  %dx%dx%d\n", be->filename, bmp->w, bmp->h, bmp->bpp));
+	nprintf(("BmpMan", "Handle %i bm_unload_fast() Fast-unloading %s.  %dx%dx%d\n", handle, be->filename, bmp->w, bmp->h, bmp->bpp));
 	bm_free_data_fast(handle);		// clears flags, bbp, data, etc
 
 	return 1;
@@ -3160,8 +3159,8 @@ void bm_unlock(int handle) {
 	Assertion(bm_inited, "bmpman must be initialized before this function can be called!");
 
 	be = bm_get_entry(handle);
-
 	be->ref_count--;
+	nprintf(("BmpMan", "Handle %i bm_unlock() Reducing lock count of %s to %i\n", handle, be->filename, be->ref_count));
 	Assert(be->ref_count >= 0);		// Trying to unlock data more times than lock was called!!!
 }
 

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -18,6 +18,7 @@
 #include "bmpman/bm_internal.h"
 #include "ddsutils/ddsutils.h"
 #include "debugconsole/console.h"
+#include "globalincs/pstypes.h"
 #include "globalincs/systemvars.h"
 #include "graphics/2d.h"
 #include "graphics/matrix.h"
@@ -1236,6 +1237,14 @@ int bm_load(const char *real_filename, int dir_type) {
 
 int bm_load(const SCP_string& filename, int dir_type) {
 	return bm_load(filename.c_str(), dir_type);
+}
+
+void bm_use(const int handle){
+	bitmap_entry *be;
+	be = bm_get_entry(handle);
+	be->load_count++;
+	//be->ref_count++;
+	nprintf(("BmpMan", "Handle %i bm_use() %s increasing load count to %d\n", handle, be->filename, be->load_count));
 }
 
 bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int *nfps, int *key, BM_TYPE *type) {
@@ -3343,4 +3352,22 @@ SDL_Surface* bm_to_sdl_surface(int handle) {
 
 	return bitmapSurface;
 
+}
+
+ubyte* bm_generate(int* handle, ubyte r, ubyte g, ubyte b, ubyte a, const vec2d& source_dimensions)
+{
+	auto size = (size_t)(source_dimensions.x * source_dimensions.y * 4); // RGBA format
+
+	auto buffer = new ubyte[size];
+	for(size_t i=0;i<size;i+=4){
+		buffer[i] = r;
+		buffer[i+1] = g;
+		buffer[i+2] = b;
+		buffer[i+3] = a;
+	}
+
+	auto id = bm_create(32, source_dimensions.x, source_dimensions.y, buffer,BMP_TEX_OTHER);
+	*handle =id;
+	nprintf(("bmpman","Handle %i bm_generate() bmpman asked to generate a texture %ix%i\n",id,(int) source_dimensions.x,(int) source_dimensions.y));
+	return buffer;
 }

--- a/code/bmpman/bmpman.h
+++ b/code/bmpman/bmpman.h
@@ -618,6 +618,13 @@ bool bm_set_render_target(int handle, int face = -1);
 bool bm_load_and_parse_eff(const char *filename, int dir_type, int *nframes, int *nfps, int *key, BM_TYPE *type);
 
 /**
+ * @brief Signals that a texture is being used, for use when a texture handle is being assigned but not loaded.
+ *
+ * @param handle of texture
+ */
+
+void bm_use(const int handle);
+/**
  * @brief Calculates & returns the current frame of an animation
  *
  * @param[in] frame1_handle  Handle of the animation
@@ -697,5 +704,7 @@ int bmpman_count_available_slots();
 bool bm_validate_filename(const SCP_string& file, bool single_frame, bool animation);
 
 SDL_Surface* bm_to_sdl_surface(int handle);
+
+ubyte* bm_generate(int* handle, ubyte r, ubyte g, ubyte b, ubyte a, const vec2d& source_dimensions);
 
 #endif

--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -197,6 +197,6 @@ void main()
 	vec3 halfVec = normalize(lightDir + eyeDir);
 	float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
 	vec4 fragmentColor = vec4(1.0);
-	fragmentColor.rgb = computeLighting(specColor.rgb, diffColor, lightDir, normal.xyz, halfVec, eyeDir, roughness, fresnel, NdotL).rgb * diffuseLightColor * attenuation * area_normalisation;
+	fragmentColor.rgb = computeLighting(specColor.rgb, diffColor, lightDir, normal.xyz, halfVec, eyeDir, roughness, NdotL).rgb * diffuseLightColor * attenuation * area_normalisation;
 	fragOut0 = max(fragmentColor, vec4(0.0));
 }

--- a/code/def_files/data/effects/lighting.sdr
+++ b/code/def_files/data/effects/lighting.sdr
@@ -24,7 +24,7 @@ float GeometrySchlickGGX(float dotAB, float k)
 {
     return dotAB / (dotAB * (1.0f - k) + k);
 }
-vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float roughness, float fresnelFactor, float dotNL)
+vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float roughness, float dotNL)
 {
 	float alpha = roughness * roughness;
 	float alphaSqr = alpha * alpha;
@@ -41,7 +41,7 @@ vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 ha
 	float distribution = alphaSqr / (PI * denom * denom);
 
 	// Fresnel Term - Fresnel-Schlick
-	vec3 fresnel = mix(specColor, FresnelSchlick(halfVec, view, specColor), fresnelFactor);
+	vec3 fresnel = FresnelSchlick(halfVec, view, specColor);
 
 	// Geometry Term - Schlick-GGX approximation
 	float r = roughness + 1.0;
@@ -66,12 +66,12 @@ vec3 ComputeGGX(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 ha
 	return (specular + diffuse) * dotNL;
 }
 
-vec3 computeLighting(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float roughness, float fresnelFactor, float dotNL) 
+vec3 computeLighting(vec3 specColor, vec3 diffColor, vec3 light, vec3 normal, vec3 halfVec, vec3 view, float roughness, float dotNL) 
 {
 	#ifdef FLAG_LIGHT_MODEL_BLINN_PHONG
-	return SpecularBlinnPhong(specColor, light, normal, halfVec, 32, fresnelFactor, dotNL);
+	return SpecularBlinnPhong(specColor, light, normal, halfVec, 32, dotNL);
 	#else
-	return ComputeGGX(specColor, diffColor, light, normal, halfVec, view, roughness, fresnelFactor, dotNL);
+	return ComputeGGX(specColor, diffColor, light, normal, halfVec, view, roughness,  dotNL);
 	#endif
 }
 

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -54,20 +54,20 @@ layout (std140) uniform modelData {
 	int blend_alpha;
 
 	vec3 emissionFactor;
-	bool overrideDiffuse;
+	bool overrideDiffuse_;
 
-	vec3 diffuseClr;
-	bool overrideGlow;
+	vec3 diffuseClr_;
+	bool overrideGlow_;
 
-	vec3 glowClr;
-	bool overrideSpec;
+	vec3 glowClr_;
+	bool overrideSpec_;
 
-	vec3 specClr;
+	vec3 specClr_;
 	bool alphaGloss;
 
 	bool gammaSpec;
 	bool envGloss;
-	bool alpha_spec;
+	bool alpha_spec_;
 	int effect_num;
 
 	vec4 fogColor;
@@ -88,7 +88,7 @@ layout (std140) uniform modelData {
 	float middist;
 	float fardist;
 
-	vec2 normalAlphaMinMax;
+	vec2 normalAlphaMinMax_;
 	int sBasemapIndex;
 	int sGlowmapIndex;
 
@@ -273,7 +273,6 @@ void main()
 	// premultiply alpha if blend_alpha is 1. assume that our blend function is srcColor + (1-Alpha)*destColor.
 	// if blend_alpha is 2, assume blend func is additive and don't modify color
 	if(blend_alpha == 1) baseColor.rgb = baseColor.rgb * baseColor.a;
-	if(overrideDiffuse) baseColor.rgb = diffuseClr;
 #endif
 	specColor = vec4(baseColor.rgb * SPEC_FACTOR_NO_SPEC_MAP, glossData);
 #ifdef FLAG_HDR
@@ -282,10 +281,6 @@ void main()
 #ifdef FLAG_SPEC_MAP
 	specColor = texture(sSpecmap, vec3(texCoord, float(sSpecmapIndex)));
 	if(alphaGloss) glossData = specColor.a;
-	if(overrideSpec) {
-		specColor.rgb = specClr;
-		fresnelFactor = 1.0;
-	}
 	if(gammaSpec) {
 		specColor.rgb = max(specColor.rgb, vec3(0.03f)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
 		fresnelFactor = 1.0;
@@ -408,7 +403,6 @@ void main()
 #endif
 #ifdef FLAG_GLOW_MAP
 	vec3 glowColor = texture(sGlowmap, vec3(texCoord, float(sGlowmapIndex))).rgb;
-	if(overrideGlow) glowColor = glowClr;
  #ifdef FLAG_HDR
 	glowColor = srgb_to_linear(glowColor) * GLOW_MAP_SRGB_MULTIPLIER;
  #endif

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -122,31 +122,18 @@ mat3 tangentMatrix;
 #ifdef FLAG_DIFFUSE_MAP
 uniform sampler2DArray sBasemap;
 #endif
-#ifdef FLAG_GLOW_MAP
 uniform sampler2DArray sGlowmap;
-#endif
-#ifdef FLAG_SPEC_MAP
 uniform sampler2DArray sSpecmap;
-#endif
 #ifdef FLAG_ENV_MAP
 uniform samplerCube sEnvmap;
 uniform samplerCube sIrrmap;
 #endif
-#ifdef FLAG_NORMAL_MAP
 uniform sampler2DArray sNormalmap;
-#endif
-#ifdef FLAG_AMBIENT_MAP
 uniform sampler2DArray sAmbientmap;
-#endif
 #ifdef FLAG_ANIMATED
 uniform sampler2D sFramebuffer;
 #endif
-#ifdef FLAG_TEAMCOLOR
-vec4 teamMask;
-#endif
-#ifdef FLAG_MISC_MAP
 uniform sampler2DArray sMiscmap;
-#endif
 #ifdef FLAG_SHADOWS
 uniform sampler2DArray shadow_map;
 #endif
@@ -188,7 +175,7 @@ void GetLightInfo(int i, out vec3 lightDir, out float attenuation)
 		attenuation = 1.0 / (1.0 + lights[i].attenuation * dist);
 	}
 }
-vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial, float gloss, float fresnel, float shadow, float aoFactor)
+vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial, float gloss, float shadow, float aoFactor)
 {
 	vec3 eyeDir = vec3(normalize(-vertIn.position).xyz);
 	vec3 lightAmbient = (emissionFactor + ambientFactor * ambientFactor) * aoFactor; // ambientFactor^2 due to legacy OpenGL compatibility behavior
@@ -209,7 +196,7 @@ vec3 CalculateLighting(vec3 normal, vec3 diffuseMaterial, vec3 specularMaterial,
 		float NdotL = clamp(dot(normal, lightDir), 0.0f, 1.0f);
 		// Ambient, Diffuse, and Specular
 		lightDiffuse += (lights[i].diffuse_color.rgb * diffuseFactor * NdotL * attenuation) * shadow;
-		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, roughness, fresnel, NdotL) * attenuation * shadow;
+		lightSpecular += lights[i].diffuse_color.rgb * computeLighting(specularMaterial, diffuseMaterial, lightDir, normal, halfVec, eyeDir, roughness, NdotL) * attenuation * shadow;
 	}
 	return diffuseMaterial * lightAmbient + lightSpecular;
 }
@@ -228,17 +215,15 @@ void main()
 	vec4 baseColor = color;
 	vec4 specColor = vec4(0.0, 0.0, 0.0, 1.0);
 	vec4 emissiveColor = vec4(0.0, 0.0, 0.0, 1.0);
-	float fresnelFactor = 0.0;
 	float glossData = defaultGloss;
-	vec2 aoFactors = vec2(1.0, 1.0);
-#ifdef	FLAG_AMBIENT_MAP
+
+	//AO map handling
 	// red channel is ambient occlusion factor which only affects ambient lighting.
 	// green is cavity occlusion factor which only affects diffuse and specular lighting.
-	aoFactors = texture(sAmbientmap, vec3(texCoord, float(sAmbientmapIndex))).xy;
-#endif
+	vec2 aoFactors = texture(sAmbientmap, vec3(texCoord, float(sAmbientmapIndex))).xy;
+
 	vec3 unitNormal = normalize(vertIn.normal);
-	vec3 normal = unitNormal;
-#ifdef FLAG_NORMAL_MAP
+	vec3 normal = unitNormal; 
    // Normal map - convert from DXT5nm
    vec2 normalSample;
    normal.rg = normalSample = (texture(sNormalmap, vec3(texCoord, float(sNormalmapIndex))).ag * 2.0) - 1.0;
@@ -249,8 +234,7 @@ void main()
    if (norm > 0.0)
       normal /= norm;
    else
-      normal = unitNormal;
-#endif
+      normal = unitNormal; 
 
 #ifdef FLAG_ANIMATED
    vec2 distort = vec2(cos(vertIn.position.x*vertIn.position.w*0.005+anim_timer*20.0)*sin(vertIn.position.y*vertIn.position.w*0.005),sin(vertIn.position.x*vertIn.position.w*0.005+anim_timer*20.0)*cos(vertIn.position.y*vertIn.position.w*0.005))*0.03;
@@ -275,22 +259,14 @@ void main()
 	if(blend_alpha == 1) baseColor.rgb = baseColor.rgb * baseColor.a;
 #endif
 	specColor = vec4(baseColor.rgb * SPEC_FACTOR_NO_SPEC_MAP, glossData);
-#ifdef FLAG_HDR
-	baseColor.rgb = srgb_to_linear(baseColor.rgb);
-#endif
-#ifdef FLAG_SPEC_MAP
+	//SPEC map handling
 	specColor = texture(sSpecmap, vec3(texCoord, float(sSpecmapIndex)));
 	if(alphaGloss) glossData = specColor.a;
-	if(gammaSpec) {
-		specColor.rgb = max(specColor.rgb, vec3(0.03f)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
-		fresnelFactor = 1.0;
-	}
-   #ifdef FLAG_HDR
-	specColor.rgb = srgb_to_linear(specColor.rgb);
-   #endif
-#endif
-	baseColor.rgb *= aoFactors.y;
-	specColor.rgb *= aoFactors.y;
+
+
+	//mundane materials should be roughly 0.03 at minimum, but allowing lower values enables
+	//exotic or non-physical material possibilites.
+	specColor.rgb = max(specColor.rgb, vec3(0.00001f)); 
 
 	// Anti-glint "trick" based on Valve's "Advanced VR Rendering" talk at GDC2015:
 	// http://media.steampowered.com/apps/valve/2015/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf Page 43
@@ -299,9 +275,10 @@ void main()
 	vec2 normDy = dFdy(unitNormal.xy);
 	float glossGeo = 1.0f - pow(clamp(max(dot(normDx,normDx), dot(normDy,normDy)),0.0,1.0),0.33);
 	glossData = min(glossData, glossGeo);
-
-#ifdef FLAG_MISC_MAP
- #ifdef FLAG_TEAMCOLOR
+	
+	//MISC map handling
+	//TEAMCOLOR
+	vec4 teamMask = vec4(0.0, 0.0, 0.0, 0.0);
 	teamMask = texture(sMiscmap, vec3(texCoord, float(sMiscmapIndex)));
 
 	//For team colors applied to a diffuse or spec map, we assume that the base color of the diffuse 
@@ -311,49 +288,42 @@ void main()
 	vec3 team_color = base_color * teamMask.x + stripe_color * teamMask.y + color_offset;
 	vec3 team_color_glow = (base_color * teamMask.b) + (stripe_color * teamMask.a);
 
-	#ifdef FLAG_HDR
-	baseColor.rgb = linear_to_srgb(baseColor.rgb);
-	specColor.rgb = linear_to_srgb(specColor.rgb);
-	#endif
-
-	baseColor.rgb += team_color;					
-	baseColor.rgb = max(baseColor.rgb, vec3(0.0));	// We need to make sure that nothing here ever goes negative
+	baseColor.rgb += team_color;
 	specColor.rgb += team_color;
-	specColor.rgb = max(specColor.rgb, vec3(0.03));
 
-	#ifdef FLAG_HDR
+	baseColor.rgb = max(baseColor.rgb, vec3(0.0));	// We need to make sure that nothing here ever goes negative
+	specColor.rgb = max(specColor.rgb, vec3(0.00001f)); 
+
+    #ifdef FLAG_HDR
 	baseColor.rgb = srgb_to_linear(baseColor.rgb);
 	specColor.rgb = srgb_to_linear(specColor.rgb);
-	#endif
+    #endif
 
- #endif
-#endif
-	// Lights aren't applied when we are rendering to the G-buffers since that gets handled later
-#ifdef FLAG_DEFERRED
- #ifdef FLAG_LIGHT
-	// Ambient lighting still needs to be done since that counts as an "emissive" color
-	vec3 lightAmbient = (emissionFactor + ambientFactor * ambientFactor) * aoFactors.x; // ambientFactor^2 due to legacy OpenGL compatibility behavior
-	emissiveColor.rgb += baseColor.rgb * lightAmbient;
- #else
-  #ifdef FLAG_SPEC_MAP
-	baseColor.rgb += pow(1.0 - clamp(dot(eyeDir, normal), 0.0, 1.0), 5.0 * clamp(glossData, 0.01, 1.0)) * specColor.rgb;
+	baseColor.rgb *= aoFactors.y;
+	specColor.rgb *= aoFactors.y;
+
+#ifdef FLAG_LIGHT
+  #ifdef FLAG_DEFERRED
+		// Lights aren't applied when we are rendering to the G-buffers since that gets handled later
+	  // Ambient lighting still needs to be done since that counts as an "emissive" color
+		// ambientFactor^2 due to legacy OpenGL compatibility behavior
+    emissiveColor.rgb += baseColor.rgb * (emissionFactor + ambientFactor * ambientFactor) * aoFactors.x;
+  #else
+    float shadow = 1.0;
+    #ifdef FLAG_SHADOWS
+      shadow = getShadowValue(shadow_map, -vertIn.position.z, vertIn.shadowPos.z, vertIn.shadowUV, fardist, middist, neardist, veryneardist);
+    #endif
+    baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specColor.rgb, glossData, shadow, aoFactors.x);
   #endif
-	// If there is no lighting then we copy the color data so far into the
-	emissiveColor.rgb += baseColor.rgb;
- #endif
 #else
- #ifdef FLAG_LIGHT
-	float shadow = 1.0;
-  #ifdef FLAG_SHADOWS
-	shadow = getShadowValue(shadow_map, -vertIn.position.z, vertIn.shadowPos.z, vertIn.shadowUV, fardist, middist, neardist, veryneardist);
-  #endif
-	baseColor.rgb = CalculateLighting(normal, baseColor.rgb, specColor.rgb, glossData, fresnelFactor, shadow, aoFactors.x);
- #else
-  #ifdef FLAG_SPEC_MAP
+	//Unlit objects are given a specular shine for the niche cases where they appear.
 	baseColor.rgb += pow(1.0 - clamp(dot(eyeDir, normal), 0.0, 1.0), 5.0 * clamp(glossData, 0.01, 1.0)) * specColor.rgb;
+  #ifdef FLAG_DEFERRED
+	  // If there is no lighting then we copy the color data so far into emissive
+    emissiveColor.rgb += baseColor.rgb;
   #endif
- #endif
 #endif
+
 #ifdef FLAG_ENV_MAP
 	#ifdef FLAG_LIGHT
 	// Bit of a hack here, pretend we're doing blinn-phong shading and use a (modified version of) the derivation from
@@ -401,19 +371,14 @@ void main()
 	emissiveColor.rgb += (specEnvLighting + diffEnvLighting) * baseColor.a;
 	#endif
 #endif
-#ifdef FLAG_GLOW_MAP
+	//Glowmap handling
 	vec3 glowColor = texture(sGlowmap, vec3(texCoord, float(sGlowmapIndex))).rgb;
  #ifdef FLAG_HDR
 	glowColor = srgb_to_linear(glowColor) * GLOW_MAP_SRGB_MULTIPLIER;
  #endif
- #ifdef FLAG_MISC_MAP
-  #ifdef FLAG_TEAMCOLOR
 	float glowColorLuminance = dot(glowColor, vec3(0.299, 0.587, 0.114));
 	glowColor = team_glow_enabled ? mix(max(team_color_glow, vec3(0.0)), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;
-  #endif
- #endif
    emissiveColor.rgb += glowColor * GLOW_MAP_INTENSITY;
-#endif
 
 #ifdef FLAG_FOG
 	vec3 finalFogColor = fogColor.rgb;
@@ -469,7 +434,7 @@ void main()
 #ifdef FLAG_DEFERRED
 	fragOut1 = vec4(vertIn.position.xyz, 1.0);
 	fragOut2 = vec4(normal, glossData);
-	fragOut3 = vec4(specColor.rgb, fresnelFactor);
+	fragOut3 = vec4(specColor.rgb, 0.0);
 	fragOut4 = emissiveColor;
 #endif
 }

--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -186,9 +186,7 @@ void main(void)
 #ifdef FLAG_ENV_MAP
 		vertOut.envReflect = vertIn[vert].envReflect;
 #endif
-#ifdef FLAG_NORMAL_MAP
 		vertOut.tangentMatrix = vertIn[vert].tangentMatrix;
-#endif
 #ifdef FLAG_FOG
 		vertOut.fogDist = vertIn[vert].fogDist;
 #endif
@@ -239,9 +237,7 @@ void main(void)
 #ifdef FLAG_ENV_MAP
 			vertOut.envReflect = vertIn[vert].envReflect;
 #endif
-#ifdef FLAG_NORMAL_MAP
 			vertOut.tangentMatrix = vertIn[vert].tangentMatrix;
-#endif
 #ifdef FLAG_FOG
 			vertOut.fogDist = vertIn[vert].fogDist;
 #endif

--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -61,20 +61,20 @@ layout (std140) uniform modelData {
 	int blend_alpha;
 
 	vec3 emissionFactor;
-	bool overrideDiffuse;
+	bool overrideDiffuse_;
 
-	vec3 diffuseClr;
-	bool overrideGlow;
+	vec3 diffuseClr_;
+	bool overrideGlow_;
 
-	vec3 glowClr;
-	bool overrideSpec;
+	vec3 glowClr_;
+	bool overrideSpec_;
 
-	vec3 specClr;
+	vec3 specClr_;
 	bool alphaGloss;
 
 	bool gammaSpec;
 	bool envGloss;
-	bool alpha_spec;
+	bool alpha_spec_;
 	int effect_num;
 
 	vec4 fogColor;
@@ -95,7 +95,7 @@ layout (std140) uniform modelData {
 	float middist;
 	float fardist;
 
-	vec2 normalAlphaMinMax;
+	vec2 normalAlphaMinMax_;
 	int sBasemapIndex;
 	int sGlowmapIndex;
 

--- a/code/def_files/data/effects/main-v.sdr
+++ b/code/def_files/data/effects/main-v.sdr
@@ -56,20 +56,20 @@ layout (std140) uniform modelData {
 	int blend_alpha;
 
 	vec3 emissionFactor;
-	bool overrideDiffuse;
+	bool overrideDiffuse_;
 
-	vec3 diffuseClr;
-	bool overrideGlow;
+	vec3 diffuseClr_;
+	bool overrideGlow_;
 
-	vec3 glowClr;
-	bool overrideSpec;
+	vec3 glowClr_;
+	bool overrideSpec_;
 
-	vec3 specClr;
+	vec3 specClr_;
 	bool alphaGloss;
 
 	bool gammaSpec;
 	bool envGloss;
-	bool alpha_spec;
+	bool alpha_spec_;
 	int effect_num;
 
 	vec4 fogColor;
@@ -90,7 +90,7 @@ layout (std140) uniform modelData {
 	float middist;
 	float fardist;
 
-	vec2 normalAlphaMinMax;
+	vec2 normalAlphaMinMax_;
 	int sBasemapIndex;
 	int sGlowmapIndex;
 

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -72,15 +72,6 @@ bool PostProcessing_override = false;
 bool Shadow_override = false;
 bool Trail_render_override = false;
 
-bool Basemap_color_override_set = false;
-float Basemap_color_override[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-
-bool Glowmap_color_override_set = false;
-float Glowmap_color_override[3] = {0.0f, 0.0f, 0.0f};
-
-bool Specmap_color_override_set = false;
-float Specmap_color_override[3] = {0.0f, 0.0f, 0.0f};
-
 // Values used for noise for thruster animations
 float Noise[NOISE_NUM_FRAMES] = { 
 	0.468225f,

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -144,16 +144,7 @@ extern bool PostProcessing_override;
 extern bool Shadow_override;
 extern bool Trail_render_override;
 
-extern bool Basemap_color_override_set;
-extern float Basemap_color_override[4];
-
-extern bool Glowmap_color_override_set;
-extern float Glowmap_color_override[3];
-
-extern bool Specmap_color_override_set;
-extern float Specmap_color_override[3];
-
-// game skill levels 
+// game skill levels
 #define	NUM_SKILL_LEVELS	5
 
 //====================================================================================

--- a/code/graphics/color.cpp
+++ b/code/graphics/color.cpp
@@ -87,6 +87,17 @@ void hdr_color::set_rgb(const int* const new_rgb)
 	this->set_rgb(new_rgb[0], new_rgb[1], new_rgb[2]);
 }
 
+/**
+ * @brief fill a set of ubytes with the current colors
+ */
+void hdr_color::fill_rgba_8bpp(ubyte * r_io, ubyte * g_io, ubyte * b_io,  ubyte * a_io)
+{
+	*r_io = (ubyte (MIN(MAX(0.0f,(red * intensity)),1.0f) * 255.0f) );
+	*b_io = (ubyte (MIN(MAX(0.0f,(green * intensity)),1.0f) * 255.0f));
+	*g_io = (ubyte (MIN(MAX(0.0f,(blue * intensity)),1.0f) * 255.0f));
+	*a_io = (ubyte (MIN(MAX(0.0f,alpha),1.0f) * 255.0f));
+}
+
 
 /**
  * @brief retreives unmultiplied 0.0f-1.0f color component.

--- a/code/graphics/color.h
+++ b/code/graphics/color.h
@@ -21,6 +21,8 @@ public:
 	void set_rgb(const color* const new_rgb);
 	void set_rgb(const int* const new_rgb);
 
+	void fill_rgba_8bpp(ubyte * r_io, ubyte * b_io, ubyte * g_io, ubyte * a_io);
+
 	float r() const;
 	float r(const float in);
 	float r(const int in);

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -6,6 +6,7 @@
 #include "light.h"
 #include "globalincs/systemvars.h"
 #include "shadows.h"
+#include "mod_table/mod_table.h"
 
 namespace {
 void scale_matrix(matrix4& mat, const vec3d& scale) {
@@ -94,7 +95,8 @@ void convert_model_material(model_uniform_data* data_out,
 		}
 
 	}
-	data_out->defaultGloss = 0.6f;
+
+	data_out->defaultGloss = int(blank_gloss_value*255.0f);
 
 	if (shader_flags & SDR_FLAG_MODEL_DIFFUSE_MAP) {
 		if (material.is_desaturated()) {
@@ -102,7 +104,6 @@ void convert_model_material(model_uniform_data* data_out,
 		} else {
 			data_out->desaturate = 0;
 		}
-
 
 		switch (material.get_blend_mode()) {
 		case ALPHA_BLEND_PREMULTIPLIED:
@@ -125,26 +126,20 @@ void convert_model_material(model_uniform_data* data_out,
 
 	if (shader_flags & SDR_FLAG_MODEL_SPEC_MAP) {
 
+
 		if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) {
 			data_out->sSpecmapIndex = bm_get_array_index(material.get_texture_map(TM_SPEC_GLOSS_TYPE));
 
-			data_out->gammaSpec = 1;
 			data_out->alphaGloss = 1;
 
 		} else {
 			data_out->sSpecmapIndex = bm_get_array_index(material.get_texture_map(TM_SPECULAR_TYPE));
 
-			data_out->gammaSpec = 0;
 			data_out->alphaGloss = 0;
 		}
 	}
 
 	if (shader_flags & SDR_FLAG_MODEL_ENV_MAP) {
-		if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) {
-			data_out->envGloss = 1;
-		} else {
-			data_out->envGloss = 0;
-		}
 
 		data_out->envMatrix = gr_env_texture_matrix;
 	}

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -103,14 +103,6 @@ void convert_model_material(model_uniform_data* data_out,
 			data_out->desaturate = 0;
 		}
 
-		if (Basemap_color_override_set) {
-			data_out->overrideDiffuse = 1;
-			data_out->diffuseClr.xyz.x = Basemap_color_override[0];
-			data_out->diffuseClr.xyz.y = Basemap_color_override[1];
-			data_out->diffuseClr.xyz.z = Basemap_color_override[2];
-		} else {
-			data_out->overrideDiffuse = 0;
-		}
 
 		switch (material.get_blend_mode()) {
 		case ALPHA_BLEND_PREMULTIPLIED:
@@ -128,26 +120,10 @@ void convert_model_material(model_uniform_data* data_out,
 	}
 
 	if (shader_flags & SDR_FLAG_MODEL_GLOW_MAP) {
-		if (Glowmap_color_override_set) {
-			data_out->overrideGlow = 1;
-			data_out->glowClr.xyz.x = Glowmap_color_override[0];
-			data_out->glowClr.xyz.y = Glowmap_color_override[1];
-			data_out->glowClr.xyz.z = Glowmap_color_override[2];
-		} else {
-			data_out->overrideGlow = 0;
-		}
 		data_out->sGlowmapIndex = bm_get_array_index(material.get_texture_map(TM_GLOW_TYPE));
 	}
 
 	if (shader_flags & SDR_FLAG_MODEL_SPEC_MAP) {
-		if (Specmap_color_override_set) {
-			data_out->overrideSpec = 1;
-			data_out->specClr.xyz.x = Specmap_color_override[0];
-			data_out->specClr.xyz.y = Specmap_color_override[1];
-			data_out->specClr.xyz.z = Specmap_color_override[2];
-		} else {
-			data_out->overrideSpec = 0;
-		}
 
 		if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) {
 			data_out->sSpecmapIndex = bm_get_array_index(material.get_texture_map(TM_SPEC_GLOSS_TYPE));

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -113,10 +113,10 @@ struct model_uniform_data {
 	int overrideSpec_; //Unused, to be removed.
 
 	vec3d specClr_; //Unused, to be removed.
-	int alphaGloss;
+	int alphaGloss; //Unused, to be removed.
 
-	int gammaSpec;
-	int envGloss;
+	int gammaSpec_; //Unused, to be removed.
+	int envGloss_; //Unused, to be removed.
 	int alpha_spec_; //Unused, to be removed.
 	int effect_num;
 

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -104,20 +104,20 @@ struct model_uniform_data {
 	int blend_alpha;
 
 	vec3d emissionFactor;
-	int overrideDiffuse;
+	int overrideDiffuse_; //Unused, to be removed.
 
-	vec3d diffuseClr;
-	int overrideGlow;
+	vec3d diffuseClr_; //Unused, to be removed.
+	int overrideGlow_; //Unused, to be removed.
 
-	vec3d glowClr;
-	int overrideSpec;
+	vec3d glowClr_; //Unused, to be removed.
+	int overrideSpec_; //Unused, to be removed.
 
-	vec3d specClr;
+	vec3d specClr_; //Unused, to be removed.
 	int alphaGloss;
 
 	int gammaSpec;
 	int envGloss;
-	int alpha_spec;
+	int alpha_spec_; //Unused, to be removed.
 	int effect_num;
 
 	vec4 fogColor;
@@ -138,7 +138,7 @@ struct model_uniform_data {
 	float middist;
 	float fardist;
 
-	vec2d normalAlphaMinMax;
+	vec2d normalAlphaMinMax_;
 	int sBasemapIndex;
 	int sGlowmapIndex;
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -102,7 +102,12 @@ extern struct shadow_disable_overrides {
 } Shadow_disable_overrides;
 extern float Thruster_easing;
 extern bool Always_use_distant_firepoints;
-
+extern int blank_reflect_texture;
+extern int blank_glow_texture;
+extern int blank_ao_texture;
+extern int blank_misc_texture;
+extern int blank_normal_texture;
+extern float blank_gloss_value;
 void mod_table_init();
 void mod_table_post_process();
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -9,6 +9,7 @@
 
 
 
+#include "bmpman/bm_internal.h"
 #define MODEL_LIB
 
 #include "bmpman/bmpman.h"
@@ -2932,8 +2933,24 @@ int texture_info::SetTexture(int n_tex)
 	if(n_tex != -1 && !bm_is_valid(n_tex))
 		return texture;
 
+	//if there already is a texture and it isn't what we're switching to, release it.
+	if (texture >= 0 && texture != original_texture && texture != n_tex) {
+		//bm_release(texture);
+	}
+
+	//If the new texture isn't the original texture, then we did not go through
+	//LoadTexture(), and need t o claim this texture.
+	if ( n_tex != original_texture && texture != n_tex) {
+		//bm_use(n_tex);
+	}
+
 	//Set the new texture
 	texture = n_tex;
+
+
+	//if this is being used to set a currently blank texture, now set original 
+	if(original_texture < 0)
+		original_texture = texture;
 
 	//If it is intentionally invalid, blank everything else
 	if(n_tex == -1)
@@ -2951,7 +2968,7 @@ int texture_info::SetTexture(int n_tex)
 
 		this->total_time = (num_frames / ((fps > 0) ? (float)fps : 1.0f));
 	}
-
+	
 	return texture;
 }
 


### PR DESCRIPTION
Also fixes the no-specular regression, after a fashion, and adds configurability for the default material properties of unset maps, and removes many of the compiler directive flags in shaders for simplicity and stuff.

They're all related changes, honest! 

In draft because none of these are actually done yet. The no-spec works, anyway. Not all the configuration is implemented. There's a squirrely bug remaining in skybox rendering. There's some dirty hacks in the implementation I can probably fix and some I probably can't. I may need to make another bmpman function to modify a texture in place to clean everything up.

But if you feel like looking at my mess, now you can!
