### PR TITLE
add initializers to mc_info

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -174,8 +174,6 @@ done_1:
 	}
 	
 	mc_info mc;
-	mc_info_init(&mc);
-
 	mc.model_instance_num = Ships[objp->instance].model_instance_num;
 	mc.model_num = sip->model_num;
 	mc.orient = &objp->orient;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -7357,11 +7357,9 @@ int avoid_player(object *objp, vec3d *goal_pos)
 //	If so, stuff *collision_point.
 int will_collide_pp(vec3d *p0, vec3d *p1, float radius, object *big_objp, vec3d *collision_point)
 {
-	mc_info	mc;
-	mc_info_init(&mc);
-
 	polymodel *pm = model_get(Ship_info[Ships[big_objp->instance].ship_info_index].model_num);
 
+	mc_info	mc;
 	mc.model_instance_num = -1;
 	mc.model_num = pm->id;				// Fill in the model to check
 	mc.orient = &big_objp->orient;			// The object's orient
@@ -16522,8 +16520,6 @@ bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*
 		}
 
 		mc_info hull_check;
-		mc_info_init(&hull_check);
-
 		hull_check.model_instance_num = model_instance_num;
 		hull_check.model_num = model_num;
 		hull_check.orient = &objp->orient;

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2739,7 +2739,6 @@ void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss)
 				vm_vec_scale_add(&end, &gpos, &gvec, model_get_radius(model_num));
 
 				mc_info hull_check;
-				mc_info_init(&hull_check);
 				hull_check.model_instance_num = shipp->model_instance_num;
 				hull_check.model_num = model_num;
 				hull_check.orient = &objp->orient;

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1172,7 +1172,6 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 	}
 
 	mc_info	mc;
-	mc_info_init(&mc);
 	int		num, asteroid_subtype;
 
 	Assert( pasteroid->type == OBJ_ASTEROID );
@@ -1891,7 +1890,6 @@ static void asteroid_test_collide(object *pasteroid_obj, object *pship_obj, mc_i
 static int asteroid_will_collide(object *pasteroid_obj, object *escort_objp)
 {
 	mc_info	mc;
-	mc_info_init(&mc);
 
 	asteroid_test_collide(pasteroid_obj, escort_objp, &mc);
 
@@ -2021,7 +2019,6 @@ float asteroid_time_to_impact(object *asteroid_objp)
 	float		time=-1.0f, total_dist, speed;
 	asteroid	*asp;
 	mc_info	mc;
-	mc_info_init(&mc);
 
 	asp = &Asteroids[asteroid_objp->instance];
 

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -829,7 +829,6 @@ void debris_hit(object *debris_obj, object * /*other_obj*/, vec3d *hitpos, float
 int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, collision_info_struct *debris_hit_info, vec3d* hitNormal)
 {
 	mc_info	mc;
-	mc_info_init(&mc);
 
 	Assert( pdebris->type == OBJ_DEBRIS );
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2470,7 +2470,6 @@ void hud_target_in_reticle_new()
 	//	Get 3d vector through center of reticle
 	vm_vec_scale_add(&terminus, &Eye_position, &Player_obj->orient.vec.fvec, TARGET_IN_RETICLE_DISTANCE);
 
-	mc_info_init(&mc);
 	mc.model_instance_num = -1;
 	mc.model_num = 0;
 	for ( A = GET_FIRST(&obj_used_list); A !=END_OF_LIST(&obj_used_list); A = GET_NEXT(A) ) {

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1222,64 +1222,39 @@ int submodel_get_num_polys(int model_num, int submodel_num);
 // the input values and call model_check_collision
 typedef struct mc_info {
 	// Input values
-	int		model_instance_num;
-	int		model_num;			// What model to check
-	int		submodel_num;		// What submodel to check if MC_SUBMODEL is set
-	matrix	*orient;				// The orient of the model
-	vec3d	*pos;					// The pos of the model in world coordinates
-	vec3d	*p0;					// The starting point of the ray (sphere) to check
-	vec3d	*p1;					// The ending point of the ray (sphere) to check
-	int		flags;				// Flags that the model_collide code looks at.  See MC_??? defines
-	float	radius;				// If MC_CHECK_THICK is set, checks a sphere moving with the radius.
-	int		lod;				// Which detail level of the submodel to check instead
-	
+	int     model_instance_num = -1;
+	int     model_num = -1;             // What model to check
+	int     submodel_num = -1;          // What submodel to check if MC_SUBMODEL is set
+	matrix  *orient = nullptr;          // The orient of the model
+	vec3d   *pos = nullptr;             // The pos of the model in world coordinates
+	vec3d   *p0 = nullptr;              // The starting point of the ray (sphere) to check
+	vec3d   *p1 = nullptr;              // The ending point of the ray (sphere) to check
+	int     flags = 0;                  // Flags that the model_collide code looks at.  See MC_??? defines
+	float   radius = 0;                 // If MC_CHECK_THICK is set, checks a sphere moving with the radius.
+	int     lod = 0;                    // Which detail level of the submodel to check instead
+
 	// Return values
-	int		num_hits;			// How many collisions were found
-	float		hit_dist;			// The distance from p0 to hitpoint
-	vec3d	hit_point;			// Where the collision occurred at in hit_submodel's coordinate system
-	vec3d	hit_point_world;	// Where the collision occurred at in world coordinates
-	int		hit_submodel;		// Which submodel got hit.
-	int		hit_bitmap;			// Which texture got hit.  -1 if not a textured poly
-	float		hit_u, hit_v;		// Where on hit_bitmap the ray hit.  Invalid if hit_bitmap < 0
-	int		shield_hit_tri;	// Which triangle on the shield got hit or -1 if none
-	vec3d	hit_normal;			//	Vector normal of polygon of collision (This is in submodel RF). CAN BE ZERO, if edge_hit is true
-	bool		edge_hit;			// Set if an edge got hit.  Only valid if MC_CHECK_THICK is set.	
-	ubyte		*f_poly;				// pointer to flat poly where we intersected
-	ubyte		*t_poly;				// pointer to tmap poly where we intersected
+	int     num_hits = 0;               // How many collisions were found
+	float   hit_dist = 0.0f;            // The distance from p0 to hitpoint
+	vec3d   hit_point = vmd_zero_vector;        // Where the collision occurred at in hit_submodel's coordinate system
+	vec3d   hit_point_world = vmd_zero_vector;  // Where the collision occurred at in world coordinates
+	int     hit_submodel = -1;          // Which submodel got hit.
+	int     hit_bitmap = -1;            // Which texture got hit.  -1 if not a textured poly
+	float   hit_u = 0.0f;               // Where on hit_bitmap the ray hit.  Invalid if hit_bitmap < 0
+	float   hit_v = 0.0f;               // ditto
+	int     shield_hit_tri = -1;        // Which triangle on the shield got hit or -1 if none
+	vec3d   hit_normal = vmd_zero_vector;       //	Vector normal of polygon of collision (This is in submodel RF). CAN BE ZERO, if edge_hit is true
+	bool    edge_hit = false;           // Set if an edge got hit.  Only valid if MC_CHECK_THICK is set.
+	ubyte   *f_poly = nullptr;          // pointer to flat poly where we intersected
+	ubyte   *t_poly = nullptr;          // pointer to tmap poly where we intersected
+	bsp_collision_leaf* bsp_leaf = nullptr;
+
 	SCP_vector<vec3d> hit_points_all;   // used only with MC_COLLIDE_ALL, contains all collision points, in world space, 
-										//     including those against backfacing polies, in arbitrary order
+	                                    //     including those against backfacing polies, in arbitrary order
 	SCP_vector<int> hit_submodels_all;  // the corresponding hit submodels of the above points
-	bsp_collision_leaf *bsp_leaf;
 
-										// flags can be changed for the case of sphere check finds an edge hit
+	                                    // NOTE: flags can be changed for the case of sphere check finds an edge hit
 } mc_info;
-
-inline void mc_info_init(mc_info *mc)
-{
-	mc->model_instance_num = -1;
-	mc->model_num = -1;
-	mc->submodel_num = -1;
-	mc->orient = nullptr;
-	mc->pos = nullptr;
-	mc->p0 = nullptr;
-	mc->p1 = nullptr;
-	mc->flags = 0;
-	mc->lod = 0;
-	mc->radius = 0;
-	mc->num_hits = 0; 
-	mc->hit_dist = 0;
-	mc->hit_point = vmd_zero_vector;
-	mc->hit_point_world = vmd_zero_vector;
-	mc->hit_submodel = -1;
-	mc->hit_bitmap = -1;
-	mc->hit_u = 0; mc->hit_v = 0;
-	mc->shield_hit_tri = -1;
-	mc->hit_normal = vmd_zero_vector;
-	mc->edge_hit = false;
-	mc->f_poly = nullptr;
-	mc->t_poly = nullptr;
-	mc->bsp_leaf = nullptr;
-}
 
 
 //======== MODEL_COLLIDE ============

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -173,7 +173,6 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 
 	// Set up model_collide info
 	mc_info mc;
-	mc_info_init(&mc);
 
 	// Do in heavy object RF
 	mc.model_num = heavy_sip->model_num;	// Fill in the model to check

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -215,8 +215,8 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 		weapon_end_pos -= The_mission.gravity * flFrametime * flFrametime * (1.f / 12);
 	}
 
-	// Goober5000 - I tried to make collision code here much saner... here begin the (major) changes
-	mc_info_init(&mc);
+
+	// Goober5000 - I tried to make collision code much saner... here begin the (major) changes
 
 	// set up collision structs
 	mc.model_instance_num = shipp->model_instance_num;

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -390,11 +390,9 @@ int weapon_will_never_hit( object *obj_weapon, object *other, obj_pair * current
 //	radius is radius of object moving from curpos to goalpos.
 int pp_collide(vec3d *curpos, vec3d *goalpos, object *goalobjp, float radius)
 {
-	mc_info mc;
-	mc_info_init(&mc);
-
 	Assert(goalobjp->type == OBJ_SHIP);
 
+	mc_info mc;
 	mc.model_instance_num = Ships[goalobjp->instance].model_instance_num;
 	mc.model_num = Ship_info[Ships[goalobjp->instance].ship_info_index].model_num;			// Fill in the model to check
 	mc.orient = &goalobjp->orient;	// The object's orient

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -500,8 +500,6 @@ ADE_FUNC(
 	}
 
 	mc_info hull_check;
-	mc_info_init(&hull_check);
-
 	hull_check.model_num = model_num;
 	hull_check.model_instance_num = model_instance_num;
 	hull_check.submodel_num = submodel;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10328,15 +10328,12 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
  */
 int ship_check_collision_fast( object * obj, object * other_obj, vec3d * hitpos)
 {
-	int num;
-	mc_info mc;
-
 	Assert( obj->type == OBJ_SHIP );
 	Assert( obj->instance >= 0 );
 
-	num = obj->instance;
+	int num = obj->instance;
 
-	mc_info_init(&mc);
+	mc_info mc;
 	mc.model_instance_num = Ships[num].model_instance_num;
 	mc.model_num = Ship_info[Ships[num].ship_info_index].model_num;	// Fill in the model to check
 	mc.orient = &obj->orient;					// The object's orient
@@ -16233,7 +16230,6 @@ int ship_return_subsys_path_normal(ship *shipp, ship_subsys *ss, vec3d *gsubpos,
 int ship_subsystem_in_sight(object* objp, ship_subsys* subsys, vec3d *eye_pos, vec3d* subsys_pos, int do_facing_check, float *dot_out, vec3d *vec_out)
 {
 	float		dist, dot;
-	mc_info	mc;
 	vec3d	terminus, eye_to_pos, subsys_fvec, subsys_to_eye_vec;
 
 	if (objp->type != OBJ_SHIP)
@@ -16265,7 +16261,7 @@ int ship_subsystem_in_sight(object* objp, ship_subsys* subsys, vec3d *eye_pos, v
 	vm_vec_normalized_dir(&eye_to_pos, subsys_pos, eye_pos);
 	vm_vec_scale_add(&terminus, eye_pos, &eye_to_pos, 100000.0f);
 
-	mc_info_init(&mc);
+	mc_info	mc;
 	mc.model_instance_num = Ships[objp->instance].model_instance_num;
 	mc.model_num = Ship_info[Ships[objp->instance].ship_info_index].model_num;			// Fill in the model to check
 	mc.orient = &objp->orient;										// The object's orientation

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -783,7 +783,6 @@ void shipfx_warpout_frame( object *objp, float frametime )
  */
 bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int sun_n )
 {
-	mc_info mc;
 	object *objp;
 	ship_obj *so;
 
@@ -794,7 +793,7 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int sun_n )
 	// every time the mc variable is reused, every parameter that model_collide reads from is reassigned.
 	// Therefore the stale fields in the rest of the struct do not matter because either a) they are never
 	// read from, or b) they are overwritten by the new collision calculation.
-	mc_info_init(&mc);
+	mc_info mc;
 
 	rp0 = *eye_pos;	
 	

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2960,7 +2960,6 @@ int beam_collide_ship(obj_pair *pair)
 
 
 	// Goober5000 - I tried to make collision code much saner... here begin the (major) changes
-	mc_info_init(&mc);
 
 	// set up collision structs, part 1
 	mc.model_instance_num = shipp->model_instance_num;
@@ -2980,9 +2979,9 @@ int beam_collide_ship(obj_pair *pair)
 	}
 
 	// set up collision structs, part 2
-	mc = mc_shield;
-	mc = mc_hull_enter;
-	mc = mc_hull_exit;
+	mc_shield = mc;
+	mc_hull_enter = mc;
+	mc_hull_exit = mc;
 	
 	// reverse this vector so that we check for exit holes as opposed to entrance holes
 	mc_hull_exit.p1 = &a_beam->last_start;
@@ -3166,7 +3165,6 @@ int beam_collide_ship(obj_pair *pair)
 int beam_collide_asteroid(obj_pair *pair)
 {
 	beam * a_beam;
-	mc_info test_collide;		
 	int model_num;
 
 	// bogus
@@ -3208,7 +3206,7 @@ int beam_collide_asteroid(obj_pair *pair)
 #endif
 
 	// do the collision
-	mc_info_init(&test_collide);
+	mc_info test_collide;
 	test_collide.model_instance_num = -1;
 	test_collide.model_num = model_num;
 	test_collide.submodel_num = -1;
@@ -3277,7 +3275,6 @@ int beam_collide_asteroid(obj_pair *pair)
 int beam_collide_missile(obj_pair *pair)
 {
 	beam *a_beam;	
-	mc_info test_collide;		
 	int model_num;
 
 	// bogus
@@ -3317,7 +3314,7 @@ int beam_collide_missile(obj_pair *pair)
 #endif
 
 	// do the collision
-	mc_info_init(&test_collide);
+	mc_info test_collide;
 	test_collide.model_instance_num = -1;
 	test_collide.model_num = model_num;
 	test_collide.submodel_num = -1;
@@ -3384,7 +3381,6 @@ int beam_collide_missile(obj_pair *pair)
 int beam_collide_debris(obj_pair *pair)
 {	
 	beam * a_beam;
-	mc_info test_collide;		
 	int model_num;
 
 	// bogus
@@ -3427,7 +3423,7 @@ int beam_collide_debris(obj_pair *pair)
 #endif
 
 	// do the collision
-	mc_info_init(&test_collide);
+	mc_info test_collide;
 	test_collide.model_instance_num = -1;
 	test_collide.model_num = model_num;
 	test_collide.submodel_num = -1;

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -1291,7 +1291,6 @@ void move_mouse(int btn, int mdx, int mdy) {
 
 int object_check_collision(object *objp, vec3d *p0, vec3d *p1, vec3d *hitpos) {
 	mc_info mc;
-	mc_info_init(&mc);
 
 	if ((objp->type == OBJ_NONE) || (objp->type == OBJ_POINT))
 		return 0;

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -715,7 +715,6 @@ void EditorViewport::level_object(matrix* orient) {
 
 int EditorViewport::object_check_collision(object* objp, vec3d* p0, vec3d* p1, vec3d* hitpos) {
 	mc_info mc;
-	mc_info_init(&mc);
 
 	if ((objp->type == OBJ_NONE) || (objp->type == OBJ_POINT)) {
 		return 0;


### PR DESCRIPTION
This initializes `mc_info` to the correct values when it is constructed, removing the need for `mc_info_init`.

This PR also fixes a group of incorrectly inverted assignments in beam.cpp.

Follow-up to #5212.