### PR TITLE
Follow-up for briefing icon scaling

### DIFF
--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -96,7 +96,7 @@ static void bitmap_ex_internal(int x,
 							   bool aabitmap,
 							   bool mirror,
 							   color* clr,
-							   int scale = 100) {
+							   float scale_factor = 1.0f) {
 	if ((w < 1) || (h < 1)) {
 		return;
 	}
@@ -118,8 +118,10 @@ static void bitmap_ex_internal(int x,
 
 	bm_get_info(gr_screen.current_bitmap, &bw, &bh);
 
-	bw = (bw * scale) / 100;
-	bh = (bh * scale) / 100;
+	if (scale_factor != 1.0f) {
+		bw = static_cast<int>(bw * scale_factor);
+		bh = static_cast<int>(bh * scale_factor);
+	}
 
 	u0 = (i2fl(sx) / i2fl(bw));
 	v0 = (i2fl(sy) / i2fl(bh));
@@ -163,7 +165,7 @@ static void bitmap_ex_internal(int x,
 	draw_textured_quad(&render_mat, x1, y1, u0, v0, x2, y2, u1, v1);
 }
 
-void gr_aabitmap(int x, int y, int resize_mode, bool mirror, int scale) {
+void gr_aabitmap(int x, int y, int resize_mode, bool mirror, float scale_factor) {
 	if (gr_screen.mode == GR_STUB) {
 		return;
 	}
@@ -174,8 +176,10 @@ void gr_aabitmap(int x, int y, int resize_mode, bool mirror, int scale) {
 
 	bm_get_info(gr_screen.current_bitmap, &w, &h);
 
-	w = (w * scale) / 100;
-	h = (h * scale) / 100;
+	if (scale_factor != 1.0f) {
+		w = static_cast<int>(w * scale_factor);
+		h = static_cast<int>(h * scale_factor);
+	}
 
 	if (resize_mode != GR_RESIZE_NONE && (gr_screen.custom_size || (gr_screen.rendering_to_texture != -1))) {
 		do_resize = 1;
@@ -239,7 +243,7 @@ void gr_aabitmap(int x, int y, int resize_mode, bool mirror, int scale) {
 					   true,
 					   mirror,
 					   &gr_screen.current_color,
-					   scale);
+					   scale_factor);
 }
 void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode, bool mirror) {
 	if (gr_screen.mode == GR_STUB) {

--- a/code/graphics/render.h
+++ b/code/graphics/render.h
@@ -25,8 +25,9 @@ void gr_flash_alpha(int r, int g, int b, int a);
  * @param y The y-coordinate of the draw call
  * @param resize_mode The resize mode for translating the coordinated
  * @param mirror @c true to mirror the image
+ * @param scale_factor a multiplier for the width and height of the bitmap
  */
-void gr_aabitmap(int x, int y, int resize_mode = GR_RESIZE_FULL, bool mirror = false, int scale = 100);
+void gr_aabitmap(int x, int y, int resize_mode = GR_RESIZE_FULL, bool mirror = false, float scale_factor = 1.0f);
 /**
  * @brief Draws a grey-scale bitmap multiplied with the current color
  * @param x The x-coordinate of the draw call

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2407,10 +2407,11 @@ int hud_anim_load(hud_anim *ha)
  * @param reverse		Play animation in reverse (default 0)
  * @param resize_mode		Resize for non-standard resolutions
  * @param mirror		Mirror along y-axis so icon points left instead of right
+ * @param scale_factor	Multiplier for the width and height
  *
  * @returns  1 on success, 0 on failure
  */
-int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int hold_last, int reverse, int resize_mode, bool mirror)
+int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int hold_last, int reverse, int resize_mode, bool mirror, float scale_factor)
 {
 	int framenum;
 
@@ -2434,7 +2435,7 @@ int hud_anim_render(hud_anim *ha, float frametime, int draw_alpha, int loop, int
 	if(emp_should_blit_gauge()){
 		gr_set_bitmap(ha->first_frame + framenum);
 		if ( draw_alpha ){
-			gr_aabitmap(ha->sx, ha->sy, resize_mode, mirror);
+			gr_aabitmap(ha->sx, ha->sy, resize_mode, mirror, scale_factor);
 		} else {
 			gr_bitmap(ha->sx, ha->sy, resize_mode);
 		}

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -149,7 +149,7 @@ void hud_num_make_mono(char *num_str, int font_num = font::FONT1);
 // functions for handling hud animations
 void hud_anim_init(hud_anim *ha, int sx, int sy, const char *filename);
 void hud_frames_init(hud_frames *hf);
-int	hud_anim_render(hud_anim *ha, float frametime, int draw_alpha=0, int loop=1, int hold_last=0, int reverse=0,int resize_mode=GR_RESIZE_FULL, bool mirror = false);
+int	hud_anim_render(hud_anim *ha, float frametime, int draw_alpha=0, int loop=1, int hold_last=0, int reverse=0,int resize_mode=GR_RESIZE_FULL, bool mirror = false, float scale_factor = 1.0f);
 int	hud_anim_load(hud_anim *ha);
 
 // functions for displaying the support view popup

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -900,7 +900,7 @@ void hud_config_render_gauges(bool API_Access)
 				resize = GR_RESIZE_NONE;
 			}
 
-			gr_aabitmap(HC_gauge_coords[i].x, HC_gauge_coords[i].y, resize, false, (int)(HC_gauge_scale * 100));
+			gr_aabitmap(HC_gauge_coords[i].x, HC_gauge_coords[i].y, resize, false, HC_gauge_scale);
 		}
 		
 		/*

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -115,7 +115,7 @@ extern const float		BRIEF_TEXT_WIPE_TIME;		// time in seconds for wipe to occur
 
 typedef struct brief_icon {
 	int		x,y,w,h;
-	int		scale;
+	float	scale_factor;
 	int		hold_x, hold_y;	// 2D screen position of icon, used to place animations
 	int		ship_class;
 	int		modelnum;
@@ -128,8 +128,7 @@ typedef struct brief_icon {
 	vec3d	pos;
 	char		label[MAX_LABEL_LEN];
 	char		closeup_label[MAX_LABEL_LEN];
-	hud_anim	fadein_anim;
-	hud_anim	fadeout_anim;
+	hud_anim	fade_anim;
 	hud_anim	highlight_anim;
 	int		flags;				// BI_* flags defined above
 } brief_icon;
@@ -300,7 +299,7 @@ void brief_init_screen(int multiplayer_flag);
 void brief_render_map(int stage_num, float frametime);
 void brief_set_new_stage(vec3d *pos, matrix *orient, int time, int stage_num);
 void brief_camera_move(float frametime, int stage_num);
-void brief_render_icon(int stage_num, int icon_num, float frametime, int selected = 0, float w_scale_factor = 1.0f, float h_scale_factor = 1.0f);
+void brief_render_icon(int stage_num, int icon_num, float frametime, int selected = 0, float scale_factor = 1.0f);
 void brief_render_icon_line(int stage_num, int line_num);
 void brief_init_map();
 void brief_icons_init();

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1574,9 +1574,12 @@ void parse_briefing(mission * /*pm*/, int flags)
 				if (optional_string("$closeup label:")) {
 					stuff_string(bi->closeup_label, F_MESSAGE, MAX_LABEL_LEN);
 				}
-				bi->scale = 100;
+
+				bi->scale_factor = 1.0f;
 				if (optional_string("$icon scale:")) {
-					stuff_int(&bi->scale);
+					int scale;
+					stuff_int(&scale);
+					bi->scale_factor = scale / 100.0f;
 				}
 
 				if (optional_string("+id:")) {

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1507,10 +1507,18 @@ void brief_check_for_anim(bool api_access, int api_x, int api_y)
 	for ( i = 0; i < bs->num_icons; i++ ) {
 		bi = &bs->icons[i];
 		brief_common_get_icon_dimensions(&iw, &ih, bi);
+
+		// could be a scaled icon
+		if (bi->scale_factor != 1.0f) {
+			iw = static_cast<int>(iw * bi->scale_factor);
+			ih = static_cast<int>(ih * bi->scale_factor);
+		}
+
 		if ( mx < bi->x ) continue;
 		if ( mx > (bi->x + iw) ) continue;
 		if ( my < bi->y ) continue;
 		if ( my > (bi->y + ih) ) continue;
+
 		// if we've got here, must be a hit
 		break;
 	}

--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -481,7 +481,7 @@ void briefing_editor_dlg::update_data(int update)
 			strcpy_s(ptr->icons[m_last_icon].closeup_label, buf);
 
 			if (m_icon_scale > 0)
-				ptr->icons[m_last_icon].scale = m_icon_scale;
+				ptr->icons[m_last_icon].scale_factor = m_icon_scale / 100.0f;
 
 			if ( m_hilight )
 				ptr->icons[m_last_icon].flags |= BI_HIGHLIGHT;
@@ -602,7 +602,7 @@ void briefing_editor_dlg::update_data(int update)
 		m_icon_team = ptr->icons[m_cur_icon].team;
 		m_icon_label = ptr->icons[m_cur_icon].label;
 		m_icon_closeup_label = ptr->icons[m_cur_icon].closeup_label;
-		m_icon_scale = ptr->icons[m_cur_icon].scale;
+		m_icon_scale = static_cast<int>(ptr->icons[m_cur_icon].scale_factor * 100.0f);
 		m_ship_type = ptr->icons[m_cur_icon].ship_class;
 		m_id = ptr->icons[m_cur_icon].id;
 		enable = TRUE;
@@ -868,8 +868,10 @@ void briefing_editor_dlg::draw_icon(object *objp)
 	if (m_cur_stage < 0)
 		return;
 
-	brief_render_icon(m_cur_stage, objp->instance, 1.0f/30.0f, objp->flags[Object::Object_Flags::Marked],
-		(float) True_rw / Briefing_window_resolution[0], (float) True_rh / Briefing_window_resolution[1]);
+	// average the w and h scale factors
+	float scale_factor = 0.5f * ((float)True_rw / Briefing_window_resolution[0] + (float)True_rh / Briefing_window_resolution[1]);
+
+	brief_render_icon(m_cur_stage, objp->instance, 1.0f/30.0f, objp->flags[Object::Object_Flags::Marked], scale_factor);
 }
 
 void briefing_editor_dlg::batch_render()
@@ -1080,7 +1082,7 @@ void briefing_editor_dlg::OnMakeIcon()
 	biconp->pos = pos;
 	biconp->flags = 0;
 	biconp->id = Cur_brief_id++;
-	biconp->scale = 100;
+	biconp->scale_factor = 1.0f;
 
 	biconp->modelnum = -1;
 	biconp->model_instance_num = -1;

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1203,13 +1203,13 @@ int CFred_mission_save::save_briefing()
 					}
 				}
 
-				if (Mission_save_format != FSO_FORMAT_RETAIL) {
+				if (Mission_save_format != FSO_FORMAT_RETAIL && bi->scale_factor != 1.0f) {
 					if (optional_string_fred("$icon scale:"))
 						parse_comments();
 					else
 						fout("\n$icon scale:");
 
-					fout(" %d", bi->scale);
+					fout(" %d", static_cast<int>(bi->scale_factor * 100.0f));
 				}
 
 				if (optional_string_fred("+id:"))
@@ -1224,20 +1224,29 @@ int CFred_mission_save::save_briefing()
 				fout(" %d", (bi->flags & BI_HIGHLIGHT) ? 1 : 0);
 
 				if (Mission_save_format != FSO_FORMAT_RETAIL) {
-					required_string_fred("$mirror:");
-					parse_comments();
+					if (optional_string_fred("$mirror:"))
+						parse_comments();
+					else
+						fout("\n$mirror:");
+
 					fout(" %d", (bi->flags & BI_MIRROR_ICON) ? 1 : 0);
 				}
 
 				if ((Mission_save_format != FSO_FORMAT_RETAIL) && (bi->flags & BI_USE_WING_ICON)) {
-					required_string_fred("$use wing icon:");
-					parse_comments();
+					if (optional_string_fred("$use wing icon:"))
+						parse_comments();
+					else
+						fout("\n$use wing icon:");
+
 					fout(" %d", (bi->flags & BI_USE_WING_ICON) ? 1 : 0);
 				}
 
 				if ((Mission_save_format != FSO_FORMAT_RETAIL) && (bi->flags & BI_USE_CARGO_ICON)) {
-					required_string_fred("$use cargo icon:");
-					parse_comments();
+					if (optional_string_fred("$use cargo icon:"))
+						parse_comments();
+					else
+						fout("\n$use cargo icon:");
+
 					fout(" %d", (bi->flags & BI_USE_CARGO_ICON) ? 1 : 0);
 				}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1232,13 +1232,13 @@ int CFred_mission_save::save_briefing()
 					}
 				}
 
-				if (save_format != MissionFormat::RETAIL) {
+				if (save_format != MissionFormat::RETAIL && bi->scale_factor != 1.0f) {
 					if (optional_string_fred("$icon scale:"))
 						parse_comments();
 					else
 						fout("\n$icon scale:");
 
-					fout(" %d", bi->scale);
+					fout(" %d", static_cast<int>(bi->scale_factor * 100.0f));
 				}
 
 				if (optional_string_fred("+id:")) {
@@ -1254,20 +1254,29 @@ int CFred_mission_save::save_briefing()
 				fout(" %d", (bi->flags & BI_HIGHLIGHT) ? 1 : 0);
 
 				if (save_format != MissionFormat::RETAIL) {
-					required_string_fred("$mirror:");
-					parse_comments();
+					if (optional_string_fred("$mirror:"))
+						parse_comments();
+					else
+						fout("\n$mirror:");
+
 					fout(" %d", (bi->flags & BI_MIRROR_ICON) ? 1 : 0);
 				}
 
 				if ((save_format != MissionFormat::RETAIL) && (bi->flags & BI_USE_WING_ICON)) {
-					required_string_fred("$use wing icon:");
-					parse_comments();
+					if (optional_string_fred("$use wing icon:"))
+						parse_comments();
+					else
+						fout("\n$use wing icon:");
+
 					fout(" %d", (bi->flags & BI_USE_WING_ICON) ? 1 : 0);
 				}
 
 				if ((save_format != MissionFormat::RETAIL) && (bi->flags & BI_USE_CARGO_ICON)) {
-					required_string_fred("$use cargo icon:");
-					parse_comments();
+					if (optional_string_fred("$use cargo icon:"))
+						parse_comments();
+					else
+						fout("\n$use cargo icon:");
+
 					fout(" %d", (bi->flags & BI_USE_CARGO_ICON) ? 1 : 0);
 				}
 


### PR DESCRIPTION
This extends the handling of scaling to all briefing icon types and uses the standard method of saving briefing icon info as the old method did not account for all cases.