### PR TITLE
Fix crash that can occur due to invalid glow point bank

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2076,7 +2076,7 @@ void model_render_glow_points(polymodel *pm, polymodel_instance *pmi, ship *ship
 		if (bank->glow_bitmap == -1)
 			continue;
 
-		if (pmi != nullptr) {
+		if ((pmi != nullptr) && (bank->submodel_parent > -1)) {
 			auto smi = &pmi->submodel[bank->submodel_parent];
 			if (smi->blown_off) {
 				continue;


### PR DESCRIPTION
PR adds extra validity check within `model_render_glowpoints` function. Other places in code that use `bank->submodel_parent` check for validity before looking up `pmi->submodel`, but this check was missing from this section (which caused a CTD in a mission restart due to `bank->submodel_parent` being -1).