### PR TITLE
Pause the UI properly based on user settings

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -113,9 +113,7 @@ namespace
 			case SDL_WINDOWEVENT_FOCUS_LOST:
 			{
 				if (fAppActive) {
-					if (!Cmdline_no_unfocus_pause) {
-						game_pause();
-					}
+					game_pause();
 
 					fAppActive = false;
 				}
@@ -126,9 +124,7 @@ namespace
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
 			{
 				if (!fAppActive) {
-					if (!Cmdline_no_unfocus_pause) {
-						game_unpause();
-					}
+					game_unpause();
 
 					fAppActive = true;
 				}

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7812,6 +7812,9 @@ void game_pause()
 	if (!GameState_Stack_Valid())
 		return;
 
+	if (!pause_if_unfocused())
+		return;
+
 	if (!(Game_mode & GM_MULTIPLAYER)){
 		switch ( gameseq_get_state() )
 		{
@@ -7876,6 +7879,9 @@ void game_pause()
 void game_unpause()
 {
 	if (!GameState_Stack_Valid())
+		return;
+
+	if (!pause_if_unfocused())
 		return;
 
 	// automatically recover from everything but an in-mission pause


### PR DESCRIPTION
Similar to windowed mode, this was another case of an in-game option that needed a few more checks added to make sure we respect the correct user setting.

I removed the commandline check in osapi opting to keep all the pause globals in freespace.cpp that osapi doesn't have access to. So rather than more includes we can just return early from the pause/unpause functions.