### PR TITLE
Allow SCPUI saving current player data to file

### DIFF
--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -500,6 +500,8 @@ ADE_FUNC(savePlayerData,
 {
 	Pilot.save_player();
 	Pilot.save_savefile();
+
+	return ADE_RETURN_NIL;
 }
 
 //**********SUBLIBRARY: UserInterface/CampaignMenu

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -498,6 +498,8 @@ ADE_FUNC(savePlayerData,
 	nullptr,
 	nullptr)
 {
+	SCP_UNUSED(L);
+
 	Pilot.save_player();
 	Pilot.save_savefile();
 

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -491,6 +491,17 @@ ADE_FUNC(playVoiceClip,
 	return ADE_RETURN_TRUE;
 }
 
+ADE_FUNC(savePlayerData,
+	l_UserInterface_Options,
+	nullptr,
+	"Saves all player data. This includes the player file and campaign file.",
+	nullptr,
+	nullptr)
+{
+	Pilot.save_player();
+	Pilot.save_savefile();
+}
+
 //**********SUBLIBRARY: UserInterface/CampaignMenu
 ADE_LIB_DERIV(l_UserInterface_Campaign,
 	"CampaignMenu",


### PR DESCRIPTION
Mimics optionsmenu.cpp line 1045 that saves both files on options close. This ensures that SCPUI options are properly respected throughout the rest of the game.