### PR TITLE
switch to new linux build image

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-5ac6f70
+    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     steps:
       - uses: actions/checkout@v1
         name: Checkout
@@ -24,7 +24,7 @@ jobs:
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
-          COMPILER: gcc-5
+          COMPILER: gcc-9
           ENABLE_QTFRED: OFF
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Linux
     needs: create_release   # Don't run this job until create_release is done and successful
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-5ac6f70
+    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     steps:
       - uses: actions/checkout@v1
         # checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.
@@ -55,7 +55,7 @@ jobs:
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
-          COMPILER: gcc-5
+          COMPILER: gcc-9
           ENABLE_QTFRED: OFF
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-5ac6f70
+    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     steps:
       - uses: actions/checkout@v1
         name: Checkout
@@ -30,7 +30,7 @@ jobs:
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
-          COMPILER: gcc-5
+          COMPILER: gcc-9
           ENABLE_QTFRED: OFF
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile

--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        compiler: [gcc-5, gcc-13, clang-16]
+        compiler: [gcc-9, gcc-13, clang-16]
         cmake_options: [""]
         include:
           # Also include configurations that check if the code compiles without the graphics backends
@@ -25,7 +25,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-5ac6f70
+    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     steps:
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        compiler: [gcc-5, gcc-13, clang-16]
+        compiler: [gcc-9, gcc-13, clang-16]
         cmake_options: [""]
         include:
           # Also include configurations that check if the code compiles without the graphics backends
@@ -22,7 +22,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-5ac6f70
+    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     steps:
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build FSO With Coverity Wrapper
     runs-on: ${{ matrix.config.os }}
-    container: ghcr.io/scp-fs2open/linux_build:sha-5ac6f70
+    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     strategy:
       fail-fast: false
       matrix:
@@ -47,7 +47,7 @@ jobs:
       - name: Configure CMake for FSO
         env:
           CONFIGURATION: Release
-          compiler: gcc-5
+          compiler: gcc-9
           ENABLE_QTFRED: OFF
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
 

--- a/ci/linux/configure_cmake.sh
+++ b/ci/linux/configure_cmake.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [ "$COMPILER" = "gcc-5" ]; then
-    export CC=gcc-5
+if [ "$COMPILER" = "gcc-9" ]; then
+    export CC=gcc-9
     export CXX=g++-5
 fi
 if [ "$COMPILER" = "gcc-13" ]; then

--- a/ci/linux/configure_cmake.sh
+++ b/ci/linux/configure_cmake.sh
@@ -2,7 +2,7 @@
 
 if [ "$COMPILER" = "gcc-9" ]; then
     export CC=gcc-9
-    export CXX=g++-5
+    export CXX=g++-9
 fi
 if [ "$COMPILER" = "gcc-13" ]; then
     export CC=gcc-13


### PR DESCRIPTION
Upgrades to Ubuntu 20.04 to fix Node v20 problem.
Bumps compiler to gcc-9.

NOTE: This breaks support in official builds for Linux distros older than Ubuntu 20.04