### PR TITLE
Fix edge case in MSAA shader

### DIFF
--- a/code/def_files/data/effects/msaa-f.sdr
+++ b/code/def_files/data/effects/msaa-f.sdr
@@ -174,7 +174,8 @@ void main()
 	for(int i = 0; i < samples; i++) {
 		vec4 localPos = texelFetch(texPos, texel, i);
 		//Calculate local weight from distance Voxel, but if the distance is 0 (i.e. no model at all), set weight to 1 to allow stuff like background emissive
-		float localWeight = max(step(-0.001, dist), 
+		//However, if the median distance is 0, only deal with current texel if it's local distance is 0 as well
+		float localWeight = max(step(-0.001, dist) * step(-0.001, localPos.z),
 			smoothstep(dist + dist * texelWidthFactor * (voxelDepth + voxelDepthFalloff), dist + dist * texelWidthFactor * voxelDepth, localPos.z) *
 			smoothstep(dist - dist * texelWidthFactor * voxelDepth, dist + dist * texelWidthFactor * (voxelDepth + voxelDepthFalloff), localPos.z)
 			);
@@ -190,7 +191,7 @@ void main()
 
 	fragOut0 = color / weight;
 	fragOut1 = pos / weight;
-	fragOut2 = normalize(normal);
+	fragOut2 = vec4(normalize(normal.xyz), normal.a / weight);
 	fragOut3 = specular / weight;
 	fragOut4 = emissive / weight;
 	gl_FragDepth = depth / weight;


### PR DESCRIPTION
In rare cases before a background with a position value of 0,0,0 (i.e., model-less, emissive background), the MSAA shader could produce unwanted glints.
This was mostly apparent when using cockpits with deferred lighting and MSAA, as the entire background scene was rendered as a model-less emissive.

Previously, the shader would just hard-set the texel weight to 1 when the median distance was 0 to actually render-in background at dist 0, but evidently, it cannot set the weight to 1 for texels that don't conform to that median. By making sure that this only applies to texels whose individual distance is 0, similar to the median distance, this problem is avoided.

Also fix that the alpha channel of the normal buffer, used for gloss, should obviously not be part of the normalization process here.