### PR TITLE
Remove new lines from default generated mission fields

### DIFF
--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -828,8 +828,8 @@ void clear_mission()
 	The_mission.author = str;
 	strcpy_s(The_mission.created, t.Format("%x at %X"));
 	strcpy_s(The_mission.modified, The_mission.created);
-	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.\n");
-	strcpy_s(The_mission.mission_desc, "Put mission description here\n");
+	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.");
+	strcpy_s(The_mission.mission_desc, "Put mission description here");
 
 	// reset alternate name & callsign stuff
 	for(i=0; i<MAX_SHIPS; i++){

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -426,8 +426,8 @@ void Editor::clearMission() {
 	The_mission.author = userName;
 	strcpy_s(The_mission.created, time_buffer);
 	strcpy_s(The_mission.modified, The_mission.created);
-	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.\n");
-	strcpy_s(The_mission.mission_desc, "Put mission description here\n");
+	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.");
+	strcpy_s(The_mission.mission_desc, "Put mission description here");
 
 	// reset alternate name & callsign stuff
 	for (auto i = 0; i < MAX_SHIPS; i++) {


### PR DESCRIPTION
Simply removes the newline characters from the default mission Notes and Description. SCPUI can be set to actually display these values but requires additional code to remove the newlines because they mess with the default SCPUI mission grid view. It's minor to deal with, but I'm also thinking it's pretty minor to just remove them by default.