### PR TITLE
Fix typo in lua error prints

### DIFF
--- a/code/scripting/lua/LuaFunction.cpp
+++ b/code/scripting/lua/LuaFunction.cpp
@@ -152,7 +152,7 @@ void LuaFunction::setReference(const LuaReference& ref) {
 
 	if (lua_type(L, -1) != LUA_TFUNCTION) {
 		lua_pop(L, 1);
-		throw LuaException("Reference does not refere to a function!");
+		throw LuaException("Reference does not refer to a function!");
 	} else {
 		lua_pop(L, 1);
 		LuaValue::setReference(ref);

--- a/code/scripting/lua/LuaTable.cpp
+++ b/code/scripting/lua/LuaTable.cpp
@@ -42,7 +42,7 @@ void LuaTable::setReference(const LuaReference& ref) {
 
 	if (lua_type(L, -1) != LUA_TTABLE) {
 		lua_pop(L, 1);
-		throw LuaException("Reference does not refere to a table!");
+		throw LuaException("Reference does not refer to a table!");
 	} else {
 		lua_pop(L, 1);
 		LuaValue::setReference(ref);


### PR DESCRIPTION
2 line typo fix `refere` -> `refer`