### PR TITLE
Remove message requirement for custom cheats

### DIFF
--- a/code/cheats_table/cheats_table.cpp
+++ b/code/cheats_table/cheats_table.cpp
@@ -16,7 +16,11 @@ bool CustomCheat::canUseCheat() {
 
 void CustomCheat::runCheat() {
 	if (!canUseCheat()) return;
-	HUD_printf("%s", cheatMsg.c_str());
+
+	//Only try to send the message if we actually have one to send and are in a mission
+	if (!cheatMsg.empty() && (Game_mode & GM_IN_MISSION))
+		HUD_printf("%s", cheatMsg.c_str());
+
 	scripting::hooks::OnCheat->run(scripting::hook_param_list(scripting::hook_param("Cheat", 's', cheatCode)));
 	CheatUsed = cheatCode;
 }
@@ -108,8 +112,9 @@ void parse_cheat_table(const char* filename) {
 				code = code.substr(0, CHEAT_BUFFER_LEN);
 			}
 
-			required_string("+Message:");
-			stuff_string(msg, F_MESSAGE);
+			if (optional_string("+Message:")) {
+				stuff_string(msg, F_MESSAGE);
+			}
 
 			if (optional_string("+RequireCheats:")) {
 				stuff_boolean(&requireCheats);


### PR DESCRIPTION
Removes the requirement for cheats to have a +Message entry and puts some checks in place so that we only try to send a message if the message has length and we're actually in a mission. (Without the latter, the game will assert and these cheats are triggerable anywhere in the game!)

With this in place you can define cheats and use the On Cheat hook to do any kind of cheat just about anywhere in the game very easily.