### PR TITLE
xstr debug filter

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -1187,6 +1187,8 @@ const char *XSTR(const char *str, int index, bool force_lookup)
 		return str;
 	}
 
+	nprintf(("XSTR", "Localizing String: %i, \"%s\"\n", index, str));
+
 	// for some internal strings, such as the ones we loaded using $Has XStr:,
 	// we want to force a lookup even if we're normally untranslated
 	if (Lcl_current_lang != LCL_UNTRANSLATED || force_lookup)

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -1187,7 +1187,9 @@ const char *XSTR(const char *str, int index, bool force_lookup)
 		return str;
 	}
 
+#ifndef NDEBUG
 	nprintf(("XSTR", "Localizing String: %i, \"%s\"\n", index, str));
+#endif
 
 	// for some internal strings, such as the ones we loaded using $Has XStr:,
 	// we want to force a lookup even if we're normally untranslated


### PR DESCRIPTION
While I was adding strings to the engine, it became obvious that there's no good way to have the engine output a list of a strings and string IDs from the engine because they are only handled when the code is running through a section with an XSTR call. Over the years SCP has added several new strings and IDs as well as allowing a few tables like controlconfigdefaults.tbl and sexps.tbl to define "built-in" strings. This made it tough to find what IDs are available to use. So my best idea was to add an `nprintf` (XSTR debug filter) for XSTRs that simply outputs to the log each string and string ID that XSTR handles as it handles them.

This is still not a fool proof way, but it's much simpler and more reliable than searching the code for 'XSTR' function references because some of those apply strings and IDs dynamically and that doesn't cover any added by tables. With this in place you can launch FSO, poke around each UI and run a mission or two. Then you'll have a reasonably complete list of strings and string IDs in the debug log.