### PR TITLE
Remove is-docked check for transfer-cargo sexp

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15245,12 +15245,6 @@ void sexp_transfer_cargo(int n)
 	if (!ship2 || !ship2->shipp)
 		return;
 
-	// we must be sure that these two objects are indeed docked
-	if (!dock_check_find_direct_docked_object(ship1->objp, ship2->objp)) {
-		Warning(LOCATION, "Tried to transfer cargo between %s and %s although they aren't docked!", ship1->name, ship2->name);
-		return;
-	}
-
 	if ( !stricmp(Cargo_names[ship1->shipp->cargo1 & CARGO_INDEX_MASK], "nothing") ) {
 		return;
 	}


### PR DESCRIPTION
Transfer-cargo is a convenience sexp to copy the cargo string from one ship to another and set the source ship cargo string to "nothing". I find it odd that this is limited to only ships that are docked as a mod could have ships that teleport cargo or other sci-fi tropes. Or a mission could need to transfer cargo between two props without docking them. Really, there's lots of possibilities and reasons to do this with ships that aren't docked together. If a FREDer does want to be sure to only transfer cargo between two docked ships, there is the is-docked sexp!

Notably the sexp description does not say it must be between two docked ships, so this PR simply removes that check and let's FREDers run wild with imagination. I can't think of a way this would affect previous uses of this sexp because it would have triggered a warning as-is, but I may be missing something. If anyone thinks it's important, this could be done behind an optional true/false parameter instead.