### PR TITLE
make fireball types dynamic

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1593,9 +1593,8 @@ static float asteroid_create_explosion(object *objp)
 		fireball_type = FIREBALL_ASTEROID;
 	}
 
-	if (fireball_type >= Num_fireball_types) {
-		Warning(LOCATION, "Invalid fireball type %i specified for an asteroid, only %i fireball types are defined.", fireball_type, Num_fireball_types);
-
+	if (fireball_type >= static_cast<int>(Fireball_info.size())) {
+		Warning(LOCATION, "Invalid fireball type %i specified for an asteroid; only " SIZE_T_ARG " fireball types are defined.", fireball_type, Fireball_info.size());
 		return 0;
 	}
 
@@ -2251,10 +2250,7 @@ static void asteroid_parse_section()
 	}
 	
 	if(optional_string("$Explosion Animations:")){
-		int temp[MAX_FIREBALL_TYPES];
-		auto parsed_ints = stuff_int_list(temp, MAX_FIREBALL_TYPES, RAW_INTEGER_TYPE);
-		asteroid_p->explosion_bitmap_anims.clear();
-		asteroid_p->explosion_bitmap_anims.insert(asteroid_p->explosion_bitmap_anims.begin(), temp, temp + parsed_ints);
+		stuff_fireball_index_list(asteroid_p->explosion_bitmap_anims, asteroid_p->name);
 	}
 
 	if (optional_string("$Explosion Radius Mult:")) {

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -33,14 +33,11 @@ class asteroid_info;
 #define FIREBALL_EXPLOSION_LARGE1	4		// Used for the big explosion when a ship breaks into pieces
 #define FIREBALL_EXPLOSION_LARGE2	5		// Used for the big explosion when a ship breaks into pieces
 
-#define MAX_FIREBALL_TYPES			32		// The maximum number of fireballs that can be defined
 #define NUM_DEFAULT_FIREBALLS		6
 
 #define MAX_FIREBALL_LOD						4
 
 #define FIREBALL_NUM_LARGE_EXPLOSIONS 2
-
-extern int fireball_used[MAX_FIREBALL_TYPES];
 
 // all this moved here by Goober5000 because it makes more sense in the H file
 typedef struct fireball_lod {
@@ -57,6 +54,7 @@ typedef struct fireball_info {
 	float				exp_color[3];	// red, green, blue
 
 	bool	use_3d_warp;
+	bool	fireball_used;
 
 	char	warp_glow[NAME_LENGTH];
 	int		warp_glow_bitmap;
@@ -66,8 +64,7 @@ typedef struct fireball_info {
 	int		warp_model_id;
 } fireball_info;
 
-extern fireball_info Fireball_info[MAX_FIREBALL_TYPES];
-extern int Num_fireball_types;
+extern SCP_vector<fireball_info> Fireball_info;
 
 // flag values for fireball struct flags member
 #define	FBF_WARP_CLOSE_SOUND_PLAYED		(1<<0)
@@ -152,5 +149,8 @@ extern bool Fireball_warp_flash;
 
 // Cyborg - get a count of how many valid fireballs are in the mission.
 int fireball_get_count();
+
+// Goober5000 - stuffs fireballs and checks that indexes are in bounds
+void stuff_fireball_index_list(SCP_vector<int> &list, const char *name);
 
 #endif /* _FIREBALLS_H */

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -132,8 +132,8 @@ void parse_ssm(const char *filename)
 				{
 					int temp = atoi(unique_id);
 
-					if ((temp < 0) || (temp >= Num_fireball_types))
-						error_display(0, "Fireball index [%d] out of range (should be 0-%d) for SSM strike [%s]", temp, Num_fireball_types - 1, s->name);
+					if (!SCP_vector_inbounds(Fireball_info, temp))
+						error_display(0, "Fireball index [%d] out of range (should be 0-%d) for SSM strike [%s]", temp, static_cast<int>(Fireball_info.size()) - 1, s->name);
 					else
 						s->fireball_type = temp;
 				}

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -234,6 +234,7 @@ void stuff_flagset(T *dest) {
 }
 
 extern size_t stuff_int_list(int *ilp, size_t max_ints, int lookup_type = RAW_INTEGER_TYPE);
+extern void stuff_int_list(SCP_vector<int> &ilp, int lookup_type = RAW_INTEGER_TYPE);
 extern size_t stuff_float_list(float* flp, size_t max_floats);
 extern void stuff_float_list(SCP_vector<float>& flp);
 extern size_t stuff_vec3d_list(vec3d *vlp, size_t max_vecs);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3995,7 +3995,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 				if (type2 == SEXP_ATOM_NUMBER || can_construe_as_integer(CTEXT(node)))
 				{
 					int num = atoi(CTEXT(node));
-					if (num < 0 || num >= Num_fireball_types)
+					if (!SCP_vector_inbounds(Fireball_info, num))
 					{
 						return SEXP_CHECK_NUM_RANGE_INVALID;
 					}
@@ -14234,7 +14234,7 @@ void sexp_explosion_effect(int n)
 		{
 			fireball_type = FIREBALL_EXPLOSION_LARGE2;
 		}
-		else if (num >= Num_fireball_types)
+		else if (!SCP_vector_inbounds(Fireball_info, num))
 		{
 			Warning(LOCATION, "explosion-effect fireball type is out of range; quitting the explosion...\n");
 			return;
@@ -14431,7 +14431,7 @@ void sexp_warp_effect(int n)
 		{
 			fireball_type = FIREBALL_KNOSSOS;
 		}
-		else if (num >= Num_fireball_types)
+		else if (!SCP_vector_inbounds(Fireball_info, num))
 		{
 			Warning(LOCATION, "warp-effect fireball type is out of range; quitting the warp...\n");
 			return;

--- a/code/scripting/api/libs/tables.cpp
+++ b/code/scripting/api/libs/tables.cpp
@@ -220,7 +220,7 @@ ADE_FUNC(__len, l_Tables_FireballClasses, NULL, "Number of fireball classes", "n
 	if (!fireballs_inited)
 		return ade_set_args(L, "i", 0);
 
-	return ade_set_args(L, "i", Num_fireball_types);
+	return ade_set_args(L, "i", static_cast<int>(Fireball_info.size()));
 }
 
 //*****SUBLIBRARY: Tables/SimulatedSpeechOverrides

--- a/code/scripting/api/objs/fireballclass.cpp
+++ b/code/scripting/api/objs/fireballclass.cpp
@@ -18,7 +18,7 @@ ADE_FUNC(__tostring, l_Fireballclass, NULL, "Fireball class name", "string", "Fi
 	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx))
 		return ade_set_error(L, "s", "");
 
 	return ade_set_args(L, "s", Fireball_info[idx].unique_id);
@@ -30,10 +30,10 @@ ADE_FUNC(__eq, l_Fireballclass, "fireballclass, fireballclass", "Checks if the t
 	if(!ade_get_args(L, "oo", l_Fireballclass.Get(&idx1), l_Fireballclass.Get(&idx2)))
 		return ade_set_error(L, "b", false);
 
-	if(idx1 < 0 || idx1 >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx1))
 		return ade_set_error(L, "b", false);
 
-	if(idx2 < 0 || idx2 >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx2))
 		return ade_set_error(L, "b", false);
 
 	return ade_set_args(L, "b", idx1 == idx2);
@@ -45,7 +45,7 @@ ADE_VIRTVAR(UniqueID, l_Fireballclass, "string", "Fireball class name", "string"
 	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx))
 		return ade_set_error(L, "s", "");
 
 	if (ADE_SETTING_VAR)
@@ -60,7 +60,7 @@ ADE_VIRTVAR(Filename, l_Fireballclass, NULL, "Fireball class animation filename 
 	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx))
 		return ade_set_error(L, "s", "");
 
 	//Currently not settable as the bitmaps are only loaded once at level start
@@ -76,7 +76,7 @@ ADE_VIRTVAR(NumberFrames, l_Fireballclass, NULL, "Amount of frames the animation
 	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "i", -1);
 
-	if(idx < 0 || idx >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx))
 		return ade_set_error(L, "i", -1);
 
 	if (ADE_SETTING_VAR)
@@ -91,7 +91,7 @@ ADE_VIRTVAR(FPS, l_Fireballclass, NULL, "The FPS with which this fireball's anim
 	if (!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_error(L, "i", -1);
 
-	if (idx < 0 || idx >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx))
 		return ade_set_error(L, "i", -1);
 
 	if (ADE_SETTING_VAR)
@@ -106,7 +106,7 @@ ADE_FUNC(isValid, l_Fireballclass, NULL, "Detects whether handle is valid", "boo
 	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ADE_RETURN_NIL;
 
-	if(idx < 0 || idx >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx))
 		return ADE_RETURN_FALSE;
 
 	return ADE_RETURN_TRUE;
@@ -118,7 +118,7 @@ ADE_FUNC(getTableIndex, l_Fireballclass, NULL, "Gets the index value of the fire
 	if(!ade_get_args(L, "o", l_Fireballclass.Get(&idx)))
 		return ade_set_args(L, "i", -1);
 
-	if(idx < 0 || idx >= Num_fireball_types)
+	if (!SCP_vector_inbounds(Fireball_info, idx))
 		return ade_set_args(L, "i", -1);
 
 	return ade_set_args(L, "i", idx + 1);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3776,10 +3776,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 	parse_game_sound("$Shockwave Sound:", &sci->blast_sound_id);
 
 	if(optional_string("$Explosion Animations:")){
-		int temp[MAX_FIREBALL_TYPES];
-		auto parsed_ints = stuff_int_list(temp, MAX_FIREBALL_TYPES, RAW_INTEGER_TYPE);
-		sip->explosion_bitmap_anims.clear();
-		sip->explosion_bitmap_anims.insert(sip->explosion_bitmap_anims.begin(), temp, temp+parsed_ints);
+		stuff_fireball_index_list(sip->explosion_bitmap_anims, sci->name);
 	}
 
 	if (optional_string("$Weapon Model Draw Distance:")) {
@@ -5808,10 +5805,7 @@ static void parse_ship_type(const char *filename, const bool replace)
 
 	if(optional_string("$Explosion Animations:"))
 	{
-		int temp[MAX_FIREBALL_TYPES];
-		auto parsed_ints = stuff_int_list(temp, MAX_FIREBALL_TYPES, RAW_INTEGER_TYPE);
-		stp->explosion_bitmap_anims.clear();
-		stp->explosion_bitmap_anims.insert(stp->explosion_bitmap_anims.begin(), temp, temp+parsed_ints);
+		stuff_fireball_index_list(stp->explosion_bitmap_anims, stp->name);
 	}
 
 	auto skip_str = "$Skip Death Roll Percent Chance:";
@@ -18142,7 +18136,8 @@ void ship_page_in()
 	int num_ship_types_used = 0;
 	int test_id __UNUSED = -1;
 
-	memset( fireball_used, 0, sizeof(int) * MAX_FIREBALL_TYPES );
+	for (auto& fi : Fireball_info)
+		fi.fireball_used = false;
 
 	i = 0;
 	for (auto sip = Ship_info.begin(); sip != Ship_info.end(); i++, ++sip) {
@@ -18256,15 +18251,13 @@ void ship_page_in()
 
 		// Page in the shockwave stuff. -C
 		shockwave_create_info_load(&sip->shockwave);
-		if(!sip->explosion_bitmap_anims.empty()) {
-			int num_fireballs = (int)sip->explosion_bitmap_anims.size();
-			for(j = 0; j < num_fireballs; j++){
-				fireball_used[sip->explosion_bitmap_anims[j]] = 1;
+		if (!sip->explosion_bitmap_anims.empty()) {
+			for (int explosion_bitmap_anim: sip->explosion_bitmap_anims) {
+				Fireball_info[explosion_bitmap_anim].fireball_used = true;
 			}
-		} else if(sip->class_type >= 0 && !Ship_types[sip->class_type].explosion_bitmap_anims.empty()) { 
-			int num_fireballs = (int)Ship_types[sip->class_type].explosion_bitmap_anims.size();
-			for(j = 0; j < num_fireballs; j++){
-				fireball_used[Ship_types[sip->class_type].explosion_bitmap_anims[j]] = 1;
+		} else if (sip->class_type >= 0 && !Ship_types[sip->class_type].explosion_bitmap_anims.empty()) {
+			for (int explosion_bitmap_anim: Ship_types[sip->class_type].explosion_bitmap_anims) {
+				Fireball_info[explosion_bitmap_anim].fireball_used = true;
 			}
 		}
 	}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2634,8 +2634,8 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 				}
 			}
 			else {
-				if ((temp < 0) || (temp >= Num_fireball_types)) {
-					error_display(0, "Fireball index [%d] out of range (should be 0-%d) for LSSM weapon [%s].", temp, Num_fireball_types - 1, wip->name);
+				if (!SCP_vector_inbounds(Fireball_info, temp)) {
+					error_display(0, "Fireball index [%d] out of range (should be 0-%d) for LSSM weapon [%s].", temp, static_cast<int>(Fireball_info.size()) - 1, wip->name);
 					wip->lssm_warpeffect = FIREBALL_WARP;
 				}
 				else {

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -7654,9 +7654,9 @@ sexp_list_item *sexp_tree::get_listing_opf_fireball()
 {
 	sexp_list_item head;
 
-	for (int i = 0; i < Num_fireball_types; ++i)
+	for (const auto &fi: Fireball_info)
 	{
-		char *unique_id = Fireball_info[i].unique_id;
+		auto unique_id = fi.unique_id;
 
 		if (strlen(unique_id) > 0)
 			head.add_data(unique_id);

--- a/fred2/warpparamsdlg.cpp
+++ b/fred2/warpparamsdlg.cpp
@@ -73,8 +73,8 @@ BOOL warp_params_dlg::OnInitDialog()
 	ptr->ResetContent();
 	for (int i = 0; i < Num_warp_types; ++i)
 		ptr->AddString(Warp_types[i]);
-	for (int i = 0; i < Num_fireball_types; ++i)
-		ptr->AddString(Fireball_info[i].unique_id);
+	for (const auto &fi: Fireball_info)
+		ptr->AddString(fi.unique_id);
 
 	// find the params of the first marked ship
 	WarpParams *params = nullptr;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -5264,9 +5264,9 @@ sexp_list_item *sexp_tree::get_listing_opf_fireball()
 {
 	sexp_list_item head;
 
-	for (int i = 0; i < Num_fireball_types; ++i)
+	for (const auto &fi: Fireball_info)
 	{
-		char *unique_id = Fireball_info[i].unique_id;
+		auto unique_id = fi.unique_id;
 
 		if (strlen(unique_id) > 0)
 			head.add_data(unique_id);


### PR DESCRIPTION
As requested by Event Horizon, this removes the limit on fireball types.  The fixed array has been replaced with a vector and the relevant code updated accordingly.  There is also a new version of `stuff_int_list()` to parse ints into a vector.

This also adds bounds checking for explosion animations that are parsed for ship classes, ship types, and asteroids, since previously there was no guarantee that the indexes would be in range.

Tested by myself and Ice Cream Man.