### PR TITLE
Reset hotkey lines before populating 

### DIFF
--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -506,6 +506,12 @@ int get_ship_hotkeys(int n)
 	return Hotkey_bits[Hotkey_lines[n].index];
 }
 
+void hotkey_lines_reset_all() {
+	for (int i = 0; i < MAX_LINES; ++i) {
+		Hotkey_lines[i] = hotkey_line();
+	}
+}
+
 // add a line of hotkey smuck to end of list
 int hotkey_line_add(const char *text, HotkeyLineType type, int index, int y)
 {
@@ -1014,6 +1020,7 @@ void mission_hotkey_init()
 
 	Scroll_offset = 0;
 	Selected_line = 1;
+	hotkey_lines_reset_all();
 	hotkey_build_listing();
 }
 

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -507,8 +507,8 @@ int get_ship_hotkeys(int n)
 }
 
 void hotkey_lines_reset_all() {
-	for (int i = 0; i < MAX_LINES; ++i) {
-		Hotkey_lines[i] = hotkey_line();
+	for (auto& line : Hotkey_lines) {
+		line = hotkey_line();
 	}
 }
 

--- a/code/mission/missionhotkey.h
+++ b/code/mission/missionhotkey.h
@@ -46,6 +46,9 @@ void mission_hotkey_mf_add( int set, int objnum, int how_to_add );
 
 void mission_hotkey_exit();
 
+// function to reset the hotkey list
+void hotkey_lines_reset_all();
+
 // function to build the hotkey listing
 void hotkey_build_listing();
 

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -1921,6 +1921,7 @@ ADE_FUNC(initHotkeysList,
 
 	reset_hotkeys();
 	hotkey_set_selected_line(1);
+	hotkey_lines_reset_all();
 	hotkey_build_listing();
 
 	// We want to allow the API to handle expanding wings on its own,


### PR DESCRIPTION
`Hotkey_lines` is populated whenever the screen is started, both in retail and SCPUI, so we should clear the array before we do so to make sure it's not polluted with data from past missions.