### PR TITLE
Expose decal options useful for modders

### DIFF
--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -338,12 +338,7 @@ void parseDecalReference(creation_info& dest_info, bool is_new_entry) {
 	}
 
 	if (required_string_if_new("+Radius:", is_new_entry)) {
-		stuff_float(&dest_info.radius);
-
-		if (dest_info.radius <= 0.0f) {
-			error_display(0, "Invalid radius of %f! Must be a positive number.", dest_info.radius);
-			dest_info.radius = 1.0f;
-		}
+		dest_info.radius = util::parseUniformRange(0.0001f);
 	}
 
 	if (required_string_if_new("+Lifetime:", is_new_entry)) {
@@ -353,6 +348,10 @@ void parseDecalReference(creation_info& dest_info, bool is_new_entry) {
 			// Require at least a small lifetime so that the calculations don't have to deal with div-by-zero
 			dest_info.lifetime = util::parseUniformRange(0.0001f);
 		}
+	}
+
+	if (optional_string("+Use Random Rotation:")) {
+		stuff_boolean(&dest_info.random_rotation);
 	}
 }
 
@@ -530,9 +529,10 @@ void addDecal(creation_info& info, object* host, int submodel, const vec3d& loca
 	newDecal.position = local_pos;
 	newDecal.orientation = local_orient;
 	if (info.width < 0.0f || info.height < 0.0f) {
-		newDecal.scale.xyz.x = info.radius;
-		newDecal.scale.xyz.y = info.radius;
-		newDecal.scale.xyz.z = info.radius;
+		float radius = info.radius.next();
+		newDecal.scale.xyz.x = radius;
+		newDecal.scale.xyz.y = radius;
+		newDecal.scale.xyz.z = radius;
 	} else {
 		newDecal.scale.xyz.x = info.width;
 		newDecal.scale.xyz.y = info.height;

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -186,7 +186,7 @@ void parse_decals_table(const char* filename) {
 	}
 
 	if (!gr_is_capable(CAPABILITY_DEFERRED_LIGHTING)) {
-		// we need deferred lighting
+		// We need deferred lighting
 		Decal_system_active = false;
 		mprintf(("Note: Decal system has been disabled due to lack of deferred lighting.\n"));
 	}
@@ -196,7 +196,7 @@ void parse_decals_table(const char* filename) {
 		mprintf(("Note: Decal system has been disabled due to lack of normal mapping.\n"));
 	}
 	if (!gr_is_capable(CAPABILITY_SEPARATE_BLEND_FUNCTIONS)) {
-		// WWe need separate blending functions for different color buffers
+		// We need separate blending functions for different color buffers
 		Decal_system_active = false;
 		mprintf(("Note: Decal system has been disabled due to lack of separate color buffer blend functions.\n"));
 	}
@@ -436,7 +436,7 @@ void renderAll() {
 	}
 
 	// Clear out any invalid decals
-	for (auto iter = active_decals.begin(); iter != active_decals.end(); ++iter) {
+	for (auto iter = active_decals.begin(); iter != active_decals.end();) {
 		if (!iter->isValid()) {
 			// if we're sitting on the very last element, popping-back will invalidate the iterator!
 			if (iter + 1 == active_decals.end()) {
@@ -448,6 +448,10 @@ void renderAll() {
 			active_decals.pop_back();
 			continue;
 		}
+
+		// next decal, only increment the iterator if we found a valid value so nothing gets skipped
+		// otherwise we may skip a decal which can then get through to the draw_list loop while being invalid
+		++iter;
 	}
 
 	if (active_decals.empty()) {
@@ -458,13 +462,14 @@ void renderAll() {
 
 	graphics::decal_draw_list draw_list(active_decals.size());
 	for (auto& decal : active_decals) {
+
+		Assertion(decal.definition_handle >= 0 && decal.definition_handle < (int)DecalDefinitions.size(),
+			"Invalid decal handle detected!");
+		auto& decalDef = DecalDefinitions[decal.definition_handle];
+
 		int diffuse_bm = -1;
 		int glow_bm = -1;
 		int normal_bm = -1;
-
-		Assertion(decal.definition_handle >= 0 && decal.definition_handle < (int) DecalDefinitions.size(),
-				  "Invalid decal handle detected!");
-		auto& decalDef = DecalDefinitions[decal.definition_handle];
 
 		auto decal_time = mission_time - decal.creation_time;
 		auto progress = decal_time / decal.lifetime;

--- a/code/decals/decals.h
+++ b/code/decals/decals.h
@@ -64,10 +64,11 @@ typedef int DecalReference;
  */
 struct creation_info {
 	DecalReference definition_handle = -1;
-	float radius = -1.0f;
+	util::UniformFloatRange radius = ::util::UniformFloatRange(-1.0f);
 	float width = -1.0f;
 	float height = -1.0f;
 	util::UniformFloatRange lifetime = ::util::UniformFloatRange(-1.0f);
+	bool random_rotation = false;
 };
 
 /**

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -140,6 +140,15 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 		matrix decal_orient;
 		vm_vector_2_matrix_norm(&decal_orient, &hit_dir, &weapon_up); // hit_dir is already normalized so we can use the more efficient function
 
+		// randomize angle of decal if specified --wookeejedi
+		if (wip->impact_decal.random_rotation) {
+			angles random_rotation_angs;
+			random_rotation_angs.b = frand() * PI;
+			matrix random_rotation_ori;
+			vm_angles_2_matrix(&random_rotation_ori, &random_rotation_angs);
+			vm_matrix_x_matrix(&decal_orient, &decal_orient, &random_rotation_ori);
+		}
+
 		decals::addDecal(wip->impact_decal, pship_obj, submodel_num, *hitpos, decal_orient);
 	}
 }


### PR DESCRIPTION
Now that decals are stable, this PR exposes two options that are very useful for modders:
1) Use a random range for the radius of decals (lifetime already uses a random range to excellent effect)
2) Add option to allow decals to use a random rotation when created.

Both are tested and work well. 