### PR TITLE
optimization for checking whether subsystems are blown

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1316,7 +1316,7 @@ void ai_turn_towards_vector(const vec3d* dest, object* objp, const vec3d* slide_
 	//	Don't allow a ship to turn if it has no engine strength.
 	// AL 3-12-98: objp may not always be a ship!
 	if ( (objp->type == OBJ_SHIP) && !(flags & AITTV_VIA_SEXP) ) {
-		if (!Ships[objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_get_subsystem_strength(&Ships[objp->instance], SUBSYSTEM_ENGINE) <= 0.0f)
+		if (!Ships[objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_subsystems_blown(&Ships[objp->instance], SUBSYSTEM_ENGINE))
 			return;
 	}
 
@@ -2567,7 +2567,7 @@ void ai_attack_object(object* attacker, object* attacked, int ship_info_index)
 	}
 
 	// don't abort a support call if you're disabled!
-	if (ship_get_subsystem_strength(&Ships[attacker->instance], SUBSYSTEM_ENGINE) > 0.0f) 
+	if (!ship_subsystems_blown(&Ships[attacker->instance], SUBSYSTEM_ENGINE)) 
 		ai_set_goal_abort_support_call(attacker, aip);
 
 	aip->ok_to_target_timestamp = timestamp(DELAY_TARGET_TIME);	//	No dynamic targeting for 7 seconds.
@@ -6152,7 +6152,7 @@ int ai_fire_primary_weapon(object *objp)
 				int	type;
 
 				type = aip->targeted_subsys->system_info->type;
-				if (ship_get_subsystem_strength(&Ships[tobjp->instance], type) == 0.0f) {
+				if (ship_subsystems_blown(&Ships[tobjp->instance], type)) {
 					aip->target_objnum = -1;
 					return 0;
 				}
@@ -9708,7 +9708,7 @@ float dock_orient_and_approach(object *docker_objp, int docker_index, object *do
 
 	// Goober5000 - moved out here to save calculations
 	if (dock_mode != DOA_DOCK_STAY)
-		if (!Ships[docker_objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_get_subsystem_strength(&Ships[docker_objp->instance], SUBSYSTEM_ENGINE) <= 0.0f)
+		if (!Ships[docker_objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_subsystems_blown(&Ships[docker_objp->instance], SUBSYSTEM_ENGINE))
 			return 9999.9f;
 
 	//	If dockee has moved much, then path will be recreated.
@@ -12031,7 +12031,7 @@ void ai_process_subobjects(int objnum)
 	}
 
 	//	Deal with a ship with blown out engines.
-	if (ship_get_subsystem_strength(shipp, SUBSYSTEM_ENGINE) == 0.0f) {
+	if (ship_subsystems_blown(shipp, SUBSYSTEM_ENGINE)) {
 		// Karajorma - if Player_use_ai is ever fixed to work on multiplayer it should be checked that any player ships 
 		// aren't under AI control here
 		if ((!(objp->flags[Object::Object_Flags::Player_ship])) && (sip->is_fighter_bomber()) && !(shipp->flags[Ship::Ship_Flags::Dying])) {
@@ -12095,7 +12095,7 @@ object *get_wing_leader(int wingnum)
 
 	//	If this ship is disabled, try another ship in the wing.
 	int n = 0;
-	while (!Ships[ship_num].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_get_subsystem_strength(&Ships[ship_num], SUBSYSTEM_ENGINE) == 0.0f) {
+	while (!Ships[ship_num].flags[Ship::Ship_Flags::Maneuver_despite_engines] && ship_subsystems_blown(&Ships[ship_num], SUBSYSTEM_ENGINE)) {
 		n++;
 
 		if (n >= wingp->current_count) {
@@ -14186,7 +14186,7 @@ void ai_maybe_depart(object *objp)
 	if (!shipp->is_departing()) {
 		if (sip->is_fighter_bomber()) {
 			if (aip->warp_out_timestamp == 0) {
-				//if (ship_get_subsystem_strength(shipp, SUBSYSTEM_WEAPONS) == 0.0f) {
+				//if (ship_subsystems_blown(shipp, SUBSYSTEM_WEAPONS)) {
 				//	aip->warp_out_timestamp = timestamp(Random::next(10, 19) * 1000);
 				//}
 			} else if (timestamp_elapsed(aip->warp_out_timestamp)) {
@@ -14666,8 +14666,8 @@ void ai_maybe_self_destruct(object *objp, ai_info *aip)
 	//	mission would be broken.
 	//	Also, don't blow up the ship if it has a ship flag preventing this - Goober5000
 	if ((Ship_info[shipp->ship_info_index].is_small_ship()) && (shipp->wingnum >= 0) && !(shipp->flags[Ship::Ship_Flags::No_disabled_self_destruct])) {
-		if ((ship_get_subsystem_strength(shipp, SUBSYSTEM_ENGINE) <= 0.0f) ||
-			(ship_get_subsystem_strength(shipp, SUBSYSTEM_WEAPONS) <= 0.0f)) {
+		if ((ship_subsystems_blown(shipp, SUBSYSTEM_ENGINE)) ||
+			(ship_subsystems_blown(shipp, SUBSYSTEM_WEAPONS))) {
 			if (aip->self_destruct_timestamp < 0)
 				aip->self_destruct_timestamp = timestamp(90 * 1000);	//	seconds until self-destruct
 		} else {

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -786,7 +786,7 @@ int get_nearest_turret_objnum(int turret_parent_objnum, ship_subsys *turret_subs
 	//	weapon_travel_dist=wip->lssm_lock_range;
 
 	// Set flag based on strength of weapons subsystem.  If weapons subsystem is destroyed, don't let turrets fire at bombs
-	bool weapon_system_ok = (ship_get_subsystem_strength(&Ships[Objects[turret_parent_objnum].instance], SUBSYSTEM_WEAPONS) > 0);
+	bool weapon_system_ok = !ship_subsystems_blown(&Ships[Objects[turret_parent_objnum].instance], SUBSYSTEM_WEAPONS);
 
 	// Initialize eeo struct.
 	eeo.turret_parent_objnum = turret_parent_objnum;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -863,12 +863,12 @@ void obj_move_call_physics(object *objp, float frametime)
 			ship *shipp = &Ships[objp->instance];
 
 			if (!shipp->flags[Ship::Ship_Flags::Maneuver_despite_engines]) {
-				float engine_strength = ship_get_subsystem_strength(shipp, SUBSYSTEM_ENGINE);
+				bool engines_blown = ship_subsystems_blown(shipp, SUBSYSTEM_ENGINE);
 				if ( ship_subsys_disrupted(shipp, SUBSYSTEM_ENGINE) ) {
-					engine_strength=0.0f;
+					engines_blown = true;
 				}
 
-				if (engine_strength == 0.0f) {	//	All this is necessary to make ship gradually come to a stop after engines are blown.
+				if (engines_blown) {	//	All this is necessary to make ship gradually come to a stop after engines are blown.
 					vm_vec_zero(&objp->phys_info.desired_vel);
 					vm_vec_zero(&objp->phys_info.desired_rotvel);
 					vm_mat_zero(&objp->phys_info.ai_desired_orient);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -841,7 +841,7 @@ void obj_player_fire_stuff( object *objp, control_info ci )
 
 	// everyone does the following for their own ships.
 	if ( ci.afterburner_start ){
-		if (Ships[objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] || ship_get_subsystem_strength(&Ships[objp->instance], SUBSYSTEM_ENGINE) > 0.0f) {
+		if (Ships[objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] || !ship_subsystems_blown(&Ships[objp->instance], SUBSYSTEM_ENGINE)) {
 			afterburners_start( objp );
 		}
 	}
@@ -951,7 +951,7 @@ void obj_move_call_physics(object *objp, float frametime)
 				if (/* (objnum_I_am_docked_or_docking_with != -1) || */
 					((aip->mode == AIM_DOCK) && ((aip->submode == AIS_DOCK_2) || (aip->submode == AIS_DOCK_3) || (aip->submode == AIS_UNDOCK_0))) ||
 					((aip->mode == AIM_WARP_OUT) && (aip->submode >= AIS_WARP_3))) {
-					if (Ships[objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] || ship_get_subsystem_strength(&Ships[objp->instance], SUBSYSTEM_ENGINE) > 0.0f){
+					if (Ships[objp->instance].flags[Ship::Ship_Flags::Maneuver_despite_engines] || !ship_subsystems_blown(&Ships[objp->instance], SUBSYSTEM_ENGINE)){
 						objp->phys_info.flags |= PF_USE_VEL;
 					} else {
 						objp->phys_info.flags &= ~PF_USE_VEL;	//	If engine blown, don't PF_USE_VEL, or ships stop immediately

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14812,7 +14812,7 @@ int ship_find_subsys(ship *sp, const char *ss_name)
 // an optimization of the below function that skips the subsystem iteration if we don't care about the exact number
 bool ship_subsystems_blown(const ship* shipp, int type, bool skip_dying_check)
 {
-	Assert ( (type >= 0) && (type < SUBSYSTEM_MAX) );
+	Assertion( (type >= 0) && (type < SUBSYSTEM_MAX), "ship_subsystems_blown() subsystem type %d is out of range!", type );
 
 	//	For a dying ship, all subsystem strengths are zero.
 	if (Objects[shipp->objnum].hull_strength <= 0.0f && !skip_dying_check)
@@ -14839,7 +14839,7 @@ float ship_get_subsystem_strength(const ship *shipp, int type, bool skip_dying_c
 	float strength;
 	ship_subsys *ssp;
 
-	Assert ( (type >= 0) && (type < SUBSYSTEM_MAX) );
+	Assertion( (type >= 0) && (type < SUBSYSTEM_MAX), "ship_get_subsystem_strength() subsystem type %d is out of range!", type );
 
 	//	For a dying ship, all subsystem strengths are zero.
 	if (Objects[shipp->objnum].hull_strength <= 0.0f && !skip_dying_check)

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1778,7 +1778,8 @@ extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns ind
 extern int ship_find_subsys(ship *sp, const char *ss_name);		// returns numerical index in linked list of subsystems
 extern int ship_get_subsys_index(ship_subsys *subsys);
 
-extern float ship_get_subsystem_strength( ship *shipp, int type, bool skip_dying_check = false, bool no_minimum_engine_str = false);
+extern bool ship_subsystems_blown(const ship *shipp, int type, bool skip_dying_check = false);
+extern float ship_get_subsystem_strength(const ship *shipp, int type, bool skip_dying_check = false, bool no_minimum_engine_str = false);
 extern ship_subsys *ship_get_subsys(const ship *shipp, const char *subsys_name);
 extern int ship_get_num_subsys(ship *shipp);
 extern ship_subsys *ship_get_closest_subsys_in_sight(ship *sp, int subsys_type, vec3d *attacker_pos);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2702,7 +2702,7 @@ void engine_wash_ship_process(ship *shipp)
 		float ship_intensity = 0;
 
 		// if engines disabled, no engine wash
-		if (ship_get_subsystem_strength(wash_shipp, SUBSYSTEM_ENGINE) < 0.01) {
+		if (ship_subsystems_blown(wash_shipp, SUBSYSTEM_ENGINE)) {
 			continue;
 		}
 


### PR DESCRIPTION
In many calls to `ship_get_subsystem_strength`, the caller doesn't care about the actual number, just whether the subsystem type is destroyed.  So this adds an optimization to check specifically for that.  In the case of `SUBSYSTEM_ENGINE`, this avoids an iteration over every subsystem on the ship which, for a ship with many turrets, can be significant.