### PR TITLE
Move no campaign warning to on Ready Room click

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -851,6 +851,8 @@ void main_hall_do(float frametime)
 			break;
 	}
 
+	extern bool Campaign_room_no_campaigns;
+
 	// do any processing based upon what happened to the snazzy menu
 	switch (snazzy_action) {
 		case SNAZZY_OVER:
@@ -904,7 +906,6 @@ void main_hall_do(float frametime)
 					Game_mode = GM_NORMAL;
 
 					// see if we have a missing campaign and force the player to select a new campaign if so
-					extern bool Campaign_room_no_campaigns;
 					if (!(Player->flags & PLAYER_FLAGS_IS_MULTI) && Campaign_file_missing &&
 						!Campaign_room_no_campaigns) {
 						int rc = popup(0,
@@ -1094,6 +1095,11 @@ void main_hall_do(float frametime)
 
 	gr_flip();
 	gr_reset_screen_scale();
+
+	// Log if we don't have a campaign set yet.
+	if (!(Player->flags & PLAYER_FLAGS_IS_MULTI) && Campaign_file_missing && !Campaign_room_no_campaigns) {
+		mprintf(("No valid campaign is currently selected for the active player!\n"));
+	}
 
 	// Display a popup if playermenu loaded a player file with a different version than expected
 	bool popup_shown = player_tips_controls();


### PR DESCRIPTION
This PR moves the valid campaign check to when the player clicks on Ready Room rather than at Mainhall Init. This offers a few advantages. First it allows getting into the game and not getting immediately greeted with a warning in some cases. Players can set options, view the tech room, etc.. all without having a valid campaign selected. Second, developers can do development on a mod without having a campaign file created yet. This still allows them to play single missions and everything. Mainhalls already default to using mainhall 0 if the campaign is invalid. Essentially this PR serves to lower the friction of the initial in-game experience.

I couldn't find any obvious problems in my testing. As best I can tell, all the appropriate places where this matters also have their own checks in place. For example, switching to Campaigns in the Simulator Room has its own warning popup and then simply stays in the single missions list.

In the place of the original check, this PR adds a log print.