### PR TITLE
fix copy-paste error in timestamp_since

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -354,7 +354,7 @@ int timestamp_since(int stamp)
 {
 	// handle special values
 	if (stamp < 0)
-		return INT_MAX;
+		return INT_MIN;
 	if (stamp == 1)
 		return 0;
 


### PR DESCRIPTION
The time since an invalid timestamp should be INT_MIN, not INT_MAX.  Follow up to #6258.