### PR TITLE
Deprecate old versions in favor of versions that use color objects

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -552,19 +552,19 @@ ADE_FUNC(setColor,
 ADE_FUNC(getColor,
 	l_Graphics,
 	"boolean",
-	"Gets the active 2D drawing color. True to return raw rgb, false to return a color object. Defaults to true.",
+	"Gets the active 2D drawing color. False to return raw rgb, true to return a color object. Defaults to false.",
 	"number, number, number, number | color",
 	"rgba color which is currently in use for 2D drawing")
 {
 	if(!Gr_inited)
 		return ADE_RETURN_NIL;
 
-	bool rc = true;
+	bool rc = false;
 	ade_get_args(L, "|b", &rc);
 
 	color cur = gr_screen.current_color;
 
-	if (rc) {
+	if (!rc) {
 		return ade_set_args(L, "iiii", (int)cur.red, (int)cur.green, (int)cur.blue, (int)cur.alpha);
 	} else {
 		return ade_set_args(L, "o", l_Color.Set(cur));

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -284,7 +284,7 @@ ADE_FUNC(clear, l_Graphics, nullptr, "Calls gr_clear(), which fills the entire s
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(clearScreen, l_Graphics, "[number red, number green, number blue, number alpha] | [color Color]",
+ADE_FUNC(clearScreen, l_Graphics, "[number|color /* red value or color object */, number green, number blue, number alpha]",
 	"Clears the screen to black, or the color specified.",
 	nullptr,
 	nullptr)
@@ -521,7 +521,7 @@ ADE_FUNC(setCamera, l_Graphics, "[camera Camera]", "Sets current camera, or rese
 
 ADE_FUNC(setColor,
 	l_Graphics,
-	"number Red, number Green, number Blue, [number Alpha] | color Color",
+	"number|color /* red value or color object */, number Green, number Blue, [number Alpha]",
 	"Sets 2D drawing color; each color number should be from 0 (darkest) to 255 (brightest)",
 	nullptr,
 	nullptr)
@@ -1887,7 +1887,7 @@ ADE_FUNC(getImageHeight, l_Graphics, "string name", "Gets image height", "number
 
 ADE_FUNC(flashScreen,
 	l_Graphics,
-	"number Red, number Green, number Blue | color Color",
+	"number|color /* red value or color object */, number Green, number Blue",
 	"Flashes the screen",
 	nullptr,
 	nullptr)

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -116,14 +116,14 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 	int a = 0;
 	color col;
 
-	if (lua_isnumber(L, 1)) {
-		if (!ade_get_args(L, "|iiii", &r, &g, &b, &a))
+	if (lua_isnumber(L, 2)) {
+		if (!ade_get_args(L, "*|iiii", &r, &g, &b, &a))
 			return ADE_RETURN_FALSE;
 
 	} else {
-		gr_init_alphacolor(&col, 0, 0, 0, 255);
+		gr_init_alphacolor(&col, 0, 0, 0, 0);
 
-		if (!ade_get_args(L, "o", l_Color.Get(&col)))
+		if (!ade_get_args(L, "*o", l_Color.Get(&col)))
 			return ADE_RETURN_FALSE;
 
 		r = col.red;
@@ -143,21 +143,21 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 ADE_FUNC(getHUDGaugeColor,
 	l_HUD,
 	"number|string gaugeNameOrIndex, [boolean ReturnType]",
-	"Color specified in the config to draw the gauge. True to return raw rgba, false to return color object. Defaults to true.",
-	"number, number, number, number",
+	"Color specified in the config to draw the gauge. False to return raw rgba, true to return color object. Defaults to false.",
+	"number, number, number, number | color",
 	"Red, green, blue, and alpha of the gauge")
 {
 	int idx = getDefaultGaugeIndex(L);
 
-	bool rc = true;
-	ade_get_args(L, "|b", &rc);
+	bool rc = false;
+	ade_get_args(L, "*|b", &rc);
 
 	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
 		return ADE_RETURN_NIL;
 
 	color cur = HUD_config.clr[idx];
 
-	if (rc) {
+	if (!rc) {
 		return ade_set_args(L, "iiii", (int)cur.red, (int)cur.green, (int)cur.blue, (int)cur.alpha);
 	} else {
 		return ade_set_args(L, "o", l_Color.Set(cur));
@@ -178,14 +178,14 @@ ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
 	int a = 255;
 	color col;
 
-	if (lua_isnumber(L, 1)) {
-		if (!ade_get_args(L, "|iiii", &r, &g, &b, &a))
+	if (lua_isnumber(L, 2)) {
+		if (!ade_get_args(L, "*|iiii", &r, &g, &b, &a))
 			return ADE_RETURN_FALSE;
 
 	} else {
 		gr_init_alphacolor(&col, 0, 0, 0, 255);
 
-		if (!ade_get_args(L, "|o", l_Color.Get(&col)))
+		if (!ade_get_args(L, "*|o", l_Color.Get(&col)))
 			return ADE_RETURN_FALSE;
 
 		r = col.red;
@@ -205,21 +205,21 @@ ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
 ADE_FUNC(getHUDGaugeColorInMission,
 	l_HUD,
 	"number|string gaugeNameOrIndex, [boolean ReturnType]",
-	"Color currently used to draw the gauge",
+	"Color currently used to draw the gauge. False returns raw rgb, true returns color object. Defaults to false.",
 	"number, number, number, number | color",
 	"Red, green, blue, and alpha of the gauge")
 {
 	int idx = getDefaultGaugeIndex(L);
 
-	bool rc = true;
-	ade_get_args(L, "|b", &rc);
+	bool rc = false;
+	ade_get_args(L, "*|b", &rc);
 
 	if ((idx < 0) || (idx >= (int)default_hud_gauges.size()))
 		return ADE_RETURN_NIL;
 
 	color cur = default_hud_gauges[idx]->getColor();
 
-	if (rc) {
+	if (!rc) {
 		return ade_set_args(L, "iiii", (int)cur.red, (int)cur.green, (int)cur.blue, (int)cur.alpha);
 	} else {
 		return ade_set_args(L, "o", l_Color.Set(cur));

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -2,6 +2,7 @@
 //
 
 #include "hud.h"
+#include "scripting/api/objs/color.h"
 #include "scripting/api/objs/enums.h"
 #include "scripting/api/objs/hudgauge.h"
 #include "scripting/api/objs/object.h"
@@ -103,17 +104,33 @@ ADE_FUNC(getHUDConfigShowStatus, l_HUD, "number|string gaugeNameOrIndex", "Gets 
 }
 
 ADE_FUNC(setHUDGaugeColor, l_HUD,
-         "number|string gaugeNameOrIndex, [number red, number green, number blue, number alpha]",
-         "Modifies color used to draw the gauge in the pilot config", "boolean", "If the operation was successful")
+         "number|string gaugeNameOrIndex, [number red, number green, number blue, number alpha] | [color Color]",
+	"Modifies color used to draw the gauge in the pilot config",
+	"boolean",
+	"If the operation was successful")
 {
 	int idx = getDefaultGaugeIndex(L);
 	int r = 0;
 	int g = 0;
 	int b = 0;
 	int a = 0;
+	color col;
 
-	if(!ade_get_args(L, "|iiii", &r, &g, &b, &a))
-		return ADE_RETURN_FALSE;
+	if (lua_isnumber(L, 1)) {
+		if (!ade_get_args(L, "|iiii", &r, &g, &b, &a))
+			return ADE_RETURN_FALSE;
+
+	} else {
+		gr_init_alphacolor(&col, 0, 0, 0, 255);
+
+		if (!ade_get_args(L, "o", l_Color.Get(&col)))
+			return ADE_RETURN_FALSE;
+
+		r = col.red;
+		g = col.green;
+		b = col.blue;
+		a = col.alpha;
+	}
 
 	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
 		return ADE_RETURN_FALSE;
@@ -125,33 +142,57 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 
 ADE_FUNC(getHUDGaugeColor,
 	l_HUD,
-	"number|string gaugeNameOrIndex",
-	"Color specified in the config to draw the gauge",
+	"number|string gaugeNameOrIndex, [boolean ReturnType]",
+	"Color specified in the config to draw the gauge. True to return raw rgba, false to return color object. Defaults to true.",
 	"number, number, number, number",
 	"Red, green, blue, and alpha of the gauge")
 {
 	int idx = getDefaultGaugeIndex(L);
 
+	bool rc = true;
+	ade_get_args(L, "|b", &rc);
+
 	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
 		return ADE_RETURN_NIL;
 
-	color c = HUD_config.clr[idx];
+	color cur = HUD_config.clr[idx];
 
-	return ade_set_args(L, "iiii", (int) c.red, (int) c.green, (int) c.blue, (int) c.alpha);
+	if (rc) {
+		return ade_set_args(L, "iiii", (int)cur.red, (int)cur.green, (int)cur.blue, (int)cur.alpha);
+	} else {
+		return ade_set_args(L, "o", l_Color.Set(cur));
+	}
+
 }
 
 ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
-         "number|string gaugeNameOrIndex, [number red, number green, number blue, number alpha]",
-         "Set color currently used to draw the gauge", "boolean", "If the operation was successful")
+         "number|string gaugeNameOrIndex, [number red, number green, number blue, number alpha] | [color Color]",
+	"Set color currently used to draw the gauge",
+	"boolean",
+	"If the operation was successful")
 {
 	int idx = getDefaultGaugeIndex(L);
 	int r = 0;
 	int g = 0;
 	int b = 0;
 	int a = 255;
+	color col;
 
-	if(!ade_get_args(L, "|iiii", &r, &g, &b, &a))
-		return ADE_RETURN_FALSE;
+	if (lua_isnumber(L, 1)) {
+		if (!ade_get_args(L, "|iiii", &r, &g, &b, &a))
+			return ADE_RETURN_FALSE;
+
+	} else {
+		gr_init_alphacolor(&col, 0, 0, 0, 255);
+
+		if (!ade_get_args(L, "|o", l_Color.Get(&col)))
+			return ADE_RETURN_FALSE;
+
+		r = col.red;
+		g = col.green;
+		b = col.blue;
+		a = col.alpha;
+	}
 
 	if ((idx < 0) || (idx >= (int)default_hud_gauges.size()))
 		return ADE_RETURN_FALSE;
@@ -163,19 +204,26 @@ ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
 
 ADE_FUNC(getHUDGaugeColorInMission,
 	l_HUD,
-	"number|string gaugeNameOrIndex",
+	"number|string gaugeNameOrIndex, [boolean ReturnType]",
 	"Color currently used to draw the gauge",
 	"number, number, number, number",
 	"Red, green, blue, and alpha of the gauge")
 {
 	int idx = getDefaultGaugeIndex(L);
 
+	bool rc = true;
+	ade_get_args(L, "|b", &rc);
+
 	if ((idx < 0) || (idx >= (int)default_hud_gauges.size()))
 		return ADE_RETURN_NIL;
 
-	color c = default_hud_gauges[idx]->getColor();
+	color cur = default_hud_gauges[idx]->getColor();
 
-	return ade_set_args(L, "iiii", (int) c.red, (int) c.green, (int) c.blue, (int) c.alpha);
+	if (rc) {
+		return ade_set_args(L, "iiii", (int)cur.red, (int)cur.green, (int)cur.blue, (int)cur.alpha);
+	} else {
+		return ade_set_args(L, "o", l_Color.Set(cur));
+	}
 }
 
 ADE_FUNC(getHUDGaugeHandle, l_HUD, "string Name", "Returns a handle to a specified HUD gauge", "HudGauge", "HUD Gauge handle, or nil if invalid")

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -104,7 +104,7 @@ ADE_FUNC(getHUDConfigShowStatus, l_HUD, "number|string gaugeNameOrIndex", "Gets 
 }
 
 ADE_FUNC(setHUDGaugeColor, l_HUD,
-         "number|string gaugeNameOrIndex, [number red, number green, number blue, number alpha] | [color Color]",
+         "number|string gaugeNameOrIndex, [number|color /* red value or color object */, number green, number blue, number alpha]",
 	"Modifies color used to draw the gauge in the pilot config",
 	"boolean",
 	"If the operation was successful")
@@ -166,7 +166,7 @@ ADE_FUNC(getHUDGaugeColor,
 }
 
 ADE_FUNC(setHUDGaugeColorInMission, l_HUD,
-         "number|string gaugeNameOrIndex, [number red, number green, number blue, number alpha] | [color Color]",
+         "number|string gaugeNameOrIndex, [number|color /* red value or color object */, number green, number blue, number alpha]",
 	"Set color currently used to draw the gauge",
 	"boolean",
 	"If the operation was successful")
@@ -206,7 +206,7 @@ ADE_FUNC(getHUDGaugeColorInMission,
 	l_HUD,
 	"number|string gaugeNameOrIndex, [boolean ReturnType]",
 	"Color currently used to draw the gauge",
-	"number, number, number, number",
+	"number, number, number, number | color",
 	"Red, green, blue, and alpha of the gauge")
 {
 	int idx = getDefaultGaugeIndex(L);

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -16,6 +16,7 @@
 #include "object/objectshield.h"
 #include "object/objectsnd.h"
 #include "scripting/api/LuaEventCallback.h"
+#include "scripting/api/objs/color.h"
 #include "scripting/lua/LuaFunction.h"
 #include "ship/ship.h"
 #include "weapon/weapon.h"
@@ -661,27 +662,28 @@ ADE_FUNC(removeSound, l_Object, "soundentry GameSnd, [subsystem Subsys=nil]",
 }
 
 
-ADE_FUNC(getIFFColor, l_Object, "number, number, number", 
-	"Gets the IFF color of the object",
-	"number, number, number", 
+ADE_FUNC(getIFFColor, l_Object, "boolean ReturnType", 
+	"Gets the IFF color of the object. True to return raw rgb, false to return color object. Defaults to true.",
+	"number, number, number | color", 
 	"IFF rgb color of the object or nil if object invalid")
 {
 	object_h* objh;
+	bool rc = true;
 
-	if (!ade_get_args(L, "o", l_Object.GetPtr(&objh)))
+	if (!ade_get_args(L, "o|b", l_Object.GetPtr(&objh), &rc))
 		return ADE_RETURN_NIL;
 
 	if (!objh->IsValid())
 		return ADE_RETURN_NIL;
 
 	auto objp = objh->objp;
-	color* col = hud_get_iff_color(objp);
+	color* cur = hud_get_iff_color(objp);
 
-	int r = col->red;
-	int g = col->green;
-	int b = col->blue;
-
-	return ade_set_args(L, "iii", r, g, b);
+	if (rc) {
+		return ade_set_args(L, "iii", (int)cur->red, (int)cur->green, (int)cur->blue, (int)cur->alpha);
+	} else {
+		return ade_set_args(L, "o", l_Color.Set(*cur));
+	}
 }
 
 } // namespace api

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -663,12 +663,12 @@ ADE_FUNC(removeSound, l_Object, "soundentry GameSnd, [subsystem Subsys=nil]",
 
 
 ADE_FUNC(getIFFColor, l_Object, "boolean ReturnType", 
-	"Gets the IFF color of the object. True to return raw rgb, false to return color object. Defaults to true.",
-	"number, number, number | color", 
+	"Gets the IFF color of the object. False to return raw rgb, true to return color object. Defaults to false.",
+	"number, number, number, number | color", 
 	"IFF rgb color of the object or nil if object invalid")
 {
 	object_h* objh;
-	bool rc = true;
+	bool rc = false;
 
 	if (!ade_get_args(L, "o|b", l_Object.GetPtr(&objh), &rc))
 		return ADE_RETURN_NIL;
@@ -679,8 +679,8 @@ ADE_FUNC(getIFFColor, l_Object, "boolean ReturnType",
 	auto objp = objh->objp;
 	color* cur = hud_get_iff_color(objp);
 
-	if (rc) {
-		return ade_set_args(L, "iii", (int)cur->red, (int)cur->green, (int)cur->blue, (int)cur->alpha);
+	if (!rc) {
+		return ade_set_args(L, "iiii", (int)cur->red, (int)cur->green, (int)cur->blue, (int)cur->alpha);
 	} else {
 		return ade_set_args(L, "o", l_Color.Set(*cur));
 	}

--- a/code/scripting/api/objs/team.cpp
+++ b/code/scripting/api/objs/team.cpp
@@ -43,12 +43,12 @@ ADE_VIRTVAR(Name, l_Team, "string", "Team name", "string", "Team name, or empty 
 ADE_FUNC(getColor,
 	l_Team,
 	"boolean ReturnType",
-	"Gets the IFF color of the specified Team. True to return raw rgb, false to return color object. Defaults to true.",
-	"number, number, number",
+	"Gets the IFF color of the specified Team. False to return raw rgb, true to return color object. Defaults to false.",
+	"number, number, number, number | color",
 	"rgb color for the specified team or nil if invalid")
 {
 	int idx;
-	bool rc = true;
+	bool rc = false;
 	if(!ade_get_args(L, "o|b", l_Team.Get(&idx), &rc))
 		return ADE_RETURN_NIL;
 
@@ -57,8 +57,8 @@ ADE_FUNC(getColor,
 
 	color* cur = iff_get_color_by_team(idx, 0, 0);
 
-	if (rc) {
-		return ade_set_args(L, "iii", (int)cur->red, (int)cur->green, (int)cur->blue, (int)cur->alpha);
+	if (!rc) {
+		return ade_set_args(L, "iiii", (int)cur->red, (int)cur->green, (int)cur->blue, (int)cur->alpha);
 	} else {
 		return ade_set_args(L, "o", l_Color.Set(*cur));
 	}

--- a/code/scripting/api/objs/team.cpp
+++ b/code/scripting/api/objs/team.cpp
@@ -48,7 +48,6 @@ ADE_FUNC(getColor,
 	"rgb color for the specified team or nil if invalid")
 {
 	int idx;
-	int r,g,b;
 	bool rc = true;
 	if(!ade_get_args(L, "o|b", l_Team.Get(&idx), &rc))
 		return ADE_RETURN_NIL;

--- a/code/scripting/api/objs/team.cpp
+++ b/code/scripting/api/objs/team.cpp
@@ -3,6 +3,7 @@
 
 #include "team.h"
 #include "iff_defs/iff_defs.h"
+#include "scripting/api/objs/color.h"
 
 namespace scripting {
 namespace api {
@@ -41,26 +42,27 @@ ADE_VIRTVAR(Name, l_Team, "string", "Team name", "string", "Team name, or empty 
 
 ADE_FUNC(getColor,
 	l_Team,
-	nullptr,
-	"Gets the IFF color of the specified Team",
+	"boolean ReturnType",
+	"Gets the IFF color of the specified Team. True to return raw rgb, false to return color object. Defaults to true.",
 	"number, number, number",
 	"rgb color for the specified team or nil if invalid")
 {
 	int idx;
 	int r,g,b;
-	if(!ade_get_args(L, "o", l_Team.Get(&idx)))
+	bool rc = true;
+	if(!ade_get_args(L, "o|b", l_Team.Get(&idx), &rc))
 		return ADE_RETURN_NIL;
 
 	if(idx < 0 || idx >= (int)Iff_info.size())
 		return ADE_RETURN_NIL;
 
-	color* col = iff_get_color_by_team(idx, 0, 0);
+	color* cur = iff_get_color_by_team(idx, 0, 0);
 
-	r = col->red;
-	g = col->green;
-	b = col->blue;
-
-	return ade_set_args(L, "iii", r, g, b);
+	if (rc) {
+		return ade_set_args(L, "iii", (int)cur->red, (int)cur->green, (int)cur->blue, (int)cur->alpha);
+	} else {
+		return ade_set_args(L, "o", l_Color.Set(*cur));
+	}
 }
 
 ADE_FUNC(isValid, l_Team, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")


### PR DESCRIPTION
I'm not sure if this is the best way to do this or even worth the possible annoyance for scripts. However, since the Lua API has full color support I was curious what it would take to convert past methods to get and set using the proper color object rather than raw rgb(sometimes a) values. Turns out there were only a handful of places.

Take it or leave it. Doesn't change underlying functionality, just unifies color handling across the API and deprecates the old methods.