### PR TITLE
Fix subsys positions in `ai_new_maybe_reposition_attack_subsys`... again

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -538,8 +538,7 @@ bool ai_new_maybe_reposition_attack_subsys() {
 	model_local_to_global_point(&geye, &ep->pnt, pm, 0, &Pl_objp->orient, &Pl_objp->pos);
 
 	// get world pos of subsystem
-	polymodel* tgt_pm = model_get(Ship_info[Ships[target_objp->instance].ship_info_index].model_num);
-	model_local_to_global_point(&gsubpos, &vmd_zero_vector, tgt_pm, aip->targeted_subsys->system_info->subobj_num, &En_objp->orient, &En_objp->pos);
+	get_subsystem_pos(&gsubpos, target_objp, aip->targeted_subsys);
 
 	// you're in sight! shoot it!
 	if (ship_subsystem_in_sight(En_objp, aip->targeted_subsys, &geye, &gsubpos, 0))


### PR DESCRIPTION
Follow-up for #5634. Changing this to `model_local_to_global_point` fixes the case where the subsystem is a submodel... but breaks when the subsystem is a special point. Use the function that already exists to determine between these cases instead.