### PR TITLE
Fix for improved subsys attack pathing

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -535,11 +535,11 @@ bool ai_new_maybe_reposition_attack_subsys() {
 
 	// get world pos of eye (stored in geye)
 	ep = &(pm->view_positions[Ships[Pl_objp->instance].current_viewpoint]);
-	model_local_to_global_point(&geye, &ep->pnt, pm->id, 0, &Pl_objp->orient, &Pl_objp->pos);
+	model_local_to_global_point(&geye, &ep->pnt, pm, 0, &Pl_objp->orient, &Pl_objp->pos);
 
 	// get world pos of subsystem
-	vm_vec_unrotate(&gsubpos, &aip->targeted_subsys->system_info->pnt, &En_objp->orient);
-	vm_vec_add2(&gsubpos, &En_objp->pos);
+	pm = model_get(Ship_info[Ships[target_objp->instance].ship_info_index].model_num);
+	model_local_to_global_point(&gsubpos, &vmd_zero_vector, pm, aip->targeted_subsys->system_info->subobj_num, &En_objp->orient, &En_objp->pos);
 
 	// you're in sight! shoot it!
 	if (ship_subsystem_in_sight(En_objp, aip->targeted_subsys, &geye, &gsubpos, 0))

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -538,8 +538,8 @@ bool ai_new_maybe_reposition_attack_subsys() {
 	model_local_to_global_point(&geye, &ep->pnt, pm, 0, &Pl_objp->orient, &Pl_objp->pos);
 
 	// get world pos of subsystem
-	pm = model_get(Ship_info[Ships[target_objp->instance].ship_info_index].model_num);
-	model_local_to_global_point(&gsubpos, &vmd_zero_vector, pm, aip->targeted_subsys->system_info->subobj_num, &En_objp->orient, &En_objp->pos);
+	polymodel* tgt_pm = model_get(Ship_info[Ships[target_objp->instance].ship_info_index].model_num);
+	model_local_to_global_point(&gsubpos, &vmd_zero_vector, tgt_pm, aip->targeted_subsys->system_info->subobj_num, &En_objp->orient, &En_objp->pos);
 
 	// you're in sight! shoot it!
 	if (ship_subsystem_in_sight(En_objp, aip->targeted_subsys, &geye, &gsubpos, 0))


### PR DESCRIPTION
The target world pos should use `model_local_to_global_point` since it could be at the end of whoever knows how many subobjects parented together.