### PR TITLE
make sexp_tree dragging more user-friendly

### DIFF
--- a/fred2/campaigneditordlg.cpp
+++ b/fred2/campaigneditordlg.cpp
@@ -516,7 +516,7 @@ void campaign_editor::OnMoveUp()
 		if ((last != -1) && (i < Total_links)) {
 			h1 = m_tree.GetParentItem(m_tree.handle(Links[i].node));
 			h2 = m_tree.GetParentItem(m_tree.handle(Links[last].node));
-			m_tree.swap_roots(h1, h2);
+			m_tree.move_root(h1, h2, true);
 			m_tree.SelectItem(m_tree.GetParentItem(m_tree.handle(Links[i].node)));
 
 			temp = Links[last];
@@ -549,7 +549,7 @@ void campaign_editor::OnMoveDown()
 		if (j < Total_links) {
 			h1 = m_tree.GetParentItem(m_tree.handle(Links[i].node));
 			h2 = m_tree.GetParentItem(m_tree.handle(Links[j].node));
-			m_tree.swap_roots(h1, h2);
+			m_tree.move_root(h1, h2, false);
 			m_tree.SelectItem(m_tree.GetParentItem(m_tree.handle(Links[i].node)));
 
 			temp = Links[j];
@@ -562,7 +562,7 @@ void campaign_editor::OnMoveDown()
 	GetDlgItem(IDC_SEXP_TREE)->SetFocus();
 }
 
-void campaign_editor::swap_handler(int node1, int node2)
+void campaign_editor::move_handler(int node1, int node2, bool insert_before)
 {
 	int index1, index2;
 	campaign_tree_link temp;
@@ -583,11 +583,13 @@ void campaign_editor::swap_handler(int node1, int node2)
 
 	temp = Links[index1];
 
-	while (index1 < index2) {
+	int offset = insert_before ? -1 : 0;
+
+	while (index1 < index2 + offset) {
 		Links[index1] = Links[index1 + 1];
 		index1++;
 	}
-	while (index1 > index2 + 1) {
+	while (index1 > index2 + offset + 1) {
 		Links[index1] = Links[index1 - 1];
 		index1--;
 	}
@@ -595,7 +597,7 @@ void campaign_editor::swap_handler(int node1, int node2)
 	Links[index1] = temp;
 
 	// update Cur_campaign_link
-	Cur_campaign_link = index1;
+	Cur_campaign_link = index2;
 }
 
 void campaign_editor::insert_handler(int old, int node)

--- a/fred2/campaigneditordlg.h
+++ b/fred2/campaigneditordlg.h
@@ -41,7 +41,7 @@ protected:
 public:
 	void mission_selected(int num);
 	void insert_handler(int old, int node);
-	void swap_handler(int node1, int node2);
+	void move_handler(int node1, int node2, bool insert_before);
 	void update();
 	void load_tree(int save = 1);
 	void save_tree(int clear = 1);

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -1208,7 +1208,7 @@ void event_editor::OnUpdateTriggerCount()
 		GetDlgItem(IDC_INTERVAL_TIME)->EnableWindow(TRUE);
 	}
 }
-void event_editor::swap_handler(int node1, int node2)
+void event_editor::move_handler(int node1, int node2, bool insert_before)
 {
 	int index1, index2, s;
 	mission_event m;
@@ -1232,12 +1232,14 @@ void event_editor::swap_handler(int node1, int node2)
 	m = m_events[index1];
 	s = m_sig[index1];
 
-	while (index1 < index2) {
+	int offset = insert_before ? -1 : 0;
+
+	while (index1 < index2 + offset) {
 		m_events[index1] = m_events[index1 + 1];
 		m_sig[index1] = m_sig[index1 + 1];
 		index1++;
 	}
-	while (index1 > index2 + 1) {
+	while (index1 > index2 + offset + 1) {
 		m_events[index1] = m_events[index1 - 1];
 		m_sig[index1] = m_sig[index1 - 1];
 		index1--;
@@ -1246,7 +1248,7 @@ void event_editor::swap_handler(int node1, int node2)
 	m_events[index1] = m;
 	m_sig[index1] = s;
 
-	cur_event = index1;
+	cur_event = index2;
 	update_cur_event();
 }
 

--- a/fred2/eventeditor.h
+++ b/fred2/eventeditor.h
@@ -59,7 +59,7 @@ public:
 	int get_event_num(HTREEITEM handle);
 	void reset_event(int num, HTREEITEM after);
 	void save_event(int e);
-	void swap_handler(int node1, int node2);
+	void move_handler(int node1, int node2, bool insert_before);
 	void insert_handler(int old, int node);
 	int query_modified();
 	void OnOK();		// default MFC OK behavior

--- a/fred2/missiongoalsdlg.cpp
+++ b/fred2/missiongoalsdlg.cpp
@@ -575,10 +575,10 @@ void CMissionGoalsDlg::OnNoMusic()
 	UpdateData(TRUE);
 }
 
-void CMissionGoalsDlg::swap_handler(int node1, int node2)
+void CMissionGoalsDlg::move_handler(int node1, int node2, bool insert_before)
 {
 	int index1, index2, s;
-	mission_goal m;
+	mission_goal g;
 
 	for (index1=0; index1<m_num_goals; index1++){
 		if (m_goals[index1].formula == node1){
@@ -594,21 +594,23 @@ void CMissionGoalsDlg::swap_handler(int node1, int node2)
 	}
 	Assert(index2 < m_num_goals);
 
-	m = m_goals[index1];
+	g = m_goals[index1];
 	s = m_sig[index1];
 
-	while (index1 < index2) {
+	int offset = insert_before ? -1 : 0;
+
+	while (index1 < index2 + offset) {
 		m_goals[index1] = m_goals[index1 + 1];
 		m_sig[index1] = m_sig[index1 + 1];
 		index1++;
 	}
-	while (index1 > index2 + 1) {
+	while (index1 > index2 + offset + 1) {
 		m_goals[index1] = m_goals[index1 - 1];
 		m_sig[index1] = m_sig[index1 - 1];
 		index1--;
 	}
 
-	m_goals[index1] = m;
+	m_goals[index1] = g;
 	m_sig[index1] = s;
 }
 

--- a/fred2/missiongoalsdlg.h
+++ b/fred2/missiongoalsdlg.h
@@ -27,7 +27,7 @@ class CMissionGoalsDlg : public CDialog
 {
 // Construction
 public:
-	void swap_handler(int node1, int node2);
+	void move_handler(int node1, int node2, bool insert_before);
 	int query_modified();
 	void OnCancel();
 	void OnOK();

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -137,7 +137,7 @@ public:
 	int get_default_value(sexp_list_item *item, char *text_buf, int op, int i);
 	int query_default_argument_available(int op);
 	int query_default_argument_available(int op, int i);
-	void swap_roots(HTREEITEM one, HTREEITEM two);
+	void move_root(HTREEITEM source, HTREEITEM dest, bool insert_before);
 	void move_branch(int source, int parent = -1);
 	HTREEITEM move_branch(HTREEITEM source, HTREEITEM parent = TVI_ROOT, HTREEITEM after = TVI_LAST);
 	void copy_branch(HTREEITEM source, HTREEITEM parent = TVI_ROOT, HTREEITEM after = TVI_LAST);

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -2605,11 +2605,14 @@ void sexp_tree::copy_branch(QTreeWidgetItem* source, QTreeWidgetItem* parent, QT
 	}
 }
 
-void sexp_tree::swap_roots(QTreeWidgetItem* one, QTreeWidgetItem* two) {
-//	copy_branch(one, TVI_ROOT, two);
-//	move_branch(two, TVI_ROOT, one);
-//	DeleteItem(one);
-	auto h = move_branch(one, itemFromIndex(rootIndex()), two);
+void sexp_tree::move_root(QTreeWidgetItem* source, QTreeWidgetItem* dest, bool insert_before) {
+	auto after = dest;
+
+	if (insert_before) {
+		Warning(LOCATION, "Inserting before a tree item is not yet implemented in qtFRED");
+	}
+
+	auto h = move_branch(source, itemFromIndex(rootIndex()), after);
 	setCurrentItem(h);
 	modified();
 }

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -194,7 +194,7 @@ class sexp_tree: public QTreeWidget {
 	int get_default_value(sexp_list_item* item, char* text_buf, int op, int i);
 	int query_default_argument_available(int op);
 	int query_default_argument_available(int op, int i);
-	void swap_roots(QTreeWidgetItem* one, QTreeWidgetItem* two);
+	void move_root(QTreeWidgetItem* source, QTreeWidgetItem* dest, bool insert_before);
 	void move_branch(int source, int parent = -1);
 	QTreeWidgetItem*
 	move_branch(QTreeWidgetItem* source, QTreeWidgetItem* parent = nullptr, QTreeWidgetItem* after = nullptr);


### PR DESCRIPTION
FREDders expect events (and goals and campaign links) to land where you drag them.  So when dragging items earlier in the list, insert them before the item they are dropped on.