### PR TITLE
Check if inputbox is valid

### DIFF
--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -3202,6 +3202,11 @@ void multi_pxo_chat_process()
 	char msg[512];
 	int msg_pixel_width;
 
+	// Bail if the input box is not ready to go
+	if (!Multi_pxo_chat_input.is_valid()) {
+		return;
+	}
+
 	// if the chat line is getting too long, fire off the message, putting the last
 	// word on the next input line.
 	memset(msg, 0, 512);

--- a/code/ui/inputbox.cpp
+++ b/code/ui/inputbox.cpp
@@ -131,6 +131,7 @@ void UI_INPUTBOX::create(UI_WINDOW *wnd, int _x, int _y, int _w, int _text_len, 
 	locked = 0;
 	valid_chars = NULL;
 	invalid_chars = NULL;
+	valid = true;
 }
 
 void UI_INPUTBOX::set_valid_chars(const char *vchars)
@@ -182,6 +183,8 @@ void UI_INPUTBOX::destroy()
 		vm_free(passwd_text);
 		passwd_text = NULL;
 	}
+
+	valid = false;
 
 	UI_GADGET::destroy();
 }
@@ -495,6 +498,11 @@ int UI_INPUTBOX::changed()
 int UI_INPUTBOX::pressed()
 {	
 	return pressed_down;
+}
+
+bool UI_INPUTBOX::is_valid()
+{
+	return valid;
 }
 
 void UI_INPUTBOX::get_text(char *out, size_t max_out_len)

--- a/code/ui/ui.h
+++ b/code/ui/ui.h
@@ -293,6 +293,7 @@ class UI_INPUTBOX : public UI_GADGET
 		color *text_color;
 		char *valid_chars;
 		char *invalid_chars;
+		bool valid; // is invalid until created and then is valid until destroyed
 
 		// cursor drawing
 		int cursor_first_frame;
@@ -391,6 +392,11 @@ class UI_INPUTBOX : public UI_GADGET
 		 * @brief Returns 1 if the Enter key was pressed
 		*/
 		int pressed();
+
+		/**
+		 * @brief Returns true if valid
+		 */
+		bool is_valid();
 
 		/**
 		 * @brief Retrieves the string currently in the inputbox


### PR DESCRIPTION
The recent fixes to InputBox handling exposed a different issue with SCPUI and logging into PXO. During the login process the method `multi_pxo_process_common()` is run, but since it's run by FSO and not the LUA API it correctly has `api_access` set to false. Thus is also runs `multi_pxo_chat_process()` which expects the chat InputBox to have non null data.

However since SCPUI has already overridden the ui creation at this point the InputBox does not get created. I thought through a number of ways to fix this, but in the end I decided a simple method to test if an InputBox is valid was the simplest.