### PR TITLE
Modular POF Features 2

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -503,7 +503,7 @@ struct w_bank
 		return *this;
 	}
 	w_bank(const w_bank& other) = default;
-	w_bank& operator=(const w_bank& other) = default;
+	w_bank& operator=(const w_bank& other) = delete;
 };
 
 struct glow_point{

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1215,7 +1215,9 @@ extern int model_find_submodel_index(const polymodel* pm, const char* name);
 // Returns the index.  second functions returns the index of the docking bay with
 // the specified name
 extern int model_find_dock_index(int modelnum, int dock_type, int index_to_start_at = 0);
+extern int model_find_dock_index(const polymodel* pm, int dock_type, int index_to_start_at = 0);
 extern int model_find_dock_name_index(int modelnum, const char* name);
+extern int model_find_dock_name_index(const polymodel* pm, const char* name);
 
 // returns the actual name of a docking point on a model, needed by Fred.
 char *model_get_dock_name(int modelnum, int index);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -482,12 +482,28 @@ struct w_bank
 	vec3d	*norm = nullptr;
 	float   *external_model_angle_offset = nullptr;
 
+	w_bank() { }
+
 	~w_bank()
 	{
 		delete[] pnt;
 		delete[] norm;
 		delete[] external_model_angle_offset;
 	}
+
+	w_bank& operator=(w_bank&& other) {
+		this->~w_bank();
+		num_slots = other.num_slots;
+		pnt = other.pnt;
+		norm = other.norm;
+		external_model_angle_offset = other.external_model_angle_offset;
+		other.pnt = nullptr;
+		other.norm = nullptr;
+		other.external_model_angle_offset = nullptr;
+		return *this;
+	}
+	w_bank(const w_bank& other) = default;
+	w_bank& operator=(const w_bank& other) = default;
 };
 
 struct glow_point{

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5121,7 +5121,6 @@ int model_find_dock_index(int modelnum, int dock_type, int index_to_start_at)
 {
 	polymodel* pm;
 
-	// get model
 	pm = model_get(modelnum);
 
 	return model_find_dock_index(pm, dock_type, index_to_start_at);
@@ -5152,8 +5151,7 @@ int model_find_dock_index(const polymodel* pm, int dock_type, int index_to_start
 int model_find_dock_name_index(int modelnum, const char* name)
 {
 	polymodel* pm;
-
-	// get model
+	
 	pm = model_get(modelnum);
 
 	return model_find_dock_name_index(pm, name);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5121,7 +5121,7 @@ int model_find_dock_index(int modelnum, int dock_type, int index_to_start_at)
 {
 	polymodel* pm;
 
-	// get model and make sure it has dockpoints
+	// get model
 	pm = model_get(modelnum);
 
 	return model_find_dock_index(pm, dock_type, index_to_start_at);
@@ -5131,6 +5131,7 @@ int model_find_dock_index(const polymodel* pm, int dock_type, int index_to_start
 {
 	int i;
 
+	// make sure it has dockpoints
 	if ( pm->n_docks <= 0 )
 		return -1;
 
@@ -5152,7 +5153,7 @@ int model_find_dock_name_index(int modelnum, const char* name)
 {
 	polymodel* pm;
 
-	// get model and make sure it has dockpoints
+	// get model
 	pm = model_get(modelnum);
 
 	return model_find_dock_name_index(pm, name);
@@ -5162,6 +5163,7 @@ int model_find_dock_name_index(const polymodel* pm, const char* name)
 {
 	int i;
 
+	// make sure it has dockpoints
 	if ( pm->n_docks <= 0 )
 		return -1;
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5119,11 +5119,18 @@ int model_find_submodel_index(int modelnum, const char *name)
 // Goober5000 - now finds more than one dockpoint of this type
 int model_find_dock_index(int modelnum, int dock_type, int index_to_start_at)
 {
-	int i;
-	polymodel *pm;
+	polymodel* pm;
 
 	// get model and make sure it has dockpoints
 	pm = model_get(modelnum);
+
+	return model_find_dock_index(pm, dock_type, index_to_start_at);
+}
+
+int model_find_dock_index(const polymodel* pm, int dock_type, int index_to_start_at)
+{
+	int i;
+
 	if ( pm->n_docks <= 0 )
 		return -1;
 
@@ -5143,11 +5150,18 @@ int model_find_dock_index(int modelnum, int dock_type, int index_to_start_at)
 // so that a desginer doesn't have to know exact names if building a mission from hand.
 int model_find_dock_name_index(int modelnum, const char* name)
 {
-	int i;
-	polymodel *pm;
+	polymodel* pm;
 
 	// get model and make sure it has dockpoints
 	pm = model_get(modelnum);
+
+	return model_find_dock_name_index(pm, name);
+}
+
+int model_find_dock_name_index(const polymodel* pm, const char* name)
+{
+	int i;
+
 	if ( pm->n_docks <= 0 )
 		return -1;
 
@@ -5156,7 +5170,7 @@ int model_find_dock_name_index(int modelnum, const char* name)
 	for(i = 0; i < Num_dock_type_names; i++)
 	{
 		if(!stricmp(name, Dock_type_names[i].name)) {
-			return model_find_dock_index(modelnum, Dock_type_names[i].def);
+			return model_find_dock_index(pm, Dock_type_names[i].def);
 		}
 	}
 	/*

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -803,7 +803,7 @@ VirtualPOFOperationAddDockPoint::VirtualPOFOperationAddDockPoint() {
 	required_string("+Source Dock Point:");
 	stuff_string(sourcedock, F_NAME);
 
-	if (optional_string("+Rename Dockpoint:")) {
+	if (optional_string("+Rename Dock Point:")) {
 		SCP_string name;
 		stuff_string(name, F_NAME);
 		renameDock = std::move(name);

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -757,7 +757,7 @@ VirtualPOFOperationAddWeapons::VirtualPOFOperationAddWeapons() {
 		stuff_int(&destbank);	
 }
 
-void VirtualPOFOperationAddWeapons::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
+void VirtualPOFOperationAddWeapons::process(polymodel* pm, model_read_deferred_tasks& /*deferredTasks*/, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
 	auto appendingPM = virtual_pof_build_cache(appendingPOF, depth);
 
 	w_bank*& banks = primary ? pm->gun_banks : pm->missile_banks;
@@ -810,7 +810,7 @@ VirtualPOFOperationAddDockPoint::VirtualPOFOperationAddDockPoint() {
 	}
 }
 	
-void VirtualPOFOperationAddDockPoint::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
+void VirtualPOFOperationAddDockPoint::process(polymodel* pm, model_read_deferred_tasks& /*deferredTasks*/, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
 	const polymodel* appendingPM = virtual_pof_build_cache(appendingPOF, depth)->pm();
 
 	int dockpoint = model_find_dock_name_index(appendingPM->id, sourcedock.c_str());
@@ -892,7 +892,7 @@ VirtualPOFOperationAddPath::VirtualPOFOperationAddPath() {
 	}
 }
 
-void VirtualPOFOperationAddPath::process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
+void VirtualPOFOperationAddPath::process(polymodel* pm, model_read_deferred_tasks& /*deferredTasks*/, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
 	const polymodel* appendingPM = virtual_pof_build_cache(appendingPOF, depth)->pm();
 
 	int sourcePathNr = -1;

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -792,7 +792,7 @@ void VirtualPOFOperationAddWeapons::process(polymodel* pm, model_read_deferred_t
 		}
 	}
 
-	banks[destbank] = object_copy_including_array_member<w_bank, false>(banks_src[sourcebank], &w_bank::num_slots, &w_bank::pnt, &w_bank::norm, &w_bank::external_model_angle_offset);
+	banks[actual_destbank] = object_copy_including_array_member<w_bank, false>(banks_src[sourcebank], &w_bank::num_slots, &w_bank::pnt, &w_bank::norm, &w_bank::external_model_angle_offset);
 }
 
 

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -803,7 +803,7 @@ VirtualPOFOperationAddDockPoint::VirtualPOFOperationAddDockPoint() {
 	required_string("+Source Dock Point:");
 	stuff_string(sourcedock, F_NAME);
 
-	if (required_string("+Parent Submodel:")) {
+	if (optional_string("+Parent Submodel:")) {
 		SCP_string name;
 		stuff_string(name, F_NAME);
 		targetParentSubsystem = std::move(name);
@@ -813,14 +813,14 @@ VirtualPOFOperationAddDockPoint::VirtualPOFOperationAddDockPoint() {
 void VirtualPOFOperationAddDockPoint::process(polymodel* pm, model_read_deferred_tasks& /*deferredTasks*/, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const {
 	const polymodel* appendingPM = virtual_pof_build_cache(appendingPOF, depth)->pm();
 
-	int dockpoint = model_find_dock_name_index(appendingPM->id, sourcedock.c_str());
+	int dockpoint = model_find_dock_name_index(appendingPM, sourcedock.c_str());
 	if (dockpoint < 0) {
 		Warning(LOCATION, "Could not find dockpoint %s on POF %s for virtual POF %s. Returning original POF", sourcedock.c_str(), appendingPOF.c_str(), virtualPof.name.c_str());
 		return;
 	}
 
 	const SCP_string& targetName = renameDock ? *renameDock : sourcedock;
-	if (model_find_dock_name_index(pm->id, targetName.c_str()) >= 0) {
+	if (model_find_dock_name_index(pm, targetName.c_str()) >= 0) {
 		Warning(LOCATION, "Dockpoint %s already exists on POF %s for virtual POF %s. Returning original POF", targetName.c_str(), pm->filename, virtualPof.name.c_str());
 		return;
 	}
@@ -879,13 +879,13 @@ VirtualPOFOperationAddPath::VirtualPOFOperationAddPath() {
 	required_string("+Source Path:");
 	stuff_string(sourcepath, F_NAME);
 
-	if (required_string("+Rename Path:")) {
+	if (optional_string("+Rename Path:")) {
 		SCP_string name;
 		stuff_string(name, F_NAME);
 		renamePath = std::move(name);
 	}
 
-	if (required_string("+Parent Submodel:")) {
+	if (optional_string("+Parent Submodel:")) {
 		SCP_string name;
 		stuff_string(name, F_NAME);
 		targetParentSubsystem = std::move(name);

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -90,6 +90,15 @@ public:
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 
+class VirtualPOFOperationAddWeapons : public VirtualPOFOperation {
+	int sourcebank, destbank = -1;
+	bool primary;
+	SCP_string appendingPOF;
+public:
+	VirtualPOFOperationAddWeapons();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
+};
+
 class VirtualPOFOperationChangeData : public VirtualPOFOperation {
 	SCP_string submodel;
 	tl::optional<vec3d> setOffset = tl::nullopt;

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -99,6 +99,26 @@ public:
 	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
 };
 
+class VirtualPOFOperationAddDockPoint : public VirtualPOFOperation {
+	SCP_string sourcedock;
+	tl::optional<SCP_string> renameDock;
+	tl::optional<SCP_string> targetParentSubsystem;
+	SCP_string appendingPOF;
+public:
+	VirtualPOFOperationAddDockPoint();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
+};
+
+class VirtualPOFOperationAddPath : public VirtualPOFOperation {
+	SCP_string sourcepath;
+	tl::optional<SCP_string> renamePath;
+	tl::optional<SCP_string> targetParentSubsystem;
+	SCP_string appendingPOF;
+public:
+	VirtualPOFOperationAddPath();
+	void process(polymodel* pm, model_read_deferred_tasks& deferredTasks, model_parse_depth depth, const VirtualPOFDefinition& virtualPof) const override;
+};
+
 class VirtualPOFOperationChangeData : public VirtualPOFOperation {
 	SCP_string submodel;
 	tl::optional<vec3d> setOffset = tl::nullopt;

--- a/code/model/modelreplace.h
+++ b/code/model/modelreplace.h
@@ -102,6 +102,7 @@ public:
 class VirtualPOFOperationAddDockPoint : public VirtualPOFOperation {
 	SCP_string sourcedock;
 	tl::optional<SCP_string> renameDock;
+	SCP_unordered_map<SCP_string, SCP_string> renamePaths;
 	tl::optional<SCP_string> targetParentSubsystem;
 	SCP_string appendingPOF;
 public:


### PR DESCRIPTION
Followup to #4590 and #4713.
Adds copying of dock points, paths, and weapon banks, pretty much completing, as far as I can tell the features for actually modifying pofs, save for anything that modifies the BSP tree.

Potential future upgrades at this point are (sub)model rotation (modifies BSP tree), replacing or removing things from a model, building models from individual vertices (modifies BSP tree) and Lua integration. However, as any of these are a rather substantial amount of work, I don't intend to implement them in the near future unless someone has actual need for it.