### PR TITLE
revert workaround for the windows runner breakage

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -144,12 +144,6 @@ jobs:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
-      # workaround for failing download of prebuilt libs in 20231016.1.0 runner
-      # https://github.com/actions/runner-images/issues/8598
-      - name: Remove Strawberry Perl from PATH
-        run: |
-          $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
-          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -186,12 +186,6 @@ jobs:
     name: Windows
     runs-on: windows-2019
     steps:
-      # workaround for failing download of prebuilt libs in 20231016.1.0 runner
-      # https://github.com/actions/runner-images/issues/8598
-      - name: Remove Strawberry Perl from PATH
-        run: |
-          $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
-          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
       - uses: actions/checkout@v1
         # Checkout repo
         name: Checkout

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -157,12 +157,6 @@ jobs:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
-      # workaround for failing download of prebuilt libs in 20231016.1.0 runner
-      # https://github.com/actions/runner-images/issues/8598
-      - name: Remove Strawberry Perl from PATH
-        run: |
-          $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
-          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -123,12 +123,6 @@ jobs:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
-      # workaround for failing download of prebuilt libs in 20231016.1.0 runner
-      # https://github.com/actions/runner-images/issues/8598
-      - name: Remove Strawberry Perl from PATH
-        run: |
-          $env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;", ""
-          "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}


### PR DESCRIPTION
Now that a fix should be in place with the 20231023.1.0 runner image it should be safe to revert the previous workaround.