### PR TITLE
Add arbitrary curves support

### DIFF
--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell 
+ * or otherwise commercially exploit the source or things you created based on the 
+ * source.
+ *
+*/ 
+
+#include "math/curve.h"
+#include "parse/parselo.h"
+
+SCP_vector<Curve> Curves;
+
+int curve_get_by_name(SCP_string in_name) {
+	for (int i = 0; i < (int)Curves.size(); i++) {
+		if (Curves[i].name == in_name)
+			return i;
+	}
+
+	return -1;
+}
+
+void parse_curve_table(const char* filename) {
+	try
+	{
+		read_file_text(filename, CF_TYPE_TABLES);
+		reset_parse();
+
+		optional_string("#Curves");
+
+		while (optional_string("$Name:")) {
+			SCP_string name;
+			stuff_string(name, F_NAME);
+
+			int index = curve_get_by_name(name);
+
+			if (index < 0) {
+				Curve curv = Curve(name);
+				curv.ParseData();
+				Curves.push_back(curv);
+			} else {
+				Curves[index].ParseData();
+			}
+		}
+	}
+	catch (const parse::ParseException& e)
+	{
+		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", filename, e.what()));
+	}
+}
+
+void fill_default_curves() {
+	for (int i = 2; i < 6; i++) {
+		for (int rev = 0; rev < 2; rev++) {
+			SCP_string name("EaseIn");
+			switch (i) {
+			case 2: name += "Quad"; break;
+			case 3: name += "Cubic"; break;
+			case 4: name += "Quart"; break;
+			case 5: name += "Quint"; break;
+			}
+			if (rev)
+				name += "Rev";
+
+			Curves.emplace_back(name);
+			Curves.back().keyframes.push_back(curve_keyframe{ vec2d { 0.0f, rev ? 1.0f : 0.0f}, CurveInterpFunction::Polynomial, (float)i, 1.0f });
+			Curves.back().keyframes.push_back(curve_keyframe{ vec2d { 1.0f, rev ? 0.0f : 1.0f}, CurveInterpFunction::Constant, 0.0f, 0.0f });
+
+			name = "EaseOut";
+			switch (i) {
+			case 2: name += "Quad"; break;
+			case 3: name += "Cubic"; break;
+			case 4: name += "Quart"; break;
+			case 5: name += "Quint"; break;
+			}
+			if (rev)
+				name += "Rev";
+
+			Curves.emplace_back(name);
+			Curves.back().keyframes.push_back(curve_keyframe{ vec2d { 0.0f, rev ? 1.0f : 0.0f}, CurveInterpFunction::Polynomial, (float)i, -1.0f });
+			Curves.back().keyframes.push_back(curve_keyframe{ vec2d { 1.0f, rev ? 0.0f : 1.0f}, CurveInterpFunction::Constant, 0.0f, 0.0f });
+
+			name = "EaseInOut";
+			switch (i) {
+			case 2: name += "Quad"; break;
+			case 3: name += "Cubic"; break;
+			case 4: name += "Quart"; break;
+			case 5: name += "Quint"; break;
+			}
+			if (rev)
+				name += "Rev";
+
+			Curves.emplace_back(name);
+			Curves.back().keyframes.push_back(curve_keyframe{ vec2d { 0.0f, rev ? 1.0f : 0.0f}, CurveInterpFunction::Polynomial, (float)i, 1.0f });
+			Curves.back().keyframes.push_back(curve_keyframe{ vec2d { 0.5f, 0.5f}, CurveInterpFunction::Polynomial, (float)i, -1.0f });
+			Curves.back().keyframes.push_back(curve_keyframe{ vec2d { 1.0f, rev ? 0.0f : 1.0f}, CurveInterpFunction::Constant, 0.0f, 0.0f });
+		}
+	}
+}
+
+void curves_init() {
+
+	Curves.clear();
+	fill_default_curves();
+
+	if (cf_exists_full("curves.tbl", CF_TYPE_TABLES))
+		parse_curve_table("curves.tbl");
+
+	parse_modular_table(NOX("*-crv.tbm"), parse_curve_table);
+}
+
+Curve::Curve(SCP_string in_name)
+{
+	name = in_name;
+}
+
+void Curve::ParseData()
+{
+	keyframes.clear();
+
+	required_string("$Keyframes:");
+	do
+	{
+		bool valid_keyframe = true;
+		curve_keyframe kframe;
+		stuff_parenthesized_vec2d(&kframe.pos);
+		required_string(":");
+
+		SCP_string type;
+		stuff_string(type, F_NAME, ",");
+
+		if (type == "Constant") {
+			kframe.interp_func = CurveInterpFunction::Constant;
+		} else if (type == "Linear") {
+			kframe.interp_func = CurveInterpFunction::Linear;
+		} else if (type == "Polynomial") {
+			kframe.interp_func = CurveInterpFunction::Polynomial;
+
+			required_string(",");
+			if (stuff_float(&kframe.param1)) {
+				bool ease_in;
+				stuff_boolean(&ease_in);
+				if (ease_in)
+					kframe.param2 = 1.0f;
+				else
+					kframe.param2 = -1.0f;
+			} else {
+				kframe.param2 = 1.0;
+			}
+		} else if (type == "Circular") {
+			kframe.interp_func = CurveInterpFunction::Circular;
+
+			if (optional_string(",")) {
+				bool ease_in;
+				stuff_boolean(&ease_in);
+				if (ease_in)
+					kframe.param2 = 1.0f;
+				else
+					kframe.param2 = -1.0f;
+			} else {
+				kframe.param2 = 1.0f;
+			}
+		} else {
+			int index = curve_get_by_name(type);
+
+			if (index < 0) {
+				Warning(LOCATION, "Unrecognized interpolation function '%s' used in '%s'. Remember that any other curves used in this curve must have been defined before this one.", 
+					type.c_str(), name.c_str());
+				valid_keyframe = false;
+			} else {
+				kframe.interp_func = CurveInterpFunction::Curve;
+				kframe.param1 = (float)index;
+			}
+		}
+
+		if (valid_keyframe && keyframes.size() > 0 && kframe.pos.x < keyframes.back().pos.x) {
+			Warning(LOCATION, "The keyframe (%f,%f) of Curve '%s' has a smaller x value than the previous keyframe. They must increase in order. Skipping this keyframe...", 
+				kframe.pos.x, kframe.pos.y, name.c_str());
+		} else {
+			keyframes.push_back(kframe);
+		}
+
+		if (optional_string("#End"))
+			return;
+
+	} while (!check_for_string("$Name:"));
+
+	if (keyframes.back().pos.x < 1.0f) {
+		Warning(LOCATION, "The last keyframe of Curve '%s' has an x value less then 1. A (1, 1) point has been added.", name.c_str());
+		curve_keyframe kframe;
+		kframe.interp_func = CurveInterpFunction::Constant;
+		kframe.pos.x = 1.0f;
+		kframe.pos.y = 1.0f;
+		keyframes.push_back(kframe);
+	}
+}
+
+
+float Curve::GetValue(float x_val) {
+	curve_keyframe* kframe = &keyframes[0];
+	vec2d* next_pos = &kframe->pos;
+	for (size_t i = 0; i < keyframes.size(); i++) {
+		kframe = &keyframes[i];
+		if (x_val < kframe->pos.x) {
+			if (i == 0) {
+				return kframe->pos.y; // 'stretch' the initial y value back to -infinity
+			} else {
+				next_pos = &kframe->pos;
+				kframe = &keyframes[i-1];
+				break;
+			}
+		}
+
+		if (i == keyframes.size() - 1) {
+			return kframe->pos.y; // 'stretch' the final y value forward to infinity
+		}
+	}
+
+	float t = (x_val - kframe->pos.x) / (next_pos->x - kframe->pos.x);
+	float out;
+	switch (kframe->interp_func) {
+		case CurveInterpFunction::Constant:
+			return kframe->pos.y;
+		case CurveInterpFunction::Linear:
+			return kframe->pos.y + t * (next_pos->y - kframe->pos.y);
+		case CurveInterpFunction::Polynomial:
+			out = kframe->param2 > 0.0f ? powf(t, kframe->param1) : (1 - powf(1 - t, kframe->param1));
+			return kframe->pos.y + out * (next_pos->y - kframe->pos.y);
+		case CurveInterpFunction::Circular:
+			out = kframe->param2 > 0.0f ? 1.0f - sqrtf(1 - powf(t, 2.0f)) : sqrtf(1.0f - powf(t - 1.0f, 2.0f));
+			return kframe->pos.y + out * (next_pos->y - kframe->pos.y);
+		case CurveInterpFunction::Curve:
+			// add 0.5 to ensure this behaves like rounding
+			out = Curves[(int)(kframe->param1 + 0.5f)].GetValue(t);
+			return kframe->pos.y + out * (next_pos->y - kframe->pos.y);
+		default:
+			UNREACHABLE("Unrecognized curve function");
+			return 0.0f;
+	}
+}

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -1,11 +1,3 @@
-/*
- * Copyright (C) Volition, Inc. 1999.  All rights reserved.
- *
- * All source code herein is the property of Volition, Inc. You may not sell 
- * or otherwise commercially exploit the source or things you created based on the 
- * source.
- *
-*/ 
 
 #include "math/curve.h"
 #include "parse/parselo.h"

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -12,9 +12,9 @@
 
 SCP_vector<Curve> Curves;
 
-int curve_get_by_name(SCP_string in_name) {
+int curve_get_by_name(SCP_string& in_name) {
 	for (int i = 0; i < (int)Curves.size(); i++) {
-		if (Curves[i].name == in_name)
+		if (SCP_string_lcase_equal_to()(Curves[i].name, in_name))
 			return i;
 	}
 
@@ -27,7 +27,7 @@ void parse_curve_table(const char* filename) {
 		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
 
-		optional_string("#Curves");
+		required_string("#Curves");
 
 		while (optional_string("$Name:")) {
 			SCP_string name;
@@ -112,7 +112,7 @@ void curves_init() {
 
 Curve::Curve(SCP_string in_name)
 {
-	name = in_name;
+	name = std::move(in_name);
 }
 
 void Curve::ParseData()

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) Volition, Inc. 1999.  All rights reserved.
+ *
+ * All source code herein is the property of Volition, Inc. You may not sell 
+ * or otherwise commercially exploit the source or things you created based on the 
+ * source.
+ *
+*/ 
+
+
+#include "math/vecmat.h"
+
+enum class CurveInterpFunction {
+	Constant,
+	Linear,
+	Polynomial,
+	Circular,
+	Curve,
+};
+
+struct curve_keyframe {
+	vec2d pos;
+	CurveInterpFunction interp_func;
+	float param1; // degree for polynomials, integer index for curves
+	float param2; // > 0 for "ease in", < 0 for "ease out" on polynomials and circular
+};
+
+class Curve {
+public :
+	SCP_string	name;
+	SCP_vector<curve_keyframe>		keyframes;
+
+public :
+	// constructor
+	Curve(SCP_string in_name);
+
+	//Get
+	float GetValue(float x_val);
+
+	//Set
+	void ParseData();
+};
+
+extern SCP_vector<Curve> Curves;
+
+extern int curve_get_by_name(SCP_string in_name);
+extern void curves_init();
+

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -43,6 +43,6 @@ public :
 
 extern SCP_vector<Curve> Curves;
 
-extern int curve_get_by_name(SCP_string in_name);
+extern int curve_get_by_name(SCP_string& in_name);
 extern void curves_init();
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3105,6 +3105,13 @@ void stuff_float_list(SCP_vector<float>& flp)
 		}, "float");
 }
 
+//	Stuff a vec2d struct, which is 2 floats.
+void stuff_vec2d(vec2d* vp)
+{
+	stuff_float(&vp->x);
+	stuff_float(&vp->y);
+}
+
 //	Stuff a vec3d struct, which is 3 floats.
 void stuff_vec3d(vec3d *vp)
 {
@@ -3120,6 +3127,26 @@ void stuff_angles_deg_phb(angles* ap) {
 	ap->p = fl_radians(ap->p);
 	ap->h = fl_radians(ap->h);
 	ap->b = fl_radians(ap->b);
+}
+
+void stuff_parenthesized_vec2d(vec2d* vp)
+{
+	ignore_white_space();
+
+	if (*Mp != '(') {
+		error_display(1, "Reading parenthesized vec2d.  Found [%c].  Expected '('.\n", *Mp);
+		throw parse::ParseException("Syntax error");
+	}
+	else {
+		Mp++;
+		stuff_vec2d(vp);
+		ignore_white_space();
+		if (*Mp != ')') {
+			error_display(1, "Reading parenthesized vec2d.  Found [%c].  Expected ')'.\n", *Mp);
+			throw parse::ParseException("Syntax error");
+		}
+		Mp++;
+	}
 }
 
 void stuff_parenthesized_vec3d(vec3d *vp)

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -231,6 +231,7 @@ extern void stuff_float_list(SCP_vector<float>& flp);
 extern size_t stuff_vec3d_list(vec3d *vlp, size_t max_vecs);
 extern void stuff_vec3d_list(SCP_vector<vec3d> &vec_list);
 extern size_t stuff_bool_list(bool *blp, size_t max_bools);
+extern void stuff_vec2d(vec2d* vp);
 extern void stuff_vec3d(vec3d *vp);
 extern void stuff_matrix(matrix *mp);
 extern void stuff_angles_deg_phb(angles* vp);
@@ -241,6 +242,7 @@ extern void find_and_stuff_or_add(const char *id, int *addr, int f_type, char *s
 	int max, const char *description);
 extern int get_string(char *str, int max = -1);
 extern void get_string(SCP_string &str);
+extern void stuff_parenthesized_vec2d(vec2d* vp);
 extern void stuff_parenthesized_vec3d(vec3d *vp);
 extern void stuff_boolean(int *i, bool a_to_eol=true);
 extern void stuff_boolean(bool *b, bool a_to_eol=true);

--- a/code/particle/particle.h
+++ b/code/particle/particle.h
@@ -75,6 +75,8 @@ namespace particle
 		bool reverse = false;					// play any animations in reverse
 		bool lifetime_from_animation = true;	// if the particle plays an animation then use the anim length for the particle life
 		float length = 0.f;						// if set, makes the particle render like a laser, oriented along its path
+		int size_lifetime_curve = -1;			// a curve idx for size over lifetime, if applicable
+		int vel_lifetime_curve = -1;			// a curve idx for velocity over lifetime, if applicable
 	} particle_info;
 
 	typedef struct particle {
@@ -95,6 +97,8 @@ namespace particle
 		bool	reverse;			// play any animations in reverse
 		int		particle_index;		// used to keep particle offset in dynamic array for orient usage
 		float   length;				// the length of the particle for laser-style rendering
+		int		size_lifetime_curve;// a curve idx for size over lifetime, if applicable
+		int vel_lifetime_curve;		// a curve idx for velocity over lifetime, if applicable
 	} particle;
 
 	typedef std::weak_ptr<particle> WeakParticlePtr;

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -3,10 +3,11 @@
 #include "particle/ParticleManager.h"
 
 #include "bmpman/bmpman.h"
+#include "math/curve.h"
 
 namespace particle {
 namespace util {
-ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f), m_length (0.0f){
+ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f), m_length (0.0f), m_size_lifetime_curve (-1){
 }
 
 void ParticleProperties::parse(bool nocreate) {
@@ -33,6 +34,26 @@ void ParticleProperties::parse(bool nocreate) {
 			m_lifetime = ::util::parseUniformRange<float>();
 		}
 	}
+
+	if (optional_string("+Size over lifetime curve:")) {
+		SCP_string buf;
+		stuff_string(buf, F_NAME);
+		m_size_lifetime_curve = curve_get_by_name(buf);
+
+		if (m_size_lifetime_curve < 0) {
+			Warning(LOCATION, "Could not find curve '%s'", buf.c_str());
+		}
+	}
+
+	if (optional_string("+Velocity scalar over lifetime curve:")) {
+		SCP_string buf;
+		stuff_string(buf, F_NAME);
+		m_vel_lifetime_curve = curve_get_by_name(buf);
+
+		if (m_vel_lifetime_curve < 0) {
+			Warning(LOCATION, "Could not find curve '%s'", buf.c_str());
+		}
+	}
 }
 
 int ParticleProperties::chooseBitmap()
@@ -52,6 +73,8 @@ void ParticleProperties::createParticle(particle_info& info) {
 		info.lifetime = m_lifetime.next();
 		info.lifetime_from_animation = false;
 	}
+	info.size_lifetime_curve = m_size_lifetime_curve;
+	info.vel_lifetime_curve = m_vel_lifetime_curve;
 
 	create(&info);
 }
@@ -61,6 +84,8 @@ WeakParticlePtr ParticleProperties::createPersistentParticle(particle_info& info
 	info.type = PARTICLE_BITMAP;
 	info.rad = m_radius.next();
 	info.length = m_length.next();
+	info.size_lifetime_curve = m_size_lifetime_curve;
+	info.vel_lifetime_curve = m_vel_lifetime_curve;
 
 	auto p = createPersistent(&info);
 

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -24,10 +24,11 @@ private:
 	SCP_vector<int> m_bitmap_list;
 	::util::UniformRange<size_t> m_bitmap_range;
 	::util::UniformFloatRange m_radius;
-
 	bool m_hasLifetime = false;
 	::util::UniformFloatRange m_lifetime;
 	::util::UniformFloatRange m_length;
+	int m_size_lifetime_curve;
+	int m_vel_lifetime_curve;
 
 	ParticleProperties();
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -749,6 +749,8 @@ add_file_folder("Localization"
 
 # Math files
 add_file_folder("Math"
+	math/curve.cpp
+	math/curve.h
 	math/bitarray.h
 	math/fix.cpp
 	math/fix.h
@@ -756,8 +758,8 @@ add_file_folder("Math"
 	math/floating.h
 	math/fvi.cpp
 	math/fvi.h
-        math/ik_solver.cpp
-        math/ik_solver.h
+	math/ik_solver.cpp
+	math/ik_solver.h
 	math/spline.cpp
 	math/spline.h
 	math/staticrand.cpp

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -90,6 +90,7 @@
 #include "lighting/lighting_profiles.h"
 #include "localization/localize.h"
 #include "math/staticrand.h"
+#include "math/curve.h"
 #include "menuui/barracks.h"
 #include "menuui/credits.h"
 #include "menuui/mainhallmenu.h"
@@ -1866,6 +1867,7 @@ void game_init()
 		bm_set_low_mem(0);		// Use all frames of bitmaps
 	}
 	
+	curves_init();
 	particle::ParticleManager::init();
 
 	iff_init();						// Goober5000 - this must be done even before species_defs :p


### PR DESCRIPTION
Essentially, allows for modders to define arbitrary functions, using piece-wise components, made from polynomial, circular or previously defined functions. We can then apply those functions to map values in a wide-variety of domains and applications. For simplicity of the initial commit, just two applications are added here, particle +Size over lifetime and particle +Velocity scalar over lifetime.

```
$Name: test1
$KeyFrames:
(0, 1): Polynomial, 2, true
(1, 0): Constant

$Name: test2
$KeyFrames:
(0, 0): Circular
(0.5, 1): EaseInQuad    ; a built-in curve
(1, 0): Constant
```

Closes #3045 
