### PR TITLE
add 'In back of ship' arrival location

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -242,7 +242,7 @@ const char *Icon_names[MIN_BRIEF_ICONS] = {
 
 // definitions for arrival locations for ships/wings
 const char *Arrival_location_names[MAX_ARRIVAL_NAMES] = {
-	"Hyperspace", "Near Ship", "In front of ship", "In back of ship", "Docking Bay",
+	"Hyperspace", "Near Ship", "In front of ship", "In back of ship", "Above ship", "Below ship", "To left of ship", "To right of ship", "Docking Bay",
 };
 
 const char *Departure_location_names[MAX_DEPARTURE_NAMES] = {
@@ -3160,7 +3160,11 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 		stuff_int(&p_objp->arrival_distance);
 
 		// Goober5000
-		if ((p_objp->arrival_distance <= 0) && ((p_objp->arrival_location == ARRIVE_NEAR_SHIP) || (p_objp->arrival_location == ARRIVE_IN_FRONT_OF_SHIP) || (p_objp->arrival_location == ARRIVE_IN_BACK_OF_SHIP)))
+		if ((p_objp->arrival_distance <= 0) && (
+			   (p_objp->arrival_location == ARRIVE_NEAR_SHIP)
+			|| (p_objp->arrival_location == ARRIVE_IN_FRONT_OF_SHIP) || (p_objp->arrival_location == ARRIVE_IN_BACK_OF_SHIP)
+			|| (p_objp->arrival_location == ARRIVE_ABOVE_SHIP) || (p_objp->arrival_location == ARRIVE_BELOW_SHIP)
+			|| (p_objp->arrival_location == ARRIVE_TO_LEFT_OF_SHIP) || (p_objp->arrival_location == ARRIVE_TO_RIGHT_OF_SHIP) ))
 		{
 			Warning(LOCATION, "Arrival distance for ship %s cannot be %d.  Setting to 1.\n", p_objp->name, p_objp->arrival_distance);
 			p_objp->arrival_distance = 1;
@@ -4591,7 +4595,11 @@ void parse_wing(mission *pm)
 		stuff_int( &wingp->arrival_distance );
 
 		// Goober5000
-		if ((wingp->arrival_distance <= 0) && ((wingp->arrival_location == ARRIVE_NEAR_SHIP) || (wingp->arrival_location == ARRIVE_IN_FRONT_OF_SHIP) || (wingp->arrival_location == ARRIVE_IN_BACK_OF_SHIP)))
+		if ((wingp->arrival_distance <= 0) && (
+			   (wingp->arrival_location == ARRIVE_NEAR_SHIP)
+			|| (wingp->arrival_location == ARRIVE_IN_FRONT_OF_SHIP) || (wingp->arrival_location == ARRIVE_IN_BACK_OF_SHIP)
+			|| (wingp->arrival_location == ARRIVE_ABOVE_SHIP) || (wingp->arrival_location == ARRIVE_BELOW_SHIP)
+			|| (wingp->arrival_location == ARRIVE_TO_LEFT_OF_SHIP) || (wingp->arrival_location == ARRIVE_TO_RIGHT_OF_SHIP) ))
 		{
 			Warning(LOCATION, "Arrival distance for wing %s cannot be %d.  Setting to 1.\n", wingp->name, wingp->arrival_distance);
 			wingp->arrival_distance = 1;
@@ -7427,7 +7435,9 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 				vm_vec_rand_vec_quick(&rand_vec);
 			else
 				static_randvec( Objects[objnum].net_signature, &rand_vec );
-		} else if ( location == ARRIVE_IN_FRONT_OF_SHIP || location == ARRIVE_IN_BACK_OF_SHIP ) {
+		} else if ( location == ARRIVE_IN_FRONT_OF_SHIP || location == ARRIVE_IN_BACK_OF_SHIP
+			     || location == ARRIVE_ABOVE_SHIP || location == ARRIVE_BELOW_SHIP
+			     || location == ARRIVE_TO_LEFT_OF_SHIP || location == ARRIVE_TO_RIGHT_OF_SHIP ) {
 			vec3d t1, t2, t3;
 			int r1, r2;
 			float x;
@@ -7454,8 +7464,15 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 			vm_vec_add2(&rand_vec, &t3);
 			vm_vec_normalize(&rand_vec);
 
-			// for "in back of ship", just flip the vector around
-			if (location == ARRIVE_IN_BACK_OF_SHIP)
+			// vertical axis: rotate to up (around X axis)
+			if (location == ARRIVE_ABOVE_SHIP || location == ARRIVE_BELOW_SHIP)
+				vm_rot_point_around_line(&rand_vec, &rand_vec, PI_2, &vmd_zero_vector, &vmd_x_vector);
+			// lateral axis: rotate to right (backwards around Y axis)
+			else if (location == ARRIVE_TO_LEFT_OF_SHIP || location == ARRIVE_TO_RIGHT_OF_SHIP)
+				vm_rot_point_around_line(&rand_vec, &rand_vec, -PI_2, &vmd_zero_vector, &vmd_y_vector);
+
+			// for the opposite directions, just flip the vector around
+			if (location == ARRIVE_IN_BACK_OF_SHIP || location == ARRIVE_BELOW_SHIP || location == ARRIVE_TO_LEFT_OF_SHIP)
 				vm_vec_negate(&rand_vec);
 		} else {
 			UNREACHABLE("Unknown location type discovered when trying to parse %s -- Please let an SCP coder know!", Ships[shipnum].ship_name);
@@ -8922,7 +8939,8 @@ bool check_for_24_1_data()
 {
 	for (int wingnum = 0; wingnum < Num_wings; wingnum++)
 	{
-		if (Wings[wingnum].arrival_location == ARRIVE_IN_BACK_OF_SHIP)
+		if (Wings[wingnum].arrival_location == ARRIVE_IN_BACK_OF_SHIP || Wings[wingnum].arrival_location == ARRIVE_ABOVE_SHIP || Wings[wingnum].arrival_location == ARRIVE_BELOW_SHIP
+			|| Wings[wingnum].arrival_location == ARRIVE_TO_LEFT_OF_SHIP || Wings[wingnum].arrival_location == ARRIVE_TO_RIGHT_OF_SHIP)
 			return true;
 	}
 
@@ -8930,7 +8948,8 @@ bool check_for_24_1_data()
 	{
 		auto shipp = &Ships[Objects[so->objnum].instance];
 
-		if (shipp->arrival_location == ARRIVE_IN_BACK_OF_SHIP)
+		if (shipp->arrival_location == ARRIVE_IN_BACK_OF_SHIP || shipp->arrival_location == ARRIVE_ABOVE_SHIP || shipp->arrival_location == ARRIVE_BELOW_SHIP
+			|| shipp->arrival_location == ARRIVE_TO_LEFT_OF_SHIP || shipp->arrival_location == ARRIVE_TO_RIGHT_OF_SHIP)
 			return true;
 	}
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -51,9 +51,10 @@ int get_special_anchor(const char *name);
 extern const gameversion::version MISSION_VERSION;
 extern const gameversion::version LEGACY_MISSION_VERSION;
 
-// This checks to see if a mission has data that requires saving in a newer format.  This would warrant
+// These check to see if a mission has data that requires saving in a newer format.  This would warrant
 // a "soft version bump" rather than a hard bump because not all missions are affected.
 extern bool check_for_23_3_data();
+extern bool check_for_24_1_data();
 
 #define WING_PLAYER_BASE	0x80000  // used by Fred to tell ship_index in a wing points to a player
 
@@ -219,11 +220,12 @@ extern char Mission_filename[80];  // filename of mission in The_mission (Fred o
 
 // defines for arrival locations.  These defines should match their counterparts in the arrival location
 // array
-#define	MAX_ARRIVAL_NAMES				4
+#define	MAX_ARRIVAL_NAMES				5
 #define	ARRIVE_AT_LOCATION			0
 #define	ARRIVE_NEAR_SHIP				1
 #define	ARRIVE_IN_FRONT_OF_SHIP		2
-#define	ARRIVE_FROM_DOCK_BAY			3
+#define	ARRIVE_IN_BACK_OF_SHIP		3
+#define	ARRIVE_FROM_DOCK_BAY			4
 
 // defines for departure locations.  These defines should match their counterparts in the departure location
 // array

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -220,12 +220,16 @@ extern char Mission_filename[80];  // filename of mission in The_mission (Fred o
 
 // defines for arrival locations.  These defines should match their counterparts in the arrival location
 // array
-#define	MAX_ARRIVAL_NAMES				5
+#define	MAX_ARRIVAL_NAMES				9
 #define	ARRIVE_AT_LOCATION			0
 #define	ARRIVE_NEAR_SHIP				1
 #define	ARRIVE_IN_FRONT_OF_SHIP		2
 #define	ARRIVE_IN_BACK_OF_SHIP		3
-#define	ARRIVE_FROM_DOCK_BAY			4
+#define ARRIVE_ABOVE_SHIP			4
+#define ARRIVE_BELOW_SHIP			5
+#define ARRIVE_TO_LEFT_OF_SHIP		6
+#define ARRIVE_TO_RIGHT_OF_SHIP		7
+#define	ARRIVE_FROM_DOCK_BAY			8
 
 // defines for departure locations.  These defines should match their counterparts in the departure location
 // array

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3135,14 +3135,23 @@ void CFred_mission_save::save_mission_internal(const char *pathname)
 	The_mission.required_fso_version = MISSION_VERSION;
 
 	// Additional incremental version update for some features
-	auto newer_version = gameversion::version(23, 3);
-	if (MISSION_VERSION >= newer_version)
+	auto version_23_3 = gameversion::version(23, 3);
+	auto version_24_1 = gameversion::version(24, 1);
+	if (MISSION_VERSION >= version_24_1)
 	{
-		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 23.3, the incremental version code can be removed");
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 24.1, the check_for_24_1_data() and check_for_23_3_data() code can be removed");
+	}
+	else if (check_for_24_1_data())
+	{
+		The_mission.required_fso_version = version_24_1;
+	}
+	else if (MISSION_VERSION >= version_23_3)
+	{
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 23.3, the check_for_23_3_data() code can be removed");
 	}
 	else if (check_for_23_3_data())
 	{
-		The_mission.required_fso_version = newer_version;
+		The_mission.required_fso_version = version_23_3;
 	}
 
 	reset_parse();

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3045,14 +3045,23 @@ void CFred_mission_save::save_mission_internal(const char* pathname)
 	The_mission.required_fso_version = MISSION_VERSION;
 
 	// Additional incremental version update for some features
-	auto newer_version = gameversion::version(23, 3);
-	if (MISSION_VERSION >= newer_version)
+	auto version_23_3 = gameversion::version(23, 3);
+	auto version_24_1 = gameversion::version(24, 1);
+	if (MISSION_VERSION >= version_24_1)
 	{
-		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 23.3, the incremental version code can be removed");
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 24.1, the check_for_24_1_data() and check_for_23_3_data() code can be removed");
+	}
+	else if (check_for_24_1_data())
+	{
+		The_mission.required_fso_version = version_24_1;
+	}
+	else if (MISSION_VERSION >= version_23_3)
+	{
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 23.3, the check_for_23_3_data() code can be removed");
 	}
 	else if (check_for_23_3_data())
 	{
-		The_mission.required_fso_version = newer_version;
+		The_mission.required_fso_version = version_23_3;
 	}
 
 	reset_parse();


### PR DESCRIPTION
Allows ships and wings to arrive behind a ship, to complement 'In front of ship'.  In fact, the arrival code is nearly identical, with just a small tweak to distinguish ahead from behind.

Since the new arrival location represents a change in mission format, this also adds code to detect for its usage and set the mission format to 24.1.  Most missions can continue to be saved as version 23.1.

Tested and works as expected.