### PR TITLE
add "override submodel impact" subsystem flag

### DIFF
--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -71,6 +71,7 @@ namespace Model {
 		No_impact_debris,    // Don't spawn the small debris on impact - m!m
 		Hide_turret_from_loadout_stats, // Turret is not accounted for in auto-generated "Turrets" line in the ship loadout window --wookieejedi
 		Turret_distant_firepoint,	//Turret barrel is very long and should be taken into account when aiming -- Kiloku
+		Override_submodel_impact,	// if a weapon impacted a submodel, but this subsystem is within range, the subsystem takes priority -- Goober5000
 
         NUM_VALUES
 	};

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -346,6 +346,7 @@ flag_def_list_new<Model::Subsystem_Flags> Subsystem_flags[] = {
 	{ "no impact debris",           Model::Subsystem_Flags::No_impact_debris,                   true, false },
 	{ "hide turret from loadout stats", Model::Subsystem_Flags::Hide_turret_from_loadout_stats, true, false },
 	{ "turret has distant firepoint", Model::Subsystem_Flags::Turret_distant_firepoint,         true, false },
+	{ "override submodel impact",   Model::Subsystem_Flags::Override_submodel_impact,           true, false },
 };
 
 const size_t Num_subsystem_flags = sizeof(Subsystem_flags)/sizeof(flag_def_list_new<Model::Subsystem_Flags>);

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -533,22 +533,23 @@ void do_subobj_heal_stuff(object* ship_objp, object* other_obj, vec3d* hitpos, i
 		ship_subsys* subsystem;
 
 		int	min_index = -1;
-
-		if (Damage_impacted_subsystem_first && subsys_hit_first > -1) {
-			min_index = subsys_hit_first;
-
-			subsys_hit_first = -1;
-		}
-		else {
+		{
 			float	min_dist = 9999999.9f;
 
-			for (i = 0; i < count; i++) {
+			// find the closest subsystem
+			for (i=0; i<count; i++) {
 				if (subsys_list[i].dist < min_dist) {
 					min_dist = subsys_list[i].dist;
 					min_index = i;
 				}
 			}
 			Assert(min_index != -1);
+		}
+
+		// if the closest system does *not* override a submodel impact, and we have a submodel impact, use it instead
+		if (Damage_impacted_subsystem_first && subsys_hit_first >= 0 && !subsys_list[min_index].ptr->system_info->flags[Model::Subsystem_Flags::Override_submodel_impact]) {
+			min_index = subsys_hit_first;
+			subsys_hit_first = -1;	// prevent the submodel impact from taking priority on the next loop iteration
 		}
 
 		subsystem = subsys_list[min_index].ptr;
@@ -861,14 +862,10 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 		ship_subsys	*subsystem;
 
 		int	min_index = -1;
-
-		if (Damage_impacted_subsystem_first && subsys_hit_first > -1) {
-			min_index = subsys_hit_first;
-
-			subsys_hit_first = -1;
-		} else {
+		{
 			float	min_dist = 9999999.9f;
 
+			// find the closest subsystem
 			for (i=0; i<count; i++) {
 				if (subsys_list[i].dist < min_dist) {
 					min_dist = subsys_list[i].dist;
@@ -876,6 +873,12 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 				}
 			}
 			Assert(min_index != -1);
+		}
+
+		// if the closest system does *not* override a submodel impact, and we have a submodel impact, use it instead
+		if (Damage_impacted_subsystem_first && subsys_hit_first >= 0 && !subsys_list[min_index].ptr->system_info->flags[Model::Subsystem_Flags::Override_submodel_impact]) {
+			min_index = subsys_hit_first;
+			subsys_hit_first = -1;	// prevent the submodel impact from taking priority on the next loop iteration
 		}
 
 		float	damage_to_apply = 0.0f;


### PR DESCRIPTION
With the `$Damage Impacted Subsystem First:` game_settings flag, weapons will damage submodels over subsystems, even if the subsystem is closer.  Yet occasionally this is not the correct behavior (e.g. for the Rahu's engines).  The new subsystem flag allows this behavior to be selectively overridden.