### PR TITLE
FRED object editor QOL improvements

### DIFF
--- a/fred2/orienteditor.cpp
+++ b/fred2/orienteditor.cpp
@@ -86,7 +86,10 @@ void orient_editor::DoDataExchange(CDataExchange* pDX)
 
 BEGIN_MESSAGE_MAP(orient_editor, CDialog)
 	//{{AFX_MSG_MAP(orient_editor)
+	ON_CBN_SELCHANGE(IDC_OBJECT_LIST, OnObjectSelected)
 	ON_BN_CLICKED(IDC_POINT_TO_CHECKBOX, OnPointTo)
+	ON_BN_CLICKED(IDC_POINT_TO_OBJECT, OnPointToObject)
+	ON_BN_CLICKED(IDC_POINT_TO_LOCATION, OnPointToLocation)
 	ON_WM_CLOSE()
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
@@ -431,6 +434,13 @@ float orient_editor::perform_input_rounding(float val) const
 	return convert(str);
 }
 
+void orient_editor::OnObjectSelected()
+{
+	((CButton*)GetDlgItem(IDC_POINT_TO_OBJECT))->SetCheck(TRUE);
+	((CButton*)GetDlgItem(IDC_POINT_TO_LOCATION))->SetCheck(FALSE);
+	OnPointToObject();
+}
+
 void orient_editor::OnPointTo()
 {
 	UpdateData(TRUE);
@@ -441,6 +451,18 @@ void orient_editor::OnPointTo()
 	GetDlgItem(IDC_SPIN11)->EnableWindow(!m_point_to);
 	GetDlgItem(IDC_SPIN12)->EnableWindow(!m_point_to);
 	GetDlgItem(IDC_SPIN13)->EnableWindow(!m_point_to);
+}
+
+void orient_editor::OnPointToObject()
+{
+	((CButton*)GetDlgItem(IDC_POINT_TO_CHECKBOX))->SetCheck(TRUE);
+	OnPointTo();
+}
+
+void orient_editor::OnPointToLocation()
+{
+	((CButton*)GetDlgItem(IDC_POINT_TO_CHECKBOX))->SetCheck(TRUE);
+	OnPointTo();
 }
 
 void orient_editor::OnCancel()

--- a/fred2/orienteditor.h
+++ b/fred2/orienteditor.h
@@ -64,7 +64,10 @@ protected:
 	// Generated message map functions
 	//{{AFX_MSG(orient_editor)
 	virtual BOOL OnInitDialog();
+	afx_msg void OnObjectSelected();
 	afx_msg void OnPointTo();
+	afx_msg void OnPointToObject();
+	afx_msg void OnPointToLocation();
 	afx_msg void OnClose();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()


### PR DESCRIPTION
1. When the "object" radio button is selected, the "point to" check box will also be selected
2. When an object is selected from the object list, the "object" radio button and "point to" check box will also be selected

Fixes #5356.