### PR TITLE
More message filters

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -427,7 +427,7 @@ void handle_legacy_backup_message(MissionMessage& msg, SCP_string wing_name) {
 	strcpy(msg.name, backup);
 }
 
-int lookup_mood(SCP_string& name) {
+int lookup_mood(SCP_string const& name) {
 	for (auto i = Builtin_moods.begin(); i != Builtin_moods.end(); ++i) {
 		if (*i == name) {
 			return (int) std::distance(Builtin_moods.begin(), i);
@@ -2094,15 +2094,19 @@ bool filters_match(MessageFilter& filter, ship* it) {
 bool outer_filters_match(MessageFilter& filter, int range, ship* sender) {
 	for (auto i: list_range(&Ship_obj_list)) {
 		auto obj = &Objects[i->objnum];
+		// Ignore dying ships
 		if (obj->flags[Object::Object_Flags::Should_be_dead]) {
 			continue;
 		}
-		if ((range >= 0) && (vm_vec_dist(&obj->pos, &Objects[sender->objnum].pos) > range)) {
+		// Ignore the sender itself
+		if (sender->objnum == i->objnum) {
 			continue;
 		}
-    if (sender->objnum == i->objnum) {
-      continue;
-    }
+		// If a range was specified, ignore anything out of range
+		if ((range > 0) && (vm_vec_dist(&obj->pos, &Objects[sender->objnum].pos) > range)) {
+			continue;
+		}
+		// If we got this far, we can check our filters
 		if (filters_match(filter, &Ships[obj->instance])) {
 			return true;
 		}

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -63,15 +63,15 @@ builtin_message Builtin_messages[] = {
   #undef X
 };
 
-#define BUILTIN_BOOST_LEVEL_ONE  1
-#define BUILTIN_BOOST_LEVEL_TWO  2
-#define BUILTIN_MATCHES_TYPE     4
-#define BUILTIN_MATCHES_FILTER   8
-#define BUILTIN_MATCHES_MOOD    16
-#define BUILTIN_MATCHES_SPECIES 32
-#define BUILTIN_MATCHES_PERSONA 64
+constexpr int BUILTIN_BOOST_LEVEL_ONE =  1;
+constexpr int BUILTIN_BOOST_LEVEL_TWO =  2;
+constexpr int BUILTIN_MATCHES_TYPE    =  4;
+constexpr int BUILTIN_MATCHES_FILTER  =  8;
+constexpr int BUILTIN_MATCHES_MOOD    = 16;
+constexpr int BUILTIN_MATCHES_SPECIES = 32;
+constexpr int BUILTIN_MATCHES_PERSONA = 64;
 
-#define BUILTIN_BOOST_LEVEL_THREE (BUILTIN_BOOST_LEVEL_ONE | BUILTIN_BOOST_LEVEL_TWO)
+constexpr int BUILTIN_BOOST_LEVEL_THREE = (BUILTIN_BOOST_LEVEL_ONE | BUILTIN_BOOST_LEVEL_TWO);
 
 int get_builtin_message_type(const char* name) {
 	for (int i = 0; i < MAX_BUILTIN_MESSAGE_TYPES; i++) {
@@ -429,7 +429,7 @@ void handle_legacy_backup_message(MissionMessage& msg, SCP_string wing_name) {
 
 int lookup_mood(SCP_string const& name) {
 	for (auto i = Builtin_moods.begin(); i != Builtin_moods.end(); ++i) {
-		if (*i == name) {
+		if (lcase_equal(*i, name)) {
 			return (int) std::distance(Builtin_moods.begin(), i);
 		}
 	}
@@ -2094,8 +2094,8 @@ bool filters_match(MessageFilter& filter, ship* it) {
 bool outer_filters_match(MessageFilter& filter, int range, ship* sender) {
 	for (auto i: list_range(&Ship_obj_list)) {
 		auto obj = &Objects[i->objnum];
-		// Ignore dying ships
-		if (obj->flags[Object::Object_Flags::Should_be_dead]) {
+		// Ignore dead/dying ships
+		if (obj->flags[Object::Object_Flags::Should_be_dead] || Ships[obj->instance].flags[Ship::Ship_Flags::Dying]) {
 			continue;
 		}
 		// Ignore the sender itself

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -163,6 +163,7 @@ typedef struct MissionMessage {
 	MessageFilter subject_filter;
 	MessageFilter outer_filter;
 	int outer_filter_radius;
+	int boost_level;
 
 	// unions for avi/wave information.  Because of issues with Fred, we are using
 	// the union to specify either the index into the avi or wave arrays above,

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -148,6 +148,7 @@ typedef struct MessageFilter {
 	SCP_vector<SCP_string> wing_name;
 	int                    species_bitfield;
 	int                    type_bitfield;
+	int                    team_bitfield;
 } MessageFilter;
 
 typedef struct MissionMessage {

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -161,6 +161,8 @@ typedef struct MissionMessage {
 
 	MessageFilter sender_filter;
 	MessageFilter subject_filter;
+	MessageFilter outer_filter;
+	int outer_filter_radius;
 
 	// unions for avi/wave information.  Because of issues with Fred, we are using
 	// the union to specify either the index into the avi or wave arrays above,


### PR DESCRIPTION
This PR introduces a few enhancements to the dynamic message system:

* Message filters can look at a ship's IFF.
* A dynamic message can be filtered based on the presence of other ships in the mission, and can do so with a range check. Alongside an IFF filter, this can be used to play different versions of a message when the speaker is "in battle" or not.
* The tiebreaker system can be further customized, for cases where two messages have filters but the author wants one to beat the other. (Maybe one of your pilots has a special arrival message for HoL ships, and another for enemy bombers. Currently, when this pilot announces HoL bombers, they'll pick one of those two at random. This feature lets you pick one message or the other.)
* Lastly, as a QoL enhancement, when a message is assigned a mood, it can automatically exclude all other moods. (This could already be done manually, but it gets annoying when you add more moods...)

All of these features are desired for BTA's upcoming release.