### PR TITLE
don't skip first debris item

### DIFF
--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -7142,7 +7142,7 @@ sexp_list_item* sexp_tree::get_listing_opf_asteroid_debris()
 
 	for (int i = 0; i < (int)Asteroid_info.size(); i++) {
 		//first three asteroids are not debris-Mjn
-		if (i > NUM_ASTEROID_SIZES) {
+		if (i > (NUM_ASTEROID_SIZES - 1)) {
 			head.add_data(Asteroid_info[i].name);
 		}
 	}

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4940,7 +4940,7 @@ sexp_list_item* sexp_tree::get_listing_opf_asteroid_debris()
 
 	for (int i = 0; i < (int)Asteroid_info.size(); i++) {
 		// first three asteroids are not debris-Mjn
-		if (i > NUM_ASTEROID_SIZES) {
+		if (i > (NUM_ASTEROID_SIZES - 1)) {
 			head.add_data(Asteroid_info[i].name);
 		}
 	}


### PR DESCRIPTION
Asteroids is a 0 based index so we need to subtract one here to prevent skipping the first debris item in the list