### PR TITLE
Adds safety checks to scripting orders with waypoints

### DIFF
--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -290,7 +290,7 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 		case AI_GOAL_WAYPOINTS:
 		case AI_GOAL_WAYPOINTS_ONCE:
 			// check if waypoint order is the current goal (ohp->odx == 0) and if it is valid
-			if ( (ohp->odx == 0) && (aip->wp_index != INVALID_WAYPOINT_POSITION) && (aip->wp_index >= 0) &&
+			if ( (ohp->odx == 0) && (aip->wp_index != INVALID_WAYPOINT_POSITION) && (aip->wp_index >= static_cast<size_t>(0)) &&
 				(aip->wp_index < aip->wp_list->get_waypoints().size()) ) {
 				objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
 			} else {

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -291,7 +291,7 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 		case AI_GOAL_WAYPOINTS_ONCE:
 			wpl = find_matching_waypoint_list(ohp->aigp->target_name);
 			if (wpl != nullptr) {
-				if ((ohp->odx == 0) && (aip->wp_index != -1)) {
+				if ( (ohp->odx == 0) && (aip->wp_index != static_cast<size_t>(-1)) ) {
 					objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
 				} else {
 					objnum = wpl->get_waypoints().front().get_objnum();

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -290,10 +290,12 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 		case AI_GOAL_WAYPOINTS:
 		case AI_GOAL_WAYPOINTS_ONCE:
 			wpl = find_matching_waypoint_list(ohp->aigp->target_name);
-			if(ohp->odx == 0) {
-				objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
-			} else {
-				objnum = wpl->get_waypoints().front().get_objnum();
+			if (wpl != nullptr) {
+				if ((ohp->odx == 0) && (aip->wp_index != -1)) {
+					objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
+				} else {
+					objnum = wpl->get_waypoints().front().get_objnum();
+				}
 			}
 			break;
 		case AI_GOAL_STAY_STILL:

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -295,7 +295,7 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 				objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
 			} else {
 				wpl = find_matching_waypoint_list(ohp->aigp->target_name);
-				if (wpl >= 0) {
+				if (wpl != nullptr) {
 					objnum = wpl->get_waypoints().front().get_objnum();
 				}
 			}

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -290,7 +290,7 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 		case AI_GOAL_WAYPOINTS:
 		case AI_GOAL_WAYPOINTS_ONCE:
 			// check if waypoint order is the current goal (ohp->odx == 0) and if it is valid
-			if ( (ohp->odx == 0) && (aip->wp_index != INVALID_WAYPOINT_POSITION) && (aip->wp_index >= static_cast<size_t>(0)) &&
+			if ( (ohp->odx == 0) && (aip->wp_index != INVALID_WAYPOINT_POSITION) &&
 				(aip->wp_index < aip->wp_list->get_waypoints().size()) ) {
 				objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
 			} else {

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -289,11 +289,13 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 			break;
 		case AI_GOAL_WAYPOINTS:
 		case AI_GOAL_WAYPOINTS_ONCE:
-			wpl = find_matching_waypoint_list(ohp->aigp->target_name);
-			if (wpl != nullptr) {
-				if ( (ohp->odx == 0) && (aip->wp_index != static_cast<size_t>(-1)) ) {
-					objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
-				} else {
+			// check if waypoint order is the current goal (ohp->odx == 0) and if it is valid
+			if ( (ohp->odx == 0) && (aip->wp_index != INVALID_WAYPOINT_POSITION) && (aip->wp_index >= 0) &&
+				(aip->wp_index < aip->wp_list->get_waypoints().size()) ) {
+				objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
+			} else {
+				wpl = find_matching_waypoint_list(ohp->aigp->target_name);
+				if (wpl >= 0) {
 					objnum = wpl->get_waypoints().front().get_objnum();
 				}
 			}


### PR DESCRIPTION
Turns out setting a waypoint order then trying to get to target of that order in the same frame triggers a crash in the scripting API for ship orders (`order.cpp` line 295). This was due to invalid lookups which lacked safety checks.

This PR adds those safety checks. Now, if this situation is encountered, it leaves `objnum` at -1 and thus returns an object for which `isValid` is false.

Fix is tested and works as expected. Also fixes #5172. Thanks @BMagnu for the additional assistance!