### PR TITLE
better safety for `ai_select_secondary_weapon`

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6287,6 +6287,12 @@ void ai_select_secondary_weapon(object *objp, ship_weapon *swp, flagset<Weapon::
 		}
 	}
 
+	Assertion(swp->current_secondary_bank >= 0, "ai_select_secondary_weapon assigned a -1 secondary bank to %s", Ships[objp->instance].ship_name);
+	// if we got an invalid bank somehow, just put it back and bail
+	if (swp->current_secondary_bank < 0) {
+		swp->current_secondary_bank = initial_bank;
+		return;
+	}
 
 	//	If switched banks, force reacquisition of aspect lock.
 	if (swp->current_secondary_bank != initial_bank) {


### PR DESCRIPTION
Meant to address #5150 , but does not resolve it. This function is a red flag in terms of possible sources for a -1 `current_secondary_bank`, lots of values initialized to -1 and then possibly written to it later. But without a test case its difficult to know what set up of weapons and priorities would actually cause that to happen, so best we can do is at least assert this function didn't mangle it, and to put back whatever was there.