### PR TITLE
Reduce absolute volume threshold

### DIFF
--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -131,7 +131,7 @@ struct aav {
 aav aav_data[3];
 
 // min volume to play a sound after all volume processing (range is 0.0 -> 1.0)
-#define	MIN_SOUND_VOLUME				0.05f
+#define	MIN_SOUND_VOLUME				0.005f
 
 static int snd_next_sig	= 1;
 


### PR DESCRIPTION
There is an absolute volume threshold of 5% after all volume concerns, most sounds will not play if they are below that threshold. While this seems reasonable, it's quite easy to hit that threshold under modest conditions. With effects volume at the second pip (1/9 volume) and the prometheus' tabled volume of 0.4, *you cannot hear your shots firing at all*.

Remember that setting some of those volume sliders rather low may be necessary for the user to achieve the desired *relative* levels among effects, voice, music, etc and that a user can turn up their system volume to make any setting, no matter how low, sound normal.

All sounds already have tabled limits and a priority system in place specifically in order to ensure the audio environment functions as desired.