### PR TITLE
some timestamp refinements

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -180,7 +180,7 @@ UI_TIMESTAMP ui_timestamp() {
 
 TIMESTAMP timestamp_delta(TIMESTAMP stamp, int delta_ms)
 {
-	if (!stamp.isValid() || stamp.isNever())
+	if (!stamp.isFinite())
 		return stamp;
 
 	if (stamp.isImmediate())
@@ -191,7 +191,7 @@ TIMESTAMP timestamp_delta(TIMESTAMP stamp, int delta_ms)
 
 UI_TIMESTAMP ui_timestamp_delta(UI_TIMESTAMP stamp, int delta_ms)
 {
-	if (!stamp.isValid() || stamp.isNever())
+	if (!stamp.isFinite())
 		return stamp;
 
 	if (stamp.isImmediate())
@@ -334,8 +334,8 @@ int timestamp_until(int stamp)
 
 int timestamp_until(TIMESTAMP stamp)
 {
-	Assertion(stamp.isValid() && !stamp.isNever(), "timestamp_until was called with a%s timestamp!", !stamp.isValid() ? "n invalid" : " Never");
-	if (!stamp.isValid() || stamp.isNever())
+	Assertion(stamp.isFinite(), "timestamp_until was called with a%s timestamp!", !stamp.isValid() ? "n invalid" : " Never");
+	if (!stamp.isFinite())
 		return INT_MAX;
 
 	if (stamp.isImmediate())
@@ -346,8 +346,8 @@ int timestamp_until(TIMESTAMP stamp)
 
 int ui_timestamp_until(UI_TIMESTAMP stamp)
 {
-	Assertion(stamp.isValid() && !stamp.isNever(), "timestamp_until was called with a%s timestamp!", !stamp.isValid() ? "n invalid" : " Never");
-	if (!stamp.isValid() || stamp.isNever())
+	Assertion(stamp.isFinite(), "timestamp_until was called with a%s timestamp!", !stamp.isValid() ? "n invalid" : " Never");
+	if (!stamp.isFinite())
 		return INT_MAX;
 
 	if (stamp.isImmediate())
@@ -369,8 +369,8 @@ int timestamp_since(int stamp)
 
 int timestamp_since(TIMESTAMP stamp)
 {
-	Assertion(stamp.isValid() && !stamp.isNever(), "timestamp_since was called with a%s timestamp!", !stamp.isValid() ? "n invalid" : " Never");
-	if (!stamp.isValid() || stamp.isNever())
+	Assertion(stamp.isFinite(), "timestamp_since was called with a%s timestamp!", !stamp.isValid() ? "n invalid" : " Never");
+	if (!stamp.isFinite())
 		return INT_MIN;
 
 	if (stamp.isImmediate())
@@ -381,8 +381,8 @@ int timestamp_since(TIMESTAMP stamp)
 
 int ui_timestamp_since(UI_TIMESTAMP stamp)
 {
-	Assertion(stamp.isValid() && !stamp.isNever(), "timestamp_since was called with a%s timestamp!", !stamp.isValid() ? "n invalid" : " Never");
-	if (!stamp.isValid() || stamp.isNever())
+	Assertion(stamp.isFinite(), "timestamp_since was called with a%s timestamp!", !stamp.isValid() ? "n invalid" : " Never");
+	if (!stamp.isFinite())
 		return INT_MIN;
 
 	if (stamp.isImmediate())
@@ -463,9 +463,9 @@ int ui_timestamp_compare(UI_TIMESTAMP t1, UI_TIMESTAMP t2)
 
 bool timestamp_in_between(TIMESTAMP stamp, TIMESTAMP before, TIMESTAMP after)
 {
-	Assertion(stamp.isValid() && !stamp.isNever(), "timestamp_in_between was called with a%s 'stamp' timestamp!", !stamp.isValid() ? "n invalid" : " Never");
-	Assertion(before.isValid() && !before.isNever(), "timestamp_in_between was called with a%s 'before' timestamp!", !before.isValid() ? "n invalid" : " Never");
-	Assertion(after.isValid() && !after.isNever(), "timestamp_in_between was called with a%s 'after' timestamp!", !after.isValid() ? "n invalid" : " Never");
+	Assertion(stamp.isFinite(), "timestamp_in_between was called with a%s 'stamp' timestamp!", !stamp.isValid() ? "n invalid" : " Never");
+	Assertion(before.isFinite(), "timestamp_in_between was called with a%s 'before' timestamp!", !before.isValid() ? "n invalid" : " Never");
+	Assertion(after.isFinite(), "timestamp_in_between was called with a%s 'after' timestamp!", !after.isValid() ? "n invalid" : " Never");
 
 	if (!stamp.isValid() || !before.isValid() || !after.isValid())
 		return false;
@@ -475,9 +475,9 @@ bool timestamp_in_between(TIMESTAMP stamp, TIMESTAMP before, TIMESTAMP after)
 
 bool ui_timestamp_in_between(UI_TIMESTAMP stamp, UI_TIMESTAMP before, UI_TIMESTAMP after)
 {
-	Assertion(stamp.isValid() && !stamp.isNever(), "ui_timestamp_in_between was called with a%s 'stamp' timestamp!", !stamp.isValid() ? "n invalid" : " Never");
-	Assertion(before.isValid() && !before.isNever(), "ui_timestamp_in_between was called with a%s 'before' timestamp!", !before.isValid() ? "n invalid" : " Never");
-	Assertion(after.isValid() && !after.isNever(), "ui_timestamp_in_between was called with a%s 'after' timestamp!", !after.isValid() ? "n invalid" : " Never");
+	Assertion(stamp.isFinite(), "ui_timestamp_in_between was called with a%s 'stamp' timestamp!", !stamp.isValid() ? "n invalid" : " Never");
+	Assertion(before.isFinite(), "ui_timestamp_in_between was called with a%s 'before' timestamp!", !before.isValid() ? "n invalid" : " Never");
+	Assertion(after.isFinite(), "ui_timestamp_in_between was called with a%s 'after' timestamp!", !after.isValid() ? "n invalid" : " Never");
 
 	if (!stamp.isValid() || !before.isValid() || !after.isValid())
 		return false;
@@ -494,7 +494,7 @@ bool timestamp_elapsed(int stamp) {
 }
 
 bool timestamp_elapsed(TIMESTAMP stamp) {
-	if (!stamp.isValid() || stamp.isNever()) {
+	if (!stamp.isFinite()) {
 		return false;
 	}
 	if (stamp.isImmediate()) {
@@ -505,7 +505,7 @@ bool timestamp_elapsed(TIMESTAMP stamp) {
 }
 
 bool ui_timestamp_elapsed(UI_TIMESTAMP ui_stamp) {
-	if (!ui_stamp.isValid() || ui_stamp.isNever()) {
+	if (!ui_stamp.isFinite()) {
 		return false;
 	}
 	if (ui_stamp.isImmediate()) {
@@ -516,7 +516,7 @@ bool ui_timestamp_elapsed(UI_TIMESTAMP ui_stamp) {
 }
 
 bool timestamp_elapsed_last_frame(TIMESTAMP stamp) {
-	if (!stamp.isValid() || stamp.isNever()) {
+	if (!stamp.isFinite()) {
 		return false;
 	}
 	if (stamp.isImmediate()) {
@@ -527,7 +527,7 @@ bool timestamp_elapsed_last_frame(TIMESTAMP stamp) {
 }
 
 bool ui_timestamp_elapsed_last_frame(UI_TIMESTAMP ui_stamp) {
-	if (!ui_stamp.isValid() || ui_stamp.isNever()) {
+	if (!ui_stamp.isFinite()) {
 		return false;
 	}
 	if (ui_stamp.isImmediate()) {
@@ -546,7 +546,7 @@ bool timestamp_elapsed_safe(int a, int b) {
 }
 
 bool timestamp_elapsed_safe(TIMESTAMP a, int b) {
-	if (!a.isValid() || a.isNever()) {
+	if (!a.isFinite()) {
 		return false;
 	}
 	if (a.isImmediate()) {
@@ -557,7 +557,7 @@ bool timestamp_elapsed_safe(TIMESTAMP a, int b) {
 }
 
 bool ui_timestamp_elapsed_safe(UI_TIMESTAMP a, int b) {
-	if (!a.isValid() || a.isNever()) {
+	if (!a.isFinite()) {
 		return false;
 	}
 	if (a.isImmediate()) {

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -180,16 +180,22 @@ UI_TIMESTAMP ui_timestamp() {
 
 TIMESTAMP timestamp_delta(TIMESTAMP stamp, int delta_ms)
 {
-	if (!stamp.isValid() || stamp.isImmediate() || stamp.isNever())
+	if (!stamp.isValid() || stamp.isNever())
 		return stamp;
+
+	if (stamp.isImmediate())
+		return TIMESTAMP(timestamp_ms() + delta_ms);
 
 	return TIMESTAMP(stamp.value() + delta_ms);
 }
 
 UI_TIMESTAMP ui_timestamp_delta(UI_TIMESTAMP stamp, int delta_ms)
 {
-	if (!stamp.isValid() || stamp.isImmediate() || stamp.isNever())
+	if (!stamp.isValid() || stamp.isNever())
 		return stamp;
+
+	if (stamp.isImmediate())
+		return UI_TIMESTAMP(timer_get_milliseconds() + delta_ms);
 
 	return UI_TIMESTAMP(stamp.value() + delta_ms);
 }
@@ -300,7 +306,7 @@ UI_TIMESTAMP ui_timestamp(int delta_ms) {
 int timestamp_until(int stamp)
 {
 	// handle special values
-	if (stamp < 0)
+	if (stamp <= 0)
 		return INT_MAX;
 	if (stamp == 1)
 		return 0;
@@ -353,7 +359,7 @@ int ui_timestamp_until(UI_TIMESTAMP stamp)
 int timestamp_since(int stamp)
 {
 	// handle special values
-	if (stamp < 0)
+	if (stamp <= 0)
 		return INT_MIN;
 	if (stamp == 1)
 		return 0;

--- a/code/io/timer.h
+++ b/code/io/timer.h
@@ -47,6 +47,7 @@ public:
 
 	inline bool isNever() const { return m_val == 0; }
 	inline bool isImmediate() const { return m_val == 1; }
+	inline bool isFinite() const { return isValid() && !isNever(); }
 };
 
 // Timestamp measuring game time.  Sensitive to time compression and pausing.
@@ -63,6 +64,7 @@ public:
 
 	inline bool isNever() const { return m_val == 0; }
 	inline bool isImmediate() const { return m_val == 1; }
+	inline bool isFinite() const { return isValid() && !isNever(); }
 };
 
 // For converting from old-style timestamps:

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -475,7 +475,7 @@ int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 
 	// need to try to make rollback shot make some kind of sense if we have invalid timestamps,
 	// and print to debugif it is.
-	if (!target_timestamp.isValid() || target_timestamp.isNever()) {
+	if (!target_timestamp.isFinite()) {
 		mprintf(("Nonsense timestamp in multi_ship_record_find_frame of %s. Get ~~Allender~~ Cyborg!\n", (target_timestamp.isValid()) ? "isNever" : "NOT isValid"));
 		return frame;
 	};
@@ -484,7 +484,7 @@ int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 
 		// need to try to make rollback shot make some kind of sense if we have invalid timestamps,
 		// and print to debug if it is.	  No need to trigger the Assert in timestamp_in_between, as it is minor here. (i + 1 should be check on previous iteration, most of the time)
-		if (!Oo_info.timestamps[i].isValid() || Oo_info.timestamps[i].isNever()) {
+		if (!Oo_info.timestamps[i].isFinite()) {
 			mprintf(("timestamps[i] is %s, get ~~Allender~~ Cyborg!\n", (Oo_info.timestamps[i].isValid()) ? "isNever" : "invalid"));
 			return frame;
 		}
@@ -500,7 +500,7 @@ int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 
 	// need to try to make rollback shot make some kind of sense if we have invalid timestamps,
 	// and print to debug if it is. No need to trigger the Assert in timestamp_in_between, as it is minor here.
-	if (!Oo_info.timestamps[MAX_FRAMES_RECORDED - 1].isValid() || Oo_info.timestamps[MAX_FRAMES_RECORDED - 1].isNever()) {
+	if (!Oo_info.timestamps[MAX_FRAMES_RECORDED - 1].isFinite()) {
 			mprintf(("timestamps[MAX_FRAMES_FRAMES_RECORDED - 1] is %s, get ~~Allender~~ Cyborg!\n", (Oo_info.timestamps[MAX_FRAMES_RECORDED - 1].isValid()) ? "isNever" : "invalid"));
 			return frame;
 	}
@@ -521,7 +521,7 @@ int multi_ship_record_find_frame(int client_frame, int time_elapsed)
 	for (int i = MAX_FRAMES_RECORDED - 2; i > Oo_info.cur_frame_index; i--) {
 		// need to try to make rollback shot make some kind of sense if we have invalid timestamps,
 		// and print to debug if it is. No need to trigger the Assert in timestamp_in_between, as it is minor here.
-		if (!Oo_info.timestamps[i].isValid() || Oo_info.timestamps[i].isNever()) {
+		if (!Oo_info.timestamps[i].isFinite()) {
 			mprintf(("timestamps[i] is %s, get ~~Allender~~ Cyborg!\n", (Oo_info.timestamps[i].isValid()) ? "isNever" : "invalid"));
 			return frame;
 		}


### PR DESCRIPTION
1. Make sure the legacy `timestamp_until()` and `timestamp_since()` functions check for any type of invalid timestamp
2. Add a useful `isFinite()` function
3. A timestamp delta on an immediate timestamp is more properly the actual delta, rather than another immediate timestamp