### PR TITLE
allow restriction to vanilla time compression range

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -200,6 +200,7 @@ Flag exe_params[] =
 	{ "-no_screenshake",	"Disable screen shaking",					true,	0,									EASY_DEFAULT,					"Gameplay",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_screenshake", },
 	{ "-vr",				"Enable Virtual Reality Mode",				true,	0,									EASY_DEFAULT,					"Gameplay",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-vr", },
 	{ "-no_unfocused_pause","Don't pause if the window isn't focused",	true,	0,									EASY_DEFAULT,					"Gameplay",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-no_unfocused_pause", },
+	{ "-orig_speedx_range", "Restrict speedup/slowdown (1x to 4x)", 	true,	0,									EASY_DEFAULT,					"Gameplay",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-orig_speedx_range", },
 
 	//flag					launcher text								FSO		on_flags							off_flags						category		reference URL
 	{ "-nosound",			"Disable all sound",						false,	0,									EASY_DEFAULT,					"Audio",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-nosound", },
@@ -534,6 +535,7 @@ cmdline_parm parse_cmdline_only(PARSE_COMMAND_LINE_STRING, "Ignore any cmdline_f
 cmdline_parm reparse_mainhall_arg("-reparse_mainhall", NULL, AT_NONE); //Cmdline_reparse_mainhall
 cmdline_parm frame_profile_write_file("-profile_write_file", NULL, AT_NONE); // Cmdline_profile_write_file
 cmdline_parm no_unfocused_pause_arg("-no_unfocused_pause", NULL, AT_NONE); //Cmdline_no_unfocus_pause
+cmdline_parm retail_time_compression_range_arg("-orig_speedx_range", NULL, AT_NONE); //Cmdline_retail_time_compression_range
 cmdline_parm benchmark_mode_arg("-benchmark_mode", NULL, AT_NONE); //Cmdline_benchmark_mode
 cmdline_parm pilot_arg("-pilot", nullptr, AT_STRING); //Cmdline_pilot
 cmdline_parm noninteractive_arg("-noninteractive", NULL, AT_NONE); //Cmdline_noninteractive
@@ -572,6 +574,7 @@ int Cmdline_verify_vps = 0;
 int Cmdline_reparse_mainhall = 0;
 bool Cmdline_profile_write_file = false;
 bool Cmdline_no_unfocus_pause = false;
+bool Cmdline_retail_time_compression_range = false;
 bool Cmdline_benchmark_mode = false;
 const char *Cmdline_pilot = nullptr;
 bool Cmdline_noninteractive = false;
@@ -2264,6 +2267,11 @@ bool SetCmdlineParams()
 	if (no_unfocused_pause_arg.found())
 	{
 		Cmdline_no_unfocus_pause = true;
+	}
+
+	if (retail_time_compression_range_arg.found())
+	{
+		Cmdline_retail_time_compression_range = true;
 	}
 	
 	if (benchmark_mode_arg.found())

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -150,6 +150,7 @@ extern int Cmdline_verify_vps;
 extern int Cmdline_reparse_mainhall;
 extern bool Cmdline_profile_write_file;
 extern bool Cmdline_no_unfocus_pause;
+extern bool Cmdline_retail_time_compression_range;
 extern bool Cmdline_benchmark_mode;
 extern const char *Cmdline_pilot;
 extern bool Cmdline_noninteractive;

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -183,8 +183,10 @@ factor_table ftables;
 // time compression/dilation values - Goober5000
 // (Volition sez "can't compress below 0.25"... not sure if
 // this is arbitrary or dictated by code)
-#define MAX_TIME_MULTIPLIER		64
-#define MAX_TIME_DIVIDER		4
+constexpr int MAX_TIME_MULTIPLIER = 64;
+constexpr int MAX_TIME_DIVIDER    =  4;
+constexpr int MAX_TIME_MULTIPLIER_RETAIL = 4;
+constexpr int MAX_TIME_DIVIDER_RETAIL   =  1;
 
 char CheatBuffer[CHEAT_BUFFER_LEN+1];
 
@@ -749,28 +751,24 @@ void process_debug_keys(int k)
 		case KEY_DEBUGGED + KEY_SHIFTED + KEY_COMMA:
 		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_COMMA:
 			if ( Game_mode & GM_NORMAL ) {
-				if ( Game_time_compression > (F1_0/MAX_TIME_DIVIDER) ) {
-					change_time_compression(0.5);
-				} else {
-					gamesnd_play_error_beep();
+				if (Game_time_compression > (F1_0 / (Cmdline_retail_time_compression_range ? MAX_TIME_DIVIDER_RETAIL : MAX_TIME_DIVIDER))) {
+					change_time_compression(0.5f);
+					break;
 				}
-			} else {
-				gamesnd_play_error_beep();
 			}
+			gamesnd_play_error_beep();
 			break;
 
 		// Goober5000: handle as normal here
 		case KEY_DEBUGGED + KEY_SHIFTED + KEY_PERIOD:
 		case KEY_DEBUGGED1 + KEY_SHIFTED + KEY_PERIOD:
 			if ( Game_mode & GM_NORMAL ) {
-				if ( Game_time_compression < (F1_0*MAX_TIME_MULTIPLIER) ) {
-					change_time_compression(2);
-				} else {
-					gamesnd_play_error_beep();
+				if (Game_time_compression < (F1_0 * (Cmdline_retail_time_compression_range ? MAX_TIME_MULTIPLIER_RETAIL : MAX_TIME_MULTIPLIER))) {
+					change_time_compression(2.0f);
+					break;
 				}
-			} else {
-				gamesnd_play_error_beep();
 			}
+			gamesnd_play_error_beep();
 			break;
 
 		//	Kill! the currently targeted ship.
@@ -2223,31 +2221,27 @@ int button_function_demo_valid(int n)
 		break;
 
 	case TIME_SLOW_DOWN:
-		if ( Game_mode & GM_NORMAL ) {
+		ret = 1;
+		if ( Game_mode & GM_NORMAL && !Time_compression_locked ) {
 			// Goober5000 - time dilation only available in cheat mode (see above);
 			// now you can do it with or without pressing the tilde, per Kazan's request
-			if ( ((Game_time_compression > F1_0) || (Cheats_enabled && (Game_time_compression > (F1_0/MAX_TIME_DIVIDER)))) && !Time_compression_locked) {
+			if ((Game_time_compression > F1_0) || (Cheats_enabled && (Game_time_compression > (F1_0 / (Cmdline_retail_time_compression_range ? MAX_TIME_DIVIDER_RETAIL : MAX_TIME_DIVIDER))))) {
 				change_time_compression(0.5f);
-			} else {
-				gamesnd_play_error_beep();
+				break;
 			}
-		} else {
-			gamesnd_play_error_beep();
 		}
-		ret = 1;
+		gamesnd_play_error_beep();
 		break;
 
 	case TIME_SPEED_UP:
-		if ( Game_mode & GM_NORMAL ) {
-			if ( (Game_time_compression < (F1_0*MAX_TIME_MULTIPLIER)) && !Time_compression_locked ) {
-				change_time_compression(2.0f);
-			} else {
-				gamesnd_play_error_beep();
-			}
-		} else {
-			gamesnd_play_error_beep();
-		}
 		ret = 1;
+		if ( Game_mode & GM_NORMAL && !Time_compression_locked ) {
+			if (Game_time_compression < (F1_0 * (Cmdline_retail_time_compression_range ? MAX_TIME_MULTIPLIER_RETAIL : MAX_TIME_MULTIPLIER))) {
+				change_time_compression(2.0f);
+				break;
+			}
+		}
+		gamesnd_play_error_beep();
 		break;
 	}
 


### PR DESCRIPTION
This provides a command-line argument to restrict the time compression range to the classic 1x - 4x.  Implements #6075.

I'm not entirely satisfied with `-orig_speedx_range` but it's the best I came up with that fit into the 19-character limit.  I'd be open to other suggestions.