### PR TITLE
Clear C++ Handles to LuaThread-stuff more aggressively

### DIFF
--- a/code/scripting/lua/LuaThread.cpp
+++ b/code/scripting/lua/LuaThread.cpp
@@ -14,23 +14,38 @@ LuaThread LuaThread::create(lua_State* L, const LuaFunction& func)
 
 	lua_pop(L, 1);
 
-	//Make sure that the C++-side reference of the LuaThread is cleared when its parents references are auto-garbage collected by lua for whatever reason (usually due to the parent thread dying).
+	//Make sure that the C++-side reference of the LuaThread (and everything it holds) is cleared when its parents references are auto-garbage collected by lua for whatever reason (usually due to the parent thread dying).
 	//To do this, register an object with a __gc method in the thread (usually we'd want to directly attach it to the thread, but only userdata will have __gc methods called).
 	//Usually we'd want to do this when the childs references are GC'd, but creating tables on child threads from C causes tests to fail for some reason.
 	auto threadRef = std::weak_ptr<UniqueLuaReference>(thread.getReference());
+	//These must be pointers to weak pointers, as we cannot know the weak pointers before creating the lambda.
+	auto delFuncRef = make_shared<std::weak_ptr<UniqueLuaReference>>();
+	auto delTabRef = make_shared<std::weak_ptr<UniqueLuaReference>>();
+	auto delUserdataRef = make_shared<std::weak_ptr<UniqueLuaReference>>();
+
 	int stack = lua_gettop(L);
 
 	//Make sure to create the function that clears the LuaThread reference BEFORE creating the userdata value, otherwise the function will be garbage-collected itself before it's called.
-	thread.deleterFunc = LuaFunction::createFromStdFunction(L, [threadRef](lua_State*, const LuaValueList&) -> LuaValueList {
-		if(!threadRef.expired())
-			threadRef.lock()->removeReference();
-		return {};
+	thread.deleterFunc = LuaFunction::createFromStdFunction(L, [threadRef, delFuncRef, delTabRef, delUserdataRef](lua_State*, const LuaValueList&) -> LuaValueList {
+			if (!threadRef.expired()) 
+				threadRef.lock()->removeReference();
+			if (!delFuncRef->expired()) 
+				delFuncRef->lock()->removeReference();
+			if (!delTabRef->expired())
+				delTabRef->lock()->removeReference();
+			if (!delUserdataRef->expired())
+				delUserdataRef->lock()->removeReference();
+			return {};
 		});
 
 	//NOW, create the dummy userdata, and its metatable
 	lua_newuserdata(L, sizeof(bool));
 	thread.deleterUserdata = UniqueLuaReference::create(L);
 	thread.deleterTable = LuaTable::create(L);
+
+	*delFuncRef = std::weak_ptr<UniqueLuaReference>(thread.deleterFunc.getReference());
+	*delTabRef = std::weak_ptr<UniqueLuaReference>(thread.deleterTable.getReference());
+	*delUserdataRef = std::weak_ptr<UniqueLuaReference>(thread.deleterUserdata);
 
 	//Since we hold references to all we need, tidy up the stack.
 	lua_settop(L, stack);


### PR DESCRIPTION
Followup to #4701.
While that last PR apparently properly cleared the thread handle, it added three more handles: A function, a table, and a userdata.
In _some_ cases, it seems that during teardown these also didn't get properly cleared along with the thread, so this PR also manually detaches the LuaHandle from the C++ side, so that deallocation does not cause a crash on exit.