### PR TITLE
Randomize particle rotation

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -139,6 +139,7 @@ bool Auto_assign_personas;
 bool Countermeasures_use_capacity;
 bool Play_thruster_sounds_for_player;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
+bool Randomize_particle_rotation;
 
 static auto DiscordOption = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
 							 .category("Other")
@@ -813,6 +814,10 @@ void parse_mod_table(const char *filename)
 			Warning(LOCATION, "The $Min draw distance must be strictly less than the $Max draw distance. Using default values for both.\n");
 			Min_draw_distance = Default_min_draw_distance;
 			Max_draw_distance = Default_max_draw_distance;
+		}
+
+		if (optional_string("$Randomize particle rotation:")) {
+			stuff_boolean(&Randomize_particle_rotation);
 		}
 
 		optional_string("#NETWORK SETTINGS");

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1398,6 +1398,7 @@ void mod_table_reset()
 			std::tuple<float, float>{ 1.0f, 1.0f },
 			std::tuple<float, float>{ 1.0f, 1.0f }
 		}};
+	Randomize_particle_rotation = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -135,6 +135,7 @@ extern bool Auto_assign_personas;
 extern bool Countermeasures_use_capacity;
 extern bool Play_thruster_sounds_for_player;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
+extern bool Randomize_particle_rotation;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -158,9 +158,9 @@ namespace particle
 		part->attached_objnum = info->attached_objnum;
 		part->attached_sig = info->attached_sig;
 		part->reverse = info->reverse;
-		part->particle_index = (int) Persistent_particles.size();
 		part->looping = false;
 		part->length = info->length;
+		part->angle = frand_range(0.0f, PI2);
 
 		switch (info->type)
 		{
@@ -474,7 +474,8 @@ namespace particle
 				batching_add_laser(framenum + cur_frame, &p0, part->radius, &p1, part->radius);
 			}
 			else {
-				batching_add_volume_bitmap(framenum + cur_frame, &pos, part->particle_index % 8, part->radius, alpha);
+				// it will subtract Physics_viewer_bank, so without the flah we counter that make it screen-aligned again
+				batching_add_volume_bitmap_rotated(framenum + cur_frame, &pos, Randomize_particle_rotation ? part->angle : Physics_viewer_bank, part->radius, alpha);
 			}
 
 

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -474,7 +474,7 @@ namespace particle
 				batching_add_laser(framenum + cur_frame, &p0, part->radius, &p1, part->radius);
 			}
 			else {
-				// it will subtract Physics_viewer_bank, so without the flah we counter that make it screen-aligned again
+				// it will subtract Physics_viewer_bank, so without the flag we counter that and make it screen-aligned again
 				batching_add_volume_bitmap_rotated(framenum + cur_frame, &pos, Randomize_particle_rotation ? part->angle : Physics_viewer_bank, part->radius, alpha);
 			}
 

--- a/code/particle/particle.h
+++ b/code/particle/particle.h
@@ -93,8 +93,8 @@ namespace particle
 		int		attached_objnum;	// if this is set, pos is relative to the attached object. velocity is ignored
 		int		attached_sig;		// to check for dead/nonexistent objects
 		bool	reverse;			// play any animations in reverse
-		int		particle_index;		// used to keep particle offset in dynamic array for orient usage
 		float   length;				// the length of the particle for laser-style rendering
+		float	angle;
 	} particle;
 
 	typedef std::weak_ptr<particle> WeakParticlePtr;


### PR DESCRIPTION
Still leaves room for more in-depth options later, but for now just a global flag. Also removes `particle_index` dunno wtf 'dynamic array usage' is about but it was used before for a janky random 90 degree rotation (which was also broken a few years ago)