### PR TITLE
add option in FRED to lock objects from being edited

### DIFF
--- a/code/object/object_flags.h
+++ b/code/object/object_flags.h
@@ -26,7 +26,8 @@ namespace Object {
 		Immobile,				// Goober5000 - doesn't move, no matter what
 		Marked,					// Object is marked (Fred).  Can be reused in FreeSpace for anything that won't be used by Fred.
 		Temp_marked,			// Temporarily marked (Fred).
-		Hidden,					// Object is hidden (not shown) and can't be manipulated
+		Hidden,					// Object is hidden (not shown in Fred) and can't be manipulated
+		Locked_from_editing,	// Object cannot be edited (Fred)
 		Collides_with_parent,	// Asteroth - Only used for weapons with 'Can_damage_shooter'
 		Attackable_if_no_collide,	// Cyborg - Allows the AI to attack this object, even if no-collide is set (Cue Admiral Ackbar)
 		Collision_cache_stale,	// This object has a stale collision cache, and will be recalculated this frame

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -234,6 +234,10 @@ BEGIN
         MENUITEM "Delete\tDel",                 32789
         MENUITEM "Delete Wing\tCtrl+Del",       33035
         MENUITEM SEPARATOR
+        MENUITEM "Lock Marked Objects",         ID_EDIT_LOCK_MARKED_OBJECTS
+        MENUITEM "Unlock All Objects",          ID_EDIT_UNLOCK_ALL_OBJECTS
+        MENUITEM "Selection Lock",              ID_SELECTION_LOCK
+        MENUITEM SEPARATOR
         MENUITEM "Disable Undo",                33055
     END
     POPUP "&View"
@@ -3491,6 +3495,10 @@ BEGIN
                             "When setting initially docked ships to initially undocked, move the smaller ship away from the dockpoint by one ship length"
     ID_EDIT_CLONEMARKEDOBJECTS 
                             "Clone every marked object in-place, like Ctrl-drag without the dragging"
+    ID_EDIT_LOCK_MARKED_OBJECTS
+                            "Prevent marked objects from being selected or moved"
+    ID_EDIT_UNLOCK_ALL_OBJECTS
+                            "Allow all objects to be selected or moved"
     ID_MISC_POINTUSINGUVEC  "When using the Object Editor to point ships, take the ship's current up-vector into account"
     ID_MUSIC_PLAYER         "Preview music files"
 END
@@ -3620,7 +3628,7 @@ BEGIN
     ID_SELECT_LIST          "Select from List\nSelect List (H)"
     ID_CONSTRAIN_Y          "Constrain movement to global Y axis\nY Constraint"
     ID_ZOOM                 "Zoom view in/out\nZoom Mode"
-    ID_SELECTION_LOCK       "Selection Lock\nSelection Lock (Spacebar)"
+    ID_SELECTION_LOCK       "Prevent selection from changing\nSelection Lock (Spacebar)"
     ID_DISSOLVE_WING        "Remove selected ships from Wing(s)\nRemove from Wing"
 END
 

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -979,14 +979,16 @@ void game_do_frame() {
 		break;
 
 	case 2:  // Control viewpoint object
-		process_controls(&Objects[view_obj].pos, &Objects[view_obj].orient, f2fl(Frametime), key);
-		object_moved(&Objects[view_obj]);
-		control_pos = Objects[view_obj].pos;
-		control_orient = Objects[view_obj].orient;
+		if (!Objects[view_obj].flags[Object::Object_Flags::Locked_from_editing]) {
+			process_controls(&Objects[view_obj].pos, &Objects[view_obj].orient, f2fl(Frametime), key);
+			object_moved(&Objects[view_obj]);
+			control_pos = Objects[view_obj].pos;
+			control_orient = Objects[view_obj].orient;
+		}
 		break;
 
 	case 1:  //	Control the current object's location and orientation
-		if (query_valid_object()) {
+		if (query_valid_object() && !Objects[cur_object_index].flags[Object::Object_Flags::Locked_from_editing]) {
 			vec3d delta_pos, leader_old_pos;
 			matrix leader_orient, leader_transpose, tmp;
 			object *leader;
@@ -1214,10 +1216,12 @@ void level_controlled() {
 		break;
 
 	case 2:  // Control viewpoint object
-		level_object(&Objects[view_obj].orient);
-		object_moved(&Objects[view_obj]);
-		set_modified();
-		FREDDoc_ptr->autosave("level object");
+		if (!Objects[view_obj].flags[Object::Object_Flags::Locked_from_editing]) {
+			level_object(&Objects[view_obj].orient);
+			object_moved(&Objects[view_obj]);
+			set_modified();
+			FREDDoc_ptr->autosave("level object");
+		}
 		break;
 
 	case 1:  //	Control the current object's location and orientation
@@ -1316,7 +1320,7 @@ int object_check_collision(object *objp, vec3d *p0, vec3d *p1, vec3d *hitpos) {
 			return 0;
 	}
 
-	if (objp->flags[Object::Object_Flags::Hidden])
+	if (objp->flags[Object::Object_Flags::Hidden, Object::Object_Flags::Locked_from_editing])
 		return 0;
 
 	if ((Show_ship_models || Show_outlines) && (objp->type == OBJ_SHIP)) {
@@ -2017,7 +2021,7 @@ int select_object(int cx, int cy) {
 	if (Briefing_dialog) {
 		best = Briefing_dialog->check_mouse_hit(cx, cy);
 		if (best >= 0) {
-			if (Selection_lock && !(Objects[best].flags[Object::Object_Flags::Marked])) {
+			if ((Selection_lock && !Objects[best].flags[Object::Object_Flags::Marked]) || Objects[best].flags[Object::Object_Flags::Locked_from_editing]) {
 				return -1;
 			}
 			return best;
@@ -2055,7 +2059,7 @@ int select_object(int cx, int cy) {
 	}
 
 	if (best >= 0) {
-		if (Selection_lock && !(Objects[best].flags[Object::Object_Flags::Marked])) {
+		if ((Selection_lock && !Objects[best].flags[Object::Object_Flags::Marked]) || Objects[best].flags[Object::Object_Flags::Locked_from_editing]) {
 			return -1;
 		}
 		return best;
@@ -2077,7 +2081,7 @@ int select_object(int cx, int cy) {
 		ptr = GET_NEXT(ptr);
 	}
 
-	if (Selection_lock && !(Objects[best].flags[Object::Object_Flags::Marked])) {
+	if ((Selection_lock && !Objects[best].flags[Object::Object_Flags::Marked]) || Objects[best].flags[Object::Object_Flags::Locked_from_editing]) {
 		return -1;
 	}
 
@@ -2098,10 +2102,12 @@ void verticalize_controlled() {
 		break;
 
 	case 2:  // Control viewpoint object
-		verticalize_object(&Objects[view_obj].orient);
-		object_moved(&Objects[view_obj]);
-		FREDDoc_ptr->autosave("align object");
-		set_modified();
+		if (!Objects[view_obj].flags[Object::Object_Flags::Locked_from_editing]) {
+			verticalize_object(&Objects[view_obj].orient);
+			object_moved(&Objects[view_obj]);
+			FREDDoc_ptr->autosave("align object");
+			set_modified();
+		}
 		break;
 
 	case 1:  //	Control the current object's location and orientation

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -304,8 +304,10 @@ BEGIN_MESSAGE_MAP(CFREDView, CView)
 	ON_COMMAND(ID_REVERT, OnRevert)
 	ON_UPDATE_COMMAND_UI(ID_REVERT, OnUpdateRevert)
 	ON_WM_SETCURSOR()
-	ON_COMMAND(ID_HIDE_OBJECTS, OnHideObjects)
+	ON_COMMAND(ID_HIDE_MARKED_OBJECTS, OnHideMarkedObjects)
 	ON_COMMAND(ID_SHOW_HIDDEN_OBJECTS, OnShowHiddenObjects)
+	ON_COMMAND(ID_EDIT_LOCK_MARKED_OBJECTS, OnLockMarkedObjects)
+	ON_COMMAND(ID_EDIT_UNLOCK_ALL_OBJECTS, OnUnlockAllObjects)
 	ON_COMMAND(ID_EDIT_UNDO, OnEditUndo)
 	ON_UPDATE_COMMAND_UI(ID_EDIT_UNDO, OnUpdateEditUndo)
 	ON_COMMAND(ID_EDITORS_BRIEFING, OnEditorsBriefing)
@@ -1315,7 +1317,7 @@ void select_objects()
 	ptr = GET_FIRST(&obj_used_list);
 	while (ptr != END_OF_LIST(&obj_used_list)) {
 		valid = 1;
-		if (ptr->flags[Object::Object_Flags::Hidden])
+		if (ptr->flags[Object::Object_Flags::Hidden, Object::Object_Flags::Locked_from_editing])
 			valid = 0;
 
 		Assert(ptr->type != OBJ_NONE);
@@ -4038,7 +4040,7 @@ BOOL CFREDView::OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message)
 	return CView::OnSetCursor(pWnd, nHitTest, message);
 }
 
-void CFREDView::OnHideObjects() 
+void CFREDView::OnHideMarkedObjects()
 {
 	object *ptr;
 
@@ -4053,13 +4055,41 @@ void CFREDView::OnHideObjects()
 	}
 }
 
-void CFREDView::OnShowHiddenObjects() 
+void CFREDView::OnShowHiddenObjects()
 {
 	object *ptr;
 
 	ptr = GET_FIRST(&obj_used_list);
 	while (ptr != END_OF_LIST(&obj_used_list)) {
 		ptr->flags.remove(Object::Object_Flags::Hidden);
+		ptr = GET_NEXT(ptr);
+	}
+
+	Update_window = 1;
+}
+
+void CFREDView::OnLockMarkedObjects()
+{
+	object *ptr;
+
+	ptr = GET_FIRST(&obj_used_list);
+	while (ptr != END_OF_LIST(&obj_used_list)) {
+		if (ptr->flags[Object::Object_Flags::Marked]) {
+            ptr->flags.set(Object::Object_Flags::Locked_from_editing);
+			unmark_object(OBJ_INDEX(ptr));
+		}
+
+		ptr = GET_NEXT(ptr);
+	}
+}
+
+void CFREDView::OnUnlockAllObjects()
+{
+	object *ptr;
+
+	ptr = GET_FIRST(&obj_used_list);
+	while (ptr != END_OF_LIST(&obj_used_list)) {
+		ptr->flags.remove(Object::Object_Flags::Locked_from_editing);
 		ptr = GET_NEXT(ptr);
 	}
 

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -261,8 +261,10 @@ protected:
 	afx_msg void OnRevert();
 	afx_msg void OnUpdateRevert(CCmdUI* pCmdUI);
 	afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
-	afx_msg void OnHideObjects();
+	afx_msg void OnHideMarkedObjects();
 	afx_msg void OnShowHiddenObjects();
+	afx_msg void OnLockMarkedObjects();
+	afx_msg void OnUnlockAllObjects();
 	afx_msg void OnEditUndo();
 	afx_msg void OnUpdateEditUndo(CCmdUI* pCmdUI);
 	afx_msg void OnEditorsBriefing();

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -1459,7 +1459,7 @@
 #define ID_CPGN_FILE_SAVE_AS            32998
 #define ID_SHOW_STARFRIELD              32999
 #define ID_REVERT                       33000
-#define ID_HIDE_OBJECTS                 33002
+#define ID_HIDE_MARKED_OBJECTS          33002
 #define ID_SHOW_HIDDEN_OBJECTS          33003
 #define ID_GROUP_SET                    33004
 #define ID_EXPAND_ALL                   33005
@@ -1520,6 +1520,8 @@
 #define ID_PREV_SUBSYS                  33060
 #define ID_CANCEL_SUBSYS                33061
 #define ID_HIGHLIGHT_SUBSYS             33062
+#define ID_EDIT_LOCK_MARKED_OBJECTS     33063
+#define ID_EDIT_UNLOCK_ALL_OBJECTS      33064
 #define ID_SHOW_DOCK_POINTS             33065
 #define ID_SHOW_PATHS                   33066
 #define ID_DUMP_STATS                   33067

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -790,6 +790,32 @@ void Editor::showHiddenObjects() {
 
 	updateAllViewports();
 }
+void Editor::lockMarkedObjects() {
+	object* ptr;
+
+	ptr = GET_FIRST(&obj_used_list);
+	while (ptr != END_OF_LIST(&obj_used_list)) {
+		if (ptr->flags[Object::Object_Flags::Marked]) {
+			ptr->flags.set(Object::Object_Flags::Locked_from_editing);
+			unmarkObject(OBJ_INDEX(ptr));
+		}
+
+		ptr = GET_NEXT(ptr);
+	}
+
+	updateAllViewports();
+}
+void Editor::unlockAllObjects() {
+	object* ptr;
+
+	ptr = GET_FIRST(&obj_used_list);
+	while (ptr != END_OF_LIST(&obj_used_list)) {
+		ptr->flags.remove(Object::Object_Flags::Locked_from_editing);
+		ptr = GET_NEXT(ptr);
+	}
+
+	updateAllViewports();
+}
 int Editor::create_waypoint(vec3d* pos, int waypoint_instance) {
 	int obj = waypoint_add(pos, waypoint_instance);
 

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -69,6 +69,9 @@ class Editor : public QObject {
 	void hideMarkedObjects();
 	void showHiddenObjects();
 
+	void lockMarkedObjects();
+	void unlockAllObjects();
+
 	int dup_object(object* objp);
 
 	int delete_object(int obj);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -549,6 +549,12 @@ void FredView::on_actionHide_Marked_Objects_triggered(bool  /*enabled*/) {
 void FredView::on_actionShow_All_Hidden_Objects_triggered(bool  /*enabled*/) {
 	fred->showHiddenObjects();
 }
+void FredView::on_actionLock_Marked_Objects_triggered(bool  /*enabled*/) {
+	fred->lockMarkedObjects();
+}
+void FredView::on_actionUnlock_All_Objects_triggered(bool  /*enabled*/) {
+	fred->unlockAllObjects();
+}
 void FredView::onUpdateViewSpeeds() {
 	ui->actionx1->setChecked(_viewport->physics_speed == 1);
 	ui->actionx2->setChecked(_viewport->physics_speed == 2);

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -62,6 +62,9 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void on_actionHide_Marked_Objects_triggered(bool enabled);
 	void on_actionShow_All_Hidden_Objects_triggered(bool enabled);
 
+	void on_actionLock_Marked_Objects_triggered(bool enabled);
+	void on_actionUnlock_All_Objects_triggered(bool enabled);
+
 	void on_actionx1_triggered(bool enabled);
 	void on_actionx2_triggered(bool enabled);
 	void on_actionx3_triggered(bool enabled);

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -71,6 +71,10 @@
     <addaction name="actionDelete"/>
     <addaction name="actionDelete_Wing"/>
     <addaction name="separator"/>
+    <addaction name="actionLock_Marked_Objects"/>
+    <addaction name="actionUnlock_All_Objects"/>
+    <addaction name="actionSelectionLock"/>
+    <addaction name="separator"/>
     <addaction name="actionDisable_Undo"/>
    </widget>
    <widget class="QMenu" name="menuView">
@@ -480,7 +484,7 @@
     <string>SelectionLock</string>
    </property>
    <property name="toolTip">
-    <string>Selection Lock (Spacebar)</string>
+    <string>Prevent selection from changing (Spacebar)</string>
    </property>
    <property name="shortcut">
     <string>Space</string>
@@ -667,6 +671,16 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Del</string>
+   </property>
+  </action>
+  <action name="actionLock_Marked_Objects">
+   <property name="text">
+    <string>&amp;Lock Marked Objects</string>
+   </property>
+  </action>
+  <action name="actionUnlock_All_Objects">
+   <property name="text">
+    <string>&amp;Unlock All Objects</string>
    </property>
   </action>
   <action name="actionDisable_Undo">


### PR DESCRIPTION
Add options to the Edit menu to lock and unlock objects.  Locked objects cannot be selected or dragged.  They can still be edited in the various editors (e.g. Ships, Objects) but not in the main viewing area.

Also add the Selection Lock option to the Edit menu.  It was previously available in the toolbar but this provides another way to access it.