### PR TITLE
Generalize linear interpolation

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2931,68 +2931,6 @@ void vm_match_bank(vec3d* out_rvec, const vec3d* goal_fvec, const matrix* match_
 	vm_vec_unrotate(out_rvec, &temp, &dest_frame);
 }
 
-// Cyborg17 - Rotational interpolation between two angle structs in radians.  Assumes that the rotation direction is the smaller arc difference.
-// src0 is the starting angle struct, src1 is the ending angle struct, interp_perc must be a float between 0.0f and 1.0f inclusive.
-// rot_vel is only used to determine the rotation direction. This functions assumes a <= 2PI rotation in any axis.  
-// You will get inaccurate results otherwise.
-void vm_interpolate_angles_quick(angles *dest0, angles *src0, angles *src1, float interp_perc) {
-	
-	Assertion((interp_perc >= 0.0f) && (interp_perc <= 1.0f), "Interpolation percentage, %f, sent to vm_interpolate_angles is invalid. The valid range is [0,1], go find a coder!", interp_perc);
-
-	angles arc_measures;
-
-	arc_measures.p = src1->p - src0->p;	
-	arc_measures.h = src1->h - src0->h;	
-	arc_measures.b = src1->b - src0->b;
-
-	  // pitch
-	  // if start and end are basically the same, assume we can basically jump to the end.
-	if ( (fabs(arc_measures.p) < 0.00001f) ) {
-		arc_measures.p = 0.0f;
-
-	} // Test if we actually need to go in the other direction
-	else if (arc_measures.p > (PI*1.5f)) {
-		arc_measures.p = PI2 - arc_measures.p;
-
-	} // Test if we actually need to go in the other direction for negative values
-	else if (arc_measures.p < -PI_2) {
-		arc_measures.p = -PI2 - arc_measures.p;
-	}
-
-	  // heading
-	  // if start and end are basically the same, assume we can basically jump to the end.
-	if ( (fabs(arc_measures.h) < 0.00001f) ) {
-		arc_measures.h = 0.0f;
-
-	} // Test if we actually need to go in the other direction
-	else if (arc_measures.h > (PI*1.5f)) {
-		arc_measures.h = PI2 - arc_measures.h;
-
-	} // Test if we actually need to go in the other direction for negative values
-	else if (arc_measures.h < -PI_2) {
-		arc_measures.h = -PI2 - arc_measures.h;
-	}
-
-	// bank
-	// if start and end are basically the same, assume we can basically jump to the end.
-	if ( (fabs(arc_measures.b) < 0.00001f) ) {
-		arc_measures.b = 0.0f;
-
-	} // Test if we actually need to go in the other direction
-	else if (arc_measures.b > (PI*1.5f)) {
-		arc_measures.b = PI2 - arc_measures.b;
-
-	} // Test if we actually need to go in the other direction for negative values
-	else if (arc_measures.b < -PI_2) {
-		arc_measures.b = -PI2 - arc_measures.b;
-	}
-
-	// Now just multiply the difference in angles by the given percentage, and then subtract it from the destination angles.
-	// If arc_measures is 0.0f, then we are basically bashing to the ending orientation without worrying about the inbetween.
-	dest0->p = src0->p + (arc_measures.p * interp_perc);
-	dest0->h = src0->h + (arc_measures.h * interp_perc);
-	dest0->b = src0->b + (arc_measures.b * interp_perc);
-}
 
 // Interpolate between two matrices, using t as a percentage progress between them.
 // Intended values for t are [0.0f, 1.0f], but values outside this range are allowed,

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -417,6 +417,16 @@ void vm_vec_scale2(vec3d *dest, float n, float d)
 	dest->xyz.z = dest->xyz.z* n * d;
 }
 
+// interpolate between two vectors
+// dest = src0 + (k * (src1 - src0))
+// Might be helpful to think of vec0 as the before, and vec1 as the after
+void vm_vec_linear_interpolate(vec3d* dest, const vec3d* src0, const vec3d* src1, const float k)
+{
+	dest->xyz.x = ((src1->xyz.x - src0->xyz.x) * k) + src0->xyz.x;
+	dest->xyz.y = ((src1->xyz.y - src0->xyz.y) * k) + src0->xyz.y;
+	dest->xyz.z = ((src1->xyz.z - src0->xyz.z) * k) + src0->xyz.z;
+}
+
 //returns dot product of 2 vectors
 float vm_vec_dot(const vec3d *v0, const vec3d *v1)
 {

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -179,6 +179,11 @@ void vm_vec_scale_add2(vec3d *dest, const vec3d *src, float k);
 //dest *= n/d
 void vm_vec_scale2(vec3d *dest, float n, float d);
 
+// interpolate between two vectors
+// dest = k * (src1 - src0)
+// Might be helpful to think of vec0 as the before, and vec1 as the after
+void vm_vec_linear_interpolate(vec3d* dest, const vec3d* src0, const vec3d* src1, float k);
+
 bool vm_vec_equal(const vec2d &self, const vec2d &other);
 
 bool vm_vec_equal(const vec3d &self, const vec3d &other);

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -595,12 +595,6 @@ vec4 vm_vec3_to_ve4(const vec3d& vec, float w = 1.0f);
 // calculates the best rvec to match another orient while maintaining a given fvec
 void vm_match_bank(vec3d* out_rvec, const vec3d* goal_fvec, const matrix* match_orient);
 
-// Cyborg17 - Rotational interpolation between two angle structs in radians, given a rotational velocity, in radians.
-// src0 is the starting angle struct, src1 is the ending angle struct, interp_perc must be a float between 0.0f and 1.0f.
-// rot_vel is only used to determine the rotation direction. Assumes that it is not a full 2PI rotation in any axis.  
-// You will get strange results otherwise.
-void vm_interpolate_angles_quick(angles* dest0, angles* src0, angles* src1, float interp_perc);
-
 // Interpolate between two matrices, using t as a percentage progress between them.
 // Intended values for t are [0.0f, 1.0f], but values outside this range are allowed,
 // as you could conceivably use these calculations to find a rotation that is outside 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -14,7 +14,8 @@
 
 #include "globalincs/globals.h" // for NAME_LENGTH
 #include "globalincs/pstypes.h"
-
+#include <array>
+ 
 #include "actions/Program.h"
 #include "gamesnd/gamesnd.h"
 #include "graphics/2d.h"

--- a/code/network/multi_ingame.cpp
+++ b/code/network/multi_ingame.cpp
@@ -44,7 +44,7 @@
 #include "io/timer.h"
 #include "playerman/player.h"
 #include "network/multi_log.h"
-
+#include "network/multi_time_manager.h"
 
 // --------------------------------------------------------------------------------------------------
 // DAVE's BIGASS INGAME JOIN WARNING/DISCLAIMER

--- a/code/network/multi_interpolate.cpp
+++ b/code/network/multi_interpolate.cpp
@@ -280,3 +280,10 @@ void interpolation_manager::replace_packet(int index, vec3d* pos, matrix* orient
 	_packets[index].desired_rotational_velocity = pip->desired_rotvel; 
 	_packets[index].orientation = *orient;
 }
+
+// the contained vectors have been cleared during object shut down.
+void multi_interpolate_clear_all()
+{
+	// clear the main container.
+	Interp_info.clear();
+}

--- a/code/network/multi_interpolate.cpp
+++ b/code/network/multi_interpolate.cpp
@@ -1,6 +1,7 @@
 #include "network/multi_interpolate.h"
-#include "globalincs/pstypes.h"
 #include "freespace.h"
+
+SCP_unordered_map<int, interpolation_manager> Interp_info;
 
 extern void multi_ship_record_signal_update(int objnum, TIMESTAMP lower_time_limit, TIMESTAMP upper_time_limit, int prev_packet_index, int current_packet_index);
 ///////////////////////////////////////////
@@ -38,6 +39,11 @@ void interpolation_manager::reassess_packet_index(vec3d* pos, matrix* ori, physi
 	_simulation_mode = true;
 }
 
+void interpolate_main_helper(int objnum, vec3d* pos, matrix* ori, physics_info* pip, vec3d* last_pos, matrix* last_orient, vec3d* gravity, bool player_ship)
+{
+	Interp_info[objnum].interpolate_main(pos, ori, pip, last_pos, last_orient, gravity, player_ship);
+}
+
 // the meat and potatoes.  Basically, this figures out if we should interpolate, and then interpolates or sims
 void interpolation_manager::interpolate_main(vec3d* pos, matrix* ori, physics_info* pip, vec3d* last_pos, matrix* last_orient, vec3d * gravity, bool player_ship)
 {
@@ -70,12 +76,7 @@ void interpolation_manager::interpolate_main(vec3d* pos, matrix* ori, physics_in
 		// we need to push this ship up to the limit of where we were on the remote instance, if we haven't already.
 		// then we need to adjust our timing since some of the sim time is used up getting to that last packet.
 		if (!_packets_expended && !_packets.empty()) {
-			*pos = _packets.front().position;
-			*ori = _packets.front().orientation;
-			pip->vel = _packets.front().velocity;
-			pip->desired_vel = _packets.front().desired_velocity;
-			pip->rotvel = _packets.front().rotational_velocity;
-			pip->desired_rotvel = _packets.front().desired_rotational_velocity;
+			physics_apply_snapshot_manual(*pos, *ori, pip->vel, pip->desired_vel, pip->rotvel, pip->desired_rotvel, _packets.front().snapshot);
 
 			sim_time -= (static_cast<float>(_packets.front().remote_missiontime) - static_cast<float>(Multi_Timing_Info.get_last_time())) / TIMESTAMP_FREQUENCY;
 			_packets_expended = true;
@@ -107,7 +108,7 @@ void interpolation_manager::interpolate_main(vec3d* pos, matrix* ori, physics_in
 		pip->speed = vm_vec_mag(&pip->vel);
 		pip->fspeed = vm_vec_dot(&ori->vec.fvec, &pip->vel);
 
-		return; // we should not try interpolating and siming, so return.
+		return; // we should not try interpolating and siming on the same call, so return.
 	}
 
 	// calc what the current timing should be.
@@ -123,41 +124,22 @@ void interpolation_manager::interpolate_main(vec3d* pos, matrix* ori, physics_in
 	CLAMP(scale, 0.001f, 0.999f);
 
 	// one by one interpolate the vectors to get the desired results.
-	vec3d temp_vector;
+	physics_snapshot temp_state;
 
-	// set new position.
-	vm_vec_sub(&temp_vector, &_packets[_upcoming_packet_index].position, &_packets[_prev_packet_index].position);
-	vm_vec_scale_add(pos, &_packets[_prev_packet_index].position, &temp_vector, scale);
-
-	// set new velocity
-	vm_vec_sub(&temp_vector, &_packets[_upcoming_packet_index].velocity, &_packets[_prev_packet_index].velocity);
-	vm_vec_scale_add(&pip->vel, &_packets[_prev_packet_index].velocity, &temp_vector, scale);
+	// Interpolation in just two lines!  Who'da thunk?
+	physics_interpolate_snapshots(temp_state, _packets[_prev_packet_index].snapshot, _packets[_upcoming_packet_index].snapshot, scale);
+	physics_apply_snapshot_manual(*pos, *ori, pip->vel, pip->desired_vel, pip->rotvel, pip->desired_rotvel, temp_state);
 
 	// we can't trust what the last position was on the local instance, so figure out what it should have been
 	// use flFrametime here because we need to know what the last position would have been if it was accurate in the last frame.
 	vm_vec_scale_add(last_pos, pos, &pip->vel, -flFrametime);
 
-	// set new desired velocity
-	vm_vec_sub(&temp_vector, &_packets[_upcoming_packet_index].desired_velocity, &_packets[_prev_packet_index].desired_velocity);
-	vm_vec_scale_add(&pip->desired_vel, &_packets[_prev_packet_index].desired_velocity, &temp_vector, scale);
-
-	// set new rotational velocity
-	vm_vec_sub(&temp_vector, &_packets[_upcoming_packet_index].rotational_velocity, &_packets[_prev_packet_index].rotational_velocity);
-	vm_vec_scale_add(&pip->rotvel, &_packets[_prev_packet_index].rotational_velocity, &temp_vector, scale);
-
-	// we only do desired rotational velocity if this is a player ship.
-	if (player_ship) {
-		vm_vec_sub(&temp_vector, &_packets[_upcoming_packet_index].desired_rotational_velocity, &_packets[_prev_packet_index].desired_rotational_velocity);
-		vm_vec_scale_add(&pip->desired_rotvel, &_packets[_prev_packet_index].desired_rotational_velocity, &temp_vector, scale);
-	} // So if AI, just set them to the same value.
-	else {
+	// AI ships do not really use desired velocity, so undo that calc for AI ships.
+	if (!player_ship) {
 		pip->desired_rotvel = pip->rotvel;
 	}
 
-	// calculate the new orientation.
-	vm_interpolate_matrices(ori, &_packets[_prev_packet_index].orientation, &_packets[_upcoming_packet_index].orientation, scale);
-
-	// a quick calculation for the last orientation, courtesy Asteroth
+	// finally, a quick calculation for the last orientation, courtesy Asteroth
 	if (!IS_VEC_NULL(&pip->rotvel)) {
 
 		vec3d normalized_rotvel;
@@ -177,7 +159,7 @@ void interpolation_manager::interpolate_main(vec3d* pos, matrix* ori, physics_in
 }
 
 // correct the ship record for player ships when an up to date packet comes in.
-void interpolation_manager::reinterpolate_previous(TIMESTAMP stamp, int prev_packet_index, int next_packet_index,  vec3d* position, matrix* orientation, vec3d* velocity, vec3d* rotational_velocity)
+void interpolation_manager::reinterpolate_previous(TIMESTAMP stamp, int prev_packet_index, int next_packet_index,  vec3d& position, matrix& orientation, vec3d& velocity, vec3d& rotational_velocity)
 {
 	// calc what the timing was previously.
 	float numerator = static_cast<float>(_packets[next_packet_index].remote_missiontime) - static_cast<float>(stamp.value());
@@ -190,19 +172,10 @@ void interpolation_manager::reinterpolate_previous(TIMESTAMP stamp, int prev_pac
 	// protect against bad floating point arithmetic making orientation or position look off
 	CLAMP(scale, 0.001f, 0.999f);
 
-	// calc the corrected physics data
-	vec3d temp_vector;
+	physics_snapshot temp_snapshot;
 
-	vm_vec_sub(&temp_vector, &_packets[next_packet_index].position, &_packets[prev_packet_index].position);
-	vm_vec_scale_add(position, &_packets[prev_packet_index].position, &temp_vector, scale);
-
-	vm_vec_sub(&temp_vector, &_packets[next_packet_index].velocity, &_packets[prev_packet_index].velocity);
-	vm_vec_scale_add(velocity, &_packets[prev_packet_index].velocity, &temp_vector, scale);
-
-	vm_vec_sub(&temp_vector, &_packets[next_packet_index].rotational_velocity, &_packets[prev_packet_index].rotational_velocity);
-	vm_vec_scale_add(rotational_velocity, &_packets[prev_packet_index].rotational_velocity, &temp_vector, scale);
-
-	vm_interpolate_matrices(orientation, &_packets[prev_packet_index].orientation, &_packets[next_packet_index].orientation, scale);
+	physics_interpolate_snapshots(temp_snapshot, _packets[_prev_packet_index].snapshot, _packets[_upcoming_packet_index].snapshot, scale);
+	physics_apply_snapshot_manual(position, orientation, velocity, rotational_velocity, temp_snapshot);
 }
 
 // add a packet to the vector, remove the last one if necessary.
@@ -273,12 +246,8 @@ void interpolation_manager::replace_packet(int index, vec3d* pos, matrix* orient
 	_packets[index].frame = _packets[index - 1].frame - 1;
 
 	_packets[index].remote_missiontime = Multi_Timing_Info.get_last_time();
-	_packets[index].position = *pos;
-	_packets[index].velocity = pip->vel;
-	_packets[index].desired_velocity = pip->desired_vel;
-	_packets[index].rotational_velocity = pip->rotvel;
-	_packets[index].desired_rotational_velocity = pip->desired_rotvel; 
-	_packets[index].orientation = *orient;
+
+	physics_populate_snapshot_manual(_packets[index].snapshot, *pos, *orient, pip->vel, pip->desired_vel, pip->rotvel, pip->desired_rotvel);
 }
 
 // the contained vectors have been cleared during object shut down.
@@ -286,4 +255,9 @@ void multi_interpolate_clear_all()
 {
 	// clear the main container.
 	Interp_info.clear();
+}
+
+// helper functiont that helps avoid include issues.
+void multi_interpolate_clear_helper(int objnum) {
+	Interp_info[objnum].clean_up();
 }

--- a/code/network/multi_interpolate.h
+++ b/code/network/multi_interpolate.h
@@ -156,3 +156,7 @@ public:
 		_source_player_index = -1;
 	}
 };
+
+void multi_interpolate_clear_all();
+
+extern SCP_unordered_map<int, interpolation_manager> Interp_info;

--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -17,7 +17,6 @@
 //
 #include "globalincs/pstypes.h"
 
-struct interp_info;
 class object;
 struct header;
 struct net_player;

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -20,6 +20,7 @@
 #include "io/joy_ff.h"
 #include "io/timer.h"
 #include "network/multi.h"
+#include "network/multi_interpolate.h"
 #include "object/objcollide.h"
 #include "object/object.h"
 #include "object/objectdock.h"
@@ -1391,8 +1392,10 @@ int collide_ship_ship( obj_pair * pair )
 									if ((LightOne == &Objects[current_player.m_player->objnum]) || (HeavyOne == &Objects[current_player.m_player->objnum])) {
 										// finally if the host is also a player, ignore making these adjustments for him because he is in a pure simulation.
 										if (&Ships[Objects[current_player.m_player->objnum].instance] != Player_ship) {
+											Assertion(Interp_info.find(current_player.m_player->objnum) != Interp_info.end(), "Somehow the collision code thinks there is not a player ship interp record in multi when there really *should* be.  This is a coder mistake, please report!");
+
 											// temp set this as an uninterpolated ship, to make the collision look more natural until the next update comes in.
-											Objects[current_player.m_player->objnum].interp_info.force_interpolation_mode();
+											Interp_info[current_player.m_player->objnum].force_interpolation_mode();
 
 											// check to see if it has been long enough since the last collision, if not, negate the damage
 											if (!timestamp_elapsed(current_player.s_info.player_collision_timestamp)) {

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -2101,7 +2101,7 @@ bool obj_compare(object* left, object* right) {
 	return OBJ_INDEX(left) == OBJ_INDEX(right);
 }
 
-void physics_populate_snapshot(physics_snapshot& snapshot, object* objp)
+void physics_populate_snapshot(physics_snapshot& snapshot, const object* objp)
 {
     Assertion(objp != nullptr, "Bad object (nullptr) passed to physics_overwrite_snapshot, please report to the SCP!");
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -657,8 +657,11 @@ void obj_delete(int objnum)
 		Error( LOCATION, "Unhandled object type %d in obj_delete_all_that_should_be_dead", objp->type );
 	}
 
+	// this avoids include issues from physics state, multi interpolate and object code
+	extern void multi_interpolate_clear_helper(int objnum);
+
 	// clean up interpolation info
-	objp->interp_info.clean_up();
+	multi_interpolate_clear_helper(objnum);
 
 	// delete any dock information we still have
 	dock_free_dock_list(objp);
@@ -1545,7 +1548,9 @@ void obj_move_all(float frametime)
 		if (!(objp->flags[Object::Object_Flags::Immobile] && objp->hull_strength > 0.0f)) {
 			// if this is an object which should be interpolated in multiplayer, do so
 			if (interpolation_object) {
-				objp->interp_info.interpolate_main(&objp->pos, &objp->orient, &objp->phys_info, &objp->last_pos, &objp->last_orient, &The_mission.gravity, objp->flags[Object::Object_Flags::Player_ship]);
+				extern void interpolate_main_helper(int objnum, vec3d* pos, matrix* ori, physics_info* pip, vec3d* last_pos, matrix* last_orient, vec3d* gravity, bool player_ship);
+
+				interpolate_main_helper(OBJ_INDEX(objp), &objp->pos, &objp->orient, &objp->phys_info, &objp->last_pos, &objp->last_orient, &The_mission.gravity, objp->flags[Object::Object_Flags::Player_ship]);
 			} else {
 				// physics
 				obj_move_call_physics(objp, frametime);
@@ -2095,3 +2100,28 @@ bool obj_compare(object* left, object* right) {
 
 	return OBJ_INDEX(left) == OBJ_INDEX(right);
 }
+
+void physics_populate_snapshot(physics_snapshot& snapshot, object* objp)
+{
+    Assertion(objp != nullptr, "Bad object (nullptr) passed to physics_overwrite_snapshot, please report to the SCP!");
+
+    snapshot.position = objp->pos;
+    snapshot.orientation = objp->orient;
+    snapshot.velocity = objp->phys_info.vel;
+    snapshot.desired_velocity = objp->phys_info.desired_vel;
+    snapshot.rotational_velocity = objp->phys_info.rotvel;
+    snapshot.desired_rotational_velocity = objp->phys_info.desired_rotvel;
+}
+
+void physics_apply_pstate_to_object(object* objp, const physics_snapshot& source)
+{
+    Assertion(objp != nullptr, "Bad object passed to phsyics snapshot application code.  This is a coder mistake, please report!");
+
+    objp->pos = source.position;
+    objp->orient = source.orientation;
+    objp->phys_info.vel = source.velocity;
+    objp->phys_info.desired_vel = source.desired_velocity;
+    objp->phys_info.rotvel = source.rotational_velocity;
+    objp->phys_info.desired_rotvel = source.desired_rotational_velocity;
+}
+

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -18,8 +18,9 @@
 #include "object/object.h"
 #include "object/object_flags.h"
 #include "physics/physics.h"
+#include "physics/physics_state.h"
+#include "io/timer.h"					// prevents some include issues with files in the actions folder
 #include "utils/event.h"
-#include "network/multi_interpolate.h"
 
 #include <functional>
 
@@ -153,8 +154,6 @@ public:
 
 	util::event<void, object*> pre_move_event;
 	util::event<void, object*> post_move_event;
-
-	interpolation_manager interp_info;
 
 	object();
 	~object();
@@ -384,5 +383,31 @@ void obj_render_queue_all();
  * @return @c true if the two pointers refer to the same object
  */
 bool obj_compare(object *left, object *right);
+
+////////////////////////////////////////////////////////////
+// physics_state api functions that require the object type
+
+/**
+ * @brief Populate a physics snapshot directly from the info in an object
+ *
+ * @param[in,out] snapshot Destination physics snapshot
+ * @param[in]     objp The object pointer that we are pulling information from
+ *
+ * @author J Fernandez
+ */
+void physics_populate_snapshot(physics_snapshot& snapshot, object* objp);
+
+/**
+ * @brief Change the object's physics info to match the info contained in a snapshot.
+ *
+ * @param[in,out] objp Destination object pointer
+ * @param[in]     source The physics snapshot we are pulling information from
+ *
+ * @details To be used when interpolating or restoring a game state.
+ * 
+ * @author J Fernandez
+ */
+void physics_apply_pstate_to_object(object* objp, const physics_snapshot& source);
+
 
 #endif

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -328,8 +328,6 @@ void obj_move_all_post(object *objp, float frametime);
 
 void obj_move_call_physics(object *objp, float frametime);
 
-// multiplayer object update stuff begins -------------------------------------------
-
 // move an observer object in multiplayer
 void obj_observer_move(float frame_time);
 

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -395,7 +395,7 @@ bool obj_compare(object *left, object *right);
  *
  * @author J Fernandez
  */
-void physics_populate_snapshot(physics_snapshot& snapshot, object* objp);
+void physics_populate_snapshot(physics_snapshot& snapshot, const object* objp);
 
 /**
  * @brief Change the object's physics info to match the info contained in a snapshot.

--- a/code/object/waypoint.cpp
+++ b/code/object/waypoint.cpp
@@ -5,6 +5,7 @@
 #include "object/object.h"
 #include "object/waypoint.h"
 #include "network/multiutil.h"
+#include <limits.h>
 
 //********************GLOBALS********************
 SCP_vector<waypoint_list> Waypoint_lists;

--- a/code/physics/physics_state.cpp
+++ b/code/physics/physics_state.cpp
@@ -1,0 +1,44 @@
+#include "physics/physics_state.h"
+
+// There are additional functions in object.cpp
+
+void physics_interpolate_snapshots(physics_snapshot& result, const physics_snapshot& before, const physics_snapshot& after, const float percent) 
+{
+	// just interpolate each item in turn.
+	vm_vec_linear_interpolate(&result.position, &before.position, &after.position, percent);
+	vm_vec_linear_interpolate(&result.velocity, &before.velocity, &after.velocity, percent);
+	vm_vec_linear_interpolate(&result.desired_velocity, &before.desired_velocity, &after.desired_velocity, percent);
+	vm_vec_linear_interpolate(&result.rotational_velocity, &before.rotational_velocity, &after.rotational_velocity, percent);
+	vm_vec_linear_interpolate(&result.desired_rotational_velocity, &before.desired_rotational_velocity, &after.desired_rotational_velocity, percent);
+	vm_interpolate_matrices(&result.orientation, &before.orientation, &after.orientation, percent);
+}
+
+void physics_apply_snapshot_manual(vec3d& position, matrix& orient, vec3d& velocity, vec3d& desired_velocity, const physics_snapshot& source)
+{
+	position = source.position;
+	orient = source.orientation;
+	velocity = source.velocity;
+	desired_velocity = source.desired_velocity;
+}
+
+void physics_apply_snapshot_manual(vec3d& position, matrix& orient, vec3d& velocity, vec3d& desired_velocity, 
+	vec3d& rotational_velocity, vec3d& desired_rotational_velocity, const physics_snapshot& source)
+{
+	position = source.position;
+	orient = source.orientation;
+	velocity = source.velocity;
+	desired_velocity = source.desired_velocity;
+	rotational_velocity = source.rotational_velocity;
+	desired_rotational_velocity = source.desired_rotational_velocity;
+}
+
+void physics_populate_snapshot_manual(physics_snapshot& destination, const vec3d& position, const matrix& orient, const vec3d& velocity, const vec3d& desired_velocity, 
+	const vec3d& rotational_velocity, const vec3d& desired_rotational_velocity)
+{
+	destination.position = position;
+	destination.orientation = orient;
+	destination.velocity = velocity;
+	destination.desired_velocity = desired_velocity;
+	destination.rotational_velocity = rotational_velocity;
+	destination.desired_rotational_velocity = desired_rotational_velocity;
+}

--- a/code/physics/physics_state.h
+++ b/code/physics/physics_state.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+#include "math/vecmat.h"
+
+// This is designed to be a small API that generalizes the FSO physics state of an object
+// and allows interpolation between two states.  Timing is not handled here however.
+
+struct physics_snapshot {
+	vec3d position;						// the position at that moment.
+	matrix orientation;					// the orientation at that moment.
+
+	vec3d velocity;						// the velocity at that moment.
+	vec3d desired_velocity;				// the desired velocity at that moment.
+
+	vec3d rotational_velocity;			// the rotational velocity at that moment.
+	vec3d desired_rotational_velocity;	// the desired rotational velocity at that moment.
+};
+
+/**
+ * @brief Interpolate two physics snapshots and get the result
+ *
+ * @param[out] 	result Destination of the interpolated info
+ * @param[in]	before The physics information that happened earlier in the simulation
+ * @param[in]	after The physics information that happened later in the simulation
+ * @param[in]	percent How much time has passed between the two states, in percent. 
+ * 		0.00 means use only before, 1.00 means use only after, 0.50 would interpolate halfway between them.
+ *
+ * @details This takes two physics snapshots of objects and uses linear interpolation to figure out
+ * 		where the objects would be given a specific time factor (percent "progress" towards after). 
+ * 
+ * @author J Fernandez
+ */
+void physics_interpolate_snapshots(physics_snapshot& result, const physics_snapshot& before, const physics_snapshot& after, const float percent);
+
+/**
+ * @brief Apply the contents of a physics state to manually specified variables
+ *
+ * @param[out] 	position Destination of the snapshot's position values
+ * @param[out] 	orient Destination of the snapshot's orientation values
+ * @param[out] 	velocity Destination of the snapshot's velocity values
+ * @param[out] 	desired_velocity Destination of the snapshot's desired velocity
+ * @param[in]	source Physics object that we are copying the values from
+ * 
+ * @details Apply a physics state to manually specified vectors and matrices.
+ * 		This overload does not include rotational velocity or desired rotational velocity.
+ * 
+ * @author J Fernandez
+ */
+void physics_apply_snapshot_manual(vec3d& position, matrix& orient, vec3d& velocity, vec3d& desired_velocity, const physics_snapshot& source);
+
+/**
+ * @brief Apply the contents of a physics state to manually specified variables
+ *
+ * @param[out] 	position Destination of the snapshot's position values
+ * @param[out] 	orient Destination of the snapshot's orientation values
+ * @param[out] 	velocity Destination of the snapshot's velocity values
+ * @param[out] 	desired_velocity Destination of the snapshot's desired velocity
+ * @param[out] 	rotational_velocity Destination of the snapshot's rotational velocity
+ * @param[out] 	desired_rotaional_velocity Destination of the snapshot's desired rotational velocity
+ * @param[in]	source Physics object that we are copying the values from
+ * 
+ * @details Apply a physics state to manually specified vectors and matrices.
+ * 
+ * @author J Fernandez
+ */
+void physics_apply_snapshot_manual(vec3d& position, matrix& orient, vec3d& velocity, vec3d& desired_velocity, vec3d& rotational_velocity, vec3d& desired_rotational_velocity, const physics_snapshot& source);
+
+/**
+ * @brief Populate a physics snapshot by specifying each input vector and matrix
+ *
+ * @param[out]	destination Destination physics snapshot
+ * @param[in]	position Position vector for populating the snapshot
+ * @param[in]	orient Matrix orientation for populating the snapshot
+ * @param[in]	velocity Velocity vector for populating the snapshot
+ * @param[in]	desired_velocity The desired velocity vector for populating the snapshot
+ * @param[in]	rotational_velocity The rotational velocity vector for populating the snapshot
+ * @param[in]	desired_rotational_velocity The desired rotational velocity vector for populating the snapshot
+ *
+ * @author J Fernandez
+ */
+void physics_populate_snapshot_manual(physics_snapshot& destination, const vec3d& position, const matrix& orient, const vec3d& velocity, const vec3d& desired_velocity, const vec3d& rotational_velocity, const vec3d& desired_rotational_velocity);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -58,6 +58,7 @@
 #include "nebula/neb.h"
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
+#include "network/multi_interpolate.h"
 #include "object/deadobjectdock.h"
 #include "object/objcollide.h"
 #include "object/object.h"
@@ -10849,7 +10850,7 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 	Assert( objnum >= 0 );
 
 	// Init multiplayer interpolation info
-	Objects[objnum].interp_info.reset(sip->n_subsystems); 
+	Interp_info[objnum].reset(sip->n_subsystems); 
 
 	shipp->model_instance_num = model_create_instance(objnum, sip->model_num);
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1128,6 +1128,8 @@ add_file_folder("PcxUtils"
 add_file_folder("Physics"
 	physics/physics.cpp
 	physics/physics.h
+	physics/physics_state.cpp
+	physics/physics_state.h
 )
 
 # PilotFile files

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -884,6 +884,7 @@ void game_level_close()
 		// De-Initialize the game subsystems
 		obj_delete_all();
 		obj_reset_colliders();
+		multi_interpolate_clear_all(); // object related
 		sexp_music_close();	// Goober5000
 		event_music_level_close();
 		game_stop_looped_sounds();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -130,6 +130,7 @@
 #include "network/multi_endgame.h"
 #include "network/multi_fstracker.h"
 #include "network/multi_ingame.h"
+#include "network/multi_interpolate.h"
 #include "network/multi_log.h"
 #include "network/multi_pause.h"
 #include "network/multi_pxo.h"


### PR DESCRIPTION
This creates a (very small) api for linear interpolation between two recorded positions, velocitites, and desired velocities and moves multiplayer over to that system.  Now that it is generalized, other games systems (esp. weapons fire) can now use this code to temporarily set an object's position to what it would be between frames.

In draft pending testing.