### PR TITLE
additional HUD fixes for VR

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -1697,7 +1697,7 @@ void hud_render_preprocess(float frametime)
 
 	if ( hud_disabled() ) {
 		// if the hud is disabled, we still need to make sure that the indicators are properly handled
-		hud_do_lock_indicators(flFrametime);
+		hud_do_lock_indicators(frametime);
 		return;
 	}
 
@@ -1823,15 +1823,15 @@ void hud_maybe_display_supernova()
 /**
  * @brief Undertakes main HUD render. 
  */
-void hud_render_all()
+void hud_render_all(float frametime)
 {
 	int i;
 
-	hud_render_gauges();
+	hud_render_gauges(-1, frametime);
 
 	// start rendering cockpit dependent gauges if possible
 	for ( i = 0; i < (int)Player_displays.size(); ++i ) {
-		hud_render_gauges(i);
+		hud_render_gauges(i, frametime);
 	}
 
 	hud_clear_msg_buffer();
@@ -1840,7 +1840,7 @@ void hud_render_all()
 	font::set_font(font::FONT1);
 }
 
-void hud_render_gauges(int cockpit_display_num)
+void hud_render_gauges(int cockpit_display_num, float frametime)
 {
 	size_t j, num_gauges;
 	ship_info* sip = &Ship_info[Player_ship->ship_info_index];
@@ -1865,9 +1865,6 @@ void hud_render_gauges(int cockpit_display_num)
 			return;
 		}
 	}
-
-	//Since we render things twice in VR mode, frametime needs to be halved for HUD, as the HUD uses the frametime to advance ANI's and crucially, the missile lock...
-	float frametime = openxr_enabled() ? flFrametime * 0.5f : flFrametime;
 
 	// Check if this ship has its own HUD gauges. 
 	if ( sip->hud_enabled ) {

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -119,8 +119,8 @@ void hud_close();
 void hud_level_close();
 void hud_update_frame(float frametime);		// updates hud systems not dependant on rendering
 void hud_render_preprocess(float frametime);			// renders 3d dependant gauges
-void hud_render_all();
-void hud_render_gauges(int cockpit_display_num = -1);
+void hud_render_all(float frametime);
+void hud_render_gauges(int cockpit_display_num, float frametime);
 void hud_stop_looped_engine_sounds();
 
 // set the offset values for this render frame

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3841,6 +3841,9 @@ void game_render_hud(camid cid, const fov_t* fov_override = nullptr)
 {
 	gr_reset_clip();
 
+	//Since we render things twice in VR mode, frametime needs to be halved for HUD, as the HUD uses the frametime to advance ANI's and crucially, the missile lock...
+	float frametime = openxr_enabled() ? flFrametime * 0.5f : flFrametime;
+
 	if(cid.isValid()) {
 		g3_start_frame(0);		// 0 = turn zbuffering off
 		g3_set_view( cid.getCamera() );
@@ -3848,13 +3851,13 @@ void game_render_hud(camid cid, const fov_t* fov_override = nullptr)
 		if (fov_override)
 			g3_set_fov(*fov_override);
 
-		hud_render_preprocess(flFrametime);
+		hud_render_preprocess(frametime);
 
 		g3_end_frame();
 	}
 
 	// main HUD rendering function
-	hud_render_all();
+	hud_render_all(frametime);
 
 	// Diminish the palette effect
 	game_flash_diminish(flFrametime);


### PR DESCRIPTION
Use a single canonical `frametime` value for all HUD rendering, in both `hud_render_preprocess` and `hud_render_all`.  Previously, certain functions called through `hud_render_preprocess` were using the full frametime, rather than the half frametime needed for VR when the HUD is rendered twice.

Fixes #5882.  ~~In draft pending confirmation of the fix from a user with a VR setup.~~ Fix confirmed by @Kerbrer.