### PR TITLE
POF version fix

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -80,6 +80,9 @@ static bool ss_warning_shown_mismatch = false;	// ditto but for a different warn
 // Anything less than this is considered incompatible.
 #define PM_COMPATIBLE_VERSION 1900
 
+// This begins the FS2 version history
+#define PM_FIRST_FREESPACE2_VERSION 2100
+
 // Anything greater than or equal to PM_COMPATIBLE_VERSION and 
 // whose major version is less than or equal to this is considered
 // compatible.  
@@ -1668,22 +1671,24 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 
 		switch (id) {
 
+			case ID_HDR2:
 			case ID_OHDR: {		//Object header
 				//vector v;
 
 				//mprintf(0,"Got chunk OHDR, len=%d\n",len);
 
-#if defined( FREESPACE1_FORMAT )
-				pm->n_models = cfread_int(fp);
-//				mprintf(( "Num models = %d\n", pm->n_models ));
-				pm->rad = cfread_float(fp);
-				pm->flags = cfread_int(fp);	// 1=Allow tiling
-#elif defined( FREESPACE2_FORMAT )
-				pm->rad = cfread_float(fp);
-				pm->flags = cfread_int(fp);	// 1=Allow tiling
-				pm->n_models = cfread_int(fp);
-//				mprintf(( "Num models = %d\n", pm->n_models ));
-#endif
+				if (id == ID_OHDR) {
+					pm->n_models = cfread_int(fp);
+//					mprintf(( "Num models = %d\n", pm->n_models ));
+					pm->rad = cfread_float(fp);
+					pm->flags = cfread_int(fp);	// 1=Allow tiling
+				}
+				if (id == ID_HDR2) {
+					pm->rad = cfread_float(fp);
+					pm->flags = cfread_int(fp);	// 1=Allow tiling
+					pm->n_models = cfread_int(fp);
+//					mprintf(( "Num models = %d\n", pm->n_models ));
+				}
                 Assertion(pm->n_models >= 1, "Models without any submodels are not supported!");
 
 				// Check for unrealistic radii
@@ -1818,6 +1823,7 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 				break;
 			}
 			
+			case ID_OBJ2:
 			case ID_SOBJ: {		//Subobject header
 				int n, parent;
 				char *p, props[MAX_PROP_LEN];
@@ -1830,9 +1836,9 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 				Assert(n < pm->n_models );
 				auto sm = &pm->submodel[n];
 
-#if defined( FREESPACE2_FORMAT )	
-				sm->rad = cfread_float(fp);		//radius
-#endif
+				if (id == ID_OBJ2) {
+					sm->rad = cfread_float(fp);		//radius
+				}
 
 				parent = cfread_int(fp);
 				sm->parent = parent;
@@ -1855,9 +1861,9 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 
 //			mprintf(( "Subobj %d, offs = %.1f, %.1f, %.1f\n", n, sm->offset.xyz.x, sm->offset.xyz.y, sm->offset.xyz.z ));
 	
-#if defined ( FREESPACE1_FORMAT )
-				sm->rad = cfread_float(fp);		//radius
-#endif
+				if (id == ID_SOBJ) {
+					sm->rad = cfread_float(fp);		//radius
+				}
 
 //				sm->tree_offset = cfread_int(fp);	//offset
 //				sm->data_offset = cfread_int(fp);	//offset

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -27,27 +27,19 @@ class polymodel;
 #define OP_TMAP2POLY	6
 #define OP_SORTNORM2	7
 
-// change header for freespace2
-//#define FREESPACE1_FORMAT
-#define FREESPACE2_FORMAT
-#if defined( FREESPACE1_FORMAT )
-#elif defined ( FREESPACE2_FORMAT )
-#else
-	#error Neither FREESPACE1_FORMAT or FREESPACE2_FORMAT defined
-#endif
-
 // endianess will be handled by cfile and others now, little-endian should be default in all cases
 
 // little-endian (Intel) IDs
 #define POF_HEADER_ID  0x4f505350	// 'OPSP' (PSPO) POF file header
-#if defined( FREESPACE1_FORMAT )
-	// FREESPACE1 FORMAT
-	#define ID_OHDR 0x5244484f			// RDHO (OHDR): POF file header
-	#define ID_SOBJ 0x4a424f53			// JBOS (SOBJ): Subobject header
-#else
-	#define ID_OHDR 0x32524448			// 2RDH (HDR2): POF file header
-	#define ID_SOBJ 0x324a424f			// 2JBO (OBJ2): Subobject header
-#endif
+
+// FREESPACE1 FORMAT
+#define ID_OHDR 0x5244484f			// RDHO (OHDR): POF file header
+#define ID_SOBJ 0x4a424f53			// JBOS (SOBJ): Subobject header
+
+// FREESPACE2 FORMAT
+#define ID_HDR2 0x32524448			// 2RDH (HDR2): POF file header
+#define ID_OBJ2 0x324a424f			// 2JBO (OBJ2): Subobject header
+
 #define ID_TXTR 0x52545854				// RTXT (TXTR): Texture filename list
 #define ID_INFO 0x464e4950				// FNIP (PINF): POF file information, like command line, etc
 #define ID_GRID 0x44495247				// DIRG (GRID): Grid information


### PR DESCRIPTION
Modelread.cpp supports POF versions as low as 1900, but early model versions were not loaded properly because they relied on preprocessor directives rather than version checks.  This changes the POF loading to correctly check version numbers and chunk IDs.

Fixes crashes when attempting to load a FS1 model.