### PR TITLE
Add CMakePresets.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,6 +250,7 @@ documentation/doxygen/*
 projects/*
 /.vs
 CMakeSettings.json
+CMakePresets.json
 
 # Weird files created by Linux
 .fuse_hidden*


### PR DESCRIPTION
This would be pretty helpful to me, as for some reason on my Mac, vscode does not automatically know how to build FSO and I have to create a preset to build it.  But every time I do, it gets added to the changes I have to uncheck when making commits.  LMK if this change is undesired for any reason as I could live with the inconvenience, if necessary.