### PR TITLE
Change special IFF color `#define`s into `extern int`s.

### DIFF
--- a/code/iff_defs/iff_defs.cpp
+++ b/code/iff_defs/iff_defs.cpp
@@ -24,6 +24,10 @@ int radar_iff_color[5][2][4];
 int iff_bright_delta;
 int *iff_color_brightness = &iff_bright_delta;
 
+int IFF_COLOR_SELECTION = 0;
+int IFF_COLOR_MESSAGE   = 1;
+int IFF_COLOR_TAGGED    = 2;
+
 // global only to file
 SCP_vector <std::pair<color, color>> Iff_colors;		// AL 1-2-97: Create two IFF colors, regular and bright
 
@@ -249,28 +253,28 @@ void parse_iff_table(const char* filename)
 		if ((optional_string("$Selection Color:")) || (optional_string("$Selection Colour:")))
 		{
 			stuff_int_list(rgb, 3, RAW_INTEGER_TYPE);
-			iff_init_color(rgb[0], rgb[1], rgb[2]);
+			IFF_COLOR_SELECTION = iff_init_color(rgb[0], rgb[1], rgb[2]);
 		}
-		else
-			iff_init_color(0xff, 0xff, 0xff);
+		else if (!Parsing_modular_table)
+			IFF_COLOR_SELECTION = iff_init_color(0xff, 0xff, 0xff);
 
 		// Marks the ship currently saying something
 		if ((optional_string("$Message Color:")) || (optional_string("$Message Colour:")))
 		{
 			stuff_int_list(rgb, 3, RAW_INTEGER_TYPE);
-			iff_init_color(rgb[0], rgb[1], rgb[2]);
+			IFF_COLOR_MESSAGE = iff_init_color(rgb[0], rgb[1], rgb[2]);
 		}
-		else
-			iff_init_color(0x7f, 0x7f, 0x7f);
+		else if (!Parsing_modular_table)
+			IFF_COLOR_MESSAGE = iff_init_color(0x7f, 0x7f, 0x7f);
 
 		// Marks the tagged ships
 		if ((optional_string("$Tagged Color:")) || (optional_string("$Tagged Colour:")))
 		{
 			stuff_int_list(rgb, 3, RAW_INTEGER_TYPE);
-			iff_init_color(rgb[0], rgb[1], rgb[2]);
+			IFF_COLOR_TAGGED = iff_init_color(rgb[0], rgb[1], rgb[2]);
 		}
-		else
-			iff_init_color(0xff, 0xff, 0x00);
+		else if (!Parsing_modular_table)
+			IFF_COLOR_TAGGED = iff_init_color(0xff, 0xff, 0x00);
 
 		// init radar blips colour table
 		int a_bright, a_dim;

--- a/code/iff_defs/iff_defs.h
+++ b/code/iff_defs/iff_defs.h
@@ -17,9 +17,10 @@
 class object;
 
 // Goober5000 - new IFF color system
-#define IFF_COLOR_SELECTION			0
-#define IFF_COLOR_MESSAGE			1
-#define IFF_COLOR_TAGGED			2
+// Now variables so that modular tables can actually affect them. -MageKing17
+extern int IFF_COLOR_SELECTION;
+extern int IFF_COLOR_MESSAGE;
+extern int IFF_COLOR_TAGGED;
 
 enum IFF_hotkey_team { Default = -1, None = 0, Friendly, Hostile };
 


### PR DESCRIPTION
Before this commit, `IFF_COLOR_SELECTION`, `IFF_COLOR_MESSAGE`, and `IFF_COLOR_TAGGED` were hardcoded indices into the `Iff_colors` vector. This could cause problems if any of these three colors were set to the same RGB values (since `iff_init_color()` doesn't create a new entry if the color already exists in the vector), and if a modular table tried to change any of these colors nothing would happen (since it would just create a new entry in `Iff_colors` without doing anything to the hardcoded indices).

This commit instead changes the `#define`s into `extern int`s, and assigns the return value of `iff_init_color()` to those global variables upon parsing the special color values, meaning that any combination of the three can be set to the same color without causing issues, and modular tables can actually modify them.

Potential clutter from unused values in the `Iff_colors` vector is basically unchanged (technically slightly worse if a modular table overrides any of these special colors with a color that doesn't already exist in the vector), but should maybe be looked at in the future.