### PR TITLE
fix persistent sounds not clearing their tally

### DIFF
--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -639,7 +639,7 @@ void obj_snd_do_frame()
 
 				// non-looping sounds that have already played once need to be removed from the object sound list
 				int sound_index = obj_snd_find(objp, osp);
-				obj_snd_delete(objp, sound_index, false);
+				obj_snd_delete(objp, sound_index);
 
 				// don't corrupt the iterating loop (next iteration will move to the deleted osp's next sibling)
 				osp = osp_prev;
@@ -776,17 +776,15 @@ int obj_snd_assign(int objnum, gamesnd_id sndnum, const vec3d *pos, int flags, c
 //
 // parameters:  objnum		=> index of object that sound is being removed from.
 //				index		=> index of sound in objsnd_num
-//				stop_sound	=> whether we stop it (defaults to true)
 //
-void obj_snd_delete(object *objp, int index, bool stop_sound)
+void obj_snd_delete(object *objp, int index)
 {
 	Assert(index > -1 && index < (int) objp->objsnd_num.size());
 
 	obj_snd *osp = &Objsnds[objp->objsnd_num[index]];
 
 	//Stop the sound
-	if (stop_sound)
-		obj_snd_stop(objp, index);
+	obj_snd_stop(objp, index);
 
 	// remove objp from the obj_snd_list
 	list_remove( &obj_snd_list, osp );

--- a/code/object/objectsnd.h
+++ b/code/object/objectsnd.h
@@ -44,7 +44,7 @@ void	obj_snd_do_frame();
 int	obj_snd_assign(int objnum, gamesnd_id sndnum, const vec3d *pos, int flags = 0, const ship_subsys *associated_sub = nullptr);
 
 //Delete specific persistent sound on object
-void obj_snd_delete(object *objp, int index, bool stop_sound = true);
+void obj_snd_delete(object *objp, int index);
 
 // if sndnum is not -1, deletes all instances of the given sound within the object
 void	obj_snd_delete_type(int objnum, gamesnd_id sndnum = gamesnd_id(), ship_subsys *ss = NULL);


### PR DESCRIPTION
When a non-looping persistent sound expires, `obj_snd_stop()` actually does need to be called.  Even though the sound is no longer playing, the `Num_obj_sounds_playing` tally needs to be decremented, otherwise it will eventually exceed its limit and prevent any additional persistent sounds from playing.  And it turns out `obj_snd_stop()` returns gracefully for sounds that aren't playing.

Follow-up to #3510.  Fixes a bug that appears to have been around since retail.