### PR TITLE
Allow setting glowpoint light intensity

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -553,6 +553,7 @@ typedef struct glow_point_bank_override {
 	bool		rotating;
 	vec3d		rotation_axis;
 	float		rotation_speed;
+	float		intensity;
 
 	bool		pulse_period_override;
 } glow_point_bank_override;

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5638,6 +5638,7 @@ void glowpoint_override_defaults(glow_point_bank_override *gpo)
 	gpo->rotating = false;
 	gpo->rotation_axis = vmd_zero_vector;
 	gpo->rotation_speed = 0.0f;
+	gpo->intensity = 1.0f;
 }
 
 SCP_vector<glow_point_bank_override>::iterator get_glowpoint_bank_override_by_name(const char* name)
@@ -5782,6 +5783,10 @@ void parse_glowpoint_table(const char *filename)
 
 			if (optional_string("+light")) {
 				gpo.is_lightsource = true;
+
+				if (optional_string("$Light intensity:")) {
+					stuff_float(&gpo.intensity);
+				}
 
 				if (optional_string("$Light radius multiplier:")) {
 					stuff_float(&gpo.radius_multi);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1851,10 +1851,10 @@ void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient,
 			vm_vec_rotate(&cone_dir_screen, &cone_dir_world, &Eye_matrix);
 			cone_dir_screen.xyz.z = -cone_dir_screen.xyz.z;
 			light_add_cone(
-				&world_pnt, &cone_dir_screen, gpo->cone_angle, gpo->cone_inner_angle, gpo->dualcone, 1.0f, light_radius, 1,
+				&world_pnt, &cone_dir_screen, gpo->cone_angle, gpo->cone_inner_angle, gpo->dualcone, 1.0f, light_radius, gpo->intensity,
 				lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z, gpt->radius);
 		} else {
-			light_add_point(&world_pnt, 1.0f, light_radius, 1,	lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z, gpt->radius);
+			light_add_point(&world_pnt, 1.0f, light_radius, gpo->intensity,	lightcolor.xyz.x, lightcolor.xyz.y, lightcolor.xyz.z, gpt->radius);
 		}
 	}
 }


### PR DESCRIPTION
Adds option to glowpoint overrides table to define the light intensity for the glowpoint. Defaults to the previous hardcoded value of 1.0f.