### PR TITLE
fix some bugs revealed by ships with long display names

### DIFF
--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -179,7 +179,7 @@ public:
 	int				killer_objtype;							// type of object that killed player
 	int				killer_species;							// Species which killed player
 	int				killer_weapon_index;						// weapon used to kill player (if applicable)
-	char			killer_parent_name[NAME_LENGTH];		// name of parent object that killed the player
+	char			killer_parent_name[NAME_LENGTH];		// name of parent object that killed the player.  Will be either a callsign, an actual ship name (not display name), or blank
 
 	int				check_for_all_alone_msg;				// timestamp to check for playing of 'all alone' msg
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1050,7 +1050,7 @@ static void shiphit_record_player_killer(object *killer_objp, player *p)
 					nprintf(("Network", "Couldn't find player object of weapon for killer of %s\n", p->callsign));
 				}
 			} else {
-				strcpy_s(p->killer_parent_name, Ships[Objects[killer_objp->parent].instance].get_display_name());
+				strcpy_s(p->killer_parent_name, Ships[Objects[killer_objp->parent].instance].ship_name);
 			}
 		} else {
 			p->killer_species = -1;
@@ -1078,7 +1078,7 @@ static void shiphit_record_player_killer(object *killer_objp, player *p)
 				nprintf(("Network", "Couldn't find player object of shockwave for killer of %s\n", p->callsign));
 			}
 		} else {
-			strcpy_s(p->killer_parent_name, Ships[Objects[killer_objp->parent].instance].get_display_name());
+			strcpy_s(p->killer_parent_name, Ships[Objects[killer_objp->parent].instance].ship_name);
 		}
 		break;
 
@@ -1106,7 +1106,7 @@ static void shiphit_record_player_killer(object *killer_objp, player *p)
 				nprintf(("Network", "Couldn't find player object for killer of %s\n", p->callsign));
 			}
 		} else {
-			strcpy_s(p->killer_parent_name, Ships[killer_objp->instance].get_display_name());
+			strcpy_s(p->killer_parent_name, Ships[killer_objp->instance].ship_name);
 		}
 		break;
 	
@@ -1129,7 +1129,7 @@ static void shiphit_record_player_killer(object *killer_objp, player *p)
 		p->killer_objtype = OBJ_BEAM;
 		if(beam_obj != -1){			
 			if((Objects[beam_obj].type == OBJ_SHIP) && (Objects[beam_obj].instance >= 0)){
-				strcpy_s(p->killer_parent_name, Ships[Objects[beam_obj].instance].get_display_name());
+				strcpy_s(p->killer_parent_name, Ships[Objects[beam_obj].instance].ship_name);
 			}
 			p->killer_species = Ship_info[Ships[Objects[beam_obj].instance].ship_info_index].species;
 		} else {			


### PR DESCRIPTION
Several related fixes:
1. Copy the actual ship name, not the display name, to `killer_parent_name` for two reasons:
  a. Since `killer_parent_name` is used to look up the ship, it must be the actual ship name, not the display name.
  b. Copying the display name can cause a buffer overflow because display names can be longer than 31 characters.
2. The display name functionality is moved to the more appropriate location in `player_generate_death_message()`.
3. Remove `player_get_killer_weapon_name()` which only served as a proxy check for whether the weapon index was used or not.
4. Use `ship_registry_get()` rather than `ship_name_lookup()`.
5. Add comments to clarify the use of `killer_parent_name`.

Fixes a bug reported in Discord.