### PR TITLE
bump MAX_AI_PROFILES

### DIFF
--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -21,7 +21,7 @@
 #define	AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL 0
 #define	AI_RANGE_AWARE_SEC_SEL_MODE_AWARE 1
 	
-#define MAX_AI_PROFILES	5
+#define MAX_AI_PROFILES	8
 
 class ai_profile_t {
 public:


### PR DESCRIPTION
Previous limit lasted from 2005-11-21 until now (from commit b33caf6f45).  We'll see how long this one lasts.