### PR TITLE
Bugfix missile time for 'aspect invulnerability time'

### DIFF
--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -61,11 +61,12 @@ int collide_weapon_weapon( obj_pair * pair )
 			A_radius *= 2;		// Makes bombs easier to hit
 		}
 		
+		float time_alive = f2fl(Missiontime - wpA->creation_time);
 		if ((The_mission.ai_profile->flags[AI::Profile_Flags::Aspect_invulnerability_fix]) && (wipA->is_locked_homing()) && (wpA->homing_object != &obj_used_list)) {
-			if ( (wipA->max_lifetime - wpA->lifeleft) < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
+			if ( time_alive < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
 				return 0;
 		}
-		else if ( (wipA->lifetime - wpA->lifeleft) < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
+		else if ( time_alive < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
 			return 0;
 	}
 
@@ -73,11 +74,13 @@ int collide_weapon_weapon( obj_pair * pair )
 		if (!(wipB->wi_flags[Weapon::Info_Flags::No_radius_doubling])) {
 			B_radius *= 2;		// Makes bombs easier to hit
 		}
+
+		float time_alive = f2fl(Missiontime - wpB->creation_time);
 		if ((The_mission.ai_profile->flags[AI::Profile_Flags::Aspect_invulnerability_fix]) && (wipB->is_locked_homing()) && (wpB->homing_object != &obj_used_list)) {
-			if ( (wipB->max_lifetime - wpB->lifeleft) < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
+			if ( time_alive < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
 				return 0;
 		}
-		else if ( (wipB->lifetime - wpB->lifeleft) < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
+		else if ( time_alive < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
 			return 0;
 	}
 


### PR DESCRIPTION
`max_lifetime - lifeleft` is not necessarily an accurate way to gauge how long a weapon has existed, partly because it can be messed with and fall at variable rates, but also (in the case which exposed this bug) because scripts can set it to arbitrary values, causing this code to make the weapon invulnerable longer (or shorter) than it should. `Missiontime - creation_time` is preferred for this reason, and all other code which needs to know how long a weapon has existed uses that.

This is fairly niche and the script could easily work around it so I don't consider it a priority for the stable.