### PR TITLE
Double the allowed cargo from 30 to 60

### DIFF
--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -179,7 +179,7 @@ typedef struct mission {
 // must be reworked so that all the flags are maintained from function to function
 #define CARGO_INDEX_MASK	0xBF
 #define CARGO_NO_DEPLETE	0x40		// CARGO_NO_DEPLETE + CARGO_INDEX_MASK must == FF
-#define MAX_CARGO				30
+#define MAX_CARGO				60
 
 
 // Goober5000 - contrail threshold (previously defined in ShipContrails.cpp)


### PR DESCRIPTION
I was gonna vectorize `Cargo_names` but it's ugly. So I'm taking the path of least resistance and just doubling the size of the array. According to the comments here, it should be OK and some brief testing showed no noticeable errors.

I thought about going all the way to 64, but I liked a nice round number instead.