### PR TITLE
Actually reset the weapon pool with SCPUI

### DIFF
--- a/code/missionui/missionweaponchoice.h
+++ b/code/missionui/missionweaponchoice.h
@@ -12,6 +12,8 @@
 #ifndef __MISSION_WEAPON_CHOICE_H__
 #define __MISSION_WEAPON_CHOICE_H__
 
+#include "mission/missionparse.h"
+
 class p_object;
 struct wss_unit;
 class ship_weapon;
@@ -83,6 +85,7 @@ void	wl_bash_ship_weapons(ship_weapon *swp, wss_unit *slot);
 
 void wl_set_default_weapons(int index, int ship_class);
 void wl_reset_to_defaults();
+void wl_init_pool(team_data* td);
 void wl_fill_slots();
 
 // Set selected slot to first placed ship

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1425,12 +1425,16 @@ ADE_FUNC(resetSelect,
 	nullptr)
 {
 	// Note this does all the things from ss_reset_to_default() in missionshipchoice.cpp except
-	// resetting UI elements - Mjn
+	// resetting UI elements. It also resets the weapon pool. - Mjn
 
 	SCP_UNUSED(L); // unused parameter
 
+	//Reset ships pool
 	ss_init_pool(&Team_data[Common_team]);
 	ss_init_units();
+
+	//Reset weapons pool
+	wl_init_pool(&Team_data[Common_team]);
 
 	if (!(Game_mode & GM_MULTIPLAYER)) {
 		wl_fill_slots();


### PR DESCRIPTION
Fixes a bug where `ui.ShipWepSelect.resetSelect` would slowly deplete the available weapon pool until no weapons are available.