### PR TITLE
add ShipBSubmodel to ship collisions

### DIFF
--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -1209,7 +1209,8 @@ int collide_ship_ship( obj_pair * pair )
 						scripting::hook_param("Ship", 'o', A),
 						scripting::hook_param("ShipB", 'o', B),
 						scripting::hook_param("Hitpos", 'o', world_hit_pos),
-						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A))));
+						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A)),
+						scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B))));
 
 				// Yes, this should be reversed.
 				b_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{ {A, B} },
@@ -1218,7 +1219,8 @@ int collide_ship_ship( obj_pair * pair )
 						scripting::hook_param("Ship", 'o', B),
 						scripting::hook_param("ShipB", 'o', A),
 						scripting::hook_param("Hitpos", 'o', world_hit_pos),
-						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B))));
+						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B)),
+						scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A))));
 			}
 
 			if(!a_override && !b_override)
@@ -1469,7 +1471,8 @@ int collide_ship_ship( obj_pair * pair )
 														   scripting::hook_param("Ship", 'o', A),
 														   scripting::hook_param("ShipB", 'o', B),
 														   scripting::hook_param("Hitpos", 'o', world_hit_pos),
-														   scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A))));
+														   scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A)),
+														   scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B))));
 			}
 			if((b_override && !a_override) || (!b_override && !a_override))
 			{
@@ -1480,7 +1483,8 @@ int collide_ship_ship( obj_pair * pair )
 														   scripting::hook_param("Ship", 'o', B),
 														   scripting::hook_param("ShipB", 'o', A),
 														   scripting::hook_param("Hitpos", 'o', world_hit_pos),
-														   scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B))));
+														   scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B)),
+														   scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A))));
 			}
 
 			return 0;

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -118,6 +118,7 @@ const std::shared_ptr<OverridableHook<CollisionConditions>> OnShipCollision = Ov
 		{"Debris", "object", "The debris object with which the ship collided (only set for debris collisions)"},
 		{"Asteroid", "object", "The asteroid object with which the ship collided (only set for asteroid collisions)"},
 		{"ShipB", "ship", "For ship-on-ship collisions, the same as \"Object\" (only set for ship-on-ship collisions)"},
+		{"ShipBSubmodel", "submodel", "For ship-on-ship collisions, the submodel of \"ShipB\" involved in the collision, if \"ShipB\" was the heavier object"},
 		{"Weapon", "weapon", "The weapon object with which the ship collided (only set for weapon collisions)"},
 		{"Beam", "weapon", "The beam object with which the ship collided (only set for beam collisions)"}});
 


### PR DESCRIPTION
Since the On Ship Collision hook can potentially be called twice, with the ships reversed, it is necessary for both parameters to have submodels specified.  Otherwise +Override would not be able to handle both cases.

Followup to #6035.