### PR TITLE
add weapon preloader

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4712,6 +4712,20 @@ int get_sexp()
 				do_preload_for_arguments(preload_turret_change_weapon, n, arg_handler);
 				break;
 
+			case OP_WEAPON_CREATE:
+				// weapon class is argument #2
+				n = CDDR(start);
+				// just as with change-ship-class/ship-create, we can use the turret-change-weapon preloader for weapon-create
+				do_preload_for_arguments(preload_turret_change_weapon, n, arg_handler);
+				break;
+
+			case OP_BEAM_FLOATING_FIRE:
+				// beam weapon class is argument #1
+				n = CDR(start);
+				// see above for weapon-create
+				do_preload_for_arguments(preload_turret_change_weapon, n, arg_handler);
+				break;
+
 			case OP_CHANGE_BACKGROUND:
 				n = CDR(start);
 				do_preload_for_arguments(stars_preload_background, n, arg_handler);


### PR DESCRIPTION
`ship-create` has had a preloader for many years, but `weapon-create` and `beam-create` did not.  This remedies that.