### PR TITLE
Conditional Impacts followup

### DIFF
--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -125,12 +125,10 @@ int collide_weapon_weapon( obj_pair * pair )
 			if (wipA->weapon_hitpoints > 0) {
 				if (wipB->weapon_hitpoints > 0) {		//	Two bombs collide, detonate both.
 					if ((wipA->wi_flags[Weapon::Info_Flags::Bomb]) && (wipB->wi_flags[Weapon::Info_Flags::Bomb])) {
-						wpA->lifeleft = 0.001f;
-						wpA->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						wpB->lifeleft = 0.001f;
-						wpB->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
+						weapon_hit(A, B, &A->pos, -1, nullptr);
 						wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
+						weapon_hit(B, A, &B->pos, -1, nullptr);
 					} else {
 						A->hull_strength -= bDamage;
 						B->hull_strength -= aDamage;
@@ -145,36 +143,31 @@ int collide_weapon_weapon( obj_pair * pair )
 						}
 						
 						if (A->hull_strength < 0.0f) {
-							wpA->lifeleft = 0.001f;
-							wpA->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 							wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
+							weapon_hit(A, B, &A->pos, -1, nullptr);
 						}
 						if (B->hull_strength < 0.0f) {
 							wpB->lifeleft = 0.001f;
-							wpB->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 							wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
+							weapon_hit(B, A, &B->pos, -1, nullptr);
 						}
 					}
 				} else {
 					A->hull_strength -= bDamage;
-					wpB->lifeleft = 0.001f;
-					wpB->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
+					weapon_hit(B, A, &B->pos, -1, nullptr);
 					if (A->hull_strength < 0.0f) {
-						wpA->lifeleft = 0.001f;
-						wpA->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
+						weapon_hit(A, B, &A->pos, -1, nullptr);
 					}
 				}
 			} else if (wipB->weapon_hitpoints > 0) {
 				B->hull_strength -= aDamage;
-				wpA->lifeleft = 0.001f;
-				wpA->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 				wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
+				weapon_hit(A, B, &A->pos, -1, nullptr);
 				if (B->hull_strength < 0.0f) {
-					wpB->lifeleft = 0.001f;
-					wpB->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
+					weapon_hit(B, A, &B->pos, -1, nullptr);
 				}
 			}
 


### PR DESCRIPTION
This is a follow up to [#6218](https://github.com/scp-fs2open/fs2open.github.com/pull/6218), and makes a few changes.

First, I switched the ordering of a couple of the table lines. Previously, the armor type came first, then the effect name, then the other conditions. However, the armor type is a condition, whereas the effect is what happens when the conditions are met, and I thought that each of those things should be clustered. So now, the effect name goes at the end.

This is modder-facing, but the feature was merged like a week ago and I would be very surprised if anyone had used it yet, so I expect it'll be fine.

Second, I added support for conditional impacts when hitting weapons (such as bombs). This got a little thornier than I anticipated, and required making a significant change in collideweaponweapon.cpp -- weapon-weapon impacts now call weapon_hit(), where previously they just set the weapon's lifetime to a very low value and let lifetime expiration take care of it.

This is sort of a big alteration. I'm not sure I've correctly understood all the implications, and I won't be surprised if the PR is rejected for this reason. (Now that I think of it, I should have put these two changes in separate branches. Oh well -- they're simple; if I need to I can split them out manually without much trouble.) There is one change in behavior that I can think of, though it's purely cosmetic: before, hitting a weapon wouldn't play the impact effect (unless 'detonate on expiration' was set), whereas now it will. Possibly there's some mod somewhere whose art style was importantly dependent on this?