### PR TITLE
Fix and expand upon debug safety catcher for ccfg.tbl flag reading.

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -23,6 +23,7 @@
 #define CCF_HAT         0x04    //!< btn is a hat
 #define CCF_BALL        0x02    //!< btn is a ball
 #define CCF_BUTTON      0x01    //!< btn is actually a button
+#define CCF_NONE        0x00    //!< No flags.  Alias is "NONE"
 
 /*!
  * These are used to index a corresponding axis value from an array.

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1400,7 +1400,8 @@ void control_enable_hook(IoActionId id, bool enable) {
 }
 
 /**
- * Stuffs the CCF flags into the given char.  Needs item_id for validation
+ * Stuffs the CCF flags into the given char.  Needs item_id for validation.
+ * @details Unknown, unrecognized, or excessive flags are silently ignored on Release builds.  Debug builds complain.
  */
 void stuff_CCF(char& flags, size_t item_id) {
 	Assert(item_id < Control_config.size());
@@ -1414,7 +1415,9 @@ void stuff_CCF(char& flags, size_t item_id) {
 	SCP_string flag_str;
 	size_t pos = 0;
 	size_t len = 0;
-
+	
+	// Lambda to add flags.
+	// Debug version Eats the substring as it is found.
 	auto ADD_FLAG = [&](char id) {
 		flag_str = ValToCCF(id);
 		pos = szTempBuffer.find(flag_str);
@@ -1425,6 +1428,8 @@ void stuff_CCF(char& flags, size_t item_id) {
 		}
 	};
 #else
+	// Lambda to add flags.
+	// Release version doesn't modify szTempBuffer as it searches for substrings.
 	auto ADD_FLAG = [&](char id) {
 		if (szTempBuffer.find(ValToCCF(id)) != SCP_string::npos)
 			flags |= id;
@@ -1438,13 +1443,38 @@ void stuff_CCF(char& flags, size_t item_id) {
 	ADD_FLAG(CCF_HAT);
 	ADD_FLAG(CCF_BALL);
 
+
 #ifndef NDEBUG
+	// Eat the "CCF_NONE" and "NONE" substrings
+	auto EAT_FLAG = [&](SCP_string str) {
+		pos = szTempBuffer.find(str);
+		len = str.length();
+			if (pos != SCP_string::npos) {
+				if (flags != 0) {
+					// Complain about bad habits
+					error_display(0,
+						"Flag 'NONE' passed to config item %i along with other flags, ignoring: \n'%s'",
+						static_cast<int>(item_id),
+						szTempBuffer.c_str()
+					);
+				}
+				szTempBuffer.erase(pos, len);
+			}
+	};
+
+	EAT_FLAG("CCF_NONE");
+	EAT_FLAG("NONE");
+
 	// Complain about any unknown flag strings
 	replace_all(szTempBuffer, ",", " ");
 	drop_white_space(szTempBuffer);
 
 	if (!szTempBuffer.empty()) {
-		error_display(0, "Unknown flags passed to config item %i, ignoring: \n'%s'", static_cast<int>(item_id), szTempBuffer.c_str());
+		error_display(0,
+			"Unknown (or excessive) flags passed to config item %i, ignoring: \n'%s'",
+			static_cast<int>(item_id),
+			szTempBuffer.c_str()
+		);
 	}
 #endif
 
@@ -2276,7 +2306,7 @@ SCP_string ValToCCF(char id) {
 	}
 
 	if (str.empty()) {
-		// If unsupported flags, or no flags at all, list as "None"
+		// If unsupported flags, or (id == CCF_NONE), list as "None"
 		str = "NONE";
 	}
 


### PR DESCRIPTION
* Expand upon some comments for clarity on assumptions and optimizations
* Define the CCF_NONE flag for posterity

Should resolve #5113 

I've confirmed a quick build test, but haven't tested on Debug or Release.