### PR TITLE
Fix for 'decloaking' effect

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -20737,6 +20737,8 @@ void ship_render_set_animated_effect(model_render_params *render_info, ship *shi
 	if ( timestamp_elapsed(shipp->shader_effect_timestamp) ) {
 		shipp->flags.set(Ship_Flags::Cloaked, sep->disables_rendering);
 		shipp->shader_effect_timestamp = TIMESTAMP::invalid();
+	} else {
+		shipp->flags.remove(Ship_Flags::Cloaked);
 	}
 }
 


### PR DESCRIPTION
Follow-up to #4757. Fixes #6164. If the effect timestamp is valid and not yet elapsed, then the cloak flag should be off. Only a fully completed, `disables_rendering` effect gets the 'cloak' flag.