### PR TITLE
allow getting of mission info even for files with long names

### DIFF
--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -211,7 +211,7 @@ void CFREDDoc::editor_init_mission() {
 	recreate_dialogs();
 }
 
-bool CFREDDoc::load_mission(char *pathname, int flags) {
+bool CFREDDoc::load_mission(const char *pathname, int flags) {
 	// make sure we're in the correct working directory!!!!!!
 	chdir(Fred_base_dir);
 
@@ -554,32 +554,23 @@ BOOL CFREDDoc::OnNewDocument() {
 }
 
 BOOL CFREDDoc::OnOpenDocument(LPCTSTR pathname) {
-	char name[1024];
-
-	if (pathname)
-		strcpy_s(mission_pathname, pathname);
-
 	if (Briefing_dialog)
 		Briefing_dialog->icon_select(-1);  // clean things up first
 
-	auto len = strlen(mission_pathname);
-	strcpy_s(name, mission_pathname);
-	if (name[len - 4] == '.')
-		len -= 4;
+	auto sep_ch = strrchr(pathname, '\\');
+	auto filename = (sep_ch != nullptr) ? (sep_ch + 1) : pathname;
+	auto len = strlen(filename);
 
-	name[len] = 0;  // drop extension
-	auto i = len;
-	while (i--)
-		if ((name[i] == '\\') || (name[i] == ':'))
-			break;
+	// drop extension and copy to Mission_filename
+	auto ext_ch = strrchr(filename, '.');
+	if (ext_ch != nullptr)
+		len = ext_ch - filename;
+	if (len >= 80)
+		len = 79;
+	strncpy(Mission_filename, filename, len);
+	Mission_filename[len] = 0;
 
-	strcpy_s(Mission_filename, name + i + 1);
-	//	for (i=1; i<=BACKUP_DEPTH; i++) {
-	//		sprintf(name + len, ".%.3d", i);
-	//		unlink(name);
-	//	}
-
-	if (!load_mission(mission_pathname)) {
+	if (!load_mission(pathname)) {
 		*Mission_filename = 0;
 		return FALSE;
 	}
@@ -592,21 +583,26 @@ BOOL CFREDDoc::OnOpenDocument(LPCTSTR pathname) {
 
 BOOL CFREDDoc::OnSaveDocument(LPCTSTR pathname) {
 	CFred_mission_save save;
-	char name[1024];
 	DWORD attrib;
 	FILE *fp;
 
-	auto len = strlen(pathname);
-	strcpy_s(name, pathname);
-	if (name[len - 4] == '.')
-		len -= 4;
+	auto sep_ch = strrchr(pathname, '\\');
+	auto filename = (sep_ch != nullptr) ? (sep_ch + 1) : pathname;
+	auto len = strlen(filename);
 
-	name[len] = 0;  // drop extension
-	while (len--)
-		if ((name[len] == '\\') || (name[len] == ':'))
-			break;
+	if (len >= MAX_FILENAME_LEN)
+		Fred_main_wnd->MessageBox("The filename is too long for FreeSpace.  The game will not be able to read this file.  Max length, including extension, is " SCP_TOKEN_TO_STR(MAX_FILENAME_LEN-1) " characters.", NULL, MB_OK | MB_ICONEXCLAMATION);
 
-	strcpy_s(Mission_filename, name + len + 1);
+	// drop extension and copy to Mission_filename
+	auto ext_ch = strrchr(filename, '.');
+	if (ext_ch != nullptr)
+		len = ext_ch - filename;
+	if (len >= 80)
+		len = 79;
+	strncpy(Mission_filename, filename, len);
+	Mission_filename[len] = 0;
+
+
 	Fred_view_wnd->global_error_check();
 	if (Briefing_dialog) {
 		Briefing_dialog->update_data(1);
@@ -629,13 +625,13 @@ BOOL CFREDDoc::OnSaveDocument(LPCTSTR pathname) {
 		}
 	}
 
-	if (save.save_mission_file((char *) pathname)) {
+	if (save.save_mission_file(pathname)) {
 		Fred_main_wnd->MessageBox("An error occured while saving!", NULL, MB_OK | MB_ICONEXCLAMATION);
 		return FALSE;
 	}
 
 	SetModifiedFlag(FALSE);
-	if (!load_mission((char *) pathname))
+	if (!load_mission(pathname))
 		Error(LOCATION, "Failed attempting to reload mission after saving.  Report this bug now!");
 
 	if (Briefing_dialog) {

--- a/fred2/freddoc.h
+++ b/fred2/freddoc.h
@@ -48,7 +48,7 @@ public:
 	 *
 	 * @returns true on success, false on failure
 	 */
-	bool load_mission(char *pathname, int flags = 0);
+	bool load_mission(const char *pathname, int flags = 0);
 
 	/**
 	 * @brief Pushes an Undo item onto the stack
@@ -144,8 +144,6 @@ public:
 	 */
 	virtual void Dump(CDumpContext &dc) const;
 #endif
-
-	char mission_pathname[256];             //!< Full pathname to the opened mission
 
 	CString undo_desc[BACKUP_DEPTH + 1];    //!< String array of the undo descriptions
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1272,7 +1272,7 @@ int CFred_mission_save::save_briefing()
 	return err;
 }
 
-int CFred_mission_save::save_campaign_file(char *pathname)
+int CFred_mission_save::save_campaign_file(const char *pathname)
 {
 	int i, j, m, flag;
 
@@ -2556,16 +2556,16 @@ int CFred_mission_save::save_messages()
 	return err;
 }
 
-int CFred_mission_save::save_mission_file(char *pathname)
+int CFred_mission_save::save_mission_file(const char *pathname)
 {
-	char backup_name[256], savepath[MAX_PATH_LEN], *p;
+	char savepath[MAX_PATH_LEN];
 
 	strcpy_s(savepath, "");
-	p = strrchr(pathname, '\\');
+	auto p = strrchr(pathname, '\\');
 	if (p) {
-		*p = '\0';
-		strcpy_s(savepath, pathname);
-		*p = '\\';
+		auto len = p - pathname;
+		strncpy(savepath, pathname, len);
+		savepath[len] = '\0';
 		strcat_s(savepath, "\\");
 	}
 	strcat_s(savepath, "saving.xxx");
@@ -2573,9 +2573,14 @@ int CFred_mission_save::save_mission_file(char *pathname)
 	save_mission_internal(savepath);
 
 	if (!err) {
+		char backup_name[MAX_PATH_LEN];
+
 		strcpy_s(backup_name, pathname);
-		if (backup_name[strlen(backup_name) - 4] == '.')
-			backup_name[strlen(backup_name) - 4] = 0;
+
+		// drop extension
+		auto ext_ch = strrchr(backup_name, '.');
+		if (ext_ch != nullptr)
+			*ext_ch = 0;
 
 		strcat_s(backup_name, ".bak");
 		cf_attrib(pathname, 0, FILE_ATTRIBUTE_READONLY, CF_TYPE_MISSIONS);

--- a/fred2/missionsave.h
+++ b/fred2/missionsave.h
@@ -150,7 +150,7 @@ public:
 	 *
 	 * @see save_mission_internal()
 	 */
-	int save_campaign_file(char *pathname);
+	int save_campaign_file(const char *pathname);
 
 	/**
 	 * @brief Saves the mission file to the given full pathname
@@ -164,7 +164,7 @@ public:
 	 *
 	 * @see save_mission_internal()
 	 */
-	int save_mission_file(char *pathname);
+	int save_mission_file(const char *pathname);
 
 	/**
 	 * @brief Save the reinforcements to file


### PR DESCRIPTION
Issue #5459 notes that mission files that are too long will crash the FRED campaign editor, but this is an artificial restriction.  The only need for a string buffer here is to enforce the correct mission extension, so use a SCP_string for this, and add checks for whether string manipulation is in fact necessary.  (In most cases it isn't.)

Fixes #5459.