### PR TITLE
Remove `max_pixel_w > 0` assertion from `split_str_once()`.

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3440,7 +3440,9 @@ char *split_str_once(char *src, int max_pixel_w)
 	bool last_was_white = false;
 
 	Assert(src);
-	Assert(max_pixel_w > 0);
+
+	if (max_pixel_w <= 0)
+		return src;  // if there's no width, skip everything else
 
 	gr_get_string_size(&w, nullptr, src);
 	if ( (w <= max_pixel_w) && !strstr(src, "\n") ) {


### PR DESCRIPTION
In at least two instances, `split_str_once()` can be called with width values derived from mod-supplied values that can be 0 or less (specifically, two hud gauges: if `+Messages:` has a `Max Width:` that's too small, or `+Directives:` has a `Max Line Width:` of 0 or less). Since user-supplied code shouldn't be tripping assertions, I looked into adding security around the calling sites when I realized that the assertion wasn't actually protecting against anything; the function would run just fine with a negative pixel width, it would just break with every whitespace. Since both calling sites that could trip the assertion already treat getting `src` back as output as an "I can't split this" error condition, it's perfectly fine (and skips iterating through the string) to just `return src` if the maximum pixel width is 0 or less, so let's just do that instead. Technically this is a behavior change in Release code, but the result of the old code would've been to spam the message log with every individual word in every message (if `Max Width:` was too small), and for directives to seemingly-randomly split only after the first word (if `Max Line Width:` was 0 or less). Not splitting at all is at least as correct, saves some pointless processing, and *should* still be obviously wrong if there was supposed to be a reasonable width value.

Classifying as a bugfix because any time user-supplied data can trip an assertion it's a bug.