### PR TITLE
Add feature to always display the damage gauge

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2021,7 +2021,7 @@ void hud_damage_popup_init()
 	Damage_flash_timer =	1;
 
 	for ( i = 0; i < SUBSYSTEM_MAX; i++ ) {
-		Pl_hud_subsys_info[i].last_str = 1000.0f;
+		Pl_hud_subsys_info[i].last_str = 1.0f;
 		Pl_hud_subsys_info[i].flash_duration_timestamp = 1;
 		Pl_hud_next_flash_timestamp = 1;
 		Pl_hud_is_bright = 0;
@@ -2074,6 +2074,11 @@ void HudGaugeDamage::initBottomBgOffset(int offset)
 void HudGaugeDamage::initLineHeight(int h)
 {
 	line_h = h;
+}
+
+void HudGaugeDamage::initDisplayValue(bool value)
+{
+	always_display = value;
 }
 
 void HudGaugeDamage::initBitmaps(const char *fname_top, const char *fname_middle, const char *fname_bottom)
@@ -2136,7 +2141,7 @@ void HudGaugeDamage::render(float  /*frametime*/)
 	for ( pss = GET_FIRST(&Player_ship->subsys_list); pss !=END_OF_LIST(&Player_ship->subsys_list); pss = GET_NEXT(pss) ) {
 		psub = pss->system_info;
 		strength = ship_get_subsystem_strength(Player_ship, psub->type);
-		if ( strength < 1 ) {
+		if ( always_display || strength < 1 ) {
 			// display the actual health of this specific subsystem --wookieejedi
 			if (pss->max_hits > 0) {
 				// get percentage if this subsystem has hitpoints to begin with
@@ -2273,7 +2278,7 @@ void HudGaugeDamage::render(float  /*frametime*/)
 	// Show hull integrity if it's below 100% or if a subsystem is damaged
 	// The second case is just to make the display look complete
 	// The third case is there to make the gauge appear only if needed if the right option is set
-	if ( screen_integrity < 100 || !info_lines.empty() ) {
+	if ( always_display || screen_integrity < 100 || !info_lines.empty() ) {
 		DamageInfo info;
 
 		info.name = XSTR( "Hull Integrity", 220);

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -492,7 +492,10 @@ protected:
 
 	int next_flash;
 	bool flash_status;
-public:
+
+	bool always_display;
+
+  public:
 	HudGaugeDamage();
 	void initBitmaps(const char *fname_top, const char *fname_middle, const char *fname_bottom);
 	void initHeaderOffsets(int x, int y);
@@ -503,6 +506,7 @@ public:
 	void initSubsysIntegValueOffsetX(int x);
 	void initBottomBgOffset(int offset);
 	void initLineHeight(int h);
+	void initDisplayValue(bool value);
 	void render(float frametime) override;
 	void pageIn() override;
 	void initialize() override;

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -4143,6 +4143,7 @@ void load_gauge_damage(gauge_settings* settings)
 	char fname_top[MAX_FILENAME_LEN] = "damage1";
 	char fname_middle[MAX_FILENAME_LEN] = "damage2";
 	char fname_bottom[MAX_FILENAME_LEN] = "damage3";
+	bool always_display = false;
 	
 	settings->origin[0] = 0.5f;
 	settings->origin[1] = 0.0f;
@@ -4200,6 +4201,9 @@ void load_gauge_damage(gauge_settings* settings)
 	if(optional_string("Bottom Background Offset:")) {
 		stuff_int(&bottom_bg_offset);
 	}
+	if(optional_string("Always Display:")) {
+		stuff_boolean(&always_display);
+	}
 
 	hud_gauge->initBitmaps(fname_top, fname_middle, fname_bottom);
 	hud_gauge->initHullIntegOffsets(hull_integ_offsets[0], hull_integ_offsets[1]);
@@ -4210,6 +4214,7 @@ void load_gauge_damage(gauge_settings* settings)
 	hud_gauge->initSubsysIntegValueOffsetX(subsys_integ_val_offset_x);
 	hud_gauge->initBottomBgOffset(bottom_bg_offset);
 	hud_gauge->initHeaderOffsets(header_offsets[0], header_offsets[1]);
+	hud_gauge->initDisplayValue(always_display);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }


### PR DESCRIPTION
Implements #5472 with a simple boolean flag for the damage gauge. If true then all damage values will always be drawn.

A note on hud.cpp line 2024: Changing the value here from 1000.0f to 1.0f prevents the subsystem damage text from flashing at mission start if Always Display is true but still ensures that the text flashes without the feature if the damage is less than 1.0f where 1.0f == 100% hull integrity.

Fixes #5472