### PR TITLE
fix fighter beam FOV calculation

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8389,7 +8389,7 @@ void process_beam_fired_packet(ubyte *data, header *hinfo)
 			shipp->beam_sys_info.model_num = Ship_info[shipp->ship_info_index].model_num;
 			shipp->beam_sys_info.turret_gun_sobj = pm->detail[0];
 			shipp->beam_sys_info.turret_num_firing_points = 1;
-			shipp->beam_sys_info.turret_fov = cosf((field_of_fire != 0.0f) ? field_of_fire : 180);
+			shipp->beam_sys_info.turret_fov = cosf(fl_radians((field_of_fire != 0.0f) ? field_of_fire : 180.0f) / 2.0f);
 			shipp->beam_sys_info.pnt = fire_info.local_fire_postion;
 			shipp->beam_sys_info.turret_firing_point[0] = fire_info.local_fire_postion;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12659,7 +12659,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				shipp->beam_sys_info.model_num = sip->model_num;
 				shipp->beam_sys_info.turret_gun_sobj = pm->detail[0];
 				shipp->beam_sys_info.turret_num_firing_points = 1;  // dummy turret info is used per firepoint
-				shipp->beam_sys_info.turret_fov = cosf((winfo_p->field_of_fire != 0.0f)?winfo_p->field_of_fire:180);
+				shipp->beam_sys_info.turret_fov = cosf(fl_radians((winfo_p->field_of_fire != 0.0f) ? winfo_p->field_of_fire : 180.0f) / 2.0f);
 
 				shipp->fighter_beam_turret_data.disruption_timestamp = timestamp(0);
 				shipp->fighter_beam_turret_data.turret_next_fire_pos = 0;


### PR DESCRIPTION
Remarkable that we're still finding bugs in fighter beams after 20 years...

Since field-of-fire angles are specified in degrees, and `cosf` accepts radians, the angle needs to be converted (and then halved, per usage elsewhere).  Although this is a bugfix, this should technically not affect fighter beam behavior because fighter beams always fire down their normals.