### PR TITLE
properly distinguish between adjusting voice and effects volume

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -40,7 +40,6 @@
 #include "sound/fsspeech.h"
 #include "species_defs/species_defs.h"
 #include "utils/Random.h"
-#include "weapon/emp.h"
 
 bool Allow_generic_backup_messages = false;
 float Command_announces_enemy_arrival_chance = 0.25;
@@ -2384,10 +2383,10 @@ void message_maybe_distort()
 		
 			if ( Message_wave_muted ) {
 				if ( !was_muted )
-					snd_set_volume(Playing_messages[i].wave, 0.0f);
+					snd_set_volume(Playing_messages[i].wave, 0.0f, true);
 			} else {
 				if ( was_muted )
-					snd_set_volume(Playing_messages[i].wave, (Master_sound_volume * aav_voice_volume));
+					snd_set_volume(Playing_messages[i].wave, (Master_voice_volume * aav_voice_volume), true);
 			}
 		}
 	}

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -1073,7 +1073,7 @@ void snd_set_volume(sound_handle sig, float volume, bool is_voice)
 	//looping sound volumes are updated in snd_do_frame
 	if(!isLoopingSound) {
 		if (is_voice) {
-			new_volume = volume * (Master_voice_volume * aav_effect_volume);
+			new_volume = volume * (Master_voice_volume * aav_voice_volume);
 		} else {
 			new_volume = volume * (Master_sound_volume * aav_effect_volume);
 		}


### PR DESCRIPTION
When messages are distorted due to EMP effects, the voice volume should be controlled by the voice setting, not the effects setting.  Fixes a bug noticed by @skdKitsune, a portion of which dates back to the original public source release.

Also, when volume is adjusted in `snd_set_volume`, make sure the correct voice volumes are used.  Fixes a copy-paste bug from #5694.