### PR TITLE
Fix ingame options init bugs

### DIFF
--- a/code/menuui/playermenu.cpp
+++ b/code/menuui/playermenu.cpp
@@ -394,6 +394,7 @@ void player_select_init()
 
 // no need to reset this to false because we only ever see player_select once per game run
 static bool Startup_warning_dialog_displayed = false;
+static bool Save_file_warning_displayed = false;
 
 void player_select_do()
 {
@@ -407,8 +408,9 @@ void player_select_do()
 		Startup_warning_dialog_displayed = true;
 	}
 
-	if (!Ingame_options_save_found && Using_in_game_options) {
+	if (!Ingame_options_save_found && Using_in_game_options && !Save_file_warning_displayed) {
 		popup(PF_BODY_BIG | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("In-game Options are enabled but a save file could not be found. You may need to update your settings in the Options menu.", 1854));
+		Save_file_warning_displayed = true;
 	}
 		
 	// set the input box at the "virtual" line 0 to be active so the player can enter a callsign

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -947,7 +947,11 @@ void os_init_registry_stuff(const char* company, const char* app)
 	// If the mod settings file doesn't exist create it if it doesn't so that the
 	// Mod_options_profile can be written to later during runtime.
 	FILE* fp = fopen(os_get_config_path(Mod_options_file_name).c_str(), "a");
-	fclose(fp);
+	if (fp != nullptr) {
+		fclose(fp);
+	} else {
+		Ingame_options_save_found = false;
+	}
 
 	// Load the mod settings profile if we have one, otherwise pull the settings from the
 	// fs2_open.ini to start with.


### PR DESCRIPTION
Fixes #6193 by adding a bool check for if the popup has been displayed and fixes #6194 by adding a null check. If the file couldn't be created then default to the old fs2_open.ini instead.