### PR TITLE
Refactor replacement texture to a modelinstance parameter

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1523,6 +1523,8 @@ void asteroid_render(object * obj, model_draw_list *scene)
 
 		render_info.set_object_number( OBJ_INDEX(obj) );
 		render_info.set_flags(MR_IS_ASTEROID);
+		if (asp->model_instance_num >= 0)
+			render_info.set_replacement_textures(model_get_instance(asp->model_instance_num)->texture_replace);
 
 		model_render_queue(&render_info, scene, Asteroid_info[asp->asteroid_type].model_num[asp->asteroid_subtype], &obj->orient, &obj->pos);	//	Replace MR_NORMAL with 0x07 for big yellow blobs
 	}

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -1197,6 +1197,9 @@ void debris_render(object * obj, model_draw_list *scene)
 		// render_info.set_flags(MR_NO_LIGHTING);
 	}
 
+	if (db->model_instance_num >= 0)
+		render_info.set_replacement_textures(model_get_instance(db->model_instance_num)->texture_replace);
+
 	submodel_render_queue( &render_info, scene, pm, pmi, db->submodel_num, &obj->orient, &obj->pos );
 
 	if (tbase != NULL && (swapped!=-1) && pm)	{

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -641,7 +641,7 @@ void HudGaugeShield::showShields(object *objp, int mode)
 			model_render_params render_info;
 
 			render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING);
-			render_info.set_replacement_textures(sp->ship_replacement_textures);
+			render_info.set_replacement_textures(model_get_instance(sp->model_instance_num)->texture_replace);
 			render_info.set_detail_level_lock(1);
 			render_info.set_object_number(OBJ_INDEX(objp));
 

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -677,7 +677,7 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp)
 		if(target_sip->model_num_hud >= 0){
 			model_render_immediate( &render_info, target_sip->model_num_hud, &target_objp->orient, &obj_pos);
 		} else {
-			render_info.set_replacement_textures(target_shipp->ship_replacement_textures);
+			render_info.set_replacement_textures(model_get_instance(target_shipp->model_instance_num)->texture_replace);
 
 			model_render_immediate( &render_info, target_sip->model_num, &target_objp->orient, &obj_pos);
 		}
@@ -777,6 +777,9 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 
 		model_render_params render_info;
 
+		if (debrisp->model_instance_num >= 0)
+			render_info.set_replacement_textures(model_get_instance(debrisp->model_instance_num)->texture_replace);
+
 		color thisColor = GaugeWirecolor;
 		bool thisOverride = GaugeWirecolorOverride;
 
@@ -863,7 +866,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 	weapon_info	*target_wip = NULL;
 	weapon		*wp = NULL;
 	object		*viewer_obj, *viewed_obj;
-	int *replacement_textures = NULL;
+	std::shared_ptr<model_texture_replace> replacement_textures = nullptr;
 	int			target_team, is_homing, is_player_missile, missile_view, viewed_model_num, hud_target_lod, w, h;
 	int flags=0;
 
@@ -902,9 +905,12 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 			viewed_obj			= wp->homing_object;
 			missile_view		= TRUE;
 			viewed_model_num	= homing_sip->model_num;
-			replacement_textures = homing_shipp->ship_replacement_textures;
 			hud_target_lod		= homing_sip->hud_target_lod;
 		}
+
+		int pmi_id = object_get_model_instance(viewed_obj);
+		if (pmi_id >= 0)
+			replacement_textures = model_get_instance(pmi_id)->texture_replace;
 
 		// take the forward orientation to be the vector from the player to the current target
 		vm_vec_sub(&orient_vec, &viewed_obj->pos, &viewer_obj->pos);
@@ -1068,7 +1074,6 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 				model_render_immediate( &render_info, homing_sip->model_num_hud, &viewed_obj->orient, &obj_pos);
 			} else {
 				render_info.set_flags(flags | MR_NO_FOGGING);
-				render_info.set_replacement_textures(homing_shipp->ship_replacement_textures);
 
 				model_render_immediate( &render_info, homing_sip->model_num, &viewed_obj->orient, &obj_pos );
 			}
@@ -1169,6 +1174,9 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 		model_clear_instance(Asteroid_info[asteroidp->asteroid_type].model_num[pof]);
 		
 		model_render_params render_info;
+
+		if (asteroidp->model_instance_num >= 0)
+			render_info.set_replacement_textures(model_get_instance(asteroidp->model_instance_num)->texture_replace);
 
 		color thisColor = GaugeWirecolor;
 		bool thisOverride = GaugeWirecolorOverride;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -149,8 +149,8 @@ struct submodel_instance
 #define TM_SPEC_GLOSS_TYPE	6		// optional reflectance map (specular and gloss)
 #define TM_AMBIENT_TYPE		7		// optional ambient occlusion map with ambient occlusion and cavity occlusion factors for red and green channels.
 #define TM_NUM_TYPES		8		//WMC - Number of texture_info objects in texture_map
-//Used by scripting - if you change this, do a search
-//to update switch() statement in lua.cpp
+									//Used by scripting - if you change this, do a search
+									//to update switch() statement in lua.cpp
 
 #define MAX_REPLACEMENT_TEXTURES MAX_MODEL_TEXTURES * TM_NUM_TYPES
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -140,12 +140,39 @@ struct submodel_instance
 	}
 };
 
+#define TM_BASE_TYPE		0		// the standard base map
+#define TM_GLOW_TYPE		1		// optional glow map
+#define TM_SPECULAR_TYPE	2		// optional specular map
+#define TM_NORMAL_TYPE		3		// optional normal map
+#define TM_HEIGHT_TYPE		4		// optional height map (for parallax mapping)
+#define TM_MISC_TYPE		5		// optional utility map
+#define TM_SPEC_GLOSS_TYPE	6		// optional reflectance map (specular and gloss)
+#define TM_AMBIENT_TYPE		7		// optional ambient occlusion map with ambient occlusion and cavity occlusion factors for red and green channels.
+#define TM_NUM_TYPES		8		//WMC - Number of texture_info objects in texture_map
+//Used by scripting - if you change this, do a search
+//to update switch() statement in lua.cpp
+
+#define MAX_REPLACEMENT_TEXTURES MAX_MODEL_TEXTURES * TM_NUM_TYPES
+
+// Goober5000 - since we need something < 0
+#define REPLACE_WITH_INVISIBLE	-47
+
+class model_texture_replace : public std::array<int, MAX_REPLACEMENT_TEXTURES> {
+public:
+	model_texture_replace() : std::array<int, MAX_REPLACEMENT_TEXTURES>() {
+		for (int& tex : *this)
+			tex = -1;
+	}
+};
+
 // Data specific to a particular instance of a model.
 struct polymodel_instance
 {
 	int id = -1;							// global model_instance num index
 	int model_num = -1;						// global model num index, same as polymodel->id
 	submodel_instance *submodel = nullptr;	// array of submodel instances; mirrors the polymodel->submodel array
+
+	std::shared_ptr<model_texture_replace> texture_replace = nullptr;
 
 	int objnum;								// id of the object using this pmi, or -1 if no object (e.g. skybox) 
 };
@@ -730,17 +757,6 @@ public:
 	int SetTexture(int n_tex);
 };
 
-#define TM_BASE_TYPE		0		// the standard base map
-#define TM_GLOW_TYPE		1		// optional glow map
-#define TM_SPECULAR_TYPE	2		// optional specular map
-#define TM_NORMAL_TYPE		3		// optional normal map
-#define TM_HEIGHT_TYPE		4		// optional height map (for parallax mapping)
-#define TM_MISC_TYPE		5		// optional utility map
-#define TM_SPEC_GLOSS_TYPE	6		// optional reflectance map (specular and gloss)
-#define TM_AMBIENT_TYPE		7		// optional ambient occlusion map with ambient occlusion and cavity occlusion factors for red and green channels.
-#define TM_NUM_TYPES		8		//WMC - Number of texture_info objects in texture_map
-									//Used by scripting - if you change this, do a search
-									//to update switch() statement in lua.cpp
 // taylor
 //WMC - OOPified
 class texture_map
@@ -764,11 +780,6 @@ public:
 		: is_ambient(false), is_transparent(false)
 	{}
 };
-
-#define MAX_REPLACEMENT_TEXTURES MAX_MODEL_TEXTURES * TM_NUM_TYPES
-
-// Goober5000 - since we need something < 0
-#define REPLACE_WITH_INVISIBLE	-47
 
 //used to describe a polygon model
 // NOTE: Because WMC OOPified the textures, this must now be treated as a class, rather than a struct.

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -83,10 +83,7 @@ class model_render_params
 
 	int Insignia_bitmap;
 
-	const int *Replacement_textures;
-	bool Manage_replacement_textures; // This is set when we are rendering a model without an associated ship object;
-									  // in that case, model_render_params is responsible for allocating and destroying
-									  // the Replacement_textures array (this is handled elsewhere otherwise)
+	std::shared_ptr<const model_texture_replace> Replacement_textures;
 
 	bool Team_color_set;
 	team_color Current_team_color;
@@ -109,7 +106,6 @@ class model_render_params
 	model_render_params& operator=(const model_render_params&) = delete;
 public:
 	model_render_params();
-	~model_render_params();
 
 	void set_flags(uint flags);
 	void set_debug_flags(uint flags);
@@ -122,7 +118,7 @@ public:
 	void set_alpha(float alpha);
 	void set_forced_bitmap(int bitmap);
 	void set_insignia_bitmap(int bitmap);
-	void set_replacement_textures(const int *textures);
+	void set_replacement_textures(std::shared_ptr<const model_texture_replace> textures);
 	void set_replacement_textures(int modelnum, const SCP_vector<texture_replace>& replacement_textures);
 	void set_team_color(const team_color &clr);
 	void set_team_color(const SCP_string &team, const SCP_string &secondaryteam, fix timestamp, int fadetime);
@@ -149,7 +145,7 @@ public:
 	float get_alpha() const;
 	int get_forced_bitmap() const;
 	int get_insignia_bitmap() const;
-	const int* get_replacement_textures() const;
+	std::shared_ptr<const model_texture_replace> get_replacement_textures() const;
 	const team_color& get_team_color() const;
 	const vec3d& get_clip_plane_pos() const;
 	const vec3d& get_clip_plane_normal() const;

--- a/code/scripting/api/objs/cockpit_display.cpp
+++ b/code/scripting/api/objs/cockpit_display.cpp
@@ -512,7 +512,7 @@ bool cockpit_displays_h::isValid() const {
 		return false;
 	}
 
-	if ( Player_cockpit_textures == NULL ) {
+	if ( Player_cockpit_textures == nullptr ) {
 		return false;
 	}
 

--- a/code/scripting/api/objs/modelinstance.h
+++ b/code/scripting/api/objs/modelinstance.h
@@ -21,6 +21,7 @@ class modelinstance_h
 
 	bool isValid() const;
 };
+DECLARE_ADE_OBJ(l_ModelInstanceTextures, modelinstance_h);
 DECLARE_ADE_OBJ(l_ModelInstance, modelinstance_h);
 
 class submodelinstance_h

--- a/code/scripting/api/objs/ship.h
+++ b/code/scripting/api/objs/ship.h
@@ -6,8 +6,6 @@
 namespace scripting {
 namespace api {
 
-DECLARE_ADE_OBJ(l_ShipTextures, object_h);
-
 //**********HANDLE: Ship
 DECLARE_ADE_OBJ(l_Ship, object_h);
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -132,7 +132,7 @@ int	Num_reinforcements = 0;
 ship	Ships[MAX_SHIPS];
 
 ship	*Player_ship;
-int		*Player_cockpit_textures;
+std::shared_ptr<model_texture_replace> Player_cockpit_textures;
 SCP_vector<cockpit_display> Player_displays;
 bool Disable_cockpits = false;
 bool Disable_cockpit_sway = false;
@@ -6829,11 +6829,6 @@ void ship::clear()
 
 	primitive_sensor_range = DEFAULT_SHIP_PRIMITIVE_SENSOR_RANGE;
 
-	if (ship_replacement_textures != nullptr) {
-		vm_free(ship_replacement_textures);
-	}
-	ship_replacement_textures = nullptr;
-
 	current_viewpoint = -1;
 
 	for (int i = 0; i < MAX_SHIP_CONTRAILS; i++)
@@ -6911,13 +6906,12 @@ const char* ship::get_display_name() const {
 
 void ship::apply_replacement_textures(const SCP_vector<texture_replace> &replacements)
 {
-	if (!replacements.empty())
-	{
-		ship_replacement_textures = (int *) vm_malloc( MAX_REPLACEMENT_TEXTURES * sizeof(int));
+	if (replacements.empty())
+		return;
 
-		for (auto i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
-			ship_replacement_textures[i] = -1;
-	}
+	polymodel_instance* pmi = model_get_instance(model_instance_num);
+
+	pmi->texture_replace = make_shared<model_texture_replace>();
 
 	auto pm = model_get(Ship_info[ship_info_index].model_num);
 
@@ -6930,8 +6924,8 @@ void ship::apply_replacement_textures(const SCP_vector<texture_replace> &replace
 			texture_map *tmap = &pm->maps[j];
 
 			int tnum = tmap->FindTexture(tr.old_texture);
-			if(tnum > -1)
-				ship_replacement_textures[j * TM_NUM_TYPES + tnum] = tr.new_texture_id;
+			if (tnum > -1)
+				(*pmi->texture_replace)[j * TM_NUM_TYPES + tnum] = tr.new_texture_id;
 		}
 	}
 }
@@ -7881,6 +7875,7 @@ extern bool Rendering_to_shadow_map;
 void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix* rot_offset, const fov_t* fov_override) {
 	ship* shipp = &Ships[objp->instance];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
+	polymodel_instance* pmi = model_get_instance(shipp->model_instance_num);
 
 	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
 
@@ -7937,7 +7932,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		render_info.set_object_number(OBJ_INDEX(objp));
 
 		// update any replacement and/or team color textures (wookieejedi), then render
-		render_info.set_replacement_textures(shipp->ship_replacement_textures);
+		render_info.set_replacement_textures(pmi->texture_replace);
 
 		if (sip->uses_team_colors)
 			render_info.set_team_color(shipp->team_name, shipp->secondary_team_name, 0, 0);
@@ -8030,7 +8025,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		model_render_params render_info;
 		render_info.set_detail_level_lock(0);
 		render_info.set_flags(render_flags);
-		render_info.set_replacement_textures(shipp->ship_replacement_textures);
+		render_info.set_replacement_textures(pmi->texture_replace);
 		render_info.set_object_number(OBJ_INDEX(objp));
 		if (sip->uses_team_colors)
 			render_info.set_team_color(shipp->team_name, shipp->secondary_team_name, 0, 0);
@@ -8101,20 +8096,14 @@ void ship_init_cockpit_displays(ship *shipp)
 		return;
 	}
 
-	if ( Player_cockpit_textures != NULL) {
+	if ( Player_cockpit_textures != nullptr) {
 		return;
 	}
 
 	// ship's cockpit texture replacements haven't been setup yet, so do it.
-	Player_cockpit_textures = (int *) vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
+	Player_cockpit_textures = make_shared<model_texture_replace>();
 
-	int i;
-
-	for ( i = 0; i < MAX_REPLACEMENT_TEXTURES; i++ ) {
-		Player_cockpit_textures[i] = -1;
-	}
-
-	for ( i = 0; i < (int)sip->displays.size(); i++ ) {
+	for ( int i = 0; i < (int)sip->displays.size(); i++ ) {
 		ship_add_cockpit_display(&sip->displays[i], cockpit_model_num);
 	}
 
@@ -8142,11 +8131,7 @@ void ship_close_cockpit_displays(ship* shipp)
 	}
 
 	Player_displays.clear();
-
-	if ( Player_cockpit_textures != NULL ) {
-		vm_free(Player_cockpit_textures);
-		Player_cockpit_textures = NULL;
-	}
+	Player_cockpit_textures.reset();
 }
 
 static void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_model_num)
@@ -8179,13 +8164,13 @@ static void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_
 	}
 
 	// create a render target for this cockpit texture
-	if ( Player_cockpit_textures[glow_target] < 0) {
-
+	auto& glow_texture = (*Player_cockpit_textures)[glow_target];
+	if ( glow_texture == -1) {
 		bm_get_info(diffuse_handle, &w, &h);
-		Player_cockpit_textures[glow_target] = bm_make_render_target(w, h, BMP_FLAG_RENDER_TARGET_DYNAMIC);
+		glow_texture = bm_make_render_target(w, h, BMP_FLAG_RENDER_TARGET_DYNAMIC);
 
 		// if no render target was made, bail
-		if ( Player_cockpit_textures[glow_target] < 0 ) {
+		if ( glow_texture < 0 ) {
 			return;
 		}
 	}
@@ -8214,7 +8199,7 @@ static void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_
 	new_display.size[0] = display->size[0];
 	new_display.size[1] = display->size[1];
 	new_display.source = glow_handle;
-	new_display.target = Player_cockpit_textures[glow_target];
+	new_display.target = glow_texture;
 
 	Player_displays.push_back(new_display);
 }
@@ -8241,7 +8226,7 @@ int ship_start_render_cockpit_display(size_t cockpit_display_num)
 		return -1;
 	}
 
-	if ( Player_cockpit_textures == NULL ) {
+	if ( Player_cockpit_textures == nullptr ) {
 		return -1;
 	}
 
@@ -8287,7 +8272,7 @@ void ship_end_render_cockpit_display(size_t cockpit_display_num)
 		return;
 	}
 
-	if ( Player_cockpit_textures == NULL ) {
+	if ( Player_cockpit_textures == nullptr ) {
 		return;
 	}
 
@@ -8354,11 +8339,6 @@ void ship_delete( object * obj )
 	shipp->objnum = -1;
 
 	animation::ModelAnimationSet::stopAnimations(model_get_instance(shipp->model_instance_num));
-
-	if (shipp->ship_replacement_textures != NULL) {
-		vm_free(shipp->ship_replacement_textures);
-		shipp->ship_replacement_textures = NULL;
-	}
 
 	// glow point banks
 	shipp->glow_point_bank_active.clear();
@@ -11087,15 +11067,14 @@ static void ship_model_change(int n, int ship_type)
 	ship_info	*sip;
 	ship			*sp;
 	polymodel * pm;
+	polymodel_instance * pmi;
 	object *objp;
 
 	Assert( n >= 0 && n < MAX_SHIPS );
 	sp = &Ships[n];
 	sip = &(Ship_info[ship_type]);
 	objp = &Objects[sp->objnum];
-
-	//Stop Animation on the old model
-	animation::ModelAnimationSet::stopAnimations(model_get_instance(sp->model_instance_num));
+	pmi = model_get_instance(sp->model_instance_num);
 
 	// get new model
 	if (sip->model_num == -1) {
@@ -11110,41 +11089,6 @@ static void ship_model_change(int n, int ship_type)
 
 	pm = model_get(sip->model_num);
 	Objects[sp->objnum].radius = model_get_radius(pm->id);
-
-	// Goober5000 - deal with texture replacement by re-applying the same code we used during parsing
-	// wookieejedi - replacement textures are loaded in mission parse, so need to load any new textures here
-	if ( !sip->replacement_textures.empty() ) {
-
-		// clear and reset replacement textures because the new positions may be different
-		if (sp->ship_replacement_textures == nullptr)
-			sp->ship_replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
-		for (auto k = 0; k < MAX_REPLACEMENT_TEXTURES; k++)
-			sp->ship_replacement_textures[k] = -1;
-
-		// now fill them in according to texture name
-		for (const auto& tr : sip->replacement_textures) {
-			// look for textures
-			for (auto j = 0; j < pm->n_textures; j++) {
-
-				texture_map* tmap = &pm->maps[j];
-				int tnum = tmap->FindTexture(tr.old_texture);
-
-				if (tnum > -1) {
-					// load new texture
-					int new_tex = bm_load_either(tr.new_texture);
-					if (new_tex > -1) {
-						sp->ship_replacement_textures[j * TM_NUM_TYPES + tnum] = new_tex;
-					}
-				}
-			}
-		}
-	} else {
-		// ensure that any texture replacements are cleared from old ship 
-		if (sp->ship_replacement_textures != nullptr) {
-			vm_free(sp->ship_replacement_textures);
-			sp->ship_replacement_textures = nullptr;
-		}
-	}
 
 	// page in nondims in game
 	if ( !Fred_running )
@@ -11206,6 +11150,40 @@ static void ship_model_change(int n, int ship_type)
 
 	// reset texture animations
 	sp->base_texture_anim_timestamp = _timestamp();
+
+	model_delete_instance(sp->model_instance_num);
+
+	// create new model instance data
+	// note: this is needed for both subsystem stuff and submodel animation stuff
+	sp->model_instance_num = model_create_instance(OBJ_INDEX(objp), sip->model_num);
+
+	// Goober5000 - deal with texture replacement by re-applying the same code we used during parsing
+	// wookieejedi - replacement textures are loaded in mission parse, so need to load any new textures here
+	// Lafiel - this now has to happen last, as the texture replacement stuff is stored in the pmi
+	if ( !sip->replacement_textures.empty() ) {
+
+		// clear and reset replacement textures because the new positions may be different
+		if (pmi->texture_replace == nullptr)
+			pmi->texture_replace = make_shared<model_texture_replace>();
+
+		// now fill them in according to texture name
+		for (const auto& tr : sip->replacement_textures) {
+			// look for textures
+			for (auto j = 0; j < pm->n_textures; j++) {
+
+				texture_map* tmap = &pm->maps[j];
+				int tnum = tmap->FindTexture(tr.old_texture);
+
+				if (tnum > -1) {
+					// load new texture
+					int new_tex = bm_load_either(tr.new_texture);
+					if (new_tex > -1) {
+						(*pmi->texture_replace)[j * TM_NUM_TYPES + tnum] = new_tex;
+					}
+				}
+			}
+		}
+	}
 }
 
 /**
@@ -11472,10 +11450,6 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	// point to new ship data
 	ship_model_change(n, ship_type);
 	sp->ship_info_index = ship_type;
-
-	// create new model instance data
-	// note: this is needed for both subsystem stuff and submodel animation stuff
-	sp->model_instance_num = model_create_instance(objnum, sip->model_num);
 
 	// if we have the same warp parameters as the ship class, we will need to update them to point to the new class
 	if (sp->warpin_params_index == sip_orig->warpin_params_index) {
@@ -15732,11 +15706,6 @@ void ship_close()
 	for (i=0; i<MAX_SHIPS; i++ )	{
 		ship *shipp = &Ships[i];
 
-		if (shipp->ship_replacement_textures != NULL) {
-			vm_free(shipp->ship_replacement_textures);
-			shipp->ship_replacement_textures = NULL;
-		}
-
 		if(shipp->warpin_effect != NULL)
 			delete shipp->warpin_effect;
 		shipp->warpin_effect = NULL;
@@ -18312,15 +18281,15 @@ void ship_page_in()
 		// is this a valid ship?
 		if (Ships[i].objnum >= 0)
 		{
+			polymodel_instance* pmi = model_get_instance(object_get_model_instance(&Objects[Ships[i].objnum]));
 			// do we have any textures?
-			if (Ships[i].ship_replacement_textures != NULL)
+			if (pmi->texture_replace != nullptr)
 			{
 				// page in replacement textures
-				for (j=0; j<MAX_REPLACEMENT_TEXTURES; j++)
+				for (const auto& texture : *pmi->texture_replace)
 				{
-					if (Ships[i].ship_replacement_textures[j] > -1)
-					{
-						bm_page_in_texture( Ships[i].ship_replacement_textures[j] );
+					if (texture >= 0) {
+						bm_page_in_texture(texture);
 					}
 				}
 			}
@@ -18449,6 +18418,8 @@ void ship_replace_active_texture(int ship_index, const char* old_name, const cha
 {
 	ship* shipp = &Ships[ship_index];
 	polymodel* pm = model_get(Ship_info[shipp->ship_info_index].model_num);
+	polymodel_instance* pmi = model_get_instance(shipp->model_instance_num);
+
 	int final_index = -1;
 
 	for (int i = 0; i < pm->n_textures; i++)
@@ -18470,14 +18441,11 @@ void ship_replace_active_texture(int ship_index, const char* old_name, const cha
 		else
 			texture = bm_load_either(new_name);
 
-		if (shipp->ship_replacement_textures == nullptr) {
-			shipp->ship_replacement_textures = (int*)vm_malloc(MAX_REPLACEMENT_TEXTURES * sizeof(int));
-
-			for (int i = 0; i < MAX_REPLACEMENT_TEXTURES; i++)
-				shipp->ship_replacement_textures[i] = -1;
+		if (pmi->texture_replace == nullptr) {
+			pmi->texture_replace = make_shared<model_texture_replace>();
 		}
 
-		shipp->ship_replacement_textures[final_index] = texture;
+		(*pmi->texture_replace)[final_index] = texture;
 	} else
 		Warning(LOCATION, "Invalid texture '%s' used for replacement texture", old_name);
 }
@@ -20997,7 +20965,7 @@ void ship_render(object* obj, model_draw_list* scene)
 	ship_render_weapon_models(&render_info, scene, obj, render_flags);
 
 	render_info.set_object_number(OBJ_INDEX(obj));
-	render_info.set_replacement_textures(shipp->ship_replacement_textures);
+	render_info.set_replacement_textures(pmi->texture_replace);
 
 	// small ships
 	if ( !( shipp->flags[Ship_Flags::Cloaked] ) ) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8103,8 +8103,8 @@ void ship_init_cockpit_displays(ship *shipp)
 	// ship's cockpit texture replacements haven't been setup yet, so do it.
 	Player_cockpit_textures = make_shared<model_texture_replace>();
 
-	for ( int i = 0; i < (int)sip->displays.size(); i++ ) {
-		ship_add_cockpit_display(&sip->displays[i], cockpit_model_num);
+	for ( auto& display : sip->displays ) {
+		ship_add_cockpit_display(&display, cockpit_model_num);
 	}
 
 	ship_set_hud_cockpit_targets();
@@ -11164,8 +11164,8 @@ static void ship_model_change(int n, int ship_type)
 	if ( !sip->replacement_textures.empty() ) {
 
 		// clear and reset replacement textures because the new positions may be different
-		if (pmi->texture_replace == nullptr)
-			pmi->texture_replace = make_shared<model_texture_replace>();
+		pmi->texture_replace = make_shared<model_texture_replace>();
+		auto& texture_replace_deref = *pmi->texture_replace;
 
 		// now fill them in according to texture name
 		for (const auto& tr : sip->replacement_textures) {
@@ -11179,7 +11179,7 @@ static void ship_model_change(int n, int ship_type)
 					// load new texture
 					int new_tex = bm_load_either(tr.new_texture);
 					if (new_tex > -1) {
-						(*pmi->texture_replace)[j * TM_NUM_TYPES + tnum] = new_tex;
+						texture_replace_deref[j * TM_NUM_TYPES + tnum] = new_tex;
 					}
 				}
 			}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11156,6 +11156,7 @@ static void ship_model_change(int n, int ship_type)
 	// create new model instance data
 	// note: this is needed for both subsystem stuff and submodel animation stuff
 	sp->model_instance_num = model_create_instance(OBJ_INDEX(objp), sip->model_num);
+	pmi = model_get_instance(sp->model_instance_num);
 
 	// Goober5000 - deal with texture replacement by re-applying the same code we used during parsing
 	// wookieejedi - replacement textures are loaded in mission parse, so need to load any new textures here

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1538,7 +1538,7 @@ extern const size_t Num_subsystem_flags;
 extern int Num_wings;
 extern ship Ships[MAX_SHIPS];
 extern ship	*Player_ship;
-extern int	*Player_cockpit_textures;
+extern std::shared_ptr<model_texture_replace> Player_cockpit_textures;
 
 // Data structure to track the active missiles
 typedef struct ship_obj {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -761,9 +761,6 @@ public:
 
 	// Goober5000 - range of primitive sensors
 	int primitive_sensor_range;
-	
-	// Goober5000 - revised nameplate implementation
-	int *ship_replacement_textures;
 
 	// Goober5000 - index into pm->view_positions[]
 	// apparently, early in FS1 development, there was a field called current_eye_index

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1662,7 +1662,7 @@ void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_shi
 				model_render_params render_info;
 
 				render_info.set_clip_plane(debris_clip_plane_pt, clip_plane_norm);
-				render_info.set_replacement_textures(shipp->ship_replacement_textures);
+				render_info.set_replacement_textures(pmi->texture_replace);
 				render_info.set_flags(render_flags);
 
 				submodel_render_queue(&render_info, scene, pm, pmi, pm->debris_objects[i], &half_ship->orient, &tmp);
@@ -1706,7 +1706,7 @@ void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_shi
 
 	render_info.set_flags(render_flags);
 	render_info.set_clip_plane(model_clip_plane_pt, clip_plane_norm);
-	render_info.set_replacement_textures(shipp->ship_replacement_textures);
+	render_info.set_replacement_textures(pmi->texture_replace);
 	render_info.set_object_number(shipp->objnum);
 
 	if (Ship_info[shipp->ship_info_index].uses_team_colors && !shipp->flags[Ship::Ship_Flags::Render_without_miscmap]) {

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2311,6 +2311,9 @@ void stars_draw_background()
 		render_info.set_alpha_mult(Nmodel_alpha);
 	render_info.set_flags(Nmodel_flags | MR_SKYBOX);
 
+	if (Nmodel_instance_num >= 0)
+		render_info.set_replacement_textures(model_get_instance(Nmodel_instance_num)->texture_replace);
+
 	model_render_immediate(&render_info, Nmodel_num, Nmodel_instance_num, &Nmodel_orient, &Eye_position, MODEL_RENDER_ALL, false);
 }
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -9021,6 +9021,9 @@ void weapon_render(object* obj, model_draw_list *scene)
 
 			render_info.set_flags(render_flags);
 
+			if (wp->model_instance_num >= 0)
+				render_info.set_replacement_textures(model_get_instance(wp->model_instance_num)->texture_replace);
+
 			model_render_queue(&render_info, scene, wip->model_num, &obj->orient, &obj->pos);
 
 			break;

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -1876,7 +1876,7 @@ void render_one_model_htl(object *objp) {
 		model_render_params render_info;
 
 		render_info.set_debug_flags(debug_flags);
-		render_info.set_replacement_textures(Ships[z].ship_replacement_textures);
+		render_info.set_replacement_textures(model_get_instance(Ships[z].model_instance_num)->texture_replace);
 
 		if (Fred_outline) {
 			render_info.set_color(Fred_outline >> 16, (Fred_outline >> 8) & 0xff, Fred_outline & 0xff);

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -874,7 +874,7 @@ void FredRenderer::render_one_model_htl(object* objp,
 		model_render_params render_info;
 		render_info.set_debug_flags(debug_flags);
 		render_info.set_color(Fred_outline >> 16, (Fred_outline >> 8) & 0xff, Fred_outline & 0xff);
-		render_info.set_replacement_textures(Ships[z].ship_replacement_textures);
+		render_info.set_replacement_textures(model_get_instance(Ships[z].model_instance_num)->texture_replace);
 		render_info.set_flags(j);
 
 		g3_done_instance(0);


### PR DESCRIPTION
Texture replace on a per-instance level was previously reserved for ships only. And for no good reason, given that the model_render parameters could take replacement lists for any model. As such, this PR refactors the whole code for replacement textures, and moves it to a member of polymodel_instance. In addition, this PR properly feeds the new replacement textures to the renderer for any applicable rendering of modelinstances.
At the same time, I've used the opportunity to clean up the code, and most importantly, replace the randomly malloc'd int array with a managed smart pointer that alloc's a fixed sized array (which also takes care of -1 initialization by itself).
