### PR TITLE
hook up cone light profile values

### DIFF
--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -339,6 +339,10 @@ void lighting_profile::parse_default_section(const char *filename)
 										&default_profile.point_light_radius);
 		parsed |= lighting_profile_value::parse(filename,"$Directional light brightness:",profile_name,
 										&default_profile.directional_light_brightness);
+		parsed |= lighting_profile_value::parse(filename,"$Cone light radius:",profile_name,
+										&default_profile.cone_light_radius);
+		parsed |= lighting_profile_value::parse(filename,"$Cone light brightness:",profile_name,
+										&default_profile.cone_light_brightness);
 		if(lighting_profile_value::parse(filename,"$Ambient light brightness:",profile_name, &default_profile.ambient_light_brightness))
 		{
 			parsed = true;


### PR DESCRIPTION
I really would like this to be in 22.4 but sneaky rakes keep getting in the way of me properly testing it...