### PR TITLE
enable commandline language setting

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -429,8 +429,10 @@ char *Cmdline_gateway_ip = nullptr;
 // Launcher related options
 cmdline_parm portable_mode("-portable_mode", NULL, AT_NONE);
 cmdline_parm joy_info("-joy_info", "Outputs SDL joystick info", AT_NONE);
+cmdline_parm lang_arg("-language", "Language name as defined in strings.tbl", AT_STRING);
 
 bool Cmdline_portable_mode = false;
+SCP_string Cmdline_lang;
 
 // Troubleshooting
 cmdline_parm loadallweapons_arg("-loadallweps", NULL, AT_NONE);	// Cmdline_load_all_weapons
@@ -1984,6 +1986,11 @@ bool SetCmdlineParams()
 	if (portable_mode.found())
 	{
 		Cmdline_portable_mode = true;
+	}
+
+	if (lang_arg.found()) 
+	{
+		Cmdline_lang = lang_arg.str();
 	}
 	
 #ifdef WIN32

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -104,6 +104,7 @@ extern char *Cmdline_gateway_ip;
 
 // Launcher related options
 extern bool Cmdline_portable_mode;
+extern SCP_string Cmdline_lang;
 
 // Troubleshooting
 extern int Cmdline_load_all_weapons;

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -143,24 +143,39 @@ void lcl_init(int lang_init)
 		}
 	}
 
-	// read the language from the registry
+	// read the language from the commandline and then registry
 	if (lang_init < 0) {
-		memset(lang_string, 0, 128);
-		// default to DEFAULT_LANGUAGE (which should be English so we don't have to put German text
-		// in tstrings in the #default section)
-		ret = os_config_read_string(nullptr, "Language", Lcl_languages[LCL_DEFAULT].lang_name);
-		strcpy_s(lang_string, ret);		
 
-		// look it up
 		lang = -1;
-		for(idx = 0; idx < (int)Lcl_languages.size(); idx++){
-			if(!stricmp(Lcl_languages[idx].lang_name, lang_string)){
-				lang = idx;
-				break;
+
+		// first try the commandline
+		if (!Cmdline_lang.empty()) {
+			for (idx = 0; idx < (int)Lcl_languages.size(); idx++) {
+				if (!stricmp(Lcl_languages[idx].lang_name, Cmdline_lang.c_str())) {
+					lang = idx;
+					break;
+				}
 			}
 		}
-		if(lang < 0){
-			lang = LCL_DEFAULT;
+
+		if (lang < 0) {
+			// now go the the registry if it's not found
+			memset(lang_string, 0, 128);
+			// default to DEFAULT_LANGUAGE (which should be English so we don't have to put German text
+			// in tstrings in the #default section)
+			ret = os_config_read_string(nullptr, "Language", Lcl_languages[LCL_DEFAULT].lang_name);
+			strcpy_s(lang_string, ret);
+
+			// look it up
+			for (idx = 0; idx < (int)Lcl_languages.size(); idx++) {
+				if (!stricmp(Lcl_languages[idx].lang_name, lang_string)) {
+					lang = idx;
+					break;
+				}
+			}
+			if (lang < 0) {
+				lang = LCL_DEFAULT;
+			}
 		}
 	} else {
 		Assert(lang_init == LCL_UNTRANSLATED || lang_init == LCL_RETAIL_HYBRID || (lang_init >= 0 && lang_init < (int)Lcl_languages.size()));


### PR DESCRIPTION
While you can set the language in Knossos, it (currently) only allows for the four built-in languages. This will accept any string and checks it against the language settings in the strings.tbl. Will set the language first by commandline. If that doesn't get a valid language it will fall back to past behavior and check the INI file/registry.

Set it like so `-language German`

This is the first step towards creating an SCPUI in-game language option (that would require a restart).