### PR TITLE
limit debug log spam from file shadows

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -826,7 +826,8 @@ static void check_file_shadows(const int root_index __UNUSED, const int pathtype
 		}
 
 		// this log message occurs in the middle of an existing line, hence the extra new lines
-		mprintf(("\nWARNING! A %sfile being indexed may be shadowed by an existing file!\n New:\n  %s\n Existing:\n  %s\n",
+		// critical files and files in same root are always logged, files in different root are behind a filter
+		nprintf(((critical || !root->path.compare(r->path)) ? "General" : "CFileSystem", "\nWARNING! A %sfile being indexed may be shadowed by an existing file!\n New:\n  %s\n Existing:\n  %s\n",
 				critical ? "critical " : "",
 				newfile.c_str(), curfile.c_str()));
 


### PR DESCRIPTION
Always log the possible shadow if:
 1) it's a critical file
 2) it's in the same root

Otherwise log it behind a debug filter ("CFileSystem").