### PR TITLE
allow targeting subsystems on already targeted ship under reticule

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2627,12 +2627,24 @@ void hud_target_in_reticle_old()
 
 	target_obj = hud_reticle_pick_target();
 	if ( target_obj != NULL ) {
+		int oldTargetNum = Player_ai->target_objnum; 
 		set_target_objnum( Player_ai, OBJ_INDEX(target_obj) );
 		hud_shield_hit_reset(target_obj);
 
 		if ( target_obj->type == OBJ_SHIP ) {
-			hud_maybe_set_sorted_turret_subsys(&Ships[target_obj->instance]);
-			hud_restore_subsystem_target(&Ships[target_obj->instance]);
+			ship* shipp = &Ships[target_obj->instance];
+
+			// if the player is attempting to target the same ship under their reticule again
+			// then lets select the nearest subsystem for them.
+			if (Automatically_select_subsystem_underreticle_when_targeting_ship &&
+				Ship_info[shipp->ship_info_index].is_big_or_huge() &&
+				oldTargetNum == Player_ai->target_objnum) {
+				hud_target_subsystem_in_reticle();
+			}
+			else {
+				hud_maybe_set_sorted_turret_subsys(&Ships[target_obj->instance]);
+				hud_restore_subsystem_target(&Ships[target_obj->instance]);
+			}
 		}
 	}
 	else {

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2636,7 +2636,7 @@ void hud_target_in_reticle_old()
 
 			// if the player is attempting to target the same ship under their reticule again
 			// then lets select the nearest subsystem for them.
-			if (Automatically_select_subsystem_under_reticle_when_targeting_ship &&
+			if (Automatically_select_subsystem_under_reticle_when_targeting_same_ship &&
 				Ship_info[shipp->ship_info_index].is_big_or_huge() &&
 				oldTargetNum == Player_ai->target_objnum) {
 				hud_target_subsystem_in_reticle();

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2636,14 +2636,14 @@ void hud_target_in_reticle_old()
 
 			// if the player is attempting to target the same ship under their reticule again
 			// then lets select the nearest subsystem for them.
-			if (Automatically_select_subsystem_underreticle_when_targeting_ship &&
+			if (Automatically_select_subsystem_under_reticle_when_targeting_ship &&
 				Ship_info[shipp->ship_info_index].is_big_or_huge() &&
 				oldTargetNum == Player_ai->target_objnum) {
 				hud_target_subsystem_in_reticle();
 			}
 			else {
-				hud_maybe_set_sorted_turret_subsys(&Ships[target_obj->instance]);
-				hud_restore_subsystem_target(&Ships[target_obj->instance]);
+				hud_maybe_set_sorted_turret_subsys(shipp);
+				hud_restore_subsystem_target(shipp);
 			}
 		}
 	}

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -419,7 +419,7 @@ void parse_mod_table(const char *filename)
 			stuff_boolean(&Dont_automatically_select_turret_when_targeting_ship);
 		}
 
-		if (optional_string("$Auto select subsystem under reticle when targeting ship:")) {
+		if (optional_string("$Auto select subsystem under reticle when targeting same ship:")) {
 			stuff_boolean(&Automatically_select_subsystem_under_reticle_when_targeting_same_ship);
 		}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -48,6 +48,7 @@ bool Enable_external_default_scripts;
 int Default_detail_level;
 bool Full_color_head_anis;
 bool Dont_automatically_select_turret_when_targeting_ship;
+bool Automatically_select_subsystem_underreticle_when_targeting_ship;
 bool Always_reset_selected_wep_on_loadout_open;
 bool Weapons_inherit_parent_collision_group;
 bool Flight_controls_follow_eyepoint_orientation;
@@ -1443,6 +1444,7 @@ void mod_table_reset()
 	Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Dont_automatically_select_turret_when_targeting_ship = false;
+	Automatically_select_subsystem_underreticle_when_targeting_ship = false;
 	Always_reset_selected_wep_on_loadout_open = false;
 	Weapons_inherit_parent_collision_group = false;
 	Flight_controls_follow_eyepoint_orientation = false;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -48,7 +48,7 @@ bool Enable_external_default_scripts;
 int Default_detail_level;
 bool Full_color_head_anis;
 bool Dont_automatically_select_turret_when_targeting_ship;
-bool Automatically_select_subsystem_underreticle_when_targeting_ship;
+bool Automatically_select_subsystem_under_reticle_when_targeting_ship;
 bool Always_reset_selected_wep_on_loadout_open;
 bool Weapons_inherit_parent_collision_group;
 bool Flight_controls_follow_eyepoint_orientation;
@@ -417,6 +417,10 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Don't automatically select a turret when targeting a ship:")) {
 			stuff_boolean(&Dont_automatically_select_turret_when_targeting_ship);
+		}
+
+		if (optional_string("$Auto select subsystem under reticle when targeting ship:")) {
+			stuff_boolean(&Automatically_select_subsystem_under_reticle_when_targeting_ship);
 		}
 
 		if (optional_string("$Supernova hits at zero:")) {
@@ -1444,7 +1448,7 @@ void mod_table_reset()
 	Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Dont_automatically_select_turret_when_targeting_ship = false;
-	Automatically_select_subsystem_underreticle_when_targeting_ship = false;
+	Automatically_select_subsystem_under_reticle_when_targeting_ship = false;
 	Always_reset_selected_wep_on_loadout_open = false;
 	Weapons_inherit_parent_collision_group = false;
 	Flight_controls_follow_eyepoint_orientation = false;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -48,7 +48,7 @@ bool Enable_external_default_scripts;
 int Default_detail_level;
 bool Full_color_head_anis;
 bool Dont_automatically_select_turret_when_targeting_ship;
-bool Automatically_select_subsystem_under_reticle_when_targeting_ship;
+bool Automatically_select_subsystem_under_reticle_when_targeting_same_ship;
 bool Always_reset_selected_wep_on_loadout_open;
 bool Weapons_inherit_parent_collision_group;
 bool Flight_controls_follow_eyepoint_orientation;
@@ -420,7 +420,7 @@ void parse_mod_table(const char *filename)
 		}
 
 		if (optional_string("$Auto select subsystem under reticle when targeting ship:")) {
-			stuff_boolean(&Automatically_select_subsystem_under_reticle_when_targeting_ship);
+			stuff_boolean(&Automatically_select_subsystem_under_reticle_when_targeting_same_ship);
 		}
 
 		if (optional_string("$Supernova hits at zero:")) {
@@ -1448,7 +1448,7 @@ void mod_table_reset()
 	Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Dont_automatically_select_turret_when_targeting_ship = false;
-	Automatically_select_subsystem_under_reticle_when_targeting_ship = false;
+	Automatically_select_subsystem_under_reticle_when_targeting_same_ship = false;
 	Always_reset_selected_wep_on_loadout_open = false;
 	Weapons_inherit_parent_collision_group = false;
 	Flight_controls_follow_eyepoint_orientation = false;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -56,7 +56,7 @@ extern bool Enable_external_default_scripts;
 extern int Default_detail_level;
 extern bool Full_color_head_anis;
 extern bool Dont_automatically_select_turret_when_targeting_ship;
-extern bool Automatically_select_subsystem_under_reticle_when_targeting_ship;
+extern bool Automatically_select_subsystem_under_reticle_when_targeting_same_ship;
 extern bool Always_reset_selected_wep_on_loadout_open;
 extern bool Weapons_inherit_parent_collision_group;
 extern bool Flight_controls_follow_eyepoint_orientation;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -56,7 +56,7 @@ extern bool Enable_external_default_scripts;
 extern int Default_detail_level;
 extern bool Full_color_head_anis;
 extern bool Dont_automatically_select_turret_when_targeting_ship;
-extern bool Automatically_select_subsystem_underreticle_when_targeting_ship;
+extern bool Automatically_select_subsystem_under_reticle_when_targeting_ship;
 extern bool Always_reset_selected_wep_on_loadout_open;
 extern bool Weapons_inherit_parent_collision_group;
 extern bool Flight_controls_follow_eyepoint_orientation;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -56,6 +56,7 @@ extern bool Enable_external_default_scripts;
 extern int Default_detail_level;
 extern bool Full_color_head_anis;
 extern bool Dont_automatically_select_turret_when_targeting_ship;
+extern bool Automatically_select_subsystem_underreticle_when_targeting_ship;
 extern bool Always_reset_selected_wep_on_loadout_open;
 extern bool Weapons_inherit_parent_collision_group;
 extern bool Flight_controls_follow_eyepoint_orientation;


### PR DESCRIPTION
This is a streamlining of functionality, that makes it so one doesn't need to hit a second key to select the subsystem under the reticule.  Instead once you have the capital ship selected, hit Target Under Reticule and it will target a subsystem under the reticule if the feature is enabled and there isn't a new target under the reticule.

