### PR TITLE
add const where appropriate to the modelrender API

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -102,7 +102,7 @@ public:
 		Stack.push_back(Current_transform);
 	}
 
-	matrix4 &get_transform()
+	const matrix4 &get_transform() const
 	{
 		return Current_transform;
 	}
@@ -115,7 +115,7 @@ public:
 		Stack.push_back(Current_transform);
 	}
 
-	void push_and_replace(matrix4 new_transform)
+	void push_and_replace(const matrix4 &new_transform)
 	{
 		Current_transform = new_transform;
 		Stack.push_back(Current_transform);
@@ -300,7 +300,7 @@ public:
 
 	void add_vertex_component(vertex_format_data::vertex_format format_type, size_t stride, size_t offset);
 
-	size_t get_vertex_stride() { return Vertex_stride; }
+	size_t get_vertex_stride() const { return Vertex_stride; }
 
 	bool operator==(const vertex_layout& other) const;
 

--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -441,7 +441,7 @@ void material::set_color(int r, int g, int b, int a)
 	Clr.xyzw.w = i2fl(a) / 255.0f;
 }
 
-void material::set_color(color &clr_in)
+void material::set_color(const color &clr_in)
 {
 	if ( clr_in.is_alphacolor ) {
 		Clr.xyzw.x = i2fl(clr_in.red) / 255.0f;

--- a/code/graphics/material.h
+++ b/code/graphics/material.h
@@ -133,7 +133,7 @@ public:
 
 	void set_color(float red, float green, float blue, float alpha);
 	void set_color(int r, int g, int b, int a);
-	void set_color(color &clr_in);
+	void set_color(const color &clr_in);
 	const vec4& get_color() const;
 
 	void set_color_scale(float scale);

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2811,7 +2811,7 @@ void vm_matrix4_get_orientation(matrix *out, const matrix4 *m)
 	out->a2d[2][2] = m->a2d[2][2];
 }
 
-void vm_matrix4_get_offset(vec3d *out, matrix4 *m)
+void vm_matrix4_get_offset(vec3d *out, const matrix4 *m)
 {
 	out->xyz.x = m->vec.pos.xyzw.x;
 	out->xyz.y = m->vec.pos.xyzw.y;

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -565,7 +565,7 @@ void vm_matrix4_set_transform(matrix4 *out, matrix *m, vec3d *v);
 
 void vm_matrix4_get_orientation(matrix *out, const matrix4 *m);
 
-void vm_matrix4_get_offset(vec3d *out, matrix4 *m);
+void vm_matrix4_get_offset(vec3d *out, const matrix4 *m);
 
 void vm_vec_transform(vec4 *dest, const vec4 *src, const matrix4 *m);
 void vm_vec_transform(vec3d *dest, const vec3d *src, const matrix4 *m, bool pos = true);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -711,10 +711,10 @@ public:
 	texture_info(int bm_handle);
 	void clear();
 
-	int GetNumFrames();
-	int GetOriginalTexture();
-	int GetTexture();
-	float GetTotalTime();
+	int GetNumFrames() const;
+	int GetOriginalTexture() const;
+	int GetTexture() const;
+	float GetTotalTime() const;
 
 	int LoadTexture(const char *filename, const char *dbg_name = "<UNKNOWN>");
 
@@ -1414,7 +1414,7 @@ bool model_get_team_color(team_color *clr, const SCP_string &team, const SCP_str
 
 void moldel_calc_facing_pts( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, float w, float z_add, vec3d *Eyeposition );
 
-void model_draw_debug_points( polymodel *pm, bsp_info * submodel, uint flags );
+void model_draw_debug_points(const polymodel *pm, const bsp_info *submodel, uint flags);
 
 void model_render_shields( polymodel * pm, uint flags );
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -611,7 +611,7 @@ ubyte Interp_subspace_r = 255;
 ubyte Interp_subspace_g = 255;
 ubyte Interp_subspace_b = 255;
 
-void model_draw_debug_points( polymodel *pm, bsp_info * submodel, uint flags )
+void model_draw_debug_points(const polymodel *pm, const bsp_info *submodel, uint flags )
 {
 	if ( flags & MR_SHOW_OUTLINE_PRESET )	{
 		return;
@@ -660,7 +660,7 @@ void model_draw_debug_points( polymodel *pm, bsp_info * submodel, uint flags )
 		gr_set_color(0,255,0);
 
 		vec3d	bounding_box[8];		// caclulated fron min/max
-		model_calc_bound_box(bounding_box,&pm->mins, &pm->maxs);
+		model_calc_bound_box(bounding_box, &pm->mins, &pm->maxs);
 
 		for (i=0; i<8; i++ )	{
 			g3_rotate_vertex( &pts[i], &bounding_box[i] );
@@ -789,7 +789,7 @@ static const int MAX_ARC_SEGMENT_POINTS = 50;
 int Num_arc_segment_points = 0;
 vec3d Arc_segment_points[MAX_ARC_SEGMENT_POINTS];
 
-void interp_render_arc_segment( vec3d *v1, vec3d *v2, int depth )
+void interp_render_arc_segment(const vec3d *v1, const vec3d *v2, int depth )
 {
 	float d = vm_vec_dist_quick( v1, v2 );
 	const float scaler = 0.30f;
@@ -2646,7 +2646,7 @@ int model_should_render_engine_glow(int objnum, int bank_obj)
 
 // Goober5000
 // uses same algorithms as in ship_do_thruster_frame
-int model_interp_get_texture(texture_info *tinfo, int elapsed_time)
+int model_interp_get_texture(const texture_info *tinfo, int elapsed_time)
 {
 	int texture, frame, cur_time, num_frames;
 	float total_time;
@@ -2751,19 +2751,19 @@ void texture_info::clear()
 	num_frames = 0;
 	total_time = 1.0f;
 }
-int texture_info::GetNumFrames()
+int texture_info::GetNumFrames() const
 {
 	return num_frames;
 }
-int texture_info::GetOriginalTexture()
+int texture_info::GetOriginalTexture() const
 {
 	return original_texture;
 }
-int texture_info::GetTexture()
+int texture_info::GetTexture() const
 {
 	return texture;
 }
-float texture_info::GetTotalTime()
+float texture_info::GetTotalTime() const
 {
 	return total_time;
 }

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1313,7 +1313,7 @@ bool maybe_swap_mins_maxs(vec3d *mins, vec3d *maxs)
 	return swap_was_necessary;
 }
 
-void model_calc_bound_box( vec3d *box, vec3d *big_mn, vec3d *big_mx)
+void model_calc_bound_box(vec3d *box, const vec3d *big_mn, const vec3d *big_mx)
 {
 	box[0].xyz.x = big_mn->xyz.x; box[0].xyz.y = big_mn->xyz.y; box[0].xyz.z = big_mn->xyz.z;
 	box[1].xyz.x = big_mx->xyz.x; box[1].xyz.y = big_mn->xyz.y; box[1].xyz.z = big_mn->xyz.z;

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -47,7 +47,7 @@ extern vec3d Arc_segment_points[];
 extern bool Scene_framebuffer_in_frame;
 color Wireframe_color;
 
-extern void interp_render_arc_segment( vec3d *v1, vec3d *v2, int depth );
+extern void interp_render_arc_segment(const vec3d *v1, const vec3d *v2, int depth);
 
 int model_render_determine_elapsed_time(int objnum, uint flags);
 
@@ -94,94 +94,95 @@ model_render_params::model_render_params() :
 model_render_params::~model_render_params() 
 {
 	if (Manage_replacement_textures)
-		vm_free(Replacement_textures);
+		vm_free(const_cast<int*>(Replacement_textures));
 }
 
-uint model_render_params::get_model_flags()
+uint model_render_params::get_model_flags() const
 {
 	return Model_flags; 
 }
 
-uint model_render_params::get_debug_flags()
+uint model_render_params::get_debug_flags() const
 {
 	return Debug_flags;
 }
 
-int model_render_params::get_object_number()
+int model_render_params::get_object_number() const
 { 
 	return Objnum; 
 }
 
-int model_render_params::get_detail_level_lock()
+int model_render_params::get_detail_level_lock() const
 { 
 	return Detail_level_locked; 
 }
 
-float model_render_params::get_depth_scale()
+float model_render_params::get_depth_scale() const
 { 
 	return Depth_scale; 
 }
 
-int model_render_params::get_warp_bitmap()
+int model_render_params::get_warp_bitmap() const
 { 
 	return Warp_bitmap; 
 }
 
-float model_render_params::get_warp_alpha()
+float model_render_params::get_warp_alpha() const
 { 
 	return Warp_alpha; 
 }
 
-const vec3d& model_render_params::get_warp_scale()
+const vec3d& model_render_params::get_warp_scale() const
 { 
 	return Warp_scale; 
 }
 
-const color& model_render_params::get_color()
+const color& model_render_params::get_color() const
 { 
 	return Color; 
 }
-float model_render_params::get_alpha()
+
+float model_render_params::get_alpha() const
 { 
 	return Xparent_alpha; 
 }
 
-int model_render_params::get_forced_bitmap()
+int model_render_params::get_forced_bitmap() const
 { 
 	return Forced_bitmap; 
 }
 
-int model_render_params::get_insignia_bitmap()
+int model_render_params::get_insignia_bitmap() const
 { 
 	return Insignia_bitmap; 
 }
 
-const int* model_render_params::get_replacement_textures()
+const int* model_render_params::get_replacement_textures() const
 { 
 	return Replacement_textures; 
 }
 
-const team_color& model_render_params::get_team_color()
+const team_color& model_render_params::get_team_color() const
 { 
 	return Current_team_color; 
 }
 
-const vec3d& model_render_params::get_clip_plane_pos()
+const vec3d& model_render_params::get_clip_plane_pos() const
 { 
 	return Clip_pos; 
 }
 
-const vec3d& model_render_params::get_clip_plane_normal()
+const vec3d& model_render_params::get_clip_plane_normal() const
 { 
 	return Clip_normal; 
 }
 
-int model_render_params::get_animated_effect_num()
+int model_render_params::get_animated_effect_num() const
 { 
 	return Animated_effect; 
 }
 
-float model_render_params::get_animated_effect_timer()
+float model_render_params::get_animated_effect_timer() const
 { 
 	return Animated_timer; 
 }
@@ -192,7 +193,7 @@ void model_render_params::set_animated_effect(int effect_num, float timer)
 	Animated_timer = timer;
 }
 
-void model_render_params::set_clip_plane(vec3d &pos, vec3d &normal)
+void model_render_params::set_clip_plane(const vec3d &pos, const vec3d &normal)
 {
 	Clip_plane_set = true;
 
@@ -200,12 +201,12 @@ void model_render_params::set_clip_plane(vec3d &pos, vec3d &normal)
 	Clip_pos = pos;
 }
 
-bool model_render_params::is_clip_plane_set()
+bool model_render_params::is_clip_plane_set() const
 {
 	return Clip_plane_set;
 }
 
-void model_render_params::set_team_color(team_color &clr)
+void model_render_params::set_team_color(const team_color &clr)
 {
 	Team_color_set = true;
 
@@ -217,22 +218,22 @@ void model_render_params::set_team_color(const SCP_string &team, const SCP_strin
 	Team_color_set = model_get_team_color(&Current_team_color, team, secondaryteam, timestamp, fadetime);
 }
 
-bool model_render_params::is_team_color_set()
+bool model_render_params::is_team_color_set() const
 {
 	return Team_color_set;
 }
 
-void model_render_params::set_replacement_textures(int *textures)
+void model_render_params::set_replacement_textures(const int *textures)
 {
 	Replacement_textures = textures;
 }
 
-void model_render_params::set_replacement_textures(int modelnum, SCP_vector<texture_replace>& replacement_textures)
+void model_render_params::set_replacement_textures(int modelnum, const SCP_vector<texture_replace>& replacement_textures)
 {
-	Replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
+	auto textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
 
 	for (int i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
-		Replacement_textures[i] = -1;
+		textures[i] = -1;
 
 	Manage_replacement_textures = true;
 
@@ -246,9 +247,11 @@ void model_render_params::set_replacement_textures(int modelnum, SCP_vector<text
 
 			int tnum = tmap->FindTexture(tr.old_texture);
 			if (tnum > -1)
-				Replacement_textures[i * TM_NUM_TYPES + tnum] = bm_load(tr.new_texture);
+				textures[i * TM_NUM_TYPES + tnum] = bm_load(tr.new_texture);
 		}
 	}
+
+	Replacement_textures = textures;
 }
 
 void model_render_params::set_insignia_bitmap(int bitmap)
@@ -266,7 +269,7 @@ void model_render_params::set_alpha(float alpha)
 	Xparent_alpha = alpha;
 }
 
-void model_render_params::set_color(color &clr)
+void model_render_params::set_color(const color &clr)
 {
 	Color = clr;
 }
@@ -276,7 +279,7 @@ void model_render_params::set_color(int r, int g, int b)
 	gr_init_color( &Color, r, g, b );
 }
 
-void model_render_params::set_warp_params(int bitmap, float alpha, vec3d &scale)
+void model_render_params::set_warp_params(int bitmap, float alpha, const vec3d &scale)
 {
 	Warp_bitmap = bitmap;
 	Warp_alpha = alpha;
@@ -308,14 +311,14 @@ void model_render_params::set_detail_level_lock(int detail_level_lock)
 	Detail_level_locked = detail_level_lock;
 }
 
-void model_render_params::set_thruster_info(mst_info &info)
+void model_render_params::set_thruster_info(const mst_info &info)
 {
 	Thruster_info = info;
 
 	CLAMP(Thruster_info.length.xyz.z, 0.1f, 1.0f);
 }
 
-const mst_info& model_render_params::get_thruster_info()
+const mst_info& model_render_params::get_thruster_info() const
 {
 	return Thruster_info;
 }
@@ -323,10 +326,10 @@ const mst_info& model_render_params::get_thruster_info()
 void model_render_params::set_outline_thickness(float thickness) {
 	Outline_thickness = thickness;
 }
-float model_render_params::get_outline_thickness() {
+float model_render_params::get_outline_thickness() const {
 	return Outline_thickness;
 }
-bool model_render_params::uses_thick_outlines() {
+bool model_render_params::uses_thick_outlines() const {
 	return Outline_thickness > 0.0f;
 }
 
@@ -335,12 +338,12 @@ void model_render_params::set_alpha_mult(float alpha) {
 	Use_alpha_mult = true;
 }
 
-bool model_render_params::is_alpha_mult_set()
+bool model_render_params::is_alpha_mult_set() const
 {
 	return Use_alpha_mult;
 }
 
-float model_render_params::get_alpha_mult()
+float model_render_params::get_alpha_mult() const
 {
 	return Alpha_mult;
 }
@@ -365,17 +368,17 @@ void model_batch_buffer::set_num_models(int n_models)
 	}
 }
 
-void model_batch_buffer::set_model_transform(matrix4 &transform, int model_id)
+void model_batch_buffer::set_model_transform(const matrix4 &transform, int model_id)
 {
 	Submodel_matrices[Current_offset + model_id] = transform;
 }
 
-void model_batch_buffer::add_matrix(matrix4 &mat)
+void model_batch_buffer::add_matrix(const matrix4 &mat)
 {
 	Submodel_matrices.push_back(mat);
 }
 
-size_t model_batch_buffer::get_buffer_offset()
+size_t model_batch_buffer::get_buffer_offset() const
 {
 	return Current_offset;
 }
@@ -455,7 +458,7 @@ void model_draw_list::add_submodel_to_batch(int model_num)
 	TransformBufferHandler.set_model_transform(transform, model_num);
 }
 
-void model_draw_list::add_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, float arc_width)
+void model_draw_list::add_arc(const vec3d *v1, const vec3d *v2, const color *primary, const color *secondary, float arc_width)
 {
 	arc_effect new_arc;
 
@@ -469,14 +472,14 @@ void model_draw_list::add_arc(vec3d *v1, vec3d *v2, color *primary, color *secon
 	Arcs.push_back(new_arc);
 }
 
-void model_draw_list::set_light_filter(vec3d *pos, float rad)
+void model_draw_list::set_light_filter(const vec3d *pos, float rad)
 {
 	Scene_light_handler.setLightFilter(pos, rad);
 
 	Current_lights_set = Scene_light_handler.bufferLights();
 }
 
-void model_draw_list::add_buffer_draw(model_material *render_material, indexed_vertex_source *vert_src, vertex_buffer *buffer, size_t texi, uint tmap_flags)
+void model_draw_list::add_buffer_draw(const model_material *render_material, const indexed_vertex_source *vert_src, const vertex_buffer *buffer, size_t texi, uint tmap_flags)
 {
 	queued_buffer_draw draw_data;
 	draw_data.render_material = *render_material;
@@ -529,7 +532,7 @@ void model_draw_list::add_buffer_draw(model_material *render_material, indexed_v
 	Render_keys.push_back((int) (Render_elements.size() - 1));
 }
 
-void model_draw_list::render_buffer(queued_buffer_draw &render_elements)
+void model_draw_list::render_buffer(const queued_buffer_draw &render_elements)
 {
 	GR_DEBUG_SCOPE("Render buffer");
 	TRACE_SCOPE(tracing::RenderBuffer);
@@ -537,10 +540,10 @@ void model_draw_list::render_buffer(queued_buffer_draw &render_elements)
 	gr_bind_uniform_buffer(uniform_block_type::ModelData, render_elements.uniform_buffer_offset,
 	                       sizeof(graphics::model_uniform_data), _dataBuffer.bufferHandle());
 
-	gr_render_model(&render_elements.render_material, render_elements.vert_src, render_elements.buffer, render_elements.texi);
+	gr_render_model(const_cast<model_material*>(&render_elements.render_material), const_cast<indexed_vertex_source*>(render_elements.vert_src), const_cast<vertex_buffer*>(render_elements.buffer), render_elements.texi);
 }
 
-vec3d model_draw_list::get_view_position()
+vec3d model_draw_list::get_view_position() const
 {
 	matrix basis_world;
 	matrix4 transform_mat = Transformations.get_transform();
@@ -562,7 +565,7 @@ vec3d model_draw_list::get_view_position()
 	return return_val;
 }
 
-void model_draw_list::push_transform(vec3d *pos, matrix *orient)
+void model_draw_list::push_transform(const vec3d *pos, const matrix *orient)
 {
 	Transformations.push(pos, orient);
 }
@@ -572,7 +575,7 @@ void model_draw_list::pop_transform()
 	Transformations.pop();
 }
 
-void model_draw_list::set_scale(vec3d *scale)
+void model_draw_list::set_scale(const vec3d *scale)
 {
 	if ( scale == NULL ) {
 		Current_scale.xyz.x = 1.0f;
@@ -630,7 +633,7 @@ void model_draw_list::render_all(gr_zbuffer_type depth_mode)
 	gr_alpha_mask_set(0, 1.0f);
 }
 
-void model_draw_list::render_arc(arc_effect &arc)
+void model_draw_list::render_arc(const arc_effect &arc)
 {
 	g3_start_instance_matrix(&arc.transform);	
 
@@ -650,7 +653,7 @@ void model_draw_list::render_arcs()
 	gr_zbuffer_set(mode);
 }
 
-void model_draw_list::add_insignia(model_render_params *params, polymodel *pm, int detail_level, int bitmap_num)
+void model_draw_list::add_insignia(const model_render_params *params, const polymodel *pm, int detail_level, int bitmap_num)
 {
 	insignia_draw_data new_insignia;
 
@@ -666,7 +669,7 @@ void model_draw_list::add_insignia(model_render_params *params, polymodel *pm, i
 	Insignias.push_back(new_insignia);
 }
 
-void model_draw_list::render_insignia(insignia_draw_data &insignia_info)
+void model_draw_list::render_insignia(const insignia_draw_data &insignia_info)
 {
 	if ( insignia_info.clip ) {
 		vec3d tmp;
@@ -695,7 +698,7 @@ void model_draw_list::render_insignias()
 	}
 }
 
-void model_draw_list::add_outline(vertex* vert_array, int n_verts, color *clr)
+void model_draw_list::add_outline(const vertex* vert_array, int n_verts, const color *clr)
 {
 	outline_draw draw_info;
 
@@ -716,7 +719,7 @@ void model_draw_list::render_outlines()
 	}
 }
 
-void model_draw_list::render_outline(outline_draw &outline_info)
+void model_draw_list::render_outline(const outline_draw &outline_info)
 {
 	g3_start_instance_matrix(&outline_info.transform);
 
@@ -726,15 +729,15 @@ void model_draw_list::render_outline(outline_draw &outline_info)
 	material_instance.set_blend_mode(ALPHA_BLEND_ALPHA_BLEND_ALPHA);
 	material_instance.set_color(outline_info.clr);
 
-	g3_render_primitives(&material_instance, outline_info.vert_array, outline_info.n_verts, PRIM_TYPE_LINES, false);
+	g3_render_primitives(&material_instance, const_cast<vertex*>(outline_info.vert_array), outline_info.n_verts, PRIM_TYPE_LINES, false);
 
 	g3_done_instance(true);
 }
 
-bool model_draw_list::sort_draw_pair(model_draw_list* target, const int a, const int b)
+bool model_draw_list::sort_draw_pair(const model_draw_list* target, const int a, const int b)
 {
-	queued_buffer_draw *draw_call_a = &target->Render_elements[a];
-	queued_buffer_draw *draw_call_b = &target->Render_elements[b];
+	auto draw_call_a = &target->Render_elements[a];
+	auto draw_call_b = &target->Render_elements[b];
 
 	if ( draw_call_a->sdr_flags != draw_call_b->sdr_flags ) {
 		return draw_call_a->sdr_flags < draw_call_b->sdr_flags;
@@ -817,7 +820,7 @@ model_draw_list::~model_draw_list() {
 	reset();
 }
 
-void model_render_add_lightning( model_draw_list *scene, model_render_params* interp, polymodel *pm, submodel_instance *smi )
+void model_render_add_lightning(model_draw_list *scene, const model_render_params* interp, const polymodel *pm, const submodel_instance *smi )
 {
 	int i;
 	float width = 0.9f;
@@ -912,7 +915,7 @@ void model_render_add_lightning( model_draw_list *scene, model_render_params* in
 	}
 }
 
-float model_render_determine_depth(int obj_num, int model_num, matrix* orient, vec3d* pos, int detail_level_locked)
+float model_render_determine_depth(int obj_num, int model_num, const matrix* orient, const vec3d* pos, int detail_level_locked)
 {
 	vec3d closest_pos;
 	float depth = model_find_closest_point( &closest_pos, model_num, -1, orient, pos, &Eye_position );
@@ -946,7 +949,7 @@ float model_render_determine_depth(int obj_num, int model_num, matrix* orient, v
 	return depth;
 }
 
-int model_render_determine_detail(float depth, int  /*obj_num*/, int model_num, matrix*  /*orient*/, vec3d*  /*pos*/, int  /*flags*/, int detail_level_locked)
+int model_render_determine_detail(float depth, int model_num, int detail_level_locked)
 {
 	int tmp_detail_level = Game_detail_level;
 
@@ -990,7 +993,7 @@ int model_render_determine_detail(float depth, int  /*obj_num*/, int model_num, 
 	}
 }
 
-void model_render_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, vertex_buffer *buffer, polymodel *pm, int mn, int detail_level, uint tmap_flags)
+void model_render_buffers(model_draw_list* scene, model_material *rendering_material, const model_render_params* interp, const vertex_buffer *buffer, const polymodel *pm, int mn, int detail_level, uint tmap_flags)
 {
 	bsp_info *submodel = nullptr;
 	const uint model_flags = interp->get_model_flags();
@@ -1062,7 +1065,7 @@ void model_render_buffers(model_draw_list* scene, model_material *rendering_mate
 
 	for ( size_t i = 0; i < buffer_size; i++ ) {
 		int tmap_num = buffer->tex_buf[i].texture;
-		texture_map *tmap = &pm->maps[tmap_num];
+		auto tmap = &pm->maps[tmap_num];
 		int rt_begin_index = tmap_num*TM_NUM_TYPES;
 		float alpha = 1.0f;
 
@@ -1103,7 +1106,7 @@ void model_render_buffers(model_draw_list* scene, model_material *rendering_mate
 
 			// doing glow maps?
 			if ( !(model_flags & MR_NO_GLOWMAPS) ) {
-				texture_info *tglow = &tmap->textures[TM_GLOW_TYPE];
+				auto tglow = &tmap->textures[TM_GLOW_TYPE];
 
 				if ( (replacement_textures != NULL) && (replacement_textures[rt_begin_index + TM_GLOW_TYPE] >= 0) ) {
 					tex_replace[TM_GLOW_TYPE] = texture_info(replacement_textures[rt_begin_index + TM_GLOW_TYPE]);
@@ -1137,10 +1140,10 @@ void model_render_buffers(model_draw_list* scene, model_material *rendering_mate
 
 			if (detail_level < 2) {
 				// likewise, etc.
-				texture_info *norm_map = &tmap->textures[TM_NORMAL_TYPE];
-				texture_info *height_map = &tmap->textures[TM_HEIGHT_TYPE];
-				texture_info *ambient_map = &tmap->textures[TM_AMBIENT_TYPE];
-				texture_info *misc_map = &tmap->textures[TM_MISC_TYPE];
+				auto norm_map = &tmap->textures[TM_NORMAL_TYPE];
+				auto height_map = &tmap->textures[TM_HEIGHT_TYPE];
+				auto ambient_map = &tmap->textures[TM_AMBIENT_TYPE];
+				auto misc_map = &tmap->textures[TM_MISC_TYPE];
 
 				if (replacement_textures != NULL) {
 					if (replacement_textures[rt_begin_index + TM_NORMAL_TYPE] >= 0) {
@@ -1260,7 +1263,7 @@ void model_render_buffers(model_draw_list* scene, model_material *rendering_mate
 	}
 }
 
-void model_render_children_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, polymodel* pm, polymodel_instance *pmi, int mn, int detail_level, uint tmap_flags, bool trans_buffer)
+void model_render_children_buffers(model_draw_list* scene, model_material *rendering_material, const model_render_params* interp, const polymodel* pm, const polymodel_instance *pmi, int mn, int detail_level, uint tmap_flags, bool trans_buffer)
 {
 	int i;
 
@@ -1340,7 +1343,7 @@ void model_render_children_buffers(model_draw_list* scene, model_material *rende
 	scene->pop_transform();
 }
 
-float model_render_determine_light_factor(model_render_params* interp, vec3d *pos, uint flags)
+float model_render_determine_light_factor(const model_render_params* interp, const vec3d *pos, uint flags)
 {
 	if ( flags & MR_IS_ASTEROID ) {
 		// Dim it based on distance
@@ -1404,7 +1407,7 @@ int model_render_determine_elapsed_time(int objnum, uint flags)
 	return timestamp_get_mission_time_in_milliseconds();
 }
 
-bool model_render_determine_autocenter(vec3d *auto_back, polymodel *pm, int detail_level, uint flags)
+bool model_render_determine_autocenter(vec3d *auto_back, const polymodel *pm, int detail_level, uint flags)
 {
 	if ( flags & MR_AUTOCENTER ) {
 		// standard autocenter using data in model
@@ -1454,7 +1457,7 @@ gr_alpha_blend model_render_determine_blend_mode(int base_bitmap, bool blending)
 	return ALPHA_BLEND_ALPHA_BLEND_ALPHA;
 }
 
-bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_num, uint flags)
+bool model_render_check_detail_box(const vec3d *view_pos, const polymodel *pm, int submodel_num, uint flags)
 {
 	Assert(pm != NULL);
 
@@ -1502,7 +1505,7 @@ bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_
 	return true;
 }
 
-void submodel_render_immediate(model_render_params *render_info, polymodel *pm, polymodel_instance *pmi, int submodel_num, matrix *orient, vec3d * pos)
+void submodel_render_immediate(const model_render_params *render_info, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *orient, const vec3d *pos)
 {
 	Assert(!pmi || pm->id == pmi->model_num);
 
@@ -1525,7 +1528,7 @@ void submodel_render_immediate(model_render_params *render_info, polymodel *pm, 
 	gr_reset_lighting();
 }
 
-void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, polymodel *pm, polymodel_instance *pmi, int submodel_num, matrix *orient, vec3d * pos)
+void submodel_render_queue(const model_render_params *render_info, model_draw_list *scene, const polymodel *pm, const polymodel_instance *pmi, int submodel_num, const matrix *orient, const vec3d *pos)
 {
 	Assert(!pmi || pm->id == pmi->model_num);
 
@@ -1651,7 +1654,7 @@ void submodel_render_queue(model_render_params *render_info, model_draw_list *sc
 }
 
 //Renders the sprite for a glowpoint.
-void model_render_glowpoint_bitmap(int point_num, vec3d *pos, matrix *orient, glow_point_bank *bank, glow_point_bank_override *gpo, polymodel *pm, polymodel_instance *pmi, ship* shipp, bool use_depth_buffer)
+void model_render_glowpoint_bitmap(int point_num, const vec3d *pos, const matrix *orient, const glow_point_bank *bank, const glow_point_bank_override *gpo, const polymodel *pm, const polymodel_instance *pmi, const ship* shipp, bool use_depth_buffer)
 {
 	glow_point *gpt = &bank->points[point_num];
 	vec3d loc_offset = gpt->pnt;
@@ -1813,7 +1816,7 @@ void model_render_glowpoint_bitmap(int point_num, vec3d *pos, matrix *orient, gl
 }
 
 //adds the glowpoint's lights, if any, to the lights vector.
-void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient, glow_point_bank *bank, glow_point_bank_override *gpo, polymodel *pm, polymodel_instance *pmi, ship* shipp)
+void model_render_glowpoint_add_light(int point_num, const vec3d *pos, const matrix *orient, const glow_point_bank *bank, const glow_point_bank_override *gpo, const polymodel *pm, const polymodel_instance *pmi, const ship* shipp)
 {
 	if(Detail.lighting <= 3 || !Deferred_lighting || gpo==nullptr || !gpo->is_lightsource) {
 		return;
@@ -1902,7 +1905,7 @@ void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient,
 }
 
 //Returns the current brightness percentage of a glowpoint, from 1.0f to 0.0f
-float model_render_get_point_activation(glow_point_bank* bank, glow_point_bank_override* gpo)
+float model_render_get_point_activation(const glow_point_bank* bank, const glow_point_bank_override* gpo)
 {
 	if(gpo == nullptr ||  !(gpo->pulse_type)){
 		return 1.0f;
@@ -1971,7 +1974,7 @@ float model_render_get_point_activation(glow_point_bank* bank, glow_point_bank_o
 	return pulse;
 }
 
-void model_render_set_glow_points(polymodel *pm, int objnum)
+void model_render_set_glow_points(const polymodel *pm, int objnum)
 {
 	int time = timestamp();
 	glow_point_bank_override *gpo = NULL;
@@ -2033,7 +2036,7 @@ void model_render_set_glow_points(polymodel *pm, int objnum)
 }
 
 //Handle all the glow points of a model being rendered.
-void model_render_glow_points(polymodel *pm, polymodel_instance *pmi, ship *shipp, matrix *orient, vec3d *pos, bool use_depth_buffer = true,bool render_sprites = true, bool add_lights= true)
+void model_render_glow_points(const polymodel *pm, const polymodel_instance *pmi, const ship *shipp, const matrix *orient, const vec3d *pos, bool use_depth_buffer = true, bool render_sprites = true, bool add_lights= true)
 {
 	Assert(pmi == nullptr || pm->id == pmi->model_num);
 
@@ -2152,7 +2155,7 @@ float model_render_get_diameter_clamped_to_min_pixel_size(const vec3d* pos, floa
 	return scaled_diameter;
 }
 
-void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, int objnum, ship *shipp, matrix *orient, vec3d *pos)
+void model_queue_render_thrusters(const model_render_params *interp, const polymodel *pm, int objnum, const ship *shipp, const matrix *orient, const vec3d *pos)
 {
 	int i, j;
 	int n_q = 0;
@@ -2454,9 +2457,9 @@ void model_queue_render_thrusters(model_render_params *interp, polymodel *pm, in
 	}
 }
 
-void model_render_insignias(insignia_draw_data *insignia_data)
+void model_render_insignias(const insignia_draw_data *insignia_data)
 {
-	polymodel *pm = insignia_data->pm;
+	auto pm = insignia_data->pm;
 	int detail_level = insignia_data->detail_level;
 	int bitmap_num = insignia_data->bitmap_num;
 
@@ -2522,7 +2525,7 @@ void model_render_insignias(insignia_draw_data *insignia_data)
 	}
 }
 
-void model_render_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, float arc_width)
+void model_render_arc(const vec3d *v1, const vec3d *v2, const color *primary, const color *secondary, float arc_width)
 {
 	Num_arc_segment_points = 0;
 
@@ -2542,7 +2545,7 @@ void model_render_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, fl
 	}
 }
 
-void model_render_debug_children(polymodel *pm, int mn, int detail_level, uint debug_flags)
+void model_render_debug_children(const polymodel *pm, int mn, int detail_level, uint debug_flags)
 {
 	int i;
 
@@ -2576,7 +2579,7 @@ void model_render_debug_children(polymodel *pm, int mn, int detail_level, uint d
 	g3_done_instance(true);
 }
 
-void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, uint debug_flags, int objnum, int detail_level_locked )
+void model_render_debug(int model_num, const matrix *orient, const vec3d *pos, uint flags, uint debug_flags, int objnum, int detail_level_locked )
 {
 	polymodel *pm = model_get(model_num);	
 	
@@ -2589,7 +2592,7 @@ void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, 
 		}
 	}
 	float depth = model_render_determine_depth(objnum, model_num, orient, pos, detail_level_locked);
-	int detail_level = model_render_determine_detail(depth, objnum, model_num, orient, pos, flags, detail_level_locked);
+	int detail_level = model_render_determine_detail(depth, model_num, detail_level_locked);
 
 	vec3d auto_back = ZERO_VECTOR;
 	bool set_autocen = model_render_determine_autocenter(&auto_back, pm, detail_level, flags);
@@ -2639,12 +2642,12 @@ void model_render_debug(int model_num, matrix *orient, vec3d * pos, uint flags, 
 	gr_zbuffer_set(save_gr_zbuffering_mode);
 }
 
-void model_render_immediate(model_render_params* render_info, int model_num, matrix* orient, vec3d* pos, int render, bool sort)
+void model_render_immediate(const model_render_params* render_info, int model_num, const matrix* orient, const vec3d* pos, int render, bool sort)
 {
 	model_render_immediate(render_info, model_num, -1, orient, pos, render, sort);
 }
 
-void model_render_immediate(model_render_params* render_info, int model_num, int model_instance_num, matrix* orient, vec3d* pos, int render, bool sort)
+void model_render_immediate(const model_render_params* render_info, int model_num, int model_instance_num, const matrix* orient, const vec3d* pos, int render, bool sort)
 {
 	model_draw_list model_list;
 
@@ -2685,12 +2688,12 @@ void model_render_immediate(model_render_params* render_info, int model_num, int
 	}
 }
 
-void model_render_queue(model_render_params* interp, model_draw_list* scene, int model_num, matrix* orient, vec3d* pos)
+void model_render_queue(const model_render_params* interp, model_draw_list* scene, int model_num, const matrix* orient, const vec3d* pos)
 {
 	model_render_queue(interp, scene, model_num, -1, orient, pos);
 }
 
-void model_render_queue(model_render_params* interp, model_draw_list* scene, int model_num, int model_instance_num, matrix* orient, vec3d* pos)
+void model_render_queue(const model_render_params* interp, model_draw_list* scene, int model_num, int model_instance_num, const matrix* orient, const vec3d* pos)
 {
 	int i;
 
@@ -2795,7 +2798,7 @@ void model_render_queue(model_render_params* interp, model_draw_list* scene, int
 	scene->push_transform(pos, orient);
 
 	float depth = model_render_determine_depth(objnum, model_num, orient, pos, interp->get_detail_level_lock());
-	int detail_level = model_render_determine_detail(depth, objnum, model_num, orient, pos, model_flags, interp->get_detail_level_lock());
+	int detail_level = model_render_determine_detail(depth, model_num, interp->get_detail_level_lock());
 
 	// If we're rendering attached weapon models, check against the ships' tabled Weapon Model Draw Distance (which defaults to 200)
 	if ( model_flags & MR_ATTACHED_MODEL && shipp != NULL ) {
@@ -3021,7 +3024,7 @@ void model_render_queue(model_render_params* interp, model_draw_list* scene, int
 }
 
 //Renders the glowpoint light sources of a model without rendering anything else of the model.
-void model_render_only_glowpoint_lights(model_render_params* interp, int model_num, int model_instance_num, matrix* orient, vec3d* pos)
+void model_render_only_glowpoint_lights(const model_render_params* interp, int model_num, int model_instance_num, const matrix* orient, const vec3d* pos)
 {
 	const int objnum = interp->get_object_number();
 	const int model_flags = interp->get_model_flags();
@@ -3077,18 +3080,18 @@ void model_render_only_glowpoint_lights(model_render_params* interp, int model_n
 	}
 }
 
-void model_render_set_wireframe_color(color* clr)
+void model_render_set_wireframe_color(const color* clr)
 {
 	Wireframe_color = *clr;
 }
 
 // renders a model as if in the tech room or briefing UI
 // model_type 1 for ship class, 2 for weapon class, 3 for pof
-bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, matrix* orient, SCP_string pof_filename, float close_zoom, vec3d close_pos)
+bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, const matrix* orient, const SCP_string &pof_filename, float close_zoom, const vec3d *close_pos)
 {
 
 	model_render_params render_info;
-	vec3d closeup_pos;
+	const vec3d *closeup_pos;
 	float closeup_zoom;
 	int model_num;
 	bool model_lighting = true;
@@ -3099,7 +3102,7 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 			ship_info* sip;
 			sip = &Ship_info[class_idx];
 
-			closeup_pos = sip->closeup_pos;
+			closeup_pos = &sip->closeup_pos;
 			closeup_zoom = sip->closeup_zoom;
 
 			if (sip->uses_team_colors) {
@@ -3119,7 +3122,7 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 			weapon_info* wip;
 			wip = &Weapon_info[class_idx];
 
-			closeup_pos = wip->closeup_pos;
+			closeup_pos = &wip->closeup_pos;
 			closeup_zoom = wip->closeup_zoom;
 
 			if (wip->wi_flags[Weapon::Info_Flags::Mr_no_lighting]) {
@@ -3166,7 +3169,7 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 
 	// Handle 3D init stuff
 	g3_start_frame(1);
-	g3_set_view_matrix(&closeup_pos, &vmd_identity_matrix, closeup_zoom * zoom);
+	g3_set_view_matrix(closeup_pos, &vmd_identity_matrix, closeup_zoom * zoom);
 
 	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
 	gr_set_view_matrix(&Eye_position, &Eye_matrix);

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -34,7 +34,7 @@ typedef enum {
 	TECH_JUMP_NODE
 } tech_render_type;
 
-inline int in_box(vec3d *min, vec3d *max, vec3d *pos, vec3d *view_position)
+inline int in_box(const vec3d *min, const vec3d *max, const vec3d *pos, const vec3d *view_position)
 {
 	vec3d point;
 
@@ -50,7 +50,7 @@ inline int in_box(vec3d *min, vec3d *max, vec3d *pos, vec3d *view_position)
 	return -1;
 }
 
-inline int in_sphere(vec3d *pos, float radius, vec3d *view_position)
+inline int in_sphere(const vec3d *pos, float radius, const vec3d *view_position)
 {
 	if ( vm_vec_dist(view_position, pos) <= radius )
 		return 1;
@@ -58,7 +58,7 @@ inline int in_sphere(vec3d *pos, float radius, vec3d *view_position)
 		return -1;
 }
 
-extern int model_interp_get_texture(texture_info *tinfo, int elapsed_time);
+extern int model_interp_get_texture(const texture_info *tinfo, int elapsed_time);
 
 class model_render_params
 {
@@ -83,7 +83,7 @@ class model_render_params
 
 	int Insignia_bitmap;
 
-	int *Replacement_textures;
+	const int *Replacement_textures;
 	bool Manage_replacement_textures; // This is set when we are rendering a model without an associated ship object;
 									  // in that case, model_render_params is responsible for allocating and destroying
 									  // the Replacement_textures array (this is handled elsewhere otherwise)
@@ -116,48 +116,48 @@ public:
 	void set_object_number(int num);
 	void set_detail_level_lock(int detail_level_lock);
 	void set_depth_scale(float scale);
-	void set_warp_params(int bitmap, float alpha, vec3d &scale);
-	void set_color(color &clr);
+	void set_warp_params(int bitmap, float alpha, const vec3d &scale);
+	void set_color(const color &clr);
 	void set_color(int r, int g, int b);
 	void set_alpha(float alpha);
 	void set_forced_bitmap(int bitmap);
 	void set_insignia_bitmap(int bitmap);
-	void set_replacement_textures(int *textures);
-	void set_replacement_textures(int modelnum, SCP_vector<texture_replace>& replacement_textures);
-	void set_team_color(team_color &clr);
+	void set_replacement_textures(const int *textures);
+	void set_replacement_textures(int modelnum, const SCP_vector<texture_replace>& replacement_textures);
+	void set_team_color(const team_color &clr);
 	void set_team_color(const SCP_string &team, const SCP_string &secondaryteam, fix timestamp, int fadetime);
-	void set_clip_plane(vec3d &pos, vec3d &normal);
+	void set_clip_plane(const vec3d &pos, const vec3d &normal);
 	void set_animated_effect(int effect_num, float timer);
-	void set_thruster_info(mst_info &info);
+	void set_thruster_info(const mst_info &info);
 	void set_outline_thickness(float thick);
 	void set_alpha_mult(float alpha);
 
-	bool is_clip_plane_set();
-	bool is_team_color_set();
-	bool is_alpha_mult_set();
-	bool uses_thick_outlines();
+	bool is_clip_plane_set() const;
+	bool is_team_color_set() const;
+	bool is_alpha_mult_set() const;
+	bool uses_thick_outlines() const;
 
-	uint get_model_flags();
-	uint get_debug_flags();
-	int get_object_number();
-	int get_detail_level_lock();
-	float get_depth_scale();
-	int get_warp_bitmap();
-	float get_warp_alpha();
-	const vec3d& get_warp_scale();
-	const color& get_color();
-	float get_alpha();
-	int get_forced_bitmap();
-	int get_insignia_bitmap();
-	const int* get_replacement_textures();
-	const team_color& get_team_color();
-	const vec3d& get_clip_plane_pos();
-	const vec3d& get_clip_plane_normal();
-	int get_animated_effect_num();
-	float get_animated_effect_timer();
-	const mst_info& get_thruster_info();
-	float get_outline_thickness();
-	float get_alpha_mult();
+	uint get_model_flags() const;
+	uint get_debug_flags() const;
+	int get_object_number() const;
+	int get_detail_level_lock() const;
+	float get_depth_scale() const;
+	int get_warp_bitmap() const;
+	float get_warp_alpha() const;
+	const vec3d& get_warp_scale() const;
+	const color& get_color() const;
+	float get_alpha() const;
+	int get_forced_bitmap() const;
+	int get_insignia_bitmap() const;
+	const int* get_replacement_textures() const;
+	const team_color& get_team_color() const;
+	const vec3d& get_clip_plane_pos() const;
+	const vec3d& get_clip_plane_normal() const;
+	int get_animated_effect_num() const;
+	float get_animated_effect_timer() const;
+	const mst_info& get_thruster_info() const;
+	float get_outline_thickness() const;
+	float get_alpha_mult() const;
 };
 
 struct arc_effect
@@ -173,7 +173,7 @@ struct arc_effect
 struct insignia_draw_data
 {
 	matrix4 transform;
-	polymodel *pm;
+	const polymodel *pm;
 	int detail_level;
 	int bitmap_num;
 
@@ -193,8 +193,8 @@ struct queued_buffer_draw
 	matrix4 transform;
 	vec3d scale;
 
-	indexed_vertex_source *vert_src;
-	vertex_buffer *buffer;
+	const indexed_vertex_source *vert_src;
+	const vertex_buffer *buffer;
 	size_t texi;
 	int flags;
 	int sdr_flags;
@@ -208,7 +208,7 @@ struct queued_buffer_draw
 
 struct outline_draw
 {
-	vertex* vert_array;
+	const vertex* vert_array;
 	int n_verts;
 
 	matrix4 transform;
@@ -229,13 +229,13 @@ public:
 
 	void reset();
 
-	size_t get_buffer_offset();
+	size_t get_buffer_offset() const;
 	void set_num_models(int n_models);
-	void set_model_transform(matrix4 &transform, int model_id);
+	void set_model_transform(const matrix4 &transform, int model_id);
 
 	void submit_buffer_data();
 
-	void add_matrix(matrix4 &mat);
+	void add_matrix(const matrix4 &mat);
 };
 
 class model_draw_list
@@ -246,10 +246,10 @@ class model_draw_list
 	scene_lights Scene_light_handler;
 	light_indexing_info Current_lights_set;
 
-	void render_arc(arc_effect &arc);
-	void render_insignia(insignia_draw_data &insignia_info);
-	void render_outline(outline_draw &outline_info);
-	void render_buffer(queued_buffer_draw &render_elements);
+	void render_arc(const arc_effect &arc);
+	void render_insignia(const insignia_draw_data &insignia_info);
+	void render_outline(const outline_draw &outline_info);
+	void render_buffer(const queued_buffer_draw &render_elements);
 	
 	SCP_vector<queued_buffer_draw> Render_elements;
 	SCP_vector<int> Render_keys;
@@ -262,7 +262,7 @@ class model_draw_list
 
 	bool Render_initialized = false; //!< A flag for checking if init_render has been called before a render_all call
 	
-	static bool sort_draw_pair(model_draw_list* target, const int a, const int b);
+	static bool sort_draw_pair(const model_draw_list* target, const int a, const int b);
 	void sort_draws();
 
 	void build_uniform_buffer();
@@ -278,47 +278,48 @@ public:
 	void add_submodel_to_batch(int model_num);
 	void start_model_batch(int n_models);
 
-	void add_buffer_draw(model_material *render_material, indexed_vertex_source *vert_src, vertex_buffer *buffer, size_t texi, uint tmap_flags);
+	void add_buffer_draw(const model_material *render_material, const indexed_vertex_source *vert_src, const vertex_buffer *buffer, size_t texi, uint tmap_flags);
 	
-	vec3d get_view_position();
-	void push_transform(vec3d* pos, matrix* orient);
+	vec3d get_view_position() const;
+	void push_transform(const vec3d* pos, const matrix* orient);
 	void pop_transform();
-	void set_scale(vec3d *scale = NULL);
+	void set_scale(const vec3d *scale = NULL);
 
-	void add_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, float arc_width);
+	void add_arc(const vec3d *v1, const vec3d *v2, const color *primary, const color *secondary, float arc_width);
 	void render_arcs();
 
-	void add_insignia(model_render_params *params, polymodel *pm, int detail_level, int bitmap_num);
+	void add_insignia(const model_render_params *params, const polymodel *pm, int detail_level, int bitmap_num);
 	void render_insignias();
 
-	void add_outline(vertex* vert_array, int n_verts, color *clr);
+	void add_outline(const vertex* vert_array, int n_verts, const color *clr);
 	void render_outlines();
 
-	void set_light_filter(vec3d *pos, float rad);
+	void set_light_filter(const vec3d *pos, float rad);
 
 	void init_render(bool sort = true);
 	void render_all(gr_zbuffer_type depth_mode = ZBUFFER_TYPE_DEFAULT);
 	void reset();
 };
-void model_render_only_glowpoint_lights(model_render_params* interp, int model_num, int model_instance_num, matrix* orient, vec3d* pos);
-float model_render_get_point_activation(glow_point_bank* bank, glow_point_bank_override* gpo);
-void model_render_glowpoint_add_light(int point_num, vec3d *pos, matrix *orient, glow_point_bank *bank, glow_point_bank_override *gpo, polymodel *pm, polymodel_instance *pmi, ship* shipp);
-void model_render_immediate(model_render_params* render_info, int model_num, matrix* orient, vec3d* pos, int render = MODEL_RENDER_ALL, bool sort = true);
-void model_render_immediate(model_render_params* render_info, int model_num, int model_instance_num, matrix* orient, vec3d* pos, int render = MODEL_RENDER_ALL, bool sort = true);
-void model_render_queue(model_render_params* render_info, model_draw_list* scene, int model_num, matrix* orient, vec3d* pos);
-void model_render_queue(model_render_params* render_info, model_draw_list* scene, int model_num, int model_instance_num, matrix* orient, vec3d* pos);
-void submodel_render_immediate(model_render_params *render_info, polymodel *pm, polymodel_instance *pmi, int submodel_num, matrix *orient, vec3d * pos);
-void submodel_render_queue(model_render_params *render_info, model_draw_list *scene, polymodel *pm, polymodel_instance *pmi, int submodel_num, matrix *orient, vec3d * pos);
-void model_render_buffers(model_draw_list* scene, model_material *rendering_material, model_render_params* interp, vertex_buffer *buffer, polymodel *pm, int mn, int detail_level, uint tmap_flags);
-bool model_render_check_detail_box(vec3d *view_pos, polymodel *pm, int submodel_num, uint flags);
-void model_render_arc(vec3d *v1, vec3d *v2, color *primary, color *secondary, float arc_width);
-void model_render_insignias(insignia_draw_data *insignia);
-void model_render_set_wireframe_color(color* clr);
-bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, matrix* orient, SCP_string pof_filename = "", float closeup_zoom = 0, vec3d closeup_pos = ZERO_VECTOR);
+
+void model_render_only_glowpoint_lights(const model_render_params* interp, int model_num, int model_instance_num, const matrix* orient, const vec3d* pos);
+float model_render_get_point_activation(const glow_point_bank* bank, const glow_point_bank_override* gpo);
+void model_render_glowpoint_add_light(int point_num, const vec3d* pos, const matrix* orient, const glow_point_bank* bank, const glow_point_bank_override* gpo, const polymodel* pm, const polymodel_instance* pmi, const ship* shipp);
+void model_render_immediate(const model_render_params* render_info, int model_num, const matrix* orient, const vec3d* pos, int render = MODEL_RENDER_ALL, bool sort = true);
+void model_render_immediate(const model_render_params* render_info, int model_num, int model_instance_num, const matrix* orient, const vec3d* pos, int render = MODEL_RENDER_ALL, bool sort = true);
+void model_render_queue(const model_render_params* render_info, model_draw_list* scene, int model_num, const matrix* orient, const vec3d* pos);
+void model_render_queue(const model_render_params* render_info, model_draw_list* scene, int model_num, int model_instance_num, const matrix* orient, const vec3d* pos);
+void submodel_render_immediate(const model_render_params* render_info, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* orient, const vec3d* pos);
+void submodel_render_queue(const model_render_params* render_info, model_draw_list* scene, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* orient, const vec3d* pos);
+void model_render_buffers(model_draw_list* scene, model_material* rendering_material, const model_render_params* interp, const vertex_buffer* buffer, const polymodel* pm, int mn, int detail_level, uint tmap_flags);
+bool model_render_check_detail_box(const vec3d* view_pos, const polymodel* pm, int submodel_num, uint flags);
+void model_render_arc(const vec3d* v1, const vec3d* v2, const color* primary, const color* secondary, float arc_width);
+void model_render_insignias(const insignia_draw_data* insignia);
+void model_render_set_wireframe_color(const color* clr);
+bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, const matrix* orient, const SCP_string& pof_filename = "", float closeup_zoom = 0, const vec3d* closeup_pos = &vmd_zero_vector);
 
 float model_render_get_diameter_clamped_to_min_pixel_size(const vec3d* pos, float diameter, float min_pixel_size);
 
-void model_render_determine_color(color *clr, float alpha, gr_alpha_blend blend_mode, bool no_texturing, bool desaturate);
+void model_render_determine_color(color* clr, float alpha, gr_alpha_blend blend_mode, bool no_texturing, bool desaturate);
 gr_alpha_blend model_render_determine_blend_mode(int base_bitmap, bool blending);
 
 #endif

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -30,7 +30,7 @@ static SCP_unordered_map<SCP_string, std::function<std::unique_ptr<VirtualPOFOpe
 */
 extern modelread_status read_model_file(polymodel* pm, const char* filename, int ferror, model_read_deferred_tasks& deferredTasks, model_parse_depth depth = {});
 extern void create_family_tree(polymodel* obj);
-extern void model_calc_bound_box(vec3d* box, vec3d* big_mn, vec3d* big_mx);
+extern void model_calc_bound_box(vec3d* box, const vec3d* big_mn, const vec3d* big_mx);
 
 /*
 * Caching base-loaded POFs, as well has providing automatic deallocation for loaded models

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -79,7 +79,7 @@ class polymodel;
 #define fl(p)	(*reinterpret_cast<float*>(p))
 #define cfl(p)  (*reinterpret_cast<const float*>(p))
 
-void model_calc_bound_box( vec3d *box, vec3d *big_mn, vec3d *big_mx);
+void model_calc_bound_box(vec3d *box, const vec3d *big_mn, const vec3d *big_mx);
 
 void interp_clear_instance();
 

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -227,7 +227,7 @@ void g3_render_primitives_textured(material* mat, vertex* verts, int n_verts, pr
 void g3_render_primitives_colored(material* mat, vertex* verts, int n_verts, primitive_type prim_type, bool orthographic = false);
 void g3_render_primitives_colored_textured(material* mat, vertex* verts, int n_verts, primitive_type prim_type, bool orthographic = false);
 
-void g3_render_rod(color *clr, int num_points, vec3d *pvecs, float width);
+void g3_render_rod(const color *clr, int num_points, const vec3d *pvecs, float width);
 
 void g3_render_laser_2d(material *mat_params, vec3d *headp, float head_width, vec3d *tailp, float tail_width, float max_len);
 

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -950,7 +950,7 @@ void g3_render_laser_2d(material *mat_params, vec3d *headp, float head_width, ve
 }
 
 // adapted from g3_draw_rod()
-void g3_render_rod(color *clr, int num_points, vec3d *pvecs, float width)
+void g3_render_rod(const color *clr, int num_points, const vec3d *pvecs, float width)
 {
 	const int MAX_ROD_VERTS = 100;
 	vec3d uvec, fvec, rvec;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -769,7 +769,7 @@ ADE_FUNC(renderBriefingModel,
 		thisType = TECH_JUMP_NODE;
 	}
 
-	return ade_set_args(L, "b", render_tech_model(thisType, x1, y1, x2, y2, zoom, lighting, -1, &orient, pof, closeup_zoom, closeup_pos));
+	return ade_set_args(L, "b", render_tech_model(thisType, x1, y1, x2, y2, zoom, lighting, -1, &orient, pof, closeup_zoom, &closeup_pos));
 }
 
 ADE_FUNC(drawBriefingMap,

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -6,7 +6,7 @@
 #include "eye.h"
 #include "texture.h"
 
-extern void model_calc_bound_box( vec3d *box, vec3d *big_mn, vec3d *big_mx);
+extern void model_calc_bound_box(vec3d *box, const vec3d *big_mn, const vec3d *big_mx);
 
 namespace scripting {
 namespace api {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -20829,7 +20829,7 @@ ship_subsys* ship_get_subsys_for_submodel(ship* shipp, int submodel)
  *
  * @return is the ship arriving, bool
  */
-bool ship::is_arriving(ship::warpstage stage, bool dock_leader_or_single)
+bool ship::is_arriving(ship::warpstage stage, bool dock_leader_or_single) const
 {
 	if (stage == ship::warpstage::BOTH) {
 		if (!dock_leader_or_single) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -842,10 +842,10 @@ public:
 	void clear();
 
     //Helper functions
-	bool is_arriving(ship::warpstage stage = ship::warpstage::BOTH, bool dock_leader_or_single = false);
-	inline bool is_departing() { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
-	inline bool cannot_warp_flags() { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled, Ship::Ship_Flags::No_subspace_drive]; }
-	inline bool is_dying_or_departing() { return is_departing() || flags[Ship::Ship_Flags::Dying]; }
+	bool is_arriving(ship::warpstage stage = ship::warpstage::BOTH, bool dock_leader_or_single = false) const;
+	inline bool is_departing() const { return flags[Ship::Ship_Flags::Depart_warp, Ship::Ship_Flags::Depart_dockbay]; }
+	inline bool cannot_warp_flags() const { return flags[Ship::Ship_Flags::Warp_broken, Ship::Ship_Flags::Warp_never, Ship::Ship_Flags::Disabled, Ship::Ship_Flags::No_subspace_drive]; }
+	inline bool is_dying_or_departing() const { return is_departing() || flags[Ship::Ship_Flags::Dying]; }
 
 	const char* get_display_name() const;
 	bool has_display_name() const;


### PR DESCRIPTION
See title.  There were some cascade effects, but the changes are mostly contained to the model code.  The calls to `gr_render_model` and `g3_render_primitives` use `const_cast` because constifying that API would require a whole other PR.