### PR TITLE
Update recent particle optimizations to fix edge case slowdowns

### DIFF
--- a/code/particle/effects/ParticleEmitterEffect.cpp
+++ b/code/particle/effects/ParticleEmitterEffect.cpp
@@ -15,7 +15,7 @@ bool ParticleEmitterEffect::processSource(ParticleSource* source) {
 	source->getOrigin()->getGlobalPosition(&emitter.pos);
 	emitter.normal = source->getOrientation()->getDirectionVector(source->getOrigin());
 
-	emit(&emitter, PARTICLE_BITMAP, m_particleBitmap);
+	emit(&emitter, PARTICLE_BITMAP, m_particleBitmap, m_range);
 
 	return false;
 }
@@ -28,11 +28,12 @@ void ParticleEmitterEffect::pageIn() {
 	bm_page_in_texture(m_particleBitmap);
 }
 
-void ParticleEmitterEffect::setValues(const particle_emitter& emitter, int bitmap) {
+void ParticleEmitterEffect::setValues(const particle_emitter& emitter, int bitmap, float range) {
 	Assert(bm_is_valid(bitmap));
 
 	m_emitter = emitter;
 	m_particleBitmap = bitmap;
+	m_range = range;
 }
 }
 }

--- a/code/particle/effects/ParticleEmitterEffect.h
+++ b/code/particle/effects/ParticleEmitterEffect.h
@@ -14,6 +14,7 @@ class ParticleEmitterEffect: public ParticleEffect {
  private:
 	particle_emitter m_emitter;
 	int m_particleBitmap = -1;
+	float m_range = -1;
 
  public:
 	ParticleEmitterEffect();
@@ -24,7 +25,7 @@ class ParticleEmitterEffect: public ParticleEffect {
 
 	void pageIn() override;
 
-	void setValues(const particle_emitter& emitter, int bitmap);
+	void setValues(const particle_emitter& emitter, int bitmap, float range);
 };
 }
 }

--- a/code/particle/particle.h
+++ b/code/particle/particle.h
@@ -165,7 +165,7 @@ namespace particle
 
 	// Creates a bunch of particles. You pass a structure
 	// rather than a bunch of parameters.
-	void emit(particle_emitter *pe, ParticleType type, int optional_data);
+	void emit(particle_emitter *pe, ParticleType type, int optional_data, float range = 1.0);
 }
 
 #endif // _PARTICLE_H

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8931,7 +8931,7 @@ static void ship_dying_frame(object *objp, int ship_num)
 				pe.max_rad = pef.max_rad; // * objp->radius;
 
 				if (pe.num_high > 0) {
-					particle::emit( &pe, particle::PARTICLE_SMOKE2, 0 );
+					particle::emit( &pe, particle::PARTICLE_SMOKE2, 0, 50 );
 				}
 
 				// do sound - maybe start a random sound, if it has played far enough.

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2013,7 +2013,7 @@ static void maybe_fireball_wipe(clip_ship* half_ship, sound_handle* handle_array
 			}
 
 			if (pe.num_high > 0) {
-				particle::emit( &pe, particle::PARTICLE_SMOKE2, 0 );
+				particle::emit( &pe, particle::PARTICLE_SMOKE2, 0, range );
 			}
 
 			if (sip->generic_debris_model_num >= 0) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2200,7 +2200,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			emitter.vel = vmd_zero_vector;
 
 			auto emitterEffect = new ParticleEmitterEffect();
-			emitterEffect->setValues(emitter, effectIndex);
+			emitterEffect->setValues(emitter, effectIndex, 10.0f);
 			wip->piercing_impact_effect = ParticleManager::get()->addEffect(emitterEffect);
 
 			if (back_velocity != 0.0f)
@@ -2211,7 +2211,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 				emitter.num_low /= 2;
 
 				auto secondaryEffect = new ParticleEmitterEffect();
-				secondaryEffect->setValues(emitter, effectIndex);
+				secondaryEffect->setValues(emitter, effectIndex, 10.0f);
 				wip->piercing_impact_secondary_effect = ParticleManager::get()->addEffect(secondaryEffect);
 			}
 		}


### PR DESCRIPTION
#5328 added a very useful culling for particles created by specific particle effects (ie weapons, now beams), though in an effort to simplify the culling process, that PR removed the necessary culling of default smoke on ships. This PR restores the culling of default smoke while also keeping the new culling of particle specific effects. Tested and works as expected, including fixing the slowdowns caused by the aforementioned removal of smoke effect culls. Thanks to @Baezon for all his discussion and help with this. 