### PR TITLE
Optimizing the trail renderer by avoidng repeated batch_find calls

### DIFF
--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -874,8 +874,8 @@ void batching_add_quad(int texture, vertex *verts)
 
 void batching_add_quad(int texture, vertex *verts, primitive_batch *batch)
 {
+	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
 	if ( texture < 0 ) {
-		Int3();
 		return;
 	}
 
@@ -895,8 +895,8 @@ void batching_add_tri(int texture, vertex *verts)
 
 void batching_add_tri(int texture, vertex *verts, primitive_batch *batch)
 {
+	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
 	if ( texture < 0 ) {
-		Int3();
 		return;
 	}
 

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -872,6 +872,15 @@ void batching_add_quad(int texture, vertex *verts)
 	batching_add_quad_internal(batch, texture, verts);
 }
 
+void batching_add_quad(int texture, vertex *verts, primitive_batch *batch)
+{
+	if ( texture < 0 ) {
+		Int3();
+		return;
+	}
+
+	batching_add_quad_internal(batch, texture, verts);
+}
 void batching_add_tri(int texture, vertex *verts)
 {
 	if ( texture < 0 ) {
@@ -880,6 +889,16 @@ void batching_add_tri(int texture, vertex *verts)
 	}
 
 	primitive_batch *batch = batching_find_batch(texture, batch_info::FLAT_EMISSIVE);
+
+	batching_add_tri_internal(batch, texture, verts);
+}
+
+void batching_add_tri(int texture, vertex *verts, primitive_batch *batch)
+{
+	if ( texture < 0 ) {
+		Int3();
+		return;
+	}
 
 	batching_add_tri_internal(batch, texture, verts);
 }

--- a/code/render/batching.h
+++ b/code/render/batching.h
@@ -126,6 +126,10 @@ void batching_add_laser(int texture, vec3d *p0, float width1, vec3d *p1, float w
 void batching_add_quad(int texture, vertex *verts);
 void batching_add_tri(int texture, vertex *verts);
 
+//these require some blurring the lines between things, but finding the batch in every call gets expensive in some cases such as trails.
+void batching_add_quad(int texture, vertex *verts, primitive_batch* batch);
+void batching_add_tri(int texture, vertex *verts, primitive_batch* batch);
+
 void batching_render_all(bool render_distortions = false);
 
 void batching_shutdown();

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -155,6 +155,7 @@ void trail_render( trail * trailp )
 	vec3d prev_top, prev_bot; vm_vec_zero(&prev_top); vm_vec_zero(&prev_bot);
 	float prev_U = 0;
 	ubyte prev_alpha = 0;
+	auto batchp = batching_find_batch(ti->texture.bitmap_id, batch_info::FLAT_EMISSIVE);
 	for (int i = 0; i < num_sections; i++) {
 		n = sections[i];
 
@@ -209,6 +210,7 @@ void trail_render( trail * trailp )
 		float current_U = i2fl(n) / trailp->info.texture_stretch;
 		vec3d current_top, current_bot;
 		trail_calc_facing_pts(&current_top, &current_bot, &trail_direction, &trailp->pos[n], w);
+		
 
 		if (i > 0) {
 			if (i == num_sections-1) {
@@ -233,7 +235,7 @@ void trail_render( trail * trailp )
 				verts[1].texture_position.v = 1.0f;
 				verts[2].texture_position.v = 0.5f;
 
-				batching_add_tri(ti->texture.bitmap_id, verts);
+				batching_add_tri(ti->texture.bitmap_id, verts, batchp);
 			} else {
 				vertex verts[4];
 				verts[0].r = verts[0].g = verts[0].b = verts[0].a = prev_alpha;
@@ -254,7 +256,7 @@ void trail_render( trail * trailp )
 				verts[0].texture_position.v = verts[3].texture_position.v = 0.0f;
 				verts[1].texture_position.v = verts[2].texture_position.v = 1.0f;
 
-				batching_add_quad(ti->texture.bitmap_id, verts);
+				batching_add_quad(ti->texture.bitmap_id, verts, batchp);
 			}
 		}
 


### PR DESCRIPTION
Building large trails is an annoyingly costly process in terms of frame times. This makes it a very little bit cheaper. Not a big enough optimization to have very visible effects, but one I think is worth doing.