### PR TITLE
make collision_group_id accessible to parse objects

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1864,6 +1864,9 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 	// Goober5000 - make the parse object aware of what it was created as
 	p_objp->created_object = &Objects[objnum];
 
+	// Goober5000 - set the collision group if one was provided
+	Objects[objnum].collision_group_id = p_objp->collision_group_id;
+
 	// Goober5000 - if this object is being created because he's docked to something,
 	// and he's in a wing, then mark the wing as having arrived
 	if (object_is_docked(p_objp) && !(p_objp->flags[Mission::Parse_Object_Flags::SF_Dock_leader]) && (p_objp->wingnum >= 0))

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -342,6 +342,7 @@ public:
 	SCP_set<size_t> orders_accepted;		// which orders this ship will accept from the player
 	p_dock_instance	*dock_list = nullptr;				// Goober5000 - parse objects this parse object is docked to
 	object *created_object = nullptr;					// Goober5000
+	int collision_group_id = 0;							// Goober5000
 	int	group = -1;								// group object is within or -1 if none.
 	int	persona_index = -1;
 	int	kamikaze_damage = 0;					// base damage for a kamikaze attack

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -324,7 +324,7 @@ ADE_FUNC(getBreedName, l_Object, NULL, "Gets object type", "string", "Object typ
 	return ade_set_args(L, "s", Object_type_names[objh->objp->type]);
 }
 
-ADE_VIRTVAR(CollisionGroups, l_Object, "number", "Collision group data", "number", "Current collision group signature. NOTE: This is a bitfield, NOT a normal number.")
+ADE_VIRTVAR(CollisionGroups, l_Object, "number", "Collision group data", "number", "Current set of collision groups. NOTE: This is a bitfield, NOT a normal number.")
 {
 	object_h *objh = NULL;
 	int id = 0;
@@ -355,6 +355,8 @@ ADE_FUNC(addToCollisionGroup, l_Object, "number group", "Adds this object to the
 
 	if (group >= 0 && group <= 31)
 		objh->objp->collision_group_id |= (1 << group);
+	else
+		Warning(LOCATION, "In addToCollisionGroup, group %d must be between 0 and 31, inclusive", group);
 
 	return ADE_RETURN_NIL;
 }
@@ -372,6 +374,8 @@ ADE_FUNC(removeFromCollisionGroup, l_Object, "number group", "Removes this objec
 
 	if (group >= 0 && group <= 31)
 		objh->objp->collision_group_id &= ~(1 << group);
+	else
+		Warning(LOCATION, "In removeFromCollisionGroup, group %d must be between 0 and 31, inclusive", group);
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/objs/parse_object.cpp
+++ b/code/scripting/api/objs/parse_object.cpp
@@ -471,6 +471,61 @@ ADE_FUNC(makeShipArrive, l_ParseObject, nullptr, "Causes this parsed ship to arr
 	return mission_maybe_make_ship_arrive(poh->getObject(), true) ? ADE_RETURN_TRUE : ADE_RETURN_FALSE;
 }
 
+ADE_VIRTVAR(CollisionGroups, l_ParseObject, "number", "Collision group data", "number", "Current set of collision groups. NOTE: This is a bitfield, NOT a normal number.")
+{
+	parse_object_h* poh = nullptr;
+	int id = 0;
+	if (!ade_get_args(L, "o|i", l_ParseObject.GetPtr(&poh), &id))
+		return ade_set_error(L, "i", 0);
+
+	if (!poh->isValid())
+		return ade_set_error(L, "i", 0);
+
+	//Set collision group data
+	if (ADE_SETTING_VAR)
+		poh->getObject()->collision_group_id = id;
+
+	return ade_set_args(L, "i", poh->getObject()->collision_group_id);
+}
+
+ADE_FUNC(addToCollisionGroup, l_ParseObject, "number group", "Adds this parsed ship to the specified collision group.  The group must be between 0 and 31, inclusive.", nullptr, "Returns nothing")
+{
+	parse_object_h* poh = nullptr;
+	int group;
+
+	if (!ade_get_args(L, "oi", l_ParseObject.GetPtr(&poh), &group))
+		return ADE_RETURN_NIL;
+
+	if (!poh->isValid())
+		return ADE_RETURN_NIL;
+
+	if (group >= 0 && group <= 31)
+		poh->getObject()->collision_group_id |= (1 << group);
+	else
+		Warning(LOCATION, "In addToCollisionGroup, group %d must be between 0 and 31, inclusive", group);
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(removeFromCollisionGroup, l_ParseObject, "number group", "Removes this parsed ship from the specified collision group.  The group must be between 0 and 31, inclusive.", nullptr, "Returns nothing")
+{
+	parse_object_h* poh = nullptr;
+	int group;
+
+	if (!ade_get_args(L, "oi", l_ParseObject.GetPtr(&poh), &group))
+		return ADE_RETURN_NIL;
+
+	if (!poh->isValid())
+		return ADE_RETURN_NIL;
+
+	if (group >= 0 && group <= 31)
+		poh->getObject()->collision_group_id &= ~(1 << group);
+	else
+		Warning(LOCATION, "In removeFromCollisionGroup, group %d must be between 0 and 31, inclusive", group);
+
+	return ADE_RETURN_NIL;
+}
+
 parse_subsys_h::parse_subsys_h() = default;
 parse_subsys_h::parse_subsys_h(p_object* obj, int subsys_offset) : _obj(obj), _subsys_offset(subsys_offset) {}
 subsys_status* parse_subsys_h::getSubsys() const { return &Subsys_status[_obj->subsys_index + _subsys_offset]; }


### PR DESCRIPTION
Add collision groups to parse objects so they can be set before arrival via script.