### PR TITLE
Intro about to play hook

### DIFF
--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -12,6 +12,10 @@ const std::shared_ptr<Hook<>> OnGameInit = Hook<>::Factory("On Game Init",
 	tl::nullopt,
 	CHA_GAMEINIT);
 
+const std::shared_ptr<Hook<>> OnIntroAboutToPlay = Hook<>::Factory("On Intro About To Play",
+	"Executed just before the intro movie is played.",
+	{});
+
 const std::shared_ptr<OverridableHook<>> OnStateStart = OverridableHook<>::Factory("On State Start",
 	"Executed whenever a new state is entered.",
 	{ 

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -6,6 +6,7 @@ namespace scripting {
 namespace hooks {
 
 extern const std::shared_ptr<Hook<>>									OnGameInit;
+extern const std::shared_ptr<Hook<>>									OnIntroAboutToPlay;
 //The On State Start hook previously used to pass OldState to the conditions, but no semantically sensible condition read the value, so we pretend it has no local condition
 extern const std::shared_ptr<OverridableHook<>>							OnStateStart;
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6653,6 +6653,10 @@ int game_main(int argc, char *argv[])
 		return 0;
 	}
 
+	if (scripting::hooks::OnIntroAboutToPlay->isActive()) {
+		scripting::hooks::OnIntroAboutToPlay->run();
+	}
+
 	if (!Is_standalone) {
 		movie::play("intro.mve");
 	}


### PR DESCRIPTION
I needed to reliably run a script for SCPUI after all game init methods have been completed but before the game actually moves on to the Intro and other game states. On Splash Screen worked but is deprecated, so this adds a new hook just before the intro that allows me to do what I need.