### PR TITLE
Virtual POF fixes

### DIFF
--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -3294,7 +3294,7 @@ void bsp_polygon_data::replace_textures_used(const SCP_map<int, int>& replacemen
 			Num_verts[it->first] -= poly.Num_verts;
 			Num_verts[it->second] += poly.Num_verts;
 			--Num_polies[it->first];
-			++Num_polies[it->first];
+			++Num_polies[it->second];
 		}
 	}
 }

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -127,7 +127,7 @@ bool read_virtual_model_file(polymodel* pm, const SCP_string& filename, model_pa
 	const auto& virtual_pof = virtual_pof_it->second[depthLocal];
 	depthLocal++;
 
-	read_model_file(pm, filename.c_str(), ferror, deferredTasks, depth);
+	read_model_file(pm, virtual_pof.basePOF.c_str(), ferror, deferredTasks, depth);
 
 	for (const auto& operation : virtual_pof.operationList)
 		operation->process(pm, deferredTasks, depth, virtual_pof);

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -392,15 +392,17 @@ void VirtualPOFOperationAddSubmodel::process(polymodel* pm, model_read_deferred_
 		SCP_vector<int> to_copy_submodels;
 		bool has_name_collision = false;
 		if (copyChildren) {
-			model_iterate_submodel_tree(appendingPM, src_subobj_no, [&to_copy_submodels, &has_name_collision, pm, appendingPM](int submodel, int /*level*/, bool /*isLeaf*/) {
+			model_iterate_submodel_tree(appendingPM, src_subobj_no, [&to_copy_submodels, &has_name_collision, &renameMap, pm, appendingPM](int submodel, int /*level*/, bool /*isLeaf*/) {
 				to_copy_submodels.emplace_back(submodel);
-				if(model_find_submodel_index(pm, appendingPM->submodel[submodel].name) != -1)
+				auto replace_with_name_it = renameMap.find(appendingPM->submodel[submodel].name);
+				if(model_find_submodel_index(pm, replace_with_name_it == renameMap.end() ? appendingPM->submodel[submodel].name : replace_with_name_it->second.c_str()) != -1)
 					has_name_collision = true;
 				});
 		}
 		else {
 			to_copy_submodels.emplace_back(src_subobj_no);
-			if (model_find_submodel_index(pm, appendingPM->submodel[src_subobj_no].name) != -1)
+			auto replace_with_name_it = renameMap.find(appendingPM->submodel[src_subobj_no].name);
+			if(model_find_submodel_index(pm, replace_with_name_it == renameMap.end() ? appendingPM->submodel[src_subobj_no].name : replace_with_name_it->second.c_str()) != -1)
 				has_name_collision = true;
 		}
 


### PR DESCRIPTION
This fixes four issues that became apparent with virtual pofs recently:
- It used the wrong filename, which meant that unless it was replacing a pof, it would complain. Adding a new virtual pof was bugged.
- It didn't consider the renaming options for copying submodels when checking for name conflicts, which meant that renaming a submodel that conflicted didn't resolve the check as it should have
- When replacing submodel numbers, it would replace already replaced numbers again, potentially corrupting the hierarchy
- When replacing textures, it incremented the wrong poly count, causing potentially corrupted geometry and meshes