### PR TITLE
fix $Movie subtitle font: for custom fonts

### DIFF
--- a/code/cutscene/movie.cpp
+++ b/code/cutscene/movie.cpp
@@ -174,10 +174,15 @@ void determine_display_positions(Player* player, PlaybackState* state) {
 void initialize_player_state(Player* player, PlaybackState* state) {
 	determine_display_positions(player, state);
 
-	state->subtitle_font = font::FontManager::getFontIndex(Movie_subtitle_font);
+	if (!Movie_subtitle_font.empty()) {
+		state->subtitle_font = font::FontManager::getFontIndex(Movie_subtitle_font);
 
-	if (state->subtitle_font < 0) {
-		Warning(LOCATION, "Failed to load subtitle font '%s'! Subtitles will be disabled.", Movie_subtitle_font.c_str());
+		if (state->subtitle_font < 0) {
+			Warning(LOCATION, "Failed to load subtitle font '%s'! Subtitles will be disabled.", Movie_subtitle_font.c_str());
+		}
+	}
+	else if (font::FontManager::numberOfFonts() > 0) {
+		state->subtitle_font = 0;	// if not explicitly specified, default to the first available font
 	}
 }
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1377,7 +1377,7 @@ void mod_table_reset()
 	Splash_logo_center = false;
 	Use_tabled_strings_for_default_language = false;
 	Dont_preempt_training_voice = false;
-	Movie_subtitle_font = "font01.vf";
+	Movie_subtitle_font = "";
 	Enable_scripts_in_fred = false;
 	Window_icon_path = "app_icon_sse";
 	Disable_built_in_translations = false;


### PR DESCRIPTION
The default movie subtitle font is font01.vf, but mods with custom font tables might not use this font.  So this changes the handling slightly so that the movie player will use whatever the first available font is.

Follow-up to #1523.  Fixes a sometimes spurious warning in mod initialization.