### PR TITLE
Use `textify_scancode_universal()` in more places.

### DIFF
--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -251,7 +251,7 @@ static bool global_condition_valid(const script_condition& condition)
 		if (Current_key_down == 0)
 			return false;
 		// WMC - could be more efficient, but whatever.
-		if (stricmp(textify_scancode(Current_key_down), condition.condition_string.c_str()) != 0)
+		if (stricmp(textify_scancode_universal(Current_key_down), condition.condition_string.c_str()) != 0)
 			return false;
 		break;
 	}

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -6678,7 +6678,7 @@ sexp_list_item *sexp_tree::get_listing_opf_keypress()
 		auto btn = Default_config[i].get_btn(CID_KEYBOARD);
 
 		if ((btn >= 0) && !Control_config[i].disabled) {
-			head.add_data(textify_scancode(btn));
+			head.add_data(textify_scancode_universal(btn));
 		}
 	}
 

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4452,7 +4452,7 @@ sexp_list_item* sexp_tree::get_listing_opf_keypress() {
 		auto btn = Default_config[i].get_btn(CID_KEYBOARD);
 
 		if ((btn >= -1) && !Control_config[i].disabled) {
-			head.add_data(textify_scancode(btn));
+			head.add_data(textify_scancode_universal(btn));
 		}
 	}
 


### PR DESCRIPTION
Controls6 (PR #4133) changed `textify_scancode()` to be more l10n-aware, and added `textify_scancode_universal()` to continue serving the function of providing the values expected by scripts. Except there was one `textify_scancode()` call in the scripting system that wasn't changed, and it also wasn't used in FRED (for providing values for the `OPF_KEYPRESS` argument type, as used with `key-pressed`). This commit fixes both of these oversights, which *should* mean that all instances where a script or mission file needs to reference a keypress now use the same strings as before controls6.