### PR TITLE
On warp complete hook

### DIFF
--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -58,6 +58,10 @@ sound_handle Player_engine_wash_loop = sound_handle::invalid();
 
 extern float splode_level;
 
+const auto OnWarpOutCompleteHook = scripting::OverridableHook<scripting::hooks::ShipSourceConditions>::Factory(
+	"On Warp Out Complete", "Called when a ship has completed the warp out animation but hasn't departed yet",
+	{{"Self", "ship", "The object that is warping out."}});
+
 const auto OnWarpOutHook = scripting::OverridableHook<scripting::hooks::ShipSourceConditions>::Factory(
 	"On Warp Out", "Called when a ship warps out.", {{"Self", "ship", "The object that is warping out."}});
 
@@ -590,6 +594,15 @@ static void shipfx_actually_warpout(ship *shipp, object *objp)
 	// let physics in on it too.
 	objp->phys_info.flags &= (~PF_WARP_OUT);
 
+	if (OnWarpOutCompleteHook->isActive()) {
+		auto params = scripting::hook_param_list(scripting::hook_param("Self", 'o', objp));
+		auto conditions = scripting::hooks::ShipSourceConditions{ shipp };
+		OnWarpOutCompleteHook->run(conditions, params);
+		if (OnWarpOutCompleteHook->isOverride(conditions, params)) {
+			return;
+		}
+	}
+	
 	// Once we get through effect, make the ship go away
 	ship_actually_depart(objp->instance);
 }

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -59,7 +59,7 @@ sound_handle Player_engine_wash_loop = sound_handle::invalid();
 extern float splode_level;
 
 const auto OnWarpOutCompleteHook = scripting::OverridableHook<scripting::hooks::ShipSourceConditions>::Factory(
-	"On Warp Out Complete", "Called when a ship has completed the warp out animation but hasn't departed yet",
+	"On Warp Out Complete", "Called when a ship has completed the warp out animation",
 	{{"Self", "ship", "The object that is warping out."}});
 
 const auto OnWarpOutHook = scripting::OverridableHook<scripting::hooks::ShipSourceConditions>::Factory(
@@ -597,14 +597,20 @@ static void shipfx_actually_warpout(ship *shipp, object *objp)
 	if (OnWarpOutCompleteHook->isActive()) {
 		auto params = scripting::hook_param_list(scripting::hook_param("Self", 'o', objp));
 		auto conditions = scripting::hooks::ShipSourceConditions{ shipp };
-		OnWarpOutCompleteHook->run(conditions, params);
 		if (OnWarpOutCompleteHook->isOverride(conditions, params)) {
+			OnWarpOutCompleteHook->run(conditions, params);
 			return;
 		}
 	}
 	
 	// Once we get through effect, make the ship go away
 	ship_actually_depart(objp->instance);
+
+	if (OnWarpOutCompleteHook->isActive()) {
+		auto params = scripting::hook_param_list(scripting::hook_param("Self", 'o', objp));
+		auto conditions = scripting::hooks::ShipSourceConditions{shipp};
+		OnWarpOutCompleteHook->run(conditions, params);
+	}
 }
 
 void WE_Default::compute_warpout_stuff(float *warp_time, vec3d *warp_pos)


### PR DESCRIPTION
This allows, for instance, scripts to make a ship do the warp out effect but without actually removing it from the mission. Should make imjump scripts and sexps much simpler and cleaner.