### PR TITLE
Fix negative child check inversion.

### DIFF
--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -5862,7 +5862,7 @@ sexp_list_item *sexp_tree::get_listing_opf_subsystem(int parent_node, int arg_in
 
 	// first child node
 	child = tree_nodes[parent_node].child;
-	if (child >= 0)
+	if (child < 0)
 		return nullptr;
 
 	switch(op)

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -3707,7 +3707,7 @@ sexp_list_item* sexp_tree::get_listing_opf_subsystem(int parent_node, int arg_in
 
 	// first child node
 	child = tree_nodes[parent_node].child;
-	if (child >= 0)
+	if (child < 0)
 		return nullptr;
 
 	switch (op) {


### PR DESCRIPTION
In PR #5202, a bunch of `Assert(child >= 0);` statements were replaced with `if (child < 0) return nullptr;`, except the first one kept the assertion's condition (inverting the logic). This fixes this accidental inversion.