### PR TITLE
additional lighting fixes

### DIFF
--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -314,7 +314,7 @@ void light_rotate_all()
  */
 int light_get_global_count()
 {
-	return (int)Static_light.size();
+	return static_cast<int>(Static_light.size());
 }
 
 /**


### PR DESCRIPTION
Fix a minor oversight from #6014; in the ship lab, there are sometimes no suns at all, so remove the assertion.  The lighting check is only needed for supernovas anyway, so make that clear.

Additionally, add further clarification for the distinction between suns, lights, and variables used only for the supernova.  Finally fix one more sun/light discrepancy that escaped notice from #6014.

Fixes an assertion in the ship lab.  Follow-up to #6014.