### PR TITLE
add skybox alpha, and add scripted functions for alpha and orientation

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -757,6 +757,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "nebula-change-fog-color",		OP_NEBULA_CHANGE_FOG_COLOR,				3,	3,			SEXP_ACTION_OPERATOR,   },	// Asteroth
 	{ "set-skybox-model",				OP_SET_SKYBOX_MODEL,					1,	8,			SEXP_ACTION_OPERATOR,	},	// taylor
 	{ "set-skybox-orientation",			OP_SET_SKYBOX_ORIENT,					3,	3,			SEXP_ACTION_OPERATOR,	},	// Goober5000
+	{ "set-skybox-alpha",				OP_SET_SKYBOX_ALPHA,					1,	1,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "set-ambient-light",				OP_SET_AMBIENT_LIGHT,					3,	3,			SEXP_ACTION_OPERATOR,	},	// Karajorma
 	{ "toggle-asteroid-field",			OP_TOGGLE_ASTEROID_FIELD,				1,	1,			SEXP_ACTION_OPERATOR,	},	// MjnMixael
 	{ "set-asteroid-field",				OP_SET_ASTEROID_FIELD,					1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// MjnMixael
@@ -21071,6 +21072,19 @@ void sexp_set_skybox_orientation(int n)
 	stars_set_background_orientation(&m);
 }
 
+// Goober5000
+void sexp_set_skybox_alpha(int n)
+{
+	int alphax1000;
+	bool is_nan, is_nan_forever;
+
+	alphax1000 = eval_num(n, is_nan, is_nan_forever);
+	if (is_nan || is_nan_forever)
+		return;
+
+	stars_set_background_alpha(alphax1000 / 1000.0f);
+}
+
 // taylor - load and set a skybox model
 void sexp_set_skybox_model(int n)
 {
@@ -28954,6 +28968,11 @@ int eval_sexp(int cur_node, int referenced_node)
 				sexp_val = SEXP_TRUE;
 				break;
 
+			case OP_SET_SKYBOX_ALPHA:
+				sexp_set_skybox_alpha(node);
+				sexp_val = SEXP_TRUE;
+				break;
+
 			case OP_TURRET_TAGGED_SPECIFIC:
 			case OP_TURRET_TAGGED_CLEAR_SPECIFIC:
 				sexp_turret_tagged_or_clear_specific(node, op_num == OP_TURRET_TAGGED_SPECIFIC);
@@ -30469,6 +30488,7 @@ int query_operator_return_type(int op)
 		case OP_ACTIVATE_GLOW_POINT_BANK:
 		case OP_SET_SKYBOX_MODEL:
 		case OP_SET_SKYBOX_ORIENT:
+		case OP_SET_SKYBOX_ALPHA:
 		case OP_SET_SUPPORT_SHIP:
 		case OP_SET_ARRIVAL_INFO:
 		case OP_SET_DEPARTURE_INFO:
@@ -32912,6 +32932,9 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_SKYBOX_FLAGS;
 
 		case OP_SET_SKYBOX_ORIENT:
+			return OPF_NUMBER;
+
+		case OP_SET_SKYBOX_ALPHA:
 			return OPF_NUMBER;
 
 		// Goober5000 - this is complicated :)
@@ -35641,6 +35664,7 @@ int get_category(int op_id)
 		case OP_SET_ARRIVAL_INFO:
 		case OP_SET_DEPARTURE_INFO:
 		case OP_SET_SKYBOX_ORIENT:
+		case OP_SET_SKYBOX_ALPHA:
 		case OP_DESTROY_INSTANTLY:
 		case OP_DESTROY_SUBSYS_INSTANTLY:
 		case OP_DEBUG:
@@ -36138,6 +36162,7 @@ int get_subcategory(int op_id)
 
 		case OP_SET_SKYBOX_MODEL:
 		case OP_SET_SKYBOX_ORIENT:
+		case OP_SET_SKYBOX_ALPHA:
 		case OP_MISSION_SET_NEBULA:
 		case OP_MISSION_SET_SUBSPACE:
 		case OP_CHANGE_BACKGROUND:
@@ -40696,6 +40721,12 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t1:\tPitch\r\n"
 		"\t2:\tBank\r\n"
 		"\t3:\tHeading\r\n"
+	},
+
+	// Goober5000
+	{ OP_SET_SKYBOX_ALPHA, "set-skybox-alpha\r\n"
+		"\tSets the current skybox transparency.  Takes 1 argument...\r\n"
+		"\t1:\tAlpha value x1000 (so 1.0 is represented as 1000)\r\n"
 	},
 
 	// Goober5000

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -907,6 +907,7 @@ enum : int {
 	OP_SET_DEBRIS_FIELD,	// MjnMixael
 	OP_SET_MOTION_DEBRIS,   // MjnMixael
 	OP_GOOD_PRIMARY_TIME,	// plieblang
+	OP_SET_SKYBOX_ALPHA,	// Goober5000
 	
 	// OP_CATEGORY_AI
 	// defined for AI goals

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -2159,6 +2159,24 @@ ADE_FUNC(removeBackgroundElement, l_Mission, "background_element el",
 	}
 }
 
+ADE_VIRTVAR(SkyboxOrientation, l_Mission, "orientation", "Sets or returns the current skybox orientation", "orientation", "the orientation")
+{
+	matrix_h* orient_h = nullptr;
+	if (ADE_SETTING_VAR && ade_get_args(L, "*|o", l_Matrix.GetPtr(&orient_h)))
+		stars_set_background_orientation(orient_h->GetMatrix());
+
+	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&Nmodel_orient)));
+}
+
+ADE_VIRTVAR(SkyboxAlpha, l_Mission, "number", "Sets or returns the current skybox alpha", "number", "the alpha")
+{
+	float alpha = 1.0f;
+	if (ADE_SETTING_VAR && ade_get_args(L, "*|f", &alpha))
+		stars_set_background_alpha(alpha);
+
+	return ade_set_args(L, "f", Nmodel_alpha);
+}
+
 ADE_FUNC(isRedAlertMission,
 	l_Mission,
 	nullptr,

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -155,6 +155,7 @@ int Nmodel_instance_num = -1;					// model instance num
 matrix Nmodel_orient = IDENTITY_MATRIX;			// model orientation
 int Nmodel_flags = DEFAULT_NMODEL_FLAGS;		// model flags
 int Nmodel_bitmap = -1;						// model texture
+float Nmodel_alpha = 1.0f;					// model transparency
 
 bool Dynamic_environment = false;
 
@@ -2306,14 +2307,14 @@ void stars_draw_background()
 	}
 
 	// draw the model at the player's eye with no z-buffering
-	render_info.set_alpha(1.0f);
+	render_info.set_alpha(Nmodel_alpha);
 	render_info.set_flags(Nmodel_flags | MR_SKYBOX);
 
 	model_render_immediate(&render_info, Nmodel_num, Nmodel_instance_num, &Nmodel_orient, &Eye_position, MODEL_RENDER_ALL, false);
 }
 
 // call this to set a specific model as the background model
-void stars_set_background_model(const char *model_name, const char *texture_name, int flags)
+void stars_set_background_model(const char* model_name, const char* texture_name, int flags, float alpha)
 {
 	int new_model = -1;
 	int new_bitmap = -1;
@@ -2329,9 +2330,10 @@ void stars_set_background_model(const char *model_name, const char *texture_name
 			new_bitmap = bm_load(texture_name);
 		}
 	}
+	CLAMP(alpha, 0.0f, 1.0f);
 
 	// see if we are actually changing anything
-	if (Nmodel_num == new_model && Nmodel_bitmap == new_bitmap && Nmodel_flags == flags) {
+	if (Nmodel_num == new_model && Nmodel_bitmap == new_bitmap && Nmodel_flags == flags && Nmodel_alpha == alpha) {
 		return;
 	}
 
@@ -2353,6 +2355,7 @@ void stars_set_background_model(const char *model_name, const char *texture_name
 	Nmodel_flags = flags;
 	Nmodel_num = new_model;
 	Nmodel_bitmap = new_bitmap;
+	Nmodel_alpha = alpha;
 
 	if (Nmodel_num >= 0) {
 		model_page_in_textures(Nmodel_num);
@@ -2373,6 +2376,12 @@ void stars_set_background_orientation(const matrix *orient)
 	} else {
 		Nmodel_orient = *orient;
 	}
+}
+
+void stars_set_background_alpha(float alpha)
+{
+	CLAMP(alpha, 0.0f, 1.0f);
+	Nmodel_alpha = alpha;
 }
 
 // lookup a starfield bitmap, return index or -1 on fail

--- a/code/starfield/starfield.h
+++ b/code/starfield/starfield.h
@@ -59,6 +59,7 @@ extern int Nmodel_instance_num;
 extern matrix Nmodel_orient;
 extern int Nmodel_flags;
 extern int Nmodel_bitmap;
+extern float Nmodel_alpha;
 
 extern bool Motion_debris_override;
 extern bool Motion_debris_enabled;
@@ -150,8 +151,9 @@ void stars_draw_sun_glow(int sun_n);
 void stars_camera_cut();
 
 // call this to set a specific model as the background model
-void stars_set_background_model(const char *model_name, const char *texture_name, int flags = DEFAULT_NMODEL_FLAGS);
+void stars_set_background_model(const char *model_name, const char *texture_name, int flags = DEFAULT_NMODEL_FLAGS, float alpha = 1.0f);
 void stars_set_background_orientation(const matrix *orient = nullptr);
+void stars_set_background_alpha(float alpha = 1.0f);
 
 // lookup a starfield bitmap, return index or -1 on fail
 int stars_find_bitmap(const char *name);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -94,11 +94,6 @@ char Fred_alt_names[MAX_SHIPS][NAME_LENGTH + 1];
 
 extern void allocate_parse_text(size_t size);
 
-extern int Nmodel_num;
-extern int Nmodel_instance_num;
-extern matrix Nmodel_orient;
-extern int Nmodel_bitmap;
-
 namespace fso {
 namespace fred {
 	


### PR DESCRIPTION
This allows the skybox orientation and alpha to be accessed and changed through Lua virtvars, and also adds a sexp to change the alpha.

Unfortunately, changing the alpha has no perceptible effect on the skybox.  This will need the attention of a graphics coder to figure out what might need updating.