### PR TITLE
Fix WeaponUsedConditions

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1889,7 +1889,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 				turret->last_fired_weapon_info_index = turret_weapon_class;
 
 				if (scripting::hooks::OnTurretFired->isActive()) {
-					scripting::hooks::OnTurretFired->run(scripting::hooks::WeaponUsedConditions{ parent_ship , turret_enemy_objp, turret_weapon_class, true },
+					scripting::hooks::OnTurretFired->run(scripting::hooks::WeaponUsedConditions{ parent_ship , turret_enemy_objp, SCP_vector<int>{ turret_weapon_class }, true },
 						scripting::hook_param_list(
 							scripting::hook_param("Ship", 'o', &Objects[parent_objnum]),
 							scripting::hook_param("Beam", 'o', objp),
@@ -2035,7 +2035,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 					wp->turret_subsys = turret;	
 
 					if (scripting::hooks::OnTurretFired->isActive()) {
-						scripting::hooks::OnTurretFired->run(scripting::hooks::WeaponUsedConditions{ parent_ship , turret_enemy_objp, turret_weapon_class, wip->subtype == WP_LASER },
+						scripting::hooks::OnTurretFired->run(scripting::hooks::WeaponUsedConditions{ parent_ship , turret_enemy_objp, SCP_vector<int>{ turret_weapon_class }, wip->subtype == WP_LASER },
 							scripting::hook_param_list(
 								scripting::hook_param("Ship", 'o', &Objects[parent_objnum]),
 								scripting::hook_param("Weapon", 'o', objp),
@@ -2160,7 +2160,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 			scripting::hooks::OnTurretFired->run(scripting::hooks::WeaponUsedConditions{
 				&Ships[Objects[tsi->parent_objnum].instance],
 				&Objects[tsi->turret->turret_enemy_objnum], 
-				tsi->weapon_class, Weapon_info[tsi->weapon_class].subtype == WP_LASER
+				SCP_vector<int>{ tsi->weapon_class }, Weapon_info[tsi->weapon_class].subtype == WP_LASER
 				},
 				scripting::hook_param_list(
 					scripting::hook_param("Ship", 'o', &Objects[tsi->parent_objnum]),

--- a/code/scripting/hook_conditions.cpp
+++ b/code/scripting/hook_conditions.cpp
@@ -249,7 +249,9 @@ HOOK_CONDITIONS_END
 
 HOOK_CONDITIONS_START(WeaponUsedConditions)
 	HOOK_CONDITION_SHIPP(WeaponUsedConditions, "that fired the weapon.", user_shipp);
-	HOOK_CONDITION(WeaponUsedConditions, "Weapon class", "Specifies the class of the weapon that was fired.", weaponclass, conditionParseWeaponClass, std::equal_to<int>());
+	HOOK_CONDITION(WeaponUsedConditions, "Weapon class", "Specifies the class of the weapon that was fired.", weaponclasses, conditionParseWeaponClass, [](const SCP_vector<int>& weaponclass_list, const int& weaponclass) -> bool {
+		return std::count(weaponclass_list.cbegin(), weaponclass_list.cend(), weaponclass) > 0;
+	});
 HOOK_CONDITIONS_END
 
 HOOK_CONDITIONS_START(WeaponSelectedConditions)

--- a/code/scripting/hook_conditions.h
+++ b/code/scripting/hook_conditions.h
@@ -105,7 +105,7 @@ struct WeaponUsedConditions {
 	HOOK_DEFINE_CONDITIONS;
 	const ship* user_shipp;
 	const object* target; // As of yet unused
-	int weaponclass;
+	SCP_vector<int> weaponclasses;
 	bool isPrimary; // As of yet unused
 };
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2185,7 +2185,7 @@ int beam_start_firing(beam *b)
 		Ships[b->objp->instance].weapons.primary_bank_ammo[b->bank]--;
 
 	if (scripting::hooks::OnBeamFired->isActive()) {
-		scripting::hooks::OnBeamFired->run(scripting::hooks::WeaponUsedConditions{ &Ships[b->objp->instance], b->target, b->weapon_info_index, true },
+		scripting::hooks::OnBeamFired->run(scripting::hooks::WeaponUsedConditions{ &Ships[b->objp->instance], b->target, SCP_vector<int>{ b->weapon_info_index }, true },
 			scripting::hook_param_list(
 				scripting::hook_param("Beam", 'o', &Objects[b->objnum]),
 				scripting::hook_param("User", 'o', b->objp),


### PR DESCRIPTION
Supercedes #5086.
Fixes #5080.

This is the IMO proper way of fixing the bug in question.
With this change, the hook behaves as it is documented.

Previously, if a weapon class was specified, the hook would only fire if the selected weapon matches the weapon class. Now, the hook will fire if any fired weapon will match the weapon class.
At the same time, the hook will, as before, only fire once per gun trigger, keeping scripts working as intended with no change.