### PR TITLE
Fix beam particle velocity

### DIFF
--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -128,6 +128,13 @@ vec3d SourceOrigin::getVelocity() const {
 			return m_origin.m_object.objp->phys_info.vel;
 		case SourceOriginType::PARTICLE:
 			return m_origin.m_particle.lock()->velocity;
+		case SourceOriginType::BEAM: {
+			beam* bm = &Beams[m_origin.m_object.objp->instance];
+			vec3d vel;
+			vm_vec_normalized_dir(&vel, &bm->last_shot, &bm->last_start);
+			vm_vec_scale(&vel, Weapon_info[bm->weapon_info_index].max_speed);
+			return vel;
+		}
 		default:
 			return m_velocity;
 	}

--- a/code/particle/ParticleSourceWrapper.h
+++ b/code/particle/ParticleSourceWrapper.h
@@ -59,9 +59,9 @@ namespace particle
 
 		void setOrientationFromNormalizedVec(const vec3d* normalizedDir, bool relative = false);
 
-		void setOrientationFromVec(const vec3d* dir, const bool relative = false);
+		void setOrientationFromVec(const vec3d* dir, bool relative = false);
 
-		void setOrientationMatrix(const matrix* mtx, const bool relative = false);
+		void setOrientationMatrix(const matrix* mtx, bool relative = false);
 
 		void setOrientationNormal(const vec3d* normal);
 


### PR DESCRIPTION
Previously, particle effects spawned from beams had their source velocity set once at the initiation of the effect, which meant that particles that continuously spawned from a slashing beam would inherit their velocity from the beam's *starting* state, such that the direction would be wrong as soon as the beam moved. I've fixed that by making beam-sourced particles get their velocity from the beam's current direction vector (it might actually be the last frame's; I'm not sure. Either way, it's close enough.), multiplied by its weapon speed.

I am somewhat concerned about performance here -- I don't have much frame of reference for how much it costs to look up these values. In particular, multiplying the vel by the beam's max_speed is only there to make things slightly more intuitive for the modder; without it, one can get identical behavior by just changing the particle effect's +Parent Velocity Factor. So if retrieving the max_speed from weapon_info has a non-negligible cost, I'd be inclined to just remove it.

Another note: a very small commit that removes unnecessary const keywords from two bools, which I was planning to include in a different pull request, seems to have ended up in this branch by mistake. This feels sort of sloppy, and if there's desire for me to disentangle these two commits and separate out the PRs more elegantly, I can, but as far as I can tell including it here won't actually hurt much of anything, so for now I'll PR as-is.