### PR TITLE
fix wing name matching

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18818,7 +18818,7 @@ int ship_squadron_wing_lookup(const char *wing_name)
 
 		for (int i = 0; i < MAX_SQUADRON_WINGS; i++)
 		{
-			if (!strnicmp(Squadron_wing_names[i], wing_name, len))
+			if (!strnicmp(Squadron_wing_names[i], wing_name, std::max(len, strlen(Squadron_wing_names[i]))))
 				return i;
 		}
 	}


### PR DESCRIPTION
The logic designed to match Epsilon and Epsilon#clone would be tripped up by Pi and Pisces.  Tweak the string matching to handle this.

Fixes a bug reported on the forums: https://www.hard-light.net/forums/index.php?topic=98576.0