### PR TITLE
address issues related to cf.openFile() error handling

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -1847,7 +1847,9 @@ int cfile_get_path_type(const SCP_string& dir)
 		auto start = buf.find_first_not_of("\\/");
 		auto end = buf.find_last_not_of("\\/");
 
-		if ( (start > 0) || (end < buf.length()-1) ) {
+		if (start == SCP_string::npos) {
+			buf = "";
+		} else if ( (start > 0) || (end < buf.length()-1) ) {
 			buf = buf.substr(start, end-start+1);
 		}
 	}

--- a/code/scripting/api/libs/cfile.cpp
+++ b/code/scripting/api/libs/cfile.cpp
@@ -106,8 +106,9 @@ ADE_FUNC(listFiles, l_CFile, "string directory, string filter",
 }
 
 ADE_FUNC(openFile, l_CFile, "string Filename, [string Mode=\"r\", string Path = \"\"]",
-		 "Opens a file. 'Mode' uses standard C fopen arguments. Use a blank string for path for any directory, or a slash for the root directory."
-			 "Be EXTREMELY CAREFUL when using this function, as you may PERMANENTLY delete any file by accident",
+		 "Opens a file. 'Mode' uses standard C fopen arguments. In read mode use a blank string for path for any directory, "
+			"or a slash for the root directory. When using write mode a valid path must be specified. "
+			"Be EXTREMELY CAREFUL when using this function, as you may PERMANENTLY delete any file by accident",
 		 "file",
 		 "File handle, or invalid file handle if the specified file couldn't be opened")
 {
@@ -124,6 +125,9 @@ ADE_FUNC(openFile, l_CFile, "string Filename, [string Mode=\"r\", string Path = 
 		path = cfile_get_path_type(n_path);
 
 	if(path == CF_TYPE_INVALID)
+		return ade_set_error(L, "o", l_File.Set(cfile_h()));
+
+	if((path == CF_TYPE_ANY) && (strchr(n_mode,'w') || strchr(n_mode,'+') || strchr(n_mode,'a')))
 		return ade_set_error(L, "o", l_File.Set(cfile_h()));
 
 	CFILE *cfp = cfopen(n_filename, n_mode, type, path);


### PR DESCRIPTION
 - fix crash bug when path only contains dir separators
 - fix error handling when no path is specified in write mode
 - clarify function documentation

Fixes #5028