### PR TITLE
Pass shortcut key character to Lua as a hook variable

### DIFF
--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -525,6 +525,9 @@ int popup_init(popup_info *pi, int flags)
 			}
 			button.addValue("Positivity", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), positivity));
 			button.addValue("Text", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), pi->button_text[cnt]));
+			//FSO currently uses the ASCII keycode for these shortcuts, so just convert that back to the key, package it, and send it to Lua
+			SCP_string thisKey(1, (char)pi->keypress[cnt]);
+			button.addValue("Shortcut", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), thisKey.c_str()));
 			buttons.addValue(cnt + 1, button);
 		}
 

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -337,8 +337,9 @@ const std::shared_ptr<OverridableHook<>> OnDialogInit = OverridableHook<>::Facto
 		{"Choices",
 			"table",
 			"A table containing the different choices for this dialog. Contains subtables, each consisting of "
-			"Positivity (an int, 0 if neutral, 1 if positive, and -1 if negative) and "
-			"Text (a string, the text of the button)."},
+			"Positivity (an int, 0 if neutral, 1 if positive, and -1 if negative), "
+			"Text (a string, the text of the button), and "
+			"Shorcut (a string, the keypress that should activate the choice or nil if no valid shortcut)."},
 		{"Title", "string", "The title of the popup window. Nil for a death popup."},
 		{"Text", "string", "The text to be displayed in the popup window. Nil for a death popup."},
 		{"IsTimeStopped", "boolean", "True if mission time was interrupted for this popup."},


### PR DESCRIPTION
Adds the keypress as a string to the On Dialog Init hook variables. Fixes #5048 .

Death popups don't seem to have a keyboard shortcut so it remains nil in that case.