### PR TITLE
Make invalid model_subsystem model_nums a hard error

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7400,7 +7400,10 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 	{
 		model_system = &(sinfo->subsystems[i]);
 		if (model_system->model_num < 0) {
-			Warning (LOCATION, "Invalid subobj_num or model_num in subsystem '%s' on ship type '%s'.\nNot linking into ship!\n\n(This warning means that a subsystem was present in the table entry and not present in the model\nit should probably be removed from the table or added to the model.)\n", model_system->subobj_name, sinfo->name );
+			Error(LOCATION, "Invalid subobj_num or model_num in subsystem '%s' on ship type '%s'.\nNot linking into ship!\n\n"
+				"This warning means that a subsystem was present in the table entry and not present in the model."
+				"It should be removed from the table or added to the model.\n"
+				"Ensure subsystem names are spelled correctly, and that submodels or special points intended to be subsystems have '$special=subsystem' in their properties.", model_system->subobj_name, sinfo->name );
 			continue;
 		}
 


### PR DESCRIPTION
I have looked at making this fail more gracefully, but the system is quite entangled. The `ship_info` has already allocated these `model_subsytem`s and they are implicitly trusted by the very subsystem itself, as well as any other ship classes which use the same model, which will *also* lean on those same `model_subsystem`s. Failing to find the model entry fails to set up a lot of data which rapidly escalates into memory errors. Consider this PR a request for help on how to make this gracefully fail as much as an advocacy to make it an error.

I have seen this surprise users at least a dozen times now. It introduces bizarre bugs and behaviors which users have difficulty reconciling with the nature of the warning, and, in the most recent case, *earlier instances of this issue on different ships masked the existence of the issue on another ship* (presumably some shenanigans with `ship_subsys_free_list`) further making it difficult for the user to diagnose the problem. Users cannot be expected to reason about memory errors, and so, we should not let the program proceed.