### PR TITLE
check for whitespace between token and comma

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5120,11 +5120,9 @@ void parse_event(mission *pm)
 
 				if (optional_string("+Background Color:")) {
 					stuff_ubyte(&ea.r);
-					if (*Mp == ',')
-						Mp++;
+					check_first_non_whitespace_char(Mp, ',', &Mp);
 					stuff_ubyte(&ea.g);
-					if (*Mp == ',')
-						Mp++;
+					check_first_non_whitespace_char(Mp, ',', &Mp);
 					stuff_ubyte(&ea.b);
 				}
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5120,9 +5120,9 @@ void parse_event(mission *pm)
 
 				if (optional_string("+Background Color:")) {
 					stuff_ubyte(&ea.r);
-					check_first_non_whitespace_char(Mp, ',', &Mp);
+					check_first_non_grayspace_char(Mp, ',', &Mp);
 					stuff_ubyte(&ea.g);
-					check_first_non_whitespace_char(Mp, ',', &Mp);
+					check_first_non_grayspace_char(Mp, ',', &Mp);
 					stuff_ubyte(&ea.b);
 				}
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2448,6 +2448,53 @@ void debug_show_mission_text()
 		printf("%c", ch);
 }
 
+// Returns whether the first character encountered in str that is not whitespace is the character to look for.
+// If so, and if after_ch is non-nullptr, it will be set to point to the first character after the character to look for.
+bool check_first_non_whitespace_char(const char *str, char char_to_look_for, char **after_ch)
+{
+	auto active_ch = str;
+	while (true)
+	{
+		if (*active_ch == '\0')
+			return false;
+		if (!is_white_space(*active_ch))
+			break;
+		active_ch++;
+	}
+
+	if (*active_ch == char_to_look_for)
+	{
+		if (after_ch != nullptr)
+			*after_ch = const_cast<char*>(active_ch + 1);	// this is ugly, but strtof and strtod do the same thing
+		return true;
+	}
+
+	return false;
+}
+
+// Do the same thing for grayspace
+bool check_first_non_grayspace_char(const char *str, char char_to_look_for, char **after_ch)
+{
+	auto active_ch = str;
+	while (true)
+	{
+		if (*active_ch == '\0')
+			return false;
+		if (!is_gray_space(*active_ch))
+			break;
+		active_ch++;
+	}
+
+	if (*active_ch == char_to_look_for)
+	{
+		if (after_ch != nullptr)
+			*after_ch = const_cast<char*>(active_ch + 1);	// this is ugly, but strtof and strtod do the same thing
+		return true;
+	}
+
+	return false;
+}
+
 bool unexpected_numeric_char(char ch)
 {
 	return (ch != '\0') && (ch != ',') && (ch != ')') && !is_white_space(ch);
@@ -2490,11 +2537,8 @@ int stuff_float(float *f, bool optional)
 		error_display(1, "Expected float, found [%.32s].\n", next_tokens(true));
 	}
 
-	if (*Mp == ',')
-	{
+	if (check_first_non_whitespace_char(Mp, ',', &Mp))
 		comma = true;
-		Mp++;
-	}
 
 	if (optional && !success)
 		Mp = str_start;
@@ -2561,11 +2605,8 @@ int stuff_int(int *i, bool optional)
 		error_display(1, "Expected int, found [%.32s].\n", next_tokens(true));
 	}
 
-	if (*Mp == ',')
-	{
+	if (check_first_non_whitespace_char(Mp, ',', &Mp))
 		comma = true;
-		Mp++;
-	}
 
 	if (optional && !success)
 		Mp = str_start;
@@ -2632,11 +2673,8 @@ int stuff_long(long *l, bool optional)
 		error_display(1, "Expected long, found [%.32s].\n", next_tokens(true));
 	}
 
-	if (*Mp == ',')
-	{
+	if (check_first_non_whitespace_char(Mp, ',', &Mp))
 		comma = true;
-		Mp++;
-	}
 
 	if (optional && !success)
 		Mp = str_start;

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2835,7 +2835,7 @@ void stuff_ubyte(ubyte *i)
 }
 
 template <typename T, typename F>
-void stuff_token_list(SCP_vector<T> &list, F stuff_one_token, const char *type_as_string)
+void stuff_token_list(SCP_vector<T> &list, F stuff_one_token, const char *type_as_string, bool skip_comma = true)
 {
 	list.clear();
 
@@ -2848,30 +2848,24 @@ void stuff_token_list(SCP_vector<T> &list, F stuff_one_token, const char *type_a
 	}
 	Mp++;
 
-	ignore_white_space();
-
-	while (*Mp != ')')
+	while (!check_first_non_whitespace_char(Mp, ')', &Mp))
 	{
+		ignore_white_space();
+
 		T item;
 		if (stuff_one_token(&item))
 			list.push_back(std::move(item));
 
-		ignore_white_space();
-
-		if (*Mp == ',')
-		{
-			Mp++;
-			ignore_white_space();
-		}
+		if (skip_comma)
+			check_first_non_grayspace_char(Mp, ',', &Mp);
 	}
-	Mp++;
 }
 
 template <typename T, typename F>
-size_t stuff_token_list(T *listp, size_t list_max, F stuff_one_token, const char *type_as_string)
+size_t stuff_token_list(T *listp, size_t list_max, F stuff_one_token, const char *type_as_string, bool skip_comma = true)
 {
 	SCP_vector<T> list;
-	stuff_token_list(list, stuff_one_token, type_as_string);
+	stuff_token_list(list, stuff_one_token, type_as_string, skip_comma);
 
 	if (list_max < list.size())
 	{
@@ -3131,7 +3125,7 @@ size_t stuff_float_list(float* flp, size_t max_floats)
 	return stuff_token_list(flp, max_floats, [](float *f)->bool {
 		stuff_float(f);
 		return true;
-	}, "float");
+	}, "float", false);	// don't skip the comma in stuff_token_list because stuff_float also skips one
 }
 
 // ditto the above, but a vector of floats...
@@ -3140,7 +3134,7 @@ void stuff_float_list(SCP_vector<float>& flp)
 	stuff_token_list(flp, [](float* buf)->bool {
 		stuff_float(buf);
 		return true;
-		}, "float");
+	}, "float", false);	// don't skip the comma in stuff_token_list because stuff_float also skips one
 }
 
 //	Stuff a vec3d struct, which is 3 floats.

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2537,7 +2537,7 @@ int stuff_float(float *f, bool optional)
 		error_display(1, "Expected float, found [%.32s].\n", next_tokens(true));
 	}
 
-	if (check_first_non_whitespace_char(Mp, ',', &Mp))
+	if (check_first_non_grayspace_char(Mp, ',', &Mp))
 		comma = true;
 
 	if (optional && !success)
@@ -2605,7 +2605,7 @@ int stuff_int(int *i, bool optional)
 		error_display(1, "Expected int, found [%.32s].\n", next_tokens(true));
 	}
 
-	if (check_first_non_whitespace_char(Mp, ',', &Mp))
+	if (check_first_non_grayspace_char(Mp, ',', &Mp))
 		comma = true;
 
 	if (optional && !success)
@@ -2673,7 +2673,7 @@ int stuff_long(long *l, bool optional)
 		error_display(1, "Expected long, found [%.32s].\n", next_tokens(true));
 	}
 
-	if (check_first_non_whitespace_char(Mp, ',', &Mp))
+	if (check_first_non_grayspace_char(Mp, ',', &Mp))
 		comma = true;
 
 	if (optional && !success)

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -146,6 +146,8 @@ extern char* alloc_block(const char* startstr, const char* endstr, int extra_cha
 // the default string length if using the F_NAME case.
 extern char *stuff_and_malloc_string(int type, const char *terminators = nullptr);
 extern void stuff_malloc_string(char **dest, int type, const char *terminators = nullptr);
+extern bool check_first_non_whitespace_char(const char *str, char ch_to_look_for, char **after_ch = nullptr);
+extern bool check_first_non_grayspace_char(const char *str, char ch_to_look_for, char **after_ch = nullptr);
 extern int stuff_float(float *f, bool optional = false);
 extern int stuff_int(int *i, bool optional = false);
 extern int stuff_long(long *l, bool optional = false);


### PR DESCRIPTION
When parsing a list of numbers, such as in the $uvec or $fvec of models, a bug was reported where whitespace before the comma caused the number parsing to fail.  This change checks for a comma after whitespace instead of checking for a comma as the very next character.