### PR TITLE
Fix Framebuffer Effects

### DIFF
--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -68,7 +68,7 @@ void gr_opengl_deferred_lighting_begin(bool clearNonColorBufs)
 	Deferred_lighting = true;
 	GL_state.ColorMask(true, true, true, true);
 	
-	GLenum buffers[] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT3, GL_COLOR_ATTACHMENT4, GL_COLOR_ATTACHMENT6 };
+	GLenum buffers[] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT3, GL_COLOR_ATTACHMENT4, GL_COLOR_ATTACHMENT5 };
 
 	if (Cmdline_msaa_enabled > 0) {
 		//Ensure MSAA Mode if necessary
@@ -226,7 +226,7 @@ void gr_opengl_deferred_lighting_finish()
 	opengl_shader_set_current(gr_opengl_maybe_create_shader(SDR_TYPE_DEFERRED_LIGHTING, 0));
 
 	// Render on top of the composite buffer texture
-	glDrawBuffer(GL_COLOR_ATTACHMENT6);
+	glDrawBuffer(GL_COLOR_ATTACHMENT5);
 	glReadBuffer(GL_COLOR_ATTACHMENT4);
 	glBlitFramebuffer(0,
 		0,
@@ -598,7 +598,7 @@ void gr_opengl_deferred_lighting_finish()
 	else {
 		// Transfer the resolved lighting back to the color texture
 		// TODO: Maybe this could be improved so that it doesn't require the copy back operation?
-		glReadBuffer(GL_COLOR_ATTACHMENT6);
+		glReadBuffer(GL_COLOR_ATTACHMENT5);
 		glBlitFramebuffer(0,
 						  0,
 						  gr_screen.max_w,

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -44,7 +44,6 @@ GLuint Scene_specular_texture_ms;
 GLuint Scene_emissive_texture_ms;
 GLuint Scene_composite_texture;
 GLuint Scene_luminance_texture;
-GLuint Scene_effect_texture;
 GLuint Scene_depth_texture;
 GLuint Scene_depth_texture_ms;
 GLuint Cockpit_depth_texture;
@@ -105,7 +104,6 @@ void opengl_setup_scene_textures()
 
 		Scene_ldr_texture = 0;
 		Scene_color_texture = 0;
-		Scene_effect_texture = 0;
 		Scene_depth_texture = 0;
 		return;
 	}
@@ -252,7 +250,7 @@ void opengl_setup_scene_textures()
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
 	opengl_set_object_label(GL_TEXTURE, Scene_composite_texture, "Scene Composite texture");
 
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT6, GL_TEXTURE_2D, Scene_composite_texture, 0);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT5, GL_TEXTURE_2D, Scene_composite_texture, 0);
 
 	//Set up luminance texture (used as input for FXAA)
 	// also used as a light accumulation buffer during the deferred pass
@@ -270,24 +268,6 @@ void opengl_setup_scene_textures()
 
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
 	opengl_set_object_label(GL_TEXTURE, Scene_luminance_texture, "Scene Luminance texture");
-
-	// setup effect texture
-	glGenTextures(1, &Scene_effect_texture);
-
-	GL_state.Texture.SetActiveUnit(0);
-	GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-	GL_state.Texture.Enable(Scene_effect_texture);
-
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
-
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, Scene_texture_width, Scene_texture_height, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
-	opengl_set_object_label(GL_TEXTURE, Scene_effect_texture, "Scene Effect texture");
-
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT5, GL_TEXTURE_2D, Scene_effect_texture, 0);
 
 	// setup cockpit depth texture
 	glGenTextures(1, &Cockpit_depth_texture);
@@ -355,9 +335,6 @@ void opengl_setup_scene_textures()
 
 		glDeleteTextures(1, &Scene_emissive_texture);
 		Scene_emissive_texture = 0;
-
-		glDeleteTextures(1, &Scene_effect_texture);
-		Scene_effect_texture = 0;
 
 		glDeleteTextures(1, &Scene_depth_texture);
 		Scene_depth_texture = 0;
@@ -667,11 +644,6 @@ void opengl_scene_texture_shutdown()
 		Scene_emissive_texture = 0;
 	}
 
-	if ( Scene_effect_texture ) {
-		glDeleteTextures(1, &Scene_effect_texture);
-		Scene_effect_texture = 0;
-	}
-
 	if ( Scene_depth_texture ) {
 		glDeleteTextures(1, &Scene_depth_texture);
 		Scene_depth_texture = 0;
@@ -729,7 +701,7 @@ void gr_opengl_scene_texture_begin()
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	} else {
-		GLenum buffers[] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT3, GL_COLOR_ATTACHMENT4, GL_COLOR_ATTACHMENT6 };
+		GLenum buffers[] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT3, GL_COLOR_ATTACHMENT4, GL_COLOR_ATTACHMENT5 };
 		glDrawBuffers(6, buffers);
 
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -832,6 +804,8 @@ void gr_opengl_copy_effect_texture()
 		return;
 	}
 
+    //Make sure we're reading from the up-to-date color texture
+    glReadBuffer(GL_COLOR_ATTACHMENT0);
 	glDrawBuffer(GL_COLOR_ATTACHMENT5);
 	glBlitFramebuffer(0, 0, gr_screen.max_w, gr_screen.max_h, 0, 0, gr_screen.max_w, gr_screen.max_h, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
@@ -1199,7 +1173,7 @@ void gr_opengl_stop_decal_pass() {
 		GL_COLOR_ATTACHMENT2,
 		GL_COLOR_ATTACHMENT3,
 		GL_COLOR_ATTACHMENT4,
-		GL_COLOR_ATTACHMENT6,
+		GL_COLOR_ATTACHMENT5,
 	};
 	glDrawBuffers(6, buffers2);
 }

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -31,7 +31,6 @@ extern GLuint Scene_normal_texture_ms;
 extern GLuint Scene_specular_texture_ms;
 extern GLuint Scene_emissive_texture_ms;
 extern GLuint Scene_luminance_texture;
-extern GLuint Scene_effect_texture;
 extern GLuint Scene_composite_texture;
 extern GLuint Scene_depth_texture;
 extern GLuint Scene_depth_texture_ms;
@@ -156,7 +155,6 @@ extern int Scene_texture_initialized;
 extern GLuint Scene_color_texture;
 extern GLuint Scene_ldr_texture;
 extern GLuint Scene_luminance_texture;
-extern GLuint Scene_effect_texture;
 
 extern int Scene_texture_width;
 extern int Scene_texture_height;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -959,7 +959,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 
 		if (material_info->get_animated_effect() > 0) {
 			if (Scene_framebuffer_in_frame) {
-				GL_state.Texture.Enable(9, GL_TEXTURE_2D, Scene_effect_texture);
+				GL_state.Texture.Enable(9, GL_TEXTURE_2D, Scene_composite_texture);
 				glDrawBuffer(GL_COLOR_ATTACHMENT0);
 			} else {
 				GL_state.Texture.Enable(9, GL_TEXTURE_2D, Framebuffer_fallback_texture_id);
@@ -1050,7 +1050,7 @@ void opengl_tnl_set_material_distortion(distortion_material* material_info)
 		});
 
 	Current_shader->program->Uniforms.setTextureUniform("frameBuffer", 2);
-	GL_state.Texture.Enable(2, GL_TEXTURE_2D, Scene_effect_texture);
+	GL_state.Texture.Enable(2, GL_TEXTURE_2D, Scene_composite_texture);
 
 	Current_shader->program->Uniforms.setTextureUniform("distMap", 3);
 	if (material_info->get_thruster_rendering()) {


### PR DESCRIPTION
Fixes #5460.
Fixes #5276.

The issue was that when the effect framebuffer was copied, it was relying on the OpenGL state having the correct texture to copy from implicitly selected. On current master, this ends up being the very stale composite texture.
This does not only break the framebuffer effects with nebulae, but makes the framebuffer effects not render anything past the model stage. Ironically including engine glows.

This PR fixes this by explicitly selecting the up-to-date color texture as the source for the texture copy. In addition, this PR uses the composite texture instead of a dedicated effect texture as the target texture for framebuffer effects. This saves one unnecessary texture, as the composite texture is no longer read from otherwise, and is thus free to use.