### PR TITLE
fix data length bug in PXO hole punch packet

### DIFF
--- a/code/network/gtrack.cpp
+++ b/code/network/gtrack.cpp
@@ -262,7 +262,8 @@ static void DeserializeGamePacket(const ubyte *data, const int data_size, game_p
 		}
 
 		case GNT_NAT_HOLE_PUNCH_REQ: {
-			if (gph->len == (GAME_HEADER_ONLY_SIZE+sizeof(hole_punch_addr_ip6))) {
+			// using data_size here since gph.len hasn't been adjusted yet
+			if (data_size == (GAME_HEADER_ONLY_SIZE+sizeof(hole_punch_addr_ip6))) {
 				auto ipv6 = reinterpret_cast<hole_punch_addr_ip6 *>(&gph->data);
 
 				PXO_GET_DATA(ipv6->addr);


### PR DESCRIPTION
The header length from the tracker is 1 byte larger than the size calculated by the client due to psnet removing that byte internally. The header length is adjusted to compensate for this, but only *after* the deserialization process, so we have to use the received packet size instead.