### PR TITLE
Remove nebula bitmap limit

### DIFF
--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -70,11 +70,7 @@ const float PROBABLY_TOO_MANY_POOFS = 100000.0f;
 int32_t Neb2_poof_flags = 0;
 
 // array of neb2 bitmaps
-char Neb2_bitmap_filenames[MAX_NEB2_BITMAPS][MAX_FILENAME_LEN] = {
-	"", "", "", "", "", ""
-};
-int Neb2_bitmap[MAX_NEB2_BITMAPS] = { -1, -1, -1, -1, -1, -1 };
-int Neb2_bitmap_count = 0;
+SCP_vector<SCP_string> Neb2_bitmap_filenames;
 
 // texture to use for this level
 char Neb2_texture_name[MAX_FILENAME_LEN] = "";
@@ -196,13 +192,12 @@ void parse_nebula_table(const char* filename)
 				continue;
 			}
 
-			if (Neb2_bitmap_count < MAX_NEB2_BITMAPS) {
-				strcpy_s(Neb2_bitmap_filenames[Neb2_bitmap_count++], name);
-			}
-			else {
-				WarningEx(LOCATION, "nebula.tbl\nExceeded maximum number of nebulas (%d)!\nSkipping %s.", MAX_NEB2_BITMAPS, name);
-			}
+			Neb2_bitmap_filenames.push_back(name);
 		}
+
+		// allow modular tables to not define poofs
+		if (Parsing_modular_table && check_for_eof())
+			return;
 
 		// poofs
 		while (required_string_one_of(3, "#end", "+Poof:", "$Name:")) {
@@ -337,7 +332,6 @@ void parse_nebula_table(const char* filename)
 // initialize neb2 stuff at game startup
 void neb2_init()
 {
-	Neb2_bitmap_count = 0;
 
 	// first parse the default table
 	parse_nebula_table("nebula.tbl");

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -58,10 +58,8 @@ extern float Neb2_fog_visibility_fireball_scaled_factor;
 extern int Neb2_poof_flags;
 const size_t MAX_NEB2_POOFS = 32;
 
-#define MAX_NEB2_BITMAPS			10
-
 // pof texture filenames
-extern char Neb2_bitmap_filenames[MAX_NEB2_BITMAPS][MAX_FILENAME_LEN];
+extern SCP_vector<SCP_string> Neb2_bitmap_filenames;
 
 // texture to use for this level
 extern char Neb2_texture_name[MAX_FILENAME_LEN];

--- a/fred2/bgbitmapdlg.cpp
+++ b/fred2/bgbitmapdlg.cpp
@@ -278,9 +278,9 @@ void bg_bitmap_dlg::create()
 		m_skybox_heading = m_skybox_heading + 360;
 
 
-	for(i=0; i<MAX_NEB2_BITMAPS; i++){
-		if(strlen(Neb2_bitmap_filenames[i]) > 0){ //-V805
-			((CComboBox*)GetDlgItem(IDC_NEB2_TEXTURE))->AddString(Neb2_bitmap_filenames[i]);
+	for (i = 0; i < (int)Neb2_bitmap_filenames.size(); i++) {
+		if (Neb2_bitmap_filenames[i].length() > 0) {
+			((CComboBox*)GetDlgItem(IDC_NEB2_TEXTURE))->AddString(Neb2_bitmap_filenames[i].c_str());
 		}
 	}
 	// if we have a texture selected already
@@ -429,7 +429,7 @@ void bg_bitmap_dlg::OnClose()
 		}
 		
 		// get the bitmap name
-		strcpy_s(Neb2_texture_name, Neb2_bitmap_filenames[m_neb2_texture]);
+		strcpy_s(Neb2_texture_name, Neb2_bitmap_filenames[m_neb2_texture].c_str());
 
 		// init the nebula
 		neb2_level_init();
@@ -659,7 +659,7 @@ void bg_bitmap_dlg::OnSelchangeNeb2Texture()
 	if (m_fog_color_override)
 	{
 		ubyte rgb[3];
-		neb2_generate_fog_color(m_neb2_texture >= 0 ? Neb2_bitmap_filenames[m_neb2_texture] : "", rgb);
+		neb2_generate_fog_color(m_neb2_texture >= 0 ? Neb2_bitmap_filenames[m_neb2_texture].c_str() : "", rgb);
 		m_fog_r = rgb[0];
 		m_fog_g = rgb[1];
 		m_fog_b = rgb[2];

--- a/fred2/bgbitmapdlg.cpp
+++ b/fred2/bgbitmapdlg.cpp
@@ -279,9 +279,7 @@ void bg_bitmap_dlg::create()
 
 
 	for (i = 0; i < (int)Neb2_bitmap_filenames.size(); i++) {
-		if (Neb2_bitmap_filenames[i].length() > 0) {
-			((CComboBox*)GetDlgItem(IDC_NEB2_TEXTURE))->AddString(Neb2_bitmap_filenames[i].c_str());
-		}
+		((CComboBox*)GetDlgItem(IDC_NEB2_TEXTURE))->AddString(Neb2_bitmap_filenames[i].c_str());
 	}
 	// if we have a texture selected already
 	if(strlen(Neb2_texture_name) > 0){ //-V805

--- a/fred2/bgbitmapdlg.cpp
+++ b/fred2/bgbitmapdlg.cpp
@@ -429,7 +429,9 @@ void bg_bitmap_dlg::OnClose()
 		}
 		
 		// get the bitmap name
-		strcpy_s(Neb2_texture_name, Neb2_bitmap_filenames[m_neb2_texture].c_str());
+		if ((m_neb2_texture >= 0) && (m_neb2_texture < (int)Neb2_bitmap_filenames.size())){
+			strcpy_s(Neb2_texture_name, Neb2_bitmap_filenames[m_neb2_texture].c_str());
+		}
 
 		// init the nebula
 		neb2_level_init();

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -7125,9 +7125,9 @@ sexp_list_item *sexp_tree::get_listing_opf_nebula_patterns()
 
 	head.add_data(SEXP_NONE_STRING);
 
-	for (int i = 0; i < MAX_NEB2_BITMAPS; i++) {
-		if (strlen(Neb2_bitmap_filenames[i]) > 0) {
-			head.add_data(Neb2_bitmap_filenames[i]);
+	for (int i = 0; i < (int)Neb2_bitmap_filenames.size(); i++) {
+		if (Neb2_bitmap_filenames[i].length() > 0) {
+			head.add_data(Neb2_bitmap_filenames[i].c_str());
 		}
 	}
 

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -7126,9 +7126,7 @@ sexp_list_item *sexp_tree::get_listing_opf_nebula_patterns()
 	head.add_data(SEXP_NONE_STRING);
 
 	for (int i = 0; i < (int)Neb2_bitmap_filenames.size(); i++) {
-		if (Neb2_bitmap_filenames[i].length() > 0) {
-			head.add_data(Neb2_bitmap_filenames[i].c_str());
-		}
+		head.add_data(Neb2_bitmap_filenames[i].c_str());
 	}
 
 	return head.next;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4924,9 +4924,7 @@ sexp_list_item* sexp_tree::get_listing_opf_nebula_patterns() {
 	head.add_data(SEXP_NONE_STRING);
 
 	for (int i = 0; i < (int)Neb2_bitmap_filenames.size(); i++) {
-		if (Neb2_bitmap_filenames[i].length() > 0) {
-			head.add_data(Neb2_bitmap_filenames[i].c_str());
-		}
+		head.add_data(Neb2_bitmap_filenames[i].c_str());
 	}
 
 	return head.next;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4923,9 +4923,9 @@ sexp_list_item* sexp_tree::get_listing_opf_nebula_patterns() {
 
 	head.add_data(SEXP_NONE_STRING);
 
-	for (int i = 0; i < MAX_NEB2_BITMAPS; i++) {
-		if (strlen(Neb2_bitmap_filenames[i]) > 0) {
-			head.add_data(Neb2_bitmap_filenames[i]);
+	for (int i = 0; i < (int)Neb2_bitmap_filenames.size(); i++) {
+		if (Neb2_bitmap_filenames[i].length() > 0) {
+			head.add_data(Neb2_bitmap_filenames[i].c_str());
 		}
 	}
 


### PR DESCRIPTION
Removes MAX_NEB2_BITMAPS which was previously just 10; a limit I hit just but modularizing the MediaVPs nebula.tbl which only adds three bitmaps to retail's 8. Instead of simply raising the limit this PR vectorizes the bitmap list. Bitmaps are only ever referenced by name (unlike poofs which use flags) so it makes sense to just make this a quick vector of strings.

Sneaks in one small QoL parsing feature to check for end of file in a modular table so that -neb.tbms which don't specify poofs won't require two #end lines.