### PR TITLE
Fix two undocking bugs for small ships

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -3338,6 +3338,8 @@ void ai_do_objects_undocked_stuff( object *docker, object *dockee )
 		dockee_aip->support_ship_objnum = -1;
 		docker_aip->support_ship_signature = -1;
 		dockee_aip->support_ship_signature = -1;
+		// clear out points for docker 
+		docker_aip->path_start = -1;
 	}
 
 	// unlink the two objects

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -2153,11 +2153,9 @@ void validate_mission_goals(int objnum, ai_info *aip)
 
 	// if the active goal is a rearm/repair or undock goal, 
 	// then put all other valid goals (which are not rearm/repair or undock goals) on hold
-	if ( (aip->goals[0].ai_mode == AI_GOAL_REARM_REPAIR || aip->goals[0].ai_mode == AI_GOAL_UNDOCK) &&
-		object_is_docked(&Objects[objnum]) ) {
+	if ( (aip->goals[0].ai_mode == AI_GOAL_REARM_REPAIR || aip->goals[0].ai_mode == AI_GOAL_UNDOCK) && object_is_docked(&Objects[objnum]) ) {
 		for ( i = 1; i < MAX_AI_GOALS; i++ ) {
-			if ( (aip->goals[i].ai_mode == AI_GOAL_NONE) ||
-				(aip->goals[i].ai_mode == AI_GOAL_UNDOCK || aip->goals[i].ai_mode == AI_GOAL_REARM_REPAIR) )
+			if ( aip->goals[i].ai_mode == AI_GOAL_NONE || aip->goals[i].ai_mode == AI_GOAL_REARM_REPAIR || aip->goals[i].ai_mode == AI_GOAL_UNDOCK )
 				continue;
 			aip->goals[i].flags.set(AI::Goal_Flags::Goal_on_hold);
 		}

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -2152,7 +2152,7 @@ void validate_mission_goals(int objnum, ai_info *aip)
 		aip->mode = AIM_NONE;
 
 	// if the active goal is a rearm/repair or undock goal, 
-	// then put all other valid goals (which are not repair goals) on hold
+	// then put all other valid goals (which are not rearm/repair or undock goals) on hold
 	if ( (aip->goals[0].ai_mode == AI_GOAL_REARM_REPAIR || aip->goals[0].ai_mode == AI_GOAL_UNDOCK) &&
 		object_is_docked(&Objects[objnum]) ) {
 		for ( i = 1; i < MAX_AI_GOALS; i++ ) {

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -2151,11 +2151,13 @@ void validate_mission_goals(int objnum, ai_info *aip)
 	if ( (aip->goals[0].ai_mode != AI_GOAL_NONE) && (aip->goals[0].flags[AI::Goal_Flags::Goal_on_hold]) )
 		aip->mode = AIM_NONE;
 
-	// if the active goal is a rearm/repair goal, the put all other valid goals (which are not repair goals)
-	// on hold
-	if ( (aip->goals[0].ai_mode == AI_GOAL_REARM_REPAIR) && object_is_docked(&Objects[objnum]) ) {
+	// if the active goal is a rearm/repair or undock goal, 
+	// then put all other valid goals (which are not repair goals) on hold
+	if ( (aip->goals[0].ai_mode == AI_GOAL_REARM_REPAIR || aip->goals[0].ai_mode == AI_GOAL_UNDOCK) &&
+		object_is_docked(&Objects[objnum]) ) {
 		for ( i = 1; i < MAX_AI_GOALS; i++ ) {
-			if ( (aip->goals[i].ai_mode == AI_GOAL_NONE) || (aip->goals[i].ai_mode == AI_GOAL_REARM_REPAIR) )
+			if ( (aip->goals[i].ai_mode == AI_GOAL_NONE) ||
+				(aip->goals[i].ai_mode == AI_GOAL_UNDOCK || aip->goals[i].ai_mode == AI_GOAL_REARM_REPAIR) )
 				continue;
 			aip->goals[i].flags.set(AI::Goal_Flags::Goal_on_hold);
 		}


### PR DESCRIPTION
Summary:
Fighters and bombers object types can be edited to accept docking or undocking orders. Undocking presented two bugs:

1. Undock never had the path properly reset to -1 when done (dock does). This lead to fighters or bombers never being able to properly attack large ships after undocking due to a conditional if check regarding paths in `ai_big_chase()` (specifically line 1338 in in `aibig.cpp`). This PR properly resets the path when undocking of a fighter is complete. (Recall undocking is completely seperate then bay arrivals or departures). This bug was likely not noticed before now because Fighters and bombers cannot normally undock, only re-arm, that has to be edited in the objecttables, so in retail it was never noticed. Also, re-arm has it's own path and orders, so that case got taken care of elsewhere. In addiition most ships that do undock are cargo ships or ships with turrets, and thus do not have primary weapons, which means the the primary bug never got noticed. Finally, fighters and bombers that are allowed and then given an undock order can still attack other fighters and bombers, this edge case was only when they would try to attack a large ship, so I'm guessing even mods that used them that way didn't really notice.

2. Previously, player or sexp given orders could override an ongoing undock order, which resulted in ships snapping back into place and other not correct movements. Joe recently documented this on his streams here (https://www.youtube.com/watch?v=0L-1FiYmN1g 10:40 mark, thanks to Goober too for the reference).  As it turns out there was already a fix in place to deal with preventing orders when reariming, so the same solution was used to fix the undocking orders.

Both fixes are tested and confirmed. Happy to answer additional questions, and once again thanks to Goober and BMagnu for assistance in tracking this down.