### PR TITLE
Add opf custom string as a lua sexp return type

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -486,6 +486,16 @@ const std::shared_ptr<scripting::Hook<scripting::hooks::ShipDepartConditions>> O
  const std::shared_ptr<scripting::Hook<>> OnLoadoutAboutToParseHook = scripting::Hook<>::Factory("On Loadout About To Parse",
 	"Called during mission load just before parsing the team loadout.",{});
 
+mission_custom_string* get_custom_string_by_name(SCP_string name) {
+	for (size_t i = 0; i < The_mission.custom_strings.size(); i++) {
+		if (The_mission.custom_strings[i].name == name) {
+			return &The_mission.custom_strings[i];
+		}
+	}
+
+	return nullptr;
+}
+
 // Goober5000
 void parse_custom_bitmap(const char *expected_string_640, const char *expected_string_1024, char *string_field_640, char *string_field_1024)
 {

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -554,6 +554,8 @@ void clear_texture_replacements();
 // Goober5000
 subsys_status *parse_get_subsys_status(p_object *pobjp, const char *subsys_name);
 
+// MjnMixael
+mission_custom_string* get_custom_string_by_name(SCP_string name);
 
 #endif
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4148,6 +4148,15 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 				}
 				break;
 
+			case OPF_MISSION_CUSTOM_STRING:
+				if (type2 != SEXP_ATOM_STRING) {
+					return SEXP_CHECK_TYPE_MISMATCH;
+				}
+
+				if (get_custom_string_by_name(CTEXT(node)) == nullptr) {
+					return SEXP_CHECK_INVALID_CUSTOM_STRING;
+				}
+
 			default: //This handles OPF_CHILD_LUA_ENUM as well
 				if (Dynamic_enums.size() > 0) {
 					if ((type - First_available_opf_id) < (int)Dynamic_enums.size()) {
@@ -34020,6 +34029,9 @@ const char *sexp_error_message(int num)
 
 		case SEXP_CHECK_INVALID_SHIP_WING_WHOLETEAM:
 			return "Invalid ship, wing, or team name";
+
+		case SEXP_CHECK_INVALID_CUSTOM_STRING:
+			return "Invalid custom string name";
 
 		default:
 			Warning(LOCATION, "Unhandled sexp error code %d!", num);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4156,6 +4156,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 				if (get_custom_string_by_name(CTEXT(node)) == nullptr) {
 					return SEXP_CHECK_INVALID_CUSTOM_STRING;
 				}
+				break;
 
 			default: //This handles OPF_CHILD_LUA_ENUM as well
 				if (Dynamic_enums.size() > 0) {

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -142,6 +142,7 @@ enum sexp_opf_t : int {
 	OPF_TRAITOR_OVERRIDE,			// MjnMixael - Traitor overrides as defined in traitor.tbl
 	OPF_LUA_GENERAL_ORDER,          // MjnMixael - General orders as defined in sexps.tbl
 	OPF_CHILD_LUA_ENUM,			    // MjnMixael - Used to let Lua Enums reference Enums
+	OPF_MISSION_CUSTOM_STRING,      // MjnMixael - The custom strings as defined in FRED
 
 	//Must always be at the end of the list
 	First_available_opf_id
@@ -1249,6 +1250,7 @@ enum sexp_error_check
 	SEXP_CHECK_INVALID_ORDER_RECIPIENT,
 	SEXP_CHECK_INVALID_SHIP_WING_WHOLETEAM,
 	SEXP_CHECK_MUST_BE_INTEGER,
+	SEXP_CHECK_INVALID_CUSTOM_STRING,
 };
 
 

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -324,7 +324,7 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum, int parent_node) const
 		table.addValue("Value", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), cs->value));
 		table.addValue("String", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), cs->text));
 
-		return LuaValue::createValue(_action.getLuaState(), table);
+		return table;
 	}
 	default:
 		if ((strcmp(argtype.first.c_str(), "enum")) == 0) {

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -57,6 +57,7 @@ static SCP_unordered_map<SCP_string, int> parameter_type_mapping{{ "boolean",   
 														  { "hudgauge",     OPF_ANY_HUD_GAUGE },
 														  { "event",        OPF_EVENT_NAME },
 														  { "child_enum",   OPF_CHILD_LUA_ENUM },
+                                                          { "custom_string",OPF_MISSION_CUSTOM_STRING },
 														  { "enum",         First_available_opf_id } };
 
 // If a parameter requires a parent parameter then it must be listed here!
@@ -314,6 +315,16 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum, int parent_node) const
 	case OPF_CHILD_LUA_ENUM: {
 		auto text = CTEXT(node);
 		return LuaValue::createValue(_action.getLuaState(), text);
+	}
+	case OPF_MISSION_CUSTOM_STRING: {
+		auto cs = get_custom_string_by_name(CTEXT(node));
+		auto table = luacpp::LuaTable::create(_action.getLuaState());
+
+		table.addValue("Name", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), cs->name));
+		table.addValue("Value", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), cs->value));
+		table.addValue("String", luacpp::LuaValue::createValue(Script_system.GetLuaSession(), cs->text));
+
+		return LuaValue::createValue(_action.getLuaState(), table);
 	}
 	default:
 		if ((strcmp(argtype.first.c_str(), "enum")) == 0) {

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -3677,6 +3677,9 @@ int sexp_tree::query_default_argument_available(int op, int i)
 		case OPF_LUA_GENERAL_ORDER:
 			return (ai_lua_get_num_general_orders() > 0) ? 1 : 0;
 
+		case OPF_MISSION_CUSTOM_STRING:
+			return The_mission.custom_strings.empty() ? 0 : 1;
+
 		default:
 			if (!Dynamic_enums.empty()) {
 				if ((type - First_available_opf_id) < (int)Dynamic_enums.size()) {
@@ -5762,6 +5765,10 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = get_listing_opf_lua_enum(parent_node, arg_index);
 			break;
 
+		case OPF_MISSION_CUSTOM_STRING:
+			list = get_listing_opf_mission_custom_strings();
+			break;
+
 		default:
 			//We're at the end of the list so check for any dynamic enums
 			list = check_for_dynamic_sexp_enum(opf);
@@ -7609,6 +7616,17 @@ sexp_list_item* sexp_tree::get_listing_opf_lua_general_orders()
 
 	for (const auto& val : orders) {
 		head.add_data(val.c_str());
+	}
+
+	return head.next;
+}
+
+sexp_list_item* sexp_tree::get_listing_opf_mission_custom_strings()
+{
+	sexp_list_item head;
+
+	for (const auto& val : The_mission.custom_strings) {
+		head.add_data(val.name.c_str());
 	}
 
 	return head.next;

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -313,6 +313,7 @@ public:
 	sexp_list_item *get_listing_opf_traitor_overrides();
 	sexp_list_item *get_listing_opf_lua_general_orders();
 	sexp_list_item *get_listing_opf_lua_enum(int parent_node, int arg_index);
+	sexp_list_item* get_listing_opf_mission_custom_strings();
 
 	// container modifier options for container data nodes
 	sexp_list_item *get_container_modifiers(int con_data_node) const;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1678,6 +1678,10 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 	case OPF_LUA_GENERAL_ORDER:
 		return (ai_lua_get_num_general_orders() > 0) ? 1 : 0;
 
+	case OPF_MISSION_CUSTOM_STRING:
+		return The_mission.custom_strings.empty() ? 0 : 1;
+		break;
+
 	default:
 		if (!Dynamic_enums.empty()) {
 			if ((type - First_available_opf_id) < (int)Dynamic_enums.size()) {
@@ -3468,6 +3472,10 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 		list = get_listing_opf_lua_enum(parent_node, arg_index);
 		break;
 
+	case OPF_MISSION_CUSTOM_STRING:
+		list = get_listing_opf_mission_custom_strings();
+		break;
+
 	default:
 		// We're at the end of the list so check for any dynamic enums
 		list = check_for_dynamic_sexp_enum(opf);
@@ -5224,6 +5232,17 @@ sexp_list_item* sexp_tree::get_listing_opf_lua_enum(int parent_node, int arg_ind
 		mprintf(("Could not find Lua Enum %s! Using <none> instead!", enum_name.c_str()));
 		head.add_data("<none>");
 	}
+	return head.next;
+}
+
+sexp_list_item* sexp_tree::get_listing_opf_mission_custom_strings()
+{
+	sexp_list_item head;
+
+	for (const auto& val : The_mission.custom_strings) {
+		head.add_data(val.name.c_str());
+	}
+
 	return head.next;
 }
 

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -361,6 +361,7 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item *get_listing_opf_traitor_overrides();
 	sexp_list_item *get_listing_opf_lua_general_orders();
 	sexp_list_item *get_listing_opf_lua_enum(int parent_node, int arg_index);
+	sexp_list_item *get_listing_opf_mission_custom_strings();
 
 	// container modifier options for container data nodes
 	sexp_list_item *get_container_modifiers(int con_data_node) const;


### PR DESCRIPTION
Exactly that. Adds Custom String as a return type that lua sexps can require. The return is a table value containing the three elements of the custom string exactly as if it was accessed by mn.CustomStrings.