### PR TITLE
Fix clang tidy again

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,20 +4,26 @@ modernize-*,\
 -modernize-avoid-c-arrays,\
 -modernize-make-unique,\
 -modernize-raw-string-literal,\
+-modernize-use-default-member-init,\
 -modernize-use-trailing-return-type,\
 -modernize-use-using,\
 performance-*,\
+-performance-no-int-to-ptr,\
 -performance-type-promotion-in-math-fn,\
 misc-*,\
+-misc-include-cleaner,\
 -misc-macro-parentheses,\
 -misc-misplaced-widening-cast,\
 -misc-non-private-member-variables-in-classes,\
 -misc-static-assert,\
 -misc-unused-parameters,\
+-misc-use-anonymous-namespace,\
 readability-*,\
 -readability-avoid-const-params-in-decls,\
 -readability-else-after-return,\
+-readability-function-cognitive-complexity,\
 -readability-function-size,\
+-readability-identifier-length,\
 -readability-identifier-naming,\
 -readability-implicit-bool-conversion,\
 -readability-inconsistent-declaration-parameter-name,\
@@ -29,7 +35,6 @@ readability-*,\
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: 'code/.*$|freespace2/.*$|qtfred/.*$|test/src/.*$|build/.*$'
-AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:          'misc-assert-side-effect.AssertMacros'
     value:        'assert,Assert,Assertion'

--- a/ci/linux/clang_tidy.sh
+++ b/ci/linux/clang_tidy.sh
@@ -22,4 +22,4 @@ echo "Running clang-tidy on changed files"
 git diff -U0 --no-color "$BASE_COMMIT..$2" | \
     $HERE/clang-tidy-diff.py -path "$(pwd)/build" -p1 \
     -regex '(code(?!((\/graphics\/shaders\/compiled)|(\/globalincs\/windebug)))|freespace2|qtfred|test|build|tools)\/.*\.(cpp|h)' \
-    -clang-tidy-binary /usr/bin/clang-tidy-9 -j$(nproc) -export-fixes "$(pwd)/clang-fixes.yaml"
+    -clang-tidy-binary /usr/bin/clang-tidy-16 -j$(nproc) -export-fixes "$(pwd)/clang-fixes.yaml"


### PR DESCRIPTION
We also need to update the actual version we're calling.
In accordance to this, this PR also disables a few warnings that were added since clang-tidy 9 that are potentially problematic / annoying for the SCP without large-scale refactoring of how we do things.
Also removes deprecated AnalyzeTemporaryDtors key.