### PR TITLE
fix an edge case in is-event-true-delay and related sexps

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -482,6 +482,28 @@ bool ui_timestamp_elapsed(UI_TIMESTAMP ui_stamp) {
 	return timer_get_milliseconds() >= ui_stamp.value();
 }
 
+bool timestamp_elapsed_last_frame(TIMESTAMP stamp) {
+	if (!stamp.isValid() || stamp.isNever()) {
+		return false;
+	}
+	if (stamp.isImmediate()) {
+		return true;
+	}
+
+	return timestamp_ms() > stamp.value();
+}
+
+bool ui_timestamp_elapsed_last_frame(UI_TIMESTAMP ui_stamp) {
+	if (!ui_stamp.isValid() || ui_stamp.isNever()) {
+		return false;
+	}
+	if (ui_stamp.isImmediate()) {
+		return true;
+	}
+
+	return timer_get_milliseconds() > ui_stamp.value();
+}
+
 bool timestamp_elapsed_safe(int a, int b) {
 	if (a == 0) {
 		return true;

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -203,7 +203,9 @@ bool ui_timestamp_in_between(UI_TIMESTAMP stamp, UI_TIMESTAMP before, UI_TIMESTA
 
 bool timestamp_elapsed( int stamp );
 bool timestamp_elapsed( TIMESTAMP stamp );
+bool timestamp_elapsed_last_frame( TIMESTAMP stamp );
 bool ui_timestamp_elapsed( UI_TIMESTAMP stamp );
+bool ui_timestamp_elapsed_last_frame( UI_TIMESTAMP stamp );
 
 // safer version of timestamp
 bool timestamp_elapsed_safe(int a, int b);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17471,7 +17471,7 @@ int sexp_event_delay_status( int n, int want_true, bool use_msecs = false)
 			if (!Fixed_chaining_to_repeat && Mission_events[i].flags & MEF_TIMESTAMP_HAS_INTERVAL) {
 				/* do not set rval */;
 			}
-			else if (!timestamp_elapsed(timestamp_delta(Mission_events[i].timestamp, delay))) {
+			else if (!timestamp_elapsed_last_frame(timestamp_delta(Mission_events[i].timestamp, delay))) {
 				rval = SEXP_FALSE;
 				break;
 			}


### PR DESCRIPTION
Originally the check for event delay was this:
```
if ( (fix) Mission_events[i].timestamp + delay >= Missiontime )
    return SEXP_FALSE;
```
This returns false even when the mission time is equal to the timestamp.  Therefore the timestamp check needs to use >, not >=.

Thanks to Durandal and ShivanSpS for helping to track this down.