### PR TITLE
fix crash in campaign editor

### DIFF
--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -670,8 +670,6 @@ void update_map_window() {
 
 	render_frame();	// "do the rendering!"
 
-	gr_flip();
-
 	show_control_mode();
 	process_pending_messages();
 


### PR DESCRIPTION
The crash in #5514 appears to be caused by some of the graphics code not being in the expected state for the synchronization.  Looking at the code in `render_frame()`, a `gr_flip()` happens after one frame ends and before the next frame begins.  That implies that this `gr_flip()` should not be here, as it is in the middle of a frame.  For additional evidence, `gr_flip()` modifies the "uniform buffer manager" state, and that is part of the stack trace preceding the crash.  Removing this `gr_flip()` fixes the crash.

The strange thing is that this code *doesn't run at all* while the campaign editor is active.  I verified this by adding a MessageBox in place of `gr_flip()`; the MessageBox doesn't display until the campaign editor is exited.  And yet, FRED crashes with `gr_flip()` present and doesn't crash with it removed.  This calls for a new category of bug; I propose "spookybug", from spooky action-at-a-distance.

Fixes #5514.