### PR TITLE
style tweaks for recently added options

### DIFF
--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -624,7 +624,7 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 		// if a ship's hotkey is the last hotkey on the list, then maybe make the hotkey -1 if
 		// we are now in mission.  Otherwise, skip this ship
 		if ( shipp->hotkey == MAX_KEYED_TARGETS ) {
-			if ((!(Game_mode & GM_IN_MISSION)) || hotkey_always_hide_ships)
+			if ((!(Game_mode & GM_IN_MISSION)) || Hotkey_always_hide_hidden_ships)
 				continue;										// skip to next ship
 			shipp->hotkey = -1;
 		}

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -120,7 +120,7 @@ shadow_disable_overrides Shadow_disable_overrides {false, false, false, false};
 float Thruster_easing;
 bool Always_use_distant_firepoints;
 bool Discord_presence;
-bool hotkey_always_hide_ships;
+bool Hotkey_always_hide_hidden_ships;
 
 static auto DiscordOption = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
 							 .category("Other")
@@ -1069,12 +1069,12 @@ void parse_mod_table(const char *filename)
 		if (optional_string("$Use distant firepoint for all turrets:")){
 			stuff_boolean(&Always_use_distant_firepoints);
 		}
-		if (optional_string("$Enable discord rich presence:")) {
+		if (optional_string("$Enable Discord rich presence:")) {
 			stuff_boolean(&Discord_presence);
 		}
 
 		if (optional_string("$Always hide hidden ships in hotkey list:")) {
-			stuff_boolean(&hotkey_always_hide_ships);
+			stuff_boolean(&Hotkey_always_hide_hidden_ships);
 		}
 
 
@@ -1218,7 +1218,7 @@ void mod_table_reset()
 	Thruster_easing = 0;
 	Always_use_distant_firepoints = false;
 	Discord_presence = true;
-	hotkey_always_hide_ships = false;
+	Hotkey_always_hide_hidden_ships = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -116,7 +116,7 @@ extern struct shadow_disable_overrides {
 extern float Thruster_easing;
 extern bool Always_use_distant_firepoints;
 extern bool Discord_presence;
-extern bool hotkey_always_hide_ships;
+extern bool Hotkey_always_hide_hidden_ships;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
1. Since Discord is both a common noun and a proper noun, capitalize it here to clarify what it refers to.
2. Capitalize the first letter of the Hotkey internal variable to follow the global variable convention.  And might as well clarify, while we're at it, that it hides hidden ships, not all ships.