### PR TITLE
Fix the `rand` SEXP's use of cached values.

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -6029,6 +6029,12 @@ int rand_sexp(int node, bool multiple)
 		// set .value and .text so random number is generated only once.
 		Sexp_nodes[node].value = SEXP_NUM_EVAL;
 		sprintf(Sexp_nodes[node].text, "%d", rand_num);
+		// any cached value is no longer relevant because we just changed the text
+		if (Sexp_nodes[node].cache)
+		{
+			delete Sexp_nodes[node].cache;
+			Sexp_nodes[node].cache = nullptr;
+		}
 	}
 	// if this is multiple with a nonzero seed provided
 	else if (seed > 0)


### PR DESCRIPTION
The `rand` SEXP stores the result of its first call in the "low" node. Prior to PR #2402, this worked fine, but after that, the value is cached when first evaluated, meaning that subsequent calls to the `rand` SEXP will always return the lowest value in the range, not whatever number was rolled the first time.

This commit makes it so that writing the rolled value to the node's `text` attribute is immediately followed by deleting the no-longer cached value, so that the SEXP continues to work as intended.