### PR TITLE
Fix CTD with HUD Preset Switching

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1323,10 +1323,8 @@ void hud_config_button_do(int n)
 			break;
 		}
 
-		if (HC_current_file >= (int)HC_preset_filenames.size()) {
+		if ((++HC_current_file) >= (int)HC_preset_filenames.size()) {
 			HC_current_file = 0;
-		} else {
-			HC_current_file++;
 		}
 
 		// load em up		

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1323,7 +1323,7 @@ void hud_config_button_do(int n)
 			break;
 		}
 
-		if ((++HC_current_file) >= (int)HC_preset_filenames.size()) {
+		if ((++HC_current_file) >= static_cast<int> (HC_preset_filenames.size())) {
 			HC_current_file = 0;
 		}
 


### PR DESCRIPTION
After #5302 it was discoved that pressing the `Next` button in the HUD presets would cause a CTD.

Thanks for @BMagnu for figuring this out
`If HC_current_file is HC_preset_filenames.size() - 1, then it'll oob on a vector access.`

Testing this PR fixes that crash.