### PR TITLE
Inherit secrets when publishing Release builds

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -411,3 +411,4 @@ jobs:
       windows_result: ${{ needs.windows_zip.result }}
       mac_result: ${{ needs.mac_zip.result }}
       releaseTag: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
Essentially, when a reusable (called) workflow is used, as in our Post Release Builds action, secrets must be explicitly included from the caller workflow via `secrets: inherit`.