### PR TITLE
add pre-parse enums support

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -891,6 +891,18 @@ sexp_ai_goal_link Sexp_ai_goal_links[] = {
 
 SCP_vector<dynamic_sexp_enum_list> Dynamic_enums;
 
+int get_dynamic_enum_position(SCP_string enum_name)
+{
+	for (int i = 0; i < (int)Dynamic_enums.size(); i++) {
+		if (!stricmp(enum_name.c_str(), Dynamic_enums[i].name.c_str())) {
+			return i;
+		}
+	}
+
+	// Didn't find anything.
+	return -1;
+}
+
 void sexp_set_skybox_model_preload(const char *name); // taylor
 int Num_skybox_flags = 6;
 const char *Skybox_flags[] = {

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -144,6 +144,8 @@ struct dynamic_sexp_enum_list {
 
 extern SCP_vector<dynamic_sexp_enum_list> Dynamic_enums;
 
+int get_dynamic_enum_position(SCP_string enum_name);
+
 // Operand return types
 #define	OPR_NUMBER				1	// returns number
 #define	OPR_BOOL				2	// returns true/false value

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -554,9 +554,9 @@ void LuaSEXP::parseTable() {
 
 				//If we're making a new Enum based off another one, let's give it a unique name
 				if (list_position >= 0) {
-					char newName[NAME_LENGTH];
-					strcpy_s(newName, enum_name.c_str());
-					strcat(newName, std::to_string(list_position).c_str());
+					SCP_string newName;
+					newName = enum_name;
+					newName.append(std::to_string(list_position));
 					thisList.name = newName;
 				}
 

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -48,6 +48,12 @@ void parse_sexp_table(const char* filename) {
 				SCP_string name;
 				stuff_string(name, F_NAME);
 
+				if (get_dynamic_enum_position(name) >= 0) {
+					error_display(0, "Lua Sexp Enum %s already exists! Skipping!\n", name.c_str());
+					continue;
+				}
+
+
 				dynamic_sexp_enum_list thisList;
 				thisList.name = name;
 


### PR DESCRIPTION
Adds ability to pre-define Lua Sexp Enums like the following example.

> #Lua Enums
> 
> $Name: Factions
>   +Enum: Galactic Terran Alliance
>   +Enum: Parliamentary Vasudan Navy
>   +Enum: Regulus Syndicate
> 
> #End

This changes inline Enum parsing to check for a previously existing Enum list and will use that if the name matches. However, if +Enum is then specified a new Enum list will be created with the original as a base and the new entries added.

Fixes #2246