### PR TITLE
Implement opf_turret_type

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -58,10 +58,18 @@ const char *Turret_target_order_names[NUM_TURRET_ORDER_TYPES] = {
 #define EEOF_BIG_ONLY		(1<<0)	// turret fires only at big and huge ships
 #define EEOF_SMALL_ONLY		(1<<1)	// turret fires only at small ships
 #define EEOF_TAGGED_ONLY	(1<<2)	// turret fires only at tagged ships
+
 #define EEOF_BEAM			(1<<3)	// turret is a beam
 #define EEOF_FLAK			(1<<4)	// turret is flak
 #define EEOF_LASER			(1<<5)	// turret is a laser
 #define EEOF_MISSILE		(1<<6)	// turret is a missile
+
+const char* Turret_valid_types[NUM_TURRET_TYPES] = {
+	"Beam",
+	"Flak",
+	"Laser",
+	"Missile",
+};
 
 typedef struct eval_enemy_obj_struct {
 	int			turret_parent_objnum;			// parent of turret

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3635,6 +3635,20 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, i
 				
 				break;
 
+			case OPF_TURRET_TYPE:
+				if (type2 != SEXP_ATOM_STRING)
+					return SEXP_CHECK_TYPE_MISMATCH;
+
+				for (i = 0; i < NUM_TURRET_TYPES; i++) {
+					if (!stricmp(CTEXT(node), Turret_valid_types[i]))
+						break;
+				}
+
+				if (i == NUM_TURRET_TYPES)
+					return SEXP_CHECK_INVALID_TURRET_TYPE;
+
+				break;
+
 			case OPF_ARMOR_TYPE:
 				if ( type2 != SEXP_ATOM_STRING )
 					return SEXP_CHECK_TYPE_MISMATCH;
@@ -29510,7 +29524,7 @@ int query_operator_argument_type(int op, int argnum)
 		case OP_TURRET_PROTECT_SHIP:
 		case OP_TURRET_UNPROTECT_SHIP:
 			if (argnum == 0)
-				return OPF_STRING;
+				return OPF_TURRET_TYPE;
 			else
 				return OPF_SHIP;
 
@@ -32434,6 +32448,9 @@ const char *sexp_error_message(int num)
 
 		case SEXP_CHECK_INVALID_TURRET_TARGET_ORDER:
 			return "Invalid turret target order";
+
+		case SEXP_CHECK_INVALID_TURRET_TYPE:
+			return "Invalid turret type";
 
 		case SEXP_CHECK_INVALID_ARMOR_TYPE:
 			return "Invalid armor type";

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -132,6 +132,7 @@ enum : int {
 	OPF_WING_FLAG,					// Goober5000 - The name of a wing flag
 	OPF_ASTEROID_DEBRIS,			// MjnMixael - Debris types as defined in asteroids.tbl
 	OPF_WING_FORMATION,				// Goober5000 - as defined in ships.tbl
+	OPF_TURRET_TYPE,
 
 	//Must always be at the end of the list
 	First_available_opf_id
@@ -1140,6 +1141,7 @@ enum sexp_error_check
 	SEXP_CHECK_INVALID_EXPLOSION_OPTION,
 	SEXP_CHECK_INVALID_SHIP_EFFECT,
 	SEXP_CHECK_INVALID_TURRET_TARGET_ORDER,
+	SEXP_CHECK_INVALID_TURRET_TYPE,
 	SEXP_CHECK_INVALID_ARMOR_TYPE,
 	SEXP_CHECK_INVALID_DAMAGE_TYPE,
 	SEXP_CHECK_INVALID_TARGET_PRIORITIES,

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -270,6 +270,9 @@ extern SCP_vector<DamageTypeStruct>	Damage_types;
 #define NUM_TURRET_ORDER_TYPES		3
 extern const char *Turret_target_order_names[NUM_TURRET_ORDER_TYPES];	//aiturret.cpp
 
+#define NUM_TURRET_TYPES 4
+extern const char* Turret_valid_types[NUM_TURRET_TYPES];
+
 // Swifty: Cockpit displays
 typedef struct cockpit_display {
 	int target;

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -3341,6 +3341,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_NEBULA_STORM_TYPE:
 		case OPF_NEBULA_POOF:
 		case OPF_TURRET_TARGET_ORDER:
+		case OPF_TURRET_TYPE:
 		case OPF_POST_EFFECT:
 		case OPF_TARGET_PRIORITIES:
 		case OPF_ARMOR_TYPE:
@@ -5307,6 +5308,10 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_turret_target_order();
 			break;
 
+		case OPF_TURRET_TYPE:
+			list = get_listing_opf_turret_types();
+			break;
+
 		case OPF_TARGET_PRIORITIES:
 			list = get_listing_opf_turret_target_priorities();
 			break;
@@ -6971,13 +6976,23 @@ sexp_list_item *sexp_tree::get_listing_opf_nebula_poof()
 	return head.next;
 }
 
-sexp_list_item *sexp_tree::get_listing_opf_turret_target_order()
+sexp_list_item* sexp_tree::get_listing_opf_turret_target_order()
 {
 	int i;
 	sexp_list_item head;
 
 	for (i=0; i<NUM_TURRET_ORDER_TYPES; i++)
 		head.add_data(Turret_target_order_names[i]);
+
+	return head.next;
+}
+
+sexp_list_item* sexp_tree::get_listing_opf_turret_types()
+{
+	sexp_list_item head;
+
+	for (int i = 0; i < NUM_TURRET_TYPES; i++)
+		head.add_data(Turret_valid_types[i]);
 
 	return head.next;
 }

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -273,6 +273,7 @@ public:
 	sexp_list_item *get_listing_opf_subsystem_or_none(int parent_node, int arg_index);
 	sexp_list_item *get_listing_opf_subsys_or_generic(int parent_node, int arg_index);
 	sexp_list_item *get_listing_opf_turret_target_order();
+	sexp_list_item* get_listing_opf_turret_types();
 	sexp_list_item *get_listing_opf_armor_type();
 	sexp_list_item *get_listing_opf_damage_type();
 	sexp_list_item *get_listing_opf_turret_target_priorities();

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1519,6 +1519,7 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 	case OPF_NEBULA_STORM_TYPE:
 	case OPF_NEBULA_POOF:
 	case OPF_TURRET_TARGET_ORDER:
+	case OPF_TURRET_TYPE:
 	case OPF_POST_EFFECT:
 	case OPF_TARGET_PRIORITIES:
 	case OPF_ARMOR_TYPE:
@@ -3199,6 +3200,10 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 		list = get_listing_opf_turret_target_order();
 		break;
 
+	case OPF_TURRET_TYPE:
+		list = get_listing_opf_turret_types();
+		break;
+
 	case OPF_TARGET_PRIORITIES:
 		list = get_listing_opf_turret_target_priorities();
 		break;
@@ -4784,6 +4789,16 @@ sexp_list_item* sexp_tree::get_listing_opf_turret_target_order() {
 	for (i = 0; i < NUM_TURRET_ORDER_TYPES; i++) {
 		head.add_data(Turret_target_order_names[i]);
 	}
+
+	return head.next;
+}
+
+sexp_list_item* sexp_tree::get_listing_opf_turret_types()
+{
+	sexp_list_item head;
+
+	for (int i = 0; i < NUM_TURRET_TYPES; i++)
+		head.add_data(Turret_valid_types[i]);
 
 	return head.next;
 }

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -320,6 +320,7 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_subsystem_or_none(int parent_node, int arg_index);
 	sexp_list_item* get_listing_opf_subsys_or_generic(int parent_node, int arg_index);
 	sexp_list_item* get_listing_opf_turret_target_order();
+	sexp_list_item* get_listing_opf_turret_types();
 	sexp_list_item* get_listing_opf_armor_type();
 	sexp_list_item* get_listing_opf_damage_type();
 	sexp_list_item* get_listing_opf_turret_target_priorities();


### PR DESCRIPTION
Really just a FREDing QoL thing, but this implements opf_turret_type to for turret-protect-ship and turret-unprotect-ship since they can only accept these 4 types anyway. But also makes it easier to enhance in the future if additional turret types are defined.