### PR TITLE
add flag to not show callsigns in escort list

### DIFF
--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -359,19 +359,22 @@ void HudGaugeEscort::renderIcon(int x, int y, int index)
 	{
 		hud_stuff_ship_name(buf, sp);
 
-		// maybe concatenate the callsign
-		if (*buf)
+		if (!Dont_show_callsigns_in_escort_list)
 		{
-			char callsign[NAME_LENGTH];
+			// maybe concatenate the callsign
+			if (*buf)
+			{
+				char callsign[NAME_LENGTH];
 
-			hud_stuff_ship_callsign(callsign, sp);
-			if (*callsign)
-				sprintf(&buf[strlen(buf)], " (%s)", callsign);
-		}
-		// maybe substitute the callsign
-		else
-		{
-			hud_stuff_ship_callsign(buf, sp);
+				hud_stuff_ship_callsign(callsign, sp);
+				if (*callsign)
+					sprintf(&buf[strlen(buf)], " (%s)", callsign);
+			}
+			// maybe substitute the callsign
+			else
+			{
+				hud_stuff_ship_callsign(buf, sp);
+			}
 		}
 	}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -151,6 +151,7 @@ bool Calculate_subsystem_hitpoints_after_parsing;
 bool Disable_internal_loadout_restoration_system;
 bool Contrails_use_absolute_speed;
 bool Lua_API_returns_nil_instead_of_invalid_object;
+bool Dont_show_callsigns_in_escort_list;
 
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Game.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
@@ -443,6 +444,10 @@ void parse_mod_table(const char *filename)
 
 			if (optional_string("$HUD drop shadows enabled by default:")) {
 				stuff_boolean(&HUD_shadows);
+			}
+
+			if (optional_string("$Don't show callsigns in the escort list:")) {
+				stuff_boolean(&Dont_show_callsigns_in_escort_list);
 			}
 
 			optional_string("#SEXP SETTINGS");
@@ -1582,6 +1587,7 @@ void mod_table_reset()
 	Disable_internal_loadout_restoration_system = false;
 	Contrails_use_absolute_speed = false;
 	Lua_API_returns_nil_instead_of_invalid_object = false;
+	Dont_show_callsigns_in_escort_list = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -160,6 +160,7 @@ extern bool Calculate_subsystem_hitpoints_after_parsing;
 extern bool Disable_internal_loadout_restoration_system;
 extern bool Contrails_use_absolute_speed;
 extern bool Lua_API_returns_nil_instead_of_invalid_object;
+extern bool Dont_show_callsigns_in_escort_list;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
As a follow-up to #5523, some mods use callsigns for their ships but prefer not to display the callsigns in the escort list.  In lieu of a more flexible way to configure escort lists, a simple flag is sufficient to implement the desired behavior.

It is recommended to ignore whitespace changes when reviewing this PR.