### PR TITLE
address 6010

### DIFF
--- a/code/globalincs/utility.h
+++ b/code/globalincs/utility.h
@@ -294,4 +294,19 @@ int find_item_with_name(const ITEM_T* item_array, int num_items, const char* str
 	return find_item_with_field(item_array, num_items, &ITEM_T::name, str);
 }
 
+template <typename VECTOR_T>
+int find_item_with_name(const VECTOR_T& item_vector, const SCP_string& str)
+{
+	int index = 0;
+	for (const auto& item : item_vector)
+	{
+		if (lcase_equal(item.name, str))
+			return index;
+		else
+			++index;
+	}
+
+	return -1;
+}
+
 #endif

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -1,16 +1,12 @@
 
+#include "globalincs/utility.h"
 #include "math/curve.h"
 #include "parse/parselo.h"
 
 SCP_vector<Curve> Curves;
 
 int curve_get_by_name(const SCP_string& in_name) {
-	for (int i = 0; i < (int)Curves.size(); i++) {
-		if (lcase_equal(Curves[i].name, in_name))
-			return i;
-	}
-
-	return -1;
+	return find_item_with_name(Curves, in_name);
 }
 
 void parse_curve_table(const char* filename) {

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -13,7 +13,7 @@ class ParticleSource;
  *
  * @ingroup particleSystems
  */
-enum class EffectType: int64_t {
+enum class EffectType: int {
 	Invalid = -1,
 	Single,
 	Composite,
@@ -36,7 +36,7 @@ enum class EffectType: int64_t {
  */
 class ParticleEffect {
  protected:
-	SCP_string m_name; //!< The name if this effect
+	SCP_string m_name; //!< The name of this effect
 
  public:
 	/**

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -22,7 +22,8 @@
 namespace {
 using namespace particle;
 
-const char* effectTypeNames[static_cast<int64_t>(EffectType::MAX)] = {
+constexpr size_t effectTypeNamesMax = static_cast<size_t>(EffectType::MAX);
+const char* effectTypeNames[effectTypeNamesMax] = {
 	"Single",
 	"Composite",
 	"Cone",
@@ -31,16 +32,17 @@ const char* effectTypeNames[static_cast<int64_t>(EffectType::MAX)] = {
 };
 
 const char* getEffectTypeName(EffectType type) {
-	Assertion(static_cast<int64_t>(type) >= static_cast<int64_t>(EffectType::Single)
-				  && static_cast<int64_t>(type) < static_cast<int64_t>(EffectType::MAX),
-			  "Invalid effect type specified!");
+	int index = static_cast<int>(type);
+	if (index >= 0 && static_cast<size_t>(index) < effectTypeNamesMax)
+		return effectTypeNames[index];
 
-	return effectTypeNames[static_cast<int64_t>(type)];
+	UNREACHABLE("Invalid effect type %d specified!", index);
+	return "INVALID";
 }
 
 ParticleEffectPtr constructEffect(const SCP_string& name, EffectType type) {
 	using namespace effects;
-	// Use an unique_ptr to make sure memory is deallocated if an exception is thrown
+	// Use a unique_ptr to make sure memory is deallocated if an exception is thrown
 	std::unique_ptr<ParticleEffect> effect;
 
 	switch (type) {
@@ -84,14 +86,11 @@ EffectType parseEffectType() {
 	SCP_string type;
 	stuff_string(type, F_NAME);
 
-	for (size_t i = 0; i < static_cast<size_t>(EffectType::MAX); ++i) {
-		if (!stricmp(type.c_str(), effectTypeNames[i])) {
-			return static_cast<EffectType>(i);
-		}
-	}
-
-	error_display(0, "Unknown effect type '%s'!", type.c_str());
-	return EffectType::Invalid;
+	int i = string_lookup(type.c_str(), effectTypeNames, effectTypeNamesMax, "EffectType", true);
+	if (i >= 0)
+		return static_cast<EffectType>(i);
+	else
+		return EffectType::Invalid;
 }
 
 void parseCallback(const char* fileName) {
@@ -171,7 +170,7 @@ ParticleEffectHandle ParticleManager::getEffectByName(const SCP_string& name)
 
 	auto foundIterator = find_if(m_effects.begin(), m_effects.end(),
 								 [&name](const std::shared_ptr<ParticleEffect>& ptr) {
-									 return !stricmp(ptr->getName().c_str(), name.c_str());
+									 return lcase_equal(ptr->getName(), name);
 								 });
 
 	if (foundIterator == m_effects.end()) {
@@ -375,7 +374,7 @@ SCP_vector<int> parseAnimationList(bool critical) {
 		// single name case
 		SCP_string name;
 		stuff_string(name, F_FILESPEC);
-		bitmap_strings.push_back(name);
+		bitmap_strings.push_back(std::move(name));
 	}
 	
 	SCP_vector<int> handles;

--- a/code/particle/ParticleManager.h
+++ b/code/particle/ParticleManager.h
@@ -96,7 +96,7 @@ class ParticleManager {
 	 * @note If possible, only call this once and then store the index. The lookup is being done by a sequential search
 	 * which means it's pretty slow.
 	 *
-	 * @param name The name of the effect that is being searchd, may not be empty
+	 * @param name The name of the effect that is being searched, may not be empty
 	 * @return The index of the effect
 	 */
 	ParticleEffectHandle getEffectByName(const SCP_string& name);

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -35,7 +35,7 @@ class GenericShapeEffect : public ParticleEffect {
 	ConeDirection m_direction = ConeDirection::Incoming;
 	::util::UniformFloatRange m_velocity;
 	::util::UniformUIntRange m_particleNum;
-	float m_particleChance;
+	float m_particleChance = 1.0f;
 	::util::UniformFloatRange m_particleRoll;
 	ParticleEffectHandle m_particleTrail = ParticleEffectHandle::invalid();
 
@@ -187,11 +187,11 @@ class GenericShapeEffect : public ParticleEffect {
 			float chance;
 			stuff_float(&chance);
 			if (chance <= 0.0f) {
-				Warning(LOCATION,
+				error_display(0,
 					"Particle %s tried to set +Chance: %f\nChances below 0 would result in no particles.",
 					m_name.c_str(), chance);
 			} else if (chance > 1.0f) {
-				Warning(LOCATION,
+				error_display(0,
 					"Particle %s tried to set +Chance: %f\nChances above 1 are ignored, please use +Number: (min,max) "
 					"to spawn multiple particles.", m_name.c_str(), chance);
 				chance = 1.0f;
@@ -201,23 +201,23 @@ class GenericShapeEffect : public ParticleEffect {
 		m_particleRoll = ::util::UniformFloatRange(m_particleChance - 1.0f, m_particleChance);
 
 		if (optional_string("+Direction:")) {
-			SCP_string dirStr;
-			stuff_string(dirStr, F_NAME);
+			char dirStr[NAME_LENGTH];
+			stuff_string(dirStr, F_NAME, NAME_LENGTH);
 
-			if (!stricmp(dirStr.c_str(), "Incoming")) {
+			if (!stricmp(dirStr, "Incoming")) {
 				m_direction = ConeDirection::Incoming;
 			}
-			else if (!stricmp(dirStr.c_str(), "Normal")) {
+			else if (!stricmp(dirStr, "Normal")) {
 				m_direction = ConeDirection::Normal;
 			}
-			else if (!stricmp(dirStr.c_str(), "Reflected")) {
+			else if (!stricmp(dirStr, "Reflected")) {
 				m_direction = ConeDirection::Reflected;
 			}
-			else if (!stricmp(dirStr.c_str(), "Reverse")) {
+			else if (!stricmp(dirStr, "Reverse")) {
 				m_direction = ConeDirection::Reverse;
 			}
 			else {
-				error_display(0, "Unknown direction name '%s'!", dirStr.c_str());
+				error_display(0, "Unknown direction name '%s'!", dirStr);
 			}
 		}
 

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -108,12 +108,12 @@ namespace particle {
 				float chance;
 				stuff_float(&chance);
 				if (chance <= 0.0f) {
-					Warning(LOCATION,
+					error_display(0,
 						"Particle %s tried to set +Chance: %f\nChances below 0 would result in no particles.",
 						m_name.c_str(),
 						chance);
 				} else if (chance >= 1.0f) {
-					Warning(LOCATION,
+					error_display(0,
 						"Particle %s tried to set +Chance: %f\nChances above 1 are ignored, please use +Number: "
 						"(min,max) to spawn multiple particles.",
 						m_name.c_str(),
@@ -129,7 +129,7 @@ namespace particle {
 				stuff_float(&radius);
 
 				if (radius < 0.001f) {
-					Warning(LOCATION, "A volume radius of %f is not valid. Must be greater than 0. Defaulting to 10.", radius);
+					error_display(0, "A volume radius of %f is not valid. Must be greater than 0. Defaulting to 10.", radius);
 					radius = 10.0f;
 				}
 				m_radius = radius;
@@ -140,7 +140,7 @@ namespace particle {
 				stuff_float(&bias);
 
 				if (bias < 0.001f) {
-					Warning(LOCATION, "A volume bias value of %f is not valid. Must be greater than 0.", bias);
+					error_display(0, "A volume bias value of %f is not valid. Must be greater than 0.", bias);
 					bias = 1.0f;
 				}
 				m_bias = bias;
@@ -151,7 +151,7 @@ namespace particle {
 				stuff_float(&stretch);
 
 				if (stretch < 0.001f) {
-					Warning(LOCATION, "A volume stretch value of %f is not valid. Must be greater than 0.", stretch);
+					error_display(0, "A volume stretch value of %f is not valid. Must be greater than 0.", stretch);
 					stretch = 1.0f;
 				}
 				m_stretch = stretch;

--- a/code/particle/effects/VolumeEffect.h
+++ b/code/particle/effects/VolumeEffect.h
@@ -24,7 +24,7 @@ namespace particle {
 			util::EffectTiming m_timing;
 
 			::util::UniformUIntRange m_particleNum;
-			float m_particleChance;
+			float m_particleChance = 1.0f;
 			::util::UniformFloatRange m_particleRoll;
 
 			::util::UniformFloatRange m_velocity;

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -252,7 +252,7 @@ namespace particle
 			return;
 		}
 
-		Particles.push_back(part);
+		Particles.push_back(std::move(part));
 	}
 
 	// Creates a single particle. See the PARTICLE_?? defines for types.

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -22,7 +22,7 @@ void ParticleProperties::parse(bool nocreate) {
 		m_radius = ::util::parseUniformRange<float>();
 		m_parentScale = true;
 	} else if (!nocreate) {
-		Error(LOCATION, "Missing +Size or +Parent Size Factor");
+		error_display(1, "Missing +Size or +Parent Size Factor");
 	}
 
 	if (optional_string("+Length:")) {
@@ -49,7 +49,7 @@ void ParticleProperties::parse(bool nocreate) {
 		m_size_lifetime_curve = curve_get_by_name(buf);
 
 		if (m_size_lifetime_curve < 0) {
-			Warning(LOCATION, "Could not find curve '%s'", buf.c_str());
+			error_display(0, "Could not find curve '%s'", buf.c_str());
 		}
 	}
 
@@ -59,22 +59,22 @@ void ParticleProperties::parse(bool nocreate) {
 		m_vel_lifetime_curve = curve_get_by_name(buf);
 
 		if (m_vel_lifetime_curve < 0) {
-			Warning(LOCATION, "Could not find curve '%s'", buf.c_str());
+			error_display(0, "Could not find curve '%s'", buf.c_str());
 		}
 	}
 
 	if (optional_string("+Rotation:")) {
-		SCP_string buf;
-		stuff_string(buf, F_NAME);
-		if (!stricmp(buf.c_str(), "DEFAULT")) {
+		char buf[NAME_LENGTH];
+		stuff_string(buf, F_NAME, NAME_LENGTH);
+		if (!stricmp(buf, "DEFAULT")) {
 			m_rotation_type = RotationType::DEFAULT;
-		} else if (!stricmp(buf.c_str(), "RANDOM")) {
+		} else if (!stricmp(buf, "RANDOM")) {
 			m_rotation_type = RotationType::RANDOM;
-		} else if (!stricmp(buf.c_str(), "SCREEN_ALIGNED") || !stricmp(buf.c_str(), "SCREEN-ALIGNED") || !stricmp(buf.c_str(), "SCREEN ALIGNED")) {
+		} else if (!stricmp(buf, "SCREEN_ALIGNED") || !stricmp(buf, "SCREEN-ALIGNED") || !stricmp(buf, "SCREEN ALIGNED")) {
 			m_rotation_type = RotationType::SCREEN_ALIGNED;
 		} else {
 			// in the future we may want to support additional types, or even a specific angle, but that is TBD
-			Warning(LOCATION, "Rotation Type %s not supported", buf.c_str());
+			error_display(0, "Rotation Type %s not supported", buf);
 		}
 	}
 }

--- a/lib/antlr4-cpp-runtime/runtime/src/tree/xpath/XPathLexer.cpp
+++ b/lib/antlr4-cpp-runtime/runtime/src/tree/xpath/XPathLexer.cpp
@@ -115,7 +115,7 @@ XPathLexer::Initializer::Initializer() {
 		if (name.empty()) {
 			_tokenNames.push_back("<INVALID>");
 		} else {
-      _tokenNames.push_back(name);
+      _tokenNames.push_back(std::move(name));
     }
 	}
 

--- a/parsers/action_expression/generated/ActionExpressionLexer.cpp
+++ b/parsers/action_expression/generated/ActionExpressionLexer.cpp
@@ -96,7 +96,7 @@ ActionExpressionLexer::Initializer::Initializer() {
 		if (name.empty()) {
 			_tokenNames.push_back("<INVALID>");
 		} else {
-      _tokenNames.push_back(name);
+      _tokenNames.push_back(std::move(name));
     }
 	}
 

--- a/parsers/action_expression/generated/ActionExpressionParser.cpp
+++ b/parsers/action_expression/generated/ActionExpressionParser.cpp
@@ -670,7 +670,7 @@ ActionExpressionParser::Initializer::Initializer() {
 		if (name.empty()) {
 			_tokenNames.push_back("<INVALID>");
 		} else {
-      _tokenNames.push_back(name);
+      _tokenNames.push_back(std::move(name));
     }
 	}
 

--- a/parsers/arg_parser/generated/ArgumentListLexer.cpp
+++ b/parsers/arg_parser/generated/ArgumentListLexer.cpp
@@ -104,7 +104,7 @@ ArgumentListLexer::Initializer::Initializer() {
 		if (name.empty()) {
 			_tokenNames.push_back("<INVALID>");
 		} else {
-      _tokenNames.push_back(name);
+      _tokenNames.push_back(std::move(name));
     }
 	}
 

--- a/parsers/arg_parser/generated/ArgumentListParser.cpp
+++ b/parsers/arg_parser/generated/ArgumentListParser.cpp
@@ -1273,7 +1273,7 @@ ArgumentListParser::Initializer::Initializer() {
 		if (name.empty()) {
 			_tokenNames.push_back("<INVALID>");
 		} else {
-      _tokenNames.push_back(name);
+      _tokenNames.push_back(std::move(name));
     }
 	}
 


### PR DESCRIPTION
I took a close look at the code involved in parsing particle tables.  There is no smoking gun, but there are several ways to polish the code which I have implemented here.  The most likely culprits for the slowdown, IMO, are the repeated conversions between SCP_string and C-string, especially in `ParticleManager::getEffectByName()`; followed by the omission of `std::move` in several places.

Addresses #6010.