### PR TITLE
Fix inadvertent AI usage of invalid weapons

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -870,9 +870,9 @@ void ai_big_chase_ct()
 	ai_chase_ct();
 }
 
-extern void ai_select_secondary_weapon(object *objp, ship_weapon *swp, int priority1 = -1, int priority2 = -1);
+extern bool ai_select_secondary_weapon(object *objp, ship_weapon *swp, int priority1 = -1, int priority2 = -1);
 extern float set_secondary_fire_delay(ai_info *aip, ship *shipp, weapon_info *swip, bool burst);
-extern void ai_choose_secondary_weapon(object *objp, ai_info *aip, object *en_objp);
+extern bool ai_choose_secondary_weapon(object *objp, ai_info *aip, object *en_objp);
 extern int maybe_avoid_big_ship(object *objp, object *ignore_objp, ai_info *aip, vec3d *goal_point, float delta_time, float time_scale = 1.f);
 
 extern void maybe_cheat_fire_synaptic(object *objp);
@@ -924,9 +924,9 @@ static void ai_big_maybe_fire_weapons(float dist_to_enemy, float dot_to_enemy)
 
 			if (tswp->num_secondary_banks > 0) {
 				if (!(En_objp->flags[Object::Object_Flags::Protected]) || (aip->goals[0].ai_mode & (AI_GOAL_DISABLE_SHIP | AI_GOAL_DISARM_SHIP))) {
-					ai_choose_secondary_weapon(Pl_objp, aip, En_objp);
+					bool valid_secondary = ai_choose_secondary_weapon(Pl_objp, aip, En_objp);
 					int current_bank = tswp->current_secondary_bank;
-					if (current_bank > -1) {
+					if (current_bank > -1 && valid_secondary) {
 						weapon_info	*swip = &Weapon_info[tswp->secondary_bank_weapons[current_bank]];
 
 						if(!(En_objp->flags[Object::Object_Flags::Protected]) || ((aip->goals[0].ai_mode & (AI_GOAL_DISABLE_SHIP | AI_GOAL_DISARM_SHIP)) && swip->wi_flags[Weapon::Info_Flags::Puncture] )) { //override lockdown on protected ships when using anti subsystem weapons - Valathil


### PR DESCRIPTION
Turns out #5156 / #5153 / #5151, i.e. not setting `current_secondary_bank` to -1, was a load-bearing bug, because of course it is. This is in practice how the AI knows that none of its secondaries are valid and to not fire, as there are plenty of checks for `current_bank >= 0` when it comes time to fire. I think this was more a happy coincidence than truly intentional though, so this PR simply has the secondary choosing code return whether or not a valid secondary has been found (and so can differentiate 'stayed on the same bank because this is a good weapon to fire' and 'stayed on the same bank because all my options were bad') mimicking the previous behavior of setting to -1 without actually setting to an invalid index. 

Fixes #5166

It doesn't appear to be related to 'smart secondary selection' as I could get retail ships to fire trebuchets and cylopses at fighters without any changes, given in practice it will depend on what they were last using, different behavior in some situations is to be expected.