### PR TITLE
Assign hud in ships.tbl

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3971,9 +3971,9 @@ int hud_get_default_gauge_index(const char *name)
 	return -1;
 }
 
-HudGauge *hud_get_gauge(const char *name)
+HudGauge *hud_get_gauge(const char *name, bool check_all_custom_gauges)
 {
-	auto gauge = hud_get_custom_gauge(name);
+	auto gauge = hud_get_custom_gauge(name, check_all_custom_gauges);
 	if (gauge == nullptr)
 	{
 		int idx = hud_get_default_gauge_index(name);

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -112,6 +112,11 @@ extern float Player_rearm_eta;
 
 extern int Hud_max_targeting_range;
 
+// maps of hud gauges configs to apply to ships as parsed in ships.tbl
+// this is cleared once parsing is completed
+// First string in the pair is the gauge name, second is the ship name
+extern SCP_vector<std::pair<SCP_string, SCP_string>> Hud_parsed_ships;
+
 void HUD_init_colors();
 void HUD_init();
 void hud_scripting_close(lua_State*);

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -598,7 +598,7 @@ public:
 
 HudGauge *hud_get_custom_gauge(const char *name, bool check_all_gauges = false);
 int hud_get_default_gauge_index(const char *name);
-HudGauge *hud_get_gauge(const char *name);
+HudGauge *hud_get_gauge(const char *name, bool check_all_custom_gauges = false);
 
 extern SCP_vector<std::unique_ptr<HudGauge>> default_hud_gauges;
 

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -394,7 +394,7 @@ void parse_hud_gauges_tbl(const char *filename)
 				}
 				break;
 			case 1:
-				mprintf(("$Ships in hud_gauges.tbl and -hdg.tbms is deprecated. Use \"$Name:\" and define Gauge Config Settings in ships.tbl per-ship instead.\n"));
+				mprintf(("$Ships in hud_gauges.tbl and -hdg.tbms can be replaced. Gauge Config Settings can now be defined per-ship in ships.tbl. \n"));
 
 				int shiparray[256];
 

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -216,6 +216,8 @@ int parse_ship_start()
 	return ship_index;
 }
 
+SCP_vector<std::pair<SCP_string, SCP_string>> Hud_parsed_ships;
+
 void parse_hud_gauges_tbl(const char *filename)
 {
 	int i;
@@ -343,6 +345,12 @@ void parse_hud_gauges_tbl(const char *filename)
 		int n_ships = 0;
 
 		while (optional_string("#Gauge Config")) {
+
+			SCP_string name;
+			if (optional_string("$Name:")) {
+				stuff_string(name, F_NAME);
+			}
+
 			ship_classes.clear();
 			switch (optional_string_either("$Ship:", "$Ships:")) {
 			case 0:
@@ -403,6 +411,16 @@ void parse_hud_gauges_tbl(const char *filename)
 					ship_classes.push_back(shiparray[i]);
 					Ship_info[shiparray[i]].hud_enabled = true;
 					Ship_info[shiparray[i]].hud_retail = retail_config;
+				}
+
+				// Here we add in any ships who set their HUD Config in ships.tbl
+				for (const auto& pair : Hud_parsed_ships) {
+					if (!stricmp(pair.first.c_str(), name.c_str())) {
+						int idx = ship_info_lookup(pair.second.c_str());
+						ship_classes.push_back(idx);
+						Ship_info[idx].hud_enabled = true;
+						Ship_info[idx].hud_retail = retail_config;
+					}
 				}
 
 				if (optional_string("$Color:")) {
@@ -580,6 +598,8 @@ void hud_positions_init()
 
 	// load missing retail gauges for the default and ship-specific HUDs
 	load_missing_retail_gauges();
+
+	Hud_parsed_ships.clear();
 }
 
 void load_missing_retail_gauges()

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3608,7 +3608,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 					return SEXP_CHECK_TYPE_MISMATCH;
 				}
 
-				if (hud_get_gauge(CTEXT(node)) == nullptr) {
+				if (hud_get_gauge(CTEXT(node), true) == nullptr) {
 					return SEXP_CHECK_INVALID_ANY_HUD_GAUGE;
 				}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2973,7 +2973,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			sip->selection_effect = 0;
 	}
 
-	// This only works if the hud gauge defined uses $ships setup and has $name defined
+	// This only works if the hud gauge defined uses $name assignment
 	if (optional_string("$HUD Gauge Configs:")) {
 		SCP_vector<SCP_string> gauge_configs;
 		stuff_string_list(gauge_configs);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2973,6 +2973,18 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			sip->selection_effect = 0;
 	}
 
+	// This only works if the hud gauge defined uses $ships setup and has $name defined
+	if (optional_string("$HUD Gauge Configs:")) {
+		SCP_vector<SCP_string> gauge_configs;
+		stuff_string_list(gauge_configs);
+
+		// Save the ship name and not the index because we don't know what the final index will be yet
+		for (const auto& config : gauge_configs) {
+			Hud_parsed_ships.push_back(std::make_pair(config, sip->name));
+		}
+
+	}
+
 	if(optional_string( "$Cockpit POF file:" ))
 	{
 		char temp[MAX_FILENAME_LEN];
@@ -6217,6 +6229,7 @@ void ship_init()
 			//Parse main TBL first
 			Removed_ships.clear();
 			Ship_info.clear();
+			Hud_parsed_ships.clear();
 			parse_shiptbl("ships.tbl");
 
 			//Then other ones


### PR DESCRIPTION
Adds a method to assign HUD gauge configs in ships.tbl for each ship rather than using the $Ships() setting in hud_gauges.tbl. This has the distinct advantage of being more modular and a little more clear to how we generally table things in FSO.

Also fixes a sexp error checking bug that would flag any custom gauge not assigned to the player ship as possibly invalid despite the fact that the player ship could change during loadout. Here we should just validate that the gauge exists at all, not that it's assigned to a specific ship.