### PR TITLE
refine timestamp_valid

### DIFF
--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -137,7 +137,7 @@ TIMESTAMP _timestamp();					// use a leading underscore for now until all timest
 UI_TIMESTAMP ui_timestamp();
 
 inline bool timestamp_valid(int stamp) {
-	return stamp != 0;
+	return stamp > 0;	// 0 is the "official" invalid for legacy timestamps, but -1 is used in a lot of places too
 }
 
 // To do timing, call this with the interval you


### PR DESCRIPTION
Change `timestamp_valid()` to also catch the common case of -1 being used for invalid as well as the "official" 0.

This addresses a few Coverity defects, but due to the widespread use of this function and on @Baezon 's recommendation, I am deferring it until after the stable build.