### PR TITLE
clean up and update macOS bundle info

### DIFF
--- a/freespace2/resources.cmake
+++ b/freespace2/resources.cmake
@@ -53,15 +53,12 @@ elseif(PLATFORM_MAC)
     set_target_properties(Freespace2 PROPERTIES MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/${subpath}/Info.plist.in")
     set_target_properties(Freespace2 PROPERTIES MACOSX_BUNDLE_ICON_FILE "FS2_Open")
     set_target_properties(Freespace2 PROPERTIES MACOSX_BUNDLE_LONG_VERSION_STRING "${FSO_FULL_VERSION_STRING}")
-    set_target_properties(Freespace2 PROPERTIES MACOSX_BUNDLE_SHORT_VERSION_STRING "${FSO_FULL_VERSION_STRING}")
-    
-    CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/${subpath}/InfoPlist.strings.in" "${CMAKE_CURRENT_BINARY_DIR}/InfoPlist.strings")
+    set_target_properties(Freespace2 PROPERTIES MACOSX_BUNDLE_SHORT_VERSION_STRING "${FSO_PRODUCT_VERSION_STRING}")
+    set_target_properties(Freespace2 PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME "FreeSpace Open")
     
     # Copy everything from the Resources directory
     add_custom_command(TARGET Freespace2 POST_BUILD
         COMMAND cp -a "${CMAKE_CURRENT_SOURCE_DIR}/${subpath}/Resources" "$<TARGET_FILE_DIR:Freespace2>/../Resources"
-        COMMAND mkdir -p "$<TARGET_FILE_DIR:Freespace2>/../Resources/English.lproj/"
-        COMMAND cp -a "${CMAKE_CURRENT_BINARY_DIR}/InfoPlist.strings" "$<TARGET_FILE_DIR:Freespace2>/../Resources/English.lproj/"
         COMMENT "Copying resources into bundle..."
     )
 else()

--- a/freespace2/resources/mac/Info.plist.in
+++ b/freespace2/resources/mac/Info.plist.in
@@ -12,16 +12,20 @@
 	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleDisplayName</key>
+	<string>FreeSpace Open</string>
 	<key>CFBundleName</key>
-	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<string>FreeSpace Open</string>
+	<key>CFBundleIdentifier</key>
+	<string>us.indiegames.scp.FreeSpaceOpen</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleShortVersionString</key>
-	<string>${FSO_FULL_VERSION_STRING}</string>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>CFBundleVersion</key>
-	<string>${FSO_FULL_VERSION_STRING}</string>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>
@@ -30,5 +34,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright 1999 Volition, Inc. &amp; Copyright 2005-2024 The Source Code Project.</string>
 </dict>
 </plist>

--- a/freespace2/resources/mac/Info.plist.in
+++ b/freespace2/resources/mac/Info.plist.in
@@ -35,6 +35,6 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 1999 Volition, Inc. &amp; Copyright 2005-2024 The Source Code Project.</string>
+	<string>Copyright 1999 Volition, Inc. &amp; Copyright 2002-2024 The Source Code Project.</string>
 </dict>
 </plist>

--- a/freespace2/resources/mac/InfoPlist.strings.in
+++ b/freespace2/resources/mac/InfoPlist.strings.in
@@ -1,5 +1,0 @@
-/* Localized versions of Info.plist keys */
-
-CFBundleShortVersionString = "FreeSpace 2 Open version ${FSO_FULL_VERSION_STRING}";
-CFBundleGetInfoString = "FreeSpace 2 Open version ${FSO_FULL_VERSION_STRING}, Copyright 1999 Volition, Inc. & Copyright 2005-2010 The Source Code Project.";
-NSHumanReadableCopyright = "Copyright 1999 Volition, Inc. & Copyright 2005-2010 The Source Code Project.";


### PR DESCRIPTION
 - Set app name properly per Apple docs
 - Use correct "FreeSpace Open" name
 - Set version properly per Apple docs
 - Add bundle identifier
 - Update copyright date
 - Remove localized strings since they are all English already