### PR TITLE
add no_fred flag for weapons, and patch no_fred for ships

### DIFF
--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -92,6 +92,7 @@ namespace Weapon {
 		Multilock_target_dead_subsys,
 		No_evasion,							// AI will not attempt to dodge this weapon - Asteroth
 		Dont_merge_indicators,				// This secondary lead indicator won't be merged with the primary lead indicator even if this is a homing weapon.
+		No_fred,							// not available in fred
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -242,6 +242,7 @@ special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info
 	{ "multilock target dead subsys",   Weapon::Info_Flags::Multilock_target_dead_subsys,		true },
 	{ "no evasion",						Weapon::Info_Flags::No_evasion,						    true },
  	{ "don't merge lead indicators",	Weapon::Info_Flags::Dont_merge_indicators,			    true },
+	{ "no_fred",						Weapon::Info_Flags::No_fred,							true },
 };
 
 const size_t num_weapon_info_flags = sizeof(Weapon_Info_Flags) / sizeof(special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info_Flags>&>);

--- a/fred2/shipeditordlg.h
+++ b/fred2/shipeditordlg.h
@@ -52,6 +52,8 @@ private:
 	int mission_type;  // indicates if single player(1) or multiplayer(0)
 	CView*	m_pSEView;
 	CCriticalSection CS_update;
+	int combo_index_to_ship_class(int combo_index);
+	int ship_class_to_combo_index(int ship_class);
 
 // Construction
 public:
@@ -103,7 +105,7 @@ public:
 	sexp_tree	m_departure_tree;
 	CString	m_ship_name;
 	CString	m_cargo1;
-	int		m_ship_class;
+	int		m_ship_class_combo_index;
 	int		m_team;
 	int		m_arrival_location;
 	int		m_departure_location;

--- a/fred2/weaponeditordlg.h
+++ b/fred2/weaponeditordlg.h
@@ -24,35 +24,26 @@ public:
 	void OnOK();
 	WeaponEditorDlg(CWnd* pParent = NULL);   // standard constructor
 
-	int m_ammo_max1;
-	int m_ammo_max2;
-	int m_ammo_max3;
-	int m_ammo_max4;
+	std::array<int, MAX_SHIP_SECONDARY_BANKS> m_ammo_max;
 	int m_last_item;
 	int m_ship;
 	int m_ship_class;
 	int m_multi_edit;
 	ship_weapon pilot, *cur_weapon;
 
+	std::array<int, MAX_SHIP_PRIMARY_BANKS> m_IDC_GUN;
+	std::array<int, MAX_SHIP_SECONDARY_BANKS> m_IDC_MISSILE;
+	std::array<int, MAX_SHIP_SECONDARY_BANKS> m_IDC_AMMO;
+	std::array<int, MAX_SHIP_SECONDARY_BANKS> m_IDC_SPIN;
+
 // Dialog Data
 	//{{AFX_DATA(WeaponEditorDlg)
 	enum { IDD = IDD_WEAPON_EDITOR };
-	CSpinButtonCtrl	m_spin4;
-	CSpinButtonCtrl	m_spin3;
-	CSpinButtonCtrl	m_spin2;
-	CSpinButtonCtrl	m_spin1;
+	std::array<int, MAX_SHIP_SECONDARY_BANKS> m_ammo;
+	std::array<CSpinButtonCtrl, MAX_SHIP_SECONDARY_BANKS> m_spin;
 	int		m_ai_class;
-	int		m_ammo1;
-	int		m_ammo2;
-	int		m_ammo3;
-	int		m_ammo4;
-	int		m_gun1;
-	int		m_gun2;
-	int		m_gun3;
-	int		m_missile1;
-	int		m_missile2;
-	int		m_missile3;
-	int		m_missile4;
+	std::array<int, MAX_SHIP_PRIMARY_BANKS> m_gun;
+	std::array<int, MAX_SHIP_SECONDARY_BANKS> m_missile;
 	int		m_cur_item;
 	//}}AFX_DATA
 
@@ -76,6 +67,10 @@ protected:
 	afx_msg void OnSelchangeMissile2();
 	afx_msg void OnSelchangeMissile3();
 	afx_msg void OnSelchangeMissile4();
+	afx_msg void OnSelchangeMissile(int secondary_index);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
+
+	int combo_index_to_weapon_class(int dialog_id, int combo_index);
+	int weapon_class_to_combo_index(int dialog_id, int weapon_class);
 };


### PR DESCRIPTION
The new `no_fred` flag prevents weapons from being listed in the dropdown lists in the weapon dialog.  Also this fixes `no_fred` ships to not appear either: previously they were hidden in the main window dropdown but still appeared in the ship editor.

In order to vastly simplify the dropdown list code, the weapon dialog was refactored to use arrays of variables rather than one hardcoded variable per bank.

Implements #3643.