### PR TITLE
lighting profile code reorg

### DIFF
--- a/code/globalincs/adjustment.cpp
+++ b/code/globalincs/adjustment.cpp
@@ -1,0 +1,163 @@
+// clang-format on
+#include "globalincs/adjustment.h"
+
+#include "globalincs/pstypes.h"
+
+//*************************************************
+//			adjustment funcs
+//*************************************************
+
+/**
+ * @brief Processes an input according to the user's configuration and returns the result.
+ */
+float adjustment::handle(float input)
+{
+	if (only_positive && input < 0.0f)
+		input = base;
+	if (has_multiplier)
+		input *= multipier;
+	// handling adjust after multiplier makes it possible to multiply by 0 and still adjust.
+	if (has_adjust)
+		input += adjust;
+	if (has_minimum)
+		input = MAX(input, minimum);
+	if (has_maximum)
+		input = MIN(input, maximum);
+	return input;
+}
+
+void adjustment::reset()
+{
+	base = 1.0f;
+	has_adjust = false;
+	has_minimum = false;
+	has_maximum = false;
+	has_multiplier = false;
+	only_positive = true;
+}
+
+void adjustment::set_adjust(float in)
+{
+	has_adjust = true;
+	adjust = in;
+}
+
+void adjustment::set_multiplier(float in)
+{
+	has_multiplier = true;
+	multipier = in;
+}
+
+void adjustment::stack_multiplier(float in)
+{
+	if (has_multiplier) {
+		multipier *= in;
+	} else {
+		multipier = in;
+		has_multiplier = true;
+	}
+}
+
+void adjustment::set_maximum(float in)
+{
+	has_maximum = true;
+	maximum = in;
+}
+
+void adjustment::set_minimum(float in)
+{
+	has_minimum = true;
+	minimum = in;
+}
+
+void adjustment::stack_minimum(float in)
+{
+	if (has_minimum) {
+		minimum = MAX(minimum, in);
+	} else {
+		minimum = in;
+		has_minimum = true;
+	}
+}
+bool adjustment::read_adjust(float* out) const
+{
+	*out = adjust;
+	return has_adjust;
+}
+bool adjustment::read_multiplier(float* out) const
+{
+	*out = multipier;
+	return has_multiplier;
+}
+/**
+ * @brief for use during the parsing of a light profile to attempt to read in an LPV
+ *
+ * @param filename for error reporting primairly
+ * @param valuename Text of the field
+ * @param profile_name The name of the profile being parsed, for error reporting
+ * @param value_target The profile object parsing into
+ * @param required If false it is an error for this to not find a value.
+ * @return true if a succesful parse, false otherwise
+ */
+bool adjustment::parse(const char* filename,
+	const char* valuename,
+	const SCP_string& profile_name,
+	adjustment* value_target,
+	bool required)
+{
+	if (optional_string(valuename)) {
+		bool parsed = true;
+		int parses = 0;
+		while (parsed) {
+			parsed = false;
+			if (parse_optional_float_into("+default:", &value_target->base)) {
+				parsed = true;
+				parses++;
+			}
+			if (parse_optional_float_into("+maximum:", &value_target->maximum)) {
+				value_target->has_maximum = true;
+				parsed = true;
+				parses++;
+			}
+			if (parse_optional_float_into("+minimum:", &value_target->minimum)) {
+				value_target->has_minimum = true;
+				parsed = true;
+				parses++;
+			}
+			if (parse_optional_float_into("+multiplier:", &value_target->multipier)) {
+				value_target->has_multiplier = true;
+				parsed = true;
+				parses++;
+			}
+			if (parse_optional_float_into("+adjust:", &value_target->adjust)) {
+				value_target->has_adjust = true;
+				parsed = true;
+				parses++;
+			}
+		}
+		if (parses == 0) {
+			Warning(LOCATION,
+				"Adjustment config '%s' in file '%s' profile '%s' parsed but set no properties, possible "
+				"malformed table.",
+				valuename,
+				filename,
+				profile_name.c_str());
+		} else if (parses > 5) {
+			Warning(LOCATION,
+				"Adjustment config '%s' in file '%s' section '%s' parsed too many properties, possible "
+				"malformed table.",
+				valuename,
+				filename,
+				profile_name.c_str());
+		}
+		return true;
+
+	} else if (required) {
+		Error(LOCATION,
+			"Expected adjustment config value '%s' in file '%s' section '%s' not found",
+			valuename,
+			filename,
+			profile_name.c_str());
+	}
+	return false;
+}

--- a/code/globalincs/adjustment.h
+++ b/code/globalincs/adjustment.h
@@ -1,0 +1,43 @@
+// clang-format on
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include "parse/parsehi.h"
+
+/**
+ * @brief To hold configuration of, and handle application of, modifiers to numeric values.
+ *
+ * Was originally made for lighting_profiles, but was extracted into it's own thing for potential reuse.
+ */
+struct adjustment {
+	float base;
+	bool only_positive = true;
+
+	float handle(float input);
+	void reset();
+	void set_adjust(const float in);
+	void set_multiplier(const float in);
+	void stack_multiplier(const float in);
+	void set_maximum(const float in);
+	void set_minimum(const float in);
+	void stack_minimum(const float in);
+
+	static bool parse(const char* filename,
+		const char* valuename,
+		const SCP_string& profile_name,
+		adjustment* value_target,
+		bool required = false);
+	bool read_multiplier(float* out) const;
+	bool read_adjust(float* out) const;
+
+  private:
+	bool has_adjust = false;
+	float adjust;
+	bool has_multiplier = false;
+	float multipier;
+	bool has_minimum = false;
+	float minimum;
+	bool has_maximum = false;
+	float maximum;
+};

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -21,6 +21,9 @@
 #include "render/3d.h"
 #include "util/uniform_structs.h"
 
+namespace ltp = lighting_profiles;
+using namespace ltp;
+
 // Structures
 struct gr_light
 {
@@ -329,8 +332,8 @@ void gr_set_ambient_light(int red, int green, int blue) {
 	gr_light_ambient[3] = 1.0f;
 }
 void gr_get_ambient_light(vec3d* light_vector) {
-	auto abv = lighting_profile::current()->ambient_light_brightness;
-	auto over = lighting_profile::current()->overall_brightness;
+	auto abv = ltp::current()->ambient_light_brightness;
+	auto over = ltp::current()->overall_brightness;
 	light_vector->xyz.x = over.handle(abv.handle(gr_light_ambient[0]));
 	light_vector->xyz.y = over.handle(abv.handle(gr_light_ambient[1]));
 	light_vector->xyz.z = over.handle(abv.handle(gr_light_ambient[2]));

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -100,6 +100,8 @@ void gr_opengl_deferred_lighting_end()
 
 extern SCP_vector<light> Lights;
 extern int Num_lights;
+namespace ltp = lighting_profiles;
+using namespace ltp; 
 static bool override_fog = false;
 
 void gr_opengl_deferred_lighting_finish()
@@ -161,7 +163,7 @@ void gr_opengl_deferred_lighting_finish()
 	{
 		GR_DEBUG_SCOPE("Build buffer data");
 
-		auto lp = lighting_profile::current();
+		auto lp = ltp::current();
 
 		auto header = uniformAligner.getHeader<deferred_global_data>();
 		if (Shadow_quality != ShadowQuality::Disabled) {

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -58,6 +58,9 @@ static GLuint Smaa_output_tex               = 0;
 static GLuint Smaa_search_tex = 0;
 static GLuint Smaa_area_tex   = 0;
 
+namespace ltp = lighting_profiles;
+using namespace ltp;
+
 void opengl_post_pass_tonemap()
 {
 	GR_DEBUG_SCOPE("Tonemapping");
@@ -69,8 +72,8 @@ void opengl_post_pass_tonemap()
 	
 	opengl_set_generic_uniform_data<graphics::generic_data::tonemapping_data>(
 		[](graphics::generic_data::tonemapping_data* data) {
-		auto ppc = lighting_profile::current_piecewise_intermediates();
-		auto tn = lighting_profile::current_tonemapper();
+		auto ppc = ltp::current_piecewise_intermediates();
+		auto tn = ltp::current_tonemapper();
 		data->tonemapper = tn;
 		data->sh_B = ppc.sh_B;
 		data->sh_lnA = ppc.sh_lnA;
@@ -81,7 +84,7 @@ void opengl_post_pass_tonemap()
 		data->x0 = ppc.x0;
 		data->x1 = ppc.x1;
 		data->y0 = ppc.y0; 
-		data->exposure = lighting_profile::current_exposure(); });
+		data->exposure = ltp::current_exposure(); });
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_ldr_texture, 0);
 

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -303,16 +303,18 @@ void LabUi::build_antialiasing_combobox()
 		}
 	}
 }
+namespace ltp = lighting_profiles;
+using namespace ltp;
 
 void LabUi::build_tone_mapper_combobox()
 {
-	with_Combo("Tonemapper", lighting_profile::tonemapper_to_name(lighting_profile::current_tonemapper()).c_str())
+	with_Combo("Tonemapper", ltp::tonemapper_to_name(ltp::current_tonemapper()).c_str())
 	{
 		for (int n = 0; n < IM_ARRAYSIZE(tonemappers); n++) {
 			const bool is_selected =
-				lighting_profile::tonemapper_to_name(lighting_profile::current_tonemapper()) == tonemappers[n];
+				ltp::tonemapper_to_name(ltp::current_tonemapper()) == tonemappers[n];
 			if (Selectable(tonemappers[n].c_str(), is_selected))
-				lighting_profile::lab_set_tonemapper(lighting_profile::name_to_tonemapper(tonemappers[n]));
+				ltp::lab_set_tonemapper(ltp::name_to_tonemapper(tonemappers[n]));
 
 			if (is_selected)
 				SetItemDefaultFocus();
@@ -323,11 +325,11 @@ void LabUi::build_tone_mapper_combobox()
 void LabUi::show_render_options()
 {
 	int bloom_level = gr_bloom_intensity();
-	float ambient_factor = lighting_profile::lab_get_ambient();
-	float light_factor = lighting_profile::lab_get_light();
-	float emissive_factor = lighting_profile::lab_get_emissive();
-	float exposure_level = lighting_profile::current_exposure();
-	auto ppcv = lighting_profile::lab_get_ppc();
+	float ambient_factor = ltp::lab_get_ambient();
+	float light_factor = ltp::lab_get_light();
+	float emissive_factor = ltp::lab_get_emissive();
+	float exposure_level = ltp::current_exposure();
+	auto ppcv = ltp::lab_get_ppc();
 
 	bool skip_setting_light_options_this_frame = false;
 
@@ -380,8 +382,8 @@ void LabUi::show_render_options()
 
 			build_tone_mapper_combobox();
 
-			if (lighting_profile::current_tonemapper() == tnm_PPC ||
-				lighting_profile::current_tonemapper() == tnm_PPC_RGB) {
+			if (ltp::current_tonemapper() == tnm_PPC ||
+				ltp::current_tonemapper() == tnm_PPC_RGB) {
 				SliderFloat("PPC Toe Strength", &ppcv.toe_strength, 0.0f, 1.0f);
 				SliderFloat("PPC Toe Length", &ppcv.toe_length, 0.0f, 1.0f);
 				SliderFloat("PPC Shoulder Angle", &ppcv.shoulder_angle, 0.0f, 1.0f);

--- a/code/lab/dialogs/lab_ui_helpers.cpp
+++ b/code/lab/dialogs/lab_ui_helpers.cpp
@@ -156,24 +156,25 @@ SCP_string get_directory_or_vp(const char* path)
 
 	return result;
 }
-
+namespace ltp = lighting_profiles;
+using namespace ltp;
 bool graphics_options_changed()
 {
 	auto stored_settings = getLabManager()->graphicsSettings;
 
-	if (stored_settings.ambient_factor != lighting_profile::lab_get_ambient())
+	if (stored_settings.ambient_factor != ltp::lab_get_ambient())
 		return true;
 
-	if (stored_settings.light_factor != lighting_profile::lab_get_light())
+	if (stored_settings.light_factor != ltp::lab_get_light())
 		return true;
 
-	if (stored_settings.emissive_factor != lighting_profile::lab_get_emissive())
+	if (stored_settings.emissive_factor != ltp::lab_get_emissive())
 		return true;
 
-	if (stored_settings.exposure_level != lighting_profile::current_exposure())
+	if (stored_settings.exposure_level != ltp::current_exposure())
 		return true;
 
-	if (stored_settings.tonemapper != lighting_profile::current_tonemapper())
+	if (stored_settings.tonemapper != ltp::current_tonemapper())
 		return true;
 
 	if (stored_settings.bloom_level != gr_bloom_intensity())
@@ -182,19 +183,19 @@ bool graphics_options_changed()
 	if (stored_settings.aa_mode != Gr_aa_mode)
 		return true;
 
-	if (stored_settings.ppcv.shoulder_angle != lighting_profile::lab_get_ppc().shoulder_angle)
+	if (stored_settings.ppcv.shoulder_angle != ltp::lab_get_ppc().shoulder_angle)
 		return true;
 
-	if (stored_settings.ppcv.shoulder_length != lighting_profile::lab_get_ppc().shoulder_length)
+	if (stored_settings.ppcv.shoulder_length != ltp::lab_get_ppc().shoulder_length)
 		return true;
 
-	if (stored_settings.ppcv.shoulder_strength != lighting_profile::lab_get_ppc().shoulder_strength)
+	if (stored_settings.ppcv.shoulder_strength != ltp::lab_get_ppc().shoulder_strength)
 		return true;
 
-	if (stored_settings.ppcv.toe_length != lighting_profile::lab_get_ppc().toe_length)
+	if (stored_settings.ppcv.toe_length != ltp::lab_get_ppc().toe_length)
 		return true;
 
-	if (stored_settings.ppcv.toe_strength != lighting_profile::lab_get_ppc().toe_strength)
+	if (stored_settings.ppcv.toe_strength != ltp::lab_get_ppc().toe_strength)
 		return true;
 
 	return false;

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -20,6 +20,7 @@ void lab_exit() {
 	getLabManager()->notify_close();
 }
 
+namespace ltp = lighting_profiles;
 LabManager::LabManager() {
 	The_mission.Reset();
 
@@ -74,13 +75,14 @@ LabManager::LabManager() {
 
 	Game_mode |= GM_LAB;
 
+	using namespace ltp;
 	graphicsSettings = gfx_options();
-	graphicsSettings.ppcv = lighting_profile::lab_get_ppc();
-	graphicsSettings.ambient_factor = lighting_profile::lab_get_ambient();
-	graphicsSettings.light_factor = lighting_profile::lab_get_light();
-	graphicsSettings.emissive_factor = lighting_profile::lab_get_emissive();
-	graphicsSettings.exposure_level = lighting_profile::current_exposure();
-	graphicsSettings.tonemapper = lighting_profile::current_tonemapper();
+	graphicsSettings.ppcv = ltp::lab_get_ppc();
+	graphicsSettings.ambient_factor = ltp::lab_get_ambient();
+	graphicsSettings.light_factor = ltp::lab_get_light();
+	graphicsSettings.emissive_factor = ltp::lab_get_emissive();
+	graphicsSettings.exposure_level = ltp::current_exposure();
+	graphicsSettings.tonemapper = ltp::current_tonemapper();
 	graphicsSettings.bloom_level = gr_bloom_intensity();
 	graphicsSettings.aa_mode = Gr_aa_mode;
 }

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -40,13 +40,15 @@ void LabRenderer::onFrame(float frametime) {
 	// the LabManager::onFrame method
 }
 
+namespace ltp = lighting_profiles;
 void LabRenderer::resetGraphicsSettings(gfx_options settings) {
-	lighting_profile::lab_set_ambient(settings.ambient_factor);
-	lighting_profile::lab_set_emissive(settings.emissive_factor);
-	lighting_profile::lab_set_exposure(settings.exposure_level);
-	lighting_profile::lab_set_light(settings.light_factor);
-	lighting_profile::lab_set_ppc(settings.ppcv);
-	lighting_profile::lab_set_tonemapper(settings.tonemapper);
+	
+	ltp::lab_set_ambient(settings.ambient_factor);
+	ltp::lab_set_emissive(settings.emissive_factor);
+	ltp::lab_set_exposure(settings.exposure_level);
+	ltp::lab_set_light(settings.light_factor);
+	ltp::lab_set_ppc(settings.ppcv);
+	ltp::lab_set_tonemapper(settings.tonemapper);
 	gr_set_bloom_intensity(settings.bloom_level);
 	Gr_aa_mode = settings.aa_mode;
 }

--- a/code/lab/renderer/lab_renderer.h
+++ b/code/lab/renderer/lab_renderer.h
@@ -68,15 +68,17 @@ enum class TextureOverride {
 };
 
 
+namespace ltp = lighting_profiles;
+
 struct gfx_options {
 	int bloom_level;
 	float ambient_factor;
 	float light_factor;
 	float emissive_factor;
 	float exposure_level;
-	piecewise_power_curve_values ppcv;
+	ltp::piecewise_power_curve_values ppcv;
 	AntiAliasMode aa_mode;
-	TonemapperAlgorithm tonemapper;
+	ltp::TonemapperAlgorithm tonemapper;
 };
 
 constexpr auto LAB_MISSION_NONE_STRING = "None";
@@ -118,8 +120,8 @@ public:
 		Motion_debris_override = false;
 	}
 
-	static void setTonemapper(TonemapperAlgorithm mode) {
-		lighting_profile::lab_set_tonemapper(mode);
+	static void setTonemapper(ltp::TonemapperAlgorithm mode) {
+		ltp::lab_set_tonemapper(mode);
 	}
 
 	void useNextTeamColorPreset() {
@@ -161,17 +163,17 @@ public:
 	void setRenderFlag(LabRenderFlag flag, bool value) { renderFlags.set(flag, value); }
 
 	static float setAmbientFactor(float factor) { 
-		lighting_profile::lab_set_ambient(factor);
+		ltp::lab_set_ambient(factor);
 		return factor; 
 	}
 
 	static float setLightFactor(float factor) {
-		lighting_profile::lab_set_light(factor);
+		ltp::lab_set_light(factor);
 		return factor; 
 	}
 
 	static float setEmissiveFactor(float factor) { 
-		lighting_profile::lab_set_emissive(factor);
+		ltp::lab_set_emissive(factor);
 		return factor; 
 	}
 
@@ -183,12 +185,12 @@ public:
 
 	float setExposureLevel(float level) {
 		exposureLevel = level;
-		lighting_profile::lab_set_exposure(level);
+		ltp::lab_set_exposure(level);
 		return level;
 	}
 	
-	static void setPPCValues(piecewise_power_curve_values ppcv) {
-		lighting_profile::lab_set_ppc(ppcv);
+	static void setPPCValues(ltp::piecewise_power_curve_values ppcv) {
+		ltp::lab_set_ppc(ppcv);
 	}
 
 	void setTextureQuality(TextureQuality quality) { textureQuality = quality; }

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -157,7 +157,7 @@ void light_add_directional(const vec3d* dir, const hdr_color* new_color, const f
 	Assert(new_color!= nullptr);
 	light_add_directional(dir, new_color->i(), new_color->r(), new_color->g(), new_color->b(), source_radius);
 }
-
+namespace ltp=lighting_profiles;
 void light_add_directional(const vec3d *dir, float intensity, float r, float g, float b, const float source_radius)
 {
 	if (Lighting_off) return;
@@ -175,7 +175,7 @@ void light_add_directional(const vec3d *dir, float intensity, float r, float g, 
 	l.b = b;
 
 	//configurable global tuning of light qualities
-	auto lp = lighting_profile::current();
+	auto lp = ltp::current();
 	l.intensity = lp->overall_brightness.handle(lp->directional_light_brightness.handle(intensity));
 	l.rada = 0.0f;
 	l.radb = 0.0f;
@@ -215,7 +215,7 @@ void light_add_point(const vec3d *pos, float r1, float r2, float intensity, floa
 	l.b = b;
 
 	//configurable global tuning of light qualities
-	auto lp = lighting_profile::current();
+	auto lp = ltp::current();
 	l.intensity = lp->overall_brightness.handle(lp->point_light_brightness.handle(intensity));
 	l.rada = lp->point_light_radius.handle(r1);
 	l.radb = lp->point_light_radius.handle(r2);
@@ -255,7 +255,7 @@ void light_add_tube(const vec3d *p0, const vec3d *p1, float r1, float r2, float 
 	l.b = b;
 
 	//configurable global tuning of light qualities
-	auto lp = lighting_profile::current();
+	auto lp = ltp::current();
 	l.intensity = lp->overall_brightness.handle(lp->tube_light_brightness.handle(intensity));
 	l.rada = lp->tube_light_radius.handle(r1);
 	l.radb = lp->tube_light_radius.handle(r2);
@@ -461,7 +461,7 @@ void light_add_cone(const vec3d *pos, const vec3d *dir, float angle, float inner
 	l.g = g;
 	l.b = b;
 
-	auto lp = lighting_profile::current();
+	auto lp = ltp::current();
 	l.intensity = lp->overall_brightness.handle(lp->cone_light_brightness.handle(intensity));
 	l.rada = lp->cone_light_radius.handle(r1);
 	l.radb = lp->cone_light_radius.handle(r2);

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -1,13 +1,17 @@
+// clang-format on
+#include "lighting/lighting_profiles.h"
+
 #include "globalincs/pstypes.h"
 #include "globalincs/safe_strings.h"
 #include "globalincs/vmallocator.h"
+
 #include "cmdline/cmdline.h"
 #include "def_files/def_files.h"
 #include "lighting/lighting.h"
-#include "lighting/lighting_profiles.h"
 #include "osapi/dialogs.h"
 #include "parse/parsehi.h"
 #include "parse/parselo.h"
+
 
 //*************************************************
 //			lighting_profile_value funcs
@@ -22,7 +26,7 @@ float lighting_profile_value::handle(float input)
 		input = base;
 	if (has_multiplier)
 		input *= multipier;
-	//handling adjust after multiplier makes it possible to multiply by 0 and still adjust.
+	// handling adjust after multiplier makes it possible to multiply by 0 and still adjust.
 	if (has_adjust)
 		input += adjust;
 	if (has_minimum)
@@ -56,12 +60,9 @@ void lighting_profile_value::set_multiplier(float in)
 
 void lighting_profile_value::stack_multiplier(float in)
 {
-	if(has_multiplier)
-	{
-		multipier*= in;
-	}
-	else 
-	{
+	if (has_multiplier) {
+		multipier *= in;
+	} else {
 		multipier = in;
 		has_multiplier = true;
 	}
@@ -81,22 +82,19 @@ void lighting_profile_value::set_minimum(float in)
 
 void lighting_profile_value::stack_minimum(float in)
 {
-	if(has_minimum)
-	{
-		minimum = MAX(minimum,in);
-	}
-	else
-	{
+	if (has_minimum) {
+		minimum = MAX(minimum, in);
+	} else {
 		minimum = in;
 		has_minimum = true;
 	}
 }
-bool lighting_profile_value::read_adjust(float *out) const
+bool lighting_profile_value::read_adjust(float* out) const
 {
 	*out = adjust;
 	return has_adjust;
 }
-bool lighting_profile_value::read_multiplier(float *out) const
+bool lighting_profile_value::read_multiplier(float* out) const
 {
 	*out = multipier;
 	return has_multiplier;
@@ -105,7 +103,7 @@ bool lighting_profile_value::read_multiplier(float *out) const
  * @brief for use during the parsing of a light profile to attempt to read in an LPV
  *
  * @param filename for error reporting primairly
- * @param valuename Text of the field 
+ * @param valuename Text of the field
  * @param profile_name The name of the profile being parsed, for error reporting
  * @param value_target The profile object parsing into
  * @param required If false it is an error for this to not find a value.
@@ -178,13 +176,13 @@ void lighting_profile::reset()
 {
 	name = "";
 
-    tonemapper = tnm_Uncharted;
+	tonemapper = tnm_Uncharted;
 
 	ppc_values.toe_strength = 0.5f;
-    ppc_values.toe_length = 0.5f;
-    ppc_values.shoulder_strength = 0.0f;
-    ppc_values.shoulder_length = 0.5f;
-    ppc_values.shoulder_angle = 0.1f;
+	ppc_values.toe_length = 0.5f;
+	ppc_values.shoulder_strength = 0.0f;
+	ppc_values.shoulder_length = 0.5f;
+	ppc_values.shoulder_angle = 0.1f;
 
 	exposure = 4.0f;
 
@@ -200,7 +198,6 @@ void lighting_profile::reset()
 	beam_light_radius.reset();
 	beam_light_radius.base = 37.5f;
 
-
 	tube_light_brightness.reset();
 	tube_light_radius.reset();
 
@@ -214,46 +211,45 @@ void lighting_profile::reset()
 
 	directional_light_brightness.reset();
 
-
 	overall_brightness.reset();
-	//Default Multiplier to maintain legacy visual compatibility
-	overall_brightness.set_multiplier(3.5f); 
+	// Default Multiplier to maintain legacy visual compatibility
+	overall_brightness.set_multiplier(3.5f);
 	overall_brightness.set_minimum(0.0f);
 	overall_brightness.stack_multiplier(Cmdline_light_power);
 
 	ambient_light_brightness.reset();
-	//Inverse of the overall brightness boost
-	ambient_light_brightness.set_multiplier(0.286f); 
+	// Inverse of the overall brightness boost
+	ambient_light_brightness.set_multiplier(0.286f);
 	ambient_light_brightness.stack_multiplier(Cmdline_ambient_power);
-	ambient_light_brightness.set_adjust(MAX(0.0f,Cmdline_emissive_power));
+	ambient_light_brightness.set_adjust(MAX(0.0f, Cmdline_emissive_power));
 
 	cockpit_light_radius_modifier.reset();
 	cockpit_light_radius_modifier.set_multiplier(1.0f);
 }
 
-TonemapperAlgorithm lighting_profile::name_to_tonemapper(SCP_string &name)
+TonemapperAlgorithm lighting_profile::name_to_tonemapper(SCP_string& name)
 {
 	SCP_tolower(name);
 	TonemapperAlgorithm r = tnm_Invalid;
-	if(name == "uncharted" || name == "uncharted 2" ){
+	if (name == "uncharted" || name == "uncharted 2") {
 		r = tnm_Uncharted;
 	}
-	if(name == "linear"){
+	if (name == "linear") {
 		r = tnm_Linear;
 	}
-	if(name == "aces"){
+	if (name == "aces") {
 		r = tnm_Aces;
 	}
-	if(name == "aces approximate"){
+	if (name == "aces approximate") {
 		r = tnm_Aces_Approx;
 	}
-	if(name == "cineon"){
+	if (name == "cineon") {
 		r = tnm_Cineon;
 	}
-	if(name == "reinhard jodie"){
+	if (name == "reinhard jodie") {
 		r = tnm_Reinhard_Jodie;
 	}
-	if(name == "reinhard extended"){
+	if (name == "reinhard extended") {
 		r = tnm_Reinhard_Extended;
 	}
 	if (name == "ppc" || name == "piecewise power curve") {
@@ -293,12 +289,12 @@ SCP_string lighting_profile::tonemapper_to_name(TonemapperAlgorithm tnm)
 	}
 }
 
-
 lighting_profile lighting_profile::default_profile;
 
-lighting_profile * lighting_profile::current(){
-	//in time this may host more complex logic to allow such things as blending between two different profiles and managing a temporary profile.
-	//put in place now so that access can be generally future-proofed from here out.
+lighting_profile* lighting_profile::current()
+{
+	// in time this may host more complex logic to allow such things as blending between two different profiles and
+	// managing a temporary profile. put in place now so that access can be generally future-proofed from here out.
 	return &lighting_profile::default_profile;
 }
 
@@ -307,12 +303,12 @@ void lighting_profile::load_profiles()
 	parse_all();
 }
 
-//The logic for grabbing all the parseable files
+// The logic for grabbing all the parseable files
 
 void lighting_profile::parse_all()
 {
 	default_profile.reset();
-	if (cf_exists_full("lighting_profiles.tbl", CF_TYPE_TABLES)){
+	if (cf_exists_full("lighting_profiles.tbl", CF_TYPE_TABLES)) {
 		mprintf(("TABLES: Starting parse of lighting profiles.tbl\n"));
 		lighting_profile::parse_file("lighting_profiles.tbl");
 	}
@@ -321,114 +317,144 @@ void lighting_profile::parse_all()
 	parse_modular_table("*-ltp.tbm", lighting_profile::parse_file);
 }
 
-void lighting_profile::parse_default_section(const char *filename)
+void lighting_profile::parse_default_section(const char* filename)
 {
 	bool parsed;
 	SCP_string buffer;
 	TonemapperAlgorithm tn;
 	const char* profile_name = "Default Profile";
-	while(!optional_string("#END DEFAULT PROFILE")){
+	while (!optional_string("#END DEFAULT PROFILE")) {
 		parsed = false;
-		if(optional_string("$Tonemapper:")){
-			stuff_string(buffer,F_NAME);
+		if (optional_string("$Tonemapper:")) {
+			stuff_string(buffer, F_NAME);
 			tn = lighting_profile::name_to_tonemapper(buffer);
 			default_profile.tonemapper = tn;
 			parsed = true;
 		}
-		parsed |= parse_optional_float_into("$PPC Toe Strength:",&default_profile.ppc_values.toe_strength);
-		parsed |= parse_optional_float_into("$PPC Toe Length:",&default_profile.ppc_values.toe_length);
-		parsed |= parse_optional_float_into("$PPC Shoulder Length:",&default_profile.ppc_values.shoulder_length);
-		parsed |= parse_optional_float_into("$PPC Shoulder Strength:",&default_profile.ppc_values.shoulder_strength);
-		parsed |= parse_optional_float_into("$PPC Shoulder Angle:",&default_profile.ppc_values.shoulder_angle);
-		parsed |= parse_optional_float_into("$Exposure:",&default_profile.exposure);
+		parsed |= parse_optional_float_into("$PPC Toe Strength:", &default_profile.ppc_values.toe_strength);
+		parsed |= parse_optional_float_into("$PPC Toe Length:", &default_profile.ppc_values.toe_length);
+		parsed |= parse_optional_float_into("$PPC Shoulder Length:", &default_profile.ppc_values.shoulder_length);
+		parsed |= parse_optional_float_into("$PPC Shoulder Strength:", &default_profile.ppc_values.shoulder_strength);
+		parsed |= parse_optional_float_into("$PPC Shoulder Angle:", &default_profile.ppc_values.shoulder_angle);
+		parsed |= parse_optional_float_into("$Exposure:", &default_profile.exposure);
 
-		parsed |= lighting_profile_value::parse(filename,"$Missile light brightness:",profile_name,
-										&default_profile.missile_light_brightness);
-		parsed |= lighting_profile_value::parse(filename,"$Missile light radius:",profile_name,
-										&default_profile.missile_light_radius);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Missile light brightness:",
+			profile_name,
+			&default_profile.missile_light_brightness);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Missile light radius:",
+			profile_name,
+			&default_profile.missile_light_radius);
 
-		parsed |= lighting_profile_value::parse(filename,"$Laser light brightness:",profile_name,
-										&default_profile.laser_light_brightness);
-		parsed |= lighting_profile_value::parse(filename,"$Laser light radius:",profile_name,
-										&default_profile.laser_light_radius);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Laser light brightness:",
+			profile_name,
+			&default_profile.laser_light_brightness);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Laser light radius:",
+			profile_name,
+			&default_profile.laser_light_radius);
 
-		parsed |= lighting_profile_value::parse(filename,"$Beam light brightness:",profile_name,
-										&default_profile.beam_light_brightness);
-		parsed |= lighting_profile_value::parse(filename,"$Beam light radius:",profile_name,
-										&default_profile.beam_light_radius);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Beam light brightness:",
+			profile_name,
+			&default_profile.beam_light_brightness);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Beam light radius:",
+			profile_name,
+			&default_profile.beam_light_radius);
 
-		parsed |= lighting_profile_value::parse(filename,"$Tube light brightness:",profile_name,
-										&default_profile.tube_light_brightness);
-		parsed |= lighting_profile_value::parse(filename,"$Tube light radius:",profile_name,
-										&default_profile.tube_light_radius);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Tube light brightness:",
+			profile_name,
+			&default_profile.tube_light_brightness);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Tube light radius:",
+			profile_name,
+			&default_profile.tube_light_radius);
 
-		parsed |= lighting_profile_value::parse(filename,"$Point light brightness:",profile_name,
-										&default_profile.point_light_brightness);
-		parsed |= lighting_profile_value::parse(filename,"$Point light radius:",profile_name,
-										&default_profile.point_light_radius);
-		parsed |= lighting_profile_value::parse(filename,"$Directional light brightness:",profile_name,
-										&default_profile.directional_light_brightness);
-		parsed |= lighting_profile_value::parse(filename,"$Cone light radius:",profile_name,
-										&default_profile.cone_light_radius);
-		parsed |= lighting_profile_value::parse(filename,"$Cone light brightness:",profile_name,
-										&default_profile.cone_light_brightness);
-		if(lighting_profile_value::parse(filename,"$Ambient light brightness:",profile_name, &default_profile.ambient_light_brightness))
-		{
+		parsed |= lighting_profile_value::parse(filename,
+			"$Point light brightness:",
+			profile_name,
+			&default_profile.point_light_brightness);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Point light radius:",
+			profile_name,
+			&default_profile.point_light_radius);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Directional light brightness:",
+			profile_name,
+			&default_profile.directional_light_brightness);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Cone light radius:",
+			profile_name,
+			&default_profile.cone_light_radius);
+		parsed |= lighting_profile_value::parse(filename,
+			"$Cone light brightness:",
+			profile_name,
+			&default_profile.cone_light_brightness);
+		if (lighting_profile_value::parse(filename,
+				"$Ambient light brightness:",
+				profile_name,
+				&default_profile.ambient_light_brightness)) {
 			parsed = true;
 			default_profile.ambient_light_brightness.stack_multiplier(Cmdline_ambient_power);
 			default_profile.ambient_light_brightness.stack_multiplier(Cmdline_light_power);
 			default_profile.ambient_light_brightness.stack_minimum(Cmdline_emissive_power);
 		}
 
-		if(lighting_profile_value::parse(filename,"$Overall brightness:",profile_name, &default_profile.overall_brightness))
-		{
+		if (lighting_profile_value::parse(filename,
+				"$Overall brightness:",
+				profile_name,
+				&default_profile.overall_brightness)) {
 			parsed = true;
 			default_profile.overall_brightness.stack_multiplier(Cmdline_light_power);
 		}
 
-		parsed |= parse_optional_float_into("$Exposure:",&default_profile.exposure);
+		parsed |= parse_optional_float_into("$Exposure:", &default_profile.exposure);
 
-		parsed |= lighting_profile_value::parse(filename, "$Cockpit light radius modifier:", profile_name,
+		parsed |= lighting_profile_value::parse(filename,
+			"$Cockpit light radius modifier:",
+			profile_name,
 			&default_profile.cockpit_light_radius_modifier);
 
-		if(!parsed){
-			stuff_string(buffer,F_RAW);
-			Warning(LOCATION,"Unhandled line in lighting profile\n\t%s",buffer.c_str());
+		if (!parsed) {
+			stuff_string(buffer, F_RAW);
+			Warning(LOCATION, "Unhandled line in lighting profile\n\t%s", buffer.c_str());
 		}
 	}
 }
 
-//Handle an individual file.
-void lighting_profile::parse_file(const char *filename)
+// Handle an individual file.
+void lighting_profile::parse_file(const char* filename)
 {
-	try
-	{
-		if (filename == nullptr){
-			//All defaults currently handled by lighting_profile.reset()
+	try {
+		if (filename == nullptr) {
+			// All defaults currently handled by lighting_profile.reset()
 			return;
 		}
 		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
-		if(optional_string("#DEFAULT PROFILE")){
+		if (optional_string("#DEFAULT PROFILE")) {
 			parse_default_section(filename);
 		}
-    }	catch (const parse::ParseException& e)
-	{
-		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n", (filename) ? filename : "<default ai_profiles.tbl>", e.what()));
+	} catch (const parse::ParseException& e) {
+		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n",
+			(filename) ? filename : "<default ai_profiles.tbl>",
+			e.what()));
 		return;
 	}
 }
 
-
-//these accessor stubs are futureproofing abstraction
-
+// these accessor stubs are futureproofing abstraction
 
 TonemapperAlgorithm lighting_profile::current_tonemapper()
 {
 	return default_profile.tonemapper;
 }
 
-const piecewise_power_curve_values & lighting_profile::current_piecewise_values()
+const piecewise_power_curve_values& lighting_profile::current_piecewise_values()
 {
 	return default_profile.ppc_values;
 }
@@ -437,87 +463,96 @@ float lighting_profile::current_exposure()
 {
 	return default_profile.exposure;
 }
-piecewise_power_curve_intermediates lighting_profile::current_piecewise_intermediates(){
+piecewise_power_curve_intermediates lighting_profile::current_piecewise_intermediates()
+{
 	return calc_intermediates(default_profile.ppc_values);
 }
-piecewise_power_curve_intermediates lighting_profile::calc_intermediates(piecewise_power_curve_values input){
+piecewise_power_curve_intermediates lighting_profile::calc_intermediates(piecewise_power_curve_values input)
+{
 
 	piecewise_power_curve_intermediates ppci;
 
-	//Some safety clamping based on John Hable's implementation: https://github.com/johnhable/fw-public
+	// Some safety clamping based on John Hable's implementation: https://github.com/johnhable/fw-public
 	CLAMP(input.toe_length, 0.0f, 1.0f);
 	CLAMP(input.toe_strength, 0.0f, 1.0f);
 	CLAMP(input.shoulder_angle, 0.0f, 1.0f);
 	CLAMP(input.shoulder_length, 0.0f, 1.0f);
 	input.shoulder_strength = fmax(0.0f, input.shoulder_strength);
 
-	ppci.x0 = input.toe_length * 0.5f; //L,F,P
-	ppci.y0 = (1.0f - input.toe_strength) * ppci.x0; //L
-	float remainingY = 1.0f - ppci.y0; 
+	ppci.x0 = input.toe_length * 0.5f;               // L,F,P
+	ppci.y0 = (1.0f - input.toe_strength) * ppci.x0; // L
+	float remainingY = 1.0f - ppci.y0;
 	float initialW = ppci.x0 + remainingY;
 	float y1_offset = (1.0f - input.shoulder_length) * remainingY;
-	ppci.x1 = ppci.x0 + y1_offset; //F,P
+	ppci.x1 = ppci.x0 + y1_offset; // F,P
 	float y1 = ppci.y0 + y1_offset;
 	float extraW = exp2f(input.shoulder_length) - 1.0f;
 	float W = initialW + extraW;
-	float overshootX = (W * 2.0f) * input.shoulder_strength + (ppci.x0-ppci.y0);
+	float overshootX = (W * 2.0f) * input.shoulder_strength + (ppci.x0 - ppci.y0);
 	float overshootY = 0.5f * input.shoulder_angle;
 
-	ppci.toe_B = ppci.x0/ppci.y0; //T
-	ppci.toe_lnA = log(ppci.y0) - ppci.toe_B*log(ppci.x0);//T
+	ppci.toe_B = ppci.x0 / ppci.y0;                          // T
+	ppci.toe_lnA = log(ppci.y0) - ppci.toe_B * log(ppci.x0); // T
 
 	float sh_x0 = (1.0f + overshootX) - ppci.x1;
 	float sh_y0 = (1.0f + overshootY) - y1;
 
-	ppci.sh_B = sh_x0/sh_y0;//S
-	ppci.sh_lnA = log(sh_y0) - ppci.sh_B*log(sh_x0);//S
-	ppci.sh_offsetX = 1.0f + overshootX; //F,P,S
-	ppci.sh_offsetY = 1.0f + overshootY; //F,P,S
+	ppci.sh_B = sh_x0 / sh_y0;                         // S
+	ppci.sh_lnA = log(sh_y0) - ppci.sh_B * log(sh_x0); // S
+	ppci.sh_offsetX = 1.0f + overshootX;               // F,P,S
+	ppci.sh_offsetY = 1.0f + overshootY;               // F,P,S
 	return ppci;
-
 }
-void lighting_profile::lab_set_exposure(float exIn){
+void lighting_profile::lab_set_exposure(float exIn)
+{
 	default_profile.exposure = exIn;
 }
 
-
-void lighting_profile::lab_set_tonemapper(TonemapperAlgorithm tnin){
+void lighting_profile::lab_set_tonemapper(TonemapperAlgorithm tnin)
+{
 	default_profile.tonemapper = tnin;
 }
 
-void lighting_profile::lab_set_ppc(piecewise_power_curve_values ppcin ){
+void lighting_profile::lab_set_ppc(piecewise_power_curve_values ppcin)
+{
 	default_profile.ppc_values = ppcin;
-
 }
 
-piecewise_power_curve_values lighting_profile::lab_get_ppc(){
+piecewise_power_curve_values lighting_profile::lab_get_ppc()
+{
 	return default_profile.ppc_values;
 }
 
-float lighting_profile::lab_get_light(){
+float lighting_profile::lab_get_light()
+{
 	float r;
 	default_profile.overall_brightness.read_multiplier(&r);
 
 	return r;
 }
-float lighting_profile::lab_get_ambient(){
+float lighting_profile::lab_get_ambient()
+{
 	float r;
 	default_profile.ambient_light_brightness.read_multiplier(&r);
 
 	return r;
 }
-float lighting_profile::lab_get_emissive(){
+float lighting_profile::lab_get_emissive()
+{
 	float r;
 	default_profile.ambient_light_brightness.read_adjust(&r);
 
 	return r;
 }
-void lighting_profile::lab_set_light(float in){
+void lighting_profile::lab_set_light(float in)
+{
 	default_profile.overall_brightness.set_multiplier(in);
 }
-void lighting_profile::lab_set_ambient(float in){
+void lighting_profile::lab_set_ambient(float in)
+{
 	default_profile.ambient_light_brightness.set_multiplier(in);
 }
-void lighting_profile::lab_set_emissive(float in){
-	default_profile.ambient_light_brightness.set_adjust(MAX(0.0f,in));
+void lighting_profile::lab_set_emissive(float in)
+{
+	default_profile.ambient_light_brightness.set_adjust(MAX(0.0f, in));
 }

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -1,7 +1,9 @@
 // clang-format on
 #pragma once
 
+#include "globalincs/adjustment.h"
 #include "globalincs/vmallocator.h"
+
 
 namespace lighting_profiles {
 // This file handles the profiles.tbl and -ltp.tbm files. The purpose of these files is to provide control over the HDR
@@ -46,65 +48,30 @@ struct piecewise_power_curve_intermediates {
 	float sh_offsetY;
 };
 
-/**
- * @brief To hold configuration of, and handle application of, modifiers to lighting values.
- */
-struct lighting_profile_value {
-	float base;
-	bool only_positive = true;
-
-	float handle(float input);
-	void reset();
-	void set_adjust(const float in);
-	void set_multiplier(const float in);
-	void stack_multiplier(const float in);
-	void set_maximum(const float in);
-	void set_minimum(const float in);
-	void stack_minimum(const float in);
-
-	static bool parse(const char* filename,
-		const char* valuename,
-		const SCP_string& profile_name,
-		lighting_profile_value* value_target,
-		bool required = false);
-	bool read_multiplier(float* out) const;
-	bool read_adjust(float* out) const;
-
-  private:
-	bool has_adjust = false;
-	float adjust;
-	bool has_multiplier = false;
-	float multipier;
-	bool has_minimum = false;
-	float minimum;
-	bool has_maximum = false;
-	float maximum;
-};
-
 class profile {
   public:
 	SCP_string name;
 	TonemapperAlgorithm tonemapper;
 	piecewise_power_curve_values ppc_values;
 	float exposure;
-	lighting_profile_value missile_light_brightness;
-	lighting_profile_value missile_light_radius;
-	lighting_profile_value laser_light_brightness;
-	lighting_profile_value laser_light_radius;
-	lighting_profile_value beam_light_brightness;
-	lighting_profile_value beam_light_radius;
+	adjustment missile_light_brightness;
+	adjustment missile_light_radius;
+	adjustment laser_light_brightness;
+	adjustment laser_light_radius;
+	adjustment beam_light_brightness;
+	adjustment beam_light_radius;
 
-	lighting_profile_value tube_light_brightness;
-	lighting_profile_value tube_light_radius;
-	lighting_profile_value point_light_brightness;
-	lighting_profile_value point_light_radius;
-	lighting_profile_value cone_light_brightness;
-	lighting_profile_value cone_light_radius;
-	lighting_profile_value directional_light_brightness;
-	lighting_profile_value ambient_light_brightness;
+	adjustment tube_light_brightness;
+	adjustment tube_light_radius;
+	adjustment point_light_brightness;
+	adjustment point_light_radius;
+	adjustment cone_light_brightness;
+	adjustment cone_light_radius;
+	adjustment directional_light_brightness;
+	adjustment ambient_light_brightness;
 	// Strictly speaking this should be handled by postproc but we need something for the non-postproc people.
-	lighting_profile_value overall_brightness;
-	lighting_profile_value cockpit_light_radius_modifier;
+	adjustment overall_brightness;
+	adjustment cockpit_light_radius_modifier;
 
 	void reset();
 
@@ -133,4 +100,4 @@ void lab_set_emissive(float in);
 void parse_all();
 void parse_file(const char* filename);
 void parse_default_section(const char* filename);
-} // namespace lighting_profiles end
+} // namespace lighting_profiles

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -1,15 +1,18 @@
+// clang-format on
 #pragma once
 
 #include "globalincs/vmallocator.h"
 
-//This file handles the lighting_profiles.tbl and -ltp.tbm files. The purpose of these files is to provide control over the HDR lighting pipeline and enviroment, and related matters.
+// This file handles the lighting_profiles.tbl and -ltp.tbm files. The purpose of these files is to provide control over
+// the HDR lighting pipeline and enviroment, and related matters.
 
-//Tonemapping options, aside from the previous standard UC2, pulled from wookiejedi and qazwsxal's
-//work on testing them for FSO, which itself was based on these references:
-//https://64.github.io/tonemapping/ Delta - Blog by 64: Tone Mapping
-//http://filmicworlds.com/blog/filmic-tonemapping-operators/ Filmic Worlds: Filmic Tonemapping Operators by John Hable
+// Tonemapping options, aside from the previous standard UC2, pulled from wookiejedi and qazwsxal's
+// work on testing them for FSO, which itself was based on these references:
+// https://64.github.io/tonemapping/ Delta - Blog by 64: Tone Mapping
+// http://filmicworlds.com/blog/filmic-tonemapping-operators/ Filmic Worlds: Filmic Tonemapping Operators by John Hable
 
-enum TonemapperAlgorithm :int {
+enum TonemapperAlgorithm : int
+{
 	tnm_Invalid = -1,
 	tnm_Linear = 0,
 	tnm_Uncharted = 1,
@@ -19,10 +22,10 @@ enum TonemapperAlgorithm :int {
 	tnm_Reinhard_Jodie = 5,
 	tnm_Reinhard_Extended = 6,
 	tnm_PPC = 7,
-	tnm_PPC_RGB= 8
+	tnm_PPC_RGB = 8
 };
 
-struct piecewise_power_curve_values{
+struct piecewise_power_curve_values {
 	float toe_strength;
 	float toe_length;
 	float shoulder_strength;
@@ -30,7 +33,7 @@ struct piecewise_power_curve_values{
 	float shoulder_angle;
 };
 
-struct piecewise_power_curve_intermediates{
+struct piecewise_power_curve_intermediates {
 	float x0;
 	float y0;
 	float x1;
@@ -45,7 +48,7 @@ struct piecewise_power_curve_intermediates{
 /**
  * @brief To hold configuration of, and handle application of, modifiers to lighting values.
  */
-struct lighting_profile_value{
+struct lighting_profile_value {
 	float base;
 	bool only_positive = true;
 
@@ -58,14 +61,18 @@ struct lighting_profile_value{
 	void set_minimum(const float in);
 	void stack_minimum(const float in);
 
-	static bool parse(const char *filename, const char * valuename, const SCP_string &profile_name, lighting_profile_value* value_target, bool required=false);
-	bool read_multiplier(float *out) const;
-	bool read_adjust(float *out) const;
+	static bool parse(const char* filename,
+		const char* valuename,
+		const SCP_string& profile_name,
+		lighting_profile_value* value_target,
+		bool required = false);
+	bool read_multiplier(float* out) const;
+	bool read_adjust(float* out) const;
 
-private:
+  private:
 	bool has_adjust = false;
 	float adjust;
-	bool has_multiplier=false;
+	bool has_multiplier = false;
 	float multipier;
 	bool has_minimum = false;
 	float minimum;
@@ -73,20 +80,20 @@ private:
 	float maximum;
 };
 
-class lighting_profile{
-public:
-	static lighting_profile * current();
-	static enum TonemapperAlgorithm name_to_tonemapper(SCP_string &name);
+class lighting_profile {
+  public:
+	static lighting_profile* current();
+	static enum TonemapperAlgorithm name_to_tonemapper(SCP_string& name);
 	static SCP_string tonemapper_to_name(TonemapperAlgorithm tnm);
 	static void load_profiles();
 	static TonemapperAlgorithm current_tonemapper();
-	static const piecewise_power_curve_values & current_piecewise_values();
+	static const piecewise_power_curve_values& current_piecewise_values();
 	static piecewise_power_curve_intermediates current_piecewise_intermediates();
 	static piecewise_power_curve_intermediates calc_intermediates(piecewise_power_curve_values input);
 	static float current_exposure();
 	static void lab_set_exposure(float exIn);
 	static void lab_set_tonemapper(TonemapperAlgorithm tnin);
-	static void lab_set_ppc(piecewise_power_curve_values ppcin );
+	static void lab_set_ppc(piecewise_power_curve_values ppcin);
 	static piecewise_power_curve_values lab_get_ppc();
 	static float lab_get_light();
 	static void lab_set_light(float in);
@@ -96,7 +103,7 @@ public:
 	static void lab_set_emissive(float in);
 
 	SCP_string name;
-    TonemapperAlgorithm tonemapper;
+	TonemapperAlgorithm tonemapper;
 	piecewise_power_curve_values ppc_values;
 	float exposure;
 	lighting_profile_value missile_light_brightness;
@@ -114,16 +121,15 @@ public:
 	lighting_profile_value cone_light_radius;
 	lighting_profile_value directional_light_brightness;
 	lighting_profile_value ambient_light_brightness;
-	//Strictly speaking this should be handled by postproc but we need something for the non-postproc people.
+	// Strictly speaking this should be handled by postproc but we need something for the non-postproc people.
 	lighting_profile_value overall_brightness;
 	lighting_profile_value cockpit_light_radius_modifier;
 
-    void reset();
+	void reset();
 
-private:
-
+  private:
 	static lighting_profile default_profile;
 	static void parse_all();
-	static void parse_file(const char *filename);
-	static void parse_default_section(const char *filename);
+	static void parse_file(const char* filename);
+	static void parse_default_section(const char* filename);
 };

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -3,8 +3,9 @@
 
 #include "globalincs/vmallocator.h"
 
-// This file handles the lighting_profiles.tbl and -ltp.tbm files. The purpose of these files is to provide control over
-// the HDR lighting pipeline and enviroment, and related matters.
+namespace lighting_profiles {
+// This file handles the profiles.tbl and -ltp.tbm files. The purpose of these files is to provide control over the HDR
+// lighting pipeline and enviroment, and related matters.
 
 // Tonemapping options, aside from the previous standard UC2, pulled from wookiejedi and qazwsxal's
 // work on testing them for FSO, which itself was based on these references:
@@ -80,28 +81,8 @@ struct lighting_profile_value {
 	float maximum;
 };
 
-class lighting_profile {
+class profile {
   public:
-	static lighting_profile* current();
-	static enum TonemapperAlgorithm name_to_tonemapper(SCP_string& name);
-	static SCP_string tonemapper_to_name(TonemapperAlgorithm tnm);
-	static void load_profiles();
-	static TonemapperAlgorithm current_tonemapper();
-	static const piecewise_power_curve_values& current_piecewise_values();
-	static piecewise_power_curve_intermediates current_piecewise_intermediates();
-	static piecewise_power_curve_intermediates calc_intermediates(piecewise_power_curve_values input);
-	static float current_exposure();
-	static void lab_set_exposure(float exIn);
-	static void lab_set_tonemapper(TonemapperAlgorithm tnin);
-	static void lab_set_ppc(piecewise_power_curve_values ppcin);
-	static piecewise_power_curve_values lab_get_ppc();
-	static float lab_get_light();
-	static void lab_set_light(float in);
-	static float lab_get_ambient();
-	static void lab_set_ambient(float in);
-	static float lab_get_emissive();
-	static void lab_set_emissive(float in);
-
 	SCP_string name;
 	TonemapperAlgorithm tonemapper;
 	piecewise_power_curve_values ppc_values;
@@ -128,8 +109,28 @@ class lighting_profile {
 	void reset();
 
   private:
-	static lighting_profile default_profile;
-	static void parse_all();
-	static void parse_file(const char* filename);
-	static void parse_default_section(const char* filename);
 };
+
+profile* current();
+enum TonemapperAlgorithm name_to_tonemapper(SCP_string& name);
+SCP_string tonemapper_to_name(TonemapperAlgorithm tnm);
+void load_profiles();
+TonemapperAlgorithm current_tonemapper();
+const piecewise_power_curve_values& current_piecewise_values();
+piecewise_power_curve_intermediates current_piecewise_intermediates();
+piecewise_power_curve_intermediates calc_intermediates(piecewise_power_curve_values input);
+float current_exposure();
+void lab_set_exposure(float exIn);
+void lab_set_tonemapper(TonemapperAlgorithm tnin);
+void lab_set_ppc(piecewise_power_curve_values ppcin);
+piecewise_power_curve_values lab_get_ppc();
+float lab_get_light();
+void lab_set_light(float in);
+float lab_get_ambient();
+void lab_set_ambient(float in);
+float lab_get_emissive();
+void lab_set_emissive(float in);
+void parse_all();
+void parse_file(const char* filename);
+void parse_default_section(const char* filename);
+} // namespace lighting_profiles end

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1240,7 +1240,7 @@ void obj_move_all_post(object *objp, float frametime)
 				}
 				if (cast_light) {
 					weapon_info* wi = &Weapon_info[Weapons[objp->instance].weapon_info_index];
-					auto lp = lighting_profile::current();
+					auto lp = lighting_profiles::current();
 					hdr_color light_color;
 					// If there is no specific color set in the table, laser render weapons have a dynamic color.
 					if (!wi->light_color_set && wi->render_type == WRT_LASER) {

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -380,6 +380,8 @@ add_file_folder("Generated Files"
 
 # GlobalIncs files
 add_file_folder("GlobalIncs"
+	globalincs/adjustment.cpp
+	globalincs/adjustment.h
 	globalincs/alphacolors.cpp
 	globalincs/alphacolors.h
 	globalincs/crashdump.cpp

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1824,10 +1824,10 @@ DCF(blight, "Sets the beam light scale factor (Default is 25.5f)")
 {
 	dc_stuff_float(&blight);
 }
-
+namespace ltp = lighting_profiles;
 float beam_current_light_radius(beam *bm, weapon_info *wip, beam_weapon_info *bwi, float noise)
 {
-	auto lp = lighting_profile::current();
+	auto lp = ltp::current();
 	float width = lp->beam_light_radius.handle(wip->light_radius);
 
 	if(bwi->beam_light_as_multiplier)
@@ -1922,7 +1922,7 @@ void beam_add_light_small(beam *bm, object *objp, vec3d *pt)
 	beam_light_color(wip, &light_color);
 	light_color.i(light_color.i() * pct);
 
-	auto lp = lighting_profile::current();
+	auto lp = ltp::current();
 	light_color.i(lp->beam_light_brightness.handle(light_color.i()));
 
 	if (light_color.i() <= 0.0f || light_rad <= 0.0f)
@@ -1950,7 +1950,7 @@ void beam_add_light_large(beam *bm, object *objp, vec3d *pt0, vec3d *pt1)
 
 	if (bwi->beam_light_flicker)
 		light_color.i(light_color.i() * noise);
-	auto lp = lighting_profile::current();
+	auto lp = ltp::current();
 	light_color.i(lp->beam_light_brightness.handle(light_color.i()));
 	light_rad = lp->beam_light_radius.handle(light_rad);
 	if (light_color.i() <= 0.0f || light_rad <= 0.0f)

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1951,7 +1951,7 @@ void game_init()
 
 	cheat_table_init();
 
-	lighting_profile::load_profiles();
+	lighting_profiles::load_profiles();
 
 	// load the list of pilot pic filenames (for barracks and pilot select popup quick reference)
 	pilot_load_pic_list();	


### PR DESCRIPTION
This is some general cleanup before I work on the flexible lighting profiles feature. The big change count is a bit deceptive, most of this is code that's already been reviewed and is just being moved.

@BMagnu some time back suggested the lighting profiles 'adjustment' code could be repurposed, so before I do significant changes to the lighting profiles code that entwines them more I'm pulling them apart here. 

Reworking the lighting profiles to a namespace comes from discussion with @TRBlount about other projects that suggested this was a good best practice to adopt rather than lots of class static members, so I'm doing that now before I start adding in new state to profiles.

And in the process I applied clang-format too, as was generally my intent with this code to begin with but it slipped my mind to keep applying it in edits.