### PR TITLE
rename Vaporize Percent Chance

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -258,7 +258,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				if (optional_string("$Glide Attack Percent:")) {
 					parse_float_list(profile->glide_attack_percent, NUM_SKILL_LEVELS);
-					//Percent is nice for modders, but here in the code we want it betwwen 0 and 1.0
+					//Percent is nice for modders, but here in the code we want it between 0 and 1.0
 					//While we're at it, verify the range
 					for (i = 0; i < NUM_SKILL_LEVELS; i++) {
 						if (profile->glide_attack_percent[i] < 0.0f || profile->glide_attack_percent[i] > 100.0f) {
@@ -271,7 +271,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				if (optional_string("$Circle Strafe Percent:")) {
 					parse_float_list(profile->circle_strafe_percent, NUM_SKILL_LEVELS);
-					//Percent is nice for modders, but here in the code we want it betwwen 0 and 1.0
+					//Percent is nice for modders, but here in the code we want it between 0 and 1.0
 					//While we're at it, verify the range
 					for (i = 0; i < NUM_SKILL_LEVELS; i++) {
 						if (profile->circle_strafe_percent[i] < 0.0f || profile->circle_strafe_percent[i] > 100.0f) {
@@ -284,7 +284,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				if (optional_string("$Glide Strafe Percent:")) {
 					parse_float_list(profile->glide_strafe_percent, NUM_SKILL_LEVELS);
-					//Percent is nice for modders, but here in the code we want it betwwen 0 and 1.0
+					//Percent is nice for modders, but here in the code we want it between 0 and 1.0
 					//While we're at it, verify the range
 					for (i = 0; i < NUM_SKILL_LEVELS; i++) {
 						if (profile->glide_strafe_percent[i] < 0.0f || profile->glide_strafe_percent[i] > 100.0f) {
@@ -297,7 +297,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				if (optional_string("$Random Sidethrust Percent:")) {
 					parse_float_list(profile->random_sidethrust_percent, NUM_SKILL_LEVELS);
-					//Percent is nice for modders, but here in the code we want it betwwen 0 and 1.0
+					//Percent is nice for modders, but here in the code we want it between 0 and 1.0
 					//While we're at it, verify the range
 					for (i = 0; i < NUM_SKILL_LEVELS; i++) {
 						if (profile->random_sidethrust_percent[i] < 0.0f || profile->random_sidethrust_percent[i] > 100.0f) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1008,7 +1008,7 @@ typedef struct ship_type_info {
 	SCP_vector<int> ai_cripple_ignores;
 
 	//Explosions
-	float vaporize_chance;
+	float skip_deathroll_chance;
 
 	//Resources
 	SCP_vector<int> explosion_bitmap_anims;
@@ -1022,7 +1022,7 @@ typedef struct ship_type_info {
 		  ff_multiplier( 0.f ), emp_multiplier( 0.f ), warp_sound_range_multiplier( 1.f ),
 		  fog_start_dist( 0.f ), fog_complete_dist( 0.f ),
 		  ai_valid_goals( 0 ), ai_active_dock( 0 ), ai_passive_dock( 0 ),
-		  vaporize_chance( 0.f )
+		  skip_deathroll_chance( 0.f )
 
 	{
         flags.reset();
@@ -1211,7 +1211,7 @@ public:
 	int death_fx_count;
 	int	shockwave_count;					// the # of total shockwaves
 	SCP_vector<int> explosion_bitmap_anims;
-	float vaporize_chance;					
+	float skip_deathroll_chance;					
 
 	particle_effect		impact_spew;
 	particle_effect		damage_spew;

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1693,18 +1693,18 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 
 	sp->death_time = sp->final_death_time = timestamp(delta_time);	// Give him 3 secs to explode
 
-	//SUSHI: What are the chances of an instant vaporization? Check the ship type (objecttypes.tbl) as well as the ship (ships.tbl)
-	float vapChance;
+	//SUSHI: What are the chances of an instant explosion? Check the ship type (objecttypes.tbl) as well as the ship (ships.tbl)
+	float skipChance;
 	if (sp->flags[Ship::Ship_Flags::Vaporize])
-		vapChance = 1.0f;
-	else if (sip->vaporize_chance > 0.0f)
-		vapChance = sip->vaporize_chance;
+		skipChance = 1.0f;
+	else if (sip->skip_deathroll_chance > 0.0f)
+		skipChance = sip->skip_deathroll_chance;
 	else if (sip->class_type >= 0)
-		vapChance = Ship_types[sip->class_type].vaporize_chance;
+		skipChance = Ship_types[sip->class_type].skip_deathroll_chance;
 	else
-		vapChance = 0.0f;
+		skipChance = 0.0f;
 
-	if (frand() < vapChance)
+	if (frand() < skipChance)
 	{
 		// LIVE FOR 100 MS
 		sp->final_death_time = timestamp(100);


### PR DESCRIPTION
This option was misleadingly named when originally introduced, so give it a more sensible name.  The old name is still accepted for backwards compatibility.