### PR TITLE
Add default player weapon flag

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -456,6 +456,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
     { "thruster",					Weapon::Info_Flags::Thruster,							true, false },
     { "in tech database",			Weapon::Info_Flags::In_tech_database,					true, false },
     { "player allowed",				Weapon::Info_Flags::Player_allowed,						true, false },
+	{ "default player weapon",		Weapon::Info_Flags::Default_player_weapon,				true, false },
     { "corkscrew",					Weapon::Info_Flags::Corkscrew,							true, false },
     { "particle spew",				Weapon::Info_Flags::Particle_spew,						true, false },
     { "esuck",						Weapon::Info_Flags::Energy_suck,						true, false },

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -27,6 +27,7 @@ namespace Weapon {
 		Thruster,							// Has thruster cone and/or glow
 		In_tech_database,
 		Player_allowed,						// allowed to be on starting wing ships/in weaponry pool
+		Default_player_weapon,				// added to the weapons pool by default
 		Bomber_plus,						// Fire this missile only at a bomber or big ship.  But not a fighter.
 		Corkscrew,							// corkscrew style missile
 		Particle_spew,						// spews particles as it travels

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -167,6 +167,7 @@ special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info
     { "no dumbfire",					Weapon::Info_Flags::No_dumbfire,						true },
 	{ "no doublefire",					Weapon::Info_Flags::No_doublefire,						true },
     { "in tech database",				Weapon::Info_Flags::In_tech_database,					true },
+	{ "default player weapon",			Weapon::Info_Flags::Default_player_weapon,				true },
     { "player allowed",					Weapon::Info_Flags::Player_allowed,                     true }, 
     { "particle spew",					Weapon::Info_Flags::Particle_spew,						true },
     { "emp",							Weapon::Info_Flags::Emp,								true },

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -854,7 +854,7 @@ void clear_mission()
 
 		count = 0;
 		for ( j = 0; j < weapon_info_size(); j++ ) {
-			if (Weapon_info[j].wi_flags[Weapon::Info_Flags::Player_allowed]) {
+			if (Weapon_info[j].wi_flags[Weapon::Info_Flags::Default_player_weapon]) {
 				if (Weapon_info[j].subtype == WP_LASER) {
 					Team_data[i].weaponry_count[count] = 16;
 				} else {

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -452,7 +452,7 @@ void Editor::clearMission() {
 
 		count = 0;
 		for (auto j = 0; j < static_cast<int>(Weapon_info.size()); j++) {
-			if (Weapon_info[j].wi_flags[Weapon::Info_Flags::Player_allowed]) {
+			if (Weapon_info[j].wi_flags[Weapon::Info_Flags::Default_player_weapon]) {
 				if (Weapon_info[j].subtype == WP_LASER) {
 					Team_data[i].weaponry_count[count] = 16;
 				} else {


### PR DESCRIPTION
Adds the weapon equivalent to "default player ship" flag. This flag defines what weapons are default in the player loadout in FRED/qtFRED. Fixes #5552