### PR TITLE
Fix SCPUI overwriting campaign data

### DIFF
--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -393,6 +393,23 @@ ADE_FUNC(
 	return ade_set_args(L, "b", player_create_new_pilot(callsign, is_multi, copy_from));
 }
 
+ADE_FUNC(unloadPilot,
+	l_UserInterface_PilotSelect,
+	nullptr,
+	"Unloads a player file & associated campaign file. Can not be used outside of pilot select!",
+	"boolean",
+	"Returns true if successful, false otherwise")
+{
+	if (gameseq_get_state() == GS_STATE_INITIAL_PLAYER_SELECT) {
+		Player = nullptr;
+		Campaign.filename[0] = '\0';
+
+		return ADE_RETURN_TRUE;
+	}
+
+	return ADE_RETURN_FALSE;
+}
+
 ADE_FUNC(isAutoselect, l_UserInterface_PilotSelect, nullptr,
          "Determines if the pilot selection screen should automatically select the default user.", "boolean",
          "true if autoselect is enabled, false otherwise")


### PR DESCRIPTION
I discovered that the way SCPUI reads in pilot info on the pilot select screen can, in some cases, cause the campaign file data to be reset and then saved on game shutdown.

Basically SCPUI reads in pilots to decide if they are a single player or multiplayer pilot. Depending on the order of operations, this causes `Player` to be set to something valid while the relevant campaign data is reset (because reading a save file always resets the data first). If the player then shuts down the game, the player file is saved and the campaign csg file is overwritten with reset data because `Player` is not nullptr.

I toyed with several ideas to avoid the player file saving in freespace.cpp line 6860/61 in these cases including a scripting hook or a global check. In the end I decided the simplest way to handle this is expose a way to unload the player and campaign file data in the pilot select game state. That way as SCPUI reads in each pilot it can then safely unload them. Then because `Player` is nullptr the save methods won't run on shutdown, overwriting potentially valid data.

This is 100% required for BtA2.