### PR TITLE
add support for .vpc extension on VP archives

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -490,9 +490,9 @@ void cf_build_pack_list( cf_root *root )
 	int i;
 
 #ifdef _WIN32
-	const char *filter = "*.vp";
+	const SCP_vector<SCP_string> filters = { "*.vpc", "*.vp" };
 #else
-	const char *filter = "*.[vV][pP]";
+	const SCP_vector<SCP_string> filters = { "*.[vV][pP][cC]", "*.[vV][pP]" };
 #endif
 
 	// now just setup all the root info
@@ -513,7 +513,11 @@ void cf_build_pack_list( cf_root *root )
 
 		SCP_vector<_file_list_t> files;
 
-		if ( !cf_get_list_of_files(filespec, files, filter) ) {
+		for (auto &filter : filters) {
+			cf_get_list_of_files(filespec, files, filter.c_str());
+		}
+
+		if (files.empty()) {
 			continue;
 		}
 


### PR DESCRIPTION
.vpc is identical to existing .vp except that it is allowed to contain compressed files. This allows builds and tooling to know that although the archive itself is retail compatible, it's content may require special handling.

Simply rename your existing .vp to .vpc to indicate that it may use compressed files. Existing tools can be updated to be able to handle the compressed content within.

Although not recommended, the same archive can exist as both .vp and .vpc for maximum compatibility. Both archives will be indexed but the content of the .vpc will have priority.