### PR TITLE
Stop lighting profile warning in specific case

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -780,13 +780,16 @@ void parse_mission_info(mission *pm, bool basic = false)
 			WarningEx(LOCATION, "Mission: %s\nUnknown AI profile %s!", pm->name, temp );
 	}
 
-	if (optional_string("$Lighting Profile:"))
-	{
+	if (optional_string("$Lighting Profile:")) {
 		stuff_string(The_mission.lighting_profile_name, F_NAME);
-	}
-	else
+	} else {
 		The_mission.lighting_profile_name = lighting_profiles::default_name();
-	lighting_profiles::switch_to(The_mission.lighting_profile_name);
+	}
+
+	// Only try to switch profiles if we have one defined!
+	if (The_mission.lighting_profile_name.length() > 0) {
+		lighting_profiles::switch_to(The_mission.lighting_profile_name);
+	}
 
 	if (optional_string("$Sound Environment:")) {
 		char preset[65] = { '\0' };


### PR DESCRIPTION
If you have a mod that doesn't define any lightning profiles and your missions don't have the `$Lighting Profile:` line in the file, then FSO will try to switch to a default lighting profile that doesn't exist and warn the user that it tried to switch to lighting profile `''`, a zero length profile name, and that it couldn't find that profile. So in that cause, just skip trying to switch lighting profiles instead of sending a warning.