### PR TITLE
Fix unreliable Sounds index retrieval

### DIFF
--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -1945,14 +1945,3 @@ int ds_get_sound_id(int channel_id)
 
 	return Channels[channel_id].snd_id;
 }
-
-/**
- * @brief Given a valid channel, returns the sound signature (typically the sound index)
- * @param channel_id
- * @return
- */
-int ds_get_sound_index(int channel_id) {
-	Assert( channel_id >= 0 );
-
-	return Channels[channel_id].sid;
-}

--- a/code/sound/ds.h
+++ b/code/sound/ds.h
@@ -95,7 +95,6 @@ void ds_stop_easy(int sid);
 int ds_get_channel_size(int channel);
 
 int ds_get_sound_id(int channel);
-int ds_get_sound_buffers_index(int channel_id);
 
 // Returns the number of channels that are actually playing
 int ds_get_number_channels();

--- a/code/sound/ds.h
+++ b/code/sound/ds.h
@@ -95,7 +95,7 @@ void ds_stop_easy(int sid);
 int ds_get_channel_size(int channel);
 
 int ds_get_sound_id(int channel);
-int ds_get_sound_index(int channel_id);
+int ds_get_sound_buffers_index(int channel_id);
 
 // Returns the number of channels that are actually playing
 int ds_get_number_channels();


### PR DESCRIPTION
Our sound code is extremely confusing, so it's no wonder that the author of these functions could not find snd_get_sound_id, which is the handle into the Sounds vector.  And it's no wonder that it was missed in review either.

Also some cleanup in the main function that was causing #5899 

Fixes #5899 

EDIT: By the way, I would love if someone could double check my tests and make sure doors are working as they are supposed to.