### PR TITLE
FRED missionsave updates

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3305,18 +3305,29 @@ int CFred_mission_save::save_music()
 
 int CFred_mission_save::save_custom_data()
 {
-	if (Mission_save_format != FSO_FORMAT_RETAIL) {
-		required_string_fred("#Custom Data");
-		parse_comments(2);
+	if (Mission_save_format != FSO_FORMAT_RETAIL && !The_mission.custom_data.empty()) {
+		if (optional_string_fred("#Custom Data", "#End")) {
+			parse_comments(2);
+		} else {
+			fout("\n\n#Custom Data");
+		}
 
 		if (The_mission.custom_data.size() > 0) {
-			required_string_fred("$begin_data_map");
-			parse_comments(2);
+			if (optional_string_fred("$begin_data_map")) {
+				parse_comments(2);
+			} else {
+				fout("\n\n$begin_data_map");
+			}
+
 			for (const auto& pair : The_mission.custom_data) {
 				fout("\n+Val: %s %s", pair.first.c_str(), pair.second.c_str());
 			}
-			required_string_fred("$end_data_map");
-			parse_comments(2);
+
+			if (optional_string_fred("$end_data_map")) {
+				parse_comments();
+			} else {
+				fout("\n$end_data_map");
+			}
 		}
 	}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3221,18 +3221,29 @@ int CFred_mission_save::save_music()
 
 int CFred_mission_save::save_custom_data()
 {
-	if (save_format != MissionFormat::RETAIL) {
-		required_string_fred("#Custom Data");
-		parse_comments(2);
+	if (save_format != MissionFormat::RETAIL && !The_mission.custom_data.empty()) {
+		if (optional_string_fred("#Custom Data", "#End")) {
+			parse_comments(2);
+		} else {
+			fout("\n\n#Custom Data");
+		}
 
 		if (The_mission.custom_data.size() > 0) {
-			required_string_fred("$begin_data_map");
-			parse_comments(2);
+			if (optional_string_fred("$begin_data_map")) {
+				parse_comments(2);
+			} else {
+				fout("\n\n$begin_data_map");
+			}
+
 			for (const auto& pair : The_mission.custom_data) {
 				fout("\n+Val: %s %s", pair.first.c_str(), pair.second.c_str());
 			}
-			required_string_fred("$end_data_map");
-			parse_comments(2);
+
+			if (optional_string_fred("$end_data_map")) {
+				parse_comments();
+			} else {
+				fout("\n$end_data_map");
+			}
 		}
 	}
 


### PR DESCRIPTION
1. Use the `optional_string_fred`/`fout` pattern so the FRED comment parser can follow along with the mission file
2. Since the #Custom Data section is optional and requires a version bump, don't output the section header if the section is empty