### PR TITLE
fix crash caused by using a moved variable

### DIFF
--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -238,14 +238,14 @@ int add_dynamic_sexp(std::unique_ptr<DynamicSEXP>&& sexp, sexp_oper_type type)
 	new_op.value = free_op_index;
 	new_op.type = type;
 
+	sexp_help_struct new_help;
+	new_help.id = new_op.value;
+	new_help.help = sexp->getHelpText();
+
 	global.operator_const_mapping.insert(std::make_pair(new_op.value, std::move(sexp)));
 
 	// Now actually add the operator to the SEXP containers
 	Operators.push_back(new_op);
-
-	sexp_help_struct new_help;
-	new_help.id = new_op.value;
-	new_help.help = sexp->getHelpText();
 	Sexp_help.push_back(new_help);
 
 	return new_op.value;


### PR DESCRIPTION
In #5894, in the `add_dynamic_sexp` function in sexp_lookup.cpp, a call to `sexp->getHelpText()` was moved to the bottom of the function.  Normally this would be fine, except that this occasion caused the `sexp` variable to be accessed after a `std::move`.  The crash can be avoided by moving the last access of the `sexp` variable just a little bit earlier.