### PR TITLE
Fix check for shadows

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -2144,11 +2144,6 @@ bool SetCmdlineParams()
 			Shadow_quality = ShadowQuality::Disabled;
 			break;
 		}
-
-		if (!gr_is_capable(CAPABILITY_SHADOWS) && Shadow_quality != ShadowQuality::Disabled) {
-			Warning(LOCATION, "Shadows are enabled, but the system does not fulfill the requirements. Disabling shadows...");
-			Shadow_quality = ShadowQuality::Disabled;
-		}
 	}
 
 	if( no_deferred_lighting_arg.found() )

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -30,6 +30,7 @@
 #include "graphics/util/GPUMemoryHeap.h"
 #include "graphics/util/UniformBuffer.h"
 #include "graphics/util/UniformBufferManager.h"
+#include "graphics/shadows.h"
 #include "io/mouse.h"
 #include "libs/jansson.h"
 #include "options/Option.h"
@@ -1692,6 +1693,11 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 	}
 
 	Gr_inited = 1;
+
+	if (!gr_is_capable(CAPABILITY_SHADOWS) && Shadow_quality != ShadowQuality::Disabled) {
+		Warning(LOCATION, "Shadows are enabled, but the system does not fulfill the requirements. Disabling shadows...");
+		Shadow_quality = ShadowQuality::Disabled;
+	}
 
 	return true;
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -749,11 +749,6 @@ void parse_mod_table(const char *filename)
 					mprintf(("Game Settings Table: '$Shadow Quality Default:' value for default shadow quality %d is invalid. Using default quality of %d...\n", quality, static_cast<int>(Shadow_quality)));
 					break;
 				}
-				
-				if (!gr_is_capable(CAPABILITY_SHADOWS) && Shadow_quality != ShadowQuality::Disabled) {
-					Warning(LOCATION, "The mod requests shadows to be enabled, but the system does not fulfill the requirements. Disabling shadows...");
-					Shadow_quality = ShadowQuality::Disabled;
-				}
 			}
 		}
 


### PR DESCRIPTION
Follow-Up to #5445.
It seems to cause crashes since gr_capability isn't available that early, so defer the shadow capability check to gr_init.
