### PR TITLE
add a maneuver-despite-engines flag

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1316,7 +1316,7 @@ void ai_turn_towards_vector(vec3d* dest, object* objp, vec3d* slide_vec, vec3d* 
 	//	Don't allow a ship to turn if it has no engine strength.
 	// AL 3-12-98: objp may not always be a ship!
 	if ( (objp->type == OBJ_SHIP) && !(flags & AITTV_VIA_SEXP) ) {
-		if (ship_get_subsystem_strength(&Ships[objp->instance], SUBSYSTEM_ENGINE) <= 0.0f)
+		if (!Ships[objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_get_subsystem_strength(&Ships[objp->instance], SUBSYSTEM_ENGINE) <= 0.0f)
 			return;
 	}
 
@@ -9791,7 +9791,7 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 
 	// Goober5000 - moved out here to save calculations
 	if (dock_mode != DOA_DOCK_STAY)
-		if (ship_get_subsystem_strength(&Ships[docker_objp->instance], SUBSYSTEM_ENGINE) <= 0.0f)
+		if (!Ships[docker_objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_get_subsystem_strength(&Ships[docker_objp->instance], SUBSYSTEM_ENGINE) <= 0.0f)
 			return 9999.9f;
 
 	//	If dockee has moved much, then path will be recreated.
@@ -12156,7 +12156,7 @@ object *get_wing_leader(int wingnum)
 
 	//	If this ship is disabled, try another ship in the wing.
 	int n = 0;
-	while (ship_get_subsystem_strength(&Ships[ship_num], SUBSYSTEM_ENGINE) == 0.0f) {
+	while (!Ships[ship_num].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_get_subsystem_strength(&Ships[ship_num], SUBSYSTEM_ENGINE) == 0.0f) {
 		n++;
 
 		if (n >= wingp->current_count) {

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -125,25 +125,25 @@ void update_ets(object* objp, float fl_frametime)
 	//					 This will translate to 71% max speed at 50% engines, and 31% max speed at 10% engines
 	//
 
-	float eng_current_strength;
+	float engine_aggregate_strength;
 	if (ship_p->flags[Ship::Ship_Flags::Maneuver_despite_engines]) {
-		// Since prev_engine_aggregate_strength isn't used anywhere else, it's ok to fake setting the strength to 100% here
-		eng_current_strength = 1.0f;
+		// Pretend our strength is 100% when this flag is active
+		engine_aggregate_strength = 1.0f;
 	} else {
-		eng_current_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE);
+		engine_aggregate_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE);
 	}
 
-	// only update max speed if aggregate engine health has changed
+	// only update max speed if engine_aggregate_strength has changed
 	// which helps minimize amount of overrides to max speed
-	if (eng_current_strength != ship_p->prev_engine_aggregate_strength) {
+	if (engine_aggregate_strength != ship_p->prev_engine_aggregate_strength) {
 		ets_update_max_speed(objp);
-		ship_p->prev_engine_aggregate_strength = eng_current_strength;
+		ship_p->prev_engine_aggregate_strength = engine_aggregate_strength;
 
 		// check if newly updated max speed should be reduced due to engine damage
 		// don't let engine strength affect max speed when playing on lowest skill level
 		if ((objp != Player_obj) || (Game_skill_level > 0)) {
-			if (eng_current_strength < SHIP_MIN_ENGINES_FOR_FULL_SPEED) {
-				objp->phys_info.max_vel.xyz.z *= fl_sqrt(eng_current_strength);
+			if (engine_aggregate_strength < SHIP_MIN_ENGINES_FOR_FULL_SPEED) {
+				objp->phys_info.max_vel.xyz.z *= fl_sqrt(engine_aggregate_strength);
 			}
 		}
 	}

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -125,10 +125,16 @@ void update_ets(object* objp, float fl_frametime)
 	//					 This will translate to 71% max speed at 50% engines, and 31% max speed at 10% engines
 	//
 
-	float eng_current_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE);
+	float eng_current_strength;
+	if (ship_p->flags[Ship::Ship_Flags::Maneuver_despite_engines]) {
+		// Since prev_engine_aggregate_strength isn't used anywhere else, it's ok to fake setting the strength to 100% here
+		eng_current_strength = 1.0f;
+	} else {
+		eng_current_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE);
+	}
 
 	// only update max speed if aggregate engine health has changed
-	// which helps minimze amount of overrides to max speed
+	// which helps minimize amount of overrides to max speed
 	if (eng_current_strength != ship_p->prev_engine_aggregate_strength) {
 		ets_update_max_speed(objp);
 		ship_p->prev_engine_aggregate_strength = eng_current_strength;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -548,6 +548,7 @@ ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::Always_death_scream,			"always-death-scream"},
 	{ Ship_Flags::No_builtin_messages,			"no-builtin-messages"},
 	{ Ship_Flags::Scramble_messages,			"scramble-messages"},
+	{ Ship_Flags::Maneuver_despite_engines,		"maneuver-despite-engines" },
 };
 
 ship_flag_description Ship_flag_descriptions[] = {
@@ -584,6 +585,7 @@ ship_flag_description Ship_flag_descriptions[] = {
 	{ Ship_Flags::Always_death_scream,			"Ship will always send a death message when destroyed."},
 	{ Ship_Flags::No_builtin_messages,			"Ship will not send any persona messages."},
 	{ Ship_Flags::Scramble_messages,			"All messages sent from this ship will appear scrambled, as if the ship had been hit by an EMP."},
+	{ Ship_Flags::Maneuver_despite_engines,		"Ship can maneuver even if its engines are disabled or disrupted" },
 };
 
 extern const size_t Num_ship_flag_names = sizeof(Ship_flag_names) / sizeof(ship_flag_name);
@@ -16147,11 +16149,15 @@ int ship_secondary_bank_has_ammo(int shipnum)
 // returns 1 if ship is able to warp, otherwise return 0
 int ship_engine_ok_to_warp(ship *sp)
 {
-	// disabled ships can't warp
-	if (sp->flags[Ship_Flags::Disabled])
+	if (sp->flags[Ship_Flags::Warp_broken] || sp->flags[Ship_Flags::Warp_never])
 		return 0;
 
-	if (sp->flags[Ship_Flags::Warp_broken] || sp->flags[Ship_Flags::Warp_never])
+	// ships which can maneuver can also warp
+	if (sp->flags[Ship_Flags::Maneuver_despite_engines])
+		return 1;
+
+	// disabled ships can't warp
+	if (sp->flags[Ship_Flags::Disabled])
 		return 0;
 
 	float engine_strength = ship_get_subsystem_strength(sp, SUBSYSTEM_ENGINE);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -646,7 +646,7 @@ public:
 	int	engine_recharge_index;			// index into array holding the engine recharge rate
 	float	weapon_energy;						// Number of EUs in energy reserves
 	int	next_manage_ets;					// timestamp for when ai can next modify ets ( -1 means never )
-	float prev_engine_aggregate_strength;	// aggregate engine health to allow for minimizing overrides to max speed --Asteroth and wookieejedi
+	float prev_engine_aggregate_strength;	// used only in update_ets() to allow for minimizing overrides to max speed --Asteroth and wookieejedi
 
 	flagset<Ship::Ship_Flags>	flags;		// flag variable to contain ship state
 	int	reinforcement_index;				// index into reinforcement struct or -1

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -646,7 +646,7 @@ public:
 	int	engine_recharge_index;			// index into array holding the engine recharge rate
 	float	weapon_energy;						// Number of EUs in energy reserves
 	int	next_manage_ets;					// timestamp for when ai can next modify ets ( -1 means never )
-	float prev_engine_aggregate_strength;	// aggregate engine health to allow for minimzing overrides to max speed --Asteroth and wookieejedi
+	float prev_engine_aggregate_strength;	// aggregate engine health to allow for minimizing overrides to max speed --Asteroth and wookieejedi
 
 	flagset<Ship::Ship_Flags>	flags;		// flag variable to contain ship state
 	int	reinforcement_index;				// index into reinforcement struct or -1

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -137,6 +137,7 @@ namespace Ship {
 		Aspect_immune,						// Kiloku -- Ship cannot be targeted by Aspect Seekers.
 		Cannot_perform_scan,		// Goober5000 - ship cannot scan other ships
 		No_targeting_limits,				//MjnMixael -- Ship is always targetable regardless of AWACS or targeting range limits
+		Maneuver_despite_engines,	// Goober5000 - ship can move even when engines are disabled or disrupted
 
 		NUM_VALUES
 


### PR DESCRIPTION
This flag ignores engine status when determining whether and how a ship can maneuver.  Implements #5503.