### PR TITLE
Adds conditional impact functionality.

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -305,10 +305,10 @@ enum class HomingAcquisitionType {
 
 struct ConditionalImpact {
 	particle::ParticleEffectHandle effect;
-	float min_health_threshold_0_to_1;
-	float max_health_threshold_0_to_1;
-	float min_angle_threshold_degrees;
-	float max_angle_threshold_degrees;
+	float min_health_threshold; //factor, 0-1
+	float max_health_threshold; //factor, 0-1
+	float min_angle_threshold; //in degrees
+	float max_angle_threshold; //in degrees
 	bool dinky;
 };
 

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -305,10 +305,10 @@ enum class HomingAcquisitionType {
 
 struct ConditionalImpact {
 	particle::ParticleEffectHandle effect;
-	float min_health_threshold;
-	float max_health_threshold;
-	float min_angle_threshold;
-	float max_angle_threshold;
+	float min_health_threshold_0_to_1;
+	float max_health_threshold_0_to_1;
+	float min_angle_threshold_degrees;
+	float max_angle_threshold_degrees;
 	bool dinky;
 };
 

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -303,6 +303,15 @@ enum class HomingAcquisitionType {
 	RANDOM,
 };
 
+struct ConditionalImpact {
+	particle::ParticleEffectHandle effect;
+	float min_health_threshold;
+	float max_health_threshold;
+	float min_angle_threshold;
+	float max_angle_threshold;
+	bool dinky;
+};
+
 struct weapon_info
 {
 	char	name[NAME_LENGTH];				// name of this weapon
@@ -485,6 +494,8 @@ struct weapon_info
 
 	particle::ParticleEffectHandle piercing_impact_effect;
 	particle::ParticleEffectHandle piercing_impact_secondary_effect;
+
+	SCP_map<int, SCP_vector<ConditionalImpact>> conditional_impacts;
 
 	particle::ParticleEffectHandle muzzle_effect;
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2353,6 +2353,33 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 	}
 
+	while (optional_string("$Conditional Impact Effect:")) {
+		int armor_index;
+		ConditionalImpact ci;
+		ci.min_health_threshold = 0.0;
+		ci.max_health_threshold = 1.0;
+		ci.min_angle_threshold = 0.0;
+		ci.max_angle_threshold = 180.0;
+		ci.dinky = false;
+		required_string("+Armor Type:");
+			stuff_string(fname, F_NAME, NAME_LENGTH);
+		armor_index = armor_type_get_idx(fname);
+		required_string("+Effect Name:");
+			ci.effect = particle::util::parseEffect(wip->name);
+		parse_optional_float_into("+Min Health Threshold:", &ci.min_health_threshold);
+		parse_optional_float_into("+Max Health Threshold:", &ci.max_health_threshold);
+		parse_optional_float_into("+Min Angle Threshold:", &ci.min_angle_threshold);
+		parse_optional_float_into("+Max Angle Threshold:", &ci.max_angle_threshold);
+		parse_optional_bool_into("+Dinky:", &ci.dinky);
+		SCP_vector<ConditionalImpact> ci_vec;
+		if (wip->conditional_impacts.count(armor_index) == 1) {
+			SCP_vector<ConditionalImpact> existing_cis = wip->conditional_impacts[armor_index];
+			ci_vec.insert(ci_vec.end(), existing_cis.begin(), existing_cis.end());
+		}
+		ci_vec.push_back(ci);
+		wip->conditional_impacts.insert_or_assign(armor_index, ci_vec);
+	}
+
 	if (optional_string("$Inflight Effect:")) {
 		auto effetIdx = particle::util::parseEffect(wip->name);
 		wip->state_effects[WeaponState::NORMAL] = effetIdx;
@@ -7497,7 +7524,55 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 		weapon_hit_do_sound(other_obj, wip, hitpos, armed_weapon, quadrant);
 	}
 
-	if (wip->impact_weapon_expl_effect.isValid() && armed_weapon) {
+
+ 	bool valid_conditional_impact = false;
+	int relevant_armor_idx = -1;
+	float relevant_fraction = 1.0f;
+	float hit_angle = 0.0f;
+	vec3d reverse_incoming = (vmd_zero_vector - weapon_obj->orient.vec.fvec);
+
+	if (hitnormal) {
+		hit_angle = vm_vec_delta_ang(hitnormal, &reverse_incoming, NULL);
+	}
+
+	if (other_obj != nullptr && other_obj->type == OBJ_SHIP) {
+		shipp = &Ships[other_obj->instance];
+		if (quadrant == -1) {
+			relevant_armor_idx = shipp->armor_type_idx;
+			relevant_fraction = other_obj->hull_strength / shipp->ship_max_hull_strength;
+		} else {
+			relevant_armor_idx = shipp->shield_armor_type_idx;
+			relevant_fraction = ship_quadrant_shield_strength(other_obj, quadrant);
+		}
+		if (wip->conditional_impacts.count(relevant_armor_idx) == 1) {
+			SCP_vector<ConditionalImpact> cis = wip->conditional_impacts[relevant_armor_idx];
+			for (auto &ci : cis) {
+				if (((!armed_weapon) == ci.dinky)
+					&& relevant_fraction >= ci.min_health_threshold
+					&& relevant_fraction <= ci.max_health_threshold
+					&& hit_angle >= fl_radians(ci.min_angle_threshold)
+					&& hit_angle <= fl_radians(ci.max_angle_threshold)
+				) {
+					auto particleSource = particle::ParticleManager::get()->createSource(ci.effect);
+					particleSource.moveTo(hitpos);
+					particleSource.setOrientationFromVec(&weapon_obj->phys_info.vel);
+					particleSource.setVelocity(&weapon_obj->phys_info.vel);
+
+					if (hitnormal)
+					{
+						particleSource.setOrientationNormal(hitnormal);
+					}
+
+					particleSource.finish();
+
+					valid_conditional_impact = true;
+				}
+			}
+		}
+	}
+
+
+	if (!valid_conditional_impact && wip->impact_weapon_expl_effect.isValid() && armed_weapon) {
 		auto particleSource = particle::ParticleManager::get()->createSource(wip->impact_weapon_expl_effect);
 		particleSource.moveTo(hitpos);
 		particleSource.setOrientationFromVec(&weapon_obj->phys_info.vel);
@@ -7509,7 +7584,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 		}
 
 		particleSource.finish();
-	} else if (wip->dinky_impact_weapon_expl_effect.isValid() && !armed_weapon) {
+	} else if (!valid_conditional_impact && wip->dinky_impact_weapon_expl_effect.isValid() && !armed_weapon && !valid_conditional_impact) {
 		auto particleSource = particle::ParticleManager::get()->createSource(wip->dinky_impact_weapon_expl_effect);
 		particleSource.moveTo(hitpos);
 		particleSource.setOrientationFromVec(&weapon_obj->phys_info.vel);
@@ -7523,7 +7598,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 		particleSource.finish();
 	}
 
-	if ((other_obj != nullptr) && (quadrant == -1) && (wip->piercing_impact_effect.isValid() && armed_weapon)) {
+	if ((other_obj != nullptr) && (quadrant == -1) && (!valid_conditional_impact && wip->piercing_impact_effect.isValid() && armed_weapon)) {
 		if ((other_obj->type == OBJ_SHIP) || (other_obj->type == OBJ_DEBRIS)) {
 
 			int ok_to_draw = 1;
@@ -9329,6 +9404,8 @@ void weapon_info::reset()
 
 	this->piercing_impact_effect = particle::ParticleEffectHandle::invalid();
 	this->piercing_impact_secondary_effect = particle::ParticleEffectHandle::invalid();
+
+	this->conditional_impacts.clear();
 
 	this->muzzle_effect = particle::ParticleEffectHandle::invalid();
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2377,7 +2377,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			ci_vec.insert(ci_vec.end(), existing_cis.begin(), existing_cis.end());
 		}
 		ci_vec.push_back(ci);
-		wip->conditional_impacts.insert_or_assign(armor_index, ci_vec);
+		wip->conditional_impacts[armor_index] = ci_vec;
 	}
 
 	if (optional_string("$Inflight Effect:")) {


### PR DESCRIPTION
This introduces a feature that allows weapons to have specialized impact particle effects that play only under particular conditions. Each conditional impact has an armor type for which it plays, and may also have minimum and maximum thresholds for health and hit angle. It can also be set as a dinky impact, to only play if the weapon isn't armed. On hit, all conditional impacts whose requirements are met will be played. Iff no conditional impacts are played, the normal impact effect or explosion will be played.

See demonstration:

[https://www.youtube.com/watch?v=WobH_JkeMAo](url)

Notes:

I use a short-circuiting logical AND to check whether the hit object exists and is a ship. If the hit object doesn't exist -- which is to say, it's a nullptr -- trying to access it (by checking whether it's a ship) causes a crash. Given that I have the check for whether it's null first, and the AND is short-circuiting, AFAICT this should never happen, but I wanted to check whether others considered this structure adequately safe. If it's not, I can just use nested if-clauses.

Possible future aspirations:

Contrary to what I previously thought, the logic for piercing impacts, which depends on armor type, does not take subsystem armor types into account -- only main hull and shield armor. I followed that pattern for this feature, but in the future it seems like it would be desirable to fix that.

Also, I might like to allow conditional impacts for things like weapons, debris, or asteroids. Probably the way to do this would be to allow those objects to have armor types.