### PR TITLE
tweak rank handling in Lua

### DIFF
--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -11,6 +11,7 @@
 #include "pilotfile/pilotfile.h"
 #include "playerman/player.h"
 #include "stats/medals.h"
+#include "scripting/api/objs/rank.h"
 #include "scripting/api/objs/shipclass.h"
 #include "scripting/lua/LuaTable.h"
 #include "ship/ship.h"
@@ -831,6 +832,29 @@ ADE_VIRTVAR(Medals,
 ADE_VIRTVAR(Rank,
 	l_ScoringStats,
 	nullptr, 
+	"Returns the player's current rank",
+	"rank",
+	"The current rank")
+{
+	scoring_stats_h* ssh;
+	if (!ade_get_args(L, "o", l_ScoringStats.GetPtr(&ssh))) {
+		return ADE_RETURN_NIL;
+	}
+	if (!ssh->isValid()) {
+		return ade_set_error(L, "o", l_Rank.Set(rank_h()));
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	int rank_index = verify_rank(ssh->get()->rank);
+	return ade_set_args(L, "o", l_Rank.Set(rank_h(rank_index)));
+}
+
+ADE_VIRTVAR(RankIndex,
+	l_ScoringStats,
+	nullptr, 
 	"Returns the player's rank as in index into Ranks",
 	"number",
 	"The rank index")
@@ -847,7 +871,8 @@ ADE_VIRTVAR(Rank,
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "i", verify_rank(ssh->get()->rank));
+	int rank_index = verify_rank(ssh->get()->rank);
+	return ade_set_args(L, "i", rank_index + 1); // Convert to Lua's 1 based index system
 }
 
 }

--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -852,29 +852,6 @@ ADE_VIRTVAR(Rank,
 	return ade_set_args(L, "o", l_Rank.Set(rank_h(rank_index)));
 }
 
-ADE_VIRTVAR(RankIndex,
-	l_ScoringStats,
-	nullptr, 
-	"Returns the player's rank as in index into Ranks",
-	"number",
-	"The rank index")
-{
-	scoring_stats_h* ssh;
-	if (!ade_get_args(L, "o", l_ScoringStats.GetPtr(&ssh))) {
-		return ADE_RETURN_NIL;
-	}
-	if (!ssh->isValid()) {
-		return ade_set_error(L, "i", 0);
-	}
-
-	if (ADE_SETTING_VAR) {
-		LuaError(L, "This property is read only.");
-	}
-
-	int rank_index = verify_rank(ssh->get()->rank);
-	return ade_set_args(L, "i", rank_index + 1); // Convert to Lua's 1 based index system
-}
-
 }
 }
 

--- a/code/scripting/api/objs/rank.cpp
+++ b/code/scripting/api/objs/rank.cpp
@@ -67,5 +67,22 @@ ADE_VIRTVAR(Bitmap, l_Rank, nullptr, "The bitmap of the rank", "string", "The bi
 	return ade_set_args(L, "s", current.getRank()->bitmap);
 }
 
+ADE_VIRTVAR(Index, l_Rank, nullptr, "The index of the rank within the Ranks list", "number", "The rank index")
+{
+	rank_h current;
+	if (!ade_get_args(L, "o", l_Rank.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+	if (!current.isValid()) {
+		return ade_set_error(L, "i", 0);
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "i", current.rank + 1); // Convert to Lua's 1 based index system
+}
+
 } // namespace api
 } // namespace scripting


### PR DESCRIPTION
Follow-up to #5280:

1. Make the Rank virtvar actually return a rank object, to be consistent with other Lua API methods
2. Add a RankIndex virtvar to replicate the previous functionality
3. Make RankIndex return the expected 1-based index for Lua

This is a breaking change to the API, but since the original API is less than a month old, the impact should be small.