### PR TITLE
Fix retail star look by applying gamma correction

### DIFF
--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1863,16 +1863,25 @@ void stars_draw_stars()
 		vDst.x = fl2i(p1.screen.xyw.x) - fl2i(p2.screen.xyw.x);
 		vDst.y = fl2i(p1.screen.xyw.y) - fl2i(p2.screen.xyw.y);
 
-		if ( ((vDst.x * vDst.x) + (vDst.y * vDst.y)) <= 4 ) {
+		float len = sqrtf((float)((vDst.x * vDst.x) + (vDst.y * vDst.y)));
+
+		color col = sp->col;
+		if (len <= 2.0f ) {
 			p1.screen.xyw.x = p2.screen.xyw.x + 1.0f;
 			p1.screen.xyw.y = p2.screen.xyw.y;
+		} else {
+			// gamma correction
+			col.red = (ubyte)((float)col.red / powf(len, 1.0f / 2.2f));
+			col.green = (ubyte)((float)col.green / powf(len, 1.0f / 2.2f));
+			col.blue = (ubyte)((float)col.blue / powf(len, 1.0f / 2.2f));
+			col.alpha = (ubyte)((float)col.alpha  / powf(len, 1.0f / 2.2f));
 		}
 		path->beginPath();
 
 		path->moveTo(p1.screen.xyw.x, p1.screen.xyw.y);
 		path->lineTo(p2.screen.xyw.x, p2.screen.xyw.y);
 
-		path->setStrokeColor(&sp->col);
+		path->setStrokeColor(&col);
 		path->stroke();
 	}
 	path->endFrame();


### PR DESCRIPTION
Fixes an issue since fs1 where the apparent brightness of stars would fluctuate wildly based on how quick the camera was moving since their brightness is not adjusted at all, yet each star is given many pixels spread over its 'trail' across the sky. I wasn't sure why square root of the length looked good, but as pointed out by qazwsxal, it approximated gamma correction, so the typical 2.2 value is used instead to better match it.

Now stars look... completely normal, regardless of whether your camera is moving or not!

Before: 

https://user-images.githubusercontent.com/17305613/221725872-b09cc9cc-4b7e-48e1-af5d-19a28c7b41b5.mp4

After:

https://user-images.githubusercontent.com/17305613/221725894-4cf1fcdb-0a2c-4a8b-bcc5-c27e98cea151.mp4



