### PR TITLE
small speedup to drawString

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1402,17 +1402,8 @@ static int drawString_sub(lua_State *L, bool use_resize_arg)
 		int curr_y = y;
 		for(int i = 0; i < num_lines; i++)
 		{
-			//Contrary to WMC's previous comment, let's make a new string each line
-			int len = linelengths[i];
-			char *buf = new char[len+1];
-			strncpy(buf, linestarts[i], len);
-			buf[len] = '\0';
-
 			//Draw the string
-			gr_string(x,curr_y,buf,resize_mode);
-
-			//Free the string we made
-			delete[] buf;
+			gr_string(x,curr_y,linestarts[i],resize_mode,linelengths[i]);
 
 			//Increment line height
 			curr_y += line_ht;

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1403,7 +1403,7 @@ static int drawString_sub(lua_State *L, bool use_resize_arg)
 		for(int i = 0; i < num_lines; i++)
 		{
 			//Draw the string
-			gr_string(x,curr_y,linestarts[i],resize_mode,linelengths[i]);
+			gr_string(x, curr_y, linestarts[i], resize_mode, linelengths[i]);
 
 			//Increment line height
 			curr_y += line_ht;


### PR DESCRIPTION
Since `gr_string` can accept a length parameter, there's no need to copy each line before it is drawn.

Related to #5495 but not one of the two options mentioned.