### PR TITLE
LUA method to check if a movie is currently playing

### DIFF
--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -25,6 +25,8 @@
 
 extern int Cmdline_nomovies;
 
+bool Movie_active = false;
+
 
 const char* Cutscene_bitmap_name[GR_NUM_RESOLUTIONS] = {
 		"ViewFootage",

--- a/code/cutscene/cutscenes.h
+++ b/code/cutscene/cutscenes.h
@@ -37,6 +37,8 @@ typedef struct cutscene_info
 
 extern SCP_vector<cutscene_info> Cutscenes;
 
+extern bool Movie_active;
+
 // initializa table data
 void cutscene_init();
 

--- a/code/cutscene/movie.cpp
+++ b/code/cutscene/movie.cpp
@@ -278,6 +278,7 @@ bool play(const char* name) {
 	// clear the screen and hide the mouse cursor
 	io::mouse::CursorManager::get()->pushStatus();
 	io::mouse::CursorManager::get()->showCursor(false);
+	Movie_active = true;
 	gr_reset_clip();
 	gr_set_color(255, 255, 255);
 	gr_set_clear_color(0, 0, 0);
@@ -303,6 +304,8 @@ bool play(const char* name) {
 		// uh-oh, movie is invalid... Abory, Retry, Fail?
 		mprintf(("MOVIE ERROR: Found invalid movie! (%s)\n", name));
 	}
+
+	Movie_active = false;
 
 	// show the mouse cursor again
 	io::mouse::CursorManager::get()->popStatus();

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -259,6 +259,11 @@ ADE_FUNC(playCutscene, l_UserInterface, "string Filename, boolean RestartMusic, 
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(isCutscenePlaying, l_UserInterface, nullptr, "Checks if a cutscene is playing.", "boolean", "Returns true if cutscene is playing, false otherwise")
+{
+	return ade_set_args(L, "b", Movie_active);
+}
+
 ADE_FUNC(launchURL, l_UserInterface, "string url", "Launches the given URL in a web browser", nullptr, nullptr)
 {
 	const char* url;


### PR DESCRIPTION
A quick LUA method to return true/false if a movie is currently playing. This allows me to fix a bug in SCPUI where cutscenes are not visible in some cases, even though they are actually being played.

While this borders on a new feature, this is something that SCPUI & BtA need and it's exceedingly low impact. If possible, I'm hoping that this can make it into 24.0 as BtA intends to release on that build.