### PR TITLE
Add 'alignment' for poofs

### DIFF
--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -840,13 +840,13 @@ void new_poof(size_t poof_info_idx, vec3d* pos) {
 	new_poof.flash = 0;
 	new_poof.radius = pinfo->scale.next();
 	new_poof.pt = *pos;
+	new_poof.rot_speed = fl_radians(pinfo->rotation.next());
 	new_poof.alpha = pinfo->alpha.next();
 	new_poof.anim_time = frand_range(0.0f, pinfo->bitmap.total_time);
 	if (pinfo->alignment != vmd_zero_vector)
 		vm_vec_rand_vec(&new_poof.up_vec);
 	else
 		new_poof.up_vec = vmd_y_vector;
-	new_poof.rot_speed = fl_radians(pinfo->rotation.next());
 
 	Neb2_poofs.push_back(new_poof);
 }

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -72,6 +72,7 @@ typedef struct poof_info {
 	::util::UniformFloatRange rotation;
 	float view_dist;
 	::util::UniformFloatRange alpha;
+	vec3d alignment;
 
 	// These values are dynamic, unlike the above and can change during a mission.
 	// They are used for fading poof types in and out via sexp
@@ -92,6 +93,7 @@ typedef struct poof_info {
 		fade_duration = -1;
 		fade_in = true;
 		fade_multiplier = -1.0f;
+		alignment = vmd_zero_vector;
 	}
 } poof_info;
 


### PR DESCRIPTION
For now just vertically, its fairly specific for the moment, but if you use an animated graphic with a rain or snow texture, poofs becomes suitable for basic weather effects. The door is left open for other kinds of alignment behavior as well.