### PR TITLE
Disallow Replace Container Data for all special argument SEXPs

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1102,7 +1102,6 @@ int Sexp_current_argument_nesting_level;
 
 // Goober5000
 bool is_blank_argument_op(int op_const);
-bool is_blank_of_op(int op_const);
 bool is_for_blank_op(int op_const); // jg18
 int get_handler_for_x_of_operator(int node);
 
@@ -2286,7 +2285,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 			// this is an instance of "Replace Container Data"
 
 			// can't be used in special argument list
-			if (type == OPF_ANYTHING || type == OPF_DATA_OR_STR_CONTAINER) {
+			if (sexp_is_blank_of_op(get_operator_const(op_node)) {
 				return SEXP_CHECK_TYPE_MISMATCH;
 			}
 
@@ -4626,7 +4625,7 @@ int get_sexp()
 		{
 			// get the first op of the parent, which should be a *_of operator
 			arg_handler = CADR(parent);
-			if (arg_handler >= 0 && !is_blank_of_op(get_operator_const(arg_handler)))
+			if (arg_handler >= 0 && !sexp_is_blank_of_op(get_operator_const(arg_handler)))
 				arg_handler = -1;
 		}
 
@@ -11733,7 +11732,7 @@ int get_handler_for_x_of_operator(int n)
 
 	// get the first op of the parent, which should be a *_of operator
 	arg_handler = CADR(conditional);
-	if (arg_handler < 0 || !is_blank_of_op(get_operator_const(arg_handler))) {
+	if (arg_handler < 0 || !sexp_is_blank_of_op(get_operator_const(arg_handler))) {
 		return -1;
 	}
 
@@ -11755,7 +11754,7 @@ bool is_blank_argument_op(int op_const)
 }
 
 // Goober5000
-bool is_blank_of_op(int op_const)
+bool sexp_is_blank_of_op(int op_const)
 {
 	if (is_for_blank_op(op_const)) {
 		return true;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2280,7 +2280,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 			// this is an instance of "Replace Container Data"
 
 			// can't be used in special argument list
-			if (sexp_is_blank_of_op(get_operator_const(op_node))) {
+			if (is_argument_provider_op(get_operator_const(op_node))) {
 				return SEXP_CHECK_TYPE_MISMATCH;
 			}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2285,7 +2285,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 			// this is an instance of "Replace Container Data"
 
 			// can't be used in special argument list
-			if (sexp_is_blank_of_op(get_operator_const(op_node)) {
+			if (sexp_is_blank_of_op(get_operator_const(op_node))) {
 				return SEXP_CHECK_TYPE_MISMATCH;
 			}
 

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1592,7 +1592,4 @@ void eval_object_ship_wing_point_team(object_ship_wing_point_team* oswpt, int no
 bool sexp_check_flag_arrays(const char *flag_name, Object::Object_Flags &object_flag, Ship::Ship_Flags &ship_flag, Mission::Parse_Object_Flags &parse_obj_flag, AI::AI_Flags &ai_flag);
 bool sexp_check_flag_array(const char* flag_name, Ship::Wing_Flags& wing_flag);
 
-// Goober5000
-extern bool sexp_is_blank_of_op(int op_const);
-
 #endif

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1585,4 +1585,7 @@ void eval_object_ship_wing_point_team(object_ship_wing_point_team* oswpt, int no
 bool sexp_check_flag_arrays(const char *flag_name, Object::Object_Flags &object_flag, Ship::Ship_Flags &ship_flag, Mission::Parse_Object_Flags &parse_obj_flag, AI::AI_Flags &ai_flag);
 bool sexp_check_flag_array(const char* flag_name, Ship::Wing_Flags& wing_flag);
 
+// Goober5000
+extern bool sexp_is_blank_of_op(int op_const);
+
 #endif

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -915,8 +915,7 @@ void sexp_tree::right_clicked(int mode)
 							// Replace Container Data submenu
 							// disallowed on variable-type SEXP args, to prevent FSO/FRED crashes
 							// also disallowed for special argument options (not supported for now)
-							if (op_type != OPF_VARIABLE_NAME && op_type != OPF_ANYTHING &&
-								op_type != OPF_DATA_OR_STR_CONTAINER) {
+							if (op_type != OPF_VARIABLE_NAME && !sexp_is_blank_of_op(Operators[op].value)) {
 								int container_data_index = 0;
 								for (const auto &container : get_all_sexp_containers()) {
 									UINT flags = MF_STRING | MF_GRAYED;

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -915,7 +915,7 @@ void sexp_tree::right_clicked(int mode)
 							// Replace Container Data submenu
 							// disallowed on variable-type SEXP args, to prevent FSO/FRED crashes
 							// also disallowed for special argument options (not supported for now)
-							if (op_type != OPF_VARIABLE_NAME && !sexp_is_blank_of_op(Operators[op].value)) {
+							if (op_type != OPF_VARIABLE_NAME && !is_argument_provider_op(Operators[op].value)) {
 								int container_data_index = 0;
 								for (const auto &container : get_all_sexp_containers()) {
 									UINT flags = MF_STRING | MF_GRAYED;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5937,7 +5937,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 				// Replace Container Data submenu
 				// disallowed on variable-type SEXP args, to prevent FSO/FRED crashes
 				// also disallowed for special argument options (not supported for now)
-				if (op_type != OPF_VARIABLE_NAME && !sexp_is_blank_of_op(Operators[op].value)) {
+				if (op_type != OPF_VARIABLE_NAME && !is_argument_provider_op(Operators[op].value)) {
 					const auto &containers = get_all_sexp_containers();
 					for (int idx = 0; idx < (int)containers.size(); ++idx) {
 						const auto &container = containers[idx];

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5937,7 +5937,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 				// Replace Container Data submenu
 				// disallowed on variable-type SEXP args, to prevent FSO/FRED crashes
 				// also disallowed for special argument options (not supported for now)
-				if (op_type != OPF_VARIABLE_NAME && op_type != OPF_ANYTHING && op_type != OPF_DATA_OR_STR_CONTAINER) {
+				if (op_type != OPF_VARIABLE_NAME && !sexp_is_blank_of_op(Operators[op].value)) {
 					const auto &containers = get_all_sexp_containers();
 					for (int idx = 0; idx < (int)containers.size(); ++idx) {
 						const auto &container = containers[idx];


### PR DESCRIPTION
Replace Container Data is currently not disallowed for the `for-*` SEXPs. This PR fixes that.

Should fix Issue #5783.