### PR TITLE
add more autosaving in FRED

### DIFF
--- a/fred2/addvariabledlg.cpp
+++ b/fred2/addvariabledlg.cpp
@@ -138,7 +138,7 @@ void CAddVariableDlg::OnOK() {
 		//		}
 		//
 		//		m_sexp_var_index = sexp_add_variable(temp_value, temp_name, type);
-		//		this get done for free CDialog::OnOk() UpdateData(TRUE);
+		//		this get done for free CDialog::OnOK() UpdateData(TRUE);
 		m_create = true;
 
 		CDialog::OnOK();

--- a/fred2/asteroideditordlg.cpp
+++ b/fred2/asteroideditordlg.cpp
@@ -316,6 +316,8 @@ void asteroid_editor::OnOK()
 	update_map_window();
 	theApp.record_window_data(&Asteroid_wnd_data, this);
 	CDialog::OnOK();
+
+	FREDDoc_ptr->autosave("asteroid field editor");
 }
 
 BOOL asteroid_editor::OnInitDialog() 

--- a/fred2/bgbitmapdlg.cpp
+++ b/fred2/bgbitmapdlg.cpp
@@ -530,6 +530,8 @@ void bg_bitmap_dlg::OnClose()
 	theApp.record_window_data(&Bg_wnd_data, this);
 	delete Bg_bitmap_dialog;
 	Bg_bitmap_dialog = NULL;
+
+	FREDDoc_ptr->autosave("background editor");
 }
 
 void bg_bitmap_dlg::update_data(int update)

--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -282,7 +282,6 @@ void briefing_editor_dlg::OnCancel()
 void briefing_editor_dlg::OnClose() 
 {
 	int bs, i, j, s, t, dup = 0;
-	briefing_editor_dlg *ptr;
 	brief_stage *sp;
 
 	m_cur_stage = -1;
@@ -303,12 +302,13 @@ void briefing_editor_dlg::OnClose()
 	}
 
 	if (dup)
-		MessageBox("You have duplicate icons names.  You should resolve these.", "Warning");
+		MessageBox("You have duplicate icon names.  You should resolve these.", "Warning");
 
 	theApp.record_window_data(&Briefing_wnd_data, this);
-	ptr = Briefing_dialog;
+	delete Briefing_dialog;
 	Briefing_dialog = NULL;
-	delete ptr;
+
+	FREDDoc_ptr->autosave("briefing editor");
 }
 
 void briefing_editor_dlg::reset_editor()

--- a/fred2/cmdbrief.cpp
+++ b/fred2/cmdbrief.cpp
@@ -11,6 +11,7 @@
 
 #include "stdafx.h"
 #include "FRED.h"
+#include "freddoc.h"
 #include "CmdBrief.h"
 #include "cfile/cfile.h"
 #include "sound/audiostr.h"
@@ -315,6 +316,11 @@ BOOL cmd_brief_dlg::DestroyWindow()
 
 	update_data();
 	m_play_bm.DeleteObject();
+
+	// the command briefing is updated whether we close it, click OK, or click Cancel,
+	// so autosave here instead of in the OK case
+	FREDDoc_ptr->autosave("command briefing editor");
+
 	return CDialog::DestroyWindow();
 }
 

--- a/fred2/debriefingeditordlg.cpp
+++ b/fred2/debriefingeditordlg.cpp
@@ -438,6 +438,8 @@ void debriefing_editor_dlg::OnClose()
 	Mission_music[SCORE_DEBRIEFING_FAILURE] = m_debriefFail_music - 1;
 
 	CDialog::OnClose();
+
+	FREDDoc_ptr->autosave("debriefing editor");
 }
 
 void debriefing_editor_dlg::OnOK()

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -602,6 +602,8 @@ void event_editor::OnButtonOk()
 	theApp.record_window_data(&Events_wnd_data, this);
 	delete Event_editor_dlg;
 	Event_editor_dlg = NULL;
+
+	FREDDoc_ptr->autosave("event editor");
 }
 
 // load controls with structure data

--- a/fred2/messageeditordlg.cpp
+++ b/fred2/messageeditordlg.cpp
@@ -80,7 +80,7 @@ BEGIN_MESSAGE_MAP(CMessageEditorDlg, CDialog)
 	ON_NOTIFY(NM_RCLICK, IDC_TREE, OnRclickTree)
 	ON_NOTIFY(TVN_BEGINLABELEDIT, IDC_TREE, OnBeginlabeleditTree)
 	ON_NOTIFY(TVN_ENDLABELEDIT, IDC_TREE, OnEndlabeleditTree)
-	ON_BN_CLICKED(ID_OK, OnOk)
+	ON_BN_CLICKED(ID_OK, OnButtonOk)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -209,12 +209,15 @@ void CMessageEditorDlg::OnOK()
 {
 }
 
-void CMessageEditorDlg::OnOk()
+void CMessageEditorDlg::OnButtonOk()
 {
 	update(m_cur_msg);
+
 	theApp.record_window_data(&Messages_wnd_data, this);
 	delete Message_editor_dlg;
 	Message_editor_dlg = NULL;
+
+	FREDDoc_ptr->autosave("message editor");
 }
 
 void CMessageEditorDlg::OnCancel()
@@ -501,7 +504,7 @@ void CMessageEditorDlg::OnClose()
 			return;
 
 		if (z == IDYES) {
-			OnOK();
+			OnButtonOk();
 			return;
 		}
 	}

--- a/fred2/messageeditordlg.h
+++ b/fred2/messageeditordlg.h
@@ -66,7 +66,7 @@ protected:
 	afx_msg void OnRclickTree(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnBeginlabeleditTree(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnEndlabeleditTree(NMHDR* pNMHDR, LRESULT* pResult);
-	afx_msg void OnOk();
+	afx_msg void OnButtonOk();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/fred2/missioncutscenesdlg.cpp
+++ b/fred2/missioncutscenesdlg.cpp
@@ -110,7 +110,7 @@ BEGIN_MESSAGE_MAP(CMissionCutscenesDlg, CDialog)
 	ON_CBN_SELCHANGE(IDC_CUTSCENE_TYPE_DROP, OnSelchangeCutsceneTypeDrop)
 	ON_EN_CHANGE(IDC_CUTSCENE_NAME, OnChangeCutsceneName)
 	ON_EN_CHANGE(IDC_CUTSCENE_HELP_BOX, OnChangeCutsceneName)
-	ON_BN_CLICKED(ID_OK, OnOk)
+	ON_BN_CLICKED(ID_OK, OnButtonOk)
 	ON_WM_CLOSE()
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
@@ -281,7 +281,7 @@ int CMissionCutscenesDlg::query_modified()
 	return 0;
 }
 
-void CMissionCutscenesDlg::OnOk()
+void CMissionCutscenesDlg::OnButtonOk()
 {
 	SCP_vector<std::pair<SCP_string, SCP_string>> names;
 
@@ -406,7 +406,7 @@ void CMissionCutscenesDlg::OnClose()
 			return;
 
 		if (z == IDYES) {
-			OnOk();
+			OnButtonOk();
 			return;
 		}
 	}

--- a/fred2/missioncutscenesdlg.h
+++ b/fred2/missioncutscenesdlg.h
@@ -68,7 +68,7 @@ protected:
 	afx_msg void OnButtonNewCutscene();
 	afx_msg void OnSelchangeCutsceneTypeDrop();
 	afx_msg void OnChangeCutsceneName();
-	afx_msg void OnOk();
+	afx_msg void OnButtonOk();
 	afx_msg void OnClose();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/fred2/missiongoalsdlg.cpp
+++ b/fred2/missiongoalsdlg.cpp
@@ -114,7 +114,7 @@ BEGIN_MESSAGE_MAP(CMissionGoalsDlg, CDialog)
 	ON_EN_CHANGE(IDC_GOAL_RATING, OnChangeGoalRating)
 	ON_CBN_SELCHANGE(IDC_GOAL_TYPE_DROP, OnSelchangeGoalTypeDrop)
 	ON_EN_CHANGE(IDC_GOAL_NAME, OnChangeGoalName)
-	ON_BN_CLICKED(ID_OK, OnOk)
+	ON_BN_CLICKED(ID_OK, OnButtonOk)
 	ON_WM_CLOSE()
 	ON_BN_CLICKED(IDC_GOAL_INVALID, OnGoalInvalid)
 	ON_EN_CHANGE(IDC_GOAL_SCORE, OnChangeGoalScore)
@@ -330,7 +330,7 @@ int CMissionGoalsDlg::query_modified()
 	return 0;
 }
 
-void CMissionGoalsDlg::OnOk()
+void CMissionGoalsDlg::OnButtonOk()
 {
 	SCP_vector<std::pair<SCP_string, SCP_string>> names;
 	int i;
@@ -381,6 +381,8 @@ void CMissionGoalsDlg::OnOk()
 
 	theApp.record_window_data(&Mission_goals_wnd_data, this);
 	CDialog::OnOK();
+
+	FREDDoc_ptr->autosave("goal editor");
 }
 
 void CMissionGoalsDlg::OnButtonNewGoal() 
@@ -514,7 +516,7 @@ void CMissionGoalsDlg::OnClose()
 			return;
 
 		if (z == IDYES) {
-			OnOk();
+			OnButtonOk();
 			return;
 		}
 	}

--- a/fred2/missiongoalsdlg.h
+++ b/fred2/missiongoalsdlg.h
@@ -76,7 +76,7 @@ protected:
 	afx_msg void OnChangeGoalRating();
 	afx_msg void OnSelchangeGoalTypeDrop();
 	afx_msg void OnChangeGoalName();
-	afx_msg void OnOk();
+	afx_msg void OnButtonOk();
 	afx_msg void OnClose();
 	afx_msg void OnGoalInvalid();
 	afx_msg void OnChangeGoalScore();

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -367,6 +367,8 @@ void CMissionNotesDlg::OnOK()
 	}
 
 	CDialog::OnOK();
+
+	FREDDoc_ptr->autosave("mission specs editor");
 }
 
 void CMissionNotesDlg::OnCancel()

--- a/fred2/orienteditor.cpp
+++ b/fred2/orienteditor.cpp
@@ -336,6 +336,8 @@ void orient_editor::OnOK()
 
 	theApp.record_window_data(&Object_wnd_data, this);
 	CDialog::OnOK();
+
+	FREDDoc_ptr->autosave("object editor");
 }
 
 void orient_editor::actually_point_object(object *ptr)

--- a/fred2/playerstarteditor.cpp
+++ b/fred2/playerstarteditor.cpp
@@ -1004,6 +1004,8 @@ void player_start_editor::OnOK()
 
 	theApp.record_window_data(&Player_wnd_data, this);
 	CDialog::OnOK();
+
+	FREDDoc_ptr->autosave("loadout editor");
 }
 
 // Returns the ship_info index of the selected and checked ship_list item or -1 if nothing is checked or 

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -364,6 +364,8 @@ void CShipEditorDlg::OnClose()
 
 	SetWindowPos(Fred_main_wnd, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_HIDEWINDOW);
 	Fred_main_wnd->SetWindowPos(&wndTop, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+
+	FREDDoc_ptr->autosave("ship editor");
 }
 
 BOOL CShipEditorDlg::Create(LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext) 

--- a/fred2/shipspecialhitpoints.cpp
+++ b/fred2/shipspecialhitpoints.cpp
@@ -43,7 +43,7 @@ BEGIN_MESSAGE_MAP(ShipSpecialHitpoints, CDialog)
 	//{{AFX_MSG_MAP(ShipSpecialHitpoints)
 	ON_BN_CLICKED(IDC_ENABLE_SPECIAL_HITPOINTS, OnEnableSpecialHitpoints)
 	ON_BN_CLICKED(IDC_ENABLE_SPECIAL_SHIELD, OnEnableSpecialShieldpoints)
-	ON_BN_CLICKED(ID_OK, OnOk)
+	ON_BN_CLICKED(ID_OK, OnButtonOk)
 	ON_BN_CLICKED(ID_CANCEL, OnCancel)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
@@ -146,7 +146,7 @@ void ShipSpecialHitpoints::OnCancel()
 	CDialog::OnCancel();
 }
 
-void ShipSpecialHitpoints::OnOk() 
+void ShipSpecialHitpoints::OnButtonOk()
 {
 	float temp_max_hull_strength;
 	int new_shield_strength, new_hull_strength;

--- a/fred2/shipspecialhitpoints.h
+++ b/fred2/shipspecialhitpoints.h
@@ -51,7 +51,7 @@ protected:
 	virtual BOOL OnInitDialog();
 	afx_msg void DoGray();
 	virtual void OnCancel();
-	virtual void OnOk();
+	virtual void OnButtonOk();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/fred2/wing_editor.cpp
+++ b/fred2/wing_editor.cpp
@@ -266,6 +266,8 @@ void wing_editor::OnClose()
 
 	SetWindowPos(Fred_main_wnd, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_HIDEWINDOW);
 	Fred_main_wnd->SetWindowPos(&wndTop, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+
+	FREDDoc_ptr->autosave("wing editor");
 }
 
 // initialize everything that update_data_safe() saves.


### PR DESCRIPTION
FRED has an autosave feature but it wasn't invoked in too many places.  This adds autosaving whenever a major dialog is closed, unless it was closed by hitting Cancel.  NB: Autosave is not yet implemented in qtFRED.

Also, `addvariabledlg` incorrectly referred to `OnOk` instead of `OnOK` and `CMessageEditorDlg` incorrectly referred to `OnOK` instead of `OnOk`, so this fixes those and distinguishes `OnOk` by renaming it `OnButtonOk` to be consistent with the event editor and other dialogs.