### PR TITLE
Allow player turrets to fire despite play dead

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11756,8 +11756,8 @@ void ai_process_subobjects(int objnum)
 	ai_info	*aip = &Ai_info[shipp->ai_index];
 	ship_info	*sip = &Ship_info[shipp->ship_info_index];
 
-	// ships that are playing dead do not process subsystems or turrets
-	if (aip->mode == AIM_PLAY_DEAD)
+	// non-player ships that are playing dead do not process subsystems or turrets
+	if ((!(objp->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) && aip->mode == AIM_PLAY_DEAD)
 		return;
 
 	polymodel_instance *pmi = model_get_instance(shipp->model_instance_num);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18812,9 +18812,9 @@ void ship_move_subsystems(object *objp)
 {
 	Assertion(objp->type == OBJ_SHIP, "ship_move_subsystems should only be called for ships!  objp type = %d", objp->type);
 	auto shipp = &Ships[objp->instance];
-
-	// ships that are playing dead do not process subsystems or turrets
-	if (Ai_info[shipp->ai_index].mode == AIM_PLAY_DEAD)
+	
+	// non-player ships that are playing dead do not process subsystems or turrets
+	if ((!(objp->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) && Ai_info[shipp->ai_index].mode == AIM_PLAY_DEAD)
 		return;
 
 	for (auto pss = GET_FIRST(&shipp->subsys_list); pss != END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss))


### PR DESCRIPTION
Follow-up to #4934. Fixes #4998 and restores behavior from before #3713 . A little unfortunate, maybe, but designers can still lock player turrets if they don't want them to do anything.