### PR TITLE
Bug fix for aspect invulnerability timing... again

### DIFF
--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -64,12 +64,17 @@ int collide_weapon_weapon( obj_pair * pair )
 		if (!(wipA->wi_flags[Weapon::Info_Flags::No_radius_doubling])) {
 			A_radius *= 2;		// Makes bombs easier to hit
 		}
+
+		// the erroneous extra time a bomb stays invulnerable without the fix
+		float extra_buggy_time = 0.0f;
+		if (wipA->is_locked_homing())
+			extra_buggy_time = (wipA->lifetime * LOCKED_HOMING_EXTENDED_LIFE_FACTOR) - wipA->lifetime;
 		
 		if ((The_mission.ai_profile->flags[AI::Profile_Flags::Aspect_invulnerability_fix]) && (wipA->is_locked_homing()) && (wpA->homing_object != &obj_used_list)) {
 			if (A_time_alive < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
 				return 0;
 		}
-		else if (A_time_alive < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
+		else if (A_time_alive - extra_buggy_time < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
 			return 0;
 	}
 
@@ -78,11 +83,16 @@ int collide_weapon_weapon( obj_pair * pair )
 			B_radius *= 2;		// Makes bombs easier to hit
 		}
 
+		// the erroneous extra time a bomb stays invulnerable without the fix
+		float extra_buggy_time = 0.0f;
+		if (wipB->is_locked_homing())
+			extra_buggy_time = (wipB->lifetime * LOCKED_HOMING_EXTENDED_LIFE_FACTOR) - wipB->lifetime;
+
 		if ((The_mission.ai_profile->flags[AI::Profile_Flags::Aspect_invulnerability_fix]) && (wipB->is_locked_homing()) && (wpB->homing_object != &obj_used_list)) {
 			if (B_time_alive < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
 				return 0;
 		}
-		else if (B_time_alive < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
+		else if (B_time_alive - extra_buggy_time < The_mission.ai_profile->delay_bomb_arm_timer[Game_skill_level] )
 			return 0;
 	}
 

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -82,6 +82,10 @@ constexpr int BANK_SWITCH_DELAY = 250;	// after switching banks, 1/4 second dela
 
 #define MAX_SPAWN_TYPES_PER_WEAPON 5
 
+// homing missiles have an extended lifetime so they don't appear to run out of gas before they can hit a moving target at extreme
+// range. Check the comment in weapon_set_tracking_info() for more details
+#define LOCKED_HOMING_EXTENDED_LIFE_FACTOR			1.2f
+
 typedef struct weapon {
 	int		weapon_info_index;			// index into weapon_info array
 	int		objnum;							// object number for this weapon

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -296,10 +296,6 @@ const float HOMING_DEFAULT_FREE_FLIGHT_FACTOR = 0.25f;
 // time delay between each swarm missile that is fired
 #define SWARM_MISSILE_DELAY				150
 
-// homing missiles have an extended lifetime so they don't appear to run out of gas before they can hit a moving target at extreme
-// range. Check the comment in weapon_set_tracking_info() for more details
-#define LOCKED_HOMING_EXTENDED_LIFE_FACTOR			1.2f
-
 // default number of missiles or bullets rearmed per load sound during rearm
 #define REARM_NUM_MISSILES_PER_BATCH 4              
 #define REARM_NUM_BALLISTIC_PRIMARIES_PER_BATCH 100 


### PR DESCRIPTION
Follow-up to #5595. As flagged by coverity, the previous PR took two conditions, one using `max_lifetime - lifeleft` and the other using `lifetime - lifeleft` and merged them into a single case `Missiontime - time_created`, which as mentioned there *is* more robust but in practice mostly matches the behavior of `max_lifetime - lifeleft`. What is the difference between `max_lifetime` and `lifetime`? It was removed in #5753 but it was very simple and not used for much
```
	if (wip->is_locked_homing()) {
		// locked homing missiles have a much longer lifespan than the AI think they do
		wip->max_lifetime = wip->lifetime * LOCKED_HOMING_EXTENDED_LIFE_FACTOR; // this is 1.2f
	}
```

Essentially, original handling was that bomb invulnerability time was extended by 20% of the weapon's lifetime. So in the case the fix flag is not being used, that time should be added back in.