### PR TITLE
restore retail behavior of chaining to repeating events

### DIFF
--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -917,7 +917,15 @@ void mission_process_event( int event )
 					}
 				}
 
-				if (!Mission_events[event - 1].result || !timestamp_elapsed(timestamp_delta(Mission_events[event - 1].timestamp, offset))) {
+				if (!Mission_events[event - 1].result) {
+					sindex = -1;  // bypass evaluation
+				}
+				// For compatibility reasons, simulate the old buggy behavior if we don't explicitly activate the bugfix.
+				// That is, if the timestamp has been set with an interval, always evaluate the event.
+				else if (!Fixed_chaining_to_repeat && Mission_events[event - 1].flags & MEF_TIMESTAMP_HAS_INTERVAL) {
+					/* do not bypass */;
+				}
+				else if (!timestamp_elapsed(timestamp_delta(Mission_events[event - 1].timestamp, offset))) {
 					sindex = -1;  // bypass evaluation
 				}
 			}

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -32,6 +32,7 @@ bool Fixed_missile_detonation;
 bool Damage_impacted_subsystem_first;
 bool Cutscene_camera_displays_hud;
 bool Alternate_chaining_behavior;
+bool Fixed_chaining_to_repeat;
 bool Use_host_orientation_for_set_camera_facing;
 bool Use_3d_ship_select;
 bool Use_3d_ship_icons;
@@ -361,6 +362,16 @@ void parse_mod_table(const char *filename)
 			}
 			else {
 				mprintf(("Game Settings Table: Using standard event chaining behavior\n"));
+			}
+		}
+
+		if (optional_string("$Fixed Chaining To Repeating Events:")) {
+			stuff_boolean(&Fixed_chaining_to_repeat);
+			if (Fixed_chaining_to_repeat) {
+				mprintf(("Game Settings Table: Using fixed chaining to repeating events\n"));
+			}
+			else {
+				mprintf(("Game Settings Table: Using retail chaining to repeating events\n"));
 			}
 		}
 
@@ -1177,6 +1188,7 @@ void mod_table_reset()
 	Damage_impacted_subsystem_first = false;
 	Cutscene_camera_displays_hud = false;
 	Alternate_chaining_behavior = false;
+	Fixed_chaining_to_repeat = false;
 	Use_host_orientation_for_set_camera_facing = false;
 	Default_ship_select_effect = 2;
 	Default_weapon_select_effect = 2;
@@ -1284,5 +1296,6 @@ void mod_table_set_version_flags()
 	}
 	if (mod_supports_version(23, 0, 0)) {
 		Shockwaves_inherit_parent_damage_type = true;	// people intuitively expect shockwaves to default to the damage type of the weapon that spawned them
+		Fixed_chaining_to_repeat = true;
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -27,6 +27,7 @@ extern bool Fixed_missile_detonation;
 extern bool Damage_impacted_subsystem_first;
 extern bool Cutscene_camera_displays_hud;
 extern bool Alternate_chaining_behavior;
+extern bool Fixed_chaining_to_repeat;
 extern bool Use_host_orientation_for_set_camera_facing;
 extern bool Use_3d_ship_select;
 extern int Default_ship_select_effect;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17126,7 +17126,10 @@ int sexp_event_delay_status( int n, int want_true, bool use_msecs = false)
 			}
 
 			// check that the event delay has elapsed, again using the same logic as in mission_process_event()
-			if (!timestamp_elapsed(timestamp_delta(Mission_events[i].timestamp, delay))) {
+			if (!Fixed_chaining_to_repeat && Mission_events[i].flags & MEF_TIMESTAMP_HAS_INTERVAL) {
+				/* do not set rval */;
+			}
+			else if (!timestamp_elapsed(timestamp_delta(Mission_events[i].timestamp, delay))) {
 				rval = SEXP_FALSE;
 				break;
 			}


### PR DESCRIPTION
To avoid changing behavior of existing mods, simulate the retail behavior unless the bugfix is explicitly activated.  The buggy retail behavior is to evaluate a chained event, not skip it, if the event is repeating, regardless of whether the repeat timestamp has elapsed.

"Fixes" #5005.