### PR TITLE
fix sunglares when lightshafts are disabled

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -710,7 +710,7 @@ void game_sunspot_process(float frametime)
 			for(idx=0; idx<n_lights; idx++)	{
 				bool in_shadow = shipfx_eye_in_shadow(&Eye_position, Viewer_obj, idx);
 
-				if (gr_lightshafts_enabled() && !in_shadow) {
+				if (!in_shadow) {
 					vec3d light_dir;				
 					light_get_global_dir(&light_dir, idx);
 
@@ -719,8 +719,7 @@ void game_sunspot_process(float frametime)
 						float dot = vm_vec_dot( &light_dir, &Eye_matrix.vec.fvec )*0.5f+0.5f;
 						Sun_spot_goal += (float)pow(dot,85.0f);
 					}
-				}
-				if ( !in_shadow )	{
+
 					// draw the glow for this sun
 					stars_draw_sun_glow(idx);				
 				}


### PR DESCRIPTION
This is another case of a bug introduced by a bugfix, in this case #3885.  The original bug inadvertently made sun glare work in most cases where it was supposed to.

This commit removes the check for lightshafts when drawing the sun glare.  Since sun glare can be drawn regardless of whether lightshafts are enabled, the only thing that matters is to check that the view is not shadowed.

Fixes #5089 