### PR TITLE
fix subcategory comparison

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5015,7 +5015,7 @@ void parse_event(mission *pm)
 		if (Fred_running) {
 			while (check_for_string("+Comment:") || check_for_string("+Background Color:") || check_for_string("+Path:")) {
 				event_annotation ea;
-				ea.path.push_back(event - &Mission_events[0]);
+				ea.path.push_back((int)(event - &Mission_events[0]));
 
 				if (optional_string("+Comment:")) {
 					stuff_string(ea.comment, F_MULTITEXT);

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -963,7 +963,7 @@ void sexp_tree::right_clicked(int mode)
 		{
 			// add only if it is not in a subcategory
 			subcategory_id = get_subcategory(Operators[i].value);
-			if (subcategory_id == -1)
+			if (subcategory_id == OP_SUBCATEGORY_NONE)
 			{
 				// put it in the appropriate menu
 				for (j=0; j<(int)op_menu.size(); j++)

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5642,7 +5642,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 	for (i = 0; i < (int) Operators.size(); i++) {
 		// add only if it is not in a subcategory
 		subcategory_id = get_subcategory(Operators[i].value);
-		if (subcategory_id == -1) {
+		if (subcategory_id == OP_SUBCATEGORY_NONE) {
 			// put it in the appropriate menu
 			for (j = 0; j < (int) op_menu.size(); j++) {
 				if (op_menu[j].id == get_category(Operators[i].value)) {


### PR DESCRIPTION
Empty subcategories are now OP_SUBCATEGORY_NONE, not -1.  Fixes #4994.

Also fixes a cast warning in missionparse.cpp.