### PR TITLE
Validate chunk size to avoid align crash and add align skip flag

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -235,6 +235,7 @@ Flag exe_params[] =
 	{ "-prefer_ipv4",		"Prefer IPv4 DNS lookups",					true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-prefer_ipv4", },
 	{ "-prefer_ipv6",		"Prefer IPv6 DNS lookups",					true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-prefer_ipv6", },
 	{ "-log_multi_packet",	"Log multi packet types ",					true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-log_multi_packet",},
+	{ "-no_bsp_align",		"Disable pof BSP data alignment",			true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_bsp_align", },
 #ifdef WIN32
 	{ "-fix_registry",	"Use a different registry path",				true,	0,									EASY_DEFAULT,					"Troubleshoot", "http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-fix_registry", },
 #endif
@@ -467,6 +468,7 @@ cmdline_parm noshadercache_arg("-noshadercache", NULL, AT_NONE);
 cmdline_parm prefer_ipv4_arg("-prefer_ipv4", nullptr, AT_NONE);
 cmdline_parm prefer_ipv6_arg("-prefer_ipv6", nullptr, AT_NONE);
 cmdline_parm log_multi_packet_arg("-log_multi_packet", nullptr, AT_NONE);
+cmdline_parm no_bsp_align_arg("-no_bsp_align", nullptr, AT_NONE);
 #ifdef WIN32
 cmdline_parm fix_registry("-fix_registry", NULL, AT_NONE);
 #endif
@@ -488,6 +490,7 @@ bool Cmdline_noshadercache = false;
 bool Cmdline_prefer_ipv4 = false;
 bool Cmdline_prefer_ipv6 = false;
 bool Cmdline_dump_packet_type = false;
+bool Cmdline_no_bsp_align = false;
 #ifdef WIN32
 bool Cmdline_alternate_registry_path = false;
 #endif
@@ -2020,6 +2023,10 @@ bool SetCmdlineParams()
 	if (lang_arg.found()) 
 	{
 		Cmdline_lang = lang_arg.str();
+	}
+
+	if (no_bsp_align_arg.found()) {
+		Cmdline_no_bsp_align = 1;
 	}
 	
 #ifdef WIN32

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -2026,7 +2026,7 @@ bool SetCmdlineParams()
 	}
 
 	if (no_bsp_align_arg.found()) {
-		Cmdline_no_bsp_align = 1;
+		Cmdline_no_bsp_align = true;
 	}
 	
 #ifdef WIN32

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2116,23 +2116,30 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 						// byte swap first thing
 						swap_bsp_data(pm, bsp_data);
 
-						auto bsp_data_size_aligned = align_bsp_data(bsp_data, nullptr, sm->bsp_data_size);
-
-						if (bsp_data_size_aligned != static_cast<uint>(sm->bsp_data_size)) {
-							auto bsp_data_aligned = reinterpret_cast<ubyte *>(vm_malloc(bsp_data_size_aligned));
-
-							align_bsp_data(bsp_data, bsp_data_aligned, sm->bsp_data_size);
-
-							// release unaligned data
-							vm_free(bsp_data);
-							bsp_data = nullptr;
-
-							nprintf(("Model", "BSP ALIGN => %s:%s resized by %d bytes (%d total)\n", pm->filename, sm->name, bsp_data_size_aligned-sm->bsp_data_size, bsp_data_size_aligned));
-
-							sm->bsp_data = bsp_data_aligned;
-							sm->bsp_data_size = bsp_data_size_aligned;
-						} else {
+						extern bool Cmdline_no_bsp_align;
+						if (Cmdline_no_bsp_align) {
 							sm->bsp_data = bsp_data;
+						}
+						else {
+							auto bsp_data_size_aligned = align_bsp_data(bsp_data, nullptr, sm->bsp_data_size);
+
+							if (bsp_data_size_aligned != static_cast<uint>(sm->bsp_data_size)) {
+								auto bsp_data_aligned = reinterpret_cast<ubyte*>(vm_malloc(bsp_data_size_aligned));
+
+								align_bsp_data(bsp_data, bsp_data_aligned, sm->bsp_data_size);
+
+								// release unaligned data
+								vm_free(bsp_data);
+								bsp_data = nullptr;
+
+								nprintf(("Model", "BSP ALIGN => %s:%s resized by %d bytes (%d total)\n", pm->filename, sm->name, bsp_data_size_aligned - sm->bsp_data_size, bsp_data_size_aligned));
+
+								sm->bsp_data = bsp_data_aligned;
+								sm->bsp_data_size = bsp_data_size_aligned;
+							}
+							else {
+								sm->bsp_data = bsp_data;
+							}
 						}
 					}
 					else {
@@ -6070,13 +6077,21 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 	do {
 		//Read Chunk type and size
 		memcpy(&bsp_chunk_type, bsp_in, 4);
-		
+
 		//Chunk type 0 is EOF, but the size is read as 0, it needs to be adjusted
 		if (bsp_chunk_type == 0) {
 			bsp_chunk_size = 4;
 		}
 		else {
 			memcpy(&bsp_chunk_size, bsp_in + 4, 4);
+		}
+
+		//Chunk size validation, if fails change it to copy the remaining data in chain
+		auto max_size = end - bsp_in;
+		if (bsp_chunk_size < 0 || bsp_chunk_size > max_size) {
+			
+			mprintf(("Invalid BSP Chunk size detected during BSP data align: Chunk Type: %d, Chunk Size: %d, Max Size: %d\n", bsp_chunk_type, bsp_chunk_size, static_cast<uint>(max_size)));
+			bsp_chunk_size = static_cast<uint>(max_size);
 		}
 
 		//mprintf(("|%d | %d|\n",bsp_chunk_type,bsp_chunk_size));

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -6073,7 +6073,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 	uint copied = 0;
 	end = bsp_in + bsp_size;
 
-	int bsp_chunk_type, bsp_chunk_size;
+	uint bsp_chunk_type, bsp_chunk_size;
 	do {
 		//Read Chunk type and size
 		memcpy(&bsp_chunk_type, bsp_in, 4);
@@ -6088,9 +6088,9 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 
 		//Chunk size validation, if fails change it to copy the remaining data in chain
 		auto max_size = end - bsp_in;
-		if (bsp_chunk_size < 0 || bsp_chunk_size > max_size) {
-			Warning(LOCATION, "Invalid BSP Chunk size detected during BSP data align: Chunk Type: %d, Chunk Size: %d, Max Size: %d", bsp_chunk_type, bsp_chunk_size, static_cast<int>(max_size));
-			bsp_chunk_size = static_cast<int>(max_size);
+		if (bsp_chunk_size > max_size) {
+			Warning(LOCATION, "Invalid BSP Chunk size detected during BSP data align: Chunk Type: %d, Chunk Size: %d, Max Size: %d", bsp_chunk_type, bsp_chunk_size, static_cast<uint>(max_size));
+			bsp_chunk_size = static_cast<uint>(max_size);
 		}
 
 		//mprintf(("|%d | %d|\n",bsp_chunk_type,bsp_chunk_size));
@@ -6101,7 +6101,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 			if ((bsp_chunk_size % 4) != 0) {
 				//mprintf(("BSP DEFPOINTS DATA ALIGNED.\n"));
 				//Get the new size
-				uint newsize = static_cast<uint>(bsp_chunk_size + 4 - (bsp_chunk_size % 4));
+				uint newsize = bsp_chunk_size + 4 - (bsp_chunk_size % 4);
 
 				if (bsp_out) {
 					//Copy the entire chunk to dest
@@ -6113,7 +6113,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 					memcpy(&vertex_offset, bsp_in + 16, 4);
 					//Move vertex data to the back of the chunk
 					memmove(bsp_out + vertex_offset + (newsize - bsp_chunk_size), bsp_out + vertex_offset, bsp_chunk_size - vertex_offset);
-					vertex_offset += (newsize - static_cast<uint>(bsp_chunk_size));
+					vertex_offset += (newsize - bsp_chunk_size);
 					//Write new vertex offset
 					memcpy(bsp_out + 16, &vertex_offset, 4);
 					//Move pointers
@@ -6132,7 +6132,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 				}
 
 				bsp_in += bsp_chunk_size;
-				copied += static_cast<uint>(bsp_chunk_size);
+				copied += bsp_chunk_size;
 			}
 		}
 		else {
@@ -6143,7 +6143,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 			}
 
 			bsp_in += bsp_chunk_size;
-			copied += static_cast<uint>(bsp_chunk_size);
+			copied += bsp_chunk_size;
 		}
 	} while (bsp_in < end);
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -6073,7 +6073,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 	uint copied = 0;
 	end = bsp_in + bsp_size;
 
-	uint bsp_chunk_type, bsp_chunk_size;
+	int bsp_chunk_type, bsp_chunk_size;
 	do {
 		//Read Chunk type and size
 		memcpy(&bsp_chunk_type, bsp_in, 4);
@@ -6090,8 +6090,8 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 		auto max_size = end - bsp_in;
 		if (bsp_chunk_size < 0 || bsp_chunk_size > max_size) {
 			
-			mprintf(("Invalid BSP Chunk size detected during BSP data align: Chunk Type: %d, Chunk Size: %d, Max Size: %d\n", bsp_chunk_type, bsp_chunk_size, static_cast<uint>(max_size)));
-			bsp_chunk_size = static_cast<uint>(max_size);
+			mprintf(("Invalid BSP Chunk size detected during BSP data align: Chunk Type: %d, Chunk Size: %d, Max Size: %d\n", bsp_chunk_type, bsp_chunk_size, static_cast<int>(max_size)));
+			bsp_chunk_size = static_cast<int>(max_size);
 		}
 
 		//mprintf(("|%d | %d|\n",bsp_chunk_type,bsp_chunk_size));
@@ -6102,7 +6102,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 			if ((bsp_chunk_size % 4) != 0) {
 				//mprintf(("BSP DEFPOINTS DATA ALIGNED.\n"));
 				//Get the new size
-				uint newsize = bsp_chunk_size + 4 - (bsp_chunk_size % 4);
+				uint newsize = static_cast<uint>(bsp_chunk_size + 4 - (bsp_chunk_size % 4));
 
 				if (bsp_out) {
 					//Copy the entire chunk to dest
@@ -6114,7 +6114,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 					memcpy(&vertex_offset, bsp_in + 16, 4);
 					//Move vertex data to the back of the chunk
 					memmove(bsp_out + vertex_offset + (newsize - bsp_chunk_size), bsp_out + vertex_offset, bsp_chunk_size - vertex_offset);
-					vertex_offset += (newsize - bsp_chunk_size);
+					vertex_offset += (newsize - static_cast<uint>(bsp_chunk_size));
 					//Write new vertex offset
 					memcpy(bsp_out + 16, &vertex_offset, 4);
 					//Move pointers
@@ -6133,7 +6133,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 				}
 
 				bsp_in += bsp_chunk_size;
-				copied += bsp_chunk_size;
+				copied += static_cast<uint>(bsp_chunk_size);
 			}
 		}
 		else {
@@ -6144,7 +6144,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 			}
 
 			bsp_in += bsp_chunk_size;
-			copied += bsp_chunk_size;
+			copied += static_cast<uint>(bsp_chunk_size);
 		}
 	} while (bsp_in < end);
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -6089,8 +6089,7 @@ uint align_bsp_data(ubyte* bsp_in, ubyte* bsp_out, uint bsp_size)
 		//Chunk size validation, if fails change it to copy the remaining data in chain
 		auto max_size = end - bsp_in;
 		if (bsp_chunk_size < 0 || bsp_chunk_size > max_size) {
-			
-			mprintf(("Invalid BSP Chunk size detected during BSP data align: Chunk Type: %d, Chunk Size: %d, Max Size: %d\n", bsp_chunk_type, bsp_chunk_size, static_cast<int>(max_size)));
+			Warning(LOCATION, "Invalid BSP Chunk size detected during BSP data align: Chunk Type: %d, Chunk Size: %d, Max Size: %d", bsp_chunk_type, bsp_chunk_size, static_cast<int>(max_size));
 			bsp_chunk_size = static_cast<int>(max_size);
 		}
 


### PR DESCRIPTION
This fixes the INF_Antaeus.pof crash of Inferno: Alliance due to unknown data found on the model BSP Data chain.

Explanation: 
While parsing the bsp data, the alignment code reads every chunk of the chain one by one, on this particular model on one of the chains at the final 8 bytes there is invalid data that looks like corrupted or trash data, this has an invalid chunk type and a negative chunk size, causing the bsp_pointer to go out of bounds.

Fix:
A check is added to make sure the chunk size value is not negative or has a value that may cause the bsp pointer to go over the max bsp_size.

A troubleshoot flag is also added to disable this process.