### PR TITLE
some refinements for retiming of object collision pairs

### DIFF
--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -1011,7 +1011,7 @@ void nav_warp(bool prewarp=false)
 	vm_vec_scale(&velocity, (float)Ai_info[Ships[Autopilot_flight_leader->instance].ai_index].waypoint_speed_cap);
 
 	// Find all ships that are supposed to autopilot with the player and move them
-	// to the cinimatic location or the final destination
+	// to the cinematic location or the final destination
 	for (int i = 0; i < MAX_SHIPS; i++)
 	{
 		if (Ships[i].objnum != -1
@@ -1020,11 +1020,12 @@ void nav_warp(bool prewarp=false)
 		{
 				vm_vec_add(&Objects[Ships[i].objnum].pos, &Objects[Ships[i].objnum].pos, &targetPos);
 				Objects[Ships[i].objnum].phys_info.vel = velocity;
+
+				// retime collision pairs
+				if (Objects[Ships[i].objnum].flags[Object::Object_Flags::Collides])
+					obj_collide_retime_cached_pairs(&Objects[Ships[i].objnum]);
 		}
 	}
-
-	// retime all collision pairs
-	obj_collide_retime_cached_pairs();
 }
 
 // ********************************************************************************************

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -612,6 +612,20 @@ void obj_collide_retime_cached_pairs()
 	}
 }
 
+void obj_collide_retime_cached_pairs(object *objp)
+{
+	int sig = objp->signature;
+
+	for ( auto& pair : Collision_cached_pairs ) {
+		auto& collision_check = pair.second;
+
+		if ( (collision_check.a == objp && collision_check.signature_a == sig)
+		  || (collision_check.b == objp && collision_check.signature_b == sig) ) {
+				collision_check.next_check_time = timestamp(0);
+		}
+	}
+}
+
 //local helper functions only used in objcollide.cpp
 namespace
 {

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -68,8 +68,11 @@ void obj_remove_collider(int obj_index);
 void obj_reset_colliders();
 void obj_sort_and_collide(SCP_vector<int>* Collision_list = nullptr);
 
-// retimes all collision pairs to be checked immediately
+// Retime all collision pairs, so that all object collisions will be rechecked immediately
 void obj_collide_retime_cached_pairs();
+
+// Retime collision pairs involving the specified object, so that collisions involving this object will be rechecked immediately
+void obj_collide_retime_cached_pairs(object *objp);
 
 // Returns TRUE if the weapon will never hit the other object.
 // If it can it predicts how long until these two objects need

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8766,7 +8766,6 @@ void sexp_set_object_position(int n)
 {
 	vec3d target_vec, orig_leader_vec;
 	object_ship_wing_point_team oswpt;
-	bool something_collides = false;
 
 	eval_object_ship_wing_point_team(&oswpt, n);
 	n = CDR(n);
@@ -8784,7 +8783,7 @@ void sexp_set_object_position(int n)
 			set_object_for_clients(oswpt.objp);
 
 			if (oswpt.objp->flags[Object::Object_Flags::Collides])
-				something_collides = true;
+				obj_collide_retime_cached_pairs(oswpt.objp);
 
 			break;
 		}
@@ -8828,7 +8827,7 @@ void sexp_set_object_position(int n)
 				}
 
 				if (objp->flags[Object::Object_Flags::Collides])
-					something_collides = true;
+					obj_collide_retime_cached_pairs(objp);
 			}
 
 			break;
@@ -8870,12 +8869,6 @@ void sexp_set_object_position(int n)
 		default:
 			break;
 	}
-
-	// retime all collision pairs (so they're checked again) if we moved something that collides
-	if (something_collides)
-	{
-		obj_collide_retime_cached_pairs();
-	}
 }
 
 // only for waypoints cause they don't get transferred the normal way
@@ -8902,7 +8895,6 @@ void sexp_set_object_orientation(int n)
 	angles a;
 	matrix target_orient;
 	object_ship_wing_point_team oswpt;
-	bool something_collides = false;
 
 	eval_object_ship_wing_point_team(&oswpt, n);
 	n = CDR(n);
@@ -8922,7 +8914,7 @@ void sexp_set_object_orientation(int n)
 			set_object_for_clients(oswpt.objp);
 
 			if (oswpt.objp->flags[Object::Object_Flags::Collides])
-				something_collides = true;
+				obj_collide_retime_cached_pairs(oswpt.objp);
 
 			break;
 		}
@@ -8943,7 +8935,7 @@ void sexp_set_object_orientation(int n)
 				set_object_for_clients(objp);
 
 				if (objp->flags[Object::Object_Flags::Collides])
-					something_collides = true;
+					obj_collide_retime_cached_pairs(objp);
 			}
 
 			break;
@@ -8963,12 +8955,6 @@ void sexp_set_object_orientation(int n)
 
 		default:
 			break;
-	}
-
-	// retime all collision pairs (so they're checked again) if we rotated something that collides
-	if (something_collides)
-	{
-		obj_collide_retime_cached_pairs();
 	}
 }
 

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -13,6 +13,7 @@
 
 #include "asteroid/asteroid.h"
 #include "debris/debris.h"
+#include "object/objcollide.h"
 #include "object/objectshield.h"
 #include "object/objectsnd.h"
 #include "scripting/api/LuaEventCallback.h"
@@ -148,6 +149,9 @@ ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)"
 			waypoint *wpt = find_waypoint_with_objnum(OBJ_INDEX(objh->objp));
 			wpt->set_pos(v3);
 		}
+
+		if (objh->objp->flags[Object::Object_Flags::Collides])
+			obj_collide_retime_cached_pairs(objh->objp);
 	}
 
 	return ade_set_args(L, "o", l_Vector.Set(objh->objp->pos));
@@ -182,6 +186,9 @@ ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (Wor
 
 	if(ADE_SETTING_VAR && mh != NULL) {
 		objh->objp->orient = *mh->GetMatrix();
+
+		if (objh->objp->flags[Object::Object_Flags::Collides])
+			obj_collide_retime_cached_pairs(objh->objp);
 	}
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&objh->objp->orient)));


### PR DESCRIPTION
1. Add a function to retime *only* the collision pairs involving a specific object.  This is useful when only one object has moved, since only collisions involving that object are affected.
2. Use this function when objects are moved for autopilot, via sexp, and via script.

Previously collision pairs were not retimed when objects were moved via script, leading to bugs.  This fixes that.