### PR TITLE
Warn instead of error for bitmap fonts in unicode

### DIFF
--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -432,9 +432,11 @@ namespace
 				{
 				case VFNT_FONT:
 					if (Unicode_text_mode) {
-						error_display(1, "Bitmap fonts are not supported in Unicode text mode!");
+						WarningEx(LOCATION, "Bitmap fonts are not supported in Unicode text mode! Font %s will be ignored.", fontName.c_str());
+						skip_to_start_of_string_one_of({"$TrueType:", "$Font:", "#End"});
+					} else {
+						parse_vfnt_font(fontName);
 					}
-					parse_vfnt_font(fontName);
 					break;
 				case NVG_FONT:
 					parse_nvg_font(fontName);


### PR DESCRIPTION
Finding a bitmap font while in unicode mode is a recoverable error. So this changes up the parsing to make that work. If we find a bitmap font, silently ignore it but warn if Extra Warn is enabled.

Fonts.tbl already errors if not enough fonts were loaded after all font parsing has completed.