### PR TITLE
Improved hud gauge loading safety

### DIFF
--- a/code/bmpman/bm_internal.h
+++ b/code/bmpman/bm_internal.h
@@ -109,7 +109,6 @@ extern SCP_vector<std::array<bitmap_slot, BM_BLOCK_SIZE>> bm_blocks;
 bitmap_slot* bm_get_slot(int handle, bool separate_ani_frames = true);
 
 inline bitmap_entry* bm_get_entry(int handle, bool separate_ani_frames = true) {
-	mprintf(("bm_get_entry"));
 	return &bm_get_slot(handle, separate_ani_frames)->entry;
 }
 

--- a/code/bmpman/bm_internal.h
+++ b/code/bmpman/bm_internal.h
@@ -109,6 +109,7 @@ extern SCP_vector<std::array<bitmap_slot, BM_BLOCK_SIZE>> bm_blocks;
 bitmap_slot* bm_get_slot(int handle, bool separate_ani_frames = true);
 
 inline bitmap_entry* bm_get_entry(int handle, bool separate_ani_frames = true) {
+	mprintf(("bm_get_entry"));
 	return &bm_get_slot(handle, separate_ani_frames)->entry;
 }
 

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -2602,12 +2602,14 @@ void *bm_malloc(int n, size_t size) {
 void bm_page_in_aabitmap(int handle, int nframes) {
 	int i;
 
-	if (handle == -1)
+	if (handle < 0)
 		return;
 
+	mprintf(("bm_page_in_aabitmap"));
 	Assert(bm_get_entry(handle)->handle == handle);
 
 	for (i = 0; i<nframes; i++) {
+		mprintf(("bm_page_in_aabitmap2"));
 		auto frame_entry = bm_get_entry(handle + i);
 
 		frame_entry->preloaded = 2;

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -2605,11 +2605,9 @@ void bm_page_in_aabitmap(int handle, int nframes) {
 	if (handle < 0)
 		return;
 
-	mprintf(("bm_page_in_aabitmap"));
 	Assert(bm_get_entry(handle)->handle == handle);
 
 	for (i = 0; i<nframes; i++) {
-		mprintf(("bm_page_in_aabitmap2"));
 		auto frame_entry = bm_get_entry(handle + i);
 
 		frame_entry->preloaded = 2;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2961,6 +2961,9 @@ void HudGaugeSupport::render(float  /*frametime*/)
 	int	show_time, w, h;
 	char	outstr[64];
 
+	if (background.first_frame < 0)
+		return;
+
 	if ( !Hud_support_view_active ) {
 		return;
 	}

--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -161,6 +161,7 @@ void HudGaugeEscort::pageIn()
 	int i;
 
 	for ( i = 0; i < NUM_ESCORT_FRAMES; i++ ) {
+		mprintf(("\n%s %d", LOCATION));
 		bm_page_in_aabitmap( Escort_gauges[i].first_frame, Escort_gauges[i].num_frames);
 	}
 }
@@ -237,6 +238,9 @@ int HudGaugeEscort::setGaugeColorEscort(int index, int team)
 void HudGaugeEscort::render(float  /*frametime*/)
 {
 	int	i = 0;
+
+	if (Escort_gauges[0].first_frame < 0)
+		return;
 
 	if ( !Show_escort_view ) {
 		return;

--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -161,7 +161,6 @@ void HudGaugeEscort::pageIn()
 	int i;
 
 	for ( i = 0; i < NUM_ESCORT_FRAMES; i++ ) {
-		mprintf(("\n%s %d", LOCATION));
 		bm_page_in_aabitmap( Escort_gauges[i].first_frame, Escort_gauges[i].num_frames);
 	}
 }

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -888,6 +888,10 @@ void HudGaugeEts::pageIn()
  */
 void HudGaugeEts::blitGauge(int index)
 {
+	if (Ets_bar.first_frame < 0) {
+		return;
+	}
+
 	int y_start, y_end, clip_h, w, h, x, y;
 
 	clip_h = fl2i( (1 - Energy_levels[index]) * ETS_bar_h );

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -1693,7 +1693,7 @@ void HudGaugeLock::renderLockTrianglesOld(int center_x, int center_y, int radius
 // draw a frame of the rotating lock triangles animation
 void HudGaugeLock::renderLockTriangles(int center_x, int center_y, float frametime)
 {
-	if ( Lock_anim.first_frame == -1 ) {
+	if ( Lock_anim.first_frame < 0 ) {
 		renderLockTrianglesOld(center_x, center_y, Lock_target_box_width/2);
 	} else {
 		// render the anim
@@ -1734,7 +1734,7 @@ void HudGaugeLock::renderLockTriangles(int center_x, int center_y, float frameti
 
 void HudGaugeLock::renderLockTrianglesNew(int center_x, int center_y, float frametime, lock_info *slot)
 {
-	if ( Lock_anim.first_frame == -1 ) {
+	if ( Lock_anim.first_frame < 0 ) {
 		renderLockTrianglesOld(center_x, center_y, Lock_target_box_width/2);
 	} else {
 		// render the anim

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -249,7 +249,11 @@ void HudGaugeReticle::initFirepointDisplay(bool firepoint, int scaleX, int scale
 
 void HudGaugeReticle::render(float  /*frametime*/)
 {
-ship_info *sip = &Ship_info[Player_ship->ship_info_index];
+	if (crosshair.first_frame < 0) {
+		return;
+	}
+
+	ship_info *sip = &Ship_info[Player_ship->ship_info_index];
 
 	if (autoaim_frame_offset > 0 || sip->autoaim_lock_snd.isValid() || sip->autoaim_lost_snd.isValid()) {
 		ship *shipp = &Ships[Objects[Player->objnum].instance];
@@ -533,6 +537,10 @@ void HudGaugeThrottle::pageIn()
 
 void HudGaugeThrottle::render(float  /*frametime*/)
 {
+	if (throttle_frames.first_frame < 0) {
+		return;
+	}
+
 	float	desired_speed, max_speed, current_speed, absolute_speed, absolute_displayed_speed, max_displayed_speed, percent_max, percent_aburn_max;
 	int	desired_y_pos, y_end;
 
@@ -812,7 +820,9 @@ void HudGaugeThreatIndicator::pageIn()
 void HudGaugeThreatIndicator::render(float  /*frametime*/)
 {
 	setGaugeColor();
-	renderBitmap(threat_arc.first_frame+1, position[0], position[1]);
+
+	if (threat_arc.first_frame >= 0)
+		renderBitmap(threat_arc.first_frame+1, position[0], position[1]);
 
 	renderLaserThreat();
 	renderLockThreat();
@@ -820,6 +830,9 @@ void HudGaugeThreatIndicator::render(float  /*frametime*/)
 
 void HudGaugeThreatIndicator::renderLaserThreat()
 {
+	if (laser_warn.first_frame < 0)
+		return;
+
 	int frame_offset, num_frames;
 
 	//Check how many frames the ani actually has
@@ -845,6 +858,9 @@ void HudGaugeThreatIndicator::renderLaserThreat()
 
 void HudGaugeThreatIndicator::renderLockThreat()
 {
+	if (lock_warn.first_frame < 0)
+		return;
+
 	int frame_offset, num_frames;
 
 	//Let's find out how many frames our ani has, and adjust accordingly

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -581,7 +581,7 @@ void HudGaugeShield::showShields(object *objp, int mode)
 	if (sip->shield_icon_index != 255) {
 		sgp = &Shield_gauges.at(sip->shield_icon_index);
 
-		if ( (sgp->first_frame == -1) && (sip->shield_icon_index < Hud_shield_filenames.size()) ) {
+		if ( (sgp->first_frame < 0) && (sip->shield_icon_index < Hud_shield_filenames.size()) ) {
 			sgp->first_frame = bm_load_animation(Hud_shield_filenames.at(sip->shield_icon_index).c_str(), &sgp->num_frames);
 			if (sgp->first_frame == -1) {
 				if (!shield_ani_warning_displayed_already) {
@@ -958,6 +958,9 @@ void HudGaugeShieldMini::pageIn()
 // Draw the miniature shield icon that is drawn near the reticle
 void HudGaugeShieldMini::showMiniShields(object *objp)
 {
+	if (Shield_mini_gauge.first_frame < 0)
+		return;
+
 	float			max_shield;
 	int			hud_color_index, range, frame_offset;
 	int			sx, sy, i;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4826,7 +4826,8 @@ void HudGaugeAutoTarget::render(float  /*frametime*/)
 
 	// draw the box background
 	setGaugeColor();
-	renderBitmap(Toggle_frame.first_frame+frame_offset, position[0], position[1]);
+	if (Toggle_frame.first_frame + frame_offset >= 0)
+		renderBitmap(Toggle_frame.first_frame+frame_offset, position[0], position[1]);
 
 	// draw the text on top
 	if (frame_offset == 1) {
@@ -4912,7 +4913,8 @@ void HudGaugeAutoSpeed::render(float  /*frametime*/)
 
 	setGaugeColor();
 
-	renderBitmap(Toggle_frame.first_frame+frame_offset, position[0], position[1]);
+	if (Toggle_frame.first_frame + frame_offset >= 0)
+		renderBitmap(Toggle_frame.first_frame+frame_offset, position[0], position[1]);
 
 	// draw the text on top
 	if (frame_offset == 3) {
@@ -5501,9 +5503,8 @@ void HudGaugeCmeasures::pageIn()
 
 void HudGaugeCmeasures::render(float  /*frametime*/)
 {
-	if ( Cmeasure_gauge.first_frame == -1) {
-		Int3();	// failed to load coutermeasure gauge background
-		return;
+	if ( Cmeasure_gauge.first_frame < 0) {
+		return;	// failed to load coutermeasure gauge background
 	}
 
 	ship_info *sip = &Ship_info[Player_ship->ship_info_index];
@@ -5551,7 +5552,7 @@ void HudGaugeAfterburner::render(float  /*frametime*/)
 	float percent_left;
 	int	clip_h,w,h;
 
-	if ( Energy_bar.first_frame == -1 ){
+	if ( Energy_bar.first_frame < 0 ){
 		return;
 	}
 
@@ -5760,7 +5761,7 @@ void HudGaugeWeaponEnergy::render(float  /*frametime*/)
 		weapon_info *wip;
 		ship_weapon *sw;
 
-		if ( Energy_bar.first_frame == -1 ) {
+		if ( Energy_bar.first_frame < 0 ) {
 			return;
 		}
 
@@ -6125,7 +6126,8 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 	setGaugeColor();
 
 	// draw top of primary display
-	renderBitmap(primary_top[ballistic_hud_index].first_frame, position[0] + top_offset_x[ballistic_hud_index], position[1]);
+	if (primary_top[ballistic_hud_index].first_frame >= 0)
+		renderBitmap(primary_top[ballistic_hud_index].first_frame, position[0] + top_offset_x[ballistic_hud_index], position[1]);
 
 	// render the header of this gauge
 	renderString(position[0] + Weapon_header_offsets[ballistic_hud_index][0], position[1] + Weapon_header_offsets[ballistic_hud_index][1], EG_WEAPON_TITLE, XSTR( "weapons", 328));
@@ -6145,10 +6147,11 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 		// It is assumed that the top primary wep frame already has this rendered.
 		if(i == 1) {
 			// used to draw the second primary weapon background
-			renderBitmap(primary_middle[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
+			if (primary_middle[ballistic_hud_index].first_frame >= 0)
+				renderBitmap(primary_middle[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
 		} else if(i != 0) {
 			// used to draw the the third, fourth, fifth, etc...
-			if(primary_last[ballistic_hud_index].first_frame != -1)
+			if(primary_last[ballistic_hud_index].first_frame >= 0)
 				renderBitmap(primary_last[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
 		}
 
@@ -6198,7 +6201,8 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 		setGaugeColor(HUD_C_BRIGHT);
 	}
 
-	renderBitmap(secondary_top[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
+	if (secondary_top[ballistic_hud_index].first_frame >= 0)
+		renderBitmap(secondary_top[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
 	name_y = y + sname_start_offset_y;
 	y += top_secondary_h;
 
@@ -6207,7 +6211,7 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 		setGaugeColor();
 		wip = &Weapon_info[sw->secondary_bank_weapons[i]];
 
-		if(i!=0) {
+		if(i!=0 && secondary_middle[ballistic_hud_index].first_frame >= 0) {
 			renderBitmap(secondary_middle[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
 		}
 
@@ -6281,7 +6285,8 @@ void HudGaugeWeapons::render(float  /*frametime*/)
 
 	y -= 0;
 	// finish drawing the background
-	renderBitmap(secondary_bottom[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
+	if (secondary_bottom[ballistic_hud_index].first_frame >= 0)
+		renderBitmap(secondary_bottom[ballistic_hud_index].first_frame, position[0] + frame_offset_x[ballistic_hud_index], y);
 }
 
 void hud_update_weapon_flash()
@@ -6843,7 +6848,8 @@ void HudGaugeWarheadCount::render(float  /*frametime*/)
 			column = i;
 		}
 
-		renderBitmap(Warhead.first_frame, position[0] + Warhead_count_offsets[0] + column * delta_x, position[1] + Warhead_count_offsets[1] + delta_y);
+		if (Warhead.first_frame >= 0)
+			renderBitmap(Warhead.first_frame, position[0] + Warhead_count_offsets[0] + column * delta_x, position[1] + Warhead_count_offsets[1] + delta_y);
 	}
 }
 
@@ -7012,7 +7018,8 @@ void HudGaugePrimaryWeapons::render(float  /*frametime*/)
 
 	setGaugeColor();
 
-	renderBitmap(_background_first.first_frame, position[0], position[1]);
+	if (_background_first.first_frame >= 0)
+		renderBitmap(_background_first.first_frame, position[0], position[1]);
 
 	// render the header of this gauge
 	renderString(position[0] + _header_offsets[0], position[1] + _header_offsets[1], EG_WEAPON_TITLE, header_text);
@@ -7025,7 +7032,8 @@ void HudGaugePrimaryWeapons::render(float  /*frametime*/)
 	for ( i = 0; i < num_primaries; ++i ) {
 		setGaugeColor();
 
-		renderBitmap(_background_entry.first_frame, position[0], position[1] + bg_y_offset);
+		if (_background_entry.first_frame >= 0)
+			renderBitmap(_background_entry.first_frame, position[0], position[1] + bg_y_offset);
 
 		auto weapon_name = Weapon_info[sw->primary_bank_weapons[i]].get_display_name();
 
@@ -7063,13 +7071,15 @@ void HudGaugePrimaryWeapons::render(float  /*frametime*/)
 	}
 
 	if ( num_primaries == 0 ) {
-		renderBitmap(_background_entry.first_frame, position[0], position[1] + bg_y_offset);
+		if (_background_entry.first_frame >= 0)
+			renderBitmap(_background_entry.first_frame, position[0], position[1] + bg_y_offset);
 		renderString(position[0] + _pname_offset_x, position[1] + text_y_offset, EG_WEAPON_P1, XSTR( "<none>", 329));
 
 		bg_y_offset += _background_entry_h;
 	}
 
-	renderBitmap(_background_last.first_frame, position[0], position[1] + bg_y_offset + _bg_last_offset_y);
+	if (_background_last.first_frame >= 0)
+		renderBitmap(_background_last.first_frame, position[0], position[1] + bg_y_offset + _bg_last_offset_y);
 }
 
 HudGaugeSecondaryWeapons::HudGaugeSecondaryWeapons():

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -395,7 +395,8 @@ void HudGaugeTargetBox::render(float frametime)
 	setGaugeColor();
 
 	// blit the background frame
-	renderBitmap(Monitor_frame.first_frame, position[0], position[1]);
+	if (Monitor_frame.first_frame >= 0)
+		renderBitmap(Monitor_frame.first_frame, position[0], position[1]);
 
 	if ( Monitor_mask >= 0 ) {
 		// render the alpha mask
@@ -461,8 +462,9 @@ void HudGaugeTargetBox::render(float frametime)
 void HudGaugeTargetBox::renderTargetForeground()
 {
 	setGaugeColor();
-
-	renderBitmap(Monitor_frame.first_frame+1, position[0], position[1]);	
+	
+	if (Monitor_frame.first_frame + 1 >= 0)
+		renderBitmap(Monitor_frame.first_frame+1, position[0], position[1]);	
 }
 
 /**
@@ -473,7 +475,7 @@ void HudGaugeTargetBox::renderTargetIntegrity(int disabled,int force_obj_num)
 	int		clip_h,w,h;
 	char		buf[16];
 
-	if ( Integrity_bar.first_frame == -1 ) 
+	if ( Integrity_bar.first_frame < 0 ) 
 		return;
 
 	if ( disabled ) {
@@ -1580,7 +1582,7 @@ void HudGaugeExtraTargetData::render(float  /*frametime*/)
 		extra_data_shown=1;
 	}
 
-	if ( extra_data_shown ) {	
+	if ( extra_data_shown && bracket.first_frame >= 0) {
 		renderBitmap(bracket.first_frame, position[0] + bracket_offsets[0], position[1] + bracket_offsets[1]);		
 	}
 }

--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -388,7 +388,7 @@ void HudGaugeWingmanStatus::renderBackground(int num_wings_to_draw)
 
 		sy += right_frame_start_offset;
 	} else {
-		if(num_wings_to_draw > 2 && bitmap > 0) {
+		if(num_wings_to_draw > 2 && bitmap >= 0) {
 			for(int i = 0; i < num_wings_to_draw - 2; i++){
 				renderBitmap(bitmap, sx, sy);
 				sx += wing_width;
@@ -399,7 +399,8 @@ void HudGaugeWingmanStatus::renderBackground(int num_wings_to_draw)
 	}
 
 	bitmap = Wingman_status_right.first_frame;
-	renderBitmap(bitmap, sx, sy);
+	if (bitmap >= 0)
+		renderBitmap(bitmap, sx, sy);
 }
 
 void HudGaugeWingmanStatus::renderDots(int wing_index, int screen_index, int num_wings_to_draw)

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -236,7 +236,8 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 	// draw top of objective display
 	setGaugeColor();
 
-	renderBitmap(directives_top.first_frame, position[0], position[1]);
+	if (directives_top.first_frame >= 0)
+		renderBitmap(directives_top.first_frame, position[0], position[1]);
 
 	// print out title
 	renderPrintf(position[0] + header_offsets[0], position[1] + header_offsets[1], EG_OBJ_TITLE, "%s", XSTR( "directives", 422));
@@ -303,12 +304,15 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 		// blit the background frames
 		setGaugeColor();
 
-		renderBitmap(directives_middle.first_frame, bx, by);
+		if (directives_middle.first_frame >= 0)
+			renderBitmap(directives_middle.first_frame, bx, by);
 		
 		by += text_h;
 
 		if ( second_line ) {
-			renderBitmap(directives_middle.first_frame, bx, by);
+
+			if (directives_top.first_frame >= 0)
+				renderBitmap(directives_middle.first_frame, bx, by);
 			
 			by += text_h;
 		}
@@ -332,7 +336,8 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 	// draw the bottom of objective display
 	setGaugeColor();
 
-	renderBitmap(directives_bottom.first_frame, bx, by + bottom_bg_offset);
+	if (directives_bottom.first_frame >= 0)
+		renderBitmap(directives_bottom.first_frame, bx, by + bottom_bg_offset);
 }
 
 /**

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -98,7 +98,8 @@ void HudGaugeRadarStd::blipDrawFlicker(blip *b, int x, int y)
 }
 void HudGaugeRadarStd::blitGauge()
 {
-	renderBitmap(Radar_gauge.first_frame+1, position[0], position[1] );
+	if (Radar_gauge.first_frame + 1 >= 0)
+		renderBitmap(Radar_gauge.first_frame+1, position[0], position[1] );
 }
 void HudGaugeRadarStd::drawBlips(int blip_type, int bright, int distort)
 {

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -465,7 +465,8 @@ void HudGaugeRadarOrb::render(float  /*frametime*/)
 
 void HudGaugeRadarOrb::blitGauge()
 {
-	renderBitmap(Radar_gauge.first_frame+1, position[0], position[1] );
+	if (Radar_gauge.first_frame + 1 >= 0)
+		renderBitmap(Radar_gauge.first_frame+1, position[0], position[1] );
 }
 
 void HudGaugeRadarOrb::pageIn()
@@ -566,6 +567,9 @@ extern float View_zoom;
 
 void HudGaugeRadarOrb::setupViewHtl()
 {
+	if (Radar_gauge.first_frame < 0)
+		return;
+
     int w,h;
 	bm_get_info(Radar_gauge.first_frame,&w, &h, NULL, NULL, NULL);
     


### PR DESCRIPTION
While *most* HUD gauges will check the validity of their bitmaps before rendering, a random smattering do not. This PR ensures *every* HUD render is gated behind a check for its bitmap and converts any `== -1` to `< 0` (as in debug uninitialized memory is often that giant ass negative int) and prevents any horrible bmpman assertions from rearing their ugly head.

It should be noted *all* invalid/missing bitmaps were already warned about before this point.