### PR TITLE
fixup error checking in regards to sexps using dynamic parameters

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2636,7 +2636,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						if (get_operator_const(op_node) < First_available_operator_id) {
 							ship_node = CDR(op_node);
 						} else {
-							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
 							
 							if (r_count < 0)
 								error_display(1,
@@ -2645,9 +2645,10 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 									argnum,
 									Sexp_nodes[op_node].text);
 							
-							ship_node = 0; //initialize it I guess
+							r_count++;     // account for the node header
+							ship_node = op_node; //initialize it I guess
 							while (r_count >= 0) {
-								ship_node = CDR(op_node);
+								ship_node = CDR(ship_node);
 								r_count--;
 							}
 						}
@@ -3367,7 +3368,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDR(z);
 						} else if (type == OPF_DOCKER_POINT) {
 							if (get_operator_const(op_node) >= First_available_operator_id) {
-								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
 								
 								if (r_count < 0)
 									error_display(1,
@@ -3376,9 +3377,10 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 										argnum,
 										Sexp_nodes[op_node].text);
 								
-								ship_node = 0;   // initialize it I guess
+								r_count++;           // account for the node header
+								ship_node = op_node; // initialize it I guess
 								while (r_count >= 0) {
-									ship_node = CDR(op_node);
+									ship_node = CDR(ship_node);
 									r_count--;
 								}
 								break;
@@ -3388,7 +3390,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						} else if (type == OPF_DOCKEE_POINT) {
 							ship_node = CDDDR(z);
 						} else if (get_operator_const(op_node) >= First_available_operator_id) {
-							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
 							
 							if (r_count < 0)
 								error_display(1,
@@ -3397,9 +3399,10 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 									argnum,
 									Sexp_nodes[op_node].text);
 							
-							ship_node = 0;   // initialize it I guess
+							r_count++;           // account for the node header
+							ship_node = op_node; // initialize it I guess
 							while (r_count >= 0) {
-								ship_node = CDR(op_node);
+								ship_node = CDR(ship_node);
 								r_count--;
 							}
 							break;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2637,17 +2637,19 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDR(op_node);
 						} else {
 							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							
+							if (r_count < 0)
+								error_display(1,
+									"Expected to find a dynamic lua parent parameter for node %i in operator %s but "
+									"found nothing!",
+									argnum,
+									Sexp_nodes[op_node].text);
+							
 							ship_node = 0; //initialize it I guess
 							while (r_count >= 0) {
 								ship_node = CDR(op_node);
 								r_count--;
 							}
-
-							if (ship_node < op_node)
-								error_display(1, "Expected to find a dynamic lua parent parameter for node %i in operator %s but found nothing!",
-									argnum,
-									Sexp_nodes[op_node].text);
-
 						}
 						break;
 				}
@@ -3366,18 +3368,19 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						} else if (type == OPF_DOCKER_POINT) {
 							if (get_operator_const(op_node) >= First_available_operator_id) {
 								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
-								ship_node = 0;   // initialize it I guess
-								while (r_count >= 0) {
-									ship_node = CDR(op_node);
-									r_count--;
-								}
-
-								if (ship_node < 0)
+								
+								if (r_count < 0)
 									error_display(1,
 										"Expected to find a dynamic lua parent parameter for node %i in operator %s "
 										"but found nothing!",
 										argnum,
 										Sexp_nodes[op_node].text);
+								
+								ship_node = 0;   // initialize it I guess
+								while (r_count >= 0) {
+									ship_node = CDR(op_node);
+									r_count--;
+								}
 								break;
 							} else {
 								ship_node = CDR(z);
@@ -3386,18 +3389,19 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDDDR(z);
 						} else if (get_operator_const(op_node) >= First_available_operator_id) {
 							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
-							ship_node = 0;   // initialize it I guess
-							while (r_count >= 0) {
-								ship_node = CDR(op_node);
-								r_count--;
-							}
-
-							if (ship_node < 0)
+							
+							if (r_count < 0)
 								error_display(1,
 									"Expected to find a dynamic lua parent parameter for node %i in operator %s "
 									"but found nothing!",
 									argnum,
 									Sexp_nodes[op_node].text);
+							
+							ship_node = 0;   // initialize it I guess
+							while (r_count >= 0) {
+								ship_node = CDR(op_node);
+								r_count--;
+							}
 							break;
 						} else {
 							UNREACHABLE("Unhandled case for OPF_DOCKER_POINT/OPF_DOCKEE_POINT");

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2636,7 +2636,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						if (get_operator_const(op_node) < First_available_operator_id) {
 							ship_node = CDR(op_node);
 						} else {
-							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
+							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
 							
 							if (r_count < 0)
 								error_display(1,
@@ -2645,10 +2645,9 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 									argnum,
 									Sexp_nodes[op_node].text);
 							
-							r_count++; //account for the node header
-							ship_node = op_node; //initialize it I guess
+							ship_node = 0; //initialize it I guess
 							while (r_count >= 0) {
-								ship_node = CDR(ship_node);
+								ship_node = CDR(op_node);
 								r_count--;
 							}
 						}
@@ -3368,7 +3367,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDR(z);
 						} else if (type == OPF_DOCKER_POINT) {
 							if (get_operator_const(op_node) >= First_available_operator_id) {
-								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
+								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
 								
 								if (r_count < 0)
 									error_display(1,
@@ -3377,10 +3376,9 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 										argnum,
 										Sexp_nodes[op_node].text);
 								
-								r_count++; //account for the node header
-								ship_node = op_node;   // initialize it I guess
+								ship_node = 0;   // initialize it I guess
 								while (r_count >= 0) {
-									ship_node = CDR(ship_node);
+									ship_node = CDR(op_node);
 									r_count--;
 								}
 								break;
@@ -3390,7 +3388,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						} else if (type == OPF_DOCKEE_POINT) {
 							ship_node = CDDDR(z);
 						} else if (get_operator_const(op_node) >= First_available_operator_id) {
-							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
+							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
 							
 							if (r_count < 0)
 								error_display(1,
@@ -3399,10 +3397,9 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 									argnum,
 									Sexp_nodes[op_node].text);
 							
-							r_count++; //account for the node header
-							ship_node = op_node;   // initialize it I guess
+							ship_node = 0;   // initialize it I guess
 							while (r_count >= 0) {
-								ship_node = CDR(ship_node);
+								ship_node = CDR(op_node);
 								r_count--;
 							}
 							break;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2637,17 +2637,17 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDR(op_node);
 						} else {
 							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							
+							if (r_count < 0)
+								error_display(1, "Expected to find a dynamic lua parent parameter for node %i in operator %s but found nothing!",
+									argnum,
+									Sexp_nodes[op_node].text);
+							
 							ship_node = 0; //initialize it I guess
 							while (r_count >= 0) {
 								ship_node = CDR(op_node);
 								r_count--;
 							}
-
-							if (ship_node < op_node)
-								error_display(1, "Expected to find a dynamic lua parent parameter for node %i in operator %s but found nothing!",
-									argnum,
-									Sexp_nodes[op_node].text);
-
 						}
 						break;
 				}
@@ -3366,18 +3366,19 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						} else if (type == OPF_DOCKER_POINT) {
 							if (get_operator_const(op_node) >= First_available_operator_id) {
 								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
-								ship_node = 0;   // initialize it I guess
-								while (r_count >= 0) {
-									ship_node = CDR(op_node);
-									r_count--;
-								}
-
-								if (ship_node < 0)
+								
+								if (r_count < 0)
 									error_display(1,
 										"Expected to find a dynamic lua parent parameter for node %i in operator %s "
 										"but found nothing!",
 										argnum,
 										Sexp_nodes[op_node].text);
+								
+								ship_node = 0;   // initialize it I guess
+								while (r_count >= 0) {
+									ship_node = CDR(op_node);
+									r_count--;
+								}
 								break;
 							} else {
 								ship_node = CDR(z);
@@ -3386,18 +3387,19 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDDDR(z);
 						} else if (get_operator_const(op_node) >= First_available_operator_id) {
 							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
-							ship_node = 0;   // initialize it I guess
-							while (r_count >= 0) {
-								ship_node = CDR(op_node);
-								r_count--;
-							}
-
-							if (ship_node < 0)
+							
+							if (r_count < 0)
 								error_display(1,
 									"Expected to find a dynamic lua parent parameter for node %i in operator %s "
 									"but found nothing!",
 									argnum,
 									Sexp_nodes[op_node].text);
+							
+							ship_node = 0;   // initialize it I guess
+							while (r_count >= 0) {
+								ship_node = CDR(op_node);
+								r_count--;
+							}
 							break;
 						} else {
 							UNREACHABLE("Unhandled case for OPF_DOCKER_POINT/OPF_DOCKEE_POINT");

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2637,17 +2637,17 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDR(op_node);
 						} else {
 							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
-							
-							if (r_count < 0)
-								error_display(1, "Expected to find a dynamic lua parent parameter for node %i in operator %s but found nothing!",
-									argnum,
-									Sexp_nodes[op_node].text);
-							
 							ship_node = 0; //initialize it I guess
 							while (r_count >= 0) {
 								ship_node = CDR(op_node);
 								r_count--;
 							}
+
+							if (ship_node < op_node)
+								error_display(1, "Expected to find a dynamic lua parent parameter for node %i in operator %s but found nothing!",
+									argnum,
+									Sexp_nodes[op_node].text);
+
 						}
 						break;
 				}
@@ -3366,19 +3366,18 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						} else if (type == OPF_DOCKER_POINT) {
 							if (get_operator_const(op_node) >= First_available_operator_id) {
 								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
-								
-								if (r_count < 0)
-									error_display(1,
-										"Expected to find a dynamic lua parent parameter for node %i in operator %s "
-										"but found nothing!",
-										argnum,
-										Sexp_nodes[op_node].text);
-								
 								ship_node = 0;   // initialize it I guess
 								while (r_count >= 0) {
 									ship_node = CDR(op_node);
 									r_count--;
 								}
+
+								if (ship_node < 0)
+									error_display(1,
+										"Expected to find a dynamic lua parent parameter for node %i in operator %s "
+										"but found nothing!",
+										argnum,
+										Sexp_nodes[op_node].text);
 								break;
 							} else {
 								ship_node = CDR(z);
@@ -3387,19 +3386,18 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDDDR(z);
 						} else if (get_operator_const(op_node) >= First_available_operator_id) {
 							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
-							
-							if (r_count < 0)
-								error_display(1,
-									"Expected to find a dynamic lua parent parameter for node %i in operator %s "
-									"but found nothing!",
-									argnum,
-									Sexp_nodes[op_node].text);
-							
 							ship_node = 0;   // initialize it I guess
 							while (r_count >= 0) {
 								ship_node = CDR(op_node);
 								r_count--;
 							}
+
+							if (ship_node < 0)
+								error_display(1,
+									"Expected to find a dynamic lua parent parameter for node %i in operator %s "
+									"but found nothing!",
+									argnum,
+									Sexp_nodes[op_node].text);
 							break;
 						} else {
 							UNREACHABLE("Unhandled case for OPF_DOCKER_POINT/OPF_DOCKEE_POINT");

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2636,8 +2636,11 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						if (get_operator_const(op_node) < First_available_operator_id) {
 							ship_node = CDR(op_node);
 						} else {
-							ship_node = op_node + get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum); //error checking uses the whole tree
-							ship_node++; //dynamic params are saved at a 0 based index, but with the whole tree we need to move up a spot
+							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							while (r_count >= 0) {
+								ship_node = CDR(op_node);
+								r_count--;
+							}
 
 							if (ship_node < op_node)
 								error_display(1, "Expected to find a dynamic lua parent parameter for node %i in operator %s but found nothing!",
@@ -3361,9 +3364,11 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDR(z);
 						} else if (type == OPF_DOCKER_POINT) {
 							if (get_operator_const(op_node) >= First_available_operator_id) {
-
-								ship_node = op_node + get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum); //error checking uses the whole tree
-								ship_node++; //dynamic params are saved at a 0 based index, but with the whole tree we need to move up a spot
+								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+								while (r_count >= 0) {
+									ship_node = CDR(op_node);
+									r_count--;
+								}
 
 								if (ship_node < 0)
 									error_display(1,
@@ -3378,9 +3383,11 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						} else if (type == OPF_DOCKEE_POINT) {
 							ship_node = CDDDR(z);
 						} else if (get_operator_const(op_node) >= First_available_operator_id) {
-
-							ship_node = op_node + get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);//error checking uses the whole tree
-							ship_node++; //dynamic params are saved at a 0 based index, but with the whole tree we need to move up a spot
+							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							while (r_count >= 0) {
+								ship_node = CDR(op_node);
+								r_count--;
+							}
 
 							if (ship_node < 0)
 								error_display(1,

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2636,7 +2636,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						if (get_operator_const(op_node) < First_available_operator_id) {
 							ship_node = CDR(op_node);
 						} else {
-							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
 							
 							if (r_count < 0)
 								error_display(1,
@@ -2645,9 +2645,10 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 									argnum,
 									Sexp_nodes[op_node].text);
 							
-							ship_node = 0; //initialize it I guess
+							r_count++; //account for the node header
+							ship_node = op_node; //initialize it I guess
 							while (r_count >= 0) {
-								ship_node = CDR(op_node);
+								ship_node = CDR(ship_node);
 								r_count--;
 							}
 						}
@@ -3367,7 +3368,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDR(z);
 						} else if (type == OPF_DOCKER_POINT) {
 							if (get_operator_const(op_node) >= First_available_operator_id) {
-								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
 								
 								if (r_count < 0)
 									error_display(1,
@@ -3376,9 +3377,10 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 										argnum,
 										Sexp_nodes[op_node].text);
 								
-								ship_node = 0;   // initialize it I guess
+								r_count++; //account for the node header
+								ship_node = op_node;   // initialize it I guess
 								while (r_count >= 0) {
-									ship_node = CDR(op_node);
+									ship_node = CDR(ship_node);
 									r_count--;
 								}
 								break;
@@ -3388,7 +3390,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						} else if (type == OPF_DOCKEE_POINT) {
 							ship_node = CDDDR(z);
 						} else if (get_operator_const(op_node) >= First_available_operator_id) {
-							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum);
 							
 							if (r_count < 0)
 								error_display(1,
@@ -3397,9 +3399,10 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 									argnum,
 									Sexp_nodes[op_node].text);
 							
-							ship_node = 0;   // initialize it I guess
+							r_count++; //account for the node header
+							ship_node = op_node;   // initialize it I guess
 							while (r_count >= 0) {
-								ship_node = CDR(op_node);
+								ship_node = CDR(ship_node);
 								r_count--;
 							}
 							break;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2637,6 +2637,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDR(op_node);
 						} else {
 							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							ship_node = 0; //initialize it I guess
 							while (r_count >= 0) {
 								ship_node = CDR(op_node);
 								r_count--;
@@ -3365,6 +3366,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						} else if (type == OPF_DOCKER_POINT) {
 							if (get_operator_const(op_node) >= First_available_operator_id) {
 								int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+								ship_node = 0;   // initialize it I guess
 								while (r_count >= 0) {
 									ship_node = CDR(op_node);
 									r_count--;
@@ -3384,6 +3386,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 							ship_node = CDDDR(z);
 						} else if (get_operator_const(op_node) >= First_available_operator_id) {
 							int r_count = get_dynamic_parameter_index(Sexp_nodes[op_node].text, argnum) + 1; //account for the node header
+							ship_node = 0;   // initialize it I guess
 							while (r_count >= 0) {
 								ship_node = CDR(op_node);
 								r_count--;


### PR DESCRIPTION
This fixes some issues with how Lua SEXPs with subsystem or dockpoint parameters will work in sexp.cpp error checking. I got lucky in my earlier tests in that my specific set of test sexps passed the checks by just happening to have the right parameters in the right places to match existing built-in sexps.

My earlier code was a copy/paste from sexp_tree.cpp to here, assuming it worked the same but of course it's just slightly different. Here the code is running down the entire node tree instead of just a specific sexp, so we have to compensate for that. Instead of returning the index to the parent parameter within the single node, I need to get the index of the parent parameter within the entire sexp list. A matter of simple math. But also since in this case sexp node names count in the index, I need to ++ to account for that as well.