### PR TITLE
patch FRED handling of starfield setup

### DIFF
--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -444,6 +444,9 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	cmd_brief_reset();
 	Show_waypoints = TRUE;
 
+	// mission creation requires the existence of a timestamp snapshot
+	timer_start_frame();
+
 	mission_campaign_clear();
 	create_new_mission();
 

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -713,6 +713,7 @@ void Editor::fix_ship_name(int ship) {
 void Editor::createNewMission() {
 	clearMission();
 	create_player(0, &vmd_zero_vector, &vmd_identity_matrix);
+	stars_post_level_init();
 }
 void Editor::hideMarkedObjects() {
 	object* ptr;

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -252,10 +252,11 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	listener(SubSystem::Ranks);
 	rank_init();
 
+	// mission creation requires the existence of a timestamp snapshot
+	timer_start_frame();
+
 	listener(SubSystem::Campaign);
 	mission_campaign_clear();
-
-	stars_post_level_init();
 
 	// neb lightning
 	listener(SubSystem::NebulaLightning);


### PR DESCRIPTION
1. Skybox initialization (and perhaps other aspects of mission initialization) requires the existence of a timestamp snapshot, so make sure a snapshot has been taken before FRED creates a mission.  Follow-up to #5343.
2. Move `stars_post_level_init()` to `Editor::createNewMission()` in qtFRED to be consistent with FRED's `create_new_mission()`.

Fixes a crash when the user tries to add a skybox when FRED first launches.