### PR TITLE
Check for parse object before team color change

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11310,7 +11310,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	if (sip->uses_team_colors)
 	{
 		// wookieejedi - maintain team color setting if possible
-		if (!Fred_running && !p_objp->team_color_setting.empty()) {
+		if (!Fred_running && p_objp != nullptr && !p_objp->team_color_setting.empty()) {
 			sp->team_name = p_objp->team_color_setting;
 		} else {
 			sp->team_name = sip->default_team_name;


### PR DESCRIPTION
If there's an unchecked parse object access, blighted will find it.

For real though, I double checked the rest of the function there's no other unchecked accesses.