### PR TITLE
allow modification of warp audible range via objecttypes.tbl

### DIFF
--- a/code/def_files/data/tables/objecttypes.tbl
+++ b/code/def_files/data/tables/objecttypes.tbl
@@ -1,5 +1,5 @@
-																		
-#Ship types																
+#Ship types
+
 $Name:					Navbuoy											
 $Max Debris Speed:		200												
 $FF Multiplier:			1.0												
@@ -12,6 +12,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Sentry Gun										
 $Counts for Alone:		YES												
 $On Hotkey List:		YES												
@@ -32,6 +33,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Escape Pod										
 $Praise Destruction:	YES												
 $On Hotkey List:		YES												
@@ -50,6 +52,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Cargo											
 $Scannable:				YES												
 $Max Debris Speed:		200												
@@ -63,6 +66,7 @@ $Fog:
 $AI:																	
 	+Passive docks:			( "cargo" )								
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Support											
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -89,6 +93,7 @@ $AI:
 	+Active docks:			( "support" )								
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Vaporize Percent Chance: 0.0											
+
 ;;WMC - Stealth ships always have another type, so this isn't used		
 $Name:					Stealth											
 $Counts for Alone:		YES												
@@ -114,6 +119,7 @@ $AI:
 	+Passive docks:			( "support" )								
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Fighter											
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -141,6 +147,7 @@ $AI:
 	+Passive docks:			( "support" )								
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Bomber											
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -168,7 +175,8 @@ $AI:
 	+Passive docks:			( "support" )								
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Vaporize Percent Chance: 0.0											
-;;WMC - This fighter/bomber type doesn't seem to be used anywhere, because no ship is set as both fighter and bomber																																																								
+
+;;WMC - This fighter/bomber type doesn't seem to be used anywhere, because no ship is set as both fighter and bomber
 $Name:					Fighter/bomber									
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -195,6 +203,7 @@ $AI:
 	+Passive docks:			( "support" )								
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Transport										
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -204,6 +213,7 @@ $Show Attack Direction:	YES
 $Max Debris Speed:		150												
 $FF Multiplier:			1.0												
 $EMP Multiplier:		2.0												
+$Warp Sound Range Multiplier:	6.0										
 $Beams Easily Hit:		YES												
 $Protected on cripple:	YES												
 $Fog:																	
@@ -223,6 +233,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Freighter										
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -233,6 +244,7 @@ $Scannable:				YES
 $Max Debris Speed:		150												
 $FF Multiplier:			1.0												
 $EMP Multiplier:		1.75											
+$Warp Sound Range Multiplier:	6.0										
 $Beams Easily Hit:		YES												
 $Protected on cripple:	YES												
 $Fog:																	
@@ -253,6 +265,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
+
 $Name:					AWACS											
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -262,6 +275,7 @@ $Show Attack Direction:	YES
 $Max Debris Speed:		150												
 $FF Multiplier:			1.0												
 $EMP Multiplier:		0.8												
+$Warp Sound Range Multiplier:	6.0										
 $Beams Easily Hit:		YES												
 $Protected on cripple:	YES												
 $Fog:																	
@@ -281,6 +295,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Gas Miner										
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -290,6 +305,7 @@ $Show Attack Direction:	YES
 $Max Debris Speed:		150												
 $FF Multiplier:			1.0												
 $EMP Multiplier:		1.0												
+$Warp Sound Range Multiplier:	6.0										
 $Beams Easily Hit:		YES												
 $Protected on cripple:	YES												
 $Fog:																	
@@ -309,6 +325,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES	
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Cruiser											
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -318,6 +335,7 @@ $Show Attack Direction:	YES
 $Max Debris Speed:		150												
 $FF Multiplier:			1.0												
 $EMP Multiplier:		0.9												
+$Warp Sound Range Multiplier:	6.0										
 $Beams Easily Hit:		YES												
 $Protected on cripple:	YES												
 $Fog:																	
@@ -337,6 +355,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Corvette										
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -346,6 +365,7 @@ $Show Attack Direction:	YES
 $Max Debris Speed:		150												
 $FF Multiplier:			1.0												
 $EMP Multiplier:		0.3333											
+$Warp Sound Range Multiplier:	6.0										
 $Beams Easily Hit:		YES												
 $Protected on cripple:	YES												
 $Fog:																	
@@ -365,6 +385,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Capital											
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -394,6 +415,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Super Cap										
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -421,6 +443,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Drydock											
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -446,6 +469,7 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
+
 $Name:					Knossos Device									
 $Counts for Alone:		YES												
 $Praise Destruction:	YES												
@@ -469,4 +493,5 @@ $AI:
 	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "stealth" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Vaporize Percent Chance: 0.0											
-#End																	
+
+#End

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -61,35 +61,33 @@ static auto WarpOption __UNUSED = options::OptionBuilder<bool>("Graphics.3dWarp"
  */
 void fireball_play_warphole_open_sound(int ship_class, fireball *fb)
 {
-	gamesnd_id sound_index;
-	float		range_multiplier = 1.0f;
-	object	*fireball_objp;	
-		
 	Assert((fb != NULL) && (fb->objnum >= 0));
 	if((fb == NULL) || (fb->objnum < 0)){
 		return;
 	}
-	fireball_objp = &Objects[fb->objnum];
+	auto fireball_objp = &Objects[fb->objnum];
+	auto sound_index = gamesnd_id(GameSounds::WARP_IN);
 
-	if(fb->warp_open_sound_index.isValid()) {
+	if (fb->warp_open_sound_index.isValid()) {
 		sound_index = fb->warp_open_sound_index;
 	} else if ((ship_class >= 0) && (ship_class < ship_info_size())) {
 		if ( Ship_info[ship_class].is_huge_ship() ) {
 			sound_index = gamesnd_id(GameSounds::CAPITAL_WARP_IN);
-		} else {
-			sound_index = gamesnd_id(GameSounds::WARP_IN);
 		}
 	}
 
-	if (Ship_info[ship_class].is_huge_ship()) {
-		fb->flags |= FBF_WARP_CAPITAL_SIZE;
-	} else if (Ship_info[ship_class].is_big_ship()) {
-		fb->flags |= FBF_WARP_CRUISER_SIZE;
-	}
-	// originally 6.0 for SIF_BIG_SHIP and 1.0 for everything else
-	range_multiplier = Ship_types[Ship_info[ship_class].class_type].warp_sound_range_multiplier;
+	if (ship_class >= 0 && ship_class < ship_info_size()) {
+		if (Ship_info[ship_class].is_huge_ship()) {
+			fb->flags |= FBF_WARP_CAPITAL_SIZE;
+		} else if (Ship_info[ship_class].is_big_ship()) {
+			fb->flags |= FBF_WARP_CRUISER_SIZE;
+		}
 
-	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius, NULL, 0, 1.0f, SND_PRIORITY_DOUBLE_INSTANCE, NULL, range_multiplier); // play warp sound effect
+		// originally 6.0 for SIF_BIG_SHIP and 1.0 for everything else
+		fb->warp_sound_range_multiplier = Ship_types[Ship_info[ship_class].class_type].warp_sound_range_multiplier;
+	}
+
+	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius, NULL, 0, 1.0f, SND_PRIORITY_DOUBLE_INSTANCE, NULL, fb->warp_sound_range_multiplier); // play warp sound effect
 }
 
 /**
@@ -97,15 +95,14 @@ void fireball_play_warphole_open_sound(int ship_class, fireball *fb)
  */
 void fireball_play_warphole_close_sound(fireball *fb)
 {
-	gamesnd_id sound_index;
+	Assert((fb != NULL) && (fb->objnum >= 0));
+	if((fb == NULL) || (fb->objnum < 0)){
+		return;
+	}
+	auto fireball_objp = &Objects[fb->objnum];
+	auto sound_index = gamesnd_id(GameSounds::WARP_OUT);
 
-	object *fireball_objp;
-
-	fireball_objp = &Objects[fb->objnum];
-
-	sound_index = gamesnd_id(GameSounds::WARP_OUT);
-
-	if ( fb->warp_close_sound_index.isValid() ) {
+	if (fb->warp_close_sound_index.isValid()) {
 		sound_index = fb->warp_close_sound_index;
 	} else if ( fb->flags & FBF_WARP_CAPITAL_SIZE ) {
 		sound_index = gamesnd_id(GameSounds::CAPITAL_WARP_OUT);
@@ -113,7 +110,7 @@ void fireball_play_warphole_close_sound(fireball *fb)
 		return;
 	}
 
-	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius); // play warp sound effect
+	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius, NULL, 0, 1.0F, SND_PRIORITY_SINGLE_INSTANCE, NULL, fb->warp_sound_range_multiplier); // play warp sound effect
 }
 
 static void fireball_generate_unique_id(char *unique_id, int buffer_len, int fireball_index)
@@ -849,6 +846,7 @@ int fireball_create(vec3d *pos, int fireball_type, int render_type, int parent_o
 	new_fireball->warp_close_sound_index = warp_close_sound;
 	new_fireball->warp_open_duration = (warp_open_duration < 0.0f) ? WARPHOLE_GROW_TIME : warp_open_duration;
 	new_fireball->warp_close_duration = (warp_close_duration < 0.0f) ? WARPHOLE_GROW_TIME : warp_close_duration;
+	new_fireball->warp_sound_range_multiplier = 1.0f;
 
 	matrix orient;
 	if(orient_override != NULL){

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -71,19 +71,23 @@ void fireball_play_warphole_open_sound(int ship_class, fireball *fb)
 	}
 	fireball_objp = &Objects[fb->objnum];
 
-	sound_index = gamesnd_id(GameSounds::WARP_IN);
-
 	if(fb->warp_open_sound_index.isValid()) {
 		sound_index = fb->warp_open_sound_index;
 	} else if ((ship_class >= 0) && (ship_class < ship_info_size())) {
 		if ( Ship_info[ship_class].is_huge_ship() ) {
 			sound_index = gamesnd_id(GameSounds::CAPITAL_WARP_IN);
-			fb->flags |= FBF_WARP_CAPITAL_SIZE;
-		} else if ( Ship_info[ship_class].is_big_ship() ) {
-			range_multiplier = 6.0f;
-			fb->flags |= FBF_WARP_CRUISER_SIZE;
+		} else {
+			sound_index = gamesnd_id(GameSounds::WARP_IN);
 		}
 	}
+
+	if (Ship_info[ship_class].is_huge_ship()) {
+		fb->flags |= FBF_WARP_CAPITAL_SIZE;
+	} else if (Ship_info[ship_class].is_big_ship()) {
+		fb->flags |= FBF_WARP_CRUISER_SIZE;
+	}
+	// originally 6.0 for SIF_BIG_SHIP and 1.0 for everything else
+	range_multiplier = Ship_types[Ship_info[ship_class].class_type].warp_sound_range_multiplier;
 
 	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius, NULL, 0, 1.0f, SND_PRIORITY_DOUBLE_INSTANCE, NULL, range_multiplier); // play warp sound effect
 }

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -92,6 +92,9 @@ typedef struct fireball {
 	gamesnd_id warp_close_sound_index;
 	float	warp_open_duration;
 	float	warp_close_duration;
+
+	// the sound multiplier is based on the ship class, but we lose that while the warp is closing
+	float	warp_sound_range_multiplier;
 } fireball;
 // end move
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5593,6 +5593,10 @@ static void parse_ship_type(const char *filename, const bool replace)
 		stuff_float(&stp->emp_multiplier);
 	}
 
+	if(optional_string("$Warp Sound Range Multiplier:")) {
+		stuff_float(&stp->warp_sound_range_multiplier);
+	}
+
 	if(optional_string("$Beams Easily Hit:")) {
 		stuff_boolean_flag(stp->flags, Ship::Type_Info_Flags::Beams_easily_hit);
 	}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -978,8 +978,15 @@ typedef struct ship_type_info {
 
 	float debris_max_speed;
 
+	// Damage multiplier for friendly fire, but only for purposes of scoring and traitor check, not actually damaging ships in-mission
 	float ff_multiplier;
+
+	// Not currently implemented. Originally used for "electronics" weapons. Deactivated in commit 941faf9ab9ed05a1b0efebf7de32c6e3c724baf7 
+	// as it broke retail compatibility.
 	float emp_multiplier;
+
+	// Modifies the audible range used for warp fireball 3d sound effects
+	float warp_sound_range_multiplier;
 
 	//Fog
 	float fog_start_dist;
@@ -1005,7 +1012,7 @@ typedef struct ship_type_info {
 
 	ship_type_info( )
 		: debris_max_speed( 0.f ),
-		  ff_multiplier( 0.f ), emp_multiplier( 0.f ),
+		  ff_multiplier( 0.f ), emp_multiplier( 0.f ), warp_sound_range_multiplier( 1.f ),
 		  fog_start_dist( 0.f ), fog_complete_dist( 0.f ),
 		  ai_valid_goals( 0 ), ai_active_dock( 0 ), ai_passive_dock( 0 ),
 		  vaporize_chance( 0.f )


### PR DESCRIPTION
The retail warp range multiplier can yield ridiculous results, like an Elysium warp being audible over 9000 meters away.  So allow the multiplier to be set via ship type.