### PR TITLE
Make sexp node comments more visible at a glance

### DIFF
--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -4791,7 +4791,9 @@ void sexp_tree::update_help(HTREEITEM h)
 	SCP_string nodeComment;
 
 	if (thisIndex >= 0) {
-		nodeComment = "Node Comments:\r\n   " + Event_annotations[thisIndex].comment;
+		if (!Event_annotations[thisIndex].comment.empty()) {
+			nodeComment = "Node Comments:\r\n   " + Event_annotations[thisIndex].comment;
+		}
 	} else {
 		nodeComment = "";
 	}
@@ -4802,6 +4804,11 @@ void sexp_tree::update_help(HTREEITEM h)
 			mini_help_box->SetWindowText("");
 		return;
 	}
+
+	// Now that we're done with top level nodes we can add the empty lines because
+	// everything else below is supposed to have help text
+	if (!nodeComment.empty())
+		nodeComment.insert(0, "\r\n\r\n");
 
 	if (SEXPT_TYPE(tree_nodes[i].type) == SEXPT_OPERATOR)
 	{
@@ -4912,8 +4919,8 @@ void sexp_tree::update_help(HTREEITEM h)
 			if (query_operator_argument_type(index, c) == OPF_MESSAGE) {
 				for (j=0; j<Num_messages; j++)
 					if (!stricmp(Messages[j].name, tree_nodes[i].text)) {
-						text.Format("Message Text:\r\n%s\r\n\r\n%s", Messages[j].message, nodeComment.c_str());
-						help_box->SetWindowText(text);
+						text.Format("Message Text:\r\n%s%s", Messages[j].message, nodeComment.c_str());
+						help_box->SetWindowText((LPCSTR)text);
 						return;
 					}
 			}
@@ -4925,12 +4932,12 @@ void sexp_tree::update_help(HTREEITEM h)
 	code = get_operator_const(tree_nodes[i].text);
 	auto str = help(code);
 	if (!str) {
-		text.Format("No help available\r\n\r\n%s", nodeComment.c_str());
+		text.Format("No help available%s", nodeComment.c_str());
 	} else {
-		text.Format("%s\r\n\r\n%s", str, nodeComment.c_str());
+		text.Format("%s%s", str, nodeComment.c_str());
 	}
 
-	help_box->SetWindowText(text);
+	help_box->SetWindowText((LPCSTR)text);
 }
 
 // find list of sexp_tree nodes with text

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -4762,7 +4762,6 @@ int sexp_tree::get_type(HTREEITEM h)
 
 void sexp_tree::update_help(HTREEITEM h)
 {
-	const char *str;
 	int i, j, z, c, code, index, sibling_place;
 	CString text;
 
@@ -4788,8 +4787,17 @@ void sexp_tree::update_help(HTREEITEM h)
 		if (tree_nodes[i].handle == h)
 			break;
 
+	int thisIndex = event_annotation_lookup(h);
+	SCP_string nodeComment;
+
+	if (thisIndex >= 0) {
+		nodeComment = "Node Comments:\r\n   " + Event_annotations[thisIndex].comment;
+	} else {
+		nodeComment = "";
+	}
+
 	if ((i >= (int)tree_nodes.size()) || !tree_nodes[i].type) {
-		help_box->SetWindowText("");
+		help_box->SetWindowText(nodeComment.c_str());
 		if (mini_help_box)
 			mini_help_box->SetWindowText("");
 		return;
@@ -4904,7 +4912,7 @@ void sexp_tree::update_help(HTREEITEM h)
 			if (query_operator_argument_type(index, c) == OPF_MESSAGE) {
 				for (j=0; j<Num_messages; j++)
 					if (!stricmp(Messages[j].name, tree_nodes[i].text)) {
-						text.Format("Message Text:\r\n%s", Messages[j].message);
+						text.Format("Message Text:\r\n%s\r\n\r\n%s", Messages[j].message, nodeComment.c_str());
 						help_box->SetWindowText(text);
 						return;
 					}
@@ -4915,11 +4923,14 @@ void sexp_tree::update_help(HTREEITEM h)
 	}
 
 	code = get_operator_const(tree_nodes[i].text);
-	str = help(code);
-	if (!str)
-		str = "No help available";
+	auto str = help(code);
+	if (!str) {
+		text.Format("No help available\r\n\r\n%s", nodeComment.c_str());
+	} else {
+		text.Format("%s\r\n\r\n%s", str, nodeComment.c_str());
+	}
 
-	help_box->SetWindowText(str);
+	help_box->SetWindowText(text);
 }
 
 // find list of sexp_tree nodes with text

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -2756,7 +2756,9 @@ void sexp_tree::update_help(QTreeWidgetItem* h) {
 	SCP_string nodeComment;
 
 	//if (thisIndex >= 0) {
-		//nodeComment = "Node Comments:\r\n   " + Event_annotations[thisIndex].comment;
+		//if (!Event_annotations[thisIndex].comment.empty()) {
+			//nodeComment = "Node Comments:\r\n   " + Event_annotations[thisIndex].comment;
+		//}
 	//} else {
 		nodeComment = "";
 	//}
@@ -2766,6 +2768,11 @@ void sexp_tree::update_help(QTreeWidgetItem* h) {
 		miniHelpChanged("");
 		return;
 	}
+
+	// Now that we're done with top level nodes we can add the empty lines because
+	// everything else below is supposed to have help text
+	if (!nodeComment.empty())
+		nodeComment.insert(0, "\r\n\r\n");
 
 	if (SEXPT_TYPE(tree_nodes[i].type) == SEXPT_OPERATOR) {
 		miniHelpChanged("");
@@ -2860,7 +2867,7 @@ void sexp_tree::update_help(QTreeWidgetItem* h) {
 			if (query_operator_argument_type(index, c) == OPF_MESSAGE) {
 				for (j = 0; j < Num_messages; j++) {
 					if (!stricmp(Messages[j].name, tree_nodes[i].text)) {
-						auto text = QString("Message Text:\n%1\r\n\r\n%2").arg(Messages[j].message, nodeComment.c_str());
+						auto text = QString("Message Text:\n%1%2").arg(Messages[j].message, nodeComment.c_str());
 						helpChanged(text);
 						return;
 					}
@@ -2875,9 +2882,9 @@ void sexp_tree::update_help(QTreeWidgetItem* h) {
 	auto str = help(code);
 	QString text;
 	if (!str) {
-		text = QString("No help available\r\n\r\n%1").arg(nodeComment.c_str());
+		text = QString("No help available%1").arg(nodeComment.c_str());
 	} else {
-		text = QString("%1\r\n\r\n%2").arg(str, nodeComment.c_str());
+		text = QString("%1%2").arg(str, nodeComment.c_str());
 	}
 
 	helpChanged(text);

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -2749,8 +2749,20 @@ void sexp_tree::update_help(QTreeWidgetItem* h) {
 		}
 	}
 
+	// Node comments are not yet implemented in qtFRED, so just adding some base code here
+	// that can be used when the feature is completed - Mjn
+
+	//int thisIndex = event_annotation_lookup(h);
+	SCP_string nodeComment;
+
+	//if (thisIndex >= 0) {
+		//nodeComment = "Node Comments:\r\n   " + Event_annotations[thisIndex].comment;
+	//} else {
+		nodeComment = "";
+	//}
+
 	if ((i >= (int) tree_nodes.size()) || !tree_nodes[i].type) {
-		helpChanged("");
+		helpChanged(nodeComment.c_str());
 		miniHelpChanged("");
 		return;
 	}
@@ -2848,7 +2860,7 @@ void sexp_tree::update_help(QTreeWidgetItem* h) {
 			if (query_operator_argument_type(index, c) == OPF_MESSAGE) {
 				for (j = 0; j < Num_messages; j++) {
 					if (!stricmp(Messages[j].name, tree_nodes[i].text)) {
-						auto text = QString("Message Text:\n%1").arg(Messages[j].message);
+						auto text = QString("Message Text:\n%1\r\n\r\n%2").arg(Messages[j].message, nodeComment.c_str());
 						helpChanged(text);
 						return;
 					}
@@ -2861,11 +2873,14 @@ void sexp_tree::update_help(QTreeWidgetItem* h) {
 
 	code = get_operator_const(tree_nodes[i].text);
 	auto str = help(code);
+	QString text;
 	if (!str) {
-		str = "No help available";
+		text = QString("No help available\r\n\r\n%1").arg(nodeComment.c_str());
+	} else {
+		text = QString("%1\r\n\r\n%2").arg(str, nodeComment.c_str());
 	}
 
-	helpChanged(QString::fromUtf8(str));
+	helpChanged(text);
 }
 
 // find list of sexp_tree nodes with text


### PR DESCRIPTION
An idea came up during a BtA team FREDing session to make node comments in the event editor more visible by including them in the help text box. This PR implements the feature. For root "Event" nodes it will display any comments instead of being blank. For Messages and Sexps any comments will be appended to the message text or sexp help.

qtFRED does not yet have support for node comments, so the base code is added where it should be, but commented out until Goober finishes porting the feature.