### PR TITLE
only run the Coverity workflow on the SCP repository

### DIFF
--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -18,6 +18,7 @@ env:
 jobs:
   build:
     name: Build FSO With Coverity Wrapper
+    if: github.repository == 'scp-fs2open/fs2open.github.com'
     runs-on: ${{ matrix.config.os }}
     container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     strategy:


### PR DESCRIPTION
This prevents Coverity from running on any forked repository, by default; both because the workflow will fail, and also because the workflow's results would be identical.  (Any forked repository can, of course, change this within its own scope.)