### PR TITLE
improve model texture parsing

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -993,7 +993,7 @@ int model_create_instance(int objnum, int model_num);
 void model_delete_instance(int model_instance_num);
 
 // Goober5000
-void model_load_texture(polymodel *pm, int i, char *file);
+void model_load_texture(polymodel *pm, int i, const char *file);
 
 SCP_set<int> model_get_textures_used(const polymodel* pm, int submodel);
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2662,8 +2662,14 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 				//mprintf(0,"  num textures = %d\n",n);
 				for (i=0; i<n; i++ )
 				{
-					char tmp_name[256];
+					char tmp_name[127];
 					cfread_string_len(tmp_name,127,fp);
+					constexpr int max_buffer_size = MAX_FILENAME_LEN - 8;	// leave room for the longest suffix, "-reflect"
+					if (strlen(tmp_name) >= max_buffer_size)
+					{
+						Warning(LOCATION, "Model '%s', texture '%s' filename is too long!  Truncating to %d characters.", pm->filename, tmp_name, max_buffer_size - 1);
+						tmp_name[max_buffer_size - 1] = '\0';
+					}
 					model_load_texture(pm, i, tmp_name);
 					//mprintf(0,"<%s>\n",name_buf);
 				}
@@ -3121,7 +3127,7 @@ modelread_status read_and_process_model_file(polymodel* pm, const char* filename
 
 
 //Goober
-void model_load_texture(polymodel *pm, int i, char *file)
+void model_load_texture(polymodel *pm, int i, const char *file)
 {
 	// NOTE: it doesn't help to use more than MAX_FILENAME_LEN here as bmpman will use that restriction
 	//       we also have to make sure there is always a trailing NUL since overflow doesn't add it


### PR DESCRIPTION
Model textures that are too long will cause a very unfriendly and hard-to-track down "ERANGE: String" error.  The situation can be greatly improved by checking the string length ahead of time, printing a friendly Warning, and truncating the filename.  This will alert the modder to the source of the problem while also allowing gameplay to continue.