### PR TITLE
Vectorize Shields_sys_types

### DIFF
--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -806,8 +806,8 @@ void clear_mission()
 	Shield_sys_teams.clear();
 	Shield_sys_teams.resize(Iff_info.size(), 0);
 
-	Shields_sys_types.clear();
-	Shields_sys_types.resize(ship_info_size(), 0);
+	Shield_sys_types.clear();
+	Shield_sys_types.resize(ship_info_size(), 0);
 
 	set_cur_indices(-1);
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -806,9 +806,8 @@ void clear_mission()
 	Shield_sys_teams.clear();
 	Shield_sys_teams.resize(Iff_info.size(), 0);
 
-	for (i=0; i<MAX_SHIP_CLASSES; i++){
-		Shield_sys_types[i] = 0;
-	}
+	Shields_sys_types.clear();
+	Shields_sys_types.resize(ship_info_size(), 0);
 
 	set_cur_indices(-1);
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -521,7 +521,7 @@ int create_ship(matrix *orient, vec3d *pos, int ship_type)
 
 	// default shield setting
 	shipp->special_shield = -1;
-	z1 = Shield_sys_teams[shipp->team];
+	z1 = Shield_sys_types[shipp->team];
 	z2 = Shield_sys_types[ship_type];
     if (((z1 == 1) && z2) || (z2 == 1))
         Objects[obj].flags.set(Object::Object_Flags::No_shields);

--- a/fred2/shieldsysdlg.cpp
+++ b/fred2/shieldsysdlg.cpp
@@ -58,7 +58,7 @@ END_MESSAGE_MAP()
 BOOL shield_sys_dlg::OnInitDialog() 
 {
 	int i, z;
-	SCP_vector<int> teams(Iff_info.size(), 0) 
+	SCP_vector<int> teams(Iff_info.size(), 0);
 	SCP_vector<int> types(ship_info_size(), 0);
 	CComboBox *box;
 

--- a/fred2/shieldsysdlg.cpp
+++ b/fred2/shieldsysdlg.cpp
@@ -22,7 +22,7 @@ static char THIS_FILE[] = __FILE__;
 #endif
 
 SCP_vector<int> Shield_sys_teams;
-int Shield_sys_types[MAX_SHIP_CLASSES] = {0};
+SCP_vector<int> Shield_sys_types(ship_info_size(), 0);
 
 /////////////////////////////////////////////////////////////////////////////
 // shield_sys_dlg dialog
@@ -58,15 +58,9 @@ END_MESSAGE_MAP()
 BOOL shield_sys_dlg::OnInitDialog() 
 {
 	int i, z;
-	int* teams = new int[Iff_info.size()]();
-	int types[MAX_SHIP_CLASSES];
+	SCP_vector<int> teams(Iff_info.size(), 0) 
+	SCP_vector<int> types(ship_info_size(), 0);
 	CComboBox *box;
-
-	for (i=0; i< (int)Iff_info.size(); i++)
-		teams[i] = 0;
-
-	for (i=0; i<MAX_SHIP_CLASSES; i++)
-		types[i] = 0;
 
 	for (i=0; i<MAX_SHIPS; i++)
 		if (Ships[i].objnum >= 0) {
@@ -84,8 +78,6 @@ BOOL shield_sys_dlg::OnInitDialog()
 			teams[Ships[i].team]++;
 			types[Ships[i].ship_info_index]++;
 		}
-
-	delete[] teams;
 
 	box = (CComboBox *) GetDlgItem(IDC_TYPE);
 	box->ResetContent();

--- a/fred2/shieldsysdlg.h
+++ b/fred2/shieldsysdlg.h
@@ -10,7 +10,7 @@
 
 
 extern SCP_vector<int> Shield_sys_teams;
-extern int Shield_sys_types[MAX_SHIP_CLASSES];
+extern SCP_vector<int> Shield_sys_types;
 
 /////////////////////////////////////////////////////////////////////////////
 // shield_sys_dlg dialog

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -100,7 +100,7 @@ extern int Nmodel_bitmap;
 namespace fso {
 namespace fred {
 	
-Editor::Editor() : currentObject{ -1 }, Shield_sys_teams(Iff_info.size(), 0), Shield_sys_types(MAX_SHIP_CLASSES, 0) {
+Editor::Editor() : currentObject{ -1 }, Shield_sys_teams(Iff_info.size(), 0), Shield_sys_types(ship_info_size(), 0) {
 	connect(fredApp, &FredApplication::onIdle, this, &Editor::update);
 
 	// When the mission changes we need to update all renderers
@@ -408,9 +408,8 @@ void Editor::clearMission() {
 	Shield_sys_teams.clear();
 	Shield_sys_teams.resize(Iff_info.size(), 0);
 
-	for (int i = 0; i < MAX_SHIP_CLASSES; i++) {
-		Shield_sys_types[i] = 0;
-	}
+	Shield_sys_types.clear();
+	Shield_sys_types.resize(ship_info_size(), 0);
 
 	setupCurrentObjectIndices(-1);
 
@@ -3119,7 +3118,7 @@ void Editor::importShieldSysData(const std::vector<int>& teams, const std::vecto
 // 0 = has shields, 1 = no shields, 2 = conflict/inconsistent
 void Editor::normalizeShieldSysData() {
 	std::vector<int> teams(Iff_info.size(), 0);
-	std::vector<int> types(MAX_SHIP_CLASSES, 0);
+	std::vector<int> types(ship_info_size(), 0);
 
 	for (int i = 0; i < MAX_SHIPS; i++) {
 		if (Ships[i].objnum >= 0) {

--- a/qtfred/src/mission/dialogs/ShieldSystemDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShieldSystemDialogModel.cpp
@@ -8,7 +8,7 @@ namespace fred {
 namespace dialogs {
 
 ShieldSystemDialogModel::ShieldSystemDialogModel(QObject* parent, EditorViewport* viewport) :
-	AbstractDialogModel(parent, viewport), _teams(Iff_info.size(), 0), _types(MAX_SHIP_CLASSES, 0) {
+	AbstractDialogModel(parent, viewport), _teams(Iff_info.size(), 0), _types(ship_info_size(), 0) {
 
 	initializeData();
 }

--- a/qtfred/src/mission/dialogs/ShieldSystemDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShieldSystemDialogModel.h
@@ -20,7 +20,7 @@ class ShieldSystemDialogModel: public AbstractDialogModel {
 	int getCurrentTeam() const { return _currTeam; }
 	int getCurrentShipType() const { return _currType; }
 	void setCurrentTeam(int team) { Assert(team >= 0 && team < (int)Iff_info.size());  modify<int>(_currTeam, team); }
-	void setCurrentShipType(int type) { Assert(type >= 0 && type < MAX_SHIP_CLASSES); modify<int>(_currType, type); }
+	void setCurrentShipType(int type) { Assert(type >= 0 && type < ship_info_size()); modify<int>(_currType, type); }
 
 	int getCurrentTeamShieldSys() const { return _teams[_currTeam]; }
 	int getCurrentTypeShieldSys() const { return _types[_currType]; }


### PR DESCRIPTION
This should safely vectorize Shields_sys_types, a global used to help manage shield systems.  This lowers the number of references to MAX_SHIP_CLASSES to 3 main areas: reload code, campaign saves, and one other dialog in FRED2.

I can't test these changes as I'm on a mac and cannot build FRED2.