### PR TITLE
Custom lua action for mainhall esc keypress

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -970,8 +970,20 @@ void main_hall_do(float frametime)
 				case ESC_PRESSED:
 					// if there is a help overlay active, then don't quit the game - just kill the overlay
 					if (!help_overlay_active(Main_hall_overlay_id)) {
-						gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
-						main_hall_exit_game();
+
+						// if there is no custom script action then exit
+						if (Main_hall->esc_action.empty()) {
+							gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
+							main_hall_exit_game();
+						} else {
+							const char* lua = Main_hall->esc_action.c_str();
+							bool success = Script_system.EvalString(lua, lua);
+							if (!success)
+								Warning(LOCATION,
+									"mainhall '+Escape Key Action' script failed to evaluate \"%s\"; check your syntax",
+									lua);
+						}
+
 					} else { // kill the overlay
 						help_overlay_set_state(Main_hall_overlay_id,gr_screen.res,0);
 					}
@@ -2657,6 +2669,11 @@ void parse_one_main_hall(bool replace, int num_resolutions, int &hall_idx, int &
 	// tooltip y location
 	if (optional_string("+Tooltip Y:")) {
 		stuff_int(&m->region_yval);
+	}
+
+	//ESC key action
+	if (optional_string("+Escape Key Script Action:")) {
+		stuff_string(m->esc_action, F_RAW);
 	}
 
 	// ---------- done parsing the main hall data ----------

--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -148,6 +148,8 @@ public:
 
 	// action
 	SCP_vector<main_hall_region> regions;
+
+	SCP_string esc_action;
 	
 	bool default_readyroom = true;
 


### PR DESCRIPTION
BtA is modernizing the UI experience. PilotSelect is becoming a title screen that includes player selection among other options. As part of this, we're removing the Barracks. Players that want to switch pilots must return to the title screen.

In order to make this seamless I want a way to force the ESC keypress during the mainhall not always be "quit game", but instead return to the game title screen.

Unless #4533 is going to be completed soon, this small table feature allows customizing the last non-customizable aspect of each mainhall with a custom script action, similar the "Script" option for door clicks.