### PR TITLE
Fix issues with newer Nvidia driver

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -3,8 +3,6 @@
 
 #include "shadows.sdr" //! #include "shadows.sdr"
 
-in vec3 beamVec;
-in vec3 lightPosition;
 out vec4 fragOut0;
 
 uniform sampler2D ColorBuffer;
@@ -26,6 +24,11 @@ layout (std140) uniform globalDeferredData {
 
 	float invScreenWidth;
 	float invScreenHeight;
+};
+
+layout (std140) uniform matrixData {
+	mat4 modelViewMatrix;
+	mat4 projMatrix;
 };
 
 layout (std140) uniform lightData {
@@ -63,23 +66,24 @@ vec3 ExpandLightSize(in vec3 lightDir, in vec3 reflectDir) {
 	vec3 centerToRay = max(dot(lightDir, reflectDir),sourceRadius) * reflectDir - lightDir;
 	return lightDir + centerToRay * clamp(sourceRadius/length(centerToRay), 0.0, 1.0);
 }
-void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 lightDir, out float attenuation, out float area_normalisation)
+void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 lightDirOut, out float attenuation, out float area_normalisation)
 {
 	if (lightType == LT_DIRECTIONAL) {
-		lightDir = normalize(lightPosition);
+		lightDirOut = normalize(lightDir);
 		attenuation = 1.0;
 		area_normalisation = 1.0;
 	} else {
+		vec3 lightPosition = modelViewMatrix[3].xyz;
 		// Positional light source
 		if (lightType == LT_POINT) {
-			lightDir = lightPosition - position.xyz;
-			float dist = length(lightDir);
+			lightDirOut = lightPosition - position.xyz;
+			float dist = length(lightDirOut);
 
 			// this chunk is unneccessary if sourceRadius= 0.0, but let's avoid a branch.
-			// given a sphere of radius sourceRadius centered at lightDir,
-			// move lightDir towards the ray defined by reflectDir
-			lightDir = ExpandLightSize(lightDir, reflectDir);
-			dist = length(lightDir);
+			// given a sphere of radius sourceRadius centered at lightDirOut,
+			// move lightDirOut towards the ray defined by reflectDir
+			lightDirOut = ExpandLightSize(lightDirOut, reflectDir);
+			dist = length(lightDirOut);
 			// Energy conservation term
 			float alpha_adjust = clamp(alpha + (sourceRadius/(2*dist)), 0.0, 1.0);
 			area_normalisation = alpha/alpha_adjust;
@@ -93,7 +97,7 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 		} 
 		else if (lightType == LT_TUBE) {  // Tube light
-			
+			vec3 beamVec = vec3(modelViewMatrix * vec4(0.0, 0.0, -scale.z, 0.0));
 			vec3 beamDir = normalize(beamVec);
 			//The actual 'lighting element' is shorter than the light volume cylinder
 			//To compensate the light is moved forward along the beam one radius and the length shortened
@@ -113,15 +117,15 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			vec3 r = d - a_t * dot(d, a_t) - c * dot(d,c);
 			float neardist = dot(r, r)/dot(b_t, r);
 			// Move along the beam by the distance we calculated
-			lightDir = sourceDir - beamDir * clamp(neardist, 0.0, beamLength);
+			lightDirOut = sourceDir - beamDir * clamp(neardist, 0.0, beamLength);
 			// Somebody with a symbolic expression simplifier or a wrinklier brain than me
 			// should figure out how to optimise these calcs - qaz
 
 
 			// this chunk is unneccessary if sourceRadius = 0.0, but let's avoid a branch.
 			// Same principle as in LT_POINT, treat chosen location as a spherelight.
-			lightDir = ExpandLightSize(lightDir, reflectDir);
-			float dist = length(lightDir);
+			lightDirOut = ExpandLightSize(lightDirOut, reflectDir);
+			float dist = length(lightDirOut);
 			// Energy conservation term
 			float alpha_adjust = min(alpha + (sourceRadius/(2*dist)), 1.0);
 			area_normalisation = alpha/alpha_adjust;
@@ -134,9 +138,9 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 		} 
 		else if (lightType == LT_CONE) {
-			lightDir = lightPosition - position.xyz;
-			float coneDot = dot(normalize(-lightDir), coneDir);
-			float dist = length(lightDir);
+			lightDirOut = lightPosition - position.xyz;
+			float coneDot = dot(normalize(-lightDirOut), coneDir);
+			float dist = length(lightDirOut);
 			attenuation = 1.0 - clamp(sqrt(dist / lightRadius), 0.0, 1.0);
 			area_normalisation = 1.0;
 
@@ -155,7 +159,7 @@ void GetLightInfo(vec3 position, in float alpha, in vec3 reflectDir, out vec3 li
 			}
 		}
 		attenuation *= attenuation;
-		lightDir = normalize(lightDir);
+		lightDirOut = normalize(lightDirOut);
 	}
 }
 

--- a/code/def_files/data/effects/deferred-v.sdr
+++ b/code/def_files/data/effects/deferred-v.sdr
@@ -27,17 +27,11 @@ layout (std140) uniform lightData {
 	float sourceRadius;
 };
 
-out vec3 lightPosition;
-out vec3 beamVec;
 void main()
 {
 	if (lightType == LT_DIRECTIONAL) {
 		gl_Position = vec4(vertPosition.xyz, 1.0);
-		lightPosition = lightDir;
 	} else {
 		gl_Position = projMatrix * modelViewMatrix * vec4(vertPosition.xyz * scale, 1.0);
-		lightPosition = modelViewMatrix[3].xyz;
-		if(lightType == LT_TUBE)
-			beamVec = vec3(modelViewMatrix * vec4(0.0, 0.0, -scale.z, 0.0));
 	}
 }


### PR DESCRIPTION
What I _think_ happened here is that the Nvidia compiler saw the calculation of ``lightPosition`` in the vertex shader (which turns out to be a dynamically uniform expression) as optimizable, but somehow messed up how its passed as a parameter to the fragment shader. If this calculation is moved to the fragment shader, which should be performance-equivalent since it's a dynamically uniform expression, the issue goes away.
Fixes #5430