### PR TITLE
Enhance OnDialogX Hooks to encompass Death Popups

### DIFF
--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -533,6 +533,7 @@ int popup_init(popup_info *pi, int flags)
 			scripting::hook_param("IsTimeStopped", 'b', Popup_time_was_stopped_in_init),
 			scripting::hook_param("IsStateRunning", 'b', static_cast<bool>(Popup_running_state)),
 			scripting::hook_param("IsInputPopup", 'b', static_cast<bool>(flags & PF_INPUT)),
+			scripting::hook_param("IsDeathPopup", 'b', false),
 			scripting::hook_param("Title", 's', pi->title),
 			scripting::hook_param("Text", 's', pi->raw_text),
 			scripting::hook_param("AllowedInput", 's', pi->valid_chars, flags & PF_INPUT));
@@ -636,7 +637,9 @@ void popup_close(popup_info *pi, int screen_id)
 
 
 	if (scripting::hooks::OnDialogClose->isActive())
-		scripting::hooks::OnDialogClose->run();
+		scripting::hooks::OnDialogClose->run(scripting::hook_param_list(
+			scripting::hook_param("IsDeathPopup", 'b', false))
+		);
 }
 
 // set the popup text color
@@ -952,7 +955,8 @@ int popup_do(popup_info *pi, int flags)
 				scripting::hook_param("Submit", 'u', luacpp::LuaFunction::createFromStdFunction(Script_system.GetLuaSession(), [&done, &choice, pi](lua_State* L, const luacpp::LuaValueList& resolveVals) {
 					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals) ? 1 : 0;
 					return luacpp::LuaValueList{};
-					})));
+					})),
+				scripting::hook_param("IsDeathPopup", 'b', true));
 
 			scripting::hooks::OnDialogFrame->run(paramList);
 			isScriptingOverride = scripting::hooks::OnDialogFrame->isOverride(paramList);

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -956,7 +956,7 @@ int popup_do(popup_info *pi, int flags)
 					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals) ? 1 : 0;
 					return luacpp::LuaValueList{};
 					})),
-				scripting::hook_param("IsDeathPopup", 'b', true));
+				scripting::hook_param("IsDeathPopup", 'b', false));
 
 			scripting::hooks::OnDialogFrame->run(paramList);
 			isScriptingOverride = scripting::hooks::OnDialogFrame->isOverride(paramList);

--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -432,7 +432,7 @@ void popupdead_draw_button_text()
 	}
 }
 
-void popup_resolve_scripting(lua_State* L, int& choice, const luacpp::LuaValueList& arguments) {
+static void popupdead_resolve_scripting(lua_State* L, int& choice, const luacpp::LuaValueList& arguments) {
 	if (arguments.empty() || !arguments[0].isValid()) {
 		LuaError(L, "Invalid type supplied to dialog submit function!");
 		return;
@@ -487,7 +487,7 @@ int popupdead_do_frame(float  /*frametime*/)
 	if (scripting::hooks::OnDialogFrame->isActive()) {
 		auto paramList = scripting::hook_param_list(
 			scripting::hook_param("Submit", 'u', luacpp::LuaFunction::createFromStdFunction(Script_system.GetLuaSession(), [&choice](lua_State* L, const luacpp::LuaValueList& resolveVals) {
-				popup_resolve_scripting(L, choice, resolveVals);
+				popupdead_resolve_scripting(L, choice, resolveVals);
 				return luacpp::LuaValueList{};
 				})),
 			scripting::hook_param("IsDeathPopup", 'b', true),

--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -31,6 +31,7 @@
 #include "playerman/player.h"
 #include "popup/popup.h"
 #include "popup/popupdead.h"
+#include "scripting/global_hooks.h"
 #include "ui/ui.h"
 
 
@@ -139,11 +140,6 @@ void popupdead_start()
 	// increment number of deaths
 	Player->failures_this_session++;
 
-
-	// create base window
-	Popupdead_window.create(Popupdead_background_coords[gr_screen.res][0], Popupdead_background_coords[gr_screen.res][1], 1, 1, 0);
-	Popupdead_window.set_foreground_bmap(Popupdead_background_filename[gr_screen.res]);
-
 	Popupdead_num_choices = 0;
 	Popupdead_multi_type = -1;
 
@@ -222,6 +218,39 @@ void popupdead_start()
 		}
 	}
 
+	io::mouse::CursorManager::get()->pushStatus();
+	io::mouse::CursorManager::get()->showCursor(true);
+
+	Popupdead_default_choice = 0;
+	Popupdead_choice = -1;
+	Popupdead_active = 1;
+
+	if (scripting::hooks::OnDialogInit->isActive())
+	{
+		luacpp::LuaTable buttons = luacpp::LuaTable::create(Script_system.GetLuaSession());
+		for (int cnt = 0; cnt < Popupdead_num_choices; cnt++) {
+			luacpp::LuaTable button = luacpp::LuaTable::create(Script_system.GetLuaSession());
+			button.addValue("Positivity", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), 0));
+			button.addValue("Text", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), Popupdead_button_text[cnt]));
+			buttons.addValue(cnt + 1, button);
+		}
+
+		auto paramList = scripting::hook_param_list(
+			scripting::hook_param("Choices", 't', buttons),
+			scripting::hook_param("IsTimeStopped", 'b', false),
+			scripting::hook_param("IsStateRunning", 'b', true),
+			scripting::hook_param("IsInputPopup", 'b', false),
+			scripting::hook_param("IsDeathPopup", 'b', true));
+
+		scripting::hooks::OnDialogInit->run(paramList);
+		if (scripting::hooks::OnDialogInit->isOverride(paramList))
+			return;
+	}
+
+	// create base window
+	Popupdead_window.create(Popupdead_background_coords[gr_screen.res][0], Popupdead_background_coords[gr_screen.res][1], 1, 1, 0);
+	Popupdead_window.set_foreground_bmap(Popupdead_background_filename[gr_screen.res]);
+
 	// create buttons
 	for (i=0; i < Popupdead_num_choices; i++) {
 		b = &Popupdead_buttons[i];
@@ -237,13 +266,6 @@ void popupdead_start()
 		b->create(&Popupdead_window, "", lx, Popupdead_region_coords[gr_screen.res][i][1], Popupdead_region_coords[gr_screen.res][i][2]-lx, Popupdead_region_coords[gr_screen.res][i][3]-Popupdead_region_coords[gr_screen.res][i][1], 0, 1);
 		b->hide();
 	}
-	
-	io::mouse::CursorManager::get()->pushStatus();
-	io::mouse::CursorManager::get()->showCursor(true);
-	
-	Popupdead_default_choice = 0;
-	Popupdead_choice = -1;
-	Popupdead_active = 1;
 }
 
 // maybe play a sound when key up/down is pressed to switch default choice
@@ -410,6 +432,22 @@ void popupdead_draw_button_text()
 	}
 }
 
+void popup_resolve_scripting(lua_State* L, int& choice, const luacpp::LuaValueList& arguments) {
+	if (arguments.empty() || !arguments[0].isValid()) {
+		LuaError(L, "Invalid type supplied to dialog submit function!");
+		return;
+	}
+
+	auto type = arguments[0].getValueType();
+
+	if (type == luacpp::ValueType::NUMBER) {
+		choice = arguments[0].getValue<int>();
+	}
+	else {
+		LuaError(L, "Invalid type supplied to dialog submit function!");
+	}
+}
+
 // Called once per frame to run the dead popup
 int popupdead_do_frame(float  /*frametime*/)
 {
@@ -445,14 +483,31 @@ int popupdead_do_frame(float  /*frametime*/)
 		Popupdead_skip_already_shown = 1;
 	}
 
+	bool isScriptingOverride = false;
+	if (scripting::hooks::OnDialogFrame->isActive()) {
+		auto paramList = scripting::hook_param_list(
+			scripting::hook_param("Submit", 'u', luacpp::LuaFunction::createFromStdFunction(Script_system.GetLuaSession(), [&choice](lua_State* L, const luacpp::LuaValueList& resolveVals) {
+				popup_resolve_scripting(L, choice, resolveVals);
+				return luacpp::LuaValueList{};
+				})),
+			scripting::hook_param("IsDeathPopup", 'b', true),
+			scripting::hook_param("Freeze", 'b', static_cast<bool>(popup_active())));
+
+		scripting::hooks::OnDialogFrame->run(paramList);
+		isScriptingOverride = scripting::hooks::OnDialogFrame->isOverride(paramList);
+	}
+
 	// don't process keys/buttons if another popup is active
 	if ( !popup_active() ) {
-		k = Popupdead_window.process();
 
-		choice = popupdead_process_keys(k);
+		if (!isScriptingOverride) {
+			k = Popupdead_window.process();
 
-		if (choice < 0) {
-			choice = popupdead_check_buttons();
+			choice = popupdead_process_keys(k);
+
+			if (choice < 0) {
+				choice = popupdead_check_buttons();
+			}
 		}
 
 		if ( choice >= 0 ) {
@@ -485,9 +540,11 @@ int popupdead_do_frame(float  /*frametime*/)
 		}
 	}
 
-	Popupdead_window.draw();
-	popupdead_force_draw_buttons();
-	popupdead_draw_button_text();
+	if (!isScriptingOverride) {
+		Popupdead_window.draw();
+		popupdead_force_draw_buttons();
+		popupdead_draw_button_text();
+	}
 
 	// maybe force the player to respawn if they've taken too long to choose
 	if (( Game_mode & GM_MULTIPLAYER ) && (The_mission.max_respawn_delay >= 0) && (ui_timestamp_elapsed(Popupdead_timer)) && (choice < 0)) {
@@ -518,6 +575,11 @@ void popupdead_close(bool play_sound)
 	Popupdead_active = 0;
 	Popupdead_skip_active = 0;
 	Popupdead_skip_already_shown = 0;
+
+	if (scripting::hooks::OnDialogClose->isActive())
+		scripting::hooks::OnDialogClose->run(scripting::hook_param_list(
+			scripting::hook_param("IsDeathPopup", 'b', true))
+		);
 }
 
 // Is there a dead popup active?

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -85,23 +85,28 @@ const std::shared_ptr<OverridableHook> OnDialogInit = OverridableHook::Factory("
 			"A table containing the different choices for this dialog. Contains subtables, each consisting of "
 			"Positivity (an int, 0 if neutral, 1 if positive, and -1 if negative) and "
 			"Text (a string, the text of the button)."},
-		{"Title", "string", "The title of the popup window."},
-		{"Text", "string", "The text to be displayed in the popup window."},
+		{"Title", "string", "The title of the popup window. Nil for a death popup."},
+		{"Text", "string", "The text to be displayed in the popup window. Nil for a death popup."},
 		{"IsTimeStopped", "boolean", "True if mission time was interrupted for this popup."},
 		{"IsStateRunning", "boolean", "True if the underlying state is still being processed and rendered."},
 		{"IsInputPopup", "boolean", "True if this popup is for entering text."},
+		{"IsDeathPopup", "boolean", "True if this popup is an in-mission death popup and should be styled as such."},
 		{"AllowedInput", "string", "A string of characters allowed to be present in the input popup. Nil if not an input popup."}
 	 });
 
 const std::shared_ptr<OverridableHook> OnDialogFrame = OverridableHook::Factory("On Dialog Frame",
 	"Invoked each frame for a system dialog. Override to prevent the system dialog from rendering and evaluating.",
 	{
-		{"Submit", "function(number | string | nil result) -> nil", "A callback function that should be called if the popup resolves. Should be string only if it is an input popup. Pass nil to abort."}
+		{"Submit", "function(number | string | nil result) -> nil", "A callback function that should be called if the popup resolves. Should be string only if it is an input popup. Pass nil to abort."},
+		{"IsDeathPopup", "boolean", "True if this popup is an in-mission death popup and should be styled as such."},
+		{"Freeze", "boolean", "If not nil and true, the popup should not process any inputs but just render."}
 	});
 
 const std::shared_ptr<Hook> OnDialogClose = Hook::Factory("On Dialog Close",
 	"Invoked when a dialog closes.",
-	{});
+	{
+		{"IsDeathPopup", "boolean", "True if this popup is an in-mission death popup and should be styled as such."}
+	});
 
 // ========== DEPRECATED ==========
 


### PR DESCRIPTION
This is a follow-up to #4806, allowing SCPUI to take full control of all popups in the game, including those on-death.
