### PR TITLE
Make sure all 4 in-game joystick options get evaluated

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -998,6 +998,9 @@ namespace joystick
 		{
 			// The new options system is in use
 			setPlayerJoystick(JoystickOption->getValue(), 0);
+			setPlayerJoystick(JoystickOption1->getValue(), 1);
+			setPlayerJoystick(JoystickOption2->getValue(), 2);
+			setPlayerJoystick(JoystickOption3->getValue(), 3);
 		}
 		else
 		{


### PR DESCRIPTION
If using the new options system, we need to evaluate all 4 joysticks, not just joy0.