### PR TITLE
Traitor overrides feature

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6499,7 +6499,7 @@ void mission::Reset()
 	command_persona = Default_command_persona;
 	strcpy_s(command_sender, DEFAULT_COMMAND);
 	debriefing_persona = debrief_find_persona_index();
-	trtr_override = nullptr;
+	traitor_override_t = nullptr;
 
 	event_music_name[ 0 ] = '\0';
 	briefing_music_name[ 0 ] = '\0';

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6499,6 +6499,7 @@ void mission::Reset()
 	command_persona = Default_command_persona;
 	strcpy_s(command_sender, DEFAULT_COMMAND);
 	debriefing_persona = debrief_find_persona_index();
+	trtr_override = nullptr;
 
 	event_music_name[ 0 ] = '\0';
 	briefing_music_name[ 0 ] = '\0';

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6499,7 +6499,7 @@ void mission::Reset()
 	command_persona = Default_command_persona;
 	strcpy_s(command_sender, DEFAULT_COMMAND);
 	debriefing_persona = debrief_find_persona_index();
-	traitor_override_t = nullptr;
+	traitor_override = nullptr;
 
 	event_music_name[ 0 ] = '\0';
 	briefing_music_name[ 0 ] = '\0';

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -150,7 +150,7 @@ typedef struct mission {
 	int	command_persona;
 	char command_sender[NAME_LENGTH];
 	int debriefing_persona;
-	traitor_override* traitor_override_t;
+	traitor_override_t* traitor_override;
 
 	// Goober5000
 	char event_music_name[NAME_LENGTH];

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -25,6 +25,7 @@
 #include "sound/sound.h"
 #include "mission/mission_flags.h"
 #include "nebula/volumetrics.h"
+#include "stats/scoring.h"
 
 //WMC - This should be here
 #define FS_MISSION_FILE_EXT				NOX(".fs2")
@@ -149,6 +150,7 @@ typedef struct mission {
 	int	command_persona;
 	char command_sender[NAME_LENGTH];
 	int debriefing_persona;
+	traitor_override *trtr_override;
 
 	// Goober5000
 	char event_music_name[NAME_LENGTH];

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -150,7 +150,7 @@ typedef struct mission {
 	int	command_persona;
 	char command_sender[NAME_LENGTH];
 	int debriefing_persona;
-	traitor_override *trtr_override;
+	traitor_override* traitor_override_t;
 
 	// Goober5000
 	char event_music_name[NAME_LENGTH];

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -1064,20 +1064,27 @@ void debrief_traitor_init()
 
 		// if traitor, set up persona-specific traitor debriefing
 		auto stagep = &Traitor_debriefing.stages[0];
+		
+		// see if we are using a traitor override
+		if (The_mission.trtr_override != nullptr) {
+			stagep->text = The_mission.trtr_override->text;
+			strcpy_s(stagep->voice, The_mission.trtr_override->voice_filename);
+			stagep->recommendation_text = The_mission.trtr_override->recommendation_text;
+		} else {
+			// see if we have a persona
+			int persona_index = The_mission.debriefing_persona;
 
-		// see if we have a persona
-		int persona_index = The_mission.debriefing_persona;
+			// use persona-specific traitor text if it exists; otherwise, use default
+			if (Traitor.debriefing_text.find(persona_index) != Traitor.debriefing_text.end())
+				stagep->text = Traitor.debriefing_text[persona_index];
+			else
+				stagep->text = Traitor.debriefing_text[-1];
 
-		// use persona-specific traitor text if it exists; otherwise, use default
-		if (Traitor.debriefing_text.find(persona_index) != Traitor.debriefing_text.end())
-			stagep->text = Traitor.debriefing_text[persona_index];
-		else
-			stagep->text = Traitor.debriefing_text[-1];
+			// choose appropriate traitor voice for this mission
+			debrief_choose_voice(stagep->voice, sizeof(stagep->voice), Traitor.traitor_voice_base, persona_index, 1);
 
-		// choose appropriate traitor voice for this mission
-		debrief_choose_voice(stagep->voice, sizeof(stagep->voice), Traitor.traitor_voice_base, persona_index, 1);
-
-		stagep->recommendation_text = Traitor.recommendation_text;
+			stagep->recommendation_text = Traitor.recommendation_text;
+		}
 	}
 
 	if (!(Game_mode & GM_MULTIPLAYER) && (Game_mode & GM_CAMPAIGN_MODE)) {

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -1066,10 +1066,10 @@ void debrief_traitor_init()
 		auto stagep = &Traitor_debriefing.stages[0];
 		
 		// see if we are using a traitor override
-		if (The_mission.traitor_override_t != nullptr) {
-			stagep->text = The_mission.traitor_override_t->text;
-			strcpy_s(stagep->voice, The_mission.traitor_override_t->voice_filename);
-			stagep->recommendation_text = The_mission.traitor_override_t->recommendation_text;
+		if (The_mission.traitor_override != nullptr) {
+			stagep->text = The_mission.traitor_override->text;
+			strcpy_s(stagep->voice, The_mission.traitor_override->voice_filename);
+			stagep->recommendation_text = The_mission.traitor_override->recommendation_text;
 		} else {
 			// see if we have a persona
 			int persona_index = The_mission.debriefing_persona;

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -1066,10 +1066,10 @@ void debrief_traitor_init()
 		auto stagep = &Traitor_debriefing.stages[0];
 		
 		// see if we are using a traitor override
-		if (The_mission.trtr_override != nullptr) {
-			stagep->text = The_mission.trtr_override->text;
-			strcpy_s(stagep->voice, The_mission.trtr_override->voice_filename);
-			stagep->recommendation_text = The_mission.trtr_override->recommendation_text;
+		if (The_mission.traitor_override_t != nullptr) {
+			stagep->text = The_mission.traitor_override_t->text;
+			strcpy_s(stagep->voice, The_mission.traitor_override_t->voice_filename);
+			stagep->recommendation_text = The_mission.traitor_override_t->recommendation_text;
 		} else {
 			// see if we have a persona
 			int persona_index = The_mission.debriefing_persona;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15838,9 +15838,9 @@ void sexp_set_traitor_override(int node)
 	SCP_string override = CTEXT(node);
 
 	if (!stricmp(override.c_str(), SEXP_NONE_STRING)) {
-		The_mission.traitor_override_t = nullptr;
+		The_mission.traitor_override = nullptr;
 	}else{
-		The_mission.traitor_override_t = get_traitor_override_pointer(override);
+		The_mission.traitor_override = get_traitor_override_pointer(override);
 	}
 }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15837,10 +15837,10 @@ void sexp_set_traitor_override(int node)
 {
 	SCP_string override = CTEXT(node);
 
-	if (!stricmp(override.c_str(), "none")) {
-		The_mission.trtr_override = nullptr;
+	if (!stricmp(override.c_str(), SEXP_NONE_STRING)) {
+		The_mission.traitor_override_t = nullptr;
 	}else{
-		The_mission.trtr_override = get_traitor_override_pointer(override);
+		The_mission.traitor_override_t = get_traitor_override_pointer(override);
 	}
 }
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -139,6 +139,7 @@ enum : int {
 	OPF_MOTION_DEBRIS,				// MjnMixael - Motion debris types as defined in stars.tbl
 	OPF_TURRET_TYPE,				// MjnMixael - Turret types as defined in aiturret.cpp
 	OPF_BOLT_TYPE,					// MjnMixael - Lightning bolt types as defined in lightning.tbl
+	OPF_TRAITOR_OVERRIDE,			// MjnMixael - Traitor overrides as defined in traitor.tbl
 
 	//Must always be at the end of the list
 	First_available_opf_id
@@ -831,6 +832,7 @@ enum : int {
 	OP_CHANGE_BACKGROUND,	// Goober5000
 	OP_CLEAR_DEBRIS,	// Goober5000
 	OP_SET_DEBRIEFING_PERSONA,	// Goober5000
+	OP_SET_TRAITOR_OVERRIDE,	//MjnMixael
 	OP_ADD_TO_COLGROUP_NEW,	// Goober5000
 	OP_REMOVE_FROM_COLGROUP_NEW,	// Goober5000
 	OP_GET_POWER_OUTPUT,	// The E
@@ -1209,6 +1211,7 @@ enum sexp_error_check
 	SEXP_CHECK_INVALID_ASTEROID,
 	SEXP_CHECK_INVALID_MOTION_DEBRIS,
 	SEXP_CHECK_INVALID_BOLT_TYPE,
+	SEXP_CHECK_INVALID_TRAITOR_OVERRIDE,
 };
 
 

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -45,7 +45,7 @@ float Assist_percentage = 0.15f;
 extern debriefing Traitor_debriefing;
 traitor_stuff Traitor;
 
-SCP_vector<traitor_override> Traitor_overrides;
+SCP_vector<traitor_override_t> Traitor_overrides;
 
 // these tables are overwritten with the values from rank.tbl
 SCP_vector<rank_stuff> Ranks;
@@ -59,7 +59,7 @@ float Scoring_scale_factors[NUM_SKILL_LEVELS] = {
 	1.25f					// insane
 };
 
-traitor_override* get_traitor_override_pointer(const SCP_string& name)
+traitor_override_t* get_traitor_override_pointer(const SCP_string& name)
 {
 	for (int i = 0; i < (int)Traitor_overrides.size(); i++) {
 		if (!stricmp(name.c_str(), Traitor_overrides[i].name.c_str())) {
@@ -350,7 +350,7 @@ void parse_traitor_tbl(const char* filename)
 				SCP_string rec;
 				stuff_string(rec, F_MULTITEXT);
 
-				traitor_override traitor;
+				traitor_override_t traitor;
 				traitor.name = name;
 				traitor.text = text;
 				traitor.recommendation_text = rec;

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -62,7 +62,7 @@ float Scoring_scale_factors[NUM_SKILL_LEVELS] = {
 traitor_override* get_traitor_override_pointer(const SCP_string& name)
 {
 	for (int i = 0; i < (int)Traitor_overrides.size(); i++) {
-		if (name == Traitor_overrides[i].name) {
+		if (!stricmp(name.c_str(), Traitor_overrides[i].name.c_str())) {
 			return &Traitor_overrides[i];
 		}
 	}

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -62,7 +62,7 @@ float Scoring_scale_factors[NUM_SKILL_LEVELS] = {
 traitor_override_t* get_traitor_override_pointer(const SCP_string& name)
 {
 	for (int i = 0; i < (int)Traitor_overrides.size(); i++) {
-		if (!stricmp(name.c_str(), Traitor_overrides[i].name.c_str())) {
+		if (SCP_string_lcase_equal_to()(name, Traitor_overrides[i].name)) {
 			return &Traitor_overrides[i];
 		}
 	}

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -45,6 +45,8 @@ float Assist_percentage = 0.15f;
 extern debriefing Traitor_debriefing;
 traitor_stuff Traitor;
 
+SCP_vector<traitor_override> Traitor_overrides;
+
 // these tables are overwritten with the values from rank.tbl
 SCP_vector<rank_stuff> Ranks;
 
@@ -56,6 +58,17 @@ float Scoring_scale_factors[NUM_SKILL_LEVELS] = {
 	1.0f,					// hard
 	1.25f					// insane
 };
+
+traitor_override* get_traitor_override_pointer(const SCP_string& name)
+{
+	for (int i = 0; i < (int)Traitor_overrides.size(); i++) {
+		if (name == Traitor_overrides[i].name) {
+			return &Traitor_overrides[i];
+		}
+	}
+
+	return nullptr;
+}
 
 static rank_stuff* get_rank_pointer(const char* rank_name)
 {
@@ -279,45 +292,73 @@ void parse_traitor_tbl(const char* filename)
 		read_file_text(filename, CF_TYPE_TABLES);
 		reset_parse();
 
-		required_string("#Debriefing_info");
+		if (optional_string("#Debriefing_info")) {
 
-		// no longer used
-		if (optional_string("$Num stages:")) {
-			int junk;
-			stuff_int(&junk); //consume the data and ignore it
-		}
-
-		// no longer used
-		if (optional_string("$Formula:")) {
-			bool junk[1];
-			stuff_bool_list(junk, 1); // consume the data and ignore it
-		}
-
-		while (check_for_string("$multi text"))
-		{
-			SCP_string text;
-			int persona = -1;
-
-			required_string("$multi text");
-			stuff_string(text, F_MULTITEXT);
-
-			if (optional_string("+Persona:"))
-			{
-				stuff_int(&persona);
-				if (persona < 0)
-				{
-					Warning(LOCATION, "Traitor information is assigned to an invalid persona: %i (must be 0 or greater).\n", persona);
-					continue;
-				}
+			// no longer used
+			if (optional_string("$Num stages:")) {
+				int junk;
+				stuff_int(&junk); // consume the data and ignore it
 			}
-			Traitor.debriefing_text[persona] = text;
+
+			// no longer used
+			if (optional_string("$Formula:")) {
+				bool junk[1];
+				stuff_bool_list(junk, 1); // consume the data and ignore it
+			}
+
+			while (check_for_string("$multi text")) {
+				SCP_string text;
+				int persona = -1;
+
+				required_string("$multi text");
+				stuff_string(text, F_MULTITEXT);
+
+				if (optional_string("+Persona:")) {
+					stuff_int(&persona);
+					if (persona < 0) {
+						Warning(LOCATION,
+							"Traitor information is assigned to an invalid persona: %i (must be 0 or greater).\n",
+							persona);
+						continue;
+					}
+				}
+				Traitor.debriefing_text[persona] = text;
+			}
+
+			if (optional_string("$Voice:"))
+				stuff_string(Traitor.traitor_voice_base, F_FILESPEC, MAX_FILENAME_LEN);
+
+			if (optional_string("$Recommendation text:"))
+				stuff_string(Traitor.recommendation_text, F_MULTITEXT);
 		}
 
-		if (optional_string("$Voice:"))
-			stuff_string(Traitor.traitor_voice_base, F_FILESPEC, MAX_FILENAME_LEN);
+		if (optional_string("#Traitor Overrides")) {
+			
+			while (optional_string("$Name:")) {
+				SCP_string name;
+				stuff_string(name, F_NAME);
 
-		if (optional_string("$Recommendation text:"))
-			stuff_string(Traitor.recommendation_text, F_MULTITEXT);
+				required_string("$Text:");
+				SCP_string text;
+				stuff_string(text, F_MULTITEXT);
+
+				required_string("$Voice Filename:");
+				char file[MAX_FILENAME_LEN];
+				stuff_string(file, F_FILESPEC, MAX_FILENAME_LEN);
+
+				required_string("$Recommendation text:");
+				SCP_string rec;
+				stuff_string(rec, F_MULTITEXT);
+
+				traitor_override traitor;
+				traitor.name = name;
+				traitor.text = text;
+				traitor.recommendation_text = rec;
+				strcpy_s(traitor.voice_filename, file);
+
+				Traitor_overrides.push_back(traitor);
+			}
+		}
 	}
 	catch (const parse::ParseException& e)
 	{

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -74,6 +74,13 @@ struct traitor_stuff {
 	SCP_string recommendation_text;
 };
 
+struct traitor_override {
+	SCP_string name;
+	SCP_string text;
+	char       voice_filename[MAX_FILENAME_LEN];
+	SCP_string recommendation_text;
+};
+
 #define STATS_FLAG_INVALID			(1<<0)
 #define STATS_FLAG_CAMPAIGN		(1<<1)
 #define STATS_FLAG_MULTIPLAYER	(1<<2)
@@ -142,6 +149,7 @@ public:
 
 extern SCP_vector<rank_stuff> Ranks;
 extern traitor_stuff Traitor;
+extern SCP_vector<traitor_override> Traitor_overrides;
 
 int verify_rank(int rank);
 
@@ -167,5 +175,7 @@ void scoring_eval_hit(object *hit_obj, object *other_obj, int from_blast = 0);
 
 // get a scaling factor for adding/subtracting from mission score
 float scoring_get_scale_factor();
+
+traitor_override* get_traitor_override_pointer(const SCP_string& name);
 
 #endif

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -74,7 +74,7 @@ struct traitor_stuff {
 	SCP_string recommendation_text;
 };
 
-struct traitor_override {
+struct traitor_override_t {
 	SCP_string name;
 	SCP_string text;
 	char       voice_filename[MAX_FILENAME_LEN];
@@ -149,7 +149,7 @@ public:
 
 extern SCP_vector<rank_stuff> Ranks;
 extern traitor_stuff Traitor;
-extern SCP_vector<traitor_override> Traitor_overrides;
+extern SCP_vector<traitor_override_t> Traitor_overrides;
 
 int verify_rank(int rank);
 
@@ -176,6 +176,6 @@ void scoring_eval_hit(object *hit_obj, object *other_obj, int from_blast = 0);
 // get a scaling factor for adding/subtracting from mission score
 float scoring_get_scale_factor();
 
-traitor_override* get_traitor_override_pointer(const SCP_string& name);
+traitor_override_t* get_traitor_override_pointer(const SCP_string& name);
 
 #endif

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -424,6 +424,7 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	techroom_intel_init();
 	hud_positions_init();
 	asteroid_init();
+	traitor_init();
 
 	// get fireball IDs for sexpression usage
 	// (we don't need to init the entire system via fireball_init, we just need the information)

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -3520,10 +3520,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 			return 0;
 
 		case OPF_TRAITOR_OVERRIDE:
-			if (Traitor_overrides.size() > 0) {
-				return 1;
-			}
-			return 0;
+			return Traitor_overrides.empty() ? 0 : 1;
 
 		default:
 			if (!Dynamic_enums.empty()) {

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -3519,6 +3519,12 @@ int sexp_tree::query_default_argument_available(int op, int i)
 			}
 			return 0;
 
+		case OPF_TRAITOR_OVERRIDE:
+			if (Traitor_overrides.size() > 0) {
+				return 1;
+			}
+			return 0;
+
 		default:
 			if (!Dynamic_enums.empty()) {
 				if ((type - First_available_opf_id) < (int)Dynamic_enums.size()) {
@@ -5592,6 +5598,10 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_bolt_types();
 			break;
 
+		case OPF_TRAITOR_OVERRIDE:
+			list = get_listing_opf_traitor_overrides();
+			break;
+
 		default:
 			//We're at the end of the list so check for any dynamic enums
 			list = check_for_dynamic_sexp_enum(opf);
@@ -7371,6 +7381,19 @@ sexp_list_item* sexp_tree::get_listing_opf_bolt_types()
 
 	for (int i = 0; i < (int)Bolt_types.size(); i++) {
 		head.add_data(Bolt_types[i].name);
+	}
+
+	return head.next;
+}
+
+sexp_list_item* sexp_tree::get_listing_opf_traitor_overrides()
+{
+	sexp_list_item head;
+
+	head.add_data(SEXP_NONE_STRING);
+
+	for (int i = 0; i < (int)Traitor_overrides.size(); i++) {
+		head.add_data(Traitor_overrides[i].name.c_str());
 	}
 
 	return head.next;

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -307,7 +307,8 @@ public:
 	sexp_list_item *get_listing_opf_sexp_containers(ContainerType con_type);
 	sexp_list_item *get_listing_opf_wing_formation();
 	sexp_list_item *check_for_dynamic_sexp_enum(int opf);
-	sexp_list_item* get_listing_opf_bolt_types();
+	sexp_list_item *get_listing_opf_bolt_types();
+	sexp_list_item *get_listing_opf_traitor_overrides();
 
 	// container modifier options for container data nodes
 	sexp_list_item *get_container_modifiers(int con_data_node) const;

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -212,6 +212,9 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	listener(SubSystem::TechroomIntel);
 	techroom_intel_init();
 
+	listener(SubSystem::Traitor);
+	traitor_init();
+
 	// get fireball IDs for sexpression usage
 	// (we don't need to init the entire system via fireball_init, we just need the information)
 	fireball_parse_tbl();

--- a/qtfred/src/mission/management.h
+++ b/qtfred/src/mission/management.h
@@ -40,6 +40,7 @@ enum class SubSystem {
 	Ships,
 	Parse,
 	TechroomIntel,
+	Traitor,
 	Nebulas,
 	Stars,
 	Ssm,

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1716,10 +1716,7 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 		return 0;
 
 	case OPF_TRAITOR_OVERRIDE:
-		if (Traitor_overrides.size() > 0) {
-			return 1;
-		}
-		return 0;
+		return Traitor_overrides.empty() ? 0 : 1;
 
 	default:
 		if (!Dynamic_enums.empty()) {

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1715,6 +1715,12 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 		}
 		return 0;
 
+	case OPF_TRAITOR_OVERRIDE:
+		if (Traitor_overrides.size() > 0) {
+			return 1;
+		}
+		return 0;
+
 	default:
 		if (!Dynamic_enums.empty()) {
 			if ((type - First_available_opf_id) < (int)Dynamic_enums.size()) {
@@ -3493,6 +3499,10 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 		list = get_listing_opf_bolt_types();
 		break;
 
+	case OPF_TRAITOR_OVERRIDE:
+		list = get_listing_opf_traitor_overrides();
+		break;
+
 	default:
 		// We're at the end of the list so check for any dynamic enums
 		list = check_for_dynamic_sexp_enum(opf);
@@ -5158,6 +5168,19 @@ sexp_list_item* sexp_tree::get_listing_opf_bolt_types()
 
 	for (int i = 0; i < (int)Bolt_types.size(); i++) {
 		head.add_data(Bolt_types[i].name);
+	}
+
+	return head.next;
+}
+
+sexp_list_item* sexp_tree::get_listing_opf_traitor_overrides()
+{
+	sexp_list_item head;
+
+	head.add_data(SEXP_NONE_STRING);
+
+	for (int i = 0; i < (int)Traitor_overrides.size(); i++) {
+		head.add_data(Traitor_overrides[i].name.c_str());
 	}
 
 	return head.next;

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -356,8 +356,9 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item *get_listing_opf_animation_name(int parent_node);
 	static sexp_list_item *get_listing_opf_sexp_containers(ContainerType con_type);
 	sexp_list_item *get_listing_opf_wing_formation();
-	sexp_list_item* check_for_dynamic_sexp_enum(int opf);
-	sexp_list_item* get_listing_opf_bolt_types();
+	sexp_list_item *check_for_dynamic_sexp_enum(int opf);
+	sexp_list_item *get_listing_opf_bolt_types();
+	sexp_list_item *get_listing_opf_traitor_overrides();
 
 	// container modifier options for container data nodes
 	sexp_list_item *get_container_modifiers(int con_data_node) const;


### PR DESCRIPTION
Adds a new Traitor Overrides feature as discussed with WookieJedi. This allows much more fine-tuned control of the traitor debrief than persona system allows.

You define a traitor debrief in traitor.tbl under the new `#traitor overrides` section. Each debrief gets a unique Name identifier. You set the text, audio file, and recommendation text for each one. A new sexp is used in FRED to define which traitor override debrief to use.

The traitor override pointer defaults to nullptr. If it remains nullptr then the old persona setup is used. Otherwise the debrief will use the override.