### PR TITLE
Add collision flag for colliding with all polies

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -869,7 +869,7 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 
 		weapon *wp = &Weapons[other_obj->instance];
 		wp->collisionInfo = new mc_info;	// The weapon will free this memory later
-		memcpy(wp->collisionInfo, &mc, sizeof(mc_info));
+		*wp->collisionInfo = mc;
 
 		return mc.num_hits;
 	}

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1297,7 +1297,7 @@ inline void mc_info_init(mc_info *mc)
 #define MC_SUBMODEL				(1<<6)			// If this is set, only check the submodel specified in mc->submodel_num. Use with MC_CHECK_MODEL
 #define MC_SUBMODEL_INSTANCE	(1<<7)			// Check submodel and its children (of a rotating submodel)
 #define MC_CHECK_INVISIBLE_FACES (1<<8)		// Check the invisible faces.
-#define MC_COLLIDE_ALL (1<<8)				// Returns ALL hits via hit_points_all, including backfacing polies hits
+#define MC_COLLIDE_ALL (1<<9)				// Returns ALL hits via hit_points_all, including backfacing polies hits
 
 
 /*

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1246,6 +1246,9 @@ typedef struct mc_info {
 	bool		edge_hit;			// Set if an edge got hit.  Only valid if MC_CHECK_THICK is set.	
 	ubyte		*f_poly;				// pointer to flat poly where we intersected
 	ubyte		*t_poly;				// pointer to tmap poly where we intersected
+	SCP_vector<vec3d> hit_points_all;   // used only with MC_COLLIDE_ALL, contains all collision points, in world space, 
+										//     including those against backfacing polies, in arbitrary order
+	SCP_vector<int> hit_submodels_all;  // the corresponding hit submodels of the above points
 	bsp_collision_leaf *bsp_leaf;
 
 										// flags can be changed for the case of sphere check finds an edge hit
@@ -1294,6 +1297,7 @@ inline void mc_info_init(mc_info *mc)
 #define MC_SUBMODEL				(1<<6)			// If this is set, only check the submodel specified in mc->submodel_num. Use with MC_CHECK_MODEL
 #define MC_SUBMODEL_INSTANCE	(1<<7)			// Check submodel and its children (of a rotating submodel)
 #define MC_CHECK_INVISIBLE_FACES (1<<8)		// Check the invisible faces.
+#define MC_COLLIDE_ALL (1<<8)				// Returns ALL hits via hit_points_all, including backfacing polies hits
 
 
 /*

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -227,8 +227,8 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	mc.p0 = &weapon_start_pos;
 	mc.p1 = &weapon_end_pos;
 	mc.lod = sip->collision_lod;
-	memcpy(&mc_shield, &mc, sizeof(mc_info));
-	memcpy(&mc_hull, &mc, sizeof(mc_info));
+	mc_shield = mc;
+	mc_hull = mc;
 
 	// (btw, these are leftover comments from below...)
 	//
@@ -382,7 +382,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	// If we found a shield collision but were only checking for a simple model
 	// collision, we can re-use the same collision info for the hull as well
 	if (shield_collision && mc_shield.flags == MC_CHECK_MODEL) {
-		memcpy(&mc_hull, &mc_shield, sizeof(mc_info));
+		mc_hull = mc_shield;
 		hull_collision = shield_collision;
 
 		// The weapon has impacted on the hull, so if it should therefore bypass
@@ -446,13 +446,13 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	// see which impact we use
 	if (shield_collision)
 	{
-		memcpy(&mc, &mc_shield, sizeof(mc_info));
+		mc = mc_shield;
 		Assert(quadrant_num >= 0);
 		valid_hit_occurred = 1;
 	}
 	else if (hull_collision)
 	{
-		memcpy(&mc, &mc_hull, sizeof(mc_info));
+		mc = mc_hull;
 		valid_hit_occurred = 1;
 	}
 
@@ -468,7 +468,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	if ( valid_hit_occurred )
 	{
 		wp->collisionInfo = new mc_info;	// The weapon will free this memory later
-		memcpy(wp->collisionInfo, &mc, sizeof(mc_info));
+		*wp->collisionInfo = mc;
 
 		bool ship_override = false, weapon_override = false;
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2980,9 +2980,9 @@ int beam_collide_ship(obj_pair *pair)
 	}
 
 	// set up collision structs, part 2
-	memcpy(&mc_shield, &mc, sizeof(mc_info));
-	memcpy(&mc_hull_enter, &mc, sizeof(mc_info));
-	memcpy(&mc_hull_exit, &mc, sizeof(mc_info));
+	mc = mc_shield;
+	mc = mc_hull_enter;
+	mc = mc_hull_exit;
 	
 	// reverse this vector so that we check for exit holes as opposed to entrance holes
 	mc_hull_exit.p1 = &a_beam->last_start;
@@ -3084,12 +3084,12 @@ int beam_collide_ship(obj_pair *pair)
 	// see which impact we use
 	if (shield_collision && valid_hit_occurred)
 	{
-		memcpy(&mc, &mc_shield, sizeof(mc_info));
+		mc = mc_shield;
 		Assert(quadrant_num >= 0);
 	}
 	else if (hull_enter_collision)
 	{
-		memcpy(&mc, &mc_hull_enter, sizeof(mc_info));
+		mc = mc_hull_enter;
 		valid_hit_occurred = 1;
 	}
 


### PR DESCRIPTION
Adds `MC_COLLIDE_ALL`, which will accrue all hits including those against backfacing polies into a vector. Since this makes `mc_info` not trivially memcopyable anymore, they're replaced with typical deep copy assignments.

This flag is not yet used, but will be for a feature in development by @BMagnu 