### PR TITLE
convert hotkey types to enum

### DIFF
--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -1171,6 +1171,9 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 				case HotkeyLineType::SUBSHIP:
 					hotkeys = get_ship_hotkeys(Selected_line);
 					break;
+
+				default:
+					break;
 			}
 
 			if (hotkeys != -1) {

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -506,7 +506,7 @@ int get_ship_hotkeys(int n)
 }
 
 // add a line of hotkey smuck to end of list
-int hotkey_line_add(const char *text, int type, int index, int y)
+int hotkey_line_add(const char *text, HotkeyLineType type, int index, int y)
 {
 	if (Num_lines >= MAX_LINES)
 		return 0;
@@ -519,7 +519,7 @@ int hotkey_line_add(const char *text, int type, int index, int y)
 }
 
 // insert a line of hotkey smuck before line 'n'.
-int hotkey_line_insert(int n, const char *text, int type, int index)
+int hotkey_line_insert(int n, const char *text, HotkeyLineType type, int index)
 {
 
 	if (Num_lines >= MAX_LINES)
@@ -539,18 +539,18 @@ int hotkey_line_insert(int n, const char *text, int type, int index)
 
 // insert a line of hotkey smuck somewhere between 'start' and end of list such that it is
 // sorted by name
-int hotkey_line_add_sorted(const char *text, int type, int index, int start)
+int hotkey_line_add_sorted(const char *text, HotkeyLineType type, int index, int start)
 {
 
 	if (Num_lines >= MAX_LINES)
 		return -1;
 
 	int z = Num_lines - 1;
-	while ((z >= start) && ((Hotkey_lines[z].type == HOTKEY_LINE_SUBSHIP) || (stricmp(text, Hotkey_lines[z].label.c_str()) < 0)))
+	while ((z >= start) && ((Hotkey_lines[z].type == HotkeyLineType::SUBSHIP) || (stricmp(text, Hotkey_lines[z].label.c_str()) < 0)))
 		z--;
 
 	z++;
-	while ((z < Num_lines) && (Hotkey_lines[z].type == HOTKEY_LINE_SUBSHIP))
+	while ((z < Num_lines) && (Hotkey_lines[z].type == HotkeyLineType::SUBSHIP))
 		z++;
 
 	return hotkey_line_insert(z, text, type, index);
@@ -575,7 +575,7 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 		hotkey_team = IFF_hotkey_team::Friendly;
 	}
 
-	hotkey_line_add(str, HOTKEY_LINE_HEADING, 0, y);
+	hotkey_line_add(str, HotkeyLineType::HEADING, 0, y);
 	y += 2;
 
 	int start = Num_lines;
@@ -623,7 +623,7 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 
 		// add it if the teams match or if the IFF says to
 		if (add_it) {
-			hotkey_line_add_sorted(shipp->get_display_name(), HOTKEY_LINE_SHIP, shipnum, start);
+			hotkey_line_add_sorted(shipp->get_display_name(), HotkeyLineType::SHIP, shipnum, start);
 		}
 	}
 
@@ -674,12 +674,12 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 			strcpy_s(wing_name, Wings[i].name);
 			end_string_at_first_hash_symbol(wing_name);
 
-			int z = hotkey_line_add_sorted(wing_name, HOTKEY_LINE_WING, i, start);
+			int z = hotkey_line_add_sorted(wing_name, HotkeyLineType::WING, i, start);
 			if (Wings[i].flags[Ship::Wing_Flags::Expanded]) {
 				for (j=0; j<Wings[i].current_count; j++) {
 					int s = Wings[i].ship_index[j];
 					if (!Ships[s].is_dying_or_departing()) {
-						z = hotkey_line_insert(z + 1, Ships[s].get_display_name(), HOTKEY_LINE_SUBSHIP, s);
+						z = hotkey_line_insert(z + 1, Ships[s].get_display_name(), HotkeyLineType::SUBSHIP, s);
 					}
 				}
 			}
@@ -696,7 +696,7 @@ int hotkey_build_team_listing(int enemy_team_mask, int y, bool list_enemies)
 	int font_height = gr_get_font_height();
 
 	for (int i=start; i<Num_lines; i++) {
-		if (Hotkey_lines[i].type == HOTKEY_LINE_SUBSHIP)
+		if (Hotkey_lines[i].type == HotkeyLineType::SUBSHIP)
 			y += font_height;
 		else
 			y += font_height + 2;
@@ -742,7 +742,7 @@ void hotkey_scroll_screen_up()
 	if (Scroll_offset) {
 		Scroll_offset--;
 		Assert(Selected_line > Scroll_offset);
-		while (!hotkey_line_query_visible(Selected_line) || (Hotkey_lines[Selected_line].type == HOTKEY_LINE_HEADING))
+		while (!hotkey_line_query_visible(Selected_line) || (Hotkey_lines[Selected_line].type == HotkeyLineType::HEADING))
 			Selected_line--;
 
 		gamesnd_play_iface(InterfaceSounds::SCROLL);
@@ -755,7 +755,7 @@ void hotkey_scroll_line_up()
 {
 	if (Selected_line > 1) {
 		Selected_line--;
-		while (Hotkey_lines[Selected_line].type == HOTKEY_LINE_HEADING)
+		while (Hotkey_lines[Selected_line].type == HotkeyLineType::HEADING)
 			Selected_line--;
 
 		if (Selected_line < Scroll_offset)
@@ -771,7 +771,7 @@ void hotkey_scroll_screen_down()
 {
 	if (Hotkey_lines[Num_lines - 1].y + gr_get_font_height() > Hotkey_lines[Scroll_offset].y + Hotkey_list_coords[gr_screen.res][3]) {
 		Scroll_offset++;
-		while (!hotkey_line_query_visible(Selected_line) || (Hotkey_lines[Selected_line].type == HOTKEY_LINE_HEADING)) {
+		while (!hotkey_line_query_visible(Selected_line) || (Hotkey_lines[Selected_line].type == HotkeyLineType::HEADING)) {
 			Selected_line++;
 			Assert(Selected_line < Num_lines);
 		}
@@ -786,7 +786,7 @@ void hotkey_scroll_line_down()
 {
 	if (Selected_line < Num_lines - 1) {
 		Selected_line++;
-		while (Hotkey_lines[Selected_line].type == HOTKEY_LINE_HEADING)
+		while (Hotkey_lines[Selected_line].type == HotkeyLineType::HEADING)
 			Selected_line++;
 
 		Assert(Selected_line > Scroll_offset);
@@ -801,7 +801,7 @@ void hotkey_scroll_line_down()
 
 void expand_wing(int line, bool forceExpand)
 {
-	if (Hotkey_lines[line].type == HOTKEY_LINE_WING) {
+	if (Hotkey_lines[line].type == HotkeyLineType::WING) {
 		int i = Hotkey_lines[line].index;
 		if (forceExpand) {
 			Wings[i].flags.set(Ship::Wing_Flags::Expanded);
@@ -810,7 +810,7 @@ void expand_wing(int line, bool forceExpand)
 		}
 		hotkey_build_listing();
 		for (int z=0; z<Num_lines; z++)
-			if ((Hotkey_lines[z].type == HOTKEY_LINE_WING) && (Hotkey_lines[z].index == i)) {
+			if ((Hotkey_lines[z].type == HotkeyLineType::WING) && (Hotkey_lines[z].index == i)) {
 				Selected_line = z;
 				break;
 			}
@@ -838,15 +838,15 @@ void reset_hotkeys()
 
 void clear_hotkeys(int line)
 {
-	int z = Hotkey_lines[line].type;
+	auto type = Hotkey_lines[line].type;
 
-	if (z == HOTKEY_LINE_WING) {
-		z = Hotkey_lines[line].index;
+	if (type == HotkeyLineType::WING) {
+		int z = Hotkey_lines[line].index;
 		int b = ~get_wing_hotkeys(line);
 		for (int i=0; i<Wings[z].current_count; i++)
 			Hotkey_bits[Wings[z].ship_index[i]] &= b;
 
-	} else if ((z == HOTKEY_LINE_SHIP) || (z == HOTKEY_LINE_SUBSHIP)) {
+	} else if ((type == HotkeyLineType::SHIP) || (type == HotkeyLineType::SUBSHIP)) {
 		Hotkey_bits[Hotkey_lines[line].index] = 0;
 	}
 }
@@ -869,28 +869,28 @@ void save_hotkeys()
 
 void add_hotkey(int hotkey, int line)
 {
-	int z = Hotkey_lines[line].type;
+	auto type = Hotkey_lines[line].type;
 
-	if (z == HOTKEY_LINE_WING) {
-		z = Hotkey_lines[line].index;
+	if (type == HotkeyLineType::WING) {
+		int z = Hotkey_lines[line].index;
 		for (int i=0; i<Wings[z].current_count; i++)
 			Hotkey_bits[Wings[z].ship_index[i]] |= (1 << hotkey);
 
-	} else if ((z == HOTKEY_LINE_SHIP) || (z == HOTKEY_LINE_SUBSHIP)) {
+	} else if ((type == HotkeyLineType::SHIP) || (type == HotkeyLineType::SUBSHIP)) {
 		Hotkey_bits[Hotkey_lines[line].index] |= (1 << hotkey);
 	}
 }
 
 void remove_hotkey(int hotkey, int line)
 {
-	int z = Hotkey_lines[line].type;
+	auto type = Hotkey_lines[line].type;
 
-	if (z == HOTKEY_LINE_WING) {
-		z = Hotkey_lines[line].index;
+	if (type == HotkeyLineType::WING) {
+		int z = Hotkey_lines[line].index;
 		for (int i=0; i<Wings[z].current_count; i++)
 			Hotkey_bits[Wings[z].ship_index[i]] &= ~(1 << hotkey);
 
-	} else if ((z == HOTKEY_LINE_SHIP) || (z == HOTKEY_LINE_SUBSHIP)) {
+	} else if ((type == HotkeyLineType::SHIP) || (type == HotkeyLineType::SUBSHIP)) {
 		Hotkey_bits[Hotkey_lines[line].index] &= ~(1 << hotkey);
 	}
 }
@@ -1163,12 +1163,12 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 			Selected_line = i + Scroll_offset;
 			int hotkeys = -1;
 			switch (Hotkey_lines[Selected_line].type) {
-				case HOTKEY_LINE_WING:
+				case HotkeyLineType::WING:
 					hotkeys = get_wing_hotkeys(Selected_line);
 					break;
 
-				case HOTKEY_LINE_SHIP:
-				case HOTKEY_LINE_SUBSHIP:
+				case HotkeyLineType::SHIP:
+				case HotkeyLineType::SUBSHIP:
 					hotkeys = get_ship_hotkeys(Selected_line);
 					break;
 			}
@@ -1215,7 +1215,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 		int width = 0;
 
 		switch (Hotkey_lines[line].type) {
-			case HOTKEY_LINE_HEADING:
+			case HotkeyLineType::HEADING:
 				gr_set_color_fast(&Color_text_heading);
 
 				gr_get_string_size(&w, &h, Hotkey_lines[line].label.c_str());
@@ -1224,7 +1224,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 				gr_line(Hotkey_ship_x[gr_screen.res] + w + 1, width, Hotkey_list_coords[gr_screen.res][0] + Hotkey_list_coords[gr_screen.res][2], width, GR_RESIZE_MENU);
 				break;
 
-			case HOTKEY_LINE_WING:
+			case HotkeyLineType::WING:
 				gr_set_bitmap(Wing_bmp);
 				bm_get_info(Wing_bmp, nullptr, &h, nullptr);
 				width = y + font_height / 2 - h / 2 - 1;
@@ -1243,8 +1243,8 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 				hotkeys = get_wing_hotkeys(line);
 				break;
 
-			case HOTKEY_LINE_SHIP:
-			case HOTKEY_LINE_SUBSHIP:
+			case HotkeyLineType::SHIP:
+			case HotkeyLineType::SUBSHIP:
 				hotkeys = get_ship_hotkeys(line);
 				break;
 
@@ -1252,7 +1252,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 				Int3();
 		}
 
-		if (Hotkey_lines[line].type != HOTKEY_LINE_HEADING) {
+		if (Hotkey_lines[line].type != HotkeyLineType::HEADING) {
 			Assert( (line - Scroll_offset) < LIST_BUTTONS_MAX );
 			List_buttons[line - Scroll_offset].update_dimensions(Hotkey_list_coords[gr_screen.res][0], y, Hotkey_list_coords[gr_screen.res][0] + Hotkey_list_coords[gr_screen.res][2] - Hotkey_list_coords[gr_screen.res][0], font_height);
 			List_buttons[line - Scroll_offset].enable();
@@ -1298,7 +1298,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 	
 		// draw ship/wing name
 		strcpy_s(buf, Hotkey_lines[line].label.c_str());
-		if (Hotkey_lines[line].type == HOTKEY_LINE_SUBSHIP) {
+		if (Hotkey_lines[line].type == HotkeyLineType::SUBSHIP) {
 			// indent
 			font::force_fit_string(buf, 255, Hotkey_list_coords[gr_screen.res][0] + Hotkey_list_coords[gr_screen.res][2] - (Hotkey_ship_x[gr_screen.res]+20));
 			gr_printf_menu(Hotkey_ship_x[gr_screen.res]+20, y, "%s", buf);

--- a/code/mission/missionhotkey.h
+++ b/code/mission/missionhotkey.h
@@ -17,14 +17,18 @@
 #define MAX_LINES MAX_SHIPS // retail was 200, bump it to match MAX_SHIPS
 
 // Types of items that can be in the hotkey list
-#define HOTKEY_LINE_HEADING 1
-#define HOTKEY_LINE_WING 2
-#define HOTKEY_LINE_SHIP 3
-#define HOTKEY_LINE_SUBSHIP 4 // ship that is in a wing
+enum class HotkeyLineType
+{
+	NONE = 0,
+	HEADING,
+	WING,
+	SHIP,
+	SUBSHIP,
+};
 
 struct hotkey_line {
 	SCP_string label;
-	int type; // type 0 is an unused line
+	HotkeyLineType type; // NONE is an unused line
 	int index;
 	int y; // Y coordinate of line
 };

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1769,7 +1769,7 @@ ADE_FUNC(initHotkeysList,
 	// so lets expand every wing in the list and not try to handle it after that.
 	for (int i = 0; i < MAX_LINES; i++) {
 		auto item = Hotkey_lines[i];
-		if (item.type == HOTKEY_LINE_WING) {
+		if (item.type == HotkeyLineType::WING) {
 			expand_wing(i, true);
 		}
 	}
@@ -1851,7 +1851,7 @@ ADE_FUNC(__len, l_Hotkeys, nullptr, "The number of valid hotkey ships", "number"
 	// this is dumb, but whatever
 	for (int i = 0; i < MAX_LINES; i++) {
 		auto item = Hotkey_lines[i];
-		if (item.type == 0) {
+		if (item.type == HotkeyLineType::NONE) {
 			s = i;
 			break;
 		}

--- a/code/scripting/api/objs/enums.cpp
+++ b/code/scripting/api/objs/enums.cpp
@@ -154,6 +154,11 @@ const lua_enum_def_list Enumerations[] = {
 	{"RPC_RELIABLE", LE_RPC_RELIABLE, true},
 	{"RPC_ORDERED", LE_RPC_ORDERED, true},
 	{"RPC_UNRELIABLE", LE_RPC_UNRELIABLE, true},
+	{"HOTKEY_LINE_NONE", LE_HOTKEY_LINE_NONE, true},
+	{"HOTKEY_LINE_HEADING", LE_HOTKEY_LINE_HEADING, true},
+	{"HOTKEY_LINE_WING", LE_HOTKEY_LINE_WING, true},
+	{"HOTKEY_LINE_SHIP", LE_HOTKEY_LINE_SHIP, true},
+	{"HOTKEY_LINE_SUBSHIP", LE_HOTKEY_LINE_SUBSHIP, true},
 };
 
 const size_t Num_enumerations = sizeof(Enumerations) / sizeof(lua_enum_def_list);

--- a/code/scripting/api/objs/enums.h
+++ b/code/scripting/api/objs/enums.h
@@ -153,6 +153,11 @@ enum lua_enum : int32_t {
 	LE_RPC_RELIABLE,
 	LE_RPC_ORDERED,
 	LE_RPC_UNRELIABLE,
+	LE_HOTKEY_LINE_NONE, // the sequence and offsets of these five #defines should correspond to the HotkeyLineType enums
+	LE_HOTKEY_LINE_HEADING,
+	LE_HOTKEY_LINE_WING,
+	LE_HOTKEY_LINE_SHIP,
+	LE_HOTKEY_LINE_SUBSHIP,
 	ENUM_NEXT_INDEX,
 	ENUM_COMBINATION,
 	ENUM_INVALID

--- a/code/scripting/api/objs/missionhotkey.cpp
+++ b/code/scripting/api/objs/missionhotkey.cpp
@@ -59,23 +59,43 @@ ADE_VIRTVAR(Text, l_Hotkey, nullptr, "The text of this hotkey line", "string", "
 ADE_VIRTVAR(Type,
 	l_Hotkey,
 	nullptr,
-	"The type of this hotkey line. 0 for nothing, 1 for heading, 2 for wing, 3 for ship, 4 for ship in a wing",
-	"number",
+	"The type of this hotkey line: HOTKEY_LINE_NONE, HOTKEY_LINE_HEADING, HOTKEY_LINE_WING, HOTKEY_LINE_SHIP, or HOTKEY_LINE_SUBSHIP.",
+	"enumeration",
 	"The type")
 {
 	hotkey_h current;
+	lua_enum eh_idx = ENUM_INVALID;
+
 	if (!ade_get_args(L, "o", l_Hotkey.Get(&current))) {
 		return ADE_RETURN_NIL;
 	}
 	if (!current.isValid()) {
-		return ade_set_error(L, "i", 0);
+		return ade_set_error(L, "o", l_Enum.Set(enum_h(eh_idx)));
 	}
 
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "i", current.getLine()->type);
+	switch (current.getLine()->type) {
+		case HotkeyLineType::NONE:
+			eh_idx = LE_HOTKEY_LINE_NONE;
+			break;
+		case HotkeyLineType::HEADING:
+			eh_idx = LE_HOTKEY_LINE_HEADING;
+			break;
+		case HotkeyLineType::WING:
+			eh_idx = LE_HOTKEY_LINE_WING;
+			break;
+		case HotkeyLineType::SHIP:
+			eh_idx = LE_HOTKEY_LINE_SHIP;
+			break;
+		case HotkeyLineType::SUBSHIP:
+			eh_idx = LE_HOTKEY_LINE_SUBSHIP;
+			break;
+	}
+
+	return ade_set_args(L, "o", l_Enum.Set(enum_h(eh_idx)));
 }
 
 ADE_VIRTVAR(Keys,
@@ -96,7 +116,7 @@ ADE_VIRTVAR(Keys,
 	}
 
 	int hotkeys;
-	if (current.getLine()->type == HOTKEY_LINE_WING)
+	if (current.getLine()->type == HotkeyLineType::WING)
 		hotkeys = get_wing_hotkeys(current.getIndex()); // for wings
 	else
 		hotkeys = get_ship_hotkeys(current.getIndex()); // for everything else (there's mastercard)

--- a/code/scripting/api/objs/missionhotkey.cpp
+++ b/code/scripting/api/objs/missionhotkey.cpp
@@ -1,4 +1,5 @@
 #include "missionhotkey.h"
+#include "enums.h"
 
 #include "mission/missionhotkey.h"
 #include "playerman/player.h"
@@ -78,9 +79,6 @@ ADE_VIRTVAR(Type,
 	}
 
 	switch (current.getLine()->type) {
-		case HotkeyLineType::NONE:
-			eh_idx = LE_HOTKEY_LINE_NONE;
-			break;
 		case HotkeyLineType::HEADING:
 			eh_idx = LE_HOTKEY_LINE_HEADING;
 			break;
@@ -92,6 +90,10 @@ ADE_VIRTVAR(Type,
 			break;
 		case HotkeyLineType::SUBSHIP:
 			eh_idx = LE_HOTKEY_LINE_SUBSHIP;
+			break;
+		case HotkeyLineType::NONE:
+		default:
+			eh_idx = LE_HOTKEY_LINE_NONE;
 			break;
 	}
 


### PR DESCRIPTION
Here's a suggested followup to #5249.  This converts the hotkey type to an enum for improved type safety.  It also adds the corresponding Lua enums and adjusts the Type virtvar to return them.