### PR TITLE
fix a minor bug with directive marking

### DIFF
--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -418,8 +418,8 @@ int comp_training_lines_by_born_on_date(const int *e1, const int *e2)
  *
  * Sort on EVENT_CURRENT and born on date, for other events (EVENT_SATISFIED, EVENT_FAILED) sort on born on date
  */
-#define MIN_SATISFIED_TIME		5
-#define MIN_FAILED_TIME			7
+#define MIN_SATISFIED_TIME		5 * MILLISECONDS_PER_SECOND
+#define MIN_FAILED_TIME			7 * MILLISECONDS_PER_SECOND
 void sort_training_objectives()
 {
 	int i, offset;


### PR DESCRIPTION
Fix units are denominated in seconds, while timestamp units are denominated in milliseconds.  This fixes the directive timing check which, after the timestamp upgrade, would time out after 5 and 7 milliseconds instead of 5 and 7 seconds.

Follow-up to #4633.