### PR TITLE
Fix glare shining through cockpits in free-look

### DIFF
--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -866,7 +866,7 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int sun_n )
 				mc.model_instance_num = -1;
 				mc.model_num = sip->cockpit_model_num;
 				mc.submodel_num = -1;
-				mc.orient = &Eye_matrix;
+				mc.orient = &eye_ori;
 				mc.pos = &pos;
 				mc.p0 = &rp0;
 				mc.p1 = &rp1;


### PR DESCRIPTION
Fixes #3098. The `shipfx_eye_in_shadow` function did a collision check for cockpits, bit did not previously take into account of the viewpoint had a non-forward orientation (IE the player was using free-look). This PR sets the collide check to take that into account with a 1 line fix. Tested with multiple FotG cockpits and fixes the issue.