### PR TITLE
fix the mysterious crash in BWO

### DIFF
--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -67,8 +67,6 @@ int Campaign_list_coords[GR_NUM_RESOLUTIONS][4] = {
 #define MODE_CAMPAIGNS	0
 #define MODE_MISSIONS	1
 
-#define MAX_LINES					200
-#define MAX_DESC_LINES			200
 #define NUM_BUTTONS				11
 #define LIST_BUTTONS_MAX		42
 
@@ -196,7 +194,7 @@ static struct {
 	int x;						// X coordinate of line
 	int y;						// Y coordinate of line
 	int flags;					// special flags, see READYROOM_FLAG_* defines above
-} sim_room_lines[MAX_LINES];
+} sim_room_lines[LIST_BUTTONS_MAX];
 
 static char Cur_campaign[MAX_FILENAME_LEN];
 static char *Mission_filenames[MAX_MISSIONS] = { NULL };
@@ -405,7 +403,7 @@ void campaign_mission_hash_table_delete()
 // add a line of sim_room smuck to end of list
 int sim_room_line_add(int type, const char *name, const char *filename, int x, int y, int flags)
 {
-	if (Num_lines >= MAX_LINES)
+	if (Num_lines >= LIST_BUTTONS_MAX)
 		return 0;
 
 	sim_room_lines[Num_lines].type = type;
@@ -1507,14 +1505,6 @@ UI_XSTR Cr_text[GR_NUM_RESOLUTIONS][CR_NUM_TEXT] = {
 	}
 };
 
-/*
-static struct {
-	char *text;
-	int len;
-} campaign_desc_lines[MAX_DESC_LINES];
-*/
-
-static int Num_desc_lines;
 static int Desc_scroll_offset;
 static int Selected_campaign_index;
 static int Active_campaign_index;
@@ -1786,7 +1776,6 @@ void campaign_room_init()
 	Campaign_room_overlay_id = help_overlay_get_index(CAMPAIGN_ROOM_OVERLAY);
 	help_overlay_set_state(Campaign_room_overlay_id,gr_screen.res,0);
 
-	Num_desc_lines = 0;
 	Desc_scroll_offset = Scroll_offset = 0;
 
 	// this stuff needs to happen before the mission_campaign_build_list() call


### PR DESCRIPTION
This is an error that existed all the way back in retail.  Each line in the simulator room (i.e. each mission name in the list) is also a "button" in the sense that clicking on it will highlight the line and set some values.  The maximum number of buttons is `LIST_BUTTONS_MAX`, but the maximum number of `sim_room_lines` was a different #define, `MAX_LINES`.  This was set to 200, a far higher value than the `LIST_BUTTONS_MAX` value of 42.  The code responsibly checked the limit, but the limit was incorrect.

(This had not been seen in previous mods because the number of lines was never high enough to reach 42.  BWO happened to use a font that was small enough to fit that many lines in the mission simulator screen.  This explains why removing fonts.tbl prevented the bug from occurring.)

Thus when the number of lines reached 42, the sim room started writing to out-of-bounds memory.  This didn't cause a crash immediately, but did corrupt the `Static_lights` vector, which in turn caused a crash as soon as a model was lit in-mission or in the ship loadout screen.  It's rather strange that this crash only occurred in optimized SSE2 builds though.

The fix is simply to use `LIST_BUTTONS_MAX` as the limit, rather than `MAX_LINES`.  This also removes the unused `MAX_DESC_LINES` and `Num_desc_lines` at the same time.

Fixes #6313.