### PR TITLE
fix crash in ship_close_cockpit_displays

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7805,7 +7805,7 @@ void ship_init_cockpit_displays(ship *shipp)
 
 void ship_close_cockpit_displays(ship* shipp)
 {
-	if (shipp->cockpit_model_instance >= 0) {
+	if (shipp && shipp->cockpit_model_instance >= 0) {
 		model_delete_instance(shipp->cockpit_model_instance);
 	}
 


### PR DESCRIPTION
This function can be called when `shipp` is null, so check for that.

Fixes #4991.