### PR TITLE
Fix asteroid wrapping

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -704,11 +704,29 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 
 	Asteroid_field.num_initial_asteroids = num_asteroids;
 
-	if (field_type == 0) {
-		Asteroid_field.field_type = FT_PASSIVE;
-	} else {
-		Asteroid_field.field_type = FT_ACTIVE;
+	switch (field_type) {
+		case 0:
+			Asteroid_field.field_type = FT_PASSIVE;
+			Asteroid_field.enhanced_visibility_checks = false;
+			break;
+		case 1:
+			Asteroid_field.field_type = FT_ACTIVE;
+			Asteroid_field.enhanced_visibility_checks = false;
+			break;
+		case 2:
+			Asteroid_field.field_type = FT_PASSIVE;
+			Asteroid_field.enhanced_visibility_checks = true;
+			break;
+		case 3:
+			Asteroid_field.field_type = FT_ACTIVE;
+			Asteroid_field.enhanced_visibility_checks = true;
+			break;
+		default: //Any other number will just give default behavior
+			Asteroid_field.field_type = FT_PASSIVE;
+			Asteroid_field.enhanced_visibility_checks = false;
+			break;
 	}
+
 	vm_vec_rand_vec_quick(&Asteroid_field.vel);
 	vm_vec_scale(&Asteroid_field.vel, (float)asteroid_speed);
 	Asteroid_field.speed = (float)asteroid_speed;
@@ -750,11 +768,6 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 		Asteroid_field.inner_max_bound = i_max;
 	}
 
-	// For now this cannot be adjusted via sexp because altering the sexp that uses
-	// repeating arguments proves challenging. If requested a specific 
-	// field-use-enhanced-checks sexp could be created.
-	Asteroid_field.enhanced_visibility_checks = false;
-
 	Asteroid_field.target_names = targets;
 
 	// Only create asteroids if we have some to create
@@ -764,13 +777,15 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 }
 
 // will replace any existing asteroid or debris field with a debris field
-void asteroid_create_debris_field(int num_asteroids, int asteroid_speed, int debris1, int debris2, int debris3, vec3d o_min, vec3d o_max)
+void asteroid_create_debris_field(int num_asteroids, int asteroid_speed, int debris1, int debris2, int debris3, vec3d o_min, vec3d o_max, bool enhanced)
 {
 	remove_all_asteroids();
 
 	Asteroid_field.num_initial_asteroids = num_asteroids;
 
 	Asteroid_field.field_type = FT_PASSIVE;
+
+	Asteroid_field.enhanced_visibility_checks = enhanced;
 
 	vm_vec_rand_vec_quick(&Asteroid_field.vel);
 	vm_vec_scale(&Asteroid_field.vel, (float)asteroid_speed);

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -750,8 +750,6 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 		Asteroid_field.inner_max_bound = i_max;
 	}
 
-	Asteroid_field.enhanced_visibility_checks = false;
-
 	// For now this cannot be adjusted via sexp because altering the sexp that uses
 	// repeating arguments proves challenging. If requested a specific 
 	// field-use-enhanced-checks sexp could be created.
@@ -1013,15 +1011,15 @@ bool asteroid_is_within_view(vec3d *pos, float range, bool range_override)
 	vec3d vec_to_asteroid;
 
 	// Distance and view cone for the position in relation to the player
-	float cur_dist = vm_vec_normalized_dir(&vec_to_asteroid, pos, &Eye_position);
-	float cur_dot = vm_vec_dot(&Eye_matrix.vec.fvec, &vec_to_asteroid);
+	float dist = vm_vec_normalized_dir(&vec_to_asteroid, pos, &Eye_position);
+	float dot = vm_vec_dot(&Eye_matrix.vec.fvec, &vec_to_asteroid);
 
 	// if asteroid is within view or far enough away then wrap
-	if (cur_dot > cos(Proj_fov)) {
+	if (dot > cos(Proj_fov)) {
 		if (range_override) {
 			return true;
 		} else {
-			if (cur_dist < range) {
+			if (dist < range) {
 				return true;
 			}
 		}
@@ -1070,7 +1068,7 @@ static void maybe_throw_asteroid()
 		if (subtype < 0)
 			return;
 
-		object* objp = asteroid_create(&Asteroid_field, ASTEROID_TYPE_LARGE, subtype, Asteroid_field.enhanced_visibility_checks);
+		object *objp = asteroid_create(&Asteroid_field, ASTEROID_TYPE_LARGE, subtype, Asteroid_field.enhanced_visibility_checks);
 		if (objp != nullptr) {
 			asteroid_aim_at_target(target_objp, objp, ASTEROID_MIN_COLLIDE_TIME + frand() * 20.0f);
 
@@ -1150,7 +1148,7 @@ static void asteroid_maybe_reposition(object *objp, asteroid_field *asfieldp)
 		if (asteroid_is_within_view(&objp->pos, asfieldp->bound_rad, asfieldp->enhanced_visibility_checks)) {
 
 			// if asteroid new position is within view then reverse velocity, otherwise wrap
-			if (asteroid_is_within_view(&objp->pos, (asfieldp->bound_rad * 1.3f), asfieldp->enhanced_visibility_checks)) {
+			if (asteroid_is_within_view(&new_pos, (asfieldp->bound_rad * 1.3f), asfieldp->enhanced_visibility_checks)) {
 
 				// if the mission has gravity, then we can't reverse. So make sure gravity is null
 				if (IS_VEC_NULL(&The_mission.gravity)) {
@@ -1180,11 +1178,11 @@ static void asteroid_maybe_reposition(object *objp, asteroid_field *asfieldp)
 		// We can wrap, so wrap!
 		if (wrap) {
 			objp->pos = new_pos;
-			asteroid* astp = &Asteroids[objp->instance];
+			asteroid *astp = &Asteroids[objp->instance];
 
 			if (asfieldp->field_type == FT_ACTIVE) {
 				// this doesnt count as a thrown asteroid anymore
-				for (asteroid_target& target : Asteroid_targets)
+				for (asteroid_target &target : Asteroid_targets)
 					if (target.objnum == astp->target_objnum)
 						target.incoming_asteroids--;
 

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -164,7 +164,7 @@ void	asteroid_level_init();
 void	asteroid_level_close();
 void	asteroid_create_all();
 void	asteroid_create_asteroid_field(int num_asteroids, int field_type, int asteroid_speed, bool brown, bool blue, bool orange, vec3d o_min, vec3d o_max, bool inner_box, vec3d i_min, vec3d i_max, SCP_vector<SCP_string> targets);
-void	asteroid_create_debris_field(int num_asteroids, int asteroid_speed, int debris1, int debris2, int debris3, vec3d o_min, vec3d o_max);
+void	asteroid_create_debris_field(int num_asteroids, int asteroid_speed, int debris1, int debris2, int debris3, vec3d o_min, vec3d o_max, bool enhanced);
 void	asteroid_render(object* obj, model_draw_list* scene);
 void	asteroid_delete( object *asteroid_objp );
 void	asteroid_process_pre( object *asteroid_objp );

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -143,6 +143,7 @@ typedef	struct asteroid_field {
 	debris_genre_t	debris_genre;		// type of debris (ship or asteroid)  [generic type]
 	int				field_debris_type[MAX_ACTIVE_DEBRIS_TYPES];	// one of the debris type defines above
 	int				num_used_field_debris_types;	// how many of the above are used
+	bool            enhanced_visibility_checks;     // if true then range checks are overridden for spawning and wrapping asteroids in the field
 
 	SCP_vector<SCP_string> target_names;	// default retail behavior is to just throw at the first big ship in the field
 } asteroid_field;
@@ -158,6 +159,7 @@ extern vec3d	Asteroid_icon_closeup_position;  // closeup position for asteroid f
 extern float	Asteroid_icon_closeup_zoom;		 // zoom position for asteroid field briefing icon rendering
 
 void	asteroid_init();
+bool    asteroid_is_within_view(vec3d *pos, float range, bool range_override = false);
 void	asteroid_level_init();
 void	asteroid_level_close();
 void	asteroid_create_all();
@@ -176,6 +178,9 @@ void	asteroid_show_brackets();
 void	asteroid_target_closest_danger();
 void asteroid_add_target(object* objp);
 int get_asteroid_index(const char* asteroid_name);
+
+// need to extern for keycontrol debug commands
+object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int asteroid_subtype, bool check_visibility = false);
 
 // need to extern for multiplayer
 void asteroid_sub_create(object *parent_objp, int asteroid_type, vec3d *relvec);

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1013,7 +1013,6 @@ void process_debug_keys(int k)
 		case KEY_DEBUGGED + KEY_U: {
 		case KEY_DEBUGGED1 + KEY_U:
 			// launch asteroid
-			object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int subtype);
 			object *objp = asteroid_create(&Asteroid_field, 0, 0);
 			if(objp == NULL) {
 				break;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5809,8 +5809,8 @@ void parse_asteroid_fields(mission *pm)
 			Asteroid_field.has_inner_bound = false;
 		}
 
-		if (optional_string("+Use Enhanced Checks:")) {
-			stuff_boolean(&Asteroid_field.enhanced_visibility_checks);
+		if (optional_string("+Use Enhanced Checks")) {
+			Asteroid_field.enhanced_visibility_checks = true;
 		}
 
 		if (optional_string("$Asteroid Targets:")) {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5809,6 +5809,10 @@ void parse_asteroid_fields(mission *pm)
 			Asteroid_field.has_inner_bound = false;
 		}
 
+		if (optional_string("+Consider Range:")) {
+			stuff_boolean(&Asteroid_field.enhanced_visibility_checks);
+		}
+
 		if (optional_string("$Asteroid Targets:")) {
 			stuff_string_list(Asteroid_field.target_names);
 		}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5809,7 +5809,7 @@ void parse_asteroid_fields(mission *pm)
 			Asteroid_field.has_inner_bound = false;
 		}
 
-		if (optional_string("+Consider Range:")) {
+		if (optional_string("+Use Enhanced Checks:")) {
 			stuff_boolean(&Asteroid_field.enhanced_visibility_checks);
 		}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -749,7 +749,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "set-ambient-light",				OP_SET_AMBIENT_LIGHT,					3,	3,			SEXP_ACTION_OPERATOR,	},	// Karajorma
 	{ "toggle-asteroid-field",			OP_TOGGLE_ASTEROID_FIELD,				1,	1,			SEXP_ACTION_OPERATOR,	},	// MjnMixael
 	{ "set-asteroid-field",				OP_SET_ASTEROID_FIELD,					1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// MjnMixael
-	{ "set-debris-field",				OP_SET_DEBRIS_FIELD,					1,	11,			SEXP_ACTION_OPERATOR,	},	// MjnMixael
+	{ "set-debris-field",				OP_SET_DEBRIS_FIELD,					1,	12,			SEXP_ACTION_OPERATOR,	},	// MjnMixael
 	{ "set-motion-debris",			    OP_SET_MOTION_DEBRIS,					1,	1,			SEXP_ACTION_OPERATOR,	},	// MjnMixael
 
 	//Jump Node Sub-Category
@@ -15747,6 +15747,12 @@ void sexp_set_debris_field(int n)
 		}
 	}
 
+	bool enhanced = false;
+	if (n >= 0) {
+		enhanced = is_sexp_true(n);
+		n = CDR(n);
+	}
+
 	if (num_asteroids > MAX_ASTEROIDS) {
 		num_asteroids = MAX_ASTEROIDS;
 	}
@@ -15761,7 +15767,8 @@ void sexp_set_debris_field(int n)
 		debris2,
 		debris3,
 		o_min,
-		o_max);
+		o_max,
+		enhanced);
 }
 
 void sexp_set_motion_debris_type(int n)
@@ -32321,8 +32328,10 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_POSITIVE;
 			else if (argnum <= 4)
 				return OPF_ASTEROID_DEBRIS;
-			else
+			else if (argnum <= 10)
 				return OPF_NUMBER;
+			else
+				return OPF_BOOL;
 
 		case OP_SET_MOTION_DEBRIS:
 			return OPF_MOTION_DEBRIS;
@@ -39884,7 +39893,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tCreates or overwrites the asteroid or debris field with an asteroid field. \r\n"
 		"\tTakes 1 or more arguments...\r\n"
 		"\t1:\tNumber of asteroids in the field, or 0 to remove an existing field\r\n" 
-		"\t2:\t0 for active field, 1 for passive field, defaults to 0\r\n"
+		"\t2:\t0 for passive field, 1 for active field, 2 for enhanced passive, 3 for enhanced active, defaults to 0\r\n"
 		"\t3:\tThe speed of the asteroids, defaults to 0\r\n"
 		"\t4:\tTrue to enable brown asteroids, defaults to true\r\n"
 		"\t5:\tTrue to enable blue asteroids, defaults to false\r\n"
@@ -39919,6 +39928,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t9:\tOuterbox Max Y, defaults to 1000\r\n"
 		"\t10:\tOuterbox Min Z, defaults to -1000\r\n"
 		"\t11:\tOuterbox Max Z, defaults to 1000\r\n"
+		"\t12:\tIf the field uses enhanced spawning checks, defaults to false\r\n"
 	},
 
 	{ OP_SET_MOTION_DEBRIS, "set-motion-debris\r\n" 

--- a/fred2/asteroideditordlg.cpp
+++ b/fred2/asteroideditordlg.cpp
@@ -107,7 +107,7 @@ BEGIN_MESSAGE_MAP(asteroid_editor, CDialog)
 	ON_BN_CLICKED(IDC_REMOVE_FIELD_TARGET, OnRemoveFieldTarget)
 	ON_BN_CLICKED(IDC_RANGE_OVERRIDE, OnEnableRangeOverride)
 	//}}AFX_MSG_MAP
-	END_MESSAGE_MAP()
+END_MESSAGE_MAP()
 
 /////////////////////////////////////////////////////////////////////////////
 // asteroid_editor message handlers

--- a/fred2/asteroideditordlg.cpp
+++ b/fred2/asteroideditordlg.cpp
@@ -57,6 +57,7 @@ asteroid_editor::asteroid_editor(CWnd* pParent /*=NULL*/)
 	m_box_min_y = _T("");
 	m_box_min_z = _T("");
 	m_field_target_index = -1;
+	m_field_enhanced_checks = FALSE;
 	m_field_targets.clear();
 	//}}AFX_DATA_INIT
 
@@ -86,6 +87,7 @@ void asteroid_editor::DoDataExchange(CDataExchange* pDX)
 	DDX_Text(pDX, IDC_INNER_MIN_X, m_box_min_x);
 	DDX_Text(pDX, IDC_INNER_MIN_Y, m_box_min_y);
 	DDX_Text(pDX, IDC_INNER_MIN_Z, m_box_min_z);
+	DDX_Check(pDX, IDC_RANGE_OVERRIDE, m_field_enhanced_checks);
 	//}}AFX_DATA_MAP
 }
 
@@ -103,8 +105,9 @@ BEGIN_MESSAGE_MAP(asteroid_editor, CDialog)
 	ON_LBN_SELCHANGE(IDC_FIELD_TARGET_LIST, OnFieldTargetChange)
 	ON_BN_CLICKED(IDC_ADD_FIELD_TARGET, OnAddFieldTarget)
 	ON_BN_CLICKED(IDC_REMOVE_FIELD_TARGET, OnRemoveFieldTarget)
+	ON_BN_CLICKED(IDC_RANGE_OVERRIDE, OnEnableRangeOverride)
 	//}}AFX_MSG_MAP
-END_MESSAGE_MAP()
+	END_MESSAGE_MAP()
 
 /////////////////////////////////////////////////////////////////////////////
 // asteroid_editor message handlers
@@ -190,6 +193,9 @@ int asteroid_editor::query_modified()
 			if (a_field[i].inner_min_bound.xyz.z != Asteroid_field.inner_min_bound.xyz.z)
 				return 1;
 		}
+
+		if (a_field[i].enhanced_visibility_checks != Asteroid_field.enhanced_visibility_checks)
+			return 1;
 
 		if (a_field[i].target_names != Asteroid_field.target_names)
 			return 1;
@@ -409,6 +415,8 @@ void asteroid_editor::update_init()
 		MODIFY(a_field[last_field].inner_max_bound.xyz.y, (float) atof(m_box_max_y));
 		MODIFY(a_field[last_field].inner_max_bound.xyz.z, (float) atof(m_box_max_z));
 
+		MODIFY(a_field[last_field].enhanced_visibility_checks, (bool)m_field_enhanced_checks);
+
 		MODIFY(a_field[last_field].target_names, m_field_targets);
 	}
 
@@ -416,6 +424,7 @@ void asteroid_editor::update_init()
 	// get from temp asteroid field into class
 	m_enable_asteroids = a_field[cur_field].num_initial_asteroids ? TRUE : FALSE;
 	m_enable_inner_bounds = a_field[cur_field].has_inner_bound ? TRUE : FALSE;
+	m_field_enhanced_checks = a_field[cur_field].enhanced_visibility_checks ? TRUE : FALSE;
 	m_density = a_field[cur_field].num_initial_asteroids;
 	if (!m_enable_asteroids)
 		m_density = 10;
@@ -593,6 +602,11 @@ void asteroid_editor::OnEnableInnerBox()
 	GetDlgItem(IDC_INNER_MAX_Y)->EnableWindow(m_enable_inner_bounds && m_enable_asteroids);
 	GetDlgItem(IDC_INNER_MIN_Z)->EnableWindow(m_enable_inner_bounds && m_enable_asteroids);
 	GetDlgItem(IDC_INNER_MAX_Z)->EnableWindow(m_enable_inner_bounds && m_enable_asteroids);
+}
+
+void asteroid_editor::OnEnableRangeOverride()
+{
+	UpdateData(TRUE);
 }
 
 // 

--- a/fred2/asteroideditordlg.h
+++ b/fred2/asteroideditordlg.h
@@ -54,6 +54,7 @@ public:
 	CString			m_box_min_y;
 	CString			m_box_min_z;
 	int				m_field_target_index;
+	int             m_field_enhanced_checks;
 	SCP_vector<SCP_string> m_field_targets;
 	//}}AFX_DATA
 
@@ -87,6 +88,7 @@ protected:
 	afx_msg void OnFieldTargetChange();
 	afx_msg void OnAddFieldTarget();
 	afx_msg void OnRemoveFieldTarget();
+	afx_msg void OnEnableRangeOverride();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -1659,6 +1659,8 @@ BEGIN
     LISTBOX         IDC_FIELD_TARGET_LIST,385,70,151,60,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "Add",IDC_ADD_FIELD_TARGET,385,136,41,14
     PUSHBUTTON      "Remove",IDC_REMOVE_FIELD_TARGET,430,136,40,14
+    CONTROL         "Use enhanced spawn checking",IDC_RANGE_OVERRIDE, "Button",BS_AUTOCHECKBOX | WS_TABSTOP,193,163,130,10
+    LTEXT           "(By default player range is checked in addition to the player view cone for spawning asteroids. In small fields you may want to override this behavior.)",IDC_STATIC,192,176,155,26
 END
 
 IDD_CAMPAIGN DIALOGEX 0, 0, 270, 441

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -827,10 +827,10 @@ int CFred_mission_save::save_asteroid_fields()
 
 		if (Asteroid_field.enhanced_visibility_checks) {
 			if (Mission_save_format != FSO_FORMAT_RETAIL) {
-				if (optional_string_fred("+Consider Range:")) {
+				if (optional_string_fred("+Use Enhanced Checks:")) {
 					parse_comments();
 				} else {
-					fout("\n+Consider Range:");
+					fout("\n+Use Enhanced Checks:");
 				}
 				fout(" %b", Asteroid_field.enhanced_visibility_checks);
 			}

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -825,6 +825,17 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
+		if (Asteroid_field.enhanced_visibility_checks) {
+			if (Mission_save_format != FSO_FORMAT_RETAIL) {
+				if (optional_string_fred("+Consider Range:")) {
+					parse_comments();
+				} else {
+					fout("\n+Consider Range:");
+				}
+				fout(" %b", Asteroid_field.enhanced_visibility_checks);
+			}
+		}
+
 		if (!Asteroid_field.target_names.empty()) {
 			fso_comment_push(";;FSO 22.0.0;;");
 			if (optional_string_fred("$Asteroid Targets:")) {

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -827,12 +827,11 @@ int CFred_mission_save::save_asteroid_fields()
 
 		if (Asteroid_field.enhanced_visibility_checks) {
 			if (Mission_save_format != FSO_FORMAT_RETAIL) {
-				if (optional_string_fred("+Use Enhanced Checks:")) {
+				if (optional_string_fred("+Use Enhanced Checks")) {
 					parse_comments();
 				} else {
-					fout("\n+Use Enhanced Checks:");
+					fout("\n+Use Enhanced Checks");
 				}
-				fout(" %b", Asteroid_field.enhanced_visibility_checks);
 			}
 		}
 

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -953,6 +953,7 @@
 #define IDC_ESCORT_PRIORITY             1504
 #define IDC_ENABLE_INNER_BOX            1505
 #define IDC_ENABLE_SPECIAL_EXP          1506
+#define IDC_RANGE_OVERRIDE              1506
 #define IDC_SPECIAL_DAMAGE              1507
 #define IDC_ENABLE_SHOCKWAVE            1508
 #define IDC_SPECIAL_BLAST               1509

--- a/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
@@ -8,6 +8,7 @@ AsteroidEditorDialogModel::AsteroidEditorDialogModel(QObject* parent, EditorView
 	AbstractDialogModel(parent, viewport),
 	_enable_asteroids(false),
 	_enable_inner_bounds(false),
+	_enable_enhanced_checking(false),
 	_num_asteroids(0),
 	_avg_speed(0),
 	_min_x(""),
@@ -81,6 +82,16 @@ void AsteroidEditorDialogModel::setInnerBoxEnabled(bool enabled)
 bool AsteroidEditorDialogModel::getInnerBoxEnabled()
 {
 	return _enable_inner_bounds;
+}
+
+void AsteroidEditorDialogModel::setEnhancedEnabled(bool enabled)
+{
+	_enable_enhanced_checking = enabled;
+}
+
+bool AsteroidEditorDialogModel::getEnhancedEnabled()
+{
+	return _enable_enhanced_checking;
 }
 
 void AsteroidEditorDialogModel::setAsteroidEnabled(_roid_types type, bool enabled)
@@ -388,12 +399,15 @@ void AsteroidEditorDialogModel::update_init()
 		}
 
 		modify(_a_field.has_inner_bound, _enable_inner_bounds);
+
+		modify(_a_field.enhanced_visibility_checks, _enable_enhanced_checking);
 	}
 
 	// get from temp asteroid field into class
 	_enable_asteroids = _a_field.num_initial_asteroids ? true : false;
 	_enable_inner_bounds = _a_field.has_inner_bound;
 	_num_asteroids = _a_field.num_initial_asteroids;
+	_enable_enhanced_checking = _a_field.enhanced_visibility_checks;
 	if (!_enable_asteroids) {
 		_num_asteroids = 10;
 	}

--- a/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.h
@@ -41,6 +41,8 @@ public:
 	bool getEnabled();
 	void setInnerBoxEnabled(bool enabled);
 	bool getInnerBoxEnabled();
+	void setEnhancedEnabled(bool enabled);
+	bool getEnhancedEnabled();
 	void setAsteroidEnabled(_roid_types type, bool enabled);
 	bool getAsteroidEnabled(_roid_types type);
 	void setNumAsteroids(int num_asteroids);
@@ -72,6 +74,7 @@ private:
 
 	bool  _enable_asteroids;
 	bool  _enable_inner_bounds;
+	bool  _enable_enhanced_checking;
 	int   _num_asteroids;
 	int   _avg_speed;
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -839,6 +839,17 @@ int CFred_mission_save::save_asteroid_fields()
 			save_vector(Asteroid_field.inner_max_bound);
 		}
 
+		if (Asteroid_field.enhanced_visibility_checks) {
+			if (save_format != MissionFormat::RETAIL) {
+				if (optional_string_fred("+Consider Range:")) {
+					parse_comments();
+				} else {
+					fout("\n+Consider Range:");
+				}
+				fout(" %b", Asteroid_field.enhanced_visibility_checks);
+			}
+		}
+
 		if (!Asteroid_field.target_names.empty()) {
 			fso_comment_push(";;FSO 22.0.0;;");
 			if (optional_string_fred("$Asteroid Targets:")) {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -841,10 +841,10 @@ int CFred_mission_save::save_asteroid_fields()
 
 		if (Asteroid_field.enhanced_visibility_checks) {
 			if (save_format != MissionFormat::RETAIL) {
-				if (optional_string_fred("+Consider Range:")) {
+				if (optional_string_fred("+Use Enhanced Checks:")) {
 					parse_comments();
 				} else {
-					fout("\n+Consider Range:");
+					fout("\n+Use Enhanced Checks:");
 				}
 				fout(" %b", Asteroid_field.enhanced_visibility_checks);
 			}

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -841,12 +841,11 @@ int CFred_mission_save::save_asteroid_fields()
 
 		if (Asteroid_field.enhanced_visibility_checks) {
 			if (save_format != MissionFormat::RETAIL) {
-				if (optional_string_fred("+Use Enhanced Checks:")) {
+				if (optional_string_fred("+Use Enhanced Checks")) {
 					parse_comments();
 				} else {
-					fout("\n+Use Enhanced Checks:");
+					fout("\n+Use Enhanced Checks");
 				}
-				fout(" %b", Asteroid_field.enhanced_visibility_checks);
 			}
 		}
 

--- a/qtfred/src/ui/dialogs/AsteroidEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/AsteroidEditorDialog.cpp
@@ -29,6 +29,8 @@ AsteroidEditorDialog::AsteroidEditorDialog(FredView *parent, EditorViewport* vie
 	connect(ui->enabled, &QCheckBox::toggled, this, &AsteroidEditorDialog::toggleEnabled);
 	connect(ui->innerBoxEnabled, &QCheckBox::toggled, this, &AsteroidEditorDialog::toggleInnerBoxEnabled);
 
+	connect(ui->enhancedFieldEnabled, &QCheckBox::toggled, this, &AsteroidEditorDialog::toggleEnhancedEnabled);
+
 	connect(ui->checkBoxBrown, &QCheckBox::toggled, this,
 				[this](bool enabled) { \
 				AsteroidEditorDialog::toggleAsteroid(AsteroidEditorDialogModel::_AST_BROWN, enabled); });
@@ -228,6 +230,12 @@ void AsteroidEditorDialog::toggleInnerBoxEnabled(bool enabled)
 	updateUI();
 }
 
+void AsteroidEditorDialog::toggleEnhancedEnabled(bool enabled)
+{
+	_model->setEnhancedEnabled(enabled);
+	updateUI();
+}
+
 void AsteroidEditorDialog::toggleAsteroid(AsteroidEditorDialogModel::_roid_types colour, bool enabled)
 {
 	_model->setAsteroidEnabled(colour, enabled);
@@ -253,6 +261,7 @@ void AsteroidEditorDialog::updateUI()
 	bool inner_box_enabled = _model->getInnerBoxEnabled();
 	bool field_is_active = (_model->getFieldType() == FT_ACTIVE);
 	bool debris_is_asteroid = (_model->getDebrisGenre() == DG_ASTEROID);
+	bool enhanced_is_active = _model->getEnhancedEnabled();
 
 	// checkboxes
 	ui->enabled->setChecked(asteroids_enabled);
@@ -260,6 +269,7 @@ void AsteroidEditorDialog::updateUI()
 	ui->checkBoxBrown->setChecked(_model->getAsteroidEnabled(AsteroidEditorDialogModel::_AST_BROWN));
 	ui->checkBoxBlue->setChecked(_model->getAsteroidEnabled(AsteroidEditorDialogModel::_AST_BLUE));
 	ui->checkBoxOrange->setChecked(_model->getAsteroidEnabled(AsteroidEditorDialogModel::_AST_ORANGE));
+	ui->enhancedFieldEnabled->setChecked(enhanced_is_active);
 
 	// radio buttons (2x groups)
 	ui->radioButtonActiveField->setChecked(field_is_active);

--- a/qtfred/src/ui/dialogs/AsteroidEditorDialog.h
+++ b/qtfred/src/ui/dialogs/AsteroidEditorDialog.h
@@ -25,6 +25,7 @@ private:
 
 	void toggleEnabled(bool enabled);
 	void toggleInnerBoxEnabled(bool enabled);
+	void toggleEnhancedEnabled(bool enabled);
 	void toggleAsteroid(AsteroidEditorDialogModel::_roid_types colour, bool enabled);
 
 	void asteroidNumberChanged(int num_asteroids);

--- a/qtfred/ui/AsteroidEditorDialog.ui
+++ b/qtfred/ui/AsteroidEditorDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>675</width>
-    <height>339</height>
+    <height>423</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,310 +26,335 @@
    <string>Debris Field Editor</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QCheckBox" name="enabled">
-     <property name="text">
-      <string>Enabled</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
-    <layout class="QHBoxLayout" name="mainLayout">
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QGroupBox" name="fieldProperties">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="accessibleName">
-        <string>Field Properties</string>
-       </property>
-       <property name="title">
-        <string>Field Properties</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_4">
-        <item row="2" column="0">
-         <widget class="QRadioButton" name="radioButtonActiveField">
-          <property name="text">
-           <string>Active Field</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">radioActivePassive</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QRadioButton" name="radioButtonPassiveField">
-          <property name="text">
-           <string>Passive Field</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">radioActivePassive</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QRadioButton" name="radioButtonAsteroid">
-          <property name="text">
-           <string>Asteroid</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">radioAsteroidDebris</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QRadioButton" name="radioButtonShip">
-          <property name="text">
-           <string>Debris</string>
-          </property>
-          <attribute name="buttonGroup">
-           <string notr="true">radioAsteroidDebris</string>
-          </attribute>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QCheckBox" name="checkBoxBrown">
-          <property name="text">
-           <string>Brown</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QCheckBox" name="checkBoxBlue">
-          <property name="text">
-           <string>Blue</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="QCheckBox" name="checkBoxOrange">
-          <property name="text">
-           <string>Orange</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="QComboBox" name="debris0"/>
-        </item>
-        <item row="8" column="2">
-         <widget class="QComboBox" name="debris1"/>
-        </item>
-        <item row="10" column="2">
-         <widget class="QComboBox" name="debris2"/>
-        </item>
-        <item row="12" column="0">
-         <widget class="QLabel" name="labelNumber">
-          <property name="text">
-           <string>Number:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="12" column="2">
-         <widget class="QSpinBox" name="spinBoxNumber"/>
-        </item>
-        <item row="13" column="0">
-         <widget class="QLabel" name="labelAvgSpeed">
-          <property name="text">
-           <string>Avg Speed:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="13" column="2">
-         <widget class="QLineEdit" name="lineEditAvgSpeed"/>
-        </item>
-        <item row="1" column="0">
-         <spacer name="verticalSpacerFieldProperties">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
+      <layout class="QHBoxLayout" name="mainLayout">
+       <item>
+        <widget class="QGroupBox" name="fieldProperties">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="accessibleName">
+          <string>Field Properties</string>
+         </property>
+         <property name="title">
+          <string>Field Properties</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="radioButtonAsteroid">
+            <property name="text">
+             <string>Asteroid</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">radioAsteroidDebris</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="7" column="2">
+           <widget class="QComboBox" name="debris1"/>
+          </item>
+          <item row="9" column="2">
+           <widget class="QComboBox" name="debris2"/>
+          </item>
+          <item row="1" column="2">
+           <widget class="QRadioButton" name="radioButtonPassiveField">
+            <property name="text">
+             <string>Passive Field</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">radioActivePassive</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="checkBoxBrown">
+            <property name="text">
+             <string>Brown</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QRadioButton" name="radioButtonShip">
+            <property name="text">
+             <string>Debris</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">radioAsteroidDebris</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="12" column="0">
+           <widget class="QLabel" name="labelAvgSpeed">
+            <property name="text">
+             <string>Avg Speed:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="0">
+           <widget class="QLabel" name="labelNumber">
+            <property name="text">
+             <string>Number:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="11" column="2">
+           <widget class="QSpinBox" name="spinBoxNumber"/>
+          </item>
+          <item row="7" column="0">
+           <widget class="QCheckBox" name="checkBoxBlue">
+            <property name="text">
+             <string>Blue</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QCheckBox" name="checkBoxOrange">
+            <property name="text">
+             <string>Orange</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="2">
+           <widget class="QLineEdit" name="lineEditAvgSpeed"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="radioButtonActiveField">
+            <property name="text">
+             <string>Active Field</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">radioActivePassive</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QComboBox" name="debris0"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="outerBox">
+         <property name="title">
+          <string>Outer Box</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_obox_minX">
+            <property name="text">
+             <string>Min X:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_obox_minY">
+            <property name="text">
+             <string>Min Y:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLineEdit" name="lineEdit_obox_minZ"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_obox_maxX">
+            <property name="text">
+             <string>Max X:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="lineEdit_obox_minX"/>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_obox_maxY">
+            <property name="text">
+             <string>Max Y:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_obox_maxZ">
+            <property name="text">
+             <string>Max Z:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="lineEdit_obox_minY"/>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_obox_minZ">
+            <property name="text">
+             <string>Min Z:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QLineEdit" name="lineEdit_obox_maxZ"/>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="lineEdit_obox_maxX"/>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="lineEdit_obox_maxY"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="innerBox">
+         <property name="title">
+          <string>Inner Box</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="lineEdit_ibox_maxX"/>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_ibox_minY">
+            <property name="text">
+             <string>Min Y:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_ibox_minX">
+            <property name="text">
+             <string>Min X:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="lineEdit_ibox_minX"/>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_ibox_minZ">
+            <property name="text">
+             <string>Min Z:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="QLineEdit" name="lineEdit_ibox_maxZ"/>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLineEdit" name="lineEdit_ibox_minY"/>
+          </item>
+          <item row="7" column="1">
+           <widget class="QLineEdit" name="lineEdit_ibox_minZ"/>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_ibox_maxZ">
+            <property name="text">
+             <string>Max Z:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLineEdit" name="lineEdit_ibox_maxY"/>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_ibox_maxY">
+            <property name="text">
+             <string>Max Y:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_ibox_maxX">
+            <property name="text">
+             <string>Max X:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QCheckBox" name="innerBoxEnabled">
+            <property name="text">
+             <string>Enabled</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
-      <widget class="QGroupBox" name="outerBox">
+      <widget class="QGroupBox" name="groupBox">
        <property name="title">
-        <string>Outer Box</string>
+        <string/>
        </property>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_obox_minX">
-          <property name="text">
-           <string>Min X:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="lineEdit_obox_minX"/>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_obox_maxX">
-          <property name="text">
-           <string>Max X:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QLineEdit" name="lineEdit_obox_maxX"/>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_obox_minY">
-          <property name="text">
-           <string>Min Y:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QLineEdit" name="lineEdit_obox_minY"/>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_obox_maxY">
-          <property name="text">
-           <string>Max Y:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QLineEdit" name="lineEdit_obox_maxY"/>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label_obox_minZ">
-          <property name="text">
-           <string>Min Z:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="QLineEdit" name="lineEdit_obox_minZ"/>
-        </item>
-        <item row="10" column="0">
-         <widget class="QLabel" name="label_obox_maxZ">
-          <property name="text">
-           <string>Max Z:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="1">
-         <widget class="QLineEdit" name="lineEdit_obox_maxZ"/>
-        </item>
-        <item row="0" column="1">
-         <spacer name="verticalSpacerOuterBox">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="innerBox">
-       <property name="title">
-        <string>Inner Box</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="1" column="0" colspan="2">
-         <widget class="QCheckBox" name="innerBoxEnabled">
-          <property name="text">
-           <string>Enabled</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_ibox_minX">
-          <property name="text">
-           <string>Min X:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="lineEdit_ibox_minX"/>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_ibox_maxX">
-          <property name="text">
-           <string>Max X:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QLineEdit" name="lineEdit_ibox_maxX"/>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_ibox_minY">
-          <property name="text">
-           <string>Min Y:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QLineEdit" name="lineEdit_ibox_minY"/>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_ibox_maxY">
-          <property name="text">
-           <string>Max Y:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="QLineEdit" name="lineEdit_ibox_maxY"/>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label_ibox_minZ">
-          <property name="text">
-           <string>Min Z:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="QLineEdit" name="lineEdit_ibox_minZ"/>
-        </item>
-        <item row="10" column="0">
-         <widget class="QLabel" name="label_ibox_maxZ">
-          <property name="text">
-           <string>Max Z:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="1">
-         <widget class="QLineEdit" name="lineEdit_ibox_maxZ"/>
-        </item>
-        <item row="0" column="0">
-         <spacer name="verticalSpacerInnerBox">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+       <widget class="QCheckBox" name="enhancedFieldEnabled">
+        <property name="geometry">
+         <rect>
+          <x>20</x>
+          <y>10</y>
+          <width>653</width>
+          <height>20</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Use ehnanced spawn checking</string>
+        </property>
+       </widget>
+       <widget class="QLabel" name="label">
+        <property name="geometry">
+         <rect>
+          <x>40</x>
+          <y>30</y>
+          <width>450</width>
+          <height>40</height>
+         </rect>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>500</width>
+          <height>200</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>(By default player range is checked in addition to the player view cone for spawning asteroids. In small fields you may want to override this behavior.)</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QDialogButtonBox" name="dialogButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="enabled">
+     <property name="text">
+      <string>Enabled</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Per discussion with WookieJedi, this fixes/enhances asteroid field spawning and wrapping for certain fields.

Basically fields with "enhanced checks" do not use range to limit the player view cone when wrapping asteroids and **do** use the view cone to check if an asteroid should be spawned (where retail does not have that check at all).

The core issue is that for small fields the existing checks for wrapping asteroids from one side to the other weren't stringent enough causing asteroids to visibly pop into and out of existence. This PR fixes that issue by adding an optional parameter for asteroid fields for "enhanced checks" that makes sure the asteroid is not within view of the player when it might be wrapped as well as when an asteroid might be created.

This shouldn't be a general bugfix because it can cause fields to entirely disappear if the player stares at them long enough resulting in major mission changes. The optional parameter preserves old behavior while offering an option for new styles of fields. By having this as a parameter of `Asteroid_field` it means that this can be controlled individually for each field in a mission. Sexp compatibility is also added here, albeit in a kind of funky way to preserve backwards compatibility with set-asteroid-field's argument list.

Finally, as part of this fix I redesigned the `asteroid_maybe_reposition` function to make it more readable at a glance. Instead of doing some checks, moving the asteroid, and then maybe moving it back after more checks are completed the function does all checks up front and then only moves the asteroid around if appropriate.