### PR TITLE
Avoid edge case divide by zero

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -166,6 +166,8 @@ void factor_table::resize(size_t size)
 	}
 }
 
+// Cyborg -- You may see a linter or coverity complain about this function, since it basically discards a lot of the result of the float division.
+// But using modulo division instead is actually about 60% slower based on some quick testing I did, and it gives the same results.
 bool factor_table::isNaturalNumberFactor(size_t factor, size_t n)
 {
 	return ((float)n / (float)factor) == n / factor;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7150,11 +7150,13 @@ void Time_model( int modelnum )
 
 	bm_get_frame_usage(&bitmaps_used_this_frame,&bitmaps_new_this_frame);
 
-	modelstats_num_polys /= framecount;
-	modelstats_num_verts /= framecount;
+	// safety check
+	if framecount > 0{ 
+		modelstats_num_polys /= framecount;
+		modelstats_num_verts /= framecount;
 
-	Tmap_npixels /=framecount;
-
+		Tmap_npixels /=framecount;
+	}
 
 	mprintf(( "'%s' is %.2f FPS\n", pof_file, i2fl(framecount)/f2fl(t2-t1) ));
 	fprintf( Time_fp, "\"%s\"\t%.0f\t%d\t%d\t%d\t%d\n", pof_file, i2fl(framecount)/f2fl(t2-t1), bitmaps_used_this_frame, modelstats_num_polys, modelstats_num_verts, Tmap_npixels );

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7151,7 +7151,7 @@ void Time_model( int modelnum )
 	bm_get_frame_usage(&bitmaps_used_this_frame,&bitmaps_new_this_frame);
 
 	// safety check
-	if framecount > 0{ 
+	if (framecount > 0) { 
 		modelstats_num_polys /= framecount;
 		modelstats_num_verts /= framecount;
 


### PR DESCRIPTION
Guarantee that this block will not divide by zero and accidentally crash while debugging. 

For coverity 1107324.

Also add a clarifying comment for another false positive coverity issue.  (turns out modulo division is slow)