### PR TITLE
Remove MAX_SHIP_CLASSES from altshipclassdlg

### DIFF
--- a/fred2/AltShipClassDlg.cpp
+++ b/fred2/AltShipClassDlg.cpp
@@ -42,7 +42,8 @@ AltShipClassDlg::AltShipClassDlg(CWnd* pParent /*=NULL*/)
 	num_string_variables = 0;
 
 	memset(string_variable_indices, -1, sizeof (int)*MAX_SEXP_VARIABLES); 
-	memset(ship_class_indices, -1, sizeof (int)*MAX_SHIP_CLASSES);
+	ship_class_indices.clear();
+	ship_class_indices.resize(ship_info_size(), -1);
 }
 
 void AltShipClassDlg::alt_class_list_rebuild() {
@@ -70,7 +71,7 @@ void AltShipClassDlg::alt_class_list_rebuild() {
 			// add it to the list
 			m_alt_class_list.AddString(buff);
 		} else {
-			if (alt_class_pool[i].ship_class >= 0 && alt_class_pool[i].ship_class < MAX_SHIP_CLASSES) {
+			if (alt_class_pool[i].ship_class >= 0 && alt_class_pool[i].ship_class < ship_info_size()) {
 				m_alt_class_list.AddString(Ship_info[alt_class_pool[i].ship_class].name);
 			} else {
 				m_alt_class_list.AddString("Invalid Ship Class");
@@ -319,7 +320,7 @@ void AltShipClassDlg::OnSelchangeAltClassList() {
 	}
 	// Ship selected
 	else {
-		for (i = 0; i < MAX_SHIP_CLASSES; i++) {
+		for (i = 0; i < ship_info_size(); i++) {
 			if (ship_class_indices[i] == alt_class_pool[index].ship_class) {
 				ship_selection = i;
 				break;

--- a/fred2/AltShipClassDlg.h
+++ b/fred2/AltShipClassDlg.h
@@ -109,7 +109,7 @@ private:
 
 	int num_string_variables;                           //!< Number of string variables in the mission
 	int string_variable_indices[MAX_SEXP_VARIABLES];    //!< maps string variables to their index in Sexp_variables
-	int ship_class_indices[MAX_SHIP_CLASSES];           //!< maps ships in the ships combobox to their index in Ship_info
+	SCP_vector ship_class_indices;           //!< maps ships in the ships combobox to their index in Ship_info
 
 	//!@
 	//! Multi-edit member.

--- a/fred2/AltShipClassDlg.h
+++ b/fred2/AltShipClassDlg.h
@@ -109,7 +109,7 @@ private:
 
 	int num_string_variables;                           //!< Number of string variables in the mission
 	int string_variable_indices[MAX_SEXP_VARIABLES];    //!< maps string variables to their index in Sexp_variables
-	SCP_vector ship_class_indices;           //!< maps ships in the ships combobox to their index in Ship_info
+	SCP_vector<int> ship_class_indices;           //!< maps ships in the ships combobox to their index in Ship_info
 
 	//!@
 	//! Multi-edit member.


### PR DESCRIPTION
This should safely remove MAX_SHIP_CLASSES from the alt ship classes dialog.  Again, I'm unable to test or build on a mac.