### PR TITLE
Small fix for thruster flicker

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2288,8 +2288,8 @@ void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, in
 			vec3d scale_vec = { { { 1.0f, 0.0f, 0.0f } } };
 
 			// normalize banks, in case of incredibly big normals
-			if ( !IS_VEC_NULL_SQ_SAFE(&world_norm) )
-				vm_vec_copy_normalize(&scale_vec, &world_norm);
+			if ( !IS_VEC_NULL_SQ_SAFE(&loc_norm) )
+				vm_vec_copy_normalize(&scale_vec, &loc_norm);
 
 			// adjust for thrust
 			(scale_vec.xyz.x *= thruster_info.length.xyz.x) -= 0.1f;


### PR DESCRIPTION
Follow-up to #88. The 'thruster length' this is being compared to is in the local frame so compare to the thruster normal in the local frame as well. Ensures the 'flicker' is consistent regardless of the orientation of the ship, only the direction of the thruster and the direction of thrust, as intended.