### PR TITLE
option to always hide hidden hotkey ships

### DIFF
--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -22,6 +22,7 @@
 #include "io/timer.h"
 #include "mission/missionhotkey.h"
 #include "missionui/missionscreencommon.h"
+#include "mod_table/mod_table.h"
 #include "object/object.h"
 #include "parse/parselo.h"
 #include "playerman/player.h"
@@ -623,7 +624,7 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 		// if a ship's hotkey is the last hotkey on the list, then maybe make the hotkey -1 if
 		// we are now in mission.  Otherwise, skip this ship
 		if ( shipp->hotkey == MAX_KEYED_TARGETS ) {
-			if ( !(Game_mode & GM_IN_MISSION) )
+			if ((!(Game_mode & GM_IN_MISSION)) || hotkey_always_hide_ships)
 				continue;										// skip to next ship
 			shipp->hotkey = -1;
 		}

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -113,6 +113,7 @@ shadow_disable_overrides Shadow_disable_overrides {false, false, false, false};
 float Thruster_easing;
 bool Always_use_distant_firepoints;
 bool Discord_presence;
+bool hotkey_always_hide_ships;
 
 static auto DiscordOption = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
 							 .category("Other")
@@ -1017,6 +1018,11 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Discord_presence);
 		}
 
+		if (optional_string("$Always hide hidden ships in hotkey list:")) {
+			stuff_boolean(&hotkey_always_hide_ships);
+		}
+
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -1154,6 +1160,7 @@ void mod_table_reset()
 	Thruster_easing = 0;
 	Always_use_distant_firepoints = false;
 	Discord_presence = true;
+	hotkey_always_hide_ships = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -103,6 +103,7 @@ extern struct shadow_disable_overrides {
 extern float Thruster_easing;
 extern bool Always_use_distant_firepoints;
 extern bool Discord_presence;
+extern bool hotkey_always_hide_ships;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
Adds a game settings table flag to always hide hidden hotkey ships. Fixes #3290