### PR TITLE
Fix hiDPI Windows Scaling

### DIFF
--- a/freespace2/resources/win/default.manifest
+++ b/freespace2/resources/win/default.manifest
@@ -41,8 +41,10 @@
     </trustInfo>
     
     <asmv3:application>
-        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-            <dpiAware>true</dpiAware>
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+			<!-- Modern windows needs to be explicitly told again that the hiDPI setting also applies to multi-monitor setups -->
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
         </asmv3:windowsSettings>
     </asmv3:application>
 </assembly>


### PR DESCRIPTION
This fixes #4588.
At least it does so on Win10, previous versions may still behave differently.
Required for #5583.