### PR TITLE
clear Parse_names on mission init

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6754,6 +6754,7 @@ void mission_init(mission *pm)
 	mission_parse_reset_callsign();
 	ai_lua_reset_general_orders();
 
+	Parse_names.clear();
 	Num_path_restrictions = 0;
 	Num_ai_dock_names = 0;
 	ai_clear_goal_target_names();


### PR DESCRIPTION
When a new mission is loaded, clear the parse names vector, in lieu of the old `Num_parse_names = 0;` line.  This fixes a bug where FRED will complain about nonexistent ships when loading a different mission.  Follow-up to #5937.