### PR TITLE
build compatibility fix

### DIFF
--- a/code/weapon/emp.cpp
+++ b/code/weapon/emp.cpp
@@ -376,6 +376,11 @@ void emp_process_ship(ship *shipp)
 	}
 }
 
+void emp_start_local(float intensity, float time)
+{
+	emp_start_local(intensity, time, "");
+}
+
 // start the emp effect for MYSELF (intensity == arbitrary intensity variable, time == time the effect will last)
 // NOTE : time should be in seconds
 void emp_start_local(float intensity, float time, const SCP_string &text)

--- a/code/weapon/emp.h
+++ b/code/weapon/emp.h
@@ -87,7 +87,8 @@ void emp_process_ship(ship *shipp);
 
 // start the emp effect for MYSELF (intensity == arbitrary intensity variable, time == time the effect will last)
 // NOTE : time should be in seconds
-void emp_start_local(float intensity, float time, const SCP_string &text = "");
+void emp_start_local(float intensity, float time, const SCP_string &text);
+void emp_start_local(float intensity, float time);
 
 // stop the emp effect cold
 void emp_stop_local();


### PR DESCRIPTION
Follow-up to #5138.  Tweak the function header to be more compatible with different build environments; some don't like the `= ""` for some reason.