### PR TITLE
Cleanup message_kill_all

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -798,11 +798,8 @@ void process_debug_keys(int k)
 		// play the next mission message
 		case KEY_DEBUGGED + KEY_V:		
 			extern int Message_debug_index;
-			extern int Num_messages_playing;
 			// stop any other messages
-			if(Num_messages_playing){
-				message_kill_all(1);
-			}
+			message_kill_all(true);
 
 			// next message
 			if(Message_debug_index >= Num_messages - 1){
@@ -821,11 +818,8 @@ void process_debug_keys(int k)
 		// play the previous mission message
 		case KEY_DEBUGGED + KEY_SHIFTED + KEY_V:
 			extern int Message_debug_index;
-			extern int Num_messages_playing;
 			// stop any other messages
-			if(Num_messages_playing){
-				message_kill_all(1);
-			}
+			message_kill_all(true);
 
 			// go maybe go down one
 			if(Message_debug_index == Num_builtin_messages - 1){

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -891,9 +891,7 @@ void message_mission_shutdown()
 	training_mission_shutdown();
 
 	// kill/stop all playing messages sounds and animations if we need to
-	if (Num_messages_playing) {
-		message_kill_all(1);
-	}
+	message_kill_all(true);
 
 	// remove the wave sounds from memory
 	for (i = 0; i < Num_message_waves; i++ ) {
@@ -955,16 +953,14 @@ void message_resume_all()
 
 // function to kill all currently playing messages.  kill_all parameter tells us to
 // kill only the animations that are playing, or wave files too
-void message_kill_all( int kill_all )
+void message_kill_all( bool kill_all )
 {
-	int i;
-
 	if (Num_messages_playing <= 0) {
 		return;
 	}
 
 	// kill sounds for all voices currently playing
-	for ( i = 0; i < Num_messages_playing; i++ ) {
+	for (int i = 0; i < Num_messages_playing; i++ ) {
 		/*if ( (Playing_messages[i].anim != NULL) && anim_playing(Playing_messages[i].anim) ) {
 			anim_stop_playing( Playing_messages[i].anim );
 			Playing_messages[i].anim=NULL;
@@ -1065,10 +1061,9 @@ int message_playing_unique()
 
 // returns the highest priority of the currently playing messages
 #define MESSAGE_GET_HIGHEST		1
-#define MESSAGE_GET_LOWEST			2
+#define MESSAGE_GET_LOWEST		2
 int message_get_priority(int which)
 {
-	int i;
 	int priority;
 
 	if ( which == MESSAGE_GET_HIGHEST ){
@@ -1077,7 +1072,7 @@ int message_get_priority(int which)
 		priority = MESSAGE_PRIORITY_HIGH;
 	}
 
-	for ( i = 0; i < Num_messages_playing; i++ ) {
+	for (int i = 0; i < Num_messages_playing; i++ ) {
 		if ( (which == MESSAGE_GET_HIGHEST) && (Playing_messages[i].priority > priority) ){
 			priority = Playing_messages[i].priority;
 		} else if ( (which == MESSAGE_GET_LOWEST) && (Playing_messages[i].priority < priority) ){
@@ -1398,10 +1393,8 @@ void message_play_anim( message_q *q )
 		// This call relies on the fact that AVI_play will return -1 if the AVI cannot be played
 		// if any messages are already playing, kill off any head anims that are currently playing.  We will
 		// only play a head anim of the newest messages being played
-		if ( Num_messages_playing > 0 ) {
-			nprintf(("messaging", "killing off any currently playing head animations\n"));
-			message_kill_all( 0 );
-		}
+		nprintf(("messaging", "killing off any currently playing head animations\n"));
+		message_kill_all(false);
 
 		if ( hud_disabled() ) {
 			return;
@@ -1637,7 +1630,7 @@ void message_queue_process()
 		// message priority.
 
 		if ( q->builtin_type == MESSAGE_HAMMER_SWINE ) {
-			message_kill_all(1);
+			message_kill_all(true);
 		} else if ( message_playing_specific_builtin(MESSAGE_HAMMER_SWINE) ) {
 			MessageQ_num = 0;
 			return;
@@ -1645,7 +1638,7 @@ void message_queue_process()
 			// builtin is playing and we have a unique message to play.  Kill currently playing message
 			// so unique can play uninterrupted.  Only unique messages higher than low priority will interrupt
 			// other messages.
-			message_kill_all(1);
+			message_kill_all(true);
 			nprintf(("messaging", "Killing all currently playing messages to play unique message\n"));
 		} else if ( message_playing_builtin() && (q->message_num < Num_builtin_messages) ) {
 			// when a builtin message is queued, we might either overlap or interrupt the currently
@@ -1656,7 +1649,7 @@ void message_queue_process()
 			if ( Num_messages_playing ) {
 				if ( message_get_priority(MESSAGE_GET_HIGHEST) < q->priority ) {
 					// lower priority message playing -- kill it.
-					message_kill_all(1);
+					message_kill_all(true);
 					nprintf(("messaging", "Killing all currently playing messages to play high priority builtin\n"));
 				} else if ( message_get_priority(MESSAGE_GET_LOWEST) > q->priority ) {
 					// queued message is a lower priority, so wait it out
@@ -1671,7 +1664,7 @@ void message_queue_process()
 			// code messages can kill any low priority mission specific messages
 			if ( Num_messages_playing ) {
 				if ( message_get_priority(MESSAGE_GET_HIGHEST) == MESSAGE_PRIORITY_LOW ) {
-					message_kill_all(1);
+					message_kill_all(true);
 					nprintf(("messaging", "Killing low priority unique messages to play code message\n"));
 				} else {
 					return;			// do nothing.

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -243,7 +243,7 @@ void	message_mission_shutdown();
 void	message_queue_process();
 int	message_is_playing();
 void	message_maybe_distort();
-void	message_kill_all( int kill_all );
+void	message_kill_all( bool kill_all );
 
 void	message_pause_all();
 void	message_resume_all();


### PR DESCRIPTION
I originally wanted to do this in #6207 but decided to keep that PR trim.. so now I'm back to finish the job and satisfy my OCD a little bit.

This fixes #6208 by generally cleaning up the code surrounding message_kill_all; Change it to bool from int parameter, remove most checks for `Num_messages_playing` before calling `message_kill_all` now that it can just return instead of assert. There are a few places where I left in the additional checks to `Num_messages_playing` because they serve as nice optimization points to skip a whole bunch of other stuff that wouldn't be needed if no messages are playing; all of them part of `message_queue_process` in missionmessage.cpp.