### PR TITLE
fix mission corruption in FRED

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1278,7 +1278,9 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 
 	Campaign_tree_formp->save_tree();  // flush all changes so they get saved.
 	Campaign_tree_viewp->sort_elements();
+
 	reset_parse();
+	raw_ptr = Parse_text_raw;
 	fred_parse_flag = 0;
 
 	pathname = cf_add_ext(pathname, FS_CAMPAIGN_FILE_EXT);
@@ -2599,8 +2601,13 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Version:");
 	parse_comments(2);
-	// Since previous versions of FreeSpace interpret this as a float, this can only have one decimal point
-	fout(" %d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor);
+	if (Mission_save_format == FSO_FORMAT_RETAIL) {
+		// All retail missions, both FS1 and FS2, have the same version
+		fout(" %d.%d", LEGACY_MISSION_VERSION.major, LEGACY_MISSION_VERSION.minor);
+	} else {
+		// Since previous versions of FreeSpace interpret this as a float, this can only have one decimal point
+		fout(" %d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor);
+	}
 
 	// XSTR
 	required_string_fred("$Name:");
@@ -3083,7 +3090,9 @@ void CFred_mission_save::save_mission_internal(const char *pathname)
 	The_mission.required_fso_version = MISSION_VERSION;
 
 	reset_parse();
+	raw_ptr = Parse_text_raw;
 	fred_parse_flag = 0;
+
 	fp = cfopen(pathname, "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
 	if (!fp) {
 		nprintf(("Error", "Can't open mission file to save.\n"));

--- a/fred2/missionsave.h
+++ b/fred2/missionsave.h
@@ -40,7 +40,7 @@ public:
 	/**
 	 * @brief Default constructor
 	 */
-	CFred_mission_save() : err(0), raw_ptr(Parse_text_raw) {}
+	CFred_mission_save() : err(0), raw_ptr(nullptr), fp(nullptr) {}
 
 	/**
 	 * @brief Move past the comment without copying it to the output file. Used for special FSO comment tags

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2259,6 +2259,7 @@ int CFred_mission_save::save_messages()
 int CFred_mission_save::save_campaign_file(const char *pathname)
 {
 	reset_parse();
+	raw_ptr = Parse_text_raw;
 	fred_parse_flag = 0;
 
 	pathname = cf_add_ext(pathname, FS_CAMPAIGN_FILE_EXT);
@@ -2494,8 +2495,13 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Version:");
 	parse_comments(2);
-	// Since previous versions of FreeSpace interpret this as a float, this can only have one decimal point
-	fout(" %d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor);
+	if (save_format == MissionFormat::RETAIL) {
+		// All retail missions, both FS1 and FS2, have the same version
+		fout(" %d.%d", LEGACY_MISSION_VERSION.major, LEGACY_MISSION_VERSION.minor);
+	} else {
+		// Since previous versions of FreeSpace interpret this as a float, this can only have one decimal point
+		fout(" %d.%d", The_mission.required_fso_version.major, The_mission.required_fso_version.minor);
+	}
 
 	// XSTR
 	required_string_fred("$Name:");
@@ -2993,7 +2999,9 @@ void CFred_mission_save::save_mission_internal(const char* pathname)
 	The_mission.required_fso_version = MISSION_VERSION;
 
 	reset_parse();
+	raw_ptr = Parse_text_raw;
 	fred_parse_flag = 0;
+
 	fp = cfopen(pathname, "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
 	if (!fp) {
 		nprintf(("Error", "Can't open mission file to save.\n"));

--- a/qtfred/src/mission/missionsave.h
+++ b/qtfred/src/mission/missionsave.h
@@ -47,7 +47,7 @@ class CFred_mission_save {
 	 * @brief Default constructor
 	 */
 	explicit CFred_mission_save(EditorViewport* viewport = nullptr, MissionFormat format = MissionFormat::STANDARD) :
-		raw_ptr(Parse_text_raw), save_format(format), _editor(viewport ? viewport->editor : nullptr), _viewport(viewport) {
+		save_format(format), _editor(viewport ? viewport->editor : nullptr), _viewport(viewport) {
 	}
 
 	/**


### PR DESCRIPTION
When using the mission importer, missions were being corrupted for very subtle reasons: due to some code reordering in prior commits, `raw_ptr` would be initialized to `Parse_text_raw` before `Parse_text_raw` itself was initialized.  This assignment was done in the `CFred_mission_save` constructor and the ordering dependency is not obvious.  Since this is a highly fragile situation and has the potential to affect any use of `parse_comments()` in FRED, it's better to explicitly assign `raw_ptr` when it is needed, and just initialize it to nullptr in the constructor.

This also sets the version number to the legacy version (0.10) when the mission is saved in the retail format.