### PR TITLE
Ensure guards ignore protected attackers

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -164,6 +164,7 @@ namespace AI {
 		Align_to_target_when_guarding_still,
 		Debris_respects_big_damage,
 		Dont_limit_change_in_speed_due_to_physics_whack,
+		Guards_ignore_protected_attackers,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -479,6 +479,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$don't limit change in speed due to physics whack:", AI::Profile_Flags::Dont_limit_change_in_speed_due_to_physics_whack);
 
+				set_flag(profile, "$guards ignore protected attackers:", AI::Profile_Flags::Guards_ignore_protected_attackers);
+
 				if (optional_string("$ai path mode:"))
 				{
 					stuff_string(buf, F_NAME, NAME_LENGTH);
@@ -837,5 +839,6 @@ void ai_profile_t::reset()
 	if (mod_supports_version(24, 2, 0)) {
 		flags.set(AI::Profile_Flags::Debris_respects_big_damage);
 		flags.set(AI::Profile_Flags::Force_beam_turret_fov);
+		flags.set(AI::Profile_Flags::Guards_ignore_protected_attackers);
 	}
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -10269,6 +10269,11 @@ void guard_object_was_hit(object *guard_objp, object *hitter_objp)
 		if (is_ignore_object(aip, OBJ_INDEX(hitter_objp)))
 			return;
 
+		//  If the hitter is protected, ignore it
+		if (The_mission.ai_profile->flags[AI::Profile_Flags::Guards_ignore_protected_attackers] && 
+			hitter_objp->flags[Object::Object_Flags::Protected])
+			return;
+
 		//	If hitter is on same team as me, don't attack him.
 		if (Ships[guard_objp->instance].team == Ships[hitter_objp->instance].team)
 			return;
@@ -10278,9 +10283,9 @@ void guard_object_was_hit(object *guard_objp, object *hitter_objp)
 			return;
 		}
 
-		// don't attack if you can't see him
+		// don't attack if you can't see it
 		if ( awacs_get_level(hitter_objp, &Ships[aip->shipnum], true) < 1.0f ) {
-			// if he's a stealth and visible, but not targetable, ok to attack.
+			// if it's stealthed and visible, but not targetable, ok to attack.
 			if ( is_object_stealth_ship(hitter_objp) ) {
 				if ( ai_is_stealth_visible(guard_objp, hitter_objp) != STEALTH_IN_FRUSTUM ) {
 					return;


### PR DESCRIPTION
Since guards going after a ship which is threatening their charge is an implicit attack order, it should be subject to the protected flag like all other similar situations, otherwise they'll chase but not fire (protected also stops firing) at the ship. 

This is definitely a bug, and an uncommon one, which is almost certainly not present in retail, but better to err on the side of caution with AI so I made it a flag targeting new versions.