### PR TITLE
Fix near z planes for the cockpit rendering

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -24,6 +24,8 @@ layout (std140) uniform globalDeferredData {
 
 	float invScreenWidth;
 	float invScreenHeight;
+
+	float nearPlane;
 };
 
 layout (std140) uniform matrixData {
@@ -168,7 +170,7 @@ void main()
 	vec2 screenPos = gl_FragCoord.xy * vec2(invScreenWidth, invScreenHeight);
 	vec3 position = texture(PositionBuffer, screenPos).xyz;
 
-	if(abs(dot(position, position)) < 0.1)
+	if(abs(dot(position, position)) < nearPlane * nearPlane)
 		discard;
 
 	vec3 diffColor = texture(ColorBuffer, screenPos).rgb;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -188,6 +188,7 @@ int gr_stencil_mode = 0;
 // Default clipping distances
 const float Default_min_draw_distance = 1.0f;
 const float Default_max_draw_distance = 1e10;
+float Min_draw_distance_cockpit = 0.02f;
 float Min_draw_distance = Default_min_draw_distance;
 float Max_draw_distance = Default_max_draw_distance;
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -36,6 +36,7 @@ class OverridableHook;
 
 extern const float Default_min_draw_distance;
 extern const float Default_max_draw_distance;
+extern float Min_draw_distance_cockpit;
 extern float Min_draw_distance;
 extern float Max_draw_distance;
 extern int Gr_inited;

--- a/code/graphics/matrix.cpp
+++ b/code/graphics/matrix.cpp
@@ -16,6 +16,8 @@ matrix4 gr_texture_matrix;
 
 matrix4 gr_env_texture_matrix;
 
+float gr_near_plane;
+
 bool gr_htl_projection_matrix_set = false;
 
 static int modelview_matrix_depth = 1;
@@ -138,6 +140,7 @@ void gr_set_proj_matrix(float fov, float aspect, float z_near, float z_far) {
 	gr_htl_projection_matrix_set = true;
 
 	matrix_uniform_up_to_date = false;
+	gr_near_plane = z_near;
 }
 
 void gr_end_proj_matrix() {

--- a/code/graphics/matrix.h
+++ b/code/graphics/matrix.h
@@ -8,6 +8,7 @@ extern matrix4 gr_model_view_matrix;
 extern matrix4 gr_projection_matrix;
 extern matrix4 gr_last_projection_matrix;
 extern matrix4 gr_env_texture_matrix;
+extern float gr_near_plane;
 
 void gr_matrix_on_frame();
 

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -254,6 +254,7 @@ void gr_opengl_deferred_lighting_finish()
 
 		header->invScreenWidth = 1.0f / gr_screen.max_w;
 		header->invScreenHeight = 1.0f / gr_screen.max_h;
+		header->nearPlane = gr_near_plane;
 
 		// Only the first directional light uses shaders so we need to know when we already saw that light
 		bool first_directional = true;

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -30,8 +30,9 @@ struct deferred_global_data {
 
 	float invScreenWidth;
 	float invScreenHeight;
+	float nearPlane;
 
-	float pad[2];
+	float pad;
 };
 
 /**

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7769,7 +7769,7 @@ void ship_render_player_ship(object* objp) {
 	if (prerenderShipModel) {
 		gr_post_process_save_zbuffer();
 
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.05f, Max_draw_distance);
+		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance_cockpit, Max_draw_distance);
 		gr_set_view_matrix(&leaning_position, &eye_orient);
 
 		model_render_params render_info;
@@ -7841,7 +7841,7 @@ void ship_render_player_ship(object* objp) {
 		gr_clear_states();
 	}
 
-	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, 0.02f, Max_draw_distance);
+	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance_cockpit, Max_draw_distance);
 	gr_set_view_matrix(&leaning_position, &eye_orient);
 
 	Shadow_view_matrix_render = gr_view_matrix;
@@ -7889,7 +7889,7 @@ void ship_render_player_ship(object* objp) {
 		gr_end_view_matrix();
 		gr_end_proj_matrix();
 
-		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
+		gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance_cockpit, Max_draw_distance);
 		gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
 		gr_deferred_lighting_msaa();


### PR DESCRIPTION
This gets rid of dark, unshaded spheres in the cockpit close to the camera by doing two things:
1. Unify all near-z distances used in cockpit rendering to one common value, and make that a proper variable instead of hardcoding it everywhere.
2. Properly pass that to the deferred lighting shader instead of having a magic constant for closest allowed shading distance in there.