### PR TITLE
Don't try to choose a secondary if there are no choices

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6241,6 +6241,10 @@ void ai_select_secondary_weapon(object *objp, ship_weapon *swp, flagset<Weapon::
 	//	Stuff weapon_bank_list with bank index of available weapons.
 	num_weapon_types = get_available_secondary_weapons(objp, weapon_id_list, weapon_bank_list);
 
+	//  If there are no valid choices, bail
+	if (num_weapon_types == 0)
+		return;
+
 	// Ignore homing weapons if we didn't specify a flag - for priority 1
 	if ((aip->ai_profile_flags[AI::Profile_Flags::Smart_secondary_weapon_selection]) && (prio1.none_set())) {
 		ignore_mask.set(Weapon::Info_Flags::Homing_aspect).set(Weapon::Info_Flags::Homing_heat).set(Weapon::Info_Flags::Homing_javelin);


### PR DESCRIPTION
Fixes #5150 by bailing early if there are no valid weapon choices to choose from. Prevents `swp->current_secondary_bank` from getting set to -1 and then never set since there's no options for the ai to set it to.

This can happen in the case of the mod using ai range awareness and the ai not having any targets in range. In this specific case `get_available_secondary_weapons()` correctly returns a value of 0.