### PR TITLE
protect model_collide input values

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1332,10 +1332,9 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 		mc.flags = (MC_CHECK_MODEL | MC_CHECK_SPHERELINE);
 
 		// copy important data
-		int copy_flags = mc.flags;  // make a copy of start end positions of sphere in  big ship RF
-		vec3d copy_p0, copy_p1;
-		copy_p0 = *mc.p0;
-		copy_p1 = *mc.p1;
+		int orig_flags = mc.flags;  // make a copy of start end positions of sphere in big ship RF
+		auto orig_p0 = mc.p0;
+		auto orig_p1 = mc.p1;
 
 		// first test against the sphere - if this fails then don't do any submodel tests
 		mc.flags = MC_ONLY_SPHERE | MC_CHECK_SPHERELINE;
@@ -1361,7 +1360,7 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 				}
 
 				// Only check single submodel now, since children of moving submodels are handled as moving as well
-				mc.flags = copy_flags | MC_SUBMODEL;
+				mc.flags = orig_flags | MC_SUBMODEL;
 
 				// check each submodel in turn
 				for (auto submodel: submodel_vector) {
@@ -1406,9 +1405,9 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 			}
 
 			// Now complete base model collision checks that do not take into account rotating submodels.
-			mc.flags = copy_flags;
-			*mc.p0 = copy_p0;
-			*mc.p1 = copy_p1;
+			mc.flags = orig_flags;
+			mc.p0 = orig_p0;
+			mc.p1 = orig_p1;
 			mc.orient = &heavy_obj->orient;
 
 			// usual ship_ship collision test

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -926,10 +926,9 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		mc.flags = (MC_CHECK_MODEL | MC_CHECK_SPHERELINE);
 
 		// copy important data
-		int copy_flags = mc.flags;  // make a copy of start end positions of sphere in  big ship RF
-		vec3d copy_p0, copy_p1;
-		copy_p0 = *mc.p0;
-		copy_p1 = *mc.p1;
+		int orig_flags = mc.flags;  // make a copy of start end positions of sphere in big ship RF
+		auto orig_p0 = mc.p0;
+		auto orig_p1 = mc.p1;
 
 		// first test against the sphere - if this fails then don't do any submodel tests
 		mc.flags = MC_ONLY_SPHERE | MC_CHECK_SPHERELINE;
@@ -955,7 +954,7 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 				}
 
 				// Only check single submodel now, since children of moving submodels are handled as moving as well
-				mc.flags = copy_flags | MC_SUBMODEL;
+				mc.flags = orig_flags | MC_SUBMODEL;
 
 				if (Ship_info[Ships[pship_obj->instance].ship_info_index].collision_lod > -1) {
 					mc.lod = Ship_info[Ships[pship_obj->instance].ship_info_index].collision_lod;
@@ -1005,9 +1004,9 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 			}
 
 			// Now complete base model collision checks that do not take into account rotating submodels.
-			mc.flags = copy_flags;
-			*mc.p0 = copy_p0;
-			*mc.p1 = copy_p1;
+			mc.flags = orig_flags;
+			mc.p0 = orig_p0;
+			mc.p1 = orig_p1;
 			mc.orient = &heavy_obj->orient;
 
 			// usual ship_ship collision test

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1233,10 +1233,10 @@ typedef struct mc_info {
 	int     model_instance_num = -1;
 	int     model_num = -1;             // What model to check
 	int     submodel_num = -1;          // What submodel to check if MC_SUBMODEL is set
-	matrix  *orient = nullptr;          // The orient of the model
-	vec3d   *pos = nullptr;             // The pos of the model in world coordinates
-	vec3d   *p0 = nullptr;              // The starting point of the ray (sphere) to check
-	vec3d   *p1 = nullptr;              // The ending point of the ray (sphere) to check
+	const matrix  *orient = nullptr;        // The orient of the model
+	const vec3d   *pos = nullptr;           // The pos of the model in world coordinates
+	const vec3d   *p0 = nullptr;            // The starting point of the ray (sphere) to check
+	const vec3d   *p1 = nullptr;            // The ending point of the ray (sphere) to check
 	int     flags = 0;                  // Flags that the model_collide code looks at.  See MC_??? defines
 	float   radius = 0;                 // If MC_CHECK_THICK is set, checks a sphere moving with the radius.
 	int     lod = 0;                    // Which detail level of the submodel to check instead

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -226,10 +226,9 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 	}
 	
 	// copy important data
-	int copy_flags = mc.flags;  // make a copy of start end positions of sphere in  big ship RF
-	vec3d copy_p0, copy_p1;
-	copy_p0 = *mc.p0;
-	copy_p1 = *mc.p1;
+	int orig_flags = mc.flags;  // make a copy of start end positions of sphere in big ship RF
+	auto orig_p0 = mc.p0;
+	auto orig_p1 = mc.p1;
 
 	// first test against the sphere - if this fails then don't do any submodel tests
 	mc.flags = MC_ONLY_SPHERE | MC_CHECK_SPHERELINE;
@@ -264,7 +263,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 			}
 
 			// Only check single submodel now, since children of moving submodels are handled as moving as well
-			mc.flags = copy_flags | MC_SUBMODEL;
+			mc.flags = orig_flags | MC_SUBMODEL;
 
 			if (heavy_sip->collision_lod > -1) {
 				mc.lod = heavy_sip->collision_lod;
@@ -318,9 +317,9 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 		}
 
 		// Now complete base model collision checks that do not take into account rotating submodels.
-		mc.flags = copy_flags;
-		*mc.p0 = copy_p0;
-		*mc.p1 = copy_p1;
+		mc.flags = orig_flags;
+		mc.p0 = orig_p0;
+		mc.p1 = orig_p1;
 		mc.orient = &heavy_obj->orient;
 
 		// usual ship_ship collision test

--- a/code/weapon/flak.h
+++ b/code/weapon/flak.h
@@ -40,9 +40,6 @@ void flak_pick_range(object *objp, vec3d *firing_pos, vec3d *predicted_target_po
 // assumes dir is normalized
 void flak_jitter_aim(vec3d *dir, float dist_to_target, float weapon_subsys_strength, weapon_info* wip);
 
-// create a muzzle flash from a flak gun based upon firing position and weapon type
-void flak_muzzle_flash(vec3d *pos, vec3d *dir, physics_info *pip, int turret_weapon_class);
-
 // set the range on a flak object
 void flak_set_range(object *objp, float range);
 


### PR DESCRIPTION
Add `const` to the `mc_info` struct so its values aren't inadvertently overwritten.  Tweak some of the collision code to prevent overwrites.

Also remove the `flak_muzzle_flash` declaration since that function no longer exists.