### PR TITLE
Mod setting to disable FSO's internal loadout restoration

### DIFF
--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -37,6 +37,7 @@
 #include "missionui/missionscreencommon.h"
 #include "missionui/missionshipchoice.h"
 #include "missionui/missionweaponchoice.h"
+#include "mod_table/mod_table.h"
 #include "network/multi.h"
 #include "network/multi_endgame.h"
 #include "network/multimsgs.h"
@@ -1117,6 +1118,10 @@ void wss_maybe_restore_loadout()
 	wss_unit	*slot;
 
 	Assert( (Ss_pool != NULL) && (Wl_pool != NULL) && (Wss_slots != NULL) );
+
+	if (Disable_internal_loadout_restoration_system) {
+		return;
+	}
 
 	// only restore if mission hasn't changed
 	if ( stricmp(Player_loadout.last_modified, The_mission.modified) != 0 ) {

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -146,6 +146,7 @@ bool Play_thruster_sounds_for_player;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
 bool Calculate_subsystem_hitpoints_after_parsing;
+bool Disable_internal_loadout_restoration_system;
 
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Other.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
@@ -289,6 +290,10 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Center splash logo:")) {
 			stuff_boolean(&Splash_logo_center);
+		}
+
+		if (optional_string("$Disable FSO Internal Loadout Restoration System:")) {
+			stuff_boolean(&Disable_internal_loadout_restoration_system);
 		}
 
 		optional_string("#LOCALIZATION SETTINGS");
@@ -1525,6 +1530,7 @@ void mod_table_reset()
 		}};
 	Randomize_particle_rotation = false;
 	Calculate_subsystem_hitpoints_after_parsing = false;
+	Disable_internal_loadout_restoration_system = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -155,6 +155,7 @@ extern bool Play_thruster_sounds_for_player;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
 extern bool Calculate_subsystem_hitpoints_after_parsing;
+extern bool Disable_internal_loadout_restoration_system;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
SCPUI rolls it's own, much more robust, loadout saving and restoration system. It turns out there are rare cases where the built-in loadout system can conflict with it, so this exposes a toggle to disable the internal one entirely.

Note: this does not disable direct loadout restore which is still used when a player restarts a mission immediately.