### PR TITLE
fictionviewer localization

### DIFF
--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -545,6 +545,26 @@ void fiction_viewer_reset()
 	}
 }
 
+SCP_string get_localized_fiction_filename(const char* filename)
+{
+	SCP_string this_filename = filename;
+	
+	// setup the localized filename string
+	int lang = lcl_get_current_lang_index();
+	if (lang > 0) {
+		size_t lastindex = this_filename.find_last_of(".");
+		this_filename = this_filename.substr(0, lastindex);
+		this_filename = this_filename + "-" + Lcl_languages[lang].lang_ext + ".txt";
+	}
+
+	// return the localized version only if it exists
+	if (cf_exists_full(this_filename.c_str(), CF_TYPE_FICTION))
+		return this_filename;
+
+	// if localized doesn't exist then return the base filename
+	return filename;
+}
+
 void fiction_viewer_load(int stage)
 {
 	Assertion(stage >= 0 && static_cast<size_t>(stage) < Fiction_viewer_stages.size(), "stage parameter must be in range of Fiction_viewer_stages!");
@@ -576,20 +596,7 @@ void fiction_viewer_load(int stage)
 	Fiction_viewer_voice = audiostream_open(stagep->voice_filename, ASF_VOICE);
 
 	// load up the text
-	SCP_string localized_filename;
-	localized_filename = stagep->story_filename;
-
-	// check if a localized version of the file exists
-	int lang = lcl_get_current_lang_index();
-	if (lang > 0) {
-		size_t lastindex = localized_filename.find_last_of(".");
-		localized_filename = localized_filename.substr(0, lastindex);
-		localized_filename = localized_filename + "-" + Lcl_languages[lang].lang_ext + ".txt";
-	}
-
-	// if it localized doesn't exist then revert to the base filename
-	if (!cf_exists_full(localized_filename.c_str(), CF_TYPE_FICTION))
-		localized_filename = stagep->story_filename;
+	SCP_string localized_filename = get_localized_fiction_filename(stagep->story_filename);
 
 	CFILE *fp = cfopen(localized_filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_FICTION);
 	if (fp == NULL)

--- a/code/missionui/fictionviewer.h
+++ b/code/missionui/fictionviewer.h
@@ -39,6 +39,7 @@ void fiction_viewer_do_frame(float frametime);
 bool mission_has_fiction();
 int fiction_viewer_ui_name_to_index(const char *ui_name);
 void fiction_viewer_reset();
+SCP_string get_localized_fiction_filename(const char* filename);
 void fiction_viewer_load(int stage);
 
 void fiction_viewer_pause();

--- a/code/scripting/api/objs/fictionviewer.cpp
+++ b/code/scripting/api/objs/fictionviewer.cpp
@@ -1,4 +1,5 @@
 #include "fictionviewer.h"
+#include "localization/localize.h"
 
 namespace scripting {
 namespace api {
@@ -30,8 +31,22 @@ ADE_VIRTVAR(TextFile, l_FictionViewerStage, nullptr, "The text file of the stage
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
 	}
+	SCP_string localized_filename;
+	localized_filename = stage.getStage()->story_filename;
 
-	return ade_set_args(L, "s", stage.getStage()->story_filename);
+	// check if a localized version of the file exists
+	int lang = lcl_get_current_lang_index();
+	if (lang > 0) {
+		size_t lastindex = localized_filename.find_last_of(".");
+		localized_filename = localized_filename.substr(0, lastindex);
+		localized_filename = localized_filename + "-" + Lcl_languages[lang].lang_ext + ".txt";
+	}
+
+	// if it localized doesn't exist then revert to the base filename
+	if (!cf_exists_full(localized_filename.c_str(), CF_TYPE_FICTION))
+		localized_filename = stage.getStage()->story_filename;
+
+	return ade_set_args(L, "s", localized_filename);
 }
 
 ADE_VIRTVAR(FontFile, l_FictionViewerStage, nullptr, "The font file of the stage", "string", "The font filename")

--- a/code/scripting/api/objs/fictionviewer.cpp
+++ b/code/scripting/api/objs/fictionviewer.cpp
@@ -1,5 +1,5 @@
 #include "fictionviewer.h"
-#include "localization/localize.h"
+#include "missionui/fictionviewer.h"
 
 namespace scripting {
 namespace api {
@@ -31,20 +31,8 @@ ADE_VIRTVAR(TextFile, l_FictionViewerStage, nullptr, "The text file of the stage
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
 	}
-	SCP_string localized_filename;
-	localized_filename = stage.getStage()->story_filename;
 
-	// check if a localized version of the file exists
-	int lang = lcl_get_current_lang_index();
-	if (lang > 0) {
-		size_t lastindex = localized_filename.find_last_of(".");
-		localized_filename = localized_filename.substr(0, lastindex);
-		localized_filename = localized_filename + "-" + Lcl_languages[lang].lang_ext + ".txt";
-	}
-
-	// if it localized doesn't exist then revert to the base filename
-	if (!cf_exists_full(localized_filename.c_str(), CF_TYPE_FICTION))
-		localized_filename = stage.getStage()->story_filename;
+	SCP_string localized_filename = get_localized_fiction_filename(stage.getStage()->story_filename);
 
 	return ade_set_args(L, "s", localized_filename);
 }

--- a/code/scripting/api/objs/fictionviewer.cpp
+++ b/code/scripting/api/objs/fictionviewer.cpp
@@ -34,7 +34,7 @@ ADE_VIRTVAR(TextFile, l_FictionViewerStage, nullptr, "The text file of the stage
 
 	SCP_string localized_filename = get_localized_fiction_filename(stage.getStage()->story_filename);
 
-	return ade_set_args(L, "s", localized_filename);
+	return ade_set_args(L, "s", localized_filename.c_str());
 }
 
 ADE_VIRTVAR(FontFile, l_FictionViewerStage, nullptr, "The font file of the stage", "string", "The font filename")


### PR DESCRIPTION
Implements true fiction viewer localization. If language setting is not English then it will try to find the fiction viewer file with the language extension applied. If the file specified is `somefile.txt` then it will search for `somefile-gr.txt`, for example, if the language setting is German. If that file is not found then it will default to the base filename `somefile.txt`.

Also updates the scpui virtvar with the same code.

Fixes #1836 for real this time