### PR TITLE
Prevent line splitting if building credits for SCPUI

### DIFF
--- a/code/menuui/credits.h
+++ b/code/menuui/credits.h
@@ -26,7 +26,7 @@ void credits_init();
 void credits_do_frame(float frametime);
 void credits_close();
 
-void credits_parse();
+void credits_parse(bool split_lines = true);
 void credits_scp_position();
 const char* credits_get_music_filename(const char* music);
 extern SCP_vector<SCP_string> Credit_text_parts;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1449,7 +1449,7 @@ ADE_FUNC(buildCredits,
 	"number",
 	"Returns 1 when completed")
 {
-	credits_parse();
+	credits_parse(false);
 	credits_scp_position();
 
 	size_t count = Credit_text_parts.size();


### PR DESCRIPTION
If we're building the credits string for SCPUI or other API access, then we aren't concerned with the retail credits UI string length limit, so skip the line splitting and return the whole string unaltered.