### PR TITLE
Remove `Attach_thrusters` submodel flag

### DIFF
--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -19,7 +19,6 @@ namespace Model {
 		Collide_invisible,				//SUSHI: If set, this submodel should allow collisions for invisible textures. For the "replacement" collision model scheme.
 		Use_render_box_offset,			// whether an offset has been defined; needed because one can't tell just by looking at render_box_offset
 		Use_render_sphere_offset,		// whether an offset has been defined; needed because one can't tell just by looking at render_sphere_offset
-		Attach_thrusters,				//zookeeper: If set and this submodel or any of its parents rotates, also rotates associated thrusters.
 
 		NUM_VALUES
 	};

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1943,8 +1943,6 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 				if (in(p, props, "$lod0_name"))
 					get_user_prop_value(p+10, sm->lod_name);
 
-				sm->flags.set(Model::Submodel_flags::Attach_thrusters, in(props, "$attach_thrusters"));
-
 				if (in(p, props, "$detail_box:")) {
 					p += 12;
 					while (*p == ' ') p++;


### PR DESCRIPTION
Even in zookeeper's original commit this flag was vestigal, and thruster movement on moving engine subsystems was done unconditionally!

https://github.com/scp-fs2open/fs2open.github.com/commit/bcf9fd90bef5c1f5229cc561d9d543ef89e81f4d