### PR TITLE
Some more fixes for laser single segment trails

### DIFF
--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -146,6 +146,7 @@ void trail_render( trail * trailp )
 
 		float total_len = speed * ti->max_life;
 		float t = vm_vec_dist(&trailp->pos[front], &trailp->pos[back]) / total_len;
+		CLAMP(t, 0.0f, 1.0f);
 		float f_alpha, b_alpha, f_width, b_width;
 		if (trailp->object_died) {
 			f_alpha = t * (ti->a_start - ti->a_end) + ti->a_end;
@@ -364,9 +365,6 @@ void trail_add_segment( trail *trailp, vec3d *pos , const matrix* orient, vec3d*
 
 void trail_set_segment( trail *trailp, vec3d *pos )
 {
-	if (trailp->single_segment)
-		return;
-
 	int next = trailp->tail-1;
 	if ( next < 0 )	{
 		next = NUM_TRAIL_SECTIONS-1;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6534,9 +6534,9 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 			// Add two segments.  One to stay at launch pos, one to move.
 			trail_add_segment( wp->trail_ptr, &objp->pos, &objp->orient, &objp->phys_info.vel);
 			if (wip->render_type == WRT_LASER) {
-				vec3d pos;
-				vm_vec_scale_add(&pos, &objp->pos, &objp->orient.vec.fvec, (wip->laser_length / 2));
-				trail_add_segment(wp->trail_ptr, &pos, &objp->orient, &objp->phys_info.vel);
+				vec3d center_pos;
+				vm_vec_scale_add(&center_pos, &objp->pos, &objp->orient.vec.fvec, (wip->laser_length / 2));
+				trail_add_segment(wp->trail_ptr, &center_pos, &objp->orient, &objp->phys_info.vel);
 			} else {
 				trail_add_segment(wp->trail_ptr, &objp->pos, &objp->orient, &objp->phys_info.vel);
 			}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6533,7 +6533,13 @@ int weapon_create( vec3d * pos, matrix * porient, int weapon_type, int parent_ob
 		if ( wp->trail_ptr != NULL )	{
 			// Add two segments.  One to stay at launch pos, one to move.
 			trail_add_segment( wp->trail_ptr, &objp->pos, &objp->orient, &objp->phys_info.vel);
-			trail_add_segment( wp->trail_ptr, &objp->pos, &objp->orient, &objp->phys_info.vel);
+			if (wip->render_type == WRT_LASER) {
+				vec3d pos;
+				vm_vec_scale_add(&pos, &objp->pos, &objp->orient.vec.fvec, (wip->laser_length / 2));
+				trail_add_segment(wp->trail_ptr, &pos, &objp->orient, &objp->phys_info.vel);
+			} else {
+				trail_add_segment(wp->trail_ptr, &objp->pos, &objp->orient, &objp->phys_info.vel);
+			}
 		}
 	}
 	else


### PR DESCRIPTION
Laser trails come from their visual center, rather than their actual position which is at their tail, however this is done when the trail is maintained every frame in `trail_set_segment` rather than when it is created, which is when all the single segment handling happens and so it 'misses that memo'.

1. Make sure this is done for trails even when created, even if it's going to be affirmed in set_segment anyway. Makes that bit clearer in general. This would be sufficient to fix the problem...
2. But also remove the early out for single segments in `trail_set_segment`, this was done since it 'theoretically' shouldn't need any maintaining what with a constant velocity and all, but let's do it anyway just to make sure the trail doesn't get 'disconnected' by any other means as well.
3. Clamp `t` in the rendering, just because some float math can sometimes make it slightly negative or something which can result in ugly stuff like negative alpha.