### PR TITLE
fix bad extraction command in mac distribution zip

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -320,7 +320,9 @@ jobs:
           path: builds
       - name: Unpack builds
         working-directory: ./builds
-        run: tar -xvzf macos-build*.tgz
+        run: |
+          tar -xvzf macos-build-Release.tgz
+          tar -xvzf macos-build-FastDebug.tgz
       - name: Create Distribution package
         working-directory: ./builds
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -413,7 +413,9 @@ jobs:
           path: builds
       - name: Unpack builds
         working-directory: ./builds
-        run: tar -xvzf macos-build*.tgz
+        run: |
+          tar -xvzf macos-build-Release.tgz
+          tar -xvzf macos-build-FastDebug.tgz
       - name: Create Distribution package
         id: generate_package
         working-directory: ./builds

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -333,7 +333,9 @@ jobs:
           path: builds
       - name: Unpack builds
         working-directory: ./builds
-        run: tar -xvzf macos-build*.tgz
+        run: |
+          tar -xvzf macos-build-Release.tgz
+          tar -xvzf macos-build-FastDebug.tgz
       - name: Create Distribution package
         working-directory: ./builds
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac


### PR DESCRIPTION
And this kids, is why you don't test locally on a system with a bunch of shell aliases and helpers in use.