### PR TITLE
Adds muzzle effect functionality.

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2111,9 +2111,6 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 
 		// muzzle flash?
 		if (Weapon_info[tsi->weapon_class].muzzle_effect.isValid()) {
-			//vec3d gun_world_pos;
-			//vm_vec_unrotate(&gun_world_pos, turret_pos, &Objects[OBJ_INDEX(objp)].orient);
-			//vm_vec_add2(&gun_world_pos, &Objects[OBJ_INDEX(objp)].pos);
 			//spawn particle effect
 			auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[tsi->weapon_class].muzzle_effect);
 			particleSource.moveTo(&turret_pos);

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1988,7 +1988,19 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 					}
 
 					// do mflash if the weapon has it
-					if (wip->muzzle_flash >= 0) {
+					if (wip->muzzle_effect.isValid()) {
+						//copy to convert from const vecs to vecs
+						//should be removed when changes are made to particle functions
+						vec3d firing_pos2 = *firing_pos;
+						vec3d firing_vec2 = *firing_vec;
+						//spawn particle effect
+						auto particleSource = particle::ParticleManager::get()->createSource(wip->muzzle_effect);
+						particleSource.moveTo(&firing_pos2);
+						particleSource.setOrientationFromVec(&firing_vec2);
+						particleSource.setVelocity(&Objects[parent_ship->objnum].phys_info.vel);
+						particleSource.finish();
+					}
+					else if (wip->muzzle_flash >= 0) {
 						mflash_create(firing_pos, firing_vec, &Objects[parent_ship->objnum].phys_info, wip->muzzle_flash);
 					}
 
@@ -2098,7 +2110,18 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 		}
 
 		// muzzle flash?
-		if (Weapon_info[tsi->weapon_class].muzzle_flash >= 0) {
+		if (Weapon_info[tsi->weapon_class].muzzle_effect.isValid()) {
+			//vec3d gun_world_pos;
+			//vm_vec_unrotate(&gun_world_pos, turret_pos, &Objects[OBJ_INDEX(objp)].orient);
+			//vm_vec_add2(&gun_world_pos, &Objects[OBJ_INDEX(objp)].pos);
+			//spawn particle effect
+			auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[tsi->weapon_class].muzzle_effect);
+			particleSource.moveTo(&turret_pos);
+			particleSource.setOrientationFromVec(&turret_fvec);
+			particleSource.setVelocity(&Objects[tsi->parent_objnum].phys_info.vel);
+			particleSource.finish();
+		}
+		else if (Weapon_info[tsi->weapon_class].muzzle_flash >= 0) {
 			mflash_create(&turret_pos, &turret_fvec, &Objects[tsi->parent_objnum].phys_info, Weapon_info[tsi->weapon_class].muzzle_flash);
 		}
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1055,8 +1055,8 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 		objp == Player_obj && Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
 	if (!(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak]) &&
 		(objp != Player_obj || Render_player_mflash || (!in_cockpit_view || player_show_ship_model))) {
+			//if there's a muzzle effect entry, we use that
 			if (Weapon_info[weapon_info_index].muzzle_effect.isValid()) {
-				//if there's a muzzle effect entry, we use that
 				vec3d gun_world_pos;
 				vm_vec_unrotate(&gun_world_pos, gun_pos, &Objects[OBJ_INDEX(objp)].orient);
 				vm_vec_add2(&gun_world_pos, &Objects[OBJ_INDEX(objp)].pos);
@@ -1067,8 +1067,8 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 				particleSource.setOrientationFromVec(gun_dir);
 				particleSource.setVelocity(&objp->phys_info.vel);
 				particleSource.finish();
+			//if there's a muzzle flash entry and no muzzle effect entry, we use the mflash
 			} else if (Weapon_info[weapon_info_index].muzzle_flash >= 0) {
-				//if there's a muzzle flash entry and no muzzle effect entry, we use the mflash
 				vec3d real_dir;
 				vm_vec_rotate(&real_dir, gun_dir, &objp->orient);
 				mflash_create(gun_pos, &real_dir, &objp->phys_info, Weapon_info[weapon_info_index].muzzle_flash, objp);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1051,12 +1051,28 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 	// HACK - let the flak guns do this on their own since they fire so quickly
 	// Also don't create if its the player in the cockpit unless he's also got show_ship_model, provided render_player_mflash isnt on
 	bool in_cockpit_view = (Viewer_mode & (VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP | VM_WARP_CHASE)) == 0;
-	bool player_show_ship_model = objp == Player_obj && Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
-	if ((Weapon_info[weapon_info_index].muzzle_flash >= 0) && !(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak]) &&
+	bool player_show_ship_model =
+		objp == Player_obj && Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
+	if (!(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak]) &&
 		(objp != Player_obj || Render_player_mflash || (!in_cockpit_view || player_show_ship_model))) {
-		vec3d real_dir;
-		vm_vec_rotate(&real_dir, gun_dir,&objp->orient);	
-		mflash_create(gun_pos, &real_dir, &objp->phys_info, Weapon_info[weapon_info_index].muzzle_flash, objp);		
+			if (Weapon_info[weapon_info_index].muzzle_effect.isValid()) {
+				//if there's a muzzle effect entry, we use that
+				vec3d gun_world_pos;
+				vm_vec_unrotate(&gun_world_pos, gun_pos, &Objects[OBJ_INDEX(objp)].orient);
+				vm_vec_add2(&gun_world_pos, &Objects[OBJ_INDEX(objp)].pos);
+
+				//spawn particle effect
+				auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[weapon_info_index].muzzle_effect);
+				particleSource.moveTo(&gun_world_pos);
+				particleSource.setOrientationFromVec(gun_dir);
+				particleSource.setVelocity(&objp->phys_info.vel);
+				particleSource.finish();
+			} else if (Weapon_info[weapon_info_index].muzzle_flash >= 0) {
+				//if there's a muzzle flash entry and no muzzle effect entry, we use the mflash
+				vec3d real_dir;
+				vm_vec_rotate(&real_dir, gun_dir, &objp->orient);
+				mflash_create(gun_pos, &real_dir, &objp->phys_info, Weapon_info[weapon_info_index].muzzle_flash, objp);
+			}
 	}
 
 	if ( pm->num_lights < 1 ) return;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -481,6 +481,8 @@ struct weapon_info
 	particle::ParticleEffectHandle piercing_impact_effect;
 	particle::ParticleEffectHandle piercing_impact_secondary_effect;
 
+	particle::ParticleEffectHandle muzzle_effect;
+
 	// Particle effect for the various states, WeaponState::NORMAL is the state for the whole lifetime, even for missiles
 	SCP_unordered_map<WeaponState, particle::ParticleEffectHandle, WeaponStateHash> state_effects;
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6795,16 +6795,6 @@ int weapon_create( const vec3d *pos, const matrix *porient, int weapon_type, int
 		wip->animations.getAll(model_get_instance(wp->model_instance_num), animation::ModelAnimationTriggerType::OnSpawn).start(animation::ModelAnimationDirection::FWD);
 	}
 
-	if (wip->muzzle_effect.isValid()) {
-		auto particleSource = particle::ParticleManager::get()->createSource(wip->muzzle_effect);
-		particleSource.moveTo(&wp->start_pos);
-		particleSource.setOrientationMatrix(orient);
-		if(parent_objp != NULL){
-			particleSource.setVelocity(&parent_objp->phys_info.vel);
-		}
-		particleSource.finish();
-	}
-
 	if (scripting::hooks::OnWeaponCreated->isActive()) {
 		scripting::hooks::OnWeaponCreated->run(scripting::hooks::WeaponCreatedConditions{ wp, &Objects[parent_objnum] },
 			scripting::hook_param_list(


### PR DESCRIPTION
In weapons.tbl, there is now an option to, instead of defining a retail-style muzzle flash, set a tabled particle effect to activate when the weapon is fired.

The effect's source velocity is set to the parent object's velocity (usually the firing ship), so using +Parent velocity factor will allow the muzzle effect to stay with a moving ship rather than quickly falling behind. It would be useful to also have the option of parenting the particle effect to the ship, but if that functionality is ever added to particle effects, it should as far as I can tell be simple to slot it into the implementation I have here.

Addressing the possible argument that this should be done via the events system instead: I agree that the events system will be useful for certain types of very complex muzzle effects, once it has triggers for that properly set up. However, most muzzle flashes, even complex ones, don't require anything more than one particle effect as implemented here, and dealing with the event system (making a table entry for the event, in addition to the table entry for the particle effect) is extra complexity that will be dead weight most of the time. I think that both options should exist so that modders can use whichever is more appropriate.