### PR TITLE
SCPUI methods required for handling closeup briefing icon stuff

### DIFF
--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -307,7 +307,7 @@ int Brief_max_line_width[GR_NUM_RESOLUTIONS] = {
 // --------------------------------------------------------------------------------------
 // Forward declarations
 // --------------------------------------------------------------------------------------
-int brief_setup_closeup(brief_icon *bi);
+int brief_setup_closeup(brief_icon *bi, bool api_access = false);
 void brief_maybe_blit_scene_cut(float frametime);
 void brief_transition_reset();
 
@@ -1305,7 +1305,7 @@ void brief_set_closeup_pos(brief_icon * /*bi*/)
 //
 // exit: 0	=>		set-up icon sucessfully
 //			-1	=>		could not setup closeup icon
-int brief_setup_closeup(brief_icon *bi)
+int brief_setup_closeup(brief_icon *bi, bool api_access)
 {
 	char				pof_filename[NAME_LENGTH];
 	ship_info		*sip=NULL;
@@ -1378,27 +1378,29 @@ int brief_setup_closeup(brief_icon *bi)
 		break;
 	}
 	
-	if ( Closeup_icon->modelnum < 0 ) {
-		if ( sip == nullptr ) {
-			Closeup_icon->modelnum = model_load(pof_filename, 0, nullptr);
-		} else {
-			Closeup_icon->modelnum = model_load(sip, true);
-			Closeup_icon->model_instance_num = model_create_instance(-1, Closeup_icon->modelnum);
-			model_set_up_techroom_instance(sip, Closeup_icon->model_instance_num);
+	if (!api_access) {
+		if (Closeup_icon->modelnum < 0) {
+			if (sip == nullptr) {
+				Closeup_icon->modelnum = model_load(pof_filename, 0, nullptr);
+			} else {
+				Closeup_icon->modelnum = model_load(sip, true);
+				Closeup_icon->model_instance_num = model_create_instance(-1, Closeup_icon->modelnum);
+				model_set_up_techroom_instance(sip, Closeup_icon->model_instance_num);
+			}
 		}
-	}
 
-	if ( Closeup_icon->modelnum >= 0 ) {
-		Closeup_icon->radius = model_get_radius(Closeup_icon->modelnum);
-	}
+		if (Closeup_icon->modelnum >= 0) {
+			Closeup_icon->radius = model_get_radius(Closeup_icon->modelnum);
+		}
 
-	vm_set_identity(&Closeup_orient);
-	vm_vec_make(&tvec, 0.0f, 0.0f, -1.0f);
-	Closeup_orient.vec.fvec = tvec;
-	vm_vec_zero(&Closeup_pos);
-	Closeup_angles.p  = 0.0f;
-	Closeup_angles.b  = 0.0f;
-	Closeup_angles.h  = PI;
+		vm_set_identity(&Closeup_orient);
+		vm_vec_make(&tvec, 0.0f, 0.0f, -1.0f);
+		Closeup_orient.vec.fvec = tvec;
+		vm_vec_zero(&Closeup_pos);
+		Closeup_angles.p = 0.0f;
+		Closeup_angles.b = 0.0f;
+		Closeup_angles.h = PI;
+	}
 
 	brief_set_closeup_pos(bi);
 
@@ -1513,7 +1515,7 @@ void brief_check_for_anim(bool api_access, int api_x, int api_y)
 		return;
 	}
 
-	if (brief_setup_closeup(bi) == 0) {
+	if (brief_setup_closeup(bi, api_access) == 0) {
 		if (!api_access) {
 			gamesnd_play_iface(InterfaceSounds::BRIEF_ICON_SELECT);
 		}

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1900,12 +1900,6 @@ void brief_do_frame(float frametime)
 void brief_api_do_frame(float frametime)
 {
 
-	// This may be needed by a future PR to get map icon clicking working through the API - Mjn
-	// if (Closeup_icon) {
-	//	Brief_mouse_up_flag = 0;
-	//}
-	//gr_reset_clip();
-
 	if (!Background_playing) {
 		int time = -1;
 		int check_jump_flag = 1;
@@ -1965,11 +1959,9 @@ void brief_api_do_frame(float frametime)
 				time,
 				Current_brief_stage);
 
-			//A few items commented out, but keeping a record for closeup icon fixing in a later PR - Mjn
-			// Brief_playing_fade_sound = 0;
 			Last_brief_stage = Current_brief_stage;
 			brief_reset_icons(Current_brief_stage);
-			// brief_update_closeup_icon(0);
+			brief_update_closeup_icon(0);
 		}
 
 	Transition_done:
@@ -1981,17 +1973,6 @@ void brief_api_do_frame(float frametime)
 		brief_api_render(frametime);
 		brief_camera_move(frametime, Current_brief_stage);
 
-		// More methods for dealing with clicking on ship icons to be solved in a future PR - Mjn
-		//if (Closeup_icon) {
-		//	gr_bitmap(Closeup_coords[gr_screen.res][BRIEF_X_COORD],
-		//		Closeup_coords[gr_screen.res][BRIEF_Y_COORD],
-		//		GR_RESIZE_MENU);
-		//}
-
-		// This may be needed in by a future PR to get map icon clicking working through the API - Mjn
-		// if (Closeup_icon) {
-		//	brief_render_closeup(Closeup_icon->ship_class, frametime);
-		//}
 	}
 }
 

--- a/code/missionui/missionbrief.h
+++ b/code/missionui/missionbrief.h
@@ -49,6 +49,11 @@ extern int Briefing_paused;	// for stopping audio and stage progression
 
 struct brief_icon;
 
+extern brief_icon* Closeup_icon;
+extern char Closeup_type_name[NAME_LENGTH];
+extern float Closeup_zoom;
+extern vec3d Closeup_cam_pos;
+
 void brief_api_init();
 void brief_api_do_frame(float frametime);
 void brief_do_next_pressed(int play_sound);
@@ -56,13 +61,14 @@ void brief_do_prev_pressed();
 void brief_do_start_pressed();
 void brief_do_end_pressed();
 void brief_api_close();
+void brief_check_for_anim(bool api_access = false, int api_x = -1, int api_y = -1);
 
 void brief_init();
 void brief_close();
 void brief_do_frame(float frametime);
-void brief_unhide_buttons();
+//void brief_unhide_buttons(); This doesn't seem to exist in the code -Mjn
 brief_icon *brief_get_closeup_icon();
-void brief_turn_off_closeup_icon();
+void brief_turn_off_closeup_icon(bool api_access = false);
 
 void briefing_stop_music(bool fade);
 void briefing_start_music();

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -3092,6 +3092,7 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 	float closeup_zoom;
 	int model_num;
 	bool model_lighting = true;
+	uint render_flags = MR_AUTOCENTER | MR_NO_FOGGING;
 
 	switch (model_type) {
 		case TECH_SHIP:
@@ -3142,6 +3143,16 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 
 			break;
 
+		case TECH_JUMP_NODE:
+			closeup_pos = close_pos;
+			closeup_zoom = close_zoom;
+			model_num = model_load(pof_filename.c_str(), 0, nullptr);
+			render_info.set_color(HUD_color_red, HUD_color_green, HUD_color_blue);
+			render_flags |= MR_NO_POLYS | MR_SHOW_OUTLINE_HTL | MR_NO_TEXTURING;
+			model_lighting = false;
+
+			break;
+
 		default:
 			return false;
 	}
@@ -3175,8 +3186,6 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 	}
 
 	render_info.set_detail_level_lock(0);
-
-	uint render_flags = MR_AUTOCENTER | MR_NO_FOGGING;
 
 	if (!lighting || !model_lighting)
 		render_flags |= MR_NO_LIGHTING;

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -3112,6 +3112,8 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 			// Make sure model is loaded
 			model_num = model_load(sip->pof_file, sip->n_subsystems, &sip->subsystems[0], 0);
 
+			break;
+
 		case TECH_WEAPON:
 			weapon_info* wip;
 			wip = &Weapon_info[class_idx];
@@ -3131,10 +3133,14 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 				return false;
 			}
 
+			break;
+
 		case TECH_POF:
 			closeup_pos = close_pos;
 			closeup_zoom = close_zoom;
 			model_num = model_load(pof_filename.c_str(), 0, nullptr);
+
+			break;
 
 		default:
 			return false;

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -30,7 +30,8 @@ extern color Wireframe_color;
 typedef enum {
 	TECH_SHIP,
 	TECH_WEAPON,
-	TECH_POF
+	TECH_POF,
+	TECH_JUMP_NODE
 } tech_render_type;
 
 inline int in_box(vec3d *min, vec3d *max, vec3d *pos, vec3d *view_position)

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -27,6 +27,12 @@ extern vec3d Object_position;
 
 extern color Wireframe_color;
 
+typedef enum {
+	TECH_SHIP,
+	TECH_WEAPON,
+	TECH_POF
+} tech_render_type;
+
 inline int in_box(vec3d *min, vec3d *max, vec3d *pos, vec3d *view_position)
 {
 	vec3d point;
@@ -307,7 +313,7 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 void model_render_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, float arc_width);
 void model_render_insignias(insignia_draw_data *insignia);
 void model_render_set_wireframe_color(color* clr);
-bool render_tech_model(bool is_ship, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, matrix* orient);
+bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, matrix* orient, SCP_string pof_filename = "", float closeup_zoom = 0, vec3d closeup_pos = ZERO_VECTOR);
 
 float model_render_get_diameter_clamped_to_min_pixel_size(const vec3d* pos, float diameter, float min_pixel_size);
 

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -49,6 +49,7 @@
 #include "scripting/api/objs/enums.h"
 #include "scripting/api/objs/player.h"
 #include "scripting/api/objs/texture.h"
+#include "scripting/api/objs/vecmath.h"
 #include "scripting/lua/LuaTable.h"
 #include "stats/medals.h"
 #include "stats/stats.h"
@@ -710,6 +711,58 @@ ADE_FUNC(commitToMission,
 	return ade_set_args(L, "i", static_cast<int>(commit_pressed(true)));
 }
 
+ADE_FUNC(renderBriefingModel,
+	l_UserInterface_Brief,
+	"string PofName, number CloseupZoom, vector CloseupPos, number X1, number Y1, number X2, number Y2, [number RotationPercent =0, number PitchPercent =0, "
+	"number "
+	"BankPercent=40, number Zoom=1.3, boolean Lighting=true]",
+	"Draws a pof. True for regular lighting, false for flat lighting.",
+	"boolean",
+	"Whether pof was rendered")
+{
+	int x1, y1, x2, y2;
+	angles rot_angles = {0.0f, 0.0f, 40.0f};
+	const char* pof;
+	float closeup_zoom;
+	vec3d closeup_pos;
+	float zoom = 1.3f;
+	bool lighting = true;
+	if (!ade_get_args(L,
+			"sfoiiii|ffffb",
+			&pof,
+			&closeup_zoom,
+			l_Vector.Get(&closeup_pos),
+			&x1,
+			&y1,
+			&x2,
+			&y2,
+			&rot_angles.h,
+			&rot_angles.p,
+			&rot_angles.b,
+			&zoom,
+			&lighting))
+		return ade_set_error(L, "b", false);
+
+	if (x2 < x1 || y2 < y1)
+		return ade_set_args(L, "b", false);
+
+	CLAMP(rot_angles.p, 0.0f, 100.0f);
+	CLAMP(rot_angles.b, 0.0f, 100.0f);
+	CLAMP(rot_angles.h, 0.0f, 100.0f);
+
+	// Handle angles
+	matrix orient = vmd_identity_matrix;
+	angles view_angles = {-0.6f, 0.0f, 0.0f};
+	vm_angles_2_matrix(&orient, &view_angles);
+
+	rot_angles.p = (rot_angles.p * 0.01f) * PI2;
+	rot_angles.b = (rot_angles.b * 0.01f) * PI2;
+	rot_angles.h = (rot_angles.h * 0.01f) * PI2;
+	vm_rotate_matrix_by_angles(&orient, &rot_angles);
+
+	return ade_set_args(L, "b", render_tech_model(TECH_POF, x1, y1, x2, y2, zoom, lighting, -1, &orient, pof, closeup_zoom, closeup_pos));
+}
+
 ADE_FUNC(drawBriefingMap,
 	l_UserInterface_Brief,
 	"number x, number y, [number width = 888, number height = 371]",
@@ -743,6 +796,31 @@ ADE_FUNC(drawBriefingMap,
 	brief_api_do_frame(flRealframetime);
 
 	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(checkStageIcons,
+	l_UserInterface_Brief,
+	"number xPos, number yPos",
+	"Sends the mouse position to the brief map rendering functions to properly highlight icons.",
+	"string, number, vector, string",
+	"If an icon is highlighted then this will return the ship name for ships or the pof to render for asteroid, jumpnode, or unknown icons. "
+	"also returns the closeup zoom, the closeup position, and the closeup label. Otherwise it returns nil")
+{
+	int x;
+	int y;
+
+	if (!ade_get_args(L, "ii", &x, &y)) {
+		LuaError(L, "X and Y coordinates not provided!");
+		return ADE_RETURN_NIL;
+	}
+
+	brief_check_for_anim(true, x, y);
+
+	if (Closeup_icon == nullptr) {
+		return ADE_RETURN_NIL;
+	} else {
+		return ade_set_args(L, "sfos", Closeup_type_name, Closeup_zoom, l_Vector.Set(Closeup_cam_pos), Closeup_icon->closeup_label);
+	}
 }
 
 ADE_FUNC(callNextMapStage,

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -715,7 +715,7 @@ ADE_FUNC(renderBriefingModel,
 	l_UserInterface_Brief,
 	"string PofName, number CloseupZoom, vector CloseupPos, number X1, number Y1, number X2, number Y2, [number RotationPercent =0, number PitchPercent =0, "
 	"number "
-	"BankPercent=40, number Zoom=1.3, boolean Lighting=true]",
+	"BankPercent=40, number Zoom=1.3, boolean Lighting=true, boolean Jumpnode=false]",
 	"Draws a pof. True for regular lighting, false for flat lighting.",
 	"boolean",
 	"Whether pof was rendered")
@@ -727,8 +727,9 @@ ADE_FUNC(renderBriefingModel,
 	vec3d closeup_pos;
 	float zoom = 1.3f;
 	bool lighting = true;
+	bool jumpNode = false;
 	if (!ade_get_args(L,
-			"sfoiiii|ffffb",
+			"sfoiiii|ffffbb",
 			&pof,
 			&closeup_zoom,
 			l_Vector.Get(&closeup_pos),
@@ -740,7 +741,8 @@ ADE_FUNC(renderBriefingModel,
 			&rot_angles.p,
 			&rot_angles.b,
 			&zoom,
-			&lighting))
+			&lighting,
+			&jumpNode))
 		return ade_set_error(L, "b", false);
 
 	if (x2 < x1 || y2 < y1)
@@ -760,7 +762,13 @@ ADE_FUNC(renderBriefingModel,
 	rot_angles.h = (rot_angles.h * 0.01f) * PI2;
 	vm_rotate_matrix_by_angles(&orient, &rot_angles);
 
-	return ade_set_args(L, "b", render_tech_model(TECH_POF, x1, y1, x2, y2, zoom, lighting, -1, &orient, pof, closeup_zoom, closeup_pos));
+	tech_render_type thisType = TECH_POF;
+
+	if (jumpNode) {
+		thisType = TECH_JUMP_NODE;
+	}
+
+	return ade_set_args(L, "b", render_tech_model(thisType, x1, y1, x2, y2, zoom, lighting, -1, &orient, pof, closeup_zoom, closeup_pos));
 }
 
 ADE_FUNC(drawBriefingMap,
@@ -802,9 +810,9 @@ ADE_FUNC(checkStageIcons,
 	l_UserInterface_Brief,
 	"number xPos, number yPos",
 	"Sends the mouse position to the brief map rendering functions to properly highlight icons.",
-	"string, number, vector, string",
+	"string, number, vector, string, number",
 	"If an icon is highlighted then this will return the ship name for ships or the pof to render for asteroid, jumpnode, or unknown icons. "
-	"also returns the closeup zoom, the closeup position, and the closeup label. Otherwise it returns nil")
+	"also returns the closeup zoom, the closeup position, the closeup label, and the icon id. Otherwise it returns nil")
 {
 	int x;
 	int y;
@@ -819,7 +827,7 @@ ADE_FUNC(checkStageIcons,
 	if (Closeup_icon == nullptr) {
 		return ADE_RETURN_NIL;
 	} else {
-		return ade_set_args(L, "sfos", Closeup_type_name, Closeup_zoom, l_Vector.Set(Closeup_cam_pos), Closeup_icon->closeup_label);
+		return ade_set_args(L, "sfosi", Closeup_type_name, Closeup_zoom, l_Vector.Set(Closeup_cam_pos), Closeup_icon->closeup_label, Closeup_icon->id);
 	}
 }
 

--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -1200,7 +1200,7 @@ ADE_FUNC(renderTechModel,
 	rot_angles.h = (rot_angles.h*0.01f) * PI2;
 	vm_rotate_matrix_by_angles(&orient, &rot_angles);
 
-	return ade_set_args(L, "b", render_tech_model(true, x1, y1, x2, y2, zoom, lighting, idx, &orient));
+	return ade_set_args(L, "b", render_tech_model(TECH_SHIP, x1, y1, x2, y2, zoom, lighting, idx, &orient));
 }
 
 // Nuke's alternate tech model rendering function
@@ -1222,7 +1222,7 @@ ADE_FUNC(renderTechModel2, l_Shipclass, "number X1, number Y1, number X2, number
 	//Handle angles
 	matrix *orient = mh->GetMatrix();
 
-	return ade_set_args(L, "b", render_tech_model(true, x1, y1, x2, y2, zoom, true, idx, orient));
+	return ade_set_args(L, "b", render_tech_model(TECH_SHIP, x1, y1, x2, y2, zoom, true, idx, orient));
 }
 
 ADE_FUNC(renderSelectModel,

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -736,7 +736,7 @@ ADE_FUNC(renderTechModel,
 	rot_angles.h = (rot_angles.h * 0.01f) * PI2;
 	vm_rotate_matrix_by_angles(&orient, &rot_angles);
 
-	return ade_set_args(L, "b", render_tech_model(false, x1, y1, x2, y2, zoom, lighting, idx, &orient));
+	return ade_set_args(L, "b", render_tech_model(TECH_WEAPON, x1, y1, x2, y2, zoom, lighting, idx, &orient));
 }
 
 // Nuke's alternate tech model rendering function
@@ -763,7 +763,7 @@ ADE_FUNC(renderTechModel2,
 	// Handle angles
 	matrix* orient = mh->GetMatrix();
 
-	return ade_set_args(L, "b", render_tech_model(false, x1, y1, x2, y2, zoom, true, idx, orient));
+	return ade_set_args(L, "b", render_tech_model(TECH_WEAPON, x1, y1, x2, y2, zoom, true, idx, orient));
 }
 
 ADE_FUNC(renderSelectModel,


### PR DESCRIPTION
This PR does three main things. First it adds an ADE_FUNC to check the mouse position against briefing icon positions. Returns the relevant icon information if the mouse if over one and also causes that icon to switch to the "highlight" frame. Second, it changes up the unified `render_tech_model()` function to allow for rendering an arbitrary POF in the same style and with pretty much the same arguments. This is necessary to handle unique briefing icon closeup cases such as "asteroid" and "unknown". Third it adds the ADE_FUNC `renderBriefingModel` which takes a POF instead of a ship or weapon class.

With this in place, SCPUI can recreate retail's ability to hover and click on briefing icons.