### PR TITLE
Fix a sound crash

### DIFF
--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -341,6 +341,12 @@ sound_load_id snd_load(game_snd_entry* entry, int *flags, int /*allow_hardware_l
 			//       but will not load a duplicate 2D entry to get stereo if 3D
 			//       version already loaded
 			if ( (Sounds[n].info.n_channels == 1) || !(flags && *flags & GAME_SND_USE_DS3D) ) {
+				// Check we need to populate the signature here, as modders may desire to use 
+				// a sound file more than once in their tables.
+				if (entry->id_sig == -1) {
+					entry->id_sig = Sounds[n].sig;
+				}
+
 				return sound_load_id(static_cast<int>(n));
 			}
 		}


### PR DESCRIPTION
Reported and fix tested by FotG team:

Missing this logic and assignment in the sound code would cause a crash in specific circumstances.  When a sound file was used more than once in the Sounds table, the sound entry was not being populated with the index to the `Sounds` array.  Later on, when we attempted to access the `Sounds` array to play the sound, the unpopulated index entry was found, triggering an assert.

AFAICT, this buggy behavior was exposed when other sound code was fixed and started accessing the correct field which again, is that same index into the `Sounds` array.