### PR TITLE
a few build fixes

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -1172,7 +1172,7 @@ void cf_build_file_list()
 		}
 
 		Warning(LOCATION, "Some critical files might be shadowed! Please check the debug log for details.\n\n"
-							"%lu file(s) detected, including:\n%s", count, shadowed.c_str());
+							SIZE_T_ARG " file(s) detected, including:\n%s", count, shadowed.c_str());
 	}
 
 	critical_shadowed.clear();

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -1297,7 +1297,7 @@ static void psnet_debug_bad_packet(const int packet_type, const uint8_t *packet_
 
 	// in case of flooding, log number of packets we've skipped during the previous window
 	if (Psnet_bad_packet_count > MAX_BAD_PACKETS_PER_WINDOW) {
-		ml_printf("WARNING: Invalid packet log window reset ... %lu non-logged packets received during previous window!", Psnet_bad_packet_count - MAX_BAD_PACKETS_PER_WINDOW);
+		ml_printf("WARNING: Invalid packet log window reset ... " SIZE_T_ARG " non-logged packets received during previous window!", Psnet_bad_packet_count - MAX_BAD_PACKETS_PER_WINDOW);
 
 		// reset count
 		Psnet_bad_packet_count = 1;

--- a/code/utils/HeapAllocator.cpp
+++ b/code/utils/HeapAllocator.cpp
@@ -177,6 +177,7 @@ bool HeapAllocator::check_connected_range(const MemoryRange& left, const MemoryR
 	return left.offset + left.size == right.offset;
 }
 void HeapAllocator::checkRangesMerged() {
+#ifndef NDEBUG
 	bool first = true;
 	size_t lastEnd = 0;
 	for (auto& range : _freeRanges) {
@@ -187,6 +188,7 @@ void HeapAllocator::checkRangesMerged() {
 		lastEnd = range.offset + range.size;
 		first = false;
 	}
+#endif
 }
 
 bool HeapAllocator::MemoryRange::operator<(const HeapAllocator::MemoryRange& other) const {

--- a/code/utils/HeapAllocator.cpp
+++ b/code/utils/HeapAllocator.cpp
@@ -177,6 +177,7 @@ bool HeapAllocator::check_connected_range(const MemoryRange& left, const MemoryR
 	return left.offset + left.size == right.offset;
 }
 void HeapAllocator::checkRangesMerged() {
+// This is a debug only function because its values are only used in debug and linters will get tripped up otherwise.
 #ifndef NDEBUG
 	bool first = true;
 	size_t lastEnd = 0;


### PR DESCRIPTION
1. use `SIZE_T_ARG` instead of `"%lu"`; should fix format warning in #5780
2. since `HeapAllocator::checkRangesMerged()` has no effect unless running in debug, `#ifdef` out the function; should fix CI warning in #5778