### PR TITLE
Fix sorting of older but active directives

### DIFF
--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -507,10 +507,9 @@ void sort_training_objectives()
 		}
 	}
 
-
-	int slot_idx, unkn_vis, last_directive;
 	// go through list and bump as needed
 	for (i=0; i<num_offset_events; i++) {
+		int slot_idx, unkn_vis, slot_directive;
 
 		// find most recent directive that would not be shown
 		for (unkn_vis=offset-1; unkn_vis>=0; unkn_vis--) {
@@ -522,22 +521,32 @@ void sort_training_objectives()
 		// find first slot that can be bumped
 		// look at the last (N-4 to N) positions
 		for (slot_idx=0; slot_idx<Max_directives; slot_idx++) {
-			if ( Training_obj_lines[i+offset] & TRAINING_OBJ_STATUS_KNOWN ) {
+			if ( Training_obj_lines[slot_idx+offset] & TRAINING_OBJ_STATUS_KNOWN ) {
 				break;
 			}
 		}
 
-		// shift and replace (mark old one as STATUS_KNOWN)
-		// store the directive that won't be shown
-		last_directive = Training_obj_lines[Training_obj_num_lines-1];
-
-		for (int j=slot_idx; j>0; j--) {
-			Training_obj_lines[j+offset-1] = Training_obj_lines[j+offset-2];
+		if (slot_idx == Max_directives){
+			// We did not manage to find space for all directives! This is bad, but nothing we can do about it.
+			break;
 		}
+
+		// Since the directive to be shown here is older than the ones currently on display, remove the directive to be bumped and then shift all others up one until that entry.
+		// Store the directive to be bumped for later.
+		slot_directive = Training_obj_lines[slot_idx+offset];
+
+		// Shift newer objectives
+		for (int j=slot_idx; j>0; j--) {
+			Training_obj_lines[j+offset] = Training_obj_lines[j+offset-1];
+		}
+
+		//Place directive to be shown in the topmost slot
 		Training_obj_lines[offset] = Training_obj_lines[unkn_vis];
-		Training_obj_lines[unkn_vis] = last_directive;
-		Training_obj_lines[unkn_vis] &= ~TRAINING_OBJ_LINES_EVENT_STATUS_MASK;
-		Training_obj_lines[unkn_vis] |= TRAINING_OBJ_STATUS_KNOWN;
+
+		//Restore bumped directive on the non-rendered slot
+		Training_obj_lines[unkn_vis] = slot_directive;
+
+		Assertion((Training_obj_lines[unkn_vis] & TRAINING_OBJ_LINES_EVENT_STATUS_MASK) == TRAINING_OBJ_STATUS_KNOWN, "Objective bumped was not known");
 	}
 
 	// remove event status


### PR DESCRIPTION
FSO should, based on code comments and common sense, display the five must current directives. But, if there are directives older then that which are still active, then these should be preferred over the oldest directives that are already completed and still shown.

Unfortunately, the logic to do that has been bugged since retail, but since you need an active directive that's sixth oldest or older to notice the issue, it probably slipped past so far.

The issues with the prior logic were:
- Usage of an incorrect loop iterator variable, resulting in replacement of the n-th shown directive in order to display the n-th older-but-active directive, regardless of the state of shown directives.
- Since the directive that is shown instead of the replaced directive is older than all other directives, it should be shown on the top of the list. For this, the directives above the slot that is freed are shifted down. There was an off-by-one error, causing the directive above the slot to be overwritten, while the slot itself (which is "free" and should be used by the directives still shown) was not overwritten.
- The directive that is replaces is not deleted, it's just switched with the one that is to-be-shown. The prior code didn't use the directive to be replaced for this however, but the last directive in the list.
- Volition never considered the case, that there is no room available. If the logic had worked as described in comments, then a case where more than ``Max_directives`` were active at once, the logic would have written out of bounds of the directives display array

fixes #6294