### PR TITLE
Moar curves

### DIFF
--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -12,6 +12,7 @@
 #include "hud/hudshield.h"
 #include "hud/hudwingmanstatus.h"
 #include "io/timer.h"
+#include "math/curve.h"
 #include "network/multi.h"
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
@@ -98,6 +99,9 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3
 
 		damage *= wip->damage_incidence_min + ((wip->damage_incidence_max - wip->damage_incidence_min) * dot);
 	}
+
+	if (wip->damage_curve_idx >= 0)
+		damage *= Curves[wip->damage_curve_idx].GetValue(f2fl(Missiontime - wp->creation_time) / wip->lifetime);
 
 	// deterine whack whack
 	float		blast = wip->mass;

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -28,6 +28,7 @@
 #include "lighting/lighting.h"
 #include "lighting/lighting_profiles.h"
 #include "math/fvi.h"
+#include "math/curve.h"
 #include "math/staticrand.h"
 #include "nebula/neb.h"
 #include "mod_table/mod_table.h"
@@ -1366,7 +1367,6 @@ void beam_render(beam *b, float u_offset)
 	vec3d fvec, top1, bottom1, top2, bottom2;
 	float scale;
 	float u_scale;	// beam tileing -Bobboau
-	float length;	// beam tileing -Bobboau
 	beam_weapon_section_info *bwsi;
 	beam_weapon_info *bwi;
 
@@ -1387,7 +1387,6 @@ void beam_render(beam *b, float u_offset)
 	// turn off backface culling
 	//int cull = gr_set_cull(0);
 
-	length = vm_vec_dist(&b->last_start, &b->last_shot);					// beam tileing -Bobboau
 
 	bwi = &Weapon_info[b->weapon_info_index].b_info;
 
@@ -1396,6 +1395,25 @@ void beam_render(beam *b, float u_offset)
 		u_offset = b->u_offset_local;			// the parameter is passed by value so this won't interfere with the u_offset in the calling function
 		b->u_offset_local += flFrametime;		// increment *after* we grab the offset so that the first frame will always be at offset=0
 	}
+
+	float alpha_mult = 1.0f;
+	if (bwi->beam_alpha_curve_idx >= 0)
+		alpha_mult *= Curves[bwi->beam_alpha_curve_idx].GetValue((b->life_total - b->life_left) / b->life_total);
+
+	float length = vm_vec_dist(&b->last_start, &b->last_shot);					// beam tileing -Bobboau
+	float per = 1.0f;
+	if (bwi->range)
+		per -= length / bwi->range;
+
+	float end_alphaf = 255.0f * alpha_mult * per;
+	float start_alphaf = 255.0f * alpha_mult;
+
+	// just to be safe
+	CLAMP(end_alphaf, 0.0f, 255.0f);
+	CLAMP(start_alphaf, 0.0f, 255.0f);
+
+	ubyte end_alpha = static_cast<ubyte>(end_alphaf);
+	ubyte start_alpha = static_cast<ubyte>(start_alphaf);
 
 	// draw all sections	
 	for (s_idx = 0; s_idx < bwi->beam_num_sections; s_idx++) {
@@ -1427,32 +1445,24 @@ void beam_render(beam *b, float u_offset)
 		verts[3]->texture_position.u = (0 + (u_offset * bwsi->translation));
 		verts[0]->texture_position.u = (0 + (u_offset * bwsi->translation));
 
-		float per = 1.0f;
-		if (bwi->range)
-			per -= length / bwi->range;
 
-		//this should never happen but, just to be safe
-		CLAMP(per, 0.0f, 1.0f);
+		verts[1]->r = end_alpha;
+		verts[2]->r = end_alpha;
+		verts[1]->g = end_alpha;
+		verts[2]->g = end_alpha;
+		verts[1]->b = end_alpha;
+		verts[2]->b = end_alpha;
+		verts[1]->a = end_alpha;
+		verts[2]->a = end_alpha;
 
-		ubyte alpha = (ubyte)(255.0f * per);
-
-		verts[1]->r = alpha;
-		verts[2]->r = alpha;
-		verts[1]->g = alpha;
-		verts[2]->g = alpha;
-		verts[1]->b = alpha;
-		verts[2]->b = alpha;
-		verts[1]->a = alpha;
-		verts[2]->a = alpha;
-
-		verts[0]->r = 255;
-		verts[3]->r = 255;
-		verts[0]->g = 255;
-		verts[3]->g = 255;
-		verts[0]->b = 255;
-		verts[3]->b = 255;
-		verts[0]->a = 255;
-		verts[3]->a = 255;
+		verts[0]->r = start_alpha;
+		verts[3]->r = start_alpha;
+		verts[0]->g = start_alpha;
+		verts[3]->g = start_alpha;
+		verts[0]->b = start_alpha;
+		verts[3]->b = start_alpha;
+		verts[0]->a = start_alpha;
+		verts[3]->a = start_alpha;
 
 		// set the right texture with additive alpha, and draw the poly
 		int framenum = 0;
@@ -4205,14 +4215,17 @@ float beam_get_ship_damage(beam *b, object *objp, vec3d* hitpos)
 		}
 	}
 
-	float damage = 0.0f;
+	float damage = wip->damage;
+
+	if (wip->damage_curve_idx >= 0)
+		damage *= Curves[wip->damage_curve_idx].GetValue((b->life_total - b->life_left) / b->life_total);
 
 	// same team. yikes
-	if ( (b->team == Ships[objp->instance].team) && (wip->damage > The_mission.ai_profile->beam_friendly_damage_cap[Game_skill_level]) ) {
+	if ( (b->team == Ships[objp->instance].team) && (damage > The_mission.ai_profile->beam_friendly_damage_cap[Game_skill_level]) ) {
 		damage = The_mission.ai_profile->beam_friendly_damage_cap[Game_skill_level] * attenuation;
 	} else {
 		// normal damage
-		damage = wip->damage * attenuation;
+		damage *= attenuation;
 	}
 
 	return damage;

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -12,6 +12,7 @@
 #include "gamesnd/gamesnd.h"
 #include "globalincs/linklist.h"
 #include "io/timer.h"
+#include "math/curve.h"
 #include "model/modelrender.h"
 #include "nebula/neb.h"
 #include "object/object.h"
@@ -273,10 +274,20 @@ void shockwave_move(object *shockwave_objp, float frametime)
 	sw->time_elapsed += frametime;
 
 	shockwave_set_framenum(shockwave_objp->instance);
-		
-	sw->radius += (frametime * sw->speed);
-	if ( sw->radius > sw->outer_radius ) {
-		sw->radius = sw->outer_radius;
+
+	weapon_info* wip = nullptr;
+	if (sw->weapon_info_index >= 0)
+		wip = &Weapon_info[sw->weapon_info_index];
+	
+	if (wip && wip->shockwave.radius_curve_idx >= 0) {
+		float val = Curves[wip->shockwave.radius_curve_idx].GetValue(sw->time_elapsed / sw->total_time);
+		sw->radius = val * sw->outer_radius;
+	} else {
+		sw->radius += (frametime * sw->speed);
+		CLAMP(sw->radius, 0.0f, sw->outer_radius);
+	}
+
+	if ( sw->time_elapsed > sw->total_time ) {
         shockwave_objp->flags.set(Object::Object_Flags::Should_be_dead);
 		return;
 	}
@@ -323,8 +334,6 @@ void shockwave_move(object *shockwave_objp, float frametime)
 		if ( weapon_area_calc_damage(objp, &sw->pos, sw->inner_radius, sw->outer_radius, sw->blast, sw->damage, &blast, &damage, sw->radius) == -1 ){
 			continue;
 		}
-
-		weapon_info* wip = NULL;
 		
 		// okay, we have damage applied, record the object signature so we don't repeatedly apply damage 
 		// but only add non-ships to the list if the Game_settings flag is set
@@ -335,7 +344,7 @@ void shockwave_move(object *shockwave_objp, float frametime)
 		switch(objp->type) {
 		case OBJ_SHIP:
 			// If we're doing an AoE Electronics shockwave, do the electronics stuff. -MageKing17
-			if ( (sw->weapon_info_index >= 0) && (Weapon_info[sw->weapon_info_index].wi_flags[Weapon::Info_Flags::Aoe_Electronics]) && !(objp->flags[Object::Object_Flags::Invulnerable]) ) {
+			if ( wip && (wip->wi_flags[Weapon::Info_Flags::Aoe_Electronics]) && !(objp->flags[Object::Object_Flags::Invulnerable]) ) {
 				weapon_do_electronics_effect(objp, &sw->pos, sw->weapon_info_index);
 			}
 			ship_apply_global_damage(objp, shockwave_objp, &sw->pos, damage, sw->damage_type_idx );
@@ -346,8 +355,7 @@ void shockwave_move(object *shockwave_objp, float frametime)
 			asteroid_hit(objp, nullptr, nullptr, damage, nullptr);
 			break;
 		case OBJ_WEAPON:
-			wip = &Weapon_info[Weapons[objp->instance].weapon_info_index];
-			if (wip->armor_type_idx >= 0)
+			if (wip && wip->armor_type_idx >= 0)
 				damage = Armor_types[wip->armor_type_idx].GetDamage(damage, shockwave_get_damage_type_idx(shockwave_objp->instance), 1.0f, false);
 
 			objp->hull_strength -= damage;
@@ -724,6 +732,8 @@ void shockwave_create_info_init(shockwave_create_info *sci)
 	sci->pof_name[ 0 ] = '\0';
 
 	sci->inner_rad = sci->outer_rad = sci->damage = sci->blast = sci->speed = 0.0f;
+
+	sci->radius_curve_idx = -1;
 
 	sci->rot_angles.p = sci->rot_angles.b = sci->rot_angles.h = 0.0f;
 	sci->rot_defined = false;

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -305,11 +305,11 @@ void shockwave_move(object *shockwave_objp, float frametime)
 
 		if(objp->type == OBJ_WEAPON) {
 			// only apply to missiles with hitpoints
-			weapon_info* wip = &Weapon_info[Weapons[objp->instance].weapon_info_index];
-			if (wip->weapon_hitpoints <= 0)
+			weapon_info* target_wip = &Weapon_info[Weapons[objp->instance].weapon_info_index];
+			if (target_wip->weapon_hitpoints <= 0)
 				continue;
 
-			if (!Shockwaves_always_damage_bombs && !(wip->wi_flags[Weapon::Info_Flags::Takes_shockwave_damage] || (sw->weapon_info_index >= 0 && Weapon_info[sw->weapon_info_index].wi_flags[Weapon::Info_Flags::Ciws])))
+			if (!Shockwaves_always_damage_bombs && !(target_wip->wi_flags[Weapon::Info_Flags::Takes_shockwave_damage] || (sw->weapon_info_index >= 0 && Weapon_info[sw->weapon_info_index].wi_flags[Weapon::Info_Flags::Ciws])))
 				continue;
 		}
 

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -282,6 +282,8 @@ void shockwave_move(object *shockwave_objp, float frametime)
 	if (wip && wip->shockwave.radius_curve_idx >= 0) {
 		float val = Curves[wip->shockwave.radius_curve_idx].GetValue(sw->time_elapsed / sw->total_time);
 		sw->radius = val * sw->outer_radius;
+		if (sw->radius < 0.0f)
+			sw->radius = 0.0f;
 	} else {
 		sw->radius += (frametime * sw->speed);
 		CLAMP(sw->radius, 0.0f, sw->outer_radius);

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -75,11 +75,12 @@ typedef struct shockwave_create_info {
 	char name[MAX_FILENAME_LEN];
 	char pof_name[MAX_FILENAME_LEN];
 
-	float inner_rad;
-	float outer_rad;
+	float inner_rad;		// max damage out to this distance
+	float outer_rad;		// 0 damage at this distance or more, outer_rad / speed is total time
 	float damage;
 	float blast;
 	float speed;
+	int radius_curve_idx;   // curve for shockwave radius over time
 	angles rot_angles;
 	bool rot_defined;		// if the modder specified rot_angles
 	bool damage_overidden;  // did this have shockwave damage specifically set or not

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -228,6 +228,7 @@ typedef struct beam_weapon_info {
 	generic_anim beam_glow;				// muzzle glow bitmap
 	float glow_length;					// (DahBlount) determines the length the muzzle glow when using a directional glow
 	bool directional_glow;				// (DahBlount) makes the muzzle glow render to a poly that is oriented along the direction of fire
+	int beam_alpha_curve_idx;			// alpha multiplier over the lifetime of the beam
 	int beam_shots;						// # of shots the beam takes
 	float beam_shrink_factor;			// what percentage of total beam lifetime when the beam starts shrinking
 	float beam_shrink_pct;				// what percent/second the beam shrinks at
@@ -340,10 +341,13 @@ struct weapon_info
 	float laser_headon_switch_ang;			// at what angle
 
 	float laser_length;
+	int laser_length_curve_idx;				// length over time curve
 	color	laser_color_1;						// for cycling between glow colors
 	color	laser_color_2;						// for cycling between glow colors
 	float	laser_head_radius, laser_tail_radius;
+	int	laser_radius_curve_idx;				// tail + head radius over time curve
 	float	collision_radius_override;          // overrides the radius for the purposes of collision
+	int laser_alpha_curve_idx;			// alpha over time curve
 
 	bool 		light_color_set;
 	hdr_color 	light_color;		//For the light cast by the projectile
@@ -362,6 +366,7 @@ struct weapon_info
 
 	float	damage;								//	damage of weapon (for missile, damage within inner radius)
 	float	damage_time;						// point in the lifetime of the weapon at which damage starts to attenuate. This applies to non-beam primaries. (DahBlount)
+	int   damage_curve_idx;					// damage over time curve
 	float	atten_damage;							// The damage to attenuate to. (DahBlount)
 	float	damage_incidence_max;				// dmg multipler when weapon hits dead-on (perpindicular)
 	float	damage_incidence_min;				// dmg multipler when weapon hits glancing (parallel)
@@ -382,14 +387,14 @@ struct weapon_info
 
 	float life_min;
 	float life_max;
-	float max_lifetime ;						// How long this weapon will actually live for
-	float	lifetime;						// How long the AI thinks this thing lives (used for distance calculations etc)
+	float	lifetime;						// How long this weapon will live for
 
 	float energy_consumed;					// Energy used up when weapon is fired
 
 	flagset<Weapon::Info_Flags>	wi_flags;							//	bit flags defining behavior, see WIF_xxxx
 
 	float turn_time;
+	int turn_rate_curve_idx;					// turn rate over time curve
 	float turn_accel_time;
 	float	cargo_size;							// cargo space taken up by individual weapon (missiles only)
 	float autoaim_fov;							// the weapon specific auto-aim field of view

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8765,7 +8765,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 				}
 
 				if (wip->wi_flags[Weapon::Info_Flags::Transparent])
-					alphaf = wp->alpha_current * 255.0f;
+					alphaf = wp->alpha_current;
 				if (wip->laser_alpha_curve_idx >= 0)
 					alphaf *= Curves[wip->laser_alpha_curve_idx].GetValue(time);
 				CLAMP(alphaf, 0.0f, 1.0f);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -27,6 +27,7 @@
 #include "iff_defs/iff_defs.h"
 #include "io/joy_ff.h"
 #include "io/timer.h"
+#include "math/curve.h"
 #include "math/staticrand.h"
 #include "missionui/missionweaponchoice.h"
 #include "mod_table/mod_table.h"
@@ -770,33 +771,33 @@ void parse_wi_flags(weapon_info *weaponp)
 
 void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 {
-	char buf[NAME_LENGTH];
+	SCP_string buf;
 
 	sprintf(buf, "%sShockwave damage:", pre_char);
-	if(optional_string(buf)) {
+	if(optional_string(buf.c_str())) {
 		stuff_float(&sci->damage);
 		sci->damage_overidden = true;
 	}
 
 	sprintf(buf, "%sShockwave damage type:", pre_char);
-	if(optional_string(buf)) {
-		stuff_string(buf, F_NAME, NAME_LENGTH);
-		sci->damage_type_idx_sav = damage_type_add(buf);
+	if(optional_string(buf.c_str())) {
+		stuff_string(buf, F_NAME);
+		sci->damage_type_idx_sav = damage_type_add(buf.c_str());
 		sci->damage_type_idx = sci->damage_type_idx_sav;
 	}
 
 	sprintf(buf, "%sBlast Force:", pre_char);
-	if(optional_string(buf)) {
+	if(optional_string(buf.c_str())) {
 		stuff_float(&sci->blast);
 	}
 
 	sprintf(buf, "%sInner Radius:", pre_char);
-	if(optional_string(buf)) {
+	if(optional_string(buf.c_str())) {
 		stuff_float(&sci->inner_rad);
 	}
 
 	sprintf(buf, "%sOuter Radius:", pre_char);
-	if(optional_string(buf)) {
+	if(optional_string(buf.c_str())) {
 		stuff_float(&sci->outer_rad);
 	}
 
@@ -805,13 +806,22 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 		sci->outer_rad = sci->inner_rad;
 	}
 
+	sprintf(buf, "%sShockwave Radius Multiplier over Lifetime Curve:", pre_char);
+	if (optional_string(buf.c_str())) {
+		SCP_string curve_name;
+		stuff_string(curve_name, F_NAME);
+		sci->radius_curve_idx = curve_get_by_name(curve_name);
+		if (sci->radius_curve_idx < 0)
+			Warning(LOCATION, "Unrecognized shockwave radius curve '%s'", curve_name.c_str());
+	}
+
 	sprintf(buf, "%sShockwave Speed:", pre_char);
-	if(optional_string(buf)) {
+	if(optional_string(buf.c_str())) {
 		stuff_float(&sci->speed);
 	}
 
 	sprintf(buf, "%sShockwave Rotation:", pre_char);
-	if(optional_string(buf)) {
+	if(optional_string(buf.c_str())) {
 		float angs[3];
 		stuff_float_list(angs, 3);
 		for(int i = 0; i < 3; i++)
@@ -834,17 +844,17 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 	}
 
 	sprintf(buf, "%sShockwave Model:", pre_char);
-	if(optional_string(buf)) {
+	if(optional_string(buf.c_str())) {
 		stuff_string(sci->pof_name, F_NAME, MAX_FILENAME_LEN);
 	}
 
 	sprintf(buf, "%sShockwave Name:", pre_char);
-	if(optional_string(buf)) {
+	if(optional_string(buf.c_str())) {
 		stuff_string(sci->name, F_NAME, MAX_FILENAME_LEN);
 	}
 
 	sprintf(buf, "%sShockwave Sound:", pre_char);
-	parse_game_sound(buf, &sci->blast_sound_id);
+	parse_game_sound(buf.c_str(), &sci->blast_sound_id);
 }
 
 static SCP_vector<SCP_string> Removed_weapons;
@@ -1212,6 +1222,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if(optional_string("@Laser Length:")) {
 		stuff_float(&wip->laser_length);
 	}
+
+	if (optional_string("@Laser Length Multiplier over Lifetime Curve:")) {
+		SCP_string curve_name;
+		stuff_string(curve_name, F_NAME);
+		wip->laser_length_curve_idx = curve_get_by_name(curve_name);
+		if (wip->laser_length_curve_idx < 0)
+			Warning(LOCATION, "Unrecognized laser length curve '%s' for weapon %s", curve_name.c_str(), wip->name);
+	}
 	
 	if(optional_string("@Laser Head Radius:")) {
 		stuff_float(&wip->laser_head_radius);
@@ -1219,6 +1237,22 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 	if(optional_string("@Laser Tail Radius:")) {
 		stuff_float(&wip->laser_tail_radius );
+	}
+
+	if (optional_string("@Laser Radius Multiplier over Lifetime Curve:")) {
+		SCP_string curve_name;
+		stuff_string(curve_name, F_NAME);
+		wip->laser_radius_curve_idx = curve_get_by_name(curve_name);
+		if (wip->laser_radius_curve_idx < 0)
+			Warning(LOCATION, "Unrecognized laser radius curve '%s' for weapon %s", curve_name.c_str(), wip->name);
+	}
+
+	if (optional_string("@Laser Opacity over Lifetime Curve:")) {
+		SCP_string curve_name;
+		stuff_string(curve_name, F_NAME);
+		wip->laser_alpha_curve_idx = curve_get_by_name(curve_name);
+		if (wip->laser_alpha_curve_idx < 0)
+			Warning(LOCATION, "Unrecognized laser alpha curve '%s' for weapon %s", curve_name.c_str(), wip->name);
 	}
 
 	if (parse_optional_color3i_into("$Light color:", &wip->light_color)) {
@@ -1297,6 +1331,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		if (optional_string("+Max:")) {
 			stuff_float(&wip->damage_incidence_max);
 		}
+	}
+
+	if (optional_string("$Damage Multiplier over Lifetime Curve:")) {
+		SCP_string curve_name;
+		stuff_string(curve_name, F_NAME);
+		wip->damage_curve_idx = curve_get_by_name(curve_name);
+		if (wip->damage_curve_idx < 0)
+			Warning(LOCATION, "Unrecognized damage curve '%s' for weapon %s", curve_name.c_str(), wip->name);
 	}
 	
 	if(optional_string("$Damage Type:")) {
@@ -1494,6 +1536,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 				}
 			}
 
+			if (optional_string("+Turn Rate Multiplier over Lifetime Curve:")) {
+				SCP_string curve_name;
+				stuff_string(curve_name, F_NAME);
+				wip->turn_rate_curve_idx = curve_get_by_name(curve_name);
+				if (wip->turn_rate_curve_idx < 0)
+					Warning(LOCATION, "Unrecognized turn rate curve '%s' for weapon %s", curve_name.c_str(), wip->name);
+			}
+
 			if(optional_string("+View Cone:")) {
 				stuff_float(&view_cone_angle);
 				wip->fov = cosf(fl_radians(view_cone_angle * 0.5f));
@@ -1545,6 +1595,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 					}
 					wip->turn_accel_time = 0.f;
 				}
+			}
+
+			if (optional_string("+Turn Rate Multiplier over Lifetime Curve:")) {
+				SCP_string curve_name;
+				stuff_string(curve_name, F_NAME);
+				wip->turn_rate_curve_idx = curve_get_by_name(curve_name);
+				if (wip->turn_rate_curve_idx < 0)
+					Warning(LOCATION, "Unrecognized turn rate curve '%s' for weapon %s", curve_name.c_str(), wip->name);
 			}
 
 			if(optional_string("+View Cone:")) {
@@ -1664,12 +1722,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 			if (optional_string("+Max Active Seekers:")) {
 				stuff_int(&wip->max_seeking);
-			}			
-
-			if (wip->is_locked_homing()) {
-				// locked homing missiles have a much longer lifespan than the AI think they do
-				wip->max_lifetime = wip->lifetime * LOCKED_HOMING_EXTENDED_LIFE_FACTOR; 
-			}
+			}		
 		}
 		else
 		{
@@ -2733,6 +2786,14 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		if (optional_string("+Directional Glow:")) {
 			stuff_float(&wip->b_info.glow_length);
 			wip->b_info.directional_glow = true;
+		}
+
+		if (optional_string("+Opacity over Lifetime Curve:")) {
+			SCP_string curve_name;
+			stuff_string(curve_name, F_NAME);
+			wip->b_info.beam_alpha_curve_idx = curve_get_by_name(curve_name);
+			if (wip->b_info.beam_alpha_curve_idx < 0)
+				Warning(LOCATION, "Unrecognized beam alpha curve '%s' for weapon %s", curve_name.c_str(), wip->name);
 		}
 
 		// # of shots (only used for type D beams)
@@ -4601,7 +4662,7 @@ MONITOR( NumWeaponsRend )
 const float weapon_glow_scale_f = 2.3f;
 const float weapon_glow_scale_r = 2.3f;
 const float weapon_glow_scale_l = 1.5f;
-const int weapon_glow_alpha = 217; // (0.85 * 255);
+const float weapon_glow_alpha = 0.85f;
 
 void weapon_delete(object *obj)
 {
@@ -5436,32 +5497,30 @@ void weapon_home(object *obj, int num, float frame_time)
 		} else
 			obj->phys_info.speed = max_speed;
 
-
+		float time_alive = f2fl(Missiontime - wp->creation_time);
 		if (wip->acceleration_time > 0.0f) {
 			// Ramp up speed linearly for the given duration
-			if (Missiontime - wp->creation_time < fl2f(wip->acceleration_time)) {
-				float t;
-
-				t = f2fl(Missiontime - wp->creation_time) / wip->acceleration_time;
-				obj->phys_info.speed = wp->launch_speed + MAX(0.0f, wp->weapon_max_vel - wp->launch_speed) * t;
+			if (time_alive < wip->acceleration_time) {
+				obj->phys_info.speed = wp->launch_speed + MAX(0.0f, wp->weapon_max_vel - wp->launch_speed) * (time_alive / wip->acceleration_time);
 			}
-		} else if (!(wip->wi_flags[Weapon::Info_Flags::No_homing_speed_ramp]) && Missiontime - wp->creation_time < i2f(1)) {
+		} else if (!(wip->wi_flags[Weapon::Info_Flags::No_homing_speed_ramp]) && time_alive < 1.0f) {
 			// Default behavior:
 			// For first second of weapon's life, it doesn't fly at top speed.  It ramps up.
-			float	t;
-
-			t = f2fl(Missiontime - wp->creation_time);
-			obj->phys_info.speed *= t*t;
+			obj->phys_info.speed *= time_alive * time_alive;
 		}
 
 		Assert( obj->phys_info.speed > 0.0f );
 
 		vm_vec_copy_scale( &obj->phys_info.desired_vel, &obj->orient.vec.fvec, obj->phys_info.speed);
 
+		vec3d turnrate_mod = vm_vec_new(1.0f, 1.0f, 1.0f);
+		if (wip->turn_rate_curve_idx >= 0)
+			turnrate_mod *= Curves[wip->turn_rate_curve_idx].GetValue(time_alive / wip->lifetime);
+
 		// turn the missile towards the target only if non-swarm.  Homing swarm missiles choose
 		// a different vector to turn towards, this is done in swarm_update_direction().
 		if ( wp->swarm_info_ptr == nullptr ) {
-			ai_turn_towards_vector(&target_pos, obj, nullptr, nullptr, 0.0f, 0, nullptr);
+			ai_turn_towards_vector(&target_pos, obj, nullptr, nullptr, 0.0f, 0, nullptr, &turnrate_mod);
 			vel = vm_vec_mag(&obj->phys_info.desired_vel);
 
 			vm_vec_copy_scale(&obj->phys_info.desired_vel, &obj->orient.vec.fvec, vel);
@@ -8671,12 +8730,24 @@ void weapon_render(object* obj, model_draw_list *scene)
 	{
 	case WRT_LASER:
 		{
-			if(wip->laser_length < 0.0001f)
-				return;
 
-			int alpha = 255;
+			float alphaf = 1.0f;
 			int framenum = 0;
 			int headon_framenum = 0;
+
+			float time = f2fl(Missiontime - wp->creation_time) / wip->lifetime;
+			float laser_length = wip->laser_length;
+			if (wip->laser_length_curve_idx >= 0)
+				laser_length *= Curves[wip->laser_length_curve_idx].GetValue(time);
+			float radius_mult = 1.0f;
+			if (wip->laser_radius_curve_idx >= 0) {
+				radius_mult = Curves[wip->laser_radius_curve_idx].GetValue(time);
+				if (radius_mult <= 0.0001f)
+					radius_mult = 0.0001f;
+			}
+
+			if (laser_length < 0.0001f)
+				return;
 
 			if (wip->laser_bitmap.first_frame >= 0) {					
 				gr_set_color_fast(&wip->laser_color_1);
@@ -8694,21 +8765,26 @@ void weapon_render(object* obj, model_draw_list *scene)
 				}
 
 				if (wip->wi_flags[Weapon::Info_Flags::Transparent])
-					alpha = fl2i(wp->alpha_current * 255.0f);
+					alphaf = wp->alpha_current * 255.0f;
+				if (wip->laser_alpha_curve_idx >= 0)
+					alphaf *= Curves[wip->laser_alpha_curve_idx].GetValue(time);
+				CLAMP(alphaf, 0.0f, 1.0f);
 
 				if (Neb_affects_weapons) {
 					float nebalpha = 1.0f;
 					if(nebula_handle_alpha(nebalpha, &obj->pos, Neb2_fog_visibility_weapon))
-						alpha = (int)(alpha * nebalpha);
+						alphaf *= nebalpha;
 				}
 
 				vec3d headp;
-				vm_vec_scale_add(&headp, &obj->pos, &obj->orient.vec.fvec, wip->laser_length);
+				vm_vec_scale_add(&headp, &obj->pos, &obj->orient.vec.fvec, laser_length);
 
 				// Scale the laser so that it always appears some configured amount of pixels wide, no matter the distance.
 				// Only affects width, length remains unchanged.
-				float scaled_head_radius = model_render_get_diameter_clamped_to_min_pixel_size(&headp, wip->laser_head_radius, Min_pixel_size_laser);
-				float scaled_tail_radius = model_render_get_diameter_clamped_to_min_pixel_size(&obj->pos, wip->laser_tail_radius, Min_pixel_size_laser);
+				float scaled_head_radius = model_render_get_diameter_clamped_to_min_pixel_size(&headp, wip->laser_head_radius * radius_mult, Min_pixel_size_laser);
+				float scaled_tail_radius = model_render_get_diameter_clamped_to_min_pixel_size(&obj->pos, wip->laser_tail_radius * radius_mult, Min_pixel_size_laser);
+
+				int alpha = static_cast<int>(alphaf * 255.0f);
 
 				// render the head-on bitmap if appropriate and maybe adjust the main bitmap's alpha
 				if (wip->laser_headon_bitmap.first_frame >= 0) {
@@ -8717,7 +8793,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 						scaled_head_radius,
 						scaled_tail_radius,
 						alpha, alpha, alpha);
-					alpha = (int)(alpha * main_bitmap_alpha_mult);
+					alpha = static_cast<int>(alphaf * main_bitmap_alpha_mult);
 				}
 
 				batching_add_laser(
@@ -8738,8 +8814,8 @@ void weapon_render(object* obj, model_draw_list *scene)
 				//  it caused uneven glow between the head and tail, which really shows in big lasers. So...fixed!    -Et1
 				vec3d headp2, tailp;
 
-				vm_vec_scale_add(&headp2, &obj->pos, &obj->orient.vec.fvec, wip->laser_length * weapon_glow_scale_l);
-				vm_vec_scale_add(&tailp, &obj->pos, &obj->orient.vec.fvec, wip->laser_length * (1 -  weapon_glow_scale_l) );
+				vm_vec_scale_add(&headp2, &obj->pos, &obj->orient.vec.fvec, laser_length * weapon_glow_scale_l);
+				vm_vec_scale_add(&tailp, &obj->pos, &obj->orient.vec.fvec, laser_length * (1 -  weapon_glow_scale_l) );
 
 				framenum = 0;
 
@@ -8778,29 +8854,28 @@ void weapon_render(object* obj, model_draw_list *scene)
 				}
 
 				if (wip->wi_flags[Weapon::Info_Flags::Transparent]) {
-					alpha = fl2i(wp->alpha_current * 255.0f);
-					alpha -= 38; // take 1.5f into account for the normal glow alpha
-
-					if (alpha < 0)
-						alpha = 0;
+					alphaf = wp->alpha_current * weapon_glow_alpha;
 				} else {
-					alpha = weapon_glow_alpha;
+					alphaf = weapon_glow_alpha;
 				}
+				if (wip->laser_alpha_curve_idx >= 0)
+					alphaf *= Curves[wip->laser_alpha_curve_idx].GetValue(time);
+				CLAMP(alphaf, 0.0f, 1.0f);
 
 				if (Neb_affects_weapons) {
 					float nebalpha = 1.0f;
 					if (nebula_handle_alpha(nebalpha, &obj->pos, Neb2_fog_visibility_weapon))
-						alpha = (int)(alpha * nebalpha);
+						alphaf *= nebalpha;
 				}
 
 				// Scale the laser so that it always appears some configured amount of pixels wide, no matter the distance.
 				// Only affects width, length remains unchanged.
-				float scaled_head_radius = model_render_get_diameter_clamped_to_min_pixel_size(&headp2, wip->laser_head_radius, Min_pixel_size_laser);
-				float scaled_tail_radius = model_render_get_diameter_clamped_to_min_pixel_size(&tailp, wip->laser_tail_radius, Min_pixel_size_laser);
+				float scaled_head_radius = model_render_get_diameter_clamped_to_min_pixel_size(&headp2, wip->laser_head_radius * radius_mult, Min_pixel_size_laser);
+				float scaled_tail_radius = model_render_get_diameter_clamped_to_min_pixel_size(&tailp, wip->laser_tail_radius * radius_mult, Min_pixel_size_laser);
 
-				int r = (c.red * alpha) / 255;
-				int g = (c.green * alpha) / 255;
-				int b = (c.blue * alpha) / 255;
+				int r = static_cast<int>(static_cast<float>(c.red) * alphaf);
+				int g = static_cast<int>(static_cast<float>(c.green) * alphaf);
+				int b = static_cast<int>(static_cast<float>(c.blue) * alphaf);
 
 				// render the head-on bitmap if appropriate and maybe adjust the main bitmap's alpha
 				if (wip->laser_glow_headon_bitmap.first_frame >= 0) {
@@ -8809,9 +8884,9 @@ void weapon_render(object* obj, model_draw_list *scene)
 						scaled_head_radius * weapon_glow_scale_f,
 						scaled_tail_radius * weapon_glow_scale_r,
 						r, g, b);
-					r = (int)(r * main_bitmap_alpha_mult);
-					g = (int)(g * main_bitmap_alpha_mult);
-					b = (int)(b * main_bitmap_alpha_mult);
+					r = static_cast<int>(static_cast<float>(c.red) * alphaf * main_bitmap_alpha_mult);
+					g = static_cast<int>(static_cast<float>(c.green) * alphaf * main_bitmap_alpha_mult);
+					b = static_cast<int>(static_cast<float>(c.blue) * alphaf * main_bitmap_alpha_mult);
 				}
 
 				batching_add_laser(
@@ -9012,10 +9087,13 @@ void weapon_info::reset()
 	this->laser_headon_switch_ang = -1.0f;
 	this->laser_headon_switch_rate = 2.0f;
 	this->laser_length = 10.0f;
+	this->laser_length_curve_idx = -1;
 	gr_init_color(&this->laser_color_1, 255, 255, 255);
 	gr_init_color(&this->laser_color_2, 255, 255, 255);
 	this->laser_head_radius = 1.0f;
 	this->laser_tail_radius = 1.0f;
+	this->laser_radius_curve_idx = -1;
+	this->laser_alpha_curve_idx = -1;
 
 	this->light_color_set = false;
 	this->light_color.reset();
@@ -9038,6 +9116,7 @@ void weapon_info::reset()
 	this->atten_damage = -1.0f;
 	this->damage_incidence_max = 1.0f;
 	this->damage_incidence_min = 1.0f;
+	this->damage_curve_idx = -1;
 
 	shockwave_create_info_init(&this->shockwave);
 	shockwave_create_info_init(&this->dinky_shockwave);
@@ -9058,7 +9137,6 @@ void weapon_info::reset()
 
 	this->life_min = -1.0f;
 	this->life_max = -1.0f;
-	this->max_lifetime = 1.0f;
 	this->lifetime = 1.0f;
 
 	this->energy_consumed = 0.0f;
@@ -9067,6 +9145,7 @@ void weapon_info::reset()
 
 	this->turn_time = 1.0f;
 	this->turn_accel_time = 0.f;
+	this->turn_rate_curve_idx = -1;
 	this->cargo_size = 1.0f;
 	this->autoaim_fov = 0.0f;
 	this->rearm_rate = 1.0f;
@@ -9224,6 +9303,7 @@ void weapon_info::reset()
 	this->b_info.beam_num_sections = 0;
 	this->b_info.glow_length = 0;
 	this->b_info.directional_glow = false;
+	this->b_info.beam_alpha_curve_idx = -1;
 	this->b_info.beam_shots = 1;
 	this->b_info.beam_shrink_factor = 0.0f;
 	this->b_info.beam_shrink_pct = 0.0f;


### PR DESCRIPTION
For #5365, adds laser length radius and alpha over time, damage over time, beam alpha over time, homing turn rate over time and shockwave radius over time.

Also removes vestigal `max_lifetime` from weapons.