### PR TITLE
Upgrade Lua Sound Handling methods

### DIFF
--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -50,6 +50,19 @@ ADE_VIRTVAR(MasterEventMusicVolume,
 	return ade_set_args(L, "f", Master_event_music_volume);
 }
 
+ADE_VIRTVAR(MasterEffectsVolume,
+	l_Audio,
+	nullptr,
+	"The current master effects volume. This property is read-only.",
+	"number",
+	"The volume in the range from 0 to 1")
+{
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read-only!");
+	}
+	return ade_set_args(L, "f", Master_sound_volume);
+}
+
 ADE_FUNC(getSoundentry, l_Audio, "string/number", "Return a sound entry matching the specified index or name. If you are using a number then the first valid index is 1", "soundentry", "soundentry or invalid handle on error")
 {
 	gamesnd_id index;

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -1147,6 +1147,9 @@ int ds_get_channel(ds_sound_handle sig)
 			if ( ds_is_channel_playing(i) == TRUE ) {
 				return i;
 			}
+			if (ds_is_channel_paused(i) == TRUE) {
+				return i;
+			}
 		}
 	}
 

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -523,7 +523,7 @@ void snd_close(void)
 // returns:		-1		=>		sound could not be played
 //					n		=>		handle for instance of sound
 //
-sound_handle snd_play_raw(sound_load_id soundnum, float pan, float vol_scale, int priority)
+sound_handle snd_play_raw(sound_load_id soundnum, float pan, float vol_scale, int priority, bool is_voice)
 {
 	game_snd gs;
 
@@ -538,7 +538,9 @@ sound_handle snd_play_raw(sound_load_id soundnum, float pan, float vol_scale, in
 	entry.id_sig      = Sounds[soundnum.value()].sig;
 	entry.filename[0] = 0;
 //	entry.flags = GAME_SND_VOICE | GAME_SND_USE_DS3D;
-	gs.flags = GAME_SND_VOICE;
+	if (is_voice) {
+		gs.flags = GAME_SND_VOICE;
+	}
 
 	gs.volume_range = util::UniformFloatRange(1.0f);
 	gs.pitch_range = util::UniformFloatRange(1.0f);
@@ -1034,7 +1036,7 @@ SCP_list<LoopingSoundInfo>::iterator find_looping_sound(SCP_list<LoopingSoundInf
  * @param sig		handle to sound, what is returned from snd_play()
  * @param volume	volume of sound (range: 0.0 -> 1.0)
  */
-void snd_set_volume(sound_handle sig, float volume)
+void snd_set_volume(sound_handle sig, float volume, bool is_voice)
 {
 	int	channel;
 	float	new_volume;
@@ -1068,7 +1070,11 @@ void snd_set_volume(sound_handle sig, float volume)
 
 	//looping sound volumes are updated in snd_do_frame
 	if(!isLoopingSound) {
-		new_volume = volume * (Master_sound_volume * aav_effect_volume);
+		if (is_voice) {
+			new_volume = volume * (Master_voice_volume * aav_effect_volume);
+		} else {
+			new_volume = volume * (Master_sound_volume * aav_effect_volume);
+		}
 		ds_set_volume( channel, new_volume );
 	}
 }

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -139,7 +139,7 @@ sound_handle snd_play(game_snd* gs, float pan = 0.0f, float vol_scale = 1.0f,
 // Play a sound directly from index returned from snd_load().  Bypasses
 // the sound management process of using game_snd.
 sound_handle snd_play_raw(sound_load_id soundnum, float pan, float vol_scale = 1.0f,
-                          int priority = SND_PRIORITY_MUST_PLAY);
+                          int priority = SND_PRIORITY_MUST_PLAY, bool is_voice = true);
 
 // Plays a sound with volume between 0 and 1.0, where 0 is the
 // inaudible and 1.0 is the loudest sound in the game.  It scales
@@ -168,7 +168,7 @@ void snd_resume(sound_handle snd_handle);
 // Sets the volume of a sound that is already playing.
 // The volume is between 0 and 1.0, where 0 is the
 // inaudible and 1.0 is the loudest sound in the game.
-void snd_set_volume(sound_handle snd_handle, float volume);
+void snd_set_volume(sound_handle snd_handle, float volume, bool is_voice = false);
 
 // Sets the panning location of a sound that is already playing.
 // Pan goes from -1.0 all the way left to 0.0 in center to 1.0 all the way right.


### PR DESCRIPTION
This PR upgrades the LUA Sound Handle methods to add the newer pause/resume methods. It also allows for specifying using either the Effects volume multiplier or the Voice volume multiplier where appropriate. 

(Note that music handling is not added here because music should still be done with AudioStream as well as the fact that there's no sound_handle methods that take the master music volume into account. They generally assume either voice or effects.)

Relies on PR #5636 and set as draft until that is merged.