### PR TITLE
More scpui options

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1808 // This is the next available ID
+// #define XSTR_SIZE	1816 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -269,6 +269,18 @@ static auto GameSkillOption __UNUSED = options::OptionBuilder<int>("Game.SkillLe
                      .importance(1)
                      .finish();
 
+bool Screenshake_enabled = true;
+
+auto ScreenShakeOption = options::OptionBuilder<bool>("Graphics.ScreenShake",
+	std::pair<const char*, int>{"Screen Shudder Effect", -1}, // do xstr
+	std::pair<const char*, int>{"Toggles the screen shake effect for weapons, afterburners, and shockwaves", -1})
+							 .category("Graphics")
+							 .default_val(Screenshake_enabled)
+							 .level(options::ExpertLevel::Advanced)
+							 .importance(55)
+							 .bind_to(&Screenshake_enabled)
+							 .finish();
+
 #define EXE_FNAME			("fs2.exe")
 
 // JAS: Code for warphole camera.
@@ -2948,6 +2960,19 @@ float get_shake(float intensity, int decay_time, int max_decay_time)
 	return shake;
 }
 
+bool is_screenshake_enabled()
+{
+	if (Game_mode & GM_MULTIPLAYER) {
+		return true;
+	} else {
+		if (Using_in_game_options) {
+			return Screenshake_enabled;
+		} else {
+			return !Cmdline_no_screenshake;
+		}
+	}
+}
+
 #define FF_SCALE	10000
 extern int Wash_on;
 extern float sn_shudder;
@@ -2964,8 +2989,8 @@ void apply_view_shake(matrix *eye_orient)
 	if ((Viewer_mode & VM_CHASE) && Apply_shudder_to_chase_view)
 		do_hud_shudder = true;
 
-	// do shakes that only affect the HUD (unless disabled by cmdline in singleplayer or enabled by mod flag)
-	if (do_hud_shudder && (!Cmdline_no_screenshake || Game_mode & GM_MULTIPLAYER)) {
+	// do shakes that only affect the HUD (unless disabled by some combination of game type and settings)
+	if (do_hud_shudder && is_screenshake_enabled()) {
 		physics_info *pi = &Player_obj->phys_info;
 
 		// Make eye shake due to afterburner

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -285,10 +285,10 @@ bool Allow_unfocused_pause = true;
 
 static SCP_string unfocused_pause_display(bool mode) { return mode ? XSTR("Yes", 1394) : XSTR("No", 1395); }
 
-auto UnfocusedPauseOption = options::OptionBuilder<bool>("Graphics.UnfocusedPause",
+auto UnfocusedPauseOption = options::OptionBuilder<bool>("Game.UnfocusedPause",
                      std::pair<const char*, int>{"Pause If Unfocused", 1814}, // do xstr
                      std::pair<const char*, int>{"Whether or not the game automatically pauses if it loses focus", 1815})
-                     .category("Graphics")
+                     .category("Game")
                      .default_val(Allow_unfocused_pause)
                      .level(options::ExpertLevel::Advanced)
                      .display(unfocused_pause_display) 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -272,14 +272,29 @@ static auto GameSkillOption __UNUSED = options::OptionBuilder<int>("Game.SkillLe
 bool Screenshake_enabled = true;
 
 auto ScreenShakeOption = options::OptionBuilder<bool>("Graphics.ScreenShake",
-	std::pair<const char*, int>{"Screen Shudder Effect", -1}, // do xstr
-	std::pair<const char*, int>{"Toggles the screen shake effect for weapons, afterburners, and shockwaves", -1})
-							 .category("Graphics")
-							 .default_val(Screenshake_enabled)
-							 .level(options::ExpertLevel::Advanced)
-							 .importance(55)
-							 .bind_to(&Screenshake_enabled)
-							 .finish();
+                     std::pair<const char*, int>{"Screen Shudder Effect", 1812}, // do xstr
+                     std::pair<const char*, int>{"Toggles the screen shake effect for weapons, afterburners, and shockwaves", 1813})
+                     .category("Graphics")
+                     .default_val(Screenshake_enabled)
+                     .level(options::ExpertLevel::Advanced)
+                     .importance(55)
+                     .bind_to(&Screenshake_enabled)
+                     .finish();
+
+bool Allow_unfocused_pause = true;
+
+static SCP_string unfocused_pause_display(bool mode) { return mode ? XSTR("Yes", 1394) : XSTR("No", 1395); }
+
+auto UnfocusedPauseOption = options::OptionBuilder<bool>("Graphics.UnfocusedPause",
+                     std::pair<const char*, int>{"Pause If Unfocused", 1814}, // do xstr
+                     std::pair<const char*, int>{"Whether or not the game automatically pauses if it loses focus", 1815})
+                     .category("Graphics")
+                     .default_val(Allow_unfocused_pause)
+                     .level(options::ExpertLevel::Advanced)
+                     .display(unfocused_pause_display) 
+                     .importance(55)
+                     .bind_to(&Allow_unfocused_pause)
+                     .finish();
 
 #define EXE_FNAME			("fs2.exe")
 
@@ -4538,13 +4553,22 @@ int game_check_key()
 	return k;
 }
 
+bool pause_if_unfocused()
+{
+	if (Using_in_game_options) {
+		return Allow_unfocused_pause;
+	} else {
+		return !Cmdline_no_unfocus_pause;
+	}
+}
+
 // same as game_check_key(), except this is used while actually in the game.  Since there
 // generally are differences between game control keys and general UI keys, makes sense to
 // have seperate functions for each case.  If you are not checking a game control while in a
 // mission, you should probably be using game_check_key() instead.
 int game_poll()
 {
-	if (!Cmdline_no_unfocus_pause)
+	if (pause_if_unfocused())
 	{
 		// If we're in a single player game, pause it.  
 		// Cyborg17 - Multiplayer *must not* have its time affected by being in the background.


### PR DESCRIPTION
Adds screenshake and unfocused pause toggles to the Options Builder for SCPUI

NOTE: This takes PR #5865 into account already for the XSTR ids.. but it's a PITA to manage that XSTR line with multiple PRs in the pipeline. Will handle any merge conflicts as merges happen.