### PR TITLE
Small fix for type5 fighter beams

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2532,7 +2532,7 @@ void beam_get_binfo(beam *b, float accuracy, int num_shots, int burst_seed, floa
 
 		// now the offsets
 		float scale_factor;
-		if (b->target != nullptr) {
+		if (usable_target && b->target != nullptr) {
 			if (bwi->t5info.target_scale_positions)
 				scale_factor = b->target->radius;
 			else


### PR DESCRIPTION
Type5 fighter beams are for several purposes not treated as 'having a target', the beam aims for straight forward regardless. For this purpose `usable_target` is used, and should also apply to the offset scaling, otherwise discrepancies will appear like the random offset scaling widly changing the beam's accuracy based on the distance to the target despite in this case always 'aiming' for a spot directly ahead at a fixed distance.