### PR TITLE
fix `NextFireTimestamp`

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -299,6 +299,12 @@ UI_TIMESTAMP ui_timestamp(int delta_ms) {
 //	Negative value gives milliseconds ago that timestamp elapsed.
 int timestamp_until(int stamp)
 {
+	// handle special values
+	if (stamp < 0)
+		return INT_MAX;
+	if (stamp == 1)
+		return 0;
+
 	// JAS: FIX
 	// HACK!! This doesn't handle rollover!
 	// (Will it ever happen?)
@@ -346,6 +352,12 @@ int ui_timestamp_until(UI_TIMESTAMP stamp)
 
 int timestamp_since(int stamp)
 {
+	// handle special values
+	if (stamp < 0)
+		return INT_MAX;
+	if (stamp == 1)
+		return 0;
+
 	return timestamp_ms() - stamp;
 }
 

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -656,7 +656,7 @@ ADE_VIRTVAR(NextFireTimestamp, l_Subsystem, "number", "The next time the turret 
 		float delta = newVal - currentTime;
 		if (delta < 0.0f)
 		{
-			Warning(LOCATION, "NextFireTimestamp: Specified value is in the past; setting to the current time");
+			mprintf(("NextFireTimestamp: Specified value is in the past; setting to the current time\n"));
 			delta = 0.0f;
 		}
 

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -649,12 +649,21 @@ ADE_VIRTVAR(NextFireTimestamp, l_Subsystem, "number", "The next time the turret 
 	if (!sso->isValid())
 		return ade_set_error(L, "f", -1.0f);
 
-	if(ADE_SETTING_VAR)
+	float currentTime = f2fl(Missiontime);
+
+	if (ADE_SETTING_VAR)
 	{
-		sso->ss->turret_next_fire_stamp = (int)(newVal * 1000);
+		float delta = newVal - currentTime;
+		if (delta < 0.0f)
+		{
+			Warning(LOCATION, "NextFireTimestamp: Specified value is in the past; setting to the current time");
+			delta = 0.0f;
+		}
+
+		sso->ss->turret_next_fire_stamp = timestamp(fl2i(delta * MILLISECONDS_PER_SECOND));
 	}
 
-	return ade_set_args(L, "f", sso->ss->turret_next_fire_stamp / 1000.0f);
+	return ade_set_args(L, "f", currentTime + timestamp_until(sso->ss->turret_next_fire_stamp) / i2fl(MILLISECONDS_PER_SECOND));
 }
 
 ADE_VIRTVAR(ModelPath, l_Subsystem, "modelpath", "The model path points belonging to this subsystem", "modelpath",


### PR DESCRIPTION
Changes `NextFireTimestamp` to work as advertised.  Fixes #6256.

EDIT: Also handles special timestamp values in `timestamp_until()` and `timestamp_since()`.