### PR TITLE
Interpolate particle spawning positions for moving spawner objects

### DIFF
--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -18,8 +18,8 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut, float interp) const {
 	vec3d offset;
 	switch (m_originType) {
 		case SourceOriginType::OBJECT: {
-			if (interp != 1.0f) {
-				vm_vec_linear_interpolate(posOut, &m_origin.m_object.objp()->last_pos, &m_origin.m_object.objp()->pos, interp);
+			if (interp != 0.0f) {
+				vm_vec_linear_interpolate(posOut, &m_origin.m_object.objp()->pos, &m_origin.m_object.objp()->last_pos, interp);
 			} else {
 				*posOut = m_origin.m_object.objp()->pos;
 			}
@@ -357,6 +357,7 @@ float SourceTiming::getLifeTimeProgress() const {
 
 	return done / (float) total;
 }
+int SourceTiming::getNextCreationTime() { return m_nextCreation; }
 bool SourceTiming::nextCreationTimeExpired() const { return timestamp_elapsed(m_nextCreation); }
 void SourceTiming::incrementNextCreationTime(int time_diff) { m_nextCreation += time_diff; }
 

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -357,7 +357,7 @@ float SourceTiming::getLifeTimeProgress() const {
 
 	return done / (float) total;
 }
-int SourceTiming::getNextCreationTime() { return m_nextCreation; }
+int SourceTiming::getNextCreationTime() const { return m_nextCreation; }
 bool SourceTiming::nextCreationTimeExpired() const { return timestamp_elapsed(m_nextCreation); }
 void SourceTiming::incrementNextCreationTime(int time_diff) { m_nextCreation += time_diff; }
 

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -269,6 +269,8 @@ class SourceTiming {
 	 */
 	float getLifeTimeProgress() const;
 
+	int getNextCreationTime();
+
 	/**
 	 * @brief Determine if the timestamp for the next particle creation has expired
 	 * @return @c true if the timestamp has expired, false otherwise

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -67,9 +67,14 @@ class SourceOrigin {
 	/**
 	 * @brief Gets the current, global position of the origin
 	 * 
+	 * For object sources, can interpolate between object's current position and its position last frame
+	 * 
 	 * Be aware for beam sources this will give *random* points along its length
 	 * 
 	 * @param posOut The pointer where the location will be stored
+	 * 
+	 * @param interp For objects, the point's position between the current-frame
+	 * and last-frame positions of the object, with 0.0 being current-frame and 1.0 being last-frame
 	 */
 	void getGlobalPosition(vec3d* posOut, float interp = 1.0f) const;
 

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -274,7 +274,7 @@ class SourceTiming {
 	 */
 	float getLifeTimeProgress() const;
 
-	int getNextCreationTime();
+	int getNextCreationTime() const;
 
 	/**
 	 * @brief Determine if the timestamp for the next particle creation has expired

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -71,7 +71,7 @@ class SourceOrigin {
 	 * 
 	 * @param posOut The pointer where the location will be stored
 	 */
-	void getGlobalPosition(vec3d* posOut) const;
+	void getGlobalPosition(vec3d* posOut, float interp = 1.0f) const;
 
 	void getHostOrientation(matrix* matOut) const;
 
@@ -96,7 +96,7 @@ class SourceOrigin {
 	 *
 	 * @param info The particle_info this should be applied to
 	 */
-	void applyToParticleInfo(particle_info& info, bool allowRelative = false) const;
+	void applyToParticleInfo(particle_info& info, bool allowRelative = false, float interp = 1.0f) const;
 
 	/**
 	 * @brief Gets the velocity of the origin host

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -4,7 +4,7 @@
 #include "parse/parselo.h"
 #pragma once
 
-#include "globalincs/pstypes.h"
+#include "freespace.h"
 #include "particle/ParticleEffect.h"
 #include "particle/ParticleManager.h"
 #include "particle/util/ParticleProperties.h"
@@ -99,12 +99,8 @@ class GenericShapeEffect : public ParticleEffect {
 		// This uses the internal features of the timing class for determining if and how many effects should be
 		// triggered this frame
 		util::EffectTiming::TimingState time_state;
-		int num_spawns = 0;
-		while (m_timing.shouldCreateEffect(source, time_state)) {
-			num_spawns++;
-		}
-
-		for (int spawn_i = 1; spawn_i <= num_spawns; spawn_i++) {
+		for (int time_since_creation = m_timing.shouldCreateEffect(source, time_state); time_since_creation >= 0; time_since_creation = m_timing.shouldCreateEffect(source, time_state)) {
+			float interp = static_cast<float>(time_since_creation)/(flFrametime * 1000.0f);
 
 			auto num = m_particleNum.next();
 
@@ -125,8 +121,6 @@ class GenericShapeEffect : public ParticleEffect {
 			vec3d dir = getNewDirection(source);
 			matrix dirMatrix;
 			vm_vector_2_matrix(&dirMatrix, &dir, nullptr, nullptr);
-
-			float interp = spawn_i/num_spawns;
 			
 			for (uint i = 0; i < num; ++i) {
 				if (m_particleChance < 1.0f) {

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -99,7 +99,13 @@ class GenericShapeEffect : public ParticleEffect {
 		// This uses the internal features of the timing class for determining if and how many effects should be
 		// triggered this frame
 		util::EffectTiming::TimingState time_state;
+		int num_spawns = 0;
 		while (m_timing.shouldCreateEffect(source, time_state)) {
+			num_spawns++;
+		}
+
+		for (int spawn_i = 1; spawn_i <= num_spawns; spawn_i++) {
+
 			auto num = m_particleNum.next();
 
 			if (source->getOrigin()->getType() == SourceOriginType::BEAM) {
@@ -119,6 +125,9 @@ class GenericShapeEffect : public ParticleEffect {
 			vec3d dir = getNewDirection(source);
 			matrix dirMatrix;
 			vm_vector_2_matrix(&dirMatrix, &dir, nullptr, nullptr);
+
+			float interp = spawn_i/num_spawns;
+			
 			for (uint i = 0; i < num; ++i) {
 				if (m_particleChance < 1.0f) {
 					auto roll = m_particleRoll.next();
@@ -132,8 +141,7 @@ class GenericShapeEffect : public ParticleEffect {
 				vm_matrix_x_matrix(&rotatedVel, &dirMatrix, &velRotation);
 
 				particle_info info;
-
-				source->getOrigin()->applyToParticleInfo(info);
+				source->getOrigin()->applyToParticleInfo(info, false, interp);
 
 				vec3d velocity = rotatedVel.vec.fvec;
 				if (TShape::scale_velocity_deviation()) {

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -24,10 +24,17 @@ bool SingleParticleEffect::processSource(ParticleSource* source) {
 	// This uses the internal features of the timing class for determining if and how many effects should be triggered
 	// this frame
 	util::EffectTiming::TimingState time_state;
+	int num_spawns = 0;
 	while (m_timing.shouldCreateEffect(source, time_state)) {
+		num_spawns++;
+	}
+
+	for (int spawn_i = 1; spawn_i <= num_spawns; spawn_i++) {
+		float interp = spawn_i/num_spawns;
+		
 		particle_info info;
 
-		source->getOrigin()->applyToParticleInfo(info);
+		source->getOrigin()->applyToParticleInfo(info, false, interp);
 
 		info.vel *= m_vel_inherit.next();
 

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -24,13 +24,8 @@ bool SingleParticleEffect::processSource(ParticleSource* source) {
 	// This uses the internal features of the timing class for determining if and how many effects should be triggered
 	// this frame
 	util::EffectTiming::TimingState time_state;
-	int num_spawns = 0;
-	while (m_timing.shouldCreateEffect(source, time_state)) {
-		num_spawns++;
-	}
-
-	for (int spawn_i = 1; spawn_i <= num_spawns; spawn_i++) {
-		float interp = spawn_i/num_spawns;
+	for (int time_since_creation = m_timing.shouldCreateEffect(source, time_state); time_since_creation >= 0; time_since_creation = m_timing.shouldCreateEffect(source, time_state)) {
+		float interp = static_cast<float>(time_since_creation)/(f2fl(Frametime) * 1000.0f);
 		
 		particle_info info;
 

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -25,12 +25,8 @@ namespace particle {
 			// This uses the internal features of the timing class for determining if and how many effects should be
 			// triggered this frame
 			util::EffectTiming::TimingState time_state;
-			int num_spawns = 0;
-			while (m_timing.shouldCreateEffect(source, time_state)) {
-				num_spawns++;
-			}
-
-			for (int spawn_i = 1; spawn_i <= num_spawns; spawn_i++) {
+			for (int time_since_creation = m_timing.shouldCreateEffect(source, time_state); time_since_creation >= 0; time_since_creation = m_timing.shouldCreateEffect(source, time_state)) {
+				float interp = static_cast<float>(time_since_creation)/(f2fl(Frametime) * 1000.0f);
 
 				auto num = m_particleNum.next();
 
@@ -50,8 +46,6 @@ namespace particle {
 
 				vec3d stretch_dir = source->getOrientation()->getDirectionVector(source->getOrigin());
 				matrix stretch_matrix = vm_stretch_matrix(&stretch_dir, m_stretch);
-
-				float interp = spawn_i/num_spawns;
 
 				for (uint i = 0; i < num; ++i) {
 					if (m_particleChance < 1.0f) {

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -25,7 +25,13 @@ namespace particle {
 			// This uses the internal features of the timing class for determining if and how many effects should be
 			// triggered this frame
 			util::EffectTiming::TimingState time_state;
+			int num_spawns = 0;
 			while (m_timing.shouldCreateEffect(source, time_state)) {
+				num_spawns++;
+			}
+
+			for (int spawn_i = 1; spawn_i <= num_spawns; spawn_i++) {
+
 				auto num = m_particleNum.next();
 
 				if (source->getOrigin()->getType() == SourceOriginType::BEAM) {
@@ -44,6 +50,9 @@ namespace particle {
 
 				vec3d stretch_dir = source->getOrientation()->getDirectionVector(source->getOrigin());
 				matrix stretch_matrix = vm_stretch_matrix(&stretch_dir, m_stretch);
+
+				float interp = spawn_i/num_spawns;
+
 				for (uint i = 0; i < num; ++i) {
 					if (m_particleChance < 1.0f) {
 						auto roll = m_particleRoll.next();
@@ -69,7 +78,7 @@ namespace particle {
 						vm_vec_rotate(&pos, &copy_pos, &stretch_matrix);
 
 					particle_info info;
-					source->getOrigin()->applyToParticleInfo(info);
+					source->getOrigin()->applyToParticleInfo(info, false, interp);
 
 					// make their velocity radial, and based on position, allows for some very cool effects
 					vec3d velocity = pos;

--- a/code/particle/util/EffectTiming.cpp
+++ b/code/particle/util/EffectTiming.cpp
@@ -49,15 +49,15 @@ bool EffectTiming::continueProcessing(const ParticleSource* source) const
 	return true;
 }
 
-bool EffectTiming::shouldCreateEffect(ParticleSource* source, EffectTiming::TimingState& localState) const
+int EffectTiming::shouldCreateEffect(ParticleSource* source, EffectTiming::TimingState& localState) const
 {
-	if (m_particlesPerSecond < 0.0f) {
+	if (m_particlesPerSecond.min() < 0.0f) {
 		// If this is not specified then on every frame we will create exactly one effect
 		if (localState.initial) {
 			localState.initial = false;
-			return true;
+			return 0;
 		} else {
-			return false;
+			return -1;
 		}
 	}
 
@@ -68,14 +68,16 @@ bool EffectTiming::shouldCreateEffect(ParticleSource* source, EffectTiming::Timi
 	if (source->getTiming()->nextCreationTimeExpired())
 	{
 		// Invert this so we can compute the time difference between effect creations
-		auto secondsPerParticle = 1.0f / m_particlesPerSecond;
-		auto time_diff_ms = fl2i(secondsPerParticle * 1000.f);
+		auto secondsPerParticle = 1.0f / m_particlesPerSecond.next();
+		// we need to clamp this to 1 because a spawn delay of 0 means we try to spawn infinite particles
+		auto time_diff_ms = std::max(fl2i(secondsPerParticle * MILLISECONDS_PER_SECOND), 1);
+		int creation_time = source->getTiming()->getNextCreationTime();
 		source->getTiming()->incrementNextCreationTime(time_diff_ms);
 
-		return true;
+		return timestamp_since(creation_time);
 	}
 
-	return false;
+	return -1;
 }
 
 EffectTiming EffectTiming::parseTiming() {
@@ -104,10 +106,13 @@ EffectTiming EffectTiming::parseTiming() {
 	}
 
 	if (optional_string("+Effects per second:")) {
-		stuff_float(&timing.m_particlesPerSecond);
-		if (timing.m_particlesPerSecond < 0.001f) {
-			error_display(0, "Invalid effect per second value %f. Setting was disabled.", timing.m_particlesPerSecond);
-			timing.m_particlesPerSecond = -1.f;
+		timing.m_particlesPerSecond = ::util::parseUniformRange<float>();
+		if (timing.m_particlesPerSecond.min() < 0.001f) {
+			error_display(0, "Invalid effects per second minimum %f. Setting was disabled.", timing.m_particlesPerSecond.min());
+			timing.m_particlesPerSecond = ::util::UniformFloatRange(-1.f);
+		}
+		if (timing.m_particlesPerSecond.max() > 1000.0f) {
+			error_display(0, "Effects per second maximum %f is above 1000. Delay between effects will be clamped to 1 millisecond.", timing.m_particlesPerSecond.max());
 		}
 	}
 

--- a/code/particle/util/EffectTiming.h
+++ b/code/particle/util/EffectTiming.h
@@ -60,11 +60,13 @@ class EffectTiming {
 	bool continueProcessing(const ParticleSource* source) const;
 
 	/**
-	 * @brief Given the properties of this timing structure, determine if a new effect should be created for a source.
+	 * @brief Given the properties of this timing structure, determine if a new effect should be created for a source,
+	 * and if so, at what point during the frame the effect should spawn.
 	 * @param source The source to check.
 	 * @param localState Internal state used by this function that is needed multiple times. Default construct
 	 * TimingState and then pass it to this function.
-	 * @return @c true if a new effect should be created, @c false. This might return @c true multiple times per frame.
+	 * If an effect should be created, @return the number of milliseconds between the creation time and the current time.
+	 * If no effect should be created, @return -1.
 	 */
 	int shouldCreateEffect(ParticleSource* source, TimingState& localState) const;
 

--- a/code/particle/util/EffectTiming.h
+++ b/code/particle/util/EffectTiming.h
@@ -38,7 +38,7 @@ class EffectTiming {
 	::util::UniformFloatRange m_delayRange;
 	::util::UniformFloatRange m_durationRange;
 
-	float m_particlesPerSecond = -1.f;
+	::util::UniformFloatRange m_particlesPerSecond = ::util::UniformFloatRange(-1.f);
  public:
 	struct TimingState {
 		bool initial = true;
@@ -66,7 +66,7 @@ class EffectTiming {
 	 * TimingState and then pass it to this function.
 	 * @return @c true if a new effect should be created, @c false. This might return @c true multiple times per frame.
 	 */
-	bool shouldCreateEffect(ParticleSource* source, TimingState& localState) const;
+	int shouldCreateEffect(ParticleSource* source, TimingState& localState) const;
 
 	/**
      * @brief Parses an effect timing class


### PR DESCRIPTION
Previously, particle effects from -part.tbm could be spawned more than once per frame, but this would only result in the particles clumping up at the spawner's position each frame. Smoothly spawning many particles along a fast-moving object's path was impossible. This PR makes it so that particles spawned between frames are placed partway along the spawner's trajectory in accordance with spawn timing, with millisecond precision.

Limitations:
- For now, this applies only to the "object" source type, so it won't affect particles spawned from beams or as trails from other particles. I intend to extend it to beams in the future, but that will be slightly more complicated so I'm leaving it off for now. I'm not sure it's even worth doing for the particle source type -- particles don't store last-frame position data, so I'd need to add that, which might be a significant performance burden.
- The interpolation is linear. For objects on a curved trajectory, the interpolation on each frame will be a straight line rather than following the curve (though this isn't very noticeable even for tightly-curving objects), and it doesn't take acceleration into account. Both of these things could probably be fixed with some effort, but I'm not convinced it's necessary.
- Millisecond precision means that there's a limit on how close together spawns can occur, relative to the speed of the spawner object. For a spawner traveling at 1000 m/s, the spawns will be no closer than 1 meter. I have ideas about how to increase the precision, and if a use case arises, I will probably implement them.

Other details:
- I fixed a preexisting issue that would cause the game to hang when +Effects per second was set to a value higher than 1000. Because the delay between spawns was calculated using milliseconds, a per-second value above 1000 would cause the delay to be rounded to 0, and the game would attempt to spawn infinitely many particles. I clamped the delay to no less than 1 millisecond, and added a warning for values above 1000.
- I made +Effects per second a random range, which effectively allows the delay between spawns to be randomized. My one concern about this is how it's presented to the modder -- the phrasing might lead people to think the randomization only happens once per second or something, rather than every spawn.