### PR TITLE
fix memory management in FontManager

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ modernize-*,\
 -modernize-make-unique,\
 -modernize-raw-string-literal,\
 -modernize-use-default-member-init,\
+-modernize-use-nodiscard,\
 -modernize-use-trailing-return-type,\
 -modernize-use-using,\
 performance-*,\

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -2,14 +2,6 @@
 
 namespace font
 {
-	FSFont::FSFont() : name(SCP_string("<Invalid>")), offsetTop(0.0f), offsetBottom(0.0f)
-	{
-	}
-
-	FSFont::~FSFont()
-	{
-	}
-
 	void FSFont::setBottomOffset(float offset)
 	{
 		this->offsetBottom = offset;

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -31,16 +31,16 @@ namespace font
 	class FSFont
 	{
 	private:
-		SCP_string name;	//!< The name of this font
-		SCP_string filename; //!< The file name used to retrieve this font
+		SCP_string name = "<Invalid>";	//!< The name of this font
+		SCP_string filename;			//!< The file name used to retrieve this font
 
 	protected:
-		float offsetTop;		//!< The offset at the top of a line of text
-		float offsetBottom;	//!< The offset at the bottom of a line of text
+		float offsetTop = 0.0f;			//!< The offset at the top of a line of text
+		float offsetBottom = 0.0f;		//!< The offset at the bottom of a line of text
 
-		float _height;
-		float _ascender;
-		float _descender;
+		float _height = 0.0f;
+		float _ascender = 0.0f;
+		float _descender = 0.0f;
 
 		void checkFontMetrics();
 
@@ -51,14 +51,14 @@ namespace font
 		*
 		* @date	23.11.2011
 		*/
-		FSFont();
+		FSFont() = default;
 
 		/**
 		* @brief	Destructor.
 		*
 		* @date	23.11.2011
 		*/
-		virtual ~FSFont();
+		virtual ~FSFont() = default;
 
 		/**
 		* @brief	Sets the name of this font.

--- a/code/graphics/software/FontManager.cpp
+++ b/code/graphics/software/FontManager.cpp
@@ -14,71 +14,78 @@
 
 namespace font
 {
-
 	SCP_map<SCP_string, TrueTypeFontData> FontManager::allocatedData;
 	SCP_map<SCP_string, std::unique_ptr<font>> FontManager::vfntFontData;
 	SCP_vector<std::unique_ptr<FSFont>> FontManager::fonts;
 
-	FSFont* FontManager::currentFont = NULL;
+	int FontManager::currentFontIndex = -1;
 
 	FSFont* FontManager::getFont(const SCP_string& name)
 	{
-		for (SCP_vector<std::unique_ptr<FSFont>>::iterator iter = fonts.begin(); iter != fonts.end(); iter++)
+		for (auto &iter: fonts)
 		{
-			if ((*iter)->getName() == name)
-				return iter->get();
-		}
-
-		return NULL;
-	}
-
-	FSFont* FontManager::getFontByFilename(const SCP_string& filename) 
-	{
-		for (auto & iter : fonts) 
-		{
-			if (iter->getFilename() == filename)
+			if (lcase_equal(iter->getName(), name))
 				return iter.get();
 		}
+
 		return nullptr;
+	}
+
+	FSFont* FontManager::getFontByFilename(const SCP_string& filename)
+	{
+		for (auto &iter: fonts)
+		{
+			if (lcase_equal(iter->getFilename(), filename))
+				return iter.get();
+		}
+
+		return nullptr;
+	}
+
+	FSFont* FontManager::getFont(int index)
+	{
+		if (!isFontNumberValid(index))
+			return nullptr;
+
+		return fonts[index].get();
 	}
 
 	FSFont *FontManager::getCurrentFont()
 	{
-		return currentFont;
+		return getFont(currentFontIndex);
 	}
 
 	int FontManager::getCurrentFontIndex()
 	{
-		if (!FontManager::isReady())
+		if (!isFontNumberValid(currentFontIndex))
 			return -1;
 
-		return FontManager::getFontIndex(currentFont);
+		return currentFontIndex;
 	}
 
 	int FontManager::getFontIndex(const SCP_string& name)
 	{
 		int index = 0;
 
-		for (SCP_vector<std::unique_ptr<FSFont>>::iterator iter = fonts.begin(); iter != fonts.end(); iter++, index++)
+		for (const auto &iter: fonts)
 		{
-			if ((*iter)->getName() == name)
+			if (lcase_equal(iter->getName(), name))
 				return index;
+			index++;
 		}
 
 		return -1;
 	}
 
-	int FontManager::getFontIndex(FSFont *font)
+	int FontManager::getFontIndexByFilename(const SCP_string& filename)
 	{
-		if (font == NULL)
-			return -1;
-
 		int index = 0;
 
-		for (SCP_vector<std::unique_ptr<FSFont>>::iterator iter = fonts.begin(); iter != fonts.end(); iter++, index++)
+		for (const auto &iter: fonts)
 		{
-			if (iter->get() == font)
+			if (lcase_equal(iter->getFilename(), filename))
 				return index;
+			index++;
 		}
 
 		return -1;
@@ -86,32 +93,33 @@ namespace font
 
 	int FontManager::numberOfFonts()
 	{
-		return (int)fonts.size();
+		return static_cast<int>(fonts.size());
 	}
 
 	bool FontManager::isReady()
 	{
-		return currentFont != NULL;
+		return isFontNumberValid(currentFontIndex);
 	}
 
 	bool FontManager::isFontNumberValid(int id)
 	{
-		return id >= 0 && id < (int)fonts.size();
+		return SCP_vector_inbounds(fonts, id);
 	}
 
-	void FontManager::setCurrentFont(FSFont *font)
+	void FontManager::setCurrentFontIndex(int id)
 	{
-		Assertion(font != NULL, "New font pointer may not be NULL!");
-		currentFont = font;
+		Assertion(isFontNumberValid(id), "New font index must be valid!");
+		currentFontIndex = id;
 	}
 
 	font* FontManager::loadFontOld(const SCP_string& typeface)
 	{
-		if (vfntFontData.find(typeface) != vfntFontData.end())
+		auto iter = vfntFontData.find(typeface);
+		if (iter != vfntFontData.end())
 		{
-			font* data = vfntFontData[typeface].get();
+			font* data = iter->second.get();
 
-			Assert(data != NULL);
+			Assert(data != nullptr);
 
 			return data;
 		}
@@ -130,20 +138,22 @@ namespace font
 			fp = cfopen(typeface.c_str(), "rb", CFILE_NORMAL, CF_TYPE_ANY);
 		}
 
-		if (fp == NULL)
+		if ( !fp )
 		{
 			mprintf(("Unable to find font file \"%s\"\n", typeface.c_str()));
-			return NULL;
+			return nullptr;
 		}
 
 		std::unique_ptr<font> fnt(new font());
-		if (!fnt)
+
+		if (typeface.size() <= MAX_FILENAME_LEN - 1)
+			strcpy_s(fnt->filename, typeface.c_str());
+		else
 		{
-			mprintf(("Unable to allocate memory for \"%s\"\n", typeface.c_str()));
-			return NULL;
+			strncpy_s(fnt->filename, typeface.c_str(), MAX_FILENAME_LEN - 1);
+			fnt->filename[MAX_FILENAME_LEN - 1] = '\0';
 		}
 
-		strcpy_s(fnt->filename, typeface.c_str());
 		cfread(&fnt->id, 4, 1, fp);
 		cfread(&fnt->version, sizeof(int), 1, fp);
 		cfread(&fnt->num_chars, sizeof(int), 1, fp);
@@ -167,16 +177,14 @@ namespace font
 		fnt->pixel_data_size = INTEL_INT(fnt->pixel_data_size); //-V570
 
 		if (fnt->kern_data_size)	{
-			fnt->kern_data = (font_kernpair *)vm_malloc(fnt->kern_data_size);
-			Assert(fnt->kern_data != NULL);
+			fnt->kern_data = new font_kernpair[fnt->kern_data_size];
 			cfread(fnt->kern_data, fnt->kern_data_size, 1, fp);
 		}
 		else {
-			fnt->kern_data = NULL;
+			fnt->kern_data = nullptr;
 		}
 		if (fnt->char_data_size)	{
-			fnt->char_data = (font_char *)vm_malloc(fnt->char_data_size);
-			Assert(fnt->char_data != NULL);
+			fnt->char_data = new font_char[fnt->char_data_size];
 			cfread(fnt->char_data, fnt->char_data_size, 1, fp);
 
 			for (int i = 0; i<fnt->num_chars; i++) {
@@ -188,15 +196,14 @@ namespace font
 			}
 		}
 		else {
-			fnt->char_data = NULL;
+			fnt->char_data = nullptr;
 		}
 		if (fnt->pixel_data_size)	{
-			fnt->pixel_data = (ubyte *)vm_malloc(fnt->pixel_data_size);
-			Assert(fnt->pixel_data != NULL);
+			fnt->pixel_data = new ubyte[fnt->pixel_data_size];
 			cfread(fnt->pixel_data, fnt->pixel_data_size, 1, fp);
 		}
 		else {
-			fnt->pixel_data = NULL;
+			fnt->pixel_data = nullptr;
 		}
 		cfclose(fp);
 
@@ -222,9 +229,9 @@ namespace font
 
 		fnt->bm_w = w;
 		fnt->bm_h = h;
-		fnt->bm_data = (ubyte *)vm_malloc(fnt->bm_w*fnt->bm_h);
-		fnt->bm_u = (int *)vm_malloc(sizeof(int)*fnt->num_chars);
-		fnt->bm_v = (int *)vm_malloc(sizeof(int)*fnt->num_chars);
+		fnt->bm_data = new ubyte[fnt->bm_w * fnt->bm_h];
+		fnt->bm_u = new int[fnt->num_chars];
+		fnt->bm_v = new int[fnt->num_chars];
 
 		memset(fnt->bm_data, 0, fnt->bm_w * fnt->bm_h);
 
@@ -238,7 +245,8 @@ namespace font
 				x = 0;
 				y += fnt->h + 2;
 				if (y + fnt->h > fnt->bm_h) {
-					Error(LOCATION, "Font too big!\n");
+					Warning(LOCATION, "Font %s too big!\n", fnt->filename);
+					return nullptr;
 				}
 			}
 			fnt->bm_u[i] = x;
@@ -262,18 +270,18 @@ namespace font
 
 		auto ptr = fnt.get();
 
-		vfntFontData[typeface] = std::move(fnt);
+		vfntFontData.emplace(typeface, std::move(fnt));
 
 		return ptr;
 	}
 
-	VFNTFont *FontManager::loadVFNTFont(const SCP_string& name)
+	std::pair<VFNTFont*, int> FontManager::loadVFNTFont(const SCP_string& name)
 	{
 		font* font = FontManager::loadFontOld(name);
 
-		if (font == NULL)
+		if (font == nullptr)
 		{
-			return NULL;
+			return { nullptr, -1 };
 		}
 		else
 		{
@@ -281,53 +289,48 @@ namespace font
 
 			auto ptr = vfnt.get();
 
-			fonts.push_back(std::move(vfnt));
+			fonts.emplace_back(std::move(vfnt));
 
-			return ptr;
+			return { ptr, static_cast<int>(fonts.size() - 1) };
 		}
 	}
 
-	NVGFont *FontManager::loadNVGFont(const SCP_string& fileName, float fontSize)
+	std::pair<NVGFont*, int> FontManager::loadNVGFont(const SCP_string& fileName, float fontSize)
 	{
-		if (allocatedData.find(fileName) == allocatedData.end())
+		auto iter = allocatedData.find(fileName);
+		if (iter == allocatedData.end())
 		{
-			CFILE *fontFile = cfopen(const_cast<char*>(fileName.c_str()), "rb", CFILE_NORMAL, CF_TYPE_ANY);
+			CFILE *fontFile = cfopen(fileName.c_str(), "rb", CFILE_NORMAL, CF_TYPE_ANY);
 
-			if (fontFile == NULL)
+			if (fontFile == nullptr)
 			{
 				mprintf(("Couldn't open font file \"%s\"\n", fileName.c_str()));
-				return NULL;
+				return { nullptr, -1 };
 			}
 
-			size_t size = static_cast<size_t>(cfilelength(fontFile));
+			int size = cfilelength(fontFile);
 
 			std::unique_ptr<ubyte[]> fontData(new ubyte[size]);
 
-			if (!fontData)
-			{
-				mprintf(("Couldn't allocate " SIZE_T_ARG " bytes for reading font file \"%s\"!\n", size, fileName.c_str()));
-				cfclose(fontFile);
-				return NULL;
-			}
-
-			if (!cfread(fontData.get(), (int)size, 1, fontFile))
+			if (!cfread(fontData.get(), size, 1, fontFile))
 			{
 				mprintf(("Error while reading font data from \"%s\"\n", fileName.c_str()));
 				cfclose(fontFile);
-				return NULL;
+				return { nullptr, -1 };
 			}
 
 			cfclose(fontFile);
 
 			TrueTypeFontData newData;
 
-			newData.size = size;
+			newData.size = static_cast<size_t>(size);
 			std::swap(newData.data, fontData);
 
-			allocatedData.insert(std::make_pair(fileName, std::move(newData)));
+			auto pair = allocatedData.emplace(fileName, std::move(newData));
+			iter = pair.first;
 		}
 
-		auto data = &allocatedData.find(fileName)->second;
+		auto data = &iter->second;
 
 		auto path = graphics::paths::PathRenderer::instance();
 
@@ -335,8 +338,8 @@ namespace font
 		
 		if (handle < 0)
 		{
-			mprintf(("Couldn't couldn't create font for file \"%s\"\n", fileName.c_str()));
-			return NULL;
+			mprintf(("Couldn't create font for file \"%s\"\n", fileName.c_str()));
+			return { nullptr, -1 };
 		}
 
 		std::unique_ptr<NVGFont> nvgFont(new NVGFont());
@@ -345,9 +348,9 @@ namespace font
 
 		auto ptr = nvgFont.get();
 
-		fonts.push_back(std::move(nvgFont));
+		fonts.emplace_back(std::move(nvgFont));
 
-		return ptr;
+		return { ptr, static_cast<int>(fonts.size() - 1) };
 	}
 
 	void FontManager::init()
@@ -360,6 +363,6 @@ namespace font
 		vfntFontData.clear();
 		fonts.clear();
 
-		currentFont = NULL;
+		currentFontIndex = -1;
 	}
 }

--- a/code/graphics/software/FontManager.h
+++ b/code/graphics/software/FontManager.h
@@ -85,14 +85,10 @@ namespace font {
 		*
 		* Returns the font pointer which is located as the specified index or @c NULL when the specified index is invald
 		*
-		* @param index The index that should be returns
+		* @param index The index that should be returned
 		* @return Font pointer
 		*/
-		inline static FSFont *getFont(int index) {
-			Assertion(index >= 0 && index < (int) fonts.size(), "Invalid font index %d given!", index);
-
-			return fonts[index].get();
-		}
+		static FSFont *getFont(int index);
 
 		/**
 		* @brief Returns the index of the currently used font
@@ -112,7 +108,6 @@ namespace font {
 		*/
 		static FSFont *getCurrentFont();
 
-
 		/**
 		* @brief Returns the index of the font with the specified @c name.
 		*
@@ -122,15 +117,12 @@ namespace font {
 		static int getFontIndex(const SCP_string &name);
 
 		/**
-		* @brief Returns the index of the specified font pointer
+		* @brief Returns the index of the font with the specified @c filename.
 		*
-		* Searches through the internal font vector and returns the index for which @verbatim (*fontIterator) == font @endverbatim
-		* is true.
-		*
-		* @param font The font which should be searched
-		* @return The index of the font or -1 when font could not be found
+		* @param filename The filename which should be searched
+		* @return The index or -1 when font could not be found
 		*/
-		static int getFontIndex(FSFont *font);
+		static int getFontIndexByFilename(const SCP_string &filename);
 
 		/**
 		* @brief Returns the number of fonts currently saved in the manager
@@ -151,12 +143,10 @@ namespace font {
 		static bool isFontNumberValid(int fontNumber);
 
 		/**
-		* @brief Sets the currently active font
-		* @param font The font which should be used, may not be @c NULL
-		*
-		* @warning The integrity of the specified pointer is not checked
+		* @brief Sets the currently active font index
+		* @param index The font index which should be used; must be in range
 		*/
-		static void setCurrentFont(FSFont *font);
+		static void setCurrentFontIndex(int index);
 
 		/**
 		* @brief Loads a TrueType font
@@ -166,10 +156,9 @@ namespace font {
 		*
 		* @param fileName The name of the font file which should be loaded
 		* @param fontSize The initial size of the font
-		* @param type The type of the font
-		* @return A FTGLFont pointer or @c NULL when font could not be loaded
+		* @return A FTGLFont pointer or @c NULL when font could not be loaded, paired with the font's index
 		*/
-		static NVGFont *loadNVGFont(const SCP_string &fileName, float fontSize = 12.0f);
+		static std::pair<NVGFont*, int> loadNVGFont(const SCP_string& fileName, float fontSize = 12.0f);
 
 		/**
 		* @brief Loads an old VFNT font
@@ -177,9 +166,9 @@ namespace font {
 		* Loads the VFNT font with the specified @c fileName and returns it in form of a VFNTFont pointer
 		*
 		* @param fileName The name of the font file
-		* @return The font pointer or @c null on error
+		* @return The font pointer or @c null on error, paired with the font's index
 		*/
-		static VFNTFont *loadVFNTFont(const SCP_string &fileName);
+		static std::pair<VFNTFont*, int> loadVFNTFont(const SCP_string& fileName);
 
 		/**
 		* @brief Loads old volition font data
@@ -210,6 +199,6 @@ namespace font {
 		static SCP_map<SCP_string, std::unique_ptr<font>> vfntFontData;
 		static SCP_vector<std::unique_ptr<FSFont>> fonts;
 
-		static FSFont *currentFont;
+		static int currentFontIndex;
 	};
 }

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -75,16 +75,6 @@ namespace font
 		return length;
 	}
 
-	NVGFont::NVGFont() : m_handle(-1), m_letterSpacing(0.0f), m_size(12.0f), m_tabWidth(20.0f)
-	{
-
-	}
-
-	NVGFont::~NVGFont()
-	{
-
-	}
-	
 	void NVGFont::setHandle(int handle)
 	{
 		Assertion(handle >= 0, "Invalid font handle passed!");

--- a/code/graphics/software/NVGFont.h
+++ b/code/graphics/software/NVGFont.h
@@ -9,18 +9,18 @@ namespace font
 	class NVGFont : public FSFont
 	{
 	private:
-		int m_handle;
-		float m_letterSpacing;
-		float m_size;
-		float m_tabWidth;
+		int m_handle = -1;
+		float m_letterSpacing = 0.0f;
+		float m_size = 12.0f;
+		float m_tabWidth = 20.0f;
 
-		font* m_specialCharacters;
+		font* m_specialCharacters = nullptr;
 
 		float m_lineHeight = 0.0f;
 
 	public:
-		NVGFont();
-		~NVGFont() override;
+		NVGFont() = default;
+		~NVGFont() override = default;
 
 		int getHandle() const { return m_handle; }
 		float getSize() const { return m_size; }

--- a/code/graphics/software/VFNTFont.cpp
+++ b/code/graphics/software/VFNTFont.cpp
@@ -113,32 +113,32 @@ namespace font
 	font::~font()
 	{
 		if (this->kern_data) {
-			vm_free(this->kern_data);
+			delete [] this->kern_data;
 			this->kern_data = NULL;
 		}
 
 		if (this->char_data) {
-			vm_free(this->char_data);
+			delete [] this->char_data;
 			this->char_data = NULL;
 		}
 
 		if (this->pixel_data) {
-			vm_free(this->pixel_data);
+			delete [] this->pixel_data;
 			this->pixel_data = NULL;
 		}
 
 		if (this->bm_data) {
-			vm_free(this->bm_data);
+			delete [] this->bm_data;
 			this->bm_data = NULL;
 		}
 
 		if (this->bm_u) {
-			vm_free(this->bm_u);
+			delete [] this->bm_u;
 			this->bm_u = NULL;
 		}
 
 		if (this->bm_v) {
-			vm_free(this->bm_v);
+			delete [] this->bm_v;
 			this->bm_v = NULL;
 		}
 	}

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -142,7 +142,8 @@ namespace
 			}
 		}
 
-		NVGFont *nvgFont = FontManager::loadNVGFont(fontFilename, size);
+		auto nvgPair = FontManager::loadNVGFont(fontFilename, size);
+		auto nvgFont = nvgPair.first;
 
 		if (nvgFont == NULL)
 		{
@@ -226,10 +227,9 @@ namespace
 					}
 				}
 				else {
-					auto old_entry = FontManager::getFontByFilename(fontName);
+					int old_index = FontManager::getFontIndexByFilename(fontName);
 					
-					if (old_entry != nullptr) {
-						int old_index = FontManager::getFontIndex(old_entry);
+					if (old_index >= 0) {
 						special_char_index = Lcl_languages[0].special_char_indexes[old_index];
 					} else {
 
@@ -256,7 +256,7 @@ namespace
 				}
 			}
 
-			auto font_id = FontManager::getFontIndex(nvgFont);
+			int font_id = nvgPair.second;
 
 			// add the index specified to all languages
 			for (auto & Lcl_language : Lcl_languages) {
@@ -293,7 +293,8 @@ namespace
 
 	void parse_vfnt_font(const SCP_string& fontFilename)
 	{
-		VFNTFont *font = FontManager::loadVFNTFont(fontFilename);
+		auto vfntPair = FontManager::loadVFNTFont(fontFilename);
+		auto font = vfntPair.first;
 
 		if (font == NULL)
 		{
@@ -315,7 +316,7 @@ namespace
 		font->setName(fontName);
 		font->setFilename(fontFilename);
 
-		auto font_id = FontManager::getFontIndex(font);
+		int font_id = vfntPair.second;
 
 		int user_defined_default_special_char_index = (int)DEFAULT_SPECIAL_CHAR_INDEX;
 		// 'default' special char index for all languages using this font
@@ -606,9 +607,9 @@ namespace font
 		return FontManager::getFont(name);
 	}
 
-	FSFont *get_font_by_filename(const SCP_string& name)
+	FSFont *get_font_by_filename(const SCP_string& filename)
 	{
-		return FontManager::getFontByFilename(name);
+		return FontManager::getFontByFilename(filename);
 	}
 
 	

--- a/code/graphics/software/font.h
+++ b/code/graphics/software/font.h
@@ -49,13 +49,12 @@ namespace font
 	void close();
 
 	/**
-	* Retrieves the font which is located at index @c font_num and sets this font
-	* as the current font
-	* @param font_num The new font number, may not be an illegal font number
+	* Sets this font number as the current font
+	* @param font_num The new font number; may not be an illegal font number
 	*/
 	inline void set_font(int fontnum)
 	{
-		FontManager::setCurrentFont(FontManager::getFont(fontnum));
+		FontManager::setCurrentFontIndex(fontnum);
 	}
 
 	/**

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -116,7 +116,7 @@ ADE_INDEXER(l_Graphics_Fonts, "number/string IndexOrFilename", "Array of loaded 
 			return ade_set_error(L, "o", l_Font.Set(font_h()));
 		}
 
-		return ade_set_args(L, "o", l_Font.Set(font_h(font::FontManager::getFont(index - 1))));
+		return ade_set_args(L, "o", l_Font.Set(font_h(index - 1)));
 	}
 	else
 	{
@@ -125,7 +125,7 @@ ADE_INDEXER(l_Graphics_Fonts, "number/string IndexOrFilename", "Array of loaded 
 		if(!ade_get_args(L, "*s", &s))
 			return ade_set_error(L, "o", l_Font.Set(font_h()));
 
-		return ade_set_args(L, "o", l_Font.Set(font_h(font::FontManager::getFont(s))));
+		return ade_set_args(L, "o", l_Font.Set(font_h(font::FontManager::getFontIndex(s))));
 	}
 }
 
@@ -137,10 +137,10 @@ ADE_VIRTVAR(CurrentFont, l_Graphics, "font", "Current font", "font", NULL)
 		return ade_set_error(L, "o", l_Font.Set(font_h()));
 
 	if(ADE_SETTING_VAR && newFh->isValid()) {
-		font::FontManager::setCurrentFont(newFh->Get());
+		font::FontManager::setCurrentFontIndex(newFh->GetIndex());
 	}
 
-	return ade_set_args(L, "o", l_Font.Set(font_h(font::FontManager::getCurrentFont())));
+	return ade_set_args(L, "o", l_Font.Set(font_h(font::FontManager::getCurrentFontIndex())));
 }
 
 //****SUBLIBRARY: Graphics/PostEffects

--- a/code/scripting/api/objs/font.cpp
+++ b/code/scripting/api/objs/font.cpp
@@ -1,25 +1,37 @@
 
 #include "font.h"
+#include "graphics/software/FontManager.h"
 
 namespace scripting {
 namespace api {
 
 //**********HANDLE: Font
-font_h::font_h(font::FSFont* fontIn): font(fontIn) {
-}
+font_h::font_h(int fontIndex):
+	_fontIndex(fontIndex)
+{}
 
-font_h::font_h(): font(NULL) {
-}
+font_h::font_h()
+	: _fontIndex(-1)
+{}
 
-font::FSFont* font_h::Get() const {
+font::FSFont* font_h::Get() const
+{
 	if (!isValid())
-		return NULL;
+		return nullptr;
 
-	return font;
+	return font::FontManager::getFont(_fontIndex);
+}
+
+int font_h::GetIndex() const
+{
+	if (!isValid())
+		return -1;
+
+	return _fontIndex;
 }
 
 bool font_h::isValid() const {
-	return font != NULL;
+	return font::FontManager::isFontNumberValid(_fontIndex);
 }
 
 ADE_OBJ(l_Font, font_h, "font", "font handle");

--- a/code/scripting/api/objs/font.h
+++ b/code/scripting/api/objs/font.h
@@ -11,14 +11,14 @@ namespace api {
 
 class font_h
 {
-	font::FSFont *font;
+	int _fontIndex;
 
 public:
-	explicit font_h(font::FSFont* fontIn);
-
+	font_h(int fontIndex);
 	font_h();
 
 	font::FSFont* Get() const;
+	int GetIndex() const;
 
 	bool isValid() const;
 };

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -151,7 +151,7 @@ ADE_FUNC(getFont, l_HudGauge, nullptr, "Returns the font used by the specified H
 	if (font_num < 0 || font_num >= font::FontManager::numberOfFonts())
 		return ade_set_error(L, "o", l_Font.Set(font_h()));
 
-	return ade_set_args(L, "o", l_Font.Set(font_h(font::FontManager::getFont(font_num))));
+	return ade_set_args(L, "o", l_Font.Set(font_h(font_num)));
 }
 
 ADE_FUNC(getOriginAndOffset, l_HudGauge, nullptr, "Returns the origin and offset of the specified HUD gauge as specified in the table.",

--- a/code/ui/window.cpp
+++ b/code/ui/window.cpp
@@ -564,7 +564,7 @@ void UI_WINDOW::add_XSTR(UI_XSTR *xstr)
 
 void UI_WINDOW::draw_one_xstr(UI_XSTR *xs, int frame)
 {
-	font::FSFont *f_backup = NULL;
+	int f_backup = -1;
 	char str[255] = "";
 
 	// sanity
@@ -580,8 +580,8 @@ void UI_WINDOW::draw_one_xstr(UI_XSTR *xs, int frame)
 	// maybe set the font
 	if(xs->font_id >= 0){
 		// backup the current font
-		Assert(font::get_current_font() != NULL);
-		f_backup = font::get_current_font();
+		f_backup = font::FontManager::getCurrentFontIndex();
+		Assert(f_backup >= 0);
 
 		// set the new font
 		font::set_font(xs->font_id);
@@ -642,8 +642,8 @@ void UI_WINDOW::draw_one_xstr(UI_XSTR *xs, int frame)
 	}
 
 	// maybe restore the old font
-	if(f_backup != NULL){
-		font::FontManager::setCurrentFont(f_backup);
+	if(f_backup >= 0){
+		font::FontManager::setCurrentFontIndex(f_backup);
 	}			
 }
 

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -6777,7 +6777,7 @@ sexp_list_item *sexp_tree::get_listing_opf_font()
 	sexp_list_item head;
 
 	for (i = 0; i < font::FontManager::numberOfFonts(); i++) {
-		head.add_data(const_cast<char*>(font::FontManager::getFont(i)->getName().c_str()));
+		head.add_data(font::FontManager::getFont(i)->getName().c_str());
 	}
 
 	return head.next;

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4388,7 +4388,7 @@ sexp_list_item* sexp_tree::get_listing_opf_font() {
 	sexp_list_item head;
 
 	for (i = 0; i < font::FontManager::numberOfFonts(); i++) {
-		head.add_data(const_cast<char*>(font::FontManager::getFont(i)->getName().c_str()));
+		head.add_data(font::FontManager::getFont(i)->getName().c_str());
 	}
 
 	return head.next;


### PR DESCRIPTION
This refactors FontManager to improve it in several ways:
1. Change all the dynamic memory management to use `new`, rather than mixing `new` and `vm_malloc`
2. Change the current font to use an index rather than a pointer
3. Take advantage of more C++11 features to avoid redundant lookups
4. Use case-insensitive name comparison
5. Avoid overflowing the `fnt->filename` field
6. Use `Warning` rather than `Error` in a non-critical error situation

Motivated by #6313 but does not fix the crash.