### PR TITLE
Revert removal of allowRelative in `applyToParticleInfo`

### DIFF
--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -84,15 +84,21 @@ void SourceOrigin::getHostOrientation(matrix* matOut) const {
 	}
 }
 
-void SourceOrigin::applyToParticleInfo(particle_info& info) const {
+void SourceOrigin::applyToParticleInfo(particle_info& info, bool allow_relative) const {
 	Assertion(m_originType != SourceOriginType::NONE, "Invalid origin type!");
 
 	switch (m_originType) {
 		case SourceOriginType::OBJECT: {
-			info.attached_objnum = static_cast<int>(OBJ_INDEX(m_origin.m_object.objp));
-			info.attached_sig = m_origin.m_object.objp->signature;
+			if (allow_relative) {
+				info.attached_objnum = static_cast<int>(OBJ_INDEX(m_origin.m_object.objp));
+				info.attached_sig = m_origin.m_object.objp->signature;
 
-			info.pos = m_offset;
+				info.pos = m_offset;
+			} else {
+				this->getGlobalPosition(&info.pos);
+				info.attached_objnum = -1;
+				info.attached_sig = -1;
+			}
 			break;
 		}
 		case SourceOriginType::PARTICLE: {

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -96,7 +96,7 @@ class SourceOrigin {
 	 *
 	 * @param info The particle_info this should be applied to
 	 */
-	void applyToParticleInfo(particle_info& info) const;
+	void applyToParticleInfo(particle_info& info, bool allowRelative = false) const;
 
 	/**
 	 * @brief Gets the velocity of the origin host


### PR DESCRIPTION
Follow-up to #5755. Before, `allowRelative` was always off, and disabled carrying over many possibly valuable bits of information from a particle's source downstream to the particle effect, why should we withhold it? Well what it means by "allow relative" is that by setting an `attached_objnum` we are implying that the particle's velocity and position are *relative* to that object, and it turns out that all weapon effects, inflight effect, homed flight effect, etc use `SourceOriginType::OBJECT` which enables that behavior if we unconditionally 'allow relative'.

None of the particle info math is built to take this into account, so for now, it needs to remain always off. There is other useful data here, so this does not disable as much as it once did, but the key 'relative motion' aspect is `attached_objnum` and `m_offset`. Otherwise, it simply takes global position like the others.