### PR TITLE
parameter deconfliction

### DIFF
--- a/code/scripting/ade_external_serializer.h
+++ b/code/scripting/ade_external_serializer.h
@@ -18,19 +18,19 @@ namespace scripting {
 
 		template<>
 		struct ade_serializable_external<vec3d> : std::true_type {
-			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& luaValue, ubyte* data, int& packet_size);
 			static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 		};
 
 		template<>
 		struct ade_serializable_external<object_ship_wing_point_team> : std::true_type {
-			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& luaValue, ubyte* data, int& packet_size);
 			static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 		};
 
 		template<>
 		struct ade_serializable_external<object_h> : std::true_type {
-			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size);
+			static void serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& luaValue, ubyte* data, int& packet_size);
 			static void deserialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, char* data_ptr, ubyte* data, int& offset);
 		};
 	}

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -26,9 +26,9 @@
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
 
-void scripting::internal::ade_serializable_external<object_h>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
+void scripting::internal::ade_serializable_external<object_h>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& luaValue, ubyte* data, int& packet_size) {
 	object_h obj;
-	value.getValue(scripting::api::l_Object.Get(&obj));
+	luaValue.getValue(scripting::api::l_Object.Get(&obj));
 	const ushort& netsig = obj.isValid() ? obj.objp()->net_signature : 0;
 	ADD_USHORT(netsig);
 }

--- a/code/scripting/api/objs/oswpt.cpp
+++ b/code/scripting/api/objs/oswpt.cpp
@@ -14,9 +14,9 @@
 #include "network/multimsgs.h"
 #include "network/multiutil.h"
 
-void scripting::internal::ade_serializable_external<object_ship_wing_point_team>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
+void scripting::internal::ade_serializable_external<object_ship_wing_point_team>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& luaValue, ubyte* data, int& packet_size) {
 	object_ship_wing_point_team oswpt;
-	value.getValue(scripting::api::l_OSWPT.Get(&oswpt));
+	luaValue.getValue(scripting::api::l_OSWPT.Get(&oswpt));
 	uint8_t oswpttype = static_cast<uint8_t>(oswpt.type);
 	ADD_DATA(oswpttype);
 	switch (oswpt.type) {

--- a/code/scripting/api/objs/vecmath.cpp
+++ b/code/scripting/api/objs/vecmath.cpp
@@ -8,9 +8,9 @@
 #include "network/multi.h"
 #include "network/multimsgs.h"
 
-void scripting::internal::ade_serializable_external<vec3d>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& value, ubyte* data, int& packet_size) {
+void scripting::internal::ade_serializable_external<vec3d>::serialize(lua_State* /*L*/, const scripting::ade_table_entry& /*tableEntry*/, const luacpp::LuaValue& luaValue, ubyte* data, int& packet_size) {
 	vec3d vec;
-	value.getValue(scripting::api::l_Vector.Get(&vec));
+	luaValue.getValue(scripting::api::l_Vector.Get(&vec));
 	ADD_VECTOR(vec);
 }
 


### PR DESCRIPTION
Prevent compiler warnings caused by the `value` parameter of the external serializers hiding the `value` member of `std::integral_constant`.

Follow-up to #6276.