### PR TITLE
Mapify builtin strings

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -452,8 +452,7 @@ void parse_stringstbl_common(const char *filename, const bool external)
 			}
 
 			if (!external) {
-				Xstr_table_map.insert(std::make_pair(index, item));
-				Xstr_table_map[index] = item; //not sure why the above doesn't copy over the data, but this one does
+				Xstr_table_map.emplace(index, item);
 			}
 
 			// clear out our vars


### PR DESCRIPTION
Changes built-in strings from an array to an unordered map very similar to translated strings. The main advantage here is places like Custom Controls being able to define an arbitrary xstr ID instead of having to find one that's unused or can be replaced from within the current limitation of 1672 strings.

This solves one of the barriers mentioned in #4523