### PR TITLE
Avoid calling `asteroid_add_target()` in FRED.

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -90,9 +90,9 @@ SCP_vector<asteroid_target> Asteroid_targets;
 static int count_incident_asteroids(int target_objnum)
 {
 	object* asteroid_objp;
-	int		count;
+	int		count = 0;
 
-	count = 0;
+	Assertion(GET_FIRST(&Asteroid_obj_list) != nullptr, "count_incident_asteroids() called before Asteroid_obj_list was initialized; this shouldn't happen. Get a coder!");
 
 	for (auto aop: list_range(&Asteroid_obj_list)) {
 		asteroid_objp = &Objects[aop->objnum];
@@ -154,6 +154,8 @@ static int asteroid_obj_list_add(int objnum)
 {
 	int index;
 
+	Assertion(GET_FIRST(&Asteroid_obj_list) != nullptr, "asteroid_obj_list_add() called before Asteroid_obj_list was initialized; this shouldn't happen. Get a coder!");
+
 	asteroid *cur_asteroid = &Asteroids[Objects[objnum].instance];
 	index = (int)(cur_asteroid - Asteroids);
 
@@ -175,6 +177,8 @@ static int asteroid_obj_list_add(int objnum)
 static void asteroid_obj_list_remove(object * obj)
 {
 	int index = obj->instance;
+
+	Assertion(GET_FIRST(&Asteroid_obj_list) != nullptr, "asteroid_obj_list_remove() called before Asteroid_obj_list was initialized; this shouldn't happen. Get a coder!");
 
 	Assert(index >= 0 && index < MAX_ASTEROID_OBJS);
 	Assert(Asteroid_objs[index].flags & ASTEROID_OBJ_USED);
@@ -2522,6 +2526,8 @@ void asteroid_show_brackets()
 	object	*asteroid_objp, *player_target;
 	asteroid	*asp;
 
+	Assertion(GET_FIRST(&Asteroid_obj_list) != nullptr, "asteroid_show_brackets() called before Asteroid_obj_list was initialized; this shouldn't happen. Get a coder!");
+
 	// get pointer to player target, so we don't need to take OBJ_INDEX() of asteroid_objp to compare to target_objnum
 	if ( Player_ai->target_objnum >= 0 ) {
 		player_target = &Objects[Player_ai->target_objnum];
@@ -2566,6 +2572,8 @@ void asteroid_target_closest_danger()
 	object	*asteroid_objp, *closest_asteroid_objp = NULL;
 	asteroid	*asp;
 	float		dist, closest_dist = 999999.0f;
+
+	Assertion(GET_FIRST(&Asteroid_obj_list) != nullptr, "asteroid_target_closest_danger() called before Asteroid_obj_list was initialized; this shouldn't happen. Get a coder!");
 
 	for (auto aop: list_range(&Asteroid_obj_list)) {
 		asteroid_objp = &Objects[aop->objnum];

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2421,11 +2421,13 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 		}
 	}
 
-	// if this is an asteroid target, add it to the list
-	for (SCP_string& name : Asteroid_field.target_names) {
-		if (stricmp(name.c_str(), shipp->ship_name) == 0) {
-			asteroid_add_target(&Objects[objnum]);
-			break;
+	if (!Fred_running) {
+		// if this is an asteroid target, add it to the list
+		for (SCP_string& name : Asteroid_field.target_names) {
+			if (stricmp(name.c_str(), shipp->ship_name) == 0) {
+				asteroid_add_target(&Objects[objnum]);
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
PR #5058 made `count_incident_asteroids()` use `Asteroid_obj_list` instead of `obj_used_list`; a perfectly sensible change in and of itself. However, PR #4827 had previously made `asteroid_obj_list_init()` only be called if FRED wasn't running (presumably because of the iteration through `Asteroid_objs` to clear flags, which is wasted effort in FRED). The problem is that without `list_init()` being called on `Asteroid_obj_list`, its `prev` and `next` were `nullptr` instead of linking back to itself, which means the beginning of the list and the end of the list were no longer considered the same (the iterator's `begin()` calls `GET_FIRST(head)`, which is effectively `head->next`, while `end()` calls `END_OF_LIST(head)`, which is effectively just `head`). This meant that iterating over `list_range(Asteroid_obj_list)` was returning `nullptr` as the first element of the list, and trying to dereference that would cause a crash. This was still not a problem in and of itself, as long as nothing tried to iterate over `Asteroid_obj_list` while FRED was running, which theoretically shouldn't be necessary...

PR #3704 changed mission parsing so that when parsing a ship with a name that matches one of the `Asteroid_field.target_names`, it would call `asteroid_add_target()` to initialize the relevant data for the asteroid field to fling asteroids at that ship. `asteroid_add_target()` calls `count_incident_asteroids()`, which (since PR #5058) iterates over `Asteroid_obj_list`, causing a crash due to dereferencing a null pointer on any mission that defines `$Asteroid Targets:` (and then actually has such a target be parsed).

While this could be solved by unconditionally initializing `Asteroid_obj_list`, there's really no need to do anything with `Asteroid_obj_list` in FRED, so instead the `asteroid_add_target()` call has been gated behind a `!Fred_running` check, and `Assertion()`s have been added to make sure `Asteroid_obj_list` has been initialized at the beginning of any function that does anything with it (besides initialize it), to catch similar problems in the future.

Fixes #5092.