### PR TITLE
FRED on mission load hook

### DIFF
--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -441,6 +441,10 @@ const std::shared_ptr<Hook<>> OnCameraSetUpHook = Hook<>::Factory("On Camera Set
 
 // ========== FRED HOOKS ==========
 
+const std::shared_ptr<Hook<>> FredOnMissionLoad = Hook<>::Factory("FRED On Mission Load",
+	"Invoked when a new mission is loaded.",
+	{});
+
 const std::shared_ptr<Hook<>> FredOnMissionSpecsSave = Hook<>::Factory("FRED On Mission Specs Save",
 	"Invoked when the Mission Specs dialog OK Button has been hit and all data is sucessfully saved.",
 	{});

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -85,6 +85,7 @@ extern const std::shared_ptr<OverridableHook<>>							OnStateEndHook;
 extern const std::shared_ptr<Hook<>>									OnCameraSetUpHook;
 
 // FRED Hooks
+extern const std::shared_ptr<Hook<>>                                    FredOnMissionLoad;
 extern const std::shared_ptr<Hook<>>									FredOnMissionSpecsSave;
 
 // deprecated

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -43,6 +43,7 @@
 #include "ship/ship.h"
 #include "starfield/starfield.h"
 #include "weapon/weapon.h"
+#include "scripting/global_hooks.h"
 
 extern int Num_objects;
 
@@ -368,6 +369,12 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 	stars_post_level_init();
 
 	recreate_dialogs();
+
+	// This hook will allow for scripts to know when a mission has been loaded
+	// which will then allow them to update any LuaEnums that may be related to sexps
+	if (scripting::hooks::FredOnMissionLoad->isActive()) {
+		scripting::hooks::FredOnMissionLoad->run();
+	}
 
 	return true;
 }


### PR DESCRIPTION
Quick FRED hook to run when a mission has been loaded. This will allow scripts to update any Lua Enums based on the parsed mission's data.