### PR TITLE
enhancements for submodel collisions

### DIFF
--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -1198,15 +1198,13 @@ int model_collide(mc_info *mc_info_obj)
 
 	}
 
-	if ( Mc->flags & MC_SUBMODEL )	{
-		// Check only one subobject
-		mc_check_subobj( Mc->submodel_num );
-		// Check submodel and any children
-	} else if (Mc->flags & MC_SUBMODEL_INSTANCE) {
+	// Check only one subobject; or check submodel and any children
+	if ( (Mc->flags & MC_SUBMODEL) || (Mc->flags & MC_SUBMODEL_INSTANCE) ) {
+		// note: within this function, MC_SUBMODEL will return after one check; but MC_SUBMODEL_INSTANCE will not
 		mc_check_subobj(Mc->submodel_num);
-	} else {
-		// Check all the the highest detail model polygons and subobjects for intersections
-
+	}
+	// Check all the the highest detail model polygons and subobjects for intersections
+	else {
 		// Don't check it or its children if it is destroyed
 		if ( Mc_pmi ) {
 			if ( !Mc_pmi->submodel[Mc_pm->detail[0]].blown_off ) {

--- a/code/object/collidedebrisship.cpp
+++ b/code/object/collidedebrisship.cpp
@@ -17,6 +17,7 @@
 #include "object/object.h"
 #include "scripting/global_hooks.h"
 #include "scripting/scripting.h"
+#include "scripting/api/objs/model.h"
 #include "scripting/api/objs/vecmath.h"
 #include "playerman/player.h"
 #include "ship/ship.h"
@@ -74,6 +75,10 @@ int collide_debris_ship( obj_pair * pair )
 		{
 			bool ship_override = false, debris_override = false;
 
+			// get submodel handle if scripting needs it
+			bool has_submodel = (debris_hit_info.heavy_submodel_num >= 0);
+			scripting::api::submodel_h smh(debris_hit_info.heavy_model_num, debris_hit_info.heavy_submodel_num);
+
 			if (scripting::hooks::OnDebrisCollision->isActive()) {
 				ship_override = scripting::hooks::OnDebrisCollision->isOverride(scripting::hooks::CollisionConditions{ {ship_objp, debris_objp} },
 					scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
@@ -84,12 +89,13 @@ int collide_debris_ship( obj_pair * pair )
 			}
 
 			if (scripting::hooks::OnShipCollision->isActive()) {
-				debris_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{{ship_objp, debris_objp}},
+				debris_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{ {ship_objp, debris_objp} },
 					scripting::hook_param_list(scripting::hook_param("Self", 'o', debris_objp),
 						scripting::hook_param("Object", 'o', ship_objp),
 						scripting::hook_param("Ship", 'o', ship_objp),
 						scripting::hook_param("Debris", 'o', debris_objp),
-						scripting::hook_param("Hitpos", 'o', hitpos)));
+						scripting::hook_param("Hitpos", 'o', hitpos),
+						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (debris_hit_info.heavy == ship_objp))));
 			}
 
 			if(!ship_override && !debris_override)
@@ -139,7 +145,7 @@ int collide_debris_ship( obj_pair * pair )
 						quadrant_num = -1;
 					}
 					if (apply_ship_damage) {
-						ship_apply_local_damage(debris_hit_info.heavy, debris_hit_info.light, &hitpos, ship_damage, Debris[debris_objp->instance].damage_type_idx, quadrant_num, CREATE_SPARKS, debris_hit_info.submodel_num);
+						ship_apply_local_damage(debris_hit_info.heavy, debris_hit_info.light, &hitpos, ship_damage, Debris[debris_objp->instance].damage_type_idx, quadrant_num, CREATE_SPARKS, debris_hit_info.heavy_submodel_num);
 					}
 				} else {
 					// don't draw sparks using sphere hit position
@@ -166,12 +172,13 @@ int collide_debris_ship( obj_pair * pair )
 			}
 			if (scripting::hooks::OnShipCollision->isActive() && ((debris_override && !ship_override) || (!debris_override && !ship_override)))
 			{
-				scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{{ship_objp, debris_objp}},
+				scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{ {ship_objp, debris_objp} },
 					scripting::hook_param_list(scripting::hook_param("Self", 'o', debris_objp),
 						scripting::hook_param("Object", 'o', ship_objp),
 						scripting::hook_param("Ship", 'o', ship_objp),
 						scripting::hook_param("Debris", 'o', debris_objp),
-						scripting::hook_param("Hitpos", 'o', hitpos)));
+						scripting::hook_param("Hitpos", 'o', hitpos),
+						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (debris_hit_info.heavy == ship_objp))));
 			}
 
 			return 0;
@@ -252,6 +259,10 @@ int collide_asteroid_ship( obj_pair * pair )
 		{
 			bool ship_override = false, asteroid_override = false;
 
+			// get submodel handle if scripting needs it
+			bool has_submodel = (asteroid_hit_info.heavy_submodel_num >= 0);
+			scripting::api::submodel_h smh(asteroid_hit_info.heavy_model_num, asteroid_hit_info.heavy_submodel_num);
+
 			//Scripting support (WMC)
 			if (scripting::hooks::OnAsteroidCollision->isActive()) {
 				ship_override = scripting::hooks::OnAsteroidCollision->isOverride(scripting::hooks::CollisionConditions{ {ship_objp, asteroid_objp} },
@@ -262,12 +273,13 @@ int collide_asteroid_ship( obj_pair * pair )
 						scripting::hook_param("Hitpos", 'o', hitpos)));
 			}
 			if (scripting::hooks::OnShipCollision->isActive()) {
-				asteroid_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{{ship_objp, asteroid_objp}},
+				asteroid_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{ {ship_objp, asteroid_objp} },
 					scripting::hook_param_list(scripting::hook_param("Self", 'o', asteroid_objp),
 						scripting::hook_param("Object", 'o', ship_objp),
 						scripting::hook_param("Ship", 'o', ship_objp),
 						scripting::hook_param("Asteroid", 'o', asteroid_objp),
-						scripting::hook_param("Hitpos", 'o', hitpos)));
+						scripting::hook_param("Hitpos", 'o', hitpos),
+						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (asteroid_hit_info.heavy == ship_objp))));
 			}
 
 			if(!ship_override && !asteroid_override)
@@ -323,7 +335,7 @@ int collide_asteroid_ship( obj_pair * pair )
 						(ship_objp->flags[Object::Object_Flags::No_shields]) || !ship_is_shield_up(ship_objp, quadrant_num) ) {
 						quadrant_num = -1;
 					}
-					ship_apply_local_damage(asteroid_hit_info.heavy, asteroid_hit_info.light, &hitpos, ship_damage, ast_damage_type, quadrant_num, CREATE_SPARKS, asteroid_hit_info.submodel_num);
+					ship_apply_local_damage(asteroid_hit_info.heavy, asteroid_hit_info.light, &hitpos, ship_damage, ast_damage_type, quadrant_num, CREATE_SPARKS, asteroid_hit_info.heavy_submodel_num);
 				} else {
 					// don't draw sparks (using sphere hitpos)
 					ship_apply_local_damage(asteroid_hit_info.light, asteroid_hit_info.heavy, &hitpos, ship_damage, ast_damage_type, MISS_SHIELDS, NO_SPARKS);
@@ -347,12 +359,13 @@ int collide_asteroid_ship( obj_pair * pair )
 			}
 			if (scripting::hooks::OnShipCollision->isActive() && ((asteroid_override && !ship_override) || (!asteroid_override && !ship_override)))
 			{
-				scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{{ship_objp, asteroid_objp}},
+				scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{ {ship_objp, asteroid_objp} },
 					scripting::hook_param_list(scripting::hook_param("Self", 'o', asteroid_objp),
 						scripting::hook_param("Object", 'o', ship_objp),
 						scripting::hook_param("Ship", 'o', ship_objp),
 						scripting::hook_param("Asteroid", 'o', asteroid_objp),
-						scripting::hook_param("Hitpos", 'o', hitpos)));
+						scripting::hook_param("Hitpos", 'o', hitpos),
+						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (asteroid_hit_info.heavy == ship_objp))));
 			}
 
 			return 0;

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1185,8 +1185,6 @@ int collide_ship_ship( obj_pair * pair )
 		ship_ship_hit_info.heavy = HeavyOne;		// heavy object, generally slower moving
 		ship_ship_hit_info.light = LightOne;		// light object, generally faster moving
 
-		vec3d world_hit_pos;
-
 		hit = ship_ship_check_collision(&ship_ship_hit_info);
 
 		pair->next_check_time = timestamp(0);
@@ -1194,6 +1192,10 @@ int collide_ship_ship( obj_pair * pair )
 		if ( hit )
 		{
 			bool a_override = false, b_override = false;
+
+			// get world hitpos - do it here in case the override hooks need it
+			vec3d world_hit_pos;
+			vm_vec_add(&world_hit_pos, &ship_ship_hit_info.heavy->pos, &ship_ship_hit_info.hit_pos);
 
 			if (scripting::hooks::OnShipCollision->isActive()) {
 				a_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{{A, B}},
@@ -1244,9 +1246,6 @@ int collide_ship_ship( obj_pair * pair )
 					vm_vec_copy_normalize(&ship_ship_hit_info.collision_normal, &ship_ship_hit_info.r_light);
 					vm_vec_negate(&ship_ship_hit_info.collision_normal);
 				}
-
-				// get world hitpos
-				vm_vec_add(&world_hit_pos, &heavy_obj->pos, &ship_ship_hit_info.r_heavy);
 
 				// do physics
 				calculate_ship_ship_collision_physics(&ship_ship_hit_info);

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -551,7 +551,8 @@ void set_hit_struct_info(collision_info_struct *hit, mc_info *mc, bool submodel_
 	hit->edge_hit = mc->edge_hit;
 	hit->hit_pos = mc->hit_point_world;
 	hit->hit_time = mc->hit_dist;
-	hit->submodel_num = mc->hit_submodel;
+	hit->heavy_model_num = mc->model_num;
+	hit->heavy_submodel_num = mc->hit_submodel;
 
 	hit->submodel_move_hit = submodel_move_hit;
 }

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -31,7 +31,8 @@ struct collision_info_struct {
 	float		impulse;					// damage scales according to impulse
 	vec3d	light_rel_vel;			// velocity of light relative to heavy before collison
 	bool	collide_rotate;		// if collision is being detected purely from rotation (or submodel movement)
-	int		submodel_num;			// submodel of heavy object that is hit
+	int		heavy_model_num;			// model of heavy object that is hit
+	int		heavy_submodel_num;			// submodel of heavy object that is hit
 	bool	edge_hit;				// if edge is hit, need to change collision normal
 	bool	submodel_move_hit;		// if collision is against a moving submodel
 	bool	is_landing;			//SUSHI: Maybe treat current collision as a landing

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -412,6 +412,19 @@ ADE_FUNC(GetVertex, l_Submodel, nullptr, "Gets the specified vertex, or a random
 	return ade_set_args(L, "o", l_Vector.Set(vert));
 }
 
+ADE_FUNC(getModel, l_Submodel, nullptr, "Gets the model that this submodel belongs to", "model", "A model, or an invalid model if the handle is not valid")
+{
+	submodel_h *smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "o", l_Model.Set(model_h()));
+
+	if (!smh->isValid())
+		return ade_set_error(L, "o", l_Model.Set(model_h()));
+
+	return ade_set_args(L, "o", l_Model.Set(model_h(smh->GetModelID())));
+}
+
 ADE_FUNC(getFirstChild, l_Submodel, nullptr, "Gets the first child submodel of this submodel", "submodel", "A submodel, or nil if there is no child, or an invalid submodel if the handle is not valid")
 {
 	submodel_h *smh = nullptr;

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -368,7 +368,6 @@ ADE_VIRTVAR(Radius, l_Submodel, nullptr, "Gets the submodel's radius", "number",
 	return ade_set_args(L, "f", smh->GetSubmodel()->rad);
 }
 
-
 ADE_FUNC(NumVertices, l_Submodel, nullptr, "Returns the number of vertices in the submodel's mesh", "submodel", "The number of vertices, or 0 if the submodel was invalid")
 {
 	submodel_h* smh = nullptr;
@@ -471,6 +470,38 @@ ADE_FUNC(isValid, l_Submodel, nullptr, "True if valid, false or nil if not", "bo
 		return ADE_RETURN_FALSE;
 
 	return ade_set_args(L, "b", smh->isValid());
+}
+
+ADE_VIRTVAR(NoCollide, l_Submodel, nullptr, "Whether the submodel and its children ignore collisions", "boolean", "The flag, or error-false if invalid")
+{
+	submodel_h* smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "b", false);
+
+	if (!smh->isValid())
+		return ade_set_error(L, "b", false);
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting NoCollide is not supported");
+
+	return ade_set_args(L, "b", smh->GetSubmodel()->flags[Model::Submodel_flags::No_collisions]);
+}
+
+ADE_VIRTVAR(NoCollideThisOnly, l_Submodel, nullptr, "Whether the submodel itself ignores collisions", "boolean", "The flag, or error-false if invalid")
+{
+	submodel_h* smh = nullptr;
+
+	if (!ade_get_args(L, "o", l_Submodel.GetPtr(&smh)))
+		return ade_set_error(L, "b", false);
+
+	if (!smh->isValid())
+		return ade_set_error(L, "b", false);
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting NoCollideThisOnly is not supported");
+
+	return ade_set_args(L, "b", smh->GetSubmodel()->flags[Model::Submodel_flags::Nocollide_this_only]);
 }
 
 

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -108,17 +108,16 @@ const std::shared_ptr<Hook<ShipSourceConditions>> OnDebrisCreated = Hook<ShipSou
 
 const std::shared_ptr<OverridableHook<CollisionConditions>> OnShipCollision = OverridableHook<CollisionConditions>::Factory("On Ship Collision",
 	"Invoked when a ship collides with another object. Note: When two ships collide this will be called twice, once "
-	"with each ship object as the \"Ship\" parameter.",
-	{{"Self", "object", "The \"other\" object that collided with the ship."},
-		{"Object",
-			"ship",
-			"The ship object with which the \"other\" object collided with. Provided for consistency with other "
-			"collision hooks."},
-		{"Ship", "ship", "Same as \"Object\""},
+	"with each ship as the \"Self\" parameter.",
+	{{"Self", "object", "The object the ship collided with."},
+		{"Object", "ship",
+			"The ship that collided with \"Self\". Provided for consistency with other collision hooks."},
+		{"Ship", "ship", "For ship-on-ship collisions, the same as \"Self\". For ship-on-object collisions, the same as \"Object\"."},
 		{"Hitpos", "vector", "The world position where the collision was detected"},
+		{"ShipSubmodel", "submodel", "The submodel of \"Ship\" involved in the collision, if \"Ship\" was the heavier object"},
 		{"Debris", "object", "The debris object with which the ship collided (only set for debris collisions)"},
 		{"Asteroid", "object", "The asteroid object with which the ship collided (only set for asteroid collisions)"},
-		{"ShipB", "ship", "For ship on ship collisions, the \"other\" ship."},
+		{"ShipB", "ship", "For ship-on-ship collisions, the same as \"Object\" (only set for ship-on-ship collisions)"},
 		{"Weapon", "weapon", "The weapon object with which the ship collided (only set for weapon collisions)"},
 		{"Beam", "weapon", "The beam object with which the ship collided (only set for beam collisions)"}});
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -40,6 +40,7 @@
 #include "parse/parselo.h"
 #include "scripting/global_hooks.h"
 #include "scripting/scripting.h"
+#include "scripting/api/objs/model.h"
 #include "scripting/api/objs/vecmath.h"
 #include "particle/particle.h"
 #include "playerman/player.h"
@@ -3236,6 +3237,10 @@ int beam_collide_ship(obj_pair *pair)
 		{
 			bool ship_override = false, weapon_override = false;
 
+			// get submodel handle if scripting needs it
+			bool has_submodel = (mc_array[i]->hit_submodel >= 0);
+			scripting::api::submodel_h smh(mc_array[i]->model_num, mc_array[i]->hit_submodel);
+
 			if (scripting::hooks::OnBeamCollision->isActive()) {
 				ship_override = scripting::hooks::OnBeamCollision->isOverride(scripting::hooks::CollisionConditions{ {ship_objp, weapon_objp} },
 					scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
@@ -3251,7 +3256,8 @@ int beam_collide_ship(obj_pair *pair)
 						scripting::hook_param("Object", 'o', ship_objp),
 						scripting::hook_param("Ship", 'o', ship_objp),
 						scripting::hook_param("Beam", 'o', weapon_objp),
-						scripting::hook_param("Hitpos", 'o', mc_array[i]->hit_point_world)));
+						scripting::hook_param("Hitpos", 'o', mc_array[i]->hit_point_world),
+						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel)));
 			}
 
 			if (!ship_override && !weapon_override)
@@ -3276,7 +3282,8 @@ int beam_collide_ship(obj_pair *pair)
 						scripting::hook_param("Object", 'o', ship_objp),
 						scripting::hook_param("Ship", 'o', ship_objp),
 						scripting::hook_param("Beam", 'o', weapon_objp),
-						scripting::hook_param("Hitpos", 'o', mc_array[i]->hit_point_world)));
+						scripting::hook_param("Hitpos", 'o', mc_array[i]->hit_point_world),
+						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel)));
 			}
 		}
 	}


### PR DESCRIPTION
In the first commit:
* Expose NoCollide and NoCollideThisOnly as virtual variables for submodels
* Allow submodels to be optionally specified in object:checkRayCollision
* Be sure to calculate ship-to-ship hit position before the override collision hook is called, in case the hook needs this value.  (The other collision hooks already calculate the hit position before the override hook.)

And in the second:
* Add the submodel that was hit to the On Ship Collision scripting hook.  (This will only be non-nil if the ship was the "heavy object".)
* Add a `getModel()` function to the scripted submodel object.
* Fix some incorrect documentation in `OnShipCollision`.

These will enhance the movement script in Star Fox: Event Horizon.