### PR TITLE
fix the rest of the autoscaled attributes

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -461,6 +461,7 @@ typedef struct ai_info {
 	ai_lua_parameters lua_ai_target;
 } ai_info;
 
+int ai_maybe_autoscale(int absolute_index = -1);
 int ai_get_autoscale_index(int absolute_index = -1);
 
 // Goober5000


### PR DESCRIPTION
PR #4516 did not cover all of the autoscaled AI class attributes, since a few of them were labeled differently.  This adds checks to grab the correct autoscale index for the remaining cases:

```
$Afterburner Use Factor:
$Shockwave Evade Chances Per Second:
$Get Away Chance:
$Secondary Range Multiplier:
```

Fortunately, Sushi's investigation was pretty thorough.  Between these remaining cases and @EatThePath's autoscaling review, this PR should cover the complete set of autoscaling situations.

Fixes #4922.