### PR TITLE
Per weapon auto convergence

### DIFF
--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -34,11 +34,12 @@ namespace Object {
 		NUM_VALUES
 	};
 
-	FLAG_LIST(Aiming_Flags){Autoaim = 0, // has autoaim
-		Auto_convergence,                // has automatic convergence
-		Std_convergence,                 // has standard - ie. non-automatic - convergence
-		Autoaim_convergence,             // has autoaim with convergence
-		Convergence_offset,              // marks that convergence has offset value
+	FLAG_LIST(Aiming_Flags){
+		Autoaim = 0,           // has autoaim
+		Auto_convergence,      // has automatic convergence
+		Std_convergence,       // has standard - ie. non-automatic - convergence
+		Autoaim_convergence,   // has autoaim with convergence
+		Convergence_offset,    // marks that convergence has offset valuem, only used for ships not weapons
 
 		NUM_VALUES};
 	}

--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -33,6 +33,14 @@ namespace Object {
 
 		NUM_VALUES
 	};
-}
+
+	FLAG_LIST(Aiming_Flags){Autoaim = 0, // has autoaim
+		Auto_convergence,                // has automatic convergence
+		Std_convergence,                 // has standard - ie. non-automatic - convergence
+		Autoaim_convergence,             // has autoaim with convergence
+		Convergence_offset,              // marks that convergence has offset value
+
+		NUM_VALUES};
+	}
 
 #endif

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12940,9 +12940,6 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 							*/
 							const bool std_convergence_flagged = (sip->aiming_flags[Object::Aiming_Flags::Std_convergence]) || (winfo_p->aiming_flags[Object::Aiming_Flags::Std_convergence]);
 
-							//Must have the auto convergence flag and a valid target
-							const bool do_auto_convergence = (aip->target_objnum != -1) && auto_convergence_flagged;
-
 							if (has_autoaim && in_automatic_aim_fov) {
 								vec3d firing_vec;
 
@@ -12955,13 +12952,13 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								}
 
 								vm_vector_2_matrix(&firing_orient, &firing_vec, NULL, NULL);
-							} else if (std_convergence_flagged || do_auto_convergence) {
+							} else if (std_convergence_flagged || (auto_convergence_flagged && (aip->target_objnum != -1))) {
 								// std & auto convergence
 								vec3d target_vec, firing_vec, convergence_offset;
 								
 								// make sure vector is of the set length
 								vm_vec_copy_normalize(&target_vec, &firing_orient.vec.fvec);
-								if (do_auto_convergence) {
+								if (auto_convergence_flagged && (aip->target_objnum != -1)) {
 									// auto convergence
 									vm_vec_scale(&target_vec, dist_to_aim);
 								} else {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12690,7 +12690,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				dist_to_aim = vm_vec_mag_quick(&plr_to_target_vec);
 
 				// Use the hightest minimum convergence distance
-				float min_convergence_distance = std::max(sip->minimum_convergence_distance, winfo_p->minimum_convergence_distance);
+				const float min_convergence_distance = std::max(sip->minimum_convergence_distance, winfo_p->minimum_convergence_distance);
 
 				// minimum convergence distance
 				if (min_convergence_distance > dist_to_aim) {
@@ -12925,10 +12925,10 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								V SIF convergence
 								no convergence or autoaim
 							*/
-							bool do_convergence = (sip->aiming_flags[Object::Aiming_Flags::Std_convergence]) || (winfo_p->aiming_flags[Object::Aiming_Flags::Std_convergence]);
+							const bool do_convergence = (sip->aiming_flags[Object::Aiming_Flags::Std_convergence]) || (winfo_p->aiming_flags[Object::Aiming_Flags::Std_convergence]);
 
 							//Must have the auto convergence flag and a valid target
-							bool do_auto_convergence = (aip->target_objnum != -1) && 
+							const bool do_auto_convergence = (aip->target_objnum != -1) && 
 								((sip->aiming_flags[Object::Aiming_Flags::Auto_convergence]) || (winfo_p->aiming_flags[Object::Aiming_Flags::Auto_convergence]));
 
 							if (has_autoaim && in_automatic_aim_fov) {
@@ -12955,7 +12955,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								} else {
 									// std convergence
 									// Use the largest convergence distance because default distance is 0.0f and we don't want that!
-									float convergence_distance = std::max(sip->convergence_distance, winfo_p->convergence_distance);
+									const float convergence_distance = std::max(sip->convergence_distance, winfo_p->convergence_distance);
 									vm_vec_scale(&target_vec, convergence_distance);
 								}
 								

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -3577,11 +3577,11 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		if (fov_temp > 180.0f)
 			fov_temp = 180.0f;
 
-		sip->aiming_flags.set(Ship::Aiming_Flags::Autoaim); 
+		sip->aiming_flags.set(Object::Aiming_Flags::Autoaim); 
 		sip->autoaim_fov = fov_temp * PI / 180.0f;
 
 		if(optional_string("+Converging Autoaim"))
-			sip->aiming_flags.set(Ship::Aiming_Flags::Autoaim_convergence);
+			sip->aiming_flags.set(Object::Aiming_Flags::Autoaim_convergence);
 
 		if(optional_string("+Minimum Distance:"))
 			stuff_float(&sip->minimum_convergence_distance);
@@ -3615,20 +3615,20 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 	{
 		if(optional_string("+Automatic"))
 		{
-			sip->aiming_flags.set(Ship::Aiming_Flags::Auto_convergence);
+			sip->aiming_flags.set(Object::Aiming_Flags::Auto_convergence);
 			if(optional_string("+Minimum Distance:"))
 				stuff_float(&sip->minimum_convergence_distance);
 		}
 		if(optional_string("+Standard"))
 		{
-            sip->aiming_flags.set(Ship::Aiming_Flags::Std_convergence);
+			sip->aiming_flags.set(Object::Aiming_Flags::Std_convergence);
 			if(required_string("+Distance:"))
 				stuff_float(&sip->convergence_distance);
 		}
 		if(optional_string("+Offset:")) {
 			stuff_vec3d(&sip->convergence_offset);
 
-            sip->aiming_flags.set(Ship::Aiming_Flags::Convergence_offset, !IS_VEC_NULL(&sip->convergence_offset));				
+            sip->aiming_flags.set(Object::Aiming_Flags::Convergence_offset, !IS_VEC_NULL(&sip->convergence_offset));				
 		}
 	}
 
@@ -12301,8 +12301,8 @@ bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj)
 	int weapon_idx = swp->primary_bank_weapons[bank_to_fire];
 	weapon_info* winfo_p = &Weapon_info[weapon_idx];
 
-	has_converging_autoaim = ((sip->aiming_flags[Ship::Aiming_Flags::Autoaim_convergence] || (The_mission.ai_profile->player_autoaim_fov[Game_skill_level] > 0.0f && !( Game_mode & GM_MULTIPLAYER ))) && aip->target_objnum != -1);
-	has_autoaim = ((has_converging_autoaim || (sip->aiming_flags[Ship::Aiming_Flags::Autoaim]) || (winfo_p->autoaim_fov > 0.0f) || (sip->bank_autoaim_fov[bank_to_fire] > 0.0f)) && aip->target_objnum != -1);
+	has_converging_autoaim = ((sip->aiming_flags[Object::Aiming_Flags::Autoaim_convergence] || winfo_p->aiming_flags[Object::Aiming_Flags::Autoaim_convergence] || (The_mission.ai_profile->player_autoaim_fov[Game_skill_level] > 0.0f && !( Game_mode & GM_MULTIPLAYER ))) && aip->target_objnum != -1);
+		has_autoaim = ((has_converging_autoaim || (sip->aiming_flags[Object::Aiming_Flags::Autoaim]) || winfo_p->aiming_flags[Object::Aiming_Flags::Autoaim] || (sip->bank_autoaim_fov[bank_to_fire] > 0.0f)) && aip->target_objnum != -1);
 
 	if (!has_autoaim) {
 		return false;
@@ -12458,9 +12458,9 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 		// lets start gun convergence / autoaim code from here - Wanderer
 		// in order to do this per weapon, this needs to be moved here from above -Mjn
-		has_converging_autoaim = ((sip->aiming_flags[Ship::Aiming_Flags::Autoaim_convergence] || (The_mission.ai_profile->player_autoaim_fov[Game_skill_level] > 0.0f && !( Game_mode & GM_MULTIPLAYER ))) && aip->target_objnum != -1);
-		has_autoaim = ((has_converging_autoaim || (sip->aiming_flags[Ship::Aiming_Flags::Autoaim]) || (winfo_p->autoaim_fov > 0.0f) || (sip->bank_autoaim_fov[bank_to_fire] > 0.0f)) && aip->target_objnum != -1);
-		needs_target_pos = ((has_autoaim || (sip->aiming_flags[Ship::Aiming_Flags::Auto_convergence])) && aip->target_objnum != -1);
+		has_converging_autoaim = ((sip->aiming_flags[Object::Aiming_Flags::Autoaim_convergence] || winfo_p->aiming_flags[Object::Aiming_Flags::Autoaim_convergence] || (The_mission.ai_profile->player_autoaim_fov[Game_skill_level] > 0.0f && !( Game_mode & GM_MULTIPLAYER ))) && aip->target_objnum != -1);
+		has_autoaim = ((has_converging_autoaim || (sip->aiming_flags[Object::Aiming_Flags::Autoaim]) || winfo_p->aiming_flags[Object::Aiming_Flags::Autoaim] || (sip->bank_autoaim_fov[bank_to_fire] > 0.0f)) && aip->target_objnum != -1);
+		needs_target_pos = ((has_autoaim || has_converging_autoaim) && aip->target_objnum != -1); // This change needs some scrutiny but it seems right?
 
 		if (needs_target_pos) {
 			if (has_autoaim) {
@@ -12689,12 +12689,15 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 				dist_to_aim = vm_vec_mag_quick(&plr_to_target_vec);
 
+				// Use the hightest minimum convergence distance
+				float min_convergence_distance = std::max(sip->minimum_convergence_distance, winfo_p->minimum_convergence_distance);
+
 				// minimum convergence distance
-				if (sip->minimum_convergence_distance > dist_to_aim) {
+				if (min_convergence_distance > dist_to_aim) {
 					float dist_mult;
-					dist_mult = sip->minimum_convergence_distance / dist_to_aim;
+					dist_mult = min_convergence_distance / dist_to_aim;
 					vm_vec_scale_add(&predicted_target_pos, &obj->pos, &plr_to_target_vec, dist_mult);
-					dist_to_aim = sip->minimum_convergence_distance;
+					dist_to_aim = min_convergence_distance;
 				}
 			}
 			
@@ -12922,6 +12925,12 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								V SIF convergence
 								no convergence or autoaim
 							*/
+							bool do_convergence = (sip->aiming_flags[Object::Aiming_Flags::Std_convergence]) || (winfo_p->aiming_flags[Object::Aiming_Flags::Std_convergence]);
+
+							//Must have the auto convergence flag and a valid target
+							bool do_auto_convergence = (aip->target_objnum != -1) && 
+								((sip->aiming_flags[Object::Aiming_Flags::Auto_convergence]) || (winfo_p->aiming_flags[Object::Aiming_Flags::Auto_convergence]));
+
 							if (has_autoaim && in_automatic_aim_fov) {
 								vec3d firing_vec;
 
@@ -12934,22 +12943,24 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								}
 
 								vm_vector_2_matrix(&firing_orient, &firing_vec, NULL, NULL);
-							} else if ((sip->aiming_flags[Ship::Aiming_Flags::Std_convergence]) || ((sip->aiming_flags[Ship::Aiming_Flags::Auto_convergence]) && (aip->target_objnum != -1))) {
+							} else if (do_convergence || do_auto_convergence) {
 								// std & auto convergence
 								vec3d target_vec, firing_vec, convergence_offset;
 								
 								// make sure vector is of the set length
 								vm_vec_copy_normalize(&target_vec, &firing_orient.vec.fvec);
-								if ((sip->aiming_flags[Ship::Aiming_Flags::Auto_convergence]) && (aip->target_objnum != -1)) {
+								if (do_auto_convergence) {
 									// auto convergence
 									vm_vec_scale(&target_vec, dist_to_aim);
 								} else {
 									// std convergence
-									vm_vec_scale(&target_vec, sip->convergence_distance);
+									// Use the largest convergence distance because default distance is 0.0f and we don't want that!
+									float convergence_distance = std::max(sip->convergence_distance, winfo_p->convergence_distance);
+									vm_vec_scale(&target_vec, convergence_distance);
 								}
 								
 								// if there is convergence offset then make use of it)
-								if (sip->aiming_flags[Ship::Aiming_Flags::Convergence_offset]) {
+								if (sip->aiming_flags[Object::Aiming_Flags::Convergence_offset]) {
 									vm_vec_unrotate(&convergence_offset, &sip->convergence_offset, &obj->orient);
 									vm_vec_add2(&target_vec, &convergence_offset);
 								}

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1471,7 +1471,7 @@ public:
 
 	SCP_map<std::pair<int, int>, int> ship_iff_info;
 
-	flagset<Ship::Aiming_Flags> aiming_flags;
+	flagset<Object::Aiming_Flags> aiming_flags;
 	float minimum_convergence_distance;
 	float convergence_distance;
 	vec3d convergence_offset;

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -221,16 +221,6 @@ namespace Ship {
 		NUM_VALUES
 	};
 
-	FLAG_LIST(Aiming_Flags) {
-		Autoaim = 0,			// has autoaim
-		Auto_convergence,		// has automatic convergence
-		Std_convergence,		// has standard - ie. non-automatic - convergence
-		Autoaim_convergence,	// has autoaim with convergence
-		Convergence_offset,		// marks that convergence has offset value
-
-		NUM_VALUES
-	};
-
     FLAG_LIST(Type_Info_Flags) {
         Counts_for_alone,
         Praise_destruction,

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -419,6 +419,10 @@ struct weapon_info
 	float	optimum_range;						// causes ai fighters to prefer this distance when attacking with the weapon
 	float weapon_min_range;           // *Minimum weapon range, default is 0 -Et1
 
+	flagset<Object::Aiming_Flags> aiming_flags;
+	float minimum_convergence_distance;
+	float convergence_distance;
+
 	bool pierce_objects;
 	bool spawn_children_on_pierce;
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1493,7 +1493,30 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			error_display(0, "Weapon %s autoaim fov was greater than 180, setting to %f\n", wip->name, fovt);
 		}
 
+		wip->aiming_flags.set(Object::Aiming_Flags::Autoaim); 
 		wip->autoaim_fov = fovt * PI / 180.0f;
+
+		if (optional_string("+Converging Autoaim"))
+			wip->aiming_flags.set(Object::Aiming_Flags::Autoaim_convergence);
+
+		if (optional_string("+Minimum Distance:"))
+			stuff_float(&wip->minimum_convergence_distance);
+	}
+
+	if (optional_string("$Convergence:")) {
+		if (optional_string("+Automatic")) {
+			wip->aiming_flags.set(Object::Aiming_Flags::Auto_convergence);
+			if (optional_string("+Minimum Distance:"))
+				stuff_float(&wip->minimum_convergence_distance);
+		}
+		if (optional_string("+Standard")) {
+			wip->aiming_flags.set(Object::Aiming_Flags::Std_convergence);
+			if (required_string("+Distance:"))
+				stuff_float(&wip->convergence_distance);
+		}
+
+		//Purposefully left off +Offset here because I don't think it makes much sense per weapon as it has more to do with ship bank positioning.
+		//Would be trivial to add if someone wanted but we'd have to decide which takes precedent.. ship or weapon?
 	}
 
 	bool temp_is_homing = false;	// this variable should ONLY be used to store the parse value.  All checks aside from the block five lines later should exclusively use wip->is_homing()
@@ -9339,6 +9362,10 @@ void weapon_info::reset()
 	// *Minimum weapon range, default is 0 -Et1
 	this->weapon_min_range = 0.0f;
 	this->optimum_range = 0.0f;
+
+	this->aiming_flags.reset();
+	this->minimum_convergence_distance = 0.0f;
+	this->convergence_distance = 100.0f;
 
 	this->pierce_objects = false;
 	this->spawn_children_on_pierce = false;


### PR DESCRIPTION
This adds per-weapon convergence features, notably allowing per-weapon autoaim + convergence. I moved the autoaim flags to Object:: from Ship:: so they could be reused. Seemed the most sensible place.. but could go elsewhere if there's a better spot.

While technically a new feature, this allows BtA to fix an issue with one of our weapons.. so really hoping to get this in for 24.2.

Fixes #4947