### PR TITLE
Make lasers less kinky

### DIFF
--- a/code/def_files/data/effects/batched-f.sdr
+++ b/code/def_files/data/effects/batched-f.sdr
@@ -15,7 +15,8 @@ layout (std140) uniform genericData {
 
 void main()
 {
-	vec4 baseColor = texture(baseMap, fragTexCoord.xyz);
+	float y =  fragTexCoord.y / fragTexCoord.w;
+	vec4 baseColor = texture(baseMap, vec3(fragTexCoord.x, y, fragTexCoord.z));
 
 	baseColor.rgb = srgb_to_linear(baseColor.rgb);
 	vec4 blendColor = vec4(srgb_to_linear(fragColor.rgb), fragColor.a);

--- a/code/def_files/data/effects/batched-v.sdr
+++ b/code/def_files/data/effects/batched-v.sdr
@@ -17,7 +17,7 @@ layout (std140) uniform genericData {
 
 void main()
 {
-	fragTexCoord = vec4(vertTexCoord.xyz, 0.0);
 	fragColor = vertColor * color;
 	gl_Position = projMatrix * modelViewMatrix * vertPosition;
+	fragTexCoord = vertTexCoord;
 }

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -262,7 +262,7 @@ struct vertex_format_data
 		COLOR4,
 		COLOR4F,
 		TEX_COORD2,
-		TEX_COORD3,
+		TEX_COORD4,
 		NORMAL,
 		TANGENT,
 		MODEL_ID,

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -76,7 +76,7 @@ static opengl_vertex_bind GL_array_binding_data[] =
 		{ vertex_format_data::COLOR4,		4, GL_UNSIGNED_BYTE,	GL_TRUE, opengl_vert_attrib::COLOR		},
 		{ vertex_format_data::COLOR4F,		4, GL_FLOAT,			GL_FALSE, opengl_vert_attrib::COLOR		},
 		{ vertex_format_data::TEX_COORD2,	2, GL_FLOAT,			GL_FALSE, opengl_vert_attrib::TEXCOORD	},
-		{ vertex_format_data::TEX_COORD3,	3, GL_FLOAT,			GL_FALSE, opengl_vert_attrib::TEXCOORD	},
+		{ vertex_format_data::TEX_COORD4,	4, GL_FLOAT,			GL_FALSE, opengl_vert_attrib::TEXCOORD	},
 		{ vertex_format_data::NORMAL,		3, GL_FLOAT,			GL_FALSE, opengl_vert_attrib::NORMAL	},
 		{ vertex_format_data::TANGENT,		4, GL_FLOAT,			GL_FALSE, opengl_vert_attrib::TANGENT	},
 		{ vertex_format_data::MODEL_ID,		1, GL_FLOAT,			GL_FALSE, opengl_vert_attrib::MODEL_ID	},

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -180,6 +180,18 @@ vec3d vm_vec_new(float x, float y, float z)
 	return vec;
 }
 
+vec4 vm_vec4_new(float x, float y, float z, float w)
+{
+	vec4 vec;
+
+	vec.xyzw.x = x;
+	vec.xyzw.y = y;
+	vec.xyzw.z = z;
+	vec.xyzw.w = w;
+
+	return vec;
+}
+
 matrix vm_matrix_new(float a0, float a1, float a2, float a3, float a4, float a5, float a6, float a7, float a8)
 {
 	matrix m;

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -73,6 +73,7 @@ extern void vm_set_identity(matrix *m);
 
 extern angles vm_angles_new(float p, float b, float h);
 extern vec3d vm_vec_new(float x, float y, float z);
+extern vec4 vm_vec4_new(float x, float y, float z, float w);
 extern matrix vm_matrix_new(float a0, float a1, float a2, float a3, float a4, float a5, float a6, float a7, float a8);
 extern matrix vm_matrix_new(vec3d rvec, vec3d uvec, vec3d fvec);
 

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -55,8 +55,8 @@ void batching_setup_vertex_layout(vertex_layout *layout, uint vert_mask)
 		layout->add_vertex_component(vertex_format_data::POSITION3, stride, (int)offsetof(batch_vertex, position));
 	}
 
-	if ( vert_mask & vertex_format_data::mask(vertex_format_data::TEX_COORD3) ) {
-		layout->add_vertex_component(vertex_format_data::TEX_COORD3, stride, (int)offsetof(batch_vertex, tex_coord));
+	if ( vert_mask & vertex_format_data::mask(vertex_format_data::TEX_COORD4) ) {
+		layout->add_vertex_component(vertex_format_data::TEX_COORD4, stride, (int)offsetof(batch_vertex, tex_coord));
 	}
 
 	if ( vert_mask & vertex_format_data::mask(vertex_format_data::COLOR4) ) {
@@ -137,18 +137,18 @@ uint batching_determine_vertex_layout(batch_info *info)
 		return vertex_format_data::mask(vertex_format_data::POSITION3) 
 			| vertex_format_data::mask(vertex_format_data::RADIUS) 
 			| vertex_format_data::mask(vertex_format_data::UVEC)
-			| vertex_format_data::mask(vertex_format_data::TEX_COORD3);
+			| vertex_format_data::mask(vertex_format_data::TEX_COORD4);
 	}
 
 	if ( info->mat_type == batch_info::VOLUME_EMISSIVE || info->mat_type == batch_info::DISTORTION ) {
 		return vertex_format_data::mask(vertex_format_data::POSITION3) 
 			| vertex_format_data::mask(vertex_format_data::COLOR4) 
-			| vertex_format_data::mask(vertex_format_data::TEX_COORD3)
+			| vertex_format_data::mask(vertex_format_data::TEX_COORD4)
 			| vertex_format_data::mask(vertex_format_data::RADIUS);
 	} else {
 		return vertex_format_data::mask(vertex_format_data::POSITION3) 
 			| vertex_format_data::mask(vertex_format_data::COLOR4) 
-			| vertex_format_data::mask(vertex_format_data::TEX_COORD3);
+			| vertex_format_data::mask(vertex_format_data::TEX_COORD4);
 	}
 }
 
@@ -208,46 +208,46 @@ void batching_add_bitmap_internal(primitive_batch *batch, int texture, vertex *p
 	// set up the UV coords
 	if ( orient & 1 ) {
 		// tri 1
-		verts[5].tex_coord.xyz.x = 1.0f;
-		verts[4].tex_coord.xyz.x = 0.0f;
-		verts[3].tex_coord.xyz.x = 0.0f;
+		verts[5].tex_coord.xyzw.x = 1.0f;
+		verts[4].tex_coord.xyzw.x = 0.0f;
+		verts[3].tex_coord.xyzw.x = 0.0f;
 
 		// tri 2
-		verts[2].tex_coord.xyz.x = 1.0f;
-		verts[1].tex_coord.xyz.x = 0.0f;
-		verts[0].tex_coord.xyz.x = 1.0f;
+		verts[2].tex_coord.xyzw.x = 1.0f;
+		verts[1].tex_coord.xyzw.x = 0.0f;
+		verts[0].tex_coord.xyzw.x = 1.0f;
 	} else {
 		// tri 1
-		verts[5].tex_coord.xyz.x = 0.0f;
-		verts[4].tex_coord.xyz.x = 1.0f;
-		verts[3].tex_coord.xyz.x = 1.0f;
+		verts[5].tex_coord.xyzw.x = 0.0f;
+		verts[4].tex_coord.xyzw.x = 1.0f;
+		verts[3].tex_coord.xyzw.x = 1.0f;
 
 		// tri 2
-		verts[2].tex_coord.xyz.x = 0.0f;
-		verts[1].tex_coord.xyz.x = 1.0f;
-		verts[0].tex_coord.xyz.x = 0.0f;
+		verts[2].tex_coord.xyzw.x = 0.0f;
+		verts[1].tex_coord.xyzw.x = 1.0f;
+		verts[0].tex_coord.xyzw.x = 0.0f;
 	}
 
 	if ( orient & 2 ) {
 		// tri 1
-		verts[5].tex_coord.xyz.y = 1.0f;
-		verts[4].tex_coord.xyz.y = 1.0f;
-		verts[3].tex_coord.xyz.y = 0.0f;
+		verts[5].tex_coord.xyzw.y = 1.0f;
+		verts[4].tex_coord.xyzw.y = 1.0f;
+		verts[3].tex_coord.xyzw.y = 0.0f;
 
 		// tri 2
-		verts[2].tex_coord.xyz.y = 1.0f;
-		verts[1].tex_coord.xyz.y = 0.0f;
-		verts[0].tex_coord.xyz.y = 0.0f;
+		verts[2].tex_coord.xyzw.y = 1.0f;
+		verts[1].tex_coord.xyzw.y = 0.0f;
+		verts[0].tex_coord.xyzw.y = 0.0f;
 	} else {
 		// tri 1
-		verts[5].tex_coord.xyz.y = 0.0f;
-		verts[4].tex_coord.xyz.y = 0.0f;
-		verts[3].tex_coord.xyz.y = 1.0f;
+		verts[5].tex_coord.xyzw.y = 0.0f;
+		verts[4].tex_coord.xyzw.y = 0.0f;
+		verts[3].tex_coord.xyzw.y = 1.0f;
 
 		// tri 2
-		verts[2].tex_coord.xyz.y = 0.0f;
-		verts[1].tex_coord.xyz.y = 1.0f;
-		verts[0].tex_coord.xyz.y = 1.0f;
+		verts[2].tex_coord.xyzw.y = 0.0f;
+		verts[1].tex_coord.xyzw.y = 1.0f;
+		verts[0].tex_coord.xyzw.y = 1.0f;
 	}
 
 	auto array_index = texture - batch->get_render_info().texture;
@@ -260,7 +260,7 @@ void batching_add_bitmap_internal(primitive_batch *batch, int texture, vertex *p
 		verts[i].radius = radius;
 
 		// Set array index
-		verts[i].tex_coord.xyz.z = (float) array_index;
+		verts[i].tex_coord.xyzw.z = (float) array_index;
 	}
 
 	batch->add_triangle(&verts[5], &verts[4], &verts[3]);
@@ -318,14 +318,14 @@ void batching_add_bitmap_rotated_internal(primitive_batch *batch, int texture, v
 	verts[0].position = p[0];
 
 	//tri 1
-	verts[5].tex_coord.xyz.x = 0.0f;	verts[5].tex_coord.xyz.y = 0.0f;
-	verts[4].tex_coord.xyz.x = 1.0f;	verts[4].tex_coord.xyz.y = 0.0f;
-	verts[3].tex_coord.xyz.x = 1.0f;	verts[3].tex_coord.xyz.y = 1.0f;
+	verts[5].tex_coord.xyzw.x = 0.0f;	verts[5].tex_coord.xyzw.y = 0.0f;
+	verts[4].tex_coord.xyzw.x = 1.0f;	verts[4].tex_coord.xyzw.y = 0.0f;
+	verts[3].tex_coord.xyzw.x = 1.0f;	verts[3].tex_coord.xyzw.y = 1.0f;
 
 	//tri 2
-	verts[2].tex_coord.xyz.x = 0.0f;	verts[2].tex_coord.xyz.y = 0.0f;
-	verts[1].tex_coord.xyz.x = 1.0f;	verts[1].tex_coord.xyz.y = 1.0f;
-	verts[0].tex_coord.xyz.x = 0.0f;	verts[0].tex_coord.xyz.y = 1.0f;
+	verts[2].tex_coord.xyzw.x = 0.0f;	verts[2].tex_coord.xyzw.y = 0.0f;
+	verts[1].tex_coord.xyzw.x = 1.0f;	verts[1].tex_coord.xyzw.y = 1.0f;
+	verts[0].tex_coord.xyzw.x = 0.0f;	verts[0].tex_coord.xyzw.y = 1.0f;
 
 	auto array_index = texture - batch->get_render_info().texture;
 	for (int i = 0; i < 6 ; i++) {
@@ -335,7 +335,7 @@ void batching_add_bitmap_rotated_internal(primitive_batch *batch, int texture, v
 		verts[i].a = clr->alpha;
 
 		verts[i].radius = radius;
-		verts[i].tex_coord.xyz.z = (float)array_index;
+		verts[i].tex_coord.xyzw.z = 0 ; //(float)array_index;
 	}
 
 	batch->add_triangle(&verts[0], &verts[1], &verts[2]);
@@ -388,22 +388,22 @@ void batching_add_polygon_internal(primitive_batch *batch, int texture, vec3d *p
 		v[i].g = clr->green;
 		v[i].b = clr->blue;
 		v[i].a = clr->alpha;
-		v[i].tex_coord.xyz.z = (float)array_index;
+		v[i].tex_coord.xyzw.z = 0; //(float)array_index;
 
 		v[i].radius = MAX(width * 0.5f, height * 0.5f);
 	}
 
-	v[0].tex_coord.xyz.x = 1.0f;
-	v[0].tex_coord.xyz.y = 0.0f;
+	v[0].tex_coord.xyzw.x = 1.0f;
+	v[0].tex_coord.xyzw.y = 0.0f;
 
-	v[1].tex_coord.xyz.x = 0.0f;
-	v[1].tex_coord.xyz.y = 0.0f;
+	v[1].tex_coord.xyzw.x = 0.0f;
+	v[1].tex_coord.xyzw.y = 0.0f;
 
-	v[2].tex_coord.xyz.x = 0.0f;
-	v[2].tex_coord.xyz.y = 1.0f;
+	v[2].tex_coord.xyzw.x = 0.0f;
+	v[2].tex_coord.xyzw.y = 1.0f;
 
-	v[3].tex_coord.xyz.x = 1.0f;
-	v[3].tex_coord.xyz.y = 1.0f;
+	v[3].tex_coord.xyzw.x = 1.0f;
+	v[3].tex_coord.xyzw.y = 1.0f;
 
 	batch->add_triangle(&v[0], &v[1], &v[2]);
 	batch->add_triangle(&v[0], &v[2], &v[3]);
@@ -425,9 +425,9 @@ void batching_add_quad_internal(primitive_batch *batch, int texture, vertex *ver
 		v[i].b = verts[i].b;
 		v[i].a = verts[i].a;
 
-		v[i].tex_coord.xyz.x = verts[i].texture_position.u;
-		v[i].tex_coord.xyz.y = verts[i].texture_position.v;
-		v[i].tex_coord.xyz.z = (float)array_index;
+		v[i].tex_coord.xyzw.x = verts[i].texture_position.u;
+		v[i].tex_coord.xyzw.y = verts[i].texture_position.v;
+		v[i].tex_coord.xyzw.z = 0 ; //(float)array_index;
 	}
 
 	batch->add_triangle(&v[0], &v[1], &v[2]);
@@ -450,9 +450,9 @@ void batching_add_tri_internal(primitive_batch *batch, int texture, vertex *vert
 		v[i].b = verts[i].b;
 		v[i].a = verts[i].a;
 
-		v[i].tex_coord.xyz.x = verts[i].texture_position.u;
-		v[i].tex_coord.xyz.y = verts[i].texture_position.v;
-		v[i].tex_coord.xyz.z = (float)array_index;
+		v[i].tex_coord.xyzw.x = verts[i].texture_position.u;
+		v[i].tex_coord.xyzw.y = verts[i].texture_position.v;
+		v[i].tex_coord.xyzw.z = 0 ; //(float)array_index;
 	}
 
 	batch->add_triangle(&v[0], &v[1], &v[2]);
@@ -500,14 +500,14 @@ void batching_add_beam_internal(primitive_batch *batch, int texture, vec3d *star
 
 	//set up the UV coords
 	//tri 1
-	verts[0].tex_coord.xyz.x = 0.0f; verts[0].tex_coord.xyz.y = 0.0f;
-	verts[1].tex_coord.xyz.x = 1.0f; verts[1].tex_coord.xyz.y = 0.0f;
-	verts[2].tex_coord.xyz.x = 1.0f; verts[2].tex_coord.xyz.y = 1.0f;
+	verts[0].tex_coord.xyzw.x = 0.0f; verts[0].tex_coord.xyzw.y = 0.0f;
+	verts[1].tex_coord.xyzw.x = 1.0f; verts[1].tex_coord.xyzw.y = 0.0f;
+	verts[2].tex_coord.xyzw.x = 1.0f; verts[2].tex_coord.xyzw.y = 1.0f;
 
 	//tri 2
-	verts[3].tex_coord.xyz.x = 0.0f; verts[3].tex_coord.xyz.y = 0.0f;
-	verts[4].tex_coord.xyz.x = 1.0f; verts[4].tex_coord.xyz.y = 1.0f;
-	verts[5].tex_coord.xyz.x = 0.0f; verts[5].tex_coord.xyz.y = 1.0f;
+	verts[3].tex_coord.xyzw.x = 0.0f; verts[3].tex_coord.xyzw.y = 0.0f;
+	verts[4].tex_coord.xyzw.x = 1.0f; verts[4].tex_coord.xyzw.y = 1.0f;
+	verts[5].tex_coord.xyzw.x = 0.0f; verts[5].tex_coord.xyzw.y = 1.0f;
 
 	auto array_index = texture - batch->get_render_info().texture;
 	for(int i = 0; i < 6; i++){
@@ -521,7 +521,7 @@ void batching_add_beam_internal(primitive_batch *batch, int texture, vec3d *star
 		} else {
 			verts[i].radius = width;
 		}
-		verts[i].tex_coord.xyz.z = (float)array_index;
+		verts[i].tex_coord.xyzw.z = 0 ; //(float)array_index;
 	}
 
 	batch->add_triangle(&verts[0], &verts[1], &verts[2]);
@@ -570,14 +570,14 @@ void batching_add_line_internal(primitive_batch *batch, int texture, vec3d *star
 
 	//set up the UV coords
 	//tri 1
-	verts[0].tex_coord.xyz.x = 0.0f; verts[0].tex_coord.xyz.y = 0.0f;
-	verts[1].tex_coord.xyz.x = 1.0f; verts[1].tex_coord.xyz.y = 0.0f;
-	verts[2].tex_coord.xyz.x = 1.0f; verts[2].tex_coord.xyz.y = 1.0f;
+	verts[0].tex_coord.xyzw.x = 0.0f; verts[0].tex_coord.xyzw.y = 0.0f;
+	verts[1].tex_coord.xyzw.x = 1.0f; verts[1].tex_coord.xyzw.y = 0.0f;
+	verts[2].tex_coord.xyzw.x = 1.0f; verts[2].tex_coord.xyzw.y = 1.0f;
 
 	//tri 2
-	verts[3].tex_coord.xyz.x = 0.0f; verts[3].tex_coord.xyz.y = 0.0f;
-	verts[4].tex_coord.xyz.x = 1.0f; verts[4].tex_coord.xyz.y = 1.0f;
-	verts[5].tex_coord.xyz.x = 0.0f; verts[5].tex_coord.xyz.y = 1.0f;
+	verts[3].tex_coord.xyzw.x = 0.0f; verts[3].tex_coord.xyzw.y = 0.0f;
+	verts[4].tex_coord.xyzw.x = 1.0f; verts[4].tex_coord.xyzw.y = 1.0f;
+	verts[5].tex_coord.xyzw.x = 0.0f; verts[5].tex_coord.xyzw.y = 1.0f;
 
 	auto array_index = texture - batch->get_render_info().texture;
 	for(batch_vertex &vert : verts){
@@ -588,7 +588,7 @@ void batching_add_line_internal(primitive_batch *batch, int texture, vec3d *star
 
 		vert.radius = width1;
 		
-		vert.tex_coord.xyz.z = (float)array_index;
+		vert.tex_coord.xyzw.z = 0 ; //(float)array_index;
 	}
 
 	batch->add_triangle(&verts[0], &verts[1], &verts[2]);
@@ -644,28 +644,24 @@ void batching_add_laser_internal(primitive_batch *batch, int texture, vec3d *p0,
 	verts[4].position = vecs[2];
 	verts[5].position = vecs[3];
 
-	verts[0].tex_coord.xyz.x = 1.0f;
-	verts[0].tex_coord.xyz.y = 0.0f;
-	verts[1].tex_coord.xyz.x = 0.0f;
-	verts[1].tex_coord.xyz.y = 0.0f;
-	verts[2].tex_coord.xyz.x = 0.0f;
-	verts[2].tex_coord.xyz.y = 1.0f;
-
-	verts[3].tex_coord.xyz.x = 1.0f;
-	verts[3].tex_coord.xyz.y = 0.0f;
-	verts[4].tex_coord.xyz.x = 0.0f;
-	verts[4].tex_coord.xyz.y = 1.0f;
-	verts[5].tex_coord.xyz.x = 1.0f;
-	verts[5].tex_coord.xyz.y = 1.0f;
-
 	auto array_index = texture - batch->get_render_info().texture;
+
+	float ratio = width2 / width1;
+	if (width1 <= 0.0f)
+		ratio = 999.0f;
+
+	verts[0].tex_coord = vm_vec4_new(1.0f, 0.0f, (float)array_index, ratio);
+	verts[1].tex_coord = vm_vec4_new(0.0f, 0.0f, (float)array_index, 1.0f);
+	verts[2].tex_coord = vm_vec4_new(0.0f, 1.0f, (float)array_index, 1.0f);
+	verts[3].tex_coord = vm_vec4_new(1.0f, 0.0f, (float)array_index, ratio);
+	verts[4].tex_coord = vm_vec4_new(0.0f, 1.0f, (float)array_index, 1.0f);
+	verts[5].tex_coord = vm_vec4_new(1.0f, ratio, (float)array_index, ratio);
+
 	for (auto& vert : verts) {
 		vert.r = (ubyte)r;
 		vert.g = (ubyte)g;
 		vert.b = (ubyte)b;
 		vert.a = 255;
-
-		vert.tex_coord.xyz.z = (float)array_index;
 	}
 
 	batch->add_triangle(&verts[0], &verts[1], &verts[2]);

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -335,7 +335,7 @@ void batching_add_bitmap_rotated_internal(primitive_batch *batch, int texture, v
 		verts[i].a = clr->alpha;
 
 		verts[i].radius = radius;
-		verts[i].tex_coord.xyzw.z = 0 ; //(float)array_index;
+		verts[i].tex_coord.xyzw.z = (float)array_index;
 	}
 
 	batch->add_triangle(&verts[0], &verts[1], &verts[2]);
@@ -388,7 +388,7 @@ void batching_add_polygon_internal(primitive_batch *batch, int texture, vec3d *p
 		v[i].g = clr->green;
 		v[i].b = clr->blue;
 		v[i].a = clr->alpha;
-		v[i].tex_coord.xyzw.z = 0; //(float)array_index;
+		v[i].tex_coord.xyzw.z = (float)array_index;
 
 		v[i].radius = MAX(width * 0.5f, height * 0.5f);
 	}
@@ -427,7 +427,7 @@ void batching_add_quad_internal(primitive_batch *batch, int texture, vertex *ver
 
 		v[i].tex_coord.xyzw.x = verts[i].texture_position.u;
 		v[i].tex_coord.xyzw.y = verts[i].texture_position.v;
-		v[i].tex_coord.xyzw.z = 0 ; //(float)array_index;
+		v[i].tex_coord.xyzw.z = (float)array_index;
 	}
 
 	batch->add_triangle(&v[0], &v[1], &v[2]);
@@ -452,7 +452,7 @@ void batching_add_tri_internal(primitive_batch *batch, int texture, vertex *vert
 
 		v[i].tex_coord.xyzw.x = verts[i].texture_position.u;
 		v[i].tex_coord.xyzw.y = verts[i].texture_position.v;
-		v[i].tex_coord.xyzw.z = 0 ; //(float)array_index;
+		v[i].tex_coord.xyzw.z = (float)array_index;
 	}
 
 	batch->add_triangle(&v[0], &v[1], &v[2]);
@@ -521,7 +521,7 @@ void batching_add_beam_internal(primitive_batch *batch, int texture, vec3d *star
 		} else {
 			verts[i].radius = width;
 		}
-		verts[i].tex_coord.xyzw.z = 0 ; //(float)array_index;
+		verts[i].tex_coord.xyzw.z = (float)array_index;
 	}
 
 	batch->add_triangle(&verts[0], &verts[1], &verts[2]);
@@ -588,7 +588,7 @@ void batching_add_line_internal(primitive_batch *batch, int texture, vec3d *star
 
 		vert.radius = width1;
 		
-		vert.tex_coord.xyzw.z = 0 ; //(float)array_index;
+		vert.tex_coord.xyzw.z = (float)array_index;
 	}
 
 	batch->add_triangle(&verts[0], &verts[1], &verts[2]);

--- a/code/render/batching.h
+++ b/code/render/batching.h
@@ -13,7 +13,7 @@
 
 struct batch_vertex {
 	vec3d position;
-	vec4 tex_coord; // 3D coordinate since we also include the array index
+	vec4 tex_coord; // 4D coordinate since we also include the array index, and a trapezoidal correction value for laser bitmaps
 	ubyte r, g, b, a;
 	float radius;
 	vec3d uvec;
@@ -123,6 +123,7 @@ void batching_add_beam(int texture, vec3d *start, vec3d *end, float width, float
 void batching_add_line(vec3d *start, vec3d *end, float widthStart, float widthEnd, color custom_color, bool translucent = true);
 void batching_add_polygon(int texture, vec3d *pos, matrix *orient, float width, float height, float alpha = 1.0f);
 void batching_add_volume_polygon(int texture, vec3d* pos, matrix* orient, float width, float height, float alpha = 1.0f);
+// be aware only this function will correctly adjust UVs for trapezoidal shapes
 void batching_add_laser(int texture, vec3d *p0, float width1, vec3d *p1, float width2, int r = 255, int g = 255, int b = 255);
 void batching_add_quad(int texture, vertex *verts);
 void batching_add_tri(int texture, vertex *verts);

--- a/code/render/batching.h
+++ b/code/render/batching.h
@@ -13,7 +13,7 @@
 
 struct batch_vertex {
 	vec3d position;
-	vec3d tex_coord; // 3D coordinate since we also include the array index
+	vec4 tex_coord; // 3D coordinate since we also include the array index
 	ubyte r, g, b, a;
 	float radius;
 	vec3d uvec;

--- a/code/render/batching.h
+++ b/code/render/batching.h
@@ -123,13 +123,12 @@ void batching_add_beam(int texture, vec3d *start, vec3d *end, float width, float
 void batching_add_line(vec3d *start, vec3d *end, float widthStart, float widthEnd, color custom_color, bool translucent = true);
 void batching_add_polygon(int texture, vec3d *pos, matrix *orient, float width, float height, float alpha = 1.0f);
 void batching_add_volume_polygon(int texture, vec3d* pos, matrix* orient, float width, float height, float alpha = 1.0f);
-// be aware only this function will correctly adjust UVs for trapezoidal shapes
 void batching_add_laser(int texture, vec3d *p0, float width1, vec3d *p1, float width2, int r = 255, int g = 255, int b = 255);
-void batching_add_quad(int texture, vertex *verts);
+void batching_add_quad(int texture, vertex *verts, float trapezoidal_correction = 1.0f);
 void batching_add_tri(int texture, vertex *verts);
 
 //these require some blurring the lines between things, but finding the batch in every call gets expensive in some cases such as trails.
-void batching_add_quad(int texture, vertex *verts, primitive_batch* batch);
+void batching_add_quad(int texture, vertex *verts, primitive_batch* batch, float trapezoidal_correction = 1.0f);
 void batching_add_tri(int texture, vertex *verts, primitive_batch* batch);
 
 void batching_render_all(bool render_distortions = false);

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -180,7 +180,7 @@ void trail_render( trail * trailp )
 		verts[0].texture_position.v = verts[3].texture_position.v = 0.0f;
 		verts[1].texture_position.v = verts[2].texture_position.v = 1.0f;
 
-		batching_add_quad(ti->texture.bitmap_id, verts, batchp);
+		batching_add_quad(ti->texture.bitmap_id, verts, batchp, b_width / f_width);
 		return;
 	}
 

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -180,7 +180,11 @@ void trail_render( trail * trailp )
 		verts[0].texture_position.v = verts[3].texture_position.v = 0.0f;
 		verts[1].texture_position.v = verts[2].texture_position.v = 1.0f;
 
-		batching_add_quad(ti->texture.bitmap_id, verts, batchp, b_width / f_width);
+		float ratio = b_width / f_width;
+		if (f_width <= 0.0f)
+			ratio = 999.0f;
+
+		batching_add_quad(ti->texture.bitmap_id, verts, batchp, ratio);
 		return;
 	}
 


### PR DESCRIPTION
Since retail, lasers with head radius != tail radius (or any trapezoidally shaped bitmap) would not have their UVs correctly interpolated across their bitmap, each triangle unaware of its existence as part of the trapezoid, creating a 'kink' across the diagonal. At the modest price of widening the texcoord vertex attribute to a vec4, we can include a correction parameter that correctly scales and interpolates the texture.

I added it for single segment trails too, because that optimization actually makes the 'kinkiness' very obvious >.>

![screen01422](https://github.com/scp-fs2open/fs2open.github.com/assets/17305613/66e4fef0-266f-4f08-b8c8-5ad760afd9a9)
