### PR TITLE
Add Option to allow weapons that hit player to place per-weapon sound

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -121,6 +121,7 @@ float Thruster_easing;
 bool Always_use_distant_firepoints;
 bool Discord_presence;
 bool hotkey_always_hide_ships;
+bool Use_weapon_class_sounds_for_hits_to_player;
 
 static auto DiscordOption = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
 							 .category("Other")
@@ -765,6 +766,10 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$Use per-weapon impact sounds for hits to player:")) {
+			stuff_boolean(&Use_weapon_class_sounds_for_hits_to_player);
+		}
+
 		optional_string("#FRED SETTINGS");
 
 		if (optional_string("$Disable Hard Coded Message Head Ani Files:")) {
@@ -1219,6 +1224,7 @@ void mod_table_reset()
 	Always_use_distant_firepoints = false;
 	Discord_presence = true;
 	hotkey_always_hide_ships = false;
+	Use_weapon_class_sounds_for_hits_to_player = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -117,6 +117,7 @@ extern float Thruster_easing;
 extern bool Always_use_distant_firepoints;
 extern bool Discord_presence;
 extern bool hotkey_always_hide_ships;
+extern bool Use_weapon_class_sounds_for_hits_to_player;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6792,7 +6792,7 @@ void weapon_hit_do_sound(object *hit_obj, weapon_info *wip, vec3d *hitpos, bool 
 		// play a shield hit if shields are above 10% max in this quadrant
 		if ( shield_str > 0.1f ) {
 			// Play a shield impact sound effect
-			if ( hit_obj == Player_obj ) {
+			if ( !(Use_weapon_class_sounds_for_hits_to_player) && (hit_obj == Player_obj)) {
 				snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIELD_HIT_YOU), hitpos, &Eye_position );
 				// AL 12-15-97: Add missile impact sound even when shield is hit
 				if ( wip->subtype == WP_MISSILE ) {
@@ -6805,14 +6805,14 @@ void weapon_hit_do_sound(object *hit_obj, weapon_info *wip, vec3d *hitpos, bool 
 			// Play a hull impact sound effect
 			switch ( wip->subtype ) {
 				case WP_LASER:
-					if ( hit_obj == Player_obj )
+					if ( !(Use_weapon_class_sounds_for_hits_to_player) && (hit_obj == Player_obj))
 						snd_play_3d( gamesnd_get_game_sound(GameSounds::PLAYER_HIT_LASER), hitpos, &Eye_position );
 					else {
 						weapon_play_impact_sound(wip, hitpos, is_armed);
 					}
 					break;
 				case WP_MISSILE:
-					if ( hit_obj == Player_obj ) 
+					if ( !(Use_weapon_class_sounds_for_hits_to_player) && (hit_obj == Player_obj)) 
 						snd_play_3d( gamesnd_get_game_sound(GameSounds::PLAYER_HIT_MISSILE), hitpos, &Eye_position);
 					else {
 						weapon_play_impact_sound(wip, hitpos, is_armed);


### PR DESCRIPTION
Weapons that lasers or missiles that hit the player also play a hard coded sound, which is not ideal when trying to give valuable audio feedback to player.

This PR allows modders to stop the behavior and have the weapon class impact sound specified in the weapons table play instead of the hard coded sounds.

Tested and works as expected.