### PR TITLE
Fix auto copies

### DIFF
--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -101,7 +101,7 @@ SCP_vector<SCP_string> ai_lua_get_general_orders(bool onlyEnabled, bool onlyVali
 {
 	SCP_vector<SCP_string> list;
 
-	for (auto order : Lua_player_orders) {
+	for (const auto& order : Lua_player_orders) {
 		if (order.second.generalOrder) {
 			bool add = false;
 
@@ -161,7 +161,7 @@ void ai_lua_validate_general_order(int sexp_op, bool validity)
 }
 
 void ai_lua_reset_general_orders() {
-	for (auto order : Lua_player_orders) {
+	for (const auto& order : Lua_player_orders) {
 		ai_lua_enable_general_order(order.first, false);
 		ai_lua_validate_general_order(order.first, false);
 	}

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -616,7 +616,7 @@ void hud_config_init_ui(bool API_Access, int x, int y, int w)
 		// can't find a better one. Need to get the furthest right and bottom
 		// pixels to be rendered to calculate the percent change. That is then
 		// used to rescale each gauge correctly for the rendering size and position. - Mjn
-		for (auto gauge : HC_gauge_regions[gr_screen.res]) {
+		for (const auto& gauge : HC_gauge_regions[gr_screen.res]) {
 			if (!stricmp(gauge.filename, NOX("none"))) {
 				continue;
 			}

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -242,7 +242,7 @@ void FillSDLArray ()
 }
 
 SDL_Scancode fs2_to_sdl(int scancode) {
-	for (auto code : SDLtoFS2) {
+	for (const auto& code : SDLtoFS2) {
 		if (code.second == scancode)
 			return code.first;
 	}

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -847,10 +847,10 @@ void LabUi::reset_animations(ship* shipp, ship_info* sip) const
 		}
 	}
 
-	for (auto entry : manual_animations) {
-		if (manual_animations[entry.first]) {
+	for (auto& entry : manual_animations) {
+		if (entry.second) {
 			sip->animations.getAll(shipp_pmi, entry.first).start(animation::ModelAnimationDirection::RWD);
-			manual_animations[entry.first] = false;
+			entry.second = false;
 		}
 	}
 

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -324,8 +324,8 @@ void LabManager::changeShipInternal() {
 
 	// If the ship class defines replacement textures, load them and apply them to the ship
 	// load the texture
-	auto replacements = SCP_vector<texture_replace>();
-	for (auto tr : ship_infop->replacement_textures) {
+	auto replacements = ship_infop->replacement_textures;
+	for (auto& tr : replacements) {
 		if (!stricmp(tr.new_texture, "invisible"))
 		{
 			// invisible is a special case
@@ -336,7 +336,6 @@ void LabManager::changeShipInternal() {
 			// try to load texture or anim as normal
 			tr.new_texture_id = bm_load_either(tr.new_texture);
 		}
-		replacements.push_back(tr);
 	}
 
 	ship_objp->apply_replacement_textures(replacements);

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -376,7 +376,7 @@ void light_apply_rgb( ubyte *param_r, ubyte *param_g, ubyte *param_b, const vec3
 	vec3d to_light;
 	float dot, dist;
 	vec3d temp;
-	for (auto l : Lights) {
+	for (const auto& l : Lights) {
 
 		dist = -1.0f;
 		switch(l.type){

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -907,7 +907,7 @@ namespace animation {
 			return false;
 
 		polymodel_instance* pmi = model_get_instance(pmi_id);
-		for(auto anim : animations)
+		for(const auto& anim : animations)
 			anim->start(pmi, direction, forced, instant, pause);
 
 		return !animations.empty();

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -239,7 +239,7 @@ void model_render_params::set_replacement_textures(int modelnum, const SCP_vecto
 
 	polymodel* pm = model_get(modelnum);
 
-	for (auto tr : replacement_textures) 
+	for (const auto& tr : replacement_textures) 
 	{
 		for (int i = 0; i < pm->n_textures; ++i) 
 		{

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -834,7 +834,7 @@ bool multi_oo_simulate_rollback_shots(int frame_idx)
 // restores ships to the positions they were in bedfore rollback.
 void multi_record_restore_positions() 
 {
-	for (auto restore_point : Oo_info.restore_points) {
+	for (const auto& restore_point : Oo_info.restore_points) {
 
 		object* objp = &Objects[restore_point.roll_objnum];
 		// reset the position, orientation, and velocity for each object

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6834,11 +6834,11 @@ void ship::apply_replacement_textures(SCP_vector<texture_replace> &replacements)
 			ship_replacement_textures[i] = -1;
 	}
 
-	// now fill them in
-	for (auto tr : replacements)
-	{
-		auto pm = model_get(Ship_info[ship_info_index].model_num);
+	auto pm = model_get(Ship_info[ship_info_index].model_num);
 
+	// now fill them in
+	for (const auto& tr : replacements)
+	{
 		// look for textures
 		for (auto j = 0; j < pm->n_textures; j++)
 		{


### PR DESCRIPTION
Some of the loops we have been adding to the code base are inefficiently using copies instead of references or const references.

Fixes about 10 coverity issues, so even though it's minor, it's a nice quick way to get those numbers down.