### PR TITLE
fix crash in QtFRED

### DIFF
--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -771,7 +771,7 @@
   </action>
   <action name="actionDraw_Outline_At_Warpin_Position">
    <property name="checkable">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="text">
     <string>Draw Outline At Warpin Position</string>


### PR DESCRIPTION
Not sure how this option became false, but it should be true in order for the checkable menu option to be set up properly.