### PR TITLE
add model filename back into debug log

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3279,7 +3279,7 @@ int model_load(const  char* filename, int n_subsystems, model_subsystem* subsyst
 
 	TRACE_SCOPE(tracing::LoadModelFile);
 
-	nprintf(("Model", "Loading model '%s' into slot '%i'\n", filename, num ));
+	mprintf(( "Loading model '%s' into slot '%i'\n", filename, num ));
 
 	pm = new polymodel;	
 	Polygon_models[num] = pm;


### PR DESCRIPTION
In #4702 this log line was changed to the 'Model' category, which made it hidden by default.  This was missed in review but should be restored as it is a fairly important line.

Fixes #5507.