### PR TITLE
Provide Lua a way to toggle the mainhall help overlay

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -2717,3 +2717,11 @@ void main_hall_unpause()
 
 	main_hall_start_ambient();
 }
+
+/**
+* Toggle the help overlay
+*/
+void main_hall_toggle_help(bool enable)
+{
+	help_overlay_set_state(Main_hall_overlay_id, main_hall_get_overlay_resolution_index(), (int)enable);
+}

--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -216,4 +216,6 @@ void main_hall_vasudan_funny();
 void main_hall_pause();
 void main_hall_unpause();
 
+void main_hall_toggle_help(bool enable);
+
 #endif

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -427,6 +427,22 @@ ADE_FUNC(startMusic, l_UserInterface_MainHall, nullptr, "Starts the mainhall mus
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(toggleHelp,
+	l_UserInterface_MainHall,
+	"boolean",
+	"Sets the mainhall F1 help overlay to display. True to display, false to hide",
+	nullptr,
+	"nothing")
+{
+	bool toggle;
+	ade_get_args(L, "b", &toggle);
+
+	main_hall_toggle_help(toggle);
+
+
+	return ADE_RETURN_NIL;
+}
+
 //**********SUBLIBRARY: UserInterface/Barracks
 ADE_LIB_DERIV(l_UserInterface_Barracks, "Barracks", nullptr,
               "API for accessing values specific to the Barracks UI.",


### PR DESCRIPTION
For being able to force it enabled on first run to help players know where to click.