### PR TITLE
Multi general api

### DIFF
--- a/code/missionui/chatbox.cpp
+++ b/code/missionui/chatbox.cpp
@@ -403,7 +403,7 @@ size_t chatbox_get_msg_target_length(char *msg)
 }
 
 // send a msg to the game chat
-void chatbox_send_msg(char msg[150])
+void chatbox_send_msg(char* msg)
 {
 	// check if this message is supposed to have a recipient
 	int target = chatbox_get_msg_target_type(msg);
@@ -421,7 +421,7 @@ void chatbox_send_msg(char msg[150])
 		send_game_chat_packet(Net_player, msg, target);
 	} else {
 		// copy the name of the player the message is being sent to
-		char temp[150];
+		char temp[CHATBOX_MAX_LEN];
 		strncpy(temp, msg + 1, target_length - 2);
 		temp[target_length - 2] = '\0';
 		send_game_chat_packet(Net_player, msg, target, nullptr, temp);
@@ -433,11 +433,11 @@ void chatbox_send_msg(char msg[150])
 // automatically split up any input text, send it, and leave the remainder 
 void chatbox_autosplit_line()
 {
-	char msg[150];
+	char msg[CHATBOX_MAX_LEN];
 	
 	// if the chat line is getting too long, fire off the message, putting the last
 	// word on the next input line.
-	memset(msg,0,150);
+	memset(msg, 0, CHATBOX_MAX_LEN);
 	Chat_inputbox.get_text(msg);
 	const char* remainder = ""; 
 
@@ -463,7 +463,7 @@ void chatbox_autosplit_line()
 
 		if (target != MULTI_MSG_ALL) {
 			// we need to add the target the message is going to before we add the rest of the string
-			char temp[150];
+			char temp[CHATBOX_MAX_LEN];
 			strncpy(temp, msg, target_length);
  			temp[target_length] = ' '; 
  			temp[target_length+1] = '\0'; 

--- a/code/missionui/chatbox.cpp
+++ b/code/missionui/chatbox.cpp
@@ -407,7 +407,6 @@ void chatbox_send_msg(char* msg)
 {
 	// check if this message is supposed to have a recipient
 	int target = chatbox_get_msg_target_type(msg);
-	size_t target_length = chatbox_get_msg_target_length(msg);
 
 	// tack on the null terminator in the boundary case
 	size_t x = strlen(msg);
@@ -422,6 +421,7 @@ void chatbox_send_msg(char* msg)
 	} else {
 		// copy the name of the player the message is being sent to
 		char temp[CHATBOX_MAX_LEN];
+		size_t target_length = chatbox_get_msg_target_length(msg);
 		strncpy(temp, msg + 1, target_length - 2);
 		temp[target_length - 2] = '\0';
 		send_game_chat_packet(Net_player, msg, target, nullptr, temp);
@@ -459,11 +459,11 @@ void chatbox_autosplit_line()
 
 		// check if this message is supposed to have a recipient
 		int target = chatbox_get_msg_target_type(msg);
-		size_t target_length = chatbox_get_msg_target_length(msg);
 
 		if (target != MULTI_MSG_ALL) {
 			// we need to add the target the message is going to before we add the rest of the string
 			char temp[CHATBOX_MAX_LEN];
+			size_t target_length = chatbox_get_msg_target_length(msg);
 			strncpy(temp, msg, target_length);
  			temp[target_length] = ' '; 
  			temp[target_length+1] = '\0'; 

--- a/code/missionui/chatbox.cpp
+++ b/code/missionui/chatbox.cpp
@@ -402,28 +402,49 @@ size_t chatbox_get_msg_target_length(char *msg)
 
 }
 
+// send a msg to the game chat
+void chatbox_send_msg(char msg[150])
+{
+	// check if this message is supposed to have a recipient
+	int target = chatbox_get_msg_target_type(msg);
+	size_t target_length = chatbox_get_msg_target_length(msg);
+
+	// tack on the null terminator in the boundary case
+	size_t x = strlen(msg);
+	if (x >= CHATBOX_MAX_LEN) {
+		msg[CHATBOX_MAX_LEN - 1] = '\0';
+	}
+
+	// if I'm the server, then broadcast the packet
+	chatbox_recall_add(msg);
+	if (target != MULTI_MSG_EXPR) {
+		send_game_chat_packet(Net_player, msg, target);
+	} else {
+		// copy the name of the player the message is being sent to
+		char temp[150];
+		strncpy(temp, msg + 1, target_length - 2);
+		temp[target_length - 2] = '\0';
+		send_game_chat_packet(Net_player, msg, target, nullptr, temp);
+	}
+
+	chatbox_add_line(msg, MY_NET_PLAYER_NUM);
+}
+
 // automatically split up any input text, send it, and leave the remainder 
 void chatbox_autosplit_line()
 {
 	char msg[150];
-	char temp[150];
-	int msg_pixel_width;
-	int target;
-	size_t target_length = 0;
 	
 	// if the chat line is getting too long, fire off the message, putting the last
 	// word on the next input line.
 	memset(msg,0,150);
 	Chat_inputbox.get_text(msg);
-	const char* remainder = "";
-
-	// check if this message is supposed to have a recipient
-	target = chatbox_get_msg_target_type(msg); 
-	target_length = chatbox_get_msg_target_length(msg); 
+	const char* remainder = ""; 
 
 	// determine if the width of the string in pixels is > than the inputbox width -- if so,
 	// then send the message
-	gr_get_string_size(&msg_pixel_width, NULL, msg);
+	int msg_pixel_width;
+	gr_get_string_size(&msg_pixel_width, nullptr, msg);
 	// if ( msg_pixel_width >= (Chatbox_inputbox_w - Player->short_callsign_width) ) {
 	if ( msg_pixel_width >= (Chatbox_inputbox_w - 25)) {
 		auto last_space = strrchr(msg, ' ');
@@ -433,22 +454,16 @@ void chatbox_autosplit_line()
 		} else {
 			remainder = "";
 		}	
-		// if I'm the server, then broadcast the packet		
-		chatbox_recall_add(msg);
+		
+		chatbox_send_msg(msg);
 
-		if (target != MULTI_MSG_EXPR) {
-  			send_game_chat_packet(Net_player, msg, target);
-		}
-		else {
-			// copy the name of the player the message is being sent to
-			strncpy(temp, msg+1, target_length-2);
-			temp[target_length-2] = '\0';
-			send_game_chat_packet(Net_player, msg, target, NULL, temp);
-		}
-		chatbox_add_line(msg, MY_NET_PLAYER_NUM);
+		// check if this message is supposed to have a recipient
+		int target = chatbox_get_msg_target_type(msg);
+		size_t target_length = chatbox_get_msg_target_length(msg);
 
 		if (target != MULTI_MSG_ALL) {
 			// we need to add the target the message is going to before we add the rest of the string
+			char temp[150];
 			strncpy(temp, msg, target_length);
  			temp[target_length] = ' '; 
  			temp[target_length+1] = '\0'; 
@@ -460,26 +475,7 @@ void chatbox_autosplit_line()
 			Chat_inputbox.set_text(remainder);
 		}
 	} else if((Chat_inputbox.pressed() && (msg[0] != '\0')) || (strlen(msg) >= CHATBOX_MAX_LEN)) { 
-		// tack on the null terminator in the boundary case
-		size_t x = strlen(msg);
-		if(x >= CHATBOX_MAX_LEN){
-			msg[CHATBOX_MAX_LEN-1] = '\0';
-		}
-	
-		// if I'm the server, then broadcast the packet		
-		chatbox_recall_add(msg);
-		if (target != MULTI_MSG_EXPR) {
-  			send_game_chat_packet(Net_player, msg, target);
-		}
-		else {
-			// copy the name of the player the message is being sent to
-			strncpy(temp, msg+1, target_length-2);
-			temp[target_length-2] = '\0';
-			send_game_chat_packet(Net_player, msg, target, NULL, temp);
-		}
-
-		chatbox_add_line(msg, MY_NET_PLAYER_NUM);
-
+		chatbox_send_msg(msg);
 		// display any remainder of text on the next line
 		Chat_inputbox.set_text(remainder);		
 	}	

--- a/code/missionui/chatbox.h
+++ b/code/missionui/chatbox.h
@@ -59,6 +59,9 @@ int chatbox_scroll_down();
 // clear the contents of the chatbox
 void chatbox_clear();
 
+// send a message to the chatbox
+void chatbox_send_msg(char msg[150]);
+
 // add a line of text (from the player identified by pid) to the chatbox
 void chatbox_add_line(const char *msg, int pid, int add_id = 1);
 

--- a/code/missionui/chatbox.h
+++ b/code/missionui/chatbox.h
@@ -60,7 +60,7 @@ int chatbox_scroll_down();
 void chatbox_clear();
 
 // send a message to the chatbox
-void chatbox_send_msg(char msg[150]);
+void chatbox_send_msg(char* msg);
 
 // add a line of text (from the player identified by pid) to the chatbox
 void chatbox_add_line(const char *msg, int pid, int add_id = 1);

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -7741,11 +7741,11 @@ SCP_string multi_sync_get_state_string(net_player* player)
 		// server should display the pct completion of all clients
 		if (Net_player != nullptr && Net_player->flags & NETINFO_FLAG_AM_MASTER) {
 			if (player->s_info.xfer_handle != -1) {
-				int pct_complete = multi_xfer_pct_complete(player->s_info.xfer_handle);
+				float pct_complete = multi_xfer_pct_complete(player->s_info.xfer_handle);
 
 				// if we've got a valid xfer handle
 				if ((pct_complete >= 0.0) && (pct_complete <= 1.0)) {
-					sprintf(txt, XSTR("Mission file xfer %d%%", 828), (int)(pct_complete * 100.0f));
+					sprintf(txt, XSTR("Mission file xfer %d%%", 828), static_cast<int>(pct_complete * 100.0f));
 				}
 				// otherwise
 				else {
@@ -7759,11 +7759,11 @@ SCP_string multi_sync_get_state_string(net_player* player)
 		else {
 			// if we've got a valid file xfer handle
 			if ((player == Net_player) && (Net_player->s_info.xfer_handle != -1)) {
-				int pct_complete = multi_xfer_pct_complete(Net_player->s_info.xfer_handle);
+				float pct_complete = multi_xfer_pct_complete(Net_player->s_info.xfer_handle);
 
 				// if we've got a valid xfer handle
 				if ((pct_complete >= 0.0) && (pct_complete <= 1.0)) {
-					sprintf(txt, XSTR("Mission file xfer %d%%", 828), (int)(pct_complete * 100.0f));
+					sprintf(txt, XSTR("Mission file xfer %d%%", 828), static_cast<int>(pct_complete * 100.0f));
 				}
 				// otherwise
 				else {

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2956,6 +2956,70 @@ ADE_FUNC(sendChat,
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(quitGame,
+	l_UserInterface_MultiGeneral,
+	nullptr, "Quits the game for the current player and returns them to the PXO lobby", nullptr, nullptr)
+{
+	SCP_UNUSED(L);
+
+	if (Game_mode & GM_MULTIPLAYER) {
+		multi_quit_game(PROMPT_ALL);
+	}
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(setPlayerState, l_UserInterface_MultiGeneral, nullptr, "Sets the current player's network state based on the current game state.", nullptr, nullptr)
+{
+	SCP_UNUSED(L);
+
+	int state = gameseq_get_state();
+
+	// We really only need to handle this for game states that the lua API
+	// completely replaces; Where the state_init() code doesn't actually run
+	// but it won't hurt to include others.
+	// This may not be an exhaustive list. Feel free to add more.
+	switch (state) {
+	case GS_STATE_BRIEFING:
+		Net_player->state = NETPLAYER_STATE_BRIEFING;
+		break;
+	case GS_STATE_CMD_BRIEF:
+		Net_player->state = NETPLAYER_STATE_CMD_BRIEFING;
+		break;
+	case GS_STATE_SHIP_SELECT:
+		Net_player->state = NETPLAYER_STATE_SHIP_SELECT;
+		break;
+	case GS_STATE_WEAPON_SELECT:
+		Net_player->state = NETPLAYER_STATE_WEAPON_SELECT;
+		break;
+	case GS_STATE_RED_ALERT:
+		Net_player->state = NETPLAYER_STATE_RED_ALERT;
+		break;
+	case GS_STATE_DEBRIEF:
+		Net_player->state = NETPLAYER_STATE_DEBRIEF;
+		break;
+	case GS_STATE_FICTION_VIEWER:
+		Net_player->state = NETPLAYER_STATE_FICTION_VIEWER;
+		break;
+	case GS_STATE_MULTI_HOST_SETUP:
+		Net_player->state = NETPLAYER_STATE_HOST_SETUP;
+		break;
+	case GS_STATE_MULTI_MISSION_SYNC:
+		Net_player->state = NETPLAYER_STATE_MISSION_SYNC;
+		break;
+	case GS_STATE_TEAM_SELECT:
+		Net_player->state = NETPLAYER_STATE_SHIP_SELECT;
+		break;
+	case GS_STATE_MULTI_CLIENT_SETUP:
+		Net_player->state = NETPLAYER_STATE_JOINED;
+		break;
+	default:
+		break;
+	}
+
+	return ADE_RETURN_NIL;
+}
+
 //**********SUBLIBRARY: UserInterface/MultiJoinGame
 ADE_LIB_DERIV(l_UserInterface_MultiJoinGame,
 	"MultiJoinGame",

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -3499,7 +3499,7 @@ ADE_FUNC(closeMultiSync,
 ADE_FUNC(runNetwork,
 	l_UserInterface_MultiSync,
 	nullptr,
-	"Runs the network required commands to update the lists and run the chat",
+	"Runs the network required commands to run the chat",
 	nullptr,
 	nullptr)
 {

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2808,14 +2808,14 @@ ADE_FUNC(getHelpText, l_UserInterface_MultiPXO, nullptr, "Gets the help text lin
 	return ade_set_args(L, "t", pages);
 }
 
-//**********SUBLIBRARY: UserInterface/Multi
-ADE_LIB_DERIV(l_UserInterface_Multi,
-	"Multi",
+//**********SUBLIBRARY: UserInterface/MultiGeneral
+ADE_LIB_DERIV(l_UserInterface_MultiGeneral,
+	"MultiGeneral",
 	nullptr,
-	"API for accessing general data related to all the non-PXO Lobby UIs.",
+	"API for accessing general data related to all Multi UIs with the exception of the PXO Lobby.",
 	l_UserInterface);
 
-ADE_VIRTVAR(StatusText, l_UserInterface_Multi, nullptr, "The current status text", "string", "the status text")
+ADE_VIRTVAR(StatusText, l_UserInterface_MultiGeneral, nullptr, "The current status text", "string", "the status text")
 {
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
@@ -2824,7 +2824,7 @@ ADE_VIRTVAR(StatusText, l_UserInterface_Multi, nullptr, "The current status text
 	return ade_set_args(L, "s", Multi_common_notify_text);
 }
 
-ADE_VIRTVAR(InfoText, l_UserInterface_Multi, nullptr, "The current info text", "string", "the info text")
+ADE_VIRTVAR(InfoText, l_UserInterface_MultiGeneral, nullptr, "The current info text", "string", "the info text")
 {
 	if (ADE_SETTING_VAR) {
 		LuaError(L, "This property is read only.");
@@ -2834,7 +2834,7 @@ ADE_VIRTVAR(InfoText, l_UserInterface_Multi, nullptr, "The current info text", "
 }
 
 ADE_FUNC(getNetGame,
-	l_UserInterface_Multi,
+	l_UserInterface_MultiGeneral,
 	nullptr,
 	"The handle to the netgame. Note that the netgame will be invalid if a multiplayer game has not been joined or created.",
 	"netgame",
@@ -2844,7 +2844,7 @@ ADE_FUNC(getNetGame,
 	return ade_set_args(L, "o", l_NetGame.Set(net_game_h()));
 }
 
-ADE_LIB_DERIV(l_Net_Players, "NetPlayers", nullptr, nullptr, l_UserInterface_Multi);
+ADE_LIB_DERIV(l_Net_Players, "NetPlayers", nullptr, nullptr, l_UserInterface_MultiGeneral);
 ADE_INDEXER(l_Net_Players,
 	"number Index",
 	"Array of net players",

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2808,6 +2808,67 @@ ADE_FUNC(getHelpText, l_UserInterface_MultiPXO, nullptr, "Gets the help text lin
 	return ade_set_args(L, "t", pages);
 }
 
+//**********SUBLIBRARY: UserInterface/Multi
+ADE_LIB_DERIV(l_UserInterface_Multi,
+	"Multi",
+	nullptr,
+	"API for accessing general data related to all the non-PXO Lobby UIs.",
+	l_UserInterface);
+
+ADE_VIRTVAR(StatusText, l_UserInterface_Multi, nullptr, "The current status text", "string", "the status text")
+{
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", Multi_common_notify_text);
+}
+
+ADE_VIRTVAR(InfoText, l_UserInterface_Multi, nullptr, "The current info text", "string", "the info text")
+{
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", Multi_common_all_text);
+}
+
+ADE_FUNC(getNetGame,
+	l_UserInterface_Multi,
+	nullptr,
+	"The handle to the netgame. Note that the netgame will be invalid if a multiplayer game has not been joined or created.",
+	"netgame",
+	"The netgame handle")
+{
+	SCP_UNUSED(L);
+	return ade_set_args(L, "o", l_NetGame.Set(net_game_h()));
+}
+
+ADE_LIB_DERIV(l_Net_Players, "NetPlayers", nullptr, nullptr, l_UserInterface_Multi);
+ADE_INDEXER(l_Net_Players,
+	"number Index",
+	"Array of net players",
+	"net_player",
+	"net player handle, or invalid handle if index is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "*i", &idx))
+		return ade_set_error(L, "s", "");
+
+	// convert from lua index
+	idx--;
+
+	if ((idx < 0) || (idx >= MAX_PLAYERS))
+		return ade_set_args(L, "o", l_NetPlayer.Set(net_player_h()));
+
+	return ade_set_args(L, "o", l_NetPlayer.Set(net_player_h(idx)));
+}
+
+ADE_FUNC(__len, l_Net_Players, nullptr, "The number of net players", "number", "The number of players.")
+{
+	return ade_set_args(L, "i", MAX_PLAYERS);
+}
+
 //**********SUBLIBRARY: UserInterface/MultiJoinGame
 ADE_LIB_DERIV(l_UserInterface_MultiJoinGame,
 	"MultiJoinGame",
@@ -2914,24 +2975,6 @@ ADE_FUNC(sendJoinRequest,
 	}
 
 	return ADE_RETURN_FALSE;
-}
-
-ADE_VIRTVAR(StatusText, l_UserInterface_MultiJoinGame, nullptr, "The current status text", "string", "the status text")
-{
-	if (ADE_SETTING_VAR) {
-		LuaError(L, "This property is read only.");
-	}
-
-	return ade_set_args(L, "s", Multi_common_notify_text);
-}
-
-ADE_VIRTVAR(InfoText, l_UserInterface_MultiJoinGame, nullptr, "The current info text", "string", "the info text")
-{
-	if (ADE_SETTING_VAR) {
-		LuaError(L, "This property is read only.");
-	}
-
-	return ade_set_args(L, "s", Multi_common_all_text);
 }
 
 ADE_LIB_DERIV(l_Active_Games, "ActiveGames", nullptr, nullptr, l_UserInterface_MultiJoinGame);
@@ -3161,41 +3204,6 @@ ADE_FUNC(runNetwork,
 	multi_create_game_do(true);
 
 	return ADE_RETURN_NIL;
-}
-
-ADE_FUNC(getNetGame, l_UserInterface_MultiHostSetup, nullptr, "The handle to the netgame", "netgame", "The netgame handle")
-{
-	SCP_UNUSED(L);
-	return ade_set_args(L, "o", l_NetGame.Set(net_game_h()));
-}
-
-ADE_LIB_DERIV(l_Net_Players, "NetPlayers", nullptr, nullptr, l_UserInterface_MultiHostSetup);
-ADE_INDEXER(l_Net_Players,
-	"number Index",
-	"Array of net players",
-	"net_player",
-	"net player handle, or invalid handle if index is invalid")
-{
-	int idx;
-	if (!ade_get_args(L, "*i", &idx))
-		return ade_set_error(L, "s", "");
-
-	// convert from lua index
-	idx--;
-
-	if ((idx < 0) || (idx >= MAX_PLAYERS))
-		return ade_set_args(L, "o", l_NetPlayer.Set(net_player_h()));
-
-	return ade_set_args(L, "o", l_NetPlayer.Set(net_player_h(idx)));
-}
-
-ADE_FUNC(__len, l_Net_Players,
-	nullptr,
-	"The number of net players",
-	"number",
-	"The number of players.")
-{
-	return ade_set_args(L, "i", MAX_PLAYERS);
 }
 
 ADE_LIB_DERIV(l_Net_Missions, "NetMissions", nullptr, nullptr, l_UserInterface_MultiHostSetup);

--- a/code/scripting/api/objs/multi_objects.cpp
+++ b/code/scripting/api/objs/multi_objects.cpp
@@ -120,7 +120,7 @@ netgame_info* net_game_h::getNetgame() const
 
 bool net_game_h::isValid() const
 {
-	if (!(Game_mode & GM_MULTIPLAYER) && (Netgame.name[0] != '\0')) {
+	if ((Game_mode & GM_MULTIPLAYER) && (Netgame.name[0] != '\0')) {
 		return true;
 	} else {
 		return false;

--- a/code/scripting/api/objs/multi_objects.cpp
+++ b/code/scripting/api/objs/multi_objects.cpp
@@ -54,6 +54,11 @@ int net_player_h::getIndex() const
 
 bool net_player_h::isValid() const
 {
+	//If we're not in multiplayer mode then there will be no players!
+	if (!(Game_mode & GM_MULTIPLAYER)) {
+		return false;
+	}
+	
 	if (player < 0 || player >= MAX_PLAYERS) {
 		return false;
 	}
@@ -111,6 +116,15 @@ net_game_h::net_game_h() {}
 netgame_info* net_game_h::getNetgame() const
 {
 	return &Netgame;
+}
+
+bool net_game_h::isValid() const
+{
+	if (!(Game_mode & GM_MULTIPLAYER) && (Netgame.name[0] != '\0')) {
+		return true;
+	} else {
+		return false;
+	}
 }
 
 active_game_h::active_game_h() : game(-1) {}
@@ -797,6 +811,20 @@ ADE_VIRTVAR(Builtin,
 
 //**********HANDLE: netgame section
 ADE_OBJ(l_NetGame, net_game_h, "netgame", "Netgame handle");
+
+ADE_FUNC(isValid,
+	l_NetGame,
+	nullptr,
+	"Detects whether handle is valid",
+	"boolean",
+	"true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+{
+	net_game_h current;
+	if (!ade_get_args(L, "o", l_NetGame.Get(&current)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", current.isValid());
+}
 
 ADE_VIRTVAR(Name,
 	l_NetGame,

--- a/code/scripting/api/objs/multi_objects.h
+++ b/code/scripting/api/objs/multi_objects.h
@@ -48,6 +48,7 @@ struct net_campaign_h {
 struct net_game_h {
 	net_game_h();
 	netgame_info* getNetgame() const;
+	bool isValid() const;
 };
 
 struct active_game_h {


### PR DESCRIPTION
This PR reorganizes the API slightly, putting them roughly in top->bottom order as you'd progress through the UIs. It also moves Netgame, NetPlayer, Status Text, and Info Text up into the newer MultiGeneral category since they apply to more places than just MultiHostSetup or MultiJoinGame. While doing so it implements some additional validation for if those are accessed outside of proper Multi game states.

Finally this PR also implements `MultiGeneral.getChat()` and `.sendChat()`.

Be aware that for reviewing purposes, ui.cpp looks like a large diff but is actually nearly unchanged with the exception of the added code for MultiGeneral's getChat(), sendChat(), quitGame() and setPlayerState(). The rest of the changes that github is showing is just re-organized but unchanged code.