### PR TITLE
rewrite primary weapon cycling

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1831,7 +1831,7 @@ int button_function_critical(int n, net_player *p = NULL)
 			}
 
 			hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-			if (ship_select_next_primary(objp, CYCLE_PRIMARY_NEXT)) {
+			if (ship_select_next_primary(objp, CycleDirection::NEXT)) {
 				ship* shipp = &Ships[objp->instance];
 				if ( timestamp_elapsed(shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank]) ) {
 					shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank] = timestamp(BANK_SWITCH_DELAY);	//	1/4 second delay until can fire
@@ -1852,7 +1852,7 @@ int button_function_critical(int n, net_player *p = NULL)
 			}
 
 			hud_gauge_popup_start(HUD_WEAPONS_GAUGE);
-			if (ship_select_next_primary(objp, CYCLE_PRIMARY_PREV)) {
+			if (ship_select_next_primary(objp, CycleDirection::PREV)) {
 				ship* shipp = &Ships[objp->instance];
 				if ( timestamp_elapsed(shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank]) ) {
 					shipp->weapons.next_primary_fire_stamp[shipp->weapons.current_primary_bank] = timestamp(BANK_SWITCH_DELAY);	//	1/4 second delay until can fire

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13657,12 +13657,9 @@ bool ship_select_next_primary(object *objp, CycleDirection direction)
 	auto sip = &Ship_info[shipp->ship_info_index];
 	auto swp = &shipp->weapons;
 
-	Assert((swp->current_primary_bank >= 0) && (swp->current_primary_bank < swp->num_primary_banks));
-
 	auto original_bank = swp->current_primary_bank;
 	auto original_link_flag = shipp->flags[Ship_Flags::Primary_linked];
 
-	// redid case structure to possibly add more primaries in the future - Goober5000
 	if ( swp->num_primary_banks == 0 )
 	{
 		if ( objp == Player_obj )
@@ -13686,6 +13683,8 @@ bool ship_select_next_primary(object *objp, CycleDirection direction)
 		UNREACHABLE("The ship %s has more primary banks than the maximum!", shipp->ship_name);
 		return false;
 	}
+
+	Assert((swp->current_primary_bank >= 0) && (swp->current_primary_bank < swp->num_primary_banks));
 
 	// set parameters based on direction
 	// (need the != operator to make this work for both)

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -63,8 +63,7 @@ extern vec3d	Original_vec_to_deader;
 
 
 // defines for 'direction' parameter of ship_select_next_primary()
-#define CYCLE_PRIMARY_NEXT		0
-#define CYCLE_PRIMARY_PREV		1
+enum class CycleDirection { NEXT, PREV };
 
 #define BANK_1		0
 #define BANK_2		1
@@ -1692,7 +1691,7 @@ extern int ship_launch_countermeasure(object *objp, int rand_val = -1);
 // for special targeting lasers
 extern void ship_process_targeting_lasers();
 
-extern int ship_select_next_primary(object *objp, int direction);
+extern bool ship_select_next_primary(object *objp, CycleDirection direction);
 extern int  ship_select_next_secondary(object *objp);
 
 // Goober5000

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -107,7 +107,6 @@ namespace Ship {
 		No_thrusters,				// The E - Thrusters on this ship are not rendered.
 		Ship_locked,				// Karajorma - Prevents the player from changing the ship class on loadout screen
 		Weapons_locked,				// Karajorma - Prevents the player from changing the weapons on the ship on the loadout screen
-		Ship_selective_linking,		// RSAXVC - Allow pilot to pick firing configuration
 		Scramble_messages,			// Goober5000 - all messages sent from this ship appear scrambled
         No_secondary_lockon,        // zookeeper - secondary lock-on disabled
         No_disabled_self_destruct,  // Goober5000 - ship will not self-destruct after 90 seconds if engines or weapons destroyed (c.f. ai_maybe_self_destruct)


### PR DESCRIPTION
Remove a whole bunch of ad-hoc code piled on top of the retail weapon cycling behavior, then replace it with a robust algorithm that takes all relevant attributes into account.

Fixes #5529.