### PR TITLE
Update container image to fix artifact uploads

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
+    container: ghcr.io/scp-fs2open/linux_build:sha-6cb62ee
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -58,7 +58,7 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         run: $GITHUB_WORKSPACE/ci/linux/generate_appimage.sh $GITHUB_WORKSPACE/build/install
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-${{ matrix.configuration }}
           path: ${{ github.workspace }}/build/install/*.AppImage
@@ -74,12 +74,12 @@ jobs:
           submodules: true
           fetch-depth: '0'
       - name: Download Release builds
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: linux-Release
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-FastDebug
           path: builds
@@ -177,7 +177,7 @@ jobs:
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
           path: ${{ github.workspace }}/build/install/*
@@ -197,12 +197,12 @@ jobs:
           submodules: true
           fetch-depth: '0'
       - name: Download Release builds
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
@@ -286,7 +286,7 @@ jobs:
         # Ref: https://github.com/actions/runner-images/issues/2619
         run: gtar -cvzf macos-build-${{ matrix.configuration }}.tgz *.app
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mac-${{ matrix.configuration }}
           path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tgz
@@ -303,12 +303,12 @@ jobs:
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: mac-Release
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: mac-FastDebug
           path: builds

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Linux
     needs: create_release   # Don't run this job until create_release is done and successful
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
+    container: ghcr.io/scp-fs2open/linux_build:sha-6cb62ee
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -116,7 +116,7 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         run: $GITHUB_WORKSPACE/ci/linux/generate_appimage.sh $GITHUB_WORKSPACE/build/install
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         # Upload the url file for use with other runners
         # upload-artifact.inputs:
         #   if-no-files-found=warn  What to do if path fails to find any files.
@@ -143,13 +143,13 @@ jobs:
           ref: '${{ github.ref }}'
       - name: Download Release builds
         # Grab the release builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-Release
           path: builds
       - name: Download FastDebug builds
         # Grab the debug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-FastDebug
           path: builds
@@ -160,7 +160,7 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Linux
       - name: Upload result package
         # Stash the result to artifact filespace
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.generate_package.outputs.package_name }}
           path: ${{ steps.generate_package.outputs.package_path }}
@@ -260,7 +260,7 @@ jobs:
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
           path: ${{ github.workspace }}/build/install/*
@@ -284,13 +284,13 @@ jobs:
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
 
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
@@ -305,13 +305,13 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Windows
 
       - name: Upload result package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.generate_package.outputs.package_name }}
           path: ${{ steps.generate_package.outputs.package_path }}
 
       - name: Upload debug package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.generate_package.outputs.debug_name }}
           path: ${{ steps.generate_package.outputs.debug_path }}
@@ -383,7 +383,7 @@ jobs:
         # Ref: https://github.com/actions/runner-images/issues/2619
         run: gtar -cvzf macos-build-${{ matrix.configuration }}.tgz *.app
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mac-${{ matrix.configuration }}
           path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tgz
@@ -400,12 +400,12 @@ jobs:
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: mac-Release
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: mac-FastDebug
           path: builds
@@ -419,7 +419,7 @@ jobs:
         working-directory: ./builds
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac
       - name: Upload result package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.generate_package.outputs.package_name }}
           path: ${{ steps.generate_package.outputs.package_path }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
+    container: ghcr.io/scp-fs2open/linux_build:sha-6cb62ee
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin
@@ -64,7 +64,7 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         run: $GITHUB_WORKSPACE/ci/linux/generate_appimage.sh $GITHUB_WORKSPACE/build/install
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-${{ matrix.configuration }}
           path: ${{ github.workspace }}/build/install/*.AppImage
@@ -81,12 +81,12 @@ jobs:
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: linux-Release
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-FastDebug
           path: builds
@@ -190,7 +190,7 @@ jobs:
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
           path: ${{ github.workspace }}/build/install/*
@@ -211,12 +211,12 @@ jobs:
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
@@ -299,7 +299,7 @@ jobs:
         # Ref: https://github.com/actions/runner-images/issues/2619
         run: gtar -cvzf macos-build-${{ matrix.configuration }}.tgz *.app
       - name: Upload build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mac-${{ matrix.configuration }}
           path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}.tgz
@@ -316,12 +316,12 @@ jobs:
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: mac-Release
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: mac-FastDebug
           path: builds

--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -25,7 +25,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
+    container: ghcr.io/scp-fs2open/linux_build:sha-6cb62ee
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -22,7 +22,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-dfd9307
+    container: ghcr.io/scp-fs2open/linux_build:sha-6cb62ee
     steps:
       # - name: Cache Qt
         # id: cache-qt-lin


### PR DESCRIPTION
The previous version of the image accidentally removed the /tmp directory which broke things in the GitHub actions.

Initially, an update for the upload/download actions was tried which had no effect but keeping these updated is probably a good idea.