### PR TITLE
add cannot-perform-scan flag

### DIFF
--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -106,6 +106,7 @@ namespace Mission {
 		SF_Fail_sound_locked_primary, 	// Kiloku - Plays fail sound when firing with locked weapons
 		SF_Fail_sound_locked_secondary,	// Kiloku - Plays fail sound when firing with locked weapons
 		SF_Aspect_immune,				// Kiloku - Ship cannot be locked onto by aspect seeking weapons
+		SF_Cannot_perform_scan,			// Goober5000 - ship cannot scan other ships
 
 		NUM_VALUES
 	};

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -325,7 +325,8 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
     { "ai-attackable-if-no-collide",		Mission::Parse_Object_Flags::OF_Attackable_if_no_collide, true, false },
     { "fail-sound-locked-primary",			Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary, true, false },
     { "fail-sound-locked-secondary",		Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary, true, false },
-    { "aspect-immune",						Mission::Parse_Object_Flags::SF_Aspect_immune, true, false }
+    { "aspect-immune",						Mission::Parse_Object_Flags::SF_Aspect_immune, true, false },
+	{ "cannot-perform-scan",			Mission::Parse_Object_Flags::SF_Cannot_perform_scan,	true, false },
 };
 
 const size_t Num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);
@@ -2663,6 +2664,18 @@ void resolve_parse_flags(object *objp, flagset<Mission::Parse_Object_Flags> &par
 
     if (parse_flags[Mission::Parse_Object_Flags::OF_Attackable_if_no_collide])
 		objp->flags.set(Object::Object_Flags::Attackable_if_no_collide);
+
+	if (parse_flags[Mission::Parse_Object_Flags::SF_Fail_sound_locked_primary])
+		shipp->flags.set(Ship::Ship_Flags::Fail_sound_locked_primary);
+
+	if (parse_flags[Mission::Parse_Object_Flags::SF_Fail_sound_locked_secondary])
+		shipp->flags.set(Ship::Ship_Flags::Fail_sound_locked_secondary);
+
+	if (parse_flags[Mission::Parse_Object_Flags::SF_Aspect_immune])
+		shipp->flags.set(Ship::Ship_Flags::Aspect_immune);
+
+	if (parse_flags[Mission::Parse_Object_Flags::SF_Cannot_perform_scan])
+		shipp->flags.set(Ship::Ship_Flags::Cannot_perform_scan);
 }
 
 void fix_old_special_explosions(p_object *p_objp, int variable_index) 

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1525,7 +1525,7 @@ int player_inspect_cargo(float frametime, char *outstr)
 
 	outstr[0] = 0;
 
-	if ( Player_ai->target_objnum < 0 ) {
+	if ( Player_ai->target_objnum < 0 || Player_ship->flags[Ship::Ship_Flags::Cannot_perform_scan] ) {
 		return 0;
 	}
 
@@ -1640,7 +1640,7 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 	outstr[0] = 0;
 	subsys = Player_ai->targeted_subsys;
 
-	if ( subsys == NULL ) {
+	if ( subsys == NULL || Player_ship->flags[Ship::Ship_Flags::Cannot_perform_scan] ) {
 		return 0;
 	} 
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -540,7 +540,8 @@ ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::No_thrusters,					"no-thrusters" },
 	{ Ship_Flags::Fail_sound_locked_primary, 	"fail-sound-locked-primary"},
 	{ Ship_Flags::Fail_sound_locked_secondary, 	"fail-sound-locked-secondary"},
-	{ Ship_Flags::Aspect_immune, 				"aspect-immune"}
+	{ Ship_Flags::Aspect_immune, 				"aspect-immune"},
+	{ Ship_Flags::Cannot_perform_scan,			"cannot-perform-scan"},
 };
 
 extern const size_t Num_ship_flag_names = sizeof(Ship_flag_names) / sizeof(ship_flag_name);

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -135,6 +135,7 @@ namespace Ship {
 		Fail_sound_locked_secondary,		// Kiloku -- Play the firing fail sound when the weapon is locked.
 		Subsystem_cache_valid,		// Goober5000 - whether the subsystem list index caches can be used
 		Aspect_immune,						// Kiloku -- Ship cannot be targeted by Aspect Seekers.
+		Cannot_perform_scan,		// Goober5000 - ship cannot scan other ships
 
 		NUM_VALUES
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3503,6 +3503,8 @@ int CFred_mission_save::save_objects()
 				fout(" \"fail-sound-locked-secondary\"");
 			if (shipp->flags[Ship::Ship_Flags::Aspect_immune])
 				fout(" \"aspect-immune\"");
+			if (shipp->flags[Ship::Ship_Flags::Cannot_perform_scan])
+				fout(" \"cannot-perform-scan\"");
 			fout(" )");
 		}
 		// -----------------------------------------------------------

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3291,6 +3291,9 @@ int CFred_mission_save::save_objects()
 			if (shipp->flags[Ship::Ship_Flags::Aspect_immune]) {
 				fout(" \"aspect-immune\"");
 			}
+			if (shipp->flags[Ship::Ship_Flags::Cannot_perform_scan]) {
+				fout(" \"cannot-perform-scan\"");
+			}
 			fout(" )");
 		}
 		// -----------------------------------------------------------


### PR DESCRIPTION
Prevents the player from performing a cargo or subsystem scan.  Can be toggled using alter-ship-flag.

Also adds some missing logic for Fail_sound_locked_primary, Fail_sound_locked_secondary, and Aspect_immune.