### PR TITLE
don't process turrets or subsystems when playing dead

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11731,6 +11731,10 @@ void ai_process_subobjects(int objnum)
 	ai_info	*aip = &Ai_info[shipp->ai_index];
 	ship_info	*sip = &Ship_info[shipp->ship_info_index];
 
+	// ships that are playing dead do not process subsystems or turrets
+	if (aip->mode == AIM_PLAY_DEAD)
+		return;
+
 	polymodel_instance *pmi = model_get_instance(shipp->model_instance_num);
 	polymodel *pm = model_get(pmi->model_num);
 

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -304,16 +304,28 @@ void ai_remove_ship_goal( ai_info *aip, int index )
 
 	if (index == aip->active_goal)
 	{
+		auto shipp = &Ships[aip->shipnum];
+
 		// rearm/repair needs a bit of extra cleanup
 		if (aip->goals[index].ai_mode == AI_GOAL_REARM_REPAIR)
-			ai_abort_rearm_request(&Objects[Ships[aip->shipnum].objnum]);
+			ai_abort_rearm_request(&Objects[shipp->objnum]);
 
-		// wookieejedi - play dead needs some extra cleanup, too
-		// there is an early return for the mode AIM_PLAY_DEAD in AI frame, so it needs to be set back to AIM_NONE
-		if (aip->ai_profile_flags[AI::Profile_Flags::Fixed_removing_play_dead_order] && 
-			(aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD || aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD_PERSISTENT)) {
-			aip->mode = AIM_NONE;
-			aip->submode_start_time = Missiontime;
+		// play dead needs some extra cleanup, too
+		if (aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD || aip->goals[index].ai_mode == AI_GOAL_PLAY_DEAD_PERSISTENT)
+		{
+			// wookieejedi - there is an early return for the mode AIM_PLAY_DEAD in AI frame, so it needs to be set back to AIM_NONE
+			if (aip->ai_profile_flags[AI::Profile_Flags::Fixed_removing_play_dead_order])
+			{
+				aip->mode = AIM_NONE;
+				aip->submode_start_time = Missiontime;
+			}
+
+			// Goober5000 - any ship subsystems will start moving now, so their initial velocity should be 0 to match original behavior
+			for (auto pss = GET_FIRST(&shipp->subsys_list); pss != END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss))
+			{
+				pss->submodel_instance_1->current_turn_rate = 0.0f;
+				pss->submodel_instance_1->current_shift_rate = 0.0f;
+			}
 		}
 
 		aip->active_goal = AI_GOAL_NONE;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18751,6 +18751,10 @@ void ship_move_subsystems(object *objp)
 	Assertion(objp->type == OBJ_SHIP, "ship_move_subsystems should only be called for ships!  objp type = %d", objp->type);
 	auto shipp = &Ships[objp->instance];
 
+	// ships that are playing dead do not process subsystems or turrets
+	if (Ai_info[shipp->ai_index].mode == AIM_PLAY_DEAD)
+		return;
+
 	for (auto pss = GET_FIRST(&shipp->subsys_list); pss != END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss))
 	{
 		auto psub = pss->system_info;


### PR DESCRIPTION
In the submodel reorganization in commit 575c050da44c213c4ef127588880f24101ca480f, subobject movement was moved out of the AI pipeline, which inadvertently removed the play-dead check that prevents subsystem movement.  This broke a few missions such as Scroll's 'Thor's Hammer'.  This PR restores the check.

Fixes #4933.