### PR TITLE
fix Lua API access to Fireballs array

### DIFF
--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -40,8 +40,6 @@ class asteroid_info;
 
 #define FIREBALL_NUM_LARGE_EXPLOSIONS 2
 
-#define MAX_FIREBALLS	200
-
 extern int fireball_used[MAX_FIREBALL_TYPES];
 
 // all this moved here by Goober5000 because it makes more sense in the H file

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -804,13 +804,13 @@ ADE_INDEXER(l_Mission_Fireballs, "number Index", "Gets handle to a fireball obje
 
 	int objnum = -1;
 	if (idx > 0)
-		objnum = object_subclass_at_index(Fireballs, MAX_FIREBALLS, idx);
+		objnum = object_subclass_at_index(Fireballs, Fireballs.size(), idx);
 
 	return ade_set_args(L, "o", l_Fireball.Set(object_h(objnum)));
 }
 ADE_FUNC(__len, l_Mission_Fireballs, NULL, "Number of fireball objects in mission. Note that this is only accurate for one frame.", "number", "Number of fireball objects in mission")
 {
-	return ade_set_args(L, "i", object_subclass_count(Fireballs, MAX_FIREBALLS));
+	return ade_set_args(L, "i", object_subclass_count(Fireballs, Fireballs.size()));
 }
 
 ADE_FUNC(addMessage, l_Mission, "string name, string text, [persona persona]", "Adds a message", "message", "The new message or invalid handle on error")


### PR DESCRIPTION
When fireballs were made dynamic in 609ed4ed94, the `MAX_FIREBALLS` #define lost any relationship to the fireball collection.  This removes it and also correctly specifies the size of the fireball collection.

This fixes a CTD when accessing items in `mn.Fireballs` via script.