### PR TITLE
refine process for capping speed due to physics whack/shock/collide

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -163,6 +163,7 @@ namespace AI {
 		Hudsquadmsg_tactical_disarm_disable,
 		Align_to_target_when_guarding_still,
 		Debris_respects_big_damage,
+		Dont_limit_change_in_speed_due_to_physics_whack,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -477,6 +477,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$debris damage respects 'big damage' flag:", AI::Profile_Flags::Debris_respects_big_damage);
 
+				set_flag(profile, "$don't limit change in speed due to physics whack:", AI::Profile_Flags::Dont_limit_change_in_speed_due_to_physics_whack);
+
 				if (optional_string("$ai path mode:"))
 				{
 					stuff_string(buf, F_NAME, NAME_LENGTH);


### PR DESCRIPTION
The three functions `physics_apply_whack`, `physics_apply_shock`, and `physics_collide_whack` limited speed after the physics had been applied, but they limited absolute speed, not the speed due to the physics.  This modifies the process to limit the change in speed.  It also adds an AI profiles flag to disable the limit if desired.

This also tweaks the three functions (by editing comments and moving lines) to be more consistent, since all three are doing very similar calculations near the end.