### PR TITLE
fix crash when changing ship classes in FRED

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10582,7 +10582,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	ph_inf = objp->phys_info;
 
 	// if this ship is the wing leader, update the ship info index that the wing keeps track of.
-	if (p_objp->wingnum > -1 && p_objp->pos_in_wing == 0) {
+	if (!Fred_running && p_objp->wingnum > -1 && p_objp->pos_in_wing == 0) {
 		Wings[p_objp->wingnum].special_ship_ship_info_index = ship_type;
 	}
 


### PR DESCRIPTION
PR #4908 had a small bug that caused a crash in FRED.  The code in question is only needed and only relevant when changing ship classes in-mission.