### PR TITLE
Fix crash on `ai_goal_purge_invalid_goals`

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -567,7 +567,7 @@ void ai_goal_purge_all_invalid_goals(ai_goal *aigp)
 	{		
 		// only purge goals for wings that are present --wookieejedi
 		if (Wings[i].current_count > 0)
-			ai_goal_purge_invalid_goals(aigp, Wings[i].ai_goals, NULL, i);
+			ai_goal_purge_invalid_goals(aigp, Wings[i].ai_goals, nullptr, i);
 	}
 }
 

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -564,8 +564,10 @@ void ai_goal_purge_all_invalid_goals(ai_goal *aigp)
 
 	// we must do the same for the wing goals
 	for (i = 0; i < Num_wings; i++)
-	{
-		ai_goal_purge_invalid_goals(aigp, Wings[i].ai_goals, NULL, i);
+	{		
+		// only purge goals for wings that are present --wookieejedi
+		if (Wings[i].current_count > 0)
+			ai_goal_purge_invalid_goals(aigp, Wings[i].ai_goals, NULL, i);
 	}
 }
 


### PR DESCRIPTION
`ai_goal_purge_invalid_goals` was previosuly provided with all wings in a mission, even if the wing was not present, which resulted in a CTD. This fixes #4899. Tested and works as expected.