### PR TITLE
use C++ casts for floating.h and floating.cpp

### DIFF
--- a/code/math/floating.cpp
+++ b/code/math/floating.cpp
@@ -22,13 +22,13 @@
  */
 float fl_roundoff(float x, int multiple)
 {
-	float half = (float) multiple / 2.0f;
+	float half = multiple / 2.0f;
 
 	if (x < 0)
 		half = -half;
 
 	x += half;
-	return (float) (((int) x / multiple) * multiple);
+	return i2fl((fl2i(x) / multiple) * multiple);
 }
 
 /**

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -30,67 +30,19 @@ inline bool fl_is_nan(float fl) {
 #define fl_sqrt(fl) sqrtf(fl)
 #define fl_isqrt(fl) (1.0f/sqrtf(fl))
 #define fl_abs(fl) fabsf(fl)
-#define i2fl(i) ((float)(i))
-#define fl2i(fl) ((int)(fl))
-#define fl2ir(fl) ((int)(fl + ((fl < 0.0f) ? -0.5f : 0.5f)))
-#define flceil(fl) (int)ceil(fl)
-#define flfloor(fl) (int)floor(fl)
-#define f2fl(fx) ((float)(fx)/65536.0f)
-#define f2d(fx) (((double)(fx))/65536.0)
-#define fl2f(fl) (int)((fl)*65536.0f)
+#define i2fl(i) (static_cast<float>(i))
+#define fl2i(fl) (static_cast<int>(fl))
+#define fl2ir(fl) (static_cast<int>(fl + (((fl) < 0.0f) ? -0.5f : 0.5f)))
+#define f2fl(fx) (static_cast<float>(fx)/65536.0f)
+#define f2d(fx) (static_cast<double>(fx)/65536.0)
+#define fl2f(fl) (static_cast<int>((fl)*65536.0f))
 #define fl_tan(fl) tanf(fl)
 
 // convert a measurement in degrees to radians
-#define fl_radians(fl)	((float)((fl) * (PI / 180.0f)))
+#define fl_radians(fl)	(static_cast<float>((fl) * (PI / 180.0f)))
 
 // convert a measurement in radians to degrees
-#define fl_degrees(fl)	((float)((fl) * (180.0f / PI)))
-
-// use this instead of:
-// for:  (int)floor(x+0.5f) use fl_round_2048(x)
-//       (int)ceil(x-0.5f)  use fl_round_2048(x)
-//       (int)floor(x-0.5f) use fl_round_2048(x-1.0f)
-//       (int)floor(x)      use fl_round_2048(x-0.5f)
-// for values in the range -2048 to 2048
-// use this instead of:
-// for:  (int)floor(x+0.5f) use fl_round_2048(x)
-//       (int)ceil(x-0.5f)  use fl_round_2048(x)
-//       (int)floor(x-0.5f) use fl_round_2048(x-1.0f)
-//       (int)floor(x)      use fl_round_2048(x-0.5f)
-// for values in the range -2048 to 2048
-
-/*
-extern const float *p_fl_magic;
-
-inline int fl_round_2048( float x )
-{
-	double tmp_quad;
-	tmp_quad = x + *p_fl_magic;
-	return *((int *)&tmp_quad);
-}
-
-inline float fl_sqrt( float x)
-{
-	float retval;
-
-	_asm fld x
-	_asm fsqrt
-	_asm fstp retval
-	
-	return retval;
-}
-
-float fl_isqrt( float x )
-{
-	float retval;
-
-	_asm fld x
-	_asm fsqrt
-	_asm fstp retval
-	
-	return 1.0f / retval;
-} 
-*/
+#define fl_degrees(fl)	(static_cast<float>((fl) * (180.0f / PI)))
 
 // sees if a floating point number is within a certain threshold (by default, epsilon) of zero
 inline bool fl_near_zero(float a, float e = std::numeric_limits<float>::epsilon())


### PR DESCRIPTION
Change the casts used in the convenience #defines in floating.h.  Since these #defines are used pretty widely, this should reduce the count of C-style casts in the codebase by quite a bit.

Also change the casts in floating.cpp while we're at it, and remove some obsolete or unused code.