### PR TITLE
fix incorrect processing of keys during ESC popup

### DIFF
--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -294,13 +294,11 @@ void popup_play_default_change_sound(popup_info *pi)
 //			POPUP_NOCHANGE		=> nothing happenned
 int popup_process_keys(popup_info *pi, int k, int flags)
 {
-	int i, masked_k;
-
 	if ( k <= 0 ) {
 		return POPUP_NOCHANGE;
 	}
 
-	for ( i = 0; i < pi->nchoices; i++ ) {
+	for ( int i = 0; i < pi->nchoices; i++ ) {
 		if ( pi->keypress[i] == key_to_ascii(k) ) {
 			Popup_default_choice=i;
 			Popup_buttons[i].press_button();
@@ -345,13 +343,6 @@ int popup_process_keys(popup_info *pi, int k, int flags)
 	default:
 		break;
 	} // end switch
-
-
-	masked_k = k & ~KEY_CTRLED;	// take out CTRL modifier only
-	if ( (Game_mode & GM_IN_MISSION) ) {
-		process_set_of_keys(masked_k, Dead_key_set_size, Dead_key_set);
-		button_info_do(&Player->bi);	// call functions based on status of button_info bit vectors
-	}
 
 	return POPUP_NOCHANGE;
 }

--- a/code/popup/popup.h
+++ b/code/popup/popup.h
@@ -48,7 +48,7 @@
 // misc
 #define PF_RUN_STATE					(1<<22)	// call the do frame of the current state underneath the popup
 #define PF_IGNORE_ESC				(1<<23)	// ignore the escape character
-#define PF_ALLOW_DEAD_KEYS			(1<<24)	// Allow player to use keyset that exists when player dies
+#define PF_UNUSED_0					(1<<24)	// Previously PF_ALLOW_DEAD_KEYS, but this was unused even in retail
 #define PF_NO_NETWORKING			(1<<25)	// don't do any networking
 
 // no special buttons


### PR DESCRIPTION
In retail, the processing of certain keys during a popup, in the `popup_process_keys()` function, was dependent upon the `PF_ALLOW_DEAD_KEYS` flag.  This flag was never used in retail, causing the if() block to be marked as dead code.  In a4e623db23, the dead code warning was addressed by removing the dependency on `PF_ALLOW_DEAD_KEYS`, which is incorrect.  The "dead keys" should only be processed during the "dead popup".  Since the "dead popup" was moved to its own de[a]dicated "popupdead" section, the "dead keys" processing can be entirely removed from the "normal popup".

Fixes a bug noticed by @PremiumColt where certain keys, especially the time compression keys, were processed while the ESC popup was active.