### PR TITLE
isValid refactor

### DIFF
--- a/code/actions/Program.cpp
+++ b/code/actions/Program.cpp
@@ -47,7 +47,7 @@ ProgramInstance::ProgramInstance(const actions::Program* program) : _program(pro
 
 ProgramState ProgramInstance::step()
 {
-	if (!_locals.host.IsValid()) {
+	if (!_locals.host.isValid()) {
 		return ProgramState::Done;
 	}
 

--- a/code/ai/ailua.cpp
+++ b/code/ai/ailua.cpp
@@ -389,7 +389,7 @@ ai_achievability ai_lua_is_achievable(const ai_goal* aigp, int objnum){
 	if (!retVals.empty() && retVals[0].getValueType() == luacpp::ValueType::USERDATA) {
 		scripting::api::enum_h enumData;
 		retVals[0].getValue(scripting::api::l_Enum.Get(&enumData));
-		if (!enumData.IsValid()) {
+		if (!enumData.isValid()) {
 			Error(LOCATION, "LuaAI SEXP achievability hook returned an invalid avilability enum.");
 			return ai_achievability::ACHIEVABLE;
 		}

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -301,7 +301,7 @@ void camera::set_rotation_facing(vec3d *in_target, float in_rotation_time, float
 
 			// if we have a host, we need the difference between the camera's current orient and the orient we want
 			// if not, we will later set the absolute orientation, rather than the orientation relative to the host
-			if (object_host.IsValid())
+			if (object_host.isValid())
 			{
 				vm_transpose(orient);
 				temp_matrix = temp_matrix * *orient;
@@ -324,7 +324,7 @@ void camera::do_frame(float  /*in_frametime*/)
 
 object *camera::get_object_host()
 {
-	if(object_host.IsValid())
+	if(object_host.isValid())
 		return object_host.objp;
 	else
 		return NULL;
@@ -337,7 +337,7 @@ int camera::get_object_host_submodel()
 
 object *camera::get_object_target()
 {
-	if(object_target.IsValid())
+	if(object_target.isValid())
 		return object_target.objp;
 	else
 		return NULL;
@@ -373,7 +373,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 	bool use_host_orient = false;
 
 	//POSITION
-	if(!(flags & CAM_STATIONARY_POS) || object_host.IsValid())
+	if(!(flags & CAM_STATIONARY_POS) || object_host.isValid())
 	{
 		c_pos = vmd_zero_vector;
 
@@ -382,7 +382,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 		pos_y.get(&pt.xyz.y, NULL);
 		pos_z.get(&pt.xyz.z, NULL);
 
-		if(object_host.IsValid())
+		if(object_host.isValid())
 		{
 			object *objp = object_host.objp;
 			int model_num = object_get_model(objp);
@@ -444,9 +444,9 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 	if(orientation != NULL)
 	{
 		bool target_set = false;
-		if(!(flags & CAM_STATIONARY_ORI) || object_target.IsValid() || object_host.IsValid())
+		if(!(flags & CAM_STATIONARY_ORI) || object_target.isValid() || object_host.isValid())
 		{
-			if(object_target.IsValid())
+			if(object_target.isValid())
 			{
 				object *target_objp = object_target.objp;
 				int model_num = object_get_model(target_objp);
@@ -481,7 +481,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 				vm_vector_2_matrix(&c_ori, &targetvec, NULL, NULL);
 				target_set = true;
 			}
-			else if(object_host.IsValid())
+			else if(object_host.isValid())
 			{
 				if(eyep)
 				{
@@ -1011,7 +1011,7 @@ int camid::getSignature()
 	return sig;
 }
 
-bool camid::isValid()
+bool camid::isValid() const
 {
 	if(idx >= Cameras.size())
 		return false;
@@ -1203,7 +1203,7 @@ vec3d normal_cache;
 void get_turret_cam_pos(camera *cam, vec3d *pos)
 {
 	object_h obj(cam->get_object_host());
-	if(!obj.IsValid())
+	if(!obj.isValid())
 		return;
 	ship* shipp = &Ships[cam->get_object_host()->instance];
 	ship_subsys* ssp = GET_FIRST(&shipp->subsys_list);
@@ -1224,7 +1224,7 @@ void get_turret_cam_pos(camera *cam, vec3d *pos)
 void get_turret_cam_orient(camera *cam, matrix *ori)
 {
 	object_h obj(cam->get_object_host());
-	if(!obj.IsValid())
+	if(!obj.isValid())
 		return;
 	vm_vector_2_matrix(ori, &normal_cache, vm_vec_same(&normal_cache, &cam->get_object_host()->orient.vec.uvec)?NULL:&cam->get_object_host()->orient.vec.uvec, NULL);
 }

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -220,8 +220,8 @@ struct Decal {
 		vm_vec_make(&scale, 1.f, 1.f, 1.f);
 	}
 
-	bool isValid() {
-		if (!object.IsValid()) {
+	bool isValid() const {
+		if (!object.isValid()) {
 			return false;
 		}
 		if (object.objp->flags[Object::Object_Flags::Should_be_dead]) {

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -442,7 +442,7 @@ public:
 	class camera *getCamera();
 	size_t getIndex();
 	int getSignature();
-	bool isValid();
+	bool isValid() const;
 };
 
 #include "globalincs/vmallocator.h"

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -177,7 +177,8 @@ namespace luacpp {
 extern int Num_objects;
 extern object Objects[];
 
-struct object_h {
+struct object_h final	// prevent subclassing because classes which might use this should have their own isValid member function
+{
 	object *objp;
 	int sig;
 

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -181,7 +181,7 @@ struct object_h {
 	object *objp;
 	int sig;
 
-	bool IsValid() const {return (objp != nullptr && objp->signature == sig && sig > 0); }
+	bool isValid() const {return (objp != nullptr && objp->signature == sig && sig > 0); }
 	object_h(object *in) {objp = in; sig = (in == nullptr) ? -1 : in->signature; }
 	object_h() { objp = nullptr; sig = -1; }
 

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -203,7 +203,7 @@ bool SourceOrigin::isValid() const {
 			return false;
 		case SourceOriginType::OBJECT:
 		case SourceOriginType::BEAM: {
-			if (!m_origin.m_object.IsValid()) {
+			if (!m_origin.m_object.isValid()) {
 				return false;
 			}
 

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -119,7 +119,7 @@ class pilotfile {
 		bool verify(const char *fname, int *rank = nullptr, char *valid_language = nullptr, int* flags = nullptr);
 
 		// whether current campaign savefile has valid data to work with
-		bool is_invalid()
+		bool is_invalid() const
 		{
 			return m_data_invalid;
 		}

--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -118,7 +118,7 @@ ADE_FUNC(playSound, l_Audio, "soundentry", "Plays the specified sound entry hand
 	if (!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 
-	if (seh == NULL || !seh->IsValid())
+	if (seh == NULL || !seh->isValid())
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 
 	auto handle = snd_play(seh->Get());
@@ -139,7 +139,7 @@ ADE_FUNC(playLoopingSound, l_Audio, "soundentry", "Plays the specified sound as 
 	if (!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 
-	if (seh == NULL || !seh->IsValid())
+	if (seh == NULL || !seh->isValid())
 		return ade_set_error(L, "o", l_Sound.Set(sound_h()));
 
 	auto handle = snd_play_looping(seh->Get());
@@ -165,7 +165,7 @@ ADE_FUNC(play3DSound, l_Audio, "soundentry, [vector source, vector listener]",
 	if (!ade_get_args(L, "o|oo", l_SoundEntry.GetPtr(&seh), l_Vector.GetPtr(&source), l_Vector.GetPtr(&listener)))
 		return ade_set_error(L, "o", l_Sound3D.Set(sound_h()));
 
-	if (seh == NULL || !seh->IsValid())
+	if (seh == NULL || !seh->isValid())
 		return ade_set_error(L, "o", l_Sound3D.Set(sound_h()));
 
 	auto handle = snd_play_3d(seh->Get(), source, listener);

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -492,7 +492,7 @@ ADE_FUNC(postGameEvent, l_Base, "gameevent Event", "Sets current game event. Not
 	if(!ade_get_args(L, "o", l_GameEvent.GetPtr(&gh)))
 		return ade_set_error(L, "b", false);
 
-	if(!gh->IsValid())
+	if(!gh->isValid())
 		return ade_set_error(L, "b", false);
 
 	gameseq_post_event(gh->Get());

--- a/code/scripting/api/libs/controls.cpp
+++ b/code/scripting/api/libs/controls.cpp
@@ -129,7 +129,7 @@ ADE_FUNC(mouseButtonDownCount,
 	if (!ade_get_args(L, "o|b", l_Enum.Get(&buttonCheck), &reset_count))
 		return ade_set_error(L, "i", -1);
 
-	if (!buttonCheck.IsValid())
+	if (!buttonCheck.isValid())
 		return ade_set_error(L, "i", -1);
 
 	switch (buttonCheck.index)

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1162,7 +1162,7 @@ ADE_FUNC(
 		return ADE_RETURN_NIL;
 	}
 
-	if (!sshp->isSubsystemValid())
+	if (!sshp->isValid())
 	{
 		return ADE_RETURN_NIL;
 	}

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -266,7 +266,7 @@ ADE_VIRTVAR(CurrentResizeMode, l_Graphics, "enumeration ResizeMode", "Current re
 
 	if (ADE_SETTING_VAR)
 	{
-		if (!resize_arg.IsValid() || resize_arg.index < LE_GR_RESIZE_NONE || resize_arg.index > LE_GR_RESIZE_MENU_NO_OFFSET)
+		if (!resize_arg.isValid() || resize_arg.index < LE_GR_RESIZE_NONE || resize_arg.index > LE_GR_RESIZE_MENU_NO_OFFSET)
 		{
 			Warning(LOCATION, "Invalid resize mode index %d", resize_arg.index);
 			return ADE_RETURN_NIL;
@@ -1057,7 +1057,7 @@ ADE_FUNC(drawTargetingBrackets, l_Graphics, "object Object, [boolean draw=true, 
 	// void hud_show_brackets(object *targetp, vertex *projected_v)
 	// in hudtarget.cpp
 
-	if( !objh->IsValid()) {
+	if( !objh->isValid()) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -1214,7 +1214,7 @@ ADE_FUNC(drawOffscreenIndicator, l_Graphics, "object Object, [boolean draw=true,
 		return ADE_RETURN_NIL;
 	}
 
-	if( !objh->IsValid()) {
+	if( !objh->isValid()) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -1318,7 +1318,7 @@ static int drawString_sub(lua_State *L, bool use_resize_arg)
 		if (!ade_get_args(L, "o", l_Enum.Get(&resize_arg)))
 			return ade_set_error(L, "i", 0);
 
-		if (!resize_arg.IsValid() || resize_arg.index < LE_GR_RESIZE_NONE || resize_arg.index > LE_GR_RESIZE_MENU_NO_OFFSET)
+		if (!resize_arg.isValid() || resize_arg.index < LE_GR_RESIZE_NONE || resize_arg.index > LE_GR_RESIZE_MENU_NO_OFFSET)
 		{
 			Warning(LOCATION, "Invalid resize mode index %d", resize_arg.index);
 			return ade_set_error(L, "i", 0);
@@ -1937,7 +1937,7 @@ ADE_FUNC(hasViewmode, l_Graphics, "enumeration", "Specifies if the current viemo
 	if (!ade_get_args(L, "o", l_Enum.GetPtr(&type)))
 		return ade_set_error(L, "b", false);
 
-	if (type == NULL || !type->IsValid())
+	if (type == NULL || !type->isValid())
 		return ade_set_error(L, "b", false);
 
 	int bit = 0;
@@ -2135,7 +2135,7 @@ ADE_FUNC(createPersistentParticle,
 	if (rev)
 		pi.reverse = false;
 
-	if (objh != nullptr && objh->IsValid()) {
+	if (objh != nullptr && objh->isValid()) {
 		pi.attached_objnum = OBJ_INDEX(objh->objp);
 		pi.attached_sig    = objh->objp->signature;
 	}
@@ -2208,7 +2208,7 @@ ADE_FUNC(createParticle,
 	if (rev)
 		pi.reverse = false;
 
-	if (objh != nullptr && objh->IsValid()) {
+	if (objh != nullptr && objh->isValid()) {
 		pi.attached_objnum = OBJ_INDEX(objh->objp);
 		pi.attached_sig    = objh->objp->signature;
 	}

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -255,7 +255,7 @@ ADE_FUNC(flashTargetBox, l_HUD, "enumeration section, [number duration_in_millis
 		return ADE_RETURN_NIL;
 
 	int section_index = 0;
-	if (section.IsValid())
+	if (section.isValid())
 	{
 		switch (section.index)
 		{
@@ -293,7 +293,7 @@ ADE_FUNC(getTargetDistance, l_HUD, "object targetee, [vector targeter_position]"
 	if (!ade_get_args(L, "o|o", l_Object.GetPtr(&targetee_h), l_Vector.GetPtr(&targeter_pos)))
 		return ADE_RETURN_NIL;
 
-	if (targetee_h == nullptr || !targetee_h->IsValid())
+	if (targetee_h == nullptr || !targetee_h->isValid())
 		return ADE_RETURN_NIL;
 
 	if (targeter_pos == nullptr)

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -544,7 +544,7 @@ ADE_INDEXER(l_Mission_WaypointLists, "number/string IndexOrWaypointListName", "A
 
 	wpl = waypointlist_h(name);
 
-	if (!wpl.IsValid()) {
+	if (!wpl.isValid()) {
 		char* end_ptr;
 		auto idx = (int)strtol(name, &end_ptr, 10);
 		if (end_ptr != name && idx >= 1) {
@@ -553,7 +553,7 @@ ADE_INDEXER(l_Mission_WaypointLists, "number/string IndexOrWaypointListName", "A
 		}
 	}
 
-	if (wpl.IsValid()) {
+	if (wpl.isValid()) {
 		return ade_set_args(L, "o", l_WaypointList.Set(wpl));
 	}
 
@@ -925,7 +925,7 @@ ADE_FUNC(sendMessage,
 		if (!ade_get_args(L, "oo|fob", l_Ship.GetPtr(&ship_h), l_Message.Get(&messageIdx), &delay, l_Enum.GetPtr(&ehp), &fromCommand))
 			return ADE_RETURN_FALSE;
 
-		if (ship_h == nullptr || !ship_h->IsValid())
+		if (ship_h == nullptr || !ship_h->isValid())
 			return ADE_RETURN_FALSE;
 
 		sender = &Ships[ship_h->objp->instance];
@@ -1156,7 +1156,7 @@ ADE_FUNC(createDebris,
 	{
 		ade_get_args(L, "|o", l_Ship.GetPtr(&source_ship));
 
-		if (source_ship == nullptr || !source_ship->IsValid())
+		if (source_ship == nullptr || !source_ship->isValid())
 			return ade_set_args(L, "o", l_Debris.Set(object_h()));
 
 		source_shipp = &Ships[source_ship->objp->instance];
@@ -1177,7 +1177,7 @@ ADE_FUNC(createDebris,
 	{
 		ade_get_args(L, "|o", l_Model.GetPtr(&mh));
 
-		if (mh == nullptr || !mh->IsValid())
+		if (mh == nullptr || !mh->isValid())
 			return ade_set_args(L, "o", l_Debris.Set(object_h()));
 
 		model_num = mh->GetID();
@@ -1186,7 +1186,7 @@ ADE_FUNC(createDebris,
 	{
 		ade_get_args(L, "|o", l_Submodel.GetPtr(&smh));
 
-		if (smh == nullptr || !smh->IsValid())
+		if (smh == nullptr || !smh->isValid())
 			return ade_set_args(L, "o", l_Debris.Set(object_h()));
 
 		model_num = smh->GetModelID();
@@ -1225,7 +1225,7 @@ ADE_FUNC(createDebris,
 
 	if (create_flags != nullptr)
 	{
-		if (!create_flags->IsValid() || !create_flags->value)
+		if (!create_flags->isValid() || !create_flags->value)
 			return ade_set_args(L, "o", l_Debris.Set(object_h()));
 
 		is_hull = (*create_flags->value & LE_DC_IS_HULL);
@@ -1267,7 +1267,7 @@ ADE_FUNC(createWaypoint, l_Mission, "[vector Position, waypointlist List]",
 
 	// determine where we need to create it - it looks like we were given a waypoint list but not a waypoint itself
 	int waypoint_instance = -1;
-	if (wlh && wlh->IsValid())
+	if (wlh && wlh->isValid())
 	{
 		int wp_list_index = find_index_of_waypoint_list(wlh->wlp);
 		int wp_index = (int) wlh->wlp->get_waypoints().size() - 1;
@@ -1304,7 +1304,7 @@ ADE_FUNC(createWeapon,
 		real_orient = orient->GetMatrix();
 	}
 
-	int parent_idx = (parent && parent->IsValid()) ? OBJ_INDEX(parent->objp) : -1;
+	int parent_idx = (parent && parent->isValid()) ? OBJ_INDEX(parent->objp) : -1;
 
 	int obj_idx = weapon_create(&pos, real_orient, wclass, parent_idx, group);
 
@@ -1412,7 +1412,7 @@ ADE_FUNC(createExplosion,
 
 	int type = big ? FIREBALL_LARGE_EXPLOSION : FIREBALL_MEDIUM_EXPLOSION;
 
-	int parent_idx = (parent && parent->IsValid()) ? OBJ_INDEX(parent->objp) : -1;
+	int parent_idx = (parent && parent->isValid()) ? OBJ_INDEX(parent->objp) : -1;
 
 	int obj_idx = fireball_create(&pos, fireballclass, type, parent_idx, radius, false, &velocity);
 
@@ -2162,7 +2162,7 @@ ADE_FUNC(getMusicScore, l_Mission, "enumeration score", "Returns the music.tbl e
 	if (!ade_get_args(L, "o", l_Enum.Get(&score)))
 		return ADE_RETURN_NIL;
 
-	if (!score.IsValid() || score.index < LE_SCORE_BRIEFING || score.index > LE_SCORE_FICTION_VIEWER)
+	if (!score.isValid() || score.index < LE_SCORE_BRIEFING || score.index > LE_SCORE_FICTION_VIEWER)
 	{
 		Warning(LOCATION, "Invalid music score index %d", score.index);
 		return ADE_RETURN_NIL;
@@ -2184,7 +2184,7 @@ ADE_FUNC(setMusicScore, l_Mission, "enumeration score, string name", "Sets the m
 	if (!ade_get_args(L, "os", l_Enum.Get(&score), &name))
 		return ADE_RETURN_NIL;
 
-	if (!score.IsValid() || score.index < LE_SCORE_BRIEFING || score.index > LE_SCORE_FICTION_VIEWER)
+	if (!score.isValid() || score.index < LE_SCORE_BRIEFING || score.index > LE_SCORE_FICTION_VIEWER)
 	{
 		Warning(LOCATION, "Invalid music score index %d", score.index);
 		return ADE_RETURN_NIL;

--- a/code/scripting/api/libs/multi.cpp
+++ b/code/scripting/api/libs/multi.cpp
@@ -32,12 +32,12 @@ namespace scripting {
 				return ade_set_error(L, "o", l_RPC.Set(nullptr));
 			}
 
-			if (!recipient.IsValid() || (recipient.index != LE_RPC_SERVER && recipient.index != LE_RPC_CLIENTS && recipient.index != LE_RPC_BOTH)) {
+			if (!recipient.isValid() || (recipient.index != LE_RPC_SERVER && recipient.index != LE_RPC_CLIENTS && recipient.index != LE_RPC_BOTH)) {
 				LuaError(L, "Tried to create an RPC with an invalid recipient enumeration!");
 				return ade_set_error(L, "o", l_RPC.Set(nullptr));
 			}
 
-			if (!mode.IsValid() || (mode.index != LE_RPC_RELIABLE && mode.index != LE_RPC_ORDERED && mode.index != LE_RPC_UNRELIABLE)) {
+			if (!mode.isValid() || (mode.index != LE_RPC_RELIABLE && mode.index != LE_RPC_ORDERED && mode.index != LE_RPC_UNRELIABLE)) {
 				LuaError(L, "Tried to create an RPC with an invalid mode enumeration!");
 				return ade_set_error(L, "o", l_RPC.Set(nullptr));
 			}

--- a/code/scripting/api/libs/testing.cpp
+++ b/code/scripting/api/libs/testing.cpp
@@ -177,7 +177,7 @@ ADE_FUNC_DEPRECATED(createParticle,
 	if(rev)
 		pi.reverse = 0;
 
-	if(objh != NULL && objh->IsValid())
+	if(objh != NULL && objh->isValid())
 	{
 		pi.attached_objnum = OBJ_INDEX(objh->objp);
 		pi.attached_sig = objh->objp->signature;

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -236,7 +236,7 @@ ADE_FUNC(maybePlayCutscene, l_UserInterface, "enumeration MovieType, boolean Res
 	if (!ade_get_args(L, "obi", l_Enum.Get(&movie_type), &restart_music, &score_index))
 		return ADE_RETURN_NIL;
 
-	if (!movie_type.IsValid() || movie_type.index < LE_MOVIE_PRE_FICTION || movie_type.index > LE_MOVIE_END_CAMPAIGN)
+	if (!movie_type.isValid() || movie_type.index < LE_MOVIE_PRE_FICTION || movie_type.index > LE_MOVIE_END_CAMPAIGN)
 	{
 		Warning(LOCATION, "Invalid movie type index %d", movie_type.index);
 		return ADE_RETURN_NIL;

--- a/code/scripting/api/objs/LuaSEXP.cpp
+++ b/code/scripting/api/objs/LuaSEXP.cpp
@@ -10,7 +10,7 @@ lua_sexp_h::lua_sexp_h(sexp::LuaSEXP* handle) : sexp_handle(handle) {
 }
 lua_sexp_h::lua_sexp_h() : sexp_handle(nullptr) {
 }
-bool lua_sexp_h::isValid() {
+bool lua_sexp_h::isValid() const {
 	return sexp_handle != nullptr;
 }
 

--- a/code/scripting/api/objs/LuaSEXP.h
+++ b/code/scripting/api/objs/LuaSEXP.h
@@ -12,7 +12,7 @@ struct lua_sexp_h {
 	lua_sexp_h(sexp::LuaSEXP* sexp_handle);
 	lua_sexp_h();
 
-	bool isValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_LuaSEXP, lua_sexp_h);

--- a/code/scripting/api/objs/ai_helper.cpp
+++ b/code/scripting/api/objs/ai_helper.cpp
@@ -31,7 +31,7 @@ inline int aici_getset_helper(lua_State* L, float control_info::* value) {
 	if (!ade_get_args(L, "o|f", l_AI_Helper.Get(&ship), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!ship.IsValid())
+	if (!ship.isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if (ADE_SETTING_VAR) {

--- a/code/scripting/api/objs/asteroid.cpp
+++ b/code/scripting/api/objs/asteroid.cpp
@@ -20,13 +20,13 @@ ADE_VIRTVAR(Target, l_Asteroid, "object", "Asteroid target object; may be object
 	if(!ade_get_args(L, "o|o", l_Asteroid.GetPtr(&oh), l_Object.GetPtr(&th)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	asteroid *asp = &Asteroids[oh->objp->instance];
 
 	if(ADE_SETTING_VAR && th != NULL) {
-		if(th->IsValid())
+		if(th->isValid())
 			asp->target_objnum = OBJ_INDEX(th->objp);
 		else
 			asp->target_objnum = -1;
@@ -46,10 +46,10 @@ ADE_FUNC(kill, l_Asteroid, "[ship killer=nil, vector hitpos=nil]", "Kills the as
 	if(!ade_get_args(L, "o|oo", l_Asteroid.GetPtr(&victim), l_Ship.GetPtr(&killer), l_Vector.GetPtr(&hitpos)))
 		return ADE_RETURN_NIL;
 
-	if(!victim->IsValid())
+	if(!victim->isValid())
 		return ADE_RETURN_NIL;
 
-	if(killer != NULL && !killer->IsValid())
+	if(killer != NULL && !killer->isValid())
 		return ADE_RETURN_NIL;
 
 	if (!hitpos)

--- a/code/scripting/api/objs/beam.cpp
+++ b/code/scripting/api/objs/beam.cpp
@@ -28,7 +28,7 @@ ADE_VIRTVAR(Class, l_Beam, "weaponclass", "Weapon's class", "weaponclass", "Weap
 	if(!ade_get_args(L, "o|o", l_Beam.GetPtr(&oh), l_Weaponclass.Get(&nc)))
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
 	beam *bp = &Beams[oh->objp->instance];
@@ -47,7 +47,7 @@ ADE_VIRTVAR(LastShot, l_Beam, "vector", "End point of the beam", "vector", "vect
 	if(!ade_get_args(L, "o|o", l_Beam.GetPtr(&oh), l_Vector.GetPtr(&vec3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	beam *bp = &Beams[oh->objp->instance];
@@ -66,7 +66,7 @@ ADE_VIRTVAR(LastStart, l_Beam, "vector", "Start point of the beam", "vector", "v
 	if(!ade_get_args(L, "o|o", l_Beam.GetPtr(&oh), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	beam *bp = &Beams[oh->objp->instance];
@@ -85,7 +85,7 @@ ADE_VIRTVAR(Target, l_Beam, "object", "Target of beam. Value may also be a deriv
 	if(!ade_get_args(L, "o|o", l_Beam.GetPtr(&objh), l_Object.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	beam *bp = NULL;
@@ -96,7 +96,7 @@ ADE_VIRTVAR(Target, l_Beam, "object", "Target of beam. Value may also be a deriv
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->IsValid())
+		if(newh && newh->isValid())
 		{
 			if(bp->target_sig != newh->sig)
 			{
@@ -121,7 +121,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Beam, "subsystem", "Subsystem that beam is target
 	if(!ade_get_args(L, "o|o", l_Beam.GetPtr(&objh), l_Subsystem.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	beam *bp = NULL;
@@ -158,7 +158,7 @@ ADE_VIRTVAR(ParentShip, l_Beam, "object", "Parent of the beam.", "object", "Beam
 	if(!ade_get_args(L, "o|o", l_Beam.GetPtr(&objh), l_Object.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	beam *bp = NULL;
@@ -169,7 +169,7 @@ ADE_VIRTVAR(ParentShip, l_Beam, "object", "Parent of the beam.", "object", "Beam
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->IsValid())
+		if(newh && newh->isValid())
 		{
 			if(bp->sig != newh->sig)
 			{
@@ -194,7 +194,7 @@ ADE_VIRTVAR(ParentSubsystem, l_Beam, "subsystem", "Subsystem that beam is fired 
 	if(!ade_get_args(L, "o|o", l_Beam.GetPtr(&objh), l_Subsystem.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	beam *bp = NULL;
@@ -230,7 +230,7 @@ ADE_VIRTVAR(Team, l_Beam, "team", "Beam's team", "team", "Beam team, or invalid 
 	if (!ade_get_args(L, "o|o", l_Beam.GetPtr(&oh), l_Team.Get(&nt)))
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
 	beam* b = &Beams[oh->objp->instance];
@@ -388,7 +388,7 @@ ADE_FUNC(vanish, l_Beam, nullptr, "Vanishes this beam from the mission.", "boole
 	if (!ade_get_args(L, "o", l_Beam.GetPtr(&objh)))
 		return ADE_RETURN_FALSE;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
 	beam_delete(&Beams[objh->objp->instance]);

--- a/code/scripting/api/objs/beam.cpp
+++ b/code/scripting/api/objs/beam.cpp
@@ -132,7 +132,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Beam, "subsystem", "Subsystem that beam is target
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->isSubsystemValid())
+		if(newh && newh->isValid())
 		{
 			if(bp->target_sig != newh->objh.sig)
 			{
@@ -205,7 +205,7 @@ ADE_VIRTVAR(ParentSubsystem, l_Beam, "subsystem", "Subsystem that beam is fired 
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->isSubsystemValid())
+		if(newh && newh->isValid())
 		{
 			if(bp->sig != newh->objh.sig)
 			{

--- a/code/scripting/api/objs/beam.cpp
+++ b/code/scripting/api/objs/beam.cpp
@@ -134,11 +134,11 @@ ADE_VIRTVAR(TargetSubsystem, l_Beam, "subsystem", "Subsystem that beam is target
 	{
 		if(newh && newh->isSubsystemValid())
 		{
-			if(bp->target_sig != newh->sig)
+			if(bp->target_sig != newh->objh.sig)
 			{
-				bp->target = newh->objp;
+				bp->target = newh->objh.objp;
 				bp->target_subsys = newh->ss;
-				bp->target_sig = newh->sig;
+				bp->target_sig = newh->objh.sig;
 			}
 		}
 		else
@@ -207,9 +207,9 @@ ADE_VIRTVAR(ParentSubsystem, l_Beam, "subsystem", "Subsystem that beam is fired 
 	{
 		if(newh && newh->isSubsystemValid())
 		{
-			if(bp->sig != newh->sig)
+			if(bp->sig != newh->objh.sig)
 			{
-				bp->objp = newh->objp;
+				bp->objp = newh->objh.objp;
 				bp->subsys = newh->ss;
 			}
 		}

--- a/code/scripting/api/objs/briefing.cpp
+++ b/code/scripting/api/objs/briefing.cpp
@@ -9,7 +9,7 @@ brief_stage_h::brief_stage_h() : br_brief(-1), br_stage(-1) {}
 
 brief_stage_h::brief_stage_h(int brief, int stage) : br_brief(brief), br_stage(stage) {}
 
-bool brief_stage_h::IsValid() const
+bool brief_stage_h::isValid() const
 {
 	return br_brief >= 0 && br_stage >= 0;
 }

--- a/code/scripting/api/objs/briefing.h
+++ b/code/scripting/api/objs/briefing.h
@@ -11,7 +11,7 @@ struct brief_stage_h {
 	int br_brief, br_stage;
 	brief_stage_h();
 	explicit brief_stage_h(int brief, int stage);
-	bool IsValid() const;
+	bool isValid() const;
 	brief_stage* getStage() const;
 };
 

--- a/code/scripting/api/objs/camera.cpp
+++ b/code/scripting/api/objs/camera.cpp
@@ -119,7 +119,7 @@ ADE_VIRTVAR(Self, l_Camera, "object", "New mount object", "object", "Camera obje
 	if(!cid.isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(ADE_SETTING_VAR && oh && oh->IsValid()) {
+	if(ADE_SETTING_VAR && oh && oh->isValid()) {
 		cid.getCamera()->set_object_host(oh->objp);
 	}
 
@@ -174,7 +174,7 @@ ADE_VIRTVAR(Target, l_Camera, "object", "New target object", "object", "Camera t
 	if(!cid.isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(ADE_SETTING_VAR && oh && oh->IsValid()) {
+	if(ADE_SETTING_VAR && oh && oh->isValid()) {
 		cid.getCamera()->set_object_target(oh->objp);
 	}
 

--- a/code/scripting/api/objs/camera.cpp
+++ b/code/scripting/api/objs/camera.cpp
@@ -137,7 +137,7 @@ ADE_VIRTVAR(SelfSubsystem, l_Camera, "subsystem", "New mount object subsystem", 
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	if(ADE_SETTING_VAR && sso && sso->isSubsystemValid()) {
-		cid.getCamera()->set_object_host(sso->objp, sso->ss->system_info->subobj_num);
+		cid.getCamera()->set_object_host(sso->objh.objp, sso->ss->system_info->subobj_num);
 	}
 
 	object *objp = cid.getCamera()->get_object_host();
@@ -192,7 +192,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Camera, "subsystem", "New target subsystem", "sub
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	if(ADE_SETTING_VAR && sso && sso->isSubsystemValid()) {
-		cid.getCamera()->set_object_target(sso->objp, sso->ss->system_info->subobj_num);
+		cid.getCamera()->set_object_target(sso->objh.objp, sso->ss->system_info->subobj_num);
 	}
 
 	object *objp = cid.getCamera()->get_object_target();

--- a/code/scripting/api/objs/camera.cpp
+++ b/code/scripting/api/objs/camera.cpp
@@ -136,7 +136,7 @@ ADE_VIRTVAR(SelfSubsystem, l_Camera, "subsystem", "New mount object subsystem", 
 	if(!cid.isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(ADE_SETTING_VAR && sso && sso->isSubsystemValid()) {
+	if(ADE_SETTING_VAR && sso && sso->isValid()) {
 		cid.getCamera()->set_object_host(sso->objh.objp, sso->ss->system_info->subobj_num);
 	}
 
@@ -191,7 +191,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Camera, "subsystem", "New target subsystem", "sub
 	if(!cid.isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(ADE_SETTING_VAR && sso && sso->isSubsystemValid()) {
+	if(ADE_SETTING_VAR && sso && sso->isValid()) {
 		cid.getCamera()->set_object_target(sso->objh.objp, sso->ss->system_info->subobj_num);
 	}
 

--- a/code/scripting/api/objs/cmd_brief.cpp
+++ b/code/scripting/api/objs/cmd_brief.cpp
@@ -8,7 +8,7 @@ cmd_brief_stage_h::cmd_brief_stage_h() : cmd_brief(-1), cmd_stage(-1) { }
 
 cmd_brief_stage_h::cmd_brief_stage_h(int brief, int stage) : cmd_brief(brief), cmd_stage(stage) { }
 
-bool cmd_brief_stage_h::IsValid() const {
+bool cmd_brief_stage_h::isValid() const {
 	return cmd_brief >= 0 && cmd_stage >= 0;
 }
 

--- a/code/scripting/api/objs/cmd_brief.h
+++ b/code/scripting/api/objs/cmd_brief.h
@@ -11,7 +11,7 @@ struct cmd_brief_stage_h {
 
 	cmd_brief_stage_h();
 	explicit cmd_brief_stage_h(int brief, int stage);
-	bool IsValid() const;
+	bool isValid() const;
 	cmd_brief_stage* getStage() const;
 };
 

--- a/code/scripting/api/objs/control_binding.cpp
+++ b/code/scripting/api/objs/control_binding.cpp
@@ -10,7 +10,7 @@ cci_h::cci_h() { idx = IoActionId::CCFG_MAX; }
 
 cci_h::cci_h(int n_id) { if (n_id < 0 || n_id > static_cast<int>(IoActionId::CCFG_MAX)) idx = IoActionId::CCFG_MAX; else idx = static_cast<IoActionId>(n_id); }
 
-bool cci_h::IsValid() { return idx != IoActionId::CCFG_MAX; }
+bool cci_h::isValid() const { return idx != IoActionId::CCFG_MAX; }
 
 IoActionId cci_h::Get() { return idx; }
 
@@ -22,7 +22,7 @@ ADE_FUNC(__tostring, l_ControlBinding, nullptr, "Key binding name", "string", "K
 	if(!ade_get_args(L, "o", l_ControlBinding.GetPtr(&cci)))
 		return ade_set_error(L, "s", "");
 
-	if(!cci->IsValid())
+	if(!cci->isValid())
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", ValToAction(cci->Get()));
@@ -34,7 +34,7 @@ ADE_VIRTVAR(Name, l_ControlBinding, nullptr, "Key binding name", "string", "Key 
 	if (!ade_get_args(L, "o", l_ControlBinding.GetPtr(&cci)))
 		return ade_set_error(L, "s", "");
 
-	if (!cci->IsValid())
+	if (!cci->isValid())
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", ValToAction(cci->Get()));
@@ -47,7 +47,7 @@ ADE_FUNC(getInputName, l_ControlBinding, "[boolean primaryBinding = true]", "The
 	if (!ade_get_args(L, "o|b", l_ControlBinding.GetPtr(&cci), &primary))
 		return ADE_RETURN_NIL;
 
-	if (!cci->IsValid()) 
+	if (!cci->isValid()) 
 		return ade_set_error(L, "s", "");
 
 	CCI &cci_ref = Control_config[cci->Get()];
@@ -62,7 +62,7 @@ ADE_FUNC(lock, l_ControlBinding, "boolean lock", "Locks this control binding whe
 	if (!ade_get_args(L, "ob", l_ControlBinding.GetPtr(&cci), &lock))
 		return ADE_RETURN_NIL;
 
-	if (!cci->IsValid()) {
+	if (!cci->isValid()) {
 		LuaError(L, "Cannot lock hooks for an invalid binding.\n");
 
 		return ADE_RETURN_NIL;
@@ -79,7 +79,7 @@ ADE_FUNC(isLocked, l_ControlBinding, nullptr, "If this control is locked", "bool
 	if (!ade_get_args(L, "o", l_ControlBinding.GetPtr(&cci)))
 		return ADE_RETURN_NIL;
 
-	if (!cci->IsValid()) {
+	if (!cci->isValid()) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -97,7 +97,7 @@ ADE_FUNC(registerHook, l_ControlBinding, "function() => void | boolean hook, [bo
 		return ADE_RETURN_NIL;
 	}
 
-	if (!cci->IsValid()) {
+	if (!cci->isValid()) {
 		return ADE_RETURN_NIL;
 	}
 
@@ -120,7 +120,7 @@ ADE_FUNC(enableScripting, l_ControlBinding, "boolean enable", "Enables scripted 
 	if (!ade_get_args(L, "ob", l_ControlBinding.GetPtr(&cci), &enable))
 		return ADE_RETURN_NIL;
 
-	if (!cci->IsValid()) {
+	if (!cci->isValid()) {
 		LuaError(L, "Cannot enable or disable scripting hooks for an invalid binding.\n");
 		
 		return ADE_RETURN_NIL;

--- a/code/scripting/api/objs/control_binding.h
+++ b/code/scripting/api/objs/control_binding.h
@@ -23,7 +23,7 @@ class cci_h {
 	/*
 	* @returns true if this object holds a valid IoActionId, false otherwise
 	*/
-	bool IsValid();
+	bool isValid() const;
 
 	IoActionId Get();
 };

--- a/code/scripting/api/objs/debriefing.cpp
+++ b/code/scripting/api/objs/debriefing.cpp
@@ -10,7 +10,7 @@ debrief_stage* debrief_stage_h::getStage() const
 	return stage;
 };
 
-bool debrief_stage_h::IsValid() const
+bool debrief_stage_h::isValid() const
 {
 	return stage != nullptr;
 }

--- a/code/scripting/api/objs/debriefing.h
+++ b/code/scripting/api/objs/debriefing.h
@@ -11,7 +11,7 @@ struct debrief_stage_h {
 	debrief_stage* stage;
 	debrief_stage_h();
 	explicit debrief_stage_h(debrief_stage* db_stage);
-	bool IsValid() const;
+	bool isValid() const;
 	debrief_stage* getStage() const;
 };
 

--- a/code/scripting/api/objs/debris.cpp
+++ b/code/scripting/api/objs/debris.cpp
@@ -22,7 +22,7 @@ ADE_VIRTVAR(IsHull, l_Debris, "boolean", "Whether or not debris is a piece of hu
 	if(!ade_get_args(L, "o|b", l_Debris.GetPtr(&oh), &b))
 		return ade_set_error(L, "b", false);
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "b", false);
 
 	debris *db = &Debris[oh->objp->instance];
@@ -42,7 +42,7 @@ ADE_VIRTVAR(OriginClass, l_Debris, "shipclass", "The shipclass of the ship this 
 	if(!ade_get_args(L, "o|o", l_Debris.GetPtr(&oh), &shipIdx))
 		return ade_set_error(L, "o", l_Shipclass.Set(-1));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Shipclass.Set(-1));
 
 	debris *db = &Debris[oh->objp->instance];
@@ -63,7 +63,7 @@ ADE_VIRTVAR(DoNotExpire, l_Debris, "boolean", "Whether the debris should expire.
 	if (!ade_get_args(L, "o|b", l_Debris.GetPtr(&objh), &set))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	debris *db = &Debris[objh->objp->instance];
@@ -97,7 +97,7 @@ ADE_VIRTVAR(LifeLeft, l_Debris, "number", "The time this debris piece will last.
 	if (!ade_get_args(L, "o|f", l_Debris.GetPtr(&objh), &lifeleft))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	debris *db = &Debris[objh->objp->instance];
@@ -114,7 +114,7 @@ ADE_FUNC(getDebrisRadius, l_Debris, NULL, "The radius of this debris piece", "nu
 	if(!ade_get_args(L, "o", l_Debris.GetPtr(&oh)))
 		return ade_set_error(L, "f", -1.0f);
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	debris *db = &Debris[oh->objp->instance];
@@ -136,7 +136,7 @@ ADE_FUNC(isValid, l_Debris, NULL, "Return if this debris handle is valid", "bool
 	if(!ade_get_args(L, "o", l_Debris.GetPtr(&oh)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", oh != NULL && oh->IsValid());
+	return ade_set_args(L, "b", oh != NULL && oh->isValid());
 }
 
 ADE_FUNC(isGeneric, l_Debris, nullptr, "Return if this debris is the generic debris model, not a model subobject", "boolean", "true if Debris_model")
@@ -145,7 +145,7 @@ ADE_FUNC(isGeneric, l_Debris, nullptr, "Return if this debris is the generic deb
 	if (!ade_get_args(L, "o", l_Debris.GetPtr(&oh)))
 		return ADE_RETURN_FALSE;
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ADE_RETURN_FALSE;
 
 	debris *db = &Debris[oh->objp->instance];
@@ -159,7 +159,7 @@ ADE_FUNC(isVaporized, l_Debris, nullptr, "Return if this debris is the vaporized
 	if (!ade_get_args(L, "o", l_Debris.GetPtr(&oh)))
 		return ADE_RETURN_FALSE;
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ADE_RETURN_FALSE;
 
 	debris *db = &Debris[oh->objp->instance];
@@ -174,7 +174,7 @@ ADE_FUNC(vanish, l_Debris, nullptr, "Vanishes this piece of debris from the miss
 	if (!ade_get_args(L, "o", l_Debris.GetPtr(&oh)))
 		return ade_set_error(L, "b", false);
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ade_set_error(L, "b", false);
 
 	//This skips all the fancy deathroll stuff, and just cleans it from the mission

--- a/code/scripting/api/objs/decaldefinition.cpp
+++ b/code/scripting/api/objs/decaldefinition.cpp
@@ -86,7 +86,7 @@ ADE_FUNC(create, l_DecalDefinitionclass, "number width, number height, number mi
 	if (idx < 0 || idx >= static_cast<int>(decals::DecalDefinitions.size()))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid() || !smh->IsValid())
+	if (!objh->isValid() || !smh->isValid())
 		return ADE_RETURN_NIL;
 
 	decals::creation_info info;

--- a/code/scripting/api/objs/enums.cpp
+++ b/code/scripting/api/objs/enums.cpp
@@ -205,7 +205,7 @@ SCP_string enum_h::getName() const
 
 	return SCP_string();
 }
-bool enum_h::IsValid() const { return index < ENUM_NEXT_INDEX || index == ENUM_COMBINATION; }
+bool enum_h::isValid() const { return index < ENUM_NEXT_INDEX || index == ENUM_COMBINATION; }
 
 enum_h operator&(const enum_h& l, const enum_h& other) {
 	Assertion(l.value && other.value, "Tried to and-combine non-combinable enums %s and %s!", l.getName().c_str(), other.getName().c_str());
@@ -308,7 +308,7 @@ ADE_FUNC(__tostring,
 		return ade_set_args(L, "s", "<INVALID>");
 	}
 
-	if (!e->IsValid()) {
+	if (!e->isValid()) {
 		return ade_set_args(L, "s", "<INVALID>");
 	}
 
@@ -352,7 +352,7 @@ ADE_FUNC(__add,
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 	}
 
-	if (e1 == nullptr || e2 == nullptr || !e1->IsValid() || !e2->IsValid() || !e1->value ||!e2->value) {
+	if (e1 == nullptr || e2 == nullptr || !e1->isValid() || !e2->isValid() || !e1->value ||!e2->value) {
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 	}
 
@@ -372,7 +372,7 @@ ADE_FUNC(__mul,
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 	}
 
-	if (e1 == nullptr || e2 == nullptr || !e1->IsValid() || !e2->IsValid() || !e1->value || !e2->value) {
+	if (e1 == nullptr || e2 == nullptr || !e1->isValid() || !e2->isValid() || !e1->value || !e2->value) {
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 	}
 

--- a/code/scripting/api/objs/enums.h
+++ b/code/scripting/api/objs/enums.h
@@ -202,7 +202,7 @@ public:
 
 	SCP_string getName() const;
 
-	bool IsValid() const;
+	bool isValid() const;
 
 	friend enum_h operator&(const enum_h& l, const enum_h& other);
 	friend enum_h operator|(const enum_h& l, const enum_h& other);

--- a/code/scripting/api/objs/executor.cpp
+++ b/code/scripting/api/objs/executor.cpp
@@ -8,7 +8,7 @@ namespace api {
 
 executor_h::executor_h() = default;
 executor_h::executor_h(std::shared_ptr<executor::Executor> executor) : m_executor(std::move(executor)) {}
-bool executor_h::isValid() { return m_executor != nullptr; }
+bool executor_h::isValid() const { return m_executor != nullptr; }
 const std::shared_ptr<executor::Executor>& executor_h::getExecutor() const { return m_executor; }
 
 //**********HANDLE: executor

--- a/code/scripting/api/objs/executor.h
+++ b/code/scripting/api/objs/executor.h
@@ -12,7 +12,7 @@ class executor_h {
 	executor_h();
 	executor_h(std::shared_ptr<executor::Executor> executor);
 
-	bool isValid();
+	bool isValid() const;
 
 	const std::shared_ptr<executor::Executor>& getExecutor() const;
 

--- a/code/scripting/api/objs/eye.cpp
+++ b/code/scripting/api/objs/eye.cpp
@@ -17,7 +17,7 @@ eye_h::eye_h(int n_m, int n_e) {
 	eye_idx = n_e;
 }
 
-bool eye_h::IsValid() {
+bool eye_h::isValid() const {
 	polymodel* pm = NULL;
 	return (model > -1
 		&& (pm = model_get(model)) != NULL
@@ -35,7 +35,7 @@ ADE_VIRTVAR(Normal, l_Eyepoint, "vector", "Eyepoint normal", "vector", "Eyepoint
 	if(!ade_get_args(L, "o|o", l_Eyepoint.GetPtr(&eh), l_Vector.GetPtr(&v)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!eh->IsValid())
+	if(!eh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	polymodel *pm = model_get(eh->model);
@@ -55,7 +55,7 @@ ADE_VIRTVAR(Position, l_Eyepoint, "vector", "Eyepoint location (Local vector)", 
 	if(!ade_get_args(L, "o|o", l_Eyepoint.GetPtr(&eh), l_Vector.GetPtr(&v)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!eh->IsValid())
+	if(!eh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	polymodel *pm = model_get(eh->model);
@@ -75,7 +75,7 @@ ADE_FUNC(isValid, l_Eyepoint, nullptr, "Detect whether this handle is valid", "b
 		return ADE_RETURN_FALSE;
 	}
 
-	return ade_set_args(L, "b", eh->IsValid());
+	return ade_set_args(L, "b", eh->isValid());
 }
 
 ADE_FUNC_DEPRECATED(IsValid,
@@ -93,7 +93,7 @@ ADE_FUNC_DEPRECATED(IsValid,
 		return ADE_RETURN_FALSE;
 	}
 
-	return ade_set_args(L, "b", eh->IsValid());
+	return ade_set_args(L, "b", eh->isValid());
 }
 
 }

--- a/code/scripting/api/objs/eye.h
+++ b/code/scripting/api/objs/eye.h
@@ -13,7 +13,7 @@ class eye_h {
 
 	eye_h();
 	eye_h(int n_m, int n_e);
-	bool IsValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_Eyepoint, eye_h);

--- a/code/scripting/api/objs/fictionviewer.cpp
+++ b/code/scripting/api/objs/fictionviewer.cpp
@@ -8,7 +8,7 @@ fiction_viewer_stage_h::fiction_viewer_stage_h() : f_stage(-1) {}
 
 fiction_viewer_stage_h::fiction_viewer_stage_h(int stage) : f_stage(stage) {}
 
-bool fiction_viewer_stage_h::IsValid() const
+bool fiction_viewer_stage_h::isValid() const
 {
 	return f_stage >= 0;
 }

--- a/code/scripting/api/objs/fictionviewer.h
+++ b/code/scripting/api/objs/fictionviewer.h
@@ -10,7 +10,7 @@ struct fiction_viewer_stage_h {
 	int f_stage;
 	fiction_viewer_stage_h();
 	explicit fiction_viewer_stage_h(int stage);
-	bool IsValid() const;
+	bool isValid() const;
 	fiction_viewer_stage* getStage() const;
 };
 

--- a/code/scripting/api/objs/fireball.cpp
+++ b/code/scripting/api/objs/fireball.cpp
@@ -20,7 +20,7 @@ ADE_VIRTVAR(Class, l_Fireball, "fireballclass", "Fireball's class", "fireballcla
 	if(!ade_get_args(L, "o|o", l_Fireball.GetPtr(&oh), l_Fireballclass.Get(&nc)))
 		return ade_set_error(L, "o", l_Fireballclass.Set(-1));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Fireballclass.Set(-1));
 
 	if (oh->objp->instance < 0 || oh->objp->instance >= static_cast<int>(Fireballs.size()))
@@ -42,7 +42,7 @@ ADE_VIRTVAR(RenderType, l_Fireball, "enumeration", "Fireball's render type", "en
 	if (!ade_get_args(L, "o|o", l_Fireball.GetPtr(&oh), l_Enum.Get(&type)))
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
 	if (oh->objp->instance < 0 || oh->objp->instance >= static_cast<int>(Fireballs.size()))
@@ -50,7 +50,7 @@ ADE_VIRTVAR(RenderType, l_Fireball, "enumeration", "Fireball's render type", "en
 
 	fireball* fb = &Fireballs[oh->objp->instance];
 
-	if (ADE_SETTING_VAR && type.IsValid()) {
+	if (ADE_SETTING_VAR && type.isValid()) {
 		int nt = -1;
 		switch (type.index) {
 		case LE_FIREBALL_MEDIUM_EXPLOSION:
@@ -90,7 +90,7 @@ ADE_VIRTVAR(TimeElapsed, l_Fireball, NULL, "Time this fireball exists in seconds
 	if(!ade_get_args(L, "o", l_Fireball.GetPtr(&oh), &nll))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if (oh->objp->instance < 0 || oh->objp->instance <= static_cast<int>(Fireballs.size())) 
@@ -108,7 +108,7 @@ ADE_VIRTVAR(TotalTime, l_Fireball, NULL, "Total lifetime of the fireball's anima
 	if (!ade_get_args(L, "o", l_Fireball.GetPtr(&oh), &nll))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if (oh->objp->instance < 0 || oh->objp->instance >= static_cast<int>(Fireballs.size()))
@@ -125,7 +125,7 @@ ADE_FUNC(isWarp, l_Fireball, NULL, "Checks if the fireball is a warp effect.", "
 	if(!ade_get_args(L, "o", l_Fireball.GetPtr(&oh)))
 		return ADE_RETURN_FALSE;
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ADE_RETURN_FALSE;
 
 	if(fireball_is_warp(oh->objp))
@@ -142,7 +142,7 @@ ADE_FUNC(vanish, l_Fireball, nullptr, "Vanishes this fireball from the mission."
 	if (!ade_get_args(L, "o", l_Fireball.GetPtr(&oh)))
 		return ade_set_error(L, "b", false);
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ade_set_error(L, "b", false);
 
 	//Should be sufficient for Fireballs, as the fireball internal functions also call this, for example to free up a fireball if the limit is reached

--- a/code/scripting/api/objs/font.cpp
+++ b/code/scripting/api/objs/font.cpp
@@ -11,14 +11,14 @@ font_h::font_h(font::FSFont* fontIn): font(fontIn) {
 font_h::font_h(): font(NULL) {
 }
 
-font::FSFont* font_h::Get() {
+font::FSFont* font_h::Get() const {
 	if (!isValid())
 		return NULL;
 
 	return font;
 }
 
-bool font_h::isValid() {
+bool font_h::isValid() const {
 	return font != NULL;
 }
 

--- a/code/scripting/api/objs/font.h
+++ b/code/scripting/api/objs/font.h
@@ -18,9 +18,9 @@ public:
 
 	font_h();
 
-	font::FSFont* Get();
+	font::FSFont* Get() const;
 
-	bool isValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_Font, font_h);

--- a/code/scripting/api/objs/gameevent.cpp
+++ b/code/scripting/api/objs/gameevent.cpp
@@ -15,7 +15,7 @@ gameevent_h::gameevent_h(int n_event) {
 	edx = n_event;
 }
 
-bool gameevent_h::IsValid() {
+bool gameevent_h::isValid() const {
 	return (edx > -1 && edx < Num_gs_event_text);
 }
 
@@ -43,7 +43,7 @@ ADE_FUNC(__tostring, l_GameEvent, NULL, "Game event name", "string", "Game event
 	if (!ade_get_args(L, "o", l_GameEvent.GetPtr(&gh)))
 		return ade_set_error(L, "s", "");
 
-	if (!gh->IsValid())
+	if (!gh->isValid())
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", GS_event_text[gh->Get()]);
@@ -56,7 +56,7 @@ ADE_VIRTVAR(Name, l_GameEvent, "string", "Game event name", "string", "Game even
 	if (!ade_get_args(L, "o|s", l_GameEvent.GetPtr(&gh), &n_name))
 		return ade_set_error(L, "s", "");
 
-	if (!gh->IsValid())
+	if (!gh->isValid())
 		return ade_set_error(L, "s", "");
 
 	int edx = gh->Get();

--- a/code/scripting/api/objs/gameevent.h
+++ b/code/scripting/api/objs/gameevent.h
@@ -17,7 +17,7 @@ public:
 
 	explicit gameevent_h(int n_event);
 
-	bool IsValid();
+	bool isValid() const;
 
 	int Get();
 

--- a/code/scripting/api/objs/gamestate.cpp
+++ b/code/scripting/api/objs/gamestate.cpp
@@ -14,7 +14,7 @@ gamestate_h::gamestate_h() { sdx = -1; }
 
 gamestate_h::gamestate_h(int n_state) { sdx = n_state; }
 
-bool gamestate_h::IsValid() { return (sdx > -1 && sdx < Num_gs_state_text); }
+bool gamestate_h::isValid() const { return (sdx > -1 && sdx < Num_gs_state_text); }
 
 int gamestate_h::Get() { return sdx; }
 
@@ -38,7 +38,7 @@ ADE_FUNC(__tostring, l_GameState, NULL, "Game state name", "string", "Game state
 	if(!ade_get_args(L, "o", l_GameState.GetPtr(&gh)))
 		return ade_set_error(L, "s", "");
 
-	if(!gh->IsValid())
+	if(!gh->isValid())
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", GS_state_text[gh->Get()]);
@@ -51,7 +51,7 @@ ADE_VIRTVAR(Name, l_GameState,"string", "Game state name", "string", "Game state
 	if(!ade_get_args(L, "o|s", l_GameState.GetPtr(&gh), &n_name))
 		return ade_set_error(L, "s", "");
 
-	if(!gh->IsValid())
+	if(!gh->isValid())
 		return ade_set_error(L, "s", "");
 
 	int sdx = gh->Get();

--- a/code/scripting/api/objs/gamestate.h
+++ b/code/scripting/api/objs/gamestate.h
@@ -15,7 +15,7 @@ class gamestate_h {
 	gamestate_h();
 	gamestate_h(int n_state);
 
-	bool IsValid();
+	bool isValid() const;
 
 	int Get();
 

--- a/code/scripting/api/objs/loop_brief.cpp
+++ b/code/scripting/api/objs/loop_brief.cpp
@@ -7,7 +7,7 @@ cmission_h::cmission_h() : l_stage(-1) {}
 
 cmission_h::cmission_h(int stage) : l_stage(stage) {}
 
-bool cmission_h::IsValid() const
+bool cmission_h::isValid() const
 {
 	return l_stage >= 0;
 }

--- a/code/scripting/api/objs/loop_brief.h
+++ b/code/scripting/api/objs/loop_brief.h
@@ -10,7 +10,7 @@ struct cmission_h {
 	int l_stage;
 	cmission_h();
 	explicit cmission_h(int stage);
-	bool IsValid() const;
+	bool isValid() const;
 	cmission* getStage() const;
 };
 

--- a/code/scripting/api/objs/luaaisexp.cpp
+++ b/code/scripting/api/objs/luaaisexp.cpp
@@ -10,7 +10,7 @@ lua_ai_sexp_h::lua_ai_sexp_h(sexp::LuaAISEXP* handle) : sexp_handle(handle) {
 }
 lua_ai_sexp_h::lua_ai_sexp_h() : sexp_handle(nullptr) {
 }
-bool lua_ai_sexp_h::isValid() {
+bool lua_ai_sexp_h::isValid() const {
 	return sexp_handle != nullptr;
 }
 

--- a/code/scripting/api/objs/luaaisexp.h
+++ b/code/scripting/api/objs/luaaisexp.h
@@ -12,7 +12,7 @@ struct lua_ai_sexp_h {
 	lua_ai_sexp_h(sexp::LuaAISEXP* sexp_handle);
 	lua_ai_sexp_h();
 
-	bool isValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_LuaAISEXP, lua_ai_sexp_h);

--- a/code/scripting/api/objs/mc_info.cpp
+++ b/code/scripting/api/objs/mc_info.cpp
@@ -13,7 +13,7 @@ mc_info_h::mc_info_h(const mc_info& val) : info(val), valid(true) {}
 mc_info_h::mc_info_h() = default;
 
 mc_info* mc_info_h::Get() { return &info; }
-bool mc_info_h::IsValid() { return valid; }
+bool mc_info_h::isValid() const { return valid; }
 
 //**********HANDLE: Collision info
 ADE_OBJ(l_ColInfo, mc_info_h, "collision_info", "Information about a collision");
@@ -26,7 +26,7 @@ ADE_VIRTVAR(Model, l_ColInfo, "model", "The model this collision info is about",
 	if(!ade_get_args(L, "o|o", l_ColInfo.GetPtr(&info), l_Model.GetPtr(&mh)))
 		return ade_set_error(L, "o", l_Model.Set(model_h()));
 
-	if (!info->IsValid())
+	if (!info->isValid())
 		return ade_set_error(L, "o", l_Model.Set(model_h()));
 
 	mc_info *collide = info->Get();
@@ -35,7 +35,7 @@ ADE_VIRTVAR(Model, l_ColInfo, "model", "The model this collision info is about",
 
 	if (ADE_SETTING_VAR && mh)
 	{
-		if (mh->IsValid())
+		if (mh->isValid())
 		{
 			collide->model_num = mh->GetID();
 		}
@@ -52,7 +52,7 @@ ADE_FUNC(getCollisionSubmodel, l_ColInfo, nullptr, "The submodel where the colli
 	if (!ade_get_args(L, "o|o", l_ColInfo.GetPtr(&info), l_Submodel.GetPtr(&sh)))
 		return ADE_RETURN_NIL;
 
-	if (!info->IsValid())
+	if (!info->isValid())
 		return ADE_RETURN_NIL;
 
 	mc_info *collide = info->Get();
@@ -70,7 +70,7 @@ ADE_FUNC(getCollisionDistance, l_ColInfo, NULL, "The distance to the closest col
 	if(!ade_get_args(L, "o", l_ColInfo.GetPtr(&info)))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (!info->IsValid())
+	if (!info->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	mc_info *collide = info->Get();
@@ -93,7 +93,7 @@ ADE_FUNC(getCollisionPoint, l_ColInfo, "[boolean local]", "The collision point o
 	if(!ade_get_args(L, "o|b", l_ColInfo.GetPtr(&info), &local))
 		return ADE_RETURN_NIL;
 
-	if (!info->IsValid())
+	if (!info->isValid())
 		return ADE_RETURN_NIL;
 
 	mc_info *collide = info->Get();
@@ -119,7 +119,7 @@ ADE_FUNC(getCollisionNormal, l_ColInfo, "[boolean local]", "The collision normal
 	if(!ade_get_args(L, "o|b", l_ColInfo.GetPtr(&info), &local))
 		return ADE_RETURN_NIL;
 
-	if (!info->IsValid())
+	if (!info->isValid())
 		return ADE_RETURN_NIL;
 
 	mc_info *collide = info->Get();
@@ -154,7 +154,7 @@ ADE_FUNC(isValid, l_ColInfo, NULL, "Detects if this handle is valid", "boolean",
 	if(!ade_get_args(L, "o", l_ColInfo.GetPtr(&info)))
 		return ADE_RETURN_FALSE;
 
-	if (info->IsValid())
+	if (info->isValid())
 		return ADE_RETURN_TRUE;
 	else
 		return ADE_RETURN_FALSE;

--- a/code/scripting/api/objs/mc_info.h
+++ b/code/scripting/api/objs/mc_info.h
@@ -18,7 +18,7 @@ class mc_info_h
 
 	mc_info *Get();
 
-	bool IsValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_ColInfo, mc_info_h);

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -13,15 +13,15 @@ namespace api {
 
 ADE_OBJ(l_Model, model_h, "model", "3D Model (POF) handle");
 
-polymodel *model_h::Get()
+polymodel *model_h::Get() const
 {
 	return model;
 }
-int model_h::GetID()
+int model_h::GetID() const
 {
 	return model ? model->id : -1;
 }
-bool model_h::IsValid()
+bool model_h::isValid() const
 {
 	return (model != nullptr);
 }
@@ -56,11 +56,11 @@ submodel_h::submodel_h(int n_modelnum, int n_submodelnum)
 {
 	model = model_get(n_modelnum);
 }
-polymodel *submodel_h::GetModel() { return IsValid() ? model : nullptr; }
-int submodel_h::GetModelID() { return IsValid() ? model->id : -1; }
-bsp_info* submodel_h::GetSubmodel() { return IsValid() ? &model->submodel[submodel_num] : nullptr; }
-int submodel_h::GetSubmodelIndex() { return IsValid() ? submodel_num : -1; }
-bool submodel_h::IsValid()
+polymodel *submodel_h::GetModel() const { return isValid() ? model : nullptr; }
+int submodel_h::GetModelID() const { return isValid() ? model->id : -1; }
+bsp_info* submodel_h::GetSubmodel() const { return isValid() ? &model->submodel[submodel_num] : nullptr; }
+int submodel_h::GetSubmodelIndex() const { return isValid() ? submodel_num : -1; }
+bool submodel_h::isValid() const
 {
 	return model != nullptr && submodel_num >= 0 && submodel_num < model->n_models;
 }
@@ -93,7 +93,7 @@ ADE_VIRTVAR(Textures, l_Model, nullptr, "Model textures", "textures", "Model tex
 	if(pm == NULL)
 		return ade_set_error(L, "o", l_ModelTextures.Set(modeltextures_h()));
 
-	if(ADE_SETTING_VAR && oth && oth->IsValid()) {
+	if(ADE_SETTING_VAR && oth && oth->isValid()) {
 		//WMC TODO: Copy code
 		LuaError(L, "Attempt to use Incomplete Feature: Modeltextures copy");
 	}
@@ -112,7 +112,7 @@ ADE_VIRTVAR(Thrusters, l_Model, nullptr, "Model thrusters", "thrusters", "Model 
 	if(pm == NULL)
 		return ade_set_error(L, "o", l_Thrusters.Set(thrusters_h()));
 
-	if(ADE_SETTING_VAR && oth && oth->IsValid()) {
+	if(ADE_SETTING_VAR && oth && oth->isValid()) {
 		LuaError(L, "Attempt to use Incomplete Feature: Thrusters copy");
 	}
 
@@ -130,7 +130,7 @@ ADE_VIRTVAR(Eyepoints, l_Model, nullptr, "Model eyepoints", "eyepoints", "Array 
 	if(pm == NULL)
 		return ade_set_error(L, "o", l_Eyepoints.Set(eyepoints_h()));
 
-	if(ADE_SETTING_VAR && eph && eph->IsValid()) {
+	if(ADE_SETTING_VAR && eph && eph->isValid()) {
 		LuaError(L, "Attempt to use Incomplete Feature: Eyepoints copy");
 	}
 
@@ -148,7 +148,7 @@ ADE_VIRTVAR(Dockingbays, l_Model, nullptr, "Model docking bays", "dockingbays", 
 	if(pm == NULL)
 		return ade_set_error(L, "o", l_Dockingbays.Set(dockingbays_h()));
 
-	if(ADE_SETTING_VAR && dbh && dbh->IsValid()) {
+	if(ADE_SETTING_VAR && dbh && dbh->isValid()) {
 		LuaError(L, "Attempt to use Incomplete Feature: Docking bays copy");
 	}
 
@@ -301,7 +301,7 @@ ADE_FUNC(isValid, l_Model, nullptr, "True if valid, false or nil if not", "boole
 	if (!ade_get_args(L, "o", l_Model.GetPtr(&mdl)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", mdl->IsValid());
+	return ade_set_args(L, "b", mdl->isValid());
 }
 
 ADE_VIRTVAR(Name, l_Submodel, nullptr, "Gets the submodel's name", "string", "The name or an empty string if invalid")
@@ -311,7 +311,7 @@ ADE_VIRTVAR(Name, l_Submodel, nullptr, "Gets the submodel's name", "string", "Th
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "s", "");
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ade_set_error(L, "s", "");
 
 	if (ADE_SETTING_VAR)
@@ -327,7 +327,7 @@ ADE_VIRTVAR(Index, l_Submodel, nullptr, "Gets the submodel's index", "number", "
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "i", -1);
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ade_set_error(L, "i", -1);
 
 	if (ADE_SETTING_VAR)
@@ -343,7 +343,7 @@ ADE_VIRTVAR(Offset, l_Submodel, nullptr, "Gets the submodel's offset from its pa
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if (ADE_SETTING_VAR)
@@ -359,7 +359,7 @@ ADE_VIRTVAR(Radius, l_Submodel, nullptr, "Gets the submodel's radius", "number",
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ADE_SETTING_VAR)
@@ -376,7 +376,7 @@ ADE_FUNC(NumVertices, l_Submodel, nullptr, "Returns the number of vertices in th
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "i", 0);
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	auto sm = smh->GetSubmodel();
@@ -393,7 +393,7 @@ ADE_FUNC(GetVertex, l_Submodel, nullptr, "Gets the specified vertex, or a random
 	if (!ade_get_args(L, "o|i", l_Submodel.GetPtr(&smh), &idx))
 		return ADE_RETURN_NIL;
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto sm = smh->GetSubmodel(); 
@@ -420,7 +420,7 @@ ADE_FUNC(getFirstChild, l_Submodel, nullptr, "Gets the first child submodel of t
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
 	auto sm = smh->GetSubmodel();
@@ -437,7 +437,7 @@ ADE_FUNC(getNextSibling, l_Submodel, nullptr, "Gets the next sibling submodel of
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
 	auto sm = smh->GetSubmodel();
@@ -454,7 +454,7 @@ ADE_FUNC(getParent, l_Submodel, nullptr, "Gets the parent submodel of this submo
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
-	if (!smh->IsValid())
+	if (!smh->isValid())
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
 	auto sm = smh->GetSubmodel();
@@ -470,7 +470,7 @@ ADE_FUNC(isValid, l_Submodel, nullptr, "True if valid, false or nil if not", "bo
 	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", smh->IsValid());
+	return ade_set_args(L, "b", smh->isValid());
 }
 
 
@@ -486,7 +486,7 @@ ADE_FUNC(__len, l_ModelSubmodels, nullptr, "Number of submodels on model", "numb
 	if (!ade_get_args(L, "o", l_ModelSubmodels.GetPtr(&msh)))
 		return ade_set_error(L, "i", 0);
 
-	if (!msh->IsValid())
+	if (!msh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	polymodel *pm = msh->Get();
@@ -519,7 +519,7 @@ ADE_INDEXER(l_ModelSubmodels, "submodel", "number|string IndexOrName", "submodel
 		index = model_find_submodel_index(msh->GetID(), name);
 	}
 
-	if (!msh->IsValid())
+	if (!msh->isValid())
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
 	polymodel *pm = msh->Get();
@@ -536,7 +536,7 @@ ADE_FUNC(isValid, l_ModelSubmodels, nullptr, "Detects whether handle is valid", 
 	if (!ade_get_args(L, "o", l_ModelSubmodels.GetPtr(&msh)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", msh->IsValid());
+	return ade_set_args(L, "b", msh->isValid());
 }
 
 
@@ -552,7 +552,7 @@ ADE_FUNC(__len, l_ModelTextures, NULL, "Number of textures on model", "number", 
 	if(!ade_get_args(L, "o", l_ModelTextures.GetPtr(&mth)))
 		return ade_set_error(L, "i", 0);
 
-	if(!mth->IsValid())
+	if(!mth->isValid())
 		return ade_set_error(L, "i", 0);
 
 	polymodel *pm = mth->Get();
@@ -574,7 +574,7 @@ ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "text
 
 	polymodel *pm = mth->Get();
 
-	if (!mth->IsValid() || s == NULL || pm == NULL)
+	if (!mth->isValid() || s == NULL || pm == NULL)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	texture_info *tinfo = NULL;
@@ -620,7 +620,7 @@ ADE_FUNC(isValid, l_ModelTextures, NULL, "Detects whether handle is valid", "boo
 	if(!ade_get_args(L, "o", l_ModelTextures.GetPtr(&mth)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", mth->IsValid());
+	return ade_set_args(L, "b", mth->isValid());
 }
 
 
@@ -638,7 +638,7 @@ ADE_FUNC(__len, l_Eyepoints, NULL, "Gets the number of eyepoints on this model",
 		return ade_set_error(L, "i", 0);
 	}
 
-	if (!eph->IsValid())
+	if (!eph->isValid())
 	{
 		return ade_set_error(L, "i", 0);
 	}
@@ -664,7 +664,7 @@ ADE_INDEXER(l_Eyepoints, "eyepoint", "Gets an eyepoint handle", "eyepoint", "eye
 		return ade_set_error(L, "o", l_Eyepoint.Set(eye_h()));
 	}
 
-	if (!eph->IsValid())
+	if (!eph->isValid())
 	{
 		return ade_set_error(L, "o", l_Eyepoint.Set(eye_h()));
 	}
@@ -683,7 +683,7 @@ ADE_INDEXER(l_Eyepoints, "eyepoint", "Gets an eyepoint handle", "eyepoint", "eye
 		return ade_set_error(L, "o", l_Eyepoint.Set(eye_h()));
 	}
 
-	if (ADE_SETTING_VAR && eh && eh->IsValid())
+	if (ADE_SETTING_VAR && eh && eh->isValid())
 	{
 		LuaError(L, "Attempted to use incomplete feature: Eyepoint copy");
 	}
@@ -697,7 +697,7 @@ ADE_FUNC(isValid, l_Eyepoints, NULL, "Detects whether handle is valid or not", "
 	if(!ade_get_args(L, "o", l_Eyepoints.GetPtr(&eph)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", eph->IsValid());
+	return ade_set_args(L, "b", eph->isValid());
 }
 
 //**********HANDLE: thrusters
@@ -712,7 +712,7 @@ ADE_FUNC(__len, l_Thrusters, NULL, "Number of thruster banks on the model", "num
 	if(!ade_get_args(L, "o", l_Thrusters.GetPtr(&trh)))
 		return ade_set_error(L, "i", -1);
 
-	if(!trh->IsValid())
+	if(!trh->isValid())
 		return ade_set_error(L, "i", -1);
 
 	polymodel *pm = trh->Get();
@@ -734,7 +734,7 @@ ADE_INDEXER(l_Thrusters, "number Index", "Array of all thrusterbanks on this thr
 
 	polymodel *pm = trh->Get();
 
-	if (!trh->IsValid() || s == NULL || pm == NULL)
+	if (!trh->isValid() || s == NULL || pm == NULL)
 		return ade_set_error(L, "o", l_Thrusterbank.Set(thrusterbank_h()));
 
 	//Determine index
@@ -762,7 +762,7 @@ ADE_FUNC(isValid, l_Thrusters, NULL, "Detects whether handle is valid", "boolean
 	if(!ade_get_args(L, "o", l_Thrusters.GetPtr(&trh)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", trh->IsValid());
+	return ade_set_args(L, "b", trh->isValid());
 }
 
 //**********HANDLE: thrusterbank
@@ -774,13 +774,13 @@ thrusterbank_h::thrusterbank_h() {
 thrusterbank_h::thrusterbank_h(thruster_bank* ba) {
 	bank = ba;
 }
-thruster_bank* thrusterbank_h::Get() {
+thruster_bank* thrusterbank_h::Get() const {
 	if (!isValid())
 		return NULL;
 
 	return bank;
 }
-bool thrusterbank_h::isValid() {
+bool thrusterbank_h::isValid() const {
 	return bank != NULL;
 }
 
@@ -851,13 +851,13 @@ glowpoint_h::glowpoint_h() {
 glowpoint_h::glowpoint_h(glow_point* np) {
 	point = np;
 }
-glow_point* glowpoint_h::Get() {
+glow_point* glowpoint_h::Get() const {
 	if (!isValid())
 		return NULL;
 
 	return point;
 }
-bool glowpoint_h::isValid() {
+bool glowpoint_h::isValid() const {
 	return point != NULL;
 }
 
@@ -930,7 +930,7 @@ ADE_INDEXER(l_Dockingbays, "dockingbay", "Gets a dockingbay handle from this mod
 		if (!ade_get_args(L, "oi|o", l_Dockingbays.GetPtr(&dbhp), &index, l_Dockingbay.GetPtr(&newVal)))
 			return ade_set_error(L, "o", l_Dockingbay.Set(dockingbay_h()));
 
-		if (!dbhp->IsValid())
+		if (!dbhp->isValid())
 			return ade_set_error(L, "o", l_Dockingbay.Set(dockingbay_h()));
 
 		index--; // Lua --> C/C++
@@ -944,7 +944,7 @@ ADE_INDEXER(l_Dockingbays, "dockingbay", "Gets a dockingbay handle from this mod
 			return ade_set_error(L, "o", l_Dockingbay.Set(dockingbay_h()));
 		}
 
-		if (!dbhp->IsValid() && name != NULL)
+		if (!dbhp->isValid() && name != NULL)
 			return ade_set_error(L, "o", l_Dockingbay.Set(dockingbay_h()));
 
 		index = model_find_dock_name_index(dbhp->GetID(), name);
@@ -967,7 +967,7 @@ ADE_FUNC(__len, l_Dockingbays, NULL, "Retrieves the number of dockingbays on thi
 	if (!ade_get_args(L, "o", l_Dockingbays.GetPtr(&dbhp)))
 		return ade_set_error(L, "i", 0);
 
-	if (!dbhp->IsValid())
+	if (!dbhp->isValid())
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", dbhp->Get()->n_docks);
@@ -978,8 +978,8 @@ ADE_OBJ(l_Dockingbay, dockingbay_h, "dockingbay", "Handle to a model docking bay
 
 dockingbay_h::dockingbay_h(polymodel* pm, int dock_idx) : model_h(pm), dock_id(dock_idx) {}
 dockingbay_h::dockingbay_h() : model_h(), dock_id(-1){}
-bool dockingbay_h::IsValid() {
-	if (!model_h::IsValid())
+bool dockingbay_h::isValid() const {
+	if (!model_h::isValid())
 	{
 		return false;
 	}
@@ -988,8 +988,8 @@ bool dockingbay_h::IsValid() {
 		return dock_id >= 0 && dock_id < this->Get()->n_docks;
 	}
 }
-dock_bay* dockingbay_h::getDockingBay() {
-	if (!this->IsValid())
+dock_bay* dockingbay_h::getDockingBay() const {
+	if (!this->isValid())
 	{
 		return NULL;
 	}
@@ -1006,7 +1006,7 @@ ADE_FUNC(__len, l_Dockingbay, NULL, "Gets the number of docking points in this b
 		return ade_set_error(L, "i", 0);
 	}
 
-	if (dbh == NULL || !dbh->IsValid())
+	if (dbh == NULL || !dbh->isValid())
 	{
 		return ade_set_error(L, "i", 0);
 	}
@@ -1022,7 +1022,7 @@ ADE_FUNC(getName, l_Dockingbay, NULL, "Gets the name of this docking bay", "stri
 		return ade_set_error(L, "s", "");
 	}
 
-	if (dbh == NULL || !dbh->IsValid())
+	if (dbh == NULL || !dbh->isValid())
 	{
 		return ade_set_error(L, "s", "");
 	}
@@ -1044,7 +1044,7 @@ ADE_FUNC(getPoint, l_Dockingbay, "number index", "Gets the location of a docking
 
 	index--; // Lua --> C/C++
 
-	if (dbh == NULL || !dbh->IsValid())
+	if (dbh == NULL || !dbh->isValid())
 	{
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 	}
@@ -1072,7 +1072,7 @@ ADE_FUNC(getNormal, l_Dockingbay, "number index", "Gets the normal of a docking 
 
 	index--; // Lua --> C/C++
 
-	if (dbh == NULL || !dbh->IsValid())
+	if (dbh == NULL || !dbh->isValid())
 	{
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 	}
@@ -1103,7 +1103,7 @@ ADE_FUNC(computeDocker, l_Dockingbay, "dockingbay",
 		return ADE_RETURN_NIL;
 	}
 
-	if (!dockee_bay_h->IsValid() || !docker_bay_h->IsValid())
+	if (!dockee_bay_h->isValid() || !docker_bay_h->isValid())
 	{
 		return ADE_RETURN_NIL;
 	}
@@ -1151,7 +1151,7 @@ ADE_FUNC(isValid, l_Dockingbay, NULL, "Detects whether is valid or not", "number
 		return ADE_RETURN_FALSE;
 	}
 
-	return ade_set_args(L, "b", dbh->IsValid());
+	return ade_set_args(L, "b", dbh->isValid());
 }
 
 }

--- a/code/scripting/api/objs/model.h
+++ b/code/scripting/api/objs/model.h
@@ -18,11 +18,11 @@ class model_h
 	explicit model_h(polymodel *n_model);
 	model_h();
 
-	polymodel *Get();
+	polymodel *Get() const;
 
-	int GetID();
+	int GetID() const;
 
-	bool IsValid();
+	bool isValid() const;
 };
 DECLARE_ADE_OBJ(l_Model, model_h);
 
@@ -37,13 +37,13 @@ public:
 	explicit submodel_h(polymodel *n_model, int n_submodelnum);
 	submodel_h();
 
-	polymodel *GetModel();
-	int GetModelID();
+	polymodel *GetModel() const;
+	int GetModelID() const;
 
-	bsp_info *GetSubmodel();
-	int GetSubmodelIndex();
+	bsp_info *GetSubmodel() const;
+	int GetSubmodelIndex() const;
 
-	bool IsValid();
+	bool isValid() const;
 };
 DECLARE_ADE_OBJ(l_Submodel, submodel_h);
 
@@ -89,9 +89,9 @@ struct thrusterbank_h
 
 	thrusterbank_h(thruster_bank* ba);
 
-	thruster_bank *Get();
+	thruster_bank *Get() const;
 
-	bool isValid();
+	bool isValid() const;
 };
 DECLARE_ADE_OBJ(l_Thrusterbank, thrusterbank_h);
 
@@ -104,9 +104,9 @@ struct glowpoint_h
 
 	glowpoint_h(glow_point* np);
 
-	glow_point* Get();
+	glow_point* Get() const;
 
-	bool isValid();
+	bool isValid() const;
 
 };
 DECLARE_ADE_OBJ(l_Glowpoint, glowpoint_h);
@@ -129,9 +129,9 @@ class dockingbay_h : public model_h
 	dockingbay_h(polymodel *pm, int dock_idx);
 	dockingbay_h();
 
-	bool IsValid();
+	bool isValid() const;
 
-	dock_bay* getDockingBay();
+	dock_bay* getDockingBay() const;
 };
 DECLARE_ADE_OBJ(l_Dockingbay, dockingbay_h);
 

--- a/code/scripting/api/objs/model_path.cpp
+++ b/code/scripting/api/objs/model_path.cpp
@@ -82,7 +82,7 @@ model_path_h::model_path_h(const ship_subsys_h& _subsys, const model_path& _path
 		verts.push_back(_path.verts[i]);
 	}
 }
-bool model_path_h::isValid() const { return subsys.isSubsystemValid(); }
+bool model_path_h::isValid() const { return subsys.isValid(); }
 
 ADE_OBJ(l_ModelPath, model_path_h, "modelpath", "Path of a model");
 

--- a/code/scripting/api/objs/model_path.cpp
+++ b/code/scripting/api/objs/model_path.cpp
@@ -47,7 +47,7 @@ ADE_VIRTVAR(Position, l_ModelPathPoint, "vector", "The current, global position 
 	}
 
 	// A submodel is only valid if the object is a ship so this is safe
-	auto objp  = p->parent->subsys.objp;
+	auto objp  = p->parent->subsys.objh.objp;
 	auto shipp = &Ships[objp->instance];
 
 	auto pmi = model_get_instance(shipp->model_instance_num);

--- a/code/scripting/api/objs/modelinstance.cpp
+++ b/code/scripting/api/objs/modelinstance.cpp
@@ -25,7 +25,7 @@ polymodel_instance *modelinstance_h::Get()
 {
 	return _pmi;
 }
-bool modelinstance_h::IsValid()
+bool modelinstance_h::isValid() const
 {
 	return (_pmi != nullptr);
 }
@@ -49,25 +49,25 @@ submodelinstance_h::submodelinstance_h()
 {}
 polymodel_instance *submodelinstance_h::GetModelInstance()
 {
-	return IsValid() ? _pmi : nullptr;
+	return isValid() ? _pmi : nullptr;
 }
 submodel_instance *submodelinstance_h::Get()
 {
-	return IsValid() ? &_pmi->submodel[_submodel_num] : nullptr;
+	return isValid() ? &_pmi->submodel[_submodel_num] : nullptr;
 }
 polymodel *submodelinstance_h::GetModel()
 {
-	return IsValid() ? _pm : nullptr;
+	return isValid() ? _pm : nullptr;
 }
 bsp_info *submodelinstance_h::GetSubmodel()
 {
-	return IsValid() ? &_pm->submodel[_submodel_num] : nullptr;
+	return isValid() ? &_pm->submodel[_submodel_num] : nullptr;
 }
 int submodelinstance_h::GetSubmodelIndex()
 {
-	return IsValid() ? _submodel_num : -1;
+	return isValid() ? _submodel_num : -1;
 }
-bool submodelinstance_h::IsValid()
+bool submodelinstance_h::isValid() const
 {
 	return _pmi != nullptr && _pm != nullptr && _submodel_num >= 0 && _submodel_num < _pm->n_models;
 }
@@ -116,7 +116,7 @@ ADE_FUNC(isValid, l_ModelInstance, nullptr, "True if valid, false or nil if not"
 	if (!ade_get_args(L, "o", l_ModelInstance.GetPtr(&mih)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", mih->IsValid());
+	return ade_set_args(L, "b", mih->isValid());
 }
 
 ADE_FUNC(getModelInstance, l_SubmodelInstance, nullptr, "Gets the model instance of this submodel", "model_instance", "A model instancve")
@@ -125,7 +125,7 @@ ADE_FUNC(getModelInstance, l_SubmodelInstance, nullptr, "Gets the model instance
 	if (!ade_get_args(L, "o", l_SubmodelInstance.GetPtr(&smih)))
 		return ade_set_error(L, "o", l_ModelInstance.Set(modelinstance_h()));
 
-	if (!smih->IsValid())
+	if (!smih->isValid())
 		return ade_set_error(L, "o", l_ModelInstance.Set(modelinstance_h()));
 
 	return ade_set_args(L, "o", l_ModelInstance.Set(modelinstance_h(smih->GetModelInstance())));
@@ -137,7 +137,7 @@ ADE_FUNC(getSubmodel, l_SubmodelInstance, nullptr, "Gets the submodel of this in
 	if (!ade_get_args(L, "o", l_SubmodelInstance.GetPtr(&smih)))
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
-	if (!smih->IsValid())
+	if (!smih->isValid())
 		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
 
 	return ade_set_args(L, "o", l_Submodel.Set(submodel_h(smih->GetModel(), smih->GetSubmodelIndex())));
@@ -150,7 +150,7 @@ ADE_VIRTVAR(Orientation, l_SubmodelInstance, "orientation", "Gets or sets the su
 	if (!ade_get_args(L, "o|o", l_SubmodelInstance.GetPtr(&smih), l_Matrix.GetPtr(&mh)))
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
-	if (!smih->IsValid())
+	if (!smih->isValid())
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
 	auto smi = smih->Get();
@@ -184,7 +184,7 @@ ADE_VIRTVAR(TranslationOffset,
 	if (!ade_get_args(L, "o|o", l_SubmodelInstance.GetPtr(&smih), l_Vector.GetPtr(&vec)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!smih->IsValid())
+	if (!smih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if (ADE_SETTING_VAR && vec != nullptr)
@@ -207,7 +207,7 @@ ADE_FUNC(findWorldPoint, l_SubmodelInstance, "vector", "Calculates the world coo
 	if (!ade_get_args(L, "oo", l_SubmodelInstance.GetPtr(&smih), l_Vector.Get(&pnt)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!smih->IsValid())
+	if (!smih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	auto pmi = smih->GetModelInstance();
@@ -226,7 +226,7 @@ ADE_FUNC(findWorldDir, l_SubmodelInstance, "vector", "Calculates the world direc
 	if (!ade_get_args(L, "oo", l_SubmodelInstance.GetPtr(&smih), l_Vector.Get(&dir)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!smih->IsValid())
+	if (!smih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	auto pmi = smih->GetModelInstance();
@@ -246,7 +246,7 @@ bool findObjectPointAndOrientationSub(lua_State *L, bool use_object, vec3d *outp
 	if (!ade_get_args(L, "ooo", l_SubmodelInstance.GetPtr(&smih), l_Vector.Get(&local_pnt), l_Matrix.GetPtr(&local_orient)))
 		return false;
 
-	if (!smih->IsValid())
+	if (!smih->isValid())
 		return false;
 
 	auto pmi = smih->GetModelInstance();
@@ -293,7 +293,7 @@ ADE_FUNC(findLocalPointAndOrientation, l_SubmodelInstance, "vector, orientation,
 	if (!ade_get_args(L, "ooo|b", l_SubmodelInstance.GetPtr(&smih), l_Vector.Get(&global_pnt), l_Matrix.GetPtr(&global_orient), &fromWorld))
 		return ade_set_error(L, "oo", l_Vector.Set(vmd_zero_vector), l_Matrix.Set(matrix_h(&vmd_zero_matrix)));
 
-	if (!smih->IsValid())
+	if (!smih->isValid())
 		return ade_set_error(L, "oo", l_Vector.Set(vmd_zero_vector), l_Matrix.Set(matrix_h(&vmd_zero_matrix)));
 
 	auto pmi = smih->GetModelInstance();
@@ -311,7 +311,7 @@ ADE_FUNC(isValid, l_SubmodelInstance, nullptr, "True if valid, false or nil if n
 	if (!ade_get_args(L, "o", l_SubmodelInstance.GetPtr(&smih)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", smih->IsValid());
+	return ade_set_args(L, "b", smih->isValid());
 }
 
 
@@ -326,7 +326,7 @@ ADE_FUNC(__len, l_ModelSubmodelInstances, nullptr, "Number of submodel instances
 	if (!ade_get_args(L, "o", l_ModelSubmodelInstances.GetPtr(&msih)))
 		return ade_set_error(L, "i", 0);
 
-	if (!msih->IsValid())
+	if (!msih->isValid())
 		return ade_set_error(L, "i", 0);
 
 	auto pmi = msih->Get();
@@ -349,7 +349,7 @@ ADE_INDEXER(l_ModelSubmodelInstances, "submodel_instance", "number|string IndexO
 		if (!ade_get_args(L, "oi", l_ModelSubmodelInstances.GetPtr(&msih), &index))
 			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
 
-		if (!msih->IsValid())
+		if (!msih->isValid())
 			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
 
 		index--; // Lua --> C/C++
@@ -361,7 +361,7 @@ ADE_INDEXER(l_ModelSubmodelInstances, "submodel_instance", "number|string IndexO
 		if (!ade_get_args(L, "os", l_ModelSubmodelInstances.GetPtr(&msih), &name))
 			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
 
-		if (!msih->IsValid() || name == nullptr)
+		if (!msih->isValid() || name == nullptr)
 			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
 
 		index = model_find_submodel_index(msih->Get()->model_num, name);
@@ -373,7 +373,7 @@ ADE_INDEXER(l_ModelSubmodelInstances, "submodel_instance", "number|string IndexO
 		if (!ade_get_args(L, "oo", l_ModelSubmodelInstances.GetPtr(&msih), l_Submodel.GetPtr(&smh)))
 			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
 
-		if (!msih->IsValid() || !smh->IsValid())
+		if (!msih->isValid() || !smh->isValid())
 			return ade_set_error(L, "o", l_SubmodelInstance.Set(submodelinstance_h()));
 
 		index = smh->GetSubmodelIndex();
@@ -394,7 +394,7 @@ ADE_FUNC(isValid, l_ModelSubmodelInstances, nullptr, "Detects whether handle is 
 	if (!ade_get_args(L, "o", l_ModelSubmodelInstances.GetPtr(&msih)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", msih->IsValid());
+	return ade_set_args(L, "b", msih->isValid());
 }
 
 }

--- a/code/scripting/api/objs/modelinstance.h
+++ b/code/scripting/api/objs/modelinstance.h
@@ -19,7 +19,7 @@ class modelinstance_h
 
 	polymodel_instance *Get();
 
-	bool IsValid();
+	bool isValid() const;
 };
 DECLARE_ADE_OBJ(l_ModelInstance, modelinstance_h);
 
@@ -42,7 +42,7 @@ public:
 	bsp_info *GetSubmodel();
 	int GetSubmodelIndex();
 
-	bool IsValid();
+	bool isValid() const;
 };
 DECLARE_ADE_OBJ(l_SubmodelInstance, submodelinstance_h);
 

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -28,7 +28,7 @@
 void object_h::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
 	object_h obj;
 	value.getValue(scripting::api::l_Object.Get(&obj));
-	const ushort& netsig = obj.IsValid() ? obj.objp->net_signature : 0;
+	const ushort& netsig = obj.isValid() ? obj.objp->net_signature : 0;
 	ADD_USHORT(netsig);
 }
 
@@ -54,7 +54,7 @@ ADE_FUNC(__eq, l_Object, "object, object", "Checks whether two object handles ar
 	if(!ade_get_args(L, "oo", l_Object.GetPtr(&o1), l_Object.GetPtr(&o2)))
 		return ADE_RETURN_FALSE;
 
-	if(!o1->IsValid() || !o2->IsValid())
+	if(!o1->isValid() || !o2->isValid())
 		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", o1->sig == o2->sig);
@@ -66,7 +66,7 @@ ADE_FUNC(__tostring, l_Object, NULL, "Returns name of object (if any)", "string"
 	if(!ade_get_args(L, "o", l_Object.GetPtr(&objh)))
 		return ade_set_error(L, "s", "");
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	char buf[512];
@@ -93,12 +93,12 @@ ADE_VIRTVAR(Parent, l_Object, "object", "Parent of the object. Value may also be
 	if(!ade_get_args(L, "o|o", l_Object.GetPtr(&objh), l_Object.GetPtr(&newparenth)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newparenth != NULL && newparenth->IsValid())
+		if(newparenth != NULL && newparenth->isValid())
 		{
 			objh->objp->parent = OBJ_INDEX(newparenth->objp);
 			objh->objp->parent_sig = newparenth->sig;
@@ -123,7 +123,7 @@ ADE_VIRTVAR(Radius, l_Object, "number", "Radius of an object", "number", "Radius
 	if (!ade_get_args(L, "o|f", l_Object.GetPtr(&objh), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if (ADE_SETTING_VAR) {
@@ -140,7 +140,7 @@ ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)"
 	if(!ade_get_args(L, "o|o", l_Object.GetPtr(&objh), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -164,7 +164,7 @@ ADE_VIRTVAR(LastPosition, l_Object, "vector", "Object world position as of last 
 	if(!ade_get_args(L, "o|o", l_Object.GetPtr(&objh), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -181,7 +181,7 @@ ADE_VIRTVAR(Orientation, l_Object, "orientation", "Object world orientation (Wor
 	if(!ade_get_args(L, "o|o", l_Object.GetPtr(&objh), l_Matrix.GetPtr(&mh)))
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h(&vmd_identity_matrix)));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h(&vmd_identity_matrix)));
 
 	if(ADE_SETTING_VAR && mh != NULL) {
@@ -201,7 +201,7 @@ ADE_VIRTVAR(LastOrientation, l_Object, "orientation", "Object world orientation 
 	if(!ade_get_args(L, "o|o", l_Object.GetPtr(&objh), l_Matrix.GetPtr(&mh)))
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h(&vmd_identity_matrix)));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h(&vmd_identity_matrix)));
 
 	if(ADE_SETTING_VAR && mh != NULL) {
@@ -217,7 +217,7 @@ ADE_VIRTVAR(ModelInstance, l_Object, nullptr, "model instance used by this objec
 	if (!ade_get_args(L, "o", l_Object.GetPtr(&objh)))
 		return ade_set_error(L, "o", l_ModelInstance.Set(modelinstance_h()));
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "o", l_ModelInstance.Set(modelinstance_h()));
 
 	if (ADE_SETTING_VAR)
@@ -237,10 +237,10 @@ ADE_VIRTVAR(Physics, l_Object, "physics", "Physics data used to move ship betwee
 	if(!ade_get_args(L, "o|o", l_Object.GetPtr(&objh), l_Physics.GetPtr(&pih)))
 		return ade_set_error(L, "o", l_Physics.Set(physics_info_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Physics.Set(physics_info_h()));
 
-	if(ADE_SETTING_VAR && pih && pih->IsValid()) {
+	if(ADE_SETTING_VAR && pih && pih->isValid()) {
 		objh->objp->phys_info = *pih->pi;
 	}
 
@@ -254,7 +254,7 @@ ADE_VIRTVAR(HitpointsLeft, l_Object, "number", "Hitpoints an object has left", "
 	if(!ade_get_args(L, "o|f", l_Object.GetPtr(&objh), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	//Set hull strength.
@@ -272,7 +272,7 @@ ADE_VIRTVAR(SimHitpointsLeft, l_Object, "number", "Simulated hitpoints an object
 	if (!ade_get_args(L, "o|f", l_Object.GetPtr(&objh), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	//Set sim hull strength.
@@ -290,11 +290,11 @@ ADE_VIRTVAR(Shields, l_Object, "shields", "Shields", "shields", "Shields handle,
 	if(!ade_get_args(L, "o|o", l_Object.GetPtr(&objh), l_Shields.GetPtr(&sobjh)))
 		return ade_set_error(L, "o", l_Shields.Set(object_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Shields.Set(object_h()));
 
 	//WMC - copy shields
-	if(ADE_SETTING_VAR && sobjh && sobjh->IsValid())
+	if(ADE_SETTING_VAR && sobjh && sobjh->isValid())
 	{
 		for(int i = 0; i < objh->objp->n_quadrants; i++)
 			shield_set_quad(objh->objp, i, shield_get_quad(sobjh->objp, i));
@@ -309,7 +309,7 @@ ADE_FUNC(getSignature, l_Object, NULL, "Gets the object's unique signature", "nu
 	if(!ade_get_args(L, "o", l_Object.GetPtr(&oh)))
 		return ade_set_error(L, "i", -1);
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "i", -1);
 
 	return ade_set_args(L, "i", oh->sig);
@@ -321,7 +321,7 @@ ADE_FUNC(isValid, l_Object, NULL, "Detects whether handle is valid", "boolean", 
 	if(!ade_get_args(L, "o", l_Object.GetPtr(&oh)))
 		return ADE_RETURN_FALSE;
 
-	return ade_set_args(L, "b", oh->IsValid());
+	return ade_set_args(L, "b", oh->isValid());
 }
 
 ADE_FUNC(isExpiring, l_Object, nullptr, "Checks whether the object has the should-be-dead flag set, which will cause it to be deleted within one frame", "boolean", "true or false according to the flag, or nil if a syntax/type error occurs")
@@ -330,7 +330,7 @@ ADE_FUNC(isExpiring, l_Object, nullptr, "Checks whether the object has the shoul
 	if (!ade_get_args(L, "o", l_Object.GetPtr(&oh)))
 		return ADE_RETURN_NIL;
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "b", oh->objp->flags[Object::Object_Flags::Should_be_dead]);
@@ -342,7 +342,7 @@ ADE_FUNC(getBreedName, l_Object, NULL, "Gets object type", "string", "Object typ
 	if(!ade_get_args(L, "o", l_Object.GetPtr(&objh)))
 		return ade_set_error(L, "s", "");
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", Object_type_names[objh->objp->type]);
@@ -355,7 +355,7 @@ ADE_VIRTVAR(CollisionGroups, l_Object, "number", "Collision group data", "number
 	if(!ade_get_args(L, "o|i", l_Object.GetPtr(&objh), &id))
 		return ade_set_error(L, "i", 0);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	//Set collision group data
@@ -374,7 +374,7 @@ ADE_FUNC(addToCollisionGroup, l_Object, "number group", "Adds this object to the
 	if (!ade_get_args(L, "oi", l_Object.GetPtr(&objh), &group))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	if (group >= 0 && group <= 31)
@@ -393,7 +393,7 @@ ADE_FUNC(removeFromCollisionGroup, l_Object, "number group", "Removes this objec
 	if (!ade_get_args(L, "oi", l_Object.GetPtr(&objh), &group))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	if (group >= 0 && group <= 31)
@@ -414,7 +414,7 @@ ADE_FUNC(getfvec, l_Object, "[boolean normalize]", "Returns the objects' current
 		return ADE_RETURN_NIL;
 	}
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	obj = objh->objp;
@@ -435,7 +435,7 @@ ADE_FUNC(getuvec, l_Object, "[boolean normalize]", "Returns the objects' current
 		return ADE_RETURN_NIL;
 	}
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	obj = objh->objp;
@@ -456,7 +456,7 @@ ADE_FUNC(getrvec, l_Object, "[boolean normalize]", "Returns the objects' current
 		return ADE_RETURN_NIL;
 	}
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	obj = objh->objp;
@@ -482,7 +482,7 @@ ADE_FUNC(
 	if(!ade_get_args(L, "ooo|b", l_Object.GetPtr(&objh), l_Vector.GetPtr(&v3a), l_Vector.GetPtr(&v3b), &local))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	obj = objh->objp;
@@ -559,7 +559,7 @@ ADE_FUNC(addPreMoveHook, l_Object, "function(object object) => void callback",
 		return ADE_RETURN_NIL;
 	}
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	objh->objp->pre_move_event.add(make_lua_callback<void, object*>(callback));
@@ -583,7 +583,7 @@ ADE_FUNC(addPostMoveHook, l_Object, "function(object object) => void callback",
 		return ADE_RETURN_NIL;
 	}
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	objh->objp->post_move_event.add(make_lua_callback<void, object*>(callback));
@@ -606,7 +606,7 @@ ADE_FUNC(assignSound, l_Object, "soundentry GameSnd, [vector Offset=nil, enumera
 	if (!ade_get_args(L, "oo|ooo", l_Object.GetPtr(&objh), l_SoundEntry.GetPtr(&seh), l_Vector.GetPtr(&offset), l_Enum.Get(&enum_flags), l_Subsystem.GetPtr(&tgsh)))
 		return ade_set_error(L, "i", -1);
 
-	if (!objh->IsValid() || !seh->IsValid() || (tgsh && (!tgsh->IsValid() || !tgsh->isSubsystemValid())))
+	if (!objh->isValid() || !seh->isValid() || (tgsh && (!tgsh->isValid() || !tgsh->isSubsystemValid())))
 		return ade_set_error(L, "i", -1);
 
 	auto objp = objh->objp;
@@ -656,7 +656,7 @@ ADE_FUNC(removeSound, l_Object, "soundentry GameSnd, [subsystem Subsys=nil]",
 	if (!ade_get_args(L, "oo|o", l_Object.GetPtr(&objh), l_SoundEntry.GetPtr(&seh), l_Subsystem.GetPtr(&tgsh)))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid() || !seh->IsValid() || (tgsh && (!tgsh->IsValid() || !tgsh->isSubsystemValid())))
+	if (!objh->isValid() || !seh->isValid() || (tgsh && (!tgsh->isValid() || !tgsh->isSubsystemValid())))
 		return ADE_RETURN_NIL;
 
 	auto objp = objh->objp;
@@ -680,7 +680,7 @@ ADE_FUNC(getIFFColor, l_Object, "boolean ReturnType",
 	if (!ade_get_args(L, "o|b", l_Object.GetPtr(&objh), &rc))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto objp = objh->objp;

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -606,7 +606,7 @@ ADE_FUNC(assignSound, l_Object, "soundentry GameSnd, [vector Offset=nil, enumera
 	if (!ade_get_args(L, "oo|ooo", l_Object.GetPtr(&objh), l_SoundEntry.GetPtr(&seh), l_Vector.GetPtr(&offset), l_Enum.Get(&enum_flags), l_Subsystem.GetPtr(&tgsh)))
 		return ade_set_error(L, "i", -1);
 
-	if (!objh->isValid() || !seh->isValid() || (tgsh && (!tgsh->isValid() || !tgsh->isSubsystemValid())))
+	if (!objh->isValid() || !seh->isValid() || (tgsh && !tgsh->isSubsystemValid()))
 		return ade_set_error(L, "i", -1);
 
 	auto objp = objh->objp;
@@ -656,7 +656,7 @@ ADE_FUNC(removeSound, l_Object, "soundentry GameSnd, [subsystem Subsys=nil]",
 	if (!ade_get_args(L, "oo|o", l_Object.GetPtr(&objh), l_SoundEntry.GetPtr(&seh), l_Subsystem.GetPtr(&tgsh)))
 		return ADE_RETURN_NIL;
 
-	if (!objh->isValid() || !seh->isValid() || (tgsh && (!tgsh->isValid() || !tgsh->isSubsystemValid())))
+	if (!objh->isValid() || !seh->isValid() || (tgsh && !tgsh->isSubsystemValid()))
 		return ADE_RETURN_NIL;
 
 	auto objp = objh->objp;

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -606,7 +606,7 @@ ADE_FUNC(assignSound, l_Object, "soundentry GameSnd, [vector Offset=nil, enumera
 	if (!ade_get_args(L, "oo|ooo", l_Object.GetPtr(&objh), l_SoundEntry.GetPtr(&seh), l_Vector.GetPtr(&offset), l_Enum.Get(&enum_flags), l_Subsystem.GetPtr(&tgsh)))
 		return ade_set_error(L, "i", -1);
 
-	if (!objh->isValid() || !seh->isValid() || (tgsh && !tgsh->isSubsystemValid()))
+	if (!objh->isValid() || !seh->isValid() || (tgsh && !tgsh->isValid()))
 		return ade_set_error(L, "i", -1);
 
 	auto objp = objh->objp;
@@ -656,7 +656,7 @@ ADE_FUNC(removeSound, l_Object, "soundentry GameSnd, [subsystem Subsys=nil]",
 	if (!ade_get_args(L, "oo|o", l_Object.GetPtr(&objh), l_SoundEntry.GetPtr(&seh), l_Subsystem.GetPtr(&tgsh)))
 		return ADE_RETURN_NIL;
 
-	if (!objh->isValid() || !seh->isValid() || (tgsh && !tgsh->isSubsystemValid()))
+	if (!objh->isValid() || !seh->isValid() || (tgsh && !tgsh->isValid()))
 		return ADE_RETURN_NIL;
 
 	auto objp = objh->objp;

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -351,7 +351,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Order, "subsystem", "Target subsystem of the orde
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->isSubsystemValid() && (ohp->aigp->ai_mode == AI_GOAL_DESTROY_SUBSYSTEM))
+		if(newh && newh->isValid() && (ohp->aigp->ai_mode == AI_GOAL_DESTROY_SUBSYSTEM))
 		{
 			objp = &Objects[newh->ss->parent_objnum];
 			if(!stricmp(Ships[objp->instance].ship_name, ohp->aigp->target_name)) {

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -22,7 +22,7 @@ order_h::order_h() {
 }
 order_h::order_h(object* objp, int n_odx) {
 	objh = object_h(objp);
-	if(objh.IsValid() && objh.objp->type == OBJ_SHIP && n_odx > -1 && n_odx < MAX_AI_GOALS)
+	if(objh.isValid() && objh.objp->type == OBJ_SHIP && n_odx > -1 && n_odx < MAX_AI_GOALS)
 	{
 		odx = n_odx;
 		sig = Ai_info[Ships[objh.objp->instance].ai_index].goals[odx].signature;
@@ -35,11 +35,11 @@ order_h::order_h(object* objp, int n_odx) {
 		aigp = NULL;
 	}
 }
-bool order_h::IsValid() {
+bool order_h::isValid() const {
 	if (objh.objp == NULL || aigp == NULL)
 		return false;
 
-	return objh.IsValid() && objh.objp->type == OBJ_SHIP && odx > -1 && odx < MAX_AI_GOALS && sig == Ai_info[Ships[objh.objp->instance].ai_index].goals[odx].signature;
+	return objh.isValid() && objh.objp->type == OBJ_SHIP && odx > -1 && odx < MAX_AI_GOALS && sig == Ai_info[Ships[objh.objp->instance].ai_index].goals[odx].signature;
 }
 
 //**********HANDLE: order
@@ -53,7 +53,7 @@ ADE_VIRTVAR(Priority, l_Order, "number", "Priority of the given order", "number"
 	if(!ade_get_args(L, "o|i", l_Order.GetPtr(&ohp), &priority))
 		return ade_set_error(L, "i", 0);
 
-	if(!ohp->IsValid())
+	if(!ohp->isValid())
 		return ade_set_error(L, "i", 0);
 
 	if(ADE_SETTING_VAR) {
@@ -69,7 +69,7 @@ ADE_FUNC(remove, l_Order, NULL, "Removes the given order from the ship's priorit
 	if(!ade_get_args(L, "o", l_Order.GetPtr(&ohp)))
 		return ADE_RETURN_NIL;
 
-	if(!ohp->IsValid())
+	if(!ohp->isValid())
 		return ADE_RETURN_FALSE;
 
 	ai_info *aip = &Ai_info[Ships[ohp->objh.objp->instance].ai_index];
@@ -86,7 +86,7 @@ ADE_FUNC(getType, l_Order, NULL, "Gets the type of the order.", "enumeration", "
 	if(!ade_get_args(L, "o", l_Order.GetPtr(&ohp)))
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
-	if(!ohp->IsValid())
+	if(!ohp->isValid())
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
 	switch(ohp->aigp->ai_mode){
@@ -185,13 +185,13 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 	if(!ade_get_args(L, "o|o", l_Order.GetPtr(&ohp), l_Object.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(!ohp->IsValid())
+	if(!ohp->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	aip = &Ai_info[Ships[ohp->objh.objp->instance].ai_index];
 
 	if(ADE_SETTING_VAR){
-		if(newh && newh->IsValid()){
+		if(newh && newh->isValid()){
 			switch(ohp->aigp->ai_mode){
 				case AI_GOAL_DESTROY_SUBSYSTEM:
 				case AI_GOAL_CHASE:
@@ -344,7 +344,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Order, "subsystem", "Target subsystem of the orde
 	if(!ade_get_args(L, "o|o", l_Order.GetPtr(&ohp), l_Subsystem.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(!ohp->IsValid())
+	if(!ohp->isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	aip = &Ai_info[Ships[ohp->objh.objp->instance].ai_index];
@@ -385,7 +385,7 @@ ADE_FUNC(isValid, l_Order, NULL, "Detects whether handle is valid", "boolean", "
 	if(!ade_get_args(L, "o", l_Order.GetPtr(&ohp)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", ohp->IsValid());
+	return ade_set_args(L, "b", ohp->isValid());
 }
 
 //**********HANDLE: shiporders
@@ -397,7 +397,7 @@ ADE_FUNC(__len, l_ShipOrders, NULL, "Number of ship orders", "number", "Number o
 	if(!ade_get_args(L, "o", l_ShipOrders.GetPtr(&objh)))
 		return ade_set_error(L, "i", 0);
 
-	if(!objh->IsValid() || objh->objp->type != OBJ_SHIP || Ships[objh->objp->instance].ai_index < 0)
+	if(!objh->isValid() || objh->objp->type != OBJ_SHIP || Ships[objh->objp->instance].ai_index < 0)
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", ai_goal_num(&Ai_info[Ships[objh->objp->instance].ai_index].goals[0]));
@@ -413,7 +413,7 @@ ADE_INDEXER(l_ShipOrders, "number Index", "Array of ship orders", "order", "Orde
 
 	i--; //Lua->FS2
 
-	if (!objh->IsValid() || i < 0 || i >= MAX_AI_GOALS)
+	if (!objh->isValid() || i < 0 || i >= MAX_AI_GOALS)
 		return ade_set_error(L, "o", l_Order.Set(order_h()));
 
 	ai_info *aip = &Ai_info[Ships[objh->objp->instance].ai_index];
@@ -430,7 +430,7 @@ ADE_FUNC(isValid, l_ShipOrders, NULL, "Detects whether handle is valid", "boolea
 	if(!ade_get_args(L, "o", l_ShipOrders.GetPtr(&oh)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", oh->IsValid());
+	return ade_set_args(L, "b", oh->isValid());
 }
 
 

--- a/code/scripting/api/objs/order.h
+++ b/code/scripting/api/objs/order.h
@@ -21,7 +21,7 @@ struct order_h
 
 	order_h(object *objp, int n_odx);
 
-	bool IsValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_Order, order_h);

--- a/code/scripting/api/objs/particle.cpp
+++ b/code/scripting/api/objs/particle.cpp
@@ -13,10 +13,10 @@ particle_h::particle_h() {
 particle_h::particle_h(const particle::WeakParticlePtr& part_p) {
 	this->part = part_p;
 }
-particle::WeakParticlePtr particle_h::Get() {
+particle::WeakParticlePtr particle_h::Get() const {
 	return this->part;
 }
-bool particle_h::isValid() {
+bool particle_h::isValid() const {
 	return !part.expired();
 }
 
@@ -188,7 +188,7 @@ ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is a
 
 	if (ADE_SETTING_VAR)
 	{
-		if (newObj != nullptr && newObj->IsValid())
+		if (newObj != nullptr && newObj->isValid())
 			ph->Get().lock()->attached_objnum = newObj->objp->signature;
 	}
 

--- a/code/scripting/api/objs/particle.h
+++ b/code/scripting/api/objs/particle.h
@@ -15,9 +15,9 @@ class particle_h
 
 	explicit particle_h(const particle::WeakParticlePtr& part_p);
 
-	particle::WeakParticlePtr Get();
+	particle::WeakParticlePtr Get() const;
 
-	bool isValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_Particle, particle_h);

--- a/code/scripting/api/objs/physics_info.cpp
+++ b/code/scripting/api/objs/physics_info.cpp
@@ -18,9 +18,9 @@ physics_info_h::physics_info_h(object* objp) {
 physics_info_h::physics_info_h(physics_info* in_pi) {
 	pi = in_pi;
 }
-bool physics_info_h::IsValid() {
+bool physics_info_h::isValid() const {
 	if (objh.objp != NULL) {
-		return objh.IsValid();
+		return objh.isValid();
 	} else {
 		return (pi != NULL);
 	}
@@ -36,7 +36,7 @@ ADE_VIRTVAR(AfterburnerAccelerationTime, l_Physics, "number", "Afterburner accel
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -53,7 +53,7 @@ ADE_VIRTVAR(AfterburnerVelocityMax, l_Physics, "vector", "Afterburner max veloci
 	if(!ade_get_args(L, "o|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -70,7 +70,7 @@ ADE_VIRTVAR(BankingConstant, l_Physics, "number", "Banking constant", "number", 
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -87,7 +87,7 @@ ADE_VIRTVAR(ForwardAccelerationTime, l_Physics, "number", "Forward acceleration 
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -104,7 +104,7 @@ ADE_VIRTVAR(ForwardDecelerationTime, l_Physics, "number", "Forward deceleration 
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -121,7 +121,7 @@ ADE_VIRTVAR(ForwardThrust, l_Physics, "number", "Forward thrust amount (-1 - 1),
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -138,7 +138,7 @@ ADE_VIRTVAR(Mass, l_Physics, "number", "Object mass", "number", "Object mass, or
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -155,7 +155,7 @@ ADE_VIRTVAR(RotationalVelocity, l_Physics, "vector", "Rotational velocity (Local
 	if(!ade_get_args(L, "o|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -172,7 +172,7 @@ ADE_VIRTVAR(RotationalVelocityDamping, l_Physics, "number", "Rotational damping,
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -189,7 +189,7 @@ ADE_VIRTVAR(RotationalVelocityDesired, l_Physics, "vector", "Desired rotational 
 	if(!ade_get_args(L, "o|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -206,7 +206,7 @@ ADE_VIRTVAR(RotationalVelocityMax, l_Physics, "vector", "Maximum rotational velo
 	if(!ade_get_args(L, "o|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -223,7 +223,7 @@ ADE_VIRTVAR(ShockwaveShakeAmplitude, l_Physics, "number", "How much shaking from
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -240,7 +240,7 @@ ADE_VIRTVAR(SideThrust, l_Physics, "number", "Side thrust amount (-1 - 1), used 
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -257,7 +257,7 @@ ADE_VIRTVAR(SlideAccelerationTime, l_Physics, "number", "Time to accelerate to m
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -274,7 +274,7 @@ ADE_VIRTVAR(SlideDecelerationTime, l_Physics, "number", "Time to decelerate from
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -291,7 +291,7 @@ ADE_VIRTVAR(Velocity, l_Physics, "vector", "Object world velocity (World vector)
 	if(!ade_get_args(L, "o|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -308,7 +308,7 @@ ADE_VIRTVAR(VelocityDamping, l_Physics, "number", "Damping, the natural period (
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -325,7 +325,7 @@ ADE_VIRTVAR(VelocityDesired, l_Physics, "vector", "Desired velocity (World vecto
 	if(!ade_get_args(L, "o|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -342,7 +342,7 @@ ADE_VIRTVAR(VelocityMax, l_Physics, "vector", "Object max local velocity (Local 
 	if(!ade_get_args(L, "o|o", l_Physics.GetPtr(&pih), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
@@ -359,7 +359,7 @@ ADE_VIRTVAR(VerticalThrust, l_Physics, "number", "Vertical thrust amount (-1 - 1
 	if(!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR) {
@@ -377,7 +377,7 @@ ADE_VIRTVAR(AfterburnerActive, l_Physics, "boolean", "Specifies if the afterburn
 	if(!ade_get_args(L, "o|b", l_Physics.GetPtr(&pih), &set))
 		return ade_set_error(L, "b", false);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "b", false);
 
 	if (ADE_SETTING_VAR)
@@ -401,7 +401,7 @@ ADE_VIRTVAR(GravityConst, l_Physics, "number", "Multiplier for the effect of gra
 	if (!ade_get_args(L, "o|f", l_Physics.GetPtr(&pih), &grav_const))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!pih->IsValid())
+	if (!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if (ADE_SETTING_VAR) {
@@ -417,7 +417,7 @@ ADE_FUNC(isValid, l_Physics, NULL, "True if valid, false or nil if not", "boolea
 	if(!ade_get_args(L, "o", l_Physics.GetPtr(&pih)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", pih->IsValid());
+	return ade_set_args(L, "b", pih->isValid());
 }
 
 ADE_FUNC(getSpeed, l_Physics, NULL, "Gets total speed as of last frame", "number", "Total speed, or 0 if handle is invalid")
@@ -426,7 +426,7 @@ ADE_FUNC(getSpeed, l_Physics, NULL, "Gets total speed as of last frame", "number
 	if(!ade_get_args(L, "o", l_Physics.GetPtr(&pih)))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	return ade_set_args(L, "f", pih->pi->speed);
@@ -438,7 +438,7 @@ ADE_FUNC(getForwardSpeed, l_Physics, NULL, "Gets total speed in the ship's 'forw
 	if(!ade_get_args(L, "o", l_Physics.GetPtr(&pih)))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	return ade_set_args(L, "f", pih->pi->fspeed);
@@ -451,7 +451,7 @@ ADE_FUNC(isAfterburnerActive, l_Physics, NULL, "True if Afterburners are on, fal
 	if(!ade_get_args(L, "o", l_Physics.GetPtr(&pih)))
 		return ADE_RETURN_NIL;
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "b", false);
 
 	if (pih->pi->flags & PF_AFTERBURNER_ON)
@@ -467,7 +467,7 @@ ADE_FUNC(isGliding, l_Physics, NULL, "True if glide mode is on, false or nil if 
 	if(!ade_get_args(L, "o", l_Physics.GetPtr(&pih)))
 		return ADE_RETURN_NIL;
 
-	if(!pih->IsValid())
+	if(!pih->isValid())
 		return ade_set_error(L, "b", false);
 
 	if (pih->pi->flags & (PF_GLIDING|PF_FORCE_GLIDE))

--- a/code/scripting/api/objs/physics_info.h
+++ b/code/scripting/api/objs/physics_info.h
@@ -25,7 +25,7 @@ struct physics_info_h
 
 	physics_info_h(physics_info *in_pi);
 
-	bool IsValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_Physics, physics_info_h);

--- a/code/scripting/api/objs/redalert.cpp
+++ b/code/scripting/api/objs/redalert.cpp
@@ -7,7 +7,7 @@ redalert_stage_h::redalert_stage_h() : ra_brief(-1), ra_stage(-1) {}
 
 redalert_stage_h::redalert_stage_h(int brief, int stage) : ra_brief(brief), ra_stage(stage) {}
 
-bool redalert_stage_h::IsValid() const
+bool redalert_stage_h::isValid() const
 {
 	return ra_brief >= 0 && ra_stage >= 0;
 }

--- a/code/scripting/api/objs/redalert.h
+++ b/code/scripting/api/objs/redalert.h
@@ -10,7 +10,7 @@ struct redalert_stage_h {
 	int ra_brief, ra_stage;
 	redalert_stage_h();
 	explicit redalert_stage_h(int brief, int stage);
-	bool IsValid() const;
+	bool isValid() const;
 	brief_stage* getStage() const;
 };
 

--- a/code/scripting/api/objs/rpc.cpp
+++ b/code/scripting/api/objs/rpc.cpp
@@ -65,7 +65,7 @@ ADE_FUNC(__call, l_RPC, "[any = nil, enumeration recipient = default /* as set o
 	if(!argument.isValid())
 		argument = luacpp::LuaValue::createNil(L);
 
-	if (!recipient.IsValid() || (recipient.index != LE_RPC_SERVER && recipient.index != LE_RPC_CLIENTS && recipient.index != LE_RPC_BOTH))
+	if (!recipient.isValid() || (recipient.index != LE_RPC_SERVER && recipient.index != LE_RPC_CLIENTS && recipient.index != LE_RPC_BOTH))
 		recipient = rpc->recipient;
 
 	lua_net_reciever recipient_lua;

--- a/code/scripting/api/objs/sexpvar.cpp
+++ b/code/scripting/api/objs/sexpvar.cpp
@@ -16,7 +16,7 @@ ADE_VIRTVAR(Name, l_SEXPVariable, "string", "SEXP Variable name.", "string", "SE
 	if (!ade_get_args(L, "o|s", l_SEXPVariable.GetPtr(&svh), &s))
 		return ade_set_error(L, "s", "");
 
-	if (!svh->IsValid())
+	if (!svh->isValid())
 		return ade_set_error(L, "s", "");
 
 	sexp_variable *sv = &Sexp_variables[svh->idx];
@@ -35,7 +35,7 @@ ADE_VIRTVAR(Persistence, l_SEXPVariable, "enumeration", "SEXP Variable persisten
 	if(!ade_get_args(L, "o|o", l_SEXPVariable.GetPtr(&svh), l_Enum.GetPtr(&type)))
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
-	if(!svh->IsValid())
+	if(!svh->isValid())
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
 	sexp_variable *sv = &Sexp_variables[svh->idx];
@@ -77,7 +77,7 @@ ADE_VIRTVAR(Type, l_SEXPVariable, "enumeration", "SEXP Variable type, uses SEXPV
 	if(!ade_get_args(L, "o|o", l_SEXPVariable.GetPtr(&svh), l_Enum.GetPtr(&type)))
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
-	if(!svh->IsValid())
+	if(!svh->isValid())
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
 	sexp_variable *sv = &Sexp_variables[svh->idx];
@@ -126,7 +126,7 @@ ADE_VIRTVAR(Value, l_SEXPVariable, "number/string", "SEXP variable value", "stri
 			return ADE_RETURN_NIL;
 	}
 
-	if(!svh->IsValid())
+	if(!svh->isValid())
 		return ADE_RETURN_NIL;
 
 	sexp_variable *sv = &Sexp_variables[svh->idx];
@@ -150,7 +150,7 @@ ADE_FUNC(__tostring, l_SEXPVariable, NULL, "Returns SEXP name", "string", "SEXP 
 	if(!ade_get_args(L, "o", l_SEXPVariable.GetPtr(&svh)))
 		return ade_set_error(L, "s", "");
 
-	if(!svh->IsValid())
+	if(!svh->isValid())
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", Sexp_variables[svh->idx].variable_name);
@@ -162,7 +162,7 @@ ADE_FUNC(isValid, l_SEXPVariable, NULL, "Detects whether handle is valid", "bool
 	if(!ade_get_args(L, "o", l_SEXPVariable.GetPtr(&svh)))
 		return ADE_RETURN_NIL;
 
-	if(!svh->IsValid())
+	if(!svh->isValid())
 		return ADE_RETURN_FALSE;
 
 	return ADE_RETURN_TRUE;
@@ -174,7 +174,7 @@ ADE_FUNC(delete, l_SEXPVariable, NULL, "Deletes a SEXP Variable", "boolean", "Tr
 	if(!ade_get_args(L, "o", l_SEXPVariable.GetPtr(&svh)))
 		return ade_set_error(L, "b", false);
 
-	if(!svh->IsValid())
+	if(!svh->isValid())
 		return ade_set_error(L, "b", false);
 
 	sexp_variable_delete(svh->idx);

--- a/code/scripting/api/objs/sexpvar.h
+++ b/code/scripting/api/objs/sexpvar.h
@@ -20,7 +20,7 @@ struct sexpvar_h
 
 	sexpvar_h(){idx=-1;variable_name[0]='\0';}
 	sexpvar_h(int n_idx){idx = n_idx; strcpy_s(variable_name, Sexp_variables[n_idx].variable_name);}
-	bool IsValid(){
+	bool isValid() const {
 		return (idx > -1
 			&& idx < MAX_SEXP_VARIABLES
 			&& (Sexp_variables[idx].type & SEXP_VARIABLE_SET)

--- a/code/scripting/api/objs/shields.cpp
+++ b/code/scripting/api/objs/shields.cpp
@@ -16,7 +16,7 @@ ADE_FUNC(__len, l_Shields, NULL, "Number of shield segments", "number", "Number 
 	if(!ade_get_args(L, "o", l_Shields.GetPtr(&objh)))
 		return ade_set_error(L, "i", -1);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "i", -1);
 
 	return ade_set_args(L, "i", objh->objp->n_quadrants);
@@ -36,7 +36,7 @@ ADE_INDEXER(l_Shields, "enumeration/number", "Gets or sets shield segment streng
 		if(!ade_get_args(L, "os|f", l_Shields.GetPtr(&objh), &qd, &nval))
 			return ade_set_error(L, "f", 0.0f);
 
-		if(!objh->IsValid())
+		if(!objh->isValid())
 			return ade_set_error(L, "f", 0.0f);
 
 		objp = objh->objp;
@@ -54,7 +54,7 @@ ADE_INDEXER(l_Shields, "enumeration/number", "Gets or sets shield segment streng
 		if(!ade_get_args(L, "oo|f", l_Shields.GetPtr(&objh), l_Enum.GetPtr(&qd), &nval))
 			return 0;
 
-		if(!objh->IsValid())
+		if(!objh->isValid())
 			return ade_set_error(L, "f", 0.0f);
 
 		objp = objh->objp;
@@ -107,7 +107,7 @@ ADE_VIRTVAR(CombinedLeft, l_Shields, "number", "Total shield hitpoints left (for
 	if(!ade_get_args(L, "o|f", l_Shields.GetPtr(&objh), &nval))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR && nval >= 0.0f) {
@@ -124,7 +124,7 @@ ADE_VIRTVAR(CombinedMax, l_Shields, "number", "Maximum shield hitpoints (for all
 	if(!ade_get_args(L, "o|f", l_Shields.GetPtr(&objh), &nval))
 		return 0;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR && nval >= 0.0f) {
@@ -140,7 +140,7 @@ ADE_FUNC(isValid, l_Shields, NULL, "Detects whether handle is valid", "boolean",
 	if(!ade_get_args(L, "o", l_Shields.GetPtr(&oh)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", oh->IsValid());
+	return ade_set_args(L, "b", oh->isValid());
 }
 
 }

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -854,7 +854,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Ship, "subsystem", "Target subsystem of ship.", "
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->isSubsystemValid())
+		if(newh && newh->isValid())
 		{
 			if (aip == Player_ai) {
 				if (aip->target_signature != newh->objh.sig)
@@ -1579,7 +1579,7 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		priority = 2.0f;
 
 	bool tgh_valid = tgh && tgh->isValid();
-	bool tgsh_valid = tgsh && tgsh->isSubsystemValid();
+	bool tgsh_valid = tgsh && tgsh->isValid();
 	int ai_mode = AI_GOAL_NONE;
 	int ai_submode = -1234567;
 	const char *ai_shipname = NULL;

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -719,7 +719,7 @@ ADE_VIRTVAR(PrimaryBanks, l_Ship, "weaponbanktype", "Array of primary weapon ban
 	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
 
 	if(ADE_SETTING_VAR && swh && swh->isValid()) {
-		ship_weapon *src = &Ships[swh->objp->instance].weapons;
+		ship_weapon *src = &Ships[swh->objh.objp->instance].weapons;
 
 		dst->current_primary_bank = src->current_primary_bank;
 		dst->num_primary_banks = src->num_primary_banks;
@@ -750,7 +750,7 @@ ADE_VIRTVAR(SecondaryBanks, l_Ship, "weaponbanktype", "Array of secondary weapon
 	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
 
 	if(ADE_SETTING_VAR && swh && swh->isValid()) {
-		ship_weapon *src = &Ships[swh->objp->instance].weapons;
+		ship_weapon *src = &Ships[swh->objh.objp->instance].weapons;
 
 		dst->current_secondary_bank = src->current_secondary_bank;
 		dst->num_secondary_banks = src->num_secondary_banks;
@@ -782,7 +782,7 @@ ADE_VIRTVAR(TertiaryBanks, l_Ship, "weaponbanktype", "Array of tertiary weapon b
 	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
 
 	if(ADE_SETTING_VAR && swh && swh->isValid()) {
-		ship_weapon *src = &Ships[swh->objp->instance].weapons;
+		ship_weapon *src = &Ships[swh->objh.objp->instance].weapons;
 
 		dst->current_tertiary_bank = src->current_tertiary_bank;
 		dst->num_tertiary_banks = src->num_tertiary_banks;
@@ -857,14 +857,14 @@ ADE_VIRTVAR(TargetSubsystem, l_Ship, "subsystem", "Target subsystem of ship.", "
 		if(newh && newh->isSubsystemValid())
 		{
 			if (aip == Player_ai) {
-				if (aip->target_signature != newh->sig)
-					hud_shield_hit_reset(newh->objp);
+				if (aip->target_signature != newh->objh.sig)
+					hud_shield_hit_reset(newh->objh.objp);
 
 				Ships[Objects[newh->ss->parent_objnum].instance].last_targeted_subobject[Player_num] = newh->ss;
 			}
 
-			aip->target_objnum = OBJ_INDEX(newh->objp);
-			aip->target_signature = newh->sig;
+			aip->target_objnum = OBJ_INDEX(newh->objh.objp);
+			aip->target_signature = newh->objh.sig;
 			aip->target_time = 0.0f;
 			set_targeted_subsys(aip, newh->ss, aip->target_objnum);
 		}
@@ -1591,7 +1591,7 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 			{
 				ai_mode = AI_GOAL_DESTROY_SUBSYSTEM;
 				ai_shipname = Ships[tgh->objp->instance].ship_name;
-				ai_submode = ship_find_subsys( &Ships[tgsh->objp->instance], tgsh->ss->system_info->subobj_name );
+				ai_submode = ship_find_subsys( &Ships[tgsh->objh.objp->instance], tgsh->ss->system_info->subobj_name );
 			}
 			else if(tgh_valid && tgh->objp->type == OBJ_WEAPON)
 			{

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -49,7 +49,7 @@ ADE_FUNC(__len, l_ShipTextures, NULL, "Number of textures on ship", "number", "N
 	if(!ade_get_args(L, "o", l_ShipTextures.GetPtr(&objh)))
 		return ade_set_error(L, "i", 0);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	polymodel *pm = model_get(Ship_info[Ships[objh->objp->instance].ship_info_index].model_num);
@@ -68,7 +68,7 @@ ADE_INDEXER(l_ShipTextures, "number/string IndexOrTextureFilename", "Array of sh
 	if (!ade_get_args(L, "os|o", l_ShipTextures.GetPtr(&oh), &s, l_Texture.GetPtr(&tdx)))
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
-	if (!oh->IsValid() || s==NULL)
+	if (!oh->isValid() || s==NULL)
 		return ade_set_error(L, "o", l_Texture.Set(texture_h()));
 
 	ship *shipp = &Ships[oh->objp->instance];
@@ -139,7 +139,7 @@ ADE_FUNC(isValid, l_ShipTextures, NULL, "Detects whether handle is valid", "bool
 	if(!ade_get_args(L, "o", l_ShipTextures.GetPtr(&oh)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", oh->IsValid());
+	return ade_set_args(L, "b", oh->isValid());
 }
 
 //**********HANDLE: Ship
@@ -153,7 +153,7 @@ ADE_INDEXER(l_Ship, "string/number NameOrIndex", "Array of ship subsystems", "su
 	if(!ade_get_args(L, "o|so", l_Ship.GetPtr(&objh), &s, l_Subsystem.GetPtr(&sub)))
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -181,7 +181,7 @@ ADE_FUNC(__len, l_Ship, NULL, "Number of subsystems on ship", "number", "Subsyst
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "i", 0);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", ship_get_num_subsys(&Ships[objh->objp->instance]));
@@ -197,7 +197,7 @@ ADE_FUNC(setFlag, l_Ship, "boolean set_it, string flag_name", "Sets or clears on
 		return ADE_RETURN_NIL;
 	int skip_args = 2;	// not 3 because there will be one more below
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto shipp = &Ships[objh->objp->instance];
@@ -235,7 +235,7 @@ ADE_FUNC(getFlag, l_Ship, "string flag_name", "Checks whether one or more flags 
 		return ADE_RETURN_NIL;
 	int skip_args = 1;	// not 2 because there will be one more below
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto shipp = &Ships[objh->objp->instance];
@@ -297,7 +297,7 @@ static int ship_getset_helper(lua_State* L, int ship::* field, bool canSet = fal
 	if (!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &value))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	ship* shipp = &Ships[objh->objp->instance];
@@ -325,7 +325,7 @@ ADE_VIRTVAR(ShieldArmorClass, l_Ship, "string", "Current Armor class of the ship
 	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ade_set_error(L, "s", "");
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -354,7 +354,7 @@ ADE_VIRTVAR(ArmorClass, l_Ship, "string", "Current Armor class", "string", "Armo
 	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ade_set_error(L, "s", "");
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -381,7 +381,7 @@ ADE_VIRTVAR(Name, l_Ship, "string", "Ship name. This is the actual name of the s
 	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ade_set_error(L, "s", "");
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -402,7 +402,7 @@ ADE_VIRTVAR(DisplayName, l_Ship, "string", "Ship display name", "string", "The d
 	if(!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ade_set_error(L, "s", "");
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -423,7 +423,7 @@ ADE_FUNC(isPlayer, l_Ship, nullptr, "Checks whether the ship is a player ship", 
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "b", false);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "b", false);
 
 	// singleplayer
@@ -453,7 +453,7 @@ ADE_VIRTVAR(AfterburnerFuelLeft, l_Ship, "number", "Afterburner fuel left", "num
 	if(!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &fuel))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -471,7 +471,7 @@ ADE_VIRTVAR(AfterburnerFuelMax, l_Ship, "number", "Afterburner fuel capacity", "
 	if(!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &fuel))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	ship_info *sip = &Ship_info[Ships[objh->objp->instance].ship_info_index];
@@ -489,7 +489,7 @@ ADE_VIRTVAR(Class, l_Ship, "shipclass", "Ship class", "shipclass", "Ship class, 
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_Shipclass.Get(&idx)))
 		return ade_set_error(L, "o", l_Shipclass.Set(-1));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Shipclass.Set(-1));
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -517,7 +517,7 @@ ADE_VIRTVAR(CountermeasuresLeft, l_Ship, "number", "Number of countermeasures le
 	if(!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &newcm))
 		return ade_set_error(L, "i", 0);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -535,7 +535,7 @@ ADE_VIRTVAR(CockpitDisplays, l_Ship, "displays", "An array of the cockpit displa
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_CockpitDisplays.GetPtr(&cdh)))
 		return ade_set_error(L, "o", l_CockpitDisplays.Set(cockpit_displays_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_CockpitDisplays.Set(cockpit_displays_h()));
 
 	if(ADE_SETTING_VAR)
@@ -553,7 +553,7 @@ ADE_VIRTVAR(CountermeasureClass, l_Ship, "weaponclass", "Weapon class mounted on
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_Weaponclass.Get(&newcm)))
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -575,7 +575,7 @@ ADE_VIRTVAR(HitpointsMax, l_Ship, "number", "Total hitpoints", "number", "Ship m
 	if(!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &newhits))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -593,7 +593,7 @@ ADE_VIRTVAR(ShieldRegenRate, l_Ship, "number", "Maximum percentage/100 of shield
 	if (!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &new_shield_regen))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -611,7 +611,7 @@ ADE_VIRTVAR(WeaponRegenRate, l_Ship, "number", "Maximum percentage/100 of weapon
 	if (!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &new_weapon_regen))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -629,7 +629,7 @@ ADE_VIRTVAR(WeaponEnergyLeft, l_Ship, "number", "Current weapon energy reserves"
 	if(!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &neweng))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -647,7 +647,7 @@ ADE_VIRTVAR(WeaponEnergyMax, l_Ship, "number", "Maximum weapon energy", "number"
 	if(!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &neweng))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	ship_info *sip = &Ship_info[Ships[objh->objp->instance].ship_info_index];
@@ -665,7 +665,7 @@ ADE_VIRTVAR(AutoaimFOV, l_Ship, "number", "FOV of ship's autoaim, if any", "numb
 	if(!ade_get_args(L, "o|f", l_Ship.GetPtr(&objh), &fov))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -687,7 +687,7 @@ ADE_VIRTVAR(PrimaryTriggerDown, l_Ship, "boolean", "Determines if primary trigge
 	if(!ade_get_args(L, "o|b", l_Ship.GetPtr(&objh), &trig))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -713,12 +713,12 @@ ADE_VIRTVAR(PrimaryBanks, l_Ship, "weaponbanktype", "Array of primary weapon ban
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_WeaponBankType.GetPtr(&swh)))
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
 	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
 
-	if(ADE_SETTING_VAR && swh && swh->IsValid()) {
+	if(ADE_SETTING_VAR && swh && swh->isValid()) {
 		ship_weapon *src = &Ships[swh->objp->instance].weapons;
 
 		dst->current_primary_bank = src->current_primary_bank;
@@ -744,12 +744,12 @@ ADE_VIRTVAR(SecondaryBanks, l_Ship, "weaponbanktype", "Array of secondary weapon
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_WeaponBankType.GetPtr(&swh)))
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
 	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
 
-	if(ADE_SETTING_VAR && swh && swh->IsValid()) {
+	if(ADE_SETTING_VAR && swh && swh->isValid()) {
 		ship_weapon *src = &Ships[swh->objp->instance].weapons;
 
 		dst->current_secondary_bank = src->current_secondary_bank;
@@ -776,12 +776,12 @@ ADE_VIRTVAR(TertiaryBanks, l_Ship, "weaponbanktype", "Array of tertiary weapon b
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_WeaponBankType.GetPtr(&swh)))
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
 	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
 
-	if(ADE_SETTING_VAR && swh && swh->IsValid()) {
+	if(ADE_SETTING_VAR && swh && swh->isValid()) {
 		ship_weapon *src = &Ships[swh->objp->instance].weapons;
 
 		dst->current_tertiary_bank = src->current_tertiary_bank;
@@ -805,7 +805,7 @@ ADE_VIRTVAR(Target, l_Ship, "object", "Target of ship. Value may also be a deriv
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_Object.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	ai_info *aip = NULL;
@@ -816,7 +816,7 @@ ADE_VIRTVAR(Target, l_Ship, "object", "Target of ship. Value may also be a deriv
 
 	if(ADE_SETTING_VAR && !(newh && aip->target_signature == newh->sig)) {
 		// we have a different target, or are clearng the target
-		if(newh && newh->IsValid())	{
+		if(newh && newh->isValid())	{
 			aip->target_objnum = OBJ_INDEX(newh->objp);
 			aip->target_signature = newh->sig;
 			aip->target_time = 0.0f;
@@ -843,7 +843,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Ship, "subsystem", "Target subsystem of ship.", "
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&oh), l_Subsystem.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	ai_info *aip = NULL;
@@ -888,7 +888,7 @@ ADE_VIRTVAR(Team, l_Ship, "team", "Ship's team", "team", "Ship team, or invalid 
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&oh), l_Team.Get(&nt)))
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
 	ship *shipp = &Ships[oh->objp->instance];
@@ -907,7 +907,7 @@ ADE_VIRTVAR(PersonaIndex, l_Ship, "number", "Persona index", "number", "The inde
 	if(!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &p_index))
 		return ade_set_error(L, "i", 0);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -925,10 +925,10 @@ ADE_VIRTVAR(Textures, l_Ship, "shiptextures", "Gets ship textures", "shiptexture
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&dh), l_Ship.GetPtr(&sh)))
 		return ade_set_error(L, "o", l_ShipTextures.Set(object_h()));
 
-	if(!dh->IsValid())
+	if(!dh->isValid())
 		return ade_set_error(L, "o", l_ShipTextures.Set(object_h()));
 
-	if(ADE_SETTING_VAR && sh && sh->IsValid()) {
+	if(ADE_SETTING_VAR && sh && sh->isValid()) {
 		ship *src = &Ships[sh->objp->instance];
 		ship *dest = &Ships[dh->objp->instance];
 
@@ -952,7 +952,7 @@ ADE_VIRTVAR(FlagAffectedByGravity, l_Ship, "boolean", "Checks for the \"affected
 	if (!ade_get_args(L, "o|b", l_Ship.GetPtr(&objh), &set))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -976,7 +976,7 @@ ADE_VIRTVAR(Disabled, l_Ship, "boolean", "The disabled state of this ship", "boo
 	if (!ade_get_args(L, "o|b", l_Ship.GetPtr(&objh), &set))
 		return ADE_RETURN_FALSE;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -1008,7 +1008,7 @@ ADE_VIRTVAR(Stealthed, l_Ship, "boolean", "Stealth status of this ship", "boolea
 	if (!ade_get_args(L, "o|b", l_Ship.GetPtr(&objh), &stealthed))
 		return ADE_RETURN_FALSE;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -1032,7 +1032,7 @@ ADE_VIRTVAR(HiddenFromSensors, l_Ship, "boolean", "Hidden from sensors status of
 	if (!ade_get_args(L, "o|b", l_Ship.GetPtr(&objh), &hidden))
 		return ADE_RETURN_FALSE;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -1056,7 +1056,7 @@ ADE_VIRTVAR(Gliding, l_Ship, "boolean", "Specifies whether this ship is currentl
 	if (!ade_get_args(L, "o|b", l_Ship.GetPtr(&objh), &gliding))
 		return ADE_RETURN_FALSE;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -1083,7 +1083,7 @@ ADE_VIRTVAR(EtsEngineIndex, l_Ship, "number", "(SET not implemented, see EtsSetI
 	if (!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &ets_idx))
 		return ade_set_error(L, "i", 0);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	if(ADE_SETTING_VAR)
@@ -1100,7 +1100,7 @@ ADE_VIRTVAR(EtsShieldIndex, l_Ship, "number", "(SET not implemented, see EtsSetI
 	if (!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &ets_idx))
 		return ade_set_error(L, "i", 0);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	if(ADE_SETTING_VAR)
@@ -1117,7 +1117,7 @@ ADE_VIRTVAR(EtsWeaponIndex, l_Ship, "number", "(SET not implemented, see EtsSetI
 	if (!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &ets_idx))
 		return ade_set_error(L, "i", 0);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	if(ADE_SETTING_VAR)
@@ -1133,7 +1133,7 @@ ADE_VIRTVAR(Orders, l_Ship, "shiporders", "Array of ship orders", "shiporders", 
 	if(!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_ShipOrders.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_ShipOrders.Set(object_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_ShipOrders.Set(object_h()));;
 
 	if(ADE_SETTING_VAR)
@@ -1151,7 +1151,7 @@ ADE_VIRTVAR(WaypointSpeedCap, l_Ship, "number", "Waypoint speed cap", "number", 
 	if (!ade_get_args(L, "o|i", l_Ship.GetPtr(&objh), &speed_cap))
 		return ade_set_error(L, "i", 0);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	ship* shipp = &Ships[objh->objp->instance];
@@ -1175,7 +1175,7 @@ static int ship_getset_location_helper(lua_State* L, int ship::* field, const ch
 	if (!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	ship* shipp = &Ships[objh->objp->instance];
@@ -1211,7 +1211,7 @@ static int ship_getset_anchor_helper(lua_State* L, int ship::* field)
 	if (!ade_get_args(L, "o|s", l_Ship.GetPtr(&objh), &s))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	ship* shipp = &Ships[objh->objp->instance];
@@ -1278,7 +1278,7 @@ ADE_FUNC(sendMessage,
 	if (!ade_get_args(L, "oo|fob", l_Ship.GetPtr(&ship_h), l_Message.Get(&messageIdx), &delay, l_Enum.GetPtr(&ehp)))
 		return ADE_RETURN_FALSE;
 
-	if (ship_h == nullptr || !ship_h->IsValid())
+	if (ship_h == nullptr || !ship_h->isValid())
 		return ADE_RETURN_FALSE;
 
 	return sendMessage_sub(L, &Ships[ship_h->objp->instance], MESSAGE_SOURCE_SHIP, messageIdx, delay, ehp);
@@ -1355,10 +1355,10 @@ ADE_FUNC(kill, l_Ship, "[object Killer, vector Hitpos]", "Kills the ship. Set \"
 	if(!ade_get_args(L, "o|oo", l_Ship.GetPtr(&victim), l_Object.GetPtr(&killer), l_Vector.GetPtr(&hitpos)))
 		return ADE_RETURN_NIL;
 
-	if(!victim->IsValid())
+	if(!victim->isValid())
 		return ADE_RETURN_NIL;
 
-	if(killer && !killer->IsValid())
+	if(killer && !killer->isValid())
 		return ADE_RETURN_NIL;
 
 	// use the current hull percentage for damage-after-death purposes
@@ -1399,7 +1399,7 @@ ADE_FUNC(addShipEffect, l_Ship, "string name, number durationMillis", "Activates
 	if (!ade_get_args(L, "o|si", l_Ship.GetPtr(&shiph), &effect, &duration))
 		return ade_set_error(L, "b", false);
 
-	if (!shiph->IsValid())
+	if (!shiph->isValid())
 		return ade_set_error(L, "b", false);
 
 	effect_num = get_effect_from_name(effect);
@@ -1421,7 +1421,7 @@ ADE_FUNC(hasShipExploded, l_Ship, NULL, "Checks if the ship explosion event has 
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&shiph)))
 		return ade_set_error(L, "i", 0);
 
-	if(!shiph->IsValid())
+	if(!shiph->isValid())
 		return ade_set_error(L, "i", 0);
 
 	ship *shipp = &Ships[shiph->objp->instance];
@@ -1445,7 +1445,7 @@ ADE_FUNC(isDepartingWarp, l_Ship, nullptr, "Checks if the ship is departing via 
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&shiph)))
 		return ade_set_error(L, "b", false);
 
-	if (!shiph->IsValid())
+	if (!shiph->isValid())
 		return ade_set_error(L, "b", false);
 
 	ship *shipp = &Ships[shiph->objp->instance];
@@ -1459,7 +1459,7 @@ ADE_FUNC(isDepartingDockbay, l_Ship, nullptr, "Checks if the ship is departing v
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&shiph)))
 		return ade_set_error(L, "b", false);
 
-	if (!shiph->IsValid())
+	if (!shiph->isValid())
 		return ade_set_error(L, "b", false);
 
 	ship *shipp = &Ships[shiph->objp->instance];
@@ -1473,7 +1473,7 @@ ADE_FUNC(isDying, l_Ship, nullptr, "Checks if the ship is dying (doing its death
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&shiph)))
 		return ade_set_error(L, "b", false);
 
-	if (!shiph->IsValid())
+	if (!shiph->isValid())
 		return ade_set_error(L, "b", false);
 
 	ship *shipp = &Ships[shiph->objp->instance];
@@ -1487,7 +1487,7 @@ ADE_FUNC(fireCountermeasure, l_Ship, NULL, "Launches a countermeasure from the s
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "b", false);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "b", false);
 
 	return ade_set_args(L, "b", ship_launch_countermeasure(objh->objp) != 0);
@@ -1499,7 +1499,7 @@ ADE_FUNC(firePrimary, l_Ship, NULL, "Fires ship primary bank(s)", "number", "Num
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "i", 0);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	int i = 0;
@@ -1514,7 +1514,7 @@ ADE_FUNC(fireSecondary, l_Ship, NULL, "Fires ship secondary bank(s)", "number", 
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "i", 0);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	return ade_set_args(L, "i", ship_fire_secondary(objh->objp, 0));
@@ -1530,7 +1530,7 @@ ADE_FUNC_DEPRECATED(getAnimationDoneTime, l_Ship, "number Type, number Subtype",
 	if(!ade_get_args(L, "o|si", l_Ship.GetPtr(&objh), &s, &subtype))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	auto type = animation::anim_match_type(s);
@@ -1548,7 +1548,7 @@ ADE_FUNC(clearOrders, l_Ship, NULL, "Clears a ship's orders list", "boolean", "T
 	object_h *objh = NULL;
 	if(!ade_get_args(L, "o", l_Object.GetPtr(&objh)))
 		return ADE_RETURN_NIL;
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "b", false);
 
 	//The actual clearing of the goals
@@ -1568,7 +1568,7 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 	if(!ade_get_args(L, "oo|oofo", l_Object.GetPtr(&objh), l_Enum.GetPtr(&eh), l_Object.GetPtr(&tgh), l_Subsystem.GetPtr(&tgsh), &priority, l_Shipclass.Get(&sclass)))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid() || !eh->IsValid())
+	if(!objh->isValid() || !eh->isValid())
 		return ade_set_error(L, "b", false);
 
 	//wtf...
@@ -1578,7 +1578,7 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 	if(priority > 2.0f)
 		priority = 2.0f;
 
-	bool tgh_valid = tgh && tgh->IsValid();
+	bool tgh_valid = tgh && tgh->isValid();
 	bool tgsh_valid = tgsh && tgsh->isSubsystemValid();
 	int ai_mode = AI_GOAL_NONE;
 	int ai_submode = -1234567;
@@ -1951,7 +1951,7 @@ ADE_FUNC_DEPRECATED(triggerAnimation, l_Ship, "string Type, [number Subtype, boo
 	if(!ade_get_args(L, "o|sibb", l_Ship.GetPtr(&objh), &s, &subtype, &b, &instant))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto type = animation::anim_match_type(s);
@@ -1981,7 +1981,7 @@ ADE_FUNC(triggerSubmodelAnimation, l_Ship, "string type, string triggeredBy, [bo
 	if (!ade_get_args(L, "oss|bbbb", l_Ship.GetPtr(&objh), &type, &trigger, &forwards, &forced, &instant, &pause))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto animtype = animation::anim_match_type(type);
@@ -2005,7 +2005,7 @@ ADE_FUNC(getSubmodelAnimation, l_Ship, "string type, string triggeredBy",
 	if (!ade_get_args(L, "oss", l_Ship.GetPtr(&objh), &type, &trigger))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto animtype = animation::anim_match_type(type);
@@ -2030,7 +2030,7 @@ ADE_FUNC(stopLoopingSubmodelAnimation, l_Ship, "string type, string triggeredBy"
 	if (!ade_get_args(L, "oss", l_Ship.GetPtr(&objh), &type, &trigger))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto animtype = animation::anim_match_type(type);
@@ -2057,7 +2057,7 @@ ADE_FUNC(setAnimationSpeed, l_Ship, "string type, string triggeredBy, [number sp
 	if (!ade_get_args(L, "oss|f", l_Ship.GetPtr(&objh), &type, &trigger, &speed))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto animtype = animation::anim_match_type(type);
@@ -2079,7 +2079,7 @@ ADE_FUNC(getSubmodelAnimationTime, l_Ship, "string type, string triggeredBy", "G
 	if (!ade_get_args(L, "oss", l_Ship.GetPtr(&objh), &type, &trigger))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	auto animtype = animation::anim_match_type(type);
@@ -2115,7 +2115,7 @@ ADE_FUNC(updateSubmodelMoveable, l_Ship, "string name, table values",
 	if (!ade_get_args(L, "ost", l_Ship.GetPtr(&objh), &name, &values))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	SCP_vector<linb::any> valuesMoveable;
@@ -2151,7 +2151,7 @@ ADE_FUNC(warpIn, l_Ship, NULL, "Warps ship in", "boolean", "True if successful, 
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	shipfx_warpin_start(objh->objp);
@@ -2165,7 +2165,7 @@ ADE_FUNC(warpOut, l_Ship, NULL, "Warps ship out", "boolean", "True if successful
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	shipfx_warpout_start(objh->objp);
@@ -2179,7 +2179,7 @@ ADE_FUNC(canWarp, l_Ship, nullptr, "Checks whether ship has a working subspace d
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -2196,7 +2196,7 @@ ADE_FUNC(canBayDepart, l_Ship, nullptr, "Checks whether ship has a bay departure
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -2214,7 +2214,7 @@ ADE_FUNC(isWarpingIn, l_Ship, NULL, "Checks if ship is warping in", "boolean", "
 	if(!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ADE_RETURN_NIL;
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -2234,7 +2234,7 @@ ADE_FUNC(getEMP, l_Ship, NULL, "Returns the current emp effect strength acting o
 		return ADE_RETURN_NIL;
 	}
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	obj = objh->objp;
@@ -2250,7 +2250,7 @@ ADE_FUNC(getTimeUntilExplosion, l_Ship, nullptr, "Returns the time in seconds un
 
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "f", -1.0f);
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -2270,7 +2270,7 @@ ADE_FUNC(setTimeUntilExplosion, l_Ship, "number Time", "Sets the time in seconds
 
 	if (!ade_get_args(L, "of", l_Ship.GetPtr(&objh), &delta_s))
 		return ade_set_error(L, "b", false);
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "b", false);
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -2295,7 +2295,7 @@ ADE_FUNC(getCallsign, l_Ship, NULL, "Gets the callsign of the ship in the curren
 		return ade_set_error(L, "s", "");
 	}
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -2322,7 +2322,7 @@ ADE_FUNC(getAltClassName, l_Ship, NULL, "Gets the alternate class name of the sh
 		return ade_set_error(L, "s", "");
 	}
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
@@ -2349,7 +2349,7 @@ ADE_FUNC(getMaximumSpeed, l_Ship, "[number energy = 0.333]", "Gets the maximum s
 		return ade_set_error(L, "f", -1.0f);
 	}
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	if (energy < 0.0f || energy > 1.0f)
@@ -2375,7 +2375,7 @@ ADE_FUNC(EtsSetIndexes, l_Ship, "number EngineIndex, number ShieldIndex, number 
 	if (!ade_get_args(L, "oiii", l_Ship.GetPtr(&objh), &ets_idx[ENGINES], &ets_idx[SHIELDS], &ets_idx[WEAPONS]))
 		return ADE_RETURN_FALSE;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
 	sanity_check_ets_inputs(ets_idx);
@@ -2397,7 +2397,7 @@ ADE_FUNC(getWing, l_Ship, NULL, "Returns the ship's wing", "wing", "Wing handle,
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "o", l_Wing.Set(-1));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Wing.Set(-1));
 
 	shipp = &Ships[objh->objp->instance];
@@ -2412,7 +2412,7 @@ ADE_FUNC(getDisplayString, l_Ship, nullptr, "Returns the string which should be 
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "s", "");
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
 	shipp = &Ships[objh->objp->instance];
@@ -2426,7 +2426,7 @@ ADE_FUNC(vanish, l_Ship, nullptr, "Vanishes this ship from the mission. Works in
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
 		return ade_set_error(L, "b", false);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "b", false);
 
 	ship_actually_depart(objh->objp->instance, SHIP_VANISHED);
@@ -2444,7 +2444,7 @@ ADE_FUNC(setGlowPointBankActive, l_Ship, "boolean active, [number bank]", "Activ
 		return ADE_RETURN_NIL;
 	int skip_args = 1;	// not 2 because there will be one more before we read the first number
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	auto shipp = &Ships[objh->objp->instance];
@@ -2480,7 +2480,7 @@ ADE_FUNC(numDocked, l_Ship, nullptr, "Returns the number of ships this ship is d
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&docker_objh)))
 		return ADE_RETURN_NIL;
 
-	if (docker_objh == nullptr || !docker_objh->IsValid())
+	if (docker_objh == nullptr || !docker_objh->isValid())
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "i", dock_count_direct_docked_objects(docker_objh->objp));
@@ -2495,7 +2495,7 @@ ADE_FUNC(isDocked, l_Ship, "[ship... dockee_ships]", "Returns whether this ship 
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&docker_objh)))
 		return ADE_RETURN_NIL;
 
-	if (docker_objh == nullptr || !docker_objh->IsValid())
+	if (docker_objh == nullptr || !docker_objh->isValid())
 		return ADE_RETURN_NIL;
 
 	while (true)
@@ -2507,7 +2507,7 @@ ADE_FUNC(isDocked, l_Ship, "[ship... dockee_ships]", "Returns whether this ship 
 		found_arg = true;
 
 		// make sure ship exists
-		if (dockee_objh == nullptr || !dockee_objh->IsValid())
+		if (dockee_objh == nullptr || !dockee_objh->isValid())
 			continue;
 
 		// see if we are docked to it
@@ -2531,7 +2531,7 @@ ADE_FUNC(setDocked, l_Ship, "ship dockee_ship, [string | number docker_point, st
 	if (!ade_get_args(L, "oo", l_Ship.GetPtr(&docker_objh), l_Ship.GetPtr(&dockee_objh)))
 		return ADE_RETURN_NIL;
 
-	if (docker_objh == nullptr || dockee_objh == nullptr || !docker_objh->IsValid() || !dockee_objh->IsValid())
+	if (docker_objh == nullptr || dockee_objh == nullptr || !docker_objh->isValid() || !dockee_objh->isValid())
 		return ADE_RETURN_NIL;
 
 	// cannot dock an object to itself
@@ -2618,7 +2618,7 @@ static int jettison_helper(lua_State *L, object_h *docker_objh, float jettison_s
 		found_arg = true;
 
 		// make sure ship exists
-		if (dockee_objh == nullptr || !dockee_objh->IsValid())
+		if (dockee_objh == nullptr || !dockee_objh->isValid())
 			continue;
 
 		// make sure we are docked to it
@@ -2651,7 +2651,7 @@ ADE_FUNC(setUndocked, l_Ship, "[ship... dockee_ships /* All docked ships by defa
 	if (!ade_get_args(L, "o", l_Ship.GetPtr(&docker_objh)))
 		return ADE_RETURN_NIL;
 
-	if (docker_objh == nullptr || !docker_objh->IsValid())
+	if (docker_objh == nullptr || !docker_objh->isValid())
 		return ADE_RETURN_NIL;
 
 	return jettison_helper(L, docker_objh, 0.0f, 1);
@@ -2665,7 +2665,7 @@ ADE_FUNC(jettison, l_Ship, "number jettison_speed, [ship... dockee_ships /* All 
 	if (!ade_get_args(L, "of", l_Ship.GetPtr(&docker_objh), &jettison_speed))
 		return ADE_RETURN_NIL;
 
-	if (docker_objh == nullptr || !docker_objh->IsValid())
+	if (docker_objh == nullptr || !docker_objh->isValid())
 		return ADE_RETURN_NIL;
 
 	return jettison_helper(L, docker_objh, jettison_speed, 2);

--- a/code/scripting/api/objs/ship_bank.cpp
+++ b/code/scripting/api/objs/ship_bank.cpp
@@ -17,8 +17,8 @@ ship_banktype_h::ship_banktype_h(object* objp_in, ship_weapon* wpn, int in_type)
 	sw = wpn;
 	type = in_type;
 }
-bool ship_banktype_h::IsValid() {
-	return object_h::IsValid() && sw != NULL && (type == SWH_PRIMARY || type == SWH_SECONDARY || type == SWH_TERTIARY);
+bool ship_banktype_h::isValid() const {
+	return object_h::isValid() && sw != NULL && (type == SWH_PRIMARY || type == SWH_SECONDARY || type == SWH_TERTIARY);
 }
 
 //**********HANDLE: Weaponbanktype
@@ -32,7 +32,7 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 	if(!ade_get_args(L, "oi|o", l_WeaponBankType.GetPtr(&sb), &idx, l_WeaponBank.GetPtr(&newbank)))
 		return ade_set_error(L, "o", l_WeaponBank.Set(ship_bank_h()));
 
-	if(!sb->IsValid())
+	if(!sb->isValid())
 		return ade_set_error(L, "o", l_WeaponBank.Set(ship_bank_h()));
 
 	switch(sb->type)
@@ -43,7 +43,7 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 
 			idx--; //Lua->FS2
 
-			if(ADE_SETTING_VAR && newbank && newbank->IsValid()) {
+			if(ADE_SETTING_VAR && newbank && newbank->isValid()) {
 				sb->sw->primary_bank_weapons[idx] = newbank->sw->primary_bank_weapons[idx];
 				sb->sw->next_primary_fire_stamp[idx] = timestamp(0);
 				sb->sw->primary_bank_ammo[idx] = newbank->sw->primary_bank_ammo[idx];
@@ -58,7 +58,7 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 
 			idx--; //Lua->FS2
 
-			if(ADE_SETTING_VAR && newbank && newbank->IsValid()) {
+			if(ADE_SETTING_VAR && newbank && newbank->isValid()) {
 				sb->sw->primary_bank_weapons[idx] = newbank->sw->primary_bank_weapons[idx];
 				sb->sw->next_primary_fire_stamp[idx] = timestamp(0);
 				sb->sw->primary_bank_ammo[idx] = newbank->sw->primary_bank_ammo[idx];
@@ -72,7 +72,7 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 
 			idx--; //Lua->FS2
 
-			if(ADE_SETTING_VAR && newbank && newbank->IsValid()) {
+			if(ADE_SETTING_VAR && newbank && newbank->isValid()) {
 				Error(LOCATION, "Tertiary bank support is still in progress");
 				//WMC: TODO
 			}
@@ -93,7 +93,7 @@ ADE_VIRTVAR(Linked, l_WeaponBankType, "boolean", "Whether bank is in linked or u
 	if(!numargs)
 		return ade_set_error(L, "b", false);
 
-	if(!bh->IsValid())
+	if(!bh->isValid())
 		return ade_set_error(L, "b", false);
 
 	switch(bh->type)
@@ -122,7 +122,7 @@ ADE_VIRTVAR(DualFire, l_WeaponBankType, "boolean", "Whether bank is in dual fire
 	if(!numargs)
 		return ade_set_error(L, "b", false);
 
-	if(!bh->IsValid())
+	if(!bh->isValid())
 		return ade_set_error(L, "b", false);
 
 	switch(bh->type)
@@ -148,7 +148,7 @@ ADE_FUNC(isValid, l_WeaponBankType, NULL, "Detects whether handle is valid", "bo
 	if(!ade_get_args(L, "o", l_WeaponBankType.GetPtr(&sb)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", sb->IsValid());
+	return ade_set_args(L, "b", sb->isValid());
 }
 
 ADE_FUNC(__len, l_WeaponBankType, NULL, "Number of weapons in the mounted bank", "number", "Number of bank weapons, or 0 if handle is invalid")
@@ -157,7 +157,7 @@ ADE_FUNC(__len, l_WeaponBankType, NULL, "Number of weapons in the mounted bank",
 	if(!ade_get_args(L, "o", l_WeaponBankType.GetPtr(&sb)))
 		return ade_set_error(L, "i", 0);
 
-	if(!sb->IsValid())
+	if(!sb->isValid())
 		return ade_set_error(L, "i", 0);
 
 	switch(sb->type)
@@ -183,8 +183,8 @@ ship_bank_h::ship_bank_h() : ship_banktype_h() {
 ship_bank_h::ship_bank_h(object* objp_in, ship_weapon* wpn, int in_type, int in_bank) : ship_banktype_h(objp_in, wpn, in_type) {
 	bank = in_bank;
 }
-bool ship_bank_h::IsValid() {
-	if(!ship_banktype_h::IsValid())
+bool ship_bank_h::isValid() const {
+	if(!ship_banktype_h::isValid())
 		return false;
 
 	if(bank < 0)
@@ -207,7 +207,7 @@ ADE_VIRTVAR(WeaponClass, l_WeaponBank, "weaponclass", "Class of weapon mounted i
 	if(!ade_get_args(L, "o|o", l_WeaponBank.GetPtr(&bh), l_Weaponclass.Get(&weaponclass)))
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
-	if(!bh->IsValid())
+	if(!bh->isValid())
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
 	switch(bh->type)
@@ -249,7 +249,7 @@ ADE_VIRTVAR(AmmoLeft, l_WeaponBank, "number", "Ammo left for the current bank", 
 	if(!ade_get_args(L, "o|i", l_WeaponBank.GetPtr(&bh), &ammo))
 		return ade_set_error(L, "i", 0);
 
-	if(!bh->IsValid())
+	if(!bh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	switch(bh->type)
@@ -284,7 +284,7 @@ ADE_VIRTVAR(AmmoMax, l_WeaponBank, "number", "Maximum ammo for the current bank<
 	if(!ade_get_args(L, "o|i", l_WeaponBank.GetPtr(&bh), &ammomax))
 		return ade_set_error(L, "i", 0);
 
-	if(!bh->IsValid())
+	if(!bh->isValid())
 		return ade_set_error(L, "i", 0);
 
 	switch(bh->type)
@@ -331,7 +331,7 @@ ADE_VIRTVAR(Armed, l_WeaponBank, "boolean", "Weapon armed status. Does not take 
 	if(!ade_get_args(L, "o|b", l_WeaponBank.GetPtr(&bh), &armthis))
 		return ade_set_error(L, "b", false);
 
-	if(!bh->IsValid())
+	if(!bh->isValid())
 		return ade_set_error(L, "b", false);
 
 	int new_armed_bank = -1;
@@ -367,7 +367,7 @@ ADE_VIRTVAR(Capacity, l_WeaponBank, "number", "The actual capacity of a weapon b
 	if(!ade_get_args(L, "o|i", l_WeaponBank.GetPtr(&bh), &newCapacity))
 		return ade_set_error(L, "i", -1);
 
-	if(!bh->IsValid())
+	if(!bh->isValid())
 		return ade_set_error(L, "i", -1);
 
 	switch(bh->type)
@@ -399,7 +399,7 @@ ADE_VIRTVAR(FOFCooldown, l_WeaponBank, "number", "The FOF cooldown value. A valu
 	if(!ade_get_args(L, "o|i", l_WeaponBank.GetPtr(&bh), &newValue))
 		return ade_set_error(L, "f", -1.f);
 
-	if(!bh->IsValid())
+	if(!bh->isValid())
 		return ade_set_error(L, "f", -1.f);
 
 	if (ADE_SETTING_VAR) {
@@ -433,7 +433,7 @@ ADE_VIRTVAR(BurstCounter, l_WeaponBank, "number", "The burst counter for this ba
 	if (!ade_get_args(L, "o|i", l_WeaponBank.GetPtr(&bh), &newCounter))
 		return ade_set_error(L, "i", -1);
 
-	if (!bh->IsValid())
+	if (!bh->isValid())
 		return ade_set_error(L, "i", -1);
 
 	switch (bh->type)
@@ -463,7 +463,7 @@ ADE_VIRTVAR(BurstSeed, l_WeaponBank, "number", "A random seed associated to the 
 	if (!ade_get_args(L, "o|i", l_WeaponBank.GetPtr(&bh), &newSeed))
 		return ade_set_error(L, "i", -1);
 
-	if (!bh->IsValid())
+	if (!bh->isValid())
 		return ade_set_error(L, "i", -1);
 
 	switch (bh->type)
@@ -492,7 +492,7 @@ ADE_FUNC(isValid, l_WeaponBank, NULL, "Detects whether handle is valid", "boolea
 	if(!ade_get_args(L, "o", l_WeaponBank.GetPtr(&bh)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", bh->IsValid());
+	return ade_set_args(L, "b", bh->isValid());
 }
 
 

--- a/code/scripting/api/objs/ship_bank.cpp
+++ b/code/scripting/api/objs/ship_bank.cpp
@@ -9,16 +9,12 @@
 namespace scripting {
 namespace api {
 
-ship_banktype_h::ship_banktype_h() : object_h () {
-	sw = NULL;
-	type = SWH_NONE;
-}
-ship_banktype_h::ship_banktype_h(object* objp_in, ship_weapon* wpn, int in_type) : object_h(objp_in) {
-	sw = wpn;
-	type = in_type;
-}
-bool ship_banktype_h::isValid() const {
-	return object_h::isValid() && sw != NULL && (type == SWH_PRIMARY || type == SWH_SECONDARY || type == SWH_TERTIARY);
+ship_banktype_h::ship_banktype_h() : objh(), sw(nullptr), type(SWH_NONE) {}
+ship_banktype_h::ship_banktype_h(object* objp_in, ship_weapon* wpn, int in_type) : objh(objp_in), sw(wpn), type(in_type) {}
+
+bool ship_banktype_h::isValid() const
+{
+	return objh.isValid() && sw != nullptr && (type == SWH_PRIMARY || type == SWH_SECONDARY || type == SWH_TERTIARY);
 }
 
 //**********HANDLE: Weaponbanktype
@@ -81,7 +77,7 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 			return ade_set_error(L, "o", l_WeaponBank.Set(ship_bank_h()));	//Invalid type
 	}
 
-	return ade_set_args(L, "o", l_WeaponBank.Set(ship_bank_h(sb->objp, sb->sw, sb->type, idx)));
+	return ade_set_args(L, "o", l_WeaponBank.Set(ship_bank_h(sb->objh.objp, sb->sw, sb->type, idx)));
 }
 
 ADE_VIRTVAR(Linked, l_WeaponBankType, "boolean", "Whether bank is in linked or unlinked fire mode (Primary-only)", "boolean", "Link status, or false if handle is invalid")
@@ -100,10 +96,10 @@ ADE_VIRTVAR(Linked, l_WeaponBankType, "boolean", "Whether bank is in linked or u
 	{
 		case SWH_PRIMARY:
 			if(ADE_SETTING_VAR && numargs > 1) {
-				Ships[bh->objp->instance].flags.set(Ship::Ship_Flags::Primary_linked, newlink);
+				Ships[bh->objh.objp->instance].flags.set(Ship::Ship_Flags::Primary_linked, newlink);
 			}
 
-			return ade_set_args(L, "b", (Ships[bh->objp->instance].flags[Ship::Ship_Flags::Primary_linked]));
+			return ade_set_args(L, "b", (Ships[bh->objh.objp->instance].flags[Ship::Ship_Flags::Primary_linked]));
 
 		case SWH_SECONDARY:
 		case SWH_TERTIARY:
@@ -129,10 +125,10 @@ ADE_VIRTVAR(DualFire, l_WeaponBankType, "boolean", "Whether bank is in dual fire
 	{
 		case SWH_SECONDARY:
 			if(ADE_SETTING_VAR && numargs > 1) {
-				Ships[bh->objp->instance].flags.set(Ship::Ship_Flags::Secondary_dual_fire, newfire);
+				Ships[bh->objh.objp->instance].flags.set(Ship::Ship_Flags::Secondary_dual_fire, newfire);
 			}
 
-			return ade_set_args(L, "b", (Ships[bh->objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire]));
+			return ade_set_args(L, "b", (Ships[bh->objh.objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire]));
 
 		case SWH_PRIMARY:
 		case SWH_TERTIARY:
@@ -297,9 +293,9 @@ ADE_VIRTVAR(AmmoMax, l_WeaponBank, "number", "Maximum ammo for the current bank<
 
 			int weapon_class = bh->sw->primary_bank_weapons[bh->bank];
 
-			Assert(bh->objp->type == OBJ_SHIP);
+			Assert(bh->objh.objp->type == OBJ_SHIP);
 
-			return ade_set_args(L, "i", get_max_ammo_count_for_primary_bank(Ships[bh->objp->instance].ship_info_index, bh->bank, weapon_class));
+			return ade_set_args(L, "i", get_max_ammo_count_for_primary_bank(Ships[bh->objh.objp->instance].ship_info_index, bh->bank, weapon_class));
 		}
 		case SWH_SECONDARY:
 		{
@@ -309,9 +305,9 @@ ADE_VIRTVAR(AmmoMax, l_WeaponBank, "number", "Maximum ammo for the current bank<
 
 			int weapon_class = bh->sw->secondary_bank_weapons[bh->bank];
 
-			Assert(bh->objp->type == OBJ_SHIP);
+			Assert(bh->objh.objp->type == OBJ_SHIP);
 
-			return ade_set_args(L, "i", get_max_ammo_count_for_bank(Ships[bh->objp->instance].ship_info_index, bh->bank, weapon_class));
+			return ade_set_args(L, "i", get_max_ammo_count_for_bank(Ships[bh->objh.objp->instance].ship_info_index, bh->bank, weapon_class));
 		}
 		case SWH_TERTIARY:
 			if(ADE_SETTING_VAR && ammomax > -1) {

--- a/code/scripting/api/objs/ship_bank.h
+++ b/code/scripting/api/objs/ship_bank.h
@@ -12,10 +12,11 @@ const int SWH_PRIMARY = 1;
 const int SWH_SECONDARY = 2;
 const int SWH_TERTIARY = 3;
 
-struct ship_banktype_h : public object_h
+struct ship_banktype_h
 {
-	int type;
+	object_h objh;
 	ship_weapon *sw;
+	int type;
 
 	ship_banktype_h();
 	ship_banktype_h(object *objp_in, ship_weapon *wpn, int in_type);

--- a/code/scripting/api/objs/ship_bank.h
+++ b/code/scripting/api/objs/ship_bank.h
@@ -20,7 +20,7 @@ struct ship_banktype_h : public object_h
 	ship_banktype_h();
 	ship_banktype_h(object *objp_in, ship_weapon *wpn, int in_type);
 
-	bool IsValid();
+	bool isValid() const;
 };
 DECLARE_ADE_OBJ(l_WeaponBankType, ship_banktype_h);
 
@@ -31,7 +31,7 @@ struct ship_bank_h : public ship_banktype_h
 	ship_bank_h();
 	ship_bank_h(object *objp_in, ship_weapon *wpn, int in_type, int in_bank);
 
-	bool IsValid();
+	bool isValid() const;
 };
 DECLARE_ADE_OBJ(l_WeaponBank, ship_bank_h);
 

--- a/code/scripting/api/objs/shipwepselect.cpp
+++ b/code/scripting/api/objs/shipwepselect.cpp
@@ -8,7 +8,7 @@ namespace api {
 
 ss_wing_info_h::ss_wing_info_h() : ss_wing(-1) {}
 ss_wing_info_h::ss_wing_info_h(int l_wing) : ss_wing(l_wing) {}
-bool ss_wing_info_h::IsValid() const
+bool ss_wing_info_h::isValid() const
 {
 	return ss_wing >= 0;
 }
@@ -19,7 +19,7 @@ ss_wing_info* ss_wing_info_h::getWing() const
 
 ss_slot_info_h::ss_slot_info_h() {}
 ss_slot_info_h::ss_slot_info_h(ss_slot_info* l_slots, int l_idx) : ss_slots(l_slots), ss_idx(l_idx) {}
-bool ss_slot_info_h::IsValid() const
+bool ss_slot_info_h::isValid() const
 {
 	return ss_slots != nullptr;
 }
@@ -30,7 +30,7 @@ ss_slot_info* ss_slot_info_h::getSlot() const
 
 wss_unit_wep_h::wss_unit_wep_h() : ss_unit(-1) {}
 wss_unit_wep_h::wss_unit_wep_h(int l_unit) : ss_unit(l_unit) {}
-bool wss_unit_wep_h::IsValid() const
+bool wss_unit_wep_h::isValid() const
 {
 	return ss_unit >= 0;
 	// return ((ss_unit >= 0) && ((ss_bank >= 0) && (ss_bank <= 6)));
@@ -42,7 +42,7 @@ wss_unit* wss_unit_wep_h::getBank() const
 
 wss_unit_count_h::wss_unit_count_h() : ss_unit(-1) {}
 wss_unit_count_h::wss_unit_count_h(int l_unit) : ss_unit(l_unit) {}
-bool wss_unit_count_h::IsValid() const
+bool wss_unit_count_h::isValid() const
 {
 	return ss_unit >= 0;
 	// return ((ss_unit >= 0) && ((ss_bank >= 0) && (ss_bank <= 6)));

--- a/code/scripting/api/objs/shipwepselect.h
+++ b/code/scripting/api/objs/shipwepselect.h
@@ -12,7 +12,7 @@ struct ss_wing_info_h {
 	int ss_wing;
 	ss_wing_info_h();
 	explicit ss_wing_info_h(int l_wing);
-	bool IsValid() const;
+	bool isValid() const;
 	ss_wing_info* getWing() const;
 };
 
@@ -21,7 +21,7 @@ struct ss_slot_info_h {
 	int ss_idx;
 	ss_slot_info_h();
 	explicit ss_slot_info_h(ss_slot_info* l_slots, int l_idx);
-	bool IsValid() const;
+	bool isValid() const;
 	ss_slot_info* getSlot() const;
 };
 
@@ -29,7 +29,7 @@ struct wss_unit_wep_h {
 	int ss_unit;
 	wss_unit_wep_h();
 	explicit wss_unit_wep_h(int l_unit);
-	bool IsValid() const;
+	bool isValid() const;
 	wss_unit* getBank() const;
 };
 
@@ -37,7 +37,7 @@ struct wss_unit_count_h {
 	int ss_unit;
 	wss_unit_count_h();
 	explicit wss_unit_count_h(int l_unit);
-	bool IsValid() const;
+	bool isValid() const;
 	wss_unit* getBank() const;
 };
 

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -14,13 +14,13 @@ sound_entry_h::sound_entry_h() {
 sound_entry_h::sound_entry_h(gamesnd_id n_idx) {
 	idx = n_idx;
 }
-game_snd* sound_entry_h::Get() {
-	if (!this->IsValid())
+game_snd* sound_entry_h::Get() const {
+	if (!this->isValid())
 		return NULL;
 
 	return gamesnd_get_game_sound(idx);
 }
-bool sound_entry_h::IsValid() {
+bool sound_entry_h::isValid() const {
 	return gamesnd_game_sound_valid(idx);
 }
 
@@ -35,7 +35,7 @@ ADE_VIRTVAR(DefaultVolume, l_SoundEntry, "number", "The default volume of this g
 	if (!ade_get_args(L, "o|f", l_SoundEntry.GetPtr(&seh), &newVal))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (seh == NULL || !seh->IsValid())
+	if (seh == NULL || !seh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	if (ADE_SETTING_VAR)
@@ -58,7 +58,7 @@ ADE_FUNC(getFilename, l_SoundEntry, NULL, "Returns the filename of this sound. I
 	if (!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
 		return ade_set_error(L, "s", "");
 
-	if (seh == NULL || !seh->IsValid())
+	if (seh == NULL || !seh->isValid())
 		return ade_set_error(L, "s", "");
 
 	Assertion(!seh->Get()->sound_entries.empty(),
@@ -75,7 +75,7 @@ ADE_FUNC(getDuration, l_SoundEntry, NULL, "Gives the length of the sound in seco
 	if (!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (seh == NULL || !seh->IsValid())
+	if (seh == NULL || !seh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	return ade_set_args(L, "f", (i2fl(gamesnd_get_max_duration(seh->Get())) / 1000.0f));
@@ -100,7 +100,7 @@ ADE_FUNC(get3DValues,
 	if (!ade_get_args(L, "oo|f", l_SoundEntry.GetPtr(&seh), l_Vector.GetPtr(&sourcePos), &radius))
 		return ade_set_error(L, "ff", -1.0f, -1.0f);
 
-	if (seh == NULL || !seh->IsValid())
+	if (seh == NULL || !seh->isValid())
 		return ade_set_error(L, "ff", -1.0f, -1.0f);
 
 	int result = snd_get_3d_vol_and_pan(seh->Get(), sourcePos, &vol, &pan, radius);
@@ -121,7 +121,7 @@ ADE_FUNC(isValid, l_SoundEntry, nullptr, "Detects whether handle is valid", "boo
 	if(!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", seh->IsValid());
+	return ade_set_args(L, "b", seh->isValid());
 }
 
 ADE_FUNC(tryLoad, l_SoundEntry, nullptr, "Detects whether handle references a sound that can be loaded", "boolean", "true if a load succeeded, false if not, nil if a syntax/type error occurs")
@@ -135,23 +135,23 @@ ADE_FUNC(tryLoad, l_SoundEntry, nullptr, "Detects whether handle references a so
 
 sound_h::sound_h() : sound_entry_h() { sig = sound_handle::invalid(); }
 sound_h::sound_h(gamesnd_id n_gs_idx, sound_handle n_sig) : sound_entry_h(n_gs_idx) { sig = n_sig; }
-sound_handle sound_h::getSignature()
+sound_handle sound_h::getSignature() const
 {
 	// We can have both regular and raw file sounds here so we have to check both
 	// else even a valid signature is never returned.
-	if (!IsValid() && !IsSoundValid())
+	if (!isValid() && !isSoundValid())
 		return sound_handle::invalid();
 
 	return sig;
 }
-bool sound_h::IsSoundValid() {
+bool sound_h::isSoundValid() const {
 	if (!sig.isValid() || ds_get_channel(sig) < 0)
 		return false;
 
 	return true;
 }
-bool sound_h::IsValid() {
-	if(!sound_entry_h::IsValid())
+bool sound_h::isValid() const {
+	if(!sound_entry_h::isValid())
 		return false;
 
 	if (!sig.isValid() || ds_get_channel(sig) < 0)
@@ -170,7 +170,7 @@ ADE_VIRTVAR(Pitch, l_Sound, "number", "Pitch of sound, from 100 to 100000", "num
 	if(!ade_get_args(L, "o|i", l_Sound.GetPtr(&sh), &newpitch))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!sh->IsSoundValid())
+	if (!sh->isSoundValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR)
@@ -192,7 +192,7 @@ ADE_FUNC(getRemainingTime, l_Sound, NULL, "The remaining time of this sound hand
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (!sh->IsSoundValid())
+	if (!sh->isSoundValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	int remaining = snd_time_remaining(sh->getSignature());
@@ -214,7 +214,7 @@ ADE_FUNC(setVolume,
 	if (!ade_get_args(L, "of|b", l_Sound.GetPtr(&sh), &newVol, &voice))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->IsSoundValid())
+	if (!sh->isSoundValid())
 		return ADE_RETURN_FALSE;
 
 	CAP(newVol, 0.0f, 1.0f);
@@ -231,7 +231,7 @@ ADE_FUNC(setPanning, l_Sound, "number", "Sets the panning of this sound. Argumen
 	if(!ade_get_args(L, "of", l_Sound.GetPtr(&sh), &newPan))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->IsSoundValid())
+	if (!sh->isSoundValid())
 		return ADE_RETURN_FALSE;
 
 	CAP(newPan, -1.0f, 1.0f);
@@ -253,7 +253,7 @@ ADE_FUNC(setPosition, l_Sound, "number value, boolean percent = true",
 	if(!ade_get_args(L, "of|b", l_Sound.GetPtr(&sh), &val, &percent))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->IsValid())
+	if (!sh->isValid())
 		return ADE_RETURN_FALSE;
 
 	if (val <= 0.0f)
@@ -272,7 +272,7 @@ ADE_FUNC(rewind, l_Sound, "number", "Rewinds the sound by the given number of se
 	if(!ade_get_args(L, "of", l_Sound.GetPtr(&sh), &val))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->IsValid())
+	if (!sh->isValid())
 		return ADE_RETURN_FALSE;
 
 	if (val <= 0.0f)
@@ -291,7 +291,7 @@ ADE_FUNC(skip, l_Sound, "number", "Skips the given number of seconds of the soun
 	if(!ade_get_args(L, "of", l_Sound.GetPtr(&sh), &val))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->IsValid())
+	if (!sh->isValid())
 		return ADE_RETURN_FALSE;
 
 	if (val <= 0.0f)
@@ -308,7 +308,7 @@ ADE_FUNC(isPlaying, l_Sound, NULL, "Specifies if this handle is currently playin
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->IsSoundValid())
+	if (!sh->isSoundValid())
 		return ade_set_error(L, "b", false);
 
 	return ade_set_args(L, "b", snd_is_playing(sh->getSignature()) == 1);
@@ -320,7 +320,7 @@ ADE_FUNC(stop, l_Sound, NULL, "Stops the sound of this handle", "boolean", "true
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->IsSoundValid())
+	if (!sh->isSoundValid())
 		return ade_set_error(L, "b", false);
 
 	snd_stop(sh->getSignature());
@@ -334,7 +334,7 @@ ADE_FUNC(pause, l_Sound, NULL, "Pauses the sound of this handle", "boolean", "tr
 	if (!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->IsSoundValid())
+	if (!sh->isSoundValid())
 		return ade_set_error(L, "b", false);
 
 	if (snd_is_paused(sh->getSignature()))
@@ -351,7 +351,7 @@ ADE_FUNC(resume, l_Sound, NULL, "Resumes the sound of this handle", "boolean", "
 	if (!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->IsSoundValid())
+	if (!sh->isSoundValid())
 		return ade_set_error(L, "b", false);
 
 	if (!snd_is_paused(sh->getSignature()))
@@ -372,7 +372,7 @@ ADE_FUNC(isValid, l_Sound, nullptr,
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", sh->IsValid());
+	return ade_set_args(L, "b", sh->isValid());
 }
 
 ADE_FUNC(isSoundValid, l_Sound, NULL, "Checks if only the sound is valid, should be used for non soundentry sounds",
@@ -382,7 +382,7 @@ ADE_FUNC(isSoundValid, l_Sound, NULL, "Checks if only the sound is valid, should
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", sh->IsSoundValid());
+	return ade_set_args(L, "b", sh->isSoundValid());
 }
 
 ADE_OBJ_DERIV(l_Sound3D, sound_h, "sound3D", "3D sound instance handle", l_Sound);
@@ -396,7 +396,7 @@ ADE_FUNC(updatePosition, l_Sound3D, "vector Position, [number radius = 0.0]", "U
 	if(!ade_get_args(L, "oo|f", l_Sound.GetPtr(&sh), l_Vector.GetPtr(&newPos), &radius))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->IsValid() || newPos == NULL)
+	if (!sh->isValid() || newPos == NULL)
 		return ade_set_error(L, "b", false);
 
 	snd_update_3d_pos(sh->getSignature(), sh->Get(), newPos, radius);

--- a/code/scripting/api/objs/sound.h
+++ b/code/scripting/api/objs/sound.h
@@ -17,9 +17,9 @@ struct sound_entry_h
 
 	explicit sound_entry_h(gamesnd_id n_idx);
 
-	game_snd *Get();
+	game_snd *Get() const;
 
-	bool IsValid();
+	bool isValid() const;
 };
 
 //**********HANDLE: SoundEntry
@@ -33,11 +33,11 @@ struct sound_h : public sound_entry_h
 
 	sound_h(gamesnd_id n_gs_idx, sound_handle n_sig);
 
-	sound_handle getSignature();
+	sound_handle getSignature() const;
 
-	bool IsSoundValid();
+	bool isSoundValid() const;
 
-	bool IsValid();
+	bool isValid() const;
 };
 
 //**********HANDLE: Sound

--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -9,7 +9,7 @@
 namespace scripting {
 namespace api {
 
-bool streaminganim_h::IsValid() {
+bool streaminganim_h::isValid() const {
 	return (ga.num_frames > 0);
 }
 streaminganim_h::streaminganim_h(const char* real_filename) {
@@ -60,7 +60,7 @@ ADE_VIRTVAR(Loop, l_streaminganim, "boolean", "Make the streaming animation loop
 	if(!ade_get_args(L, "o|b", l_streaminganim.GetPtr(&sah), &loop))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	if (ADE_SETTING_VAR) {
@@ -81,7 +81,7 @@ ADE_VIRTVAR(Pause, l_streaminganim, "boolean", "Pause the streaming animation.",
 	if(!ade_get_args(L, "o|b", l_streaminganim.GetPtr(&sah), &pause))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	if (ADE_SETTING_VAR) {
@@ -102,7 +102,7 @@ ADE_VIRTVAR(Reverse, l_streaminganim, "boolean", "Make the streaming animation p
 	if(!ade_get_args(L, "o|b", l_streaminganim.GetPtr(&sah), &reverse))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	if (ADE_SETTING_VAR) {
@@ -123,7 +123,7 @@ ADE_VIRTVAR(Grayscale, l_streaminganim, "boolean", "Whether the streaming animat
 	if (!ade_get_args(L, "o|b", l_streaminganim.GetPtr(&sah), &grayscale))
 		return ADE_RETURN_NIL;
 
-	if (!sah->IsValid())
+	if (!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	if (ADE_SETTING_VAR) {
@@ -140,7 +140,7 @@ ADE_FUNC(getFilename, l_streaminganim, NULL, "Get the filename of the animation"
 	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "s", sah->ga.filename);
@@ -154,7 +154,7 @@ ADE_FUNC(getFrameCount, l_streaminganim, nullptr, "Get the number of frames in t
 	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "i", sah->ga.num_frames);
@@ -168,7 +168,7 @@ ADE_FUNC(getFrameIndex, l_streaminganim, nullptr, "Get the current frame index o
 	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	int cframe = sah->ga.current_frame;
@@ -187,7 +187,7 @@ ADE_FUNC(getHeight, l_streaminganim, nullptr, "Get the height of the animation i
 	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "i", sah->ga.height);
@@ -201,7 +201,7 @@ ADE_FUNC(getWidth, l_streaminganim, nullptr, "Get the width of the animation in 
 	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "i", sah->ga.width);
@@ -213,7 +213,7 @@ ADE_FUNC(isValid, l_streaminganim, nullptr, "Detects whether handle is valid", "
 	if(!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", sah->IsValid());
+	return ade_set_args(L, "b", sah->isValid());
 }
 
 ADE_FUNC(preload, l_streaminganim, NULL, "Load all apng animations into memory, enabling apng frame cache if not already enabled", "boolean", "true if preload was successful, nil if a syntax/type error occurs")
@@ -245,7 +245,7 @@ ADE_FUNC(process, l_streaminganim, "[number x1, number y1, number x2, number y2,
 					 &ge.draw))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	if (sah->ga.use_hud_color)
@@ -301,7 +301,7 @@ ADE_FUNC(timeLeft, l_streaminganim, nullptr, "Get the amount of time left in the
 	if (!ade_get_args(L, "o", l_streaminganim.GetPtr(&sah)))
 		return ADE_RETURN_NIL;
 
-	if(!sah->IsValid())
+	if(!sah->isValid())
 		return ADE_RETURN_NIL;
 
 	float timeLeft = 0.0f;

--- a/code/scripting/api/objs/streaminganim.h
+++ b/code/scripting/api/objs/streaminganim.h
@@ -12,7 +12,7 @@ class streaminganim_h {
  public:
 	generic_anim ga;
 
-	bool IsValid();
+	bool isValid() const;
 	explicit streaminganim_h (const char* filename);
 	~streaminganim_h();
 

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -26,12 +26,12 @@ ship_subsys_h::ship_subsys_h() : object_h() {
 ship_subsys_h::ship_subsys_h(object* objp_in, ship_subsys* sub) : object_h(objp_in) {
 	ss = sub;
 }
-bool ship_subsys_h::isSubsystemValid() const { return object_h::IsValid() && objp->type == OBJ_SHIP && ss != nullptr; }
+bool ship_subsys_h::isSubsystemValid() const { return object_h::isValid() && objp->type == OBJ_SHIP && ss != nullptr; }
 
 void ship_subsys_h::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
 	ship_subsys_h subsys;
 	value.getValue(l_Subsystem.Get(&subsys));
-	const ushort& netsig = subsys.IsValid() ? subsys.objp->net_signature : 0;
+	const ushort& netsig = subsys.isValid() ? subsys.objp->net_signature : 0;
 	const int& subsys_index = subsys.isSubsystemValid() ? ship_get_subsys_index(subsys.ss) : -1;
 	ADD_USHORT(netsig);
 	ADD_INT(subsys_index);
@@ -458,7 +458,7 @@ ADE_VIRTVAR(Target, l_Subsystem, "object", "Object targeted by this subsystem. I
 	ship_subsys *ss = sso->ss;
 
 	if(ADE_SETTING_VAR)	{
-		if (objh && objh->IsValid()) {
+		if (objh && objh->isValid()) {
 			ss->turret_enemy_objnum = OBJ_INDEX(objh->objp);
 			ss->turret_enemy_sig = objh->sig;
 			ss->targeted_subsys = nullptr;
@@ -717,7 +717,7 @@ ADE_FUNC(getModelFlag,
 		return ADE_RETURN_NIL;
 	int skip_args = 1;	// not 2 because there will be one more below
 
-	if (!sso->IsValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	do {
@@ -794,7 +794,7 @@ ADE_FUNC(isTargetInFOV, l_Subsystem, "object Target", "Determines if the object 
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Object.GetPtr(&newh)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid() || !newh || !newh->IsValid() || !(sso->ss->system_info->type == SUBSYSTEM_TURRET))
+	if (!sso->isSubsystemValid() || !newh || !newh->isValid() || !(sso->ss->system_info->type == SUBSYSTEM_TURRET))
 		return ADE_RETURN_NIL;
 
 	vec3d	tpos,tvec;

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -28,7 +28,7 @@ bool ship_subsys_h::isValid() const { return objh.isValid() && objh.objp->type =
 void ship_subsys_h::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
 	ship_subsys_h subsys;
 	value.getValue(l_Subsystem.Get(&subsys));
-	const ushort& netsig = subsys.isValid() ? subsys.objh.objp->net_signature : 0;
+	const ushort& netsig = subsys.objh.isValid() ? subsys.objh.objp->net_signature : 0;
 	const int& subsys_index = subsys.isValid() ? ship_get_subsys_index(subsys.ss) : -1;
 	ADD_USHORT(netsig);
 	ADD_INT(subsys_index);

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -20,18 +20,15 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 namespace scripting {
 namespace api {
 
-ship_subsys_h::ship_subsys_h() : object_h() {
-	ss = NULL;
-}
-ship_subsys_h::ship_subsys_h(object* objp_in, ship_subsys* sub) : object_h(objp_in) {
-	ss = sub;
-}
-bool ship_subsys_h::isSubsystemValid() const { return object_h::isValid() && objp->type == OBJ_SHIP && ss != nullptr; }
+ship_subsys_h::ship_subsys_h() : objh(), ss(nullptr) {}
+ship_subsys_h::ship_subsys_h(object* objp_in, ship_subsys* sub) : objh(objp_in), ss(sub) {}
+
+bool ship_subsys_h::isSubsystemValid() const { return objh.isValid() && objh.objp->type == OBJ_SHIP && ss != nullptr; }
 
 void ship_subsys_h::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
 	ship_subsys_h subsys;
 	value.getValue(l_Subsystem.Get(&subsys));
-	const ushort& netsig = subsys.isValid() ? subsys.objp->net_signature : 0;
+	const ushort& netsig = subsys.isSubsystemValid() ? subsys.objh.objp->net_signature : 0;
 	const int& subsys_index = subsys.isSubsystemValid() ? ship_get_subsys_index(subsys.ss) : -1;
 	ADD_USHORT(netsig);
 	ADD_INT(subsys_index);
@@ -224,7 +221,7 @@ ADE_VIRTVAR(HitpointsLeft, l_Subsystem, "number", "Subsystem hitpoints left", "n
 		//Only go down to 0 hits
 		sso->ss->current_hits = MAX(0.0f, f);
 
-		ship *shipp = &Ships[sso->objp->instance];
+		ship *shipp = &Ships[sso->objh.objp->instance];
 		if (f <= -1.0f && sso->ss->current_hits <= 0.0f) {
 			do_subobj_destroyed_stuff(shipp, sso->ss, NULL);
 		}
@@ -248,7 +245,7 @@ ADE_VIRTVAR(HitpointsMax, l_Subsystem, "number", "Subsystem hitpoints max", "num
 	{
 		sso->ss->max_hits = MIN(0.0f, f);
 
-		ship_recalc_subsys_strength(&Ships[sso->objp->instance]);
+		ship_recalc_subsys_strength(&Ships[sso->objh.objp->instance]);
 	}
 
 	return ade_set_args(L, "f", sso->ss->max_hits);
@@ -285,7 +282,7 @@ ADE_VIRTVAR(WorldPosition, l_Subsystem, "vector",
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	vec3d world_pos;
-	get_subsystem_world_pos(sso->objp, sso->ss, &world_pos);
+	get_subsystem_world_pos(sso->objh.objp, sso->ss, &world_pos);
 
 	return ade_set_args(L, "o", l_Vector.Set(world_pos));
 }
@@ -300,7 +297,7 @@ ADE_VIRTVAR(GunPosition, l_Subsystem, "vector", "Subsystem gun position with reg
 	if (!sso->isSubsystemValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	polymodel *pm = model_get(Ship_info[Ships[sso->objp->instance].ship_info_index].model_num);
+	polymodel *pm = model_get(Ship_info[Ships[sso->objh.objp->instance].ship_info_index].model_num);
 	Assert(pm != NULL);
 
 	if(sso->ss->system_info->turret_gun_sobj < 0)
@@ -410,7 +407,7 @@ ADE_VIRTVAR(PrimaryBanks, l_Subsystem, "weaponbanktype", "Array of primary weapo
 		memcpy(dst->primary_bank_weapons, src->primary_bank_weapons, sizeof(dst->primary_bank_weapons));
 	}
 
-	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(sso->objp, dst, SWH_PRIMARY)));
+	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(sso->objh.objp, dst, SWH_PRIMARY)));
 }
 
 ADE_VIRTVAR(SecondaryBanks, l_Subsystem, "weaponbanktype", "Array of secondary weapon banks", "weaponbanktype", "Secondary banks, or invalid weaponbanktype handle if subsystem handle is invalid")
@@ -441,7 +438,7 @@ ADE_VIRTVAR(SecondaryBanks, l_Subsystem, "weaponbanktype", "Array of secondary w
 		memcpy(dst->secondary_next_slot, src->secondary_next_slot, sizeof(dst->secondary_next_slot));
 	}
 
-	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(sso->objp, dst, SWH_SECONDARY)));
+	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(sso->objh.objp, dst, SWH_SECONDARY)));
 }
 
 
@@ -717,7 +714,7 @@ ADE_FUNC(getModelFlag,
 		return ADE_RETURN_NIL;
 	int skip_args = 1;	// not 2 because there will be one more below
 
-	if (!sso->isValid())
+	if (!sso->isSubsystemValid())
 		return ADE_RETURN_NIL;
 
 	do {
@@ -798,7 +795,7 @@ ADE_FUNC(isTargetInFOV, l_Subsystem, "object Target", "Determines if the object 
 		return ADE_RETURN_NIL;
 
 	vec3d	tpos,tvec;
-	ship_get_global_turret_info(sso->objp, sso->ss->system_info, &tpos, &tvec);
+	ship_get_global_turret_info(sso->objh.objp, sso->ss->system_info, &tpos, &tvec);
 
 	int in_fov = object_in_turret_fov(newh->objp,sso->ss,&tvec,&tpos,vm_vec_dist(&newh->objp->pos,&tpos));
 
@@ -819,7 +816,7 @@ ADE_FUNC(isPositionInFOV, l_Subsystem, "vector Target", "Determines if a positio
 		return ADE_RETURN_NIL;
 
 	vec3d tpos, tvec;
-	ship_get_global_turret_info(sso->objp, sso->ss->system_info, &tpos, &tvec);
+	ship_get_global_turret_info(sso->objh.objp, sso->ss->system_info, &tpos, &tvec);
 
 	vec3d v2e;
 	vm_vec_normalized_dir(&v2e, &target, &tpos);
@@ -865,11 +862,11 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRan
 	//Get default turret info
 	vec3d gpos, gvec;
 
-	ship_get_global_turret_gun_info(sso->objp, sso->ss, &gpos, false, &gvec, true, nullptr);
+	ship_get_global_turret_gun_info(sso->objh.objp, sso->ss, &gpos, false, &gvec, true, nullptr);
 	if (override_gvec != nullptr)
 		gvec = *override_gvec;
 
-	bool rtn = turret_fire_weapon(wnum, sso->ss, OBJ_INDEX(sso->objp), &gpos, &gvec, NULL, flak_range);
+	bool rtn = turret_fire_weapon(wnum, sso->ss, OBJ_INDEX(sso->objh.objp), &gpos, &gvec, NULL, flak_range);
 
 	sso->ss->turret_next_fire_pos++;
 
@@ -891,7 +888,7 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 		return ADE_RETURN_NIL;
 
 	//Get default turret info
-	object *objp = sso->objp;
+	object *objp = sso->objh.objp;
 
 	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 	auto pm = model_get(pmi->model_num);
@@ -914,7 +911,7 @@ ADE_FUNC(getTurretHeading, l_Subsystem, NULL, "Returns the turrets forward vecto
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	vec3d gvec;
-	object *objp = sso->objp;
+	object *objp = sso->objh.objp;
 
 	auto pmi = model_get_instance(Ships[objp->instance].model_instance_num);
 	auto pm = model_get(pmi->model_num);
@@ -961,7 +958,7 @@ ADE_FUNC(
 
 	vec3d gpos, gvec;
 
-	ship_get_global_turret_gun_info(sso->objp, sso->ss, &gpos, false, &gvec, true, nullptr);
+	ship_get_global_turret_gun_info(sso->objh.objp, sso->ss, &gpos, false, &gvec, true, nullptr);
 
 	return ade_set_args(L, "oo", l_Vector.Set(gpos), l_Vector.Set(gvec));
 }
@@ -994,7 +991,7 @@ ADE_FUNC(getParent, l_Subsystem, NULL, "The object parent of this subsystem, is 
 	if (!sso->isSubsystemValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	return ade_set_object_with_breed(L, OBJ_INDEX(sso->objp));
+	return ade_set_object_with_breed(L, OBJ_INDEX(sso->objh.objp));
 }
 
 ADE_FUNC(isInViewFrom, l_Subsystem, "vector from",
@@ -1011,10 +1008,10 @@ ADE_FUNC(isInViewFrom, l_Subsystem, "vector from",
 		return ADE_RETURN_FALSE;
 
 	vec3d world_pos;
-	get_subsystem_world_pos(sso->objp, sso->ss, &world_pos);
+	get_subsystem_world_pos(sso->objh.objp, sso->ss, &world_pos);
 
 	// Disable facing check since the HUD code does the same
-	bool in_sight = ship_subsystem_in_sight(sso->objp, sso->ss, from, &world_pos, false);
+	bool in_sight = ship_subsystem_in_sight(sso->objh.objp, sso->ss, from, &world_pos, false);
 
 	return ade_set_args(L, "b", in_sight);
 }

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -23,13 +23,13 @@ namespace api {
 ship_subsys_h::ship_subsys_h() : objh(), ss(nullptr) {}
 ship_subsys_h::ship_subsys_h(object* objp_in, ship_subsys* sub) : objh(objp_in), ss(sub) {}
 
-bool ship_subsys_h::isSubsystemValid() const { return objh.isValid() && objh.objp->type == OBJ_SHIP && ss != nullptr; }
+bool ship_subsys_h::isValid() const { return objh.isValid() && objh.objp->type == OBJ_SHIP && ss != nullptr; }
 
 void ship_subsys_h::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
 	ship_subsys_h subsys;
 	value.getValue(l_Subsystem.Get(&subsys));
-	const ushort& netsig = subsys.isSubsystemValid() ? subsys.objh.objp->net_signature : 0;
-	const int& subsys_index = subsys.isSubsystemValid() ? ship_get_subsys_index(subsys.ss) : -1;
+	const ushort& netsig = subsys.isValid() ? subsys.objh.objp->net_signature : 0;
+	const int& subsys_index = subsys.isValid() ? ship_get_subsys_index(subsys.ss) : -1;
 	ADD_USHORT(netsig);
 	ADD_INT(subsys_index);
 }
@@ -53,7 +53,7 @@ ADE_FUNC(__tostring, l_Subsystem, NULL, "Returns name of subsystem", "string", "
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ade_set_error(L, "s", "");
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", ship_subsys_get_name(sso->ss));
@@ -68,7 +68,7 @@ ADE_VIRTVAR(ArmorClass, l_Subsystem, "string", "Current Armor class", "string", 
 	if(!ade_get_args(L, "o|s", l_Subsystem.GetPtr(&sso), &s))
 		return ade_set_error(L, "s", "");
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "s", "");
 
 	ship_subsys *ssys = sso->ss;
@@ -96,7 +96,7 @@ ADE_VIRTVAR(AWACSIntensity, l_Subsystem, "number", "Subsystem AWACS intensity", 
 	if(!ade_get_args(L, "o|f", l_Subsystem.GetPtr(&sso), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR && f >= 0.0f)
@@ -112,7 +112,7 @@ ADE_VIRTVAR(AWACSRadius, l_Subsystem, "number", "Subsystem AWACS radius", "numbe
 	if(!ade_get_args(L, "o|f", l_Subsystem.GetPtr(&sso), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR && f >= 0.0f)
@@ -128,7 +128,7 @@ ADE_VIRTVAR(Orientation, l_Subsystem, "orientation", "Orientation of subobject o
 	if (!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Matrix.GetPtr(&mh)))
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
 	auto smi = sso->ss->submodel_instance_1;
@@ -160,7 +160,7 @@ ADE_VIRTVAR(GunOrientation, l_Subsystem, "orientation", "Orientation of turret g
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Matrix.GetPtr(&mh)))
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Matrix.Set(matrix_h()));
 
 	auto smi = sso->ss->submodel_instance_2;
@@ -188,7 +188,7 @@ ADE_VIRTVAR(TranslationOffset,
 	if (!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Vector.GetPtr(&vec)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	auto smi = sso->ss->submodel_instance_1;
@@ -213,7 +213,7 @@ ADE_VIRTVAR(HitpointsLeft, l_Subsystem, "number", "Subsystem hitpoints left", "n
 	if(!ade_get_args(L, "o|f", l_Subsystem.GetPtr(&sso), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR)
@@ -238,7 +238,7 @@ ADE_VIRTVAR(HitpointsMax, l_Subsystem, "number", "Subsystem hitpoints max", "num
 	if(!ade_get_args(L, "o|f", l_Subsystem.GetPtr(&sso), &f))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR)
@@ -258,7 +258,7 @@ ADE_VIRTVAR(Position, l_Subsystem, "vector", "Subsystem position with regards to
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Vector.GetPtr(&v)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v != NULL)
@@ -278,7 +278,7 @@ ADE_VIRTVAR(WorldPosition, l_Subsystem, "vector",
 	if (!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Vector.GetPtr(&v)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	vec3d world_pos;
@@ -294,7 +294,7 @@ ADE_VIRTVAR(GunPosition, l_Subsystem, "vector", "Subsystem gun position with reg
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Vector.GetPtr(&v)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	polymodel *pm = model_get(Ship_info[Ships[sso->objh.objp->instance].ship_info_index].model_num);
@@ -318,7 +318,7 @@ ADE_VIRTVAR(Name, l_Subsystem, "string", "Subsystem name", "string", "Subsystem 
 	if(!ade_get_args(L, "o|s", l_Subsystem.GetPtr(&sso), &s))
 		return ade_set_error(L, "s", "");
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != NULL && strlen(s))
@@ -335,7 +335,7 @@ ADE_VIRTVAR(NumFirePoints, l_Subsystem, "number", "Number of firepoints", "numbe
 	if (!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ade_set_error(L, "i", 0);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "i", 0);
 
 	if (ADE_SETTING_VAR)
@@ -353,7 +353,7 @@ ADE_VIRTVAR(FireRateMultiplier, l_Subsystem, "number", "Factor by which turret's
 	if (!ade_get_args(L, "o|f", l_Subsystem.GetPtr(&sso), &multiplier))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if (ADE_SETTING_VAR)
@@ -374,7 +374,7 @@ ADE_FUNC(getModelName, l_Subsystem, NULL, "Returns the original name of the subs
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ade_set_error(L, "s", "");
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", sso->ss->system_info->subobj_name);
@@ -386,12 +386,12 @@ ADE_VIRTVAR(PrimaryBanks, l_Subsystem, "weaponbanktype", "Array of primary weapo
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Subsystem.GetPtr(&sso2)))
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
 	ship_weapon *dst = &sso->ss->weapons;
 
-	if (ADE_SETTING_VAR && sso2 && sso2->isSubsystemValid()) {
+	if (ADE_SETTING_VAR && sso2 && sso2->isValid()) {
 		ship_weapon *src = &sso2->ss->weapons;
 
 		dst->current_primary_bank = src->current_primary_bank;
@@ -416,12 +416,12 @@ ADE_VIRTVAR(SecondaryBanks, l_Subsystem, "weaponbanktype", "Array of secondary w
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Subsystem.GetPtr(&sso2)))
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
 	ship_weapon *dst = &sso->ss->weapons;
 
-	if (ADE_SETTING_VAR && sso2 && sso2->isSubsystemValid()) {
+	if (ADE_SETTING_VAR && sso2 && sso2->isValid()) {
 		ship_weapon *src = &sso2->ss->weapons;
 
 		dst->current_secondary_bank = src->current_secondary_bank;
@@ -449,7 +449,7 @@ ADE_VIRTVAR(Target, l_Subsystem, "object", "Object targeted by this subsystem. I
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Object.GetPtr(&objh)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	ship_subsys *ss = sso->ss;
@@ -478,7 +478,7 @@ ADE_VIRTVAR(TurretResets, l_Subsystem, "boolean", "Specifies whether this turret
 	if (!ade_get_args(L, "o|b", l_Subsystem.GetPtr(&sso), &newVal))
 		return ADE_RETURN_FALSE;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_FALSE;
 
 	if(ADE_SETTING_VAR)
@@ -499,7 +499,7 @@ ADE_VIRTVAR(TurretResetDelay, l_Subsystem, "number", "The time (in milliseconds)
 	if (!ade_get_args(L, "o|i", l_Subsystem.GetPtr(&sso), &newVal))
 		return ade_set_error(L, "i", -1);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "i", -1);
 
 	if (!(sso->ss->system_info->flags[Model::Subsystem_Flags::Turret_reset_idle]))
@@ -521,7 +521,7 @@ ADE_VIRTVAR(TurnRate, l_Subsystem, "number", "The turn rate", "number", "Turnrat
 	if (!ade_get_args(L, "o|f", l_Subsystem.GetPtr(&sso), &newVal))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	if(ADE_SETTING_VAR)
@@ -539,7 +539,7 @@ ADE_VIRTVAR(Targetable, l_Subsystem, "boolean", "Targetability of this subsystem
 	if (!ade_get_args(L, "o|b", l_Subsystem.GetPtr(&sso), &newVal))
 		return ade_set_error(L, "b", false);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "b", false);
 
 	if(ADE_SETTING_VAR)
@@ -556,7 +556,7 @@ ADE_VIRTVAR(Radius, l_Subsystem, "number", "The radius of this subsystem", "numb
 	if (!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR)
@@ -574,7 +574,7 @@ ADE_VIRTVAR(TurretLocked, l_Subsystem, "boolean", "Whether the turret is locked.
 	if (!ade_get_args(L, "o|b", l_Subsystem.GetPtr(&sso), &newVal))
 		return ade_set_error(L, "b", false);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "b", false);
 
 	if(ADE_SETTING_VAR)
@@ -592,7 +592,7 @@ ADE_VIRTVAR(TurretLockedWithTimestamp, l_Subsystem, "boolean", "Behaves like Tur
 	if (!ade_get_args(L, "o|b", l_Subsystem.GetPtr(&sso), &newVal))
 		return ade_set_error(L, "b", false);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "b", false);
 
 	if(ADE_SETTING_VAR)
@@ -610,7 +610,7 @@ ADE_VIRTVAR(BeamFree, l_Subsystem, "boolean", "Whether the turret is beam-freed.
 	if (!ade_get_args(L, "o|b", l_Subsystem.GetPtr(&sso), &newVal))
 		return ade_set_error(L, "b", false);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "b", false);
 
 	if(ADE_SETTING_VAR)
@@ -628,7 +628,7 @@ ADE_VIRTVAR(BeamFreeWithTimestamp, l_Subsystem, "boolean", "Behaves like BeamFre
 	if (!ade_get_args(L, "o|b", l_Subsystem.GetPtr(&sso), &newVal))
 		return ade_set_error(L, "b", false);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "b", false);
 
 	if(ADE_SETTING_VAR)
@@ -646,7 +646,7 @@ ADE_VIRTVAR(NextFireTimestamp, l_Subsystem, "number", "The next time the turret 
 	if (!ade_get_args(L, "o|f", l_Subsystem.GetPtr(&sso), &newVal))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	if(ADE_SETTING_VAR)
@@ -664,7 +664,7 @@ ADE_VIRTVAR(ModelPath, l_Subsystem, "modelpath", "The model path points belongin
 	if (!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ade_set_error(L, "o", l_ModelPath.Set(model_path_h()));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_ModelPath.Set(model_path_h()));
 
 	if (ADE_SETTING_VAR) {
@@ -691,7 +691,7 @@ ADE_FUNC(targetingOverride, l_Subsystem, "boolean", "If set to true, AI targetin
 	if(!ade_get_args(L, "ob", l_Subsystem.GetPtr(&sso), &targetOverride))
 		return ADE_RETURN_FALSE;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_FALSE;
 
 	ship_subsys *ss = sso->ss;
@@ -714,7 +714,7 @@ ADE_FUNC(getModelFlag,
 		return ADE_RETURN_NIL;
 	int skip_args = 1;	// not 2 because there will be one more below
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	do {
@@ -749,7 +749,7 @@ ADE_FUNC(hasFired, l_Subsystem, NULL, "Determine if a subsystem has fired", "boo
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	if(sso->ss->flags[Ship::Subsystem_Flags::Has_fired]){
@@ -766,7 +766,7 @@ ADE_FUNC(isTurret, l_Subsystem, NULL, "Determines if this subsystem is a turret"
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "b", sso->ss->system_info->type == SUBSYSTEM_TURRET);
@@ -778,7 +778,7 @@ ADE_FUNC(isMultipartTurret, l_Subsystem, NULL, "Determines if this subsystem is 
 	if (!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	return ade_set_args(L, "b", sso->ss->system_info->type == SUBSYSTEM_TURRET && sso->ss->system_info->turret_gun_sobj != sso->ss->system_info->subobj_num);
@@ -791,7 +791,7 @@ ADE_FUNC(isTargetInFOV, l_Subsystem, "object Target", "Determines if the object 
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Object.GetPtr(&newh)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid() || !newh || !newh->isValid() || !(sso->ss->system_info->type == SUBSYSTEM_TURRET))
+	if (!sso->isValid() || !newh || !newh->isValid() || !(sso->ss->system_info->type == SUBSYSTEM_TURRET))
 		return ADE_RETURN_NIL;
 
 	vec3d	tpos,tvec;
@@ -812,7 +812,7 @@ ADE_FUNC(isPositionInFOV, l_Subsystem, "vector Target", "Determines if a positio
 	if (!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Vector.Get(&target)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid() || !(sso->ss->system_info->type == SUBSYSTEM_TURRET))
+	if (!sso->isValid() || !(sso->ss->system_info->type == SUBSYSTEM_TURRET))
 		return ADE_RETURN_NIL;
 
 	vec3d tpos, tvec;
@@ -837,7 +837,7 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRan
 	if (!ade_get_args(L, "o|ifo", l_Subsystem.GetPtr(&sso), &wnum, &flak_range, l_Vector.GetPtr(&override_gvec)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	// no place to fire a weapon; this may not actually be a turret
@@ -881,7 +881,7 @@ ADE_FUNC(rotateTurret, l_Subsystem, "vector Pos, boolean reset=false", "Rotates 
 	if (!ade_get_args(L, "oo|b", l_Subsystem.GetPtr(&sso), l_Vector.Get(&pos), &reset))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	if (sso->ss->submodel_instance_1 == nullptr || sso->ss->submodel_instance_2 == nullptr)
@@ -907,7 +907,7 @@ ADE_FUNC(getTurretHeading, l_Subsystem, NULL, "Returns the turrets forward vecto
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	vec3d gvec;
@@ -932,7 +932,7 @@ ADE_FUNC(getFOVs, l_Subsystem, nullptr, "Returns current turrets FOVs", "number,
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	model_subsystem *tp = sso->ss->system_info;
@@ -953,7 +953,7 @@ ADE_FUNC(
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ade_set_error(L, "oo", l_Vector.Set(vmd_zero_vector), l_Vector.Set(vmd_zero_vector));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "oo", l_Vector.Set(vmd_zero_vector), l_Vector.Set(vmd_zero_vector));
 
 	vec3d gpos, gvec;
@@ -970,7 +970,7 @@ ADE_FUNC(getTurretMatrix, l_Subsystem, nullptr, "Returns current subsystems turr
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ADE_RETURN_NIL;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_NIL;
 
 	model_subsystem *tp = sso->ss->system_info;
@@ -988,7 +988,7 @@ ADE_FUNC(getParent, l_Subsystem, NULL, "The object parent of this subsystem, is 
 	if(!ade_get_args(L, "o|o", l_Subsystem.GetPtr(&sso), l_Ship.GetPtr(&objhp)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	return ade_set_object_with_breed(L, OBJ_INDEX(sso->objh.objp));
@@ -1004,7 +1004,7 @@ ADE_FUNC(isInViewFrom, l_Subsystem, "vector from",
 	if(!ade_get_args(L, "oo", l_Subsystem.GetPtr(&sso), l_Vector.GetPtr(&from)))
 		return ADE_RETURN_FALSE;
 
-	if (!sso->isSubsystemValid())
+	if (!sso->isValid())
 		return ADE_RETURN_FALSE;
 
 	vec3d world_pos;
@@ -1022,7 +1022,7 @@ ADE_FUNC(isValid, l_Subsystem, NULL, "Detects whether handle is valid", "boolean
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "b", sso->isSubsystemValid());
+	return ade_set_args(L, "b", sso->isValid());
 }
 
 }

--- a/code/scripting/api/objs/subsystem.h
+++ b/code/scripting/api/objs/subsystem.h
@@ -16,7 +16,7 @@ struct ship_subsys_h
 	ship_subsys_h();
 	ship_subsys_h(object *objp_in, ship_subsys *sub);
 
-	bool isSubsystemValid() const;
+	bool isValid() const;
 
 	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
 	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);

--- a/code/scripting/api/objs/subsystem.h
+++ b/code/scripting/api/objs/subsystem.h
@@ -8,9 +8,11 @@ namespace scripting {
 namespace api {
 
 
-struct ship_subsys_h : public object_h
+struct ship_subsys_h
 {
+	object_h objh;
 	ship_subsys *ss;	//Pointer to subsystem, or NULL for the hull
+
 	ship_subsys_h();
 	ship_subsys_h(object *objp_in, ship_subsys *sub);
 

--- a/code/scripting/api/objs/techroom.cpp
+++ b/code/scripting/api/objs/techroom.cpp
@@ -6,7 +6,7 @@ namespace api {
 sim_mission_h::sim_mission_h() : missionIdx(-1), isCMission(false) {}
 sim_mission_h::sim_mission_h(int index, bool cmission) : missionIdx(index), isCMission(cmission) {}
 
-bool sim_mission_h::IsValid() const
+bool sim_mission_h::isValid() const
 {
 	return missionIdx >= 0;
 }
@@ -22,7 +22,7 @@ sim_mission* sim_mission_h::getStage() const
 cutscene_info_h::cutscene_info_h() : cutscene(-1) {}
 cutscene_info_h::cutscene_info_h(int scene) : cutscene(scene) {}
 
-bool cutscene_info_h::IsValid() const
+bool cutscene_info_h::isValid() const
 {
 	return SCP_vector_inbounds(Cutscenes, cutscene);
 }
@@ -228,7 +228,7 @@ ADE_FUNC(isValid, l_TechRoomCutscene, NULL, "Detects whether cutscene is valid",
 		return ADE_RETURN_NIL;
 	}
 
-	return ade_set_args(L, "b", current.IsValid());
+	return ade_set_args(L, "b", current.isValid());
 }
 
 } // namespace api

--- a/code/scripting/api/objs/techroom.h
+++ b/code/scripting/api/objs/techroom.h
@@ -12,7 +12,7 @@ struct sim_mission_h {
 	bool isCMission;
 	sim_mission_h();
 	explicit sim_mission_h(int index, bool cmission);
-	bool IsValid() const;
+	bool isValid() const;
 	sim_mission* getStage() const;
 };
 
@@ -20,7 +20,7 @@ struct cutscene_info_h {
 	int cutscene;
 	cutscene_info_h();
 	explicit cutscene_info_h(int scene);
-	bool IsValid() const;
+	bool isValid() const;
 	cutscene_info* getScene() const;
 };
 

--- a/code/scripting/api/objs/texturemap.cpp
+++ b/code/scripting/api/objs/texturemap.cpp
@@ -27,13 +27,13 @@ texture_map_h::texture_map_h(polymodel* n_model, texture_map* n_tmap) {
 	tmap = n_tmap;
 }
 texture_map* texture_map_h::Get() {
-	if(!this->IsValid())
+	if(!this->isValid())
 		return NULL;
 
 	return tmap;
 }
 int texture_map_h::GetSize() {
-	if(!this->IsValid())
+	if(!this->isValid())
 		return 0;
 
 	switch(type)
@@ -46,7 +46,7 @@ int texture_map_h::GetSize() {
 			return 0;
 	}
 }
-bool texture_map_h::IsValid() {
+bool texture_map_h::isValid() const {
 	if(tmap == NULL)
 		return false;
 
@@ -55,9 +55,9 @@ bool texture_map_h::IsValid() {
 		case THT_INDEPENDENT:
 			return true;
 		case THT_OBJECT:
-			return obj.IsValid();
+			return obj.isValid();
 		case THT_MODEL:
-			return mdl.IsValid();
+			return mdl.isValid();
 		default:
 			Error(LOCATION, "Bad type in texture_map_h; debug this.");
 			return false;

--- a/code/scripting/api/objs/texturemap.h
+++ b/code/scripting/api/objs/texturemap.h
@@ -36,7 +36,7 @@ class texture_map_h
 
 	int GetSize();
 
-	bool IsValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_TextureMap, texture_map_h);

--- a/code/scripting/api/objs/waypoint.cpp
+++ b/code/scripting/api/objs/waypoint.cpp
@@ -18,13 +18,13 @@ ADE_FUNC(getList, l_Waypoint, NULL, "Returns the waypoint list", "waypointlist",
 	if(!ade_get_args(L, "o", l_Waypoint.GetPtr(&oh)))
 		return ade_set_error(L, "o", l_WaypointList.Set(waypointlist_h()));
 
-	if(oh->IsValid() && oh->objp->type == OBJ_WAYPOINT) {
+	if(oh->isValid() && oh->objp->type == OBJ_WAYPOINT) {
 		wp_list = find_waypoint_list_with_instance(oh->objp->instance);
 		if(wp_list != NULL)
 			wpl = waypointlist_h(wp_list);
 	}
 
-	if (wpl.IsValid()) {
+	if (wpl.isValid()) {
 		return ade_set_args(L, "o", l_WaypointList.Set(wpl));
 	}
 
@@ -48,7 +48,7 @@ waypointlist_h::waypointlist_h(const char* wlname)
 		wlp = find_matching_waypoint_list(wlname);
 	}
 }
-bool waypointlist_h::IsValid() {
+bool waypointlist_h::isValid() const {
 	return (wlp != NULL && !strcmp(wlp->get_name(), name));
 }
 
@@ -63,7 +63,7 @@ ADE_INDEXER(l_WaypointList, "number Index", "Array of waypoints that are part of
 	if( !ade_get_args(L, "oi", l_WaypointList.GetPtr( &wlh ), &idx))
 		return ade_set_error( L, "o", l_Waypoint.Set( object_h() ) );
 
-	if(!wlh->IsValid())
+	if(!wlh->isValid())
 		return ade_set_error( L, "o", l_Waypoint.Set( object_h() ) );
 
 	//Lua-->FS2
@@ -115,7 +115,7 @@ ADE_FUNC(isValid, l_WaypointList, NULL, "Return if this waypointlist handle is v
 	if ( !ade_get_args(L, "o", l_WaypointList.GetPtr(&wlh)) ) {
 		return ADE_RETURN_FALSE;
 	}
-	return ade_set_args(L, "b", wlh != NULL && wlh->IsValid());
+	return ade_set_args(L, "b", wlh != NULL && wlh->isValid());
 }
 
 }

--- a/code/scripting/api/objs/waypoint.h
+++ b/code/scripting/api/objs/waypoint.h
@@ -17,7 +17,7 @@ struct waypointlist_h
 	waypointlist_h();
 	explicit waypointlist_h(waypoint_list *n_wlp);
 	explicit waypointlist_h(const char* wlname);
-	bool IsValid();
+	bool isValid() const;
 };
 
 DECLARE_ADE_OBJ(l_WaypointList, waypointlist_h);

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -148,7 +148,7 @@ ADE_VIRTVAR(ParentTurret, l_Weapon, "subsystem", "Turret which fired this weapon
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->isSubsystemValid())
+		if(newh && newh->isValid())
 		{
 			if(wp->turret_subsys != newh->ss)
 			{
@@ -259,7 +259,7 @@ ADE_VIRTVAR(HomingSubsystem, l_Weapon, "subsystem", "Subsystem that weapon will 
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->isSubsystemValid())
+		if(newh && newh->isValid())
 		{
 			if(wp->target_sig != newh->objh.sig)
 			{

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -24,7 +24,7 @@ ADE_VIRTVAR(Class, l_Weapon, "weaponclass", "Weapon's class", "weaponclass", "We
 	if(!ade_get_args(L, "o|o", l_Weapon.GetPtr(&oh), l_Weaponclass.Get(&nc)))
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
 	weapon *wp = &Weapons[oh->objp->instance];
@@ -46,7 +46,7 @@ ADE_VIRTVAR(DestroyedByWeapon, l_Weapon, "boolean", "Whether weapon was destroye
 	if(!numargs)
 		return ade_set_error(L, "b", false);
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "b", false);
 
 	weapon *wp = &Weapons[oh->objp->instance];
@@ -65,7 +65,7 @@ ADE_VIRTVAR(LifeLeft, l_Weapon, "number", "Weapon life left (in seconds)", "numb
 	if(!ade_get_args(L, "o|f", l_Weapon.GetPtr(&oh), &nll))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	weapon *wp = &Weapons[oh->objp->instance];
@@ -84,7 +84,7 @@ ADE_VIRTVAR(FlakDetonationRange, l_Weapon, "number", "Range at which flak will d
 	if(!ade_get_args(L, "o|f", l_Weapon.GetPtr(&oh), &rng))
 		return ade_set_error(L, "f", 0.0f);
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	weapon *wp = &Weapons[oh->objp->instance];
@@ -103,7 +103,7 @@ ADE_VIRTVAR(Target, l_Weapon, "object", "Target of weapon. Value may also be a d
 	if(!ade_get_args(L, "o|o", l_Weapon.GetPtr(&objh), l_Object.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	weapon *wp = NULL;
@@ -114,7 +114,7 @@ ADE_VIRTVAR(Target, l_Weapon, "object", "Target of weapon. Value may also be a d
 
 	if(ADE_SETTING_VAR)
 	{
-		if(newh && newh->IsValid())
+		if(newh && newh->isValid())
 		{
 			if(wp->target_sig != newh->sig || !weapon_has_homing_object(wp))
 			{
@@ -137,7 +137,7 @@ ADE_VIRTVAR(ParentTurret, l_Weapon, "subsystem", "Turret which fired this weapon
 	if(!ade_get_args(L, "o|o", l_Weapon.GetPtr(&objh), l_Subsystem.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	weapon *wp = NULL;
@@ -174,7 +174,7 @@ ADE_VIRTVAR(HomingObject, l_Weapon, "object", "Object that weapon will home in o
 	if(!ade_get_args(L, "o|o", l_Weapon.GetPtr(&objh), l_Object.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	weapon *wp = NULL;
@@ -185,7 +185,7 @@ ADE_VIRTVAR(HomingObject, l_Weapon, "object", "Object that weapon will home in o
 
 	if(ADE_SETTING_VAR)
 	{
-		if (newh && newh->IsValid())
+		if (newh && newh->isValid())
 		{
 			if (wp->target_sig != newh->sig)
 			{
@@ -212,7 +212,7 @@ ADE_VIRTVAR(HomingPosition, l_Weapon, "vector", "Position that weapon will home 
 	if(!ade_get_args(L, "o|o", l_Weapon.GetPtr(&objh), l_Vector.GetPtr(&v3)))
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	weapon *wp = NULL;
@@ -248,7 +248,7 @@ ADE_VIRTVAR(HomingSubsystem, l_Weapon, "subsystem", "Subsystem that weapon will 
 	if(!ade_get_args(L, "o|o", l_Weapon.GetPtr(&objh), l_Subsystem.GetPtr(&newh)))
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	if(!objh->IsValid())
+	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	weapon *wp = NULL;
@@ -292,7 +292,7 @@ ADE_VIRTVAR(Team, l_Weapon, "team", "Weapon's team", "team", "Weapon team, or in
 	if(!ade_get_args(L, "o|o", l_Weapon.GetPtr(&oh), l_Team.Get(&nt)))
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
 	weapon *wp = &Weapons[oh->objp->instance];
@@ -314,7 +314,7 @@ ADE_VIRTVAR(OverrideHoming, l_Weapon, "boolean",
 	if (!ade_get_args(L, "o|b", l_Weapon.GetPtr(&oh), &new_val))
 		return ade_set_error(L, "b", false);
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ade_set_error(L, "b", false);
 
 	weapon* wp = &Weapons[oh->objp->instance];
@@ -333,7 +333,7 @@ ADE_FUNC(isArmed, l_Weapon, "[boolean HitTarget]", "Checks if the weapon is arme
 	if(!ade_get_args(L, "o|b", l_Weapon.GetPtr(&oh), &hit_target))
 		return ADE_RETURN_FALSE;
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ADE_RETURN_FALSE;
 
 	weapon *wp = &Weapons[oh->objp->instance];
@@ -351,7 +351,7 @@ ADE_FUNC(getCollisionInformation, l_Weapon, nullptr, "Returns the collision info
 	if(!ade_get_args(L, "o", l_Weapon.GetPtr(&oh)))
 		return ADE_RETURN_NIL;
 
-	if(!oh->IsValid())
+	if(!oh->isValid())
 		return ADE_RETURN_NIL;
 
 	weapon *wp = &Weapons[oh->objp->instance];
@@ -380,7 +380,7 @@ ADE_FUNC(triggerSubmodelAnimation, l_Weapon, "string type, string triggeredBy, [
 	if (!ade_get_args(L, "oss|bbbb", l_Weapon.GetPtr(&objh), &type, &trigger, &forwards, &forced, &instant, &pause))
 		return ADE_RETURN_NIL;
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
 	weapon* wp = &Weapons[objh->objp->instance];
@@ -403,7 +403,7 @@ ADE_FUNC(getSubmodelAnimationTime, l_Weapon, "string type, string triggeredBy", 
 	if (!ade_get_args(L, "oss", l_Weapon.GetPtr(&objh), &type, &trigger))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!objh->IsValid())
+	if (!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	auto animtype = animation::anim_match_type(type);
@@ -428,7 +428,7 @@ ADE_FUNC(vanish, l_Weapon, nullptr, "Vanishes this weapon from the mission.", "b
 	if (!ade_get_args(L, "o", l_Weapon.GetPtr(&oh)))
 		return ade_set_error(L, "b", false);
 
-	if (!oh->IsValid())
+	if (!oh->isValid())
 		return ade_set_error(L, "b", false);
 
 	oh->objp->flags.set(Object::Object_Flags::Should_be_dead);

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -261,9 +261,9 @@ ADE_VIRTVAR(HomingSubsystem, l_Weapon, "subsystem", "Subsystem that weapon will 
 	{
 		if(newh && newh->isSubsystemValid())
 		{
-			if(wp->target_sig != newh->sig)
+			if(wp->target_sig != newh->objh.sig)
 			{
-				weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, OBJ_INDEX(newh->objp), 1, newh->ss);
+				weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, OBJ_INDEX(newh->objh.objp), 1, newh->ss);
 			}
 			else
 			{

--- a/code/scripting/api/objs/wing.cpp
+++ b/code/scripting/api/objs/wing.cpp
@@ -31,7 +31,7 @@ ADE_INDEXER(l_Wing, "number Index", "Array of ships in the wing", "ship", "Ship 
 	//Lua-->FS2
 	sdx--;
 
-	if(ADE_SETTING_VAR && ndx != NULL && ndx->IsValid()) {
+	if(ADE_SETTING_VAR && ndx != NULL && ndx->isValid()) {
 		Wings[wdx].ship_index[sdx] = ndx->objp->instance;
 	}
 


### PR DESCRIPTION
Refactor the scripting code in several ways to prepare for #6006:

1. Standardize on `isValid()` versus other capitalization
2. Make validity member functions `const`.
3. Prevent `object_h` from being subclassed; change the other handles that use it to do so via member variables
4. Change `isSubsystemValid` to `isValid`