### PR TITLE
Disallow overly large input in FRED Orientation Editor

### DIFF
--- a/fred2/orienteditor.cpp
+++ b/fred2/orienteditor.cpp
@@ -411,6 +411,11 @@ float orient_editor::convert(const CString &str) const
 		val = (float)INT_MAX;
 	}
 
+	// disallow input smaller than INT_MIN
+	if (val < (float)INT_MIN) {
+		val = (float)INT_MIN;
+	}
+
 	return val;
 }
 

--- a/fred2/orienteditor.cpp
+++ b/fred2/orienteditor.cpp
@@ -403,7 +403,15 @@ float orient_editor::convert(const CString &str) const
 			buf[j++] = buf[i];
 
 	buf[j] = 0;
-	return (float) atof(buf);
+
+	float val = (float)atof(buf);
+
+	// disallow input larger than INT_MAX
+	if (val > (float)INT_MAX) {
+		val = (float)INT_MAX;
+	}
+
+	return val;
 }
 
 /**


### PR DESCRIPTION
Fixes #4564 by limiting input to `INT_MAX` whenever we're converting the string to a float. qtFRED limits input while typing, so this fix isn't needed there.