### PR TITLE
Decouple MSAA from deferred_end

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -790,6 +790,7 @@ typedef struct screen {
 	std::function<void()> gf_post_process_restore_zbuffer;
 
 	std::function<void(bool clearNonColorBufs)> gf_deferred_lighting_begin;
+	std::function<void()> gf_deferred_lighting_msaa;
 	std::function<void()> gf_deferred_lighting_end;
 	std::function<void()> gf_deferred_lighting_finish;
 
@@ -1092,6 +1093,7 @@ inline void gr_post_process_restore_zbuffer()
 }
 
 #define gr_deferred_lighting_begin		GR_CALL(gr_screen.gf_deferred_lighting_begin)
+#define gr_deferred_lighting_msaa		GR_CALL(gr_screen.gf_deferred_lighting_msaa)
 #define gr_deferred_lighting_end		GR_CALL(gr_screen.gf_deferred_lighting_end)
 #define gr_deferred_lighting_finish		GR_CALL(gr_screen.gf_deferred_lighting_finish)
 

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -226,6 +226,10 @@ void gr_stub_deferred_lighting_begin(bool /*clearNonColorBufs*/)
 {
 }
 
+void gr_stub_deferred_lighting_msaa() 
+{
+}
+
 void gr_stub_deferred_lighting_end()
 {
 }
@@ -514,6 +518,7 @@ bool gr_stub_init()
 	gr_screen.gf_copy_effect_texture = gr_stub_copy_effect_texture;
 
 	gr_screen.gf_deferred_lighting_begin = gr_stub_deferred_lighting_begin;
+	gr_screen.gf_deferred_lighting_msaa = gr_stub_deferred_lighting_msaa;
 	gr_screen.gf_deferred_lighting_end = gr_stub_deferred_lighting_end;
 	gr_screen.gf_deferred_lighting_finish = gr_stub_deferred_lighting_finish;
 

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -972,6 +972,7 @@ void opengl_setup_function_pointers()
 	gr_screen.gf_copy_effect_texture = gr_opengl_copy_effect_texture;
 
 	gr_screen.gf_deferred_lighting_begin = gr_opengl_deferred_lighting_begin;
+	gr_screen.gf_deferred_lighting_msaa = gr_opengl_deferred_lighting_msaa;
 	gr_screen.gf_deferred_lighting_end = gr_opengl_deferred_lighting_end;
 	gr_screen.gf_deferred_lighting_finish = gr_opengl_deferred_lighting_finish;
 

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -99,6 +99,63 @@ void gr_opengl_deferred_lighting_begin(bool clearNonColorBufs)
 	}
 }
 
+void gr_opengl_deferred_lighting_msaa()
+{
+	if (!Deferred_lighting)
+		return;
+
+	if (Cmdline_msaa_enabled <= 0)
+		return;
+	
+	GR_DEBUG_SCOPE("MSAA Pass");
+	GL_state.BindFrameBuffer(Scene_framebuffer);
+
+	GLenum buffers[] = {GL_COLOR_ATTACHMENT0,
+		GL_COLOR_ATTACHMENT1,
+		GL_COLOR_ATTACHMENT2,
+		GL_COLOR_ATTACHMENT3,
+		GL_COLOR_ATTACHMENT4};
+	glDrawBuffers(5, buffers);
+
+	int msaa_resolve_flags = 0;
+	switch (Cmdline_msaa_enabled) {
+	case 4:
+		msaa_resolve_flags = SDR_FLAG_MSAA_SAMPLES_4;
+		break;
+	case 8:
+		msaa_resolve_flags = SDR_FLAG_MSAA_SAMPLES_8;
+		break;
+	case 16:
+		msaa_resolve_flags = SDR_FLAG_MSAA_SAMPLES_16;
+		break;
+	default:
+		UNREACHABLE("Disallowed MSAA shader sample count!");
+		break;
+	}
+
+	opengl_shader_set_current(gr_opengl_maybe_create_shader(SDR_TYPE_MSAA_RESOLVE, msaa_resolve_flags));
+	GL_state.Texture.Enable(0, GL_TEXTURE_2D_MULTISAMPLE, Scene_color_texture_ms);
+	GL_state.Texture.Enable(1, GL_TEXTURE_2D_MULTISAMPLE, Scene_position_texture_ms);
+	GL_state.Texture.Enable(2, GL_TEXTURE_2D_MULTISAMPLE, Scene_normal_texture_ms);
+	GL_state.Texture.Enable(3, GL_TEXTURE_2D_MULTISAMPLE, Scene_specular_texture_ms);
+	GL_state.Texture.Enable(4, GL_TEXTURE_2D_MULTISAMPLE, Scene_emissive_texture_ms);
+	GL_state.Texture.Enable(5, GL_TEXTURE_2D_MULTISAMPLE, Scene_depth_texture_ms);
+	Current_shader->program->Uniforms.setTextureUniform("texColor", 0);
+	Current_shader->program->Uniforms.setTextureUniform("texPos", 1);
+	Current_shader->program->Uniforms.setTextureUniform("texNormal", 2);
+	Current_shader->program->Uniforms.setTextureUniform("texSpecular", 3);
+	Current_shader->program->Uniforms.setTextureUniform("texEmissive", 4);
+	Current_shader->program->Uniforms.setTextureUniform("texDepth", 5);
+	opengl_set_generic_uniform_data<graphics::generic_data::msaa_data>(
+		[&](graphics::generic_data::msaa_data* data) {
+			data->samples = Cmdline_msaa_enabled;
+			data->fov = Proj_fov;
+		});
+	GL_state.SetAlphaBlendMode(gr_alpha_blend::ALPHA_BLEND_NONE);
+	GL_state.SetZbufferType(ZBUFFER_TYPE_WRITE);
+	opengl_draw_full_screen_textured(0, 0, 1, 1);
+}
+
 void gr_opengl_deferred_lighting_end()
 {
 	if(!Deferred_lighting)
@@ -106,57 +163,7 @@ void gr_opengl_deferred_lighting_end()
 
 	GR_DEBUG_SCOPE("Deferred lighting end");
 
-	if (Cmdline_msaa_enabled > 0) {
-		GR_DEBUG_SCOPE("MSAA Pass");
-		GL_state.BindFrameBuffer(Scene_framebuffer);
-
-		GLenum buffers[] = {GL_COLOR_ATTACHMENT0,
-			GL_COLOR_ATTACHMENT1,
-			GL_COLOR_ATTACHMENT2,
-			GL_COLOR_ATTACHMENT3,
-			GL_COLOR_ATTACHMENT4};
-		glDrawBuffers(5, buffers);
-
-		int msaa_resolve_flags = 0;
-		switch (Cmdline_msaa_enabled) {
-		case 4:
-			msaa_resolve_flags = SDR_FLAG_MSAA_SAMPLES_4;
-			break;
-		case 8:
-			msaa_resolve_flags = SDR_FLAG_MSAA_SAMPLES_8;
-			break;
-		case 16:
-			msaa_resolve_flags = SDR_FLAG_MSAA_SAMPLES_16;
-			break;
-		default:
-			UNREACHABLE("Disallowed MSAA shader sample count!");
-			break;
-		}
-
-		opengl_shader_set_current(gr_opengl_maybe_create_shader(SDR_TYPE_MSAA_RESOLVE, msaa_resolve_flags));
-		GL_state.Texture.Enable(0, GL_TEXTURE_2D_MULTISAMPLE, Scene_color_texture_ms);
-		GL_state.Texture.Enable(1, GL_TEXTURE_2D_MULTISAMPLE, Scene_position_texture_ms);
-		GL_state.Texture.Enable(2, GL_TEXTURE_2D_MULTISAMPLE, Scene_normal_texture_ms);
-		GL_state.Texture.Enable(3, GL_TEXTURE_2D_MULTISAMPLE, Scene_specular_texture_ms);
-		GL_state.Texture.Enable(4, GL_TEXTURE_2D_MULTISAMPLE, Scene_emissive_texture_ms);
-		GL_state.Texture.Enable(5, GL_TEXTURE_2D_MULTISAMPLE, Scene_depth_texture_ms);
-		Current_shader->program->Uniforms.setTextureUniform("texColor", 0);
-		Current_shader->program->Uniforms.setTextureUniform("texPos", 1);
-		Current_shader->program->Uniforms.setTextureUniform("texNormal", 2);
-		Current_shader->program->Uniforms.setTextureUniform("texSpecular", 3);
-		Current_shader->program->Uniforms.setTextureUniform("texEmissive", 4);
-		Current_shader->program->Uniforms.setTextureUniform("texDepth", 5);
-		opengl_set_generic_uniform_data<graphics::generic_data::msaa_data>([&](graphics::generic_data::msaa_data* data) {
-			data->samples = Cmdline_msaa_enabled;
-			data->fov = Proj_fov;
-		});
-		GL_state.SetAlphaBlendMode(gr_alpha_blend::ALPHA_BLEND_NONE);
-		GL_state.SetZbufferType(ZBUFFER_TYPE_WRITE);
-		opengl_draw_full_screen_textured(0, 0, 1, 1);
-	}
-
 	Deferred_lighting = false;
-
 
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
 

--- a/code/graphics/opengl/gropengldeferred.h
+++ b/code/graphics/opengl/gropengldeferred.h
@@ -6,6 +6,7 @@ void gr_opengl_deferred_init();
 
 void opengl_clear_deferred_buffers();
 void gr_opengl_deferred_lighting_begin(bool clearNonColorBufs = false);
+void gr_opengl_deferred_lighting_msaa();
 void gr_opengl_deferred_lighting_end();
 void gr_opengl_deferred_lighting_finish();
 

--- a/code/graphics/vulkan/vulkan_stubs.cpp
+++ b/code/graphics/vulkan/vulkan_stubs.cpp
@@ -90,6 +90,8 @@ void stub_copy_effect_texture() {}
 
 void stub_deferred_lighting_begin(bool /*clearNonColorBufs*/) {}
 
+void stub_deferred_lighting_msaa() {}
+
 void stub_deferred_lighting_end() {}
 
 void stub_deferred_lighting_finish() {}
@@ -300,6 +302,7 @@ void init_stub_pointers()
 	gr_screen.gf_copy_effect_texture = stub_copy_effect_texture;
 
 	gr_screen.gf_deferred_lighting_begin = stub_deferred_lighting_begin;
+	gr_screen.gf_deferred_lighting_msaa = stub_deferred_lighting_msaa;
 	gr_screen.gf_deferred_lighting_end = stub_deferred_lighting_end;
 	gr_screen.gf_deferred_lighting_finish = stub_deferred_lighting_finish;
 

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -264,6 +264,7 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 			transparent_objects.push_back(obj);
 		}
 	}
+	gr_deferred_lighting_msaa();
 	gr_deferred_lighting_end();
 
 	// we're done rendering models so flush render states
@@ -347,6 +348,7 @@ void obj_render_queue_all()
 
 	gr_clear_states();
 	gr_set_fill_mode(GR_FILL_MODE_SOLID);
+	gr_deferred_lighting_msaa();
 
 	decals::renderAll();
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7892,6 +7892,7 @@ void ship_render_player_ship(object* objp) {
 		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
 		gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
+		gr_deferred_lighting_msaa();
 		gr_deferred_lighting_end();
 		gr_deferred_lighting_finish();
 


### PR DESCRIPTION
Fixes #5466.

Basically, decals are an effect which need to happen _before_ deferred lighting is calculated, but _after_ MSAA resolve has happened as they need to read from the g-buffer.
This PR pulls out MSAA resolve from the deferred_end method and makes it its own method, so that there is a window between MSAA resolve and deferred lighting where these types of effects can be rendered.