### PR TITLE
Save player after changing campaign in scpui

### DIFF
--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -535,6 +535,7 @@ ADE_FUNC(selectCampaign,
 	}
 
 	campaign_select_campaign(filename);
+	Pilot.save_player();
 
 	return ADE_RETURN_TRUE;
 }


### PR DESCRIPTION
SCPUI loads the campaign file from the player file after leaving the Barracks and in a few other cases. Normally this is fine, but if the player recently changed campaigns, the player save file will be out of date. So this one-line change forces saving the player file whenever the campaign is changed in SCPUI.