### PR TITLE
Add some security to avoid invalid `Random::next()` calls.

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1049,6 +1049,7 @@ bool asteroid_is_within_view(vec3d *pos, float range, bool range_override)
  */
 static void maybe_throw_asteroid()
 {
+	Assertion(Asteroid_field.num_used_field_debris_types > 0, "maybe_throw_asteroid() called while num_used_field_debris_types was 0; this should never happen, get a coder!");
 
 	for (asteroid_target& target : Asteroid_targets) {
 		if (!timestamp_elapsed(target.throw_stamp))
@@ -2581,6 +2582,11 @@ void asteroid_frame()
 
 	// Only throw if active field
 	if (Asteroid_field.field_type == FT_PASSIVE) {
+		return;
+	}
+
+	// If no asteroid types are defined for the field, abort.
+	if (Asteroid_field.num_used_field_debris_types <= 0) {
 		return;
 	}
 

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -501,11 +501,11 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 		}
 		else if (vaporize) {
 			db->model_num = Debris_vaporize_model;
-			db->submodel_num = Random::next(Debris_num_submodels);
+			db->submodel_num = (Debris_num_submodels <= 0 ? 0 : Random::next(Debris_num_submodels));
 		}
 		else {
 			db->model_num = Debris_model;
-			db->submodel_num = Random::next(Debris_num_submodels);
+			db->submodel_num = (Debris_num_submodels <= 0 ? 0 : Random::next(Debris_num_submodels));
 		}
 	}
 	else {
@@ -644,7 +644,7 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 		if (spark_timeout >= 0) {
 			db->fire_timeout = _timestamp(spark_timeout);
 		} else if (parent_objnum >= 0) {
-			float t = 1000*Objects[parent_objnum].radius/3 + Random::next(fl2i(1000*3*Objects[parent_objnum].radius));
+			float t = 1000*Objects[parent_objnum].radius/3 + (fl2i(1000*3*Objects[parent_objnum].radius) == 0 ? 0 : Random::next(fl2i(1000*3*Objects[parent_objnum].radius)));
 			db->fire_timeout = _timestamp(fl2i(t));		// fireballs last from 5 - 30 seconds
 		} else {
 			db->fire_timeout = TIMESTAMP::immediate();

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -327,7 +327,7 @@ void ssm_create(object *target, vec3d *start, size_t ssm_index, ssm_firing_info 
 	// Init the ssm data
 
 	count = Ssm_info[ssm_index].count;
-	if (Ssm_info[ssm_index].max_count != -1) {
+	if (Ssm_info[ssm_index].max_count != -1 && (Ssm_info[ssm_index].max_count - count) > 0) {
 		count += Random::next(count, Ssm_info[ssm_index].max_count);
 	}
 


### PR DESCRIPTION
There were a few instances of `Random::next()` being called without ensuring its arguments couldn't trip an assertion. This should hopefully catch them all.