### PR TITLE
Fix DRADIS blips

### DIFF
--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -35,7 +35,7 @@
 
 HudGaugeRadarDradis::HudGaugeRadarDradis():
 HudGaugeRadar(HUD_OBJECT_RADAR_BSG, 255, 255, 255), 
-xy_plane(-1), xz_yz_plane(-1), sweep_plane(-1), target_brackets(-1), unknown_contact_icon(-1), sweep_duration(6.0), sweep_percent(0.0), scale(1.20f), sub_y_clip(false)
+xy_plane(-1), xz_yz_plane(-1), sweep_plane(-1), target_brackets(-1), unknown_contact_icon(-1), sweep_duration(6 * MILLISECONDS_PER_SECOND), sweep_percent(0.0f), scale(1.20f), sub_y_clip(false)
 {
 	vm_vec_copy_scale(&sweep_normal_x, &vmd_zero_vector, 1.0f);
 	vm_vec_copy_scale(&sweep_normal_y, &vmd_zero_vector, 1.0f);
@@ -138,7 +138,7 @@ void HudGaugeRadarDradis::plotBlip(blip* b, vec3d *pos, float *alpha)
 	if (b->last_update.isNever()) {
 		*alpha = 0.0f;
 	} else {
-		*alpha = ((sweep_duration - timestamp_since(b->last_update)) / sweep_duration) * fade_multi / 2.0f;
+		*alpha = ((sweep_duration - timestamp_since(b->last_update)) / i2fl(sweep_duration)) * fade_multi / 2.0f;
 
 		if (*alpha < 0.0f) {
 			*alpha = 0.0f;
@@ -382,7 +382,7 @@ void HudGaugeRadarDradis::drawSweeps()
 	if (sweep_plane == -1)
 		return;
 	
-	sweep_percent = (fmod(((float)game_get_overall_frametime() / (float)65536), sweep_duration) /  sweep_duration) * PI * 2; // convert to radians from 0 <-> 1
+	sweep_percent = (fmod(f2fl(game_get_overall_frametime()) * MILLISECONDS_PER_SECOND, static_cast<float>(sweep_duration)) /  sweep_duration) * PI2; // convert to radians from 0 <-> 1
 	float sweep_perc_z = sweep_percent * -0.5f;
 
 	vec3d sweep_a;

--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -117,32 +117,33 @@ void HudGaugeRadarDradis::plotBlip(blip* b, vec3d *pos, float *alpha)
 	*pos = b->position;
 	vm_vec_normalize(pos);
 
-	if (ship_is_tagged(b->objp)) {
+	auto objp = &Objects[b->objnum];
+
+	if (ship_is_tagged(objp)) {
 		*alpha = 1.0f;
 		return;
 	}
 
 	float fade_multi = 1.5f;
 	
-	if (b->objp->type == OBJ_SHIP) {
-		if (Ships[b->objp->instance].flags[Ship::Ship_Flags::Stealth]) {
+	if (objp->type == OBJ_SHIP) {
+		if (Ships[objp->instance].flags[Ship::Ship_Flags::Stealth]) {
 			fade_multi *= 2.0f;
 		}
 	}
+
+	auto& last_update = Blip_last_update[b->objnum];
 	
 	// If the blip has been pinged by the local x-axis sweep, update
 	if (std::abs(vm_vec_dot(&sweep_normal_x, pos)) < 0.01f) {
-		b->last_update = _timestamp();
+		last_update = _timestamp();
 	}
 
-	if (b->last_update.isNever()) {
+	if (last_update.isNever()) {
 		*alpha = 0.0f;
 	} else {
-		*alpha = ((sweep_duration - timestamp_since(b->last_update)) / i2fl(sweep_duration)) * fade_multi / 2.0f;
-
-		if (*alpha < 0.0f) {
-			*alpha = 0.0f;
-		}
+		*alpha = ((sweep_duration - timestamp_since(last_update)) / i2fl(sweep_duration)) * fade_multi / 2.0f;
+		CLAMP(*alpha, 0.0f, 1.0f);
 	}
 }
 

--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -35,7 +35,7 @@
 
 HudGaugeRadarDradis::HudGaugeRadarDradis():
 HudGaugeRadar(HUD_OBJECT_RADAR_BSG, 255, 255, 255), 
-xy_plane(-1), xz_yz_plane(-1), sweep_plane(-1), target_brackets(-1), unknown_contact_icon(-1), sweep_duration(6 * MILLISECONDS_PER_SECOND), sweep_percent(0.0f), scale(1.20f), sub_y_clip(false)
+xy_plane(-1), xz_yz_plane(-1), sweep_plane(-1), target_brackets(-1), unknown_contact_icon(-1), sweep_duration(6 * MILLISECONDS_PER_SECOND), sweep_angle(0.0f), scale(1.20f), sub_y_clip(false)
 {
 	vm_vec_copy_scale(&sweep_normal_x, &vmd_zero_vector, 1.0f);
 	vm_vec_copy_scale(&sweep_normal_y, &vmd_zero_vector, 1.0f);
@@ -382,16 +382,18 @@ void HudGaugeRadarDradis::drawSweeps()
 	if (sweep_plane == -1)
 		return;
 	
-	sweep_percent = (fmod(f2fl(game_get_overall_frametime()) * MILLISECONDS_PER_SECOND, static_cast<float>(sweep_duration)) /  sweep_duration) * PI2; // convert to radians from 0 <-> 1
-	float sweep_perc_z = sweep_percent * -0.5f;
+	float modulo = fmod(f2fl(game_get_overall_frametime()) * MILLISECONDS_PER_SECOND, static_cast<float>(sweep_duration));
+	float fraction = modulo / sweep_duration;
+	sweep_angle = fraction * PI2; // convert to radians from 0 <-> 1
+	float sweep_angle_z = sweep_angle * -0.5f;
 
 	vec3d sweep_a;
 	vec3d sweep_b;
 	vec3d sweep_c;
 	
-	vm_rot_point_around_line(&sweep_a, &vmd_y_vector, sweep_percent, &vmd_zero_vector, &vmd_z_vector); // Sweep line: XZ
-	vm_rot_point_around_line(&sweep_b, &vmd_y_vector, sweep_percent, &vmd_zero_vector, &vmd_x_vector); // Sweep line: YZ
-	vm_rot_point_around_line(&sweep_c, &vmd_x_vector, sweep_perc_z, &vmd_zero_vector, &vmd_y_vector); // Sweep line: XY
+	vm_rot_point_around_line(&sweep_a, &vmd_y_vector, sweep_angle, &vmd_zero_vector, &vmd_z_vector); // Sweep line: XZ
+	vm_rot_point_around_line(&sweep_b, &vmd_y_vector, sweep_angle, &vmd_zero_vector, &vmd_x_vector); // Sweep line: YZ
+	vm_rot_point_around_line(&sweep_c, &vmd_x_vector, sweep_angle_z, &vmd_zero_vector, &vmd_y_vector); // Sweep line: XY
 	
 	vm_vec_copy_scale(&sweep_normal_x, &sweep_a, 1.0f);
 	vm_vec_copy_scale(&sweep_normal_y, &sweep_b, 1.0f);
@@ -409,11 +411,9 @@ void HudGaugeRadarDradis::drawSweeps()
 		g3_render_rect_oriented(&mat_params, &vmd_zero_vector, &sweep_b, scale, scale);
 		g3_render_rect_oriented(&mat_params, &vmd_zero_vector, &sweep_c, scale, scale);
 
-		float rotation = sweep_percent;
-
-		vm_rot_point_around_line(&sweep_a, &vmd_y_vector, rotation, &vmd_zero_vector, &vmd_z_vector); // Sweep line: XZ
-		vm_rot_point_around_line(&sweep_b, &vmd_y_vector, rotation, &vmd_zero_vector, &vmd_x_vector); // Sweep line: YZ
-		vm_rot_point_around_line(&sweep_c, &vmd_x_vector,sweep_perc_z, &vmd_zero_vector, &vmd_y_vector); // Sweep line: YZ
+		vm_rot_point_around_line(&sweep_a, &vmd_y_vector, sweep_angle, &vmd_zero_vector, &vmd_z_vector); // Sweep line: XZ
+		vm_rot_point_around_line(&sweep_b, &vmd_y_vector, sweep_angle, &vmd_zero_vector, &vmd_x_vector); // Sweep line: YZ
+		vm_rot_point_around_line(&sweep_c, &vmd_x_vector, sweep_angle_z, &vmd_zero_vector, &vmd_y_vector); // Sweep line: YZ
 		
 		//gr_set_bitmap(sweep_plane, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL);
 

--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -399,11 +399,6 @@ void HudGaugeRadarDradis::drawSweeps()
 	vm_vec_copy_scale(&sweep_normal_y, &sweep_b, 1.0f);
 	
 	g3_start_instance_matrix(&vmd_zero_vector, /*&Player_obj->orient*/&vmd_identity_matrix, true);
-//		gr_set_bitmap(sweep_plane, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, 1.0f);
-		
-// 		g3_draw_polygon(&vmd_zero_vector, &sweep_a, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT);
-// 		g3_draw_polygon(&vmd_zero_vector, &sweep_b, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT);
-// 		g3_draw_polygon(&vmd_zero_vector, &sweep_c, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT);
 
 		material mat_params;
 		material_set_unlit(&mat_params, sweep_plane, 1.0f, true, false);
@@ -415,40 +410,9 @@ void HudGaugeRadarDradis::drawSweeps()
 		vm_rot_point_around_line(&sweep_b, &vmd_y_vector, sweep_angle, &vmd_zero_vector, &vmd_x_vector); // Sweep line: YZ
 		vm_rot_point_around_line(&sweep_c, &vmd_x_vector, sweep_angle_z, &vmd_zero_vector, &vmd_y_vector); // Sweep line: YZ
 		
-		//gr_set_bitmap(sweep_plane, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL);
-
-// 		g3_draw_polygon(&vmd_zero_vector, &sweep_a, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT); // Sweep line: XZ
-// 		g3_draw_polygon(&vmd_zero_vector, &sweep_b, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT); // Sweep line: YZ
-// 		g3_draw_polygon(&vmd_zero_vector, &sweep_c, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT);
-
 		g3_render_rect_oriented(&mat_params, &vmd_zero_vector, &sweep_a, scale, scale); // Sweep line: XZ
 		g3_render_rect_oriented(&mat_params, &vmd_zero_vector, &sweep_b, scale, scale); // Sweep line: YZ
 		g3_render_rect_oriented(&mat_params, &vmd_zero_vector, &sweep_c, scale, scale);
-
-		/*int dist = 90;
-
-		for(int i = 1; i < dist; i++)
-		{
-			float rotation = sweep_percent - (i * RADIANS_PER_DEGREE);
-			float alpha	= (1.0f - (float)((float)i / (float)dist)) * 0.25f;
-			
-			//if (i < 2)
-				//alpha = 1.0f;
-
-			gr_set_bitmap(sweep_plane, GR_ALPHABLEND_FILTER, GR_BITBLT_MODE_NORMAL, alpha);
-			
-			vm_rot_point_around_line(&sweep_a, &vmd_y_vector, rotation, &vmd_zero_vector, &vmd_z_vector); // Sweep line: XZ
-			vm_rot_point_around_line(&sweep_b, &vmd_y_vector, rotation, &vmd_zero_vector, &vmd_x_vector); // Sweep line: YZ
-			
-			g3_draw_polygon(&vmd_zero_vector, &sweep_a, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT); // Sweep line: XZ
-			g3_draw_polygon(&vmd_zero_vector, &sweep_b, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT); // Sweep line: YZ
-			
-			if (i < (dist * 0.5f))
-			{
-				vm_rot_point_around_line(&sweep_c, &vmd_x_vector,sweep_perc_z + (i * RADIANS_PER_DEGREE), &vmd_zero_vector, &vmd_y_vector); // Sweep line: YZ
-				g3_draw_polygon(&vmd_zero_vector, &sweep_c, scale, scale, TMAP_FLAG_TEXTURED | TMAP_HTL_3D_UNLIT);
-			}
-		}*/
 		
 	g3_done_instance(true);
 }

--- a/code/radar/radardradis.h
+++ b/code/radar/radardradis.h
@@ -25,7 +25,7 @@ class HudGaugeRadarDradis: public HudGaugeRadar
 	int target_brackets;
 	int unknown_contact_icon;
 
-	float sweep_duration; // in seconds
+	int sweep_duration; // in milliseconds
 	float sweep_percent;
 
 	matrix view_perturb;

--- a/code/radar/radardradis.h
+++ b/code/radar/radardradis.h
@@ -26,7 +26,7 @@ class HudGaugeRadarDradis: public HudGaugeRadar
 	int unknown_contact_icon;
 
 	int sweep_duration; // in milliseconds
-	float sweep_percent;
+	float sweep_angle;
 
 	matrix view_perturb;
 	vec3d Orb_eye_position;

--- a/code/radar/radarsetup.h
+++ b/code/radar/radarsetup.h
@@ -36,10 +36,9 @@ typedef struct blip	{
 	int radar_color_image_2d;
 	int radar_image_size;
 	float radar_projection_size;
-	TIMESTAMP last_update;
 
 	float   dist;
-	object* objp;
+	int		objnum;
 } blip;
 
 
@@ -70,6 +69,8 @@ extern blip	Blip_dim_list[MAX_BLIP_TYPES];			// linked list of dim blips
 
 extern blip	Blips[MAX_BLIPS];								// blips pool
 extern int	N_blips;										// next blip index to take from pool
+
+extern SCP_map<int, TIMESTAMP> Blip_last_update;	// map of objnums to timestamps
 
 // blip flags
 #define BLIP_CURRENT_TARGET	(1<<0)

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -283,9 +283,14 @@ ADE_FUNC(findPointOnLineNearestSkewLine,
 	return ade_set_args(L, "o", l_Vector.Set(dest));
 }
 
-ADE_FUNC(getFrametimeOverall, l_Base, NULL, "The overall frame time in seconds since the engine has started", "number", "Overall time (seconds)")
+ADE_FUNC(getFrametimeOverall, l_Base, nullptr, "The overall frame time in fix units (seconds * 65536) since the engine has started", "number", "Overall time (fix units)")
 {
 	return ade_set_args(L, "x", game_get_overall_frametime());
+}
+
+ADE_FUNC(getSecondsOverall, l_Base, nullptr, "The overall time in seconds since the engine has started", "number", "Overall time (seconds)")
+{
+	return ade_set_args(L, "f", f2fl(game_get_overall_frametime()));
 }
 
 ADE_FUNC(getMissionFrametime, l_Base, nullptr, "Gets how long this frame is calculated to take. Use it to for animations, physics, etc to make incremental changes. Increased or decreased based on current time compression", "number", "Frame time (seconds)")

--- a/freespace2/freespace.h
+++ b/freespace2/freespace.h
@@ -123,7 +123,7 @@ void change_time_compression(float multiplier);
 // call this to set frametime properly (once per frame)
 void game_set_frametime(int state);
 
-// overall frametime of game, indepedent of mission timer
+// overall frametime of game in fix units (seconds * 65536), independent of mission timer
 fix game_get_overall_frametime();
 
 // Used to halt all looping game sounds


### PR DESCRIPTION
Several improvements and fixes to the DRADIS radar, one of which (tracking blip expiration) dates back to the original implementation.

1. Convert `sweep_duration` from seconds to milliseconds to work correctly with the timestamp system.  Also clarify use of `game_get_overall_frametime()`, especially with `ba.getFrametimeOverall()`; and add `ba.getSecondsOverall()` to do what `ba.getFrametimeOverall()` allegedly did.
2. Fix a bug where blips expired immediately every frame; they now track their expiration by object
3. Store object numbers rather than object pointers
4. Clamp both the high bound and the low bound of alpha values
5. Change sweep_percent field to sweep_angle to be more accurate
6. Remove some obsolete commented code

Follow-up to #5839.  Fixes blips immediately fading out in Solaris, BTRL, and Diaspora.