### PR TITLE
add missing #includes to fix compilation

### DIFF
--- a/code/sound/voicerec.cpp
+++ b/code/sound/voicerec.cpp
@@ -56,10 +56,13 @@
 
 // FreeSpace includes
 #include "cfile/cfile.h"
+#include "gamesequence/gamesequence.h"
 #include "hud/hudsquadmsg.h"
 #include "io/keycontrol.h"
 #include "osapi/osapi.h"
 #include "playerman/player.h"
+#include "popup/popup.h"
+#include "popup/popupdead.h"
 #include "ship/ship.h"
 
 #include <SDL_syswm.h>


### PR DESCRIPTION
These #include lines are needed for the changes introduced in #5492.  Not sure why they weren't picked up by CI, or why they work in some compilers but not others.