### PR TITLE
Persona species enhancements

### DIFF
--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -176,14 +176,16 @@ extern SCP_vector<SCP_string> Generic_message_filenames;
 #define PERSONA_FLAG_LARGE		(1<<2)		// for large ships
 #define PERSONA_FLAG_COMMAND	(1<<3)		// for terran command
 // be sure that MAX_PERSONA_TYPES is always 1 greater than the last type bitfield above!!!
+// for non-type flags, add them in reverse order from the end
 
-#define PERSONA_FLAG_USED		(1<<31)
+#define PERSONA_FLAG_NO_AUTOMATIC_ASSIGNMENT        (1<<29)     // when you don't want characters showing up unexpectedly
+#define PERSONA_FLAG_SUBSTITUTE_MISSING_MESSAGES    (1<<30)
+#define PERSONA_FLAG_USED                           (1<<31)
 
 typedef struct persona_s {
 	char	name[NAME_LENGTH];
 	int	flags;
 	int species;
-	bool substitute_missing_messages;
 } Persona;
 
 extern Persona *Personas;

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -185,7 +185,7 @@ extern SCP_vector<SCP_string> Generic_message_filenames;
 typedef struct persona_s {
 	char	name[NAME_LENGTH];
 	int	flags;
-	int species;
+	int species_bitfield;
 } Persona;
 
 extern Persona *Personas;

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -177,7 +177,6 @@ extern SCP_vector<SCP_string> Generic_message_filenames;
 #define PERSONA_FLAG_COMMAND	(1<<3)		// for terran command
 // be sure that MAX_PERSONA_TYPES is always 1 greater than the last type bitfield above!!!
 
-#define PERSONA_FLAG_VASUDAN	(1<<30)
 #define PERSONA_FLAG_USED		(1<<31)
 
 typedef struct persona_s {

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -301,10 +301,21 @@ BOOL CShipEditorDlg::Create()
 	for ( i = 0; i < Num_personas; i++ ) {
 		if ( Personas[i].flags & PERSONA_FLAG_WINGMAN ) {
 			CString persona_name = Personas[i].name;
-			if (Personas[i].species > 0) {
+
+			// see if the bitfield matches one and only one species
+			int species = -1;
+			for (size_t j = 0; j < 32 && j < Species_info.size(); j++) {
+				if (Personas[i].species_bitfield == (1 << j)) {
+					species = (int)j;
+					break;
+				}
+			}
+
+			// if it is an exact species that isn't the first
+			if (species > 0) {
 				persona_name += "-";
 
-				auto species_name = Species_info[Personas[i].species].species_name;
+				auto species_name = Species_info[species].species_name;
 				size_t len = strlen(species_name);
 				for (size_t j = 0; j < 3 && j < len; j++)
 					persona_name += species_name[j];

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -300,14 +300,14 @@ BOOL CShipEditorDlg::Create()
 
 	for ( i = 0; i < Num_personas; i++ ) {
 		if ( Personas[i].flags & PERSONA_FLAG_WINGMAN ) {
-			// don't bother putting any vasudan personas on the list -- done automatically by code
-//			if ( Personas[i].flags & PERSONA_FLAG_VASUDAN ){
-//				continue;
-//			}
-
 			CString persona_name = Personas[i].name;
-			if ( Personas[i].flags & PERSONA_FLAG_VASUDAN ){
-				persona_name += " -Vas";
+			if (Personas[i].species > 0) {
+				persona_name += "-";
+
+				auto species_name = Species_info[Personas[i].species].species_name;
+				size_t len = strlen(species_name);
+				for (size_t j = 0; j < 3 && j < len; j++)
+					persona_name += species_name[j];
 			}
 
 			index = ptr->AddString(persona_name);

--- a/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
@@ -324,10 +324,21 @@ void ShipEditorDialog::updateColumnTwo()
 	for (i = 0; i < Num_personas; i++) {
 		if (Personas[i].flags & PERSONA_FLAG_WINGMAN) {
 			SCP_string persona_name = Personas[i].name;
-			if (Personas[i].species > 0) {
+
+			// see if the bitfield matches one and only one species
+			int species = -1;
+			for (size_t j = 0; j < 32 && j < Species_info.size(); j++) {
+				if (Personas[i].species_bitfield == (1 << j)) {
+					species = (int)j;
+					break;
+				}
+			}
+
+			// if it is an exact species that isn't the first
+			if (species > 0) {
 				persona_name += "-";
 
-				auto species_name = Species_info[Personas[i].species].species_name;
+				auto species_name = Species_info[species].species_name;
 				size_t len = strlen(species_name);
 				for (size_t j = 0; j < 3 && j < len; j++)
 					persona_name += species_name[j];

--- a/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
@@ -323,10 +323,14 @@ void ShipEditorDialog::updateColumnTwo()
 	ui->personaCombo->addItem("<none>", QVariant(-1));
 	for (i = 0; i < Num_personas; i++) {
 		if (Personas[i].flags & PERSONA_FLAG_WINGMAN) {
-
 			SCP_string persona_name = Personas[i].name;
-			if (Personas[i].flags & PERSONA_FLAG_VASUDAN) {
-				persona_name += " -Vas";
+			if (Personas[i].species > 0) {
+				persona_name += "-";
+
+				auto species_name = Species_info[Personas[i].species].species_name;
+				size_t len = strlen(species_name);
+				for (size_t j = 0; j < 3 && j < len; j++)
+					persona_name += species_name[j];
 			}
 
 			ui->personaCombo->addItem(persona_name.c_str(), QVariant(i));


### PR DESCRIPTION
Implements features from #5020:
1. Personas can now be assigned to multiple species
2. Personas can be excluded from automatic assignment if the game picks a random persona

Also removes the obsolete `PERSONA_FLAG_VASUDAN` and turns the `substitute_missing_messages` field into a proper flag to match the others.

Additionally, this fixes the addition of the -Vas suffix on the wingmen personas in FRED, which had been broken since the species_defs upgrade.