### PR TITLE
Refactor Msg_scrollback_lines

### DIFF
--- a/code/hud/hudmessage.h
+++ b/code/hud/hudmessage.h
@@ -36,17 +36,13 @@ typedef struct HUD_message_data {
 } HUD_message_data;
 
 typedef struct line_node {
-	line_node* next;
-	line_node* prev;
 	fix time;  // timestamp when message was added
 	int source;  // who/what the source of the message was (for color coding)
 	int x;
 	int y;
 	int underline_width;
-	char *text;
+	SCP_string text;
 } line_node;
-
-extern line_node Msg_scrollback_used_list;
 
 typedef struct Hud_display_info {
 	HUD_message_data msg;
@@ -74,7 +70,6 @@ void HUD_init_fixed_text();			//	Clear all pending fixed text.
 void HUD_add_to_scrollback(const char *text, int source);
 void hud_add_line_to_scrollback(const char *text, int source, int t, int x, int y, int w);
 void hud_add_msg_to_scrollback(const char *text, int source, int t);
-void hud_free_scrollback_list();
 
 class HudGaugeMessages: public HudGauge // HUD_MESSAGE_LINES
 {

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6705,7 +6705,6 @@ void game_shutdown(void)
 	particle::close();			// close out the particle system
 	weapon_close();					// free any memory that was allocated for the weapons
 	ship_close();					// free any memory that was allocated for the ships
-	hud_free_scrollback_list();// free space allocated to store hud messages in hud scrollback
 
 	decals::shutdown();
 


### PR DESCRIPTION
Ended up having a couple hours free, so I went at it. Refactor's handling of message scrollback. Changes the linked list to a vector which removes the soft limit of 1000 message lines. Generally just cleans up the code. This PR also moves line splits to init of the scrollback game state instead of when a message is added to scrollback. 

I tested scrollback with 0 messages, with more messages than can be displayed at once (requiring scrolling), and messages with/without needing to be split (once or more than once).

Things to note:
1) Msg_scrollback_vec contains unsplit scrollback messages. This will be later used for SCPUI access.
2) Msg_scrollback_lines contains the actual split lines for display and should only be valid when scrollback game state is active.

This possibly resolves #3662 if that was referring to line splits in the UI rather than in the little blue rendering box seen during a mission because the font can be reset on the game state change and the line splits will be done based on the currently active font. I didn't thoroughly test this because there was no clear example in the ticket to try and reproduce. My local tests showed proper line splits throughout.