### PR TITLE
make initialization consistent among FSO, FRED, and qtFRED

### DIFF
--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -691,14 +691,6 @@ void brief_init_screen(int  /*multiplayer_flag*/)
 	bscreen.resize          = GR_RESIZE_MENU;
 }
 
-// --------------------------------------------------------------------------------------
-//	brief_init_colors()
-//
-//
-void brief_init_colors()
-{
-}
-
 bool brief_special_closeup(int briefing_icon_type)
 {
 	switch (briefing_icon_type)
@@ -870,7 +862,6 @@ void brief_init_map()
 	The_grid = brief_create_default_grid();
 	brief_maybe_create_new_grid(The_grid, pos, orient, 1);
 
-	brief_init_colors();
 	brief_move_icon_reset();
 
 	brief_preload_anims();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1951,6 +1951,7 @@ void game_init()
 
 	player_controls_init();
 	model_init();	
+	virtual_pof_init();
 
 	event_music_init();
 
@@ -1970,7 +1971,6 @@ void game_init()
 	sexp_startup();
 
 	obj_init();	
-	virtual_pof_init();
 	mflash_game_init();	
 	armor_init();
 	ai_init();


### PR DESCRIPTION
Make the initialization sequence consistent so that FSO, FRED, and qtFRED call their initialization functions in the same order.  Most of the changes involve bringing FRED and qtFRED into sync with FSO.  This fixes fireball prerequisites for the ship types table, applies the script initialization fixes from #5946 to FRED, and generally removes the possibility of any surprises due to FRED differing from FSO.

Also remove the empty `brief_init_colors()` function.