### PR TITLE
"On Frame but actually Wait before you continue"-Executor

### DIFF
--- a/code/scripting/api/libs/async.cpp
+++ b/code/scripting/api/libs/async.cpp
@@ -257,6 +257,8 @@ ADE_FUNC(awaitRunOnFrame,
 		gr_flip();
 	}
 
+	gr_free_screen(screen_id);
+
 	if(promise.isErrored())
 		return ADE_RETURN_NIL;
 

--- a/code/scripting/api/libs/async.cpp
+++ b/code/scripting/api/libs/async.cpp
@@ -218,7 +218,7 @@ ADE_FUNC(run,
 
 ADE_FUNC(awaitRunOnFrame,
 	l_Async,
-	"function() => any body,",
+	"function() => any body",
 	"Runs an asynchronous function in an OnFrameExecutor context and busy-waits for the coroutine to finish. "
 	"Inside this function you can use async.await to suspend the function until a promise resolves. "
 	"This is useful for cases where you need a scripting process to run over multiple frames, even when "

--- a/code/scripting/api/libs/async.cpp
+++ b/code/scripting/api/libs/async.cpp
@@ -218,7 +218,7 @@ ADE_FUNC(run,
 
 ADE_FUNC(awaitRunOnFrame,
 	l_Async,
-	"function() => any body, [bool clearScreen = false]",
+	"function() => any body,",
 	"Runs an asynchronous function in an OnFrameExecutor context and busy-waits for the coroutine to finish. "
 	"Inside this function you can use async.await to suspend the function until a promise resolves. "
 	"This is useful for cases where you need a scripting process to run over multiple frames, even when "
@@ -229,7 +229,7 @@ ADE_FUNC(awaitRunOnFrame,
 	luacpp::LuaFunction body;
 	std::shared_ptr<executor::IExecutionContext> context;
 
-	if (!ade_get_args(L, "u|ob", &body)) {
+	if (!ade_get_args(L, "u", &body)) {
 		return ADE_RETURN_NIL;
 	}
 


### PR DESCRIPTION
What this does is basically providing an async.run that is able to run _and await_ an async with a built-in On Frame executor, but in a way that blocks _all other engine code_.
This makes it useful for things that need multiple frames, but the engine is in an unstable state where there simply are not multiple frames to be had until other things happen.
Two examples quickly become apparent for when this occurs:
1. Imagine you want to add animated transitions between game states. If you hook into a game state change, you simply never get a frame, so any attempt at starting an async will end up happening simultaneously to the stuff in the next game state. This new function will allow to start and run an async that yields and draws multiple frames _during_ the state change of FSO.
2. Say you have a script that does things that take a long time, like load many models from disk. You may be somewhere like on mission init, where you can't allow the game to proceed before you're done loading, but the loading takes so long, that windows starts flagging FSO as unresponsive, or you want to display a progress bar. This would allow you to add yields and draw calls for a progress bar interleaved into the loading code, without running the risk of FSO proceeding.

There is precedent in the engine for "halting" the state like this with a loop containing os_poll and gr_flip in stuff like how popups are handled, so this is not actually doing any new unknown witchcraft.