### PR TITLE
Ignore voice recognition events while game is paused.

### DIFF
--- a/code/sound/voicerec.cpp
+++ b/code/sound/voicerec.cpp
@@ -88,7 +88,7 @@ namespace
 		switch (e.syswm.msg->msg.win.msg)
 		{
 		case WM_RECOEVENT:
-			if (Game_mode & GM_IN_MISSION && Cmdline_voice_recognition && gameseq_get_state() != GS_STATE_GAME_PAUSED)
+			if (Game_mode & GM_IN_MISSION && Cmdline_voice_recognition && gameseq_get_state() != GS_STATE_GAME_PAUSED && !popup_active() && !popupdead_is_active())
 			{
 				VOICEREC_process_event(e.syswm.msg->msg.win.hwnd);
 				return true;

--- a/code/sound/voicerec.cpp
+++ b/code/sound/voicerec.cpp
@@ -88,7 +88,7 @@ namespace
 		switch (e.syswm.msg->msg.win.msg)
 		{
 		case WM_RECOEVENT:
-			if (Game_mode & GM_IN_MISSION && Cmdline_voice_recognition)
+			if (Game_mode & GM_IN_MISSION && Cmdline_voice_recognition && gameseq_get_state() != GS_STATE_GAME_PAUSED)
 			{
 				VOICEREC_process_event(e.syswm.msg->msg.win.hwnd);
 				return true;


### PR DESCRIPTION
If you pause the game, say something into the microphone, then unpause, it can abruptly perform an action based on voice recognition; this is probably counter to player expectations. This adds a `gameseq_get_state() != GS_STATE_GAME_PAUSED` check to the existing conditional.