### PR TITLE
Adjustments to max vel changes from ETS

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1644,7 +1644,7 @@ void set_accel_for_target_speed(object *objp, float tspeed)
 
 	aip = &Ai_info[Ships[objp->instance].ai_index];
 
-	max_speed = Ships[objp->instance].current_max_speed;
+	max_speed = objp->phys_info.max_vel.xyz.z;
 
 	if (max_speed > 0.0f) {
 		AI_ci.forward = tspeed/max_speed;
@@ -1955,7 +1955,7 @@ int num_enemies_attacking(int objnum)
 /**
  * Scan all the ships in *objp's wing. Return the lowest maximum speed of a ship in the wing.
  *
- * Current maximum speed (based on energy settings) is shipp->current_max_speed
+ * Current maximum speed (based on energy settings) is objp->phys_info.max_vel.xyz.z
  */
 float get_wing_lowest_max_speed(object *objp)
 {
@@ -1970,7 +1970,7 @@ float get_wing_lowest_max_speed(object *objp)
 	shipp = &Ships[objp->instance];
 	wingnum = shipp->wingnum;
 
-	lowest_max_speed = shipp->current_max_speed;
+	lowest_max_speed = objp->phys_info.max_vel.xyz.z;
 
 	if ( wingnum == -1 )
 		return lowest_max_speed;
@@ -1988,13 +1988,13 @@ float get_wing_lowest_max_speed(object *objp)
 		if ((oaip->mode == AIM_WAYPOINTS) && (oshipp->wingnum == wingnum)) {
 			//	Note: If a ship in the wing has a super low max speed, probably its engines are disabled.  So, fly along and
 			//	ignore the poor guy.
-			float	cur_max = oshipp->current_max_speed;
+			float	cur_max = o->phys_info.max_vel.xyz.z;
 
 			if (object_is_docked(o)) {
 				cur_max *= o->phys_info.mass / dock_calc_total_docked_mass(o);
 			}
 							
-			if ((oshipp->current_max_speed > 5.0f) && (cur_max < lowest_max_speed)) {
+			if ((o->phys_info.max_vel.xyz.z > 5.0f) && (cur_max < lowest_max_speed)) {
 				lowest_max_speed = cur_max;
 			}
 		}
@@ -2026,14 +2026,16 @@ float get_wing_lowest_av_ab_speed(object *objp)
 
 	wingnum = shipp->wingnum;
 
-	if (((shipp->flags[Ship::Ship_Flags::Afterburner_locked]) || !(sip->flags[Ship::Info_Flags::Afterburner])) || (shipp->current_max_speed < 5.0f) || (objp->phys_info.afterburner_max_vel.xyz.z <= shipp->current_max_speed) || !(aip->ai_flags[AI::AI_Flags::Free_afterburner_use] || aip->ai_profile_flags[AI::Profile_Flags::Free_afterburner_use]))	{
-		lowest_max_av_ab_speed = shipp->current_max_speed;
+	if (((shipp->flags[Ship::Ship_Flags::Afterburner_locked]) || !(sip->flags[Ship::Info_Flags::Afterburner])) || (objp->phys_info.max_vel.xyz.z < 5.0f) || 
+		(objp->phys_info.afterburner_max_vel.xyz.z <= objp->phys_info.max_vel.xyz.z) || !(aip->ai_flags[AI::AI_Flags::Free_afterburner_use]
+			|| aip->ai_profile_flags[AI::Profile_Flags::Free_afterburner_use]))	{
+		lowest_max_av_ab_speed = objp->phys_info.max_vel.xyz.z;
 	}
 	else
 	{
 		recharge_scale = Energy_levels[shipp->engine_recharge_index] * 2.0f * The_mission.ai_profile->afterburner_recharge_scale[Game_skill_level];
 		recharge_scale = sip->afterburner_recover_rate * recharge_scale / (sip->afterburner_burn_rate + sip->afterburner_recover_rate * recharge_scale);
-		lowest_max_av_ab_speed = recharge_scale * (objp->phys_info.afterburner_max_vel.xyz.z - shipp->current_max_speed) + shipp->current_max_speed;
+		lowest_max_av_ab_speed = recharge_scale * (objp->phys_info.afterburner_max_vel.xyz.z - objp->phys_info.max_vel.xyz.z) + objp->phys_info.max_vel.xyz.z;
 	}
 	
 
@@ -2054,14 +2056,14 @@ float get_wing_lowest_av_ab_speed(object *objp)
 		if ((oaip->mode == AIM_WAYPOINTS) && (oshipp->wingnum == wingnum) && (oaip->ai_flags[AI::AI_Flags::Formation_object, AI::AI_Flags::Formation_wing])) {
 			
 			float cur_max;
-			if ((oshipp->flags[Ship::Ship_Flags::Afterburner_locked]) || !(osip->flags[Ship::Info_Flags::Afterburner]) || (o->phys_info.afterburner_max_vel.xyz.z <= oshipp->current_max_speed) || !(oaip->ai_flags[AI::AI_Flags::Free_afterburner_use] || oaip->ai_profile_flags[AI::Profile_Flags::Free_afterburner_use])) {
-				cur_max = oshipp->current_max_speed;
+			if ((oshipp->flags[Ship::Ship_Flags::Afterburner_locked]) || !(osip->flags[Ship::Info_Flags::Afterburner]) || (o->phys_info.afterburner_max_vel.xyz.z <= o->phys_info.max_vel.xyz.z) || !(oaip->ai_flags[AI::AI_Flags::Free_afterburner_use] || oaip->ai_profile_flags[AI::Profile_Flags::Free_afterburner_use])) {
+				cur_max = o->phys_info.max_vel.xyz.z;
 			}
 			else
 			{
 				recharge_scale = Energy_levels[shipp->engine_recharge_index] * 2.0f * The_mission.ai_profile->afterburner_recharge_scale[Game_skill_level];
 				recharge_scale = osip->afterburner_recover_rate * recharge_scale / (osip->afterburner_burn_rate + osip->afterburner_recover_rate * recharge_scale);
-				cur_max = recharge_scale * (o->phys_info.afterburner_max_vel.xyz.z - oshipp->current_max_speed) + oshipp->current_max_speed;
+				cur_max = recharge_scale * (o->phys_info.afterburner_max_vel.xyz.z - o->phys_info.max_vel.xyz.z) + o->phys_info.max_vel.xyz.z;
 			}
 
 			if (object_is_docked(o)) {
@@ -2069,7 +2071,7 @@ float get_wing_lowest_av_ab_speed(object *objp)
 			}
 			//	Note: If a ship in the wing has a super low max speed, probably its engines are disabled.  So, fly along and
 			//	ignore the poor guy.				
-			if ((oshipp->current_max_speed > 5.0f) && (cur_max < lowest_max_av_ab_speed)) {
+			if ((o->phys_info.max_vel.xyz.z > 5.0f) && (cur_max < lowest_max_av_ab_speed)) {
 				lowest_max_av_ab_speed = cur_max;
 			}
 		}
@@ -4698,7 +4700,7 @@ void ai_fly_to_target_position(vec3d* target_pos, bool* pl_done_p=NULL, bool* pl
 		if (ab_allowed) {
 			float self_ab_scale = Energy_levels[shipp->engine_recharge_index] * 2.0f * The_mission.ai_profile->afterburner_recharge_scale[Game_skill_level];
 			self_ab_scale = sip->afterburner_recover_rate * self_ab_scale / (sip->afterburner_burn_rate + sip->afterburner_recover_rate * self_ab_scale);
-			self_ab_speed = 0.95f * (self_ab_scale * (Pl_objp->phys_info.afterburner_max_vel.xyz.z - shipp->current_max_speed) + shipp->current_max_speed);
+			self_ab_speed = 0.95f * (self_ab_scale * (Pl_objp->phys_info.afterburner_max_vel.xyz.z - Pl_objp->phys_info.max_vel.xyz.z) + Pl_objp->phys_info.max_vel.xyz.z);
 		}
 	}
 
@@ -4710,7 +4712,7 @@ void ai_fly_to_target_position(vec3d* target_pos, bool* pl_done_p=NULL, bool* pl
 
 	if ((self_ab_speed < 5.0f) || (max_allowed_ab_speed < 5.0f)){ // || ((shipp->wingnum != -1) && (dist_to_goal / max_allowed_ab_speed < 5.0f))){
 		ab_allowed = false;
-	} else if (max_allowed_ab_speed < shipp->current_max_speed) {
+	} else if (max_allowed_ab_speed < Pl_objp->phys_info.max_vel.xyz.z) {
 		if (max_allowed_speed < max_allowed_ab_speed) {
 			max_allowed_speed = max_allowed_ab_speed;
 		} else {
@@ -4749,16 +4751,16 @@ void ai_fly_to_target_position(vec3d* target_pos, bool* pl_done_p=NULL, bool* pl
 		}
 
 		if (!(Pl_objp->phys_info.flags & PF_AFTERBURNER_ON )) {
-			if (aip->prev_accel * shipp->current_max_speed > max_allowed_ab_speed) {
-				accelerate_ship(aip, max_allowed_ab_speed / shipp->current_max_speed);
+			if (aip->prev_accel * Pl_objp->phys_info.max_vel.xyz.z > max_allowed_ab_speed) {
+				accelerate_ship(aip, max_allowed_ab_speed / Pl_objp->phys_info.max_vel.xyz.z);
 			}
 		}
 	} else {
 		if (Pl_objp->phys_info.flags & PF_AFTERBURNER_ON ) {
 			afterburners_stop(Pl_objp);
 		}
-		if (aip->prev_accel * shipp->current_max_speed > max_allowed_speed) {
-			accelerate_ship(aip, max_allowed_speed / shipp->current_max_speed);
+		if (aip->prev_accel * Pl_objp->phys_info.max_vel.xyz.z > max_allowed_speed) {
+			accelerate_ship(aip, max_allowed_speed / Pl_objp->phys_info.max_vel.xyz.z);
 		}
 	}
 
@@ -12556,13 +12558,13 @@ int ai_formation()
 	} else if (dist_to_goal > 200.0f) {
 		if (dot_to_goal > -0.5f) {
 			turn_towards_point(Pl_objp, &goal_point, nullptr, 0.0f, leader_orient, AITTV_SLOW_BANK_ACCEL);
-			float range_speed = shipp->current_max_speed - leader_speed;
+			float range_speed = Pl_objp->phys_info.max_vel.xyz.z - leader_speed;
 			if (range_speed > 0.0f) {
 				set_accel_for_target_speed(Pl_objp, leader_speed + range_speed * (dist_to_goal+100.0f)/500.0f);
 				if (Pl_objp->phys_info.flags & PF_AFTERBURNER_ON)
 					afterburners_stop(Pl_objp);
 			} else {
-				set_accel_for_target_speed(Pl_objp, shipp->current_max_speed);
+				set_accel_for_target_speed(Pl_objp, Pl_objp->phys_info.max_vel.xyz.z);
 				if (ab_allowed) {
 					if (!(Pl_objp->phys_info.flags & PF_AFTERBURNER_ON) && (dot_to_goal > 0.4f)) {
 						float percent_left = 100.0f * shipp->afterburner_fuel / sip->afterburner_fuel_capacity;
@@ -12602,13 +12604,13 @@ int ai_formation()
 		} else if (dist_to_goal > 75.0f) {
 			turn_towards_point(Pl_objp, &future_goal_point_2, nullptr, 0.0f, leader_orient, AITTV_SLOW_BANK_ACCEL);
 			float	delta_speed;
-			float range_speed = shipp->current_max_speed - leader_speed;
+			float range_speed = Pl_objp->phys_info.max_vel.xyz.z - leader_speed;
 			if (range_speed > 0.0f) {
 				delta_speed = dist_to_goal_2/500.0f * range_speed;
 				if (Pl_objp->phys_info.flags & PF_AFTERBURNER_ON)
 					afterburners_stop(Pl_objp);
 			} else {
-				delta_speed = shipp->current_max_speed - leader_speed;
+				delta_speed = Pl_objp->phys_info.max_vel.xyz.z - leader_speed;
 				if (ab_allowed) {
 					if (!(Pl_objp->phys_info.flags & PF_AFTERBURNER_ON) && (dot_to_goal > 0.6f)) {
 						float percent_left = 100.0f * shipp->afterburner_fuel / sip->afterburner_fuel_capacity;
@@ -12673,7 +12675,7 @@ int ai_formation()
 					set_accel_for_target_speed(Pl_objp, leader_speed + 1.5f * dot_to_goal - 1.0f);
 				}
 
-				float range_speed = shipp->current_max_speed - leader_speed;
+				float range_speed = Pl_objp->phys_info.max_vel.xyz.z - leader_speed;
 				if (range_speed > 0.0f) {
 					if (Pl_objp->phys_info.flags & PF_AFTERBURNER_ON)
 						afterburners_stop(Pl_objp);
@@ -12701,7 +12703,7 @@ int ai_formation()
 				// Goober5000 7/5/2006 changed to leader_speed from 0.0f
 				set_accel_for_target_speed(Pl_objp, leader_speed);
 
-				float range_speed = shipp->current_max_speed - leader_speed;
+				float range_speed = Pl_objp->phys_info.max_vel.xyz.z - leader_speed;
 				if (range_speed > 0.0f) {
 					if (Pl_objp->phys_info.flags & PF_AFTERBURNER_ON)
 						afterburners_stop(Pl_objp);
@@ -15110,9 +15112,6 @@ void ai_process( object * obj, int ai_index, float frametime )
 	AI_ci.heading = 0.0f;
 
 	ai_frame(OBJ_INDEX(obj));
-
-	// the ships maximum velocity now depends on the energy flowing to engines
-	obj->phys_info.max_vel.xyz.z = shipp->current_max_speed;
 
 	//	In certain circumstances, the AI says don't fly in the normal way.
 	//	One circumstance is in docking and undocking, when the ship is moving

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -52,6 +52,9 @@ void ets_init_ship(object* obj)
 		sp->next_manage_ets = -1;
 	}
 	set_default_recharge_rates(obj);
+
+	float y = Energy_levels[sp->engine_recharge_index];
+	obj->phys_info.max_vel.xyz.z = ets_get_max_speed(obj, y);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -117,11 +120,6 @@ void update_ets(object* objp, float fl_frametime)
 		}
 	}
 
-	// calculate the top speed of the ship based on the energy flow to engines
-	float y = Energy_levels[ship_p->engine_recharge_index];
-
-	ship_p->current_max_speed = ets_get_max_speed(objp, y);
-
 	// AL 11-15-97: Rules for engine strength affecting max speed:
 	//						1. if strength >= 0.5 no affect 
 	//						2. if strength < 0.5 then max_speed = sqrt(strength)
@@ -133,7 +131,7 @@ void update_ets(object* objp, float fl_frametime)
 	// don't let engine strength affect max speed when playing on lowest skill level
 	if ( (objp != Player_obj) || (Game_skill_level > 0) ) {
 		if ( strength < SHIP_MIN_ENGINES_FOR_FULL_SPEED ) {
-			ship_p->current_max_speed *= fl_sqrt(strength);
+			objp->phys_info.max_vel.xyz.z *= fl_sqrt(strength);
 		}
 	}
 
@@ -483,6 +481,12 @@ void increase_recharge_rate(object* obj, SYSTEM_TYPE ship_system)
 
 	if ( obj == Player_obj )
 		snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS), 0.0f );
+
+
+	// calculate the top speed of the ship based on the energy flow to engines
+	float y = Energy_levels[ship_p->engine_recharge_index];
+
+	obj->phys_info.max_vel.xyz.z = ets_get_max_speed(obj, y);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -602,6 +606,11 @@ void decrease_recharge_rate(object* obj, SYSTEM_TYPE ship_system)
 
 	if ( obj == Player_obj )
 		snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS), 0.0f );
+
+	// calculate the top speed of the ship based on the energy flow to engines
+	float y = Energy_levels[ship_p->engine_recharge_index];
+
+	obj->phys_info.max_vel.xyz.z = ets_get_max_speed(obj, y);
 }
 
 void transfer_energy_weapon_common(object *objp, float from_field, float to_field, float *from_delta, float *to_delta, float from_max, float to_max, float scale, float eff)

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -544,7 +544,7 @@ void HudGaugeThrottle::render(float  /*frametime*/)
 		current_speed = 0.0f;
 	}
 
-	max_speed = Ships[Player_obj->instance].current_max_speed;
+	max_speed = Player_obj->phys_info.max_vel.xyz.z;
 	if ( max_speed <= 0 ) {
 		max_speed = sip->max_vel.xyz.z;
 	}

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -2193,7 +2193,7 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 			gr_printf_no_resize(sx, sy, "%s", outstr);
 			sy += dy;
 
-			gr_printf_no_resize(sx, sy, "Max speed = %d, (%d%%)", (int) shipp->current_max_speed, (int) (100.0f * vm_vec_mag(&target_objp->phys_info.vel)/shipp->current_max_speed));
+			gr_printf_no_resize(sx, sy, "Max speed = %d, (%d%%)", (int)target_objp->phys_info.max_vel.xyz.z, (int) (100.0f * vm_vec_mag(&target_objp->phys_info.vel)/target_objp->phys_info.max_vel.xyz.z));
 			sy += dy;
 			
 			// data can be found in target montior
@@ -2231,7 +2231,7 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 			// print out energy transfer information on the ship
 			sy = gr_screen.center_offset_y + 70;
 
-			sprintf(outstr,"MAX G/E: %.0f/%.0f",shipp->weapon_energy,shipp->current_max_speed);
+			sprintf(outstr,"MAX G/E: %.0f/%.0f",shipp->weapon_energy, target_objp->phys_info.max_vel.xyz.z);
 			gr_printf_no_resize(sx, sy, "%s", outstr);
 			sy += dy;
 			 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6107,7 +6107,7 @@ bool post_process_mission(mission *pm)
 	// determine if player start has initial velocity and set forward cruise percent to relect this
 	// this should check prev_ramp_vel because that is in local coordinates --wookieejedi
 	if ( Player_obj->phys_info.prev_ramp_vel.xyz.z > 0.0f )
-		Player->ci.forward_cruise_percent = Player_obj->phys_info.prev_ramp_vel.xyz.z / Player_ship->current_max_speed * 100.0f;
+		Player->ci.forward_cruise_percent = Player_obj->phys_info.prev_ramp_vel.xyz.z / Player_obj->phys_info.max_vel.xyz.z * 100.0f;
 
 	// Kazan - player use AI at start?
 	if (pm->flags[Mission::Mission_Flags::Player_start_ai])

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -714,7 +714,7 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 
 				//SUSHI: If gliding, don't do anything for speed matching
 				if (!( (Objects[Player->objnum].phys_info.flags & PF_GLIDING) || (Objects[Player->objnum].phys_info.flags & PF_FORCE_GLIDE) )) {
-					pmax_speed = Ships[Player_obj->instance].current_max_speed;
+					pmax_speed = Player_obj->phys_info.max_vel.xyz.z;
 					if (pmax_speed > 0.0f) {
 						ci->forward_cruise_percent = (tspeed / pmax_speed) * 100.0f;
 					} else {
@@ -1011,9 +1011,9 @@ void read_player_controls(object *objp, float frametime)
 					gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_STOP );
 				} else {
 					if ( Warpout_forced ) {
-						Ships[objp->instance].current_max_speed = target_warpout_speed * 2.0f;
-					} else if (Ships[objp->instance].current_max_speed < target_warpout_speed) {
-						Ships[objp->instance].current_max_speed = target_warpout_speed + 5.0f;
+						objp->phys_info.max_vel.xyz.z = target_warpout_speed * 2.0f;
+					} else if (objp->phys_info.max_vel.xyz.z < target_warpout_speed) {
+						objp->phys_info.max_vel.xyz.z = target_warpout_speed + 5.0f;
 					}
 
 					diff = target_warpout_speed - objp->phys_info.fspeed;
@@ -1021,7 +1021,7 @@ void read_player_controls(object *objp, float frametime)
 					if ( diff < 0.0f ) 
 						diff = 0.0f;
 					
-					Player->ci.forward = ((target_warpout_speed + diff) / Ships[objp->instance].current_max_speed);
+					Player->ci.forward = ((target_warpout_speed + diff) / objp->phys_info.max_vel.xyz.z);
 				}
 			
 				if ( Player->control_mode == PCM_WARPOUT_STAGE1 )
@@ -1052,10 +1052,6 @@ void read_player_controls(object *objp, float frametime)
 		}
 	}
 
-	// the ships maximum velocity now depends on the energy flowing to engines
-	if(objp->type != OBJ_OBSERVER){
-		objp->phys_info.max_vel.xyz.z = Ships[objp->instance].current_max_speed;
-	} 
 	if(Player_obj->type == OBJ_SHIP && !Player_use_ai){	
 		// only read player control info if player ship is not dead
 		// or if Player_use_ai is disabed

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6534,7 +6534,6 @@ void ship::clear()
 	weapon_recharge_index = INTIAL_WEAPON_RECHARGE_INDEX;
 	engine_recharge_index = INTIAL_ENGINE_RECHARGE_INDEX;
 	weapon_energy = 0;
-	current_max_speed = 0.0f;
 	next_manage_ets = timestamp(0);
 
 	flags.reset();
@@ -6961,8 +6960,6 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 	}
 
 	ets_init_ship(objp);	// init ship fields that are used for the ETS
-
-	shipp->current_max_speed = Ship_info[ship_type].max_speed;
 
 	shipp->flags.set(Ship_Flags::Engines_on);
 
@@ -11397,14 +11394,6 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 		sp->cmeasure_count = MAX(0, fl2i(sip->cmeasure_max / cm_cargo_size) - cm_used);
 	} else {
 		sp->cmeasure_count = MAX(0, sip->cmeasure_max - (sip_orig->cmeasure_max - sp->cmeasure_count));
-	}
-
-	// avoid cases where either of these are 0
-	if (sp->current_max_speed != 0 && sip_orig->max_speed != 0) {
-		sp->current_max_speed = sip->max_speed * (sp->current_max_speed / sip_orig->max_speed);
-	}
-	else {
-		sp->current_max_speed = sip->max_speed;
 	}
 
 	ship_set_default_weapons(sp, sip);
@@ -16728,9 +16717,9 @@ int ship_return_seconds_to_goal(ship *sp)
 
 	// Goober5000 - handle cap
 	if (aip->waypoint_speed_cap > 0)
-		max_speed = MIN(sp->current_max_speed, aip->waypoint_speed_cap);
+		max_speed = MIN(objp->phys_info.max_vel.xyz.z, aip->waypoint_speed_cap);
 	else
-		max_speed = sp->current_max_speed;
+		max_speed = objp->phys_info.max_vel.xyz.z;
 
 	if ( aip->mode == AIM_WAYPOINTS ) {
 		// Is traveling a waypoint path

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -645,7 +645,6 @@ public:
 	int	weapon_recharge_index;			// index into array holding the weapon recharge rate
 	int	engine_recharge_index;			// index into array holding the engine recharge rate
 	float	weapon_energy;						// Number of EUs in energy reserves
-	float	current_max_speed;				// Max ship speed (based on energy diverted to engines)
 	int	next_manage_ets;					// timestamp for when ai can next modify ets ( -1 means never )
 
 	flagset<Ship::Ship_Flags>	flags;		// flag variable to contain ship state


### PR DESCRIPTION
The ship's `current_max_speed` stores the max speed given the ship's ETS settings and it's what most things will read from, while every frame its own physics `phys_info.max_vel.xyz.z` is updated to that value. This indirection is harmful because it basically prevents any modification of a ship's max velocity through scripting through its physics values. Instead the `current_max_speed` should be removed, and `phys_info.max_vel.xyz.z` should be modified and acted upon directly, they store the exact same value (which was also enforced every frame).

Other changes in hudets.cpp meant to facilitate script access is that max speed should only be adjusted when the engine energy is actually adjusted, prior the speed was set based on engine energy every frame, even on ships without ETS. 