### PR TITLE
make mission log dynamic

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -812,7 +812,7 @@ void hud_scrollback_button_pressed(int n)
 
 		case SHOW_EVENTS_BUTTON:
 			Scrollback_mode = SCROLLBACK_MODE_EVENT_LOG;
-			Scroll_max = Num_log_lines * gr_get_font_height();
+			Scroll_max = mission_log_scrollback_num_lines() * gr_get_font_height();
 			hud_scroll_reset();
 			break;
 
@@ -913,9 +913,9 @@ void hud_scrollback_init()
 	Background_bitmap = bm_load(Hud_mission_log_fname[gr_screen.res]);
 	// Status_bitmap = bm_load(Hud_mission_log_status_fname[gr_screen.res]);
 
-	message_log_init_scrollback(Hud_mission_log_list_coords[gr_screen.res][2]);
+	mission_log_init_scrollback(Hud_mission_log_list_coords[gr_screen.res][2]);
 	if (Scrollback_mode == SCROLLBACK_MODE_EVENT_LOG)
-		Scroll_max = Num_log_lines * gr_get_font_height();
+		Scroll_max = mission_log_scrollback_num_lines() * gr_get_font_height();
 	else if (Scrollback_mode == SCROLLBACK_MODE_OBJECTIVES)
 		Scroll_max = Num_obj_lines * gr_get_font_height();
 	else
@@ -928,7 +928,7 @@ void hud_scrollback_init()
 void hud_scrollback_close()
 {
 	ML_objectives_close();
-	message_log_shutdown_scrollback();
+	mission_log_shutdown_scrollback();
 	if (Background_bitmap >= 0)
 		bm_release(Background_bitmap);
 	//if (Status_bitmap >= 0)
@@ -960,7 +960,7 @@ void hud_scrollback_do_frame(float  /*frametime*/)
 
 			} else if (Scrollback_mode == SCROLLBACK_MODE_MSGS_LOG) {
 				Scrollback_mode = SCROLLBACK_MODE_EVENT_LOG;
-				Scroll_max = Num_log_lines * gr_get_font_height();
+				Scroll_max = mission_log_scrollback_num_lines() * gr_get_font_height();
 				hud_scroll_reset();
 
 			} else {
@@ -975,7 +975,7 @@ void hud_scrollback_do_frame(float  /*frametime*/)
 		case KEY_SHIFTED | KEY_TAB:
 			if (Scrollback_mode == SCROLLBACK_MODE_OBJECTIVES) {
 				Scrollback_mode = SCROLLBACK_MODE_EVENT_LOG;
-				Scroll_max = Num_log_lines * gr_get_font_height();
+				Scroll_max = mission_log_scrollback_num_lines() * gr_get_font_height();
 				hud_scroll_reset();
 
 			} else if (Scrollback_mode == SCROLLBACK_MODE_MSGS_LOG) {

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -230,14 +230,6 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 	}
 
 #ifndef NDEBUG
-	if ( (Log_entries.size() % 10) == 0 ) {
-		static size_t largest_size_save = Log_entries.size();
-		if ( (Log_entries.size() > 350) && (Log_entries.size() > largest_size_save) ){
-			largest_size_save = Log_entries.size();
-			nprintf(("missionlog", "new highwater point reached for mission log (" SIZE_T_ARG " entries).\n", largest_size_save));
-		}
-	}
-
 	float mission_time = f2fl(Missiontime);
 	int minutes = (int)(mission_time / 60);
 	int seconds = (int)mission_time % 60;
@@ -352,7 +344,7 @@ int mission_log_get_time_indexed( LogType type, const char *pname, const char *s
 				}
 
 				if ( (!stricmp(entry->pname, pname) && !stricmp(entry->sname, sname)) || (!stricmp(entry->pname, sname) && !stricmp(entry->sname, pname)) ) {
-					found = 1;
+					found = true;
 				}
 			} else {
 				// for non dock/undock goals, then the names are important!
@@ -368,11 +360,11 @@ int mission_log_get_time_indexed( LogType type, const char *pname, const char *s
 				// if we are looking for a subsystem entry, the subsystem names must be compared
 				if ((type == LOG_SHIP_SUBSYS_DESTROYED || type == LOG_CAP_SUBSYS_CARGO_REVEALED)) {
 					if ( (sname == NULL) || !subsystem_stricmp(sname, entry->sname) ) {
-						found = 1;
+						found = true;
 					}
 				} else {
 					if ( (sname == NULL) || !stricmp(sname, entry->sname) ) {
-						found = 1;
+						found = true;
 					}
 				}
 			}

--- a/code/mission/missionlog.cpp
+++ b/code/mission/missionlog.cpp
@@ -54,30 +54,30 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 	}
 
 	Log_entries.emplace_back();
-	auto entry = &Log_entries.back();
+	auto &entry = Log_entries.back();
 
-	entry->type = type;
+	entry.type = type;
 	if ( pname ) {
 		Assert (strlen(pname) < NAME_LENGTH);
-		strncpy_s(entry->pname, pname, NAME_LENGTH - 1);
+		strncpy_s(entry.pname, pname, NAME_LENGTH - 1);
 	} else
-		strcpy_s( entry->pname, EMPTY_LOG_NAME );
+		strcpy_s( entry.pname, EMPTY_LOG_NAME );
 
 	if ( sname ) {
 		Assert (strlen(sname) < NAME_LENGTH);
-		strncpy_s(entry->sname, sname, NAME_LENGTH - 1);
+		strncpy_s(entry.sname, sname, NAME_LENGTH - 1);
 	} else
-		strcpy_s( entry->sname, EMPTY_LOG_NAME );
+		strcpy_s( entry.sname, EMPTY_LOG_NAME );
 
-	entry->index = info_index;
-	entry->flags = flags;
-	entry->primary_team = -1;
-	entry->secondary_team = -1;
-	entry->pname_display = entry->pname;
-	entry->sname_display = entry->sname;
+	entry.index = info_index;
+	entry.flags = flags;
+	entry.primary_team = -1;
+	entry.secondary_team = -1;
+	entry.pname_display = entry.pname;
+	entry.sname_display = entry.sname;
 
-	end_string_at_first_hash_symbol(entry->pname_display);
-	end_string_at_first_hash_symbol(entry->sname_display);
+	end_string_at_first_hash_symbol(entry.pname_display);
+	end_string_at_first_hash_symbol(entry.sname_display);
 
 	// determine the contents of the flags member based on the type of entry we added.  We need to store things
 	// like team for the primary and (possibly) secondary object for this entry.
@@ -102,11 +102,11 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 		}
 
 		Assert (index >= 0);
-		entry->primary_team = Ships[index].team;
-		entry->pname_display = Ships[index].get_display_name();
+		entry.primary_team = Ships[index].team;
+		entry.pname_display = Ships[index].get_display_name();
 
 		if (Ships[index].flags[Ship::Ship_Flags::Hide_mission_log]) {
-			entry->flags |= MLF_HIDDEN;
+			entry.flags |= MLF_HIDDEN;
 		}
 
 		// some of the entries have a secondary component.  Figure out what is up with them.
@@ -114,8 +114,8 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 			if ( sname ) {
 				index = ship_name_lookup( sname );
 				Assert (index >= 0);
-				entry->secondary_team = Ships[index].team;
-				entry->sname_display = Ships[index].get_display_name();
+				entry.secondary_team = Ships[index].team;
+				entry.sname_display = Ships[index].get_display_name();
 			}
 		} else if ( type == LOG_SHIP_DESTROYED ) {
 			if ( sname ) {
@@ -129,12 +129,12 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 					{
 						// argh. badness
 						Int3();
-						entry->secondary_team = Player_ship->team;
+						entry.secondary_team = Player_ship->team;
 					}
 					else
 					{
-						entry->secondary_team = Ships[Objects[Net_players[np_index].m_player->objnum].instance].team;
-						entry->sname_display = Ships[Objects[Net_players[np_index].m_player->objnum].instance].get_display_name();
+						entry.secondary_team = Ships[Objects[Net_players[np_index].m_player->objnum].instance].team;
+						entry.sname_display = Ships[Objects[Net_players[np_index].m_player->objnum].instance].get_display_name();
 					}
 				}
 				else 
@@ -146,11 +146,11 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 						if ( index == -1 ) {
 							break;
 						}
-						entry->secondary_team = Ships_exited[index].team;
-						entry->sname_display = Ships_exited[index].display_name;
+						entry.secondary_team = Ships_exited[index].team;
+						entry.sname_display = Ships_exited[index].display_name;
 					} else {
-						entry->secondary_team = Ships[index].team;
-						entry->sname_display = Ships[index].get_display_name();
+						entry.secondary_team = Ships[index].team;
+						entry.sname_display = Ships[index].get_display_name();
 					}
 				}
  			} else {
@@ -158,10 +158,10 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 			}
 		} else if ( (type == LOG_SHIP_SUBSYS_DESTROYED) && (Ship_info[Ships[index].ship_info_index].is_small_ship()) ) {
 			// make subsystem destroyed entries for small ships hidden
-			entry->flags |= MLF_HIDDEN;
+			entry.flags |= MLF_HIDDEN;
 		} else if ( (type == LOG_SHIP_ARRIVED) && (Ships[index].wingnum != -1 ) ) {
 			// arrival of ships in wings don't display
-			entry->flags |= MLF_HIDDEN;
+			entry.flags |= MLF_HIDDEN;
 		}
 		break;
 
@@ -188,9 +188,9 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 				}
 			}
 			Assert( si != -1 );
-			entry->primary_team = Ships[si].team;
+			entry.primary_team = Ships[si].team;
 		} else {
-			entry->primary_team = info_index;
+			entry.primary_team = info_index;
 		}
 
 #ifndef NDEBUG
@@ -214,19 +214,19 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 
 		// don't display waypoint done entries
 	case LOG_WAYPOINTS_DONE:
-		entry->flags |= MLF_HIDDEN;
+		entry.flags |= MLF_HIDDEN;
 		break;
 
 	default:
 		break;
 	}
 
-	entry->timestamp = Missiontime;
-	entry->timer_padding = The_mission.HUD_timer_padding;
+	entry.timestamp = Missiontime;
+	entry.timer_padding = The_mission.HUD_timer_padding;
 
 	// if in multiplayer and I am the master, send this log entry to everyone
 	if ( MULTIPLAYER_MASTER ){
-		send_mission_log_packet( entry );
+		send_mission_log_packet( &entry );
 	}
 
 #ifndef NDEBUG
@@ -235,58 +235,58 @@ void mission_log_add_entry(LogType type, const char *pname, const char *sname, i
 	int seconds = (int)mission_time % 60;
 
 	// record the entry to the debug log too
-	switch (entry->type) {
+	switch (entry.type) {
 		case LOG_SHIP_DESTROYED:
 		case LOG_WING_DESTROYED:
-			nprintf(("missionlog", "MISSION LOG: %s destroyed at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s destroyed at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_SHIP_ARRIVED:
 		case LOG_WING_ARRIVED:
-			nprintf(("missionlog", "MISSION LOG: %s arrived at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s arrived at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_SHIP_DEPARTED:
 		case LOG_WING_DEPARTED:
-			nprintf(("missionlog", "MISSION LOG: %s departed at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s departed at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_SHIP_DOCKED:
 		case LOG_SHIP_UNDOCKED:
-			nprintf(("missionlog", "MISSION LOG: %s %sdocked with %s at %02d:%02d\n", entry->pname, entry->type == LOG_SHIP_UNDOCKED ? "un" : "", entry->sname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s %sdocked with %s at %02d:%02d\n", entry.pname, entry.type == LOG_SHIP_UNDOCKED ? "un" : "", entry.sname, minutes, seconds));
 			break;
 		case LOG_SHIP_SUBSYS_DESTROYED:
-			nprintf(("missionlog", "MISSION LOG: %s subsystem %s destroyed at %02d:%02d\n", entry->pname, entry->sname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s subsystem %s destroyed at %02d:%02d\n", entry.pname, entry.sname, minutes, seconds));
 			break;
 		case LOG_SHIP_DISABLED:
-			nprintf(("missionlog", "MISSION LOG: %s disabled at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s disabled at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_SHIP_DISARMED:
-			nprintf(("missionlog", "MISSION LOG: %s disarmed at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s disarmed at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_PLAYER_CALLED_FOR_REARM:
-			nprintf(("missionlog", "MISSION LOG: Player %s called for rearm at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: Player %s called for rearm at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_PLAYER_ABORTED_REARM:
-			nprintf(("missionlog", "MISSION LOG: Player %s aborted rearm at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: Player %s aborted rearm at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_PLAYER_CALLED_FOR_REINFORCEMENT:
-			nprintf(("missionlog", "MISSION LOG: A player called for reinforcement %s at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: A player called for reinforcement %s at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_GOAL_SATISFIED:
-			nprintf(("missionlog", "MISSION LOG: Goal %s satisfied at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: Goal %s satisfied at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_GOAL_FAILED:
-			nprintf(("missionlog", "MISSION LOG: Goal %s failed at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: Goal %s failed at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 		case LOG_WAYPOINTS_DONE:
-			nprintf(("missionlog", "MISSION LOG: %s completed waypoint path %s at %02d:%02d\n", entry->pname, entry->sname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s completed waypoint path %s at %02d:%02d\n", entry.pname, entry.sname, minutes, seconds));
 			break;
 		case LOG_CARGO_REVEALED:
-			nprintf(("missionlog", "MISSION LOG: %s cargo %s revealed at %02d:%02d\n", entry->pname, Cargo_names[entry->index], minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s cargo %s revealed at %02d:%02d\n", entry.pname, Cargo_names[entry.index], minutes, seconds));
 			break;
 		case LOG_CAP_SUBSYS_CARGO_REVEALED:
-			nprintf(("missionlog", "MISSION LOG: %s subsystem %s cargo %s revealed at %02d:%02d\n", entry->pname, entry->sname, Cargo_names[entry->index], minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s subsystem %s cargo %s revealed at %02d:%02d\n", entry.pname, entry.sname, Cargo_names[entry.index], minutes, seconds));
 			break;
 		case LOG_SELF_DESTRUCTED:
-			nprintf(("missionlog", "MISSION LOG: %s self-destructed at %02d:%02d\n", entry->pname, minutes, seconds));
+			nprintf(("missionlog", "MISSION LOG: %s self-destructed at %02d:%02d\n", entry.pname, minutes, seconds));
 			break;
 	}
 #endif
@@ -302,25 +302,25 @@ void mission_log_add_entry_multi( LogType type, const char *pname, const char *s
 	Assert ( !(Net_player->flags & NETINFO_FLAG_AM_MASTER) );
 
 	Log_entries.emplace_back();
-	auto entry = &Log_entries.back();
+	auto &entry = Log_entries.back();
 
-	entry->type = type;
+	entry.type = type;
 	if ( pname ) {
 		Assert (strlen(pname) < NAME_LENGTH);
-		strcpy_s(entry->pname, pname);
+		strcpy_s(entry.pname, pname);
 	}
 	if ( sname ) {
 		Assert (strlen(sname) < NAME_LENGTH);
-		strcpy_s(entry->sname, sname);
+		strcpy_s(entry.sname, sname);
 	}
-	entry->index = index;
+	entry.index = index;
 
-	entry->flags = flags;
-	entry->timestamp = timestamp;
-	entry->timer_padding = The_mission.HUD_timer_padding;
+	entry.flags = flags;
+	entry.timestamp = timestamp;
+	entry.timer_padding = The_mission.HUD_timer_padding;
 
-	entry->pname_display = entry->pname;
-	entry->sname_display = entry->sname;
+	entry.pname_display = entry.pname;
+	entry.sname_display = entry.sname;
 }
 
 // function to determine is the given event has taken place count number of times.
@@ -329,11 +329,10 @@ int mission_log_get_time_indexed( LogType type, const char *pname, const char *s
 {
 	Assertion(count > 0, "The count parameter is %d; it should be greater than 0!", count);
 
-	for (const auto &ii: Log_entries) {
-		auto entry = &ii;
+	for (const auto& entry: Log_entries) {
 		bool found = false;
 
-		if ( entry->type == type ) {
+		if ( entry.type == type ) {
 			// if we are looking for a dock/undock entry, then we don't care about the order in which the names
 			// were passed into this function.  Count the entry as found if either name matches both in the other
 			// set.
@@ -343,7 +342,7 @@ int mission_log_get_time_indexed( LogType type, const char *pname, const char *s
 					return 0;
 				}
 
-				if ( (!stricmp(entry->pname, pname) && !stricmp(entry->sname, sname)) || (!stricmp(entry->pname, sname) && !stricmp(entry->sname, pname)) ) {
+				if ( (!stricmp(entry.pname, pname) && !stricmp(entry.sname, sname)) || (!stricmp(entry.pname, sname) && !stricmp(entry.sname, pname)) ) {
 					found = true;
 				}
 			} else {
@@ -353,17 +352,17 @@ int mission_log_get_time_indexed( LogType type, const char *pname, const char *s
 					return 0;
 				}
 
-				if ( stricmp(entry->pname, pname) != 0 ) {
+				if ( stricmp(entry.pname, pname) != 0 ) {
 					continue;
 				}
 
 				// if we are looking for a subsystem entry, the subsystem names must be compared
 				if ((type == LOG_SHIP_SUBSYS_DESTROYED || type == LOG_CAP_SUBSYS_CARGO_REVEALED)) {
-					if ( (sname == NULL) || !subsystem_stricmp(sname, entry->sname) ) {
+					if ( (sname == NULL) || !subsystem_stricmp(sname, entry.sname) ) {
 						found = true;
 					}
 				} else {
-					if ( (sname == NULL) || !stricmp(sname, entry->sname) ) {
+					if ( (sname == NULL) || !stricmp(sname, entry.sname) ) {
 						found = true;
 					}
 				}
@@ -374,7 +373,7 @@ int mission_log_get_time_indexed( LogType type, const char *pname, const char *s
 
 				if ( !count ) {
 					if (time) {
-						*time = entry->timestamp;
+						*time = entry.timestamp;
 					}
 
 					return 1;
@@ -400,10 +399,8 @@ int mission_log_get_count( LogType type, const char *pname, const char *sname )
 {
 	int count = 0;
 
-	for (const auto& ii : Log_entries) {
-		auto entry = &ii;
-
-		if ( entry->type == type ) {
+	for (const auto& entry : Log_entries) {
+		if ( entry.type == type ) {
 			// if we are looking for a dock/undock entry, then we don't care about the order in which the names
 			// were passed into this function.  Count the entry as found if either name matches both in the other
 			// set.
@@ -413,7 +410,7 @@ int mission_log_get_count( LogType type, const char *pname, const char *sname )
 					return 0;
 				}
 
-				if ( (!stricmp(entry->pname, pname) && !stricmp(entry->sname, sname)) || (!stricmp(entry->pname, sname) && !stricmp(entry->sname, pname)) ) {
+				if ( (!stricmp(entry.pname, pname) && !stricmp(entry.sname, sname)) || (!stricmp(entry.pname, sname) && !stricmp(entry.sname, pname)) ) {
 					count++;
 				}
 			} else {
@@ -423,11 +420,11 @@ int mission_log_get_count( LogType type, const char *pname, const char *sname )
 					return 0;
 				}
 
-				if ( stricmp(entry->pname, pname) != 0 ) {
+				if ( stricmp(entry.pname, pname) != 0 ) {
 					continue;
 				}
 
-				if ( (sname == NULL) || !stricmp(sname, entry->sname) ) {
+				if ( (sname == NULL) || !stricmp(sname, entry.sname) ) {
 					count++;
 				}
 			}
@@ -518,15 +515,13 @@ void mission_log_init_scrollback(int pw, bool split_string)
 
 	Log_scrollback_vec.clear();
 
-	for (const auto& ii : Log_entries) {
-		auto entry = &ii;
-
-		if (entry->flags & MLF_HIDDEN)
+	for (const auto& entry : Log_entries) {
+		if (entry.flags & MLF_HIDDEN)
 			continue;
 
 		// don't display failed bonus goals
-		if (entry->type == LOG_GOAL_FAILED) {
-			int type = Mission_goals[entry->index].type & GOAL_TYPE_MASK;
+		if (entry.type == LOG_GOAL_FAILED) {
+			int type = Mission_goals[entry.index].type & GOAL_TYPE_MASK;
 
 			if (type == BONUS_GOAL) {
 				continue;
@@ -536,35 +531,35 @@ void mission_log_init_scrollback(int pw, bool split_string)
 		log_line_complete thisEntry;
 
 		// track time of event (normal Missiontime format)
-		thisEntry.timestamp = entry->timestamp;
-		thisEntry.timer_padding = entry->timer_padding;
+		thisEntry.timestamp = entry.timestamp;
+		thisEntry.timer_padding = entry.timer_padding;
 
 		// keep track of base color for the entry
 		int thisColor;
 
 		// Goober5000
-		if ((entry->type == LOG_GOAL_SATISFIED) || (entry->type == LOG_GOAL_FAILED))
+		if ((entry.type == LOG_GOAL_SATISFIED) || (entry.type == LOG_GOAL_FAILED))
 			thisColor = LOG_COLOR_BRIGHT;
-		else if (entry->primary_team >= 0)
-			thisColor = mission_log_team_get_color(entry->primary_team);
+		else if (entry.primary_team >= 0)
+			thisColor = mission_log_team_get_color(entry.primary_team);
 		else
 			thisColor = LOG_COLOR_OTHER;
 
-		if ( (Lcl_gr) && ((entry->type == LOG_GOAL_FAILED) || (entry->type == LOG_GOAL_SATISFIED)) ) {
+		if ( (Lcl_gr) && ((entry.type == LOG_GOAL_FAILED) || (entry.type == LOG_GOAL_SATISFIED)) ) {
 			// in german goal events, just say "objective" instead of objective name
 			// this is cuz we can't translate objective names
 			message_log_add_seg(&thisEntry.objective, OBJECT_X, thisColor, "Einsatzziel");
-		} else if ( (Lcl_pl) && ((entry->type == LOG_GOAL_FAILED) || (entry->type == LOG_GOAL_SATISFIED)) ) {
+		} else if ( (Lcl_pl) && ((entry.type == LOG_GOAL_FAILED) || (entry.type == LOG_GOAL_SATISFIED)) ) {
 			// same thing for polish
 			message_log_add_seg(&thisEntry.objective, OBJECT_X, thisColor, "Cel misji");
 		} else {
-			message_log_add_seg(&thisEntry.objective, OBJECT_X, thisColor, entry->pname_display.c_str());
+			message_log_add_seg(&thisEntry.objective, OBJECT_X, thisColor, entry.pname_display.c_str());
 		}
 
 		//Set the flags for objectives
-		if (entry->type == LOG_GOAL_SATISFIED) {
+		if (entry.type == LOG_GOAL_SATISFIED) {
 			thisEntry.objective.flags = LOG_FLAG_GOAL_TRUE;
-		} else if (entry->type == LOG_GOAL_FAILED) {
+		} else if (entry.type == LOG_GOAL_FAILED) {
 			thisEntry.objective.flags = LOG_FLAG_GOAL_FAILED;
 		} else {
 			thisEntry.objective.flags = 0;
@@ -574,21 +569,21 @@ void mission_log_init_scrollback(int pw, bool split_string)
 		X = ACTION_X;
 
 		// Goober5000
-		if (entry->secondary_team >= 0)
-			thisColor = mission_log_team_get_color(entry->secondary_team);
+		if (entry.secondary_team >= 0)
+			thisColor = mission_log_team_get_color(entry.secondary_team);
 		else
 			thisColor = LOG_COLOR_NORMAL;
 
 		char text[256];
 
-		switch (entry->type) {
+		switch (entry.type) {
 			case LOG_SHIP_DESTROYED:
 				message_log_add_segs(XSTR( "Destroyed", 404), LOG_COLOR_NORMAL, 0, &thisEntry.segments, split_string);
-				if (!entry->sname_display.empty()) {
+				if (!entry.sname_display.empty()) {
 					message_log_add_segs(XSTR("  Kill: ", 405), LOG_COLOR_NORMAL, 0, &thisEntry.segments, split_string);
-					message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.segments, split_string);
-					if (entry->index >= 0) {
-						sprintf(text, NOX(" (%d%%)"), entry->index);
+					message_log_add_segs(entry.sname_display.c_str(), thisColor, 0, &thisEntry.segments, split_string);
+					if (entry.index >= 0) {
+						sprintf(text, NOX(" (%d%%)"), entry.index);
 						message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.segments, split_string);
 					}
 				}
@@ -607,8 +602,8 @@ void mission_log_init_scrollback(int pw, bool split_string)
 				break;
 
 			case LOG_WING_ARRIVED:
-				if (entry->index > 1){
-					sprintf(text, XSTR( "Arrived (wave %d)", 407), entry->index);
+				if (entry.index > 1){
+					sprintf(text, XSTR( "Arrived (wave %d)", 407), entry.index);
 				} else {
 					strcpy_s(text, XSTR( "Arrived", 406));
 				}
@@ -625,12 +620,12 @@ void mission_log_init_scrollback(int pw, bool split_string)
 
 			case LOG_SHIP_DOCKED:
 				message_log_add_segs(XSTR("Docked with ", 409), LOG_COLOR_NORMAL, 0, &thisEntry.segments, split_string);
-				message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.segments, split_string);
+				message_log_add_segs(entry.sname_display.c_str(), thisColor, 0, &thisEntry.segments, split_string);
 				break;
 
 			case LOG_SHIP_SUBSYS_DESTROYED: {
-				ship_info* sip = &Ship_info[(int)((entry->index >> 16) & 0xffff)];
-				int model_index = (int)(entry->index & 0xffff);
+				ship_info* sip = &Ship_info[(int)((entry.index >> 16) & 0xffff)];
+				int model_index = (int)(entry.index & 0xffff);
 				const char* subsys_name;
 				if (strlen(sip->subsystems[model_index].alt_sub_name)) {
 					subsys_name = sip->subsystems[model_index].alt_sub_name;
@@ -646,7 +641,7 @@ void mission_log_init_scrollback(int pw, bool split_string)
 
 			case LOG_SHIP_UNDOCKED:
 				message_log_add_segs(XSTR("Undocked with ", 412), LOG_COLOR_NORMAL, 0, &thisEntry.segments, split_string);
-				message_log_add_segs(entry->sname_display.c_str(), thisColor, 0, &thisEntry.segments, split_string);
+				message_log_add_segs(entry.sname_display.c_str(), thisColor, 0, &thisEntry.segments, split_string);
 				break;
 
 			case LOG_SHIP_DISABLED:
@@ -670,30 +665,30 @@ void mission_log_init_scrollback(int pw, bool split_string)
 				break;
 
 			case LOG_CARGO_REVEALED:
-				Assert( entry->index >= 0 );
-				Assert(!(entry->index & CARGO_NO_DEPLETE));
+				Assert( entry.index >= 0 );
+				Assert(!(entry.index & CARGO_NO_DEPLETE));
 
 				message_log_add_segs(XSTR("Cargo revealed: ", 418), LOG_COLOR_NORMAL, 0, &thisEntry.segments, split_string);
-				strncpy(text, Cargo_names[entry->index], sizeof(text) - 1);
+				strncpy(text, Cargo_names[entry.index], sizeof(text) - 1);
 				message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.segments, split_string);
 				break;
 
 			case LOG_CAP_SUBSYS_CARGO_REVEALED:
-				Assert( entry->index >= 0 );
-				Assert(!(entry->index & CARGO_NO_DEPLETE));
+				Assert( entry.index >= 0 );
+				Assert(!(entry.index & CARGO_NO_DEPLETE));
 
-				message_log_add_segs(entry->sname_display.c_str(), LOG_COLOR_NORMAL, 0, &thisEntry.segments, split_string);
+				message_log_add_segs(entry.sname_display.c_str(), LOG_COLOR_NORMAL, 0, &thisEntry.segments, split_string);
 				message_log_add_segs(XSTR( " subsystem cargo revealed: ", 1488), LOG_COLOR_NORMAL, 0, &thisEntry.segments, split_string);
-				strncpy(text, Cargo_names[entry->index], sizeof(text) - 1);
+				strncpy(text, Cargo_names[entry.index], sizeof(text) - 1);
 				message_log_add_segs(text, LOG_COLOR_BRIGHT, 0, &thisEntry.segments, split_string);
 				break;
 
 
 			case LOG_GOAL_SATISFIED:
 			case LOG_GOAL_FAILED: {
-				int type = Mission_goals[entry->index].type & GOAL_TYPE_MASK;
+				int type = Mission_goals[entry.index].type & GOAL_TYPE_MASK;
 				sprintf( text, XSTR( "%s objective ", 419), Goal_type_text(type) );
-				if ( entry->type == LOG_GOAL_SATISFIED )
+				if ( entry.type == LOG_GOAL_SATISFIED )
 					strcat_s(text, XSTR( "satisfied.", 420));
 				else
 					strcat_s(text, XSTR( "failed.", 421));

--- a/code/mission/missionlog.h
+++ b/code/mission/missionlog.h
@@ -43,9 +43,7 @@ enum LogType {
 
 // structure definition for log entries
 
-#define MLF_ESSENTIAL						(1 << 0)	// this entry is essential for goal checking code
-#define MLF_OBSOLETE						(1 << 1)	// this entry is obsolete and will be removed
-#define MLF_HIDDEN							(1 << 2)	// entry doesn't show up in displayed log.
+#define MLF_HIDDEN							(1 << 0)	// entry doesn't show up in displayed log.
 
 // defines for log flags
 #define LOG_FLAG_GOAL_FAILED (1 << 0)
@@ -87,9 +85,6 @@ struct log_line_complete {
 	SCP_vector<log_text_seg> segments;
 };
 
-extern SCP_vector<log_line_complete> Log_scrollback_vec;
-extern int Num_log_lines;
-
 // function prototypes
 
 // to be called before each mission starts
@@ -112,13 +107,16 @@ extern int mission_log_get_time_indexed(LogType type, const char *name, const ch
 extern int mission_log_get_count(LogType type, const char *pname, const char *sname);
 
 // get the team for a log item
-extern int message_log_color_get_team(int msg_color);
+extern int mission_log_color_get_team(int msg_color);
 
 // get the actual color for a line item
 extern const color *log_line_get_color(int tag);
 
-void message_log_init_scrollback(int pw, bool split_string = true);
-void message_log_shutdown_scrollback();
-void mission_log_scrollback(int line_offset, int list_x, int list_y, int list_w, int list_h);
+extern void mission_log_init_scrollback(int pw, bool split_string = true);
+extern void mission_log_shutdown_scrollback();
+extern void mission_log_scrollback(int line_offset, int list_x, int list_y, int list_w, int list_h);
+
+extern int mission_log_scrollback_num_lines();
+extern const log_line_complete* mission_log_scrollback_get_line(int index);
 
 #endif

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2078,10 +2078,8 @@ ADE_FUNC(initMissionLog, l_UserInterface_MissionLog, nullptr, "Initializes the M
 {
 	SCP_UNUSED(L);
 
-	Log_scrollback_vec.clear(); // Make sure the vector is empty before we start
-
-	//explicitely do not split lines!
-	message_log_init_scrollback(0, false);
+	//explicitly do not split lines!
+	mission_log_init_scrollback(0, false);
 
 	return ADE_RETURN_NIL;
 }
@@ -2090,7 +2088,7 @@ ADE_FUNC(closeMissionLog, l_UserInterface_MissionLog, nullptr, "Clears the Missi
 {
 	SCP_UNUSED(L);
 
-	message_log_shutdown_scrollback();
+	mission_log_shutdown_scrollback();
 
 	return ADE_RETURN_NIL;
 }
@@ -2107,7 +2105,7 @@ ADE_INDEXER(l_Log_Entries,
 		return ade_set_error(L, "o", l_Log_Entry.Set(log_entry_h()));
 	idx--; //Convert to Lua's 1 based index system
 
-	if ((idx < 0) || (idx >= (int)Log_scrollback_vec.size()))
+	if ((idx < 0) || (idx >= mission_log_scrollback_num_lines()))
 		return ade_set_error(L, "o", l_Log_Entry.Set(log_entry_h()));
 
 	return ade_set_args(L, "o", l_Log_Entry.Set(log_entry_h(idx)));
@@ -2115,7 +2113,7 @@ ADE_INDEXER(l_Log_Entries,
 
 ADE_FUNC(__len, l_Log_Entries, nullptr, "The number of mission log entries", "number", "The number of log entries.")
 {
-	return ade_set_args(L, "i", (int)Log_scrollback_vec.size());
+	return ade_set_args(L, "i", mission_log_scrollback_num_lines());
 }
 
 ADE_LIB_DERIV(l_Log_Messages, "Log_Messages", nullptr, nullptr, l_UserInterface_MissionLog);

--- a/code/scripting/api/objs/missionlog.cpp
+++ b/code/scripting/api/objs/missionlog.cpp
@@ -14,23 +14,23 @@ namespace api {
 log_entry_h::log_entry_h() : section(-1) {}
 log_entry_h::log_entry_h(int l_section) : section(l_section) {}
 
-log_line_complete* log_entry_h::getSection() const
+const log_line_complete* log_entry_h::getSection() const
 {
 	if (!isValid())
 		return nullptr;
 
-	return &Log_scrollback_vec[section];
+	return mission_log_scrollback_get_line(section);
 }
 
 bool log_entry_h::isValid() const
 {
-	return section >= 0 && section < (int)Log_scrollback_vec.size();
+	return section >= 0 && section < mission_log_scrollback_num_lines();
 }
 
 message_entry_h::message_entry_h() : section(-1) {}
 message_entry_h::message_entry_h(int l_section) : section(l_section) {}
 
-line_node* message_entry_h::getSection() const
+const line_node* message_entry_h::getSection() const
 {
 	if (!isValid())
 		return nullptr;

--- a/code/scripting/api/objs/missionlog.h
+++ b/code/scripting/api/objs/missionlog.h
@@ -11,7 +11,7 @@ struct log_entry_h {
 	int section;
 	log_entry_h();
 	explicit log_entry_h(int l_section);
-	log_line_complete* getSection() const;
+	const log_line_complete* getSection() const;
 	bool isValid() const;
 };
 
@@ -19,7 +19,7 @@ struct message_entry_h {
 	int section;
 	message_entry_h();
 	explicit message_entry_h(int l_section);
-	line_node* getSection() const;
+	const line_node* getSection() const;
 	bool isValid() const;
 };
 


### PR DESCRIPTION
Change the mission log from a static array to a dynamic vector.  This removes any chance of the mission log running into a limit (as regularly happened with the last mission of Shepherds before the limit bump) and also prevents strange mission bugs caused by culling obsolete entries.

This also unifies the API a bit by renaming the public `message_log_` function prefixes to `mission_log_`, removing the redundant `Num_log_lines` variable, and removing `Log_scrollback_vec` from the header.

Implements #5878.