### PR TITLE
add support for predicting arrival warp distance

### DIFF
--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -39,7 +39,6 @@
 #define	REDUCED_DAMP_VEL		30		// change in velocity at which reduced_damp_time is 2000 ms
 #define	REDUCED_DAMP_TIME		2000	// ms (2.0 sec)
 #define	WEAPON_SHAKE_TIME		500	//	ms (0.5 sec)	viewer shake time after hit by weapon (implemented via afterburner shake)
-#define	SPECIAL_WARP_T_CONST	0.651	// special warp time constant (loose 99 % of excess speed in 3 sec)
 
 void update_reduced_damp_timestamp( physics_info *pi, float impulse );
 float velocity_ramp (float v_in, float v_goal, float time_const, float t);
@@ -345,18 +344,18 @@ void physics_sim_vel(vec3d * position, physics_info * pi, matrix *orient, vec3d*
 	vec3d grav_vel = vmd_zero_vector;
 	int special_warp_in = FALSE;
 	float excess = local_v_in.xyz.z - pi->max_vel.xyz.z;
-	if (excess > 5 && (pi->flags & PF_SPECIAL_WARP_IN)) {
+	if (excess > 5 && (pi->flags & PF_SUPERCAP_WARP_IN)) {
 		special_warp_in = TRUE;
-		float exp_factor = float(exp(-sim_time / SPECIAL_WARP_T_CONST));
+		float exp_factor = float(exp(-sim_time / SUPERCAP_WARP_T_CONST));
 		local_v_out.xyz.z = pi->max_vel.xyz.z + excess * exp_factor;
-		local_disp.xyz.z = (pi->max_vel.xyz.z * sim_time) + excess * (float(SPECIAL_WARP_T_CONST) * (1.0f - exp_factor));
+		local_disp.xyz.z = (pi->max_vel.xyz.z * sim_time) + excess * (float(SUPERCAP_WARP_T_CONST) * (1.0f - exp_factor));
 	} else if (pi->flags & PF_SPECIAL_WARP_OUT) {
-		float exp_factor = float(exp(-sim_time / SPECIAL_WARP_T_CONST));
+		float exp_factor = float(exp(-sim_time / SUPERCAP_WARP_T_CONST));
 		vec3d temp;
 		vm_vec_rotate(&temp, &pi->prev_ramp_vel, orient);
 		float deficeit = temp.xyz.z - local_v_in.xyz.z;
 		local_v_out.xyz.z = local_v_in.xyz.z + deficeit * (1.0f - exp_factor);
-		local_disp.xyz.z = (local_v_in.xyz.z * sim_time) + deficeit * (sim_time - (float(SPECIAL_WARP_T_CONST) * (1.0f - exp_factor)));
+		local_disp.xyz.z = (local_v_in.xyz.z * sim_time) + deficeit * (sim_time - (float(SUPERCAP_WARP_T_CONST) * (1.0f - exp_factor)));
 	} else {
 		apply_physics (damp.xyz.z, local_desired_vel.xyz.z, local_v_in.xyz.z, sim_time, &local_v_out.xyz.z, &local_disp.xyz.z);
 		if (pi->gravity_const != 0.0f) {
@@ -366,8 +365,8 @@ void physics_sim_vel(vec3d * position, physics_info * pi, matrix *orient, vec3d*
 	}
 
 	// maybe turn off special warp in flag
-	if ((pi->flags & PF_SPECIAL_WARP_IN) && (excess < 5)) {
-		pi->flags &= ~(PF_SPECIAL_WARP_IN);
+	if ((pi->flags & PF_SUPERCAP_WARP_IN) && (excess < 5)) {
+		pi->flags &= ~(PF_SUPERCAP_WARP_IN);
 	}
 
 	// update world position from local to world coords using orient

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -352,7 +352,7 @@ void physics_sim_vel(vec3d * position, physics_info * pi, matrix *orient, vec3d*
 		float exp_factor = float(exp(-sim_time / SUPERCAP_WARP_T_CONST));
 		local_v_out.xyz.z = pi->max_vel.xyz.z + excess * exp_factor;
 		local_disp.xyz.z = (pi->max_vel.xyz.z * sim_time) + excess * (float(SUPERCAP_WARP_T_CONST) * (1.0f - exp_factor));
-	} else if (pi->flags & PF_SPECIAL_WARP_OUT) {
+	} else if (pi->flags & PF_SUPERCAP_WARP_OUT) {
 		float exp_factor = float(exp(-sim_time / SUPERCAP_WARP_T_CONST));
 		vec3d temp;
 		vm_vec_rotate(&temp, &pi->prev_ramp_vel, orient);

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -41,6 +41,7 @@
 #define	WEAPON_SHAKE_TIME		500	//	ms (0.5 sec)	viewer shake time after hit by weapon (implemented via afterburner shake)
 
 const float SUPERCAP_WARP_T_CONST = 0.651f;	// special warp time constant (lose 99 % of excess speed in 3 sec)
+const float SUPERCAP_WARP_EXCESS_SPD_THRESHOLD = 5.0f;	// more than this many m/s faster than the ship's max speed and we use the above damp constant instead
 
 void update_reduced_damp_timestamp( physics_info *pi, float impulse );
 float velocity_ramp (float v_in, float v_goal, float time_const, float t);
@@ -346,7 +347,7 @@ void physics_sim_vel(vec3d * position, physics_info * pi, matrix *orient, vec3d*
 	vec3d grav_vel = vmd_zero_vector;
 	int special_warp_in = FALSE;
 	float excess = local_v_in.xyz.z - pi->max_vel.xyz.z;
-	if (excess > 5 && (pi->flags & PF_SUPERCAP_WARP_IN)) {
+	if (excess > SUPERCAP_WARP_EXCESS_SPD_THRESHOLD && (pi->flags & PF_SUPERCAP_WARP_IN)) {
 		special_warp_in = TRUE;
 		float exp_factor = float(exp(-sim_time / SUPERCAP_WARP_T_CONST));
 		local_v_out.xyz.z = pi->max_vel.xyz.z + excess * exp_factor;
@@ -367,7 +368,7 @@ void physics_sim_vel(vec3d * position, physics_info * pi, matrix *orient, vec3d*
 	}
 
 	// maybe turn off special warp in flag
-	if ((pi->flags & PF_SUPERCAP_WARP_IN) && (excess < 5)) {
+	if ((pi->flags & PF_SUPERCAP_WARP_IN) && (excess < SUPERCAP_WARP_EXCESS_SPD_THRESHOLD)) {
 		pi->flags &= ~(PF_SUPERCAP_WARP_IN);
 	}
 

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -40,6 +40,8 @@
 #define	REDUCED_DAMP_TIME		2000	// ms (2.0 sec)
 #define	WEAPON_SHAKE_TIME		500	//	ms (0.5 sec)	viewer shake time after hit by weapon (implemented via afterburner shake)
 
+const float SUPERCAP_WARP_T_CONST = 0.651f;	// special warp time constant (lose 99 % of excess speed in 3 sec)
+
 void update_reduced_damp_timestamp( physics_info *pi, float impulse );
 float velocity_ramp (float v_in, float v_goal, float time_const, float t);
 float glide_ramp (float v_in, float v_goal, float ramp_time_const, float accel_mult, float t);

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -27,7 +27,7 @@
 #define	PF_WARP_IN				(1 << 9)	//	Use when ship is warping in
 #define	PF_SUPERCAP_WARP_IN		(1 << 10)	//	Use when ship is warping in and we want to slow the ship faster than normal game physics
 #define	PF_WARP_OUT				(1 << 11)	//	Use when ship is warping out
-#define	PF_SPECIAL_WARP_OUT		(1 << 12)	//	Use when ship is warping out and we want to slow the ship faster than normal game physics
+#define	PF_SUPERCAP_WARP_OUT	(1 << 12)	//	Use when ship is warping out and we want to slow the ship faster than normal game physics
 #define PF_BOOSTER_ON			(1 << 13)
 #define PF_GLIDING				(1 << 14)
 #define PF_FORCE_GLIDE			(1 << 15)

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -35,7 +35,7 @@
 #define PF_MANEUVER_NO_DAMP		(1 << 17)	// Goober5000 - don't damp velocity changes in physics; used for instantaneous acceleration
 #define PF_BALLISTIC			(1 << 18)	// Asteroth - not moving 'under its own power', simplified physics calculations
 
-constexpr float SUPERCAP_WARP_T_CONST = 0.651f;	// special warp time constant (lose 99 % of excess speed in 3 sec)
+extern const float SUPERCAP_WARP_T_CONST;
 
 //information for physics sim for an object
 typedef struct physics_info {

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -25,7 +25,7 @@
 #define	PF_AFTERBURNER_WAIT		(1 << 7)	// true when afterburner cannot be used.  replaces variable used in afterburner code
 #define	PF_CONST_VEL			(1 << 8)	// Use velocity in phys_info struct.  Optimize weapons in phys_sim 
 #define	PF_WARP_IN				(1 << 9)	//	Use when ship is warping in
-#define	PF_SPECIAL_WARP_IN		(1 << 10)	//	Use when ship is warping in and we want to slow the ship faster than normal game physics
+#define	PF_SUPERCAP_WARP_IN		(1 << 10)	//	Use when ship is warping in and we want to slow the ship faster than normal game physics
 #define	PF_WARP_OUT				(1 << 11)	//	Use when ship is warping out
 #define	PF_SPECIAL_WARP_OUT		(1 << 12)	//	Use when ship is warping out and we want to slow the ship faster than normal game physics
 #define PF_BOOSTER_ON			(1 << 13)

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -36,6 +36,7 @@
 #define PF_BALLISTIC			(1 << 18)	// Asteroth - not moving 'under its own power', simplified physics calculations
 
 extern const float SUPERCAP_WARP_T_CONST;
+extern const float SUPERCAP_WARP_EXCESS_SPD_THRESHOLD;
 
 //information for physics sim for an object
 typedef struct physics_info {

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -35,6 +35,8 @@
 #define PF_MANEUVER_NO_DAMP		(1 << 17)	// Goober5000 - don't damp velocity changes in physics; used for instantaneous acceleration
 #define PF_BALLISTIC			(1 << 18)	// Asteroth - not moving 'under its own power', simplified physics calculations
 
+constexpr float SUPERCAP_WARP_T_CONST = 0.651f;	// special warp time constant (lose 99 % of excess speed in 3 sec)
+
 //information for physics sim for an object
 typedef struct physics_info {
 	uint		flags;			//misc physics flags

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3550,7 +3550,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 	// get ship parameters for warpin and warpout
 	// Note: if the index is not -1, we must have already assigned warp parameters, probably because we are now
 	// parsing a TBM.  In that case, inherit from ourselves.
-	// Note2: In retail, supercaps have the PF_SPECIAL_WARP_IN applied by default (but not PF_SPECIAL_WARP_OUT).  So,
+	// Note2: In retail, supercaps have the PF_SUPERCAP_WARP_IN applied by default (but not PF_SUPERCAP_WARP_OUT).  So,
 	// if we are parsing a supercap for the first time, and this is a warpin, set the flag.
 	sip->warpin_params_index = parse_warp_params(sip->warpin_params_index >= 0 ? &Warp_params[sip->warpin_params_index] : nullptr, WarpDirection::WARP_IN, info_type_name, sip->name, first_time && is_supercap_for_warp_params);
 	sip->warpout_params_index = parse_warp_params(sip->warpout_params_index >= 0 ? &Warp_params[sip->warpout_params_index] : nullptr, WarpDirection::WARP_OUT, info_type_name, sip->name, false);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -83,9 +83,6 @@ extern vec3d	Original_vec_to_deader;
 
 #define RF_IS_AVAILABLE			(1<<0)			// reinforcement is now available
 
-#define	SUPERCAP_WARP_T_CONST	0.651	// special warp time constant (loose 99 % of excess speed in 3 sec)
-
-
 typedef struct {
 	char	name[NAME_LENGTH];	// ship or wing name (ship and wing names don't collide)
 	int	type;						// what operations this reinforcement unit can perform

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -83,6 +83,9 @@ extern vec3d	Original_vec_to_deader;
 
 #define RF_IS_AVAILABLE			(1<<0)			// reinforcement is now available
 
+#define	SUPERCAP_WARP_T_CONST	0.651	// special warp time constant (loose 99 % of excess speed in 3 sec)
+
+
 typedef struct {
 	char	name[NAME_LENGTH];	// ship or wing name (ship and wing names don't collide)
 	int	type;						// what operations this reinforcement unit can perform

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3730,6 +3730,29 @@ int WE_Default::getWarpOrientation(matrix* output)
     return 1;
 }
 
+float shipfx_calculate_arrival_warp_distance(object *objp)
+{
+	Assert(objp != nullptr && objp->type == OBJ_SHIP);
+
+	// c.f. WE_Default::warpStart()
+	float half_length, warping_dist;
+	if (object_is_docked(objp))
+	{
+		half_length = dock_calc_max_semilatus_rectum_parallel_to_axis(objp, Z_AXIS);
+		warping_dist = 2.0f * half_length;
+	}
+	else
+	{
+		warping_dist = ship_class_get_length(&Ship_info[Ships[objp->instance].ship_info_index]);
+		half_length = 0.5f * warping_dist;
+	}
+	float warping_time = shipfx_calculate_warp_time(objp, WarpDirection::WARP_IN, half_length, warping_dist);
+	float warping_speed = warping_dist / warping_time;
+
+	// the total distance is a full length from its current position, plus the time it takes to slow down from its warping speed
+	// TODO
+}
+
 //********************-----CLASS: WE_BSG-----********************//
 WE_BSG::WE_BSG(object *n_objp, WarpDirection n_direction)
 	:WarpEffect(n_objp, n_direction)

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3732,7 +3732,7 @@ int WE_Default::getWarpOrientation(matrix* output)
 
 float shipfx_calculate_arrival_warp_distance(object *objp)
 {
-	Assert(objp != nullptr && objp->type == OBJ_SHIP);
+	Assertion(objp != nullptr && objp->type == OBJ_SHIP, "Object parameter to shipfx_calculate_arrival_warp_distance must be a ship!");
 
 	// c.f. WE_Default::warpStart()
 	float half_length, warping_dist;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3634,7 +3634,7 @@ int WE_Default::warpFrame(float frametime)
 			// notify physics to slow down
 			if (params->special_warp_physics) {
 				// let physics know this is a special warp in
-				objp->phys_info.flags |= PF_SPECIAL_WARP_IN;
+				objp->phys_info.flags |= PF_SUPERCAP_WARP_IN;
 			}
 		}
 	}
@@ -3750,7 +3750,16 @@ float shipfx_calculate_arrival_warp_distance(object *objp)
 	float warping_speed = warping_dist / warping_time;
 
 	// the total distance is a full length from its current position, plus the time it takes to slow down from its warping speed
-	// TODO
+	float decel_time_const = objp->phys_info.forward_decel_time_const;
+	if (Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Supercap]) {
+		// super cap style warpins are annoying, one time constant while above their max speed, a different one while slowing down from there
+		float supercap_slowdown_dist = (warping_speed - (objp->phys_info.max_vel.xyz.z + 5.0f))  * SUPERCAP_WARP_T_CONST;
+		float regular_slowdown_dist = (objp->phys_info.max_vel.xyz.z + 5.0f) * decel_time_const;
+
+		return warping_dist + supercap_slowdown_dist + regular_slowdown_dist;
+	} else {
+		return warping_dist + warping_speed * decel_time_const;
+	}
 }
 
 //********************-----CLASS: WE_BSG-----********************//

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3733,6 +3733,7 @@ int WE_Default::getWarpOrientation(matrix* output)
 float shipfx_calculate_arrival_warp_distance(object *objp)
 {
 	Assertion(objp != nullptr && objp->type == OBJ_SHIP, "Object parameter to shipfx_calculate_arrival_warp_distance must be a ship!");
+	auto shipp = &Ships[objp->instance];
 
 	// c.f. WE_Default::warpStart()
 	float half_length, warping_dist;
@@ -3743,15 +3744,17 @@ float shipfx_calculate_arrival_warp_distance(object *objp)
 	}
 	else
 	{
-		warping_dist = ship_class_get_length(&Ship_info[Ships[objp->instance].ship_info_index]);
+		warping_dist = ship_class_get_length(&Ship_info[shipp->ship_info_index]);
 		half_length = 0.5f * warping_dist;
 	}
 	float warping_time = shipfx_calculate_warp_time(objp, WarpDirection::WARP_IN, half_length, warping_dist);
 	float warping_speed = warping_dist / warping_time;
 
+	auto warpin_params = &Warp_params[shipp->warpin_params_index];
+
 	// the total distance is a full length from its current position, plus the distance it takes to slow down from its warping speed
 	float decel_time_const = objp->phys_info.forward_decel_time_const;
-	if (Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Supercap]) {
+	if (warpin_params->special_warp_physics) {
 		// super cap style warpins are annoying, one time constant while above their max speed, a different one while slowing down from there
 		float supercap_slowdown_dist = (warping_speed - (objp->phys_info.max_vel.xyz.z + SUPERCAP_WARP_EXCESS_SPD_THRESHOLD)) * SUPERCAP_WARP_T_CONST;
 		float regular_slowdown_dist = (objp->phys_info.max_vel.xyz.z + SUPERCAP_WARP_EXCESS_SPD_THRESHOLD) * decel_time_const;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3749,7 +3749,7 @@ float shipfx_calculate_arrival_warp_distance(object *objp)
 	float warping_time = shipfx_calculate_warp_time(objp, WarpDirection::WARP_IN, half_length, warping_dist);
 	float warping_speed = warping_dist / warping_time;
 
-	// the total distance is a full length from its current position, plus the time it takes to slow down from its warping speed
+	// the total distance is a full length from its current position, plus the distance it takes to slow down from its warping speed
 	float decel_time_const = objp->phys_info.forward_decel_time_const;
 	if (Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Supercap]) {
 		// super cap style warpins are annoying, one time constant while above their max speed, a different one while slowing down from there

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3509,11 +3509,11 @@ int WE_Default::warpStart()
 		effect_time += SHIPFX_WARP_DELAY;
 
 		// turn off warpin physics in case we're jumping out immediately
-		objp->phys_info.flags &= ~PF_SPECIAL_WARP_IN;
+		objp->phys_info.flags &= ~PF_SUPERCAP_WARP_IN;
 
 		// maybe turn on warpout physics
 		if (params->special_warp_physics) {
-			objp->phys_info.flags |= PF_SPECIAL_WARP_OUT;
+			objp->phys_info.flags |= PF_SUPERCAP_WARP_OUT;
 		}
 	}
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -3753,8 +3753,8 @@ float shipfx_calculate_arrival_warp_distance(object *objp)
 	float decel_time_const = objp->phys_info.forward_decel_time_const;
 	if (Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Supercap]) {
 		// super cap style warpins are annoying, one time constant while above their max speed, a different one while slowing down from there
-		float supercap_slowdown_dist = (warping_speed - (objp->phys_info.max_vel.xyz.z + 5.0f))  * SUPERCAP_WARP_T_CONST;
-		float regular_slowdown_dist = (objp->phys_info.max_vel.xyz.z + 5.0f) * decel_time_const;
+		float supercap_slowdown_dist = (warping_speed - (objp->phys_info.max_vel.xyz.z + SUPERCAP_WARP_EXCESS_SPD_THRESHOLD)) * SUPERCAP_WARP_T_CONST;
+		float regular_slowdown_dist = (objp->phys_info.max_vel.xyz.z + SUPERCAP_WARP_EXCESS_SPD_THRESHOLD) * decel_time_const;
 
 		return warping_dist + supercap_slowdown_dist + regular_slowdown_dist;
 	} else {

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -113,7 +113,7 @@ extern SCP_vector<WarpParams> Warp_params;
 extern int find_or_add_warp_params(const WarpParams &params);
 
 extern float shipfx_calculate_warp_time(object *objp, WarpDirection warp_dir, float half_length, float warping_dist);
-
+extern float shipfx_calculate_arrival_warp_distance(object *objp);
 
 // =================================================
 //          SHIP SHADOW EFFECT STUFF

--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -241,6 +241,7 @@ BOOL CFREDApp::InitInstance() {
 	Highlight_selectable_subsys = GetProfileInt("Preferences", "Highlight selectable subsys", Highlight_selectable_subsys);
 	Draw_outlines_on_selected_ships = GetProfileInt("Preferences", "Draw outlines on selected ships", 1) != 0;
 	Point_using_uvec = GetProfileInt("Preferences", "Point using uvec", Point_using_uvec);
+	Draw_outline_at_warpin_position = GetProfileInt("Preferences", "Draw outline at warpin position", 0) != 0;
 
 	read_window("Main window", &Main_wnd_data);
 	read_window("Ship window", &Ship_wnd_data);
@@ -518,6 +519,7 @@ void CFREDApp::write_ini_file(int degree) {
 	WriteProfileInt("Preferences", "Highlight selectable subsys", Highlight_selectable_subsys);
 	WriteProfileInt("Preferences", "Draw outlines on selected ships", Draw_outlines_on_selected_ships ? 1 : 0);
 	WriteProfileInt("Preferences", "Point using uvec", Point_using_uvec);
+	WriteProfileInt("Preferences", "Draw outline at warpin position", Draw_outline_at_warpin_position ? 1 : 0);
 
 	if (!degree) {
 		record_window_data(&Waypoint_wnd_data, &Waypoint_editor_dialog);

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -264,7 +264,8 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "Show Ship Models\tShift+Alt+M", 32820, CHECKED
         MENUITEM "Show Outlines\tShift+Alt+O",  32980
-        MENUITEM "Draw Outlines on Selected Ships", 32982, CHECKED
+        MENUITEM "Draw Outlines on Selected Ships", ID_VIEW_OUTLINES_ON_SELECTED, CHECKED
+        MENUITEM "Draw Outline at Warpin Position", ID_VIEW_OUTLINE_AT_WARPIN, CHECKED
         MENUITEM "Show Ship Info\tShift+Alt+I", 32823, CHECKED, HELP
         MENUITEM "Show Coordinates\tShift+Alt+C", 32915
         MENUITEM "Show Grid Positions\tShift+Alt+P", 32914

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -1881,9 +1881,13 @@ void render_one_model_htl(object *objp) {
 			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 		}
 
-		if (Draw_outline_at_warpin_position && Ships[z].arrival_cue != Locked_sexp_true && Ships[z].arrival_cue != Locked_sexp_false && !Ships[z].flags[Ship::Ship_Flags::No_arrival_warp]) {
+		if (Draw_outline_at_warpin_position
+			&& (Ships[z].arrival_cue != Locked_sexp_true || Ships[z].arrival_delay > 0)
+			&& Ships[z].arrival_cue != Locked_sexp_false
+			&& !Ships[z].flags[Ship::Ship_Flags::No_arrival_warp])
+		{
 			int warp_type = Warp_params[Ships[z].warpin_params_index].warp_type;
-			if (warp_type == WT_DEFAULT || warp_type == WT_DEFAULT_THEN_KNOSSOS || warp_type == WT_DEFAULT_WITH_FIREBALL) {
+			if (warp_type == WT_DEFAULT || warp_type == WT_KNOSSOS || warp_type == WT_DEFAULT_THEN_KNOSSOS || (warp_type & WT_DEFAULT_WITH_FIREBALL)) {
 				float warpin_dist = shipfx_calculate_arrival_warp_distance(objp);
 
 				// project the ship forward as far as it should go

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -100,7 +100,8 @@ int Show_grid = 1;
 int Show_grid_positions = 1;
 int Show_horizon = 0;
 int Show_outlines = 0;
-bool Draw_outlines_on_selected_ships = false;
+bool Draw_outlines_on_selected_ships = true;
+bool Draw_outline_at_warpin_position = false;
 int Show_stars = 1;
 int Single_axis_constraint = 0;
 int True_rw, True_rh;
@@ -237,13 +238,6 @@ void render_model_x_htl(vec3d *pos, grid *gridp, int col_scheme = 0);
  * @param[in] objp Object to maybe draw
  */
 void render_one_model_htl(object *objp);
-
-/**
- * @brief Draws a model without HTL
- *
- * @param[in] objp Object to maybe draw
- */
-void render_one_model_nohtl(object *objp);
 
 /**
  * @brief Draws a single briefing icon, if the given object is an icon
@@ -1887,6 +1881,21 @@ void render_one_model_htl(object *objp) {
 			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 		}
 
+		if (Draw_outline_at_warpin_position && Ships[z].arrival_cue != Locked_sexp_true && Ships[z].arrival_cue != Locked_sexp_false && !Ships[z].flags[Ship::Ship_Flags::No_arrival_warp]) {
+			int warp_type = Warp_params[Ships[z].warpin_params_index].warp_type;
+			if (warp_type == WT_DEFAULT || warp_type == WT_DEFAULT_THEN_KNOSSOS || warp_type == WT_DEFAULT_WITH_FIREBALL) {
+				float warpin_dist = shipfx_calculate_arrival_warp_distance(objp);
+
+				// project the ship forward as far as it should go
+				vec3d warpin_pos;
+				vm_vec_scale_add(&warpin_pos, &objp->pos, &objp->orient.vec.fvec, warpin_dist);
+
+				render_info.set_color(65, 65, 65);	// grey; see rgba_defaults
+				render_info.set_flags(j | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
+				model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &warpin_pos);
+			}
+		}
+
 		g3_done_instance(0);
 
 		if (Show_ship_models) {
@@ -1950,142 +1959,6 @@ void render_one_model_htl(object *objp) {
 	}
 
 	render_model_x_htl(&objp->pos, The_grid);
-	render_count++;
-}
-
-void render_one_model_nohtl(object *objp) {
-	int j, z;
-	uint debug_flags = 0;
-	object *o2;
-
-	Assert(objp->type != OBJ_NONE);
-
-	if (objp->type == OBJ_JUMP_NODE) {
-		return;
-	}
-
-	if ((objp->type == OBJ_WAYPOINT) && !Show_waypoints)
-		return;
-
-	if ((objp->type == OBJ_START) && !Show_starts)
-		return;
-
-	if ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) {
-		if (!Show_ships)
-			return;
-
-		if (!Show_iff[Ships[objp->instance].team])
-			return;
-	}
-
-	if (objp->flags[Object::Object_Flags::Hidden])
-		return;
-
-	rendering_order[render_count] = OBJ_INDEX(objp);
-	Fred_outline = 0;
-
-	if (!Draw_outlines_on_selected_ships && ((OBJ_INDEX(objp) == cur_object_index) || (objp->flags[Object::Object_Flags::Marked])))
-		/* don't draw the outlines we would normally draw */;
-
-	else if ((OBJ_INDEX(objp) == cur_object_index) && !Bg_bitmap_dialog)
-		Fred_outline = FRED_COLOUR_WHITE;
-
-	else if ((objp->flags[Object::Object_Flags::Marked]) && !Bg_bitmap_dialog)  // is it a marked object?
-		Fred_outline = FRED_COLOUR_YELLOW_GREEN;
-
-	else if ((objp->type == OBJ_SHIP) && Show_outlines) {
-		color *iff_color = iff_get_color_by_team_and_object(Ships[objp->instance].team, -1, 1, objp);
-
-		Fred_outline = (iff_color->red << 16) | (iff_color->green << 8) | (iff_color->blue);
-
-	} else if ((objp->type == OBJ_START) && Show_outlines) {
-		Fred_outline = 0x007f00;
-
-	} else
-		Fred_outline = 0;
-
-	// build flags
-	if ((Show_ship_models || Show_outlines) && ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START))) {
-		if (Show_ship_models) {
-			j = MR_NORMAL;
-		} else {
-			j = MR_NO_POLYS;
-		}
-
-		if (Show_dock_points) {
-			debug_flags |= MR_DEBUG_BAY_PATHS;
-		}
-
-		if (Show_paths_fred) {
-			debug_flags |= MR_DEBUG_PATHS;
-		}
-
-		z = objp->instance;
-
-		model_clear_instance(Ship_info[Ships[z].ship_info_index].model_num);
-
-		//		if (!viewpoint || OBJ_INDEX(objp) != cur_object_index)
-		{
-			model_render_params render_info;
-
-			if (Fred_outline) {
-				render_info.set_flags(j | MR_SHOW_OUTLINE | MR_NO_TEXTURING | MR_NO_LIGHTING);
-				render_info.set_color(Fred_outline >> 16, (Fred_outline >> 8) & 0xff, Fred_outline & 0xff);
-			} else {
-				render_info.set_flags(j);
-			}
-
-			render_info.set_debug_flags(debug_flags);
-			render_info.set_replacement_textures(Ships[z].ship_replacement_textures);
-
-			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, &objp->orient, &objp->pos);
-		}
-
-	} else {
-		int r = 0, g = 0, b = 0;
-
-		if (objp->type == OBJ_SHIP) {
-			if (!Show_ships)
-				return;
-
-			color *iff_color = iff_get_color_by_team_and_object(Ships[objp->instance].team, -1, 1, objp);
-
-			r = iff_color->red;
-			g = iff_color->green;
-			b = iff_color->blue;
-
-		} else if (objp->type == OBJ_START) {
-			r = 0;	g = 127;	b = 0;
-
-		} else if (objp->type == OBJ_WAYPOINT) {
-			r = 96;	g = 0;	b = 112;
-
-		} else if (objp->type == OBJ_POINT) {
-			if (objp->instance != BRIEFING_LOOKAT_POINT_ID) {
-				return;
-			}
-
-			r = 196;	g = 32;	b = 196;
-
-		} else
-			Assert(0);
-
-		if (Fred_outline)
-			draw_orient_sphere2(Fred_outline, objp, r, g, b);
-		else
-			draw_orient_sphere(objp, r, g, b);
-	}
-
-	if (objp->type == OBJ_WAYPOINT) {
-		for (j = 0; j < render_count; j++) {
-			o2 = &Objects[rendering_order[j]];
-			if (o2->type == OBJ_WAYPOINT)
-				if ((o2->instance == objp->instance - 1) || (o2->instance == objp->instance + 1))
-					rpd_line(&o2->pos, &objp->pos);
-		}
-	}
-
-	render_model_x(&objp->pos, The_grid);
 	render_count++;
 }
 

--- a/fred2/fredrender.h
+++ b/fred2/fredrender.h
@@ -20,7 +20,8 @@ extern int Show_grid;       //!< Bool. If nonzero, draw the grid
 extern int Show_grid_positions;     //!< Bool. If nonzero, draw an elevation line from each object to the grid.
 extern int Show_coordinates;        //!< Bool. If nonzero, draw the coordinates of each object on their label
 extern int Show_outlines;           //!< Bool. If nonzero, draw each object's mesh. If models are shown, highlight them in white.
-extern bool Draw_outlines_on_selected_ships;	// If a ship is selected, don't draw the mesh lines that would normally be drawn
+extern bool Draw_outlines_on_selected_ships;	// If a ship is selected, draw mesh lines
+extern bool Draw_outline_at_warpin_position;	// Project an outline at the place where the ship will arrive after warping in
 extern int Show_stars;              //!< Bool. If nonzero, draw the starfield, nebulas, and suns. Might also handle skyboxes
 extern int Single_axis_constraint;  //!< Bool. If nonzero, constrain movement to one axis
 extern int Show_distances;          //!< Bool. If nonzero, draw lines between each object and display their distance on the middle of each line

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -263,6 +263,8 @@ BEGIN_MESSAGE_MAP(CFREDView, CView)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_OUTLINES, OnUpdateViewOutlines)
 	ON_COMMAND(ID_VIEW_OUTLINES_ON_SELECTED, OnViewOutlinesOnSelected)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_OUTLINES_ON_SELECTED, OnUpdateViewOutlinesOnSelected)
+	ON_COMMAND(ID_VIEW_OUTLINE_AT_WARPIN, OnViewOutlineAtWarpin)
+	ON_UPDATE_COMMAND_UI(ID_VIEW_OUTLINE_AT_WARPIN, OnUpdateViewOutlineAtWarpin)
 	ON_UPDATE_COMMAND_UI(ID_NEW_SHIP_TYPE, OnUpdateNewShipType)
 	ON_COMMAND(ID_SHOW_STARFIELD, OnShowStarfield)
 	ON_UPDATE_COMMAND_UI(ID_SHOW_STARFIELD, OnUpdateShowStarfield)
@@ -3767,6 +3769,18 @@ void CFREDView::OnViewOutlinesOnSelected()
 void CFREDView::OnUpdateViewOutlinesOnSelected(CCmdUI* pCmdUI) 
 {
 	pCmdUI->SetCheck(Draw_outlines_on_selected_ships);
+}
+
+void CFREDView::OnViewOutlineAtWarpin()
+{
+	Draw_outline_at_warpin_position = !Draw_outline_at_warpin_position;
+	theApp.write_ini_file();
+	Update_window = 1;
+}
+
+void CFREDView::OnUpdateViewOutlineAtWarpin(CCmdUI* pCmdUI)
+{
+	pCmdUI->SetCheck(Draw_outline_at_warpin_position);
 }
 
 void CFREDView::OnUpdateNewShipType(CCmdUI* pCmdUI) 

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -222,6 +222,8 @@ protected:
 	afx_msg void OnUpdateViewOutlines(CCmdUI* pCmdUI);
 	afx_msg void OnViewOutlinesOnSelected();
 	afx_msg void OnUpdateViewOutlinesOnSelected(CCmdUI* pCmdUI);
+	afx_msg void OnViewOutlineAtWarpin();
+	afx_msg void OnUpdateViewOutlineAtWarpin(CCmdUI* pCmdUI);
 	afx_msg void OnUpdateNewShipType(CCmdUI* pCmdUI);
 	afx_msg void OnShowStarfield();
 	afx_msg void OnUpdateShowStarfield(CCmdUI* pCmdUI);

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -1424,6 +1424,7 @@
 #define ID_SHOW_SHIPS                   32990
 #define ID_SHOW_STARTS                  32991
 #define ID_TOGGLE_VIEWPOINT             32992
+#define ID_VIEW_OUTLINE_AT_WARPIN       32993
 #define ID_CPGN_FILE_NEW                32995
 #define ID_CPGN_FILE_OPEN               32996
 #define ID_CPGN_FILE_SAVE               32997

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -21,6 +21,7 @@ struct ViewSettings {
 	bool Show_coordinates = false;
 	bool Show_outlines = false;
 	bool Draw_outlines_on_selected_ships = true;
+	bool Draw_outline_at_warpin_position = false;
 	bool Show_grid_positions = true;
 	bool Show_dock_points = false;
 	bool Show_starts = true;

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -18,6 +18,7 @@
 #include <lighting/lighting.h>
 #include <starfield/starfield.h>
 #include <ship/ship.h>
+#include <ship/shipfx.h>
 #include <jumpnode/jumpnode.h>
 #include <asteroid/asteroid.h>
 #include <iff_defs/iff_defs.h>
@@ -876,7 +877,22 @@ void FredRenderer::render_one_model_htl(object* objp,
 
 		g3_done_instance(0);
 
-		model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, &objp->orient, &objp->pos);
+		model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
+
+		if (view().Draw_outline_at_warpin_position && Ships[z].arrival_cue != Locked_sexp_true && Ships[z].arrival_cue != Locked_sexp_false && !Ships[z].flags[Ship::Ship_Flags::No_arrival_warp]) {
+			int warp_type = Warp_params[Ships[z].warpin_params_index].warp_type;
+			if (warp_type == WT_DEFAULT || warp_type == WT_DEFAULT_THEN_KNOSSOS || warp_type == WT_DEFAULT_WITH_FIREBALL) {
+				float warpin_dist = shipfx_calculate_arrival_warp_distance(objp);
+
+				// project the ship forward as far as it should go
+				vec3d warpin_pos;
+				vm_vec_scale_add(&warpin_pos, &objp->pos, &objp->orient.vec.fvec, warpin_dist);
+
+				render_info.set_color(65, 65, 65);	// grey; see rgba_defaults
+				render_info.set_flags(j | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
+				model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &warpin_pos);
+			}
+		}
 	} else {
 		int r = 0, g = 0, b = 0;
 

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -879,9 +879,13 @@ void FredRenderer::render_one_model_htl(object* objp,
 
 		model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 
-		if (view().Draw_outline_at_warpin_position && Ships[z].arrival_cue != Locked_sexp_true && Ships[z].arrival_cue != Locked_sexp_false && !Ships[z].flags[Ship::Ship_Flags::No_arrival_warp]) {
+		if (view().Draw_outline_at_warpin_position 
+			&& (Ships[z].arrival_cue != Locked_sexp_true || Ships[z].arrival_delay > 0)
+			&& Ships[z].arrival_cue != Locked_sexp_false
+			&& !Ships[z].flags[Ship::Ship_Flags::No_arrival_warp])
+		{
 			int warp_type = Warp_params[Ships[z].warpin_params_index].warp_type;
-			if (warp_type == WT_DEFAULT || warp_type == WT_DEFAULT_THEN_KNOSSOS || warp_type == WT_DEFAULT_WITH_FIREBALL) {
+			if (warp_type == WT_DEFAULT || warp_type == WT_KNOSSOS || warp_type == WT_DEFAULT_THEN_KNOSSOS || (warp_type & WT_DEFAULT_WITH_FIREBALL)) {
 				float warpin_dist = shipfx_calculate_arrival_warp_distance(objp);
 
 				// project the ship forward as far as it should go

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -286,6 +286,7 @@ void FredView::syncViewOptions() {
 	connectActionToViewSetting(ui->actionShow_Ship_Models, &_viewport->view.Show_ship_models);
 	connectActionToViewSetting(ui->actionShow_Outlines, &_viewport->view.Show_outlines);
 	connectActionToViewSetting(ui->actionDraw_Outlines_On_Selected_Ships, &_viewport->view.Draw_outlines_on_selected_ships);
+	connectActionToViewSetting(ui->actionDraw_Outline_At_Warpin_Position, &_viewport->view.Draw_outline_at_warpin_position);
 	connectActionToViewSetting(ui->actionShow_Ship_Info, &_viewport->view.Show_ship_info);
 	connectActionToViewSetting(ui->actionShow_Coordinates, &_viewport->view.Show_coordinates);
 	connectActionToViewSetting(ui->actionShow_Grid_Positions, &_viewport->view.Show_grid_positions);

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -104,6 +104,7 @@
     <addaction name="actionShow_Ship_Models"/>
     <addaction name="actionShow_Outlines"/>
     <addaction name="actionDraw_Outlines_On_Selected_Ships"/>
+    <addaction name="actionDraw_Outline_At_Warpin_Position"/>
     <addaction name="actionShow_Ship_Info"/>
     <addaction name="actionShow_Coordinates"/>
     <addaction name="actionShow_Grid_Positions"/>
@@ -766,6 +767,14 @@
    </property>
    <property name="text">
     <string>Draw Outlines on Selected Ships</string>
+   </property>
+  </action>
+  <action name="actionDraw_Outline_At_Warpin_Position">
+   <property name="checkable">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Draw Outline At Warpin Position</string>
    </property>
   </action>
   <action name="actionShow_Coordinates">


### PR DESCRIPTION
This adds the ability to calculate the arrival distance of a ship using the default warp effect.  There is a new option (in both FRED and qtFRED) to display a gray wireframe outline of the ship projected forward to its final location.

Credit to @Baezon for figuring out the math involved.