### PR TITLE
Add waypoints-no-formation flag

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -32,6 +32,8 @@ namespace AI {
 		Unload_primaries,			//	Fire primaries as fast as possible!
 		Trying_unsuccessfully_to_warp,	// Trying to warp, but can't warp at the moment
 		Free_afterburner_use,		// Use afterburners while following waypoints or flying towards objects
+		Waypoints_no_formation,		// wont get into formation when running waypoints as part of a wing
+
 
 		NUM_VALUES
 	};

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -216,11 +216,13 @@ int	Mission_all_attack = 0;					//	!0 means all teams attack all teams.
 ai_flag_name Ai_flag_names[] = {
 	{AI::AI_Flags::No_dynamic,				"no-dynamic",			},
 	{AI::AI_Flags::Free_afterburner_use,	"free-afterburner-use",	},
+	{AI::AI_Flags::Waypoints_no_formation,		"waypoints-no-formation" },
 };
 
 ai_flag_description Ai_flag_descriptions[] = {
 	{AI::AI_Flags::No_dynamic,				"Will stop allowing the AI to pursue dynamic goals (eg: chasing ships it was not ordered to)."},
 	{AI::AI_Flags::Free_afterburner_use,	"Will allow AI to use afterburners when attacking a big ship, flying to a target position, guarding a ship, and flying in formation."},
+	{AI::AI_Flags::Waypoints_no_formation,		"Ship will not form up with its wingmates while running waypoints with them." },
 };
 
 extern const int Num_ai_flag_names = sizeof(Ai_flag_names) / sizeof(ai_flag_name);
@@ -12648,6 +12650,11 @@ int ai_formation()
 	}
 	
 	if (aip->mode == AIM_WAYPOINTS) {
+		// skip if they have the flag
+		if (aip->ai_flags[AI::AI_Flags::Waypoints_no_formation] || 
+			(shipp->wingnum >= 0 && Wings[shipp->wingnum].flags[Ship::Wing_Flags::Waypoints_no_formation]))
+			return 1;
+
 		if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_ai_path_order_bug]){
 			// skip if wing leader has no waypoint order or a different waypoint list
 			// ...or if it's a different start index or direction

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -669,7 +669,8 @@ wing_flag_name Wing_flag_names[] = {
 	{ Wing_Flags::No_arrival_warp,					"no-arrival-warp" },
 	{ Wing_Flags::No_departure_warp,				"no-departure-warp" },
 	{ Wing_Flags::Same_arrival_warp_when_docked,	"same-arrival-warp-when-docked" },
-	{ Wing_Flags::Same_departure_warp_when_docked,	"same-departure-warp-when-docked" }
+	{ Wing_Flags::Same_departure_warp_when_docked,	"same-departure-warp-when-docked" },
+	{ Wing_Flags::Waypoints_no_formation,	"waypoints-no-formation" }
 };
 
 wing_flag_description Wing_flag_descriptions[] = {
@@ -679,7 +680,8 @@ wing_flag_description Wing_flag_descriptions[] = {
 	{ Wing_Flags::No_arrival_warp,					"No ship in the wing will use a warp effect upon arrival."},
 	{ Wing_Flags::No_departure_warp,				"No ship in the wing will use a warp effect upon departure."},
 	{ Wing_Flags::Same_arrival_warp_when_docked,	"All ships in the wing will use the same warp effect size upon arrival as if they were not docked instead of the enlarged aggregate size."},
-	{ Wing_Flags::Same_departure_warp_when_docked,	"All ships in the wing will use the same warp effect size upon departure as if they were not docked instead of the enlarged aggregate size."}
+	{ Wing_Flags::Same_departure_warp_when_docked,	"All ships in the wing will use the same warp effect size upon departure as if they were not docked instead of the enlarged aggregate size."},
+	{ Wing_Flags::Waypoints_no_formation,		"Ships in the wing will not try to form up when running a waypoint together." },
 };
 
 extern const size_t Num_wing_flag_names = sizeof(Wing_flag_names) / sizeof(wing_flag_name);

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -296,6 +296,7 @@ namespace Ship {
 		Same_arrival_warp_when_docked,		// Goober5000
 		Same_departure_warp_when_docked,	// Goober5000
 		No_first_wave_message,		// don't play arrival message for the first wave
+		Waypoints_no_formation, // wing will not try to form up when running a waypoint together
 
 		NUM_VALUES
 	};


### PR DESCRIPTION
Ships in a wing automatically getting into formation with their wing leader when they share the same waypoint order is nice, but can surprise and frustrate fredders in certain circumstances, #6056 and $fix ai path order bug being good examples of this. They were genuine bugs which deserved fixing anyway, but sometimes its more hassle to the fredder than its worth, so this lets them turn it on and off at will.