### PR TITLE
patch qtFRED's handling of hud gauges

### DIFF
--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -142,6 +142,7 @@ int main(int argc, char* argv[]) {
 								 { SubSystem::Species,           app.tr("Initializing species") },
 								 { SubSystem::BriefingIcons,     app.tr("Initializing briefing icons") },
 								 { SubSystem::HudCommOrders,     app.tr("Initializing HUD comm orders") },
+								 { SubSystem::HudGaugePositions, app.tr("Initializing HUD gauge positions") },
 								 { SubSystem::AlphaColors,       app.tr("Initializing alpha colors") },
 								 { SubSystem::GameSound,         app.tr("Initializing briefing icons") },
 								 { SubSystem::MissionBrief,      app.tr("Initializing briefings") },

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -212,6 +212,9 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	listener(SubSystem::TechroomIntel);
 	techroom_intel_init();
 
+	listener(SubSystem::HudGaugePositions);
+	hud_positions_init();
+
 	listener(SubSystem::Traitor);
 	traitor_init();
 

--- a/qtfred/src/mission/management.h
+++ b/qtfred/src/mission/management.h
@@ -28,6 +28,7 @@ enum class SubSystem {
 	Species,
 	BriefingIcons,
 	HudCommOrders,
+	HudGaugePositions,
 	AlphaColors,
 	GameSound,
 	MissionBrief,

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4472,23 +4472,28 @@ sexp_list_item* sexp_tree::get_listing_opf_builtin_hud_gauge() {
 sexp_list_item *sexp_tree::get_listing_opf_custom_hud_gauge()
 {
 	sexp_list_item head;
-	SCP_unordered_set<SCP_string> all_gauges;
+	// prevent duplicate names, comparing case-insensitively
+	SCP_unordered_set<SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to> all_gauges;
 
 	for (auto &gauge : default_hud_gauges)
 	{
-		all_gauges.insert(gauge->getCustomGaugeName());
-		head.add_data(gauge->getCustomGaugeName());
+		SCP_string name = gauge->getCustomGaugeName();
+		if (!name.empty() && all_gauges.count(name) == 0)
+		{
+			head.add_data(name.c_str());
+			all_gauges.insert(std::move(name));
+		}
 	}
 
 	for (auto &si : Ship_info)
 	{
 		for (auto &gauge : si.hud_gauges)
 		{
-			// avoid duplicating any HUD gauges
-			if (all_gauges.count(gauge->getCustomGaugeName()) == 0)
+			SCP_string name = gauge->getCustomGaugeName();
+			if (!name.empty() && all_gauges.count(name) == 0)
 			{
-				all_gauges.insert(gauge->getCustomGaugeName());
-				head.add_data(gauge->getCustomGaugeName());
+				head.add_data(name.c_str());
+				all_gauges.insert(std::move(name));
 			}
 		}
 	}


### PR DESCRIPTION
There was a missing function call in qtFRED's initialization, which prevented custom HUD gauges from being loaded.  This adds that.  Additionally, this updates the deduplication code in `get_listing_opf_custom_hud_gauge` to match its counterpart in FRED.

Fixes #5422.