### PR TITLE
sync setting and getting of collides and no_collide

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -16481,6 +16481,14 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 				}
 			}
 
+			// special case: the "no_collide" parse object flag is the same, but opposite, as the "collides" object flag
+			if (parse_obj_flag == Mission::Parse_Object_Flags::OF_No_collide)
+			{
+				auto tmp_flagset = oswpt.objp->flags;
+				tmp_flagset.set(Object::Object_Flags::Collides, !set_flag);
+				obj_set_flags(oswpt.objp, tmp_flagset);
+			}
+
 			// see if we have an ai flag to set
 			if (ai_flag != AI::AI_Flags::NUM_VALUES)
 			{
@@ -16494,6 +16502,12 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 		case OSWPT_TYPE_PARSE_OBJECT:
 			if (!future_ships) {
 				return;
+			}
+
+			// special case: the "collides" object flag is the same, but opposite, as the "no_collide" parse object flag
+			if (object_flag == Object::Object_Flags::Collides)
+			{
+				oswpt.ship_entry->p_objp->flags.set(Mission::Parse_Object_Flags::OF_No_collide, !set_flag);
 			}
 
 			// see if we have a p_object flag to set
@@ -16619,7 +16633,11 @@ int sexp_are_ship_flags_set(int node)
 				return SEXP_FALSE;
 		}
 
-		// we don't check parse flags
+		// we don't check parse flags, except for one that can be an object flag in reverse
+		if (parse_obj_flag == Mission::Parse_Object_Flags::OF_No_collide) {
+			if (objp->flags[Object::Object_Flags::Collides])
+				return SEXP_FALSE;
+		}
 
 		if (ai_flag != AI::AI_Flags::NUM_VALUES) {
 			if (!(aip->ai_flags[ai_flag]))

--- a/code/scripting/api/objs/parse_object.cpp
+++ b/code/scripting/api/objs/parse_object.cpp
@@ -183,7 +183,12 @@ ADE_FUNC(getFlag, l_ParseObject, "string flag_name", "Checks whether one or more
 			return ADE_RETURN_FALSE;
 		}
 
-		// we only check parse flags
+		// we only check parse flags, unless this is the one object flag that is the same thing in reverse
+		if (object_flag == Object::Object_Flags::Collides)
+		{
+			if (pobjp->flags[Mission::Parse_Object_Flags::OF_No_collide])
+				return ADE_RETURN_FALSE;
+		}
 
 		if (parse_obj_flag != Mission::Parse_Object_Flags::NUM_VALUES)
 		{

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -269,7 +269,12 @@ ADE_FUNC(getFlag, l_Ship, "string flag_name", "Checks whether one or more flags 
 				return ADE_RETURN_FALSE;
 		}
 
-		// we don't check parse flags
+		// we don't check parse flags, except for one that can be an object flag in reverse
+		if (parse_obj_flag == Mission::Parse_Object_Flags::OF_No_collide)
+		{
+			if (objp->flags[Object::Object_Flags::Collides])
+				return ADE_RETURN_FALSE;
+		}
 
 		if (ai_flag != AI::AI_Flags::NUM_VALUES)
 		{


### PR DESCRIPTION
The `collides` and `no_collide` flags are equivalent, but opposite.  So when sexps or scripts get or set those flags, allow each to be used as an anti-synonym (not exactly an antonym) for the other.