### PR TITLE
fix wing leader check

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -522,7 +522,7 @@ void ai_goal_purge_invalid_goals( ai_goal *aigp, ai_goal *goal_list, ai_info *ai
 
 					// for wings we grab the ship type of the wing leader
 					if (ai_wingnum >= 0) {
-						ai_ship_type = Ship_info[Ships[Wings[ai_wingnum].special_ship].ship_info_index].class_type;
+						ai_ship_type = Ship_info[Ships[Wings[ai_wingnum].ship_index[Wings[ai_wingnum].special_ship]].ship_info_index].class_type;
 					}
 					// otherwise we simply grab it from the ship itself
 					else {


### PR DESCRIPTION
The `special ship` field stores the index in the wing's `ship_index` array.  It does not store the shipnum itself.

Discovered in the course of coding #4889.