### PR TITLE
str_wrap_to_width followup

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -754,7 +754,7 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 		//Get text size
 		for(int i = 0; i < num_text_lines; i++)
 		{
-			gr_get_string_size(&w, &h, text_line_ptrs[i], text_line_lens[i]);
+			gr_get_string_size(&w, &h, text_line_ptrs[i], static_cast<size_t>(text_line_lens[i]));
 
 			if(w > tw)
 				tw = w;

--- a/code/gamehelp/contexthelp.cpp
+++ b/code/gamehelp/contexthelp.cpp
@@ -499,7 +499,7 @@ void help_overlay_blit(int overlay_id, int resolution_index)
 	font::set_font(help_overlaylist[overlay_id].fontlist.at(resolution_index));
 	for (idx = 0; idx < textcount; idx++) {
 		gr_set_color_fast(&Color_black);
-		gr_get_string_size(&width, &height, help_overlaylist[overlay_id].textlist.at(0).at(idx).string, (int)strlen(help_overlaylist[overlay_id].textlist.at(0).at(idx).string));
+		gr_get_string_size(&width, &height, help_overlaylist[overlay_id].textlist.at(0).at(idx).string, strlen(help_overlaylist[overlay_id].textlist.at(0).at(idx).string));
 		gr_rect(help_overlaylist[overlay_id].textlist.at(resolution_index).at(idx).x_coord-2*HELP_PADDING, help_overlaylist[overlay_id].textlist.at(resolution_index).at(idx).y_coord-3*HELP_PADDING, width+4*HELP_PADDING, height+4*HELP_PADDING, GR_RESIZE_MENU);
 		gr_set_color_fast(&Color_bright_white);
 		gr_printf_menu(help_overlaylist[overlay_id].textlist.at(resolution_index).at(idx).x_coord, help_overlaylist[overlay_id].textlist.at(resolution_index).at(idx).y_coord,

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1002,7 +1002,7 @@ extern void gr_printf_menu_zoomed( int x, int y, const char * format, SCP_FORMAT
 extern void gr_printf_no_resize( int x, int y, const char * format, SCP_FORMAT_STRING ... )  SCP_FORMAT_STRING_ARGS(3, 4);
 
 // Returns the size of the string in pixels in w and h
-extern void gr_get_string_size( int *w, int *h, const char * text, int len = 9999 );
+extern void gr_get_string_size( int *w, int *h, const char * text, size_t len = std::string::npos );
 
 // Returns the height of the current font
 extern int gr_get_font_height();

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -779,7 +779,7 @@ void endDrawing(graphics::paths::PathRenderer* path) {
 }
 }
 
-void gr_string(float sx, float sy, const char* s, int resize_mode, int in_length) {
+void gr_string(float sx, float sy, const char* s, int resize_mode, size_t in_length) {
 	if (gr_screen.mode == GR_STUB) {
 		return;
 	}
@@ -797,10 +797,10 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, int in_length
 	}
 
 	size_t length;
-	if (in_length < 0) {
+	if (in_length == std::string::npos) {
 		length = strlen(s);
 	} else {
-		length = (size_t) in_length;
+		length = in_length;
 	}
 
 	FSFont* currentFont = FontManager::getCurrentFont();

--- a/code/graphics/render.h
+++ b/code/graphics/render.h
@@ -60,7 +60,7 @@ void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode = 
  * @param resize_mode The mode for translating the screen positions
  * @param length The number of bytes in the string to render. -1 will render the whole string.
  */
-void gr_string(float x, float y, const char* string, int resize_mode = GR_RESIZE_FULL, int length = -1);
+void gr_string(float x, float y, const char* string, int resize_mode = GR_RESIZE_FULL, size_t length = std::string::npos);
 /**
  * @brief Renders the specified string to the screen using the current font and color
  * @param x The x-coordinate
@@ -69,7 +69,7 @@ void gr_string(float x, float y, const char* string, int resize_mode = GR_RESIZE
  * @param resize_mode The mode for translating the screen positions
  * @param length The number of bytes in the string to render. -1 will render the whole string.
  */
-inline void gr_string(int x, int y, const char* string, int resize_mode = GR_RESIZE_FULL, int length = -1)
+inline void gr_string(int x, int y, const char* string, int resize_mode = GR_RESIZE_FULL, size_t length = std::string::npos)
 {
 	gr_string(i2fl(x), i2fl(y), string, resize_mode, length);
 }

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -669,7 +669,7 @@ int gr_get_dynamic_font_lines(int number_default_lines) {
 	return fl2i((number_default_lines * 10) / (gr_get_font_height() + 1));
 }
 
-void gr_get_string_size(int *w1, int *h1, const char *text, int len)
+void gr_get_string_size(int *w1, int *h1, const char *text, size_t len)
 {
 	if (!FontManager::isReady())
 	{
@@ -685,7 +685,7 @@ void gr_get_string_size(int *w1, int *h1, const char *text, int len)
 	float w = 0.0f;
 	float h = 0.0f;
 
-	FontManager::getCurrentFont()->getStringSize(text, static_cast<size_t>(len), -1, &w, &h);
+	FontManager::getCurrentFont()->getStringSize(text, len, -1, &w, &h);
 
 	if (w1)
 	{

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -305,7 +305,7 @@ void HudGaugeMessages::processMessageBuffer()
 		ptr = strstr(msg, NOX(": "));
 		if ( ptr ) {
 			int sw;
-			gr_get_string_size(&sw, nullptr, msg, (int)(ptr + 2 - msg));
+			gr_get_string_size(&sw, nullptr, msg, (ptr + 2 - msg));
 			offset = sw;
 		}
 
@@ -641,7 +641,7 @@ void hud_add_msg_to_scrollback(const char *text, int source, int t)
 
 	// determine the length of the sender's name for underlining
 	if (ptr) {
-		gr_get_string_size(&w, nullptr, buf, (int)(ptr - buf));
+		gr_get_string_size(&w, nullptr, buf, (ptr - buf));
 	}
 
 	// create the new node for the vector
@@ -843,7 +843,7 @@ void hud_initialize_scrollback_lines()
 
 			int width = 0;
 			int height = 0;
-			gr_get_string_size(&width, &height, node_msg.text.c_str(), (int)node_msg.text.length());
+			gr_get_string_size(&width, &height, node_msg.text.c_str(), node_msg.text.length());
 
 			int max_width = Hud_mission_log_list2_coords[gr_screen.res][2];
 			if (width > max_width) {

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -639,7 +639,7 @@ void credits_init()
 
 	for (iter = Credit_text_parts.begin(); iter != Credit_text_parts.end(); ++iter)
 	{
-		gr_get_string_size(NULL, &temp_h, iter->c_str(), (int)iter->length());
+		gr_get_string_size(NULL, &temp_h, iter->c_str(), iter->length());
 
 		h = h + temp_h;
 	}
@@ -855,12 +855,12 @@ void credits_do_frame(float  /*frametime*/)
 				length = std::numeric_limits<size_t>::max();
 			}
 
-			gr_get_string_size(&width, &height, iter->c_str() + currentPos, static_cast<int>(length));
+			gr_get_string_size(&width, &height, iter->c_str() + currentPos, length);
 			// Check if the text part is actually visible
 			if (Credit_position + y_offset + height > 0.0f)
 			{
 				float x = static_cast<float>((gr_screen.clip_width_unscaled - width) / 2);
-				gr_string(x, Credit_position + y_offset, iter->c_str() + currentPos, GR_RESIZE_MENU, static_cast<int>(length));
+				gr_string(x, Credit_position + y_offset, iter->c_str() + currentPos, GR_RESIZE_MENU, length);
 			}
 
 			y_offset += height;

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2352,12 +2352,12 @@ void wl_render_weapon_desc(float frametime)
 	if (!Weapon_desc_wipe_done) {
 		// draw mid-wipe version
 		// decide which char is last (and bright)
-		int bright_char_index = (int)(Weapon_desc_wipe_time_elapsed * WEAPON_DESC_MAX_LENGTH / WEAPON_DESC_WIPE_TIME);
-		int i, w, h, curr_len;
+		size_t bright_char_index = (size_t)(Weapon_desc_wipe_time_elapsed * WEAPON_DESC_MAX_LENGTH / WEAPON_DESC_WIPE_TIME);
+		int i, w, h;
 		
 		// draw weapon title (above weapon anim)
 		for (i=0; i<2; i++) {
-			curr_len = (int)strlen(Weapon_desc_lines[i]);
+			size_t curr_len = strlen(Weapon_desc_lines[i]);
 
 			if (bright_char_index < curr_len) {
 				// save bright char and plunk in some nulls to shorten string
@@ -2385,7 +2385,7 @@ void wl_render_weapon_desc(float frametime)
 
 		// draw weapon desc (below weapon anim)
 		for (i=2; i<WEAPON_DESC_MAX_LINES; i++) {
-			curr_len = (int)strlen(Weapon_desc_lines[i]);
+			size_t curr_len = strlen(Weapon_desc_lines[i]);
 
 			if (bright_char_index < curr_len) {
 				// save bright char and plunk in some nulls to shorten string
@@ -2439,9 +2439,10 @@ void wl_render_weapon_desc(float frametime)
  */
 void wl_weapon_desc_start_wipe()
 {
-	int currchar_src = 0, currline_dest = 2, currchar_dest = 0, i;
+	size_t currchar_src = 0;
+	int currline_dest = 2, currchar_dest = 0, i;
 	int w, h;
-	int title_len = (int)strlen(Weapon_info[Selected_wl_class].title);
+	size_t title_len = strlen(Weapon_info[Selected_wl_class].title);
 
 	// init wipe vars
 	Weapon_desc_wipe_time_elapsed = 0.0f;
@@ -2452,7 +2453,7 @@ void wl_weapon_desc_start_wipe()
 	gr_get_string_size(&w, &h, Weapon_info[Selected_wl_class].title, title_len);
 	if (w > Weapon_title_max_width[gr_screen.res]) {
 		// split
-		currchar_src = (int)(((float)title_len / (float)w) * Weapon_title_max_width[gr_screen.res]);			// char to start space search at
+		currchar_src = (size_t)(((float)title_len / (float)w) * Weapon_title_max_width[gr_screen.res]);			// char to start space search at
 		while (Weapon_desc_lines[0][currchar_src] != ' ') {
 			currchar_src--;
 			if (currchar_src <= 0) {
@@ -2960,7 +2961,7 @@ void wl_render_icon_count(int num, int x, int y)
 	Assert(number_to_draw >= 0);
 
 	sprintf(buf, "%d", number_to_draw);
-	gr_get_string_size(&num_w, &num_h, buf, (int)strlen(buf));
+	gr_get_string_size(&num_w, &num_h, buf, strlen(buf));
 
 	// render
 	gr_set_color_fast(&Color_white);

--- a/code/osapi/DebugWindow.cpp
+++ b/code/osapi/DebugWindow.cpp
@@ -145,7 +145,7 @@ float DebugWindow::print_line(float bottom_y, const LineInfo& line) {
 	gr_set_color_fast(&Color_white);
 
 	for (size_t i = 0; i < split_lines.size(); ++i) {
-		gr_string(max_category_width + 18.f, y_pos, split_lines[i], GR_RESIZE_NONE, line_lengths[i]);
+		gr_string(max_category_width + 18.f, y_pos, split_lines[i], GR_RESIZE_NONE, static_cast<size_t>(line_lengths[i]));
 
 		y_pos += font::get_current_font()->getHeight();
 	}

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3471,7 +3471,6 @@ void display_parse_diagnostics()
 char *split_str_once(char *src, int max_pixel_w)
 {
 	char *brk = nullptr;
-	int i, w, len;
 	bool last_was_white = false;
 
 	Assert(src);
@@ -3479,12 +3478,14 @@ char *split_str_once(char *src, int max_pixel_w)
 	if (max_pixel_w <= 0)
 		return src;  // if there's no width, skip everything else
 
+	int w;
 	gr_get_string_size(&w, nullptr, src);
 	if ( (w <= max_pixel_w) && !strstr(src, "\n") ) {
 		return nullptr;  // string doesn't require a cut
 	}
 
-	len = (int)strlen(src);
+	size_t i;
+	size_t len = strlen(src);
 	for (i=0; i<len; i++) {
 		gr_get_string_size(&w, nullptr, src, i + 1);
 

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -15,10 +15,7 @@
 #include <csetjmp>
 
 #include <cctype>
-#include <string>
-#include "globalincs/safe_strings.h"
 #include "globalincs/version.h"
-#include "globalincs/vmallocator.h"
 #include "localization/fhash.h"
 #include "localization/localize.h"
 #include "mission/missionparse.h"
@@ -32,8 +29,6 @@
 #include "utils/encoding.h"
 #include "utils/unicode.h"
 
-#include <stdint.h>
-#include <string.h>
 #include <utf8.h>
 
 using namespace parse;
@@ -3818,53 +3813,57 @@ int split_str(const char *src, int max_pixel_w, SCP_vector<int> &n_chars, SCP_ve
 }
 
 // A narrower but much faster alternative to split_str(), takes a string and a max pixel length, returns a vector with
-// one string per line. Does not currently support a max line count or ignoring of characters.
-SCP_vector<SCP_string>
-str_wrap_to_width(const SCP_string& source_string, int max_pixel_length, bool strip_leading_whitespace)
+// one pair (offset and length) per line. Does not currently support a max line count or ignoring of characters.
+SCP_vector<std::pair<size_t, size_t>> str_wrap_to_width(const SCP_string& source_string, int max_pixel_width, bool strip_leading_whitespace, size_t source_start, size_t source_length)
 {
-	// To avoid any unexpected side effects, we're copying the orignal string.
-	SCP_string new_string = SCP_string(source_string);
+	auto lines = SCP_vector<std::pair<size_t, size_t>>();
 
-	SCP_vector<SCP_string> lines = SCP_vector<SCP_string>();
+	if (source_length == std::string::npos)
+		source_length = source_string.length() - source_start;
 
-	while (strip_leading_whitespace && !new_string.empty() && is_white_space(new_string[0])) {
-		new_string.erase(0, 1);
-	}
-	if (new_string.empty())
-		return lines;
+	Assertion(source_start + source_length <= source_string.length(), "In str_wrap_to_width(), source length must not exceed the actual length of the string!");
+
+	size_t pos_start = source_start;
+	size_t pos_end = source_start + source_length;
+
+	// Advance past leading whitespace.
+	while (strip_leading_whitespace && (pos_start < pos_end) && is_white_space(source_string[pos_start]))
+		pos_start++;
 
 	// Handle existing line breaks in the string recursively, then append the results.
-	auto newline_at = new_string.find_first_of(UNICODE_CHAR('\n'));
-	while (!new_string.empty() && newline_at < std::string::npos) {
-		if (newline_at == 0) {
+	while (pos_start < pos_end) {
+		auto newline_at = source_string.find_first_of(UNICODE_CHAR('\n'), pos_start);
+		if (newline_at == std::string::npos || newline_at >= source_length)
+			break;
+
+		if (newline_at == pos_start) {
 			// No content to split so just pushing a new string on.
-			lines.emplace_back();
+			lines.emplace_back(pos_start, 0);
 		} else {
-			SCP_vector<SCP_string> sublines =
-				str_wrap_to_width(new_string.substr(0, newline_at), max_pixel_length, strip_leading_whitespace);
-			for (auto line : sublines) {
-				lines.emplace_back(line);
-			}
+			auto sublines = str_wrap_to_width(source_string, max_pixel_width, strip_leading_whitespace, pos_start, (newline_at - pos_start));
+			lines.reserve(lines.size() + sublines.size());
+			std::move(sublines.begin(), sublines.end(), std::back_inserter(lines));
 		}
-		new_string.erase(0, newline_at + 1);
-		newline_at = new_string.find_first_of(UNICODE_CHAR('\n'));
+
+		pos_start = newline_at + 1;
 	}
-	// With newlines handled, now moving into actually wrapping the content.
-	while (!new_string.empty()) {
+
+	// With newlines handled, now move into actually wrapping the content.
+	while (pos_start < pos_end) {
 		auto split_at = std::string::npos;
 		// no newlines found, check length.
-		size_t stringlen = new_string.length();
-		int linelen = 0;
-		gr_get_string_size(&linelen, nullptr, new_string.c_str());
+		size_t stringlen = pos_end - pos_start;
+		int line_width = 0;
+		gr_get_string_size(&line_width, nullptr, source_string.c_str() + pos_start, stringlen);
 		if (stringlen <= 1) {
 			// in this case checking is pointless, single-character strings can't wrap.
 			// copy into the return vector and then bail.
-			lines.emplace_back(new_string.c_str());
+			lines.emplace_back(pos_start, stringlen);
 			break;
-		} else if (linelen < max_pixel_length) {
+		} else if (line_width < max_pixel_width) {
 			// The remaining string is shorter than our limit so we're done.
 			// copy into the return vector and then bail.
-			lines.emplace_back(new_string.c_str());
+			lines.emplace_back(pos_start, stringlen);
 			break;
 		} else {
 			size_t search_min = 0;
@@ -3872,12 +3871,12 @@ str_wrap_to_width(const SCP_string& source_string, int max_pixel_length, bool st
 			size_t center = 0;
 			while ((search_max - search_min) > 0) {
 				center = search_min + ((search_max - search_min) / 2);
-				gr_get_string_size(&linelen, nullptr, new_string.substr(0, center).c_str());
-				if (linelen == max_pixel_length) {
+				gr_get_string_size(&line_width, nullptr, source_string.c_str() + pos_start, center);
+				if (line_width == max_pixel_width) {
 					search_max = center;
 					search_min = center;
 					split_at = center;
-				} else if (linelen > max_pixel_length) {
+				} else if (line_width > max_pixel_width) {
 					search_max = MIN(center, search_max - 1);
 					split_at = search_max;
 				} else {
@@ -3886,37 +3885,36 @@ str_wrap_to_width(const SCP_string& source_string, int max_pixel_length, bool st
 				}
 			}
 		}
-		if (split_at >= stringlen) { // don't split out of bounds
-			split_at = stringlen - 1;
-		}
-		if (split_at <= 0) {
-			// we need to always remove something from the current line or we're stuck
-			split_at = 1;
-		} else if (!is_white_space(new_string.at(split_at))) {
+
+		// don't split out of bounds, but it's ok to split exactly on the string boundary
+		if (split_at > stringlen) {
+			split_at = stringlen;
+		} else if (split_at < stringlen) {
 			// split_at is now the last point where we can split, but could be mid-word
 			// work backwards to find whitespace.
-			for (int n = ((int)split_at) - 1; n >= 0; n--) {
-				if (is_white_space(new_string.at(n))) {
-					split_at = (size_t)n;
-					n = -1;
-				}
-			}
+			while ((split_at > 0) && !is_white_space(source_string[pos_start + split_at]))
+				split_at--;
+
+			// we need to always remove something from the current line or we're stuck
+			if (split_at == 0)
+				split_at = 1;
 		}
 
-		lines.emplace_back(new_string.substr(0, split_at));
-		new_string.erase(0, split_at);
-		// To trim the front whitespace off the next line
-		while (!new_string.empty() && is_white_space(new_string[0])) {
-			new_string.erase(0, 1);
-		}
+		lines.emplace_back(pos_start, split_at);
+		pos_start += split_at;
+
+		// Trim the leading whitespace off the next line.
+		while ((pos_start < pos_end) && is_white_space(source_string[pos_start]))
+			pos_start++;
 	}
+
 	return lines;
 }
 
-SCP_vector<SCP_string> str_wrap_to_width(const char* source_string, int max_pixel_length, bool strip_leading_whitespace)
+SCP_vector<std::pair<size_t, size_t>> str_wrap_to_width(const char* source_string, int max_pixel_width, bool strip_leading_whitespace, size_t source_length)
 {
-	// SCP_string temp = SCP_string(source_string);
-	return str_wrap_to_width(SCP_string(source_string), max_pixel_length, strip_leading_whitespace);
+	// TODO: actual C-string implementation
+	return str_wrap_to_width(SCP_string(source_string), max_pixel_width, strip_leading_whitespace, 0, source_length);
 }
 
 // Goober5000

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -334,11 +334,10 @@ int split_str(const char* src,
 			  unicode::codepoint_t ignore_char = (unicode::codepoint_t) -1,
 			  bool strip_leading_whitespace = true);
 
-SCP_vector<SCP_string> str_wrap_to_width(const SCP_string& source_string, int max_pixel_length,
-			  bool strip_leading_whitespace = true);
+SCP_vector<std::pair<size_t, size_t>> str_wrap_to_width(const SCP_string& source_string, int max_pixel_width, bool strip_leading_whitespace = true, size_t source_start = 0, size_t source_length = std::string::npos);
 
-SCP_vector<SCP_string> str_wrap_to_width(const char* source_string, int max_pixel_length,
-			  bool strip_leading_whitespace = true);
+SCP_vector<std::pair<size_t, size_t>> str_wrap_to_width(const char* source_string, int max_pixel_width, bool strip_leading_whitespace = true, size_t source_length = std::string::npos);
+
 // fred
 extern int required_string_fred(const char *pstr, const char *end = NULL);
 extern int required_string_either_fred(const char *str1, const char *str2);


### PR DESCRIPTION
This refactors the `str_wrap_to_width` function into one that returns string offsets and lengths rather than newly constructed strings.  The algorithm is unchanged (except for one minor bugfix), but the performance is improved because the function no longer copies and re-copies the strings.  This also takes advantage of the optional parameters in `gr_string` and `gr_get_string_size` that provide a string length.

This also fixes an edge case in string wrapping where a word that fits exactly on the border no longer rapidly flips between one line and the next.

As a secondary cleanup, by using `size_t` in the right places, it is no longer necessary to cast a whole bunch of `size_t` parameters to `int`.  This allows a bunch of casts to be removed at the cost of adding one cast of `int` to `size_t`.

Tested with standard string wrapping, newline wrapping, and long-strings-within-newlines wrapping.  Also tested with several different string wrapping sources.

Followup to #5607.