### PR TITLE
mission version numbers should be major.minor

### DIFF
--- a/code/globalincs/version.cpp
+++ b/code/globalincs/version.cpp
@@ -19,13 +19,17 @@ bool check_at_least(const version& v) {
 	return get_executable_version() >= v;
 }
 
-SCP_string format_version(const version& v) {
+SCP_string format_version(const version& v, bool exclude_build) {
 	SCP_stringstream ss;
 
-	ss << v.major << "." << v.minor << "." << v.build;
+	ss << v.major << "." << v.minor;
 
-	if (v.revision != 0) {
-		ss << "." << v.revision;
+	if (!exclude_build) {
+		ss << "." << v.build;
+
+		if (v.revision != 0) {
+			ss << "." << v.revision;
+		}
 	}
 
 	return ss.str();

--- a/code/globalincs/version.h
+++ b/code/globalincs/version.h
@@ -83,10 +83,11 @@ bool check_at_least(const version& v);
 
 /**
  * @brief Returns the string representation of the passed version
- * @param major The version to format
+ * @param v The version to format
+ * @param exclude_build Whether to exclude the build and revision numbers (i.e. only print major and minor)
  * @returns A string representation of the version number
  */
-SCP_string format_version(const version& v);
+SCP_string format_version(const version& v, bool exclude_build = false);
 
 /**
  * @brief

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -84,7 +84,8 @@
 // MISSION_VERSION should be the earliest version of FSO that can load the current mission format without
 // requiring version-specific comments.  It should be updated whenever the format changes, but it should
 // not be updated simply because the engine's version changed.
-const gameversion::version MISSION_VERSION = gameversion::version(22, 3, 0);
+// NOTE: The version can only have two numbers because old FRED builds expect the version to be a float.
+const gameversion::version MISSION_VERSION = gameversion::version(22, 3);
 const gameversion::version LEGACY_MISSION_VERSION = gameversion::version(0, 10);
 
 LOCAL struct {

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -234,7 +234,7 @@ bool CFREDDoc::load_mission(char *pathname, int flags) {
 
 		// the version will have been assigned before loading was aborted
 		if (!gameversion::check_at_least(The_mission.required_fso_version)) {
-			sprintf(name, "The file \"%s\" cannot be %sed because it requires FSO version %s", pathname, term, format_version(The_mission.required_fso_version).c_str());
+			sprintf(name, "The file \"%s\" cannot be %sed because it requires FSO version %s", pathname, term, format_version(The_mission.required_fso_version, true).c_str());
 		} else {
 			sprintf(name, "Unable to %s the file \"%s\".", term, pathname);
 		}
@@ -258,9 +258,9 @@ bool CFREDDoc::load_mission(char *pathname, int flags) {
 	// message 3: warning about saving under a new version
 	if (!(flags & MPF_IMPORT_FSM) && (The_mission.required_fso_version != LEGACY_MISSION_VERSION) && (MISSION_VERSION > The_mission.required_fso_version)) {
 		SCP_string msg = "This mission's file format is ";
-		msg += format_version(The_mission.required_fso_version);
+		msg += format_version(The_mission.required_fso_version, true);
 		msg += ".  When you save this mission, the file format will be migrated to ";
-		msg += format_version(MISSION_VERSION);
+		msg += format_version(MISSION_VERSION, true);
 		msg += ".  FSO versions earlier than this will not be able to load the mission.";
 		Fred_view_wnd->MessageBox(msg.c_str());
 	}

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2529,7 +2529,8 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Version:");
 	parse_comments(2);
-	fout(" %d.%d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor, The_mission.required_fso_version.build);
+	// Since previous versions of FreeSpace interpret this as a float, this can only have one decimal point
+	fout(" %d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor);
 
 	// XSTR
 	required_string_fred("$Name:");

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1405,7 +1405,7 @@ bool game_start_mission()
 		if ( !(Game_mode & GM_MULTIPLAYER) ) {
 			// the version will have been assigned before loading was aborted
 			if (!gameversion::check_at_least(The_mission.required_fso_version)) {
-				popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("This mission requires FSO version %s", 1671), format_version(The_mission.required_fso_version).c_str());
+				popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("This mission requires FSO version %s", 1671), format_version(The_mission.required_fso_version, true).c_str());
 			}
 			// standard load failure
 			else {

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -163,7 +163,7 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 			msg += "\" cannot be ";
 			msg += term;
 			msg += "ed because it requires FSO version ";
-			msg += format_version(The_mission.required_fso_version);
+			msg += format_version(The_mission.required_fso_version, true);
 			msg += ".";
 		}
 		else {
@@ -207,9 +207,9 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 	// message 3: warning about saving under a new version
 	if (!(flags & MPF_IMPORT_FSM) && (The_mission.required_fso_version != LEGACY_MISSION_VERSION) && (MISSION_VERSION > The_mission.required_fso_version)) {
 		SCP_string msg = "This mission's file format is ";
-		msg += format_version(The_mission.required_fso_version);
+		msg += format_version(The_mission.required_fso_version, true);
 		msg += ".  When you save this mission, the file format will be migrated to ";
-		msg += format_version(MISSION_VERSION);
+		msg += format_version(MISSION_VERSION, true);
 		msg += ".  FSO versions earlier than this will not be able to load the mission.";
 
 		_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Information,

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2230,7 +2230,8 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Version:");
 	parse_comments(2);
-	fout(" %d.%d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor, The_mission.required_fso_version.build);
+	// Since previous versions of FreeSpace interpret this as a float, this can only have one decimal point
+	fout(" %d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor);
 
 	// XSTR
 	required_string_fred("$Name:");
@@ -2239,7 +2240,7 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Author:");
 	parse_comments();
-	fout(" %s", The_mission.author);
+	fout(" %s", The_mission.author.c_str());
 
 	required_string_fred("$Created:");
 	parse_comments();


### PR DESCRIPTION
Since older builds of FRED parse the mission version as a float, the version can contain a maximum of one decimal point.  These changes allow FRED and FSO to disregard the build number when loading, saving, or comparing versions.

There is also a small fix to qtfred's saving of the author field.

Follow-up to #5152.