### PR TITLE
more category updates

### DIFF
--- a/code/parse/sexp/EngineSEXP.h
+++ b/code/parse/sexp/EngineSEXP.h
@@ -20,6 +20,7 @@ class EngineSEXPFactory {
 	SCP_string _helpText;
 
 	int _category = OP_CATEGORY_NONE;
+	SCP_string _categoryName;
 
 	int _subcategory = OP_SUBCATEGORY_NONE;
 	SCP_string _subcategoryName;
@@ -104,6 +105,17 @@ class EngineSEXPFactory {
 	 * @return The factory
 	 */
 	EngineSEXPFactory& category(int cat);
+	/**
+	 * @brief Sets the category of the SEXP.
+	 *
+	 * This can be a new category which will be created automatically.
+	 *
+	 * This or the number variant is a required value!
+	 *
+	 * @param cat The name of the category
+	 * @return The factory
+	 */
+	EngineSEXPFactory& category(const SCP_string& cat);
 
 	/**
 	 * @brief The subcategory of this SEXP
@@ -171,6 +183,7 @@ class EngineSEXP : public DynamicSEXP {
 
   private:
 	void setCategory(int category);
+	void setCategoryName(SCP_string category);
 	void setSubcategory(int subcategory);
 	void setSubcategoryName(SCP_string subcategory);
 	void setHelpText(SCP_string helpText);
@@ -179,6 +192,7 @@ class EngineSEXP : public DynamicSEXP {
 	void setAction(EngineSexpAction action);
 
 	int _category = OP_CATEGORY_NONE;
+	SCP_string _categoryName;
 
 	int _subcategory = OP_SUBCATEGORY_NONE;
 	SCP_string _subcategoryName;

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -76,26 +76,6 @@ int LuaSEXP::get_return_type(const SCP_string& name)
 	}
 }
 
-int LuaSEXP::get_category(const SCP_string& name) {
-	for (auto& subcat : op_menu) {
-		if (subcat.name == name) {
-			return subcat.id;
-		}
-	}
-
-	return OP_CATEGORY_NONE;
-}
-
-int LuaSEXP::get_subcategory(const SCP_string& name, int category) {
-	for (auto& subcat : op_submenu) {
-		if (subcat.name == name && category_of_subcategory(subcat.id) == category) {
-			return subcat.id;
-		}
-	}
-
-	return OP_SUBCATEGORY_NONE;
-}
-
 LuaSEXP::LuaSEXP(const SCP_string& name) : DynamicSEXP(name) {
 }
 void LuaSEXP::initialize() {

--- a/code/parse/sexp/LuaSEXP.h
+++ b/code/parse/sexp/LuaSEXP.h
@@ -33,8 +33,6 @@ protected:
  public:
 	static std::pair<SCP_string, int> get_parameter_type(const SCP_string& name);
 	static int get_return_type(const SCP_string& name);
-	static int get_category(const SCP_string& name);
-	static int get_subcategory(const SCP_string& name, int category);
 
 	explicit LuaSEXP(const SCP_string& name);
 

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -198,6 +198,26 @@ DynamicSEXP* get_dynamic_sexp(int operator_const)
 
 	return iter->second.get();
 }
+int get_category(const SCP_string& name)
+{
+	for (auto& cat : op_menu) {
+		if (SCP_string_lcase_equal_to()(cat.name, name)) {
+			return cat.id;
+		}
+	}
+
+	return OP_CATEGORY_NONE;
+}
+int get_subcategory(const SCP_string& name, int category)
+{
+	for (auto& subcat : op_submenu) {
+		if (SCP_string_lcase_equal_to()(subcat.name, name) && get_category_of_subcategory(subcat.id) == category) {
+			return subcat.id;
+		}
+	}
+
+	return OP_SUBCATEGORY_NONE;
+}
 int get_category_of_subcategory(int subcategory_id)
 {
 	const auto& global = globals();

--- a/code/parse/sexp/sexp_lookup.h
+++ b/code/parse/sexp/sexp_lookup.h
@@ -28,6 +28,21 @@ int add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp, sexp_oper_type type = 
 DynamicSEXP* get_dynamic_sexp(int operator_const);
 
 /**
+ * @brief Given a category name, return the category index
+ * @param name The category name
+ * @return The category index or OP_CATEGORY_NONE if not found
+ */
+int get_category(const SCP_string& name);
+
+/**
+ * @brief Given a category and a subcategory name, return the subcategory index
+ * @param name The subcategory name
+ * @param category The parent category
+ * @return The subcategory index or OP_SUBCATEGORY_NONE if not found
+ */
+int get_subcategory(const SCP_string& name, int category);
+
+/**
  * @brief Given a subcategory constant, return its parent category
  * @param subcategory_id The subcategory constant to check
  * @return The category or OP_CATEGORY_NONE if there isn't one


### PR DESCRIPTION
1. Allow categories, not just subcategories, to be added by scripted SEXPs.
2. Allow subcategories in different categories to have the same name.