### PR TITLE
Fix Coverity WorkFlow

### DIFF
--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -2,13 +2,13 @@ name: Weekly Coverity Scan for Freespace Open
 # adapted from code by "albert-github" on the doxygen repository
 # many thanks for figuring this out first so it could be less painful for us!
 
-# This mode is for testing
+#This mode is for testing
 #on: [push, pull_request]
 
 # In production, push on a specific schedule
 on:
   schedule:
-    - cron: "1 0 * * 5" # Run once per a week on Friday morning (midnight UTC, 4 AM EST), to avoid Coverity's submission limits
+    - cron: "5 0 * * 5" # Run once per a week on Friday morning (midnight UTC, 4 AM EST), to avoid Coverity's submission limits
 
 env:
   QT_VERSION: 5.12.12
@@ -19,23 +19,16 @@ jobs:
   build:
     name: Build FSO With Coverity Wrapper
     runs-on: ${{ matrix.config.os }}
+    container: ghcr.io/scp-fs2open/linux_build:sha-5ac6f70
     strategy:
       fail-fast: false
       matrix:
         config:
           - { name: "GCC on ubuntu", os: ubuntu-latest, build_type: "Release" }
-    steps:
-      - name: Install Dependencies
-        run: |
-          sudo apt-get install ninja-build
-          sudo apt install cmake libsdl2-dev g++
-          sudo apt-get install libopenal-dev
-          sudo apt-get install -y libudev-dev
-          sudo apt-get install doxygen
-          sudo apt install graphviz
 
+    steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v1
         with:
           submodules: recursive # `true` to checkout submodules, `recursive` to recursively checkout submodules
 
@@ -50,13 +43,6 @@ jobs:
         run: |
           echo "$(pwd)/cov-scan/bin" >> $GITHUB_PATH
           echo "NPROC=$(getconf _NPROCESSORS_ONLN)" >> $GITHUB_ENV
-
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
-        with:
-          vulkan-query-version: 1.3.204.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
 
       - name: Configure CMake for FSO
         env:


### PR DESCRIPTION
This fixes the weekly coverity workflow by ny using container images and switching to Checkout V1.

Also removes Vulkan SDK install, since it seems to be taken care of by the new containers or is disabled.