### PR TITLE
untangle turret code a bit

### DIFF
--- a/code/ai/aiinternal.h
+++ b/code/ai/aiinternal.h
@@ -26,10 +26,10 @@ int object_is_targetable(object *target, ship *viewer);
 int num_nearby_fighters(int enemy_team_mask, vec3d *pos, float threshold);
 
 //Returns true if OK for *aip to fire its current weapon at its current target.
-int check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int secondary_bank, ship_subsys* turret);
+bool check_ok_to_fire(int objnum, int target_objnum, weapon_info *wip, int secondary_bank, vec3d *firing_pos_global);
 
 //Returns true if *aip has a line of sight to its current target.
-bool check_los(int objnum, int target_objnum, float threshold, int primary_bank, int secondary_bank, ship_subsys* turret);
+bool check_los(int objnum, int target_objnum, float threshold, int primary_bank, int secondary_bank, vec3d *firing_pos_global);
 
 //Does all the stuff needed to aim and fire a turret.
 void ai_turret_execute_behavior(ship *shipp, ship_subsys *ss);

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1200,7 +1200,7 @@ void ship_get_global_turret_info(const object *objp, const model_subsystem *tp, 
  * @param gpos          Absolute position of gun firing point
  * @param gvec          Vector from *gpos to *targetp
  * @param use_angles    Use current angles
- * @param targetp       Pointer to target object
+ * @param targetp       Absolute position of target object
  */
 void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos, vec3d *gvec, int use_angles, vec3d *targetp)
 {
@@ -1220,6 +1220,7 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 	if (use_angles) {
 		model_instance_local_to_global_dir(gvec, &tp->turret_norm, pm, pmi, tp->turret_gun_sobj, &objp->orient);
 	} else if (tp->flags[Model::Subsystem_Flags::Share_fire_direction]) {
+		Assertion(targetp != nullptr, "The targetp parameter must not be null here!");
 		vec3d avg_gun_pos, avg_gpos;
 		vm_vec_avg_n(&avg_gun_pos, tp->turret_num_firing_points, tp->turret_firing_point);
 
@@ -1227,6 +1228,7 @@ void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos
 
 		vm_vec_normalized_dir(gvec, targetp, &avg_gpos);
 	} else {
+		Assertion(targetp != nullptr, "The targetp parameter must not be null here!");
 		vm_vec_normalized_dir(gvec, targetp, gpos);
 	}
 }

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -1211,7 +1211,7 @@ void get_turret_cam_pos(camera *cam, vec3d *pos)
 	{
 		if(ssp->system_info->subobj_num == cam->get_object_host_submodel())
 		{
-			ship_get_global_turret_gun_info(cam->get_object_host(), ssp, pos, &normal_cache, 1, NULL);
+			ship_get_global_turret_gun_info(cam->get_object_host(), ssp, pos, true, &normal_cache, true, nullptr);
 			vec3d offset = vmd_zero_vector;
 			offset.xyz.x = 0.0001f;
 			vm_vec_add2(pos, &offset); // prevent beam turrets from crashing with a nullvec

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1091,7 +1091,7 @@ extern int modelstats_num_sortnorms;
 #endif
 
 // Tries to move joints so that the turret points to the point dst.
-extern int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_subsys *ss, vec3d *dst, bool reset = false);
+extern int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_subsys *ss, vec3d *dst);
 
 // Rotates the angle of a submodel.  Use this so the right unlocked axis
 // gets stuffed.

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -66,7 +66,7 @@ namespace Model {
         Turret_use_ammo,			// enables ammo consumption for turrets (DahBlount)
         Autorepair_if_disabled,		// Allows the subsystem to repair itself even if disabled (MageKing17)
         No_autorepair_if_disabled,	// Inversion of the previous; disallows this particular subsystem if the ship-wide flag is set (MageKing17)
-        Share_fire_direction,		// (DahBlount) Whenever the turret fires, make all firing points fire in the same direction.
+        Share_fire_direction,		// (DahBlount) Whenever the turret fires a beam, make all beams fire in the same direction.
         No_sparks,          // Subsystem does not generate sparks if hit - m!m
 		No_impact_debris,    // Don't spawn the small debris on impact - m!m
 		Hide_turret_from_loadout_stats, // Turret is not accounted for in auto-generated "Turrets" line in the ship loadout window --wookieejedi

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4375,10 +4375,10 @@ void submodel_translate(bsp_info *sm, submodel_instance *smi)
 	submodel_canonicalize_translation(sm, smi);
 }
 
-// Tries to move joints so that the turret points to the point dst.
+// Tries to move joints so that the turret points to the point dst.  If dst is nullptr, the turret's joints are reset.
 // turret1 is the angles of the turret, turret2 is the angles of the gun from turret
 //	Returns 1 if rotated gun, 0 if no gun to rotate (rotation handled by AI)
-int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_subsys *ss, vec3d *dst, bool reset)
+int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_subsys *ss, vec3d *dst)
 {
 	model_subsystem *turret = ss->system_info;
 
@@ -4401,7 +4401,7 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 	// Find the heading and pitch that the gun needs to turn to
 	float desired_base_angle, desired_gun_angle;
 
-	if (!reset) {
+	if (dst) {
 		vec3d world_axis, world_pos, planar_dst, dir, rotated_vec;
 		matrix save_base_orient;
 
@@ -4476,10 +4476,10 @@ int model_rotate_gun(object *objp, polymodel *pm, polymodel_instance *pmi, ship_
 	float step_size = turret->turret_turning_rate * calc_time;
 	float base_delta, gun_delta;
 
-	if (reset)
-		step_size /= 3.0f;
-	else
+	if (dst)
 		ss->rotation_timestamp = timestamp(turret->turret_reset_delay);
+	else
+		step_size /= 3.0f;
 
 	base_delta = vm_interp_angle(&base_smi->cur_angle, desired_base_angle, step_size, turret->turret_base_fov > -1.0f);
 	gun_delta = vm_interp_angle(&gun_smi->cur_angle, desired_gun_angle, step_size);

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -896,7 +896,7 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 	auto pm = model_get(pmi->model_num);
 
-	int ret_val = model_rotate_gun(objp, pm, pmi, sso->ss, &pos, reset);
+	int ret_val = model_rotate_gun(objp, pm, pmi, sso->ss, reset ? nullptr : &pos);
 
 	if (ret_val)
 		return ADE_RETURN_TRUE;

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -865,7 +865,7 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRan
 	//Get default turret info
 	vec3d gpos, gvec;
 
-	ship_get_global_turret_gun_info(sso->objp, sso->ss, &gpos, &gvec, 1, NULL);
+	ship_get_global_turret_gun_info(sso->objp, sso->ss, &gpos, false, &gvec, true, nullptr);
 	if (override_gvec != nullptr)
 		gvec = *override_gvec;
 
@@ -961,7 +961,7 @@ ADE_FUNC(
 
 	vec3d gpos, gvec;
 
-	ship_get_global_turret_gun_info(sso->objp, sso->ss, &gpos, &gvec, 1, NULL);
+	ship_get_global_turret_gun_info(sso->objp, sso->ss, &gpos, false, &gvec, true, nullptr);
 
 	return ade_set_args(L, "oo", l_Vector.Set(gpos), l_Vector.Set(gvec));
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7407,6 +7407,7 @@ void ship_subsys::clear()
 	targeted_subsys = NULL;
 	scripting_target_override = false;
 	last_fired_weapon_info_index = -1;
+	shared_fire_direction_beam_objnum = -1;
 
 	turret_pick_big_attack_point_timestamp = timestamp(0);
 	turret_big_attack_point = vmd_zero_vector;
@@ -7603,6 +7604,9 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 		ship_system->disruption_timestamp=timestamp(0);
 		ship_system->turret_pick_big_attack_point_timestamp = timestamp(0);
 		ship_system->scripting_target_override = false;
+		ship_system->last_fired_weapon_info_index = -1;
+		ship_system->shared_fire_direction_beam_objnum = -1;
+
 		vm_vec_zero(&ship_system->turret_big_attack_point);
 		for(j = 0; j < NUM_TURRET_ORDER_TYPES; j++)
 		{

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -374,6 +374,7 @@ public:
 	ship_subsys	*targeted_subsys;					//	subsystem this turret is attacking
 	bool	scripting_target_override;
 	int		last_fired_weapon_info_index;		// which weapon class was last fired
+	int		shared_fire_direction_beam_objnum;		// reference beam for shared fire direction
 
 	int		turret_pick_big_attack_point_timestamp;	//	Next time to pick an attack point for this turret
 	vec3d	turret_big_attack_point;			//	local coordinate of point for this turret to attack on enemy
@@ -1920,7 +1921,7 @@ int is_support_allowed(object *objp, bool do_simple_check = false);
 //	Stuffs:
 //		*gpos: absolute position of gun firing point
 //		*gvec: vector fro *gpos to *targetp
-void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos, vec3d *gvec, int use_angles, vec3d *targetp);
+void ship_get_global_turret_gun_info(object *objp, ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, vec3d *targetp);
 
 //	Given an object and a turret on that object, return the global position and forward vector
 //	of the turret.   The gun normal is the unrotated gun normal, (the center of the FOV cone), not

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -4157,8 +4157,6 @@ int beam_ok_to_fire(beam *b)
 		vec3d aim_dir;
 		vm_vec_sub(&aim_dir, &b->last_shot, &b->last_start);
 		vm_vec_normalize(&aim_dir);
-		vec3d turret_dir, turret_pos;
-		beam_get_global_turret_gun_info(b->objp, b->subsys, &turret_pos, false, &turret_dir, true, nullptr, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 
 		if (The_mission.ai_profile->flags[AI::Profile_Flags::Force_beam_turret_fov]) {
 			vec3d turret_normal;
@@ -4174,6 +4172,8 @@ int beam_ok_to_fire(beam *b)
 				return 0;
 			}
 		} else {
+			vec3d turret_dir, turret_pos;
+			beam_get_global_turret_gun_info(b->objp, b->subsys, &turret_pos, false, &turret_dir, true, nullptr, (b->flags & BF_IS_FIGHTER_BEAM) != 0);
 			if (vm_vec_dot(&aim_dir, &turret_dir) < b->subsys->system_info->turret_fov) {
 				nprintf(("BEAM", "BEAM : powering beam down because of FOV condition!\n"));
 				return 0;
@@ -4182,16 +4182,13 @@ int beam_ok_to_fire(beam *b)
 
 		if (b->subsys->system_info->flags[Model::Subsystem_Flags::Turret_hull_check]) {
 			int model_num = Ship_info[shipp->ship_info_index].model_num;
-			vec3d end;
-			vm_vec_scale_add(&end, &turret_pos, &aim_dir, model_get_radius(model_num));
-
 			mc_info hull_check;
 			hull_check.model_instance_num = shipp->model_instance_num;
 			hull_check.model_num = model_num;
 			hull_check.orient = &b->objp->orient;
 			hull_check.pos = &b->objp->pos;
-			hull_check.p0 = &turret_pos;
-			hull_check.p1 = &end;
+			hull_check.p0 = &b->last_start;
+			hull_check.p1 = &b->last_shot;
 			hull_check.flags = MC_CHECK_MODEL | MC_CHECK_RAY;
 
 			if (model_collide(&hull_check)) {


### PR DESCRIPTION
1. make `check_ok_to_fire` return a boolean (like `check_los`)
2. make `check_ok_to_fire` and `check_los` both use a position argument since we don't need the whole turret
3. remove the redundant position prediction code from `ship_get_global_turret_gun_info` (since that needs to be a "pure" function) while making sure "share fire direction" still works
4. skip calculation of the vector in `ship_get_global_turret_gun_info` if we don't need it
5. move the position prediction code out of `aifft_rotate_turret` and into its own function
6. prune some gun position calculation calls since in most cases one will suffice
7. fix position "jitter" with weapon subsystem damage in missions that use gravity
8. `model_rotate_gun` now uses a nullptr position for a reset instead of an extra boolean argument
9. use a more efficient method to calculate gun barrel length
10. a couple variable name changes for clarity
11. fix the "share fire direction" flag

~~Currently being tested with help from Rajjia.~~ Tested with no issues found.