### PR TITLE
Disable clang misc-no-recursion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ misc-*,\
 -misc-include-cleaner,\
 -misc-macro-parentheses,\
 -misc-misplaced-widening-cast,\
+-misc-no-recursion,\
 -misc-non-private-member-variables-in-classes,\
 -misc-static-assert,\
 -misc-unused-parameters,\


### PR DESCRIPTION
As seen in #6265, our SEXP tree is evidently implemented as a recursive tree iterator, and clang just flags any change to that as a result.