### PR TITLE
Fix for ets changes when engines are <15%

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -538,7 +538,8 @@ bool ai_new_maybe_reposition_attack_subsys() {
 	model_local_to_global_point(&geye, &ep->pnt, pm, 0, &Pl_objp->orient, &Pl_objp->pos);
 
 	// get world pos of subsystem
-	get_subsystem_pos(&gsubpos, target_objp, aip->targeted_subsys);
+	polymodel* tgt_pm = model_get(Ship_info[Ships[target_objp->instance].ship_info_index].model_num);
+	model_local_to_global_point(&gsubpos, &vmd_zero_vector, tgt_pm, aip->targeted_subsys->system_info->subobj_num, &En_objp->orient, &En_objp->pos);
 
 	// you're in sight! shoot it!
 	if (ship_subsystem_in_sight(En_objp, aip->targeted_subsys, &geye, &gsubpos, 0))

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -538,8 +538,7 @@ bool ai_new_maybe_reposition_attack_subsys() {
 	model_local_to_global_point(&geye, &ep->pnt, pm, 0, &Pl_objp->orient, &Pl_objp->pos);
 
 	// get world pos of subsystem
-	polymodel* tgt_pm = model_get(Ship_info[Ships[target_objp->instance].ship_info_index].model_num);
-	model_local_to_global_point(&gsubpos, &vmd_zero_vector, tgt_pm, aip->targeted_subsys->system_info->subobj_num, &En_objp->orient, &En_objp->pos);
+	get_subsystem_pos(&gsubpos, target_objp, aip->targeted_subsys);
 
 	// you're in sight! shoot it!
 	if (ship_subsystem_in_sight(En_objp, aip->targeted_subsys, &geye, &gsubpos, 0))

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -125,30 +125,32 @@ void update_ets(object* objp, float fl_frametime)
 	//					 This will translate to 71% max speed at 50% engines, and 31% max speed at 10% engines
 	//
 
-	float engine_aggregate_strength;
+	float effective_engine_strength;
+	float actual_engine_strength;
 	if (ship_p->flags[Ship::Ship_Flags::Maneuver_despite_engines]) {
 		// Pretend our strength is 100% when this flag is active
-		engine_aggregate_strength = 1.0f;
+		effective_engine_strength = 1.0f;
+		actual_engine_strength = 1.0f;
 	} else {
-		engine_aggregate_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE);
-	}
+		effective_engine_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE);
 
-	// very annoying, but ship_get_subsystem_strength will typically cap at no lower than 15% strength reported
-	// causing the condition below to possibly erroneously believe the engine strength isn't changing while being
-	// repaired below that threshold. use the ACTUAL strength for this check
-	float actual_engine_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE, false, true);
+		// very annoying, but ship_get_subsystem_strength will typically cap at no lower than 15% strength reported
+		// causing the condition below to possibly erroneously believe the engine strength isn't changing while being
+		// repaired below that threshold. use the ACTUAL strength for this check
+		actual_engine_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE, false, true);
+	}
 
 	// only update max speed if engine_aggregate_strength has changed
 	// which helps minimize amount of overrides to max speed
-	if (actual_engine_strength != ship_p->prev_engine_aggregate_strength) {
+	if (actual_engine_strength != ship_p->prev_engine_strength) {
 		ets_update_max_speed(objp);
-		ship_p->prev_engine_aggregate_strength = actual_engine_strength;
+		ship_p->prev_engine_strength = actual_engine_strength;
 
 		// check if newly updated max speed should be reduced due to engine damage
 		// don't let engine strength affect max speed when playing on lowest skill level
 		if ((objp != Player_obj) || (Game_skill_level > 0)) {
-			if (engine_aggregate_strength < SHIP_MIN_ENGINES_FOR_FULL_SPEED) {
-				objp->phys_info.max_vel.xyz.z *= fl_sqrt(engine_aggregate_strength);
+			if (effective_engine_strength < SHIP_MIN_ENGINES_FOR_FULL_SPEED) {
+				objp->phys_info.max_vel.xyz.z *= fl_sqrt(effective_engine_strength);
 			}
 		}
 	}

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -133,11 +133,16 @@ void update_ets(object* objp, float fl_frametime)
 		engine_aggregate_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE);
 	}
 
+	// very annoying, but ship_get_subsystem_strength will typically cap at no lower than 15% strength reported
+	// causing the condition below to possibly erroneously believe the engine strength isn't changing while being
+	// repaired below that threshold. use the ACTUAL strength for this check
+	float actual_engine_strength = ship_get_subsystem_strength(ship_p, SUBSYSTEM_ENGINE, false, true);
+
 	// only update max speed if engine_aggregate_strength has changed
 	// which helps minimize amount of overrides to max speed
-	if (engine_aggregate_strength != ship_p->prev_engine_aggregate_strength) {
+	if (actual_engine_strength != ship_p->prev_engine_aggregate_strength) {
 		ets_update_max_speed(objp);
-		ship_p->prev_engine_aggregate_strength = engine_aggregate_strength;
+		ship_p->prev_engine_aggregate_strength = actual_engine_strength;
 
 		// check if newly updated max speed should be reduced due to engine damage
 		// don't let engine strength affect max speed when playing on lowest skill level

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14808,7 +14808,7 @@ int ship_find_subsys(ship *sp, const char *ss_name)
 // 0.0 and 1.0 which is the relative combined strength of the given subsystem type.  The number
 // calculated for the engines is slightly different.  Once an engine reaches < 15% of its hits, its
 // output drops to that %.  A dead engine has no output.
-float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check )
+float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check, bool no_minimum_engine_str )
 {
 	float strength;
 	ship_subsys *ssp;
@@ -14841,7 +14841,7 @@ float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check 
 				float ratio;
 
 				ratio = ssp->current_hits / ssp->max_hits;
-				if ( ratio < ENGINE_MIN_STR )
+				if ( ratio < ENGINE_MIN_STR && !no_minimum_engine_str)
 					ratio = ENGINE_MIN_STR;
 
 				percent += ratio;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6628,7 +6628,7 @@ void ship::clear()
 	weapon_recharge_index = INTIAL_WEAPON_RECHARGE_INDEX;
 	engine_recharge_index = INTIAL_ENGINE_RECHARGE_INDEX;
 	weapon_energy = 0;
-	prev_engine_aggregate_strength = 1.0f;
+	prev_engine_strength = 1.0f;
 	next_manage_ets = timestamp(0);
 
 	flags.reset();

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -645,7 +645,7 @@ public:
 	int	engine_recharge_index;			// index into array holding the engine recharge rate
 	float	weapon_energy;						// Number of EUs in energy reserves
 	int	next_manage_ets;					// timestamp for when ai can next modify ets ( -1 means never )
-	float prev_engine_aggregate_strength;	// used only in update_ets() to allow for minimizing overrides to max speed --Asteroth and wookieejedi
+	float prev_engine_strength;	// used only in update_ets() to allow for minimizing overrides to max speed --Asteroth and wookieejedi
 
 	flagset<Ship::Ship_Flags>	flags;		// flag variable to contain ship state
 	int	reinforcement_index;				// index into reinforcement struct or -1

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1778,7 +1778,7 @@ extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns ind
 extern int ship_find_subsys(ship *sp, const char *ss_name);		// returns numerical index in linked list of subsystems
 extern int ship_get_subsys_index(ship_subsys *subsys);
 
-extern float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check = false );
+extern float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check = false, bool no_minimum_engine_str = false);
 extern ship_subsys *ship_get_subsys(const ship *shipp, const char *subsys_name);
 extern int ship_get_num_subsys(ship *shipp);
 extern ship_subsys *ship_get_closest_subsys_in_sight(ship *sp, int subsys_type, vec3d *attacker_pos);


### PR DESCRIPTION
The ship's maximum velocity is updated when the ship's engine strength changes, but `ship_get_subsystem_strength` always reports 15% when below 15%, causing the code to erroneously believe the engine strength isn't changing (when it is probably auto-repairing). Repairing under this threshold wouldn't cause the max velocity to change, but it is supposed to prevent ETS changes from ignoring the whole engine damage bit, so use the actual engine strength to determine when to apply 'damaged' engine velocities.