### PR TITLE
add "Calculate subsystem hitpoints after parsing" option

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -144,6 +144,7 @@ bool Countermeasures_use_capacity;
 bool Play_thruster_sounds_for_player;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
+bool Calculate_subsystem_hitpoints_after_parsing;
 
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Other.Discord", "Discord Presence", "Toggle Discord Rich Presence")
 							 .category("Other")
@@ -436,8 +437,7 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Use_host_orientation_for_set_camera_facing);
 			if (Use_host_orientation_for_set_camera_facing) {
 				mprintf(("Game Settings Table: Using host orientation for set-camera-facing\n"));
-			}
-			else {
+			} else {
 				mprintf(("Game Settings Table: Using identity orientation for set-camera-facing\n"));
 			}
 		}
@@ -1012,18 +1012,35 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Fixed Turret Collisions:")) {
 			stuff_boolean(&Fixed_turret_collisions);
+			if (Fixed_turret_collisions) {
+				mprintf(("Game Settings Table: Using fixed turret collisions (shooting a turret barrel will always register)\n"));
+			} else {
+				mprintf(("Game Settings Table: Using retail turret collisions (shooting a turret barrel will register if it is within the radius of the base)\n"));
+			}
 		}
 
 		if (optional_string("$Fixed Missile Detonation:")) {
 			stuff_boolean(&Fixed_missile_detonation);
+			if (Fixed_missile_detonation) {
+				mprintf(("Game Settings Table: Using fixed missile detonation (missiles will cross an entire subsystem before detonating)\n"));
+			} else {
+				mprintf(("Game Settings Table: Using retail missile detonation (missiles will detonate when they reach the center coordinates of a subsystem)\n"));
+			}
 		}
 
 		if (optional_string("$Damage Impacted Subsystem First:")) {
 			stuff_boolean(&Damage_impacted_subsystem_first);
+			if (Damage_impacted_subsystem_first) {
+				mprintf(("Game Settings Table: Damage Impacted Subsystem First set to TRUE (weapons will damage the subsystem they impact before any others)\n"));
+			} else {
+				mprintf(("Game Settings Table: Damage Impacted Subsystem First set to FALSE (weapons will damage the closest subsystem before any others)\n"));
+			}
 		}
 
 		if (optional_string("$Use 3d ship select:")) {
 			stuff_boolean(&Use_3d_ship_select);
+			if (Use_3d_ship_select)
+				mprintf(("Game Settings Table: Using 3D ship select\n"));
 		}
 
 		if (optional_string("$Default ship select effect:")) {
@@ -1039,10 +1056,14 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Use 3d ship icons:")) {
 			stuff_boolean(&Use_3d_ship_icons);
+			if (Use_3d_ship_icons)
+				mprintf(("Game Settings Table: Using 3D ship icons\n"));
 		}
 
 		if (optional_string("$Use 3d weapon select:")) {
 			stuff_boolean(&Use_3d_weapon_select);
+			if (Use_3d_weapon_select)
+				mprintf(("Game Settings Table: Using 3D weapon select\n"));
 		}
 
 		if (optional_string("$Default weapon select effect:")) {
@@ -1058,10 +1079,14 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Use 3d weapon icons:")) {
 			stuff_boolean(&Use_3d_weapon_icons);
+			if (Use_3d_weapon_icons)
+				mprintf(("Game Settings Table: Using 3D weapon icons\n"));
 		}
 
 		if (optional_string("$Use 3d overhead ship:")) {
 			stuff_boolean(&Use_3d_overhead_ship);
+			if (Use_3d_overhead_ship)
+				mprintf(("Game Settings Table: Using 3D overhead ship\n"));
 		}
 
 		if (optional_string("$Default overhead ship style:")) {
@@ -1092,8 +1117,7 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Beams_use_damage_factors);
 			if (Beams_use_damage_factors) {
 				mprintf(("Game Settings Table: Beams will use Damage Factors\n"));
-			}
-			else {
+			} else {
 				mprintf(("Game Settings Table: Beams will ignore Damage Factors (retail behavior)\n"));
 			}
 		}
@@ -1166,14 +1190,20 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Shockwaves Always Damage Bombs:")) {
 			stuff_boolean(&Shockwaves_always_damage_bombs);
+			if (Shockwaves_always_damage_bombs)
+				mprintf(("Game Settings Table: Shockwaves always damage bombs\n"));
 		}
 
 		if (optional_string("$Shockwaves Damage All Object Types Once:")) {
 			stuff_boolean(&Shockwaves_damage_all_obj_types_once);
+			if (Shockwaves_damage_all_obj_types_once)
+				mprintf(("Game Settings Table: Shockwaves damage all object types once\n"));
 		}
 
 		if (optional_string("$Shockwaves Inherit Parent Weapon Damage Type:")) {
 			stuff_boolean(&Shockwaves_inherit_parent_damage_type);
+			if (Shockwaves_inherit_parent_damage_type)
+				mprintf(("Game Settings Table: Shockwaves inherit parent damage type\n"));
 		}
 
 		if (optional_string("$Inherited Shockwave Damage Type Added Suffix:")) {
@@ -1205,6 +1235,8 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Swarmers Lead Targets:")) {
 			stuff_boolean(&Swarmers_lead_targets);
+			if (Swarmers_lead_targets)
+				mprintf(("Game Settings Table: Swarmers lead targets\n"));
 		}
 
 		if (optional_string("$Damage Threshold for Weapons Subsystems to Trigger Turret Inaccuracy:")) {
@@ -1278,6 +1310,14 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Countermeasures use capacity:")) {
 			stuff_boolean(&Countermeasures_use_capacity);
+		}
+
+		if (optional_string("$Calculate subsystem hitpoints after parsing:")) {
+			stuff_boolean(&Calculate_subsystem_hitpoints_after_parsing);
+			if (Calculate_subsystem_hitpoints_after_parsing)
+				mprintf(("Game Settings Table: Subsystem hitpoints will be calculated after parsing\n"));
+			else
+				mprintf(("Game Settings Table: Subsystem hitpoints will be calculated as they are parsed\n"));
 		}
 
 		required_string("#END");
@@ -1456,6 +1496,7 @@ void mod_table_reset()
 			std::tuple<float, float>{ 1.0f, 1.0f }
 		}};
 	Randomize_particle_rotation = false;
+	Calculate_subsystem_hitpoints_after_parsing = false;
 }
 
 void mod_table_set_version_flags()
@@ -1470,5 +1511,8 @@ void mod_table_set_version_flags()
 	if (mod_supports_version(23, 0, 0)) {
 		Shockwaves_inherit_parent_damage_type = true;	// people intuitively expect shockwaves to default to the damage type of the weapon that spawned them
 		Fixed_chaining_to_repeat = true;
+	}
+	if (mod_supports_version(24, 0, 0)) {
+		Calculate_subsystem_hitpoints_after_parsing = true;		// this is essentially a bugfix
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -140,6 +140,7 @@ extern bool Countermeasures_use_capacity;
 extern bool Play_thruster_sounds_for_player;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
+extern bool Calculate_subsystem_hitpoints_after_parsing;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5002,13 +5002,6 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		subsystems[i].reset();
 	}
 	
-	float	hull_percentage_of_hits = 100.0f;
-	//If the ship already has subsystem entries (ie this is a modular table)
-	//make sure hull_percentage_of_hits is set properly
-	for(auto i=0; i < sip->n_subsystems; i++) {
-		hull_percentage_of_hits -= sip->subsystems[i].max_subsys_strength / sip->max_hull_strength;
-	}
-
 	while (cont_flag) {
 		int r = required_string_one_of(3, "#End", "$Subsystem:", type_name);
 		switch (r) {
@@ -5101,8 +5094,11 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			sfo_return = stuff_float_optional(&percentage_of_hits);
 			if(sfo_return==2)
 			{
-				hull_percentage_of_hits -= percentage_of_hits;
-				sp->max_subsys_strength = sip->max_hull_strength * (percentage_of_hits / 100.0f);
+				if (Calculate_subsystem_hitpoints_after_parsing)
+					sp->max_subsys_strength = percentage_of_hits;
+				else
+					sp->max_subsys_strength = sip->max_hull_strength * (percentage_of_hits / 100.0f);
+
 				sp->type = SUBSYSTEM_UNKNOWN;
 			}
 			if(sfo_return > 0)
@@ -5390,13 +5386,6 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		}
 	}	
 
-	// must be > 0//no it doesn't :P -Bobboau
-	// yes it does! - Goober5000
-	// (we don't want a div-0 error)
-	if (hull_percentage_of_hits <= 0.0f )
-	{
-		//Warning(LOCATION, "The subsystems defined for the %s can take more (or the same) combined damage than the ship itself. Adjust the tables so that the percentages add up to less than 100", sip->name);
-	}
 	// when done reading subsystems, malloc and copy the subsystem data to the ship info structure
 	int orig_n_subsystems = sip->n_subsystems;
 	if ( n_subsystems > 0 ) {
@@ -5979,6 +5968,16 @@ static void ship_parse_post_cleanup()
 			error_display(0, "$Player Minimum Velocity Z-value (%f) is negative or greater than max velocity Z-value (%f), setting to zero\nFix for ship '%s'\n",
 					sip->min_vel.xyz.z, sip->max_vel.xyz.z, sip->name);
 			sip->min_vel.xyz.z = 0.0f;
+		}
+
+		// we might need to calculate subsystem strength
+		if (Calculate_subsystem_hitpoints_after_parsing)
+		{
+			for (int i = 0; i < sip->n_subsystems; ++i)
+			{
+				auto sp = &sip->subsystems[i];
+				sp->max_subsys_strength = sip->max_hull_strength * (sp->max_subsys_strength / 100.0f);
+			}
 		}
 	}
 


### PR DESCRIPTION
Subsystem hitpoints are calculated as a percentage of the ship's hull strength as they are parsed.  If a modular table modifies the ship's hull strength, the subsystems are not modified at the same time.  This can lead to unreasonably large or small subsystem hitpoint values, as recently seen in the 1.3.0 version of Cardinal Spear.

This PR adds an option to defer hitpoint calculation until after parsing so that the subsystem is a percentage of the correct hull strength.  Since this may affect the balance of existing mods, it is off by default unless the build targets 24.0 or later.

This also removes the long-unused `hull_percentage_of_hits` check and adds several log statements for significant options in game_settings.tbl.