### PR TITLE
campaign error message improvement

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1816 // This is the next available ID
+// #define XSTR_SIZE	1817 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -1070,6 +1070,9 @@ void barracks_button_pressed(int n)
 			} else {
 				gamesnd_play_iface(InterfaceSounds::SCROLL);
 
+				// we now have a new pilot, so try to load its current campaign, falling back if necessary
+				mission_load_up_campaign(true);
+
 				if (Campaign_file_missing) {
 					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "The currently active campaign cannot be found.  Please select another...", 1600));
 					gameseq_post_event(GS_EVENT_CAMPAIGN_ROOM);
@@ -1080,6 +1083,9 @@ void barracks_button_pressed(int n)
 		case B_ACCEPT_BUTTON:
 			if (Num_pilots && !barracks_pilot_accepted()) {
 				gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
+
+				// we now have a new pilot, so try to load its current campaign, falling back if necessary
+				mission_load_up_campaign(true);
 
 				if (Campaign_file_missing) {
 					popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR( "The currently active campaign cannot be found.  Please select another...", 1600));

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -906,8 +906,7 @@ void main_hall_do(float frametime)
 					Game_mode = GM_NORMAL;
 
 					// see if we have a missing campaign and force the player to select a new campaign if so
-					if (!(Player->flags & PLAYER_FLAGS_IS_MULTI) && Campaign_file_missing &&
-						!Campaign_room_no_campaigns) {
+					if (!(Player->flags & PLAYER_FLAGS_IS_MULTI) && Campaign_file_missing && !Campaign_room_no_campaigns) {
 						int rc = popup(0,
 							3,
 							XSTR("Go to Campaign Room", 1607),
@@ -933,7 +932,6 @@ void main_hall_do(float frametime)
 							break;
 						}
 					} else {
-
 						gameseq_post_event(GS_EVENT_NEW_CAMPAIGN);
 						gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 					}

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -917,7 +917,11 @@ int sim_room_button_pressed(int n)
 
 		case CAMPAIGN_TAB:
 			if ( !strlen(Campaign.filename) ) {
-				popup( PF_USE_AFFIRMATIVE_ICON | PF_NO_NETWORKING, 1, POPUP_OK, XSTR( "The currently active campaign cannot be found, unable to switch to campaign mode!", 1612));
+				if (Campaign_load_failure == CAMPAIGN_ERROR_MISSING) {
+					popup(PF_USE_AFFIRMATIVE_ICON | PF_NO_NETWORKING, 1, POPUP_OK, XSTR("The currently active campaign cannot be found.  Unable to switch to campaign mode.", 1612));
+				} else {
+					popup(PF_USE_AFFIRMATIVE_ICON | PF_NO_NETWORKING, 1, POPUP_OK, XSTR("The currently active campaign cannot be loaded.  Unable to switch to campaign mode.", 1816));
+				}
 				break;
 			}
 
@@ -1050,7 +1054,9 @@ void sim_room_init()
 		Campaign.filename[0] = 0;
 		Campaign.num_missions = 0;
 
-		mission_campaign_load_failure_popup();
+		// don't display the popup in the sim room - first because there is already logic to prevent listing campaign missions,
+		// second because there's not much the player can do about it in the sim room, and third because displaying the popup
+		// clears the error code
 	}
 
 	Num_campaign_missions = 0;

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -634,19 +634,25 @@ int mission_campaign_load(const char* filename, const char* full_path, player* p
 		if ((Game_mode & GM_MULTIPLAYER) && Campaign.num_missions > UINT8_MAX)
 			throw parse::ParseException("Number of campaign missions is too high and breaks multi!");
 	}
-	catch (const parse::ParseException& e)
+	catch (const parse::FileOpenException& foe)
 	{
-		mprintf(("Error parsing '%s'\r\nError message = %s.\r\n", filename, e.what()));
+		mprintf(("Error opening '%s'\r\nError message = %s.\r\n", filename, foe.what()));
 
 		Campaign.filename[0] = 0;
 		Campaign.num_missions = 0;
 
-		if (!Fred_running && !(Game_mode & GM_MULTIPLAYER)) {
-			Campaign_file_missing = 1;
-			Campaign_load_failure = CAMPAIGN_ERROR_MISSING;
-			return CAMPAIGN_ERROR_MISSING;
-		}
+		Campaign_file_missing = 1;
+		Campaign_load_failure = CAMPAIGN_ERROR_MISSING;
+		return CAMPAIGN_ERROR_MISSING;
+	}
+	catch (const parse::ParseException& pe)
+	{
+		mprintf(("Error parsing '%s'\r\nError message = %s.\r\n", filename, pe.what()));
 
+		Campaign.filename[0] = 0;
+		Campaign.num_missions = 0;
+
+		Campaign_file_missing = 1;
 		Campaign_load_failure = CAMPAIGN_ERROR_CORRUPT;
 		return CAMPAIGN_ERROR_CORRUPT;
 	}

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -1545,6 +1545,11 @@ bool campaign_is_ignored(const char *filename)
 	return false;
 }
 
+static bool campaign_reportable_error(int val)
+{
+	return val != 0 && val != CAMPAIGN_ERROR_MISSING && val != CAMPAIGN_ERROR_IGNORED;
+}
+
 // returns 0: loaded, !0: error
 int mission_load_up_campaign(bool fall_back_from_current)
 {

--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -60,7 +60,7 @@ char *Campaign_names[MAX_CAMPAIGNS] = { NULL };
 char *Campaign_file_names[MAX_CAMPAIGNS] = { NULL };
 char *Campaign_descs[MAX_CAMPAIGNS] = { NULL };
 int	Num_campaigns;
-int Campaign_file_missing;
+bool Campaign_file_missing = false;
 int Campaign_load_failure = 0;
 int Campaign_names_inited = 0;
 SCP_vector<SCP_string> Ignored_campaigns;
@@ -428,7 +428,7 @@ int mission_campaign_load(const char* filename, const char* full_path, player* p
 	char name[NAME_LENGTH], type[NAME_LENGTH], temp[NAME_LENGTH];
 
 	if (campaign_is_ignored(filename)) {
-		Campaign_file_missing = 1;
+		Campaign_file_missing = true;
 		Campaign_load_failure = CAMPAIGN_ERROR_IGNORED;
 		return CAMPAIGN_ERROR_IGNORED;
 	}
@@ -641,7 +641,7 @@ int mission_campaign_load(const char* filename, const char* full_path, player* p
 		Campaign.filename[0] = 0;
 		Campaign.num_missions = 0;
 
-		Campaign_file_missing = 1;
+		Campaign_file_missing = true;
 		Campaign_load_failure = CAMPAIGN_ERROR_MISSING;
 		return CAMPAIGN_ERROR_MISSING;
 	}
@@ -652,7 +652,7 @@ int mission_campaign_load(const char* filename, const char* full_path, player* p
 		Campaign.filename[0] = 0;
 		Campaign.num_missions = 0;
 
-		Campaign_file_missing = 1;
+		Campaign_file_missing = true;
 		Campaign_load_failure = CAMPAIGN_ERROR_CORRUPT;
 		return CAMPAIGN_ERROR_CORRUPT;
 	}
@@ -687,7 +687,7 @@ int mission_campaign_load(const char* filename, const char* full_path, player* p
 	}
 
 	// all is good here, move along
-	Campaign_file_missing = 0;
+	Campaign_file_missing = false;
 
 	return 0;
 }
@@ -727,7 +727,7 @@ void mission_campaign_init()
 {
 	mission_campaign_clear();
 
-	Campaign_file_missing = 0;
+	Campaign_file_missing = false;
 
 	player_loadout_init();
 }
@@ -1564,7 +1564,7 @@ int mission_load_up_campaign( player *pl )
 			return mission_campaign_load(pl->current_campaign, nullptr, pl);
 		}
 		else {
-			Campaign_file_missing = 1;
+			Campaign_file_missing = true;
 		}
 	}
 

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -161,8 +161,8 @@ extern SCP_vector<SCP_string> Ignored_campaigns;
 
 extern char Default_campaign_file_name[MAX_FILENAME_LEN - 4];
 
-// if the campaign file is missing this will get set for us to check against
-extern int Campaign_file_missing;
+extern bool Campaign_file_missing;	// if the campaign file is missing this will get set for us to check against
+extern int Campaign_load_failure;
 
 /*
  * initialise Player_loadout with default values

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -30,8 +30,6 @@ struct sexp_variable;
 #define CAMPAIGN_ERROR_SAVEFILE			-4
 #define CAMPAIGN_ERROR_IGNORED			-5
 
-inline bool campaign_reportable_error(int val) { return val != 0 && val != CAMPAIGN_ERROR_MISSING && val != CAMPAIGN_ERROR_IGNORED; }
-
 // types of campaigns -- these defines match the string literals listed below which
 // are found in the campaign files.  I don't think that we need campaigns for furball
 // missions.

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -30,6 +30,8 @@ struct sexp_variable;
 #define CAMPAIGN_ERROR_SAVEFILE			-4
 #define CAMPAIGN_ERROR_IGNORED			-5
 
+inline bool campaign_reportable_error(int val) { return val != 0 && val != CAMPAIGN_ERROR_MISSING && val != CAMPAIGN_ERROR_IGNORED; }
+
 // types of campaigns -- these defines match the string literals listed below which
 // are found in the campaign files.  I don't think that we need campaigns for furball
 // missions.
@@ -218,7 +220,7 @@ int mission_campaign_get_info(const char *filename, char *name, int *type, int *
 int mission_campaign_get_mission_list(const char *filename, char **list, int max);
 
 // load up a campaign for the current player.
-int mission_load_up_campaign( player *p = NULL );
+int mission_load_up_campaign(bool fall_back_from_current = false);
 
 // stores mission goals and events in Campaign struct
 void mission_campaign_store_goals_and_events();

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2104,10 +2104,9 @@ int parse_get_line(char *lineout, int max_line_len, const char *start, int max_s
 // Goober5000 - added ability to read somewhere other than Parse_text
 void read_file_text(const char *filename, int mode, char *processed_text, char *raw_text)
 {
-	// copy the filename
-	if (!filename)
-		throw parse::ParseException("Invalid filename");
+	Assertion(filename, "Filename must not be null!");
 
+	// copy the filename
 	strcpy_s(Current_filename_sub, filename);
 
 	// if we are paused then processed_text and raw_text must not be NULL!!
@@ -2231,13 +2230,13 @@ void read_raw_file_text(const char *filename, int mode, char *raw_text)
 	CFILE	*mf;
 	int	file_is_encrypted;
 
-	Assert(filename);
+	Assertion(filename, "Filename must not be null!");
 
 	mf = cfopen(filename, "rb", CFILE_NORMAL, mode);
 	if (mf == NULL)
 	{
 		nprintf(("Error", "Wokka!  Error opening file (%s)!\n", filename));
-		throw parse::ParseException("Failed to open file");
+		throw parse::FileOpenException("Failed to open file");
 	}
 
 	// read the entire file in
@@ -2245,7 +2244,7 @@ void read_raw_file_text(const char *filename, int mode, char *raw_text)
 
 	if(!file_len) {
 		nprintf(("Error", "Oh noes!!  File is empty! (%s)!\n", filename));
-		throw parse::ParseException("Failed to open file");
+		throw parse::ParseException("File is empty");
 	}
 
 	// For the possible Latin1 -> UTF-8 conversion we need to reallocate the raw_text at some point and we can only do
@@ -2469,10 +2468,9 @@ void read_file_bytes(const char *filename, int mode, char *raw_bytes)
 {
 	CFILE	*mf;
 
-	// copy the filename
-	if (!filename)
-		throw parse::ParseException("Invalid filename");
+	Assertion(filename, "Filename must not be null!");
 
+	// copy the filename
 	strcpy_s(Current_filename_sub, filename);
 
 	// if we are paused then raw_bytes must not be NULL!!
@@ -2484,7 +2482,7 @@ void read_file_bytes(const char *filename, int mode, char *raw_bytes)
 	if (mf == nullptr)
 	{
 		nprintf(("Error", "Wokka!  Error opening file (%s)!\n", filename));
-		throw parse::ParseException("Failed to open file");
+		throw parse::FileOpenException("Failed to open file");
 	}
 
 	// read the entire file in
@@ -2492,7 +2490,7 @@ void read_file_bytes(const char *filename, int mode, char *raw_bytes)
 
 	if(!file_len) {
 		nprintf(("Error", "Oh noes!!  File is empty! (%s)!\n", filename));
-		throw parse::ParseException("Failed to open file");
+		throw parse::ParseException("File is empty");
 	}
 
 	if (raw_bytes == nullptr) {

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2105,6 +2105,8 @@ int parse_get_line(char *lineout, int max_line_len, const char *start, int max_s
 void read_file_text(const char *filename, int mode, char *processed_text, char *raw_text)
 {
 	Assertion(filename, "Filename must not be null!");
+	if (!filename)
+		throw parse::FileOpenException("Filename must not be null!");
 
 	// copy the filename
 	strcpy_s(Current_filename_sub, filename);
@@ -2231,6 +2233,8 @@ void read_raw_file_text(const char *filename, int mode, char *raw_text)
 	int	file_is_encrypted;
 
 	Assertion(filename, "Filename must not be null!");
+	if (!filename)
+		throw parse::FileOpenException("Filename must not be null!");
 
 	mf = cfopen(filename, "rb", CFILE_NORMAL, mode);
 	if (mf == NULL)
@@ -2469,6 +2473,8 @@ void read_file_bytes(const char *filename, int mode, char *raw_bytes)
 	CFILE	*mf;
 
 	Assertion(filename, "Filename must not be null!");
+	if (!filename)
+		throw parse::FileOpenException("Filename must not be null!");
 
 	// copy the filename
 	strcpy_s(Current_filename_sub, filename);

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -418,6 +418,13 @@ namespace parse
 		~ParseException() noexcept override = default;
 	};
 
+	class FileOpenException : public ParseException
+	{
+	public:
+		explicit FileOpenException(const std::string& msg) : ParseException(msg) {}
+		~FileOpenException() noexcept override = default;
+	};
+
 	class VersionException : public std::runtime_error
 	{
 	private:

--- a/fred2/campaigneditordlg.cpp
+++ b/fred2/campaigneditordlg.cpp
@@ -192,6 +192,8 @@ void campaign_editor::load_campaign(const char *filename, const char *full_path)
 			MessageBox("Requested campaign file is corrupt.", "Could not load campaign file");
 		else if (result == CAMPAIGN_ERROR_SEXP_EXHAUSTED)
 			MessageBox("Requested campaign requires too many SEXPs.", "Could not load campaign file");
+		else if (result == CAMPAIGN_ERROR_MISSING)
+			MessageBox("Requested campaign file could not be found.", "Could not load campaign file");
 		else if (result == CAMPAIGN_ERROR_SAVEFILE)
 			MessageBox("The pilot savefile for this campaign is invalid for the current mod.", "Could not load campaign file");
 		else if (result == CAMPAIGN_ERROR_IGNORED)

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5691,7 +5691,7 @@ void game_enter_state( int old_state, int new_state )
 	}
 
 	switch (new_state) {
-		case GS_STATE_MAIN_MENU:				
+		case GS_STATE_MAIN_MENU: {
 			// in multiplayer mode, be sure that we are not doing networking anymore.
 			if ( Game_mode & GM_MULTIPLAYER ) {
 				Assert( Net_player != nullptr );
@@ -5711,13 +5711,18 @@ void game_enter_state( int old_state, int new_state )
 			}
 
 			// determine which ship this guy is currently based on
-			mission_load_up_campaign(Player);
+			const auto result = mission_load_up_campaign(Player);
 
+			// if there was a problem, pass an empty main hall which will set up appropriate defaults
+			if (result != 0) {
+				main_hall_init("");
+			}
 			// if we're coming from the end of a campaign, we want to load the first mainhall of the campaign
-			// otherwise load the mainhall for the mission the player's up to
-			if (Campaign.next_mission == -1) {
+			else if (Campaign.next_mission == -1) {
 				main_hall_init(Campaign.missions[0].main_hall);
-			} else {
+			}
+			// otherwise load the mainhall for the mission the player's up to
+			else {
 				main_hall_init(Campaign.missions[Campaign.next_mission].main_hall);
 			}
 
@@ -5745,6 +5750,7 @@ void game_enter_state( int old_state, int new_state )
 				Cmdline_start_mission = nullptr;
 			}
 			break;
+		}
 
 		case GS_STATE_START_GAME:
 			main_hall_stop_music(true);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5711,7 +5711,8 @@ void game_enter_state( int old_state, int new_state )
 			}
 
 			// determine which ship this guy is currently based on
-			const auto result = mission_load_up_campaign(Player);
+			// if we are seeing the main hall for the first time, allow falling back when the current campaign isn't available
+			const auto result = mission_load_up_campaign(old_state == GS_STATE_INITIAL_PLAYER_SELECT);
 
 			// if there was a problem, pass an empty main hall which will set up appropriate defaults
 			if (result != 0) {


### PR DESCRIPTION
This improves campaign load error handling in several ways.  The code now makes a better distinction between load failures that occurred because the file was missing, vs ones that occurred because of some actual error such as a parsing failure or savefile incompatibility.  The error when the player clicks on the campaign room has been updated to reflect this.

Also, the fallback behavior has been changed.  If the player's current campaign cannot be found, the code now automatically falls back to the mod's default campaign or the first campaign in the campaign list.  To avoid problems, this only happens when the game is started for the first time or when the player chooses a new pilot; in all other cases there is no fallback from the current campaign, whether or not it can be found.  (This fallback behavior was inadvertently already implemented for mods which 'ignored' the player's current campaign.)

The main hall code also correctly checks for a campaign load error rather than assuming the current campaign has valid data.

Finally, some exceptions have been changed to Assertions and the `Campaign_file_missing` variable has been changed to a boolean.