### PR TITLE
fix a couple bugs in the campaign editor

### DIFF
--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -57,8 +57,13 @@ struct sexp_variable;
 #define CMISSION_FLAG_SKIPPED				(1<<1)	// set if skipped, else not
 #define CMISSION_FLAG_HAS_LOOP				(1<<2)	// mission loop, e.g. FS2 SOC loops
 #define CMISSION_FLAG_HAS_FORK				(1<<3)	// campaign fork, e.g. Scroll or BWO (mutually exclusive with loop)
-// internal flags start from the end
+
+// internal flags start from the end, except for some flags that are grandfathered in
 #define CMISSION_FLAG_FRED_LOAD_PENDING		(1<<31)	// originally handled by num_goals being set to -1
+#define CMISSION_FIRST_INTERNAL_FLAG		CMISSION_FLAG_FRED_LOAD_PENDING
+
+// all flags below FIRST_INTERNAL_FLAG, except SKIPPED, HAS_LOOP, and HAS_FORK
+#define CMISSION_EXTERNAL_FLAG_MASK		((static_cast<unsigned int>(CMISSION_FIRST_INTERNAL_FLAG) - 1) & ~CMISSION_FLAG_SKIPPED & ~CMISSION_FLAG_HAS_LOOP & ~CMISSION_FLAG_HAS_FORK)
 
 #define CAMPAIGN_LOOP_MISSION_UNINITIALIZED	-2
 

--- a/fred2/campaigneditordlg.cpp
+++ b/fred2/campaigneditordlg.cpp
@@ -919,7 +919,7 @@ void campaign_editor::OnCustomTechDB()
 		Campaign.flags &= ~CF_CUSTOM_TECH_DATABASE;
 }
 
-CString campaign_editor::GetPathWithoutFile()
+CString campaign_editor::GetPathWithoutFile() const
 {
 	if (m_current_campaign_path.IsEmpty())
 		return m_current_campaign_path;
@@ -931,4 +931,14 @@ CString campaign_editor::GetPathWithoutFile()
 	}
 
 	return path;
+}
+
+void campaign_editor::SetCurrentCampaignPath(const CString& path)
+{
+	m_current_campaign_path = path;
+}
+
+const CString &campaign_editor::GetCurrentCampaignPath() const
+{
+	return m_current_campaign_path;
 }

--- a/fred2/campaigneditordlg.h
+++ b/fred2/campaigneditordlg.h
@@ -31,7 +31,7 @@ private:
 	int m_num_links;
 	int m_last_mission;
 	CString	m_current_campaign_path;
-	CString GetPathWithoutFile();
+	CString GetPathWithoutFile() const;
 
 protected:
 	campaign_editor();           // protected constructor used by dynamic creation
@@ -49,7 +49,7 @@ public:
 	void initialize( bool init_files, bool clear_path );
 	void load_campaign(const char *filename, const char *full_path);
 	void update_loop_desc_window();
-	void campaign_editor::save_loop_desc_window();
+	void save_loop_desc_window();
 	//{{AFX_DATA(campaign_editor)
 	enum { IDD = IDD_CAMPAIGN };
 	campaign_sexp_tree	m_tree;
@@ -63,6 +63,9 @@ public:
 	CString	m_branch_brief_sound;
 	BOOL	m_custom_tech_db;
 	//}}AFX_DATA
+
+	void SetCurrentCampaignPath(const CString& path);
+	const CString &GetCurrentCampaignPath() const;
 
 // Attributes
 public:

--- a/fred2/campaigntreewnd.cpp
+++ b/fred2/campaigntreewnd.cpp
@@ -37,6 +37,7 @@ IMPLEMENT_DYNCREATE(campaign_tree_wnd, CFrameWnd)
 // campaign_tree_wnd
 
 campaign_tree_wnd::campaign_tree_wnd()
+	: g_err(0)
 {
 }
 
@@ -188,7 +189,8 @@ void campaign_tree_wnd::OnCpgnFileSave()
 	}
 	*/	
 
-	if (save.save_campaign_file(Campaign.filename))
+	auto full_path = (LPCSTR)Campaign_tree_formp->GetCurrentCampaignPath();
+	if (save.save_campaign_file(full_path))
 	{
 		MessageBox("An error occured while saving!", "Error", MB_OK | MB_ICONEXCLAMATION);
 		return;
@@ -200,9 +202,7 @@ void campaign_tree_wnd::OnCpgnFileSave()
 
 void campaign_tree_wnd::OnCpgnFileSaveAs() 
 {
-	char *old_name = NULL;
-	char campaign_path[256];
-	CString name;
+	const char *old_name = nullptr;
 	CFred_mission_save save;
 
 	Campaign_tree_formp->update();
@@ -210,9 +210,13 @@ void campaign_tree_wnd::OnCpgnFileSaveAs()
 		old_name = Campaign.filename;
 
 	CFileDialog dlg(FALSE, "fc2", old_name, OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT, "FreeSpace Campaign files (*.fc2)|*.fc2||", this);
+	auto campaign_path = Campaign_tree_formp->GetCurrentCampaignPath();
+	if (!campaign_path.IsEmpty())
+		dlg.m_ofn.lpstrInitialDir = (LPCSTR)campaign_path;
+
 	if (dlg.DoModal() == IDOK)
 	{
-		name = dlg.GetFileName();
+		auto name = dlg.GetFileName();
 		if (strlen(name) > MAX_FILENAME_LEN - 1) {
 			MessageBox("Filename is too long", "Error");
 			return;
@@ -223,13 +227,13 @@ void campaign_tree_wnd::OnCpgnFileSaveAs()
 		}
 
 		string_copy(Campaign.filename, name, MAX_FILENAME_LEN - 1);
-		string_copy(campaign_path, dlg.GetPathName(), 256 - 1);
-		if (save.save_campaign_file(campaign_path))
+		if (save.save_campaign_file((LPCSTR)dlg.GetPathName()))
 		{
 			MessageBox("An error occured while saving!", "Error", MB_OK | MB_ICONEXCLAMATION);
 			return;
 		}
 
+		Campaign_tree_formp->SetCurrentCampaignPath(dlg.GetPathName());
 		Campaign_modified = 0;
 	}
 }

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1355,10 +1355,13 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 		required_string_fred("+Flags:", "$Mission:");
 		parse_comments();
 
+		// don't save any internal flags
+		auto flags_to_save = Campaign.missions[m].flags & CMISSION_EXTERNAL_FLAG_MASK;
+
 		// Goober5000
 		if (Mission_save_format != FSO_FORMAT_RETAIL) {
 			// don't save Bastion flag
-			fout(" %d", Campaign.missions[m].flags & ~CMISSION_FLAG_BASTION);
+			fout(" %d", flags_to_save & ~CMISSION_FLAG_BASTION);
 
 			// new main hall stuff
 			if (optional_string_fred("+Main Hall:", "$Mission:"))
@@ -1369,7 +1372,7 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 			fout(" %s", Campaign.missions[m].main_hall.c_str());
 		} else {
 			// save Bastion flag properly
-			fout(" %d", Campaign.missions[m].flags | ((Campaign.missions[m].main_hall != "") ? CMISSION_FLAG_BASTION : 0));
+			fout(" %d", flags_to_save | ((Campaign.missions[m].main_hall != "") ? CMISSION_FLAG_BASTION : 0));
 		}
 
 		if (Campaign.missions[m].debrief_persona_index > 0) {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2339,10 +2339,13 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 		required_string_fred("+Flags:", "$Mission:");
 		parse_comments();
 
+		// don't save any internal flags
+		auto flags_to_save = cm.flags & CMISSION_EXTERNAL_FLAG_MASK;
+
 		// Goober5000
 		if (save_format != MissionFormat::RETAIL) {
 			// don't save Bastion flag
-			fout(" %d", cm.flags & ~CMISSION_FLAG_BASTION);
+			fout(" %d", flags_to_save & ~CMISSION_FLAG_BASTION);
 
 			// new main hall stuff
 			if (optional_string_fred("+Main Hall:", "$Mission:")) {
@@ -2354,7 +2357,7 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 			fout(" %s", cm.main_hall.c_str());
 		} else {
 			// save Bastion flag properly
-			fout(" %d", cm.flags | ((! cm.main_hall.empty()) ? CMISSION_FLAG_BASTION : 0));
+			fout(" %d", flags_to_save | ((! cm.main_hall.empty()) ? CMISSION_FLAG_BASTION : 0));
 		}
 
 		if (cm.debrief_persona_index > 0) {


### PR DESCRIPTION
1. When saving a campaign, the save directory should be the one that the campaign was just loaded from.  If prompting the user, this should be the default save directory.  This fixes a bug where campaigns were saved to %APPDATA% instead of where the FREDder might expect.  This has been a bug ever since the migration of the game files from FreeSpace2 to %APPDATA%.
2. When saving a campaign, save only the external mission flags, not the working flags that are maintained during gameplay but have no meaning in the saved file.