### PR TITLE
Add some parameters for corkscrew starting angle

### DIFF
--- a/code/weapon/corkscrew.cpp
+++ b/code/weapon/corkscrew.cpp
@@ -145,6 +145,13 @@ int cscrew_create(object *obj)
 	// get the "center" pointing vector
 	vec3d neg;
 	neg = obj->orient.vec.uvec;
+
+	if (wip->cs_random_angle) {
+		vm_rot_point_around_line(&neg, &neg, frand_range(0.0f, PI2), &vmd_zero_vector, &obj->orient.vec.fvec);
+	} else {
+		vm_rot_point_around_line(&neg, &neg, wip->cs_angle, &vmd_zero_vector, &obj->orient.vec.fvec);
+	}
+
 	if(Corkscrew_down_first){
 		vm_vec_negate(&neg);
 	}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -524,8 +524,10 @@ struct weapon_info
 	int cs_num_fired;
 	float cs_radius;
 	float cs_twist;
-	int cs_crotate;
+	bool cs_crotate;
 	int cs_delay;
+	bool cs_random_angle;
+	float cs_angle;
 
 	//electronics info - phreak 5/3/03
 	int elec_time;				//how long it lasts, in milliseconds

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2320,6 +2320,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		if(optional_string("+Twist:")) {
 			stuff_float(&wip->cs_twist);
 		}
+
+		if (optional_string("+Random Start Angle:")) {
+			stuff_boolean(&wip->cs_random_angle);
+		}
+
+		if (optional_string("+Start Angle:")) {
+			stuff_float(&wip->cs_angle);
+		}
 	}
 
 	//electronics tag optional stuff
@@ -9081,8 +9089,10 @@ void weapon_info::reset()
 	this->cs_num_fired = 4;
 	this->cs_radius = 1.25f;
 	this->cs_delay = 30;
-	this->cs_crotate = 1;
+	this->cs_crotate = true;
 	this->cs_twist = 5.0f;
+	this->cs_random_angle = false;
+	this->cs_angle = 0.0f;
 
 	this->elec_time = 8000;
 	this->elec_eng_mult = 1.0f;


### PR DESCRIPTION
Closes #5272. Adds the ability to set the angle on the corkscrew the weapons starts on. Either random, or a specific angle, for now.