### PR TITLE
Upgraded Asteroid Field SEXPs

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -702,7 +702,7 @@ void remove_all_asteroids()
 }
 
 // will replace any existing asteroid or debris field with an asteroid field
-void asteroid_create_asteroid_field(int num_asteroids, int field_type, int asteroid_speed, bool brown, bool blue, bool orange, vec3d o_min, vec3d o_max, bool inner_box, vec3d i_min, vec3d i_max, SCP_vector<SCP_string> targets)
+void asteroid_create_asteroid_field(int num_asteroids, int field_type, int asteroid_speed, vec3d o_min, vec3d o_max, bool inner_box, vec3d i_min, vec3d i_max, SCP_vector<SCP_string> asteroid_types)
 {
 	remove_all_asteroids();
 
@@ -740,15 +740,7 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 
 	Asteroid_field.field_asteroid_type.clear();
 
-	if (brown) {
-		Asteroid_field.field_asteroid_type.push_back("Brown");
-	}
-	if (blue) {
-		Asteroid_field.field_asteroid_type.push_back("Blue");
-	}
-	if (orange) {
-		Asteroid_field.field_asteroid_type.push_back("Orange");
-	}
+	Asteroid_field.field_asteroid_type = std::move(asteroid_types);
 
 	Asteroid_field.min_bound = o_min;
 	Asteroid_field.max_bound = o_max;
@@ -765,8 +757,6 @@ void asteroid_create_asteroid_field(int num_asteroids, int field_type, int aster
 		Asteroid_field.inner_min_bound = i_min;
 		Asteroid_field.inner_max_bound = i_max;
 	}
-
-	Asteroid_field.target_names = std::move(targets);
 
 	// Only create asteroids if we have some to create
 	if ((!Asteroid_field.field_asteroid_type.empty()) && (num_asteroids > 0)) {

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -163,7 +163,7 @@ bool    asteroid_is_within_view(vec3d *pos, float range, bool range_override = f
 void	asteroid_level_init();
 void	asteroid_level_close();
 void	asteroid_create_all();
-void	asteroid_create_asteroid_field(int num_asteroids, int field_type, int asteroid_speed, bool brown, bool blue, bool orange, vec3d o_min, vec3d o_max, bool inner_box, vec3d i_min, vec3d i_max, SCP_vector<SCP_string> targets);
+void	asteroid_create_asteroid_field(int num_asteroids, int field_type, int asteroid_speed, vec3d o_min, vec3d o_max, bool inner_box, vec3d i_min, vec3d i_max, SCP_vector<SCP_string> asteroid_types);
 void	asteroid_create_debris_field(int num_asteroids, int asteroid_speed, SCP_vector<int> debris_types, vec3d o_min, vec3d o_max, bool enhanced);
 void	asteroid_render(object* obj, model_draw_list* scene);
 void	asteroid_delete( object *asteroid_objp );

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -16679,26 +16679,27 @@ void sexp_config_field_targets(int n)
 	}
 
 	if (targets.size() == 0) {
-		if (!toggle) {
-			Asteroid_field.target_names.clear();
-		} else {
+		if (toggle) {
 			// No ships provided to add so abort
 			return;
-		}
-	}
-
-	if (toggle) {
-		// Add the targets
-		for (const auto& ship : targets) {
-			// Check if the ship is already in the target_names
-			if (std::find(Asteroid_field.target_names.begin(), Asteroid_field.target_names.end(), ship) == Asteroid_field.target_names.end()) {
-				Asteroid_field.target_names.push_back(ship);
-			}
+		} else {
+			Asteroid_field.target_names.clear();
+			return;
 		}
 	} else {
-		// Remove the targets
-		for (const auto& ship : targets) {
-			Asteroid_field.target_names.erase(std::remove(Asteroid_field.target_names.begin(), Asteroid_field.target_names.end(), ship), Asteroid_field.target_names.end());
+		if (toggle) {
+			// Add the targets
+			for (const auto& ship : targets) {
+				// Check if the ship is already in the target_names
+				if (std::find(Asteroid_field.target_names.begin(), Asteroid_field.target_names.end(), ship) == Asteroid_field.target_names.end()) {
+					Asteroid_field.target_names.push_back(ship);
+				}
+			}
+		} else {
+			// Remove the targets
+			for (const auto& ship : targets) {
+				Asteroid_field.target_names.erase(std::remove(Asteroid_field.target_names.begin(), Asteroid_field.target_names.end(), ship), Asteroid_field.target_names.end());
+			}
 		}
 	}
 }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4059,6 +4059,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 					for (const auto& item : list) {
 						if (!stricmp(CTEXT(node), item.c_str())) {
 							valid = true;
+							break;
 						}
 					}
 
@@ -16703,7 +16704,7 @@ void sexp_config_asteroid_field(int n)
 				}
 			}
 
-			asteroid_types.push_back(CTEXT(n));
+			asteroid_types.emplace_back(CTEXT(n));
 		}
 	}
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -16489,7 +16489,7 @@ void sexp_set_asteroid_field(int n, bool new_sexp)
 	SCP_vector<SCP_string> targets;
 	if (!new_sexp) {
 		if (n >= 0) {
-			for (; n >= 0; true ? n = CDR(n) : n = -1) {
+			for (; n >= 0;n = CDR(n)) {
 				auto ship_entry = eval_ship(n);
 				if (!ship_entry)
 					continue;
@@ -16500,7 +16500,7 @@ void sexp_set_asteroid_field(int n, bool new_sexp)
 	} else {
 		if (n >= 0) {
 			auto list = get_list_valid_asteroid_subtypes();
-			for (; n >= 0; true ? n = CDR(n) : n = -1) {
+			for (; n >= 0;n = CDR(n)) {
 
 				// Verify that it's a valid asteroid type
 				for (const auto& item : list) {
@@ -16565,7 +16565,7 @@ void sexp_set_debris_field(int n, bool new_sexp)
 	if (!new_sexp) {
 		if (n >= 0) {
 			int debris1 = get_asteroid_index(CTEXT(n));
-			if (debris1 > 0) {
+			if (debris1 >= 0) {
 				debris_types.push_back(debris1);
 			}
 			n = CDR(n);
@@ -16573,7 +16573,7 @@ void sexp_set_debris_field(int n, bool new_sexp)
 
 		if (n >= 0) {
 			int debris2 = get_asteroid_index(CTEXT(n));
-			if (debris2 > 0) {
+			if (debris2 >= 0) {
 				debris_types.push_back(debris2);
 			}
 			n = CDR(n);
@@ -16581,7 +16581,7 @@ void sexp_set_debris_field(int n, bool new_sexp)
 
 		if (n >= 0) {
 			int debris3 = get_asteroid_index(CTEXT(n));
-			if (debris3 > 0) {
+			if (debris3 >= 0) {
 				debris_types.push_back(debris3);
 			}
 			n = CDR(n);
@@ -16628,7 +16628,7 @@ void sexp_set_debris_field(int n, bool new_sexp)
 
 	if (new_sexp) {
 		if (n >= 0) {
-			for (; n >= 0; true ? n = CDR(n) : n = -1) {
+			for (; n >= 0; n = CDR(n)) {
 
 				// Verify that it's a valid debris type
 				auto idx = get_asteroid_index(CTEXT(n));
@@ -16669,7 +16669,7 @@ void sexp_config_field_targets(int n)
 
 	SCP_vector<SCP_string> targets;
 	if (n >= 0) {
-		for (; n >= 0; true ? n = CDR(n) : n = -1) {
+		for (; n >= 0; n = CDR(n)) {
 			auto ship_entry = eval_ship(n);
 			if (!ship_entry)
 				continue;

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -134,7 +134,8 @@ enum sexp_opf_t : int {
 	OPF_TRANSLATING_SUBSYSTEM,		// Goober5000 - a translating subsystem
 	OPF_ANY_HUD_GAUGE,				// Goober5000 - both custom and builtin
 	OPF_WING_FLAG,					// Goober5000 - The name of a wing flag
-	OPF_ASTEROID_DEBRIS,			// MjnMixael - Debris types as defined in asteroids.tbl
+	OPF_ASTEROID_TYPES,				// MjnMixael - Asteroids from asteroids.tbl, asteroid types only
+	OPF_DEBRIS_TYPES,				// MjnMixael - Asteroids from asteroids.tbl, debris types only
 	OPF_WING_FORMATION,				// Goober5000 - as defined in ships.tbl
 	OPF_MOTION_DEBRIS,				// MjnMixael - Motion debris types as defined in stars.tbl
 	OPF_TURRET_TYPE,				// MjnMixael - Turret types as defined in aiturret.cpp
@@ -910,8 +911,10 @@ enum : int {
 	OP_VALIDATE_GENERAL_ORDERS,		// MjnMixael
 	OP_USED_CHEAT,	// Kiloku
 	OP_SET_ASTEROID_FIELD,	// MjnMixael
-
 	OP_SET_DEBRIS_FIELD,	// MjnMixael
+	OP_CONFIG_ASTEROID_FIELD,  // MjnMixael
+	OP_CONFIG_DEBRIS_FIELD,  // MjnMixael
+	OP_CONFIG_FIELD_TARGETS,  // MjnMixael
 	OP_SET_MOTION_DEBRIS,   // MjnMixael
 	OP_GOOD_PRIMARY_TIME,	// plieblang
 	OP_SET_SKYBOX_ALPHA,	// Goober5000

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -1015,6 +1015,8 @@ void sexp_tree::right_clicked(int mode)
 							case OP_ADD_SUN_BITMAP:
 							case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 							case OP_KEY_RESET:
+							case OP_SET_ASTEROID_FIELD:
+							case OP_SET_DEBRIS_FIELD:
 								j = (int)op_menu.size();	// don't allow these operators to be visible
 								break;
 						}
@@ -1071,6 +1073,8 @@ void sexp_tree::right_clicked(int mode)
 							case OP_ADD_SUN_BITMAP:
 							case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 							case OP_KEY_RESET:
+							case OP_SET_ASTEROID_FIELD:
+							case OP_SET_DEBRIS_FIELD:
 								j = (int)op_submenu.size();	// don't allow these operators to be visible
 								break;
 						}
@@ -3661,9 +3665,17 @@ int sexp_tree::query_default_argument_available(int op, int i)
 			}
 			return 0;
 
-		case OPF_ASTEROID_DEBRIS:
-			if ((Asteroid_info.size() - NUM_ASTEROID_SIZES) > 0) {
+		case OPF_ASTEROID_TYPES:
+			if (get_list_valid_asteroid_subtypes().size() > 0) {
 				return 1;
+			}
+			return 0;
+
+		case OPF_DEBRIS_TYPES:
+			for (const auto& this_asteroid : Asteroid_info) {
+				if (this_asteroid.type == ASTEROID_TYPE_DEBRIS) {
+					return 1;
+				}
 			}
 			return 0;
 
@@ -5745,8 +5757,12 @@ sexp_list_item *sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 			list = nullptr;
 			break;
 
-		case OPF_ASTEROID_DEBRIS:
-			list = get_listing_opf_asteroid_debris();
+		case OPF_ASTEROID_TYPES:
+			list = get_listing_opf_asteroid_types();
+			break;
+		
+		case OPF_DEBRIS_TYPES:
+			list = get_listing_opf_debris_types();
 			break;
 
 		case OPF_WING_FORMATION:
@@ -7523,16 +7539,30 @@ sexp_list_item *sexp_tree::get_listing_opf_nebula_patterns()
 	return head.next;
 }
 
-sexp_list_item* sexp_tree::get_listing_opf_asteroid_debris()
+sexp_list_item* sexp_tree::get_listing_opf_asteroid_types()
 {
 	sexp_list_item head;
 
 	head.add_data(SEXP_NONE_STRING);
 
-	for (int i = 0; i < (int)Asteroid_info.size(); i++) {
-		//first three asteroids are not debris-Mjn
-		if (i > (NUM_ASTEROID_SIZES - 1)) {
-			head.add_data(Asteroid_info[i].name);
+	auto list = get_list_valid_asteroid_subtypes();
+
+	for (const auto& this_asteroid : list) {
+		head.add_data(this_asteroid.c_str());
+	}
+
+	return head.next;
+}
+
+sexp_list_item* sexp_tree::get_listing_opf_debris_types()
+{
+	sexp_list_item head;
+
+	head.add_data(SEXP_NONE_STRING);
+
+	for (const auto& this_asteroid : Asteroid_info) {
+		if (this_asteroid.type == ASTEROID_TYPE_DEBRIS) {
+			head.add_data(this_asteroid.name);
 		}
 	}
 

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -3666,7 +3666,7 @@ int sexp_tree::query_default_argument_available(int op, int i)
 			return 0;
 
 		case OPF_ASTEROID_TYPES:
-			if (get_list_valid_asteroid_subtypes().size() > 0) {
+			if (!get_list_valid_asteroid_subtypes().empty()) {
 				return 1;
 			}
 			return 0;
@@ -7539,7 +7539,7 @@ sexp_list_item *sexp_tree::get_listing_opf_nebula_patterns()
 	return head.next;
 }
 
-sexp_list_item* sexp_tree::get_listing_opf_asteroid_types()
+sexp_list_item *sexp_tree::get_listing_opf_asteroid_types()
 {
 	sexp_list_item head;
 
@@ -7554,7 +7554,7 @@ sexp_list_item* sexp_tree::get_listing_opf_asteroid_types()
 	return head.next;
 }
 
-sexp_list_item* sexp_tree::get_listing_opf_debris_types()
+sexp_list_item *sexp_tree::get_listing_opf_debris_types()
 {
 	sexp_list_item head;
 

--- a/fred2/sexp_tree.h
+++ b/fred2/sexp_tree.h
@@ -298,7 +298,8 @@ public:
 	sexp_list_item *get_listing_opf_wing_flags();
 	sexp_list_item *get_listing_opf_team_colors();
 	sexp_list_item *get_listing_opf_nebula_patterns();
-	sexp_list_item *get_listing_opf_asteroid_debris();
+	sexp_list_item *get_listing_opf_asteroid_types();
+	sexp_list_item *get_listing_opf_debris_types();
 	sexp_list_item *get_listing_opf_motion_debris();
 	sexp_list_item *get_listing_opf_game_snds();
 	sexp_list_item *get_listing_opf_fireball();

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1672,7 +1672,7 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 		return 0;
 
 	case OPF_ASTEROID_TYPES:
-		if (get_list_valid_asteroid_subtypes().size() > 0) {
+		if (!get_list_valid_asteroid_subtypes().empty()) {
 			return 1;
 		}
 		return 0;
@@ -5209,7 +5209,7 @@ sexp_list_item* sexp_tree::get_listing_opf_message_types()
 	return head.next;
 }
 
-sexp_list_item* sexp_tree::get_listing_opf_asteroid_types()
+sexp_list_item *sexp_tree::get_listing_opf_asteroid_types()
 {
 	sexp_list_item head;
 
@@ -5224,7 +5224,7 @@ sexp_list_item* sexp_tree::get_listing_opf_asteroid_types()
 	return head.next;
 }
 
-sexp_list_item* sexp_tree::get_listing_opf_debris_types()
+sexp_list_item *sexp_tree::get_listing_opf_debris_types()
 {
 	sexp_list_item head;
 

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -1671,9 +1671,17 @@ int sexp_tree::query_default_argument_available(int op, int i) {
 		}
 		return 0;
 
-	case OPF_ASTEROID_DEBRIS:
-		if ((Asteroid_info.size() - NUM_ASTEROID_SIZES) > 0) {
+	case OPF_ASTEROID_TYPES:
+		if (get_list_valid_asteroid_subtypes().size() > 0) {
 			return 1;
+		}
+		return 0;
+
+	case OPF_DEBRIS_TYPES:
+		for (const auto& this_asteroid : Asteroid_info) {
+			if (this_asteroid.type == ASTEROID_TYPE_DEBRIS) {
+				return 1;
+			}
 		}
 		return 0;
 
@@ -3449,8 +3457,12 @@ sexp_list_item* sexp_tree::get_listing_opf(int opf, int parent_node, int arg_ind
 		list = nullptr;
 		break;
 
-	case OPF_ASTEROID_DEBRIS:
-		list = get_listing_opf_asteroid_debris();
+	case OPF_ASTEROID_TYPES:
+		list = get_listing_opf_asteroid_types();
+		break;
+
+	case OPF_DEBRIS_TYPES:
+		list = get_listing_opf_debris_types();
 		break;
 
 	case OPF_WING_FORMATION:
@@ -5197,16 +5209,30 @@ sexp_list_item* sexp_tree::get_listing_opf_message_types()
 	return head.next;
 }
 
-sexp_list_item* sexp_tree::get_listing_opf_asteroid_debris()
+sexp_list_item* sexp_tree::get_listing_opf_asteroid_types()
 {
 	sexp_list_item head;
 
 	head.add_data(SEXP_NONE_STRING);
 
-	for (int i = 0; i < (int)Asteroid_info.size(); i++) {
-		// first three asteroids are not debris-Mjn
-		if (i > (NUM_ASTEROID_SIZES - 1)) {
-			head.add_data(Asteroid_info[i].name);
+	auto list = get_list_valid_asteroid_subtypes();
+
+	for (const auto& this_asteroid : list) {
+		head.add_data(this_asteroid.c_str());
+	}
+
+	return head.next;
+}
+
+sexp_list_item* sexp_tree::get_listing_opf_debris_types()
+{
+	sexp_list_item head;
+
+	head.add_data(SEXP_NONE_STRING);
+
+	for (const auto& this_asteroid : Asteroid_info) {
+		if (this_asteroid.type == ASTEROID_TYPE_DEBRIS) {
+			head.add_data(this_asteroid.name);
 		}
 	}
 
@@ -6095,6 +6121,8 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 					case OP_ADD_SUN_BITMAP:
 					case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 					case OP_KEY_RESET:
+					case OP_SET_ASTEROID_FIELD:
+					case OP_SET_DEBRIS_FIELD:
 						j = (int) op_menu.size();    // don't allow these operators to be visible
 						break;
 					}
@@ -6168,6 +6196,8 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 					case OP_ADD_SUN_BITMAP:
 					case OP_JUMP_NODE_SET_JUMPNODE_NAME:
 					case OP_KEY_RESET:
+					case OP_SET_ASTEROID_FIELD:
+					case OP_SET_DEBRIS_FIELD:
 						j = (int) op_submenu.size();    // don't allow these operators to be visible
 						break;
 					}

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -347,8 +347,8 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_team_colors();
 	sexp_list_item* get_listing_opf_nebula_patterns();
 	sexp_list_item* get_listing_opf_motion_debris();
-	sexp_list_item* get_listing_opf_asteroid_types();
-	sexp_list_item* get_listing_opf_debris_types();
+	static sexp_list_item* get_listing_opf_asteroid_types();
+	static sexp_list_item* get_listing_opf_debris_types();
 	sexp_list_item* get_listing_opf_game_snds();
 	sexp_list_item* get_listing_opf_fireball();
 	sexp_list_item *get_listing_opf_species();

--- a/qtfred/src/ui/widgets/sexp_tree.h
+++ b/qtfred/src/ui/widgets/sexp_tree.h
@@ -347,7 +347,8 @@ class sexp_tree: public QTreeWidget {
 	sexp_list_item* get_listing_opf_team_colors();
 	sexp_list_item* get_listing_opf_nebula_patterns();
 	sexp_list_item* get_listing_opf_motion_debris();
-	sexp_list_item* get_listing_opf_asteroid_debris();
+	sexp_list_item* get_listing_opf_asteroid_types();
+	sexp_list_item* get_listing_opf_debris_types();
 	sexp_list_item* get_listing_opf_game_snds();
 	sexp_list_item* get_listing_opf_fireball();
 	sexp_list_item *get_listing_opf_species();


### PR DESCRIPTION
Follow-up to #6021 which enhanced asteroid/debris fields to allow more than three types to be active at once. This PR replaces the older set-asteroid-field and set-debris-field SEXPs with the newer config-asteroid-field and config-debris-field sexps that allow selecting more than three types to be active.

One core difference here is that the sexp for Active Asteroid Fields no longer sets the field targets within the same SEXP. A new config-field-targets SEXP has been added that allows adding/removing field targets arbitrarily which actually ends up being kind of a nice side-effect upgrade to the whole system.

The old SEXPs are deprecated and hidden, but still function as they used to according to my tests.