### PR TITLE
Unhardcode renderSelectModel zoom value

### DIFF
--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -1267,10 +1267,10 @@ ADE_FUNC(renderTechModel2, l_Shipclass, "number X1, number Y1, number X2, number
 
 ADE_FUNC(renderSelectModel,
 	l_Shipclass,
-	"boolean restart, number x, number y, [number width = 629, number height = 355, number = currentEffectSetting]",
+	"boolean restart, number x, number y, [number width = 629, number height = 355, number currentEffectSetting = default, number zoom = 1.3]",
 	"Draws the 3D select ship model with the chosen effect at the specified coordinates. Restart should "
 	"be true on the first frame this is called and false on subsequent frames. Valid selection effects are 1 (fs1) or 2 (fs2), "
-	"defaults to the mod setting or the model's setting.",
+	"defaults to the mod setting or the model's setting. Zoom is a multiplier to the model's closeup_zoom value.",
 	"boolean",
 	"true if rendered, false if error")
 {
@@ -1281,7 +1281,8 @@ ADE_FUNC(renderSelectModel,
 	int x2 = 629;
 	int y2 = 355;
 	int effect = -1;
-	if (!ade_get_args(L, "obii|iii", l_Shipclass.Get(&idx), &restart, &x1, &y1, &x2, &y2, &effect))
+	float zoom = 1.3f;
+	if (!ade_get_args(L, "obii|iiif", l_Shipclass.Get(&idx), &restart, &x1, &y1, &x2, &y2, &effect, &zoom))
 		return ADE_RETURN_NIL;
 
 	if (idx < 0 || idx >= ship_info_size())
@@ -1331,7 +1332,7 @@ ADE_FUNC(renderSelectModel,
 		y2,
 		&ShipRot,
 		&sip->closeup_pos,
-		sip->closeup_zoom * 1.3f,
+		sip->closeup_zoom * zoom,
 		rev_rate,
 		MR_AUTOCENTER | MR_NO_FOGGING,
 		GR_RESIZE_NONE,

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -846,11 +846,11 @@ ADE_FUNC(renderTechModel2,
 
 ADE_FUNC(renderSelectModel,
 	l_Weaponclass,
-	"number x, number y, [number width = 629, number height = 355, number = currentEffectSetting]",
+	"number x, number y, [number width = 629, number height = 355, number currentEffectSetting = default, zoom = 0.65]",
 	"Draws the 3D select weapon model with the chosen effect at the specified coordinates. Restart should "
 	"be true on the first frame this is called and false on subsequent frames. Note that primary weapons "
 	"will not render anything if they do not have a valid pof model defined! Valid selection effects are 1 (fs1) or 2 (fs2), "
-	"defaults to the mod setting or the model's setting.",
+	"defaults to the mod setting or the model's setting. Zoom is a multiplier to the model's closeup_zoom value.",
 	"boolean",
 	"true if rendered, false if error")
 {
@@ -861,7 +861,8 @@ ADE_FUNC(renderSelectModel,
 	int x2 = 629;
 	int y2 = 355;
 	int effect = -1;
-	if (!ade_get_args(L, "obii|iii", l_Weaponclass.Get(&idx), &restart, &x1, &y1, &x2, &y2, &effect))
+	float zoom = 0.65f;
+	if (!ade_get_args(L, "obii|iiif", l_Weaponclass.Get(&idx), &restart, &x1, &y1, &x2, &y2, &effect, &zoom))
 		return ADE_RETURN_NIL;
 
 	if (idx < 0 || idx >= weapon_info_size())
@@ -903,7 +904,7 @@ ADE_FUNC(renderSelectModel,
 		y2,
 		&WepRot,
 		&wip->closeup_pos,
-		wip->closeup_zoom * 0.65f,
+		wip->closeup_zoom * zoom,
 		REVOLUTION_RATE,
 		MR_IS_MISSILE | MR_AUTOCENTER | MR_NO_FOGGING,
 		GR_RESIZE_NONE,

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -846,7 +846,7 @@ ADE_FUNC(renderTechModel2,
 
 ADE_FUNC(renderSelectModel,
 	l_Weaponclass,
-	"number x, number y, [number width = 629, number height = 355, number currentEffectSetting = default, zoom = 0.65]",
+	"number x, number y, [number width = 629, number height = 355, number currentEffectSetting = default, number zoom = 0.65]",
 	"Draws the 3D select weapon model with the chosen effect at the specified coordinates. Restart should "
 	"be true on the first frame this is called and false on subsequent frames. Note that primary weapons "
 	"will not render anything if they do not have a valid pof model defined! Valid selection effects are 1 (fs1) or 2 (fs2), "


### PR DESCRIPTION
I was fighting a UI bug where the weapons were rendering way closer to the camera than they should have been in SCPUI. Once I started digging further I found these hardcoded zoom multipliers. I'm sure I copied these from the retail UI code but that no longer makes sense here and it's poor design.

So this exposes the zoom multiplier with a default value of what it is currently. Additionally this fixes a small error in the scripting.html documentation.

While this one walks the line between feature and fix, and BtA can release without it, we'd love to be able to have this fix in 24.0.0 since it's pretty well contained to the scripting API.