### PR TITLE
Properly check if we're running in a windowed mode

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1754,17 +1754,6 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, int d_mode, 
 	return true;
 }
 
-void gr_force_windowed()
-{
-	if ( !Gr_inited ) {
-		return;
-	}
-
-	if ( Os_debugger_running ) {
-		os_sleep(1000);
-	}
-}
-
 int gr_activated = 0;
 void gr_activate(int active)
 {

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1779,7 +1779,7 @@ void gr_activate(int active)
 	}
 
 	if (active) {
-		if (Cmdline_fullscreen_window || Cmdline_window) {
+		if (gr_is_viewport_window()) {
 			os::getMainViewport()->restore();
 		} else {
 			os::getMainViewport()->setState(os::ViewportState::Fullscreen);
@@ -1789,7 +1789,7 @@ void gr_activate(int active)
 	}
 
 	if (active) {
-		if (!Cmdline_fullscreen_window && !Cmdline_window) {
+		if (!gr_is_viewport_window()) {
 			gr_set_gamma(Gr_gamma);
 		}
 	}
@@ -2967,4 +2967,29 @@ void gr_get_post_process_effect_names(SCP_vector<SCP_string>& names)
 	for (const auto& eff : effects) {
 		names.push_back(eff.name);
 	}
+}
+
+bool gr_is_viewport_window()
+{
+	if (Fred_running) {
+		return true;
+	}
+	
+	if (Using_in_game_options) {
+		switch (Gr_configured_window_state)
+		{
+		case os::ViewportState::Windowed:
+		case os::ViewportState::Borderless:
+			return true;
+			break;
+		default:
+			break;
+		}
+	} else {
+		if (Cmdline_window || Cmdline_fullscreen_window) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1428,6 +1428,8 @@ void gr_set_gamma(float gamma);
 
 void gr_get_post_process_effect_names(SCP_vector<SCP_string> &names);
 
+bool gr_is_viewport_window();
+
 // Include this last to make the 2D rendering function available everywhere
 #include "graphics/render.h"
 

--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -100,7 +100,7 @@ namespace os
 		//buttons not clickable. So as a hotfix, the dialog has no blocking parent in that case and
 		//is instead rendered as it's own window
 		SDL_Window* getDialogParent() {
-			return !(Cmdline_fullscreen_window || Cmdline_window) ? NULL : os::getSDLMainWindow();
+			return !(gr_is_viewport_window()) ? NULL : os::getSDLMainWindow();
 		}
 
 		void AssertMessage(const char * text, const char * filename, int linenum, const char * format, ...)


### PR DESCRIPTION
There were a few cases that didn't account for the newer in-game option when checking for Windowed mode. This PR resolves that which fixes the issue where the in-game option wasn't accounted for at start up or when creating dialog prompts.