### PR TITLE
Organize and map additional keys to librocket

### DIFF
--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -335,16 +335,50 @@ Input::KeyIdentifier translateKey(SDL_Keycode Key)
 		return Rocket::Core::Input::KI_DOWN;
 	case SDLK_KP_PLUS:
 		return Rocket::Core::Input::KI_ADD;
-	case SDLK_BACKSPACE:
-		return Rocket::Core::Input::KI_BACK;
-	case SDLK_DELETE:
-		return Rocket::Core::Input::KI_DELETE;
+	case SDLK_KP_MINUS:
+		return Rocket::Core::Input::KI_SUBTRACT;
+	case SDLK_KP_MULTIPLY:
+		return Rocket::Core::Input::KI_MULTIPLY;
 	case SDLK_KP_DIVIDE:
 		return Rocket::Core::Input::KI_DIVIDE;
+	case SDLK_KP_DECIMAL:
+		return Rocket::Core::Input::KI_DECIMAL;
+	case SDLK_KP_ENTER:
+		return Rocket::Core::Input::KI_NUMPADENTER;
+	case SDLK_MINUS:
+		return Rocket::Core::Input::KI_OEM_MINUS;
+	case SDLK_EQUALS:
+		return Rocket::Core::Input::KI_OEM_PLUS;
+	case SDLK_BACKSPACE:
+		return Rocket::Core::Input::KI_BACK;
+	case SDLK_LEFTBRACKET:
+		return Rocket::Core::Input::KI_OEM_4;
+	case SDLK_RIGHTBRACKET:
+		return Rocket::Core::Input::KI_OEM_6;
+	case SDLK_BACKSLASH:
+		return Rocket::Core::Input::KI_OEM_5;
+	case SDLK_SEMICOLON:
+		return Rocket::Core::Input::KI_OEM_1;
+	case SDLK_QUOTE:
+		return Rocket::Core::Input::KI_OEM_7;
+	case SDLK_COMMA:
+		return Rocket::Core::Input::KI_OEM_COMMA;
+	case SDLK_PERIOD:
+		return Rocket::Core::Input::KI_OEM_PERIOD;
+	case SDLK_SLASH:
+		return Rocket::Core::Input::KI_OEM_2;
+	case SDLK_INSERT:
+		return Rocket::Core::Input::KI_INSERT;
+	case SDLK_HOME:
+		return Rocket::Core::Input::KI_HOME;
+	case SDLK_PAGEUP:
+		return Rocket::Core::Input::KI_PRIOR;
+	case SDLK_DELETE:
+		return Rocket::Core::Input::KI_DELETE;
 	case SDLK_END:
 		return Rocket::Core::Input::KI_END;
-	case SDLK_ESCAPE:
-		return Rocket::Core::Input::KI_ESCAPE;
+	case SDLK_PAGEDOWN:
+		return Rocket::Core::Input::KI_NEXT;
 	case SDLK_F1:
 		return Rocket::Core::Input::KI_F1;
 	case SDLK_F2:
@@ -375,28 +409,28 @@ Input::KeyIdentifier translateKey(SDL_Keycode Key)
 		return Rocket::Core::Input::KI_F14;
 	case SDLK_F15:
 		return Rocket::Core::Input::KI_F15;
-	case SDLK_HOME:
-		return Rocket::Core::Input::KI_HOME;
-	case SDLK_INSERT:
-		return Rocket::Core::Input::KI_INSERT;
+	case SDLK_ESCAPE:
+		return Rocket::Core::Input::KI_ESCAPE;
 	case SDLK_LCTRL:
 		return Rocket::Core::Input::KI_LCONTROL;
-	case SDLK_LSHIFT:
-		return Rocket::Core::Input::KI_LSHIFT;
-	case SDLK_KP_MULTIPLY:
-		return Rocket::Core::Input::KI_MULTIPLY;
-	case SDLK_PAUSE:
-		return Rocket::Core::Input::KI_PAUSE;
 	case SDLK_RCTRL:
 		return Rocket::Core::Input::KI_RCONTROL;
+	case SDLK_LALT:
+		return Rocket::Core::Input::KI_LMETA;
+	case SDLK_RALT:
+		return Rocket::Core::Input::KI_RMETA;
+	case SDLK_CAPSLOCK:
+		return Rocket::Core::Input::KI_CAPITAL;
+	case SDLK_PAUSE:
+		return Rocket::Core::Input::KI_PAUSE;
 	case SDLK_RETURN:
 		return Rocket::Core::Input::KI_RETURN;
+	case SDLK_LSHIFT:
+		return Rocket::Core::Input::KI_LSHIFT;
 	case SDLK_RSHIFT:
 		return Rocket::Core::Input::KI_RSHIFT;
 	case SDLK_SPACE:
 		return Rocket::Core::Input::KI_SPACE;
-	case SDLK_KP_MINUS:
-		return Rocket::Core::Input::KI_SUBTRACT;
 	case SDLK_TAB:
 		return Rocket::Core::Input::KI_TAB;
 	};


### PR DESCRIPTION
Simple PR that slightly reorganizes the keymapping list and maps some of the other keys that were originally left off. Without this, librocket/scpui cannot detect those keypresses.