### PR TITLE
$Beaminfo implies "beam" flag!

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2577,6 +2577,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 	// beam weapon optional stuff
 	if ( optional_string("$BeamInfo:") ) {
+		wip->wi_flags.set(Weapon::Info_Flags::Beam);
 		// beam type
 		if(optional_string("+Type:")) {
 			stuff_string(fname, F_NAME, NAME_LENGTH);


### PR DESCRIPTION
Fix for an annoying case I ran into, beam weapon behaved oddly because I forgot to add the "beam" flag. These flags are dumb. If they specified any $Beaminfo, it's a beam full-stop.