### PR TITLE
Fix for modular table contrail initialization

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4607,6 +4607,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		}
 
 		trail_info *ci = &sip->ct_info[sip->ct_count++];
+		trail_info_init(ci);
 		
 		required_string("+Offset:");
 		stuff_vec3d(&ci->pt);
@@ -4630,8 +4631,6 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				ci->a_decay_exponent = 1.0f;
 			}
 		}
-		else if (first_time)
-			ci->a_decay_exponent = 1.0f;
 
 		required_string("+Max Life:");
 		stuff_float(&ci->max_life);
@@ -4657,8 +4656,6 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				ci->texture_stretch = 1.0f;
 			}
 		}
-		else if (first_time)
-			ci->texture_stretch = 1.0f;
 
 		if (optional_string("+Faded Out Sections:") ) {
 			stuff_int(&ci->n_fade_out_sections);

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -24,6 +24,21 @@
 static int Num_trails = 0;
 static trail Trails;
 
+void trail_info_init(trail_info* t_info) {
+	t_info->pt = vmd_zero_vector;
+	t_info->w_start = 0.0f;
+	t_info->w_end = 0.0f;
+	t_info->a_start = 0.0f;
+	t_info->a_end = 0.0f;
+	t_info->a_decay_exponent = 1.0f;
+	t_info->max_life = 0.0f;
+	t_info->stamp = 0;
+	generic_bitmap_init(&t_info->texture);
+	t_info->texture_stretch = 1.0f;
+	t_info->n_fade_out_sections = 0;
+	t_info->spread = 0.0f;
+}
+
 // Reset everything between levels
 void trail_level_init()
 {

--- a/code/weapon/trails.h
+++ b/code/weapon/trails.h
@@ -52,6 +52,8 @@ typedef struct trail {
 
 } trail;
 
+void trail_info_init(trail_info* t_info);
+
 // Call at the start of freespace to init trails
 
 // Call at start of level to reinit all missilie trail stuff


### PR DESCRIPTION
If new contrails are defined in a modular tbm, certain fields may not be initialized correctly (namely `a_decay_exponent` and `texture_stretch`, which must be 1), since they are typically only initialized on the ship's first definition, so I've added an explicit trail info initializer. Ship contrails are the only one with this issue, since they are the only circumstance of an unknown, variable amount of trail_infos.