### PR TITLE
fix change-soundtrack after <No Music>

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -606,7 +606,10 @@ void event_music_level_start(int force_soundtrack)
 
 	// Check that soundtrack index is in range, except that < 0 means no soundtrack
 	if (Current_soundtrack_num < 0)
+	{
+		Pattern_timer_id = TIMESTAMP::never();	// update the timestamp as if a soundtrack did start
 		return;
+	}
 	Assert(Current_soundtrack_num < (int)Soundtracks.size());
 	if (Current_soundtrack_num >= (int)Soundtracks.size())
 		return;


### PR DESCRIPTION
The fix in #5578 assumed that a previously playing soundtrack would properly set the timestamp, but if no soundtrack was previously played at all, this wouldn't happen.  So if we deliberately don't play a soundtrack, be sure to set the timestamp as if `event_music_do_frame()` had been called.

Fixes #5705.