### PR TITLE
Makes random life factor of children configurable.

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -418,6 +418,8 @@ struct weapon_info
     int maximum_children_spawned;		// An upper bound for the total number of spawned children, used by multi
     spawn_weapon_info spawn_info[MAX_SPAWN_TYPES_PER_WEAPON];
 
+	float as_child_life_rand_factor;
+
 	// swarm count
 	short swarm_count;						// how many swarm missiles are fired for this weapon
 	int SwarmWait;                  // *Swarm firewait, default is 150  -Et1

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -418,7 +418,7 @@ struct weapon_info
     int maximum_children_spawned;		// An upper bound for the total number of spawned children, used by multi
     spawn_weapon_info spawn_info[MAX_SPAWN_TYPES_PER_WEAPON];
 
-	float as_child_life_rand_factor;
+	float lifetime_variation_factor_when_child;
 
 	// swarm count
 	short swarm_count;						// how many swarm missiles are fired for this weapon

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2616,9 +2616,9 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 	}
 
-	if (optional_string("$As Child Life Rand Factor:"))
+	if (optional_string("$Lifetime Variation Factor When Child:"))
 	{
-		stuff_float(&wip->as_child_life_rand_factor);
+		stuff_float(&wip->lifetime_variation_factor_when_child);
 	}
 
 	if (wip->wi_flags[Weapon::Info_Flags::Local_ssm] && optional_string("$Local SSM:"))
@@ -6974,7 +6974,7 @@ void spawn_child_weapons(object *objp, int spawn_index_override)
 						rand_val = static_randf(objp->net_signature + j);
 					}
 
-					float child_factor = child_wip->as_child_life_rand_factor;
+					float child_factor = child_wip->lifetime_variation_factor_when_child;
 
 					Weapons[Objects[weapon_objnum].instance].lifeleft *= std::max(0.01f, rand_val*(child_factor*2.0f) + (1.0f - child_factor));
 					if (child_wip->wi_flags[Weapon::Info_Flags::Remote]) {
@@ -9250,7 +9250,7 @@ void weapon_info::reset()
 		this->spawn_info[i].spawn_chance = 1.f;
 	}
 
-	this->as_child_life_rand_factor = 0.2;
+	this->lifetime_variation_factor_when_child = 0.2;
 
 	this->swarm_count = -1;
 	// *Default is 150  -Et1

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2616,6 +2616,11 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 	}
 
+	if (optional_string("$As Child Life Rand Factor:"))
+	{
+		stuff_float(&wip->as_child_life_rand_factor);
+	}
+
 	if (wip->wi_flags[Weapon::Info_Flags::Local_ssm] && optional_string("$Local SSM:"))
 	{
 		if(optional_string("+Warpout Delay:")) {
@@ -6969,7 +6974,9 @@ void spawn_child_weapons(object *objp, int spawn_index_override)
 						rand_val = static_randf(objp->net_signature + j);
 					}
 
-					Weapons[Objects[weapon_objnum].instance].lifeleft *= rand_val*0.4f + 0.8f;
+					float child_factor = child_wip->as_child_life_rand_factor;
+
+					Weapons[Objects[weapon_objnum].instance].lifeleft *= std::max(0.01f, rand_val*(child_factor*2.0f) + (1.0f - child_factor));
 					if (child_wip->wi_flags[Weapon::Info_Flags::Remote]) {
 						parent_shipp->weapons.detonate_weapon_time = timestamp((int)(DEFAULT_REMOTE_DETONATE_TRIGGER_WAIT * 1000));
 						parent_shipp->weapons.remote_detonaters_active++;
@@ -9242,6 +9249,8 @@ void weapon_info::reset()
 		this->spawn_info[i].spawn_interval_delay = -1.f;
 		this->spawn_info[i].spawn_chance = 1.f;
 	}
+
+	this->as_child_life_rand_factor = 0.2;
 
 	this->swarm_count = -1;
 	// *Default is 150  -Et1


### PR DESCRIPTION
While working on another feature that involves weapon spawning, I discovered that the lifetime of spawned weapons is automatically increased or decreased by a hardcoded random factor bounded at 0.2 in either direction, and began screaming.

@Baezon pointed out that the proper way to approach this would be to make it configurable, so I did that. I think it's sort of a tossup whether it's better to have it be a parameter on the parent weapon or on the child weapon, but I went with child. I also made it so that the parameter can be arbitrarily large, but the resulting random multiplier for lifetime is bounded at 0.01.

Also, I'm 100% open to suggestions for the parameter name, because this one sucks.