### PR TITLE
Allow for more field of fire cooldown shenanigans

### DIFF
--- a/code/scripting/api/objs/ship_bank.cpp
+++ b/code/scripting/api/objs/ship_bank.cpp
@@ -395,12 +395,6 @@ ADE_VIRTVAR(FOFCooldown, l_WeaponBank, "number", "The FOF cooldown value. A valu
 	if(!bh->isValid())
 		return ade_set_error(L, "f", -1.f);
 
-	if (ADE_SETTING_VAR) {
-		CLAMP(newValue, 0.0f, 1.0f);
-		bh->typeh.sw->primary_bank_fof_cooldown[bh->bank] = newValue;
-		return ade_set_args(L, "f", bh->typeh.sw->primary_bank_fof_cooldown[bh->bank]);
-	}
-
 	switch(bh->typeh.type)
 	{
 		case SWH_PRIMARY:
@@ -409,6 +403,13 @@ ADE_VIRTVAR(FOFCooldown, l_WeaponBank, "number", "The FOF cooldown value. A valu
 			float reset_amount = (timestamp_until(bh->typeh.sw->last_primary_fire_stamp[bh->bank]) / 1000.0f) * wif->fof_reset_rate;
 			auto val = bh->typeh.sw->primary_bank_fof_cooldown[bh->bank] + reset_amount;
 			CLAMP(val, 0.0f, 1.0f);
+
+			if (ADE_SETTING_VAR) {
+				CLAMP(newValue, 0.0f, 1.0f);
+				bh->typeh.sw->primary_bank_fof_cooldown[bh->bank] = newValue;
+				val = newValue;
+			}
+
 			return ade_set_args(L, "f", val);
 		}
 		case SWH_SECONDARY:

--- a/code/scripting/api/objs/ship_bank.cpp
+++ b/code/scripting/api/objs/ship_bank.cpp
@@ -399,8 +399,6 @@ ADE_VIRTVAR(FOFCooldown, l_WeaponBank, "number", "The FOF cooldown value. A valu
 	{
 		case SWH_PRIMARY:
 		{
-			auto val = bh->typeh.sw->primary_bank_fof_cooldown[bh->bank];
-
 			if (ADE_SETTING_VAR) {
 				CLAMP(newValue, 0.0f, 1.0f);
 				bh->typeh.sw->primary_bank_fof_cooldown[bh->bank] = newValue;

--- a/code/scripting/api/objs/ship_bank.cpp
+++ b/code/scripting/api/objs/ship_bank.cpp
@@ -399,18 +399,14 @@ ADE_VIRTVAR(FOFCooldown, l_WeaponBank, "number", "The FOF cooldown value. A valu
 	{
 		case SWH_PRIMARY:
 		{
-			auto wif = &Weapon_info[bh->typeh.sw->primary_bank_weapons[bh->bank]];
-			float reset_amount = (timestamp_until(bh->typeh.sw->last_primary_fire_stamp[bh->bank]) / 1000.0f) * wif->fof_reset_rate;
-			auto val = bh->typeh.sw->primary_bank_fof_cooldown[bh->bank] + reset_amount;
-			CLAMP(val, 0.0f, 1.0f);
+			auto val = bh->typeh.sw->primary_bank_fof_cooldown[bh->bank];
 
 			if (ADE_SETTING_VAR) {
 				CLAMP(newValue, 0.0f, 1.0f);
 				bh->typeh.sw->primary_bank_fof_cooldown[bh->bank] = newValue;
-				val = newValue;
 			}
 
-			return ade_set_args(L, "f", val);
+			return ade_set_args(L, "f", bh->typeh.sw->primary_bank_fof_cooldown[bh->bank]);
 		}
 		case SWH_SECONDARY:
 		case SWH_TERTIARY:

--- a/code/scripting/api/objs/ship_bank.cpp
+++ b/code/scripting/api/objs/ship_bank.cpp
@@ -389,15 +389,16 @@ ADE_VIRTVAR(FOFCooldown, l_WeaponBank, "number", "The FOF cooldown value. A valu
 {
 	ship_bank_h *bh = NULL;
 	float newValue = -1.f;
-	if(!ade_get_args(L, "o|i", l_WeaponBank.GetPtr(&bh), &newValue))
+	if(!ade_get_args(L, "o|f", l_WeaponBank.GetPtr(&bh), &newValue))
 		return ade_set_error(L, "f", -1.f);
 
 	if(!bh->isValid())
 		return ade_set_error(L, "f", -1.f);
 
 	if (ADE_SETTING_VAR) {
-		LuaError(L, "This function does not support setting values yet!");
-		return ade_set_error(L, "f", -1.f);
+		CLAMP(newValue, 0.0f, 1.0f);
+		bh->typeh.sw->primary_bank_fof_cooldown[bh->bank] = newValue;
+		return ade_set_args(L, "f", bh->typeh.sw->primary_bank_fof_cooldown[bh->bank]);
 	}
 
 	switch(bh->typeh.type)

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -712,6 +712,36 @@ ADE_VIRTVAR(BurstDelay, l_Weaponclass, "number", "The time in seconds between sh
 	return ade_set_args(L, "f", Weapon_info[idx].burst_delay);
 }
 
+ADE_VIRTVAR(FieldOfFire, l_Weaponclass, "number", "The angular spread for shots of this weapon.", "number", "Fof in degrees, or 0 if handle is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
+		return ade_set_error(L, "f", 0.0f);
+
+	if (idx < 0 || idx >= weapon_info_size())
+		return ade_set_error(L, "f", 0.0f);
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting FieldOfFire is not supported");
+
+	return ade_set_args(L, "f", Weapon_info[idx].field_of_fire);
+}
+
+ADE_VIRTVAR(MaxFieldOfFire, l_Weaponclass, "number", "The maximum field of fire this weapon can have if it increases while firing.", "number", "Max Fof in degrees, or 0 if handle is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
+		return ade_set_error(L, "f", 0.0f);
+
+	if (idx < 0 || idx >= weapon_info_size())
+		return ade_set_error(L, "f", 0.0f);
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting MaxFieldOfFire is not supported");
+
+	return ade_set_args(L, "f", Weapon_info[idx].max_fof_spread);
+}
+
 ADE_VIRTVAR(BeamLife, l_Weaponclass, "number", "The time in seconds that a beam lasts while firing.", "number", "Beam life, or 0 if handle is invalid or the weapon is not a beam")
 {
 	int idx;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10448,6 +10448,19 @@ void ship_process_post(object * obj, float frametime)
 	// update radar status of the ship
 	ship_radar_process(obj, shipp, sip);
 
+	// update fof cooldowns
+	for (int i = 0; i < shipp->weapons.num_primary_banks; i++) {
+		if (shipp->weapons.primary_bank_weapons[i] < 0)
+			continue;
+
+		weapon_info* wip = &Weapon_info[shipp->weapons.primary_bank_weapons[i]];
+		
+		if (wip->fof_reset_rate > 0.0f) {
+			shipp->weapons.primary_bank_fof_cooldown[i] -= wip->fof_reset_rate * flFrametime;
+			CLAMP(shipp->weapons.primary_bank_fof_cooldown[i], 0.0f, 1.0f);
+		}
+	}
+
 	if ( (!(shipp->is_arriving()) || (Ai_info[shipp->ai_index].mode == AIM_BAY_EMERGE)
 		|| ((Warp_params[shipp->warpin_params_index].warp_type == WT_IN_PLACE_ANIM) && (shipp->flags[Ship_Flags::Arriving_stage_2])) )
 		&&	!(shipp->flags[Ship_Flags::Depart_warp]))
@@ -12512,11 +12525,8 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			next_fire_delay *= 1.0f + (effective_primary_banks - 1) * 0.5f;		//	50% time penalty if banks linked
 		}
 
-		if (winfo_p->fof_spread_rate > 0.0f)
-		{
-			//Adjust the primary_bank_fof_cooldown based on how long it's been since the last shot. 
-			float reset_amount = (timestamp_until(swp->last_primary_fire_stamp[bank_to_fire]) / 1000.0f) * winfo_p->fof_reset_rate;
-			swp->primary_bank_fof_cooldown[bank_to_fire] += winfo_p->fof_spread_rate + reset_amount;
+		if (winfo_p->fof_spread_rate > 0.0f) {
+			swp->primary_bank_fof_cooldown[bank_to_fire] += winfo_p->fof_spread_rate;
 			CLAMP(swp->primary_bank_fof_cooldown[bank_to_fire], 0.0f, 1.0f);
 		}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10456,7 +10456,7 @@ void ship_process_post(object * obj, float frametime)
 		weapon_info* wip = &Weapon_info[shipp->weapons.primary_bank_weapons[i]];
 		
 		if (wip->fof_reset_rate > 0.0f) {
-			shipp->weapons.primary_bank_fof_cooldown[i] -= wip->fof_reset_rate * flFrametime;
+			shipp->weapons.primary_bank_fof_cooldown[i] -= wip->fof_reset_rate * frametime;
 			CLAMP(shipp->weapons.primary_bank_fof_cooldown[i], 0.0f, 1.0f);
 		}
 	}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3449,23 +3449,29 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	if(optional_string("$FOF:")){
 		stuff_float(&wip->field_of_fire);
 
-		if(optional_string("+FOF Spread Rate:")){
+		bool max_required = false;
+		if (optional_string("+FOF Spread Rate:")) {
 			stuff_float(&wip->fof_spread_rate);
-			if(required_string("+FOF Reset Rate:")){
+			if (required_string("+FOF Reset Rate:")) {
 				stuff_float(&wip->fof_reset_rate);
 			}
+			max_required = true;
+		}
 
-			if(required_string("+Max FOF:")){
-				float max_fof;
-				stuff_float(&max_fof);
-				wip->max_fof_spread = max_fof - wip->field_of_fire;
+		if (optional_string("+Max FOF:")){
+			float max_fof;
+			stuff_float(&max_fof);
+			wip->max_fof_spread = max_fof - wip->field_of_fire;
 
-				if (wip->max_fof_spread <= 0.0f) {
-					Warning(LOCATION, "WARNING: +Max FOF must be at least as big as $FOF for '%s'! Defaulting to match $FOF, no spread will occur!", wip->name);
-					wip->max_fof_spread = 0.0f;
-				}
+			if (wip->max_fof_spread <= 0.0f) {
+				Warning(LOCATION, "WARNING: +Max FOF must be at least as big as $FOF for '%s'! Defaulting to match $FOF, no spread will occur!", wip->name);
+				wip->max_fof_spread = 0.0f;
 			}
 		}
+
+		if (max_required && wip->max_fof_spread <= 0.0f) {
+			Error(LOCATION, "ERROR: +Max FOF for '%s' must be used if +FOF Spread Rate: is used!", wip->name);
+		}		
 	}
 
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3464,13 +3464,15 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			wip->max_fof_spread = max_fof - wip->field_of_fire;
 
 			if (wip->max_fof_spread <= 0.0f) {
-				Warning(LOCATION, "WARNING: +Max FOF must be at least as big as $FOF for '%s'! Defaulting to match $FOF, no spread will occur!", wip->name);
+				error_display(0, "+Max FOF must be at least as big as $FOF for '%s'! Defaulting to match $FOF, no spread will occur!", wip->name);
 				wip->max_fof_spread = 0.0f;
 			}
 		}
 
 		if (max_required && wip->max_fof_spread <= 0.0f) {
-			Error(LOCATION, "ERROR: +Max FOF for '%s' must be used if +FOF Spread Rate: is used!", wip->name);
+			error_display(0, "+Max FOF for '%s' must be used if +FOF Spread Rate: is used! Disabling FOF spread instead...", wip->name);
+			wip->fof_spread_rate = 0.0f;
+			wip->fof_reset_rate = 0.0f;
 		}		
 	}
 


### PR DESCRIPTION
This allows a scripter to override the 'fof cooldown' i.e. where in between its regular fof and its max fof it is at the moment, this way they can make it be based on whatever, instead of just spread and reset rate. As part of this +Max Fof no longer requires spread rate, since it's harmless to provided a max fof but no engine builtin way for it to reach that max.