### PR TITLE
Improve performance of collision retiming

### DIFF
--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -1023,7 +1023,7 @@ void nav_warp(bool prewarp=false)
 
 				// retime collision pairs
 				if (Objects[Ships[i].objnum].flags[Object::Object_Flags::Collides])
-					obj_collide_cache_stale();
+					obj_collide_obj_cache_stale(&Objects[Ships[i].objnum]);
 		}
 	}
 }

--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -1023,7 +1023,7 @@ void nav_warp(bool prewarp=false)
 
 				// retime collision pairs
 				if (Objects[Ships[i].objnum].flags[Object::Object_Flags::Collides])
-					obj_collide_retime_cached_pairs(&Objects[Ships[i].objnum]);
+					obj_collide_cache_stale();
 		}
 	}
 }

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -25,7 +25,6 @@
 int Num_pairs = 0;
 int Num_pairs_checked = 0;
 
-SCP_vector<object*> Stale_collision_time_objects;
 SCP_vector<int> Collision_sort_list;
 
 class collider_pair
@@ -615,7 +614,6 @@ void obj_collide_retime_cached_pairs()
 		if (pair.signature_a != pair.a->signature || pair.signature_b != pair.b->signature) {
 			it = Collision_cached_pairs.erase(it);
 		} else {			
-			mprintf(("\n%d: %f and %f stale", Framecount, pair.a->radius, pair.b->radius));
 			pair.next_check_time = timestamp(0);
 			it++;
 		}
@@ -624,7 +622,7 @@ void obj_collide_retime_cached_pairs()
 
 void obj_collide_cache_stale()
 {
-	//Collision_cache_stale = true;
+	Collision_cache_stale = true;
 }
 
 //local helper functions only used in objcollide.cpp
@@ -886,14 +884,11 @@ void obj_collide_pair(object *A, object *B)
         collision_info->next_check_time = timestamp(0);
     }
 
-	mprintf(("\n%d: %f and %f checking", Framecount, A->radius, B->radius));
-
     if ( valid ) {
         // if this signature is valid, make the necessary checks to see if we need to collide check
         if ( collision_info->next_check_time == -1 ) {
             return;
         } else if ( !timestamp_elapsed(collision_info->next_check_time) ) {
-			mprintf(("\n%d: %f and %f skipped", Framecount, A->radius, B->radius));
 			return;
         }
     } else {
@@ -965,10 +960,8 @@ void obj_collide_pair(object *A, object *B)
     if ( check_collision(&new_pair) ) {
         // don't have to check ever again
         collision_info->next_check_time = -1;
-		mprintf(("\n%d: %f and %f check never", Framecount, A->radius, B->radius));
     } else {
         collision_info->next_check_time = new_pair.next_check_time;
-		mprintf(("\n%d: %f and %f check %d", Framecount, A->radius, B->radius, new_pair.next_check_time));
     }
 }
 
@@ -1063,13 +1056,6 @@ void obj_sort_and_collide(SCP_vector<int>* Collision_list)
 		obj_quicksort_colliders(&sort_list_z, 0, (int)(sort_list_z.size() - 1), 2);
 	}
 	obj_find_overlap_colliders(sort_list_y, sort_list_z, 2, true);
-
-	for (auto objp : Stale_collision_time_objects) {
-		if (objp) {
-			objp->flags.remove(Object::Object_Flags::Collide_time_stale);
-		}
-	}
-	Stale_collision_time_objects.clear();
 }
 
 void collide_apply_gravity_flags_weapons() {

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -608,21 +608,25 @@ void obj_reset_colliders()
 
 void obj_collide_retime_cached_pairs()
 {
+	TRACE_SCOPE(tracing::RetimeCollisionCache);
+
 	auto it = Collision_cached_pairs.begin();
 	while (it != Collision_cached_pairs.end()) {
 		auto &pair = it->second;
 		if (pair.signature_a != pair.a->signature || pair.signature_b != pair.b->signature) {
 			it = Collision_cached_pairs.erase(it);
-		} else {			
-			pair.next_check_time = timestamp(0);
+		} else {
+			if (pair.a->flags[Object::Object_Flags::Collision_cache_stale] || pair.b->flags[Object::Object_Flags::Collision_cache_stale])
+				pair.next_check_time = timestamp(0);
 			it++;
 		}
 	}
 }
 
-void obj_collide_cache_stale()
+void obj_collide_obj_cache_stale(object* objp)
 {
 	Collision_cache_stale = true;
+	objp->flags.set(Object::Object_Flags::Collision_cache_stale);
 }
 
 //local helper functions only used in objcollide.cpp

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -55,7 +55,7 @@ int reject_obj_pair_on_parent(object *A, object *B)
 {
 	if (A->flags[Object::Object_Flags::Collides_with_parent] || B->flags[Object::Object_Flags::Collides_with_parent])
 		return 0;
-	
+
 	if (A->type == OBJ_SHIP) {
 		if (B->type == OBJ_DEBRIS) {
 			if (B->parent_sig == A->signature) {
@@ -1028,7 +1028,6 @@ void obj_sort_and_collide(SCP_vector<int>* Collision_list)
 		obj_collide_retime_cached_pairs();
 		Collision_cache_stale = false;
 	}
-
 
 	// the main use case is to go through the main Collision detection list, so use that if
 	// nothing is defined.

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -44,7 +44,7 @@ public:
 	{}
 };
 
-static SCP_vector<object*> Collision_cache_stale_objects;
+static SCP_set<object*> Collision_cache_stale_objects;
 static SCP_unordered_map<uint, collider_pair> Collision_cached_pairs;
 
 class checkobject;
@@ -630,7 +630,7 @@ void obj_collide_retime_stale_pairs()
 void obj_collide_obj_cache_stale(object* objp)
 {
 	objp->flags.set(Object::Object_Flags::Collision_cache_stale);
-	Collision_cache_stale_objects.push_back(objp);
+	Collision_cache_stale_objects.insert(objp);
 }
 
 //local helper functions only used in objcollide.cpp

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -69,10 +69,7 @@ void obj_reset_colliders();
 void obj_sort_and_collide(SCP_vector<int>* Collision_list = nullptr);
 
 // Retime all collision pairs, so that all object collisions will be rechecked immediately
-void obj_collide_retime_cached_pairs();
-
-// Retime collision pairs involving the specified object, so that collisions involving this object will be rechecked immediately
-void obj_collide_retime_cached_pairs(object *objp);
+void obj_collide_cache_stale();
 
 // Returns TRUE if the weapon will never hit the other object.
 // If it can it predicts how long until these two objects need

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -69,7 +69,7 @@ void obj_reset_colliders();
 void obj_sort_and_collide(SCP_vector<int>* Collision_list = nullptr);
 
 // Retime all collision pairs, so that all object collisions will be rechecked immediately
-void obj_collide_cache_stale();
+void obj_collide_obj_cache_stale(object* objp);
 
 // Returns TRUE if the weapon will never hit the other object.
 // If it can it predicts how long until these two objects need

--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -29,6 +29,7 @@ namespace Object {
 		Hidden,					// Object is hidden (not shown) and can't be manipulated
 		Collides_with_parent,	// Asteroth - Only used for weapons with 'Can_damage_shooter'
 		Attackable_if_no_collide,	// Cyborg - Allows the AI to attack this object, even if no-collide is set (Cue Admiral Ackbar)
+		Collision_cache_stale,	// This object has a stale collision cache, and will be recalculated this frame
 
 		NUM_VALUES
 	};

--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -29,6 +29,7 @@ namespace Object {
 		Hidden,					// Object is hidden (not shown) and can't be manipulated
 		Collides_with_parent,	// Asteroth - Only used for weapons with 'Can_damage_shooter'
 		Attackable_if_no_collide,	// Cyborg - Allows the AI to attack this object, even if no-collide is set (Cue Admiral Ackbar)
+		Collide_time_stale,		// This object *ignores* predictive collision check deferring into the future, it is always checked every frame
 
 		NUM_VALUES
 	};

--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -29,7 +29,6 @@ namespace Object {
 		Hidden,					// Object is hidden (not shown) and can't be manipulated
 		Collides_with_parent,	// Asteroth - Only used for weapons with 'Can_damage_shooter'
 		Attackable_if_no_collide,	// Cyborg - Allows the AI to attack this object, even if no-collide is set (Cue Admiral Ackbar)
-		Collide_time_stale,		// This object *ignores* predictive collision check deferring into the future, it is always checked every frame
 
 		NUM_VALUES
 	};

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8783,7 +8783,7 @@ void sexp_set_object_position(int n)
 			set_object_for_clients(oswpt.objp);
 
 			if (oswpt.objp->flags[Object::Object_Flags::Collides])
-				obj_collide_retime_cached_pairs(oswpt.objp);
+				obj_collide_cache_stale();
 
 			break;
 		}
@@ -8827,7 +8827,7 @@ void sexp_set_object_position(int n)
 				}
 
 				if (objp->flags[Object::Object_Flags::Collides])
-					obj_collide_retime_cached_pairs(objp);
+					obj_collide_cache_stale();
 			}
 
 			break;
@@ -8914,7 +8914,7 @@ void sexp_set_object_orientation(int n)
 			set_object_for_clients(oswpt.objp);
 
 			if (oswpt.objp->flags[Object::Object_Flags::Collides])
-				obj_collide_retime_cached_pairs(oswpt.objp);
+				obj_collide_cache_stale();
 
 			break;
 		}
@@ -8935,7 +8935,7 @@ void sexp_set_object_orientation(int n)
 				set_object_for_clients(objp);
 
 				if (objp->flags[Object::Object_Flags::Collides])
-					obj_collide_retime_cached_pairs(objp);
+					obj_collide_cache_stale();
 			}
 
 			break;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8783,7 +8783,7 @@ void sexp_set_object_position(int n)
 			set_object_for_clients(oswpt.objp);
 
 			if (oswpt.objp->flags[Object::Object_Flags::Collides])
-				obj_collide_cache_stale();
+				obj_collide_obj_cache_stale(oswpt.objp);
 
 			break;
 		}
@@ -8827,7 +8827,7 @@ void sexp_set_object_position(int n)
 				}
 
 				if (objp->flags[Object::Object_Flags::Collides])
-					obj_collide_cache_stale();
+					obj_collide_obj_cache_stale(objp);
 			}
 
 			break;
@@ -8914,7 +8914,7 @@ void sexp_set_object_orientation(int n)
 			set_object_for_clients(oswpt.objp);
 
 			if (oswpt.objp->flags[Object::Object_Flags::Collides])
-				obj_collide_cache_stale();
+				obj_collide_obj_cache_stale(oswpt.objp);
 
 			break;
 		}
@@ -8935,7 +8935,7 @@ void sexp_set_object_orientation(int n)
 				set_object_for_clients(objp);
 
 				if (objp->flags[Object::Object_Flags::Collides])
-					obj_collide_cache_stale();
+					obj_collide_obj_cache_stale(objp);
 			}
 
 			break;

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -151,7 +151,7 @@ ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)"
 		}
 
 		if (objh->objp->flags[Object::Object_Flags::Collides])
-			obj_collide_retime_cached_pairs(objh->objp);
+			obj_collide_cache_stale();
 	}
 
 	return ade_set_args(L, "o", l_Vector.Set(objh->objp->pos));
@@ -210,7 +210,7 @@ ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (Wor
 		objh->objp->orient = *mh->GetMatrix();
 
 		if (objh->objp->flags[Object::Object_Flags::Collides])
-			obj_collide_retime_cached_pairs(objh->objp);
+			obj_collide_cache_stale();
 	}
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&objh->objp->orient)));

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -133,7 +133,7 @@ ADE_VIRTVAR(Radius, l_Object, "number", "Radius of an object", "number", "Radius
 	return ade_set_args(L, "f", objh->objp->radius);
 }
 
-ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)", "vector", "World position, or null vector if handle is invalid.")
+ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)", "vector", "World position, or null vector if handle is invalid")
 {
 	object_h *objh;
 	vec3d *v3=NULL;
@@ -174,7 +174,7 @@ ADE_VIRTVAR(LastPosition, l_Object, "vector", "Object world position as of last 
 	return ade_set_args(L, "o", l_Vector.Set(objh->objp->last_pos));
 }
 
-ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (World orientation)", "orientation", "Orientation, or null orientation if handle is invalid.")
+ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (World orientation)", "orientation", "Orientation, or null orientation if handle is invalid")
 {
 	object_h *objh;
 	matrix_h *mh=NULL;

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -151,7 +151,7 @@ ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)"
 		}
 
 		if (objh->objp->flags[Object::Object_Flags::Collides])
-			obj_collide_cache_stale();
+			obj_collide_obj_cache_stale(objh->objp);
 	}
 
 	return ade_set_args(L, "o", l_Vector.Set(objh->objp->pos));
@@ -188,7 +188,7 @@ ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (Wor
 		objh->objp->orient = *mh->GetMatrix();
 
 		if (objh->objp->flags[Object::Object_Flags::Collides])
-			obj_collide_cache_stale();
+			obj_collide_obj_cache_stale(objh->objp);
 	}
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&objh->objp->orient)));

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -133,7 +133,7 @@ ADE_VIRTVAR(Radius, l_Object, "number", "Radius of an object", "number", "Radius
 	return ade_set_args(L, "f", objh->objp->radius);
 }
 
-ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)", "vector", "World position, or null vector if handle is invalid. Setting this value will recalculate collision culling with regards to this object.")
+ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)", "vector", "World position, or null vector if handle is invalid.")
 {
 	object_h *objh;
 	vec3d *v3=NULL;
@@ -157,28 +157,6 @@ ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)"
 	return ade_set_args(L, "o", l_Vector.Set(objh->objp->pos));
 }
 
-ADE_FUNC(SetPositionNoCollideRetime, l_Object, "vector", "Object world position (World vector)", "vector", "Updates the position WITHOUT recalculating collisions. This is faster, but may cause incorrect collisions if moved too far.")
-{
-	object_h* objh = nullptr;
-	vec3d* v3 = nullptr;
-
-	if (!ade_get_args(L, "oo", l_Object.GetPtr(&objh), l_Vector.GetPtr(&v3)))
-		return ADE_RETURN_NIL;
-
-	if (!objh->IsValid())
-		return ADE_RETURN_NIL;
-
-	if (v3) {
-		objh->objp->pos = *v3;
-		if (objh->objp->type == OBJ_WAYPOINT) {
-			waypoint* wpt = find_waypoint_with_objnum(OBJ_INDEX(objh->objp));
-			wpt->set_pos(v3);
-		}
-	}
-
-	return ADE_RETURN_NIL;
-}
-
 ADE_VIRTVAR(LastPosition, l_Object, "vector", "Object world position as of last frame (World vector)", "vector", "World position, or null vector if handle is invalid")
 {
 	object_h *objh;
@@ -196,7 +174,7 @@ ADE_VIRTVAR(LastPosition, l_Object, "vector", "Object world position as of last 
 	return ade_set_args(L, "o", l_Vector.Set(objh->objp->last_pos));
 }
 
-ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (World orientation)", "orientation", "Orientation, or null orientation if handle is invalid. Setting this value will recalculate collision culling with regards to this object.")
+ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (World orientation)", "orientation", "Orientation, or null orientation if handle is invalid.")
 {
 	object_h *objh;
 	matrix_h *mh=NULL;
@@ -214,23 +192,6 @@ ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (Wor
 	}
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&objh->objp->orient)));
-}
-
-ADE_FUNC(SetOrientNoCollideRetime, l_Object, "orientation", "Object world orientation (World orientation)", "vector", "Updates the orientation WITHOUT recalculating collisions. This is faster, but may cause incorrect collisions if moved too far.")
-{
-	object_h* objh = nullptr;
-	matrix_h* mh = nullptr;
-
-	if (!ade_get_args(L, "oo", l_Object.GetPtr(&objh), l_Matrix.GetPtr(&mh)))
-		return ADE_RETURN_NIL;
-
-	if (!objh->IsValid())
-		return ADE_RETURN_NIL;
-
-	if (mh)
-		objh->objp->orient = *mh->GetMatrix();
-
-	return ADE_RETURN_NIL;
 }
 
 ADE_VIRTVAR(LastOrientation, l_Object, "orientation", "Object world orientation as of last frame (World orientation)", "orientation", "Orientation, or null orientation if handle is invalid")

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -41,6 +41,7 @@ Category LoadBatchingBuffers("Load batching buffers", true);
 Category SortColliders("Sort Colliders", false);
 Category FindOverlapColliders("Find overlap colliders", false);
 Category CollidePair("Collide Pair", false);
+Category RetimeCollisionCache("Retime Collision Cache", false);
 
 Category WeaponPostMove("Weapon post move", false);
 Category ShipPostMove("Ship post move", false);

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -54,6 +54,7 @@ extern Category LoadBatchingBuffers;
 extern Category SortColliders;
 extern Category FindOverlapColliders;
 extern Category CollidePair;
+extern Category RetimeCollisionCache;
 
 extern Category WeaponPostMove;
 extern Category ShipPostMove;


### PR DESCRIPTION
Follow-up to #5487 

#5442 adds invalidation of collision check timings on ships who've had their position or orientation changed via script, which prevents any erroneous collision behavior, but since this involves going through all the collision pairs, if done too much like say, on dozens of ships every frame (not that I would ever do such a thing >.>) the cost can add up.

Instead of adding extra script bells and whistles to skip this step in 5487, the cost of fixing this invalidation can be greatly improved. Instead of immediately retiming all or even some pairs, any operations will instead set a global flag, then once per frame directly before collision go through all the pairs to retime them, *and* cull any invalid pairs.

Simply going through the pairs is often the bigger cost than the actually re-triggered collisions! ~~For this reason, I have removed the single object version of the collision retiming, since although it makes logical sense, it actually does not actually save much actual performance.~~ (After review below, an object flag is added so that only the specifically invalidated objects are recalculated during the single pass so as to avoid resetting potentially still correct timestamps) So by doing once per frame, we avoid multiple calls in one frame from adding up, and by culling we also make any subsequent triggers hopefully quicker as well. 

After the stable, there is still the possibility of adding a scripted object flag to avoid triggering this global flag for further optimization, but I think this suffices for the stable.