### PR TITLE
some polishing of recent changes

### DIFF
--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -248,7 +248,7 @@ void ai_lua_start_general(int lua_sexp_id, int target_objnum)
 	ai_info aip;
 	aip.shipnum = -1;
 
-	if (target_objnum >= 0) {
+	if (target_objnum >= 0 && Objects[target_objnum].type == OBJ_SHIP) {
 		aip.lua_ai_target = {object_ship_wing_point_team(&Ships[Objects[target_objnum].instance]), {}};
 	}
 	

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -8782,3 +8782,36 @@ void clear_texture_replacements()
 {
 	Fred_texture_replacements.clear();
 }
+
+bool check_for_23_3_data()
+{
+	auto e_list = ai_lua_get_general_orders(true);
+	if (!e_list.empty())
+		return true;
+	auto v_list = ai_lua_get_general_orders(false, true);
+	if (!v_list.empty())
+		return true;
+
+	for (const auto& msg : Messages)
+	{
+		if (!msg.note.empty())
+			return true;
+	}
+
+	for (const auto& so : list_range(&Ship_obj_list))
+	{
+		auto shipp = &Ships[Objects[so->objnum].instance];
+
+		auto shipp_params = &Warp_params[shipp->warpin_params_index];
+		auto sip_params = &Warp_params[Ship_info[shipp->ship_info_index].warpin_params_index];
+		if (shipp_params->supercap_warp_physics != sip_params->supercap_warp_physics)
+			return true;
+
+		shipp_params = &Warp_params[shipp->warpout_params_index];
+		sip_params = &Warp_params[Ship_info[shipp->ship_info_index].warpout_params_index];
+		if (shipp_params->supercap_warp_physics != sip_params->supercap_warp_physics)
+			return true;
+	}
+
+	return false;
+}

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -51,6 +51,10 @@ int get_special_anchor(const char *name);
 extern const gameversion::version MISSION_VERSION;
 extern const gameversion::version LEGACY_MISSION_VERSION;
 
+// This checks to see if a mission has data that requires saving in a newer format.  This would warrant
+// a "soft version bump" rather than a hard bump because not all missions are affected.
+extern bool check_for_23_3_data();
+
 #define WING_PLAYER_BASE	0x80000  // used by Fred to tell ship_index in a wing points to a player
 
 // mission parse flags used for parse_mission() to tell what kind of information to get from the mission file
@@ -400,7 +404,7 @@ extern SCP_vector<p_object> Parse_objects;
 extern p_object Support_ship_pobj, *Arriving_support_ship;
 extern p_object Ship_arrival_list;
 
-typedef struct {
+typedef struct team_data {
 	// ships
 	int		default_ship;  // default ship type for player start point (recommended choice)
 	int		num_ship_choices; // number of ship choices inside ship_list 

--- a/code/missionui/missionweaponchoice.h
+++ b/code/missionui/missionweaponchoice.h
@@ -12,11 +12,10 @@
 #ifndef __MISSION_WEAPON_CHOICE_H__
 #define __MISSION_WEAPON_CHOICE_H__
 
-#include "mission/missionparse.h"
-
 class p_object;
 struct wss_unit;
 class ship_weapon;
+struct team_data;
 
 // mask regions for icons in the scrollable lists
 #define ICON_PRIMARY_0				28

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3126,6 +3126,17 @@ void CFred_mission_save::save_mission_internal(const char *pathname)
 	// Migrate the version!
 	The_mission.required_fso_version = MISSION_VERSION;
 
+	// Additional incremental version update for some features
+	auto newer_version = gameversion::version(23, 3);
+	if (MISSION_VERSION >= newer_version)
+	{
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 23.3, the incremental version code can be removed");
+	}
+	else if (check_for_23_3_data())
+	{
+		The_mission.required_fso_version = newer_version;
+	}
+
 	reset_parse();
 	raw_ptr = Parse_text_raw;
 	fred_parse_flag = 0;

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3035,6 +3035,17 @@ void CFred_mission_save::save_mission_internal(const char* pathname)
 	// Migrate the version!
 	The_mission.required_fso_version = MISSION_VERSION;
 
+	// Additional incremental version update for some features
+	auto newer_version = gameversion::version(23, 3);
+	if (MISSION_VERSION >= newer_version)
+	{
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 23.3, the incremental version code can be removed");
+	}
+	else if (check_for_23_3_data())
+	{
+		The_mission.required_fso_version = newer_version;
+	}
+
 	reset_parse();
 	raw_ptr = Parse_text_raw;
 	fred_parse_flag = 0;


### PR DESCRIPTION
1. The player can target other object types besides ships, so when creating an `object_ship_wing_point_team`, make sure it is a ship
2. A few recent mission features require a version bump, but not all missions use these features; so do a "soft bump" where the mission version is updated only if necessary
3. Remove an unneeded #include by adding a `struct team_data` declaration (see #5599)