### PR TITLE
make sure class_type exists when used

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -556,12 +556,17 @@ void ai_goal_purge_invalid_goals( ai_goal *aigp, ai_goal *goal_list, ai_info *ai
 					}
 
 					// grab the ship type of the ship that is being disarmed/disabled
-					ship_type_info *crippled_ships_type = &Ship_types[Ship_info[Ships[ship_index].ship_info_index].class_type];
+					int crippled_ship_type = Ship_info[Ships[ship_index].ship_info_index].class_type;
 
-					// work through all the ship types which to see if the class matching our ai ship must ignore the ship 
+					if (ai_ship_type < 0 || crippled_ship_type < 0)
+						break;
+
+					ship_type_info *crippled_ship_type_info = &Ship_types[crippled_ship_type];
+
+					// work through all the ship types to see if the class matching our ai ship must ignore the ship 
 					// being disarmed/disabled
-					for ( j=0 ; j < (int)crippled_ships_type->ai_cripple_ignores.size(); j++) {
-						if (crippled_ships_type->ai_cripple_ignores[j] == ai_ship_type) {
+					for ( j=0 ; j < (int)crippled_ship_type_info->ai_cripple_ignores.size(); j++) {
+						if (crippled_ship_type_info->ai_cripple_ignores[j] == ai_ship_type) {
 							purge_goal->flags.set(AI::Goal_Flags::Purge);
 						}
 					}
@@ -2428,8 +2433,9 @@ void ai_process_mission_orders( int objnum, ai_info *aip )
 		// don't protect-ship for tactical goals
 		if (current_goal->ai_mode != AI_GOAL_DESTROY_SUBSYSTEM && current_goal->ai_mode != AI_GOAL_DISABLE_SHIP_TACTICAL && current_goal->ai_mode != AI_GOAL_DISARM_SHIP_TACTICAL) {
 			if (aip->target_objnum != -1) {
+				int class_type = Ship_info[Ships[shipnum].ship_info_index].class_type;
 				//	Only protect if _not_ a capital ship.  We don't want the Lucifer accidentally getting protected.
-				if (Ship_types[Ship_info[Ships[shipnum].ship_info_index].class_type].flags[Ship::Type_Info_Flags::AI_protected_on_cripple])
+				if (class_type >= 0 && Ship_types[class_type].flags[Ship::Type_Info_Flags::AI_protected_on_cripple])
 					Objects[aip->target_objnum].flags.set(Object::Object_Flags::Protected);
 			}
 		} else	//	Just in case this ship had been protected, unprotect it.

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1104,7 +1104,7 @@ int find_turret_enemy(ship_subsys *turret_subsys, int objnum, vec3d *tpos, vec3d
 	ai_info	*aip = &Ai_info[Ships[Objects[objnum].instance].ai_index];
 	sip = &Ship_info[Ships[Objects[objnum].instance].ship_info_index];
 
-	if ((Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::Turret_tgt_ship_tgt]) && (aip->target_objnum != -1)) {
+	if ((sip->class_type >= 0) && (Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::Turret_tgt_ship_tgt]) && (aip->target_objnum != -1)) {
 		int target_objnum = aip->target_objnum;
 
 		if (Objects[target_objnum].signature == aip->target_signature) {

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -86,7 +86,10 @@ void fireball_play_warphole_open_sound(int ship_class, fireball *fb)
 		}
 
 		// originally 6.0 for SIF_BIG_SHIP and 1.0 for everything else
-		fb->warp_sound_range_multiplier = Ship_types[Ship_info[ship_class].class_type].warp_sound_range_multiplier;
+		if (Ship_info[ship_class].class_type >= 0)
+			fb->warp_sound_range_multiplier = Ship_types[Ship_info[ship_class].class_type].warp_sound_range_multiplier;
+		else
+			fb->warp_sound_range_multiplier = 1.0f;
 	}
 
 	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius, NULL, 0, 1.0f, SND_PRIORITY_DOUBLE_INSTANCE, NULL, fb->warp_sound_range_multiplier); // play warp sound effect

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2073,7 +2073,7 @@ bool evaluate_ship_as_closest_target(esct *esct_p)
 	}
 
 	// bail if harmless
-	if ( Ship_info[esct_p->shipp->ship_info_index].class_type > -1 && !(Ship_types[Ship_info[esct_p->shipp->ship_info_index].class_type].flags[Ship::Type_Info_Flags::Target_as_threat])) {
+	if ( Ship_info[esct_p->shipp->ship_info_index].class_type < 0 || !(Ship_types[Ship_info[esct_p->shipp->ship_info_index].class_type].flags[Ship::Type_Info_Flags::Target_as_threat])) {
 		return false;
 	}
 
@@ -3583,8 +3583,8 @@ void hud_show_hostile_triangle()
 			continue;
 		}
 
-		// always ignore cargo containers and navbuoys
-		if ( Ship_info[sp->ship_info_index].class_type > -1 && !(Ship_types[Ship_info[sp->ship_info_index].class_type].flags[Ship::Type_Info_Flags::Show_attack_direction]) ) {
+		// always ignore cargo containers, navbouys, etc, and non-ships
+		if ( Ship_info[sp->ship_info_index].class_type < 0 || !(Ship_types[Ship_info[sp->ship_info_index].class_type].flags[Ship::Type_Info_Flags::Show_attack_direction]) ) {
 			continue;
 		}
 

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -2116,7 +2116,7 @@ bool filters_match(MessageFilter& filter, ship* it) {
 		    && filter_matches(hud_get_ship_class(it), filter.class_name)
 		    && filter_matches(wing_name, filter.wing_name)
 		    && filter_matches(Ship_info[it->ship_info_index].species, filter.species_bitfield)
-		    && filter_matches(Ship_info[it->ship_info_index].class_type, filter.type_bitfield)
+		    && (Ship_info[it->ship_info_index].class_type < 0 || filter_matches(Ship_info[it->ship_info_index].class_type, filter.type_bitfield))
 		    && filter_matches(it->team, filter.team_bitfield);
 	}
 }

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1382,7 +1382,7 @@ int brief_setup_closeup(brief_icon *bi, bool api_access)
 		if (Closeup_icon->closeup_label[0] == '\0') {
 			strcpy_s(Closeup_icon->closeup_label, sip->get_display_name());
 
-			if (!Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::No_class_display]
+			if ((sip->class_type < 0 || !Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::No_class_display])
 				&& (sip->is_small_ship() || sip->is_big_ship() || sip->is_huge_ship() || sip->flags[Ship::Info_Flags::Sentrygun])) {
 					strcat_s(Closeup_icon->closeup_label, XSTR(" class", 434));
 			}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17017,7 +17017,7 @@ void ship_maybe_praise_player(ship *deader_sp)
 	}
 
 	// don't praise the destruction of navbuoys, cargo or other non-flyable ship types
-    if ((Ship_info[deader_sp->ship_info_index].class_type > 0) && !(Ship_types[Ship_info[deader_sp->ship_info_index].class_type].flags[Ship::Type_Info_Flags::Praise_destruction])) {
+    if ((Ship_info[deader_sp->ship_info_index].class_type >= 0) && !(Ship_types[Ship_info[deader_sp->ship_info_index].class_type].flags[Ship::Type_Info_Flags::Praise_destruction])) {
 		return;
 	}
 
@@ -17069,7 +17069,7 @@ void ship_maybe_praise_self(ship *deader_sp, ship *killer_sp)
 	}
 
 	// don't praise the destruction of navbuoys, cargo or other non-flyable ship types
-	if ( (Ship_info[deader_sp->ship_info_index].class_type > 0) && !(Ship_types[Ship_info[deader_sp->ship_info_index].class_type].flags[Ship::Type_Info_Flags::Praise_destruction]) ) {
+	if ( (Ship_info[deader_sp->ship_info_index].class_type >= 0) && !(Ship_types[Ship_info[deader_sp->ship_info_index].class_type].flags[Ship::Type_Info_Flags::Praise_destruction]) ) {
 		return;
 	}
 
@@ -17588,7 +17588,9 @@ ship_type_info *ship_get_type_info(object *objp)
 	Assert(objp->type == OBJ_SHIP);
 	Assert(objp->instance > -1);
 	Assert(Ships[objp->instance].ship_info_index > -1);
-	Assert(Ship_info[Ships[objp->instance].ship_info_index].class_type > -1);
+
+	if (Ship_info[Ships[objp->instance].ship_info_index].class_type < 0)
+		return nullptr;
 
 	return &Ship_types[Ship_info[Ships[objp->instance].ship_info_index].class_type];
 }

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1693,15 +1693,19 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 
 	sp->death_time = sp->final_death_time = timestamp(delta_time);	// Give him 3 secs to explode
 
-	//SUSHI: What are the chances of an instant vaporization? Check the ship type first (objecttypes.tbl), then the ship (ships.tbl)
-	ship_type_info *stp = &Ship_types[sip->class_type];
-	float vapChance = stp->vaporize_chance;
-	if (sip->vaporize_chance > 0.0f)
+	//SUSHI: What are the chances of an instant vaporization? Check the ship type (objecttypes.tbl) as well as the ship (ships.tbl)
+	float vapChance;
+	if (sp->flags[Ship::Ship_Flags::Vaporize])
+		vapChance = 1.0f;
+	else if (sip->vaporize_chance > 0.0f)
 		vapChance = sip->vaporize_chance;
+	else if (sip->class_type >= 0)
+		vapChance = Ship_types[sip->class_type].vaporize_chance;
+	else
+		vapChance = 0.0f;
 
-	if (sp->flags[Ship::Ship_Flags::Vaporize] || frand() < vapChance) {
-		// Assert(Ship_info[sp->ship_info_index].flags & SIF_SMALL_SHIP);
-
+	if (frand() < vapChance)
+	{
 		// LIVE FOR 100 MS
 		sp->final_death_time = timestamp(100);
 	}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3728,7 +3728,7 @@ void beam_handle_collisions(beam *b)
 			if (Objects[target].type == OBJ_SHIP) {
 				ship_type_info *sti;
 				sti = ship_get_type_info(&Objects[target]);
-				if (sti->flags[Ship::Type_Info_Flags::No_huge_impact_eff])
+				if (!sti || sti->flags[Ship::Type_Info_Flags::No_huge_impact_eff])
 					draw_effects = 0;
 			}
 		}

--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -975,7 +975,7 @@ void briefing_editor_dlg::update_positions()
 void briefing_editor_dlg::OnMakeIcon() 
 {
 	const char *name;
-	int z, team, ship, waypoint, count = -1;
+	int team, ship, waypoint, count = -1;
 	int cargo = 0, cargo_count = 0, freighter_count = 0;
 	object *ptr;
 	vec3d min, max, pos;
@@ -1028,7 +1028,6 @@ void briefing_editor_dlg::OnMakeIcon()
 			if (ship >= 0) {
 				team = Ships[ship].team;
 
-				z = ship_query_general_type(ship);
 				if (Ship_info[Ships[ship].ship_info_index].flags[Ship::Info_Flags::Cargo])
 					cargo_count++;
 


### PR DESCRIPTION
A mission in Mantle caused an invalid vector access when checking whether to vaporize a ship whose ship type was -1.  Turns out having "no type" is actually allowed, so I audited all `class_type` accesses throughout the code for potential -1 accesses.  Most were properly checked but a few were not.  A few others needed to be tweaked.

(I suspect this is something that would be on the Coverity list if it isn't already.)