### PR TITLE
fix compilation warnings

### DIFF
--- a/code/graphics/opengl/gropenglopenxr.cpp
+++ b/code/graphics/opengl/gropenglopenxr.cpp
@@ -1,5 +1,16 @@
 #include "gropenglopenxr.h"
 
+// this block should go before the #includes otherwise MSVC will sometimes warn about APIENTRY redefinition
+// (glad.h checks for redefinition of the symbol, but minwindef.h does not)
+#ifdef WIN32
+
+#define XR_USE_PLATFORM_WIN32
+#include <unknwn.h>
+
+#endif
+// the other platforms do not go before the #includes because this will cause conflicts from symbols defined in XLib,
+// specifically None and Always; see https://stackoverflow.com/questions/22476110/c-compiling-error-including-x11-x-h-x11-xlib-h
+
 #include "io/cursor.h"
 #include "io/mouse.h"
 #include "graphics/matrix.h"
@@ -10,13 +21,7 @@
 #include "graphics/opengl/ShaderProgram.h"
 #include "osapi/osapi.h"
 
-
-#ifdef WIN32
-
-#define XR_USE_PLATFORM_WIN32
-#include <unknwn.h>
-
-#elif defined __APPLE_CC__
+#if defined __APPLE_CC__
 
 //Not supported
 

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -30,12 +30,15 @@ inline bool fl_is_nan(float fl) {
 #define fl_sqrt(fl) sqrtf(fl)
 #define fl_isqrt(fl) (1.0f/sqrtf(fl))
 #define fl_abs(fl) fabsf(fl)
-#define i2fl(i) (static_cast<float>(i))
-#define fl2i(fl) (static_cast<int>(fl))
-#define fl2ir(fl) (static_cast<int>(fl + (((fl) < 0.0f) ? -0.5f : 0.5f)))
-#define f2fl(fx) (static_cast<float>(fx)/65536.0f)
-#define f2d(fx) (static_cast<double>(fx)/65536.0)
-#define fl2f(fl) (static_cast<int>((fl)*65536.0f))
+#define i2fl(i) (static_cast<float>(i))                                     // int to float
+#define l2d(l) (static_cast<double>(l))                                     // long to double
+#define fl2i(fl) (static_cast<int>(fl))                                     // float to int
+#define d2l(d) (static_cast<long>(d))                                       // double to long
+#define fl2ir(fl) (static_cast<int>(fl + (((fl) < 0.0f) ? -0.5f : 0.5f)))   // float to int, rounding
+#define d2lr(d) (static_cast<long>(d + (((d) < 0.0) ? -0.5 : 0.5)))         // double to long, rounding
+#define f2fl(fx) (static_cast<float>(fx)/65536.0f)                          // fix to float
+#define f2d(fx) (static_cast<double>(fx)/65536.0)                           // fix to double
+#define fl2f(fl) (static_cast<int>((fl)*65536.0f))                          // float to fix
 #define fl_tan(fl) tanf(fl)
 
 // convert a measurement in degrees to radians

--- a/code/network/multi_log.cpp
+++ b/code/network/multi_log.cpp
@@ -66,8 +66,8 @@ void multi_log_write_trailer()
 // write out some info about stuff
 void multi_log_write_update()
 {
-	time_t diff = difftime(time(NULL), Multi_log_open_systime);
-	time_t hours, mins, seconds;
+	long diff = d2lr(difftime(time(nullptr), Multi_log_open_systime));
+	long hours, mins, seconds;
 
 	// figure out some time values
 	hours = diff / 3600;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8952,9 +8952,11 @@ void weapon_render(object* obj, model_draw_list *scene)
 
 				// render the head-on bitmap if appropriate and maybe adjust the main bitmap's alpha
 				if (wip->laser_glow_headon_bitmap.first_frame >= 0) {
-					float head_alpha = 1.0 - main_bitmap_alpha_mult;
+					float head_alpha = 1.0f - main_bitmap_alpha_mult;
 
-					r = (int)(r * head_alpha);   g = (int)(g * head_alpha);   b = (int)(b * head_alpha);
+					r = fl2i(r * head_alpha);
+					g = fl2i(g * head_alpha);
+					b = fl2i(b * head_alpha);
 
 					batching_add_laser(
 						wip->laser_glow_headon_bitmap.first_frame + headon_framenum,
@@ -9258,7 +9260,7 @@ void weapon_info::reset()
 		this->spawn_info[i].spawn_chance = 1.f;
 	}
 
-	this->lifetime_variation_factor_when_child = 0.2;
+	this->lifetime_variation_factor_when_child = 0.2f;
 
 	this->swarm_count = -1;
 	// *Default is 150  -Et1


### PR DESCRIPTION
Fixes the few remaining compilation warnings in the current codebase.  Also adds comments to the various casting macros for clarity.