### PR TITLE
pre parse icons to get an accurate count

### DIFF
--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -345,6 +345,36 @@ void brief_icon_parse_cleanup() {
 	}
 }
 
+int Num_icons_in_table = 0;
+
+// This is explicitely used to count the number of icons listed in the tbl
+// so that we can correctly parse each icon into a species without any off-by-N errors.
+// This allows modular icons.tbls to build upon the retail icons.tbl.
+void brief_pre_parse_icons()
+{
+	try {
+		read_file_text("icons.tbl", CF_TYPE_TABLES);
+		reset_parse();
+
+		required_string("#Start");
+
+		//If we're in the new format, then nothing to do!
+		if (check_for_string("$Species:"))
+			return;
+
+		char junk[MAX_FILENAME_LEN];
+		while (optional_string("$Name:")) {
+			stuff_string(junk, F_NAME, MAX_FILENAME_LEN);
+			Num_icons_in_table++;
+		}
+
+		required_string("#End");
+	} 
+	catch (const parse::ParseException& e) {
+		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", "icons.tbl", e.what()));
+	}
+}
+
 // --------------------------------------------------------------------------------------
 //	brief_parse_icon_tbl()
 //
@@ -371,7 +401,7 @@ void brief_parse_icon_tbl(const char* filename)
 		}
 
 		bool new_style_parsing = false;
-		if (check_for_string("$Species:"))
+		if (Parsing_modular_table || check_for_string("$Species:")) //Do not allow modular tables to use the old format! -Mjn
 			new_style_parsing = true;
 
 		if (new_style_parsing) {
@@ -417,14 +447,36 @@ void brief_parse_icon_tbl(const char* filename)
 			}
 		}
 		else { // old style
+
+			size_t Num_species_in_table = 0;
+			
+			//Calculate how many species we're going to try to parse icons for using the pre-parsed count
+			if (Num_icons_in_table % MIN_BRIEF_ICONS != 0)
+				Warning(LOCATION,
+					"An incorrect number of icons was found in icons.tbl. There should be %i icons per species listed!",
+					MIN_BRIEF_ICONS);
+
+			Num_species_in_table = Num_icons_in_table / MIN_BRIEF_ICONS;
+
+			if (Num_species_in_table % BRIEF_ICON_TYPES != 0)
+				Error(LOCATION,
+					"There was somehow a number of icons divisible by %i, but is now not divisible by %i. Get a "
+					"coder!",
+					MIN_BRIEF_ICONS,
+					BRIEF_ICON_TYPES);
+
+			Num_species_in_table = Num_species_in_table / BRIEF_ICON_TYPES;
+
 			for (int icon_type = 0; icon_type < MIN_BRIEF_ICONS; icon_type++) { // NOLINT(modernize-loop-convert)
-				for (species = 0; species < unique_icons_species.size(); species++) {
+				for (species = 0; species < Num_species_in_table; species++) {
 					// if this check isn't true we're missing entries and will complain about it later in brief_icon_parse_cleanup()
-					if (check_for_string("$Name:"))
+					if (check_for_string("$Name:")) {
 						Species_info[unique_icons_species[species]].bii_indices[icon_type] = add_briefing_icons();
+					}
 				}
 			}
 
+			//This can still be reached if the above Warning is ignored-Mjn
 			const size_t max_icons = unique_icons_species.size() * MIN_BRIEF_ICONS;
 			if (!check_for_string("#End"))
 				Warning(LOCATION, "Too many icons in icons.tbl; only the first " SIZE_T_ARG " will be used", max_icons);
@@ -438,6 +490,9 @@ void brief_parse_icon_tbl(const char* filename)
 
 void brief_icons_init() {
 	Briefing_icon_info.clear();
+
+	//This is super dumb, but retail format is bad and should feel bad for making me do this-Mjn
+	brief_pre_parse_icons();
 
 	brief_parse_icon_tbl("icons.tbl");
 

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -63,6 +63,9 @@
 #define ICON_JUMP_NODE						33
 #define ICON_TRANSPORT						34
 
+#define BRIEF_ICON_TYPES					3
+
+//If any types are added here then be sure to update BRIEF_ICON_TYPES
 typedef struct briefing_icon_info {
 	generic_anim	regular;
 	hud_anim		fade;


### PR DESCRIPTION
Fixes #4894 by pre-parsing the icons.tbl to get a count of how many times $Name: is found. Then during actual parse if icons.tbl we use that to limit how many species we're defining icons for instead of `unique_icons_species.size()` because some of those species may be defined later by a modular table. There may be a better way to do this, but it was the best idea I could think of this morning.