### PR TITLE
Fix Enum assignments

### DIFF
--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -169,6 +169,7 @@ int script_state::CreateLuaState()
 	for(i = 0; i < Num_enumerations; i++)
 	{
 		eh.index = Enumerations[i].def;
+		eh.value = Enumerations[i].value;
 		eh.is_constant = true;
 
 		ade_set_args(L, "o", l_Enum.Set(eh));


### PR DESCRIPTION
In my recent enum refactor, I may have forgotten to assign the bitfield enums to the actually globally set ones, causing Asserts when globally accessed enums were used.