### PR TITLE
Fix SSM strikes with a variable count.

### DIFF
--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -328,7 +328,7 @@ void ssm_create(object *target, vec3d *start, size_t ssm_index, ssm_firing_info 
 
 	count = Ssm_info[ssm_index].count;
 	if (Ssm_info[ssm_index].max_count != -1 && (Ssm_info[ssm_index].max_count - count) > 0) {
-		count += Random::next(count, Ssm_info[ssm_index].max_count);
+		count = Random::next(count, Ssm_info[ssm_index].max_count);
 	}
 
 	// override in multiplayer


### PR DESCRIPTION
In #2464, a somewhat hard-to-understand equation involving taking the modulo of a random number was replaced with a function that would do those calculations instead. The problem is that the function performed the *entire* formula, while the code it replaced was only operating on the *difference* between the two numbers. Fortunately, this is as easy to fix as changing a `+=` into just an `=`.