### PR TITLE
Scpui Mission Log

### DIFF
--- a/code/hud/hudmessage.h
+++ b/code/hud/hudmessage.h
@@ -44,6 +44,8 @@ typedef struct line_node {
 	SCP_string text;
 } line_node;
 
+extern SCP_vector<line_node> Msg_scrollback_vec;
+
 typedef struct Hud_display_info {
 	HUD_message_data msg;
 	int y;						// y Coordinate to draw message at

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -738,27 +738,27 @@ void message_log_init_scrollback(int pw)
 
 		switch (entry->type) {
 			case LOG_SHIP_DESTROYED:
-				message_log_add_segs(XSTR( "Destroyed", 404), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR( "Destroyed", 404), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				if (!entry->sname_display.empty()) {
-					message_log_add_segs(XSTR("  Kill: ", 405), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
-					message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.actions);
+					message_log_add_segs(XSTR("  Kill: ", 405), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
+					message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.segments);
 					if (entry->index >= 0) {
 						sprintf(text, NOX(" (%d%%)"), entry->index);
-						message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.actions);
+						message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.segments);
 					}
 				}
 				break;
 
 			case LOG_SELF_DESTRUCTED:
-				message_log_add_segs(XSTR("Self destructed", 1476), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Self destructed", 1476), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_WING_DESTROYED:
-				message_log_add_segs(XSTR("Destroyed", 404), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Destroyed", 404), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_SHIP_ARRIVED:
-				message_log_add_segs(XSTR("Arrived", 406), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Arrived", 406), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_WING_ARRIVED:
@@ -767,20 +767,20 @@ void message_log_init_scrollback(int pw)
 				} else {
 					strcpy_s(text, XSTR( "Arrived", 406));
 				}
-				message_log_add_segs(text, LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(text, LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_SHIP_DEPARTED:
-				message_log_add_segs(XSTR("Departed", 408), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Departed", 408), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_WING_DEPARTED:
-				message_log_add_segs(XSTR("Departed", 408), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Departed", 408), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_SHIP_DOCKED:
-				message_log_add_segs(XSTR("Docked with ", 409), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
-				message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Docked with ", 409), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
+				message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.segments);
 				break;
 
 			case LOG_SHIP_SUBSYS_DESTROYED: {
@@ -788,54 +788,54 @@ void message_log_init_scrollback(int pw)
 				int idx = ship_name_lookup(entry->pname, 1);
 				const char* subsys_name = ship_subsys_get_name(ship_get_indexed_subsys(&Ships[idx], model_index));
 
-				message_log_add_segs(XSTR("Subsystem ", 410), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
-				message_log_add_segs(subsys_name, LOG_COLOR_BRIGHT, 0, &thisEntry.actions);
-				message_log_add_segs(XSTR(" destroyed", 411), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Subsystem ", 410), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
+				message_log_add_segs(subsys_name, LOG_COLOR_BRIGHT, 0, &thisEntry.segments);
+				message_log_add_segs(XSTR(" destroyed", 411), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 			}
 
 			case LOG_SHIP_UNDOCKED:
-				message_log_add_segs(XSTR("Undocked with ", 412), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
-				message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Undocked with ", 412), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
+				message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.segments);
 				break;
 
 			case LOG_SHIP_DISABLED:
-				message_log_add_segs(XSTR("Disabled", 413), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Disabled", 413), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_SHIP_DISARMED:
-				message_log_add_segs(XSTR("Disarmed", 414), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Disarmed", 414), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_PLAYER_CALLED_FOR_REARM:
-				message_log_add_segs(XSTR(" called for rearm", 415), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR(" called for rearm", 415), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_PLAYER_ABORTED_REARM:
-				message_log_add_segs(XSTR(" aborted rearm", 416), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR(" aborted rearm", 416), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_PLAYER_CALLED_FOR_REINFORCEMENT:
-				message_log_add_segs(XSTR("Called in as reinforcement", 417), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Called in as reinforcement", 417), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				break;
 
 			case LOG_CARGO_REVEALED:
 				Assert( entry->index >= 0 );
 				Assert(!(entry->index & CARGO_NO_DEPLETE));
 
-				message_log_add_segs(XSTR("Cargo revealed: ", 418), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(XSTR("Cargo revealed: ", 418), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				strncpy(text, Cargo_names[entry->index], sizeof(text) - 1);
-				message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.actions);
+				message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.segments);
 				break;
 
 			case LOG_CAP_SUBSYS_CARGO_REVEALED:
 				Assert( entry->index >= 0 );
 				Assert(!(entry->index & CARGO_NO_DEPLETE));
 
-				message_log_add_segs(entry->sname_display.c_str(), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
-				message_log_add_segs(XSTR( " subsystem cargo revealed: ", 1488), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
+				message_log_add_segs(entry->sname_display.c_str(), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
+				message_log_add_segs(XSTR( " subsystem cargo revealed: ", 1488), LOG_COLOR_NORMAL, 0, &thisEntry.segments);
 				strncpy(text, Cargo_names[entry->index], sizeof(text) - 1);
-				message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.actions);
+				message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.segments);
 				break;
 
 
@@ -848,7 +848,7 @@ void message_log_init_scrollback(int pw)
 				else
 					strcat_s(text, XSTR( "failed.", 421));
 
-				message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.actions );
+				message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.segments);
 				break;
 			}	// matches case statement!
 			default:
@@ -922,12 +922,12 @@ void mission_log_scrollback(int line_offset, int list_x, int list_y, int list_w,
 		font::force_fit_string(buf, 256, ACTION_X - OBJECT_X - 8);
 		gr_string(list_x + Log_scrollback_vec[i].objective.x, list_y + y, buf, GR_RESIZE_MENU);
 
-		// print the actions
-		for (int j = 0; j < (int)Log_scrollback_vec[i].actions.size(); j++) {
+		// print the segments
+		for (int j = 0; j < (int)Log_scrollback_vec[i].segments.size(); j++) {
 
-			const auto& thisSeg = Log_scrollback_vec[i].actions[j];
+			const auto& thisSeg = Log_scrollback_vec[i].segments[j];
 
-			color this_color = log_line_get_color(Log_scrollback_vec[i].actions[j].color);
+			color this_color = log_line_get_color(Log_scrollback_vec[i].segments[j].color);
 			gr_set_color_fast(&this_color);
 
 			strcpy_s(buf, thisSeg.text.get());

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -910,6 +910,12 @@ void mission_log_scrollback(int line_offset, int list_x, int list_y, int list_w,
 		// print the objective
 		color obj_color = log_line_get_color(Log_scrollback_vec[i].objective.color);
 		gr_set_color_fast(&obj_color);
+
+		// check the flags
+		if ((Log_scrollback_vec[i].objective.flags & LOG_FLAG_GOAL_TRUE) || (Log_scrollback_vec[i].objective.flags & LOG_FLAG_GOAL_FAILED)) {
+			printSymbols = true;
+			symbolFlag = Log_scrollback_vec[i].objective.flags;
+		}
 			
 		char buf[256];
 		strcpy_s(buf, Log_scrollback_vec[i].objective.text.get());
@@ -928,10 +934,6 @@ void mission_log_scrollback(int line_offset, int list_x, int list_y, int list_w,
 			font::force_fit_string(buf, 256, list_w - thisSeg.x);
 			gr_string(list_x + thisSeg.x, list_y + y, buf, GR_RESIZE_MENU);
 
-			if ((thisSeg.flags & LOG_FLAG_GOAL_TRUE) || (thisSeg.flags & LOG_FLAG_GOAL_FAILED)) {
-				printSymbols = true;
-				symbolFlag = thisSeg.flags;
-			}
 		}
 
 		if (printSymbols) {

--- a/code/mission/missionlog.h
+++ b/code/mission/missionlog.h
@@ -14,6 +14,7 @@
 
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
+#include "graphics/2d.h"
 
 // defined for different mission log entries
 
@@ -46,6 +47,15 @@ enum LogType {
 #define MLF_OBSOLETE						(1 << 1)	// this entry is obsolete and will be removed
 #define MLF_HIDDEN							(1 << 2)	// entry doesn't show up in displayed log.
 
+// defines for log flags
+#define LOG_FLAG_GOAL_FAILED (1 << 0)
+#define LOG_FLAG_GOAL_TRUE (1 << 1)
+
+// defines for log colors
+#define LOG_COLOR_NORMAL 0
+#define LOG_COLOR_BRIGHT 1
+#define LOG_COLOR_OTHER 2
+
 struct log_entry {
 	LogType type;            // one of the log #defines in MissionLog.h
 	int flags;               // flags used for status of this log entry
@@ -62,6 +72,20 @@ struct log_entry {
 	SCP_string sname_display;
 };
 
+struct log_text_seg {
+	SCP_vm_unique_ptr<char> text; // the text
+	int color;                    // color text should be displayed in
+	int x;                        // x offset to display text at
+	int flags;                    // used to possibly print special characters when displaying the log
+};
+
+struct log_line_complete {
+	fix timestamp;
+	log_text_seg objective;
+	SCP_vector<log_text_seg> actions;
+};
+
+extern SCP_vector<log_line_complete> Log_scrollback_vec;
 extern int Num_log_lines;
 
 // function prototypes
@@ -84,6 +108,12 @@ extern int mission_log_get_time_indexed(LogType type, const char *name, const ch
 
 // get the number of times an event happened
 extern int mission_log_get_count(LogType type, const char *pname, const char *sname);
+
+// get the team for a log item
+extern int message_log_color_get_team(int msg_color);
+
+// get the actual color for a line item
+extern color log_line_get_color(int tag);
 
 void message_log_init_scrollback(int pw);
 void message_log_shutdown_scrollback();

--- a/code/mission/missionlog.h
+++ b/code/mission/missionlog.h
@@ -82,7 +82,7 @@ struct log_text_seg {
 struct log_line_complete {
 	fix timestamp;
 	log_text_seg objective;
-	SCP_vector<log_text_seg> actions;
+	SCP_vector<log_text_seg> segments;
 };
 
 extern SCP_vector<log_line_complete> Log_scrollback_vec;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1740,7 +1740,7 @@ ADE_INDEXER(l_Log_Messages,
 		return ade_set_error(L, "o", l_Message_Entry.Set(message_entry_h()));
 	idx--; //Convert to Lua's 1 based index system
 
-	if ((idx < 0) || (idx >= (int)Log_scrollback_vec.size()))
+	if ((idx < 0) || (idx >= (int)Msg_scrollback_vec.size()))
 		return ade_set_error(L, "o", l_Message_Entry.Set(message_entry_h()));
 
 	return ade_set_args(L, "o", l_Message_Entry.Set(message_entry_h(idx)));

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -46,6 +46,7 @@
 #include "scripting/api/objs/briefing.h"
 #include "scripting/api/objs/debriefing.h"
 #include "scripting/api/objs/shipwepselect.h"
+#include "scripting/api/objs/missionlog.h"
 #include "scripting/api/objs/color.h"
 #include "scripting/api/objs/enums.h"
 #include "scripting/api/objs/player.h"
@@ -1672,6 +1673,84 @@ ADE_VIRTVAR(Complete, l_UserInterface_Credits, nullptr, "The complete credits st
 
 	return ade_set_args(L, "s", credits_complete);
 }
+
+//**********SUBLIBRARY: UserInterface/MissionLog
+ADE_LIB_DERIV(l_UserInterface_MissionLog,
+	"MissionLog",
+	nullptr,
+	"API for accessing data related to the mission log UI.<br><b>Warning:</b> This is an internal "
+	"API for the new UI system. This should not be used by other code and may be removed in the future!",
+	l_UserInterface);
+
+ADE_FUNC(initMissionLog, l_UserInterface_MissionLog, nullptr, "Initializes the Mission Log data. Must be used before Mission Log is accessed.", nullptr, nullptr)
+{
+	SCP_UNUSED(L);
+
+	Log_scrollback_vec.clear(); // Make sure the vector is empty before we start
+
+	// Width here is used to determine if a log line needs to be split into multiple lines.
+	// That makes sense for retail, but not so much for the API. Telling it to use the entire screen width
+	// should be sufficient to prevent unnecessary line breaks given how short most log lines are in the mission log.
+	message_log_init_scrollback(gr_screen.max_w);
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(closeMissionLog, l_UserInterface_MissionLog, nullptr, "Clears the Mission Log data. Should be used when finished accessing Mission Log Entries.", nullptr, nullptr)
+{
+	SCP_UNUSED(L);
+
+	message_log_shutdown_scrollback();
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_LIB_DERIV(l_Log_Entries, "Log_Entries", nullptr, nullptr, l_UserInterface_MissionLog);
+ADE_INDEXER(l_Log_Entries,
+	"number Index",
+	"Array of mission log entries",
+	"log_entry",
+	"log entry handle, or invalid handle if index is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "*i", &idx))
+		return ade_set_error(L, "o", l_Log_Entry.Set(log_entry_h()));
+	idx--; //Convert to Lua's 1 based index system
+
+	if ((idx < 0) || (idx >= (int)Log_scrollback_vec.size()))
+		return ade_set_error(L, "o", l_Log_Entry.Set(log_entry_h()));
+
+	return ade_set_args(L, "o", l_Log_Entry.Set(log_entry_h(idx)));
+}
+
+ADE_FUNC(__len, l_Log_Entries, nullptr, "The number of mission log entries", "number", "The number of log entries.")
+{
+	return ade_set_args(L, "i", (int)Log_scrollback_vec.size());
+}
+
+ADE_LIB_DERIV(l_Log_Messages, "Log_Messages", nullptr, nullptr, l_UserInterface_MissionLog);
+ADE_INDEXER(l_Log_Messages,
+	"number Index",
+	"Array of message log entries",
+	"message_entry",
+	"message entry handle, or invalid handle if index is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "*i", &idx))
+		return ade_set_error(L, "o", l_Message_Entry.Set(message_entry_h()));
+	idx--; //Convert to Lua's 1 based index system
+
+	if ((idx < 0) || (idx >= (int)Log_scrollback_vec.size()))
+		return ade_set_error(L, "o", l_Message_Entry.Set(message_entry_h()));
+
+	return ade_set_args(L, "o", l_Message_Entry.Set(message_entry_h(idx)));
+}
+
+ADE_FUNC(__len, l_Log_Messages, nullptr, "The number of mission message entries", "number", "The number of message entries.")
+{
+	return ade_set_args(L, "i", (int)Msg_scrollback_vec.size());
+}
+
 //**********SUBLIBRARY: UserInterface/PauseScreen
 ADE_LIB_DERIV(l_UserInterface_PauseScreen,
 	"PauseScreen",

--- a/code/scripting/api/objs/missionlog.cpp
+++ b/code/scripting/api/objs/missionlog.cpp
@@ -102,12 +102,12 @@ ADE_VIRTVAR(ObjectiveColor, l_Log_Entry, nullptr, "The objective color of the lo
 	return ade_set_args(L, "o", l_Color.Set(ac));
 }
 
-ADE_VIRTVAR(ActionTexts,
+ADE_VIRTVAR(SegmentTexts,
 	l_Log_Entry,
 	nullptr,
-	"Gets a table of action texts in the log entry",
+	"Gets a table of segment texts in the log entry",
 	"{ number => string ... }",
-	"The action texts table")
+	"The segment texts table")
 {
 	log_entry_h current;
 	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
@@ -116,19 +116,19 @@ ADE_VIRTVAR(ActionTexts,
 
 	auto table = luacpp::LuaTable::create(L);
 
-	for (size_t i = 0; i < current.getSection()->actions.size(); i++) {
-		table.addValue(i + 1, current.getSection()->actions[i].text.get()); // translate to Lua index
+	for (size_t i = 0; i < current.getSection()->segments.size(); i++) {
+		table.addValue(i + 1, current.getSection()->segments[i].text.get()); // translate to Lua index
 	}
 
 	return ade_set_args(L, "t", &table);
 }
 
-ADE_VIRTVAR(ActionColors,
+ADE_VIRTVAR(SegmentColors,
 	l_Log_Entry,
 	nullptr,
-	"Gets a table of action colors in the log entry.",
+	"Gets a table of segment colors in the log entry.",
 	"{ number => color ... }",
-	"The action colors table")
+	"The segment colors table")
 {
 	log_entry_h current;
 	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
@@ -137,9 +137,9 @@ ADE_VIRTVAR(ActionColors,
 
 	auto table = luacpp::LuaTable::create(L);
 
-	for (size_t i = 0; i < current.getSection()->actions.size(); i++) {
+	for (size_t i = 0; i < current.getSection()->segments.size(); i++) {
 
-		color ac = log_line_get_color(current.getSection()->actions[i].color);
+		color ac = log_line_get_color(current.getSection()->segments[i].color);
 		table.addValue(i + 1, l_Color.Set(ac)); // translate to Lua index
 	}
 

--- a/code/scripting/api/objs/missionlog.cpp
+++ b/code/scripting/api/objs/missionlog.cpp
@@ -1,0 +1,228 @@
+#include "missionlog.h"
+
+
+
+#include "iff_defs/iff_defs.h"
+#include "ship/ship.h"
+#include "globalincs/alphacolors.h"
+#include "parse/parselo.h"
+#include "scripting/api/objs/color.h"
+
+namespace scripting {
+namespace api {
+
+log_entry_h::log_entry_h() : section(-1) {}
+log_entry_h::log_entry_h(int l_section) : section(l_section) {}
+
+log_line_complete* log_entry_h::getSection() const
+{
+	return &Log_scrollback_vec[section];
+}
+
+message_entry_h::message_entry_h() : section(-1) {}
+message_entry_h::message_entry_h(int l_section) : section(l_section) {}
+
+line_node* message_entry_h::getSection() const
+{
+	return &Msg_scrollback_vec[section];
+}
+
+//**********HANDLE: log entry
+ADE_OBJ(l_Log_Entry, log_entry_h, "log_entry", "Log Entry handle");
+
+ADE_VIRTVAR(Timestamp, l_Log_Entry, nullptr, "The timestamp of the log entry", "string", "The timestamp")
+{
+	log_entry_h current;
+	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	int seconds = fl2i(f2fl(current.getSection()->timestamp));
+
+	// format the time information into strings
+	SCP_string time;
+	sprintf(time, "%.1d:%.2d:%.2d", (seconds / 3600) % 10, (seconds / 60) % 60, seconds % 60);
+
+	return ade_set_args(L, "s", time.c_str());
+}
+
+ADE_VIRTVAR(Flags, l_Log_Entry, nullptr, "The flag of the log entry. 1 for Goal True, 2 for Goal Failed, 0 otherwise.", "string", "The flag")
+{
+	log_entry_h current;
+	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	int this_flag = 0;
+
+	if (current.getSection()->objective.flags & LOG_FLAG_GOAL_TRUE)
+		this_flag = 1;
+
+	if (current.getSection()->objective.flags & LOG_FLAG_GOAL_FAILED)
+		this_flag = 2;
+
+	return ade_set_args(L, "i", this_flag);
+}
+
+ADE_VIRTVAR(ObjectiveText, l_Log_Entry, nullptr, "The objective text of the log entry", "string", "The objective text")
+{
+	log_entry_h current;
+	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current.getSection()->objective.text.get());
+}
+
+ADE_VIRTVAR(ObjectiveColor, l_Log_Entry, nullptr, "The objective color of the log entry.", "color", "The objective color")
+{
+	log_entry_h current;
+	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	color ac = log_line_get_color(current.getSection()->objective.color);
+
+	return ade_set_args(L, "o", l_Color.Set(ac));
+}
+
+ADE_VIRTVAR(ActionTexts,
+	l_Log_Entry,
+	nullptr,
+	"Gets a table of action texts in the log entry",
+	"{ number => string ... }",
+	"The action texts table")
+{
+	log_entry_h current;
+	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	auto table = luacpp::LuaTable::create(L);
+
+	for (size_t i = 0; i < current.getSection()->actions.size(); i++) {
+		table.addValue(i + 1, current.getSection()->actions[i].text.get()); // translate to Lua index
+	}
+
+	return ade_set_args(L, "t", &table);
+}
+
+ADE_VIRTVAR(ActionColors,
+	l_Log_Entry,
+	nullptr,
+	"Gets a table of action colors in the log entry.",
+	"{ number => color ... }",
+	"The action colors table")
+{
+	log_entry_h current;
+	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	auto table = luacpp::LuaTable::create(L);
+
+	for (size_t i = 0; i < current.getSection()->actions.size(); i++) {
+
+		color ac = log_line_get_color(current.getSection()->actions[i].color);
+		table.addValue(i + 1, l_Color.Set(ac)); // translate to Lua index
+	}
+
+	return ade_set_args(L, "t", &table);
+}
+
+//**********HANDLE: message entry
+ADE_OBJ(l_Message_Entry, message_entry_h, "message_entry", "Log Entry handle");
+
+ADE_VIRTVAR(Timestamp, l_Message_Entry, nullptr, "The timestamp of the message entry", "string", "The timestamp")
+{
+	message_entry_h current;
+	if (!ade_get_args(L, "o", l_Message_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	int seconds = fl2i(f2fl(current.getSection()->time));
+
+	// format the time information into strings
+	SCP_string time;
+	sprintf(time, "%.1d:%.2d:%.2d", (seconds / 3600) % 10, (seconds / 60) % 60, seconds % 60);
+
+	return ade_set_args(L, "s", time.c_str());
+}
+
+ADE_VIRTVAR(Color, l_Message_Entry, nullptr, "The color of the message entry.", "color", "The color")
+{
+	message_entry_h current;
+	if (!ade_get_args(L, "o", l_Message_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+	color this_color;
+
+	int team = HUD_source_get_team(current.getSection()->source);
+
+	if (team >= 0) {
+		this_color = *iff_get_color_by_team(team, Player_ship->team, 0);
+	} else {
+		switch (current.getSection()->source) {
+		case HUD_SOURCE_TRAINING:
+			this_color = Color_bright_blue;
+			break;
+
+		case HUD_SOURCE_TERRAN_CMD:
+			this_color = Color_bright_white;
+			break;
+
+		case HUD_SOURCE_IMPORTANT:
+		case HUD_SOURCE_FAILED:
+		case HUD_SOURCE_SATISFIED:
+			this_color = Color_bright_white;
+			break;
+
+		default:
+			this_color = Color_text_normal;
+			break;
+		}
+	}
+
+	return ade_set_args(L, "o", l_Color.Set(this_color));
+}
+
+ADE_VIRTVAR(Text, l_Message_Entry, nullptr, "The text of the message entry", "string", "The text")
+{
+	message_entry_h current;
+	if (!ade_get_args(L, "o", l_Message_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current.getSection()->text.c_str());
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/objs/missionlog.h
+++ b/code/scripting/api/objs/missionlog.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "mission/missionlog.h"
+#include "hud/hudmessage.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+struct log_entry_h {
+	int section;
+	log_entry_h();
+	explicit log_entry_h(int l_section);
+	log_line_complete* getSection() const;
+};
+
+struct message_entry_h {
+	int section;
+	message_entry_h();
+	explicit message_entry_h(int l_section);
+	line_node* getSection() const;
+};
+
+DECLARE_ADE_OBJ(l_Log_Entry, log_entry_h);
+DECLARE_ADE_OBJ(l_Message_Entry, message_entry_h);
+
+} // namespace api
+} // namespace scripting

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1362,6 +1362,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/mc_info.h
 	scripting/api/objs/message.cpp
 	scripting/api/objs/message.h
+	scripting/api/objs/missionlog.cpp
+	scripting/api/objs/missionlog.h
 	scripting/api/objs/model.cpp
 	scripting/api/objs/model.h
 	scripting/api/objs/modelinstance.cpp


### PR DESCRIPTION
API access to the elements required for the mission log UI.

EDIT: I should add that this also slightly changes how log entry flags are done. The flags are used only for Goal True or Goal Failed and all they functionally do is tell the game whether or not to draw a little circle next to the log entry filled with either red or green. In the past this was saved to the log entry action item (there are multiple actions (bits of colored text) per log entry. It makes little sense to have to parse all of those for each action since it applies to the entire entry no matter what. So now we save the flags to the parent "objective" item only and look there.