### PR TITLE
synchronize simulation timestamps across the entire frame

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -634,8 +634,8 @@ void timestamp_update_time_compression()
 	}
 
 	// grab the independent variable of the equation before we change anything
-	// (we need to take a new snapshot to get the accurate value, but this is ok
-	// since time compression is only updated at the start of the frame)
+	// (we need to get the live value to be accurate, which takes a new snapshot,
+	// but this is ok since time compression is only updated at the start of the frame)
 	auto timestamp_raw = timestamp_get_raw(true);
 
 	// we need to move the counter offset to make the raw timestamp zero (so that it can start ticking with a new multiplier)
@@ -649,6 +649,9 @@ void timestamp_update_time_compression()
 	// now we can set the new info
 	Timestamp_current_time_compression = Game_time_compression;
 	Timestamp_time_compression_multiplier = static_cast<float>(Game_time_compression) / F1_0;
+
+	// and now take a new snapshot so that the raw timestamp is correct for this frame
+	timestamp_get_raw(true);
 }
 
 // ======================================== mission-specific stuff ========================================

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -41,6 +41,9 @@ static bool Timestamp_sudo_paused = false;
 static uint64_t Timestamp_microseconds_at_mission_start = 0;
 
 
+static uint64_t timestamp_get_raw(bool start_frame = false);
+
+
 static uint64_t get_performance_counter()
 {
 	Assertion(Timer_inited, "This function can only be used when the timer system is initialized!");
@@ -73,6 +76,12 @@ void timer_init()
 
 		atexit(timer_close);
 	}
+}
+
+void timer_start_frame()
+{
+	// take a snapshot of the raw timestamp at the beginning of the frame
+	timestamp_get_raw(true);
 }
 
 // ======================================== getting time ========================================
@@ -129,15 +138,21 @@ std::uint64_t timer_get_nanoseconds()
     return static_cast<uint64_t>(time * Timer_to_nanoseconds);
 }
 
-static uint64_t timestamp_get_raw()
+static uint64_t timestamp_get_raw(bool start_frame)
 {
-	static uint64_t timestamp_raw;
-	if (Timestamp_is_paused) {
-		timestamp_raw = Timestamp_paused_at_counter;
-	} else {
-		timestamp_raw = get_performance_counter();
+	static uint64_t timestamp_raw = 0;
+
+	// The simulation timestamp is only updated at the beginning of the frame
+	// because we want all timestamps within a frame to be identical.
+	if (start_frame)
+	{
+		if (Timestamp_is_paused)
+			timestamp_raw = Timestamp_paused_at_counter;
+		else
+			timestamp_raw = get_performance_counter();
+
+		timestamp_raw -= Timestamp_offset_from_counter;
 	}
-	timestamp_raw -= Timestamp_offset_from_counter;
 
 	return timestamp_raw;
 }

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -121,7 +121,7 @@ int timer_get_milliseconds()
 		return 0;
 	}
 
-	return static_cast<int>(timer_get_microseconds() / 1000);
+	return static_cast<int>(timer_get_microseconds() / MICROSECONDS_PER_MILLISECOND);
 }
 
 std::uint64_t timer_get_microseconds()
@@ -163,7 +163,7 @@ static uint64_t timestamp_get_microseconds()
 }
 
 static int timestamp_ms() {
-	return static_cast<int>(timestamp_get_microseconds() / 1000);
+	return static_cast<int>(timestamp_get_microseconds() / MICROSECONDS_PER_MILLISECOND);
 }
 
 int timestamp() {
@@ -596,7 +596,7 @@ void timestamp_adjust_pause_offset(int delta_milliseconds)
 	if (Timestamp_offset_from_counter == 0) {
 		Timestamp_offset_from_counter = get_performance_counter();
 	} else {
-		Timestamp_offset_from_counter += static_cast<uint64_t>(static_cast<uint64_t>(delta_milliseconds) * 1000 / Timer_to_microseconds);
+		Timestamp_offset_from_counter += static_cast<uint64_t>(static_cast<uint64_t>(delta_milliseconds) * MICROSECONDS_PER_MILLISECOND / Timer_to_microseconds);
 	}
 }
 

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -634,7 +634,9 @@ void timestamp_update_time_compression()
 	}
 
 	// grab the independent variable of the equation before we change anything
-	auto timestamp_raw = timestamp_get_raw();
+	// (we need to take a new snapshot to get the accurate value, but this is ok
+	// since time compression is only updated at the start of the frame)
+	auto timestamp_raw = timestamp_get_raw(true);
 
 	// we need to move the counter offset to make the raw timestamp zero (so that it can start ticking with a new multiplier)
 	Timestamp_offset_from_counter += timestamp_raw;

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -89,6 +89,7 @@ public:
 
 extern void timer_init();
 extern void timer_close();
+extern void timer_start_frame();
 
 //==========================================================================
 // These functions return the time since the timer was initialized in

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -949,6 +949,9 @@ void game_do_frame() {
 
 	inc_mission_time();
 
+	// sync all timestamps across the entire frame
+	timer_start_frame();
+
 	viewer_position = my_orient.vec.fvec;
 	vm_vec_scale(&viewer_position, my_pos.xyz.z);
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4237,26 +4237,20 @@ void lock_time_compression(bool is_locked)
 
 void change_time_compression(float multiplier)
 {
-	fix modified = fl2f( f2fl(Game_time_compression) * multiplier );
-
-	Desired_time_compression = Game_time_compression = modified;
+	Desired_time_compression = fl2f( f2fl(Game_time_compression) * multiplier );
 	Time_compression_change_rate = 0;
-
-	timestamp_update_time_compression();
 }
 
-void set_time_compression(float multiplier, float change_time)
+void set_time_compression(float compression, float change_time)
 {
+	Desired_time_compression = fl2f(compression);
+
 	if(change_time <= 0.0f)
 	{
-		Game_time_compression = Desired_time_compression = fl2f(multiplier);
 		Time_compression_change_rate = 0;
-
-		timestamp_update_time_compression();
 		return;
 	}
 
-	Desired_time_compression = fl2f(multiplier);
 	Time_compression_change_rate = fl2f( f2fl(Desired_time_compression - Game_time_compression) / change_time );
 }
 
@@ -4326,18 +4320,24 @@ void game_set_frametime(int state)
 	//Handle changes in time compression
 	if(Game_time_compression != Desired_time_compression)
 	{
-		bool ascending = Desired_time_compression > Game_time_compression;
-		if(Time_compression_change_rate)
-		{
-			Game_time_compression += fixmul(Time_compression_change_rate, Frametime);
-			timestamp_update_time_compression();
-		}
-		if((ascending && Game_time_compression > Desired_time_compression)
-			|| (!ascending && Game_time_compression < Desired_time_compression))
+		if (Time_compression_change_rate == 0)
 		{
 			Game_time_compression = Desired_time_compression;
-			timestamp_update_time_compression();
 		}
+		else
+		{
+			bool ascending = Desired_time_compression > Game_time_compression;
+
+			Game_time_compression += fixmul(Time_compression_change_rate, Frametime);
+
+			if((ascending && Game_time_compression > Desired_time_compression)
+				|| (!ascending && Game_time_compression < Desired_time_compression))
+			{
+				Game_time_compression = Desired_time_compression;
+			}
+		}
+
+		timestamp_update_time_compression();
 	}
 
 	Frametime = fixmul(Frametime, Game_time_compression);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4266,6 +4266,9 @@ void game_set_frametime(int state)
 	float frame_cap_diff;
 	bool do_pre_player_skip = false;
 
+	// sync all timestamps across the entire frame
+	timer_start_frame();
+
 	thistime = timer_get_fixed_seconds();
 
 	if ( Last_time == 0 )	

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -421,6 +421,9 @@ void EditorViewport::game_do_frame(const int cur_object_index) {
 		return;
 	}
 
+	// sync all timestamps across the entire frame
+	timer_start_frame();
+
 	viewer_position = my_orient.vec.fvec;
 	vm_vec_scale(&viewer_position, my_pos.xyz.z);
 


### PR DESCRIPTION
Prior to the timer upgrade, all simulation timestamps shared identical timer and timestamp values for the duration of the frame, since they were only updated within the `game_set_frametime` function.  Since the timer upgrade depends on the system clock, timestamps evaluated near the end of the frame will be very slightly later than timestamps evaluated near the beginning of the frame.  It is desirable to keep them all in sync.

This PR tweaks the timestamp system to take a snapshot at the beginning of the frame, then use that snapshot for the entire duration of the frame.  This only affects simulation timestamps; real-time timestamps still use the live timer.

This is a redo of PR #5266, with some small additional tweaks.

Update: this now fixes the bug discovered in #5287.