### PR TITLE
some streaming animation fixes

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -719,7 +719,7 @@ void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool m
 			else if (ge->draw == true) {
 				// currently only for lua streaminganim objects
 				// and don't draw them unless requested...
-				gr_bitmap_uv(x, y, ge->width, ge->height, ge->u0, ge->v0, ge->u1, ge->v1, GR_RESIZE_NONE);
+				gr_bitmap_uv(x, y, ge->width, ge->height, ge->u0, ge->v0, ge->u1, ge->v1, ge->resize_mode);
 			}
 		}
 	}

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -519,7 +519,7 @@ void generic_render_png_stream(generic_anim* ga)
  * @param [in] *ga  animation data
  * @param [in] frametime  how long this frame took
  */
-void generic_anim_render_fixed_frame_delay(generic_anim* ga, float frametime)
+void generic_anim_render_fixed_frame_delay(generic_anim* ga, float frametime, float alpha = 1.0f)
 {
 	float keytime = 0.0;
 
@@ -580,10 +580,19 @@ void generic_anim_render_fixed_frame_delay(generic_anim* ga, float frametime)
 			} else {
 				generic_render_eff_stream(ga);
 			}
-			gr_set_bitmap(ga->bitmap_id);
+
+			if (alpha == 1.0f) {
+				gr_set_bitmap(ga->bitmap_id);
+			} else {
+				gr_set_bitmap(ga->bitmap_id, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha);
+			}
 		}
 		else {
-			gr_set_bitmap(ga->first_frame + ga->current_frame);
+			if (alpha == 1.0f) {
+				gr_set_bitmap(ga->first_frame + ga->current_frame);
+			} else {
+				gr_set_bitmap(ga->first_frame + ga->current_frame, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha);
+			}
 		}
 	}
 }
@@ -703,7 +712,7 @@ void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool m
 		generic_anim_render_variable_frame_delay(ga, frametime, a);
 	}
 	else {
-		generic_anim_render_fixed_frame_delay(ga, frametime);
+		generic_anim_render_fixed_frame_delay(ga, frametime, a);
 	}
 
 	if(ga->num_frames > 0) {

--- a/code/graphics/generic.h
+++ b/code/graphics/generic.h
@@ -67,6 +67,7 @@ public:
 	float u0, v0, u1, v1;
 	float alpha;
 	bool draw;
+	int resize_mode;
 
 	generic_extras()
 		: width(0), height(0)
@@ -74,6 +75,7 @@ public:
 		, u1(1.0f), v1(1.0f)
 		, alpha(1.0f)
 		, draw(true)
+		, resize_mode(0)	// GR_RESIZE_NONE
 	{}
 };
 

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -60,6 +60,8 @@ static float lua_Opacity = 1.0f;
 static int lua_Opacity_type = GR_ALPHABLEND_FILTER;
 static int lua_ResizeMode = GR_RESIZE_NONE;
 
+int get_resize_mode() { return lua_ResizeMode; }
+
 //****SUBLIBRARY: Graphics/Cameras
 ADE_LIB_DERIV(l_Graphics_Cameras, "Cameras", NULL, "Cameras", l_Graphics);
 

--- a/code/scripting/api/libs/graphics.h
+++ b/code/scripting/api/libs/graphics.h
@@ -7,8 +7,9 @@ namespace api {
 
 extern model_draw_list *Current_scene;
 
+extern int get_resize_mode();
+
 DECLARE_ADE_LIB(l_Graphics);
 
 }
 }
-

--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -1,6 +1,7 @@
 //
 //
 
+#include "scripting/api/libs/graphics.h"
 #include "streaminganim.h"
 #include "freespace.h"
 
@@ -268,7 +269,10 @@ ADE_FUNC(process, l_streaminganim, "[number x1, number y1, number x2, number y2,
 		if (x2 != INT_MAX) ge.width = x2 - x1;
 		if (y2 != INT_MAX) ge.height = y2 - y1;
 
-		// note; generic_anim_render will default to GR_RESIZE_NONE when ge is provided
+		// use the currently active resize mode for scripting
+		// (generic_anim_render will use this field when ge is provided)
+		ge.resize_mode = get_resize_mode();
+
 		generic_anim_render(&sah->ga, flFrametime, x1, y1, false, &ge);
 	}
 

--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -11,7 +11,18 @@ namespace api {
 bool streaminganim_h::IsValid() {
 	return (ga.num_frames > 0);
 }
-streaminganim_h::streaminganim_h(const char* filename) {
+streaminganim_h::streaminganim_h(const char* real_filename) {
+	char filename[MAX_FILENAME_LEN];
+
+	// make sure no one passed an extension
+	memset(filename, 0, MAX_FILENAME_LEN);
+	strncpy(filename, real_filename, MAX_FILENAME_LEN - 1);
+	char* p = strrchr(filename, '.');
+	if (p) {
+		mprintf(("Someone passed an extension to streaminganim_h for file '%s'\n", real_filename));
+		*p = 0;
+	}
+
 	generic_anim_init(&ga, filename);
 }
 streaminganim_h::~streaminganim_h() {


### PR DESCRIPTION
1. Since other functions in the scripting API remove extensions before loading the files, and since the internal functions expect them to be removed, the streaming anim API should handle that too.
2. Make streaming animations obey the current scripting resize mode.
3. Make streaming animations obey the passed alpha value.