### PR TITLE
Modernise CFLAGS on Mac/Linux

### DIFF
--- a/cmake/toolchain-apple-clang.cmake
+++ b/cmake/toolchain-apple-clang.cmake
@@ -4,7 +4,7 @@ MESSAGE(STATUS "Doing configuration specific to Apple Clang...")
 # TODO: Actually add Mac specific flags here...
 
 # Suppress specific warning
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -funroll-loops -fsigned-char -Wno-unknown-pragmas")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fsigned-char -Wno-unknown-pragmas")
 
 # Omit "conversion from string literal to 'char *' is deprecated" warnings.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings")

--- a/cmake/toolchain-apple-clang.cmake
+++ b/cmake/toolchain-apple-clang.cmake
@@ -13,6 +13,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wno-char-subscripts")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
 
-set(CMAKE_CXX_FLAGS_RELEASE "-Wno-unused-variable")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -Wno-unused-variable -Wno-unused-parameter")
 
-set(CMAKE_CXX_FLAGS_DEBUG "-Wextra -Wshadow -Wno-unused-parameter")
+set(CMAKE_CXX_FLAGS_DEBUG "-Og -g -Wshadow")

--- a/cmake/toolchain-clang.cmake
+++ b/cmake/toolchain-clang.cmake
@@ -33,7 +33,7 @@ set(COMPILER_FLAGS "")
 _enable_extra_compiler_warnings_flags()
 set(COMPILER_FLAGS "${COMPILER_FLAGS} ${_flags}")
 
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -funroll-loops -fsigned-char -Wno-unknown-pragmas")
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -fsigned-char -Wno-unknown-pragmas")
 
 # Omit "argument unused during compilation" when clang is used with ccache.
 if(${CMAKE_CXX_COMPILER} MATCHES "ccache")
@@ -85,7 +85,7 @@ endif()
 
 set(COMPILER_FLAGS_RELEASE "-O2 -Wno-unused-variable -Wno-unused-parameter")
 
-set(COMPILER_FLAGS_DEBUG "-O0 -g -Wshadow")
+set(COMPILER_FLAGS_DEBUG "-Og -g -Wshadow")
 
 # Always use the base flags and add our compiler flags at the bacl
 set(CMAKE_CXX_FLAGS "${CXX_BASE_FLAGS} ${COMPILER_FLAGS}")
@@ -120,7 +120,7 @@ if (FSO_FATAL_WARNINGS)
 	target_compile_options(compiler INTERFACE "-Werror")
 endif()
 
-# Always define this to make sure that the fixed width format macros are available
+# Always define this to make sure that the fixed-width format macros are available
 target_compile_definitions(compiler INTERFACE __STDC_FORMAT_MACROS)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR MINGW)

--- a/cmake/toolchain-gcc.cmake
+++ b/cmake/toolchain-gcc.cmake
@@ -45,7 +45,7 @@ endif()
 _enable_extra_compiler_warnings_flags()
 set(COMPILER_FLAGS "${COMPILER_FLAGS} ${_flags}")
 
-set(COMPILER_FLAGS "${COMPILER_FLAGS} -funroll-loops -fsigned-char -Wno-unknown-pragmas")
+set(COMPILER_FLAGS "${COMPILER_FLAGS} -fsigned-char -Wno-unknown-pragmas")
 
 if (NOT GCC_INCREMENTAL_LINKING)
 	# Place each function and data in its own section so the linker can
@@ -115,7 +115,7 @@ endif()
 
 set(COMPILER_FLAGS_RELEASE "-O2 -Wno-unused-variable -Wno-unused-but-set-variable -Wno-array-bounds -Wno-empty-body -Wno-clobbered  -Wno-unused-parameter")
 
-set(COMPILER_FLAGS_DEBUG "-O0 -g -Wshadow")
+set(COMPILER_FLAGS_DEBUG "-Og -g -Wshadow")
 
 # Always use the base flags and add our compiler flags at the back
 set(CMAKE_CXX_FLAGS "${CXX_BASE_FLAGS} ${COMPILER_FLAGS}")
@@ -165,7 +165,7 @@ if (FSO_FATAL_WARNINGS)
 	target_compile_options(compiler INTERFACE "-Werror")
 endif()
 
-# Always define this to make sure that the fixed width format macros are available
+# Always define this to make sure that the fixed-width format macros are available
 target_compile_definitions(compiler INTERFACE __STDC_FORMAT_MACROS=1)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR MINGW)

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -48,7 +48,7 @@ bool fireballs_parsed = false;
 
 bool Fireball_use_3d_warp = false;
 
-static auto WarpOption = options::OptionBuilder<bool>("Graphics.3dWarp", "3D Warp", "Use a 3D model for warp effects")
+static auto WarpOption __UNUSED = options::OptionBuilder<bool>("Graphics.3dWarp", "3D Warp", "Use a 3D model for warp effects")
                              .category("Graphics")
                              .default_val(true)
                              .level(options::ExpertLevel::Advanced)

--- a/code/fireball/warpineffect.cpp
+++ b/code/fireball/warpineffect.cpp
@@ -24,7 +24,7 @@
 
 bool Fireball_warp_flash = false;
 
-static auto WarpFlashOption = options::OptionBuilder<bool>("Graphics.WarpFlash", "Warp Flash", "Show flash upon warp open or close")
+static auto WarpFlashOption __UNUSED = options::OptionBuilder<bool>("Graphics.WarpFlash", "Warp Flash", "Show flash upon warp open or close")
 							 .category("Graphics")
 							 .default_val(true)
 							 .level(options::ExpertLevel::Advanced)

--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -45,7 +45,7 @@ static bool music_volume_change_listener(float new_val, bool /*initial*/)
 	return true;
 }
 
-static auto MusicVolumeOption = options::OptionBuilder<float>("Audio.Music", "Music", "Volume used for playing music")
+static auto MusicVolumeOption __UNUSED = options::OptionBuilder<float>("Audio.Music", "Music", "Volume used for playing music")
                                     .category("Audio")
                                     .default_val(Default_music_volume)
                                     .range(0.0f, 1.0f)

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -251,14 +251,14 @@ const SCP_vector<std::pair<int, SCP_string>> DetailLevelValues = {{ 0, "Minimum"
                                                                   { 3, "High" },
                                                                   { 4, "Ultra" }, };
 
-const auto ModelDetailOption =
+const auto ModelDetailOption __UNUSED =
 	options::OptionBuilder<int>("Graphics.Detail", "Model Detail", "Detail level of models").importance(8).category(
 		"Graphics").values(DetailLevelValues).default_val(MAX_DETAIL_LEVEL).change_listener([](int val, bool) {
 		Detail.detail_distance = val;
 		return true;
 	}).finish();
 
-const auto TexturesOption = options::OptionBuilder<int>("Graphics.Texture",
+const auto TexturesOption __UNUSED = options::OptionBuilder<int>("Graphics.Texture",
                                                         "3D Hardware Textures",
                                                         "Level of detail of textures").importance(6).category("Graphics").values(
 	DetailLevelValues).default_val(MAX_DETAIL_LEVEL).change_listener([](int val, bool) {
@@ -266,7 +266,7 @@ const auto TexturesOption = options::OptionBuilder<int>("Graphics.Texture",
 	return true;
 }).finish();
 
-const auto ParticlesOption = options::OptionBuilder<int>("Graphics.Particles",
+const auto ParticlesOption __UNUSED = options::OptionBuilder<int>("Graphics.Particles",
                                                          "Particles",
                                                          "Level of detail for particles").importance(5).category(
 	"Graphics").values(DetailLevelValues).default_val(MAX_DETAIL_LEVEL).change_listener([](int val, bool) {
@@ -274,7 +274,7 @@ const auto ParticlesOption = options::OptionBuilder<int>("Graphics.Particles",
 	return true;
 }).finish();
 
-const auto SmallDebrisOption =
+const auto SmallDebrisOption __UNUSED =
 	options::OptionBuilder<int>("Graphics.SmallDebris", "Impact Effects", "Level of detail of impact effects").category(
 		"Graphics").values(DetailLevelValues).default_val(MAX_DETAIL_LEVEL).importance(4).change_listener([](int val,
 	                                                                                                         bool) {
@@ -282,7 +282,7 @@ const auto SmallDebrisOption =
 		return true;
 	}).finish();
 
-const auto ShieldEffectsOption = options::OptionBuilder<int>("Graphics.ShieldEffects",
+const auto ShieldEffectsOption __UNUSED = options::OptionBuilder<int>("Graphics.ShieldEffects",
                                                              "Shield Hit Effects",
                                                              "Level of detail of shield impacts").importance(3).category(
 	"Graphics").values(DetailLevelValues).default_val(MAX_DETAIL_LEVEL).change_listener([](int val, bool) {
@@ -290,7 +290,7 @@ const auto ShieldEffectsOption = options::OptionBuilder<int>("Graphics.ShieldEff
 	return true;
 }).finish();
 
-const auto StarsOption =
+const auto StarsOption __UNUSED =
 	options::OptionBuilder<int>("Graphics.Stars", "Stars", "Number of stars in the mission").importance(2).category(
 		"Graphics").values(DetailLevelValues).default_val(MAX_DETAIL_LEVEL).change_listener([](int val, bool) {
 		Detail.num_stars = val;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -111,7 +111,7 @@ static bool gamma_change_listener(float new_val, bool initial)
 	return true;
 }
 
-static auto GammaOption =
+static auto GammaOption __UNUSED =
     options::OptionBuilder<float>("Graphics.Gamma", "Brightness", "The brighness value used for the game window")
         .category("Graphics")
         .default_val(1.0f)
@@ -127,7 +127,7 @@ const SCP_vector<std::pair<int, SCP_string>> DetailLevelValues = {{ 0, "Minimum"
                                                                   { 3, "High" },
                                                                   { 4, "Ultra" }, };
 
-const auto LightingOption = options::OptionBuilder<int>("Graphics.Lighting", "Lighting", "Level of detail of the lighting")
+const auto LightingOption __UNUSED = options::OptionBuilder<int>("Graphics.Lighting", "Lighting", "Level of detail of the lighting")
 		.importance(1)
 		.category("Graphics")
 		.values(DetailLevelValues)
@@ -161,7 +161,7 @@ static bool mode_change_func(os::ViewportState state, bool initial)
 	return true;
 }
 
-static auto WindowModeOption = options::OptionBuilder<os::ViewportState>("Graphics.WindowMode", "Window Mode",
+static auto WindowModeOption __UNUSED = options::OptionBuilder<os::ViewportState>("Graphics.WindowMode", "Window Mode",
 																		 "Controls how the game window is created.")
 								   .category("Graphics")
 								   .level(options::ExpertLevel::Beginner)
@@ -373,7 +373,7 @@ static auto ResolutionOption =
 
 bool Gr_enable_soft_particles = false;
 
-static auto SoftParticlesOption = options::OptionBuilder<bool>("Graphics.SoftParticles", "Soft Particles",
+static auto SoftParticlesOption __UNUSED = options::OptionBuilder<bool>("Graphics.SoftParticles", "Soft Particles",
                                                                "Enable or disable soft particle rendering.")
                                       .category("Graphics")
                                       .level(options::ExpertLevel::Advanced)
@@ -384,7 +384,7 @@ static auto SoftParticlesOption = options::OptionBuilder<bool>("Graphics.SoftPar
 
 flagset<FramebufferEffects> Gr_framebuffer_effects;
 
-static auto FramebufferEffectsOption =
+static auto FramebufferEffectsOption __UNUSED =
     options::OptionBuilder<flagset<FramebufferEffects>>(
         "Graphics.FramebufferEffects", "Framebuffer effects",
         "Controls which framebuffer effects will be applied to the scene.")
@@ -402,7 +402,7 @@ static auto FramebufferEffectsOption =
 AntiAliasMode Gr_aa_mode = AntiAliasMode::None;
 AntiAliasMode Gr_aa_mode_last_frame = AntiAliasMode::None;
 
-static auto AAOption = options::OptionBuilder<AntiAliasMode>("Graphics.AAMode", "Anti Aliasing",
+static auto AAOption __UNUSED = options::OptionBuilder<AntiAliasMode>("Graphics.AAMode", "Anti Aliasing",
                                                              "Controls the anti aliasing mode of the engine.")
                            .category("Graphics")
                            .level(options::ExpertLevel::Advanced)
@@ -429,7 +429,7 @@ bool gr_is_smaa_mode(AntiAliasMode mode) {
 
 bool Gr_post_processing_enabled = true;
 
-static auto PostProcessOption =
+static auto PostProcessOption __UNUSED =
     options::OptionBuilder<bool>("Graphics.PostProcessing", "Post processing",
                                  "Controls whether post processing is enabled in the engine")
         .category("Graphics")
@@ -441,7 +441,7 @@ static auto PostProcessOption =
 
 bool Gr_enable_vsync = true;
 
-static auto VSyncOption = options::OptionBuilder<bool>("Graphics.VSync", "Vertical Sync",
+static auto VSyncOption __UNUSED = options::OptionBuilder<bool>("Graphics.VSync", "Vertical Sync",
                                                        "Controls how the engine does vertical synchronization")
                               .category("Graphics")
                               .level(options::ExpertLevel::Advanced)

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -50,7 +50,7 @@ extern int ENVMAP;
 const SCP_vector<std::pair<int, SCP_string>> TextureFilteringValues = {{ 0, "Bilinear" },
                                                                       { 1, "Trilinear" }, };
 
-static auto TextureFilteringOption = options::OptionBuilder<int>("Graphics.TextureFilter", "Texture Filtering", "Texture filtering option")
+static auto TextureFilteringOption __UNUSED = options::OptionBuilder<int>("Graphics.TextureFilter", "Texture Filtering", "Texture filtering option")
 								 .importance(1)
 								 .category("Graphics")
 								 .values(TextureFilteringValues)

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -40,7 +40,7 @@ PostEffectUniformType mapUniformNameToType(const SCP_string& uniform_name)
 // used by In-Game Options menu
 bool Post_processing_enable_lightshafts = true;
 
-auto LightshaftsOption =
+auto LightshaftsOption __UNUSED =
 	options::OptionBuilder<bool>("Graphics.Lightshafts", "Lightshafts", "Enable lightshafts (requires post-processing)")
 		.category("Graphics")
 		.default_val(true)
@@ -51,7 +51,7 @@ auto LightshaftsOption =
 
 int Post_processing_bloom_intensity = 25; // using default value of Cmdline_bloom_intensity
 
-auto BloomIntensityOption = options::OptionBuilder<int>("Graphics.BloomIntensity",
+auto BloomIntensityOption __UNUSED = options::OptionBuilder<int>("Graphics.BloomIntensity",
 	"Bloom intensity",
 	"Set bloom intensity (requires post-processing)")
 	.category("Graphics")

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -56,7 +56,7 @@ int Mouse_dz = 0;
 
 int Mouse_sensitivity = 4;
 
-static auto MouseSensitivityOption =
+static auto MouseSensitivityOption __UNUSED =
     options::OptionBuilder<int>("Input.MouseSensitivity", "Sensitivity", "The sentitivity of the mouse input.")
         .category("Input")
         .range(0, 9)
@@ -70,7 +70,7 @@ bool Use_mouse_to_fly = false;
 
 static SCP_string mouse_mode_display(bool mode) { return mode ? "Joy-0" : "Mouse"; }
 
-static auto UseMouseOption = options::OptionBuilder<bool>("Input.UseMouse", "Mouse", "Use the mouse for flying")
+static auto UseMouseOption __UNUSED = options::OptionBuilder<bool>("Input.UseMouse", "Mouse", "Use the mouse for flying")
                                  .category("Input")
 				 .display(mouse_mode_display) 
                                  .level(options::ExpertLevel::Beginner)

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -127,7 +127,7 @@ debriefing	*Debriefing;						// pointer to correct debriefing
 
 bool Briefing_voice_enabled = true; // flag which turn on/off voice playback of briefings/debriefings
 
-static auto BriefingVoiceOption = options::OptionBuilder<bool>("Audio.BriefingVoice", "Briefing voice",
+static auto BriefingVoiceOption __UNUSED = options::OptionBuilder<bool>("Audio.BriefingVoice", "Briefing voice",
                                                                "Enable or disable voice playback in the briefing.")
                                       .category("Audio")
                                       .level(options::ExpertLevel::Beginner)

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -141,7 +141,7 @@ bool Play_thruster_sounds_for_player;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
 
-static auto DiscordOption = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
+static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
 							 .category("Other")
 							 .default_val(Discord_presence)
 							 .level(options::ExpertLevel::Advanced)

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -134,7 +134,7 @@ const SCP_vector<std::pair<int, SCP_string>> DetailLevelValues = {{ 0, "Minimum"
                                                                   { 3, "High" },
                                                                   { 4, "Ultra" }, };
 
-const auto ModelDetailOption = options::OptionBuilder<int>("Graphics.NebulaDetail",
+const auto NebulaDetailOption __UNUSED = options::OptionBuilder<int>("Graphics.NebulaDetail",
                                                            "Nebula Detail",
                                                            "Detail level of nebulas").category("Graphics").values(
 	DetailLevelValues).default_val(MAX_DETAIL_LEVEL).importance(7).change_listener([](int val, bool) {

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -62,7 +62,7 @@ static bool effects_volume_change_listener(float new_val, bool /*initial*/)
 	return true;
 }
 
-static auto EffectVolumeOption =
+static auto EffectVolumeOption __UNUSED =
     options::OptionBuilder<float>("Audio.Effects", "Effects", "Volume used for playing in-game effects")
         .category("Audio")
         .default_val(Default_sound_volume)
@@ -83,7 +83,7 @@ static bool voice_volume_change_listener(float new_val, bool /*initial*/)
 	return true;
 }
 
-static auto VoiceVolumeOption =
+static auto VoiceVolumeOption __UNUSED =
     options::OptionBuilder<float>("Audio.Voice", "Voice", "Volume used for playing voice audio")
         .category("Audio")
         .default_val(Default_voice_volume)

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -52,7 +52,7 @@ static SCP_string shockwave_mode_display(bool mode) { return mode ? "3D" : "2D";
 
 static bool Use_3D_shockwaves = true;
 
-static auto Shockwave3DMode =
+static auto Shockwave3DMode __UNUSED =
     options::OptionBuilder<bool>("Graphics.3DShockwaves", "Shockwaves", "The way shockwaves are displayed.")
         .category("Graphics")
         .display(shockwave_mode_display)

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -256,7 +256,7 @@ static SCP_string skill_level_display(int value)
 	return SCP_string(Skill_level_names(value, true));
 }
 
-static auto GameSkillOption =
+static auto GameSkillOption __UNUSED =
     options::OptionBuilder<int>("Game.SkillLevel", "Skill Level", "The skill level for the game.")
         .category("Game")
         .range(0, 4)


### PR DESCRIPTION
Per GCC optimisation guide, which applies equally well to clang:
* -funroll-loops should not be used unless directed by profiling. The compiler will already unroll loops when it's a good idea.
* clang and gcc now have -Og optimisation levels designed to enable debugging with good performance.

(second attempt at PR #4562)