### PR TITLE
fix campaign loading in FRED

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -1660,7 +1660,7 @@ void campaign_reset(const SCP_string& campaign_file)
 
 	mission_campaign_savefile_delete(filename.c_str());
 
-	const int load_status = mission_campaign_load(filename.c_str(), nullptr, 1 , false);	// retail doesn't reset stats when resetting the campaign
+	const int load_status = mission_campaign_load(filename.c_str(), nullptr, nullptr, 1 , false);	// retail doesn't reset stats when resetting the campaign
 
 	// see if we successfully loaded this campaign
 	if (load_status == 0) {

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -376,9 +376,6 @@ void mission_campaign_get_sw_info()
 {
     int i, count, ship_list[MAX_SHIP_CLASSES], weapon_list[MAX_WEAPON_TYPES];
 
-	memset(Campaign.ships_allowed, 0, sizeof(Campaign.ships_allowed));
-	memset(Campaign.weapons_allowed, 0, sizeof(Campaign.weapons_allowed));
-
     if (optional_string("+Starting Ships:")) {
         count = (int)stuff_int_list(ship_list, MAX_SHIP_CLASSES, SHIP_INFO_TYPE);
 
@@ -422,7 +419,7 @@ void mission_campaign_get_sw_info()
  * this file.  If you change the format of the campaign file, you should be sure these related
  * functions work properly and update them if it breaks them.
  */
-int mission_campaign_load(const char* filename, player* pl, int load_savefile, bool reset_stats)
+int mission_campaign_load(const char* filename, const char* full_path, player* pl, int load_savefile, bool reset_stats)
 {
 	int i;
 	char name[NAME_LENGTH], type[NAME_LENGTH], temp[NAME_LENGTH];
@@ -443,15 +440,15 @@ int mission_campaign_load(const char* filename, player* pl, int load_savefile, b
 		load_savefile = 0;
 	}
 
+	// be sure to remove all old malloced strings of Mission_names
+	// we must also free any goal stuff that was from a previous campaign
+	// this also frees sexpressions so the next call to init_sexp will be able to reclaim
+	// nodes previously used by another campaign.
+	mission_campaign_clear();
+
 	// read the mission file and get the list of mission filenames
 	try
 	{
-		// be sure to remove all old malloced strings of Mission_names
-		// we must also free any goal stuff that was from a previous campaign
-		// this also frees sexpressions so the next call to init_sexp will be able to reclaim
-		// nodes previously used by another campaign.
-		mission_campaign_clear();
-
 		strcpy_s( Campaign.filename, filename );
 
 		// only initialize the sexpression stuff when Fred isn't running.  It'll screw things up major
@@ -460,7 +457,7 @@ int mission_campaign_load(const char* filename, player* pl, int load_savefile, b
 			init_sexp();		// must initialize the sexpression stuff
 		}
 
-		read_file_text( filename );
+		read_file_text( full_path ? full_path : filename );
 		reset_parse();
 
 		// copy filename to campaign structure minus the extension
@@ -488,19 +485,16 @@ int mission_campaign_load(const char* filename, player* pl, int load_savefile, b
 		if ( i == MAX_CAMPAIGN_TYPES )
 			Error(LOCATION, "Unknown campaign type %s!", type);
 
-		Campaign.desc = NULL;
 		if (optional_string("+Description:"))
 			Campaign.desc = stuff_and_malloc_string(F_MULTITEXT, NULL);
 
 		// if the type is multiplayer -- get the number of players
-		Campaign.num_players = 0;
 		if ( Campaign.type != CAMPAIGN_TYPE_SINGLE) {
 			required_string("+Num players:");
 			stuff_int( &(Campaign.num_players) );
 		}		
 
 		// parse flags - Goober5000
-		Campaign.flags = CF_DEFAULT_VALUE;
 		if (optional_string("$Flags:"))
 		{
 			stuff_int( &(Campaign.flags) );
@@ -510,7 +504,6 @@ int mission_campaign_load(const char* filename, player* pl, int load_savefile, b
 		mission_campaign_get_sw_info();
 
 		// parse the mission file and actually read in the mission stuff
-		Campaign.num_missions = 0;
 		while ( required_string_either("#End", "$Mission:") ) {
 			cmission *cm;
 
@@ -677,11 +670,6 @@ int mission_campaign_load(const char* filename, player* pl, int load_savefile, b
 	// the campaign save file for this player.  Since all campaign loads go through this routine, I
 	// think this place should be the only necessary place to load the campaign save stuff.  The campaign
 	// save file will get written when a mission has ended by player choice.
-	Campaign.next_mission = 0;
-	Campaign.prev_mission = -1;
-	Campaign.current_mission = -1;
-	Campaign.loop_mission = CAMPAIGN_LOOP_MISSION_UNINITIALIZED;
-	Campaign.num_missions_completed = 0;
 
 	// loading the campaign will get us to the current and next mission that the player must fly
 	// plus load all of the old goals that future missions might rely on.
@@ -1329,11 +1317,11 @@ void mission_campaign_clear()
 	memset(Campaign.name, 0, NAME_LENGTH);
 	memset(Campaign.filename, 0, MAX_FILENAME_LEN);
 	Campaign.type = 0;
-	Campaign.flags = 0;
+	Campaign.flags = CF_DEFAULT_VALUE;
 	Campaign.num_missions = 0;
 	Campaign.num_missions_completed = 0;
 	Campaign.current_mission = -1;
-	Campaign.next_mission = -1;
+	Campaign.next_mission = 0;
 	Campaign.prev_mission = -1;
 	Campaign.loop_enabled = 0;
 	Campaign.loop_mission = CAMPAIGN_LOOP_MISSION_UNINITIALIZED;
@@ -1688,7 +1676,7 @@ int mission_load_up_campaign( player *pl )
 	// last used...
 	if ( strlen(pl->current_campaign) ) {
 		if (!campaign_is_ignored(pl->current_campaign)) {
-			return mission_campaign_load(pl->current_campaign, pl);
+			return mission_campaign_load(pl->current_campaign, nullptr, pl);
 		}
 		else {
 			Campaign_file_missing = 1;
@@ -1696,7 +1684,7 @@ int mission_load_up_campaign( player *pl )
 	}
 
 	// builtin...
-	rc = mission_campaign_load(Default_campaign_file_name, pl);
+	rc = mission_campaign_load(Default_campaign_file_name, nullptr, pl);
 
 	// everything else...
 	if (rc < 0) {
@@ -1718,7 +1706,7 @@ int mission_load_up_campaign( player *pl )
 			}
 
 			// try to load it, whatever "it" is
-			rc = mission_campaign_load(Campaign_file_names[idx], pl);
+			rc = mission_campaign_load(Campaign_file_names[idx], nullptr, pl);
 		}
 
 		mission_campaign_free_list();

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -168,7 +168,7 @@ void player_loadout_init();
 void mission_campaign_init( void );
 
 // load up and initialize a new campaign
-int mission_campaign_load(const char* filename, player* pl = nullptr, int load_savefile = 1, bool reset_stats = true);
+int mission_campaign_load(const char* filename, const char* full_path = nullptr, player* pl = nullptr, int load_savefile = 1, bool reset_stats = true);
 
 bool campaign_is_ignored(const char *filename);
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6216,18 +6216,22 @@ bool post_process_mission(mission *pm)
 	return true;
 }
 
-int get_mission_info(const char *filename, mission *mission_p, bool basic)
+int get_mission_info(const char *filename, mission *mission_p, bool basic, bool filename_is_full_path)
 {
-	char real_fname[MAX_FILENAME_LEN];
-	
-	strncpy(real_fname, filename, MAX_FILENAME_LEN-1);
-	real_fname[sizeof(real_fname)-1] = '\0';
-	
-	char *p = strrchr(real_fname, '.');
-	if (p) *p = 0; // remove any extension
-	strcat_s(real_fname, FS_MISSION_FILE_EXT);  // append mission extension
-
 	int filelength;
+	char real_fname_buf[MAX_FILENAME_LEN];
+	const char *real_fname = real_fname_buf;
+	
+	if (filename_is_full_path) {
+		real_fname = filename;
+	} else {
+		strncpy(real_fname_buf, filename, MAX_FILENAME_LEN-1);
+		real_fname_buf[sizeof(real_fname_buf)-1] = '\0';
+	
+		char *p = strrchr(real_fname_buf, '.');
+		if (p) *p = 0; // remove any extension
+		strcat_s(real_fname_buf, FS_MISSION_FILE_EXT);  // append mission extension
+	}
 
 	// if mission_p is NULL, make it point to The_mission
 	if ( mission_p == NULL )

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -499,7 +499,7 @@ void mission_parse_reset_callsign();
 int is_training_mission();
 
 // code to save/restore mission parse stuff
-int get_mission_info(const char *filename, mission *missionp = NULL, bool basic = true);
+int get_mission_info(const char *filename, mission *missionp = nullptr, bool basic = true, bool filename_is_full_path = false);
 
 // Goober5000
 void parse_dock_one_docked_object(p_object *pobjp, p_object *parent_pobjp);

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1510,7 +1510,7 @@ void pilotfile::csg_reset_data()
 
 	// reset campaign status
 	Campaign.prev_mission = -1;
-	Campaign.next_mission = -1;
+	Campaign.next_mission = 0;
 	Campaign.num_missions_completed = 0;
 
 	// techroom reset

--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -336,7 +336,7 @@ ADE_FUNC(loadCampaign, l_Player, "string campaign", "Loads the specified campaig
 	strcpy_s(pl->current_campaign, filename); // track new campaign for player
 
 	// attempt to load the campaign
-	const int load_status = mission_campaign_load(filename, pl);
+	const int load_status = mission_campaign_load(filename, nullptr, pl);
 
 	// see if we successfully loaded this campaign and it's at the beginning
 	if (load_status == 0 && Campaign.prev_mission < 0) {

--- a/fred2/campaigneditordlg.h
+++ b/fred2/campaigneditordlg.h
@@ -30,6 +30,8 @@ class campaign_editor : public CFormView
 private:
 	int m_num_links;
 	int m_last_mission;
+	CString	m_current_campaign_path;
+	CString GetPathWithoutFile();
 
 protected:
 	campaign_editor();           // protected constructor used by dynamic creation
@@ -44,8 +46,8 @@ public:
 	void load_tree(int save = 1);
 	void save_tree(int clear = 1);
 	int handler(int code, int node, char *str = NULL);
-	void initialize( int init_files = 1 );
-	void load_campaign();
+	void initialize( bool init_files, bool clear_path );
+	void load_campaign(const char *filename, const char *full_path);
 	void update_loop_desc_window();
 	void campaign_editor::save_loop_desc_window();
 	//{{AFX_DATA(campaign_editor)

--- a/fred2/campaignfilelistbox.cpp
+++ b/fred2/campaignfilelistbox.cpp
@@ -46,38 +46,54 @@ END_MESSAGE_MAP()
 /////////////////////////////////////////////////////////////////////////////
 // campaign_filelist_box message handlers
 
-void campaign_filelist_box::initialize()
+void campaign_filelist_box::initialize(const CString &path)
 {
-	int i, z, num_files;
-	char *mission_filenames[2000];
-	char mission_filenames_arr[2000][MAX_FILENAME_LEN];
+	int i, z;
+	SCP_vector<SCP_string> mission_filenames;
+	SCP_string filter;
 	mission a_mission;
 
 	ResetContent();
 
+	// if there's a path, cf_get_file_list will look there; if not, it will use the file filter in the standard location
+	if (!path.IsEmpty())
+	{
+		filter = (LPCTSTR)path;
+		if (filter.back() != DIR_SEPARATOR_CHAR)
+			filter += DIR_SEPARATOR_CHAR;
+	}
+	filter += "*.fs2";
+
 	extern int Skip_packfile_search;
 	Skip_packfile_search = 1;
-	num_files = cf_get_file_list_preallocated(2000, mission_filenames_arr, mission_filenames, CF_TYPE_MISSIONS, "*.fs2");
+	cf_get_file_list(mission_filenames, CF_TYPE_MISSIONS, filter.c_str());
 	Skip_packfile_search = 0;
 
-	i=0;
 
-	while (i < num_files)
+	for (i = 0; i < (int)mission_filenames.size(); i++)
 	{
-		// make a call to get the mission info for this mission.  Passing a misison as the second
+		// add the extension; the file list box wants to display it, and we need it for absolute paths anyway
+		mission_filenames[i] += ".fs2";
+
+		// make a call to get the mission info for this mission.  Passing a mission as the second
 		// parameter will prevent The_mission from getting overwritten.
-		get_mission_info( mission_filenames[i] , &a_mission );
-		strcat(mission_filenames[i],".fs2");
+		if (path.IsEmpty())
+			get_mission_info(mission_filenames[i].c_str(), &a_mission);
+		else
+		{
+			auto file_to_load = mission_filenames[i];
+			if (!path.IsEmpty())
+				file_to_load = (LPCTSTR)path + file_to_load;
+			get_mission_info(file_to_load.c_str(), &a_mission, true, true);
+		}
 
 		// only add missions of the appropriate type to the file listbox
 		if ( (Campaign.type == CAMPAIGN_TYPE_SINGLE) && (a_mission.game_type & (MISSION_TYPE_SINGLE|MISSION_TYPE_TRAINING)) )
-			AddString(mission_filenames[i]);
+			AddString(mission_filenames[i].c_str());
 		else if ( (Campaign.type == CAMPAIGN_TYPE_MULTI_COOP) && (a_mission.game_type & MISSION_TYPE_MULTI_COOP) )
-			AddString(mission_filenames[i]);
+			AddString(mission_filenames[i].c_str());
 		else if ( (Campaign.type == CAMPAIGN_TYPE_MULTI_TEAMS) && (a_mission.game_type & MISSION_TYPE_MULTI_TEAMS) )
-			AddString(mission_filenames[i]);
-
-		i++;
+			AddString(mission_filenames[i].c_str());
 	} 
 	
 
@@ -88,5 +104,4 @@ void campaign_filelist_box::initialize()
 			i--;  // recheck for name just in case there are two (should be impossible but can't be sure)
 		}
 	}
-	
 }

--- a/fred2/campaignfilelistbox.h
+++ b/fred2/campaignfilelistbox.h
@@ -17,7 +17,7 @@ class campaign_filelist_box : public CListBox
 {
 // Construction
 public:
-	void initialize();
+	void initialize(const CString &path);
 	campaign_filelist_box();
 
 // Attributes

--- a/fred2/campaigntreeview.cpp
+++ b/fred2/campaigntreeview.cpp
@@ -1078,7 +1078,7 @@ void campaign_tree_view::drop_mission(int m, CPoint point)
 	// update and reinitialize dialog items
 	if ( Campaign.type != CAMPAIGN_TYPE_SINGLE ) {
 		Campaign_tree_formp->update();
-		Campaign_tree_formp->initialize(0);
+		Campaign_tree_formp->initialize(false, false);
 	}
 
 	listbox->DeleteString(item);
@@ -1242,7 +1242,7 @@ void campaign_tree_view::OnRemoveMission()
 	// in the mission might have changed because of deletion of the first mission
 	if ( Campaign.type != CAMPAIGN_TYPE_SINGLE ) {
 		Campaign_tree_formp->update();
-		Campaign_tree_formp->initialize();
+		Campaign_tree_formp->initialize(true, false);
 	}
 }
 

--- a/fred2/campaigntreewnd.cpp
+++ b/fred2/campaigntreewnd.cpp
@@ -103,7 +103,6 @@ BOOL campaign_tree_wnd::OnCreateClient(LPCREATESTRUCT, CCreateContext* pContext)
 	// activate the input view
 	SetActiveView(Campaign_tree_formp);
 	OnCpgnFileNew();
-//	Campaign_tree_formp->load_campaign();
 	Fred_main_wnd->EnableWindow(FALSE);
 	return TRUE;
 }
@@ -115,7 +114,7 @@ void campaign_tree_wnd::OnUpdateCpgnFileOpen(CCmdUI* pCmdUI)
 
 void campaign_tree_wnd::OnCpgnFileOpen() 
 {
-	CString name;
+	CString name, full_path;
 
 	if (Campaign_modified)
 		if (save_modified())
@@ -133,8 +132,9 @@ void campaign_tree_wnd::OnCpgnFileOpen()
 		if (!strlen(name))
 			return;
 
-		string_copy(Campaign.filename, name, MAX_FILENAME_LEN - 1);
-		Campaign_tree_formp->load_campaign();
+		full_path = dlg.GetPathName();
+
+		Campaign_tree_formp->load_campaign((LPCTSTR)name, (LPCTSTR)full_path);
 	}
 }
 
@@ -219,7 +219,7 @@ void campaign_tree_wnd::OnCpgnFileSaveAs()
 		}
 
 		if (!strlen(name)){
-			return;		
+			return;
 		}
 
 		string_copy(Campaign.filename, name, MAX_FILENAME_LEN - 1);
@@ -246,7 +246,7 @@ void campaign_tree_wnd::OnCpgnFileNew()
 	strcpy_s(Campaign.name, "Unnamed");
 	Campaign.desc = NULL;
 	Campaign_tree_viewp->free_links();
-	Campaign_tree_formp->initialize();
+	Campaign_tree_formp->initialize(true, true);
 	Campaign_modified = 0;
 	Campaign.flags = CF_DEFAULT_VALUE;
 	((CButton *) (Campaign_tree_formp->GetDlgItem(IDC_CUSTOM_TECH_DB)))->SetCheck(0);


### PR DESCRIPTION
Load campaigns using the full path provided by the user, not just from the configured mod paths.

Also tweaks initialization based on the campaign having already been cleared in `mission_campaign_clear()`.