### PR TITLE
handle parse objects that are out of order

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -4732,6 +4732,9 @@ void parse_wing(mission *pm)
 				// swap the parse objects
 				std::swap(Parse_objects[this_iter->second], Parse_objects[prev_iter->second]);
 
+				// swap the swapped net signatures so they are in their original order
+				std::swap(Parse_objects[this_iter->second].net_signature, Parse_objects[prev_iter->second].net_signature);
+
 				// swap the indexes in our temporary map
 				std::swap(this_iter->second, prev_iter->second);
 


### PR DESCRIPTION
Occasionally, FRED can save a mission with a wing's ships out of order; this can happen if ships are deleted and FRED finds a free index in the middle of the ship list.  This can cause benign but confusing mismatches in the ship registry, the hotkey list, and other places -- and it's also possible some mismatches may not be so benign, e.g. in multiplayer.  Anyway, it's better for the ships to appear in the order the wing expects them, so this adds a routine to swap them around if necessary.

Due to a change in indentation, I recommend viewing the diff while hiding whitespace changes.