### PR TITLE
synchronize simulation timestamps across the entire frame

### DIFF
--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -89,6 +89,7 @@ public:
 
 extern void timer_init();
 extern void timer_close();
+extern void timer_start_frame();
 
 //==========================================================================
 // These functions return the time since the timer was initialized in

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4266,6 +4266,9 @@ void game_set_frametime(int state)
 	float frame_cap_diff;
 	bool do_pre_player_skip = false;
 
+	// sync all timestamps across the entire frame
+	timer_start_frame();
+
 	thistime = timer_get_fixed_seconds();
 
 	if ( Last_time == 0 )	


### PR DESCRIPTION
Prior to the timer upgrade, all simulation timestamps shared identical timer and timestamp values for the duration of the frame, since they were only updated within the `game_set_frametime` function.  Since the timer upgrade depends on the system clock, timestamps evaluated near the end of the frame will be very slightly later than timestamps evaluated near the beginning of the frame.  It is desirable to keep them all in sync.

This PR tweaks the timestamp system to take a snapshot at the beginning of the frame, then use that snapshot for the entire duration of the frame.  This only affects simulation timestamps; real-time timestamps still use the live timer.