### PR TITLE
Fix Insignia Checkbox in the Lab

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7351,7 +7351,7 @@ void HudGaugeHardpoints::render(float  /*frametime*/)
 	vertex draw_point;
 	vec3d subobj_pos;
 
-	int render_flags = MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_TEXTURING | MR_NO_ZBUFFER;
+	uint64_t render_flags = MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING | MR_NO_TEXTURING | MR_NO_ZBUFFER;
 
 	setGaugeColor();
 	float alpha = gr_screen.current_color.alpha / 255.0f;

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -570,7 +570,7 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp)
 	target_shipp	= &Ships[target_objp->instance];
 	target_sip		= &Ship_info[target_shipp->ship_info_index];
 
-	int flags=0;
+	uint64_t flags = 0;
 	if ( Detail.targetview_model )	{
 		// take the forward orientation to be the vector from the player to the current target
 		vm_vec_sub(&orient_vec, &target_objp->pos, &Player_obj->pos);
@@ -746,7 +746,7 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 	debris	*debrisp;
 	vec3d	orient_vec, up_vector;
 	float		factor;	
-	int flags=0;
+	uint64_t flags = 0;
 
 	debrisp = &Debris[target_objp->instance];
 
@@ -868,7 +868,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 	object		*viewer_obj, *viewed_obj;
 	std::shared_ptr<model_texture_replace> replacement_textures = nullptr;
 	int			target_team, is_homing, is_player_missile, missile_view, viewed_model_num, hud_target_lod, w, h;
-	int flags=0;
+	uint64_t flags = 0;
 
 	target_team = obj_team(target_objp);
 
@@ -1141,7 +1141,7 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 	float			time_to_impact, factor;	
 	int			pof;
 
-	int flags=0;									//draw flags for wireframe
+	uint64_t flags = 0;									//draw flags for wireframe
 	asteroidp = &Asteroids[target_objp->instance];
 
 	pof = asteroidp->asteroid_subtype;

--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -407,7 +407,7 @@ void CJumpNode::Render(model_draw_list *scene, const vec3d *pos, const vec3d *vi
 
 	matrix node_orient = IDENTITY_MATRIX;
 
-	int mr_flags = MR_NO_LIGHTING | MR_NO_BATCH;
+	uint64_t mr_flags = MR_NO_LIGHTING | MR_NO_BATCH;
 	if(!(m_flags & JN_SHOW_POLYS)) {
 		mr_flags |= MR_NO_CULL | MR_NO_POLYS | MR_SHOW_OUTLINE | MR_SHOW_OUTLINE_HTL | MR_NO_TEXTURING;
 	}

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -95,7 +95,7 @@ void LabRenderer::renderModel(float frametime) {
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_miscmap, renderFlags[LabRenderFlag::NoMiscMap]);
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_weapons, !renderFlags[LabRenderFlag::ShowWeapons]);
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_ambientmap, renderFlags[LabRenderFlag::NoAOMap]);
-		Ships[obj->instance].flags.set(Ship::Ship_Flags::No_insignias, renderFlags[LabRenderFlag::ShowInsignia]);
+		Ships[obj->instance].flags.set(Ship::Ship_Flags::No_insignias, !renderFlags[LabRenderFlag::ShowInsignia]);
 
 		Ships[obj->instance].team_name = currentTeamColor;
 

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -95,6 +95,7 @@ void LabRenderer::renderModel(float frametime) {
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_miscmap, renderFlags[LabRenderFlag::NoMiscMap]);
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_weapons, !renderFlags[LabRenderFlag::ShowWeapons]);
 		Ships[obj->instance].flags.set(Ship::Ship_Flags::Render_without_ambientmap, renderFlags[LabRenderFlag::NoAOMap]);
+		Ships[obj->instance].flags.set(Ship::Ship_Flags::No_insignias, renderFlags[LabRenderFlag::ShowInsignia]);
 
 		Ships[obj->instance].team_name = currentTeamColor;
 

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -632,7 +632,7 @@ void techroom_ships_render(float frametime)
 	gr_set_proj_matrix(Proj_fov, gr_screen.clip_aspect, Min_draw_distance, Max_draw_distance);
 	gr_set_view_matrix(&Eye_position, &Eye_matrix);
 
-	uint render_flags = MR_AUTOCENTER;
+	uint64_t render_flags = MR_AUTOCENTER;
 
 	if(noLighting)
 		render_flags |= MR_NO_LIGHTING;

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1549,7 +1549,7 @@ int restore_wss_data(ubyte *data)
 	return offset;
 }
 
-void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, int w, int h, ship_info *sip, int resize_mode, const vec3d *closeup_pos)
+void draw_model_icon(int model_id, uint64_t flags, float closeup_zoom, int x, int y, int w, int h, ship_info *sip, int resize_mode, const vec3d *closeup_pos)
 {
 	matrix	object_orient	= IDENTITY_MATRIX;
 	angles rot_angles = vmd_zero_angles;
@@ -1662,7 +1662,7 @@ void draw_model_icon(int model_id, int flags, float closeup_zoom, int x, int y, 
 }
 
 void light_set_all_relevent();
-void draw_model_rotating(model_render_params *render_info, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, vec3d *closeup_pos, float closeup_zoom, float rev_rate, int flags, int resize_mode, int effect)
+void draw_model_rotating(model_render_params *render_info, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, vec3d *closeup_pos, float closeup_zoom, float rev_rate, uint64_t flags, int resize_mode, int effect)
 {
 	//WMC - Can't draw a non-model
 	if (model_id < 0)

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -221,8 +221,8 @@ int store_wss_data(ubyte *data, const unsigned int max_size, interface_snd_id so
 int restore_wss_data(ubyte *data);
 
 class ship_info;
-void draw_model_icon(int model_id, int flags, float closeup_zoom, int x1, int x2, int y1, int y2, ship_info* sip = NULL, int resize_mode = GR_RESIZE_FULL, const vec3d *closeup_pos = &vmd_zero_vector);
-void draw_model_rotating(model_render_params *render_info, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, vec3d *closeup_pos=NULL, float closeup_zoom = .65f, float rev_rate = REVOLUTION_RATE, int flags = MR_AUTOCENTER | MR_NO_FOGGING, int resize_mode=GR_RESIZE_FULL, int effect = 2);
+void draw_model_icon(int model_id, uint64_t flags, float closeup_zoom, int x1, int x2, int y1, int y2, ship_info* sip = NULL, int resize_mode = GR_RESIZE_FULL, const vec3d *closeup_pos = &vmd_zero_vector);
+void draw_model_rotating(model_render_params *render_info, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, vec3d *closeup_pos=NULL, float closeup_zoom = .65f, float rev_rate = REVOLUTION_RATE, uint64_t flags = MR_AUTOCENTER | MR_NO_FOGGING, int resize_mode=GR_RESIZE_FULL, int effect = 2);
 
 void common_set_team_pointers(int team);
 void common_reset_team_pointers();

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1047,6 +1047,7 @@ void model_set_detail_level(int n);
 #define MR_FORCE_CLAMP				(1<<29)		// force clamp - Hery
 #define MR_EMPTY_SLOT5				(1<<30)		// Use a animated Shader - Valathil
 #define MR_ATTACHED_MODEL			(1<<31)		// Used for attached weapon model lodding
+#define MR_NO_INSIGNIA				(1<<32)		// Disable the insignias for ... reasons
 
 #define MR_DEBUG_PIVOTS				(1<<0)		// Show the pivot points
 #define MR_DEBUG_PATHS				(1<<1)		// Show the paths associated with a model

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1438,11 +1438,11 @@ bool model_get_team_color(team_color *clr, const SCP_string &team, const SCP_str
 
 void moldel_calc_facing_pts( vec3d *top, vec3d *bot, vec3d *fvec, vec3d *pos, float w, float z_add, vec3d *Eyeposition );
 
-void model_draw_debug_points(const polymodel *pm, const bsp_info *submodel, uint flags);
+void model_draw_debug_points(const polymodel *pm, const bsp_info *submodel, uint64_t flags);
 
-void model_render_shields( polymodel * pm, uint flags );
+void model_render_shields( polymodel * pm, uint64_t flags );
 
-void model_draw_paths_htl( int model_num, uint flags );
+void model_draw_paths_htl( int model_num, uint64_t flags );
 
 void model_draw_bay_paths_htl(int model_num);
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1047,7 +1047,7 @@ void model_set_detail_level(int n);
 #define MR_FORCE_CLAMP				(1<<29)		// force clamp - Hery
 #define MR_EMPTY_SLOT5				(1<<30)		// Use a animated Shader - Valathil
 #define MR_ATTACHED_MODEL			(1<<31)		// Used for attached weapon model lodding
-#define MR_NO_INSIGNIA				(1<<32)		// Disable the insignias for ... reasons
+constexpr uint64_t MR_NO_INSIGNIA = 2147483648;	// Disable the insignias for ... reasons.  Also << more than 31 causes UB, so that's (1<<32)
 
 #define MR_DEBUG_PIVOTS				(1<<0)		// Show the pivot points
 #define MR_DEBUG_PATHS				(1<<1)		// Show the paths associated with a model

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -611,7 +611,7 @@ ubyte Interp_subspace_r = 255;
 ubyte Interp_subspace_g = 255;
 ubyte Interp_subspace_b = 255;
 
-void model_draw_debug_points(const polymodel *pm, const bsp_info *submodel, uint flags )
+void model_draw_debug_points(const polymodel *pm, const bsp_info *submodel, uint64_t flags )
 {
 	if ( flags & MR_SHOW_OUTLINE_PRESET )	{
 		return;
@@ -686,7 +686,7 @@ void model_draw_debug_points(const polymodel *pm, const bsp_info *submodel, uint
 /**
  * Debug code to show all the paths of a model
  */
-void model_draw_paths_htl( int model_num, uint flags )
+void model_draw_paths_htl( int model_num, uint64_t flags )
 {
 	int i,j;
 	vec3d pnt;
@@ -867,7 +867,7 @@ int interp_box_offscreen( vec3d *min, vec3d *max )
 	return IBOX_ALL_ON;	
 }
 
-void model_render_shields( polymodel * pm, uint flags )
+void model_render_shields( polymodel * pm, uint64_t flags )
 {
 	int i, j;
 	shield_tri *tri;

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -49,7 +49,7 @@ color Wireframe_color;
 
 extern void interp_render_arc_segment(const vec3d *v1, const vec3d *v2, int depth);
 
-int model_render_determine_elapsed_time(int objnum, uint flags);
+int model_render_determine_elapsed_time(int objnum, uint64_T flags);
 
 model_batch_buffer TransformBufferHandler;
 
@@ -90,7 +90,7 @@ model_render_params::model_render_params() :
 	gr_init_color(&Color, 0, 0, 0);
 }
 
-uint model_render_params::get_model_flags() const
+uint64_t model_render_params::get_model_flags() const
 {
 	return Model_flags; 
 }
@@ -289,7 +289,7 @@ void model_render_params::set_object_number(int num)
 	Objnum = num;
 }
 
-void model_render_params::set_flags(uint flags)
+void model_render_params::set_flags(uint64_t flags)
 {
 	Model_flags = flags;
 }
@@ -977,7 +977,7 @@ int model_render_determine_detail(float depth, int model_num, int detail_level_l
 void model_render_buffers(model_draw_list* scene, model_material *rendering_material, const model_render_params* interp, const vertex_buffer *buffer, const polymodel *pm, int mn, int detail_level, uint tmap_flags)
 {
 	bsp_info *submodel = nullptr;
-	const uint model_flags = interp->get_model_flags();
+	const uint64_t model_flags = interp->get_model_flags();
 	const uint debug_flags = interp->get_debug_flags();
 	const int obj_num = interp->get_object_number();
 
@@ -1264,7 +1264,7 @@ void model_render_children_buffers(model_draw_list* scene, model_material *rende
 		}
 	}
 
-	const uint model_flags = interp->get_model_flags();
+	const uint64_t model_flags = interp->get_model_flags();
 
 	if (sm->flags[Model::Submodel_flags::Is_thruster]) {
 		if ( !( model_flags & MR_SHOW_THRUSTERS ) ) {
@@ -1325,7 +1325,7 @@ void model_render_children_buffers(model_draw_list* scene, model_material *rende
 	scene->pop_transform();
 }
 
-float model_render_determine_light_factor(const model_render_params* interp, const vec3d *pos, uint flags)
+float model_render_determine_light_factor(const model_render_params* interp, const vec3d *pos, uint64_t flags)
 {
 	if ( flags & MR_IS_ASTEROID ) {
 		// Dim it based on distance
@@ -1373,7 +1373,7 @@ float model_render_determine_box_scale()
 
 // Goober5000
 // Returns milliseconds since texture animation started.
-int model_render_determine_elapsed_time(int objnum, uint flags)
+int model_render_determine_elapsed_time(int objnum, uint64_t flags)
 {
 	if ( objnum >= 0 ) {
 		object *objp = &Objects[objnum];
@@ -1389,7 +1389,7 @@ int model_render_determine_elapsed_time(int objnum, uint flags)
 	return timestamp_get_mission_time_in_milliseconds();
 }
 
-bool model_render_determine_autocenter(vec3d *auto_back, const polymodel *pm, int detail_level, uint flags)
+bool model_render_determine_autocenter(vec3d *auto_back, const polymodel *pm, int detail_level, uint64_t flags)
 {
 	if ( flags & MR_AUTOCENTER ) {
 		// standard autocenter using data in model
@@ -1439,7 +1439,7 @@ gr_alpha_blend model_render_determine_blend_mode(int base_bitmap, bool blending)
 	return ALPHA_BLEND_ALPHA_BLEND_ALPHA;
 }
 
-bool model_render_check_detail_box(const vec3d *view_pos, const polymodel *pm, int submodel_num, uint flags)
+bool model_render_check_detail_box(const vec3d *view_pos, const polymodel *pm, int submodel_num, uint64_t flags)
 {
 	Assert(pm != NULL);
 
@@ -1528,7 +1528,7 @@ void submodel_render_queue(const model_render_params *render_info, model_draw_li
 		rendering_material.set_team_color(render_info->get_team_color());
 	}
 		
-	uint flags = render_info->get_model_flags();
+	uint64_t flags = render_info->get_model_flags();
 	int objnum = render_info->get_object_number();
 
 	// Set the flags we will pass to the tmapper
@@ -2685,7 +2685,7 @@ void model_render_queue(const model_render_params* interp, model_draw_list* scen
 	int i;
 
 	const int objnum = interp->get_object_number();
-	const int model_flags = interp->get_model_flags();
+	const uint64_t model_flags = interp->get_model_flags();
 
 	model_material rendering_material;
 	polymodel *pm = model_get(model_num);
@@ -2980,7 +2980,8 @@ void model_render_queue(const model_render_params* interp, model_draw_list* scen
 		}
 	}
 
-	if ( !( model_flags & MR_NO_TEXTURING ) ) {
+	// MARKED!
+	if ( !( model_flags & MR_NO_TEXTURING ) && !( model_flags & MR_NO_INSIGNIA) ) {
 		scene->add_insignia(interp, pm, detail_level, interp->get_insignia_bitmap());
 	}
 
@@ -3014,7 +3015,7 @@ void model_render_queue(const model_render_params* interp, model_draw_list* scen
 void model_render_only_glowpoint_lights(const model_render_params* interp, int model_num, int model_instance_num, const matrix* orient, const vec3d* pos)
 {
 	const int objnum = interp->get_object_number();
-	const int model_flags = interp->get_model_flags();
+	const uint64_t model_flags = interp->get_model_flags();
 
 	polymodel *pm = model_get(model_num);
 	polymodel_instance *pmi = nullptr;
@@ -3117,7 +3118,7 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 	float closeup_zoom;
 	int model_num;
 	bool model_lighting = true;
-	uint render_flags = MR_AUTOCENTER | MR_NO_FOGGING;
+	uint64_t render_flags = MR_AUTOCENTER | MR_NO_FOGGING;
 
 	switch (model_type) {
 		case TECH_SHIP:

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -49,7 +49,7 @@ color Wireframe_color;
 
 extern void interp_render_arc_segment(const vec3d *v1, const vec3d *v2, int depth);
 
-int model_render_determine_elapsed_time(int objnum, uint64_T flags);
+int model_render_determine_elapsed_time(int objnum, uint64_t flags);
 
 model_batch_buffer TransformBufferHandler;
 
@@ -2532,7 +2532,7 @@ void model_render_arc(const vec3d *v1, const vec3d *v2, const color *primary, co
 	}
 }
 
-void model_render_debug_children(const polymodel *pm, int mn, int detail_level, uint debug_flags)
+void model_render_debug_children(const polymodel *pm, int mn, int detail_level, uint64_t debug_flags)
 {
 	int i;
 
@@ -2566,7 +2566,7 @@ void model_render_debug_children(const polymodel *pm, int mn, int detail_level, 
 	g3_done_instance(true);
 }
 
-void model_render_debug(int model_num, const matrix *orient, const vec3d *pos, uint flags, uint debug_flags, int objnum, int detail_level_locked )
+void model_render_debug(int model_num, const matrix *orient, const vec3d *pos, uint64_t flags, uint debug_flags, int objnum, int detail_level_locked )
 {
 	polymodel *pm = model_get(model_num);	
 	

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -307,7 +307,7 @@ void model_render_queue(const model_render_params* render_info, model_draw_list*
 void submodel_render_immediate(const model_render_params* render_info, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* orient, const vec3d* pos);
 void submodel_render_queue(const model_render_params* render_info, model_draw_list* scene, const polymodel* pm, const polymodel_instance* pmi, int submodel_num, const matrix* orient, const vec3d* pos);
 void model_render_buffers(model_draw_list* scene, model_material* rendering_material, const model_render_params* interp, const vertex_buffer* buffer, const polymodel* pm, int mn, int detail_level, uint tmap_flags);
-bool model_render_check_detail_box(const vec3d* view_pos, const polymodel* pm, int submodel_num, uint flags);
+bool model_render_check_detail_box(const vec3d* view_pos, const polymodel* pm, int submodel_num, uint64_t flags);
 void model_render_arc(const vec3d* v1, const vec3d* v2, const color* primary, const color* secondary, float arc_width);
 void model_render_insignias(const insignia_draw_data* insignia);
 void model_render_set_wireframe_color(const color* clr);

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -62,7 +62,7 @@ extern int model_interp_get_texture(const texture_info *tinfo, int elapsed_time)
 
 class model_render_params
 {
-	uint Model_flags;
+	uint64_t Model_flags;
 	uint Debug_flags;
 
 	int Objnum;
@@ -107,7 +107,7 @@ class model_render_params
 public:
 	model_render_params();
 
-	void set_flags(uint flags);
+	void set_flags(uint64_t flags);
 	void set_debug_flags(uint flags);
 	void set_object_number(int num);
 	void set_detail_level_lock(int detail_level_lock);
@@ -133,7 +133,7 @@ public:
 	bool is_alpha_mult_set() const;
 	bool uses_thick_outlines() const;
 
-	uint get_model_flags() const;
+	uint64_t get_model_flags() const;
 	uint get_debug_flags() const;
 	int get_object_number() const;
 	int get_detail_level_lock() const;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -20993,6 +20993,10 @@ void ship_render(object* obj, model_draw_list* scene)
 		render_flags |= MR_NO_LIGHTING;
 	}
 
+	if (shipp->flags[Ship_Flags::No_insignias]) {
+		render_flags |= MR_NO_INSIGNIA;		
+	}
+
 	uint debug_flags = render_info.get_debug_flags();
 
 	if (shipp->flags[Ship_Flags::Render_without_diffuse]) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -20797,7 +20797,7 @@ int ship_render_get_insignia(object* obj, ship* shipp)
 	return -1;
 }
 
-void ship_render_set_animated_effect(model_render_params *render_info, ship *shipp, uint * /*render_flags*/)
+void ship_render_set_animated_effect(model_render_params *render_info, ship *shipp, uint64_t * /*render_flags*/)
 {
 	if ( !shipp->shader_effect_timestamp.isValid() || Rendering_to_shadow_map ) {
 		return;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8081,7 +8081,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 			gr_zbuffer_clear(true);
 	}
 
-	uint render_flags = MR_NORMAL;
+	uint64_t render_flags = MR_NORMAL;
 	render_flags |= MR_NO_FOGGING;
 
 	if (shipp->flags[Ship::Ship_Flags::Glowmaps_disabled]) {
@@ -20629,7 +20629,7 @@ void ship_render_batch_thrusters(object *obj)
 	}
 }
 
-void ship_render_weapon_models(model_render_params *ship_render_info, model_draw_list *scene, object *obj, int render_flags)
+void ship_render_weapon_models(model_render_params *ship_render_info, model_draw_list *scene, object *obj, uint64_t render_flags)
 {
 	int num = obj->instance;
 	ship *shipp = &Ships[num];
@@ -20907,7 +20907,7 @@ void ship_render(object* obj, model_draw_list* scene)
 		}
 	}
 
-	uint render_flags = MR_NORMAL;
+	uint64_t render_flags = MR_NORMAL;
 
 	if ( shipp->large_ship_blowup_index >= 0 )	{
 		shipfx_large_blowup_queue_render(scene, shipp);

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -141,6 +141,7 @@ namespace Ship {
 		Maneuver_despite_engines,	// Goober5000 - ship can move even when engines are disabled or disrupted
 		Force_primary_unlinking,	// plieblang - turned on when the ship is under good-primary-time
 		No_scanned_cargo,                 //MjnMixael -- The cargo will never be revealed, instead always returning "Scanned" or "Not Scanned"
+		No_insignias,				// Cyborg do not render insignias, even when one is defined for them.
 
 		NUM_VALUES
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1622,7 +1622,7 @@ void shipfx_queue_render_ship_halves_and_debris(model_draw_list *scene, clip_shi
 	vm_vec_add2(&debris_clip_plane_pt, &half_ship->local_pivot);
 
 	// set up render flags
-	uint render_flags = MR_NORMAL;
+	uint64_t render_flags = MR_NORMAL;
 
 	if ( Rendering_to_shadow_map ) {
 		render_flags |= MR_NO_TEXTURING | MR_NO_LIGHTING;

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -153,7 +153,7 @@ int Stars_background_inited = 0;			// if we're inited
 int Nmodel_num = -1;							// model num
 int Nmodel_instance_num = -1;					// model instance num
 matrix Nmodel_orient = IDENTITY_MATRIX;			// model orientation
-int Nmodel_flags = DEFAULT_NMODEL_FLAGS;		// model flags
+uint64_t Nmodel_flags = DEFAULT_NMODEL_FLAGS;		// model flags
 int Nmodel_bitmap = -1;						// model texture
 float Nmodel_alpha = 1.0f;					// model transparency
 
@@ -1676,7 +1676,7 @@ void subspace_render()
 
 	gr_zbuffer_set(GR_ZBUFF_NONE);
 
-	int render_flags = MR_NO_LIGHTING | MR_ALL_XPARENT;
+	uint64_t render_flags = MR_NO_LIGHTING | MR_ALL_XPARENT;
 
 	Interp_subspace = 1;
 	Interp_subspace_offset_u = 1.0f - subspace_offset_u;

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2317,7 +2317,7 @@ void stars_draw_background()
 	model_render_immediate(&render_info, Nmodel_num, Nmodel_instance_num, &Nmodel_orient, &Eye_position, MODEL_RENDER_ALL, false);
 }
 
-void stars_set_background_model(int new_model, int new_bitmap, int flags, float alpha)
+void stars_set_background_model(int new_model, int new_bitmap, uint64_t flags, float alpha)
 {
 	if (gr_screen.mode == GR_STUB) {
 		return;
@@ -2362,7 +2362,7 @@ void stars_set_background_model(int new_model, int new_bitmap, int flags, float 
 }
 
 // call this to set a specific model as the background model
-void stars_set_background_model(const char* model_name, const char* texture_name, int flags, float alpha)
+void stars_set_background_model(const char* model_name, const char* texture_name, uint64_t flags, float alpha)
 {
 	int new_model = -1;
 	int new_bitmap = -1;

--- a/code/starfield/starfield.h
+++ b/code/starfield/starfield.h
@@ -57,7 +57,7 @@ extern SCP_vector<background_t> Backgrounds;
 extern int Nmodel_num;
 extern int Nmodel_instance_num;
 extern matrix Nmodel_orient;
-extern int Nmodel_flags;
+extern uint64_t Nmodel_flags;
 extern int Nmodel_bitmap;
 extern float Nmodel_alpha;
 

--- a/code/starfield/starfield.h
+++ b/code/starfield/starfield.h
@@ -151,8 +151,8 @@ void stars_draw_sun_glow(int sun_n);
 void stars_camera_cut();
 
 // call this to set a specific model as the background model
-void stars_set_background_model(int new_model, int new_bitmap = -1, int flags = DEFAULT_NMODEL_FLAGS, float alpha = 1.0f);
-void stars_set_background_model(const char *model_name, const char *texture_name, int flags = DEFAULT_NMODEL_FLAGS, float alpha = 1.0f);
+void stars_set_background_model(int new_model, int new_bitmap = -1, uint64_t flags = DEFAULT_NMODEL_FLAGS, float alpha = 1.0f);
+void stars_set_background_model(const char *model_name, const char *texture_name, uint64_t flags = DEFAULT_NMODEL_FLAGS, float alpha = 1.0f);
 void stars_set_background_orientation(const matrix *orient = nullptr);
 void stars_set_background_alpha(float alpha = 1.0f);
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -9082,7 +9082,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 		{
 			model_render_params render_info;
 
-			uint render_flags = MR_NORMAL|MR_IS_MISSILE|MR_NO_BATCH;
+			uint64_t render_flags = MR_NORMAL|MR_IS_MISSILE|MR_NO_BATCH;
 
 			if (wip->wi_flags[Weapon::Info_Flags::Mr_no_lighting])
 				render_flags |= MR_NO_LIGHTING;

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -1797,7 +1797,7 @@ void render_one_model_briefing_screen(object *objp) {
 }
 
 void render_one_model_htl(object *objp) {
-	int j, z;
+	int z;
 	uint debug_flags = 0;
 	object *o2;
 
@@ -1851,7 +1851,7 @@ void render_one_model_htl(object *objp) {
 	if ((Show_ship_models || Show_outlines) && ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START))) {
 		g3_start_instance_matrix(&Eye_position, &Eye_matrix, 0);
 
-		j = MR_NORMAL;
+		uint64_t flags = MR_NORMAL;
 
 		if (Show_dock_points) {
 			debug_flags |= MR_DEBUG_BAY_PATHS;
@@ -1866,11 +1866,11 @@ void render_one_model_htl(object *objp) {
 		model_clear_instance(Ship_info[Ships[z].ship_info_index].model_num);
 
 		if (!Lighting_on) {
-			j |= MR_NO_LIGHTING;
+			flags |= MR_NO_LIGHTING;
 		}
 
 		if (FullDetail) {
-			j |= MR_FULL_DETAIL;
+			flags |= MR_FULL_DETAIL;
 		}
 
 		model_render_params render_info;
@@ -1880,7 +1880,7 @@ void render_one_model_htl(object *objp) {
 
 		if (Fred_outline) {
 			render_info.set_color(Fred_outline >> 16, (Fred_outline >> 8) & 0xff, Fred_outline & 0xff);
-			render_info.set_flags(j | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
+			render_info.set_flags(flags | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
 			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 		}
 
@@ -1898,7 +1898,7 @@ void render_one_model_htl(object *objp) {
 				vm_vec_scale_add(&warpin_pos, &objp->pos, &objp->orient.vec.fvec, warpin_dist);
 
 				render_info.set_color(65, 65, 65);	// grey; see rgba_defaults
-				render_info.set_flags(j | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
+				render_info.set_flags(flags | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
 				model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &warpin_pos);
 			}
 		}
@@ -1906,7 +1906,7 @@ void render_one_model_htl(object *objp) {
 		g3_done_instance(0);
 
 		if (Show_ship_models) {
-			render_info.set_flags(j);
+			render_info.set_flags(flags);
 			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 		}
 	} else {
@@ -1955,7 +1955,7 @@ void render_one_model_htl(object *objp) {
 	}
 
 	if (objp->type == OBJ_WAYPOINT) {
-		for (j = 0; j < render_count; j++) {
+		for (int j = 0; j < render_count; j++) {
 			o2 = &Objects[rendering_order[j]];
 			if (o2->type == OBJ_WAYPOINT) {
 				if ((o2->instance == objp->instance - 1) || (o2->instance == objp->instance + 1)) {

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -788,7 +788,7 @@ void FredRenderer::render_model_x_htl(vec3d* pos, grid* gridp, int  /*col_scheme
 void FredRenderer::render_one_model_htl(object* objp,
 										int cur_object_index,
 										bool Bg_bitmap_dialog) {
-	int j, z;
+	int z;
 	object* o2;
 
 	Assert(objp->type != OBJ_NONE);
@@ -839,11 +839,13 @@ void FredRenderer::render_one_model_htl(object* objp,
 
 	// build flags
 	if ((view().Show_ship_models || view().Show_outlines) && ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START))) {
+		uint64_t flags = 0;
+
 		g3_start_instance_matrix(&Eye_position, &Eye_matrix, 0);
 		if (view().Show_ship_models) {
-			j = MR_NORMAL;
+			flags = MR_NORMAL;
 		} else {
-			j = MR_NO_POLYS;
+			flags = MR_NO_POLYS;
 		}
 
 		uint debug_flags = 0;
@@ -860,22 +862,22 @@ void FredRenderer::render_one_model_htl(object* objp,
 		model_clear_instance(Ship_info[Ships[z].ship_info_index].model_num);
 
 		if (!view().Lighting_on) {
-			j |= MR_NO_LIGHTING;
+			flags |= MR_NO_LIGHTING;
 		}
 
 		if (view().FullDetail) {
-			j |= MR_FULL_DETAIL;
+			flags |= MR_FULL_DETAIL;
 		}
 
 		if (Fred_outline) {
-			j |= MR_SHOW_OUTLINE_HTL;
+			flags |= MR_SHOW_OUTLINE_HTL;
 		}
 
 		model_render_params render_info;
 		render_info.set_debug_flags(debug_flags);
 		render_info.set_color(Fred_outline >> 16, (Fred_outline >> 8) & 0xff, Fred_outline & 0xff);
 		render_info.set_replacement_textures(model_get_instance(Ships[z].model_instance_num)->texture_replace);
-		render_info.set_flags(j);
+		render_info.set_flags(flags);
 
 		g3_done_instance(0);
 
@@ -895,7 +897,7 @@ void FredRenderer::render_one_model_htl(object* objp,
 				vm_vec_scale_add(&warpin_pos, &objp->pos, &objp->orient.vec.fvec, warpin_dist);
 
 				render_info.set_color(65, 65, 65);	// grey; see rgba_defaults
-				render_info.set_flags(j | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
+				render_info.set_flags(flags | MR_SHOW_OUTLINE_HTL | MR_NO_LIGHTING | MR_NO_POLYS | MR_NO_TEXTURING);
 				model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &warpin_pos);
 			}
 		}


### PR DESCRIPTION
Add a ship flag and an MR flag to turn rendering on and off.  Also standardize the type for MR flags to be uint64_t so that the new flag will fit.

Fixes #6062 

Note: (1<<32) and above causes UB, so I just put the value and put the bitshift in the comments.