### PR TITLE
allow getting message names in script generation

### DIFF
--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -2109,7 +2109,7 @@ BEGIN
     GROUPBOX        "Script Options",IDC_SCRIPT_OPTIONS,143,7,257,214
     GROUPBOX        "Script Entry Format",IDC_ENTRY,149,17,246,76
     EDITTEXT        IDC_ENTRY_FORMAT,154,28,109,56,ES_MULTILINE | ES_AUTOHSCROLL | ES_WANTRETURN
-    LTEXT           "$filename - name of the message file\r\n$message - text of the message\r\n$persona - persona of the sender\r\n$sender - name of the sender\r\n\r\nNote that $persona and $sender will only appear for the Message section.",IDC_STATIC,270,28,120,58
+    LTEXT           "$name - name of the message\r\n$filename - name of the message file\r\n$message - text of the message\r\n$persona - persona of the sender\r\n$sender - name of the sender\r\n\r\nNote that $persona and $sender will only appear for the Message section.",IDC_STATIC,270,28,120,58
     GROUPBOX        "Export",IDC_EXPORT,276,98,119,83
     CONTROL         "Everything",IDC_EXPORT_EVERYTHING,"Button",BS_AUTORADIOBUTTON,280,108,99,9
     CONTROL         "Just Command Briefings",IDC_EXPORT_COMMAND_BRIEFINGS,

--- a/fred2/voiceactingmanager.cpp
+++ b/fred2/voiceactingmanager.cpp
@@ -435,6 +435,7 @@ void VoiceActingManager::OnGenerateScript()
 			entry.Replace("$message", stage->text.c_str());
 			entry.Replace("$persona", "<no persona specified>");
 			entry.Replace("$sender", "<no sender specified>");
+			entry.Replace("$name", "<no name specified>");
 
 			fout("%s\n\n\n", (char *) (LPCTSTR) entry);
 		}
@@ -454,6 +455,7 @@ void VoiceActingManager::OnGenerateScript()
 			entry.Replace("$message", stage->text.c_str());
 			entry.Replace("$persona", "<no persona specified>");
 			entry.Replace("$sender", "<no sender specified>");
+			entry.Replace("$name", "<no name specified>");
 
 			fout("%s\n\n\n", (char *) (LPCTSTR) entry);
 		}
@@ -473,6 +475,7 @@ void VoiceActingManager::OnGenerateScript()
 			entry.Replace("$message", stage->text.c_str());
 			entry.Replace("$persona", "<no persona specified>");
 			entry.Replace("$sender", "<no sender specified>");
+			entry.Replace("$name", "<no name specified>");
 	
 			fout("%s\n\n\n", (char *) (LPCTSTR) entry);
 		}
@@ -516,6 +519,8 @@ void VoiceActingManager::export_one_message(const MMessage *message)
 {
 	CString entry = m_script_entry_format;
 	entry.Replace("\r\n", "\n");
+
+	entry.Replace("$name", message->name);
 
 	// replace file name
 	entry.Replace("$filename", message->wave_info.name);


### PR DESCRIPTION
A quick feature to print Message Names as part of script generation. This is useful for Lua sexps that send messages on behalf of ships where the code won't be able to find the Sender from a send-message SEXP. In the case of BtA's specific message-alt SEXPs, the "sender" is always built-in to the message name itself.