### PR TITLE
restored the keyboard hotkey for envmap export.

### DIFF
--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -191,6 +191,10 @@ void LabManager::onFrame(float frametime) {
 				RotationSpeedDivisor = 100.f;
 			break;
 
+		case KEY_M:
+			gr_dump_envmap(Renderer->currentMissionBackground.c_str());
+			break;
+
 		case KEY_ESC:
 			notify_close();
 			break;


### PR DESCRIPTION
There's a gui button for this too, but the hotkey is still listed in the ui text and it's a bit more convenient for doing large batches of these, so I put it back in.