### PR TITLE
upgrade timestamps referenced in freespace.cpp

### DIFF
--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -12,7 +12,6 @@
 #include "debugconsole/console.h"
 #include "globalincs/pstypes.h"
 #include "graphics/2d.h"
-#include "io/timer.h"
 #include "nebula/neb.h"
 #include "options/Option.h"
 
@@ -33,12 +32,6 @@ int Cutscene_bar_flags = CUB_NONE;
 float Cutscene_delta_time = 1.0f;
 //How far along a change is (0 to 1)
 float Cutscene_bars_progress = 1.0f;
-
-//FADEIN STUFF
-shader Viewer_shader;
-FadeType Fade_type = FI_NONE;
-int Fade_start_timestamp = 0;
-int Fade_end_timestamp = 0;
 
 // The detail level.  Anything below zero draws simple models earlier than it
 // should.   Anything above zero draws higher detail models longer than it should.

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -59,19 +59,6 @@
 extern float Cutscene_bars_progress, Cutscene_delta_time;
 extern int Cutscene_bar_flags;
 
-//-----Fadein stuff
-struct shader;
-extern shader Viewer_shader;
-
-enum FadeType {
-	FI_NONE,
-	FI_FADEIN,
-	FI_FADEOUT
-};
-extern FadeType Fade_type;
-extern int Fade_start_timestamp;
-extern int Fade_end_timestamp;
-
 
 typedef struct vei {
 	angles_t	angles;			//	Angles defining viewer location.

--- a/code/graphics/light.cpp
+++ b/code/graphics/light.cpp
@@ -15,6 +15,7 @@
 
 #include "cmdline/cmdline.h"
 #include "graphics/2d.h"
+#include "io/timer.h"
 #include "lighting/lighting.h"
 #include "lighting/lighting_profiles.h"
 #include "math/bitarray.h"
@@ -42,6 +43,12 @@ struct gr_light
 
 	int type;
 };
+
+//FADEIN STUFF
+shader Viewer_shader;
+FadeType Fade_type = FadeType::FI_NONE;
+TIMESTAMP Fade_start_timestamp = TIMESTAMP::invalid();
+TIMESTAMP Fade_end_timestamp = TIMESTAMP::invalid();
 
 // Variables
 SCP_vector<gr_light> gr_lights;

--- a/code/graphics/light.h
+++ b/code/graphics/light.h
@@ -5,6 +5,20 @@
 #include "lighting/lighting.h"
 #include "cmdline/cmdline.h"
 
+//-----Fadein stuff
+struct shader;
+extern shader Viewer_shader;
+
+enum class FadeType {
+	FI_NONE = 0,
+	FI_FADEIN,
+	FI_FADEOUT
+};
+extern FadeType Fade_type;
+extern TIMESTAMP Fade_start_timestamp;
+extern TIMESTAMP Fade_end_timestamp;
+
+
 //Variables
 extern int Num_active_gr_lights;
 
@@ -12,6 +26,7 @@ extern const float gr_light_color[4];
 extern const float gr_light_zero[4];
 extern const float gr_light_emission[4];
 extern float gr_light_ambient[4];
+
 
 //Functions
 void gr_set_light(light *fs_light);

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -87,6 +87,23 @@ int Training_bind_warning = -1;  // Missiontime at which we last gave warning
 int Training_message_visible;
 training_message_queue Training_message_queue[TRAINING_MESSAGE_QUEUE_MAX];
 
+int	Training_context = 0;
+int	Training_context_speed_set;
+int	Training_context_speed_min;
+int	Training_context_speed_max;
+TIMESTAMP	Training_context_speed_timestamp;
+waypoint_list *Training_context_path;
+int Training_context_goal_waypoint;
+int Training_context_at_waypoint;
+float	Training_context_distance;
+
+int Players_target = UNINITIALIZED;
+int Players_mlocked = UNINITIALIZED; // for is-missile-locked - Sesquipedalian
+ship_subsys *Players_targeted_subsys;
+TIMESTAMP Players_target_timestamp;
+TIMESTAMP Players_mlocked_timestamp;
+
+
 // coordinates for training messages
 int Training_message_window_coords[GR_NUM_RESOLUTIONS][2] = {
 	{ 174, 40 },
@@ -369,6 +386,17 @@ void training_mission_init()
 	if ( The_mission.game_type & MISSION_TYPE_TRAINING ) {
 		Player->flags &= ~(PLAYER_FLAGS_MATCH_TARGET | PLAYER_FLAGS_MSG_MODE | PLAYER_FLAGS_AUTO_TARGETING | PLAYER_FLAGS_AUTO_MATCH_SPEED | PLAYER_FLAGS_LINK_PRIMARY | PLAYER_FLAGS_LINK_SECONDARY );
 	}
+
+	Training_context = 0;
+	Training_context_speed_set = 0;
+	Training_context_speed_timestamp = TIMESTAMP::invalid();
+	Training_context_path = nullptr;
+
+	Players_target = UNINITIALIZED;
+	Players_mlocked = UNINITIALIZED;
+	Players_targeted_subsys = nullptr;
+	Players_target_timestamp = TIMESTAMP::invalid();
+	Players_mlocked_timestamp = TIMESTAMP::invalid();
 }
 
 int comp_training_lines_by_born_on_date(const int *e1, const int *e2)

--- a/code/mission/missiontraining.h
+++ b/code/mission/missiontraining.h
@@ -12,11 +12,29 @@
 
 #include "hud/hud.h"
 
+class TIMESTAMP;
+
 extern int Max_directives;
 extern int Training_message_method;
 extern int Training_num_lines;
 extern int Training_message_visible;
 extern int Training_failure;
+
+extern int Training_context;
+extern int Training_context_speed_min;
+extern int Training_context_speed_max;
+extern int Training_context_speed_set;
+extern TIMESTAMP Training_context_speed_timestamp;
+extern waypoint_list *Training_context_path;
+extern int Training_context_goal_waypoint;
+extern int Training_context_at_waypoint;
+extern float Training_context_distance;
+
+extern int Players_target;
+extern int Players_mlocked;
+extern ship_subsys *Players_targeted_subsys;
+extern TIMESTAMP Players_target_timestamp;
+extern TIMESTAMP Players_mlocked_timestamp;
 
 void training_mission_init();
 void training_mission_shutdown();

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1357,20 +1357,6 @@ extern int Locked_sexp_true, Locked_sexp_false;
 extern int Directive_count;
 extern int Sexp_useful_number;  // a variable to pass useful info in from external modules
 extern bool Assume_event_is_current;
-extern int Training_context;
-extern int Training_context_speed_min;
-extern int Training_context_speed_max;
-extern int Training_context_speed_set;
-extern int Training_context_speed_timestamp;
-extern waypoint_list *Training_context_path;
-extern int Training_context_goal_waypoint;
-extern int Training_context_at_waypoint;
-extern float Training_context_distance;
-extern int Players_target;
-extern int Players_mlocked;
-extern ship_subsys *Players_targeted_subsys;
-extern int Players_target_timestamp;
-extern int Players_mlocked_timestamp;
 extern int Sexp_clipboard;  // used by Fred
 
 extern SCP_vector<int> Current_sexp_operator;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -243,7 +243,7 @@ void game_show_framerate();			// draws framerate in lower right corner
 struct big_expl_flash {
 	float max_flash_intensity;	// max intensity
 	float cur_flash_intensity;	// cur intensity
-	int	flash_start;		// start time
+	TIMESTAMP	flash_start;		// start time
 };
 
 #define FRAME_FILTER 16
@@ -524,7 +524,7 @@ float Game_flash_red = 0.0f;
 float Game_flash_green = 0.0f;
 float Game_flash_blue = 0.0f;
 float Sun_spot = 0.0f;
-big_expl_flash Big_expl_flash = {0.0f, 0.0f, 0};
+big_expl_flash Big_expl_flash = {0.0f, 0.0f, TIMESTAMP::invalid()};
 
 // game shudder stuff (in ms)
 bool Game_shudder_perpetual = false;
@@ -564,7 +564,7 @@ void game_flash_reset()
 	Sun_spot = 0.0f;
 	Big_expl_flash.max_flash_intensity = 0.0f;
 	Big_expl_flash.cur_flash_intensity = 0.0f;
-	Big_expl_flash.flash_start = 0;
+	Big_expl_flash.flash_start = TIMESTAMP::invalid();
 }
 
 extern float Framerate;
@@ -613,7 +613,7 @@ void big_explosion_flash(float flash)
 {
 	CLAMP(flash, 0.0f, 1.0f);
 
-	Big_expl_flash.flash_start = timestamp(1);
+	Big_expl_flash.flash_start = TIMESTAMP::immediate();
 	Big_expl_flash.max_flash_intensity = flash;
 	Big_expl_flash.cur_flash_intensity = 0.0f;
 }
@@ -787,18 +787,23 @@ static void game_flash_diminish(float frametime)
 	} 
 
 	// update big_explosion_cur_flash
+	if (Big_expl_flash.flash_start.isValid()) {
 #define	TIME_UP		1500
 #define	TIME_DOWN	2500
-	int duration = TIME_UP + TIME_DOWN;
-	int time = timestamp_until(Big_expl_flash.flash_start);
-	if (time > -duration) {
-		time = -time;
-		if (time < TIME_UP) {
-			Big_expl_flash.cur_flash_intensity = Big_expl_flash.max_flash_intensity * time / (float) TIME_UP;
-		} else {
-			time -= TIME_UP;
-			Big_expl_flash.cur_flash_intensity = Big_expl_flash.max_flash_intensity * ((float) TIME_DOWN - time) / (float) TIME_DOWN;
+		int duration = TIME_UP + TIME_DOWN;
+		int time = timestamp_until(Big_expl_flash.flash_start);
+		if (time > -duration) {
+			time = -time;
+			if (time < TIME_UP) {
+				Big_expl_flash.cur_flash_intensity = Big_expl_flash.max_flash_intensity * time / (float)TIME_UP;
+			}
+			else {
+				time -= TIME_UP;
+				Big_expl_flash.cur_flash_intensity = Big_expl_flash.max_flash_intensity * ((float)TIME_DOWN - time) / (float)TIME_DOWN;
+			}
 		}
+	} else {
+		Big_expl_flash.cur_flash_intensity = 0.0f;
 	}
 	
 	if ( Use_palette_flash )	{
@@ -2504,7 +2509,7 @@ int tst_bitmap = -1;
 float tst_x, tst_y;
 float tst_offset, tst_offset_total;
 int tst_mode;
-int tst_stamp;
+TIMESTAMP tst_stamp;
 void game_tst_frame_pre()
 {
 	// start tst
@@ -2640,7 +2645,7 @@ void game_tst_frame()
 				switch(tst_mode){
 				case 0:
 					tst_mode = 1;
-					tst_stamp = timestamp(1000);
+					tst_stamp = _timestamp(1000);
 					tst_offset = fl_abs(tst_offset_total);
 					break;				
 
@@ -3798,7 +3803,7 @@ void game_render_hud(camid cid)
 //100% blackness
 void game_reset_shade_frame()
 {
-	Fade_type = FI_NONE;
+	Fade_type = FadeType::FI_NONE;
 	gr_create_shader(&Viewer_shader, 0, 0, 0, 0);
 }
 
@@ -3811,33 +3816,33 @@ void game_shade_frame(float  /*frametime*/)
 
 	GR_DEBUG_SCOPE("Shade frame");
 
-	if (Fade_type != FI_NONE) {
-		Assert(Fade_start_timestamp > 0);
-		Assert(Fade_end_timestamp > 0);
-		Assert(Fade_end_timestamp > Fade_start_timestamp);
+	if (Fade_type != FadeType::FI_NONE) {
+		Assertion(Fade_start_timestamp.isValid(), "When Fade_type is set, Fade_start_timestamp must be valid!");
+		Assertion(Fade_end_timestamp.isValid(), "When Fade_type is set, Fade_end_timestamp must be valid!");
+		Assertion(timestamp_compare(Fade_end_timestamp, Fade_start_timestamp) > 0, "Fade_end_timestamp must be after Fade_start_timestamp!");
 
-		if( timestamp() >= Fade_start_timestamp ) {
+		if (timestamp_elapsed(Fade_start_timestamp)) {
 			int startAlpha = 0;
 			int endAlpha = 0;
 
-			if (Fade_type == FI_FADEOUT) {
+			if (Fade_type == FadeType::FI_FADEOUT) {
 				endAlpha = 255;
-			} else if (Fade_type == FI_FADEIN) {
+			} else if (Fade_type == FadeType::FI_FADEIN) {
 				startAlpha = 255;
 			}
 
 			int alpha = 0;
 
-			if( timestamp() < Fade_end_timestamp ) {
-				int duration = (Fade_end_timestamp - Fade_start_timestamp);
-				int elapsed = (timestamp() - Fade_start_timestamp);
+			if (!timestamp_elapsed(Fade_end_timestamp)) {
+				int duration = timestamp_get_delta(Fade_start_timestamp, Fade_end_timestamp);
+				int elapsed = timestamp_since(Fade_start_timestamp);
 
 				alpha = fl2i( (float)startAlpha + (((float)endAlpha - (float)startAlpha) / (float)duration) * (float)elapsed );
 			} else {
 				//Fade finished
-				Fade_type = FI_NONE;
-				Fade_start_timestamp = 0;
-				Fade_end_timestamp = 0;
+				Fade_type = FadeType::FI_NONE;
+				Fade_start_timestamp = TIMESTAMP::invalid();
+				Fade_end_timestamp = TIMESTAMP::invalid();
 
 				alpha = endAlpha;
 			}
@@ -6851,7 +6856,7 @@ void game_do_training_checks()
 		if ((s >= Training_context_speed_min) && (s <= Training_context_speed_max)) {
 			if (!Training_context_speed_set) {
 				Training_context_speed_set = 1;
-				Training_context_speed_timestamp = timestamp();
+				Training_context_speed_timestamp = _timestamp();
 			}
 
 		} else
@@ -6887,12 +6892,12 @@ void game_do_training_checks()
 	if ((Players_target == UNINITIALIZED) || (Player_ai->target_objnum != Players_target) || (Player_ai->targeted_subsys != Players_targeted_subsys)) {
 		Players_target = Player_ai->target_objnum;
 		Players_targeted_subsys = Player_ai->targeted_subsys;
-		Players_target_timestamp = timestamp();
+		Players_target_timestamp = _timestamp();
 	}
 	// following added by Sesquipedalian for is_missile_locked
 	if ((Players_mlocked == UNINITIALIZED) || (Player_ai->current_target_is_locked != Players_mlocked)) {
 		Players_mlocked = Player_ai->current_target_is_locked;
-		Players_mlocked_timestamp = timestamp();
+		Players_mlocked_timestamp = _timestamp();
 	}
 
 }


### PR DESCRIPTION
Convert additional timestamps to use the new timestamp system.  This covers all timestamps referred to in freespace.cpp.  For purposes of organization, the fade-in/fade-out timestamps have been moved to light.h|cpp and the training timestamps have been moved to missiontraining.h|cpp.

There are also several related code enhancements:
1. `FadeType` has been converted from `enum` to `enum class`
2. Initialization of the various training variables has been added to `training_mission_init` (previously they had never been reset between missions)
3. Validity checks have been added to the relevant locations for these timestamps