### PR TITLE
fix "this ship name is already in use" bug

### DIFF
--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -1085,7 +1085,7 @@ int CShipEditorDlg::update_data(int redraw)
 		m_ship_name.TrimRight(); 
 		ptr = GET_FIRST(&obj_used_list);
 		while (ptr != END_OF_LIST(&obj_used_list)) {
-			if (((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) && (cur_object_index != OBJ_INDEX(ptr))) {
+			if (((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) && (single_ship != ptr->instance)) {
 				str = Ships[ptr->instance].ship_name;
 				if (!stricmp(m_ship_name, str)) {
 					if (bypass_errors)

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
@@ -429,7 +429,7 @@ namespace fso {
 					drop_white_space(_m_ship_name);
 					ptr = GET_FIRST(&obj_used_list);
 					while (ptr != END_OF_LIST(&obj_used_list)) {
-						if (((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) && (_editor->currentObject != OBJ_INDEX(ptr))) {
+						if (((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) && (single_ship != ptr->instance)) {
 							str = Ships[ptr->instance].ship_name;
 							if (!stricmp(_m_ship_name.c_str(), str)) {
 								auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Error,


### PR DESCRIPTION
This rather insidious FRED bug was all down to an improper check for the current ship.  It is possible for multiple objects of different types to be selected at the same time.  If, for example, a waypoint and ship are selected, and the waypoint was selected first, the waypoint will be what `cur_object_index` refers to.  Since the ship is the one and only ship selected, it will be what `single_ship` refers to.  Therefore, to avoid flagging its own ship name as a duplicate, the loop should exclude the single ship, not the current object.

The bug can be reliably triggered by selecting a waypoint, then adding a ship to the selection, then switching the focus to another application and back to FRED.  This finally squashes the bug.