### PR TITLE
Flush empty cbrief voice filenames to "None"

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1545,6 +1545,10 @@ int CFred_mission_save::save_cmd_brief()
 		required_string_fred("$end_multi_text", "$Stage Text:");
 		parse_comments();
 
+		if (!drop_white_space(Cur_cmd_brief->stage[stage].ani_filename)[0]) {
+			strcpy_s(Cur_cmd_brief->stage[stage].ani_filename, "<default>");
+		}
+
 		required_string_fred("$Ani Filename:");
 		parse_comments();
 		fout(" %s", Cur_cmd_brief->stage[stage].ani_filename);

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1549,6 +1549,10 @@ int CFred_mission_save::save_cmd_brief()
 		parse_comments();
 		fout(" %s", Cur_cmd_brief->stage[stage].ani_filename);
 
+		if (!drop_white_space(Cur_cmd_brief->stage[stage].wave_filename)[0]) {
+			strcpy_s(Cur_cmd_brief->stage[stage].wave_filename, "None");
+		}
+
 		required_string_fred("+Wave Filename:", "$Ani Filename:");
 		parse_comments();
 		fout(" %s", Cur_cmd_brief->stage[stage].wave_filename);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1315,6 +1315,10 @@ int CFred_mission_save::save_cmd_brief()
 		required_string_fred("$end_multi_text", "$Stage Text:");
 		parse_comments();
 
+		if (!drop_white_space(Cur_cmd_brief->stage[stage].ani_filename)[0]) {
+			strcpy_s(Cur_cmd_brief->stage[stage].ani_filename, "<default>");
+		}
+
 		required_string_fred("$Ani Filename:");
 		parse_comments();
 		fout(" %s", Cur_cmd_brief->stage[stage].ani_filename);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1319,6 +1319,10 @@ int CFred_mission_save::save_cmd_brief()
 		parse_comments();
 		fout(" %s", Cur_cmd_brief->stage[stage].ani_filename);
 
+		if (!drop_white_space(Cur_cmd_brief->stage[stage].wave_filename)[0]) {
+			strcpy_s(Cur_cmd_brief->stage[stage].wave_filename, "None");
+		}
+
 		required_string_fred("+Wave Filename:", "$Ani Filename:");
 		parse_comments();
 		fout(" %s", Cur_cmd_brief->stage[stage].wave_filename);


### PR DESCRIPTION
Just like briefings and debriefs do, this way the user can just delete the field for the same effect.