### PR TITLE
Fix an issue with animation directions

### DIFF
--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -299,13 +299,15 @@ namespace animation {
 		
 		if (direction == ModelAnimationDirection::RWD) {
 			instanceData.state = ModelAnimationState::RUNNING;
-			instanceData.time -= timeOffset;
+			instanceData.time -= timeOffset; 
+			instanceData.canonicalDirection = ModelAnimationDirection::RWD;
 			if (force)
 				instanceData.time = instant ? 0 : instanceData.duration - timeOffset;
 		}
 		else {
 			instanceData.state = ModelAnimationState::RUNNING;
 			instanceData.time += timeOffset;
+			instanceData.canonicalDirection = ModelAnimationDirection::FWD;
 			if (force)
 				instanceData.time = instant ? instanceData.duration : 0 + timeOffset;
 		}


### PR DESCRIPTION
Follow-up to #5451. Adds explicit directionality setting which was meant to be moved into this position after the animation drivers update. Can visibly cause issues when animations are started and then reversed before it completes.