### PR TITLE
Scpui language selector

### DIFF
--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -344,12 +344,7 @@ namespace
 			stuff_string(lang_name, F_NAME, LCL_LANG_NAME_LEN + 1);
 
 			// find language and set the index, or if not found move to the next one
-			for (auto i = 0; i < (int)Lcl_languages.size(); ++i) {
-				if (!strcmp(Lcl_languages[i].lang_name, lang_name)) {
-					lang_idx = i;
-					break;
-				}
-			}
+			lang_idx = lcl_find_lang_index_by_name(lang_name);
 
 			if (lang_idx == -1) {
 				Warning(LOCATION, "Ignoring invalid language (%s) specified by font (%s); not built-in or in strings.tbl",

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -148,7 +148,9 @@ auto LanguageOption = options::OptionBuilder<int>("Game.Language",
 							   .serializer(language_serializer)
 							   .enumerator(language_enumerator)
 							   .display(language_display)
-							   .change_listener(false)
+							   .change_listener([](int val, bool){
+							       return false; //This makes it so that changing the language requires a game restart
+							   })
 							   .flags({options::OptionFlags::ForceMultiValueSelection})
 							   .category("Game")
 							   .default_val(0)

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -177,7 +177,7 @@ void lcl_init(int lang_init)
 
 	// if we only have one language at this point, we need to setup the builtin languages as we might be dealing with an old style strings.tbl
 	// which doesn't support anything beyond the builtin languages. Note, we start at i = 1 because we added the first language above.
-	if ((No_built_in_languages == false) && (static_cast<int>(Lcl_languages.size()) == 1)) {
+	if (!No_built_in_languages && (static_cast<int>(Lcl_languages.size()) == 1)) {
 		for (int i=1; i<NUM_BUILTIN_LANGUAGES; i++) {
 			Lcl_languages.push_back(Lcl_builtin_languages[i]);
 		}
@@ -212,9 +212,7 @@ void lcl_init(int lang_init)
 			strcpy_s(lang_string, ret);
 
 			// look it up
-			for (int idx = 0; idx < static_cast<int>(Lcl_languages.size()); idx++) {
-				lang = lcl_find_lang_index_by_name(lang_string);
-			}
+			lang = lcl_find_lang_index_by_name(lang_string);
 			if (lang < 0) {
 				lang = LCL_DEFAULT;
 			}

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -104,7 +104,7 @@ int language_deserializer(const json_t* value)
 	const char* ext;
 
 	json_error_t err;
-	if (json_unpack_ex((json_t*)value, &err, 0, "{s:s, s:s}", "name", &lang, "id", &ext) != 0) {
+	if (json_unpack_ex((json_t*)value, &err, 0, "{s:s, s:s}", "name", &lang, "ext", &ext) != 0) {
 		throw json_exception(err);
 	}
 
@@ -123,7 +123,7 @@ int language_deserializer(const json_t* value)
  */
 json_t* language_serializer(int lang)
 {
-	return json_pack("{ssss}", "name", Lcl_languages[lang].lang_name, "id", Lcl_languages[lang].lang_ext);
+	return json_pack("{ssss}", "name", Lcl_languages[lang].lang_name, "ext", Lcl_languages[lang].lang_ext);
 }
 
 static SCP_vector<int> language_enumerator()

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -36,10 +36,10 @@ SCP_vector<lang_info> Lcl_languages;
 // These are the original languages supported by FS2. The code expects these languages to be supported even if the tables don't
 
 lang_info Lcl_builtin_languages[NUM_BUILTIN_LANGUAGES] = {
-	{ "English",		"",		{127,0,176,0,0},	589986744},				// English ("" is correct; the game data files do not use a language extension for English)
-	{ "German",			"gr",	{164,0,176,0,0},	-1132430286 },			// German
-	{ "French",			"fr",	{164,0,176,0,0},	0 },					// French
-	{ "Polish",			"pl",	{127,0,176,0,0},	-1131728960},			// Polish
+	{ "English",  -1, "",   {127,0,176,0,0}, 589986744},    // English ("" is correct; the game data files do not use a language extension for English)
+	{ "German",   -1, "gr", {164,0,176,0,0}, -1132430286 }, // German
+	{ "French",   -1, "fr", {164,0,176,0,0}, 0 },           // French
+	{ "Polish",   -1, "pl", {127,0,176,0,0}, -1131728960},  // Polish
 };
 
 int Lcl_special_chars;
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1789 // This is the next available ID
+// #define XSTR_SIZE	1790 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset
@@ -110,15 +110,15 @@ static SCP_vector<int> language_enumerator()
 
 static SCP_string language_display(int value)
 {
-	return Lcl_languages[value].lang_name;
+	return XSTR(Lcl_languages[value].lang_name, Lcl_languages[value].xstr);
 }
 
 // Used to persist the language selection
 int Language_choice_index = -1;
 
 auto LanguageOption = options::OptionBuilder<int>("Game.Language",
-							   std::pair<const char*, int>{"Language", 1750},
-							   std::pair<const char*, int>{"The language to display", 1751})
+							   std::pair<const char*, int>{"Select Language", 1143},
+							   std::pair<const char*, int>{"The language to display", 1789})
 							   .enumerator(language_enumerator)
 							   .display(language_display)
 							   .bind_to_once(&Language_choice_index)
@@ -252,6 +252,11 @@ void parse_stringstbl_quick(const char *filename)
 			while (required_string_either("#End","$Language:")) {
 				required_string("$Language:");
 				stuff_string(language.lang_name, F_RAW, LCL_LANG_NAME_LEN + 1);
+				if (optional_string("+XSTR:")) {
+					stuff_int(&language.xstr);
+				} else {
+					language.xstr = -1;
+				}
 				required_string("+Extension:");
 				stuff_string(language.lang_ext, F_RAW, LCL_LANG_NAME_LEN + 1);
 

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -148,7 +148,7 @@ auto LanguageOption = options::OptionBuilder<int>("Game.Language",
 							   .serializer(language_serializer)
 							   .enumerator(language_enumerator)
 							   .display(language_display)
-							   .change_listener([](int val, bool){
+							   .change_listener([](int, bool){
 							       return false; //This makes it so that changing the language requires a game restart
 							   })
 							   .flags({options::OptionFlags::ForceMultiValueSelection})

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -37,6 +37,7 @@
 // language info table
 typedef struct lang_info {
 	char lang_name[LCL_LANG_NAME_LEN + 1];				// literal name of the language
+	int xstr;											// the xstr id for the language name itself. Used for the built-in langauge selector
 	char lang_ext[LCL_LANG_NAME_LEN + 1];				// the extension used for adding to names on disk access
 	SCP_vector<ubyte> special_char_indexes;				// where in the font do we have the special characters for this language
 														// note: treats 0 as "none" since a zero offset in a font makes no sense

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -71,6 +71,9 @@ extern bool *Lcl_unexpected_tstring_check;
 // LOCALIZE FUNCTIONS
 //
 
+// get the index of a language in the array by name
+int lcl_find_lang_index_by_name(const SCP_string& lang);
+
 // get an index we can use to look into the array, since we now have three different ways of using English
 // (translated, untranslated, and hybrid: internal translated, external untranslated)
 int lcl_get_current_lang_index();

--- a/code/localization/localize.h
+++ b/code/localization/localize.h
@@ -37,7 +37,7 @@
 // language info table
 typedef struct lang_info {
 	char lang_name[LCL_LANG_NAME_LEN + 1];				// literal name of the language
-	int xstr;											// the xstr id for the language name itself. Used for the built-in langauge selector
+	int xstr;											// the xstr id for the language name itself. Used for the built-in language selector
 	char lang_ext[LCL_LANG_NAME_LEN + 1];				// the extension used for adding to names on disk access
 	SCP_vector<ubyte> special_char_indexes;				// where in the font do we have the special characters for this language
 														// note: treats 0 as "none" since a zero offset in a font makes no sense

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -308,7 +308,7 @@ void parse_mod_table(const char *filename)
 		if (optional_string("$Don't initalize built-in languages by default:")) {
 			stuff_boolean(&No_built_in_languages);
 
-			mprintf(("Game Settings Table: Don't initialize built-in languages by default: %s\n", No_built_in_languages));
+			mprintf(("Game Settings Table: Don't initialize built-in languages by default: %s\n", No_built_in_languages ? "yes" : "no"));
 		}
 
 		if (optional_string("$Don't pre-empt training message voice:")) {

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -74,6 +74,7 @@ int Splash_fade_in_time;
 int Splash_fade_out_time;
 bool Splash_logo_center;
 bool Use_tabled_strings_for_default_language;
+bool No_built_in_languages;
 bool Dont_preempt_training_voice;
 SCP_string Movie_subtitle_font;
 bool Enable_scripts_in_fred; // By default FRED does not initialize the scripting system
@@ -302,6 +303,12 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Use_tabled_strings_for_default_language);
 
 			mprintf(("Game Settings Table: Use tabled strings (translations) for the default language: %s\n", Use_tabled_strings_for_default_language ? "yes" : "no"));
+		}
+
+		if (optional_string("$Don't initalize built-in languages by default:")) {
+			stuff_boolean(&No_built_in_languages);
+
+			mprintf(("Game Settings Table: Don't initialize built-in languages by default: %s\n", No_built_in_languages));
 		}
 
 		if (optional_string("$Don't pre-empt training message voice:")) {
@@ -1449,6 +1456,7 @@ void mod_table_reset()
 	Splash_fade_out_time = 0;
 	Splash_logo_center = false;
 	Use_tabled_strings_for_default_language = false;
+	No_built_in_languages = false;
 	Dont_preempt_training_voice = false;
 	Movie_subtitle_font = "";
 	Enable_scripts_in_fred = false;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -81,6 +81,7 @@ extern int Splash_fade_in_time;
 extern int Splash_fade_out_time;
 extern bool Splash_logo_center;
 extern bool Use_tabled_strings_for_default_language;
+extern bool No_built_in_languages;
 extern bool Dont_preempt_training_voice;
 extern SCP_string Movie_subtitle_font;
 extern bool Enable_scripts_in_fred;


### PR DESCRIPTION
Adds the ability to select the game's language from the in-game options menu with SCPUI. Right now this requires the game to be restarted because many xstr strings are initialized on game_init and not when they are actually displayed/needed. This could be changed in the future.

This also adds a feature to strings.tbl to assign an XSTR to the language name itself.

This also adds a feature to game_settings.tbl to prevent FSO from initializing the three additional built-in languages. This allows mods who don't support those languages to remove them from the SCPUI language selector.