### PR TITLE
replace keybinds in debriefing

### DIFF
--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -25,6 +25,7 @@
 #include "mission/missionbriefcommon.h"
 #include "mission/missioncampaign.h"
 #include "mission/missiongoals.h"
+#include "mission/missiontraining.h"
 #include "missionui/chatbox.h"
 #include "missionui/missiondebrief.h"
 #include "missionui/missionpause.h"
@@ -2593,10 +2594,14 @@ void debrief_disable_accept()
 
 // Goober5000 - replace any variables with their values
 // karajorma/jg18 - replace container references as well
+// MjnMixael - replace keybinds also
 void debrief_replace_stage_text(debrief_stage &stage)
 {
 	sexp_replace_variable_names_with_values(stage.text);
 	sexp_replace_variable_names_with_values(stage.recommendation_text);
 	sexp_container_replace_refs_with_values(stage.text);
 	sexp_container_replace_refs_with_values(stage.recommendation_text);
+
+	stage.text = message_translate_tokens(stage.text.c_str());
+	stage.recommendation_text = message_translate_tokens(stage.recommendation_text.c_str());
 }


### PR DESCRIPTION
Quick addition to replace keybinds in debriefings at the same time that the code already replaces variables and containers. Fixes #3241