### PR TITLE
Improve Volumetrics Performance

### DIFF
--- a/code/def_files/data/effects/volumetric-f.sdr
+++ b/code/def_files/data/effects/volumetric-f.sdr
@@ -21,9 +21,11 @@ layout (std140) uniform genericData {
 	vec3 globalLightDiffuse;
 	float stepsize;
 	vec3 nebPos;
-	float globalstepalpha;
+	float opacitydistance;
 	vec3 nebSize;
 	float alphalim;
+	vec3 nebulaColor;
+	float udfScale;
 	float emissiveSpreadFactor;
 	float emissiveIntensity;
 	float emissiveFalloff;
@@ -92,11 +94,13 @@ void main()
 
 	vec3 sidestep = 1.0 / vec3(textureSize(volume_tex, 0));
 
-	for(float stept = maxtMin; stept < mintMax; stept += stepsize) {
+	for(float stept = maxtMin; stept < mintMax;) {
 		//Step setup
 		vec3 position = camera + rayDirection * stept - nebPos;
 		vec3 sampleposition = position / nebSize + 0.5;
 		vec4 volume_sample = textureGrad(volume_tex, sampleposition, gradX, gradY);
+
+		float stepsize_current = min(max(stepsize, volume_sample.x * udfScale), mintMax - stept);
 
 #ifdef DO_EDGE_SMOOTHING
 		//Average 3D texel with texels on corner, in an attempt to reduce jagged edges.
@@ -117,7 +121,7 @@ void main()
 		float stepcolor_alpha = volume_sample.a;
 #endif
 
-		float stepalpha = globalstepalpha * stepcolor_alpha;
+		float stepalpha = -(pow(alphalim, 1.0 / (opacitydistance / stepsize_current)) - 1.0f) * stepcolor_alpha;
 		//All the following computations are just required if we have a stepcoloralpha that is non-zero.
 		if(stepcolor_alpha > 0.01)
 		{
@@ -127,10 +131,10 @@ void main()
 			//Diffuse
 #ifdef NOISE
 			//Mix the actual nebula color with the noise color depending on the product of the noise channels multiplied with intensity, smooth-clamped from 0 to 1
-			vec3 stepcolor_neb = mix(volume_sample.rgb, noiseColor,
+			vec3 stepcolor_neb = mix(nebulaColor, noiseColor,
 				smoothstep(0, 1, (textureGrad(noise_volume_tex, position / noiseColorScale1, gradX, gradY).r + textureGrad(noise_volume_tex, position / noiseColorScale2, gradX, gradY).g) / 2.0 * noiseIntensity));
 #else
-			vec3 stepcolor_neb = volume_sample.rgb;
+			vec3 stepcolor_neb = nebulaColor;
 #endif
 			vec3 stepcolor_diffuse = stepcolor_neb * henyey_greenstein(dot(rayDirection, globalLightDirection));
 			float directionalLightStep = 4.0 / float(directionalLightSampleSteps);
@@ -145,17 +149,17 @@ void main()
 			stepcolor_diffuse *= beer_powder_norm * (1 - exp(-directionalLightDepth * 2.0)) * exp(-directionalLightDepth);
 
 			//Emissive
-			cumnebdist += stepcolor_alpha * stepsize;
+			cumnebdist += stepcolor_alpha * stepsize_current;
 			vec3 emissive_lod = textureLod(emissive, fragTexCoord.xy, clamp(cumnebdist * emissiveSpreadFactor, 0, float(textureQueryLevels(emissive) - 1))).rgb;
-			vec3 stepcolor_emissive = emissive_lod.rgb * pow(1 - globalstepalpha, (depth - stept) * emissiveFalloff) * emissiveIntensity;
+			vec3 stepcolor_emissive = emissive_lod.rgb * pow(alphalim, 1.0 / (opacitydistance / ((depth - stept) * emissiveFalloff + 0.01))) * emissiveIntensity;
 
 			//Step finish
 			vec3 stepcolor = clamp(stepcolor_diffuse + stepcolor_emissive, 0, 1);
-			float stepalpha = globalstepalpha * stepcolor_alpha;
 			cumcolor += stepalpha * cumOMAlpha * stepcolor;
 		}
 
 		cumOMAlpha *= 1.0 - stepalpha;
+		stept += stepsize_current;
 
 		if(cumOMAlpha < alphalim)
 			break;

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -99,6 +99,14 @@ struct ivec2 {
 	int x, y;
 };
 
+inline bool operator<(const ivec3& l, const ivec3& r){
+	return l.x < r.x || (l.x == r.x && (l.y < r.y || (l.y == r.y && l.z < r.z)));
+}
+
+inline bool operator<(const ivec2& l, const ivec2& r){
+	return l.x < r.x || (l.x == r.x && l.y < r.y);
+}
+
 namespace scripting {
 	class ade_table_entry;
 }

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -525,6 +525,8 @@ void gr_opengl_deferred_lighting_finish()
 	}
 	else if (The_mission.volumetrics && !override_fog) {
 		GR_DEBUG_SCOPE("Volumetric Nebulae");
+		TRACE_SCOPE(tracing::Volumetrics);
+
 		const volumetric_nebula& neb = *The_mission.volumetrics;
 
 		Assertion(neb.isVolumeBitmapValid(), "The volumetric nebula was not properly initialized!");
@@ -550,9 +552,11 @@ void gr_opengl_deferred_lighting_finish()
 			uint32_t array_index;
 			gr_set_texture_addressing(TMAP_ADDRESS_CLAMP);
 			gr_opengl_tcache_set(neb.getVolumeBitmapHandle(), TCACHE_TYPE_3DTEX, &u_scale, &v_scale, &array_index, 3);
+			glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 			if (neb.getNoiseActive()) {
 				gr_set_texture_addressing(TMAP_ADDRESS_WRAP);
 				gr_opengl_tcache_set(neb.getNoiseVolumeBitmapHandle(), TCACHE_TYPE_3DTEX, &u_scale, &v_scale, &array_index, 4);
+				glTexParameteri(GL_TEXTURE_3D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 			}
 		}
 

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -571,8 +571,12 @@ void gr_opengl_deferred_lighting_finish()
 			data->nebPos = neb.getPos();
 			data->nebSize = neb.getSize();
 			data->stepsize = neb.getStepsize();
-			data->globalstepalpha = neb.getStepalpha();
+			data->opacitydistance = neb.getOpacityDistance();
 			data->alphalimit = neb.getAlphaLim();
+			data->nebColor[0] = std::get<0>(neb.getNebulaColor());
+			data->nebColor[1] = std::get<1>(neb.getNebulaColor());
+			data->nebColor[2] = std::get<2>(neb.getNebulaColor());
+			data->udfScale = neb.getUDFScale();
 			data->emissiveSpreadFactor = neb.getEmissiveSpread();
 			data->emissiveIntensity = neb.getEmissiveIntensity();
 			data->emissiveFalloff = neb.getEmissiveFalloff();

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -319,10 +319,13 @@ struct volumetric_fog_data {
 	float stepsize;
 	
 	vec3d nebPos;
-	float globalstepalpha;
+	float opacitydistance;
 	
 	vec3d nebSize;
 	float alphalimit;
+
+	float nebColor[3];
+	float udfScale;
 	
 	float emissiveSpreadFactor;
 	float emissiveIntensity;

--- a/code/nebula/volumetrics.cpp
+++ b/code/nebula/volumetrics.cpp
@@ -507,7 +507,7 @@ float volumetric_nebula::getAlphaToPos(const vec3d& pnt, float distance_mult) co
 	}
 
 	float alpha = 1.0f;
-	const float stepalpha = -(powf(getAlphaLim(), 1.0 / (getOpacityDistance() / getStepsize())) - 1.0f);
+	const float stepalpha = -(powf(getAlphaLim(), 1.0f / (getOpacityDistance() / getStepsize())) - 1.0f);
 	const int n = 1 << resolution;
 	for (float stept = maxTmin; stept < minTmax; stept += getStepsize()) {
 		vec3d localpos = (Eye_position + (ray_direction * stept) - bb_min) / size * static_cast<float>(n);

--- a/code/nebula/volumetrics.cpp
+++ b/code/nebula/volumetrics.cpp
@@ -151,6 +151,10 @@ const vec3d& volumetric_nebula::getSize() const {
 	return size;
 }
 
+const std::tuple<float, float, float>& volumetric_nebula::getNebulaColor() const {
+	return nebulaColor;
+}
+
 bool volumetric_nebula::getEdgeSmoothing() const {
 	return Detail.nebula_detail == MAX_DETAIL_LEVEL || doEdgeSmoothing; //Only for highest setting, or when the lab has an override.
 }
@@ -177,10 +181,6 @@ float volumetric_nebula::getOpacityDistance() const {
 
 float volumetric_nebula::getStepsize() const {
 	return getOpacityDistance() / static_cast<float>(getSteps());
-}
-
-float volumetric_nebula::getStepalpha() const {
-	return -(powf(getAlphaLim(), 1.0f / static_cast<float>(getSteps())) - 1.0f);
 }
 
 float volumetric_nebula::getAlphaLim() const {
@@ -246,6 +246,25 @@ static anl::CInstructionIndex getCustomNoise(anl::CKernel& kernel, const SCP_str
 	return builder.eval(expression);
 }
 
+static inline std::array<ivec3, 6> getNeighbors(const ivec3& pnt){
+	return {
+		ivec3{pnt.x+1, pnt.y, pnt.z},
+		ivec3{pnt.x-1, pnt.y, pnt.z},
+		ivec3{pnt.x, pnt.y+1, pnt.z},
+		ivec3{pnt.x, pnt.y-1, pnt.z},
+		ivec3{pnt.x, pnt.y, pnt.z+1},
+		ivec3{pnt.x, pnt.y, pnt.z-1}
+	};
+}
+
+//Nebula distance must be a lower bound to avoid errors, so subtract sqrt(2) in each dimension
+static inline float getNebDistSquared(const ivec3& l, const ivec3& r, const vec3d& scale) {
+	int dx = (l.x - r.x) * (l.x - r.x) - 2;
+	int dy = (l.y - r.y) * (l.y - r.y) - 2;
+	int dz = (l.z - r.z) * (l.z - r.z) - 2;
+	return (dx < 0 ? 0 : dx) * scale.xyz.x * scale.xyz.x + (dy < 0 ? 0 : dy) * scale.xyz.y * scale.xyz.y + (dz < 0 ? 0 : dz) * scale.xyz.z * scale.xyz.z;
+}
+
 void volumetric_nebula::renderVolumeBitmap() {
 	Assertion(!hullPof.empty(), "Volumetric Nebula was not properly configured. Did you call parse_volumetric_nebula()?");
 	Assertion(!isVolumeBitmapValid(), "Volume bitmap was already rendered!");
@@ -277,6 +296,7 @@ void volumetric_nebula::renderVolumeBitmap() {
 	//Calculate minimum "bottom left" corner of scaled size box
 	vec3d bl = pm->mins - (size * ((scaleFactor - 1.0f) / 2.0f / scaleFactor));
 
+	//Go through sampling procedure to test where the nebula even is
 	for (int x = 0; x < nSample; x++) {
 		for (int y = 0; y < nSample; y++) {
 			vec3d start = bl;
@@ -321,26 +341,98 @@ void volumetric_nebula::renderVolumeBitmap() {
 
 	model_unload(modelnum);
 
+	//Sample the nebula values from the binary cubegrid.
 	volumeBitmapData = make_unique<ubyte[]>(n * n * n * 4);
-	float oversamplingDivisor = 255.0f / static_cast<float>((1 << (oversampling - 1)) + 1);
+	int oversamplingCount = (1 << (oversampling - 1)) + 1;
+	float oversamplingDivisor = 255.1f / static_cast<float>(oversamplingCount);
 	for (int x = 0; x < n; x++) {
 		for (int y = 0; y < n; y++) {
 			for (int z = 0; z < n; z++) {
-				volumeBitmapData[COLOR_3D_ARRAY_POS(n, R, x, y, z)] = static_cast<ubyte>(std::get<0>(nebulaColor) * 255.0f);
-				volumeBitmapData[COLOR_3D_ARRAY_POS(n, G, x, y, z)] = static_cast<ubyte>(std::get<1>(nebulaColor) * 255.0f);
-				volumeBitmapData[COLOR_3D_ARRAY_POS(n, B, x, y, z)] = static_cast<ubyte>(std::get<2>(nebulaColor) * 255.0f);
-				
-				float sum = 0.0f;
+				int sum = 0;
 				for (int sx = x * oversampling; sx <= (x + 1) * oversampling; sx++) {
 					for (int sy = y * oversampling; sy <= (y + 1) * oversampling; sy++) {
 						for (int sz = z * oversampling; sz <= (z + 1) * oversampling; sz++) {
 							if (volumeSampleCache[sx * nSample * nSample + sy * nSample + sz])
-								sum += 1.0f;
+								sum++;
 						}
 					}
 				}
-				
-				volumeBitmapData[COLOR_3D_ARRAY_POS(n, A, x, y, z)] = static_cast<ubyte>(sum * oversamplingDivisor);
+
+				volumeBitmapData[COLOR_3D_ARRAY_POS(n, A, x, y, z)] = static_cast<ubyte>(static_cast<float>(sum) * oversamplingDivisor);
+			}
+		}
+	}
+
+	// Test for edges in the nebula to compute the UDF
+	auto volumeEdgeCache = make_unique<ivec3[]>(n * n * n);
+	SCP_set<ivec3> udfBFS_checking, udfBFS_to_check;
+
+	for (int x = 0; x < n; x++) {
+		for (int y = 0; y < n; y++) {
+			for (int z = 0; z < n; z++) {
+				const ubyte& nebula_density = volumeBitmapData[COLOR_3D_ARRAY_POS(n, A, x, y, z)];
+
+				//If we have neither full nor no nebula presence, it's an edge.
+				if (nebula_density > 0 && nebula_density < 255) {
+					udfBFS_to_check.emplace(ivec3{x, y, z});
+					volumeEdgeCache[x * n * n + y * n + z] = ivec3{x, y, z};
+				}
+				else {
+					bool found_edge = false;
+					//it's possible that we get completely sharp edges. So test for that.
+					for (const ivec3& neighbor : getNeighbors({x, y, z})){
+						if (neighbor.x < 0 || neighbor.x >= n || neighbor.y < 0 || neighbor.y >= n || neighbor.z < 0 || neighbor.z >= n)
+							continue;
+
+						if (nebula_density != volumeBitmapData[COLOR_3D_ARRAY_POS(n, A, neighbor.x, neighbor.y, neighbor.z)]){
+							found_edge = true;
+							break;
+						}
+					}
+
+					if (found_edge) {
+						udfBFS_to_check.emplace(ivec3{x, y, z});
+						volumeEdgeCache[x * n * n + y * n + z] = ivec3{x, y, z};
+					}
+					else
+						volumeEdgeCache[x * n * n + y * n + z] = ivec3{-1, -1, -1};
+				}
+			}
+		}
+	}
+
+	//BFS from the known nebula edges to find the distance to the closest edge
+	while(!udfBFS_to_check.empty()){
+		udfBFS_checking = udfBFS_to_check;
+		udfBFS_to_check.clear();
+
+		for (const ivec3& toCheck : udfBFS_checking){
+			const ivec3& closestEdgeTile = volumeEdgeCache[toCheck.x * n * n + toCheck.y * n + toCheck.z];
+
+			for (const ivec3& neighbor : getNeighbors(toCheck)) {
+				if (neighbor.x < 0 || neighbor.x >= n || neighbor.y < 0 || neighbor.y >= n || neighbor.z < 0 || neighbor.z >= n)
+					continue;
+
+				ivec3& neighborClosestEdgeTile = volumeEdgeCache[neighbor.x * n * n + neighbor.y * n + neighbor.z];
+
+				if (neighborClosestEdgeTile.x < 0 || getNebDistSquared(neighbor, closestEdgeTile, size) < getNebDistSquared(neighbor, neighborClosestEdgeTile, size)) {
+					neighborClosestEdgeTile = closestEdgeTile;
+					udfBFS_to_check.emplace(neighbor);
+				}
+			}
+		}
+	}
+
+	//Compute the actual UDF from the BFS
+	//scale is the maximal distance possible.
+	udfScale = vm_vec_mag(&size);
+	for (int x = 0; x < n; x++) {
+		for (int y = 0; y < n; y++) {
+			for (int z = 0; z < n; z++) {
+				float dist = sqrtf(getNebDistSquared(ivec3{x, y, z}, volumeEdgeCache[x * n * n + y * n + z], size)) / static_cast<float>(n); //in meters
+				volumeBitmapData[COLOR_3D_ARRAY_POS(n, R, x, y, z)] = static_cast<ubyte>(dist / udfScale * 255.0f); //UDF
+				volumeBitmapData[COLOR_3D_ARRAY_POS(n, G, x, y, z)] = 0; // Reserved
+				volumeBitmapData[COLOR_3D_ARRAY_POS(n, B, x, y, z)] = 0; // Reserved
 			}
 		}
 	}
@@ -392,6 +484,10 @@ int volumetric_nebula::getNoiseVolumeBitmapHandle() const {
 	return noiseVolumeBitmapHandle;
 }
 
+float volumetric_nebula::getUDFScale() const {
+	return udfScale;
+}
+
 float volumetric_nebula::getAlphaToPos(const vec3d& pnt, float distance_mult) const {
 	// This pretty much emulates the volumetric shader. This could be slow, so I hope it's not needed too often
 	vec3d ray_direction;
@@ -411,7 +507,7 @@ float volumetric_nebula::getAlphaToPos(const vec3d& pnt, float distance_mult) co
 	}
 
 	float alpha = 1.0f;
-	const float stepalpha = getStepalpha();
+	const float stepalpha = -(powf(getAlphaLim(), 1.0 / (getOpacityDistance() / getStepsize())) - 1.0f);
 	const int n = 1 << resolution;
 	for (float stept = maxTmin; stept < minTmax; stept += getStepsize()) {
 		vec3d localpos = (Eye_position + (ray_direction * stept) - bb_min) / size * static_cast<float>(n);

--- a/code/nebula/volumetrics.h
+++ b/code/nebula/volumetrics.h
@@ -76,6 +76,8 @@ class volumetric_nebula {
 	int noiseVolumeBitmapHandle = -1;
 	std::unique_ptr<ubyte[]> noiseVolumeBitmapData = nullptr;
 
+	float udfScale = 1.0f;
+
 	//Friend things that are allowed to directly manipulate "current" volumetrics. Only FRED and the Lab. In all other cases, "sensibly constant" values behave properly RAII and stay constant afterwards.
 	friend class LabUi; //Lab
 	friend class CFred_mission_save; //FRED
@@ -89,6 +91,7 @@ public:
 
 	const vec3d& getPos() const;
 	const vec3d& getSize() const;
+	const std::tuple<float, float, float>& getNebulaColor() const;
 
 	bool getEdgeSmoothing() const;
 	int getSteps() const;
@@ -96,7 +99,6 @@ public:
 
 	float getOpacityDistance() const;
 	float getStepsize() const;
-	float getStepalpha() const;
 	float getAlphaLim() const;
 
 	float getEmissiveSpread() const;
@@ -116,6 +118,7 @@ public:
 	void renderVolumeBitmap();
 	int getVolumeBitmapHandle() const;
 	int getNoiseVolumeBitmapHandle() const;
+	float getUDFScale() const;
 
 	float getAlphaToPos(const vec3d& pnt, float distance_mult) const;
 };

--- a/code/tracing/categories.cpp
+++ b/code/tracing/categories.cpp
@@ -96,6 +96,8 @@ Category RenderNavBracket("Render Nav bracket", true);
 Category MainFrame("Main Frame", true);
 Category PageFlip("Page flip", true);
 
+Category Volumetrics("Volumetrics", true);
+
 Category NanoVGFlushFrame("NanoVG flush frame", true);
 Category NanoVGDrawFill("NanoVG Draw fill", true);
 Category NanoVGDrawConvexFill("NanoVG Draw convex fill", true);

--- a/code/tracing/categories.h
+++ b/code/tracing/categories.h
@@ -109,6 +109,8 @@ extern Category RenderNavBracket;
 extern Category MainFrame;
 extern Category PageFlip;
 
+extern Category Volumetrics;
+
 extern Category NanoVGFlushFrame;
 extern Category NanoVGDrawFill;
 extern Category NanoVGDrawConvexFill;


### PR DESCRIPTION
Since voluemtrics are starting to see some actual use, it's time to grab some of the low-hanging fruit for performance.
Notably, previous volumetrics would raymarch until the opacity of the nebula trended towards maximum.
That is evidently bad for any pixel that is outside of the actual nebula, but within the area where the nebula needs to be tested for. These parts would require many, many samples, so especially sparse nebula that needed many steps were really really slow.
This improves on this by supplying the shader with an unsigned distance function of the volumetrics. Essentially, the shader is able to increase its nebula query step-size to x if it knows, that the nebula will not change within this distance x. 
In addition, as this makes the stepsize dynamic, it allows to fix the banding that was observed for things in nebulae before.
One downside is that preparing the mission takes a tiny bit longer to load as the UDF needs to be calculated, but that's probably negligible

Some screenshots to show the differences.
<details>
  <summary>base-case, nebula quality 1/5:</summary>
previously:

![pre_low](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/4dd3d05c-014c-4ff0-842d-00e159fdb6c0)
this PR:
![post_low](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/af421328-8e15-4be6-ab1b-d1a83aae9ab4)
comment: Almost no change, as the low setting prevents a large number of steps anyways.
</details>
<details>
  <summary>base-case, nebula quality 5/5:</summary>
previously:

![pre_high](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/c51c8ed2-5e2c-46ae-b686-3b974ce12e5f)
this PR:
![post_high](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/00a2b788-c5be-499b-b15a-469a18ee0547)
comment: Basically halved the volumetrics cost.
</details>
<details>
  <summary>worst-case, nebula quality 1/5:</summary>
previously:

![pre3_low](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/a2043fde-9dd5-48a1-99cc-c193dabd868b)
this PR:
![post3_low](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/311de5d9-875a-45d0-80da-94ff629cf385)
comment: Almost no change, except for more stable frametimes for some reason.
</details>
<details>
  <summary>worst-case, nebula quality 5/5:</summary>
previously:

![pre3_high](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/8f829712-51d9-4430-829a-4d3e776edff6)
this PR:
![post3_high](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/4732083c-0bdc-435e-ad08-aabe67952827)
comment: This is the case where the UDF can have the largest impact: A very thick nebula (thus needing low-distance steps to converge to maximum opacity) with regions that don't actually contain nebula. Nebula cost is only a third of what it was prior to the PR
</details>
<details>
  <summary>quality improvement</summary>
previously:

![pre2_low](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/9a41a2b1-e367-4209-b9ae-6b226d7bcc6a)
this PR:
![post2_low](https://github.com/scp-fs2open/fs2open.github.com/assets/6238428/25117724-d3f5-4561-a6ed-4176c8771a01)
comment: As visible, this PR gets rid of the banding on the ship in the nebula. This is the case for all quality levels (though higher quality levels were able to have more, respectively less visible bands prior to this PR). As the entire screen quickly converges to full opacity, the UDF does not improve performance here.
</details>