### PR TITLE
Refactor gameplay help

### DIFF
--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -11,6 +11,7 @@
 
 #include "controlconfig/controlsconfig.h"
 #include "freespace.h"
+#include "gamehelp/gameplayhelp.h"
 #include "gamesequence/gamesequence.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
@@ -22,33 +23,41 @@
 
 
 
-// text positioning constats
+// text positioning constants
 #define TITLE_Y			35
 #define Y_START			70
 #define X_OFFSET_1		70
 
 // pixel offset for description of key from where key binding starts
-#define KEY_DESCRIPTION_OFFSET	193	
+// increased this from 193 to 250 to account for allowing multiple keys -Mjn
+#define KEY_DESCRIPTION_OFFSET	250	
 
 // different gameplay help pages
+enum : int {
+	// The first 9 are the retail pages
+	GP_HELP_BASIC_KEYS,
+	GP_HELP_MOVEMENT_KEYS,
+	GP_HELP_COMMON_TARGET_KEYS,
+	GP_HELP_ADVANCED_TARGET_KEYS,
+	GP_HELP_MESSAGING,
+	GP_HELP_WEAPON_KEYS,
+	GP_HELP_THROTTLE_AND_ETS_KEYS,
+	GP_HELP_VIEW_KEYS,
+	GP_HELP_MISC_KEYS,
+	GP_HELP_MULTI_KEYS,
+
+	// Any others defined here will have unique sections within the vector
+	// but will need special handling to display in the retail UI
+	GP_HELP_FUNCTION_KEYS
+};
+
 #define GP_FIRST_SCREEN									0		// keep up to date
-
-#define GP_HELP_BASIC_KEYS								0
-#define GP_HELP_MOVEMENT_KEYS							1
-#define GP_HELP_COMMON_TARGET_KEYS					2
-#define GP_HELP_ADVANCED_TARGET_KEYS				3
-#define GP_HELP_MESSAGING								4
-#define GP_HELP_WEAPON_KEYS							5
-#define GP_HELP_THROTTLE_AND_ETS_KEYS				6
-#define GP_HELP_VIEW_KEYS								7
-#define GP_HELP_MISC_KEYS								8
-#define GP_HELP_MULTI_KEYS								9
-
 #define GP_LAST_SCREEN_SINGLE							8		// keep up to date
 #define GP_LAST_SCREEN_MULTI							9		// keep up to date
+#define GP_NUM_HELP_SECTIONS							10		// keep up to date
 
 // set this to GP_LAST_SCREEN_SINGLE or GP_LAST_SCREEN_MULTI based upon what game mode we're in
-int Gp_last_screen;
+static int Gp_last_screen;
 
 #define NUM_BUTTONS						3
 #define PREVIOUS_PAGE_BUTTON			0
@@ -109,10 +118,11 @@ static int Gameplay_help_inited = 0;
 
 static int Current_help_page;
 
+static SCP_vector<gameplay_help_section> Help_text;
 
-void gameplay_help_blit_control_line(int x, int y, int id)
+void gameplay_help_init_control_line(int id, gameplay_help_section &thisHelp)
 {
-	char			buf[256];
+	char buf[256];
 
 	auto ci = &Control_config[id];
 
@@ -121,43 +131,304 @@ void gameplay_help_blit_control_line(int x, int y, int id)
 	strcpy_s(buf, ci->first.textify().c_str());
 
 	if (!ci->second.empty()) {
-		strcat_s(buf, XSTR( ", ", 129));
+		strcat_s(buf, XSTR(", ", 129));
 		strcat_s(buf, ci->second.textify().c_str());
 	}
 
 	if (ci->empty()) {
-		strcpy_s(buf, XSTR( "no binding", 130));
+		strcpy_s(buf, XSTR("no binding", 130));
 	}
 
-	gr_string(x,y,buf,GR_RESIZE_MENU);
-
-//	gr_string(x+KEY_DESCRIPTION_OFFSET,y,ci->text,GR_RESIZE_MENU);
-	gr_string(x+KEY_DESCRIPTION_OFFSET, y, XSTR(ci->text.c_str(), CONTROL_CONFIG_XSTR + id), GR_RESIZE_MENU);
+	thisHelp.key.push_back(buf);
+	thisHelp.text.push_back(XSTR(ci->text.c_str(), CONTROL_CONFIG_XSTR + id));
 }
 
-void gameplay_help_blit_control_line_raw(int x, int y, const char *control_text, const char *control_description)
+void gameplay_help_init_control_line_raw(const char* control_text, const char* control_description, gameplay_help_section &thisHelp)
 {
-	gr_string(x,y,control_text,GR_RESIZE_MENU);
-	gr_string(x+KEY_DESCRIPTION_OFFSET,y,control_description,GR_RESIZE_MENU);
+	thisHelp.key.push_back(control_text);
+	thisHelp.text.push_back(control_description);
+}
+
+// displays the given help key and text at the specified
+// x and y coordinates
+void gameplay_help_blit_help_text(int x, int y, const SCP_string *control_text, const SCP_string *control_description)
+{
+	gr_string(x, y, control_text->c_str(), GR_RESIZE_MENU);
+	gr_string(x + KEY_DESCRIPTION_OFFSET, y, control_description->c_str(), GR_RESIZE_MENU);
+}
+
+// displays a help section header at the specified y coordinate and an x coordinate
+// calculated from the header string's length
+void gameplay_help_blit_header_text(int y_offset, const SCP_string *header)
+{
+	gr_set_color_fast(&Color_bright);
+	int w;
+	gr_get_string_size(&w, nullptr, header->c_str());
+	gr_printf_menu((gr_screen.clip_width - w) / 2, y_offset, "%s", header->c_str());
+	gr_set_color_fast(&Color_normal);
 }
 
 // game_play_help_set_title() will display the title for the help screen and
 // set the font for the rest of the screen
-void gameplay_help_set_title(const char *title)
+void gameplay_help_set_title(const SCP_string *title)
 {
 	int sy=TITLE_Y;
 	char buf[128];
 
 	gr_set_color_fast(&Color_bright);
 	int w;
-	gr_get_string_size(&w, NULL, title);
+	gr_get_string_size(&w, nullptr, title->c_str());
 
-	gr_printf_menu((gr_screen.clip_width_unscaled - w) / 2,sy,"%s", title);
+	gr_printf_menu((gr_screen.clip_width_unscaled - w) / 2,sy,"%s", title->c_str());
 
 	sprintf(buf, XSTR("Page %d of %d", 132), Current_help_page + 1, Gp_last_screen + 1);
 	gr_get_string_size(&w, NULL, buf);
 	gr_printf_menu((gr_screen.clip_width_unscaled - w) / 2, sy + gr_get_font_height() + 2, "%s", buf);
 	gr_set_color_fast(&Color_normal);
+}
+
+// Inits all the gameplay help text and returns it
+// in a nice organized vector of help sections
+SCP_vector<gameplay_help_section> gameplay_help_init_text()
+{
+	SCP_vector<gameplay_help_section> complete_help_text;
+
+	for (int i = 0; i <= GP_NUM_HELP_SECTIONS; i++) {
+
+		gameplay_help_section thisHelp;
+
+		switch (i) {
+
+		case GP_HELP_BASIC_KEYS:
+			thisHelp.title = XSTR("Basic Keys", 133);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line(END_MISSION, thisHelp);
+			gameplay_help_init_control_line(FIRE_PRIMARY, thisHelp);
+			gameplay_help_init_control_line(MAX_THROTTLE, thisHelp);
+			gameplay_help_init_control_line(ZERO_THROTTLE, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEXT, thisHelp);
+			gameplay_help_init_control_line(TARGET_PREV, thisHelp);
+			gameplay_help_init_control_line(TOGGLE_AUTO_TARGETING, thisHelp);
+
+			break;
+
+		case GP_HELP_MOVEMENT_KEYS:
+			thisHelp.title = XSTR("Movement Keys", 147);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line(FORWARD_THRUST, thisHelp);
+			gameplay_help_init_control_line(MAX_THROTTLE, thisHelp);
+			gameplay_help_init_control_line(ONE_THIRD_THROTTLE, thisHelp);
+			gameplay_help_init_control_line(TWO_THIRDS_THROTTLE, thisHelp);
+			gameplay_help_init_control_line(MINUS_5_PERCENT_THROTTLE, thisHelp);
+			gameplay_help_init_control_line(PLUS_5_PERCENT_THROTTLE, thisHelp);
+			gameplay_help_init_control_line(ZERO_THROTTLE, thisHelp);
+			gameplay_help_init_control_line(AFTERBURNER, thisHelp);
+			gameplay_help_init_control_line(REVERSE_THRUST, thisHelp);
+			gameplay_help_init_control_line(PITCH_FORWARD, thisHelp);
+			gameplay_help_init_control_line(PITCH_BACK, thisHelp);
+			gameplay_help_init_control_line(YAW_LEFT, thisHelp);
+			gameplay_help_init_control_line(YAW_RIGHT, thisHelp);
+			gameplay_help_init_control_line(BANK_LEFT, thisHelp);
+			gameplay_help_init_control_line(BANK_RIGHT, thisHelp);
+			gameplay_help_init_control_line(BANK_WHEN_PRESSED, thisHelp);
+
+			break;
+
+		case GP_HELP_COMMON_TARGET_KEYS:
+			thisHelp.title = XSTR("Basic Targeting Keys", 148);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line(TARGET_NEXT, thisHelp);
+			gameplay_help_init_control_line(TARGET_PREV, thisHelp);
+			gameplay_help_init_control_line(TOGGLE_AUTO_TARGETING, thisHelp);
+			gameplay_help_init_control_line(TARGET_SHIP_IN_RETICLE, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEXT_CLOSEST_HOSTILE, thisHelp);
+			gameplay_help_init_control_line(TARGET_PREV_CLOSEST_HOSTILE, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEXT_CLOSEST_FRIENDLY, thisHelp);
+			gameplay_help_init_control_line(TARGET_PREV_CLOSEST_FRIENDLY, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEXT_SUBOBJECT, thisHelp);
+			gameplay_help_init_control_line(TARGET_PREV_SUBOBJECT, thisHelp);
+			gameplay_help_init_control_line(TARGET_SUBOBJECT_IN_RETICLE, thisHelp);
+			gameplay_help_init_control_line(MATCH_TARGET_SPEED, thisHelp);
+			gameplay_help_init_control_line(TOGGLE_AUTO_MATCH_TARGET_SPEED, thisHelp);
+
+			break;
+
+		case GP_HELP_ADVANCED_TARGET_KEYS:
+			thisHelp.title = XSTR("Advanced Targeting Keys", 149);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line(TARGET_CLOSEST_SHIP_ATTACKING_SELF, thisHelp);
+			gameplay_help_init_control_line(TARGET_CLOSEST_SHIP_ATTACKING_TARGET, thisHelp);
+			gameplay_help_init_control_line(TARGET_LAST_TRANMISSION_SENDER, thisHelp);
+			gameplay_help_init_control_line(TARGET_TARGETS_TARGET, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEXT_ESCORT_SHIP, thisHelp);
+			gameplay_help_init_control_line(TARGET_CLOSEST_REPAIR_SHIP, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEXT_UNINSPECTED_CARGO, thisHelp);
+			gameplay_help_init_control_line(TARGET_PREV_UNINSPECTED_CARGO, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEWEST_SHIP, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEXT_BOMB, thisHelp);
+			gameplay_help_init_control_line(TARGET_PREV_BOMB, thisHelp);
+			gameplay_help_init_control_line(STOP_TARGETING_SHIP, thisHelp);
+			gameplay_help_init_control_line(TARGET_NEXT_LIVE_TURRET, thisHelp);
+			gameplay_help_init_control_line(TARGET_PREV_LIVE_TURRET, thisHelp);
+			gameplay_help_init_control_line(STOP_TARGETING_SUBSYSTEM, thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("F5...F12", 143), XSTR("Select target assigned to that hotkey", 150), thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("Shift-F5...F12", 151), XSTR("Add/remove target from that hotkey", 152), thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("Alt-Shift-F5...F12", 153), XSTR("Clear that hotkey", 154), thisHelp);
+
+			break;
+
+		case GP_HELP_MESSAGING:
+			thisHelp.title = XSTR("Messaging Keys", 155);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line(SQUADMSG_MENU, thisHelp);
+			gameplay_help_init_control_line(REARM_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(ATTACK_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(DISARM_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(DISABLE_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(CAPTURE_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(ENGAGE_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(FORM_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(IGNORE_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(PROTECT_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(COVER_MESSAGE, thisHelp);
+			gameplay_help_init_control_line(WARP_MESSAGE, thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("F5...F12", 143),
+				XSTR("send specified order to these target(s)", 156),
+				thisHelp);
+
+			break;
+
+		case GP_HELP_WEAPON_KEYS:
+			thisHelp.title = XSTR("Weapon Keys", 157);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line(FIRE_PRIMARY, thisHelp);
+			gameplay_help_init_control_line(FIRE_SECONDARY, thisHelp);
+			gameplay_help_init_control_line(CYCLE_NEXT_PRIMARY, thisHelp);
+			gameplay_help_init_control_line(CYCLE_PREV_PRIMARY, thisHelp);
+			gameplay_help_init_control_line(CYCLE_SECONDARY, thisHelp);
+			gameplay_help_init_control_line(CYCLE_NUM_MISSLES, thisHelp);
+			gameplay_help_init_control_line(LAUNCH_COUNTERMEASURE, thisHelp);
+
+			break;
+
+		case GP_HELP_THROTTLE_AND_ETS_KEYS:
+			thisHelp.title = XSTR("Energy Management Keys", 158);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line(SHIELD_EQUALIZE, thisHelp);
+			gameplay_help_init_control_line(SHIELD_XFER_TOP, thisHelp);
+			gameplay_help_init_control_line(SHIELD_XFER_BOTTOM, thisHelp);
+			gameplay_help_init_control_line(SHIELD_XFER_LEFT, thisHelp);
+			gameplay_help_init_control_line(SHIELD_XFER_RIGHT, thisHelp);
+			gameplay_help_init_control_line(INCREASE_WEAPON, thisHelp);
+			gameplay_help_init_control_line(DECREASE_WEAPON, thisHelp);
+			gameplay_help_init_control_line(INCREASE_SHIELD, thisHelp);
+			gameplay_help_init_control_line(DECREASE_SHIELD, thisHelp);
+			gameplay_help_init_control_line(INCREASE_ENGINE, thisHelp);
+			gameplay_help_init_control_line(DECREASE_ENGINE, thisHelp);
+			gameplay_help_init_control_line(ETS_EQUALIZE, thisHelp);
+			/*
+			gameplay_help_init_control_line(XFER_LASER, thisHelp);
+			gameplay_help_init_control_line(XFER_SHIELD, thisHelp);
+			*/
+
+			break;
+
+		case GP_HELP_MISC_KEYS:
+			thisHelp.title = XSTR("Miscellaneous Keys", 159);
+
+			thisHelp.header = "";
+
+			// ending mission
+			gameplay_help_init_control_line(END_MISSION, thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("ESC", 160), XSTR("invoke abort mission popup", 161), thisHelp);
+
+			// time compression
+			gameplay_help_init_control_line(TIME_SPEED_UP, thisHelp);
+			gameplay_help_init_control_line(TIME_SLOW_DOWN, thisHelp);
+
+			// radar keys
+			gameplay_help_init_control_line(RADAR_RANGE_CYCLE, thisHelp);
+
+			// escort view keys
+			gameplay_help_init_control_line(ADD_REMOVE_ESCORT, thisHelp);
+			gameplay_help_init_control_line(ESCORT_CLEAR, thisHelp);
+
+			// Pause, Print Screenshot
+			gameplay_help_init_control_line_raw(XSTR("Pause", 162), XSTR("pause game", 163), thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("Print Scrn", 164), XSTR("take screen shot", 165), thisHelp);
+
+			break;
+
+		case GP_HELP_VIEW_KEYS:
+			thisHelp.title = XSTR("View Keys", 166);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line(PADLOCK_UP, thisHelp);
+			gameplay_help_init_control_line(PADLOCK_DOWN, thisHelp);
+			gameplay_help_init_control_line(PADLOCK_LEFT, thisHelp);
+			gameplay_help_init_control_line(PADLOCK_RIGHT, thisHelp);
+			gameplay_help_init_control_line(VIEW_CHASE, thisHelp);
+			gameplay_help_init_control_line(VIEW_EXTERNAL, thisHelp);
+			gameplay_help_init_control_line(VIEW_EXTERNAL_TOGGLE_CAMERA_LOCK, thisHelp);
+			gameplay_help_init_control_line(VIEW_SLEW, thisHelp);
+			gameplay_help_init_control_line(VIEW_DIST_INCREASE, thisHelp);
+			gameplay_help_init_control_line(VIEW_DIST_DECREASE, thisHelp);
+			gameplay_help_init_control_line(VIEW_CENTER, thisHelp);
+			gameplay_help_init_control_line(VIEW_OTHER_SHIP, thisHelp);
+
+			break;
+
+		case GP_HELP_MULTI_KEYS:
+			thisHelp.title = XSTR("Multiplayer Keys", 167);
+
+			thisHelp.header = XSTR("Ingame messaging keys (tap for text, hold for voice)", 168);
+
+			gameplay_help_init_control_line(MULTI_MESSAGE_ALL, thisHelp);
+			gameplay_help_init_control_line(MULTI_MESSAGE_FRIENDLY, thisHelp);
+			gameplay_help_init_control_line(MULTI_MESSAGE_HOSTILE, thisHelp);
+			gameplay_help_init_control_line(MULTI_MESSAGE_TARGET, thisHelp);
+
+			break;
+
+		case GP_HELP_FUNCTION_KEYS:
+			thisHelp.title = XSTR("Function Keys", 134);
+
+			thisHelp.header = "";
+
+			gameplay_help_init_control_line_raw(XSTR("F1", 135), XSTR("context-sensitive help", 136), thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("F2", 137),
+				XSTR("options screen (available anywhere in game)", 138),
+				thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("F3", 139), XSTR("hotkey assignment", 140), thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("F4", 141), XSTR("HUD message scroll-back", 142), thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("F5...F12", 143), XSTR("hotkeys", 144), thisHelp);
+			gameplay_help_init_control_line_raw(XSTR("Shift-Esc", 145),
+				XSTR("quit FreeSpace 2 immediately", 146),
+				thisHelp);
+
+			break;
+
+		}
+
+		complete_help_text.push_back(thisHelp);
+	}
+
+	return complete_help_text;
 }
 
 // called once when the gameplay help state is entered
@@ -169,6 +440,9 @@ void gameplay_help_init()
 	if ( Gameplay_help_inited ) {
 		return;
 	}
+
+	// init all the help text
+	Help_text = gameplay_help_init_text();
 
 	common_set_interface_palette("InterfacePalette");  // set the interface palette
 	Ui_window.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);
@@ -204,7 +478,7 @@ void gameplay_help_init()
 
 	Background_bitmap = bm_load(Game_help_filename[gr_screen.res]);
 
-	Current_help_page = GP_HELP_BASIC_KEYS;
+	Current_help_page = GP_FIRST_SCREEN;
 	Gameplay_help_inited = 1;
 }
 
@@ -297,456 +571,43 @@ void gameplay_help_draw_text()
 
 	separation = gr_get_font_height() + 3;
 
-	switch ( Current_help_page ) {
+	gameplay_help_section thisHelp = Help_text[Current_help_page];
 
-		case GP_HELP_BASIC_KEYS:
-		{
-			gameplay_help_set_title(XSTR("Basic Keys", 133));
-			x_offset = X_OFFSET_1;
-			y_offset = Y_START;
+	gameplay_help_set_title(&thisHelp.title);
+	x_offset = X_OFFSET_1;
+	y_offset = Y_START;
 
+	// if we have a header then display it
+	if (thisHelp.header.length() > 0) {
+		gameplay_help_blit_header_text(y_offset, &thisHelp.header);
+		y_offset += separation;
+	}
+
+	// blit help text for each key
+	for (int i = 0; i < (int)thisHelp.key.size(); i++) {
+		y_offset += separation;
+		gameplay_help_blit_help_text(x_offset, y_offset, &thisHelp.key[i], &thisHelp.text[i]);
+	}
+
+	// Special handling of function keys to display on the same page as the basic keys
+	if (Current_help_page == GP_HELP_BASIC_KEYS) {
+
+		y_offset += separation;
+		y_offset += separation;
+
+		thisHelp = Help_text[GP_HELP_FUNCTION_KEYS];
+
+		gameplay_help_blit_header_text(y_offset, &thisHelp.title);
+
+		y_offset += separation;
+		y_offset += separation;
+
+		// blit help text for each key
+		for (int i = 0; i < (int)thisHelp.key.size(); i++) {
 			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, END_MISSION);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, FIRE_PRIMARY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, MAX_THROTTLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, ZERO_THROTTLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, TARGET_NEXT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, TARGET_PREV);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, TOGGLE_AUTO_TARGETING);
-
-			y_offset += separation;
-			y_offset += separation;
-
-			gr_set_color_fast(&Color_bright);
-			int w;
-			gr_get_string_size(&w, NULL, XSTR("Function Keys", 134));
-			gr_printf_menu((gr_screen.clip_width - w) / 2, y_offset, "%s", XSTR("Function Keys", 134));
-			gr_set_color_fast(&Color_normal);
-
-			y_offset += separation;
-			y_offset += separation;
-
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR("F1", 135), XSTR("context-sensitive help", 136));
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR("F2", 137), XSTR("options screen (available anywhere in game)", 138));
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR("F3", 139), XSTR("hotkey assignment", 140));
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR("F4", 141), XSTR("HUD message scroll-back", 142));
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR("F5...F12", 143), XSTR("hotkeys", 144));
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR("Shift-Esc", 145), XSTR("quit FreeSpace 2 immediately", 146));
-
-			break;
+			gameplay_help_blit_help_text(x_offset, y_offset, &thisHelp.key[i], &thisHelp.text[i]);
 		}
-		case GP_HELP_MOVEMENT_KEYS:
-			gameplay_help_set_title(XSTR( "Movement Keys", 147));
-			x_offset=X_OFFSET_1;
-			y_offset=Y_START;
-
-			gameplay_help_blit_control_line(x_offset, y_offset,FORWARD_THRUST);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,MAX_THROTTLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,ONE_THIRD_THROTTLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TWO_THIRDS_THROTTLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,MINUS_5_PERCENT_THROTTLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,PLUS_5_PERCENT_THROTTLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,ZERO_THROTTLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,AFTERBURNER);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,REVERSE_THRUST);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,PITCH_FORWARD);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,PITCH_BACK);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,YAW_LEFT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,YAW_RIGHT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,BANK_LEFT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,BANK_RIGHT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,BANK_WHEN_PRESSED);
-			break;
-
-		case GP_HELP_COMMON_TARGET_KEYS:
-			gameplay_help_set_title(XSTR( "Basic Targeting Keys", 148));
-			x_offset=X_OFFSET_1;
-			y_offset=Y_START;
-
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEXT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_PREV);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TOGGLE_AUTO_TARGETING);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_SHIP_IN_RETICLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEXT_CLOSEST_HOSTILE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_PREV_CLOSEST_HOSTILE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEXT_CLOSEST_FRIENDLY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_PREV_CLOSEST_FRIENDLY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEXT_SUBOBJECT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_PREV_SUBOBJECT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_SUBOBJECT_IN_RETICLE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,MATCH_TARGET_SPEED);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TOGGLE_AUTO_MATCH_TARGET_SPEED);
-			break;
-
-		case GP_HELP_ADVANCED_TARGET_KEYS:
-			gameplay_help_set_title(XSTR( "Advanced Targeting Keys", 149));
-			x_offset=X_OFFSET_1;
-			y_offset=Y_START;
-
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_CLOSEST_SHIP_ATTACKING_SELF);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_CLOSEST_SHIP_ATTACKING_TARGET);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_LAST_TRANMISSION_SENDER);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_TARGETS_TARGET);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEXT_ESCORT_SHIP);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_CLOSEST_REPAIR_SHIP);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEXT_UNINSPECTED_CARGO);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_PREV_UNINSPECTED_CARGO);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEWEST_SHIP);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEXT_BOMB);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_PREV_BOMB);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,STOP_TARGETING_SHIP);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_NEXT_LIVE_TURRET);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TARGET_PREV_LIVE_TURRET);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,STOP_TARGETING_SUBSYSTEM);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR( "F5...F12", 143), XSTR( "Select target assigned to that hotkey", 150));
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR( "Shift-F5...F12", 151), XSTR( "Add/remove target from that hotkey", 152));
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR( "Alt-Shift-F5...F12", 153), XSTR( "Clear that hotkey", 154));
-
-			break;
-
-		case GP_HELP_MESSAGING:
-			gameplay_help_set_title(XSTR( "Messaging Keys", 155));
-			x_offset=X_OFFSET_1;
-			y_offset=Y_START;
-
-			gameplay_help_blit_control_line(x_offset, y_offset,SQUADMSG_MENU);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,REARM_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,ATTACK_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,DISARM_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,DISABLE_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,CAPTURE_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,ENGAGE_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,FORM_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,IGNORE_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,PROTECT_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,COVER_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,WARP_MESSAGE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset, y_offset, XSTR( "F5...F12", 143), XSTR( "send specified order to these target(s)", 156));
-			break;
-
-		case GP_HELP_WEAPON_KEYS:
-			gameplay_help_set_title(XSTR( "Weapon Keys", 157));
-			x_offset=X_OFFSET_1;
-			y_offset=Y_START;
-
-			gameplay_help_blit_control_line(x_offset, y_offset,FIRE_PRIMARY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,FIRE_SECONDARY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,CYCLE_NEXT_PRIMARY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,CYCLE_PREV_PRIMARY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,CYCLE_SECONDARY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,CYCLE_NUM_MISSLES);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,LAUNCH_COUNTERMEASURE);
-			break;
-
-		case GP_HELP_THROTTLE_AND_ETS_KEYS:
-			gameplay_help_set_title(XSTR( "Energy Management Keys", 158));
-			x_offset=X_OFFSET_1;
-			y_offset=Y_START;
-
-			gameplay_help_blit_control_line(x_offset, y_offset,SHIELD_EQUALIZE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,SHIELD_XFER_TOP);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,SHIELD_XFER_BOTTOM);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,SHIELD_XFER_LEFT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,SHIELD_XFER_RIGHT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,INCREASE_WEAPON);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,DECREASE_WEAPON);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,INCREASE_SHIELD);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,DECREASE_SHIELD);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,INCREASE_ENGINE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,DECREASE_ENGINE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,ETS_EQUALIZE);
-/*
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,XFER_LASER);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,XFER_SHIELD);
-*/
-			break;
-
-		case GP_HELP_MISC_KEYS:
-			gameplay_help_set_title(XSTR( "Miscellaneous Keys", 159));
-			x_offset=X_OFFSET_1;
-			y_offset=Y_START;
-
-			// ending mission
-			//
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,END_MISSION);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset,y_offset, XSTR( "ESC", 160), XSTR( "invoke abort mission popup", 161));
-
-			// time compression
-			//
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TIME_SPEED_UP);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,TIME_SLOW_DOWN);
-
-			// radar keys
-			//
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,RADAR_RANGE_CYCLE);
-
-			// escort view keys
-			//
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,ADD_REMOVE_ESCORT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,ESCORT_CLEAR);
-
-			// Pause, Print Screenshot
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset,y_offset, XSTR( "Pause", 162), XSTR( "pause game", 163));            
-
-			y_offset += separation;
-			gameplay_help_blit_control_line_raw(x_offset,y_offset, XSTR( "Print Scrn", 164), XSTR( "take screen shot", 165));            
-
-			break;
-
-		case GP_HELP_VIEW_KEYS:
-			gameplay_help_set_title(XSTR( "View Keys", 166));
-			x_offset=X_OFFSET_1;
-			y_offset=Y_START;
-
-			gameplay_help_blit_control_line(x_offset, y_offset,PADLOCK_UP);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,PADLOCK_DOWN);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,PADLOCK_LEFT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,PADLOCK_RIGHT);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,VIEW_CHASE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,VIEW_EXTERNAL);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,VIEW_EXTERNAL_TOGGLE_CAMERA_LOCK);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,VIEW_SLEW);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,VIEW_DIST_INCREASE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,VIEW_DIST_DECREASE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,VIEW_CENTER);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset,VIEW_OTHER_SHIP);
-			break;
-
-		case GP_HELP_MULTI_KEYS:
-		{
-			gameplay_help_set_title(XSTR("Multiplayer Keys", 167));
-			x_offset = X_OFFSET_1;
-			y_offset = Y_START;
-
-			// ingame messaging
-			gr_set_color_fast(&Color_bright);
-			int w;
-			gr_get_string_size(&w, NULL, XSTR("Ingame messaging keys (tap for text, hold for voice)", 168));
-			gr_printf_menu((gr_screen.clip_width - w) / 2, y_offset, "%s", XSTR("Ingame messaging keys (tap for text, hold for voice)", 168));
-			gr_set_color_fast(&Color_normal);
-
-			y_offset += separation;
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, MULTI_MESSAGE_ALL);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, MULTI_MESSAGE_FRIENDLY);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, MULTI_MESSAGE_HOSTILE);
-
-			y_offset += separation;
-			gameplay_help_blit_control_line(x_offset, y_offset, MULTI_MESSAGE_TARGET);
-
-			break;
-		}
-
-	} //	end switch		
+	}		
 }
 
 // gameplay_help_do_frame() is the function that displays help when acutally playing the game

--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -52,7 +52,7 @@ enum : int {
 	// but will need special handling to display in the retail UI
 	GP_HELP_FUNCTION_KEYS, 
 
-	First_avialable_section
+	First_available_section
 };
 
 #define GP_FIRST_SCREEN									0		// keep up to date
@@ -196,7 +196,7 @@ SCP_vector<gameplay_help_section> gameplay_help_init_text()
 {
 	SCP_vector<gameplay_help_section> complete_help_text;
 
-	for (int i = 0; i < First_avialable_section; i++) {
+	for (int i = 0; i < First_available_section; i++) {
 
 		gameplay_help_section thisHelp;
 

--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -423,6 +423,9 @@ SCP_vector<gameplay_help_section> gameplay_help_init_text()
 
 			break;
 
+		default:
+			continue;
+
 		}
 
 		complete_help_text.push_back(thisHelp);

--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -34,7 +34,7 @@
 
 // different gameplay help pages
 enum : int {
-	// The first 9 are the retail pages
+	// The first 9 are the basic retail pages
 	GP_HELP_BASIC_KEYS,
 	GP_HELP_MOVEMENT_KEYS,
 	GP_HELP_COMMON_TARGET_KEYS,
@@ -44,17 +44,20 @@ enum : int {
 	GP_HELP_THROTTLE_AND_ETS_KEYS,
 	GP_HELP_VIEW_KEYS,
 	GP_HELP_MISC_KEYS,
+
+	// Plus one for multi only
 	GP_HELP_MULTI_KEYS,
 
 	// Any others defined here will have unique sections within the vector
 	// but will need special handling to display in the retail UI
-	GP_HELP_FUNCTION_KEYS
+	GP_HELP_FUNCTION_KEYS, 
+
+	First_avialable_section
 };
 
 #define GP_FIRST_SCREEN									0		// keep up to date
 #define GP_LAST_SCREEN_SINGLE							8		// keep up to date
 #define GP_LAST_SCREEN_MULTI							9		// keep up to date
-#define GP_NUM_HELP_SECTIONS							10		// keep up to date
 
 // set this to GP_LAST_SCREEN_SINGLE or GP_LAST_SCREEN_MULTI based upon what game mode we're in
 static int Gp_last_screen;
@@ -193,7 +196,7 @@ SCP_vector<gameplay_help_section> gameplay_help_init_text()
 {
 	SCP_vector<gameplay_help_section> complete_help_text;
 
-	for (int i = 0; i <= GP_NUM_HELP_SECTIONS; i++) {
+	for (int i = 0; i < First_avialable_section; i++) {
 
 		gameplay_help_section thisHelp;
 

--- a/code/gamehelp/gameplayhelp.h
+++ b/code/gamehelp/gameplayhelp.h
@@ -12,6 +12,15 @@
 #ifndef __GAMEPLAY_HELP_H__
 #define __GAMEPLAY_HELP_H__
 
+struct gameplay_help_section {
+	SCP_string title;
+	SCP_string header;
+	SCP_vector<SCP_string> key;
+	SCP_vector<SCP_string> text;
+};
+
+SCP_vector<gameplay_help_section> gameplay_help_init_text();
+
 void gameplay_help_init();
 void gameplay_help_do_frame(float frametime);
 


### PR DESCRIPTION
Refactors the in-mission gameplay help with SPCUI in mind. Instead of defining text strings at the same time as drawing them, it now inits all the help text into a vector of help sections first. On frame it will draw the current section. Special handling is in place to deal with some minor unique retail UI cases (like function keys).

With this in place, Lua can be granted access to the vector of help text much easier in a later PR so that the UI can be replicated in SCPUI.