### PR TITLE
another follow-up to #6021

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5857,7 +5857,6 @@ void parse_asteroid_fields(mission *pm)
 		}
 
 		Asteroid_field.field_debris_type.clear();
-
 		Asteroid_field.field_asteroid_type.clear();
 
 		// Debris types
@@ -5866,7 +5865,9 @@ void parse_asteroid_fields(mission *pm)
 			// Obsolete and only for backwards compatibility
 			for (int j = 0; j < MAX_RETAIL_DEBRIS_TYPES; j++) {
 				if (optional_string("+Field Debris Type:")) {
-					stuff_int(&Asteroid_field.field_debris_type[j]);
+					int subtype;
+					stuff_int(&subtype);
+					Asteroid_field.field_debris_type.push_back(subtype);
 				}
 			}
 
@@ -5881,7 +5882,7 @@ void parse_asteroid_fields(mission *pm)
 				} else {
 					WarningEx(LOCATION, "Mission %s\n Invalid asteroid debris %s!", pm->name, ast_name.c_str());
 				}
-				}
+			}
 
 		// Asteroid types
 		} else {


### PR DESCRIPTION
When loading a legacy mission that contains a debris field, FSO will try to index into an empty vector, causing an out-of-bounds exception.  This can be seen by loading Derelict mission dl1-08, "The Horror in the Deep".

The `// Obsolete and only for backwards compatibility` code added in #6021 properly handles asteroid fields, but not debris fields; so the fix is simply to apply the logic to debris fields as well.