### PR TITLE
fix random selection of message candidates

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1979,7 +1979,7 @@ int pick_persona(ship* shipp) {
 	if (count == 1) {
 		return candidates[0];
 	} else if (count > 1) {
-		return candidates[Random::next(0, count)];
+		return candidates[Random::next(count)];
 	} else if (persona_type & PERSONA_FLAG_SUPPORT) {
 		// Species without a support persona (e.g. the UEF) historically used the
 		// first support persona; retain that behavior


### PR DESCRIPTION
The `Random::next(low, high)` function returns a value in [low, high].  This location should use the single-argument version, `Random::next(int modulus)`, which returns a value in [0, modulus-1].