### PR TITLE
Vectorize multi pxo

### DIFF
--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2272,7 +2272,7 @@ void multi_pxo_get_channels()
 void multi_pxo_clear_channels()
 {
 	// only clear a non-null list
-	if(Multi_pxo_channels.empty()){		
+	if(!Multi_pxo_channels.empty()){		
 		Multi_pxo_channels.clear();
 		Multi_pxo_channels.shrink_to_fit();
 

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2365,8 +2365,11 @@ void multi_pxo_make_channels(char *chan_str)
  */
 pxo_channel *multi_pxo_add_channel(char *name)
 {
-	pxo_channel channel = {'\0', '\0', -1, 0};
+	pxo_channel channel;
 	strcpy_s(channel.name, name);
+	strcpy_s(channel.desc, "");
+	channel.num_users = -1;
+	channel.num_servers = 0;
 	Multi_pxo_channels_vec.push_back(channel);
 	return &Multi_pxo_channels_vec.back();
 }
@@ -2525,7 +2528,7 @@ void multi_pxo_blit_channels()
 	if (Multi_pxo_channel_start < 0) {
 		return;
 	}
-	for (size_t i = 0; i < Multi_pxo_channels_vec.size(); i++) {		
+	for (int i = 0; i < static_cast<int>(Multi_pxo_channels_vec.size()); i++) {		
 		// if this is the currently selected item, highlight it
 		if(i == Multi_pxo_channel_select){
 			gr_set_color_fast(&Color_bright);

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -492,7 +492,7 @@ int Multi_pxo_max_chat_display[GR_NUM_RESOLUTIONS] = {
 #define CHAT_MODE_MOTD					5			// message of the day from the chat server
 
 // the chat list
-SCP_vector<chat_line> Multi_pxo_chat;
+SCP_list<chat_line> Multi_pxo_chat;
 
 // the current line to start displaying from
 int Multi_pxo_chat_start = 0;
@@ -2921,7 +2921,6 @@ void multi_pxo_chat_clear()
 {
 	// clear the text in all the lines
 	Multi_pxo_chat.clear();
-	Multi_pxo_chat.shrink_to_fit();
 	Multi_pxo_chat_start = 0;
 	Multi_pxo_chat_slider.set_numberItems(0);
 }
@@ -3067,7 +3066,8 @@ void multi_pxo_chat_blit()
 
 	for (int i = Multi_pxo_chat_start; i < static_cast<int>(Multi_pxo_chat.size()); i++) {
 		if (disp_count < gr_get_dynamic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])) {
-			const chat_line* line = &Multi_pxo_chat[i];
+			SCP_list<chat_line>::iterator line = Multi_pxo_chat.begin();
+			std::advance(line, i);
 			char* tok;
 			switch (line->mode) {
 			// if this is text from the server, display it all "bright"

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2274,7 +2274,7 @@ void multi_pxo_clear_channels()
 	// only clear a non-null list
 	if(Multi_pxo_channels.empty()){		
 		Multi_pxo_channels.clear();
-		Multi_pxo_channels.resize(0);
+		Multi_pxo_channels.shrink_to_fit();
 
 		// item we're going to start displaying at
 		Multi_pxo_channel_start = 0;
@@ -2478,7 +2478,7 @@ void multi_pxo_channel_refresh_servers()
 	}
 
 	// traverse the list of existing channels we know about and query the game tracker about them
-	for (auto channel : Multi_pxo_channels) {
+	for (auto &channel : Multi_pxo_channels) {
 		if (strlen(channel.name)) {
 			// copy in the info
 			memset(&filter, 0, sizeof(filter_game_list_struct));
@@ -2742,7 +2742,7 @@ void multi_pxo_handle_channel_change()
 void multi_pxo_clear_players()
 {
 	Multi_pxo_players.clear();
-	Multi_pxo_players.resize(0);
+	Multi_pxo_players.shrink_to_fit();
 	Multi_pxo_player_start = 0;	
 	Multi_pxo_player_select = -1;
 }
@@ -2921,7 +2921,7 @@ void multi_pxo_chat_clear()
 {
 	// clear the text in all the lines
 	Multi_pxo_chat.clear();
-	Multi_pxo_chat.resize(0);
+	Multi_pxo_chat.shrink_to_fit();
 	Multi_pxo_chat_start = 0;
 	Multi_pxo_chat_slider.set_numberItems(0);
 }

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -3128,9 +3128,6 @@ void multi_pxo_chat_blit()
  */
 void multi_pxo_goto_bottom()
 {
-	chat_line *backup;
-	int idx;
-	
 	// if we have less than the displayable amount of lines, do nothing
 	if(static_cast<int>(Multi_pxo_chat_vec.size()) <= gr_get_dynamic_font_lines(Multi_pxo_max_chat_display[gr_screen.res])){
 		// nothing to do for the slider
@@ -3907,7 +3904,7 @@ int multi_pxo_find_popup()
 			lookup = multi_pxo_find_channel(Multi_pxo_find_channel);
 			
 			// if we couldn't find it, don't join
-			if(lookup != NULL){				
+			if(lookup != nullptr){				
 				multi_pxo_join_channel(lookup);
 			}
 		}

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2101,7 +2101,7 @@ void multi_pxo_api_process()
 				if (ON_CHANNEL() ) {
 					lookup = multi_pxo_find_channel(Multi_pxo_channel_current.name);
 
-					if (lookup != NULL)
+					if (lookup != nullptr)
 						lookup->num_users++;
 				}
 				break;
@@ -2119,7 +2119,7 @@ void multi_pxo_api_process()
 				if ( ON_CHANNEL() ) {
 					lookup = multi_pxo_find_channel(Multi_pxo_channel_current.name);
 
-					if (lookup != NULL)
+					if (lookup != nullptr)
 						lookup->num_users--;
 				}
 				break;
@@ -2142,20 +2142,20 @@ void multi_pxo_api_process()
 				memset( &Multi_pxo_channel_current, 0, sizeof(pxo_channel) );
 				Multi_pxo_channel_switch.num_users = -1;			
 
-				SetNewChatChannel(NULL);
+				SetNewChatChannel(nullptr);
 
 				strcpy_s(Multi_pxo_channel_current.name, cmd->data);
 
 				// if we don't already have this guy on the list, add him
 				lookup = multi_pxo_find_channel(Multi_pxo_channel_current.name);
 	
-				if (lookup == NULL) {
+				if (lookup == nullptr) {
 					// create a new channel with the given name and place it on the channel list, return a pointer or NULL on fail
 					lookup = multi_pxo_add_channel(Multi_pxo_channel_current.name);
 				}
 
 				// set the user count to be 0
-				if (lookup != NULL)
+				if (lookup != nullptr)
 					lookup->num_users = 0;
 
 				// set our "last" channel to be this one
@@ -2186,8 +2186,8 @@ void multi_pxo_process_nick_change(char *data)
 	
 	// get the new string
 	from = strtok(data," ");
-	to = strtok(NULL,"");
-	if((from != NULL) && (to != NULL)){
+	to = strtok(nullptr,"");
+	if((from != nullptr) && (to != nullptr)){
 		int ply = multi_pxo_find_player(from);
 		if(ply > 0){
 			Multi_pxo_players_vec[ply] = to;
@@ -2238,7 +2238,7 @@ void multi_pxo_channel_count_update(char *name, int count)
 	// lookup the channel name on the normal list	
 	lookup = multi_pxo_find_channel(name);
 
-	if (lookup != NULL) {
+	if (lookup != nullptr) {
 		lookup->num_servers = (ushort)count;
 
 		nprintf(("Network","PXO : updated channel %s server count to %d\n",name,count));
@@ -2324,19 +2324,19 @@ void multi_pxo_make_channels(char *chan_str)
 	Multi_pxo_channel_last_refresh = f2fl(timer_get_fixed_seconds());
 
 	name_tok = strtok(chan_str," ");
-	if(name_tok == NULL){
+	if(name_tok == nullptr){
 		return;
 	} 
 	name_tok += 1;
 	do {
 		// parse the user count token		
-		user_tok = strtok(NULL," ");
+		user_tok = strtok(nullptr," ");
 
 		// parse the channel description token
-		desc_tok = strtok(NULL,"$");
+		desc_tok = strtok(nullptr,"$");
 
 		// something invalid in the data, return here.....
-		if((name_tok == NULL) || (user_tok == NULL) || (desc_tok == NULL)){
+		if((name_tok == nullptr) || (user_tok == nullptr) || (desc_tok == nullptr)){
 			return;
 		}
 
@@ -2348,13 +2348,13 @@ void multi_pxo_make_channels(char *chan_str)
 			// see if it exists already, and if so, just update the user count
 			lookup = multi_pxo_find_channel(name_tok);
 			
-			if(lookup != NULL){
+			if(lookup != nullptr){
 				lookup->num_users = (short)num_users;
 			}
 			// add the channel
 			else {
 				res = multi_pxo_add_channel(name_tok);
-				if(res != NULL){
+				if(res != nullptr){
 					res->num_users = (short)num_users;
 					strcpy_s(res->desc,desc_tok);
 				}		
@@ -2362,8 +2362,8 @@ void multi_pxo_make_channels(char *chan_str)
 		}				
 
 		// get the next name token
-		name_tok = strtok(NULL," ");
-	} while(name_tok != NULL);
+		name_tok = strtok(nullptr," ");
+	} while(name_tok != nullptr);
 
 	// refresh channels
 	multi_pxo_set_status_text(XSTR("Connected to Parallax Online",951));	
@@ -2376,7 +2376,7 @@ void multi_pxo_make_channels(char *chan_str)
 	// if we don't already have this guy on the list, add him
 	if(ON_CHANNEL()){
 		lookup = multi_pxo_find_channel(Multi_pxo_channel_current.name);
-		if(lookup == NULL){
+		if(lookup == nullptr){
 			// create a new channel with the given name and place it on the channel list, return a pointer or NULL on fail
 			multi_pxo_add_channel(Multi_pxo_channel_current.name);
 		}
@@ -2445,7 +2445,7 @@ void multi_pxo_process_channels()
 
 		// see if we have a mouse click on the channel region
 		if(Multi_pxo_channel_button.pressed()){
-			Multi_pxo_channel_button.get_mouse_pos(NULL,&my);
+			Multi_pxo_channel_button.get_mouse_pos(nullptr,&my);
 
 			// index from the top
 			item_index = my / (gr_get_font_height() + 1);
@@ -2660,7 +2660,7 @@ void multi_pxo_join_channel(pxo_channel *chan)
 		// decrement the count of our current channel
 		pxo_channel *lookup;
 		lookup = multi_pxo_find_channel(Multi_pxo_channel_current.name);
-		if(lookup != NULL){
+		if(lookup != nullptr){
 			lookup->num_users--;
 		}
 
@@ -2704,7 +2704,7 @@ void multi_pxo_handle_channel_change()
 	}
 
 	// if we are, check the status
-	switch(SetNewChatChannel(NULL)){
+	switch(SetNewChatChannel(nullptr)){
 	// failed to switch
 	case -1 :
 		// unset our switching struct
@@ -2734,13 +2734,13 @@ void multi_pxo_handle_channel_change()
 		// if we don't already have this guy on the list, add him
 		pxo_channel *lookup;
 		lookup = multi_pxo_find_channel(Multi_pxo_channel_current.name);
-		if(lookup == NULL){
+		if(lookup == nullptr){
 			// create a new channel with the given name and place it on the channel list, return a pointer or NULL on fail
 			lookup = multi_pxo_add_channel(Multi_pxo_channel_current.name);
 		}
 
 		// set the user count to be 1 (just me)
-		if(lookup != NULL){
+		if(lookup != nullptr){
 			lookup->num_users = 1;
 		}
 
@@ -2831,7 +2831,7 @@ void multi_pxo_process_players()
 
 	// see if we have a mouse click on the channel region
 	if(Multi_pxo_player_button.pressed()){
-		Multi_pxo_player_button.get_mouse_pos(NULL,&my);
+		Multi_pxo_player_button.get_mouse_pos(nullptr,&my);
 
 		// index from the top
 		item_index = my / (gr_get_font_height() + 1);

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2519,11 +2519,10 @@ void multi_pxo_blit_channels()
 	char chan_users[15];
 	char chan_servers[15];
 	int user_w,server_w;
-	int disp_count,y_start;
+	int y_start;
 	int line_height = gr_get_font_height() + 1;
 
 	// blit as many channels as we can
-	disp_count = 0;
 	y_start = Multi_pxo_chan_coords[gr_screen.res][1];
 	if (Multi_pxo_channel_start < 0) {
 		return;
@@ -2567,7 +2566,6 @@ void multi_pxo_blit_channels()
 		gr_string(Multi_pxo_chan_coords[gr_screen.res][0] + Multi_pxo_chan_coords[gr_screen.res][2] - Multi_pxo_chan_column_offsets[gr_screen.res][CHAN_GAMES_COLUMN], y_start, chan_servers, GR_RESIZE_MENU);
 
 		// increment the displayed count
-		disp_count++;
 		y_start += line_height;		
 
 	};

--- a/code/network/multi_pxo.h
+++ b/code/network/multi_pxo.h
@@ -50,6 +50,11 @@ typedef struct pxo_channel {
 
 extern SCP_vector<pxo_channel> Multi_pxo_channels_vec;
 
+// player related stuff -------------------------------------------
+#define MAX_PLAYER_NAME_LEN 32
+
+extern SCP_vector<SCP_string> Multi_pxo_players_vec;
+
 // ----------------------------------------------------------------------------------------------------
 // PXO FUNCTIONS
 //

--- a/code/network/multi_pxo.h
+++ b/code/network/multi_pxo.h
@@ -64,7 +64,7 @@ typedef struct chat_line {
 	int mode;
 } chat_line;
 
-extern SCP_vector<chat_line> Multi_pxo_chat;
+extern SCP_list<chat_line> Multi_pxo_chat;
 
 // ----------------------------------------------------------------------------------------------------
 // PXO FUNCTIONS

--- a/code/network/multi_pxo.h
+++ b/code/network/multi_pxo.h
@@ -55,6 +55,16 @@ extern SCP_vector<pxo_channel> Multi_pxo_channels_vec;
 
 extern SCP_vector<SCP_string> Multi_pxo_players_vec;
 
+// chat related stuff ----------------------------------------------
+#define MAX_CHAT_LINE_LEN 256
+
+typedef struct chat_line {
+	char text[MAX_CHAT_LINE_LEN + 1];
+	int mode;
+} chat_line;
+
+extern SCP_vector<chat_line> Multi_pxo_chat_vec;
+
 // ----------------------------------------------------------------------------------------------------
 // PXO FUNCTIONS
 //

--- a/code/network/multi_pxo.h
+++ b/code/network/multi_pxo.h
@@ -37,6 +37,19 @@
 #define MULTI_PXO_GAME_TRACKER_IP		"gt.pxo.com"
 #define MULTI_PXO_CHAT_IP					"chat.pxo.net"
 
+// channel related stuff -------------------------------------------
+#define MAX_CHANNEL_NAME_LEN 32
+#define MAX_CHANNEL_DESCRIPT_LEN 120
+
+typedef struct pxo_channel {
+	char name[MAX_CHANNEL_NAME_LEN + 1];     // name
+	char desc[MAX_CHANNEL_DESCRIPT_LEN + 1]; // description
+	short num_users;                         // # users, or -1 if not in use
+	short num_servers;                       // the # of servers registered on this channel
+} pxo_channel;
+
+extern SCP_vector<pxo_channel> Multi_pxo_channels_vec;
+
 // ----------------------------------------------------------------------------------------------------
 // PXO FUNCTIONS
 //

--- a/code/network/multi_pxo.h
+++ b/code/network/multi_pxo.h
@@ -48,12 +48,13 @@ typedef struct pxo_channel {
 	short num_servers;                       // the # of servers registered on this channel
 } pxo_channel;
 
-extern SCP_vector<pxo_channel> Multi_pxo_channels_vec;
+extern SCP_vector<pxo_channel> Multi_pxo_channels;
 
 // player related stuff -------------------------------------------
+#define MAX_CHAT_LINES 500 //Abritrary size limit. After this number, old messages are removed from the start of the chat vector
 #define MAX_PLAYER_NAME_LEN 32
 
-extern SCP_vector<SCP_string> Multi_pxo_players_vec;
+extern SCP_vector<SCP_string> Multi_pxo_players;
 
 // chat related stuff ----------------------------------------------
 #define MAX_CHAT_LINE_LEN 256
@@ -63,7 +64,7 @@ typedef struct chat_line {
 	int mode;
 } chat_line;
 
-extern SCP_vector<chat_line> Multi_pxo_chat_vec;
+extern SCP_vector<chat_line> Multi_pxo_chat;
 
 // ----------------------------------------------------------------------------------------------------
 // PXO FUNCTIONS


### PR DESCRIPTION
This PR prepares multi_pxo for SCPUI's API by converting the three main linked lists (channels, players, chat) to vectors. It moves some defines to the header for the API to eventually use as well.

This turned out to be kind of a booger because all three lists were implemented slightly differently and converting from a linked list to a vector for FSO's built-in UI isn't always straightforward. That said, tests showed each list rendering correctly. Channels were clickable (and joinable). Players are also clickable and the Player Info button worked as expected. Chat no longer has a limit of 60 messages. Sending, receiving, and scrolling all seem to be working.