### PR TITLE
Coverity: Create a copy of the object

### DIFF
--- a/code/options/OptionsManager.cpp
+++ b/code/options/OptionsManager.cpp
@@ -40,15 +40,14 @@ std::unique_ptr<json_t> OptionsManager::getValueFromConfig(const SCP_string& key
 {
 	auto override_iter = _config_overrides.find(key);
 	if (override_iter != _config_overrides.end()) {
-		// We return a reference to an existing object so we need to increment the reference count
-		json_incref(override_iter->second.get());
-		return std::unique_ptr<json_t>(override_iter->second.get());
+		json_t temp = *override_iter->second.get();
+		return std::unique_ptr<json_t>(&temp);
 	}
 
 	auto changed_iter = _changed_values.find(key);
 	if (changed_iter != _changed_values.end()) {
-		json_incref(changed_iter->second.get());
-		return std::unique_ptr<json_t>(changed_iter->second.get());
+		json_t temp = *changed_iter->second.get();
+		return std::unique_ptr<json_t>(&temp);
 	}
 
 	auto parts = parse_key(key);


### PR DESCRIPTION
Instead of returning the unique pointer, which would make it a shared unique pointer (bad).  This method is only used to get the value stored in the config and the reference will be destroyed pretty quickly after being called.  Sure, it is more efficient to use the pointer to get the info, but I don't think it's worth it to rewrite the methods here, and we don't need the efficiency since this is used to update the UI.

And it's not feasible to convert to shared pointer, since there are so many references to unique pointers in this code.  It's just better to just make a quick copy here.

I have to turn this through a test, still.