### PR TITLE
Fix screenshudder option issue

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3001,7 +3001,7 @@ bool is_screenshake_enabled()
 		return true;
 	} else {
 		if (Using_in_game_options) {
-			return Screenshake_enabled;
+			return ScreenShakeOption->getValue();
 		} else {
 			return !Cmdline_no_screenshake;
 		}


### PR DESCRIPTION
This is another instance where our internal options system is prone to having things optimized out by the compiler if referencing the controlling global variable directly. So we have to go through the options system to retrieve the value instead.

Fixes #6167