### PR TITLE
Fix HDR conversions in main shader

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -236,6 +236,10 @@ void main()
 		}
 		baseColor = texture(sBasemap, vec3(diffuseTexCoord, float(sBasemapIndex)));
 
+		if (FLAG_ACTIVE(MODEL_SDR_FLAG_HDR)) {
+			baseColor.rgb = srgb_to_linear(baseColor.rgb);
+		}
+
 		if (FLAG_ACTIVE(MODEL_SDR_FLAG_ALPHA_MULT)) {
 			baseColor.a *= alphaMult;
 		}
@@ -264,6 +268,10 @@ void main()
 			specColor.rgb = max(specColor.rgb, vec3(0.03f)); // hardcoded minimum specular value. read John Hable's blog post titled 'Everything Is Shiny'. 
 			fresnelFactor = 1.0;
 		}
+		
+		if (FLAG_ACTIVE(MODEL_SDR_FLAG_HDR)) {
+			specColor.rgb = srgb_to_linear(specColor.rgb);
+		}
 	}
 
 	baseColor.rgb *= aoFactors.y;
@@ -283,10 +291,20 @@ void main()
 			vec3 team_color = base_color * teamMask.x + stripe_color * teamMask.y + color_offset;
 			team_color_glow = (base_color * teamMask.b) + (stripe_color * teamMask.a);
 
+			if (FLAG_ACTIVE(MODEL_SDR_FLAG_HDR)) {
+				baseColor.rgb = linear_to_srgb(baseColor.rgb);
+				specColor.rgb = linear_to_srgb(specColor.rgb);
+			}
+
 			baseColor.rgb += team_color;					
 			baseColor.rgb = max(baseColor.rgb, vec3(0.0));	// We need to make sure that nothing here ever goes negative
 			specColor.rgb += team_color;
 			specColor.rgb = max(specColor.rgb, vec3(0.03));
+			
+			if (FLAG_ACTIVE(MODEL_SDR_FLAG_HDR)) {
+				baseColor.rgb = srgb_to_linear(baseColor.rgb);
+				specColor.rgb = srgb_to_linear(specColor.rgb);
+			}
 		}
 	}
 
@@ -295,13 +313,13 @@ void main()
 		if (FLAG_ACTIVE(MODEL_SDR_FLAG_LIGHT)) {
 			// Ambient lighting still needs to be done since that counts as an "emissive" color
 			vec3 lightAmbient = (emissionFactor + ambientFactor * ambientFactor) * aoFactors.x; // ambientFactor^2 due to legacy OpenGL compatibility behavior
-			emissiveColor.rgb += srgb_to_linear(baseColor.rgb) * lightAmbient;
+			emissiveColor.rgb += baseColor.rgb * lightAmbient;
 		} else {
 			if (FLAG_ACTIVE(MODEL_SDR_FLAG_SPEC)) {
 				baseColor.rgb += pow(1.0 - clamp(dot(eyeDir, normal), 0.0, 1.0), 5.0 * clamp(glossData, 0.01, 1.0)) * specColor.rgb;
 			}
 			// If there is no lighting then we copy the color data so far into the
-			emissiveColor.rgb += srgb_to_linear(baseColor.rgb);
+			emissiveColor.rgb += baseColor.rgb;
 		}
 	} else {
 		if (FLAG_ACTIVE(MODEL_SDR_FLAG_LIGHT)) {
@@ -373,11 +391,17 @@ void main()
 				glowColor = team_glow_enabled ? mix(max(team_color_glow, vec3(0.0)), glowColor, clamp(glowColorLuminance - teamMask.b - teamMask.a, 0.0, 1.0)) : glowColor;
 			}
 		}
-		emissiveColor.rgb += srgb_to_linear(glowColor) * GLOW_MAP_INTENSITY;
+		if (FLAG_ACTIVE(MODEL_SDR_FLAG_HDR)) {
+			glowColor = srgb_to_linear(glowColor) * GLOW_MAP_SRGB_MULTIPLIER;
+		}
+		emissiveColor.rgb += glowColor * GLOW_MAP_INTENSITY;
 	}
 
 	if (FLAG_ACTIVE(MODEL_SDR_FLAG_FOG)) {
 		vec3 finalFogColor = fogColor.rgb;
+		if (FLAG_ACTIVE(MODEL_SDR_FLAG_HDR)) {
+			finalFogColor = srgb_to_linear(finalFogColor);
+		}
 		if (FLAG_ACTIVE(MODEL_SDR_FLAG_DIFFUSE)) {
 			if(blend_alpha == 1) finalFogColor *= baseColor.a;
 		}
@@ -416,17 +440,10 @@ void main()
 		}
 	}
 
-	if (FLAG_ACTIVE(MODEL_SDR_FLAG_HDR)) {
-		baseColor.rgb = srgb_to_linear(baseColor.rgb);
-		specColor.rgb = srgb_to_linear(specColor.rgb);
-	}
-
 	if (!(FLAG_ACTIVE(MODEL_SDR_FLAG_DEFERRED))) {
 		// emissive colors won't be added later when we are using forward rendering so we need to do that here
 		baseColor.rgb += emissiveColor.rgb;
 	}
-
-
 
 	fragOut0 = baseColor;
 


### PR DESCRIPTION
#5055 changed the way SDR->HDR conversion was handled for textures.
This was incorrect for some cases, causing #5282.
#5282 however did not fully fix the issues but only fix them for handling of envmaps (and in the process likely incorrectly appyling SDR->HDR conversions in the SDR-only non-deferred pipeline, but I have not validated this).
This PR properly fixes the SDR->HDR conversion for all textures simply by reverting to how the old shader deals with the conversion, just with the new style of conditionals in the shader. This fixes some models being way too dark models with high specularity and low-light glowmaps.