### PR TITLE
use proper stats block for display in barracks

### DIFF
--- a/code/menuui/barracks.cpp
+++ b/code/menuui/barracks.cpp
@@ -568,14 +568,12 @@ int barracks_new_pilot_selected()
 		return -1;
 	}
 
-	if (!Pilot.load_savefile(Cur_pilot, Cur_pilot->current_campaign)) {
-		// set single player squad image to multi if campaign can't be loaded
-		strcpy_s(Cur_pilot->s_squad_filename, Cur_pilot->m_squad_filename);
-	}
-
 	// init stuff to reflect new pilot
 	int i;
-	barracks_init_stats(&Cur_pilot->stats);
+	scoring_struct pstats;
+
+	Pilot.export_stats(&pstats);
+	barracks_init_stats(&pstats);
 	strcpy_s(stripped, Cur_pilot->image_filename);
 	barracks_strip_pcx(stripped);
 	for (i=0; i<Num_pilot_images; i++) {

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -455,7 +455,7 @@ bool pilotfile::export_stats(scoring_struct *stats)
 
 	// same for medals
 	for (auto &item : p_stats->medals_earned) {
-		if ( (item.index >= 0) && (item.index < stats->medal_counts.size()) ) {
+		if ( (item.index >= 0) && (item.index < static_cast<int>(stats->medal_counts.size())) ) {
 			stats->medal_counts[item.index] = item.val;
 		}
 	}

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -412,7 +412,7 @@ void pilotfile::reset_stats()
  */
 bool pilotfile::export_stats(scoring_struct *stats)
 {
-	scoring_special_t *p_stats = NULL;
+	scoring_special_t *p_stats = nullptr;
 
 	if ( !stats ) {
 		return false;

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -402,3 +402,63 @@ void pilotfile::reset_stats()
 		ss_stats[i]->medals_earned.clear();
 	}
 }
+
+/**
+ * @brief Export stats to given scoring struct, sanitized for current mod data
+ * 
+ * @param[out] stats Scoring struct for exported data
+ * 
+ * @returns true if stats were exported successfully
+ */
+bool pilotfile::export_stats(scoring_struct *stats)
+{
+	scoring_special_t *p_stats = NULL;
+
+	if ( !stats ) {
+		return false;
+	}
+
+	stats->init();
+
+	if (Game_mode & GM_MULTIPLAYER) {
+		p_stats = &multi_stats;
+	} else {
+		p_stats = &all_time_stats;
+	}
+
+	stats->score = p_stats->score;
+	stats->rank = p_stats->rank;
+	stats->assists = p_stats->assists;
+	stats->kill_count = p_stats->kill_count;
+	stats->kill_count_ok = p_stats->kill_count_ok;
+	stats->bonehead_kills = p_stats->bonehead_kills;
+
+	stats->p_shots_fired = p_stats->p_shots_fired;
+	stats->p_shots_hit = p_stats->p_shots_hit;
+	stats->p_bonehead_hits = p_stats->p_bonehead_hits;
+
+	stats->s_shots_fired = p_stats->s_shots_fired;
+	stats->s_shots_hit = p_stats->s_shots_hit;
+	stats->s_bonehead_hits = p_stats->s_bonehead_hits;
+
+	stats->flight_time = p_stats->flight_time;
+	stats->missions_flown = p_stats->missions_flown;
+	stats->last_flown = p_stats->last_flown;
+	stats->last_backup = p_stats->last_backup;
+
+	// only export ships that this mod knows about (should already be index)
+	for (auto &item : p_stats->ship_kills) {
+		if ( (item.index >= 0) && (item.index < MAX_SHIP_CLASSES) ) {
+			stats->kills[item.index] = item.val;
+		}
+	}
+
+	// same for medals
+	for (auto &item : p_stats->medals_earned) {
+		if ( (item.index >= 0) && (item.index < stats->medal_counts.size()) ) {
+			stats->medal_counts[item.index] = item.val;
+		}
+	}
+
+	return true;
+}

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -100,6 +100,15 @@ class pilotfile {
 		void reset_stats();
 
 		/**
+		 * @brief Export stats to given scoring struct, sanitized for current mod data
+		 * 
+		 * @param[out] stats Scoring struct for exported data
+		 * 
+		 * @returns true if stats were exported successfully
+		 */
+		bool export_stats(scoring_struct *stats);
+
+		/**
 		 * Verifies a pilot file with the given filename
 		 * 
 		 * @param[in]  filename     The filename of the pilot file to test. Must have the .JSON extension.


### PR DESCRIPTION
There are 3 different stats blocks: two in the pilot file for single and multi, and one in the campaign savefile. The stats block in the savefile has historically been used in the barracks if possible since it's sanitized for the current mod data. Unfortunately this means that the stats will change if the campaign changes or is restarted.

However it is possible to easily produce a sanitized scoring struct based on the stats blocks from the pilot file. This allows us to use true all-time stats for display in the barracks while still accounting for mod differences.