### PR TITLE
check for out-of-range persona

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3445,8 +3445,13 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 
 	// parse the persona index if present
 	// For backwards compatbility only
-	if (optional_string("+Persona Index:"))
+	if (optional_string("+Persona Index:")) {
 		stuff_int(&p_objp->persona_index);
+		if (p_objp->persona_index < -1 || p_objp->persona_index >= (int)Personas.size()) {
+			Warning(LOCATION, "Persona index %d for %s is out of range!  Setting to -1.", p_objp->persona_index, p_objp->name);
+			p_objp->persona_index = -1;
+		}
+	}
 
 	if (optional_string("+Persona Name:")) {
 		SCP_string persona;


### PR DESCRIPTION
For missions which use the Persona Index method, make sure the mod doesn't load a persona index that is out of range for the personas it knows about.