### PR TITLE
handle extension mismatch in event music

### DIFF
--- a/code/sound/ffmpeg/FFmpegWaveFile.cpp
+++ b/code/sound/ffmpeg/FFmpegWaveFile.cpp
@@ -211,6 +211,20 @@ bool FFmpegWaveFile::Open(const char* pszFilename, bool keep_ext)
 			auto res = cf_find_file_location(pszFilename, CF_TYPE_ANY);
 
 			if (!res.found) {
+#ifndef NDEBUG
+				char truncated_filename[MAX_FILENAME_LEN];
+				strcpy_s(truncated_filename, filename);
+				auto ext_ch = strrchr(truncated_filename, '.');
+				if (ext_ch != nullptr)
+					*ext_ch = '\0';
+
+				// see if the file exists with a different extension
+				res = cf_find_file_location_ext(truncated_filename, NUM_AUDIO_EXT, audio_ext_list, CF_TYPE_ANY);
+				if (res.found) {
+					Warning(LOCATION, "File %s was not found with its specified extension, but another file %s exists in the modpack.  Please update the extension and adjust audio specifications if necessary.", filename, res.name_ext.c_str());
+				}
+#endif
+
 				throw FFmpegException("File not found.");
 			}
 


### PR DESCRIPTION
~~Currently, menu music will trim the extension and look for both OGG and WAV files, but event music will use the exact extension specified.  This behavior dates all the way back to commit f969eb52a2 from 2010.  There doesn't seem to be an obvious reason for this, and it leads to a bug in FSPort where in some cases music will not play during a mission, in situations where the table uses .wav but the music pack provides .ogg.  So, let's make event music extension-agnostic.~~

Currently, menu music will trim the extension and look for both OGG and WAV files, but event music will use the exact extension specified.  This is intended but could lead to unexpected results in mods, so display a warning for the modder.