### PR TITLE
Setting up Vampirism again... again

### DIFF
--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2459,13 +2459,13 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 				object* parent = &Objects[other_obj->parent];
 
 				if ((parent->type == OBJ_SHIP) && (parent->signature == other_obj->parent_sig)) {
-					ship* shipparent = &Ships[parent->instance];
+					ship* shipp_parent = &Ships[parent->instance];
 
 					if (!parent->flags[Object::Object_Flags::Should_be_dead]) {
 						parent->hull_strength += damage * wip->vamp_regen;
 
-						if (parent->hull_strength > shipparent->ship_max_hull_strength) {
-							parent->hull_strength = shipparent->ship_max_hull_strength;
+						if (parent->hull_strength > shipp_parent->ship_max_hull_strength) {
+							parent->hull_strength = shipp_parent->ship_max_hull_strength;
 						}
 					}
 				}

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2451,14 +2451,19 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 
 		// if weapon is vampiric, slap healing on shooter instead of target
 		weapon_info_index = shiphit_get_damage_weapon(other_obj);
+
 		if (weapon_info_index >= 0) {
 			weapon_info* wip = &Weapon_info[weapon_info_index];
+
 			if ((wip->wi_flags[Weapon::Info_Flags::Vampiric]) && (other_obj->parent > 0)) {
 				object* parent = &Objects[other_obj->parent];
+
 				if ((parent->type == OBJ_SHIP) && (parent->signature == other_obj->parent_sig)) {
 					ship* shipparent = &Ships[parent->instance];
+
 					if (!parent->flags[Object::Object_Flags::Should_be_dead]) {
 						parent->hull_strength += damage * wip->vamp_regen;
+
 						if (parent->hull_strength > shipparent->ship_max_hull_strength) {
 							parent->hull_strength = shipparent->ship_max_hull_strength;
 						}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -496,6 +496,9 @@ struct weapon_info
 	float weapon_reduce;					// how much energy removed from weapons systems
 	float afterburner_reduce;			// how much energy removed from weapons systems
 
+	// Vampirism Effect Multiplier
+	float vamp_regen;					// Factor by which a vampiric weapon will multiply the healing done to the shooter
+
 	// tag stuff
 	float	tag_time;						// how long the tag lasts		
 	int tag_level;							// tag level (1 - 3)

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -86,6 +86,7 @@ namespace Weapon {
 		Require_exact_los,					// If secondary or in turret, will only fire if ship has line of sight to target
 		Can_damage_shooter,					// this weapon and any of its descendants can damage its shooter - Asteroth
 		Heals,								// 'damage' heals instead of actually damaging - Asteroth
+		Vampiric,						    // damage applied also brings back health to the shooter - Strygon
 		SecondaryNoAmmo,					// Secondaries that only use energy
 		No_collide,
 		Multilock_target_dead_subsys,

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -236,6 +236,7 @@ special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info
 	{ "require exact los",				Weapon::Info_Flags::Require_exact_los,					true },
 	{ "can damage shooter",				Weapon::Info_Flags::Can_damage_shooter,					true },
 	{ "heals",							Weapon::Info_Flags::Heals,						        true },
+	{"vampiric",						Weapon::Info_Flags::Vampiric,							true },
 	{ "secondary no ammo",				Weapon::Info_Flags::SecondaryNoAmmo,					true },
 	{ "no collide",						Weapon::Info_Flags::No_collide,						    true },
 	{ "multilock target dead subsys",   Weapon::Info_Flags::Multilock_target_dead_subsys,		true },
@@ -2223,6 +2224,23 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		stuff_float(&wip->afterburner_reduce);
 	}
 
+	// Multiplier for the healing done to the shooter of the weapon.
+	if (optional_string("$Vampiric Healing Factor:")) {
+		stuff_float(&wip->vamp_regen);
+		if (!(wip->wi_flags[Weapon::Info_Flags::Vampiric])) {
+			Warning(LOCATION,
+				"$Vampiric Healing Factor specified for weapon %s but this weapon does not have the \"Vampiric\" "
+				"weapon flag set. Automatically setting the flag",
+				wip->name);
+			wip->wi_flags.set(Weapon::Info_Flags::Vampiric);
+		}
+		if (wip->vamp_regen <= 0) {
+			Warning(LOCATION,
+				"Vampiric Healing Factor \'%s\' must be greater than zero\nResetting value to default.",
+				wip->name);
+			wip->vamp_regen = 1.0f;
+		}
+	}
 	if (optional_string("$Corkscrew:"))
 	{
 		if(optional_string("+Num Fired:")) {
@@ -8936,6 +8954,8 @@ void weapon_info::reset()
 
 	this->weapon_reduce = ESUCK_DEFAULT_WEAPON_REDUCE;
 	this->afterburner_reduce = ESUCK_DEFAULT_AFTERBURNER_REDUCE;
+
+	this->vamp_regen = 1.0f;
 
 	this->tag_time = -1.0f;
 	this->tag_level = -1;


### PR DESCRIPTION
I've returned to this project after a year of not working on it. Got most of the changes from last time added, along with warnings for missing flags or bad values. The core principle is still the same:

-Vampirism flag enables the ability to regain health by dealing hull damage to a ship.
-"$Vampiric Healing Factor:" is the multiplier by which the final hull damage dealt is multiplied by. This value now cannot go below 0.

This now DOES work with shockwaves and beams and primaries and secondaries.