### PR TITLE
Several coverity fixes

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -766,7 +766,7 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 		Asteroid_field.inner_max_bound = i_max;
 	}
 
-	Asteroid_field.target_names = targets;
+	Asteroid_field.target_names = std::move(targets);
 
 	// Only create asteroids if we have some to create
 	if ((!Asteroid_field.field_asteroid_type.empty()) && (num_asteroids > 0)) {

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -595,7 +595,7 @@ static void cf_add_mod_roots(const char* rootDirectory, uint32_t basic_location)
 
 			cf_root* root = cf_create_root();
 
-			root->path = rootPath;
+			root->path = std::move(rootPath);
 			if (primary) {
 				root->location_flags = basic_location | CF_LOCATION_TYPE_PRIMARY_MOD;
 			} else {

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -2784,10 +2784,12 @@ bool CCB::operator!=(const CCB& A) const {
 }
 
 bool CCB::has_first_conflict(const CCB& A) const {
+	// coverity[copy_paste_error:FALSE]
 	return !first.empty() && (first.conflicts_with(A.first) || first.conflicts_with(A.second));
 }
 
 bool CCB::has_second_conflict(const CCB& A) const {
+	// coverity[copy_paste_error:FALSE]
 	return !second.empty() && (second.conflicts_with(A.first) || second.conflicts_with(A.second));
 }
 

--- a/code/cutscene/ffmpeg/SubtitleDecoder.cpp
+++ b/code/cutscene/ffmpeg/SubtitleDecoder.cpp
@@ -122,7 +122,7 @@ void SubtitleDecoder::pushSubtitleFrame(AVPacket* packet, AVSubtitle* subtitle) 
 	}
 
 	SubtitleFramePtr frame(new SubtitleFrame());
-	frame->text = processed_text;
+	frame->text = std::move(processed_text);
 
 	frame->displayStartTime = start_time;
 	frame->displayEndTime = end_time;

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -174,7 +174,7 @@ void parse_decals_table(const char* filename) {
 			SCP_string name;
 			stuff_string(name, F_NAME);
 
-			DecalDefinition def(name);
+			DecalDefinition def(std::move(name));
 			def.parse();
 
 			DecalDefinitions.push_back(std::move(def));

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -1005,7 +1005,7 @@ void gamesnd_parse_entry(game_snd *gs, bool &orig_no_create, SCP_vector<game_snd
 			}
 		}
 
-		gs->name = name;
+		gs->name = std::move(name);
 	}
 	else
 	{
@@ -1013,7 +1013,7 @@ void gamesnd_parse_entry(game_snd *gs, bool &orig_no_create, SCP_vector<game_snd
 		{
 			Warning(LOCATION, "No existing sound entry with name \"%s\" found!", name.c_str());
 			no_create = false;
-			gs->name = name;
+			gs->name = std::move(name);
 		}
 		else
 		{
@@ -1299,7 +1299,7 @@ void parse_sound_table(const char* filename)
 							}
 						}
 
-						Snds.push_back(game_snd(tempSound));
+						Snds.emplace_back(std::move(tempSound));
 					}
 				}
 

--- a/code/globalincs/undosys.cpp
+++ b/code/globalincs/undosys.cpp
@@ -27,7 +27,7 @@ void Undo_system::clamp_stacks() {
 	// This while() shouldn't ever be triggered, but this is a safety to prevent any weird edge-cases.
 	while (redo_stack.size() > max_undos) {
 		delete redo_stack.front();
-		undo_stack.pop_front();
+		redo_stack.pop_front();
 	}
 }
 

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -5520,7 +5520,7 @@ void load_gauge_scripting(gauge_settings* settings) {
 	SCP_string name;
 	stuff_string(name, F_NAME);
 
-	hud_gauge->initName(name);
+	hud_gauge->initName(std::move(name));
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -31,7 +31,7 @@ void LabUi::object_changed()
 		trigger = false;
 }
 
-void LabUi::build_species_entry(species_info species_def, int species_idx) const
+void LabUi::build_species_entry(const species_info &species_def, int species_idx) const
 {
 	with_TreeNode(species_def.species_name)
 	{

--- a/code/lab/dialogs/lab_ui.h
+++ b/code/lab/dialogs/lab_ui.h
@@ -13,7 +13,7 @@ class LabUi {
   private:
 	void build_options_menu();
 	void build_ship_list() const;
-	void build_species_entry(species_info species_def, int species_idx) const;
+	void build_species_entry(const species_info &species_def, int species_idx) const;
 	void build_weapon_list() const;
 	void build_weapon_subtype_list() const;
 	void build_background_list() const;

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -28,7 +28,7 @@ void parse_curve_table(const char* filename) {
 			int index = curve_get_by_name(name);
 
 			if (index < 0) {
-				Curve curv = Curve(name);
+				Curve curv = Curve(std::move(name));
 				curv.ParseData();
 				Curves.push_back(curv);
 			} else {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -8386,6 +8386,8 @@ int get_special_anchor(const char *name)
 
 	strcpy_s(tmp, name+5);
 	iff_name = strtok(tmp, " >");
+	if (iff_name == nullptr)
+		return -1;
 
 	// hack substitute "hostile" for "enemy"
 	if (!stricmp(iff_name, "enemy"))

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -340,7 +340,7 @@ void HudGaugeDirectives::render(float  /*frametime*/)
 
 		if ( second_line ) {
 
-			if (directives_top.first_frame >= 0)
+			if (directives_middle.first_frame >= 0)
 				renderBitmap(directives_middle.first_frame, bx, by);
 			
 			by += text_h;

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -1377,7 +1377,7 @@ void stuff_string(SCP_string &outstr, int type, const char *terminators)
 	}
 	else
 	{
-		outstr = read_str;
+		outstr = std::move(read_str);
 	}
 
 	diag_printf("Stuffed string = [%.30s]\n", outstr.c_str());

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2784,7 +2784,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 						SCP_string triggeredBy = CTEXT(CDDR(ship_node));
 						SCP_tolower(triggeredBy);
 						
-						if(std::find_if(animations.cbegin(), animations.cend(), [triggerType, triggeredBy](const std::remove_reference<decltype(animations)>::type::value_type& animation) -> bool {
+						if(std::find_if(animations.cbegin(), animations.cend(), [&triggerType, &triggeredBy](const std::remove_reference<decltype(animations)>::type::value_type& animation) -> bool {
 							if (animation.type != triggerType)
 								return false;
 
@@ -13358,7 +13358,7 @@ void sexp_set_player_orders(int n)
 		std::set<size_t> diff;
 		std::set_difference(shipp->orders_accepted.begin(), shipp->orders_accepted.end(), orders.begin(), orders.end(),
 							std::inserter(diff, diff.end()));
-		shipp->orders_accepted = diff;
+		shipp->orders_accepted = std::move(diff);
 	}
 }
 
@@ -13401,7 +13401,7 @@ void sexp_set_order_allowed_for_target(int n)
 		std::set<size_t> diff;
 		std::set_difference(shipp->orders_allowed_against.begin(), shipp->orders_allowed_against.end(), orders.begin(), orders.end(),
 							std::inserter(diff, diff.end()));
-		shipp->orders_allowed_against = diff;
+		shipp->orders_allowed_against = std::move(diff);
 	}
 }
 
@@ -16397,7 +16397,7 @@ void sexp_set_asteroid_field(int n)
 		inner_box,
 		i_min,
 		i_max,
-		targets);
+		std::move(targets));
 
 }
 
@@ -16491,7 +16491,7 @@ void sexp_set_debris_field(int n)
 	asteroid_create_debris_field(
 		num_asteroids,
 		asteroid_speed,
-		debris_types,
+		std::move(debris_types),
 		o_min,
 		o_max,
 		enhanced);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -9085,6 +9085,7 @@ int sexp_angle_vectors(int node) {
 	if (is_nan1 || is_nan2)
 		return SEXP_NAN;
 
+	// coverity[uninit_use_in_call:FALSE] - v1 and v2 are always populated by eval_vec3d
 	if (IS_VEC_NULL(&v1) || IS_VEC_NULL(&v2))
 		return SEXP_NAN;
 
@@ -19036,7 +19037,7 @@ void sexp_weapon_create(int n)
 	is_locked = (target_objnum >= 0) ? 1 : 0;	// assume full lock; this lets lasers track if people want them to
 
 	// create the weapon
-	// coverity[uninit_use_in_call] - weapon_pos is always populated by eval_vec3d
+	// coverity[uninit_use_in_call:FALSE] - weapon_pos is always populated by eval_vec3d
 	weapon_objnum = weapon_create(&weapon_pos, &weapon_orient, weapon_class, parent_objnum, -1, is_locked);
 
 	// maybe make the weapon track its target

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -54,7 +54,7 @@ void parse_sexp_table(const char* filename) {
 
 
 				dynamic_sexp_enum_list thisList;
-				thisList.name = name;
+				thisList.name = std::move(name);
 
 				while (optional_string("+Enum:")) {
 					SCP_string item;

--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -264,7 +264,7 @@ ParticleSourceWrapper ParticleManager::createSource(ParticleEffectHandle index)
 		// To ensure this we reserve the number of sources we will need (current sources + sources being created)
 		if (m_processingSources) {
 			// If we are already in our onFrame, we need to apply the hack to the right vector though
-			m_deferredSourceAdding.reserve(m_sources.size() + childEffects.size());
+			m_deferredSourceAdding.reserve(m_deferredSourceAdding.size() + childEffects.size());
 		} else {
 			m_sources.reserve(m_sources.size() + childEffects.size());
 		}

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1759,7 +1759,7 @@ ADE_INDEXER(l_UserInterface_Cutscenes,
 	if (!ade_get_args(L, "*s", &name))
 		return ade_set_error(L, "o", l_TechRoomCutscene.Set(cutscene_info_h(-1)));
 
-	// coverity[uninit_use_in_call] - name is assigned via ade_get_args
+	// coverity[uninit_use_in_call:FALSE] - name is assigned via ade_get_args
 	int idx = get_cutscene_index_by_name(name);
 
 	if (idx < 0) {

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -771,6 +771,8 @@ thruster_bank* thrusterbank_h::Get() const
 {
 	if (!isValid())
 		return nullptr;
+
+	// coverity[returned_null:FALSE] - isValid() specifically checks for modelh.Get() returning null
 	return &modelh.Get()->thrusters[thrusterbank_index];
 }
 bool thrusterbank_h::isValid() const
@@ -891,6 +893,8 @@ glow_point_bank* glowpointbank_h::Get() const
 {
 	if (!isValid())
 		return nullptr;
+
+	// coverity[returned_null:FALSE] - isValid() specifically checks for modelh.Get() returning null
 	return &modelh.Get()->glow_point_banks[glowpointbank_index];
 }
 bool glowpointbank_h::isValid() const
@@ -1114,6 +1118,7 @@ ADE_FUNC(__len, l_ModelDockingbays, NULL, "Retrieves the number of dockingbays o
 	if (!dbhp->isValid())
 		return ade_set_error(L, "i", 0);
 
+	// coverity[returned_null:FALSE] - isValid() specifically checks for model_get() returning null
 	return ade_set_args(L, "i", dbhp->Get()->n_docks);
 }
 
@@ -1127,6 +1132,7 @@ bool dockingbay_h::isValid() const
 	if (!modelh.isValid())
 		return false;
 
+	// coverity[returned_null:FALSE] - isValid() specifically checks for model_get() returning null
 	return dock_id >= 0 && dock_id < modelh.Get()->n_docks;
 }
 dock_bay* dockingbay_h::getDockingBay() const
@@ -1134,6 +1140,7 @@ dock_bay* dockingbay_h::getDockingBay() const
 	if (!isValid())
 		return nullptr;
 
+	// coverity[returned_null:FALSE] - isValid() specifically checks for model_get() returning null
 	return &modelh.Get()->docking_bays[dock_id];
 }
 

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -137,9 +137,9 @@ void script_parse_lua_script(const char *filename) {
 
 		script_function func;
 		func.language = SC_LUA;
-		func.function = function;
+		func.function = std::move(function);
 
-		Script_system.AddGameInitFunction(func);
+		Script_system.AddGameInitFunction(std::move(func));
 	} catch (const LuaException& e) {
 		LuaError(Script_system.GetLuaSession(), "Failed to parse %s: %s", filename, e.what());
 	}
@@ -686,7 +686,7 @@ void script_state::ParseChunkSub(script_function& script_func, const char* debug
 		auto function = LuaFunction::createFromCode(LuaState, source, function_name);
 		function.setErrorFunction(LuaFunction::createFromCFunction(LuaState, ade_friendly_error));
 
-		script_func.function = function;
+		script_func.function = std::move(function);
 	} catch (const LuaException& e) {
 		LuaError(GetLuaSession(), "%s", e.what());
 	}

--- a/code/scripting/util/LuaValueSerializer.cpp
+++ b/code/scripting/util/LuaValueSerializer.cpp
@@ -74,7 +74,7 @@ json_t* LuaValueSerializer::tableToJsonArray(const luacpp::LuaTable& table)
 		if (!table.getValue(i, arrayVal)) {
 			json_array_append_new(jsonArray, json_null());
 		} else {
-			LuaValueSerializer valueSerializer(arrayVal);
+			LuaValueSerializer valueSerializer(std::move(arrayVal));
 			json_array_append_new(jsonArray, valueSerializer.toJson());
 		}
 	}

--- a/code/ship/awacs.cpp
+++ b/code/ship/awacs.cpp
@@ -290,7 +290,7 @@ const     float FULLY_TARGETABLE        = (viewer_has_primitive_sensors ? ((dist
 				if (test > Awacs[idx].subsys->awacs_radius)
 					continue;
 
-				// coverity[dead_error_line] - closest_index will be a value other than -1 on future loop iterations
+				// coverity[dead_error_line:FALSE] - closest_index will be a value other than -1 on future loop iterations
 				if ((closest_index == -1) || (test < closest))
 				{
 					closest = test;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11043,11 +11043,9 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 		for (int bank = 0; bank < pm->n_glow_point_banks; bank++) {
 			glow_point_bank_override* gpo = nullptr;
 
-			if (sip) {
-				SCP_unordered_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(bank);
-				if (gpoi != sip->glowpoint_bank_override_map.end()) {
-					gpo = (glow_point_bank_override*)sip->glowpoint_bank_override_map[bank];
-				}
+			SCP_unordered_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(bank);
+			if (gpoi != sip->glowpoint_bank_override_map.end()) {
+				gpo = (glow_point_bank_override*)sip->glowpoint_bank_override_map[bank];
 			}
 
 			if (gpo) {
@@ -11197,11 +11195,9 @@ static void ship_model_change(int n, int ship_type)
 		for (int bank = 0; bank < pm->n_glow_point_banks; bank++) {
 			glow_point_bank_override* gpo = nullptr;
 
-			if (sip) {
-				SCP_unordered_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(bank);
-				if (gpoi != sip->glowpoint_bank_override_map.end()) {
-					gpo = (glow_point_bank_override*)sip->glowpoint_bank_override_map[bank];
-				}
+			SCP_unordered_map<int, void*>::iterator gpoi = sip->glowpoint_bank_override_map.find(bank);
+			if (gpoi != sip->glowpoint_bank_override_map.end()) {
+				gpo = (glow_point_bank_override*)sip->glowpoint_bank_override_map[bank];
 			}
 
 			if (gpo) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14547,6 +14547,8 @@ int ship_info_lookup(const char *token)
 	{
 		// chop off right parenthesis (it exists because otherwise the left wouldn't have been flagged)
 		char *p2 = strchr(temp2, ')');
+		if (!p2)
+			return -1;
 		*p2 = '\0';
 
 		// assemble using hash

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3211,12 +3211,12 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 	if (optional_string("$Default Team:")) {
 		char temp[NAME_LENGTH];
 		stuff_string(temp, F_NAME, NAME_LENGTH);
-		SCP_string name = temp;
 		if (!stricmp(temp, "none")) {
 			sip->uses_team_colors = true;
 		} else {
+			SCP_string name = temp;
 			if (Team_Colors.find(name) != Team_Colors.end()) {
-				sip->default_team_name = name;
+				sip->default_team_name = std::move(name);
 				sip->uses_team_colors = true;
 			} else {
 				Warning(LOCATION, "Team name %s is invalid. Teams must be defined in colors.tbl.\n", temp);

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -207,7 +207,7 @@ void parse_rank_table(const char* filename)
 						continue;
 					}
 				}
-				rank_p->promotion_text[persona] = buf;
+				rank_p->promotion_text[persona] = std::move(buf);
 			}
 
 			if (rank_p->promotion_text.find(-1) == rank_p->promotion_text.end())
@@ -339,7 +339,7 @@ void parse_traitor_tbl(const char* filename)
 						continue;
 					}
 				}
-				Traitor.debriefing_text[persona] = text;
+				Traitor.debriefing_text[persona] = std::move(text);
 			}
 
 			if (optional_string("$Voice:"))
@@ -368,12 +368,12 @@ void parse_traitor_tbl(const char* filename)
 				stuff_string(rec, F_MULTITEXT);
 
 				traitor_override_t traitor;
-				traitor.name = name;
-				traitor.text = text;
-				traitor.recommendation_text = rec;
+				traitor.name = std::move(name);
+				traitor.text = std::move(text);
+				traitor.recommendation_text = std::move(rec);
 				strcpy_s(traitor.voice_filename, file);
 
-				Traitor_overrides.push_back(traitor);
+				Traitor_overrides.push_back(std::move(traitor));
 			}
 		}
 	}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2574,7 +2574,7 @@ void beam_get_binfo(beam *b, float accuracy, int num_shots, int burst_seed, floa
 				vm_vec_random_in_circle(&pos1, &center, &orient, 1.f, bwi->t5info.start_pos == Type5BeamPos::RANDOM_OUTSIDE);
 
 			if (bwi->t5info.end_pos != Type5BeamPos::CENTER)
-				vm_vec_random_in_circle(&pos2, &center, &orient, 1.f, bwi->t5info.start_pos == Type5BeamPos::RANDOM_OUTSIDE);
+				vm_vec_random_in_circle(&pos2, &center, &orient, 1.f, bwi->t5info.end_pos == Type5BeamPos::RANDOM_OUTSIDE);
 
 			if (bwi->t5info.no_translate || bwi->t5info.end_pos == Type5BeamPos::SAME_RANDOM)
 				pos2 = pos1;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -3487,7 +3487,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			temp_data.ssm_entry = fname;
 			if (Delayed_SSM_data.find(wip->name) == Delayed_SSM_data.end())
 				Delayed_SSM_names.push_back(wip->name);
-			Delayed_SSM_data[wip->name] = temp_data;
+			Delayed_SSM_data[wip->name] = std::move(temp_data);
 		} else {
 			// We'll still want to validate the index later. -MageKing17
 			delayed_ssm_index_data temp_data;
@@ -3495,7 +3495,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			temp_data.linenum = get_line_num();
 			if (Delayed_SSM_indices_data.find(wip->name) == Delayed_SSM_indices_data.end())
 				Delayed_SSM_indices.push_back(wip->name);
-			Delayed_SSM_indices_data[wip->name] = temp_data;
+			Delayed_SSM_indices_data[wip->name] = std::move(temp_data);
 		}
 	}// SSM index -Bobboau
 


### PR DESCRIPTION
Fix, or mark as false positive, several issues flagged by Coverity.
* using `std::move` instead of copying, and change some parameters from value to reference
* fix or mark potential copy-paste mistakes
* various checking of parameter and return values
* miscellaneous fixes, and change some 'intentional' markers to 'false positive' markers