### PR TITLE
Warn dogfight weapons

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3955,13 +3955,16 @@ int CFred_mission_save::save_players()
 				fout("\t@%s\t", Sexp_variables[var_idx].variable_name);
 			} else {
 				fout("\t\"%s\"\t", Ship_info[Team_data[i].ship_list[j]].name);
-				// Check the weapons pool for at least one dogfight weapon for this ship type
-				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
-					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] & DOGFIGHT_WEAPON) {
-						num_dogfight_weapons++;
-						break;
-					}
 
+				// Check the weapons pool for at least one dogfight weapon for this ship type
+				if (IS_MISSION_MULTI_DOGFIGHT) {
+					for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
+						if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] &
+							DOGFIGHT_WEAPON) {
+							num_dogfight_weapons++;
+							break;
+						}
+					}
 				}
 			}
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3985,7 +3985,7 @@ int CFred_mission_save::save_players()
 		// make sure we have at least one dogfight weapon for each ship type in a dogfight mission
 		if (IS_MISSION_MULTI_DOGFIGHT && (num_dogfight_weapons != Team_data[i].num_ship_choices)) {
 			MessageBox(nullptr,
-				"Warning: This mission is a dogfight mission but no dogfight weapons are available in the loadout!", "No dogfight weapons",
+				"Warning: This mission is a dogfight mission but no dogfight weapons are available for at least one ship in the loadout!", "No dogfight weapons",
 				MB_OK);
 		}
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3945,6 +3945,8 @@ int CFred_mission_save::save_players()
 		fout(" (\n");
 
 		int num_dogfight_weapons = 0;
+		SCP_vector<SCP_string> dogfight_ships;
+
 		for (j = 0; j < Team_data[i].num_ship_choices; j++) {
 			// Check to see if a variable name should be written for the class rather than a number
 			if (strlen(Team_data[i].ship_list_variables[j])) {
@@ -3971,10 +3973,11 @@ int CFred_mission_save::save_players()
 			// Check the weapons pool for at least one dogfight weapon for this ship type
 			if (IS_MISSION_MULTI_DOGFIGHT) {
 				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
-					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] &
-						DOGFIGHT_WEAPON) {
+					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] & DOGFIGHT_WEAPON) {
 						num_dogfight_weapons++;
 						break;
+					} else {
+						dogfight_ships.push_back(Ship_info[Team_data[i].ship_list[j]].name);
 					}
 				}
 			}
@@ -3984,8 +3987,13 @@ int CFred_mission_save::save_players()
 
 		// make sure we have at least one dogfight weapon for each ship type in a dogfight mission
 		if (IS_MISSION_MULTI_DOGFIGHT && (num_dogfight_weapons != Team_data[i].num_ship_choices)) {
+			for (int numErrors = 0; numErrors < (int)dogfight_ships.size(); numErrors++) {
+				mprintf(("Warning: Ship %s has no dogfight weapons allowed\n", dogfight_ships[numErrors].c_str()));
+			}
 			MessageBox(nullptr,
-				"Warning: This mission is a dogfight mission but no dogfight weapons are available for at least one ship in the loadout!", "No dogfight weapons",
+				"Warning: This mission is a dogfight mission but no dogfight weapons are available for at least one "
+				"ship in the loadout! In Debug mode a list of ships will be printed to the log.",
+				"No dogfight weapons",
 				MB_OK);
 		}
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3955,17 +3955,6 @@ int CFred_mission_save::save_players()
 				fout("\t@%s\t", Sexp_variables[var_idx].variable_name);
 			} else {
 				fout("\t\"%s\"\t", Ship_info[Team_data[i].ship_list[j]].name);
-
-				// Check the weapons pool for at least one dogfight weapon for this ship type
-				if (IS_MISSION_MULTI_DOGFIGHT) {
-					for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
-						if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] &
-							DOGFIGHT_WEAPON) {
-							num_dogfight_weapons++;
-							break;
-						}
-					}
-				}
 			}
 
 			// Now check if we should write a variable or a number for the amount of ships available
@@ -3977,6 +3966,17 @@ int CFred_mission_save::save_players()
 				fout("@%s\n", Sexp_variables[var_idx].variable_name);
 			} else {
 				fout("%d\n", Team_data[i].ship_count[j]);
+			}
+
+			// Check the weapons pool for at least one dogfight weapon for this ship type
+			if (IS_MISSION_MULTI_DOGFIGHT) {
+				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
+					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] &
+						DOGFIGHT_WEAPON) {
+						num_dogfight_weapons++;
+						break;
+					}
+				}
 			}
 		}
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3972,7 +3972,7 @@ int CFred_mission_save::save_players()
 
 			// Check the weapons pool for at least one dogfight weapon for this ship type
 			if (IS_MISSION_MULTI_DOGFIGHT) {
-				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
+				for (int wepCount = 0; wepCount < Team_data[i].num_weapon_choices; wepCount++) {
 					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] & DOGFIGHT_WEAPON) {
 						num_dogfight_weapons++;
 						break;

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3944,6 +3944,7 @@ int CFred_mission_save::save_players()
 		parse_comments();
 		fout(" (\n");
 
+		int num_dogfight_weapons = 0;
 		for (j = 0; j < Team_data[i].num_ship_choices; j++) {
 			// Check to see if a variable name should be written for the class rather than a number
 			if (strlen(Team_data[i].ship_list_variables[j])) {
@@ -3954,6 +3955,14 @@ int CFred_mission_save::save_players()
 				fout("\t@%s\t", Sexp_variables[var_idx].variable_name);
 			} else {
 				fout("\t\"%s\"\t", Ship_info[Team_data[i].ship_list[j]].name);
+				// Check the weapons pool for at least one dogfight weapon for this ship type
+				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
+					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] & DOGFIGHT_WEAPON) {
+						num_dogfight_weapons++;
+						break;
+					}
+
+				}
 			}
 
 			// Now check if we should write a variable or a number for the amount of ships available
@@ -3969,6 +3978,13 @@ int CFred_mission_save::save_players()
 		}
 
 		fout(")");
+
+		// make sure we have at least one dogfight weapon for each ship type in a dogfight mission
+		if (IS_MISSION_MULTI_DOGFIGHT && (num_dogfight_weapons != Team_data[i].num_ship_choices)) {
+			MessageBox(nullptr,
+				"Warning: This mission is a dogfight mission but no dogfight weapons are available in the loadout!", "No dogfight weapons",
+				MB_OK);
+		}
 
 		if (optional_string_fred("+Weaponry Pool:", "$Starting Shipname:")) {
 			parse_comments(2);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3775,7 +3775,7 @@ int CFred_mission_save::save_players()
 
 			// Check the weapons pool for at least one dogfight weapon for this ship type
 			if (IS_MISSION_MULTI_DOGFIGHT) {
-				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
+				for (int wepCount = 0; wepCount < Team_data[i].num_weapon_choices; wepCount++) {
 					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] & DOGFIGHT_WEAPON) {
 						num_dogfight_weapons++;
 						break;

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3747,6 +3747,7 @@ int CFred_mission_save::save_players()
 		parse_comments();
 		fout(" (\n");
 
+		int num_dogfight_weapons = 0;
 		for (j = 0; j < Team_data[i].num_ship_choices; j++) {
 			// Check to see if a variable name should be written for the class rather than a number
 			if (strlen(Team_data[i].ship_list_variables[j])) {
@@ -3757,6 +3758,14 @@ int CFred_mission_save::save_players()
 				fout("\t@%s\t", Sexp_variables[var_idx].variable_name);
 			} else {
 				fout("\t\"%s\"\t", Ship_info[Team_data[i].ship_list[j]].name);
+				// Check the weapons pool for at least one dogfight weapon for this ship type
+				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
+					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] & DOGFIGHT_WEAPON) {
+						num_dogfight_weapons++;
+						break;
+					}
+
+				}
 			}
 
 			// Now check if we should write a variable or a number for the amount of ships available
@@ -3772,6 +3781,13 @@ int CFred_mission_save::save_players()
 		}
 
 		fout(")");
+
+		// make sure we have at least one dogfight weapon for each ship type in a dogfight mission
+		if (IS_MISSION_MULTI_DOGFIGHT && (num_dogfight_weapons != Team_data[i].num_ship_choices)) {
+			MessageBox(nullptr,
+				"Warning: This mission is a dogfight mission but no dogfight weapons are available in the loadout!", "No dogfight weapons",
+				MB_OK);
+		}
 
 		if (optional_string_fred("+Weaponry Pool:", "$Starting Shipname:")) {
 			parse_comments(2);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3758,17 +3758,6 @@ int CFred_mission_save::save_players()
 				fout("\t@%s\t", Sexp_variables[var_idx].variable_name);
 			} else {
 				fout("\t\"%s\"\t", Ship_info[Team_data[i].ship_list[j]].name);
-
-				// Check the weapons pool for at least one dogfight weapon for this ship type
-				if (IS_MISSION_MULTI_DOGFIGHT) {
-					for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
-						if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] &
-							DOGFIGHT_WEAPON) {
-							num_dogfight_weapons++;
-							break;
-						}
-					}
-				}
 			}
 
 			// Now check if we should write a variable or a number for the amount of ships available
@@ -3780,6 +3769,17 @@ int CFred_mission_save::save_players()
 				fout("@%s\n", Sexp_variables[var_idx].variable_name);
 			} else {
 				fout("%d\n", Team_data[i].ship_count[j]);
+			}
+
+			// Check the weapons pool for at least one dogfight weapon for this ship type
+			if (IS_MISSION_MULTI_DOGFIGHT) {
+				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
+					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] &
+						DOGFIGHT_WEAPON) {
+						num_dogfight_weapons++;
+						break;
+					}
+				}
 			}
 		}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3748,6 +3748,8 @@ int CFred_mission_save::save_players()
 		fout(" (\n");
 
 		int num_dogfight_weapons = 0;
+		SCP_vector<SCP_string> dogfight_ships;
+
 		for (j = 0; j < Team_data[i].num_ship_choices; j++) {
 			// Check to see if a variable name should be written for the class rather than a number
 			if (strlen(Team_data[i].ship_list_variables[j])) {
@@ -3774,10 +3776,11 @@ int CFred_mission_save::save_players()
 			// Check the weapons pool for at least one dogfight weapon for this ship type
 			if (IS_MISSION_MULTI_DOGFIGHT) {
 				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
-					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] &
-						DOGFIGHT_WEAPON) {
+					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] & DOGFIGHT_WEAPON) {
 						num_dogfight_weapons++;
 						break;
+					} else {
+						dogfight_ships.push_back(Ship_info[Team_data[i].ship_list[j]].name);
 					}
 				}
 			}
@@ -3787,8 +3790,13 @@ int CFred_mission_save::save_players()
 
 		// make sure we have at least one dogfight weapon for each ship type in a dogfight mission
 		if (IS_MISSION_MULTI_DOGFIGHT && (num_dogfight_weapons != Team_data[i].num_ship_choices)) {
+			for (int numErrors = 0; numErrors < (int)dogfight_ships.size(); numErrors++) {
+				mprintf(("Warning: Ship %s has no dogfight weapons allowed\n", dogfight_ships[numErrors].c_str()));
+			}
 			MessageBox(nullptr,
-				"Warning: This mission is a dogfight mission but no dogfight weapons are available for at least one ship in the loadout!", "No dogfight weapons",
+				"Warning: This mission is a dogfight mission but no dogfight weapons are available for at least one "
+				"ship in the loadout! In Debug mode a list of ships will be printed to the log.",
+				"No dogfight weapons",
 				MB_OK);
 		}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3758,13 +3758,16 @@ int CFred_mission_save::save_players()
 				fout("\t@%s\t", Sexp_variables[var_idx].variable_name);
 			} else {
 				fout("\t\"%s\"\t", Ship_info[Team_data[i].ship_list[j]].name);
-				// Check the weapons pool for at least one dogfight weapon for this ship type
-				for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
-					if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] & DOGFIGHT_WEAPON) {
-						num_dogfight_weapons++;
-						break;
-					}
 
+				// Check the weapons pool for at least one dogfight weapon for this ship type
+				if (IS_MISSION_MULTI_DOGFIGHT) {
+					for (int wepCount = 0; wepCount <= Team_data[i].num_weapon_choices; wepCount++) {
+						if (Ship_info[Team_data[i].ship_list[j]].allowed_weapons[Team_data[i].weaponry_pool[wepCount]] &
+							DOGFIGHT_WEAPON) {
+							num_dogfight_weapons++;
+							break;
+						}
+					}
 				}
 			}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3788,7 +3788,7 @@ int CFred_mission_save::save_players()
 		// make sure we have at least one dogfight weapon for each ship type in a dogfight mission
 		if (IS_MISSION_MULTI_DOGFIGHT && (num_dogfight_weapons != Team_data[i].num_ship_choices)) {
 			MessageBox(nullptr,
-				"Warning: This mission is a dogfight mission but no dogfight weapons are available in the loadout!", "No dogfight weapons",
+				"Warning: This mission is a dogfight mission but no dogfight weapons are available for at least one ship in the loadout!", "No dogfight weapons",
 				MB_OK);
 		}
 


### PR DESCRIPTION
Fixes #3100 and Mantis 2107 by doing a quick check for dogfight weapons for each ship in the loadout if the mission is a dogfight mission. If not at least one weapon for each ship type then show a warning.