### PR TITLE
make sure events are current before they become special

### DIFF
--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -782,6 +782,7 @@ int mission_get_event_status(int event)
 {
 	// check for directive special events first.  We will always return from this part of the if statement
 	if ( Mission_events[event].flags & MEF_DIRECTIVE_SPECIAL ) {
+		Assertion(Mission_events[event].flags & MEF_CURRENT, "An event should have MEF_CURRENT set if it also has MEF_DIRECTIVE_SPECIAL set");
 
 		// if this event is temporarily true, return as such
 		if ( Mission_events[event].flags & MEF_DIRECTIVE_TEMP_TRUE ){
@@ -820,6 +821,8 @@ void mission_event_set_directive_special(int event)
 	if((event < 0) || (event >= (int)Mission_events.size())){
 		return;
 	}
+
+	Assertion(Mission_events[event].flags & MEF_CURRENT, "An event should have MEF_CURRENT set before it has MEF_DIRECTIVE_SPECIAL set");
 
 	Mission_events[event].flags |= MEF_DIRECTIVE_SPECIAL;
 
@@ -950,9 +953,12 @@ void mission_process_event( int event )
 
 		// if the directive count is a special value, deal with that first.  Mark the event as a special
 		// event, and unmark it when the directive is true again.
-		if ( (Directive_count == DIRECTIVE_WING_ZERO) && !(Mission_events[event].flags & MEF_DIRECTIVE_SPECIAL) ) {			
-			// make it special - which basically just means that its true until the next wave arrives
-			mission_event_set_directive_special(event);
+		if ( (Directive_count == DIRECTIVE_WING_ZERO) && !(Mission_events[event].flags & MEF_DIRECTIVE_SPECIAL) ) {
+			// only mark it special if it's actually current
+			if (Mission_events[event].flags & MEF_CURRENT) {
+				// make it special - which basically just means that its true until the next wave arrives
+				mission_event_set_directive_special(event);
+			}
 
 			Directive_count = 0;
 		} else if ( (Mission_events[event].flags & MEF_DIRECTIVE_SPECIAL) && Directive_count > 1 ) {			


### PR DESCRIPTION
There is an implicit assumption in the code that the `MEF_DIRECTIVE_SPECIAL` flag could not be set on an event until after the `MEF_CURRENT` flag was also set.  This change makes that assumption explicit, and also adds a check in `mission_process_event` to be sure the flag setting doesn't happen out of order.  This situation is very rare, but can happen if the following conditions are true:

1. there is an event directive checking for the destruction of a wing
2. the wing has multiple waves
3. the directive uses the older `is-event-true-delay` technique to control when it is displayed
4. the directive becomes temporarily true before it can be displayed and while there are still waves remaining

This previously caused the "directive special" logic to occur before the "event current" logic occurred, skipping the proper setting of `born_on_date`.

Fixes Github #5725 and Mantis 930.