### PR TITLE
Fix #5759 Sticky Support Ship

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12809,18 +12809,19 @@ void ai_do_repair_frame(object *objp, ai_info *aip, float frametime)
 
 				//	See if fully repaired.  If so, cause process to stop.
 				if ( repaired ) {
-
 					// We can repair ships without being docked, so only do this if we are docked
 					if (repair_aip->submode == AIS_DOCK_4) {
 						repair_aip->submode = AIS_UNDOCK_0;
-					} else { // Undocking ends the repair, but since we don't need to do that in this case, end it here
+						repair_aip->submode_start_time = Missiontime;
+						// if repairing player object -- tell him done with repair
+						if (!MULTIPLAYER_CLIENT) {
+							ai_do_objects_repairing_stuff(objp, &Objects[support_objnum], REPAIR_INFO_COMPLETE);
+						}
+					} 
+					//If Repairing self
+					else if (&Objects[support_objnum] == objp) { // Undocking ends the repair,
+														// but since we don'tneed to do that in this case, end it here
 						ai_do_objects_repairing_stuff(objp, &Objects[support_objnum], REPAIR_INFO_END);
-					}
-					repair_aip->submode_start_time = Missiontime;
-
-					// if repairing player object -- tell him done with repair
-					if ( !MULTIPLAYER_CLIENT ) {
-						ai_do_objects_repairing_stuff( objp, &Objects[support_objnum], REPAIR_INFO_COMPLETE );
 					}
 				}
 			}

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12822,6 +12822,9 @@ void ai_do_repair_frame(object *objp, ai_info *aip, float frametime)
 					else if (&Objects[support_objnum] == objp) { // Undocking ends the repair,
 														// but since we don'tneed to do that in this case, end it here
 						ai_do_objects_repairing_stuff(objp, &Objects[support_objnum], REPAIR_INFO_END);
+						if (!MULTIPLAYER_CLIENT) {
+							hud_support_view_stop();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fix #5759 by making sure the code is only run once on undock and add extra check to make sure that the ending code is only run if doing a force repair.