### PR TITLE
Fix: Always check for nullptrs and make red-alert respect cur_waves from last mission

### DIFF
--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -938,7 +938,9 @@ void red_alert_bash_ship_status()
 				wingp->current_wave = rws->latest_wave;
 				
 				// make sure that num_waves can accomodate having extra wings.
+				// this would happen if the mission we are entering has too few waves.
 				if (wingp->num_waves < wingp->current_wave){
+					mprintf(("Red alert warning: make sure that the current mission has at least as many waves as exited last mission. Bashing the number of waves of wing %s to %i!\n", wingp->name, wingp->current_wave));					
 					wingp->num_waves = wingp->current_wave;
 				}
 

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -939,7 +939,8 @@ void red_alert_bash_ship_status()
 				
 				// make sure that num_waves can accommodate the new value of current_wave.
 				// this would happen if the mission we are entering has too few waves.
-				if (wingp->num_waves < wingp->current_wave){
+				if (wingp->num_waves < wingp->current_wave)
+				{
 					mprintf(("Red alert warning: wing %s in the current mission has fewer waves than in the last mission.  Bashing the number of waves from %i to %i.\n", wingp->name, wingp->num_waves, wingp->current_wave));
 					wingp->num_waves = wingp->current_wave;
 				}

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -936,6 +936,11 @@ void red_alert_bash_ship_status()
 
 				// assign the wave number to the wing
 				wingp->current_wave = rws->latest_wave;
+				
+				// make sure that num_waves can accomodate having extra wings.
+				if (wingp->num_waves < wingp->current_wave){
+					wingp->num_waves = wingp->current_wave;
+				}
 
 				if (rws->latest_wave > 1)
 				{

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -937,10 +937,10 @@ void red_alert_bash_ship_status()
 				// assign the wave number to the wing
 				wingp->current_wave = rws->latest_wave;
 				
-				// make sure that num_waves can accomodate having extra wings.
+				// make sure that num_waves can accommodate the new value of current_wave.
 				// this would happen if the mission we are entering has too few waves.
 				if (wingp->num_waves < wingp->current_wave){
-					mprintf(("Red alert warning: make sure that the current mission has at least as many waves as exited last mission. Bashing the number of waves of wing %s to %i!\n", wingp->name, wingp->current_wave));					
+					mprintf(("Red alert warning: wing %s in the current mission has fewer waves than in the last mission.  Bashing the number of waves from %i to %i.\n", wingp->name, wingp->num_waves, wingp->current_wave));
 					wingp->num_waves = wingp->current_wave;
 				}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11902,7 +11902,12 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 
 	// zookeeper - If we're switching in the loadout screen, make sure we retain initial velocity set in FRED
 	if (!(Game_mode & GM_IN_MISSION) && !(Fred_running)) {
-		Objects[sp->objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;
+		if (p_objp != nullptr){
+			Objects[sp->objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;		
+		} else {
+			Objects[sp->objnum].phys_info.speed = 0.0f;
+		}
+
 		// prev_ramp_vel needs to be in local coordinates
 		// set z of prev_ramp_vel to initial velocity
 		vm_vec_zero(&Objects[sp->objnum].phys_info.prev_ramp_vel);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11901,12 +11901,8 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	}
 
 	// zookeeper - If we're switching in the loadout screen, make sure we retain initial velocity set in FRED
-	if (!(Game_mode & GM_IN_MISSION) && !(Fred_running)) {
-		if (p_objp != nullptr){
-			Objects[sp->objnum].phys_info.speed = (float) p_objp->initial_velocity * sip->max_speed / 100.0f;		
-		} else {
-			Objects[sp->objnum].phys_info.speed = 0.0f;
-		}
+	if (!(Game_mode & GM_IN_MISSION) && !(Fred_running) && (p_objp != nullptr)) {
+		Objects[sp->objnum].phys_info.speed = p_objp->initial_velocity * sip->max_speed / 100.0f;
 
 		// prev_ramp_vel needs to be in local coordinates
 		// set z of prev_ramp_vel to initial velocity


### PR DESCRIPTION
Fixes part of the cause of a crash reported on discord.  This is now very unlikely to happen, but everywhere else in this function checks that `p_objp` is not null before dereferencing.  Also, while working on this, goober and I saw that the current wave was sometimes exceeding the wave count of the second mission, so fix that as well.

Tested on the data that originally crashed FSO, and it no longer does.  Ships also properly show up as Gamma 5, Gamma 6, etc