### PR TITLE
Fix compilation with GCC14

### DIFF
--- a/lib/discord/thirdparty/rapidjson/document.h
+++ b/lib/discord/thirdparty/rapidjson/document.h
@@ -316,7 +316,8 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+	//You're not allowed to reassign const string refs
+    GenericStringRef& operator=(const GenericStringRef& rhs) = delete;
 
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }


### PR DESCRIPTION
Turns out the rapidjson lib that's shipped with our version of the discord rich presence library does not compile under GCC14.
Reason being that one of the string types allows reassignment, which is illegal as the underlying data is marked const.
The reason this didn't error earlier is, I suspect, that this is a template class, so only stuff that's actually used is instantiated. As the reassignment function was never used, this wasn't an issue. GCC14 however seems to notice the error and complains despite the function not being used.
So, to fix it, just delete the reassignment operator.