### PR TITLE
Add safety to crusty old physics code (coverity issue)

### DIFF
--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -1315,8 +1315,24 @@ void avd_movement::setAVD(float final_position, float total_movement_time, float
 	TSi = timestamp();
 	
 	Vm = (Pf-Pi-0.5f*(Vi*Tai)-0.5f*(Vf*Taf)) / (Tf - 0.5f*Tai - 0.5f*Taf);
-	Ai = (Vm-Vi)/Tai;
-	Af = (Vf-Vm)/Taf;
+
+	// Cyborg - Many coverity dividing by zero issues were caused by this piece of low level code. Most places that called this function were also not checking inputs. 
+	// The two if blocks in this function do not guarantee that they will not be float zero (e.g. tai = 2.0 taf = 0.0 Tf = 1.0)
+	// The reason why this code use to work even when there were divisions by zero is that the NAN results were gated behind Taf > 0.0 and Tai > 0.0
+	// checks in other functions. Ai, initial Acceleration, and Af, final Acceleration, are completely meaningless and explicitly disabled if their respective
+	// time amounts are zero or less than zero. So instead of just letting some NAN's chill out in memory, waiting for someone else to unwisely access them,
+	// we are going to explicitly set them to zero, like a good engine should.
+	if (Tai <= 0.0f){
+		Ai = 0.0;
+	} else {
+		Ai = (Vm-Vi)/Tai;
+	}
+
+	if (Taf <= 0.0f){
+		Af = 0.0f;
+	} else {
+		Af = (Vf-Vm)/Taf;
+	}
 }
 
 void avd_movement::setVD(float total_movement_time, float ending_acceleration_time, float final_velocity)
@@ -1334,7 +1350,14 @@ void avd_movement::setVD(float total_movement_time, float ending_acceleration_ti
 
 	TSi = timestamp();
 	Ai = 0.0f;
-	Af = (Vf-Vm)/Taf;
+
+	// Avoid division by float zero. See the note in setAVD for more info.
+	if (Taf <= 0.0f){
+		Af = 0.0f;
+	} else {
+		Af = (Vf-Vm)/Taf;
+	}
+	
 	Pf = Pi + Pf*(Tf - Taf) + Vm*Taf + 0.5f*Af*(Taf*Taf);
 }
 

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -1318,7 +1318,7 @@ void avd_movement::setAVD(float final_position, float total_movement_time, float
 
 	// Cyborg - Many coverity dividing by zero issues were caused by this piece of low level code. Most places that called this function were also not checking inputs. 
 	// The two if blocks in this function do not guarantee that they will not be float zero (e.g. tai = 2.0 taf = 0.0 Tf = 1.0)
-	// The reason why this code use to work even when there were divisions by zero is that the NAN results were gated behind Taf > 0.0 and Tai > 0.0
+	// The reason why this code used to work even when there were divisions by zero is that the NAN results were gated behind Taf > 0.0 and Tai > 0.0
 	// checks in other functions. Ai, initial Acceleration, and Af, final Acceleration, are completely meaningless and explicitly disabled if their respective
 	// time amounts are zero or less than zero. So instead of just letting some NAN's chill out in memory, waiting for someone else to unwisely access them,
 	// we are going to explicitly set them to zero, like a good engine should.


### PR DESCRIPTION
These few lines of code were what many coverity issues were pointing at.  After looking at the surrounding functions and figuring out what these variables are for, I've determined that nothing is guaranteeing that Tai and Taf are greater than 0.  The only reason why we probably haven't seen issues related to this is that use of the Ai and Af are *currently* gated behind Tai and Taf being > 0 (depending on the variable).  So, that if we ever wanted to expand the avd_movement class, we might run into those values being garbage.  So, we should should ensure that these Ai and Af are set to zero (no acceleration) when no acceleration time is passed to these functions.

In draft until I can run a test.  I do this a lot, but I'm a lot closer to being able to run these kinds of tests than I have before.  

If I did something incorrectly, it would show up in camera movement, especially camera movement performed by sexps.