### PR TITLE
Ensure 'split ships' are team colored

### DIFF
--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1679,6 +1679,16 @@ void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_shi
 	render_info.set_replacement_textures(shipp->ship_replacement_textures);
 	render_info.set_object_number(shipp->objnum);
 
+	if (Ship_info[shipp->ship_info_index].uses_team_colors && !shipp->flags[Ship::Ship_Flags::Render_without_miscmap]) {
+		team_color model_team_color;
+
+		bool team_color_set = model_get_team_color(&model_team_color, shipp->team_name, shipp->secondary_team_name, shipp->team_change_timestamp, shipp->team_change_time);
+
+		if (team_color_set) {
+			render_info.set_team_color(model_team_color);
+		}
+	}
+
 	model_render_queue(&render_info, scene, pm->id, &half_ship->orient, &orig_ship_world_center);
 }
 


### PR DESCRIPTION
Apply team coloring to half-exploded ship halves as they are split.