### PR TITLE
fix instructor check

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13884,7 +13884,7 @@ void ai_execute_behavior(ai_info *aip)
 			ship	*shipp = &Ships[aip->shipnum];
 			ship_info	*sip = &Ship_info[shipp->ship_info_index];
 
-			if (is_instructor(&Objects[shipp->objnum])) {
+			if (!is_instructor(&Objects[shipp->objnum])) {
 				if (sip->is_big_or_huge()) {
 					aip->mode = AIM_NONE;
 				} else {


### PR DESCRIPTION
Fix the instructor check for whether a ship should circle or not.  Follow-up to #5353.  Fixes #5478.