### PR TITLE
Fix max Z speed when using ETS and engine damage tracking

### DIFF
--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -118,7 +118,6 @@ void update_ets(object* objp, float fl_frametime)
 		}
 	}
 
-	// update max speed, moved from 'update_ets' function as part of max speed cleanup -Asteroth and wookieejedi
 	// AL 11-15-97: Rules for engine strength affecting max speed:
 	//						1. if strength >= 0.5 no affect
 	//						2. if strength < 0.5 then max_speed = sqrt(strength)
@@ -130,9 +129,9 @@ void update_ets(object* objp, float fl_frametime)
 
 	// only update max speed if aggregate engine health has changed
 	// which helps minimze amount of overrides to max speed
-	if (eng_current_strength != ship_p->prev_engine_aggregate_hits) {
+	if (eng_current_strength != ship_p->prev_engine_aggregate_strength) {
 		ets_update_max_speed(objp);
-		ship_p->prev_engine_aggregate_hits = eng_current_strength;
+		ship_p->prev_engine_aggregate_strength = eng_current_strength;
 
 		// check if newly updated max speed should be reduced due to engine damage
 		// don't let engine strength affect max speed when playing on lowest skill level

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -159,8 +159,11 @@ float ets_get_max_speed(object* objp, float engine_energy)
 	}
 }
 
-void update_max_speed(object* ship_objp)
+void ets_update_max_speed(object* ship_objp)
 {
+	Assertion(ship_objp != nullptr, "Invalid object pointer passed!");
+	Assertion(ship_objp->type == OBJ_SHIP, "Object needs to be a ship object!");
+
 	// get max possible speed then adjust and set based on engine health
 	ship* shipp = &Ships[ship_objp->instance];
 
@@ -305,7 +308,7 @@ void set_recharge_rates(object* obj, int shields, int weapons, int engines) {
 	Ships[obj->instance].weapon_recharge_index = weapons;
 	Ships[obj->instance].engine_recharge_index = engines;
 
-	update_max_speed(obj);
+	ets_update_max_speed(obj);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -490,7 +493,7 @@ void increase_recharge_rate(object* obj, SYSTEM_TYPE ship_system)
 	if ( obj == Player_obj )
 		snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS), 0.0f );
 
-	update_max_speed(obj);
+	ets_update_max_speed(obj);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -611,7 +614,7 @@ void decrease_recharge_rate(object* obj, SYSTEM_TYPE ship_system)
 	if ( obj == Player_obj )
 		snd_play( gamesnd_get_game_sound(GameSounds::ENERGY_TRANS), 0.0f );
 
-	update_max_speed(obj);
+	ets_update_max_speed(obj);
 }
 
 void transfer_energy_weapon_common(object *objp, float from_field, float to_field, float *from_delta, float *to_delta, float from_max, float to_max, float scale, float eff)

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -55,9 +55,9 @@ void ets_init_ship(object* obj)
 }
 
 // -------------------------------------------------------------------------------------------------
-// update_ets() is called once per frame for every OBJ_SHIP in the game.  The amount of energy
-// to send to the weapons and shields is calculated.  The
-// amount of time elapsed from the previous call is passed in as the parameter fl_frametime.
+// update_ets() is called once per frame for every OBJ_SHIP in the game.  
+// The amount of energy to send to the weapons and shields is calculated.
+// The amount of time elapsed from the previous call is passed in as the parameter fl_frametime.
 //
 // parameters:   obj          ==> object that is updating their energy system
 //               fl_frametime ==> game frametime (in seconds)

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -56,7 +56,7 @@ void ets_init_ship(object* obj)
 
 // -------------------------------------------------------------------------------------------------
 // update_ets() is called once per frame for every OBJ_SHIP in the game.  The amount of energy
-// to send to the weapons and shields is calculated, and the top ship speed is calculated.  The
+// to send to the weapons and shields is calculated.  The
 // amount of time elapsed from the previous call is passed in as the parameter fl_frametime.
 //
 // parameters:   obj          ==> object that is updating their energy system

--- a/code/hud/hudets.h
+++ b/code/hud/hudets.h
@@ -53,7 +53,7 @@ void transfer_energy_to_shields(object* obj);
 void transfer_energy_to_weapons(object* obj);
 
 float ets_get_max_speed(object* objp, float engine_energy);
-void update_max_speed(object* ship_objp);
+void ets_update_max_speed(object* ship_objp);
 void sanity_check_ets_inputs(int (&ets_indexes)[num_retail_ets_gauges]);
 bool validate_ship_ets_indxes(const int &ship_idx, int (&ets_indexes)[num_retail_ets_gauges]);
 void zero_one_ets (int *reduce, int *add1, int *add2);

--- a/code/hud/hudets.h
+++ b/code/hud/hudets.h
@@ -53,6 +53,7 @@ void transfer_energy_to_shields(object* obj);
 void transfer_energy_to_weapons(object* obj);
 
 float ets_get_max_speed(object* objp, float engine_energy);
+void update_max_speed(object* ship_objp);
 void sanity_check_ets_inputs(int (&ets_indexes)[num_retail_ets_gauges]);
 bool validate_ship_ets_indxes(const int &ship_idx, int (&ets_indexes)[num_retail_ets_gauges]);
 void zero_one_ets (int *reduce, int *add1, int *add2);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -16146,8 +16146,7 @@ void sexp_deal_with_ship_flag(int node, bool process_subsequent_nodes, Object::O
 				if (set_it) {
 					zero_one_ets(&ship_entry->shipp->shield_recharge_index, &ship_entry->shipp->weapon_recharge_index, &ship_entry->shipp->engine_recharge_index);
 
-					float x = Energy_levels[Ships[ship_entry->objp->instance].engine_recharge_index];
-					ship_entry->objp->phys_info.max_vel.xyz.z = ets_get_max_speed(ship_entry->objp, x);
+					update_max_speed(ship_entry->objp);
 				} else if (object_flag_orig[Object::Object_Flags::No_shields]) {
 					set_default_recharge_rates(ship_entry->objp);
 				}
@@ -16234,8 +16233,7 @@ void multi_sexp_deal_with_ship_flag()
 				if (set_it) {
 					zero_one_ets(&shipp->shield_recharge_index, &shipp->weapon_recharge_index, &shipp->engine_recharge_index);
 
-					float x = Energy_levels[shipp->engine_recharge_index];
-					Objects[shipp->objnum].phys_info.max_vel.xyz.z = ets_get_max_speed(&Objects[shipp->objnum], x);
+					update_max_speed(&Objects[shipp->objnum]);
 				} else if (object_flag_orig[Object::Object_Flags::No_shields]) {
 					set_default_recharge_rates(&Objects[shipp->objnum]);
 				}
@@ -16367,8 +16365,7 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 				if (set_flag) {
 					zero_one_ets(&oswpt.ship_entry->shipp->shield_recharge_index, &oswpt.ship_entry->shipp->weapon_recharge_index, &oswpt.ship_entry->shipp->engine_recharge_index);
 
-					float x = Energy_levels[oswpt.ship_entry->shipp->engine_recharge_index];
-					Objects[oswpt.ship_entry->shipp->objnum].phys_info.max_vel.xyz.z = ets_get_max_speed(&Objects[oswpt.ship_entry->shipp->objnum], x);
+					update_max_speed(&Objects[oswpt.ship_entry->shipp->objnum]);
 				} else if (object_flag_orig[Object::Object_Flags::No_shields]) {
 					set_default_recharge_rates(oswpt.objp);
 				}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -16146,7 +16146,7 @@ void sexp_deal_with_ship_flag(int node, bool process_subsequent_nodes, Object::O
 				if (set_it) {
 					zero_one_ets(&ship_entry->shipp->shield_recharge_index, &ship_entry->shipp->weapon_recharge_index, &ship_entry->shipp->engine_recharge_index);
 
-					update_max_speed(ship_entry->objp);
+					ets_update_max_speed(ship_entry->objp);
 				} else if (object_flag_orig[Object::Object_Flags::No_shields]) {
 					set_default_recharge_rates(ship_entry->objp);
 				}
@@ -16233,7 +16233,7 @@ void multi_sexp_deal_with_ship_flag()
 				if (set_it) {
 					zero_one_ets(&shipp->shield_recharge_index, &shipp->weapon_recharge_index, &shipp->engine_recharge_index);
 
-					update_max_speed(&Objects[shipp->objnum]);
+					ets_update_max_speed(&Objects[shipp->objnum]);
 				} else if (object_flag_orig[Object::Object_Flags::No_shields]) {
 					set_default_recharge_rates(&Objects[shipp->objnum]);
 				}
@@ -16365,7 +16365,7 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 				if (set_flag) {
 					zero_one_ets(&oswpt.ship_entry->shipp->shield_recharge_index, &oswpt.ship_entry->shipp->weapon_recharge_index, &oswpt.ship_entry->shipp->engine_recharge_index);
 
-					update_max_speed(&Objects[oswpt.ship_entry->shipp->objnum]);
+					ets_update_max_speed(&Objects[oswpt.ship_entry->shipp->objnum]);
 				} else if (object_flag_orig[Object::Object_Flags::No_shields]) {
 					set_default_recharge_rates(oswpt.objp);
 				}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6572,7 +6572,7 @@ void ship::clear()
 	weapon_recharge_index = INTIAL_WEAPON_RECHARGE_INDEX;
 	engine_recharge_index = INTIAL_ENGINE_RECHARGE_INDEX;
 	weapon_energy = 0;
-	prev_engine_aggregate_hits = 1.0f;
+	prev_engine_aggregate_strength = 1.0f;
 	next_manage_ets = timestamp(0);
 
 	flags.reset();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6572,6 +6572,7 @@ void ship::clear()
 	weapon_recharge_index = INTIAL_WEAPON_RECHARGE_INDEX;
 	engine_recharge_index = INTIAL_ENGINE_RECHARGE_INDEX;
 	weapon_energy = 0;
+	prev_engine_aggregate_hits = 1.0f;
 	next_manage_ets = timestamp(0);
 
 	flags.reset();

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -646,7 +646,7 @@ public:
 	int	engine_recharge_index;			// index into array holding the engine recharge rate
 	float	weapon_energy;						// Number of EUs in energy reserves
 	int	next_manage_ets;					// timestamp for when ai can next modify ets ( -1 means never )
-	float prev_engine_aggregate_hits;	// aggregate engine health to allow for minimzing overrides to max speed --Asteroth and wookieejedi
+	float prev_engine_aggregate_strength;	// aggregate engine health to allow for minimzing overrides to max speed --Asteroth and wookieejedi
 
 	flagset<Ship::Ship_Flags>	flags;		// flag variable to contain ship state
 	int	reinforcement_index;				// index into reinforcement struct or -1

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -646,6 +646,7 @@ public:
 	int	engine_recharge_index;			// index into array holding the engine recharge rate
 	float	weapon_energy;						// Number of EUs in energy reserves
 	int	next_manage_ets;					// timestamp for when ai can next modify ets ( -1 means never )
+	float prev_engine_aggregate_hits;	// aggregate engine health to allow for minimzing overrides to max speed --Asteroth and wookieejedi
 
 	flagset<Ship::Ship_Flags>	flags;		// flag variable to contain ship state
 	int	reinforcement_index;				// index into reinforcement struct or -1

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -21,6 +21,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
 #include "hud/hud.h"
+#include "hud/hudets.h"
 #include "hud/hudmessage.h"
 #include "hud/hudtarget.h"
 #include "iff_defs/iff_defs.h"
@@ -2408,6 +2409,8 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 
 		// apply damage to subsystems, and get back any remaining damage that needs to go to the hull
 		damage = do_subobj_hit_stuff(ship_objp, other_obj, hitpos, submodel_num, damage, &apply_hull_armor);
+
+		update_max_speed(ship_objp);
 
 		// damage scaling doesn't apply to subsystems, but it does to the hull
 		damage *= damage_scale;

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2410,8 +2410,6 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 		// apply damage to subsystems, and get back any remaining damage that needs to go to the hull
 		damage = do_subobj_hit_stuff(ship_objp, other_obj, hitpos, submodel_num, damage, &apply_hull_armor);
 
-		ets_update_max_speed(ship_objp);
-
 		// damage scaling doesn't apply to subsystems, but it does to the hull
 		damage *= damage_scale;
 		

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2410,7 +2410,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 		// apply damage to subsystems, and get back any remaining damage that needs to go to the hull
 		damage = do_subobj_hit_stuff(ship_objp, other_obj, hitpos, submodel_num, damage, &apply_hull_armor);
 
-		update_max_speed(ship_objp);
+		ets_update_max_speed(ship_objp);
 
 		// damage scaling doesn't apply to subsystems, but it does to the hull
 		damage *= damage_scale;


### PR DESCRIPTION
Follow up for #5137 and #5292. This engine strength check thus needs to be added to all instances where `max_vel.xyz.z` is updated, so a function was created and added in respective locations. Fixes #5367.