### PR TITLE
Print option settings to the log

### DIFF
--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -72,7 +72,7 @@ bool Use_mouse_to_fly = false;
 static SCP_string mouse_mode_display(bool mode) { return mode ? XSTR("Joy-0", 1699) : XSTR("Mouse", 1774); }
 
 static auto UseMouseOption __UNUSED = options::OptionBuilder<bool>("Input.UseMouse",
-                     std::pair<const char*, int>{"Mouse", 1376},
+                     std::pair<const char*, int>{"Mouse", 1373},
                      std::pair<const char*, int>{"Whether or not to use the mouse for flying", 1765})
                      .category("Input")
                      .display(mouse_mode_display) 

--- a/code/options/OptionsManager.cpp
+++ b/code/options/OptionsManager.cpp
@@ -196,4 +196,20 @@ void OptionsManager::loadInitialValues()
 	}
 }
 
+void OptionsManager::printValues()
+{
+	mprintf(("Printing in-game options values!\n"));
+	for (auto& opt : _options) {
+		// If we're not using in-game options and the option is not a retail option, then skip
+		// This ensures we only log options that are actually impacting the current game instance
+		// This code set aside until PR 5895 is merged
+		//if (!Using_in_game_options && !(opt->getFlags()[options::OptionFlags::RetailBuiltinOption])){
+		//	continue;
+		//}
+		mprintf(("Option.%s: %s\n",
+			opt->getConfigKey().c_str(),
+			opt->getCurrentValueDescription().display.c_str()));
+	}
+}
+
 } // namespace options

--- a/code/options/OptionsManager.h
+++ b/code/options/OptionsManager.h
@@ -54,6 +54,8 @@ class OptionsManager {
 	void discardChanges();
 
 	void loadInitialValues();
+
+	void printValues();
 };
 
 }

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2050,6 +2050,8 @@ void game_init()
 
 	mprintf(("cfile_init() took %d\n", e1 - s1));
 
+	options::OptionsManager::instance()->printValues();
+
 	// if we are done initializing, start showing the cursor
 	io::mouse::CursorManager::get()->showCursor(true);
 
@@ -5214,6 +5216,14 @@ void game_leave_state( int old_state, int new_state )
 		case GS_STATE_SCRIPTING_MISSION:
 			end_mission = 0;  // these events shouldn't end a mission
 			break;
+	}
+
+	// This is kind of a hack but it ensures options are logged even if scripting calls for a state change with an override active
+	if (old_state == GS_STATE_OPTIONS_MENU) {
+			if (new_state != GS_STATE_CONTROL_CONFIG && new_state != GS_STATE_HUD_CONFIG) {
+				// print the options settings again to log any player-made changes
+				options::OptionsManager::instance()->printValues();
+			}
 	}
 
 	if (scripting::hooks::OnStateAboutToEndHook->isActive() || scripting::hooks::OnStateEndHook->isActive())


### PR DESCRIPTION
Adds code to print player options to the log at game start and when the options game state is closed. Fixes #5900.

Has the additional benefit of not only printing most of the ini file data, but also any retail options as well. Once #5895 is merged there is a small bit of additional code here that can be uncommented to only print in-game options if they are active while also still always printing built-in retail options.

This also fixes an incorrect xstr setting for the mouse input option title in OptionsManager.