### PR TITLE
subcategory fixes and followup

### DIFF
--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1314,6 +1314,7 @@ extern SCP_vector<SCP_string> *Current_event_log_container_buffer;
 extern SCP_vector<SCP_string> *Current_event_log_argument_buffer;
 
 extern void init_sexp();
+extern void sexp_startup();
 extern void sexp_shutdown();
 extern int alloc_sexp(const char *text, int type, int subtype, int first, int rest);
 extern int find_free_sexp();

--- a/code/parse/sexp/EngineSEXP.cpp
+++ b/code/parse/sexp/EngineSEXP.cpp
@@ -83,11 +83,11 @@ EngineSEXPFactory::ArgumentListBuilder EngineSEXPFactory::beginArgList() { retur
 
 dummy_return EngineSEXPFactory::finish()
 {
-	Assertion(_category >= 0, "Engine SEXP %s: A category has to be specified!", m_sexp->getName().c_str());
+	Assertion(_category >= 0 && _category != OP_CATEGORY_NONE, "Engine SEXP %s: A category has to be specified!", m_sexp->getName().c_str());
 	Assertion(_returnType >= 0, "Engine SEXP %s: A return type has to be specified!", m_sexp->getName().c_str());
 
 	m_sexp->setCategory(_category);
-	if (_subcategory >= 0) {
+	if (_subcategory >= 0 && _subcategory != OP_SUBCATEGORY_NONE) {
 		m_sexp->setSubcategory(_subcategory);
 	} else {
 		Assertion(!_subcategoryName.empty(), "A subcategory has to be specified!");
@@ -183,10 +183,10 @@ EngineSEXPFactory EngineSEXP::create(const SCP_string& name)
 void EngineSEXP::initialize()
 {
 	// Initialize subcategory now that we know that it is safe to do so
-	if (_subcategory < 0) {
+	if (_subcategory == OP_SUBCATEGORY_NONE) {
 		_subcategory = get_subcategory(_subcategoryName);
 
-		if (_subcategory < 0) {
+		if (_subcategory == OP_SUBCATEGORY_NONE) {
 			_subcategory = add_subcategory(_category, _subcategoryName);
 		}
 	}

--- a/code/parse/sexp/EngineSEXP.h
+++ b/code/parse/sexp/EngineSEXP.h
@@ -19,9 +19,9 @@ class EngineSEXPFactory {
 
 	SCP_string _helpText;
 
-	int _category = -1;
+	int _category = OP_CATEGORY_NONE;
 
-	int _subcategory = -1;
+	int _subcategory = OP_SUBCATEGORY_NONE;
 	SCP_string _subcategoryName;
 
 	int _returnType = -1;

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -14,7 +14,7 @@ static const SCP_unordered_set<int> allowed_oswpt_parameters{ OPF_SHIP, OPF_WING
 LuaAISEXP::LuaAISEXP(const SCP_string& name) : LuaSEXP(name) {
 	_return_type = OPR_AI_GOAL;
 	_category = OP_CATEGORY_AI;
-	_subcategory = -1;
+	_subcategory = OP_SUBCATEGORY_NONE;
 }
 
 void LuaAISEXP::initialize() {

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -160,6 +160,17 @@ int add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp, sexp_oper_type type)
 		return -1;
 	}
 
+	// sanity check
+	int subcategory = sexp->getSubcategory();
+	if (subcategory != OP_SUBCATEGORY_NONE)
+	{
+		int category = sexp->getCategory();
+		int implied_category = category_of_subcategory(subcategory);
+
+		if (category != implied_category)
+			Warning(LOCATION, "Operator %s has a category that is not a parent of its subcategory!", name.c_str());
+	}
+
 	// For now, all dynamic SEXPS are only valid in missions
 	new_op.value = free_op_index;
 	new_op.type = type;

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -408,7 +408,7 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	gamesnd_parse_soundstbl();		// needs to be loaded after species stuff but before interface/weapon/ship stuff - taylor
 	mission_brief_common_init();	
 
-	sexp::dynamic_sexp_init(); // Must happen before ship init for LuaAI
+	sexp_startup(); // Must happen before ship init for LuaAI
 
 	animation::ModelAnimationParseHelper::parseTables();
 	obj_init();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1946,8 +1946,8 @@ void game_init()
 
 	animation::ModelAnimationParseHelper::parseTables();
 
-	// Initialize dynamic SEXPs. Must happen before ship init for LuaAI
-	sexp::dynamic_sexp_init();
+	// Initialize SEXPs. Must happen before ship init for LuaAI
+	sexp_startup();
 
 	obj_init();	
 	virtual_pof_init();

--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char* argv[]) {
 								 { SubSystem::Campaign,          app.tr("Initializing campaign system") },
 								 { SubSystem::NebulaLightning,   app.tr("Initializing nebula lightning") },
 								 { SubSystem::FFmpeg,            app.tr("Initializing FFmpeg") },
-								 { SubSystem::DynamicSEXPs,      app.tr("Initializing dynamic SEXP system") },
+								 { SubSystem::SEXPs,             app.tr("Initializing SEXP system") },
 								 { SubSystem::ScriptingInitHook, app.tr("Running game init scripting hook") },
 	};
 

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -168,9 +168,9 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	listener(SubSystem::MissionBrief);
 	mission_brief_common_init();
 
-	// Initialize dynamic SEXPs. Must happen before ship init for LuaAI
-	listener(SubSystem::DynamicSEXPs);
-	sexp::dynamic_sexp_init();
+	// Initialize SEXPs. Must happen before ship init for LuaAI
+	listener(SubSystem::SEXPs);
+	sexp_startup();
 
 	listener(SubSystem::Objects);
 	obj_init();

--- a/qtfred/src/mission/management.h
+++ b/qtfred/src/mission/management.h
@@ -48,7 +48,7 @@ enum class SubSystem {
 	Campaign,
 	NebulaLightning,
 	FFmpeg,
-	DynamicSEXPs,
+	SEXPs,
 	ScriptingInitHook,
 };
 


### PR DESCRIPTION
Several items here:
1. Patches several category and subcategory validation checks (comparisons to -1 rather than _NONE) that were missed in #4965.
2. Adds sanity checks to both built-in operators and scripted sexps to ensure categories and subcategories are consistent.
3. Deconflicts several built-in sexps that had inconsistent categories.

The inconsistent operators were:
* script-eval-string
* set-wing-formation
* get-ets-value
* turret-get-primary-ammo
* turret-get-secondary-ammo
* get-fov

Follow-up to #4965 and #4995.