### PR TITLE
Default profile name needs to be added after reset()

### DIFF
--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -257,6 +257,8 @@ void parse_all()
 {
 	Profiles[default_profile_name] = profile();
 	Profiles[default_profile_name].reset();
+	//.reset() resets name to "" which makes sense in all cases but this one
+	Profiles[default_profile_name].name = default_profile_name;
 	_current.reset();
 	if (cf_exists_full("lighting_profiles.tbl", CF_TYPE_TABLES)) {
 		mprintf(("TABLES: Starting parse of lighting profiles.tbl\n"));


### PR DESCRIPTION
The default lighting profile name was getting cleared by `.reset()` which meant the list in FRED, for mods that only had the default profile, to call it "", an empty string. On mission save, this would not match `default_lighting_profile` name comparison and cause the mission to save out the line `$Lighting Profile: ` and that would then cause a warning on mission parse that FSO couldn't find lighting profile `""`.

This fixes that by making sure the default profile has the correct name.