### PR TITLE
Fix poof name parsing and fix lab not knowing about the new parsing

### DIFF
--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -310,7 +310,7 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 				(ambient_light_level >> 16) & 0xff);
 
 			strcpy_s(Neb2_texture_name, "");
-			Neb2_poof_flags = ((1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5));
+			Neb2_poof_flags = 0;
 			bool nebula = false;
 			if (optional_string("+Neb2:")) {
 				nebula = true;
@@ -327,8 +327,15 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 			}
 
 			if (nebula){
-				required_string("+Neb2Flags:");
-				stuff_int(&Neb2_poof_flags);
+				if (optional_string("+Neb2Flags:")) {
+					stuff_int(&Neb2_poof_flags);
+				}
+				// Get poofs by name
+				if (optional_string("+Neb2 Poofs List:")) {
+					SCP_vector<SCP_string> poofs_list;
+					stuff_string_list(poofs_list);
+					neb2_set_poof_bits(poofs_list);
+				}
 
 				if (flags[Mission::Mission_Flags::Fullneb]) {
 					neb2_post_level_init(flags[Mission::Mission_Flags::Neb2_fog_color_override]);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5428,14 +5428,7 @@ void parse_bitmaps(mission *pm)
 		if (optional_string("+Neb2 Poofs List:")) {
 			SCP_vector<SCP_string> poofs_list;
 			stuff_string_list(poofs_list);
-
-			for (const SCP_string &thisPoof : poofs_list) {
-				for (size_t i = 0; i < Poof_info.size(); i++) {
-					if (Poof_info[i].name == thisPoof) {
-						Neb2_poof_flags |= (1 << i);
-					}
-				}
-			}
+			neb2_set_poof_bits(poofs_list);
 		}
 
 		// initialize neb effect. its gross to do this here, but Fred is dumb so I have no choice ... :(

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -332,6 +332,19 @@ void neb2_init()
 	parse_modular_table("*-neb.tbm", parse_nebula_table);
 }
 
+// set the bits for poofs from a list of poof names
+void neb2_set_poof_bits(SCP_vector<SCP_string> list)
+{
+	Neb2_poof_flags = 0; //Make absolutely sure flags are zero'd before we start adding to it-Mjn
+	for (const SCP_string& thisPoof : list) {
+		for (int i = 0; i < (int)Poof_info.size(); i++) {
+			if (Poof_info[i].name == thisPoof) {
+				Neb2_poof_flags |= (1 << i);
+			}
+		}
+	}
+}
+
 bool poof_is_used(size_t idx) {
 	return (Neb2_poof_flags & (1 << idx)) != 0;
 }
@@ -351,10 +364,6 @@ void neb2_pre_level_init()
 
 	strcpy_s(Neb2_texture_name, "");
 	Neb2_poof_flags = 0;
-
-	for (int i = 0; i < (int)MAX_NEB2_POOFS; i++) {
-		Neb2_poof_flags |= (1 << i);
-	}
 
 	strcpy_s(Mission_parse_storm_name, "none");
 }

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -333,12 +333,12 @@ void neb2_init()
 }
 
 // set the bits for poofs from a list of poof names
-void neb2_set_poof_bits(SCP_vector<SCP_string> list)
+void neb2_set_poof_bits(const SCP_vector<SCP_string>& list)
 {
 	Neb2_poof_flags = 0; //Make absolutely sure flags are zero'd before we start adding to it-Mjn
 	for (const SCP_string& thisPoof : list) {
 		for (int i = 0; i < (int)Poof_info.size(); i++) {
-			if (Poof_info[i].name == thisPoof) {
+			if (SCP_string_lcase_equal_to()(Poof_info[i].name, thisPoof)) {
 				Neb2_poof_flags |= (1 << i);
 			}
 		}

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -130,7 +130,7 @@ typedef struct neb2_detail {
 void neb2_init();
 
 // set poof bits using a list of poof names
-void neb2_set_poof_bits(SCP_vector<SCP_string> list);
+void neb2_set_poof_bits(const SCP_vector<SCP_string>& list);
 
 //init neb stuff  - WMC
 void neb2_level_init();

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -129,6 +129,9 @@ typedef struct neb2_detail {
 // initialize neb2 stuff at game startup
 void neb2_init();
 
+// set poof bits using a list of poof names
+void neb2_set_poof_bits(SCP_vector<SCP_string> list);
+
 //init neb stuff  - WMC
 void neb2_level_init();
 


### PR DESCRIPTION
#4856 broke the new nebula poof parsing by zero'ing the list and then immediately setting all the bits before the parse happened. This resulted in Neb2_poof_flags == -1 before it even starts trying to set bits from the list of poof names. This PR removes that and moves the bit setting to it's own method and then calls that method during mission parsing. Also makes sure the Lab is aware of the new poof parsing option.