### PR TITLE
Preload subspace tunnel flag

### DIFF
--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -35,6 +35,7 @@ namespace Mission {
 		Toggle_start_chase_view,	// Toggles (versus the default) whether the player starts the mission in chase view - Goober5000
 		Neb2_fog_color_override,	// Whether to use explicit fog colors instead of checking the palette - Goober5000
 		Fullneb_background_bitmaps, // Show background bitmaps despite fullneb
+		Preload_subspace,			// Preload the subspace tunnel for both the sexp and specs checkbox (for scripts) - MjnMixael
 		
 		NUM_VALUES
 	};

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4573,7 +4573,7 @@ int get_sexp()
 
 			case OP_MISSION_SET_SUBSPACE:
 				// set flag for Goober5000
-				Subspace_sexp_used = true;
+				The_mission.flags.set(Mission::Mission_Flags::Preload_subspace);
 				break;
 
 			case OP_WARP_EFFECT:

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -165,8 +165,6 @@ int Nmodel_bitmap = -1;						// model texture
 
 bool Dynamic_environment = false;
 
-bool Subspace_sexp_used = false;
-
 bool Motion_debris_override = false;
 bool Motion_debris_enabled = true;
 
@@ -886,8 +884,6 @@ void stars_pre_level_init(bool clear_backgrounds)
 
 	// also clear the preload indexes
 	Preload_background_indexes.clear();
-
-	Subspace_sexp_used = false;
 
 	Dynamic_environment = false;
 	Motion_debris_override = false;
@@ -2090,7 +2086,7 @@ void stars_page_in()
 
 	// Initialize the subspace stuff
 
-	if ( Game_subspace_effect || Subspace_sexp_used ) {
+	if (Game_subspace_effect || (The_mission.flags[Mission::Mission_Flags::Preload_subspace])) {
 		Subspace_model_inner = model_load("subspace_small.pof", 0, nullptr);
 		Assert(Subspace_model_inner >= 0);
 

--- a/code/starfield/starfield.h
+++ b/code/starfield/starfield.h
@@ -53,8 +53,6 @@ extern matrix Nmodel_orient;
 extern int Nmodel_flags;
 extern int Nmodel_bitmap;
 
-extern bool Subspace_sexp_used;
-
 extern bool Motion_debris_override;
 extern bool Motion_debris_enabled;
 

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -957,6 +957,7 @@ BEGIN
     CONTROL         "Toggle Showing Goals In Briefing",IDC_TOGGLE_SHOWING_GOALS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,181,142,10
     CONTROL         "Mission End to Mainhall",IDC_END_TO_MAINHALL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,191,142,10
+    CONTROL         "Preload Subspace Tunnel",IDC_PRELOAD_SUBSPACE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,326,201,142,10
     CONTROL         "Override #Command in event messages",IDC_OVERRIDE_HASHCOMMAND,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,166,172,142,10
 END

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -75,6 +75,7 @@ CMissionNotesDlg::CMissionNotesDlg(CWnd* pParent /*=NULL*/) : CDialog(CMissionNo
 	m_toggle_showing_goals = FALSE;
 	m_end_to_mainhall = FALSE;
 	m_override_hashcommand = FALSE;
+	m_preload_subspace = FALSE;
 	m_max_hull_repair_val = 0.0f;
 	m_max_subsys_repair_val = 100.0f;
 	m_contrail_threshold = CONTRAIL_THRESHOLD_DEFAULT;
@@ -128,6 +129,7 @@ void CMissionNotesDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_TOGGLE_SHOWING_GOALS, m_toggle_showing_goals);
 	DDX_Check(pDX, IDC_END_TO_MAINHALL, m_end_to_mainhall);
 	DDX_Check(pDX, IDC_OVERRIDE_HASHCOMMAND, m_override_hashcommand);
+	DDX_Check(pDX, IDC_PRELOAD_SUBSPACE, m_preload_subspace);
 	DDX_Text(pDX, IDC_MAX_HULL_REPAIR_VAL, m_max_hull_repair_val);
 	DDV_MinMaxFloat(pDX, m_max_hull_repair_val, 0, 100);
 	DDX_Text(pDX, IDC_MAX_SUBSYS_REPAIR_VAL, m_max_subsys_repair_val);
@@ -297,6 +299,9 @@ void CMissionNotesDlg::OnOK()
 	// Override #Command
 	The_mission.flags.set(Mission::Mission_Flags::Override_hashcommand, m_override_hashcommand != 0);
 
+	// Preload Subspace Tunnel
+	The_mission.flags.set(Mission::Mission_Flags::Preload_subspace, m_preload_subspace != 0);
+
 	if ( flags != The_mission.flags ){
 		set_modified();
 	}
@@ -401,6 +406,7 @@ BOOL CMissionNotesDlg::OnInitDialog()
 	m_toggle_showing_goals = (The_mission.flags[Mission::Mission_Flags::Toggle_showing_goals]) ? 1 : 0;
 	m_end_to_mainhall = (The_mission.flags[Mission::Mission_Flags::End_to_mainhall]) ? 1 : 0;
 	m_override_hashcommand = (The_mission.flags[Mission::Mission_Flags::Override_hashcommand]) ? 1 : 0;
+	m_preload_subspace = (The_mission.flags[Mission::Mission_Flags::Preload_subspace]) ? 1 : 0;
 
 	m_loading_640=_T(The_mission.loading_screen[GR_640]);
 	m_loading_1024=_T(The_mission.loading_screen[GR_1024]);

--- a/fred2/missionnotesdlg.h
+++ b/fred2/missionnotesdlg.h
@@ -66,6 +66,7 @@ public:
 	BOOL		m_toggle_showing_goals;
 	BOOL		m_end_to_mainhall;
 	BOOL		m_override_hashcommand;
+	BOOL        m_preload_subspace;
 	float		m_max_hull_repair_val;
 	float		m_max_subsys_repair_val;
 	BOOL		m_contrail_threshold_flag;

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -1115,6 +1115,7 @@
 #define IDC_ALT_CLASS_UP                1602
 #define IDC_ALT_CLASS_DOWN              1603
 #define IDC_ALT_CLASS_INSERT            1604
+#define IDC_PRELOAD_SUBSPACE            1605
 #define IDC_SKY_FLAG_NO_LIGHTING        1609
 #define IDC_SKY_FLAG                    1610
 #define IDC_SKY_FLAG_XPARENT            1610

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -82,6 +82,7 @@ MissionSpecDialog::MissionSpecDialog(FredView* parent, EditorViewport* viewport)
 	connect(ui->toggle2DMission, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Mission_2d); });
 	connect(ui->toggleGoalsInBriefing, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Toggle_showing_goals); });
 	connect(ui->toggleMissionEndToMainhall, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::End_to_mainhall); });
+	connect(ui->togglePreloadSubspace, &QCheckBox::toggled, this, [this](bool param) {flagToggled(param, Mission::Mission_Flags::Preload_subspace); });
 
 	// AI Profiles
 	connect(ui->aiProfileCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &MissionSpecDialog::aiProfileIndexChanged);
@@ -253,6 +254,7 @@ void MissionSpecDialog::updateFlags() {
 	ui->toggleScramble->setChecked(flags[Mission::Mission_Flags::Scramble]);
 	ui->toggleHullRepair->setChecked(flags[Mission::Mission_Flags::Support_repairs_hull]);
 	ui->toggleTrail->setChecked(flags[Mission::Mission_Flags::Toggle_ship_trails]);
+	ui->togglePreloadSubspace->setChecked(flags[Mission::Mission_Flags::Preload_subspace]);
 }
 
 void MissionSpecDialog::updateAIProfiles() {

--- a/qtfred/ui/MissionSpecDialog.ui
+++ b/qtfred/ui/MissionSpecDialog.ui
@@ -342,6 +342,15 @@
                </color>
               </brush>
              </colorrole>
+             <colorrole role="PlaceholderText">
+              <brush brushstyle="NoBrush">
+               <color alpha="128">
+                <red>0</red>
+                <green>0</green>
+                <blue>0</blue>
+               </color>
+              </brush>
+             </colorrole>
             </active>
             <inactive>
              <colorrole role="Text">
@@ -353,11 +362,29 @@
                </color>
               </brush>
              </colorrole>
+             <colorrole role="PlaceholderText">
+              <brush brushstyle="NoBrush">
+               <color alpha="128">
+                <red>0</red>
+                <green>0</green>
+                <blue>0</blue>
+               </color>
+              </brush>
+             </colorrole>
             </inactive>
             <disabled>
              <colorrole role="Text">
               <brush brushstyle="SolidPattern">
                <color alpha="255">
+                <red>0</red>
+                <green>0</green>
+                <blue>0</blue>
+               </color>
+              </brush>
+             </colorrole>
+             <colorrole role="PlaceholderText">
+              <brush brushstyle="NoBrush">
+               <color alpha="128">
                 <red>0</red>
                 <green>0</green>
                 <blue>0</blue>
@@ -917,6 +944,13 @@
           </attribute>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="togglePreloadSubspace">
+          <property name="text">
+           <string>Preload Subspace Tunnel</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
@@ -1027,12 +1061,12 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="mt_multiGroup"/>
   <buttongroup name="m_flagGroup">
    <property name="exclusive">
     <bool>false</bool>
    </property>
   </buttongroup>
+  <buttongroup name="mt_multiGroup"/>
   <buttongroup name="mt_baseGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Adds a mission flag to preload the subspace tunnel. Allows for missions with scripts that call the effect to make sure it's preloaded without having to do some hacky sexp just to get that feature to work.

FRED support tested and working. qtFRED not so much because qtFRED currently CTD's just after startup on the SCP master branch, but I'm fairly certain it's implemented properly.