### PR TITLE
Expose method to kill all current voice messages

### DIFF
--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -959,7 +959,9 @@ void message_kill_all( int kill_all )
 {
 	int i;
 
-	Assert( Num_messages_playing );
+	if (Num_messages_playing <= 0) {
+		return;
+	}
 
 	// kill sounds for all voices currently playing
 	for ( i = 0; i < Num_messages_playing; i++ ) {

--- a/code/scripting/api/libs/audio.cpp
+++ b/code/scripting/api/libs/audio.cpp
@@ -418,5 +418,14 @@ ADE_FUNC(pauseVoiceMessages,
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(killVoiceMessages, l_Audio, nullptr, "Kills all currently playing voice messages.", nullptr, nullptr)
+{
+	SCP_UNUSED(L);
+
+	message_kill_all(true);
+
+	return ADE_RETURN_NIL;
+}
+
 } // namespace api
 } // namespace scripting


### PR DESCRIPTION
Add a way for Lua to stop all currently playing voice messages. This is handy for checkpoints, for example; being able to stop messages when a checkpoint is selected.

Also removes an Assert in favor of a return. I don't see a reason an Assert is needed in the kill function when instead it can just do nothing if there's nothing to do.