### PR TITLE
Update build image with curl and jq preinstalled

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-8a6bbbe
+    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -31,11 +31,6 @@ jobs:
           # cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
           # setup-python: 'false'
           # aqtversion: ==1.1.3
-      # seriously, what the fuck why do i have to do this
-      - name: Add curl to the container
-        run: |    
-          apt-get update -y 
-          apt -y install curl jq
       - uses: actions/checkout@v1
         name: Checkout
         with:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Linux
     needs: create_release   # Don't run this job until create_release is done and successful
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-8a6bbbe
+    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -87,10 +87,6 @@ jobs:
           # cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
           # setup-python: 'false'
           # aqtversion: ==1.1.3
-      - name: Add curl to the container
-        run: |    
-          apt-get update -y 
-          apt -y install curl jq
       - uses: actions/checkout@v1
         # checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.
         name: Checkout

--- a/.github/workflows/build-standalone.yaml
+++ b/.github/workflows/build-standalone.yaml
@@ -20,10 +20,6 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
-    - name: Add curl to the container
-      run: |    
-        apt-get update -y
-        apt -y install curl jq
     - uses: actions/checkout@v1
       name: Checkout
       with:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-8a6bbbe
+    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -31,10 +31,6 @@ jobs:
           # cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
           # setup-python: 'false'
           # aqtversion: ==1.1.3
-      - name: Add curl to the container
-        run: |    
-          apt-get update -y
-          apt -y install curl jq
       - uses: actions/checkout@v1
         name: Checkout
         with:

--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -25,7 +25,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-8a6bbbe
+    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -22,7 +22,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-8a6bbbe
+    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -38,10 +38,6 @@ jobs:
           # cached: ${{ steps.cache-qt-lin.outputs.cache-hit }}
           # setup-python: 'false'
           # aqtversion: ==1.1.3
-      - name: Add curl to the container
-        run: |    
-          apt-get update -y
-          apt -y install curl jq
       - uses: actions/checkout@v1
         name: Checkout
         with:


### PR DESCRIPTION
The install step in the CI pipeline is no longer needed after this change and has been removed.