### PR TITLE
Fix broken collision pair caching

### DIFF
--- a/code/globalincs/globals.h
+++ b/code/globalincs/globals.h
@@ -72,6 +72,7 @@
 #define MAX_POLYGON_MODELS  300
 
 // object.h
+//If this value exceeds 2^16-1, this will break collision pair caching as is. Proceed with caution.
 #define MAX_OBJECTS			5000	//Increased from 3500 to 5000 in 2022	
 
 // from weapon.h (and beam.h)

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -27,6 +27,8 @@ int Num_pairs_checked = 0;
 
 SCP_vector<int> Collision_sort_list;
 
+static_assert(1 << collision_cache_bitshift > MAX_OBJECTS, "Collision pair caching currently relies on the highest possible objnum being less than 2^collision_cache_bitshift.");
+
 class collider_pair
 {
 public:
@@ -867,7 +869,7 @@ void obj_collide_pair(object *A, object *B)
     }
 
     bool valid = false;
-    uint key = (OBJ_INDEX(A) << 12) + OBJ_INDEX(B);
+    uint key = (OBJ_INDEX(A) << collision_cache_bitshift) + OBJ_INDEX(B);
 
     collider_pair* collision_info = &Collision_cached_pairs[key];
 

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -43,6 +43,8 @@ struct collision_info_struct {
 #define MIN_LANDING_SOUND_VEL			2.0f
 #define LANDING_POS_OFFSET				0.05f
 
+constexpr uint32_t collision_cache_bitshift = 16;
+
 //===============================================================================
 // GENERAL COLLISION DETECTION HELPER FUNCTIONS 
 // These are in CollideGeneral.cpp and are used by one or more of the collision-


### PR DESCRIPTION
Turns out, when we last increase the maximum object count, we inadvertently broke collisions.
Collision pair caching used a 12-bit bitshift, so any objects with an objnum >= 4096 (which are quite common in large missions with our new cap) could overwrite collision data from older collision pairs.
For stuff like weapons or other things with short lifetimes, this isn't really noticable, but it can lead to something like a "will-never-collide" of a ship-weapon pair to overwrite the next collision check of a ship-ship pair, causing that ship-ship pair to never collide again.
This PR does two things:
1. Increase the bitshift to 16 bits, so that we actually use all available space in the collision pair key and no longer run into issues with 5000 objects.
2. Add a static_assert that will error out if the MAX_OBJECTS define is increased past the limit given by the 16 bits from the collision pair cache.

Since this is quite the severe regression, I suggest a point release for 24.0 from this.