### PR TITLE
disable the fog pass when rendering cockpits

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -898,6 +898,8 @@ typedef struct screen {
 	std::function<void(gr_sync sync)> gf_sync_delete;
 
 	std::function<void(int x, int y, int width, int height)> gf_set_viewport;
+
+	std::function<void(bool set_override)> gf_override_fog;
 } screen;
 
 // handy macro
@@ -1101,6 +1103,8 @@ inline void gr_post_process_restore_zbuffer()
 #define gr_shadow_map_start				GR_CALL(gr_screen.gf_shadow_map_start)
 #define gr_shadow_map_end				GR_CALL(gr_screen.gf_shadow_map_end)
 #define gr_render_shield_impact			GR_CALL(gr_screen.gf_render_shield_impact)
+
+#define gr_override_fog					GR_CALL(gr_screen.gf_override_fog)
 
 inline void gr_render_primitives(material* material_info,
 	primitive_type prim_type,

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -565,5 +565,7 @@ bool gr_stub_init()
 
 	gr_screen.gf_set_viewport = [](int /*x*/, int /*y*/, int /*width*/, int /*height*/) {};
 
+	gr_screen.gf_override_fog = [](bool /*b*/) {};
+
 	return true;
 }

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1025,6 +1025,8 @@ void opengl_setup_function_pointers()
 
 	gr_screen.gf_set_viewport = gr_opengl_set_viewport;
 
+	gr_screen.gf_override_fog = gr_opengl_override_fog;
+
 	// NOTE: All function pointers here should have a Cmdline_nohtl check at the top
 	//       if they shouldn't be run in non-HTL mode, Don't keep separate entries.
 	// *****************************************************************************

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -98,6 +98,7 @@ void gr_opengl_deferred_lighting_end()
 
 extern SCP_vector<light> Lights;
 extern int Num_lights;
+static bool override_fog = false;
 
 void gr_opengl_deferred_lighting_finish()
 {
@@ -294,7 +295,7 @@ void gr_opengl_deferred_lighting_finish()
 	// Now reset back to drawing into the color buffer
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
-	if (The_mission.flags[Mission::Mission_Flags::Fullneb] && Neb2_render_mode != NEB2_RENDER_NONE) {
+	if (The_mission.flags[Mission::Mission_Flags::Fullneb] && Neb2_render_mode != NEB2_RENDER_NONE && !override_fog) {
 		GL_state.SetAlphaBlendMode(ALPHA_BLEND_NONE);
 		gr_zbuffer_set(GR_ZBUFF_NONE);
 		opengl_shader_set_current(gr_opengl_maybe_create_shader(SDR_TYPE_SCENE_FOG, 0));
@@ -345,6 +346,10 @@ void gr_opengl_deferred_lighting_finish()
 	gr_clear_states();
 }
 
+void gr_opengl_override_fog(bool set_override)
+{
+	override_fog = set_override;
+}
 
 void gr_opengl_draw_deferred_light_sphere(const vec3d *position)
 {

--- a/code/graphics/opengl/gropengldeferred.h
+++ b/code/graphics/opengl/gropengldeferred.h
@@ -17,4 +17,6 @@ void gr_opengl_draw_deferred_light_cylinder(const vec3d *position, const matrix 
 
 void gr_opengl_deferred_shutdown();
 
+void gr_opengl_override_fog(bool set_override);
+
 void opengl_draw_sphere();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3439,8 +3439,10 @@ void game_render_frame( camid cid )
 		gr_end_proj_matrix();
 		gr_end_view_matrix();
 
+		gr_override_fog(true);
 		GR_DEBUG_SCOPE("Render Cockpit");
 		ship_render_player_ship(Viewer_obj);
+		gr_override_fog(false);
 
 		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
 		gr_set_view_matrix(&Eye_position, &Eye_matrix);


### PR DESCRIPTION
This was reported to happen in TBP and Solaris. What's happening here is that when both fogging and deferred cockpits are enabled, the fog shader will run during the cockpit pass, producing unintended results (in this case, objects that should be occluded by fog shining through the cockpit geometry). Disabling the fog pass during the cockpit pass fixes this