### PR TITLE
Add debris density

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -374,6 +374,7 @@ MONITOR(NumHullDebris)
  * @param exp_center	Explosion center in global coordinates
  * @param hull_flag		Whether this debris is a chunk of a ship's hull (as opposed to shrapnel)
  * @param exp_force		Explosion force, used to assign velocity to pieces. 1.0f assigns velocity like before. 2.0f assigns twice as much to non-inherited part of velocity
+ * @param source_subsys	The subsystem this debris came from, if any
  */
 object *debris_create(object *source_obj, int model_num, int submodel_num, vec3d *pos, vec3d *exp_center, bool hull_flag, float exp_force, ship_subsys* source_subsys)
 {

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -71,13 +71,13 @@ void debris_delete( object * obj );
 void debris_process_post( object * obj, float frame_time);
 
 // Create debris, set velocity, and fire scripting hook
-object *debris_create( object *source_obj, int model_num, int submodel_num, vec3d *pos, vec3d *exp_center, bool hull_flag, float exp_force );
+object *debris_create( object *source_obj, int model_num, int submodel_num, vec3d *pos, vec3d *exp_center, bool hull_flag, float exp_force, ship_subsys* source_subsys = nullptr );
 
 // Create debris but don't do anything else
 object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_type_index, int team, float hull_strength, int spark_timeout, int model_num, int submodel_num, vec3d *pos, matrix *orient, bool hull_flag, bool vaporize, int damage_type_idx);
 
 // Set velocity after debris creation
-void debris_create_set_velocity(debris *db, ship *source_shipp, vec3d *exp_center, float exp_force);
+void debris_create_set_velocity(debris *db, ship *source_shipp, vec3d *exp_center, float exp_force, ship_subsys* source_subsys = nullptr);
 
 // Fire scripting hook after debris creation
 void debris_create_fire_hook(object *obj, object *source_obj);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -247,6 +247,8 @@ public:
 
 	actions::ProgramSet beam_warmdown_program;
 
+	float density;
+
     void reset();
 
     model_subsystem();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1002,6 +1002,7 @@ void ship_info::clone(const ship_info& other)
 	debris_damage_mult = other.debris_damage_mult;
 	debris_arc_percent = other.debris_arc_percent;
 	debris_gravity_const = other.debris_gravity_const;
+	debris_density = other.debris_density;
 	debris_ambient_sound = other.debris_ambient_sound;
 	debris_collision_sound_light = other.debris_collision_sound_light;
 	debris_collision_sound_heavy = other.debris_collision_sound_heavy;
@@ -1351,6 +1352,7 @@ void ship_info::move(ship_info&& other)
 	debris_damage_mult = other.debris_damage_mult;
 	debris_arc_percent = other.debris_arc_percent;
 	debris_gravity_const = other.debris_gravity_const;
+	debris_density = other.debris_density;
 	debris_ambient_sound = other.debris_ambient_sound;
 	debris_collision_sound_light = other.debris_collision_sound_light;
 	debris_collision_sound_heavy = other.debris_collision_sound_heavy;
@@ -1775,6 +1777,7 @@ ship_info::ship_info()
 	debris_damage_mult = 1.0f;
 	debris_arc_percent = 0.5f;
 	debris_gravity_const = 1.0f;
+	debris_density = 1.0f;
 	debris_ambient_sound = GameSounds::DEBRIS;
 	debris_collision_sound_light = gamesnd_id();
 	debris_collision_sound_heavy = gamesnd_id();
@@ -3303,6 +3306,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		} else if (first_time) {
 			sip->debris_gravity_const = sip->dying_gravity_const;
 		}
+
+		if (optional_string("+Debris Density"))
+			stuff_float(&sip->debris_density);
+
 		gamesnd_id ambient_snd, collision_snd_light, collision_snd_heavy, explosion_snd;
 		if (parse_game_sound("+Ambient Sound:", &ambient_snd))
 			sip->debris_ambient_sound = ambient_snd;
@@ -5079,6 +5086,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 				sp->turret_max_bomb_ownage = -1;
 				sp->turret_max_target_ownage = -1;
+				sp->density = 1.0f;
 			}
 			sfo_return = stuff_float_optional(&percentage_of_hits);
 			if(sfo_return==2)
@@ -5260,6 +5268,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 						Warning(LOCATION, "RoF multiplier not set for subsystem\n'%s' in %s '%s'.", sp->subobj_name, info_type_name, sip->name);
 					}
 				}
+			}
+
+			if (optional_string("$Debris Density:")) {
+				stuff_float(&sp->density);
 			}
 
 			if (optional_string("$Flags:")) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1219,6 +1219,7 @@ public:
 	float			debris_damage_mult;
 	float			debris_arc_percent;
 	float			debris_gravity_const;			// see gravity_const above
+	float			debris_density;
 	gamesnd_id		debris_ambient_sound;
 	gamesnd_id		debris_collision_sound_light;
 	gamesnd_id		debris_collision_sound_heavy;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -151,7 +151,7 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, ship *s
 		fireball_create(&end_world_pos, fireball_type, FIREBALL_MEDIUM_EXPLOSION, OBJ_INDEX(ship_objp), pm->submodel[live_debris_submodel].rad);
 
 		// create debris
-		live_debris_obj = debris_create(ship_objp, pm->id, live_debris_submodel, &end_world_pos, exp_center, 1, exp_mag);
+		live_debris_obj = debris_create(ship_objp, pm->id, live_debris_submodel, &end_world_pos, exp_center, 1, exp_mag, subsys);
 
 		// only do if debris is created
 		if (live_debris_obj) {


### PR DESCRIPTION
Just like ship density, allows for a ship class specific multiplier for debris mass and MOI, including subsystem debris-specific density.

Address the last point of #5278