### PR TITLE
Pause and Resume voices

### DIFF
--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -16,6 +16,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
 #include "io/key.h"
+#include "mission/missionmessage.h"
 #include "missionui/missionscreencommon.h"
 #include "sound/audiostr.h"
 #include "ui/ui.h"
@@ -516,6 +517,7 @@ void gameplay_help_leave()
 	// unpause all game sounds
 	weapon_unpause_sounds();
 	audiostream_unpause_all();
+	message_resume_all();
 
 	Help_text.clear();
 
@@ -633,6 +635,7 @@ void gameplay_help_do_frame(float  /*frametime*/)
 	// make sure game sounds are paused
 	weapon_pause_sounds();
 	audiostream_pause_all();
+	message_pause_all();
 
 	k = Ui_window.process() & ~KEY_DEBUGGED;
 	gameplay_help_process_key(k);

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -874,6 +874,7 @@ void hud_scrollback_init()
 	// pause all game sounds
 	weapon_pause_sounds();
 	audiostream_pause_all();
+	message_pause_all();
 
 	hud_initialize_scrollback_lines();
 
@@ -934,6 +935,7 @@ void hud_scrollback_close()
 	// unpause all game sounds
 	weapon_unpause_sounds();
 	audiostream_unpause_all();
+	message_resume_all();
 
 }
 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1511,7 +1511,8 @@ void game_do_end_mission_popup()
 		game_stop_time();
 		game_stop_looped_sounds();
 		audiostream_pause_all();
-		snd_stop_all();
+		weapon_pause_sounds();
+		message_pause_all();
 
 		pf_flags = PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON | PF_USE_NEGATIVE_ICON;
 		choice = popup(pf_flags, 3, POPUP_NO, XSTR( "&Yes, Quit", 28), XSTR( "Yes, &Restart", 29), XSTR( "Do you really want to end the mission?", 30));
@@ -1532,6 +1533,8 @@ void game_do_end_mission_popup()
 				game_start_subspace_ambient_sound();
 			}
 			audiostream_unpause_all();
+			weapon_unpause_sounds();
+			message_resume_all();
 			break;
 		}
 

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -21,6 +21,7 @@
 #include "io/key.h"
 #include "io/timer.h"
 #include "mission/missionhotkey.h"
+#include "mission/missionmessage.h"
 #include "missionui/missionscreencommon.h"
 #include "mod_table/mod_table.h"
 #include "object/object.h"
@@ -962,6 +963,9 @@ void mission_hotkey_init()
 	// pause all game music
 	audiostream_pause_all();
 
+	// pause all voices
+	message_pause_all();
+
 	reset_hotkeys();
 	common_set_interface_palette();  // set the interface palette
 	Ui_window.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);
@@ -1031,6 +1035,9 @@ void mission_hotkey_close()
 
 	// unpause all game music
 	audiostream_unpause_all();
+
+	// unpause all voices
+	message_resume_all();
 
 	Ui_window.destroy();
 	common_free_interface_palette();		// restore game palette

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -884,6 +884,26 @@ int message_queue_priority_compare(const message_q *ma, const message_q *mb)
 	}
 }
 
+//	Pauses all currently playing messages in the message queue
+void message_pause_all()
+{
+	for (int i = 0; i < Num_messages_playing; i++) {
+		if ((Playing_messages[i].wave.isValid()) && snd_is_playing(Playing_messages[i].wave)) {
+			snd_pause(Playing_messages[i].wave);
+		}
+	}
+}
+
+//	Resumes playing any paused messages in the message queue
+void message_resume_all()
+{
+	for (int i = 0; i < Num_messages_playing; i++) {
+		if ((Playing_messages[i].wave.isValid()) && snd_is_paused(Playing_messages[i].wave)) {
+			snd_resume(Playing_messages[i].wave);
+		}
+	}
+}
+
 // function to kill all currently playing messages.  kill_all parameter tells us to
 // kill only the animations that are playing, or wave files too
 void message_kill_all( int kill_all )

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -239,6 +239,9 @@ int	message_is_playing();
 void	message_maybe_distort();
 void	message_kill_all( int kill_all );
 
+void	message_pause_all();
+void	message_resume_all();
+
 void	message_queue_message(int message_num, int priority, int timing, const char *who_from, int source, int group, int delay, int builtin_type, int event_num_to_cancel);
 
 // functions which send messages to player -- called externally

--- a/code/missionui/missionpause.cpp
+++ b/code/missionui/missionpause.cpp
@@ -18,6 +18,7 @@
 #include "hud/hud.h"
 #include "hud/hudmessage.h"
 #include "io/key.h"
+#include "mission/missionmessage.h"
 #include "missionui/missionpause.h"
 #include "network/multi_pause.h"
 #include "object/object.h"
@@ -113,6 +114,9 @@ void pause_init()
 
 	// pause all game music
 	audiostream_pause_all();
+
+	// pause voices
+	message_pause_all();
 
 	Pause_win.create(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled, 0);	
 
@@ -249,6 +253,9 @@ void pause_close()
 
 	// unpause all weapon sounds
 	weapon_unpause_sounds();
+
+	// unpause voices
+	message_resume_all();
 
 	// deinit stuff
 	if(Pause_saved_screen != -1) {

--- a/code/network/multi_pause.cpp
+++ b/code/network/multi_pause.cpp
@@ -17,6 +17,7 @@
 #include "gamesequence/gamesequence.h"
 #include "network/stand_gui.h"
 #include "gamesnd/gamesnd.h"
+#include "mission/missionmessage.h"
 #include "network/multiutil.h"
 #include "network/multiui.h"
 #include "network/multimsgs.h"
@@ -336,6 +337,9 @@ void multi_pause_init()
 		// pause all game music
 		audiostream_pause_all();
 
+		// pause all voices
+		message_pause_all();
+
 		// switch off the text messaging system if it is active
 		multi_msg_text_flush();
 
@@ -472,6 +476,9 @@ void multi_pause_close(int end_mission)
 
 	// unpause beam weapon sounds
 	weapon_unpause_sounds();
+
+	// unpause voices
+	message_resume_all();
 
 	// eat keys timestamp
 	Multi_pause_eat = f2fl(timer_get_fixed_seconds());

--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -6,6 +6,7 @@
 #include "gamesnd/gamesnd.h"
 #include "menuui/credits.h"
 #include "menuui/mainhallmenu.h"
+#include "mission/missionmessage.h"
 #include "missionui/missionbrief.h"
 #include "render/3d.h"
 #include "weapon/weapon.h"
@@ -378,6 +379,27 @@ ADE_FUNC(pauseWeaponSounds,
 		weapon_pause_sounds();
 	} else {
 		weapon_unpause_sounds();
+	}
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(pauseVoiceMessages,
+	l_Audio,
+	"boolean pause",
+	"Pauses or unpauses all voice message sounds. The boolean argument should be true to pause and false to unpause.",
+	nullptr,
+	nullptr)
+{
+	bool pause;
+
+	if (!ade_get_args(L, "b", &pause))
+		return ADE_RETURN_NIL;
+
+	if (pause) {
+		message_pause_all();
+	} else {
+		message_resume_all();
 	}
 
 	return ADE_RETURN_NIL;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2367,6 +2367,7 @@ ADE_FUNC(initPause, l_UserInterface_PauseScreen, nullptr, "Makes sure everything
 
 	weapon_pause_sounds();
 	audiostream_pause_all();
+	message_pause_all();
 
 	Paused = true;
 
@@ -2379,6 +2380,7 @@ ADE_FUNC(closePause, l_UserInterface_PauseScreen, nullptr, "Makes sure everythin
 
 	weapon_unpause_sounds();
 	audiostream_unpause_all();
+	message_resume_all();
 
 	// FSO can run pause_init() before the actual games state change when the game loses focus
 	// so this is required to make sure that the saved screen is cleared if SCPUI takes over

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -1160,9 +1160,7 @@ int ds_get_channel(ds_sound_handle sig)
  */
 int ds_get_channel_raw(ds_sound_handle sig)
 {
-	int i;
-
-	for (i = 0; i < MAX_CHANNELS; i++) {
+	for (int i = 0; i < MAX_CHANNELS; i++) {
 		if (Channels[i].source_id && (Channels[i].sig == sig)) {
 			return i;
 		}
@@ -1192,7 +1190,7 @@ int ds_is_channel_playing(int channel_id)
  * @return Channel number, if not playing, return -1.
  * @param channel id to sound, what is returned from ds_get_channel()
  */
-int ds_is_channel_paused(int channel_id)
+bool ds_is_channel_paused(int channel_id)
 {
 	if (Channels[channel_id].source_id != 0) {
 		ALint status;
@@ -1202,7 +1200,7 @@ int ds_is_channel_paused(int channel_id)
 		return (status == AL_PAUSED);
 	}
 
-	return 0;
+	return false;
 }
 
 /**

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -1154,6 +1154,24 @@ int ds_get_channel(ds_sound_handle sig)
 }
 
 /**
+ * Return the channel number that contains the sound identified by sig.
+ * This differs from ds_get_channel() in that it does not check that the sound is currently playing.
+ * @return Channel number, if not playing, return -1.
+ */
+int ds_get_channel_raw(ds_sound_handle sig)
+{
+	int i;
+
+	for (i = 0; i < MAX_CHANNELS; i++) {
+		if (Channels[i].source_id && (Channels[i].sig == sig)) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+/**
  * @todo Documentation
  */
 int ds_is_channel_playing(int channel_id)
@@ -1170,12 +1188,52 @@ int ds_is_channel_playing(int channel_id)
 }
 
 /**
+ * Returns if a channel is paused or not.
+ * @return Channel number, if not playing, return -1.
+ * @param channel id to sound, what is returned from ds_get_channel()
+ */
+int ds_is_channel_paused(int channel_id)
+{
+	if (Channels[channel_id].source_id != 0) {
+		ALint status;
+
+		OpenAL_ErrorPrint(alGetSourcei(Channels[channel_id].source_id, AL_SOURCE_STATE, &status));
+
+		return (status == AL_PAUSED);
+	}
+
+	return 0;
+}
+
+/**
  * @todo Documentation
  */
 void ds_stop_channel(int channel_id)
 {
 	if ( Channels[channel_id].source_id != 0 ) {
 		OpenAL_ErrorPrint( alSourceStop(Channels[channel_id].source_id) );
+	}
+}
+
+/**
+ * Pauses a channel.
+ * @param channel id to sound, what is returned from ds_get_channel()
+ */
+void ds_pause_channel(int channel_id)
+{
+	if (Channels[channel_id].source_id != 0) {
+		OpenAL_ErrorPrint(alSourcePause(Channels[channel_id].source_id));
+	}
+}
+
+/**
+ * Resumes playing a channel.
+ * @param channel id to sound, what is returned from ds_get_channel()
+ */
+void ds_resume_channel(int channel_id)
+{
+	if (Channels[channel_id].source_id != 0) {
+		OpenAL_ErrorPrint(alSourcePlay(Channels[channel_id].source_id));
 	}
 }
 

--- a/code/sound/ds.h
+++ b/code/sound/ds.h
@@ -63,8 +63,12 @@ void ds_unload_buffer(int sid);
 ds_sound_handle ds_play(int sid, int snd_id, int priority, const EnhancedSoundData* enhanced_sound_data, float volume,
                         float pan, int looping, bool is_voice_msg = false);
 int ds_get_channel(ds_sound_handle sig);
+int ds_get_channel_raw(ds_sound_handle sig);
 int ds_is_channel_playing(int channel);
+int ds_is_channel_paused(int channel_id);
 void ds_stop_channel(int channel);
+void ds_pause_channel(int channel_id);
+void ds_resume_channel(int channel_id);
 void ds_stop_channel_all();
 void ds_set_volume( int channel, float vol );
 void ds_set_pan( int channel, float pan );

--- a/code/sound/ds.h
+++ b/code/sound/ds.h
@@ -65,7 +65,7 @@ ds_sound_handle ds_play(int sid, int snd_id, int priority, const EnhancedSoundDa
 int ds_get_channel(ds_sound_handle sig);
 int ds_get_channel_raw(ds_sound_handle sig);
 int ds_is_channel_playing(int channel);
-int ds_is_channel_paused(int channel_id);
+bool ds_is_channel_paused(int channel_id);
 void ds_stop_channel(int channel);
 void ds_pause_channel(int channel_id);
 void ds_resume_channel(int channel_id);

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -966,6 +966,48 @@ void snd_stop(sound_handle sig)
 }
 
 /**
+ * Pauses a sound
+ *
+ * @param sig handle to sound, what is returned from snd_play()
+ */
+void snd_pause(sound_handle sig)
+{
+	int channel;
+
+	if (!ds_initialized)
+		return;
+	if (!sig.isValid())
+		return;
+
+	channel = ds_get_channel(sig);
+	if (channel == -1)
+		return;
+
+	ds_pause_channel(channel);
+}
+
+/**
+ * Resumes a sound
+ *
+ * @param sig handle to sound, what is returned from snd_play()
+ */
+void snd_resume(sound_handle sig)
+{
+	int channel;
+
+	if (!ds_initialized)
+		return;
+	if (!sig.isValid())
+		return;
+
+	channel = ds_get_channel_raw(sig);
+	if (channel == -1)
+		return;
+
+	ds_resume_channel(channel);
+}
+
+/**
  * Stop all playing sound channels (including looping sounds)
  *
  * NOTE: This stops all sounds that are playing from Channels[] sound buffers.
@@ -1139,6 +1181,38 @@ int snd_is_playing(sound_handle sig)
 
 	is_playing = ds_is_channel_playing(channel);
 	if ( is_playing == TRUE ) {
+		return 1;
+	}
+
+	return 0;
+}
+
+// ---------------------------------------------------------------------------------------
+// snd_is_paused()
+//
+// Determine if a sound is paused
+//
+// returns:			1				=> sound is currently paused
+//						0				=> sound is not paused
+//
+// parameters:		sig	=> signature of sound, what is returned from snd_play()
+//
+int snd_is_paused(sound_handle sig)
+{
+	int channel, is_paused;
+
+	if (!ds_initialized)
+		return 0;
+
+	if (!sig.isValid())
+		return 0;
+
+	channel = ds_get_channel_raw(sig);
+	if (channel == -1)
+		return 0;
+
+	is_paused = ds_is_channel_paused(channel);
+	if (is_paused == TRUE) {
 		return 1;
 	}
 

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -972,14 +972,12 @@ void snd_stop(sound_handle sig)
  */
 void snd_pause(sound_handle sig)
 {
-	int channel;
-
 	if (!ds_initialized)
 		return;
 	if (!sig.isValid())
 		return;
 
-	channel = ds_get_channel(sig);
+	int channel = ds_get_channel(sig);
 	if (channel == -1)
 		return;
 
@@ -993,14 +991,12 @@ void snd_pause(sound_handle sig)
  */
 void snd_resume(sound_handle sig)
 {
-	int channel;
-
 	if (!ds_initialized)
 		return;
 	if (!sig.isValid())
 		return;
 
-	channel = ds_get_channel_raw(sig);
+	int channel = ds_get_channel_raw(sig);
 	if (channel == -1)
 		return;
 
@@ -1197,26 +1193,20 @@ int snd_is_playing(sound_handle sig)
 //
 // parameters:		sig	=> signature of sound, what is returned from snd_play()
 //
-int snd_is_paused(sound_handle sig)
+bool snd_is_paused(sound_handle sig)
 {
-	int channel, is_paused;
-
 	if (!ds_initialized)
-		return 0;
+		return false;
 
 	if (!sig.isValid())
-		return 0;
+		return false;
 
-	channel = ds_get_channel_raw(sig);
+	int channel = ds_get_channel_raw(sig);
 	if (channel == -1)
-		return 0;
+		return false;
 
-	is_paused = ds_is_channel_paused(channel);
-	if (is_paused == TRUE) {
-		return 1;
-	}
+	return ds_is_channel_paused(channel);
 
-	return 0;
 }
 
 // ---------------------------------------------------------------------------------------

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -185,7 +185,7 @@ void	snd_stop_all();
 // determines if the sound handle is still palying
 int snd_is_playing(sound_handle snd_handle);
 
-int snd_is_paused(sound_handle sig);
+bool snd_is_paused(sound_handle sig);
 
 // change the looping status of a sound that is playing
 void snd_chg_loop_status(sound_handle snd_handle, int loop);

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -161,6 +161,10 @@ sound_handle snd_play_looping(game_snd* gs, float pan = 0.0f, int start_loop = -
 
 void snd_stop(sound_handle snd_handle);
 
+void snd_pause(sound_handle snd_handle);
+
+void snd_resume(sound_handle snd_handle);
+
 // Sets the volume of a sound that is already playing.
 // The volume is between 0 and 1.0, where 0 is the
 // inaudible and 1.0 is the loudest sound in the game.
@@ -180,6 +184,8 @@ void	snd_stop_all();
 
 // determines if the sound handle is still palying
 int snd_is_playing(sound_handle snd_handle);
+
+int snd_is_paused(sound_handle sig);
 
 // change the looping status of a sound that is playing
 void snd_chg_loop_status(sound_handle snd_handle, int loop);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5234,6 +5234,7 @@ void game_leave_state( int old_state, int new_state )
 				if (Game_mode & GM_IN_MISSION) {
 					weapon_unpause_sounds();
 					audiostream_unpause_all();
+					message_resume_all();
 
 					// multi doesn't pause here so time keeps going
 					if ( !(Game_mode & GM_MULTIPLAYER) ) {
@@ -5744,6 +5745,7 @@ void game_enter_state( int old_state, int new_state )
 				if (Game_mode & GM_IN_MISSION) {
 					weapon_pause_sounds();
 					audiostream_pause_all();
+					message_pause_all();
 
 					// multi doesn't pause here so time needs to keep going
 					if ( !(Game_mode & GM_MULTIPLAYER) ) {


### PR DESCRIPTION
Not sure if this ever worked in retail, but it should in 2023. This adds sound methods to pause and resume sound handles which are then used in mission message to pause and resume voices. I've added the appropriate pause/resume methods to all areas expected (essentially all the same places where weapons and audiostreams (music) are paused as well).