### PR TITLE
hide key-reset

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -38453,8 +38453,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tMarks the specified default key as having not been pressed, so key-pressed will be false "
 		"until the player presses it again.  See key-pressed help for more information about "
 		"what a default key is.\r\n\r\n"
-		"\tNote that this sexp will not work properly in repeating events.  Use key-reset-multiple "
-		"if this is to be called multiple times in one event.\r\n\r\n"
+		"\tNote that this sexp will only fire once when used in a repeating event, which may not be what you want.  Use key-reset-multiple "
+		"if a key should be reset each time the event repeats.\r\n\r\n"
 		"Returns a boolean value.  Takes 1 or more arguments...\r\n"
 		"\tAll:\tDefault key to reset." },
 
@@ -38463,7 +38463,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tMarks the specified default key as having not been pressed, so key-pressed will be false "
 		"until the player presses it again.  See key-pressed help for more information about "
 		"what a default key is.\r\n\r\n"
-		"\tThis sexp, unlike key-reset, will work properly if called multiple times in one event.\r\n\r\n"
+		"\tNote that this sexp will fire every time an event repeats.  If you only want a key to be reset once regardless of how many times the event repeats, use key-reset.\r\n\r\n"
 		"Returns a boolean value.  Takes 1 or more arguments...\r\n"
 		"\tAll:\tDefault key to reset." },
 

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -1014,6 +1014,7 @@ void sexp_tree::right_clicked(int mode)
 							case OP_ADD_BACKGROUND_BITMAP:
 							case OP_ADD_SUN_BITMAP:
 							case OP_JUMP_NODE_SET_JUMPNODE_NAME:
+							case OP_KEY_RESET:
 								j = (int)op_menu.size();	// don't allow these operators to be visible
 								break;
 						}
@@ -1069,6 +1070,7 @@ void sexp_tree::right_clicked(int mode)
 							case OP_ADD_BACKGROUND_BITMAP:
 							case OP_ADD_SUN_BITMAP:
 							case OP_JUMP_NODE_SET_JUMPNODE_NAME:
+							case OP_KEY_RESET:
 								j = (int)op_submenu.size();	// don't allow these operators to be visible
 								break;
 						}

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -6074,6 +6074,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 					case OP_ADD_BACKGROUND_BITMAP:
 					case OP_ADD_SUN_BITMAP:
 					case OP_JUMP_NODE_SET_JUMPNODE_NAME:
+					case OP_KEY_RESET:
 						j = (int) op_menu.size();    // don't allow these operators to be visible
 						break;
 					}
@@ -6146,6 +6147,7 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 					case OP_ADD_BACKGROUND_BITMAP:
 					case OP_ADD_SUN_BITMAP:
 					case OP_JUMP_NODE_SET_JUMPNODE_NAME:
+					case OP_KEY_RESET:
 						j = (int) op_submenu.size();    // don't allow these operators to be visible
 						break;
 					}


### PR DESCRIPTION
Hides the `key-reset` operator in FRED and elaborates on the help descriptions for both it and `key-reset-multiple`.  Implements #6076.