### PR TITLE
Add offset for tabled particle effects

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1933,7 +1933,10 @@ int ai_big_maybe_enter_strafe_mode(const object *pl_objp, int weapon_objnum)
 	weapon_objp = &Objects[weapon_objnum];
 	Assert(weapon_objp->type == OBJ_WEAPON);
 
-	Assert(weapon_objp->parent >= 0 && weapon_objp->parent < MAX_OBJECTS);
+	if (weapon_objp->parent < 0) {
+		return 0;
+	}
+	Assert(weapon_objp->parent < MAX_OBJECTS);
 	parent_objp = &Objects[weapon_objp->parent];
 	if ( (parent_objp->signature != weapon_objp->parent_sig) || (parent_objp->type != OBJ_SHIP) ) {
 		return 0;

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1199,7 +1199,7 @@ void ship_get_global_turret_info(const object *objp, const model_subsystem *tp, 
  * @param use_angles    Use current angles
  * @param targetp       Absolute position of target object
  */
-void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, const vec3d *targetp)
+void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, const vec3d *targetp, vec3d *local_pos)
 {
 	vec3d *gun_pos;
 	model_subsystem *tp = ssp->system_info;
@@ -1212,6 +1212,10 @@ void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp,
 		gun_pos = &avg_gun_pos;
 	} else {
 		gun_pos = &tp->turret_firing_point[ssp->turret_next_fire_pos % tp->turret_num_firing_points];
+	}
+
+	if (local_pos != nullptr) {
+		*local_pos = *gun_pos;
 	}
 
 	model_instance_local_to_global_point(gpos, gun_pos, pm, pmi, tp->turret_gun_sobj, &objp->orient, &objp->pos);
@@ -1941,10 +1945,11 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 
 				vec3d firing_pos_buf;
 				const vec3d *firing_pos = &firing_pos_buf;
+				vec3d local_firing_pos;
 
 				// zookeeper - Firepoints should cycle normally between shots, 
 				// so we need to get the position info separately for each shot
-				ship_get_global_turret_gun_info(&Objects[parent_objnum], turret, &firing_pos_buf, false, nullptr, true, nullptr);
+				ship_get_global_turret_gun_info(&Objects[parent_objnum], turret, &firing_pos_buf, false, nullptr, true, nullptr, &local_firing_pos);
 
 				weapon_objnum = weapon_create(firing_pos, &firing_orient, turret_weapon_class, parent_objnum, -1, 1, 0, 0.0f, turret);
 				weapon_set_tracking_info(weapon_objnum, parent_objnum, turret->turret_enemy_objnum, 1, turret->targeted_subsys);		
@@ -1993,7 +1998,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 					if (wip->muzzle_effect.isValid()) {
 						//spawn particle effect
 						auto particleSource = particle::ParticleManager::get()->createSource(wip->muzzle_effect);
-						particleSource.moveTo(firing_pos);
+						particleSource.moveToTurret(&Objects[parent_ship->objnum], turret->system_info->turret_gun_sobj);
 						particleSource.setOrientationFromVec(firing_vec);
 						particleSource.setVelocity(&Objects[parent_ship->objnum].phys_info.vel);
 						particleSource.finish();

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1995,7 +1995,6 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 						//spawn particle effect
 						auto particleSource = particle::ParticleManager::get()->createSource(wip->muzzle_effect);
 						particleSource.moveToTurret(&Objects[parent_ship->objnum], turret->system_info->turret_gun_sobj, turret->turret_next_fire_pos);
-						particleSource.setOrientationFromVec(firing_vec);
 						particleSource.setVelocity(&Objects[parent_ship->objnum].phys_info.vel);
 						particleSource.finish();
 					}
@@ -2112,8 +2111,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 		if (Weapon_info[tsi->weapon_class].muzzle_effect.isValid()) {
 			//spawn particle effect
 			auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[tsi->weapon_class].muzzle_effect);
-			particleSource.moveTo(&turret_pos);
-			particleSource.setOrientationFromVec(&turret_fvec);
+			particleSource.moveToTurret(&Objects[tsi->parent_objnum], tsi->turret->system_info->turret_gun_sobj, tsi->turret->turret_next_fire_pos - 1);
 			particleSource.setVelocity(&Objects[tsi->parent_objnum].phys_info.vel);
 			particleSource.finish();
 		}

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -39,8 +39,8 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut) const {
 			break;
 		}
 		case SourceOriginType::VECTOR: {
+			offset = m_offset + *posOut;
 			*posOut = m_origin.m_pos;
-			offset = m_offset;
 			break;
 		}
 		case SourceOriginType::BEAM: {

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -198,13 +198,23 @@ void SourceOrigin::applyToParticleInfo(particle_info& info, bool allow_relative,
 			break;
 		}
 		case SourceOriginType::TURRET: {
-			this->getGlobalPosition(&info.pos, tabled_offset);
 			if (allow_relative) {
 				info.attached_objnum = m_origin.m_object.objnum;
 				info.attached_sig = m_origin.m_object.sig;
 
-				info.pos -= m_origin.m_object.objp()->pos;
+				ship* shipp = &Ships[m_origin.m_object.objp()->instance];
+
+				polymodel* pm = model_get(Ship_info[shipp->ship_info_index].model_num);
+
+				ship_subsys* sss = ship_get_indexed_subsys(shipp, pm->submodel[m_origin.m_subobject].subsys_num);
+
+				vec3d gvec;
+
+				ship_get_global_turret_gun_info(m_origin.m_object.objp(), sss, &info.pos, false, &gvec, true, nullptr, nullptr, true);
+
+				vm_vec_scale_add2(&info.pos, &gvec, tabled_offset.value_or(vmd_zero_vector).xyz.z);
 			} else {
+				this->getGlobalPosition(&info.pos, tabled_offset);
 				info.attached_objnum = -1;
 				info.attached_sig = -1;
 			}

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -118,7 +118,7 @@ void SourceOrigin::applyToParticleInfo(particle_info& info, bool allow_relative,
 				info.attached_objnum = m_origin.m_object.objnum;
 				info.attached_sig = m_origin.m_object.sig;
 
-				info.pos = m_offset;
+				info.pos = m_offset + manual_offset.value_or(vmd_zero_vector);
 			} else {
 				this->getGlobalPosition(&info.pos, manual_offset);
 				info.attached_objnum = -1;

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -413,10 +413,8 @@ bool SourceOrigin::isValid() const {
 			}
 			ship* shipp = &Ships[m_origin.m_object.objp()->instance];
 			polymodel* pm = model_get(Ship_info[shipp->ship_info_index].model_num);
-			if (pm->submodel[m_origin.m_subobject].subsys_num < 0) {
-				return false;
-			}
-			return true;
+			
+			return pm->submodel[m_origin.m_subobject].subsys_num >= 0;
 		}
 		case SourceOriginType::SUBOBJECT:
 			if (m_origin.m_subobject < 0) {

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -28,7 +28,7 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut, float interp, tl::optional<v
 
 			// we add whatever offset already exists to the tabled offset specified by the modder
 			vec3d combined_offset = m_offset + tabled_offset.value_or(vmd_zero_vector);
-			vm_vec_unrotate(&offset, &m_offset, &m_origin.m_object.objp()->orient);
+			vm_vec_unrotate(&offset, &combined_offset, &m_origin.m_object.objp()->orient);
 			break;
 		}
 		case SourceOriginType::SUBOBJECT: {
@@ -61,6 +61,7 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut, float interp, tl::optional<v
 			} else {
 				obj_pos = m_origin.m_object.objp()->pos;
 			}
+			
 			vec3d *gun_pos;
 			vec3d gvec;
 			model_subsystem *tp = sss->system_info;

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -18,11 +18,14 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut) const {
 	vec3d offset;
 	switch (m_originType) {
 		case SourceOriginType::OBJECT: {
+			// add together the m_offset and the current value of posOut, which is storing the effect's modder-specified manual offset
+			vec3d combined_offset = m_offset + *posOut;
 			*posOut = m_origin.m_object.objp()->pos;
-			vm_vec_unrotate(&offset, &m_offset, &m_origin.m_object.objp()->orient);
+			vm_vec_unrotate(&offset, &combined_offset, &m_origin.m_object.objp()->orient);
 			break;
 		}
 		case SourceOriginType::PARTICLE: {
+			vec3d combined_offset = m_offset + *posOut;
 			*posOut = m_origin.m_particle.lock()->pos;
 
 			matrix m = vmd_identity_matrix;
@@ -31,7 +34,7 @@ void SourceOrigin::getGlobalPosition(vec3d* posOut) const {
 			vm_vec_normalize_safe(&dir);
 			vm_vector_2_matrix_norm(&m, &dir);
 
-			vm_vec_unrotate(&offset, &m_offset, &m);
+			vm_vec_unrotate(&offset, &combined_offset, &m);
 
 			break;
 		}

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -198,11 +198,6 @@ class SourceOrigin {
  * SourceOrigin or gathered from the parent object, depending on host type. Host orientation is applied before position offset.
  * SourceOrientation is applied after position offset.
  * 
- * 
- * A source's SourceOrientation is distinct from its host orientation. The host orientation is either defined in
- * SourceOrigin or gathered from the parent object, depending on host type. Host orientation is applied before position offset.
- * SourceOrientation is applied after position offset.
- * 
  * An orientation can be either relative or global. In relative mode all transforms should be relative to the host
  * object and its orientation. In global mode, all directions are in world-space,
  * and host orientation is overridden completely (though it will still affect the orientation of position offsets).

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -51,6 +51,9 @@ class SourceOrigin {
 	struct {
 		vec3d m_pos;
 
+		// this is used only for vector-type sources, and is not used when the effect's parent is an object
+		matrix m_host_orientation;
+
 		object_h m_object;
 
 		int m_subobject;
@@ -134,7 +137,7 @@ class SourceOrigin {
 	 * @brief Moves the source to the specified world location
 	 * @param pos The world position
 	 */
-	void moveTo(const vec3d* pos);
+	void moveTo(const vec3d* pos, const matrix* orientation = &vmd_identity_matrix);
 
 	/**
 	 * @brief Moves the source to the specified beam object
@@ -220,7 +223,7 @@ class SourceOrientation {
 
 	void setFromMatrix(const matrix& mat, bool relative = false);
 
-	vec3d getDirectionVector(const SourceOrigin* origin) const;
+	vec3d getDirectionVector(const SourceOrigin* origin, bool allow_relative = false) const;
 
 	bool isRelative() const { return m_isRelative; }
 

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -55,6 +55,8 @@ class SourceOrigin {
 
 		int m_subobject;
 
+		int m_fire_pos;
+
 		WeakParticlePtr m_particle;
 	} m_origin;
 
@@ -79,7 +81,7 @@ class SourceOrigin {
 	 */
 	void getGlobalPosition(vec3d* posOut, tl::optional<vec3d> manual_offset = tl::nullopt) const;
 
-	void getHostOrientation(matrix* matOut) const;
+	void getHostOrientation(matrix* matOut, bool allow_relative) const;
 
 	inline SourceOriginType getType() const { return m_originType; }
 
@@ -159,7 +161,7 @@ class SourceOrigin {
 	 * @param objp The hosting object
 	 * @param offset The position relative to this object
 	 */
-	void moveToTurret(const object* objp, int subobject);
+	void moveToTurret(const object* objp, int subobject, int fire_pos);
 
 	/**
 	 * @brief Moves the source to the specified particle

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -52,6 +52,7 @@ class SourceOrigin {
 		vec3d m_pos;
 
 		// this is used only for vector-type sources, and is not used when the effect's parent is an object
+		// when the parent is an object, we get the relevant orientation from the object, so that it stays updated
 		matrix m_host_orientation;
 
 		object_h m_object;
@@ -191,9 +192,17 @@ class SourceOrigin {
  *
  * Currently only the forward direction vector is useful because the other vectors of the matrix are chosen pretty
  * arbitrarily. This also contains a normal vector if it was specified when creating the source.
- *
+ * 
+ * A source's SourceOrientation is distinct from its host orientation. The host orientation is either defined in
+ * SourceOrigin or gathered from the parent object, depending on host type. Host orientation is applied before position offset.
+ * SourceOrientation is applied after position offset.
+ * 
  * An orientation can be either relative or global. In relative mode all transforms should be relative to the host
- * object while in global mode all directions are in world-space. Normals are always in world-space.
+ * object and its orientation. In global mode, all directions are in world-space,
+ * and host orientation is overridden completely (though it will still affect the orientation of position offsets).
+ * 
+ * Normals are always in world-space.
+ * 
  */
 class SourceOrientation {
  private:

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -11,6 +11,8 @@
 
 #include "io/timer.h"
 
+#include <tl/optional.hpp>
+
 struct weapon;
 
 struct weapon_info;
@@ -71,7 +73,7 @@ class SourceOrigin {
 	 * 
 	 * @param posOut The pointer where the location will be stored
 	 */
-	void getGlobalPosition(vec3d* posOut) const;
+	void getGlobalPosition(vec3d* posOut, tl::optional<vec3d> manual_offset = tl::nullopt) const;
 
 	void getHostOrientation(matrix* matOut) const;
 
@@ -96,7 +98,7 @@ class SourceOrigin {
 	 *
 	 * @param info The particle_info this should be applied to
 	 */
-	void applyToParticleInfo(particle_info& info, bool allowRelative = false) const;
+	void applyToParticleInfo(particle_info& info, bool allowRelative = false, tl::optional<vec3d> manual_offset = tl::nullopt) const;
 
 	/**
 	 * @brief Gets the velocity of the origin host

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -29,6 +29,8 @@ enum class SourceOriginType {
 	VECTOR, //!< World-space offset
 	BEAM, //!< A beam
 	OBJECT, //!< An object
+	SUBOBJECT, //!< A subobject
+	TURRET, //!< A turret
 	PARTICLE //!< A particle
 };
 
@@ -50,6 +52,8 @@ class SourceOrigin {
 		vec3d m_pos;
 
 		object_h m_object;
+
+		int m_subobject;
 
 		WeakParticlePtr m_particle;
 	} m_origin;
@@ -142,6 +146,20 @@ class SourceOrigin {
 	 * @param offset The position relative to this object
 	 */
 	void moveToObject(const object* objp, const vec3d* offset);
+
+		/**
+	 * @brief Moves the source to the specified object with an offset
+	 * @param objp The hosting object
+	 * @param offset The position relative to this object
+	 */
+	void moveToSubobject(const object* objp, int subobject, const vec3d* offset);
+
+	/**
+	 * @brief Moves the source to the specified object with an offset
+	 * @param objp The hosting object
+	 * @param offset The position relative to this object
+	 */
+	void moveToTurret(const object* objp, int subobject);
 
 	/**
 	 * @brief Moves the source to the specified particle

--- a/code/particle/ParticleSourceWrapper.cpp
+++ b/code/particle/ParticleSourceWrapper.cpp
@@ -83,10 +83,10 @@ namespace particle
 		}
 	}	
 
-	void ParticleSourceWrapper::moveToTurret(const object* obj, int subobject)
+	void ParticleSourceWrapper::moveToTurret(const object* obj, int subobject, int fire_pos)
 	{
 		for (auto& source : m_sources) {
-			source->getOrigin()->moveToTurret(obj, subobject);
+			source->getOrigin()->moveToTurret(obj, subobject, fire_pos);
 		}
 	}	
 	

--- a/code/particle/ParticleSourceWrapper.cpp
+++ b/code/particle/ParticleSourceWrapper.cpp
@@ -75,6 +75,20 @@ namespace particle
 			source->getOrigin()->moveToObject(obj, d);
 		}
 	}	
+
+	void ParticleSourceWrapper::moveToSubobject(const object* obj, int subobject, const vec3d* d)
+	{
+		for (auto& source : m_sources) {
+			source->getOrigin()->moveToSubobject(obj, subobject, d);
+		}
+	}	
+
+	void ParticleSourceWrapper::moveToTurret(const object* obj, int subobject)
+	{
+		for (auto& source : m_sources) {
+			source->getOrigin()->moveToTurret(obj, subobject);
+		}
+	}	
 	
 	void ParticleSourceWrapper::moveToBeam(const object* obj)
 	{

--- a/code/particle/ParticleSourceWrapper.cpp
+++ b/code/particle/ParticleSourceWrapper.cpp
@@ -98,11 +98,11 @@ namespace particle
 		}
 	}
 
-	void ParticleSourceWrapper::moveTo(const vec3d* pos)
+	void ParticleSourceWrapper::moveTo(const vec3d* pos, const matrix* orientation)
 	{
 		for (auto& source : m_sources)
 		{
-			source->getOrigin()->moveTo(pos);
+			source->getOrigin()->moveTo(pos, orientation);
 		}
 	}
 

--- a/code/particle/ParticleSourceWrapper.h
+++ b/code/particle/ParticleSourceWrapper.h
@@ -57,7 +57,7 @@ namespace particle
 
 		void moveToBeam(const object* obj);
 
-		void moveTo(const vec3d* pos);
+		void moveTo(const vec3d* pos, const matrix* orientation = &vmd_identity_matrix);
 
 		void setVelocity(const vec3d* vel);
 

--- a/code/particle/ParticleSourceWrapper.h
+++ b/code/particle/ParticleSourceWrapper.h
@@ -51,6 +51,10 @@ namespace particle
 
 		void moveToObject(const object* obj, const vec3d* localPos);
 
+		void moveToSubobject(const object* obj, int subobject, const vec3d* localPos);
+
+		void moveToTurret(const object* obj, int subobject);
+
 		void moveToBeam(const object* obj);
 
 		void moveTo(const vec3d* pos);

--- a/code/particle/ParticleSourceWrapper.h
+++ b/code/particle/ParticleSourceWrapper.h
@@ -53,7 +53,7 @@ namespace particle
 
 		void moveToSubobject(const object* obj, int subobject, const vec3d* localPos);
 
-		void moveToTurret(const object* obj, int subobject);
+		void moveToTurret(const object* obj, int subobject, int fire_pos);
 
 		void moveToBeam(const object* obj);
 

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -132,10 +132,7 @@ class GenericShapeEffect : public ParticleEffect {
 				vm_matrix_x_matrix(&rotatedVel, &dirMatrix, &velRotation);
 
 				particle_info info;
-				// we temporarily store the modder-specified offset in the position field
-				// applying the offset will be handled during getGlobalPosition
-				info.pos = m_particleProperties.m_manual_offset;
-				source->getOrigin()->applyToParticleInfo(info);
+				source->getOrigin()->applyToParticleInfo(info, false, m_particleProperties.m_manual_offset);
 
 				vec3d velocity = rotatedVel.vec.fvec;
 				if (TShape::scale_velocity_deviation()) {

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -48,18 +48,18 @@ class GenericShapeEffect : public ParticleEffect {
 	vec3d getNewDirection(const ParticleSource* source) const {
 		switch (m_direction) {
 			case ConeDirection::Incoming:
-				return source->getOrientation()->getDirectionVector(source->getOrigin());
+			return source->getOrientation()->getDirectionVector(source->getOrigin(), m_particleProperties.m_parent_local);
 			case ConeDirection::Normal: {
 				vec3d normal;
 				if (!source->getOrientation()->getNormal(&normal)) {
 					mprintf(("Effect '%s' tried to use normal direction for source without a normal!\n", m_name.c_str()));
-					return source->getOrientation()->getDirectionVector(source->getOrigin());
+					return source->getOrientation()->getDirectionVector(source->getOrigin(), m_particleProperties.m_parent_local);
 				}
 
 				return normal;
 			}
 			case ConeDirection::Reflected: {
-				vec3d out = source->getOrientation()->getDirectionVector(source->getOrigin());
+				vec3d out = source->getOrientation()->getDirectionVector(source->getOrigin(), m_particleProperties.m_parent_local);
 				vec3d normal;
 				if (!source->getOrientation()->getNormal(&normal)) {
 					mprintf(("Effect '%s' tried to use normal direction for source without a normal!\n", m_name.c_str()));
@@ -77,7 +77,7 @@ class GenericShapeEffect : public ParticleEffect {
 				return out;
 			}
 			case ConeDirection::Reverse: {
-				vec3d out = source->getOrientation()->getDirectionVector(source->getOrigin());
+				vec3d out = source->getOrientation()->getDirectionVector(source->getOrigin(), m_particleProperties.m_parent_local);
 				vm_vec_scale(&out, -1.0f);
 				return out;
 			}

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -132,7 +132,9 @@ class GenericShapeEffect : public ParticleEffect {
 				vm_matrix_x_matrix(&rotatedVel, &dirMatrix, &velRotation);
 
 				particle_info info;
-
+				// we temporarily store the modder-specified offset in the position field
+				// applying the offset will be handled during getGlobalPosition
+				info.pos = m_particleProperties.m_manual_offset;
 				source->getOrigin()->applyToParticleInfo(info);
 
 				vec3d velocity = rotatedVel.vec.fvec;

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -48,7 +48,7 @@ class GenericShapeEffect : public ParticleEffect {
 	vec3d getNewDirection(const ParticleSource* source) const {
 		switch (m_direction) {
 			case ConeDirection::Incoming:
-			return source->getOrientation()->getDirectionVector(source->getOrigin(), m_particleProperties.m_parent_local);
+				return source->getOrientation()->getDirectionVector(source->getOrigin(), m_particleProperties.m_parent_local);
 			case ConeDirection::Normal: {
 				vec3d normal;
 				if (!source->getOrientation()->getNormal(&normal)) {

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -132,7 +132,7 @@ class GenericShapeEffect : public ParticleEffect {
 				vm_matrix_x_matrix(&rotatedVel, &dirMatrix, &velRotation);
 
 				particle_info info;
-				source->getOrigin()->applyToParticleInfo(info, false, m_particleProperties.m_manual_offset);
+				source->getOrigin()->applyToParticleInfo(info, m_particleProperties.m_parent_local, m_particleProperties.m_manual_offset);
 
 				vec3d velocity = rotatedVel.vec.fvec;
 				if (TShape::scale_velocity_deviation()) {

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -26,7 +26,7 @@ bool SingleParticleEffect::processSource(ParticleSource* source) {
 	util::EffectTiming::TimingState time_state;
 	while (m_timing.shouldCreateEffect(source, time_state)) {
 		particle_info info;
-		source->getOrigin()->applyToParticleInfo(info, false, m_particleProperties.m_manual_offset);
+		source->getOrigin()->applyToParticleInfo(info, m_particleProperties.m_parent_local, m_particleProperties.m_manual_offset);
 
 		info.vel *= m_vel_inherit.next();
 

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -26,8 +26,7 @@ bool SingleParticleEffect::processSource(ParticleSource* source) {
 	util::EffectTiming::TimingState time_state;
 	while (m_timing.shouldCreateEffect(source, time_state)) {
 		particle_info info;
-
-		source->getOrigin()->applyToParticleInfo(info);
+		source->getOrigin()->applyToParticleInfo(info, false, m_particleProperties.m_manual_offset);
 
 		info.vel *= m_vel_inherit.next();
 

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -69,6 +69,9 @@ namespace particle {
 						vm_vec_rotate(&pos, &copy_pos, &stretch_matrix);
 
 					particle_info info;
+					// we temporarily store the modder-specified offset in the position field
+					// applying the offset will be handled during getGlobalPosition
+					info.pos = m_particleProperties.m_manual_offset;
 					source->getOrigin()->applyToParticleInfo(info);
 
 					// make their velocity radial, and based on position, allows for some very cool effects

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -69,7 +69,7 @@ namespace particle {
 						vm_vec_rotate(&pos, &copy_pos, &stretch_matrix);
 
 					particle_info info;
-					source->getOrigin()->applyToParticleInfo(info, false, m_particleProperties.m_manual_offset);
+					source->getOrigin()->applyToParticleInfo(info, m_particleProperties.m_parent_local, m_particleProperties.m_manual_offset);
 
 					// make their velocity radial, and based on position, allows for some very cool effects
 					vec3d velocity = pos;

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -69,10 +69,7 @@ namespace particle {
 						vm_vec_rotate(&pos, &copy_pos, &stretch_matrix);
 
 					particle_info info;
-					// we temporarily store the modder-specified offset in the position field
-					// applying the offset will be handled during getGlobalPosition
-					info.pos = m_particleProperties.m_manual_offset;
-					source->getOrigin()->applyToParticleInfo(info);
+					source->getOrigin()->applyToParticleInfo(info, false, m_particleProperties.m_manual_offset);
 
 					// make their velocity radial, and based on position, allows for some very cool effects
 					vec3d velocity = pos;

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -42,7 +42,7 @@ namespace particle {
 						num += 1;
 				}
 
-				vec3d stretch_dir = source->getOrientation()->getDirectionVector(source->getOrigin());
+				vec3d stretch_dir = source->getOrientation()->getDirectionVector(source->getOrigin(), m_particleProperties.m_parent_local);
 				matrix stretch_matrix = vm_stretch_matrix(&stretch_dir, m_stretch);
 				for (uint i = 0; i < num; ++i) {
 					if (m_particleChance < 1.0f) {

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -81,6 +81,10 @@ void ParticleProperties::parse(bool nocreate) {
 	if (optional_string("+Offset:")) {
 		stuff_vec3d(&m_manual_offset);
 	}
+
+	if (optional_string("+Remain local to parent:")) {
+		stuff_boolean(&m_parent_local);
+	}
 }
 
 int ParticleProperties::chooseBitmap()

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -7,7 +7,7 @@
 
 namespace particle {
 namespace util {
-ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f), m_length (0.0f), m_size_lifetime_curve (-1), m_vel_lifetime_curve (-1), m_rotation_type(RotationType::DEFAULT) {
+ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f), m_length (0.0f), m_size_lifetime_curve (-1), m_vel_lifetime_curve (-1), m_rotation_type(RotationType::DEFAULT), m_manual_offset (vmd_zero_vector) {
 }
 
 void ParticleProperties::parse(bool nocreate) {
@@ -77,6 +77,10 @@ void ParticleProperties::parse(bool nocreate) {
 			error_display(0, "Rotation Type %s not supported", buf);
 		}
 	}
+
+	if (optional_string("+Offset")) {
+		stuff_vec3d(&m_manual_offset);
+	}
 }
 
 int ParticleProperties::chooseBitmap()
@@ -120,6 +124,10 @@ void ParticleProperties::createParticle(particle_info& info) {
 		default:
 			UNREACHABLE("Rotation type not supported");
 	}
+
+	// we temporarily store the modder-specified offset in the position field
+	// applying the offset will be handled during getGlobalPosition
+	info.pos = m_manual_offset;
 
 	create(&info);
 }

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -78,7 +78,7 @@ void ParticleProperties::parse(bool nocreate) {
 		}
 	}
 
-	if (optional_string("+Offset")) {
+	if (optional_string("+Offset:")) {
 		stuff_vec3d(&m_manual_offset);
 	}
 }
@@ -124,10 +124,6 @@ void ParticleProperties::createParticle(particle_info& info) {
 		default:
 			UNREACHABLE("Rotation type not supported");
 	}
-
-	// we temporarily store the modder-specified offset in the position field
-	// applying the offset will be handled during getGlobalPosition
-	info.pos = m_manual_offset;
 
 	create(&info);
 }

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -36,6 +36,7 @@ private:
 	int m_vel_lifetime_curve;
 	RotationType m_rotation_type;
 	vec3d m_manual_offset;
+	bool m_parent_local = false;
 
 	ParticleProperties();
 

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -35,6 +35,7 @@ private:
 	int m_size_lifetime_curve;
 	int m_vel_lifetime_curve;
 	RotationType m_rotation_type;
+	vec3d m_manual_offset;
 
 	ParticleProperties();
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9287,7 +9287,7 @@ static void ship_dying_frame(object *objp, int ship_num)
 					auto source = particle::ParticleManager::get()->createSource(sip->death_effect);
 
 					// Use the position since the ship is going to be invalid soon
-					source.moveTo(&objp->pos);
+					source.moveTo(&objp->pos, &objp->orient);
 					source.setVelocity(&objp->phys_info.vel);
 
 					source.finish();
@@ -12903,6 +12903,8 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 						for(int s = 0; s<sub_shots; s++){
 							pnt = pm->gun_banks[bank_to_fire].pnt[pt];
+							vec3d dir;
+							dir = pm->gun_banks[bank_to_fire].norm[pt];
 							// Use 0 instead of bank_to_fire as index to external weapon model firingpoints 
 							if (weapon_model && weapon_model->n_guns) {
 								if (winfo_p->wi_flags[Weapon::Info_Flags::External_weapon_fp]) {
@@ -13026,7 +13028,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								}
 							}
 							// create the muzzle flash effect
-							shipfx_flash_create( obj, sip->model_num, &pnt, &obj->orient.vec.fvec, 1, weapon_idx );
+							shipfx_flash_create( obj, sip->model_num, &pnt, &dir, 1, weapon_idx );
 
 							// maybe shudder the ship - if its me
 							if((winfo_p->wi_flags[Weapon::Info_Flags::Shudder]) && (obj == Player_obj) && !(Game_mode & GM_STANDALONE_SERVER)){
@@ -13711,7 +13713,9 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 				pnt_index = 0;
 			}
 			shipp->secondary_point_reload_pct.set(bank, pnt_index, 0.0f);
-			pnt = pm->missile_banks[bank].pnt[pnt_index++];
+			pnt = pm->missile_banks[bank].pnt[pnt_index];
+			vec3d dir;
+			dir = pm->missile_banks[bank].norm[pnt_index++];
 
 			polymodel *weapon_model = NULL;
 			if(wip->external_model_num >= 0){
@@ -13767,7 +13771,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 				has_fired = true;
 
 				// create the muzzle flash effect
-				shipfx_flash_create(obj, sip->model_num, &pnt, &obj->orient.vec.fvec, 0, weapon_idx);
+				shipfx_flash_create(obj, sip->model_num, &pnt, &dir, 0, weapon_idx);
 
 				if((wip->wi_flags[Weapon::Info_Flags::Shudder]) && (obj == Player_obj) && !(Game_mode & GM_STANDALONE_SERVER)){
 					// calculate some arbitrary value between 100

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1930,7 +1930,7 @@ int is_support_allowed(object *objp, bool do_simple_check = false);
 //	Stuffs:
 //		*gpos: absolute position of gun firing point
 //		*gvec: vector fro *gpos to *targetp
-void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, const vec3d *targetp, vec3d *local_pos = nullptr, bool output_in_model_local_space = false);
+void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, const vec3d *targetp);
 
 //	Given an object and a turret on that object, return the global position and forward vector
 //	of the turret.   The gun normal is the unrotated gun normal, (the center of the FOV cone), not

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1930,7 +1930,7 @@ int is_support_allowed(object *objp, bool do_simple_check = false);
 //	Stuffs:
 //		*gpos: absolute position of gun firing point
 //		*gvec: vector fro *gpos to *targetp
-void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, const vec3d *targetp);
+void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, const vec3d *targetp, vec3d *local_pos = nullptr);
 
 //	Given an object and a turret on that object, return the global position and forward vector
 //	of the turret.   The gun normal is the unrotated gun normal, (the center of the FOV cone), not

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1930,7 +1930,7 @@ int is_support_allowed(object *objp, bool do_simple_check = false);
 //	Stuffs:
 //		*gpos: absolute position of gun firing point
 //		*gvec: vector fro *gpos to *targetp
-void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, const vec3d *targetp, vec3d *local_pos = nullptr);
+void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp, vec3d *gpos, bool avg_origin, vec3d *gvec, bool use_angles, const vec3d *targetp, vec3d *local_pos = nullptr, bool output_in_model_local_space = false);
 
 //	Given an object and a turret on that object, return the global position and forward vector
 //	of the turret.   The gun normal is the unrotated gun normal, (the center of the FOV cone), not

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1055,19 +1055,19 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 		objp == Player_obj && Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
 	if (!(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak]) &&
 		(objp != Player_obj || Render_player_mflash || (!in_cockpit_view || player_show_ship_model))) {
-			//if there's a muzzle effect entry, we use that
+			// if there's a muzzle effect entry, we use that
 			if (Weapon_info[weapon_info_index].muzzle_effect.isValid()) {
 				vec3d gun_world_pos;
 				vm_vec_unrotate(&gun_world_pos, gun_pos, &Objects[OBJ_INDEX(objp)].orient);
 				vm_vec_add2(&gun_world_pos, &Objects[OBJ_INDEX(objp)].pos);
 
-				//spawn particle effect
+				// spawn particle effect
 				auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[weapon_info_index].muzzle_effect);
-				particleSource.moveTo(&gun_world_pos);
+				particleSource.moveToObject(objp, gun_pos);
 				particleSource.setOrientationFromVec(gun_dir);
 				particleSource.setVelocity(&objp->phys_info.vel);
 				particleSource.finish();
-			//if there's a muzzle flash entry and no muzzle effect entry, we use the mflash
+			// if there's a muzzle flash entry and no muzzle effect entry, we use the mflash
 			} else if (Weapon_info[weapon_info_index].muzzle_flash >= 0) {
 				vec3d real_dir;
 				vm_vec_rotate(&real_dir, gun_dir, &objp->orient);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1064,14 +1064,12 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 				// spawn particle effect
 				auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[weapon_info_index].muzzle_effect);
 				particleSource.moveToObject(objp, gun_pos);
-				particleSource.setOrientationFromVec(gun_dir);
+				particleSource.setOrientationFromVec(gun_dir, true);
 				particleSource.setVelocity(&objp->phys_info.vel);
 				particleSource.finish();
 			// if there's a muzzle flash entry and no muzzle effect entry, we use the mflash
 			} else if (Weapon_info[weapon_info_index].muzzle_flash >= 0) {
-				vec3d real_dir;
-				vm_vec_rotate(&real_dir, gun_dir, &objp->orient);
-				mflash_create(gun_pos, &real_dir, &objp->phys_info, Weapon_info[weapon_info_index].muzzle_flash, objp);
+				mflash_create(gun_pos, gun_dir, &objp->phys_info, Weapon_info[weapon_info_index].muzzle_flash, objp);
 			}
 	}
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3958,8 +3958,9 @@ void beam_handle_collisions(beam *b)
 						// stream of fire for big ships
 						if (width <= Objects[target].radius * BEAM_AREA_PERCENT) {
 							auto particleSource = particle::ParticleManager::get()->createSource(wi->piercing_impact_effect);
-							particleSource.moveTo(&b->f_collisions[idx].cinfo.hit_point_world);
-							particleSource.setOrientationFromNormalizedVec(&fvec);
+							matrix fvec_orient;
+							vm_vector_2_matrix_norm(&fvec_orient, &fvec);
+							particleSource.moveTo(&b->f_collisions[idx].cinfo.hit_point_world, &fvec_orient);
 							particleSource.setOrientationNormal(&worldNormal);
 
 							particleSource.finish();
@@ -3986,15 +3987,14 @@ void beam_handle_collisions(beam *b)
 					}
 
 					auto particleSource = particle::ParticleManager::get()->createSource(wi->impact_weapon_expl_effect);
-					particleSource.moveTo(&b->f_collisions[idx].cinfo.hit_point_world);
-					particleSource.setOrientationNormal(&worldNormal);
-
 					vec3d fvec;
 					vm_vec_sub(&fvec, &b->last_shot, &b->last_start);
-
+					matrix fvec_orient = vmd_identity_matrix;
 					if (!IS_VEC_NULL(&fvec)) {
-						particleSource.setOrientationFromVec(&fvec);
+						vm_vector_2_matrix_norm(&fvec_orient, &fvec);
 					}
+					particleSource.moveTo(&b->f_collisions[idx].cinfo.hit_point_world, &fvec_orient);
+					particleSource.setOrientationNormal(&worldNormal);
 
 					particleSource.finish();
 				}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7572,7 +7572,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 				) {
 					auto particleSource = particle::ParticleManager::get()->createSource(ci.effect);
 					particleSource.moveTo(hitpos);
-					particleSource.setOrientationFromVec(&weapon_obj->phys_info.vel);
+					particleSource.setOrientationMatrix(&weapon_obj->orient);
 					particleSource.setVelocity(&weapon_obj->phys_info.vel);
 
 					if (hitnormal)
@@ -7592,7 +7592,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 	if (!valid_conditional_impact && wip->impact_weapon_expl_effect.isValid() && armed_weapon) {
 		auto particleSource = particle::ParticleManager::get()->createSource(wip->impact_weapon_expl_effect);
 		particleSource.moveTo(hitpos);
-		particleSource.setOrientationFromVec(&weapon_obj->phys_info.vel);
+		particleSource.setOrientationMatrix(&weapon_obj->orient);
 		particleSource.setVelocity(&weapon_obj->phys_info.vel);
 
 		if (hitnormal)
@@ -7604,7 +7604,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 	} else if (!valid_conditional_impact && wip->dinky_impact_weapon_expl_effect.isValid() && !armed_weapon) {
 		auto particleSource = particle::ParticleManager::get()->createSource(wip->dinky_impact_weapon_expl_effect);
 		particleSource.moveTo(hitpos);
-		particleSource.setOrientationFromVec(&weapon_obj->phys_info.vel);
+		particleSource.setOrientationMatrix(&weapon_obj->orient);
 		particleSource.setVelocity(&weapon_obj->phys_info.vel);
 
 		if (hitnormal)

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5901,8 +5901,8 @@ void weapon_process_post(object * obj, float frame_time)
 					// do the spawn effect
 					if (wip->spawn_info[i].spawn_effect.isValid()) {
 						auto particleSource = particle::ParticleManager::get()->createSource(wip->spawn_info[i].spawn_effect);
-						particleSource.moveTo(&obj->pos);
-						particleSource.setOrientationFromVec(&obj->phys_info.vel);
+
+						particleSource.moveTo(&obj->pos, &obj->orient);
 						particleSource.setVelocity(&obj->phys_info.vel);
 						particleSource.finish();
 					}
@@ -7571,8 +7571,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 					&& hit_angle <= fl_radians(ci.max_angle_threshold)
 				) {
 					auto particleSource = particle::ParticleManager::get()->createSource(ci.effect);
-					particleSource.moveTo(hitpos);
-					particleSource.setOrientationMatrix(&weapon_obj->orient);
+					particleSource.moveTo(hitpos, &weapon_obj->last_orient);
 					particleSource.setVelocity(&weapon_obj->phys_info.vel);
 
 					if (hitnormal)
@@ -7591,8 +7590,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 
 	if (!valid_conditional_impact && wip->impact_weapon_expl_effect.isValid() && armed_weapon) {
 		auto particleSource = particle::ParticleManager::get()->createSource(wip->impact_weapon_expl_effect);
-		particleSource.moveTo(hitpos);
-		particleSource.setOrientationMatrix(&weapon_obj->orient);
+		particleSource.moveTo(hitpos, &weapon_obj->last_orient);
 		particleSource.setVelocity(&weapon_obj->phys_info.vel);
 
 		if (hitnormal)
@@ -7603,8 +7601,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 		particleSource.finish();
 	} else if (!valid_conditional_impact && wip->dinky_impact_weapon_expl_effect.isValid() && !armed_weapon) {
 		auto particleSource = particle::ParticleManager::get()->createSource(wip->dinky_impact_weapon_expl_effect);
-		particleSource.moveTo(hitpos);
-		particleSource.setOrientationMatrix(&weapon_obj->orient);
+		particleSource.moveTo(hitpos, &weapon_obj->last_orient);
 		particleSource.setVelocity(&weapon_obj->phys_info.vel);
 
 		if (hitnormal)
@@ -7647,8 +7644,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 				using namespace particle;
 
 				auto primarySource = ParticleManager::get()->createSource(wip->piercing_impact_effect);
-				primarySource.moveTo(&weapon_obj->pos);
-				primarySource.setOrientationMatrix(&weapon_obj->last_orient);
+				primarySource.moveTo(&weapon_obj->pos, &weapon_obj->last_orient);
 				primarySource.setVelocity(&weapon_obj->phys_info.vel);
 
 				if (hitnormal)
@@ -7660,8 +7656,7 @@ void weapon_hit( object * weapon_obj, object * other_obj, vec3d * hitpos, int qu
 
 				if (wip->piercing_impact_secondary_effect.isValid()) {
 					auto secondarySource = ParticleManager::get()->createSource(wip->piercing_impact_secondary_effect);
-					secondarySource.moveTo(&weapon_obj->pos);
-					secondarySource.setOrientationMatrix(&weapon_obj->last_orient);
+					secondarySource.moveTo(&weapon_obj->pos, &weapon_obj->last_orient);
 					secondarySource.setVelocity(&weapon_obj->phys_info.vel);
 
 					if (hitnormal)


### PR DESCRIPTION
This allows modders to specify a three-dimensional offset for a tabled particle effect, whereupon the position of the effect will be modified accordingly. This should work for effects spawned from objects, particles, vectors, and beams.

The offset is relative to the spawner's orientation. Unfortunately, this only works fully for objects. Other spawner types have a direction vector, but not a full orientation matrix, so in those cases the x and y axes are undefined. (In practice this seems to mean that they end up sort of pointed toward the global orientation to the extent that's possible.) This includes weapon hit effects, which are spawned from vectors, not the weapon object.

In future I would like to address this by adding an optional orientation field to SourceOrigin, which can then be populated with spawner orientation data where relevant -- such as the weapon's orientation for hit effects.