### PR TITLE
If we're not drawing weapon models then skip all this

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12253,7 +12253,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 				for ( w = 0; w < numtimes; w++ ) {
 					polymodel *weapon_model = NULL;
-					if(winfo_p->external_model_num >= 0) 
+					if (sip->draw_primary_models[bank_to_fire] && (winfo_p->external_model_num >= 0)) 
 						weapon_model = model_get(winfo_p->external_model_num);
 
 					if (weapon_model)


### PR DESCRIPTION
Fixing a 9 year old bug with a single line change. If we're not showing primary weapon models then we don't need to look up any of its information at all, including where to fire from. Fixes #3112