### PR TITLE
add wing status to red-alert system

### DIFF
--- a/code/missionui/redalert.h
+++ b/code/missionui/redalert.h
@@ -26,8 +26,8 @@ void	red_alert_invalidate_timestamp();
 int	red_alert_in_progress();
 void red_alert_maybe_move_to_next_mission();
 
-void red_alert_store_wingman_status();
-void red_alert_bash_wingman_status();
+void red_alert_store_ship_status();
+void red_alert_bash_ship_status();
 void red_alert_clear();
 
 void red_alert_voice_pause();
@@ -52,7 +52,20 @@ typedef struct red_alert_ship_status {
 	SCP_vector<wep_t>	secondary_weapons;
 } red_alert_ship_status;
 
-extern SCP_vector<red_alert_ship_status> Red_alert_wingman_status;
+typedef struct red_alert_wing_status {
+	SCP_string	name;
+	int			latest_wave = 0;
+
+	// these aren't currently used but might be needed in the future
+	int			wave_count = 0;
+	int			total_arrived_count = 0;
+	int			total_departed = 0;
+	int			total_destroyed = 0;
+	int			total_vanished = 0;
+} red_alert_wing_status;
+
+extern SCP_vector<red_alert_ship_status> Red_alert_ship_status;
+extern SCP_vector<red_alert_wing_status> Red_alert_wing_status;
 extern SCP_string Red_alert_precursor_mission;
 #endif
 

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -16,6 +16,7 @@ struct sexp_container;
 // current pilot constants
 static const unsigned int PLR_FILE_ID = 0x5f524c50;	// "PLR_" in file
 static const unsigned int CSG_FILE_ID = 0x5f475343;	// "CSG_" in file
+
 // NOTE: Version should be bumped only for adding/removing sections or section
 //       content.  It should *NOT* be bumped for limit bumps or anything of
 //       that sort!
@@ -26,6 +27,7 @@ static const unsigned int CSG_FILE_ID = 0x5f475343;	// "CSG_" in file
 //   3 - Add SEXP containers
 //   4   Controls are removed, and instead a preset name is saved/loaded
 static const ubyte PLR_VERSION = 4;
+
 //   0 - initial version
 //   1 - re-add recent missions
 //   2 - separate single/multi squad name & pic
@@ -34,7 +36,8 @@ static const ubyte PLR_VERSION = 4;
 //   5 - save rank to flags for quick access
 //   6 - add SEXP containers
 //   7 - Controls are removed, and instead a preset name is saved/loaded.
-static const ubyte CSG_VERSION = 7;
+//   8 - red-alert wing status
+static const ubyte CSG_VERSION = 8;
 
 // pilotfile::version and pilotfile::csg_version value when a file isn't loaded (or was just closed)
 static const ubyte PLR_VERSION_INVALID = 0xFF;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6237,10 +6237,14 @@ void ship_add_exited_ship( ship *sp, Ship::Exit_Flags reason )
 	entry.obj_signature = Objects[sp->objnum].signature;
 	entry.ship_class = sp->ship_info_index;
 	entry.team = sp->team;
+	entry.wingnum = sp->wingnum;
 	entry.flags += reason;
-	// if ship is red alert, flag as such
+	// copy some flags
 	if (sp->flags[Ship_Flags::Red_alert_store_status]) {
         entry.flags.set(Ship::Exit_Flags::Red_alert_carry);
+	}
+	if (sp->flags[Ship_Flags::From_player_wing]) {
+		entry.flags.set(Ship::Exit_Flags::From_player_wing);
 	}
 	entry.time = Missiontime;
 	entry.hull_strength = int(Objects[sp->objnum].hull_strength);
@@ -6473,7 +6477,6 @@ vec3d get_submodel_offset(int model, int submodel){
 // Reset all ship values to empty/unused.
 void ship::clear()
 {
-
 	objnum = -1;
 	ai_index = -1;
 	ship_info_index = -1;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -881,6 +881,7 @@ typedef struct exited_ship {
 	int		obj_signature;
 	int		ship_class;
 	int		team;
+	int		wingnum;
 	flagset<Ship::Exit_Flags> flags;
 	fix		time;
 	int		hull_strength;

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -149,6 +149,7 @@ namespace Ship {
 		Player_deleted,
 		Been_tagged,
 		Red_alert_carry,
+		From_player_wing,
 
 		NUM_VALUES
 	};

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1351,9 +1351,9 @@ void game_post_level_init()
 							(The_mission.ambient_light_level >> 8) & 0xff,
 							(The_mission.ambient_light_level >> 16) & 0xff);
 
-	// If this is a red alert mission in campaign mode, bash wingman status
+	// If this is a red alert mission in campaign mode, bash status
 	if ( (Game_mode & GM_CAMPAIGN_MODE) && red_alert_mission() ) {
-		red_alert_bash_wingman_status();
+		red_alert_bash_ship_status();
 	}
 
 	freespace_mission_load_stuff();


### PR DESCRIPTION
If consecutive red-alert missions have different numbers of ships in a wing, then calculating the number of waves will not be correct.  This necessitates the addition of wing status to the stored data for red-alert sequences.

Not only must wing data be stored in `Red_alert_wing_status`, but also in the CSG file.  This necessitates a version bump.  Fortunately, the current design of CSG files allows extra data to be added to a section without breaking old builds, since the CSG loader will just skip over the unrecognized data.

This also renames `red_alert_wingman_status` to `red_alert_ship_status` since it's not limited to wingmen, as well as fixing the omission of exited ships if they are in the player's wing but don't have the red-alert-carry flag.

Fixes #5637.  Follow-up to #4457 and #5609.