### PR TITLE
Fix animated background bitmaps rendering with incorrect framerate

### DIFF
--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -108,10 +108,12 @@ typedef struct starfield_bitmap_instance {
 	int div_x, div_y;								// # of x and y divisions
 	angles ang;										// angles from FRED
 	int star_bitmap_index;							// index into starfield_bitmap array
+	int timestamp;
+	int cur_frame;
 	int n_verts;
 	vertex *verts;
 
-	starfield_bitmap_instance() : scale_x(1.0f), scale_y(1.0f), div_x(1), div_y(1), star_bitmap_index(0), n_verts(0), verts(NULL) {
+	starfield_bitmap_instance() : scale_x(1.0f), scale_y(1.0f), div_x(1), div_y(1), star_bitmap_index(0), timestamp(0), cur_frame(0), n_verts(0), verts(NULL) {
 		ang.p = 0.0f;
 		ang.b = 0.0f;
 		ang.h = 0.0f;
@@ -1502,6 +1504,36 @@ void stars_draw_sun_glow(int sun_n)
 	//gr_zbuffer_set(zbuff);
 }
 
+int stars_get_next_frame(starfield_bitmap_instance &inst, starfield_bitmap &bm, int timestamp_ms)
+{
+	int bitmap_id = bm.bitmap_id;
+	
+	// After frame 0 we check if we should animate
+	if (inst.timestamp > 0) {
+
+		// Has the ms-per-frame passed since the last frame update?
+		if ((timestamp_ms - inst.timestamp) >= (1000 / bm.fps)) {
+			bitmap_id = inst.cur_frame + 1;
+
+			// Should we loop back to start?
+			if (bitmap_id >= (bm.bitmap_id + bm.n_frames)) {
+				bitmap_id = bm.bitmap_id;
+			}
+
+		} else {
+			return inst.cur_frame;
+		}
+	} else { //draw frame 0 at start
+		bitmap_id = bm.bitmap_id;
+	}
+
+	// Save the timestamp and bitmap id for the next frame check
+	inst.timestamp = timestamp_ms;
+	inst.cur_frame = bitmap_id;
+
+	return bitmap_id;
+}
+
 void stars_draw_bitmaps(int show_bitmaps)
 {
 	GR_DEBUG_SCOPE("Draw Bitmaps");
@@ -1549,13 +1581,13 @@ void stars_draw_bitmaps(int show_bitmaps)
 
 		if (Starfield_bitmaps[star_index].xparent) {
 			if (Starfield_bitmaps[star_index].fps) {
-				bitmap_id = Starfield_bitmaps[star_index].bitmap_id + ((timestamp() / (int)(Starfield_bitmaps[star_index].fps)) % Starfield_bitmaps[star_index].n_frames);
+				bitmap_id = stars_get_next_frame(Starfield_bitmap_instances[idx], Starfield_bitmaps[star_index], timestamp());
 			} else {
 				bitmap_id = Starfield_bitmaps[star_index].bitmap_id;
 			}
 		} else {
 			if (Starfield_bitmaps[star_index].fps) {
-				bitmap_id = Starfield_bitmaps[star_index].bitmap_id + ((timestamp() / (int)(Starfield_bitmaps[star_index].fps)) % Starfield_bitmaps[star_index].n_frames);
+				bitmap_id = stars_get_next_frame(Starfield_bitmap_instances[idx], Starfield_bitmaps[star_index], timestamp());
 				blending = true;
 				alpha = 0.9999f;
 			} else {

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1511,9 +1511,12 @@ int stars_get_next_frame(starfield_bitmap_instance &inst, starfield_bitmap &bm, 
 	// After frame 0 we check if we should animate
 	if (inst.timestamp > 0) {
 
+		int mpf = 1000 / bm.fps; // The expected ms per frame for this animation
+		int time_passed = timestamp_ms - inst.timestamp; // Amount of time passed since last check
+
 		// Has the ms-per-frame passed since the last frame update?
-		if ((timestamp_ms - inst.timestamp) >= (1000 / bm.fps)) {
-			bitmap_id = inst.cur_frame + 1;
+		if (time_passed >= mpf) {
+			bitmap_id = inst.cur_frame + (time_passed / mpf);
 
 			// Should we loop back to start?
 			if (bitmap_id >= (bm.bitmap_id + bm.n_frames)) {


### PR DESCRIPTION
Fixes #5538 by implementing better formula for frame calculation. The previous formula would always result in at least a 1 frame increase in the animation for every mission frame drawn unless the framerate of the animation was >= the current game's framerate.

This newer formula calculates the ms an animation frame should be drawn for. If timestamp >= that amount of time is when we go to the next frame. Otherwise we draw the current frame again.