### PR TITLE
Mark the nightly upload step as succesful as long as at least one mirror got the file

### DIFF
--- a/ci/linux/upload_dist_package.sh
+++ b/ci/linux/upload_dist_package.sh
@@ -10,9 +10,19 @@ HERE=$(dirname "$SCRIPT")
 source $HERE/dist_functions.sh
 
 if [ "$UPLOAD_TYPE" = "nightly" ]; then
-    SSHPASS=$INDIEGAMES_SSHPASS upload_files_to_sftp "$INDIEGAMES_USER@scp.indiegames.us" "public_html/builds/nightly"
+    any_success=false
+    if SSHPASS=$INDIEGAMES_SSHPASS upload_files_to_sftp "$INDIEGAMES_USER@scp.indiegames.us" "public_html/builds/nightly"; then
+        any_success=true
+    fi
 
-    SSHPASS=$DATACORDER_SSHPASS upload_files_to_sftp "$DATACORDER_USER@porphyrion.feralhosting.com" "www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly"
+    if SSHPASS=$DATACORDER_SSHPASS upload_files_to_sftp "$DATACORDER_USER@porphyrion.feralhosting.com" "www/datacorder.porphyrion.feralhosting.com/public_html/builds/nightly"; then
+        any_success=true
+    fi
+
+    if [ "$any_success" = "false" ]; then
+        echo "All uploads failed"
+        exit 1
+    fi
 elif [ "$UPLOAD_TYPE" = "test" ]; then
     SSHPASS=$DATACORDER_SSHPASS upload_files_to_sftp "$DATACORDER_USER@porphyrion.feralhosting.com" "www/datacorder.porphyrion.feralhosting.com/public_html/builds/test"
 else


### PR DESCRIPTION
We should post nightlies even if one mirror fails since it'll still be available on the other mirrors.
Unfortunately, the failed mirror will still be referenced in the forum post and Knossos will still try to download the nightly from the failed mirror but that's preferable to having no nightly at all. Forum users will just have to try both links and Knossos will try both mirrors anyway.

Due to the current server migration of scp.indiegames.us, the upload will fail but the download link will still work since it currently just redirects to the mirror (datacorder).