### PR TITLE
All poofs on by default

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5552,6 +5552,10 @@ void parse_bitmaps(mission *pm)
 	// set the ambient light
 
 	// neb2 info
+
+	// all poofs on by default
+	for (size_t i = 0; i < Poof_info.size(); i++)
+		Neb2_poof_flags += (1 << i);
 	bool nebula = false;
 	if (optional_string("+Neb2:")) {
 		nebula = true;


### PR DESCRIPTION
This fixes a regression where missions which relied on all poofs on by default would now have none. In this position used to be the same check that turned on all 6 poofs. As always, if a nebula is actually specified, this will get completely overwritten.