### PR TITLE
create a `process_ship_subsystems` routine for subsystem operations

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19466,28 +19466,13 @@ void ship_set_new_ai_class(ship *shipp, int new_ai_class)
 }
 
 // Goober5000
-void ship_subsystem_set_new_ai_class(ship *shipp, const char *subsystem, int new_ai_class)
+void ship_subsystem_set_new_ai_class(ship_subsys *ss, int new_ai_class)
 {
-	Assert(shipp);
-	Assert(subsystem);
+	Assert(ss);
 	Assert(new_ai_class >= 0);
 
-	ship_subsys *ss;
-
-	// find the ship subsystem by searching ship's subsys_list
-	ss = GET_FIRST( &shipp->subsys_list );
-	while ( ss != END_OF_LIST( &shipp->subsys_list ) )
-	{
-		// if we found the subsystem
-		if ( !subsystem_stricmp(ss->system_info->subobj_name, subsystem))
-		{
-			// set ai class
-			ss->weapons.ai_class = new_ai_class;
-			return;
-		}
-
-		ss = GET_NEXT( ss );
-	}
+	// set ai class
+	ss->weapons.ai_class = new_ai_class;
 }
 
 // Goober5000 - will attempt to load an insignia bitmap and set it as active for the wing

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -2019,7 +2019,7 @@ void ship_class_get_actual_center(const ship_info *sip, vec3d *center_pos);
 
 // Goober5000 - used by change-ai-class
 extern void ship_set_new_ai_class(ship *shipp, int new_ai_class);
-extern void ship_subsystem_set_new_ai_class(ship *shipp, const char *subsystem, int new_ai_class);
+extern void ship_subsystem_set_new_ai_class(ship_subsys *ss, int new_ai_class);
 
 // wing squad logos - Goober5000
 extern void wing_load_squad_bitmap(wing *w);


### PR DESCRIPTION
Many SEXP operators that work on subsystems use very similar code.  This new function allows the operator implementations to be streamlined and makes future modifications easier.  For example, the `change-ai-class` operator now works with names such as `<all turrets>` as well as specific subsystems.

Inspired by #6210 although not a direct implementation of it.