### PR TITLE
scripting refactor to compose handle types

### DIFF
--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -70,89 +70,89 @@ ADE_VIRTVAR(Submodels, l_Model, nullptr, "Model submodels", "submodels", "Model 
 {
 	model_h *mdl = nullptr;
 	if (!ade_get_args(L, "o", l_Model.GetPtr(&mdl)))
-		return ade_set_error(L, "o", l_ModelSubmodels.Set(modelsubmodels_h()));
+		return ade_set_error(L, "o", l_ModelSubmodels.Set(model_h()));
 
 	polymodel *pm = mdl->Get();
 	if (!pm)
-		return ade_set_error(L, "o", l_ModelSubmodels.Set(modelsubmodels_h()));
+		return ade_set_error(L, "o", l_ModelSubmodels.Set(model_h()));
 
 	if (ADE_SETTING_VAR)
 		LuaError(L, "Attempt to use Incomplete Feature: Modelsubmodels copy");
 
-	return ade_set_args(L, "o", l_ModelSubmodels.Set(modelsubmodels_h(pm)));
+	return ade_set_args(L, "o", l_ModelSubmodels.Set(model_h(pm)));
 }
 
 ADE_VIRTVAR(Textures, l_Model, nullptr, "Model textures", "textures", "Model textures, or an invalid textures handle if the model handle is invalid")
 {
 	model_h *mdl = NULL;
-	modeltextures_h *oth = NULL;
+	model_h *oth = NULL;
 	if(!ade_get_args(L, "o|o", l_Model.GetPtr(&mdl), l_ModelTextures.GetPtr(&oth)))
-		return ade_set_error(L, "o", l_ModelTextures.Set(modeltextures_h()));
+		return ade_set_error(L, "o", l_ModelTextures.Set(model_h()));
 
 	polymodel *pm = mdl->Get();
 	if(pm == NULL)
-		return ade_set_error(L, "o", l_ModelTextures.Set(modeltextures_h()));
+		return ade_set_error(L, "o", l_ModelTextures.Set(model_h()));
 
 	if(ADE_SETTING_VAR && oth && oth->isValid()) {
 		//WMC TODO: Copy code
 		LuaError(L, "Attempt to use Incomplete Feature: Modeltextures copy");
 	}
 
-	return ade_set_args(L, "o", l_ModelTextures.Set(modeltextures_h(pm)));
+	return ade_set_args(L, "o", l_ModelTextures.Set(model_h(pm)));
 }
 
 ADE_VIRTVAR(Thrusters, l_Model, nullptr, "Model thrusters", "thrusters", "Model thrusters, or an invalid thrusters handle if the model handle is invalid")
 {
 	model_h *mdl = NULL;
-	thrusters_h *oth = NULL;
-	if(!ade_get_args(L, "o|o", l_Model.GetPtr(&mdl), l_Thrusters.GetPtr(&oth)))
-		return ade_set_error(L, "o", l_Thrusters.Set(thrusters_h()));
+	model_h *oth = NULL;
+	if(!ade_get_args(L, "o|o", l_Model.GetPtr(&mdl), l_ModelThrusters.GetPtr(&oth)))
+		return ade_set_error(L, "o", l_ModelThrusters.Set(model_h()));
 
 	polymodel *pm = mdl->Get();
 	if(pm == NULL)
-		return ade_set_error(L, "o", l_Thrusters.Set(thrusters_h()));
+		return ade_set_error(L, "o", l_ModelThrusters.Set(model_h()));
 
 	if(ADE_SETTING_VAR && oth && oth->isValid()) {
 		LuaError(L, "Attempt to use Incomplete Feature: Thrusters copy");
 	}
 
-	return ade_set_args(L, "o", l_Thrusters.Set(thrusters_h(pm)));
+	return ade_set_args(L, "o", l_ModelThrusters.Set(model_h(pm)));
 }
 
 ADE_VIRTVAR(Eyepoints, l_Model, nullptr, "Model eyepoints", "eyepoints", "Array of eyepoints, or an invalid eyepoints handle if the model handle is invalid")
 {
 	model_h *mdl = NULL;
-	eyepoints_h *eph = NULL;
-	if(!ade_get_args(L, "o|o", l_Model.GetPtr(&mdl), l_Eyepoints.GetPtr(&eph)))
-		return ade_set_error(L, "o", l_Eyepoints.Set(eyepoints_h()));
+	model_h *eph = NULL;
+	if(!ade_get_args(L, "o|o", l_Model.GetPtr(&mdl), l_ModelEyepoints.GetPtr(&eph)))
+		return ade_set_error(L, "o", l_ModelEyepoints.Set(model_h()));
 
 	polymodel *pm = mdl->Get();
 	if(pm == NULL)
-		return ade_set_error(L, "o", l_Eyepoints.Set(eyepoints_h()));
+		return ade_set_error(L, "o", l_ModelEyepoints.Set(model_h()));
 
 	if(ADE_SETTING_VAR && eph && eph->isValid()) {
 		LuaError(L, "Attempt to use Incomplete Feature: Eyepoints copy");
 	}
 
-	return ade_set_args(L, "o", l_Eyepoints.Set(eyepoints_h(pm)));
+	return ade_set_args(L, "o", l_ModelEyepoints.Set(model_h(pm)));
 }
 
 ADE_VIRTVAR(Dockingbays, l_Model, nullptr, "Model docking bays", "dockingbays", "Array of docking bays, or an invalid dockingbays handle if the model handle is invalid")
 {
 	model_h *mdl = NULL;
-	dockingbays_h *dbh = NULL;
-	if(!ade_get_args(L, "o|o", l_Model.GetPtr(&mdl), l_Dockingbays.GetPtr(&dbh)))
-		return ade_set_error(L, "o", l_Dockingbays.Set(dockingbays_h()));
+	model_h *dbh = NULL;
+	if(!ade_get_args(L, "o|o", l_Model.GetPtr(&mdl), l_ModelDockingbays.GetPtr(&dbh)))
+		return ade_set_error(L, "o", l_ModelDockingbays.Set(model_h()));
 
 	polymodel *pm = mdl->Get();
 	if(pm == NULL)
-		return ade_set_error(L, "o", l_Dockingbays.Set(dockingbays_h()));
+		return ade_set_error(L, "o", l_ModelDockingbays.Set(model_h()));
 
 	if(ADE_SETTING_VAR && dbh && dbh->isValid()) {
 		LuaError(L, "Attempt to use Incomplete Feature: Docking bays copy");
 	}
 
-	return ade_set_args(L, "o", l_Dockingbays.Set(dockingbays_h(pm)));
+	return ade_set_args(L, "o", l_ModelDockingbays.Set(model_h(pm)));
 }
 
 ADE_VIRTVAR(BoundingBoxMax, l_Model, "vector", "Model bounding box maximum", "vector", "Model bounding box, or an empty vector if the handle is not valid")
@@ -475,14 +475,11 @@ ADE_FUNC(isValid, l_Submodel, nullptr, "True if valid, false or nil if not", "bo
 
 
 //**********HANDLE: modelsubmodels
-ADE_OBJ(l_ModelSubmodels, modelsubmodels_h, "submodels", "Array of submodels");
-
-modelsubmodels_h::modelsubmodels_h(polymodel* pm) : model_h(pm){}
-modelsubmodels_h::modelsubmodels_h() : model_h(){}
+ADE_OBJ(l_ModelSubmodels, model_h, "submodels", "Array of submodels");
 
 ADE_FUNC(__len, l_ModelSubmodels, nullptr, "Number of submodels on model", "number", "Number of model submodels")
 {
-	modelsubmodels_h *msh;
+	model_h *msh;
 	if (!ade_get_args(L, "o", l_ModelSubmodels.GetPtr(&msh)))
 		return ade_set_error(L, "i", 0);
 
@@ -499,7 +496,7 @@ ADE_FUNC(__len, l_ModelSubmodels, nullptr, "Number of submodels on model", "numb
 
 ADE_INDEXER(l_ModelSubmodels, "submodel", "number|string IndexOrName", "submodel", "Model submodels, or invalid modelsubmodels handle if model handle is invalid")
 {
-	modelsubmodels_h *msh = nullptr;
+	model_h *msh = nullptr;
 	int index = -1;
 
 	if (lua_isnumber(L, 2))
@@ -532,7 +529,7 @@ ADE_INDEXER(l_ModelSubmodels, "submodel", "number|string IndexOrName", "submodel
 
 ADE_FUNC(isValid, l_ModelSubmodels, nullptr, "Detects whether handle is valid", "boolean", "true if valid, false if invalid, nil if a syntax/type error occurs")
 {
-	modelsubmodels_h *msh;
+	model_h *msh;
 	if (!ade_get_args(L, "o", l_ModelSubmodels.GetPtr(&msh)))
 		return ADE_RETURN_FALSE;
 
@@ -541,14 +538,11 @@ ADE_FUNC(isValid, l_ModelSubmodels, nullptr, "Detects whether handle is valid", 
 
 
 //**********HANDLE: modeltextures
-ADE_OBJ(l_ModelTextures, modeltextures_h, "textures", "Array of textures");
-
-modeltextures_h::modeltextures_h(polymodel* pm) : model_h(pm){}
-modeltextures_h::modeltextures_h() : model_h(){}
+ADE_OBJ(l_ModelTextures, model_h, "textures", "Array of textures");
 
 ADE_FUNC(__len, l_ModelTextures, NULL, "Number of textures on model", "number", "Number of model textures")
 {
-	modeltextures_h *mth;
+	model_h *mth;
 	if(!ade_get_args(L, "o", l_ModelTextures.GetPtr(&mth)))
 		return ade_set_error(L, "i", 0);
 
@@ -565,7 +559,7 @@ ADE_FUNC(__len, l_ModelTextures, NULL, "Number of textures on model", "number", 
 
 ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "texture", "Model textures, or invalid modeltextures handle if model handle is invalid")
 {
-	modeltextures_h *mth = NULL;
+	model_h *mth = NULL;
 	texture_h* new_tex   = nullptr;
 	const char* s        = nullptr;
 
@@ -616,7 +610,7 @@ ADE_INDEXER(l_ModelTextures, "texture", "number Index/string TextureName", "text
 
 ADE_FUNC(isValid, l_ModelTextures, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
 {
-	modeltextures_h *mth;
+	model_h *mth;
 	if(!ade_get_args(L, "o", l_ModelTextures.GetPtr(&mth)))
 		return ADE_RETURN_FALSE;
 
@@ -625,15 +619,12 @@ ADE_FUNC(isValid, l_ModelTextures, NULL, "Detects whether handle is valid", "boo
 
 
 //**********HANDLE: eyepoints
-ADE_OBJ(l_Eyepoints, eyepoints_h, "eyepoints", "Array of model eye points");
+ADE_OBJ(l_ModelEyepoints, model_h, "eyepoints", "Array of model eye points");
 
-eyepoints_h::eyepoints_h(polymodel* pm) : model_h(pm){}
-eyepoints_h::eyepoints_h() : model_h(){}
-
-ADE_FUNC(__len, l_Eyepoints, NULL, "Gets the number of eyepoints on this model", "number", "Number of eyepoints on this model or 0 on error")
+ADE_FUNC(__len, l_ModelEyepoints, NULL, "Gets the number of eyepoints on this model", "number", "Number of eyepoints on this model or 0 on error")
 {
-	eyepoints_h *eph = NULL;
-	if (!ade_get_args(L, "o", l_Eyepoints.GetPtr(&eph)))
+	model_h *eph = NULL;
+	if (!ade_get_args(L, "o", l_ModelEyepoints.GetPtr(&eph)))
 	{
 		return ade_set_error(L, "i", 0);
 	}
@@ -653,13 +644,13 @@ ADE_FUNC(__len, l_Eyepoints, NULL, "Gets the number of eyepoints on this model",
 	return ade_set_args(L, "i", pm->n_view_positions);
 }
 
-ADE_INDEXER(l_Eyepoints, "eyepoint", "Gets an eyepoint handle", "eyepoint", "eye handle or invalid handle on error")
+ADE_INDEXER(l_ModelEyepoints, "eyepoint", "Gets an eyepoint handle", "eyepoint", "eye handle or invalid handle on error")
 {
-	eyepoints_h *eph = NULL;
+	model_h *eph = NULL;
 	int index = -1;
 	eye_h *eh = NULL;
 
-	if (!ade_get_args(L, "oi|o", l_Eyepoints.GetPtr(&eph), &index, l_Eyepoint.GetPtr(&eh)))
+	if (!ade_get_args(L, "oi|o", l_ModelEyepoints.GetPtr(&eph), &index, l_Eyepoint.GetPtr(&eh)))
 	{
 		return ade_set_error(L, "o", l_Eyepoint.Set(eye_h()));
 	}
@@ -691,25 +682,22 @@ ADE_INDEXER(l_Eyepoints, "eyepoint", "Gets an eyepoint handle", "eyepoint", "eye
 	return ade_set_args(L, "o", l_Eyepoint.Set(eye_h(eph->GetID(), index)));
 }
 
-ADE_FUNC(isValid, l_Eyepoints, NULL, "Detects whether handle is valid or not", "boolean", "true if valid false otherwise")
+ADE_FUNC(isValid, l_ModelEyepoints, NULL, "Detects whether handle is valid or not", "boolean", "true if valid false otherwise")
 {
-	eyepoints_h *eph;
-	if(!ade_get_args(L, "o", l_Eyepoints.GetPtr(&eph)))
+	model_h *eph;
+	if(!ade_get_args(L, "o", l_ModelEyepoints.GetPtr(&eph)))
 		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", eph->isValid());
 }
 
 //**********HANDLE: thrusters
-ADE_OBJ(l_Thrusters, thrusters_h, "thrusters", "The thrusters of a model");
+ADE_OBJ(l_ModelThrusters, model_h, "thrusters", "The thrusters of a model");
 
-thrusters_h::thrusters_h(polymodel* pm) : model_h(pm){}
-thrusters_h::thrusters_h() : model_h(){}
-
-ADE_FUNC(__len, l_Thrusters, NULL, "Number of thruster banks on the model", "number", "Number of thrusterbanks")
+ADE_FUNC(__len, l_ModelThrusters, NULL, "Number of thruster banks on the model", "number", "Number of thrusterbanks")
 {
-	thrusters_h *trh;
-	if(!ade_get_args(L, "o", l_Thrusters.GetPtr(&trh)))
+	model_h *trh;
+	if(!ade_get_args(L, "o", l_ModelThrusters.GetPtr(&trh)))
 		return ade_set_error(L, "i", -1);
 
 	if(!trh->isValid())
@@ -723,13 +711,13 @@ ADE_FUNC(__len, l_Thrusters, NULL, "Number of thruster banks on the model", "num
 	return ade_set_args(L, "i", pm->n_thrusters);
 }
 
-ADE_INDEXER(l_Thrusters, "number Index", "Array of all thrusterbanks on this thruster", "thrusterbank", "Handle to the thrusterbank or invalid handle if index is invalid")
+ADE_INDEXER(l_ModelThrusters, "number Index", "Array of all thrusterbanks on this thruster", "thrusterbank", "Handle to the thrusterbank or invalid handle if index is invalid")
 {
-	thrusters_h *trh = NULL;
+	model_h *trh = NULL;
 	const char* s    = nullptr;
 	thrusterbank_h newThr;
 
-	if (!ade_get_args(L, "os|o", l_Thrusters.GetPtr(&trh), &s, l_Thrusterbank.Get(&newThr)))
+	if (!ade_get_args(L, "os|o", l_ModelThrusters.GetPtr(&trh), &s, l_Thrusterbank.Get(&newThr)))
 		return ade_set_error(L, "o", l_Thrusterbank.Set(thrusterbank_h()));
 
 	polymodel *pm = trh->Get();
@@ -756,10 +744,10 @@ ADE_INDEXER(l_Thrusters, "number Index", "Array of all thrusterbanks on this thr
 	return ade_set_args(L, "o", l_Thrusterbank.Set(bank));
 }
 
-ADE_FUNC(isValid, l_Thrusters, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+ADE_FUNC(isValid, l_ModelThrusters, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
 {
-	thrusters_h *trh;
-	if(!ade_get_args(L, "o", l_Thrusters.GetPtr(&trh)))
+	model_h *trh;
+	if(!ade_get_args(L, "o", l_ModelThrusters.GetPtr(&trh)))
 		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", trh->isValid());
@@ -914,20 +902,17 @@ ADE_FUNC(isValid, l_Glowpoint, NULL, "Returns whether this handle is valid or no
 }
 
 //**********HANDLE: dockingbays
-ADE_OBJ(l_Dockingbays, dockingbays_h, "dockingbays", "The docking bays of a model");
+ADE_OBJ(l_ModelDockingbays, model_h, "dockingbays", "The docking bays of a model");
 
-dockingbays_h::dockingbays_h(polymodel* pm) : model_h(pm){}
-dockingbays_h::dockingbays_h() : model_h(){}
-
-ADE_INDEXER(l_Dockingbays, "dockingbay", "Gets a dockingbay handle from this model. If a string is given then a dockingbay with that name is searched.", "dockingbay", "Handle or invalid handle on error")
+ADE_INDEXER(l_ModelDockingbays, "dockingbay", "Gets a dockingbay handle from this model. If a string is given then a dockingbay with that name is searched.", "dockingbay", "Handle or invalid handle on error")
 {
-	dockingbays_h *dbhp = NULL;
+	model_h *dbhp = NULL;
 	int index = -1;
 	dockingbay_h *newVal = NULL;
 
 	if (lua_isnumber(L, 2))
 	{
-		if (!ade_get_args(L, "oi|o", l_Dockingbays.GetPtr(&dbhp), &index, l_Dockingbay.GetPtr(&newVal)))
+		if (!ade_get_args(L, "oi|o", l_ModelDockingbays.GetPtr(&dbhp), &index, l_Dockingbay.GetPtr(&newVal)))
 			return ade_set_error(L, "o", l_Dockingbay.Set(dockingbay_h()));
 
 		if (!dbhp->isValid())
@@ -939,7 +924,7 @@ ADE_INDEXER(l_Dockingbays, "dockingbay", "Gets a dockingbay handle from this mod
 	{
 		const char* name = nullptr;
 
-		if (!ade_get_args(L, "os|o", l_Dockingbays.GetPtr(&dbhp), &name, l_Dockingbay.GetPtr(&newVal)))
+		if (!ade_get_args(L, "os|o", l_ModelDockingbays.GetPtr(&dbhp), &name, l_Dockingbay.GetPtr(&newVal)))
 		{
 			return ade_set_error(L, "o", l_Dockingbay.Set(dockingbay_h()));
 		}
@@ -960,11 +945,11 @@ ADE_INDEXER(l_Dockingbays, "dockingbay", "Gets a dockingbay handle from this mod
 	return ade_set_args(L, "o", l_Dockingbay.Set(dockingbay_h(pm, index)));
 }
 
-ADE_FUNC(__len, l_Dockingbays, NULL, "Retrieves the number of dockingbays on this model", "number", "number of docking bays or 0 on error")
+ADE_FUNC(__len, l_ModelDockingbays, NULL, "Retrieves the number of dockingbays on this model", "number", "number of docking bays or 0 on error")
 {
-	dockingbays_h *dbhp = NULL;
+	model_h *dbhp = NULL;
 
-	if (!ade_get_args(L, "o", l_Dockingbays.GetPtr(&dbhp)))
+	if (!ade_get_args(L, "o", l_ModelDockingbays.GetPtr(&dbhp)))
 		return ade_set_error(L, "i", 0);
 
 	if (!dbhp->isValid())
@@ -976,25 +961,21 @@ ADE_FUNC(__len, l_Dockingbays, NULL, "Retrieves the number of dockingbays on thi
 //**********HANDLE: dockingbay
 ADE_OBJ(l_Dockingbay, dockingbay_h, "dockingbay", "Handle to a model docking bay");
 
-dockingbay_h::dockingbay_h(polymodel* pm, int dock_idx) : model_h(pm), dock_id(dock_idx) {}
-dockingbay_h::dockingbay_h() : model_h(), dock_id(-1){}
-bool dockingbay_h::isValid() const {
-	if (!model_h::isValid())
-	{
+dockingbay_h::dockingbay_h(polymodel* pm, int dock_idx) : modelh(pm), dock_id(dock_idx) {}
+dockingbay_h::dockingbay_h() : modelh(), dock_id(-1){}
+bool dockingbay_h::isValid() const
+{
+	if (!modelh.isValid())
 		return false;
-	}
-	else
-	{
-		return dock_id >= 0 && dock_id < this->Get()->n_docks;
-	}
-}
-dock_bay* dockingbay_h::getDockingBay() const {
-	if (!this->isValid())
-	{
-		return NULL;
-	}
 
-	return &this->Get()->docking_bays[dock_id];
+	return dock_id >= 0 && dock_id < modelh.Get()->n_docks;
+}
+dock_bay* dockingbay_h::getDockingBay() const
+{
+	if (!isValid())
+		return nullptr;
+
+	return &modelh.Get()->docking_bays[dock_id];
 }
 
 ADE_FUNC(__len, l_Dockingbay, NULL, "Gets the number of docking points in this bay", "number", "The number of docking points or 0 on error")

--- a/code/scripting/api/objs/model.h
+++ b/code/scripting/api/objs/model.h
@@ -47,38 +47,14 @@ public:
 };
 DECLARE_ADE_OBJ(l_Submodel, submodel_h);
 
-class modelsubmodels_h : public model_h
-{
- public:
-	 modelsubmodels_h(polymodel *pm);
-	 modelsubmodels_h();
-};
-DECLARE_ADE_OBJ(l_ModelSubmodels, modelsubmodels_h);
+DECLARE_ADE_OBJ(l_ModelSubmodels, model_h);
 
-class modeltextures_h : public model_h
-{
- public:
-	modeltextures_h(polymodel *pm);
-	modeltextures_h();
-};
-DECLARE_ADE_OBJ(l_ModelTextures, modeltextures_h);
+DECLARE_ADE_OBJ(l_ModelTextures, model_h);
 
-class eyepoints_h : public model_h
-{
- public:
-	eyepoints_h(polymodel *pm);
-	eyepoints_h();
-};
-DECLARE_ADE_OBJ(l_Eyepoints, eyepoints_h);
+DECLARE_ADE_OBJ(l_ModelEyepoints, model_h);
 
 // Thrusters:
-class thrusters_h : public model_h
-{
- public:
-	thrusters_h(polymodel *pm);
-	thrusters_h();
-};
-DECLARE_ADE_OBJ(l_Thrusters, thrusters_h);
+DECLARE_ADE_OBJ(l_ModelThrusters, model_h);
 
 // Thrusterbank:
 struct thrusterbank_h
@@ -111,18 +87,13 @@ struct glowpoint_h
 };
 DECLARE_ADE_OBJ(l_Glowpoint, glowpoint_h);
 
-// Glowbanks:
-class dockingbays_h : public model_h
-{
- public:
-	dockingbays_h(polymodel *pm);
-	dockingbays_h();
-};
-DECLARE_ADE_OBJ(l_Dockingbays, dockingbays_h);
+// Docking bays:
+DECLARE_ADE_OBJ(l_ModelDockingbays, model_h);
 
-class dockingbay_h : public model_h
+class dockingbay_h
 {
  private:
+	model_h modelh;
 	int dock_id;
 
  public:
@@ -131,6 +102,7 @@ class dockingbay_h : public model_h
 
 	bool isValid() const;
 
+	model_h* getModelH() const;
 	dock_bay* getDockingBay() const;
 };
 DECLARE_ADE_OBJ(l_Dockingbay, dockingbay_h);

--- a/code/scripting/api/objs/ship_bank.cpp
+++ b/code/scripting/api/objs/ship_bank.cpp
@@ -40,11 +40,11 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 			idx--; //Lua->FS2
 
 			if(ADE_SETTING_VAR && newbank && newbank->isValid()) {
-				sb->sw->primary_bank_weapons[idx] = newbank->sw->primary_bank_weapons[idx];
+				sb->sw->primary_bank_weapons[idx] = newbank->typeh.sw->primary_bank_weapons[idx];
 				sb->sw->next_primary_fire_stamp[idx] = timestamp(0);
-				sb->sw->primary_bank_ammo[idx] = newbank->sw->primary_bank_ammo[idx];
-				sb->sw->primary_bank_start_ammo[idx] = newbank->sw->primary_bank_start_ammo[idx];
-				sb->sw->primary_bank_capacity[idx] = newbank->sw->primary_bank_capacity[idx];
+				sb->sw->primary_bank_ammo[idx] = newbank->typeh.sw->primary_bank_ammo[idx];
+				sb->sw->primary_bank_start_ammo[idx] = newbank->typeh.sw->primary_bank_start_ammo[idx];
+				sb->sw->primary_bank_capacity[idx] = newbank->typeh.sw->primary_bank_capacity[idx];
 				sb->sw->primary_bank_rearm_time[idx] = timestamp(0);
 			}
 			break;
@@ -55,11 +55,11 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 			idx--; //Lua->FS2
 
 			if(ADE_SETTING_VAR && newbank && newbank->isValid()) {
-				sb->sw->primary_bank_weapons[idx] = newbank->sw->primary_bank_weapons[idx];
+				sb->sw->primary_bank_weapons[idx] = newbank->typeh.sw->primary_bank_weapons[idx];
 				sb->sw->next_primary_fire_stamp[idx] = timestamp(0);
-				sb->sw->primary_bank_ammo[idx] = newbank->sw->primary_bank_ammo[idx];
-				sb->sw->primary_bank_start_ammo[idx] = newbank->sw->primary_bank_start_ammo[idx];
-				sb->sw->primary_bank_capacity[idx] = newbank->sw->primary_bank_capacity[idx];
+				sb->sw->primary_bank_ammo[idx] = newbank->typeh.sw->primary_bank_ammo[idx];
+				sb->sw->primary_bank_start_ammo[idx] = newbank->typeh.sw->primary_bank_start_ammo[idx];
+				sb->sw->primary_bank_capacity[idx] = newbank->typeh.sw->primary_bank_capacity[idx];
 			}
 			break;
 		case SWH_TERTIARY:
@@ -82,24 +82,24 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 
 ADE_VIRTVAR(Linked, l_WeaponBankType, "boolean", "Whether bank is in linked or unlinked fire mode (Primary-only)", "boolean", "Link status, or false if handle is invalid")
 {
-	ship_banktype_h *bh;
+	ship_banktype_h *bth;
 	bool newlink = false;
-	int numargs = ade_get_args(L, "o|b", l_WeaponBankType.GetPtr(&bh), &newlink);
+	int numargs = ade_get_args(L, "o|b", l_WeaponBankType.GetPtr(&bth), &newlink);
 
 	if(!numargs)
 		return ade_set_error(L, "b", false);
 
-	if(!bh->isValid())
+	if(!bth->isValid())
 		return ade_set_error(L, "b", false);
 
-	switch(bh->type)
+	switch(bth->type)
 	{
 		case SWH_PRIMARY:
 			if(ADE_SETTING_VAR && numargs > 1) {
-				Ships[bh->objh.objp->instance].flags.set(Ship::Ship_Flags::Primary_linked, newlink);
+				Ships[bth->objh.objp->instance].flags.set(Ship::Ship_Flags::Primary_linked, newlink);
 			}
 
-			return ade_set_args(L, "b", (Ships[bh->objh.objp->instance].flags[Ship::Ship_Flags::Primary_linked]));
+			return ade_set_args(L, "b", (Ships[bth->objh.objp->instance].flags[Ship::Ship_Flags::Primary_linked]));
 
 		case SWH_SECONDARY:
 		case SWH_TERTIARY:
@@ -111,24 +111,24 @@ ADE_VIRTVAR(Linked, l_WeaponBankType, "boolean", "Whether bank is in linked or u
 
 ADE_VIRTVAR(DualFire, l_WeaponBankType, "boolean", "Whether bank is in dual fire mode (Secondary-only)", "boolean", "Dual fire status, or false if handle is invalid")
 {
-	ship_banktype_h *bh;
+	ship_banktype_h *bth;
 	bool newfire = false;
-	int numargs = ade_get_args(L, "o|b", l_WeaponBankType.GetPtr(&bh), &newfire);
+	int numargs = ade_get_args(L, "o|b", l_WeaponBankType.GetPtr(&bth), &newfire);
 
 	if(!numargs)
 		return ade_set_error(L, "b", false);
 
-	if(!bh->isValid())
+	if(!bth->isValid())
 		return ade_set_error(L, "b", false);
 
-	switch(bh->type)
+	switch(bth->type)
 	{
 		case SWH_SECONDARY:
 			if(ADE_SETTING_VAR && numargs > 1) {
-				Ships[bh->objh.objp->instance].flags.set(Ship::Ship_Flags::Secondary_dual_fire, newfire);
+				Ships[bth->objh.objp->instance].flags.set(Ship::Ship_Flags::Secondary_dual_fire, newfire);
 			}
 
-			return ade_set_args(L, "b", (Ships[bh->objh.objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire]));
+			return ade_set_args(L, "b", (Ships[bth->objh.objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire]));
 
 		case SWH_PRIMARY:
 		case SWH_TERTIARY:
@@ -173,24 +173,21 @@ ADE_FUNC(__len, l_WeaponBankType, NULL, "Number of weapons in the mounted bank",
 //**********HANDLE: Weaponbank
 ADE_OBJ_NO_MULTI(l_WeaponBank, ship_bank_h, "weaponbank", "Ship/subystem weapons bank handle");
 
-ship_bank_h::ship_bank_h() : ship_banktype_h() {
-	bank = -1;
-}
-ship_bank_h::ship_bank_h(object* objp_in, ship_weapon* wpn, int in_type, int in_bank) : ship_banktype_h(objp_in, wpn, in_type) {
-	bank = in_bank;
-}
-bool ship_bank_h::isValid() const {
-	if(!ship_banktype_h::isValid())
+ship_bank_h::ship_bank_h() : typeh(), bank(-1) {}
+ship_bank_h::ship_bank_h(object* objp_in, ship_weapon* wpn, int in_type, int in_bank) : typeh(objp_in, wpn, in_type), bank(in_bank) {}
+bool ship_bank_h::isValid() const
+{
+	if(!typeh.isValid())
 		return false;
 
 	if(bank < 0)
 		return false;
 
-	if(type == SWH_PRIMARY && bank >= sw->num_primary_banks)
+	if(typeh.type == SWH_PRIMARY && bank >= typeh.sw->num_primary_banks)
 		return false;
-	if(type == SWH_SECONDARY && bank >= sw->num_secondary_banks)
+	if(typeh.type == SWH_SECONDARY && bank >= typeh.sw->num_secondary_banks)
 		return false;
-	if(type == SWH_TERTIARY && bank >= sw->num_tertiary_banks)
+	if(typeh.type == SWH_TERTIARY && bank >= typeh.sw->num_tertiary_banks)
 		return false;
 
 	return true;
@@ -206,30 +203,30 @@ ADE_VIRTVAR(WeaponClass, l_WeaponBank, "weaponclass", "Class of weapon mounted i
 	if(!bh->isValid())
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
-	switch(bh->type)
+	switch(bh->typeh.type)
 	{
 		case SWH_PRIMARY:
 			if(ADE_SETTING_VAR && weaponclass > -1) {
-				bh->sw->primary_bank_weapons[bh->bank] = weaponclass;
+				bh->typeh.sw->primary_bank_weapons[bh->bank] = weaponclass;
 				if (Weapon_info[weaponclass].wi_flags[Weapon::Info_Flags::Ballistic]) {
-					bh->sw->primary_bank_start_ammo[bh->bank] = (int)std::lround(bh->sw->primary_bank_capacity[bh->bank] / Weapon_info[weaponclass].cargo_size);
+					bh->typeh.sw->primary_bank_start_ammo[bh->bank] = (int)std::lround(bh->typeh.sw->primary_bank_capacity[bh->bank] / Weapon_info[weaponclass].cargo_size);
 				}
 			}
 
-			return ade_set_args(L, "o", l_Weaponclass.Set(bh->sw->primary_bank_weapons[bh->bank]));
+			return ade_set_args(L, "o", l_Weaponclass.Set(bh->typeh.sw->primary_bank_weapons[bh->bank]));
 		case SWH_SECONDARY:
 			if(ADE_SETTING_VAR && weaponclass > -1) {
-				bh->sw->secondary_bank_weapons[bh->bank] = weaponclass;
-				bh->sw->secondary_bank_start_ammo[bh->bank] = (int)std::lround(bh->sw->secondary_bank_capacity[bh->bank] / Weapon_info[weaponclass].cargo_size);
+				bh->typeh.sw->secondary_bank_weapons[bh->bank] = weaponclass;
+				bh->typeh.sw->secondary_bank_start_ammo[bh->bank] = (int)std::lround(bh->typeh.sw->secondary_bank_capacity[bh->bank] / Weapon_info[weaponclass].cargo_size);
 			}
 
-			return ade_set_args(L, "o", l_Weaponclass.Set(bh->sw->secondary_bank_weapons[bh->bank]));
+			return ade_set_args(L, "o", l_Weaponclass.Set(bh->typeh.sw->secondary_bank_weapons[bh->bank]));
 		case SWH_TERTIARY:
 			if(ADE_SETTING_VAR && weaponclass > -1) {
-				//bh->sw->tertiary_bank_weapons[bh->bank] = weaponclass;
+				//bh->typeh.sw->tertiary_bank_weapons[bh->bank] = weaponclass;
 			}
 
-			// return ade_set_args(L, "o", l_Weaponclass.Set(bh->sw->tertiary_bank_weapons[bh->bank]));
+			// return ade_set_args(L, "o", l_Weaponclass.Set(bh->typeh.sw->tertiary_bank_weapons[bh->bank]));
 			// Error(LOCATION, "Tertiary bank support is still in progress");
 			// WMC: TODO
 			return ADE_RETURN_FALSE;
@@ -248,25 +245,25 @@ ADE_VIRTVAR(AmmoLeft, l_WeaponBank, "number", "Ammo left for the current bank", 
 	if(!bh->isValid())
 		return ade_set_error(L, "i", 0);
 
-	switch(bh->type)
+	switch(bh->typeh.type)
 	{
 		case SWH_PRIMARY:
 			if(ADE_SETTING_VAR && ammo > -1) {
-				bh->sw->primary_bank_ammo[bh->bank] = ammo;
+				bh->typeh.sw->primary_bank_ammo[bh->bank] = ammo;
 			}
 
-			return ade_set_args(L, "i", bh->sw->primary_bank_ammo[bh->bank]);
+			return ade_set_args(L, "i", bh->typeh.sw->primary_bank_ammo[bh->bank]);
 		case SWH_SECONDARY:
 			if(ADE_SETTING_VAR && ammo > -1) {
-				bh->sw->secondary_bank_ammo[bh->bank] = ammo;
+				bh->typeh.sw->secondary_bank_ammo[bh->bank] = ammo;
 			}
 
-			return ade_set_args(L, "i", bh->sw->secondary_bank_ammo[bh->bank]);
+			return ade_set_args(L, "i", bh->typeh.sw->secondary_bank_ammo[bh->bank]);
 		case SWH_TERTIARY:
 			if(ADE_SETTING_VAR && ammo > -1) {
-				bh->sw->tertiary_bank_ammo = ammo;
+				bh->typeh.sw->tertiary_bank_ammo = ammo;
 			}
-			return ade_set_args(L, "i", bh->sw->tertiary_bank_ammo);
+			return ade_set_args(L, "i", bh->typeh.sw->tertiary_bank_ammo);
 	}
 
 	return ade_set_error(L, "i", 0);
@@ -283,38 +280,38 @@ ADE_VIRTVAR(AmmoMax, l_WeaponBank, "number", "Maximum ammo for the current bank<
 	if(!bh->isValid())
 		return ade_set_error(L, "i", 0);
 
-	switch(bh->type)
+	switch(bh->typeh.type)
 	{
 		case SWH_PRIMARY:
 		{
 			if(ADE_SETTING_VAR && ammomax > -1) {
-				bh->sw->primary_bank_capacity[bh->bank] = ammomax;
+				bh->typeh.sw->primary_bank_capacity[bh->bank] = ammomax;
 			}
 
-			int weapon_class = bh->sw->primary_bank_weapons[bh->bank];
+			int weapon_class = bh->typeh.sw->primary_bank_weapons[bh->bank];
 
-			Assert(bh->objh.objp->type == OBJ_SHIP);
+			Assert(bh->typeh.objh.objp->type == OBJ_SHIP);
 
-			return ade_set_args(L, "i", get_max_ammo_count_for_primary_bank(Ships[bh->objh.objp->instance].ship_info_index, bh->bank, weapon_class));
+			return ade_set_args(L, "i", get_max_ammo_count_for_primary_bank(Ships[bh->typeh.objh.objp->instance].ship_info_index, bh->bank, weapon_class));
 		}
 		case SWH_SECONDARY:
 		{
 			if(ADE_SETTING_VAR && ammomax > -1) {
-				bh->sw->secondary_bank_capacity[bh->bank] = ammomax;
+				bh->typeh.sw->secondary_bank_capacity[bh->bank] = ammomax;
 			}
 
-			int weapon_class = bh->sw->secondary_bank_weapons[bh->bank];
+			int weapon_class = bh->typeh.sw->secondary_bank_weapons[bh->bank];
 
-			Assert(bh->objh.objp->type == OBJ_SHIP);
+			Assert(bh->typeh.objh.objp->type == OBJ_SHIP);
 
-			return ade_set_args(L, "i", get_max_ammo_count_for_bank(Ships[bh->objh.objp->instance].ship_info_index, bh->bank, weapon_class));
+			return ade_set_args(L, "i", get_max_ammo_count_for_bank(Ships[bh->typeh.objh.objp->instance].ship_info_index, bh->bank, weapon_class));
 		}
 		case SWH_TERTIARY:
 			if(ADE_SETTING_VAR && ammomax > -1) {
-				bh->sw->tertiary_bank_capacity = ammomax;
+				bh->typeh.sw->tertiary_bank_capacity = ammomax;
 			}
 
-			return ade_set_args(L, "i", bh->sw->tertiary_bank_capacity);
+			return ade_set_args(L, "i", bh->typeh.sw->tertiary_bank_capacity);
 	}
 
 	return ade_set_error(L, "i", 0);
@@ -334,23 +331,23 @@ ADE_VIRTVAR(Armed, l_WeaponBank, "boolean", "Weapon armed status. Does not take 
 	if(armthis)
 		new_armed_bank = bh->bank;
 
-	switch(bh->type)
+	switch(bh->typeh.type)
 	{
 		case SWH_PRIMARY:
 			if(ADE_SETTING_VAR) {
-				bh->sw->current_primary_bank = new_armed_bank;
+				bh->typeh.sw->current_primary_bank = new_armed_bank;
 			}
-			return ade_set_args(L, "b", bh->sw->current_primary_bank == bh->bank);
+			return ade_set_args(L, "b", bh->typeh.sw->current_primary_bank == bh->bank);
 		case SWH_SECONDARY:
 			if(ADE_SETTING_VAR) {
-				bh->sw->current_secondary_bank = new_armed_bank;
+				bh->typeh.sw->current_secondary_bank = new_armed_bank;
 			}
-			return ade_set_args(L, "b", bh->sw->current_secondary_bank == bh->bank);
+			return ade_set_args(L, "b", bh->typeh.sw->current_secondary_bank == bh->bank);
 		case SWH_TERTIARY:
 			if(ADE_SETTING_VAR) {
-				bh->sw->current_tertiary_bank = new_armed_bank;
+				bh->typeh.sw->current_tertiary_bank = new_armed_bank;
 			}
-			return ade_set_args(L, "b", bh->sw->current_tertiary_bank == bh->bank);
+			return ade_set_args(L, "b", bh->typeh.sw->current_tertiary_bank == bh->bank);
 	}
 
 	return ade_set_error(L, "b", false);
@@ -366,23 +363,23 @@ ADE_VIRTVAR(Capacity, l_WeaponBank, "number", "The actual capacity of a weapon b
 	if(!bh->isValid())
 		return ade_set_error(L, "i", -1);
 
-	switch(bh->type)
+	switch(bh->typeh.type)
 	{
 		case SWH_PRIMARY:
 			if(ADE_SETTING_VAR && newCapacity > 0) {
-				bh->sw->primary_bank_capacity[bh->bank] = newCapacity;
+				bh->typeh.sw->primary_bank_capacity[bh->bank] = newCapacity;
 			}
-			return ade_set_args(L, "i", bh->sw->primary_bank_capacity[bh->bank]);
+			return ade_set_args(L, "i", bh->typeh.sw->primary_bank_capacity[bh->bank]);
 		case SWH_SECONDARY:
 			if(ADE_SETTING_VAR && newCapacity > 0) {
-				bh->sw->secondary_bank_capacity[bh->bank] = newCapacity;
+				bh->typeh.sw->secondary_bank_capacity[bh->bank] = newCapacity;
 			}
-			return ade_set_args(L, "i", bh->sw->secondary_bank_capacity[bh->bank]);
+			return ade_set_args(L, "i", bh->typeh.sw->secondary_bank_capacity[bh->bank]);
 		case SWH_TERTIARY:
 			if(ADE_SETTING_VAR && newCapacity > 0) {
-				bh->sw->tertiary_bank_capacity = newCapacity;
+				bh->typeh.sw->tertiary_bank_capacity = newCapacity;
 			}
-			return ade_set_args(L, "i", bh->sw->tertiary_bank_capacity);
+			return ade_set_args(L, "i", bh->typeh.sw->tertiary_bank_capacity);
 	}
 
 	return ade_set_error(L, "i", -1);
@@ -403,13 +400,13 @@ ADE_VIRTVAR(FOFCooldown, l_WeaponBank, "number", "The FOF cooldown value. A valu
 		return ade_set_error(L, "f", -1.f);
 	}
 
-	switch(bh->type)
+	switch(bh->typeh.type)
 	{
 		case SWH_PRIMARY:
 		{
-			auto wif = &Weapon_info[bh->sw->primary_bank_weapons[bh->bank]];
-			float reset_amount = (timestamp_until(bh->sw->last_primary_fire_stamp[bh->bank]) / 1000.0f) * wif->fof_reset_rate;
-			auto val = bh->sw->primary_bank_fof_cooldown[bh->bank] + reset_amount;
+			auto wif = &Weapon_info[bh->typeh.sw->primary_bank_weapons[bh->bank]];
+			float reset_amount = (timestamp_until(bh->typeh.sw->last_primary_fire_stamp[bh->bank]) / 1000.0f) * wif->fof_reset_rate;
+			auto val = bh->typeh.sw->primary_bank_fof_cooldown[bh->bank] + reset_amount;
 			CLAMP(val, 0.0f, 1.0f);
 			return ade_set_args(L, "f", val);
 		}
@@ -432,18 +429,18 @@ ADE_VIRTVAR(BurstCounter, l_WeaponBank, "number", "The burst counter for this ba
 	if (!bh->isValid())
 		return ade_set_error(L, "i", -1);
 
-	switch (bh->type)
+	switch (bh->typeh.type)
 	{
 	case SWH_PRIMARY:
 		if (ADE_SETTING_VAR) {
-			bh->sw->burst_counter[bh->bank] = newCounter - 1;
+			bh->typeh.sw->burst_counter[bh->bank] = newCounter - 1;
 		}
-		return ade_set_args(L, "i", bh->sw->burst_counter[bh->bank] + 1);
+		return ade_set_args(L, "i", bh->typeh.sw->burst_counter[bh->bank] + 1);
 	case SWH_SECONDARY:
 		if (ADE_SETTING_VAR) {
-			bh->sw->burst_counter[MAX_SHIP_PRIMARY_BANKS + bh->bank] = newCounter - 1;
+			bh->typeh.sw->burst_counter[MAX_SHIP_PRIMARY_BANKS + bh->bank] = newCounter - 1;
 		}
-		return ade_set_args(L, "i", bh->sw->burst_counter[MAX_SHIP_PRIMARY_BANKS + bh->bank] + 1);
+		return ade_set_args(L, "i", bh->typeh.sw->burst_counter[MAX_SHIP_PRIMARY_BANKS + bh->bank] + 1);
 	case SWH_TERTIARY:
 		LuaError(L, "Burst counter is not valid for tertiary banks!");
 		return ade_set_error(L, "i", -1);
@@ -462,18 +459,18 @@ ADE_VIRTVAR(BurstSeed, l_WeaponBank, "number", "A random seed associated to the 
 	if (!bh->isValid())
 		return ade_set_error(L, "i", -1);
 
-	switch (bh->type)
+	switch (bh->typeh.type)
 	{
 	case SWH_PRIMARY:
 		if (ADE_SETTING_VAR) {
-			bh->sw->burst_seed[bh->bank] = newSeed;
+			bh->typeh.sw->burst_seed[bh->bank] = newSeed;
 		}
-		return ade_set_args(L, "i", bh->sw->burst_seed[bh->bank]);
+		return ade_set_args(L, "i", bh->typeh.sw->burst_seed[bh->bank]);
 	case SWH_SECONDARY:
 		if (ADE_SETTING_VAR) {
-			bh->sw->burst_seed[MAX_SHIP_PRIMARY_BANKS + bh->bank] = newSeed;
+			bh->typeh.sw->burst_seed[MAX_SHIP_PRIMARY_BANKS + bh->bank] = newSeed;
 		}
-		return ade_set_args(L, "i", bh->sw->burst_seed[MAX_SHIP_PRIMARY_BANKS + bh->bank]);
+		return ade_set_args(L, "i", bh->typeh.sw->burst_seed[MAX_SHIP_PRIMARY_BANKS + bh->bank]);
 	case SWH_TERTIARY:
 		LuaError(L, "Burst seed is not valid for tertiary banks!");
 		return ade_set_error(L, "i", -1);

--- a/code/scripting/api/objs/ship_bank.h
+++ b/code/scripting/api/objs/ship_bank.h
@@ -25,8 +25,9 @@ struct ship_banktype_h
 };
 DECLARE_ADE_OBJ(l_WeaponBankType, ship_banktype_h);
 
-struct ship_bank_h : public ship_banktype_h
+struct ship_bank_h
 {
+	ship_banktype_h typeh;
 	int bank;
 
 	ship_bank_h();

--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -68,7 +68,7 @@ ADE_FUNC(getFilename, l_SoundEntry, NULL, "Returns the filename of this sound. I
 	return ade_set_args(L, "s", seh->Get()->sound_entries[0].filename);
 }
 
-ADE_FUNC(getDuration, l_SoundEntry, NULL, "Gives the length of the sound in seconds. If the sound has multiple entries or a pitch range then the maximum duration of the sound will be returned.", "number", "the length, or -1 on error")
+ADE_FUNC(getDuration, l_SoundEntry, NULL, "Returns the length of the sound in seconds. If the sound has multiple entries or a pitch range then the maximum duration of the sound will be returned.", "number", "the length, or -1 on error")
 {
 	sound_entry_h *seh = NULL;
 
@@ -133,31 +133,30 @@ ADE_FUNC(tryLoad, l_SoundEntry, nullptr, "Detects whether handle references a so
 	return ade_set_args(L, "b", gamesnd_game_sound_try_load(seh->idx));
 }
 
-sound_h::sound_h() : sound_entry_h() { sig = sound_handle::invalid(); }
-sound_h::sound_h(gamesnd_id n_gs_idx, sound_handle n_sig) : sound_entry_h(n_gs_idx) { sig = n_sig; }
+sound_h::sound_h() : entryh(), sig(sound_handle::invalid()) {}
+sound_h::sound_h(gamesnd_id n_gs_idx, sound_handle n_sig) : entryh(n_gs_idx), sig(n_sig) {}
 sound_handle sound_h::getSignature() const
 {
-	// We can have both regular and raw file sounds here so we have to check both
-	// else even a valid signature is never returned.
-	if (!isValid() && !isSoundValid())
+	// We can have both regular and raw file sounds here, so the sound itself
+	// can be valid even if the soundentry is not.
+	if (!isValid())
 		return sound_handle::invalid();
 
 	return sig;
 }
-bool sound_h::isSoundValid() const {
+bool sound_h::isValid() const
+{
+	// We can have both regular and raw file sounds here, so the sound itself
+	// can be valid even if the soundentry is not.
 	if (!sig.isValid() || ds_get_channel(sig) < 0)
 		return false;
 
 	return true;
 }
-bool sound_h::isValid() const {
-	if(!sound_entry_h::isValid())
-		return false;
-
-	if (!sig.isValid() || ds_get_channel(sig) < 0)
-		return false;
-
-	return true;
+bool sound_h::isValidWithEntry() const
+{
+	// Check if the sound itself *and* its soundentry are both valid
+	return entryh.isValid() && isValid();
 }
 
 //**********HANDLE: Sound
@@ -170,7 +169,7 @@ ADE_VIRTVAR(Pitch, l_Sound, "number", "Pitch of sound, from 100 to 100000", "num
 	if(!ade_get_args(L, "o|i", l_Sound.GetPtr(&sh), &newpitch))
 		return ade_set_error(L, "f", 0.0f);
 
-	if (!sh->isSoundValid())
+	if (!sh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR)
@@ -192,7 +191,7 @@ ADE_FUNC(getRemainingTime, l_Sound, NULL, "The remaining time of this sound hand
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "f", -1.0f);
 
-	if (!sh->isSoundValid())
+	if (!sh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
 	int remaining = snd_time_remaining(sh->getSignature());
@@ -203,7 +202,7 @@ ADE_FUNC(getRemainingTime, l_Sound, NULL, "The remaining time of this sound hand
 ADE_FUNC(setVolume,
 	l_Sound,
 	"number, [boolean voice = false]",
-	"Sets the volume of this sound instance. Set voice to true to use the voice channel multiplier. False to use the "
+	"Sets the volume of this sound instance. Set voice to true to use the voice channel multiplier, or false to use the "
 	"effects channel multiplier",
 	"boolean",
 	"true if succeeded, false otherwise")
@@ -214,7 +213,7 @@ ADE_FUNC(setVolume,
 	if (!ade_get_args(L, "of|b", l_Sound.GetPtr(&sh), &newVol, &voice))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->isSoundValid())
+	if (!sh->isValid())
 		return ADE_RETURN_FALSE;
 
 	CAP(newVol, 0.0f, 1.0f);
@@ -224,14 +223,14 @@ ADE_FUNC(setVolume,
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(setPanning, l_Sound, "number", "Sets the panning of this sound. Argument ranges from -1 for left to 1 for right", "boolean", "true if succeeded, false otherwise")
+ADE_FUNC(setPanning, l_Sound, "number", "Sets the panning of this sound. Argument ranges from -1.0 for left to 1.0 for right", "boolean", "true if succeeded, false otherwise")
 {
 	sound_h *sh;
 	float newPan = -1.0f;
 	if(!ade_get_args(L, "of", l_Sound.GetPtr(&sh), &newPan))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->isSoundValid())
+	if (!sh->isValid())
 		return ADE_RETURN_FALSE;
 
 	CAP(newPan, -1.0f, 1.0f);
@@ -243,7 +242,7 @@ ADE_FUNC(setPanning, l_Sound, "number", "Sets the panning of this sound. Argumen
 
 
 ADE_FUNC(setPosition, l_Sound, "number value, boolean percent = true",
-		 "Sets the absolute position of the sound. If boolean argument is true then the value is given as a percentage<br>"
+		 "Sets the absolute position of the sound. If boolean argument is true then the value is given as a percentage.<br>"
 			 "This operation fails if there is no backing soundentry!",
 		 "boolean", "true if successful, false otherwise")
 {
@@ -253,7 +252,7 @@ ADE_FUNC(setPosition, l_Sound, "number value, boolean percent = true",
 	if(!ade_get_args(L, "of|b", l_Sound.GetPtr(&sh), &val, &percent))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->isValid())
+	if (!sh->isValidWithEntry())
 		return ADE_RETURN_FALSE;
 
 	if (val <= 0.0f)
@@ -272,7 +271,7 @@ ADE_FUNC(rewind, l_Sound, "number", "Rewinds the sound by the given number of se
 	if(!ade_get_args(L, "of", l_Sound.GetPtr(&sh), &val))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->isValid())
+	if (!sh->isValidWithEntry())
 		return ADE_RETURN_FALSE;
 
 	if (val <= 0.0f)
@@ -291,7 +290,7 @@ ADE_FUNC(skip, l_Sound, "number", "Skips the given number of seconds of the soun
 	if(!ade_get_args(L, "of", l_Sound.GetPtr(&sh), &val))
 		return ADE_RETURN_FALSE;
 
-	if (!sh->isValid())
+	if (!sh->isValidWithEntry())
 		return ADE_RETURN_FALSE;
 
 	if (val <= 0.0f)
@@ -302,13 +301,13 @@ ADE_FUNC(skip, l_Sound, "number", "Skips the given number of seconds of the soun
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(isPlaying, l_Sound, NULL, "Specifies if this handle is currently playing", "boolean", "true if playing, false if otherwise")
+ADE_FUNC(isPlaying, l_Sound, NULL, "Checks if this handle is currently playing", "boolean", "true if playing, false if otherwise")
 {
 	sound_h *sh;
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->isSoundValid())
+	if (!sh->isValid())
 		return ade_set_error(L, "b", false);
 
 	return ade_set_args(L, "b", snd_is_playing(sh->getSignature()) == 1);
@@ -320,7 +319,7 @@ ADE_FUNC(stop, l_Sound, NULL, "Stops the sound of this handle", "boolean", "true
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->isSoundValid())
+	if (!sh->isValid())
 		return ade_set_error(L, "b", false);
 
 	snd_stop(sh->getSignature());
@@ -334,7 +333,7 @@ ADE_FUNC(pause, l_Sound, NULL, "Pauses the sound of this handle", "boolean", "tr
 	if (!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->isSoundValid())
+	if (!sh->isValid())
 		return ade_set_error(L, "b", false);
 
 	if (snd_is_paused(sh->getSignature()))
@@ -351,7 +350,7 @@ ADE_FUNC(resume, l_Sound, NULL, "Resumes the sound of this handle", "boolean", "
 	if (!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->isSoundValid())
+	if (!sh->isValid())
 		return ade_set_error(L, "b", false);
 
 	if (!snd_is_paused(sh->getSignature()))
@@ -363,10 +362,20 @@ ADE_FUNC(resume, l_Sound, NULL, "Resumes the sound of this handle", "boolean", "
 }
 
 ADE_FUNC(isValid, l_Sound, nullptr,
-         "Detects whether the whole handle is valid.<br>"
-         "<b>Warning:</b> This does not work for sounds started by a "
-         "directly loaded sound file! Use isSoundValid() in that case instead.",
-         "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+         "Detects whether this sound, as well as its associated sound entry, are both valid.<br>"
+         "<b>Warning:</b> A sound can be usable without a sound entry! This function will not return true for sounds started by a "
+         "directly loaded sound file. Use isSoundValid() in that case instead.",
+         "boolean", "true if sound and entry are both valid, false if not, nil if a syntax/type error occurs")
+{
+	sound_h *sh;
+	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", sh->isValidWithEntry());
+}
+
+ADE_FUNC(isSoundValid, l_Sound, NULL, "Checks if the sound is valid without regard for whether the entry is valid. Should be used for non soundentry sounds.",
+		 "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
 {
 	sound_h *sh;
 	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
@@ -375,19 +384,13 @@ ADE_FUNC(isValid, l_Sound, nullptr,
 	return ade_set_args(L, "b", sh->isValid());
 }
 
-ADE_FUNC(isSoundValid, l_Sound, NULL, "Checks if only the sound is valid, should be used for non soundentry sounds",
-		 "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
-{
-	sound_h *sh;
-	if(!ade_get_args(L, "o", l_Sound.GetPtr(&sh)))
-		return ADE_RETURN_NIL;
-
-	return ade_set_args(L, "b", sh->isSoundValid());
-}
-
 ADE_OBJ_DERIV(l_Sound3D, sound_h, "sound3D", "3D sound instance handle", l_Sound);
 
-ADE_FUNC(updatePosition, l_Sound3D, "vector Position, [number radius = 0.0]", "Updates the given 3D sound with the specified position and an optional range value", "boolean", "true if succeesed, false otherwise")
+ADE_FUNC(updatePosition, l_Sound3D,
+	"vector Position, [number radius = 0.0]",
+	"Updates the given 3D sound with the specified position and an optional range value.<br>"
+		"This operation fails if there is no backing soundentry!",
+	"boolean", "true if succeeded, false otherwise")
 {
 	sound_h *sh;
 	vec3d *newPos = NULL;
@@ -396,10 +399,10 @@ ADE_FUNC(updatePosition, l_Sound3D, "vector Position, [number radius = 0.0]", "U
 	if(!ade_get_args(L, "oo|f", l_Sound.GetPtr(&sh), l_Vector.GetPtr(&newPos), &radius))
 		return ade_set_error(L, "b", false);
 
-	if (!sh->isValid() || newPos == NULL)
+	if (!sh->isValidWithEntry() || newPos == NULL)
 		return ade_set_error(L, "b", false);
 
-	snd_update_3d_pos(sh->getSignature(), sh->Get(), newPos, radius);
+	snd_update_3d_pos(sh->getSignature(), sh->entryh.Get(), newPos, radius);
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/scripting/api/objs/sound.h
+++ b/code/scripting/api/objs/sound.h
@@ -25,8 +25,9 @@ struct sound_entry_h
 //**********HANDLE: SoundEntry
 DECLARE_ADE_OBJ(l_SoundEntry, sound_entry_h);
 
-struct sound_h : public sound_entry_h
+struct sound_h
 {
+	sound_entry_h entryh;
 	sound_handle sig;
 
 	sound_h();
@@ -35,9 +36,8 @@ struct sound_h : public sound_entry_h
 
 	sound_handle getSignature() const;
 
-	bool isSoundValid() const;
-
-	bool isValid() const;
+	bool isValid() const;			// This is the function that is checked by ade_set_args
+	bool isValidWithEntry() const;
 };
 
 //**********HANDLE: Sound


### PR DESCRIPTION
Several handle types in the scripting API used inheritance where composition would be more appropriate.  This refactors those types, as well as removing the various handle types that were just aliases for `model_h`.  These are just the C++-side types; all the Lua types remain as-is.

This also refactors `sound_h` to move the previous `isSoundValid` to `isValid` so that `ade_set_args` will work properly for sounds with the `Lua_API_returns_nil_instead_of_invalid_object` flag.  The subclassing from `sound_entry_h` was removed and the "full validity check" was moved to `isValidWithEntry`.  The Lua side remains unaffected, but additional documentation was added to clarify the usage.

Follow-up to #6009 and prerequisite to #6006 due to the `isValid` refactor for `sound_h`.

Depends on #6009; ~~in draft until that is merged~~.