### PR TITLE
Do not clear Help Text

### DIFF
--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -517,8 +517,6 @@ void gameplay_help_leave()
 	weapon_unpause_sounds();
 	audiostream_unpause_all();
 
-	Help_text.clear();
-
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 	game_flush();
 }


### PR DESCRIPTION
Gameplay Help only inits once, so once Help_Text is populated we shouldn't clear it or we get an out of bounds vector crash upon the second time entering Gameplay Help UI.