### PR TITLE
Add Game Option to refresh selected weapon in loadout

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -1515,13 +1515,13 @@ void wl_maybe_reset_selected_slot()
 
 /**
  * If Selected_wl_class is -1, choose the first weapon available from the pool for an animation
- *  - on second thought, choose the first weapon that is oin the ship, then go to the pools
+ *  - on second thought, choose the first weapon that is on the ship, then go to the pools
  */
 void wl_maybe_reset_selected_weapon_class()
 {
 	int i;
 
-	if ( Selected_wl_class >= 0 ) 
+	if ( (Selected_wl_class >= 0) && !(Always_reset_selected_wep_on_loadout_open) ) 
 		return;
 
 	Assert( Wss_slots != NULL );

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -48,6 +48,7 @@ bool Enable_external_default_scripts;
 int Default_detail_level;
 bool Full_color_head_anis;
 bool Dont_automatically_select_turret_when_targeting_ship;
+bool Always_reset_selected_wep_on_loadout_open;
 bool Weapons_inherit_parent_collision_group;
 bool Flight_controls_follow_eyepoint_orientation;
 int FS2NetD_port;
@@ -145,7 +146,6 @@ bool Play_thruster_sounds_for_player;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
 bool Calculate_subsystem_hitpoints_after_parsing;
-bool Always_reset_selected_wep_on_loadout_open;
 
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Other.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
@@ -1124,6 +1124,10 @@ void parse_mod_table(const char *filename)
 			}
 		}
 
+		if (optional_string("$Always refresh selected weapon when viewing loadout:")) {
+			stuff_boolean(&Always_reset_selected_wep_on_loadout_open);
+		}
+
 		if (optional_string("$Weapons inherit parent collision group:")) {
 			stuff_boolean(&Weapons_inherit_parent_collision_group);
 			if (Weapons_inherit_parent_collision_group)
@@ -1343,10 +1347,6 @@ void parse_mod_table(const char *filename)
 				mprintf(("Game Settings Table: Subsystem hitpoints will be calculated as they are parsed\n"));
 		}
 
-		if (optional_string("$Always refresh selected weapon when viewing loadout:")) {
-			stuff_boolean(&Always_reset_selected_wep_on_loadout_open);
-		}
-
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -1420,6 +1420,7 @@ void mod_table_reset()
 	Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Dont_automatically_select_turret_when_targeting_ship = false;
+	Always_reset_selected_wep_on_loadout_open = false;
 	Weapons_inherit_parent_collision_group = false;
 	Flight_controls_follow_eyepoint_orientation = false;
 	FS2NetD_port = 0;
@@ -1524,7 +1525,6 @@ void mod_table_reset()
 		}};
 	Randomize_particle_rotation = false;
 	Calculate_subsystem_hitpoints_after_parsing = false;
-	Always_reset_selected_wep_on_loadout_open = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -145,6 +145,7 @@ bool Play_thruster_sounds_for_player;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
 bool Calculate_subsystem_hitpoints_after_parsing;
+bool Always_reset_selected_wep_on_loadout_open;
 
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Other.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
@@ -1342,6 +1343,10 @@ void parse_mod_table(const char *filename)
 				mprintf(("Game Settings Table: Subsystem hitpoints will be calculated as they are parsed\n"));
 		}
 
+		if (optional_string("$Always refresh selected weapon when viewing loadout:")) {
+			stuff_boolean(&Always_reset_selected_wep_on_loadout_open);
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -1519,6 +1524,7 @@ void mod_table_reset()
 		}};
 	Randomize_particle_rotation = false;
 	Calculate_subsystem_hitpoints_after_parsing = false;
+	Always_reset_selected_wep_on_loadout_open = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -56,6 +56,7 @@ extern bool Enable_external_default_scripts;
 extern int Default_detail_level;
 extern bool Full_color_head_anis;
 extern bool Dont_automatically_select_turret_when_targeting_ship;
+extern bool Always_reset_selected_wep_on_loadout_open;
 extern bool Weapons_inherit_parent_collision_group;
 extern bool Flight_controls_follow_eyepoint_orientation;
 extern int FS2NetD_port;
@@ -154,7 +155,6 @@ extern bool Play_thruster_sounds_for_player;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
 extern bool Calculate_subsystem_hitpoints_after_parsing;
-extern bool Always_reset_selected_wep_on_loadout_open;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -154,6 +154,7 @@ extern bool Play_thruster_sounds_for_player;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
 extern bool Calculate_subsystem_hitpoints_after_parsing;
+extern bool Always_reset_selected_wep_on_loadout_open;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
This PR adds an option to always ensure the viewed weapon is one that can actually be on the selected ship when first clicking on the weapon loadout.

If you go to the loadout in the briefing and view the weapons on your ship, then go and change your ship class and go back to the weapon loadout screen, you will see that the weapon shown in the window on the right side is from your very first viewing before you changed your ship class. Displaying a weapon not allowed on a ship by default can be confusing to players, especially on mods like FotG where most ships have unique weapons.

The player can still of course click on a non-allowed weapon to view it, but with this PR the player will be initially shown a selected weapon that is allowed on the ship when opening the loadout editor.

Tested and works as expected.