### PR TITLE
Fix MSAA for some graphics drivers

### DIFF
--- a/code/def_files/data/effects/msaa-f.sdr
+++ b/code/def_files/data/effects/msaa-f.sdr
@@ -5,7 +5,6 @@ out vec4 fragOut2;
 out vec4 fragOut3;
 out vec4 fragOut4;
 out vec4 fragOut5;
-out float gl_FragDepth;
 
 uniform sampler2DMS texColor;
 uniform sampler2DMS texPos;


### PR DESCRIPTION
Some OpenGL drivers, apparently mostly Apple's, don't just ignore redeclarations of built in variables (as Linux & Windows drivers for AMD and Nvidia seem to), but actively error out.
So, remove the redeclaration, and MSAA will work again on macs and possibly other drivers that might have had this behaviour.