### PR TITLE
patch hud-lock iteration for objects that aren't ships

### DIFF
--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -836,14 +836,15 @@ void hud_lock_acquire_uncaged_target(lock_info *current_lock, weapon_info *wip)
 	bool actively_locking = false;
 
 	for ( A = GET_FIRST(&obj_used_list); A !=END_OF_LIST(&obj_used_list); A = GET_NEXT(A) ) {
-		ship* sp = &Ships[A->instance];
+		if (A->flags[Object::Object_Flags::Should_be_dead])
+			continue;
 
 		if (!weapon_multilock_can_lock_on_target(Player_obj, A, wip, &dot))
 			continue;
 
 		bool in_range = weapon_secondary_world_pos_in_range(Player_obj, wip, &A->pos);
 
-		if ( Ship_info[sp->ship_info_index].is_big_or_huge() ) {
+		if ( A->type == OBJ_SHIP && Ship_info[Ships[A->instance].ship_info_index].is_big_or_huge() ) {
 			lock_info temp_lock;
 
 			temp_lock.obj = A;

--- a/code/ship/awacs.cpp
+++ b/code/ship/awacs.cpp
@@ -194,10 +194,10 @@ float awacs_get_level(object *target, ship *viewer, int use_awacs)
 	int distance = (int) vm_vec_mag_quick(&dist_vec);
 
 // redone by Goober5000
-#define ALWAYS_TARGETABLE		1.5f
-#define MARGINALLY_TARGETABLE	0.5f
-#define UNTARGETABLE			-1.0f
-#define FULLY_TARGETABLE		(viewer_has_primitive_sensors ? ((distance < viewer->primitive_sensor_range) ? MARGINALLY_TARGETABLE : UNTARGETABLE) : ALWAYS_TARGETABLE)
+constexpr float ALWAYS_TARGETABLE       = 1.5f;
+constexpr float MARGINALLY_TARGETABLE   = 0.5f;
+constexpr float UNTARGETABLE            = -1.0f;
+const     float FULLY_TARGETABLE        = (viewer_has_primitive_sensors ? ((distance < viewer->primitive_sensor_range) ? MARGINALLY_TARGETABLE : UNTARGETABLE) : ALWAYS_TARGETABLE);
 
 	// if the viewer is me, and I'm a multiplayer observer, its always viewable
 	if ((viewer == Player_ship) && (Game_mode & GM_MULTIPLAYER) && (Net_player != NULL) && MULTI_OBSERVER(Net_players[MY_NET_PLAYER_NUM]))
@@ -316,14 +316,14 @@ float awacs_get_level(object *target, ship *viewer, int use_awacs)
 			return UNTARGETABLE;
 		}
 	}
-	// all other ships
+	// all other objects
 	else
 	{
-		// if this is not a nebula mission, its always targetable
+		// if this is not a nebula mission, it's always targetable
 		if (!nebula_enabled)
 			return FULLY_TARGETABLE;
 
-		// if the ship is within range of an awacs, its fully targetable
+		// if the object is within range of an awacs, it's fully targetable
 		if (closest_index >= 0)
 			return FULLY_TARGETABLE;
 


### PR DESCRIPTION
Since `hud_lock_acquire_uncaged_target` assumes every item is a ship, it probably intended to iterate over `Ship_obj_list`, not `obj_used_list`.