### PR TITLE
Allow accepting a pilot without changing gamestate

### DIFF
--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -694,7 +694,7 @@ int barracks_pilot_accepted()
 	return 0;
 }
 
-void barracks_accept_pilot(player* plr) {
+void barracks_accept_pilot(player* plr, bool changeState) {
 	// set pilot image
 	if (Game_mode & GM_MULTIPLAYER) {
 		player_set_squad_bitmap(plr, plr->m_squad_filename, true);
@@ -712,7 +712,10 @@ void barracks_accept_pilot(player* plr) {
 	multi_options_init_globals();
 
 	os_config_write_string(nullptr, "LastPlayer", plr->callsign);
-	gameseq_post_event(GS_EVENT_MAIN_MENU);
+
+	if (changeState) {
+		gameseq_post_event(GS_EVENT_MAIN_MENU);
+	}
 }
 
 // scroll up barracks pilot list one line

--- a/code/menuui/barracks.h
+++ b/code/menuui/barracks.h
@@ -25,6 +25,6 @@ void barracks_do_frame(float frametime);
 // close the barracks
 void barracks_close();
 
-void barracks_accept_pilot(player* plr);
+void barracks_accept_pilot(player* plr, bool changeState);
 
 #endif // _BARRACKS_H

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -520,15 +520,16 @@ ADE_FUNC(listSquadImages, l_UserInterface_Barracks, nullptr, "Lists the names of
 	return ade_set_args(L, "t", &out);
 }
 
-ADE_FUNC(acceptPilot, l_UserInterface_Barracks, "player selection", "Accept the given player as the current player",
+ADE_FUNC(acceptPilot, l_UserInterface_Barracks, "player selection, boolean changeState", "Accept the given player as the current player. Set second argument to false to prevent returning to the mainhall",
          "boolean", "true on success, false otherwise")
 {
 	player_h* plh;
-	if (!ade_get_args(L, "o", l_Player.GetPtr(&plh))) {
+	bool changeState = true;
+	if (!ade_get_args(L, "o|b", l_Player.GetPtr(&plh), &changeState)) {
 		return ADE_RETURN_FALSE;
 	}
 
-	barracks_accept_pilot(plh->get());
+	barracks_accept_pilot(plh->get(), changeState);
 	return ADE_RETURN_TRUE;
 }
 


### PR DESCRIPTION
There are some actions in SCPUI barracks menu that can cause Player to get set to nullptr and there's currently no way to accept a player without also returning to the mainhall. This should never have been a combined action but m!m didn't have that kind of foresight in 2018.. so here we are.

An optional parameter that allows skipping returning to the mainhall as part of this function which is only used by the API. This will allow me to fix a bug in SCPUI where Player gets left as nullptr.

I should clarify that the only code that runs `barracks_accept_pilot` is the Lua API. The retail UI runs `barracks_pilot_accepted` instead.