### PR TITLE
fix waypoint marking

### DIFF
--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -503,6 +503,7 @@ void CFREDView::OnUpdateViewGrid(CCmdUI* pCmdUI)
 void CFREDView::OnViewWaypoints() 
 {
 	Show_waypoints = !Show_waypoints;
+	correct_marking();
 	Update_window = 1;
 }
 


### PR DESCRIPTION
When the Show Waypoints option is toggled, the marking was not updated as it was for the other options (Show Ships, Show Starts, Show IFFs).  Fix this by calling `correct_marking()`.