### PR TITLE
On loading complete hook

### DIFF
--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -31,6 +31,9 @@ const std::shared_ptr<Hook<>> OnLoadScreen = Hook<>::Factory("On Load Screen",
 	"Executed regularly during loading of a mission.",
 	{ {"Progress", "number", "A number from 0 to 1 indicating how far along the loading process the game is."}});
 
+const std::shared_ptr<Hook<>> OnLoadComplete =
+	Hook<>::Factory("On Load Complete", "Executed once a mission load has completed.", {});
+
 const std::shared_ptr<Hook<>> OnCampaignMissionAccept = Hook<>::Factory("On Campaign Mission Accept",
 	"Invoked after a campaign mission once the player accepts the result and moves on to the next mission instead of replaying it.",
 	{});

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -12,6 +12,7 @@ extern const std::shared_ptr<Hook<>>									OnIntroAboutToPlay;
 extern const std::shared_ptr<OverridableHook<>>							OnStateStart;
 
 extern const std::shared_ptr<Hook<>>									OnLoadScreen;
+extern const std::shared_ptr<Hook<>>									OnLoadComplete;
 extern const std::shared_ptr<Hook<>>									OnCampaignMissionAccept;
 extern const std::shared_ptr<Hook<>>									OnBriefStage;
 extern const std::shared_ptr<Hook<>>									OnMissionStart; 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1276,6 +1276,13 @@ void game_loading_callback_close()
 	Game_loading_background = -1;
 
 	font::set_font(font::FONT1);
+
+	// Mission loading during multi doesn't always set a new state event
+	// so this hook will let Lua scripts know we've finished no matter what
+	// game type is currently being played.
+	if (scripting::hooks::OnLoadComplete->isActive()) {
+		scripting::hooks::OnLoadComplete->run();
+	}
 }
 
 /**


### PR DESCRIPTION
Mission loading during Multi Mission Sync does not change game-state after the load completes, which is the traditional way to know when loading has finished. This is a simple hook that runs when loading completes regardless of game state and solves that problem.