### PR TITLE
Fix trail overlap

### DIFF
--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -1017,6 +1017,7 @@ void batching_render_batch_item(primitive_batch_item* item,
 	} else {
 		batched_bitmap_material material_def;
 
+		material_def.set_cull_mode(item->batch_item_info.mat_type != batch_info::FLAT_EMISSIVE_WITH_BACKFACES);
 		material_set_batched_bitmap(&material_def, item->batch_item_info.texture, 1.0f, 2.0f);
 		gr_render_primitives_batched(&material_def, PRIM_TYPE_TRIS, layout, (int)item->offset, (int)item->n_verts, buffer_num);
 	}

--- a/code/render/batching.cpp
+++ b/code/render/batching.cpp
@@ -967,8 +967,6 @@ void batching_add_quad_twisted(int texture, vertex *verts, primitive_batch *batc
     batching_add_quad_twisted_internal(batch, texture, verts);
 }
 
-void batching_add_quad_twisted(int texture, vertex *verts, primitive_batch* batch);
-
 void batching_add_tri(int texture, vertex *verts)
 {
 	Assertion((texture >= 0), "batching_add_tri() attempted for invalid texture");

--- a/code/render/batching.h
+++ b/code/render/batching.h
@@ -22,6 +22,7 @@ struct batch_vertex {
 struct batch_info {
 	enum material_type {
 		FLAT_EMISSIVE,
+		FLAT_EMISSIVE_WITH_BACKFACES,
 		VOLUME_EMISSIVE,
 		DISTORTION,
 		FLAT_OPAQUE,

--- a/code/render/batching.h
+++ b/code/render/batching.h
@@ -129,6 +129,7 @@ void batching_add_tri(int texture, vertex *verts);
 
 //these require some blurring the lines between things, but finding the batch in every call gets expensive in some cases such as trails.
 void batching_add_quad(int texture, vertex *verts, primitive_batch* batch, float trapezoidal_correction = 1.0f);
+void batching_add_quad_twisted(int texture, vertex *verts, primitive_batch* batch);
 void batching_add_tri(int texture, vertex *verts, primitive_batch* batch);
 
 void batching_render_all(bool render_distortions = false);

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -332,7 +332,7 @@ void trail_render( trail * trailp )
 
 				verts[0].texture_position.v = verts[3].texture_position.v = 0.0f;
 				verts[1].texture_position.v = verts[2].texture_position.v = 1.0f;
-				if (Detail.num_particles = NUM_DEFAULT_DETAIL_LEVELS) {
+				if (Detail.num_particles == NUM_DEFAULT_DETAIL_LEVELS) {
 					batching_add_quad_twisted(ti->texture.bitmap_id, verts, batchp);
 				} else {
 					batching_add_quad(ti->texture.bitmap_id, verts, batchp);

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -149,7 +149,7 @@ void trail_render( trail * trailp )
 		return;
 	}
 
-	auto batchp = batching_find_batch(ti->texture.bitmap_id, batch_info::FLAT_EMISSIVE);
+	auto batchp = batching_find_batch(ti->texture.bitmap_id, batch_info::FLAT_EMISSIVE_WITH_BACKFACES);
 
 	if (trailp->single_segment) {
 		Assertion(trailp->tail == 2, "Single segment trail with more than two values!");

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -333,7 +333,7 @@ void trail_render( trail * trailp )
 				verts[0].texture_position.v = verts[3].texture_position.v = 0.0f;
 				verts[1].texture_position.v = verts[2].texture_position.v = 1.0f;
 
-				batching_add_quad(ti->texture.bitmap_id, verts, batchp);
+				batching_add_quad_twisted(ti->texture.bitmap_id, verts, batchp);
 			}
 		}
 

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -332,8 +332,12 @@ void trail_render( trail * trailp )
 
 				verts[0].texture_position.v = verts[3].texture_position.v = 0.0f;
 				verts[1].texture_position.v = verts[2].texture_position.v = 1.0f;
-
-				batching_add_quad_twisted(ti->texture.bitmap_id, verts, batchp);
+				if (Detail.num_particles = NUM_DEFAULT_DETAIL_LEVELS) {
+					batching_add_quad_twisted(ti->texture.bitmap_id, verts, batchp);
+				} else {
+					batching_add_quad(ti->texture.bitmap_id, verts, batchp);
+				}
+				
 			}
 		}
 


### PR DESCRIPTION
This makes a change to the way trails are rendered in order to remedy an issue where trail segments would visibly "overlap" with themselves when twisted. It does this by increasing the number of tris in each segment from 2 to 4. This appears to have a significant performance impact in very trail-heavy scenarios, so the change only takes effect when particle detail is set to max. (I would be entirely willing to switch it to a different detail setting, like model, if that's deemed more appropriate.)

More profiling would be useful in future to figure out exactly where the performance drop is coming from, but for now, under typical circumstances, it should be fine.