### PR TITLE
Fix Coverity buffer not null terminated issues

### DIFF
--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -952,10 +952,11 @@ void debrief_choose_voice(char *voice_dest, size_t buf_size, char *voice_base, i
 void debrief_choose_medal_variant(char *buf, int medal_earned, int zero_based_version_index)
 {
 	Assert(buf != NULL && medal_earned >= 0 && zero_based_version_index >= 0);
+	Assertion(strlen(Resolution_prefixes[gr_screen.res]) + strlen(Medals[medal_earned].debrief_bitmap) < MAX_FILENAME_LEN, "The filename for %s is over the filename length limit of 31 characters.  On release builds, this filename will be shortened and will not work.", buf);
 
 	// start with the regular file name, adapted for resolution
-	sprintf(buf, NOX("%s%s"), Resolution_prefixes[gr_screen.res], Medals[medal_earned].debrief_bitmap);
-
+	snprintf(buf, MAX_FILENAME_LEN, NOX("%s%s"), Resolution_prefixes[gr_screen.res], Medals[medal_earned].debrief_bitmap);
+	
 	// if the medal has multiple versions, we may want to choose a specific bitmap
 	char *p = strstr(buf, "##");
 	if (p != NULL)
@@ -975,6 +976,7 @@ void debrief_choose_medal_variant(char *buf, int medal_earned, int zero_based_ve
 
 		sprintf(number, NOX("%.2d"), version);
 		Assert(strlen(number) == 2);
+		// coverity 1522943: Covscan thinks p is not null terminated, but buf, the string that it points to *is* null terminated.
 		strncpy(p, number, 2);
 	}
 }

--- a/code/model/modelanimation.cpp
+++ b/code/model/modelanimation.cpp
@@ -1182,7 +1182,8 @@ namespace animation {
 
 	SCP_string anim_name_from_subsys(model_subsystem* ss) {
 		char namelower[MAX_NAME_LEN];
-		strncpy(namelower, ss->subobj_name, MAX_NAME_LEN);
+		strncpy(namelower, ss->subobj_name, MAX_NAME_LEN - 1);
+		namelower[MAX_NAME_LEN - 1] = '\0';
 		strlwr(namelower);
 		return namelower;
 	}
@@ -1535,7 +1536,9 @@ namespace animation {
 			auto anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(true));
 
 			char namelower[MAX_NAME_LEN];
-			strncpy(namelower, sp->subobj_name, MAX_NAME_LEN);
+			// Double Check that this string is null terminated since strncpy does not explicitly null terminate Cov 1523269
+			strncpy(namelower, sp->subobj_name, MAX_NAME_LEN - 1);
+			namelower[MAX_NAME_LEN - 1] = '\0';
 			strlwr(namelower);
 			//since sp->type is not set without reading the pof, we need to infer it by subsystem name (which works, since the same name is used to match the submodels name, which is used to match the type in pof parsing)
 			//sadly, we also need to check for engine and radar, since these take precedent (as in, an engineturret is an engine before a turret type)


### PR DESCRIPTION
This should fix the outstanding buffer not null terminated issues on coverity.  If there is a better option, especially for the two places that add assertions, please let me know, as c-strings are not my strongest suit.