### PR TITLE
add versioning support to missions

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -60,7 +60,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // add a new string to the code, you must assign it a new index.  Use the number below for
 // that index and increase the number below by one.
 // retail XSTR_SIZE = 1570
-#define XSTR_SIZE	1671
+#define XSTR_SIZE	1672
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -15,6 +15,7 @@
 
 #include "ai/ai.h"
 #include "ai/ai_profiles.h"
+#include "globalincs/version.h"
 #include "graphics/2d.h"
 #include "io/keycontrol.h"
 #include "model/model.h"
@@ -42,12 +43,11 @@ struct p_dock_instance;
 
 int get_special_anchor(const char *name);
 
-// update version when mission file format changes, and add approprate code
-// to check loaded mission version numbers in the parse code.  Also, be sure
-// to update both MissionParse and MissionSave (FRED) when changing the
-// mission file format!
-#define	MISSION_VERSION 0.10f
-#define	FRED_MISSION_VERSION 0.10f
+// MISSION_VERSION should be the earliest version of FSO that can load the current mission format without
+// requiring version-specific comments.  It should be updated whenever the format changes, but it should
+// not be updated simply because the engine's version changed.
+extern const gameversion::version MISSION_VERSION;
+extern const gameversion::version LEGACY_MISSION_VERSION;
 
 #define WING_PLAYER_BASE	0x80000  // used by Fred to tell ship_index in a wing points to a player
 
@@ -110,7 +110,7 @@ typedef struct mission_cutscene {
 typedef struct mission {
 	char	name[NAME_LENGTH];
 	char	author[NAME_LENGTH];
-	float	version;
+	gameversion::version	required_fso_version;
 	char	created[DATE_TIME_LENGTH];
 	char	modified[DATE_TIME_LENGTH];
 	char	notes[NOTES_LENGTH];

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -14,6 +14,7 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 #include "globalincs/flagset.h"
+#include "globalincs/version.h"
 #include "def_files/def_files.h"
 #include "utils/unicode.h"
 
@@ -397,6 +398,17 @@ namespace parse
 	public:
 		explicit ParseException(const std::string& msg) : std::runtime_error(msg) {}
 		~ParseException() noexcept override = default;
+	};
+
+	class VersionException : public std::runtime_error
+	{
+	private:
+		gameversion::version _required_version;
+
+	public:
+		explicit VersionException(const std::string& msg, const gameversion::version& required_version) : std::runtime_error(msg), _required_version(required_version) {}
+		~VersionException() noexcept override = default;
+		const gameversion::version& required_version() { return _required_version; }
 	};
 
 	/**

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2514,7 +2514,7 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Version:");
 	parse_comments(2);
-	fout(" %.2f", FRED_MISSION_VERSION);
+	fout(" %d.%d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor, The_mission.required_fso_version.build);
 
 	// XSTR
 	required_string_fred("$Name:");
@@ -2897,6 +2897,9 @@ void CFred_mission_save::save_mission_internal(const char *pathname)
 
 	t = CTime::GetCurrentTime();
 	strcpy_s(The_mission.modified, t.Format("%x at %X"));
+
+	// Migrate the version!
+	The_mission.required_fso_version = MISSION_VERSION;
 
 	reset_parse();
 	fred_parse_flag = 0;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1403,7 +1403,14 @@ bool game_start_mission()
 
 	if ( !load_success ) {
 		if ( !(Game_mode & GM_MULTIPLAYER) ) {
-			popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "Attempt to load the mission failed", 169));
+			// the version will have been assigned before loading was aborted
+			if (!gameversion::check_at_least(The_mission.required_fso_version)) {
+				popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("This mission requires FSO version %s", 1671), format_version(The_mission.required_fso_version).c_str());
+			}
+			// standard load failure
+			else {
+				popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Attempt to load the mission failed", 169));
+			}
 			gameseq_post_event(GS_EVENT_MAIN_MENU);
 		} else {
 			multi_quit_game(PROMPT_NONE, MULTI_END_NOTIFY_NONE, MULTI_END_ERROR_LOAD_FAIL);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2215,7 +2215,7 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Version:");
 	parse_comments(2);
-	fout(" %.2f", FRED_MISSION_VERSION);
+	fout(" %d.%d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor, The_mission.required_fso_version.build);
 
 	// XSTR
 	required_string_fred("$Name:");
@@ -2612,8 +2612,10 @@ void CFred_mission_save::save_mission_internal(const char* pathname)
 
 	time(&rawtime);
 	auto timeinfo = localtime(&rawtime);
-
 	strftime(The_mission.modified, sizeof(The_mission.modified), "%x at %X", timeinfo);
+
+	// Migrate the version!
+	The_mission.required_fso_version = MISSION_VERSION;
 
 	reset_parse();
 	fred_parse_flag = 0;


### PR DESCRIPTION
This finally enables the `$Version:` field in FreeSpace missions, which has been present ever since the beginning of FS1's development but has never been used for its intended purpose.  This field now stores the version of FSO that is required to run the mission.  If the version of the engine is not sufficient to run the version of the mission, then a) the mission is hidden from the mission listing, or b) a friendly notification is displayed if the mission is loaded anyway (for example, through a campaign).  Furthermore, FRED will notify the user if the mission's version is migrated from any version other than the legacy 0.10.

It will be the responsibility of coders who modify the mission format to also update the `MISSION_VERSION` constant with the appropriate major/minor/build/revision of the format change.