### PR TITLE
Fix glowpoints on animated submodels

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1662,7 +1662,7 @@ void model_render_glowpoint_bitmap(int point_num, vec3d *pos, matrix *orient, gl
 	vec3d submodel_static_offset; // The associated submodel's static offset in the ship's frame of reference
 	bool submodel_rotation = false;
 
-	if ( bank->submodel_parent > 0 && pm->submodel[bank->submodel_parent].flags[Model::Submodel_flags::Can_move] && shipp != nullptr ) {
+	if ( bank->submodel_parent > 0 && pm->submodel[bank->submodel_parent].flags[Model::Submodel_flags::Can_move] ) {
 		model_find_submodel_offset(&submodel_static_offset, pm, bank->submodel_parent);
 
 		submodel_rotation = true;


### PR DESCRIPTION
Since #2983, this does not depend on being a ship, and will allow glow points to follow animated submodels on models which arent ships.