### PR TITLE
Mainhall ignore input

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -68,7 +68,7 @@ static main_hall_defines *Main_hall = nullptr;
 
 static int Main_hall_music_index = -1;
 
-bool Main_hall_poll_key = 1;
+bool Main_hall_poll_key = true;
 
 int Vasudan_funny = 0;
 int Vasudan_funny_plate = -1;
@@ -747,7 +747,7 @@ void main_hall_do(float frametime)
 
 	// process any keypresses/mouse events
 	snazzy_action = -1;
-	code = snazzy_menu_do(Main_hall_mask_data, Main_hall_mask_w, Main_hall_mask_h, (int)Main_hall->regions.size(), Main_hall_region, &snazzy_action, Main_hall_poll_key, &key);
+	code = snazzy_menu_do(Main_hall_mask_data, Main_hall_mask_w, Main_hall_mask_h, static_cast<int>(Main_hall->regions.size()), Main_hall_region, &snazzy_action, static_cast<int>(Main_hall_poll_key), &key);
 
 	if (key) {
 		game_process_cheats(key);

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -68,6 +68,8 @@ static main_hall_defines *Main_hall = nullptr;
 
 static int Main_hall_music_index = -1;
 
+bool Main_hall_poll_key = 1;
+
 int Vasudan_funny = 0;
 int Vasudan_funny_plate = -1;
 
@@ -745,7 +747,7 @@ void main_hall_do(float frametime)
 
 	// process any keypresses/mouse events
 	snazzy_action = -1;
-	code = snazzy_menu_do(Main_hall_mask_data, Main_hall_mask_w, Main_hall_mask_h, (int)Main_hall->regions.size(), Main_hall_region, &snazzy_action, 1, &key);
+	code = snazzy_menu_do(Main_hall_mask_data, Main_hall_mask_w, Main_hall_mask_h, (int)Main_hall->regions.size(), Main_hall_region, &snazzy_action, Main_hall_poll_key, &key);
 
 	if (key) {
 		game_process_cheats(key);

--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -161,6 +161,8 @@ public:
 
 extern SCP_vector< SCP_vector<main_hall_defines> > Main_hall_defines;
 
+extern bool Main_hall_poll_key;
+
 
 // initialize the main hall proper 
 void main_hall_init(const SCP_string &main_hall_name);

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -120,7 +120,7 @@ ADE_FUNC(enableInput,
 
 	scpui::enableInput(ctx);
 	game_flush();
-	Main_hall_poll_key = 0;
+	Main_hall_poll_key = false;
 
 	return ADE_RETURN_TRUE;
 }
@@ -129,7 +129,7 @@ ADE_FUNC(disableInput, l_UserInterface, "", "Disables UI input", "boolean", "tru
 {
 	scpui::disableInput();
 	game_flush();
-	Main_hall_poll_key = 1;
+	Main_hall_poll_key = true;
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -119,6 +119,8 @@ ADE_FUNC(enableInput,
 	}
 
 	scpui::enableInput(ctx);
+	game_flush();
+	Main_hall_poll_key = 0;
 
 	return ADE_RETURN_TRUE;
 }
@@ -126,6 +128,8 @@ ADE_FUNC(enableInput,
 ADE_FUNC(disableInput, l_UserInterface, "", "Disables UI input", "boolean", "true if successful")
 {
 	scpui::disableInput();
+	game_flush();
+	Main_hall_poll_key = 1;
 
 	return ADE_RETURN_TRUE;
 }


### PR DESCRIPTION
Mainhall is the only place where retail UI and SCPUI mix (using dialogs) and there are times when I need it to not process keypresses.. notably when taking user input in the form of typing. The existing enable/disable input methods do not override this behavior so this adds a simple bool to toggle it.