### PR TITLE
add some XSTR entries

### DIFF
--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -643,7 +643,9 @@ const char *translate_key(char *key)
 
 	if (!first.empty() && !second.empty()) {
 		strcpy_s(text, first.textify().c_str());
-		strcat_s(text, " or ");
+		strcat_s(text, " ");
+		strcat_s(text, XSTR("or", 1672));
+		strcat_s(text, " ");
 		strcat_s(text, second.textify().c_str());
 
 	} else if (!first.empty()) {
@@ -653,7 +655,7 @@ const char *translate_key(char *key)
 		strcpy_s(text, second.textify().c_str());
 
 	} else {
-			strcpy_s(text, "None");
+			strcpy_s(text, XSTR("None", 1673));
 	}
 
 	return text;
@@ -664,7 +666,7 @@ const char *textify_scancode(int code)
 	static char text[BTN_MSG_LEN];
 
 	if (code < 0)
-		return "None";
+		return XSTR("None", 1673);
 
 	int keycode = code & KEY_MASK;
 

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -216,7 +216,7 @@ json_t* joystick_serializer(Joystick* joystick)
 SCP_string joystick_display(Joystick* stick)
 {
 	if (stick == nullptr) {
-		return "None";
+		return XSTR("None", 1673);
 	}
 	return stick->getName();
 }

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -275,7 +275,7 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 	// (DahBlount) - Remember to load the debris anims
 	stars_load_debris(false);
 
-	if (mission_name != "None") {
+	if (mission_name != LAB_MISSION_NONE_STRING) {
 		read_file_text((mission_name + ".fs2").c_str(), CF_TYPE_MISSIONS);
 		reset_parse();
 

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -62,7 +62,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1672
+// #define XSTR_SIZE	1675
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1084,7 +1084,7 @@ void ship_select_blit_ship_info()
 		if(sum != 0)
 			sprintf(str, "%d", sum);
 		else
-			strcpy_s(str, "None");
+			strcpy_s(str, XSTR("None", 1673));
 		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, str, GR_RESIZE_MENU);
 	}
 	else
@@ -1098,7 +1098,7 @@ void ship_select_blit_ship_info()
 		}
 		else
 		{
-			strcpy_s(str, "None");
+			strcpy_s(str, XSTR("None", 1673));
 		}
 		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, str, GR_RESIZE_MENU);
 	}
@@ -1120,7 +1120,7 @@ void ship_select_blit_ship_info()
 		}
 		else
 		{
-			strcpy_s(str, "None");
+			strcpy_s(str, XSTR("None", 1673));
 		}
 		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, str, GR_RESIZE_MENU);
 	}

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1561,7 +1561,9 @@ int player_inspect_cargo(float frametime, char *outstr)
 	// if cargo is already revealed
 	if ( cargo_sp->flags[Ship::Ship_Flags::Cargo_revealed] ) {
 		if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) ) {
-			char *cargo_name = Cargo_names[cargo_sp->cargo1 & CARGO_INDEX_MASK];
+			auto cargo_name = (cargo_sp->cargo1 & CARGO_INDEX_MASK) == 0
+				? XSTR("Nothing", 1674)
+				: Cargo_names[cargo_sp->cargo1 & CARGO_INDEX_MASK];
             Assert(cargo_sip->flags[Ship::Info_Flags::Cargo] || cargo_sip->flags[Ship::Info_Flags::Transport]);
 
 			if ( cargo_name[0] == '#' ) {
@@ -1661,7 +1663,9 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 	// if cargo is already revealed
 	if (subsys->flags[Ship::Subsystem_Flags::Cargo_revealed]) {
 		if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) ) {
-			char *cargo_name = Cargo_names[subsys->subsys_cargo_name & CARGO_INDEX_MASK];
+			auto cargo_name = (subsys->subsys_cargo_name & CARGO_INDEX_MASK) == 0
+				? XSTR("Nothing", 1674)
+				: Cargo_names[subsys->subsys_cargo_name & CARGO_INDEX_MASK];
 
 			if ( cargo_name[0] == '#' ) {
 				sprintf(outstr, XSTR("passengers: %s", 83), cargo_name+1 );


### PR DESCRIPTION
Add some entries for "or" and "None", mostly in the controls code.  Note that there is already an XSTR entry for "none", but it does not have the right capitalization.  Also note that "None" is localized in `textify_scancode` but not `textify_scancode_universal`.

This also makes "Nothing" cargo use appropriate localization.

Fixes #5227.