### PR TITLE
fix splash crash and add supplemental script hook

### DIFF
--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -12,6 +12,10 @@ const std::shared_ptr<Hook<>> OnGameInit = Hook<>::Factory("On Game Init",
 	tl::nullopt,
 	CHA_GAMEINIT);
 
+const std::shared_ptr<Hook<>> OnSplashEnd = Hook<>::Factory("On Splash End",
+	"Executed just after the splash screen fades out.",
+	{});
+
 const std::shared_ptr<Hook<>> OnIntroAboutToPlay = Hook<>::Factory("On Intro About To Play",
 	"Executed just before the intro movie is played.",
 	{});

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -6,6 +6,7 @@ namespace scripting {
 namespace hooks {
 
 extern const std::shared_ptr<Hook<>>									OnGameInit;
+extern const std::shared_ptr<Hook<>>									OnSplashEnd;
 extern const std::shared_ptr<Hook<>>									OnIntroAboutToPlay;
 //The On State Start hook previously used to pass OldState to the conditions, but no semantically sensible condition read the value, so we pretend it has no local condition
 extern const std::shared_ptr<OverridableHook<>>							OnStateStart;

--- a/code/scripting/hook_api.h
+++ b/code/scripting/hook_api.h
@@ -152,6 +152,9 @@ class HookImpl : public HookBase {
 	template <typename... Args>
 	int run(condition_t condition, detail::HookParameterInstanceList<Args...> argsList = hook_param_list<Args...>()) const
 	{
+		if (!Scripting_game_init_run)
+			return 0;
+
 		SCP_vector<SCP_string> paramNames;
 		argsList.setHookVars(paramNames);
 
@@ -183,6 +186,9 @@ class HookImpl<void> : public HookBase {
 	template <typename... Args>
 	int run(detail::HookParameterInstanceList<Args...> argsList = hook_param_list<Args...>()) const
 	{
+		if (!Scripting_game_init_run)
+			return 0;
+
 		SCP_vector<SCP_string> paramNames;
 		argsList.setHookVars(paramNames);
 
@@ -239,6 +245,9 @@ class OverridableHookImpl : public Hook<condition_t> {
 	template <typename... Args>
 	bool isOverride(condition_t condition, detail::HookParameterInstanceList<Args...> argsList = hook_param_list<Args...>()) const
 	{
+		if (!Scripting_game_init_run)
+			return false;
+
 		SCP_vector<SCP_string> paramNames;
 		argsList.setHookVars(paramNames);
 
@@ -270,6 +279,9 @@ protected:
 	template <typename... Args>
 	bool isOverride(detail::HookParameterInstanceList<Args...> argsList = hook_param_list<Args...>()) const
 	{
+		if (!Scripting_game_init_run)
+			return false;
+
 		SCP_vector<SCP_string> paramNames;
 		argsList.setHookVars(paramNames);
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -32,6 +32,7 @@ using namespace scripting;
 script_state Script_system("FS2_Open Scripting");
 bool Output_scripting_meta = false;
 bool Output_scripting_json = false;
+bool Scripting_game_init_run = false;
 
 flag_def_list Script_conditions[] = 
 {

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -350,6 +350,7 @@ void script_init();
 extern class script_state Script_system;
 extern bool Output_scripting_meta;
 extern bool Output_scripting_json;
+extern bool Scripting_game_init_run;
 
 //*************************Conditional scripting*************************
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -439,6 +439,11 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 		scripting::hooks::OnSplashScreen->run();
 	}
 
+	// A non-deprecated hook that runs after the splash screen has faded out.
+	if (scripting::hooks::OnSplashEnd->isActive()) {
+		scripting::hooks::OnSplashEnd->run();
+	}
+
 	return true;
 }
 

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -431,6 +431,7 @@ bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 	Fred_main_wnd -> init_tools();
 
 	Script_system.RunInitFunctions();
+	Scripting_game_init_run = true;	// set this immediately before OnGameInit so that OnGameInit *itself* will run
 	if (scripting::hooks::OnGameInit->isActive()) {
 		scripting::hooks::OnGameInit->run();
 	}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2008,6 +2008,8 @@ void game_init()
 		main_hall_table_init();
 	}
 
+	// Note: os_poll() cannot be called after this line and before OnGameInit->run(), otherwise UI hooks (like OnMouseMove) will run before
+	// scripting has completely initialized.
 	script_init();			//WMC
 
 	// This needs to be done after the dynamic SEXP init so that our documentation contains the dynamic sexps
@@ -2020,8 +2022,6 @@ void game_init()
 	// Do this before the initial scripting hook runs in case that hook does something with the UI
 	scpui::initialize();
 
-	game_title_screen_close();
-
 	Script_system.RunInitFunctions();
 	if (scripting::hooks::OnGameInit->isActive()) {
 		scripting::hooks::OnGameInit->run();
@@ -2030,6 +2030,9 @@ void game_init()
 	if (scripting::hooks::OnSplashScreen->isActive()) {
 		scripting::hooks::OnSplashScreen->run();
 	}
+
+	// This calls os_poll() so it must go after OnGameInit->run().
+	game_title_screen_close();
 
 	// convert old pilot files (if they need it)
 	convert_pilot_files();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2032,6 +2032,11 @@ void game_init()
 	// This calls os_poll() so it must go after OnGameInit->run().
 	game_title_screen_close();
 
+	// A non-deprecated hook that runs after the splash screen has faded out.
+	if (scripting::hooks::OnSplashEnd->isActive()) {
+		scripting::hooks::OnSplashEnd->run();
+	}
+
 	// convert old pilot files (if they need it)
 	convert_pilot_files();
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2008,16 +2008,14 @@ void game_init()
 		main_hall_table_init();
 	}
 
+	Viewer_mode = 0;
+
+	// Now that all data has been loaded, post-process anything from game_settings before we initialize scripting
+	mod_table_post_process();
+
 	// Note: os_poll() cannot be called after this line and before OnGameInit->run(), otherwise UI hooks (like OnMouseMove) will run before
 	// scripting has completely initialized.
 	script_init();			//WMC
-
-	// This needs to be done after the dynamic SEXP init so that our documentation contains the dynamic sexps
-	if (Cmdline_output_sexp_info) {
-		output_sexps("sexps.html");
-	}
-
-	Viewer_mode = 0;
 
 	// Do this before the initial scripting hook runs in case that hook does something with the UI
 	scpui::initialize();
@@ -2045,8 +2043,6 @@ void game_init()
 			libs::discord::init();
 		}
 	}
-
-	mod_table_post_process();
 
 	nprintf(("General", "Ships.tbl is : %s\n", Game_ships_tbl_valid ? "VALID" : "INVALID!!!!"));
 	nprintf(("General", "Weapons.tbl is : %s\n", Game_weapons_tbl_valid ? "VALID" : "INVALID!!!!"));
@@ -6794,6 +6790,11 @@ int game_main(int argc, char *argv[])
 		cfile_spew_pack_file_crcs();
 		game_shutdown();
 		return 0;
+	}
+
+	// This needs to be done after the dynamic SEXP init so that our documentation contains the dynamic sexps
+	if (Cmdline_output_sexp_info) {
+		output_sexps("sexps.html");
 	}
 
 	if (scripting::hooks::OnIntroAboutToPlay->isActive()) {

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2013,14 +2013,14 @@ void game_init()
 	// Now that all data has been loaded, post-process anything from game_settings before we initialize scripting
 	mod_table_post_process();
 
-	// Note: os_poll() cannot be called after this line and before OnGameInit->run(), otherwise UI hooks (like OnMouseMove) will run before
-	// scripting has completely initialized.
+	// Note: Avoid calling any non-script functions after this line and before OnGameInit->run(), lest they run before scripting has completely initialized.
 	script_init();			//WMC
 
 	// Do this before the initial scripting hook runs in case that hook does something with the UI
 	scpui::initialize();
 
 	Script_system.RunInitFunctions();
+	Scripting_game_init_run = true;	// set this immediately before OnGameInit so that OnGameInit *itself* will run
 	if (scripting::hooks::OnGameInit->isActive()) {
 		scripting::hooks::OnGameInit->run();
 	}
@@ -2029,7 +2029,7 @@ void game_init()
 		scripting::hooks::OnSplashScreen->run();
 	}
 
-	// This calls os_poll() so it must go after OnGameInit->run().
+	// This calls os_poll() so it should be placed after script initialization.
 	game_title_screen_close();
 
 	// A non-deprecated hook that runs after the splash screen has faded out.

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -299,6 +299,11 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 		scripting::hooks::OnSplashScreen->run();
 	}
 
+	// A non-deprecated hook that runs after the splash screen has faded out.
+	if (scripting::hooks::OnSplashEnd->isActive()) {
+		scripting::hooks::OnSplashEnd->run();
+	}
+
 	return true;
 }
 

--- a/qtfred/src/mission/management.cpp
+++ b/qtfred/src/mission/management.cpp
@@ -291,6 +291,7 @@ initialize(const std::string& cfilepath, int argc, char* argv[], Editor* editor,
 
 	listener(SubSystem::ScriptingInitHook);
 	Script_system.RunInitFunctions();
+	Scripting_game_init_run = true;	// set this immediately before OnGameInit so that OnGameInit *itself* will run
 	if (scripting::hooks::OnGameInit->isActive()) {
 		scripting::hooks::OnGameInit->run();
 	}


### PR DESCRIPTION
This PR fixes a crash in the initialization sequence and makes a few defense-in-depth improvements to address related risks.

PR #5379 introduced a bug that everyone, including me, missed the first time around:
> It's worth noting this moves `game_title_screen_close()` above the script hooks for On Game Init and On Splash Screen. This is so that anything that runs on Game Init that might draw to the screen won't have the splash screen fade-out rendered directly afterwards.

Now, script initialization occurs through several functions called in sequence.  During this sequence, the script system is not completely initialized, and therefore `os_poll()` cannot be called lest it invoke other scripting hooks.  Unfortunately, `game_title_screen_close()` calls `os_poll()`, so it needs to be moved back to its original location.  To address the needs of mods that want to draw to the screen without having the splash screen fade-out rendered on top of it, this PR also provides a new On Splash End hook, which was the alternate solution originally proposed in #5379.

This also moves `Viewer_mode = 0` and `mod_table_post_process()` prior to script initialization so that scripts can depend on completely configured data, and moves sexp.html creation out of the middle of script initialization and over to a more appropriate location in `game_main` where other similar command-line functions are handled.