### PR TITLE
Actually handle a missing `Fade_anim` properly.

### DIFF
--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1230,9 +1230,7 @@ void brief_render(float frametime)
 		}
 	}
 
-	if (Fade_anim.first_frame != -1) {
-		brief_maybe_blit_scene_cut(frametime);
-	}
+	brief_maybe_blit_scene_cut(frametime);
 
 #if !defined(NDEBUG)
 	gr_set_color_fast(&Color_normal);
@@ -2137,12 +2135,12 @@ void brief_maybe_blit_scene_cut(float frametime)
 
 		Fade_anim.time_elapsed += frametime;
 
-		if ( !Brief_playing_fade_sound ) {
+		if (Fade_anim.first_frame != -1 && !Brief_playing_fade_sound) {
 			gamesnd_play_iface(InterfaceSounds::BRIEFING_STATIC);
 			Brief_playing_fade_sound = 1;
 		}
 
-		if ( Fade_anim.time_elapsed > Fade_anim.total_time ) {
+		if (Fade_anim.first_frame == -1 || Fade_anim.time_elapsed > Fade_anim.total_time) {
 			Fade_anim.time_elapsed = 0.0f;
 			Start_fade_up_anim = 0;
 			Start_fade_down_anim = 1;
@@ -2176,7 +2174,7 @@ void brief_maybe_blit_scene_cut(float frametime)
 
 		Fade_anim.time_elapsed += frametime;
 
-		if ( Fade_anim.time_elapsed > Fade_anim.total_time ) {
+		if (Fade_anim.first_frame == -1 || Fade_anim.time_elapsed > Fade_anim.total_time) {
 			Fade_anim.time_elapsed = 0.0f;
 			Start_fade_up_anim = 0;
 			Start_fade_down_anim = 0;


### PR DESCRIPTION
When I made FSO not crash with demo data in PR #1156, I avoided calling `brief_maybe_blit_scene_cut()` if `Fade_anim` didn't load, when I should've made it do what the icculus port does in demo mode: pretend the animation finished immediately.

With this commit, the first mission of the demo correctly advances past the first briefing stage.