### PR TITLE
move @ removal up

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2054,9 +2054,7 @@ static void parse_ship(const char *filename, bool replace)
 	required_string("$Name:");
 	stuff_string(fname, F_NAME, NAME_LENGTH);
 
-	// Remove @ symbol
-	// these used to denote ships that would
-	// only be parsed in demo builds
+	// Remove @ symbol -- these used to denote ships that would only be parsed in demo builds
 	if (fname[0] == '@') {
 		backspace(fname);
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2053,6 +2053,14 @@ static void parse_ship(const char *filename, bool replace)
 
 	required_string("$Name:");
 	stuff_string(fname, F_NAME, NAME_LENGTH);
+
+	// Remove @ symbol
+	// these used to denote ships that would
+	// only be parsed in demo builds
+	if (fname[0] == '@') {
+		backspace(fname);
+	}
+
 	diag_printf("Ship name -- %s\n", fname);
 
 	if (optional_string("+nocreate")) {
@@ -2077,13 +2085,6 @@ static void parse_ship(const char *filename, bool replace)
 			Removed_ships.push_back(fname);
 			remove_ship = true;
 		}
-	}
-
-	//Remove @ symbol
-	//these used to denote weapons that would
-	//only be parsed in demo builds
-	if ( fname[0] == '@' ) {
-		backspace(fname);
 	}
 
 	//Check if ship exists already

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -806,9 +806,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	required_string("$Name:");
 	stuff_string(fname, F_NAME, NAME_LENGTH);
 
-	// Remove @ symbol
-	// these used to denote weapons that would
-	// only be parsed in demo builds
+	// Remove @ symbol -- these used to denote weapons that would only be parsed in demo builds
 	if (fname[0] == '@') {
 		backspace(fname);
 	}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -805,6 +805,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 	required_string("$Name:");
 	stuff_string(fname, F_NAME, NAME_LENGTH);
+
+	// Remove @ symbol
+	// these used to denote weapons that would
+	// only be parsed in demo builds
+	if (fname[0] == '@') {
+		backspace(fname);
+	}
+
 	diag_printf("Weapon name -- %s\n", fname);
 
 	if(optional_string("+nocreate")) {
@@ -829,13 +837,6 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			Removed_weapons.push_back(fname);
 			remove_weapon = true;
 		}
-	}
-
-	//Remove @ symbol
-	//these used to denote weapons that would
-	//only be parsed in demo builds
-	if ( fname[0] == '@' ) {
-		backspace(fname);
 	}
 
 	//Check if weapon exists already


### PR DESCRIPTION
Ran into this in BtA. For the purposes of +remove, `@Shipname` is not the same as `Shipname` which is different from all other parsing. This PR resolves that by moving the code that removes the @ from the name to directly after the name parsing so that the @ symbol is truly completely ignored by the code as documented in the Wiki.