### PR TITLE
Fix Flashlights

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -138,6 +138,8 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			float coneDot = dot(normalize(-lightDir), coneDir);
 			float dist = length(lightDir);
 			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
+			area_normalisation = 1.0;
+
 			if(dualCone) {
 				if(abs(coneDot) < coneAngle) {
 					discard;


### PR DESCRIPTION
Area_normalisation term in deferred shader was not getting set properly for cone lights, which caused things like ship headlights to not work properly.

Tested and fixes issue as expected. Thanks to Qaz and EatThePath for pointing out how to fix it!