### PR TITLE
Fix option manager importance

### DIFF
--- a/code/options/Option.cpp
+++ b/code/options/Option.cpp
@@ -181,9 +181,10 @@ void OptionBase::setRangeValues(float min, float max)
 }
 
 bool operator<(const OptionBase& lhs, const OptionBase& rhs) {
-	if (lhs._category < rhs._category)
+	auto val = stricmp(lhs._category.first, rhs._category.first);
+	if (val < 0)
 		return true;
-	if (rhs._category < lhs._category)
+	if (val > 0)
 		return false;
 	return lhs._importance > rhs._importance; // Importance is sorted from highest to lowest
 }


### PR DESCRIPTION
Really, fixing category comparison, allowing importance to be used. When options are displayed, they are sorted first by their category, and then by the supplied 'importance' value. But the category comparison was done directly, using direct pointer values, in effect never comparing equal and never using importance.