### PR TITLE
Split up debris and asteroid types

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -602,7 +602,7 @@ void asteroid_create_all()
 
 	int num_debris_types = 0;
 
-	// get number of ship debris types
+	// get number of debris types
 	if (Asteroid_field.debris_genre == DG_DEBRIS) {
 		for (idx=0; idx<MAX_ACTIVE_DEBRIS_TYPES; idx++) {
 			if (Asteroid_field.field_debris_type[idx] != -1) {
@@ -619,25 +619,25 @@ void asteroid_create_all()
 		}
 	}
 
-	// Load Asteroid/ship models
+	// Load Asteroid/debris models
 	if (Asteroid_field.debris_genre == DG_DEBRIS) {
 		for (idx=0; idx<num_debris_types; idx++) {
 			asteroid_load(Asteroid_field.field_debris_type[idx], 0);
 		}
 	} else {
-		if (Asteroid_field.field_debris_type[0] != -1) {
+		if (Asteroid_field.field_asteroid_type[0]) {
 			asteroid_load(ASTEROID_TYPE_SMALL, 0);
 			asteroid_load(ASTEROID_TYPE_MEDIUM, 0);
 			asteroid_load(ASTEROID_TYPE_LARGE, 0);
 		}
 
-		if (Asteroid_field.field_debris_type[1] != -1) {
+		if (Asteroid_field.field_asteroid_type[1]) {
 			asteroid_load(ASTEROID_TYPE_SMALL, 1);
 			asteroid_load(ASTEROID_TYPE_MEDIUM, 1);
 			asteroid_load(ASTEROID_TYPE_LARGE, 1);
 		}
 
-		if (Asteroid_field.field_debris_type[2] != -1) {
+		if (Asteroid_field.field_asteroid_type[2]) {
 			asteroid_load(ASTEROID_TYPE_SMALL, 2);
 			asteroid_load(ASTEROID_TYPE_MEDIUM, 2);
 			asteroid_load(ASTEROID_TYPE_LARGE, 2);
@@ -653,7 +653,7 @@ void asteroid_create_all()
 			int counter = Random::next(Asteroid_field.num_used_field_debris_types);
 			int subtype = -1;
 			for (int j = 0; j < NUM_ASTEROID_POFS; j++) {
-				if (Asteroid_field.field_debris_type[j] >= 0) {
+				if (Asteroid_field.field_asteroid_type[j]) {
 					if (counter == 0) {
 						subtype = j;
 						break;
@@ -732,21 +732,25 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 	Asteroid_field.speed = (float)asteroid_speed;
 	Asteroid_field.debris_genre = DG_ASTEROID;
 
-	Asteroid_field.field_debris_type[0] = -1;
-	Asteroid_field.field_debris_type[1] = -1;
-	Asteroid_field.field_debris_type[2] = -1;
+	for (int j = 0; j < MAX_ACTIVE_DEBRIS_TYPES; j++) {
+			Asteroid_field.field_debris_type[j] = -1;
+	}
+
+	for (int j = 0; j < NUM_ASTEROID_SIZES; j++) {
+			Asteroid_field.field_asteroid_type[j] = false;
+	}
 
 	int count = 0;
 	if (brown) {
-		Asteroid_field.field_debris_type[0] = 1;
+		Asteroid_field.field_asteroid_type[0] = true;
 		count++;
 	}
 	if (blue) {
-		Asteroid_field.field_debris_type[1] = 1;
+		Asteroid_field.field_asteroid_type[1] = true;
 		count++;
 	}
 	if (orange) {
-		Asteroid_field.field_debris_type[2] = 1;
+		Asteroid_field.field_asteroid_type[2] = true;
 		count++;
 	}
 
@@ -792,9 +796,13 @@ void asteroid_create_debris_field(int num_asteroids, int asteroid_speed, int deb
 	Asteroid_field.speed = (float)asteroid_speed;
 	Asteroid_field.debris_genre = DG_DEBRIS;
 
-	Asteroid_field.field_debris_type[0] = -1;
-	Asteroid_field.field_debris_type[1] = -1;
-	Asteroid_field.field_debris_type[2] = -1;
+	for (int j = 0; j < MAX_ACTIVE_DEBRIS_TYPES; j++) {
+		Asteroid_field.field_debris_type[j] = -1;
+	}
+
+	for (int j = 0; j < NUM_ASTEROID_SIZES; j++) {
+		Asteroid_field.field_asteroid_type[j] = false;
+	}
 
 	int count = 0;
 	for (int i = 0; i < MAX_ACTIVE_DEBRIS_TYPES; i++) {
@@ -850,9 +858,13 @@ void asteroid_level_init()
 	Asteroid_field.has_inner_bound = false;
 	Asteroid_field.field_type = FT_ACTIVE;
 	Asteroid_field.debris_genre = DG_ASTEROID;
-	Asteroid_field.field_debris_type[0] = -1;
-	Asteroid_field.field_debris_type[1] = -1;
-	Asteroid_field.field_debris_type[2] = -1;
+	for (int j = 0; j < MAX_ACTIVE_DEBRIS_TYPES; j++) {
+		Asteroid_field.field_debris_type[j] = -1;
+	}
+
+	for (int j = 0; j < NUM_ASTEROID_SIZES; j++) {
+		Asteroid_field.field_asteroid_type[j] = false;
+	}
 	Asteroid_field.num_used_field_debris_types = 0;
 	Asteroid_field.target_names.clear();
 
@@ -1070,7 +1082,7 @@ static void maybe_throw_asteroid()
 		int counter = Random::next(Asteroid_field.num_used_field_debris_types);
 		int subtype = -1;
 		for (int i = 0; i < NUM_ASTEROID_POFS; i++) {
-			if (Asteroid_field.field_debris_type[i] >= 0) {
+			if (Asteroid_field.field_asteroid_type[i]) {
 				if (counter == 0) {
 					subtype = i;
 					break;
@@ -2712,7 +2724,7 @@ void asteroid_page_in()
 				Assertion(i < NUM_ASTEROID_SIZES, "Got invalid call to load a debris type instead of asteroid type!");
 				asip = &Asteroid_info[i];
 			} else {
-				// ship debris - always full until empty
+				// debris - always full until empty
 				if (Asteroid_field.field_debris_type[i] != -1) {
 					asip = &Asteroid_info[Asteroid_field.field_debris_type[i]];
 				} else {
@@ -2723,14 +2735,14 @@ void asteroid_page_in()
 
 			for (k=0; k<NUM_ASTEROID_POFS; k++) {
 
-				// SHIP DEBRIS - use subtype 0
+				// DEBRIS FIELDS - always use subtype 0
 				if (Asteroid_field.debris_genre == DG_DEBRIS) {
 					if (k > 0) {
 						break;
 					}
 				} else {
-					// ASTEROID DEBRIS - use subtype (Asteroid_field.field_debris_type[] != -1)
-					if (Asteroid_field.field_debris_type[k] == -1) {
+					// ASTEROID FIELDS - use subtype k, if active
+					if (!Asteroid_field.field_asteroid_type[k]) {
 						continue;
 					}
 				}

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -144,6 +144,7 @@ typedef	struct asteroid_field {
 	field_type_t		field_type;		// active throws and wraps, passive does not
 	debris_genre_t	debris_genre;		// type of debris (ship or asteroid)  [generic type]
 	int				field_debris_type[MAX_ACTIVE_DEBRIS_TYPES];	// one of the debris type defines above
+	bool            field_asteroid_type[NUM_ASTEROID_SIZES];
 	int				num_used_field_debris_types;	// how many of the above are used
 	bool            enhanced_visibility_checks;     // if true then range checks are overridden for spawning and wrapping asteroids in the field
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5830,9 +5830,13 @@ void parse_asteroid_fields(mission *pm)
 			Asteroid_field.debris_genre = (debris_genre_t)type;
 		}
 
-		Asteroid_field.field_debris_type[0] = -1;
-		Asteroid_field.field_debris_type[1] = -1;
-		Asteroid_field.field_debris_type[2] = -1;
+		for (int j = 0; j < MAX_ACTIVE_DEBRIS_TYPES; j++) {
+			Asteroid_field.field_debris_type[j] = -1;
+		}
+
+		for (int j = 0; j < NUM_ASTEROID_SIZES; j++) {
+			Asteroid_field.field_asteroid_type[j] = false;
+		}
 
 		// Debris types
 		if (Asteroid_field.debris_genre == DG_DEBRIS) {
@@ -5865,24 +5869,24 @@ void parse_asteroid_fields(mission *pm)
 		} else {
 
 			// Obsolete and only for backwards compatibility
-			for (int j = 0; j < MAX_ACTIVE_DEBRIS_TYPES; j++) {
+			for (int j = 0; j < NUM_ASTEROID_SIZES; j++) {
 				if (optional_string("+Field Debris Type:")) {
 					int subtype;
 					stuff_int(&subtype);
-					Asteroid_field.field_debris_type[subtype] = 1;
+					Asteroid_field.field_asteroid_type[subtype] = true;
 					count++;
 				}
 			}
 
 			// Get asteroids by name
-			for (int j = 0; j < MAX_ACTIVE_DEBRIS_TYPES; j++) {
+			for (int j = 0; j < NUM_ASTEROID_SIZES; j++) {
 				if (optional_string("+Field Debris Type Name:")) {
 					SCP_string ast_name;
 					stuff_string(ast_name, F_NAME);
 					int subtype = get_asteroid_index(ast_name.c_str());
 					// If the returned index is valid but not one of the first three then it's a debris type instead of asteroid
 					if ((subtype >= 0) && (subtype < NUM_ASTEROID_SIZES)) {
-						Asteroid_field.field_debris_type[subtype] = 1;
+						Asteroid_field.field_asteroid_type[subtype] = true;
 						count++;
 					} else {
 						WarningEx(LOCATION, "Mission %s\n Invalid asteroid %s!", pm->name, ast_name.c_str());
@@ -5906,7 +5910,7 @@ void parse_asteroid_fields(mission *pm)
 
 		// backward compatibility
 		if ( (Asteroid_field.debris_genre == DG_ASTEROID) && (Asteroid_field.num_used_field_debris_types == 0) ) {
-			Asteroid_field.field_debris_type[0] = 0;
+			Asteroid_field.field_asteroid_type[0] = true;
 			Asteroid_field.num_used_field_debris_types = 1;
 		}
 

--- a/fred2/asteroideditordlg.cpp
+++ b/fred2/asteroideditordlg.cpp
@@ -279,7 +279,7 @@ int asteroid_editor::validate_data()
 			}
 		}
 
-		// check if passive, ship debris field, at least one speceis selected
+		// check if passive, ship debris field, at least one debris type selected
 		if (a_field[0].field_type == FT_PASSIVE) {
 			if (a_field[0].debris_genre == DG_DEBRIS) {
 				if ( (a_field[0].field_debris_type[0] == -1) && (a_field[0].field_debris_type[1] == -1) && (a_field[0].field_debris_type[2] == -1) ) {
@@ -291,7 +291,7 @@ int asteroid_editor::validate_data()
 
 		// check at least one asteroid subtype is selected
 		if (a_field[0].debris_genre == DG_ASTEROID) {
-			if ( (a_field[0].field_debris_type[0] == -1) && (a_field[0].field_debris_type[1] == -1) && (a_field[0].field_debris_type[2] == -1) ) {
+			if ( (!a_field[0].field_asteroid_type[0]) && (!a_field[0].field_asteroid_type[1]) && (!a_field[0].field_asteroid_type[2]) ) {
 				MessageBox("You must choose one or more asteroid subtypes");
 				return 0;
 			}
@@ -335,7 +335,7 @@ BOOL asteroid_editor::OnInitDialog()
 
 void asteroid_editor::update_init()
 {
-	int num_asteroids, idx, cur_choice;
+	int num_asteroids, idx;
 	CString str;
 
 	UpdateData(TRUE);
@@ -374,6 +374,7 @@ void asteroid_editor::update_init()
 			for (idx=0; idx<MAX_ACTIVE_DEBRIS_TYPES; idx++) {
 				// loop over combo boxes, store the item data of the cur selection, -1 in no cur selection
 				int cur_sel = ((CComboBox*)GetDlgItem(Dlg_id[idx]))->GetCurSel();
+				int cur_choice;
 				if (cur_sel != CB_ERR) {
 					cur_choice = (int)((CComboBox*)GetDlgItem(Dlg_id[idx]))->GetItemData(cur_sel);
 				} else {
@@ -384,28 +385,29 @@ void asteroid_editor::update_init()
 		}
 
 		if ( m_debris_genre == DG_ASTEROID ) {
+			bool cur_choice;
 			if ( ((CButton *)GetDlgItem(IDC_SUBTYPE1))->GetCheck() == 1) {
-				cur_choice = 1;
+				cur_choice = true;
 			} else {
-				cur_choice = -1;
+				cur_choice = false;
 			}
-			MODIFY(a_field[cur_field].field_debris_type[0], cur_choice);
+			MODIFY(a_field[cur_field].field_asteroid_type[0], cur_choice);
 
 
 			if ( ((CButton *)GetDlgItem(IDC_SUBTYPE2))->GetCheck() == 1) {
-				cur_choice = 1;
+				cur_choice = true;
 			} else {
-				cur_choice = -1;
+				cur_choice = false;
 			}
-			MODIFY(a_field[cur_field].field_debris_type[1], cur_choice);
+			MODIFY(a_field[cur_field].field_asteroid_type[1], cur_choice);
 
 
 			if ( ((CButton *)GetDlgItem(IDC_SUBTYPE3))->GetCheck() == 1) {
-				cur_choice = 1;
+				cur_choice = true;
 			} else {
-				cur_choice = -1;
+				cur_choice = false;
 			}
-			MODIFY(a_field[cur_field].field_debris_type[2], cur_choice);
+			MODIFY(a_field[cur_field].field_asteroid_type[2], cur_choice);
 		}
 
 		MODIFY(a_field[last_field].has_inner_bound, (bool)m_enable_inner_bounds);
@@ -499,9 +501,9 @@ void asteroid_editor::update_init()
 	}
 
 	// set up asteroid subtype checkboxes
-	((CButton*)GetDlgItem(IDC_SUBTYPE1))->SetCheck(a_field[cur_field].field_debris_type[0] == 1);
-	((CButton*)GetDlgItem(IDC_SUBTYPE2))->SetCheck(a_field[cur_field].field_debris_type[1] == 1);
-	((CButton*)GetDlgItem(IDC_SUBTYPE3))->SetCheck(a_field[cur_field].field_debris_type[2] == 1);
+	((CButton*)GetDlgItem(IDC_SUBTYPE1))->SetCheck(a_field[cur_field].field_asteroid_type[0]);
+	((CButton*)GetDlgItem(IDC_SUBTYPE2))->SetCheck(a_field[cur_field].field_asteroid_type[1]);
+	((CButton*)GetDlgItem(IDC_SUBTYPE3))->SetCheck(a_field[cur_field].field_asteroid_type[2]);
 
 	UpdateData(FALSE);
 	OnEnableAsteroids();

--- a/fred2/dumpstats.cpp
+++ b/fred2/dumpstats.cpp
@@ -242,12 +242,9 @@ void DumpStats::get_background_stats(CString &buffer)
 				temp.Format("\tShip Debris\r\n");
 				buffer += temp;
 
-				// species
-				temp.Format("\t\tSpecies: ");
-				for (size_t i=0; i<Species_info.size(); i++) {
-					if (Asteroid_field.field_debris_type[i] >= 0) {
-						temp += CString(Species_info[(Asteroid_field.field_debris_type[i] / NUM_ASTEROID_SIZES) - 1].species_name) + " ";
-					}
+				temp.Format("\t\tTypes: ");
+				for (size_t j = 0; j < MAX_ACTIVE_DEBRIS_TYPES; j++) {
+					temp += CString(Asteroid_info[Asteroid_field.field_debris_type[j]].name) + ", ";
 				}
 
 				temp += "\r\n";

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -784,8 +784,8 @@ int CFred_mission_save::save_asteroid_fields()
 			}
 		} else {
 			// asteroid subtypes stored in field_debris_type as -1 or 1
-			for (int idx = 0; idx < MAX_ACTIVE_DEBRIS_TYPES; idx++) {
-				if (Asteroid_field.field_debris_type[idx] != -1) {
+			for (int idx = 0; idx < NUM_ASTEROID_SIZES; idx++) {
+				if (Asteroid_field.field_asteroid_type[idx] != false) {
 
 					if (Mission_save_format == FSO_FORMAT_RETAIL) {
 						if (optional_string_fred("+Field Debris Type:")) {

--- a/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
@@ -335,9 +335,9 @@ bool AsteroidEditorDialogModel::validate_data()
 
 		// check at least one asteroid subtype is selected
 		if (_a_field.debris_genre == DG_ASTEROID) {
-			if ( (_a_field.field_debris_type[_AST_BROWN] == -1) && \
-					(_a_field.field_debris_type[_AST_BLUE] == -1) && \
-					(_a_field.field_debris_type[_AST_ORANGE] == -1) ) {
+			if ( (!_a_field.field_asteroid_type[_AST_BROWN]) && \
+					(!_a_field.field_asteroid_type[_AST_BLUE]) && \
+					(!_a_field.field_asteroid_type[_AST_ORANGE]) ) {
 				showErrorDialogNoCancel("You must choose one or more asteroid subtypes\n");
 				return false;
 			}
@@ -393,9 +393,9 @@ void AsteroidEditorDialogModel::update_init()
 
 		// asteroids
 		if ( _debris_genre == DG_ASTEROID ) {
-			modify(_a_field.field_debris_type[_AST_BROWN], getAsteroidEnabled(_AST_BROWN) == true ? 1 : -1);
-			modify(_a_field.field_debris_type[_AST_BLUE], getAsteroidEnabled(_AST_BLUE) == true ? 1 : -1);
-			modify(_a_field.field_debris_type[_AST_ORANGE], getAsteroidEnabled(_AST_ORANGE) == true ? 1 : -1);
+			modify(_a_field.field_asteroid_type[_AST_BROWN], getAsteroidEnabled(_AST_BROWN));
+			modify(_a_field.field_asteroid_type[_AST_BLUE], getAsteroidEnabled(_AST_BLUE));
+			modify(_a_field.field_asteroid_type[_AST_ORANGE], getAsteroidEnabled(_AST_ORANGE));
 		}
 
 		modify(_a_field.has_inner_bound, _enable_inner_bounds);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -799,8 +799,8 @@ int CFred_mission_save::save_asteroid_fields()
 			}
 		} else {
 			// asteroid subtypes stored in field_debris_type as -1 or 1
-			for (int idx = 0; idx < MAX_ACTIVE_DEBRIS_TYPES; idx++) {
-				if (Asteroid_field.field_debris_type[idx] != -1) {
+			for (int idx = 0; idx < NUM_ASTEROID_SIZES; idx++) {
+				if (Asteroid_field.field_asteroid_type[idx] != false) {
 
 					if (save_format != MissionFormat::RETAIL) {
 						if (optional_string_fred("+Field Debris Type:")) {


### PR DESCRIPTION
Currently asteroid fields save the asteroid types and the debris types in the same array within the asteroid field struct. See code example below. This PR moves asteroid types into their own array, `field_asteroid_type` that's a bool instead of an int. This will allow another feature I'm working on later; unlimited debris types rather than debris being limited to three types. You can then create a really nice field of space junk!

This also slightly adjusts usage of MAX_ACTIVE_DEBRIS_TYPES and NUM_ASTEROID_SIZES to match the newer handling. This will be further adjusted in future PRs where MAX_ACTIVE_DEBRIS_TYPES is entirely removed in favor of `Asteroid_field.field_debris_type.size()`

Old & Crusty
```
if (Asteroid_field.debris_genre == DG_ASTEROID) {
	Asteroid_field.field_debris_type[0] = 1; // brown asteroid active
	Asteroid_field.field_debris_type[1] = 1; // blue asteroid active
	Asteroid_field.field_debris_type[2] = 1; // orange asteroid active

	Asteroid_field.field_debris_type[0] = -1; // brown asteroid inactive
	Asteroid_field.field_debris_type[1] = -1; // blue asteroid inactive
	Asteroid_field.field_debris_type[2] = -1; // orange asteroid inactive
}

if (Asteroid_field.debris_genre == DG_DEBRIS) {
	Asteroid_field.field_debris_type[0] = asteroid_idx; // debris idx active
	Asteroid_field.field_debris_type[1] = asteroid_idx; // debris idx active
	Asteroid_field.field_debris_type[2] = asteroid_idx; // debris idx active

	Asteroid_field.field_debris_type[0] = -1; // debris inactive
	Asteroid_field.field_debris_type[1] = -1; // debris inactive
	Asteroid_field.field_debris_type[2] = -1; // debris inactive
}
```

New & Shiny
```
if (Asteroid_field.debris_genre == DG_ASTEROID) {
	Asteroid_field.field_asteroid_type[0] = true; // brown asteroid active
	Asteroid_field.field_asteroid_type[1] = true; // blue asteroid active
	Asteroid_field.field_asteroid_type[2] = true; // orange asteroid active

	Asteroid_field.field_asteroid_type[0] = false; // brown asteroid inactive
	Asteroid_field.field_asteroid_type[1] = false; // blue asteroid inactive
	Asteroid_field.field_asteroid_type[2] = false; // orange asteroid inactive
}

if (Asteroid_field.debris_genre == DG_DEBRIS) {
	Asteroid_field.field_debris_type[0] = asteroid_idx; // debris idx active
	Asteroid_field.field_debris_type[1] = asteroid_idx; // debris idx active
	Asteroid_field.field_debris_type[2] = asteroid_idx; // debris idx active

	Asteroid_field.field_debris_type[0] = -1; // debris inactive
	Asteroid_field.field_debris_type[1] = -1; // debris inactive
	Asteroid_field.field_debris_type[2] = -1; // debris inactive
}
```