### PR TITLE
Cleanup ui cutscene api

### DIFF
--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -60,6 +60,18 @@ static cutscene_info *get_cutscene_pointer(char *cutscene_filename)
 	return NULL;
 }
 
+int get_cutscene_index_by_name(const char* name)
+{
+	for (int i = 0; i < (int)Cutscenes.size(); i++) {
+		if (!stricmp(name, Cutscenes[i].name)) {
+			return i;
+		}
+	}
+
+	// Didn't find anything.
+	return -1;
+}
+
 static void cutscene_info_init(cutscene_info *csni)
 {
 	csni->filename[0] = '\0';

--- a/code/cutscene/cutscenes.cpp
+++ b/code/cutscene/cutscenes.cpp
@@ -62,7 +62,7 @@ static cutscene_info *get_cutscene_pointer(char *cutscene_filename)
 
 int get_cutscene_index_by_name(const char* name)
 {
-	for (int i = 0; i < (int)Cutscenes.size(); i++) {
+	for (int i = 0; i < static_cast<int>(Cutscenes.size()); i++) {
 		if (!stricmp(name, Cutscenes[i].name)) {
 			return i;
 		}

--- a/code/cutscene/cutscenes.h
+++ b/code/cutscene/cutscenes.h
@@ -48,4 +48,6 @@ void cutscenes_screen_do_frame();
 
 void cutscene_mark_viewable(const char* filename);
 
+int get_cutscene_index_by_name(const char* name);
+
 #endif

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1620,12 +1620,28 @@ ADE_LIB_DERIV(l_UserInterface_Cutscenes, "Cutscenes", nullptr, nullptr, l_UserIn
 ADE_INDEXER(l_UserInterface_Cutscenes,
 	"number Index",
 	"Array of cutscenes",
-	"custscene_info",
+	"cutscene_info",
 	"Cutscene handle, or invalid handle if index is invalid")
 {
-	int idx;
-	if (!ade_get_args(L, "*i", &idx))
-		return ade_set_error(L, "s", "");
+	const char* name;
+	if (!ade_get_args(L, "*s", &name))
+		return ade_set_error(L, "o", l_TechRoomCutscene.Set(cutscene_info_h(-1)));
+
+	int idx = get_cutscene_index_by_name(name);
+
+	if (idx < 0) {
+		try {
+			idx = std::stoi(name);
+			idx--; // Lua->FS2
+		} catch (const std::exception&) {
+			// Not a number
+			return ade_set_error(L, "o", l_TechRoomCutscene.Set(cutscene_info_h(-1)));
+		}
+
+		if (!SCP_vector_inbounds(Cutscenes, idx)) {
+			return ade_set_error(L, "o", l_TechRoomCutscene.Set(cutscene_info_h(-1)));
+		}
+	}
 
 	return ade_set_args(L, "o", l_TechRoomCutscene.Set(cutscene_info_h(idx)));
 }

--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -24,10 +24,10 @@ cutscene_info_h::cutscene_info_h(int scene) : cutscene(scene) {}
 
 bool cutscene_info_h::IsValid() const
 {
-	return cutscene >= 0;
+	return SCP_vector_inbounds(Cutscenes, cutscene);
 }
 
-cutscene_info* cutscene_info_h::getStage() const
+cutscene_info* cutscene_info_h::getScene() const
 {
 	return &Cutscenes[cutscene];
 }
@@ -120,7 +120,7 @@ ADE_VIRTVAR(isCampaignMission, l_TechRoomMission, nullptr, "If the mission is ca
 }
 
 //**********HANDLE: tech cutscenes
-ADE_OBJ(l_TechRoomCutscene, cutscene_info_h, "custscene_info", "Tech Room cutscene handle");
+ADE_OBJ(l_TechRoomCutscene, cutscene_info_h, "cutscene_info", "Tech Room cutscene handle");
 
 ADE_VIRTVAR(Name, l_TechRoomCutscene, nullptr, "The name of the cutscene", "string", "The cutscene name")
 {
@@ -133,7 +133,7 @@ ADE_VIRTVAR(Name, l_TechRoomCutscene, nullptr, "The name of the cutscene", "stri
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current.getStage()->name);
+	return ade_set_args(L, "s", current.getScene()->name);
 }
 
 ADE_VIRTVAR(Filename, l_TechRoomCutscene, nullptr, "The filename of the cutscene", "string", "The cutscene filename")
@@ -147,7 +147,7 @@ ADE_VIRTVAR(Filename, l_TechRoomCutscene, nullptr, "The filename of the cutscene
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current.getStage()->filename);
+	return ade_set_args(L, "s", current.getScene()->filename);
 }
 
 ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description", "string", "The cutscene description")
@@ -161,7 +161,7 @@ ADE_VIRTVAR(Description, l_TechRoomCutscene, nullptr, "The cutscene description"
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current.getStage()->description);
+	return ade_set_args(L, "s", current.getScene()->description);
 }
 
 ADE_VIRTVAR(isVisible,
@@ -179,8 +179,8 @@ ADE_VIRTVAR(isVisible,
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
 	}
-	if (current.getStage()->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] &&
-		!current.getStage()->flags[Cutscene::Cutscene_Flags::Never_viewable]) 
+	if (current.getScene()->flags[Cutscene::Cutscene_Flags::Viewable, Cutscene::Cutscene_Flags::Always_viewable] &&
+		!current.getScene()->flags[Cutscene::Cutscene_Flags::Never_viewable]) 
 	{
 		return ade_set_args(L, "b", true);
 	} else {
@@ -202,7 +202,7 @@ ADE_VIRTVAR(CustomData, l_TechRoomCutscene, nullptr, "Gets the custom data table
 
 	auto table = luacpp::LuaTable::create(L);
 
-	for (const auto& pair : current.getStage()->custom_data)
+	for (const auto& pair : current.getScene()->custom_data)
 	{
 		table.addValue(pair.first, pair.second);
 	}
@@ -217,8 +217,18 @@ ADE_FUNC(hasCustomData, l_TechRoomCutscene, nullptr, "Detects whether the cutsce
 		return ADE_RETURN_NIL;
 	}
 
-	bool result = !current.getStage()->custom_data.empty();
+	bool result = !current.getScene()->custom_data.empty();
 	return ade_set_args(L, "b", result);
+}
+
+ADE_FUNC(isValid, l_TechRoomCutscene, NULL, "Detects whether cutscene is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+{
+	cutscene_info_h current;
+	if (!ade_get_args(L, "o", l_TechRoomCutscene.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	return ade_set_args(L, "b", current.IsValid());
 }
 
 } // namespace api

--- a/code/scripting/api/objs/techroom.h
+++ b/code/scripting/api/objs/techroom.h
@@ -21,7 +21,7 @@ struct cutscene_info_h {
 	cutscene_info_h();
 	explicit cutscene_info_h(int scene);
 	bool IsValid() const;
-	cutscene_info* getStage() const;
+	cutscene_info* getScene() const;
 };
 
 DECLARE_ADE_OBJ(l_TechRoomMission, sim_mission_h);


### PR DESCRIPTION
Cleanup & formalize cutscene Lua API. Fixes spelling errors and strange method names. Also fixes Lua index off-by-one error that prevented getting cutscene at position 0 because Lua starts at 1. Allows getting a cutscene by name or index now and adds isValid() to match other Lua Indexers. Also prevents crash if accessing an out of bounds cutscene index.

Note that the spelling error, while printed to the scripting.html, is not actually used by scripts, so these changes should be backwards compatible.