### PR TITLE
Disable cmdline overrides

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -222,6 +222,7 @@ Flag exe_params[] =
 
 	//flag					launcher text								FSO		on_flags							off_flags						category		reference URL
 	{ "-no_set_gamma",		"Disable setting of gamma",					true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_set_gamma", },
+	{ "-no_ingame_options",	"Disable using ingame options",				true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_ingame_options", },
 	{ "-nomovies",			"Disable video playback",					true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nomovies", },
 	{ "-noparseerrors",		"Disable parsing errors",					true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-noparseerrors", },
 	{ "-loadallweps",		"Load all weapons, even those not used",	true,	0,									EASY_DEFAULT,					"Troubleshoot",	"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-loadallweps", },
@@ -460,6 +461,7 @@ SCP_string Cmdline_lang;
 cmdline_parm loadallweapons_arg("-loadallweps", NULL, AT_NONE);	// Cmdline_load_all_weapons
 cmdline_parm nomovies_arg("-nomovies", NULL, AT_NONE);		// Cmdline_nomovies  -- Allows video streaming
 cmdline_parm no_set_gamma_arg("-no_set_gamma", NULL, AT_NONE);	// Cmdline_no_set_gamma
+cmdline_parm no_ingame_options_arg("-no_ingame_options", NULL, AT_NONE); // Cmdline_no_ingame_options
 cmdline_parm no_fbo_arg("-disable_fbo", NULL, AT_NONE);		// Cmdline_no_fbo
 cmdline_parm no_pbo_arg("-disable_pbo", NULL, AT_NONE);		// Cmdline_no_pbo
 cmdline_parm mipmap_arg("-mipmap", NULL, AT_NONE);			// Cmdline_mipmap
@@ -483,6 +485,7 @@ cmdline_parm fix_registry("-fix_registry", NULL, AT_NONE);
 int Cmdline_load_all_weapons = 0;
 int Cmdline_nomovies = 0;
 int Cmdline_no_set_gamma = 0;
+bool Cmdline_no_ingame_options = false;
 int Cmdline_no_fbo = 0;
 int Cmdline_no_pbo = 0;
 int Cmdline_ati_color_swap = 0;
@@ -1931,6 +1934,10 @@ bool SetCmdlineParams()
 	if( no_set_gamma_arg.found() )
 	{
 		Cmdline_no_set_gamma = 1;
+	}
+
+	if (no_ingame_options_arg.found()) {
+		Cmdline_no_ingame_options = true;
 	}
 
 	if(no_vsync_arg.found() )

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1720,13 +1720,13 @@ bool SetCmdlineParams()
 	// d3d windowed
 	if(window_arg.found()) {
 		// We need to set both values since we don't know if we are going to use the new config system
-		options::OptionsManager::instance()->setOverride("Graphics.WindowMode", "0");
+		//options::OptionsManager::instance()->setOverride("Graphics.WindowMode", "0");
 		Cmdline_window = 1;
 	}
 
 	if ( fullscreen_window_arg.found( ) )
 	{
-		options::OptionsManager::instance()->setOverride("Graphics.WindowMode", "1");
+		//options::OptionsManager::instance()->setOverride("Graphics.WindowMode", "1");
 		Cmdline_fullscreen_window = 1;
 		Cmdline_window = 0; /* Make sure no-one sets both */
 	}
@@ -1743,13 +1743,13 @@ bool SetCmdlineParams()
 		int width = 0;
 		int height = 0;
 
-		if ( sscanf(Cmdline_res, "%dx%d", &width, &height) == 2 ) {
+		/*if (sscanf(Cmdline_res, "%dx%d", &width, &height) == 2) {
 			SCP_string override;
 			sprintf(override, "{\"width\":%d,\"height\":%d}", width, height);
 			options::OptionsManager::instance()->setOverride("Graphics.Resolution", override);
 		} else {
 			Warning(LOCATION, "Failed to parse -res parameter \"%s\". Must be in format \"<width>x<height>\".\n", Cmdline_res);
-		}
+		}*/
 	}
 	if(window_res_arg.found()){
 		int width = 0;

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -114,6 +114,7 @@ extern SCP_string Cmdline_lang;
 extern int Cmdline_load_all_weapons;
 extern int Cmdline_nomovies;	// WMC Toggles movie playing support
 extern int Cmdline_no_set_gamma;
+extern bool Cmdline_no_ingame_options;
 extern int Cmdline_no_fbo;
 extern int Cmdline_no_pbo;
 extern int Cmdline_mipmap;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1387,6 +1387,14 @@ void mod_table_init()
 
 	// parse any modular tables
 	parse_modular_table("*-mod.tbm", parse_mod_table);
+
+	// if we have the troubleshoot commandline flag to override ingame options then disable them right after all
+	// parsing so we can be sure it doesn't affect anything past this point during engine init.
+	if (Cmdline_no_ingame_options && Using_in_game_options) {
+		Using_in_game_options = false;
+		mprintf((
+			"Game Settings Table: Disabling in-game options system because the commandline override was detected!.\n"));
+	}
 }
 
 // game_settings.tbl is parsed before graphics are actually initialized, so we can't calculate the resolution at that time


### PR DESCRIPTION
Comments out the lines to let commandline resolution and window mode override ingame options. (Comment out because the code is still good to keep around for reference as we're all learning the new OptionsBuilder code.)

Also adds a commandline to disable using any ingame options. That makes it so that ingame options either all used or none of them are, removing the past hybrid behavior.