### PR TITLE
Allow way to prevent scpui loading hires animations

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -131,6 +131,7 @@ bool Always_use_distant_firepoints;
 bool Discord_presence;
 bool Hotkey_always_hide_hidden_ships;
 bool Use_weapon_class_sounds_for_hits_to_player;
+bool SCPUI_loads_hi_res_animations;
 
 static auto DiscordOption = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
 							 .category("Other")
@@ -765,6 +766,10 @@ void parse_mod_table(const char *filename)
 
 		}
 
+		if (optional_string("$SCPUI attempts to load hires animations:")) {
+			stuff_boolean(&SCPUI_loads_hi_res_animations);
+		}
+
 		optional_string("#NETWORK SETTINGS");
 
 		if (optional_string("$FS2NetD port:")) {
@@ -1283,6 +1288,7 @@ void mod_table_reset()
 	Discord_presence = true;
 	Hotkey_always_hide_hidden_ships = false;
 	Use_weapon_class_sounds_for_hits_to_player = false;
+	SCPUI_loads_hi_res_animations = true;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -127,6 +127,7 @@ extern bool Always_use_distant_firepoints;
 extern bool Discord_presence;
 extern bool Hotkey_always_hide_hidden_ships;
 extern bool Use_weapon_class_sounds_for_hits_to_player;
+extern bool SCPUI_loads_hi_res_animations;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -22,6 +22,7 @@
 #include "graphics/2d.h"
 #include "graphics/generic.h"
 #include "graphics/material.h"
+#include "mod_table/mod_table.h"
 #include "tracing/categories.h"
 #include "tracing/tracing.h"
 #define BMPMAN_INTERNAL
@@ -198,7 +199,8 @@ bool RocketRenderingInterface::LoadTexture(TextureHandle& texture_handle, Vector
 
 	std::unique_ptr<Texture> tex(new Texture());
 	// If there is a file that ends with an animation extension, try to load that
-	if (generic_anim_init_and_stream(&tex->animation, filename.c_str(), BM_TYPE_NONE, true) == 0) {
+	if (generic_anim_init_and_stream(&tex->animation, filename.c_str(), BM_TYPE_NONE, SCPUI_loads_hi_res_animations) ==
+		0) {
 		tex->is_animation = true;
 
 		texture_dimensions.x = tex->animation.width;


### PR DESCRIPTION
By default SCPUI/librocket follows FSO's trend of substituting `2_animname.ext` for `animname.ext` if the game's resolution is larger than a certain amount. SCPUI can correctly scale animations dynamically so this behavior isn't required anymore. 

The substitution can be a problem in the case of naming conflicts with upstream files. A local mod may have a hires cb_default but the game hands over the retail 2_cb_default instead. That is not ideal. However, there may still be situations (retail/mediavps) where it would be preferred to get the hires filename in place of the normal one. So this PR allows a quick toggle to enable or disable the behavior for SCPUI.