### PR TITLE
Better rand vec for createRandomorientation

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1374,7 +1374,7 @@ void compute_point_on_plane(vec3d *q, const plane *planep, const vec3d *p)
 	vm_vec_scale_add(q, p, &normal, -k);
 }
 
-//	Generate a random vector that's normalized.
+//	Generate a fairly random vector that's normalized.
 void vm_vec_rand_vec(vec3d *rvec)
 {
 	rvec->xyz.x = (frand() - 0.5f) * 2;

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -428,7 +428,7 @@ void compute_point_on_plane(vec3d *q, const plane *planep, const vec3d *p);
 //						plane_point		=>		plane point
 void vm_project_point_onto_plane(vec3d *new_point, const vec3d *point, const vec3d *plane_normal, const vec3d *plane_point);
 
-//	Returns random vector, normalized
+//	Returns fairly random vector, normalized
 void vm_vec_rand_vec(vec3d *rvec);
 
 // Given an point "in" rotate it by "angle" around an

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -219,7 +219,7 @@ ADE_FUNC(createRandomOrientation, l_Base, nullptr, "Creates a random orientation
 	vec3d fvec, uvec;
 	matrix fvec_orient, final_orient;
 
-	vm_vec_rand_vec(&fvec);
+	vm_vec_random_in_sphere(&fvec, &vmd_zero_vector, 1.0f, true);
 	vm_vector_2_matrix(&fvec_orient, &fvec, nullptr, nullptr);
 
 	vm_vec_random_in_circle(&uvec, &vmd_zero_vector, &fvec_orient, 1.0f, true);


### PR DESCRIPTION
Follow-up to #6152. Forgot that `vm_vec_rand_vec` still uses the 'cube' method instead of the one in `vm_vec_random_in_sphere` which actually uses spherically uniform points. I thought about updating createRandomVector this way, and then updating `vm_vec_rand_vec` this way, and well maybe that's better for a separate PR.