### PR TITLE
Bugfix HUD target direction triangle

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -3029,6 +3029,7 @@ void HudGaugeReticleTriangle::renderTriangle(vec3d *hostile_pos, int aspect_flag
 		}
 	}
 
+	// even if the screen position overflowed, it will still be pointing in the correct direction
 	unsize( &hostile_vertex.screen.xyw.x, &hostile_vertex.screen.xyw.y );
 
 	ang = atan2_safe(-(hostile_vertex.screen.xyw.y - tablePosY), hostile_vertex.screen.xyw.x - tablePosX);
@@ -6521,11 +6522,9 @@ void HudGaugeOffscreen::calculatePosition(vertex* target_point, vec3d *tpos, vec
 	codes_or = (ubyte)(target_point->codes | eye_vertex->codes);
 	clip_line(&target_point,&eye_vertex,codes_or,0);
 
-	if (!(target_point->flags&PF_PROJECTED))
-		g3_project_vertex(target_point);
+	g3_project_vertex(target_point);
 
-	if (!(eye_vertex->flags&PF_PROJECTED))
-		g3_project_vertex(eye_vertex);
+	g3_project_vertex(eye_vertex);
 
 	if (eye_vertex->flags&PF_OVERFLOW) {
 		Int3();			//	This is unlikely to happen, but can if a clip goes through the player's eye.
@@ -7442,8 +7441,8 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 
 					//unsize(&xc, &yc);
 					//unsize(&draw_point.screen.xyw.x, &draw_point.screen.xyw.y);
-
-					renderCircle((int)draw_point.screen.xyw.x + position[0], (int)draw_point.screen.xyw.y + position[1], 10);
+					if (!(draw_point.flags & PF_OVERFLOW))
+						renderCircle((int)draw_point.screen.xyw.x + position[0], (int)draw_point.screen.xyw.y + position[1], 10);
 					//renderCircle(xc, yc, 25);
 				} else {
 					model_render_params weapon_render_info;

--- a/code/render/3dmath.cpp
+++ b/code/render/3dmath.cpp
@@ -225,10 +225,18 @@ int g3_project_vertex(vertex *p)
 
 	if ( p->flags & PF_PROJECTED )
 		return p->flags;
+
+	if (p->world.xyz.z == 0.0f) {
+		p->screen.xyw.x = 0.0;
+		p->screen.xyw.y = 0.0;
+		p->screen.xyw.w = 0.0; 
+		p->flags |= PF_OVERFLOW & PF_PROJECTED;
+		return;
+	}
 	
 	w = 1.0f / p->world.xyz.z;
 
-	if (p->world.xyz.z <= MIN_Z) {
+	if (p->world.xyz.z < MIN_Z) {
 		p->flags |= PF_OVERFLOW;
 	}
 

--- a/code/render/3dmath.cpp
+++ b/code/render/3dmath.cpp
@@ -231,7 +231,7 @@ int g3_project_vertex(vertex *p)
 		p->screen.xyw.y = 0.0;
 		p->screen.xyw.w = 0.0; 
 		p->flags |= PF_OVERFLOW & PF_PROJECTED;
-		return;
+		return p->flags;
 	}
 	
 	w = 1.0f / p->world.xyz.z;

--- a/code/render/3dmath.cpp
+++ b/code/render/3dmath.cpp
@@ -225,20 +225,25 @@ int g3_project_vertex(vertex *p)
 
 	if ( p->flags & PF_PROJECTED )
 		return p->flags;
+	
+	w = 1.0f / p->world.xyz.z;
 
-	if ( p->world.xyz.z <= MIN_Z ) {
+	if (p->world.xyz.z <= MIN_Z) {
 		p->flags |= PF_OVERFLOW;
-	} else {
-		w = 1.0f / p->world.xyz.z;
+	}
 
+	if (w < 0.0f) {
+		p->screen.xyw.x = (Canvas_width + (p->world.xyz.x * Canvas_width * -w)) * 0.5f;
+		p->screen.xyw.y = (Canvas_height - (p->world.xyz.y * Canvas_height * -w)) * 0.5f;
+	} else {
 		p->screen.xyw.x = (Canvas_width + (p->world.xyz.x * Canvas_width * w)) * 0.5f;
 		p->screen.xyw.y = (Canvas_height - (p->world.xyz.y * Canvas_height * w)) * 0.5f;
-		 
-		if ( w > 1.0f ) w = 1.0f;		
-		
-		p->screen.xyw.w = w;
-		p->flags |= PF_PROJECTED;
 	}
+		 
+	CAP(w, -1.0f, 1.0f);
+		
+	p->screen.xyw.w = w;
+	p->flags |= PF_PROJECTED;	
 	
 	return p->flags;
 }

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -841,8 +841,10 @@ void fredhtl_render_subsystem_bounding_box(subsys_to_render *s2r)
 	vm_vec_add2(&center_pt, &objp->pos);
 	g3_rotate_vertex(&text_center, &center_pt);
 	g3_project_vertex(&text_center);
-	gr_set_color_fast(&colour_white);
-	gr_string( (int)text_center.screen.xyw.x,  (int)text_center.screen.xyw.y, buf.c_str() );
+	if (!(text_center.flags & PF_OVERFLOW)) {
+		gr_set_color_fast(&colour_white);
+		gr_string((int)text_center.screen.xyw.x, (int)text_center.screen.xyw.y, buf.c_str());
+	}
 }
 
 void fred_disable_htl() {

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -268,8 +268,10 @@ void fredhtl_render_subsystem_bounding_box(subsys_to_render *s2r)
 	vm_vec_add2(&center_pt, &objp->pos);
 	g3_rotate_vertex(&text_center, &center_pt);
 	g3_project_vertex(&text_center);
-	gr_set_color_fast(&colour_white);
-	gr_string( (int)text_center.screen.xyw.x,  (int)text_center.screen.xyw.y, buf.c_str() );
+	if (!(text_center.flags & PF_OVERFLOW)) {
+		gr_set_color_fast(&colour_white);
+		gr_string((int)text_center.screen.xyw.x, (int)text_center.screen.xyw.y, buf.c_str());
+	}
 }
 
 void render_active_rect(bool box_marking, const Marking_box& marking_box) {


### PR DESCRIPTION
Follow-up to #5656. In that PR, in determining the direction to point for the HUD target triangle, the calculation uses the `screen` position of the projected point, but `g3_project_vertex` early returns and leaves `screen` uninitialized if the point is behind the camera. However, VR requires the screen position and not the old `world` position (the point transformed into the camera space).

This PR still sets the `PF_OVERFLOW` flag, but projects the point regardless (and flips it because everything would be backwards). This way it can still give a meaningful result, while alerting any callers it's behind the camera. All callers properly check for this flag in all relevant behavior, or have been updated to do so to ensure behavior is unchanged.

Tagging @BMagnu to hopefully ensure this still works as expected in VR.