### PR TITLE
Switch options manager from signaling empty keys with exceptions to use optional<> 

### DIFF
--- a/code/options/Option.cpp
+++ b/code/options/Option.cpp
@@ -123,7 +123,7 @@ OptionBase::OptionBase(SCP_string config_key, SCP_string title, SCP_string descr
 }
 
 //Return the option value from the config
-std::unique_ptr<json_t> OptionBase::getConfigValue() const { return _parent->getValueFromConfig(_config_key); }
+tl::optional<std::unique_ptr<json_t>> OptionBase::getConfigValue() const { return _parent->getValueFromConfig(_config_key); }
 
 //Return the option expert_level value
 ExpertLevel OptionBase::getExpertLevel() const { return _expert_level; }

--- a/code/options/OptionsManager.cpp
+++ b/code/options/OptionsManager.cpp
@@ -5,6 +5,7 @@
 #include "Option.h"
 #include "mod_table/mod_table.h"
 #include "osapi/osregistry.h"
+#include <tl/optional.hpp>
 
 namespace {
 
@@ -36,7 +37,7 @@ OptionsManager* options::OptionsManager::instance()
 }
 
 //Gets the value of an option from the Config using the option key
-std::unique_ptr<json_t> OptionsManager::getValueFromConfig(const SCP_string& key) const
+tl::optional<std::unique_ptr<json_t>> OptionsManager::getValueFromConfig(const SCP_string& key) const
 {
 	auto override_iter = _config_overrides.find(key);
 	if (override_iter != _config_overrides.end()) {
@@ -60,8 +61,8 @@ std::unique_ptr<json_t> OptionsManager::getValueFromConfig(const SCP_string& key
 	auto value = os_config_read_string(parts.first.c_str(), parts.second.c_str(), (const char*)0, true);
 
 	if (value == nullptr) {
-		// TODO: This is not really an error but I would like to avoid return nullptr here...
-		throw std::runtime_error("No value available");
+		// Signal that there is no value for this key
+		return tl::nullopt;
 	}
 
 	json_error_t err;

--- a/code/options/OptionsManager.h
+++ b/code/options/OptionsManager.h
@@ -3,6 +3,7 @@
 #include "globalincs/pstypes.h"
 #include "libs/jansson.h"
 #include <memory>
+#include <tl/optional.hpp>
 
 namespace options {
 
@@ -26,7 +27,7 @@ class OptionsManager {
 
 	~OptionsManager();
 
-	std::unique_ptr<json_t> getValueFromConfig(const SCP_string& key) const;
+	tl::optional<std::unique_ptr<json_t>> getValueFromConfig(const SCP_string& key) const;
 
 	void setConfigValue(const SCP_string& key, std::unique_ptr<json_t>&& value);
 


### PR DESCRIPTION
This cleans up an old TODO and addresses(partially) #6287. Exceptions are no longer routine for unset options, but other exception sources are possible in getting options so the handling is still present.

I have run the game with these changes and it still appears to function properly in general and respect my options and defaults, but if there's any in-depth stress testing of the options manager that should be undertaken to verify it I am unsure what it would be.