### PR TITLE
allow a ship class's type to be set more than once

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4081,7 +4081,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			ship_type_index = ship_type_name_lookup(cur_flag);
 
 			// set ship class type
-			if ((ship_type_index >= 0) && (sip->class_type < 0))
+			if (ship_type_index >= 0)
 				sip->class_type = ship_type_index;
 
 			// check various ship flags


### PR DESCRIPTION
There was an extra check during ship class parsing that prevented a ship class's type from being set if it had been set already.  This dates back to commit 5f3a6ec7 and was added as a parsing safeguard rather than as part of any modular table checks.  Since the parsing has changed, this extra check is no longer applicable.  Removing the check allows a ship class with a different type to be created using an existing ship class as a template.