### PR TITLE
Force expand wings instead of toggle for scpui

### DIFF
--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -799,11 +799,15 @@ void hotkey_scroll_line_down()
 		gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 }
 
-void expand_wing(int line)
+void expand_wing(int line, bool forceExpand)
 {
 	if (Hotkey_lines[line].type == HOTKEY_LINE_WING) {
 		int i = Hotkey_lines[line].index;
-        Wings[i].flags.toggle(Ship::Wing_Flags::Expanded);
+		if (forceExpand) {
+			Wings[i].flags.set(Ship::Wing_Flags::Expanded);
+		} else {
+			Wings[i].flags.toggle(Ship::Wing_Flags::Expanded);
+		}
 		hotkey_build_listing();
 		for (int z=0; z<Num_lines; z++)
 			if ((Hotkey_lines[z].type == HOTKEY_LINE_WING) && (Hotkey_lines[z].index == i)) {

--- a/code/mission/missionhotkey.h
+++ b/code/mission/missionhotkey.h
@@ -49,7 +49,7 @@ void hotkey_build_listing();
 void hotkey_set_selected_line(int line);
 
 // function to expand a wing in the hotkey list and sets Selected_line to the first ship in the wing
-void expand_wing(int line);
+void expand_wing(int line, bool forceExpand = false);
 
 // function to return the hotkeys for a wing
 extern int get_wing_hotkeys(int n);

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1755,7 +1755,7 @@ ADE_FUNC(initHotkeysList,
 	for (int i = 0; i < MAX_LINES; i++) {
 		auto item = Hotkey_lines[i];
 		if (item.type == HOTKEY_LINE_WING) {
-			expand_wing(i);
+			expand_wing(i, true);
 		}
 	}
 


### PR DESCRIPTION
Toggle caused the list to load different each time it was called. This enforces the same behavior every time.