### PR TITLE
use large asteroids speed when chucking asteroids

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -966,7 +966,8 @@ static void asteroid_aim_at_target(object *objp, object *asteroid_objp, float de
 		vm_vec_add2(&rand_vec, &objp->orient.vec.rvec);
 	vm_vec_normalize(&rand_vec);
 
-	speed = Asteroid_info[ASTEROID_TYPE_LARGE].max_speed * (frand()/2.0f + 0.5f);
+	auto asp = &Asteroids[asteroid_objp->instance];
+	speed = Asteroid_info[asp->asteroid_type].max_speed * (frand()/2.0f + 0.5f);
 	
 	vm_vec_copy_scale(&asteroid_objp->phys_info.vel, &rand_vec, -speed);
 	asteroid_objp->phys_info.desired_vel = asteroid_objp->phys_info.vel;

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -966,7 +966,7 @@ static void asteroid_aim_at_target(object *objp, object *asteroid_objp, float de
 		vm_vec_add2(&rand_vec, &objp->orient.vec.rvec);
 	vm_vec_normalize(&rand_vec);
 
-	speed = Asteroid_info[0].max_speed * (frand()/2.0f + 0.5f);
+	speed = Asteroid_info[ASTEROID_TYPE_LARGE].max_speed * (frand()/2.0f + 0.5f);
 	
 	vm_vec_copy_scale(&asteroid_objp->phys_info.vel, &rand_vec, -speed);
 	asteroid_objp->phys_info.desired_vel = asteroid_objp->phys_info.vel;


### PR DESCRIPTION
Chucked asteroids are always large. Therefore use their speed, not the speed of the 1st parsed/small asteroid. Should not affect retail because it uses the same speed for all three asteroids