### PR TITLE
Assorted beam fixes

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -836,5 +836,6 @@ void ai_profile_t::reset()
 	}
 	if (mod_supports_version(24, 2, 0)) {
 		flags.set(AI::Profile_Flags::Debris_respects_big_damage);
+		flags.set(AI::Profile_Flags::Force_beam_turret_fov);
 	}
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12670,7 +12670,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				shipp->beam_sys_info.model_num = sip->model_num;
 				shipp->beam_sys_info.turret_gun_sobj = pm->detail[0];
 				shipp->beam_sys_info.turret_num_firing_points = 1;  // dummy turret info is used per firepoint
-				shipp->beam_sys_info.turret_fov = cosf(fl_radians((winfo_p->field_of_fire != 0.0f) ? winfo_p->field_of_fire : 180.0f) / 2.0f);
+				shipp->beam_sys_info.turret_fov = -1.0f;
 
 				shipp->fighter_beam_turret_data.disruption_timestamp = timestamp(0);
 				shipp->fighter_beam_turret_data.turret_next_fire_pos = 0;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3145,7 +3145,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			if (optional_string("+Per Burst Rotation:")) {
 				stuff_float(&t5info->per_burst_rot);
 				t5info->per_burst_rot = fl_radians(t5info->per_burst_rot);
-				if (t5info->per_burst_rot < -PI2 || t5info->per_burst_rot > PI2) {
+				if (t5info->per_burst_rot > PI2) {
 					Warning(LOCATION, "Per Burst Rotation on beam '%s' must not exceed 360 degrees.", wip->name);
 					t5info->per_burst_rot = 0.0f;
 				}


### PR DESCRIPTION
A few fixes here

- Fighters use a fake turret for fighter beams including filling in `turret_fov`, possibly based on the weapon's field of fire. `turret_fov` is *only* used by the beam code in order to prematurely terminate a beam that has gone out of the turret's fov. This should *never* apply to fighter beams, because it makes no sense.
The fake turret should have an fov of -1 (for 360 coverage) and the code that checks against the fov shouldn't bother with checking fighter beams in any case.
- `beam_aim` early returns for non-targeting beams without coordinates or a target. This would apply to omni beams fired without a target, which is perfectly fine! Nor should `beam_get_binfo` early return in similar circumstances.
- Relatedly, the `Force_beam_turret_fov` is really important! Without it, moving subojects will be disregarded, and other fovs like elevation and base fov will be disregarded. It's a no brainer fix, and should target new versions.
- Exceeding -PI2 for "Per Burst Rotation" is not a concern, all negative values are interpreted as random.