### PR TITLE
Allow overriding low-level keypresses

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2091,7 +2091,7 @@ int control_config_bind_key_on_frame(int ctrl, selItem item, bool API_Access)
 		}
 
 		if ((ctrl == BANK_WHEN_PRESSED || ctrl == GLIDE_WHEN_PRESSED) && (Last_key >= 0) && (k <= 0) &&
-			!keyd_pressed[Last_key]) {
+			!key_is_pressed(Last_key)) {
 			// If the selected cc_item is BANK_WHEN_PRESSED or GLIDE_WHEN_PRESSED, and
 			// If the polled key is a modifier, and
 			// k was consumed, and
@@ -2820,12 +2820,12 @@ int check_control_used(int id, int key)
 
 		// check what current modifiers are pressed
 		mask = 0;
-		if (keyd_pressed[KEY_LSHIFT] || key_down_count(KEY_LSHIFT) || keyd_pressed[KEY_RSHIFT] || key_down_count(KEY_RSHIFT)) {
+		if (key_is_pressed(KEY_LSHIFT, true) || key_is_pressed(KEY_RSHIFT, true)) {
 			// Any shift key is pressed, add KEY_SHIFTED mask
 			mask |= KEY_SHIFTED;
 		}
 
-		if (keyd_pressed[KEY_LALT] || key_down_count(KEY_LALT) || keyd_pressed[KEY_RALT] || key_down_count(KEY_RALT)) {
+		if (key_is_pressed(KEY_LALT, true) || key_is_pressed(KEY_RALT, true)) {
 			// Any alt key is pressed, add KEY_ALTED to the mask
 			mask |= KEY_ALTED;
 		}
@@ -2841,7 +2841,7 @@ int check_control_used(int id, int key)
 
 			z &= KEY_MASK;
 
-			if (keyd_pressed[z] || key_down_count(z)) {
+			if (key_is_pressed(z, true)) {
 				// Key combo is pressed, control activated
 				control_used(id);
 				return 1;

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -508,7 +508,7 @@ int hud_squadmsg_read_key( int k )
 		// after messaging is over.  Return true for a while.
 		if ( !timestamp_elapsed(Msg_eat_key_timestamp) ) {
 			for (i = 0; i < num_keys_used; i++ ) {
-				if ( keyd_pressed[keys_used[i]] )
+				if ( key_is_pressed(keys_used[i]) )
 					return 1;
 			}
 		}
@@ -524,7 +524,7 @@ int hud_squadmsg_read_key( int k )
 				key_found = 1;
 			}
 
-			if ( keyd_pressed[k] ) {
+			if ( key_is_pressed(k) ) {
 				key_found = 1;
 			}
 

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -22,20 +22,23 @@
 #include "osapi/osapi.h"
 
 //-------- Variable accessed by outside functions ---------
-ubyte				keyd_repeat;
-ubyte				keyd_pressed[NUM_KEYS];
-int				keyd_time_when_last_pressed;
+bool				key_allow_repeat;
 
 typedef struct keyboard	{
 	enum class key_state : uint8_t { RELEASED, PRESSED, PRESSED_OVERRIDDEN };
 	std::array<key_state, NUM_KEYS> state;
 	SCP_queue<uint> key_queue;
-	uint				TimeKeyWentDown[NUM_KEYS];
-	uint				TimeKeyHeldDown[NUM_KEYS];
-	uint				TimeKeyDownChecked[NUM_KEYS];
-	uint				NumDowns[NUM_KEYS];
-	uint				NumUps[NUM_KEYS];
-	int				down_check[NUM_KEYS];  // nonzero if has been pressed yet this mission
+
+	//The time that the key was pressed
+	uint TimeKeyWentDown[NUM_KEYS];
+
+	//The cumulative time that the key has been held down.
+	//This explicitly excludes any time the button has been down in the current press if the button is pressed.
+	uint TimeKeyHeldDown[NUM_KEYS];
+	uint TimeKeyDownChecked[NUM_KEYS];
+	uint NumDowns[NUM_KEYS];
+	uint NumUps[NUM_KEYS];
+	int down_check[NUM_KEYS];  // nonzero if has been pressed yet this mission
 } keyboard;
 
 keyboard key_data;
@@ -301,7 +304,7 @@ void key_flush()
 	CurTime = timer_get_milliseconds();
 
 	for (i=0; i<NUM_KEYS; i++ )	{
-		keyd_pressed[i] = 0;
+		key_data.state[i] = keyboard::key_state::RELEASED;
 		key_data.TimeKeyDownChecked[i] = CurTime;
 		key_data.TimeKeyWentDown[i] = CurTime;
 		key_data.TimeKeyHeldDown[i] = 0;
@@ -310,16 +313,6 @@ void key_flush()
 	}
 
 	SDL_UnlockMutex( key_lock );	
-}
-
-//	A nifty function which performs the function:
-//		n = (n+1) % KEY_BUFFER_SIZE
-//	(assuming positive values of n).
-int add_one( int n )
-{
-	n++;
-	if ( n >= KEY_BUFFER_SIZE ) n=0;
-	return n;
 }
 
 // Returns 1 if character waiting... 0 otherwise
@@ -355,11 +348,16 @@ int key_inkey()
 		key_data.key_queue.pop();
 	}
 
-	SDL_UnlockMutex( key_lock );	
+	SDL_UnlockMutex( key_lock );
 
 	Current_key_down = key;
 
 	return key;
+}
+
+bool key_is_pressed(int keycode, bool include_since_last_count) {
+	Assertion(keycode >= 0 && keycode < NUM_KEYS, "Checked status for invalid keycode!");
+	return key_data.state[keycode] == keyboard::key_state::PRESSED || (include_since_last_count && key_down_count(keycode) > 0);
 }
 
 // If not installed, uses BIOS and returns getch();
@@ -387,20 +385,20 @@ uint key_get_shift_status()
 
 	SDL_LockMutex( key_lock );		
 
-	if ( keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT] )
+	if ( key_is_pressed(KEY_LSHIFT) || key_is_pressed(KEY_RSHIFT) )
 		shift_status |= KEY_SHIFTED;
 
-	if ( keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT] )
+	if ( key_is_pressed(KEY_LALT) || key_is_pressed(KEY_RALT) )
 		shift_status |= KEY_ALTED;
 
-	if ( keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL] )
+	if ( key_is_pressed(KEY_LCTRL) || key_is_pressed(KEY_RCTRL) )
 		shift_status |= KEY_CTRLED;
 
 #ifndef NDEBUG
-	if (keyd_pressed[KEY_DEBUG_KEY])
+	if (key_is_pressed(KEY_DEBUG_KEY))
 		shift_status |= KEY_DEBUGGED;
 #else
-	if (keyd_pressed[KEY_DEBUG_KEY]) {
+	if (key_is_pressed(KEY_DEBUG_KEY)) {
 		mprintf(("Cheats_enabled = %i, Key_normal_game = %i\n", Cheats_enabled, Key_normal_game));
 		if ((Cheats_enabled) && Key_normal_game) {
 			mprintf(("Debug key\n"));
@@ -415,11 +413,8 @@ uint key_get_shift_status()
 
 //	Returns amount of time key (specified by "code") has been down since last call.
 //	Returns float, unlike key_down_time() which returns a fix.
-float key_down_timef(uint scancode)	
+float key_down_timef(uint scancode)
 {
-	uint time_down, time;
-	uint delta_time;
-
 	if ( !key_inited ) {
 		return 0.0f;
 	}
@@ -430,13 +425,14 @@ float key_down_timef(uint scancode)
 
 	SDL_LockMutex( key_lock );		
 
-	time = timer_get_milliseconds();
-	delta_time = time - key_data.TimeKeyDownChecked[scancode];
+	uint time = timer_get_milliseconds();
+	uint last_check_time = key_data.TimeKeyDownChecked[scancode];
+	uint delta_time = time - last_check_time;
 	key_data.TimeKeyDownChecked[scancode] = time;
 
 	if ( delta_time <= 1 ) {
-		key_data.TimeKeyWentDown[scancode] = time;
-		if (keyd_pressed[scancode])	{
+		key_data.TimeKeyHeldDown[scancode] = 0;
+		if (key_is_pressed(scancode))	{
 			SDL_UnlockMutex( key_lock );		
 			return 1.0f;
 		} else	{
@@ -445,13 +441,13 @@ float key_down_timef(uint scancode)
 		}
 	}
 
-	if ( !keyd_pressed[scancode] )	{
-		time_down = key_data.TimeKeyHeldDown[scancode];
-		key_data.TimeKeyHeldDown[scancode] = 0;
-	} else	{
-		time_down =  time - key_data.TimeKeyWentDown[scancode];
-		key_data.TimeKeyWentDown[scancode] = time;
+	uint time_down = key_data.TimeKeyHeldDown[scancode];
+	if ( key_is_pressed(scancode) ) {
+		//Since the stored time only updates on button release and reset on this check,
+		//the time the button has been held down this time needs to be added
+		time_down += time - MAX(key_data.TimeKeyWentDown[scancode], last_check_time);
 	}
+	key_data.TimeKeyHeldDown[scancode] = 0;
 
 	SDL_UnlockMutex( key_lock );		
 
@@ -481,7 +477,7 @@ int key_down_count(int scancode)
 //void key_mark( uint code, int state )
 void key_mark( uint code, int state, uint latency )
 {
-	uint scancode, breakbit, temp, event_time;
+	uint scancode, breakbit, event_time;
 	ushort keycode;	
 
 	if ( !key_inited ) return;
@@ -504,32 +500,24 @@ void key_mark( uint code, int state, uint latency )
 	
 	if (breakbit) {
 		// Key going up
-		keyd_pressed[scancode] = 0;
+		key_data.state[scancode] = keyboard::key_state::RELEASED;
 		key_data.NumUps[scancode]++;
-
-		// What is the point of this code?  "temp" is never used!
-		temp = 0;
-		temp |= keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT];
-		temp |= keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT];
-		temp |= keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL];
-		temp |= keyd_pressed[KEY_DEBUG_KEY];
 	
-		if (event_time < key_data.TimeKeyWentDown[scancode]) {
-			key_data.TimeKeyHeldDown[scancode] = 0;
-		} else {
+		if (event_time >= key_data.TimeKeyWentDown[scancode]) {
+			//If the suspected key lift is "before" the key was pressed (i.e. fluctuating latency) we don't add any time to the pressed time since last poll
 			key_data.TimeKeyHeldDown[scancode] += event_time - key_data.TimeKeyWentDown[scancode];
 		}
 
 		Current_key_down = scancode;
-		if ( keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT] ) {
+		if ( key_is_pressed(KEY_LSHIFT) || key_is_pressed(KEY_RSHIFT) ) {
 			Current_key_down |= KEY_SHIFTED;
 		}
 
-		if ( keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT] ) {
+		if ( key_is_pressed(KEY_LALT) || key_is_pressed(KEY_RALT) ) {
 			Current_key_down |= KEY_ALTED;
 		}
 
-		if ( keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL] ) {
+		if ( key_is_pressed(KEY_LCTRL) || key_is_pressed(KEY_RCTRL) ) {
 			Current_key_down |= KEY_CTRLED;
 		}
 
@@ -539,25 +527,24 @@ void key_mark( uint code, int state, uint latency )
 		}
 	} else {
 		// Key going down
-		keyd_time_when_last_pressed = event_time;
-		if (!keyd_pressed[scancode]) {
+		if (!key_is_pressed(scancode)) {
 			// First time down
 			key_data.TimeKeyWentDown[scancode] = event_time;
-			keyd_pressed[scancode] = 1;
+			key_data.state[scancode] = keyboard::key_state::PRESSED;
 			key_data.NumDowns[scancode]++;
 			key_data.down_check[scancode]++;
 
 			//WMC - For scripting
 			Current_key_down = scancode;
-			if ( keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT] ) {
+			if ( key_is_pressed(KEY_LSHIFT) || key_is_pressed(KEY_RSHIFT) ) {
 				Current_key_down |= KEY_SHIFTED;
 			}
 
-			if ( keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT] ) {
+			if ( key_is_pressed(KEY_LALT) || key_is_pressed(KEY_RALT) ) {
 				Current_key_down |= KEY_ALTED;
 			}
 
-			if ( keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL] ) {
+			if ( key_is_pressed(KEY_LCTRL) || key_is_pressed(KEY_RCTRL) ) {
 				Current_key_down |= KEY_CTRLED;
 			}
 
@@ -565,7 +552,7 @@ void key_mark( uint code, int state, uint latency )
 				scripting::hooks::OnKeyPressed->run(scripting::hook_param_list(
 					scripting::hook_param("Key", 's', textify_scancode_universal(Current_key_down))));
 			}
-		} else if (!keyd_repeat) {
+		} else if (!key_allow_repeat) {
 			// Don't buffer repeating key if repeat mode is off
 			scancode = 0xAA;		
 		} 
@@ -573,24 +560,24 @@ void key_mark( uint code, int state, uint latency )
 		if ( scancode!=0xAA ) {
 			keycode = (unsigned short)scancode;
 
-			if ( keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT] ) {
+			if ( key_is_pressed(KEY_LSHIFT) || key_is_pressed(KEY_RSHIFT) ) {
 				keycode |= KEY_SHIFTED;
 			}
 
-			if ( keyd_pressed[KEY_LALT] || keyd_pressed[KEY_RALT] ) {
+			if ( key_is_pressed(KEY_LALT) || key_is_pressed(KEY_RALT) ) {
 				keycode |= KEY_ALTED;
 			}
 
-			if ( keyd_pressed[KEY_LCTRL] || keyd_pressed[KEY_RCTRL] ) {
+			if ( key_is_pressed(KEY_LCTRL) || key_is_pressed(KEY_RCTRL) ) {
 				keycode |= KEY_CTRLED;
 			}
 
 #ifndef NDEBUG
-			if ( keyd_pressed[KEY_DEBUG_KEY] ) {
+			if ( key_is_pressed(KEY_DEBUG_KEY) ) {
 				keycode |= KEY_DEBUGGED;
 			}
 #else
-			if ( keyd_pressed[KEY_DEBUG_KEY] ) {
+			if ( key_is_pressed(KEY_DEBUG_KEY) ) {
 				mprintf(("Cheats_enabled = %i, Key_normal_game = %i\n", Cheats_enabled, Key_normal_game));
 				if (Cheats_enabled && Key_normal_game) {
 					keycode |= KEY_DEBUGGED1;
@@ -634,8 +621,7 @@ void key_init()
 
 	FillSDLArray();
 
-	keyd_time_when_last_pressed = timer_get_milliseconds();
-	keyd_repeat = 1;
+	key_allow_repeat = true;
 
 	// Clear the keyboard array
 	key_flush();

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -25,10 +25,7 @@
 #define KEY_BUFFER_SIZE 16
 
 //-------- Variable accessed by outside functions ---------
-ubyte				keyd_buffer_type;		// 0=No buffer, 1=buffer ASCII, 2=buffer scans
 ubyte				keyd_repeat;
-uint				keyd_last_pressed;
-uint				keyd_last_released;
 ubyte				keyd_pressed[NUM_KEYS];
 int				keyd_time_when_last_pressed;
 
@@ -520,7 +517,6 @@ void key_mark( uint code, int state, uint latency )
 	
 	if (breakbit) {
 		// Key going up
-		keyd_last_released = scancode;
 		keyd_pressed[scancode] = 0;
 		key_data.NumUps[scancode]++;
 
@@ -556,7 +552,6 @@ void key_mark( uint code, int state, uint latency )
 		}
 	} else {
 		// Key going down
-		keyd_last_pressed = scancode;
 		keyd_time_when_last_pressed = event_time;
 		if (!keyd_pressed[scancode]) {
 			// First time down
@@ -660,7 +655,6 @@ void key_init()
 	FillSDLArray();
 
 	keyd_time_when_last_pressed = timer_get_milliseconds();
-	keyd_buffer_type = 1;
 	keyd_repeat = 1;
 
 	// Clear the keyboard array

--- a/code/io/key.cpp
+++ b/code/io/key.cpp
@@ -520,6 +520,20 @@ void key_mark( uint code, int state, uint latency )
 			Current_key_down |= KEY_CTRLED;
 		}
 
+#ifndef NDEBUG
+		if ( key_is_pressed(KEY_DEBUG_KEY) ) {
+			Current_key_down |= KEY_DEBUGGED;
+		}
+#else
+		if ( key_is_pressed(KEY_DEBUG_KEY) ) {
+				mprintf(("Cheats_enabled = %i, Key_normal_game = %i\n", Cheats_enabled, Key_normal_game));
+				if (Cheats_enabled && Key_normal_game) {
+					Current_key_down |= KEY_DEBUGGED1;
+				}
+			}
+
+#endif
+
 		if (scripting::hooks::OnKeyReleased->isActive()) {
 			scripting::hooks::OnKeyReleased->run(scripting::hooks::KeyPressConditions{ static_cast<int>(scancode) },
 				scripting::hook_param_list(
@@ -556,6 +570,20 @@ void key_mark( uint code, int state, uint latency )
 			if ( key_is_pressed(KEY_LCTRL) || key_is_pressed(KEY_RCTRL) ) {
 				Current_key_down |= KEY_CTRLED;
 			}
+
+#ifndef NDEBUG
+			if ( key_is_pressed(KEY_DEBUG_KEY) ) {
+				Current_key_down |= KEY_DEBUGGED;
+			}
+#else
+			if ( key_is_pressed(KEY_DEBUG_KEY) ) {
+				mprintf(("Cheats_enabled = %i, Key_normal_game = %i\n", Cheats_enabled, Key_normal_game));
+				if (Cheats_enabled && Key_normal_game) {
+					Current_key_down |= KEY_DEBUGGED1;
+				}
+			}
+
+#endif
 
 			bool overrideKey = false;
 			if (scripting::hooks::OnKeyPressed->isActive()) {

--- a/code/io/key.h
+++ b/code/io/key.h
@@ -36,6 +36,8 @@ SDL_Scancode fs2_to_sdl( int scancode );
 int key_to_ascii(int keycode );
 int key_inkey();
 
+bool key_is_pressed(int keycode, bool include_since_last_count = false);
+
 // global flag that will enable/disable the backspace key from stopping execution
 //extern int Backspace_debug;
 

--- a/code/io/key.h
+++ b/code/io/key.h
@@ -20,9 +20,6 @@ const size_t SIZE_OF_ASCII_TABLE = 128;
 extern int shifted_ascii_table[SIZE_OF_ASCII_TABLE];
 extern int ascii_table[SIZE_OF_ASCII_TABLE];
 
-extern ubyte keyd_pressed[NUM_KEYS];
-
-
 // O/S level hooks...
 void key_init();
 void key_level_init();
@@ -44,7 +41,7 @@ int key_inkey();
 
 uint key_get_shift_status();
 int key_down_count(int scancode);
-int key_checkch();
+bool key_checkch();
 
 extern SCP_string CheatUsed;
 extern int Cheats_enabled;

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1265,17 +1265,17 @@ void process_debug_keys(int k)
 		case KEY_PADMINUS: {
 			int init_flag = 0;
 
-			if ( keyd_pressed[KEY_1] )	{
+			if ( key_is_pressed(KEY_1) ) {
 				init_flag = 1;
 				HUD_color_red -= 4;
 			} 
 
-			if ( keyd_pressed[KEY_2] )	{
+			if ( key_is_pressed(KEY_2) ) {
 				init_flag = 1;
 				HUD_color_green -= 4;
-			} 
+			}
 
-			if ( keyd_pressed[KEY_3] )	{
+			if ( key_is_pressed(KEY_3) ) {
 				init_flag = 1;
 				HUD_color_blue -= 4;
 			} 
@@ -1294,17 +1294,17 @@ void process_debug_keys(int k)
 		case KEY_PADPLUS: {
 			int init_flag = 0;
 
-			if ( keyd_pressed[KEY_1] )	{
+			if ( key_is_pressed(KEY_1) ) {
 				init_flag = 1;
 				HUD_color_red += 4;
 			} 
 
-			if ( keyd_pressed[KEY_2] )	{
+			if ( key_is_pressed(KEY_2) ) {
 				init_flag = 1;
 				HUD_color_green += 4;
 			} 
 
-			if ( keyd_pressed[KEY_3] )	{
+			if ( key_is_pressed(KEY_3) ) {
 				init_flag = 1;
 				HUD_color_blue += 4;
 			} 
@@ -1458,7 +1458,7 @@ void process_player_ship_keys(int k)
 	// moved this line to beginning of function since hotkeys now encompass
 	// F5 - F12.  We can return after using F11 as a hotkey.
 	ppsk_hotkeys(masked_k);
-	if (keyd_pressed[KEY_DEBUG_KEY]){
+	if (key_is_pressed(KEY_DEBUG_KEY)){
 		return;
 	}
 

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -875,7 +875,7 @@ void credits_do_frame(float  /*frametime*/)
 	Credits_last_time = temp_time;
 
 	float fl_frametime = i2fl(Credits_frametime) / 1000.f;
-	if (keyd_pressed[KEY_LSHIFT]) {
+	if (key_is_pressed(KEY_LSHIFT)) {
 		Credit_position -= fl_frametime * Credits_scroll_rate * 4.0f;
 	} else {
 		Credit_position -= fl_frametime * Credits_scroll_rate;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -824,7 +824,7 @@ DCF_BOOL( Arcs, Interp_lightning )
 
 int interp_box_offscreen( vec3d *min, vec3d *max )
 {
-	if ( keyd_pressed[KEY_LSHIFT] )	{
+	if ( key_is_pressed(KEY_LSHIFT) )	{
 		return IBOX_ALL_ON;
 	}
 

--- a/code/network/multi_voice.cpp
+++ b/code/network/multi_voice.cpp
@@ -742,12 +742,12 @@ int multi_voice_keydown()
 
 	// if we're pre-game, we should just be checking the keyboard bitflags
 	if(!(Game_mode & GM_IN_MISSION)){	
-		return (keyd_pressed[MULTI_VOICE_KEY] && !(keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT])) ? 1 : 0;
+		return (key_is_pressed(MULTI_VOICE_KEY) && !(key_is_pressed(KEY_LSHIFT) || key_is_pressed(KEY_RSHIFT))) ? 1 : 0;
 	} 
 
 	// in-mission, paused - treat just like any other "chattable" screen.
 	if(gameseq_get_state() == GS_STATE_MULTI_PAUSED){
-		return (keyd_pressed[MULTI_VOICE_KEY] && !(keyd_pressed[KEY_LSHIFT] || keyd_pressed[KEY_RSHIFT])) ? 1 : 0;
+		return (key_is_pressed(MULTI_VOICE_KEY) && !(key_is_pressed(KEY_LSHIFT) || key_is_pressed(KEY_RSHIFT))) ? 1 : 0;
 	}
 
 	// ingame, unpaused, rely on the multi-messaging system (ingame)

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -841,7 +841,7 @@ void read_keyboard_controls( control_info * ci, float frame_time, physics_info *
 
 		// for debugging, check to see if the debug key is down -- if so, make fire the debug laser instead
 #ifndef NDEBUG
-		if ( keyd_pressed[KEY_DEBUG_KEY] ) {
+		if ( key_is_pressed(KEY_DEBUG_KEY) ) {
 			ci->fire_debug_count = ci->fire_primary_count;
 			ci->fire_primary_count = 0;
 		}

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -64,7 +64,7 @@ const std::shared_ptr<Hook<ControlActionConditions>> OnActionStopped = Hook<Cont
 const std::shared_ptr<OverridableHook<KeyPressConditions>> OnKeyPressed = OverridableHook<KeyPressConditions>::Factory("On Key Pressed",
 	"Invoked whenever a key is pressed. If overridden, FSO behaves as if this key has simply not been pressed. "
 	"The only thing that FSO will do with this key if overridden is fire the corresponding OnKeyReleased hook once the key is released. "
-	"Be especially careful if overriding modifier keys with this.",
+	"Be especially careful if overriding modifier keys (such as Alt and Shift) with this.",
 	{
 		{"Key", "string", "The scancode of the key that has been pressed."},
 		{"RawKey", "string", "The scancode of the key that has been pressed, without modifiers applied."}

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -61,13 +61,23 @@ const std::shared_ptr<Hook<ControlActionConditions>> OnActionStopped = Hook<Cont
 	"Invoked whenever a user action is no longer invoked through control input.",
 	{ {"Action", "string", "The name of the action that was stopped."} });
 
-const std::shared_ptr<Hook<>> OnKeyPressed = Hook<>::Factory("On Key Pressed",
-	"Invoked whenever a key is pressed.",
-	{ {"Key", "string", "The scancode of the key that has been pressed."} });
+const std::shared_ptr<OverridableHook<KeyPressConditions>> OnKeyPressed = OverridableHook<KeyPressConditions>::Factory("On Key Pressed",
+	"Invoked whenever a key is pressed. If overridden, FSO behaves as if this key has simply not been pressed. "
+	"The only thing that FSO will do with this key if overridden is fire the corresponding OnKeyReleased hook once the key is released. "
+	"Be especially careful if overriding modifier keys with this.",
+	{
+		{"Key", "string", "The scancode of the key that has been pressed."},
+		{"RawKey", "string", "The scancode of the key that has been pressed, without modifiers applied."}
+	});
 
-const std::shared_ptr<Hook<>> OnKeyReleased = Hook<>::Factory("On Key Released",
+const std::shared_ptr<Hook<KeyPressConditions>> OnKeyReleased = Hook<KeyPressConditions>::Factory("On Key Released",
 	"Invoked whenever a key is released.",
-	{ {"Key", "string", "The scancode of the key that has been released."} });
+	{
+		{"Key", "string", "The scancode of the key that has been pressed."},
+		{"RawKey", "string", "The scancode of the key that has been pressed, without modifiers applied."},
+		{"TimeHeld", "number", "The time that this key has been held down in milliseconds. Can be 0 if input latency fluctuates."},
+		{"WasOverridden", "boolean", "Whether or not the key press corresponding to this release was overridden."}
+	});
 
 const std::shared_ptr<Hook<>> OnMouseMoved = Hook<>::Factory("On Mouse Moved",
 	"Invoked whenever the mouse is moved.",

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -20,8 +20,8 @@ extern const std::shared_ptr<Hook<>>									OnGameplayStart;
 
 extern const std::shared_ptr<Hook<ControlActionConditions>>				OnAction;
 extern const std::shared_ptr<Hook<ControlActionConditions>>				OnActionStopped;
-extern const std::shared_ptr<Hook<>>									OnKeyPressed;
-extern const std::shared_ptr<Hook<>>									OnKeyReleased;
+extern const std::shared_ptr<OverridableHook<KeyPressConditions>>		OnKeyPressed;
+extern const std::shared_ptr<Hook<KeyPressConditions>>					OnKeyReleased;
 extern const std::shared_ptr<Hook<>>									OnMouseMoved;
 extern const std::shared_ptr<Hook<>>									OnMousePressed;
 extern const std::shared_ptr<Hook<>>									OnMouseReleased;

--- a/code/scripting/hook_conditions.cpp
+++ b/code/scripting/hook_conditions.cpp
@@ -98,6 +98,8 @@ static bool conditionObjectIsWeaponDo(fnc_t fnc, const object* objp, const value
 }
 
 static int conditionCompareRawControl(int keypress, const int& cached_key) {
+	//For reasons only known to Volition, LCtrl and RCtrl are differentiated in name, while Alt and Shift are not.
+	//As only the first of these identical names will be matched, replace the R versions with the L versions
 	int key_down = keypress & KEY_MASK;
 	switch(key_down) {
 		case KEY_RALT:

--- a/code/scripting/hook_conditions.cpp
+++ b/code/scripting/hook_conditions.cpp
@@ -300,7 +300,7 @@ HOOK_CONDITIONS_START(ObjectDrawConditions)
 HOOK_CONDITIONS_END
 
 HOOK_CONDITIONS_START(KeyPressConditions)
-	HOOK_CONDITION(KeyPressConditions, "Raw key press", "The key that is pressed, with no consideration for any modifier keys.", keycode, conditionParseRawControl, conditionCompareRawControl);
+	HOOK_CONDITION(KeyPressConditions, "Raw KeyPress", "The key that is pressed, with no consideration for any modifier keys.", keycode, conditionParseRawControl, conditionCompareRawControl);
 HOOK_CONDITIONS_END
 
 }

--- a/code/scripting/hook_conditions.h
+++ b/code/scripting/hook_conditions.h
@@ -129,6 +129,11 @@ struct ObjectDrawConditions {
 	const object* drawn_from_objp;
 };
 
+struct KeyPressConditions {
+	HOOK_DEFINE_CONDITIONS;
+	int keycode;
+};
+
 }
 }
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -239,10 +239,25 @@ static bool global_condition_valid(const script_condition& condition)
 			return false;
 		if (Current_key_down == 0)
 			return false;
-		// WMC - could be more efficient, but whatever.
-		if (stricmp(textify_scancode_universal(Current_key_down), condition.condition_string.c_str()) != 0)
-			return false;
-		break;
+
+		//Remove key masks that the API does not check against
+		int key_down_modifier = ~(KEY_CTRLED | KEY_DEBUGGED | KEY_DEBUGGED1) & ~KEY_MASK & Current_key_down;
+
+		//For reasons only known to Volition, LCtrl and RCtrl are differentiated in name, while Alt and Shift are not.
+		//As only the first of these identical names will be matched, replace the R versions with the L versions
+		int key_down = Current_key_down & KEY_MASK;
+		switch(key_down) {
+			case KEY_RALT:
+				key_down = KEY_LALT;
+				break;
+			case KEY_RSHIFT:
+				key_down = KEY_LSHIFT;
+				break;
+			default:
+				break;
+		}
+
+		return condition.condition_cached_value == (key_down | key_down_modifier);
 	}
 
 	case CHC_VERSION: {
@@ -327,6 +342,45 @@ int cache_condition(ConditionalType type, const SCP_string& value){
 		{
 			return 0;
 		}
+	}
+	case CHC_KEYPRESS:
+	{
+		int keycode = 0;
+		//Technically, keys can be also CTRLED and DEBUGGED, but since the API never made a distinction, they will not be cached and filtered later
+		if (value.find("Alt") != SCP_string::npos)
+		{
+			keycode |= KEY_ALTED;
+		}
+		if (value.find("Shift") != SCP_string::npos)
+		{
+			keycode |= KEY_SHIFTED;
+		}
+
+		//Now, if Alt / Shift is ONLY the modifer, remove them here. If they are the only key pressed, the modifier still needs to be enabled, but the key also needs matching
+		SCP_string key_copy = value;
+		if (key_copy.rfind("Alt-", 0) == 0){
+			key_copy = key_copy.substr(4);
+		}
+		if (key_copy.rfind("Shift-", 0) == 0){
+			key_copy = key_copy.substr(6);
+		}
+
+		bool foundKey = false;
+		for (int key = 0; key < NUM_KEYS; key++){
+			extern const char *Scan_code_text_english[];
+			if (stricmp(Scan_code_text_english[key], key_copy.c_str()) == 0) {
+				keycode |= key & KEY_MASK;
+				foundKey = true;
+				break;
+			}
+		}
+
+		if (!foundKey) {
+			Warning(LOCATION, "No key %s found for %s in conditional hook! The hook will not trigger!", key_copy.c_str(), value.c_str());
+			return -1;
+		}
+
+		return keycode;
 	}
 	default:
 		return -1;

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -241,7 +241,7 @@ static bool global_condition_valid(const script_condition& condition)
 			return false;
 
 		//Remove key masks that the API does not check against
-		int key_down_modifier = ~(KEY_CTRLED | KEY_DEBUGGED | KEY_DEBUGGED1) & ~KEY_MASK & Current_key_down;
+		int key_down_modifier = ~KEY_CTRLED & ~KEY_MASK & Current_key_down;
 
 		//Pretend that debug is the same as cheat
 		if (key_down_modifier & KEY_DEBUGGED)

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -243,6 +243,10 @@ static bool global_condition_valid(const script_condition& condition)
 		//Remove key masks that the API does not check against
 		int key_down_modifier = ~(KEY_CTRLED | KEY_DEBUGGED | KEY_DEBUGGED1) & ~KEY_MASK & Current_key_down;
 
+		//Pretend that debug is the same as cheat
+		if (key_down_modifier & KEY_DEBUGGED)
+			key_down_modifier = (key_down_modifier & ~KEY_DEBUGGED) | KEY_DEBUGGED1;
+
 		//For reasons only known to Volition, LCtrl and RCtrl are differentiated in name, while Alt and Shift are not.
 		//As only the first of these identical names will be matched, replace the R versions with the L versions
 		int key_down = Current_key_down & KEY_MASK;
@@ -347,6 +351,10 @@ int cache_condition(ConditionalType type, const SCP_string& value){
 	{
 		int keycode = 0;
 		//Technically, keys can be also CTRLED and DEBUGGED, but since the API never made a distinction, they will not be cached and filtered later
+		if (value.find("Cheat") != SCP_string::npos)
+		{
+			keycode |= KEY_DEBUGGED1;
+		}
 		if (value.find("Alt") != SCP_string::npos)
 		{
 			keycode |= KEY_ALTED;
@@ -358,6 +366,9 @@ int cache_condition(ConditionalType type, const SCP_string& value){
 
 		//Now, if Alt / Shift is ONLY the modifer, remove them here. If they are the only key pressed, the modifier still needs to be enabled, but the key also needs matching
 		SCP_string key_copy = value;
+		if (key_copy.rfind("Cheat-", 0) == 0){
+			key_copy = key_copy.substr(6);
+		}
 		if (key_copy.rfind("Alt-", 0) == 0){
 			key_copy = key_copy.substr(4);
 		}

--- a/code/scripting/scripting.h
+++ b/code/scripting/scripting.h
@@ -101,6 +101,7 @@ struct script_condition
 	// CHC_STATE, CHC_OBJECTTYPE - stores the value of enum matching the name requested by the condition string.
 	// CHC_SHIPCLASS, CHC_WEAPONCLASS - stores the index of the info object requested by the condition
 	// CHC_VERSION, CHC_APPLICATION - stores validity of the check in 1 for true or 0 for false, as the condition will not change after load.
+	// CHC_KEYPRESS - stores the keycode
 	// see ConditionedHook::AddCondition for exact implimentation
 	int condition_cached_value;
 };

--- a/code/ui/checkbox.cpp
+++ b/code/ui/checkbox.cpp
@@ -156,7 +156,7 @@ void UI_CHECKBOX::process(int focus)
 		position = 2;
 
 	if (focus)
-		if ( (oldposition == 2) && (keyd_pressed[KEY_SPACEBAR] || keyd_pressed[KEY_ENTER]) )
+		if ( (oldposition == 2) && (key_is_pressed(KEY_SPACEBAR) || key_is_pressed(KEY_ENTER)) )
 			position = 2;
 
 	pressed_down = 0;

--- a/code/ui/radio.cpp
+++ b/code/ui/radio.cpp
@@ -167,7 +167,7 @@ void UI_RADIO::process(int focus)
 		position = 2;
 
 	if (focus)
-		if ( (oldposition == 2) && (keyd_pressed[KEY_SPACEBAR] || keyd_pressed[KEY_ENTER]) )
+		if ( (oldposition == 2) && (key_is_pressed(KEY_SPACEBAR) || key_is_pressed(KEY_ENTER)) )
 			position = 2;
 
 	pressed_down = 0;


### PR DESCRIPTION
Closes #4533.

This PR makes the On Key Pressed hook overridable.
Overriding a keypress will make the press basically non-existent to FSO. The only thing that the keypress will have an effect on apart from the override itself is that an On Key Released hook will still fire once the respective key is released.

This allows scripts as requested in the linked issue, such as the following to catch all escape's while in the scripting state:
```
$State: GS_STATE_SCRIPTING
$Raw KeyPress: Esc
$On Key Pressed: [
]
+Override: [
   return true
]
```

In order to achieve this, a bit of code-cleanup was needed. Key-Down checks now entirely run through function calls as opposed to reading the raw key array. The underlying data structures were cleaned, with unused ones removed and tidied. All data was moved within the keyboard struct. Key hold down timings had to be rewritten, which incidentally also fixes a bunch of potential edge case bugs I saw in the old code. Finally, the key queue is implemented as an actual queue and not as a poor-man's ring buffer.

In addition, the condition logic for key presses and raw key presses now caches, making checks by condition much faster than before, and thus also much faster than comparing in lua itself.