### PR TITLE
remove incorrect setting of ship status

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4269,7 +4269,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, bool force_create, 
 			}
 
 			// subsequent waves of ships will not be in the ship registry, so add them
-			if (!ship_registry_get(p_objp->name))
+			if (!ship_registry_exists(p_objp->name))
 			{
 				ship_registry_entry entry(p_objp->name);
 				entry.status = ShipStatus::NOT_YET_PRESENT;
@@ -8373,6 +8373,16 @@ void mission_bring_in_support_ship( object *requester_objp )
 			break;
 		i++;
 	} while(true);
+
+	// create a ship registry entry for the support ship
+	{
+		ship_registry_entry entry(pobj->name);
+		entry.status = ShipStatus::NOT_YET_PRESENT;
+		entry.p_objp = pobj;
+
+		Ship_registry.push_back(entry);
+		Ship_registry_map[pobj->name] = static_cast<int>(Ship_registry.size() - 1);
+	}
 
 	pobj->team = requester_shipp->team;
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2514,11 +2514,21 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 	}
 
 	// assign/update parse object in ship registry entry if needed
+	// (this is unrelated to ship registry state management and is only here because apparently in-game joining needs it;
+	// in the normal course of ship creation, the pointers and status are updated elsewhere)
 	auto ship_it = Ship_registry_map.find(shipp->ship_name);
-
 	if (ship_it != Ship_registry_map.end()) {
 		auto entry = &Ship_registry[ship_it->second];
-		entry->status = ShipStatus::NOT_YET_PRESENT;
+
+		if (entry->status == ShipStatus::INVALID) {
+			Warning(LOCATION, "Potential in-game join bug: ship registry status for %s is INVALID", shipp->ship_name);
+		}
+		if (entry->p_objp == nullptr) {
+			Warning(LOCATION, "Potential in-game join bug: ship registry parse object for %s is nullptr", shipp->ship_name);
+		} else if (entry->p_objp != p_objp) {
+			Warning(LOCATION, "Potential in-game join bug: ship registry parse object for %s is different from its expected value", shipp->ship_name);
+		}
+
 		entry->p_objp = p_objp;
 	}
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2521,12 +2521,12 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 		auto entry = &Ship_registry[ship_it->second];
 
 		if (entry->status == ShipStatus::INVALID) {
-			Warning(LOCATION, "Potential in-game join bug: ship registry status for %s is INVALID", shipp->ship_name);
+			Warning(LOCATION, "Potential bug: ship registry status for %s is INVALID", shipp->ship_name);
 		}
 		if (entry->p_objp == nullptr) {
-			Warning(LOCATION, "Potential in-game join bug: ship registry parse object for %s is nullptr", shipp->ship_name);
+			Warning(LOCATION, "Potential bug: ship registry parse object for %s is nullptr", shipp->ship_name);
 		} else if (entry->p_objp != p_objp) {
-			Warning(LOCATION, "Potential in-game join bug: ship registry parse object for %s is different from its expected value", shipp->ship_name);
+			Warning(LOCATION, "Potential bug: ship registry parse object for %s is different from its expected value", shipp->ship_name);
 		}
 
 		entry->p_objp = p_objp;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -186,6 +186,11 @@ int ship_registry_get_index(const char *name)
 	return -1;
 }
 
+bool ship_registry_exists(const char *name)
+{
+	return Ship_registry_map.find(name) != Ship_registry_map.end();
+}
+
 const ship_registry_entry *ship_registry_get(const char *name)
 {
 	auto ship_it = Ship_registry_map.find(name);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -941,6 +941,7 @@ extern SCP_vector<ship_registry_entry> Ship_registry;
 extern SCP_unordered_map<SCP_string, int, SCP_string_lcase_hash, SCP_string_lcase_equal_to> Ship_registry_map;
 
 extern int ship_registry_get_index(const char *name);
+extern bool ship_registry_exists(const char *name);
 extern const ship_registry_entry *ship_registry_get(const char *name);
 
 #define REGULAR_WEAPON	(1<<0)


### PR DESCRIPTION
There is a bit of code in missionparse that sets the parse object because in-game joining needs it.  This is unrelated to ship status, so the status shouldn't be changed.  This fixes the bug and adds a comment to clarify the situation, as well as some warnings to help track down incorrect joining states.

Fixes #5661.  Follow-up to #5658 (where the regression was introduced) and #4836 (which fixed in-game joining).

Also adds a ship registry entry for support ships, since in testing that issue was (correctly) flagged by the warnings.