### PR TITLE
fix flags in modular weapon entries being cleared

### DIFF
--- a/code/globalincs/flagset.h
+++ b/code/globalincs/flagset.h
@@ -100,6 +100,20 @@ class flagset {
 		return *this;
 	}
 
+	template<typename TIter>
+	flagset<T>& set_multiple_from_source(const flagset<T>& source, TIter begin, TIter end) {
+		auto current = begin;
+		while (current != end) {
+			if (source[*current]) {
+				set(*current, true);
+			}
+
+			current = std::next(current);
+		}
+
+		return *this;
+	}
+
 	flagset<T>& remove(T idx) {
 		return set(idx, false);
 	}


### PR DESCRIPTION
When weapon flags are parsed in a modular table and override the previous set of flags, certain flags must be kept to preserve the behavior of the weapon.  The previous `preset_wi_flags` technique only worked if all such flags (homing, has-display-name, even whether the weapon turns) were set in the same modular table.  If a modular table overrode the flags but didn't specify those lines over again, mysterious and subtle bugs would occur.

This modifies the flag parsing to explicitly preserve all appropriate flags from the existing weapon entry, which fixes the bug.  It also allows all of the flags to be specified in one place, rather than scattering `preset_wi_flags` assignments throughout `parse_weapon`.  And this also adds quite a few flags to the flag list that were not handled at all under the previous design.

Finally this fixes a few incorrect assignments of default values to fields that should only happen the first time a weapon entry is parsed.