### PR TITLE
Allow lua to lock/unlock cutscenes

### DIFF
--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -1,4 +1,5 @@
 #include "techroom.h"
+#include "pilotfile/pilotfile.h"
 
 namespace scripting {
 namespace api {
@@ -166,18 +167,20 @@ ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description"
 
 ADE_VIRTVAR(isVisible,
 	l_TechRoomCutscene,
-	nullptr,
+	"boolean",
 	"If the cutscene should be visible by default",
 	"boolean",
 	"true if visible, false if not visible")
 {
 	cutscene_info_h current;
-	if (!ade_get_args(L, "o", l_TechRoomCutscene.Get(&current))) {
+	bool visible;
+	if (!ade_get_args(L, "o|b", l_TechRoomCutscene.Get(&current), &visible)) {
 		return ADE_RETURN_NIL;
 	}
 
 	if (ADE_SETTING_VAR) {
-		LuaError(L, "This property is read only.");
+		current.getStage()->flags.set(Cutscene::Cutscene_Flags::Viewable, visible);
+		Pilot.save_savefile();
 	}
 	if (current.getScene()->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] &&
 		!current.getScene()->flags[Cutscene::Cutscene_Flags::Never_viewable]) 

--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -179,7 +179,7 @@ ADE_VIRTVAR(isVisible,
 	}
 
 	if (ADE_SETTING_VAR) {
-		current.getStage()->flags.set(Cutscene::Cutscene_Flags::Viewable, visible);
+		current.getScene()->flags.set(Cutscene::Cutscene_Flags::Viewable, visible);
 		Pilot.save_savefile();
 	}
 	if (current.getScene()->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] &&


### PR DESCRIPTION
Allows scripts to arbitrarily lock/unlock cutscenes which will allow for mods to lock/unlock cutscenes at times outside of playing campaign missions if they desire.