### PR TITLE
add is-species SEXP operator

### DIFF
--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -416,14 +416,15 @@ enum : int {
 	OP_NUM_SHIPS_IN_BATTLE,	// phreak
 	OP_CURRENT_SPEED, // WMCoolmon
 	OP_IS_IFF,	// Goober5000
+	OP_IS_SPECIES,	// Goober5000
 	OP_NUM_WITHIN_BOX,	// WMCoolmon
 	OP_SCRIPT_EVAL_NUM, // WMCoolmon
 	OP_SCRIPT_EVAL_STRING, // WMCoolmon
 	OP_NUM_SHIPS_IN_WING,	// Karajorma
 	OP_GET_PRIMARY_AMMO, // Karajorma
 	OP_GET_SECONDARY_AMMO, // Karajorma
+
 	OP_NUM_ASSISTS, // Karajorma
-	
 	OP_SHIP_SCORE, // Karajorma
 	OP_SHIP_DEATHS, // Karajorma
 	OP_RESPAWNS_LEFT, // Karajorma
@@ -434,7 +435,6 @@ enum : int {
 	OP_PRIMARY_FIRED_SINCE, // Karajorma
 	OP_SECONDARY_FIRED_SINCE, // Karajorma
 	OP_CUTSCENES_GET_FOV, // Echelon9
-	OP_GET_THROTTLE_SPEED, // Karajorma
 	OP_HITS_LEFT_SUBSYSTEM_GENERIC, // Goober5000
 	OP_HITS_LEFT_SUBSYSTEM_SPECIFIC, // Goober5000
 	OP_GET_OBJECT_PITCH,	// Goober5000
@@ -456,12 +456,14 @@ enum : int {
 	OP_IS_IN_BOX, // Sushi
 	OP_IS_IN_MISSION, // Goober5000
 	OP_ARE_SHIP_FLAGS_SET, // Karajorma
+	OP_ARE_WING_FLAGS_SET, // Goober5000
+
+	OP_GET_THROTTLE_SPEED, // Karajorma
+	OP_HAS_ARMOR_TYPE, // MjnMixael
 	OP_TURRET_GET_PRIMARY_AMMO, // DahBlount, part of the turret ammo code
+	OP_TURRET_GET_SECONDARY_AMMO,	// DahBlount, part of the turret ammo code
 	OP_TURRET_HAS_PRIMARY_WEAPON,      // MjnMixael
 	OP_TURRET_HAS_SECONDARY_WEAPON, // MjnMixael
-	OP_HAS_ARMOR_TYPE, // MjnMixael
-	
-	OP_TURRET_GET_SECONDARY_AMMO,	// DahBlount, part of the turret ammo code
 	OP_IS_DOCKED,	// Goober5000
 	OP_IS_IN_TURRET_FOV,	// Goober5000
 	OP_GET_HOTKEY, // wookieejedi
@@ -472,13 +474,12 @@ enum : int {
 	OP_SCRIPT_EVAL_BOOL, // Goober5000
 	OP_IS_CONTAINER_EMPTY,	// Karajorma/jg18
 	OP_GET_CONTAINER_SIZE,	// Karajorma/jg18
+
 	OP_LIST_HAS_DATA,	// Karajorma/jg18
 	OP_LIST_DATA_INDEX,	// Karajorma/jg18
 	OP_MAP_HAS_KEY,	// Karajorma/jg18
 	OP_MAP_HAS_DATA_ITEM,	// Karajorma/jg18
 	OP_ANGLE_FVEC_TARGET, // Lafiel
-	
-	OP_ARE_WING_FLAGS_SET, // Goober5000
 	OP_IS_SHIP_EMP_ACTIVE,	// MjnMixael
 	OP_PLAYER_IS_CHEATING_BASTARD,	// The E
 	OP_TURRET_FIRED_SINCE,	// Asteroth


### PR DESCRIPTION
As noted on Discord, there was previously no `is-species` operator.  Now there is.

As a bonus, this also fixes a bug where the pre-existing `is-iff` operator did not work with wings that had not yet arrived.

Tested and handles all possibilities.