### PR TITLE
do not update the gl buffer for a batch if the batch is empty

### DIFF
--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -943,7 +943,8 @@ void batching_allocate_and_load_buffer(primitive_batch_buffer *draw_queue)
 		offset += item->n_verts;
 	}
 
-	if (draw_queue->buffer_num.isValid()) {
+	// if there are no items in this batch, we will never render it and thus there is no need to update it in vmem
+	if (num_items && draw_queue->buffer_num.isValid()) {
 		gr_update_buffer_data(draw_queue->buffer_num, draw_queue->buffer_size, draw_queue->buffer_ptr);
 	}
 }


### PR DESCRIPTION
This addresses behaviour described in #5112. Profiling reveals that we are spending a lot of time per frame updating the buffers we use for batched rendering, even if the batches are nominally "empty" and thus wouldn't be rendered. This shows for example in cases where a lot of trails are spawned; even once all those trails have expired, the buffers created for them are still opened and updated, which involves a round trip through the GPU driver and PCIe bus, with all the overhead that implies. 
The change here removes the buffer update in those cases, meaning that while batch rendering itself might still be slow in extreme cases (see #5112 for an example mod and mission), it will no longer incur a _permanent_ performance penalty.

This is part of an ongoing effort to improve the performance of this piece of code, and should be considered a stopgap measure at best.