### PR TITLE
SEXP parsing cleanup and fixes

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -1114,17 +1114,22 @@ int get_string_or_variable (char *str)
 	ignore_white_space();
 
 	// Variable
-	if (*Mp == '@')
+	if (*Mp == SEXP_VARIABLE_CHAR)
 	{
+		auto saved_Mp = Mp;
 		Mp++;
 		stuff_string_white(str);
 		int sexp_variable_index = get_index_sexp_variable_name(str);
 
 		// We only want String variables
-		Assertion (sexp_variable_index != -1, "Didn't find variable name \"%s\"", str);
-		Assert (Sexp_variables[sexp_variable_index].type & SEXP_VARIABLE_STRING);
-
-		result = PARSING_FOUND_VARIABLE;
+		if (sexp_variable_index >= 0)
+			result = PARSING_FOUND_VARIABLE;
+		else
+		{
+			Mp = saved_Mp;
+			stuff_string_white(str);
+			error_display(1, "Expected \"%s\" to be a variable", str);
+		}
 	}
 	// Quoted string
 	else if (*Mp == '"')
@@ -1135,7 +1140,7 @@ int get_string_or_variable (char *str)
 	else
 	{
 		get_string(str);
-		Error(LOCATION, "Invalid entry \"%s\"  found in get_string_or_variable. Must be a quoted string or a string variable name.", str);
+		error_display(1, "Invalid entry \"%s\" found in get_string_or_variable. Must be a quoted string or a string variable name.", str);
 	}
 
 	return result;
@@ -1149,17 +1154,22 @@ int get_string_or_variable (SCP_string &str)
 	ignore_white_space();
 
 	// Variable
-	if (*Mp == '@')
+	if (*Mp == SEXP_VARIABLE_CHAR)
 	{
+		auto saved_Mp = Mp;
 		Mp++;
 		stuff_string_white(str);
 		int sexp_variable_index = get_index_sexp_variable_name(str);
 
 		// We only want String variables
-		Assertion (sexp_variable_index != -1, "Didn't find variable name \"%s\"", str.c_str());
-		Assert (Sexp_variables[sexp_variable_index].type & SEXP_VARIABLE_STRING);
-
-		result = PARSING_FOUND_VARIABLE;
+		if (sexp_variable_index >= 0)
+			result = PARSING_FOUND_VARIABLE;
+		else
+		{
+			Mp = saved_Mp;
+			stuff_string_white(str);
+			error_display(1, "Expected \"%s\" to be a variable", str.c_str());
+		}
 	}
 	// Quoted string
 	else if (*Mp == '"')
@@ -1170,7 +1180,7 @@ int get_string_or_variable (SCP_string &str)
 	else
 	{
 		get_string(str);
-		Error(LOCATION, "Invalid entry \"%s\"  found in get_string_or_variable. Must be a quoted string or a string variable name.", str.c_str());
+		error_display(1, "Invalid entry \"%s\" found in get_string_or_variable. Must be a quoted string or a string variable name.", str.c_str());
 	}
 
 	return result;
@@ -2762,13 +2772,14 @@ int stuff_int_optional(int *i)
 // index of the variable in the following slot.
 void stuff_int_or_variable(int *i, int *var_index, bool need_positive_value)
 {
-	if (*Mp == '@')
+	if (*Mp == SEXP_VARIABLE_CHAR)
 	{
-		Mp++;
 		int value = -1;
 		SCP_string str;
-		stuff_string(str, F_NAME);
 
+		auto saved_Mp = Mp;
+		Mp++;
+		stuff_string(str, F_NAME);
 		int index = get_index_sexp_variable_name(str);
 
 		if (index > -1 && index < MAX_SEXP_VARIABLES)
@@ -2784,7 +2795,8 @@ void stuff_int_or_variable(int *i, int *var_index, bool need_positive_value)
 		}
 		else
 		{
-
+			Mp = saved_Mp;
+			stuff_string(str, F_NAME);
 			error_display(1, "Invalid variable name \"%s\" found.", str.c_str());
 		}
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -4100,6 +4100,24 @@ void consolidate_double_characters(char *src, char ch)
 	}
 }
 
+char *three_dot_truncate(char *buffer, const char *source, size_t buffer_size)
+{
+	Assertion(buffer && source, "Arguments must not be null!");
+
+	// this would be silly
+	if (buffer_size < 6)
+	{
+		*buffer = '\0';
+		return buffer;
+	}
+
+	strncpy(buffer, source, buffer_size);
+	if (buffer[buffer_size - 1] != '\0')
+		strcpy(&buffer[buffer_size - 6], "[...]");
+
+	return buffer;
+}
+
 // Goober5000
 // Returns position of replacement, or a negative value if replacement failed: -1 if search string was not found, -2 if replacement would exceed max length, or -3 if any string argument is null
 // Note that the parameter here is max *length*, not max buffer size.  Leave room for the null-terminator!

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -79,6 +79,9 @@ extern int get_index_of_first_hash_symbol(SCP_string &src, bool ignore_doubled_h
 
 extern void consolidate_double_characters(char *str, char ch);
 
+// for limiting strings that may be very long; useful for dialog boxes
+char *three_dot_truncate(char *buffer, const char *source, size_t buffer_size);
+
 // white space
 extern int is_white_space(char ch);
 extern int is_white_space(unicode::codepoint_t cp);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -33364,7 +33364,12 @@ const char *CTEXT(int n)
 
 			if (!(Sexp_nodes[arg_n].flags & SNF_CHECKED_ARG_FOR_VAR))
 			{
-				Sexp_nodes[arg_n].cached_variable_index = check_sexp_node_text_for_sexp_variable(text);
+				// nodes that have an officially formatted variable will store the variable index in the token
+				if (Sexp_nodes[arg_n].type & SEXP_FLAG_VARIABLE)
+					Sexp_nodes[arg_n].cached_variable_index = atoi(text);
+				else
+					Sexp_nodes[arg_n].cached_variable_index = check_sexp_node_text_for_sexp_variable(text);
+
 				Sexp_nodes[arg_n].flags |= SNF_CHECKED_ARG_FOR_VAR;
 			}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4367,7 +4367,7 @@ int get_sexp()
 			// was closing quote not found?
 			if (*(Mp + 1 + len) != '\"') {
 				error_display(0, "Unexpected end of quoted string embedded in sexp!");
-				skip_sexp(true);
+				skip_sexp(true);	// this will have the effect of skipping to the end of the file or string
 				return Locked_sexp_false;
 			}
 			// bump past closing quote

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -36649,7 +36649,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"arrays and pointers.\r\n\r\nPlease note that only numeric variables are supported.  Any "
 		"attempt to access a string variable will result in a value of SEXP_NAN_FOREVER being returned.\r\n\r\n"
 		"Takes 1 argument...\r\n"
-		"\t1:\tIndex of variable, from 0 to MAX_SEXP_VARIABLES - 1." },
+		"\t1:\tIndex of variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1." },
 
 	{ OP_SET_VARIABLE_BY_INDEX, "set-variable-by-index (originally variable-array-set)\r\n"
 		"\tSets the value of the variable specified by the given index.  This is an alternate way "
@@ -36657,7 +36657,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"arrays and pointers.\r\n\r\nIn contrast to get-variable-by-index, note that this sexp "
 		"*does* allow the modification of string variables.\r\n\r\n"
 		"Takes 2 arguments...\r\n"
-		"\t1:\tIndex of variable, from 0 to MAX_SEXP_VARIABLES - 1.\r\n"
+		"\t1:\tIndex of variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1.\r\n"
 		"\t2:\tValue to be set." },
 
 	{ OP_COPY_VARIABLE_FROM_INDEX, "copy-variable-from-index\r\n"
@@ -36665,14 +36665,14 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"This is very similar to get-variable-by-index, except the result is stored in a new variable rather than "
 		"being returned by value.  One important difference is that this sexp can be used to copy string variables as well as numeric variables.\r\n\r\n"
 		"Takes 2 arguments...\r\n"
-		"\t1:\tIndex of source variable, from 0 to MAX_SEXP_VARIABLES - 1.\r\n"
+		"\t1:\tIndex of source variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1.\r\n"
 		"\t2:\tDestination variable.  The type of this variable must match the type of the variable referenced by the index." },
 
 	{ OP_COPY_VARIABLE_BETWEEN_INDEXES, "copy-variable-between-indexes\r\n"
 		"\tRetrieves the value of the variable specified by the first index and stores it in the variable specified by the second index.  The first variable is not modified.\r\n\r\n"
 		"Takes 2 arguments...\r\n"
-		"\t1:\tIndex of source variable, from 0 to MAX_SEXP_VARIABLES - 1.\r\n"
-		"\t2:\tIndex of destination variable, from 0 to MAX_SEXP_VARIABLES - 1.  The types of both variables must match." },
+		"\t1:\tIndex of source variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1.\r\n"
+		"\t2:\tIndex of destination variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1.  The types of both variables must match." },
 
 	// Karajorma/jg18
 	{ OP_CONTAINER_ADD_TO_LIST, "add-to-list\r\n"
@@ -37489,7 +37489,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_STRING_CONCATENATE, "string-concatenate (deprecated in favor of string-concatenate-block)\r\n"
 		"\tConcatenates two strings, putting the result into a string variable.  If the length of the string will "
-		"exceed the sexp variable token limit (currently 32), it will be truncated.\r\n\r\n"
+		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH) " - 1), it will be truncated.\r\n\r\n"
 		"Takes 3 arguments...\r\n"
 		"\t1: First string\r\n"
 		"\t2: Second string\r\n"
@@ -37498,7 +37498,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_STRING_CONCATENATE_BLOCK, "string-concatenate-block\r\n"
 		"\tConcatenates two or more strings, putting the result into a string variable.  If the length of the string will "
-		"exceed the sexp variable token limit (currently 32), it will be truncated.\r\n\r\n"
+		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH) " - 1), it will be truncated.\r\n\r\n"
 		"Takes 3 or more arguments...\r\n"
 		"\t1: String variable to hold the result\r\n"
 		"\tRest: Strings to concatenate.  At least two of these are required; the rest are optional.\r\n" },
@@ -37506,7 +37506,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_STRING_GET_SUBSTRING, "string-get-substring\r\n"
 		"\tExtracts a substring from a parent string, putting the result into a string variable.  If the length of the string will "
-		"exceed the sexp variable token limit (currently 32), it will be truncated.\r\n\r\n"
+		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH) " - 1), it will be truncated.\r\n\r\n"
 		"Takes 3 arguments...\r\n"
 		"\t1: Parent string\r\n"
 		"\t2: Index at which the substring begins (0-based)\r\n"
@@ -37516,7 +37516,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_STRING_SET_SUBSTRING, "string-set-substring\r\n"
 		"\tReplaces a substring from a parent string with a new string, putting the result into a string variable.  If the length of the string will "
-		"exceed the sexp variable token limit (currently 32), it will be truncated.\r\n\r\n"
+		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH) " - 1), it will be truncated.\r\n\r\n"
 		"Takes 3 arguments...\r\n"
 		"\t1: Parent string\r\n"
 		"\t2: Index at which the substring begins (0-based)\r\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -33436,11 +33436,6 @@ const char *CTEXT(int n)
 
 			sexp_variable_index = Sexp_nodes[arg_n].cached_variable_index;
 		}
-		// just check the text of the argument for a variable
-		else
-		{
-			sexp_variable_index = check_sexp_node_text_for_sexp_variable(text);
-		}
 
 		// if we have a variable, return the variable value, else return the regular argument
 		if (sexp_variable_index >= 0)

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -35574,6 +35574,16 @@ bool usable_in_campaign(int op_id)
 	}
 }
 
+// For tokenizing in SEXP help
+#define MAX_SEXP_VARIABLES_1		249
+#define TOKEN_LENGTH_1				31
+#if (MAX_SEXP_VARIABLES_1) != (MAX_SEXP_VARIABLES - 1)
+#error MAX_SEXP_VARIABLES_1 must be equal to MAX_SEXP_VARIABLES - 1!
+#endif
+#if (TOKEN_LENGTH_1) != (TOKEN_LENGTH - 1)
+#error TOKEN_LENGTH_1 must be equal to TOKEN_LENGTH - 1!
+#endif
+
 // clang-format off
 SCP_vector<sexp_help_struct> Sexp_help = {
 	{ OP_PLUS, "Plus (Arithmetic operator)\r\n"
@@ -36733,7 +36743,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"arrays and pointers.\r\n\r\nPlease note that only numeric variables are supported.  Any "
 		"attempt to access a string variable will result in a value of SEXP_NAN_FOREVER being returned.\r\n\r\n"
 		"Takes 1 argument...\r\n"
-		"\t1:\tIndex of variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1." },
+		"\t1:\tIndex of variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES_1) "." },
 
 	{ OP_SET_VARIABLE_BY_INDEX, "set-variable-by-index (originally variable-array-set)\r\n"
 		"\tSets the value of the variable specified by the given index.  This is an alternate way "
@@ -36741,7 +36751,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"arrays and pointers.\r\n\r\nIn contrast to get-variable-by-index, note that this sexp "
 		"*does* allow the modification of string variables.\r\n\r\n"
 		"Takes 2 arguments...\r\n"
-		"\t1:\tIndex of variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1.\r\n"
+		"\t1:\tIndex of variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES_1) ".\r\n"
 		"\t2:\tValue to be set." },
 
 	{ OP_COPY_VARIABLE_FROM_INDEX, "copy-variable-from-index\r\n"
@@ -36749,14 +36759,14 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"This is very similar to get-variable-by-index, except the result is stored in a new variable rather than "
 		"being returned by value.  One important difference is that this sexp can be used to copy string variables as well as numeric variables.\r\n\r\n"
 		"Takes 2 arguments...\r\n"
-		"\t1:\tIndex of source variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1.\r\n"
+		"\t1:\tIndex of source variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES_1) ".\r\n"
 		"\t2:\tDestination variable.  The type of this variable must match the type of the variable referenced by the index." },
 
 	{ OP_COPY_VARIABLE_BETWEEN_INDEXES, "copy-variable-between-indexes\r\n"
 		"\tRetrieves the value of the variable specified by the first index and stores it in the variable specified by the second index.  The first variable is not modified.\r\n\r\n"
 		"Takes 2 arguments...\r\n"
-		"\t1:\tIndex of source variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1.\r\n"
-		"\t2:\tIndex of destination variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES) " - 1.  The types of both variables must match." },
+		"\t1:\tIndex of source variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES_1) ".\r\n"
+		"\t2:\tIndex of destination variable, from 0 to " SCP_TOKEN_TO_STR(MAX_SEXP_VARIABLES_1) ".  The types of both variables must match." },
 
 	// Karajorma/jg18
 	{ OP_CONTAINER_ADD_TO_LIST, "add-to-list\r\n"
@@ -37573,7 +37583,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_STRING_CONCATENATE, "string-concatenate (deprecated in favor of string-concatenate-block)\r\n"
 		"\tConcatenates two strings, putting the result into a string variable.  If the length of the string will "
-		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH) " - 1), it will be truncated.\r\n\r\n"
+		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH_1) "), it will be truncated.\r\n\r\n"
 		"Takes 3 arguments...\r\n"
 		"\t1: First string\r\n"
 		"\t2: Second string\r\n"
@@ -37582,7 +37592,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_STRING_CONCATENATE_BLOCK, "string-concatenate-block\r\n"
 		"\tConcatenates two or more strings, putting the result into a string variable.  If the length of the string will "
-		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH) " - 1), it will be truncated.\r\n\r\n"
+		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH_1) "), it will be truncated.\r\n\r\n"
 		"Takes 3 or more arguments...\r\n"
 		"\t1: String variable to hold the result\r\n"
 		"\tRest: Strings to concatenate.  At least two of these are required; the rest are optional.\r\n" },
@@ -37590,7 +37600,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_STRING_GET_SUBSTRING, "string-get-substring\r\n"
 		"\tExtracts a substring from a parent string, putting the result into a string variable.  If the length of the string will "
-		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH) " - 1), it will be truncated.\r\n\r\n"
+		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH_1) "), it will be truncated.\r\n\r\n"
 		"Takes 3 arguments...\r\n"
 		"\t1: Parent string\r\n"
 		"\t2: Index at which the substring begins (0-based)\r\n"
@@ -37600,7 +37610,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	// Goober5000
 	{ OP_STRING_SET_SUBSTRING, "string-set-substring\r\n"
 		"\tReplaces a substring from a parent string with a new string, putting the result into a string variable.  If the length of the string will "
-		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH) " - 1), it will be truncated.\r\n\r\n"
+		"exceed the sexp variable token limit (" SCP_TOKEN_TO_STR(TOKEN_LENGTH_1) "), it will be truncated.\r\n\r\n"
 		"Takes 3 arguments...\r\n"
 		"\t1: Parent string\r\n"
 		"\t2: Index at which the substring begins (0-based)\r\n"

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -581,6 +581,12 @@ BOOL CFREDDoc::OnOpenDocument(LPCTSTR pathname) {
 	return TRUE;
 }
 
+// For tokenizing
+#define MAX_FILENAME_LEN_1	31
+#if (MAX_FILENAME_LEN_1) != (MAX_FILENAME_LEN - 1)
+#error MAX_FILENAME_LEN_1 must be equal to MAX_FILENAME_LEN - 1!
+#endif
+
 BOOL CFREDDoc::OnSaveDocument(LPCTSTR pathname) {
 	CFred_mission_save save;
 	DWORD attrib;
@@ -591,7 +597,7 @@ BOOL CFREDDoc::OnSaveDocument(LPCTSTR pathname) {
 	auto len = strlen(filename);
 
 	if (len >= MAX_FILENAME_LEN)
-		Fred_main_wnd->MessageBox("The filename is too long for FreeSpace.  The game will not be able to read this file.  Max length, including extension, is " SCP_TOKEN_TO_STR(MAX_FILENAME_LEN-1) " characters.", NULL, MB_OK | MB_ICONEXCLAMATION);
+		Fred_main_wnd->MessageBox("The filename is too long for FreeSpace.  The game will not be able to read this file.  Max length, including extension, is " SCP_TOKEN_TO_STR(MAX_FILENAME_LEN_1) " characters.", NULL, MB_OK | MB_ICONEXCLAMATION);
 
 	// drop extension and copy to Mission_filename
 	auto ext_ch = strrchr(filename, '.');


### PR DESCRIPTION
This is a cleanup and upgrade of the SEXP parsing mechanism that makes the whole thing a lot more robust.  Error handling has been upgraded, several cases that previously caused a crash will fail gracefully, and some cases that previously caused an error can now be recovered with a straightforward "Attempt to load the mission failed".  The case that caused parsing to fail on Black Horizon mission 7, "Alone in the Void" -- a message name that started with an `@` character -- now works successfully.  The code has also been refactored and cleaned up a bit.