### PR TITLE
fix wing cues and add some more error checks

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1434,6 +1434,7 @@ void sexp_unmark_persistent(int n)
 		return;
 	}
 
+	// see sexp_mark_persistent
 	if ( (n == Locked_sexp_true) || (n == Locked_sexp_false) ){
 		return;
 	}
@@ -1455,6 +1456,7 @@ int free_one_sexp(int num)
 	Assert(Sexp_nodes[num].type != SEXP_NOT_USED);  // make sure it is actually used
 	Assert(!(Sexp_nodes[num].type & SEXP_FLAG_PERSISTENT));
 
+	// never free these nodes
 	if ((num == Locked_sexp_true) || (num == Locked_sexp_false))
 		return 0;
 
@@ -1797,6 +1799,8 @@ int get_operator_index(const char *token)
 int get_operator_index(int node)
 {
 	Assertion(node >= 0 && node < Num_sexp_nodes, "Passed an out-of-range node index (%d) to get_operator_index(int)!", node);
+	if (node < 0 || node >= Num_sexp_nodes)
+		return NOT_A_SEXP_OPERATOR;
 
 	if (!Fred_running && (Sexp_nodes[node].op_index != NO_OPERATOR_INDEX_DEFINED) ) {
 		return Sexp_nodes[node].op_index;
@@ -1816,13 +1820,17 @@ int get_operator_const(const char *token)
 	int	idx = get_operator_index(token);
 
 	if (idx == NOT_A_SEXP_OPERATOR)
-		return 0;
+		return OP_NOT_AN_OP;
 
 	return Operators[idx].value;
 }
 
 int get_operator_const(int node)
 {
+	Assertion(node >= 0 && node < Num_sexp_nodes, "Passed an out-of-range node index (%d) to get_operator_const(int)!", node);
+	if (node < 0 || node >= Num_sexp_nodes)
+		return OP_NOT_AN_OP;
+
 	if (!Fred_running && Sexp_nodes[node].op_index >= 0) {
 		return Operators[Sexp_nodes[node].op_index].value;
 	}
@@ -1830,7 +1838,7 @@ int get_operator_const(int node)
 	int	idx = get_operator_index(node);
 
 	if (idx == NOT_A_SEXP_OPERATOR)
-		return 0;
+		return OP_NOT_AN_OP;
 
 	return Operators[idx].value;
 }

--- a/fred2/wing.cpp
+++ b/fred2/wing.cpp
@@ -168,6 +168,8 @@ int create_wing() {
 		}
 
 		Wings[wing].clear();
+		Wings[wing].arrival_cue = Locked_sexp_true;
+		Wings[wing].departure_cue = Locked_sexp_false;
 
 		if (dlg.DoModal() == IDCANCEL)
 			return -1;

--- a/qtfred/src/mission/EditorWing.cpp
+++ b/qtfred/src/mission/EditorWing.cpp
@@ -184,6 +184,8 @@ int Editor::create_wing()
 		}
 
 		Wings[wing].clear();
+		Wings[wing].arrival_cue = Locked_sexp_true;
+		Wings[wing].departure_cue = Locked_sexp_false;
 
 		auto dlg = _lastActiveViewport->dialogProvider->createFormWingDialog();
 


### PR DESCRIPTION
Fixes #5045 by correctly initializing wing arrival and departure cues.  Follow-up to #4856.  Also adds a bit more SEXP error checking.