### PR TITLE
Ensure effect animations load before static bitmaps

### DIFF
--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -191,7 +191,7 @@ void parse_nebula_table(const char* filename)
 			optional_string("+Nebula:");
 			stuff_string(name, F_NAME, MAX_FILENAME_LEN);
 
-			if (!(generic_bitmap_exists(name))) {
+			if (!generic_bitmap_exists(name) && !generic_anim_exists(name)) {
 				error_display(0, "Nebula bitmap %s was not found!, skipping!", name);
 				continue;
 			}
@@ -217,7 +217,7 @@ void parse_nebula_table(const char* filename)
 
 				strcpy_s(pooft.name, name);
 
-				if (!(generic_bitmap_exists(pooft.bitmap_filename))) {
+				if (!generic_bitmap_exists(pooft.bitmap_filename) && !generic_anim_exists(pooft.bitmap_filename)) {
 					error_display(0, "Bitmap defined for nebula poof %s was not found. Skipping!", pooft.name);
 					continue;
 				}
@@ -284,7 +284,7 @@ void parse_nebula_table(const char* filename)
 				}
 
 				//We can't skip here because we'd have to back out the entire poof from the vector-Mjn
-				if (!(generic_bitmap_exists(poofp->bitmap_filename)))
+				if (!generic_bitmap_exists(poofp->bitmap_filename) && !generic_anim_exists(poofp->bitmap_filename))
 					error_display(0, "Bitmap defined for nebula poof %s was not found!", poofp->name);
 
 				if (optional_string("$Scale:"))
@@ -484,15 +484,16 @@ void neb2_post_level_init(bool fog_color_override)
 	// load in all nebula bitmaps
 	for (poof_info &pinfo : Poof_info) {
 		if (pinfo.bitmap.first_frame < 0) {
-			pinfo.bitmap.first_frame = bm_load(pinfo.bitmap_filename);
-
-			if (pinfo.bitmap.first_frame >= 0) {
-				pinfo.bitmap.num_frames = 1;
-				pinfo.bitmap.total_time = 1.0f;
-			}		// fall back to an animated type
-			else if (generic_anim_load(&pinfo.bitmap)) {
-				mprintf(("Could not find a usable bitmap for nebula poof '%s'!\n", pinfo.name));
-				Warning(LOCATION, "Could not find a usable bitmap (%s) for nebula poof '%s'!\n", pinfo.bitmap_filename, pinfo.name);
+			if (generic_anim_load(&pinfo.bitmap)) {
+				// fall back to non-animated type
+				pinfo.bitmap.first_frame = bm_load(pinfo.bitmap_filename);
+				if (pinfo.bitmap.first_frame >= 0) {
+					pinfo.bitmap.num_frames = 1;
+					pinfo.bitmap.total_time = 1.0f;
+				} else {
+					mprintf(("Could not find a usable bitmap for nebula poof '%s'!\n", pinfo.name));
+					Warning(LOCATION, "Could not find a usable bitmap (%s) for nebula poof '%s'!\n", pinfo.bitmap_filename, pinfo.name);
+				}
 			}
 		}
 	}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3982,57 +3982,55 @@ void weapon_load_bitmaps(int weapon_index)
 	wip = &Weapon_info[weapon_index];
 
 	if ( (wip->render_type == WRT_LASER) && (wip->laser_bitmap.first_frame < 0) ) {
-		wip->laser_bitmap.first_frame = bm_load(wip->laser_bitmap.filename);
-
-		if (wip->laser_bitmap.first_frame >= 0) {
-			wip->laser_bitmap.num_frames = 1;
-			wip->laser_bitmap.total_time = 1;
-		}
-		// fall back to an animated type
-		else if ( generic_anim_load(&wip->laser_bitmap) ) {
-			mprintf(("Could not find a usable bitmap for '%s'!\n", wip->name));
-			Warning(LOCATION, "Could not find a usable bitmap (%s) for weapon '%s'!\n", wip->laser_bitmap.filename, wip->name);
+		if (generic_anim_load(&wip->laser_bitmap)) {
+			// fall back to non-animated type
+			wip->laser_bitmap.first_frame = bm_load(wip->laser_bitmap.filename);
+			if (wip->laser_bitmap.first_frame >= 0) {
+				wip->laser_bitmap.num_frames = 1;
+				wip->laser_bitmap.total_time = 1.0f;
+			}
+			else {
+				mprintf(("Could not find a usable bitmap for '%s'!\n", wip->name));
+				Warning(LOCATION, "Could not find a usable bitmap (%s) for weapon '%s'!\n", wip->laser_bitmap.filename, wip->name);
+			}
 		}
 
 		// now see if we also have a glow
-		if ( strlen(wip->laser_glow_bitmap.filename) ) {
+		if (strlen(wip->laser_glow_bitmap.filename) && generic_anim_load(&wip->laser_glow_bitmap)) {
+			// fall back to non-animated type
 			wip->laser_glow_bitmap.first_frame = bm_load(wip->laser_glow_bitmap.filename);
-
 			if (wip->laser_glow_bitmap.first_frame >= 0) {
 				wip->laser_glow_bitmap.num_frames = 1;
-				wip->laser_glow_bitmap.total_time = 1;
+				wip->laser_glow_bitmap.total_time = 1.0f;
 			}
-			// fall back to an animated type
-			else if ( generic_anim_load(&wip->laser_glow_bitmap) ) {
-				mprintf(("Could not find a usable glow bitmap for '%s'!\n", wip->name));
+			else {
+				mprintf(("Could not find a usable glow bitmap for weapon '%s'!\n", wip->name));
 				Warning(LOCATION, "Could not find a usable glow bitmap (%s) for weapon '%s'!\n", wip->laser_glow_bitmap.filename, wip->name);
 			}
 		}
 
-		if (strlen(wip->laser_headon_bitmap.filename)) {
+		if (strlen(wip->laser_headon_bitmap.filename) && generic_anim_load(&wip->laser_headon_bitmap)) {
+			// fall back to non-animated type
 			wip->laser_headon_bitmap.first_frame = bm_load(wip->laser_headon_bitmap.filename);
-
 			if (wip->laser_headon_bitmap.first_frame >= 0) {
 				wip->laser_headon_bitmap.num_frames = 1;
-				wip->laser_headon_bitmap.total_time = 1;
+				wip->laser_headon_bitmap.total_time = 1.0f;
 			}
-			// fall back to an animated type
-			else if (generic_anim_load(&wip->laser_headon_bitmap)) {
-				mprintf(("Could not find a usable head-on bitmap for '%s'!\n", wip->name));
+			else {
+				mprintf(("Could not find a usable head-on bitmap for weapon '%s'!\n", wip->name));
 				Warning(LOCATION, "Could not find a usable head-on bitmap (%s) for weapon '%s'!\n", wip->laser_headon_bitmap.filename, wip->name);
 			}
 		}
 
-		if (strlen(wip->laser_glow_headon_bitmap.filename)) {
+		if (strlen(wip->laser_glow_headon_bitmap.filename) && generic_anim_load(&wip->laser_glow_headon_bitmap)) {
+			// fall back to non-animated type
 			wip->laser_glow_headon_bitmap.first_frame = bm_load(wip->laser_glow_headon_bitmap.filename);
-
 			if (wip->laser_glow_headon_bitmap.first_frame >= 0) {
 				wip->laser_glow_headon_bitmap.num_frames = 1;
-				wip->laser_glow_headon_bitmap.total_time = 1;
+				wip->laser_glow_headon_bitmap.total_time = 1.0f;
 			}
-			// fall back to an animated type
-			else if (generic_anim_load(&wip->laser_glow_headon_bitmap)) {
-				mprintf(("Could not find a usable glow head-on bitmap for '%s'!\n", wip->name));
+			else {
+				mprintf(("Could not find a usable glow head-on bitmap for weapon '%s'!\n", wip->name));
 				Warning(LOCATION, "Could not find a usable glow head-on bitmap (%s) for weapon '%s'!\n", wip->laser_glow_headon_bitmap.filename, wip->name);
 			}
 		}


### PR DESCRIPTION
For poofs and laser bitmaps specifically. Notably, this fixes apngs when used for these purposes, as otherwise those apngs are valid static bitmaps, and would not be usable as an animation.