### PR TITLE
Fix RefCounting on invalid textures

### DIFF
--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -12,7 +12,7 @@ namespace api {
 
 texture_h::texture_h() = default;
 texture_h::texture_h(int bm, bool refcount) : handle(bm) {
-	if (refcount)
+	if (refcount && isValid())
 		bm_get_entry(bm)->load_count++;
 }
 texture_h::~texture_h()


### PR DESCRIPTION
Fixes #4935.
#4822 introduced proper refcounting for lua-held textures. Unfortunately, it failed to account for the creation of invalid textures, which caused a failed attempt at refcounting invalid textures, causing an Assert.
This now adds a check, that only texture objects which are actually valid will be refcounted.