### PR TITLE
bump missionlog limit

### DIFF
--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -26,7 +26,7 @@
 
 
 
-#define MAX_LOG_ENTRIES		700
+#define MAX_LOG_ENTRIES		1500
 
 // used for high water mark for culling out log entries
 #define LOG_CULL_MARK				((int)(MAX_LOG_ENTRIES * 0.95f))


### PR DESCRIPTION
This limit has not been bumped since the original public source release.  The final mission in Shepherds has been experiencing mysterious bugs which were finally tracked down to the mission log overflowing its limit and discarding log entries.  Ideally the mission log should be made dynamic and the pruning mechanisms removed, but for the 24.0 release, it suffices to bump the limit.

Colt tested a build with the bumped limit and it fixed all of the mysterious bugs in the affected mission.