### PR TITLE
Generic random distributions, including curve-based

### DIFF
--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -339,7 +339,7 @@ void parseDecalReference(creation_info& dest_info, bool is_new_entry) {
 	}
 
 	if (required_string_if_new("+Radius:", is_new_entry)) {
-		dest_info.radius = util::parseUniformRange(0.0001f);
+		dest_info.radius = util::ParsedRandomFloatRange::parseRandomRange(0.0001f);
 	}
 
 	if (required_string_if_new("+Lifetime:", is_new_entry)) {
@@ -347,7 +347,7 @@ void parseDecalReference(creation_info& dest_info, bool is_new_entry) {
 			dest_info.lifetime = util::UniformFloatRange(-1.0f);
 		} else {
 			// Require at least a small lifetime so that the calculations don't have to deal with div-by-zero
-			dest_info.lifetime = util::parseUniformRange(0.0001f);
+			dest_info.lifetime = util::ParsedRandomFloatRange::parseRandomRange(0.0001f);
 		}
 	}
 

--- a/code/decals/decals.h
+++ b/code/decals/decals.h
@@ -65,10 +65,10 @@ typedef int DecalReference;
  */
 struct creation_info {
 	DecalReference definition_handle = -1;
-	util::UniformFloatRange radius = ::util::UniformFloatRange(-1.0f);
+	util::ParsedRandomFloatRange radius = ::util::UniformFloatRange(-1.0f);
 	float width = -1.0f;
 	float height = -1.0f;
-	util::UniformFloatRange lifetime = ::util::UniformFloatRange(-1.0f);
+	util::ParsedRandomFloatRange lifetime = ::util::UniformFloatRange(-1.0f);
 	bool random_rotation = false;
 };
 

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -794,7 +794,7 @@ void parse_gamesnd_soundset(game_snd* gs, bool no_create) {
 
 	if (required_string_no_create("+Volume:", no_create))
 	{
-		gs->volume_range = util::parseUniformRange(0.0f, 1.0f);
+		gs->volume_range = util::ParsedRandomFloatRange::parseRandomRange(0.0f, 1.0f);
 	}
 
 	if (optional_string("+3D Sound:"))
@@ -843,10 +843,10 @@ void parse_gamesnd_soundset(game_snd* gs, bool no_create) {
 	}
 
 	if (optional_string("+Pitch:")) {
-		gs->pitch_range = util::parseUniformRange(0.0001f);
+		gs->pitch_range = util::UniformFloatRange(0.0001f);
 	} else if (!no_create) {
 		// Default pitch is 1.0
-		gs->pitch_range = util::UniformFloatRange(1.0f);
+		gs->pitch_range = util::ParsedRandomFloatRange::parseRandomRange(1.0f);
 	}
 }
 

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -9,7 +9,8 @@ int curve_get_by_name(const SCP_string& in_name) {
 	return find_item_with_name(Curves, in_name);
 }
 
-int pdf_to_cdf(Curve curve) {
+int pdf_to_cdf(int curve_index) {
+	Curve curve = Curves[curve_index];
 	SCP_vector<std::pair<float, float>> pdf_samples;
 	for (float x = 0.f; x < 1.f; x += 0.01f) {
 		pdf_samples.emplace_back(curve.GetValue(x), x);

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -37,6 +37,9 @@ public :
 	//Get
 	float GetValue(float x_val) const;
 
+	// Get
+	float GetValueIntegrated(float x_val) const;
+
 	//Set
 	void ParseData();
 };

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -44,6 +44,6 @@ public :
 extern SCP_vector<Curve> Curves;
 
 extern int curve_get_by_name(const SCP_string& in_name);
-extern int pdf_to_cdf(Curve curve);
+extern int pdf_to_cdf(int curve);
 extern void curves_init();
 

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  * Copyright (C) Volition, Inc. 1999.  All rights reserved.
  *

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -44,5 +44,6 @@ public :
 extern SCP_vector<Curve> Curves;
 
 extern int curve_get_by_name(const SCP_string& in_name);
+extern int pdf_to_cdf(Curve curve);
 extern void curves_init();
 

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -277,7 +277,7 @@ void parse_nebula_table(const char* filename)
 					error_display(0, "Bitmap defined for nebula poof %s was not found!", poofp->name);
 
 				if (optional_string("$Scale:"))
-					poofp->scale = ::util::parseUniformRange<float>(0.01f, 100000.0f);
+					poofp->scale = ::util::ParsedRandomFloatRange::parseRandomRange(0.01f, 100000.0f);
 
 				if (optional_string("$Density:")) {
 					stuff_float(&poofp->density);
@@ -299,7 +299,7 @@ void parse_nebula_table(const char* filename)
 				}
 
 				if (optional_string("$Rotation:"))
-					poofp->rotation = ::util::parseUniformRange<float>(-1000.0f, 1000.0f);
+					poofp->rotation = util::ParsedRandomFloatRange::parseRandomRange(-1000.0f, 1000.0f);
 
 				if (optional_string("$View Distance:")) {
 					stuff_float(&poofp->view_dist);
@@ -318,7 +318,7 @@ void parse_nebula_table(const char* filename)
 				}
 
 				if (optional_string("$Alpha:")) {
-					poofp->alpha = ::util::parseUniformRange<float>(0.0f, 1.0f);
+					poofp->alpha = util::ParsedRandomFloatRange::parseRandomRange(0.0f, 1.0f);
 				}
 			}
 		}

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -67,11 +67,11 @@ typedef struct poof_info {
 	char name[NAME_LENGTH];
 	char bitmap_filename[MAX_FILENAME_LEN];
 	generic_anim bitmap;
-	::util::UniformFloatRange scale;
+	::util::ParsedRandomFloatRange scale;
 	float density;						 // poofs per square meter; can get *really* small but vague approximation is ok at those levels
-	::util::UniformFloatRange rotation;
+	::util::ParsedRandomFloatRange rotation;
 	float view_dist;
-	::util::UniformFloatRange alpha;
+	::util::ParsedRandomFloatRange alpha;
 	vec3d alignment;
 
 	// These values are dynamic, unlike the above and can change during a mission.
@@ -81,14 +81,15 @@ typedef struct poof_info {
 	bool fade_in;			// true if fading the poof type in, false if fading out
 	float fade_multiplier;	// the current multiplier for a poof's alpha transparency used to render the poofs of this type
 
-	poof_info() {
+	poof_info() : 
+		scale(::util::UniformFloatRange(175.f, 175.f)),
+		rotation(::util::UniformFloatRange(-3.7f, 3.7f)),
+		alpha(::util::UniformFloatRange(0.8f, 0.8f))
+	{
 		bitmap_filename[0] = '\0';
 		generic_anim_init(&bitmap);
-		scale = ::util::UniformFloatRange(175.0f, 175.0f);
 		density = 1 / (110.f * 110.f * 110.f);
-		rotation = ::util::UniformFloatRange(-3.7f, 3.7f);
 		view_dist = 250.f;
-		alpha = ::util::UniformFloatRange(0.8f, 0.8f);
 		fade_start = TIMESTAMP::invalid();
 		fade_duration = -1;
 		fade_in = true;

--- a/code/particle/effects/ConeShape.h
+++ b/code/particle/effects/ConeShape.h
@@ -45,7 +45,7 @@ class ConeShape {
 				deviation = 1.0f;
 			}
 
-			m_normalDeviation = ::util::NormalFloatRange(0.0, fl_radians(deviation));
+			m_normalDeviation = ::util::NormalFloatRange(0.f, fl_radians(deviation));
 		}
 	}
 

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -33,15 +33,15 @@ class GenericShapeEffect : public ParticleEffect {
 	util::ParticleProperties m_particleProperties;
 
 	ConeDirection m_direction = ConeDirection::Incoming;
-	::util::UniformFloatRange m_velocity;
-	::util::UniformUIntRange m_particleNum;
+	::util::ParsedRandomFloatRange m_velocity;
+	::util::ParsedRandomRange<uint> m_particleNum;
 	float m_particleChance = 1.0f;
-	::util::UniformFloatRange m_particleRoll;
+	::util::ParsedRandomFloatRange m_particleRoll;
 	ParticleEffectHandle m_particleTrail = ParticleEffectHandle::invalid();
 
 	util::EffectTiming m_timing;
 
-	::util::UniformFloatRange m_vel_inherit;
+	::util::ParsedRandomFloatRange m_vel_inherit;
 
 	TShape m_shape;
 
@@ -176,11 +176,11 @@ class GenericShapeEffect : public ParticleEffect {
 		m_shape.parse(nocreate);
 
 		if (internal::required_string_if_new("+Velocity:", nocreate)) {
-			m_velocity = ::util::parseUniformRange<float>();
+			m_velocity = ::util::ParsedRandomFloatRange::parseRandomRange();
 		}
 
 		if (internal::required_string_if_new("+Number:", nocreate)) {
-			m_particleNum = ::util::parseUniformRange<uint>();
+			m_particleNum = ::util::ParsedRandomRange<uint>::parseRandomRange();
 		}
 		if (!nocreate) {
 			m_particleChance = 1.0f;
@@ -231,7 +231,7 @@ class GenericShapeEffect : public ParticleEffect {
 		}
 
 		if (optional_string("+Parent Velocity Factor:")) {
-			m_vel_inherit = ::util::parseUniformRange<float>();
+			m_vel_inherit = ::util::ParsedRandomFloatRange::parseRandomRange();
 		}
 
 		m_timing = util::EffectTiming::parseTiming();

--- a/code/particle/effects/SingleParticleEffect.cpp
+++ b/code/particle/effects/SingleParticleEffect.cpp
@@ -44,7 +44,7 @@ void SingleParticleEffect::parseValues(bool nocreate) {
 	m_particleProperties.parse(nocreate);
 
 	if (optional_string("+Parent Velocity Factor:")) {
-		m_vel_inherit = ::util::parseUniformRange<float>();
+		m_vel_inherit = ::util::ParsedRandomFloatRange::parseRandomRange();
 	}
 
 	m_timing = util::EffectTiming::parseTiming();

--- a/code/particle/effects/SingleParticleEffect.h
+++ b/code/particle/effects/SingleParticleEffect.h
@@ -20,7 +20,7 @@ class SingleParticleEffect: public ParticleEffect {
 
 	util::EffectTiming m_timing;
 
-	::util::UniformFloatRange m_vel_inherit;
+	::util::ParsedRandomFloatRange m_vel_inherit;
 
  public:
 	explicit SingleParticleEffect(const SCP_string& name);

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -96,11 +96,11 @@ namespace particle {
 			m_particleProperties.parse(nocreate);
 
 			if (internal::required_string_if_new("+Velocity:", nocreate)) {
-				m_velocity = ::util::parseUniformRange<float>();
+				m_velocity = ::util::ParsedRandomFloatRange::parseRandomRange();
 			}
 
 			if (internal::required_string_if_new("+Number:", nocreate)) {
-				m_particleNum = ::util::parseUniformRange<uint>();
+				m_particleNum = ::util::ParsedRandomRange<uint>::parseRandomRange();
 			}
 
 			if (!nocreate) {
@@ -161,7 +161,7 @@ namespace particle {
 			}
 
 			if (optional_string("+Parent Velocity Factor:")) {
-				m_vel_inherit = ::util::parseUniformRange<float>();
+				m_vel_inherit = ::util::ParsedRandomFloatRange::parseRandomRange();
 			}
 
 			m_timing = util::EffectTiming::parseTiming();

--- a/code/particle/effects/VolumeEffect.h
+++ b/code/particle/effects/VolumeEffect.h
@@ -23,13 +23,13 @@ namespace particle {
 			float m_stretch = 1.0f;
 			util::EffectTiming m_timing;
 
-			::util::UniformUIntRange m_particleNum;
+			::util::ParsedRandomRange<uint> m_particleNum;
 			float m_particleChance = 1.0f;
-			::util::UniformFloatRange m_particleRoll;
+			::util::ParsedRandomFloatRange m_particleRoll;
 
-			::util::UniformFloatRange m_velocity;
+			::util::ParsedRandomFloatRange m_velocity;
 
-			::util::UniformFloatRange m_vel_inherit;
+			::util::ParsedRandomFloatRange m_vel_inherit;
 
 		public:
 			explicit VolumeEffect(const SCP_string& name);

--- a/code/particle/util/EffectTiming.cpp
+++ b/code/particle/util/EffectTiming.cpp
@@ -92,7 +92,7 @@ EffectTiming EffectTiming::parseTiming() {
 		}
 		else {
 			timing.m_duration = Duration::Range;
-			timing.m_durationRange = ::util::parseUniformRange<float>(0.0f);
+			timing.m_durationRange = ::util::ParsedRandomFloatRange::parseRandomRange(0.0f);
 		}
 	}
 
@@ -101,12 +101,12 @@ EffectTiming EffectTiming::parseTiming() {
 			error_display(0, "+Delay is not valid for one-time effects!");
 		}
 		else {
-			timing.m_delayRange = ::util::parseUniformRange<float>(0.0f);
+			timing.m_delayRange = ::util::ParsedRandomFloatRange::parseRandomRange(0.0f);
 		}
 	}
 
 	if (optional_string("+Effects per second:")) {
-		timing.m_particlesPerSecond = ::util::parseUniformRange<float>();
+		timing.m_particlesPerSecond = ::util::ParsedRandomFloatRange::parseRandomRange();
 		if (timing.m_particlesPerSecond.min() < 0.001f) {
 			error_display(0, "Invalid effects per second minimum %f. Setting was disabled.", timing.m_particlesPerSecond.min());
 			timing.m_particlesPerSecond = ::util::UniformFloatRange(-1.f);

--- a/code/particle/util/EffectTiming.h
+++ b/code/particle/util/EffectTiming.h
@@ -35,10 +35,10 @@ enum class Duration {
 class EffectTiming {
  private:
 	Duration m_duration;
-	::util::UniformFloatRange m_delayRange;
-	::util::UniformFloatRange m_durationRange;
+	::util::ParsedRandomFloatRange m_delayRange;
+	::util::ParsedRandomFloatRange m_durationRange;
 
-	::util::UniformFloatRange m_particlesPerSecond = ::util::UniformFloatRange(-1.f);
+	::util::ParsedRandomFloatRange m_particlesPerSecond = ::util::UniformFloatRange(-1.f);
  public:
 	struct TimingState {
 		bool initial = true;

--- a/code/particle/util/ParticleProperties.cpp
+++ b/code/particle/util/ParticleProperties.cpp
@@ -4,10 +4,11 @@
 
 #include "bmpman/bmpman.h"
 #include "math/curve.h"
+#include "utils/RandomRange.h"
 
 namespace particle {
 namespace util {
-ParticleProperties::ParticleProperties() : m_radius(0.0f, 1.0f), m_lifetime(0.0f, 1.0f), m_length (0.0f), m_size_lifetime_curve (-1), m_vel_lifetime_curve (-1), m_rotation_type(RotationType::DEFAULT) {
+ParticleProperties::ParticleProperties() : m_radius(::util::UniformFloatRange(0.0f, 1.0f)), m_lifetime(::util::UniformFloatRange(0.0f, 1.0f)), m_length(::util::UniformFloatRange(0.0f)), m_size_lifetime_curve(-1), m_vel_lifetime_curve (-1), m_rotation_type(RotationType::DEFAULT) {
 }
 
 void ParticleProperties::parse(bool nocreate) {
@@ -17,16 +18,16 @@ void ParticleProperties::parse(bool nocreate) {
 	}
 
 	if (optional_string("+Size:")) {
-		m_radius = ::util::parseUniformRange<float>();
+		m_radius = ::util::ParsedRandomFloatRange::parseRandomRange();
 	} else if (optional_string("+Parent Size Factor:")) {
-		m_radius = ::util::parseUniformRange<float>();
+		m_radius = ::util::ParsedRandomFloatRange::parseRandomRange();
 		m_parentScale = true;
 	} else if (!nocreate) {
 		error_display(1, "Missing +Size or +Parent Size Factor");
 	}
 
 	if (optional_string("+Length:")) {
-		m_length = ::util::parseUniformRange<float>();
+		m_length = ::util::ParsedRandomFloatRange::parseRandomRange();
 	}
 
 	if (optional_string("+Lifetime:")) {
@@ -35,12 +36,12 @@ void ParticleProperties::parse(bool nocreate) {
 			m_hasLifetime = false;
 		} else {
 			m_hasLifetime = true;
-			m_lifetime = ::util::parseUniformRange<float>();
+			m_lifetime = ::util::ParsedRandomFloatRange::parseRandomRange();
 		}
 	} else if (optional_string("+Parent Lifetime Factor:")) {
 		m_hasLifetime = true;
 		m_parentLifetime = true;
-		m_lifetime = ::util::parseUniformRange<float>();
+		m_lifetime = ::util::ParsedRandomFloatRange::parseRandomRange();
 	}
 
 	if (optional_string("+Size over lifetime curve:")) {

--- a/code/particle/util/ParticleProperties.h
+++ b/code/particle/util/ParticleProperties.h
@@ -26,12 +26,12 @@ private:
 
 	SCP_vector<int> m_bitmap_list;
 	::util::UniformRange<size_t> m_bitmap_range;
-	::util::UniformFloatRange m_radius;
+	::util::ParsedRandomFloatRange m_radius;
 	bool m_parentLifetime = false;
 	bool m_parentScale = false;
 	bool m_hasLifetime = false;
-	::util::UniformFloatRange m_lifetime;
-	::util::UniformFloatRange m_length;
+	::util::ParsedRandomFloatRange m_lifetime;
+	::util::ParsedRandomFloatRange m_length;
 	int m_size_lifetime_curve;
 	int m_vel_lifetime_curve;
 	RotationType m_rotation_type;

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -95,8 +95,8 @@ struct game_snd
 	GameSoundCycleType cycle_type = GameSoundCycleType::SequentialCycle;
 	size_t last_entry_index; //!< The last sound entry used by this sound.
 
-	util::UniformFloatRange pitch_range; //!< The range of possible pitch values used randomly for this sound
-	util::UniformFloatRange volume_range; //!< The possible range of the default volume (range is (0, 1]).
+	util::ParsedRandomFloatRange pitch_range; //!< The range of possible pitch values used randomly for this sound
+	util::ParsedRandomFloatRange volume_range; //!< The possible range of the default volume (range is (0, 1]).
 
 	EnhancedSoundData enhanced_sound_data;
 

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -533,9 +533,10 @@ class ParsedRandomRange {
 	
 
   public:
-	ParsedRandomRange(variant random_range)
+	  template<typename T>
+	ParsedRandomRange(T&& random_range)
 	{
-		m_random_range = random_range;
+		m_random_range = std::forward<T>(random_range);
 	}
 	ParsedRandomRange() {
 		m_random_range = UniformFloatRange();

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -165,7 +165,7 @@ class BoundedNormalDistribution {
 	inline BoundedNormalDistribution() : BoundedNormalDistribution(param_type{std::normal_distribution<float>::param_type{0.5f, 1.f}, 0.f, 1.f}) {}
 	inline BoundedNormalDistribution(param_type curve) : m_param(curve) {}
 	inline void reset() {}
-	inline param_type param()
+	inline param_type param() const
 	{
 		return m_param;
 	}
@@ -359,7 +359,7 @@ class CurveNumberDistribution {
 	inline CurveNumberDistribution() : CurveNumberDistribution(param_type{-1, NAN, NAN}) {}
 	inline CurveNumberDistribution(param_type curve) : m_param(curve) {}
 	inline void reset() {}
-	inline param_type param()
+	inline param_type param() const
 	{
 		return m_param;
 	}
@@ -455,7 +455,7 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 	optional_string(")");
 
 	if (curve_params.curve < 0) {
-		error_display(0, "Curve %s not found! Random distributions using this curve will return 0.", &curve_name);
+		error_display(0, "Curve %s not found! Random distributions using this curve will return 0.", curve_name.c_str());
 		return CurveFloatRange(curve_params);
 	} else {
 		bool y_below_0 = false;
@@ -472,15 +472,13 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 
 		if (y_below_0) {
 			error_display(0,
-				"Curve %s goes below zero along the Y axis. Random distributions using this curve will return 0.",
-				&curve_name);
+				"Curve %s goes below zero along the Y axis. Random distributions using this curve will return 0.", curve_name.c_str());
 			curve_params.curve = -1;
 			return CurveFloatRange(curve_params);
 		}
 		if (no_y_above_0) {
 			error_display(0,
-				"Curve %s has no values above zero along the Y axis. Random distributions using this curve will return 0.",
-				&curve_name);
+				"Curve %s has no values above zero along the Y axis. Random distributions using this curve will return 0.", curve_name.c_str());
 			curve_params.curve = -1;
 			return CurveFloatRange(curve_params);
 		}

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -562,8 +562,9 @@ class ParsedRandomRange {
 			}
 		}
 	}
-	ParsedRandomRange& operator=(variant random_range) {
-		m_random_range = random_range;
+	template<typename T>
+	ParsedRandomRange& operator=(T&& random_range) {
+		m_random_range = std::forward<T>(random_range);
 		return *this;
 	}
 };

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -185,20 +185,20 @@ class BoundedNormalDistribution {
 	{
 		return this->operator()(generator, m_param);
 	}
-	inline result_type min()
+	inline result_type min() const
 	{
 		return m_param.min;
 	}
-	inline result_type max()
+	inline result_type max() const
 	{
 		return m_param.max;
 	}
-	inline bool operator==(const BoundedNormalDistribution& other)
+	inline bool operator==(const BoundedNormalDistribution& other) const
 	{
 		return (m_param.normal_parameters == other.m_param.normal_parameters && fl_equal(m_param.min, other.m_param.min) &&
 				fl_equal(m_param.max, other.m_param.max));
 	}
-	inline bool operator!=(const BoundedNormalDistribution& other)
+	inline bool operator!=(const BoundedNormalDistribution& other) const
 	{
 		return !(*this == other);
 	}
@@ -222,7 +222,7 @@ inline BoundedNormalFloatRange parseNormalFloatRange(float min = std::numeric_li
 
 	if (num == 0) {
 		error_display(0, "Need at least one value to form a random range!");
-		return BoundedNormalFloatRange();
+		return {};
 	} else if (num == 1) {
 		return BoundedNormalFloatRange(BoundedNormalDistribution::param_type{std::normal_distribution<float>::param_type(valueList[0]), parsed_min, parsed_max});
 	}
@@ -403,19 +403,19 @@ class CurveNumberDistribution {
 	{
 		return this->operator()(generator, m_param);
 	}
-	inline result_type min()
+	inline result_type min() const
 	{
 		return Curves[m_param.curve].keyframes.front().pos.x;
 	}
-	inline result_type max()
+	inline result_type max() const
 	{
 		return Curves[m_param.curve].keyframes.back().pos.x;
 	}
-	inline bool operator==(const CurveNumberDistribution& other)
+	inline bool operator==(const CurveNumberDistribution& other) const
 	{
 		return (m_param.curve == other.m_param.curve && fl_equal(m_param.min, other.m_param.min) && fl_equal(m_param.max, other.m_param.max));
 	}
-	inline bool operator!=(const CurveNumberDistribution& other)
+	inline bool operator!=(const CurveNumberDistribution& other) const
 	{
 		return !(*this == other);
 	}
@@ -437,7 +437,7 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 
 	if (curve_params.curve < 0) {
 		error_display(0, "Curve %s not found! Random distributions using this curve will return 0.", curve_name.c_str());
-		return CurveFloatRange(curve_params);
+		return {curve_params};
 	} else {
 		bool y_below_0 = false;
 		bool no_y_above_0 = true;
@@ -455,13 +455,13 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 			error_display(0,
 				"Curve %s goes below zero along the Y axis. Random distributions using this curve will return 0.", curve_name.c_str());
 			curve_params.curve = -1;
-			return CurveFloatRange(curve_params);
+			return {curve_params};
 		}
 		if (no_y_above_0) {
 			error_display(0,
 				"Curve %s has no values above zero along the Y axis. Random distributions using this curve will return 0.", curve_name.c_str());
 			curve_params.curve = -1;
-			return CurveFloatRange(curve_params);
+			return {curve_params};
 		}
 	}
 
@@ -496,8 +496,7 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 		curve_params.max = max;
 	}
 
-
-	return CurveFloatRange(curve_params);
+	return {curve_params};
 }
 
 template<typename result_type>

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -301,8 +301,7 @@ typedef UniformRange<uint> UniformUIntRange;
  */
 template <typename Value>
 UniformRange<Value> parseUniformRange(Value min = std::numeric_limits<float>::lowest()/2.1f,
-	Value max = std::numeric_limits<float>::max()/2.1f,
-	bool do_limits_check = true)
+	Value max = std::numeric_limits<float>::max()/2.1f)
 {
 	Assertion(min <= max, "Invalid min-max values specified!");
 

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -212,7 +212,7 @@ using BoundedNormalFloatRange = RandomRange<float, BoundedNormalDistribution, st
  *
  * @ingroup randomUtils
  */
-inline BoundedNormalFloatRange parseNormalFloatRange(float min = -INFINITY, float max = INFINITY)
+inline BoundedNormalFloatRange parseNormalFloatRange(float min = std::numeric_limits<float>::lowest()/2.1f, float max = std::numeric_limits<float>::max()/2.1f)
 {
 	float valueList[2];
 	auto num = parse_number_list(valueList);
@@ -300,8 +300,8 @@ typedef UniformRange<uint> UniformUIntRange;
  * @ingroup randomUtils
  */
 template <typename Value>
-UniformRange<Value> parseUniformRange(Value min = -INFINITY,
-	Value max = INFINITY,
+UniformRange<Value> parseUniformRange(Value min = std::numeric_limits<float>::lowest()/2.1f,
+	Value max = std::numeric_limits<float>::max()/2.1f,
 	bool do_limits_check = true)
 {
 	Assertion(min <= max, "Invalid min-max values specified!");
@@ -436,7 +436,7 @@ std::basic_istream<_CharT, _Traits>& operator>>(std::basic_istream<_CharT, _Trai
 
 using CurveFloatRange = RandomRange<float, CurveNumberDistribution, std::minstd_rand>;
 
-inline CurveFloatRange parseCurveFloatRange(float min = -INFINITY, float max = INFINITY) {
+inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<float>::lowest()/2.1f, float max = std::numeric_limits<float>::max()/2.1f) {
 	CurveNumberDistribution::param_type curve_params;
 
 	optional_string("(");
@@ -513,7 +513,7 @@ class ParsedRandomRange {
 	inline result_type max() const {
 		return static_cast<result_type>(mpark::visit([](auto& range) { return range.max(); }, m_random_range));
 	}
-	static ParsedRandomRange parseRandomRange(float min = -INFINITY, float max = INFINITY) {
+	static ParsedRandomRange parseRandomRange(float min = std::numeric_limits<float>::lowest()/2.1f, float max = std::numeric_limits<float>::max()/2.1f) {
 		switch (optional_string_either("NORMAL", "CURVE")) {
 			case 0: {
 				return ParsedRandomRange(parseNormalFloatRange(min, max));

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -474,7 +474,7 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 	}
 
 	if (curve_params.curve < 0) {
-		error_display(0, "Curve %s not found!", &curve_name);
+		error_display(0, "Curve %s not found! Random distributions using this curve will return 0.", &curve_name);
 	}
 
 	return CurveFloatRange(curve_params);

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -2,6 +2,7 @@
 
 #include "globalincs/pstypes.h"
 #include "parse/parselo.h"
+#include "math/curve.h"
 
 #include <random>
 #include <type_traits>
@@ -71,6 +72,7 @@ class RandomRange {
 	bool m_constant;
 	ValueType m_minValue;
 	ValueType m_maxValue;
+	int m_curve = -1;
 
  public:
 	template<typename... Ts>
@@ -103,6 +105,9 @@ class RandomRange {
 	ValueType next() const {
 		if (m_constant) {
 			return m_minValue;
+		} else if (m_curve >= 0) {
+			float interp = Curves[m_curve].GetValue(frand());
+			return (interp * (m_maxValue - m_minValue)) + m_minValue;
 		}
 
 		return m_distribution(m_generator);
@@ -259,6 +264,13 @@ UniformRange<Value> parseUniformRange(Value min = std::numeric_limits<Value>::mi
 		return UniformRange<Value>(valueList[0]);
 	} else {
 		return UniformRange<Value>(valueList[0], valueList[1]);
+	}
+
+	if (optional_string(",")) {
+		SCP_string name;
+		stuff_string(&name, F_NAME);
+		int pdf_curve = curve_get_by_name(name);
+		m_curve = pdf_to_cdf(pdf_curve);
 	}
 }
 }

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -370,6 +370,9 @@ class CurveNumberDistribution {
 	template <typename Generator>
 	inline result_type operator()(Generator& generator, const param_type& param)
 	{
+		if (param.curve < 0) {
+			return 0.f;
+		}
 		float max_integral = Curves[param.curve].GetValueIntegrated(Curves[param.curve].keyframes.back().pos.x);
 		float rand =
 			std::generate_canonical<float, std::numeric_limits<float>::digits, Generator>(generator) * max_integral;
@@ -448,7 +451,7 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 	curve_params.curve = curve_get_by_name(curve_name);
 
 	if (curve_params.min > curve_params.max) {
-	error_display(0, "Minimum value %f is more than maximum value %f!", (float)curve_params.min, (float)curve_params.max);
+		error_display(0, "Minimum value %f is more than maximum value %f!", (float)curve_params.min, (float)curve_params.max);
 		std::swap(curve_params.min, curve_params.max);
 	}
 
@@ -468,6 +471,10 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 	if (curve_params.max > max) {
 		error_display(0, "Second value (%f) is greater than the maximum %f!", (float)curve_params.max, (float)max);
 		curve_params.max = max;
+	}
+
+	if (curve_params.curve < 0) {
+		error_display(0, "Curve %s not found!", &curve_name);
 	}
 
 	return CurveFloatRange(curve_params);

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -476,14 +476,35 @@ inline CurveFloatRange parseCurveFloatRange(float min = -INFINITY, float max = I
 template<typename result_type>
 
 class ParsedRandomRange {
-	mpark::variant<UniformFloatRange, BoundedNormalFloatRange, CurveFloatRange> m_random_range;
+	class DefaultRandomRange {
+	  public:
+		inline float next() const {
+			UNREACHABLE("DefaultRandomRange used; get a coder!");
+			return NAN;
+		};
+		inline float min() const {
+			UNREACHABLE("DefaultRandomRange used; get a coder!");
+			return NAN;
+		};
+		inline float max() const {
+			UNREACHABLE("DefaultRandomRange used; get a coder!");
+			return NAN;
+		};
+	};
+  public:
+	  using variant = mpark::variant<DefaultRandomRange, UniformFloatRange, BoundedNormalFloatRange, CurveFloatRange>;
+  private:
+	variant m_random_range;
 
   public:
-	ParsedRandomRange(mpark::variant<UniformFloatRange, BoundedNormalFloatRange, CurveFloatRange> random_range)
+	ParsedRandomRange(variant random_range)
 	{
 		m_random_range = random_range;
 	}
-	inline result_type next() {
+	ParsedRandomRange() {
+		m_random_range = DefaultRandomRange();
+	};
+	inline result_type next() const {
 		return static_cast<result_type>(mpark::visit([] (auto& range) { return range.next(); }, m_random_range));
 	}
 	inline result_type min() const {
@@ -505,12 +526,13 @@ class ParsedRandomRange {
 			}
 		}
 	}
-	ParsedRandomRange& operator=(mpark::variant<UniformFloatRange, BoundedNormalFloatRange, CurveFloatRange> random_range) {
+	ParsedRandomRange& operator=(variant random_range) {
 		m_random_range = random_range;
 		return *this;
 	}
 };
 
 using ParsedRandomFloatRange = ParsedRandomRange<float>;
+using ParsedRandomUintRange = ParsedRandomRange<uint>;
 
 }


### PR DESCRIPTION
This PR 1. adds support for probability distributions defined by curves and 2. allows all tabled instances of uniform random ranges to use uniform, normal, or curve-based ranges (without breaking backwards-compatibility, of course).

@Baezon will probably want to see this.