### PR TITLE
Make restriction which ships accept Lua player orders configurable

### DIFF
--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -186,6 +186,24 @@ bool ai_lua_is_valid_target(int sexp_op, int target_objnum, ship* self, size_t o
 	return ai_lua_is_valid_target_lua(mode, target_objnum, self);
 }
 
+bool ai_lua_is_valid_ship(int sexp_op, bool isWing, ship* self)
+{
+	const player_order_lua& order = *ai_lua_find_player_order(sexp_op);
+
+	switch (order.shipRestrictions) {
+	case player_order_lua::ship_restrictions::ANY:
+		return true;
+	case player_order_lua::ship_restrictions::WING:
+		return isWing;
+	case player_order_lua::ship_restrictions::IN_PLAYER_WING:
+		return self->wingnum != -1 && Ships[Player_obj->instance].wingnum == self->wingnum;
+	case player_order_lua::ship_restrictions::PLAYER_WING:
+		return isWing && self->wingnum != -1 && Ships[Player_obj->instance].wingnum == self->wingnum;
+	}
+
+	return false;
+}
+
 ai_achievability ai_lua_is_achievable(const ai_goal* aigp, int objnum){
 	const auto& lua_ai = Lua_ai_modes.at(aigp->ai_submode);
 

--- a/code/ai/ailua.h
+++ b/code/ai/ailua.h
@@ -20,6 +20,7 @@ struct player_order_lua {
 	SCP_string parseText = "";
 	SCP_string displayText = "";
 	enum class target_restrictions : int { TARGET_ALLIES, TARGET_ALL, TARGET_OWN, TARGET_ENEMIES, TARGET_SAME_WING, TARGET_PLAYER_WING, TARGET_ALL_CAPS, TARGET_ALLIED_CAPS, TARGET_ENEMY_CAPS, TARGET_NOT_SELF } targetRestrictions = target_restrictions::TARGET_ALL;
+	enum class ship_restrictions : int { ANY, WING, IN_PLAYER_WING, PLAYER_WING } shipRestrictions = ship_restrictions::ANY;
 };
 
 
@@ -31,4 +32,5 @@ const player_order_lua* ai_lua_find_player_order(int sexp_op);
 void ai_lua(ai_info* aip);
 void ai_lua_start(ai_goal* aigp, object* objp);
 bool ai_lua_is_valid_target(int sexp_op, int target_objnum, ship* self, size_t order);
+bool ai_lua_is_valid_ship(int sexp_op, bool isWing, ship* self);
 ai_achievability ai_lua_is_achievable(const ai_goal* aigp, int objnum);

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -225,7 +225,7 @@ SCP_vector<squadmsg_history> Squadmsg_history;
 // forward declarations
 void hud_add_issued_order(const char *name, int order);
 void hud_update_last_order(const char *target, int order_source, int special_index);
-bool hud_squadmsg_is_target_order_valid(size_t order, ai_info *aip = nullptr);
+bool hud_squadmsg_is_target_order_valid(size_t order, ai_info *aip = nullptr, bool isWing = false);
 bool hud_squadmsg_ship_valid(ship *shipp, object *objp = nullptr);
 
 // function to set up variables needed when messaging mode is started
@@ -757,7 +757,7 @@ bool hud_squadmsg_ship_order_valid( int shipnum, int order )
 // returns true or false if the Players target is valid for the given order
 // find_order is true when we need to search the comm_orders array for the order entry.  We have
 // to do this action in some cases since all we know is the actual "value" of the order
-bool hud_squadmsg_is_target_order_valid(size_t order, ai_info *aip )
+bool hud_squadmsg_is_target_order_valid(size_t order, ai_info *aip, bool isWing )
 {
 	int target_objnum;
 	ship *shipp, *ordering_shipp;
@@ -771,7 +771,7 @@ bool hud_squadmsg_is_target_order_valid(size_t order, ai_info *aip )
 
 	//If it's a lua order, defer to luaai
 	if (Player_orders[order].lua_id != -1) {
-		return ai_lua_is_valid_target(Player_orders[order].lua_id, target_objnum, ordering_shipp, order);
+		return ai_lua_is_valid_ship(Player_orders[order].lua_id, isWing, ordering_shipp) && ai_lua_is_valid_target(Player_orders[order].lua_id, target_objnum, ordering_shipp, order);
 	}
 
 	// orders which don't operate on targets are always valid
@@ -1356,7 +1356,7 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 		message = MESSAGE_NO_TARGET;
 	}
 
-	if (hud_squadmsg_is_target_order_valid((size_t)command, ainfo)) {
+	if (hud_squadmsg_is_target_order_valid((size_t)command, ainfo, true)) {
 		target_shipname = nullptr;
 		target_team = -1;
 		if (ainfo->target_objnum != -1) {
@@ -2088,7 +2088,7 @@ void hud_squadmsg_wing_command()
 
 		// do some other checks to possibly gray out other items.
 		// if no target, remove any items which are associated with the players target
-		if ( !hud_squadmsg_is_target_order_valid((int)order_id, 0) )
+		if ( !hud_squadmsg_is_target_order_valid((int)order_id, 0, true) )
 			MsgItems[Num_menu_items].active = 0;
 
 		// if no ship in the wing can depart then gray out the departure order

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -158,6 +158,17 @@ void LuaAISEXP::parseTable() {
 			}
 		}
 
+		if (optional_string("+Ship Restrictions:")) {
+			int result = optional_string_one_of(4, "Any", "Wing", "On Player Wing", "Player Wing");
+			if (result == -1) {
+				error_display(0, "Unknown ship restriction for player order %s. Assuming \"	Any\".", order.displayText.c_str());
+				order.shipRestrictions = player_order_lua::ship_restrictions::ANY;
+			}
+			else {
+				order.shipRestrictions = static_cast<player_order_lua::ship_restrictions>(result);
+			}
+		}
+
 		if (optional_string("+Acknowledge Message:")) {
 			SCP_string message;
 			stuff_string(message, F_NAME);


### PR DESCRIPTION
This is the pendant to +Target Restriction: which can disable certain Lua AI orders for invalid targets, in that it disables giving Lua AI orders to certain ships.
Since this _should_ be done using objecttypes, this is more for context-sensitive AI orders that need finer control (such as orders that are only valid for the player's wingmates, or orders like formation flying which only make sense when given to a full wing and not just one ship)