### PR TITLE
Fix Modern-style Sounds Using Number Indices

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -1260,23 +1260,25 @@ void parse_sound_table(const char* filename)
 					if (gamesnd_parse_line(&tempSound, "$Name:", &Snds))
 					{
 						int tempIndex = static_cast<int>(Snds.size());
+						bool name_not_match_index = (atoi(tempSound.name.c_str()) != tempIndex) && !tempSound.sound_entries.empty() && (tempSound.sound_entries[0].filename[0] != '\0');
 
 						if (tempSound.flags & GAME_SND_RETAIL_STYLE)
 						{
 							// retail sounds must have names that match their indexes
-							if ((atoi(tempSound.name.c_str()) != tempIndex) && !tempSound.sound_entries.empty() && (tempSound.sound_entries[0].filename[0] != '\0'))
+							if (name_not_match_index)
 								Warning(LOCATION, "Retail-style sound %s has a name that does not match its index %d!", tempSound.name.c_str(), tempIndex);
 						}
 						else
 						{
 							// prevent new sounds from colliding with reserved indexes
-							while (gamesnd_is_reserved_game_index(tempIndex))
-							{
-								Snds.emplace_back();
-								sprintf(Snds.back().name, "%d", tempIndex);
-								Snds.back().sound_entries.emplace_back();
-								tempIndex = static_cast<int>(Snds.size());
-							}
+							if (name_not_match_index)
+								while (gamesnd_is_reserved_game_index(tempIndex))
+								{
+									Snds.emplace_back();
+									sprintf(Snds.back().name, "%d", tempIndex);
+									Snds.back().sound_entries.emplace_back();
+									tempIndex = static_cast<int>(Snds.size());
+								}
 						}
 
 						Snds.push_back(game_snd(tempSound));
@@ -1300,24 +1302,26 @@ void parse_sound_table(const char* filename)
 					if (gamesnd_parse_line(&tempSound, "$Name:", &Snds_iface))
 					{
 						int tempIndex = static_cast<int>(Snds_iface.size());
+						bool name_not_match_index = (atoi(tempSound.name.c_str()) != tempIndex) && !tempSound.sound_entries.empty() && (tempSound.sound_entries[0].filename[0] != '\0');
 
 						if (tempSound.flags & GAME_SND_RETAIL_STYLE)
 						{
 							// retail sounds must have names that match their indexes
-							if ((atoi(tempSound.name.c_str()) != tempIndex) && !tempSound.sound_entries.empty() && (tempSound.sound_entries[0].filename[0] != '\0'))
+							if (name_not_match_index)
 								Warning(LOCATION, "Retail-style sound %s has a name that does not match its index %d!", tempSound.name.c_str(), tempIndex);
 						}
 						else
 						{
 							// prevent new sounds from colliding with reserved indexes
-							while (gamesnd_is_reserved_interface_index(tempIndex))
-							{
-								Snds_iface.emplace_back();
-								sprintf(Snds_iface.back().name, "%d", tempIndex);
-								Snds_iface.back().sound_entries.emplace_back();
-								Snds_iface_handle.push_back(sound_handle::invalid());
-								tempIndex = static_cast<int>(Snds_iface.size());
-							}
+							if (name_not_match_index)
+								while (gamesnd_is_reserved_interface_index(tempIndex))
+								{
+									Snds_iface.emplace_back();
+									sprintf(Snds_iface.back().name, "%d", tempIndex);
+									Snds_iface.back().sound_entries.emplace_back();
+									Snds_iface_handle.push_back(sound_handle::invalid());
+									tempIndex = static_cast<int>(Snds_iface.size());
+								}
 						}
 
 						Snds_iface.push_back(game_snd(tempSound));

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -1271,7 +1271,8 @@ void parse_sound_table(const char* filename)
 						else
 						{
 							// prevent new sounds from colliding with reserved indexes
-							if (name_not_match_index) {
+							if (name_not_match_index) 
+							{
 								while (gamesnd_is_reserved_game_index(tempIndex))
 								{
 									Snds.emplace_back();
@@ -1314,7 +1315,8 @@ void parse_sound_table(const char* filename)
 						else
 						{
 							// prevent new sounds from colliding with reserved indexes
-							if (name_not_match_index) {
+							if (name_not_match_index) 
+							{
 								while (gamesnd_is_reserved_interface_index(tempIndex))
 								{
 									Snds_iface.emplace_back();

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -1271,7 +1271,7 @@ void parse_sound_table(const char* filename)
 						else
 						{
 							// prevent new sounds from colliding with reserved indexes
-							if (name_not_match_index)
+							if (name_not_match_index) {
 								while (gamesnd_is_reserved_game_index(tempIndex))
 								{
 									Snds.emplace_back();
@@ -1279,6 +1279,7 @@ void parse_sound_table(const char* filename)
 									Snds.back().sound_entries.emplace_back();
 									tempIndex = static_cast<int>(Snds.size());
 								}
+							}
 						}
 
 						Snds.push_back(game_snd(tempSound));
@@ -1313,7 +1314,7 @@ void parse_sound_table(const char* filename)
 						else
 						{
 							// prevent new sounds from colliding with reserved indexes
-							if (name_not_match_index)
+							if (name_not_match_index) {
 								while (gamesnd_is_reserved_interface_index(tempIndex))
 								{
 									Snds_iface.emplace_back();
@@ -1322,6 +1323,7 @@ void parse_sound_table(const char* filename)
 									Snds_iface_handle.push_back(sound_handle::invalid());
 									tempIndex = static_cast<int>(Snds_iface.size());
 								}
+							}
 						}
 
 						Snds_iface.push_back(game_snd(tempSound));


### PR DESCRIPTION
PR #6112 protected retail sound indices from being overwritten with the intent of when modders used string names for sounds,. Though that PR ended up being a bit overprotective because it made it so that using the modern sound format but still using numbered names did not work. In other words, for mods that use the modern sound format but still use numbered names, FSO sees the new format but then sees the numbers are within a protected range and offsets them, which means the sound index values referenced in ships and weapons table now are not correct and thus do not play.

This PR fixes that edge-case. Tested and works as expected. Also, if folks would rather just rever the entire protective offset aspect I am fine with that and we can instead just make a warning to the modder that their sound name will overwrite a protected range (though the changes of this PR to check if the name is the index should still be included, since an overwrite warning is not needed if the index and name are already the same).