### PR TITLE
Fix renderLeadCurrentTarget

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4108,9 +4108,10 @@ void HudGaugeLeadIndicator::renderLeadCurrentTarget()
 			renderIndicator(frame_offset, targetp, &lead_target_pos);
 		}
 	}
-	//Cyborg - this `else return;` would force the secondary indicator off if a dumbfire had a longer range than the primaries.
-	//Sure this is not a very common case, but we're safe from any ill effects because we're not going to try to render 
-	//any primary indicators after this point anyway (the first argument for renderIndicator is forced to 0 below).  
+	//Cyborg - this `else return;` would force the secondary indicator off if no primaries are available.
+	//Sure this is not a very common case, but we don't need the early return.
+	//We are safe from any ill effects because we're not going to try to render any primary indicators 
+	//after this point anyway (the first argument for renderIndicator is forced to 0 below).  
 	//Anyone who rewrites this function to somehow re-evaluate primary indicators will have to revist this.
 	//else return;
 


### PR DESCRIPTION
This fixes an edge case in the Average and Multiple modes, where secondary lead indicator rendering was skipped by continue statements when the primary weapons were out of range.   I also added some comments that help people actually understand what this function does as it is very confusing.

Also this remove the return on the else.  I have looked over this function for a long time.  It doesn't need the return because that return will be reached when there are no valid primary weapons, but everything after it only has to do with secondary weapon indicator rendering.

I did test it, but I could use some independent verification that this didn't break any indicator behavior, although it really shouldn't.

Fixes #5088 