### PR TITLE
Removed unused variables in HUD code

### DIFF
--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -103,11 +103,6 @@ extern int HUD_color_alpha;
 
 extern color HUD_color_debug;
 
-// Values used "wiggle" the HUD.  In the 2D HUD case, the clip region accounts
-// for these, but for the 3d-type hud stuff, you need to add these in manually.
-extern float HUD_offset_x;
-extern float HUD_offset_y;
-
 // the offset of the player's view vector and the ship forward vector in pixels (Swifty)
 extern int HUD_nose_x;
 extern int HUD_nose_y;


### PR DESCRIPTION
Followup to #5656.
Removes now unused and undefined variables that just had a stray declaration left.