### PR TITLE
Allow Modders to Set Rotational Scaling Multiplier for Asteroids/Debris

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -401,12 +401,24 @@ object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int asteroi
 	vec3d rotvel;
 	if ( Game_mode & GM_NORMAL ) {
 		vm_vec_rand_vec_quick(&rotvel);
-		vm_vec_scale(&rotvel, frand()/4.0f + 0.1f);
+		float rot_vel_multiplier = frand()/4.0f + 0.1f;
+		// cap rotational velocity scaling if max is set --wookieejedi
+		if (asip->max_rotational_vel_multiplier >= 0.0f) {
+			vm_vec_scale(&rotvel, MIN(asip->max_rotational_vel_multiplier, rot_vel_multiplier));
+		} else {
+			vm_vec_scale(&rotvel, rot_vel_multiplier);
+		}
 		objp->phys_info.rotvel = rotvel;
 		vm_vec_rand_vec_quick(&objp->phys_info.vel);
 	} else {
 		static_randvec( rand_base++, &rotvel );
-		vm_vec_scale(&rotvel, static_randf(rand_base++)/4.0f + 0.1f);
+		float rot_vel_multiplier = static_randf(rand_base++)/4.0f + 0.1f;
+		// cap rotational velocity scaling if max is set --wookieejedi
+		if (asip->max_rotational_vel_multiplier >= 0.0f) {
+			vm_vec_scale(&rotvel, MIN(asip->max_rotational_vel_multiplier, rot_vel_multiplier));
+		} else {
+			vm_vec_scale(&rotvel, rot_vel_multiplier);
+		}
 		objp->phys_info.rotvel = rotvel;
 		static_randvec( rand_base++, &objp->phys_info.vel );
 	}
@@ -2236,6 +2248,10 @@ static void asteroid_parse_section()
 
 	if (optional_string("$Max Speed:")) {
 		stuff_float(&asteroid_p->max_speed);
+	}
+
+	if (optional_string("$Max Rotational Velocity Multiplier:")) {
+		stuff_float(&asteroid_p->max_rotational_vel_multiplier);
 	}
 
 	if(optional_string("$Damage Type:")) {

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -401,24 +401,12 @@ object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int asteroi
 	vec3d rotvel;
 	if ( Game_mode & GM_NORMAL ) {
 		vm_vec_rand_vec_quick(&rotvel);
-		float rot_vel_multiplier = frand()/4.0f + 0.1f;
-		// cap rotational velocity scaling if max is set --wookieejedi
-		if (asip->max_rotational_vel_multiplier >= 0.0f) {
-			vm_vec_scale(&rotvel, MIN(asip->max_rotational_vel_multiplier, rot_vel_multiplier));
-		} else {
-			vm_vec_scale(&rotvel, rot_vel_multiplier);
-		}
+		vm_vec_scale(&rotvel, asip->rotational_vel_multiplier * (frand()/4.0f + 0.1f));
 		objp->phys_info.rotvel = rotvel;
 		vm_vec_rand_vec_quick(&objp->phys_info.vel);
 	} else {
 		static_randvec( rand_base++, &rotvel );
-		float rot_vel_multiplier = static_randf(rand_base++)/4.0f + 0.1f;
-		// cap rotational velocity scaling if max is set --wookieejedi
-		if (asip->max_rotational_vel_multiplier >= 0.0f) {
-			vm_vec_scale(&rotvel, MIN(asip->max_rotational_vel_multiplier, rot_vel_multiplier));
-		} else {
-			vm_vec_scale(&rotvel, rot_vel_multiplier);
-		}
+		vm_vec_scale(&rotvel, asip->rotational_vel_multiplier * (static_randf(rand_base++)/4.0f + 0.1f));
 		objp->phys_info.rotvel = rotvel;
 		static_randvec( rand_base++, &objp->phys_info.vel );
 	}
@@ -2250,8 +2238,8 @@ static void asteroid_parse_section()
 		stuff_float(&asteroid_p->max_speed);
 	}
 
-	if (optional_string("$Max Rotational Velocity Multiplier:")) {
-		stuff_float(&asteroid_p->max_rotational_vel_multiplier);
+	if (optional_string("$Rotational Velocity Multiplier:")) {
+		stuff_float(&asteroid_p->rotational_vel_multiplier);
 	}
 
 	if(optional_string("$Damage Type:")) {

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -63,7 +63,7 @@ public:
 	int			num_detail_levels;								// number of detail levels for this ship
 	int			detail_distance[MAX_ASTEROID_DETAIL_LEVELS];	// distance to change detail levels at
 	float		max_speed;										// cap on speed for asteroid
-	float		max_rotational_vel_multiplier;					// cap on rotational velocity multiplier for asteroid --wookieejedi
+	float		rotational_vel_multiplier;						// rotational velocity multiplier for asteroid --wookieejedi
 	int			damage_type_idx;								//Damage type of the asteroid
 	int			damage_type_idx_sav;							// stored value from table used to reset damage_type_idx
 	float		inner_rad;										// radius within which maximum area effect damage is applied
@@ -82,7 +82,7 @@ public:
 
 	asteroid_info( )
 		: type(ASTEROID_TYPE_DEBRIS), num_detail_levels(0), max_speed(0), 
-		  max_rotational_vel_multiplier(-1), damage_type_idx(0),
+		  rotational_vel_multiplier(1), damage_type_idx(0),
 		  damage_type_idx_sav( -1 ), inner_rad( 0 ), outer_rad( 0 ),
 		  damage( 0 ), blast( 0 ), initial_asteroid_strength( 0 ),
 		  fireball_radius_multiplier( -1 ), spawn_weight( 1 ), gravity_const( 0 )

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -63,6 +63,7 @@ public:
 	int			num_detail_levels;								// number of detail levels for this ship
 	int			detail_distance[MAX_ASTEROID_DETAIL_LEVELS];	// distance to change detail levels at
 	float		max_speed;										// cap on speed for asteroid
+	float		max_rotational_vel_multiplier;					// cap on rotational velocity multiplier for asteroid --wookieejedi
 	int			damage_type_idx;								//Damage type of the asteroid
 	int			damage_type_idx_sav;							// stored value from table used to reset damage_type_idx
 	float		inner_rad;										// radius within which maximum area effect damage is applied
@@ -80,7 +81,8 @@ public:
 	float		gravity_const;									// multiplier for mission gravity
 
 	asteroid_info( )
-		: type(ASTEROID_TYPE_DEBRIS), num_detail_levels(0), max_speed(0), damage_type_idx(0),
+		: type(ASTEROID_TYPE_DEBRIS), num_detail_levels(0), max_speed(0), 
+		  max_rotational_vel_multiplier(-1), damage_type_idx(0),
 		  damage_type_idx_sav( -1 ), inner_rad( 0 ), outer_rad( 0 ),
 		  damage( 0 ), blast( 0 ), initial_asteroid_strength( 0 ),
 		  fireball_radius_multiplier( -1 ), spawn_weight( 1 ), gravity_const( 0 )


### PR DESCRIPTION
Previously, there was no way to limit the velocity at which asteroids/debris randomly rotated. There was a way to set maximum speed, thus this PR follows that convention and adds a way to cap the rotational velocity scaling. This PR allows modders to set caps per type, including setting the value to 0 for no rotation.

A single scaling value was used b/c it was the most straightforward value to se via table and it was the employed the least code changes. Asteroids pick a random normalized vector for their rotation when spawning, and then that value is scaled by a random multiplier.