### PR TITLE
Add fov values to .pof models

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2899,7 +2899,7 @@ bool turret_adv_fov_test(ship_subsys *ss, vec3d *gvec, vec3d *v2e, float size_mo
 bool turret_fov_test(ship_subsys *ss, vec3d *gvec, vec3d *v2e, float size_mod)
 {
 	bool in_fov = false;
-	if (ss->system_info->flags[Model::Subsystem_Flags::Turret_base_restricted_fov])
+	if (ss->system_info->turret_base_fov > -1.0f)
 		in_fov = turret_adv_fov_test(ss, gvec, v2e, size_mod);
 	else
 		in_fov = turret_std_fov_test(ss, gvec, v2e, size_mod);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -194,7 +194,7 @@ public:
 	vec3d	turret_norm;						//	direction this turret faces (i.e. the normal to the turret base, or the center of the field of view)
 	float	turret_fov;							//	dot of turret_norm:vec_to_enemy > this means can see
 	float	turret_max_fov;						//  dot of turret_norm:vec_to_enemy <= this means barrels can elevate up to the target
-	float	turret_base_fov;						//  turret's base's fov
+	float	turret_base_fov;					//  turret's base's fov, -1 means no restriction
 	int		turret_num_firing_points;			// number of firing points on this turret
 	vec3d	turret_firing_point[MAX_TFP];		//	in parent object's reference frame, point from which to fire.
 	int		turret_gun_sobj;					// Which subobject in this model the firing points are linked to.

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -43,8 +43,9 @@ namespace Model {
 		Fire_on_target,		// prevents turret from firing unless it is pointing at the firingpoints are pointing at the target
 		No_ss_targeting,	// toggles the subsystem targeting for the turret
 		Turret_reset_idle,	// makes turret reset to their initial position if the target is out of field of view
-		Turret_base_restricted_fov,	// tells the game to use additional calculations should turret have a limited base fov or elevation
-		Turret_barrel_override_fov,	// indicates the ships.tbl FOV should override the POF FOV
+		Turret_barrel_fov_overridden,	// indicates the ships.tbl value should override the pof value
+		Turret_base_fov_overridden,	// ..
+		Turret_max_fov_overridden,	// ..
 		Carry_shockwave,	// subsystem - even with 'carry no damage' flag - will carry shockwave damage to the hull
 		Allow_landing,		// This subsystem can be landed on
 		Fov_edge_check,		// Tells the game to use better FOV edge checking with this turret

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4973,6 +4973,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			float	turning_rate;
 			float	percentage_of_hits;
 			bool turret_has_base_fov = false;
+			bool turret_has_max_fov = false;
 			bool turret_has_barrel_fov = false;
 			model_subsystem *sp = NULL;			// to append on the ships list of subsystems
 			
@@ -5134,26 +5135,27 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			}
 
 			if(optional_string("$Maximum Barrel Elevation:")){
-				int value;
-				stuff_int(&value);
-				CAP(value, 0, 90);
-				float angle = fl_radians(90 - value);
+				float value;
+				stuff_float(&value);
+				CAP(value, 0.0f, 90.0f);
+				float angle = fl_radians(90.0f - value);
 				sp->turret_max_fov = cosf(angle);
+				turret_has_max_fov = true;
 			}
 
 			if(optional_string("$Turret Base FOV:")) {
-				int value;
-				stuff_int(&value);
-				CAP(value, 0, 359);
+				float value;
+				stuff_float(&value);
+				CAP(value, 0.0f, 360.0f);
 				float angle = fl_radians(value)/2.0f;
 				sp->turret_base_fov = cosf(angle);
 				turret_has_base_fov = true;
 			}
 
 			if (optional_string("$Turret Barrel FOV:")) {
-				int value;
-				stuff_int(&value);
-				CAP(value, 0, 359);
+				float value;
+				stuff_float(&value);
+				CAP(value, 0.0f, 360.0f);
 				float angle = fl_radians(value) / 2.0f;
 				sp->turret_fov = cosf(angle);
 				turret_has_barrel_fov = true;
@@ -5253,10 +5255,12 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 					sip->flags.set(Ship::Info_Flags::Allow_landings);
 			}
 
-            if (turret_has_base_fov)
-                sp->flags.set(Model::Subsystem_Flags::Turret_base_restricted_fov);
 			if (turret_has_barrel_fov)
-				sp->flags.set(Model::Subsystem_Flags::Turret_barrel_override_fov);
+				sp->flags.set(Model::Subsystem_Flags::Turret_barrel_fov_overridden);
+			if (turret_has_base_fov)
+				sp->flags.set(Model::Subsystem_Flags::Turret_base_fov_overridden);
+			if (turret_has_max_fov)
+				sp->flags.set(Model::Subsystem_Flags::Turret_max_fov_overridden);
 
 			if (optional_string("+non-targetable")) {
 				Warning(LOCATION, "Grammar error in table file.  Please change \"+non-targetable\" to \"+untargetable\".");

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -4028,7 +4028,6 @@ int beam_ok_to_fire(beam *b)
 
 			if (b->flags & BF_IS_FIGHTER_BEAM) {
 				turret_normal = b->objp->orient.vec.fvec;
-                b->subsys->system_info->flags.remove(Model::Subsystem_Flags::Turret_base_restricted_fov);
 			} else {
 				model_instance_local_to_global_dir(&turret_normal, &b->subsys->system_info->turret_norm, Ships[b->objp->instance].model_instance_num, b->subsys->system_info->subobj_num, &b->objp->orient, true);
 			}


### PR DESCRIPTION
Allows parsing $base_fov and $max_fov from turret subobject properties, allowing all 3 values to be defined in the model, as well as overriden by table. Additionally cleans up the overall handling and consistency of these values a bit.