### PR TITLE
Change the discord option category to "game"

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -266,6 +266,7 @@ static auto VideoDisplayOption = options::OptionBuilder<int>("Graphics.Display",
                      .serializer(videodisplay_serializer)
                      .enumerator(videodisplay_enumerator)
                      .display(videodisplay_display)
+                     .flags({options::OptionFlags::ForceMultiValueSelection})
                      .default_val(0)
                      .change_listener(videodisplay_change)
                      .importance(99)

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -150,10 +150,10 @@ bool Calculate_subsystem_hitpoints_after_parsing;
 bool Disable_internal_loadout_restoration_system;
 bool Contrails_use_absolute_speed;
 
-static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Other.Discord",
+static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Game.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
                      std::pair<const char*, int>{"Toggle Discord Rich Presence", 1755})
-                     .category("Other")
+                     .category("Game")
                      .default_val(Discord_presence)
                      .level(options::ExpertLevel::Advanced)
                      .importance(55)


### PR DESCRIPTION
Moves the Discord option to a real category and force dropdown selector for the Display Selection option because the display names can be too long for a button option.