### PR TITLE
Fixes for lab backgrounds and curve initialization

### DIFF
--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -288,7 +288,7 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 		if (optional_string("+Flags:"))
 			stuff_flagset(&flags);
 
-		skip_to_start_of_string_one_of(SCP_vector<SCP_string>{ "+Volumetric Nebula:", "$Skybox Model:", "#Background bitmaps" });
+		skip_to_start_of_string_one_of(SCP_vector<SCP_string>{ "+Volumetric Nebula:", "$Skybox Model:", "$Lighting Profile:", "#Background bitmaps" });
 		if (optional_string("+Volumetric Nebula:")) {
 			//Rendering usually happens in post-mission-init, just do it now in the lab
 			The_mission.volumetrics.emplace().parse_volumetric_nebula().renderVolumeBitmap();
@@ -297,13 +297,10 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 			volumetrics_level_close();
 		}
 
-		ltp_name = ltp::default_name();
-
 		// Are we using a skybox?
-		//skip to appears to skip to the end of the file if this are absent
-		//so if there's no skybox we need to advance past it
-		skip_to_start_of_string_either("$Skybox Model:","$Lighting Profile:");
-
+		//skip will skip to the end of the file (or to the 'end' string) if any string is absent,
+		//so be sure to include any section that might be found
+		skip_to_start_of_string_one_of(SCP_vector<SCP_string>{ "$Skybox Model:", "$Lighting Profile:", "#Background bitmaps" });
 		strcpy_s(skybox_model, "");
 		if (optional_string("$Skybox Model:")) {
 			stuff_string(skybox_model, F_NAME, MAX_FILENAME_LEN);
@@ -322,17 +319,13 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 
 			stars_set_background_model(skybox_model, nullptr, skybox_flags);
 			stars_set_background_orientation(&skybox_orientation);
-
 		}
-		ltp_name="";
-		skip_to_start_of_string_either("$Lighting Profile:","#Background bitmap");
+
+		skip_to_start_of_string_either("$Lighting Profile:", "#Background bitmaps");
+		ltp_name = ltp::default_name();
 		if(optional_string("$Lighting Profile:")){
 			stuff_string(ltp_name,F_NAME);
 		}
-		else {
-			ltp_name = ltp::default_name();
-		}
-	
 		if (ltp_name != ltp::current()->name) {
 				ltp::switch_to(ltp_name);
 		}

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -2,36 +2,36 @@
 #include "mission/management.h"
 
 #include "object.h"
+#include <project.h>
+#include <libs/ffmpeg/FFmpeg.h>
 
-#include <localization/localize.h>
-#include <ui/QtGraphicsOperations.h>
+#include <cutscene/cutscenes.h>
+#include <gamesnd/eventmusic.h>
+#include <globalincs/alphacolors.h>
+#include <hud/hudsquadmsg.h>
+#include <iff_defs/iff_defs.h>
 #include <io/key.h>
 #include <io/mouse.h>
-#include <iff_defs/iff_defs.h>
-#include <weapon/weapon.h>
-#include <stats/medals.h>
+#include <localization/fhash.h>
+#include <localization/localize.h>
+#include <math/curve.h>
+#include <menuui/mainhallmenu.h>
+#include <menuui/techmenu.h>
+#include <mission/missioncampaign.h>
+#include <missionui/fictionviewer.h>
 #include <model/modelreplace.h>
 #include <nebula/neb.h>
-#include <starfield/starfield.h>
-#include <sound/audiostr.h>
-#include <project.h>
+#include <nebula/neblightning.h>
+#include <parse/sexp/sexp_lookup.h>
 #include <scripting/scripting.h>
 #include <scripting/global_hooks.h>
-#include <hud/hudsquadmsg.h>
-#include <globalincs/alphacolors.h>
-
-#include <menuui/techmenu.h>
-#include <localization/fhash.h>
-#include <gamesnd/eventmusic.h>
-#include <cutscene/cutscenes.h>
-#include <missionui/fictionviewer.h>
-#include <menuui/mainhallmenu.h>
+#include <sound/audiostr.h>
+#include <starfield/starfield.h>
+#include <stats/medals.h>
 #include <stats/scoring.h>
-#include <mission/missioncampaign.h>
-#include <nebula/neblightning.h>
-#include <libs/ffmpeg/FFmpeg.h>
-#include <parse/sexp/sexp_lookup.h>
+#include <ui/QtGraphicsOperations.h>
 #include <utils/Random.h>
+#include <weapon/weapon.h>
 
 #include <clocale>
 
@@ -145,6 +145,7 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 	mouse_init();
 
 	listener(SubSystem::Particles);
+	curves_init();
 	particle::ParticleManager::init();
 
 	listener(SubSystem::Iff);


### PR DESCRIPTION
1. Patch the string skipping behavior for backgrounds in the lab.  Not all the strings were accounted for in each section, which would occasionally cause some sections to be incorrectly skipped; and one of the strings was wrong.  Also tidy up the assignment of `ltp_name`.
2. Since `curves_init()` was added to FRED, add it to qtFRED too.  Also sort the list of #include statements in that file.

Followup to #5380 and #5408.  Also fixes a bug mentioned in Discord where background bitmaps were not being loaded in the lab.