### PR TITLE
Fix a bug in mission log with subsys names

### DIFF
--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -795,9 +795,14 @@ void message_log_init_scrollback(int pw)
 				break;
 
 			case LOG_SHIP_SUBSYS_DESTROYED: {
+				ship_info* sip = &Ship_info[(int)((entry->index >> 16) & 0xffff)];
 				int model_index = (int)(entry->index & 0xffff);
-				int idx = ship_name_lookup(entry->pname, 1);
-				const char* subsys_name = ship_subsys_get_name(ship_get_indexed_subsys(&Ships[idx], model_index));
+				const char* subsys_name;
+				if (strlen(sip->subsystems[model_index].alt_sub_name)) {
+					subsys_name = sip->subsystems[model_index].alt_sub_name;
+				} else {
+					subsys_name = sip->subsystems[model_index].name;
+				}
 
 				message_log_add_segs(XSTR("Subsystem ", 410), LOG_COLOR_NORMAL, 0, &thisEntry.actions);
 				message_log_add_segs(subsys_name, LOG_COLOR_BRIGHT, 0, &thisEntry.actions);


### PR DESCRIPTION
The more specific `sub_name` (which `ship_subsys_get_name` retrieves) is copied from `alt_sub_name`, so this should be equivalent, and doesn't rely on the ship still being around.