### PR TITLE
convert arrival/departure locations to enum classes

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3063,7 +3063,7 @@ void HudGaugeSupport::render(float  /*frametime*/)
 		renderStringAlignCenter(position[0], position[1] + text_val_offset_y, w, outstr);
 	} else {
 		if ( Hud_support_objnum == -1 ) {
-			if (The_mission.support_ships.arrival_location == ARRIVE_FROM_DOCK_BAY)
+			if (The_mission.support_ships.arrival_location == ArrivalLocation::FROM_DOCK_BAY)
 			{
 				strcpy_s(outstr, XSTR( "exiting hangar", 1622));
 			}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -452,7 +452,7 @@ bool post_process_mission(mission *pm);
 int allocate_subsys_status();
 void parse_common_object_data(p_object	*objp);
 void parse_asteroid_fields(mission *pm);
-int mission_set_arrival_location(int anchor, int location, int distance, int objnum, int path_mask, vec3d *new_pos, matrix *new_orient);
+int mission_set_arrival_location(int anchor, ArrivalLocation location, int distance, int objnum, int path_mask, vec3d *new_pos, matrix *new_orient);
 int get_anchor(const char *name);
 void mission_parse_set_up_initial_docks();
 void mission_parse_set_arrival_locations();
@@ -1961,7 +1961,7 @@ int parse_create_object(p_object *pobjp, bool standalone_ship)
 	// warp it in (moved from parse_create_object_sub)
 	if ((Game_mode & GM_IN_MISSION) && (!Fred_running) && (!Game_restoring))
 	{
-		if ((Ships[objp->instance].wingnum < 0) && (pobjp->arrival_location != ARRIVE_FROM_DOCK_BAY))
+		if ((Ships[objp->instance].wingnum < 0) && (pobjp->arrival_location != ArrivalLocation::FROM_DOCK_BAY))
 		{
 			shipfx_warpin_start(objp);
 		}
@@ -2496,15 +2496,13 @@ int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 			// if this ship isn't in a wing, determine its arrival location
 			if (shipp->wingnum == -1)
 			{
-				int location;
-
 				// multiplayer clients set the arrival location of ships to be at location since their
 				// position has already been determined.  Don't actually set the variable since we
 				// don't want the warp effect to show if coming from a dock bay.
-				location = p_objp->arrival_location;
+				auto location = p_objp->arrival_location;
 
 				if (MULTIPLAYER_CLIENT)
-					location = ARRIVE_AT_LOCATION;
+					location = ArrivalLocation::AT_LOCATION;
 
 				anchor_objnum = mission_set_arrival_location(p_objp->arrival_anchor, location, p_objp->arrival_distance, objnum, p_objp->arrival_path_mask, NULL, NULL);
 
@@ -3153,7 +3151,9 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 
 	parse_common_object_data(p_objp);  // get initial conditions and subsys status
 
-	find_and_stuff("$Arrival Location:", &p_objp->arrival_location, F_NAME, Arrival_location_names, Num_arrival_names, "Arrival Location");
+	find_and_stuff("$Arrival Location:", &temp, F_NAME, Arrival_location_names, Num_arrival_names, "Arrival Location");
+	if (temp >= 0)
+		p_objp->arrival_location = static_cast<ArrivalLocation>(temp);
 
 	if (optional_string("+Arrival Distance:"))
 	{
@@ -3161,17 +3161,17 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 
 		// Goober5000
 		if ((p_objp->arrival_distance <= 0) && (
-			   (p_objp->arrival_location == ARRIVE_NEAR_SHIP)
-			|| (p_objp->arrival_location == ARRIVE_IN_FRONT_OF_SHIP) || (p_objp->arrival_location == ARRIVE_IN_BACK_OF_SHIP)
-			|| (p_objp->arrival_location == ARRIVE_ABOVE_SHIP) || (p_objp->arrival_location == ARRIVE_BELOW_SHIP)
-			|| (p_objp->arrival_location == ARRIVE_TO_LEFT_OF_SHIP) || (p_objp->arrival_location == ARRIVE_TO_RIGHT_OF_SHIP) ))
+			   (p_objp->arrival_location == ArrivalLocation::NEAR_SHIP)
+			|| (p_objp->arrival_location == ArrivalLocation::IN_FRONT_OF_SHIP) || (p_objp->arrival_location == ArrivalLocation::IN_BACK_OF_SHIP)
+			|| (p_objp->arrival_location == ArrivalLocation::ABOVE_SHIP) || (p_objp->arrival_location == ArrivalLocation::BELOW_SHIP)
+			|| (p_objp->arrival_location == ArrivalLocation::TO_LEFT_OF_SHIP) || (p_objp->arrival_location == ArrivalLocation::TO_RIGHT_OF_SHIP) ))
 		{
 			Warning(LOCATION, "Arrival distance for ship %s cannot be %d.  Setting to 1.\n", p_objp->name, p_objp->arrival_distance);
 			p_objp->arrival_distance = 1;
 		}
 	}
 
-	if (p_objp->arrival_location != ARRIVE_AT_LOCATION)
+	if (p_objp->arrival_location != ArrivalLocation::AT_LOCATION)
 	{
 		required_string("$Arrival Anchor:");
 		stuff_string(name, F_NAME, NAME_LENGTH);
@@ -3204,9 +3204,11 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 	required_string("$Arrival Cue:");
 	p_objp->arrival_cue = get_sexp_main();
 
-	find_and_stuff("$Departure Location:", &p_objp->departure_location, F_NAME, Departure_location_names, Num_arrival_names, "Departure Location");
+	find_and_stuff("$Departure Location:", &temp, F_NAME, Departure_location_names, Num_arrival_names, "Departure Location");
+	if (temp >= 0)
+		p_objp->departure_location = static_cast<DepartureLocation>(temp);
 
-	if (p_objp->departure_location != DEPART_AT_LOCATION)
+	if (p_objp->departure_location != DepartureLocation::AT_LOCATION)
 	{
 		required_string("$Departure Anchor:");
 		stuff_string(name, F_NAME, NAME_LENGTH);
@@ -4148,7 +4150,7 @@ int parse_wing_create_ships( wing *wingp, int num_to_create, bool force_create, 
 
 		// if wing is coming from docking bay, then be sure that ship we are arriving from actually exists
 		// (or will exist).
-		if ( wingp->arrival_location == ARRIVE_FROM_DOCK_BAY ) {
+		if ( wingp->arrival_location == ArrivalLocation::FROM_DOCK_BAY ) {
 			Assert( wingp->arrival_anchor >= 0 );
 			auto anchor_ship_entry = ship_registry_get(Parse_names[wingp->arrival_anchor]);
 
@@ -4588,7 +4590,10 @@ void parse_wing(mission *pm)
 		stuff_float(&wingp->formation_scale);
 	}
 
-	find_and_stuff("$Arrival Location:", &wingp->arrival_location, F_NAME, Arrival_location_names, Num_arrival_names, "Arrival Location");
+	int temp;
+	find_and_stuff("$Arrival Location:", &temp, F_NAME, Arrival_location_names, Num_arrival_names, "Arrival Location");
+	if (temp >= 0)
+		wingp->arrival_location = static_cast<ArrivalLocation>(temp);
 
 	if ( optional_string("+Arrival Distance:") )
 	{
@@ -4596,17 +4601,17 @@ void parse_wing(mission *pm)
 
 		// Goober5000
 		if ((wingp->arrival_distance <= 0) && (
-			   (wingp->arrival_location == ARRIVE_NEAR_SHIP)
-			|| (wingp->arrival_location == ARRIVE_IN_FRONT_OF_SHIP) || (wingp->arrival_location == ARRIVE_IN_BACK_OF_SHIP)
-			|| (wingp->arrival_location == ARRIVE_ABOVE_SHIP) || (wingp->arrival_location == ARRIVE_BELOW_SHIP)
-			|| (wingp->arrival_location == ARRIVE_TO_LEFT_OF_SHIP) || (wingp->arrival_location == ARRIVE_TO_RIGHT_OF_SHIP) ))
+			   (wingp->arrival_location == ArrivalLocation::NEAR_SHIP)
+			|| (wingp->arrival_location == ArrivalLocation::IN_FRONT_OF_SHIP) || (wingp->arrival_location == ArrivalLocation::IN_BACK_OF_SHIP)
+			|| (wingp->arrival_location == ArrivalLocation::ABOVE_SHIP) || (wingp->arrival_location == ArrivalLocation::BELOW_SHIP)
+			|| (wingp->arrival_location == ArrivalLocation::TO_LEFT_OF_SHIP) || (wingp->arrival_location == ArrivalLocation::TO_RIGHT_OF_SHIP) ))
 		{
 			Warning(LOCATION, "Arrival distance for wing %s cannot be %d.  Setting to 1.\n", wingp->name, wingp->arrival_distance);
 			wingp->arrival_distance = 1;
 		}
 	}
 
-	if ( wingp->arrival_location != ARRIVE_AT_LOCATION )
+	if ( wingp->arrival_location != ArrivalLocation::AT_LOCATION )
 	{
 		required_string("$Arrival Anchor:");
 		stuff_string(name, F_NAME, NAME_LENGTH);
@@ -4639,9 +4644,11 @@ void parse_wing(mission *pm)
 	required_string("$Arrival Cue:");
 	wingp->arrival_cue = get_sexp_main();
 	
-	find_and_stuff("$Departure Location:", &wingp->departure_location, F_NAME, Departure_location_names, Num_arrival_names, "Departure Location");
+	find_and_stuff("$Departure Location:", &temp, F_NAME, Departure_location_names, Num_arrival_names, "Departure Location");
+	if (temp >= 0)
+		wingp->departure_location = static_cast<DepartureLocation>(temp);
 
-	if ( wingp->departure_location != DEPART_AT_LOCATION )
+	if ( wingp->departure_location != DepartureLocation::AT_LOCATION )
 	{
 		required_string("$Departure Anchor:");
 		stuff_string( name, F_NAME, NAME_LENGTH );
@@ -6884,7 +6891,7 @@ void mission_set_wing_arrival_location( wing *wingp, int num_to_set )
 	// get the starting index into the ship_index array of the first ship whose location we need set.
 
 	index = wingp->current_count - num_to_set;
-	if ( (wingp->arrival_location == ARRIVE_FROM_DOCK_BAY) || (wingp->arrival_location == ARRIVE_AT_LOCATION) ) {
+	if ( (wingp->arrival_location == ArrivalLocation::FROM_DOCK_BAY) || (wingp->arrival_location == ArrivalLocation::AT_LOCATION) ) {
 		while ( index < wingp->current_count ) {
 			object *objp;
 
@@ -6936,7 +6943,7 @@ void mission_set_wing_arrival_location( wing *wingp, int num_to_set )
 					));
 			}
 
-			if (wingp->arrival_location != ARRIVE_FROM_DOCK_BAY) {
+			if (wingp->arrival_location != ArrivalLocation::FROM_DOCK_BAY) {
 				shipfx_warpin_start(objp);
 			}
 		}
@@ -7358,13 +7365,13 @@ bool mission_check_ship_yet_to_arrive(const char *name)
  * Sets the arrival location of a parse object according to the arrival location of the object.
  * @return objnum of anchor ship if there is one, -1 otherwise.
  */
-int mission_set_arrival_location(int anchor, int location, int dist, int objnum, int path_mask, vec3d *new_pos, matrix *new_orient)
+int mission_set_arrival_location(int anchor, ArrivalLocation location, int dist, int objnum, int path_mask, vec3d *new_pos, matrix *new_orient)
 {
 	int shipnum, anchor_objnum;
 	vec3d anchor_pos, rand_vec, new_fvec;
 	matrix orient;
 
-	if ( location == ARRIVE_AT_LOCATION )
+	if ( location == ArrivalLocation::AT_LOCATION )
 		return -1;
 
 	Assert(anchor >= 0);
@@ -7395,7 +7402,7 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 	// arrive at its placed location
 	if (shipnum < 0)
 	{
-		Assert ( location != ARRIVE_FROM_DOCK_BAY );		// bogus data somewhere!!!  get mwa
+		Assert ( location != ArrivalLocation::FROM_DOCK_BAY );		// bogus data somewhere!!!  get mwa
 		nprintf (("allender", "couldn't find ship for arrival anchor -- using location ship created at"));
 		return -1;
 	}
@@ -7407,7 +7414,7 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 	anchor_pos = Objects[anchor_objnum].pos;
 
 	// if arriving from docking bay, then set ai mode and call function as per AL's instructions.
-	if ( location == ARRIVE_FROM_DOCK_BAY ) {
+	if ( location == ArrivalLocation::FROM_DOCK_BAY ) {
 		// if we get an error, just let the ship arrive(?)
 		if ( ai_acquire_emerge_path(&Objects[objnum], anchor_objnum, path_mask) == -1 ) {
 			// get MWA or AL -- not sure what to do here when we cannot acquire a path
@@ -7429,15 +7436,15 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 		// this ship should have.  Arriving near a ship we use a random normalized vector
 		// scaled by the distance given by the designer.  Arriving in front of a ship means
 		// entering the battle in the view cone.
-		if ( location == ARRIVE_NEAR_SHIP ) {
+		if ( location == ArrivalLocation::NEAR_SHIP ) {
 			// get a random vector -- use static randvec if in multiplayer
 			if ( Game_mode & GM_NORMAL )
 				vm_vec_rand_vec_quick(&rand_vec);
 			else
 				static_randvec( Objects[objnum].net_signature, &rand_vec );
-		} else if ( location == ARRIVE_IN_FRONT_OF_SHIP || location == ARRIVE_IN_BACK_OF_SHIP
-			     || location == ARRIVE_ABOVE_SHIP || location == ARRIVE_BELOW_SHIP
-			     || location == ARRIVE_TO_LEFT_OF_SHIP || location == ARRIVE_TO_RIGHT_OF_SHIP ) {
+		} else if ( location == ArrivalLocation::IN_FRONT_OF_SHIP || location == ArrivalLocation::IN_BACK_OF_SHIP
+			     || location == ArrivalLocation::ABOVE_SHIP || location == ArrivalLocation::BELOW_SHIP
+			     || location == ArrivalLocation::TO_LEFT_OF_SHIP || location == ArrivalLocation::TO_RIGHT_OF_SHIP ) {
 			vec3d t1, t2, t3;
 			int r1, r2;
 			float x;
@@ -7465,14 +7472,14 @@ int mission_set_arrival_location(int anchor, int location, int dist, int objnum,
 			vm_vec_normalize(&rand_vec);
 
 			// vertical axis: rotate to up (around X axis)
-			if (location == ARRIVE_ABOVE_SHIP || location == ARRIVE_BELOW_SHIP)
+			if (location == ArrivalLocation::ABOVE_SHIP || location == ArrivalLocation::BELOW_SHIP)
 				vm_rot_point_around_line(&rand_vec, &rand_vec, PI_2, &vmd_zero_vector, &vmd_x_vector);
 			// lateral axis: rotate to right (backwards around Y axis)
-			else if (location == ARRIVE_TO_LEFT_OF_SHIP || location == ARRIVE_TO_RIGHT_OF_SHIP)
+			else if (location == ArrivalLocation::TO_LEFT_OF_SHIP || location == ArrivalLocation::TO_RIGHT_OF_SHIP)
 				vm_rot_point_around_line(&rand_vec, &rand_vec, -PI_2, &vmd_zero_vector, &vmd_y_vector);
 
 			// for the opposite directions, just flip the vector around
-			if (location == ARRIVE_IN_BACK_OF_SHIP || location == ARRIVE_BELOW_SHIP || location == ARRIVE_TO_LEFT_OF_SHIP)
+			if (location == ArrivalLocation::IN_BACK_OF_SHIP || location == ArrivalLocation::BELOW_SHIP || location == ArrivalLocation::TO_LEFT_OF_SHIP)
 				vm_vec_negate(&rand_vec);
 		} else {
 			UNREACHABLE("Unknown location type discovered when trying to parse %s -- Please let an SCP coder know!", Ships[shipnum].ship_name);
@@ -7583,7 +7590,7 @@ int mission_did_ship_arrive(p_object *objp, bool force_arrival)
 
 		// check to see if this ship is to arrive via a docking bay.  If so, and the ship to arrive from
 		// doesn't exist, don't create.
-		if ( objp->arrival_location == ARRIVE_FROM_DOCK_BAY ) {
+		if ( objp->arrival_location == ArrivalLocation::FROM_DOCK_BAY ) {
 			Assert( objp->arrival_anchor >= 0 );
 			auto anchor_ship_entry = ship_registry_get(Parse_names[objp->arrival_anchor]);
 
@@ -7923,7 +7930,8 @@ int mission_do_departure(object *objp, bool goal_is_to_warp)
 {
 	Assert(objp->type == OBJ_SHIP);
 	bool beginning_departure;
-	int location, anchor, path_mask;
+	DepartureLocation location;
+	int anchor, path_mask;
 	ship *shipp = &Ships[objp->instance];
 	ai_info *aip = &Ai_info[shipp->ai_index];
 
@@ -7988,7 +7996,7 @@ int mission_do_departure(object *objp, bool goal_is_to_warp)
 
 	// if departing to a docking bay, try to find the anchor ship to depart to.  If not found, then
 	// just make it warp out like anything else.
-	if (location == DEPART_AT_DOCK_BAY)
+	if (location == DepartureLocation::TO_DOCK_BAY)
 	{
 		Assert(anchor >= 0);
 		auto anchor_ship_entry = ship_registry_get(Parse_names[anchor]);
@@ -8088,7 +8096,7 @@ void mission_eval_departures()
 			// AL 12-30-97: Added SF_CANNOT_WARP to check
 			// Goober5000 - fixed so that it WILL eval when SF_CANNOT_WARP if departing to dockbay
 			// wookieejedi - fixed so it accounts for break and never warp too
-			if ( shipp->is_dying_or_departing() || ( !(ship_can_warp_full_check(shipp)) && (shipp->departure_location != DEPART_AT_DOCK_BAY)) || ship_subsys_disrupted(shipp, SUBSYSTEM_ENGINE) ) {
+			if ( shipp->is_dying_or_departing() || ( !(ship_can_warp_full_check(shipp)) && (shipp->departure_location != DepartureLocation::TO_DOCK_BAY)) || ship_subsys_disrupted(shipp, SUBSYSTEM_ENGINE) ) {
 				continue;
 			}
 
@@ -8939,8 +8947,8 @@ bool check_for_24_1_data()
 {
 	for (int wingnum = 0; wingnum < Num_wings; wingnum++)
 	{
-		if (Wings[wingnum].arrival_location == ARRIVE_IN_BACK_OF_SHIP || Wings[wingnum].arrival_location == ARRIVE_ABOVE_SHIP || Wings[wingnum].arrival_location == ARRIVE_BELOW_SHIP
-			|| Wings[wingnum].arrival_location == ARRIVE_TO_LEFT_OF_SHIP || Wings[wingnum].arrival_location == ARRIVE_TO_RIGHT_OF_SHIP)
+		if (Wings[wingnum].arrival_location == ArrivalLocation::IN_BACK_OF_SHIP || Wings[wingnum].arrival_location == ArrivalLocation::ABOVE_SHIP || Wings[wingnum].arrival_location == ArrivalLocation::BELOW_SHIP
+			|| Wings[wingnum].arrival_location == ArrivalLocation::TO_LEFT_OF_SHIP || Wings[wingnum].arrival_location == ArrivalLocation::TO_RIGHT_OF_SHIP)
 			return true;
 	}
 
@@ -8948,8 +8956,8 @@ bool check_for_24_1_data()
 	{
 		auto shipp = &Ships[Objects[so->objnum].instance];
 
-		if (shipp->arrival_location == ARRIVE_IN_BACK_OF_SHIP || shipp->arrival_location == ARRIVE_ABOVE_SHIP || shipp->arrival_location == ARRIVE_BELOW_SHIP
-			|| shipp->arrival_location == ARRIVE_TO_LEFT_OF_SHIP || shipp->arrival_location == ARRIVE_TO_RIGHT_OF_SHIP)
+		if (shipp->arrival_location == ArrivalLocation::IN_BACK_OF_SHIP || shipp->arrival_location == ArrivalLocation::ABOVE_SHIP || shipp->arrival_location == ArrivalLocation::BELOW_SHIP
+			|| shipp->arrival_location == ArrivalLocation::TO_LEFT_OF_SHIP || shipp->arrival_location == ArrivalLocation::TO_RIGHT_OF_SHIP)
 			return true;
 	}
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -32,6 +32,8 @@
 
 struct wing;
 struct p_dock_instance;
+enum class ArrivalLocation;
+enum class DepartureLocation;
 
 #define NUM_NEBULAS			3				// how many background nebulas we have altogether
 #define NUM_NEBULA_COLORS	9
@@ -86,9 +88,9 @@ extern bool check_for_24_1_data();
 
 // Goober5000
 typedef struct support_ship_info {
-	int		arrival_location;				// arrival location
+	ArrivalLocation		arrival_location;				// arrival location
 	int		arrival_anchor;					// arrival anchor
-	int		departure_location;				// departure location
+	DepartureLocation	departure_location;				// departure location
 	int		departure_anchor;				// departure anchor
 	float	max_hull_repair_val;			// % of a ship's hull that can be repaired -C
 	float	max_subsys_repair_val;			// same thing, except for subsystems -C
@@ -218,24 +220,28 @@ typedef struct mission {
 extern mission The_mission;
 extern char Mission_filename[80];  // filename of mission in The_mission (Fred only)
 
-// defines for arrival locations.  These defines should match their counterparts in the arrival location
-// array
+// enums for arrival locations.  The integer values of these enums should match their counterparts in the arrival location array
 #define	MAX_ARRIVAL_NAMES				9
-#define	ARRIVE_AT_LOCATION			0
-#define	ARRIVE_NEAR_SHIP				1
-#define	ARRIVE_IN_FRONT_OF_SHIP		2
-#define	ARRIVE_IN_BACK_OF_SHIP		3
-#define ARRIVE_ABOVE_SHIP			4
-#define ARRIVE_BELOW_SHIP			5
-#define ARRIVE_TO_LEFT_OF_SHIP		6
-#define ARRIVE_TO_RIGHT_OF_SHIP		7
-#define	ARRIVE_FROM_DOCK_BAY			8
+enum class ArrivalLocation : int
+{
+	AT_LOCATION = 0,
+	NEAR_SHIP = 1,
+	IN_FRONT_OF_SHIP = 2,
+	IN_BACK_OF_SHIP = 3,
+	ABOVE_SHIP = 4,
+	BELOW_SHIP = 5,
+	TO_LEFT_OF_SHIP = 6,
+	TO_RIGHT_OF_SHIP = 7,
+	FROM_DOCK_BAY = 8
+};
 
-// defines for departure locations.  These defines should match their counterparts in the departure location
-// array
+// enums for departure locations.  The integer values of these enums should match their counterparts in the departure location array
 #define MAX_DEPARTURE_NAMES			2
-#define DEPART_AT_LOCATION				0
-#define DEPART_AT_DOCK_BAY				1
+enum class DepartureLocation : int
+{
+	AT_LOCATION = 0,
+	TO_DOCK_BAY = 1
+};
 
 #define	MAX_GOAL_TYPE_NAMES	3
 
@@ -356,14 +362,14 @@ public:
 	int	initial_hull = 100;
 	int	initial_shields = 100;
 
-	int	arrival_location = ARRIVE_AT_LOCATION;
+	ArrivalLocation arrival_location = ArrivalLocation::AT_LOCATION;
 	int	arrival_distance = 0;					// used when arrival location is near or in front of some ship
 	int	arrival_anchor = -1;						// ship used for anchoring an arrival point
 	int arrival_path_mask = 0;					// Goober5000
 	int	arrival_cue = -1;				//	Index in Sexp_nodes of this sexp.
 	int	arrival_delay = 0;
 
-	int	departure_location = DEPART_AT_LOCATION;
+	DepartureLocation departure_location = DepartureLocation::AT_LOCATION;
 	int	departure_anchor = -1;
 	int departure_path_mask = 0;				// Goober5000
 	int	departure_cue = -1;			//	Index in Sexp_nodes of this sexp.

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1111,7 +1111,7 @@ ADE_FUNC(createShip,
 		mission_log_add_entry(LOG_SHIP_ARRIVED, shipp->ship_name, nullptr, -1, show_in_log ? 0 : MLF_HIDDEN);
 
 		if (scripting::hooks::OnShipArrive->isActive()) {
-			scripting::hooks::OnShipArrive->run(scripting::hooks::ShipArriveConditions{ shipp, ARRIVE_AT_LOCATION, nullptr },
+			scripting::hooks::OnShipArrive->run(scripting::hooks::ShipArriveConditions{ shipp, ArrivalLocation::AT_LOCATION, nullptr },
 				scripting::hook_param_list(
 					scripting::hook_param("Ship", 'o', &Objects[obj_idx])
 				));

--- a/code/scripting/api/objs/parse_object.cpp
+++ b/code/scripting/api/objs/parse_object.cpp
@@ -422,7 +422,8 @@ ADE_VIRTVAR(Subsystems, l_ParseObject, nullptr, "Get the list of subsystems of t
 	return ade_set_args(L, "t", tbl);
 }
 
-static int parse_object_getset_location_helper(lua_State* L, int p_object::* field, const char* location_type, const char** location_names, size_t location_names_size)
+template <typename LOC>
+static int parse_object_getset_location_helper(lua_State* L, LOC p_object::* field, const char* location_type, const char** location_names, size_t location_names_size)
 {
 	parse_object_h* poh;
 	const char* s = nullptr;
@@ -440,10 +441,10 @@ static int parse_object_getset_location_helper(lua_State* L, int p_object::* fie
 			Warning(LOCATION, "%s location '%s' not found.", location_type, s);
 			return ADE_RETURN_NIL;
 		}
-		poh->getObject()->*field = location;
+		poh->getObject()->*field = static_cast<LOC>(location);
 	}
 
-	return ade_set_args(L, "s", location_names[poh->getObject()->*field]);
+	return ade_set_args(L, "s", location_names[static_cast<int>(poh->getObject()->*field)]);
 }
 
 ADE_VIRTVAR(ArrivalLocation, l_ParseObject, "string", "The ship's arrival location", "string", "Arrival location, or nil if handle is invalid")

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1169,7 +1169,8 @@ ADE_VIRTVAR(WaypointSpeedCap, l_Ship, "number", "Waypoint speed cap", "number", 
 	return ade_set_args(L, "i", aip->waypoint_speed_cap);
 }
 
-static int ship_getset_location_helper(lua_State* L, int ship::* field, const char* location_type, const char** location_names, size_t location_names_size)
+template <typename LOC>
+static int ship_getset_location_helper(lua_State* L, LOC ship::* field, const char* location_type, const char** location_names, size_t location_names_size)
 {
 	object_h* objh;
 	const char* s = nullptr;
@@ -1189,10 +1190,10 @@ static int ship_getset_location_helper(lua_State* L, int ship::* field, const ch
 			Warning(LOCATION, "%s location '%s' not found.", location_type, s);
 			return ADE_RETURN_NIL;
 		}
-		shipp->*field = location;
+		shipp->*field = static_cast<LOC>(location);
 	}
 
-	return ade_set_args(L, "s", location_names[shipp->*field]);
+	return ade_set_args(L, "s", location_names[static_cast<int>(shipp->*field)]);
 }
 
 ADE_VIRTVAR(ArrivalLocation, l_Ship, "string", "The ship's arrival location", "string", "Arrival location, or nil if handle is invalid")

--- a/code/scripting/api/objs/wing.cpp
+++ b/code/scripting/api/objs/wing.cpp
@@ -263,7 +263,8 @@ ADE_VIRTVAR(TotalVanished, l_Wing, nullptr, "Gets the number of ships that have 
 	return wing_getset_helper(L, &wing::total_vanished);
 }
 
-static int wing_getset_location_helper(lua_State* L, int wing::* field, const char* location_type, const char** location_names, size_t location_names_size)
+template <typename LOC>
+static int wing_getset_location_helper(lua_State* L, LOC wing::* field, const char* location_type, const char** location_names, size_t location_names_size)
 {
 	int wingnum;
 	const char* s = nullptr;
@@ -281,10 +282,10 @@ static int wing_getset_location_helper(lua_State* L, int wing::* field, const ch
 			Warning(LOCATION, "%s location '%s' not found.", location_type, s);
 			return ADE_RETURN_NIL;
 		}
-		Wings[wingnum].*field = location;
+		Wings[wingnum].*field = static_cast<LOC>(location);
 	}
 
-	return ade_set_args(L, "s", location_names[Wings[wingnum].*field]);
+	return ade_set_args(L, "s", location_names[static_cast<int>(Wings[wingnum].*field)]);
 }
 
 ADE_VIRTVAR(ArrivalLocation, l_Wing, "string", "The wing's arrival location", "string", "Arrival location, or nil if handle is invalid")

--- a/code/scripting/hook_conditions.h
+++ b/code/scripting/hook_conditions.h
@@ -6,6 +6,7 @@ class object;
 class ship;
 struct weapon;
 class ship_subsys;
+enum class ArrivalLocation;
 
 #define HOOK_DEFINE_CONDITIONS static const SCP_unordered_map<SCP_string, const std::unique_ptr<const ParseableCondition>> conditions
 
@@ -85,7 +86,7 @@ struct ObjectDeathConditions {
 struct ShipArriveConditions {
 	HOOK_DEFINE_CONDITIONS;
 	const ship* spawned_shipp;
-	int arrival_location; // As of yet unused
+	ArrivalLocation arrival_location; // As of yet unused
 	const object* spawn_anchor_objp; // As of yet unused
 };
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6687,14 +6687,14 @@ void ship::clear()
 
 	time_cargo_revealed = 0;
 
-	arrival_location = 0;
+	arrival_location = ArrivalLocation::AT_LOCATION;
 	arrival_distance = 0;
 	arrival_anchor = -1;
 	arrival_path_mask = 0;
 	arrival_cue = -1;
 	arrival_delay = 0;
 
-	departure_location = 0;
+	departure_location = DepartureLocation::AT_LOCATION;
 	departure_anchor = -1;
 	departure_path_mask = 0;
 	departure_cue = -1;
@@ -7056,14 +7056,14 @@ void wing::clear()
 	special_ship = 0;
 	special_ship_ship_info_index = -1;
 
-	arrival_location = ARRIVE_AT_LOCATION;
+	arrival_location = ArrivalLocation::AT_LOCATION;
 	arrival_distance = 0;
 	arrival_anchor = -1;
 	arrival_path_mask = 0;
 	arrival_cue = -1;
 	arrival_delay = 0;
 
-	departure_location = DEPART_AT_LOCATION;
+	departure_location = DepartureLocation::AT_LOCATION;
 	departure_anchor = -1;
 	departure_path_mask = 0;
 	departure_cue = -1;
@@ -16426,7 +16426,7 @@ bool ship_can_warp_full_check(ship* sp)
 bool ship_can_bay_depart(ship* sp)
 {
 	// if this ship belongs to a wing, then use the wing departure information
-	int departure_location;
+	DepartureLocation departure_location;
 	int departure_anchor;
 	int departure_path_mask;
 	if (sp->wingnum >= 0)
@@ -16441,7 +16441,7 @@ bool ship_can_bay_depart(ship* sp)
 		departure_path_mask = sp->departure_path_mask;
 	}
 	
-	if ( departure_location == DEPART_AT_DOCK_BAY )
+	if ( departure_location == DepartureLocation::TO_DOCK_BAY )
 	{
 		Assertion( departure_anchor >= 0, "Ship %s must have a valid departure anchor", sp->ship_name );
 		auto anchor_ship_entry = ship_registry_get(Parse_names[departure_anchor]);
@@ -18523,7 +18523,7 @@ int is_support_allowed(object *objp, bool do_simple_check)
 	if (!do_simple_check)
 	{
 		// make sure, if exiting from bay, that parent ship is in the mission!
-		if ((result == 0 || result == 2) && (The_mission.support_ships.arrival_location == ARRIVE_FROM_DOCK_BAY))
+		if ((result == 0 || result == 2) && (The_mission.support_ships.arrival_location == ArrivalLocation::FROM_DOCK_BAY))
 		{
 			Assert(The_mission.support_ships.arrival_anchor != -1);
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -618,14 +618,14 @@ public:
 	
 	fix	time_cargo_revealed;					// time at which the cargo was revealed
 
-	int	arrival_location;
+	ArrivalLocation arrival_location;
 	int	arrival_distance;		// how far away this ship should arrive
 	int	arrival_anchor;			// name of object this ship arrives near (or in front of)
 	int	arrival_path_mask;		// Goober5000 - possible restrictions on which bay paths to use
 	int	arrival_cue;
 	int	arrival_delay;
 
-	int	departure_location;		// depart to hyperspace or someplace else (like docking bay)
+	DepartureLocation departure_location;	// depart to hyperspace or someplace else (like docking bay)
 	int	departure_anchor;		// when docking bay -- index of ship to use
 	int departure_path_mask;	// Goober5000 - possible restrictions on which bay paths to use
 	int	departure_cue;			// sexpression to eval when departing
@@ -1587,14 +1587,14 @@ typedef struct wing {
 	int	special_ship;							// the leader of the wing.  An index into ship_index[].
 	int special_ship_ship_info_index;					// the ship info index of the special ship
 
-	int	arrival_location;						// arrival and departure information for wings -- similar to info for ships
+	ArrivalLocation arrival_location;			// arrival and departure information for wings -- similar to info for ships
 	int	arrival_distance;						// distance from some ship where this ship arrives
 	int	arrival_anchor;						// name of object this ship arrives near (or in front of)
 	int	arrival_path_mask;					// Goober5000 - possible restrictions on which bay paths to use
 	int	arrival_cue;
 	int	arrival_delay;
 
-	int	departure_location;
+	DepartureLocation departure_location;
 	int	departure_anchor;						// name of object that we depart to (in case of dock bays)
 	int departure_path_mask;				// Goober5000 - possible restrictions on which bay paths to use
 	int	departure_cue;

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -2628,7 +2628,7 @@ int CFREDView::global_error_check()
 				return -1;
 			}
 
-			if (Ships[i].arrival_location != ARRIVE_AT_LOCATION) {
+			if (Ships[i].arrival_location != ArrivalLocation::AT_LOCATION) {
 				if (Ships[i].arrival_anchor < 0){
 					if (error("Ship \"%s\" requires a valid arrival target", Ships[i].ship_name)){
 						return 1;
@@ -2636,7 +2636,7 @@ int CFREDView::global_error_check()
 				}
 			}
 
-			if (Ships[i].departure_location != DEPART_AT_LOCATION) {
+			if (Ships[i].departure_location != DepartureLocation::AT_LOCATION) {
 				if (Ships[i].departure_anchor < 0){
 					if (error("Ship \"%s\" requires a valid departure target", Ships[i].ship_name)){
 						return 1;
@@ -2833,13 +2833,13 @@ int CFREDView::global_error_check()
 				return -1;
 			}
 
-			if (Wings[i].arrival_location != ARRIVE_AT_LOCATION) {
+			if (Wings[i].arrival_location != ArrivalLocation::AT_LOCATION) {
 				if (Wings[i].arrival_anchor < 0)
 					if (error("Wing \"%s\" requires a valid arrival target", Wings[i].name))
 						return 1;
 			}
 
-			if (Wings[i].departure_location != DEPART_AT_LOCATION) {
+			if (Wings[i].departure_location != DepartureLocation::AT_LOCATION) {
 				if (Wings[i].departure_anchor < 0)
 					if (error("Wing \"%s\" requires a valid departure target", Wings[i].name))
 						return 1;

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3603,14 +3603,14 @@ int CFred_mission_save::save_objects()
 		save_common_object_data(&Objects[shipp->objnum], &Ships[i]);
 
 		if (shipp->wingnum >= 0) {
-			shipp->arrival_location = ARRIVE_AT_LOCATION;
+			shipp->arrival_location = ArrivalLocation::AT_LOCATION;
 		}
 
 		required_string_fred("$Arrival Location:");
 		parse_comments();
-		fout(" %s", Arrival_location_names[shipp->arrival_location]);
+		fout(" %s", Arrival_location_names[static_cast<int>(shipp->arrival_location)]);
 
-		if (shipp->arrival_location != ARRIVE_AT_LOCATION) {
+		if (shipp->arrival_location != ArrivalLocation::AT_LOCATION) {
 			if (optional_string_fred("+Arrival Distance:", "$Name:")) {
 				parse_comments();
 			} else {
@@ -3641,7 +3641,7 @@ int CFred_mission_save::save_objects()
 
 		// Goober5000
 		if (Mission_save_format != FSO_FORMAT_RETAIL) {
-			if ((shipp->arrival_location == ARRIVE_FROM_DOCK_BAY) && (shipp->arrival_path_mask > 0)) {
+			if ((shipp->arrival_location == ArrivalLocation::FROM_DOCK_BAY) && (shipp->arrival_path_mask > 0)) {
 				int anchor_shipnum;
 				polymodel *pm;
 
@@ -3676,14 +3676,14 @@ int CFred_mission_save::save_objects()
 		fout(" %s", sexp_out.c_str());
 
 		if (shipp->wingnum >= 0) {
-			shipp->departure_location = DEPART_AT_LOCATION;
+			shipp->departure_location = DepartureLocation::AT_LOCATION;
 		}
 
 		required_string_fred("$Departure Location:");
 		parse_comments();
-		fout(" %s", Departure_location_names[shipp->departure_location]);
+		fout(" %s", Departure_location_names[static_cast<int>(shipp->departure_location)]);
 
-		if (shipp->departure_location != DEPART_AT_LOCATION) {
+		if (shipp->departure_location != DepartureLocation::AT_LOCATION) {
 			required_string_fred("$Departure Anchor:");
 			parse_comments();
 
@@ -3695,7 +3695,7 @@ int CFred_mission_save::save_objects()
 
 		// Goober5000
 		if (Mission_save_format != FSO_FORMAT_RETAIL) {
-			if ((shipp->departure_location == DEPART_AT_DOCK_BAY) && (shipp->departure_path_mask > 0)) {
+			if ((shipp->departure_location == DepartureLocation::TO_DOCK_BAY) && (shipp->departure_path_mask > 0)) {
 				int anchor_shipnum;
 				polymodel *pm;
 
@@ -4959,9 +4959,9 @@ int CFred_mission_save::save_wings()
 
 		required_string_fred("$Arrival Location:");
 		parse_comments();
-		fout(" %s", Arrival_location_names[Wings[i].arrival_location]);
+		fout(" %s", Arrival_location_names[static_cast<int>(Wings[i].arrival_location)]);
 
-		if (Wings[i].arrival_location != ARRIVE_AT_LOCATION) {
+		if (Wings[i].arrival_location != ArrivalLocation::AT_LOCATION) {
 			if (optional_string_fred("+Arrival Distance:", "$Name:"))
 				parse_comments();
 			else
@@ -4990,7 +4990,7 @@ int CFred_mission_save::save_wings()
 
 		// Goober5000
 		if (Mission_save_format != FSO_FORMAT_RETAIL) {
-			if ((Wings[i].arrival_location == ARRIVE_FROM_DOCK_BAY) && (Wings[i].arrival_path_mask > 0)) {
+			if ((Wings[i].arrival_location == ArrivalLocation::FROM_DOCK_BAY) && (Wings[i].arrival_path_mask > 0)) {
 				int anchor_shipnum;
 				polymodel *pm;
 
@@ -5026,9 +5026,9 @@ int CFred_mission_save::save_wings()
 
 		required_string_fred("$Departure Location:");
 		parse_comments();
-		fout(" %s", Departure_location_names[Wings[i].departure_location]);
+		fout(" %s", Departure_location_names[static_cast<int>(Wings[i].departure_location)]);
 
-		if (Wings[i].departure_location != DEPART_AT_LOCATION) {
+		if (Wings[i].departure_location != DepartureLocation::AT_LOCATION) {
 			required_string_fred("$Departure Anchor:");
 			parse_comments();
 
@@ -5040,7 +5040,7 @@ int CFred_mission_save::save_wings()
 
 		// Goober5000
 		if (Mission_save_format != FSO_FORMAT_RETAIL) {
-			if ((Wings[i].departure_location == DEPART_AT_DOCK_BAY) && (Wings[i].departure_path_mask > 0)) {
+			if ((Wings[i].departure_location == DepartureLocation::TO_DOCK_BAY) && (Wings[i].departure_path_mask > 0)) {
 				int anchor_shipnum;
 				polymodel *pm;
 

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -559,21 +559,21 @@ void CShipEditorDlg::initialize_data(int full_update)
 								cue_init = 1;
 								a_cue = Ships[i].arrival_cue;
 								d_cue = Ships[i].departure_cue;
-								m_arrival_location = Ships[i].arrival_location;
+								m_arrival_location = static_cast<int>(Ships[i].arrival_location);
 								m_arrival_dist.init(Ships[i].arrival_distance);
 								m_arrival_target = Ships[i].arrival_anchor;
 								m_arrival_delay.init(Ships[i].arrival_delay);
-								m_departure_location = Ships[i].departure_location;
+								m_departure_location = static_cast<int>(Ships[i].departure_location);
 								m_departure_delay.init(Ships[i].departure_delay);
 								m_departure_target = Ships[i].departure_anchor;
 
 							} else {
 								cue_init++;
-								if (Ships[i].arrival_location != m_arrival_location){
+								if (static_cast<int>(Ships[i].arrival_location) != m_arrival_location){
 									m_arrival_location = -1;
 								}
 
-								if (Ships[i].departure_location != m_departure_location){
+								if (static_cast<int>(Ships[i].departure_location) != m_departure_location){
 									m_departure_location = -1;
 								}
 
@@ -785,7 +785,7 @@ void CShipEditorDlg::initialize_data(int full_update)
 
 	box = (CComboBox *) GetDlgItem(IDC_ARRIVAL_TARGET);
 	// must put the appropriate ships into the list depending on arrival location
-	if ( m_arrival_location != ARRIVE_FROM_DOCK_BAY ){
+	if ( m_arrival_location != static_cast<int>(ArrivalLocation::FROM_DOCK_BAY) ){
 		management_add_ships_to_combo( box, SHIPS_2_COMBO_SPECIAL | SHIPS_2_COMBO_ALL_SHIPS );
 	} else {
 		management_add_ships_to_combo( box, SHIPS_2_COMBO_DOCKING_BAY_ONLY );
@@ -815,7 +815,7 @@ void CShipEditorDlg::initialize_data(int full_update)
 
 	box = (CComboBox *)GetDlgItem(IDC_DEPARTURE_TARGET);
 	// must put the appropriate ships into the list depending on departure location
-	if ( m_departure_location == DEPART_AT_DOCK_BAY ){
+	if ( m_departure_location == static_cast<int>(DepartureLocation::TO_DOCK_BAY) ){
 		management_add_ships_to_combo( box, SHIPS_2_COMBO_DOCKING_BAY_ONLY );
 	} else {
 		box->ResetContent();
@@ -887,7 +887,7 @@ void CShipEditorDlg::initialize_data(int full_update)
 			GetDlgItem(IDC_ARRIVAL_DISTANCE)->EnableWindow(FALSE);
 			GetDlgItem(IDC_ARRIVAL_TARGET)->EnableWindow(FALSE);
 		}
-		if (m_arrival_location == ARRIVE_FROM_DOCK_BAY) {
+		if (m_arrival_location == static_cast<int>(ArrivalLocation::FROM_DOCK_BAY)) {
 			GetDlgItem(IDC_RESTRICT_ARRIVAL)->EnableWindow(enable);
 			GetDlgItem(IDC_CUSTOM_WARPIN_PARAMS)->EnableWindow(FALSE);
 		} else {
@@ -901,7 +901,7 @@ void CShipEditorDlg::initialize_data(int full_update)
 		} else {
 			GetDlgItem(IDC_DEPARTURE_TARGET)->EnableWindow(FALSE);
 		}
-		if (m_departure_location == DEPART_AT_DOCK_BAY) {
+		if (m_departure_location == static_cast<int>(DepartureLocation::TO_DOCK_BAY)) {
 			GetDlgItem(IDC_RESTRICT_DEPARTURE)->EnableWindow(enable);
 			GetDlgItem(IDC_CUSTOM_WARPOUT_PARAMS)->EnableWindow(FALSE);
 		} else {
@@ -1345,9 +1345,9 @@ int CShipEditorDlg::update_ship(int ship)
 	if (Ships[ship].wingnum < 0) {
 
 		if (m_arrival_location != -1)
-			MODIFY(Ships[ship].arrival_location, m_arrival_location);
+			MODIFY(Ships[ship].arrival_location, static_cast<ArrivalLocation>(m_arrival_location));
 		if (m_departure_location != -1)
-			MODIFY(Ships[ship].departure_location, m_departure_location);
+			MODIFY(Ships[ship].departure_location, static_cast<DepartureLocation>(m_departure_location));
 
 		if (!multi_edit || m_update_arrival) {  // should we update the arrival cue?
 			if (Ships[ship].arrival_cue >= 0)
@@ -1372,7 +1372,7 @@ int CShipEditorDlg::update_ship(int ship)
 
 			// if the arrival is not hyperspace or docking bay -- force arrival distance to be
 			// greater than 2*radius of target.
-			if (((m_arrival_location != ARRIVE_FROM_DOCK_BAY) && (m_arrival_location != ARRIVE_AT_LOCATION)) && (z >= 0) && !(z & SPECIAL_ARRIVAL_ANCHOR_FLAG)) {
+			if (((m_arrival_location != static_cast<int>(ArrivalLocation::FROM_DOCK_BAY)) && (m_arrival_location != static_cast<int>(ArrivalLocation::AT_LOCATION))) && (z >= 0) && !(z & SPECIAL_ARRIVAL_ANCHOR_FLAG)) {
 			d = int(std::min(500.0f, 2.0f * Objects[Ships[ship].objnum].radius));
 				if ((Ships[ship].arrival_distance < d) && (Ships[ship].arrival_distance > -d)) {
 					str.Format("Ship must arrive at least %d meters away from target.\n"
@@ -1986,7 +1986,7 @@ void CShipEditorDlg::OnSelchangeArrivalLocation()
 		}
 
 		// determine which items we should put into the arrival target combo box
-		if ( m_arrival_location == ARRIVE_FROM_DOCK_BAY ) {
+		if ( m_arrival_location == static_cast<int>(ArrivalLocation::FROM_DOCK_BAY) ) {
 			management_add_ships_to_combo( box, SHIPS_2_COMBO_DOCKING_BAY_ONLY );
 		} else {
 			management_add_ships_to_combo( box, SHIPS_2_COMBO_SPECIAL | SHIPS_2_COMBO_ALL_SHIPS );
@@ -1997,7 +1997,7 @@ void CShipEditorDlg::OnSelchangeArrivalLocation()
 		GetDlgItem(IDC_ARRIVAL_TARGET)->EnableWindow(FALSE);
 	}
 
-	if (m_arrival_location == ARRIVE_FROM_DOCK_BAY)	{
+	if (m_arrival_location == static_cast<int>(ArrivalLocation::FROM_DOCK_BAY))	{
 		GetDlgItem(IDC_RESTRICT_ARRIVAL)->EnableWindow(TRUE);
 		GetDlgItem(IDC_CUSTOM_WARPIN_PARAMS)->EnableWindow(FALSE);
 	} else {
@@ -2022,7 +2022,7 @@ void CShipEditorDlg::OnSelchangeDepartureLocation()
 
 		// we need to build up the list box content based on the departure type.  When
 		// from a docking bay, only show ships in the list which have them.  Show all ships otherwise
-		if ( m_departure_location == DEPART_AT_DOCK_BAY ) {
+		if ( m_departure_location == static_cast<int>(DepartureLocation::TO_DOCK_BAY) ) {
 			management_add_ships_to_combo( box, SHIPS_2_COMBO_DOCKING_BAY_ONLY );
 		} else {
 			// I think that this section is currently illegal
@@ -2033,7 +2033,7 @@ void CShipEditorDlg::OnSelchangeDepartureLocation()
 		box->EnableWindow(FALSE);
 	}
 
-	if (m_departure_location == DEPART_AT_DOCK_BAY)	{
+	if (m_departure_location == static_cast<int>(DepartureLocation::TO_DOCK_BAY))	{
 		GetDlgItem(IDC_RESTRICT_DEPARTURE)->EnableWindow(TRUE);
 		GetDlgItem(IDC_CUSTOM_WARPOUT_PARAMS)->EnableWindow(FALSE);
 	} else {
@@ -2432,7 +2432,7 @@ void CShipEditorDlg::OnRestrictArrival()
 	// grab stuff from GUI
 	UpdateData(TRUE);
 
-	if (m_arrival_location != ARRIVE_FROM_DOCK_BAY)
+	if (m_arrival_location != static_cast<int>(ArrivalLocation::FROM_DOCK_BAY))
 	{
 		Int3();
 		return;
@@ -2476,7 +2476,7 @@ void CShipEditorDlg::OnRestrictDeparture()
 	// grab stuff from GUI
 	UpdateData(TRUE);
 
-	if (m_departure_location != DEPART_AT_DOCK_BAY)
+	if (m_departure_location != static_cast<int>(DepartureLocation::TO_DOCK_BAY))
 	{
 		Int3();
 		return;

--- a/fred2/wing_editor.cpp
+++ b/fred2/wing_editor.cpp
@@ -359,8 +359,8 @@ void wing_editor::initialize_data_safe(int full_update)
 		if (m_formation_scale.Right(1) == CString("."))
 			m_formation_scale.Append("0");
 
-		m_arrival_location = Wings[cur_wing].arrival_location;
-		m_departure_location = Wings[cur_wing].departure_location;
+		m_arrival_location = static_cast<int>(Wings[cur_wing].arrival_location);
+		m_departure_location = static_cast<int>(Wings[cur_wing].departure_location);
 		m_arrival_delay = Wings[cur_wing].arrival_delay;
 		m_arrival_delay_min = Wings[cur_wing].wave_delay_min;
 		m_arrival_delay_max = Wings[cur_wing].wave_delay_max;
@@ -370,7 +370,7 @@ void wing_editor::initialize_data_safe(int full_update)
 		m_no_dynamic = (Wings[cur_wing].flags[Ship::Wing_Flags::No_dynamic])?1:0;
 
 		// Add the ships/special items to the combo box here before data is updated
-		if ( m_arrival_location == ARRIVE_FROM_DOCK_BAY ) {
+		if ( m_arrival_location == static_cast<int>(ArrivalLocation::FROM_DOCK_BAY) ) {
 			management_add_ships_to_combo( arrival_box, SHIPS_2_COMBO_DOCKING_BAY_ONLY );
 		} else {
 			management_add_ships_to_combo( arrival_box, SHIPS_2_COMBO_SPECIAL | SHIPS_2_COMBO_ALL_SHIPS );
@@ -398,7 +398,7 @@ void wing_editor::initialize_data_safe(int full_update)
 		}
 
 		// add the ships to the departure target combo box
-		if ( m_departure_location == DEPART_AT_DOCK_BAY ) {
+		if ( m_departure_location == static_cast<int>(DepartureLocation::TO_DOCK_BAY) ) {
 			management_add_ships_to_combo( departure_box, SHIPS_2_COMBO_DOCKING_BAY_ONLY );
 		} else {
 			departure_box->ResetContent();
@@ -474,7 +474,7 @@ void wing_editor::initialize_data_safe(int full_update)
 		GetDlgItem(IDC_ARRIVAL_DISTANCE)->EnableWindow(FALSE);
 		GetDlgItem(IDC_ARRIVAL_TARGET)->EnableWindow(FALSE);
 	}
-	if (m_arrival_location == ARRIVE_FROM_DOCK_BAY) {
+	if (m_arrival_location == static_cast<int>(ArrivalLocation::FROM_DOCK_BAY)) {
 		GetDlgItem(IDC_RESTRICT_ARRIVAL)->EnableWindow(enable);
 		GetDlgItem(IDC_CUSTOM_WARPIN_PARAMS)->EnableWindow(FALSE);
 	} else {
@@ -488,7 +488,7 @@ void wing_editor::initialize_data_safe(int full_update)
 	} else {
 		GetDlgItem(IDC_DEPARTURE_TARGET)->EnableWindow(FALSE);
 	}
-	if (m_departure_location == DEPART_AT_DOCK_BAY) {
+	if (m_departure_location == static_cast<int>(DepartureLocation::TO_DOCK_BAY)) {
 		GetDlgItem(IDC_RESTRICT_DEPARTURE)->EnableWindow(enable);
 		GetDlgItem(IDC_CUSTOM_WARPOUT_PARAMS)->EnableWindow(FALSE);
 	} else {
@@ -800,8 +800,8 @@ void wing_editor::update_data_safe()
 	MODIFY(Wings[cur_wing].formation, m_formation - 1);
 	MODIFY(Wings[cur_wing].formation_scale, (float)atof(m_formation_scale));
 
-	MODIFY(Wings[cur_wing].arrival_location, m_arrival_location);
-	MODIFY(Wings[cur_wing].departure_location, m_departure_location);
+	MODIFY(Wings[cur_wing].arrival_location, static_cast<ArrivalLocation>(m_arrival_location));
+	MODIFY(Wings[cur_wing].departure_location, static_cast<DepartureLocation>(m_departure_location));
 	MODIFY(Wings[cur_wing].arrival_delay, m_arrival_delay);
 	if (m_arrival_delay_min > m_arrival_delay_max) {
 		if (!bypass_errors) {
@@ -820,7 +820,7 @@ void wing_editor::update_data_safe()
 		MODIFY(Wings[cur_wing].arrival_anchor, i);
 
 		// when arriving near or in front of a ship, be sure that we are far enough away from it!!!
-		if (((m_arrival_location != ARRIVE_AT_LOCATION) && (m_arrival_location != ARRIVE_FROM_DOCK_BAY)) && (i >= 0) && !(i & SPECIAL_ARRIVAL_ANCHOR_FLAG)) {
+		if (((m_arrival_location != static_cast<int>(ArrivalLocation::AT_LOCATION)) && (m_arrival_location != static_cast<int>(ArrivalLocation::FROM_DOCK_BAY))) && (i >= 0) && !(i & SPECIAL_ARRIVAL_ANCHOR_FLAG)) {
 			d = int(std::min(500.0f, 2.0f * Objects[Ships[i].objnum].radius));
 			if ((Wings[cur_wing].arrival_distance < d) && (Wings[cur_wing].arrival_distance > -d)) {
 				if (!bypass_errors) {
@@ -1252,7 +1252,7 @@ void wing_editor::OnSelchangeArrivalLocation()
 		}
 
 		// determine which items we should put into the arrival target combo box
-		if ( m_arrival_location == ARRIVE_FROM_DOCK_BAY ) {
+		if ( m_arrival_location == static_cast<int>(ArrivalLocation::FROM_DOCK_BAY) ) {
 			management_add_ships_to_combo( box, SHIPS_2_COMBO_DOCKING_BAY_ONLY );
 		} else {
 			management_add_ships_to_combo( box, SHIPS_2_COMBO_SPECIAL | SHIPS_2_COMBO_ALL_SHIPS );
@@ -1263,7 +1263,7 @@ void wing_editor::OnSelchangeArrivalLocation()
 		GetDlgItem(IDC_ARRIVAL_TARGET)->EnableWindow(FALSE);
 	}
 
-	if (m_arrival_location == ARRIVE_FROM_DOCK_BAY)	{
+	if (m_arrival_location == static_cast<int>(ArrivalLocation::FROM_DOCK_BAY))	{
 		GetDlgItem(IDC_RESTRICT_ARRIVAL)->EnableWindow(TRUE);
 		GetDlgItem(IDC_CUSTOM_WARPIN_PARAMS)->EnableWindow(FALSE);
 	} else {
@@ -1287,7 +1287,7 @@ void wing_editor::OnSelchangeDepartureLocation()
 		}
 		// we need to build up the list box content based on the departure type.  When
 		// from a docking bay, only show ships in the list which have them.  Show all ships otherwise
-		if ( m_departure_location == DEPART_AT_DOCK_BAY ) {
+		if ( m_departure_location == static_cast<int>(DepartureLocation::TO_DOCK_BAY) ) {
 			management_add_ships_to_combo( box, SHIPS_2_COMBO_DOCKING_BAY_ONLY );
 		} else {
 			// I think that this section is currently illegal
@@ -1298,7 +1298,7 @@ void wing_editor::OnSelchangeDepartureLocation()
 		GetDlgItem(IDC_DEPARTURE_TARGET)->EnableWindow(FALSE);
 	}
 
-	if (m_departure_location == DEPART_AT_DOCK_BAY)	{
+	if (m_departure_location == static_cast<int>(DepartureLocation::TO_DOCK_BAY))	{
 		GetDlgItem(IDC_RESTRICT_DEPARTURE)->EnableWindow(TRUE);
 		GetDlgItem(IDC_CUSTOM_WARPOUT_PARAMS)->EnableWindow(FALSE);
 	} else {
@@ -1375,7 +1375,7 @@ void wing_editor::OnRestrictArrival()
 	// grab stuff from GUI
 	UpdateData(TRUE);
 
-	if (m_arrival_location != ARRIVE_FROM_DOCK_BAY)
+	if (m_arrival_location != static_cast<int>(ArrivalLocation::FROM_DOCK_BAY))
 	{
 		Int3();
 		return;
@@ -1410,7 +1410,7 @@ void wing_editor::OnRestrictDeparture()
 	// grab stuff from GUI
 	UpdateData(TRUE);
 
-	if (m_departure_location != DEPART_AT_DOCK_BAY)
+	if (m_departure_location != static_cast<int>(DepartureLocation::TO_DOCK_BAY))
 	{
 		Int3();
 		return;

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -2040,7 +2040,7 @@ int Editor::global_error_check_impl() {
 				return -1;
 			}
 
-			if (Ships[i].arrival_location != ARRIVE_AT_LOCATION) {
+			if (Ships[i].arrival_location != ArrivalLocation::AT_LOCATION) {
 				if (Ships[i].arrival_anchor < 0) {
 					if (error("Ship \"%s\" requires a valid arrival target", Ships[i].ship_name)) {
 						return 1;
@@ -2048,7 +2048,7 @@ int Editor::global_error_check_impl() {
 				}
 			}
 
-			if (Ships[i].departure_location != DEPART_AT_LOCATION) {
+			if (Ships[i].departure_location != DepartureLocation::AT_LOCATION) {
 				if (Ships[i].departure_anchor < 0) {
 					if (error("Ship \"%s\" requires a valid departure target", Ships[i].ship_name)) {
 						return 1;
@@ -2256,7 +2256,7 @@ int Editor::global_error_check_impl() {
 				return -1;
 			}
 
-			if (Wings[i].arrival_location != ARRIVE_AT_LOCATION) {
+			if (Wings[i].arrival_location != ArrivalLocation::AT_LOCATION) {
 				if (Wings[i].arrival_anchor < 0) {
 					if (error("Wing \"%s\" requires a valid arrival target", Wings[i].name)) {
 						return 1;
@@ -2264,7 +2264,7 @@ int Editor::global_error_check_impl() {
 				}
 			}
 
-			if (Wings[i].departure_location != DEPART_AT_LOCATION) {
+			if (Wings[i].departure_location != DepartureLocation::AT_LOCATION) {
 				if (Wings[i].departure_anchor < 0) {
 					if (error("Wing \"%s\" requires a valid departure target", Wings[i].name)) {
 						return 1;

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.cpp
@@ -220,22 +220,22 @@ namespace fso {
 											cue_init = 1;
 											_m_arrival_tree_formula = Ships[i].arrival_cue;
 											_m_departure_tree_formula = Ships[i].departure_cue;
-											_m_arrival_location = Ships[i].arrival_location;
+											_m_arrival_location = static_cast<int>(Ships[i].arrival_location);
 											_m_arrival_dist = Ships[i].arrival_distance;
 											_m_arrival_target = Ships[i].arrival_anchor;
 											_m_arrival_delay = Ships[i].arrival_delay;
-											_m_departure_location = Ships[i].departure_location;
+											_m_departure_location = static_cast<int>(Ships[i].departure_location);
 											_m_departure_delay = Ships[i].departure_delay;
 											_m_departure_target = Ships[i].departure_anchor;
 
 										}
 										else {
 											cue_init++;
-											if (Ships[i].arrival_location != _m_arrival_location) {
+											if (static_cast<int>(Ships[i].arrival_location) != _m_arrival_location) {
 												_m_arrival_location = -1;
 											}
 
-											if (Ships[i].departure_location != _m_departure_location) {
+											if (static_cast<int>(Ships[i].departure_location) != _m_departure_location) {
 												_m_departure_location = -1;
 											}
 
@@ -681,9 +681,9 @@ namespace fso {
 				if (Ships[ship].wingnum < 0) {
 
 					if (_m_arrival_location != -1)
-						Ships[ship].arrival_location = _m_arrival_location;
+						Ships[ship].arrival_location = static_cast<ArrivalLocation>(_m_arrival_location);
 					if (_m_departure_location != -1)
-						Ships[ship].departure_location = _m_departure_location;
+						Ships[ship].departure_location = static_cast<DepartureLocation>(_m_departure_location);
 
 					if (!multi_edit || _m_update_arrival) { // should we update the arrival cue?
 						if (Ships[ship].arrival_cue >= 0)
@@ -706,7 +706,7 @@ namespace fso {
 
 						// if the arrival is not hyperspace or docking bay -- force arrival distance to be
 						// greater than 2*radius of target.
-						if (((_m_arrival_location != ARRIVE_FROM_DOCK_BAY) && (_m_arrival_location != ARRIVE_AT_LOCATION)) &&
+						if (((_m_arrival_location != static_cast<int>(ArrivalLocation::FROM_DOCK_BAY)) && (_m_arrival_location != static_cast<int>(ArrivalLocation::AT_LOCATION))) &&
 							(_m_arrival_target >= 0) && !(_m_arrival_target & SPECIAL_ARRIVAL_ANCHOR_FLAG)) {
 							d = int(std::min(500.0f, 2.0f * Objects[Ships[ship].objnum].radius));
 							if ((Ships[ship].arrival_distance < d) && (Ships[ship].arrival_distance > -d)) {
@@ -1005,14 +1005,24 @@ namespace fso {
 				return _m_player_ship;
 			}
 
-			void ShipEditorDialogModel::setArrivalLocation(const int value)
+			void ShipEditorDialogModel::setArrivalLocationIndex(const int value)
 			{
 				modify(_m_arrival_location, value);
 			}
 
-			int ShipEditorDialogModel::getArrivalLocation() const
+			int ShipEditorDialogModel::getArrivalLocationIndex() const
 			{
 				return _m_arrival_location;
+			}
+
+			void ShipEditorDialogModel::setArrivalLocation(const ArrivalLocation value)
+			{
+				modify(_m_arrival_location, static_cast<int>(value));
+			}
+
+			ArrivalLocation ShipEditorDialogModel::getArrivalLocation() const
+			{
+				return static_cast<ArrivalLocation>(_m_arrival_location);
 			}
 
 			void ShipEditorDialogModel::setArrivalTarget(const int value)
@@ -1076,14 +1086,24 @@ namespace fso {
 				return _m_no_arrival_warp;
 			}
 
-			void ShipEditorDialogModel::setDepartureLocation(const int value)
+			void ShipEditorDialogModel::setDepartureLocationIndex(const int value)
 			{
 				modify(_m_departure_location, value);
 			}
 
-			int ShipEditorDialogModel::getDepartureLocation() const
+			int ShipEditorDialogModel::getDepartureLocationIndex() const
 			{
 				return _m_departure_location;
+			}
+
+			void ShipEditorDialogModel::setDepartureLocation(const DepartureLocation value)
+			{
+				modify(_m_departure_location, static_cast<int>(value));
+			}
+
+			DepartureLocation ShipEditorDialogModel::getDepartureLocation() const
+			{
+				return static_cast<DepartureLocation>(_m_departure_location);
 			}
 
 			void ShipEditorDialogModel::setDepartureTarget(const int value)

--- a/qtfred/src/mission/dialogs/ShipEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditorDialogModel.h
@@ -122,8 +122,10 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 	void setPlayer(const bool);
 	bool getPlayer() const;
 
-	void setArrivalLocation(const int);
-	int getArrivalLocation() const;
+	void setArrivalLocationIndex(const int);
+	int getArrivalLocationIndex() const;
+	void setArrivalLocation(const ArrivalLocation);
+	ArrivalLocation getArrivalLocation() const;
 
 	void setArrivalTarget(const int);
 	int getArrivalTarget() const;
@@ -143,8 +145,10 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 	void setNoArrivalWarp(const int);
 	int getNoArrivalWarp() const;
 
-	void setDepartureLocation(const int);
-	int getDepartureLocation() const;
+	void setDepartureLocationIndex(const int);
+	int getDepartureLocationIndex() const;
+	void setDepartureLocation(const DepartureLocation);
+	DepartureLocation getDepartureLocation() const;
 
 	void setDepartureTarget(const int);
 	int getDepartureTarget() const;

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3522,14 +3522,14 @@ int CFred_mission_save::save_objects()
 		save_common_object_data(&Objects[shipp->objnum], &Ships[i]);
 
 		if (shipp->wingnum >= 0) {
-			shipp->arrival_location = ARRIVE_AT_LOCATION;
+			shipp->arrival_location = ArrivalLocation::AT_LOCATION;
 		}
 
 		required_string_fred("$Arrival Location:");
 		parse_comments();
-		fout(" %s", Arrival_location_names[shipp->arrival_location]);
+		fout(" %s", Arrival_location_names[static_cast<int>(shipp->arrival_location)]);
 
-		if (shipp->arrival_location != ARRIVE_AT_LOCATION) {
+		if (shipp->arrival_location != ArrivalLocation::AT_LOCATION) {
 			if (optional_string_fred("+Arrival Distance:", "$Name:")) {
 				parse_comments();
 			} else {
@@ -3560,7 +3560,7 @@ int CFred_mission_save::save_objects()
 
 		// Goober5000
 		if (save_format != MissionFormat::RETAIL) {
-			if ((shipp->arrival_location == ARRIVE_FROM_DOCK_BAY) && (shipp->arrival_path_mask > 0)) {
+			if ((shipp->arrival_location == ArrivalLocation::FROM_DOCK_BAY) && (shipp->arrival_path_mask > 0)) {
 				int anchor_shipnum;
 				polymodel* pm;
 
@@ -3596,14 +3596,14 @@ int CFred_mission_save::save_objects()
 		fout(" %s", sexp_out.c_str());
 
 		if (shipp->wingnum >= 0) {
-			shipp->departure_location = DEPART_AT_LOCATION;
+			shipp->departure_location = DepartureLocation::AT_LOCATION;
 		}
 
 		required_string_fred("$Departure Location:");
 		parse_comments();
-		fout(" %s", Departure_location_names[shipp->departure_location]);
+		fout(" %s", Departure_location_names[static_cast<int>(shipp->departure_location)]);
 
-		if (shipp->departure_location != DEPART_AT_LOCATION) {
+		if (shipp->departure_location != DepartureLocation::AT_LOCATION) {
 			required_string_fred("$Departure Anchor:");
 			parse_comments();
 
@@ -3616,7 +3616,7 @@ int CFred_mission_save::save_objects()
 
 		// Goober5000
 		if (save_format != MissionFormat::RETAIL) {
-			if ((shipp->departure_location == DEPART_AT_DOCK_BAY) && (shipp->departure_path_mask > 0)) {
+			if ((shipp->departure_location == DepartureLocation::TO_DOCK_BAY) && (shipp->departure_path_mask > 0)) {
 				int anchor_shipnum;
 				polymodel* pm;
 
@@ -5121,9 +5121,9 @@ int CFred_mission_save::save_wings()
 
 		required_string_fred("$Arrival Location:");
 		parse_comments();
-		fout(" %s", Arrival_location_names[Wings[i].arrival_location]);
+		fout(" %s", Arrival_location_names[static_cast<int>(Wings[i].arrival_location)]);
 
-		if (Wings[i].arrival_location != ARRIVE_AT_LOCATION) {
+		if (Wings[i].arrival_location != ArrivalLocation::AT_LOCATION) {
 			if (optional_string_fred("+Arrival Distance:", "$Name:")) {
 				parse_comments();
 			} else {
@@ -5154,7 +5154,7 @@ int CFred_mission_save::save_wings()
 
 		// Goober5000
 		if (save_format != MissionFormat::RETAIL) {
-			if ((Wings[i].arrival_location == ARRIVE_FROM_DOCK_BAY) && (Wings[i].arrival_path_mask > 0)) {
+			if ((Wings[i].arrival_location == ArrivalLocation::FROM_DOCK_BAY) && (Wings[i].arrival_path_mask > 0)) {
 				int anchor_shipnum;
 				polymodel* pm;
 
@@ -5191,9 +5191,9 @@ int CFred_mission_save::save_wings()
 
 		required_string_fred("$Departure Location:");
 		parse_comments();
-		fout(" %s", Departure_location_names[Wings[i].departure_location]);
+		fout(" %s", Departure_location_names[static_cast<int>(Wings[i].departure_location)]);
 
-		if (Wings[i].departure_location != DEPART_AT_LOCATION) {
+		if (Wings[i].departure_location != DepartureLocation::AT_LOCATION) {
 			required_string_fred("$Departure Anchor:");
 			parse_comments();
 
@@ -5206,7 +5206,7 @@ int CFred_mission_save::save_wings()
 
 		// Goober5000
 		if (save_format != MissionFormat::RETAIL) {
-			if ((Wings[i].departure_location == DEPART_AT_DOCK_BAY) && (Wings[i].departure_path_mask > 0)) {
+			if ((Wings[i].departure_location == DepartureLocation::TO_DOCK_BAY) && (Wings[i].departure_path_mask > 0)) {
 				int anchor_shipnum;
 				polymodel* pm;
 

--- a/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditorDialog.cpp
@@ -358,7 +358,7 @@ void ShipEditorDialog::updateColumnTwo()
 void ShipEditorDialog::updateArrival()
 {
 	util::SignalBlockers blockers(this);
-	auto idx = _model->getArrivalLocation();
+	auto idx = _model->getArrivalLocationIndex();
 	int i;
 	ui->arrivalLocationCombo->clear();
 	for (i = 0; i < MAX_ARRIVAL_NAMES; i++) {
@@ -369,7 +369,7 @@ void ShipEditorDialog::updateArrival()
 	object* objp;
 	int restrict_to_players;
 	ui->arrivalTargetCombo->clear();
-	if (_model->getArrivalLocation() != ARRIVE_FROM_DOCK_BAY) {
+	if (_model->getArrivalLocation() != ArrivalLocation::FROM_DOCK_BAY) {
 		// Add Special Arrivals
 		for (restrict_to_players = 0; restrict_to_players < 2; restrict_to_players++) {
 			for (i = 0; i < (int)Iff_info.size(); i++) {
@@ -437,7 +437,7 @@ void ShipEditorDialog::updateArrival()
 void ShipEditorDialog::updateDeparture()
 {
 	util::SignalBlockers blockers(this);
-	auto idx = _model->getDepartureLocation();
+	auto idx = _model->getDepartureLocationIndex();
 	int i;
 	ui->departureLocationCombo->clear();
 	for (i = 0; i < MAX_DEPARTURE_NAMES; i++) {
@@ -512,14 +512,14 @@ void ShipEditorDialog::enableDisable()
 		ui->restrictDeparturePathsButton->setEnabled(false);
 	} else {
 		ui->arrivalLocationCombo->setEnabled(_model->getUIEnable());
-		if (_model->getArrivalLocation()) {
+		if (_model->getArrivalLocationIndex()) {
 			ui->arrivalDistanceEdit->setEnabled(_model->getUIEnable());
 			ui->arrivalTargetCombo->setEnabled(_model->getUIEnable());
 		} else {
 			ui->arrivalDistanceEdit->setEnabled(false);
 			ui->arrivalTargetCombo->setEnabled(false);
 		}
-		if (_model->getArrivalLocation() == ARRIVE_FROM_DOCK_BAY) {
+		if (_model->getArrivalLocation() == ArrivalLocation::FROM_DOCK_BAY) {
 			ui->restrictArrivalPathsButton->setEnabled(_model->getUIEnable());
 			ui->customWarpinButton->setEnabled(false);
 		} else {
@@ -528,12 +528,12 @@ void ShipEditorDialog::enableDisable()
 		}
 
 		ui->departureLocationCombo->setEnabled(_model->getUIEnable());
-		if (_model->getDepartureLocation()) {
+		if (_model->getDepartureLocationIndex()) {
 			ui->departureTargetCombo->setEnabled(_model->getUIEnable());
 		} else {
 			ui->departureTargetCombo->setEnabled(false);
 		}
-		if (_model->getDepartureLocation() == DEPART_AT_DOCK_BAY) {
+		if (_model->getDepartureLocation() == DepartureLocation::TO_DOCK_BAY) {
 			ui->restrictDeparturePathsButton->setEnabled(_model->getUIEnable());
 			ui->customWarpoutButton->setEnabled(false);
 		} else {
@@ -734,7 +734,7 @@ void ShipEditorDialog::playerChanged(const bool enabled)
 void ShipEditorDialog::arrivalLocationChanged(const int index)
 {
 	auto arrivalLocationIdx = ui->arrivalLocationCombo->itemData(index).value<int>();
-	_model->setArrivalLocation(arrivalLocationIdx);
+	_model->setArrivalLocationIndex(arrivalLocationIdx);
 }
 
 void ShipEditorDialog::arrivalTargetChanged(const int index)
@@ -766,7 +766,7 @@ void ShipEditorDialog::ArrivalCueChanged(const bool value)
 void ShipEditorDialog::departureLocationChanged(const int index)
 {
 	auto depLocationIdx = ui->departureLocationCombo->itemData(index).value<int>();
-	_model->setDepartureLocation(depLocationIdx);
+	_model->setDepartureLocationIndex(depLocationIdx);
 }
 
 void ShipEditorDialog::departureTargetChanged(const int index)


### PR DESCRIPTION
To enforce type safety for arrival and departure locations, this converts them to enum classes.  Various casts are added when appropriate to convert between the indexed and enum values.