### PR TITLE
Add beam particles

### DIFF
--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -39,6 +39,20 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut) const {
 			offset = m_offset;
 			break;
 		}
+		case SourceOriginType::BEAM: {
+			auto beam = &Beams[m_origin.m_object.objp->instance];
+			*posOut = beam->last_start;
+			// randomly weighted towards the start
+			// proportion along the beam the beam stopped, of its total potential length
+			float dist_adjusted = vm_vec_dist(&beam->last_start, &beam->last_shot) / beam->range;
+			// randomly sample from the weighted distribution, excluding points beyond the last_shot
+			auto t = (1.0f - sqrtf(frand_range(powf(1.f - dist_adjusted, 2.0f), 1.0f)));
+			vec3d dir;
+			vm_vec_normalized_dir(&dir, &beam->last_shot, &beam->last_start);
+			*posOut += (dir * beam->range) * (t);
+			offset = m_offset;
+			break;
+		}
 		default: {
 			*posOut = vmd_zero_vector;
 			offset = m_offset;
@@ -55,6 +69,11 @@ void SourceOrigin::getHostOrientation(matrix* matOut) const {
 		break;
 	case SourceOriginType::PARTICLE:
 		vm_vector_2_matrix(matOut, &m_origin.m_particle.lock()->velocity, nullptr, nullptr);
+		break;
+	case SourceOriginType::BEAM:
+		vec3d vec = vmd_zero_vector;
+		vm_vec_normalized_dir(&vec, &Beams[m_origin.m_object.objp->instance].last_shot, &Beams[m_origin.m_object.objp->instance].last_start);
+		vm_vector_2_matrix(matOut, &vec, nullptr, nullptr);
 		break;
 	case SourceOriginType::VECTOR: // Intentional fall-through, plain vectors have no orientation
 	default:
@@ -74,6 +93,12 @@ void SourceOrigin::applyToParticleInfo(particle_info& info, bool allowRelative) 
 
 				info.pos = m_offset;
 				break;
+			}
+			case SourceOriginType::BEAM: {
+				// although the source has an 'attached object', this does not apply to particles it creates
+				info.attached_objnum = -1;
+				info.attached_sig = -1;
+				this->getGlobalPosition(&info.pos);
 			}
 			case SourceOriginType::PARTICLE: // Intentional fall-through
 			case SourceOriginType::VECTOR: // Intentional fall-through
@@ -124,6 +149,13 @@ void SourceOrigin::moveTo(vec3d* pos) {
 	m_origin.m_pos = *pos;
 }
 
+void SourceOrigin::moveToBeam(object* objp) {
+	Assertion(objp, "Invalid object pointer passed!");
+
+	m_originType = SourceOriginType::BEAM;
+	m_origin.m_object = object_h(objp);
+}
+
 void SourceOrigin::moveToObject(object* objp, vec3d* offset) {
 	Assertion(objp, "Invalid object pointer passed!");
 	Assertion(offset, "Invalid vector pointer passed!");
@@ -143,14 +175,15 @@ bool SourceOrigin::isValid() const {
 	switch (m_originType) {
 		case SourceOriginType::NONE:
 			return false;
-		case SourceOriginType::OBJECT: {
+		case SourceOriginType::OBJECT:
+		case SourceOriginType::BEAM: {
 			if (!m_origin.m_object.IsValid()) {
 				return false;
 			}
 
 			auto objp = m_origin.m_object.objp;
 
-			if (objp->type != OBJ_WEAPON) {
+			if (objp->type != OBJ_WEAPON && objp->type != OBJ_BEAM) {
 				// The following checks are only relevant for weapons
 				return true;
 			}
@@ -160,10 +193,14 @@ bool SourceOrigin::isValid() const {
 				return true;
 			}
 
-			weapon* wp = &Weapons[objp->instance];
-
 			// Make sure we stay in the same weapon state
-			return wp->weapon_state == m_weaponState;
+			if (objp->type == OBJ_BEAM) {
+				beam* bm = &Beams[objp->instance];
+				return bm->weapon_state == m_weaponState;
+			} else {
+				weapon* wp = &Weapons[objp->instance];
+				return wp->weapon_state == m_weaponState;
+			}
 		}
 		case SourceOriginType::PARTICLE:
 			return !m_origin.m_particle.expired();

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -42,14 +42,14 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut) const {
 		case SourceOriginType::BEAM: {
 			auto beam = &Beams[m_origin.m_object.objp->instance];
 			*posOut = beam->last_start;
-			// randomly weighted towards the start
+			// weight the random points towards the start linearly
 			// proportion along the beam the beam stopped, of its total potential length
 			float dist_adjusted = vm_vec_dist(&beam->last_start, &beam->last_shot) / beam->range;
 			// randomly sample from the weighted distribution, excluding points beyond the last_shot
 			auto t = (1.0f - sqrtf(frand_range(powf(1.f - dist_adjusted, 2.0f), 1.0f)));
 			vec3d dir;
 			vm_vec_normalized_dir(&dir, &beam->last_shot, &beam->last_start);
-			*posOut += (dir * beam->range) * (t);
+			*posOut += (dir * beam->range) * t;
 			offset = m_offset;
 			break;
 		}

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -63,6 +63,7 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut) const {
 	vm_vec_add2(posOut, &offset);
 }
 void SourceOrigin::getHostOrientation(matrix* matOut) const {
+	vec3d vec;
 	switch (m_originType) {
 	case SourceOriginType::OBJECT:
 		*matOut = m_origin.m_object.objp->orient;
@@ -71,7 +72,7 @@ void SourceOrigin::getHostOrientation(matrix* matOut) const {
 		vm_vector_2_matrix(matOut, &m_origin.m_particle.lock()->velocity, nullptr, nullptr);
 		break;
 	case SourceOriginType::BEAM:
-		vec3d vec = vmd_zero_vector;
+		vec = vmd_zero_vector;
 		vm_vec_normalized_dir(&vec, &Beams[m_origin.m_object.objp->instance].last_shot, &Beams[m_origin.m_object.objp->instance].last_start);
 		vm_vector_2_matrix(matOut, &vec, nullptr, nullptr);
 		break;

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -95,12 +95,7 @@ void SourceOrigin::applyToParticleInfo(particle_info& info, bool allowRelative) 
 				info.pos = m_offset;
 				break;
 			}
-			case SourceOriginType::BEAM: {
-				// although the source has an 'attached object', this does not apply to particles it creates
-				info.attached_objnum = -1;
-				info.attached_sig = -1;
-				this->getGlobalPosition(&info.pos);
-			}
+			case SourceOriginType::BEAM: // Intentional fall-through
 			case SourceOriginType::PARTICLE: // Intentional fall-through
 			case SourceOriginType::VECTOR: // Intentional fall-through
 			default: {

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -67,7 +67,7 @@ class SourceOrigin {
 	/**
 	 * @brief Gets the current, global position of the origin
 	 * 
-	 * Be aware for beam soruces this will give *random* points along its length
+	 * Be aware for beam sources this will give *random* points along its length
 	 * 
 	 * @param posOut The pointer where the location will be stored
 	 */

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -25,7 +25,7 @@ namespace particle {
 enum class SourceOriginType {
 	NONE, //!< Invalid origin
 	VECTOR, //!< World-space offset
-	BEAM,
+	BEAM, //!< A beam
 	OBJECT, //!< An object
 	PARTICLE //!< A particle
 };

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -25,6 +25,7 @@ namespace particle {
 enum class SourceOriginType {
 	NONE, //!< Invalid origin
 	VECTOR, //!< World-space offset
+	BEAM,
 	OBJECT, //!< An object
 	PARTICLE //!< A particle
 };
@@ -65,6 +66,9 @@ class SourceOrigin {
 
 	/**
 	 * @brief Gets the current, global position of the origin
+	 * 
+	 * Be aware for beam soruces this will give *random* points along its length
+	 * 
 	 * @param posOut The pointer where the location will be stored
 	 */
 	void getGlobalPosition(vec3d* posOut) const;
@@ -111,6 +115,12 @@ class SourceOrigin {
 	 * @param pos The world position
 	 */
 	void moveTo(vec3d* pos);
+
+	/**
+	 * @brief Moves the source to the specified beam object
+	 * @param objp The hosting beam
+	 */
+	void moveToBeam(object* objp);
 
 	/**
 	 * @brief Moves the source to the specified object with an offset

--- a/code/particle/ParticleSourceWrapper.cpp
+++ b/code/particle/ParticleSourceWrapper.cpp
@@ -74,6 +74,14 @@ namespace particle
 		{
 			source->getOrigin()->moveToObject(obj, d);
 		}
+	}	
+	
+	void ParticleSourceWrapper::moveToBeam(object* obj)
+	{
+		for (auto& source : m_sources)
+		{
+			source->getOrigin()->moveToBeam(obj);
+		}
 	}
 
 	void ParticleSourceWrapper::moveTo(vec3d* pos)

--- a/code/particle/ParticleSourceWrapper.h
+++ b/code/particle/ParticleSourceWrapper.h
@@ -51,6 +51,8 @@ namespace particle
 
 		void moveToObject(object* obj, vec3d* localPos);
 
+		void moveToBeam(object* obj);
+
 		void moveTo(vec3d* pos);
 
 		void setVelocity(vec3d* vel);

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -107,7 +107,7 @@ class GenericShapeEffect : public ParticleEffect {
 				object* b_obj = source->getOrigin()->getObjectHost();
 				float dist = vm_vec_dist(&Beams[b_obj->instance].last_start, &Beams[b_obj->instance].last_shot) / 1000.0f;
 				float km;
-				float remainder = modf(dist, &km);
+				float remainder = modff(dist, &km);
 				uint old_num = num;
 				num = (uint)(old_num * km); // multiply by the number of kilometers
 				num += (uint)(old_num * remainder); // try to add any remainders if we have more than 1 per kilometer

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -109,8 +109,8 @@ class GenericShapeEffect : public ParticleEffect {
 				float km;
 				float remainder = modf(dist, &km);
 				uint old_num = num;
-				num = (uint)(old_num * remainder); // try to add any remainders if we have more than 1 per kilometer
-				num += (uint)(old_num * km); // multiply by the number of kilometers
+				num = (uint)(old_num * km); // multiply by the number of kilometers
+				num += (uint)(old_num * remainder); // try to add any remainders if we have more than 1 per kilometer
 				// if we still have nothing let's give it one last shot
 				if (num < 1 && frand() < remainder * old_num)
 					num += 1;

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -35,8 +35,8 @@ namespace particle {
 					float km;
 					float remainder = modf(dist, &km);
 					uint old_num = num;
-					num = (uint)(old_num * remainder); // try to add any remainders if we have more than 1 per kilometer
-					num += (uint)(old_num * km); // multiply by the number of kilometers
+					num = (uint)(old_num * km); // multiply by the number of kilometers
+					num += (uint)(old_num * remainder); // try to add any remainders if we have more than 1 per kilometer
 					// if we still have nothing let's give it one last shot
 					if (num < 1 && frand() < remainder * old_num)
 						num += 1;

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -33,7 +33,7 @@ namespace particle {
 					object* b_obj = source->getOrigin()->getObjectHost();
 					float dist = vm_vec_dist(&Beams[b_obj->instance].last_start, &Beams[b_obj->instance].last_shot) / 1000.0f;
 					float km;
-					float remainder = modf(dist, &km);
+					float remainder = modff(dist, &km);
 					uint old_num = num;
 					num = (uint)(old_num * km); // multiply by the number of kilometers
 					num += (uint)(old_num * remainder); // try to add any remainders if we have more than 1 per kilometer

--- a/code/weapon/beam.h
+++ b/code/weapon/beam.h
@@ -25,6 +25,31 @@ struct obj_pair;
 struct beam_weapon_info;
 struct vec3d;
 
+enum class WeaponState : uint32_t
+{
+	INVALID,
+
+	// States for laser weapons
+	NORMAL, //!< For laser weapons that have only one state
+
+	// Missile states following
+	FREEFLIGHT, //!< The initial flight state where the missile is "unpowered"
+	IGNITION, //!< The moment when the missile comes out of free flight
+	HOMED_FLIGHT, //!< The missile is homing in on its target
+	UNHOMED_FLIGHT, //!< The missile does not currently target an object
+
+	// Beam states following
+	WARMUP, //!< The beam is charging up
+	FIRING, //!< The beam is firing, and there's a beam and everything
+	PAUSED, //!< The beam is technically firing, but it's in between bursts
+	WARMDOWN, //!< The beam is cooling down
+};
+struct WeaponStateHash {
+	size_t operator()(const WeaponState& state) const {
+		return static_cast<size_t>(state);
+	}
+};
+
 typedef enum class BeamType {
 	DIRECT_FIRE,	// unidirectional beam; used to be BEAM_TYPE_A
 	SLASHING,		// "slash" in one direction; used to be BEAM_TYPE_B
@@ -192,6 +217,8 @@ typedef struct beam {
 
 	bool rotates;					// type 5s only, determines whether it rotates
 	float type5_rot_speed;          // how fast it rotates if it does
+
+	WeaponState weapon_state;  
 } beam;
 
 extern std::array<beam, MAX_BEAMS> Beams;				// all beams

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -80,25 +80,6 @@ enum class LR_Objecttypes { LRO_SHIPS, LRO_WEAPONS };
 
 #define MAX_SPAWN_TYPES_PER_WEAPON 5
 
-enum class WeaponState : uint32_t
-{
-	INVALID,
-
-	// States for laser weapons
-	NORMAL, //!< For laser weapons that have only one state
-
-	// Missile states following
-	FREEFLIGHT, //!< The initial flight state where the missile is "unpowered"
-	IGNITION, //!< The moment when the missile comes out of free flight
-	HOMED_FLIGHT, //!< The missile is homing in on its target
-	UNHOMED_FLIGHT, //!< The missile does not currently target an object
-};
-struct WeaponStateHash {
-	size_t operator()(const WeaponState& state) const {
-		return static_cast<size_t>(state);
-	}
-};
-
 typedef struct weapon {
 	int		weapon_info_index;			// index into weapon_info array
 	int		objnum;							// object number for this weapon

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3021,6 +3021,16 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 		}
 
+		if (optional_string("+Firing Length Effect:")) {
+			auto effetIdx = particle::util::parseEffect(wip->name);
+			wip->state_effects.insert(std::make_pair(WeaponState::FIRING, effetIdx));
+		}
+
+		if (optional_string("+Paused Length Effect:")) {
+			auto effetIdx = particle::util::parseEffect(wip->name);
+			wip->state_effects.insert(std::make_pair(WeaponState::PAUSED, effetIdx));
+		}
+
 		if (optional_string("+Beam Flags:")) {
 			parse_string_flag_list(wip->b_info.flags, Beam_info_flags, Num_beam_info_flags, nullptr);
 		}


### PR DESCRIPTION
Adds a new `SourceOriginType` for particle sources corresponding to the entire length of a beam. All the special beam handling definitely... *chafes* a little with the framework, but I'm confident that if beams are to be done in the framework this is the best way to do it. Key here is that when asked for the origin's position, it gives random positions along its length, allowing all the existing shape and volume effects to otherwise work the same. 

The random distribution along its length is also biased towards the start of the beam, linearly decaying to 0 at its maximum range. This is done so that the distribution of particles essentially matches the opacity of the beam graphic itself, which also linearly decays to 0 towards its end.

Closes #3050