### PR TITLE
Restore (mostly-)retail debrief failure counting behavior.

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1114,7 +1114,6 @@ void mission_campaign_mission_over(bool do_next_mission)
 
 	// Goober5000 - player-persistent variables are handled when the mission is
 	// over, not necessarily when the mission is accepted
-	Player->failures_this_session = 0;
 
 	// update campaign.mission stats (used to allow backout inRedAlert)
 	// .. but we don't do this if we are inside of the prev/current loop hack

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -2015,6 +2015,14 @@ void debrief_init(bool API_Access)
 		debrief_init_music();
 	}
 
+	if ((Game_mode & GM_CAMPAIGN_MODE) && (Campaign.next_mission == Campaign.current_mission)) {
+		// Better luck next time; increase retries.
+		Player->failures_this_session++;
+	} else {
+		// Clear retry count regardless of whether or not the player accepts.
+		Player->failures_this_session = 0;
+	}
+
 	if (Game_mode & GM_MULTIPLAYER) {
 		multi_debrief_init();
 


### PR DESCRIPTION
Back in 2008 (in commit 2c45dbbb5f77404e4d1833369cd2f40594731a81), some retail code incrementing `Player->failures_this_session` was removed, seemingly by accident. A month later, a bug related to this was fixed (in commit 28a408deee3496b8f6d81768778c3ff1f2397515) in a different way. Since this fix is rendered redundant by the restoration of the original behavior, I've removed it and put back in the old behavior. This is only "mostly-retail" because the retail code didn't check `Game_mode & GM_CAMPAIGN_MODE`.

This restores the old behavior of allowing a player to skip a mission without having to die (and see the death popup, which doesn't happen in some missions that show a debriefing if the player dies). Since the logic is so straightforward (and other "mission failed" checks in the debriefing code use the same or at least very similar logic), it *should* work with any existing mods... but that "should" is so wide, and this change could affect so many things, that I've got it in draft form to start with because more research is needed before fiddling with a foundational system like the debriefing screen.