### PR TITLE
fix warp time durations

### DIFF
--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -1052,7 +1052,7 @@ float fireball_wormhole_intensity(fireball *fb)
 		rad = (float)pow((fb->total_time - t) / fb->warp_close_duration, 0.4f);
 	}
 	return rad;
-} 
+}
 
 extern void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float max_radius, bool warp_3d, int warp_glow_bitmap, int warp_ball_bitmap, int warp_model_id);
 

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -235,7 +235,7 @@ private:
 	float warping_time;			// time to go through the effect
 	float warping_speed;		// speed to go through the effect
 
-	void compute_warpout_stuff(float *warp_time, vec3d *warp_pos);
+	void compute_warpout_stuff(float *ship_move_time, vec3d *warp_pos);
 
 	//Total data
 	int total_time_start;


### PR DESCRIPTION
Properly set the warp durations when ships arrive and depart, so that the warp animation can open and close smoothly without any discontinuities.

~~In draft pending additional tests.~~  Tested by myself and Gamma39er.