### PR TITLE
optimize collision code a bit

### DIFF
--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -65,6 +65,7 @@ static void update_danger_weapon(object *pship_obj, object *weapon_obj)
 /** 
  * Deal with weapon-ship hit stuff.  
  * Separated from check_collision routine below because of multiplayer reasons.
+ * When hit_dir was added in commit a3422b4, it was passed by value.  Since it is no longer modified locally in the function, it can be passed by pointer.
  */
 static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, vec3d *world_hitpos, vec3d *hitpos, int quadrant_num, int submodel_num, const vec3d *hit_dir)
 {


### PR DESCRIPTION
This was motivated by the recent Coverity report.  Coverity noticed that a few of the copy assignments could be replaced by move assignments, but on further investigation one copy each in `ship_weapon_check_collision()` and `beam_collide_ship()` can be entirely removed, another either/or copy in each can be replaced with an either/or pointer assignment, and a few copies can be done only when needed.  Another vec3d copy can be replaced with a vec3d pointer since there is no longer a need to keep a local copy.