### PR TITLE
fix swapping of things in FRED

### DIFF
--- a/fred2/campaigneditordlg.cpp
+++ b/fred2/campaigneditordlg.cpp
@@ -556,31 +556,30 @@ void campaign_editor::swap_handler(int node1, int node2)
 			break;
 		}
 	}
-
 	Assert(index1 < Total_links);
+
 	for (index2=0; index2<Total_links; index2++){
 		if ((Links[index2].from == Cur_campaign_mission) && (Links[index2].node == node2)){
 			break;
 		}
 	}
-
 	Assert(index2 < Total_links);
+
 	temp = Links[index1];
-//	Links[index1] = Links[index2];
+
 	while (index1 < index2) {
 		Links[index1] = Links[index1 + 1];
 		index1++;
 	}
-
 	while (index1 > index2 + 1) {
 		Links[index1] = Links[index1 - 1];
 		index1--;
 	}
 
+	Links[index1] = temp;
+
 	// update Cur_campaign_link
 	Cur_campaign_link = index1;
-
-	Links[index1] = temp;
 }
 
 void campaign_editor::insert_handler(int old, int node)

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -1210,32 +1210,33 @@ void event_editor::OnUpdateTriggerCount()
 }
 void event_editor::swap_handler(int node1, int node2)
 {
-	int index1, index2;
+	int index1, index2, s;
 	mission_event m;
 
 	save();
+
 	for (index1=0; index1<m_num_events; index1++){
 		if (m_events[index1].formula == node1){
 			break;
 		}
 	}
-
 	Assert(index1 < m_num_events);
+
 	for (index2=0; index2<m_num_events; index2++){
 		if (m_events[index2].formula == node2){
 			break;
 		}
 	}
-
 	Assert(index2 < m_num_events);
+
 	m = m_events[index1];
-//	m_events[index1] = m_events[index2];
+	s = m_sig[index1];
+
 	while (index1 < index2) {
 		m_events[index1] = m_events[index1 + 1];
 		m_sig[index1] = m_sig[index1 + 1];
 		index1++;
 	}
-
 	while (index1 > index2 + 1) {
 		m_events[index1] = m_events[index1 - 1];
 		m_sig[index1] = m_sig[index1 - 1];
@@ -1243,6 +1244,8 @@ void event_editor::swap_handler(int node1, int node2)
 	}
 
 	m_events[index1] = m;
+	m_sig[index1] = s;
+
 	cur_event = index1;
 	update_cur_event();
 }

--- a/fred2/missiongoalsdlg.cpp
+++ b/fred2/missiongoalsdlg.cpp
@@ -577,7 +577,7 @@ void CMissionGoalsDlg::OnNoMusic()
 
 void CMissionGoalsDlg::swap_handler(int node1, int node2)
 {
-	int index1, index2;
+	int index1, index2, s;
 	mission_goal m;
 
 	for (index1=0; index1<m_num_goals; index1++){
@@ -585,23 +585,23 @@ void CMissionGoalsDlg::swap_handler(int node1, int node2)
 			break;
 		}
 	}
-
 	Assert(index1 < m_num_goals);
+
 	for (index2=0; index2<m_num_goals; index2++){
 		if (m_goals[index2].formula == node2){
 			break;
 		}
 	}
-
 	Assert(index2 < m_num_goals);
+
 	m = m_goals[index1];
-//	m_goals[index1] = m_goals[index2];
+	s = m_sig[index1];
+
 	while (index1 < index2) {
 		m_goals[index1] = m_goals[index1 + 1];
 		m_sig[index1] = m_sig[index1 + 1];
 		index1++;
 	}
-
 	while (index1 > index2 + 1) {
 		m_goals[index1] = m_goals[index1 - 1];
 		m_sig[index1] = m_sig[index1 - 1];
@@ -609,6 +609,7 @@ void CMissionGoalsDlg::swap_handler(int node1, int node2)
 	}
 
 	m_goals[index1] = m;
+	m_sig[index1] = s;
 }
 
 void CMissionGoalsDlg::OnChangeGoalScore() 


### PR DESCRIPTION
This properly updates event and goal signatures when events are moved around.  Fixes Mantis bugs 1005, 1961, and 2998.