### PR TITLE
Event currency tweaks

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -948,9 +948,9 @@ void mission_campaign_store_goals_and_events()
 		// event evaluation
 		if ( event.formula == -1 ) {
 			if ( event.result )
-				stored_event.status = EVENT_SATISFIED;
+				stored_event.status = (int)EventStatus::SATISFIED;
 			else
-				stored_event.status = EVENT_FAILED;
+				stored_event.status = (int)EventStatus::FAILED;
 		} else
 			UNREACHABLE("Mission event formula should be -1 at end-of-mission");
 	}

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -948,9 +948,9 @@ void mission_campaign_store_goals_and_events()
 		// event evaluation
 		if ( event.formula == -1 ) {
 			if ( event.result )
-				stored_event.status = (int)EventStatus::SATISFIED;
+				stored_event.status = static_cast<int>(EventStatus::SATISFIED);
 			else
-				stored_event.status = (int)EventStatus::FAILED;
+				stored_event.status = static_cast<int>(EventStatus::FAILED);
 		} else
 			UNREACHABLE("Mission event formula should be -1 at end-of-mission");
 	}

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -774,18 +774,18 @@ void mission_goal_status_change( int goal_num, int new_status)
 }
 
 // return value:
-//   EVENT_UNBORN    = event has yet to be available (not yet evaluatable)
-//   EVENT_CURRENT   = current (evaluatable), but not yet true
-//   EVENT_SATISFIED = event has occured (true)
-//   EVENT_FAILED    = event failed, can't possibly become true anymore
-int mission_get_event_status(int event)
+//   UNBORN    = event has yet to be available (not yet evaluatable)
+//   CURRENT   = current (evaluatable), but not yet true
+//   SATISFIED = event has occured (true)
+//   FAILED    = event failed, can't possibly become true anymore
+EventStatus mission_get_event_status(int event)
 {
 	// check for directive special events first.  We will always return from this part of the if statement
 	if ( Mission_events[event].flags & MEF_DIRECTIVE_SPECIAL ) {
 
 		// if this event is temporarily true, return as such
 		if ( Mission_events[event].flags & MEF_DIRECTIVE_TEMP_TRUE ){
-			return EVENT_SATISFIED;
+			return EventStatus::SATISFIED;
 		}
 
 		// if the timestamp has elapsed, we can "mark" this directive as true although it's really not.
@@ -794,24 +794,24 @@ int mission_get_event_status(int event)
 			Mission_events[event].flags |= MEF_DIRECTIVE_TEMP_TRUE;
 		}
 
-		return EVENT_CURRENT;
+		return EventStatus::CURRENT;
 	} else if (Mission_events[event].flags & MEF_CURRENT) {
 		if (!Mission_events[event].born_on_date.isValid()) {
 			Mission_events[event].born_on_date = _timestamp();
 		}
 
 		if (Mission_events[event].result) {
-			return EVENT_SATISFIED;
+			return EventStatus::SATISFIED;
 		}
 
 		if (Mission_events[event].formula < 0) {
-			return EVENT_FAILED;
+			return EventStatus::FAILED;
 		}
 
-		return EVENT_CURRENT;
+		return EventStatus::CURRENT;
 	}
 
-	return EVENT_UNBORN;
+	return EventStatus::UNBORN;
 }
 
 void mission_event_set_directive_special(int event)

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -937,7 +937,7 @@ void mission_process_event( int event )
 	}
 
 	if (sindex >= 0) {
-		Sexp_useful_number = 1;
+		Assume_event_is_current = true;
 		if (Snapshot_all_events || Mission_events[event].mission_log_flags != 0) {
 			Log_event = true;
 			
@@ -964,7 +964,7 @@ void mission_process_event( int event )
 			Mission_events[event].count = Directive_count;
 		}
 
-		if (Sexp_useful_number){
+		if (Assume_event_is_current){
 			Mission_events[event].flags |= MEF_CURRENT;
 		}
 

--- a/code/mission/missiongoals.h
+++ b/code/mission/missiongoals.h
@@ -66,11 +66,14 @@ extern SCP_vector<mission_goal> Mission_goals;	// structure for the goals of thi
 
 // defined for event states.  We will also use the satisfied/failed for saving event information
 // in campaign save file
-#define EVENT_UNBORN			0  // event can't be evaluated yet
-#define EVENT_CURRENT		1  // event can currently be evaluated, but not satisfied or failed yet
-#define EVENT_SATISFIED		2
-#define EVENT_FAILED			3
-#define EVENT_INCOMPLETE	4	// used in campaign save file.  used when event isn't satisfied yet
+enum class EventStatus : int
+{
+	UNBORN = 0,		// event can't be evaluated yet
+	CURRENT = 1,	// event can currently be evaluated, but not satisfied or failed yet
+	SATISFIED = 2,
+	FAILED = 3,
+	INCOMPLETE = 4	// used in campaign save file.  used when event isn't satisfied yet
+};
 
 #define MEF_CURRENT					(1 << 0)		// is event current or past current yet?
 #define MEF_DIRECTIVE_SPECIAL		(1 << 1)		// used to mark a directive as true even though not fully satisfied
@@ -168,7 +171,7 @@ int mission_goals_incomplete(int desired_type, int team = -1);
 void mission_goal_mark_objectives_complete();
 void mission_goal_mark_events_complete();
 
-int mission_get_event_status(int event);
+EventStatus mission_get_event_status(int event);
 void mission_goal_validation_change( int goal_num, bool valid );
 
 // mark an event as directive special

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -269,15 +269,15 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 			}
 
 			switch (mission_get_event_status(z)) {
-			case EVENT_CURRENT:
+			case EventStatus::CURRENT:
 				c = &Color_bright_white;
 				break;
 
-			case EVENT_FAILED:
+			case EventStatus::FAILED:
 				c = &Color_bright_red;
 				break;
 
-			case EVENT_SATISFIED:
+			case EventStatus::SATISFIED:
 				t = Mission_events[z].satisfied_time;
 				Assertion(t.isValid(), "Since event %s was satisfied, satisfied_time must be valid here", Mission_events[z].name.c_str());
 				if (timestamp_since(t) < 2 * MILLISECONDS_PER_SECOND) {
@@ -382,7 +382,7 @@ int comp_training_lines_by_born_on_date(const int *e1, const int *e2)
 #define MIN_FAILED_TIME			7
 void sort_training_objectives()
 {
-	int i, event_status, offset;
+	int i, offset;
 
 	// start by sorting on born on date
 	insertion_sort(Training_obj_lines, Training_obj_num_lines, comp_training_lines_by_born_on_date);
@@ -399,7 +399,7 @@ void sort_training_objectives()
 	int num_offset_events = 0;
 	for (i=0; i<offset; i++) {
 		int event_num = TRAINING_OBJ_LINES_MASK(i);
-		event_status = mission_get_event_status(event_num);
+		auto event_status = mission_get_event_status(event_num);
 		
 		// if this is a multiplayer tvt game, and this is event is for another team, don't touch it
 		if(MULTI_TEAM && (Net_player != NULL)){
@@ -408,10 +408,10 @@ void sort_training_objectives()
 			}
 		}
 
-		if (event_status == EVENT_CURRENT)  {
+		if (event_status == EventStatus::CURRENT)  {
 			Training_obj_lines[i] |= TRAINING_OBJ_STATUS_UNKNOWN;
 			num_offset_events++;
-		} else if (event_status ==	EVENT_SATISFIED) {
+		} else if (event_status == EventStatus::SATISFIED) {
 			Assertion(Mission_events[event_num].satisfied_time.isValid(), "Since event %s was satisfied, satisfied_time must be valid here", Mission_events[event_num].name.c_str());
 			if (timestamp_since(Mission_events[event_num].satisfied_time) < MIN_SATISFIED_TIME) {
 				Training_obj_lines[i] |= TRAINING_OBJ_STATUS_UNKNOWN;
@@ -419,7 +419,7 @@ void sort_training_objectives()
 			} else {
 				Training_obj_lines[i] |= TRAINING_OBJ_STATUS_KNOWN;
 			}
-		} else if (event_status ==	EVENT_FAILED) {
+		} else if (event_status == EventStatus::FAILED) {
 			Assertion(Mission_events[event_num].satisfied_time.isValid(), "Since event %s failed, satisfied_time must be valid here", Mission_events[event_num].name.c_str());
 			if (timestamp_since(Mission_events[event_num].satisfied_time) < MIN_FAILED_TIME) {
 				Training_obj_lines[i] |= TRAINING_OBJ_STATUS_UNKNOWN;
@@ -438,7 +438,7 @@ void sort_training_objectives()
 	// go through lines offset to Training_obj_num_lines to check which should be shown, since some will need to be bumped
 	for (i=offset; i<Training_obj_num_lines; i++) {
 		int event_num = TRAINING_OBJ_LINES_MASK(i);
-		event_status = mission_get_event_status(event_num);
+		auto event_status = mission_get_event_status(event_num);
 
 		// if this is a multiplayer tvt game, and this is event is for another team, it can be bumped
 		if(MULTI_TEAM && (Net_player != NULL)){
@@ -448,16 +448,16 @@ void sort_training_objectives()
 			}
 		}
 
-		if (event_status == EVENT_CURRENT)  {
+		if (event_status == EventStatus::CURRENT)  {
 			Training_obj_lines[i] |= TRAINING_OBJ_STATUS_UNKNOWN;
-		} else if (event_status ==	EVENT_SATISFIED) {
+		} else if (event_status == EventStatus::SATISFIED) {
 			Assertion(Mission_events[event_num].satisfied_time.isValid(), "Since event %s was satisfied, satisfied_time must be valid here", Mission_events[event_num].name.c_str());
 			if (timestamp_since(Mission_events[event_num].satisfied_time) < MIN_SATISFIED_TIME) {
 				Training_obj_lines[i] |= TRAINING_OBJ_STATUS_UNKNOWN;
 			} else {
 				Training_obj_lines[i] |= TRAINING_OBJ_STATUS_KNOWN;
 			}
-		} else if (event_status ==	EVENT_FAILED) {
+		} else if (event_status == EventStatus::FAILED) {
 			Assertion(Mission_events[event_num].satisfied_time.isValid(), "Since event %s failed, satisfied_time must be valid here", Mission_events[event_num].name.c_str());
 			if (timestamp_since(Mission_events[event_num].satisfied_time) < MIN_FAILED_TIME) {
 				Training_obj_lines[i] |= TRAINING_OBJ_STATUS_UNKNOWN;
@@ -513,12 +513,12 @@ void sort_training_objectives()
  */
 void training_check_objectives()
 {
-	int i, event_idx, event_status;
+	int i, event_idx;
 
 	Training_obj_num_lines = 0;
 	for (event_idx=0; event_idx<(int)Mission_events.size(); event_idx++) {
-		event_status = mission_get_event_status(event_idx);
-		if ( (event_status != EVENT_UNBORN) && !Mission_events[event_idx].objective_text.empty() && (timestamp_since(Mission_events[event_idx].born_on_date) > Directive_wait_time) ) {
+		auto event_status = mission_get_event_status(event_idx);
+		if ( (event_status != EventStatus::UNBORN) && !Mission_events[event_idx].objective_text.empty() && (timestamp_since(Mission_events[event_idx].born_on_date) > Directive_wait_time) ) {
 			if (!Training_failure || !strnicmp(Mission_events[event_idx].name.c_str(), XSTR( "Training failed", 423), 15)) {
 
 				// check for the actual objective
@@ -551,7 +551,7 @@ void training_check_objectives()
 
 				// if there is a keypress message with directive, process that too.
 				if (!Mission_events[event_idx].objective_key_text.empty()) {
-					if (event_status == EVENT_CURRENT) {
+					if (event_status == EventStatus::CURRENT) {
 
 						// not in objective list, need to add it
 						if (i == Training_obj_num_lines) {

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -290,6 +290,10 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 					c = &Color_bright_blue;
 				}
 				break;
+
+			default:
+				// stick with Color_normal
+				break;
 			}
 		}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17585,7 +17585,7 @@ int sexp_previous_event_status( int n, EventStatus status )
 
 			} else {
 				// now return KNOWN_TRUE or KNOWN_FALSE based on the status field in the goal structure
-				if ( Campaign.missions[mission_num].events[i].status == (int)status )
+				if ( Campaign.missions[mission_num].events[i].status == static_cast<int>(status) )
 					rval = SEXP_KNOWN_TRUE;
 				else
 					rval = SEXP_KNOWN_FALSE;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17537,7 +17537,7 @@ int sexp_previous_goal_status( int n, int status )
 // sexpression which gets the status of an event from a previous mission.  Like the above function but
 // dealing with events instead of goals.  Again, the status parameter tells the code if we are looking
 // for an event_true, event_false, or event_incomplete status
-int sexp_previous_event_status( int n, int status )
+int sexp_previous_event_status( int n, EventStatus status )
 {
 	int rval = 0;
 	int i, mission_num;
@@ -17558,8 +17558,8 @@ int sexp_previous_event_status( int n, int status )
 
 		// if the mission name wasn't found -- make this return FALSE for the event status.
 		if ( i == -1 ) {
-			nprintf(("General", "Couldn't find mission name \"%s\" in current campaign's list of missions.\nReturning %s for event-status function.\n", mission_name, (status==EVENT_SATISFIED)?"false":"true"));
-			if ( status == EVENT_SATISFIED ) {
+			nprintf(("General", "Couldn't find mission name \"%s\" in current campaign's list of missions.\nReturning %s for event-status function.\n", mission_name, (status==EventStatus::SATISFIED)?"false":"true"));
+			if ( status == EventStatus::SATISFIED ) {
 				rval = SEXP_KNOWN_FALSE;
 			} else {
 				rval = SEXP_KNOWN_TRUE;
@@ -17577,15 +17577,15 @@ int sexp_previous_event_status( int n, int status )
 			}
 
 			if ( i == (int)Campaign.missions[mission_num].events.size() ) {
-				Warning(LOCATION, "Couldn't find event name \"%s\" in mission %s.\nReturning %s for event_status function.", name, mission_name, (status==EVENT_SATISFIED)?"false":"true");
-				if ( status == EVENT_SATISFIED )
+				Warning(LOCATION, "Couldn't find event name \"%s\" in mission %s.\nReturning %s for event_status function.", name, mission_name, (status==EventStatus::SATISFIED)?"false":"true");
+				if ( status == EventStatus::SATISFIED )
 					rval = SEXP_KNOWN_FALSE;
 				else
 					rval = SEXP_KNOWN_TRUE;
 
 			} else {
 				// now return KNOWN_TRUE or KNOWN_FALSE based on the status field in the goal structure
-				if ( Campaign.missions[mission_num].events[i].status == status )
+				if ( Campaign.missions[mission_num].events[i].status == (int)status )
 					rval = SEXP_KNOWN_TRUE;
 				else
 					rval = SEXP_KNOWN_FALSE;
@@ -17602,7 +17602,7 @@ int sexp_previous_event_status( int n, int status )
 			else
 				rval = SEXP_KNOWN_FALSE;
 		} else {
-			if ( status == EVENT_SATISFIED )
+			if ( status == EventStatus::SATISFIED )
 				rval = SEXP_KNOWN_TRUE;
 			else
 				rval = SEXP_KNOWN_FALSE;
@@ -26675,15 +26675,15 @@ int eval_sexp(int cur_node, int referenced_node)
 				break;
 
 			case OP_PREVIOUS_EVENT_TRUE:
-				sexp_val = sexp_previous_event_status( node, EVENT_SATISFIED );
+				sexp_val = sexp_previous_event_status( node, EventStatus::SATISFIED );
 				break;
 
 			case OP_PREVIOUS_EVENT_FALSE:
-				sexp_val = sexp_previous_event_status( node, EVENT_FAILED );
+				sexp_val = sexp_previous_event_status( node, EventStatus::FAILED );
 				break;
 
 			case OP_PREVIOUS_EVENT_INCOMPLETE:
-				sexp_val = sexp_previous_event_status( node, EVENT_INCOMPLETE );
+				sexp_val = sexp_previous_event_status( node, EventStatus::INCOMPLETE );
 				break;
 
 			case OP_EVENT_TRUE:

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1353,6 +1353,7 @@ extern size_t Max_operator_length;
 extern int Locked_sexp_true, Locked_sexp_false;
 extern int Directive_count;
 extern int Sexp_useful_number;  // a variable to pass useful info in from external modules
+extern bool Assume_event_is_current;
 extern int Training_context;
 extern int Training_context_speed_min;
 extern int Training_context_speed_max;


### PR DESCRIPTION
In the course of investigating #5725, I made a few minor code enhancements:
1. convert event status to enum
2. split off the event currency functionality from `Sexp_useful_number`, for clarity
3. move where `Sexp_useful_number` (now `Assume_event_is_current`) is set, to increase its visibility and group it with more appropriate code
4. fix `sexp_event_delay_status` to properly set `Assume_event_is_current` in all return paths