### PR TITLE
some validity checks to order sending

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -231,7 +231,6 @@ void hud_add_issued_order(const char *name, int order);
 void hud_update_last_order(const char *target, int order_source, int special_index);
 bool hud_squadmsg_is_target_order_valid(size_t order, ai_info *aip = nullptr);
 bool hud_squadmsg_ship_valid(ship *shipp, object *objp = nullptr);
-bool hud_squadmsg_ship_order_valid( int shipnum, int order );
 
 // function to set up variables needed when messaging mode is started
 void hud_squadmsg_start()
@@ -1529,11 +1528,11 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 		int ship_num;
 
 		// get a random ship in the wing to send the message to the player		
-		ship_num = ship_get_random_ship_in_wing( wingnum, SHIP_GET_UNSILENCED );
+		ship_num = ship_get_random_ship_in_wing( wingnum, SHIP_GET_UNSILENCED, 0.0, 0, command );
 		
 		// in multiplayer, its possible that all ships in a wing are players. so we'll just send from a random ship		
 		if(ship_num == -1 && (Game_mode & GM_MULTIPLAYER)){
-			ship_num = ship_get_random_ship_in_wing(wingnum);
+			ship_num = ship_get_random_ship_in_wing(wingnum, SHIP_GET_ANY_SHIP, 0.0, 0, command);
 		}
 		
 		// only send message if ship is found.  There appear to be cases where all ships
@@ -2097,6 +2096,18 @@ void hud_squadmsg_wing_command()
 		// if no target, remove any items which are associated with the players target
 		if ( !hud_squadmsg_is_target_order_valid((int)order_id, 0) )
 			MsgItems[Num_menu_items].active = 0;
+
+		// if no ship in the wing can depart then gray out the departure order
+		if (order_id == DEPART_ITEM) {
+			int active = 0;
+			for (int i = 0; i < wingp->current_count; i++) {
+				if (hud_squadmsg_ship_order_valid(wingp->ship_index[i], (int)order_id)) {
+					active = 1;
+					break;
+				}
+			}
+			MsgItems[Num_menu_items].active = active;
+		}
 
 		Num_menu_items++;
 	

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -166,6 +166,9 @@ void hud_enemymsg_toggle();						// debug function to allow messaging of enemies
 // Added for voicer implementation
 void hud_squadmsg_do_mode( int mode );
 
+// Added for checking message validity - Mjn
+bool hud_squadmsg_ship_order_valid(int shipnum, int order);
+
 class HudGaugeSquadMessage: public HudGauge
 {
 protected:

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15664,7 +15664,7 @@ int ship_get_random_player_wing_ship( int flags, float max_dist, int persona_ind
 
 // like above function, but returns a random ship in the given wing -- no restrictions
 // input:	max_dist	=>	OPTIONAL PARAMETER (default value 0.0f) max range ship can be from player
-int ship_get_random_ship_in_wing(int wingnum, int flags, float max_dist, int get_first)
+int ship_get_random_ship_in_wing(int wingnum, int flags, float max_dist, int get_first, int order_id)
 {
 	int i, ship_index, slist[MAX_SHIPS_PER_WING], count, which_one;
 
@@ -15675,6 +15675,13 @@ int ship_get_random_ship_in_wing(int wingnum, int flags, float max_dist, int get
 
 		if ( Ships[ship_index].flags[Ship_Flags::Dying] ) {
 			continue;
+		}
+
+		// specific to sending messages, make sure the ship selected can actually do the order
+		if (order_id >= 0) {
+			if (!hud_squadmsg_ship_order_valid(ship_index, order_id)) {
+				continue;
+			}
 		}
 
 		// see if ship meets our criterea

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1801,7 +1801,7 @@ ship_subsys *ship_return_next_subsys(ship *shipp, int type, vec3d *attacker_pos)
 
 extern int ship_get_random_team_ship(int team_mask, int flags = SHIP_GET_ANY_SHIP, float max_dist = 0.0f);
 extern int ship_get_random_player_wing_ship(int flags = SHIP_GET_ANY_SHIP, float max_dist = 0.0f, int persona_index = -1, int get_first = 0, int multi_team = -1);
-extern int ship_get_random_ship_in_wing(int wingnum, int flags = SHIP_GET_ANY_SHIP, float max_dist = 0.0f, int get_first = 0);
+extern int ship_get_random_ship_in_wing(int wingnum, int flags = SHIP_GET_ANY_SHIP, float max_dist = 0.0f, int get_first = 0, int order_id = -1);
 
 // return ship index
 int ship_get_random_targetable_ship();


### PR DESCRIPTION
As requested by Wookie, this PR does a few things to verify some order-sending things. 

First it checks that at least one ship in a wing can depart before marking the order as allowed on the Comms Board. 

Second it enhances `ship_get_random_ship_in_wing()` to be able to check if a ship can actually perform an order. If it can't, then don't select the ship. This prevents ships that can't perform a "wing" or "all ships" order from acknowledging the order as if they can.