### PR TITLE
Add option to deprecate hooks

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -174,7 +174,7 @@ static auto WindowModeOption = options::OptionBuilder<os::ViewportState>("Graphi
 								   .finish();
 
 const std::shared_ptr<scripting::OverridableHook<>> OnFrameHook = scripting::OverridableHook<>::Factory(
-	"On Frame", "Called every frame as the last action before showing the frame result to the user.", {}, CHA_ONFRAME);
+	"On Frame", "Called every frame as the last action before showing the frame result to the user.", {}, tl::nullopt, CHA_ONFRAME);
 
 // z-buffer stuff
 int gr_zbuffering        = 0;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1204,6 +1204,10 @@ bool mod_supports_version(int major, int minor, int build)
 	return Targeted_version >= gameversion::version(major, minor, build, 0);
 }
 
+bool mod_supports_version(const gameversion::version& version) {
+	return Targeted_version >= version;
+}
+
 void mod_table_reset()
 {
 	Directive_wait_time = 3000;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -57,7 +57,6 @@ extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
 extern float Emp_pain_flash_factor;
 extern std::tuple<float, float, float> Emp_pain_flash_color;
-extern gameversion::version Targeted_version;
 extern SCP_string Window_title;
 extern SCP_string Mod_title;
 extern SCP_string Mod_version;
@@ -155,3 +154,5 @@ void mod_table_reset();
  * @return @c true if the mod specified support for this or a later version, @c false otherwise
  */
 bool mod_supports_version(int major, int minor, int build);
+
+bool mod_supports_version(const gameversion::version& version);

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -57,6 +57,7 @@ extern float Generic_pain_flash_factor;
 extern float Shield_pain_flash_factor;
 extern float Emp_pain_flash_factor;
 extern std::tuple<float, float, float> Emp_pain_flash_color;
+extern gameversion::version Targeted_version;
 extern SCP_string Window_title;
 extern SCP_string Mod_title;
 extern SCP_string Mod_version;

--- a/code/scripting/api/libs/engine.cpp
+++ b/code/scripting/api/libs/engine.cpp
@@ -68,7 +68,7 @@ ADE_FUNC(addHook,
 			LuaError(L, "Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 		}
 		else {
-			Warning(LOCATION, "Hook '%s' is deprecated from version %s should be replaced!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+			Warning(LOCATION, "Hook '%s' is deprecated from version %s and should be replaced!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			shownWarn = true;
 		}
 		if (override_func.isValid()) {
@@ -79,7 +79,7 @@ ADE_FUNC(addHook,
 				LuaError(L, "Overriding Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
 			else if (!shownWarn) {
-				Warning(LOCATION, "Overriding Hook '%s' is deprecated from version %s should be replaced!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+				Warning(LOCATION, "Overriding Hook '%s' is deprecated from version %s and should be replaced!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
 		}
 	}

--- a/code/scripting/api/libs/engine.cpp
+++ b/code/scripting/api/libs/engine.cpp
@@ -64,7 +64,7 @@ ADE_FUNC(addHook,
 		if (deprecation.level_hook == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
 			LuaError(L, "Hook '%s' is removed since version %s and cannot be used!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 		}
-		else if (deprecation.deprecatedSince <= Targeted_version) {
+		else if (mod_supports_version(deprecation.deprecatedSince)) {
 			LuaError(L, "Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 		}
 		else {
@@ -75,7 +75,7 @@ ADE_FUNC(addHook,
 			if (deprecation.level_override == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
 				LuaError(L, "Overriding Hook '%s' is removed since version %s and cannot be used!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
-			else if (deprecation.deprecatedSince <= Targeted_version) {
+			else if (mod_supports_version(deprecation.deprecatedSince)) {
 				LuaError(L, "Overriding Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
 			else if (!shownWarn) {

--- a/code/scripting/api/libs/engine.cpp
+++ b/code/scripting/api/libs/engine.cpp
@@ -58,6 +58,32 @@ ADE_FUNC(addHook,
 		action.hook.override_function.function = override_func;
 	}
 
+	if (action_hook->getDeprecation()) {
+		const auto& deprecation = *action_hook->getDeprecation();
+		bool shownWarn = false;
+		if (deprecation.level_hook == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
+			LuaError(L, "Hook '%s' is removed since version %s and cannot be used!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+		}
+		else if (deprecation.deprecatedSince <= Targeted_version) {
+			LuaError(L, "Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+		}
+		else {
+			Warning(LOCATION, "Hook '%s' is deprecated from version %s should be replaced!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+			shownWarn = true;
+		}
+		if (override_func.isValid()) {
+			if (deprecation.level_override == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
+				LuaError(L, "Overriding Hook '%s' is removed since version %s and cannot be used!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+			}
+			else if (deprecation.deprecatedSince <= Targeted_version) {
+				LuaError(L, "Overriding Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+			}
+			else if (!shownWarn) {
+				Warning(LOCATION, "Overriding Hook '%s' is deprecated from version %s should be replaced!", action_hook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+			}
+		}
+	}
+
 	if (conditionals.isValid()) {
 		for (const auto& tableEntry : conditionals) {
 			const auto& key   = tableEntry.first;

--- a/code/scripting/doc_html.cpp
+++ b/code/scripting/doc_html.cpp
@@ -499,6 +499,29 @@ void output_html_doc(const ScriptingDocumentation& doc, const SCP_string& filena
 			} else {
 				fputs("<br><i>This hook is <b>not</b> overridable</i>", fp);
 			}
+			if (hook.deprecation) {
+				if (hook.deprecation->level_hook == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
+					fprintf(fp,
+						"<br><b>Removed starting with version %d.%d.%d.</b>\n",
+						hook.deprecation->deprecatedSince.major,
+						hook.deprecation->deprecatedSince.minor,
+						hook.deprecation->deprecatedSince.build);
+				}
+				else if (hook.deprecation->level_override == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
+					fprintf(fp,
+						"<br><b>Deprecated (+Override removed) starting with version %d.%d.%d.</b>\n",
+						hook.deprecation->deprecatedSince.major,
+						hook.deprecation->deprecatedSince.minor,
+						hook.deprecation->deprecatedSince.build);
+				}
+				else {
+					fprintf(fp,
+						"<br><b>Deprecated starting with version %d.%d.%d.</b>\n",
+						hook.deprecation->deprecatedSince.major,
+						hook.deprecation->deprecatedSince.minor,
+						hook.deprecation->deprecatedSince.build);
+				}
+			}
 			if (!hook.parameters.empty()) {
 				fputs("<br><b>Hook Variables:</b>", fp);
 				output_hook_variable_list(fp, hook.parameters);

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -12,12 +12,6 @@ const std::shared_ptr<Hook<>> OnGameInit = Hook<>::Factory("On Game Init",
 	tl::nullopt,
 	CHA_GAMEINIT);
 
-const std::shared_ptr<OverridableHook<>> OnSplashScreen = OverridableHook<>::Factory("On Splash Screen",
-	"Will be called once when the splash screen shows for the first time.",
-	{},
-	tl::nullopt,
-	CHA_SPLASHSCREEN);
-
 const std::shared_ptr<OverridableHook<>> OnStateStart = OverridableHook<>::Factory("On State Start",
 	"Executed whenever a new state is entered.",
 	{ 
@@ -407,6 +401,12 @@ const std::shared_ptr<Hook<>> OnCameraSetUpHook = Hook<>::Factory("On Camera Set
 
 // ========== DEPRECATED ==========
 
+const std::shared_ptr<OverridableHook<>> OnSplashScreen = OverridableHook<>::Factory("On Splash Screen",
+	"Will be called once when the splash screen shows for the first time.",
+	{},
+	HookDeprecationOptions(gameversion::version(23, 0), HookDeprecationOptions::DeprecationLevel::LEVEL_WARN, HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR),
+	CHA_SPLASHSCREEN);
+
 const std::shared_ptr<OverridableHook<ObjectDeathConditions>> OnDeath = OverridableHook<ObjectDeathConditions>::Factory("On Death",
 	"Invoked when an object (ship or asteroid) has been destroyed.  Deprecated in favor of On Ship Destroyed and On Asteroid Destroyed.",
 	{
@@ -416,7 +416,8 @@ const std::shared_ptr<OverridableHook<ObjectDeathConditions>> OnDeath = Overrida
 		{"Hitpos",
 			"vector",
 			"The position of the hit that caused the death (only set for ships and only if available)"},
-	});
+	},
+	HookDeprecationOptions(gameversion::version(23, 0)));
 
 } // namespace hooks
 } // namespace scripting

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -9,11 +9,13 @@ namespace hooks {
 const std::shared_ptr<Hook<>> OnGameInit = Hook<>::Factory("On Game Init",
 	"Executed at the start of the engine after all game data has been loaded.",
 	{},
+	tl::nullopt,
 	CHA_GAMEINIT);
 
 const std::shared_ptr<OverridableHook<>> OnSplashScreen = OverridableHook<>::Factory("On Splash Screen",
 	"Will be called once when the splash screen shows for the first time.",
 	{},
+	tl::nullopt,
 	CHA_SPLASHSCREEN);
 
 const std::shared_ptr<OverridableHook<>> OnStateStart = OverridableHook<>::Factory("On State Start",
@@ -324,6 +326,7 @@ const std::shared_ptr<OverridableHook<ObjectDrawConditions>> OnHudDraw = Overrid
 		{"Self", "object", "The object from which the scene is viewed."},
 		{"Player", "object", "The player object."} 
 	},
+	tl::nullopt,
 	CHA_HUDDRAW);
 
 const std::shared_ptr<OverridableHook<ObjectDrawConditions>> OnObjectRender = OverridableHook<ObjectDrawConditions>::Factory("On Object Render",
@@ -335,6 +338,7 @@ const std::shared_ptr<OverridableHook<ObjectDrawConditions>> OnObjectRender = Ov
 const std::shared_ptr<Hook<>> OnSimulation = Hook<>::Factory("On Simulation",
 	"Invoked every time that FSO processes physics and AI.",
 	{},
+	tl::nullopt,
 	CHA_SIMULATION);
 
 const std::shared_ptr<OverridableHook<>> OnDialogInit = OverridableHook<>::Factory("On Dialog Init",

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -6,7 +6,6 @@ namespace scripting {
 namespace hooks {
 
 extern const std::shared_ptr<Hook<>>									OnGameInit;
-extern const std::shared_ptr<OverridableHook<>>							OnSplashScreen;
 //The On State Start hook previously used to pass OldState to the conditions, but no semantically sensible condition read the value, so we pretend it has no local condition
 extern const std::shared_ptr<OverridableHook<>>							OnStateStart;
 
@@ -79,6 +78,7 @@ extern const std::shared_ptr<OverridableHook<>>							OnStateEndHook;
 extern const std::shared_ptr<Hook<>>									OnCameraSetUpHook;
 
 // deprecated
+extern const std::shared_ptr<OverridableHook<>>							OnSplashScreen;
 extern const std::shared_ptr<OverridableHook<ObjectDeathConditions>>	OnDeath;
 
 }

--- a/code/scripting/hook_api.cpp
+++ b/code/scripting/hook_api.cpp
@@ -70,8 +70,9 @@ HookBase::HookBase(SCP_string hookName,
 				   SCP_string description,
 				   SCP_vector<HookVariableDocumentation> parameters,
 				   const SCP_unordered_map<SCP_string, const std::unique_ptr<const ParseableCondition>>& conditions,
+				   tl::optional<HookDeprecationOptions> deprecation,
 				   int32_t hookId)
-	: _conditions(conditions), _hookName(std::move(hookName)), _description(std::move(description)), _parameters(std::move(parameters))
+	: _conditions(conditions), _hookName(std::move(hookName)), _description(std::move(description)), _parameters(std::move(parameters)), _deprecation(std::move(deprecation))
 {
 	// If we specify a forced id then use that. This is for special hooks that need a guaranteed id
 	if (hookId >= 0) {
@@ -85,6 +86,7 @@ HookBase::HookBase(SCP_string hookName,
 const SCP_string& HookBase::getHookName() const { return _hookName; }
 const SCP_string& HookBase::getDescription() const { return _description; }
 const SCP_vector<HookVariableDocumentation>& HookBase::getParameters() const { return _parameters; }
+const tl::optional<HookDeprecationOptions>& HookBase::getDeprecation() const { return _deprecation; }
 int32_t HookBase::getHookId() const { return _hookId; }
 HookBase::~HookBase() = default;
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -780,7 +780,7 @@ void script_state::ParseGlobalChunk(ConditionalActions hookType, const char* deb
 				error_display(1, "Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
 			else {
-				error_display(0, "Hook '%s' is deprecated from version %s should be replaced!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+				error_display(0, "Hook '%s' is deprecated from version %s and should be replaced!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 				shownWarn = true;
 			}
 		}
@@ -792,7 +792,7 @@ void script_state::ParseGlobalChunk(ConditionalActions hookType, const char* deb
 				error_display(1, "Overriding Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
 			else if (!shownWarn) {
-				error_display(0, "Overriding Hook '%s' is deprecated from version %s should be replaced!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+				error_display(0, "Overriding Hook '%s' is deprecated from version %s and should be replaced!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
 		}
 	}
@@ -880,7 +880,7 @@ bool script_state::ParseCondition(const char *filename)
 					error_display(1, "Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 				}
 				else {
-					error_display(0, "Hook '%s' is deprecated from version %s should be replaced!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+					error_display(0, "Hook '%s' is deprecated from version %s and should be replaced!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 					shownWarn = true;
 				}
 			}
@@ -892,7 +892,7 @@ bool script_state::ParseCondition(const char *filename)
 					error_display(1, "Overriding Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 				}
 				else if(!shownWarn) {
-					error_display(0, "Overriding Hook '%s' is deprecated from version %s should be replaced!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
+					error_display(0, "Overriding Hook '%s' is deprecated from version %s and should be replaced!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 				}
 			}
 		}

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -520,7 +520,7 @@ ScriptingDocumentation script_state::OutputDocumentation(const scripting::Docume
 			  });
 	for (const auto& hook : sortedHooks) {
 		doc.actions.push_back(
-			{hook->getHookName(), hook->getDescription(), hook->getParameters(), hook->_conditions, hook->isOverridable()});
+			{hook->getHookName(), hook->getDescription(), hook->getParameters(), hook->_conditions, hook->getDeprecation(), hook->isOverridable()});
 	}
 
 	OutputLuaDocumentation(doc, errorReporter);

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -18,6 +18,7 @@
 #include "parse/parselo.h"
 #include "scripting/doc_html.h"
 #include "scripting/doc_json.h"
+#include "scripting/global_hooks.h"
 #include "scripting/scripting_doc.h"
 #include "ship/ship.h"
 #include "tracing/tracing.h"
@@ -73,28 +74,24 @@ void script_parse_table(const char* filename)
 
 		if (optional_string("#Global Hooks")) {
 			if (optional_string("$Global:")) {
-				extern const std::shared_ptr<OverridableHook<>> OnFrame;
-				st->ParseGlobalChunk(CHA_ONFRAME, "Global", OnFrame);
+				extern const std::shared_ptr<OverridableHook<>> OnFrameHook;
+				st->ParseGlobalChunk(CHA_ONFRAME, "Global", OnFrameHook);
 			}
 
 			if (optional_string("$Splash:")) {
-				extern const std::shared_ptr<OverridableHook<>> OnSplashScreen;
-				st->ParseGlobalChunk(CHA_SPLASHSCREEN, "Splash", OnSplashScreen);
+				st->ParseGlobalChunk(CHA_SPLASHSCREEN, "Splash", hooks::OnSplashScreen);
 			}
 
 			if (optional_string("$GameInit:")) {
-				extern const std::shared_ptr<Hook<>> OnGameInit;
-				st->ParseGlobalChunk(CHA_GAMEINIT, "GameInit", OnGameInit);
+				st->ParseGlobalChunk(CHA_GAMEINIT, "GameInit", hooks::OnGameInit);
 			}
 
 			if (optional_string("$Simulation:")) {
-				extern const std::shared_ptr<Hook<>> OnSimulation;
-				st->ParseGlobalChunk(CHA_SIMULATION, "Simulation", OnSimulation);
+				st->ParseGlobalChunk(CHA_SIMULATION, "Simulation", hooks::OnSimulation);
 			}
 
 			if (optional_string("$HUD:")) {
-				extern const std::shared_ptr<OverridableHook<>> OnHudDraw;
-				st->ParseGlobalChunk(CHA_HUDDRAW, "HUD", OnHudDraw);
+				st->ParseGlobalChunk(CHA_HUDDRAW, "HUD", hooks::OnHudDraw);
 			}
 
 			required_string("#End");

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -776,7 +776,7 @@ void script_state::ParseGlobalChunk(ConditionalActions hookType, const char* deb
 			if (deprecation.level_hook == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
 				error_display(1, "Hook '%s' is removed since version %s and cannot be used!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
-			else if (deprecation.deprecatedSince <= Targeted_version) {
+			else if (mod_supports_version(deprecation.deprecatedSince)) {
 				error_display(1, "Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
 			else {
@@ -788,7 +788,7 @@ void script_state::ParseGlobalChunk(ConditionalActions hookType, const char* deb
 			if (deprecation.level_override == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
 				error_display(1, "Overriding Hook '%s' is removed since version %s and cannot be used!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
-			else if (deprecation.deprecatedSince <= Targeted_version) {
+			else if (mod_supports_version(deprecation.deprecatedSince)) {
 				error_display(1, "Overriding Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", parentHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 			}
 			else if (!shownWarn) {
@@ -876,7 +876,7 @@ bool script_state::ParseCondition(const char *filename)
 				if (deprecation.level_hook == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
 					error_display(1, "Hook '%s' is removed since version %s and cannot be used!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 				}
-				else if (deprecation.deprecatedSince <= Targeted_version) {
+				else if (mod_supports_version(deprecation.deprecatedSince)) {
 					error_display(1, "Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 				}
 				else {
@@ -888,7 +888,7 @@ bool script_state::ParseCondition(const char *filename)
 				if (deprecation.level_override == HookDeprecationOptions::DeprecationLevel::LEVEL_ERROR) {
 					error_display(1, "Overriding Hook '%s' is removed since version %s and cannot be used!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 				}
-				else if (deprecation.deprecatedSince <= Targeted_version) {
+				else if (mod_supports_version(deprecation.deprecatedSince)) {
 					error_display(1, "Overriding Hook '%s' is deprecated since version %s and cannot be used if the mod targets that version or higher!", currHook->getHookName().c_str(), gameversion::format_version(deprecation.deprecatedSince).c_str());
 				}
 				else if(!shownWarn) {

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -194,7 +194,7 @@ public:
 	                          const char* debug_str = nullptr);
 	bool EvalString(const char* string, const char* debug_str = nullptr);
 	void ParseChunk(script_hook *dest, const char* debug_str=NULL);
-	void ParseGlobalChunk(ConditionalActions hookType, const char* debug_str=nullptr);
+	void ParseGlobalChunk(ConditionalActions hookType, const char* debug_str=nullptr, const std::shared_ptr<scripting::HookBase> parentHook=nullptr);
 	bool ParseCondition(const char *filename="<Unknown>");
 	void AddConditionedHook(int action_id, script_action hook);
 	void AssayActions();

--- a/code/scripting/scripting_doc.h
+++ b/code/scripting/scripting_doc.h
@@ -76,6 +76,7 @@ struct DocumentationAction {
 	SCP_string description;
 	SCP_vector<HookVariableDocumentation> parameters;
 	const SCP_unordered_map<SCP_string, const std::unique_ptr<const ParseableCondition>>& conditions;
+	const tl::optional<HookDeprecationOptions>& deprecation;
 	bool overridable;
 };
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -472,6 +472,10 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	if (scripting::hooks::OnGameInit->isActive()) {
 		scripting::hooks::OnGameInit->run();
 	}
+	//Technically after the splash screen, but the best we can do these days. Since the override is hard-deprecated, we don't need to check it.
+	if (scripting::hooks::OnSplashScreen->isActive()) {
+		scripting::hooks::OnSplashScreen->run();
+	}
 
 	return true;
 }

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -260,6 +260,10 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	if (scripting::hooks::OnGameInit->isActive()) {
 		scripting::hooks::OnGameInit->run();
 	}
+	//Technically after the splash screen, but the best we can do these days. Since the override is hard-deprecated, we don't need to check it.
+	if (scripting::hooks::OnSplashScreen->isActive()) {
+		scripting::hooks::OnSplashScreen->run();
+	}
 
 	return true;
 }


### PR DESCRIPTION
Adds the ability to deprecate scripting hooks and does so with the OnDeath and the OnSplashScreen hooks.
Fixes #4742 and closes #3171.
This PR approaches hook deprecation with two stages:
There is a warn-type deprecate that will warn but run the hook if the target version is below the deprecation version, and error out if the target version is the same or above the deprecation version.
Secondly, there is an error-type deprecate that will always hard-error if a user attempts to use it for situations (like the OnSplashScreen override) where function of the hook / override cannot be feasibly enabled, even in a limited fashion for mods targeting older versions.
In addition, these override-modes can be set differently for the actual hook and its override, if applicable.