### PR TITLE
Downgrade this warning to a log print

### DIFF
--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -669,7 +669,7 @@ void LuaSEXP::parseTable() {
 			}
 
 			if (thisList.list.size() == 0) {
-				error_display(0, "Parsed empty enum list '%s'\n", thisList.name.c_str());
+				mprintf(("Parsed empty enum list '%s'. Adding <none>.\n", thisList.name.c_str()));
 				thisList.list.push_back("<none>");
 			}
 


### PR DESCRIPTION
Because it's not actually a problem if scripters are building enum lists On Game Init, which is intended to be allowed.