### PR TITLE
Add `GetVertex()` and `NumVertices()` script functions and clean up random submodel point retrieval a bit

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -251,10 +251,10 @@ void debris_process_post(object * obj, float frame_time)
 
 			int n, n_arcs = Random::next(1, 3);		// Create 1-3 sparks
 
-			vec3d v1, v2, v3, v4;
-
-			submodel_get_two_random_points_better(db->model_num, db->submodel_num, &v1, &v2);
-			submodel_get_two_random_points_better(db->model_num, db->submodel_num, &v3, &v4);
+			vec3d v1 = submodel_get_random_point(db->model_num, db->submodel_num);
+			vec3d v2 = submodel_get_random_point(db->model_num, db->submodel_num);
+			vec3d v3 = submodel_get_random_point(db->model_num, db->submodel_num);
+			vec3d v4 = submodel_get_random_point(db->model_num, db->submodel_num);
 
 			n = 0;
 
@@ -327,11 +327,7 @@ void debris_process_post(object * obj, float frame_time)
 				// Maybe move a vertex....  20% of the time maybe?
 				int mr = Random::next();
 				if ( mr < Random::MAX_VALUE/5 )	{
-					vec3d v1, v2;
-
-					submodel_get_two_random_points_better(db->model_num, db->submodel_num, &v1, &v2);
-
-					db->arc_pts[i][mr % 2] = v1;
+					db->arc_pts[i][mr % 2] = submodel_get_random_point(db->model_num, db->submodel_num);
 				}
 			}
 		}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2358,10 +2358,8 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 
 		for (iLoop = 0; iLoop < num_sparks; iLoop++)
 		{
-			vec3d v1, v2;
-
 			// DA 10/20/98 - sparks must be chosen on the hull and not any submodel
-			submodel_get_two_random_points_better(sip->model_num, pm->detail[0], &v1, &v2);
+			vec3d v1 = submodel_get_random_point(sip->model_num, pm->detail[0]);
 			ship_hit_sparks_no_rotate(&Objects[objnum], &v1);
 		}
 	}

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1183,9 +1183,7 @@ void model_instance_clear_arcs(polymodel *pm, polymodel_instance *pmi);
 void model_instance_add_arc(polymodel *pm, polymodel_instance *pmi, int sub_model_num, vec3d *v1, vec3d *v2, int arc_type, color *primary_color_1 = nullptr, color *primary_color_2 = nullptr, color *secondary_color = nullptr);
 
 // Gets two random points on the surface of a submodel
-extern void submodel_get_two_random_points(int model_num, int submodel_num, vec3d *v1, vec3d *v2, vec3d *n1 = NULL, vec3d *n2 = NULL);
-
-extern void submodel_get_two_random_points_better(int model_num, int submodel_num, vec3d * v1, vec3d * v2, int seed = -1);
+extern vec3d submodel_get_random_point(int model_num, int submodel_num, int seed = -1);
 
 // gets the average position of the mesh at a particular z slice, approximately
 void submodel_get_cross_sectional_avg_pos(int model_num, int submodel_num, float z_slice_pos, vec3d* pos);

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1229,42 +1229,25 @@ static int submodel_get_points_internal(int model_num, int submodel_num)
 /**
  * Gets two random points on a model
  */
-void submodel_get_two_random_points(int model_num, int submodel_num, vec3d *v1, vec3d *v2, vec3d *n1, vec3d *n2 )
+vec3d submodel_get_random_point_fallback(int model_num, int submodel_num)
 {
 	int nv = submodel_get_points_internal(model_num, submodel_num);
 
-	// this is not only because of the immediate div-0 error but also because of the less immediate expectation for at least one point (preferably two) to be found
+	// this is not only because of the immediate div-0 error but also because of the less immediate expectation for at least one point to be found
 	if (nv <= 0) {
 		polymodel *pm = model_get(model_num);
 		Error(LOCATION, "Model %d ('%s') must have at least one point from submodel_get_points_internal!", model_num, (pm == NULL) ? "<null model?!?>" : pm->filename);
 
 		// in case people ignore the error...
-		vm_vec_zero(v1);
-		vm_vec_zero(v2);
-		if (n1 != NULL) {
-			vm_vec_zero(n1);
-		}
-		if (n2 != NULL) {
-			vm_vec_zero(n2);
-		}
-		return;
+		return vmd_zero_vector;
 	}
 
 	int vn1 = Random::next(nv);
-	int vn2 = Random::next(nv);
 
-	*v1 = *Interp_verts[vn1];
-	*v2 = *Interp_verts[vn2];
-
-	if(n1 != NULL){
-		*n1 = *Interp_norms[vn1];
-	}
-	if(n2 != NULL){
-		*n2 = *Interp_norms[vn2];
-	}
+	return *Interp_verts[vn1];
 }
 
-void submodel_get_two_random_points_better(int model_num, int submodel_num, vec3d *v1, vec3d *v2, int seed)
+vec3d submodel_get_random_point(int model_num, int submodel_num, int seed)
 {
 	polymodel *pm = model_get(model_num);
 
@@ -1273,12 +1256,10 @@ void submodel_get_two_random_points_better(int model_num, int submodel_num, vec3
 			submodel_num = pm->detail[0];
 		}
 
-		// the Shivan Comm Node does not have a collision tree, for one
 		if (pm->submodel[submodel_num].collision_tree_index < 0) {
 			nprintf(("Model", "In submodel_get_two_random_points_better(), model %s does not have a collision tree!  Falling back to submodel_get_two_random_points().\n", pm->filename));
 
-			submodel_get_two_random_points(model_num, submodel_num, v1, v2);
-			return;
+			return submodel_get_random_point_fallback(model_num, submodel_num);
 		}
 
 		bsp_collision_tree *tree = model_get_bsp_collision_tree(pm->submodel[submodel_num].collision_tree_index);
@@ -1287,21 +1268,19 @@ void submodel_get_two_random_points_better(int model_num, int submodel_num, vec3
 
 		// this is not only because of the immediate div-0 error but also because of the less immediate expectation for at least one point (preferably two) to be found
 		if (nv <= 0) {
-			Error(LOCATION, "Model %d ('%s') must have at least one point from submodel_get_points_internal!", model_num, (pm == NULL) ? "<null model?!?>" : pm->filename);
+			Error(LOCATION, "Model %d ('%s') must have at least one point in its collision tree!", model_num, (pm == NULL) ? "<null model?!?>" : pm->filename);
 
 			// in case people ignore the error...
-			vm_vec_zero(v1);
-			vm_vec_zero(v2);
-
-			return;
+			return vmd_zero_vector;
 		}
 
 		int seed_num = seed == -1 ? Random::next() : seed;
 		int vn1 = static_rand(seed_num) % nv;
-		int vn2 = static_rand(seed_num) % nv;
 
-		*v1 = tree->point_list[vn1];
-		*v2 = tree->point_list[vn2];
+		return tree->point_list[vn1];
+	} else {
+		Assertion(false, "submodel_get_random_point called on an invalid model!");
+		return vmd_zero_vector;
 	}
 }
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1256,8 +1256,9 @@ vec3d submodel_get_random_point(int model_num, int submodel_num, int seed)
 			submodel_num = pm->detail[0];
 		}
 
+		// the Shivan Comm Node does not have a collision tree, for one
 		if (pm->submodel[submodel_num].collision_tree_index < 0) {
-			nprintf(("Model", "In submodel_get_two_random_points_better(), model %s does not have a collision tree!  Falling back to submodel_get_two_random_points().\n", pm->filename));
+			nprintf(("Model", "In submodel_get_random_point(), model %s does not have a collision tree!  Falling back to submodel_get_random_point_fallback().\n", pm->filename));
 
 			return submodel_get_random_point_fallback(model_num, submodel_num);
 		}

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -338,7 +338,7 @@ ADE_VIRTVAR(Offset, l_Submodel, nullptr, "Gets the submodel's offset from its pa
 
 ADE_VIRTVAR(Radius, l_Submodel, nullptr, "Gets the submodel's radius", "number", "The radius of the submodel or -1 if invalid")
 {
-	submodel_h *smh = nullptr;
+	submodel_h* smh = nullptr;
 
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "f", -1.0f);
@@ -350,6 +350,23 @@ ADE_VIRTVAR(Radius, l_Submodel, nullptr, "Gets the submodel's radius", "number",
 		LuaError(L, "Setting the submodel radius is not implemented");
 
 	return ade_set_args(L, "f", smh->GetSubmodel()->rad);
+}
+
+
+ADE_FUNC(NumVertices, l_Submodel, nullptr, "Returns the number of vertices in the submodel's mesh", "submodel", "The number of vertices, or 0 if the submodel was invalid")
+{
+	submodel_h* smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "i", 0);
+
+	if (!smh->IsValid())
+		return ade_set_error(L, "i", 0);
+
+	auto sm = smh->GetSubmodel();
+	bsp_collision_tree* tree = model_get_bsp_collision_tree(sm->collision_tree_index);
+
+	return ade_set_args(L, "i", tree->n_verts);
 }
 
 ADE_FUNC(GetVertex, l_Submodel, nullptr, "Gets the specified vertex, or a random one if no index specified", "submodel", "A vertex position, or nil if the submodel was invalid")

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -352,6 +352,34 @@ ADE_VIRTVAR(Radius, l_Submodel, nullptr, "Gets the submodel's radius", "number",
 	return ade_set_args(L, "f", smh->GetSubmodel()->rad);
 }
 
+ADE_FUNC(GetVertex, l_Submodel, nullptr, "Gets the specified vertex, or a random one if no index specified", "submodel", "A vertex position, or nil if the submodel was invalid")
+{
+	submodel_h* smh = nullptr;
+	int idx = -1;
+
+	if (!ade_get_args(L, "o|i", l_Submodel.GetPtr(&smh), &idx))
+		return ADE_RETURN_NIL;
+
+	if (!smh->IsValid())
+		return ADE_RETURN_NIL;
+
+	auto sm = smh->GetSubmodel(); 
+	bsp_collision_tree* tree = model_get_bsp_collision_tree(sm->collision_tree_index);
+
+	if (idx >= tree->n_verts)
+		return ADE_RETURN_NIL;
+
+	vec3d vert;
+
+	if (idx < 0) {
+		vert = submodel_get_random_point(smh->GetModelID(), smh->GetSubmodelIndex());
+	} else {
+		vert = tree->point_list[idx];
+	}
+
+	return ade_set_args(L, "o", l_Vector.Set(vert));
+}
+
 ADE_FUNC(getFirstChild, l_Submodel, nullptr, "Gets the first child submodel of this submodel", "submodel", "A submodel, or nil if there is no child, or an invalid submodel if the handle is not valid")
 {
 	submodel_h *smh = nullptr;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8740,9 +8740,8 @@ static void ship_dying_frame(object *objp, int ship_num)
 				vec3d outpnt;
 				polymodel *pm = model_get(sip->model_num);
 
-				// Gets two random points on the surface of a submodel
+				// Get a random point on the surface of a submodel
 				vec3d pnt1 = submodel_get_random_point(pm->id, pm->detail[0]);
-				vec3d pnt2 = submodel_get_random_point(pm->id, pm->detail[0]);
 
 				model_instance_local_to_global_point(&outpnt, &pnt1, shipp->model_instance_num, pm->detail[0], &objp->orient, &objp->pos );
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8737,11 +8737,12 @@ static void ship_dying_frame(object *objp, int ship_num)
 		// Do fireballs for Big ship with propagating explostion, but not Kamikaze
 		if (!(Ai_info[shipp->ai_index].ai_flags[AI::AI_Flags::Kamikaze]) && ship_get_exp_propagates(shipp) && (sip->death_roll_r_mult > 0.0f)) {
 			if ( timestamp_elapsed(shipp->next_fireball))	{
-				vec3d outpnt, pnt1, pnt2;
+				vec3d outpnt;
 				polymodel *pm = model_get(sip->model_num);
 
 				// Gets two random points on the surface of a submodel
-				submodel_get_two_random_points_better(pm->id, pm->detail[0], &pnt1, &pnt2);
+				vec3d pnt1 = submodel_get_random_point(pm->id, pm->detail[0]);
+				vec3d pnt2 = submodel_get_random_point(pm->id, pm->detail[0]);
 
 				model_instance_local_to_global_point(&outpnt, &pnt1, shipp->model_instance_num, pm->detail[0], &objp->orient, &objp->pos );
 
@@ -8852,10 +8853,11 @@ static void ship_dying_frame(object *objp, int ship_num)
 				}
 				// Find two random vertices on the model, then average them
 				// and make the piece start there.
-				vec3d tmp, outpnt, pnt1, pnt2;
+				vec3d tmp, outpnt;
 
 				// Gets two random points on the surface of a submodel [KNOSSOS]
-				submodel_get_two_random_points_better(pm->id, pm->detail[0], &pnt1, &pnt2);
+				vec3d pnt1 = submodel_get_random_point(pm->id, pm->detail[0]);
+				vec3d pnt2 = submodel_get_random_point(pm->id, pm->detail[0]);
 
 				vm_vec_avg( &tmp, &pnt1, &pnt2 );
 				model_instance_local_to_global_point(&outpnt, &tmp, pm, pmi, pm->detail[0], &objp->orient, &objp->pos );

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -362,10 +362,9 @@ void shipfx_blow_up_model(object *obj, int submodel, int ndebris, vec3d *exp_cen
 	}
 
 	for (i=0; i<ndebris; i++ )	{
-		vec3d pnt1, pnt2;
-
 		// Gets two random points on the surface of a submodel
-		submodel_get_two_random_points_better(pm->id, submodel, &pnt1, &pnt2);
+		vec3d pnt1 = submodel_get_random_point(pm->id, submodel);
+		vec3d pnt2 = submodel_get_random_point(pm->id, submodel);
 
 		vec3d tmp, outpnt;
 
@@ -2238,9 +2237,10 @@ void shipfx_do_lightning_arcs_frame( ship *shipp )
 
 		int n, n_arcs = Random::next(1, 3);
 
-		vec3d v1, v2, v3, v4;
-		submodel_get_two_random_points_better(model_num, -1, &v1, &v2);
-		submodel_get_two_random_points_better(model_num, -1, &v3, &v4);
+		vec3d v1 = submodel_get_random_point(model_num, -1);
+		vec3d v2 = submodel_get_random_point(model_num, -1);
+		vec3d v3 = submodel_get_random_point(model_num, -1);
+		vec3d v4 = submodel_get_random_point(model_num, -1);
 
 		// For large ships, cap the length to be 25% of max radius
 		if ( obj->radius > 200.0f )	{
@@ -2350,8 +2350,7 @@ void shipfx_do_lightning_arcs_frame( ship *shipp )
 				// Maybe move a vertex....  20% of the time maybe?
 				int mr = Random::next();
 				if ( mr < Random::MAX_VALUE/5 )	{
-					vec3d v1, v2;
-					submodel_get_two_random_points_better(model_num, -1, &v1, &v2);
+					vec3d v1 = submodel_get_random_point(model_num, -1);
 
 					vec3d static_one;
 

--- a/code/starfield/supernova.cpp
+++ b/code/starfield/supernova.cpp
@@ -97,7 +97,7 @@ DCF_INT2(sn_part, sn_particles, 0, INT_MAX, "Sets number of supernova particles 
 void supernova_do_particles()
 {
 	int idx;
-	vec3d a, b, ta, tb;
+	vec3d a, b;
 	vec3d norm, sun_temp;
 
 	// no player ship
@@ -128,7 +128,8 @@ void supernova_do_particles()
 
 		// emit
 		for(idx=0; idx<10; idx++) {
-			submodel_get_two_random_points_better(Ship_info[Player_ship->ship_info_index].model_num, 0, &ta, &tb);
+			vec3d ta = submodel_get_random_point(Ship_info[Player_ship->ship_info_index].model_num, 0);
+			vec3d tb = submodel_get_random_point(Ship_info[Player_ship->ship_info_index].model_num, 0);
 
 			// rotate into world space
 			vm_vec_unrotate(&a, &ta, &Player_obj->orient);

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2337,7 +2337,8 @@ void beam_get_binfo(beam *b, float accuracy, int num_shots, int burst_seed, floa
 			vm_vec_zero(&b->binfo.dir_b);
 		} else {
 			// get random model points, this is useful for big ships, because we never miss when shooting at them
-			submodel_get_two_random_points_better(model_num, 0, &b->binfo.dir_a, &b->binfo.dir_b, seed);
+			b->binfo.dir_a = submodel_get_random_point(model_num, 0, seed);
+			b->binfo.dir_b = submodel_get_random_point(model_num, 0, seed);
 		}
 		break;
 
@@ -2428,8 +2429,8 @@ void beam_get_binfo(beam *b, float accuracy, int num_shots, int burst_seed, floa
 		if (usable_target) {
 			// set up our two kinds of random points if needed
 			if (bwi->t5info.start_pos == Type5BeamPos::RANDOM_INSIDE || bwi->t5info.end_pos == Type5BeamPos::RANDOM_INSIDE) {
-				vec3d temp1, temp2;
-				submodel_get_two_random_points_better(model_num, 0, &temp1, &temp2, seed);
+				vec3d temp1 = submodel_get_random_point(model_num, 0, seed);
+				vec3d temp2 = submodel_get_random_point(model_num, 0, seed);
 				vm_vec_rotate(&rand1_on, &temp1, &b->target->orient);
 				vm_vec_rotate(&rand2_on, &temp2, &b->target->orient);
 				rand1_on += b->target->pos;


### PR DESCRIPTION
`GetVertex` allows for retrieval of specific vertices or random ones, and with `NumVertices()` a scripter could even do some advanced 'model parsing' type operations if they were feeling spicy, but random retrieval was my main goal.

Additionally, cleans up `submodel_get_two_random_points_better` a bit, there's no real reason for this function to get two points at a time, even if that's a common case, resulting in awkward scenarios where callers need to declare useless temporaries when they only need one. Instead it should return a single vertex, and you can call it more than once if you need more (and for what it's worth, the Shivan Comm Node *does* have a collision tree).