### PR TITLE
Handle oct30 covscan issues

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -681,6 +681,8 @@ CFILE* _cfopen(const char* source, int line, const char* file_path, const char* 
 		} else {
 			// Path type given?
 			Assert( dir_type != CF_TYPE_ANY );
+			if (dir_type == CF_TYPE_ANY)
+				return NULL;
 
 			// Create the directory if necessary
 			cf_create_directory(dir_type, location_flags);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1840,11 +1840,13 @@ void model_render_glowpoint_add_light(int point_num, const vec3d *pos, const mat
 		vm_vec_sub(&loc_offset, &gpt->pnt, &submodel_static_offset);
 
 		tempv = loc_offset;
-		if (IS_VEC_NULL(&loc_norm)) {	// zero vectors are allowed for glowpoint norms
-			model_instance_local_to_global_point(&loc_offset, &tempv, pm, pmi, bank->submodel_parent);
-		} else {
-			vec3d tempn = loc_norm;
-			model_instance_local_to_global_point_dir(&loc_offset, &loc_norm, &tempv, &tempn, pm, pmi, bank->submodel_parent);
+		if (pmi){
+			if (IS_VEC_NULL(&loc_norm)) {	// zero vectors are allowed for glowpoint norms
+				model_instance_local_to_global_point(&loc_offset, &tempv, pm, pmi, bank->submodel_parent);
+			} else {
+				vec3d tempn = loc_norm;
+				model_instance_local_to_global_point_dir(&loc_offset, &loc_norm, &tempv, &tempn, pm, pmi, bank->submodel_parent);
+			}
 		}
 	}
 
@@ -1868,7 +1870,7 @@ void model_render_glowpoint_add_light(int point_num, const vec3d *pos, const mat
 			return;
 	}
 
-	if( (gpo->type_override?gpo->type:bank->type)==0)
+	if( (pmi && gpo->type_override?gpo->type:bank->type)==0)
 	{
 		float pulse = model_render_get_point_activation(bank, gpo);
 		if (pulse == 0.0f)

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1840,13 +1840,14 @@ void model_render_glowpoint_add_light(int point_num, const vec3d *pos, const mat
 		vm_vec_sub(&loc_offset, &gpt->pnt, &submodel_static_offset);
 
 		tempv = loc_offset;
-		if (pmi){
-			if (IS_VEC_NULL(&loc_norm)) {	// zero vectors are allowed for glowpoint norms
-				model_instance_local_to_global_point(&loc_offset, &tempv, pm, pmi, bank->submodel_parent);
-			} else {
-				vec3d tempn = loc_norm;
-				model_instance_local_to_global_point_dir(&loc_offset, &loc_norm, &tempv, &tempn, pm, pmi, bank->submodel_parent);
-			}
+
+		if (!pmi){
+			model_local_to_global_point(&loc_offset, &tempv, pm, bank->submodel_parent);
+		} else if (IS_VEC_NULL(&loc_norm)) {	// zero vectors are allowed for glowpoint norms
+			model_instance_local_to_global_point(&loc_offset, &tempv, pm, pmi, bank->submodel_parent);
+		} else {
+			vec3d tempn = loc_norm;
+			model_instance_local_to_global_point_dir(&loc_offset, &loc_norm, &tempv, &tempn, pm, pmi, bank->submodel_parent);
 		}
 	}
 
@@ -1870,7 +1871,7 @@ void model_render_glowpoint_add_light(int point_num, const vec3d *pos, const mat
 			return;
 	}
 
-	if( (pmi && gpo->type_override?gpo->type:bank->type)==0)
+	if( (gpo->type_override?gpo->type:bank->type)==0)
 	{
 		float pulse = model_render_get_point_activation(bank, gpo);
 		if (pulse == 0.0f)
@@ -1893,7 +1894,11 @@ void model_render_glowpoint_add_light(int point_num, const vec3d *pos, const mat
 				cone_dir_rot = gpo->cone_direction;
 			}
 
-			model_instance_local_to_global_dir(&cone_dir_model, &cone_dir_rot, pm, pmi, bank->submodel_parent);
+			if (pmi)
+				model_instance_local_to_global_dir(&cone_dir_model, &cone_dir_rot, pm, pmi, bank->submodel_parent);
+			else 
+				cone_dir_model = cone_dir_rot;
+				
 			vm_vec_unrotate(&cone_dir_world, &cone_dir_model, orient);
 			vm_vec_rotate(&cone_dir_screen, &cone_dir_world, &Eye_matrix);
 			cone_dir_screen.xyz.z = -cone_dir_screen.xyz.z;

--- a/code/starfield/nebula.cpp
+++ b/code/starfield/nebula.cpp
@@ -104,6 +104,10 @@ int load_nebula_sub(const char *filename)
 	cfread( &num_tris, sizeof(int), 1, fp );
 	Assert( num_tris < MAX_TRIS );
 
+	// Cyborg - can't load nonsense.
+	if (num_pts <= 0 || num_pts >= MAX_POINTS || num_tris <= 0 || num_tris >= MAX_TRIS)
+		return 0;
+
 	int i;
 	for (i=0; i<num_pts; i++ )	{
 		float xf, yf;


### PR DESCRIPTION
This handles the remaining coverity issues that popped up on the October 30th scan.

This going to need an eye from a graphics coder if possible.  The code is not safely relying on pmi being not null, but I'm not sure if I fixed that correctly.