### PR TITLE
Add child enum suffix option

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -916,6 +916,8 @@ SCP_vector<dynamic_sexp_enum_list> Dynamic_enums;
 
 SCP_vector<dynamic_sexp_parameter_list> Dynamic_parameters;
 
+SCP_vector<dynamic_sexp_child_enum_suffixes> Dynamic_enum_suffixes;
+
 int get_dynamic_parameter_index(const SCP_string &op_name, int param)
 {
 	for (int i = 0; i < (int)Dynamic_parameters.size(); i++) {
@@ -951,6 +953,21 @@ int get_dynamic_parameter_index(const SCP_string &op_name, int param)
 
 	// Didn't find anything.
 	return -1;
+}
+
+// Gets the custom suffix to append when using child enums. If we have a match
+// for operator name and parameter index, then return the suffix. Otherwise return
+// an empty string
+SCP_string get_child_enum_suffix(const SCP_string& op_name, int param_index)
+{
+	for (int i = 0; i < (int)Dynamic_enum_suffixes.size(); i++) {
+		if (lcase_equal(Dynamic_enum_suffixes[i].operator_name, op_name)) {
+			if (Dynamic_enum_suffixes[i].param_index == param_index) {
+				return Dynamic_enum_suffixes[i].suffix;
+			}
+		}
+	}
+	return "";
 }
 
 int get_dynamic_enum_position(const SCP_string &enum_name)

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -960,7 +960,7 @@ int get_dynamic_parameter_index(const SCP_string &op_name, int param)
 // an empty string
 SCP_string get_child_enum_suffix(const SCP_string& op_name, int param_index)
 {
-	for (int i = 0; i < (int)Dynamic_enum_suffixes.size(); i++) {
+	for (size_t i = 0; i < Dynamic_enum_suffixes.size(); i++) {
 		if (lcase_equal(Dynamic_enum_suffixes[i].operator_name, op_name)) {
 			if (Dynamic_enum_suffixes[i].param_index == param_index) {
 				return Dynamic_enum_suffixes[i].suffix;

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -161,9 +161,19 @@ struct dynamic_sexp_parameter_list {
 
 extern SCP_vector<dynamic_sexp_parameter_list> Dynamic_parameters;
 
+struct dynamic_sexp_child_enum_suffixes {
+	SCP_string operator_name;
+	int param_index;
+	SCP_string suffix;
+};
+
+extern SCP_vector<dynamic_sexp_child_enum_suffixes> Dynamic_enum_suffixes;
+
 int get_dynamic_parameter_index(const SCP_string &op_name, int param);
 
 int get_dynamic_enum_position(const SCP_string &enum_name);
+
+SCP_string get_child_enum_suffix(const SCP_string& op_name, int param_index);
 
 // Operand return types
 enum sexp_opr_t : int {

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -730,6 +730,14 @@ void LuaSEXP::parseTable() {
 
 		}
 
+		if (type_str == "child_enum") {
+			if (optional_string("+Suffix:")) {
+				SCP_string suffix;
+				stuff_string(suffix, F_NAME);
+				Dynamic_enum_suffixes.push_back({_name, param_index, suffix});
+			}
+		}
+
 		if (variable_arg_part) {
 			_varargs_type_pattern.push_back(type);
 		} else {

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -7570,21 +7570,24 @@ sexp_list_item* sexp_tree::get_listing_opf_lua_enum(int parent_node, int arg_ind
 		return nullptr;
 	}
 
+	// Append the suffix if it exists
+	SCP_string enum_name = tree_nodes[child].text + get_child_enum_suffix(tree_nodes[parent_node].text, arg_index);
+
 	sexp_list_item head;
 
-	int item = get_dynamic_enum_position(tree_nodes[child].text);
+	int item = get_dynamic_enum_position(enum_name);
 
 	if (item >= 0 && item < static_cast<int>(Dynamic_enums.size())) {
 
 		for (const SCP_string& enum_item : Dynamic_enums[item].list) {
 			head.add_data(enum_item.c_str());
 		}
-		return head.next;
 	} else {
 		// else if enum is invalid do this
-		error_display(1, "Could not find Lua Enum %s!", tree_nodes[child].text);
-		return nullptr;
+		mprintf(("Could not find Lua Enum %s! Using <none> instead!", enum_name.c_str()));
+		head.add_data("<none>");
 	}
+	return head.next;
 }
 
 sexp_list_item* sexp_tree::get_listing_opf_lua_general_orders()

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5201,21 +5201,24 @@ sexp_list_item* sexp_tree::get_listing_opf_lua_enum(int parent_node, int arg_ind
 		return nullptr;
 	}
 
+	// Append the suffix if it exists
+	SCP_string enum_name = tree_nodes[child].text + get_child_enum_suffix(tree_nodes[parent_node].text, arg_index);
+
 	sexp_list_item head;
 
-	int item = get_dynamic_enum_position(tree_nodes[child].text);
+	int item = get_dynamic_enum_position(enum_name);
 
 	if (item >= 0 && item < static_cast<int>(Dynamic_enums.size())) {
 
 		for (const SCP_string& enum_item : Dynamic_enums[item].list) {
 			head.add_data(enum_item.c_str());
 		}
-		return head.next;
 	} else {
 		// else if enum is invalid do this
-		error_display(1, "Could not find Lua Enum %s!", tree_nodes[child].text);
-		return nullptr;
+		mprintf(("Could not find Lua Enum %s! Using <none> instead!", enum_name.c_str()));
+		head.add_data("<none>");
 	}
+	return head.next;
 }
 
 sexp_list_item* sexp_tree::get_listing_opf_game_snds() {


### PR DESCRIPTION
This feature adds, hopefully, the final level of arbitrary do-whatever-you-want-ness to lua sexps. The existing `child_enum` parameter type takes whatever the parent parameter's text is and looks for a Lua Enum list with that name. It was originally intended to be able to have the parent be a Lua Enum list of Lua Enum lists. But I realized it can be whatever you want, currently. The parent could a `ship` type and then the game would look for a Lua Enum list with the name of the ship. That's handy, but it's a one-off. You can only have one list with that name.

With this upgrade a `child_enum` can optionally specify a list name suffix. So if the parent parameter is a ship, the child_enum can specify to look for a Lua Enum list that's `shipname + suffix`.

This also downgrades an Error to a log print. If the code can't find the specified enum list we don't have to hard stop. We can just return `<none>` and move on.