### PR TITLE
Increase sound update rate

### DIFF
--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -454,7 +454,7 @@ void obj_snd_do_frame()
 	if ( Obj_snd_enabled == FALSE )
 		return;
 
-	if ( ui_timestamp_since(Obj_snd_last_update) > 100 ) {
+	if ( ui_timestamp_since(Obj_snd_last_update) > 20 ) {
 		Obj_snd_last_update = ui_timestamp();
 	} else {
 		return;


### PR DESCRIPTION
Presumably for almost-certainly-now-irrelevant performance reasons, object sounds are not updated every frame, but with maneuvering thruster sound loops or fast weapons even 100ms can be noticeable, so I think we can afford to drop it down some more.