### PR TITLE
speed up FRED reloading with this one weird trick

### DIFF
--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -60,6 +60,7 @@ extern bool check_for_23_3_data();
 // mission parse flags used for parse_mission() to tell what kind of information to get from the mission file
 #define MPF_ONLY_MISSION_INFO	(1 << 0)
 #define MPF_IMPORT_FSM			(1 << 1)
+#define MPF_FAST_RELOAD			(1 << 2)	// skip clearing some stuff so we can load the mission faster (usually since it's the same mission)
 
 // bitfield definitions for missions game types
 #define OLD_MAX_GAME_TYPES				4					// needed for compatibility

--- a/fred2/campaigntreewnd.cpp
+++ b/fred2/campaigntreewnd.cpp
@@ -71,7 +71,7 @@ BOOL campaign_tree_wnd::OnCreateClient(LPCREATESTRUCT, CCreateContext* pContext)
 	LoadAccelTable("IDR_ACC_CAMPAIGN");
 	Mission_filename_cb_format = RegisterClipboardFormat("Mission Filename");
 	Campaign_modified = 0;
-	clear_mission();
+	clear_mission(true);
 
 	// create a splitter with 1 row, 2 columns
 	if (!m_splitter.CreateStatic(this, 1, 2))

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -115,7 +115,7 @@ bool CFREDDoc::autoload() {
 	}
 
 	// Load Backup.002
-	r = load_mission(name);
+	r = load_mission(name, MPF_FAST_RELOAD);
 	Update_window = 1;
 
 	// Delete Backup.001
@@ -227,7 +227,7 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 	// activate the localizer hash table
 	fhash_flush();
 
-	clear_mission();
+	clear_mission(flags & MPF_FAST_RELOAD);
 
 	// message 1: required version
 	if (!parse_main(pathname, flags)) {
@@ -457,7 +457,7 @@ void CFREDDoc::OnFileImportFSM() {
 	if (Briefing_dialog)
 		Briefing_dialog->icon_select(-1);
 
-	clear_mission();
+	clear_mission(true);
 
 	int num_files = 0;
 	int successes = 0;
@@ -490,7 +490,7 @@ void CFREDDoc::OnFileImportFSM() {
 		strcpy_s(fs1_path, fs1_path_mfc);
 
 		// load mission into memory
-		if (!load_mission(fs1_path, MPF_IMPORT_FSM))
+		if (!load_mission(fs1_path, MPF_IMPORT_FSM | MPF_FAST_RELOAD))
 			continue;
 
 		// get filename
@@ -652,7 +652,7 @@ BOOL CFREDDoc::OnSaveDocument(LPCTSTR pathname) {
 	}
 
 	SetModifiedFlag(FALSE);
-	if (!load_mission(pathname))
+	if (!load_mission(pathname, MPF_FAST_RELOAD))
 		Error(LOCATION, "Failed attempting to reload mission after saving.  Report this bug now!");
 
 	if (Briefing_dialog) {

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -766,7 +766,7 @@ void reset_mission()
 	stars_post_level_init();
 }
 
-void clear_mission()
+void clear_mission(bool fast_reload)
 {
 	char *str;
 	int i, j, count;
@@ -782,7 +782,10 @@ void clear_mission()
 	mission_init(&The_mission);
 
 	obj_init();
-	model_free_all();				// Free all existing models
+
+	if (!fast_reload)
+		model_free_all();				// Free all existing models
+
 	ai_init();
 	asteroid_level_init();
 	ship_level_init();

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -77,7 +77,7 @@ int create_object(vec3d* pos, int waypoint_instance = -1);
 int create_player(vec3d* pos, matrix* orient, int type = -1);
 void create_new_mission();
 void reset_mission();
-void clear_mission();
+void clear_mission(bool fast_reload = false);
 int query_valid_object(int index = cur_object_index);
 int query_valid_ship(int index = cur_object_index);
 int query_valid_waypoint(int index = cur_object_index);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -140,7 +140,7 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 	// activate the localizer hash table
 	fhash_flush();
 
-	clearMission();
+	clearMission(flags & MPF_FAST_RELOAD);
 
 	std::string filepath = mission_name;
 	auto res = cf_find_file_location(filepath.c_str(), CF_TYPE_MISSIONS);
@@ -388,7 +388,7 @@ void Editor::unmarkObject(int obj) {
 	}
 }
 
-void Editor::clearMission() {
+void Editor::clearMission(bool fast_reload) {
 	// clean up everything we need to before we reset back to defaults.
 #if 0
     if (Briefing_dialog){
@@ -401,7 +401,10 @@ void Editor::clearMission() {
 	mission_init(&The_mission);
 
 	obj_init();
-	model_free_all();                // Free all existing models
+
+	if (!fast_reload)
+		model_free_all();                // Free all existing models
+
 	ai_init();
 	asteroid_level_init();
 	ship_level_init();

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -185,7 +185,7 @@ class Editor : public QObject {
 	static int getAigoal_list_size();
 	const char* error_check_initial_orders(ai_goal* goals, int ship, int wing);
   private:
-	void clearMission();
+	void clearMission(bool fast_reload = false);
 
 	void initialSetup();
 

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -70,7 +70,7 @@ FredView::FredView(QWidget* parent) : QMainWindow(parent), ui(new Ui::FredView()
 	ui->actionUndo->setShortcuts(QKeySequence::Undo);
 	ui->actionDelete->setShortcuts(QKeySequence::Delete);
 
-	connect(ui->actionOpen, &QAction::triggered, this, &FredView::openLoadMissionDIalog);
+	connect(ui->actionOpen, &QAction::triggered, this, &FredView::openLoadMissionDialog);
 	connect(ui->actionNew, &QAction::triggered, this, &FredView::newMission);
 
 	connect(fredApp, &FredApplication::onIdle, this, &FredView::updateUI);
@@ -152,7 +152,7 @@ void FredView::loadMissionFile(const QString& pathName) {
 	}
 }
 
-void FredView::openLoadMissionDIalog() {
+void FredView::openLoadMissionDialog() {
 	qDebug() << "Loading from directory:" << QDir::currentPath();
 	QString pathName = QFileDialog::getOpenFileName(this, tr("Load mission"), QString(), tr("FS2 missions (*.fs2)"));
 

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -39,7 +39,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void showContextMenu(const QPoint& globalPos);
 
  public slots:
-	void openLoadMissionDIalog();
+	void openLoadMissionDialog();
 
 	void newMission();
 


### PR DESCRIPTION
Thanks to @notimaginative's detective work, nearly all of the FRED stalling when saving a mission can be avoided by simply not calling `model_free_all()`.  By checking a flag in `clear_mission()`, multiple situations can avoid this slowdown, including reload-after-save and import-FSM.