### PR TITLE
Remove the screen signature

### DIFF
--- a/code/anim/animplay.cpp
+++ b/code/anim/animplay.cpp
@@ -397,8 +397,6 @@ int anim_show_next_frame(anim_instance *instance, float frametime)
 
 		t1 = timer_get_fixed_seconds();
 		for ( i = 0; i < frame_diff; i++ ) {
-			anim_check_for_palette_change(instance);			
-
 			// if we're playing backwards, every frame must be a keyframe and we set the data ptr here
 			if(instance->direction == ANIM_DIRECT_REVERSE){
 				if ( anim_instance_is_streamed(instance) ) {
@@ -789,9 +787,6 @@ anim *anim_load(const char *real_filename, int cf_dir_type, int file_mapped)
 		}
 
 		cfclose(fp);
-
-		// store screen signature, so we can tell if palette changes
-		ptr->screen_sig = gr_screen.signature;
 
 		anim_set_palette(ptr);
 	}

--- a/code/anim/packunpack.cpp
+++ b/code/anim/packunpack.cpp
@@ -18,13 +18,6 @@
 const int packer_code = PACKER_CODE;
 const int transparent_code = 254;
 
-void anim_check_for_palette_change(anim_instance *instance) {
-	if ( instance->parent->screen_sig != gr_screen.signature ) {
-		instance->parent->screen_sig = gr_screen.signature;
-		anim_set_palette(instance->parent);
-	}
-}
-
 anim_instance *init_anim_instance(anim *ptr, int bpp)
 {
 	anim_instance *inst;
@@ -96,8 +89,6 @@ ubyte *anim_get_next_raw_buffer(anim_instance *inst, int xlate_pal, int aabitmap
 		inst->file_offset = inst->parent->file_offset;
 		return NULL;
 	}
-
-	anim_check_for_palette_change(inst);
 
 	if ( anim_instance_is_streamed(inst) ) {
 		if ( xlate_pal ){

--- a/code/anim/packunpack.h
+++ b/code/anim/packunpack.h
@@ -58,7 +58,6 @@ typedef struct anim {
 	ubyte			xparent_g;		// green component for the transparent color in source image
 	ubyte			xparent_b;		// blue component for the transparent color in source image
 	int			flags;
-	uint			screen_sig;	
 	int			file_offset;	// file offset to start of frame data
 	int			cache_file_offset;
 	ubyte			*cache;
@@ -105,7 +104,6 @@ anim_instance *init_anim_instance(anim *ptr, int bpp);
 void	free_anim_instance(anim_instance *inst);
 ubyte *anim_get_next_raw_buffer(anim_instance *inst, int xlate_pal, int aabitmap, int bpp);
 void	anim_set_palette(anim *a);
-void	anim_check_for_palette_change(anim_instance *inst);
 
 
 #endif  /* __PACKUNPACK_H__ */

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -78,8 +78,6 @@ io::mouse::Cursor* Web_cursor = NULL;
 
 int Gr_inited = 0;
 
-uint Gr_signature = 0;
-
 float Gr_gamma = 1.0f;
 
 static SCP_vector<float> gamma_value_enumerator()
@@ -1299,8 +1297,6 @@ static bool gr_init_sub(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, i
 	Gr_save_menu_zoomed_offset_X = Gr_menu_zoomed_offset_X = Gr_menu_offset_X;
 	Gr_save_menu_zoomed_offset_Y = Gr_menu_zoomed_offset_Y = Gr_menu_offset_Y;
 	
-
-	gr_screen.signature = Gr_signature++;
 	gr_screen.bits_per_pixel = depth;
 	gr_screen.bytes_per_pixel= depth / 8;
 	gr_screen.rendering_to_texture = -1;
@@ -1738,7 +1734,6 @@ void gr_init_color(color *c, int r, int g, int b)
 	CAP(g, 0, 255);
 	CAP(b, 0, 255);
 
-	c->screen_sig = gr_screen.signature;
 	c->red = (ubyte)r;
 	c->green = (ubyte)g;
 	c->blue = (ubyte)b;
@@ -1776,21 +1771,12 @@ void gr_set_color( int r, int g, int b )
 
 void gr_set_color_fast(color *dst)
 {
-	if ( dst->screen_sig != gr_screen.signature ) {
-		if (dst->is_alphacolor) {
-			gr_init_alphacolor( dst, dst->red, dst->green, dst->blue, dst->alpha, dst->ac_type );
-		} else {
-			gr_init_color( dst, dst->red, dst->green, dst->blue );
-		}
-	}
-
 	gr_screen.current_color = *dst;
 }
 
 // shader functions
 void gr_create_shader(shader *shade, ubyte r, ubyte g, ubyte b, ubyte c )
 {
-	shade->screen_sig = gr_screen.signature;
 	shade->r = r;
 	shade->g = g;
 	shade->b = b;
@@ -1800,9 +1786,6 @@ void gr_create_shader(shader *shade, ubyte r, ubyte g, ubyte b, ubyte c )
 void gr_set_shader(shader *shade)
 {
 	if (shade) {
-		if (shade->screen_sig != gr_screen.signature) {
-			gr_create_shader( shade, shade->r, shade->g, shade->b, shade->c );
-		}
 		gr_screen.current_shader = *shade;
 	} else {
 		gr_create_shader( &gr_screen.current_shader, 0, 0, 0, 0 );

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -360,7 +360,6 @@ extern int gr_stencil_mode;
  * of the values you want to use in the shade primitive.
  */
 typedef struct shader {
-	uint screen_sig;  // current mode this is in
 	ubyte r, g, b, c; // factors and constant
 	ubyte lookup[256];
 } shader;
@@ -373,7 +372,6 @@ typedef struct shader {
 // If you need to get the rgb values of a "color" struct call
 // gr_get_colors after calling gr_set_colors_fast.
 typedef struct color {
-	uint		screen_sig;
 	int		is_alphacolor;
 	int		alphacolor;
 	int		magic;
@@ -654,7 +652,6 @@ enum class BufferUsageHint { Static, Dynamic, Streaming, PersistentMapping };
 typedef void* gr_sync;
 
 typedef struct screen {
-	uint signature = 0;       // changes when mode or palette or width or height changes
 	int max_w = 0, max_h = 0; // Width and height
 	int max_w_unscaled = 0, max_h_unscaled = 0;
 	int max_w_unscaled_zoomed = 0, max_h_unscaled_zoomed = 0;

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -413,7 +413,6 @@ void generic_render_ani_stream(generic_anim *ga)
 		mprintf(("frame: %d\n", ga->current_frame));
 	#endif
 
-	anim_check_for_palette_change(ga->ani.instance);
 	// if we're using bitmap polys
 	BM_SELECT_TEX_FORMAT();
 	if(ga->direction & GENERIC_ANIM_DIRECTION_BACKWARDS) {


### PR DESCRIPTION
As discussed in #5064, there is a piece of legacy code in the graphics initialization code that references a "screen signature". Back in the olden days, this value was used to track whether or not certain data needed to be reinitialized in response to changes in the graphics environment; this is no longer a concern with our current render backend.

Closes #5064