### PR TITLE
ship flag to exempt it from nebula targeting restrictions

### DIFF
--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -106,6 +106,7 @@ namespace Mission {
 		SF_Fail_sound_locked_primary, 	// Kiloku - Plays fail sound when firing with locked weapons
 		SF_Fail_sound_locked_secondary,	// Kiloku - Plays fail sound when firing with locked weapons
 		SF_Aspect_immune,				// Kiloku - Ship cannot be locked onto by aspect seeking weapons
+		SF_No_nebula_targeting_limits,	// MjnMixael - Ship is always targetable in a nebula regardless of AWACS range
 
 		NUM_VALUES
 	};

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -325,7 +325,8 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "ai-attackable-if-no-collide",		Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
     { "fail-sound-locked-primary",			Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary, true, false },
     { "fail-sound-locked-secondary",		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false },
-    { "aspect-immune",						Mission::Parse_Object_Flags::SF_Aspect_immune, true, false }
+    { "aspect-immune",						Mission::Parse_Object_Flags::SF_Aspect_immune, true, false },
+	{ "no-nebula-targeting-limits",			Mission::Parse_Object_Flags::SF_No_nebula_targeting_limits, true, false},
 };
 
 const size_t Num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);

--- a/code/ship/awacs.cpp
+++ b/code/ship/awacs.cpp
@@ -232,6 +232,15 @@ float awacs_get_level(object *target, ship *viewer, int use_awacs)
 			return FULLY_TARGETABLE;
 	}
 
+	// check for an exempt ship. Exempt ships are _always_ visible
+	if (target->type == OBJ_SHIP)
+	{
+		Assert( shipp != NULL );
+		int target_is_exempt = (shipp->flags[Ship::Ship_Flags::No_nebula_targeting_limits]);
+		if (target_is_exempt)
+			return FULLY_TARGETABLE;
+	}
+
 	// check for a tagged ship. TAG'd ships are _always_ visible
 	if (target->type == OBJ_SHIP)
 	{

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -540,7 +540,8 @@ ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::No_thrusters,					"no-thrusters" },
 	{ Ship_Flags::Fail_sound_locked_primary, 	"fail-sound-locked-primary"},
 	{ Ship_Flags::Fail_sound_locked_secondary, 	"fail-sound-locked-secondary"},
-	{ Ship_Flags::Aspect_immune, 				"aspect-immune"}
+	{ Ship_Flags::Aspect_immune, 				"aspect-immune"},
+	{ Ship_Flags::No_nebula_targeting_limits,	"no-nebula-targeting-limits"}
 };
 
 extern const size_t Num_ship_flag_names = sizeof(Ship_flag_names) / sizeof(ship_flag_name);

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -135,6 +135,7 @@ namespace Ship {
 		Fail_sound_locked_secondary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
 		Subsystem_cache_valid,		// Goober5000 - whether the subsystem list index caches can be used
 		Aspect_immune,						// Kiloku -- Ship cannot be targeted by Aspect Seekers.
+		No_nebula_targeting_limits,		//MjnMixael -- Ship is always targetable in a nebula regardless of AWACS range
 
 		NUM_VALUES
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3503,6 +3503,8 @@ int CFred_mission_save::save_objects()
 				fout(" \"fail-sound-locked-secondary\"");
 			if (shipp->flags[Ship::Ship_Flags::Aspect_immune])
 				fout(" \"aspect-immune\"");
+			if (shipp->flags[Ship::Ship_Flags::No_nebula_targeting_limits])
+				fout(" \"no-nebula-targeting-limits\"");
 			fout(" )");
 		}
 		// -----------------------------------------------------------


### PR DESCRIPTION
Adds a ship flag to exempt a ship from nebular targeting range restrictions and make it always targetable. Fixes #4195