### PR TITLE
Properly init cockpit_model_instance to -1

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6591,6 +6591,8 @@ void ship::clear()
 
 	autoaim_fov = 0.0f;
 
+	cockpit_model_instance = -1;
+
 	multi_client_collision_timestamp = TIMESTAMP::immediate();
 
 	passive_arc_next_times.clear();


### PR DESCRIPTION
This would otherwise cause a crash when a cockpitless model gets loaded, leaves cockpit_model_instance at 0, and then tries to clear the cockpit instance 0 again once the ship gets cleaned.