### PR TITLE
additional constraint on Command arrival messages

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -7522,7 +7522,7 @@ void mission_eval_arrivals() {
 	// of other wings.  We use the timestamps to delay the arrival message slightly for
 	// better effect
 	if (timestamp_valid(Arrival_message_delay_timestamp) && timestamp_elapsed(Arrival_message_delay_timestamp) && !MULTI_TEAM) {
-		bool use_terran_cmd = (Command_announces_enemy_arrival_chance >= 0) && (frand() < Command_announces_enemy_arrival_chance);
+		bool use_terran_cmd = !The_mission.flags[Mission::Mission_Flags::No_builtin_command] && (Command_announces_enemy_arrival_chance >= 0) && (frand() < Command_announces_enemy_arrival_chance);
 
 		rship = ship_get_random_player_wing_ship(SHIP_GET_UNSILENCED);
 		ship* subject = (Arrival_message_subject < 0) ? nullptr : &Ships[Arrival_message_subject];


### PR DESCRIPTION
Command should not be considered if the mission explicitly prevents Command from sending builtin messages.

Follow-up to #5290.