### PR TITLE
codesign Mac builds to prevent broken app message

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -269,6 +269,18 @@ jobs:
           ARCH: ${{ matrix.arch }}
           XDG_RUNTIME_DIR: /root
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
+      - name: Sign builds
+        working-directory: ./build/bin
+        run: |
+          # make sure OpenAL framework is signed
+          find . -name OpenAL -type f | while read xx; do codesign --force -s - $xx; done
+          find . -name OpenAL.framework -type d | while read xx; do codesign --force -s - $xx; done
+          # make sure dylibs are signed
+          find . -name \*.dylib -type f | while read xx; do codesign --force -s - $xx; done
+          # sign binaries
+          find . -perm +111 -type f | grep MacOS | while read xx; do codesign --force -s - $xx; done
+          # sign apps
+          find . -name \*.app -maxdepth 1 | while read xx; do codesign --force -s - $xx; done
       - name: Package build result
         working-directory: ./build/bin
         # Use GNU tar here (part of runner image) to avoid weird corruption bug with bsdtar

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -339,6 +339,18 @@ jobs:
           ARCH: ${{ matrix.arch }}
           XDG_RUNTIME_DIR: /root
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
+      - name: Sign builds
+        working-directory: ./build/bin
+        run: |
+          # make sure OpenAL framework is signed
+          find . -name OpenAL -type f | while read xx; do codesign --force -s - $xx; done
+          find . -name OpenAL.framework -type d | while read xx; do codesign --force -s - $xx; done
+          # make sure dylibs are signed
+          find . -name \*.dylib -type f | while read xx; do codesign --force -s - $xx; done
+          # sign binaries
+          find . -perm +111 -type f | grep MacOS | while read xx; do codesign --force -s - $xx; done
+          # sign apps
+          find . -name \*.app -maxdepth 1 | while read xx; do codesign --force -s - $xx; done
       - name: Package build result
         working-directory: ./build/bin
         # Use GNU tar here (part of runner image) to avoid weird corruption bug with bsdtar

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -282,6 +282,18 @@ jobs:
           ARCH: ${{ matrix.arch }}
           XDG_RUNTIME_DIR: /root
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
+      - name: Sign builds
+        working-directory: ./build/bin
+        run: |
+          # make sure OpenAL framework is signed
+          find . -name OpenAL -type f | while read xx; do codesign --force -s - $xx; done
+          find . -name OpenAL.framework -type d | while read xx; do codesign --force -s - $xx; done
+          # make sure dylibs are signed
+          find . -name \*.dylib -type f | while read xx; do codesign --force -s - $xx; done
+          # sign binaries
+          find . -perm +111 -type f | grep MacOS | while read xx; do codesign --force -s - $xx; done
+          # sign apps
+          find . -name \*.app -maxdepth 1 | while read xx; do codesign --force -s - $xx; done
       - name: Package build result
         working-directory: ./build/bin
         # Use GNU tar here (part of runner image) to avoid weird corruption bug with bsdtar


### PR DESCRIPTION
Apple Silicon Macs require that all code is signed in order to run. Our builds are partially signed due to the SDL framework already being signed, so it is seen as broken. To fix that we need to codesign all the rest of the necessary files with an ad-hoc signature in order to allow the builds to work properly.