### PR TITLE
Do not unload debrief bitmaps in API mode

### DIFF
--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -2115,11 +2115,13 @@ void debrief_close(bool API_Access)
 	}
 
 	// unload bitmaps
-	if (Background_bitmap >= 0){
+	// Not used by the API
+	if (!API_Access && Background_bitmap >= 0) {
 		bm_release(Background_bitmap);
 	}
 
-	if (Award_bg_bitmap >= 0){
+	// Not used by the API
+	if (!API_Access && Award_bg_bitmap >= 0) {
 		bm_release(Award_bg_bitmap);
 	}
 


### PR DESCRIPTION
Fixes an issue where SCPUI Debrief would accidentally unload whatever's in the first 2 bitmap slots, usually fonts

I couldn't decide whether to init `Background_bitmaps` to -1, set it to -1 if loading is skipped, or just skip unloading. All would work. I opted for skipping unloading to match how the API does everything else.