### PR TITLE
Fred autorecover

### DIFF
--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -377,6 +377,7 @@ struct CFileLocation {
 	SCP_string full_name;
 	size_t size          = 0;
 	size_t offset        = 0;
+	time_t m_time        = 0;
 	const void* data_ptr = nullptr;
 
 	explicit CFileLocation(bool found_in = false) : found(found_in) {}

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -77,7 +77,7 @@ CFREDDoc::CFREDDoc() {
 
 	FREDDoc_ptr = this;
 
-	for (i = 0; i < BACKUP_DEPTH; i++)
+	for (i = 0; i < MISSION_BACKUP_DEPTH; i++)
 		undo_desc[i].Empty();
 }
 
@@ -124,7 +124,7 @@ bool CFREDDoc::autoload() {
 	cf_delete(backup_name, CF_TYPE_MISSIONS);
 
 	// Rename Backups. .002 becomes .001, .003 becomes .002, etc.
-	for (i = 1; i < BACKUP_DEPTH; i++) {
+	for (i = 1; i < MISSION_BACKUP_DEPTH; i++) {
 		sprintf(backup_name + len, ".%.3d", i + 1);
 		sprintf(name + len, ".%.3d", i);
 		cf_rename(backup_name, name, CF_TYPE_MISSIONS);
@@ -155,7 +155,7 @@ int CFREDDoc::autosave(char *desc) {
 		return -1;
 	}
 
-	for (i = BACKUP_DEPTH; i > 1; i--) {
+	for (i = MISSION_BACKUP_DEPTH; i > 1; i--) {
 		undo_desc[i] = undo_desc[i - 1];
 	}
 
@@ -604,7 +604,7 @@ BOOL CFREDDoc::OnOpenDocument(LPCTSTR pathname)
 	// now check all the autosaves
 	SCP_string backup_name;
 	CFileLocation backup_res;
-	for (int i = 1; i <= BACKUP_DEPTH; ++i)
+	for (int i = 1; i <= MISSION_BACKUP_DEPTH; ++i)
 	{
 		backup_name = MISSION_BACKUP_NAME;
 		char extension[5];

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -535,7 +535,7 @@ void CFREDDoc::OnFileImportFSM() {
 	if (num_files > 1)
 	{
 		create_new_mission();
-		MessageBox(NULL, "Import complete.  Please check the destination folder to verify all missions were imported successfully.", "Status", MB_OK);
+		Fred_view_wnd->MessageBox("Import complete.  Please check the destination folder to verify all missions were imported successfully.", "Status", MB_OK);
 	}
 	else if (num_files == 1)
 	{
@@ -816,7 +816,7 @@ Assert((flag == 0) || (flag == 1));
 
 //	fp = cfopen(filename, flag ? "wb" : "rb");
 //	if (!fp)
-//		MessageBox(NULL, strerror(errno), "File Open Error!", MB_ICONSTOP);
+//		Fred_view_wnd->MessageBox(strerror(errno), "File Open Error!", MB_ICONSTOP);
 
 //	Find highest used object if writing.
 if (flag == 1) {

--- a/fred2/freddoc.h
+++ b/fred2/freddoc.h
@@ -10,7 +10,8 @@
  */
 #include "MissionSave.h"
 
-#define MISSION_BACKUP_NAME "Backup"
+#define MISSION_BACKUP_NAME     "Backup"
+#define MISSION_BACKUP_DEPTH    9
 
 #define US_WORLD_CHANGED    0x01
 #define US_VIEW_CHANGED     0x02
@@ -145,7 +146,7 @@ public:
 	virtual void Dump(CDumpContext &dc) const;
 #endif
 
-	CString undo_desc[BACKUP_DEPTH + 1];    //!< String array of the undo descriptions
+	CString undo_desc[MISSION_BACKUP_DEPTH + 1];    //!< String array of the undo descriptions
 
 protected:
 	/**

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -810,11 +810,14 @@ void clear_mission(bool fast_reload)
 			}
 		}
 	}
-	t = CTime::GetCurrentTime();
+
+	time_t currentTime;
+	time(&currentTime);
+	auto timeinfo = localtime(&currentTime);
 
 	strcpy_s(The_mission.name, "Untitled");
 	The_mission.author = str;
-	strcpy_s(The_mission.created, t.Format("%x at %X"));
+	time_to_mission_info_string(timeinfo, The_mission.created, DATE_TIME_LENGTH - 1);
 	strcpy_s(The_mission.modified, The_mission.created);
 	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.");
 	strcpy_s(The_mission.mission_desc, "Put mission description here");
@@ -2534,4 +2537,9 @@ void update_texture_replacements(const char *old_name, const char *new_name)
 		if (!stricmp(ii->ship_name, old_name))
 			strcpy_s(ii->ship_name, new_name);
 	}
+}
+
+void time_to_mission_info_string(const std::tm* src, char* dest, size_t dest_max_len)
+{
+	std::strftime(dest, dest_max_len, "%x at %X", src);
 }

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -143,4 +143,6 @@ extern void stuff_special_arrival_anchor_name(char* buf, int iff_index, int rest
 extern void stuff_special_arrival_anchor_name(char* buf, int anchor_num, int retail_format);
 extern void update_texture_replacements(const char* old_name, const char* new_name);
 
+extern void time_to_mission_info_string(const std::tm* src, char* dest, size_t dest_max_len);
+
 #endif

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3126,10 +3126,11 @@ int CFred_mission_save::save_mission_info()
 
 void CFred_mission_save::save_mission_internal(const char *pathname)
 {
-	CTime t;
+	time_t currentTime;
+	time(&currentTime);
+	auto timeinfo = localtime(&currentTime);
 
-	t = CTime::GetCurrentTime();
-	strcpy_s(The_mission.modified, t.Format("%x at %X"));
+	time_to_mission_info_string(timeinfo, The_mission.modified, DATE_TIME_LENGTH - 1);
 
 	// Migrate the version!
 	The_mission.required_fso_version = MISSION_VERSION;

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -92,9 +92,9 @@ int CFred_mission_save::autosave_mission_file(char *pathname)
 	auto len = strlen(pathname);
 	strcpy_s(backup_name, pathname);
 	strcpy_s(name2, pathname);
-	sprintf(backup_name + len, ".%.3d", BACKUP_DEPTH);
+	sprintf(backup_name + len, ".%.3d", MISSION_BACKUP_DEPTH);
 	cf_delete(backup_name, CF_TYPE_MISSIONS);
-	for (i = BACKUP_DEPTH; i > 1; i--) {
+	for (i = MISSION_BACKUP_DEPTH; i > 1; i--) {
 		sprintf(backup_name + len, ".%.3d", i - 1);
 		sprintf(name2 + len, ".%.3d", i);
 		cf_rename(backup_name, name2, CF_TYPE_MISSIONS);

--- a/fred2/missionsave.h
+++ b/fred2/missionsave.h
@@ -24,8 +24,6 @@
 
 struct sexp_container;
 
-#define BACKUP_DEPTH	9
-
 /**
  * @class CFred_mission_save
  *

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -33,6 +33,7 @@
 
 #include "object.h"
 #include "management.h"
+#include "util.h"
 #include "FredApplication.h"
 
 namespace {
@@ -418,13 +419,11 @@ void Editor::clearMission(bool fast_reload) {
 
 	time_t currentTime;
 	time(&currentTime);
-	auto tm_info = localtime(&currentTime);
-	char time_buffer[26];
-	strftime(time_buffer, 26, "%Y-%m-%d %H:%M:%S", tm_info);
+	auto timeinfo = localtime(&currentTime);
 
 	strcpy_s(The_mission.name, "Untitled");
 	The_mission.author = userName;
-	strcpy_s(The_mission.created, time_buffer);
+	time_to_mission_info_string(timeinfo, The_mission.created, DATE_TIME_LENGTH - 1);
 	strcpy_s(The_mission.modified, The_mission.created);
 	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.");
 	strcpy_s(The_mission.mission_desc, "Put mission description here");

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -127,6 +127,61 @@ void Editor::update() {
 	}
 }
 
+std::string Editor::maybeUseAutosave(const std::string& filepath)
+{
+	// first, just grab the info of this mission
+	if (!parse_main(filepath.c_str(), MPF_ONLY_MISSION_INFO))
+		return filepath;
+	SCP_string created = The_mission.created;
+	CFileLocation res = cf_find_file_location(filepath.c_str(), CF_TYPE_ANY);
+	time_t modified = res.m_time;
+	if (!res.found)
+	{
+		UNREACHABLE("Couldn't find path '%s' even though parse_main() succeeded!", filepath.c_str());
+		return filepath;	// just load the actual specified file
+	}
+
+	// now check all the autosaves
+	SCP_string backup_name;
+	CFileLocation backup_res;
+	for (int i = 1; i <= MISSION_BACKUP_DEPTH; ++i)
+	{
+		backup_name = MISSION_BACKUP_NAME;
+		char extension[5];
+		sprintf(extension, ".%.3d", i);
+		backup_name += extension;
+
+		backup_res = cf_find_file_location(backup_name.c_str(), CF_TYPE_MISSIONS);
+		if (backup_res.found && parse_main(backup_res.full_name.c_str(), MPF_ONLY_MISSION_INFO))
+		{
+			SCP_string this_created = The_mission.created;
+			time_t this_modified = backup_res.m_time;
+
+			if (created == this_created && this_modified > modified)
+				break;
+		}
+
+		backup_name.clear();
+	}
+
+	// maybe load from the backup instead
+	if (!backup_name.empty())
+	{
+		SCP_string prompt = "Autosaved file ";
+		prompt += backup_name;
+		prompt += " has a file modification time more recent than the specified file.  Do you want to load the autosave instead?";
+
+		auto z = _lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Question,
+																	"Recover from autosave",
+																	prompt.c_str(),
+																	{ DialogButton::Yes, DialogButton::No });
+		if (z == DialogButton::Yes)
+			return backup_res.full_name.c_str();
+	}
+
+	return filepath;
+}
+
 bool Editor::loadMission(const std::string& mission_name, int flags) {
 	char name[512], * old_name;
 	int i, j, k, ob;

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -15,6 +15,9 @@
 #include <memory>
 #include <stdexcept>
 
+#define MISSION_BACKUP_NAME     "Backup"
+#define MISSION_BACKUP_DEPTH    9
+
 namespace fso {
 namespace fred {
 

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -39,6 +39,8 @@ class Editor : public QObject {
 
 	void createNewMission();
 
+	std::string maybeUseAutosave(const std::string& filepath);
+
 	/*! Load a mission. */
 	bool loadMission(const std::string& filepath, int flags = 0);
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -79,9 +79,9 @@ int CFred_mission_save::autosave_mission_file(char* pathname)
 	auto len = strlen(pathname);
 	strcpy_s(backup_name, pathname);
 	strcpy_s(name2, pathname);
-	sprintf(backup_name + len, ".%.3d", BACKUP_DEPTH);
+	sprintf(backup_name + len, ".%.3d", MISSION_BACKUP_DEPTH);
 	cf_delete(backup_name, CF_TYPE_MISSIONS);
-	for (i = BACKUP_DEPTH; i > 1; i--) {
+	for (i = MISSION_BACKUP_DEPTH; i > 1; i--) {
 		sprintf(backup_name + len, ".%.3d", i - 1);
 		sprintf(name2 + len, ".%.3d", i);
 		cf_rename(backup_name, name2, CF_TYPE_MISSIONS);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3035,11 +3035,11 @@ int CFred_mission_save::save_mission_info()
 
 void CFred_mission_save::save_mission_internal(const char* pathname)
 {
-	time_t rawtime;
+	time_t currentTime;
+	time(&currentTime);
+	auto timeinfo = localtime(&currentTime);
 
-	time(&rawtime);
-	auto timeinfo = localtime(&rawtime);
-	strftime(The_mission.modified, sizeof(The_mission.modified), "%x at %X", timeinfo);
+	time_to_mission_info_string(timeinfo, The_mission.modified, DATE_TIME_LENGTH - 1);
 
 	// Migrate the version!
 	The_mission.required_fso_version = MISSION_VERSION;

--- a/qtfred/src/mission/missionsave.h
+++ b/qtfred/src/mission/missionsave.h
@@ -27,8 +27,6 @@ struct sexp_container;
 namespace fso {
 namespace fred {
 
-#define BACKUP_DEPTH    9
-
 enum class MissionFormat {
 	RETAIL = 0, STANDARD = 1, COMPATIBILITY_MODE = 2
 };

--- a/qtfred/src/mission/util.cpp
+++ b/qtfred/src/mission/util.cpp
@@ -25,6 +25,7 @@ void stuff_special_arrival_anchor_name(char *buf, int iff_index, int restrict_to
 
 	strlwr(buf);
 }
+
 void stuff_special_arrival_anchor_name(char* buf, int anchor_num, int retail_format) {
 	// filter out iff
 	int iff_index = anchor_num;
@@ -57,6 +58,7 @@ void generate_weaponry_usage_list_team(int team, int* arr) {
 		}
 	}
 }
+
 void generate_weaponry_usage_list_wing(int wing_num, int* arr) {
 	int i, j;
 	ship_weapon* swp;
@@ -84,4 +86,9 @@ void generate_weaponry_usage_list_wing(int wing_num, int* arr) {
 			}
 		}
 	}
+}
+
+void time_to_mission_info_string(const std::tm* src, char* dest, size_t dest_max_len)
+{
+	std::strftime(dest, dest_max_len, "%x at %X", src);
 }

--- a/qtfred/src/mission/util.h
+++ b/qtfred/src/mission/util.h
@@ -8,3 +8,5 @@ void stuff_special_arrival_anchor_name(char *buf, int anchor_num, int retail_for
 void generate_weaponry_usage_list_team(int team, int *arr);
 
 void generate_weaponry_usage_list_wing(int wing_num, int *arr);
+
+void time_to_mission_info_string(const std::tm* src, char* dest, size_t dest_max_len);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -143,7 +143,9 @@ void FredView::loadMissionFile(const QString& pathName) {
 	try {
 		QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
-		fred->loadMission(pathName.toStdString());
+		auto pathToLoad = fred->maybeUseAutosave(pathName.toStdString());
+
+		fred->loadMission(pathToLoad);
 
 		QApplication::restoreOverrideCursor();
 	} catch (const fso::fred::mission_load_error&) {


### PR DESCRIPTION
FRED will periodically autosave the mission to a series of Backup.NNN files in %APPDATA%, but this is not widely known, and in any case the user typically must restore the file himself in the event of a crash.  This PR adds code to the File -> Open routine that will automatically check all of the autosaved files whenever the user opens the mission.  If an autosaved file has the same creation date but a newer modification time than the desired file, FRED will prompt the user to open the autosave instead.

This PR adds equivalent code to qtFRED as well, but the autosaving of Backup.NNN files has not been implemented in qtFRED yet.

Implements #6118.