### PR TITLE
Revert "synchronize simulation timestamps across the entire frame"

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -41,9 +41,6 @@ static bool Timestamp_sudo_paused = false;
 static uint64_t Timestamp_microseconds_at_mission_start = 0;
 
 
-static uint64_t timestamp_get_raw(bool start_frame = false);
-
-
 static uint64_t get_performance_counter()
 {
 	Assertion(Timer_inited, "This function can only be used when the timer system is initialized!");
@@ -76,12 +73,6 @@ void timer_init()
 
 		atexit(timer_close);
 	}
-}
-
-void timer_start_frame()
-{
-	// take a snapshot of the raw timestamp at the beginning of the frame
-	timestamp_get_raw(true);
 }
 
 // ======================================== getting time ========================================
@@ -138,21 +129,15 @@ std::uint64_t timer_get_nanoseconds()
     return static_cast<uint64_t>(time * Timer_to_nanoseconds);
 }
 
-static uint64_t timestamp_get_raw(bool start_frame)
+static uint64_t timestamp_get_raw()
 {
-	static uint64_t timestamp_raw = 0;
-
-	// The simulation timestamp is only updated at the beginning of the frame
-	// because we want all timestamps within a frame to be identical.
-	if (start_frame)
-	{
-		if (Timestamp_is_paused)
-			timestamp_raw = Timestamp_paused_at_counter;
-		else
-			timestamp_raw = get_performance_counter();
-
-		timestamp_raw -= Timestamp_offset_from_counter;
+	uint64_t timestamp_raw;
+	if (Timestamp_is_paused) {
+		timestamp_raw = Timestamp_paused_at_counter;
+	} else {
+		timestamp_raw = get_performance_counter();
 	}
+	timestamp_raw -= Timestamp_offset_from_counter;
 
 	return timestamp_raw;
 }

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -41,6 +41,9 @@ static bool Timestamp_sudo_paused = false;
 static uint64_t Timestamp_microseconds_at_mission_start = 0;
 
 
+static uint64_t timestamp_get_raw(bool start_frame = false);
+
+
 static uint64_t get_performance_counter()
 {
 	Assertion(Timer_inited, "This function can only be used when the timer system is initialized!");
@@ -73,6 +76,12 @@ void timer_init()
 
 		atexit(timer_close);
 	}
+}
+
+void timer_start_frame()
+{
+	// take a snapshot of the raw timestamp at the beginning of the frame
+	timestamp_get_raw(true);
 }
 
 // ======================================== getting time ========================================
@@ -129,15 +138,21 @@ std::uint64_t timer_get_nanoseconds()
     return static_cast<uint64_t>(time * Timer_to_nanoseconds);
 }
 
-static uint64_t timestamp_get_raw()
+static uint64_t timestamp_get_raw(bool start_frame)
 {
-	uint64_t timestamp_raw;
-	if (Timestamp_is_paused) {
-		timestamp_raw = Timestamp_paused_at_counter;
-	} else {
-		timestamp_raw = get_performance_counter();
+	static uint64_t timestamp_raw = 0;
+
+	// The simulation timestamp is only updated at the beginning of the frame
+	// because we want all timestamps within a frame to be identical.
+	if (start_frame)
+	{
+		if (Timestamp_is_paused)
+			timestamp_raw = Timestamp_paused_at_counter;
+		else
+			timestamp_raw = get_performance_counter();
+
+		timestamp_raw -= Timestamp_offset_from_counter;
 	}
-	timestamp_raw -= Timestamp_offset_from_counter;
 
 	return timestamp_raw;
 }
@@ -619,7 +634,7 @@ void timestamp_update_time_compression()
 	}
 
 	// grab the independent variable of the equation before we change anything
-	auto timestamp_raw = timestamp_get_raw();
+	auto timestamp_raw = timestamp_get_raw(true);
 
 	// we need to move the counter offset to make the raw timestamp zero (so that it can start ticking with a new multiplier)
 	Timestamp_offset_from_counter += timestamp_raw;

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -41,9 +41,6 @@ static bool Timestamp_sudo_paused = false;
 static uint64_t Timestamp_microseconds_at_mission_start = 0;
 
 
-static uint64_t timestamp_get_raw(bool start_frame = false);
-
-
 static uint64_t get_performance_counter()
 {
 	Assertion(Timer_inited, "This function can only be used when the timer system is initialized!");
@@ -76,12 +73,6 @@ void timer_init()
 
 		atexit(timer_close);
 	}
-}
-
-void timer_start_frame()
-{
-	// take a snapshot of the raw timestamp at the beginning of the frame
-	timestamp_get_raw(true);
 }
 
 // ======================================== getting time ========================================
@@ -138,21 +129,15 @@ std::uint64_t timer_get_nanoseconds()
     return static_cast<uint64_t>(time * Timer_to_nanoseconds);
 }
 
-static uint64_t timestamp_get_raw(bool start_frame)
+static uint64_t timestamp_get_raw()
 {
-	static uint64_t timestamp_raw = 0;
-
-	// The simulation timestamp is only updated at the beginning of the frame
-	// because we want all timestamps within a frame to be identical.
-	if (start_frame)
-	{
-		if (Timestamp_is_paused)
-			timestamp_raw = Timestamp_paused_at_counter;
-		else
-			timestamp_raw = get_performance_counter();
-
-		timestamp_raw -= Timestamp_offset_from_counter;
+	static uint64_t timestamp_raw;
+	if (Timestamp_is_paused) {
+		timestamp_raw = Timestamp_paused_at_counter;
+	} else {
+		timestamp_raw = get_performance_counter();
 	}
+	timestamp_raw -= Timestamp_offset_from_counter;
 
 	return timestamp_raw;
 }
@@ -634,7 +619,7 @@ void timestamp_update_time_compression()
 	}
 
 	// grab the independent variable of the equation before we change anything
-	auto timestamp_raw = timestamp_get_raw(true);
+	auto timestamp_raw = timestamp_get_raw();
 
 	// we need to move the counter offset to make the raw timestamp zero (so that it can start ticking with a new multiplier)
 	Timestamp_offset_from_counter += timestamp_raw;

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -89,6 +89,7 @@ public:
 
 extern void timer_init();
 extern void timer_close();
+extern void timer_start_frame();
 
 //==========================================================================
 // These functions return the time since the timer was initialized in

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -89,7 +89,6 @@ public:
 
 extern void timer_init();
 extern void timer_close();
-extern void timer_start_frame();
 
 //==========================================================================
 // These functions return the time since the timer was initialized in

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4266,6 +4266,9 @@ void game_set_frametime(int state)
 	float frame_cap_diff;
 	bool do_pre_player_skip = false;
 
+	// sync all timestamps across the entire frame
+	timer_start_frame();
+
 	thistime = timer_get_fixed_seconds();
 
 	if ( Last_time == 0 )	

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4266,9 +4266,6 @@ void game_set_frametime(int state)
 	float frame_cap_diff;
 	bool do_pre_player_skip = false;
 
-	// sync all timestamps across the entire frame
-	timer_start_frame();
-
 	thistime = timer_get_fixed_seconds();
 
 	if ( Last_time == 0 )	


### PR DESCRIPTION
EDIT: reverts scp-fs2open/fs2open.github.com#5266

Alas async and mission time are not acting reliably after this commit. Seems like removing the `if (start_frame)` check fixes things, but of course that's not the proper fix since that just restores the old behavior. ~~I've tried tracking things down and updating places where I think things should go, but no luck so far. It looks like Goober is pretty busy with RL ATM too, so I'm going to post this revert PR to fix the bug in the interim.~~

From Goober on Discord:
```This will need a proper investigation but I don't know how much time I'll have in the next few days to look at it. I think 5287 is thinking along the right lines but is not actually the correct fix. I'd say that leaving the missiontime and time compression bugs in the nightly builds would be a lot more disruptive than simply reverting to the pre-21st behavior.  So we should revert 5266 for now, then re-add 5266 with the time compression fix once we figure out what's going on. ```



Did some more examinations, seems the timestamp goes negative at mission start b/c `Timestamp_offset_from_counter` is larger than the value of `get_performance_counter()`.
```
Entering game at time =  12.194

start frame was true for timestamp

 'timestamp_raw' = 121939419 (get_performance_counter())
 
 'Timestamp_offset_from_counter' = 198181376 

 'timestamp_raw' updated = -76241957 (raw - offset_counter) 
```

For comparison, with the older behavior this is what an example of what happens
```
Entering game at time =  19.070

start frame was true for timestamp (always)
  
  'timestamp_raw' = 190700853 (get_performance_counter())

  'Timestamp_offset_from_counter' = 190648661 

  'timestamp_raw updated' = 52192 (raw - offset_counter) 
```

Ultimately  I traced the reason that the `Timestamp_offset_from_counter` gets too high is because in `timestamp_update_time_compression()` the call to `timestamp_get_raw` was using the new default false argument. It looks like it needs to have the new `true` optional argument added instead. EDTI: that alone does not quite fix time compression though. 

```
	// grab the independent variable of the equation before we change anything
	auto timestamp_raw = timestamp_get_raw();

	// we need to move the counter offset to make the raw timestamp zero (so that it can start ticking with a new multiplier)
	Timestamp_offset_from_counter += timestamp_raw;
	Timestamp_paused_at_counter += timestamp_raw;
``` 