### PR TITLE
Fix AI subsys reposition oversight

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -604,6 +604,7 @@ bool ai_new_maybe_reposition_attack_subsys() {
 		else
 			good_pos = &world_goal_pos;
 		aip->next_dynamic_path_check_time = timestamp( AI_DYNAMIC_PATH_RECHECK_DELAY );
+		aip->last_dynamic_path_goal = *good_pos;
 
 	}
 	else{ //Not enough time has passed till recheck.


### PR DESCRIPTION
Follow-up to #4087. Gotta actually write to this value, so we don't go towards zero every other time.
Fixes #5453 