### PR TITLE
safety check for lua_tostring()

### DIFF
--- a/code/globalincs/utility.h
+++ b/code/globalincs/utility.h
@@ -309,4 +309,12 @@ int find_item_with_name(const VECTOR_T& item_vector, const SCP_string& str)
 	return -1;
 }
 
+template <typename NULLISH_T>
+NULLISH_T coalesce(NULLISH_T possibly_null, NULLISH_T value_if_null)
+{
+	Assertion(value_if_null != nullptr, "value_if_null can never be null itself!");
+
+	return (possibly_null != nullptr) ? possibly_null : value_if_null;
+}
+
 #endif

--- a/code/osapi/dialogs.cpp
+++ b/code/osapi/dialogs.cpp
@@ -156,7 +156,7 @@ namespace os
 			//error handler for Lua.
 			if (format == NULL)
 			{
-				msgStream << "LUA ERROR: " << lua_tostring(L, -1);
+				msgStream << "LUA ERROR: " << lua_tostring_nullsafe(L, -1);
 				lua_pop(L, -1);
 			}
 			else
@@ -186,9 +186,9 @@ namespace os
 				lua_remove(L, -2);
 
 				if (lua_pcall(L, 0, 1, 0) != 0)
-					msgStream << "Error while retrieving stack: " << lua_tostring(L, -1);
+					msgStream << "Error while retrieving stack: " << lua_tostring_nullsafe(L, -1);
 				else
-					msgStream << lua_tostring(L, -1);
+					msgStream << lua_tostring_nullsafe(L, -1);
 
 				lua_pop(L, 1);
 			}

--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -172,9 +172,9 @@ int ade_index_handler(lua_State* L) {
 	lua_pop(L, 1);    //WMC - metatable
 
 	if (type_name != nullptr) {
-		LuaError(L, "Could not find index '%s' in type '%s'", lua_tostring(L, key_ldx), type_name);
+		LuaError(L, "Could not find index '%s' in type '%s'", lua_tostring_nullsafe(L, key_ldx), type_name);
 	} else {
-		LuaError(L, "Could not find index '%s'", lua_tostring(L, key_ldx));
+		LuaError(L, "Could not find index '%s'", lua_tostring_nullsafe(L, key_ldx));
 	}
 	return 0;
 }
@@ -264,7 +264,7 @@ const SCP_vector<SCP_string>& ade_manager::getTypeNames() const { return _type_n
 
 static int deprecatedFunctionHandler(lua_State* L)
 {
-	const char* functionName = lua_tostring(L, lua_upvalueindex(1));
+	const char* functionName = lua_tostring_nullsafe(L, lua_upvalueindex(1));
 	LuaError(L,
 			 "Deprecated function '%s' has been called that is not available in the targeted engine version. Check "
 			 "the documentation for a possible replacement.",
@@ -839,7 +839,7 @@ SCP_string ade_tostring(lua_State *L, int argnum, bool add_typeinfo)
 			break;
 
 		case LUA_TSTRING:
-			s = lua_tostring(L, argnum);
+			s = lua_tostring_nullsafe(L, argnum);
 			if (add_typeinfo)
 				sprintf(buf, "String [%s]", s);
 			else
@@ -868,13 +868,10 @@ SCP_string ade_tostring(lua_State *L, int argnum, bool add_typeinfo)
 				lua_pushnil(L);
 				if (lua_next(L, argnum))
 				{
-					firstkey = lua_tostring(L, -2);
-					if (firstkey != nullptr)
-					{
-						buf += ", First key: [";
-						buf += firstkey;
-						buf += "]";
-					}
+					firstkey = lua_tostring_nullsafe(L, -2);
+					buf += ", First key: [";
+					buf += firstkey;
+					buf += "]";
 					lua_pop(L, 1);	//Key
 				}
 				lua_pop(L, 1);	//Nil
@@ -889,7 +886,7 @@ SCP_string ade_tostring(lua_State *L, int argnum, bool add_typeinfo)
 			if (upname != nullptr)
 			{
 				buf += " ";
-				buf += lua_tostring(L, -1);
+				buf += lua_tostring_nullsafe(L, -1);
 				buf += "()";
 				lua_pop(L, 1);
 			}
@@ -922,7 +919,7 @@ SCP_string ade_tostring(lua_State *L, int argnum, bool add_typeinfo)
 
 		default:
 			if (add_typeinfo)
-				sprintf(buf, "<UNKNOWN>: %s (%f) (%s)", lua_typename(L, type), lua_tonumber(L, argnum), lua_tostring(L, argnum));
+				sprintf(buf, "<UNKNOWN>: %s (%f) (%s)", lua_typename(L, type), lua_tonumber(L, argnum), lua_tostring_nullsafe(L, argnum));
 			else
 				buf = "Unknown Lua type";
 			break;

--- a/code/scripting/ade.h
+++ b/code/scripting/ade.h
@@ -6,6 +6,7 @@
 
 #include "globalincs/pstypes.h"
 #include "globalincs/version.h"
+#include "globalincs/utility.h"
 
 #include "object/object.h"
 #include "scripting/ade_doc.h"
@@ -25,6 +26,8 @@ extern "C" {
  * These functions enable the code to communicate with external scripts and expose an API for them to use
  */
 
+// lua_tostring will return NULL if and only if it cannot convert to a string; nil values are converted to "nil"
+#define lua_tostring_nullsafe(L,i)	coalesce(lua_tostring(L,i), "<UNABLE TO CONVERT TO STRING>")
 
 namespace scripting {
 

--- a/code/scripting/ade_args.cpp
+++ b/code/scripting/ade_args.cpp
@@ -38,7 +38,7 @@ bool get_single_arg(lua_State* L, const get_args_state& state, char fmt, const c
 	Assertion(fmt == 's', "Invalid character '%c' for string type!", fmt);
 
 	if (lua_isstring(L, state.nargs)) {
-		auto value = lua_tostring(L, state.nargs);
+		auto value = lua_tostring_nullsafe(L, state.nargs);
 
 		if (Unicode_text_mode) {
 			// Validate the string when we are in unicode mode to ensure that FSO doesn't just crash when a

--- a/code/scripting/ade_args.h
+++ b/code/scripting/ade_args.h
@@ -235,7 +235,7 @@ inline int ade_get_args(lua_State* L, const char* fmt, Args&&... args)
 		// WMC - Try and get at function name from upvalue
 		if (!get_args_lfunction && !lua_isnone(L, lua_upvalueindex(ADE_FUNCNAME_UPVALUE_INDEX))) {
 			if (lua_type(L, lua_upvalueindex(ADE_FUNCNAME_UPVALUE_INDEX)) == LUA_TSTRING)
-				strcpy_s(state.funcname, lua_tostring(L, lua_upvalueindex(ADE_FUNCNAME_UPVALUE_INDEX)));
+				strcpy_s(state.funcname, lua_tostring_nullsafe(L, lua_upvalueindex(ADE_FUNCNAME_UPVALUE_INDEX)));
 		}
 
 		// WMC - Totally unknown function

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -86,7 +86,7 @@ ADE_FUNC(error, l_Base, "string Message", "Displays a FreeSpace error message wi
 	if (Cmdline_lua_devmode) {
 		nprintf(("scripting", "ERROR: %s\n", str.c_str()));
 	} else {
-		Error(LOCATION, "%s", lua_tostring(L, -1));
+		Error(LOCATION, "%s", lua_tostring_nullsafe(L, -1));
 	}
 
 	return ADE_RETURN_NIL;

--- a/code/scripting/api/objs/file.cpp
+++ b/code/scripting/api/objs/file.cpp
@@ -132,7 +132,7 @@ ADE_FUNC(read,
 		//int num = 0;
 		if (type == LUA_TSTRING)
 		{
-			fmt = lua_tostring(L, i);
+			fmt = lua_tostring_nullsafe(L, i);
 			if (!stricmp(fmt, "*n"))
 			{
 				double d = 0.0f;
@@ -280,7 +280,7 @@ ADE_FUNC(write, l_File, "string|number, any...",
 	{
 		if (type == LUA_TSTRING)
 		{
-			auto s = lua_tostring(L, l_pos);
+			auto s = lua_tostring_nullsafe(L, l_pos);
 			if (cfwrite(s, (int)sizeof(char), (int)strlen(s), cfp->get()))
 				num_successful++;
 		}


### PR DESCRIPTION
The return value of `lua_tostring()` is NULL if (and only if) the string conversion failed.  Many places in the code did not check for this situation, which led to the crash in #6290.

Fixes #6290.