### PR TITLE
Implement direction-blind contrails option.

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -147,6 +147,7 @@ std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
 bool Calculate_subsystem_hitpoints_after_parsing;
 bool Disable_internal_loadout_restoration_system;
+bool Contrails_use_absolute_speed;
 
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Other.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
@@ -1352,6 +1353,10 @@ void parse_mod_table(const char *filename)
 				mprintf(("Game Settings Table: Subsystem hitpoints will be calculated as they are parsed\n"));
 		}
 
+		if (optional_string("$Contrails use absolute speed:")) {
+			stuff_boolean(&Contrails_use_absolute_speed);
+		}
+
 		required_string("#END");
 	}
 	catch (const parse::ParseException& e)
@@ -1531,6 +1536,7 @@ void mod_table_reset()
 	Randomize_particle_rotation = false;
 	Calculate_subsystem_hitpoints_after_parsing = false;
 	Disable_internal_loadout_restoration_system = false;
+	Contrails_use_absolute_speed = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -156,6 +156,7 @@ extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
 extern bool Calculate_subsystem_hitpoints_after_parsing;
 extern bool Disable_internal_loadout_restoration_system;
+extern bool Contrails_use_absolute_speed;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/ship/shipcontrails.cpp
+++ b/code/ship/shipcontrails.cpp
@@ -160,6 +160,8 @@ void ct_ship_process(ship *shipp)
 // if the object is below the limit for contrails
 int ct_below_limit(object *objp)
 {
+	if (Contrails_use_absolute_speed)
+		return objp->phys_info.speed < (float) The_mission.contrail_threshold;
 	return objp->phys_info.fspeed < (float) The_mission.contrail_threshold;
 }
 


### PR DESCRIPTION
One of the features requested in #5378 (specifically the one requested in #5274), this adds a new "$Contrails use absolute speed:" option to game_settings.tbl, which makes the `ct_below_limit()` function check `objp->phys_info.speed` instead of `objp->phys_info.fspeed`. This allows contrails to appear when moving in a direction other than forwards.