### PR TITLE
Dehardcode Command arrival message chance

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -41,6 +41,7 @@
 #include "weapon/emp.h"
 
 bool Allow_generic_backup_messages = false;
+float Command_announces_enemy_arrival_chance = 0.25;
 
 SCP_vector<SCP_string> Builtin_moods;
 int Current_mission_mood;
@@ -639,6 +640,19 @@ void parse_msgtbl()
 		if (optional_string("#Message Settings")) {
 			if (optional_string("$Allow Any Ship To Send Backup Messages:")) {
 				stuff_boolean(&Allow_generic_backup_messages);
+			}
+			if (optional_string("$Chance for Command to announce enemy arrival:")) {
+				int scratch;
+				stuff_int(&scratch);
+				if (scratch < 0) {
+					Warning(LOCATION, "$Chance for Command to announce enemy arrival: is negative; assuming 0");
+					Command_announces_enemy_arrival_chance = 0;
+				} else if (scratch > 100) {
+					Warning(LOCATION, "$Chance for Command to announce enemy arrival: is over 100; assuming 100");
+					Command_announces_enemy_arrival_chance = 100;
+				} else {
+					Command_announces_enemy_arrival_chance = static_cast<float>(scratch) / 100;
+				}
 			}
 		}
 

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -649,7 +649,7 @@ void parse_msgtbl()
 					Command_announces_enemy_arrival_chance = 0;
 				} else if (scratch > 100) {
 					Warning(LOCATION, "$Chance for Command to announce enemy arrival: is over 100; assuming 100");
-					Command_announces_enemy_arrival_chance = 100;
+					Command_announces_enemy_arrival_chance = 1;
 				} else {
 					Command_announces_enemy_arrival_chance = static_cast<float>(scratch) / 100;
 				}

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -57,6 +57,7 @@ extern SCP_vector<message_extra> Message_waves;
 
 extern SCP_vector<SCP_string> Builtin_moods;
 extern int Current_mission_mood;
+extern float Command_announces_enemy_arrival_chance;
 
 // Builtin messages
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -7496,8 +7496,7 @@ void mission_eval_arrivals() {
 	// of other wings.  We use the timestamps to delay the arrival message slightly for
 	// better effect
 	if (timestamp_valid(Arrival_message_delay_timestamp) && timestamp_elapsed(Arrival_message_delay_timestamp) && !MULTI_TEAM) {
-		// use terran command 25% of time
-		bool use_terran_cmd = ((frand() - 0.75) > 0.0f);
+		bool use_terran_cmd = (Command_announces_enemy_arrival_chance >= 0) && (frand() < Command_announces_enemy_arrival_chance);
 
 		rship = ship_get_random_player_wing_ship(SHIP_GET_UNSILENCED);
 		ship* subject = (Arrival_message_subject < 0) ? nullptr : &Ships[Arrival_message_subject];


### PR DESCRIPTION
Historically, there's been a hardcoded 25% chance for Command to announce an enemy wing arrival. This is problematic for mods without Command, like BTA.