### PR TITLE
Cockpit fov option

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -14,8 +14,9 @@
 #include "ship/ship.h"        //compute_slew_matrix
 
 //*************************IMPORTANT GLOBALS*************************
-fov_t VIEWER_ZOOM_DEFAULT = 0.75f;			//	Default viewer zoom, 0.625 as per multi-lateral agreement on 3/24/97
-fov_t COCKPIT_ZOOM_DEFAULT = 0.75f;
+#define DEFAULT_FOV 0.75f;
+fov_t VIEWER_ZOOM_DEFAULT = DEFAULT_FOV;
+fov_t COCKPIT_ZOOM_DEFAULT = DEFAULT_FOV;
 float Sexp_fov = 0.0f;
 warp_camera Warp_camera;
 
@@ -54,6 +55,9 @@ APPLY_TO_FOV_T(*, mul)
 APPLY_TO_FOV_T(+, add)
 APPLY_TO_FOV_T(-, sub)
 
+// Used to set the default value for in-game options
+static float fov_default = DEFAULT_FOV;
+
 static SCP_string fov_display(float val)
 {
 	auto degrees = fl_degrees(val);
@@ -71,7 +75,22 @@ auto FovOption = options::OptionBuilder<float>("Graphics.FOV",
 					      return true;
 					 })
 					 .display(fov_display)
-					 .default_val(0.75f)
+					 .default_val(fov_default)
+					 .level(options::ExpertLevel::Advanced)
+					 .importance(60)
+					 .finish();
+
+auto CockpitFovOption = options::OptionBuilder<float>("Graphics.CockpitFOV",
+					 std::pair<const char*, int>{"Cockpit Field Of View", -1}, // Do XSTR before merging
+					 std::pair<const char*, int>{"The vertical field of view for cockpit rendering. Only works if cockpits are active.", -1})
+					 .category("Graphics")
+					 .range(0.436332f, 1.5708f)
+					 .change_listener([](const float& val, bool) {
+					      COCKPIT_ZOOM_DEFAULT = val;
+					      return true;
+					 })
+					 .display(fov_display)
+					 .default_val(fov_default)
 					 .level(options::ExpertLevel::Advanced)
 					 .importance(60)
 					 .finish();

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -82,9 +82,9 @@ auto FovOption = options::OptionBuilder<float>("Graphics.FOV",
 bool Use_cockpit_fov = false;
 
 auto CockpitFOVToggleOption = options::OptionBuilder<bool>("Graphics.CockpitFOVToggle",
-					 std::pair<const char*, int>{"Cockpit FOV Toggle", -1},
-					 std::pair<const char*, int>{"Whether or not to use a different FOV for cockpit rendering from normal rendering", -1})
-					 .category("Graphics")
+					 std::pair<const char*, int>{"Cockpit FOV Toggle", 1838},
+					 std::pair<const char*, int>{"Whether or not to use a different FOV for cockpit rendering from normal rendering", 1839})
+					 .category(std::make_pair("Graphics", 1825))
 					 .default_val(false)
 					 .change_listener([](bool val, bool) {
 					      if (!val) {
@@ -98,9 +98,9 @@ auto CockpitFOVToggleOption = options::OptionBuilder<bool>("Graphics.CockpitFOVT
 					 .finish();
 
 auto CockpitFovOption = options::OptionBuilder<float>("Graphics.CockpitFOV",
-					 std::pair<const char*, int>{"Cockpit Field Of View", -1}, // Do XSTR before merging
-					 std::pair<const char*, int>{"The vertical field of view for cockpit rendering. Only works if cockpits are active and cockpit FOV toggle is turned on.", -1})
-					 .category("Graphics")
+					 std::pair<const char*, int>{"Cockpit Field Of View", 1840},
+					 std::pair<const char*, int>{"The vertical field of view for cockpit rendering. Only works if cockpits are active and cockpit FOV toggle is turned on.", 1841})
+					 .category(std::make_pair("Graphics", 1825))
 					 .range(0.436332f, 1.5708f)
 					 .change_listener([](const float& val, bool) {
 					      if (Use_cockpit_fov){

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -14,7 +14,6 @@
 #include "ship/ship.h"        //compute_slew_matrix
 
 //*************************IMPORTANT GLOBALS*************************
-#define DEFAULT_FOV 0.75f;
 fov_t VIEWER_ZOOM_DEFAULT = DEFAULT_FOV;
 fov_t COCKPIT_ZOOM_DEFAULT = DEFAULT_FOV;
 float Sexp_fov = 0.0f;
@@ -80,19 +79,41 @@ auto FovOption = options::OptionBuilder<float>("Graphics.FOV",
 					 .importance(60)
 					 .finish();
 
+bool Use_cockpit_fov = false;
+
+auto CockpitFOVToggleOption = options::OptionBuilder<bool>("Graphics.CockpitFOVToggle",
+					 std::pair<const char*, int>{"Cockpit FOV Toggle", -1},
+					 std::pair<const char*, int>{"Whether or not to use a different FOV for cockpit rendering from normal rendering", -1})
+					 .category("Graphics")
+					 .default_val(false)
+					 .change_listener([](bool val, bool) {
+					      if (!val) {
+					           COCKPIT_ZOOM_DEFAULT = VIEWER_ZOOM_DEFAULT;
+					      }
+					      return true; // This option will always persist so we never return false
+					 })
+					 .level(options::ExpertLevel::Advanced)
+					 .bind_to(&Use_cockpit_fov)
+					 .importance(61)
+					 .finish();
+
 auto CockpitFovOption = options::OptionBuilder<float>("Graphics.CockpitFOV",
 					 std::pair<const char*, int>{"Cockpit Field Of View", -1}, // Do XSTR before merging
-					 std::pair<const char*, int>{"The vertical field of view for cockpit rendering. Only works if cockpits are active.", -1})
+					 std::pair<const char*, int>{"The vertical field of view for cockpit rendering. Only works if cockpits are active and cockpit FOV toggle is turned on.", -1})
 					 .category("Graphics")
 					 .range(0.436332f, 1.5708f)
 					 .change_listener([](const float& val, bool) {
-					      COCKPIT_ZOOM_DEFAULT = val;
+					      if (Use_cockpit_fov){
+					           COCKPIT_ZOOM_DEFAULT = val;
+						  } else {
+							  COCKPIT_ZOOM_DEFAULT = VIEWER_ZOOM_DEFAULT;
+						  }
 					      return true;
 					 })
 					 .display(fov_display)
 					 .default_val(fov_default)
 					 .level(options::ExpertLevel::Advanced)
-					 .importance(60)
+					 .importance(62)
 					 .finish();
 
 //*************************CLASS: camera*************************

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -55,7 +55,7 @@ APPLY_TO_FOV_T(+, add)
 APPLY_TO_FOV_T(-, sub)
 
 // Used to set the default value for in-game options
-static float fov_default = DEFAULT_FOV;
+static constexpr float fov_default = DEFAULT_FOV;
 
 static SCP_string fov_display(float val)
 {

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -20,6 +20,8 @@
 #define	EXTERN_CAM_BBOX_CONSTANT_PADDING			5.0f
 #define	EXTERN_CAM_BBOX_MULTIPLIER_PADDING			1.5f
 
+#define DEFAULT_FOV 0.75f;
+
 struct asymmetric_fov {
 	float left, right, up, down;
 	friend asymmetric_fov operator* (const asymmetric_fov&, const float&);

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1900,7 +1900,7 @@ bool SetCmdlineParams()
 		if (val > 0.1) {
 			VIEWER_ZOOM_DEFAULT = val;
 		} else {
-			VIEWER_ZOOM_DEFAULT = 0.75f;
+			VIEWER_ZOOM_DEFAULT = DEFAULT_FOV;
 		}
 	}
 

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1838 // This is the next available ID
+// #define XSTR_SIZE	1842 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset


### PR DESCRIPTION
Adds Cockpit FOV as an in-game option along with a global to toggle using it, per discussion with Lafiel. Also sets a define for the default FOV of 0.75 that is used in multiple places. There are lot of options PRs pending with XSTR changes so this will just be set as draft until those are merged and I can update this one's XSTRs, but otherwise the code is complete.