### PR TITLE
Print in game options data to scripting output files

### DIFF
--- a/code/scripting/doc_html.cpp
+++ b/code/scripting/doc_html.cpp
@@ -550,6 +550,15 @@ void output_html_doc(const ScriptingDocumentation& doc, const SCP_string& filena
 
 	fputs("</dd>", fp);
 
+	//***Options
+	fputs("<dt><b>In Game Options</b></dt>", fp);
+	fputs("<dd><dl>", fp);
+	for (const auto& option : doc.options) {
+		fprintf(fp, "<dt><b>%s</b></dt>", option.title.c_str());
+		fprintf(fp, "<dd><b>Key:</b> %s</dd>", option.key.c_str());
+		fprintf(fp, "<dd><b>Description:</b> %s</dd>", option.description.c_str());
+	}
+
 	//***Enumerations
 	fprintf(fp, "<dt id=\"Enumerations\"><h2>Enumerations</h2></dt>");
 	for (const auto& enumeration : doc.enumerations) {

--- a/code/scripting/doc_json.cpp
+++ b/code/scripting/doc_json.cpp
@@ -273,6 +273,21 @@ void output_json_doc(const ScriptingDocumentation& doc, const SCP_string& filena
 		json_object_set_new(root.get(), "conditions", conditionArray);
 	}
 	{
+		json_t* optionsArray = json_array();
+
+		for (const auto& option : doc.options) {
+			json_t* optionsObject = json_object();
+
+			json_object_set_new(optionsObject, "title", json_string(option.title.c_str()));
+			json_object_set_new(optionsObject, "key", json_string(option.key.c_str()));
+			json_object_set_new(optionsObject, "description", json_string(option.description.c_str()));
+
+			json_array_append_new(optionsArray, optionsObject);
+		}
+
+		json_object_set_new(root.get(), "options", optionsArray);
+	}
+	{
 		json_t* enumObject = json_object();
 
 		for (const auto& enumVal : doc.enumerations) {

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -304,10 +304,22 @@ void script_state::OutputLuaDocumentation(ScriptingDocumentation& doc,
 	//***Enumerations
 	for (uint32_t i = 0; i < Num_enumerations; i++) {
 		DocumentationEnum e;
-		e.name  = Enumerations[i].name;
+		e.name = Enumerations[i].name;
 		e.value = Enumerations[i].def;
 
 		doc.enumerations.push_back(e);
+	}
+
+	auto& optionsList = options::OptionsManager::instance()->getOptions();
+	for (auto& option : optionsList) {
+		const options::OptionBase* thisOpt = option.get();
+
+		DocumentationOption o;
+		o.title = thisOpt->getTitle();
+		o.description = thisOpt->getDescription();
+		o.key = thisOpt->getConfigKey();
+
+		doc.options.push_back(o);
 	}
 }
 

--- a/code/scripting/scripting_doc.h
+++ b/code/scripting/scripting_doc.h
@@ -71,6 +71,12 @@ struct DocumentationEnum {
 	int value;
 };
 
+struct DocumentationOption {
+	SCP_string title;
+	SCP_string description;
+	SCP_string key;
+};
+
 struct DocumentationAction {
 	SCP_string name;
 	SCP_string description;
@@ -90,6 +96,8 @@ struct ScriptingDocumentation {
 	SCP_vector<std::unique_ptr<DocumentationElement>> elements;
 
 	SCP_vector<DocumentationEnum> enumerations;
+	
+	SCP_vector<DocumentationOption> options;
 };
 
 }


### PR DESCRIPTION
What it says on the tin. Prints in-game options title, key, & description to scripting.html and scripting.json

Fixes #6222