### PR TITLE
Fix for changing the number of banks on a ship

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2554,9 +2554,6 @@ static void parse_weapon_bank(ship_info *sip, bool is_primary, int *num_banks, i
 	const char *default_banks_str = is_primary ? "$Default PBanks:" : "$Default SBanks:";
 	const char *bank_capacities_str = is_primary ? "$PBank Capacity:" : "$SBank Capacity:";
 
-	// we initialize to the previous parse, which presumably worked
-	int num_bank_capacities = num_banks != NULL ? *num_banks : 0;
-
 	if (optional_string(default_banks_str))
 	{
 		// get weapon list
@@ -2565,6 +2562,9 @@ static void parse_weapon_bank(ship_info *sip, bool is_primary, int *num_banks, i
 		else
 			stuff_int_list(bank_default_weapons, max_banks, WEAPON_LIST_TYPE);
 	}
+
+	// we initialize to the previous parse, which presumably worked
+	int num_bank_capacities = num_banks != NULL ? *num_banks : 0;
 
 	if (optional_string(bank_capacities_str))
 	{


### PR DESCRIPTION
The number of capacities is initialized to the previous number of banks, and expected to match the number of banks (not talking to the model yet, so just still based on the number of table entries), but the actual listing of banks can change immediately afterward, erroneously triggering the 'incongruous num banks and num capacities' warning if they dont explicitly set the number of capacities to the new number. Initialize *after* any bank number changes may have happened. 