### PR TITLE
Refactor Lua Enums

### DIFF
--- a/code/scripting/api/libs/bitops.cpp
+++ b/code/scripting/api/libs/bitops.cpp
@@ -40,31 +40,31 @@ ADE_FUNC(OR, l_BitOps, "number, number, [number, number, number, number, number,
 ADE_FUNC(EnumAND, l_BitOps, "enumeration, enumeration, [enumeration, enumeration, enumeration, enumeration, enumeration, enumeration, enumeration, enumeration]", "Values for which bitwise boolean AND operation is performed", "number", "Result of the AND operation")
 {
 	enum_h a[10];
-	int c;
+	enum_h c;
 	int n = ade_get_args(L, "oo|oooooooo", l_Enum.Get(&a[0]), l_Enum.Get(&a[1]), l_Enum.Get(&a[2]), l_Enum.Get(&a[3]), l_Enum.Get(&a[4]), l_Enum.Get(&a[5]), l_Enum.Get(&a[6]), l_Enum.Get(&a[7]), l_Enum.Get(&a[8]), l_Enum.Get(&a[9]));
 	if (n < 2)
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
-	c = a[0].index;
+	c = a[0];
 	for (int i = 1; i < n; ++i)
-		c &= a[i].index;
+		c = c & a[i];
 
-	return ade_set_args(L, "o", l_Enum.Set(enum_h(c)));
+	return ade_set_args(L, "o", l_Enum.Set(c));
 }
 
 ADE_FUNC(EnumOR, l_BitOps, "enumeration, enumeration, [enumeration, enumeration, enumeration, enumeration, enumeration, enumeration, enumeration, enumeration]", "Values for which bitwise boolean OR operation is performed", "number", "Result of the OR operation")
 {
 	enum_h a[10];
-	int c;
+	enum_h c;
 	int n = ade_get_args(L, "oo|oooooooo", l_Enum.Get(&a[0]), l_Enum.Get(&a[1]), l_Enum.Get(&a[2]), l_Enum.Get(&a[3]), l_Enum.Get(&a[4]), l_Enum.Get(&a[5]), l_Enum.Get(&a[6]), l_Enum.Get(&a[7]), l_Enum.Get(&a[8]), l_Enum.Get(&a[9]));
 	if (n < 2)
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
-	c = a[0].index;
+	c = a[0];
 	for (int i = 1; i < n; ++i)
-		c |= a[i].index;
+		c = c | a[i];
 
-	return ade_set_args(L, "o", l_Enum.Set(enum_h(c)));
+	return ade_set_args(L, "o", l_Enum.Set(c));
 }
 
 ADE_FUNC(XOR, l_BitOps, "number, number", "Values for which bitwise boolean XOR operation is performed", "number", "Result of the XOR operation")

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -214,7 +214,7 @@ ADE_VIRTVAR(CurrentOpacityType, l_Graphics, "enumeration", "Current alpha blendi
 			lua_Opacity_type = GR_ALPHABLEND_NONE;
 	}
 
-	int rtn;
+	lua_enum rtn;
 	switch(lua_Opacity_type)
 	{
 		case GR_ALPHABLEND_FILTER:
@@ -270,7 +270,7 @@ ADE_VIRTVAR(CurrentResizeMode, l_Graphics, "enumeration ResizeMode", "Current re
 		lua_ResizeMode = resize_arg.index - LE_GR_RESIZE_NONE;
 	}
 
-	return ade_set_args(L, "o", l_Enum.Set(enum_h(LE_GR_RESIZE_NONE + lua_ResizeMode)));
+	return ade_set_args(L, "o", l_Enum.Set(enum_h(static_cast<lua_enum>(LE_GR_RESIZE_NONE + lua_ResizeMode))));
 }
 
 ADE_FUNC(clear, l_Graphics, nullptr, "Calls gr_clear(), which fills the entire screen with the currently active color.  Useful if you want to have a fresh start for drawing things.  (Call this between setClip and resetClip if you only want to clear part of the screen.)", nullptr, nullptr)

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -2068,6 +2068,9 @@ ADE_FUNC(createPersistentParticle,
 				pi.type          = particle::PARTICLE_BITMAP;
 			}
 			break;
+		default:
+			LuaError(L, "Invalid particle enum for createParticle(). Can only support PARTICLE_* enums!");
+			return ADE_RETURN_NIL;
 		}
 	}
 
@@ -2138,6 +2141,9 @@ ADE_FUNC(createParticle,
 				pi.type          = particle::PARTICLE_BITMAP;
 			}
 			break;
+		default:
+			LuaError(L, "Invalid particle enum for createParticle(). Can only support PARTICLE_* enums!");
+			return ADE_RETURN_NIL;
 		}
 	}
 

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1135,13 +1135,13 @@ ADE_FUNC(createDebris,
 
 	if (create_flags != nullptr)
 	{
-		if (!create_flags->IsValid())
+		if (!create_flags->IsValid() || !create_flags->value)
 			return ade_set_args(L, "o", l_Debris.Set(object_h()));
 
-		is_hull = (create_flags->index & LE_DC_IS_HULL);
-		vaporize = (create_flags->index & LE_DC_VAPORIZE);
-		set_velocity = (create_flags->index & LE_DC_SET_VELOCITY);
-		fire_hook = (create_flags->index & LE_DC_FIRE_HOOK);
+		is_hull = (*create_flags->value & LE_DC_IS_HULL);
+		vaporize = (*create_flags->value & LE_DC_VAPORIZE);
+		set_velocity = (*create_flags->value & LE_DC_SET_VELOCITY);
+		fire_hook = (*create_flags->value & LE_DC_FIRE_HOOK);
 	}
 
 	int spark_timeout_millis = spark_timeout < 0.0f ? -1 : fl2i(spark_timeout * MILLISECONDS_PER_SECOND);

--- a/code/scripting/api/libs/testing.cpp
+++ b/code/scripting/api/libs/testing.cpp
@@ -168,6 +168,9 @@ ADE_FUNC_DEPRECATED(createParticle,
 				    pi.type          = particle::PARTICLE_BITMAP;
 			    }
 			    break;
+			default:
+				LuaError(L, "Invalid particle enum for createParticle(). Can only support PARTICLE_* enums!");
+				return ADE_RETURN_NIL;
 		}
 	}
 

--- a/code/scripting/api/objs/enums.cpp
+++ b/code/scripting/api/objs/enums.cpp
@@ -8,168 +8,164 @@
 namespace scripting {
 namespace api {
 
-//**********OBJECT: constant class
-//WMC NOTE -
-//While you can have enumeration indexes in any order, make sure
-//that any new enumerations have indexes of NEXT INDEX (see below)
-//or after. Don't forget to increment NEXT INDEX after you're done.
-//=====================================
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-// clang-format off
-flag_def_list Enumerations[] = {
-	{"ALPHABLEND_FILTER", LE_ALPHABLEND_FILTER, 0},
-	{"ALPHABLEND_NONE", LE_ALPHABLEND_NONE, 0},
-	{"CFILE_TYPE_NORMAL", LE_CFILE_TYPE_NORMAL, 0},
-	{"CFILE_TYPE_MEMORY_MAPPED", LE_CFILE_TYPE_MEMORY_MAPPED, 0},
-	{"MOUSE_LEFT_BUTTON", LE_MOUSE_LEFT_BUTTON, 0},
-	{"MOUSE_RIGHT_BUTTON", LE_MOUSE_RIGHT_BUTTON, 0},
-	{"MOUSE_MIDDLE_BUTTON", LE_MOUSE_MIDDLE_BUTTON, 0},
-	{"ORDER_ATTACK", LE_ORDER_ATTACK, 0},
-	{"ORDER_ATTACK_ANY", LE_ORDER_ATTACK_ANY, 0},
-	{"ORDER_DEPART", LE_ORDER_DEPART, 0},
-	{"ORDER_DISABLE", LE_ORDER_DISABLE, 0},
-	{"ORDER_DISARM", LE_ORDER_DISARM, 0},
-	{"ORDER_DOCK", LE_ORDER_DOCK, 0},
-	{"ORDER_EVADE", LE_ORDER_EVADE, 0},
-	{"ORDER_FLY_TO", LE_ORDER_FLY_TO, 0},
-	{"ORDER_FORM_ON_WING", LE_ORDER_FORM_ON_WING, 0},
-	{"ORDER_GUARD", LE_ORDER_GUARD, 0},
-	{"ORDER_IGNORE_SHIP", LE_ORDER_IGNORE, 0},
-	{"ORDER_KEEP_SAFE_DISTANCE", LE_ORDER_KEEP_SAFE_DISTANCE, 0},
-	{"ORDER_PLAY_DEAD", LE_ORDER_PLAY_DEAD, 0},
-	{"ORDER_PLAY_DEAD_PERSISTENT", LE_ORDER_PLAY_DEAD_PERSISTENT, 0},
-	{"ORDER_REARM", LE_ORDER_REARM, 0},
-	{"ORDER_STAY_NEAR", LE_ORDER_STAY_NEAR, 0},
-	{"ORDER_STAY_STILL", LE_ORDER_STAY_STILL, 0},
-	{"ORDER_UNDOCK", LE_ORDER_UNDOCK, 0},
-	{"ORDER_WAYPOINTS", LE_ORDER_WAYPOINTS, 0},
-	{"ORDER_WAYPOINTS_ONCE", LE_ORDER_WAYPOINTS_ONCE, 0},
-	{"ORDER_ATTACK_WING", LE_ORDER_ATTACK_WING, 0},
-	{"ORDER_GUARD_WING", LE_ORDER_GUARD_WING, 0},
-	{"ORDER_ATTACK_SHIP_CLASS", LE_ORDER_ATTACK_SHIP_CLASS, 0},
-	{"PARTICLE_DEBUG", LE_PARTICLE_DEBUG, 0},
-	{"PARTICLE_BITMAP", LE_PARTICLE_BITMAP, 0},
-	{"PARTICLE_FIRE", LE_PARTICLE_FIRE, 0},
-	{"PARTICLE_SMOKE", LE_PARTICLE_SMOKE, 0},
-	{"PARTICLE_SMOKE2", LE_PARTICLE_SMOKE2, 0},
-	{"PARTICLE_PERSISTENT_BITMAP", LE_PARTICLE_PERSISTENT_BITMAP, 0},
-	{"SEXPVAR_CAMPAIGN_PERSISTENT", LE_SEXPVAR_CAMPAIGN_PERSISTENT, 0},
-	{"SEXPVAR_NOT_PERSISTENT", LE_SEXPVAR_NOT_PERSISTENT, 0},
-	{"SEXPVAR_PLAYER_PERSISTENT", LE_SEXPVAR_PLAYER_PERSISTENT, 0},
-	{"SEXPVAR_TYPE_NUMBER", LE_SEXPVAR_TYPE_NUMBER, 0},
-	{"SEXPVAR_TYPE_STRING", LE_SEXPVAR_TYPE_STRING, 0},
-	{"TEXTURE_STATIC", LE_TEXTURE_STATIC, 0},
-	{"TEXTURE_DYNAMIC", LE_TEXTURE_DYNAMIC, 0},
-	{"LOCK", LE_LOCK, 0},
-	{"UNLOCK", LE_UNLOCK, 0},
-	{"NONE", LE_NONE, 0},
-	{"SHIELD_FRONT", LE_SHIELD_FRONT, 0},
-	{"SHIELD_LEFT", LE_SHIELD_LEFT, 0},
-	{"SHIELD_RIGHT", LE_SHIELD_RIGHT, 0},
-	{"SHIELD_BACK", LE_SHIELD_BACK, 0},
-	{"MISSION_REPEAT", LE_MISSION_REPEAT, 0},
-	{"NORMAL_CONTROLS", LE_NORMAL_CONTROLS, 0},
-	{"LUA_STEERING_CONTROLS", LE_LUA_STEERING_CONTROLS, 0},
-	{"LUA_FULL_CONTROLS", LE_LUA_FULL_CONTROLS, 0},
-	{"NORMAL_BUTTON_CONTROLS", LE_NORMAL_BUTTON_CONTROLS, 0},
-	{"LUA_ADDITIVE_BUTTON_CONTROL", LE_LUA_ADDITIVE_BUTTON_CONTROL, 0},
-	{"LUA_OVERRIDE_BUTTON_CONTROL", LE_LUA_OVERRIDE_BUTTON_CONTROL, 0},
-	{"VM_INTERNAL", LE_VM_INTERNAL, 0},
-	{"VM_EXTERNAL", LE_VM_EXTERNAL, 0},
-	{"VM_TRACK", LE_VM_TRACK, 0},
-	{"VM_DEAD_VIEW", LE_VM_DEAD_VIEW, 0},
-	{"VM_CHASE", LE_VM_CHASE, 0},
-	{"VM_OTHER_SHIP", LE_VM_OTHER_SHIP, 0},
-	{"VM_EXTERNAL_CAMERA_LOCKED", LE_VM_EXTERNAL_CAMERA_LOCKED, 0},
-	{"VM_CAMERA_LOCKED", LE_VM_CAMERA_LOCKED, 0},
-	{"VM_WARP_CHASE", LE_VM_WARP_CHASE, 0},
-	{"VM_PADLOCK_UP", LE_VM_PADLOCK_UP, 0},
-	{"VM_PADLOCK_REAR", LE_VM_PADLOCK_REAR, 0},
-	{"VM_PADLOCK_LEFT", LE_VM_PADLOCK_LEFT, 0},
-	{"VM_PADLOCK_RIGHT", LE_VM_PADLOCK_RIGHT, 0},
-	{"VM_WARPIN_ANCHOR", LE_VM_WARPIN_ANCHOR, 0},
-	{"VM_TOPDOWN", LE_VM_TOPDOWN, 0},
-	{"VM_FREECAMERA", LE_VM_FREECAMERA, 0},
-	{"VM_CENTERING", LE_VM_CENTERING, 0},
-	{"MESSAGE_PRIORITY_LOW", LE_MESSAGE_PRIORITY_LOW, 0},
-	{"MESSAGE_PRIORITY_NORMAL", LE_MESSAGE_PRIORITY_NORMAL, 0},
-	{"MESSAGE_PRIORITY_HIGH", LE_MESSAGE_PRIORITY_HIGH, 0},
-	{"OPTION_TYPE_SELECTION", LE_OPTION_TYPE_SELECTION, 0},
-	{"OPTION_TYPE_RANGE", LE_OPTION_TYPE_RANGE, 0},
-	{"AUDIOSTREAM_EVENTMUSIC", LE_ASF_EVENTMUSIC, 0},
-	{"AUDIOSTREAM_MENUMUSIC", LE_ASF_MENUMUSIC, 0},
-	{"AUDIOSTREAM_VOICE", LE_ASF_VOICE, 0},
-	{"CONTEXT_VALID", LE_CONTEXT_VALID, 0},
-	{"CONTEXT_SUSPENDED", LE_CONTEXT_SUSPENDED, 0},
-	{"CONTEXT_INVALID", LE_CONTEXT_INVALID, 0},
-	{"FIREBALL_MEDIUM_EXPLOSION", LE_FIREBALL_MEDIUM_EXPLOSION, 0},
-	{"FIREBALL_LARGE_EXPLOSION", LE_FIREBALL_LARGE_EXPLOSION, 0},
-	{"FIREBALL_WARP_EFFECT", LE_FIREBALL_WARP_EFFECT, 0},
-	{"GR_RESIZE_NONE", LE_GR_RESIZE_NONE, 0},
-	{"GR_RESIZE_FULL", LE_GR_RESIZE_FULL, 0},
-	{"GR_RESIZE_FULL_CENTER", LE_GR_RESIZE_FULL_CENTER, 0},
-	{"GR_RESIZE_MENU", LE_GR_RESIZE_MENU, 0},
-	{"GR_RESIZE_MENU_ZOOMED", LE_GR_RESIZE_MENU_ZOOMED, 0},
-	{"GR_RESIZE_MENU_NO_OFFSET", LE_GR_RESIZE_MENU_NO_OFFSET, 0},
-	// the following OS_ definitions use bitfield values, not the indexes in enums.h
-	{"OS_NONE", 0, 0},
-	{"OS_MAIN", OS_MAIN, 0},
-	{"OS_ENGINE", OS_ENGINE, 0},
-	{"OS_TURRET_BASE_ROTATION", OS_TURRET_BASE_ROTATION, 0},
-	{"OS_TURRET_GUN_ROTATION", OS_TURRET_GUN_ROTATION, 0},
-	{"OS_SUBSYS_ALIVE", OS_SUBSYS_ALIVE, 0},
-	{"OS_SUBSYS_DEAD", OS_SUBSYS_DEAD, 0},
-	{"OS_SUBSYS_DAMAGED", OS_SUBSYS_DAMAGED, 0},
-	{"OS_SUBSYS_ROTATION", OS_SUBSYS_ROTATION, 0},
-	{"OS_PLAY_ON_PLAYER", OS_PLAY_ON_PLAYER, 0},
-	{"OS_LOOPING_DISABLED", OS_LOOPING_DISABLED, 0},
-	// end of OS_ definitions
-	{ "MOVIE_PRE_FICTION", LE_MOVIE_PRE_FICTION, 0 },
-	{ "MOVIE_PRE_CMD_BRIEF", LE_MOVIE_PRE_CMD_BRIEF, 0 },
-	{ "MOVIE_PRE_BRIEF", LE_MOVIE_PRE_BRIEF, 0 },
-	{ "MOVIE_PRE_GAME", LE_MOVIE_PRE_GAME, 0 },
-	{ "MOVIE_PRE_DEBRIEF", LE_MOVIE_PRE_DEBRIEF, 0 },
-	{ "MOVIE_POST_DEBRIEF", LE_MOVIE_POST_DEBRIEF, 0 },
-	{ "MOVIE_END_CAMPAIGN", LE_MOVIE_END_CAMPAIGN, 0 },
-	{"TBOX_FLASH_NAME", LE_TBOX_FLASH_NAME, 0},
-	{"TBOX_FLASH_CARGO", LE_TBOX_FLASH_CARGO, 0},
-	{"TBOX_FLASH_HULL", LE_TBOX_FLASH_HULL, 0},
-	{"TBOX_FLASH_STATUS", LE_TBOX_FLASH_STATUS, 0},
-	{"TBOX_FLASH_SUBSYS", LE_TBOX_FLASH_SUBSYS, 0},
-	{"LUAAI_ACHIEVABLE", LE_LUAAI_ACHIEVABLE, 0},
-	{"LUAAI_NOT_YET_ACHIEVABLE", LE_LUAAI_NOT_YET_ACHIEVABLE, 0},
-	{"LUAAI_UNACHIEVABLE", LE_LUAAI_UNACHIEVABLE, 0},
-	{"SCORE_BRIEFING", LE_SCORE_BRIEFING, 0},
-	{"SCORE_DEBRIEFING_SUCCESS", LE_SCORE_DEBRIEFING_SUCCESS, 0},
-	{"SCORE_DEBRIEFING_AVERAGE", LE_SCORE_DEBRIEFING_AVERAGE, 0},
-	{"SCORE_DEBRIEFING_FAILURE", LE_SCORE_DEBRIEFING_FAILURE, 0},
-	{"SCORE_FICTION_VIEWER", LE_SCORE_FICTION_VIEWER, 0},
-	{"NOT_YET_PRESENT", LE_NOT_YET_PRESENT, 0},
-	{"PRESENT", LE_PRESENT, 0},
-	{"EXITED", LE_EXITED, 0},
-	{"DC_IS_HULL", LE_DC_IS_HULL, 0},
-	{"DC_VAPORIZE", LE_DC_VAPORIZE, 0},
-	{"DC_SET_VELOCITY", LE_DC_SET_VELOCITY, 0},
-	{"DC_FIRE_HOOK", LE_DC_FIRE_HOOK, 0}
+const lua_enum_def_list Enumerations[] = {
+	{"ALPHABLEND_FILTER", LE_ALPHABLEND_FILTER, true},
+	{"ALPHABLEND_NONE", LE_ALPHABLEND_NONE, true},
+	{"CFILE_TYPE_NORMAL", LE_CFILE_TYPE_NORMAL, true},
+	{"CFILE_TYPE_MEMORY_MAPPED", LE_CFILE_TYPE_MEMORY_MAPPED, true},
+	{"MOUSE_LEFT_BUTTON", LE_MOUSE_LEFT_BUTTON, true},
+	{"MOUSE_RIGHT_BUTTON", LE_MOUSE_RIGHT_BUTTON, true},
+	{"MOUSE_MIDDLE_BUTTON", LE_MOUSE_MIDDLE_BUTTON, true},
+	{"ORDER_ATTACK", LE_ORDER_ATTACK, true},
+	{"ORDER_ATTACK_ANY", LE_ORDER_ATTACK_ANY, true},
+	{"ORDER_DEPART", LE_ORDER_DEPART, true},
+	{"ORDER_DISABLE", LE_ORDER_DISABLE, true},
+	{"ORDER_DISARM", LE_ORDER_DISARM, true},
+	{"ORDER_DOCK", LE_ORDER_DOCK, true},
+	{"ORDER_EVADE", LE_ORDER_EVADE, true},
+	{"ORDER_FLY_TO", LE_ORDER_FLY_TO, true},
+	{"ORDER_FORM_ON_WING", LE_ORDER_FORM_ON_WING, true},
+	{"ORDER_GUARD", LE_ORDER_GUARD, true},
+	{"ORDER_IGNORE_SHIP", LE_ORDER_IGNORE, true},
+	{"ORDER_KEEP_SAFE_DISTANCE", LE_ORDER_KEEP_SAFE_DISTANCE, true},
+	{"ORDER_PLAY_DEAD", LE_ORDER_PLAY_DEAD, true},
+	{"ORDER_PLAY_DEAD_PERSISTENT", LE_ORDER_PLAY_DEAD_PERSISTENT, true},
+	{"ORDER_REARM", LE_ORDER_REARM, true},
+	{"ORDER_STAY_NEAR", LE_ORDER_STAY_NEAR, true},
+	{"ORDER_STAY_STILL", LE_ORDER_STAY_STILL, true},
+	{"ORDER_UNDOCK", LE_ORDER_UNDOCK, true},
+	{"ORDER_WAYPOINTS", LE_ORDER_WAYPOINTS, true},
+	{"ORDER_WAYPOINTS_ONCE", LE_ORDER_WAYPOINTS_ONCE, true},
+	{"ORDER_ATTACK_WING", LE_ORDER_ATTACK_WING, true},
+	{"ORDER_GUARD_WING", LE_ORDER_GUARD_WING, true},
+	{"ORDER_ATTACK_SHIP_CLASS", LE_ORDER_ATTACK_SHIP_CLASS, true},
+	{"PARTICLE_DEBUG", LE_PARTICLE_DEBUG, true},
+	{"PARTICLE_BITMAP", LE_PARTICLE_BITMAP, true},
+	{"PARTICLE_FIRE", LE_PARTICLE_FIRE, true},
+	{"PARTICLE_SMOKE", LE_PARTICLE_SMOKE, true},
+	{"PARTICLE_SMOKE2", LE_PARTICLE_SMOKE2, true},
+	{"PARTICLE_PERSISTENT_BITMAP", LE_PARTICLE_PERSISTENT_BITMAP, true},
+	{"SEXPVAR_CAMPAIGN_PERSISTENT", LE_SEXPVAR_CAMPAIGN_PERSISTENT, true},
+	{"SEXPVAR_NOT_PERSISTENT", LE_SEXPVAR_NOT_PERSISTENT, true},
+	{"SEXPVAR_PLAYER_PERSISTENT", LE_SEXPVAR_PLAYER_PERSISTENT, true},
+	{"SEXPVAR_TYPE_NUMBER", LE_SEXPVAR_TYPE_NUMBER, true},
+	{"SEXPVAR_TYPE_STRING", LE_SEXPVAR_TYPE_STRING, true},
+	{"TEXTURE_STATIC", LE_TEXTURE_STATIC, true},
+	{"TEXTURE_DYNAMIC", LE_TEXTURE_DYNAMIC, true},
+	{"LOCK", LE_LOCK, true},
+	{"UNLOCK", LE_UNLOCK, true},
+	{"NONE", LE_NONE, true},
+	{"SHIELD_FRONT", LE_SHIELD_FRONT, true},
+	{"SHIELD_LEFT", LE_SHIELD_LEFT, true},
+	{"SHIELD_RIGHT", LE_SHIELD_RIGHT, true},
+	{"SHIELD_BACK", LE_SHIELD_BACK, true},
+	{"MISSION_REPEAT", LE_MISSION_REPEAT, true},
+	{"NORMAL_CONTROLS", LE_NORMAL_CONTROLS, true},
+	{"LUA_STEERING_CONTROLS", LE_LUA_STEERING_CONTROLS, true},
+	{"LUA_FULL_CONTROLS", LE_LUA_FULL_CONTROLS, true},
+	{"NORMAL_BUTTON_CONTROLS", LE_NORMAL_BUTTON_CONTROLS, true},
+	{"LUA_ADDITIVE_BUTTON_CONTROL", LE_LUA_ADDITIVE_BUTTON_CONTROL, true},
+	{"LUA_OVERRIDE_BUTTON_CONTROL", LE_LUA_OVERRIDE_BUTTON_CONTROL, true},
+	{"VM_INTERNAL", LE_VM_INTERNAL, true},
+	{"VM_EXTERNAL", LE_VM_EXTERNAL, true},
+	{"VM_TRACK", LE_VM_TRACK, true},
+	{"VM_DEAD_VIEW", LE_VM_DEAD_VIEW, true},
+	{"VM_CHASE", LE_VM_CHASE, true},
+	{"VM_OTHER_SHIP", LE_VM_OTHER_SHIP, true},
+	{"VM_EXTERNAL_CAMERA_LOCKED", LE_VM_EXTERNAL_CAMERA_LOCKED, true},
+	{"VM_CAMERA_LOCKED", LE_VM_CAMERA_LOCKED, true},
+	{"VM_WARP_CHASE", LE_VM_WARP_CHASE, true},
+	{"VM_PADLOCK_UP", LE_VM_PADLOCK_UP, true},
+	{"VM_PADLOCK_REAR", LE_VM_PADLOCK_REAR, true},
+	{"VM_PADLOCK_LEFT", LE_VM_PADLOCK_LEFT, true},
+	{"VM_PADLOCK_RIGHT", LE_VM_PADLOCK_RIGHT, true},
+	{"VM_WARPIN_ANCHOR", LE_VM_WARPIN_ANCHOR, true},
+	{"VM_TOPDOWN", LE_VM_TOPDOWN, true},
+	{"VM_FREECAMERA", LE_VM_FREECAMERA, true},
+	{"VM_CENTERING", LE_VM_CENTERING, true},
+	{"MESSAGE_PRIORITY_LOW", LE_MESSAGE_PRIORITY_LOW, true},
+	{"MESSAGE_PRIORITY_NORMAL", LE_MESSAGE_PRIORITY_NORMAL, true},
+	{"MESSAGE_PRIORITY_HIGH", LE_MESSAGE_PRIORITY_HIGH, true},
+	{"OPTION_TYPE_SELECTION", LE_OPTION_TYPE_SELECTION, true},
+	{"OPTION_TYPE_RANGE", LE_OPTION_TYPE_RANGE, true},
+	{"AUDIOSTREAM_EVENTMUSIC", LE_ASF_EVENTMUSIC, true},
+	{"AUDIOSTREAM_MENUMUSIC", LE_ASF_MENUMUSIC, true},
+	{"AUDIOSTREAM_VOICE", LE_ASF_VOICE, true},
+	{"CONTEXT_VALID", LE_CONTEXT_VALID, true},
+	{"CONTEXT_SUSPENDED", LE_CONTEXT_SUSPENDED, true},
+	{"CONTEXT_INVALID", LE_CONTEXT_INVALID, true},
+	{"FIREBALL_MEDIUM_EXPLOSION", LE_FIREBALL_MEDIUM_EXPLOSION, true},
+	{"FIREBALL_LARGE_EXPLOSION", LE_FIREBALL_LARGE_EXPLOSION, true},
+	{"FIREBALL_WARP_EFFECT", LE_FIREBALL_WARP_EFFECT, true},
+	{"GR_RESIZE_NONE", LE_GR_RESIZE_NONE, true},
+	{"GR_RESIZE_FULL", LE_GR_RESIZE_FULL, true},
+	{"GR_RESIZE_FULL_CENTER", LE_GR_RESIZE_FULL_CENTER, true},
+	{"GR_RESIZE_MENU", LE_GR_RESIZE_MENU, true},
+	{"GR_RESIZE_MENU_ZOOMED", LE_GR_RESIZE_MENU_ZOOMED, true},
+	{"GR_RESIZE_MENU_NO_OFFSET", LE_GR_RESIZE_MENU_NO_OFFSET, true},
+	{"OS_NONE", LE_OS_NONE, 0, true},
+	{"OS_MAIN", LE_OS_MAIN, OS_MAIN, true},
+	{"OS_ENGINE", LE_OS_ENGINE, OS_ENGINE, true},
+	{"OS_TURRET_BASE_ROTATION", LE_OS_TURRET_BASE_ROTATION, OS_TURRET_BASE_ROTATION, true},
+	{"OS_TURRET_GUN_ROTATION", LE_OS_TURRET_GUN_ROTATION, OS_TURRET_GUN_ROTATION, true},
+	{"OS_SUBSYS_ALIVE", LE_OS_SUBSYS_ALIVE, OS_SUBSYS_ALIVE, true},
+	{"OS_SUBSYS_DEAD", LE_OS_SUBSYS_DEAD, OS_SUBSYS_DEAD, true},
+	{"OS_SUBSYS_DAMAGED", LE_OS_SUBSYS_DAMAGED, OS_SUBSYS_DAMAGED, true},
+	{"OS_SUBSYS_ROTATION", LE_OS_SUBSYS_ROTATION, OS_SUBSYS_ROTATION, true},
+	{"OS_PLAY_ON_PLAYER", LE_OS_PLAY_ON_PLAYER, OS_PLAY_ON_PLAYER, true},
+	{"OS_LOOPING_DISABLED", LE_OS_LOOPING_DISABLED, OS_LOOPING_DISABLED, true},
+	{ "MOVIE_PRE_FICTION", LE_MOVIE_PRE_FICTION, true },
+	{ "MOVIE_PRE_CMD_BRIEF", LE_MOVIE_PRE_CMD_BRIEF, true },
+	{ "MOVIE_PRE_BRIEF", LE_MOVIE_PRE_BRIEF, true },
+	{ "MOVIE_PRE_GAME", LE_MOVIE_PRE_GAME, true },
+	{ "MOVIE_PRE_DEBRIEF", LE_MOVIE_PRE_DEBRIEF, true },
+	{ "MOVIE_POST_DEBRIEF", LE_MOVIE_POST_DEBRIEF, true },
+	{ "MOVIE_END_CAMPAIGN", LE_MOVIE_END_CAMPAIGN, true },
+	{"TBOX_FLASH_NAME", LE_TBOX_FLASH_NAME, true},
+	{"TBOX_FLASH_CARGO", LE_TBOX_FLASH_CARGO, true},
+	{"TBOX_FLASH_HULL", LE_TBOX_FLASH_HULL, true},
+	{"TBOX_FLASH_STATUS", LE_TBOX_FLASH_STATUS, true},
+	{"TBOX_FLASH_SUBSYS", LE_TBOX_FLASH_SUBSYS, true},
+	{"LUAAI_ACHIEVABLE", LE_LUAAI_ACHIEVABLE, true},
+	{"LUAAI_NOT_YET_ACHIEVABLE", LE_LUAAI_NOT_YET_ACHIEVABLE, true},
+	{"LUAAI_UNACHIEVABLE", LE_LUAAI_UNACHIEVABLE, true},
+	{"SCORE_BRIEFING", LE_SCORE_BRIEFING, true},
+	{"SCORE_DEBRIEFING_SUCCESS", LE_SCORE_DEBRIEFING_SUCCESS, true},
+	{"SCORE_DEBRIEFING_AVERAGE", LE_SCORE_DEBRIEFING_AVERAGE, true},
+	{"SCORE_DEBRIEFING_FAILURE", LE_SCORE_DEBRIEFING_FAILURE, true},
+	{"SCORE_FICTION_VIEWER", LE_SCORE_FICTION_VIEWER, true},
+	{"NOT_YET_PRESENT", LE_NOT_YET_PRESENT, true},
+	{"PRESENT", LE_PRESENT, true},
+	{"EXITED", LE_EXITED, true},
+	{"DC_IS_HULL", LE_DC_IS_HULL, (1 << 0), true},
+	{"DC_VAPORIZE", LE_DC_VAPORIZE, (1 << 1), true},
+	{"DC_SET_VELOCITY", LE_DC_SET_VELOCITY, (1 << 2), true},
+	{"DC_FIRE_HOOK", LE_DC_FIRE_HOOK, (1 << 3), true}
 };
-// clang-format on
 
-//DO NOT FORGET to increment NEXT INDEX: !!!!!!!!!!!!!
-
-size_t Num_enumerations = sizeof(Enumerations) / sizeof(flag_def_list);
+const size_t Num_enumerations = sizeof(Enumerations) / sizeof(lua_enum_def_list);
 
 
 enum_h::enum_h() {
-	index = -1;
+	index = ENUM_INVALID;
 	is_constant = false;
 }
-enum_h::enum_h(int n_index)
+enum_h::enum_h(lua_enum n_index)
 {
 	index = n_index;
 	is_constant = false;
+	for (size_t i = 0; i < Num_enumerations; i++) {
+		if (Enumerations[i].def == index) {
+			value = Enumerations[i].value;
+			break;
+		}
+	}
 }
 SCP_string enum_h::getName() const
 {
+	if (name)
+		return *name;
+
 	for (size_t i = 0; i < Num_enumerations; i++) {
 		if (Enumerations[i].def == index) {
 			return Enumerations[i].name;
@@ -178,17 +174,63 @@ SCP_string enum_h::getName() const
 
 	return SCP_string();
 }
-bool enum_h::IsValid() const { return (index > -1 && index < ENUM_NEXT_INDEX); }
+bool enum_h::IsValid() const { return index < ENUM_NEXT_INDEX || index == ENUM_COMBINATION; }
+
+enum_h operator&(const enum_h& l, const enum_h& other) {
+	Assertion(l.value && other.value, "Tried to and-combine non-combinable enums %s and %s!", l.getName().c_str(), other.getName().c_str());
+
+	enum_h enumerator{ lua_enum::ENUM_COMBINATION };
+	enumerator.value = *l.value & *other.value;
+
+	if (l.last_op == enum_h::last_combine_op::OR)
+		enumerator.name = '(' + l.getName() + ')';
+	else
+		enumerator.name = l.getName();
+
+	*enumerator.name += " & ";
+
+	if (other.last_op == enum_h::last_combine_op::OR)
+		*enumerator.name += '(' + other.getName() + ')';
+	else
+		*enumerator.name += other.getName();
+
+	enumerator.last_op = enum_h::last_combine_op::AND;
+
+	return enumerator;
+}
+
+enum_h operator|(const enum_h& l, const enum_h& other) {
+	Assertion(l.value && other.value, "Tried to or-combine non-combinable enums %s and %s!", l.getName().c_str(), other.getName().c_str());
+
+	enum_h enumerator{ lua_enum::ENUM_COMBINATION };
+	enumerator.value = *l.value | *other.value;
+
+	if (l.last_op == enum_h::last_combine_op::AND)
+		enumerator.name = '(' + l.getName() + ')';
+	else
+		enumerator.name = l.getName();
+
+	*enumerator.name += " | ";
+
+	if (other.last_op == enum_h::last_combine_op::AND)
+		*enumerator.name += '(' + other.getName() + ')';
+	else
+		*enumerator.name += other.getName();
+
+	enumerator.last_op = enum_h::last_combine_op::OR;
+
+	return enumerator;
+}
 
 ADE_OBJ(l_Enum, enum_h, "enumeration", "Enumeration object");
 
 ADE_FUNC(__newindex,
 		 l_Enum,
 		 "enumeration",
-		 "Sets enumeration to specified value (if it is not a global",
+		 "Sets enumeration to specified value (if it is not a global)",
 		 "enumeration",
 		 "enumeration") {
-	enum_h* e1 = NULL, * e2 = NULL;
+	enum_h* e1 = nullptr, * e2 = nullptr;
 	if (!ade_get_args(L, "oo", l_Enum.GetPtr(&e1), l_Enum.GetPtr(&e2))) {
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 	}
@@ -202,16 +244,16 @@ ADE_FUNC(__newindex,
 
 ADE_FUNC(__tostring,
 		 l_Enum,
-		 NULL,
+		 nullptr,
 		 "Returns enumeration name",
 		 "string",
 		 "Enumeration name, or \"<INVALID>\" if invalid") {
-	enum_h* e = NULL;
+	enum_h* e = nullptr;
 	if (!ade_get_args(L, "o", l_Enum.GetPtr(&e))) {
 		return ade_set_args(L, "s", "<INVALID>");
 	}
 
-	if (e->index < 1 || e->index >= ENUM_NEXT_INDEX) {
+	if (!e->IsValid()) {
 		return ade_set_args(L, "s", "<INVALID>");
 	}
 
@@ -228,21 +270,61 @@ ADE_FUNC(__eq,
 		 "Compares the two enumerations for equality",
 		 "boolean",
 		 "true if equal, false otherwise") {
-	enum_h* e1 = NULL;
-	enum_h* e2 = NULL;
+	enum_h* e1 = nullptr;
+	enum_h* e2 = nullptr;
 
 	if (!ade_get_args(L, "oo", l_Enum.GetPtr(&e1), l_Enum.GetPtr(&e2))) {
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 	}
 
-	if (e1 == NULL || e2 == NULL) {
+	if (e1 == nullptr || e2 == nullptr) {
 		return ADE_RETURN_FALSE;
 	}
 
-	return ade_set_args(L, "b", e1->index == e2->index);
+	return ade_set_args(L, "b", e1->index == ENUM_COMBINATION ? e1->value == e2->value : e1->index == e2->index);
 }
 
-ADE_VIRTVAR(IntValue, l_Enum, "enumeration", "Internal value of the enum.  Probably not useful unless this enum is a bitfield or corresponds to a #define somewhere else in the source code.", "number", "Integer (index) value of the enum")
+ADE_FUNC(__add,
+	l_Enum,
+	"enumeration",
+	"Calculates the logical OR of the two enums. Only applicable for certain bitfield enums (OS_*, DC_*, ...)",
+	"enumeration",
+	"Result of the OR operation. Invalid enum if input was not a valid enum or a bitfield enum.") {
+	enum_h* e1 = nullptr;
+	enum_h* e2 = nullptr;
+
+	if (!ade_get_args(L, "oo", l_Enum.GetPtr(&e1), l_Enum.GetPtr(&e2))) {
+		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
+	}
+
+	if (e1 == nullptr || e2 == nullptr || !e1->IsValid() || !e2->IsValid() || !e1->value ||!e2->value) {
+		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
+	}
+
+	return ade_set_args(L, "o", l_Enum.Set(*e1 | *e2));
+}
+
+ADE_FUNC(__mul,
+	l_Enum,
+	"enumeration",
+	"Calculates the logical AND of the two enums. Only applicable for certain bitfield enums (OS_*, DC_*, ...)",
+	"enumeration",
+	"Result of the AND operation. Invalid enum if input was not a valid enum or a bitfield enum.") {
+	enum_h* e1 = nullptr;
+	enum_h* e2 = nullptr;
+
+	if (!ade_get_args(L, "oo", l_Enum.GetPtr(&e1), l_Enum.GetPtr(&e2))) {
+		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
+	}
+
+	if (e1 == nullptr || e2 == nullptr || !e1->IsValid() || !e2->IsValid() || !e1->value || !e2->value) {
+		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
+	}
+
+	return ade_set_args(L, "o", l_Enum.Set(*e1 & *e2));
+}
+
+ADE_VIRTVAR_DEPRECATED(IntValue, l_Enum, "enumeration", "Internal value of the enum.  Probably not useful unless this enum is a bitfield or corresponds to a #define somewhere else in the source code.", "number", "Integer (index) value of the enum", gameversion::version(22, 4), "Deprecated in favor of Value")
 {
 	enum_h* e = nullptr;
 	if (!ade_get_args(L, "o", l_Enum.GetPtr(&e))) {
@@ -254,7 +336,22 @@ ADE_VIRTVAR(IntValue, l_Enum, "enumeration", "Internal value of the enum.  Proba
 		return ADE_RETURN_NIL;
 	}
 
-	return ade_set_args(L, "i", e->index);
+	return ade_set_args(L, "i", static_cast<int32_t>(e->index));
+}
+
+ADE_VIRTVAR(Value, l_Enum, "enumeration", "Internal bitfield value of the enum. -1 if the enum is not a bitfield", "number", "Integer value of the enum")
+{
+	enum_h* e = nullptr;
+	if (!ade_get_args(L, "o", l_Enum.GetPtr(&e))) {
+		return ade_set_args(L, "i", -1);
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "Value is read only!");
+		return ADE_RETURN_NIL;
+	}
+
+	return ade_set_args(L, "i", e->value.value_or(-1));
 }
 
 }

--- a/code/scripting/api/objs/enums.h
+++ b/code/scripting/api/objs/enums.h
@@ -7,147 +7,181 @@
 #include "globalincs/pstypes.h"
 #include "scripting/ade_api.h"
 
+#include <tl/optional.hpp>
+
 namespace scripting {
 namespace api {
 
-const int32_t LE_ALPHABLEND_FILTER           = 14;
-const int32_t LE_ALPHABLEND_NONE             = 27;
-const int32_t LE_CFILE_TYPE_NORMAL           = 20;
-const int32_t LE_CFILE_TYPE_MEMORY_MAPPED    = 21;
-const int32_t LE_MOUSE_LEFT_BUTTON           = 1;
-const int32_t LE_MOUSE_RIGHT_BUTTON          = 2;
-const int32_t LE_MOUSE_MIDDLE_BUTTON         = 3;
-const int32_t LE_ORDER_ATTACK                = 28;
-const int32_t LE_ORDER_ATTACK_ANY            = 29;
-const int32_t LE_ORDER_DEPART                = 30;
-const int32_t LE_ORDER_DISABLE               = 31;
-const int32_t LE_ORDER_DISARM                = 32;
-const int32_t LE_ORDER_DOCK                  = 33;
-const int32_t LE_ORDER_EVADE                 = 34;
-const int32_t LE_ORDER_FLY_TO                = 35;
-const int32_t LE_ORDER_FORM_ON_WING          = 36;
-const int32_t LE_ORDER_GUARD                 = 37;
-const int32_t LE_ORDER_IGNORE                = 38;
-const int32_t LE_ORDER_KEEP_SAFE_DISTANCE    = 39;
-const int32_t LE_ORDER_PLAY_DEAD             = 40;
-const int32_t LE_ORDER_PLAY_DEAD_PERSISTENT  = 77;
-const int32_t LE_ORDER_REARM                 = 41;
-const int32_t LE_ORDER_STAY_NEAR             = 42;
-const int32_t LE_ORDER_STAY_STILL            = 43;
-const int32_t LE_ORDER_UNDOCK                = 44;
-const int32_t LE_ORDER_WAYPOINTS             = 45;
-const int32_t LE_ORDER_WAYPOINTS_ONCE        = 46;
-const int32_t LE_ORDER_ATTACK_WING           = 69;
-const int32_t LE_ORDER_GUARD_WING            = 70;
-const int32_t LE_ORDER_ATTACK_SHIP_CLASS     = 74;
-const int32_t LE_PARTICLE_DEBUG              = 4;
-const int32_t LE_PARTICLE_BITMAP             = 5;
-const int32_t LE_PARTICLE_FIRE               = 6;
-const int32_t LE_PARTICLE_SMOKE              = 7;
-const int32_t LE_PARTICLE_SMOKE2             = 8;
-const int32_t LE_PARTICLE_PERSISTENT_BITMAP  = 9;
-const int32_t LE_SEXPVAR_CAMPAIGN_PERSISTENT = 22;
-const int32_t LE_SEXPVAR_NOT_PERSISTENT      = 23;
-const int32_t LE_SEXPVAR_PLAYER_PERSISTENT   = 24;
-const int32_t LE_SEXPVAR_TYPE_NUMBER         = 25;
-const int32_t LE_SEXPVAR_TYPE_STRING         = 26;
-const int32_t LE_TEXTURE_STATIC              = 10;
-const int32_t LE_TEXTURE_DYNAMIC             = 11;
-const int32_t LE_LOCK                        = 12;
-const int32_t LE_UNLOCK                      = 13;
-const int32_t LE_NONE                        = 15;
-const int32_t LE_SHIELD_FRONT                = 16;
-const int32_t LE_SHIELD_LEFT                 = 17;
-const int32_t LE_SHIELD_RIGHT                = 18;
-const int32_t LE_SHIELD_BACK                 = 19;
-const int32_t LE_MISSION_REPEAT              = 47;
-const int32_t LE_NORMAL_CONTROLS             = 48;
-const int32_t LE_LUA_STEERING_CONTROLS       = 49;
-const int32_t LE_LUA_FULL_CONTROLS           = 50;
-const int32_t LE_NORMAL_BUTTON_CONTROLS      = 51;
-const int32_t LE_LUA_ADDITIVE_BUTTON_CONTROL = 52;
-const int32_t LE_LUA_OVERRIDE_BUTTON_CONTROL = 53;
-const int32_t LE_VM_INTERNAL                 = 54;
-const int32_t LE_VM_EXTERNAL                 = 55;
-const int32_t LE_VM_TRACK                    = 56;
-const int32_t LE_VM_DEAD_VIEW                = 57;
-const int32_t LE_VM_CHASE                    = 58;
-const int32_t LE_VM_OTHER_SHIP               = 59;
-const int32_t LE_VM_EXTERNAL_CAMERA_LOCKED   = 60;
-const int32_t LE_VM_CAMERA_LOCKED            = 75;
-const int32_t LE_VM_WARP_CHASE               = 61;
-const int32_t LE_VM_PADLOCK_UP               = 62;
-const int32_t LE_VM_PADLOCK_REAR             = 63;
-const int32_t LE_VM_PADLOCK_LEFT             = 64;
-const int32_t LE_VM_PADLOCK_RIGHT            = 65;
-const int32_t LE_VM_WARPIN_ANCHOR            = 66;
-const int32_t LE_VM_TOPDOWN                  = 67;
-const int32_t LE_VM_FREECAMERA               = 68;
-const int32_t LE_VM_CENTERING                = 76;
-const int32_t LE_MESSAGE_PRIORITY_LOW        = 71;
-const int32_t LE_MESSAGE_PRIORITY_NORMAL     = 72;
-const int32_t LE_MESSAGE_PRIORITY_HIGH       = 73;
-const int32_t LE_OPTION_TYPE_SELECTION       = 78;
-const int32_t LE_OPTION_TYPE_RANGE           = 79;
-const int32_t LE_ASF_EVENTMUSIC              = 80;
-const int32_t LE_ASF_MENUMUSIC               = 81;
-const int32_t LE_ASF_VOICE                   = 82;
-const int32_t LE_CONTEXT_VALID               = 83;
-const int32_t LE_CONTEXT_SUSPENDED           = 84;
-const int32_t LE_CONTEXT_INVALID             = 85;
-const int32_t LE_FIREBALL_MEDIUM_EXPLOSION   = 86;
-const int32_t LE_FIREBALL_LARGE_EXPLOSION    = 87;
-const int32_t LE_FIREBALL_WARP_EFFECT        = 88;
-const int32_t LE_GR_RESIZE_NONE              = 89; // the sequence and offsets of the LE_GR_* #defines should correspond to the GR_* #defines
-const int32_t LE_GR_RESIZE_FULL              = 90;
-const int32_t LE_GR_RESIZE_FULL_CENTER       = 91;
-const int32_t LE_GR_RESIZE_MENU              = 92;
-const int32_t LE_GR_RESIZE_MENU_ZOOMED       = 93;
-const int32_t LE_GR_RESIZE_MENU_NO_OFFSET    = 94;
-const int32_t LE_TBOX_FLASH_NAME             = 95;
-const int32_t LE_TBOX_FLASH_CARGO            = 96;
-const int32_t LE_TBOX_FLASH_HULL             = 97;
-const int32_t LE_TBOX_FLASH_STATUS           = 98;
-const int32_t LE_TBOX_FLASH_SUBSYS           = 99;
-const int32_t LE_LUAAI_ACHIEVABLE			 = 100;
-const int32_t LE_LUAAI_NOT_YET_ACHIEVABLE	 = 101;
-const int32_t LE_LUAAI_UNACHIEVABLE			 = 102;
-const int32_t LE_MOVIE_PRE_FICTION           = 103; // the sequence and offsets of the LE_MOVIE_* #defines should correspond to the MOVIE_* #defines
-const int32_t LE_MOVIE_PRE_CMD_BRIEF         = 104;
-const int32_t LE_MOVIE_PRE_BRIEF             = 105;
-const int32_t LE_MOVIE_PRE_GAME              = 106;
-const int32_t LE_MOVIE_PRE_DEBRIEF           = 107;
-const int32_t LE_MOVIE_POST_DEBRIEF          = 108;
-const int32_t LE_MOVIE_END_CAMPAIGN          = 109;
-const int32_t LE_SCORE_BRIEFING              = 110; // the sequence and offsets of the LE_SCORE_* #defines should correspond to the SCORE_* #defines
-const int32_t LE_SCORE_DEBRIEFING_SUCCESS    = 111;
-const int32_t LE_SCORE_DEBRIEFING_AVERAGE    = 112;
-const int32_t LE_SCORE_DEBRIEFING_FAILURE    = 113;
-const int32_t LE_SCORE_FICTION_VIEWER        = 114;
-const int32_t LE_NOT_YET_PRESENT             = 115; // the sequence and offsets of these three #defines should correspond to the ShipStatus enums
-const int32_t LE_PRESENT                     = 116;
-const int32_t LE_EXITED                      = 117;
-const int32_t LE_DC_IS_HULL                  = (1<<0); // the following definitions are bitfields independent of the usual indexing
-const int32_t LE_DC_VAPORIZE                 = (1<<1);
-const int32_t LE_DC_SET_VELOCITY             = (1<<2);
-const int32_t LE_DC_FIRE_HOOK                = (1<<3);
+enum lua_enum : int32_t {
+	LE_ALPHABLEND_FILTER,
+	LE_ALPHABLEND_NONE,
+	LE_CFILE_TYPE_NORMAL,
+	LE_CFILE_TYPE_MEMORY_MAPPED,
+	LE_MOUSE_LEFT_BUTTON,
+	LE_MOUSE_RIGHT_BUTTON,
+	LE_MOUSE_MIDDLE_BUTTON,
+	LE_ORDER_ATTACK,
+	LE_ORDER_ATTACK_ANY,
+	LE_ORDER_DEPART,
+	LE_ORDER_DISABLE,
+	LE_ORDER_DISARM,
+	LE_ORDER_DOCK,
+	LE_ORDER_EVADE,
+	LE_ORDER_FLY_TO,
+	LE_ORDER_FORM_ON_WING,
+	LE_ORDER_GUARD,
+	LE_ORDER_IGNORE,
+	LE_ORDER_KEEP_SAFE_DISTANCE,
+	LE_ORDER_PLAY_DEAD,
+	LE_ORDER_PLAY_DEAD_PERSISTENT,
+	LE_ORDER_REARM,
+	LE_ORDER_STAY_NEAR,
+	LE_ORDER_STAY_STILL,
+	LE_ORDER_UNDOCK,
+	LE_ORDER_WAYPOINTS,
+	LE_ORDER_WAYPOINTS_ONCE,
+	LE_ORDER_ATTACK_WING,
+	LE_ORDER_GUARD_WING,
+	LE_ORDER_ATTACK_SHIP_CLASS,
+	LE_PARTICLE_DEBUG,
+	LE_PARTICLE_BITMAP,
+	LE_PARTICLE_FIRE,
+	LE_PARTICLE_SMOKE,
+	LE_PARTICLE_SMOKE2,
+	LE_PARTICLE_PERSISTENT_BITMAP,
+	LE_SEXPVAR_CAMPAIGN_PERSISTENT,
+	LE_SEXPVAR_NOT_PERSISTENT,
+	LE_SEXPVAR_PLAYER_PERSISTENT,
+	LE_SEXPVAR_TYPE_NUMBER,
+	LE_SEXPVAR_TYPE_STRING,
+	LE_TEXTURE_STATIC,
+	LE_TEXTURE_DYNAMIC,
+	LE_LOCK,
+	LE_UNLOCK,
+	LE_NONE,
+	LE_SHIELD_FRONT,
+	LE_SHIELD_LEFT,
+	LE_SHIELD_RIGHT,
+	LE_SHIELD_BACK,
+	LE_MISSION_REPEAT,
+	LE_NORMAL_CONTROLS,
+	LE_LUA_STEERING_CONTROLS,
+	LE_LUA_FULL_CONTROLS,
+	LE_NORMAL_BUTTON_CONTROLS,
+	LE_LUA_ADDITIVE_BUTTON_CONTROL,
+	LE_LUA_OVERRIDE_BUTTON_CONTROL,
+	LE_VM_INTERNAL,
+	LE_VM_EXTERNAL,
+	LE_VM_TRACK,
+	LE_VM_DEAD_VIEW,
+	LE_VM_CHASE,
+	LE_VM_OTHER_SHIP,
+	LE_VM_EXTERNAL_CAMERA_LOCKED,
+	LE_VM_CAMERA_LOCKED,
+	LE_VM_WARP_CHASE,
+	LE_VM_PADLOCK_UP,
+	LE_VM_PADLOCK_REAR,
+	LE_VM_PADLOCK_LEFT,
+	LE_VM_PADLOCK_RIGHT,
+	LE_VM_WARPIN_ANCHOR,
+	LE_VM_TOPDOWN,
+	LE_VM_FREECAMERA,
+	LE_VM_CENTERING,
+	LE_MESSAGE_PRIORITY_LOW,
+	LE_MESSAGE_PRIORITY_NORMAL,
+	LE_MESSAGE_PRIORITY_HIGH,
+	LE_OPTION_TYPE_SELECTION,
+	LE_OPTION_TYPE_RANGE,
+	LE_ASF_EVENTMUSIC,
+	LE_ASF_MENUMUSIC,
+	LE_ASF_VOICE,
+	LE_CONTEXT_VALID,
+	LE_CONTEXT_SUSPENDED,
+	LE_CONTEXT_INVALID,
+	LE_FIREBALL_MEDIUM_EXPLOSION,
+	LE_FIREBALL_LARGE_EXPLOSION,
+	LE_FIREBALL_WARP_EFFECT,
+	LE_GR_RESIZE_NONE, // the sequence and offsets of the LE_GR_* #defines should correspond to the GR_* #defines
+	LE_GR_RESIZE_FULL,
+	LE_GR_RESIZE_FULL_CENTER,
+	LE_GR_RESIZE_MENU,
+	LE_GR_RESIZE_MENU_ZOOMED,
+	LE_GR_RESIZE_MENU_NO_OFFSET,
+	LE_TBOX_FLASH_NAME,
+	LE_TBOX_FLASH_CARGO,
+	LE_TBOX_FLASH_HULL,
+	LE_TBOX_FLASH_STATUS,
+	LE_TBOX_FLASH_SUBSYS,
+	LE_LUAAI_ACHIEVABLE,
+	LE_LUAAI_NOT_YET_ACHIEVABLE,
+	LE_LUAAI_UNACHIEVABLE,
+	LE_OS_NONE,
+	LE_OS_MAIN,
+	LE_OS_ENGINE,
+	LE_OS_TURRET_BASE_ROTATION,
+	LE_OS_TURRET_GUN_ROTATION,
+	LE_OS_SUBSYS_ALIVE,
+	LE_OS_SUBSYS_DEAD,
+	LE_OS_SUBSYS_DAMAGED,
+	LE_OS_SUBSYS_ROTATION,
+	LE_OS_PLAY_ON_PLAYER,
+	LE_OS_LOOPING_DISABLED,
+	LE_MOVIE_PRE_FICTION, // the sequence and offsets of the LE_MOVIE_* #defines should correspond to the MOVIE_* #defines
+	LE_MOVIE_PRE_CMD_BRIEF,
+	LE_MOVIE_PRE_BRIEF,
+	LE_MOVIE_PRE_GAME,
+	LE_MOVIE_PRE_DEBRIEF,
+	LE_MOVIE_POST_DEBRIEF,
+	LE_MOVIE_END_CAMPAIGN,
+	LE_SCORE_BRIEFING, // the sequence and offsets of the LE_SCORE_* #defines should correspond to the SCORE_* #defines
+	LE_SCORE_DEBRIEFING_SUCCESS,
+	LE_SCORE_DEBRIEFING_AVERAGE,
+	LE_SCORE_DEBRIEFING_FAILURE,
+	LE_SCORE_FICTION_VIEWER,
+	LE_NOT_YET_PRESENT, // the sequence and offsets of these three #defines should correspond to the ShipStatus enums
+	LE_PRESENT,
+	LE_EXITED,
+	LE_DC_IS_HULL,
+	LE_DC_VAPORIZE,
+	LE_DC_SET_VELOCITY,
+	LE_DC_FIRE_HOOK,
+	ENUM_NEXT_INDEX,
+	ENUM_COMBINATION,
+	ENUM_INVALID
+};
 
-const int ENUM_NEXT_INDEX = 118; // <<<<<<<<<<<<<<<<<<<<<<
-extern flag_def_list Enumerations[];
-extern size_t Num_enumerations;
+struct lua_enum_def_list : public flag_def_list_new<lua_enum> {
+	tl::optional<int32_t> value;
+	lua_enum_def_list(const char* name, lua_enum flag, bool in_use) : flag_def_list_new<lua_enum>{ name, flag, in_use, false }, value(tl::nullopt) {}
+	lua_enum_def_list(const char* name, lua_enum flag, int32_t in_value, bool in_use) : flag_def_list_new<lua_enum>{ name, flag, in_use, false }, value(in_value) {}
+};
+
+extern const lua_enum_def_list Enumerations[];
+extern const size_t Num_enumerations;
 
 struct enum_h {
-	int index;
+private:
+	enum class last_combine_op { NATIVE, AND, OR };
+	tl::optional<SCP_string> name;
+	last_combine_op last_op = last_combine_op::NATIVE;
+
+public:
+	lua_enum index;
 	bool is_constant;
+	tl::optional<int32_t> value;
 
 	enum_h();
 
-	explicit enum_h(int n_index);
+	explicit enum_h(lua_enum n_index);
 
 	SCP_string getName() const;
 
 	bool IsValid() const;
+
+	friend enum_h operator&(const enum_h& l, const enum_h& other);
+	friend enum_h operator|(const enum_h& l, const enum_h& other);
 };
+
 
 DECLARE_ADE_OBJ(l_Enum, enum_h);
 

--- a/code/scripting/api/objs/enums.h
+++ b/code/scripting/api/objs/enums.h
@@ -152,8 +152,8 @@ enum lua_enum : int32_t {
 
 struct lua_enum_def_list : public flag_def_list_new<lua_enum> {
 	tl::optional<int32_t> value;
-	lua_enum_def_list(const char* name, lua_enum flag, bool in_use) : flag_def_list_new<lua_enum>{ name, flag, in_use, false }, value(tl::nullopt) {}
-	lua_enum_def_list(const char* name, lua_enum flag, int32_t in_value, bool in_use) : flag_def_list_new<lua_enum>{ name, flag, in_use, false }, value(in_value) {}
+	lua_enum_def_list(const char* enum_name, lua_enum flag, bool used) : flag_def_list_new<lua_enum>{ enum_name, flag, used, false }, value(tl::nullopt) {}
+	lua_enum_def_list(const char* enum_name, lua_enum flag, int32_t val, bool used) : flag_def_list_new<lua_enum>{ enum_name, flag, used, false }, value(val) {}
 };
 
 extern const lua_enum_def_list Enumerations[];

--- a/code/scripting/api/objs/enums.h
+++ b/code/scripting/api/objs/enums.h
@@ -152,8 +152,8 @@ enum lua_enum : int32_t {
 
 struct lua_enum_def_list : public flag_def_list_new<lua_enum> {
 	tl::optional<int32_t> value;
-	lua_enum_def_list(const char* enum_name, lua_enum flag, bool used) : flag_def_list_new<lua_enum>{ enum_name, flag, used, false }, value(tl::nullopt) {}
-	lua_enum_def_list(const char* enum_name, lua_enum flag, int32_t val, bool used) : flag_def_list_new<lua_enum>{ enum_name, flag, used, false }, value(val) {}
+	constexpr lua_enum_def_list(const char* enum_name, lua_enum flag, bool used) : flag_def_list_new<lua_enum>{ enum_name, flag, used, false }, value(tl::nullopt) {}
+	constexpr lua_enum_def_list(const char* enum_name, lua_enum flag, int32_t val, bool used) : flag_def_list_new<lua_enum>{ enum_name, flag, used, false }, value(val) {}
 };
 
 extern const lua_enum_def_list Enumerations[];

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -553,7 +553,7 @@ ADE_FUNC(addPostMoveHook, l_Object, "function(object object) => void callback",
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(assignSound, l_Object, "soundentry GameSnd, [vector Offset=nil, enumeration Flags=0, subsystem Subsys=nil]",
+ADE_FUNC(assignSound, l_Object, "soundentry GameSnd, [vector Offset=nil, enumeration Flags=OS_NONE, subsystem Subsys=nil]",
 	"Assigns a sound to this object, with optional offset, sound flags (OS_XXXX), and associated subsystem.",
 	"number",
 	"Returns the index of the sound on this object, or -1 if a sound could not be assigned.")
@@ -576,8 +576,8 @@ ADE_FUNC(assignSound, l_Object, "soundentry GameSnd, [vector Offset=nil, enumera
 	auto subsys = tgsh ? tgsh->ss : nullptr;
 	if (!offset)
 		offset = &vmd_zero_vector;
-	if (enum_flags.index >= 0)
-		flags = enum_flags.index;
+	if (enum_flags.value)
+		flags = *enum_flags.value;
 
 	int snd_idx = obj_snd_assign(OBJ_INDEX(objp), gs_id, offset, flags, subsys);
 

--- a/code/scripting/api/objs/option.cpp
+++ b/code/scripting/api/objs/option.cpp
@@ -122,7 +122,7 @@ ADE_VIRTVAR(Type, l_Option, nullptr, "The type of this option. One of the OPTION
 		return ADE_RETURN_NIL;
 	}
 
-	int32_t enum_val = -1;
+	lua_enum enum_val = ENUM_INVALID;
 	switch (opt->get()->getType()) {
 	case options::OptionType::Selection:
 		enum_val = LE_OPTION_TYPE_SELECTION;

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -82,7 +82,7 @@ ADE_FUNC(remove, l_Order, NULL, "Removes the given order from the ship's priorit
 ADE_FUNC(getType, l_Order, NULL, "Gets the type of the order.", "enumeration", "The type of the order as one of the ORDER_* enumerations.")
 {
 	order_h *ohp = NULL;
-	int eh_idx = -1;
+	lua_enum eh_idx = ENUM_INVALID;
 	if(!ade_get_args(L, "o", l_Order.GetPtr(&ohp)))
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1751,6 +1751,8 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 			}
 			break;
 		}
+		default:
+			return ade_set_error(L, "b", false);
 	}
 
 	//Nothing got set!

--- a/code/scripting/api/objs/ship_registry_entry.cpp
+++ b/code/scripting/api/objs/ship_registry_entry.cpp
@@ -53,7 +53,7 @@ ADE_VIRTVAR(Status, l_ShipRegistryEntry, nullptr, "Status of ship", "enumeration
 	if (ADE_SETTING_VAR)
 		LuaError(L, "This property is read only.");
 
-	return ade_set_args(L, "o", l_Enum.Set(enum_h(LE_NOT_YET_PRESENT + (int)Ship_registry[idx].status)));
+	return ade_set_args(L, "o", l_Enum.Set(enum_h(static_cast<lua_enum>(LE_NOT_YET_PRESENT + (int)Ship_registry[idx].status))));
 }
 
 ADE_FUNC(getParsedShip, l_ShipRegistryEntry, nullptr, "Return the parsed ship associated with this ship registry entry", "parse_object", "The parsed ship, or nil if handle is invalid.  If this ship entry is for a ship-create'd ship, the returned handle may be invalid.")


### PR DESCRIPTION
This PR refactors the lua enum system away from arbitrary indices to it being a proper enum. At the same time, it facilitates explicit bitfield values to allow for bitfield enums without the double-usage of indices as was the case previously.
This fixes a number of bugs associated with lua enums:
1. Bitfield enums now no longer test as equal to other unrelated enums.
2. Bitfield enums now display their proper name instead of an arbitrary unrelated one.
3. Combined bitfield enums now properly display which combination of enums they are.
