### PR TITLE
Remove `Int3()`s from `message_translate_tokens()`.

### DIFF
--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -661,9 +661,7 @@ SCP_string message_translate_tokens(const char *text)
 				break;
 
 			// make sure we aren't going to have any type of out-of-bounds issues
-			if ( ((toke2 - text) < 0) || ((toke2 - text) >= (ptr_s)sizeof(temp)) ) {
-				Int3();
-			} else {
+			if ( (toke2 > text) && ((toke2 - text) < (ptr_s)sizeof(temp)) ) {
 				strncpy(temp, text, toke2 - text);  // isolate token into seperate buffer
 				temp[toke2 - text] = 0;  // null terminate string
 				ptr = translate_key(temp);  // try and translate key
@@ -698,9 +696,7 @@ SCP_string message_translate_tokens(const char *text)
 				break;
 
 			// make sure we aren't going to have any type of out-of-bounds issues
-			if ( ((toke1 - text) < 0) || ((toke1 - text) >= (ptr_s)sizeof(temp)) ) {
-				Int3();
-			} else {
+			if ( (toke1 > text) && ((toke1 - text) < (ptr_s)sizeof(temp)) ) {
 				strncpy(temp, text, toke1 - text);  // isolate token into seperate buffer
 				temp[toke1 - text] = 0;  // null terminate string
 				ptr = translate_message_token(temp);  // try and translate key


### PR DESCRIPTION
In f350e06851d71694db8d20e9c8536f46379ff6a7, two Int3()s were added to `message_translate_tokens()`, to check for possible out-of-bounds errors. However, in c70fdc3a52dc732c34fd954f2934b864db73f198, just a couple months later, the code being protected by those bounds checks were put into `else` branches, meaning the `Int3()`s became redundant. This wouldn't actually cause any problems unless somebody passed a string with two `$`s at least 40 characters apart to `message_translate_tokens()`. Cue #4876, which started calling `message_translate_tokens()` on debriefing stages and recommendations, which can contain color tags. This still wouldn't cause problems as long as the color tags are in pairs within close proximity (`translate_key()` would say "that's not the name of a scan code" and leave the text between the two tags alone), but as soon as two color tags are far enough apart to trip the bounds check conditional, the `Int3()` would be hit. This is still fine on Release builds, which ignore `Int3()`s, but triggers a breakpoint on debug builds, which depending on the user's system, can result in a CTD. Since, as far as I can tell, the `Int3()`s haven't actually been meaningful since 2006, I've just removed them (and inverted the conditionals), and testing by the affected user confirms that it no longer CTDs.