### PR TITLE
add support for decompression of DDS textures

### DIFF
--- a/code/bmpman/bmpman.cpp
+++ b/code/bmpman/bmpman.cpp
@@ -1027,10 +1027,6 @@ int bm_is_compressed(int num) {
 	auto entry = bm_get_entry(num);
 	BM_TYPE type = BM_TYPE_NONE;
 
-	//duh
-	if (!Use_compressed_textures)
-		return 0;
-
 	type = entry->comp_type;
 
 	switch (type) {

--- a/code/ddsutils/bcdec.h
+++ b/code/ddsutils/bcdec.h
@@ -1,0 +1,1329 @@
+﻿/* bcdec.h - v0.96
+   provides functions to decompress blocks of BC compressed images
+   written by Sergii "iOrange" Kudlai in 2022
+
+   This library does not allocate memory and is trying to use as less stack as possible
+
+   The library was never optimized specifically for speed but for the overall size
+   it has zero external dependencies and is not using any runtime functions
+
+   Supported BC formats:
+   BC1 (also known as DXT1) + it's "binary alpha" variant BC1A (DXT1A)
+   BC2 (also known as DXT3)
+   BC3 (also known as DXT5)
+   BC4 (also known as ATI1N)
+   BC5 (also known as ATI2N)
+   BC6H (HDR format)
+   BC7
+
+   BC1/BC2/BC3/BC7 are expected to decompress into 4*4 RGBA blocks 8bit per component (32bit pixel)
+   BC4/BC5 are expected to decompress into 4*4 R/RG blocks 8bit per component (8bit and 16bit pixel)
+   BC6H is expected to decompress into 4*4 RGB blocks of either 32bit float or 16bit "half" per
+   component (96bit or 48bit pixel)
+
+   For more info, issues and suggestions please visit https://github.com/iOrange/bcdec
+
+   CREDITS:
+      Aras Pranckevicius (@aras-p)      - BC1/BC3 decoders optimizations (up to 3x the speed)
+                                        - BC6H/BC7 bits pulling routines optimizations
+                                        - optimized BC6H by moving unquantize out of the loop
+                                        - Split BC6H decompression function into 'half' and
+                                          'float' variants
+
+   bugfixes:
+      @linkmauve
+
+   LICENSE: See end of file for license information.
+*/
+
+#ifndef BCDEC_HEADER_INCLUDED
+#define BCDEC_HEADER_INCLUDED
+
+/* if BCDEC_STATIC causes problems, try defining BCDECDEF to 'inline' or 'static inline' */
+#ifndef BCDECDEF
+#ifdef BCDEC_STATIC
+#define BCDECDEF    static
+#else
+#ifdef __cplusplus
+#define BCDECDEF    extern "C"
+#else
+#define BCDECDEF    extern
+#endif
+#endif
+#endif
+
+/*  Used information sources:
+    https://docs.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression
+    https://docs.microsoft.com/en-us/windows/win32/direct3d11/bc6h-format
+    https://docs.microsoft.com/en-us/windows/win32/direct3d11/bc7-format
+    https://docs.microsoft.com/en-us/windows/win32/direct3d11/bc7-format-mode-reference
+
+    ! WARNING ! Khronos's BPTC partitions tables contain mistakes, do not use them!
+    https://www.khronos.org/registry/DataFormat/specs/1.1/dataformat.1.1.html#BPTC
+
+    ! Use tables from here instead !
+    https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_compression_bptc.txt
+
+    Leaving it here as it's a nice read
+    https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/
+
+    Fast half to float function from here
+    https://gist.github.com/rygorous/2144712
+*/
+
+#define BCDEC_BC1_BLOCK_SIZE    8
+#define BCDEC_BC2_BLOCK_SIZE    16
+#define BCDEC_BC3_BLOCK_SIZE    16
+#define BCDEC_BC4_BLOCK_SIZE    8
+#define BCDEC_BC5_BLOCK_SIZE    16
+#define BCDEC_BC6H_BLOCK_SIZE   16
+#define BCDEC_BC7_BLOCK_SIZE    16
+
+#define BCDEC_BC1_COMPRESSED_SIZE(w, h)     ((((w)>>2)*((h)>>2))*BCDEC_BC1_BLOCK_SIZE)
+#define BCDEC_BC2_COMPRESSED_SIZE(w, h)     ((((w)>>2)*((h)>>2))*BCDEC_BC2_BLOCK_SIZE)
+#define BCDEC_BC3_COMPRESSED_SIZE(w, h)     ((((w)>>2)*((h)>>2))*BCDEC_BC3_BLOCK_SIZE)
+#define BCDEC_BC4_COMPRESSED_SIZE(w, h)     ((((w)>>2)*((h)>>2))*BCDEC_BC4_BLOCK_SIZE)
+#define BCDEC_BC5_COMPRESSED_SIZE(w, h)     ((((w)>>2)*((h)>>2))*BCDEC_BC5_BLOCK_SIZE)
+#define BCDEC_BC6H_COMPRESSED_SIZE(w, h)    ((((w)>>2)*((h)>>2))*BCDEC_BC6H_BLOCK_SIZE)
+#define BCDEC_BC7_COMPRESSED_SIZE(w, h)     ((((w)>>2)*((h)>>2))*BCDEC_BC7_BLOCK_SIZE)
+
+BCDECDEF void bcdec_bc1(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
+BCDECDEF void bcdec_bc2(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
+BCDECDEF void bcdec_bc3(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
+BCDECDEF void bcdec_bc4(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
+BCDECDEF void bcdec_bc5(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
+BCDECDEF void bcdec_bc6h_float(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned);
+BCDECDEF void bcdec_bc6h_half(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned);
+BCDECDEF void bcdec_bc7(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
+
+
+#ifdef BCDEC_IMPLEMENTATION
+
+static void bcdec__color_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int onlyOpaqueMode) {
+    unsigned short c0, c1;
+    unsigned int refColors[4]; /* 0xAABBGGRR */
+    unsigned char* dstColors;
+    unsigned int colorIndices;
+    int i, j, idx;
+    unsigned int r0, g0, b0, r1, g1, b1, r, g, b;
+
+    c0 = ((unsigned short*)compressedBlock)[0];
+    c1 = ((unsigned short*)compressedBlock)[1];
+
+    /* Expand 565 ref colors to 888 */
+    r0 = (((c0 >> 11) & 0x1F) * 527 + 23) >> 6;
+    g0 = (((c0 >> 5)  & 0x3F) * 259 + 33) >> 6;
+    b0 =  ((c0        & 0x1F) * 527 + 23) >> 6;
+    refColors[0] = 0xFF000000 | (b0 << 16) | (g0 << 8) | r0;
+
+    r1 = (((c1 >> 11) & 0x1F) * 527 + 23) >> 6;
+    g1 = (((c1 >> 5)  & 0x3F) * 259 + 33) >> 6;
+    b1 =  ((c1        & 0x1F) * 527 + 23) >> 6;
+    refColors[1] = 0xFF000000 | (b1 << 16) | (g1 << 8) | r1;
+
+    if (c0 > c1 || onlyOpaqueMode) {    /* Standard BC1 mode (also BC3 color block uses ONLY this mode) */
+        /* color_2 = 2/3*color_0 + 1/3*color_1
+           color_3 = 1/3*color_0 + 2/3*color_1 */
+        r = (2 * r0 + r1 + 1) / 3;
+        g = (2 * g0 + g1 + 1) / 3;
+        b = (2 * b0 + b1 + 1) / 3;
+        refColors[2] = 0xFF000000 | (b << 16) | (g << 8) | r;
+
+        r = (r0 + 2 * r1 + 1) / 3;
+        g = (g0 + 2 * g1 + 1) / 3;
+        b = (b0 + 2 * b1 + 1) / 3;
+        refColors[3] = 0xFF000000 | (b << 16) | (g << 8) | r;
+    } else {                            /* Quite rare BC1A mode */
+        /* color_2 = 1/2*color_0 + 1/2*color_1;
+           color_3 = 0;                         */
+        r = (r0 + r1 + 1) >> 1;
+        g = (g0 + g1 + 1) >> 1;
+        b = (b0 + b1 + 1) >> 1;
+        refColors[2] = 0xFF000000 | (b << 16) | (g << 8) | r;
+
+        refColors[3] = 0x00000000;
+    }
+
+    colorIndices = ((unsigned int*)compressedBlock)[1];
+
+    /* Fill out the decompressed color block */
+    dstColors = (unsigned char*)decompressedBlock;
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            idx = colorIndices & 0x03;
+            ((unsigned int*)dstColors)[j] = refColors[idx];
+            colorIndices >>= 2;
+        }
+
+        dstColors += destinationPitch;
+    }
+}
+
+static void bcdec__sharp_alpha_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
+    unsigned short* alpha;
+    unsigned char* decompressed;
+    int i, j;
+
+    alpha = (unsigned short*)compressedBlock;
+    decompressed = (unsigned char*)decompressedBlock;
+
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            decompressed[j * 4] = ((alpha[i] >> (4 * j)) & 0x0F) * 17;
+        }
+
+        decompressed += destinationPitch;
+    }
+}
+
+static void bcdec__smooth_alpha_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int pixelSize) {
+    unsigned char* decompressed;
+    unsigned char alpha[8];
+    int i, j;
+    unsigned long long block, indices;
+
+    block = *(unsigned long long*)compressedBlock;
+    decompressed = (unsigned char*)decompressedBlock;
+
+    alpha[0] = block & 0xFF;
+    alpha[1] = (block >> 8) & 0xFF;
+
+    if (alpha[0] > alpha[1]) {
+        /* 6 interpolated alpha values. */
+        alpha[2] = (6 * alpha[0] +     alpha[1] + 1) / 7;   /* 6/7*alpha_0 + 1/7*alpha_1 */
+        alpha[3] = (5 * alpha[0] + 2 * alpha[1] + 1) / 7;   /* 5/7*alpha_0 + 2/7*alpha_1 */
+        alpha[4] = (4 * alpha[0] + 3 * alpha[1] + 1) / 7;   /* 4/7*alpha_0 + 3/7*alpha_1 */
+        alpha[5] = (3 * alpha[0] + 4 * alpha[1] + 1) / 7;   /* 3/7*alpha_0 + 4/7*alpha_1 */
+        alpha[6] = (2 * alpha[0] + 5 * alpha[1] + 1) / 7;   /* 2/7*alpha_0 + 5/7*alpha_1 */
+        alpha[7] = (    alpha[0] + 6 * alpha[1] + 1) / 7;   /* 1/7*alpha_0 + 6/7*alpha_1 */
+    }
+    else {
+        /* 4 interpolated alpha values. */
+        alpha[2] = (4 * alpha[0] +     alpha[1] + 1) / 5;   /* 4/5*alpha_0 + 1/5*alpha_1 */
+        alpha[3] = (3 * alpha[0] + 2 * alpha[1] + 1) / 5;   /* 3/5*alpha_0 + 2/5*alpha_1 */
+        alpha[4] = (2 * alpha[0] + 3 * alpha[1] + 1) / 5;   /* 2/5*alpha_0 + 3/5*alpha_1 */
+        alpha[5] = (    alpha[0] + 4 * alpha[1] + 1) / 5;   /* 1/5*alpha_0 + 4/5*alpha_1 */
+        alpha[6] = 0x00;
+        alpha[7] = 0xFF;
+    }
+
+    indices = block >> 16;
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            decompressed[j * pixelSize] = alpha[indices & 0x07];
+            indices >>= 3;
+        }
+
+        decompressed += destinationPitch;
+    }
+}
+
+typedef struct bcdec__bitstream {
+    unsigned long long low;
+    unsigned long long high;
+} bcdec__bitstream_t;
+
+static int bcdec__bitstream_read_bits(bcdec__bitstream_t* bstream, int numBits) {
+    unsigned int mask = (1 << numBits) - 1;
+    /* Read the low N bits */
+    unsigned int bits = (bstream->low & mask);
+
+    bstream->low >>= numBits;
+    /* Put the low N bits of "high" into the high 64-N bits of "low". */
+    bstream->low |= (bstream->high & mask) << (sizeof(bstream->high) * 8 - numBits);
+    bstream->high >>= numBits;
+    
+    return bits;
+}
+
+static int bcdec__bitstream_read_bit(bcdec__bitstream_t* bstream) {
+    return bcdec__bitstream_read_bits(bstream, 1);
+}
+
+/*  reversed bits pulling, used in BC6H decoding
+    why ?? just why ??? */
+static int bcdec__bitstream_read_bits_r(bcdec__bitstream_t* bstream, int numBits) {
+    int bits = bcdec__bitstream_read_bits(bstream, numBits);
+    /* Reverse the bits. */
+    int result = 0;
+    while (numBits--) {
+        result <<= 1;
+        result |= (bits & 1);
+        bits >>= 1;
+    }
+    return result;
+}
+
+
+
+BCDECDEF void bcdec_bc1(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
+    bcdec__color_block(compressedBlock, decompressedBlock, destinationPitch, 0);
+}
+
+BCDECDEF void bcdec_bc2(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
+    bcdec__color_block(((char*)compressedBlock) + 8, decompressedBlock, destinationPitch, 1);
+    bcdec__sharp_alpha_block(compressedBlock, ((char*)decompressedBlock) + 3, destinationPitch);
+}
+
+BCDECDEF void bcdec_bc3(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
+    bcdec__color_block(((char*)compressedBlock) + 8, decompressedBlock, destinationPitch, 1);
+    bcdec__smooth_alpha_block(compressedBlock, ((char*)decompressedBlock) + 3, destinationPitch, 4);
+}
+
+BCDECDEF void bcdec_bc4(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
+    bcdec__smooth_alpha_block(compressedBlock, decompressedBlock, destinationPitch, 1);
+}
+
+BCDECDEF void bcdec_bc5(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
+    bcdec__smooth_alpha_block(compressedBlock, decompressedBlock, destinationPitch, 2);
+    bcdec__smooth_alpha_block(((char*)compressedBlock) + 8, ((char*)decompressedBlock) + 1, destinationPitch, 2);
+}
+
+/* http://graphics.stanford.edu/~seander/bithacks.html#VariableSignExtend */
+static int bcdec__extend_sign(int val, int bits) {
+    return (val << (32 - bits)) >> (32 - bits);
+}
+
+static int bcdec__transform_inverse(int val, int a0, int bits, int isSigned) {
+    /* If the precision of A0 is "p" bits, then the transform algorithm is:
+       B0 = (B0 + A0) & ((1 << p) - 1) */
+    val = (val + a0) & ((1 << bits) - 1);
+    if (isSigned) {
+        val = bcdec__extend_sign(val, bits);
+    }
+    return val;
+}
+
+/* pretty much copy-paste from documentation */
+static int bcdec__unquantize(int val, int bits, int isSigned) {
+    int unq, s = 0;
+
+    if (!isSigned) {
+        if (bits >= 15) {
+            unq = val;
+        } else if (!val) {
+            unq = 0;
+        } else if (val == ((1 << bits) - 1)) {
+            unq = 0xFFFF;
+        } else {
+            unq = ((val << 16) + 0x8000) >> bits;
+        }
+    } else {
+        if (bits >= 16) {
+            unq = val;
+        } else {
+            if (val < 0) {
+                s = 1;
+                val = -val;
+            }
+
+            if (val == 0) {
+                unq = 0;
+            } else if (val >= ((1 << (bits - 1)) - 1)) {
+                unq = 0x7FFF;
+            } else {
+                unq = ((val << 15) + 0x4000) >> (bits - 1);
+            }
+
+            if (s) {
+                unq = -unq;
+            }
+        }
+    }
+    return unq;
+}
+
+static int bcdec__interpolate(int a, int b, int* weights, int index) {
+    return (a * (64 - weights[index]) + b * weights[index] + 32) >> 6;
+}
+
+static unsigned short bcdec__finish_unquantize(int val, int isSigned) {
+    int s;
+
+    if (!isSigned) {
+        return (unsigned short)((val * 31) >> 6);                   /* scale the magnitude by 31 / 64 */
+    } else {
+        val = (val < 0) ? -(((-val) * 31) >> 5) : (val * 31) >> 5;  /* scale the magnitude by 31 / 32 */
+        s = 0;
+        if (val < 0) {
+            s = 0x8000;
+            val = -val;
+        }
+        return (unsigned short)(s | val);
+    }
+}
+
+/* modified half_to_float_fast4 from https://gist.github.com/rygorous/2144712 */
+static float bcdec__half_to_float_quick(unsigned short half) {
+    typedef union {
+        unsigned int u;
+        float f;
+    } FP32;
+
+    static const FP32 magic = { 113 << 23 };
+    static const unsigned int shifted_exp = 0x7c00 << 13;   /* exponent mask after shift */
+    FP32 o;
+    unsigned int exp;
+
+    o.u = (half & 0x7fff) << 13;                            /* exponent/mantissa bits */
+    exp = shifted_exp & o.u;                                /* just the exponent */
+    o.u += (127 - 15) << 23;                                /* exponent adjust */
+
+    /* handle exponent special cases */
+    if (exp == shifted_exp) {                               /* Inf/NaN? */
+        o.u += (128 - 16) << 23;                            /* extra exp adjust */
+    } else if (exp == 0) {                                  /* Zero/Denormal? */
+        o.u += 1 << 23;                                     /* extra exp adjust */
+        o.f -= magic.f;                                     /* renormalize */
+    }
+
+    o.u |= (half & 0x8000) << 16;                           /* sign bit */
+    return o.f;
+}
+
+BCDECDEF void bcdec_bc6h_half(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned) {
+    static char actual_bits_count[4][14] = {
+        { 10, 7, 11, 11, 11, 9, 8, 8, 8, 6, 10, 11, 12, 16 },   /*  W */
+        {  5, 6,  5,  4,  4, 5, 6, 5, 5, 6, 10,  9,  8,  4 },   /* dR */
+        {  5, 6,  4,  5,  4, 5, 5, 6, 5, 6, 10,  9,  8,  4 },   /* dG */
+        {  5, 6,  4,  4,  5, 5, 5, 5, 6, 6, 10,  9,  8,  4 }    /* dB */
+    };
+
+    /* There are 32 possible partition sets for a two-region tile.
+       Each 4x4 block represents a single shape.
+       Here also every fix-up index has MSB bit set. */
+    static unsigned char partition_sets[32][4][4] = {
+        { {128, 0,   1, 1}, {0, 0, 1, 1}, {  0, 0, 1, 1}, {0, 0, 1, 129} },   /*  0 */
+        { {128, 0,   0, 1}, {0, 0, 0, 1}, {  0, 0, 0, 1}, {0, 0, 0, 129} },   /*  1 */
+        { {128, 1,   1, 1}, {0, 1, 1, 1}, {  0, 1, 1, 1}, {0, 1, 1, 129} },   /*  2 */
+        { {128, 0,   0, 1}, {0, 0, 1, 1}, {  0, 0, 1, 1}, {0, 1, 1, 129} },   /*  3 */
+        { {128, 0,   0, 0}, {0, 0, 0, 1}, {  0, 0, 0, 1}, {0, 0, 1, 129} },   /*  4 */
+        { {128, 0,   1, 1}, {0, 1, 1, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} },   /*  5 */
+        { {128, 0,   0, 1}, {0, 0, 1, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} },   /*  6 */
+        { {128, 0,   0, 0}, {0, 0, 0, 1}, {  0, 0, 1, 1}, {0, 1, 1, 129} },   /*  7 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {  0, 0, 0, 1}, {0, 0, 1, 129} },   /*  8 */
+        { {128, 0,   1, 1}, {0, 1, 1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} },   /*  9 */
+        { {128, 0,   0, 0}, {0, 0, 0, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} },   /* 10 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {  0, 0, 0, 1}, {0, 1, 1, 129} },   /* 11 */
+        { {128, 0,   0, 1}, {0, 1, 1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} },   /* 12 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {  1, 1, 1, 1}, {1, 1, 1, 129} },   /* 13 */
+        { {128, 0,   0, 0}, {1, 1, 1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} },   /* 14 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {  0, 0, 0, 0}, {1, 1, 1, 129} },   /* 15 */
+        { {128, 0,   0, 0}, {1, 0, 0, 0}, {  1, 1, 1, 0}, {1, 1, 1, 129} },   /* 16 */
+        { {128, 1, 129, 1}, {0, 0, 0, 1}, {  0, 0, 0, 0}, {0, 0, 0,   0} },   /* 17 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {129, 0, 0, 0}, {1, 1, 1,   0} },   /* 18 */
+        { {128, 1, 129, 1}, {0, 0, 1, 1}, {  0, 0, 0, 1}, {0, 0, 0,   0} },   /* 19 */
+        { {128, 0, 129, 1}, {0, 0, 0, 1}, {  0, 0, 0, 0}, {0, 0, 0,   0} },   /* 20 */
+        { {128, 0,   0, 0}, {1, 0, 0, 0}, {129, 1, 0, 0}, {1, 1, 1,   0} },   /* 21 */
+        { {128, 0,   0, 0}, {0, 0, 0, 0}, {129, 0, 0, 0}, {1, 1, 0,   0} },   /* 22 */
+        { {128, 1,   1, 1}, {0, 0, 1, 1}, {  0, 0, 1, 1}, {0, 0, 0, 129} },   /* 23 */
+        { {128, 0, 129, 1}, {0, 0, 0, 1}, {  0, 0, 0, 1}, {0, 0, 0,   0} },   /* 24 */
+        { {128, 0,   0, 0}, {1, 0, 0, 0}, {129, 0, 0, 0}, {1, 1, 0,   0} },   /* 25 */
+        { {128, 1, 129, 0}, {0, 1, 1, 0}, {  0, 1, 1, 0}, {0, 1, 1,   0} },   /* 26 */
+        { {128, 0, 129, 1}, {0, 1, 1, 0}, {  0, 1, 1, 0}, {1, 1, 0,   0} },   /* 27 */
+        { {128, 0,   0, 1}, {0, 1, 1, 1}, {129, 1, 1, 0}, {1, 0, 0,   0} },   /* 28 */
+        { {128, 0,   0, 0}, {1, 1, 1, 1}, {129, 1, 1, 1}, {0, 0, 0,   0} },   /* 29 */
+        { {128, 1, 129, 1}, {0, 0, 0, 1}, {  1, 0, 0, 0}, {1, 1, 1,   0} },   /* 30 */
+        { {128, 0, 129, 1}, {1, 0, 0, 1}, {  1, 0, 0, 1}, {1, 1, 0,   0} }    /* 31 */
+    };
+
+    static int aWeight3[8] = { 0, 9, 18, 27, 37, 46, 55, 64 };
+    static int aWeight4[16] = { 0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64 };
+
+    bcdec__bitstream_t bstream;
+    int mode, partition, numPartitions, i, j, partitionSet, indexBits, index, ep_i, actualBits0Mode;
+    int r[4], g[4], b[4];       /* wxyz */
+    unsigned short* decompressed;
+    int* weights;
+
+    decompressed = (unsigned short*)decompressedBlock;
+
+    bstream.low = ((unsigned long long*)compressedBlock)[0];
+    bstream.high = ((unsigned long long*)compressedBlock)[1];
+
+    r[0] = r[1] = r[2] = r[3] = 0;
+    g[0] = g[1] = g[2] = g[3] = 0;
+    b[0] = b[1] = b[2] = b[3] = 0;
+
+    mode = bcdec__bitstream_read_bits(&bstream, 2);
+    if (mode > 1) {
+        mode |= (bcdec__bitstream_read_bits(&bstream, 3) << 2);
+    }
+
+    /* modes >= 11 (10 in my code) are using 0 one, others will read it from the bitstream */
+    partition = 0;
+
+    switch (mode) {
+        /* mode 1 */
+        case 0b00: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 75 bits (10.555, 10.555, 10.555) */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rx[4:0] */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 0;
+        } break;
+
+        /* mode 2 */
+        case 0b01: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 75 bits (7666, 7666, 7666) */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* gy[5]   */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* gz[5]   */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 7);        /* rw[6:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 7);        /* gw[6:0] */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* by[5]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 7);        /* bw[6:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* bz[5]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* rx[5:0] */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* gx[5:0] */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* bx[5:0] */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 6);        /* ry[5:0] */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 6);        /* rz[5:0] */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 1;
+        } break;
+
+        /* mode 3 */
+        case 0b00010: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (11.555, 11.444, 11.444) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rx[4:0] */
+            r[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* rw[10]  */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gx[3:0] */
+            g[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* gw[10]  */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* bx[3:0] */
+            b[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* bw[10]  */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 2;
+        } break;
+
+        /* mode 4 */
+        case 0b00110: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (11.444, 11.555, 11.444) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* rx[3:0] */
+            r[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* rw[10]  */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            g[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* gw[10]  */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* bx[3:0] */
+            b[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* bw[10]  */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* ry[3:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* rz[3:0] */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 3;
+        } break;
+
+        /* mode 5 */
+        case 0b01010: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (11.444, 11.444, 11.555) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* rx[3:0] */
+            r[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* rw[10]  */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gx[3:0] */
+            g[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* gw[10]  */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* bw[10]  */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* ry[3:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* rz[3:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */ 
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 4;
+        } break;
+
+        /* mode 6 */
+        case 0b01110: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (9555, 9555, 9555) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 9);        /* rw[8:0] */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 9);        /* gw[8:0] */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 9);        /* bw[8:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rx[4:0] */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gx[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 5;
+        } break;
+
+        /* mode 7 */
+        case 0b10010: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (8666, 8555, 8555) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* rw[7:0] */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* gw[7:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* bw[7:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* rx[5:0] */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 6);        /* ry[5:0] */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 6);        /* rz[5:0] */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 6;
+        } break;
+
+        /* mode 8 */
+        case 0b10110: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (8555, 8666, 8555) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* rw[7:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* gw[7:0] */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* gy[5]   */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* bw[7:0] */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* gz[5]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rx[4:0] */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* gx[5:0] */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* zx[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* bx[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 7;
+        } break;
+
+        /* mode 9 */
+        case 0b11010: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (8555, 8555, 8666) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* rw[7:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* gw[7:0] */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* by[5]   */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 8);        /* bw[7:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* bz[5]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* bw[4:0] */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 5);        /* gx[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* bx[5:0] */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 5);        /* ry[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 5);        /* rz[4:0] */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 8;
+        } break;
+
+        /* mode 10 */
+        case 0b11110: {
+            /* Partitition indices: 46 bits
+               Partition: 5 bits
+               Color Endpoints: 72 bits (6666, 6666, 6666) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 6);        /* rw[5:0] */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gz[4]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream);            /* bz[0]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 1;       /* bz[1]   */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* by[4]   */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 6);        /* gw[5:0] */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* gy[5]   */
+            b[2] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* by[5]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 2;       /* bz[2]   */
+            g[2] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* gy[4]   */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 6);        /* bw[5:0] */
+            g[3] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* gz[5]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 3;       /* bz[3]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 5;       /* bz[5]   */
+            b[3] |= bcdec__bitstream_read_bit(&bstream) << 4;       /* bz[4]   */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* rx[5:0] */
+            g[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gy[3:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* gx[5:0] */
+            g[3] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gz[3:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 6);        /* bx[5:0] */
+            b[2] |= bcdec__bitstream_read_bits(&bstream, 4);        /* by[3:0] */
+            r[2] |= bcdec__bitstream_read_bits(&bstream, 6);        /* ry[5:0] */
+            r[3] |= bcdec__bitstream_read_bits(&bstream, 6);        /* rz[5:0] */
+            partition = bcdec__bitstream_read_bits(&bstream, 5);    /* d[4:0]  */
+            mode = 9;
+        } break;
+
+        /* mode 11 */
+        case 0b00011: {
+            /* Partitition indices: 63 bits
+               Partition: 0 bits
+               Color Endpoints: 60 bits (10.10, 10.10, 10.10) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rx[9:0] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gx[9:0] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bx[9:0] */
+            mode = 10;
+        } break;
+
+        /* mode 12 */
+        case 0b00111: {
+            /* Partitition indices: 63 bits
+               Partition: 0 bits
+               Color Endpoints: 60 bits (11.9, 11.9, 11.9) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 9);        /* rx[8:0] */
+            r[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* rw[10]  */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 9);        /* gx[8:0] */
+            g[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* gw[10]  */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 9);        /* bx[8:0] */
+            b[0] |= bcdec__bitstream_read_bit(&bstream) << 10;      /* bw[10]  */
+            mode = 11;
+        } break;
+
+        /* mode 13 */
+        case 0b01011: {
+            /* Partitition indices: 63 bits
+               Partition: 0 bits
+               Color Endpoints: 60 bits (12.8, 12.8, 12.8) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 8);        /* rx[7:0] */
+            r[0] |= bcdec__bitstream_read_bits_r(&bstream, 2) << 10;/* rx[10:11] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 8);        /* gx[7:0] */
+            g[0] |= bcdec__bitstream_read_bits_r(&bstream, 2) << 10;/* gx[10:11] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 8);        /* bx[7:0] */
+            b[0] |= bcdec__bitstream_read_bits_r(&bstream, 2) << 10;/* bx[10:11] */
+            mode = 12;
+        } break;
+
+        /* mode 14 */
+        case 0b01111: {
+            /* Partitition indices: 63 bits
+               Partition: 0 bits
+               Color Endpoints: 60 bits (16.4, 16.4, 16.4) */
+            r[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* rw[9:0] */
+            g[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* gw[9:0] */
+            b[0] |= bcdec__bitstream_read_bits(&bstream, 10);       /* bw[9:0] */
+            r[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* rx[3:0] */
+            r[0] |= bcdec__bitstream_read_bits_r(&bstream, 6) << 10;/* rw[10:15] */
+            g[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* gx[3:0] */
+            g[0] |= bcdec__bitstream_read_bits_r(&bstream, 6) << 10;/* gw[10:15] */
+            b[1] |= bcdec__bitstream_read_bits(&bstream, 4);        /* bx[3:0] */
+            b[0] |= bcdec__bitstream_read_bits_r(&bstream, 6) << 10;/* bw[10:15] */
+            mode = 13;
+        } break;
+
+        default: {
+            /* Modes 10011, 10111, 11011, and 11111 (not shown) are reserved.
+               Do not use these in your encoder. If the hardware is passed blocks
+               with one of these modes specified, the resulting decompressed block
+               must contain all zeroes in all channels except for the alpha channel. */
+            for (i = 0; i < 4; ++i) {
+                for (j = 0; j < 4; ++j) {
+                    decompressed[j * 3 + 0] = 0;
+                    decompressed[j * 3 + 1] = 0;
+                    decompressed[j * 3 + 2] = 0;
+                }
+                decompressed += destinationPitch;
+            }
+
+            return;
+        }
+    }
+
+    numPartitions = (mode >= 10) ? 0 : 1;
+
+    actualBits0Mode = actual_bits_count[0][mode];
+    if (isSigned) {
+        r[0] = bcdec__extend_sign(r[0], actualBits0Mode);
+        g[0] = bcdec__extend_sign(g[0], actualBits0Mode);
+        b[0] = bcdec__extend_sign(b[0], actualBits0Mode);
+    }
+
+    /* Mode 11 (like Mode 10) does not use delta compression,
+       and instead stores both color endpoints explicitly.  */
+    if ((mode != 9 && mode != 10) || isSigned) {
+        for (i = 1; i < (numPartitions + 1) * 2; ++i) {
+            r[i] = bcdec__extend_sign(r[i], actual_bits_count[1][mode]);
+            g[i] = bcdec__extend_sign(g[i], actual_bits_count[2][mode]);
+            b[i] = bcdec__extend_sign(b[i], actual_bits_count[3][mode]);
+        }
+    }
+
+    if (mode != 9 && mode != 10) {
+        for (i = 1; i < (numPartitions + 1) * 2; ++i) {
+            r[i] = bcdec__transform_inverse(r[i], r[0], actualBits0Mode, isSigned);
+            g[i] = bcdec__transform_inverse(g[i], g[0], actualBits0Mode, isSigned);
+            b[i] = bcdec__transform_inverse(b[i], b[0], actualBits0Mode, isSigned);
+        }
+    }
+
+    for (i = 0; i < (numPartitions + 1) * 2; ++i) {
+        r[i] = bcdec__unquantize(r[i], actualBits0Mode, isSigned);
+        g[i] = bcdec__unquantize(g[i], actualBits0Mode, isSigned);
+        b[i] = bcdec__unquantize(b[i], actualBits0Mode, isSigned);
+    }
+
+    weights = (mode >= 10) ? aWeight4 : aWeight3;
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            partitionSet = (mode >= 10) ? ((i|j) ? 0 : 128) : partition_sets[partition][i][j];
+
+            indexBits = (mode >= 10) ? 4 : 3;
+            /* fix-up index is specified with one less bit */
+            /* The fix-up index for subset 0 is always index 0 */
+            if (partitionSet & 0x80) {
+                indexBits--;
+            }
+            partitionSet &= 0x01;
+
+            index = bcdec__bitstream_read_bits(&bstream, indexBits);
+
+            ep_i = partitionSet * 2;
+            decompressed[j * 3 + 0] = bcdec__finish_unquantize(
+                                            bcdec__interpolate(r[ep_i], r[ep_i+1], weights, index), isSigned);
+            decompressed[j * 3 + 1] = bcdec__finish_unquantize(
+                                            bcdec__interpolate(g[ep_i], g[ep_i+1], weights, index), isSigned);
+            decompressed[j * 3 + 2] = bcdec__finish_unquantize(
+                                            bcdec__interpolate(b[ep_i], b[ep_i+1], weights, index), isSigned);
+        }
+
+        decompressed += destinationPitch;
+    }
+}
+
+BCDECDEF void bcdec_bc6h_float(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned) {
+    unsigned short block[16*3];
+    float* decompressed;
+    const unsigned short* b;
+    int i, j;
+
+    bcdec_bc6h_half(compressedBlock, block, 4*3, isSigned);
+    b = block;
+    decompressed = (float*)decompressedBlock;
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            decompressed[j * 3 + 0] = bcdec__half_to_float_quick(*b++);
+            decompressed[j * 3 + 1] = bcdec__half_to_float_quick(*b++);
+            decompressed[j * 3 + 2] = bcdec__half_to_float_quick(*b++);
+        }
+        decompressed += destinationPitch;
+    }
+}
+
+static void bcdec__swap_values(int* a, int* b) {
+    a[0] ^= b[0], b[0] ^= a[0], a[0] ^= b[0];
+}
+
+BCDECDEF void bcdec_bc7(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
+    static char actual_bits_count[2][8] = {
+        { 4, 6, 5, 7, 5, 7, 7, 5 },     /* RGBA  */
+        { 0, 0, 0, 0, 6, 8, 7, 5 },     /* Alpha */
+    };
+
+    /* There are 64 possible partition sets for a two-region tile.
+       Each 4x4 block represents a single shape.
+       Here also every fix-up index has MSB bit set. */
+    static unsigned char partition_sets[2][64][4][4] = {
+        {   /* Partition table for 2-subset BPTC */
+            { {128, 0,   1, 1}, {0, 0,   1, 1}, {  0, 0, 1, 1}, {0, 0, 1, 129} }, /*  0 */
+            { {128, 0,   0, 1}, {0, 0,   0, 1}, {  0, 0, 0, 1}, {0, 0, 0, 129} }, /*  1 */
+            { {128, 1,   1, 1}, {0, 1,   1, 1}, {  0, 1, 1, 1}, {0, 1, 1, 129} }, /*  2 */
+            { {128, 0,   0, 1}, {0, 0,   1, 1}, {  0, 0, 1, 1}, {0, 1, 1, 129} }, /*  3 */
+            { {128, 0,   0, 0}, {0, 0,   0, 1}, {  0, 0, 0, 1}, {0, 0, 1, 129} }, /*  4 */
+            { {128, 0,   1, 1}, {0, 1,   1, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} }, /*  5 */
+            { {128, 0,   0, 1}, {0, 0,   1, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} }, /*  6 */
+            { {128, 0,   0, 0}, {0, 0,   0, 1}, {  0, 0, 1, 1}, {0, 1, 1, 129} }, /*  7 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {  0, 0, 0, 1}, {0, 0, 1, 129} }, /*  8 */
+            { {128, 0,   1, 1}, {0, 1,   1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} }, /*  9 */
+            { {128, 0,   0, 0}, {0, 0,   0, 1}, {  0, 1, 1, 1}, {1, 1, 1, 129} }, /* 10 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {  0, 0, 0, 1}, {0, 1, 1, 129} }, /* 11 */
+            { {128, 0,   0, 1}, {0, 1,   1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} }, /* 12 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {  1, 1, 1, 1}, {1, 1, 1, 129} }, /* 13 */
+            { {128, 0,   0, 0}, {1, 1,   1, 1}, {  1, 1, 1, 1}, {1, 1, 1, 129} }, /* 14 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {  0, 0, 0, 0}, {1, 1, 1, 129} }, /* 15 */
+            { {128, 0,   0, 0}, {1, 0,   0, 0}, {  1, 1, 1, 0}, {1, 1, 1, 129} }, /* 16 */
+            { {128, 1, 129, 1}, {0, 0,   0, 1}, {  0, 0, 0, 0}, {0, 0, 0,   0} }, /* 17 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {129, 0, 0, 0}, {1, 1, 1,   0} }, /* 18 */
+            { {128, 1, 129, 1}, {0, 0,   1, 1}, {  0, 0, 0, 1}, {0, 0, 0,   0} }, /* 19 */
+            { {128, 0, 129, 1}, {0, 0,   0, 1}, {  0, 0, 0, 0}, {0, 0, 0,   0} }, /* 20 */
+            { {128, 0,   0, 0}, {1, 0,   0, 0}, {129, 1, 0, 0}, {1, 1, 1,   0} }, /* 21 */
+            { {128, 0,   0, 0}, {0, 0,   0, 0}, {129, 0, 0, 0}, {1, 1, 0,   0} }, /* 22 */
+            { {128, 1,   1, 1}, {0, 0,   1, 1}, {  0, 0, 1, 1}, {0, 0, 0, 129} }, /* 23 */
+            { {128, 0, 129, 1}, {0, 0,   0, 1}, {  0, 0, 0, 1}, {0, 0, 0,   0} }, /* 24 */
+            { {128, 0,   0, 0}, {1, 0,   0, 0}, {129, 0, 0, 0}, {1, 1, 0,   0} }, /* 25 */
+            { {128, 1, 129, 0}, {0, 1,   1, 0}, {  0, 1, 1, 0}, {0, 1, 1,   0} }, /* 26 */
+            { {128, 0, 129, 1}, {0, 1,   1, 0}, {  0, 1, 1, 0}, {1, 1, 0,   0} }, /* 27 */
+            { {128, 0,   0, 1}, {0, 1,   1, 1}, {129, 1, 1, 0}, {1, 0, 0,   0} }, /* 28 */
+            { {128, 0,   0, 0}, {1, 1,   1, 1}, {129, 1, 1, 1}, {0, 0, 0,   0} }, /* 29 */
+            { {128, 1, 129, 1}, {0, 0,   0, 1}, {  1, 0, 0, 0}, {1, 1, 1,   0} }, /* 30 */
+            { {128, 0, 129, 1}, {1, 0,   0, 1}, {  1, 0, 0, 1}, {1, 1, 0,   0} }, /* 31 */
+            { {128, 1,   0, 1}, {0, 1,   0, 1}, {  0, 1, 0, 1}, {0, 1, 0, 129} }, /* 32 */
+            { {128, 0,   0, 0}, {1, 1,   1, 1}, {  0, 0, 0, 0}, {1, 1, 1, 129} }, /* 33 */
+            { {128, 1,   0, 1}, {1, 0, 129, 0}, {  0, 1, 0, 1}, {1, 0, 1,   0} }, /* 34 */
+            { {128, 0,   1, 1}, {0, 0,   1, 1}, {129, 1, 0, 0}, {1, 1, 0,   0} }, /* 35 */
+            { {128, 0, 129, 1}, {1, 1,   0, 0}, {  0, 0, 1, 1}, {1, 1, 0,   0} }, /* 36 */
+            { {128, 1,   0, 1}, {0, 1,   0, 1}, {129, 0, 1, 0}, {1, 0, 1,   0} }, /* 37 */
+            { {128, 1,   1, 0}, {1, 0,   0, 1}, {  0, 1, 1, 0}, {1, 0, 0, 129} }, /* 38 */
+            { {128, 1,   0, 1}, {1, 0,   1, 0}, {  1, 0, 1, 0}, {0, 1, 0, 129} }, /* 39 */
+            { {128, 1, 129, 1}, {0, 0,   1, 1}, {  1, 1, 0, 0}, {1, 1, 1,   0} }, /* 40 */
+            { {128, 0,   0, 1}, {0, 0,   1, 1}, {129, 1, 0, 0}, {1, 0, 0,   0} }, /* 41 */
+            { {128, 0, 129, 1}, {0, 0,   1, 0}, {  0, 1, 0, 0}, {1, 1, 0,   0} }, /* 42 */
+            { {128, 0, 129, 1}, {1, 0,   1, 1}, {  1, 1, 0, 1}, {1, 1, 0,   0} }, /* 43 */
+            { {128, 1, 129, 0}, {1, 0,   0, 1}, {  1, 0, 0, 1}, {0, 1, 1,   0} }, /* 44 */
+            { {128, 0,   1, 1}, {1, 1,   0, 0}, {  1, 1, 0, 0}, {0, 0, 1, 129} }, /* 45 */
+            { {128, 1,   1, 0}, {0, 1,   1, 0}, {  1, 0, 0, 1}, {1, 0, 0, 129} }, /* 46 */
+            { {128, 0,   0, 0}, {0, 1, 129, 0}, {  0, 1, 1, 0}, {0, 0, 0,   0} }, /* 47 */
+            { {128, 1,   0, 0}, {1, 1, 129, 0}, {  0, 1, 0, 0}, {0, 0, 0,   0} }, /* 48 */
+            { {128, 0, 129, 0}, {0, 1,   1, 1}, {  0, 0, 1, 0}, {0, 0, 0,   0} }, /* 49 */
+            { {128, 0,   0, 0}, {0, 0, 129, 0}, {  0, 1, 1, 1}, {0, 0, 1,   0} }, /* 50 */
+            { {128, 0,   0, 0}, {0, 1,   0, 0}, {129, 1, 1, 0}, {0, 1, 0,   0} }, /* 51 */
+            { {128, 1,   1, 0}, {1, 1,   0, 0}, {  1, 0, 0, 1}, {0, 0, 1, 129} }, /* 52 */
+            { {128, 0,   1, 1}, {0, 1,   1, 0}, {  1, 1, 0, 0}, {1, 0, 0, 129} }, /* 53 */
+            { {128, 1, 129, 0}, {0, 0,   1, 1}, {  1, 0, 0, 1}, {1, 1, 0,   0} }, /* 54 */
+            { {128, 0, 129, 1}, {1, 0,   0, 1}, {  1, 1, 0, 0}, {0, 1, 1,   0} }, /* 55 */
+            { {128, 1,   1, 0}, {1, 1,   0, 0}, {  1, 1, 0, 0}, {1, 0, 0, 129} }, /* 56 */
+            { {128, 1,   1, 0}, {0, 0,   1, 1}, {  0, 0, 1, 1}, {1, 0, 0, 129} }, /* 57 */
+            { {128, 1,   1, 1}, {1, 1,   1, 0}, {  1, 0, 0, 0}, {0, 0, 0, 129} }, /* 58 */
+            { {128, 0,   0, 1}, {1, 0,   0, 0}, {  1, 1, 1, 0}, {0, 1, 1, 129} }, /* 59 */
+            { {128, 0,   0, 0}, {1, 1,   1, 1}, {  0, 0, 1, 1}, {0, 0, 1, 129} }, /* 60 */
+            { {128, 0, 129, 1}, {0, 0,   1, 1}, {  1, 1, 1, 1}, {0, 0, 0,   0} }, /* 61 */
+            { {128, 0, 129, 0}, {0, 0,   1, 0}, {  1, 1, 1, 0}, {1, 1, 1,   0} }, /* 62 */
+            { {128, 1,   0, 0}, {0, 1,   0, 0}, {  0, 1, 1, 1}, {0, 1, 1, 129} }  /* 63 */
+        },
+        {   /* Partition table for 3-subset BPTC */
+            { {128, 0, 1, 129}, {0,   0,   1, 1}, {  0,   2,   2, 1}, {  2,   2, 2, 130} }, /*  0 */
+            { {128, 0, 0, 129}, {0,   0,   1, 1}, {130,   2,   1, 1}, {  2,   2, 2,   1} }, /*  1 */
+            { {128, 0, 0,   0}, {2,   0,   0, 1}, {130,   2,   1, 1}, {  2,   2, 1, 129} }, /*  2 */
+            { {128, 2, 2, 130}, {0,   0,   2, 2}, {  0,   0,   1, 1}, {  0,   1, 1, 129} }, /*  3 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {129,   1,   2, 2}, {  1,   1, 2, 130} }, /*  4 */
+            { {128, 0, 1, 129}, {0,   0,   1, 1}, {  0,   0,   2, 2}, {  0,   0, 2, 130} }, /*  5 */
+            { {128, 0, 2, 130}, {0,   0,   2, 2}, {  1,   1,   1, 1}, {  1,   1, 1, 129} }, /*  6 */
+            { {128, 0, 1,   1}, {0,   0,   1, 1}, {130,   2,   1, 1}, {  2,   2, 1, 129} }, /*  7 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {129,   1,   1, 1}, {  2,   2, 2, 130} }, /*  8 */
+            { {128, 0, 0,   0}, {1,   1,   1, 1}, {129,   1,   1, 1}, {  2,   2, 2, 130} }, /*  9 */
+            { {128, 0, 0,   0}, {1,   1, 129, 1}, {  2,   2,   2, 2}, {  2,   2, 2, 130} }, /* 10 */
+            { {128, 0, 1,   2}, {0,   0, 129, 2}, {  0,   0,   1, 2}, {  0,   0, 1, 130} }, /* 11 */
+            { {128, 1, 1,   2}, {0,   1, 129, 2}, {  0,   1,   1, 2}, {  0,   1, 1, 130} }, /* 12 */
+            { {128, 1, 2,   2}, {0, 129,   2, 2}, {  0,   1,   2, 2}, {  0,   1, 2, 130} }, /* 13 */
+            { {128, 0, 1, 129}, {0,   1,   1, 2}, {  1,   1,   2, 2}, {  1,   2, 2, 130} }, /* 14 */
+            { {128, 0, 1, 129}, {2,   0,   0, 1}, {130,   2,   0, 0}, {  2,   2, 2,   0} }, /* 15 */
+            { {128, 0, 0, 129}, {0,   0,   1, 1}, {  0,   1,   1, 2}, {  1,   1, 2, 130} }, /* 16 */
+            { {128, 1, 1, 129}, {0,   0,   1, 1}, {130,   0,   0, 1}, {  2,   2, 0,   0} }, /* 17 */
+            { {128, 0, 0,   0}, {1,   1,   2, 2}, {129,   1,   2, 2}, {  1,   1, 2, 130} }, /* 18 */
+            { {128, 0, 2, 130}, {0,   0,   2, 2}, {  0,   0,   2, 2}, {  1,   1, 1, 129} }, /* 19 */
+            { {128, 1, 1, 129}, {0,   1,   1, 1}, {  0,   2,   2, 2}, {  0,   2, 2, 130} }, /* 20 */
+            { {128, 0, 0, 129}, {0,   0,   0, 1}, {130,   2,   2, 1}, {  2,   2, 2,   1} }, /* 21 */
+            { {128, 0, 0,   0}, {0,   0, 129, 1}, {  0,   1,   2, 2}, {  0,   1, 2, 130} }, /* 22 */
+            { {128, 0, 0,   0}, {1,   1,   0, 0}, {130,   2, 129, 0}, {  2,   2, 1,   0} }, /* 23 */
+            { {128, 1, 2, 130}, {0, 129,   2, 2}, {  0,   0,   1, 1}, {  0,   0, 0,   0} }, /* 24 */
+            { {128, 0, 1,   2}, {0,   0,   1, 2}, {129,   1,   2, 2}, {  2,   2, 2, 130} }, /* 25 */
+            { {128, 1, 1,   0}, {1,   2, 130, 1}, {129,   2,   2, 1}, {  0,   1, 1,   0} }, /* 26 */
+            { {128, 0, 0,   0}, {0,   1, 129, 0}, {  1,   2, 130, 1}, {  1,   2, 2,   1} }, /* 27 */
+            { {128, 0, 2,   2}, {1,   1,   0, 2}, {129,   1,   0, 2}, {  0,   0, 2, 130} }, /* 28 */
+            { {128, 1, 1,   0}, {0, 129,   1, 0}, {  2,   0,   0, 2}, {  2,   2, 2, 130} }, /* 29 */
+            { {128, 0, 1,   1}, {0,   1,   2, 2}, {  0,   1, 130, 2}, {  0,   0, 1, 129} }, /* 30 */
+            { {128, 0, 0,   0}, {2,   0,   0, 0}, {130,   2,   1, 1}, {  2,   2, 2, 129} }, /* 31 */
+            { {128, 0, 0,   0}, {0,   0,   0, 2}, {129,   1,   2, 2}, {  1,   2, 2, 130} }, /* 32 */
+            { {128, 2, 2, 130}, {0,   0,   2, 2}, {  0,   0,   1, 2}, {  0,   0, 1, 129} }, /* 33 */
+            { {128, 0, 1, 129}, {0,   0,   1, 2}, {  0,   0,   2, 2}, {  0,   2, 2, 130} }, /* 34 */
+            { {128, 1, 2,   0}, {0, 129,   2, 0}, {  0,   1, 130, 0}, {  0,   1, 2,   0} }, /* 35 */
+            { {128, 0, 0,   0}, {1,   1, 129, 1}, {  2,   2, 130, 2}, {  0,   0, 0,   0} }, /* 36 */
+            { {128, 1, 2,   0}, {1,   2,   0, 1}, {130,   0, 129, 2}, {  0,   1, 2,   0} }, /* 37 */
+            { {128, 1, 2,   0}, {2,   0,   1, 2}, {129, 130,   0, 1}, {  0,   1, 2,   0} }, /* 38 */
+            { {128, 0, 1,   1}, {2,   2,   0, 0}, {  1,   1, 130, 2}, {  0,   0, 1, 129} }, /* 39 */
+            { {128, 0, 1,   1}, {1,   1, 130, 2}, {  2,   2,   0, 0}, {  0,   0, 1, 129} }, /* 40 */
+            { {128, 1, 0, 129}, {0,   1,   0, 1}, {  2,   2,   2, 2}, {  2,   2, 2, 130} }, /* 41 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {130,   1,   2, 1}, {  2,   1, 2, 129} }, /* 42 */
+            { {128, 0, 2,   2}, {1, 129,   2, 2}, {  0,   0,   2, 2}, {  1,   1, 2, 130} }, /* 43 */
+            { {128, 0, 2, 130}, {0,   0,   1, 1}, {  0,   0,   2, 2}, {  0,   0, 1, 129} }, /* 44 */
+            { {128, 2, 2,   0}, {1,   2, 130, 1}, {  0,   2,   2, 0}, {  1,   2, 2, 129} }, /* 45 */
+            { {128, 1, 0,   1}, {2,   2, 130, 2}, {  2,   2,   2, 2}, {  0,   1, 0, 129} }, /* 46 */
+            { {128, 0, 0,   0}, {2,   1,   2, 1}, {130,   1,   2, 1}, {  2,   1, 2, 129} }, /* 47 */
+            { {128, 1, 0, 129}, {0,   1,   0, 1}, {  0,   1,   0, 1}, {  2,   2, 2, 130} }, /* 48 */
+            { {128, 2, 2, 130}, {0,   1,   1, 1}, {  0,   2,   2, 2}, {  0,   1, 1, 129} }, /* 49 */
+            { {128, 0, 0,   2}, {1, 129,   1, 2}, {  0,   0,   0, 2}, {  1,   1, 1, 130} }, /* 50 */
+            { {128, 0, 0,   0}, {2, 129,   1, 2}, {  2,   1,   1, 2}, {  2,   1, 1, 130} }, /* 51 */
+            { {128, 2, 2,   2}, {0, 129,   1, 1}, {  0,   1,   1, 1}, {  0,   2, 2, 130} }, /* 52 */
+            { {128, 0, 0,   2}, {1,   1,   1, 2}, {129,   1,   1, 2}, {  0,   0, 0, 130} }, /* 53 */
+            { {128, 1, 1,   0}, {0, 129,   1, 0}, {  0,   1,   1, 0}, {  2,   2, 2, 130} }, /* 54 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {  2,   1, 129, 2}, {  2,   1, 1, 130} }, /* 55 */
+            { {128, 1, 1,   0}, {0, 129,   1, 0}, {  2,   2,   2, 2}, {  2,   2, 2, 130} }, /* 56 */
+            { {128, 0, 2,   2}, {0,   0,   1, 1}, {  0,   0, 129, 1}, {  0,   0, 2, 130} }, /* 57 */
+            { {128, 0, 2,   2}, {1,   1,   2, 2}, {129,   1,   2, 2}, {  0,   0, 2, 130} }, /* 58 */
+            { {128, 0, 0,   0}, {0,   0,   0, 0}, {  0,   0,   0, 0}, {  2, 129, 1, 130} }, /* 59 */
+            { {128, 0, 0, 130}, {0,   0,   0, 1}, {  0,   0,   0, 2}, {  0,   0, 0, 129} }, /* 60 */
+            { {128, 2, 2,   2}, {1,   2,   2, 2}, {  0,   2,   2, 2}, {129,   2, 2, 130} }, /* 61 */
+            { {128, 1, 0, 129}, {2,   2,   2, 2}, {  2,   2,   2, 2}, {  2,   2, 2, 130} }, /* 62 */
+            { {128, 1, 1, 129}, {2,   0,   1, 1}, {130,   2,   0, 1}, {  2,   2, 2,   0} }  /* 63 */
+        }
+    };
+
+    static int aWeight2[] = { 0, 21, 43, 64 };
+    static int aWeight3[] = { 0, 9, 18, 27, 37, 46, 55, 64 };
+    static int aWeight4[] = { 0, 4, 9, 13, 17, 21, 26, 30, 34, 38, 43, 47, 51, 55, 60, 64 };
+
+    static unsigned char sModeHasPBits = 0b11001011;
+
+    bcdec__bitstream_t bstream;
+    int mode, partition, numPartitions, numEndpoints, i, j, k, rotation, partitionSet;
+    int indexSelectionBit, indexBits, indexBits2, index, index2;
+    int endpoints[6][4];
+    char indices[4][4];
+    int r, g, b, a;
+    int* weights, * weights2;
+    unsigned char* decompressed;
+
+    decompressed = (unsigned char*)decompressedBlock;
+
+    bstream.low = ((unsigned long long*)compressedBlock)[0];
+    bstream.high = ((unsigned long long*)compressedBlock)[1];
+
+    for (mode = 0; mode < 8 && (0 == bcdec__bitstream_read_bit(&bstream)); ++mode);
+
+    /* unexpected mode, clear the block (transparent black) */
+    if (mode >= 8) {
+        for (i = 0; i < 4; ++i) {
+            for (j = 0; j < 4; ++j) {
+                decompressed[j * 4 + 0] = 0;
+                decompressed[j * 4 + 1] = 0;
+                decompressed[j * 4 + 2] = 0;
+                decompressed[j * 4 + 3] = 0;
+            }
+            decompressed += destinationPitch;
+        }
+
+        return;
+    }
+
+    partition = 0;
+    numPartitions = 1;
+    rotation = 0;
+    indexSelectionBit = 0;
+
+    if (mode == 0 || mode == 1 || mode == 2 || mode == 3 || mode == 7) {
+        numPartitions = (mode == 0 || mode == 2) ? 3 : 2;
+        partition = bcdec__bitstream_read_bits(&bstream, (mode == 0) ? 4 : 6);
+    }
+
+    numEndpoints = numPartitions * 2;
+
+    if (mode == 4 || mode == 5) {
+        rotation = bcdec__bitstream_read_bits(&bstream, 2);
+
+        if (mode == 4) {
+            indexSelectionBit = bcdec__bitstream_read_bit(&bstream);
+        }
+    }
+
+    /* Extract endpoints */
+    /* RGB */
+    for (i = 0; i < 3; ++i) {
+        for (j = 0; j < numEndpoints; ++j) {
+            endpoints[j][i] = bcdec__bitstream_read_bits(&bstream, actual_bits_count[0][mode]);
+        }
+    }
+    /* Alpha (if any) */
+    if (actual_bits_count[1][mode] > 0) {
+        for (j = 0; j < numEndpoints; ++j) {
+            endpoints[j][3] = bcdec__bitstream_read_bits(&bstream, actual_bits_count[1][mode]);
+        }
+    }
+
+    /* Fully decode endpoints */
+    /* First handle modes that have P-bits */
+    if (mode == 0 || mode == 1 || mode == 3 || mode == 6 || mode == 7) {
+        for (i = 0; i < numEndpoints; ++i) {
+            /* component-wise left-shift */
+            for (j = 0; j < 4; ++j) {
+                endpoints[i][j] <<= 1;
+            }
+        }
+
+        /* if P-bit is shared */
+        if (mode == 1) {
+            i = bcdec__bitstream_read_bit(&bstream);
+            j = bcdec__bitstream_read_bit(&bstream);
+
+            /* rgb component-wise insert pbits */
+            for (k = 0; k < 3; ++k) {
+                endpoints[0][k] |= i;
+                endpoints[1][k] |= i;
+                endpoints[2][k] |= j;
+                endpoints[3][k] |= j;
+            }
+        } else if (sModeHasPBits & (1 << mode)) {
+            /* unique P-bit per endpoint */
+            for (i = 0; i < numEndpoints; ++i) {
+                j = bcdec__bitstream_read_bit(&bstream);
+                for (k = 0; k < 4; ++k) {
+                    endpoints[i][k] |= j;
+                }
+            }
+        }
+    }
+
+    for (i = 0; i < numEndpoints; ++i) {
+        /* get color components precision including pbit */
+        j = actual_bits_count[0][mode] + ((sModeHasPBits >> mode) & 1);
+
+        for (k = 0; k < 3; ++k) {
+            /* left shift endpoint components so that their MSB lies in bit 7 */
+            endpoints[i][k] = endpoints[i][k] << (8 - j);
+            /* Replicate each component's MSB into the LSBs revealed by the left-shift operation above */
+            endpoints[i][k] = endpoints[i][k] | (endpoints[i][k] >> j);
+        }
+
+        /* get alpha component precision including pbit */
+        j = actual_bits_count[1][mode] + ((sModeHasPBits >> mode) & 1);
+
+        /* left shift endpoint components so that their MSB lies in bit 7 */
+        endpoints[i][3] = endpoints[i][3] << (8 - j);
+        /* Replicate each component's MSB into the LSBs revealed by the left-shift operation above */
+        endpoints[i][3] = endpoints[i][3] | (endpoints[i][3] >> j);
+    }
+
+    /* If this mode does not explicitly define the alpha component */
+    /* set alpha equal to 1.0 */
+    if (!actual_bits_count[1][mode]) {
+        for (j = 0; j < numEndpoints; ++j) {
+            endpoints[j][3] = 0xFF;
+        }
+    }
+
+    /* Determine weights tables */
+    indexBits = (mode == 0 || mode == 1) ? 3 : ((mode == 6) ? 4 : 2);
+    indexBits2 = (mode == 4) ? 3 : ((mode == 5) ? 2 : 0);
+    weights = (indexBits == 2) ? aWeight2 : ((indexBits == 3) ? aWeight3 : aWeight4);
+    weights2 = (indexBits2 == 2) ? aWeight2 : aWeight3;
+
+    /* Quite inconvenient that indices aren't interleaved so we have to make 2 passes here */
+    /* Pass #1: collecting color indices */
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            partitionSet = (numPartitions == 1) ? ((i | j) ? 0 : 128) : partition_sets[numPartitions - 2][partition][i][j];
+
+            indexBits = (mode == 0 || mode == 1) ? 3 : ((mode == 6) ? 4 : 2);
+            /* fix-up index is specified with one less bit */
+            /* The fix-up index for subset 0 is always index 0 */
+            if (partitionSet & 0x80) {
+                indexBits--;
+            }
+
+            indices[i][j] = bcdec__bitstream_read_bits(&bstream, indexBits);
+        }
+    }
+
+    /* Pass #2: reading alpha indices (if any) and interpolating & rotating */
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            partitionSet = (numPartitions == 1) ? ((i|j) ? 0 : 128) : partition_sets[numPartitions - 2][partition][i][j];
+            partitionSet &= 0x03;
+
+            index = indices[i][j];
+
+            if (!indexBits2) {
+                r = bcdec__interpolate(endpoints[partitionSet * 2][0], endpoints[partitionSet * 2 + 1][0], weights, index);
+                g = bcdec__interpolate(endpoints[partitionSet * 2][1], endpoints[partitionSet * 2 + 1][1], weights, index);
+                b = bcdec__interpolate(endpoints[partitionSet * 2][2], endpoints[partitionSet * 2 + 1][2], weights, index);
+                a = bcdec__interpolate(endpoints[partitionSet * 2][3], endpoints[partitionSet * 2 + 1][3], weights, index);
+            } else {
+                index2 = bcdec__bitstream_read_bits(&bstream, (i|j) ? indexBits2 : (indexBits2 - 1));
+                /* The index value for interpolating color comes from the secondary index bits for the texel
+                   if the mode has an index selection bit and its value is one, and from the primary index bits otherwise.
+                   The alpha index comes from the secondary index bits if the block has a secondary index and
+                   the block either doesn’t have an index selection bit or that bit is zero, and from the primary index bits otherwise. */
+                if (!indexSelectionBit) {
+                    r = bcdec__interpolate(endpoints[partitionSet * 2][0], endpoints[partitionSet * 2 + 1][0],  weights,  index);
+                    g = bcdec__interpolate(endpoints[partitionSet * 2][1], endpoints[partitionSet * 2 + 1][1],  weights,  index);
+                    b = bcdec__interpolate(endpoints[partitionSet * 2][2], endpoints[partitionSet * 2 + 1][2],  weights,  index);
+                    a = bcdec__interpolate(endpoints[partitionSet * 2][3], endpoints[partitionSet * 2 + 1][3], weights2, index2);
+                } else {
+                    r = bcdec__interpolate(endpoints[partitionSet * 2][0], endpoints[partitionSet * 2 + 1][0], weights2, index2);
+                    g = bcdec__interpolate(endpoints[partitionSet * 2][1], endpoints[partitionSet * 2 + 1][1], weights2, index2);
+                    b = bcdec__interpolate(endpoints[partitionSet * 2][2], endpoints[partitionSet * 2 + 1][2], weights2, index2);
+                    a = bcdec__interpolate(endpoints[partitionSet * 2][3], endpoints[partitionSet * 2 + 1][3],  weights,  index);
+                }
+            }
+
+            switch (rotation) {
+                case 1: {   /* 01 – Block format is Scalar(R) Vector(AGB) - swap A and R */
+                    bcdec__swap_values(&a, &r);
+                } break;
+                case 2: {   /* 10 – Block format is Scalar(G) Vector(RAB) - swap A and G */
+                    bcdec__swap_values(&a, &g);
+                } break;
+                case 3: {   /* 11 - Block format is Scalar(B) Vector(RGA) - swap A and B */
+                    bcdec__swap_values(&a, &b);
+                } break;
+            }
+
+            decompressed[j * 4 + 0] = r;
+            decompressed[j * 4 + 1] = g;
+            decompressed[j * 4 + 2] = b;
+            decompressed[j * 4 + 3] = a;
+        }
+
+        decompressed += destinationPitch;
+    }
+}
+
+#endif /* BCDEC_IMPLEMENTATION */
+
+#endif /* BCDEC_HEADER_INCLUDED */
+
+/* LICENSE:
+
+This software is available under 2 licenses -- choose whichever you prefer.
+
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+
+Copyright (c) 2022 Sergii Kudlai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+ALTERNATIVE B - The Unlicense
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>
+
+*/

--- a/code/ddsutils/ddsutils.cpp
+++ b/code/ddsutils/ddsutils.cpp
@@ -3,6 +3,10 @@
 #include "cfile/cfile.h"
 #include "osapi/osregistry.h"
 
+#include <glad/glad.h>
+
+#define BCDEC_IMPLEMENTATION 1
+#include "ddsutils/bcdec.h"
 
 /*	Currently supported formats:
  *		DXT1a	(compressed)
@@ -12,12 +16,9 @@
  *		uncompressed 1555	(16-bit, 1-bit being alpha)
  *		uncompressed 8888	(32-bit)
  *		uncompressed 888	(24-bit, no alpha)
- *		paletted 8-bit		(256 colors)
+ *		uncompressed R8		(8-bit, Red channel as luminance)
  */
- 
 
-int Texture_compression_available = 0;
-int Use_compressed_textures = 0;
 
 // power of two check, to verify that a given DDS will always be usable since
 // some may not be power-of-2
@@ -26,39 +27,219 @@ static inline int is_power_of_two(int w, int h)
 	return ( (w && !(w & (w-1))) && (h && !(h & (h-1))) );
 }
 
-// This function is used to verify that the file format specified in the DX10 Header
-// is supported by the OpenGL extensions
-bool dds_read_dx10_header(CFILE* dds_file, DDS_HEADER_DXT10* header) 
+static bool valid_dx10_format(const DDS_HEADER_DXT10 &header)
 {
-	header->dxgiFormat			= static_cast<DXGI_FORMAT>(cfread_uint(dds_file));
-	header->resourceDimension	= static_cast<D3D10_RESOURCE_DIMENSION>(cfread_uint(dds_file));
-	header->miscFlag			= cfread_uint(dds_file);
-	header->arraySize			= cfread_uint(dds_file);
-	header->miscFlags2			= cfread_uint(dds_file);
+	switch (header.dxgiFormat) {
+		case DXGI_FORMAT::DXGI_FORMAT_BC7_TYPELESS:
+		case DXGI_FORMAT::DXGI_FORMAT_BC7_UNORM:
+		case DXGI_FORMAT::DXGI_FORMAT_BC7_UNORM_SRGB:
+			return true;
 
-	switch (header->dxgiFormat) {
-	case DXGI_FORMAT::DXGI_FORMAT_BC7_TYPELESS:
-	case DXGI_FORMAT::DXGI_FORMAT_BC7_UNORM:
-	case DXGI_FORMAT::DXGI_FORMAT_BC7_UNORM_SRGB:
-		return true;
-	default:
-		return false;
+		default:
+			return false;
 	}
 }
 
-int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *height, int *bpp, int *compression_type, int *levels, size_t *size, ubyte *palette)
+static bool conversion_needed(const DDS_HEADER &dds_header)
+{
+	if ((dds_header.ddspf.dwFlags & DDPF_FOURCC) != DDPF_FOURCC) {
+		return false;
+	}
+
+	switch (dds_header.ddspf.dwFourCC) {
+		case FOURCC_DXT1:
+		case FOURCC_DXT3:
+		case FOURCC_DXT5:
+			return !GLAD_GL_EXT_texture_compression_s3tc;
+
+		case FOURCC_DX10:
+			// anything other than BC7 will end up invalid
+			return !GLAD_GL_ARB_texture_compression_bptc;
+
+		default:
+			break;
+	}
+
+	// anything not specifically listed should end up invalid
+	return false;
+}
+
+// Memory usage for uncompressed textures is quite high. Some MVP assets can
+// require well over a GB of VRAM for a single ship after conversion. To help
+// alleviate this we need to resize those textures where possible. At 1024x1024
+// the memory requirement is reduced to about 36 MB per ship with a full set
+// of textures.
+//
+// NOTE: modifies header!!
+//
+// returns: number of mipmap levels to skip
+static uint conversion_resize(DDS_HEADER &dds_header)
+{
+	const size_t MAX_SIZE = 1024;
+	uint width, height, depth, offset = 0;
+
+	if (dds_header.dwMipMapCount <= 1) {
+		return 0;
+	}
+
+	width = dds_header.dwWidth;
+	height = dds_header.dwHeight;
+	depth = dds_header.dwDepth;
+
+	// drop levels until we get to an appropriate size, but make sure we have
+	// at least 1 mipmap level remaining at the end (in case there's not a full chain)
+	while (((width > MAX_SIZE) || (height > MAX_SIZE)) && (offset < dds_header.dwMipMapCount-1)) {
+		width >>= 1;
+		height >>= 1;
+		depth >>= 1;
+
+		++offset;
+	}
+
+	// no change needed
+	if ( !offset ) {
+		return offset;
+	}
+
+	// update header with new values
+	dds_header.dwWidth = std::max(1U, width);
+	dds_header.dwHeight = std::max(1U, height);
+	dds_header.dwDepth = std::max(1U, depth);
+
+	return offset;
+}
+
+static int _dds_read_header(CFILE *ddsfile, DDS_HEADER &dds_header, DDS_HEADER_DXT10 *dds_header_dx10 = nullptr)
+{
+	DDS_HEADER_DXT10 dx10_header;
+
+	// read the code
+	int code = cfread_int(ddsfile);
+
+	// check it
+	if (code != DDS_FILECODE) {
+		return DDS_ERROR_BAD_HEADER;
+	}
+
+	// read header variables
+	dds_header.dwSize				= cfread_uint(ddsfile);
+	dds_header.dwFlags				= cfread_uint(ddsfile);
+	dds_header.dwHeight				= cfread_uint(ddsfile);
+	dds_header.dwWidth				= cfread_uint(ddsfile);
+	dds_header.dwPitchOrLinearSize	= cfread_uint(ddsfile);
+	dds_header.dwDepth				= cfread_uint(ddsfile);
+	dds_header.dwMipMapCount		= cfread_uint(ddsfile);
+
+	// skip over the crap we don't care about
+	cfseek(ddsfile, 11*4, CF_SEEK_CUR);
+
+	dds_header.ddspf.dwSize			= cfread_uint(ddsfile);
+	dds_header.ddspf.dwFlags		= cfread_uint(ddsfile);
+	dds_header.ddspf.dwFourCC		= cfread_uint(ddsfile);
+	dds_header.ddspf.dwRGBBitCount	= cfread_uint(ddsfile);
+	dds_header.ddspf.dwRBitMask		= cfread_uint(ddsfile);
+	dds_header.ddspf.dwGBitMask		= cfread_uint(ddsfile);
+	dds_header.ddspf.dwBBitMask		= cfread_uint(ddsfile);
+	dds_header.ddspf.dwABitMask		= cfread_uint(ddsfile);
+
+	dds_header.dwCaps		= cfread_uint(ddsfile);
+	dds_header.dwCaps2		= cfread_uint(ddsfile);
+
+	// Unused but need them checked for later
+	dds_header.dwCaps3		= cfread_uint(ddsfile);
+	dds_header.dwCaps4		= cfread_uint(ddsfile);
+	dds_header.dwReserved2	= cfread_uint(ddsfile);
+
+	if (dds_header.ddspf.dwFourCC == FOURCC_DX10) {
+		dx10_header.dxgiFormat			= static_cast<DXGI_FORMAT>(cfread_uint(ddsfile));
+		dx10_header.resourceDimension	= static_cast<D3D10_RESOURCE_DIMENSION>(cfread_uint(ddsfile));
+		dx10_header.miscFlag			= cfread_uint(ddsfile);
+		dx10_header.arraySize			= cfread_uint(ddsfile);
+		dx10_header.miscFlags2			= cfread_uint(ddsfile);
+
+		if (dds_header_dx10) {
+			memcpy(dds_header_dx10, &dx10_header, sizeof(DDS_HEADER_DXT10));
+		}
+	}
+
+	// sanitize values
+	dds_header.dwDepth = std::max(1U, dds_header.dwDepth);
+	dds_header.dwMipMapCount = std::max(1U, dds_header.dwMipMapCount);
+
+#ifndef NDEBUG
+	if (dds_header.dwDepth > 1) {
+		Assertion(dds_header.dwFlags & DDSD_DEPTH, "ERROR: Volume texture missing proper flags!!");
+	}
+#endif
+
+	// set pitch manually (per MS docs)
+	dds_header.dwFlags &= ~DDSD_LINEARSIZE;
+	dds_header.dwFlags |= DDSD_PITCH;
+
+	if (dds_header.ddspf.dwFlags & DDPF_FOURCC) {
+		int block_size = (dds_header.ddspf.dwFourCC == FOURCC_DXT1) ? 8 : 16;
+		dds_header.dwPitchOrLinearSize = std::max(1U, (dds_header.dwWidth+3)/4) * block_size;
+	} else {
+		// this isn't technically correct, but it's only wrong for formats we don't support
+		dds_header.dwPitchOrLinearSize = (dds_header.dwWidth * dds_header.ddspf.dwRGBBitCount + 7) / 8;
+	}
+
+	return DDS_ERROR_NONE;
+}
+
+static size_t compute_dds_size(const DDS_HEADER &dds_header)
+{
+	uint d_width, d_height, d_depth;
+	size_t d_size = 0;
+
+	for (auto i = 0; i < dds_header.dwMipMapCount; i++) {
+		d_width = std::max(1U, dds_header.dwWidth >> i);
+		d_height = std::max(1U, dds_header.dwHeight >> i);
+		d_depth = std::max(1U, dds_header.dwDepth >> i);
+
+		if (dds_header.ddspf.dwFlags & DDPF_FOURCC) {
+			// size of data block (4x4)
+			d_size += ((d_width + 3) / 4) * ((d_height + 3) / 4) * d_depth * ((dds_header.ddspf.dwFourCC == FOURCC_DXT1) ? 8 : 16);
+		} else {
+			d_size += d_width * d_height * d_depth * (dds_header.ddspf.dwRGBBitCount / 8);
+		}
+	}
+
+	// assumes valid cubemap (should be checked elsewhere)
+	if (dds_header.dwCaps2 & DDSCAPS2_CUBEMAP) {
+		// the previously computed size is just per face, mult by 6 for full size
+		d_size *= 6;
+	}
+
+	Assertion(d_size > 0, "ERROR: DDS size computed to 0!!");
+
+	return d_size;
+}
+
+static int get_bit_count(const DDS_HEADER &dds_header)
+{
+	if (dds_header.ddspf.dwFlags & DDPF_RGB) {
+		return dds_header.ddspf.dwRGBBitCount;
+	} else if (dds_header.ddspf.dwFlags & DDPF_FOURCC) {
+		if (dds_header.ddspf.dwFourCC == FOURCC_DXT1) {
+			return 24;
+		} else {
+			return 32;
+		}
+	}
+
+	return 0;
+}
+
+int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *height, int *bpp, int *compression_type, int *levels, size_t *size)
 {
 	DDS_HEADER dds_header;
 	DDS_HEADER_DXT10 dds_header_dx10;
-	int code = 0;
 	CFILE *ddsfile;
 	char real_name[MAX_FILENAME_LEN];
 	int retval = DDS_ERROR_NONE;
 	int ct = DDS_UNCOMPRESSED;
-	int bits = 0;
-	int i, is_cubemap = 0;
-	uint32_t d_width = 0, d_height = 0, d_depth = 0;
-	size_t d_size = 0;
+	int is_cubemap = 0;
 
 
 	if (img_cfp == NULL) {
@@ -81,113 +262,36 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 		ddsfile = img_cfp;
 	}
 
-	// read the code
-	code = cfread_int(ddsfile);
+	retval = _dds_read_header(ddsfile, dds_header, &dds_header_dx10);
 
-	// check it
-	if (code != DDS_FILECODE) {
-		retval = DDS_ERROR_BAD_HEADER;
+	if (retval != DDS_ERROR_NONE) {
 		goto Done;
 	}
 
-	// read header variables
-	dds_header.dwSize				= cfread_uint(ddsfile);
-	dds_header.dwFlags				= cfread_uint(ddsfile);
-	dds_header.dwHeight				= cfread_uint(ddsfile);
-	dds_header.dwWidth				= cfread_uint(ddsfile);
-	dds_header.dwPitchOrLinearSize	= cfread_uint(ddsfile);
-	dds_header.dwDepth				= cfread_uint(ddsfile);
-	dds_header.dwMipMapCount		= cfread_uint(ddsfile);
+	// check for valid cubemap (we require all 6 faces)
+	if (dds_header.dwCaps2 & DDSCAPS2_CUBEMAP) {
+		if ( !(dds_header.dwCaps2 & DDSCAPS2_CUBEMAP_ALLFACES) ) {
+			retval = DDS_ERROR_CUBEMAP_FACES;
+			ct = DDS_DXT_INVALID;
+			goto Done;
+		}
 
-	// skip over the crap we don't care about
-	for (i = 0; i < 11; i++)
-		cfread_uint(ddsfile);
+		// it's a valid cubemap, probably
+		is_cubemap = 1;
+	}
 
-	dds_header.ddspf.dwSize				= cfread_uint(ddsfile);
-	dds_header.ddspf.dwFlags			= cfread_uint(ddsfile);
-	dds_header.ddspf.dwFourCC			= cfread_uint(ddsfile);
-	dds_header.ddspf.dwRGBBitCount		= cfread_uint(ddsfile);
-	dds_header.ddspf.dwRBitMask			= cfread_uint(ddsfile);
-	dds_header.ddspf.dwGBitMask			= cfread_uint(ddsfile);
-	dds_header.ddspf.dwBBitMask			= cfread_uint(ddsfile);
-	dds_header.ddspf.dwABitMask			= cfread_uint(ddsfile);
-
-	dds_header.dwCaps		= cfread_uint(ddsfile);
-	dds_header.dwCaps2		= cfread_uint(ddsfile);
-
-	// Unused but need them checked for later
-	dds_header.dwCaps3		= cfread_uint(ddsfile);
-	dds_header.dwCaps4		= cfread_uint(ddsfile);
-	dds_header.dwReserved2	= cfread_uint(ddsfile);
-
-	// sanity
-	if (dds_header.dwDepth == 0)
-		dds_header.dwDepth = 1;
-
-	if (dds_header.dwMipMapCount < 1)
-		dds_header.dwMipMapCount = 1;
-
-	d_width = dds_header.dwWidth;
-	d_height = dds_header.dwHeight;
-	d_depth = dds_header.dwDepth;
-
-	// calculate the type and size of the data
+	// determine and verify the type of data for internal use
 	if (dds_header.ddspf.dwFlags & DDPF_FOURCC) {
-		// did I mention lately that I hate Microsoft?
-		// this is here to fix the situation where Microsoft doesn't follow their own docs
-		if ( !(dds_header.dwFlags & (DDSD_LINEARSIZE | DDSD_PITCH) ) || dds_header.dwPitchOrLinearSize <= 0 ) {
-			// calculate the block size, mult by 8 for DXT1, 16 for DXT3 & 5
-			d_size = ((dds_header.dwWidth + 3)/4) * ((dds_header.dwHeight + 3)/4) * ((dds_header.dwDepth + 3)/4) * ((dds_header.ddspf.dwFourCC == FOURCC_DXT1) ? 8 : 16);
-		} else {
-			d_size = dds_header.dwPitchOrLinearSize;
-		}
-
-		// if we have mipmaps then compute them into the final size too
-		for (i = 1; i < (int)dds_header.dwMipMapCount; i++) {
-			// reduce size by half for the next pass
-			d_width /= 2;
-			d_height /= 2;
-
-			if (d_width <= 0)
-				d_width = 1;
-
-			if (d_height <= 0)
-				d_height = 1;
-
-			// size of data block (4x4)
-			d_size += ((d_width + 3) / 4) * ((d_height + 3) / 4) * ((dds_header.ddspf.dwFourCC == FOURCC_DXT1) ? 8 : 16);
-		}
-
-		if ( dds_header.dwCaps2 & DDSCAPS2_CUBEMAP ) {
-			if ( !(dds_header.dwCaps2 & DDSCAPS2_CUBEMAP_ALLFACES) ) {
-				retval = DDS_ERROR_CUBEMAP_FACES;
-				ct = DDS_DXT_INVALID;
-				goto Done;
-			}
-
-			// it's a valid cubemap, probably
-			is_cubemap = 1;
-
-			// the previously computed size is just per face, mult by 6 for full size
-			d_size *= 6;
-		}
-
-		Assert( d_size > 0 );
-		*size = d_size;
-
 		switch (dds_header.ddspf.dwFourCC) {
 			case FOURCC_DXT1:
-				bits = 24;
 				ct = (is_cubemap) ? DDS_CUBEMAP_DXT1 : DDS_DXT1;
 				break;
 
 			case FOURCC_DXT3:
-				bits = 32;
 				ct = (is_cubemap) ? DDS_CUBEMAP_DXT3 : DDS_DXT3;
 				break;
 
 			case FOURCC_DXT5:
-				bits = 32;
 				ct = (is_cubemap) ? DDS_CUBEMAP_DXT5 : DDS_DXT5;
 				break;
 
@@ -200,9 +304,8 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 				break;
 
 			case FOURCC_DX10:
-				if (dds_read_dx10_header(ddsfile, &dds_header_dx10)) {
+				if (valid_dx10_format(dds_header_dx10)) {
 					// Currently only BC7 is supported
-					bits = 32;
 					ct = DDS_BC7;
 				} else {
 					retval = DDS_ERROR_UNSUPPORTED;
@@ -218,51 +321,27 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 				goto Done;
 				break;
 		}
-	} else if ( dds_header.ddspf.dwFlags & (DDPF_RGB | DDPF_PALETTEINDEXED8) ) {
-		d_size += d_width * d_height * d_depth * (dds_header.ddspf.dwRGBBitCount / 8);
-
-		// calculate full data size for all mipmap levels
-		for (i = 1; i < (int)dds_header.dwMipMapCount; i++) {
-			d_width /= 2;
-			d_height /= 2;
-			d_depth /= 2;
-
-			if (d_width < 1)
-				d_width = 1;
-
-			if (d_height < 1)
-				d_height = 1;
-
-			if (d_depth < 1)
-				d_depth = 1;
-
-			d_size += d_width * d_height * d_depth * (dds_header.ddspf.dwRGBBitCount / 8);
-		}
-
-		Assert( d_size > 0 );
-
-		if ( dds_header.dwCaps2 & DDSCAPS2_CUBEMAP ) {
-			if ( !(dds_header.dwCaps2 & DDSCAPS2_CUBEMAP_ALLFACES) ) {
-				retval = DDS_ERROR_CUBEMAP_FACES;
-				ct = DDS_DXT_INVALID;
-				goto Done;
-			}
-
-			// it's a valid cubemap, probably
-			is_cubemap = 1;
-
-			// the previously computed size is just per face, mult by 6 for full size
-			d_size *= 6;
-		}
-
-		*size = d_size;
-		
-		bits = dds_header.ddspf.dwRGBBitCount;
+	} else if (dds_header.ddspf.dwFlags & DDPF_RGB) {
 		ct = (is_cubemap) ? DDS_CUBEMAP_UNCOMPRESSED : DDS_UNCOMPRESSED;
 	} else {
 		// it's not a readable format
 		retval = DDS_ERROR_INVALID_FORMAT;
 		goto Done;
+	}
+
+	// maybe do conversion if format not supported
+	if (conversion_needed(dds_header)) {
+		// switch to uncompressed format and reset vars
+		dds_header.ddspf.dwFlags &= ~DDPF_FOURCC;
+		dds_header.ddspf.dwFlags |= DDPF_RGB;
+
+		dds_header.ddspf.dwRGBBitCount = 32;
+
+		// NOTE: modifies header and returns offset for mipmap count
+		dds_header.dwMipMapCount -= conversion_resize(dds_header);
+		dds_header.dwMipMapCount = std::max(1U, dds_header.dwMipMapCount);
+
+		ct = (is_cubemap) ? DDS_CUBEMAP_UNCOMPRESSED : DDS_UNCOMPRESSED;
 	}
 
 	// we don't support compressed, non-power-of-2 images
@@ -271,15 +350,12 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 		goto Done;
 	}
 
-	// make sure that the video card can handle compressed textures before using them
-	if ( !Use_compressed_textures && (ct != DDS_UNCOMPRESSED) && (ct != DDS_DXT_INVALID) ) {
-		retval = DDS_ERROR_NO_COMPRESSION;
-		goto Done;
-	}
-
 	// stuff important info
+	if (size)
+		*size = compute_dds_size(dds_header);
+
 	if (bpp)
-		*bpp = bits;
+		*bpp = get_bit_count(dds_header);
 
 	if (compression_type)
 		*compression_type = ct;
@@ -292,12 +368,6 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 
 	if (levels)
 		*levels = dds_header.dwMipMapCount;
-
-	if (palette && (bits == 8)) {
-		cfseek(ddsfile, (ct == DDS_BC7) ? DX10_OFFSET : DDS_OFFSET, CF_SEEK_SET);
-		cfread(palette, 1, 1024, ddsfile);
-	}
-
 
 Done:
 	if (img_cfp == NULL) {
@@ -313,11 +383,10 @@ Done:
 int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
 {
 	int retval;
-	int w,h,ct,lvl;
 	size_t size = 0;
-	int bits = 0;
 	CFILE *cfp;
 	char real_name[MAX_FILENAME_LEN];
+	DDS_HEADER dds_header;
 
 	// this better not happen.. ever
 	Assert(filename != NULL);
@@ -332,25 +401,104 @@ int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
 	cfp = cfopen(real_name, "rb", CFILE_NORMAL, cf_type);
 
 	// just in case
-	if (cfp == NULL)
+	if (cfp == nullptr)
 		return DDS_ERROR_INVALID_FILENAME;
 
 	// read the header -- if its at this stage, it should be legal.
-	retval = dds_read_header(real_name, cfp, &w, &h, &bits, &ct, &lvl, &size);
+	retval = _dds_read_header(cfp, dds_header);
 	Assert(retval == DDS_ERROR_NONE);
 
 	// this really shouldn't be needed but better safe than sorry
 	if (retval != DDS_ERROR_NONE) {
+		cfclose(cfp);
 		return retval;
 	}
 
-	cfseek(cfp, (ct == DDS_BC7) ? DX10_OFFSET : DDS_OFFSET, CF_SEEK_SET);
+	cfseek(cfp, (dds_header.ddspf.dwFourCC == FOURCC_DX10) ? DX10_OFFSET : DDS_OFFSET, CF_SEEK_SET);
+
+	size = compute_dds_size(dds_header);
 
 	// read in the data
-	cfread(data, 1, (int)size, cfp);
+	if ( !conversion_needed(dds_header) ) {
+		cfread(data, 1, (int)size, cfp);
+	} else {
+		// Compression format not supported, convert to BGRA
+		ubyte *comp_data = (ubyte*)vm_malloc(size);
+
+		cfread(comp_data, 1, (int)size, cfp);
+
+		ubyte *src = comp_data;
+		ubyte *dst = data;
+
+		uint d_width, d_height, d_depth;
+		size_t data_offset = 0;
+
+		// NOTE: this alters the width, height, and depth values in the header,
+		//       so we have to jump through some hoops to get the proper values
+		const uint mipmap_offset = conversion_resize(dds_header);
+
+		const int num_faces = (dds_header.dwCaps2 & DDSCAPS2_CUBEMAP) ? 6 : 1;
+		const bool has_depth = (dds_header.dwFlags & DDSD_DEPTH) == DDSD_DEPTH;
+
+		for (int f = 0; f < num_faces; ++f) {
+			// if we resized then skip over all of that data (altering values to match pre-resize)
+			for (uint x = 0; x < mipmap_offset; ++x) {
+				d_width = std::max(1U, dds_header.dwWidth << (mipmap_offset - x));
+				d_height = std::max(1U, dds_header.dwHeight << (mipmap_offset - x));
+				d_depth = has_depth ? std::max(1U, dds_header.dwDepth << (mipmap_offset - x)) : 1U;
+
+				src += (d_width * d_height * d_depth);
+			}
+
+			for (uint m = mipmap_offset; m < dds_header.dwMipMapCount; ++m) {
+				// width/height/depth at post-resize mipmap sizes, so compensate here
+				d_width = std::max(1U, dds_header.dwWidth >> (m - mipmap_offset));
+				d_height = std::max(1U, dds_header.dwHeight >> (m - mipmap_offset));
+				d_depth = std::max(1U, dds_header.dwDepth >> (m - mipmap_offset));
+
+				for (auto d = 0; d < d_depth; ++d) {
+					for (auto i = 0; i < d_height; i += 4) {
+						for (auto j = 0; j < d_width; j += 4) {
+							dst = data + data_offset + ((i * d_width + j) * 4);
+
+							if (dds_header.ddspf.dwFourCC == FOURCC_DX10) {
+								bcdec_bc7(src, dst, d_width * 4);
+								src += BCDEC_BC7_BLOCK_SIZE;
+							} else if (dds_header.ddspf.dwFourCC == FOURCC_DXT5) {
+								bcdec_bc3(src, dst, d_width * 4);
+								src += BCDEC_BC3_BLOCK_SIZE;
+							} else if (dds_header.ddspf.dwFourCC == FOURCC_DXT1) {
+								bcdec_bc1(src, dst, d_width * 4);
+								src += BCDEC_BC1_BLOCK_SIZE;
+							} else if (dds_header.ddspf.dwFourCC == FOURCC_DXT3) {
+								bcdec_bc2(src, dst, d_width * 4);
+								src += BCDEC_BC2_BLOCK_SIZE;
+							}
+						}
+					}
+				}
+
+				// we need it in bgra, XOR to the rescue
+				for (size_t x = data_offset; x < (data_offset + (d_width * d_height * d_depth * 4)); x += 4) {
+					data[x] ^= data[x+2], data[x+2] ^= data[x], data[x] ^= data[x+2];
+				}
+
+				// bump data offset to next layer
+				data_offset += (d_width * d_height * d_depth * 4);
+			}
+		}
+
+		vm_free(comp_data);
+		comp_data = nullptr;
+
+		// switch to uncompressed format and reset vars (needed below to get correct bit count)
+		dds_header.ddspf.dwFlags &= ~DDPF_FOURCC;
+		dds_header.ddspf.dwFlags |= DDPF_RGB;
+		dds_header.ddspf.dwRGBBitCount = 32;
+	}
 
 	if (bpp)
-		*bpp = (ubyte)bits;
+		*bpp = (ubyte)get_bit_count(dds_header);
 
 	// we look done here
 	cfclose(cfp);

--- a/code/ddsutils/ddsutils.cpp
+++ b/code/ddsutils/ddsutils.cpp
@@ -3,7 +3,12 @@
 #include "cfile/cfile.h"
 #include "osapi/osregistry.h"
 
-#include "glad/glad.h"
+#ifdef WITH_OPENGL
+#include <glad/glad.h>
+#else
+static constexpr int GLAD_GL_EXT_texture_compression_s3tc = 0;
+static constexpr int GLAD_GL_ARB_texture_compression_bptc = 0;
+#endif
 
 #define BCDEC_IMPLEMENTATION 1
 PUSH_SUPPRESS_WARNINGS

--- a/code/ddsutils/ddsutils.cpp
+++ b/code/ddsutils/ddsutils.cpp
@@ -192,7 +192,7 @@ static size_t compute_dds_size(const DDS_HEADER &dds_header)
 	uint d_width, d_height, d_depth;
 	size_t d_size = 0;
 
-	for (auto i = 0; i < dds_header.dwMipMapCount; i++) {
+	for (uint i = 0; i < dds_header.dwMipMapCount; i++) {
 		d_width = std::max(1U, dds_header.dwWidth >> i);
 		d_height = std::max(1U, dds_header.dwHeight >> i);
 		d_depth = std::max(1U, dds_header.dwDepth >> i);
@@ -456,9 +456,9 @@ int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
 				d_height = std::max(1U, dds_header.dwHeight >> (m - mipmap_offset));
 				d_depth = std::max(1U, dds_header.dwDepth >> (m - mipmap_offset));
 
-				for (auto d = 0; d < d_depth; ++d) {
-					for (auto i = 0; i < d_height; i += 4) {
-						for (auto j = 0; j < d_width; j += 4) {
+				for (uint d = 0; d < d_depth; ++d) {
+					for (uint i = 0; i < d_height; i += 4) {
+						for (uint j = 0; j < d_width; j += 4) {
 							dst = data + data_offset + ((i * d_width + j) * 4);
 
 							if (dds_header.ddspf.dwFourCC == FOURCC_DX10) {

--- a/code/ddsutils/ddsutils.cpp
+++ b/code/ddsutils/ddsutils.cpp
@@ -3,10 +3,12 @@
 #include "cfile/cfile.h"
 #include "osapi/osregistry.h"
 
-#include <glad/glad.h>
+#include "glad/glad.h"
 
 #define BCDEC_IMPLEMENTATION 1
+PUSH_SUPPRESS_WARNINGS
 #include "ddsutils/bcdec.h"
+POP_SUPPRESS_WARNINGS
 
 /*	Currently supported formats:
  *		DXT1a	(compressed)

--- a/code/ddsutils/ddsutils.h
+++ b/code/ddsutils/ddsutils.h
@@ -59,6 +59,7 @@
 #define DDSD_HEIGHT				0x00000002
 #define DDSD_CAPS				0x00000001
 #define DDSD_MIPMAPCOUNT		0x00020000
+#define DDSD_DEPTH				0x00800000
 
 #define DDSCAPS_COMPLEX			0x00000008
 #define DDSCAPS_PRIMARYSURFACE	0x00000200
@@ -278,7 +279,7 @@ typedef struct {
 //reads a dds header
 //returns one of the error values
 //'compression_type' comes back as one of the DDS_DXTC* defines
-int dds_read_header(const char *filename, CFILE *img_cfp = NULL, int *width = 0, int *height = 0, int *bpp = 0, int *compression_type = 0, int *levels = 0, size_t *size = 0, ubyte *palette = NULL);
+int dds_read_header(const char *filename, CFILE *img_cfp = NULL, int *width = 0, int *height = 0, int *bpp = 0, int *compression_type = 0, int *levels = 0, size_t *size = 0);
 
 //reads bitmap
 //size of the data it stored in size
@@ -289,8 +290,5 @@ void dds_save_image(int width, int height, int bpp, int num_mipmaps, ubyte *data
 
 //returns a string from a DDS error code
 const char *dds_error_string(int code);
-
-extern int Texture_compression_available;
-extern int Use_compressed_textures;
 
 #endif //__DDS_H

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -1202,9 +1202,6 @@ static bool printNextDebugMessage() {
 #endif
 
 static void init_extensions() {
-	// if S3TC compression is found, then "GL_ARB_texture_compression" must be an extension
-	Use_compressed_textures = GLAD_GL_EXT_texture_compression_s3tc;
-	Texture_compression_available = true;
 	// Swifty put this in, but it's not doing anything. Once he uses it, he can uncomment it.
 	//int use_base_vertex = Is_Extension_Enabled(OGL_ARB_DRAW_ELEMENTS_BASE_VERTEX);
 
@@ -1412,8 +1409,8 @@ bool gr_opengl_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps)
 		  GL_max_renderbuffer_size,
 		  GL_max_renderbuffer_size ));
 
-	mprintf(( "  Can use compressed textures: %s\n", Use_compressed_textures ? NOX("YES") : NOX("NO") ));
-	mprintf(( "  Texture compression available: %s\n", Texture_compression_available ? NOX("YES") : NOX("NO") ));
+	mprintf(( "  S3TC texture support: %s\n", GLAD_GL_EXT_texture_compression_s3tc ? NOX("YES") : NOX("NO") ));
+	mprintf(( "  BPTC texture support: %s\n", GLAD_GL_ARB_texture_compression_bptc ? NOX("YES") : NOX("NO") ));
 	mprintf(( "  Post-processing enabled: %s\n", (Gr_post_processing_enabled) ? "YES" : "NO"));
 	mprintf(( "  Using %s texture filter.\n", (GL_mipmap_filter) ? NOX("trilinear") : NOX("bilinear") ));
 

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1225,7 +1225,7 @@ int opengl_compress_image( ubyte **compressed_data, ubyte *in_data, int width, i
 {
 	Assert( in_data != NULL );
 
-	if ( !Texture_compression_available ) {
+	if ( !GLAD_GL_EXT_texture_compression_s3tc ) {
 		return 0;
 	}
 


### PR DESCRIPTION
Adds bcdec lib to convert compressed DDS textures to RGBA based on what the system supports. BC7 if BPTC extension not supported, DXT? if S3TC extension not supported.

Should support cubemaps and volume textures but those were not tested.

Addtional changes:
 - remove indexed DDS support since it had bugs but didn't work anyway (R8 should be used instead)
 - fix issues with volume textures (nothing to test with)
 - remove old compression support flags as they are now obsolete

Fixes #4920