### PR TITLE
Fix 5405

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -547,8 +547,11 @@ namespace joystick
 	{
 		_joystick = SDL_JoystickOpen(device_id);
 
-		if (_joystick == nullptr)
-			throw std::exception("Failed to open a joystick, get a coder!");
+		if (_joystick == nullptr) {
+			SCP_stringstream msg;
+			msg << "Failed to open joystick with id " << device_id << ", get a coder!";
+			throw std::runtime_error(msg.str());
+		}
 
 		fillValues();
 	}

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -329,7 +329,7 @@ void enumerateJoysticks(SCP_vector<JoystickPtr>& outVec)
 
 				outVec.push_back(std::move(ptr));
 			}
-			catch (const std::exception e)
+			catch (const std::exception &e)
 			{
 				mprintf(("  An error occured while attempting to enumerate joystick %i.\n", i));
 				mprintf(("    %s\n", e.what()));

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -322,10 +322,20 @@ void enumerateJoysticks(SCP_vector<JoystickPtr>& outVec)
 	mprintf(("Printing joystick info:\n"));
 
 	for (auto i = 0; i < num; ++i) {
-		auto ptr = JoystickPtr(new Joystick(i));
-		ptr->printInfo();
+			try
+			{
+				auto ptr = JoystickPtr(new Joystick(i));
+				ptr->printInfo();
 
-		outVec.push_back(std::move(ptr));
+				outVec.push_back(std::move(ptr));
+			}
+			catch (const std::exception e)
+			{
+				mprintf(("  An error occured while attempting to enumerate joystick %i.\n", i));
+				mprintf(("    %s\n", e.what()));
+				mprintf(("    %s\n", SDL_GetError()));
+				SDL_ClearError();
+			}
 	}
 }
 
@@ -537,7 +547,8 @@ namespace joystick
 	{
 		_joystick = SDL_JoystickOpen(device_id);
 
-		Assertion(_joystick != nullptr, "Failed to open a joystick, get a coder!");
+		if (_joystick != nullptr)
+			throw std::exception("Failed to open a joystick, get a coder!");
 
 		fillValues();
 	}

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -547,7 +547,7 @@ namespace joystick
 	{
 		_joystick = SDL_JoystickOpen(device_id);
 
-		if (_joystick != nullptr)
+		if (_joystick == nullptr)
 			throw std::exception("Failed to open a joystick, get a coder!");
 
 		fillValues();

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -61,6 +61,9 @@ namespace io
 			 * object is deleted.
 			 *
 			 * @param device_id The SDL device index
+			 * 
+			 * @throws a std::exception if SDL_JoystickOpen() could not open the joystick. Clients creating a Joystick
+			 *   instance should call SDL_GetError() afterwards to get details from SDL.
 			 */
 			explicit Joystick(int device_id);
 

--- a/code/io/joy.h
+++ b/code/io/joy.h
@@ -62,7 +62,7 @@ namespace io
 			 *
 			 * @param device_id The SDL device index
 			 * 
-			 * @throws a std::exception if SDL_JoystickOpen() could not open the joystick. Clients creating a Joystick
+			 * @throws a std::runtime_error if SDL_JoystickOpen() could not open the joystick. Clients creating a Joystick
 			 *   instance should call SDL_GetError() afterwards to get details from SDL.
 			 */
 			explicit Joystick(int device_id);


### PR DESCRIPTION
As it was recently proven with #5405, joysticks may be enumerated by the OS but may fail when SDL attempts to open them.  The original assert within the io::joystick::Joystick constructor was triggered when a Nintendo Switch controller was plugged in and effectively halted FSO from recovering.

This fix changes that `Assertion` into a throw and `enumerateJoysticks` has been updated to catch the thrown exception and log the error message.  It should allow users to play FSO with having the bugged-out controller disabled/unavailable.

These changes should also hide the GUID of the controller, since get-flags and joy-info need to enumerate the joysticks before they can get the GUID.