### PR TITLE
Verify this is in bounds and add vector_inbound macro

### DIFF
--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -26,6 +26,16 @@ bool SCP_vector_contains(SCP_vector<T>& vector, T item) {
 }
 
 template <typename T>
+bool SCP_vector_inbounds(SCP_vector<T>& vector, int idx) {
+	return ((idx >= 0) && (idx < static_cast<int>(vector.size())));
+}
+
+template <typename T>
+bool SCP_vector_inbounds(SCP_vector<T>& vector, size_t idx) {
+	return ((idx >= 0) && (idx < vector.size()));
+}
+
+template <typename T>
 using SCP_list = std::list<T, std::allocator<T>>;
 
 

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -26,13 +26,13 @@ bool SCP_vector_contains(SCP_vector<T>& vector, T item) {
 }
 
 template <typename T>
-bool SCP_vector_inbounds(SCP_vector<T>& vector, int idx) {
+inline bool SCP_vector_inbounds(SCP_vector<T>& vector, int idx) {
 	return ((idx >= 0) && (idx < static_cast<int>(vector.size())));
 }
 
 template <typename T>
-bool SCP_vector_inbounds(SCP_vector<T>& vector, size_t idx) {
-	return ((idx >= 0) && (idx < vector.size()));
+inline bool SCP_vector_inbounds(SCP_vector<T>& vector, size_t idx) {
+	return idx < vector.size();
 }
 
 template <typename T>

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -111,7 +111,7 @@ int language_deserializer(const json_t* value)
 	int id = lcl_find_lang_index_by_name(lang);
 
 	//does the extension also match? If not then we probably have a new language, so use default instead
-	if (!stricmp(Lcl_languages[id].lang_ext, ext)) {
+	if (SCP_vector_inbounds(Lcl_languages, id) && !stricmp(Lcl_languages[id].lang_ext, ext)) {
 		return id;
 	}
 


### PR DESCRIPTION
This language check should have verified the index is in bounds for the vector, so this PR fixes that. 

It also adds a method and an overload to do the inbounds check a little more clearly where needed in the future.