### PR TITLE
update GitHub actions for nightly builds

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -181,6 +181,7 @@ jobs:
         with:
           name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
           path: ${{ github.workspace }}/build/install/*
+
   windows_zip:
     name: Build Windows distribution zip
     needs: build_windows
@@ -328,3 +329,14 @@ jobs:
           DATACORDER_USER: ${{ secrets.DATACORDER_USER }}
           DATACORDER_SSHPASS: ${{ secrets.DATACORDER_PASSWORD }}
         run: $GITHUB_WORKSPACE/ci/linux/upload_dist_package.sh nightly
+
+  post_build:
+    name: Post builds to Nebula and Forum
+    needs: [linux_zip, windows_zip, mac_zip]
+    uses: ./.github/workflows/post-build-nightly.yaml
+    with:
+      linux_result: ${{ needs.linux_zip.result }}
+      windows_result: ${{ needs.windows_zip.result }}
+      mac_result: ${{ needs.mac_zip.result }}
+      releaseTag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/post-build-nightly.yaml
+++ b/.github/workflows/post-build-nightly.yaml
@@ -1,0 +1,82 @@
+name: Post Nightly builds
+
+on:
+  workflow_call:
+    # Trigger when called by other workflows
+    inputs:
+      linux_result:   # job.result; either success, failure, canceled or skipped
+        required: true
+        type: string
+      windows_result: # job.result
+        required: true
+        type: string
+      mac_result: # job.result
+        required: true
+        type: string
+      releaseTag:
+        required: true
+        type: string
+
+  workflow_dispatch:
+    # Trigger manually from Github
+    inputs:
+      releaseTag:
+        description: Nightly Tag
+        required: true
+        type: string
+
+env:
+  GITHUB_REPO: ${{ github.repository }} # repo this workflow was called from
+  INDIEGAMES_USER: ${{ secrets.INDIEGAMES_USER }}
+  INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
+  NEBULA_USER: ${{ secrets.NEBULA_USER }}
+  NEBULA_PASSWORD: ${{ secrets.NEBULA_PASSWORD }}
+  HLP_API: ${{ secrets.HLP_API }}
+  HLP_KEY: ${{ secrets.HLP_KEY }}
+  RELEASE_TAG: ${{ inputs.releaseTag }}
+
+jobs:
+  post_builds:
+    name: Post builds on Nebula and the forums
+    runs-on: ubuntu-latest
+    steps:
+      - name: Caller
+        # Name of what called this yaml.  Used to debug auto/manual step being triggered
+        run: echo "github.event_name= ${{ github.event_name }}"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install Python dependencies
+        run: pip install -r ci/post/requirements.txt
+
+      - name: Post Builds (Auto trigger)
+        if: ${{ (github.event_name == 'workflow_call') || (github.event_name == 'push') }}
+        env:
+          LINUX_RESULT: ${{ inputs.linux_result }}
+          WINDOWS_RESULT: ${{ inputs.windows_result }}
+          MAC_RESULT: ${{ inputs.mac_result }}
+          GITHUB_REPO: ${{ github.repository }} # repo this workflow was called from
+          INDIEGAMES_USER: ${{ secrets.INDIEGAMES_USER }}
+          INDIEGAMES_SSHPASS: ${{ secrets.INDIEGAMES_PASSWORD }}
+          NEBULA_USER: ${{ secrets.NEBULA_USER }}
+          NEBULA_PASSWORD: ${{ secrets.NEBULA_PASSWORD }}
+          HLP_API: ${{ secrets.HLP_API }}
+          HLP_KEY: ${{ secrets.HLP_KEY }}
+          RELEASE_TAG: ${{ inputs.releaseTag }}
+        run: python ci/post/main.py nightly
+
+      - name: Post Builds (Manual trigger)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        # assume user knows what they're doing...
+        env:
+          LINUX_RESULT: success
+          WINDOWS_RESULT: success
+          MAC_RESULT: success
+        run: |
+          echo "releaseTag= ${{ env.RELEASE_TAG }}"
+          echo "repository= ${{ github.repository }}"
+          python ci/post/main.py nightly


### PR DESCRIPTION
This is a proposed update to allow GitHub Actions to run the nightly build in the same way that it currently runs the release build.  Assuming this works, the nightlybuild repository will no longer be needed.

This simply edits the config files for nightly builds in a similar way as the existing config files for release builds, so reviews and testing will be vital.

In draft status pending additional feedback.