### PR TITLE
Fixes CTD with new Friendly Fire Feature

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7456,8 +7456,8 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 
 			// if this is friendly fire, we check for the friendly fire cap values
 			if (wp->team == shipp->team) {
-				if (wobjp->parent > -1 && &Objects[wobjp->parent] == other_obj && The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level] >= 0.f) {
-					// if this is a ship shooting itself, we use the self damage cap
+				if (wobjp->parent > -1 && &Objects[wobjp->parent] == objp && The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level] >= 0.f) {
+					// if this is a ship damaging itself, we use the self damage cap
 					damage = MIN(damage, The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level]);
 				} else if (The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
 					// otherwise we use the friendly damage cap

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7451,17 +7451,19 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 				weapon_do_electronics_effect(objp, pos, Weapons[wobjp->instance].weapon_info_index);
 			}
 
-			weapon* wp = &Weapons[wobjp->instance];
-			ship* shipp = &Ships[other_obj->instance];
+			if ((other_obj != nullptr) && (other_obj->type == OBJ_SHIP)) {
+				weapon* wp = &Weapons[wobjp->instance];
+				ship* shipp = &Ships[other_obj->instance];
 
-			// if this is friendly fire, we check for the friendly fire cap values
-			if (wp->team == shipp->team) {
-				if (&Objects[wobjp->parent] == other_obj && The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level] >= 0.f) {
-					// if this is a ship shooting itself, we use the self damage cap
-					damage = MIN(damage, The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level]);
-				} else if (The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
-					// otherwise we use the friendly damage cap
-					damage = MIN(damage, The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level]);
+				// if this is friendly fire, we check for the friendly fire cap values
+				if (wp->team == shipp->team) {
+					if (wobjp->parent > -1 && &Objects[wobjp->parent] == other_obj && The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level] >= 0.f) {
+						// if this is a ship shooting itself, we use the self damage cap
+						damage = MIN(damage, The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level]);
+					} else if (The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
+						// otherwise we use the friendly damage cap
+						damage = MIN(damage, The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level]);
+					}
 				}
 			}
 
@@ -7479,12 +7481,14 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 			if (target_wip->armor_type_idx >= 0)
 				damage = Armor_types[target_wip->armor_type_idx].GetDamage(damage, wip->shockwave.damage_type_idx, 1.0f, false);
 
-			weapon* wp = &Weapons[wobjp->instance];
-			weapon* target_wp = &Weapons[other_obj->instance];
+			if ((other_obj != nullptr) && (other_obj->type == OBJ_SHIP)) {
+				weapon* wp = &Weapons[wobjp->instance];
+				weapon* target_wp = &Weapons[other_obj->instance];
 			
-			// if this is friendly fire, we check for the friendly fire cap value
-			if (wp->team == target_wp->team && The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
-				damage = MIN(damage, The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level]);
+				// if this is friendly fire, we check for the friendly fire cap value
+				if (wp->team == target_wp->team && The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
+					damage = MIN(damage, The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level]);
+				}
 			}
 
 			objp->hull_strength -= damage;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7451,19 +7451,17 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 				weapon_do_electronics_effect(objp, pos, Weapons[wobjp->instance].weapon_info_index);
 			}
 
-			if ((other_obj != nullptr) && (other_obj->type == OBJ_SHIP)) {
-				weapon* wp = &Weapons[wobjp->instance];
-				ship* shipp = &Ships[other_obj->instance];
+			weapon* wp = &Weapons[wobjp->instance];
+			ship* shipp = &Ships[objp->instance];
 
-				// if this is friendly fire, we check for the friendly fire cap values
-				if (wp->team == shipp->team) {
-					if (wobjp->parent > -1 && &Objects[wobjp->parent] == other_obj && The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level] >= 0.f) {
-						// if this is a ship shooting itself, we use the self damage cap
-						damage = MIN(damage, The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level]);
-					} else if (The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
-						// otherwise we use the friendly damage cap
-						damage = MIN(damage, The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level]);
-					}
+			// if this is friendly fire, we check for the friendly fire cap values
+			if (wp->team == shipp->team) {
+				if (wobjp->parent > -1 && &Objects[wobjp->parent] == other_obj && The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level] >= 0.f) {
+					// if this is a ship shooting itself, we use the self damage cap
+					damage = MIN(damage, The_mission.ai_profile->weapon_self_damage_cap[Game_skill_level]);
+				} else if (The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
+					// otherwise we use the friendly damage cap
+					damage = MIN(damage, The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level]);
 				}
 			}
 
@@ -7481,14 +7479,12 @@ void weapon_do_area_effect(object *wobjp, shockwave_create_info *sci, vec3d *pos
 			if (target_wip->armor_type_idx >= 0)
 				damage = Armor_types[target_wip->armor_type_idx].GetDamage(damage, wip->shockwave.damage_type_idx, 1.0f, false);
 
-			if ((other_obj != nullptr) && (other_obj->type == OBJ_SHIP)) {
-				weapon* wp = &Weapons[wobjp->instance];
-				weapon* target_wp = &Weapons[other_obj->instance];
-			
-				// if this is friendly fire, we check for the friendly fire cap value
-				if (wp->team == target_wp->team && The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
-					damage = MIN(damage, The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level]);
-				}
+			weapon* wp = &Weapons[wobjp->instance];
+			weapon* target_wp = &Weapons[objp->instance];
+		
+			// if this is friendly fire, we check for the friendly fire cap value
+			if (wp->team == target_wp->team && The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level] >= 0.f) {
+				damage = MIN(damage, The_mission.ai_profile->weapon_friendly_damage_cap[Game_skill_level]);
 			}
 
 			objp->hull_strength -= damage;


### PR DESCRIPTION
On current master I was hitting a CTD when firing a weapon with a shockwave at close range (ie player is within the shockwave zone). This code is part of the new friendly fire feature from #6265. The minidump showed `other_obj` was `null`, so this PR adds some safety checks.

Tested and this fixes the crashes.