### PR TITLE
Allow 0-Asteroid setups

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2454,6 +2454,10 @@ void asteroid_init()
 	// parse any modular tables
 	parse_modular_table("*-ast.tbm", asteroid_parse_tbl);
 
+	//No asteroids defined. Bail!
+	if (asteroid_list.empty())
+		return;
+
 	// now verify the asteroids were found and put them in the correct order
 	verify_asteroid_list();
 
@@ -2609,6 +2613,9 @@ void asteroid_target_closest_danger()
 
 void asteroid_page_in()
 {
+	if (Asteroid_info.empty())
+		return;
+
 	if (Asteroid_field.num_initial_asteroids > 0 ) {
 		int i, j, k;
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1331,6 +1331,11 @@ int brief_setup_closeup(brief_icon *bi, bool api_access)
 		break;
 
 	case ICON_ASTEROID_FIELD:
+		if(Asteroid_icon_closeup_model[0] == '\0') {
+			Error(LOCATION, "Tried to display an asteroid field icon, but no asteroids are available.");
+			break;
+		}
+
 		strcpy_s(pof_filename, Asteroid_icon_closeup_model);
 		if (Closeup_icon->closeup_label[0] == '\0') {
 			strcpy_s(Closeup_icon->closeup_label, XSTR("Asteroid", 431));

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1332,8 +1332,9 @@ int brief_setup_closeup(brief_icon *bi, bool api_access)
 
 	case ICON_ASTEROID_FIELD:
 		if(Asteroid_icon_closeup_model[0] == '\0') {
-			Error(LOCATION, "Tried to display an asteroid field icon, but no asteroids are available.");
-			break;
+			Warning(LOCATION, "Tried to display an asteroid field icon, but no asteroids are available.");
+			Closeup_icon = nullptr;
+			return -1;
 		}
 
 		strcpy_s(pof_filename, Asteroid_icon_closeup_model);


### PR DESCRIPTION
Implements part of #5255.
This allows for an asteroid table to be functionally empty, not requiring any asteroids to be set up.
Evidently, this will disallow the usage of asteroid fields, but some TC's may not need any, so allow these to set up without asteroids.