### PR TITLE
Use the correct variables in this function

### DIFF
--- a/code/network/multi_interpolate.cpp
+++ b/code/network/multi_interpolate.cpp
@@ -179,9 +179,9 @@ void interpolation_manager::interpolate_main(vec3d* pos, matrix* ori, physics_in
 // correct the ship record for player ships when an up to date packet comes in.
 void interpolation_manager::reinterpolate_previous(TIMESTAMP stamp, int prev_packet_index, int next_packet_index,  vec3d* position, matrix* orientation, vec3d* velocity, vec3d* rotational_velocity)
 {
-	// calc what the current timing should be.
-	float numerator = static_cast<float>(_packets[_upcoming_packet_index].remote_missiontime) - static_cast<float>(stamp.value());
-	float denominator = static_cast<float>(_packets[_upcoming_packet_index].remote_missiontime) - static_cast<float>(_packets[_prev_packet_index].remote_missiontime);
+	// calc what the timing was previously.
+	float numerator = static_cast<float>(_packets[next_packet_index].remote_missiontime) - static_cast<float>(stamp.value());
+	float denominator = static_cast<float>(_packets[next_packet_index].remote_missiontime) - static_cast<float>(_packets[prev_packet_index].remote_missiontime);
 
 	denominator = (denominator > 0.05f) ? denominator : 0.05f;
 	


### PR DESCRIPTION
These were never set to the correct variables, which is to say the incoming parameters.  Based on the comment also never being edited, I am guessing this is a copy paste mistake.  The effect of the wrong variables being placed there is that player ships were likely more easy to hit in PvP modes.  This makes sense, as my original expectation for the effectiveness of this function would be more subtle effect on PvP accuracy.

This is also the reason why #5003 is failing its checks.