### PR TITLE
Basic implementation of some audio options in-game

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1832 // This is the next available ID
+// #define XSTR_SIZE	1838 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -178,9 +178,9 @@ static size_t Ds_active_env_idx = 0;
 bool Ingame_efx = false;
 
 static auto EnableEFXOption = options::OptionBuilder<bool>("Audio.EnableEFX",
-                     std::pair<const char*, int>{"Use Audio EFX", -1},
-                     std::pair<const char*, int>{"Toggle whether OpenAL Audio EFX are used or not", -1})
-                     .category("Audio") //1826
+                     std::pair<const char*, int>{"Use Audio EFX", 1832},
+                     std::pair<const char*, int>{"Toggle whether OpenAL Audio EFX are used or not", 1833})
+                     .category(std::make_pair("Audio", 1826))
                      .level(options::ExpertLevel::Advanced)
                      .default_val(false)
                      .bind_to_once(&Ingame_efx)

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -20,6 +20,7 @@
 #include "sound/dscap.h"
 #include "sound/openal.h"
 #include "sound/sound.h" // jg18 - for enhanced sound
+#include "options/Option.h"
 
 
 typedef struct sound_buffer
@@ -173,6 +174,18 @@ ALuint AL_EFX_aux_id = 0;
 static ALuint AL_EFX_effect_id = 0;
 static bool Ds_active_env = false;
 static size_t Ds_active_env_idx = 0;
+
+bool Ingame_efx = false;
+
+static auto EnableEFXOption = options::OptionBuilder<bool>("Audio.EnableEFX",
+                     std::pair<const char*, int>{"Use Audio EFX", -1},
+                     std::pair<const char*, int>{"Toggle whether OpenAL Audio EFX are used or not", -1})
+                     .category("Audio") //1826
+                     .level(options::ExpertLevel::Advanced)
+                     .default_val(false)
+                     .bind_to_once(&Ingame_efx)
+                     .importance(69)
+                     .finish();
 
 
 static void *al_load_function(const char *func_name)
@@ -400,6 +413,7 @@ int ds_init()
 	}
 
 	sample_rate = os_config_read_uint("Sound", "SampleRate", sample_rate);
+
 	attrList[1] = sample_rate;
 	SCP_string playback_device;
 	SCP_string capture_device;
@@ -455,7 +469,15 @@ int ds_init()
 
 	if ( alcIsExtensionPresent(ds_sound_device, (const ALchar*)"ALC_EXT_EFX") == AL_TRUE ) {
 		mprintf(("  Found extension \"ALC_EXT_EFX\".\n"));
-		Ds_use_eax = os_config_read_uint("Sound", "EnableEFX", Fred_running);
+		if (Using_in_game_options) {
+			if (Fred_running) {
+				Ds_use_eax = Fred_running;
+			} else {
+				Ds_use_eax = EnableEFXOption->getValue();
+			}
+		} else {
+			Ds_use_eax = os_config_read_uint("Sound", "EnableEFX", Fred_running);
+		}
 	}
 
 	if (Ds_use_eax == 1) {

--- a/code/sound/openal.cpp
+++ b/code/sound/openal.cpp
@@ -116,9 +116,9 @@ static bool playbackdevice_change(int /*device*/, bool initial)
 	return false;
 }
 static auto PlaybackDeviceOption = options::OptionBuilder<int>("Audio.PlaybackDevice",
-                     std::pair<const char*, int>{"Playback Device", -1}, //DO XSTRs!
-                     std::pair<const char*, int>{"The device used for audio playback", -1})
-                     .category("Audio") //1826
+                     std::pair<const char*, int>{"Playback Device", 1834},
+                     std::pair<const char*, int>{"The device used for audio playback", 1835})
+                     .category(std::make_pair("Audio", 1826))
                      .level(options::ExpertLevel::Beginner)
                      .deserializer(playbackdevice_deserializer)
                      .serializer(playbackdevice_serializer)
@@ -191,9 +191,9 @@ static bool capturedevice_change(int /*device*/, bool initial)
 	return false;
 }
 static auto CaptureDeviceOption = options::OptionBuilder<int>("Audio.CaptureDevice",
-                     std::pair<const char*, int>{"Capture Device", -1}, //DO XSTRs!
-                     std::pair<const char*, int>{"The device used for audio capture", -1})
-                     .category("Audio") //1826
+                     std::pair<const char*, int>{"Capture Device", 1836},
+                     std::pair<const char*, int>{"The device used for audio capture", 1837})
+                     .category(std::make_pair("Audio", 1826))
                      .level(options::ExpertLevel::Beginner)
                      .deserializer(capturedevice_deserializer)
                      .serializer(capturedevice_serializer)

--- a/code/sound/openal.cpp
+++ b/code/sound/openal.cpp
@@ -101,7 +101,7 @@ static SCP_string playbackdevice_display(int id)
 	sprintf(out, "(%d) %s", id + 1, PlaybackDeviceList[id].c_str());
 	return out;
 }
-static bool playbackdevice_change(int device, bool initial)
+static bool playbackdevice_change(int /*device*/, bool initial)
 {
 	if (initial) {
 		return false; // On game boot always return false
@@ -176,7 +176,7 @@ static SCP_string capturedevice_display(int id)
 	sprintf(out, "(%d) %s", id + 1, CaptureDeviceList[id].c_str());
 	return out;
 }
-static bool capturedevice_change(int device, bool initial)
+static bool capturedevice_change(int /*device*/, bool initial)
 {
 	if (initial) {
 		return false; // On game boot always return false

--- a/code/sound/openal.cpp
+++ b/code/sound/openal.cpp
@@ -2,6 +2,9 @@
 #include "globalincs/pstypes.h"
 #include "sound/openal.h"
 #include "osapi/osregistry.h"
+#include "options/Option.h"
+#include "parse/parselo.h"
+#include "libs/jansson.h"
 
 #include <string>
 #include <algorithm>
@@ -52,6 +55,155 @@ static SCP_vector<OALdevice> CaptureDevices;
 #define ALC_ALL_DEVICES_SPECIFIER                0x1013
 #endif
 
+// List of audio device names for the in-game option
+SCP_vector<SCP_string> PlaybackDeviceList;
+
+static int playbackdevice_deserializer(const json_t* value)
+{
+	const char* device;
+
+	json_error_t err;
+	if (json_unpack_ex((json_t*)value, &err, 0, "s", &device) != 0) {
+		throw json_exception(err);
+	}
+
+	int id = openal_find_playback_device_by_name(device);
+
+	if (SCP_vector_inbounds(PlaybackDeviceList, id)) {
+		return id;
+	}
+
+	return -1;
+}
+static json_t* playbackdevice_serializer(int value)
+{
+	if (!SCP_vector_inbounds(PlaybackDeviceList, value)) {
+		return json_pack("s", "");
+	}
+	
+	return json_pack("s", PlaybackDeviceList[value].c_str());
+}
+static SCP_vector<int> playbackdevice_enumerator()
+{
+	SCP_vector<int> vals;
+	for (int i = 0; i < static_cast<int>(PlaybackDeviceList.size()); ++i) {
+		vals.push_back(i);
+	}
+	return vals;
+}
+static SCP_string playbackdevice_display(int id)
+{
+	if (!SCP_vector_inbounds(PlaybackDeviceList, id)) {
+		return "";
+	}
+	
+	SCP_string out;
+	sprintf(out, "(%d) %s", id + 1, PlaybackDeviceList[id].c_str());
+	return out;
+}
+static bool playbackdevice_change(int device, bool initial)
+{
+	if (initial) {
+		return false; // On game boot always return false
+	}
+
+	// Looking at ds.cpp's ds_init(), it's probably possible to not require a restart for this
+	// but for now let's keep this simple and just restart. If/when this is implemented the device
+	// parameter will be required. Currently playing audio will need to be copied from the old device
+	// to the new as part of the initialization. This will require deeper changes to the audio code
+	// which can be handled later in a follow-up PR.
+
+	return false;
+}
+static auto PlaybackDeviceOption = options::OptionBuilder<int>("Audio.PlaybackDevice",
+                     std::pair<const char*, int>{"Playback Device", -1}, //DO XSTRs!
+                     std::pair<const char*, int>{"The device used for audio playback", -1})
+                     .category("Audio") //1826
+                     .level(options::ExpertLevel::Beginner)
+                     .deserializer(playbackdevice_deserializer)
+                     .serializer(playbackdevice_serializer)
+                     .enumerator(playbackdevice_enumerator)
+                     .display(playbackdevice_display)
+                     .flags({options::OptionFlags::ForceMultiValueSelection})
+                     .default_val(0)
+                     .change_listener(playbackdevice_change)
+                     .importance(99)
+                     .finish();
+
+// List of audio device names for the in-game option
+SCP_vector<SCP_string> CaptureDeviceList;
+
+static int capturedevice_deserializer(const json_t* value)
+{
+	const char* device;
+
+	json_error_t err;
+	if (json_unpack_ex((json_t*)value, &err, 0, "s", &device) != 0) {
+		throw json_exception(err);
+	}
+
+	int id = openal_find_capture_device_by_name(device);
+
+	if (SCP_vector_inbounds(CaptureDeviceList, id)) {
+		return id;
+	}
+
+	return -1;
+}
+static json_t* capturedevice_serializer(int value)
+{
+	if (!SCP_vector_inbounds(CaptureDeviceList, value)) {
+		return json_pack("s", "");
+	}
+	
+	return json_pack("s", CaptureDeviceList[value].c_str());
+}
+static SCP_vector<int> capturedevice_enumerator()
+{
+	SCP_vector<int> vals;
+	for (int i = 0; i < static_cast<int>(CaptureDeviceList.size()); ++i) {
+		vals.push_back(i);
+	}
+	return vals;
+}
+static SCP_string capturedevice_display(int id)
+{
+	if (!SCP_vector_inbounds(CaptureDeviceList, id)) {
+		return "";
+	}
+	
+	SCP_string out;
+	sprintf(out, "(%d) %s", id + 1, CaptureDeviceList[id].c_str());
+	return out;
+}
+static bool capturedevice_change(int device, bool initial)
+{
+	if (initial) {
+		return false; // On game boot always return false
+	}
+
+	// Looking at ds.cpp's ds_init(), it's probably possible to not require a restart for this
+	// but for now let's keep this simple and just restart. If/when this is implemented the device
+	// parameter will be required. Currently playing audio will need to be copied from the old device
+	// to the new as part of the initialization. This will require deeper changes to the audio code
+	// which can be handled later in a follow-up PR.
+
+	return false;
+}
+static auto CaptureDeviceOption = options::OptionBuilder<int>("Audio.CaptureDevice",
+                     std::pair<const char*, int>{"Capture Device", -1}, //DO XSTRs!
+                     std::pair<const char*, int>{"The device used for audio capture", -1})
+                     .category("Audio") //1826
+                     .level(options::ExpertLevel::Beginner)
+                     .deserializer(capturedevice_deserializer)
+                     .serializer(capturedevice_serializer)
+                     .enumerator(capturedevice_enumerator)
+                     .display(capturedevice_display)
+                     .flags({options::OptionFlags::ForceMultiValueSelection})
+                     .default_val(0)
+                     .change_listener(capturedevice_change)
+                     .importance(99)
+                     .finish();
 
 //--------------------------------------------------------------------------
 // openal_error_string()
@@ -116,7 +268,20 @@ static bool openal_device_sort_func(const OALdevice &d1, const OALdevice &d2)
 
 static void find_playback_device(OpenALInformation* info)
 {
-	const char *user_device = os_config_read_string( "Sound", "PlaybackDevice", NULL );
+	// First, build a list of device names for the in-game option to use and pull from
+	for (auto& device : info->playback_devices) {
+		OALdevice new_device(device.c_str());
+		PlaybackDeviceList.push_back(new_device.device_name);
+	}
+	
+	const char* user_device = os_config_read_string("Sound", "PlaybackDevice", nullptr);
+
+	if (Using_in_game_options) {
+		if (SCP_vector_inbounds(PlaybackDeviceList, PlaybackDeviceOption->getValue())) {
+			user_device = PlaybackDeviceList[PlaybackDeviceOption->getValue()].c_str();
+		}
+	}
+
 	const char *default_device = info->default_playback_device.c_str();
 
 	// in case they are the same, we only want to test it once
@@ -215,7 +380,20 @@ static void find_playback_device(OpenALInformation* info)
 
 static void find_capture_device(OpenALInformation* info)
 {
-	const char *user_device = os_config_read_string( "Sound", "CaptureDevice", NULL );
+	// First, build a list of device names for the in-game option to use and pull from
+	for (auto& device : info->capture_devices) {
+		OALdevice new_device(device.c_str());
+		CaptureDeviceList.push_back(new_device.device_name);
+	}
+	
+	const char* user_device = os_config_read_string("Sound", "CaptureDevice", nullptr);
+
+	if (Using_in_game_options) {
+		if (SCP_vector_inbounds(CaptureDevices, CaptureDeviceOption->getValue())) {
+			user_device = CaptureDevices[CaptureDeviceOption->getValue()].device_name.c_str();
+		}
+	}
+
 	const char *default_device = info->default_capture_device.c_str();
 
 	// in case they are the same, we only want to test it once
@@ -264,6 +442,30 @@ static void find_capture_device(OpenALInformation* info)
 
 		break;
 	}
+}
+
+// find a playback device's vector index
+int openal_find_playback_device_by_name(const SCP_string& device)
+{
+	for (int i = 0; i < static_cast<int>(PlaybackDeviceList.size()); i++) {
+		if (!stricmp(PlaybackDeviceList[i].c_str(), device.c_str())) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+// find a capture device's vector index
+int openal_find_capture_device_by_name(const SCP_string& device)
+{
+	for (int i = 0; i < static_cast<int>(CaptureDeviceList.size()); i++) {
+		if (!stricmp(CaptureDeviceList[i].c_str(), device.c_str())) {
+			return i;
+		}
+	}
+
+	return -1;
 }
 
 // initializes hardware device from perferred/default/enumerated list

--- a/code/sound/openal.h
+++ b/code/sound/openal.h
@@ -34,6 +34,9 @@ struct OpenALInformation {
 
 OpenALInformation openal_get_platform_information();
 
+int openal_find_playback_device_by_name(const SCP_string& device);
+int openal_find_capture_device_by_name(const SCP_string& device);
+
 // if an error occurs after executing 'x' then do 'y'
 #define OpenAL_ErrorCheck( x, y )	do {	\
 	x;	\


### PR DESCRIPTION
Adds EAX and Audio Device selection to the in-game options. All currently require a restart but it may be possible to remove that requirement in the future.

There are lot of options PRs pending with XSTR changes so this will just be set as draft until those are merged and I can update this one's XSTRs, but otherwise the code is complete.