### PR TITLE
Remove some overzealous prints

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -470,9 +470,6 @@ float vm_vec_copy_normalize(vec3d *dest, const vec3d *src)
 
 	//	Mainly here to trap attempts to normalize a null vector.
 	if (m <= 0.0f) {
-		mprintf(("Null vec3d in vec3d normalize.\n"
-				 "Trace out of vecmat.cpp and find offending code.\n"));
-
 		dest->xyz.x = 1.0f;
 		dest->xyz.y = 0.0f;
 		dest->xyz.z = 0.0f;

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -470,6 +470,8 @@ float vm_vec_copy_normalize(vec3d *dest, const vec3d *src)
 
 	//	Mainly here to trap attempts to normalize a null vector.
 	if (m <= 0.0f) {
+		nprintf(("Network", "Null vec3d in vec3d normalize.\n"
+			"Trace out of vecmat.cpp and find offending code.\n"));
 		dest->xyz.x = 1.0f;
 		dest->xyz.y = 0.0f;
 		dest->xyz.z = 0.0f;

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -52,7 +52,6 @@ class GenericShapeEffect : public ParticleEffect {
 			case ConeDirection::Normal: {
 				vec3d normal;
 				if (!source->getOrientation()->getNormal(&normal)) {
-					mprintf(("Effect '%s' tried to use normal direction for source without a normal!\n", m_name.c_str()));
 					return source->getOrientation()->getDirectionVector(source->getOrigin());
 				}
 
@@ -62,7 +61,6 @@ class GenericShapeEffect : public ParticleEffect {
 				vec3d out = source->getOrientation()->getDirectionVector(source->getOrigin());
 				vec3d normal;
 				if (!source->getOrientation()->getNormal(&normal)) {
-					mprintf(("Effect '%s' tried to use normal direction for source without a normal!\n", m_name.c_str()));
 					return out;
 				}
 


### PR DESCRIPTION
- Normal-based particle effects being spawned in a situation with no normal is a totally expected situation with a totally reasonable fall back. For instance, a weapon impact effect which spawns a particle as though it were 'bouncing' off its target would generate this warning everytime it detonated without hitting anything.
- Null vectors being normalized was definitely more a concern the developers had while developing, now, scripters can call this function directly, so it can certainly not be assumed and once again, has reasonable (and obvious, to a possibly concerned scripter) fallback

Most importantly of all, both of these situations can happen numerous times, and can REALLY clutter the log. I'm open to `nprintf` instead, but I don't think they're necessary.