### PR TITLE
Fix OpenXR Linkage in FastDebug

### DIFF
--- a/lib/openxr/src/loader/CMakeLists.txt
+++ b/lib/openxr/src/loader/CMakeLists.txt
@@ -92,6 +92,8 @@ if(BUILD_WITH_WAYLAND_HEADERS)
     target_include_directories(openxr_loader PRIVATE ${WAYLAND_CLIENT_INCLUDE_DIRS})
 endif()
 
+target_compile_definitions(openxr_loader PUBLIC "$<$<CONFIG:FastDebug>:_ITERATOR_DEBUG_LEVEL=0>")
+
 # set_target_properties(openxr_loader PROPERTIES FOLDER ${LOADER_FOLDER})
 
 if(LOADER_EXTERNAL_GEN_DEPENDS)


### PR DESCRIPTION
The openxr_loader subproject needs the debug iterator level correctly set, as otherwise FastDebug will actually compile the loader with release optimizations, causing linker errors.