### PR TITLE
more robust object iteration

### DIFF
--- a/code/object/object.h
+++ b/code/object/object.h
@@ -15,6 +15,7 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 #include "math/vecmat.h"
+#include "object/object.h"
 #include "object/object_flags.h"
 #include "physics/physics.h"
 #include "utils/event.h"
@@ -159,13 +160,30 @@ private:
 	object& operator= (const object & other); // no implementation
 };
 
+extern int Num_objects;
+extern object Objects[];
+
 struct object_h {
 	object *objp;
 	int sig;
 
 	bool IsValid() const {return (objp != NULL && objp->signature == sig && sig > 0);}
-	object_h(object *in){objp=in; if(objp!=NULL){sig=in->signature;}}
+	object_h(object *in){objp=in; sig = (in == nullptr) ? -1 : in->signature;}
 	object_h(){objp=NULL;sig=-1;}
+
+	object_h(int objnum)
+	{
+		if (objnum >= 0 && objnum < MAX_OBJECTS)
+		{
+			objp = &Objects[objnum];
+			sig = objp->signature;
+		}
+		else
+		{
+			objp = nullptr;
+			sig = -1;
+		}
+	}
 };
 
 // object backup struct used by Fred.
@@ -194,13 +212,10 @@ public:
 extern int Object_inited;
 extern int Show_waypoints;
 
-// The next signature for the next newly created object. Zero is bogus
-extern int Object_next_signature;		
-extern int Num_objects;
-
-extern object Objects[];
+extern int Object_next_signature;		// The next signature for the next newly created object. Zero is bogus
 extern int Highest_object_index;		//highest objnum
 extern int Highest_ever_object_index;
+
 extern object obj_free_list;
 extern object obj_used_list;
 extern object obj_create_list;

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -83,9 +83,46 @@ extern TIMESTAMP Game_shudder_time;
 extern int Game_shudder_total;
 extern float Game_shudder_intensity;
 
+constexpr int COUNT_OBJECTS = -1000;
+
+// Returns the indexth object subclass
+template <typename A>
+int object_subclass_at_index(A& object_subclass_array, size_t array_size, int index)
+{
+	int count = 0;
+
+	for (size_t i = 0; i < array_size; ++i)
+	{
+		int objnum = object_subclass_array[i].objnum;
+		if (objnum < 0 || objnum >= MAX_OBJECTS)
+			continue;
+		if (Objects[objnum].flags[Object::Object_Flags::Should_be_dead])
+			continue;
+
+		++count;
+
+		if (count == index)
+		{
+			return object_subclass_array[i].objnum;
+		}
+	}
+
+	if (index == COUNT_OBJECTS)
+		return count;
+	else
+		return -1;
+}
+
+// Counts the number of indexable objects
+template <typename A>
+int object_subclass_count(A& object_subclass_array, size_t array_size)
+{
+	return object_subclass_at_index(object_subclass_array, array_size, COUNT_OBJECTS);
+}
+
+
 namespace scripting {
 namespace api {
-
 
 //**********LIBRARY: Mission
 ADE_LIB(l_Mission, "Mission", "mn", "Mission library");
@@ -185,12 +222,12 @@ ADE_INDEXER(l_Mission_Asteroids, "number Index", "Gets asteroid", "asteroid", "A
 	if( !ade_get_args(L, "*i", &idx) ) {
 		return ade_set_error( L, "o", l_Asteroid.Set( object_h() ) );
 	}
-	if( idx > -1 && idx < asteroid_count() ) {
-		idx--; //Convert from Lua to C, as lua indices start from 1, not 0
-		return ade_set_args(L, "o", l_Asteroid.Set(object_h(&Objects[Asteroids[idx].objnum])));
-	}
 
-	return ade_set_error(L, "o", l_Asteroid.Set( object_h() ) );
+	int objnum = -1;
+	if (idx > 0)
+		objnum = object_subclass_at_index(Asteroids, MAX_ASTEROIDS, idx);
+
+	return ade_set_args(L, "o", l_Asteroid.Set( object_h(objnum) ) );
 }
 
 ADE_FUNC(__len, l_Mission_Asteroids, NULL,
@@ -199,7 +236,7 @@ ADE_FUNC(__len, l_Mission_Asteroids, NULL,
 		 "Number of asteroids in the mission, or 0 if asteroids are not enabled")
 {
 	if(Asteroids_enabled) {
-		return ade_set_args(L, "i", asteroid_count());
+		return ade_set_args(L, "i", object_subclass_count(Asteroids, MAX_ASTEROIDS));
 	}
 	return ade_set_args(L, "i", 0);
 }
@@ -383,32 +420,20 @@ ADE_INDEXER(l_Mission_Ships, "number/string IndexOrName", "Gets ship", "ship", "
 
 	int idx = ship_name_lookup(name);
 
-	if(idx > -1)
+	if (idx >= 0)
 	{
 		return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[idx].objnum])));
 	}
 	else
 	{
 		idx = atoi(name);
-		if(idx > 0)
-		{
-			int count=1;
 
-			for(int i = 0; i < MAX_SHIPS; i++)
-			{
-				if (Ships[i].objnum < 0 || Objects[Ships[i].objnum].type != OBJ_SHIP)
-					continue;
+		int objnum = -1;
+		if (idx > 0)
+			objnum = object_subclass_at_index(Ships, MAX_SHIPS, idx);
 
-				if(count == idx) {
-					return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[i].objnum])));
-				}
-
-				count++;
-			}
-		}
+		return ade_set_args(L, "o", l_Ship.Set(object_h(objnum)));
 	}
-
-	return ade_set_error(L, "o", l_Ship.Set(object_h()));
 }
 
 ADE_FUNC(__len, l_Mission_Ships, NULL,
@@ -418,10 +443,7 @@ ADE_FUNC(__len, l_Mission_Ships, NULL,
 		 "number",
 		 "Number of ships in the mission, or 0 if ships haven't been initialized yet")
 {
-	if(Ships_inited)
-		return ade_set_args(L, "i", ship_get_num_ships());
-	else
-		return ade_set_args(L, "i", 0);
+	return ade_set_args(L, "i", object_subclass_count(Ships, MAX_SHIPS));
 }
 
 //****SUBLIBRARY: Mission/ParsedShips
@@ -479,7 +501,7 @@ ADE_INDEXER(l_Mission_Waypoints, "number Index", "Array of waypoints in the curr
 	object *ptr = GET_FIRST(&obj_used_list);
 	while (ptr != END_OF_LIST(&obj_used_list))
 	{
-		if (ptr->type == OBJ_WAYPOINT)
+		if (ptr->type == OBJ_WAYPOINT && !ptr->flags[Object::Object_Flags::Should_be_dead])
 			count++;
 
 		if(count == idx) {
@@ -494,11 +516,15 @@ ADE_INDEXER(l_Mission_Waypoints, "number Index", "Array of waypoints in the curr
 
 ADE_FUNC(__len, l_Mission_Waypoints, NULL, "Gets number of waypoints in mission. Note that this is only accurate for one frame.", "number", "Number of waypoints in the mission")
 {
-	uint count=0;
-	for(uint i = 0; i < MAX_OBJECTS; i++)
+	int count=0;
+
+	object *ptr = GET_FIRST(&obj_used_list);
+	while (ptr != END_OF_LIST(&obj_used_list))
 	{
-		if (Objects[i].type == OBJ_WAYPOINT)
+		if (ptr->type == OBJ_WAYPOINT && !ptr->flags[Object::Object_Flags::Should_be_dead])
 			count++;
+
+		ptr = GET_NEXT(ptr);
 	}
 
 	return ade_set_args(L, "i", count);
@@ -546,26 +572,15 @@ ADE_INDEXER(l_Mission_Weapons, "number Index", "Gets handle to a weapon object i
 	if(!ade_get_args(L, "*i", &idx))
 		return ade_set_error(L, "o", l_Weapon.Set(object_h()));
 
-	//Remember, Lua indices start at 0.
-	int count=1;
+	int objnum = -1;
+	if (idx > 0)
+		objnum = object_subclass_at_index(Weapons, MAX_WEAPONS, idx);
 
-	for(int i = 0; i < MAX_WEAPONS; i++)
-	{
-		if (Weapons[i].weapon_info_index < 0 || Weapons[i].objnum < 0 || Objects[Weapons[i].objnum].type != OBJ_WEAPON)
-			continue;
-
-		if(count == idx) {
-			return ade_set_args(L, "o", l_Weapon.Set(object_h(&Objects[Weapons[i].objnum])));
-		}
-
-		count++;
-	}
-
-	return ade_set_error(L, "o", l_Weapon.Set(object_h()));
+	return ade_set_args(L, "o", l_Weapon.Set(object_h(objnum)));
 }
 ADE_FUNC(__len, l_Mission_Weapons, NULL, "Number of weapon objects in mission. Note that this is only accurate for one frame.", "number", "Number of weapon objects in mission")
 {
-	return ade_set_args(L, "i", Num_weapons);
+	return ade_set_args(L, "i", object_subclass_count(Weapons, MAX_WEAPONS));
 }
 
 //****SUBLIBRARY: Mission/Beams
@@ -577,26 +592,15 @@ ADE_INDEXER(l_Mission_Beams, "number Index", "Gets handle to a beam object in th
 	if(!ade_get_args(L, "*i", &idx))
 		return ade_set_error(L, "o", l_Beam.Set(object_h()));
 
-	//Remember, Lua indices start at 0.
-	int count=1;
+	int objnum = -1;
+	if (idx > 0)
+		objnum = object_subclass_at_index(Beams, MAX_BEAMS, idx);
 
-	for(int i = 0; i < MAX_BEAMS; i++)
-	{
-		if (Beams[i].weapon_info_index < 0 || Beams[i].objnum < 0 || Objects[Beams[i].objnum].type != OBJ_BEAM)
-			continue;
-
-		if(count == idx) {
-			return ade_set_args(L, "o", l_Beam.Set(object_h(&Objects[Beams[i].objnum])));
-		}
-
-		count++;
-	}
-
-	return ade_set_error(L, "o", l_Beam.Set(object_h()));
+	return ade_set_args(L, "o", l_Beam.Set(object_h(objnum)));
 }
 ADE_FUNC(__len, l_Mission_Beams, NULL, "Number of beam objects in mission. Note that this is only accurate for one frame.", "number", "Number of beam objects in mission")
 {
-	return ade_set_args(L, "i", Beam_count);
+	return ade_set_args(L, "i", object_subclass_count(Beams, MAX_BEAMS));
 }
 
 //****SUBLIBRARY: Mission/Wings
@@ -796,27 +800,15 @@ ADE_INDEXER(l_Mission_Fireballs, "number Index", "Gets handle to a fireball obje
 	if (!ade_get_args(L, "*i", &idx))
 		return ade_set_error(L, "o", l_Fireball.Set(object_h()));
 
-	//Remember, Lua indices start at 1.
-	int count = 1;
+	int objnum = -1;
+	if (idx > 0)
+		objnum = object_subclass_at_index(Fireballs, MAX_FIREBALLS, idx);
 
-	for (auto& current_fireball : Fireballs) {
-		if (current_fireball.fireball_info_index < 0 || current_fireball.objnum < 0 || Objects[current_fireball.objnum].type != OBJ_FIREBALL)
-			continue;
-
-		if (count == idx) {
-			return ade_set_args(L, "o", l_Fireball.Set(object_h(&Objects[current_fireball.objnum])));
-		}
-
-		count++;
-
-	}
-
-	return ade_set_error(L, "o", l_Fireball.Set(object_h()));
+	return ade_set_args(L, "o", l_Fireball.Set(object_h(objnum)));
 }
 ADE_FUNC(__len, l_Mission_Fireballs, NULL, "Number of fireball objects in mission. Note that this is only accurate for one frame.", "number", "Number of fireball objects in mission")
 {
-	int count = fireball_get_count();
-	return ade_set_args(L, "i", count);
+	return ade_set_args(L, "i", object_subclass_count(Fireballs, MAX_FIREBALLS));
 }
 
 ADE_FUNC(addMessage, l_Mission, "string name, string text, [persona persona]", "Adds a message", "message", "The new message or invalid handle on error")
@@ -2223,6 +2215,16 @@ ADE_FUNC(getShipList,
 		//Similarly, an empty list is defined by the head's next element being itself, hence an empty list will immediately return nil just fine
 		so = GET_NEXT(so);
 
+		// skip should-be-dead ships
+		if (so != nullptr) {
+			while (so != END_OF_LIST(&Ship_obj_list)) {
+				if (!Objects[so->objnum].flags[Object::Object_Flags::Should_be_dead]) {
+					break;
+				}
+				so = GET_NEXT(so);
+			}
+		}
+
 		if (so == END_OF_LIST(&Ship_obj_list) || so == nullptr) {
 			return luacpp::LuaValueList{ luacpp::LuaValue::createNil(LInner) };
 		}
@@ -2244,6 +2246,16 @@ ADE_FUNC(getMissileList,
 		//Since the first element of a list is the next element from the head, and we start this function with the the captured "mo" object being the head, this GET_NEXT will return the first element on first call of this lambda.
 		//Similarly, an empty list is defined by the head's next element being itself, hence an empty list will immediately return nil just fine
 		mo = GET_NEXT(mo);
+
+		// skip should-be-dead missiles
+		if (mo != nullptr) {
+			while (mo != END_OF_LIST(&Missile_obj_list)) {
+				if (!Objects[mo->objnum].flags[Object::Object_Flags::Should_be_dead]) {
+					break;
+				}
+				mo = GET_NEXT(mo);
+			}
+		}
 
 		if (mo == END_OF_LIST(&Missile_obj_list) || mo == nullptr) {
 			return luacpp::LuaValueList{ luacpp::LuaValue::createNil(LInner) };

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -300,6 +300,18 @@ ADE_FUNC(isValid, l_Object, NULL, "Detects whether handle is valid", "boolean", 
 	return ade_set_args(L, "b", oh->IsValid());
 }
 
+ADE_FUNC(isExpiring, l_Object, nullptr, "Checks whether the object has the should-be-dead flag set, which will cause it to be deleted within one frame", "boolean", "true or false according to the flag, or nil if a syntax/type error occurs")
+{
+	object_h* oh;
+	if (!ade_get_args(L, "o", l_Object.GetPtr(&oh)))
+		return ADE_RETURN_NIL;
+
+	if (!oh->IsValid())
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", oh->objp->flags[Object::Object_Flags::Should_be_dead]);
+}
+
 ADE_FUNC(getBreedName, l_Object, NULL, "Gets object type", "string", "Object type name, or empty string if handle is invalid")
 {
 	object_h *objh;


### PR DESCRIPTION
When iterating through various object collections, check for the should-be-dead flag to avoid returning objects that are on the verge of being deleted.

Separately, this adds the `isExpiring` function to check for should-be-dead objects.

This PR also makes object iteration consistent across all object types, both to reduce code duplication and to ensure that the length and iteration are done using the same algorithm.  Furthermore, if the number of should-be-dead objects is nonzero, the Lua array count for that frame will be different from the internal array count for that frame.

Fixes #5034.

In draft status pending tests.