### PR TITLE
address issue 5980

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -977,9 +977,7 @@ int CFred_mission_save::save_bitmaps()
 		}
 
 		// save our flags
-		if (Mission_save_format == FSO_FORMAT_RETAIL) {
-			MessageBox(nullptr, "Warning: Background flags (including the fixed-angles-in-mission-file flag) are not supported in retail.  The sun and bitmap angles will be loaded differently by previous versions.", "Incompatibility with retail mission format", MB_OK);
-		} else if (background->flags.any_set()) {
+		if (Mission_save_format != FSO_FORMAT_RETAIL && background->flags.any_set()) {
 			if (optional_string_fred("+Flags:")) {
 				parse_comments();
 			} else {
@@ -2608,6 +2606,18 @@ int CFred_mission_save::save_mission_file(const char *pathname)
 		strcat_s(savepath, "\\");
 	}
 	strcat_s(savepath, "saving.xxx");
+
+	// only display this warning once, and only when the user explicitly saves, as opposed to autosave
+	static bool Displayed_retail_background_warning = false;
+	if (Mission_save_format != FSO_FORMAT_STANDARD && !Displayed_retail_background_warning) {
+		for (const auto &bg : Backgrounds) {
+			if (bg.flags[Starfield::Background_Flags::Corrected_angles_in_mission_file]) {
+				MessageBox(nullptr, "Warning: Background flags (including the fixed-angles-in-mission-file flag) are not supported in retail.  The sun and bitmap angles will be loaded differently by previous versions.", "Incompatibility with retail mission format", MB_OK);
+				Displayed_retail_background_warning = true;
+				break;
+			}
+		}
+	}
 
 	save_mission_internal(savepath);
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -977,7 +977,7 @@ int CFred_mission_save::save_bitmaps()
 		}
 
 		// save our flags
-		if (Mission_save_format != FSO_FORMAT_RETAIL && background->flags.any_set()) {
+		if (Mission_save_format == FSO_FORMAT_STANDARD && background->flags.any_set()) {
 			if (optional_string_fred("+Flags:")) {
 				parse_comments();
 			} else {
@@ -994,7 +994,6 @@ int CFred_mission_save::save_bitmaps()
 		for (j = 0; j < background->suns.size(); j++) {
 			starfield_list_entry *sle = &background->suns[j];
 
-
 			// filename
 			required_string_fred("$Sun:");
 			parse_comments();
@@ -1004,7 +1003,7 @@ int CFred_mission_save::save_bitmaps()
 			required_string_fred("+Angles:");
 			parse_comments();
 			angles ang = sle->ang;
-			if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
+			if (Mission_save_format != FSO_FORMAT_STANDARD || !background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
 				stars_uncorrect_background_sun_angles(&ang);
 			fout(" %f %f %f", ang.p, ang.b, ang.h);
 
@@ -1027,7 +1026,7 @@ int CFred_mission_save::save_bitmaps()
 			required_string_fred("+Angles:");
 			parse_comments();
 			angles ang = sle->ang;
-			if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
+			if (Mission_save_format != FSO_FORMAT_STANDARD || !background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
 				stars_uncorrect_background_bitmap_angles(&ang);
 			fout(" %f %f %f", ang.p, ang.b, ang.h);
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -992,12 +992,7 @@ int CFred_mission_save::save_bitmaps()
 		}
 
 		// save our flags
-		if (save_format == MissionFormat::RETAIL) {
-			_viewport->dialogProvider->showButtonDialog(DialogType::Warning,
-				"Incompatibility with retail mission format",
-				"Warning: Background flags (including the fixed-angles-in-mission-file flag) are not supported in retail.  The sun and bitmap angles will be loaded differently by previous versions.",
-				{ DialogButton::Ok });
-		} else if (background->flags.any_set()) {
+		if (save_format != MissionFormat::RETAIL && background->flags.any_set()) {
 			if (optional_string_fred("+Flags:")) {
 				parse_comments();
 			} else {
@@ -2507,6 +2502,21 @@ int CFred_mission_save::save_mission_file(const char* pathname_in)
 		strcat_s(savepath, DIR_SEPARATOR_STR);
 	}
 	strcat_s(savepath, "saving.xxx");
+
+	// only display this warning once, and only when the user explicitly saves, as opposed to autosave
+	static bool Displayed_retail_background_warning = false;
+	if (save_format != MissionFormat::STANDARD && !Displayed_retail_background_warning) {
+		for (const auto &bg : Backgrounds) {
+			if (bg.flags[Starfield::Background_Flags::Corrected_angles_in_mission_file]) {
+				_viewport->dialogProvider->showButtonDialog(DialogType::Warning,
+					"Incompatibility with retail mission format",
+					"Warning: Background flags (including the fixed-angles-in-mission-file flag) are not supported in retail.  The sun and bitmap angles will be loaded differently by previous versions.",
+					{ DialogButton::Ok });
+				Displayed_retail_background_warning = true;
+				break;
+			}
+		}
+	}
 
 	save_mission_internal(savepath);
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -992,7 +992,7 @@ int CFred_mission_save::save_bitmaps()
 		}
 
 		// save our flags
-		if (save_format != MissionFormat::RETAIL && background->flags.any_set()) {
+		if (save_format == MissionFormat::STANDARD && background->flags.any_set()) {
 			if (optional_string_fred("+Flags:")) {
 				parse_comments();
 			} else {
@@ -1018,7 +1018,7 @@ int CFred_mission_save::save_bitmaps()
 			required_string_fred("+Angles:");
 			parse_comments();
 			angles ang = sle->ang;
-			if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
+			if (save_format != MissionFormat::STANDARD || !background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
 				stars_uncorrect_background_sun_angles(&ang);
 			fout(" %f %f %f", ang.p, ang.b, ang.h);
 
@@ -1041,7 +1041,7 @@ int CFred_mission_save::save_bitmaps()
 			required_string_fred("+Angles:");
 			parse_comments();
 			angles ang = sle->ang;
-			if (!background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
+			if (save_format != MissionFormat::STANDARD || !background->flags[Starfield::Background_Flags::Corrected_angles_in_mission_file])
 				stars_uncorrect_background_bitmap_angles(&ang);
 			fout(" %f %f %f", ang.p, ang.b, ang.h);
 


### PR DESCRIPTION
This fixes the several bugs listed in issue #5980, as follows:
1. Only display the background angle warning once per session, instead of every time FRED automatically autosaves and for every background.
2. Instead of removing all blank backgrounds and then re-adding one, remove all but one blank background.  This preserves any flag changes made on that background.
3. Always save background angles in the old, uncorrected format if the save format is not set to Standard.  Previously angles would be saved in the corrected format, which would be interpreted by retail as a completely different set of angles.

Tested and ready for review.