### PR TITLE
increase mission author name length limit

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -470,7 +470,7 @@ void parse_mission_info(mission *pm, bool basic = false)
 	stuff_string(pm->name, F_NAME, NAME_LENGTH);
 
 	required_string("$Author:");
-	stuff_string(pm->author, F_NAME, NAME_LENGTH);
+	stuff_string(pm->author, F_NAME);
 
 	required_string("$Created:");
 	stuff_string(pm->created, F_DATE, DATE_TIME_LENGTH);
@@ -6308,7 +6308,7 @@ int get_mission_info(const char *filename, mission *mission_p, bool basic, bool 
 void mission::Reset()
 {
 	name[ 0 ] = '\0';
-	author[ 0 ] = '\0';
+	author = "";
 	version = 0.;
 	created[ 0 ] = '\0';
 	modified[ 0 ] = '\0';

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -109,7 +109,7 @@ typedef struct mission_cutscene {
 
 typedef struct mission {
 	char	name[NAME_LENGTH];
-	char	author[NAME_LENGTH];
+	SCP_string	author;
 	float	version;
 	char	created[DATE_TIME_LENGTH];
 	char	modified[DATE_TIME_LENGTH];

--- a/fred2/dumpstats.cpp
+++ b/fred2/dumpstats.cpp
@@ -137,7 +137,7 @@ void DumpStats::get_mission_stats(CString &buffer)
 	temp.Format("Filename: %s\r\n", Mission_filename);
 	buffer += temp;
 
-	temp.Format("Author: %s\r\n", The_mission.author);
+	temp.Format("Author: %s\r\n", The_mission.author.c_str());
 	buffer += temp;
 
 	temp.Format("Description: %s\r\n", The_mission.mission_desc);

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -862,8 +862,7 @@ void clear_mission()
 	t = CTime::GetCurrentTime();
 
 	strcpy_s(The_mission.name, "Untitled");
-	strncpy(The_mission.author, str, NAME_LENGTH - 1);
-	The_mission.author[NAME_LENGTH - 1] = 0;
+	The_mission.author = str;
 	strcpy_s(The_mission.created, t.Format("%x at %X"));
 	strcpy_s(The_mission.modified, The_mission.created);
 	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.\n");

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -314,7 +314,7 @@ void CMissionNotesDlg::OnOK()
 	pad_with_newline(m_mission_notes, NOTES_LENGTH - 1);
 
 	string_copy(The_mission.name, m_mission_title, NAME_LENGTH - 1, 1);
-	The_mission.author = m_designer_name;
+	string_copy(The_mission.author, m_designer_name, true);
 	string_copy(The_mission.loading_screen[GR_640], m_loading_640, NAME_LENGTH - 1, 1);
 	string_copy(The_mission.loading_screen[GR_1024], m_loading_1024, NAME_LENGTH - 1, 1);
 	deconvert_multiline_string(The_mission.notes, m_mission_notes, NOTES_LENGTH - 1);

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -314,7 +314,7 @@ void CMissionNotesDlg::OnOK()
 	pad_with_newline(m_mission_notes, NOTES_LENGTH - 1);
 
 	string_copy(The_mission.name, m_mission_title, NAME_LENGTH - 1, 1);
-	string_copy(The_mission.author, m_designer_name, NAME_LENGTH - 1, 1);
+	The_mission.author = m_designer_name;
 	string_copy(The_mission.loading_screen[GR_640], m_loading_640, NAME_LENGTH - 1, 1);
 	string_copy(The_mission.loading_screen[GR_1024], m_loading_1024, NAME_LENGTH - 1, 1);
 	deconvert_multiline_string(The_mission.notes, m_mission_notes, NOTES_LENGTH - 1);
@@ -374,7 +374,7 @@ BOOL CMissionNotesDlg::OnInitDialog()
 	dogfight = (CButton *)GetDlgItem(IDC_DOGFIGHT);
 
 	m_mission_title_orig = m_mission_title = _T(The_mission.name);
-	m_designer_name_orig = m_designer_name = _T(The_mission.author);
+	m_designer_name_orig = m_designer_name = _T(The_mission.author.c_str());
 	m_created = _T(The_mission.created);
 	m_modified = _T(The_mission.modified);
 	convert_multiline_string(m_mission_notes_orig, The_mission.notes);

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2523,7 +2523,7 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Author:");
 	parse_comments();
-	fout(" %s", The_mission.author);
+	fout(" %s", The_mission.author.c_str());
 
 	required_string_fred("$Created:");
 	parse_comments();


### PR DESCRIPTION
Change author from a char array to a basic string.

This particular string is never used outside of FRED and SCPUI, both of which handle it internally as CString and SCP_string, we're just truncating it to pass it around internally. The FRED field allows unlimited input and SCPUI can handle long strings in a more modern way (can wrap, auto-overflow, etc). So let's just keep it as a string and remove the limit entirely.