### PR TITLE
Expose Minimum LoS Detection Radius

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -471,6 +471,10 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$firing requires exact los:", AI::Profile_Flags::Require_exact_los);
 
+				if (optional_string("$exact los minimum detection radius:")) {
+					stuff_float(&profile->los_min_detection_radius);
+				}
+
 				set_flag(profile, "$fighterbay arrivals use carrier orientation:", AI::Profile_Flags::Fighterbay_arrivals_use_carrier_orient);
 
 				set_flag(profile, "$fighterbay departures use carrier orientation:", AI::Profile_Flags::Fighterbay_departures_use_carrier_orient);
@@ -721,6 +725,7 @@ void ai_profile_t::reset()
 
     flags.reset();
 
+    los_min_detection_radius = 10.0f;
     ai_path_mode = AI_PATH_MODE_NORMAL;
 	subsystem_path_radii = 0;
     bay_arrive_speed_mult = 1.0f;

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -99,6 +99,9 @@ public:
 
 	float detail_distance_mult[MAX_DETAIL_LEVEL + 1];	//MAX_DETAIL_LEVEL really needs to be 4
 
+	// minimum radius for the line-of-sight (los) detection --wookieejedi
+	float los_min_detection_radius;
+
 	int ai_path_mode;
 
 	// radii to use for the radius for subsystem path points and default value --wookieejedi

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6235,7 +6235,7 @@ int ai_fire_primary_weapon(object *objp)
 	weapon_info* wip = &Weapon_info[swp->primary_bank_weapons[swp->current_primary_bank]];
 	if (aip->target_objnum != -1 && (The_mission.ai_profile->flags[AI::Profile_Flags::Require_exact_los] || wip->wi_flags[Weapon::Info_Flags::Require_exact_los])) {
 		//Check if th AI has Line of Sight and is allowed to fire
-		if (!check_los(OBJ_INDEX(objp), aip->target_objnum, 10.0f, swp->current_primary_bank, -1, nullptr)) {
+		if (!check_los(OBJ_INDEX(objp), aip->target_objnum, The_mission.ai_profile->los_min_detection_radius, swp->current_primary_bank, -1, nullptr)) {
 			return 0;
 		}
 	}
@@ -6612,7 +6612,7 @@ bool check_ok_to_fire(int objnum, int target_objnum, const weapon_info *wip, int
 
 		if (The_mission.ai_profile->flags[AI::Profile_Flags::Require_exact_los] || wip->wi_flags[Weapon::Info_Flags::Require_exact_los]) {
 			//Check if th AI has Line of Sight and is allowed to fire
-			if (!check_los(objnum, target_objnum, 10.0f, -1, secondary_bank, firing_pos_global)) {
+			if (!check_los(objnum, target_objnum, The_mission.ai_profile->los_min_detection_radius, -1, secondary_bank, firing_pos_global)) {
 				return false;
 			}
 		}


### PR DESCRIPTION
The somewhat modern AI flag for `Require_exact_los` is extremely useful in multiple different situations, for example making large capital ship weapons not fire into friendly surrounding ships on accident. When the feature was added, the `check_los` function was provided with a default value of `10.0` meters for minimum radius detection. This PR exposes that value to modders so they can set it to a reasonable value depending on the ship sizes of their specific needs (for example, modders may not want to incur the cost of checking LoS on every small ship that is zipping around and instead use the LoS check only to avoid firing if a large capitial ship is in the firing path). And as a note, the los value just uses a simple numerical comparison check, so the los detection could be set to a negative value with no consequence (hence why error messages were not added, though if folks would like I can certainly add them).