### PR TITLE
fix qtFRED initialization

### DIFF
--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -204,6 +204,8 @@ int main(int argc, char* argv[]) {
 		QTimer::singleShot(500, [&]() {
 			fred->loadMission(Cmdline_start_mission);
 		});
+	} else {
+		fred->createNewMission();
 	}
 
 	// Render first correct frame

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -491,8 +491,6 @@ void Editor::initialSetup() {
 
 	Id_select_type_waypoint = (int) (Ship_info.size());
 	Id_select_type_jump_node = (int) (Ship_info.size() + 1);
-
-	createNewMission();
 }
 
 void Editor::setupCurrentObjectIndices(int selectedObj) {


### PR DESCRIPTION
The `stars_post_level_init()` change in #5403 exposed a bug where qtFRED would sometimes try to render the mission before all setup had been completed, causing a crash because `Show_iffs` was zero-length.  This was due to the mission being created in the middle of initialization, instead of after initialization was complete.  This fix moves `createNewMission()` to main.cpp, after initialization has finished, and in parallel with the command-line option to load a mission.