### PR TITLE
Fix HUD slewing

### DIFF
--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -734,6 +734,43 @@ void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool m
 	}
 }
 
+void generic_anim_render_ex(generic_anim* ga, float frametime, int x, int y, int w, int h, bool menu, const generic_extras* ge)
+{
+	if ((ge != nullptr) && (ga->use_hud_color == true)) {
+		Warning(LOCATION, "Monochrome generic anims can't use extra info (yet)");
+		return;
+	}
+
+	float a = 1.0f;
+	if (ge != nullptr) {
+		a = ge->alpha;
+	}
+	if (ga->type == BM_TYPE_PNG) {
+		generic_anim_render_variable_frame_delay(ga, frametime, a);
+	}
+	else {
+		generic_anim_render_fixed_frame_delay(ga, frametime, a);
+	}
+
+	if (ga->num_frames > 0) {
+		ga->previous_frame = ga->current_frame;
+
+		if (ga->use_hud_color) {
+			gr_aabitmap_ex(x, y, w, h, 0, 0, (menu ? GR_RESIZE_MENU : GR_RESIZE_FULL));
+		}
+		else {
+			if (ge == nullptr) {
+				gr_bitmap_ex(x, y, w, h, 0, 0, (menu ? GR_RESIZE_MENU : GR_RESIZE_FULL));
+			}
+			else if (ge->draw == true) {
+				// currently only for lua streaminganim objects
+				// and don't draw them unless requested...
+				gr_bitmap_uv(x, y, w, h, ge->u0, ge->v0, ge->u1, ge->v1, ge->resize_mode);
+			}
+		}
+	}
+}
+
 /*
  * @brief reset an animation back to the start
  *

--- a/code/graphics/generic.h
+++ b/code/graphics/generic.h
@@ -91,5 +91,6 @@ int generic_anim_stream(generic_anim *ga, const bool cache = true);
 int generic_bitmap_load(generic_bitmap *gb);
 void generic_anim_unload(generic_anim *ga);
 void generic_anim_render(generic_anim *ga, float frametime, int x, int y, bool menu = false, const generic_extras *ge = nullptr);
+void generic_anim_render_ex(generic_anim* ga, float frametime, int x, int y, int w, int h, bool menu = false, const generic_extras* ge = nullptr);
 void generic_anim_reset(generic_anim *ga);
 #endif

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1033,8 +1033,8 @@ void HudGauge::renderCircle(int x, int y, int diameter, bool filled)
 
 void HudGauge::setClip(int x, int y, int w, int h)
 {
-	int hx = fl2i(HUD_offset_x);
-	int hy = fl2i(HUD_offset_y);
+	int hx;
+	int hy;
 
 	if ( gr_screen.rendering_to_texture != -1 ) {
 		gr_set_screen_scale(canvas_w, canvas_h, -1, -1, target_w, target_h, target_w, target_h, true);
@@ -1051,6 +1051,8 @@ void HudGauge::setClip(int x, int y, int w, int h)
 
 		gr_set_clip(hx, hy, w, h);
 	} else {
+		hx = fl2i(HUD_offset_x);
+		hy = fl2i(HUD_offset_y);
 		if (reticle_follow) {
 			hx += HUD_nose_x;
 			hy += HUD_nose_y;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -91,10 +91,6 @@ color HUD_color_debug;										// grey debug text shown on HUD
 
 static sound_handle Player_engine_snd_loop = sound_handle::invalid();
 
-// HUD render frame offsets
-float HUD_offset_x = 0.0f;
-float HUD_offset_y = 0.0f;
-
 // the offset of the player's view vector and the ship forward vector in pixels (Swifty)
 int HUD_nose_x;
 int HUD_nose_y;
@@ -1033,8 +1029,8 @@ void HudGauge::renderCircle(int x, int y, int diameter, bool filled)
 
 void HudGauge::setClip(int x, int y, int w, int h)
 {
-	int hx;
-	int hy;
+	int hx = 0;
+	int hy = 0;
 
 	if ( gr_screen.rendering_to_texture != -1 ) {
 		gr_set_screen_scale(canvas_w, canvas_h, -1, -1, target_w, target_h, target_w, target_h, true);
@@ -1051,8 +1047,6 @@ void HudGauge::setClip(int x, int y, int w, int h)
 
 		gr_set_clip(hx, hy, w, h);
 	} else {
-		hx = 0;//fl2i(HUD_offset_x);
-		hy = 0;//fl2i(HUD_offset_y);
 		if (reticle_follow) {
 			hx += HUD_nose_x;
 			hy += HUD_nose_y;
@@ -1092,9 +1086,6 @@ void HudGauge::resetClip()
 
 		gr_set_clip(hx, hy, w, h);
 	} else {
-		hx = 0;// fl2i(HUD_offset_x);
-		hy = 0;// fl2i(HUD_offset_y);
-
 		gr_resize_screen_pos(&hx, &hy);
 		gr_set_screen_scale(base_w, base_h);
 
@@ -3755,40 +3746,6 @@ int hud_objective_notify_active()
  */
 void HUD_set_offsets(object *viewer_obj, int wiggedy_wack, matrix *eye_orient)
 {
-	if ( (viewer_obj == Player_obj) && wiggedy_wack ){		
-		vec3d tmp;
-		vertex pt;
-
-		HUD_offset_x = 0.0f;
-		HUD_offset_y = 0.0f;
-
-		vm_vec_scale_add( &tmp, &Eye_position, &eye_orient->vec.fvec, 100.0f );
-		
-		(void) g3_rotate_vertex(&pt,&tmp);
-
-		g3_project_vertex(&pt);
-
-		gr_unsize_screen_posf( &pt.screen.xyw.x, &pt.screen.xyw.y );
-		HUD_offset_x -= 0.45f * (i2fl(gr_screen.clip_width_unscaled)*0.5f - pt.screen.xyw.x);
-		HUD_offset_y -= 0.45f * (i2fl(gr_screen.clip_height_unscaled)*0.5f - pt.screen.xyw.y);
-
-		if ( HUD_offset_x > 100.0f )	{
-			HUD_offset_x = 100.0f;
-		} else if ( HUD_offset_x < -100.0f )	{
-			HUD_offset_x += 100.0f;
-		}
-
-		if ( HUD_offset_y > 100.0f )	{
-			HUD_offset_y = 100.0f;
-		} else if ( HUD_offset_y < -100.0f )	{
-			HUD_offset_y += 100.0f;
-		}
-
-	} else {
-		HUD_offset_x = 0.0f;
-		HUD_offset_y = 0.0f;
-	}
-
 	if ( Viewer_mode & ( VM_TOPDOWN | VM_CHASE ) ) {
 		HUD_nose_x = 0;
 		HUD_nose_y = 0;
@@ -3852,10 +3809,7 @@ void HUD_get_nose_coordinates(int *x, int *y)
  */
 void HUD_reset_clip()
 {
-	int hx = 0;// fl2i(HUD_offset_x);
-	int hy = 0;// fl2i(HUD_offset_y);
-
-	gr_set_clip(hx, hy, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled);
+	gr_set_clip(0, 0, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled);
 }
 
 /**
@@ -3863,10 +3817,7 @@ void HUD_reset_clip()
  */
 void HUD_set_clip(int x, int y, int w, int h)
 {
-	int hx = 0;// fl2i(HUD_offset_x);
-	int hy = 0;// fl2i(HUD_offset_y);
-
-	gr_set_clip(hx+x, hy+y, w, h);
+	gr_set_clip(x, y, w, h);
 }
 
 /**

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -4135,7 +4135,7 @@ void HudGaugeSupernova::render(float  /*frametime*/)
 }
 
 HudGaugeFlightPath::HudGaugeFlightPath():
-HudGauge(HUD_OBJECT_FLIGHT_PATH, HUD_CENTER_RETICLE, false, false, VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY, 255, 255, 255)
+HudGauge3DAnchor(HUD_OBJECT_FLIGHT_PATH, HUD_CENTER_RETICLE, false, false, VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY, 255, 255, 255)
 {
 }
 

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3744,7 +3744,7 @@ int hud_objective_notify_active()
  * @param wiggedy_wack
  * @param eye_orient 
  */
-void HUD_set_offsets(object *viewer_obj, int wiggedy_wack, matrix *eye_orient)
+void HUD_set_offsets()
 {
 	if ( Viewer_mode & ( VM_TOPDOWN | VM_CHASE ) ) {
 		HUD_nose_x = 0;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1051,17 +1051,22 @@ void HudGauge::setClip(int x, int y, int w, int h)
 
 		gr_set_clip(hx, hy, w, h);
 	} else {
-		if ( reticle_follow ) {
+		if (reticle_follow) {
 			hx += HUD_nose_x;
 			hy += HUD_nose_y;
+
+			gr_resize_screen_pos(&hx, &hy);
+			gr_set_screen_scale(base_w, base_h);
+			gr_unsize_screen_pos(&hx, &hy);
+		}
+		else {
+			gr_set_screen_scale(base_w, base_h);
 		}
 
-		gr_resize_screen_pos(&hx, &hy);
-
-		gr_set_screen_scale(base_w, base_h);
+		x += hx;
+		y += hy;
 		gr_resize_screen_pos(&x, &y, &w, &h);
-
-		gr_set_clip(hx+x, hy+y, w, h, GR_RESIZE_NONE);
+		gr_set_clip(x, y, w, h, GR_RESIZE_NONE);
 	}
 
 	gr_reset_screen_scale();

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1051,8 +1051,8 @@ void HudGauge::setClip(int x, int y, int w, int h)
 
 		gr_set_clip(hx, hy, w, h);
 	} else {
-		hx = fl2i(HUD_offset_x);
-		hy = fl2i(HUD_offset_y);
+		hx = 0;//fl2i(HUD_offset_x);
+		hy = 0;//fl2i(HUD_offset_y);
 		if (reticle_follow) {
 			hx += HUD_nose_x;
 			hy += HUD_nose_y;
@@ -1092,8 +1092,8 @@ void HudGauge::resetClip()
 
 		gr_set_clip(hx, hy, w, h);
 	} else {
-		hx = fl2i(HUD_offset_x);
-		hy = fl2i(HUD_offset_y);
+		hx = 0;// fl2i(HUD_offset_x);
+		hy = 0;// fl2i(HUD_offset_y);
 
 		gr_resize_screen_pos(&hx, &hy);
 		gr_set_screen_scale(base_w, base_h);
@@ -3852,8 +3852,8 @@ void HUD_get_nose_coordinates(int *x, int *y)
  */
 void HUD_reset_clip()
 {
-	int hx = fl2i(HUD_offset_x);
-	int hy = fl2i(HUD_offset_y);
+	int hx = 0;// fl2i(HUD_offset_x);
+	int hy = 0;// fl2i(HUD_offset_y);
 
 	gr_set_clip(hx, hy, gr_screen.max_w_unscaled, gr_screen.max_h_unscaled);
 }
@@ -3863,8 +3863,8 @@ void HUD_reset_clip()
  */
 void HUD_set_clip(int x, int y, int w, int h)
 {
-	int hx = fl2i(HUD_offset_x);
-	int hy = fl2i(HUD_offset_y);
+	int hx = 0;// fl2i(HUD_offset_x);
+	int hy = 0;// fl2i(HUD_offset_y);
 
 	gr_set_clip(hx+x, hy+y, w, h);
 }

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -277,7 +277,7 @@ public:
 	void initOriginAndOffset(float originX, float originY, int offsetX, int offsetY);
 	void initCoords(bool use_coords, int coordsX, int coordsY);
 
-	void initSlew(bool slew);
+	virtual void initSlew(bool slew);
 	void initCockpitTarget(const char* display_name, int _target_x, int _target_y, int _target_w, int _target_h, int _canvas_w, int _canvas_h);
 	void initRenderStatus(bool render);
 
@@ -360,6 +360,21 @@ public:
 	void resize(float *x, float *y);
 	void setClip(int x, int y, int w, int h);
 	void resetClip();
+};
+
+//Use this instead of HudGauge whenever you have a HudGauge that is anchored in 3D-space (i.e. takes its rendering coordinates from g3_rotate/project_vertex, as these MUST NEVER slew.
+class HudGauge3DAnchor : public HudGauge {
+
+public:
+	HudGauge3DAnchor() 
+		: HudGauge() { }
+	HudGauge3DAnchor(int _gauge_object, int _gauge_config, bool /*_slew*/, bool _message, int _disabled_views, int r, int g, int b)
+		: HudGauge(_gauge_object, _gauge_config, false, _message, _disabled_views, r, g, b) { }
+	// constructor for custom gauges
+	HudGauge3DAnchor(int _gauge_config, bool /*_slew*/, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y)
+		: HudGauge(_gauge_config, false, r, g, b, _custom_name, _custom_text, frame_fname, txtoffset_x, txtoffset_y) { }
+
+	void initSlew(bool /*slew*/) override {};
 };
 
 class HudGaugeMissionTime: public HudGauge // HUD_MISSION_TIME
@@ -562,7 +577,7 @@ public:
 	void render(float frametime) override;
 };
 
-class HudGaugeFlightPath: public HudGauge
+class HudGaugeFlightPath: public HudGauge3DAnchor
 {
 	hud_frames Marker;
 

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -129,7 +129,7 @@ void hud_render_gauges(int cockpit_display_num = -1);
 void hud_stop_looped_engine_sounds();
 
 // set the offset values for this render frame
-void HUD_set_offsets(object *viewer_obj, int wiggedy_wack, matrix *eye_orient);
+void HUD_set_offsets();
 // returns the offset between the player's view vector and the forward vector of the ship in pixels (Swifty)
 void HUD_get_nose_coordinates(int *x, int *y);
 

--- a/code/hud/hudbrackets.cpp
+++ b/code/hud/hudbrackets.cpp
@@ -331,7 +331,7 @@ int draw_subsys_brackets(graphics::line_draw_list* draw_list, ship_subsys* subsy
 }
 
 HudGaugeBrackets::HudGaugeBrackets():
-HudGauge(HUD_OBJECT_BRACKETS, HUD_OFFSCREEN_INDICATOR, false, true, VM_DEAD_VIEW, 255, 255, 255)
+HudGauge3DAnchor(HUD_OBJECT_BRACKETS, HUD_OFFSCREEN_INDICATOR, false, true, VM_DEAD_VIEW, 255, 255, 255)
 {
 }
 

--- a/code/hud/hudbrackets.h
+++ b/code/hud/hudbrackets.h
@@ -25,7 +25,7 @@ void draw_brackets_diamond_quick(graphics::line_draw_list* draw_list, int x1, in
 
 int draw_subsys_brackets(graphics::line_draw_list* draw_list, ship_subsys* subsys, int min_width, int min_height, bool draw = true, bool set_color = true, int* draw_coords = NULL);
 
-class HudGaugeBrackets: public HudGauge
+class HudGaugeBrackets: public HudGauge3DAnchor
 {
 protected:
 	int attacking_dot;

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1658,10 +1658,6 @@ void hud_config_as_observer(ship *shipp,ai_info *aif)
 	// store the current hud
 	hud_config_backup();
 
-	// bash these values so the HUD is not offset incorrectly
-	HUD_offset_x = 0.0f;
-	HUD_offset_y = 0.0f;
-
 	// initialize the observer HUD
 	hud_observer_init(shipp,aif);	
 }

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -107,7 +107,7 @@ void hud_init_missile_lock()
 }
 
 HudGaugeLock::HudGaugeLock():
-HudGauge(HUD_OBJECT_LOCK, HUD_LEAD_INDICATOR, false, false, VM_DEAD_VIEW, 255, 255, 255)
+HudGauge3DAnchor(HUD_OBJECT_LOCK, HUD_LEAD_INDICATOR, false, false, VM_DEAD_VIEW, 255, 255, 255)
 {
 }
 

--- a/code/hud/hudlock.h
+++ b/code/hud/hudlock.h
@@ -24,7 +24,7 @@ void hud_do_lock_indicators(float frametime);
 void hud_stop_looped_locking_sounds();
 void hud_lock_reset(float lock_time_scale=1.0f);
 
-class HudGaugeLock: public HudGauge
+class HudGaugeLock: public HudGauge3DAnchor
 {
 protected:
 	hud_anim Lock_gauge;

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1215,10 +1215,6 @@ void HudGaugeTalkingHead::render(float frametime)
 
 			int hx = tablePosX + Anim_offsets[0];
 			int hy = tablePosY + Anim_offsets[1];
-			/*if (gr_screen.rendering_to_texture == -1) {
-				hx += fl2i(HUD_offset_x);
-				hy += fl2i(HUD_offset_y);
-			}*/
 
 			generic_anim_render(head_anim,frametime, fl2ir(hx / scale_x), fl2ir(hy / scale_y));
 			// draw title

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1208,17 +1208,19 @@ void HudGaugeTalkingHead::render(float frametime)
 
 			//renderBitmap is slew corrected, so use uncorrected position
 			renderBitmap(Head_frame.first_frame, position[0], position[1]);		// head ani border
-			float scale_x = i2fl(Anim_size[0]) / i2fl(head_anim->width);
-			float scale_y = i2fl(Anim_size[1]) / i2fl(head_anim->height);
-			gr_set_screen_scale(fl2ir(base_w / scale_x), fl2ir(base_h / scale_y));
-			setGaugeColor();
 
 			int hx = tablePosX + Anim_offsets[0];
 			int hy = tablePosY + Anim_offsets[1];
 
-			generic_anim_render(head_anim,frametime, fl2ir(hx / scale_x), fl2ir(hy / scale_y));
-			// draw title
+			if (gr_screen.rendering_to_texture != -1) 
+				gr_set_screen_scale(canvas_w, canvas_h, -1, -1, target_w, target_h, target_w, target_h, true);
+			else
+				gr_set_screen_scale(base_w, base_h);
+
+			generic_anim_render_ex(head_anim,frametime, hx, hy, Anim_size[0], Anim_size[1]);
 			gr_reset_screen_scale();
+
+			// draw title
 			renderString(position[0] + Header_offsets[0], position[1] + Header_offsets[1], XSTR("message", 217));
 		} else {
 			for (int j = 0; j < Num_messages_playing; ++j) {

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1180,17 +1180,33 @@ void HudGaugeTalkingHead::render(float frametime)
 			// hud_set_default_color();
 			setGaugeColor();
 
+			int tablePosX = position[0];
+			int tablePosY = position[1];
+			if (reticle_follow) {
+				int nx = HUD_nose_x;
+				int ny = HUD_nose_y;
+
+				gr_resize_screen_pos(&nx, &ny);
+				gr_set_screen_scale(base_w, base_h);
+				gr_unsize_screen_pos(&nx, &ny);
+				gr_reset_screen_scale();
+
+				tablePosX += nx;
+				tablePosY += ny;
+			}
+
 			// clear
-			setClip(position[0] + Anim_offsets[0], position[1] + Anim_offsets[1], Anim_size[0], Anim_size[1]);
+			setClip(tablePosX + Anim_offsets[0], tablePosY + Anim_offsets[1], Anim_size[0], Anim_size[1]);
 			gr_clear();
 			resetClip();
 
+			//renderBitmap is slew corrected, so use uncorrected position
 			renderBitmap(Head_frame.first_frame, position[0], position[1]);		// head ani border
 			float scale_x = i2fl(Anim_size[0]) / i2fl(head_anim->width);
 			float scale_y = i2fl(Anim_size[1]) / i2fl(head_anim->height);
 			gr_set_screen_scale(fl2ir(base_w / scale_x), fl2ir(base_h / scale_y));
 			setGaugeColor();
-			generic_anim_render(head_anim,frametime, fl2ir((position[0] + Anim_offsets[0] + HUD_offset_x) / scale_x), fl2ir((position[1] + Anim_offsets[1] + HUD_offset_y) / scale_y));
+			generic_anim_render(head_anim,frametime, fl2ir((tablePosX + Anim_offsets[0] + HUD_offset_x) / scale_x), fl2ir((tablePosY + Anim_offsets[1] + HUD_offset_y) / scale_y));
 			// draw title
 			gr_set_screen_scale(base_w, base_h);
 			renderString(position[0] + Header_offsets[0], position[1] + Header_offsets[1], XSTR("message", 217));

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1212,7 +1212,15 @@ void HudGaugeTalkingHead::render(float frametime)
 			float scale_y = i2fl(Anim_size[1]) / i2fl(head_anim->height);
 			gr_set_screen_scale(fl2ir(base_w / scale_x), fl2ir(base_h / scale_y));
 			setGaugeColor();
-			generic_anim_render(head_anim,frametime, fl2ir((tablePosX + Anim_offsets[0] + HUD_offset_x) / scale_x), fl2ir((tablePosY + Anim_offsets[1] + HUD_offset_y) / scale_y));
+
+			int hx = tablePosX + Anim_offsets[0];
+			int hy = tablePosY + Anim_offsets[1];
+			if (gr_screen.rendering_to_texture == -1) {
+				hx += fl2i(HUD_offset_x);
+				hy += fl2i(HUD_offset_y);
+			}
+
+			generic_anim_render(head_anim,frametime, fl2ir(hx / scale_x), fl2ir(hy / scale_y));
 			// draw title
 			gr_reset_screen_scale();
 			renderString(position[0] + Header_offsets[0], position[1] + Header_offsets[1], XSTR("message", 217));

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1188,7 +1188,7 @@ void HudGaugeTalkingHead::render(float frametime)
 
 			int tablePosX = position[0];
 			int tablePosY = position[1];
-			if (reticle_follow) {
+			if (reticle_follow && gr_screen.rendering_to_texture == -1) {
 				int nx = HUD_nose_x;
 				int ny = HUD_nose_y;
 
@@ -1215,10 +1215,10 @@ void HudGaugeTalkingHead::render(float frametime)
 
 			int hx = tablePosX + Anim_offsets[0];
 			int hy = tablePosY + Anim_offsets[1];
-			if (gr_screen.rendering_to_texture == -1) {
+			/*if (gr_screen.rendering_to_texture == -1) {
 				hx += fl2i(HUD_offset_x);
 				hy += fl2i(HUD_offset_y);
-			}
+			}*/
 
 			generic_anim_render(head_anim,frametime, fl2ir(hx / scale_x), fl2ir(hy / scale_y));
 			// draw title

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -444,6 +444,10 @@ void HudGaugeMessages::render(float  /*frametime*/)
 	// dependant on max_width, max_lines, and line_height
 	setClip(position[0], position[1], Window_width, Window_height+2);
 
+	//Since setClip already sets makes drawing local, further renderings mustn't additionally slew
+	bool doSlew = reticle_follow;
+	reticle_follow = false;
+
 	for ( SCP_vector<Hud_display_info>::iterator m = active_messages.begin(); m != active_messages.end(); ++m) {
 		if ( !timestamp_elapsed(m->total_life) ) {
 			if ( !(Player->flags & PLAYER_FLAGS_MSG_MODE) || !Hidden_by_comms_menu) {
@@ -459,6 +463,8 @@ void HudGaugeMessages::render(float  /*frametime*/)
 			}
 		}
 	}
+
+	reticle_follow = doSlew;
 }
 
 //	Similar to HUD printf, but shows only one message at a time, at a fixed location.
@@ -1196,7 +1202,7 @@ void HudGaugeTalkingHead::render(float frametime)
 			}
 
 			// clear
-			setClip(tablePosX + Anim_offsets[0], tablePosY + Anim_offsets[1], Anim_size[0], Anim_size[1]);
+			setClip(position[0] + Anim_offsets[0], position[1] + Anim_offsets[1], Anim_size[0], Anim_size[1]);
 			gr_clear();
 			resetClip();
 
@@ -1208,7 +1214,7 @@ void HudGaugeTalkingHead::render(float frametime)
 			setGaugeColor();
 			generic_anim_render(head_anim,frametime, fl2ir((tablePosX + Anim_offsets[0] + HUD_offset_x) / scale_x), fl2ir((tablePosY + Anim_offsets[1] + HUD_offset_y) / scale_y));
 			// draw title
-			gr_set_screen_scale(base_w, base_h);
+			gr_reset_screen_scale();
 			renderString(position[0] + Header_offsets[0], position[1] + Header_offsets[1], XSTR("message", 217));
 		} else {
 			for (int j = 0; j < Num_messages_playing; ++j) {

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -365,8 +365,8 @@ void hud_shield_show_mini(object *objp, int x_force, int y_force, int x_hull_off
 	if (!Shield_mini_loaded)
 		return;
 
-	sx = (x_force == -1) ? Shield_mini_coords[gr_screen.res][0]+fl2i(HUD_offset_x) : x_force;
-	sy = (y_force == -1) ? Shield_mini_coords[gr_screen.res][1]+fl2i(HUD_offset_y) : y_force;
+	sx = (x_force == -1) ? Shield_mini_coords[gr_screen.res][0]/* + fl2i(HUD_offset_x)*/ : x_force;
+	sy = (y_force == -1) ? Shield_mini_coords[gr_screen.res][1]/* + fl2i(HUD_offset_y)*/ : y_force;
 
 	// draw the ship first
 	hud_shield_maybe_flash(HUD_TARGET_MINI_ICON, SHIELD_HIT_TARGET, Shield_hit_data[SHIELD_HIT_TARGET].hull_hit_index);
@@ -596,10 +596,10 @@ void HudGaugeShield::showShields(object *objp, int mode)
 	sx = position[0];
 	sy = position[1];
 
-	if (gr_screen.rendering_to_texture == -1) {
+	/*if (gr_screen.rendering_to_texture == -1) {
 		sx += fl2i(HUD_offset_x);
 		sy += fl2i(HUD_offset_y);
-	}
+	}*/
 
 	// draw the ship first
 	maybeFlashShield(SHIELD_HIT_PLAYER, Shield_hit_data[SHIELD_HIT_PLAYER].hull_hit_index);
@@ -975,10 +975,10 @@ void HudGaugeShieldMini::showMiniShields(object *objp)
 
 	sx = position[0];
 	sy = position[1];
-	if (gr_screen.rendering_to_texture == -1) {
+	/*if (gr_screen.rendering_to_texture == -1) {
 		sx+=fl2i(HUD_offset_x);
 		sy+=fl2i(HUD_offset_y);
-	}
+	}*/
 
 	// draw the ship first
 	maybeFlashShield(SHIELD_HIT_TARGET, Shield_hit_data[SHIELD_HIT_TARGET].hull_hit_index);
@@ -1070,10 +1070,10 @@ void HudGaugeShieldMini::showIntegrity(float p_target_integrity)
 	final_pos[0] += position[0];
 	final_pos[1] += position[1];
 
-	if (gr_screen.rendering_to_texture == -1) {
+	/*if (gr_screen.rendering_to_texture == -1) {
 		final_pos[0] += fl2i(HUD_offset_x);
 		final_pos[1] += fl2i(HUD_offset_y);
-	}
+	}*/
 
 	sprintf(text_integrity, "%d", numeric_integrity);
 	if ( numeric_integrity < 100 ) {

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -596,8 +596,10 @@ void HudGaugeShield::showShields(object *objp, int mode)
 	sx = position[0];
 	sy = position[1];
 
-	sx += fl2i(HUD_offset_x);
-	sy += fl2i(HUD_offset_y);
+	if (gr_screen.rendering_to_texture == -1) {
+		sx += fl2i(HUD_offset_x);
+		sy += fl2i(HUD_offset_y);
+	}
 
 	// draw the ship first
 	maybeFlashShield(SHIELD_HIT_PLAYER, Shield_hit_data[SHIELD_HIT_PLAYER].hull_hit_index);
@@ -971,8 +973,12 @@ void HudGaugeShieldMini::showMiniShields(object *objp)
 
 	setGaugeColor();
 
-	sx = position[0]+fl2i(HUD_offset_x);
-	sy = position[1]+fl2i(HUD_offset_y);
+	sx = position[0];
+	sy = position[1];
+	if (gr_screen.rendering_to_texture == -1) {
+		sx+=fl2i(HUD_offset_x);
+		sy+=fl2i(HUD_offset_y);
+	}
 
 	// draw the ship first
 	maybeFlashShield(SHIELD_HIT_TARGET, Shield_hit_data[SHIELD_HIT_TARGET].hull_hit_index);
@@ -1061,8 +1067,13 @@ void HudGaugeShieldMini::showIntegrity(float p_target_integrity)
 		}
 	}
 
-	final_pos[0] += fl2i( HUD_offset_x ) + position[0];
-	final_pos[1] += fl2i( HUD_offset_y ) + position[1];
+	final_pos[0] += position[0];
+	final_pos[1] += position[1];
+
+	if (gr_screen.rendering_to_texture == -1) {
+		final_pos[0] += fl2i(HUD_offset_x);
+		final_pos[1] += fl2i(HUD_offset_y);
+	}
 
 	sprintf(text_integrity, "%d", numeric_integrity);
 	if ( numeric_integrity < 100 ) {

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -365,8 +365,8 @@ void hud_shield_show_mini(object *objp, int x_force, int y_force, int x_hull_off
 	if (!Shield_mini_loaded)
 		return;
 
-	sx = (x_force == -1) ? Shield_mini_coords[gr_screen.res][0]/* + fl2i(HUD_offset_x)*/ : x_force;
-	sy = (y_force == -1) ? Shield_mini_coords[gr_screen.res][1]/* + fl2i(HUD_offset_y)*/ : y_force;
+	sx = (x_force == -1) ? Shield_mini_coords[gr_screen.res][0] : x_force;
+	sy = (y_force == -1) ? Shield_mini_coords[gr_screen.res][1] : y_force;
 
 	// draw the ship first
 	hud_shield_maybe_flash(HUD_TARGET_MINI_ICON, SHIELD_HIT_TARGET, Shield_hit_data[SHIELD_HIT_TARGET].hull_hit_index);
@@ -595,11 +595,6 @@ void HudGaugeShield::showShields(object *objp, int mode)
 
 	sx = position[0];
 	sy = position[1];
-
-	/*if (gr_screen.rendering_to_texture == -1) {
-		sx += fl2i(HUD_offset_x);
-		sy += fl2i(HUD_offset_y);
-	}*/
 
 	// draw the ship first
 	maybeFlashShield(SHIELD_HIT_PLAYER, Shield_hit_data[SHIELD_HIT_PLAYER].hull_hit_index);
@@ -975,10 +970,6 @@ void HudGaugeShieldMini::showMiniShields(object *objp)
 
 	sx = position[0];
 	sy = position[1];
-	/*if (gr_screen.rendering_to_texture == -1) {
-		sx+=fl2i(HUD_offset_x);
-		sy+=fl2i(HUD_offset_y);
-	}*/
 
 	// draw the ship first
 	maybeFlashShield(SHIELD_HIT_TARGET, Shield_hit_data[SHIELD_HIT_TARGET].hull_hit_index);
@@ -1069,11 +1060,6 @@ void HudGaugeShieldMini::showIntegrity(float p_target_integrity)
 
 	final_pos[0] += position[0];
 	final_pos[1] += position[1];
-
-	/*if (gr_screen.rendering_to_texture == -1) {
-		final_pos[0] += fl2i(HUD_offset_x);
-		final_pos[1] += fl2i(HUD_offset_y);
-	}*/
 
 	sprintf(text_integrity, "%d", numeric_integrity);
 	if ( numeric_integrity < 100 ) {

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2758,8 +2758,10 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 	y1 += position[1];
 	x1 += position[0];
 
-	x1 += HUD_offset_x;
-	y1 += HUD_offset_y;
+	if (gr_screen.rendering_to_texture == -1) {
+		x1 += HUD_offset_x;
+		y1 += HUD_offset_y;
+	}
 
 	y2 = sinf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
 	x2 = cosf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
@@ -2767,8 +2769,10 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 	y2 += position[1];
 	x2 += position[0];
 
-	x2 += HUD_offset_x;
-	y2 += HUD_offset_y;
+	if (gr_screen.rendering_to_texture == -1) {
+		x2 += HUD_offset_x;
+		y2 += HUD_offset_y;
+	}
 
 	x3 = x1 - T_BASE_LENGTH * sinf(dot_product);
 	y3 = y1 + T_BASE_LENGTH * cosf(dot_product);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2758,10 +2758,10 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 	y1 += position[1];
 	x1 += position[0];
 
-	if (gr_screen.rendering_to_texture == -1) {
+	/*if (gr_screen.rendering_to_texture == -1) {
 		x1 += HUD_offset_x;
 		y1 += HUD_offset_y;
-	}
+	}*/
 
 	y2 = sinf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
 	x2 = cosf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
@@ -2769,10 +2769,10 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 	y2 += position[1];
 	x2 += position[0];
 
-	if (gr_screen.rendering_to_texture == -1) {
+	/*if (gr_screen.rendering_to_texture == -1) {
 		x2 += HUD_offset_x;
 		y2 += HUD_offset_y;
-	}
+	}*/
 
 	x3 = x1 - T_BASE_LENGTH * sinf(dot_product);
 	y3 = y1 + T_BASE_LENGTH * cosf(dot_product);
@@ -3011,9 +3011,9 @@ void HudGaugeReticleTriangle::renderTriangle(vec3d *hostile_pos, int aspect_flag
 	}
 	else {
 		//Technically not non-slewing, but keeps old behaviour
-		tablePosX = position[0] + fl2i(HUD_offset_x + HUD_nose_x);
-		tablePosY = position[1] + fl2i(HUD_offset_y + HUD_nose_y);
-	}
+		tablePosX = position[0] + fl2i(/*HUD_offset_x +*/HUD_nose_x);
+		tablePosY = position[1] + fl2i(/*HUD_offset_y +*/HUD_nose_y);
+	}								   
 
 	if (hostile_vertex.codes == 0)  { // on screen
 		int		projected_x, projected_y;
@@ -4288,7 +4288,7 @@ void HudGaugeLeadSight::renderSight(int frame_offset, vec3d *target_pos, vec3d *
 
 		//We need to do slewing manually only on the non-3D-dependant part of the hud, so make the rendering function believe that we don't slew
 		reticle_follow = false;
-		renderBitmap(Lead_sight.first_frame + frame_offset, fl2i(reticle_target_sx) + fl2i(HUD_offset_x), fl2i(reticle_target_sy) + fl2i(HUD_offset_y));
+		renderBitmap(Lead_sight.first_frame + frame_offset, fl2i(reticle_target_sx)/* + fl2i(HUD_offset_x)*/, fl2i(reticle_target_sy)/* + fl2i(HUD_offset_y)*/);
 		reticle_follow = do_slew;
 	}
 }

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2758,21 +2758,11 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 	y1 += position[1];
 	x1 += position[0];
 
-	/*if (gr_screen.rendering_to_texture == -1) {
-		x1 += HUD_offset_x;
-		y1 += HUD_offset_y;
-	}*/
-
 	y2 = sinf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
 	x2 = cosf(dot_product) * (Radius - T_OFFSET_FROM_CIRCLE - T_LENGTH);
 
 	y2 += position[1];
 	x2 += position[0];
-
-	/*if (gr_screen.rendering_to_texture == -1) {
-		x2 += HUD_offset_x;
-		y2 += HUD_offset_y;
-	}*/
 
 	x3 = x1 - T_BASE_LENGTH * sinf(dot_product);
 	y3 = y1 + T_BASE_LENGTH * cosf(dot_product);
@@ -3011,8 +3001,8 @@ void HudGaugeReticleTriangle::renderTriangle(vec3d *hostile_pos, int aspect_flag
 	}
 	else {
 		//Technically not non-slewing, but keeps old behaviour
-		tablePosX = position[0] + fl2i(/*HUD_offset_x +*/HUD_nose_x);
-		tablePosY = position[1] + fl2i(/*HUD_offset_y +*/HUD_nose_y);
+		tablePosX = position[0] + fl2i(HUD_nose_x);
+		tablePosY = position[1] + fl2i(HUD_nose_y);
 	}								   
 
 	if (hostile_vertex.codes == 0)  { // on screen
@@ -4288,7 +4278,7 @@ void HudGaugeLeadSight::renderSight(int frame_offset, vec3d *target_pos, vec3d *
 
 		//We need to do slewing manually only on the non-3D-dependant part of the hud, so make the rendering function believe that we don't slew
 		reticle_follow = false;
-		renderBitmap(Lead_sight.first_frame + frame_offset, fl2i(reticle_target_sx)/* + fl2i(HUD_offset_x)*/, fl2i(reticle_target_sy)/* + fl2i(HUD_offset_y)*/);
+		renderBitmap(Lead_sight.first_frame + frame_offset, fl2i(reticle_target_sx), fl2i(reticle_target_sy));
 		reticle_follow = do_slew;
 	}
 }

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4194,7 +4194,7 @@ void HudGaugeLeadIndicator::renderLeadQuick(vec3d *target_world_pos, object *tar
 }
 
 HudGaugeLeadSight::HudGaugeLeadSight():
-HudGauge3DAnchor(HUD_OBJECT_LEAD_SIGHT, HUD_LEAD_INDICATOR, true, false, VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY | VM_OTHER_SHIP, 255, 255, 255)
+HudGauge(HUD_OBJECT_LEAD_SIGHT, HUD_LEAD_INDICATOR, true, false, VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY | VM_OTHER_SHIP, 255, 255, 255)
 {
 }
 
@@ -4260,11 +4260,32 @@ void HudGaugeLeadSight::renderSight(int frame_offset, vec3d *target_pos, vec3d *
 		float reticle_target_sx = target_sx - Lead_sight_half[0] - target_lead_sx;
 		float reticle_target_sy = target_sy - Lead_sight_half[1] - target_lead_sy;
 
-		reticle_target_sx += position[0] + 0.5f;
-		reticle_target_sy += position[1] + 0.5f;
+		int tablePosX = position[0];
+		int tablePosY = position[1];
+
+		bool do_slew = reticle_follow;
+		if (do_slew) {
+			int nx = HUD_nose_x;
+			int ny = HUD_nose_y;
+
+			gr_resize_screen_pos(&nx, &ny);
+			gr_set_screen_scale(base_w, base_h);
+			gr_unsize_screen_pos(&nx, &ny);
+			gr_reset_screen_scale();
+
+			tablePosX += nx;
+			tablePosY += ny;
+		}
+
+		reticle_target_sx += tablePosX + 0.5f;
+		reticle_target_sy += tablePosY + 0.5f;
 
 		setGaugeColor();
+
+		//We need to do slewing manually only on the non-3D-dependant part of the hud, so make the rendering function believe that we don't slew
+		reticle_follow = false;
 		renderBitmap(Lead_sight.first_frame + frame_offset, fl2i(reticle_target_sx) + fl2i(HUD_offset_x), fl2i(reticle_target_sy) + fl2i(HUD_offset_y));
+		reticle_follow = do_slew;
 	}
 }
 

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -579,7 +579,7 @@ public:
 	void pageIn() override;
 };
 
-class HudGaugeLeadSight: public HudGauge3DAnchor
+class HudGaugeLeadSight: public HudGauge
 {
 protected:
 	hud_frames Lead_sight;

--- a/code/hud/hudtarget.h
+++ b/code/hud/hudtarget.h
@@ -543,7 +543,7 @@ public:
 	void render(float frametime) override;
 };
 
-class HudGaugeOffscreen: public HudGauge
+class HudGaugeOffscreen: public HudGauge3DAnchor
 {
 protected:
 	float Max_offscreen_tri_seperation;
@@ -562,7 +562,7 @@ public:
 	void pageIn() override;
 };
 
-class HudGaugeLeadIndicator: public HudGauge
+class HudGaugeLeadIndicator: public HudGauge3DAnchor
 {
 protected:
 	hud_frames Lead_indicator_gauge;
@@ -579,7 +579,7 @@ public:
 	void pageIn() override;
 };
 
-class HudGaugeLeadSight: public HudGauge
+class HudGaugeLeadSight: public HudGauge3DAnchor
 {
 protected:
 	hud_frames Lead_sight;

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1269,7 +1269,7 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 	matrix		camera_orient = IDENTITY_MATRIX;
 	vec3d		orient_vec, up_vector;
 	float			factor, dist;
-	int			hx, hy, w, h;
+	int			hx = 0, hy = 0, w, h;
 	SCP_list<CJumpNode>::iterator jnp;
 	
 	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
@@ -1330,8 +1330,10 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 		}
 
 		// account for hud shaking
-		hx = fl2i(HUD_offset_x);
-		hy = fl2i(HUD_offset_y);
+		if (gr_screen.rendering_to_texture == -1) {
+			hx = fl2i(HUD_offset_x);
+			hy = fl2i(HUD_offset_y);
+		}
 
 		sprintf(outstr,XSTR( "d: %.0f", 340), dist);
 		hud_num_make_mono(outstr, font_num);
@@ -2111,11 +2113,13 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 			break;
 	}
 
-	int hx, hy;
+	int hx = 0, hy = 0;
 
 	// Account for HUD shaking
-	hx = fl2i(HUD_offset_x);
-	hy = fl2i(HUD_offset_y);
+	if (gr_screen.rendering_to_texture == -1) {
+		hx = fl2i(HUD_offset_x);
+		hy = fl2i(HUD_offset_y);
+	}
 
 	// print out the target distance and speed
 	sprintf(outstr,XSTR( "d: %.0f%s", 350), displayed_target_distance, modifiers[Player_ai->current_target_dist_trend]);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1330,10 +1330,10 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 		}
 
 		// account for hud shaking
-		if (gr_screen.rendering_to_texture == -1) {
+		/*if (gr_screen.rendering_to_texture == -1) {
 			hx = fl2i(HUD_offset_x);
 			hy = fl2i(HUD_offset_y);
-		}
+		}*/
 
 		sprintf(outstr,XSTR( "d: %.0f", 340), dist);
 		hud_num_make_mono(outstr, font_num);
@@ -2116,10 +2116,10 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 	int hx = 0, hy = 0;
 
 	// Account for HUD shaking
-	if (gr_screen.rendering_to_texture == -1) {
+	/*if (gr_screen.rendering_to_texture == -1) {
 		hx = fl2i(HUD_offset_x);
 		hy = fl2i(HUD_offset_y);
-	}
+	}*/
 
 	// print out the target distance and speed
 	sprintf(outstr,XSTR( "d: %.0f%s", 350), displayed_target_distance, modifiers[Player_ai->current_target_dist_trend]);

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1329,12 +1329,6 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 			dist = dist * Hud_unit_multiplier;
 		}
 
-		// account for hud shaking
-		/*if (gr_screen.rendering_to_texture == -1) {
-			hx = fl2i(HUD_offset_x);
-			hy = fl2i(HUD_offset_y);
-		}*/
-
 		sprintf(outstr,XSTR( "d: %.0f", 340), dist);
 		hud_num_make_mono(outstr, font_num);
 		gr_get_string_size(&w,&h,outstr);
@@ -2113,21 +2107,13 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 			break;
 	}
 
-	int hx = 0, hy = 0;
-
-	// Account for HUD shaking
-	/*if (gr_screen.rendering_to_texture == -1) {
-		hx = fl2i(HUD_offset_x);
-		hy = fl2i(HUD_offset_y);
-	}*/
-
 	// print out the target distance and speed
 	sprintf(outstr,XSTR( "d: %.0f%s", 350), displayed_target_distance, modifiers[Player_ai->current_target_dist_trend]);
 
 	hud_num_make_mono(outstr, font_num);
 	gr_get_string_size(&w,&h,outstr);
 
-	renderString(position[0] + Dist_offsets[0]+hx, position[1] + Dist_offsets[1]+hy, EG_TBOX_DIST, outstr);	
+	renderString(position[0] + Dist_offsets[0], position[1] + Dist_offsets[1], EG_TBOX_DIST, outstr);	
 
 #if 0
 	current_target_speed = vm_vec_dist(&target_objp->pos, &target_objp->last_pos) / frametime;
@@ -2155,7 +2141,7 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 	sprintf(outstr, XSTR( "s: %.0f%s", 351), displayed_target_speed, (displayed_target_speed>1)?modifiers[Player_ai->current_target_speed_trend]:"");
 	hud_num_make_mono(outstr, font_num);
 
-	renderString(position[0] + Speed_offsets[0]+hx, position[1] + Speed_offsets[1]+hy, EG_TBOX_SPEED, outstr);
+	renderString(position[0] + Speed_offsets[0], position[1] + Speed_offsets[1], EG_TBOX_SPEED, outstr);
 
 	//
 	// output target info for debug purposes only, this will be removed later

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -1061,7 +1061,21 @@ void HudGaugeTrainingMessages::render(float  /*frametime*/)
 	gr_set_screen_scale(base_w, base_h);
 	height = gr_get_font_height();
 	gr_set_shader(&Training_msg_glass);
-	gr_shade(position[0], position[1], TRAINING_MESSAGE_WINDOW_WIDTH, Training_num_lines * height + height);
+
+	int nx = 0;
+	int ny = 0;
+
+	if (reticle_follow) {
+		nx = HUD_nose_x;
+		ny = HUD_nose_y;
+
+		gr_reset_screen_scale();
+		gr_resize_screen_pos(&nx, &ny);
+		gr_set_screen_scale(base_w, base_h);
+		gr_unsize_screen_pos(&nx, &ny);
+	}
+
+	gr_shade(position[0] + nx, position[1] + ny, TRAINING_MESSAGE_WINDOW_WIDTH, Training_num_lines * height + height);
 	gr_reset_screen_scale();
 
 	gr_set_color_fast(&Color_bright_blue);

--- a/code/render/3dmath.cpp
+++ b/code/render/3dmath.cpp
@@ -10,7 +10,6 @@
 
 
 #include "graphics/2d.h"
-#include "hud/hud.h" //For HUD_offset_*
 #include "render/3dinternal.h"
 #include "tracing/Monitor.h"
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3374,9 +3374,7 @@ void game_render_frame( camid cid )
 	}
 
 	if (!(Game_mode & GM_LAB)) {
-		// maybe offset the HUD (jitter stuff) and measure the 2D displacement between the player's view and ship vector
-		int dont_offset = ((Game_mode & GM_MULTIPLAYER) && (Net_player->flags & NETINFO_FLAG_OBSERVER));
-		HUD_set_offsets(Viewer_obj, !dont_offset, &eye_no_jitter);
+		HUD_set_offsets();
 	}
 
 	// for multiplayer clients, call code in Shield.cpp to set up the Shield_hit array.  Have to


### PR DESCRIPTION
This PR fixes wildly inconsistent HUD slewing behaviour in FSO.
Some gauges just didn't slew at all, some slewed incorrectly, while some were allowed to slew even if they must not slew ever.
This also removes the effect of HUD_offset_x/y, as that seems to be partly redundant with HUD_nose_x/y, and causes HUD gauges to never be anywhere near correct as soon as its nonzero. However, as there may have been plans for it, it's just commented out instead of removed outright.
Prerequisite for #5583.