### PR TITLE
Provide a way to account for timer padding in the mission log

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -645,7 +645,7 @@ void hud_add_msg_to_scrollback(const char *text, int source, int t)
 	}
 
 	// create the new node for the vector
-	line_node newLine = {t, source, 0, 1, w, ""};
+	line_node newLine = {t, The_mission.HUD_timer_padding, source, 0, 1, w, ""};
 	newLine.text = text;
 
 	Msg_scrollback_vec.push_back(newLine);
@@ -853,7 +853,7 @@ void hud_initialize_scrollback_lines()
 				char* text = c_text;
 
 				char* split = split_str_once(text, max_width);
-				Msg_scrollback_lines.push_back({node_msg.time, node_msg.source, node_msg.x, 1, node_msg.underline_width, text});
+				Msg_scrollback_lines.push_back({node_msg.time, The_mission.HUD_timer_padding, node_msg.source, node_msg.x, 1, node_msg.underline_width, text});
 
 				while (split != nullptr) {
 					text = split;
@@ -864,7 +864,7 @@ void hud_initialize_scrollback_lines()
 					if (split == nullptr)
 						offset = height / 3;
 
-					Msg_scrollback_lines.push_back({0, node_msg.source, node_msg.x, offset, 0, text});
+					Msg_scrollback_lines.push_back({0, 0, node_msg.source, node_msg.x, offset, 0, text});
 				}
 			} else {
 				node_msg.y = height / 3;

--- a/code/hud/hudmessage.h
+++ b/code/hud/hudmessage.h
@@ -38,6 +38,7 @@ typedef struct HUD_message_data {
 
 typedef struct line_node {
 	fix time;  // timestamp when message was added
+	int timer_padding; // the mission timer padding, in seconds, at the time the message was added
 	int source;  // who/what the source of the message was (for color coding)
 	int x;
 	int y;

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -355,6 +355,7 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 	}
 
 	entry->timestamp = Missiontime;
+	entry->timer_padding = The_mission.HUD_timer_padding;
 
 	// if in multiplayer and I am the master, send this log entry to everyone
 	if ( MULTIPLAYER_MASTER ){
@@ -468,6 +469,7 @@ void mission_log_add_entry_multi( LogType type, const char *pname, const char *s
 
 	entry->flags = flags;
 	entry->timestamp = timestamp;
+	entry->timer_padding = The_mission.HUD_timer_padding;
 
 	entry->pname_display = entry->pname;
 	entry->sname_display = entry->sname;
@@ -698,6 +700,7 @@ void message_log_init_scrollback(int pw, bool split_string)
 
 		// track time of event (normal Missiontime format)
 		thisEntry.timestamp = entry->timestamp;
+		thisEntry.timer_padding = entry->timer_padding;
 
 		// keep track of base color for the entry
 		int thisColor;

--- a/code/mission/missionlog.h
+++ b/code/mission/missionlog.h
@@ -60,6 +60,7 @@ struct log_entry {
 	LogType type;            // one of the log #defines in MissionLog.h
 	int flags;               // flags used for status of this log entry
 	fix timestamp;           // time in fixed seconds when entry was made from beginning of mission
+	int timer_padding;		 // the mission timer padding, in seconds, when the entry was created
 	char pname[NAME_LENGTH]; // name of primary object of this action
 	char sname[NAME_LENGTH]; // name of secondary object of this action
 	int index;               // a generic entry which can contain things like wave # (for wing arrivals), goal #, etc
@@ -81,6 +82,7 @@ struct log_text_seg {
 
 struct log_line_complete {
 	fix timestamp;
+	int timer_padding;
 	log_text_seg objective;
 	SCP_vector<log_text_seg> segments;
 };

--- a/code/scripting/api/objs/missionlog.cpp
+++ b/code/scripting/api/objs/missionlog.cpp
@@ -78,6 +78,29 @@ ADE_VIRTVAR(Timestamp, l_Log_Entry, nullptr, "The timestamp of the log entry", "
 	return ade_set_args(L, "s", time.c_str());
 }
 
+ADE_VIRTVAR(paddedTimestamp, l_Log_Entry, nullptr, "The timestamp of the log entry that accounts for timer padding", "string", "The timestamp")
+{
+	log_entry_h current;
+	if (!ade_get_args(L, "o", l_Log_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+	if (!current.isValid()) {
+		return ade_set_error(L, "s", "");
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	int seconds = f2i(current.getSection()->timestamp) + current.getSection()->timer_padding;
+
+	// format the time information into strings
+	SCP_string time;
+	sprintf(time, "%.1d:%.2d:%.2d", (seconds / 3600) % 10, (seconds / 60) % 60, seconds % 60);
+
+	return ade_set_args(L, "s", time.c_str());
+}
+
 ADE_VIRTVAR(Flags, l_Log_Entry, nullptr, "The flag of the log entry. 1 for Goal True, 2 for Goal Failed, 0 otherwise.", "number", "The flag")
 {
 	log_entry_h current;
@@ -216,6 +239,29 @@ ADE_VIRTVAR(Timestamp, l_Message_Entry, nullptr, "The timestamp of the message e
 	}
 
 	int seconds = f2i(current.getSection()->time);
+
+	// format the time information into strings
+	SCP_string time;
+	sprintf(time, "%.1d:%.2d:%.2d", (seconds / 3600) % 10, (seconds / 60) % 60, seconds % 60);
+
+	return ade_set_args(L, "s", time.c_str());
+}
+
+ADE_VIRTVAR(paddedTimestamp, l_Message_Entry, nullptr, "The timestamp of the message entry that accounts for mission timer padding", "string", "The timestamp")
+{
+	message_entry_h current;
+	if (!ade_get_args(L, "o", l_Message_Entry.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+	if (!current.isValid()) {
+		return ade_set_error(L, "s", "");
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	int seconds = f2i(current.getSection()->time) + current.getSection()->timer_padding;
 
 	// format the time information into strings
 	SCP_string time;


### PR DESCRIPTION
Simply saves the current timer padding when a log entry is created. Provides a way for SCPUI to get the padded time instead of the regular time.

This takes the padded timer feature a little further than I originally intended but it ended up being confusing to have the mission clock say 25+ minutes while messages and events were still happening at -7 minutes. So this provides SCPUI a way to keep the illusion alive if a mod wants to.

I thought about making it default behavior and adding it to the retail UI as well, but that seemed a step too far. Open to discussion on that, though. Regular time is still useful for development and testing purposes because that's the real game clock.