### PR TITLE
Remove some int3s from offscreen indicator drawing

### DIFF
--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6541,7 +6541,7 @@ void HudGaugeOffscreen::calculatePosition(vertex* target_point, vec3d *tpos, vec
 	g3_project_vertex(eye_vertex);
 
 	if (eye_vertex->flags&PF_OVERFLOW) {
-		Int3();			//	This is unlikely to happen, but can if a clip goes through the player's eye.
+		//	This is unlikely to happen, but can if a clip goes through the player's eye.
 		Player_ai->target_objnum = -1;
 		if (!in_frame)
 			g3_end_frame();
@@ -6604,7 +6604,6 @@ void HudGaugeOffscreen::calculatePosition(vertex* target_point, vec3d *tpos, vec
 			xpos = gr_screen.clip_right_unscaled - half_gauge_length;
 
 	} else {
-		Int3();
 		if (!in_frame)
 			g3_end_frame();
 		return;

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6542,7 +6542,6 @@ void HudGaugeOffscreen::calculatePosition(vertex* target_point, vec3d *tpos, vec
 
 	if (eye_vertex->flags&PF_OVERFLOW) {
 		//	This is unlikely to happen, but can if a clip goes through the player's eye.
-		Player_ai->target_objnum = -1;
 		if (!in_frame)
 			g3_end_frame();
 		return;


### PR DESCRIPTION
Under some very odd scenarios the math for doing an offscreen indicator might not get a valid position, but there's 0 reason to `int3()` about it.

Users *have* run into it, and I have not investigated it, but Mjn has to some extent: "This is something with 4k resolution. I suspect an actual engine bug. Something about BtA is causing xpos in the HudGaugeOffscreen::calculatePosition to be larger than 0.. at least in my reproductions.. and that is not expected."

But if this is a matter of an errant frame or two, I'm not sure trying to keep this around is worth the hassle. In both cases, the function will simply abort and not render the indicator.