### PR TITLE
Make the $Shots parameter work for beams.

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1782,7 +1782,6 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 				return false;
 			}
 
-			int current_burst_index = old_burst_counter * wip->shots;
 			for (int i = 0; i < wip->shots; i++) {
 				beam_fire_info fire_info;
 
@@ -1801,7 +1800,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 				fire_info.burst_seed = old_burst_seed;
 				fire_info.fire_method = BFM_TURRET_FIRED;
 				fire_info.per_burst_rotation = swp->per_burst_rot;
-				fire_info.burst_index = current_burst_index;
+				fire_info.burst_index = (old_burst_counter * wip->shots) + i;
 
 				// fire a beam weapon
 				weapon_objnum = beam_fire(&fire_info);
@@ -1822,7 +1821,6 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 							));
 					}
 				}
-				current_burst_index++;
 			}
 			turret->flags.set(Ship::Subsystem_Flags::Has_fired); //set fired flag for scripting -nike
 			return true;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -21377,12 +21377,10 @@ void sexp_beam_fire(int node, bool at_coords)
 		// fire the beam
 		if (fire_info.beam_info_index != -1) {
 			fire_info.fire_method = BFM_TURRET_FORCE_FIRED;
-			int current_burst_index = 0;
 			for ( int i = 0; i < Weapon_info[fire_info.beam_info_index].shots; i++ ) {
-				fire_info.burst_index = current_burst_index;
+				fire_info.burst_index = i;
 				beam_fire(&fire_info);
 				fire_info.turret->turret_next_fire_pos++;
-				current_burst_index++;
 			}
 		} else {
 			// it would appear the turret doesn't have any beam weapons

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -21289,7 +21289,6 @@ void sexp_beam_fire(int node, bool at_coords)
 	// zero stuff out
 	memset(&fire_info, 0, sizeof(beam_fire_info));
 	fire_info.accuracy = 0.000001f;							// this will guarantee a hit
-	fire_info.burst_index = 0;
 
 	// get the firing ship
 	auto shooter = eval_ship(n);
@@ -21375,16 +21374,20 @@ void sexp_beam_fire(int node, bool at_coords)
 		}
 	}
 
-	// fire the beam
-	if (fire_info.beam_info_index != -1) {
-		fire_info.fire_method = BFM_TURRET_FORCE_FIRED;
-
-		beam_fire(&fire_info);
-		fire_info.turret->turret_next_fire_pos++;
-	} else {
-		// it would appear the turret doesn't have any beam weapons
-		Warning(LOCATION, "Couldn't fire turret on ship %s; subsystem %s has no beam weapons", CTEXT(node), CTEXT(CDR(node)));
-	}
+		// fire the beam
+		if (fire_info.beam_info_index != -1) {
+			fire_info.fire_method = BFM_TURRET_FORCE_FIRED;
+			int current_burst_index = 0;
+			for ( int i = 0; i < Weapon_info[fire_info.beam_info_index].shots; i++ ) {
+				fire_info.burst_index = current_burst_index;
+				beam_fire(&fire_info);
+				fire_info.turret->turret_next_fire_pos++;
+				current_burst_index++;
+			}
+		} else {
+			// it would appear the turret doesn't have any beam weapons
+			Warning(LOCATION, "Couldn't fire turret on ship %s; subsystem %s has no beam weapons", CTEXT(node), CTEXT(CDR(node)));
+		}
 }	
 
 void sexp_beam_floating_fire(int n)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12669,7 +12669,6 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					}else{
 						j=v;
 					}
-					int current_burst_index = old_burst_counter * numtimes;
 					for ( w = 0; w < numtimes; w++ ) {
 						beam_fire_info fbfire_info;
 						shipp->beam_sys_info.turret_norm.xyz.x = 0.0f;
@@ -12698,7 +12697,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 						fbfire_info.turret = &shipp->fighter_beam_turret_data;
 						fbfire_info.bfi_flags = BFIF_IS_FIGHTER_BEAM;
 						fbfire_info.bank = bank_to_fire;
-						fbfire_info.burst_index = current_burst_index;
+						fbfire_info.burst_index = (old_burst_counter * numtimes) + i;
 						fbfire_info.burst_seed = old_burst_seed;
 						fbfire_info.per_burst_rotation = swp->per_burst_rot;
 
@@ -12710,7 +12709,6 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 						beam_fire(&fbfire_info);
 						has_fired = true;
 						num_fired++;
-						current_burst_index++;
 					}
 				}
 			}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -525,7 +525,7 @@ int beam_fire(beam_fire_info *fire_info)
 	} else {
 		float burst_rot = 0.0f;
 		if (new_item->type == BeamType::OMNI && !wip->b_info.t5info.burst_rot_pattern.empty()) {
-			burst_rot = wip->b_info.t5info.burst_rot_pattern[fire_info->burst_index];
+			burst_rot = wip->b_info.t5info.burst_rot_pattern[fire_info->burst_index % wip->b_info.t5info.burst_rot_pattern.size()];
 		}
 		beam_get_binfo(new_item, fire_info->accuracy, wip->b_info.beam_shots,fire_info->burst_seed, burst_rot, fire_info->per_burst_rotation);			// to fill in b_info	- the set of directional aim vectors
 	}	


### PR DESCRIPTION
This makes it so that the $Shots parameter, normally used for multishot weapons like shotguns (not to be confused with +shots, a beam info parameter used for antifighter beams), works correctly for beam weapons.

Multishot beams now work properly if they're fired normally from turrets, fired using the fire-beam SEXP, or fired as fighter primaries.

For Type 5 beams, the +burst rotation pattern will advance for each shot fired simultaneously, in addition to advancing between shots in a burst, allowing a modder to have beams which fire several shots in a pattern. This was previously possible using beams spawned as submunitions or from subspace, but now it works for beams fired normally. (This was the main reason I wanted this feature.)

I also modified the use of the burst rotation pattern so that if given a burst index larger than the length of the pattern, it wraps around to the beginning. Previously, a larger burst index would access memory beyond the array, and either crash the game or fire the beam at random angles.

All of this should be completely backwards-compatible, with the sole exception of cases where mods had beams with completely superfluous multishot specified. (Or cases where a beam was accessing random memory beyond the burst rot pattern, I guess?)

Since it involves loops added to preexisting code, some of the implementation is a little messy, especially the fighter primary version. I'm open to thoughts on how to make the code cleaner.