### PR TITLE
Remove the cd checks that always returned true anyway

### DIFF
--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -122,7 +122,6 @@ int Multi_button_info_id = 0;										// identifier of the stored button info t
 active_game* Active_game_head;									// linked list of active games displayed on Join screen
 int Active_game_count;												// for interface screens as well
 CFILE* Multi_chat_stream;											// for streaming multiplayer chat strings to a file
-int Multi_has_cd = 0;												// if this machine has a cd or not (call multi_common_verify_cd() to set this)
 int Multi_connection_speed;										// connection speed of this machine.
 int Multi_num_players_at_start = 0;								// the # of players present (kept track of only on the server) at the very start of the mission
 short Multi_id_num = 0;												// for assigning player id #'s
@@ -245,11 +244,6 @@ void multi_vars_init()
 
 	// reentrant variable
 	Multi_read_count = 0;
-
-	// unset the "have cd" var
-	// NOTE: we unset this here because we are going to be calling multi_common_verify_cd() 
-	//       immediately after this (in multi_level_init() to re-check the status)
-	Multi_has_cd = 0;
 
 	// current file checksum
 	Multi_current_file_checksum = 0;

--- a/code/network/multi.h
+++ b/code/network/multi.h
@@ -735,7 +735,7 @@ typedef struct network_buffer {
 #define NETINFO_FLAG_ACCEPT_OBSERVER		(1<<18)		// accepted as observer
 #define NETINFO_FLAG_ACCEPT_CLIENT			(1<<19)		// accepted as client
 #define NETINFO_FLAG_WARPING_OUT			(1<<20)		// clients keep track of this for themselves to know if they should be leaving
-#define NETINFO_FLAG_HAS_CD					(1<<21)		// the player has a CD in the drive
+#define NETINFO_FLAG_UNUSED					(1<<21)		// Used to be a flag for if the player had a CD in the drive
 #define NETINFO_FLAG_RELIABLE_CONNECTED		(1<<22)		// reliable socket is now active
 #define NETINFO_FLAG_MT_GET_FAILED			(1<<23)		// set during MT stats update process indicating we didn't properly get his stats
 #define NETINFO_FLAG_MT_SEND_FAILED			(1<<24)		// set during MT stats update process indicating we didn't properly send his stats
@@ -893,7 +893,6 @@ extern int Multi_button_info_id;										// identifier of the stored button inf
 extern active_game* Active_game_head;								// linked list of active games displayed on Join screen
 extern int Active_game_count;											// for interface screens as well
 extern CFILE* Multi_chat_stream;										// for streaming multiplayer chat strings to a file
-extern int Multi_has_cd;												// if this machine has a cd or not (call multi_common_verify_cd() to set this)
 extern int Multi_num_players_at_start;								// the # of players present (kept track of only on the server) at the very start of the mission
 extern short Multi_id_num;												// for assigning player id #'s
 

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -1630,11 +1630,6 @@ void process_accept_packet(ubyte* data, header* hinfo)
 	multi_options_local_load(&Net_player->p_info.options, Net_player);
 	Net_player->p_info.team = team;	
 
-	// determine if I have a CD
-	if(Multi_has_cd){
-		Net_player->flags |= NETINFO_FLAG_HAS_CD;
-	}	
-
 	// set accept code in netplayer for this guy
 	if ( code & ACCEPT_INGAME ){
 		Net_player->flags |= NETINFO_FLAG_ACCEPT_INGAME;
@@ -2387,11 +2382,8 @@ void send_netplayer_update_packet( net_player *pl )
 				ADD_INT(Net_players[idx].p_info.ship_class);				
 				ADD_INT(Net_players[idx].tracker_player_id);
 
-				if(Net_players[idx].flags & NETINFO_FLAG_HAS_CD){
-					val = 1;
-				} else {
-					val = 0;
-				}
+				//Used to be a check for a CD here --Mjn
+				val = 1;
 				ADD_DATA(val);				
 			}
 		}
@@ -2424,12 +2416,8 @@ void send_netplayer_update_packet( net_player *pl )
 		ADD_INT(Net_player->p_info.ship_class);		
 		ADD_INT(Multi_tracker_id);
 
-		// add if I have a CD or not
-		if(Multi_has_cd){
-			val = 1;
-		} else {
-			val = 0;
-		}
+		// Used to check or a CD here but that has been removed --Mjn
+		val = 1;
 		ADD_DATA(val);		
 
 		// add a final stop byte
@@ -2477,12 +2465,7 @@ void process_netplayer_update_packet( ubyte *data, header *hinfo )
 			GET_INT(new_state);
 			GET_INT(Net_players[player_num].p_info.ship_class);			
 			GET_INT(Net_players[player_num].tracker_player_id);
-			GET_DATA(has_cd);
-			if(has_cd){
-				Net_players[player_num].flags |= NETINFO_FLAG_HAS_CD;
-			} else {
-				Net_players[player_num].flags &= ~(NETINFO_FLAG_HAS_CD);
-			}			
+			GET_DATA(has_cd); //unused		
 
 			// if he's changing state to joined, send a team update
 			if((Net_players[player_num].state == NETPLAYER_STATE_JOINING) && (new_state == NETPLAYER_STATE_JOINED) && (Netgame.type_flags & NG_TYPE_TEAM)){

--- a/code/network/multiui.h
+++ b/code/network/multiui.h
@@ -81,9 +81,6 @@ void multi_common_load_palette();
 void multi_common_set_palette();
 void multi_common_unload_palette();
 
-// call this to verify if we have a CD in the drive or not
-void multi_common_verify_cd();
-
 // variables to hold the mission and campaign lists
 extern SCP_vector<multi_create_info> Multi_create_mission_list;
 extern SCP_vector<multi_create_info> Multi_create_campaign_list;

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3200,10 +3200,6 @@ DCF(multi,"changes multiplayer settings (Multiplayer)")
 		multi_make_fake_players(MAX_PLAYERS);
 #endif
 
-	} else if (dc_optional_string("givecd")) {
-		extern int Multi_has_cd;
-		Multi_has_cd = 1;
-
 	} else if (dc_optional_string("oo")) {
 		int new_flags;
 

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -186,7 +186,6 @@ void game_start_time(bool){}
 bool game_time_is_stopped(){return false;}
 void game_stop_time(bool){}
 int game_get_default_skill_level(){return 0;}
-int find_freespace_cd(char*){return 0;}
 void game_do_state_common(int, int){}
 void game_set_frametime(int){}
 void game_increase_skill_level(){}

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -182,9 +182,6 @@ void game_shudder_apply(int time, float intensity, bool perpetual = false, bool 
 
 //===================================================================
 
-// make sure a CD is in the drive before continuing (returns 1 to continue, otherwise 0).
-int find_freespace_cd(char *volume_name=NULL);
-
 // Used to tell the player that a feature is disabled by build settings
 void game_feature_disabled_popup();
 

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -190,7 +190,6 @@ void game_start_time(bool){}
 bool game_time_is_stopped(){return false;}
 void game_stop_time(bool){}
 int game_get_default_skill_level(){return 0;}
-int find_freespace_cd(char*){return 0;}
 void game_do_state_common(int, int){}
 void game_set_frametime(int){}
 void game_increase_skill_level(){}


### PR DESCRIPTION
Per discussion in #scp, this removes the checks for a cd-rom. The checks always returned a val of 1 anyway.

I left the bits in place for the network packets because I wasn't sure what should be done there.