### PR TITLE
Add death message as a dialog HV

### DIFF
--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -240,7 +240,8 @@ void popupdead_start()
 			scripting::hook_param("IsTimeStopped", 'b', false),
 			scripting::hook_param("IsStateRunning", 'b', true),
 			scripting::hook_param("IsInputPopup", 'b', false),
-			scripting::hook_param("IsDeathPopup", 'b', true));
+			scripting::hook_param("IsDeathPopup", 'b', true),
+			scripting::hook_param("DeathMessage", 's', Player->death_message.c_str()));
 
 		scripting::hooks::OnDialogInit->run(paramList);
 		if (scripting::hooks::OnDialogInit->isOverride(paramList))

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -362,7 +362,8 @@ const std::shared_ptr<OverridableHook<>> OnDialogInit = OverridableHook<>::Facto
 		{"IsStateRunning", "boolean", "True if the underlying state is still being processed and rendered."},
 		{"IsInputPopup", "boolean", "True if this popup is for entering text."},
 		{"IsDeathPopup", "boolean", "True if this popup is an in-mission death popup and should be styled as such."},
-		{"AllowedInput", "string", "A string of characters allowed to be present in the input popup. Nil if not an input popup."}
+		{"AllowedInput", "string", "A string of characters allowed to be present in the input popup. Nil if not an input popup."},
+		{"DeathMessage", "string", "The death message if the dialog is a death popup. Nil if not a death popup."}
 	 });
 
 const std::shared_ptr<OverridableHook<>> OnDialogFrame = OverridableHook<>::Factory("On Dialog Frame",


### PR DESCRIPTION
Adds the death message that is normally drawn to the screen as an HV of the death popup hook so that SCPUI can #dothingswithit