### PR TITLE
Fix a warning

### DIFF
--- a/code/scripting/api/objs/control_binding.cpp
+++ b/code/scripting/api/objs/control_binding.cpp
@@ -10,7 +10,7 @@ cci_h::cci_h() { idx = IoActionId::CCFG_MAX; }
 
 cci_h::cci_h(int n_id) { if (n_id < 0 || n_id > static_cast<int>(IoActionId::CCFG_MAX)) idx = IoActionId::CCFG_MAX; else idx = static_cast<IoActionId>(n_id); }
 
-bool cci_h::IsValid() { return idx < IoActionId::CCFG_MAX; }
+bool cci_h::IsValid() { return idx != IoActionId::CCFG_MAX; }
 
 IoActionId cci_h::Get() { return idx; }
 

--- a/code/scripting/api/objs/control_binding.cpp
+++ b/code/scripting/api/objs/control_binding.cpp
@@ -6,11 +6,11 @@
 namespace scripting {
 namespace api {
 
-cci_h::cci_h() { idx = CCFG_MAX; }
+cci_h::cci_h() { idx = IoActionId::CCFG_MAX; }
 
-cci_h::cci_h(int n_id) { idx = static_cast<IoActionId>(n_id); }
+cci_h::cci_h(int n_id) { if (n_id < 0 || n_id > static_cast<int>(IoActionId::CCFG_MAX)) idx = IoActionId::CCFG_MAX; else idx = static_cast<IoActionId>(n_id); }
 
-bool cci_h::IsValid() { return (idx > -1 && idx < IoActionId::CCFG_MAX); }
+bool cci_h::IsValid() { return idx < IoActionId::CCFG_MAX; }
 
 IoActionId cci_h::Get() { return idx; }
 


### PR DESCRIPTION
We shouldn't be checking that the `cci_h` is valid by seeing if it is greater than -1 because by that point it never will be.  Instead, we should be checking that the incoming id is valid and setting to the invalid state if it is not.