### PR TITLE
Allow using container data with ai-waypoints* SEXPs

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -904,7 +904,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, char
 		int ref_type;
 
 		ref_type = Sexp_nodes[CDR(node)].subtype;
-		if (ref_type == SEXP_ATOM_STRING) {  // referenced by name
+		if (ref_type == SEXP_ATOM_STRING || ref_type == SEXP_ATOM_CONTAINER_DATA) {  // referenced by name
 			// save the waypoint path name -- the list will get resolved when the goal is checked
 			// for achievability.
 			aigp->target_name = ai_get_goal_target_name(CTEXT(CDR(node)), &aigp->target_name_index);  // waypoint path name;


### PR DESCRIPTION
Using Replace Container Data as the "waypoint path" argument in `ai-waypoints` and `ai-waypoints-once` currently works in FRED but triggers a crash ('Int3()') in game. This change fixes that.

Should fix Issue #5109.