### PR TITLE
Add command line option for window resolution

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1734,7 +1734,7 @@ bool SetCmdlineParams()
 			sprintf(override, "{\"width\":%d,\"height\":%d}", width, height);
 			options::OptionsManager::instance()->setOverride("Graphics.Resolution", override);
 		} else {
-			mprintf(("Failed to parse -res parameter \"%s\". Must be in format \"<width>x<height>\".\n", Cmdline_res));
+			Warning(LOCATION, "Failed to parse -res parameter \"%s\". Must be in format \"<width>x<height>\".\n", Cmdline_res);
 		}
 	}
 	if(window_res_arg.found()){
@@ -1744,7 +1744,7 @@ bool SetCmdlineParams()
 		if ( sscanf(window_res_arg.str(), "%dx%d", &width, &height) == 2 ) {
 			Cmdline_window_res.emplace(width, height);
 		} else {
-			mprintf(("Failed to parse -res parameter \"%s\". Must be in format \"<width>x<height>\".\n", Cmdline_res));
+			Warning(LOCATION, "Failed to parse -window_res parameter \"%s\". Must be in format \"<width>x<height>\".\n", window_res_arg.str());
 		}
 	}
 	if(center_res_arg.found()){

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -511,6 +511,7 @@ cmdline_parm save_render_targets_arg("-save_render_target", NULL, AT_NONE);	// C
 cmdline_parm window_arg("-window", NULL, AT_NONE);				// Cmdline_window
 cmdline_parm fullscreen_window_arg("-fullscreen_window", "Fullscreen/borderless window (Windows only)", AT_NONE);
 cmdline_parm res_arg("-res", "Resolution, formatted like 1600x900", AT_STRING);
+cmdline_parm window_res_arg("-window_res", "Window resolution, formatted like 1600x900.", AT_STRING);
 cmdline_parm center_res_arg("-center_res", "Resolution of center monitor, formatted like 1600x900", AT_STRING);
 cmdline_parm verify_vps_arg("-verify_vps", NULL, AT_NONE);	// Cmdline_verify_vps  -- spew VP crcs to vp_crcs.txt
 cmdline_parm parse_cmdline_only(PARSE_COMMAND_LINE_STRING, "Ignore any cmdline_fso.cfg files", AT_NONE);
@@ -548,6 +549,7 @@ int Cmdline_show_stats = 0;
 int Cmdline_save_render_targets = 0;
 int Cmdline_window = 0;
 int Cmdline_fullscreen_window = 0;
+tl::optional<std::pair<uint16_t, uint16_t>>Cmdline_window_res = tl::nullopt;
 char *Cmdline_res = 0;
 char *Cmdline_center_res = 0;
 int Cmdline_verify_vps = 0;
@@ -1731,6 +1733,16 @@ bool SetCmdlineParams()
 			SCP_string override;
 			sprintf(override, "{\"width\":%d,\"height\":%d}", width, height);
 			options::OptionsManager::instance()->setOverride("Graphics.Resolution", override);
+		} else {
+			mprintf(("Failed to parse -res parameter \"%s\". Must be in format \"<width>x<height>\".\n", Cmdline_res));
+		}
+	}
+	if(window_res_arg.found()){
+		int width = 0;
+		int height = 0;
+
+		if ( sscanf(window_res_arg.str(), "%dx%d", &width, &height) == 2 ) {
+			Cmdline_window_res.emplace(width, height);
 		} else {
 			mprintf(("Failed to parse -res parameter \"%s\". Must be in format \"<width>x<height>\".\n", Cmdline_res));
 		}

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -510,7 +510,8 @@ cmdline_parm stats_arg("-stats", NULL, AT_NONE);				// Cmdline_show_stats
 cmdline_parm save_render_targets_arg("-save_render_target", NULL, AT_NONE);	// Cmdline_save_render_targets
 cmdline_parm window_arg("-window", NULL, AT_NONE);				// Cmdline_window
 cmdline_parm fullscreen_window_arg("-fullscreen_window", "Fullscreen/borderless window (Windows only)", AT_NONE);
-cmdline_parm res_arg("-res", "Resolution, formatted like 1600x900", AT_STRING);
+cmdline_parm deprecated_res_arg("-res", "Deprecated, resolution, formatted like 1600x900", AT_STRING);
+cmdline_parm render_res_arg("-render_res", "Resolution, formatted like 1600x900", AT_STRING);
 cmdline_parm window_res_arg("-window_res", "Window resolution, formatted like 1600x900.", AT_STRING);
 cmdline_parm center_res_arg("-center_res", "Resolution of center monitor, formatted like 1600x900", AT_STRING);
 cmdline_parm verify_vps_arg("-verify_vps", NULL, AT_NONE);	// Cmdline_verify_vps  -- spew VP crcs to vp_crcs.txt
@@ -1723,8 +1724,14 @@ bool SetCmdlineParams()
 		Cmdline_window = 0; /* Make sure no-one sets both */
 	}
 
-	if(res_arg.found()){
-		Cmdline_res = res_arg.str();
+	if(render_res_arg.found() || deprecated_res_arg.found()){
+		if (render_res_arg.found()) {
+			Cmdline_res = render_res_arg.str();
+		}
+		else {
+			Cmdline_res = deprecated_res_arg.str();
+			mprintf(("Deprecated -res argument. Use -render_res instead...\n"));
+		}
 
 		int width = 0;
 		int height = 0;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -6,12 +6,13 @@
  * source.
  *
 
-*/ 
+*/
 
 
 #ifndef FS_CMDLINE_HEADER_FILE
 #define FS_CMDLINE_HEADER_FILE
 
+#include <tl/optional.hpp>
 
 int parse_cmdline(int argc, char *argv[]);
 
@@ -46,6 +47,7 @@ extern int Cmdline_use_last_pilot;
 extern int Cmdline_window;
 extern int Cmdline_fullscreen_window;
 extern char *Cmdline_res;
+extern tl::optional<std::pair<uint16_t, uint16_t>>Cmdline_window_res;
 extern char *Cmdline_center_res;
 
 

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2588,6 +2588,7 @@ void gr_flip(bool execute_scripting)
 
 	TRACE_SCOPE(tracing::PageFlip);
 	gr_screen.gf_flip();
+	gr_setup_frame();
 }
 
 void gr_print_timestamp(int x, int y, fix timestamp, int resize_mode)

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -696,6 +696,8 @@ typedef struct screen {
 	// switch onscreen, offscreen
 	std::function<void()> gf_flip;
 
+	std::function<void()> gf_setup_frame;
+
 	// sets the clipping region
 	std::function<void(int x, int y, int w, int h, int resize_mode)> gf_set_clip;
 
@@ -1009,6 +1011,10 @@ extern void gr_activate(int active);
 
 //#define gr_flip				GR_CALL(gr_screen.gf_flip)
 void gr_flip(bool execute_scripting = true);
+
+inline void gr_setup_frame() {
+	gr_screen.gf_setup_frame();
+}
 
 //#define gr_set_clip			GR_CALL(gr_screen.gf_set_clip)
 inline void gr_set_clip(int x, int y, int w, int h, int resize_mode=GR_RESIZE_FULL)

--- a/code/graphics/grstub.cpp
+++ b/code/graphics/grstub.cpp
@@ -18,6 +18,11 @@
 #include "bmpman/bm_internal.h"
 
 
+void gr_stub_setup_frame()
+{
+
+}
+
 uint gr_stub_lock()
 {
 	return 1;
@@ -449,6 +454,7 @@ bool gr_stub_init()
 
 	// function pointers...
 	gr_screen.gf_flip				= gr_stub_flip;
+	gr_screen.gf_setup_frame		= gr_stub_setup_frame;
 	gr_screen.gf_set_clip			= gr_stub_set_clip;
 	gr_screen.gf_reset_clip			= gr_stub_reset_clip;
 	

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -106,6 +106,18 @@ void gr_opengl_flip()
 	if (!GL_initted)
 		return;
 
+	if (Cmdline_window_res) {
+		GL_state.BindFrameBuffer(0, GL_DRAW_FRAMEBUFFER);
+		GL_state.BindFrameBuffer(Back_framebuffer, GL_READ_FRAMEBUFFER);
+
+		glReadBuffer(GL_COLOR_ATTACHMENT0);
+		glDrawBuffer(GL_BACK);
+		glBlitFramebuffer(0, 0, gr_screen.max_w, gr_screen.max_h, 0, 0, Cmdline_window_res->first, Cmdline_window_res->second, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+		glDrawBuffer(GL_NONE);
+
+		GL_state.PopFramebufferState();
+	}
+
 	if (Cmdline_gl_finish)
 		glFinish();
 
@@ -120,6 +132,17 @@ void gr_opengl_flip()
 		mprintf(("!!DEBUG!! OpenGL Errors this frame: %i\n", ic));
 	}
 #endif
+}
+
+void gr_opengl_setup_frame() {
+	if (!GL_initted)
+		return;
+
+	if (Cmdline_window_res) {
+		GL_state.PushFramebufferState();
+		GL_state.BindFrameBuffer(Back_framebuffer);
+		glViewport(0, 0, gr_screen.max_w, gr_screen.max_h);
+	}
 }
 
 void gr_opengl_set_clip(int x, int y, int w, int h, int resize_mode)
@@ -900,6 +923,7 @@ int opengl_init_display_device()
 void opengl_setup_function_pointers()
 {
 	gr_screen.gf_flip				= gr_opengl_flip;
+	gr_screen.gf_setup_frame		= gr_opengl_setup_frame;
 	gr_screen.gf_set_clip			= gr_opengl_set_clip;
 	gr_screen.gf_reset_clip			= gr_opengl_reset_clip;
 
@@ -1342,11 +1366,15 @@ bool gr_opengl_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	Gr_current_green = &Gr_green;
 	Gr_current_alpha = &Gr_alpha;
 
+
+	gr_setup_frame();
 	gr_opengl_reset_clip();
 	gr_opengl_clear();
 	gr_opengl_flip();
+	gr_setup_frame();
 	gr_opengl_clear();
 	gr_opengl_flip();
+	gr_setup_frame();
 	gr_opengl_clear();
 
 	glGetIntegerv(GL_MAX_ELEMENTS_VERTICES, &GL_max_elements_vertices);

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -49,6 +49,10 @@ GLuint Scene_depth_texture_ms;
 GLuint Cockpit_depth_texture;
 GLuint Scene_stencil_buffer;
 
+GLuint Back_framebuffer;
+GLuint Back_texture;
+GLuint Back_depth_texture;
+
 GLuint Distortion_framebuffer = 0;
 GLuint Distortion_texture[2];
 int Distortion_switch = 0;
@@ -522,6 +526,53 @@ void opengl_setup_scene_textures()
 
 		GL_state.Texture.SetActiveUnit(0);
 		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
+	}
+
+	if (Cmdline_window_res) {
+		//Gen Framebuffer
+		glGenFramebuffers(1, &Back_framebuffer);
+		GL_state.BindFrameBuffer(Back_framebuffer);
+		opengl_set_object_label(GL_FRAMEBUFFER, Back_framebuffer, "Backbuffer");
+
+		// setup main render texture
+
+		// setup high dynamic range color texture
+		glGenTextures(1, &Back_texture);
+
+		GL_state.Texture.SetActiveUnit(0);
+		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
+		GL_state.Texture.Enable(Back_texture);
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, gr_screen.max_w, gr_screen.max_h, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
+
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Back_texture, 0);
+		opengl_set_object_label(GL_TEXTURE, Back_texture, "Backbuffer texture");
+
+		glGenTextures(1, &Back_depth_texture);
+
+		GL_state.Texture.SetActiveUnit(0);
+		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
+		GL_state.Texture.Enable(Back_depth_texture);
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_NONE);
+
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, gr_screen.max_w, gr_screen.max_h, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
+		opengl_set_object_label(GL_TEXTURE, Back_depth_texture, "Backbuffer depth texture");
+
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Back_depth_texture, 0);
+		gr_zbuffer_set(GR_ZBUFF_FULL);
+		glClear(GL_DEPTH_BUFFER_BIT);
 	}
 
 	//Setup thruster distortion framebuffer

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -38,6 +38,9 @@ extern GLuint Scene_depth_texture_ms;
 extern GLuint Cockpit_depth_texture;
 extern GLuint Scene_stencil_buffer;
 
+extern GLuint Back_framebuffer;
+extern GLuint Back_texture;
+
 void gr_opengl_update_distortion();
 
 void gr_opengl_sphere(material *material_def, float rad);

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -14,6 +14,7 @@
 #define BMPMAN_INTERNAL
 #include "gropenglstate.h"
 #include "gropengltexture.h"
+#include "gropengldraw.h"
 #include "bmpman/bm_internal.h"
 #include "bmpman/bmpman.h"
 #include "cmdline/cmdline.h"
@@ -1702,8 +1703,13 @@ int opengl_set_render_target( int slot, int face, int is_static )
 			}
 		}
 
-		GL_state.BindFrameBuffer(0);
-		glBindRenderbuffer(GL_RENDERBUFFER, 0);
+		if(Cmdline_window_res) {
+			GL_state.BindFrameBuffer(Back_framebuffer);
+		}
+		else {
+			GL_state.BindFrameBuffer(0);
+			glBindRenderbuffer(GL_RENDERBUFFER, 0);
+		}
 
 		// done with this render target so lets move on
 		render_target = NULL;

--- a/code/graphics/vulkan/vulkan_stubs.cpp
+++ b/code/graphics/vulkan/vulkan_stubs.cpp
@@ -15,6 +15,8 @@ gr_buffer_handle stub_create_buffer(BufferType, BufferUsageHint)
 	return gr_buffer_handle::invalid();
 }
 
+void stub_setup_frame() {}
+
 void stub_delete_buffer(gr_buffer_handle /*handle*/) {}
 
 int stub_preload(int /*bitmap_num*/, int /*is_aabitmap*/) { return 0; }
@@ -237,6 +239,7 @@ void stub_delete_query_object(int /*obj*/) {}
 void init_stub_pointers()
 {
 	// function pointers...
+	gr_screen.gf_setup_frame = stub_setup_frame;
 	gr_screen.gf_set_clip = stub_set_clip;
 	gr_screen.gf_reset_clip = stub_reset_clip;
 

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -86,6 +86,10 @@ const std::shared_ptr<scripting::Hook<>> OnMouseWheelHook = scripting::Hook<>::F
 		{"MouseWheelX", "number", "Positive if moved right, negative if moved left."},
 	});
 
+#define SCALE_MOUSE_TO_WINDOW(x, y, op) \
+	static_cast<decltype(x)>(Cmdline_window_res ? static_cast<float>(x) op (static_cast<float>(gr_screen.max_w) / static_cast<float>(Cmdline_window_res->first)) : x), \
+	static_cast<decltype(y)>(Cmdline_window_res ? static_cast<float>(y) op (static_cast<float>(gr_screen.max_h) / static_cast<float>(Cmdline_window_res->second)) : y)
+
 namespace
 {
 	bool mouse_key_event_handler(const SDL_Event& e)
@@ -124,7 +128,7 @@ namespace
 			return false;
 		}
 
-		mouse_event(e.motion.x, e.motion.y, e.motion.xrel, e.motion.yrel);
+		mouse_event(SCALE_MOUSE_TO_WINDOW(e.motion.x, e.motion.y, *), SCALE_MOUSE_TO_WINDOW(e.motion.xrel, e.motion.yrel, *));
 
 		return true;
 	}
@@ -516,7 +520,7 @@ void mouse_get_delta(int *dx, int *dy, int *dz)
 void mouse_force_pos(int x, int y)
 {
 	if (os_foreground()) {  // only mess with windows's mouse if we are in control of it
-		SDL_WarpMouseInWindow(os::getSDLMainWindow(), x, y);
+		SDL_WarpMouseInWindow(os::getSDLMainWindow(), SCALE_MOUSE_TO_WINDOW(x, y, /));
 	}
 }
 
@@ -603,6 +607,12 @@ int mouse_get_pos_unscaled( int *xpos, int *ypos )
 void mouse_get_real_pos(int *mx, int *my)
 {
 	SDL_GetMouseState(mx, my);
+	if (Cmdline_window_res) {
+		if (mx)
+			*mx *= gr_screen.max_w / Cmdline_window_res->first;
+		if (my)
+			*my *= gr_screen.max_h / Cmdline_window_res->second;
+	}
 }
 
 void mouse_set_pos(int xpos, int ypos)

--- a/freespace2/SDLGraphicsOperations.cpp
+++ b/freespace2/SDLGraphicsOperations.cpp
@@ -192,8 +192,15 @@ std::unique_ptr<os::Viewport> SDLGraphicsOperations::createViewport(const os::Vi
 
 	int x;
 	int y;
+	uint32_t width = props.width;
+	uint32_t height = props.height;
 
-	if (bounds.w == (int)props.width && bounds.h == (int)props.height) {
+	if (Cmdline_window_res) {
+		width = Cmdline_window_res->first;
+		height = Cmdline_window_res->second;
+	}
+
+	if (bounds.w == (int)width && bounds.h == (int)height) {
 		// If we have the same size as the desktop we explicitly specify 0,0 to make sure that the window borders aren't hidden
 		mprintf(("SDL: Creating window at %d,%d because window has same size as desktop.\n", bounds.x, bounds.y));
 		x = bounds.x;
@@ -206,8 +213,8 @@ std::unique_ptr<os::Viewport> SDLGraphicsOperations::createViewport(const os::Vi
 	SDL_Window* window = SDL_CreateWindow(props.title.c_str(),
 										  x,
 										  y,
-										  props.width,
-										  props.height,
+										  width,
+										  height,
 										  windowflags);
 	if (window == nullptr) {
 		mprintf(("Failed to create SDL Window: %s\n", SDL_GetError()));

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6107,7 +6107,6 @@ void game_do_state_common(int state,int no_networking)
 #endif
 	Last_frame_ui_timestamp = ui_timestamp();
 
-
 	io::mouse::CursorManager::doFrame();		// determine if to draw the mouse this frame
 	snd_do_frame();								// update sound system
 	event_music_do_frame();						// music needs to play across many states


### PR DESCRIPTION
This allows FSO to render the actual game at a different resolution from the window, by routing all rendering through an additional framebuffer (only if the option is actually used, for performance reasons).

I.e. -res 1920x1080 -window_res 1000x1000 will render the game and UI at 1080p, but the window will be 1000 by 1000 pixels large, with the image stretched to fit.

There are mainly two uses for this:
1. It allows a modder to test HUD / Mainhall / UI-setup for high resolutions or strange aspect ratios, even if the modder has no screen that could actually support that resolution.
2. In VR, users will regularly run FSO at resolutions higher than their displays, as the VR image is sent to the HMD before the downscaling. Without this, they'd also need a screen to support this to allow for mouse input / rendering over the entire game area. Thus, required for #5583.