### PR TITLE
Add cockpit 'sway'

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1178,9 +1178,9 @@ bool HudGauge::canRender()
 	if (render_for_cockpit_toggle > 0) {
 		if ((Viewer_mode & VM_CHASE) && (render_for_cockpit_toggle == 2)) {
 			return true;
-		} else if (cockpitActive && (render_for_cockpit_toggle == 2)) {
+		} else if (Cockpit_active && (render_for_cockpit_toggle == 2)) {
 			return false;
-		} else if (!cockpitActive && (render_for_cockpit_toggle == 1)) {
+		} else if (!Cockpit_active && (render_for_cockpit_toggle == 1)) {
 			return false;
 		}
 	}

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -323,11 +323,23 @@ ADE_FUNC(isCommMenuOpen, l_HUD, nullptr, "Returns whether the HUD comm menu is c
 
 ADE_VIRTVAR(toggleCockpits, l_HUD, "boolean", "Gets or sets whether the the cockpit model will be rendered.", "boolean", "true if being rendered, false otherwise")
 {
-	bool choice = !disableCockpits;
+	bool choice = !Disable_cockpits;
 
 	if (ADE_SETTING_VAR && ade_get_args(L, "*b", &choice))
 	{
-		disableCockpits = !choice;
+		Disable_cockpits = !choice;
+	}
+
+	return ade_set_args(L, "b", choice);
+}
+
+ADE_VIRTVAR(toggleCockpitSway, l_HUD, "boolean", "Gets or sets whether the the cockpit model will sway due to ship acceleration.", "boolean", "true if using 'sway', false otherwise")
+{
+	bool choice = !Disable_cockpit_sway;
+
+	if (ADE_SETTING_VAR && ade_get_args(L, "*b", &choice))
+	{
+		Disable_cockpit_sway = !choice;
 	}
 
 	return ade_set_args(L, "b", choice);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7824,7 +7824,7 @@ void ship_render_player_ship(object* objp) {
 	ship_get_eye_local(&eye_pos, &eye_orient, objp);
 	vm_vec_copy_scale(&eye_offset, &eye_pos, -1.0f);
 	if (!Disable_cockpit_sway)
-		eye_offset += sip->cockpit_sway_val * objp->phys_info.acceleration / 5000.0f;
+		eye_offset += sip->cockpit_sway_val * objp->phys_info.acceleration;
 
 	fov_t fov_backup = Proj_fov;
 	g3_set_fov(Sexp_fov <= 0.0f ? COCKPIT_ZOOM_DEFAULT : Sexp_fov);
@@ -7898,7 +7898,7 @@ void ship_render_player_ship(object* objp) {
 			vec3d offset = sip->cockpit_offset;
 			vm_vec_unrotate(&offset, &offset, &objp->orient);
 			if (!Disable_cockpit_sway)
-				offset += sip->cockpit_sway_val * objp->phys_info.acceleration / 5000.0f;
+				offset += sip->cockpit_sway_val * objp->phys_info.acceleration;
 			model_render_immediate(&shadow_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &offset);
 		}
 
@@ -7947,7 +7947,7 @@ void ship_render_player_ship(object* objp) {
 		vec3d offset = sip->cockpit_offset;
 		vm_vec_unrotate(&offset, &offset, &objp->orient);
 		if (!Disable_cockpit_sway)
-			offset += sip->cockpit_sway_val * objp->phys_info.acceleration / 5000.0f;
+			offset += sip->cockpit_sway_val * objp->phys_info.acceleration;
 		model_render_immediate(&render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &offset);
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -133,8 +133,9 @@ ship	Ships[MAX_SHIPS];
 ship	*Player_ship;
 int		*Player_cockpit_textures;
 SCP_vector<cockpit_display> Player_displays;
-bool disableCockpits = false;
-bool cockpitActive = false;
+bool Disable_cockpits = false;
+bool Disable_cockpit_sway = false;
+bool Cockpit_active = false;
 
 wing	Wings[MAX_WINGS];
 bool	Ships_inited = false;
@@ -930,6 +931,7 @@ void ship_info::clone(const ship_info& other)
 
 	strcpy_s(cockpit_pof_file, other.cockpit_pof_file);
 	cockpit_offset = other.cockpit_offset;
+	cockpit_sway_val = other.cockpit_sway_val;
 	strcpy_s(pof_file, other.pof_file);
 	strcpy_s(pof_file_hud, other.pof_file_hud);
 	strcpy_s(pof_file_tech, other.pof_file_tech);
@@ -1281,6 +1283,7 @@ void ship_info::move(ship_info&& other)
 
 	std::swap(cockpit_pof_file, other.cockpit_pof_file);
 	std::swap(cockpit_offset, other.cockpit_offset);
+	cockpit_sway_val = other.cockpit_sway_val;
 	std::swap(pof_file, other.pof_file);
 	std::swap(pof_file_hud, other.pof_file_hud);
 	std::swap(pof_file_tech, other.pof_file_tech);
@@ -1650,6 +1653,7 @@ ship_info::ship_info()
 
 	cockpit_pof_file[0] = '\0';
 	vm_vec_zero(&cockpit_offset);
+	cockpit_sway_val = 0.0;
 	pof_file[0] = '\0';
 	pof_file_hud[0] = '\0';
 	pof_file_tech[0] = '\0';
@@ -2932,6 +2936,12 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 	{
 		stuff_vec3d(&sip->cockpit_offset);
 	}
+
+	if (optional_string("+Cockpit Sway Multiplier:"))
+	{
+		stuff_float(&sip->cockpit_sway_val);
+	}
+
 	while(optional_string( "$Cockpit Display:" )) 
 	{
 		cockpit_display_info display;
@@ -7790,11 +7800,11 @@ void ship_render_player_ship(object* objp) {
 
 	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
 
-	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !disableCockpits;
+	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
 	const bool renderShipModel = (sip->flags[Ship::Info_Flags::Show_ship_model])
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK)
 			|| !(Viewer_mode & VM_EXTERNAL));
-	cockpitActive = renderCockpitModel;
+	Cockpit_active = renderCockpitModel;
 
 	//Nothing to do
 	if (!(renderCockpitModel || renderShipModel)) {
@@ -7813,6 +7823,8 @@ void ship_render_player_ship(object* objp) {
 	matrix eye_orient;
 	ship_get_eye_local(&eye_pos, &eye_orient, objp);
 	vm_vec_copy_scale(&eye_offset, &eye_pos, -1.0f);
+	if (!Disable_cockpit_sway)
+		eye_offset += sip->cockpit_sway_val * objp->phys_info.acceleration / 5000.0f;
 
 	fov_t fov_backup = Proj_fov;
 	g3_set_fov(Sexp_fov <= 0.0f ? COCKPIT_ZOOM_DEFAULT : Sexp_fov);
@@ -7885,6 +7897,8 @@ void ship_render_player_ship(object* objp) {
 			shadow_render_info.set_object_number(OBJ_INDEX(objp));
 			vec3d offset = sip->cockpit_offset;
 			vm_vec_unrotate(&offset, &offset, &objp->orient);
+			if (!Disable_cockpit_sway)
+				offset += sip->cockpit_sway_val * objp->phys_info.acceleration / 5000.0f;
 			model_render_immediate(&shadow_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &offset);
 		}
 
@@ -7932,6 +7946,8 @@ void ship_render_player_ship(object* objp) {
 		render_info.set_replacement_textures(Player_cockpit_textures);
 		vec3d offset = sip->cockpit_offset;
 		vm_vec_unrotate(&offset, &offset, &objp->orient);
+		if (!Disable_cockpit_sway)
+			offset += sip->cockpit_sway_val * objp->phys_info.acceleration / 5000.0f;
 		model_render_immediate(&render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &offset);
 	}
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -283,8 +283,9 @@ typedef struct cockpit_display {
 	char name[MAX_FILENAME_LEN];
 } cockpit_display;
 
-extern bool disableCockpits;
-extern bool cockpitActive;
+extern bool Disable_cockpits;
+extern bool Disable_cockpit_sway;
+extern bool Cockpit_active;
 
 extern SCP_vector<cockpit_display> Player_displays;
 
@@ -1156,6 +1157,7 @@ public:
 
 	char		cockpit_pof_file[MAX_FILENAME_LEN];	// POF file for cockpit view
 	vec3d		cockpit_offset;
+	float   cockpit_sway_val;					// multiplier for cockpit 'swaying'
 	char		pof_file[MAX_FILENAME_LEN];			// POF file to load/associate with ship
 	char		pof_file_hud[MAX_FILENAME_LEN];		// POF file to load for the HUD target box
 	char		pof_file_tech[MAX_FILENAME_LEN];	// POF file to load for the techroom


### PR DESCRIPTION
Just adds a portion of the ship's acceleration to the camera, probably quite dependent on the size of the cockpit model so it's a multiplier the modder can fiddle with to their content along with a scripted toggle. Also normalizes naming of `cockpitActive` and `disableCockpits`