### PR TITLE
convert some instances of frand_range to Random::next

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1578,7 +1578,7 @@ ship_subsys *aifft_find_turret_subsys(object *objp, ship_subsys *ssp, object *en
 	if(stride <= 0){
 		stride = 1;
 	}
-	int offset = (int)frand_range(0.0f, (float)(aifft_list_size % stride));
+	int offset = Random::next(aifft_list_size % stride);
 	int idx;
 	float dot_fov_modifier = 0.0f;
 

--- a/code/cheats_table/cheats_table.cpp
+++ b/code/cheats_table/cheats_table.cpp
@@ -82,7 +82,7 @@ void SpawnShipCheat::runCheat() {
 				if (ptr->system_info->type == SUBSYSTEM_TURRET)
 				{
 					ptr->weapons.flags.set(Ship::Weapon_Flags::Beam_Free);
-					ptr->turret_next_fire_stamp = timestamp((int)frand_range(50.0f, 4000.0f));
+					ptr->turret_next_fire_stamp = timestamp(Random::next(50, 4000));
 				}
 			}
 

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -357,7 +357,7 @@ void ssm_create(object *target, vec3d *start, size_t ssm_index, ssm_firing_info 
 		ssm.sinfo.start_pos.resize(count);
 
 		for (idx = 0; idx < count; idx++) {
-			ssm.sinfo.delay_stamp[idx] = _timestamp(200 + (int)frand_range(-199.0f, 1000.0f));
+			ssm.sinfo.delay_stamp[idx] = _timestamp(200 + Random::next(-199, 1000));
 			ssm_get_random_start_pos(&ssm.sinfo.start_pos[idx], start, &dir, ssm_index);
 		}
 

--- a/code/menuui/fishtank.cpp
+++ b/code/menuui/fishtank.cpp
@@ -167,7 +167,7 @@ void fishtank_start()
 	Fish_inited = 1;
 
 	// generate a random # of fish
-	int count = (int)frand_range(1.0f, (float)(MAX_FISH - 1));
+	int count = Random::next(1, MAX_FISH);
 	for(idx=0; idx<count; idx++){
 		fish_generate();
 	}		

--- a/code/nebula/neblightning.cpp
+++ b/code/nebula/neblightning.cpp
@@ -664,14 +664,14 @@ void nebl_process()
 		
 	// random stamp
 	if(Nebl_stamp == -1){
-		Nebl_stamp = timestamp((int)frand_range((float)Storm->min, (float)Storm->max));
+		Nebl_stamp = timestamp(Random::next(Storm->min, Storm->max));
 		return;
 	}	
 
 	// maybe make a bolt
 	if(timestamp_elapsed(Nebl_stamp)){
 		// determine how many bolts to spew
-		num_bolts = (uint)frand_range((float)Storm->min_count, (float)Storm->max_count);
+		num_bolts = Random::next(Storm->min_count, Storm->max_count);
 		for(idx=0; idx<num_bolts; idx++){
 			vec3d start;
 			do {
@@ -711,12 +711,12 @@ void nebl_process()
 				vm_vec_add(&strike, &start, &the_mixture);
 			}
 
-			int type = (int)frand_range(0.0f, (float)(Storm->num_bolt_types-1));
+			int type = Random::next(Storm->num_bolt_types);
 			nebl_bolt(Storm->bolt_types[type], &start, &strike);
 		}
 
 		// reset the timestamp
-		Nebl_stamp = timestamp((int)frand_range((float)Storm->min, (float)Storm->max));
+		Nebl_stamp = timestamp(Random::next(Storm->min, Storm->max));
 	}	
 }
 

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -5439,14 +5439,7 @@ void multi_pxo_ban_parse_banner_file()
 	if (num_banners > 1) {
 		do {
 			// randomly pick a file for download
-			idx = (int)frand_range(0.0f, (float)num_banners);
-
-			if (idx >= num_banners){
-				idx = num_banners - 1;
-			}
-			if (idx < 0){
-				idx = 0;
-			}
+			idx = Random::next(num_banners);
 		} while (Multi_pxo_banner.ban_file == banners[idx]);
 	}
 

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -818,7 +818,7 @@ DCF(mj_make, "Makes a multijoin game? (Multiplayer)")
 
 		// timestamp it so we get random timeouts
 		if(newitem != NULL){
-			// newitem->heard_from_timer = timestamp((int)frand_range(500.0f, 10000.0f));
+			// newitem->heard_from_timer = timestamp(Random::next(500, 10000));
 		}
 	}
 }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20949,7 +20949,7 @@ void sexp_beam_or_turret_free_one(ship_subsys *turret, bool is_beam, bool free)
 			if (!(turret->weapons.flags[Ship::Weapon_Flags::Beam_Free]))
 			{
 				turret->weapons.flags.set(Ship::Weapon_Flags::Beam_Free);
-				turret->turret_next_fire_stamp = timestamp((int)frand_range(50.0f, 4000.0f));
+				turret->turret_next_fire_stamp = timestamp(Random::next(50, 4000));
 			}
 		}
 		else
@@ -20966,7 +20966,7 @@ void sexp_beam_or_turret_free_one(ship_subsys *turret, bool is_beam, bool free)
 			if (turret->weapons.flags[Ship::Weapon_Flags::Turret_Lock])
 			{
 				turret->weapons.flags.remove(Ship::Weapon_Flags::Turret_Lock);
-				turret->turret_next_fire_stamp = timestamp((int)frand_range(50.0f, 4000.0f));
+				turret->turret_next_fire_stamp = timestamp(Random::next(50, 4000));
 			}
 		}
 		else

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7551,7 +7551,7 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 		ship_system->turret_next_fire_stamp = timestamp(0);
 		ship_system->turret_next_enemy_check_stamp = timestamp(0);
 		ship_system->turret_enemy_objnum = -1;
-		ship_system->turret_next_fire_stamp = timestamp((int) frand_range(1.0f, 500.0f));	// next time this turret can fire
+		ship_system->turret_next_fire_stamp = timestamp(Random::next(1, 500));	// next time this turret can fire
 		ship_system->turret_last_fire_direction = model_system->turret_norm;
 		ship_system->turret_next_fire_pos = 0;
 		ship_system->turret_time_enemy_in_range = 0.0f;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2474,7 +2474,7 @@ void shipfx_do_lightning_frame( ship * /*shipp*/ )
 	shipp->lightning_stamp = timestamp(stamp);
 
 	// ah, now we can create some lightning bolts
-	count = Random::next(0, count);
+	count = Random::next(count+1);
 	while(count > 0){
 		// get 2 points on the hull of the ship
 		v1 = submodel_get_random_point(shipp->modelnum, 0);
@@ -2497,7 +2497,7 @@ void shipfx_do_lightning_frame( ship * /*shipp*/ )
 		binfo.num_strikes = 3;
 		binfo.noise = 0.045f;
 		binfo.life = 375;
-		binfo.delay = Random::next(0, 1600);
+		binfo.delay = Random::next(1600+1);
 		nebl_bolt(&binfo);
 		count--;
 
@@ -2523,7 +2523,7 @@ void shipfx_do_lightning_frame( ship * /*shipp*/ )
 		binfo.num_strikes = 3;
 		binfo.noise = 0.045f;
 		binfo.life = 375;
-		binfo.delay = Random::next(0, 1600);
+		binfo.delay = Random::next(1600+1);
 		nebl_bolt(&binfo);
 		count--;
 	}
@@ -2613,7 +2613,7 @@ void shipfx_do_shockwave_stuff(ship *shipp, shockwave_create_info *sci)
 		sci2.rot_angles.b = frand_range(0.0f, 1.99f*PI);
 		sci2.rot_angles.h = frand_range(0.0f, 1.99f*PI);
 
-		shockwave_create(shipp->objnum, &shockwave_pos, &sci2, SW_SHIP_DEATH, Random::next(0, 350));
+		shockwave_create(shipp->objnum, &shockwave_pos, &sci2, SW_SHIP_DEATH, Random::next(350+1));
 		
 		// next shockwave
 		cur += step;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2474,7 +2474,7 @@ void shipfx_do_lightning_frame( ship * /*shipp*/ )
 	shipp->lightning_stamp = timestamp(stamp);
 
 	// ah, now we can create some lightning bolts
-	count = (int)frand_range(0.0f, (float)count);
+	count = Random::next(0, count);
 	while(count > 0){
 		// get 2 points on the hull of the ship
 		v1 = submodel_get_random_point(shipp->modelnum, 0);
@@ -2497,7 +2497,7 @@ void shipfx_do_lightning_frame( ship * /*shipp*/ )
 		binfo.num_strikes = 3;
 		binfo.noise = 0.045f;
 		binfo.life = 375;
-		binfo.delay = (int)frand_range(0.0f, 1600.0f);
+		binfo.delay = Random::next(0, 1600);
 		nebl_bolt(&binfo);
 		count--;
 
@@ -2523,7 +2523,7 @@ void shipfx_do_lightning_frame( ship * /*shipp*/ )
 		binfo.num_strikes = 3;
 		binfo.noise = 0.045f;
 		binfo.life = 375;
-		binfo.delay = (int)frand_range(0.0f, 1600.0f);
+		binfo.delay = Random::next(0, 1600);
 		nebl_bolt(&binfo);
 		count--;
 	}
@@ -2613,7 +2613,7 @@ void shipfx_do_shockwave_stuff(ship *shipp, shockwave_create_info *sci)
 		sci2.rot_angles.b = frand_range(0.0f, 1.99f*PI);
 		sci2.rot_angles.h = frand_range(0.0f, 1.99f*PI);
 
-		shockwave_create(shipp->objnum, &shockwave_pos, &sci2, SW_SHIP_DEATH, (int)frand_range(0.0f, 350.0f));
+		shockwave_create(shipp->objnum, &shockwave_pos, &sci2, SW_SHIP_DEATH, Random::next(0, 350));
 		
 		// next shockwave
 		cur += step;

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1523,7 +1523,7 @@ void beam_generate_muzzle_particles(beam *b)
 	b->Beam_muzzle_stamp = timestamp(hack_time);
 
 	// randomly generate 10 to 20 particles
-	particle_count = (int)frand_range(0.0f, (float)wip->b_info.beam_particle_count);
+	particle_count = Random::next(0, wip->b_info.beam_particle_count);
 
 	// get turret info - position and normal
 	turret_pos = b->last_start;

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1523,7 +1523,7 @@ void beam_generate_muzzle_particles(beam *b)
 	b->Beam_muzzle_stamp = timestamp(hack_time);
 
 	// randomly generate 10 to 20 particles
-	particle_count = Random::next(0, wip->b_info.beam_particle_count);
+	particle_count = Random::next(wip->b_info.beam_particle_count+1);
 
 	// get turret info - position and normal
 	turret_pos = b->last_start;

--- a/code/weapon/emp.cpp
+++ b/code/weapon/emp.cpp
@@ -610,7 +610,7 @@ void emp_randomize_chars(char *str)
 	// shuffle chars around
 	for(idx=0; idx<(int)(strlen(str)-1); idx++){
 		if(frand_range(0.0f, 1.0f) < Emp_intensity){
-			char_index = (int)frand_range(0.0f, (float)(NUM_RANDOM_CHARS - 1));
+			char_index = Random::next(NUM_RANDOM_CHARS);
 			str[idx] = Emp_random_char[char_index];
 		}
 	}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2555,7 +2555,7 @@ void game_tst_frame()
 		tst_time = (int) time(nullptr);
 
 		// load the tst bitmap		
-		switch((int)frand_range(0.0f, 3.0)){
+		switch(Random::next(4)){
 		case 0:			
 			tst_bitmap = bm_load("ig_jim");
 			left = 1;


### PR DESCRIPTION
Some of the `frand_range` calls were used for integer calculations, so we can use `Random::next` now.

This also reduces the number of C-style casts in the codebase.