### PR TITLE
call reset() on new profiles to ensure properly set default values.

### DIFF
--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -315,6 +315,7 @@ void parse_profile_section(const char* filename)
 		stuff_string(buffer, F_NAME);
 		if (Profiles.find(buffer) == Profiles.end()) {
 			Profiles[buffer] = profile();
+			Profiles[buffer].reset();
 		}
 		profile* p = &Profiles.at(buffer);
 		SCP_string endtag = "#END PROFILES";


### PR DESCRIPTION
fixes some issues with the named profiles features