### PR TITLE
fix issues with get_text() and set_text() for INPUTBOX

### DIFF
--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -9232,7 +9232,7 @@ void multi_passwd_do(char *passwd)
 		// if the input box text has changed
 		if(Multi_pwd_passwd.changed()){
 			strcpy(passwd,"");
-			Multi_pwd_passwd.get_text(passwd);
+			Multi_pwd_passwd.get_text(passwd, MAX_PASSWD_LEN+1);
 		}
 
 		// process any button pressed

--- a/code/ui/inputbox.cpp
+++ b/code/ui/inputbox.cpp
@@ -99,6 +99,7 @@ void UI_INPUTBOX::create(UI_WINDOW *wnd, int _x, int _y, int _w, int _text_len, 
 
 	base_create( wnd, UI_KIND_INPUTBOX, _x, _y, _w, th+4 );
 	text = (char *) vm_malloc( _text_len + 1);
+	memset(text, 0, _text_len + 1);
 
 	// input boxes no longer use background
 	_flags |= UI_INPUTBOX_FLAG_NO_BACK;
@@ -496,10 +497,15 @@ int UI_INPUTBOX::pressed()
 	return pressed_down;
 }
 
-void UI_INPUTBOX::get_text(char *out)
+void UI_INPUTBOX::get_text(char *out, size_t max_out_len)
 {
-	strncpy(out, text, length);
-	out[length] = 0;
+	strncpy(out, text, max_out_len);
+	out[max_out_len-1] = 0;
+}
+
+void UI_INPUTBOX::get_text(SCP_string &out)
+{
+	out = text;
 }
 
 void UI_INPUTBOX::set_text(const char *in)
@@ -510,7 +516,7 @@ void UI_INPUTBOX::set_text(const char *in)
 	if (in_length > length)
 		Assert(0);	// tried to force text into an input box that won't fit into allocated memory
 
-	strcpy(text, in);
+	strncpy(text, in, length);
 	
 	if (flags & UI_INPUTBOX_FLAG_PASSWD) {
 		memset(passwd_text, INPUTBOX_PASSWD_CHAR, strlen(text));

--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -395,9 +395,26 @@ class UI_INPUTBOX : public UI_GADGET
 		/**
 		 * @brief Retrieves the string currently in the inputbox
 		 * @param[out] out Destination char[] to copy the string to
+		 * @param[max_out_len] max_out_len Maximum length of out string
 		*/
-		void get_text(char* out);
-		
+		void get_text(char* out, size_t max_out_len);
+
+		/**
+		 * @brief Retrieves the string currently in the inputbox
+		 * @param[out] out Destination char[] to copy the string to
+		*/
+		template<size_t size>
+		inline void get_text(char (&out)[size])
+		{
+			get_text(out, size);
+		}
+
+		/**
+		 * @brief Retrieves the string currently in the inputbox
+		 * @param[out] out Destination SCP_String to copy the string to
+		*/
+		void get_text(SCP_string &out);
+
 		/**
 		 * @brief Sets the string in the inputbox
 		 * @param[in] in Source char[] to copy the string from


### PR DESCRIPTION
Fix multiple buffer out-of-bounds issues with INPUTBOX text. Change get_text() to use safer calling methods and use strncpy() in set_text() to avoid issue with incoming text being longer than what is allocated for the control.