### PR TITLE
properly handle game sounds with numeric IDs

### DIFF
--- a/code/scripting/api/objs/sound.cpp
+++ b/code/scripting/api/objs/sound.cpp
@@ -58,12 +58,8 @@ ADE_FUNC(getFilename, l_SoundEntry, NULL, "Returns the filename of this sound. I
 	if (!ade_get_args(L, "o", l_SoundEntry.GetPtr(&seh)))
 		return ade_set_error(L, "s", "");
 
-	if (seh == NULL || !seh->isValid())
+	if (seh == NULL || !seh->isValid() || seh->Get()->sound_entries.empty())
 		return ade_set_error(L, "s", "");
-
-	Assertion(!seh->Get()->sound_entries.empty(),
-			  "Sound entry vector of sound %s is empty! This should not happen. Get a coder!",
-			  seh->Get()->name.c_str());
 
 	return ade_set_args(L, "s", seh->Get()->sound_entries[0].filename);
 }


### PR DESCRIPTION
Patches the gamesnd system in several ways to properly fix the bug identified in #6196.  Due to the way the new sound system was written, sounds with numeric IDs were not necessarily added in their indexed location, even though the code assumed (even prior to #6112) that this would be the case.  The code now uses the proper index for both old *and* new style sounds.  This is done by ensuring, in `gamesnd_parse_entry()`, that the vector contains an entry for the specified numeric ID before doing a search for that ID.

Due to the slightly modified population of the gamesnd vectors, the `Snds_iface_handle` vector is now populated after parsing the various sounds.tbl files rather than during parsing.

Separately, this makes consistent the handling of the `sound_entries` vector which could potentially be empty but also treated an empty state as an assertion failure.