### PR TITLE
Slightly clean up RPC API

### DIFF
--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -125,9 +125,6 @@ typedef struct vec3d {
 		} xyz;
 		float a1d[3];
 	};
-
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 } vec3d;
 
 typedef struct vec2d {

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -188,9 +188,6 @@ struct object_h final	// prevent subclassing because classes which might use thi
 	bool isValid() const;
 	object* objp() const;
 	object* objp_or_null() const;
-
-	static void serialize(lua_State* L, const scripting::ade_table_entry& tableEntry, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	static void deserialize(lua_State* L, const scripting::ade_table_entry& tableEntry, char* data_ptr, ubyte* data, int& offset);
 };
 
 // object backup struct used by Fred.

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1633,9 +1633,6 @@ struct object_ship_wing_point_team
 
 	bool operator==(const object_ship_wing_point_team &other) const;
 	bool operator!=(const object_ship_wing_point_team &other) const;
-
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 
 void eval_object_ship_wing_point_team(object_ship_wing_point_team* oswpt, int node, const char* ctext_override = nullptr);

--- a/code/scripting/ade_external_serializer.h
+++ b/code/scripting/ade_external_serializer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace scripting {
+	namespace internal {
+		template <typename T>
+		struct ade_serializable_external : std::false_type { };
+
+		/*
+		 * If you need a multi serializer that shouldn't be part of the struct (i.e. because the struct isn't just a lua handler, but also used elsewhere),
+		 * then you can declare and external serializer here and implement it in the cpp of the respective scripting object
+		 * */
+
+		template<>
+		struct ade_serializable_external<vec3d> : std::true_type {
+			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+			static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+		};
+
+		template<>
+		struct ade_serializable_external<object_ship_wing_point_team> : std::true_type {
+			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+			static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+		};
+
+		template<>
+		struct ade_serializable_external<object_h> : std::true_type {
+			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+			static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+		};
+	}
+}

--- a/code/scripting/ade_external_serializer.h
+++ b/code/scripting/ade_external_serializer.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <type_traits>
+#include "globalincs/pstypes.h"
+
+struct object_ship_wing_point_team;
+struct object_h;
+
 namespace scripting {
 	namespace internal {
 		template <typename T>

--- a/code/scripting/api/objs/bytearray.h
+++ b/code/scripting/api/objs/bytearray.h
@@ -14,8 +14,8 @@ struct bytearray_h {
 
 	const SCP_vector<uint8_t>& data() const;
 
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+	static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+	static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 
 DECLARE_ADE_OBJ(l_Bytearray, bytearray_h);

--- a/code/scripting/api/objs/enums.h
+++ b/code/scripting/api/objs/enums.h
@@ -240,8 +240,8 @@ public:
 	friend enum_h operator&(const enum_h& l, const enum_h& other);
 	friend enum_h operator|(const enum_h& l, const enum_h& other);
 
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+	static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+	static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 
 

--- a/code/scripting/api/objs/gameevent.h
+++ b/code/scripting/api/objs/gameevent.h
@@ -21,8 +21,8 @@ public:
 
 	int Get();
 
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+	static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+	static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 
 DECLARE_ADE_OBJ(l_GameEvent, gameevent_h);

--- a/code/scripting/api/objs/gamestate.h
+++ b/code/scripting/api/objs/gamestate.h
@@ -19,8 +19,8 @@ class gamestate_h {
 
 	int Get();
 
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+	static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+	static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 
 DECLARE_ADE_OBJ(l_GameState, gamestate_h);

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -33,7 +33,7 @@ void scripting::internal::ade_serializable_external<object_h>::serialize(lua_Sta
 	ADD_USHORT(netsig);
 }
 
-void scripting::internal::ade_serializable_external<object_h>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
+void scripting::internal::ade_serializable_external<object_h>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) { // NOLINT
 	ushort net_signature;
 	GET_USHORT(net_signature);
 	new(data_ptr) object_h(multi_get_network_object(net_signature));

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -26,14 +26,14 @@
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
 
-void object_h::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
+void scripting::internal::ade_serializable_external<object_h>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
 	object_h obj;
 	value.getValue(scripting::api::l_Object.Get(&obj));
 	const ushort& netsig = obj.isValid() ? obj.objp()->net_signature : 0;
 	ADD_USHORT(netsig);
 }
 
-void object_h::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
+void scripting::internal::ade_serializable_external<object_h>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
 	ushort net_signature;
 	GET_USHORT(net_signature);
 	new(data_ptr) object_h(multi_get_network_object(net_signature));

--- a/code/scripting/api/objs/oswpt.cpp
+++ b/code/scripting/api/objs/oswpt.cpp
@@ -43,7 +43,7 @@ void scripting::internal::ade_serializable_external<object_ship_wing_point_team>
 	}
 }
 
-void scripting::internal::ade_serializable_external<object_ship_wing_point_team>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
+void scripting::internal::ade_serializable_external<object_ship_wing_point_team>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) { // NOLINT
 	uint8_t oswpttype;
 	GET_DATA(oswpttype);
 	switch (static_cast<oswpt_type>(oswpttype)) {

--- a/code/scripting/api/objs/oswpt.cpp
+++ b/code/scripting/api/objs/oswpt.cpp
@@ -14,7 +14,7 @@
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
 
-void object_ship_wing_point_team::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
+void scripting::internal::ade_serializable_external<object_ship_wing_point_team>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
 	object_ship_wing_point_team oswpt;
 	value.getValue(scripting::api::l_OSWPT.Get(&oswpt));
 	uint8_t oswpttype = static_cast<uint8_t>(oswpt.type);
@@ -43,7 +43,7 @@ void object_ship_wing_point_team::serialize(lua_State* /*L*/, const scripting::a
 	}
 }
 
-void object_ship_wing_point_team::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
+void scripting::internal::ade_serializable_external<object_ship_wing_point_team>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
 	uint8_t oswpttype;
 	GET_DATA(oswpttype);
 	switch (static_cast<oswpt_type>(oswpttype)) {

--- a/code/scripting/api/objs/parse_object.h
+++ b/code/scripting/api/objs/parse_object.h
@@ -16,8 +16,8 @@ class parse_object_h {
 
 	bool isValid() const;
 
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+	static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+	static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 
 DECLARE_ADE_OBJ(l_ParseObject, parse_object_h);
@@ -34,8 +34,8 @@ class parse_subsys_h {
 
 	bool isValid() const;
 
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+	static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+	static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 
 DECLARE_ADE_OBJ(l_ParseSubsystem, parse_subsys_h);

--- a/code/scripting/api/objs/subsystem.h
+++ b/code/scripting/api/objs/subsystem.h
@@ -18,8 +18,8 @@ struct ship_subsys_h
 
 	bool isValid() const;
 
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+	static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+	static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 DECLARE_ADE_OBJ(l_Subsystem, ship_subsys_h);
 

--- a/code/scripting/api/objs/vecmath.cpp
+++ b/code/scripting/api/objs/vecmath.cpp
@@ -14,7 +14,7 @@ void scripting::internal::ade_serializable_external<vec3d>::serialize(lua_State*
 	ADD_VECTOR(vec);
 }
 
-void scripting::internal::ade_serializable_external<vec3d>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
+void scripting::internal::ade_serializable_external<vec3d>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) { // NOLINT
 	vec3d vec;
 	GET_VECTOR(vec);
 	new(data_ptr) vec3d(std::move(vec));

--- a/code/scripting/api/objs/vecmath.cpp
+++ b/code/scripting/api/objs/vecmath.cpp
@@ -8,13 +8,13 @@
 #include "network/multi.h"
 #include "network/multimsgs.h"
 
-void vec3d::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
+void scripting::internal::ade_serializable_external<vec3d>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
 	vec3d vec;
 	value.getValue(scripting::api::l_Vector.Get(&vec));
 	ADD_VECTOR(vec);
 }
 
-void vec3d::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
+void scripting::internal::ade_serializable_external<vec3d>::deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset) {
 	vec3d vec;
 	GET_VECTOR(vec);
 	new(data_ptr) vec3d(std::move(vec));

--- a/code/scripting/api/objs/vecmath.h
+++ b/code/scripting/api/objs/vecmath.h
@@ -45,8 +45,8 @@ struct matrix_h {
 
 	void SetStatus(MatrixState n_status);
 
-	void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
-	void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
+	static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+	static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 };
 
 DECLARE_ADE_OBJ(l_Matrix, matrix_h);

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1245,6 +1245,7 @@ add_file_folder("Scripting"
 	scripting/ade_args.h
 	scripting/ade_doc.cpp
 	scripting/ade_doc.h
+	scripting/ade_external_serializer.h
 	scripting/doc_html.cpp
 	scripting/doc_html.h
 	scripting/doc_json.cpp


### PR DESCRIPTION
Previously, RPC serialization methods were picked as follows:
1. If the lua object is marked as NO_MULTI (which is sensible for things that aren't synchronized on each client), don't allow serialization
2. Does the underlying C-type of the specific lua object have a ``serialize`` method, if so, use it.
3. Is the underlying C-type a fundamental type, then use builtin fundamental serializers.
4. If no serializer is available, don't allow serialization.

This had some issues for types that needed to be serializable, but were not constrained to the scripting code. These types, such as vec3d, the oswpt type, or object_h (which probably _should_ be constrained to the scripting code, but that's another can of worms), needed to have an ugly, scripting-API-specific serializer method.
This PR extends the serialization method dispatch with external serializer methods. These allow declaration of types that have serializer methods without them needing to be directly within the type.
Types that are within the scripting code only should still prefer to use serializer methods within the class, as they're easier to spot and diagnose if there is an issue.