### PR TITLE
Lua method to free all loaded models

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -2169,5 +2169,13 @@ ADE_FUNC(screenToBlob, l_Graphics, nullptr, "Captures the current render target 
 	return ade_set_args(L, "s", gr_blob_screen().c_str());
 }
 
+ADE_FUNC(freeAllModels, l_Graphics, nullptr, "Releases all loaded models and frees the memory. Intended for use in UI situations "
+	"and not within missions. Use at your own risk!", nullptr, nullptr)
+{
+	model_free_all();
+
+	return ADE_RETURN_NIL;
+}
+
 } // namespace api
 } // namespace scripting

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -2170,7 +2170,7 @@ ADE_FUNC(screenToBlob, l_Graphics, nullptr, "Captures the current render target 
 }
 
 ADE_FUNC(freeAllModels, l_Graphics, nullptr, "Releases all loaded models and frees the memory. Intended for use in UI situations "
-	"and not within missions. Use at your own risk!", nullptr, nullptr)
+	"and not within missions. Do not use after mission parse. Use at your own risk!", nullptr, nullptr)
 {
 	SCP_UNUSED(L);
 	

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -2172,6 +2172,8 @@ ADE_FUNC(screenToBlob, l_Graphics, nullptr, "Captures the current render target 
 ADE_FUNC(freeAllModels, l_Graphics, nullptr, "Releases all loaded models and frees the memory. Intended for use in UI situations "
 	"and not within missions. Use at your own risk!", nullptr, nullptr)
 {
+	SCP_UNUSED(L);
+	
 	model_free_all();
 
 	return ADE_RETURN_NIL;


### PR DESCRIPTION
I realize this one is inherently risky because if someone uses it at the wrong time, fun things could happen. However, as SCPUI becomes more fully featured I have run into issues regarding having too many models loaded and giving the scripts a way to cleanup after themselves seems like a good idea.

For example; if 3D ship and weapon selection is enabled then the current SCPUI scripts will, during the first mission load of an instance of FSO, load and render every player allowed ship and weapon to a texture, saving each to a png blob for use in ship and weapon selection. In practice it works well, but lower end computers ran into out of memory errors.

I instead moved that whole function to On Game Init which solves the out of memory during a mission load for those computers (because FSO frees all models before starting a mission load), but it means that now until the player runs a mission the game has a large number of models and weapons sitting in memory. If they then go to the tech room and start viewing ships they can eventually run into the same issues because SCPUI has no way to clean up.

So with this I can free up all loaded models after the icons are made or when the tech room is loaded/exited, etc.