### PR TITLE
fix macOS build packaging issues

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -288,12 +288,12 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
       - name: Package build result
         working-directory: ./build
-        run: cd bin && tar -cvzf macos-build.tar *.app
+        run: cd bin && tar -cvzf macos-build-${{ matrix.configuration }}.tar.gz *.app
       - name: Upload build result
         uses: actions/upload-artifact@v2
         with:
           name: mac-${{ matrix.configuration }}
-          path: ${{ github.workspace }}/build/bin/macos-build.tar
+          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tar.gz
   mac_zip:
     name: Build Mac distribution zip
     needs: build_mac
@@ -311,11 +311,17 @@ jobs:
         with:
           name: mac-Release
           path: builds
+      - name: Unpack Release build
+        working-directory: ./builds
+        run: tar -xvzf macos-build-Release.tar.gz
       - name: Download FastDebug builds
         uses: actions/download-artifact@v2
         with:
           name: mac-FastDebug
           path: builds
+      - name: Unpack FastDebug build
+        working-directory: ./builds
+        run: tar -xvzf macos-build-FastDebug.tar.gz
       - name: Create Distribution package
         working-directory: ./builds
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -381,12 +381,12 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
       - name: Package build result
         working-directory: ./build
-        run: cd bin && tar -cvzf macos-build.tar *.app
+        run: cd bin && tar -cvzf macos-build-${{ matrix.configuration }}.tar.gz *.app
       - name: Upload build result
         uses: actions/upload-artifact@v2
         with:
           name: mac-${{ matrix.configuration }}
-          path: ${{ github.workspace }}/build/bin/macos-build.tar
+          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tar.gz
   mac_zip:
     name: Build Mac distribution zip
     needs: build_mac
@@ -404,11 +404,17 @@ jobs:
         with:
           name: mac-Release
           path: builds
+      - name: Unpack Release build
+        working-directory: ./builds
+        run: tar -xvzf macos-build-Release.tar.gz
       - name: Download FastDebug builds
         uses: actions/download-artifact@v2
         with:
           name: mac-FastDebug
           path: builds
+      - name: Unpack FastDebug build
+        working-directory: ./builds
+        run: tar -xvzf macos-build-FastDebug.tar.gz
       - name: Create Distribution package
         id: generate_package
         working-directory: ./builds

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -301,12 +301,12 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
       - name: Package build result
         working-directory: ./build
-        run: cd bin && tar -cvzf macos-build.tar *.app
+        run: cd bin && tar -cvzf macos-build-${{ matrix.configuration }}.tar.gz *.app
       - name: Upload build result
         uses: actions/upload-artifact@v2
         with:
           name: mac-${{ matrix.configuration }}
-          path: ${{ github.workspace }}/build/bin/macos-build.tar
+          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tar.gz
   mac_zip:
     name: Build Mac distribution zip
     needs: build_mac
@@ -324,11 +324,17 @@ jobs:
         with:
           name: mac-Release
           path: builds
+      - name: Unpack Release build
+        working-directory: ./builds
+        run: tar -xvzf macos-build-Release.tar.gz
       - name: Download FastDebug builds
         uses: actions/download-artifact@v2
         with:
           name: mac-FastDebug
           path: builds
+      - name: Unpack FastDebug build
+        working-directory: ./builds
+        run: tar -xvzf macos-build-FastDebug.tar.gz
       - name: Create Distribution package
         working-directory: ./builds
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac

--- a/ci/linux/create_dist_pack.sh
+++ b/ci/linux/create_dist_pack.sh
@@ -26,7 +26,7 @@ elif [ "$OS" = "Windows" ]; then
     echo "debug_name=$(get_package_name)-debug-$ARCH-$SIMD.7z" >> $GITHUB_OUTPUT
     echo "debug_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-debug-$ARCH-$SIMD.7z")" >> $GITHUB_OUTPUT
 elif [ "$OS" = "Mac" ]; then
-    tar -cvzf "$(get_package_name)-builds-Mac.tar.gz" *
+    tar -cvzf "$(get_package_name)-builds-Mac.tar.gz" *.app
 
     echo "package_path=$(pwd)/$(get_package_name)-builds-Mac.tar.gz" >> $GITHUB_OUTPUT
     echo "package_name=$(get_package_name)-builds-Mac.tar.gz" >> $GITHUB_OUTPUT


### PR DESCRIPTION
 - handle double archiving of macOS builds so they'll work properly with Knossos
 - fix issue where only a single configuration was included in the package (Release or FastDebug, not both)