### PR TITLE
refinements of jump node features

### DIFF
--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -675,10 +675,7 @@ void HudGaugeBrackets::renderBoundingBrackets(int x1, int y1, int x2, int y2, in
 					if(jnp->GetSCPObject() == t_objp)
 						break;
 				}
-				
-				strcpy_s(temp_name, jnp->GetDisplayName());
-				end_string_at_first_hash_symbol(temp_name);
-				tinfo_name = temp_name;
+				tinfo_name = jnp->GetDisplayName();
 				break;
 		}
 

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1320,9 +1320,7 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 		renderTargetIntegrity(1);
 		setGaugeColor();
 
-		strcpy_s(outstr, jnp->GetDisplayName());
-		end_string_at_first_hash_symbol(outstr);
-		renderString(position[0] + Name_offsets[0], position[1] + Name_offsets[1], EG_TBOX_NAME, outstr);	
+		renderString(position[0] + Name_offsets[0], position[1] + Name_offsets[1], EG_TBOX_NAME, jnp->GetDisplayName());
 
 		dist = Player_ai->current_target_distance;
 		if ( Hud_unit_multiplier > 0.0f ) {	// use a different displayed distance scale

--- a/code/jumpnode/jumpnode.h
+++ b/code/jumpnode/jumpnode.h
@@ -27,6 +27,7 @@ class model_draw_list;
 #define JN_SHOW_POLYS				(1<<1)		//Display model normally, rather than as wireframe
 #define JN_HIDE						(1<<2)		//Hides a jump node
 #define JN_SPECIAL_MODEL			(1<<3)		//If non-default model
+#define JN_HAS_DISPLAY_NAME			(1<<4)		//If it has a display name
 
 #define JN_DEFAULT_MODEL            "subspacenode.pof"
 
@@ -76,9 +77,10 @@ public:
     void SetVisibility(bool enabled);
     
     //Query
-    bool IsHidden();
-    bool IsColored();
-    bool IsSpecialModel();
+    bool IsHidden() const;
+    bool IsColored() const;
+    bool IsSpecialModel() const;
+    bool HasDisplayName() const;
 
     //Rendering
 	void Render(vec3d *pos, vec3d *view_pos = NULL);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5280,8 +5280,6 @@ void parse_waypoints_and_jumpnodes(mission *pm)
 		if (optional_string("+Display Name:")) {
 			stuff_string(jump_display_name, F_NAME, NAME_LENGTH);
 			jnp.SetDisplayName(jump_display_name);
-		} else {
-			jnp.SetDisplayName(jump_name);
 		}
 
 		if(optional_string("+Model File:")){

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -35265,7 +35265,7 @@ int get_subcategory(int op_id)
 		case OP_SET_MOTION_DEBRIS:
 			return CHANGE_SUBCATEGORY_BACKGROUND_AND_NEBULA;
 
-		case OP_JUMP_NODE_SET_JUMPNODE_NAME: //
+		case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 		case OP_JUMP_NODE_SET_JUMPNODE_DISPLAY_NAME:
 		case OP_JUMP_NODE_SET_JUMPNODE_COLOR:
 		case OP_JUMP_NODE_SET_JUMPNODE_MODEL:
@@ -39591,7 +39591,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t4: Everywhere (optional).  Whether the effect is applied to all camera views.\r\n"
 	},
 
-	{ OP_JUMP_NODE_SET_JUMPNODE_NAME, "set-jumpnode-name\r\n"
+	{ OP_JUMP_NODE_SET_JUMPNODE_NAME, "set-jumpnode-name (deprecated in favor of set-jumpnode-display-name)\r\n"
 		"\tSets the name of a jump node. Takes 2 arguments...\r\n"
 		"\t1: Name of jump node to change name for\r\n"
 		"\t2: New name for jump node\r\n\r\n"

--- a/fred2/jumpnodedlg.cpp
+++ b/fred2/jumpnodedlg.cpp
@@ -68,6 +68,7 @@ BEGIN_MESSAGE_MAP(jumpnode_dlg, CDialog)
 	ON_BN_CLICKED(IDC_NODE_HIDDEN, OnHidden)
 	ON_WM_CLOSE()
 	ON_WM_INITMENU()
+	ON_EN_KILLFOCUS(IDC_NAME, OnKillfocusName)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -181,7 +182,7 @@ int jumpnode_dlg::update_data()
 	if (!GetSafeHwnd())
 		return 0;
 
-	if (Objects[cur_object_index].type == OBJ_JUMP_NODE) {
+	if (query_valid_object() && Objects[cur_object_index].type == OBJ_JUMP_NODE) {
 		for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
 			if(jnp->GetSCPObject() == &Objects[cur_object_index])
 				break;
@@ -375,4 +376,21 @@ void jumpnode_dlg::OnHidden()
 		m_hidden = 1;
 
 	((CButton*)GetDlgItem(IDC_NODE_HIDDEN))->SetCheck(m_hidden);
+}
+
+void jumpnode_dlg::OnKillfocusName()
+{
+	char buffer[NAME_LENGTH];
+
+	// Note, in this dialog, UpdateData(TRUE) is not used to move data from controls to variables until the dialog is closed, so we edit the control text directly
+
+	// grab the name
+	GetDlgItemText(IDC_NAME, buffer, NAME_LENGTH);
+
+	// if this name has a hash, truncate it for the display name
+	if (get_pointer_to_first_hash_symbol(buffer))
+		end_string_at_first_hash_symbol(buffer);
+
+	// set the display name derived from this name
+	SetDlgItemText(IDC_ALT_NAME, buffer);
 }

--- a/fred2/jumpnodedlg.h
+++ b/fred2/jumpnodedlg.h
@@ -55,6 +55,7 @@ protected:
 	afx_msg void OnInitMenu(CMenu* pMenu);
 	afx_msg void OnClose();
 	afx_msg void OnHidden();
+	afx_msg void OnKillfocusName();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -4601,14 +4601,22 @@ int CFred_mission_save::save_waypoints()
 
 		if (Mission_save_format != FSO_FORMAT_RETAIL) {
 
-			if (jnp->GetDisplayName()[0] != '\0') {
-				if (optional_string_fred("+Display Name:", "$Jump Node:")) {
-					parse_comments();
-				} else {
-					fout("\n+Display Name:");
+			// The display name is only written if there was one at the start to avoid introducing inconsistencies
+			if (jnp->HasDisplayName()) {
+				char truncated_name[NAME_LENGTH];
+				strcpy_s(truncated_name, jnp->GetName());
+				end_string_at_first_hash_symbol(truncated_name);
+
+				// Also, the display name is not written if it's just the truncation of the name at the hash
+				if (strcmp(jnp->GetDisplayName(), truncated_name) != 0) {
+					if (optional_string_fred("+Display Name:", "$Jump Node:")) {
+						parse_comments();
+					} else {
+						fout("\n+Display Name:");
+					}
+
+					fout_ext("", "%s", jnp->GetDisplayName());
 				}
-					
-				fout_ext("", "%s", jnp->GetDisplayName());
 			}
 
 			if (jnp->IsSpecialModel()) {

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -1011,6 +1011,7 @@ void sexp_tree::right_clicked(int mode)
 							case OP_TRIGGER_SUBMODEL_ANIMATION:
 							case OP_ADD_BACKGROUND_BITMAP:
 							case OP_ADD_SUN_BITMAP:
+							case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 								j = (int)op_menu.size();	// don't allow these operators to be visible
 								break;
 						}
@@ -1065,6 +1066,7 @@ void sexp_tree::right_clicked(int mode)
 							case OP_TRIGGER_SUBMODEL_ANIMATION:
 							case OP_ADD_BACKGROUND_BITMAP:
 							case OP_ADD_SUN_BITMAP:
+							case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 								j = (int)op_submenu.size();	// don't allow these operators to be visible
 								break;
 						}

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -4755,14 +4755,22 @@ int CFred_mission_save::save_waypoints()
 
 		if (save_format != MissionFormat::RETAIL) {
 			
-			if (jnp->GetDisplayName()[0] != '\0') {
-				if (optional_string_fred("+Display Name:", "$Jump Node:")) {
-					parse_comments();
-				} else {
-					fout("\n+Display Name:");
+			// The display name is only written if there was one at the start to avoid introducing inconsistencies
+			if (jnp->HasDisplayName()) {
+				char truncated_name[NAME_LENGTH];
+				strcpy_s(truncated_name, jnp->GetName());
+				end_string_at_first_hash_symbol(truncated_name);
+
+				// Also, the display name is not written if it's just the truncation of the name at the hash
+				if (strcmp(jnp->GetDisplayName(), truncated_name) != 0) {
+					if (optional_string_fred("+Display Name:", "$Jump Node:")) {
+						parse_comments();
+					} else {
+						fout("\n+Display Name:");
+					}
+
+					fout_ext("", "%s", jnp->GetDisplayName());
 				}
-				
-				fout_ext("", "%s", jnp->GetDisplayName());
 			}
 			
 			if (jnp->IsSpecialModel()) {

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5979,6 +5979,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 					case OP_TRIGGER_SUBMODEL_ANIMATION:
 					case OP_ADD_BACKGROUND_BITMAP:
 					case OP_ADD_SUN_BITMAP:
+					case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 						j = (int) op_menu.size();    // don't allow these operators to be visible
 						break;
 					}
@@ -6050,6 +6051,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 					case OP_TRIGGER_SUBMODEL_ANIMATION:
 					case OP_ADD_BACKGROUND_BITMAP:
 					case OP_ADD_SUN_BITMAP:
+					case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 						j = (int) op_submenu.size();    // don't allow these operators to be visible
 						break;
 					}


### PR DESCRIPTION
1. Deprecate the old set-jumpnode-name sexp now that there is a set-jumpnode-display-name
2. Make the display name design consistent with ships and weapons; in particular add a `HasDisplayName()` function and automatically generate the display name for hash-truncated names
3. Keep the display name in sync when the name is changed in the FRED dialog
4. Fix the overriding of hash-truncated names with display names on the HUD
5. Fix the incorrect setting of the alphacolor flag when using FRED
6. Fix array out-of-bounds access when no object is selected

Follow-up to #5401.