### PR TITLE
Fix issues with campaign-persistent containers

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -857,7 +857,9 @@ int mission_campaign_previous_mission()
 	}
 
 	// copy backed up containers over
-	Campaign.persistent_containers = Campaign.red_alert_containers;
+	for (const auto& ra_container : Campaign.red_alert_containers) {
+		Campaign.persistent_containers.emplace_back(ra_container);
+	}
 	
 	Pilot.save_savefile();
 
@@ -1056,7 +1058,9 @@ void mission_campaign_store_containers(ContainerType persistence_type, bool stor
 	}
 
 	if (store_red_alert) {
-		Campaign.persistent_containers = Campaign.red_alert_containers;
+		for (const auto& current_con : Campaign.red_alert_containers) {
+			Campaign.persistent_containers.emplace_back(current_con);
+		}
 	}
 
 	for (const auto &container : get_all_sexp_containers()) {

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1511,6 +1511,10 @@ void pilotfile::csg_reset_data()
 	Campaign.persistent_variables.clear();
 	Campaign.red_alert_variables.clear();
 
+	// clear out containers
+	Campaign.persistent_containers.clear();
+	Campaign.red_alert_containers.clear();
+
 	// clear red alert data
 	Red_alert_wingman_status.clear();
 


### PR DESCRIPTION
Campaign-persistent containers were getting clobbered by red alert containers and also weren't always being cleared alongside campaign-persistent variables.

Fixes Issue #5458.