### PR TITLE
Scpui hotkeys

### DIFF
--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -479,19 +479,21 @@ void mission_hotkey_validate()
 // get the Hotkey_bits of a whole wing (bits must be set in all ships of wing for a hotkey bit to be set)
 int get_wing_hotkeys(int n)
 {
+	int idx = Hotkey_lines[n].index;
+	
 	int total = 0xffffffff;
 
-	Assert((n >= 0) && (n < Num_wings));
-	for (int i=0; i<Wings[n].current_count; i++) {
+	Assert((idx >= 0) && (idx < Num_wings));
+	for (int i = 0; i < Wings[idx].current_count; i++) {
 		int ship_index;
 
 		// don't count the player ship for the total -- you cannot assign the player since bad things
 		// can happen on the hud.
-		ship_index = Wings[n].ship_index[i];
+		ship_index = Wings[idx].ship_index[i];
 		if ( &Ships[ship_index] == Player_ship )
 			continue;
 
-		total &= Hotkey_bits[Wings[n].ship_index[i]];
+		total &= Hotkey_bits[Wings[idx].ship_index[i]];
 	}
 
 	return total;
@@ -835,7 +837,7 @@ void clear_hotkeys(int line)
 
 	if (z == HOTKEY_LINE_WING) {
 		z = Hotkey_lines[line].index;
-		int b = ~get_wing_hotkeys(z);
+		int b = ~get_wing_hotkeys(line);
 		for (int i=0; i<Wings[z].current_count; i++)
 			Hotkey_bits[Wings[z].ship_index[i]] &= b;
 
@@ -1157,12 +1159,12 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 			int hotkeys = -1;
 			switch (Hotkey_lines[Selected_line].type) {
 				case HOTKEY_LINE_WING:
-					hotkeys = get_wing_hotkeys(Hotkey_lines[Selected_line].index);
+					hotkeys = get_wing_hotkeys(Selected_line);
 					break;
 
 				case HOTKEY_LINE_SHIP:
 				case HOTKEY_LINE_SUBSHIP:
-					hotkeys = Hotkey_bits[Hotkey_lines[Selected_line].index];
+					hotkeys = get_ship_hotkeys(Selected_line);
 					break;
 			}
 
@@ -1233,12 +1235,12 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 //				gr_line(ICON_LIST_X + 6, i, ICON_LIST_X + 8, i, GR_RESIZE_MENU);
 //				gr_line(ICON_LIST_X + 4, i + 2, ICON_LIST_X + 4, i + 4, GR_RESIZE_MENU);
 
-				hotkeys = get_wing_hotkeys(Hotkey_lines[line].index);
+				hotkeys = get_wing_hotkeys(line);
 				break;
 
 			case HOTKEY_LINE_SHIP:
 			case HOTKEY_LINE_SUBSHIP:
-				hotkeys = Hotkey_bits[Hotkey_lines[line].index];
+				hotkeys = get_ship_hotkeys(line);
 				break;
 
 			default:

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -98,15 +98,9 @@ static const char *Hotkey_mask_fname[GR_NUM_RESOLUTIONS] = {
 #define HOTKEY_X		575
 #define HOTKEY_Y		41
 */
- 
-#define HOTKEY_LINE_HEADING	1
-#define HOTKEY_LINE_WING		2
-#define HOTKEY_LINE_SHIP		3
-#define HOTKEY_LINE_SUBSHIP	4  // ship that is in a wing
 
 #define WING_FLAG	0x80000
 
-#define MAX_LINES					200
 #define NUM_BUTTONS				10
 #define LIST_BUTTONS_MAX		50
 
@@ -258,15 +252,7 @@ static UI_XSTR Hotkey_text[GR_NUM_RESOLUTIONS][HOTKEY_NUM_TEXT] = {
 	}
 };
 
-
-
-static struct {
-	SCP_string label;
-	int type;
-	int index;
-	int y;  // Y coordinate of line
-} Hotkey_lines[MAX_LINES];
-
+hotkey_line Hotkey_lines[MAX_LINES];
 static int Cur_hotkey = 0;
 static int Scroll_offset;
 static int Num_lines;
@@ -523,6 +509,11 @@ int get_wing_hotkeys(int n)
 	return total;
 }
 
+int get_ship_hotkeys(int n)
+{
+	return Hotkey_bits[Hotkey_lines[n].index];
+}
+
 // add a line of hotkey smuck to end of list
 int hotkey_line_add(const char *text, int type, int index, int y)
 {
@@ -723,6 +714,11 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 
 	y += font_height + 8;
 	return y;
+}
+
+void hotkey_set_selected_line(int line)
+{
+	Selected_line = line;
 }
 
 void hotkey_build_listing()

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -33,7 +33,7 @@
 #include "weapon/weapon.h"
 
 
-static int Key_sets[MAX_KEYED_TARGETS] = {
+int Key_sets[MAX_KEYED_TARGETS] = {
 	KEY_F5,
 	KEY_F6,
 	KEY_F7,
@@ -272,9 +272,8 @@ int Hotkey_overlay_id;
 // not trivial since our current keysets (F5 - F12) do not have sequential keycodes
 int mission_hotkey_get_set_num( int k )
 {
-	int i;
 
-	for (i = 0; i < MAX_KEYED_TARGETS; i++ ) {
+	for (int i = 0; i < MAX_KEYED_TARGETS; i++ ) {
 		if ( Key_sets[i] == k ) {
 			return i;
 		}
@@ -287,15 +286,14 @@ int mission_hotkey_get_set_num( int k )
 // function to maybe restore some hotkeys during the first N seconds of the mission
 void mission_hotkey_maybe_restore()
 {
-	int i, index;
 
-	for ( i = 0; i < Num_hotkeys_saved; i++ ) {
+	for (int i = 0; i < Num_hotkeys_saved; i++ ) {
 		// don't process something that has no set
 		if ( Hotkey_saved_info[i].setnum == -1 )
 			continue;
 
 		// the ship is present, add it to the given set.
-		index = ship_name_lookup(Hotkey_saved_info[i].name);
+		int index = ship_name_lookup(Hotkey_saved_info[i].name);
 		if ( index != -1 ) {
 			hud_target_hotkey_add_remove( Hotkey_saved_info[i].setnum, &Objects[Ships[index].objnum], HOTKEY_USER_ADDED );
 			Hotkey_saved_info[i].setnum = -1;
@@ -311,11 +309,8 @@ void mission_hotkey_maybe_restore()
 //
 void mission_hotkey_set_defaults()
 {
-	int		i,j;
-	wing		*wp;
-	ship		*sp;
 
-	for ( i = 0; i < MAX_KEYED_TARGETS; i++ ) {
+	for (int i = 0; i < MAX_KEYED_TARGETS; i++ ) {
 		hud_target_hotkey_clear(i);
 	}
 
@@ -342,7 +337,7 @@ void mission_hotkey_set_defaults()
 		}
 
 		Assert(A->instance >= 0 && A->instance < MAX_SHIPS);
-		sp = &Ships[A->instance];		
+		ship *sp = &Ships[A->instance];		
 
 		if ( sp->hotkey == -1 )
 			continue;
@@ -358,8 +353,8 @@ void mission_hotkey_set_defaults()
 	}
 
 	// Check for wings with a hotkey assigned
-	for ( i = 0; i < Num_wings; i++ ) {
-		wp = &Wings[i];
+	for (int i = 0; i < Num_wings; i++ ) {
+		wing *wp = &Wings[i];
 
 		if ( wp->hotkey == -1 )  
 			continue;
@@ -368,11 +363,11 @@ void mission_hotkey_set_defaults()
 		if ( wp->hotkey == MAX_KEYED_TARGETS )
 			continue;
 
-		for ( j = 0; j < wp->current_count; j++ ) {
+		for (int j = 0; j < wp->current_count; j++ ) {
 			if ( wp->ship_index[j] == -1 )
 				continue;
 
-			sp = &Ships[wp->ship_index[j]];
+			ship *sp = &Ships[wp->ship_index[j]];
 			hud_target_hotkey_add_remove( wp->hotkey, &Objects[sp->objnum], HOTKEY_MISSION_FILE_ADDED );
 		}				
 	}
@@ -388,11 +383,6 @@ void mission_hotkey_reset_saved()
 // sets N seconds into the mission
 void mission_hotkey_maybe_save_sets()
 {
-	int i;
-	htarget_list	*hitem, *plist;
-	HK_save_info *hkp;
-	bool found_player_hotkey;
-
 	if ( !timestamp_elapsed(Mission_hotkey_save_timestamp) ) {
 		mission_hotkey_maybe_restore();
 		return;
@@ -402,20 +392,21 @@ void mission_hotkey_maybe_save_sets()
 	if ( Hotkey_sets_saved )
 		return;
 
-	for ( i = 0; i < MAX_HOTKEY_TARGET_ITEMS; i++ )
+	for (int i = 0; i < MAX_HOTKEY_TARGET_ITEMS; i++ )
 		Hotkey_saved_info[i].setnum = -1;
 
 	Num_hotkeys_saved = 0;
-	hkp = &(Hotkey_saved_info[0]);
+	HK_save_info *hkp = &(Hotkey_saved_info[0]);
 
-	for ( i = 0; i < MAX_KEYED_TARGETS; i++ ) {
+	for (int i = 0; i < MAX_KEYED_TARGETS; i++ ) {
 
 		// get the list.  do nothing if list is empty
-		plist = &(Player->keyed_targets[i]);
+		htarget_list *plist = &(Player->keyed_targets[i]);
 		if ( EMPTY(plist) )
 			continue;
 
-		found_player_hotkey = false;
+		bool found_player_hotkey = false;
+		htarget_list* hitem;
 		for ( hitem = GET_FIRST(plist); hitem != END_OF_LIST(plist); hitem = GET_NEXT(hitem) )
 			if (hitem->how_added == HOTKEY_USER_ADDED)
 				found_player_hotkey = true;
@@ -450,20 +441,17 @@ void mission_hotkey_mf_add( int set, int objnum, int how_to_add )
 
 void mission_hotkey_validate()
 {
-	htarget_list	*hitem, *plist;
-	object			*A;
-	int				obj_valid, i;
-
-	for ( i = 0; i < MAX_KEYED_TARGETS; i++ ) {
-		plist = &(Players[Player_num].keyed_targets[i]);
+	for (int i = 0; i < MAX_KEYED_TARGETS; i++ ) {
+		htarget_list* plist = &(Players[Player_num].keyed_targets[i]);
 		if ( EMPTY( plist ) )			// no items in list, then do nothing
 			continue;
 
-		hitem = GET_FIRST(plist);
+		htarget_list *hitem = GET_FIRST(plist);
 		while ( hitem != END_OF_LIST(plist) ) {
 
 			// ensure this object is still valid and in the obj_used_list
-			obj_valid = FALSE;
+			int obj_valid = FALSE;
+			object* A;
 			for ( A = GET_FIRST(&obj_used_list); A !=END_OF_LIST(&obj_used_list); A = GET_NEXT(A) ) {
 				if (A->flags[Object::Object_Flags::Should_be_dead])
 					continue;
@@ -478,7 +466,7 @@ void mission_hotkey_validate()
 				temp = GET_NEXT(hitem);
 				list_remove( plist, hitem );
 				list_append( &htarget_free_list, hitem );
-				hitem->objp = NULL;
+				hitem->objp = nullptr;
 				hitem = temp;
 				continue;
 			}
@@ -491,10 +479,10 @@ void mission_hotkey_validate()
 // get the Hotkey_bits of a whole wing (bits must be set in all ships of wing for a hotkey bit to be set)
 int get_wing_hotkeys(int n)
 {
-	int i, total = 0xffffffff;
+	int total = 0xffffffff;
 
 	Assert((n >= 0) && (n < Num_wings));
-	for (i=0; i<Wings[n].current_count; i++) {
+	for (int i=0; i<Wings[n].current_count; i++) {
 		int ship_index;
 
 		// don't count the player ship for the total -- you cannot assign the player since bad things
@@ -530,12 +518,11 @@ int hotkey_line_add(const char *text, int type, int index, int y)
 // insert a line of hotkey smuck before line 'n'.
 int hotkey_line_insert(int n, const char *text, int type, int index)
 {
-	int z;
 
 	if (Num_lines >= MAX_LINES)
 		return 0;
 
-	z = Num_lines++;
+	int z = Num_lines++;
 	while (z > n) {
 		Hotkey_lines[z] = Hotkey_lines[z - 1];
 		z--;
@@ -551,12 +538,11 @@ int hotkey_line_insert(int n, const char *text, int type, int index)
 // sorted by name
 int hotkey_line_add_sorted(const char *text, int type, int index, int start)
 {
-	int z;
 
 	if (Num_lines >= MAX_LINES)
 		return -1;
 
-	z = Num_lines - 1;
+	int z = Num_lines - 1;
 	while ((z >= start) && ((Hotkey_lines[z].type == HOTKEY_LINE_SUBSHIP) || (stricmp(text, Hotkey_lines[z].label.c_str()) < 0)))
 		z--;
 
@@ -569,10 +555,8 @@ int hotkey_line_add_sorted(const char *text, int type, int index, int start)
 
 int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 {
-	ship_obj *so;
-	const char *str = NULL;
-	int i, j, s, z, start, team_mask;
-	int font_height = gr_get_font_height();
+	const char *str = nullptr;
+	int team_mask;
 	IFF_hotkey_team hotkey_team;
 
 	if (list_enemies)
@@ -591,7 +575,8 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 	hotkey_line_add(str, HOTKEY_LINE_HEADING, 0, y);
 	y += 2;
 
-	start = Num_lines;
+	int start = Num_lines;
+	ship_obj* so;
 
 	for ( so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so) ) {
 		bool add_it;
@@ -639,7 +624,7 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 		}
 	}
 
-	for (i=0; i<Num_wings; i++) {
+	for (int i=0; i<Num_wings; i++) {
 		bool add_it;
 		char wing_name[NAME_LENGTH];
 
@@ -672,6 +657,8 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 				Wings[i].hotkey = -1;
 			}
 
+			int j;
+
 			// don't add any wing data whose ships are hidden from sensors
 			for ( j = 0; j < Wings[i].current_count; j++ ) {
 				if ( Ships[Wings[i].ship_index[j]].flags[Ship::Ship_Flags::Hidden_from_sensors] )
@@ -684,10 +671,10 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 			strcpy_s(wing_name, Wings[i].name);
 			end_string_at_first_hash_symbol(wing_name);
 
-			z = hotkey_line_add_sorted(wing_name, HOTKEY_LINE_WING, i, start);
+			int z = hotkey_line_add_sorted(wing_name, HOTKEY_LINE_WING, i, start);
 			if (Wings[i].flags[Ship::Wing_Flags::Expanded]) {
 				for (j=0; j<Wings[i].current_count; j++) {
-					s = Wings[i].ship_index[j];
+					int s = Wings[i].ship_index[j];
 					if (!Ships[s].is_dying_or_departing()) {
 						z = hotkey_line_insert(z + 1, Ships[s].get_display_name(), HOTKEY_LINE_SUBSHIP, s);
 					}
@@ -703,7 +690,9 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 		return y - 2;
 	}
 
-	for (i=start; i<Num_lines; i++) {
+	int font_height = gr_get_font_height();
+
+	for (int i=start; i<Num_lines; i++) {
 		if (Hotkey_lines[i].type == HOTKEY_LINE_SUBSHIP)
 			y += font_height;
 		else
@@ -723,11 +712,11 @@ void hotkey_set_selected_line(int line)
 
 void hotkey_build_listing()
 {
-	int y, enemy_team_mask;
+	int y;
 
 	Num_lines = y = 0;
 
-	enemy_team_mask = iff_get_attackee_mask(Player_ship->team);
+	int enemy_team_mask = iff_get_attackee_mask(Player_ship->team);
 
 	y = hotkey_build_team_listing(enemy_team_mask, y, false);
 	y = hotkey_build_team_listing(enemy_team_mask, y, true);
@@ -735,12 +724,10 @@ void hotkey_build_listing()
 
 int hotkey_line_query_visible(int n)
 {
-	int y;
-
 	if ((n < 0) || (n >= Num_lines))
 		return 0;
 	
-	y = Hotkey_lines[n].y - Hotkey_lines[Scroll_offset].y;
+	int y = Hotkey_lines[n].y - Hotkey_lines[Scroll_offset].y;
 	if ((y < 0) || (y + gr_get_font_height() > Hotkey_list_coords[gr_screen.res][3]))
 		return 0;
 
@@ -809,15 +796,13 @@ void hotkey_scroll_line_down()
 		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
-void expand_wing()
+void expand_wing(int line)
 {
-	int i, z;
-
-	if (Hotkey_lines[Selected_line].type == HOTKEY_LINE_WING) {
-		i = Hotkey_lines[Selected_line].index;
+	if (Hotkey_lines[line].type == HOTKEY_LINE_WING) {
+		int i = Hotkey_lines[line].index;
         Wings[i].flags.toggle(Ship::Wing_Flags::Expanded);
 		hotkey_build_listing();
-		for (z=0; z<Num_lines; z++)
+		for (int z=0; z<Num_lines; z++)
 			if ((Hotkey_lines[z].type == HOTKEY_LINE_WING) && (Hotkey_lines[z].index == i)) {
 				Selected_line = z;
 				break;
@@ -827,13 +812,12 @@ void expand_wing()
 
 void reset_hotkeys()
 {
-	int i;
 	htarget_list *hitem, *plist;
 
-	for (i=0; i<MAX_SHIPS; i++)
+	for (int i=0; i<MAX_SHIPS; i++)
 		Hotkey_bits[i] = 0;
 
-	for ( i=0; i<MAX_KEYED_TARGETS; i++ ) {
+	for (int i=0; i<MAX_KEYED_TARGETS; i++ ) {
 		plist = &(Players[Player_num].keyed_targets[i]);
 		if ( EMPTY(plist) ) // no items in list, then do nothing
 			continue;
@@ -845,29 +829,27 @@ void reset_hotkeys()
 	}
 }
 
-void clear_hotkeys()
+void clear_hotkeys(int line)
 {
-	int i, b, z;
+	int z = Hotkey_lines[line].type;
 
-	z = Hotkey_lines[Selected_line].type;
 	if (z == HOTKEY_LINE_WING) {
-		z = Hotkey_lines[Selected_line].index;
-		b = ~get_wing_hotkeys(z);
-		for (i=0; i<Wings[z].current_count; i++)
+		z = Hotkey_lines[line].index;
+		int b = ~get_wing_hotkeys(z);
+		for (int i=0; i<Wings[z].current_count; i++)
 			Hotkey_bits[Wings[z].ship_index[i]] &= b;
 
 	} else if ((z == HOTKEY_LINE_SHIP) || (z == HOTKEY_LINE_SUBSHIP)) {
-		Hotkey_bits[Hotkey_lines[Selected_line].index] = 0;
+		Hotkey_bits[Hotkey_lines[line].index] = 0;
 	}
 }
 
 void save_hotkeys()
 {
-	ship_obj *so;
-	int i;
-
-	for (i=0; i<MAX_KEYED_TARGETS; i++) {
+	for (int i=0; i<MAX_KEYED_TARGETS; i++) {
 		hud_target_hotkey_clear(i);
+		ship_obj* so;
+
 		for ( so = GET_FIRST(&Ship_obj_list); so != END_OF_LIST(&Ship_obj_list); so = GET_NEXT(so) ) {
 			if (Objects[so->objnum].flags[Object::Object_Flags::Should_be_dead])
 				continue;
@@ -878,33 +860,31 @@ void save_hotkeys()
 	}
 }
 
-void add_hotkey(int hotkey)
+void add_hotkey(int hotkey, int line)
 {
-	int i, z;
+	int z = Hotkey_lines[line].type;
 
-	z = Hotkey_lines[Selected_line].type;
 	if (z == HOTKEY_LINE_WING) {
-		z = Hotkey_lines[Selected_line].index;
-		for (i=0; i<Wings[z].current_count; i++)
+		z = Hotkey_lines[line].index;
+		for (int i=0; i<Wings[z].current_count; i++)
 			Hotkey_bits[Wings[z].ship_index[i]] |= (1 << hotkey);
 
 	} else if ((z == HOTKEY_LINE_SHIP) || (z == HOTKEY_LINE_SUBSHIP)) {
-		Hotkey_bits[Hotkey_lines[Selected_line].index] |= (1 << hotkey);
+		Hotkey_bits[Hotkey_lines[line].index] |= (1 << hotkey);
 	}
 }
 
-void remove_hotkey()
+void remove_hotkey(int hotkey, int line)
 {
-	int i, z;
+	int z = Hotkey_lines[line].type;
 
-	z = Hotkey_lines[Selected_line].type;
 	if (z == HOTKEY_LINE_WING) {
-		z = Hotkey_lines[Selected_line].index;
-		for (i=0; i<Wings[z].current_count; i++)
-			Hotkey_bits[Wings[z].ship_index[i]] &= ~(1 << Cur_hotkey);
+		z = Hotkey_lines[line].index;
+		for (int i=0; i<Wings[z].current_count; i++)
+			Hotkey_bits[Wings[z].ship_index[i]] &= ~(1 << hotkey);
 
 	} else if ((z == HOTKEY_LINE_SHIP) || (z == HOTKEY_LINE_SUBSHIP)) {
-		Hotkey_bits[Hotkey_lines[Selected_line].index] &= ~(1 << Cur_hotkey);
+		Hotkey_bits[Hotkey_lines[line].index] &= ~(1 << hotkey);
 	}
 }
 
@@ -920,12 +900,12 @@ void hotkey_button_pressed(int n)
 			break;
 
 		case ADD_HOTKEY_BUTTON:
-			add_hotkey(Cur_hotkey);
+			add_hotkey(Cur_hotkey, Selected_line);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case REMOVE_HOTKEY_BUTTON:
-			remove_hotkey();
+			remove_hotkey(Cur_hotkey, Selected_line);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
@@ -950,7 +930,7 @@ void hotkey_button_pressed(int n)
 			break;
 
 		case CLEAR_BUTTON:
-			clear_hotkeys();
+			clear_hotkeys(Selected_line);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
@@ -969,9 +949,6 @@ void hotkey_button_pressed(int n)
 //
 void mission_hotkey_init()
 {
-	int i;
-	hotkey_buttons *b;
-
 	// pause all weapon sounds
 	weapon_pause_sounds();
 
@@ -983,8 +960,8 @@ void mission_hotkey_init()
 	Ui_window.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);
 	Ui_window.set_mask_bmap(Hotkey_mask_fname[gr_screen.res]);
 
-	for (i=0; i<NUM_BUTTONS; i++) {
-		b = &Buttons[gr_screen.res][i];
+	for (int i=0; i<NUM_BUTTONS; i++) {
+		hotkey_buttons *b = &Buttons[gr_screen.res][i];
 
 		b->button.create(&Ui_window, "", b->x, b->y, 60, 30, i < 2 ? 1 : 0, 1);
 		// set up callback for when a mouse first goes over a button
@@ -994,11 +971,11 @@ void mission_hotkey_init()
 	}
 
 	// add all xstr text
-	for(i=0; i<HOTKEY_NUM_TEXT; i++) {
+	for(int i=0; i<HOTKEY_NUM_TEXT; i++) {
 		Ui_window.add_XSTR(&Hotkey_text[gr_screen.res][i]);
 	}
 
-	for (i=0; i<LIST_BUTTONS_MAX; i++) {
+	for (int i=0; i<LIST_BUTTONS_MAX; i++) {
 		List_buttons[i].create(&Ui_window, "", 0, 0, 60, 30, (i < 2), 1);
 		List_buttons[i].hide();
 		List_buttons[i].disable();
@@ -1060,18 +1037,13 @@ void mission_hotkey_close()
 //
 void mission_hotkey_do_frame(float  /*frametime*/)
 {
-	char buf[256];
-	int i, k, w, h, y, z, line, hotkeys;
-	int font_height = gr_get_font_height();
-	int select_tease_line = -1;  // line mouse is down on, but won't be selected until button released
-	color circle_color;
 
 	if ( help_overlay_active(Hotkey_overlay_id) ) {
 		Buttons[gr_screen.res][HELP_BUTTON].button.reset_status();
 		Ui_window.set_ignore_gadgets(1);
 	}
 
-	k = Ui_window.process() & ~KEY_DEBUGGED;
+	int k = Ui_window.process() & ~KEY_DEBUGGED;
 
 	if ( (k > 0) || B1_JUST_RELEASED ) {
 		if ( help_overlay_active(Hotkey_overlay_id) ) {
@@ -1114,17 +1086,17 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 		case KEY_TAB:
 		case KEY_ENTER:
 		case KEY_PADENTER:
-			expand_wing();
+			expand_wing(Selected_line);
 			break;
 
 		case KEY_EQUAL:
 		case KEY_PADPLUS:
-			add_hotkey(Cur_hotkey);
+			add_hotkey(Cur_hotkey, Selected_line);
 			break;
 
 		case KEY_MINUS:
 		case KEY_PADMINUS:
-			remove_hotkey();
+			remove_hotkey(Cur_hotkey, Selected_line);
 			break;
 
 		case KEY_F2:			
@@ -1136,28 +1108,33 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 			break;
 
 		case KEY_CTRLED | KEY_C:
-			clear_hotkeys();
+			clear_hotkeys(Selected_line);
 			break;
 	}	// end switch
 
-	// ?
-	for (i=0; i<MAX_KEYED_TARGETS; i++) {
+	// if the key that was pressed is one of the hotkeys
+	// then set that as the active hotkey.
+	// if the hotkey was shifted then add it to the current
+	// selected line.
+	for (int i=0; i<MAX_KEYED_TARGETS; i++) {
 		if (k == Key_sets[i])
 			Cur_hotkey = i;
 
 		if (k == (Key_sets[i] | KEY_SHIFTED))
-			add_hotkey(i);
+			add_hotkey(i, Selected_line);
 	}
 
 	// handle pressed buttons
-	for (i=0; i<NUM_BUTTONS; i++) {
+	for (int i=0; i<NUM_BUTTONS; i++) {
 		if (Buttons[gr_screen.res][i].button.pressed()) {
 			hotkey_button_pressed(i);
 			break;					// only need to handle 1 button @ a time
 		}
 	}
 
-	for (i=0; i<LIST_BUTTONS_MAX; i++) {
+	int select_tease_line = -1; // line mouse is down on, but won't be selected until button released
+
+	for (int i=0; i<LIST_BUTTONS_MAX; i++) {
 		// check for tease line
 		if (List_buttons[i].button_down()) {
 			select_tease_line = i + Scroll_offset;
@@ -1166,16 +1143,18 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 		// check for selected list item
 		if (List_buttons[i].pressed()) {
 			Selected_line = i + Scroll_offset;
-			List_buttons[i].get_mouse_pos(&z, NULL);
+
+			int z;
+			List_buttons[i].get_mouse_pos(&z, nullptr);
 			z += Hotkey_list_coords[gr_screen.res][0];		// adjust to full screen space
 			if ((z >= Hotkey_wing_icon_x[gr_screen.res]) && (z < (Hotkey_wing_icon_x[gr_screen.res]) + Hotkey_function_field_width[gr_screen.res])) {
-				expand_wing();
+				expand_wing(Selected_line);
 			}
 		}
 
 		if (List_buttons[i].double_clicked()) {
 			Selected_line = i + Scroll_offset;
-			hotkeys = -1;
+			int hotkeys = -1;
 			switch (Hotkey_lines[Selected_line].type) {
 				case HOTKEY_LINE_WING:
 					hotkeys = get_wing_hotkeys(Hotkey_lines[Selected_line].index);
@@ -1189,9 +1168,9 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 
 			if (hotkeys != -1) {
 				if (hotkeys & (1 << Cur_hotkey))
-					remove_hotkey();
+					remove_hotkey(Cur_hotkey, Selected_line);
 				else
-					add_hotkey(Cur_hotkey);
+					add_hotkey(Cur_hotkey, Selected_line);
 			}
 		}
 	}
@@ -1205,36 +1184,44 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 		gr_clear();
 
 	Ui_window.draw();
+	color circle_color;
 	gr_init_color(&circle_color, 160, 160, 0);
 
 	// draw the big "F10" in the little box	
 	font::set_font(font::FONT2);
 	gr_set_color_fast(&Color_text_normal);
+
+	char buf[256];
 	strcpy_s(buf, textify_scancode(Key_sets[Cur_hotkey]));
+
+	int w, h;
 	gr_get_string_size(&w, &h, buf);
 	gr_printf_menu(Hotkey_function_name_coords[gr_screen.res][0] + (Hotkey_function_name_coords[gr_screen.res][2] - w) / 2, Hotkey_function_name_coords[gr_screen.res][1], "%s", buf);
 
 	font::set_font(font::FONT1);
-	line = Scroll_offset;
+	int line = Scroll_offset;
 	while (hotkey_line_query_visible(line)) {
-		z = Hotkey_lines[line].index;
-		y = Hotkey_list_coords[gr_screen.res][1] + Hotkey_lines[line].y - Hotkey_lines[Scroll_offset].y;
-		hotkeys = 0;
+		//int z = Hotkey_lines[line].index;
+		int y = Hotkey_list_coords[gr_screen.res][1] + Hotkey_lines[line].y - Hotkey_lines[Scroll_offset].y;
+		int hotkeys = 0;
+		int font_height = gr_get_font_height();
+		int width = 0;
+
 		switch (Hotkey_lines[line].type) {
 			case HOTKEY_LINE_HEADING:
 				gr_set_color_fast(&Color_text_heading);
 
 				gr_get_string_size(&w, &h, Hotkey_lines[line].label.c_str());
-				i = y + h / 2 - 1;
-				gr_line(Hotkey_list_coords[gr_screen.res][0], i, Hotkey_ship_x[gr_screen.res] - 2, i, GR_RESIZE_MENU);
-				gr_line(Hotkey_ship_x[gr_screen.res] + w + 1, i, Hotkey_list_coords[gr_screen.res][0] + Hotkey_list_coords[gr_screen.res][2], i, GR_RESIZE_MENU);
+				width = y + h / 2 - 1;
+				gr_line(Hotkey_list_coords[gr_screen.res][0], width, Hotkey_ship_x[gr_screen.res] - 2, width, GR_RESIZE_MENU);
+				gr_line(Hotkey_ship_x[gr_screen.res] + w + 1, width, Hotkey_list_coords[gr_screen.res][0] + Hotkey_list_coords[gr_screen.res][2], width, GR_RESIZE_MENU);
 				break;
 
 			case HOTKEY_LINE_WING:
 				gr_set_bitmap(Wing_bmp);
-				bm_get_info(Wing_bmp, NULL, &h, NULL);
-				i = y + font_height / 2 - h / 2 - 1;
-				gr_bitmap(Hotkey_wing_icon_x[gr_screen.res], i, GR_RESIZE_MENU);
+				bm_get_info(Wing_bmp, nullptr, &h, nullptr);
+				width = y + font_height / 2 - h / 2 - 1;
+				gr_bitmap(Hotkey_wing_icon_x[gr_screen.res], width, GR_RESIZE_MENU);
 
 //				i = y + font_height / 2 - 1;
 //				gr_set_color_fast(&circle_color);
@@ -1281,7 +1268,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 
 		// print active hotkeys associated for this line
 		if (hotkeys) {
-			for (i=0; i<MAX_KEYED_TARGETS; i++) {
+			for (int i=0; i<MAX_KEYED_TARGETS; i++) {
 				if (hotkeys & (1 << i)) {
 					gr_printf_menu(Hotkey_list_coords[gr_screen.res][0] + Hotkey_function_field_width[gr_screen.res]*i, y, "%s", textify_scancode(Key_sets[i]));
 				}
@@ -1316,7 +1303,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 		line++;
 	}
 
-	i = line - Scroll_offset;
+	int i = line - Scroll_offset;
 	while (i < LIST_BUTTONS_MAX)
 		List_buttons[i++].disable();
 

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -33,7 +33,7 @@
 #include "weapon/weapon.h"
 
 
-int Key_sets[MAX_KEYED_TARGETS] = {
+static int Key_sets[MAX_KEYED_TARGETS] = {
 	KEY_F5,
 	KEY_F6,
 	KEY_F7,
@@ -305,9 +305,10 @@ void mission_hotkey_maybe_restore()
 // mission_hotkey_set_defaults()
 //
 // Set up the hotkey lists for the player based on the mission designer
-// defaults.  
+// defaults. 
+// Set restore to false to explicitely ignore player saved values. 
 //
-void mission_hotkey_set_defaults()
+void mission_hotkey_set_defaults(bool restore)
 {
 
 	for (int i = 0; i < MAX_KEYED_TARGETS; i++ ) {
@@ -321,7 +322,7 @@ void mission_hotkey_set_defaults()
 	// if we have hotkeys saved from the previous run of this mission, then simply keep the cleared
 	// sets, and let the restore code take care of it!  This works because this function is currently
 	// only called from one place -- after the mission loads.
-	if ( Num_hotkeys_saved > 0 ) {
+	if ( restore && (Num_hotkeys_saved > 0) ) {
 		mission_hotkey_maybe_restore();
 		return;
 	}

--- a/code/mission/missionhotkey.h
+++ b/code/mission/missionhotkey.h
@@ -13,8 +13,6 @@
 #define __MISSIONHOTKEY_H__
 
 #include "globalincs/globals.h"
-#include "io/key.h"
-#include "playerman/player.h"
 
 #define MAX_LINES MAX_SHIPS // retail was 200, bump it to match MAX_SHIPS
 

--- a/code/mission/missionhotkey.h
+++ b/code/mission/missionhotkey.h
@@ -12,6 +12,25 @@
 #ifndef __MISSIONHOTKEY_H__
 #define __MISSIONHOTKEY_H__
 
+#include "globalincs/globals.h"
+
+#define MAX_LINES MAX_SHIPS // retail was 200, bump it to match MAX_SHIPS
+
+// Types of items that can be in the hotkey list
+#define HOTKEY_LINE_HEADING 1
+#define HOTKEY_LINE_WING 2
+#define HOTKEY_LINE_SHIP 3
+#define HOTKEY_LINE_SUBSHIP 4 // ship that is in a wing
+
+struct hotkey_line {
+	SCP_string label;
+	int type; // type 0 is an unused line
+	int index;
+	int y; // Y coordinate of line
+};
+
+extern hotkey_line Hotkey_lines[MAX_LINES];
+
 void mission_hotkey_init();
 void mission_hotkey_close();
 void mission_hotkey_do_frame(float frametime);
@@ -22,6 +41,22 @@ void mission_hotkey_reset_saved();
 void mission_hotkey_mf_add( int set, int objnum, int how_to_add );
 
 void mission_hotkey_exit();
+
+// function to build the hotkey listing
+void hotkey_build_listing();
+
+// function to set the selected hotkey line
+void hotkey_set_selected_line(int line);
+
+// function to expand a wing in the hotkey list
+// uses the Selected_line var, so set that first
+void expand_wing();
+
+// function to return the hotkeys for a wing
+extern int get_wing_hotkeys(int n);
+
+// function to return the hotkeys for a ship
+extern int get_ship_hotkeys(int n);
 
 // function to return the hotkey set number of the given key
 extern int mission_hotkey_get_set_num( int k );

--- a/code/mission/missionhotkey.h
+++ b/code/mission/missionhotkey.h
@@ -24,8 +24,6 @@
 #define HOTKEY_LINE_SHIP 3
 #define HOTKEY_LINE_SUBSHIP 4 // ship that is in a wing
 
-extern int Key_sets[MAX_KEYED_TARGETS];
-
 struct hotkey_line {
 	SCP_string label;
 	int type; // type 0 is an unused line
@@ -38,7 +36,7 @@ extern hotkey_line Hotkey_lines[MAX_LINES];
 void mission_hotkey_init();
 void mission_hotkey_close();
 void mission_hotkey_do_frame(float frametime);
-void mission_hotkey_set_defaults();
+void mission_hotkey_set_defaults(bool restore = true);
 void mission_hotkey_validate();
 void mission_hotkey_maybe_save_sets();
 void mission_hotkey_reset_saved();
@@ -70,7 +68,8 @@ void remove_hotkey(int hotkey, int line);
 // function to clear all hotkeys from a hotkey line
 void clear_hotkeys(int line);
 
-// function to reset the mission hotkeys
+// function to reset the mission hotkeys for this specific session in the ui
+// does not reset to mission defaults!
 void reset_hotkeys();
 
 // function to save hotkey changes

--- a/code/mission/missionhotkey.h
+++ b/code/mission/missionhotkey.h
@@ -13,6 +13,8 @@
 #define __MISSIONHOTKEY_H__
 
 #include "globalincs/globals.h"
+#include "io/key.h"
+#include "playerman/player.h"
 
 #define MAX_LINES MAX_SHIPS // retail was 200, bump it to match MAX_SHIPS
 
@@ -21,6 +23,8 @@
 #define HOTKEY_LINE_WING 2
 #define HOTKEY_LINE_SHIP 3
 #define HOTKEY_LINE_SUBSHIP 4 // ship that is in a wing
+
+extern int Key_sets[MAX_KEYED_TARGETS];
 
 struct hotkey_line {
 	SCP_string label;
@@ -48,15 +52,29 @@ void hotkey_build_listing();
 // function to set the selected hotkey line
 void hotkey_set_selected_line(int line);
 
-// function to expand a wing in the hotkey list
-// uses the Selected_line var, so set that first
-void expand_wing();
+// function to expand a wing in the hotkey list and sets Selected_line to the first ship in the wing
+void expand_wing(int line);
 
 // function to return the hotkeys for a wing
 extern int get_wing_hotkeys(int n);
 
 // function to return the hotkeys for a ship
 extern int get_ship_hotkeys(int n);
+
+// function to add a hotkey to a hotkey line
+void add_hotkey(int hotkey, int line);
+
+// function to remove a hotkey from a hotkey line
+void remove_hotkey(int hotkey, int line);
+
+// function to clear all hotkeys from a hotkey line
+void clear_hotkeys(int line);
+
+// function to reset the mission hotkeys
+void reset_hotkeys();
+
+// function to save hotkey changes
+void save_hotkeys();
 
 // function to return the hotkey set number of the given key
 extern int mission_hotkey_get_set_num( int k );

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1677,7 +1677,7 @@ ADE_VIRTVAR(Complete, l_UserInterface_Credits, nullptr, "The complete credits st
 
 //**********SUBLIBRARY: UserInterface/Hotkeys
 ADE_LIB_DERIV(l_UserInterface_Hotkeys,
-	"GameHelp",
+	"MissionHotkeys",
 	nullptr,
 	"API for accessing data related to the mission hotkeys UI.<br><b>Warning:</b> This is an internal "
 	"API for the new UI system. This should not be used by other code and may be removed in the future!",

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1692,16 +1692,16 @@ ADE_FUNC(initHotkeysList,
 {
 	SCP_UNUSED(L);
 
+	reset_hotkeys();
 	hotkey_set_selected_line(1);
 	hotkey_build_listing();
 
 	// We want to allow the API to handle expanding wings on its own,
 	// so lets expand every wing in the list and not try to handle it after that.
-	for (int i = 0; i <= MAX_LINES; i++) {
+	for (int i = 0; i < MAX_LINES; i++) {
 		auto item = Hotkey_lines[i];
 		if (item.type == HOTKEY_LINE_WING) {
-			hotkey_set_selected_line(i);
-			expand_wing();
+			expand_wing(i);
 		}
 	}
 
@@ -1711,19 +1711,33 @@ ADE_FUNC(initHotkeysList,
 	return ADE_RETURN_NIL;
 }
 
-/*ADE_FUNC(closeHotkeysList,
+ADE_FUNC(resetHotkeys,
 	l_UserInterface_Hotkeys,
 	nullptr,
-	"Clears the hotkeys list. Should be used when finished accessing hotkeys.",
+	"Resets the hotkeys list to mission defaults. Returns nothing.",
 	nullptr,
 	nullptr)
 {
 	SCP_UNUSED(L);
 
-	Help_text.clear();
+	reset_hotkeys();
 
 	return ADE_RETURN_NIL;
-}*/
+}
+
+ADE_FUNC(saveHotkeys,
+	l_UserInterface_Hotkeys,
+	nullptr,
+	"Saves changes to the hotkey list. Returns nothing.",
+	nullptr,
+	nullptr)
+{
+	SCP_UNUSED(L);
+
+	save_hotkeys();
+
+	return ADE_RETURN_NIL;
+}
 
 ADE_LIB_DERIV(l_Hotkeys, "Hotkeys_List", nullptr, nullptr, l_UserInterface_Hotkeys);
 ADE_INDEXER(l_Hotkeys,
@@ -1747,7 +1761,7 @@ ADE_FUNC(__len, l_Hotkeys, nullptr, "The number of valid hotkey ships", "number"
 {
 	int s = 0;
 
-	for (int i = 0; i <= MAX_LINES; i++) {
+	for (int i = 0; i < MAX_LINES; i++) {
 		auto item = Hotkey_lines[i];
 		if (item.type == 0) {
 			s = i - 1;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1714,7 +1714,7 @@ ADE_FUNC(initHotkeysList,
 ADE_FUNC(resetHotkeys,
 	l_UserInterface_Hotkeys,
 	nullptr,
-	"Resets the hotkeys list to mission defaults. Returns nothing.",
+	"Resets the hotkeys list to previous setting, removing anything that wasn't saved. Returns nothing.",
 	nullptr,
 	nullptr)
 {
@@ -1735,6 +1735,24 @@ ADE_FUNC(saveHotkeys,
 	SCP_UNUSED(L);
 
 	save_hotkeys();
+
+	return ADE_RETURN_NIL;
+}
+
+// This is not a retail UI feature, but it's just good design to allow it.
+// This will allow SCPUI to create a restore to mission defaults button.
+ADE_FUNC(resetHotkeysDefault,
+	l_UserInterface_Hotkeys,
+	nullptr,
+	"Resets the hotkeys list to the default mission setting. Returns nothing.",
+	nullptr,
+	nullptr)
+{
+	SCP_UNUSED(L);
+
+	// argument to false, because if we're doing this we explicitely do not want
+	// to restore player's saved values
+	mission_hotkey_set_defaults(false);
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1761,10 +1761,11 @@ ADE_FUNC(__len, l_Hotkeys, nullptr, "The number of valid hotkey ships", "number"
 {
 	int s = 0;
 
+	// this is dumb, but whatever
 	for (int i = 0; i < MAX_LINES; i++) {
 		auto item = Hotkey_lines[i];
 		if (item.type == 0) {
-			s = i - 1;
+			s = i;
 			break;
 		}
 	}

--- a/code/scripting/api/objs/missionhotkey.cpp
+++ b/code/scripting/api/objs/missionhotkey.cpp
@@ -69,9 +69,9 @@ ADE_VIRTVAR(Keys,
 	int hotkeys;
 
 	if (current.getLine()->type == HOTKEY_LINE_WING)
-		hotkeys = get_wing_hotkeys(Hotkey_lines[current.getIndex()].index); // for wings
+		hotkeys = get_wing_hotkeys(current.getLine()->index); // for wings
 	else
-		hotkeys = get_ship_hotkeys(Hotkey_lines[current.getIndex()].index); // for everything else (there's mastercard)
+		hotkeys = get_ship_hotkeys(current.getLine()->index); // for everything else (there's mastercard)
 
 	auto table = luacpp::LuaTable::create(L);
 

--- a/code/scripting/api/objs/missionhotkey.cpp
+++ b/code/scripting/api/objs/missionhotkey.cpp
@@ -1,6 +1,7 @@
 #include "missionhotkey.h"
 
 #include "mission/missionhotkey.h"
+#include "playerman/player.h"
 
 namespace scripting {
 namespace api {

--- a/code/scripting/api/objs/missionhotkey.cpp
+++ b/code/scripting/api/objs/missionhotkey.cpp
@@ -1,0 +1,91 @@
+#include "missionhotkey.h"
+
+#include "mission/missionhotkey.h"
+#include "player.h"
+
+namespace scripting {
+namespace api {
+
+hotkey_h::hotkey_h() : line(-1) {}
+hotkey_h::hotkey_h(int l_line) : line(l_line) {}
+
+hotkey_line* hotkey_h::getLine() const
+{
+	return &Hotkey_lines[line];
+}
+
+int hotkey_h::getIndex() const
+{
+	return line;
+}
+
+//**********HANDLE: help section
+ADE_OBJ(l_Hotkey, hotkey_h, "hotkey_ship", "Help Section handle");
+
+ADE_VIRTVAR(Text, l_Hotkey, nullptr, "The text of this hotkey line", "string", "The text")
+{
+	hotkey_h current;
+	if (!ade_get_args(L, "o", l_Hotkey.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current.getLine()->label);
+}
+
+ADE_VIRTVAR(Type,
+	l_Hotkey,
+	nullptr,
+	"The type of this hotkey line. 0 for nothing, 1 for heading, 2 for wing, 3 for ship, 4 for ship in a wing",
+	"number",
+	"The type")
+{
+	hotkey_h current;
+	if (!ade_get_args(L, "o", l_Hotkey.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "i", current.getLine()->type);
+}
+
+ADE_VIRTVAR(Keys,
+	l_Hotkey,
+	nullptr,
+	"Gets a table of hotkeys set to the ship in the order from F5 - F12",
+	"{ number => boolean ... }",
+	"The hotkeys table")
+{
+	hotkey_h current;
+	if (!ade_get_args(L, "o", l_Hotkey.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	int hotkeys;
+
+	if (current.getLine()->type == HOTKEY_LINE_WING)
+		hotkeys = get_wing_hotkeys(Hotkey_lines[current.getIndex()].index); // for wings
+	else
+		hotkeys = get_ship_hotkeys(Hotkey_lines[current.getIndex()].index); // for everything else (there's mastercard)
+
+	auto table = luacpp::LuaTable::create(L);
+
+	for (int i = 0; i < MAX_KEYED_TARGETS; i++) {
+		bool key_active = false;
+		if (hotkeys & (1 << i)) {
+			key_active = true;
+		}
+		table.addValue(i + 1, key_active); // translate to Lua index
+	}
+
+	return ade_set_args(L, "t", &table);
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/objs/missionhotkey.cpp
+++ b/code/scripting/api/objs/missionhotkey.cpp
@@ -1,7 +1,6 @@
 #include "missionhotkey.h"
 
 #include "mission/missionhotkey.h"
-#include "player.h"
 
 namespace scripting {
 namespace api {
@@ -85,6 +84,71 @@ ADE_VIRTVAR(Keys,
 	}
 
 	return ade_set_args(L, "t", &table);
+}
+
+ADE_FUNC(addHotkey,
+	l_Hotkey,
+	"number Key",
+	"Adds a hotkey to the to the ship in the list. 1-8 correspond to F5-F12. Returns nothing.",
+	nullptr,
+	nullptr)
+{
+	SCP_UNUSED(L);
+
+	hotkey_h current;
+	int key;
+	if (!ade_get_args(L, "oi", l_Hotkey.Get(&current), &key)) {
+		return ADE_RETURN_NIL;
+	}
+	key--;
+
+	int hotkey = Key_sets[key];
+
+	add_hotkey(current.getIndex(), hotkey);
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(removeHotkey,
+	l_Hotkey,
+	"number Key",
+	"Removes a hotkey from the ship in the list. 1-8 correspond to F5-F12. Returns nothing.",
+	nullptr,
+	nullptr)
+{
+	SCP_UNUSED(L);
+
+	hotkey_h current;
+	int key;
+	if (!ade_get_args(L, "oi", l_Hotkey.Get(&current), &key)) {
+		return ADE_RETURN_NIL;
+	}
+	key--;
+
+	int hotkey = Key_sets[key];
+
+	remove_hotkey(current.getIndex(), hotkey);
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(clearHotkeys,
+	l_Hotkey,
+	nullptr,
+	"Clears all hotkeys from the ship in the list. Returns nothing.",
+	nullptr,
+	nullptr)
+{
+	SCP_UNUSED(L);
+
+	hotkey_h current;
+	if (!ade_get_args(L, "o", l_Hotkey.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	clear_hotkeys(current.getIndex());
+
+	return ADE_RETURN_NIL;
 }
 
 } // namespace api

--- a/code/scripting/api/objs/missionhotkey.cpp
+++ b/code/scripting/api/objs/missionhotkey.cpp
@@ -69,9 +69,9 @@ ADE_VIRTVAR(Keys,
 	int hotkeys;
 
 	if (current.getLine()->type == HOTKEY_LINE_WING)
-		hotkeys = get_wing_hotkeys(current.getLine()->index); // for wings
+		hotkeys = get_wing_hotkeys(current.getIndex()); // for wings
 	else
-		hotkeys = get_ship_hotkeys(current.getLine()->index); // for everything else (there's mastercard)
+		hotkeys = get_ship_hotkeys(current.getIndex()); // for everything else (there's mastercard)
 
 	auto table = luacpp::LuaTable::create(L);
 
@@ -104,7 +104,7 @@ ADE_FUNC(addHotkey,
 
 	int hotkey = Key_sets[key];
 
-	add_hotkey(current.getIndex(), hotkey);
+	add_hotkey(hotkey, current.getIndex());
 
 	return ADE_RETURN_NIL;
 }
@@ -127,7 +127,7 @@ ADE_FUNC(removeHotkey,
 
 	int hotkey = Key_sets[key];
 
-	remove_hotkey(current.getIndex(), hotkey);
+	remove_hotkey(hotkey, current.getIndex());
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/objs/missionhotkey.cpp
+++ b/code/scripting/api/objs/missionhotkey.cpp
@@ -102,9 +102,7 @@ ADE_FUNC(addHotkey,
 	}
 	key--;
 
-	int hotkey = Key_sets[key];
-
-	add_hotkey(hotkey, current.getIndex());
+	add_hotkey(key, current.getIndex());
 
 	return ADE_RETURN_NIL;
 }
@@ -125,9 +123,7 @@ ADE_FUNC(removeHotkey,
 	}
 	key--;
 
-	int hotkey = Key_sets[key];
-
-	remove_hotkey(hotkey, current.getIndex());
+	remove_hotkey(key, current.getIndex());
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/objs/missionhotkey.h
+++ b/code/scripting/api/objs/missionhotkey.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "mission/missionhotkey.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+struct hotkey_h {
+	int line;
+	hotkey_h();
+	explicit hotkey_h(int l_line);
+	hotkey_line* getLine() const;
+	int getIndex() const;
+};
+
+DECLARE_ADE_OBJ(l_Hotkey, hotkey_h);
+
+} // namespace api
+} // namespace scripting

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1362,6 +1362,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/mc_info.h
 	scripting/api/objs/message.cpp
 	scripting/api/objs/message.h
+	scripting/api/objs/missionhotkey.cpp
+	scripting/api/objs/missionhotkey.h
 	scripting/api/objs/model.cpp
 	scripting/api/objs/model.h
 	scripting/api/objs/modelinstance.cpp


### PR DESCRIPTION
API methods for recreating the hotkeys UI. I hate everything about how this UI is both designed to be used and how the code works to run it. But redoing all that was outside the scope of what I'm here for. However, the result of this work does change some bits to undo some of the spaghetti.

This ended up being a little larger than expected, but I was touching enough of missionhotkeys.cpp that I figured I'd tidy up a little bit. Mostly that means NULL -> nullptr and correctly scoping variables.

Tests in the retail UI seem to show no change in functionality, though I admittedly have seldom used this screen in 20 years so I'm not super familiar with it.

Tests of the API were able to successfully get accurate data and correctly set/clear additional hotkeys for ships and have those changes work in the mission space.