### PR TITLE
Move these checks into asteroid.cpp

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -739,7 +739,10 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 
 	Asteroid_field.target_names = targets;
 
-	asteroid_create_all();
+	// Only create asteroids if we have some to create
+	if ((count > 0) && (num_asteroids > 0)) {
+		asteroid_create_all();
+	}
 }
 
 // will replace any existing asteroid or debris field with a debris field
@@ -794,7 +797,10 @@ void asteroid_create_debris_field(int num_asteroids, int asteroid_speed, int deb
 
 	Asteroid_field.bound_rad = MAX(3000.0f, b_rad);
 
-	asteroid_create_all();
+	// Only create debris if we have some to create
+	if ((count > 0) && (num_asteroids > 0)) {
+		asteroid_create_all();
+	}
 }
 
 /**

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15335,9 +15335,6 @@ void sexp_set_asteroid_field(int n)
 		n = CDR(n);
 	}
 
-	if (!brown && !blue && !orange)
-		return;
-
 	int o_minx = -1000, o_miny = -1000, o_minz = -1000;
 	int o_maxx = 1000, o_maxy = 1000, o_maxz = 1000;
 
@@ -15472,9 +15469,6 @@ void sexp_set_debris_field(int n)
 		debris3 = get_asteroid_position(CTEXT(n));
 		n = CDR(n);
 	}
-
-	if ((debris1 == -1) && (debris2 == -1) && (debris3 == -1))
-		return;
 
 	int o_minx = -1000, o_miny = -1000, o_minz = -1000;
 	int o_maxx = 1000, o_maxy = 1000, o_maxz = 1000;


### PR DESCRIPTION
If types aren't specified then the sexp logic ends early. This is another thing that I missed when making requested changes to the original PR. If the sexp logic ends early then fields cannot be removed by simply specifying 0 for the number of asteroids. So move these checks into the asteroid.cpp function that runs after asteroids have already been cleared but before new ones are created.