### PR TITLE
exposes wing formation via scripting

### DIFF
--- a/code/scripting/api/libs/tables.cpp
+++ b/code/scripting/api/libs/tables.cpp
@@ -3,19 +3,20 @@
 
 #include "tables.h"
 
+#include "scripting/api/objs/decaldefinition.h"
+#include "scripting/api/objs/fireballclass.h"
+#include "scripting/api/objs/intelentry.h"
 #include "scripting/api/objs/shipclass.h"
 #include "scripting/api/objs/shiptype.h"
 #include "scripting/api/objs/weaponclass.h"
-#include "scripting/api/objs/intelentry.h"
-#include "scripting/api/objs/fireballclass.h"
-#include "scripting/api/objs/decaldefinition.h"
+#include "scripting/api/objs/wingformation.h"
 
+#include "decals/decals.h"
+#include "fireball/fireballs.h"
+#include "menuui/techmenu.h"
+#include "mission/missionmessage.h"
 #include "ship/ship.h"
 #include "weapon/weapon.h"
-#include "menuui/techmenu.h"
-#include "fireball/fireballs.h"
-#include "mission/missionmessage.h"
-#include "decals/decals.h"
 
 
 extern bool Ships_inited;
@@ -292,6 +293,51 @@ ADE_VIRTVAR(DecalOptionActive, l_Tables, "boolean", "Gets or sets whether the de
 	}
 
 	return ade_set_args(L, "b", choice);
+}
+
+//*****SUBLIBRARY: Tables/WingFormations
+ADE_LIB_DERIV(l_Tables_WingFormations, "WingFormations", nullptr, nullptr, l_Tables);
+
+ADE_INDEXER(l_Tables_WingFormations, "number/string IndexOrName", "Array of wing formations", "wingformation", "Wing formation handle, or invalid handle if name is invalid")
+{
+	const char* name;
+	if (!ade_get_args(L, "*s", &name))
+		return 0;
+
+	// default is always the first formation
+	if (!stricmp(name, "Default"))
+		return ade_set_args(L, "o", l_WingFormation.Set(0));
+
+	// look up by name
+	int idx = wing_formation_lookup(name);
+
+	// if found, add 1 since "Default" is always first
+	if (idx >= 0)
+	{
+		idx++;
+	}
+	// look up by number
+	else
+	{
+		// atoi is good enough here, 0 is invalid anyway
+		idx = atoi(name);
+		if (idx > 0)
+		{
+			idx--; // Lua --> C/C++
+		}
+		else
+		{
+			return ade_set_args(L, "o", l_WingFormation.Set(-1));
+		}
+	}
+
+	return ade_set_args(L, "o", l_WingFormation.Set(idx));
+}
+
+ADE_FUNC(__len, l_Tables_WingFormations, nullptr, "Number of wing formations", "number", "Number of wing formations")
+{
+	// add 1 since "Default" is always first
+	return ade_set_args(L, "i", static_cast<int>(Wing_formations.size()) + 1);
 }
 
 }

--- a/code/scripting/api/objs/fireballclass.cpp
+++ b/code/scripting/api/objs/fireballclass.cpp
@@ -15,8 +15,7 @@ ADE_OBJ(l_Fireballclass, int, "fireballclass", "Fireball class handle");
 ADE_FUNC(__tostring, l_Fireballclass, NULL, "Fireball class name", "string", "Fireball class unique id, or an empty string if handle is invalid")
 {
 	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Fireballclass.Get(&idx), &s))
+	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "s", "");
 
 	if(idx < 0 || idx >= Num_fireball_types)
@@ -43,26 +42,30 @@ ADE_FUNC(__eq, l_Fireballclass, "fireballclass, fireballclass", "Checks if the t
 ADE_VIRTVAR(UniqueID, l_Fireballclass, "string", "Fireball class name", "string", "Fireball class unique id, or empty string if handle is invalid")
 {
 	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx), &s))
+	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "s", "");
 
 	if(idx < 0 || idx >= Num_fireball_types)
 		return ade_set_error(L, "s", "");
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "This property is read-only");
 
 	return ade_set_args(L, "s", Fireball_info[idx].unique_id);
 }
 
 ADE_VIRTVAR(Filename, l_Fireballclass, NULL, "Fireball class animation filename (LOD 0)", "string", "Filename, or empty string if handle is invalid")
 {
-	//Currently not settable as the bitmaps are only loaded once at level start
 	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx), &s))
+	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "s", "");
 
 	if(idx < 0 || idx >= Num_fireball_types)
 		return ade_set_error(L, "s", "");
+
+	//Currently not settable as the bitmaps are only loaded once at level start
+	if (ADE_SETTING_VAR)
+		LuaError(L, "This property is read-only");
 
 	return ade_set_args(L, "s", Fireball_info[idx].lod[0].filename);
 }
@@ -70,12 +73,14 @@ ADE_VIRTVAR(Filename, l_Fireballclass, NULL, "Fireball class animation filename 
 ADE_VIRTVAR(NumberFrames, l_Fireballclass, NULL, "Amount of frames the animation has (LOD 0)", "number", "Amount of frames, or -1 if handle is invalid")
 {
 	int idx;
-	float f = 0.0f;
-	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx), &f))
+	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "i", -1);
 
 	if(idx < 0 || idx >= Num_fireball_types)
 		return ade_set_error(L, "i", -1);
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "This property is read-only");
 
 	return ade_set_args(L, "i", Fireball_info[idx].lod[0].num_frames);
 }
@@ -83,12 +88,14 @@ ADE_VIRTVAR(NumberFrames, l_Fireballclass, NULL, "Amount of frames the animation
 ADE_VIRTVAR(FPS, l_Fireballclass, NULL, "The FPS with which this fireball's animation is played (LOD 0)", "number", "FPS, or -1 if handle is invalid")
 {
 	int idx;
-	float f = 0.0f;
-	if (!ade_get_args(L, "o", l_Fireballclass.Get(&idx), &f))
+	if (!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "i", -1);
 
 	if (idx < 0 || idx >= Num_fireball_types)
 		return ade_set_error(L, "i", -1);
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "This property is read-only");
 
 	return ade_set_args(L, "i", Fireball_info[idx].lod[0].fps);
 }
@@ -116,5 +123,6 @@ ADE_FUNC(getTableIndex, l_Fireballclass, NULL, "Gets the index value of the fire
 
 	return ade_set_args(L, "i", idx + 1);
 }
+
 }
 }

--- a/code/scripting/api/objs/wing.cpp
+++ b/code/scripting/api/objs/wing.cpp
@@ -1,9 +1,11 @@
 //
 //
 
-#include "wing.h"
 #include "ship.h"
 #include "object/object.h"
+#include "wing.h"
+#include "wingformation.h"
+
 #include "ship/ship.h"
 
 extern bool sexp_check_flag_array(const char *flag_name, Ship::Wing_Flags &wing_flag);
@@ -178,6 +180,47 @@ static int wing_getset_helper(lua_State* L, int wing::* field, bool canSet = fal
 	}
 
 	return ade_set_args(L, "i", Wings[wingnum].*field);
+}
+
+ADE_VIRTVAR(Formation, l_Wing, "wingformation", "Gets or sets the formation of the wing.", "wingformation", "Wing formation, or nil if wing is invalid")
+{
+	int wingnum, formation_id = -1;
+
+	if (!ade_get_args(L, "o|o", l_Wing.Get(&wingnum), l_WingFormation.Get(&formation_id)))
+		return ADE_RETURN_NIL;
+
+	if (wingnum < 0 || wingnum >= Num_wings)
+		return ADE_RETURN_NIL;
+
+	wing* wingp = &Wings[wingnum];
+
+	if (ADE_SETTING_VAR && formation_id >= 0)
+	{
+		wingp->formation = formation_id - 1;		// offset from Default
+	}
+
+	return ade_set_args(L, "o", l_WingFormation.Set(formation_id));
+}
+
+ADE_VIRTVAR(FormationScale, l_Wing, "number", "Gets or sets the scale (i.e. distance multiplier) of the current wing formation.", "number", "scale of wing formation, nil if wing or formation invalid")
+{
+	int wingnum;
+	float formation_scale = 0.0f;
+
+	if (!ade_get_args(L, "o|f", l_Wing.Get(&wingnum), &formation_scale))
+		return ADE_RETURN_NIL;
+
+	if (wingnum < 0 || wingnum >= Num_wings)
+		return ADE_RETURN_NIL;
+
+	wing* wingp = &Wings[wingnum];
+
+	if (ADE_SETTING_VAR && formation_scale != 0.0f)
+	{
+		wingp->formation_scale = formation_scale;
+	}
+
+	return ade_set_args(L, "f", wingp->formation_scale);
 }
 
 ADE_VIRTVAR(CurrentCount, l_Wing, nullptr, "Gets the number of ships in the wing that are currently present", "number", "Number of ships, or nil if invalid handle")

--- a/code/scripting/api/objs/wingformation.cpp
+++ b/code/scripting/api/objs/wingformation.cpp
@@ -1,0 +1,82 @@
+//
+//
+
+#include "wingformation.h"
+
+#include "ship/ship.h"
+
+namespace scripting {
+namespace api {
+
+// NOTE: the wing formation index runs 1 through Wing_formations.size(), offset by 1 from the internal contents.  Index 0 is Default.
+// This is necessary because the first formation is Default, but Default isn't actually stored internally as a formation.
+
+//**********HANDLE: WingFormation
+ADE_OBJ(l_WingFormation, int, "wingformation", "Wing formation handle");
+
+ADE_FUNC(__tostring, l_WingFormation, nullptr, "Wing formation name", "string", "Wing formation name, or an empty string if handle is invalid")
+{
+	int formation_id;
+	if (!ade_get_args(L, "o", l_WingFormation.Get(&formation_id)))
+		return ade_set_error(L, "s", "");
+
+	if (formation_id == 0)
+		return ade_set_args(L, "s", "Default");
+
+	formation_id--;	// offset from Default
+
+	if (formation_id < 0 || formation_id >= (int)Wing_formations.size())
+		return ade_set_error(L, "s", "");
+
+	return ade_set_args(L, "s", Wing_formations[formation_id].name);
+}
+
+ADE_FUNC(__eq, l_WingFormation, "wingformation, wingformation", "Checks if the two formations are equal", "boolean", "true if equal, false otherwise")
+{
+	int idx1, idx2;
+	if (!ade_get_args(L, "oo", l_WingFormation.Get(&idx1), l_WingFormation.Get(&idx2)))
+		return ade_set_error(L, "b", false);
+
+	if (idx1 < 0 || idx1 >= (int)Wing_formations.size() + 1)
+		return ade_set_error(L, "b", false);
+
+	if (idx2 < 0 || idx2 >= (int)Wing_formations.size() + 1)
+		return ade_set_error(L, "b", false);
+
+	return ade_set_args(L, "b", idx1 == idx2);
+}
+
+ADE_VIRTVAR(Name, l_WingFormation, "string", "Wing formation name", "string", "Wing formation name, or empty string if handle is invalid")
+{
+	int formation_id;
+	if (!ade_get_args(L, "o", l_WingFormation.Get(&formation_id)))
+		return ade_set_error(L, "s", "");
+
+	if (formation_id == 0)
+		return ade_set_args(L, "s", "Default");
+
+	formation_id--;	// offset from Default
+
+	if (formation_id < 0 || formation_id >= (int)Wing_formations.size())
+		return ade_set_error(L, "s", "");
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "This property is read-only");
+
+	return ade_set_args(L, "s", Wing_formations[formation_id].name);
+}
+
+ADE_FUNC(isValid, l_WingFormation, nullptr, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+{
+	int formation_id;
+	if (!ade_get_args(L, "o", l_WingFormation.Get(&formation_id)))
+		return ADE_RETURN_NIL;
+
+	if (formation_id < 0 || formation_id >= (int)Wing_formations.size() + 1)
+		return ADE_RETURN_FALSE;
+
+	return ADE_RETURN_TRUE;
+}
+
+}
+}

--- a/code/scripting/api/objs/wingformation.h
+++ b/code/scripting/api/objs/wingformation.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+#include "scripting/ade.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+DECLARE_ADE_OBJ(l_WingFormation, int);
+
+}
+}

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1441,6 +1441,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/weapon.h
 	scripting/api/objs/wing.cpp
 	scripting/api/objs/wing.h
+	scripting/api/objs/wingformation.cpp
+	scripting/api/objs/wingformation.h
 )
 
 add_file_folder("Scripting\\\\Lua"


### PR DESCRIPTION
A rework of #4980, adding a wing formation type and a way to access them via `tb.WingFormations`.

Also fixes some flaws in the fireball class, which the wing formation class is based on.