### PR TITLE
allow invalid arguments to be nil

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -150,6 +150,7 @@ bool Randomize_particle_rotation;
 bool Calculate_subsystem_hitpoints_after_parsing;
 bool Disable_internal_loadout_restoration_system;
 bool Contrails_use_absolute_speed;
+bool Lua_API_returns_nil_instead_of_invalid_object;
 
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Game.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
@@ -295,6 +296,11 @@ void parse_mod_table(const char *filename)
 
 		if (optional_string("$Disable FSO Internal Loadout Restoration System:")) {
 			stuff_boolean(&Disable_internal_loadout_restoration_system);
+		}
+
+		if (optional_string("$Lua API returns nil instead of invalid object:")) {
+			stuff_boolean(&Lua_API_returns_nil_instead_of_invalid_object);
+			mprintf(("Game Settings Table: Lua API returns nil instead of invalid object: %s\n", Lua_API_returns_nil_instead_of_invalid_object ? "yes" : "no"));
 		}
 
 		optional_string("#LOCALIZATION SETTINGS");
@@ -1557,6 +1563,7 @@ void mod_table_reset()
 	Calculate_subsystem_hitpoints_after_parsing = false;
 	Disable_internal_loadout_restoration_system = false;
 	Contrails_use_absolute_speed = false;
+	Lua_API_returns_nil_instead_of_invalid_object = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -159,6 +159,7 @@ extern bool Randomize_particle_rotation;
 extern bool Calculate_subsystem_hitpoints_after_parsing;
 extern bool Disable_internal_loadout_restoration_system;
 extern bool Contrails_use_absolute_speed;
+extern bool Lua_API_returns_nil_instead_of_invalid_object;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -222,6 +222,26 @@ const char* ade_get_type_string(lua_State* L, int argnum);
  */
 bool ade_is_internal_type(const char* typeName);
 
+template <typename T, typename = int>
+struct ade_is_valid : std::false_type
+{
+	static inline bool get(const T& /*t*/)
+	{
+		//Things without an isValid are always considered valid from this point of view.
+		return true;
+	}
+};
+
+template <typename T>
+struct ade_is_valid <T, decltype((void)(std::declval<T>().isValid()), 0)> : std::true_type
+{
+	static inline bool get(const T& t)
+	{
+		//Things with an isValid return that.
+		return t.isValid();
+	}
+};
+
 /**
  * @brief Converts an object index to something that can be used with ade_set_args.
  *

--- a/code/scripting/ade_args.h
+++ b/code/scripting/ade_args.h
@@ -366,13 +366,20 @@ int ade_set_args(lua_State* L, const char* fmt, Args&&... args)
 }
 
 /**
- * @brief Return a value in error
+ * @brief Return a value in error.  Normally this behaves just like ade_set_args, but it can be configured to return nil instead.
  *
  * Should be used if the value is not valid
  *
  * @ingroup ade_api
  */
-#define ade_set_error ade_set_args
+template <typename... Args>
+int ade_set_error(lua_State* L, const char* fmt, Args&&... args)
+{
+	if (Lua_API_returns_nil_instead_of_invalid_object)
+		return 0;	// ADE_RETURN_NIL
+	else
+		return ade_set_args(L, fmt, std::forward<Args>(args)...);
+}
 }
 
 #endif //FS2_OPEN_ADE_ARGS_H

--- a/code/scripting/ade_args.h
+++ b/code/scripting/ade_args.h
@@ -305,6 +305,17 @@ template<typename T>
 void set_single_arg(lua_State* L, char fmt, ade_odata_setter<T>&& od)
 {
 	Assertion(fmt == 'o', "Invalid format character '%c' for object type!", fmt);
+
+	if (Lua_API_returns_nil_instead_of_invalid_object) {
+		// If the underlying type has an isValid, it'll be evaluated; otherwise it'll be always true.
+		bool isValid = ade_is_valid<T>::get(od.value);
+
+		if (!isValid) {
+			lua_pushnil(L);
+			return;
+		}
+	}
+
 	// Use the common helper method
 	luacpp::convert::pushValue(L, std::forward<ade_odata_setter<T>>(od));
 }
@@ -373,7 +384,7 @@ int ade_set_args(lua_State* L, const char* fmt, Args&&... args)
  * @ingroup ade_api
  */
 template <typename... Args>
-int ade_set_error(lua_State* L, const char* fmt, Args&&... args)
+inline int ade_set_error(lua_State* L, const char* fmt, Args&&... args)
 {
 	if (Lua_API_returns_nil_instead_of_invalid_object)
 		return 0;	// ADE_RETURN_NIL

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -590,6 +590,16 @@ ADE_FUNC(isEngineVersionAtLeast,
 	return ade_set_args(L, "b", gameversion::check_at_least(version));
 }
 
+ADE_FUNC(usesInvalidInsteadOfNil,
+	l_Base,
+	nullptr,
+	"Checks if the '$Lua API returns nil instead of invalid object:' option is set in game_settings.tbl.",
+	"boolean",
+	"true if the option is set, false otherwise")
+{
+	return Lua_API_returns_nil_instead_of_invalid_object ? ADE_RETURN_TRUE : ADE_RETURN_FALSE;
+}
+
 ADE_FUNC(getCurrentLanguage,
 		 l_Base,
 		 nullptr,


### PR DESCRIPTION
A design choice very early in FSO's scripting development established that invalid results return invalid objects.  By using a game_settings.tbl flag, this allows invalid results to return nil instead.

~~This also standardizes on `isValid()` (versus capitalized versions) and makes validity member functions `const`.~~  See #6009 

Thanks to Lafiel for help with the template stuff.