### PR TITLE
Enable debug scope on release builds

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1316,7 +1316,7 @@ class DebugScope {
 };
 }
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) || defined(FS_OPENGL_DEBUG)
 #define GR_DEBUG_SCOPE(name) ::graphics::DebugScope SCP_TOKEN_CONCAT(gr_scope, __LINE__)(name)
 #else
 #define GR_DEBUG_SCOPE(name) do {} while(false)


### PR DESCRIPTION
When profiling, you want to have GL debug information available on release builds. This gives you a better idea where there's bits with poor performance.
Without:
![image](https://user-images.githubusercontent.com/2259858/222958355-68951527-05e9-4690-ab05-d5161eb3a681.png)
With:
![image](https://user-images.githubusercontent.com/2259858/222958365-3bab7f3e-1e97-4885-afea-70563a13997f.png)
