### PR TITLE
handle special characters in additional places in FRED

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -760,6 +760,7 @@ void lcl_fred_replace_stuff(SCP_string &text)
 	if (!Fred_running)
 		return;
 
+	// this should be kept in sync with the FRED functions in management.cpp and Editor.cpp
 	replace_all(text, "\"", "$quote");
 	replace_all(text, ";", "$semicolon");
 	replace_all(text, "/", "$slash");

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -221,64 +221,14 @@ void pad_with_newline(CString& str, int max_size) {
 	}
 }
 
-// medal_stuff Medals[NUM_MEDALS];
-/*
-void parse_medal_tbl()
+void lcl_fred_replace_stuff(CString &text)
 {
-	int rval, num_medals;
-
-	// open localization
-	lcl_ext_open();
-
-	if ((rval = setjmp(parse_abort)) != 0) {
-		mprintf(("TABLES: Unable to parse '%s'!  Error code = %i.\n", "medals.tbl", rval));
-		lcl_ext_close();
-		return;
-	} 
-
-	read_file_text("medals.tbl");
-	reset_parse();
-
-	// parse in all the rank names
-	num_medals = 0;
-	required_string("#Medals");
-	while ( required_string_either("#End", "$Name:") ) {
-		Assert ( num_medals < NUM_MEDALS);
-		required_string("$Name:");
-		stuff_string( Medals[num_medals].name, F_NAME, NULL );
-		required_string("$Bitmap:");
-		stuff_string( Medals[num_medals].bitmap, F_NAME, NULL );
-		required_string("$Num mods:");
-		stuff_int( &Medals[num_medals].num_versions);
-
-		// some medals are based on kill counts.  When string +Num Kills: is present, we know that
-		// this medal is a badge and should be treated specially
-		Medals[num_medals].kills_needed = 0;
-
-		if ( optional_string("+Num Kills:") ) {
-			char buf[MULTITEXT_LENGTH + 1];
-
-			stuff_int( &Medals[num_medals].kills_needed );
-
-			required_string("$Wavefile 1:");
-			stuff_string(buf, F_NAME, NULL, MAX_FILENAME_LEN);
-
-			required_string("$Wavefile 2:");
-			stuff_string(buf, F_NAME, NULL, MAX_FILENAME_LEN);
-
-			required_string("$Promotion Text:");
-			stuff_string(buf, F_MULTITEXT, NULL);
-		}
-
-		num_medals++;
-	}
-
-	required_string("#End");      
-
-	// close localization
-	lcl_ext_close();
+	// this should be kept in sync with the function in localize.cpp
+	text.Replace("\"", "$quote");
+	text.Replace(";", "$semicolon");
+	text.Replace("/", "$slash");
+	text.Replace("\\", "$backslash");
 }
-*/
 
 void brief_init_colors();
 

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -67,6 +67,7 @@ void deconvert_multiline_string(char* dest, const CString& str, size_t max_len);
 void deconvert_multiline_string(SCP_string& dest, const CString& str);
 void strip_quotation_marks(CString& str);
 void pad_with_newline(CString& str, int max_size);
+void lcl_fred_replace_stuff(CString& text);
 
 bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps);
 void set_physics_controls();

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -16,8 +16,8 @@
 #include "CustomWingNames.h"
 #include "soundenvironmentdlg.h"
 #include "Management.h"
-#include "gamesnd/eventmusic.h"
 #include "cfile/cfile.h"
+#include "gamesnd/eventmusic.h"
 #include "mission/missionparse.h"
 #include "mission/missionmessage.h"
 
@@ -301,14 +301,13 @@ void CMissionNotesDlg::OnOK()
 		set_modified();
 	}
 
-	//if there's a odd number of quotation marks, the mission won't parse
-	//If there are an even number, nothing after the first one appears
-	//So just get rid of them
-	strip_quotation_marks(m_mission_title);
-	strip_quotation_marks(m_designer_name);
-	strip_quotation_marks(m_mission_notes);
-	strip_quotation_marks(m_mission_desc);
-	strip_quotation_marks(m_squad_name);
+	// originally the dialog stripped out quotation marks here;
+	// now it handles all special characters
+	lcl_fred_replace_stuff(m_mission_title);
+	lcl_fred_replace_stuff(m_designer_name);
+	lcl_fred_replace_stuff(m_mission_notes);
+	lcl_fred_replace_stuff(m_mission_desc);
+	lcl_fred_replace_stuff(m_squad_name);
 
 	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
 	pad_with_newline(m_mission_notes, NOTES_LENGTH - 1);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -3154,6 +3154,15 @@ void Editor::pad_with_newline(SCP_string& str, size_t max_size) {
 	}
 }
 
+void Editor::lcl_fred_replace_stuff(QString& text)
+{
+	// this should be kept in sync with the function in localize.cpp
+	text.replace("\"", "$quote");
+	text.replace(";", "$semicolon");
+	text.replace("/", "$slash");
+	text.replace("\\", "$backslash");
+}
+
 
 } // namespace fred
 } // namespace fso

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -179,6 +179,7 @@ class Editor : public QObject {
 
 	static void strip_quotation_marks(SCP_string& str);
 	static void pad_with_newline(SCP_string& str, size_t max_size);
+	static void lcl_fred_replace_stuff(QString& text);
 
 	static const ai_goal_list* getAi_goal_list();
 	static int getAigoal_list_size();

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -436,12 +436,18 @@ bool CampaignEditorDialogModel::_saveTo(QString file) const {
 
 	mission_campaign_clear();
 
-	strncpy(Campaign.name, qPrintable(campaignName), NAME_LENGTH);
+	// handle special characters
+	QString modified_name = campaignName;
+	QString modified_desc = campaignDescr.toPlainText();
+	_viewport->editor->lcl_fred_replace_stuff(modified_name);
+	_viewport->editor->lcl_fred_replace_stuff(modified_desc);
+
+	strncpy(Campaign.name, qPrintable(modified_name), NAME_LENGTH);
 
 	Campaign.type = campaignTypes.indexOf(campaignType);
 
-	if (! campaignDescr.isEmpty())
-		Campaign.desc = vm_strdup(qPrintable(campaignDescr.toPlainText()));
+	if (!modified_desc.isEmpty())
+		Campaign.desc = vm_strdup(qPrintable(modified_desc));
 
 	Campaign.num_players = numPlayers;
 
@@ -549,6 +555,7 @@ bool CampaignEditorDialogModel::_saveTo(QString file) const {
 						cm.flags |= CMISSION_FLAG_HAS_LOOP;
 
 						QString descr = br.loopDescr->toPlainText();
+						_viewport->editor->lcl_fred_replace_stuff(descr);
 						if (descr.isEmpty())
 							cm.mission_branch_desc = nullptr;
 						else

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -11,6 +11,7 @@
 #include "ui/dialogs/MissionSpecDialog.h"
 
 #include "cfile/cfile.h"
+#include "localization/localize.h"
 #include "mission/missionmessage.h"
 
 #include <QtWidgets>
@@ -102,14 +103,13 @@ bool MissionSpecDialogModel::apply() {
 		The_mission.contrail_threshold = CONTRAIL_THRESHOLD_DEFAULT;
 	}
 	
-	//if there's a odd number of quotation marks, the mission won't parse
-	//If there are an even number, nothing after the first one appears
-	//So just get rid of them
-	Editor::strip_quotation_marks(_m_mission_title);
-	Editor::strip_quotation_marks(_m_designer_name);
-	Editor::strip_quotation_marks(_m_mission_notes);
-	Editor::strip_quotation_marks(_m_mission_desc);
-	Editor::strip_quotation_marks(_m_squad_name);
+	// originally the dialog stripped out quotation marks here;
+	// now it handles all special characters
+	lcl_fred_replace_stuff(_m_mission_title);
+	lcl_fred_replace_stuff(_m_designer_name);
+	lcl_fred_replace_stuff(_m_mission_notes);
+	lcl_fred_replace_stuff(_m_mission_desc);
+	lcl_fred_replace_stuff(_m_squad_name);
 
 	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
 	Editor::pad_with_newline(_m_mission_notes, NOTES_LENGTH - 1);


### PR DESCRIPTION
Kitsune discovered that special characters, notably semicolons, were not properly handled in the Mission Specs editor.  This adds appropriate handling of special characters for fields in that editor, similar fields in the campaign editor, and the corresponding places in qtFRED.  This also makes error messages more descriptive for campaign load failures.