### PR TITLE
fix team color parsing

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2934,9 +2934,12 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 		stuff_string(temp, F_NAME, NAME_LENGTH);
 		p_objp->team_color_setting = temp;
 
-		if (Team_Colors.find(p_objp->team_color_setting) == Team_Colors.end()) {
-			mprintf(("Invalid team color specified in mission file for ship %s, resetting to default\n", p_objp->name));
-			p_objp->team_color_setting = sip->default_team_name;
+		//If team color is not default then verify
+		if (stricmp(p_objp->team_color_setting.c_str(), sip->default_team_name.c_str()) != 0) {
+			if (Team_Colors.find(p_objp->team_color_setting) == Team_Colors.end()) {
+				mprintf(("Invalid team color specified in mission file for ship %s, resetting to default\n", p_objp->name));
+				p_objp->team_color_setting = sip->default_team_name;
+			}
 		}
 	}
 

--- a/fred2/initialstatus.cpp
+++ b/fred2/initialstatus.cpp
@@ -402,6 +402,7 @@ BOOL initial_status::OnInitDialog()
 			if (Ship_info[shipp->ship_info_index].uses_team_colors) {
 				//Add a "None" entry at the beginning to allow simple deselection of colours
 				int t = m_team_color_setting.AddString("None");
+				m_team_color_setting.SetCurSel(i);
 				m_team_color_setting.SetItemData(t, i);
 				++i;
 


### PR DESCRIPTION
"None" is a valid team color setting so we don't need to warn in the log and then set team color to "none". Also fixes a small bug where FRED would never show "None" as selected in the Initial Status dialog box.