### PR TITLE
fix Assertion in turret_swarm_set_up_info

### DIFF
--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -333,7 +333,7 @@ void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, weapon_inf
 	parent_obj = &Objects[parent_objnum];
 	Assert(parent_obj->type == OBJ_SHIP);
 	shipp = &Ships[parent_obj->instance];
-	Assert((turret->turret_enemy_objnum >= 0) && (turret->turret_enemy_objnum < MAX_OBJECTS));
+	Assert(turret->turret_enemy_objnum < MAX_OBJECTS);
 	if((turret->turret_enemy_objnum < 0) || (turret->turret_enemy_objnum >= MAX_OBJECTS)){
 		return;
 	}


### PR DESCRIPTION
It appears that `(turret->turret_enemy_objnum < 0)` is an expected and allowed condition, so just assert that the objnum does not exceed MAX_OBJECTS.

Fixes #5470.