### PR TITLE
Modular traitor + cleanup

### DIFF
--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -273,28 +273,26 @@ int verify_rank(int ranki)
 	return ranki;
 }
 
-void parse_traitor_tbl()
+void parse_traitor_tbl(const char* filename)
 {
 	try
 	{
-		read_file_text("traitor.tbl", CF_TYPE_TABLES);
+		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
 
-		// simplified form of the debriefing stuff.
-		auto debrief = &Traitor_debriefing;
 		required_string("#Debriefing_info");
 
-		//required_string("$Num stages:");			// would assert if non 1 value was parsed so let's just skip it -Mjn
-		//stuff_int(&debrief->num_stages);
-		//Assert(debrief->num_stages == 1);
-		debrief->num_stages = 1; // must always be 1
+		// no longer used
+		if (optional_string("$Num stages:")) {
+			int junk;
+			stuff_int(&junk); //consume the data and ignore it
+		}
 
-		int stage_num = 0;
-		auto stagep = &debrief->stages[stage_num++];
-
-		//required_string("$Formula:");				// the table value was just ignored so let's skip it -Mjn
-		stagep->formula = 1;						// sexp nodes aren't initialized yet, but node 1 will be Locked_sexp_true
-		skip_to_start_of_string("$multi text");		// just skip over the sexp, since it must always be locked-true anyway
+		// no longer used
+		if (optional_string("$Formula:")) {
+			bool junk[1];
+			stuff_bool_list(junk, 1); // consume the data and ignore it
+		}
 
 		while (check_for_string("$multi text"))
 		{
@@ -316,22 +314,39 @@ void parse_traitor_tbl()
 			Traitor.debriefing_text[persona] = text;
 		}
 
-		if (Traitor.debriefing_text.find(-1) == Traitor.debriefing_text.end())
-		{
-			Warning(LOCATION, "Traitor is missing default debriefing information.\n");
-			Traitor.debriefing_text[-1] = "";
-		}
-
 		if (optional_string("$Voice:"))
 			stuff_string(Traitor.traitor_voice_base, F_FILESPEC, MAX_FILENAME_LEN);
 
-		required_string("$Recommendation text:");
-		stuff_string(Traitor.recommendation_text, F_MULTITEXT);
+		if (optional_string("$Recommendation text:"))
+			stuff_string(Traitor.recommendation_text, F_MULTITEXT);
 	}
 	catch (const parse::ParseException& e)
 	{
 		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", "traitor.tbl", e.what()));
 		return;
+	}
+}
+
+// initialize traitor stuff at game startup
+void traitor_init()
+{
+	// there is only ever one traitor debriefing stage
+	Traitor_debriefing.num_stages = 1;
+	Traitor_debriefing.stages[0].formula = 1;
+
+	// initialize this to an empty string so it can be optional
+	Traitor.recommendation_text = "";
+
+	// first parse the default table
+	parse_traitor_tbl("traitor.tbl");
+
+	// parse any modular tables
+	parse_modular_table("*-trtr.tbm", parse_traitor_tbl);
+
+	// check that we have the default traitor info
+	if (Traitor.debriefing_text.find(-1) == Traitor.debriefing_text.end()) {
+		Warning(LOCATION, "Traitor is missing default debriefing information.\n");
+		Traitor.debriefing_text[-1] = "";
 	}
 }
 

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -146,7 +146,7 @@ extern traitor_stuff Traitor;
 int verify_rank(int rank);
 
 void rank_init();
-void parse_traitor_tbl();
+void traitor_init();
 void scoring_close();
 
 void scoring_level_init( scoring_struct *score );

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1876,7 +1876,7 @@ void game_init()
 	control_config_common_init();				// sets up localization stuff in the control config
 
 	rank_init();
-	parse_traitor_tbl();
+	traitor_init();
 	medals_init();
 
 	cutscene_init();


### PR DESCRIPTION
Makes traitor.tbl modular with -trtr.tbm, allowing to modify/add to upstream traitor personas or overwrite upstream voice base & recommendation text.

Also cleans up my previous cleanup, making the code much clearer. Matches how other tables consume junk data to discard it during parsing (cutscenes and $cd, for example). This will make it easier for me to extend the table in a future PR, since we're not skipping over everything to get to $multi_text.