### PR TITLE
replace pointers with indexes in object_h

### DIFF
--- a/code/actions/types/MoveToSubmodel.cpp
+++ b/code/actions/types/MoveToSubmodel.cpp
@@ -26,7 +26,7 @@ ActionResult MoveToSubmodel::execute(ProgramLocals& locals) const
 	// The calling code should ensure that this never happens
 	Assertion(locals.hostSubobject >= 0, "Did not have a valid host subobject.");
 
-	auto instance = object_get_model_instance(locals.host.objp);
+	auto instance = object_get_model_instance(locals.host.objp());
 	Assertion(instance != -1, "Model instances are required if a host subobject is specified.");
 
 	auto pmi = model_get_instance(instance);

--- a/code/actions/types/ParticleEffectAction.cpp
+++ b/code/actions/types/ParticleEffectAction.cpp
@@ -37,7 +37,7 @@ ActionResult ParticleEffectAction::execute(ProgramLocals& locals) const
 	vec3d local_pos;
 	matrix local_orient;
 	if (locals.hostSubobject != -1) {
-		auto instance = object_get_model_instance(locals.host.objp);
+		auto instance = object_get_model_instance(locals.host.objp());
 		Assertion(instance != -1, "Model instances are required if a host subobject is specified.");
 
 		auto pmi = model_get_instance(instance);
@@ -59,7 +59,7 @@ ActionResult ParticleEffectAction::execute(ProgramLocals& locals) const
 
 	auto direction = locals.variables.getValue({"locals", "direction"}).getVector();
 
-	source.moveToObject(locals.host.objp, &local_pos);
+	source.moveToObject(locals.host.objp(), &local_pos);
 	source.setOrientationFromNormalizedVec(&direction, true);
 
 	source.finish();

--- a/code/actions/types/PlaySoundAction.cpp
+++ b/code/actions/types/PlaySoundAction.cpp
@@ -26,7 +26,7 @@ ActionResult PlaySoundAction::execute(ProgramLocals& locals) const
 	vec3d local_pos;
 	matrix local_orient;
 	if (locals.hostSubobject != -1) {
-		auto instance = object_get_model_instance(locals.host.objp);
+		auto instance = object_get_model_instance(locals.host.objp());
 		Assertion(instance != -1, "Model instances are required if a host subobject is specified.");
 
 		auto pmi = model_get_instance(instance);
@@ -47,8 +47,8 @@ ActionResult PlaySoundAction::execute(ProgramLocals& locals) const
 	local_pos += locals.variables.getValue({"locals", "position"}).getVector();
 
 	vec3d global_pos;
-	vm_vec_unrotate(&global_pos, &local_pos, &locals.host.objp->orient);
-	global_pos += locals.host.objp->pos;
+	vm_vec_unrotate(&global_pos, &local_pos, &locals.host.objp()->orient);
+	global_pos += locals.host.objp()->pos;
 
 	const auto soundId = gamesnd_get_by_name(m_soundIdExpression.execute(locals.variables).c_str());
 

--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -635,6 +635,6 @@ void do_random_sidethrust(ai_info *aip, ship_info *sip);
 void ai_formation_object_recalculate_slotnums(int form_objnum, int exiting_objnum = -1);
 
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, object** first_intersect_obj = nullptr);
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<int>&& excluded_object_ids = {}, float threshold = 10.0f, bool test_for_shields = false, bool test_for_hull = true, float* first_intersect_dist = nullptr, object** first_intersect_obj = nullptr);
 
 #endif

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6703,7 +6703,7 @@ bool check_los(int objnum, int target_objnum, float threshold, int primary_bank,
 	vec3d end = Objects[target_objnum].pos;
 
 	//Don't collision check against ourselves or our target
-	return test_line_of_sight(&start, &end, {&Objects[objnum], &Objects[target_objnum]}, threshold);
+	return test_line_of_sight(&start, &end, {objnum, target_objnum}, threshold);
 }
 
 //	--------------------------------------------------------------------------
@@ -16698,7 +16698,7 @@ void maybe_cheat_fire_synaptic(object *objp)
 	}
 }
 
-bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*>&& excluded_objects, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, object** first_intersect_obj) {
+bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<int>&& excluded_object_ids, float threshold, bool test_for_shields, bool test_for_hull, float* first_intersect_dist, object** first_intersect_obj) {
 	bool collides = false;
 
 	for (object* objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
@@ -16706,7 +16706,7 @@ bool test_line_of_sight(vec3d* from, vec3d* to, std::unordered_set<const object*
 			continue;
 
 		//Don't collision check against excluded objects
-		if (excluded_objects.count(objp) > 0)
+		if (excluded_object_ids.count(OBJ_INDEX(objp)) > 0)
 			continue;
 
 		int model_num = 0;

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -364,10 +364,7 @@ void camera::do_frame(float  /*in_frametime*/)
 
 object *camera::get_object_host()
 {
-	if(object_host.isValid())
-		return object_host.objp;
-	else
-		return NULL;
+	return object_host.objp_or_null();
 }
 
 int camera::get_object_host_submodel()
@@ -377,10 +374,7 @@ int camera::get_object_host_submodel()
 
 object *camera::get_object_target()
 {
-	if(object_target.isValid())
-		return object_target.objp;
-	else
-		return NULL;
+	return object_target.objp_or_null();
 }
 
 int camera::get_object_target_submodel()
@@ -424,7 +418,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 
 		if(object_host.isValid())
 		{
-			object *objp = object_host.objp;
+			object *objp = object_host.objp();
 			int model_num = object_get_model(objp);
 			polymodel *pm = nullptr;
 			polymodel_instance *pmi = nullptr;
@@ -438,8 +432,8 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 
 			if(object_host_submodel < 0 || pm == NULL)
 			{
-				vm_vec_unrotate(&c_pos, &pt, &object_host.objp->orient);
-				vm_vec_add2(&c_pos, &object_host.objp->pos);
+				vm_vec_unrotate(&c_pos, &pt, &object_host.objp()->orient);
+				vm_vec_add2(&c_pos, &object_host.objp()->pos);
 			}
 			else
 			{
@@ -488,7 +482,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 		{
 			if(object_target.isValid())
 			{
-				object *target_objp = object_target.objp;
+				object *target_objp = object_target.objp();
 				int model_num = object_get_model(target_objp);
 				polymodel *target_pm = nullptr;
 				polymodel_instance *target_pmi = nullptr;
@@ -525,7 +519,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 			{
 				if(eyep)
 				{
-					vm_vector_2_matrix(&c_ori, &host_normal, vm_vec_same(&host_normal, &object_host.objp->orient.vec.uvec)?NULL:&object_host.objp->orient.vec.uvec, NULL);
+					vm_vector_2_matrix(&c_ori, &host_normal, vm_vec_same(&host_normal, &object_host.objp()->orient.vec.uvec)?NULL:&object_host.objp()->orient.vec.uvec, NULL);
 					target_set = true;
 				}
 				else if (use_host_orient)
@@ -534,7 +528,7 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 				}
 				else
 				{
-					c_ori = object_host.objp->orient;
+					c_ori = object_host.objp()->orient;
 				}
 			}
 			else

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -224,13 +224,13 @@ struct Decal {
 		if (!object.isValid()) {
 			return false;
 		}
-		if (object.objp->flags[Object::Object_Flags::Should_be_dead]) {
+		if (object.objp()->flags[Object::Object_Flags::Should_be_dead]) {
 			return false;
 		}
 
-		if (orig_obj_type != object.objp->type) {
+		if (orig_obj_type != object.objp()->type) {
 			mprintf(("Decal object type for object %d has changed from %s to %s. Please let m!m know about this\n",
-			         OBJ_INDEX(object.objp), Object_type_names[orig_obj_type], Object_type_names[object.objp->type]));
+			         object.objnum, Object_type_names[orig_obj_type], Object_type_names[object.objp()->type]));
 			return false;
 		}
 
@@ -241,7 +241,7 @@ struct Decal {
 			}
 		}
 
-		auto objp = object.objp;
+		auto objp = object.objp();
 		if (objp->type == OBJ_SHIP) {
 			auto shipp = &Ships[objp->instance];
 			auto model_instance = model_get_instance(shipp->model_instance_num);
@@ -393,9 +393,9 @@ void initializeMission() {
 }
 
 matrix4 getDecalTransform(Decal& decal) {
-	Assertion(decal.object.objp->type == OBJ_SHIP, "Only ships are currently supported for decals!");
+	Assertion(decal.object.objp()->type == OBJ_SHIP, "Only ships are currently supported for decals!");
 
-	auto objp = decal.object.objp;
+	auto objp = decal.object.objp();
 	auto ship = &Ships[objp->instance];
 	auto pmi = model_get_instance(ship->model_instance_num);
 	auto pm = model_get(pmi->model_num);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -81,6 +81,44 @@ int Object_next_signature = 1;	//0 is bogus, start at 1
 int Object_inited = 0;
 int Show_waypoints = 0;
 
+object_h::object_h(int in_objnum)
+	: objnum(in_objnum)
+{
+	if (objnum >= 0 && objnum < MAX_OBJECTS)
+		sig = Objects[objnum].signature;
+	else
+		objnum = -1;
+}
+
+object_h::object_h(const object* in_objp)
+{
+	if (in_objp)
+	{
+		objnum = OBJ_INDEX(in_objp);
+		sig = in_objp->signature;
+	}
+}
+
+object_h::object_h()
+{}
+
+bool object_h::isValid() const
+{
+	// a signature of 0 is invalid, per obj_init()
+	if (objnum < 0 || sig <= 0 || objnum >= MAX_OBJECTS)
+		return false;
+	return Objects[objnum].signature == sig;
+}
+
+object* object_h::objp() const
+{
+	return &Objects[objnum];
+}
+
+object* object_h::objp_or_null() const
+{
+	return isValid() ? &Objects[objnum] : nullptr;
+}
 
 //WMC - Made these prettier
 const char *Object_type_names[MAX_OBJECT_TYPES] = {

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -179,26 +179,16 @@ extern object Objects[];
 
 struct object_h final	// prevent subclassing because classes which might use this should have their own isValid member function
 {
-	object *objp;
-	int sig;
+	int objnum = -1;
+	int sig = -1;
 
-	bool isValid() const {return (objp != nullptr && objp->signature == sig && sig > 0); }
-	object_h(object *in) {objp = in; sig = (in == nullptr) ? -1 : in->signature; }
-	object_h() { objp = nullptr; sig = -1; }
+	object_h(const object* in_objp);
+	object_h(int in_objnum);
+	object_h();
 
-	object_h(int objnum)
-	{
-		if (objnum >= 0 && objnum < MAX_OBJECTS)
-		{
-			objp = &Objects[objnum];
-			sig = objp->signature;
-		}
-		else
-		{
-			objp = nullptr;
-			sig = -1;
-		}
-	}
+	bool isValid() const;
+	object* objp() const;
+	object* objp_or_null() const;
 
 	static void serialize(lua_State* L, const scripting::ade_table_entry& tableEntry, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
 	static void deserialize(lua_State* L, const scripting::ade_table_entry& tableEntry, char* data_ptr, ubyte* data, int& offset);

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -77,7 +77,7 @@ class SourceOrigin {
 
 	inline SourceOriginType getType() const { return m_originType; }
 
-	inline object* getObjectHost() const { return m_origin.m_object.objp; }
+	inline object* getObjectHost() const { return m_origin.m_object.objp_or_null(); }
 
 	/**
 	 * @brief Determines if the origin is valid

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1061,7 +1061,7 @@ ADE_FUNC(drawTargetingBrackets, l_Graphics, "object Object, [boolean draw=true, 
 		return ADE_RETURN_NIL;
 	}
 
-	object *targetp = objh->objp;
+	object *targetp = objh->objp();
 
 	int x1,x2,y1,y2;
 	int bound_rc, pof;
@@ -1218,7 +1218,7 @@ ADE_FUNC(drawOffscreenIndicator, l_Graphics, "object Object, [boolean draw=true,
 		return ADE_RETURN_NIL;
 	}
 
-	object *targetp = objh->objp;
+	object *targetp = objh->objp();
 	bool in_frame = g3_in_frame() > 0;
 
 	if (!in_frame)
@@ -2171,8 +2171,8 @@ ADE_FUNC(createPersistentParticle,
 		pi.reverse = false;
 
 	if (objh != nullptr && objh->isValid()) {
-		pi.attached_objnum = OBJ_INDEX(objh->objp);
-		pi.attached_sig    = objh->objp->signature;
+		pi.attached_objnum = objh->objnum;
+		pi.attached_sig    = objh->sig;
 	}
 
 	particle::WeakParticlePtr p = particle::createPersistent(&pi);
@@ -2244,8 +2244,8 @@ ADE_FUNC(createParticle,
 		pi.reverse = false;
 
 	if (objh != nullptr && objh->isValid()) {
-		pi.attached_objnum = OBJ_INDEX(objh->objp);
-		pi.attached_sig    = objh->objp->signature;
+		pi.attached_objnum = objh->objnum;
+		pi.attached_sig    = objh->sig;
 	}
 
 	particle::create(&pi);

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -320,7 +320,7 @@ ADE_FUNC(getTargetDistance, l_HUD, "object targetee, [vector targeter_position]"
 		}
 	}
 
-	auto dist = hud_find_target_distance(targetee_h->objp, targeter_pos);
+	auto dist = hud_find_target_distance(targetee_h->objp(), targeter_pos);
 	return ade_set_args(L, "f", dist);
 }
 

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -928,7 +928,7 @@ ADE_FUNC(sendMessage,
 		if (ship_h == nullptr || !ship_h->isValid())
 			return ADE_RETURN_FALSE;
 
-		sender = &Ships[ship_h->objp->instance];
+		sender = &Ships[ship_h->objp()->instance];
 		messageSource = MESSAGE_SOURCE_SHIP;
 	}
 
@@ -1159,7 +1159,7 @@ ADE_FUNC(createDebris,
 		if (source_ship == nullptr || !source_ship->isValid())
 			return ade_set_args(L, "o", l_Debris.Set(object_h()));
 
-		source_shipp = &Ships[source_ship->objp->instance];
+		source_shipp = &Ships[source_ship->objp()->instance];
 		source_objnum = source_shipp->objnum;
 		source_class = source_shipp->ship_info_index;
 		model_num = Ship_info[source_class].model_num;
@@ -1304,7 +1304,7 @@ ADE_FUNC(createWeapon,
 		real_orient = orient->GetMatrix();
 	}
 
-	int parent_idx = (parent && parent->isValid()) ? OBJ_INDEX(parent->objp) : -1;
+	int parent_idx = (parent && parent->isValid()) ? parent->objnum : -1;
 
 	int obj_idx = weapon_create(&pos, real_orient, wclass, parent_idx, group);
 
@@ -1412,7 +1412,7 @@ ADE_FUNC(createExplosion,
 
 	int type = big ? FIREBALL_LARGE_EXPLOSION : FIREBALL_MEDIUM_EXPLOSION;
 
-	int parent_idx = (parent && parent->isValid()) ? OBJ_INDEX(parent->objp) : -1;
+	int parent_idx = (parent && parent->isValid()) ? parent->objnum : -1;
 
 	int obj_idx = fireball_create(&pos, fireballclass, type, parent_idx, radius, false, &velocity);
 
@@ -2296,7 +2296,7 @@ int testLineOfSight_internal(lua_State* L, bool returnDist_and_Obj) {
 		return ADE_RETURN_TRUE;
 	}
 
-	std::unordered_set<const object*> excludedObjectIDs;
+	std::unordered_set<int> excludedObjectIDs;
 
 	if (excludedObjects.isValid()) {
 		for (const auto& object : excludedObjects) {
@@ -2305,7 +2305,7 @@ int testLineOfSight_internal(lua_State* L, bool returnDist_and_Obj) {
 				try {
 					object_h obj;
 					object.second.getValue(l_Object.Get(&obj));
-					excludedObjectIDs.emplace(obj.objp);
+					excludedObjectIDs.emplace(obj.objnum);
 				}
 				catch (const luacpp::LuaException& /*e*/) {
 					// We were likely fed a userdata that was not an object. 

--- a/code/scripting/api/libs/testing.cpp
+++ b/code/scripting/api/libs/testing.cpp
@@ -179,8 +179,8 @@ ADE_FUNC_DEPRECATED(createParticle,
 
 	if(objh != NULL && objh->isValid())
 	{
-		pi.attached_objnum = OBJ_INDEX(objh->objp);
-		pi.attached_sig = objh->objp->signature;
+		pi.attached_objnum = objh->objnum;
+		pi.attached_sig = objh->sig;
 	}
 
 	particle::WeakParticlePtr p = particle::createPersistent(&pi);

--- a/code/scripting/api/objs/ai_helper.cpp
+++ b/code/scripting/api/objs/ai_helper.cpp
@@ -89,7 +89,7 @@ ADE_FUNC(turnTowardsPoint,
 		return ADE_RETURN_NIL;
 	}
 
-	ai_turn_towards_vector(target, ship.objp, nullptr, nullptr, bank, (diffTurn ? 0 : AITTV_FAST) | (argnum >= 5 ? AITTV_FORCE_DELTA_BANK : 0), nullptr, modifier);
+	ai_turn_towards_vector(target, ship.objp(), nullptr, nullptr, bank, (diffTurn ? 0 : AITTV_FAST) | (argnum >= 5 ? AITTV_FORCE_DELTA_BANK : 0), nullptr, modifier);
 	return ADE_RETURN_NIL;
 }
 
@@ -111,9 +111,9 @@ ADE_FUNC(turnTowardsOrientation,
 	}
 
 	matrix* mat = target->GetMatrix();
-	vec3d targetVec = mat->vec.fvec + ship.objp->pos;
+	vec3d targetVec = mat->vec.fvec + ship.objp()->pos;
 
-	ai_turn_towards_vector(&targetVec, ship.objp, nullptr, nullptr, 0.0f, (diffTurn ? 0 : AITTV_FAST), &mat->vec.rvec, modifier);
+	ai_turn_towards_vector(&targetVec, ship.objp(), nullptr, nullptr, 0.0f, (diffTurn ? 0 : AITTV_FAST), &mat->vec.rvec, modifier);
 	return ADE_RETURN_NIL;
 }
 

--- a/code/scripting/api/objs/asteroid.cpp
+++ b/code/scripting/api/objs/asteroid.cpp
@@ -23,11 +23,11 @@ ADE_VIRTVAR(Target, l_Asteroid, "object", "Asteroid target object; may be object
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
-	asteroid *asp = &Asteroids[oh->objp->instance];
+	asteroid *asp = &Asteroids[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && th != NULL) {
 		if(th->isValid())
-			asp->target_objnum = OBJ_INDEX(th->objp);
+			asp->target_objnum = th->objnum;
 		else
 			asp->target_objnum = -1;
 	}
@@ -53,12 +53,12 @@ ADE_FUNC(kill, l_Asteroid, "[ship killer=nil, vector hitpos=nil]", "Kills the as
 		return ADE_RETURN_NIL;
 
 	if (!hitpos)
-		hitpos = &victim->objp->pos;
+		hitpos = &victim->objp()->pos;
 
 	if (killer)
-		asteroid_hit(victim->objp, killer->objp, hitpos, victim->objp->hull_strength + 1, nullptr);
+		asteroid_hit(victim->objp(), killer->objp(), hitpos, victim->objp()->hull_strength + 1, nullptr);
 	else
-		asteroid_hit(victim->objp, NULL,         hitpos, victim->objp->hull_strength + 1, nullptr);
+		asteroid_hit(victim->objp(), NULL,           hitpos, victim->objp()->hull_strength + 1, nullptr);
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/scripting/api/objs/beam.cpp
+++ b/code/scripting/api/objs/beam.cpp
@@ -31,7 +31,7 @@ ADE_VIRTVAR(Class, l_Beam, "weaponclass", "Weapon's class", "weaponclass", "Weap
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
-	beam *bp = &Beams[oh->objp->instance];
+	beam *bp = &Beams[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && nc > -1) {
 		bp->weapon_info_index = nc;
@@ -50,7 +50,7 @@ ADE_VIRTVAR(LastShot, l_Beam, "vector", "End point of the beam", "vector", "vect
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	beam *bp = &Beams[oh->objp->instance];
+	beam *bp = &Beams[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && vec3) {
 		bp->last_shot = *vec3;
@@ -69,7 +69,7 @@ ADE_VIRTVAR(LastStart, l_Beam, "vector", "Start point of the beam", "vector", "v
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
-	beam *bp = &Beams[oh->objp->instance];
+	beam *bp = &Beams[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && v3) {
 		bp->last_start = *v3;
@@ -89,8 +89,8 @@ ADE_VIRTVAR(Target, l_Beam, "object", "Target of beam. Value may also be a deriv
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
@@ -100,7 +100,7 @@ ADE_VIRTVAR(Target, l_Beam, "object", "Target of beam. Value may also be a deriv
 		{
 			if(bp->target_sig != newh->sig)
 			{
-				bp->target = newh->objp;
+				bp->target = newh->objp();
 				bp->target_sig = newh->sig;
 			}
 		}
@@ -125,8 +125,8 @@ ADE_VIRTVAR(TargetSubsystem, l_Beam, "subsystem", "Subsystem that beam is target
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
@@ -136,7 +136,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Beam, "subsystem", "Subsystem that beam is target
 		{
 			if(bp->target_sig != newh->objh.sig)
 			{
-				bp->target = newh->objh.objp;
+				bp->target = newh->objh.objp();
 				bp->target_subsys = newh->ss;
 				bp->target_sig = newh->objh.sig;
 			}
@@ -162,8 +162,8 @@ ADE_VIRTVAR(ParentShip, l_Beam, "object", "Parent of the beam.", "object", "Beam
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
@@ -173,7 +173,7 @@ ADE_VIRTVAR(ParentShip, l_Beam, "object", "Parent of the beam.", "object", "Beam
 		{
 			if(bp->sig != newh->sig)
 			{
-				bp->objp = newh->objp;
+				bp->objp = newh->objp();
 				bp->sig = newh->sig;
 			}
 		}
@@ -198,8 +198,8 @@ ADE_VIRTVAR(ParentSubsystem, l_Beam, "subsystem", "Subsystem that beam is fired 
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
@@ -209,7 +209,7 @@ ADE_VIRTVAR(ParentSubsystem, l_Beam, "subsystem", "Subsystem that beam is fired 
 		{
 			if(bp->sig != newh->objh.sig)
 			{
-				bp->objp = newh->objh.objp;
+				bp->objp = newh->objh.objp();
 				bp->subsys = newh->ss;
 			}
 		}
@@ -233,7 +233,7 @@ ADE_VIRTVAR(Team, l_Beam, "team", "Beam's team", "team", "Beam team, or invalid 
 	if (!oh->isValid())
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
-	beam* b = &Beams[oh->objp->instance];
+	beam* b = &Beams[oh->objp()->instance];
 
 	if (ADE_SETTING_VAR && nt >= 0 && nt < (int)Iff_info.size())
 		b->team = (char)nt;
@@ -248,8 +248,8 @@ ADE_FUNC(getCollisionCount, l_Beam, NULL, "Get the number of collisions in frame
 		return ADE_RETURN_NIL;
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ADE_RETURN_NIL;
 
@@ -269,8 +269,8 @@ ADE_FUNC(getCollisionPosition, l_Beam, "number", "Get the position of the define
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
@@ -292,8 +292,8 @@ ADE_FUNC(getCollisionInformation, l_Beam, "number", "Get the collision informati
 		return ade_set_error(L, "o", l_ColInfo.Set(mc_info_h()));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_ColInfo.Set(mc_info_h()));
 
@@ -314,8 +314,8 @@ ADE_FUNC(getCollisionObject, l_Beam, "number", "Get the target of the defined co
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
@@ -336,8 +336,8 @@ ADE_FUNC(isExitCollision, l_Beam, "number", "Checks if the defined collision was
 		return ADE_RETURN_NIL;
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ADE_RETURN_NIL;
 
@@ -355,8 +355,8 @@ ADE_FUNC(getStartDirectionInfo, l_Beam, NULL, "Gets the start information about 
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
@@ -372,8 +372,8 @@ ADE_FUNC(getEndDirectionInfo, l_Beam, NULL, "Gets the end information about the 
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	beam *bp = NULL;
-	if(objh->objp->instance > -1)
-		bp = &Beams[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		bp = &Beams[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
@@ -391,7 +391,7 @@ ADE_FUNC(vanish, l_Beam, nullptr, "Vanishes this beam from the mission.", "boole
 	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
-	beam_delete(&Beams[objh->objp->instance]);
+	beam_delete(&Beams[objh->objp()->instance]);
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/scripting/api/objs/camera.cpp
+++ b/code/scripting/api/objs/camera.cpp
@@ -120,7 +120,7 @@ ADE_VIRTVAR(Self, l_Camera, "object", "New mount object", "object", "Camera obje
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	if(ADE_SETTING_VAR && oh && oh->isValid()) {
-		cid.getCamera()->set_object_host(oh->objp);
+		cid.getCamera()->set_object_host(oh->objp());
 	}
 
 	return ade_set_object_with_breed(L, OBJ_INDEX(cid.getCamera()->get_object_host()));
@@ -137,7 +137,7 @@ ADE_VIRTVAR(SelfSubsystem, l_Camera, "subsystem", "New mount object subsystem", 
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	if(ADE_SETTING_VAR && sso && sso->isValid()) {
-		cid.getCamera()->set_object_host(sso->objh.objp, sso->ss->system_info->subobj_num);
+		cid.getCamera()->set_object_host(sso->objh.objp(), sso->ss->system_info->subobj_num);
 	}
 
 	object *objp = cid.getCamera()->get_object_host();
@@ -175,7 +175,7 @@ ADE_VIRTVAR(Target, l_Camera, "object", "New target object", "object", "Camera t
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	if(ADE_SETTING_VAR && oh && oh->isValid()) {
-		cid.getCamera()->set_object_target(oh->objp);
+		cid.getCamera()->set_object_target(oh->objp());
 	}
 
 	return ade_set_object_with_breed(L, OBJ_INDEX(cid.getCamera()->get_object_target()));
@@ -192,7 +192,7 @@ ADE_VIRTVAR(TargetSubsystem, l_Camera, "subsystem", "New target subsystem", "sub
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	if(ADE_SETTING_VAR && sso && sso->isValid()) {
-		cid.getCamera()->set_object_target(sso->objh.objp, sso->ss->system_info->subobj_num);
+		cid.getCamera()->set_object_target(sso->objh.objp(), sso->ss->system_info->subobj_num);
 	}
 
 	object *objp = cid.getCamera()->get_object_target();

--- a/code/scripting/api/objs/debris.cpp
+++ b/code/scripting/api/objs/debris.cpp
@@ -25,7 +25,7 @@ ADE_VIRTVAR(IsHull, l_Debris, "boolean", "Whether or not debris is a piece of hu
 	if(!oh->isValid())
 		return ade_set_error(L, "b", false);
 
-	debris *db = &Debris[oh->objp->instance];
+	debris *db = &Debris[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR) {
 		db->is_hull = b;
@@ -45,7 +45,7 @@ ADE_VIRTVAR(OriginClass, l_Debris, "shipclass", "The shipclass of the ship this 
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Shipclass.Set(-1));
 
-	debris *db = &Debris[oh->objp->instance];
+	debris *db = &Debris[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR) {
 		if (shipIdx >= 0 && shipIdx < ship_info_size())
@@ -66,7 +66,7 @@ ADE_VIRTVAR(DoNotExpire, l_Debris, "boolean", "Whether the debris should expire.
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	debris *db = &Debris[objh->objp->instance];
+	debris *db = &Debris[objh->objp()->instance];
 
 	if (ADE_SETTING_VAR)
 	{
@@ -100,7 +100,7 @@ ADE_VIRTVAR(LifeLeft, l_Debris, "number", "The time this debris piece will last.
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	debris *db = &Debris[objh->objp->instance];
+	debris *db = &Debris[objh->objp()->instance];
 
 	if (ADE_SETTING_VAR)
 		db->lifeleft = lifeleft;
@@ -117,7 +117,7 @@ ADE_FUNC(getDebrisRadius, l_Debris, NULL, "The radius of this debris piece", "nu
 	if(!oh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
-	debris *db = &Debris[oh->objp->instance];
+	debris *db = &Debris[oh->objp()->instance];
 
 	polymodel *pm = model_get(db->model_num);
 
@@ -148,7 +148,7 @@ ADE_FUNC(isGeneric, l_Debris, nullptr, "Return if this debris is the generic deb
 	if (!oh->isValid())
 		return ADE_RETURN_FALSE;
 
-	debris *db = &Debris[oh->objp->instance];
+	debris *db = &Debris[oh->objp()->instance];
 
 	return ade_set_args(L, "b", debris_is_generic(db));
 }
@@ -162,7 +162,7 @@ ADE_FUNC(isVaporized, l_Debris, nullptr, "Return if this debris is the vaporized
 	if (!oh->isValid())
 		return ADE_RETURN_FALSE;
 
-	debris *db = &Debris[oh->objp->instance];
+	debris *db = &Debris[oh->objp()->instance];
 
 	return ade_set_args(L, "b", debris_is_vaporized(db));
 }
@@ -178,7 +178,7 @@ ADE_FUNC(vanish, l_Debris, nullptr, "Vanishes this piece of debris from the miss
 		return ade_set_error(L, "b", false);
 
 	//This skips all the fancy deathroll stuff, and just cleans it from the mission
-	oh->objp->flags.set(Object::Object_Flags::Should_be_dead);
+	oh->objp()->flags.set(Object::Object_Flags::Should_be_dead);
 
 	return ade_set_args(L, "b", true);
 }

--- a/code/scripting/api/objs/decaldefinition.cpp
+++ b/code/scripting/api/objs/decaldefinition.cpp
@@ -101,7 +101,7 @@ ADE_FUNC(create, l_DecalDefinitionclass, "number width, number height, number mi
 	else
 		info.lifetime = util::UniformFloatRange(minLifetime, maxLifetime);
 
-	decals::addDecal(info, objh->objp, smh->GetSubmodelIndex(), local_pos == nullptr ? vmd_zero_vector : *local_pos, local_orient == nullptr ? vmd_identity_matrix : *local_orient->GetMatrix());
+	decals::addDecal(info, objh->objp(), smh->GetSubmodelIndex(), local_pos == nullptr ? vmd_zero_vector : *local_pos, local_orient == nullptr ? vmd_identity_matrix : *local_orient->GetMatrix());
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/objs/fireball.cpp
+++ b/code/scripting/api/objs/fireball.cpp
@@ -23,10 +23,10 @@ ADE_VIRTVAR(Class, l_Fireball, "fireballclass", "Fireball's class", "fireballcla
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Fireballclass.Set(-1));
 
-	if (oh->objp->instance < 0 || oh->objp->instance >= static_cast<int>(Fireballs.size()))
+	if (oh->objp()->instance < 0 || oh->objp()->instance >= static_cast<int>(Fireballs.size()))
 		return ade_set_error(L, "o", l_Fireballclass.Set(-1));
 
-	fireball *fb = &Fireballs[oh->objp->instance];
+	fireball *fb = &Fireballs[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && nc > -1) {
 		fb->fireball_info_index = nc;
@@ -45,10 +45,10 @@ ADE_VIRTVAR(RenderType, l_Fireball, "enumeration", "Fireball's render type", "en
 	if (!oh->isValid())
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
-	if (oh->objp->instance < 0 || oh->objp->instance >= static_cast<int>(Fireballs.size()))
+	if (oh->objp()->instance < 0 || oh->objp()->instance >= static_cast<int>(Fireballs.size()))
 		return ade_set_error(L, "o", l_Enum.Set(enum_h()));
 
-	fireball* fb = &Fireballs[oh->objp->instance];
+	fireball* fb = &Fireballs[oh->objp()->instance];
 
 	if (ADE_SETTING_VAR && type.isValid()) {
 		int nt = -1;
@@ -93,10 +93,10 @@ ADE_VIRTVAR(TimeElapsed, l_Fireball, NULL, "Time this fireball exists in seconds
 	if(!oh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	if (oh->objp->instance < 0 || oh->objp->instance <= static_cast<int>(Fireballs.size())) 
+	if (oh->objp()->instance < 0 || oh->objp()->instance <= static_cast<int>(Fireballs.size())) 
 		return ade_set_error(L, "f", 0.0f);
 
-	fireball *fb = &Fireballs[oh->objp->instance];
+	fireball *fb = &Fireballs[oh->objp()->instance];
 
 	return ade_set_args(L, "f", fb->time_elapsed);
 }
@@ -111,10 +111,10 @@ ADE_VIRTVAR(TotalTime, l_Fireball, NULL, "Total lifetime of the fireball's anima
 	if (!oh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	if (oh->objp->instance < 0 || oh->objp->instance >= static_cast<int>(Fireballs.size()))
+	if (oh->objp()->instance < 0 || oh->objp()->instance >= static_cast<int>(Fireballs.size()))
 		return ade_set_error(L, "f", 0.0f);
 
-	fireball* fb = &Fireballs[oh->objp->instance];
+	fireball* fb = &Fireballs[oh->objp()->instance];
 
 	return ade_set_args(L, "f", fb->total_time);
 }
@@ -128,7 +128,7 @@ ADE_FUNC(isWarp, l_Fireball, NULL, "Checks if the fireball is a warp effect.", "
 	if(!oh->isValid())
 		return ADE_RETURN_FALSE;
 
-	if(fireball_is_warp(oh->objp))
+	if(fireball_is_warp(oh->objp()))
 		return ADE_RETURN_TRUE;
 
 	return ADE_RETURN_FALSE;
@@ -146,7 +146,7 @@ ADE_FUNC(vanish, l_Fireball, nullptr, "Vanishes this fireball from the mission."
 		return ade_set_error(L, "b", false);
 
 	//Should be sufficient for Fireballs, as the fireball internal functions also call this, for example to free up a fireball if the limit is reached
-	obj_delete(OBJ_INDEX(oh->objp));
+	obj_delete(oh->objnum);
 
 	return ade_set_args(L, "b", true);
 }

--- a/code/scripting/api/objs/model_path.cpp
+++ b/code/scripting/api/objs/model_path.cpp
@@ -47,7 +47,7 @@ ADE_VIRTVAR(Position, l_ModelPathPoint, "vector", "The current, global position 
 	}
 
 	// A submodel is only valid if the object is a ship so this is safe
-	auto objp  = p->parent->subsys.objh.objp;
+	auto objp  = p->parent->subsys.objh.objp();
 	auto shipp = &Ships[objp->instance];
 
 	auto pmi = model_get_instance(shipp->model_instance_num);

--- a/code/scripting/api/objs/particle.cpp
+++ b/code/scripting/api/objs/particle.cpp
@@ -189,7 +189,7 @@ ADE_VIRTVAR(AttachedObject, l_Particle, "object", "The object this particle is a
 	if (ADE_SETTING_VAR)
 	{
 		if (newObj != nullptr && newObj->isValid())
-			ph->Get().lock()->attached_objnum = newObj->objp->signature;
+			ph->Get().lock()->attached_objnum = newObj->sig;
 	}
 
 	return ade_set_object_with_breed(L, ph->Get().lock()->attached_objnum);

--- a/code/scripting/api/objs/physics_info.cpp
+++ b/code/scripting/api/objs/physics_info.cpp
@@ -7,23 +7,21 @@
 namespace scripting {
 namespace api {
 
-physics_info_h::physics_info_h() {
-	objh = object_h();
-	pi = NULL;
+physics_info_h::physics_info_h()
+	: objh(), pi(nullptr)
+{}
+physics_info_h::physics_info_h(object* objp)
+	: objh(objp), pi(nullptr)
+{
+	if (objh.isValid())
+		pi = &objh.objp()->phys_info;
 }
-physics_info_h::physics_info_h(object* objp) {
-	objh = object_h(objp);
-	pi = &objp->phys_info;
-}
-physics_info_h::physics_info_h(physics_info* in_pi) {
-	pi = in_pi;
-}
-bool physics_info_h::isValid() const {
-	if (objh.objp != NULL) {
-		return objh.isValid();
-	} else {
-		return (pi != NULL);
-	}
+physics_info_h::physics_info_h(physics_info* in_pi)
+	: objh(), pi(in_pi)
+{}
+bool physics_info_h::isValid() const
+{
+	return pi != nullptr && objh.isValid();
 }
 
 
@@ -297,7 +295,7 @@ ADE_VIRTVAR(Velocity, l_Physics, "vector", "Object world velocity (World vector)
 	if(ADE_SETTING_VAR && v3 != NULL) {
 		pih->pi->vel = *v3;
 		pih->pi->speed = vm_vec_mag(&pih->pi->vel);							
-		pih->pi->fspeed = vm_vec_dot(&pih->objh.objp->orient.vec.fvec, &pih->pi->vel);
+		pih->pi->fspeed = vm_vec_dot(&pih->objh.objp()->orient.vec.fvec, &pih->pi->vel);
 		if (Fix_scripted_velocity)
 			pih->pi->flags |= PF_SCRIPTED_VELOCITY; // set flag to ensure physics respects this new value
 	}
@@ -492,11 +490,11 @@ ADE_FUNC(applyWhack, l_Physics, "vector Impulse, [ vector Position]", "Applies a
 
 	objh = pih->objh;
 	if (offset == nullptr)
-		offset = &objh.objp->pos;
+		offset = &objh.objp()->pos;
 	else
-		vm_vec_add2(offset, &objh.objp->pos);
+		vm_vec_add2(offset, &objh.objp()->pos);
 
-	ship_apply_whack(impulse, offset, objh.objp);
+	ship_apply_whack(impulse, offset, objh.objp());
 
 	return ADE_RETURN_TRUE;
 
@@ -514,10 +512,10 @@ ADE_FUNC(applyWhackWorld, l_Physics, "vector Impulse, [ vector Position]", "Appl
 
 	objh = pih->objh;
 	if (!world_pos) {
-		world_pos = &objh.objp->pos;
+		world_pos = &objh.objp()->pos;
 	}
 
-	ship_apply_whack(impulse, world_pos, objh.objp);
+	ship_apply_whack(impulse, world_pos, objh.objp());
 
 	return ADE_RETURN_TRUE;
 

--- a/code/scripting/api/objs/shields.cpp
+++ b/code/scripting/api/objs/shields.cpp
@@ -19,7 +19,7 @@ ADE_FUNC(__len, l_Shields, NULL, "Number of shield segments", "number", "Number 
 	if(!objh->isValid())
 		return ade_set_error(L, "i", -1);
 
-	return ade_set_args(L, "i", objh->objp->n_quadrants);
+	return ade_set_args(L, "i", objh->objp()->n_quadrants);
 }
 
 ADE_INDEXER(l_Shields, "enumeration/number", "Gets or sets shield segment strength. Use \"SHIELD_*\" enumerations (for standard 4-quadrant shields) or index of a specific segment, or NONE for the entire shield", "number", "Segment/shield strength, or 0 if handle is invalid")
@@ -39,7 +39,7 @@ ADE_INDEXER(l_Shields, "enumeration/number", "Gets or sets shield segment streng
 		if(!objh->isValid())
 			return ade_set_error(L, "f", 0.0f);
 
-		objp = objh->objp;
+		objp = objh->objp();
 
 		//Which quadrant?
 		int qdi;
@@ -57,7 +57,7 @@ ADE_INDEXER(l_Shields, "enumeration/number", "Gets or sets shield segment streng
 		if(!objh->isValid())
 			return ade_set_error(L, "f", 0.0f);
 
-		objp = objh->objp;
+		objp = objh->objp();
 
 		switch(qd->index)
 		{
@@ -111,10 +111,10 @@ ADE_VIRTVAR(CombinedLeft, l_Shields, "number", "Total shield hitpoints left (for
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR && nval >= 0.0f) {
-		shield_set_strength(objh->objp, nval);
+		shield_set_strength(objh->objp(), nval);
 	}
 
-	return ade_set_args(L, "f", shield_get_strength(objh->objp));
+	return ade_set_args(L, "f", shield_get_strength(objh->objp()));
 }
 
 ADE_VIRTVAR(CombinedMax, l_Shields, "number", "Maximum shield hitpoints (for all segments combined)", "number", "Combined maximum shield strength, or 0 if handle is invalid")
@@ -128,10 +128,10 @@ ADE_VIRTVAR(CombinedMax, l_Shields, "number", "Maximum shield hitpoints (for all
 		return ade_set_error(L, "f", 0.0f);
 
 	if(ADE_SETTING_VAR && nval >= 0.0f) {
-		shield_set_max_strength(objh->objp, nval);
+		shield_set_max_strength(objh->objp(), nval);
 	}
 
-	return ade_set_args(L, "f", shield_get_max_strength(objh->objp));
+	return ade_set_args(L, "f", shield_get_max_strength(objh->objp()));
 }
 
 ADE_FUNC(isValid, l_Shields, NULL, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -57,7 +57,7 @@ ADE_INDEXER(l_Ship, "string/number NameOrIndex", "Array of ship subsystems", "su
 	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	ship_subsys *ss = ship_get_subsys(shipp, s);
 
 	if(ss == NULL)
@@ -73,7 +73,7 @@ ADE_INDEXER(l_Ship, "string/number NameOrIndex", "Array of ship subsystems", "su
 	if(ss == NULL)
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
-	return ade_set_args(L, "o", l_Subsystem.Set(ship_subsys_h(objh->objp, ss)));
+	return ade_set_args(L, "o", l_Subsystem.Set(ship_subsys_h(objh->objp(), ss)));
 }
 
 ADE_FUNC(__len, l_Ship, NULL, "Number of subsystems on ship", "number", "Subsystem number, or 0 if handle is invalid")
@@ -85,7 +85,7 @@ ADE_FUNC(__len, l_Ship, NULL, "Number of subsystems on ship", "number", "Subsyst
 	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
-	return ade_set_args(L, "i", ship_get_num_subsys(&Ships[objh->objp->instance]));
+	return ade_set_args(L, "i", ship_get_num_subsys(&Ships[objh->objp()->instance]));
 }
 
 ADE_FUNC(setFlag, l_Ship, "boolean set_it, string flag_name", "Sets or clears one or more flags - this function can accept an arbitrary number of flag arguments.  The flag names can be any string that the alter-ship-flag SEXP operator supports.", nullptr, "Returns nothing")
@@ -101,7 +101,7 @@ ADE_FUNC(setFlag, l_Ship, "boolean set_it, string flag_name", "Sets or clears on
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	auto shipp = &Ships[objh->objp->instance];
+	auto shipp = &Ships[objh->objp()->instance];
 	object_ship_wing_point_team oswpt(shipp);
 
 	do {
@@ -139,8 +139,8 @@ ADE_FUNC(getFlag, l_Ship, "string flag_name", "Checks whether one or more flags 
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	auto shipp = &Ships[objh->objp->instance];
-	auto objp = objh->objp;
+	auto objp = objh->objp();
+	auto shipp = &Ships[objp->instance];
 	auto aip = &Ai_info[shipp->ai_index];
 
 	do {
@@ -201,7 +201,7 @@ static int ship_getset_helper(lua_State* L, int ship::* field, bool canSet = fal
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 
 	if (ADE_SETTING_VAR)
 	{
@@ -229,7 +229,7 @@ ADE_VIRTVAR(ShieldArmorClass, l_Ship, "string", "Current Armor class of the ship
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	int atindex;
 	if (ADE_SETTING_VAR && s != nullptr) {
 		atindex = armor_type_get_idx(s);
@@ -258,7 +258,7 @@ ADE_VIRTVAR(ImpactDamageClass, l_Ship, "string", "Current Impact Damage class", 
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	int damage_index;
 
 	if (ADE_SETTING_VAR && s != nullptr) {
@@ -288,7 +288,7 @@ ADE_VIRTVAR(ArmorClass, l_Ship, "string", "Current Armor class", "string", "Armo
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	int atindex;
 	if (ADE_SETTING_VAR && s != nullptr) {
 		atindex = armor_type_get_idx(s);
@@ -315,7 +315,7 @@ ADE_VIRTVAR(Name, l_Ship, "string", "Ship name. This is the actual name of the s
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && s != nullptr) {
 		auto len = sizeof(shipp->ship_name);
@@ -336,7 +336,7 @@ ADE_VIRTVAR(DisplayName, l_Ship, "string", "Ship display name", "string", "The d
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && s != nullptr) {
 		shipp->display_name = s;
@@ -360,7 +360,7 @@ ADE_FUNC(isPlayer, l_Ship, nullptr, "Checks whether the ship is a player ship", 
 	// singleplayer
 	if (!(Game_mode & GM_MULTIPLAYER))
 	{
-		if (Player_obj == objh->objp)
+		if (Player_obj == objh->objp())
 			return ADE_RETURN_TRUE;
 		else
 			return ADE_RETURN_FALSE;
@@ -369,7 +369,7 @@ ADE_FUNC(isPlayer, l_Ship, nullptr, "Checks whether the ship is a player ship", 
 	else
 	{
 		// try and find the player
-		int np_index = multi_find_player_by_object(objh->objp);
+		int np_index = multi_find_player_by_object(objh->objp());
 		if ((np_index >= 0) && (np_index < MAX_PLAYERS))
 			return ADE_RETURN_TRUE;
 		else
@@ -387,7 +387,7 @@ ADE_VIRTVAR(AfterburnerFuelLeft, l_Ship, "number", "Afterburner fuel left", "num
 	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && fuel >= 0.0f)
 		shipp->afterburner_fuel = fuel;
@@ -405,7 +405,7 @@ ADE_VIRTVAR(AfterburnerFuelMax, l_Ship, "number", "Afterburner fuel capacity", "
 	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	ship_info *sip = &Ship_info[Ships[objh->objp->instance].ship_info_index];
+	ship_info *sip = &Ship_info[Ships[objh->objp()->instance].ship_info_index];
 
 	if(ADE_SETTING_VAR && fuel >= 0.0f)
 		sip->afterburner_fuel_capacity = fuel;
@@ -423,10 +423,10 @@ ADE_VIRTVAR(Class, l_Ship, "shipclass", "Ship class", "shipclass", "Ship class, 
 	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Shipclass.Set(-1));
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && idx > -1) {
-		change_ship_type(objh->objp->instance, idx, 1);
+		change_ship_type(objh->objp()->instance, idx, 1);
 		if (shipp == Player_ship) {
 			// update HUD and RTT cockpit gauges if applicable
 			set_current_hud();
@@ -451,7 +451,7 @@ ADE_VIRTVAR(CountermeasuresLeft, l_Ship, "number", "Number of countermeasures le
 	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && newcm > -1)
 		shipp->cmeasure_count = newcm;
@@ -474,7 +474,7 @@ ADE_VIRTVAR(CockpitDisplays, l_Ship, "displays", "An array of the cockpit displa
 		LuaError(L, "Attempted to use incomplete feature: Cockpit displays copy");
 	}
 
-	return ade_set_args(L, "o", l_CockpitDisplays.Set(cockpit_displays_h(OBJ_INDEX(objh->objp))));
+	return ade_set_args(L, "o", l_CockpitDisplays.Set(cockpit_displays_h(objh->objnum)));
 }
 
 ADE_VIRTVAR(CountermeasureClass, l_Ship, "weaponclass", "Weapon class mounted on this ship's countermeasure point", "weaponclass", "Countermeasure hardpoint weapon class, or invalid weaponclass handle if no countermeasure class or ship handle is invalid")
@@ -487,7 +487,7 @@ ADE_VIRTVAR(CountermeasureClass, l_Ship, "weaponclass", "Weapon class mounted on
 	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR) {
 		shipp->current_cmeasure = newcm;
@@ -509,7 +509,7 @@ ADE_VIRTVAR(HitpointsMax, l_Ship, "number", "Total hitpoints", "number", "Ship m
 	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && newhits > -1)
 		shipp->ship_max_hull_strength = newhits;
@@ -527,7 +527,7 @@ ADE_VIRTVAR(ShieldRegenRate, l_Ship, "number", "Maximum percentage/100 of shield
 	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if (ADE_SETTING_VAR && new_shield_regen > -1)
 		shipp->max_shield_regen_per_second = new_shield_regen;
@@ -545,7 +545,7 @@ ADE_VIRTVAR(WeaponRegenRate, l_Ship, "number", "Maximum percentage/100 of weapon
 	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if (ADE_SETTING_VAR && new_weapon_regen > -1)
 		shipp->max_weapon_regen_per_second = new_weapon_regen;
@@ -563,7 +563,7 @@ ADE_VIRTVAR(WeaponEnergyLeft, l_Ship, "number", "Current weapon energy reserves"
 	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && neweng > -1)
 		shipp->weapon_energy = neweng;
@@ -581,7 +581,7 @@ ADE_VIRTVAR(WeaponEnergyMax, l_Ship, "number", "Maximum weapon energy", "number"
 	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	ship_info *sip = &Ship_info[Ships[objh->objp->instance].ship_info_index];
+	ship_info *sip = &Ship_info[Ships[objh->objp()->instance].ship_info_index];
 
 	if(ADE_SETTING_VAR && neweng > -1)
 		sip->max_weapon_reserve = neweng;
@@ -599,7 +599,7 @@ ADE_VIRTVAR(AutoaimFOV, l_Ship, "number", "FOV of ship's autoaim, if any", "numb
 	if(!objh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && fov >= 0.0f) {
 		if (fov > 180.0)
@@ -621,7 +621,7 @@ ADE_VIRTVAR(PrimaryTriggerDown, l_Ship, "boolean", "Determines if primary trigge
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR)
 	{
@@ -647,10 +647,10 @@ ADE_VIRTVAR(PrimaryBanks, l_Ship, "weaponbanktype", "Array of primary weapon ban
 	if(!objh->isValid())
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
-	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
+	ship_weapon *dst = &Ships[objh->objp()->instance].weapons;
 
 	if(ADE_SETTING_VAR && swh && swh->isValid()) {
-		ship_weapon *src = &Ships[swh->objh.objp->instance].weapons;
+		ship_weapon *src = &Ships[swh->objh.objp()->instance].weapons;
 
 		dst->current_primary_bank = src->current_primary_bank;
 		dst->num_primary_banks = src->num_primary_banks;
@@ -665,7 +665,7 @@ ADE_VIRTVAR(PrimaryBanks, l_Ship, "weaponbanktype", "Array of primary weapon ban
 		memcpy(dst->primary_bank_weapons, src->primary_bank_weapons, sizeof(dst->primary_bank_weapons));
 	}
 
-	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(objh->objp, dst, SWH_PRIMARY)));
+	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(objh->objp(), dst, SWH_PRIMARY)));
 }
 
 ADE_VIRTVAR(SecondaryBanks, l_Ship, "weaponbanktype", "Array of secondary weapon banks", "weaponbanktype", "Secondary weapon banks, or invalid weaponbanktype handle if ship handle is invalid")
@@ -678,10 +678,10 @@ ADE_VIRTVAR(SecondaryBanks, l_Ship, "weaponbanktype", "Array of secondary weapon
 	if(!objh->isValid())
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
-	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
+	ship_weapon *dst = &Ships[objh->objp()->instance].weapons;
 
 	if(ADE_SETTING_VAR && swh && swh->isValid()) {
-		ship_weapon *src = &Ships[swh->objh.objp->instance].weapons;
+		ship_weapon *src = &Ships[swh->objh.objp()->instance].weapons;
 
 		dst->current_secondary_bank = src->current_secondary_bank;
 		dst->num_secondary_banks = src->num_secondary_banks;
@@ -697,7 +697,7 @@ ADE_VIRTVAR(SecondaryBanks, l_Ship, "weaponbanktype", "Array of secondary weapon
 		memcpy(dst->secondary_next_slot, src->secondary_next_slot, sizeof(dst->secondary_next_slot));
 	}
 
-	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(objh->objp, dst, SWH_SECONDARY)));
+	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(objh->objp(), dst, SWH_SECONDARY)));
 }
 
 ADE_VIRTVAR(TertiaryBanks, l_Ship, "weaponbanktype", "Array of tertiary weapon banks", "weaponbanktype", "Tertiary weapon banks, or invalid weaponbanktype handle if ship handle is invalid")
@@ -710,10 +710,10 @@ ADE_VIRTVAR(TertiaryBanks, l_Ship, "weaponbanktype", "Array of tertiary weapon b
 	if(!objh->isValid())
 		return ade_set_error(L, "o", l_WeaponBankType.Set(ship_banktype_h()));
 
-	ship_weapon *dst = &Ships[objh->objp->instance].weapons;
+	ship_weapon *dst = &Ships[objh->objp()->instance].weapons;
 
 	if(ADE_SETTING_VAR && swh && swh->isValid()) {
-		ship_weapon *src = &Ships[swh->objh.objp->instance].weapons;
+		ship_weapon *src = &Ships[swh->objh.objp()->instance].weapons;
 
 		dst->current_tertiary_bank = src->current_tertiary_bank;
 		dst->num_tertiary_banks = src->num_tertiary_banks;
@@ -725,7 +725,7 @@ ADE_VIRTVAR(TertiaryBanks, l_Ship, "weaponbanktype", "Array of tertiary weapon b
 		dst->tertiary_bank_start_ammo = src->tertiary_bank_start_ammo;
 	}
 
-	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(objh->objp, dst, SWH_TERTIARY)));
+	return ade_set_args(L, "o", l_WeaponBankType.Set(ship_banktype_h(objh->objp(), dst, SWH_TERTIARY)));
 }
 
 ADE_VIRTVAR(Target, l_Ship, "object", "Target of ship. Value may also be a deriviative of the 'object' class, such as 'ship'.", "object", "Target object, or invalid object handle if no target or ship handle is invalid")
@@ -740,21 +740,21 @@ ADE_VIRTVAR(Target, l_Ship, "object", "Target of ship. Value may also be a deriv
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	ai_info *aip = NULL;
-	if(Ships[objh->objp->instance].ai_index > -1)
-		aip = &Ai_info[Ships[objh->objp->instance].ai_index];
+	if(Ships[objh->objp()->instance].ai_index > -1)
+		aip = &Ai_info[Ships[objh->objp()->instance].ai_index];
 	else
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	if(ADE_SETTING_VAR && !(newh && aip->target_signature == newh->sig)) {
 		// we have a different target, or are clearng the target
 		if(newh && newh->isValid())	{
-			aip->target_objnum = OBJ_INDEX(newh->objp);
+			aip->target_objnum = newh->objnum;
 			aip->target_signature = newh->sig;
 			aip->target_time = 0.0f;
 			set_targeted_subsys(aip, nullptr, -1);
 
 			if (aip == Player_ai)
-				hud_shield_hit_reset(newh->objp);
+				hud_shield_hit_reset(newh->objp());
 		} else if (lua_isnil(L, 2)) {
 			aip->target_objnum = -1;
 			aip->target_signature = -1;
@@ -778,8 +778,8 @@ ADE_VIRTVAR(TargetSubsystem, l_Ship, "subsystem", "Target subsystem of ship.", "
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	ai_info *aip = NULL;
-	if(Ships[oh->objp->instance].ai_index > -1)
-		aip = &Ai_info[Ships[oh->objp->instance].ai_index];
+	if(Ships[oh->objp()->instance].ai_index > -1)
+		aip = &Ai_info[Ships[oh->objp()->instance].ai_index];
 	else
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
@@ -789,12 +789,12 @@ ADE_VIRTVAR(TargetSubsystem, l_Ship, "subsystem", "Target subsystem of ship.", "
 		{
 			if (aip == Player_ai) {
 				if (aip->target_signature != newh->objh.sig)
-					hud_shield_hit_reset(newh->objh.objp);
+					hud_shield_hit_reset(newh->objh.objp());
 
 				Ships[Objects[newh->ss->parent_objnum].instance].last_targeted_subobject[Player_num] = newh->ss;
 			}
 
-			aip->target_objnum = OBJ_INDEX(newh->objh.objp);
+			aip->target_objnum = newh->objh.objnum;
 			aip->target_signature = newh->objh.sig;
 			aip->target_time = 0.0f;
 			set_targeted_subsys(aip, newh->ss, aip->target_objnum);
@@ -822,7 +822,7 @@ ADE_VIRTVAR(Team, l_Ship, "team", "Ship's team", "team", "Ship team, or invalid 
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
-	ship *shipp = &Ships[oh->objp->instance];
+	ship *shipp = &Ships[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && nt > -1) {
 		shipp->team = nt;
@@ -841,7 +841,7 @@ ADE_VIRTVAR(PersonaIndex, l_Ship, "number", "Persona index", "number", "The inde
 	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR && p_index > 0)
 		shipp->persona_index = p_index - 1;
@@ -859,10 +859,10 @@ ADE_VIRTVAR(Textures, l_Ship, "modelinstancetextures", "Gets ship textures", "mo
 	if(!dh->isValid())
 		return ade_set_error(L, "o", l_ModelInstanceTextures.Set(modelinstance_h()));
 
-	polymodel_instance *dest = model_get_instance(Ships[dh->objp->instance].model_instance_num);
+	polymodel_instance *dest = model_get_instance(Ships[dh->objp()->instance].model_instance_num);
 
 	if(ADE_SETTING_VAR && sh && sh->isValid()) {
-		polymodel_instance *src = model_get_instance(Ships[sh->objp->instance].model_instance_num);
+		polymodel_instance *src = model_get_instance(Ships[sh->objp()->instance].model_instance_num);
 
 		if (src->texture_replace != nullptr)
 		{
@@ -884,7 +884,7 @@ ADE_VIRTVAR(FlagAffectedByGravity, l_Ship, "boolean", "Checks for the \"affected
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR)
 	{
@@ -908,7 +908,7 @@ ADE_VIRTVAR(Disabled, l_Ship, "boolean", "The disabled state of this ship", "boo
 	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR)
 	{
@@ -940,7 +940,7 @@ ADE_VIRTVAR(Stealthed, l_Ship, "boolean", "Stealth status of this ship", "boolea
 	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR)
 	{
@@ -964,7 +964,7 @@ ADE_VIRTVAR(HiddenFromSensors, l_Ship, "boolean", "Hidden from sensors status of
 	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR)
 	{
@@ -988,7 +988,7 @@ ADE_VIRTVAR(Gliding, l_Ship, "boolean", "Specifies whether this ship is currentl
 	if (!objh->isValid())
 		return ADE_RETURN_FALSE;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if(ADE_SETTING_VAR)
 	{
@@ -998,7 +998,7 @@ ADE_VIRTVAR(Gliding, l_Ship, "boolean", "Specifies whether this ship is currentl
 		}
 	}
 
-	if (objh->objp->phys_info.flags & PF_GLIDING || objh->objp->phys_info.flags & PF_FORCE_GLIDE)
+	if (objh->objp()->phys_info.flags & PF_GLIDING || objh->objp()->phys_info.flags & PF_FORCE_GLIDE)
 		return ADE_RETURN_TRUE;
 	else
 		return ADE_RETURN_FALSE;
@@ -1018,7 +1018,7 @@ ADE_VIRTVAR(EtsEngineIndex, l_Ship, "number", "(SET not implemented, see EtsSetI
 	if(ADE_SETTING_VAR)
 		LuaError(L, "Attempted to set incomplete feature: ETS Engine Index (see EtsSetIndexes)");
 
-	return ade_set_args(L, "i", Ships[objh->objp->instance].engine_recharge_index);
+	return ade_set_args(L, "i", Ships[objh->objp()->instance].engine_recharge_index);
 }
 
 ADE_VIRTVAR(EtsShieldIndex, l_Ship, "number", "(SET not implemented, see EtsSetIndexes)", "number", "Ships ETS Shield index value, 0 to MAX_ENERGY_INDEX")
@@ -1035,7 +1035,7 @@ ADE_VIRTVAR(EtsShieldIndex, l_Ship, "number", "(SET not implemented, see EtsSetI
 	if(ADE_SETTING_VAR)
 		LuaError(L, "Attempted to set incomplete feature: ETS Shield Index (see EtsSetIndexes)");
 
-	return ade_set_args(L, "i", Ships[objh->objp->instance].shield_recharge_index);
+	return ade_set_args(L, "i", Ships[objh->objp()->instance].shield_recharge_index);
 }
 
 ADE_VIRTVAR(EtsWeaponIndex, l_Ship, "number", "(SET not implemented, see EtsSetIndexes)", "number", "Ships ETS Weapon index value, 0 to MAX_ENERGY_INDEX")
@@ -1052,7 +1052,7 @@ ADE_VIRTVAR(EtsWeaponIndex, l_Ship, "number", "(SET not implemented, see EtsSetI
 	if(ADE_SETTING_VAR)
 		LuaError(L, "Attempted to set incomplete feature: ETS Weapon Index (see EtsSetIndexes)");
 
-	return ade_set_args(L, "i", Ships[objh->objp->instance].weapon_recharge_index);
+	return ade_set_args(L, "i", Ships[objh->objp()->instance].weapon_recharge_index);
 }
 
 ADE_VIRTVAR(Orders, l_Ship, "shiporders", "Array of ship orders", "shiporders", "Ship orders, or invalid handle if ship handle is invalid")
@@ -1070,7 +1070,7 @@ ADE_VIRTVAR(Orders, l_Ship, "shiporders", "Array of ship orders", "shiporders", 
 		LuaError(L, "Attempted to use incomplete feature: Ai orders copy. Use giveOrder instead");
 	}
 
-	return ade_set_args(L, "o", l_ShipOrders.Set(object_h(objh->objp)));
+	return ade_set_args(L, "o", l_ShipOrders.Set(object_h(objh->objp())));
 }
 
 ADE_VIRTVAR(WaypointSpeedCap, l_Ship, "number", "Waypoint speed cap", "number", "The limit on the ship's speed for traversing waypoints.  -1 indicates no speed cap.  0 will be returned if handle is invalid.")
@@ -1083,7 +1083,7 @@ ADE_VIRTVAR(WaypointSpeedCap, l_Ship, "number", "Waypoint speed cap", "number", 
 	if (!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 	ai_info* aip = &Ai_info[shipp->ai_index];
 
 	if (ADE_SETTING_VAR)
@@ -1108,7 +1108,7 @@ static int ship_getset_location_helper(lua_State* L, LOC ship::* field, const ch
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 
 	if (ADE_SETTING_VAR && s != nullptr)
 	{
@@ -1144,7 +1144,7 @@ static int ship_getset_anchor_helper(lua_State* L, int ship::* field)
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 
 	if (ADE_SETTING_VAR && s != nullptr)
 	{
@@ -1211,7 +1211,7 @@ ADE_FUNC(sendMessage,
 	if (ship_h == nullptr || !ship_h->isValid())
 		return ADE_RETURN_FALSE;
 
-	return sendMessage_sub(L, &Ships[ship_h->objp->instance], MESSAGE_SOURCE_SHIP, messageIdx, delay, ehp);
+	return sendMessage_sub(L, &Ships[ship_h->objp()->instance], MESSAGE_SOURCE_SHIP, messageIdx, delay, ehp);
 }
 
 ADE_FUNC(turnTowardsPoint,
@@ -1232,7 +1232,7 @@ ADE_FUNC(turnTowardsPoint,
 		return ADE_RETURN_NIL;
 	}
 
-	ai_turn_towards_vector(target, shiph.objp, nullptr, nullptr, bank, (diffTurn ? 0 : AITTV_FAST) | (argnum >= 5 ? AITTV_FORCE_DELTA_BANK : 0), nullptr, modifier);
+	ai_turn_towards_vector(target, shiph.objp(), nullptr, nullptr, bank, (diffTurn ? 0 : AITTV_FAST) | (argnum >= 5 ? AITTV_FORCE_DELTA_BANK : 0), nullptr, modifier);
 	return ADE_RETURN_NIL;
 }
 
@@ -1254,9 +1254,9 @@ ADE_FUNC(turnTowardsOrientation,
 	}
 
 	matrix* mat = target->GetMatrix();
-	vec3d targetVec = mat->vec.fvec + ship.objp->pos;
+	vec3d targetVec = mat->vec.fvec + ship.objp()->pos;
 
-	ai_turn_towards_vector(&targetVec, ship.objp, nullptr, nullptr, 0.0f, (diffTurn ? 0 : AITTV_FAST), &mat->vec.rvec, modifier);
+	ai_turn_towards_vector(&targetVec, ship.objp(), nullptr, nullptr, 0.0f, (diffTurn ? 0 : AITTV_FAST), &mat->vec.rvec, modifier);
 	return ADE_RETURN_NIL;
 }
 
@@ -1269,11 +1269,11 @@ ADE_FUNC(getCenterPosition, l_Ship, nullptr, "Returns the position of the ship's
 		return ADE_RETURN_NIL;
 
 	// find local center
-	ship_class_get_actual_center(&Ship_info[Ships[shiph->objp->instance].ship_info_index], &actual_local_center);
+	ship_class_get_actual_center(&Ship_info[Ships[shiph->objp()->instance].ship_info_index], &actual_local_center);
 
 	// find world position of the center
-	vm_vec_unrotate(&center_pos, &actual_local_center, &shiph->objp->orient);
-	vm_vec_add2(&center_pos, &shiph->objp->pos);
+	vm_vec_unrotate(&center_pos, &actual_local_center, &shiph->objp()->orient);
+	vm_vec_add2(&center_pos, &shiph->objp()->pos);
 
 	return ade_set_args(L, "o", l_Vector.Set(center_pos));
 }
@@ -1293,9 +1293,9 @@ ADE_FUNC(kill, l_Ship, "[object Killer, vector Hitpos]", "Kills the ship. Set \"
 
 	// use the current hull percentage for damage-after-death purposes
 	// (note that this does not actually affect scoring)
-	float percent_killed = get_hull_pct(victim->objp);
+	float percent_killed = get_hull_pct(victim->objp());
 
-	ship_hit_kill(victim->objp, killer ? killer->objp : nullptr, hitpos, percent_killed, (killer && victim->sig == killer->sig), true);
+	ship_hit_kill(victim->objp(), killer ? killer->objp() : nullptr, hitpos, percent_killed, (killer && victim->sig == killer->sig), true);
 
 	return ADE_RETURN_TRUE;
 }
@@ -1319,9 +1319,10 @@ ADE_FUNC(checkVisibility,
 
 	ship* viewer_shipp = nullptr;
 	ship* viewed_shipp = nullptr;
-	viewed_shipp = &Ships[v1->objp->instance];
+	viewed_shipp = &Ships[v1->objp()->instance];
 	if (v2)
-		viewer_shipp = &Ships[v2->objp->instance];
+		viewer_shipp = &Ships[v2->objp()->instance];
+
 	return ade_set_args(L, "i", ship_check_visibility(viewed_shipp, viewer_shipp));
 }
 
@@ -1341,7 +1342,7 @@ ADE_FUNC(addShipEffect, l_Ship, "string name, number durationMillis", "Activates
 	if (effect_num == -1)
 		return ade_set_error(L, "b", false);
 
-	ship* shipp = &Ships[shiph->objp->instance];
+	ship* shipp = &Ships[shiph->objp()->instance];
 
 	shipp->shader_effect_num = effect_num;
 	shipp->shader_effect_duration = duration;
@@ -1359,7 +1360,7 @@ ADE_FUNC(hasShipExploded, l_Ship, NULL, "Checks if the ship explosion event has 
 	if(!shiph->isValid())
 		return ade_set_error(L, "i", 0);
 
-	ship *shipp = &Ships[shiph->objp->instance];
+	ship *shipp = &Ships[shiph->objp()->instance];
 
 	if (shipp->flags[Ship::Ship_Flags::Dying]) {
 		if (shipp->final_death_time == 0) {
@@ -1383,7 +1384,7 @@ ADE_FUNC(isArrivingWarp, l_Ship, nullptr, "Checks if the ship is arriving via wa
 	if (!shiph->isValid())
 		return ade_set_error(L, "b", false);
 
-	ship *shipp = &Ships[shiph->objp->instance];
+	ship *shipp = &Ships[shiph->objp()->instance];
 
 	return ade_set_args(L, "b", shipp->is_arriving(ship::warpstage::BOTH, false));
 }
@@ -1397,7 +1398,7 @@ ADE_FUNC(isDepartingWarp, l_Ship, nullptr, "Checks if the ship is departing via 
 	if (!shiph->isValid())
 		return ade_set_error(L, "b", false);
 
-	ship *shipp = &Ships[shiph->objp->instance];
+	ship *shipp = &Ships[shiph->objp()->instance];
 
 	return ade_set_args(L, "b", shipp->flags[Ship::Ship_Flags::Depart_warp]);
 }
@@ -1411,7 +1412,7 @@ ADE_FUNC(isDepartingDockbay, l_Ship, nullptr, "Checks if the ship is departing v
 	if (!shiph->isValid())
 		return ade_set_error(L, "b", false);
 
-	ship *shipp = &Ships[shiph->objp->instance];
+	ship *shipp = &Ships[shiph->objp()->instance];
 
 	return ade_set_args(L, "b", shipp->flags[Ship::Ship_Flags::Depart_dockbay]);
 }
@@ -1425,7 +1426,7 @@ ADE_FUNC(isDying, l_Ship, nullptr, "Checks if the ship is dying (doing its death
 	if (!shiph->isValid())
 		return ade_set_error(L, "b", false);
 
-	ship *shipp = &Ships[shiph->objp->instance];
+	ship *shipp = &Ships[shiph->objp()->instance];
 
 	return ade_set_args(L, "b", shipp->flags[Ship::Ship_Flags::Dying]);
 }
@@ -1439,7 +1440,7 @@ ADE_FUNC(fireCountermeasure, l_Ship, NULL, "Launches a countermeasure from the s
 	if(!objh->isValid())
 		return ade_set_error(L, "b", false);
 
-	return ade_set_args(L, "b", ship_launch_countermeasure(objh->objp) != 0);
+	return ade_set_args(L, "b", ship_launch_countermeasure(objh->objp()) != 0);
 }
 
 ADE_FUNC(firePrimary, l_Ship, NULL, "Fires ship primary bank(s)", "number", "Number of primary banks fired")
@@ -1452,7 +1453,7 @@ ADE_FUNC(firePrimary, l_Ship, NULL, "Fires ship primary bank(s)", "number", "Num
 		return ade_set_error(L, "i", 0);
 
 	int i = 0;
-	i += ship_fire_primary(objh->objp);
+	i += ship_fire_primary(objh->objp());
 
 	return ade_set_args(L, "i", i);
 }
@@ -1466,7 +1467,7 @@ ADE_FUNC(fireSecondary, l_Ship, NULL, "Fires ship secondary bank(s)", "number", 
 	if(!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
-	return ade_set_args(L, "i", ship_fire_secondary(objh->objp, 0));
+	return ade_set_args(L, "i", ship_fire_secondary(objh->objp(), 0));
 }
 
 ADE_FUNC_DEPRECATED(getAnimationDoneTime, l_Ship, "number Type, number Subtype", "Gets time that animation will be done", "number", "Time (seconds), or 0 if ship handle is invalid",
@@ -1486,7 +1487,7 @@ ADE_FUNC_DEPRECATED(getAnimationDoneTime, l_Ship, "number Type, number Subtype",
 	if(type == animation::ModelAnimationTriggerType::None)
 		return ADE_RETURN_FALSE;
 
-	int time_ms = Ship_info[Ships[objh->objp->instance].ship_info_index].animations.getAll(model_get_instance(Ships[objh->objp->instance].model_instance_num), type, subtype).getTime();
+	int time_ms = Ship_info[Ships[objh->objp()->instance].ship_info_index].animations.getAll(model_get_instance(Ships[objh->objp()->instance].model_instance_num), type, subtype).getTime();
 	float time_s = (float)time_ms / 1000.0f;
 
 	return ade_set_args(L, "f", time_s);
@@ -1501,7 +1502,7 @@ ADE_FUNC(clearOrders, l_Ship, NULL, "Clears a ship's orders list", "boolean", "T
 		return ade_set_error(L, "b", false);
 
 	//The actual clearing of the goals
-	ai_clear_ship_goals( &Ai_info[Ships[objh->objp->instance].ai_index]);
+	ai_clear_ship_goals( &Ai_info[Ships[objh->objp()->instance].ai_index]);
 
 	return ADE_RETURN_TRUE;
 }
@@ -1539,35 +1540,35 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 			if(tgsh_valid)
 			{
 				ai_mode = AI_GOAL_DESTROY_SUBSYSTEM;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
-				ai_submode = ship_find_subsys( &Ships[tgsh->objh.objp->instance], tgsh->ss->system_info->subobj_name );
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
+				ai_submode = ship_find_subsys( &Ships[tgsh->objh.objp()->instance], tgsh->ss->system_info->subobj_name );
 			}
-			else if(tgh_valid && tgh->objp->type == OBJ_WEAPON)
+			else if(tgh_valid && tgh->objp()->type == OBJ_WEAPON)
 			{
 				ai_mode = AI_GOAL_CHASE_WEAPON;
-				ai_submode = tgh->objp->instance;
+				ai_submode = tgh->objp()->instance;
 			}
-			else if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			else if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = AI_GOAL_CHASE;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 				ai_submode = SM_ATTACK;
 			}
 			break;
 		}
 		case LE_ORDER_DOCK:
 		{
-			ai_shipname = Ships[tgh->objp->instance].ship_name;
+			ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			ai_mode = AI_GOAL_DOCK;
 			ai_submode = AIS_DOCK_0;
 			break;
 		}
 		case LE_ORDER_WAYPOINTS:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_WAYPOINT)
+			if(tgh_valid && tgh->objp()->type == OBJ_WAYPOINT)
 			{
 				ai_mode = AI_GOAL_WAYPOINTS;
-				waypoint_list *wp_list = find_waypoint_list_with_instance(tgh->objp->instance);
+				waypoint_list *wp_list = find_waypoint_list_with_instance(tgh->objp()->instance);
 				if(wp_list != NULL)
 					ai_shipname = wp_list->get_name();
 			}
@@ -1575,10 +1576,10 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		}
 		case LE_ORDER_WAYPOINTS_ONCE:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_WAYPOINT)
+			if(tgh_valid && tgh->objp()->type == OBJ_WAYPOINT)
 			{
 				ai_mode = AI_GOAL_WAYPOINTS_ONCE;
-				waypoint_list *wp_list = find_waypoint_list_with_instance(tgh->objp->instance);
+				waypoint_list *wp_list = find_waypoint_list_with_instance(tgh->objp()->instance);
 				if(wp_list != NULL)
 					ai_shipname = wp_list->get_name();
 			}
@@ -1592,10 +1593,10 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		}
 		case LE_ORDER_FORM_ON_WING:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = AI_GOAL_FORM_ON_WING;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 				ai_submode = 0;
 			}
 			break;
@@ -1605,41 +1606,41 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 			ai_mode = AI_GOAL_UNDOCK;
 			ai_submode = AIS_UNDOCK_0;
 
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			}
 			break;
 		}
 		case LE_ORDER_GUARD:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = AI_GOAL_GUARD;
 				ai_submode = AIS_GUARD_PATROL;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			}
 			break;
 		}
 		case LE_ORDER_DISABLE:
 		case LE_ORDER_DISABLE_TACTICAL:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = (eh->index == LE_ORDER_DISABLE) ? AI_GOAL_DISABLE_SHIP : AI_GOAL_DISABLE_SHIP_TACTICAL;
 				ai_submode = -SUBSYSTEM_ENGINE;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			}
 			break;
 		}
 		case LE_ORDER_DISARM:
 		case LE_ORDER_DISARM_TACTICAL:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = (eh->index == LE_ORDER_DISARM) ? AI_GOAL_DISARM_SHIP : AI_GOAL_DISARM_SHIP_TACTICAL;
 				ai_submode = -SUBSYSTEM_TURRET;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			}
 			break;
 		}
@@ -1652,49 +1653,49 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		case LE_ORDER_IGNORE:
 		case LE_ORDER_IGNORE_NEW:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = (eh->index == LE_ORDER_IGNORE) ? AI_GOAL_IGNORE : AI_GOAL_IGNORE_NEW;
 				ai_submode = 0;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			}
 			break;
 		}
 		case LE_ORDER_EVADE:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = AI_GOAL_EVADE_SHIP;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			}
 			break;
 		}
 		case LE_ORDER_STAY_NEAR:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = AI_GOAL_STAY_NEAR_SHIP;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 				ai_submode = -1;
 			}
 			break;
 		}
 		case LE_ORDER_KEEP_SAFE_DISTANCE:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = AI_GOAL_KEEP_SAFE_DISTANCE;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 				ai_submode = -1;
 			}
 			break;
 		}
 		case LE_ORDER_REARM:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = AI_GOAL_REARM_REPAIR;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 				ai_submode = 0;
 			}
 			break;
@@ -1702,9 +1703,9 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		case LE_ORDER_STAY_STILL:
 		{
 			ai_mode = AI_GOAL_STAY_STILL;
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 			}
 			break;
 		}
@@ -1720,19 +1721,19 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		}
 		case LE_ORDER_FLY_TO:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
 				ai_mode = AI_GOAL_FLY_TO_SHIP;
-				ai_shipname = Ships[tgh->objp->instance].ship_name;
+				ai_shipname = Ships[tgh->objp()->instance].ship_name;
 				ai_submode = 0;
 			}
 			break;
 		}
 		case LE_ORDER_ATTACK_WING:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
-				ship *shipp = &Ships[tgh->objp->instance];
+				ship *shipp = &Ships[tgh->objp()->instance];
 				if (shipp->wingnum != -1)
 				{
 					ai_mode = AI_GOAL_CHASE_WING;
@@ -1744,9 +1745,9 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		}
 		case LE_ORDER_GUARD_WING:
 		{
-			if(tgh_valid && tgh->objp->type == OBJ_SHIP)
+			if(tgh_valid && tgh->objp()->type == OBJ_SHIP)
 			{
-				ship *shipp = &Ships[tgh->objp->instance];
+				ship *shipp = &Ships[tgh->objp()->instance];
 				if (shipp->wingnum != -1)
 				{
 					ai_mode = AI_GOAL_GUARD_WING;
@@ -1775,7 +1776,7 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		return ade_set_error(L, "b", false);
 
 	//Fire off the goal
-	ai_add_ship_goal_scripting(ai_mode, ai_submode, (int)(priority*100.0f), ai_shipname, &Ai_info[Ships[objh->objp->instance].ai_index]);
+	ai_add_ship_goal_scripting(ai_mode, ai_submode, (int)(priority*100.0f), ai_shipname, &Ai_info[Ships[objh->objp()->instance].ai_index]);
 
 	return ADE_RETURN_TRUE;
 }
@@ -1795,7 +1796,7 @@ ADE_FUNC(doManeuver,
 	if(!ade_get_args(L, "oifffbfffb|i", l_Ship.GetPtr(&objh), &duration, &heading, &pitch, &bank, &apply_all_rotate, &up, &sideways, &forward, &apply_all_move, &maneuver_flags))
 		return ADE_RETURN_NIL;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	ai_info *aip = &Ai_info[shipp->ai_index];
 	control_info *cip = &aip->ai_override_ci;
 
@@ -1907,7 +1908,7 @@ ADE_FUNC_DEPRECATED(triggerAnimation, l_Ship, "string Type, [number Subtype, boo
 	if(type == animation::ModelAnimationTriggerType::None)
 		return ADE_RETURN_FALSE;
 
-	Ship_info[Ships[objh->objp->instance].ship_info_index].animations.getAll(model_get_instance(Ships[objh->objp->instance].model_instance_num), type, subtype).start(b ? animation::ModelAnimationDirection::FWD : animation::ModelAnimationDirection::RWD, instant, instant);
+	Ship_info[Ships[objh->objp()->instance].ship_info_index].animations.getAll(model_get_instance(Ships[objh->objp()->instance].model_instance_num), type, subtype).start(b ? animation::ModelAnimationDirection::FWD : animation::ModelAnimationDirection::RWD, instant, instant);
 
 	return ADE_RETURN_TRUE;
 }
@@ -1937,7 +1938,7 @@ ADE_FUNC(triggerSubmodelAnimation, l_Ship, "string type, string triggeredBy, [bo
 	if (animtype == animation::ModelAnimationTriggerType::None)
 		return ADE_RETURN_FALSE;
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 
 	return Ship_info[shipp->ship_info_index].animations.parseScripted(model_get_instance(shipp->model_instance_num), animtype, trigger).start(forwards ? animation::ModelAnimationDirection::FWD : animation::ModelAnimationDirection::RWD, forced || instant, instant, pause) ? ADE_RETURN_TRUE : ADE_RETURN_FALSE;
 }
@@ -1961,7 +1962,7 @@ ADE_FUNC(getSubmodelAnimation, l_Ship, "string type, string triggeredBy",
 	if (animtype == animation::ModelAnimationTriggerType::None)
 		return ade_set_args(L, "o", l_AnimationHandle.Set(animation::ModelAnimationSet::AnimationList{}));
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 
 	return ade_set_args(L, "o", l_AnimationHandle.Set(Ship_info[shipp->ship_info_index].animations.parseScripted(model_get_instance(shipp->model_instance_num), animtype, trigger)));
 }
@@ -1986,7 +1987,7 @@ ADE_FUNC(stopLoopingSubmodelAnimation, l_Ship, "string type, string triggeredBy"
 	if (animtype == animation::ModelAnimationTriggerType::None)
 		return ADE_RETURN_FALSE;
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 
 	Ship_info[shipp->ship_info_index].animations.parseScripted(model_get_instance(shipp->model_instance_num), animtype, trigger).setFlag(animation::Animation_Instance_Flags::Stop_after_next_loop);
 	return ADE_RETURN_TRUE;
@@ -2013,7 +2014,7 @@ ADE_FUNC(setAnimationSpeed, l_Ship, "string type, string triggeredBy, [number sp
 	if (animtype == animation::ModelAnimationTriggerType::None)
 		return ADE_RETURN_NIL;
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 
 	Ship_info[shipp->ship_info_index].animations.parseScripted(model_get_instance(shipp->model_instance_num), animtype, trigger).setSpeed(speed);
 
@@ -2035,7 +2036,7 @@ ADE_FUNC(getSubmodelAnimationTime, l_Ship, "string type, string triggeredBy", "G
 	if (animtype == animation::ModelAnimationTriggerType::None)
 		return ade_set_error(L, "f", 0.0f);
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 
 	int time_ms = Ship_info[shipp->ship_info_index].animations.parseScripted(model_get_instance(shipp->model_instance_num), animtype, trigger).getTime();
 	float time_s = (float)time_ms / 1000.0f;
@@ -2090,7 +2091,7 @@ ADE_FUNC(updateSubmodelMoveable, l_Ship, "string name, table values",
 		}
 	}
 
-	ship* shipp = &Ships[objh->objp->instance];
+	ship* shipp = &Ships[objh->objp()->instance];
 	return Ship_info[shipp->ship_info_index].animations.updateMoveable(model_get_instance(shipp->model_instance_num), name, valuesMoveable) ? ADE_RETURN_TRUE : ADE_RETURN_FALSE;
 }
 
@@ -2103,7 +2104,7 @@ ADE_FUNC(warpIn, l_Ship, NULL, "Warps ship in", "boolean", "True if successful, 
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	shipfx_warpin_start(objh->objp);
+	shipfx_warpin_start(objh->objp());
 
 	return ADE_RETURN_TRUE;
 }
@@ -2117,7 +2118,7 @@ ADE_FUNC(warpOut, l_Ship, NULL, "Warps ship out", "boolean", "True if successful
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	shipfx_warpout_start(objh->objp);
+	shipfx_warpout_start(objh->objp());
 
 	return ADE_RETURN_TRUE;
 }
@@ -2131,7 +2132,7 @@ ADE_FUNC(canWarp, l_Ship, nullptr, "Checks whether ship has a working subspace d
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	if( ship_can_warp_full_check(shipp) ){
 		return ADE_RETURN_TRUE;
 	}
@@ -2148,7 +2149,7 @@ ADE_FUNC(canBayDepart, l_Ship, nullptr, "Checks whether ship has a bay departure
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	if( ship_can_bay_depart(shipp) ){
 		return ADE_RETURN_TRUE;
 	}
@@ -2168,7 +2169,7 @@ ADE_FUNC_DEPRECATED(isWarpingIn, l_Ship, NULL, "Checks if ship is in stage 1 of 
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	if(shipp->is_arriving(ship::warpstage::STAGE1, false)){
 		return ADE_RETURN_TRUE;
 	}
@@ -2186,7 +2187,7 @@ ADE_FUNC(isWarpingStage1, l_Ship, NULL, "Checks if ship is in stage 1 of warping
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	if(shipp->is_arriving(ship::warpstage::STAGE1, false)){
 		return ADE_RETURN_TRUE;
 	}
@@ -2203,7 +2204,7 @@ ADE_FUNC(isWarpingStage2, l_Ship, NULL, "Checks if ship is in stage 2 of warping
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 	if(shipp->is_arriving(ship::warpstage::STAGE2, false)){
 		return ADE_RETURN_TRUE;
 	}
@@ -2223,7 +2224,7 @@ ADE_FUNC(getEMP, l_Ship, NULL, "Returns the current emp effect strength acting o
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	obj = objh->objp;
+	obj = objh->objp();
 
 	ship *shipp = &Ships[obj->instance];
 
@@ -2239,7 +2240,7 @@ ADE_FUNC(getTimeUntilExplosion, l_Ship, nullptr, "Returns the time in seconds un
 	if(!objh->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if (!timestamp_valid(shipp->final_death_time))
 		return ade_set_args(L, "f", -1.0f);
@@ -2259,7 +2260,7 @@ ADE_FUNC(setTimeUntilExplosion, l_Ship, "number Time", "Sets the time in seconds
 	if (!objh->isValid())
 		return ade_set_error(L, "b", false);
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if (!timestamp_valid(shipp->final_death_time))
 		return ade_set_args(L, "b", false);
@@ -2284,7 +2285,7 @@ ADE_FUNC(getCallsign, l_Ship, NULL, "Gets the callsign of the ship in the curren
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if (shipp->callsign_index < 0)
 		return ade_set_args(L, "s", "");
@@ -2311,7 +2312,7 @@ ADE_FUNC(getAltClassName, l_Ship, NULL, "Gets the alternate class name of the sh
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	ship *shipp = &Ships[objh->objp->instance];
+	ship *shipp = &Ships[objh->objp()->instance];
 
 	if (shipp->alt_type_index < 0)
 		return ade_set_args(L, "s", "");
@@ -2346,7 +2347,7 @@ ADE_FUNC(getMaximumSpeed, l_Ship, "[number energy = 0.333]", "Gets the maximum s
 	}
 	else
 	{
-		return ade_set_args(L, "f", ets_get_max_speed(objh->objp, energy));
+		return ade_set_args(L, "f", ets_get_max_speed(objh->objp(), energy));
 	}
 }
 
@@ -2366,9 +2367,9 @@ ADE_FUNC(EtsSetIndexes, l_Ship, "number EngineIndex, number ShieldIndex, number 
 
 	sanity_check_ets_inputs(ets_idx);
 
-	int sindex = objh->objp->instance;
+	int sindex = objh->objp()->instance;
 	if (validate_ship_ets_indxes(sindex, ets_idx)) {
-		set_recharge_rates(objh->objp, ets_idx[SHIELDS], ets_idx[WEAPONS], ets_idx[ENGINES]);
+		set_recharge_rates(objh->objp(), ets_idx[SHIELDS], ets_idx[WEAPONS], ets_idx[ENGINES]);
 		return ADE_RETURN_TRUE;
 	} else {
 		return ADE_RETURN_FALSE;
@@ -2384,7 +2385,7 @@ ADE_FUNC(getParsedShip, l_Ship, nullptr, "Returns the parsed ship that was used 
 	if(!objh->isValid())
 		return ade_set_error(L, "o", l_ParseObject.Set(parse_object_h(nullptr)));
 
-	auto shipp = &Ships[objh->objp->instance];
+	auto shipp = &Ships[objh->objp()->instance];
 	auto ship_entry = ship_registry_get(shipp->ship_name);
 	if (!ship_entry || !ship_entry->has_p_objp())
 		return ade_set_args(L, "o", l_ParseObject.Set(parse_object_h(nullptr)));
@@ -2403,7 +2404,7 @@ ADE_FUNC(getWing, l_Ship, NULL, "Returns the ship's wing", "wing", "Wing handle,
 	if(!objh->isValid())
 		return ade_set_error(L, "o", l_Wing.Set(-1));
 
-	shipp = &Ships[objh->objp->instance];
+	shipp = &Ships[objh->objp()->instance];
 	return ade_set_args(L, "o", l_Wing.Set(shipp->wingnum));
 }
 
@@ -2418,7 +2419,7 @@ ADE_FUNC(getDisplayString, l_Ship, nullptr, "Returns the string which should be 
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	shipp = &Ships[objh->objp->instance];
+	shipp = &Ships[objh->objp()->instance];
 	return ade_set_args(L, "s", shipp->get_display_name());
 }
 
@@ -2432,7 +2433,7 @@ ADE_FUNC(vanish, l_Ship, nullptr, "Vanishes this ship from the mission. Works in
 	if (!objh->isValid())
 		return ade_set_error(L, "b", false);
 
-	ship_actually_depart(objh->objp->instance, SHIP_VANISHED);
+	ship_actually_depart(objh->objp()->instance, SHIP_VANISHED);
 
 	return ade_set_args(L, "b", true);
 }
@@ -2450,7 +2451,7 @@ ADE_FUNC(setGlowPointBankActive, l_Ship, "boolean active, [number bank]", "Activ
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	auto shipp = &Ships[objh->objp->instance];
+	auto shipp = &Ships[objh->objp()->instance];
 
 	// read as many bank numbers as we have
 	while (internal::Ade_get_args_skip = ++skip_args, ade_get_args(L, "|i", &bank_num) > 0)
@@ -2486,7 +2487,7 @@ ADE_FUNC(numDocked, l_Ship, nullptr, "Returns the number of ships this ship is d
 	if (docker_objh == nullptr || !docker_objh->isValid())
 		return ADE_RETURN_NIL;
 
-	return ade_set_args(L, "i", dock_count_direct_docked_objects(docker_objh->objp));
+	return ade_set_args(L, "i", dock_count_direct_docked_objects(docker_objh->objp()));
 }
 
 ADE_FUNC(isDocked, l_Ship, "[ship... dockee_ships]", "Returns whether this ship is docked to all of the specified dockee ships, or is docked at all if no ships are specified", "boolean", "Returns whether the ship is docked")
@@ -2514,7 +2515,7 @@ ADE_FUNC(isDocked, l_Ship, "[ship... dockee_ships]", "Returns whether this ship 
 			continue;
 
 		// see if we are docked to it
-		if (!dock_check_find_direct_docked_object(docker_objh->objp, dockee_objh->objp))
+		if (!dock_check_find_direct_docked_object(docker_objh->objp(), dockee_objh->objp()))
 			return ADE_RETURN_FALSE;
 	}
 
@@ -2523,7 +2524,7 @@ ADE_FUNC(isDocked, l_Ship, "[ship... dockee_ships]", "Returns whether this ship 
 		return ADE_RETURN_TRUE;
 
 	// if we didn't find any specified ships, then see if we are docked at all
-	return object_is_docked(docker_objh->objp) ? ADE_RETURN_TRUE : ADE_RETURN_FALSE;
+	return object_is_docked(docker_objh->objp()) ? ADE_RETURN_TRUE : ADE_RETURN_FALSE;
 }
 
 ADE_FUNC(setDocked, l_Ship, "ship dockee_ship, [string | number docker_point, string | number dockee_point]", "Immediately docks this ship with another ship.", "boolean", "Returns whether the docking was successful, or nil if an input was invalid")
@@ -2538,11 +2539,11 @@ ADE_FUNC(setDocked, l_Ship, "ship dockee_ship, [string | number docker_point, st
 		return ADE_RETURN_NIL;
 
 	// cannot dock an object to itself
-	if (docker_objh->objp->instance == dockee_objh->objp->instance)
+	if (docker_objh->objp()->instance == dockee_objh->objp()->instance)
 		return ADE_RETURN_FALSE;
 
-	auto docker_shipp = &Ships[docker_objh->objp->instance];
-	auto dockee_shipp = &Ships[dockee_objh->objp->instance];
+	auto docker_shipp = &Ships[docker_objh->objp()->instance];
+	auto dockee_shipp = &Ships[dockee_objh->objp()->instance];
 
 	auto docker_pm = model_get(Ship_info[docker_shipp->ship_info_index].model_num);
 	auto dockee_pm = model_get(Ship_info[dockee_shipp->ship_info_index].model_num);
@@ -2592,16 +2593,16 @@ ADE_FUNC(setDocked, l_Ship, "ship dockee_ship, [string | number docker_point, st
 	}
 
 	//Make sure that the specified dockpoints are all free (if not, do nothing)
-	if (dock_find_object_at_dockpoint(docker_objh->objp, docker_point) != nullptr ||
-		dock_find_object_at_dockpoint(dockee_objh->objp, dockee_point) != nullptr)
+	if (dock_find_object_at_dockpoint(docker_objh->objp(), docker_point) != nullptr ||
+		dock_find_object_at_dockpoint(dockee_objh->objp(), dockee_point) != nullptr)
 	{
 		// at least one of the specified dockpoints is occupied
 		return ADE_RETURN_FALSE;
 	}
 
 	//Set docked
-	dock_orient_and_approach(docker_objh->objp, docker_point, dockee_objh->objp, dockee_point, DOA_DOCK_STAY);
-	ai_do_objects_docked_stuff(docker_objh->objp, docker_point, dockee_objh->objp, dockee_point, true);
+	dock_orient_and_approach(docker_objh->objp(), docker_point, dockee_objh->objp(), dockee_point, DOA_DOCK_STAY);
+	ai_do_objects_docked_stuff(docker_objh->objp(), docker_point, dockee_objh->objp(), dockee_point, true);
 
 	return ADE_RETURN_TRUE;
 }
@@ -2625,10 +2626,10 @@ static int jettison_helper(lua_State *L, object_h *docker_objh, float jettison_s
 			continue;
 
 		// make sure we are docked to it
-		if (!dock_check_find_direct_docked_object(docker_objh->objp, dockee_objh->objp))
+		if (!dock_check_find_direct_docked_object(docker_objh->objp(), dockee_objh->objp()))
 			continue;
 
-		object_jettison_cargo(docker_objh->objp, dockee_objh->objp, jettison_speed, true);
+		object_jettison_cargo(docker_objh->objp(), dockee_objh->objp(), jettison_speed, true);
 		num_ships_undocked++;
 	}
 
@@ -2637,9 +2638,9 @@ static int jettison_helper(lua_State *L, object_h *docker_objh, float jettison_s
 	{
 		// Goober5000 - as with ai_deathroll_start, we can't simply iterate through the dock list while we're
 		// undocking things.  So just repeatedly jettison the first object.
-		while (object_is_docked(docker_objh->objp))
+		while (object_is_docked(docker_objh->objp()))
 		{
-			object_jettison_cargo(docker_objh->objp, dock_get_first_docked_object(docker_objh->objp), jettison_speed, true);
+			object_jettison_cargo(docker_objh->objp(), dock_get_first_docked_object(docker_objh->objp()), jettison_speed, true);
 			num_ships_undocked++;
 		}
 	}
@@ -2691,7 +2692,7 @@ ADE_FUNC(AddElectricArc, l_Ship, "vector firstPoint, vector secondPoint, number 
 	if (!objh->isValid())
 		return ade_set_error(L, "i", 0);
 
-	auto shipp = &Ships[objh->objp->instance];
+	auto shipp = &Ships[objh->objp()->instance];
 
 	// spawn the arc in the first unused slot
 	for (int i = 0; i < MAX_ARC_EFFECTS; i++) {
@@ -2731,7 +2732,7 @@ ADE_FUNC(DeleteElectricArc, l_Ship, "number index",
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	auto shipp = &Ships[objh->objp->instance];
+	auto shipp = &Ships[objh->objp()->instance];
 
 	index--;	// Lua -> FS2
 	if (index >= 0 && index < MAX_ARC_EFFECTS)
@@ -2760,7 +2761,7 @@ ADE_FUNC(ModifyElectricArc, l_Ship, "number index, vector firstPoint, vector sec
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	auto shipp = &Ships[objh->objp->instance];
+	auto shipp = &Ships[objh->objp()->instance];
 
 	index--;	// Lua -> FS2
 	if (index >= 0 && index < MAX_ARC_EFFECTS)

--- a/code/scripting/api/objs/ship_bank.cpp
+++ b/code/scripting/api/objs/ship_bank.cpp
@@ -77,7 +77,7 @@ ADE_INDEXER(l_WeaponBankType, "number Index", "Array of weapon banks", "weaponba
 			return ade_set_error(L, "o", l_WeaponBank.Set(ship_bank_h()));	//Invalid type
 	}
 
-	return ade_set_args(L, "o", l_WeaponBank.Set(ship_bank_h(sb->objh.objp, sb->sw, sb->type, idx)));
+	return ade_set_args(L, "o", l_WeaponBank.Set(ship_bank_h(sb->objh.objp(), sb->sw, sb->type, idx)));
 }
 
 ADE_VIRTVAR(Linked, l_WeaponBankType, "boolean", "Whether bank is in linked or unlinked fire mode (Primary-only)", "boolean", "Link status, or false if handle is invalid")
@@ -96,10 +96,10 @@ ADE_VIRTVAR(Linked, l_WeaponBankType, "boolean", "Whether bank is in linked or u
 	{
 		case SWH_PRIMARY:
 			if(ADE_SETTING_VAR && numargs > 1) {
-				Ships[bth->objh.objp->instance].flags.set(Ship::Ship_Flags::Primary_linked, newlink);
+				Ships[bth->objh.objp()->instance].flags.set(Ship::Ship_Flags::Primary_linked, newlink);
 			}
 
-			return ade_set_args(L, "b", (Ships[bth->objh.objp->instance].flags[Ship::Ship_Flags::Primary_linked]));
+			return ade_set_args(L, "b", (Ships[bth->objh.objp()->instance].flags[Ship::Ship_Flags::Primary_linked]));
 
 		case SWH_SECONDARY:
 		case SWH_TERTIARY:
@@ -125,10 +125,10 @@ ADE_VIRTVAR(DualFire, l_WeaponBankType, "boolean", "Whether bank is in dual fire
 	{
 		case SWH_SECONDARY:
 			if(ADE_SETTING_VAR && numargs > 1) {
-				Ships[bth->objh.objp->instance].flags.set(Ship::Ship_Flags::Secondary_dual_fire, newfire);
+				Ships[bth->objh.objp()->instance].flags.set(Ship::Ship_Flags::Secondary_dual_fire, newfire);
 			}
 
-			return ade_set_args(L, "b", (Ships[bth->objh.objp->instance].flags[Ship::Ship_Flags::Secondary_dual_fire]));
+			return ade_set_args(L, "b", (Ships[bth->objh.objp()->instance].flags[Ship::Ship_Flags::Secondary_dual_fire]));
 
 		case SWH_PRIMARY:
 		case SWH_TERTIARY:
@@ -290,9 +290,9 @@ ADE_VIRTVAR(AmmoMax, l_WeaponBank, "number", "Maximum ammo for the current bank<
 
 			int weapon_class = bh->typeh.sw->primary_bank_weapons[bh->bank];
 
-			Assert(bh->typeh.objh.objp->type == OBJ_SHIP);
+			Assert(bh->typeh.objh.objp()->type == OBJ_SHIP);
 
-			return ade_set_args(L, "i", get_max_ammo_count_for_primary_bank(Ships[bh->typeh.objh.objp->instance].ship_info_index, bh->bank, weapon_class));
+			return ade_set_args(L, "i", get_max_ammo_count_for_primary_bank(Ships[bh->typeh.objh.objp()->instance].ship_info_index, bh->bank, weapon_class));
 		}
 		case SWH_SECONDARY:
 		{
@@ -302,9 +302,9 @@ ADE_VIRTVAR(AmmoMax, l_WeaponBank, "number", "Maximum ammo for the current bank<
 
 			int weapon_class = bh->typeh.sw->secondary_bank_weapons[bh->bank];
 
-			Assert(bh->typeh.objh.objp->type == OBJ_SHIP);
+			Assert(bh->typeh.objh.objp()->type == OBJ_SHIP);
 
-			return ade_set_args(L, "i", get_max_ammo_count_for_bank(Ships[bh->typeh.objh.objp->instance].ship_info_index, bh->bank, weapon_class));
+			return ade_set_args(L, "i", get_max_ammo_count_for_bank(Ships[bh->typeh.objh.objp()->instance].ship_info_index, bh->bank, weapon_class));
 		}
 		case SWH_TERTIARY:
 			if(ADE_SETTING_VAR && ammomax > -1) {

--- a/code/scripting/api/objs/waypoint.cpp
+++ b/code/scripting/api/objs/waypoint.cpp
@@ -18,8 +18,8 @@ ADE_FUNC(getList, l_Waypoint, NULL, "Returns the waypoint list", "waypointlist",
 	if(!ade_get_args(L, "o", l_Waypoint.GetPtr(&oh)))
 		return ade_set_error(L, "o", l_WaypointList.Set(waypointlist_h()));
 
-	if(oh->isValid() && oh->objp->type == OBJ_WAYPOINT) {
-		wp_list = find_waypoint_list_with_instance(oh->objp->instance);
+	if(oh->isValid() && oh->objp()->type == OBJ_WAYPOINT) {
+		wp_list = find_waypoint_list_with_instance(oh->objp()->instance);
 		if(wp_list != NULL)
 			wpl = waypointlist_h(wp_list);
 	}

--- a/code/scripting/api/objs/weapon.cpp
+++ b/code/scripting/api/objs/weapon.cpp
@@ -27,7 +27,7 @@ ADE_VIRTVAR(Class, l_Weapon, "weaponclass", "Weapon's class", "weaponclass", "We
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Weaponclass.Set(-1));
 
-	weapon *wp = &Weapons[oh->objp->instance];
+	weapon *wp = &Weapons[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && nc > -1) {
 		wp->weapon_info_index = nc;
@@ -49,7 +49,7 @@ ADE_VIRTVAR(DestroyedByWeapon, l_Weapon, "boolean", "Whether weapon was destroye
 	if(!oh->isValid())
 		return ade_set_error(L, "b", false);
 
-	weapon *wp = &Weapons[oh->objp->instance];
+	weapon *wp = &Weapons[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && numargs > 1) {
 		wp->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon, b);
@@ -68,7 +68,7 @@ ADE_VIRTVAR(LifeLeft, l_Weapon, "number", "Weapon life left (in seconds)", "numb
 	if(!oh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	weapon *wp = &Weapons[oh->objp->instance];
+	weapon *wp = &Weapons[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && nll >= 0.0f) {
 		wp->lifeleft = nll;
@@ -87,7 +87,7 @@ ADE_VIRTVAR(FlakDetonationRange, l_Weapon, "number", "Range at which flak will d
 	if(!oh->isValid())
 		return ade_set_error(L, "f", 0.0f);
 
-	weapon *wp = &Weapons[oh->objp->instance];
+	weapon *wp = &Weapons[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && rng >= 0.0f) {
 		wp->det_range = rng;
@@ -107,8 +107,8 @@ ADE_VIRTVAR(Target, l_Weapon, "object", "Target of weapon. Value may also be a d
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	weapon *wp = NULL;
-	if(objh->objp->instance > -1)
-		wp = &Weapons[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		wp = &Weapons[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
@@ -118,12 +118,12 @@ ADE_VIRTVAR(Target, l_Weapon, "object", "Target of weapon. Value may also be a d
 		{
 			if(wp->target_sig != newh->sig || !weapon_has_homing_object(wp))
 			{
-				weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, OBJ_INDEX(newh->objp), 1);
+				weapon_set_tracking_info(objh->objnum, objh->objp()->parent, newh->objnum, 1);
 			}
 		}
 		else
 		{
-			weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, -1);
+			weapon_set_tracking_info(objh->objnum, objh->objp()->parent, -1);
 		}
 	}
 
@@ -141,8 +141,8 @@ ADE_VIRTVAR(ParentTurret, l_Weapon, "subsystem", "Turret which fired this weapon
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	weapon *wp = NULL;
-	if(objh->objp->instance > -1)
-		wp = &Weapons[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		wp = &Weapons[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
@@ -178,8 +178,8 @@ ADE_VIRTVAR(HomingObject, l_Weapon, "object", "Object that weapon will home in o
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
 	weapon *wp = NULL;
-	if(objh->objp->instance > -1)
-		wp = &Weapons[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		wp = &Weapons[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Object.Set(object_h()));
 
@@ -189,12 +189,12 @@ ADE_VIRTVAR(HomingObject, l_Weapon, "object", "Object that weapon will home in o
 		{
 			if (wp->target_sig != newh->sig)
 			{
-				weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, OBJ_INDEX(newh->objp), 1);
+				weapon_set_tracking_info(objh->objnum, objh->objp()->parent, newh->objnum, 1);
 			}
 		}
 		else
 		{
-			weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, -1);
+			weapon_set_tracking_info(objh->objnum, objh->objp()->parent, -1);
 		}
 	}
 
@@ -216,8 +216,8 @@ ADE_VIRTVAR(HomingPosition, l_Weapon, "vector", "Position that weapon will home 
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	weapon *wp = NULL;
-	if(objh->objp->instance > -1)
-		wp = &Weapons[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		wp = &Weapons[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
@@ -252,8 +252,8 @@ ADE_VIRTVAR(HomingSubsystem, l_Weapon, "subsystem", "Subsystem that weapon will 
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
 	weapon *wp = NULL;
-	if(objh->objp->instance > -1)
-		wp = &Weapons[objh->objp->instance];
+	if(objh->objp()->instance > -1)
+		wp = &Weapons[objh->objp()->instance];
 	else
 		return ade_set_error(L, "o", l_Subsystem.Set(ship_subsys_h()));
 
@@ -263,7 +263,7 @@ ADE_VIRTVAR(HomingSubsystem, l_Weapon, "subsystem", "Subsystem that weapon will 
 		{
 			if(wp->target_sig != newh->objh.sig)
 			{
-				weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, OBJ_INDEX(newh->objh.objp), 1, newh->ss);
+				weapon_set_tracking_info(objh->objnum, objh->objp()->parent, newh->objh.objnum, 1, newh->ss);
 			}
 			else
 			{
@@ -273,7 +273,7 @@ ADE_VIRTVAR(HomingSubsystem, l_Weapon, "subsystem", "Subsystem that weapon will 
 		}
 		else
 		{
-			weapon_set_tracking_info(OBJ_INDEX(objh->objp), objh->objp->parent, -1);
+			weapon_set_tracking_info(objh->objnum, objh->objp()->parent, -1);
 		}
 
 		// need to update the position for multiplayer.
@@ -295,7 +295,7 @@ ADE_VIRTVAR(Team, l_Weapon, "team", "Weapon's team", "team", "Weapon team, or in
 	if(!oh->isValid())
 		return ade_set_error(L, "o", l_Team.Set(-1));
 
-	weapon *wp = &Weapons[oh->objp->instance];
+	weapon *wp = &Weapons[oh->objp()->instance];
 
 	if(ADE_SETTING_VAR && nt > -1 && nt < (int)Iff_info.size()) {
 		wp->team = nt;
@@ -317,7 +317,7 @@ ADE_VIRTVAR(OverrideHoming, l_Weapon, "boolean",
 	if (!oh->isValid())
 		return ade_set_error(L, "b", false);
 
-	weapon* wp = &Weapons[oh->objp->instance];
+	weapon* wp = &Weapons[oh->objp()->instance];
 
 	if (ADE_SETTING_VAR) {
 		wp->weapon_flags.set(Weapon::Weapon_Flags::Overridden_homing, new_val);
@@ -336,7 +336,7 @@ ADE_FUNC(isArmed, l_Weapon, "[boolean HitTarget]", "Checks if the weapon is arme
 	if(!oh->isValid())
 		return ADE_RETURN_FALSE;
 
-	weapon *wp = &Weapons[oh->objp->instance];
+	weapon *wp = &Weapons[oh->objp()->instance];
 
 	if(weapon_armed(wp, hit_target))
 		return ADE_RETURN_TRUE;
@@ -354,7 +354,7 @@ ADE_FUNC(getCollisionInformation, l_Weapon, nullptr, "Returns the collision info
 	if(!oh->isValid())
 		return ADE_RETURN_NIL;
 
-	weapon *wp = &Weapons[oh->objp->instance];
+	weapon *wp = &Weapons[oh->objp()->instance];
 
 	if (wp->collisionInfo != nullptr)
 		return ade_set_args(L, "o", l_ColInfo.Set(mc_info_h(*wp->collisionInfo)));
@@ -383,7 +383,7 @@ ADE_FUNC(triggerSubmodelAnimation, l_Weapon, "string type, string triggeredBy, [
 	if (!objh->isValid())
 		return ADE_RETURN_NIL;
 
-	weapon* wp = &Weapons[objh->objp->instance];
+	weapon* wp = &Weapons[objh->objp()->instance];
 	weapon_info* wip = &Weapon_info[wp->weapon_info_index];
 	if(wip->render_type != WRT_POF || wp->model_instance_num < 0)
 		return ADE_RETURN_FALSE;
@@ -410,7 +410,7 @@ ADE_FUNC(getSubmodelAnimationTime, l_Weapon, "string type, string triggeredBy", 
 	if (animtype == animation::ModelAnimationTriggerType::None)
 		return ade_set_error(L, "f", 0.0f);
 
-	weapon* wp = &Weapons[objh->objp->instance];
+	weapon* wp = &Weapons[objh->objp()->instance];
 	weapon_info* wip = &Weapon_info[wp->weapon_info_index];
 	if (wip->render_type != WRT_POF || wp->model_instance_num < 0)
 		return ade_set_error(L, "f", 0.0f);
@@ -431,7 +431,7 @@ ADE_FUNC(vanish, l_Weapon, nullptr, "Vanishes this weapon from the mission.", "b
 	if (!oh->isValid())
 		return ade_set_error(L, "b", false);
 
-	oh->objp->flags.set(Object::Object_Flags::Should_be_dead);
+	oh->objp()->flags.set(Object::Object_Flags::Should_be_dead);
 
 	return ade_set_args(L, "b", true);
 }

--- a/code/scripting/api/objs/wing.cpp
+++ b/code/scripting/api/objs/wing.cpp
@@ -32,7 +32,7 @@ ADE_INDEXER(l_Wing, "number Index", "Array of ships in the wing", "ship", "Ship 
 	sdx--;
 
 	if(ADE_SETTING_VAR && ndx != NULL && ndx->isValid()) {
-		Wings[wdx].ship_index[sdx] = ndx->objp->instance;
+		Wings[wdx].ship_index[sdx] = ndx->objp()->instance;
 	}
 
 	return ade_set_args(L, "o", l_Ship.Set(object_h(&Objects[Ships[Wings[wdx].ship_index[sdx]].objnum])));


### PR DESCRIPTION
This refactors the object_h struct to store objects as indexes rather than pointers.  This is a prerequisite for making the collection of objects dynamic in the future.  See also #6100.

Follow-up to #5800 and #5829.

~~In draft pending tests.~~  Tested and ready for review.