### PR TITLE
Fix github CI deprecation warnings

### DIFF
--- a/ci/linux/create_dist_pack.sh
+++ b/ci/linux/create_dist_pack.sh
@@ -10,27 +10,27 @@ source $HERE/dist_functions.sh
 if [ "$OS" = "Linux" ]; then
     tar -cvzf "$(get_package_name)-builds-Linux.tar.gz" *
 
-    echo "::set-output name=package_path::$(pwd)/$(get_package_name)-builds-Linux.tar.gz"
-    echo "::set-output name=package_name::$(get_package_name)-builds-Linux.tar.gz"
-    echo "::set-output name=package_mime::$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-Linux.tar.gz")"
+    echo "package_path=$(pwd)/$(get_package_name)-builds-Linux.tar.gz" >> $GITHUB_OUTPUT
+    echo "package_name=$(get_package_name)-builds-Linux.tar.gz" >> $GITHUB_OUTPUT
+    echo "package_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-Linux.tar.gz")" >> $GITHUB_OUTPUT
 elif [ "$OS" = "Windows" ]; then
     7z a -xr'!*.pdb' "$(get_package_name)-builds-$ARCH-$SIMD.zip" "*"
 
-    echo "::set-output name=package_path::$(pwd)/$(get_package_name)-builds-$ARCH-$SIMD.zip"
-    echo "::set-output name=package_name::$(get_package_name)-builds-$ARCH-$SIMD.zip"
-    echo "::set-output name=package_mime::$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-$ARCH-$SIMD.zip")"
+    echo "package_path=$(pwd)/$(get_package_name)-builds-$ARCH-$SIMD.zip" >> $GITHUB_OUTPUT
+    echo "package_name=$(get_package_name)-builds-$ARCH-$SIMD.zip" >> $GITHUB_OUTPUT
+    echo "package_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-$ARCH-$SIMD.zip")" >> $GITHUB_OUTPUT
 
     7z a "$(get_package_name)-debug-$ARCH-$SIMD.7z" "*.pdb"
 
-    echo "::set-output name=debug_path::$(pwd)/$(get_package_name)-debug-$ARCH-$SIMD.7z"
-    echo "::set-output name=debug_name::$(get_package_name)-debug-$ARCH-$SIMD.7z"
-    echo "::set-output name=debug_mime::$(file -b --mime-type "$(pwd)/$(get_package_name)-debug-$ARCH-$SIMD.7z")"
+    echo "debug_path=$(pwd)/$(get_package_name)-debug-$ARCH-$SIMD.7z" >> $GITHUB_OUTPUT
+    echo "debug_name=$(get_package_name)-debug-$ARCH-$SIMD.7z" >> $GITHUB_OUTPUT
+    echo "debug_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-debug-$ARCH-$SIMD.7z")" >> $GITHUB_OUTPUT
 elif [ "$OS" = "Mac" ]; then
     tar -cvzf "$(get_package_name)-builds-Mac.tar.gz" *
 
-    echo "::set-output name=package_path::$(pwd)/$(get_package_name)-builds-Mac.tar.gz"
-    echo "::set-output name=package_name::$(get_package_name)-builds-Mac.tar.gz"
-    echo "::set-output name=package_mime::$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-Mac.tar.gz")"
+    echo "package_path=$(pwd)/$(get_package_name)-builds-Mac.tar.gz" >> $GITHUB_OUTPUT
+    echo "package_name=$(get_package_name)-builds-Mac.tar.gz" >> $GITHUB_OUTPUT
+    echo "package_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-Mac.tar.gz")" >> $GITHUB_OUTPUT
 else
     echo "Invalid OS: $OS"
 fi


### PR DESCRIPTION
removes soon to be deprecated github CI commands. For details see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/