### PR TITLE
Fix coverity variable cannot be negative issues

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2533,6 +2533,10 @@ void control_config_do_frame(float frametime)
 		if (List_buttons[i].pressed()) {
 			// Select the pressed line
 			Selected_line = i + Scroll_offset;
+
+			// Cyborg - Quick assertion for Coverity 1093701.  Not likely to happen, but we check for a negative Selected Line later.
+			Assertion(Selected_line > -1, "control_config_do_frame() has somehow managed to get a negative Selected_line index of %d.  Please get an SCP member.", Selected_line);
+
 			Selected_item = selItem::None;
 			List_buttons[i].get_mouse_pos(&x, &y);
 

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1369,7 +1369,7 @@ int multi_oo_pack_data(net_player *pl, object *objp, ushort oo_flags, ubyte *dat
 	}	
 
 	// Cyborg17 - add the subsystem data, now with packer function.
-	if ((MULTIPLAYER_MASTER || objp->flags[Object::Object_Flags::Player_ship]) && shipp->ship_info_index >= 0) {
+	if (MULTIPLAYER_MASTER || objp->flags[Object::Object_Flags::Player_ship]) {
 		SCP_vector<ubyte> flags;
 		SCP_vector<float> subsys_data;
 		ubyte i = 0;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11712,7 +11712,13 @@ int ship_launch_countermeasure(object *objp, int rand_val)
 		return 0;
 	}
 
-	shipp->cmeasure_fire_stamp = timestamp(Weapon_info[shipp->current_cmeasure].cmeasure_firewait);	//	Can launch every cmeasure wait
+	// Cyborg: Coverity 1523546, check that we have a valid countermeasure before setting the delay. (Could help things work more intuitively if CM is changed mid-mission)
+	if (shipp->current_cmeasure > -1){
+		shipp->cmeasure_fire_stamp = timestamp(Weapon_info[shipp->current_cmeasure].cmeasure_firewait);	//	Can launch every cmeasure wait
+	} else {
+		shipp->cmeasure_fire_stamp = timestamp(0);
+	}
+
 #ifndef NDEBUG
 	if (Weapon_energy_cheat) {
 		shipp->cmeasure_count++;

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2310,8 +2310,13 @@ static void ship_do_damage(object *ship_objp, object *other_obj, vec3d *hitpos, 
 	// damage scaling due to big damage, supercap, etc
 	float damage_scale = 1.0f; 
 	// if this is a weapon
-	if (other_obj_is_weapon)
-		damage_scale = weapon_get_damage_scale(&Weapon_info[Weapons[other_obj->instance].weapon_info_index], other_obj, ship_objp);
+	if (other_obj_is_weapon){
+		// Cyborg - Coverity 1523515, this was the only place in ship_do_damage that we weren't checking weapon_info_index
+		Assertion(Weapons[other_obj->instance].weapon_info_index > -1, "Weapon info index in ship_do_damage was found to be a negative value of %d.  Please report this to an SCP coder!", Weapons[other_obj->instance].weapon_info_index);
+		if (Weapons[other_obj->instance].weapon_info_index > -1){
+			damage_scale = weapon_get_damage_scale(&Weapon_info[Weapons[other_obj->instance].weapon_info_index], other_obj, ship_objp);
+		}
+	}
 
 	if (other_obj && other_obj->parent >= 0 && Objects[other_obj->parent].signature == other_obj->parent_sig) {
 		if(Objects[other_obj->parent].flags[Object::Object_Flags::Player_ship])


### PR DESCRIPTION
This handles all new (and one old) variable cannot be negative issues.  Based on the severity, I've either added just an Assert or added a full check.

This includes an actual edge case bug, where a garbage timestamp might get set when no countermeasure is set, keeping the player from firing a countermeasure if a countermeasure is added to their ship.