### PR TITLE
check for potential issues in FRED missions

### DIFF
--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1253,6 +1253,7 @@ enum sexp_error_check
 	SEXP_CHECK_INVALID_SHIP_WING_WHOLETEAM,
 	SEXP_CHECK_MUST_BE_INTEGER,
 	SEXP_CHECK_INVALID_CUSTOM_STRING,
+	SEXP_CHECK_POTENTIAL_ISSUE,
 };
 
 
@@ -1418,6 +1419,7 @@ extern int get_operator_const(int node);
 extern int find_operator_index(int op_const);
 
 extern int check_sexp_syntax(int node, int return_type = OPR_BOOL, int recursive = 0, int *bad_node = 0 /*NULL*/, sexp_mode mode = sexp_mode::GENERAL);
+extern int check_sexp_potential_issues(int node, int *bad_node, SCP_string &issue_msg);
 extern int get_sexp_main(void);	//	Returns start node
 extern int run_sexp(const char* sexpression, bool run_eval_num = false, bool *is_nan_or_nan_forever = nullptr); // debug and lua sexps
 extern int stuff_sexp_variable_list();

--- a/fred2/campaigntreewnd.cpp
+++ b/fred2/campaigntreewnd.cpp
@@ -467,9 +467,9 @@ int campaign_tree_wnd::fred_check_sexp(int sexp, int type, char *msg, ...)
 		err = 1;
 
 	if (err)
-		return internal_error(error_buf.c_str());
+		return internal_error("%s", error_buf.c_str());
 
-	if (error(error_buf.c_str()))
+	if (error("%s", error_buf.c_str()))
 		return 1;
 
 	return 0;

--- a/fred2/fred.cpp
+++ b/fred2/fred.cpp
@@ -244,6 +244,7 @@ BOOL CFREDApp::InitInstance() {
 	Draw_outlines_on_selected_ships = GetProfileInt("Preferences", "Draw outlines on selected ships", 1) != 0;
 	Point_using_uvec = GetProfileInt("Preferences", "Point using uvec", Point_using_uvec);
 	Draw_outline_at_warpin_position = GetProfileInt("Preferences", "Draw outline at warpin position", 0) != 0;
+	Error_checker_checks_potential_issues = GetProfileInt("Preferences", "Error checker checks potential issues", 1) != 0;
 
 	read_window("Main window", &Main_wnd_data);
 	read_window("Ship window", &Ship_wnd_data);
@@ -524,6 +525,7 @@ void CFREDApp::write_ini_file(int degree) {
 	WriteProfileInt("Preferences", "Draw outlines on selected ships", Draw_outlines_on_selected_ships ? 1 : 0);
 	WriteProfileInt("Preferences", "Point using uvec", Point_using_uvec);
 	WriteProfileInt("Preferences", "Draw outline at warpin position", Draw_outline_at_warpin_position ? 1 : 0);
+	WriteProfileInt("Preferences", "Error checker checks potential issues", Error_checker_checks_potential_issues ? 1 : 0);
 
 	if (!degree) {
 		record_window_data(&Waypoint_wnd_data, &Waypoint_editor_dialog);

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -385,6 +385,7 @@ BEGIN
         MENUITEM "Mission Statistics\tCtrl+Shift+D", 33067
         MENUITEM "Music Player",                ID_MUSIC_PLAYER
         MENUITEM SEPARATOR
+        MENUITEM "Error checker checks for potential issues", ID_ERROR_CHECKER_CHECKS_POTENTIAL_ISSUES, CHECKED
         MENUITEM "Error checker\tShift+H",      32978
     END
     POPUP "&Help"

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -102,6 +102,7 @@ int Show_horizon = 0;
 int Show_outlines = 0;
 bool Draw_outlines_on_selected_ships = true;
 bool Draw_outline_at_warpin_position = false;
+bool Error_checker_checks_potential_issues = true;
 int Show_stars = 1;
 int Single_axis_constraint = 0;
 int True_rw, True_rh;

--- a/fred2/fredrender.h
+++ b/fred2/fredrender.h
@@ -22,6 +22,7 @@ extern int Show_coordinates;        //!< Bool. If nonzero, draw the coordinates 
 extern int Show_outlines;           //!< Bool. If nonzero, draw each object's mesh. If models are shown, highlight them in white.
 extern bool Draw_outlines_on_selected_ships;	// If a ship is selected, draw mesh lines
 extern bool Draw_outline_at_warpin_position;	// Project an outline at the place where the ship will arrive after warping in
+extern bool Error_checker_checks_potential_issues;	// Error checker checks not only outright errors but also potential issues
 extern int Show_stars;              //!< Bool. If nonzero, draw the starfield, nebulas, and suns. Might also handle skyboxes
 extern int Single_axis_constraint;  //!< Bool. If nonzero, constrain movement to one axis
 extern int Show_distances;          //!< Bool. If nonzero, draw lines between each object and display their distance on the middle of each line

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -268,6 +268,8 @@ BEGIN_MESSAGE_MAP(CFREDView, CView)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_OUTLINES_ON_SELECTED, OnUpdateViewOutlinesOnSelected)
 	ON_COMMAND(ID_VIEW_OUTLINE_AT_WARPIN, OnViewOutlineAtWarpin)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_OUTLINE_AT_WARPIN, OnUpdateViewOutlineAtWarpin)
+	ON_COMMAND(ID_ERROR_CHECKER_CHECKS_POTENTIAL_ISSUES, OnErrorCheckerChecksPotentialIssues)
+	ON_UPDATE_COMMAND_UI(ID_ERROR_CHECKER_CHECKS_POTENTIAL_ISSUES, OnUpdateErrorCheckerChecksPotentialIssues)
 	ON_UPDATE_COMMAND_UI(ID_NEW_SHIP_TYPE, OnUpdateNewShipType)
 	ON_COMMAND(ID_SHOW_STARFIELD, OnShowStarfield)
 	ON_UPDATE_COMMAND_UI(ID_SHOW_STARFIELD, OnUpdateShowStarfield)
@@ -3400,7 +3402,8 @@ int CFREDView::fred_check_sexp(int sexp, int type, const char *location, ...)
 			return 1;
 	}
 
-	z = check_sexp_potential_issues(sexp, &faulty_node, issue_msg);
+	if (Error_checker_checks_potential_issues)
+		z = check_sexp_potential_issues(sexp, &faulty_node, issue_msg);
 	if (z)
 	{
 		convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);
@@ -3821,6 +3824,18 @@ void CFREDView::OnViewOutlineAtWarpin()
 void CFREDView::OnUpdateViewOutlineAtWarpin(CCmdUI* pCmdUI)
 {
 	pCmdUI->SetCheck(Draw_outline_at_warpin_position);
+}
+
+void CFREDView::OnErrorCheckerChecksPotentialIssues()
+{
+	Error_checker_checks_potential_issues = !Error_checker_checks_potential_issues;
+	theApp.write_ini_file();
+	Update_window = 1;
+}
+
+void CFREDView::OnUpdateErrorCheckerChecksPotentialIssues(CCmdUI* pCmdUI)
+{
+	pCmdUI->SetCheck(Error_checker_checks_potential_issues);
 }
 
 void CFREDView::OnUpdateNewShipType(CCmdUI* pCmdUI) 

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -3365,41 +3365,56 @@ int CFREDView::internal_error(const char *msg, ...)
 	return -1;
 }
 
-int CFREDView::fred_check_sexp(int sexp, int type, const char *msg, ...)
+int CFREDView::fred_check_sexp(int sexp, int type, const char *location, ...)
 {
-	SCP_string buf, sexp_buf, error_buf, bad_node_str;
+	SCP_string location_buf, sexp_buf, error_buf, bad_node_str, issue_msg;
 	int err = 0, z, faulty_node;
 	va_list args;
 
-	va_start(args, msg);
-	vsprintf(buf, msg, args);
+	va_start(args, location);
+	vsprintf(location_buf, location, args);
 	va_end(args);
 
 	if (sexp == -1)
 		return 0;
 
 	z = check_sexp_syntax(sexp, type, 1, &faulty_node);
-	if (!z)
-		return 0;
+	if (z)
+	{
+		convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);
+		truncate_message_lines(sexp_buf, 30);
 
-	convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);
-	truncate_message_lines(sexp_buf, 30);
+		stuff_sexp_text_string(bad_node_str, faulty_node, SEXP_ERROR_CHECK_MODE);
+		if (!bad_node_str.empty())		// the previous function adds a space at the end
+			bad_node_str.pop_back();
 
-	stuff_sexp_text_string(bad_node_str, faulty_node, SEXP_ERROR_CHECK_MODE);
-	if (!bad_node_str.empty()) {	// the previous function adds a space at the end
-		bad_node_str.pop_back();
+		sprintf(error_buf, "Error in %s: %s\n\n%s\n\n(Bad node appears to be: %s)", location_buf.c_str(), sexp_error_message(z), sexp_buf.c_str(), bad_node_str.c_str());
+
+		if (z < 0 && z > -100)
+			err = 1;
+
+		if (err)
+			return internal_error("%s", error_buf.c_str());
+
+		if (error("%s", error_buf.c_str()))
+			return 1;
 	}
 
-	sprintf(error_buf, "Error in %s: %s\n\nIn sexpression: %s\n\n(Bad node appears to be: %s)", buf.c_str(), sexp_error_message(z), sexp_buf.c_str(), bad_node_str.c_str());
+	z = check_sexp_potential_issues(sexp, &faulty_node, issue_msg);
+	if (z)
+	{
+		convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);
+		truncate_message_lines(sexp_buf, 30);
 
-	if (z < 0 && z > -100)
-		err = 1;
+		stuff_sexp_text_string(bad_node_str, faulty_node, SEXP_ERROR_CHECK_MODE);
+		if (!bad_node_str.empty())		// the previous function adds a space at the end
+			bad_node_str.pop_back();
 
-	if (err)
-		return internal_error(error_buf.c_str());
+		sprintf(error_buf, "Potential issue detected in %s:\n%s\n\n%s\n\n(Suspect node appears to be: %s)", location_buf.c_str(), issue_msg.c_str(), sexp_buf.c_str(), bad_node_str.c_str());
 
-	if (error(error_buf.c_str()))
-		return 1;
+		if (Fred_main_wnd->MessageBox(error_buf.c_str(), "Warning", MB_OKCANCEL | MB_ICONINFORMATION) != IDOK)
+			return 1;
+	}
 
 	return 0;
 }

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -44,7 +44,7 @@ protected: // create from serialization only
 public:
 
 	int global_error_check_mixed_player_wing(int w);
-	int fred_check_sexp(int sexp, int type, const char *msg, ...);
+	int fred_check_sexp(int sexp, int type, const char *location, ...);
 	int internal_error(const char *msg, ...);
 	int error(const char *msg, ...);
 	int global_error_check();

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -225,6 +225,8 @@ protected:
 	afx_msg void OnUpdateViewOutlinesOnSelected(CCmdUI* pCmdUI);
 	afx_msg void OnViewOutlineAtWarpin();
 	afx_msg void OnUpdateViewOutlineAtWarpin(CCmdUI* pCmdUI);
+	afx_msg void OnErrorCheckerChecksPotentialIssues();
+	afx_msg void OnUpdateErrorCheckerChecksPotentialIssues(CCmdUI* pCmdUI);
 	afx_msg void OnUpdateNewShipType(CCmdUI* pCmdUI);
 	afx_msg void OnShowStarfield();
 	afx_msg void OnUpdateShowStarfield(CCmdUI* pCmdUI);

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -1450,6 +1450,7 @@
 #define ID_SHOW_STARTS                  32991
 #define ID_TOGGLE_VIEWPOINT             32992
 #define ID_VIEW_OUTLINE_AT_WARPIN       32993
+#define ID_ERROR_CHECKER_CHECKS_POTENTIAL_ISSUES 32994
 #define ID_CPGN_FILE_NEW                32995
 #define ID_CPGN_FILE_OPEN               32996
 #define ID_CPGN_FILE_SAVE               32997

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -2539,7 +2539,8 @@ int Editor::fred_check_sexp(int sexp, int type, const char* location, ...) {
 			return 1;
 	}
 
-	z = check_sexp_potential_issues(sexp, &faulty_node, issue_msg);
+	if (_lastActiveViewport->Error_checker_checks_potential_issues)
+		z = check_sexp_potential_issues(sexp, &faulty_node, issue_msg);
 	if (z)
 	{
 		convert_sexp_to_string(sexp_buf, sexp, SEXP_ERROR_CHECK_MODE);

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -271,7 +271,7 @@ class Editor : public QObject {
 	int error(SCP_FORMAT_STRING const char* msg, ...) SCP_FORMAT_STRING_ARGS(2, 3);
 	int internal_error(SCP_FORMAT_STRING const char* msg, ...) SCP_FORMAT_STRING_ARGS(2, 3);
 
-	int fred_check_sexp(int sexp, int type, const char* msg, ...);
+	int fred_check_sexp(int sexp, int type, const char* location, ...);
 
 
 	int global_error_check_mixed_player_wing(int w);

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -163,6 +163,7 @@ class EditorViewport {
 	bool Group_rotate = true;
 	bool Lookat_mode = false;
 	bool Move_ships_when_undocking = true;
+	bool Error_checker_checks_potential_issues = true;
 
 	Editor* editor = nullptr;
 	FredRenderer* renderer = nullptr;

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -134,6 +134,7 @@ void FredView::setEditor(Editor* editor, EditorViewport* viewport) {
 			[this]() { ui->actionRestore_Camera_Pos->setEnabled(!IS_VEC_NULL(&_viewport->saved_cam_orient.vec.fvec)); });
 
 	connect(this, &FredView::viewIdle, this, [this]() { ui->actionMove_Ships_When_Undocking->setChecked(_viewport->Move_ships_when_undocking); });
+	connect(this, &FredView::viewIdle, this, [this]() { ui->actionError_Checker_Checks_Potential_Issues->setChecked(_viewport->Error_checker_checks_potential_issues); });
 }
 
 void FredView::loadMissionFile(const QString& pathName) {
@@ -1098,6 +1099,9 @@ void FredView::on_actionCancel_Subsystem_triggered(bool) {
 }
 void FredView::on_actionMove_Ships_When_Undocking_triggered(bool) {
 	_viewport->Move_ships_when_undocking = !_viewport->Move_ships_when_undocking;
+}
+void FredView::on_actionError_Checker_Checks_Potential_Issues_triggered(bool) {
+	_viewport->Error_checker_checks_potential_issues = !_viewport->Error_checker_checks_potential_issues;
 }
 void FredView::on_actionError_Checker_triggered(bool) {
 	fred->global_error_check();

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -125,6 +125,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 
 	void on_actionMove_Ships_When_Undocking_triggered(bool);
 
+	void on_actionError_Checker_Checks_Potential_Issues_triggered(bool);
 	void on_actionError_Checker_triggered(bool);
 
 	void on_actionAbout_triggered(bool);

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -230,6 +230,7 @@
     <addaction name="actionMove_Ships_When_Undocking"/>
     <addaction name="actionMission_Statistics"/>
     <addaction name="separator"/>
+    <addaction name="actionError_Checker_Checks_Potential_Issues"/>
     <addaction name="actionError_Checker"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -1422,6 +1423,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+D</string>
+   </property>
+  </action>
+  <action name="actionError_Checker_Checks_Potential_Issues">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Error checker checks for potential issues</string>
    </property>
   </action>
   <action name="actionError_Checker">


### PR DESCRIPTION
Add a routine to the sexp syntax checker that also checks for potential issues.  These are not definitive errors, but situations that might trip up mission designers.  Currently there is one issue checked: the destruction of a wing that has multiple waves and arrives from a docking bay.