### PR TITLE
Command fixes and tweaks

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -1844,7 +1844,10 @@ void message_queue_message( int message_num, int priority, int timing, const cha
 		// of the wave and head
 		// ADDENDUM -- Since the special hack is specifically for mission-unique messages, don't
 		// convert built-in messages to Command
-		if ( builtin_type < 0 && !stricmp(who_from, The_mission.command_sender) ) {
+		if ( builtin_type < 0
+			&& (!stricmp(who_from, The_mission.command_sender)
+				|| (The_mission.flags[Mission::Mission_Flags::Override_hashcommand] && !stricmp(who_from, DEFAULT_COMMAND))
+				) ) {
 			// ADDENDUM 2 -- perform an additional check: only convert this message if a WAV exists for it
 			auto m = &Messages[message_num];
 			if (m->wave_info.index >= 0) {

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -54,6 +54,7 @@ extern SCP_vector<message_extra> Message_waves;
 
 // define used for sender of a message when you want it to be Terran Command
 #define DEFAULT_COMMAND			"Command"
+#define DEFAULT_HASHCOMMAND		"#" DEFAULT_COMMAND
 
 extern SCP_vector<SCP_string> Builtin_moods;
 extern int Current_mission_mood;


### PR DESCRIPTION
In a few places where the game checks for the command sender, it should check for #Command as well, as long as the mission flag to override #Command is present.

Additionally, while the mission's command sender was originally intended to be a ship, it has been used to specify an alternative to #Command as well.  But this caused problems when the "override #Command" mission flag was active, as it transformed a hashed source into a non-hashed source.  So this commit adds a check to treat the source as hashed, if necessary, if a replacement has occurred.

Fixes #5749.