### PR TITLE
enhance lock-perspective to also lock slew mode

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -218,6 +218,7 @@ static struct Cheat cheatsTable[] = {
 
 int Tool_enabled = 0;
 bool Perspective_locked=false;
+bool Slew_locked=false;
 
 extern int AI_watch_object;
 extern int Countermeasures_enabled;

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -217,8 +217,6 @@ static struct Cheat cheatsTable[] = {
 
 
 int Tool_enabled = 0;
-bool Perspective_locked=false;
-bool Slew_locked=false;
 
 extern int AI_watch_object;
 extern int Countermeasures_enabled;

--- a/code/io/keycontrol.h
+++ b/code/io/keycontrol.h
@@ -19,8 +19,6 @@
 
 extern int Dead_key_set[];
 extern int Dead_key_set_size;
-extern bool Perspective_locked;
-extern bool Slew_locked;
 
 extern int Ignored_keys[];	//!< Ignored_keys[CCFG_MAX]; Set by sexp. If >0; value is number of times the key will be temporarily. If <0, key is permamently ignored.
 

--- a/code/io/keycontrol.h
+++ b/code/io/keycontrol.h
@@ -20,6 +20,7 @@
 extern int Dead_key_set[];
 extern int Dead_key_set_size;
 extern bool Perspective_locked;
+extern bool Slew_locked;
 
 extern int Ignored_keys[];	//!< Ignored_keys[CCFG_MAX]; Set by sexp. If >0; value is number of times the key will be temporarily. If <0, key is permamently ignored.
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -25986,6 +25986,8 @@ void sexp_force_perspective(int n)
 			return;
 		switch(option)
 		{
+			case -1:
+				break;
 			case 0:
 				Viewer_mode = 0;
 				break;
@@ -25997,6 +25999,9 @@ void sexp_force_perspective(int n)
 				break;
 			case 3:
 				Viewer_mode = VM_TOPDOWN;
+				break;
+			default:
+				Warning(LOCATION, "Unhandled option %d supplied to lock-perspective!", option);
 				break;
 		}
 		n = CDR(n);
@@ -33347,7 +33352,7 @@ int query_operator_argument_type(int op, int argnum)
 
 		case OP_CUTSCENES_FORCE_PERSPECTIVE:
 			if (argnum == 1)
-				return OPF_POSITIVE;
+				return OPF_NUMBER;
 			else
 				return OPF_BOOL;
 
@@ -40910,7 +40915,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tPrevents or allows the player from changing the view mode.  "
 		"Takes 1 or 2 arguments...\r\n"
 		"\t1:\tTrue to lock the view mode, false to unlock it\r\n"
-		"\t2:\tWhat view mode to lock; 0 for first-person, 1 for chase, 2 for external, 3 for top-down\r\n"
+		"\t2:\tWhat view mode to lock; 0 for first-person, 1 for chase, 2 for external, 3 for top-down, or -1 to not change the current view mode\r\n"
 		"\t3:\tIf in first-person, true to lock the hat/slew/free-look view, false to unlock it (optional)\r\n"
 	},
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -40916,7 +40916,7 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"Takes 1 or 2 arguments...\r\n"
 		"\t1:\tTrue to lock the view mode, false to unlock it\r\n"
 		"\t2:\tWhat view mode to lock; 0 for first-person, 1 for chase, 2 for external, 3 for top-down, or -1 to not change the current view mode\r\n"
-		"\t3:\tIf in first-person, true to lock the hat/slew/free-look view, false to unlock it (optional)\r\n"
+		"\t3:\tIf in first-person, true to lock the hat/slew/free-look/target-track mode, false to unlock it (optional)\r\n"
 	},
 
 	{ OP_SET_CAMERA_SHUDDER, "set-camera-shudder\r\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -737,7 +737,7 @@ SCP_vector<sexp_oper> Operators = {
 	{ "show-subtitle-text",				OP_CUTSCENES_SHOW_SUBTITLE_TEXT,		6,	15,			SEXP_ACTION_OPERATOR,	},
 	{ "show-subtitle-image",			OP_CUTSCENES_SHOW_SUBTITLE_IMAGE,		8,	11,			SEXP_ACTION_OPERATOR,	},
 	{ "clear-subtitles",				OP_CLEAR_SUBTITLES,						0,	0,			SEXP_ACTION_OPERATOR,	},
-	{ "lock-perspective",				OP_CUTSCENES_FORCE_PERSPECTIVE,			1,	2,			SEXP_ACTION_OPERATOR,	},
+	{ "lock-perspective",				OP_CUTSCENES_FORCE_PERSPECTIVE,			1,	3,			SEXP_ACTION_OPERATOR,	},
 	{ "set-camera-shudder",				OP_SET_CAMERA_SHUDDER,					2,	4,			SEXP_ACTION_OPERATOR,	},
 	{ "supernova-start",				OP_SUPERNOVA_START,						1,	1,			SEXP_ACTION_OPERATOR,	},
 	{ "supernova-stop",					OP_SUPERNOVA_STOP,						0,	0,			SEXP_ACTION_OPERATOR,	},	//CommanderDJ
@@ -25981,10 +25981,10 @@ void sexp_force_perspective(int n)
 	if(n != -1)
 	{
 		bool is_nan, is_nan_forever;
-		n = eval_num(n, is_nan, is_nan_forever);
+		int option = eval_num(n, is_nan, is_nan_forever);
 		if (is_nan || is_nan_forever)
 			return;
-		switch(n)
+		switch(option)
 		{
 			case 0:
 				Viewer_mode = 0;
@@ -25998,6 +25998,16 @@ void sexp_force_perspective(int n)
 			case 3:
 				Viewer_mode = VM_TOPDOWN;
 				break;
+		}
+		n = CDR(n);
+
+		// optionally prevent hat/slew/free-look
+		if (n != -1)
+		{
+			Slew_locked = is_sexp_true(n);
+
+			if (Slew_locked)
+				Viewer_mode |= VM_CENTERING;	// start centering so that we don't get stuck in a slewed position
 		}
 	}
 }
@@ -33336,10 +33346,10 @@ int query_operator_argument_type(int op, int argnum)
 			return OPF_NONE;
 
 		case OP_CUTSCENES_FORCE_PERSPECTIVE:
-			if(argnum==0)
-				return OPF_BOOL;
-			else
+			if (argnum == 1)
 				return OPF_POSITIVE;
+			else
+				return OPF_BOOL;
 
 		case OP_SET_CAMERA_SHUDDER:
 			if (argnum == 0 || argnum == 1)
@@ -40900,7 +40910,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tPrevents or allows the player from changing the view mode.  "
 		"Takes 1 or 2 arguments...\r\n"
 		"\t1:\tTrue to lock the view mode, false to unlock it\r\n"
-		"\t2:\tWhat view mode to lock; 0 for first-person, 1 for chase, 2 for external, 3 for top-down"
+		"\t2:\tWhat view mode to lock; 0 for first-person, 1 for chase, 2 for external, 3 for top-down\r\n"
+		"\t3:\tIf in first-person, true to lock the hat/slew/free-look view, false to unlock it (optional)\r\n"
 	},
 
 	{ OP_SET_CAMERA_SHUDDER, "set-camera-shudder\r\n"

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -237,6 +237,9 @@ extern FlightMode Player_flight_mode;
 extern float Flight_cursor_extent;
 extern float Flight_cursor_deadzone;
 
+extern bool Perspective_locked;
+extern bool Slew_locked;
+
 extern void player_init();							// initialization per level
 extern void player_level_init();
 extern void player_controls_init();				// initialize Descent style controls for use in various places

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -64,6 +64,8 @@ angles chase_slew_angles;
 angles Player_flight_cursor;
 
 FlightMode Player_flight_mode = FlightMode::ShipLocked;
+bool Perspective_locked = false;
+bool Slew_locked = false;
 
 auto FlightModeOption = options::OptionBuilder<FlightMode>("Game.FlightMode",
 	std::pair<const char*, int>{"Flight Mode", 1842},

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1008,6 +1008,7 @@ void game_level_init()
 	Game_shudder_time = TIMESTAMP::invalid();
 
 	Perspective_locked = false;
+	Slew_locked = false;
 
 	// reset the geometry map and distortion map batcher, this should to be done pretty soon in this mission load process (though it's not required)
 	batch_reset();


### PR DESCRIPTION
Adds an optional argument to the `lock-perspective` sexp to allow locking of the 'free look' or 'padlock' view.  This prevents the player from looking around which might not be desired in certain forced perspective situations.