### PR TITLE
utility functions for counting and searching

### DIFF
--- a/code/globalincs/utility.h
+++ b/code/globalincs/utility.h
@@ -147,4 +147,145 @@ typename T::size_type stringcost(const T& op, const T& input, typename T::size_t
     return cost;
 }
 
+template <typename T>
+int count_items_with_name(const char* name, const T* item_array, int num_items)
+{
+	Assert(name != nullptr && item_array != nullptr);
+
+	int count = 0;
+	for (int i = 0; i < num_items; ++i)
+		if (!stricmp(name, item_array[i].name))
+			++count;
+
+	return count;
+}
+
+template <typename T>
+int count_items_with_name(const char* name, const T& item_vector)
+{
+	Assert(name != nullptr);
+
+	int count = 0;
+	for (const auto& item : item_vector)
+		if (!stricmp(name, item.name))
+			++count;
+
+	return count;
+}
+
+template <typename T>
+int count_items_with_scp_string_name(const char* name, const T& item_vector)
+{
+	Assert(name != nullptr);
+
+	int count = 0;
+	for (const auto& item : item_vector)
+		if (!stricmp(name, item.name.c_str()))
+			++count;
+
+	return count;
+}
+
+template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
+int find_item_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const char* str)
+{
+	Assert(str != nullptr);
+
+	int index = 0;
+	for (const ITEM_T& item : item_vector)
+	{
+		if (!stricmp(item.*field, str))
+			return index;
+		else
+			++index;
+	}
+
+	return -1;
+}
+
+template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
+int find_item_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const SCP_string& str)
+{
+	int index = 0;
+	for (const ITEM_T& item : item_vector)
+	{
+		if (lcase_equal(item.*field, str))
+			return index;
+		else
+			++index;
+	}
+
+	return -1;
+}
+
+template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
+int find_item_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const FIELD_T& search)
+{
+	int index = 0;
+	for (const ITEM_T& item : item_vector)
+	{
+		if (item.*field == search)
+			return index;
+		else
+			++index;
+	}
+
+	return -1;
+}
+
+template <typename ITEM_T, typename FIELD_T>
+int find_item_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const char* str)
+{
+	Assert(str != nullptr);
+
+	for (int i = 0; i < num_items; ++i)
+		if (!stricmp(item_array[i].*field, str))
+			return i;
+
+	return -1;
+}
+
+template <typename ITEM_T, typename FIELD_T>
+int find_item_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const SCP_string& str)
+{
+	for (int i = 0; i < num_items; ++i)
+		if (lcase_equal(item_array[i].*field, str))
+			return i;
+
+	return -1;
+}
+
+template <typename ITEM_T, typename FIELD_T>
+int find_item_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const FIELD_T& search)
+{
+	for (int i = 0; i < num_items; ++i)
+		if (item_array[i].*field == search)
+			return i;
+
+	return -1;
+}
+
+template <typename VECTOR_T>
+int find_item_with_name(const VECTOR_T& item_vector, const char* str)
+{
+	Assert(str != nullptr);
+
+	int index = 0;
+	for (const auto& item : item_vector)
+	{
+		if (!stricmp(item.name, str))
+			return index;
+		else
+			++index;
+	}
+
+	return -1;
+}
+
+template <typename ITEM_T>
+int find_item_with_name(const ITEM_T* item_array, int num_items, const char* str)
+{
+	return find_item_with_field(item_array, num_items, &ITEM_T::name, str);
+}
+
 #endif

--- a/code/globalincs/utility.h
+++ b/code/globalincs/utility.h
@@ -150,7 +150,8 @@ typename T::size_type stringcost(const T& op, const T& input, typename T::size_t
 template <typename T>
 int count_items_with_name(const char* name, const T* item_array, int num_items)
 {
-	Assert(name != nullptr && item_array != nullptr);
+	if (!name || !item_array)
+		return 0;
 
 	int count = 0;
 	for (int i = 0; i < num_items; ++i)
@@ -163,7 +164,8 @@ int count_items_with_name(const char* name, const T* item_array, int num_items)
 template <typename T>
 int count_items_with_name(const char* name, const T& item_vector)
 {
-	Assert(name != nullptr);
+	if (!name)
+		return 0;
 
 	int count = 0;
 	for (const auto& item : item_vector)
@@ -176,7 +178,8 @@ int count_items_with_name(const char* name, const T& item_vector)
 template <typename T>
 int count_items_with_scp_string_name(const char* name, const T& item_vector)
 {
-	Assert(name != nullptr);
+	if (!name)
+		return 0;
 
 	int count = 0;
 	for (const auto& item : item_vector)
@@ -189,7 +192,8 @@ int count_items_with_scp_string_name(const char* name, const T& item_vector)
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
 int find_item_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const char* str)
 {
-	Assert(str != nullptr);
+	if (!str)
+		return -1;
 
 	int index = 0;
 	for (const ITEM_T& item : item_vector)
@@ -236,7 +240,8 @@ int find_item_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, c
 template <typename ITEM_T, typename FIELD_T>
 int find_item_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const char* str)
 {
-	Assert(str != nullptr);
+	if (!str)
+		return -1;
 
 	for (int i = 0; i < num_items; ++i)
 		if (!stricmp(item_array[i].*field, str))
@@ -268,7 +273,8 @@ int find_item_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T
 template <typename VECTOR_T>
 int find_item_with_name(const VECTOR_T& item_vector, const char* str)
 {
-	Assert(str != nullptr);
+	if (!str)
+		return -1;
 
 	int index = 0;
 	for (const auto& item : item_vector)

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -1986,45 +1986,6 @@ int check_operator_argument_count(int count, int op)
 	return 1;
 }
 
-template <typename T>
-int count_items_with_name(const char *name, const T* item_array, int num_items)
-{
-	Assert(name != nullptr && item_array != nullptr);
-
-	int count = 0;
-	for (int i = 0; i < num_items; ++i)
-		if (!stricmp(name, item_array[i].name))
-			++count;
-
-	return count;
-}
-
-template <typename T>
-int count_items_with_name(const char *name, const T& item_vector)
-{
-	Assert(name != nullptr);
-
-	int count = 0;
-	for (const auto &item: item_vector)
-		if (!stricmp(name, item.name))
-			++count;
-
-	return count;
-}
-
-template <typename T>
-int count_items_with_scp_string_name(const char *name, const T& item_vector)
-{
-	Assert(name != nullptr);
-
-	int count = 0;
-	for (const auto &item: item_vector)
-		if (!stricmp(name, item.name.c_str()))
-			++count;
-
-	return count;
-}
-
 // helper functions for check_container_value_data_type()
 bool check_container_data_sexp_arg_type(ContainerType con_type, bool is_string, bool is_number)
 {

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -21,6 +21,7 @@
 #include "wing.h"
 
 #include "ai/aigoals.h"
+#include "globalincs/utility.h"
 #include "hud/hudets.h"
 #include "hud/hudshield.h"
 #include "mission/missionlog.h"
@@ -258,15 +259,10 @@ ADE_VIRTVAR(ImpactDamageClass, l_Ship, "string", "Current Impact Damage class", 
 		return ade_set_error(L, "s", "");
 
 	ship *shipp = &Ships[objh->objp->instance];
-	int damage_index = -1;
+	int damage_index;
 
 	if (ADE_SETTING_VAR && s != nullptr) {
-		for (size_t i = 0; i < Damage_types.size(); i++) {
-			if (!stricmp(Damage_types[i].name, s)) {
-				damage_index = (int)i;
-				break;
-			}
-		}
+		damage_index = find_item_with_name(Damage_types, s);
 		shipp->collision_damage_type_idx = damage_index;
 	} else {
 		damage_index = shipp->collision_damage_type_idx;


### PR DESCRIPTION
Inspired by #6178, this moves the existing `count_items_with_name()` functions into utility.h and adds additional functions for finding specific items with a given `.name` or, more generally, a given field.  The `Damage_types` search has been converted to illustrate how these functions can be used.