### PR TITLE
Set timer padding sexp

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1778,8 +1778,8 @@ void HudGaugeMissionTime::render(float  /*frametime*/)
 	int minutes=0;
 	int seconds=0;
 	
-	mission_time = f2fl(Missiontime);  // convert to seconds
-
+	mission_time = f2fl(Missiontime) + (float)The_mission.HUD_timer_padding;  // convert to seconds
+	
 	minutes=(int)(mission_time/60);
 	seconds=(int)mission_time%60;
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -24,6 +24,7 @@
 #include "gamesnd/eventmusic.h"
 #include "globalincs/alphacolors.h"
 #include "globalincs/linklist.h"
+#include "hud/hud.h"
 #include "hud/hudescort.h"
 #include "hud/hudets.h"
 #include "hud/hudsquadmsg.h"
@@ -6530,7 +6531,7 @@ void mission::Reset()
 	cutscenes.clear( );
 
 	gravity = vmd_zero_vector;
-
+	HUD_timer_padding = 0;
 	volumetrics.reset();
 }
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -145,6 +145,7 @@ typedef struct mission {
 	tl::optional<volumetric_nebula> volumetrics;
 	sound_env	sound_environment;
 	vec3d   gravity;
+	int     HUD_timer_padding;
 
 	// Goober5000
 	int	command_persona;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -373,6 +373,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "time-docked",					OP_TIME_DOCKED,							3,	3,			SEXP_INTEGER_OPERATOR,	},
 	{ "time-undocked",					OP_TIME_UNDOCKED,						3,	3,			SEXP_INTEGER_OPERATOR,	},
 	{ "time-to-goal",					OP_TIME_TO_GOAL,						1,	1,			SEXP_INTEGER_OPERATOR,	},	// tcrayford
+	{ "set-hud-timer-padding",			OP_SET_HUD_TIME_PAD,					1,	1,			SEXP_ACTION_OPERATOR,	},  // MjnMixael
 
 	//Conditionals Category
 	{ "cond",							OP_COND,								1,	INT_MAX,	SEXP_CONDITIONAL_OPERATOR,},
@@ -19156,6 +19157,18 @@ int sexp_time_to_goal(int n)
 	return time;
 }
 
+void sexp_set_hud_time_pad(int n)
+{
+	bool is_nan, is_nan_forever;
+	int pad;
+
+	pad = eval_num(n, is_nan, is_nan_forever);
+	if (is_nan || is_nan_forever)
+		return;
+
+	The_mission.HUD_timer_padding = pad;
+}
+
 // Karajorma
 void sexp_reset_orders (int  /*n*/)
 {
@@ -27814,6 +27827,11 @@ int eval_sexp(int cur_node, int referenced_node)
 				sexp_val = sexp_time_to_goal(node);
 				break;
 
+			case OP_SET_HUD_TIME_PAD:
+				sexp_set_hud_time_pad(node);
+				sexp_val = SEXP_TRUE;
+				break;
+
 
 			// Karajorma
 			case OP_RESET_ORDERS:
@@ -29623,6 +29641,7 @@ int query_operator_return_type(int op)
 		case OP_NOP:
 		case OP_GOALS_ID:
 		case OP_SEND_MESSAGE:
+		case OP_SET_HUD_TIME_PAD:
 		case OP_SELF_DESTRUCT:
 		case OP_NEXT_MISSION:
 		case OP_END_CAMPAIGN:
@@ -30420,6 +30439,9 @@ int query_operator_argument_type(int op, int argnum)
 
 		case OP_TIME_TO_GOAL:
 				return OPF_SHIP;
+
+		case OP_SET_HUD_TIME_PAD:
+			return OPF_POSITIVE;
 
 		case OP_WAS_DESTROYED_BY_DELAY:
 			if (argnum == 0)
@@ -34408,6 +34430,7 @@ int get_category(int op_id)
 		case OP_TIME_DOCKED:
 		case OP_TIME_UNDOCKED:
 		case OP_TIME_TO_GOAL:
+		case OP_SET_HUD_TIME_PAD:
 			return OP_CATEGORY_TIME;
 
 		case OP_SHIELDS_LEFT:
@@ -36297,6 +36320,14 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tReturns the number of seconds until a ship reaches its waypoint\r\n\r\n"
 		"Returns a number value.  Takes 1 argument...\r\n"
 		"\t1:\tName of ship to check waypoint time." },
+
+	// MjnMixael
+	{ OP_SET_HUD_TIME_PAD, "Set HUD Timer Padding (Action operator)\r\n"
+		"\tSets an additional padding that is added only to the visible clock on the HUD. "
+		"It does not affect the actual mission time or the mission log! Time is an illusion "
+		"and the illusion here exists only on the HUD.\r\n\r\n"
+		"Takes 1 argument...\r\n"
+		"\t1:\tThe amount of time to add to the clock in seconds." },
 
 	{ OP_AFTERBURNER_LEFT, "Afterburner left\r\n"
 		"\tReturns a ship's current engine energy as a percentage.\r\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -30441,7 +30441,7 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_SHIP;
 
 		case OP_SET_HUD_TIME_PAD:
-			return OPF_POSITIVE;
+			return OPF_NUMBER;
 
 		case OP_WAS_DESTROYED_BY_DELAY:
 			if (argnum == 0)

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -350,6 +350,7 @@ enum : int {
 	OP_TIME_DOCKED,
 	OP_TIME_UNDOCKED,
 	OP_TIME_TO_GOAL, // tcrayford
+	OP_SET_HUD_TIME_PAD, // MjnMixael
 	
 	// OP_CATEGORY_STATUS
 	

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1459,6 +1459,22 @@ ADE_FUNC(getMissionTime, l_Mission, nullptr, "Game time in seconds since the mis
 	return ade_set_args(L, "x", Missiontime);
 }
 
+ADE_VIRTVAR(MissionHUDTimerPadding,
+	l_Mission,
+	"number",
+	"Gets or sets padding currently applied to the HUD mission timer.",
+	"number",
+	"the padding in seconds")
+{
+	int pad;
+
+	if (ADE_SETTING_VAR && ade_get_args(L, "*i", &pad)) {
+		The_mission.HUD_timer_padding = pad;
+	}
+
+	return ade_set_args(L, "i", The_mission.HUD_timer_padding);
+}
+
 //WMC - These are in freespace.cpp
 ADE_FUNC(loadMission, l_Mission, "string missionName", "Loads a mission", "boolean", "True if mission was loaded, otherwise false")
 {


### PR DESCRIPTION
BtA has a couple missions with "time skips". In order to help sell the illusion we dreamt up this sexp that simply pads out the HUD timer with N seconds. It's entirely an illusion. Does not affect actual mission time or the mission log in any way.

Also adds a virtvar to get/set the same value.