### PR TITLE
Fix some issues with damage application

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -150,6 +150,7 @@ namespace AI {
 		Fixed_removing_play_dead_order,
 		Disable_bay_emerge_timeout,
 		Adjusted_AI_class_autoscale,
+		Carry_shield_difficulty_scaling_bug,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -772,7 +772,8 @@ void ai_profile_t::reset()
 	if (mod_supports_version(3, 6, 10)) {
 		flags.set(AI::Profile_Flags::Reset_last_hit_target_time_for_player_hits);
 	}
-	if (mod_supports_version(3, 6, 14)) {
+	// backwards compatible flag for a bug accidentally introduced during this time
+	if (mod_supports_version(3, 6, 14) && !mod_supports_version(23, 0, 0)) {
 		flags.set(AI::Profile_Flags::Carry_shield_difficulty_scaling_bug);
 	}
 	if (mod_supports_version(21, 4, 0)) {

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -610,6 +610,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$use adjusted AI class autoscale:", AI::Profile_Flags::Adjusted_AI_class_autoscale);
 
+				set_flag(profile, "$carry shield difficulty scaling bug:", AI::Profile_Flags::Carry_shield_difficulty_scaling_bug);
+
 
 				// if we've been through once already and are at the same place, force a move
 				if (saved_Mp && (saved_Mp == Mp))
@@ -769,6 +771,9 @@ void ai_profile_t::reset()
 	// and this flag has been enabled ever since 3.6.10
 	if (mod_supports_version(3, 6, 10)) {
 		flags.set(AI::Profile_Flags::Reset_last_hit_target_time_for_player_hits);
+	}
+	if (mod_supports_version(3, 6, 14)) {
+		flags.set(AI::Profile_Flags::Carry_shield_difficulty_scaling_bug);
 	}
 	if (mod_supports_version(21, 4, 0)) {
 		flags.set(AI::Profile_Flags::Fixed_ship_weapon_collision);

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -773,7 +773,7 @@ void ai_profile_t::reset()
 		flags.set(AI::Profile_Flags::Reset_last_hit_target_time_for_player_hits);
 	}
 	// backwards compatible flag for a bug accidentally introduced during this time
-	if (mod_supports_version(3, 6, 14) && !mod_supports_version(23, 0, 0)) {
+	if (mod_supports_version(3, 6, 14) && !mod_supports_version(23, 1, 0)) {
 		flags.set(AI::Profile_Flags::Carry_shield_difficulty_scaling_bug);
 	}
 	if (mod_supports_version(21, 4, 0)) {

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2382,7 +2382,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 			}
 
 			float shield_factor = 1.0f;
-			if (weapon_info_index > 0 )
+			if (weapon_info_index >= 0 )
 				shield_factor = Weapon_info[weapon_info_index].shield_factor;
 
 			// apply shield damage


### PR DESCRIPTION
Poor Nuke was clearly aware of the risk of accidentally applying player damage difficulty scaling more than once, but alas, that's what's happened.

The code is really pointlessly confusing (which may have contributed to the bug being written), so I've tried to give it a good makeover and comment more. 

The main issue is that shockwaves and area blasts will erroneously always report as having hit the shield, usually not a big deal, it checks the shield is empty, so in essence all of the damage overflows to the hull anyway. However, damage difficulty scaling *is* applied to the damage before being passed to the hull damage calculation, where it gets applied *again*, squaring the scale factor and possibly greatly changing the damage in effect. So, unless the backwards compatible flag is checked, remove difficulty scaling from the 'overflow' damage.