### PR TITLE
Add `line of sight` as optional AI override

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -878,6 +878,8 @@ void parse_ai_class()
 	set_aic_flag(aicp, "$ai can slow down when attacking big ships:", AI::Profile_Flags::Ai_can_slow_down_attacking_big_ships);
 
 	set_aic_flag(aicp, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
+
+	set_aic_flag(aicp, "$firing requires exact los:", AI::Profile_Flags::Require_exact_los);
 }
 
 void reset_ai_class_names()


### PR DESCRIPTION
Many values in `ai.tbl` can be inserted as overrides for their equivalent `Ai_profiles.tbl` values. (They are all optional and if not set for an AI class, the values in AI Profiles will be used.)

This is particularly useful for making very specific AI classes that still follow the main AI profiles table with easy to change values.

This PR adds `$firing requires exact los:` as an optional override to set in `ai.tbl`. This particular override is very useful, since it can be set to off by default in the `ai_profiles.tbl` for performance, but then set to on for some select AI classes within `ai.tbl`, and those AI classes can be easily changed on the fly in a mission.