### PR TITLE
SCPUI needs to be able run game_close_level

### DIFF
--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1464,7 +1464,7 @@ ADE_FUNC(loadMission, l_Mission, "string missionName", "Loads a mission", "boole
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(unloadMission, l_Mission, "boolean forceUnload", "Stops the current mission and unloads it. If forceUnload is true "
+ADE_FUNC(unloadMission, l_Mission, "[boolean forceUnload]", "Stops the current mission and unloads it. If forceUnload is true "
 	"then the mission unload logic will run regardless of if a mission is loaded or not. Use with caution.", nullptr, nullptr)
 {
 	bool forceUnload = false;

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1464,11 +1464,13 @@ ADE_FUNC(loadMission, l_Mission, "string missionName", "Loads a mission", "boole
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(unloadMission, l_Mission, NULL, "Stops the current mission and unloads it", NULL, NULL)
+ADE_FUNC(unloadMission, l_Mission, "boolean forceUnload", "Stops the current mission and unloads it. If forceUnload is true "
+	"then the mission unload logic will run regardless of if a mission is loaded or not. Use with caution.", nullptr, nullptr)
 {
-	SCP_UNUSED(L); // unused parameter
+	bool forceUnload = false;
+	ade_get_args(L, "|b", &forceUnload);
 
-	if(Game_mode & GM_IN_MISSION)
+	if(forceUnload || Game_mode & GM_IN_MISSION)
 	{
 		game_level_close();
 		Game_mode &= ~GM_IN_MISSION;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5543,7 +5543,8 @@ void game_enter_state( int old_state, int new_state )
 	}
 
 	switch (new_state) {
-		case GS_STATE_MAIN_MENU:				
+		case GS_STATE_MAIN_MENU:			
+			game_start_time();
 			// in multiplayer mode, be sure that we are not doing networking anymore.
 			if ( Game_mode & GM_MULTIPLAYER ) {
 				Assert( Net_player != nullptr );

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5543,8 +5543,7 @@ void game_enter_state( int old_state, int new_state )
 	}
 
 	switch (new_state) {
-		case GS_STATE_MAIN_MENU:			
-			game_start_time();
+		case GS_STATE_MAIN_MENU:				
 			// in multiplayer mode, be sure that we are not doing networking anymore.
 			if ( Game_mode & GM_MULTIPLAYER ) {
 				Assert( Net_player != nullptr );


### PR DESCRIPTION
Fixes #4755 ~~by making sure the timer is not ever paused during a mainhall game state. We can't rely on UI-specific code to restart the timer after mission load if SCPUI is being used, so it should be done whenever the mainhall is entered probably. I didn't do a deep dive into the timer functions, so maybe there's a more appropriate fix elsewhere.~~

-by adding the ability to run `game_level_close()` from the scripting interface.