### PR TITLE
by default, start texture animation at the beginning of a mission

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -635,6 +635,11 @@ uint64_t timestamp_get_mission_time_in_microseconds()
 	return timestamp_get_microseconds() - Timestamp_microseconds_at_mission_start;
 }
 
+int timestamp_get_mission_time_in_milliseconds()
+{
+	return static_cast<int>(timestamp_get_mission_time_in_microseconds() / MICROSECONDS_PER_MILLISECOND);
+}
+
 void timestamp_offset_mission_time(float offset)
 {
 	auto time = static_cast<uint64_t>(static_cast<long double>(offset) * MICROSECONDS_PER_SECOND);

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -121,9 +121,10 @@ extern int timer_get_seconds();				// seconds since program started... not accur
 
 // conversion factors
 constexpr int MILLISECONDS_PER_SECOND = 1000;
-constexpr uint64_t MICROSECONDS_PER_SECOND = 1000000;
-constexpr uint64_t NANOSECONDS_PER_SECOND = 1000000000;
-constexpr uint64_t NANOSECONDS_PER_MICROSECOND = 1000;
+constexpr int MICROSECONDS_PER_MILLISECOND = 1000;
+constexpr int NANOSECONDS_PER_MICROSECOND = 1000;
+constexpr uint64_t MICROSECONDS_PER_SECOND = MICROSECONDS_PER_MILLISECOND * MILLISECONDS_PER_SECOND;
+constexpr uint64_t NANOSECONDS_PER_SECOND = NANOSECONDS_PER_MICROSECOND * MICROSECONDS_PER_SECOND;
 
 // use this call to get the current counter value (which represents the time at the time
 // this function is called).  I.e. it doesn't return a count that would be in the future,
@@ -245,6 +246,7 @@ void timestamp_start_mission();
 // Calculate the current mission time using the timestamps
 fix timestamp_get_mission_time();
 uint64_t timestamp_get_mission_time_in_microseconds();
+int timestamp_get_mission_time_in_milliseconds();
 
 // Advance mission time by specific offset (for in-game joining)
 void timestamp_offset_mission_time(float offset);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1365,7 +1365,8 @@ int model_render_determine_elapsed_time(int objnum, uint flags)
 		return timestamp_since(Skybox_timestamp);
 	}
 
-	return 0;
+	// by default, assume texture animation started at the beginning of the mission
+	return timestamp_get_mission_time_in_milliseconds();
 }
 
 bool model_render_determine_autocenter(vec3d *auto_back, polymodel *pm, int detail_level, uint flags)


### PR DESCRIPTION
For all POFs that use animated textures, if no starting timestamp is specified, assume animation started at the beginning of the mission.  This fixes a bug reported in Starfox: Event Horizon where weapon POF animated textures stopped animating after the texture timestamp upgrade.