### PR TITLE
add a HUD virtvar for contrast

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -81,7 +81,7 @@ int HUD_color_blue = 0;
 int HUD_color_alpha = HUD_COLOR_ALPHA_DEFAULT;		// 1 -> HUD_COLOR_ALPHA_USER_MAX
 
 int HUD_draw     = 1;
-int HUD_contrast = 0;										// high or lo contrast (for nebula, etc)
+bool HUD_high_contrast = false;										// high or low contrast (for nebula, etc)
 bool HUD_shadows = false;
 
 // Goober5000
@@ -488,17 +488,17 @@ void HudGauge::setGaugeColor(int bright_index)
 	if(bright_index != HUD_C_NONE){
 		switch(bright_index){
 		case HUD_C_DIM:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_DIM_HI : HUD_NEW_ALPHA_DIM;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_DIM_HI : HUD_NEW_ALPHA_DIM;
 			gr_init_alphacolor(&gauge_color, gauge_color.red, gauge_color.green, gauge_color.blue, alpha);
 			break;
 
 		case HUD_C_NORMAL:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_NORMAL_HI : HUD_NEW_ALPHA_NORMAL;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_NORMAL_HI : HUD_NEW_ALPHA_NORMAL;
 			gr_init_alphacolor(&gauge_color, gauge_color.red, gauge_color.green, gauge_color.blue, alpha);
 			break;
 
 		case HUD_C_BRIGHT:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_BRIGHT_HI : HUD_NEW_ALPHA_BRIGHT;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_BRIGHT_HI : HUD_NEW_ALPHA_BRIGHT;
 			gr_init_alphacolor(&gauge_color, gauge_color.red, gauge_color.green, gauge_color.blue, alpha);
 			break;
 
@@ -528,15 +528,15 @@ void HudGauge::setGaugeColor(int bright_index)
 	} else {
 		switch(maybeFlashSexp()) {
 		case 0:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_DIM_HI : HUD_NEW_ALPHA_DIM;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_DIM_HI : HUD_NEW_ALPHA_DIM;
 			gr_init_alphacolor(&gauge_color, gauge_color.red, gauge_color.green, gauge_color.blue, alpha);
 			break;
 		case 1:			
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_BRIGHT_HI : HUD_NEW_ALPHA_BRIGHT;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_BRIGHT_HI : HUD_NEW_ALPHA_BRIGHT;
 			gr_init_alphacolor(&gauge_color, gauge_color.red, gauge_color.green, gauge_color.blue, alpha);
 			break;
 		default:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_NORMAL_HI : HUD_NEW_ALPHA_NORMAL;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_NORMAL_HI : HUD_NEW_ALPHA_NORMAL;
 			gr_init_alphacolor(&gauge_color, gauge_color.red, gauge_color.green, gauge_color.blue, alpha);
 		}
 	}
@@ -1302,12 +1302,12 @@ void HUD_init()
 	last_percent_throttle = 0.0f;
 
 	// default to high contrast in the nebula
-	HUD_contrast = 0;
+	HUD_high_contrast = false;
 	HUD_draw     = 1;
 	HUD_disable_except_messages = 0;
 
 	if(The_mission.flags[Mission::Mission_Flags::Fullneb]){
-		HUD_contrast = 1;
+		HUD_high_contrast = true;
 	}
 
 	// reset to infinite
@@ -3319,17 +3319,17 @@ void hud_set_gauge_color(int gauge_index, int bright_index)
 	if(bright_index != HUD_C_NONE){
 		switch(bright_index){
 		case HUD_C_DIM:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_DIM_HI : HUD_NEW_ALPHA_DIM;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_DIM_HI : HUD_NEW_ALPHA_DIM;
 			gr_init_alphacolor(use_color, use_color->red, use_color->green, use_color->blue, alpha);
 			break;
 
 		case HUD_C_NORMAL:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_NORMAL_HI : HUD_NEW_ALPHA_NORMAL;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_NORMAL_HI : HUD_NEW_ALPHA_NORMAL;
 			gr_init_alphacolor(use_color, use_color->red, use_color->green, use_color->blue, alpha);
 			break;
 
 		case HUD_C_BRIGHT:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_BRIGHT_HI : HUD_NEW_ALPHA_BRIGHT;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_BRIGHT_HI : HUD_NEW_ALPHA_BRIGHT;
 			gr_init_alphacolor(use_color, use_color->red, use_color->green, use_color->blue, alpha);
 			break;
 
@@ -3359,15 +3359,15 @@ void hud_set_gauge_color(int gauge_index, int bright_index)
 	} else {
 		switch(flash_status) {
 		case 0:
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_DIM_HI : HUD_NEW_ALPHA_DIM;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_DIM_HI : HUD_NEW_ALPHA_DIM;
 			gr_init_alphacolor(use_color, use_color->red, use_color->green, use_color->blue, alpha);
 			break;
 		case 1:			
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_BRIGHT_HI : HUD_NEW_ALPHA_BRIGHT;
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_BRIGHT_HI : HUD_NEW_ALPHA_BRIGHT;
 			gr_init_alphacolor(use_color, use_color->red, use_color->green, use_color->blue, alpha);
 			break;
 		default:			
-			alpha = HUD_contrast ? HUD_NEW_ALPHA_NORMAL_HI : HUD_NEW_ALPHA_NORMAL;	
+			alpha = HUD_high_contrast ? HUD_NEW_ALPHA_NORMAL_HI : HUD_NEW_ALPHA_NORMAL;
 			gr_init_alphacolor(use_color, use_color->red, use_color->green, use_color->blue, alpha);
 			break;
 		}
@@ -3870,12 +3870,12 @@ void hud_save_restore_camera_data(int save)
 
 void hud_toggle_contrast()
 {
-	HUD_contrast = !HUD_contrast;
+	HUD_high_contrast = !HUD_high_contrast;
 }
 
-void hud_set_contrast(int high)
+void hud_set_contrast(bool high)
 {
-	HUD_contrast = high;
+	HUD_high_contrast = high;
 }
 
 void hud_toggle_shadows()

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -69,7 +69,7 @@ enum class HudAlignment
 };
 
 extern int HUD_draw;
-extern int HUD_contrast;
+extern bool HUD_high_contrast;
 extern bool HUD_shadows;
 
 #define HUD_NUM_COLOR_LEVELS	16
@@ -203,7 +203,7 @@ int hud_disabled_except_messages();
 
 // contrast stuff
 void hud_toggle_contrast();
-void hud_set_contrast(int high);
+void hud_set_contrast(bool high);
 void hud_toggle_shadows();
 
 class HudGauge 

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -45,6 +45,19 @@ ADE_VIRTVAR(HUDDrawn, l_HUD, "boolean", "Current HUD draw status", "boolean", "I
 		return ADE_RETURN_FALSE;
 }
 
+ADE_VIRTVAR(HUDHighContrast, l_HUD, "boolean", "Gets or sets whether the HUD is currently high-contrast", "boolean", "Whether the HUD is high-contrast")
+{
+	bool value = false;
+
+	if(!ade_get_args(L, "*|b", &value))
+		return ADE_RETURN_NIL;
+
+	if(ADE_SETTING_VAR)
+		HUD_high_contrast = value;
+
+	return ade_set_args(L, "b", HUD_high_contrast);
+}
+
 ADE_VIRTVAR(HUDDisabledExceptMessages, l_HUD, "boolean", "Specifies if only the messages gauges of the hud are drawn", "boolean", "true if only the message gauges are drawn, false otherwise")
 {
 	bool to_draw = false;

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2757,7 +2757,7 @@ void stars_set_nebula(bool activate, float range)
     if (activate)
 	{
 		Toggle_text_alpha = TOGGLE_TEXT_NEBULA_ALPHA;
-		HUD_contrast = 1;
+		HUD_high_contrast = true;
 
 		Neb2_render_mode = NEB2_RENDER_HTL;
 		Neb2_awacs = range;
@@ -2775,7 +2775,7 @@ void stars_set_nebula(bool activate, float range)
 	else
 	{
 		Toggle_text_alpha = TOGGLE_TEXT_NORMAL_ALPHA;
-		HUD_contrast = 0;
+		HUD_high_contrast = false;
 
 		Neb2_render_mode = NEB2_RENDER_NONE;
 		Neb2_awacs = -1.0f;


### PR DESCRIPTION
Adds a hu.HUDHighContrast virtvar.  Also renames `HUD_contrast` to `HUD_high_contrast` for clarity and makes it a boolean.