### PR TITLE
Update PR build image and compilers

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
+    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -35,12 +35,6 @@ jobs:
         name: Checkout
         with:
           submodules: true
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
-        with:
-          vulkan-query-version: 1.3.204.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Linux
     needs: create_release   # Don't run this job until create_release is done and successful
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
+    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -93,12 +93,6 @@ jobs:
         with:
           submodules: true  # `true` to checkout submodules, `recursive` to recursively checkout submodules
           ref: '${{ github.ref }}'
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
-        with:
-          vulkan-query-version: 1.3.204.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}

--- a/.github/workflows/build-standalone.yaml
+++ b/.github/workflows/build-standalone.yaml
@@ -24,12 +24,6 @@ jobs:
       name: Checkout
       with:
         submodules: true
-    - name: Prepare Vulkan SDK
-      uses: humbletim/setup-vulkan-sdk@v1.2.0
-      with:
-        vulkan-query-version: 1.3.204.0
-        vulkan-components: Vulkan-Headers, Vulkan-Loader
-        vulkan-use-cache: true
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
+    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -41,12 +41,6 @@ jobs:
           [[ "${{ github.ref }}" =~ ^refs\/heads\/test\/(.*)$ ]]
           # Override the revision string so that the builds are named correctly
           echo "set(FSO_VERSION_REVISION_STR ${BASH_REMATCH[1]})" > "version_override.cmake"
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
-        with:
-          vulkan-query-version: 1.3.204.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}

--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -13,19 +13,19 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        compiler: [gcc-5, gcc-10]
+        compiler: [gcc-5, gcc-13, clang-16]
         cmake_options: [""]
         include:
           # Also include configurations that check if the code compiles without the graphics backends
           - configuration: Debug
-            compiler: gcc-10
+            compiler: gcc-13
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
           - configuration: Release
-            compiler: gcc-10
+            compiler: gcc-13
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
+    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -50,13 +50,20 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}
+      - name: Configure ccache
+        run: |
+          ccache --set-config=sloppiness=pch_defines,time_macros
+          ccache -p
 
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
           COMPILER: ${{ matrix.compiler }}
           JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
+          CCACHE_PATH: /usr/local/bin/ccache
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build
         run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all
+      - name: Show CCache statistics
+        run: ccache --show-stats

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -10,19 +10,19 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        compiler: [gcc-5, gcc-10, clang-9]
+        compiler: [gcc-5, gcc-13, clang-16]
         cmake_options: [""]
         include:
           # Also include configurations that check if the code compiles without the graphics backends
           - configuration: Debug
-            compiler: gcc-10
+            compiler: gcc-13
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
           - configuration: Release
-            compiler: gcc-10
+            compiler: gcc-13
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-3d30dc5
+    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -47,17 +47,16 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
-        with:
-          vulkan-query-version: 1.3.204.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
+          save: false # Caches are created by a separate job and only restored for PRs
+          verbose: 1
+      - name: Configure ccache
+        run: ccache --set-config=sloppiness=pch_defines,time_macros
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
           COMPILER: ${{ matrix.compiler }}
           JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
+          CCACHE_PATH: /usr/local/bin/ccache
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build
@@ -68,6 +67,8 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
           XDG_RUNTIME_DIR: /root
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
+      - name: Show CCache statistics
+        run: ccache --show-stats
       - name: Run Clang Tidy
         # Clang-tidy reuses the precompiled headers so this only makes sense for the clang compilers
         if: startsWith(matrix.compiler, 'clang-')
@@ -211,6 +212,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}
+          save: false # Caches are created by a separate job and only restored for PRs
       - name: Prepare Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,20 +47,6 @@ endif()
 
 PROJECT(FS2_Open LANGUAGES ${FSO_LANGUAGES})
 
-find_program(CCACHE_PROGRAM ccache)
-# Currently only GCC support ccache properly without generating additional warnings
-# Enable ccache on Mac even for clang
-if(CCACHE_PROGRAM AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR APPLE))
-	if(NOT CMAKE_C_COMPILER_LAUNCHER)
-		message(STATUS "Using ccache for C compilation: ${CCACHE_PROGRAM}")
-		SET(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
-	endif()
-	if(NOT CMAKE_CXX_COMPILER_LAUNCHER)
-		message(STATUS "Using ccache for C++ compilation: ${CCACHE_PROGRAM}")
-		SET(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
-	endif()
-endif()
-
 IF(CMAKE_CROSSCOMPILING)
 	SET(IMPORT_EXE_DIR "IMPORT_EXE_DIR-NOTFOUND" CACHE FILEPATH "Required for a cross compiling build, point to binary directory of a cmake build for the real OS")
 	INCLUDE(${IMPORT_EXE_DIR}/ImportExecutables.cmake)

--- a/ci/linux/configure_cmake.sh
+++ b/ci/linux/configure_cmake.sh
@@ -4,14 +4,13 @@ if [ "$COMPILER" = "gcc-5" ]; then
     export CC=gcc-5
     export CXX=g++-5
 fi
-if [ "$COMPILER" = "gcc-10" ]; then
-    export CC=gcc-10
-    export CXX=g++-10
+if [ "$COMPILER" = "gcc-13" ]; then
+    export CC=gcc-13
+    export CXX=g++-13
 fi
-if [ "$COMPILER" = "clang-9" ]; then
-    # Work around bug in clang that uses the wrong installation directory: https://bugs.llvm.org/show_bug.cgi?id=47460
-    export CC=$(readlink -f $(which clang-9))
-    export CXX=$(readlink -f $(which clang++-9))
+if [ "$COMPILER" = "clang-16" ]; then
+    export CC=clang-16
+    export CXX=clang++-16
 fi
 
 LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH
@@ -34,6 +33,11 @@ if [[ "$COMPILER" =~ ^clang.*$ ]]; then
     CXXFLAGS="$CXXFLAGS -Qunused-arguments"
 fi
 
+if [ ! "$CCACHE_PATH" = "" ]; then
+    echo "Using ccache at $CCACHE_PATH"
+    CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER_LAUNCHER=$CCACHE_PATH -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_PATH"
+fi
+
 mkdir build
 cd build
 
@@ -44,7 +48,11 @@ export LD_LIBRARY_PATH
 if [ "$RUNNER_OS" = "macOS" ]; then
     brew install ninja
 fi
+
+# CMAKE_JOB_POOLS and CMAKE_JOB_POOL_LINK ensure that when using ninja, link operations are done sequentially
+# we have some build rules that do not play nice with parallel invocation and that fixes these issues
+
 cmake -G Ninja -DFSO_FATAL_WARNINGS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $CMAKE_OPTIONS $PLATFORM_CMAKE_OPTIONS \
     -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DCMAKE_BUILD_TYPE=$CONFIGURATION \
     -DFFMPEG_USE_PRECOMPILED=ON -DFSO_BUILD_TESTS=ON -DFSO_BUILD_INCLUDED_LIBS=ON -DFSO_BUILD_QTFRED=OFF \
-    -DSHADERS_ENABLE_COMPILATION=ON ..
+    -DSHADERS_ENABLE_COMPILATION=ON -DCMAKE_JOB_POOLS=link=1 -DCMAKE_JOB_POOL_LINK=link ..

--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -425,6 +425,7 @@ DCF(bm_used, "Shows BmpMan Slot Usage") {
 
 	SCP_stringstream text;
 	text << "BmpMan Used Slots\n";
+	text << "  " << std::dec << std::setw(4) << std::setfill('0') << none << ", NONE\n";
 	text << "  " << std::dec << std::setw(4) << std::setfill('0') << pcx  << ", PCX\n";
 	text << "  " << std::dec << std::setw(4) << std::setfill('0') << user << ", User\n";
 	text << "  " << std::dec << std::setw(4) << std::setfill('0') << tga  << ", TGA\n";

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -451,7 +451,7 @@ const char* Joy_button_text_french_u[] = {
 	"Bouton 13",		"Bouton 14",		"Bouton 15",		"Bouton 16",		"Bouton 17",		"Bouton 18",
 	"Bouton 19",		"Bouton 20",		"Bouton 21",		"Bouton 22",		"Bouton 23",		"Bouton 24",
 	"Bouton 25",		"Bouton 26",		"Bouton 27",		"Bouton 28",		"Bouton 29",		"Bouton 30",
-	"Bouton 31",		"Bouton 32",		"Chapeau Arri\xc3\xa8""re",		"Chapeau Avant",		"Chapeau Gauche",		"Chapeau Droite"
+	"Bouton 31",		"Bouton 32",		("Chapeau Arri\xc3\xa8""re"),		"Chapeau Avant",		"Chapeau Gauche",		"Chapeau Droite"
 };
 
 const char* Joy_button_text_polish_u[] = {
@@ -460,7 +460,7 @@ const char* Joy_button_text_polish_u[] = {
 	"Przyc.13",	"Przyc.14",	"Przyc.15",	"Przyc.16",	"Przyc.17",	"Przyc.18",
 	"Przyc.19",	"Przyc.20",	"Przyc.21",	"Przyc.22",	"Przyc.23",	"Przyc.24",
 	"Przyc.25",	"Przyc.26",	"Przyc.27",	"Przyc.28",	"Przyc.29",	"Przyc.30",
-	"Przyc.31",	"Przyc.32",	"Hat Ty\xc5\x82",		"Hat Prz\xc3\xb3""d",	"Hat Lewo",		"Hat Prawo"
+	"Przyc.31",	"Przyc.32",	"Hat Ty\xc5\x82",		("Hat Prz\xc3\xb3""d"),	"Hat Lewo",		"Hat Prawo"
 };
 
 const char* Joy_button_text_english_u[] = {

--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -222,7 +222,6 @@ void cutscene_mark_viewable(const char* filename)
 
 	// change to lower case
 	strlwr(file);
-	int i = 0;
 	for (SCP_vector<cutscene_info>::iterator cut = Cutscenes.begin(); cut != Cutscenes.end(); ++cut)
 	{
 		// change the cutscene file name to lower case
@@ -235,7 +234,6 @@ void cutscene_mark_viewable(const char* filename)
 			cut->flags.set(Cutscene::Cutscene_Flags::Viewable);
 			return;
 		}
-		i++;
 	}
 
 	Warning(LOCATION, "Could not find cutscene '%s' in listing; cannot mark it viewable...", filename);

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -288,7 +288,7 @@ constexpr bool LoggingEnabled = false;
 // Disabling this functionality is dangerous, crazy values can run rampant unchecked, and the longer it's disabled
 // the more likely you are to have problems getting it working again.
 #if defined(NDEBUG)
-#	define Assert(expr) do { ASSUME(expr); } while (false)
+#	define Assert(expr) do { ASSUME(expr); (void)sizeof(expr); } while (false)
 #else
 #	define Assert(expr) do {\
 		if (!(expr)) {\

--- a/code/globalincs/toolchain/clang.h
+++ b/code/globalincs/toolchain/clang.h
@@ -34,7 +34,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do { } while (false)
+#	define Assertion(expr, msg, ...)  do { (void)sizeof(expr); } while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers

--- a/code/globalincs/toolchain/gcc.h
+++ b/code/globalincs/toolchain/gcc.h
@@ -34,7 +34,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do {} while (false)
+#	define Assertion(expr, msg, ...)  do { (void)sizeof(expr); } while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers

--- a/code/globalincs/toolchain/mingw.h
+++ b/code/globalincs/toolchain/mingw.h
@@ -36,7 +36,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do {} while (false)
+#	define Assertion(expr, msg, ...)  do { (void)sizeof(expr); } while (false)
 #else
 /*
  * NOTE: Assertion() can only use its proper functionality in compilers

--- a/code/globalincs/toolchain/msvc.h
+++ b/code/globalincs/toolchain/msvc.h
@@ -39,7 +39,7 @@
 #define ASSUME(x)
 
 #if defined(NDEBUG)
-#	define Assertion(expr, msg, ...)  do { ASSUME(expr); } while (false)
+#	define Assertion(expr, msg, ...)  do { ASSUME(expr); (void)sizeof(expr); } while (false)
 #else
 #	define Assertion(expr, msg, ...)                                    \
 		do {                                                            \

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -1396,11 +1396,11 @@ void gauge_assign_common(const gauge_settings* settings, std::unique_ptr<T>&& hu
 		for (auto ship_index = settings->ship_idx->begin(); ship_index != settings->ship_idx->end(); ++ship_index) {
 			std::unique_ptr<T> instance(new T());
 			*instance = *hud_gauge;
-			Ship_info[*ship_index].hud_gauges.push_back(move(instance));
+			Ship_info[*ship_index].hud_gauges.push_back(std::move(instance));
 		}
 		// Previous instance goes out of scope here and is destructed
 	} else {
-		default_hud_gauges.push_back(move(hud_gauge));
+		default_hud_gauges.push_back(std::move(hud_gauge));
 	}
 }
 

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -2064,7 +2064,7 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 	object		*target_objp;
 	ship			*shipp = NULL;
 	debris		*debrisp = NULL;
-	ship_info	*sip = NULL;
+	__UNUSED ship_info	*sip = NULL;
 	int is_ship = 0;
 	float		displayed_target_distance, displayed_target_speed, current_target_distance, current_target_speed;
 
@@ -2088,7 +2088,7 @@ void HudGaugeTargetBox::showTargetData(float  /*frametime*/)
 			break;
 
 		case OBJ_DEBRIS:
-			debrisp = &Debris[target_objp->instance]; 
+			debrisp = &Debris[target_objp->instance];
 			sip = &Ship_info[debrisp->ship_info_index];
 			break;
 

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -1129,7 +1129,6 @@ namespace joystick
 		init();
 
 		json_t* array = json_array();
-		size_t len = 0;
 
 		// Get the JSON info of each detected joystick and attach it to array
 		for (auto& joystick : joysticks) {
@@ -1137,7 +1136,6 @@ namespace joystick
 
 			if (object != nullptr) {
 				json_array_append_new(array, object);
-				len++;
 			}
 		}
 

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -382,15 +382,12 @@ int key_inkey()
 //	Else returns pending key (or waits for one if none waiting).
 int key_getch()
 {
-	int dummy=0;
 	int in;
 
 	if ( !key_inited ) return 0;
 	
 	while (!key_checkch()){
 		os_poll();
-
-		dummy++;
 	}
 	in = key_inkey();
 

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -159,7 +159,7 @@ void mission_log_obsolete_entries(LogType type, const char *pname)
 // that this event is for.  Don't add entries with this function for multiplayer
 void mission_log_add_entry(LogType type, const char *pname, const char *sname, int info_index, int flags)
 {
-	int last_entry_save;
+	__UNUSED int last_entry_save;
 	log_entry *entry;	
 
 	// multiplayer clients don't use this function to add log entries -- they will get

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1751,11 +1751,6 @@ void model_render_glowpoint_bitmap(int point_num, const vec3d *pos, const matrix
 				p.r = p.g = p.b = p.a = (ubyte)(255.0f * MAX(d,0.0f));
 
 				if((gpo && gpo->glow_bitmap_override)?(gpo->glow_bitmap > -1):(bank->glow_bitmap > -1)) {
-					int gpflags = TMAP_FLAG_GOURAUD | TMAP_FLAG_RGB | TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT | TMAP_FLAG_EMISSIVE;
-
-					if (use_depth_buffer)
-						gpflags |= TMAP_FLAG_SOFT_QUAD;
-
 					int bitmap_id = (gpo && gpo->glow_bitmap_override) ? gpo->glow_bitmap : bank->glow_bitmap;
 
 					if ( use_depth_buffer ) {

--- a/code/network/multi_lua.cpp
+++ b/code/network/multi_lua.cpp
@@ -130,7 +130,7 @@ static luacpp::LuaValue process_lua_data(ubyte* data, int& offset, lua_State* L)
 			luacpp::LuaValue value = process_lua_data(data, offset, L);
 			table.addValue(std::move(index), std::move(value));
 		}
-		return std::move(table);
+		return table;
 	}
 	default:
 		UNREACHABLE("Got invalid lua multi packet data type %d!", dataType);

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -110,7 +110,7 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 {
 	object *heavy_obj	= ship_ship_hit_info->heavy;
 	object *light_obj = ship_ship_hit_info->light;
-	int	player_involved;	// flag to indicate that A or B is the Player_obj
+	__UNUSED int player_involved;	// flag to indicate that A or B is the Player_obj
 
 	Assert( heavy_obj->type == OBJ_SHIP );
 	Assert( light_obj->type == OBJ_SHIP );

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -335,7 +335,8 @@ float shield_get_quad(object *objp, int quadrant_num) {
 	// no shield generator, so behave as normal
 	else
 	*/
-		return objp->shield_quadrant[quadrant_num];
+
+	return objp->shield_quadrant[quadrant_num];
 }
 
 float shield_get_strength(object *objp)

--- a/code/parse/sexp/EngineSEXP.cpp
+++ b/code/parse/sexp/EngineSEXP.cpp
@@ -5,7 +5,6 @@
 #include "parse/sexp.h"
 
 namespace sexp {
-
 EngineSEXPFactory::ArgumentListBuilder::ArgumentListBuilder(EngineSEXPFactory* parent) : _parent(parent) {}
 EngineSEXPFactory::ArgumentListBuilder& EngineSEXPFactory::ArgumentListBuilder::arg(int type, SCP_string help_text)
 {
@@ -20,11 +19,11 @@ EngineSEXPFactory::ArgumentListBuilder& EngineSEXPFactory::ArgumentListBuilder::
 {
 	Assertion(std::find_if(_parent->_arguments.begin(),
 				  _parent->_arguments.end(),
-				  [](const argument& arg) { return arg.optional_marker; }) == _parent->_arguments.end(),
+				  EngineSEXPFactory::isArgumentOptional) == _parent->_arguments.end(),
 		"Optional marker was already added!");
 	Assertion(std::find_if(_parent->_arguments.begin(),
 				  _parent->_arguments.end(),
-				  [](const argument& arg) { return arg.varargs_marker; }) == _parent->_arguments.end(),
+				  EngineSEXPFactory::isArgumentVarargsMarker) == _parent->_arguments.end(),
 		"Adding optional arguments after varags specifier is not allowed!");
 
 	argument arg;
@@ -37,7 +36,7 @@ EngineSEXPFactory::ArgumentListBuilder& EngineSEXPFactory::ArgumentListBuilder::
 {
 	Assertion(std::find_if(_parent->_arguments.begin(),
 				  _parent->_arguments.end(),
-				  [](const argument& arg) { return arg.varargs_marker; }) == _parent->_arguments.end(),
+				  EngineSEXPFactory::isArgumentVarargsMarker) == _parent->_arguments.end(),
 		"Varargs marker was already added!");
 
 	argument arg;
@@ -169,6 +168,14 @@ EngineSEXPFactory& EngineSEXPFactory::action(EngineSexpAction act)
 {
 	_action = std::move(act);
 	return *this;
+}
+bool EngineSEXPFactory::isArgumentOptional(const EngineSEXPFactory::argument& arg)
+{
+	return arg.optional_marker;
+}
+bool EngineSEXPFactory::isArgumentVarargsMarker(const EngineSEXPFactory::argument& arg)
+{
+	return arg.varargs_marker;
 }
 EngineSEXP::EngineSEXP(const SCP_string& name) : DynamicSEXP(name) {}
 

--- a/code/parse/sexp/EngineSEXP.h
+++ b/code/parse/sexp/EngineSEXP.h
@@ -36,6 +36,8 @@ class EngineSEXPFactory {
 		bool optional_marker = false;
 		bool varargs_marker = false;
 	};
+	static bool isArgumentOptional(const argument& arg);
+	static bool isArgumentVarargsMarker(const argument& arg);
 
 	SCP_vector<argument> _arguments;
 

--- a/code/scripting/hook_api.cpp
+++ b/code/scripting/hook_api.cpp
@@ -12,9 +12,9 @@ class HookManager {
   public:
 	int32_t addHook(HookBase* hook)
 	{
+		const auto doesHookExist = [hook](const HookBase* test) { return test->getHookName() == hook->getHookName(); };
 		Assertion(std::find_if(_hooks.cbegin(),
-							   _hooks.cend(),
-							   [hook](const HookBase* test) { return test->getHookName() == hook->getHookName(); }) ==
+							   _hooks.cend(), doesHookExist) ==
 					  _hooks.cend(),
 				  "Hook '%s' already exists!",
 				  hook->getHookName().c_str());
@@ -26,9 +26,10 @@ class HookManager {
 
 	void addHookWithId(HookBase* hook)
 	{
+		const auto doesHookExist = [hook](const HookBase* test) { return test->getHookName() == hook->getHookName(); };
 		Assertion(std::find_if(_hooks.cbegin(),
 							   _hooks.cend(),
-							   [hook](const HookBase* test) { return test->getHookName() == hook->getHookName(); }) ==
+					  doesHookExist) ==
 					  _hooks.cend(),
 				  "Hook '%s' already exists!",
 				  hook->getHookName().c_str());

--- a/code/scripting/util/LuaValueDeserializer.cpp
+++ b/code/scripting/util/LuaValueDeserializer.cpp
@@ -46,7 +46,7 @@ luacpp::LuaValue LuaValueDeserializer::jsonToValue(json_t* json) const
 		{
 			objectTbl.addValue(std::get<0>(pair), jsonToValue(std::get<1>(pair)));
 		}
-		return std::move(objectTbl);
+		return objectTbl;
 	}
 	case JSON_ARRAY: {
 		auto arrayTbl = luacpp::LuaTable::create(m_L);
@@ -56,7 +56,7 @@ luacpp::LuaValue LuaValueDeserializer::jsonToValue(json_t* json) const
 			arrayTbl.addValue(i, jsonToValue(value));
 			++i;
 		}
-		return std::move(arrayTbl);
+		return arrayTbl;
 	}
 	case JSON_STRING: {
 		const auto val = json_string_value(json);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1652,13 +1652,6 @@ void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_shi
 			if ( create_debris ) {
 				half_ship->draw_debris[i] = DEBRIS_FREE;		// mark debris to not render with model
 				vec3d center_to_debris, debris_vel, radial_vel;
-				// check if last debris piece, ie, debris_count == 0
-				int debris_count = 0;
-				for (int j=0; j<pm->num_debris_objects; j++ ) {
-					if (half_ship->draw_debris[j] == DEBRIS_DRAW) {
-						debris_count++;
-					}
-				} 
 				// do debris create here, but not for live debris
 				// debris vel (1) split ship vel (2) split ship rotvel (3) random
 				if ( !is_live_debris ) {


### PR DESCRIPTION
This advances the versions for Clang to 16 and GCC to 13 along with fixing any warnings these new versions are detecting now.

The new image versions also include Vulkan so the additional workflow step for installing that is not necessary anymore.