### PR TITLE
Add shudder multipliers

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1062,6 +1062,7 @@ void ship_info::clone(const ship_info& other)
 
 	max_hull_strength = other.max_hull_strength;
 	ship_recoil_modifier = other.ship_recoil_modifier;
+	ship_shudder_modifier = other.ship_shudder_modifier;
 	max_shield_strength = other.max_shield_strength;
 	max_shield_recharge = other.max_shield_recharge;
 	auto_shield_spread = other.auto_shield_spread;
@@ -1394,6 +1395,7 @@ void ship_info::move(ship_info&& other)
 
 	max_hull_strength = other.max_hull_strength;
 	ship_recoil_modifier = other.ship_recoil_modifier;
+	ship_shudder_modifier = other.ship_shudder_modifier;
 	max_shield_strength = other.max_shield_strength;
 	max_shield_recharge = other.max_shield_recharge;
 	auto_shield_spread = other.auto_shield_spread;
@@ -1822,6 +1824,7 @@ ship_info::ship_info()
 	weapon_model_draw_distance = 200.0f;
 
 	ship_recoil_modifier = 1.0f;
+	ship_shudder_modifier = 1.0f;
 
 	max_hull_strength = 100.0f;
 	max_shield_strength = 0.0f;
@@ -3655,6 +3658,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 	if (optional_string("$Ship Recoil Modifier:")){
 		stuff_float(&sip->ship_recoil_modifier);
+	}
+
+	if (optional_string("$Ship Shudder Modifier:")) {
+		stuff_float(&sip->ship_shudder_modifier);
 	}
 
 	if(optional_string("$Shields:")) {
@@ -12660,7 +12667,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 							if((winfo_p->wi_flags[Weapon::Info_Flags::Shudder]) && (obj == Player_obj) && !(Game_mode & GM_STANDALONE_SERVER)){
 								// calculate some arbitrary value between 100
 								// (mass * velocity) / 10
-								game_shudder_apply(500, (winfo_p->mass * winfo_p->max_speed) * 0.1f);
+								game_shudder_apply(500, (winfo_p->mass * winfo_p->max_speed) * 0.1f * sip->ship_shudder_modifier * winfo_p->shudder_modifier);
 							}
 
 							num_fired++;
@@ -13400,7 +13407,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 				if((wip->wi_flags[Weapon::Info_Flags::Shudder]) && (obj == Player_obj) && !(Game_mode & GM_STANDALONE_SERVER)){
 					// calculate some arbitrary value between 100
 					// (mass * velocity) / 10
-					game_shudder_apply(500, (wip->mass * wip->max_speed) * 0.1f);
+					game_shudder_apply(500, (wip->mass * wip->max_speed) * 0.1f * sip->ship_shudder_modifier * wip->shudder_modifier);
 				}
 
 				num_fired++;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1281,6 +1281,9 @@ public:
 	// Recoil modifier for the ship
 	float ship_recoil_modifier;
 
+	// Shudder modifier for the ship
+	float ship_shudder_modifier;
+
 	float	max_hull_strength;				// Max hull strength of this class of ship.
 	float	max_shield_strength;
 	float	auto_shield_spread;				// Thickness of the shield

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -496,6 +496,8 @@ struct weapon_info
 	// Recoil effect
 	float recoil_modifier;
 
+	float shudder_modifier;
+
 	// Energy suck effect
 	float weapon_reduce;					// how much energy removed from weapons systems
 	float afterburner_reduce;			// how much energy removed from weapons systems

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2265,6 +2265,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		stuff_float(&wip->recoil_modifier);
 	}
 
+	if (optional_string("$Shudder Modifier:")) {
+		if (!(wip->wi_flags[Weapon::Info_Flags::Shudder])) {
+			Warning(LOCATION, "$Shudder Modifier specified for weapon %s but this weapon does not have the \"shudder\" weapon flag set. Automatically setting the flag", wip->name);
+			wip->wi_flags.set(Weapon::Info_Flags::Shudder);
+		}
+		stuff_float(&wip->shudder_modifier);
+	}
+
 	// Energy suck optional stuff (if WIF_ENERGY_SUCK is not set, none of this matters anyway)
 	if( optional_string("$Leech Weapon:") ){
 		stuff_float(&wip->weapon_reduce);
@@ -9045,6 +9053,7 @@ void weapon_info::reset()
 	this->emp_time = EMP_DEFAULT_TIME;	// Goober5000: <-- Look!  I fixed a Volition bug!  Gimme $5, Dave!
 
 	this->recoil_modifier = 1.0f;
+	this->shudder_modifier = 1.0f;
 
 	this->weapon_reduce = ESUCK_DEFAULT_WEAPON_REDUCE;
 	this->afterburner_reduce = ESUCK_DEFAULT_AFTERBURNER_REDUCE;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2963,7 +2963,7 @@ void apply_view_shake(matrix *eye_orient)
 
 		// Make eye shake due to engine wash
 		if (Player_obj->type == OBJ_SHIP && (Ships[Player_obj->instance].wash_intensity > 0) && Wash_on ) {
-			float wash_intensity = Ships[Player_obj->instance].wash_intensity;
+			float wash_intensity = Ships[Player_obj->instance].wash_intensity * Ship_info[Ships[Player_obj->instance].ship_info_index].ship_shudder_modifier;
 	
 			tangles.p += get_shake(0.07f * wash_intensity, -1, 0);
 			tangles.h += get_shake(0.07f * wash_intensity, -1, 0);


### PR DESCRIPTION
Works very similarly to the recoil multipliers, only affecting camera shudder instead of physical recoil. Both the ship and the weapon can have multipliers allowing them to behave differently than their mass x velocity might suggest.