### PR TITLE
fix barrel roll crash in Star Fox: Event Horizon

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2518,6 +2518,7 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 
 	if (ship_it != Ship_registry_map.end()) {
 		auto entry = &Ship_registry[ship_it->second];
+		entry->status = ShipStatus::NOT_YET_PRESENT;
 		entry->p_objp = p_objp;
 	}
 
@@ -4261,6 +4262,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, bool force_create, 
 			if (!ship_registry_get(p_objp->name))
 			{
 				ship_registry_entry entry(p_objp->name);
+				entry.status = ShipStatus::NOT_YET_PRESENT;
 				entry.p_objp = p_objp;
 
 				Ship_registry.push_back(entry);
@@ -4880,6 +4882,7 @@ void post_process_ships_wings()
 	for (auto &p_obj : Parse_objects)
 	{
 		ship_registry_entry entry(p_obj.name);
+		entry.status = ShipStatus::NOT_YET_PRESENT;
 		entry.p_objp = &p_obj;
 
 		Ship_registry.push_back(entry);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -6593,7 +6593,7 @@ void eval_object_ship_wing_point_team(object_ship_wing_point_team *oswpt, int no
 				break;
 
 			default:
-				Assertion(false, "Unhandled ship status!");
+				UNREACHABLE("Unhandled ship registry entry status for %s: %d", ship_entry->name, (int)ship_entry->status);
 		}
 
 		return;
@@ -16267,8 +16267,8 @@ void sexp_deal_with_ship_flag(int node, bool process_subsequent_nodes, Object::O
 				Current_sexp_network_packet.send_ship(ship_entry->shipp); 
 			}
 		}
-		// if it's not in-mission
-		else
+		// if it hasn't arrived yet
+		else if (ship_entry->status == ShipStatus::NOT_YET_PRESENT)
 		{
 			// see if we have a p_object flag to set
 			if (p_object_flag != Mission::Parse_Object_Flags::NUM_VALUES)
@@ -16495,12 +16495,13 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 				// set or clear?
 				Ai_info[oswpt.ship_entry->shipp->ai_index].ai_flags.set(ai_flag, set_flag);
 			}
-			
+
 			// no break statement. We want to fall through.
 			FALLTHROUGH;
 			
 		case OSWPT_TYPE_PARSE_OBJECT:
-			if (!future_ships) {
+			// only apply the flag to future ships if we want to and we are able to
+			if (!future_ships || !oswpt.ship_entry->p_objp) {
 				return;
 			}
 
@@ -16511,7 +16512,7 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 			}
 
 			// see if we have a p_object flag to set
-			if (parse_obj_flag != Mission::Parse_Object_Flags::NUM_VALUES && oswpt.ship_entry->p_objp != nullptr)
+			if (parse_obj_flag != Mission::Parse_Object_Flags::NUM_VALUES)
 			{
 				oswpt.ship_entry->p_objp->flags.set(parse_obj_flag, set_flag);
 			}
@@ -16520,7 +16521,6 @@ void sexp_alter_ship_flag_helper(object_ship_wing_point_team &oswpt, bool future
 		default:
 			break;
 	}
-
 }
 
 void alter_flag_for_all_ships(bool future_ships, Object::Object_Flags object_flag, Ship::Ship_Flags ship_flag, Mission::Parse_Object_Flags parse_obj_flag, AI::AI_Flags ai_flag, bool set_flag)

--- a/code/scripting/api/objs/oswpt.cpp
+++ b/code/scripting/api/objs/oswpt.cpp
@@ -62,7 +62,11 @@ void object_ship_wing_point_team::deserialize(lua_State* /*L*/, const scripting:
 	case oswpt_type::PARSE_OBJECT: {
 		ushort net_signature;
 		GET_USHORT(net_signature);
-		new(data_ptr) object_ship_wing_point_team(mission_parse_get_arrival_ship(net_signature));
+		auto p_objp = mission_parse_get_arrival_ship(net_signature);
+		if (p_objp == nullptr)
+			new(data_ptr) object_ship_wing_point_team;
+		else
+			new(data_ptr) object_ship_wing_point_team(p_objp);
 		break;
 	}
 	case oswpt_type::WING:

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -900,8 +900,11 @@ extern int ship_find_exited_ship_by_signature( int signature);
 // Stuff for overall ship status, useful for reference by sexps and scripts.  Status changes occur in the same frame as mission log entries.
 enum class ShipStatus
 {
+	// The ship_registry_entry hasn't been initialized yet
+	INVALID = 0,
+
 	// A ship is on the arrival list as a parse object
-	NOT_YET_PRESENT = 0,
+	NOT_YET_PRESENT,
 
 	// A ship is currently in-mission, and its objp and shipp pointers are valid
 	PRESENT,
@@ -915,7 +918,7 @@ enum class ShipStatus
 
 struct ship_registry_entry
 {
-	ShipStatus status = ShipStatus::NOT_YET_PRESENT;
+	ShipStatus status = ShipStatus::INVALID;
 	char name[NAME_LENGTH];
 
 	p_object *p_objp = nullptr;


### PR DESCRIPTION
The Star Fox barrel roll effect is achieved using a script which spawns a new ship.  The script sets no-collide on this spawned ship, but it also tries to set the ship flag for all future ships -- and future ships require a parse object, which doesn't exist for a created ship.  This patches the FALLTHROUGH in the sexp code to account for that possibility.

Separately, there are other ways a parse object pointer could become null through unusual code states, so this adds an INVALID status and several additional checks to defend against this crash in other circumstances.