### PR TITLE
Prevent compiler optimization

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4569,7 +4569,7 @@ int game_check_key()
 bool pause_if_unfocused()
 {
 	if (Using_in_game_options) {
-		return Allow_unfocused_pause;
+		return UnfocusedPauseOption->getValue();
 	} else {
 		return !Cmdline_no_unfocus_pause;
 	}


### PR DESCRIPTION
Was playing on the latest nightly after #5955 was merged when I realized my UI paused when unfocused. Thought I fixed that... well turns out this ran into the same issue as lightshafts in #5689 where the compiler was entirely optimizing out the global in non-Debug builds. So let's do the same thing here and instead of referencing the global directly, we'll get at it through the OptionsManager.