### PR TITLE
Fix retail options not saving

### DIFF
--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -29,6 +29,8 @@
 #include "missionui/missionscreencommon.h"
 #include "nebula/neb.h"
 #include "network/multi.h"
+#include "options/OptionsManager.h"
+#include "options/Option.h"
 #include "osapi/osregistry.h"
 #include "pilotfile/pilotfile.h"
 #include "popup/popup.h"
@@ -677,6 +679,11 @@ void options_cancel_exit()
 		Detail = Detail_original;
 	}
 
+	// We have to discard in game options here
+	if (Using_in_game_options) {
+		options::OptionsManager::instance()->discardChanges();
+	}
+
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }
 
@@ -701,6 +708,68 @@ void options_change_gamma(float delta)
 	sprintf(tmp_gamma_string, NOX("%.2f"), gamma);
 
 	os_config_write_string( NULL, NOX("GammaD3D"), tmp_gamma_string );
+
+	if (Using_in_game_options) {
+		const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey("Graphics.Gamma");
+		if (thisOpt != nullptr) {
+			auto val = thisOpt->getCurrentValueDescription();
+			SCP_string newVal = std::to_string(gamma);  // OptionsManager stores values as serialized strings
+			thisOpt->setValueDescription({val.display, newVal.c_str()});
+		}
+	}
+}
+
+void options_set_ingame_binary_option(SCP_string key, bool value)
+{
+	if (!Using_in_game_options) {
+		return;
+	}
+
+	const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey(key);
+	if (thisOpt != nullptr) {
+		auto val = thisOpt->getCurrentValueDescription();
+		SCP_string newVal = value ? "true" : "false";  // OptionsManager stores values as serialized strings
+		thisOpt->setValueDescription({val.display, newVal.c_str()});
+	}
+}
+
+void options_set_ingame_multi_option(SCP_string key, int value)
+{
+	if (!Using_in_game_options) {
+		return;
+	}
+
+	const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey(key);
+	if (thisOpt != nullptr) {
+		auto values = thisOpt->getValidValues();
+		thisOpt->setValueDescription(values[value]);
+	}
+}
+
+void options_set_ingame_range_option(SCP_string key, int value)
+{
+	if (!Using_in_game_options) {
+		return;
+	}
+
+	const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey(key);
+	if (thisOpt != nullptr) {
+		SCP_string newVal = std::to_string(value);  // OptionsManager stores values as serialized strings
+		thisOpt->setValueDescription({newVal.c_str(), newVal.c_str()});
+	}
+}
+
+void options_set_ingame_range_option(SCP_string key, float value)
+{
+	if (!Using_in_game_options) {
+		return;
+	}
+
+	const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey(key);
+	if (thisOpt != nullptr) {
+		SCP_string newVal = std::to_string(value);  // OptionsManager stores values as serialized strings
+		thisOpt->setValueDescription({newVal.c_str(), newVal.c_str()});
+	}
 }
 
 void options_button_pressed(int n)
@@ -751,6 +820,7 @@ void options_button_pressed(int n)
 
 			// BEGIN - detail level tab buttons
 
+			// Target View Rendering is currently not handled by in-game options, assumes "On"
 		case HUD_TARGETVIEW_RENDER_ON:
 			Detail.targetview_model = 1;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
@@ -761,6 +831,7 @@ void options_button_pressed(int n)
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
+			// Planets is currently not handled by in-game options, assumes "On"
 		case PLANETS_ON:
 			Detail.planets_suns = 1;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
@@ -771,6 +842,7 @@ void options_button_pressed(int n)
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
+			// Weapon extras is currently not handled by in-game options, assumes "On"
 		case WEAPON_EXTRAS_ON:
 			Detail.weapon_extras = 1;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
@@ -809,29 +881,35 @@ void options_button_pressed(int n)
 
 		case GAMMA_DOWN:
 			options_change_gamma(-0.05f);
+			// Gamma in-game change is handled in the above method
 			break;
 
 		case GAMMA_UP:
 			options_change_gamma(0.05f);
+			// Gamma in-game change is handled in the above method
 			break;
 
 		case BRIEF_VOICE_ON:
 			Briefing_voice_enabled = true;
+			options_set_ingame_binary_option("Audio.BriefingVoice", true);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case BRIEF_VOICE_OFF:
 			Briefing_voice_enabled = false;
+			options_set_ingame_binary_option("Audio.BriefingVoice", false);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case MOUSE_ON:
 			Use_mouse_to_fly = 1;
+			options_set_ingame_binary_option("Input.UseMouse", true);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case MOUSE_OFF:
 			Use_mouse_to_fly = 0;
+			options_set_ingame_binary_option("Input.UseMouse", false);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 	}
@@ -843,6 +921,7 @@ void options_sliders_update()
 	if (Options_sliders[gr_screen.res][OPT_SOUND_VOLUME_SLIDER].slider.pos != Sound_volume_int) {
 		Sound_volume_int = Options_sliders[gr_screen.res][OPT_SOUND_VOLUME_SLIDER].slider.pos;
 		snd_set_effects_volume((float) (Sound_volume_int) / 9.0f);
+		options_set_ingame_range_option("Audio.Effects", Master_sound_volume); // Volume options save the global float, not the range slider position
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
@@ -850,7 +929,7 @@ void options_sliders_update()
 	if (Options_sliders[gr_screen.res][OPT_MUSIC_VOLUME_SLIDER].slider.pos != Music_volume_int) {
 		Music_volume_int = Options_sliders[gr_screen.res][OPT_MUSIC_VOLUME_SLIDER].slider.pos;
 		event_music_set_volume((float) (Music_volume_int) / 9.0f);
-
+		options_set_ingame_range_option("Audio.Music", Master_event_music_volume); // Volume options save the global float, not the range slider position
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
@@ -858,28 +937,46 @@ void options_sliders_update()
 	if (Options_sliders[gr_screen.res][OPT_VOICE_VOLUME_SLIDER].slider.pos != Voice_volume_int) {
 		Voice_volume_int = Options_sliders[gr_screen.res][OPT_VOICE_VOLUME_SLIDER].slider.pos;
 		snd_set_voice_volume((float) (Voice_volume_int) / 9.0f);
+		options_set_ingame_range_option("Audio.Voice", Master_voice_volume); // Volume options save the global float, not the range slider position
 		options_play_voice_clip();
 	}
 
 	if (Mouse_sensitivity != Options_sliders[gr_screen.res][OPT_MOUSE_SENS_SLIDER].slider.pos) {
 		Mouse_sensitivity = Options_sliders[gr_screen.res][OPT_MOUSE_SENS_SLIDER].slider.pos;
+		options_set_ingame_range_option("Input.MouseSensitivity", Mouse_sensitivity);
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	if (Joy_sensitivity != Options_sliders[gr_screen.res][OPT_JOY_SENS_SLIDER].slider.pos) {
 		Joy_sensitivity = Options_sliders[gr_screen.res][OPT_JOY_SENS_SLIDER].slider.pos;
+		options_set_ingame_range_option("Input.JoystickSensitivity", Joy_sensitivity);
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	if (Joy_dead_zone_size != Options_sliders[gr_screen.res][OPT_JOY_DEADZONE_SLIDER].slider.pos * 5) {
 		Joy_dead_zone_size = Options_sliders[gr_screen.res][OPT_JOY_DEADZONE_SLIDER].slider.pos * 5;
+		options_set_ingame_range_option("Input.JoystickDeadZone", Joy_dead_zone_size);
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
 
 	if (Game_skill_level != Options_sliders[gr_screen.res][OPT_SKILL_SLIDER].slider.pos) {
 		Game_skill_level = Options_sliders[gr_screen.res][OPT_SKILL_SLIDER].slider.pos;
+		options_set_ingame_range_option("Game.SkillLevel", Game_skill_level);
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 	}
+}
+
+void options_detail_sliders_in_game_update()
+{
+	// Save in-game options settings
+	options_set_ingame_multi_option("Graphics.Detail", Detail.detail_distance);
+	options_set_ingame_multi_option("Graphics.NebulaDetail", Detail.nebula_detail);
+	options_set_ingame_multi_option("Graphics.Texture", Detail.hardware_textures);
+	options_set_ingame_multi_option("Graphics.Particles", Detail.num_particles);
+	options_set_ingame_multi_option("Graphics.SmallDebris", Detail.num_small_debris);
+	options_set_ingame_multi_option("Graphics.ShieldEffects", Detail.shield_effects);
+	options_set_ingame_multi_option("Graphics.Stars", Detail.num_stars);
+	options_set_ingame_multi_option("Graphics.Lighting", Detail.lighting);
 }
 
 void options_accept()
@@ -892,6 +989,15 @@ void options_accept()
 			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "PXO is selected but password or username is missing");
 			return;
 		}
+	}
+
+	// We have to save in game options here
+	if (Using_in_game_options) {
+		// detail sliders are updated every frame but it's silly to run OptionsManager every frame, too
+		// so just set them on Accept and then persist.
+		options_detail_sliders_in_game_update();
+
+		options::OptionsManager::instance()->persistChanges();
 	}
 
 	// If music is zero volume, disable
@@ -1192,6 +1298,10 @@ void options_menu_do_frame(float  /*frametime*/)
 
 		case KEY_F3: // SCP ingame options
 			if (Using_in_game_options) {
+				// Going into F3 Options needs to either discard or save the changes made here. 
+				// There's an argument to be made for both but I feel like saving is the better choice - Mjn
+				options::OptionsManager::instance()->persistChanges();
+
 				gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 				gameseq_post_event(GS_EVENT_INGAME_OPTIONS);
 			}

--- a/code/menuui/optionsmenu.h
+++ b/code/menuui/optionsmenu.h
@@ -39,6 +39,9 @@ void options_menu_init();
 void options_menu_close();
 void options_menu_do_frame(float frametime);
 
+// For optionsmenumulti.cpp
+void options_set_ingame_binary_option(SCP_string key, bool value);
+
 // kill the options menu
 void options_cancel_exit();
 

--- a/code/menuui/optionsmenumulti.cpp
+++ b/code/menuui/optionsmenumulti.cpp
@@ -1005,8 +1005,10 @@ void options_multi_protocol_button_pressed(int n)
 
 		if(!Om_local_broadcast){			
 			Om_local_broadcast = 1;
+			options_set_ingame_binary_option("Multi.LocalBroadcast", true);
 		} else {
 			Om_local_broadcast = 0;
+			options_set_ingame_binary_option("Multi.LocalBroadcast", false);
 		}
 
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
@@ -1048,10 +1050,12 @@ void options_multi_protocol_button_pressed(int n)
 			Om_tracker_login.enable();
 			Om_tracker_passwd.enable();
 			Om_tracker_squad_name.enable();
+			options_set_ingame_binary_option("Multi.TogglePXO", true);
 		} else {
 			Om_tracker_login.disable();
 			Om_tracker_passwd.disable();
 			Om_tracker_squad_name.disable();
+			options_set_ingame_binary_option("Multi.TogglePXO", false);
 		}
 
 		// play a sound
@@ -1539,6 +1543,7 @@ void options_multi_gen_button_pressed(int n)
 		if(!Om_gen_xfer_multidata){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_xfer_multidata = 1;
+			options_set_ingame_binary_option("Multi.TransferMissions", true);
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -1549,6 +1554,7 @@ void options_multi_gen_button_pressed(int n)
 		if(Om_gen_xfer_multidata){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_xfer_multidata = 0;
+			options_set_ingame_binary_option("Multi.TransferMissions", false);
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -1559,6 +1565,7 @@ void options_multi_gen_button_pressed(int n)
 		if(!Om_gen_flush_cache){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_flush_cache = 1;
+			options_set_ingame_binary_option("Multi.FlushCache", true);
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -1569,6 +1576,7 @@ void options_multi_gen_button_pressed(int n)
 		if(Om_gen_flush_cache){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			Om_gen_flush_cache = 0;
+			options_set_ingame_binary_option("Multi.FlushCache", false);
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}

--- a/code/options/OptionsManager.cpp
+++ b/code/options/OptionsManager.cpp
@@ -111,6 +111,17 @@ void OptionsManager::removeOption(const OptionBase* option)
 	                   [option](const std::unique_ptr<const OptionBase>& ptr) { return ptr.get() == option; }));
 }
 
+// Returns an option with the specified name
+const OptionBase* OptionsManager::getOptionByKey(SCP_string key)
+{
+	for (size_t i = 0; i < _options.size(); i++) {
+		if (_options[i].get()->getConfigKey() == key) {
+			return _options[i].get();
+		}
+	}
+	return nullptr;
+}
+
 //Returns a table of all built-in options available
 const SCP_vector<std::unique_ptr<const options::OptionBase>>& OptionsManager::getOptions()
 {

--- a/code/options/OptionsManager.h
+++ b/code/options/OptionsManager.h
@@ -36,6 +36,8 @@ class OptionsManager {
 
 	void removeOption(const OptionBase* option);
 
+	const OptionBase* OptionsManager::getOptionByKey(SCP_string name);
+
 	const SCP_vector<std::unique_ptr<const options::OptionBase>>& getOptions();
 
 	bool persistOptionChanges(const options::OptionBase* option);

--- a/code/options/OptionsManager.h
+++ b/code/options/OptionsManager.h
@@ -36,7 +36,7 @@ class OptionsManager {
 
 	void removeOption(const OptionBase* option);
 
-	const OptionBase* OptionsManager::getOptionByKey(SCP_string name);
+	const OptionBase* getOptionByKey(SCP_string name);
 
 	const SCP_vector<std::unique_ptr<const options::OptionBase>>& getOptions();
 


### PR DESCRIPTION
#5895 turned `Using_in_game_options` on by default. This caused FSO to load all options from the new Options Manager values rather than the old registry values. Since retail obviously doesn't use SCPUI, we need to make sure that we then properly save retail options values to Options Manager also.