### PR TITLE
Better account for runtime gravity changes

### DIFF
--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1042,3 +1042,29 @@ void obj_sort_and_collide(SCP_vector<int>* Collision_list)
 	}
 	obj_find_overlap_colliders(sort_list_y, sort_list_z, 2, true);
 }
+
+void collide_apply_gravity_flags_weapons() {
+	for (int i = 0; i < MAX_OBJECTS; i++) {
+		object* obj = &Objects[i];
+		if (Objects[i].type != OBJ_WEAPON)
+			continue;
+
+		weapon* wp = &Weapons[Objects[i].instance];
+		weapon_info* wip = &Weapon_info[wp->weapon_info_index];
+
+		if (!wip->is_homing() || (wp->weapon_flags[Weapon::Weapon_Flags::No_homing])) {
+			// homing weapons dont get any gravity stuff
+			if (wip->acceleration_time <= 0.0f || Missiontime - wp->creation_time >= fl2f(wip->acceleration_time)) {
+				// if the weapon doesn't accelerate, or has finished accelerating...
+				if (The_mission.gravity == vmd_zero_vector || obj->phys_info.gravity_const == 0.0f) {
+					obj->phys_info.flags |= PF_CONST_VEL;
+					obj->phys_info.flags &= ~PF_BALLISTIC;
+				}
+				else {
+					obj->phys_info.flags |= PF_BALLISTIC;
+					obj->phys_info.flags &= ~PF_CONST_VEL;
+				}
+			}
+		}
+	}
+}

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1045,7 +1045,7 @@ void obj_sort_and_collide(SCP_vector<int>* Collision_list)
 
 void collide_apply_gravity_flags_weapons() {
 	for (object* obj = GET_FIRST(&obj_used_list); obj != END_OF_LIST(&obj_used_list); obj = GET_NEXT(obj)) {
-		if (obj->type != OBJ_WEAPON)
+		if (obj->type != OBJ_WEAPON || obj->flags[Object::Object_Flags::Should_be_dead])
 			continue;
 
 		weapon* wp = &Weapons[obj->instance];

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -1044,12 +1044,11 @@ void obj_sort_and_collide(SCP_vector<int>* Collision_list)
 }
 
 void collide_apply_gravity_flags_weapons() {
-	for (int i = 0; i < MAX_OBJECTS; i++) {
-		object* obj = &Objects[i];
-		if (Objects[i].type != OBJ_WEAPON)
+	for (object* obj = GET_FIRST(&obj_used_list); obj != END_OF_LIST(&obj_used_list); obj = GET_NEXT(obj)) {
+		if (obj->type != OBJ_WEAPON)
 			continue;
 
-		weapon* wp = &Weapons[Objects[i].instance];
+		weapon* wp = &Weapons[obj->instance];
 		weapon_info* wip = &Weapon_info[wp->weapon_info_index];
 
 		if (!wip->is_homing() || (wp->weapon_flags[Weapon::Weapon_Flags::No_homing])) {

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -134,4 +134,8 @@ int get_ship_quadrant_from_global(vec3d *global_pos, object *objp);
 int reject_due_collision_groups(object *A, object *B);
 
 void init_collision_info_struct(collision_info_struct *cis);
+
+// goes over weapons applying gravity-relevant flags
+// VERY IMPORTANT if gravity was just turned on or off
+void collide_apply_gravity_flags_weapons();
 #endif

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13727,7 +13727,14 @@ void sexp_set_gravity_accel(int node)
 		return;
 
 	float fl_accel = (float)(-accel) / 100.0f;
+	vec3d old_gravity = The_mission.gravity;
 	The_mission.gravity = vm_vec_new(0.0f, fl_accel, 0.0f);
+
+	if ((IS_VEC_NULL(&old_gravity) && !IS_VEC_NULL(&The_mission.gravity)) ||
+		(!IS_VEC_NULL(&old_gravity) && IS_VEC_NULL(&The_mission.gravity))) {
+		// gravity was turned on or turned off
+		collide_apply_gravity_flags_weapons();
+	}
 
 	// do the multiplayer callback
 	if (MULTIPLAYER_MASTER) {
@@ -13743,7 +13750,13 @@ void multi_sexp_set_gravity_accel()
 
 	Current_sexp_network_packet.get_float(accel);
 
+	vec3d old_gravity = The_mission.gravity;
 	The_mission.gravity = vm_vec_new(0.0f, accel, 0.0f);
+	if ((IS_VEC_NULL(&old_gravity) && !IS_VEC_NULL(&The_mission.gravity)) ||
+		(!IS_VEC_NULL(&old_gravity) && IS_VEC_NULL(&The_mission.gravity))) {
+		// gravity was turned on or turned off
+		collide_apply_gravity_flags_weapons();
+	}
 }
 
 // this function get called by send-message or send-message random with the name of the message, sender,

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1598,7 +1598,14 @@ ADE_VIRTVAR(Gravity, l_Mission, "vector", "Gravity acceleration vector in meters
 
 	if (ADE_SETTING_VAR && ade_get_args(L, "*o", l_Vector.GetPtr(&gravity_vec)))
 	{
+		vec3d old_gravity = The_mission.gravity;
 		The_mission.gravity = *gravity_vec;
+
+		if ((IS_VEC_NULL(&old_gravity) && !IS_VEC_NULL(&The_mission.gravity)) || 
+			(!IS_VEC_NULL(&old_gravity) && IS_VEC_NULL(&The_mission.gravity))) {
+			// gravity was turned on or turned off
+			collide_apply_gravity_flags_weapons();
+		}
 	}
 
 	return ade_set_args(L, "o", l_Vector.Set(The_mission.gravity));


### PR DESCRIPTION
Whether a weapon has `PF_CONST_VEL` or `PF_BALLISTIC` depends on whether there is gravity *at the moment*, not just when it was fired.