### PR TITLE
Scanning is chaos, let's make it sane

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -1587,16 +1587,12 @@ int hud_target_ship_can_be_scanned(ship *shipp)
 	if (shipp->flags[Ship::Ship_Flags::Cargo_revealed])
 		return 0;
 
-	// allow ships with scannable flag set
-	if (shipp->flags[Ship::Ship_Flags::Scannable])
+	// The old behavior treats some ship types as always scannable. The new behavior only checks the ship's Scannable flag.
+	if (shipp->flags[Ship::Ship_Flags::Scannable]) {
 		return 1;
-
-	if (!Use_new_scanning_behavior) {
-		// ignore ships that don't carry cargo
-		if ((sip->class_type < 0) || !(Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::Scannable]))
-			return 0;
-	} else {
-		// In new behavior if we are here then the ship does not have the scannable flag so it's not scannable!
+	} else if (Use_new_scanning_behavior) {
+		return 0;
+	} else if ((sip->class_type < 0) || !(Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::Scannable])) {
 		return 0;
 	}
 

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -1591,9 +1591,14 @@ int hud_target_ship_can_be_scanned(ship *shipp)
 	if (shipp->flags[Ship::Ship_Flags::Scannable])
 		return 1;
 
-	// ignore ships that don't carry cargo
-	if ((sip->class_type < 0) || !(Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::Scannable]))
+	if (!Use_new_scanning_behavior) {
+		// ignore ships that don't carry cargo
+		if ((sip->class_type < 0) || !(Ship_types[sip->class_type].flags[Ship::Type_Info_Flags::Scannable]))
+			return 0;
+	} else {
+		// In new behavior if we are here then the ship does not have the scannable flag so it's not scannable!
 		return 0;
+	}
 
 	return 1;
 }

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -57,7 +57,7 @@ static int Target_static_next;
 static int Target_static_playing;
 sound_handle Target_static_looping = sound_handle::invalid();
 
-int Target_display_cargo;
+bool Target_display_cargo;
 char Cargo_string[256] = "";
 
 #ifndef NDEBUG

--- a/code/hud/hudtargetbox.h
+++ b/code/hud/hudtargetbox.h
@@ -30,7 +30,7 @@ class object;
 #define TBOX_FLASH_SUBSYS			4
 
 extern sound_handle Target_static_looping;
-extern int Target_display_cargo;
+extern bool Target_display_cargo;
 extern char Cargo_string[256];
 
 extern int Target_window_coords[GR_NUM_RESOLUTIONS][4];

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1852 // This is the next available ID
+// #define XSTR_SIZE	1854 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1850 // This is the next available ID
+// #define XSTR_SIZE	1852 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2091,6 +2091,7 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 	}
 
 	shipp->cargo1 = p_objp->cargo1;
+	strcpy_s(shipp->cargo_title, p_objp->cargo_title);
 
 	shipp->arrival_location = p_objp->arrival_location;
 	shipp->arrival_distance = p_objp->arrival_distance;
@@ -2422,6 +2423,7 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 		}
 
 		ptr->subsys_cargo_name = sssp->subsys_cargo_name;
+		strcpy_s(ptr->subsys_cargo_title, sssp->subsys_cargo_title);
 
 		if (sssp->ai_class != SUBSYS_STATUS_NO_CHANGE)
 			ptr->weapons.ai_class = sssp->ai_class;
@@ -3149,6 +3151,11 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 		stuff_string(name, F_NAME, NAME_LENGTH);
 	}
 
+	if (optional_string("$Cargo Title:"))
+	{
+		stuff_string(p_objp->cargo_title, F_NAME, NAME_LENGTH);
+	}
+
 	parse_common_object_data(p_objp);  // get initial conditions and subsys status
 
 	find_and_stuff("$Arrival Location:", &temp, F_NAME, Arrival_location_names, Num_arrival_names, "Arrival Location");
@@ -3762,6 +3769,11 @@ void parse_common_object_data(p_object *p_objp)
 				}
 			}
 			Subsys_status[i].subsys_cargo_name = index;
+		}
+
+		Subsys_status[i].subsys_cargo_title[0] = '\0';
+		if (optional_string("+Cargo Title:")) {
+			stuff_string(Subsys_status[i].subsys_cargo_title, F_NAME, NAME_LENGTH);
 		}
 
 		if (optional_string("+AI Class:"))

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -319,6 +319,7 @@ typedef struct subsys_status {
 	int	secondary_ammo[MAX_SHIP_SECONDARY_BANKS];
 	int	ai_class;
 	int	subsys_cargo_name;
+	char subsys_cargo_title[NAME_LENGTH];
 } subsys_status;
 
 typedef struct texture_replace {
@@ -354,6 +355,7 @@ public:
 	int loadout_team = -1;						// original team, should never be changed after being set!!
 	int	ai_goals = -1;							// sexp of lists of goals that this ship should try and do
 	char	cargo1 = '\0';
+	char cargo_title[NAME_LENGTH] = "";
 	SCP_string team_color_setting;
 
 	int	subsys_index = -1;						// index into subsys_status array

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -449,11 +449,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&HUD_shadows);
 			}
 
-		if (optional_string("$Unify scanning behavior:")) {
-			stuff_boolean(&Use_new_scanning_behavior);
-		}
+			if (optional_string("$Unify scanning behavior:")) {
+				stuff_boolean(&Use_new_scanning_behavior);
+			}
 
-		optional_string("#SEXP SETTINGS");
 			if (optional_string("$Don't show callsigns in the escort list:")) {
 				stuff_boolean(&Dont_show_callsigns_in_escort_list);
 			}

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -151,6 +151,7 @@ bool Randomize_particle_rotation;
 bool Calculate_subsystem_hitpoints_after_parsing;
 bool Disable_internal_loadout_restoration_system;
 bool Contrails_use_absolute_speed;
+bool Use_new_scanning_behavior;
 bool Lua_API_returns_nil_instead_of_invalid_object;
 bool Dont_show_callsigns_in_escort_list;
 bool Fix_scripted_velocity;
@@ -448,6 +449,11 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&HUD_shadows);
 			}
 
+		if (optional_string("$Unify scanning behavior:")) {
+			stuff_boolean(&Use_new_scanning_behavior);
+		}
+
+		optional_string("#SEXP SETTINGS");
 			if (optional_string("$Don't show callsigns in the escort list:")) {
 				stuff_boolean(&Dont_show_callsigns_in_escort_list);
 			}
@@ -1609,6 +1615,7 @@ void mod_table_reset()
 	Calculate_subsystem_hitpoints_after_parsing = false;
 	Disable_internal_loadout_restoration_system = false;
 	Contrails_use_absolute_speed = false;
+	Use_new_scanning_behavior = false;
 	Lua_API_returns_nil_instead_of_invalid_object = false;
 	Dont_show_callsigns_in_escort_list = false;
 	Fix_scripted_velocity = false;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -160,6 +160,7 @@ extern bool Randomize_particle_rotation;
 extern bool Calculate_subsystem_hitpoints_after_parsing;
 extern bool Disable_internal_loadout_restoration_system;
 extern bool Contrails_use_absolute_speed;
+extern bool Use_new_scanning_behavior;
 extern bool Lua_API_returns_nil_instead_of_invalid_object;
 extern bool Dont_show_callsigns_in_escort_list;
 extern bool Fix_scripted_velocity;

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -265,7 +265,8 @@ void player_set_squad_bitmap(player *p, const char *fnamem, bool ismulti);
 // set squadron
 void player_set_squad(player *p, char *squad_name);
 
-int player_inspect_cargo(float frametime, char *outstr);
+bool player_inspect_cargo(float frametime, char *outstr);
+bool better_player_inspect_cargo(float frametime, char* outstr);
 
 extern int use_descent;						// player is using descent-style physics
 extern void toggle_player_object();		// toggles between descent-style ship and player ship

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1701,7 +1701,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 		if ( dot < CARGO_MIN_DOT_TO_REVEAL ) {
 			if (reveal_cargo) {
 				if (cargo_sp->cargo_title[0] != '\0') {
-					sprintf(outstr, XSTR("%s: <unknown>", 1842), cargo_sp->cargo_title);
+					sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
 				} else {
 					strcpy(outstr, XSTR("cargo: <unknown>", 86));
 				}
@@ -1720,7 +1720,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 
 		if (reveal_cargo) {
 			if (cargo_sp->cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: inspecting", 1843), cargo_sp->cargo_title);
+				sprintf(outstr, XSTR("%s: inspecting", 1851), cargo_sp->cargo_title);
 			} else {
 				strcpy(outstr, XSTR("cargo: inspecting", 88));
 			}
@@ -1739,7 +1739,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 	} else {
 		if (reveal_cargo){
 			if (cargo_sp->cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: <unknown>", 1842), cargo_sp->cargo_title);
+				sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
 			} else {
 				strcpy(outstr, XSTR("cargo: <unknown>", 86));
 			}
@@ -1848,7 +1848,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 		if ( (dot < CARGO_MIN_DOT_TO_REVEAL) || (!subsys_in_view) ) {
 			if (reveal_cargo)
 				if (subsys->subsys_cargo_title[0] != '\0') {
-					sprintf(outstr, XSTR("%s: <unknown>", 1842), subsys->subsys_cargo_title);
+					sprintf(outstr, XSTR("%s: <unknown>", 1850), subsys->subsys_cargo_title);
 				} else {
 					strcpy(outstr, XSTR("cargo: <unknown>", 86));
 				}
@@ -1866,7 +1866,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 
 		if (reveal_cargo)
 			if (subsys->subsys_cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: inspecting", 1843), subsys->subsys_cargo_title);
+				sprintf(outstr, XSTR("%s: inspecting", 1851), subsys->subsys_cargo_title);
 			} else {
 				strcpy(outstr, XSTR("cargo: inspecting", 88));
 			}
@@ -1888,7 +1888,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 	} else {
 		if (reveal_cargo)
 			if (subsys->subsys_cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: <unknown>", 1842), subsys->subsys_cargo_title);
+				sprintf(outstr, XSTR("%s: <unknown>", 1850), subsys->subsys_cargo_title);
 			} else {
 				strcpy(outstr, XSTR("cargo: <unknown>", 86));
 			}

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1701,7 +1701,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 		if ( dot < CARGO_MIN_DOT_TO_REVEAL ) {
 			if (reveal_cargo) {
 				if (cargo_sp->cargo_title[0] != '\0') {
-					sprintf(outstr, XSTR("%s: <unknown>", 1817), cargo_sp->cargo_title);
+					sprintf(outstr, XSTR("%s: <unknown>", 1842), cargo_sp->cargo_title);
 				} else {
 					strcpy(outstr, XSTR("cargo: <unknown>", 86));
 				}
@@ -1720,7 +1720,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 
 		if (reveal_cargo) {
 			if (cargo_sp->cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: inspecting", 1818), cargo_sp->cargo_title);
+				sprintf(outstr, XSTR("%s: inspecting", 1843), cargo_sp->cargo_title);
 			} else {
 				strcpy(outstr, XSTR("cargo: inspecting", 88));
 			}
@@ -1739,7 +1739,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 	} else {
 		if (reveal_cargo){
 			if (cargo_sp->cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: <unknown>", 1817), cargo_sp->cargo_title);
+				sprintf(outstr, XSTR("%s: <unknown>", 1842), cargo_sp->cargo_title);
 			} else {
 				strcpy(outstr, XSTR("cargo: <unknown>", 86));
 			}
@@ -1848,7 +1848,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 		if ( (dot < CARGO_MIN_DOT_TO_REVEAL) || (!subsys_in_view) ) {
 			if (reveal_cargo)
 				if (subsys->subsys_cargo_title[0] != '\0') {
-					sprintf(outstr, XSTR("%s: <unknown>", 1817), subsys->subsys_cargo_title);
+					sprintf(outstr, XSTR("%s: <unknown>", 1842), subsys->subsys_cargo_title);
 				} else {
 					strcpy(outstr, XSTR("cargo: <unknown>", 86));
 				}
@@ -1866,7 +1866,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 
 		if (reveal_cargo)
 			if (subsys->subsys_cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: inspecting", 1818), subsys->subsys_cargo_title);
+				sprintf(outstr, XSTR("%s: inspecting", 1843), subsys->subsys_cargo_title);
 			} else {
 				strcpy(outstr, XSTR("cargo: inspecting", 88));
 			}
@@ -1888,7 +1888,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 	} else {
 		if (reveal_cargo)
 			if (subsys->subsys_cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: <unknown>", 1817), subsys->subsys_cargo_title);
+				sprintf(outstr, XSTR("%s: <unknown>", 1842), subsys->subsys_cargo_title);
 			} else {
 				strcpy(outstr, XSTR("cargo: <unknown>", 86));
 			}

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1594,7 +1594,7 @@ int player_process_pending_praise()
 	return 1;
 }
 
-int player_inspect_cap_subsys_cargo(float frametime, char *outstr);
+bool player_inspect_cap_subsys_cargo(float frametime, char *outstr);
 
 /**
  * See if the player should be inspecting cargo, and update progress.
@@ -1602,21 +1602,18 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr);
  * @param frametime	Time since last frame in seconds
  * @param outstr (output parm) holds string that HUD should display
  *
- * @return 1 if player should display outstr on HUD; 0if don't display cargo on HUD
+ * @return true if player should display outstr on HUD; false if don't display cargo on HUD
  */
-int player_inspect_cargo(float frametime, char *outstr)
+bool player_inspect_cargo(float frametime, char *outstr)
 {
 	object		*cargo_objp;
-	ship			*cargo_sp;
+	ship		*cargo_sp;
 	ship_info	*cargo_sip;
-	vec3d		vec_to_cargo;
-	float			dot;
-	int scan_subsys;
 
 	outstr[0] = 0;
 
 	if ( Player_ai->target_objnum < 0 || Player_ship->flags[Ship::Ship_Flags::Cannot_perform_scan] ) {
-		return 0;
+		return false;
 	}
 
 	cargo_objp = &Objects[Player_ai->target_objnum];
@@ -1624,35 +1621,58 @@ int player_inspect_cargo(float frametime, char *outstr)
 	cargo_sp = &Ships[cargo_objp->instance];
 	cargo_sip = &Ship_info[cargo_sp->ship_info_index];
 
-	// Goober5000 - possibly swap cargo scan behavior
-    scan_subsys = cargo_sip->is_huge_ship();
-    if (cargo_sp->flags[Ship::Ship_Flags::Toggle_subsystem_scanning])
-		scan_subsys = !scan_subsys;
-	if (scan_subsys)
-		return player_inspect_cap_subsys_cargo(frametime, outstr);
-
-	// check if target is ship class that can be inspected
-	// MWA -- 1/27/98 -- added fighters/bombers to this list.  For multiplayer, we
-	// want to show callsign of player
-	// G5K -- 10/20/08 -- moved the callsign code into hud_stuff_ship_callsign, where
-	// it makes more sense
-
-	// scannable cargo behaves differently.  Scannable cargo is either "scanned" or "not scanned".  This flag
-	// can be set on any ship.  Any ship with this set won't have "normal" cargo behavior
-	if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) ) {
-        if (!(cargo_sip->flags[Ship::Info_Flags::Cargo] || cargo_sip->flags[Ship::Info_Flags::Transport])) {
-			return 0;
+	if (Use_new_scanning_behavior) {
+		// If this flag is active, no matter the ship class, we do subsystem scanning
+		if (cargo_sp->flags[Ship::Ship_Flags::Toggle_subsystem_scanning]) {
+			return player_inspect_cap_subsys_cargo(frametime, outstr);
 		}
+	} else {
+		// Goober5000 - possibly swap cargo scan behavior
+		int scan_subsys = cargo_sip->is_huge_ship();
+		if (cargo_sp->flags[Ship::Ship_Flags::Toggle_subsystem_scanning])
+			scan_subsys = !scan_subsys;
+		if (scan_subsys)
+			return player_inspect_cap_subsys_cargo(frametime, outstr);
+	}
+
+	if (Use_new_scanning_behavior) {
+		// If this flag is inactive then the ship cannot be scanned at all
+		if (!(cargo_sp->flags[Ship::Ship_Flags::Scannable])) {
+			return false;
+		}
+	} else {
+		// check if target is ship class that can be inspected
+		// MWA -- 1/27/98 -- added fighters/bombers to this list.  For multiplayer, we
+		// want to show callsign of player
+		// G5K -- 10/20/08 -- moved the callsign code into hud_stuff_ship_callsign, where
+		// it makes more sense
+
+		// scannable cargo behaves differently.  Scannable cargo is either "scanned" or "not scanned".  This flag
+		// can be set on any ship.  Any ship with this set won't have "normal" cargo behavior
+		if (!(cargo_sp->flags[Ship::Ship_Flags::Scannable])) {
+			if (!(cargo_sip->flags[Ship::Info_Flags::Cargo] || cargo_sip->flags[Ship::Info_Flags::Transport])) {
+				return false;
+			}
+		}
+	}
+
+	// Whether or not we are scanning in a mode that will reveal the cargo contents
+	bool reveal_cargo = false;
+	if (Use_new_scanning_behavior && !(cargo_sp->flags[Ship::Ship_Flags::No_scanned_cargo])) {
+		reveal_cargo = true;
+	} else if (!(cargo_sp->flags[Ship::Ship_Flags::Scannable])) {
+		reveal_cargo = true;
 	}
 
 	// if cargo is already revealed
 	if ( cargo_sp->flags[Ship::Ship_Flags::Cargo_revealed] ) {
-		if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) ) {
+		if (reveal_cargo) {
 			auto cargo_name = (cargo_sp->cargo1 & CARGO_INDEX_MASK) == 0
 				? XSTR("Nothing", 1674)
 				: Cargo_names[cargo_sp->cargo1 & CARGO_INDEX_MASK];
-            Assert(cargo_sip->flags[Ship::Info_Flags::Cargo] || cargo_sip->flags[Ship::Info_Flags::Transport]);
-
+			//Why was this assert here? I'm not sure it makes much sense because any ship can be scanned and have cargo revealed...
+            //Assert(cargo_sip->flags[Ship::Info_Flags::Cargo] || cargo_sip->flags[Ship::Info_Flags::Transport]);
+			
 			if ( cargo_name[0] == '#' ) {
 				sprintf(outstr, XSTR("passengers: %s", 83), cargo_name+1 );
 			} else {
@@ -1666,7 +1686,7 @@ int player_inspect_cargo(float frametime, char *outstr)
 		// are in the process of scanning
 		Player->cargo_inspect_time = 0;
 
-		return 1;
+		return true;
 	}
 
 	// see if player is within inspection range
@@ -1675,18 +1695,19 @@ int player_inspect_cargo(float frametime, char *outstr)
 	scan_dist *= player_sip->scanning_range_multiplier;
 
 	if ( Player_ai->current_target_distance < scan_dist ) {
+		vec3d vec_to_cargo;
 
 		// check if player is facing cargo, do not proceed with inspection if not
 		vm_vec_normalized_dir(&vec_to_cargo, &cargo_objp->pos, &Player_obj->pos);
-		dot = vm_vec_dot(&vec_to_cargo, &Player_obj->orient.vec.fvec);
+		float dot = vm_vec_dot(&vec_to_cargo, &Player_obj->orient.vec.fvec);
 		if ( dot < CARGO_MIN_DOT_TO_REVEAL ) {
-			if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) )
+			if (reveal_cargo)
 				strcpy(outstr,XSTR( "cargo: <unknown>", 86));
 			else
 				strcpy(outstr,XSTR( "not scanned", 87));
 			hud_targetbox_end_flash(TBOX_FLASH_CARGO);
 			Player->cargo_inspect_time = 0;
-			return 1;
+			return true;
 		}
 
 		// player is facing the cargo, and within range, so proceed with inspection
@@ -1694,7 +1715,7 @@ int player_inspect_cargo(float frametime, char *outstr)
 			Player->cargo_inspect_time += (int)std::lround(frametime*1000);
 		}
 
-		if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) )
+		if (reveal_cargo)
 			strcpy(outstr,XSTR( "cargo: inspecting", 88));
 		else
 			strcpy(outstr,XSTR( "scanning", 89));
@@ -1708,48 +1729,59 @@ int player_inspect_cargo(float frametime, char *outstr)
 			Player->cargo_inspect_time = 0;
 		}
 	} else {
-		if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) )
+		if (reveal_cargo)
 			strcpy(outstr,XSTR( "cargo: <unknown>", 86));
 		else
 			strcpy(outstr,XSTR( "not scanned", 87));
 	}
 
-	return 1;
+	return true;
 }
 
 /**
  * @return 1 if player should display outstr on HUD; 0 if don't display cargo on HUD
  */
-int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
+bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 {
 	object		*cargo_objp;
-	ship			*cargo_sp;
+	ship		*cargo_sp;
 	ship_info	*cargo_sip;
-	vec3d		vec_to_cargo;
-	float			dot;
 	ship_subsys	*subsys;
 
 	outstr[0] = 0;
 	subsys = Player_ai->targeted_subsys;
 
 	if ( subsys == NULL || Player_ship->flags[Ship::Ship_Flags::Cannot_perform_scan] ) {
-		return 0;
-	} 
+		return false;
+	}
 
 	cargo_objp = &Objects[Player_ai->target_objnum];
 	Assert(cargo_objp->type == OBJ_SHIP);
 	cargo_sp = &Ships[cargo_objp->instance];
 	cargo_sip = &Ship_info[cargo_sp->ship_info_index];
 
+	// If we're using the new scanning behavior then we have to check that the ship is actually scannable first
+	if (Use_new_scanning_behavior && !(cargo_sp->flags[Ship::Ship_Flags::Scannable])) {
+		return false;
+	}
+
 	// don't do any sort of scanning thing unless capship has a non-"nothing" cargo
 	// this compensates for changing the "no display" index from -1 to 0
 	if (subsys->subsys_cargo_name == 0) {
-		return 0;
+		return false;
+	}
+
+	// Whether or not we are scanning in a mode that will reveal the cargo contents
+	bool reveal_cargo = false;
+	if (Use_new_scanning_behavior && !(cargo_sp->flags[Ship::Ship_Flags::No_scanned_cargo])) {
+		reveal_cargo = true;
+	} else if (!(cargo_sp->flags[Ship::Ship_Flags::Scannable])) {
+		reveal_cargo = true;
 	}
 
 	// if cargo is already revealed
 	if (subsys->flags[Ship::Subsystem_Flags::Cargo_revealed]) {
-		if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) ) {
+		if (reveal_cargo) {
 			auto cargo_name = (subsys->subsys_cargo_name & CARGO_INDEX_MASK) == 0
 				? XSTR("Nothing", 1674)
 				: Cargo_names[subsys->subsys_cargo_name & CARGO_INDEX_MASK];
@@ -1767,7 +1799,7 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 		// are in the process of scanning
 		Player->cargo_inspect_time = 0;
 
-		return 1;
+		return true;
 	}
 
 	// see if player is within inspection range [ok for subsys]
@@ -1789,20 +1821,22 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 	scan_dist *= player_sip->scanning_range_multiplier;
 
 	if ( Player_ai->current_target_distance < scan_dist ) {
+		vec3d vec_to_cargo;
+
 		// check if player is facing cargo, do not proceed with inspection if not
 		vm_vec_normalized_dir(&vec_to_cargo, &subsys_pos, &Player_obj->pos);
-		dot = vm_vec_dot(&vec_to_cargo, &Player_obj->orient.vec.fvec);
+		float dot = vm_vec_dot(&vec_to_cargo, &Player_obj->orient.vec.fvec);
 		int hud_targetbox_subsystem_in_view(object *target_objp, int *sx, int *sy);
 		subsys_in_view = hud_targetbox_subsystem_in_view(cargo_objp, &x, &y);
 
 		if ( (dot < CARGO_MIN_DOT_TO_REVEAL) || (!subsys_in_view) ) {
-			if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) )
+			if (reveal_cargo)
 				strcpy(outstr,XSTR( "cargo: <unknown>", 86));
 			else
 				strcpy(outstr,XSTR( "not scanned", 87));
 			hud_targetbox_end_flash(TBOX_FLASH_CARGO);
 			Player->cargo_inspect_time = 0;
-			return 1;
+			return true;
 		}
 
 		// player is facing the cargo, and within range, so proceed with inspection
@@ -1810,7 +1844,7 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 			Player->cargo_inspect_time += (int)std::lround(frametime*1000);
 		}
 
-		if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) )
+		if (reveal_cargo)
 			strcpy(outstr,XSTR( "cargo: inspecting", 88));
 		else
 			strcpy(outstr,XSTR( "scanning", 89));
@@ -1828,13 +1862,13 @@ int player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 			Player->cargo_inspect_time = 0;
 		}
 	} else {
-		if ( !(cargo_sp->flags[Ship::Ship_Flags::Scannable]) )
+		if (reveal_cargo)
 			strcpy(outstr,XSTR( "cargo: <unknown>", 86));
 		else
 			strcpy(outstr,XSTR( "not scanned", 87));
 	}
 
-	return 1;
+	return true;
 }
 
 

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1668,7 +1668,11 @@ bool player_inspect_cargo(float frametime, char *outstr)
             //Assert(cargo_sip->flags[Ship::Info_Flags::Cargo] || cargo_sip->flags[Ship::Info_Flags::Transport]);
 
 			if (cargo_sp->cargo_title[0] != '\0') {
-				sprintf(outstr, "%s: %s", cargo_sp->cargo_title, cargo_name);
+				if (cargo_sp->cargo_title[0] == '#') {
+					sprintf(outstr, "%s", cargo_sp->cargo_title, cargo_name);
+				} else {
+					sprintf(outstr, "%s: %s", cargo_sp->cargo_title, cargo_name);
+				}
 			} else {
 				if (cargo_name[0] == '#') {
 					sprintf(outstr, XSTR("passengers: %s", 83), cargo_name + 1);
@@ -1701,7 +1705,11 @@ bool player_inspect_cargo(float frametime, char *outstr)
 		if ( dot < CARGO_MIN_DOT_TO_REVEAL ) {
 			if (reveal_cargo) {
 				if (cargo_sp->cargo_title[0] != '\0') {
-					sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
+					if (cargo_sp->cargo_title[0] == '#') {
+						sprintf(outstr, XSTR("<unknown>", 1850), cargo_sp->cargo_title);
+					} else {
+						sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
+					}
 				} else {
 					strcpy(outstr, XSTR("cargo: <unknown>", 86));
 				}
@@ -1720,7 +1728,11 @@ bool player_inspect_cargo(float frametime, char *outstr)
 
 		if (reveal_cargo) {
 			if (cargo_sp->cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: inspecting", 1851), cargo_sp->cargo_title);
+				if (cargo_sp->cargo_title[0] == '#') {
+					sprintf(outstr, XSTR("inspecting", 1851), cargo_sp->cargo_title);
+				} else {
+					sprintf(outstr, XSTR("%s: inspecting", 1851), cargo_sp->cargo_title);
+				}
 			} else {
 				strcpy(outstr, XSTR("cargo: inspecting", 88));
 			}
@@ -1739,7 +1751,11 @@ bool player_inspect_cargo(float frametime, char *outstr)
 	} else {
 		if (reveal_cargo){
 			if (cargo_sp->cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
+				if (cargo_sp->cargo_title[0] == '#') {
+					sprintf(outstr, XSTR("<unknown>", 1850), cargo_sp->cargo_title);
+				} else {
+					sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
+				}
 			} else {
 				strcpy(outstr, XSTR("cargo: <unknown>", 86));
 			}

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1669,7 +1669,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 
 			if (cargo_sp->cargo_title[0] != '\0') {
 				if (cargo_sp->cargo_title[0] == '#') {
-					sprintf(outstr, "%s", cargo_sp->cargo_title, cargo_name);
+					sprintf(outstr, "%s", cargo_name);
 				} else {
 					sprintf(outstr, "%s: %s", cargo_sp->cargo_title, cargo_name);
 				}
@@ -1706,7 +1706,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 			if (reveal_cargo) {
 				if (cargo_sp->cargo_title[0] != '\0') {
 					if (cargo_sp->cargo_title[0] == '#') {
-						sprintf(outstr, XSTR("<unknown>", 1850), cargo_sp->cargo_title);
+						sprintf(outstr, XSTR("<unknown>", 1852));
 					} else {
 						sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
 					}
@@ -1729,7 +1729,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 		if (reveal_cargo) {
 			if (cargo_sp->cargo_title[0] != '\0') {
 				if (cargo_sp->cargo_title[0] == '#') {
-					sprintf(outstr, XSTR("inspecting", 1851), cargo_sp->cargo_title);
+					sprintf(outstr, XSTR("inspecting", 1853));
 				} else {
 					sprintf(outstr, XSTR("%s: inspecting", 1851), cargo_sp->cargo_title);
 				}
@@ -1752,7 +1752,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 		if (reveal_cargo){
 			if (cargo_sp->cargo_title[0] != '\0') {
 				if (cargo_sp->cargo_title[0] == '#') {
-					sprintf(outstr, XSTR("<unknown>", 1850), cargo_sp->cargo_title);
+					sprintf(outstr, XSTR("<unknown>", 1852));
 				} else {
 					sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
 				}
@@ -1815,7 +1815,11 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 				? XSTR("Nothing", 1674)
 				: Cargo_names[subsys->subsys_cargo_name & CARGO_INDEX_MASK];
 			if (subsys->subsys_cargo_title[0] != '\0') {
-				sprintf(outstr, "%s: %s", subsys->subsys_cargo_title, cargo_name);
+				if (subsys->subsys_cargo_title[0] == '#') {
+					sprintf(outstr, "%s", cargo_name);
+				} else {
+					sprintf(outstr, "%s: %s", subsys->subsys_cargo_title, cargo_name);
+				}
 			} else {
 				if (cargo_name[0] == '#') {
 					sprintf(outstr, XSTR("passengers: %s", 83), cargo_name + 1);
@@ -1864,7 +1868,11 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 		if ( (dot < CARGO_MIN_DOT_TO_REVEAL) || (!subsys_in_view) ) {
 			if (reveal_cargo)
 				if (subsys->subsys_cargo_title[0] != '\0') {
-					sprintf(outstr, XSTR("%s: <unknown>", 1850), subsys->subsys_cargo_title);
+					if (subsys->subsys_cargo_title[0] == '#') {
+						sprintf(outstr, XSTR("<unknown>", 1852));
+					} else {
+						sprintf(outstr, XSTR("%s: <unknown>", 1850), subsys->subsys_cargo_title);
+					}
 				} else {
 					strcpy(outstr, XSTR("cargo: <unknown>", 86));
 				}
@@ -1882,7 +1890,11 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 
 		if (reveal_cargo)
 			if (subsys->subsys_cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: inspecting", 1851), subsys->subsys_cargo_title);
+				if (subsys->subsys_cargo_title[0] == '#') {
+					sprintf(outstr, XSTR("inspecting", 1853));
+				} else {
+					sprintf(outstr, XSTR("%s: inspecting", 1851), subsys->subsys_cargo_title);
+				}
 			} else {
 				strcpy(outstr, XSTR("cargo: inspecting", 88));
 			}
@@ -1904,7 +1916,11 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 	} else {
 		if (reveal_cargo)
 			if (subsys->subsys_cargo_title[0] != '\0') {
-				sprintf(outstr, XSTR("%s: <unknown>", 1850), subsys->subsys_cargo_title);
+				if (subsys->subsys_cargo_title[0] == '#') {
+					sprintf(outstr, XSTR("<unknown>", 1852));
+				} else {
+					sprintf(outstr, XSTR("%s: <unknown>", 1850), subsys->subsys_cargo_title);
+				}
 			} else {
 				strcpy(outstr, XSTR("cargo: <unknown>", 86));
 			}

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -1706,7 +1706,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 			if (reveal_cargo) {
 				if (cargo_sp->cargo_title[0] != '\0') {
 					if (cargo_sp->cargo_title[0] == '#') {
-						sprintf(outstr, XSTR("<unknown>", 1852));
+						strcpy(outstr, XSTR("<unknown>", 1852));
 					} else {
 						sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
 					}
@@ -1729,7 +1729,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 		if (reveal_cargo) {
 			if (cargo_sp->cargo_title[0] != '\0') {
 				if (cargo_sp->cargo_title[0] == '#') {
-					sprintf(outstr, XSTR("inspecting", 1853));
+					strcpy(outstr, XSTR("inspecting", 1853));
 				} else {
 					sprintf(outstr, XSTR("%s: inspecting", 1851), cargo_sp->cargo_title);
 				}
@@ -1752,7 +1752,7 @@ bool player_inspect_cargo(float frametime, char *outstr)
 		if (reveal_cargo){
 			if (cargo_sp->cargo_title[0] != '\0') {
 				if (cargo_sp->cargo_title[0] == '#') {
-					sprintf(outstr, XSTR("<unknown>", 1852));
+					strcpy(outstr, XSTR("<unknown>", 1852));
 				} else {
 					sprintf(outstr, XSTR("%s: <unknown>", 1850), cargo_sp->cargo_title);
 				}
@@ -1869,7 +1869,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 			if (reveal_cargo)
 				if (subsys->subsys_cargo_title[0] != '\0') {
 					if (subsys->subsys_cargo_title[0] == '#') {
-						sprintf(outstr, XSTR("<unknown>", 1852));
+						strcpy(outstr, XSTR("<unknown>", 1852));
 					} else {
 						sprintf(outstr, XSTR("%s: <unknown>", 1850), subsys->subsys_cargo_title);
 					}
@@ -1891,7 +1891,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 		if (reveal_cargo)
 			if (subsys->subsys_cargo_title[0] != '\0') {
 				if (subsys->subsys_cargo_title[0] == '#') {
-					sprintf(outstr, XSTR("inspecting", 1853));
+					strcpy(outstr, XSTR("inspecting", 1853));
 				} else {
 					sprintf(outstr, XSTR("%s: inspecting", 1851), subsys->subsys_cargo_title);
 				}
@@ -1917,7 +1917,7 @@ bool player_inspect_cap_subsys_cargo(float frametime, char *outstr)
 		if (reveal_cargo)
 			if (subsys->subsys_cargo_title[0] != '\0') {
 				if (subsys->subsys_cargo_title[0] == '#') {
-					sprintf(outstr, XSTR("<unknown>", 1852));
+					strcpy(outstr, XSTR("<unknown>", 1852));
 				} else {
 					sprintf(outstr, XSTR("%s: <unknown>", 1850), subsys->subsys_cargo_title);
 				}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7491,6 +7491,7 @@ void ship_subsys::clear()
 	disruption_timestamp = timestamp(0);
 
 	subsys_cargo_name = 0;
+	subsys_cargo_title[0] = '\0';
 	time_subsys_cargo_revealed = 0;
 
 	triggered_rotation_index = -1;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -621,6 +621,7 @@ ship_flag_name Ship_flag_names[] = {
 	{ Ship_Flags::No_builtin_messages,			"no-builtin-messages"},
 	{ Ship_Flags::Scramble_messages,			"scramble-messages"},
 	{ Ship_Flags::Maneuver_despite_engines,		"maneuver-despite-engines" },
+	{ Ship_Flags::No_scanned_cargo,             "no-scanned-cargo"},
 	{ Ship_Flags::EMP_doesnt_scramble_messages,	"emp-doesn't-scramble-messages" },
 };
 
@@ -660,6 +661,7 @@ ship_flag_description Ship_flag_descriptions[] = {
 	{ Ship_Flags::No_builtin_messages,			"Ship will not send any persona messages."},
 	{ Ship_Flags::Scramble_messages,			"All messages sent from or received by this ship will appear scrambled, as if the ship had been hit by an EMP." },
 	{ Ship_Flags::Maneuver_despite_engines,		"Ship can maneuver even if its engines are disabled or disrupted" },
+	{ Ship_Flags::No_scanned_cargo,             "Ship cargo will never be revealed and will instead only show scanned or not scanned."},
 	{ Ship_Flags::EMP_doesnt_scramble_messages, "EMP does not affect whether messages appear scrambled when sent from or received by this ship." },
 };
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -661,7 +661,7 @@ ship_flag_description Ship_flag_descriptions[] = {
 	{ Ship_Flags::No_builtin_messages,			"Ship will not send any persona messages."},
 	{ Ship_Flags::Scramble_messages,			"All messages sent from or received by this ship will appear scrambled, as if the ship had been hit by an EMP." },
 	{ Ship_Flags::Maneuver_despite_engines,		"Ship can maneuver even if its engines are disabled or disrupted" },
-	{ Ship_Flags::No_scanned_cargo,             "Ship cargo will never be revealed and will instead only show scanned or not scanned."},
+	{ Ship_Flags::No_scanned_cargo,             "Ship cargo will never be revealed and will instead only show scanned or not scanned. Only available if using New Scanning Behavior in game_settings.tbl."},
 	{ Ship_Flags::EMP_doesnt_scramble_messages, "EMP does not affect whether messages appear scrambled when sent from or received by this ship." },
 };
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -404,6 +404,7 @@ public:
 	int disruption_timestamp;							// time at which subsystem isn't disrupted
 
 	int subsys_cargo_name;			// cap ship cargo on subsys
+	char subsys_cargo_title[NAME_LENGTH];  // cap ship cargo title (IE: Cargo: or Passengers:)
 	fix time_subsys_cargo_revealed;	// added by Goober5000
 
 	int triggered_rotation_index;		//the actual currently running animation and assosiated states
@@ -552,6 +553,7 @@ public:
 	ubyte	pre_death_explosion_happened;		// If set, it means the 4 or 5 smaller explosions 
 	ubyte wash_killed;
 	char	cargo1;
+	char cargo_title[NAME_LENGTH];
 
 	// ship wing status info
 	char	wing_status_wing_index;			// wing index (0-4) in wingman status gauge

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -140,6 +140,7 @@ namespace Ship {
 		No_targeting_limits,				//MjnMixael -- Ship is always targetable regardless of AWACS or targeting range limits
 		Maneuver_despite_engines,	// Goober5000 - ship can move even when engines are disabled or disrupted
 		Force_primary_unlinking,	// plieblang - turned on when the ship is under good-primary-time
+		No_scanned_cargo,                 //MjnMixael -- The cargo will never be revealed, instead always returning "Scanned" or "Not Scanned"
 
 		NUM_VALUES
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1808,6 +1808,17 @@ int CFred_mission_save::save_common_object_data(object *objp, ship *shipp)
 			fout_ext(NULL, "%s", Cargo_names[ptr->subsys_cargo_name]);
 		}
 
+		if (Mission_save_format != FSO_FORMAT_RETAIL) {
+			if (ptr->subsys_cargo_title[0] != '\0') {
+				if (optional_string_fred("+Cargo Title:", "$Name:", "+Subsystem:")) {
+					parse_comments();
+				} else {
+					fout("\n+Cargo Title:");
+				}
+				fout_ext(nullptr, "%s", ptr->subsys_cargo_title);
+			}
+		}
+
 		if (ptr->system_info->type == SUBSYSTEM_TURRET)
 			save_turret_info(ptr, SHIP_INDEX(shipp));
 
@@ -3600,6 +3611,17 @@ int CFred_mission_save::save_objects()
 		required_string_fred("$Cargo 1:");
 		parse_comments();
 		fout_ext(" ", "%s", Cargo_names[shipp->cargo1]);
+
+		if (Mission_save_format != FSO_FORMAT_RETAIL) {
+			if (shipp->cargo_title[0] != '\0') {
+				if (optional_string_fred("$Cargo Title:", "$Name:")) {
+					parse_comments();
+				} else {
+					fout("\n$Cargo Title:");
+				}
+				fout_ext(nullptr, "%s", shipp->cargo_title);
+			}
+		}
 
 		save_common_object_data(&Objects[shipp->objnum], &Ships[i]);
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1590,6 +1590,17 @@ int CFred_mission_save::save_common_object_data(object* objp, ship* shipp)
 			fout_ext(NULL, "%s", Cargo_names[ptr->subsys_cargo_name]);
 		}
 
+		if (save_format != MissionFormat::RETAIL) {
+			if (ptr->subsys_cargo_title[0] != '\0') {
+				if (optional_string_fred("+Cargo Title:", "$Name:", "+Subsystem:")) {
+					parse_comments();
+				} else {
+					fout("\n+Cargo Title:");
+				}
+				fout_ext(nullptr, "%s", ptr->subsys_cargo_title);
+			}
+		}
+
 		if (ptr->system_info->type == SUBSYSTEM_TURRET) {
 			save_turret_info(ptr, SHIP_INDEX(shipp));
 		}
@@ -3518,6 +3529,17 @@ int CFred_mission_save::save_objects()
 		required_string_fred("$Cargo 1:");
 		parse_comments();
 		fout_ext(" ", "%s", Cargo_names[shipp->cargo1]);
+
+		if (save_format != MissionFormat::RETAIL) {
+			if (shipp->cargo_title[0] != '\0') {
+				if (optional_string_fred("$Cargo Title:", "$Name:")) {
+					parse_comments();
+				} else {
+					fout("\n$Cargo Title:");
+				}
+				fout_ext(nullptr, "%s", shipp->cargo_title);
+			}
+		}
 
 		save_common_object_data(&Objects[shipp->objnum], &Ships[i]);
 


### PR DESCRIPTION
Are you tired of remembering whether you need Scannable to get cargo names to appear? Or maybe you're sick of Toggle Subsystem Scanning having different effects based on the ship type? Did you once want to have a mission where a transport wasn't scannable at all? Then have I got the PR for you!

This PR introduces a game_settings flag to unify scanning behavior. When enabled, all ships, no matter the ship class, will react the same way to all the scanning ship flags.

1) They are not scannable by default
2) Settings Scannable makes them.. uh.. scannable and cargo will be revealed by default
3) A new flag available with alter-ship-flag, called no-scanned-cargo, changes the behavior to scanned/unscanned instead of revealing the cargo
4) Toggle Subsystem Scanning must be enabled to swap scanning mode into subsystem scanning mode and works for all ship types

ADDITIONALLY: This PR fixes #5922 by allowing a mission file to define $Cargo Title: (or +Cargo Title: for subsystems). When this is set instead of Cargo: ITEM or Passengers: ITEM, the string will concatenate TITLE: ITEM. Note that I didn't not add FRED UI support because I'm within a couple months of diving into qtFRED in earnest, so I thought I'd save the effort. FRED will correctly read and save the Title values, though.