### PR TITLE
fix coverity task

### DIFF
--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Configure CMake for FSO
         env:
           CONFIGURATION: Release
-          compiler: gcc-9
+          COMPILER: gcc-9
           ENABLE_QTFRED: OFF
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
 


### PR DESCRIPTION
Per @notimaginative, change the `compiler` variable to uppercase to match its usage in the rest of the file.  This should allow the coverity task to start running again.