### PR TITLE
fix query_node_argument_type()

### DIFF
--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -1804,18 +1804,24 @@ void sexp_tree::edit_bg_color(HTREEITEM h)
 }
 
 // given a tree node, returns the argument type it should be.
+// OPF_NULL means no value (or a "void" value) is returned.  OPF_NONE means there shouldn't be any argument at this position at all.
 int sexp_tree::query_node_argument_type(int node) const
 {
-	int parent_node = tree_nodes[node].parent; 
-	Assert(parent_node >= 0);
-	int argnum = find_argument_number(parent_node, node); 
+	int parent_node = tree_nodes[node].parent;
+	if (parent_node < 0) {		// parent nodes are -1 for a top-level operator like 'when'
+		return OPF_NULL;
+	}
+
+	int argnum = find_argument_number(parent_node, node);
 	if (argnum < 0) {
 		return OPF_NONE;
 	}
+
 	int op_num = get_operator_index(tree_nodes[parent_node].text);
 	if (op_num < 0) {
 		return OPF_NONE;
 	}
+
 	return query_operator_argument_type(op_num, argnum);
 }
 

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -777,17 +777,23 @@ int sexp_tree::identify_arg_type(int node) {
 }
 
 // given a tree node, returns the argument type it should be.
+// OPF_NULL means no value (or a "void" value) is returned.  OPF_NONE means there shouldn't be any argument at this position at all.
 int sexp_tree::query_node_argument_type(int node) const {
 	int parent_node = tree_nodes[node].parent;
-	Assert(parent_node >= 0);
+	if (parent_node < 0) {		// parent nodes are -1 for a top-level operator like 'when'
+		return OPF_NULL;
+	}
+
 	int argnum = find_argument_number(parent_node, node);
 	if (argnum < 0) {
 		return OPF_NONE;
 	}
+
 	int op_num = get_operator_index(tree_nodes[parent_node].text);
 	if (op_num < 0) {
 		return OPF_NONE;
 	}
+
 	return query_operator_argument_type(op_num, argnum);
 }
 


### PR DESCRIPTION
Calling `query_node_argument_type()` on a node with no parent is a valid use case, so return the proper argument type.  Fixes a crash discovered by Applemush.