### PR TITLE
Add way to offset directive help text only

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -3708,7 +3708,7 @@ void load_gauge_directives(gauge_settings* settings)
 	char fname_middle[MAX_FILENAME_LEN] = "directives2";
 	char fname_bottom[MAX_FILENAME_LEN] = "directives3";
 	int bottom_bg_offset = 0;
-	int key_line_offset = 0;
+	int key_line_x_offset = 0;
 	
 	settings->origin[0] = 0.0f;
 	settings->origin[1] = 0.5f;
@@ -3757,8 +3757,8 @@ void load_gauge_directives(gauge_settings* settings)
 	if ( optional_string("Max Line Width:") ) {
 		stuff_int(&max_line_width);
 	}
-	if (optional_string("Key Line Offset:")) {
-		stuff_int(&key_line_offset);
+	if (optional_string("Key Line X Offset:")) {
+		stuff_int(&key_line_x_offset);
 	}
 
 	hud_gauge->initBitmaps(fname_top, fname_middle, fname_bottom);
@@ -3768,7 +3768,7 @@ void load_gauge_directives(gauge_settings* settings)
 	hud_gauge->initTextStartOffsets(text_start_offsets[0], text_start_offsets[1]);
 	hud_gauge->initHeaderOffsets(header_offsets[0], header_offsets[1]);
 	hud_gauge->initMaxLineWidth(max_line_width);
-	hud_gauge->initKeyLineOffset(key_line_offset);
+	hud_gauge->initKeyLineXOffset(key_line_x_offset);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -3708,6 +3708,7 @@ void load_gauge_directives(gauge_settings* settings)
 	char fname_middle[MAX_FILENAME_LEN] = "directives2";
 	char fname_bottom[MAX_FILENAME_LEN] = "directives3";
 	int bottom_bg_offset = 0;
+	int key_line_offset = 0;
 	
 	settings->origin[0] = 0.0f;
 	settings->origin[1] = 0.5f;
@@ -3756,6 +3757,9 @@ void load_gauge_directives(gauge_settings* settings)
 	if ( optional_string("Max Line Width:") ) {
 		stuff_int(&max_line_width);
 	}
+	if (optional_string("Key Line Offset:")) {
+		stuff_int(&key_line_offset);
+	}
 
 	hud_gauge->initBitmaps(fname_top, fname_middle, fname_bottom);
 	hud_gauge->initMiddleFrameOffsetY(middle_frame_offset_y);
@@ -3764,6 +3768,7 @@ void load_gauge_directives(gauge_settings* settings)
 	hud_gauge->initTextStartOffsets(text_start_offsets[0], text_start_offsets[1]);
 	hud_gauge->initHeaderOffsets(header_offsets[0], header_offsets[1]);
 	hud_gauge->initMaxLineWidth(max_line_width);
+	hud_gauge->initKeyLineOffset(key_line_offset);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -142,9 +142,9 @@ void HudGaugeDirectives::initMaxLineWidth(int w)
 	max_line_width = w;
 }
 
-void HudGaugeDirectives::initKeyLineOffset(int offset)
+void HudGaugeDirectives::initKeyLineXOffset(int offset)
 {
-	key_line_offset = offset;
+	key_line_x_offset = offset;
 }
 
 void HudGaugeDirectives::initBottomBgOffset(int offset)
@@ -255,14 +255,14 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 		y = position[1] + text_start_offsets[1] + Training_obj_num_display_lines * text_h;
 		z = TRAINING_OBJ_LINES_MASK(i + offset);
 
-		int line_offset = 0;
+		int line_x_offset = 0;
 
 		c = &Color_normal;
 		if (Training_obj_lines[i + offset] & TRAINING_OBJ_LINES_KEY) {
 			SCP_string temp_buf = message_translate_tokens(Mission_events[z].objective_key_text.c_str());  // remap keys
 			strcpy_s(buf, temp_buf.c_str());
 			c = &Color_bright_green;
-			line_offset = key_line_offset;
+			line_x_offset = key_line_x_offset;
 		} else {
 			strcpy_s(buf, Mission_events[z].objective_text.c_str());
 			if (Mission_events[z].count){
@@ -332,7 +332,7 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 		// blit the text
 		gr_set_color_fast(c);
 		
-		renderString(x + line_offset, y, EG_OBJ1 + i, buf);
+		renderString(x + line_x_offset, y, EG_OBJ1 + i, buf);
 		
 		Training_obj_num_display_lines++;
 

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -142,6 +142,11 @@ void HudGaugeDirectives::initMaxLineWidth(int w)
 	max_line_width = w;
 }
 
+void HudGaugeDirectives::initKeyLineOffset(int offset)
+{
+	key_line_offset = offset;
+}
+
 void HudGaugeDirectives::initBottomBgOffset(int offset)
 {
 	bottom_bg_offset = offset;
@@ -250,11 +255,14 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 		y = position[1] + text_start_offsets[1] + Training_obj_num_display_lines * text_h;
 		z = TRAINING_OBJ_LINES_MASK(i + offset);
 
+		int line_offset = 0;
+
 		c = &Color_normal;
 		if (Training_obj_lines[i + offset] & TRAINING_OBJ_LINES_KEY) {
 			SCP_string temp_buf = message_translate_tokens(Mission_events[z].objective_key_text.c_str());  // remap keys
 			strcpy_s(buf, temp_buf.c_str());
 			c = &Color_bright_green;
+			line_offset = key_line_offset;
 		} else {
 			strcpy_s(buf, Mission_events[z].objective_text.c_str());
 			if (Mission_events[z].count){
@@ -324,7 +332,7 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 		// blit the text
 		gr_set_color_fast(c);
 		
-		renderString(x, y, EG_OBJ1 + i, buf);
+		renderString(x + line_offset, y, EG_OBJ1 + i, buf);
 		
 		Training_obj_num_display_lines++;
 

--- a/code/mission/missiontraining.h
+++ b/code/mission/missiontraining.h
@@ -39,6 +39,7 @@ protected:
 	int text_start_offsets[2];
 	int text_h;
 	int max_line_width;
+	int key_line_offset;
 public:
 	HudGaugeDirectives();
 	void initBitmaps(char *fname_top, char *fname_middle, char *fname_bottom);
@@ -48,6 +49,7 @@ public:
 	void initTextStartOffsets(int x, int y);
 	void initTextHeight(int h);
 	void initMaxLineWidth(int w);
+	void initKeyLineOffset(int offset);
 	void render(float frametime) override;
 	void pageIn() override;
 	bool canRender() override;

--- a/code/mission/missiontraining.h
+++ b/code/mission/missiontraining.h
@@ -39,7 +39,7 @@ protected:
 	int text_start_offsets[2];
 	int text_h;
 	int max_line_width;
-	int key_line_offset;
+	int key_line_x_offset;
 public:
 	HudGaugeDirectives();
 	void initBitmaps(char *fname_top, char *fname_middle, char *fname_bottom);
@@ -49,7 +49,7 @@ public:
 	void initTextStartOffsets(int x, int y);
 	void initTextHeight(int h);
 	void initMaxLineWidth(int w);
-	void initKeyLineOffset(int offset);
+	void initKeyLineXOffset(int offset);
 	void render(float frametime) override;
 	void pageIn() override;
 	bool canRender() override;


### PR DESCRIPTION
It's bothered my design sensibilities for a long time that Directives and Directive Help Text are both aligned left. There have even been instances where someone reported they didn't understand a directive in BtA that turned out to be helper text for the directive above.

So to help with clarity this PR adds a way to offset only help text lines to help make things a little more obvious.