### PR TITLE
Possible fix for weapon fired hook conditions

### DIFF
--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -273,6 +273,7 @@ const std::shared_ptr<Hook<WeaponUsedConditions>> OnPrimaryFired = Hook<WeaponUs
 	{
 		{"User", "ship", "The ship that has fired the weapon."},
 		{"Target", "object", "The current target of this ship."},
+		{"BankIndex", "number", "The index of the bank that has fired."},
 	});
 
 const std::shared_ptr<Hook<WeaponUsedConditions>> OnSecondaryFired = Hook<WeaponUsedConditions>::Factory("On Secondary Fire",

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -265,6 +265,7 @@ const std::shared_ptr<Hook<WeaponUsedConditions>> OnWeaponFired = Hook<WeaponUse
 	{
 		{"User", "ship", "The ship that has fired the weapon."},
 		{"Target", "object", "The current target of this ship."},
+		{"BankIndex", "number", "The index of the bank that has fired."},
 	});
 
 const std::shared_ptr<Hook<WeaponUsedConditions>> OnPrimaryFired = Hook<WeaponUsedConditions>::Factory("On Primary Fire",

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12540,19 +12540,19 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			target = &Objects[Player_ai->target_objnum]; 
 
 		for (int bank = 0; bank < MAX_SHIP_PRIMARY_BANKS; bank++) {
-			if(banks_fired & (1 << bank))
+			if(banks_fired & (1 << bank)){
 				//Start Animation in Forced mode: Always restart it from its initial position rather than just flip it to FWD motion if it was still moving. This is to make it work best for uses like recoil.
 				sip->animations.getAll(model_get_instance(shipp->model_instance_num), animation::ModelAnimationTriggerType::PrimaryFired, bank).start(animation::ModelAnimationDirection::FWD, true);
-		}
 
-		if (scripting::hooks::OnWeaponFired->isActive() || scripting::hooks::OnPrimaryFired->isActive()) {
-			auto param_list = scripting::hook_param_list(
-				scripting::hook_param("User", 'o', objp),
-				scripting::hook_param("Target", 'o', target)
-			);
-			auto conditions = scripting::hooks::WeaponUsedConditions{ shipp, target, weapon_idx, true };
-			scripting::hooks::OnWeaponFired->run(conditions, param_list);
-			scripting::hooks::OnPrimaryFired->run(conditions, param_list);
+				//Run scripting hooks only if the actual bank has fired
+				if (scripting::hooks::OnWeaponFired->isActive() || scripting::hooks::OnPrimaryFired->isActive()) {
+					auto param_list = scripting::hook_param_list(scripting::hook_param("User", 'o', objp),
+						scripting::hook_param("Target", 'o', target));
+					auto conditions = scripting::hooks::WeaponUsedConditions{shipp, target, shipp->weapons.primary_bank_weapons[bank], true};
+					scripting::hooks::OnWeaponFired->run(conditions, param_list);
+					scripting::hooks::OnPrimaryFired->run(conditions, param_list);
+				}
+			}
 		}
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12549,7 +12549,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					auto param_list = scripting::hook_param_list(
 						scripting::hook_param("User", 'o', objp),
 						scripting::hook_param("Target", 'o', target),
-						scripting::hook_param("BankIndex", 'i', bank));
+						scripting::hook_param("BankIndex", 'i', bank + 1));
 					auto conditions = scripting::hooks::WeaponUsedConditions{shipp, target, shipp->weapons.primary_bank_weapons[bank], true};
 					scripting::hooks::OnWeaponFired->run(conditions, param_list);
 					scripting::hooks::OnPrimaryFired->run(conditions, param_list);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12546,8 +12546,10 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 				//Run scripting hooks only if the actual bank has fired
 				if (scripting::hooks::OnWeaponFired->isActive() || scripting::hooks::OnPrimaryFired->isActive()) {
-					auto param_list = scripting::hook_param_list(scripting::hook_param("User", 'o', objp),
-						scripting::hook_param("Target", 'o', target));
+					auto param_list = scripting::hook_param_list(
+						scripting::hook_param("User", 'o', objp),
+						scripting::hook_param("Target", 'o', target),
+						scripting::hook_param("BankIndex", 'i', bank));
 					auto conditions = scripting::hooks::WeaponUsedConditions{shipp, target, shipp->weapons.primary_bank_weapons[bank], true};
 					scripting::hooks::OnWeaponFired->run(conditions, param_list);
 					scripting::hooks::OnPrimaryFired->run(conditions, param_list);


### PR DESCRIPTION
Moves the `OnWeaponFired` and `OnPrimaryFired` hooks up into the loop that checks which banks have actually fired a weapon which fixes #5080 . The issue is that `weapon_idx` doesn't always refer the weapon that was fired. Instead it refers to the weapon that tried to fire. In the case of 5080, this included the Ammo Pack if the player was set to Linked Primary Mode. The Ammo Pack is set to No Linked Primaries so the code above here exits early and doesn't fire the weapon. But for the scripting hooks, that's too late because `weapon_idx` has already been changed to refer to the Ammo Pack.

With this PR fix we can pass the weapon of the bank that actually fired to the hook. This also means that the hook will fire once for each bank, though. I _think_ that's actually preferred because it'd be more accurate but I'm unsure. It's early and I didn't sleep great so I'm probably missing some other unintended effect that may have.