### PR TITLE
Ingame options respect mods

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1854 // This is the next available ID
+// #define XSTR_SIZE	1855 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -408,7 +408,7 @@ void player_select_do()
 	}
 
 	if (!Ingame_options_save_found && Using_in_game_options) {
-		popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("In-game Options are enabled but a save file could not be found. You may need to update your settings in the Options menu.", 1816));
+		popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("In-game Options are enabled but a save file could not be found. You may need to update your settings in the Options menu.", 1842));
 	}
 		
 	// set the input box at the "virtual" line 0 to be active so the player can enter a callsign

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -408,7 +408,7 @@ void player_select_do()
 	}
 
 	if (!Ingame_options_save_found && Using_in_game_options) {
-		popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("In-game Options are enabled but a save file could not be found. You may need to update your settings in the Options menu.", 1842));
+		popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("In-game Options are enabled but a save file could not be found. You may need to update your settings in the Options menu.", 1854));
 	}
 		
 	// set the input box at the "virtual" line 0 to be active so the player can enter a callsign

--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -406,6 +406,10 @@ void player_select_do()
 		popup(PF_TITLE_BIG | PF_TITLE_RED | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, text);
 		Startup_warning_dialog_displayed = true;
 	}
+
+	if (!Ingame_options_save_found && Using_in_game_options) {
+		popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("In-game Options are enabled but a save file could not be found. You may need to update your settings in the Options menu.", 1816));
+	}
 		
 	// set the input box at the "virtual" line 0 to be active so the player can enter a callsign
 	if (Player_select_input_mode) {

--- a/code/options/OptionsManager.cpp
+++ b/code/options/OptionsManager.cpp
@@ -57,7 +57,7 @@ std::unique_ptr<json_t> OptionsManager::getValueFromConfig(const SCP_string& key
 		throw std::runtime_error("Invalid key");
 	}
 
-	auto value = os_config_read_string(parts.first.c_str(), parts.second.c_str());
+	auto value = os_config_read_string(parts.first.c_str(), parts.second.c_str(), (const char*)0, true);
 
 	if (value == nullptr) {
 		// TODO: This is not really an error but I would like to avoid return nullptr here...
@@ -156,7 +156,7 @@ bool OptionsManager::persistOptionChanges(const options::OptionBase* option)
 
 	auto val = json_dump_string(iter->second.get(), JSON_COMPACT | JSON_ENSURE_ASCII | JSON_ENCODE_ANY);
 
-	os_config_write_string(parts.first.c_str(), parts.second.c_str(), val.c_str());
+	os_config_write_string(parts.first.c_str(), parts.second.c_str(), val.c_str(), true);
 
 	auto changed = option->valueChanged(iter->second.get());
 
@@ -178,7 +178,7 @@ SCP_vector<const options::OptionBase*> OptionsManager::persistChanges()
 
 		auto val = json_dump_string(entry.second.get(), JSON_COMPACT | JSON_ENSURE_ASCII | JSON_ENCODE_ANY);
 
-		os_config_write_string(parts.first.c_str(), parts.second.c_str(), val.c_str());
+		os_config_write_string(parts.first.c_str(), parts.second.c_str(), val.c_str(), true);
 	}
 	SCP_vector<const options::OptionBase*> unchanged;
 

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -864,7 +864,7 @@ void os_init_registry_stuff(const char* company, const char* app)
 		// Trim any trailing folders so we get just the name of the root mod folder
 		str = str.substr(0, str.find_first_of(DIR_SEPARATOR_CHAR));
 		// Now trim off any Knossos versioning details so that settings are not mod version specific
-		size_t pos = str.find("-");
+		size_t pos = str.rfind("-");
 		str = (pos != std::string::npos) ? str.substr(0, pos) : str;
 		// Make sure we have a usable string
 		if (str.length() > 0) {

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -904,9 +904,15 @@ void os_init_registry_stuff(const char* company, const char* app)
 			return result;
 		};
 
-		while (!isSemanticVersion(getLastSection(str))) {
+		int count = 0;
+
+		// The count is used here as a limiter. If we don't find the semantic version after a
+		// few tries then we are probably running the game outside of the Knossos/KNet environment. 
+		// So after that we should give up and go with the string we have.
+		while (!isSemanticVersion(getLastSection(str)) && (count <= 4)) {
 			size_t dashPos = str.rfind("-");
 			str = (dashPos != std::string::npos) ? str.substr(0, dashPos) : str;
+			count++;
 		}
 
 		// Now we know we have just the mod root and the version. So drop the version and we're done!

--- a/code/osapi/osregistry.h
+++ b/code/osapi/osregistry.h
@@ -25,6 +25,8 @@ extern const char *Osreg_title;
 
 extern const char *Osreg_config_file_name;
 
+extern bool Ingame_options_save_found;
+
 // ------------------------------------------------------------------------------------------------------------
 // REGISTRY FUNCTIONS
 //

--- a/code/osapi/osregistry.h
+++ b/code/osapi/osregistry.h
@@ -39,22 +39,22 @@ void os_init_registry_stuff( const char *company, const char *app);
 void os_deinit_registry_stuff();
 
 // Writes a string to the registry
-void os_config_write_string( const char *section, const char *name, const char *value );
+void os_config_write_string(const char* section, const char* name, const char* value, bool use_mod_file = false);
 
 // Writes an unsigned int to the INI file.  
-void os_config_write_uint( const char *section, const char *name, unsigned int value );
+void os_config_write_uint(const char* section, const char* name, unsigned int value, bool use_mod_file = false);
 
-bool os_config_has_value(const char *section, const char *name);
+bool os_config_has_value(const char* section, const char* name, bool use_mod_file = false);
 
 // Reads a string from the INI file.  If default is passed,
 // and the string isn't found, returns ptr to default otherwise
 // returns NULL;    Copy the return value somewhere before
 // calling os_read_string again, because it might reuse the
 // same buffer.
-const char * os_config_read_string( const char *section, const char *name, const char *default_value=0 /*NULL*/ );
+const char * os_config_read_string( const char *section, const char *name, const char *default_value=0, bool use_mod_file = false /*NULL*/ );
 
 // Reads a string from the INI file.  Default_value must 
 // be passed, and if 'name' isn't found, then returns default_value
-unsigned int  os_config_read_uint( const char *section, const char *name, unsigned int default_value );
+unsigned int  os_config_read_uint( const char *section, const char *name, unsigned int default_value, bool use_mod_file = false );
 
 #endif


### PR DESCRIPTION
This PR fixes #5697 by changing how in-game settings are saved and loaded. The key thing Wookie and I wanted here was to have these settings saved in a way that's specific to each mod but agnostic of mod versions (as far as Knossos/Nebula goes). The challenge there is that different mod versions are entirely unique mods to FSO even though Knossos knows better.

The solution this PR offers is a new ini file saved to `%appdata/HardLightProductions\FreeSpaceOpen\data`. This file is titled based on the `Cmdline_mod` parameter (`retail_fs2_settings.ini` if it's nullptr) by trimming a mod folder's version data off of it. For example, `MPVS-4.7.2` becomes `MVPS_settings.ini` and will work for all version of the MediaVPs.

There's almost certainly room for improvement here but this needs to be solved sooner rather than later and a PR will get the discussion really going.