### PR TITLE
choose random splash image

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -66,6 +66,7 @@ SCP_string Window_title;
 SCP_string Mod_title;
 SCP_string Mod_version;
 bool Unicode_text_mode;
+SCP_vector<SCP_string> Splash_screens;
 bool Use_tabled_strings_for_default_language;
 bool Dont_preempt_training_voice;
 SCP_string Movie_subtitle_font;
@@ -211,6 +212,20 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Unicode_text_mode);
 
 			mprintf(("Game Settings Table: Unicode mode: %s\n", Unicode_text_mode ? "yes" : "no"));
+		}
+
+		if (optional_string("$Splash screens:")) {
+			SCP_string splash_bitmap;
+			while (optional_string("+Bitmap:")) {
+				stuff_string(splash_bitmap, F_NAME);
+
+				// remove extension?
+				if (drop_extension(splash_bitmap)) {
+					mprintf(("Game Settings Table: Removed extension on splash screen file name %s\n", splash_bitmap.c_str()));
+				}
+
+				Splash_screens.push_back(splash_bitmap);
+			}
 		}
 
 		optional_string("#LOCALIZATION SETTINGS");

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -60,6 +60,7 @@ extern SCP_string Window_title;
 extern SCP_string Mod_title;
 extern SCP_string Mod_version;
 extern bool Unicode_text_mode;
+extern SCP_vector<SCP_string> Splash_screens;
 extern bool Use_tabled_strings_for_default_language;
 extern bool Dont_preempt_training_voice;
 extern SCP_string Movie_subtitle_font;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7456,7 +7456,7 @@ void game_title_screen_display()
 		Game_title_logo = bm_load(Game_logo_screen_fname[gr_screen.res]);
 
 		if (!Splash_screens.empty()) {
-			Game_title_bitmap = bm_load(Splash_screens[Random::next(0, (int)Splash_screens.size() - 1)].c_str());
+			Game_title_bitmap = bm_load(Splash_screens[Random::next(0, (int)Splash_screens.size())].c_str());
 		} else {
 			Game_title_bitmap = bm_load(Game_title_screen_fname[gr_screen.res]);
 		}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7454,7 +7454,12 @@ void game_title_screen_display()
 	if(!condhook_override)
 	{
 		Game_title_logo = bm_load(Game_logo_screen_fname[gr_screen.res]);
-		Game_title_bitmap = bm_load(Game_title_screen_fname[gr_screen.res]);
+
+		if (!Splash_screens.empty()) {
+			Game_title_bitmap = bm_load(Splash_screens[Random::next(0, (int)Splash_screens.size() - 1)].c_str());
+		} else {
+			Game_title_bitmap = bm_load(Game_title_screen_fname[gr_screen.res]);
+		}
 
 		if (Game_title_bitmap != -1)
 		{


### PR DESCRIPTION
As requested by @wookieejedi . This allows to specify a list of splash screen bitmaps in game_settings.tbl and then one will be chosen at random to display on game init. If the vector is empty then it defaults to pre_load/2_pre_load as is the current behavior.