### PR TITLE
Add fast versions of script setting position and orientation

### DIFF
--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -29,6 +29,7 @@ namespace Object {
 		Hidden,					// Object is hidden (not shown) and can't be manipulated
 		Collides_with_parent,	// Asteroth - Only used for weapons with 'Can_damage_shooter'
 		Attackable_if_no_collide,	// Cyborg - Allows the AI to attack this object, even if no-collide is set (Cue Admiral Ackbar)
+		Collide_time_stale,		// This object *ignores* predictive collision check deferring into the future, it is always checked every frame
 
 		NUM_VALUES
 	};


### PR DESCRIPTION
#5442 adds invalidation of collision check timings on ships who've had their position or orientation changed via script, which prevents any erroneous collision behavior, but since this involves going through all the collision pairs, if done too much like say, on dozens of ships every frame (not that I would ever do such a thing >.>) the cost can add up.

This adds 'unsafe' setPosition and setOrientation functions without this step, accepting responsibility for collision issues and making clearer the relationship to *how far* the object is moved.