### PR TITLE
has-armor-type sexp

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -25217,25 +25217,32 @@ int sexp_has_armor_type(int node)
 		armor = -1;
 	} else {
 		armor = armor_type_get_idx(CTEXT(node));
+
+		//warn and return if the armor is not found
+		if (armor < 0) {
+			Warning(LOCATION, "Armor %s not found on ship %s", CTEXT(node), shipp->ship_name);
+			return SEXP_NAN;
+		}
 	}
 	node = CDR(node);
 
 	// get the armor to check against
 	int currentArmor = -1;
-	for (; node != -1; node = CDR(node)) {
-		if (!stricmp(SEXP_HULL_STRING, CTEXT(node))) {
-			currentArmor = shipp->armor_type_idx;
-		} else if (!stricmp(SEXP_SHIELD_STRING, CTEXT(node))) {
-			currentArmor = shipp->shield_armor_type_idx;
-		} else {
-			// get the subsystem
-			ship_subsys* ss = ship_get_subsys(shipp, CTEXT(node));
-			if (ss == nullptr) {
-				continue;
-			}
 
-			currentArmor = ss->armor_type_idx;
+	if (!stricmp(SEXP_HULL_STRING, CTEXT(node))) {
+		currentArmor = shipp->armor_type_idx;
+	} else if (!stricmp(SEXP_SHIELD_STRING, CTEXT(node))) {
+		currentArmor = shipp->shield_armor_type_idx;
+	} else {
+		// get the subsystem
+		ship_subsys* ss = ship_get_subsys(shipp, CTEXT(node));
+
+		if (ss == nullptr) {
+			Warning(LOCATION, "Subsystem %s not found on ship %s", CTEXT(node), shipp->ship_name);
+			return SEXP_NAN;
 		}
+
+		currentArmor = ss->armor_type_idx;
 	}
 
 	if (currentArmor == armor)

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -25220,7 +25220,7 @@ int sexp_has_armor_type(int node)
 
 		//warn and return if the armor is not found
 		if (armor < 0) {
-			Warning(LOCATION, "Armor %s not found on ship %s", CTEXT(node), shipp->ship_name);
+			Warning(LOCATION, "Armor %s is not a valid entry in armor.tbl!", CTEXT(node));
 			return SEXP_NAN;
 		}
 	}

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -415,6 +415,7 @@ enum : int {
 	OP_IS_IN_MISSION, // Goober5000
 	OP_ARE_SHIP_FLAGS_SET, // Karajorma
 	OP_TURRET_GET_PRIMARY_AMMO, // DahBlount, part of the turret ammo code
+	OP_HAS_ARMOR_TYPE, // MjnMixael
 	
 	OP_TURRET_GET_SECONDARY_AMMO,	// DahBlount, part of the turret ammo code
 	OP_IS_DOCKED,	// Goober5000

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -5820,6 +5820,7 @@ sexp_list_item *sexp_tree::get_listing_opf_subsystem(int parent_node, int arg_in
 
 		// Armor types need Hull and Shields but not Simulated Hull
 		case OP_SET_ARMOR_TYPE:
+		case OP_HAS_ARMOR_TYPE:
 			special_subsys = OPS_ARMOR;
 			break;
 

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -3672,6 +3672,7 @@ sexp_list_item* sexp_tree::get_listing_opf_subsystem(int parent_node, int arg_in
 
 		// Armor types need Hull and Shields but not Simulated Hull
 	case OP_SET_ARMOR_TYPE:
+	case OP_HAS_ARMOR_TYPE:
 		special_subsys = OPS_ARMOR;
 		break;
 


### PR DESCRIPTION
Adds the sexp to check the current armor of a ship or ship's subsystem. Fixes #2854