### PR TITLE
Add a warning for cases when we couldn't load a trail bitmap

### DIFF
--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -842,7 +842,7 @@ void batching_add_line(vec3d *start, vec3d *end, float widthStart, float widthEn
 
 void batching_add_laser(int texture, vec3d *p0, float width1, vec3d *p1, float width2, int r, int g, int b)
 {
-	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
+	Assertion((texture >= 0), "batching_add_laser() attempted for invalid texture");
 	if ( texture < 0 ) {
 		return;
 	}
@@ -854,7 +854,7 @@ void batching_add_laser(int texture, vec3d *p0, float width1, vec3d *p1, float w
 
 void batching_add_volume_polygon(int texture, vec3d* pos, matrix* orient, float width, float height, float alpha)
 {
-	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
+	Assertion((texture >= 0), "batching_add_volume_polygon() attempted for invalid texture");
 	if (texture < 0) {
 		return;
 	}
@@ -875,7 +875,7 @@ void batching_add_volume_polygon(int texture, vec3d* pos, matrix* orient, float 
 
 void batching_add_polygon(int texture, vec3d *pos, matrix *orient, float width, float height, float alpha)
 {
-	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
+	Assertion((texture >= 0), "batching_add_polygon() attempted for invalid texture");
 	if ( texture < 0 ) {
 		return;
 	}
@@ -890,7 +890,7 @@ void batching_add_polygon(int texture, vec3d *pos, matrix *orient, float width, 
 
 void batching_add_quad(int texture, vertex *verts, float trapezoidal_correction)
 {
-	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
+	Assertion((texture >= 0), "batching_add_quad() attempted for invalid texture");
 	if ( texture < 0 ) {
 		return;
 	}
@@ -902,7 +902,7 @@ void batching_add_quad(int texture, vertex *verts, float trapezoidal_correction)
 
 void batching_add_quad(int texture, vertex *verts, primitive_batch *batch, float trapezoidal_correction)
 {
-	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
+	Assertion((texture >= 0), "batching_add_quad() attempted for invalid texture");
 	if ( texture < 0 ) {
 		return;
 	}
@@ -911,7 +911,7 @@ void batching_add_quad(int texture, vertex *verts, primitive_batch *batch, float
 }
 void batching_add_tri(int texture, vertex *verts)
 {
-	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
+	Assertion((texture >= 0), "batching_add_tri() attempted for invalid texture");
 	if ( texture < 0 ) {
 		return;
 	}
@@ -923,7 +923,7 @@ void batching_add_tri(int texture, vertex *verts)
 
 void batching_add_tri(int texture, vertex *verts, primitive_batch *batch)
 {
-	Assertion((texture >= 0), "batching_add_...() attempted for invalid texture");
+	Assertion((texture >= 0), "batching_add_tri() attempted for invalid texture");
 	if ( texture < 0 ) {
 		return;
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4646,6 +4646,9 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		stuff_string(name_tmp, F_NAME, NAME_LENGTH);
 		generic_bitmap_init(&ci->texture, name_tmp);
 		generic_bitmap_load(&ci->texture);
+		if (ci->texture == -1) {
+			Warning(LOCATION, "Trail bitmap %s could not be loaded. Trail will not be rendered.", name_tmp);
+		}
 
 		if (optional_string("+Bitmap Stretch:")) {
 			stuff_float(&ci->texture_stretch);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4646,7 +4646,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		stuff_string(name_tmp, F_NAME, NAME_LENGTH);
 		generic_bitmap_init(&ci->texture, name_tmp);
 		generic_bitmap_load(&ci->texture);
-		if (ci->texture == -1) {
+		if (ci->texture.bitmap_id == -1) {
 			Warning(LOCATION, "Trail bitmap %s could not be loaded. Trail will not be rendered.", name_tmp);
 		}
 

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -131,7 +131,6 @@ void trail_render( trail * trailp )
 	trail_info *ti	= &trailp->info;
 
 	if (ti->texture.bitmap_id <= 0) {
-		Warning(LOCATION, "Trail bitmap %s could not be loaded.", ti->texture.filename);
 		return;
 	}
 

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -129,6 +129,12 @@ void trail_render( trail * trailp )
 		return;
 
 	trail_info *ti	= &trailp->info;
+
+	if (ti->texture.bitmap_id <= 0) {
+		Warning(LOCATION, "Trail bitmap %s could not be loaded.", ti->texture.filename);
+		return;
+	}
+
 	auto batchp = batching_find_batch(ti->texture.bitmap_id, batch_info::FLAT_EMISSIVE);
 
 	if (trailp->single_segment) {
@@ -204,8 +210,6 @@ void trail_render( trail * trailp )
 
 	if (num_sections <= 1)
 		return;
-
-	Assertion(ti->texture.bitmap_id != -1, "Weapon trail %s could not be loaded", ti->texture.filename); // We can leave this as an assert, but tell them how to fix it. --Chief
 
 	float w_size = (ti->w_end - ti->w_start);
 	float a_size = (ti->a_end - ti->a_start);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4137,8 +4137,13 @@ void weapon_load_bitmaps(int weapon_index)
 		}
 	}
 
-	if ( (wip->wi_flags[Weapon::Info_Flags::Trail]) && (wip->tr_info.texture.bitmap_id < 0) )
+	if ((wip->wi_flags[Weapon::Info_Flags::Trail]) && (wip->tr_info.texture.bitmap_id < 0)) {
 		generic_bitmap_load(&wip->tr_info.texture);
+
+		if (ti->texture.bitmap_id == -1) {
+			Warning(LOCATION, "Trail bitmap %s could not be loaded. Trail will not be rendered.", wip->tr_info.texture.filename);
+		}
+	}
 
 	//WMC - Don't try to load an anim if no anim is specified, Mmkay?
 	if (wip->wi_flags[Weapon::Info_Flags::Particle_spew]) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4140,7 +4140,7 @@ void weapon_load_bitmaps(int weapon_index)
 	if ((wip->wi_flags[Weapon::Info_Flags::Trail]) && (wip->tr_info.texture.bitmap_id < 0)) {
 		generic_bitmap_load(&wip->tr_info.texture);
 
-		if (ti->texture.bitmap_id == -1) {
+		if (wip->tr_info.texture.bitmap_id == -1) {
 			Warning(LOCATION, "Trail bitmap %s could not be loaded. Trail will not be rendered.", wip->tr_info.texture.filename);
 		}
 	}


### PR DESCRIPTION
Based on [this question by Kitsune on discord](https://discord.com/channels/223511295431933953/223511363807346691/1130507954873958501), I did some digging and it turns out if a trail bitmap is missing, the engine never warns about it; we silently swallow this on release builds and assert unhelpfully on debug and fastdbg. we shouldn't do that.