### PR TITLE
Increase Lua safety

### DIFF
--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -9,6 +9,7 @@ extern "C" {
 #include "scripting/lua/lua_ext.h"
 
 #ifdef WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #else
 #include <sys/stat.h>

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -214,8 +214,12 @@ int script_state::CreateLuaState()
 
 		//Instead of just removing open alltogether
 		lua_pushstring(L, "open");
-		lua_pushcfunction(L, io_open_limited);
-		lua_rawset(L, io_ldx);
+		lua_rawgeti(L, 1, -1); //grab the old function to stack 3
+		lua_pushcfunction(L, io_open_limited); //put the new function to stack 4
+		lua_getfenv(L, -2); //put the old function's environment to stack 5
+		lua_setfenv(L, -2); //grab the old function's environment and put it to stack 4 (new function)
+		lua_rawseti(L, io_ldx, -3);
+		lua_pop(L, 2); //since we did a rawseti, both the old function and the key string are still on stack;
 	}
 	lua_pop(L, 1);	//io table
 

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -154,6 +154,17 @@ int script_state::CreateLuaState()
 	}
 	lua_pop(L, 1);	//os table
 
+	lua_pushstring(L, "io");
+	lua_rawget(L, LUA_GLOBALSINDEX);
+	int io_ldx = lua_gettop(L);
+	if(lua_istable(L, io_ldx))
+	{
+		lua_pushstring(L, "popen");
+		lua_pushnil(L);
+		lua_rawset(L, io_ldx);
+	}
+	lua_pop(L, 1);	//io table
+
 	//*****INITIALIZE ADE
 	uint i;
 	mprintf(("LUA: Beginning ADE initialization\n"));


### PR DESCRIPTION
Increases overall safety by preventing lua from executing malicious code.
We actually do this kind of securing for the os library already, but the io library has similar issues.
We don't want to disable all io though, so apply some fairly restrictive filtering as to what can be opened.

Tested to work with scripts that use the io lib