### PR TITLE
tweak mac build packaging

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -287,13 +287,15 @@ jobs:
           XDG_RUNTIME_DIR: /root
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
       - name: Package build result
-        working-directory: ./build
-        run: cd bin && tar -cvzf macos-build-${{ matrix.configuration }}.tar.gz *.app
+        working-directory: ./build/bin
+        # Use GNU tar here (part of runner image) to avoid weird corruption bug with bsdtar
+        # Ref: https://github.com/actions/runner-images/issues/2619
+        run: gtar -cvzf macos-build-${{ matrix.configuration }}.tgz *.app
       - name: Upload build result
         uses: actions/upload-artifact@v2
         with:
           name: mac-${{ matrix.configuration }}
-          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tar.gz
+          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tgz
   mac_zip:
     name: Build Mac distribution zip
     needs: build_mac
@@ -311,17 +313,14 @@ jobs:
         with:
           name: mac-Release
           path: builds
-      - name: Unpack Release build
-        working-directory: ./builds
-        run: tar -xvzf macos-build-Release.tar.gz
       - name: Download FastDebug builds
         uses: actions/download-artifact@v2
         with:
           name: mac-FastDebug
           path: builds
-      - name: Unpack FastDebug build
+      - name: Unpack builds
         working-directory: ./builds
-        run: tar -xvzf macos-build-FastDebug.tar.gz
+        run: tar -xvzf macos-build*.tgz
       - name: Create Distribution package
         working-directory: ./builds
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -380,13 +380,15 @@ jobs:
           XDG_RUNTIME_DIR: /root
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
       - name: Package build result
-        working-directory: ./build
-        run: cd bin && tar -cvzf macos-build-${{ matrix.configuration }}.tar.gz *.app
+        working-directory: ./build/bin
+        # Use GNU tar here (part of runner image) to avoid weird corruption bug with bsdtar
+        # Ref: https://github.com/actions/runner-images/issues/2619
+        run: gtar -cvzf macos-build-${{ matrix.configuration }}.tgz *.app
       - name: Upload build result
         uses: actions/upload-artifact@v2
         with:
           name: mac-${{ matrix.configuration }}
-          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tar.gz
+          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tgz
   mac_zip:
     name: Build Mac distribution zip
     needs: build_mac
@@ -404,17 +406,14 @@ jobs:
         with:
           name: mac-Release
           path: builds
-      - name: Unpack Release build
-        working-directory: ./builds
-        run: tar -xvzf macos-build-Release.tar.gz
       - name: Download FastDebug builds
         uses: actions/download-artifact@v2
         with:
           name: mac-FastDebug
           path: builds
-      - name: Unpack FastDebug build
+      - name: Unpack builds
         working-directory: ./builds
-        run: tar -xvzf macos-build-FastDebug.tar.gz
+        run: tar -xvzf macos-build*.tgz
       - name: Create Distribution package
         id: generate_package
         working-directory: ./builds

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -300,13 +300,15 @@ jobs:
           XDG_RUNTIME_DIR: /root
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
       - name: Package build result
-        working-directory: ./build
-        run: cd bin && tar -cvzf macos-build-${{ matrix.configuration }}.tar.gz *.app
+        working-directory: ./build/bin
+        # Use GNU tar here (part of runner image) to avoid weird corruption bug with bsdtar
+        # Ref: https://github.com/actions/runner-images/issues/2619
+        run: gtar -cvzf macos-build-${{ matrix.configuration }}.tgz *.app
       - name: Upload build result
         uses: actions/upload-artifact@v2
         with:
           name: mac-${{ matrix.configuration }}
-          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tar.gz
+          path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tgz
   mac_zip:
     name: Build Mac distribution zip
     needs: build_mac
@@ -324,17 +326,14 @@ jobs:
         with:
           name: mac-Release
           path: builds
-      - name: Unpack Release build
-        working-directory: ./builds
-        run: tar -xvzf macos-build-Release.tar.gz
       - name: Download FastDebug builds
         uses: actions/download-artifact@v2
         with:
           name: mac-FastDebug
           path: builds
-      - name: Unpack FastDebug build
+      - name: Unpack builds
         working-directory: ./builds
-        run: tar -xvzf macos-build-FastDebug.tar.gz
+        run: tar -xvzf macos-build*.tgz
       - name: Create Distribution package
         working-directory: ./builds
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac


### PR DESCRIPTION
Use GNU tar instead of the default bsdtar. This works around some weird corruption bug triggered by the combination of the GitHub runner-VM, the llvm linker, and bsdtar.

Adjust intermediate filenames such that they don't get uploaded to indiegames by mistake.

Unpack builds as a single step instead of two.