### PR TITLE
QtFRED: Custom Warp Dialog

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -88,6 +88,8 @@ add_file_folder("Source/Mission/Dialogs/ShipEditor"
 	src/mission/dialogs/ShipEditor/ShipTBLViewerModel.h
 	src/mission/dialogs/ShipEditor/ShipPathsDialogModel.cpp
 	src/mission/dialogs/ShipEditor/ShipPathsDialogModel.h
+	src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
+	src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
 )
 
 add_file_folder("Source/UI"
@@ -156,6 +158,8 @@ add_file_folder("Source/UI/Dialogs/ShipEditor"
 	src/ui/dialogs/ShipEditor/ShipTBLViewer.cpp
 	src/ui/dialogs/ShipEditor/ShipPathsDialog.h
 	src/ui/dialogs/ShipEditor/ShipPathsDialog.cpp
+	src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
+	src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
 )
 
 add_file_folder("Source/UI/Util"
@@ -206,6 +210,7 @@ add_file_folder("UI"
 	ui/ShipTextureReplacementDialog.ui
 	ui/ShipTBLViewer.ui
 	ui/ShipPathsDialog.ui
+	ui/ShipCustomWarpDialog.ui
 )
 
 add_file_folder("Resources"

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
@@ -1,9 +1,7 @@
 #include "ShipCustomWarpDialogModel.h"
 
 #include "ship/shipfx.h"
-namespace fso {
-namespace fred {
-namespace dialogs {
+namespace fso::fred::dialogs {
 ShipCustomWarpDialogModel::ShipCustomWarpDialogModel(QObject* parent, EditorViewport* viewport, bool departure)
 	: AbstractDialogModel(parent, viewport), _m_departure(departure)
 {
@@ -280,5 +278,3 @@ void ShipCustomWarpDialogModel::setPlayerSpeed(const double newValue)
 	modify(_m_player_warpout_speed, static_cast<float>(newValue));
 }
 } // namespace dialogs
-} // namespace fred
-} // namespace fso

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
@@ -57,7 +57,7 @@ bool ShipCustomWarpDialogModel::apply()
 	if (!_m_anim.empty()) {
 		strcpy_s(params.anim, _m_anim.c_str());
 	}
-	params.supercap_warp_physics = (_m_supercap_warp_physics == true);
+	params.supercap_warp_physics = _m_supercap_warp_physics;
 	if (_m_departure && _m_player_warpout_speed) {
 		params.warpout_player_speed = _m_player_warpout_speed;
 	}
@@ -201,7 +201,7 @@ void ShipCustomWarpDialogModel::initializeData()
 			_m_anim = params->anim;
 		}
 
-		_m_supercap_warp_physics = params->supercap_warp_physics ? true : false;
+		_m_supercap_warp_physics = params->supercap_warp_physics;
 
 		if (params->warpout_player_speed > 0.0f) {
 			_m_player_warpout_speed = params->warpout_player_speed;
@@ -224,7 +224,7 @@ void ShipCustomWarpDialogModel::setType(const int index)
 {
 	modify(_m_warp_type, index);
 }
-void ShipCustomWarpDialogModel::setStartSound(const SCP_string newSound)
+void ShipCustomWarpDialogModel::setStartSound(const SCP_string& newSound)
 {
 	if (!newSound.empty()) {
 		modify(_m_start_sound, newSound);
@@ -233,7 +233,7 @@ void ShipCustomWarpDialogModel::setStartSound(const SCP_string newSound)
 		set_modified();
 	}
 }
-void ShipCustomWarpDialogModel::setEndSound(const SCP_string newSound)
+void ShipCustomWarpDialogModel::setEndSound(const SCP_string& newSound)
 {
 	if (!newSound.empty()) {
 		modify(_m_end_sound, newSound);

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
@@ -1,0 +1,163 @@
+#include "ShipCustomWarpDialogModel.h"
+
+#include "ship/shipfx.h"
+namespace fso {
+namespace fred {
+namespace dialogs {
+ShipCustomWarpDialogModel::ShipCustomWarpDialogModel(QObject* parent, EditorViewport* viewport, bool departure)
+	: AbstractDialogModel(parent, viewport), _m_departure(departure)
+{
+	initializeData();
+}
+
+bool ShipCustomWarpDialogModel::apply()
+{
+	return false;
+}
+
+void ShipCustomWarpDialogModel::reject() {}
+
+int ShipCustomWarpDialogModel::getType() const
+{
+	return _m_warp_type;
+}
+
+SCP_string ShipCustomWarpDialogModel::getStartSound() const
+{
+	return _m_start_sound;
+}
+
+SCP_string ShipCustomWarpDialogModel::getEndSound() const
+{
+	return _m_end_sound;
+}
+
+float ShipCustomWarpDialogModel::getEngageTime() const
+{
+	return _m_warpout_engage_time;
+}
+
+float ShipCustomWarpDialogModel::getSpeed() const
+{
+	return _m_speed;
+}
+
+float ShipCustomWarpDialogModel::getTime() const
+{
+	return _m_time;
+}
+
+float ShipCustomWarpDialogModel::getExponent() const
+{
+	return _m_accel_exp;
+}
+
+float ShipCustomWarpDialogModel::getRadius() const
+{
+	return _m_radius;
+}
+
+SCP_string ShipCustomWarpDialogModel::getAnim() const
+{
+	return _m_anim;
+}
+
+bool ShipCustomWarpDialogModel::getSupercap() const
+{
+	return _m_supercap_warp_physics;
+}
+
+float ShipCustomWarpDialogModel::getPlayerSpeed() const
+{
+	return _m_player_warpout_speed;
+}
+
+bool ShipCustomWarpDialogModel::departMode() const
+{
+	return _m_departure;
+}
+
+bool ShipCustomWarpDialogModel::isPlayer() const
+{
+	return _m_player;
+}
+
+void ShipCustomWarpDialogModel::initializeData()
+{
+	// find the params of the first marked ship
+	WarpParams* params = nullptr;
+	for (object* objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
+		if ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) {
+			if (objp->flags[Object::Object_Flags::Marked]) {
+				if (!_m_departure) {
+					params = &Warp_params[Ships[objp->instance].warpin_params_index];
+				} else {
+					params = &Warp_params[Ships[objp->instance].warpout_params_index];
+				}
+				if (objp->type = OBJ_START) {
+					_m_player = true;
+				}
+				break;
+			}
+		}
+	}
+
+	if (params != nullptr) {
+		if (params->warp_type & WT_DEFAULT_WITH_FIREBALL) {
+			_m_warp_type = (params->warp_type & WT_FLAG_MASK) + Num_warp_types;
+		} else if (params->warp_type >= 0 && params->warp_type < Num_warp_types) {
+			_m_warp_type = params->warp_type;
+		}
+
+		if (params->snd_start.isValid()) {
+			_m_start_sound = gamesnd_get_game_sound(params->snd_start)->name;
+		}
+		if (params->snd_end.isValid()) {
+			_m_end_sound = gamesnd_get_game_sound(params->snd_end)->name;
+		}
+
+		if (params->warpout_engage_time > 0) {
+			_m_warpout_engage_time = i2fl(params->warpout_engage_time) / 1000.0f;
+		}
+
+		if (params->speed > 0.0f) {
+			_m_speed = params->speed;
+		}
+
+		if (params->time > 0.0f) {
+			_m_time = i2fl(params->time) / 1000.0f;
+		}
+		if (params->accel_exp > 0.0f) {
+			_m_accel_exp = params->accel_exp;
+		}
+
+		if (params->radius > 0.0f) {
+			_m_radius = params->radius;
+		}
+
+		if (strlen(params->anim) > 0) {
+			_m_anim = params->anim;
+		}
+
+		_m_supercap_warp_physics = params->supercap_warp_physics ? true : false;
+
+		if (params->warpout_player_speed > 0.0f) {
+			_m_player_warpout_speed = params->warpout_player_speed;
+		}
+	}
+}
+
+void ShipCustomWarpDialogModel::set_modified()
+{
+	if (!_modified) {
+		_modified = true;
+	}
+}
+
+bool ShipCustomWarpDialogModel::query_modified() const
+{
+	return _modified;
+}
+} // namespace dialogs
+} // namespace fred
+} // namespace fso

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
@@ -156,7 +156,7 @@ void ShipCustomWarpDialogModel::initializeData()
 				} else {
 					params = &Warp_params[Ships[objp->instance].warpout_params_index];
 				}
-				if (objp->type = OBJ_START) {
+				if (objp->type == OBJ_START) {
 					_m_player = true;
 				}
 				break;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
@@ -61,7 +61,7 @@ bool ShipCustomWarpDialogModel::apply()
 	}
 	int index = find_or_add_warp_params(params);
 
-	for (object* objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
+	for (object* objp : list_range(&obj_used_list)) {
 		if ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) {
 			if (objp->flags[Object::Object_Flags::Marked]) {
 				if (!_m_departure)
@@ -146,7 +146,7 @@ void ShipCustomWarpDialogModel::initializeData()
 {
 	// find the params of the first marked ship
 	WarpParams* params = nullptr;
-	for (object* objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
+	for (object* objp : list_range(&obj_used_list)) {
 		if ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) {
 			if (objp->flags[Object::Object_Flags::Marked]) {
 				if (!_m_departure) {

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
@@ -1,0 +1,64 @@
+#pragma once
+#include "../AbstractDialogModel.h"
+namespace fso {
+namespace fred {
+namespace dialogs {
+class ShipCustomWarpDialogModel : public AbstractDialogModel {
+  private:
+	void initializeData();
+	template <typename T>
+	void modify(T& a, const T& b);
+	bool _modified = false;
+	bool _m_departure;
+
+	int _m_warp_type;
+	SCP_string _m_start_sound;
+	SCP_string _m_end_sound;
+	float _m_warpout_engage_time;
+	float _m_speed;
+	float _m_time;
+	float _m_accel_exp;
+	float _m_radius;
+	SCP_string _m_anim;
+	bool _m_supercap_warp_physics;
+	float _m_player_warpout_speed;
+
+	bool _m_player = false;
+	void set_modified();
+
+  public:
+	ShipCustomWarpDialogModel(QObject* parent, EditorViewport* viewport, bool departure);
+	bool apply() override;
+	void reject() override;
+
+	int getType() const;
+	SCP_string getStartSound() const;
+	SCP_string getEndSound() const;
+	float getEngageTime() const;
+	float getSpeed() const;
+	float getTime() const;
+	float getExponent() const;
+	float getRadius() const;
+	SCP_string getAnim() const;
+	bool getSupercap() const;
+	float getPlayerSpeed() const;
+
+	bool departMode() const;
+	bool isPlayer() const;
+
+	bool query_modified() const;
+};
+
+template <typename T>
+inline void ShipCustomWarpDialogModel::modify(T& a, const T& b)
+{
+	if (a != b) {
+		a = b;
+		set_modified();
+		modelChanged();
+	}
+}
+
+} // namespace dialogs
+} // namespace fred
+} // namespace fso

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
@@ -3,10 +3,19 @@
 namespace fso {
 namespace fred {
 namespace dialogs {
+/**
+ * @brief Model for QtFRED's Custom warp dialog
+ */
 class ShipCustomWarpDialogModel : public AbstractDialogModel {
   private:
+	/**
+	 * @brief Initialises data for the model
+	 */
 	void initializeData();
 	template <typename T>
+	/**
+	 * @brief Copies rvalue to the lvalue while setting the modified variable.
+	 */
 	void modify(T& a, const T& b);
 	bool _modified = false;
 	bool _m_departure;
@@ -24,32 +33,95 @@ class ShipCustomWarpDialogModel : public AbstractDialogModel {
 	float _m_player_warpout_speed;
 
 	bool _m_player = false;
+	/**
+	 * @brief Marks the model as modifed
+	 */
 	void set_modified();
 
   public:
+	/**
+	 * @brief Constructor
+	 * @param [in] parent The parent dialog.
+	 * @param [in] viewport The viewport this dialog is attacted to.
+	 * @param [in] departure Whether the dialog is changeing warp-in or warp-out.
+	 */
 	ShipCustomWarpDialogModel(QObject* parent, EditorViewport* viewport, bool departure);
 	bool apply() override;
 	void reject() override;
 
-	//Getters
+	// Getters
+	/**
+	 * @brief Getter
+	 * @return Index of warp type
+	 */
 	int getType() const;
+	/**
+	 * @brief Getter
+	 * @return Sound name
+	 */
 	SCP_string getStartSound() const;
+	/**
+	 * @brief Getter
+	 * @return Sound name
+	 */
 	SCP_string getEndSound() const;
+	/**
+	 * @brief Getter
+	 * @return Engage time in seconds
+	 */
 	float getEngageTime() const;
+	/**
+	 * @brief Getter
+	 * @return ship speed
+	 */
 	float getSpeed() const;
+	/**
+	 * @brief Getter
+	 * @return Time in seconds
+	 */
 	float getTime() const;
+	/**
+	 * @brief Getter
+	 * @return Exponent
+	 */
 	float getExponent() const;
+	/**
+	 * @brief Getter
+	 * @return Radius of effect
+	 */
 	float getRadius() const;
+	/**
+	 * @brief Getter
+	 * @return anim name
+	 */
 	SCP_string getAnim() const;
+	/**
+	 * @brief Getter
+	 * @return Supercap Physics
+	 */
 	bool getSupercap() const;
+	/**
+	 * @brief Getter
+	 * @return Player Warpout Speed
+	 */
 	float getPlayerSpeed() const;
-
+	/**
+	 * @brief Getter
+	 * @return If the model is in depart mode.
+	 */
 	bool departMode() const;
+	/**
+	 * @brief Getter
+	 * @return If the model is working on a player.
+	 */
 	bool isPlayer() const;
-
+	/**
+	 * @brief Getter
+	 * @return If the model has been modified.
+	 */
 	bool query_modified() const;
 
-	//Setters
+	// Setters
 	void setType(const int index);
 	void setStartSound(const SCP_string);
 	void setEndSound(const SCP_string);

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
@@ -123,8 +123,8 @@ class ShipCustomWarpDialogModel : public AbstractDialogModel {
 
 	// Setters
 	void setType(const int index);
-	void setStartSound(const SCP_string);
-	void setEndSound(const SCP_string);
+	void setStartSound(const SCP_string&);
+	void setEndSound(const SCP_string&);
 	void setEngageTime(const double);
 	void setSpeed(const double);
 	void setTime(const double);

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
@@ -31,6 +31,7 @@ class ShipCustomWarpDialogModel : public AbstractDialogModel {
 	bool apply() override;
 	void reject() override;
 
+	//Getters
 	int getType() const;
 	SCP_string getStartSound() const;
 	SCP_string getEndSound() const;
@@ -47,6 +48,19 @@ class ShipCustomWarpDialogModel : public AbstractDialogModel {
 	bool isPlayer() const;
 
 	bool query_modified() const;
+
+	//Setters
+	void setType(const int index);
+	void setStartSound(const SCP_string);
+	void setEndSound(const SCP_string);
+	void setEngageTime(const double);
+	void setSpeed(const double);
+	void setTime(const double);
+	void setExponent(const double);
+	void setRadius(const double);
+	void setAnim(const SCP_string&);
+	void setSupercap(const bool);
+	void setPlayerSpeed(const double);
 };
 
 template <typename T>

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "../AbstractDialogModel.h"
-namespace fso {
-namespace fred {
-namespace dialogs {
+namespace fso::fred::dialogs {
 /**
  * @brief Model for QtFRED's Custom warp dialog
  */
@@ -146,5 +144,3 @@ inline void ShipCustomWarpDialogModel::modify(T& a, const T& b)
 }
 
 } // namespace dialogs
-} // namespace fred
-} // namespace fso

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
@@ -7,9 +7,7 @@
 
 #include <QCloseEvent>
 
-namespace fso {
-namespace fred {
-namespace dialogs {
+namespace fso::fred::dialogs {
 ShipCustomWarpDialog::ShipCustomWarpDialog(QDialog* parent, EditorViewport* viewport, bool departure)
 	: QDialog(parent), ui(new Ui::ShipCustomWarpDialog()),
 	  _model(new ShipCustomWarpDialogModel(this, viewport, departure)), _viewport(viewport)
@@ -211,6 +209,4 @@ void ShipCustomWarpDialog::animChanged()
 		_model->setAnim("");
 	}
 }
-} // namespace dialogs
-} // namespace fred
-} // namespace fso
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
@@ -57,7 +57,7 @@ ShipCustomWarpDialog::ShipCustomWarpDialog(QDialog* parent, EditorViewport* view
 	if (departure) {
 		this->setWindowTitle("Edit Warp-Out Parameters");
 	} else {
-		this->setWindowTitle("Edit Warp-in Parameters");
+		this->setWindowTitle("Edit Warp-In Parameters");
 	}
 	updateUI(true);
 	// Resize the dialog to the minimum size
@@ -94,7 +94,7 @@ void ShipCustomWarpDialog::updateUI(const bool firstrun)
 	if (firstrun) {
 		for (int i = 0; i < Num_warp_types; ++i) {
 			SCP_string name = Warp_types[i];
-			if (name == "Hyperspace") {
+			if (i == WT_HYPERSPACE) {
 				name = "Star Wars";
 			}
 			ui->comboBoxType->addItem(name.c_str());
@@ -135,7 +135,7 @@ void ShipCustomWarpDialog::updateUI(const bool firstrun)
 		}
 	}
 
-	if (ui->comboBoxType->itemText(ui->comboBoxType->currentIndex()) == "Homeworld") {
+	if (ui->comboBoxType->currentIndex() == WT_SWEEPER) {
 		ui->lineEditAnim->setEnabled(true);
 		ui->labelAnim->setEnabled(true);
 	} else {
@@ -143,7 +143,7 @@ void ShipCustomWarpDialog::updateUI(const bool firstrun)
 		ui->labelAnim->setEnabled(false);
 	}
 
-	if (ui->comboBoxType->itemText(ui->comboBoxType->currentIndex()) == "Star Wars") {
+	if (ui->comboBoxType->currentIndex() == WT_HYPERSPACE) {
 		ui->doubleSpinBoxExponent->setEnabled(true);
 		ui->labelExponent->setEnabled(true);
 	} else {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
@@ -1,0 +1,119 @@
+#include "ShipCustomWarpDialog.h"
+
+#include "ui_ShipCustomWarpDialog.h"
+
+#include <ship/shipfx.h>
+#include <ui/util/SignalBlockers.h>
+
+#include <QCloseEvent>
+
+namespace fso {
+namespace fred {
+namespace dialogs {
+ShipCustomWarpDialog::ShipCustomWarpDialog(QDialog* parent, EditorViewport* viewport, bool departure)
+	: QDialog(parent), ui(new Ui::ShipCustomWarpDialog()),
+	  _model(new ShipCustomWarpDialogModel(this, viewport, departure)), _viewport(viewport)
+{
+	ui->setupUi(this);
+	connect(this, &QDialog::accepted, _model.get(), &ShipCustomWarpDialogModel::apply);
+	connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ShipCustomWarpDialog::rejectHandler);
+
+	updateUI(true);
+
+	// Resize the dialog to the minimum size
+	resize(QDialog::sizeHint());
+}
+
+ShipCustomWarpDialog::~ShipCustomWarpDialog() = default;
+void ShipCustomWarpDialog::closeEvent(QCloseEvent* e)
+{
+	if (_model->query_modified()) {
+		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question,
+			"Changes detected",
+			"Do you want to keep your changes?",
+			{DialogButton::Yes, DialogButton::No, DialogButton::Cancel});
+
+		if (button == DialogButton::Cancel) {
+			e->ignore();
+			return;
+		}
+
+		if (button == DialogButton::Yes) {
+			accept();
+			return;
+		}
+		if (button == DialogButton::No) {
+			_model->reject();
+		}
+	}
+
+	QDialog::closeEvent(e);
+}
+void ShipCustomWarpDialog::updateUI(const bool firstrun)
+{
+	util::SignalBlockers blockers(this);
+	if (firstrun) {
+		for (int i = 0; i < Num_warp_types; ++i) {
+			SCP_string name = Warp_types[i];
+			if (name == "Hyperspace") {
+				name = "Star Wars";
+			}
+			ui->comboBoxType->addItem(name.c_str());
+		}
+		for (const auto& fi : Fireball_info) {
+			ui->comboBoxType->addItem(fi.unique_id);
+		}
+		ui->comboBoxType->setCurrentIndex(_model->getType());
+
+		ui->lineEditStartSound->setText(_model->getStartSound().c_str());
+		ui->lineEditEndSound->setText(_model->getEndSound().c_str());
+		if (!_model->departMode()) {
+			ui->doubleSpinBoxEngage->setVisible(false);
+			ui->labelEngageTime->setVisible(false);
+		} else {
+			ui->doubleSpinBoxEngage->setValue(_model->getEngageTime());
+		}
+
+		ui->doubleSpinBoxSpeed->setValue(_model->getSpeed());
+		ui->doubleSpinBoxTime->setValue(_model->getTime());
+
+		if (_model->departMode()) {
+			ui->labelExponent->setText(tr("Deceleration Exponent:"));
+		} else {
+			ui->labelExponent->setText(tr("Aceleration Exponent:"));
+		}
+		ui->doubleSpinBoxExponent->setValue(_model->getExponent());
+		ui->doubleSpinBoxRadius->setValue(_model->getRadius());
+		ui->lineEditAnim->setText(_model->getAnim().c_str());
+		if (_model->getSupercap()) {
+			ui->checkBoxSupercap->setChecked(true);
+		}
+		if (!_model->isPlayer() || !_model->departMode()) {
+			ui->labelPlayerSpeed->setVisible(false);
+			ui->doubleSpinBoxPlayerSpeed->setVisible(false);
+		} else {
+			ui->doubleSpinBoxPlayerSpeed->setValue(_model->getPlayerSpeed());
+		}
+	}
+
+	if (ui->comboBoxType->itemText(ui->comboBoxType->currentIndex()) == "Homeworld")
+		{
+		ui->lineEditAnim->setVisible(true);
+		ui->labelAnim->setVisible(true);
+	} else {
+		ui->lineEditAnim->setVisible(false);
+		ui->labelAnim->setVisible(false);
+	}
+
+	if (ui->comboBoxType->itemText(ui->comboBoxType->currentIndex()) == "Star Wars") {
+		ui->doubleSpinBoxExponent->setVisible(true);
+		ui->labelExponent->setVisible(true);
+	} else {
+		ui->doubleSpinBoxExponent->setVisible(false);
+		ui->labelExponent->setVisible(false);
+	}
+}
+void ShipCustomWarpDialog::rejectHandler() {}
+} // namespace dialogs
+} // namespace fred
+} // namespace fso

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
@@ -16,6 +16,7 @@ ShipCustomWarpDialog::ShipCustomWarpDialog(QDialog* parent, EditorViewport* view
 {
 	ui->setupUi(this);
 	connect(this, &QDialog::accepted, _model.get(), &ShipCustomWarpDialogModel::apply);
+
 	connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ShipCustomWarpDialog::rejectHandler);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, [this]() { updateUI(false); });
@@ -178,9 +179,9 @@ void ShipCustomWarpDialog::startSoundChanged()
 	// enviroments
 	QString temp(ui->lineEditStartSound->text());
 	if (!temp.isEmpty()) {
-		_model.get()->setStartSound(temp.toLatin1().constData());
+		_model->setStartSound(temp.toLatin1().constData());
 	} else {
-		_model.get()->setStartSound("");
+		_model->setStartSound("");
 	}
 }
 void ShipCustomWarpDialog::endSoundChanged()
@@ -189,9 +190,9 @@ void ShipCustomWarpDialog::endSoundChanged()
 	// enviroments
 	QString temp(ui->lineEditEndSound->text());
 	if (!temp.isEmpty()) {
-		_model.get()->setEndSound(temp.toLatin1().constData());
+		_model->setEndSound(temp.toLatin1().constData());
 	} else {
-		_model.get()->setEndSound("");
+		_model->setEndSound("");
 	}
 }
 void ShipCustomWarpDialog::animChanged()
@@ -200,9 +201,9 @@ void ShipCustomWarpDialog::animChanged()
 	// enviroments
 	QString temp(ui->lineEditAnim->text());
 	if (!temp.isEmpty()) {
-		_model.get()->setAnim(temp.toLatin1().constData());
+		_model->setAnim(temp.toLatin1().constData());
 	} else {
-		_model.get()->setAnim("");
+		_model->setAnim("");
 	}
 }
 } // namespace dialogs

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
@@ -56,6 +56,11 @@ ShipCustomWarpDialog::ShipCustomWarpDialog(QDialog* parent, EditorViewport* view
 		_model.get(),
 		&ShipCustomWarpDialogModel::setPlayerSpeed);
 
+	if (departure) {
+		this->setWindowTitle("Edit Warp-Out Parameters");
+	} else {
+		this->setWindowTitle("Edit Warp-in Parameters");
+	}
 	updateUI(true);
 	// Resize the dialog to the minimum size
 	resize(QDialog::sizeHint());
@@ -104,8 +109,8 @@ void ShipCustomWarpDialog::updateUI(const bool firstrun)
 		ui->lineEditStartSound->setText(_model->getStartSound().c_str());
 		ui->lineEditEndSound->setText(_model->getEndSound().c_str());
 		if (!_model->departMode()) {
-			ui->doubleSpinBoxEngage->setVisible(false);
-			ui->labelEngageTime->setVisible(false);
+			ui->doubleSpinBoxEngage->setEnabled(false);
+			ui->labelEngageTime->setEnabled(false);
 		} else {
 			ui->doubleSpinBoxEngage->setValue(_model->getEngageTime());
 		}
@@ -116,7 +121,7 @@ void ShipCustomWarpDialog::updateUI(const bool firstrun)
 		if (_model->departMode()) {
 			ui->labelExponent->setText(tr("Deceleration Exponent:"));
 		} else {
-			ui->labelExponent->setText(tr("Aceleration Exponent:"));
+			ui->labelExponent->setText(tr("Acceleration Exponent:"));
 		}
 		ui->doubleSpinBoxExponent->setValue(_model->getExponent());
 		ui->doubleSpinBoxRadius->setValue(_model->getRadius());
@@ -125,27 +130,27 @@ void ShipCustomWarpDialog::updateUI(const bool firstrun)
 			ui->checkBoxSupercap->setChecked(true);
 		}
 		if (!_model->isPlayer() || !_model->departMode()) {
-			ui->labelPlayerSpeed->setVisible(false);
-			ui->doubleSpinBoxPlayerSpeed->setVisible(false);
+			ui->labelPlayerSpeed->setEnabled(false);
+			ui->doubleSpinBoxPlayerSpeed->setEnabled(false);
 		} else {
 			ui->doubleSpinBoxPlayerSpeed->setValue(_model->getPlayerSpeed());
 		}
 	}
 
 	if (ui->comboBoxType->itemText(ui->comboBoxType->currentIndex()) == "Homeworld") {
-		ui->lineEditAnim->setVisible(true);
-		ui->labelAnim->setVisible(true);
+		ui->lineEditAnim->setEnabled(true);
+		ui->labelAnim->setEnabled(true);
 	} else {
-		ui->lineEditAnim->setVisible(false);
-		ui->labelAnim->setVisible(false);
+		ui->lineEditAnim->setEnabled(false);
+		ui->labelAnim->setEnabled(false);
 	}
 
 	if (ui->comboBoxType->itemText(ui->comboBoxType->currentIndex()) == "Star Wars") {
-		ui->doubleSpinBoxExponent->setVisible(true);
-		ui->labelExponent->setVisible(true);
+		ui->doubleSpinBoxExponent->setEnabled(true);
+		ui->labelExponent->setEnabled(true);
 	} else {
-		ui->doubleSpinBoxExponent->setVisible(false);
-		ui->labelExponent->setVisible(false);
+		ui->doubleSpinBoxExponent->setEnabled(false);
+		ui->labelExponent->setEnabled(false);
 	}
 }
 void ShipCustomWarpDialog::rejectHandler()

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
@@ -27,23 +27,23 @@ ShipCustomWarpDialog::ShipCustomWarpDialog(QDialog* parent, EditorViewport* view
 	connect(ui->lineEditStartSound, &QLineEdit::editingFinished, this, &ShipCustomWarpDialog::startSoundChanged);
 	connect(ui->lineEditEndSound, &QLineEdit::editingFinished, this, &ShipCustomWarpDialog::endSoundChanged);
 	connect(ui->doubleSpinBoxEngage,
-		qOverload<double>(&QDoubleSpinBox::valueChanged),
+		QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		_model.get(),
 		&ShipCustomWarpDialogModel::setEngageTime);
 	connect(ui->doubleSpinBoxSpeed,
-		qOverload<double>(&QDoubleSpinBox::valueChanged),
+		QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		_model.get(),
 		&ShipCustomWarpDialogModel::setSpeed);
 	connect(ui->doubleSpinBoxTime,
-		qOverload<double>(&QDoubleSpinBox::valueChanged),
+		QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		_model.get(),
 		&ShipCustomWarpDialogModel::setTime);
 	connect(ui->doubleSpinBoxExponent,
-		qOverload<double>(&QDoubleSpinBox::valueChanged),
+		QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		_model.get(),
 		&ShipCustomWarpDialogModel::setExponent);
 	connect(ui->doubleSpinBoxRadius,
-		qOverload<double>(&QDoubleSpinBox::valueChanged),
+		QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		_model.get(),
 		&ShipCustomWarpDialogModel::setRadius);
 	connect(ui->checkBoxSupercap, &QCheckBox::toggled, _model.get(), [=](bool param) {
@@ -51,7 +51,7 @@ ShipCustomWarpDialog::ShipCustomWarpDialog(QDialog* parent, EditorViewport* view
 	});
 	connect(ui->lineEditAnim, &QLineEdit::editingFinished, this, &ShipCustomWarpDialog::animChanged);
 	connect(ui->doubleSpinBoxPlayerSpeed,
-		qOverload<double>(&QDoubleSpinBox::valueChanged),
+		QOverload<double>::of(&QDoubleSpinBox::valueChanged),
 		_model.get(),
 		&ShipCustomWarpDialogModel::setPlayerSpeed);
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h>
+
+#include <QtWidgets/QDialog>
+
+namespace fso {
+namespace fred {
+namespace dialogs {
+namespace Ui {
+class ShipCustomWarpDialog;
+}
+
+class ShipCustomWarpDialog : public QDialog {
+	Q_OBJECT
+  public:
+	explicit ShipCustomWarpDialog(QDialog* parent, EditorViewport* viewport, const bool departure = false);
+	~ShipCustomWarpDialog() override;
+
+  protected:
+	void closeEvent(QCloseEvent*) override;
+
+  private:
+	std::unique_ptr<Ui::ShipCustomWarpDialog> ui;
+	std::unique_ptr<ShipCustomWarpDialogModel> _model;
+	EditorViewport* _viewport;
+	void updateUI(const bool firstRun = false);
+	void rejectHandler();
+};
+} // namespace dialogs
+} // namespace fred
+} // namespace fso

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
@@ -25,6 +25,10 @@ class ShipCustomWarpDialog : public QDialog {
 	EditorViewport* _viewport;
 	void updateUI(const bool firstRun = false);
 	void rejectHandler();
+
+	void startSoundChanged();
+	void endSoundChanged();
+	void animChanged();
 };
 } // namespace dialogs
 } // namespace fred

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
@@ -3,9 +3,7 @@
 
 #include <QtWidgets/QDialog>
 
-namespace fso {
-namespace fred {
-namespace dialogs {
+namespace fso::fred::dialogs {
 namespace Ui {
 class ShipCustomWarpDialog;
 }
@@ -58,6 +56,4 @@ class ShipCustomWarpDialog : public QDialog {
 	 */
 	void animChanged();
 };
-} // namespace dialogs
-} // namespace fred
-} // namespace fso
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.h
@@ -9,25 +9,53 @@ namespace dialogs {
 namespace Ui {
 class ShipCustomWarpDialog;
 }
-
+/**
+ * @brief QtFRED's Custom Warp Editor
+ */
 class ShipCustomWarpDialog : public QDialog {
 	Q_OBJECT
   public:
+	/**
+	 * @brief Constructor
+	 * @param [in] parent The parent dialog.
+	 * @param [in] viewport The viewport this dialog is attacted to.
+	 * @param [in] departure Whether the dialog is changeing warp-in or warp-out.
+	 */
 	explicit ShipCustomWarpDialog(QDialog* parent, EditorViewport* viewport, const bool departure = false);
 	~ShipCustomWarpDialog() override;
 
   protected:
+	/**
+	 * @brief Overides the Dialogs Close event to add a confermation dialog
+	 * @param [in] *e The event.
+	 */
 	void closeEvent(QCloseEvent*) override;
 
   private:
 	std::unique_ptr<Ui::ShipCustomWarpDialog> ui;
 	std::unique_ptr<ShipCustomWarpDialogModel> _model;
 	EditorViewport* _viewport;
+	/**
+	 * @brief Populates the UI
+	 * @param [in] firstRun If this is the first run.
+	 */
 	void updateUI(const bool firstRun = false);
+	/**
+	 * @brief Check if the user meant to cancel
+	 */
 	void rejectHandler();
 
+	/**
+	 * @brief Update model with the contents of the start sound text box
+	 */
 	void startSoundChanged();
+	/**
+	 * @brief Update model with the contents of the end sound text box
+	 */
 	void endSoundChanged();
+	/**
+	 * @brief Update model with the contents of the anim text box
+	 */
 	void animChanged();
 };
 } // namespace dialogs

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -879,7 +879,8 @@ void ShipEditorDialog::on_restrictArrivalPathsButton_clicked()
 }
 void ShipEditorDialog::on_customWarpinButton_clicked()
 {
-	// TODO:: Custom warp Dialog
+	auto dialog = new dialogs::ShipCustomWarpDialog(this, _viewport, false);
+	dialog->show();
 }
 void ShipEditorDialog::on_restrictDeparturePathsButton_clicked()
 {
@@ -888,7 +889,9 @@ void ShipEditorDialog::on_restrictDeparturePathsButton_clicked()
 	dialog->show();
 }
 void ShipEditorDialog::on_customWarpoutButton_clicked()
-{ // TODO:: Custom warp Dialog
+{
+	auto dialog = new dialogs::ShipCustomWarpDialog(this, _viewport, true);
+	dialog->show();
 }
 } // namespace dialogs
 } // namespace fred

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
@@ -12,6 +12,7 @@
 #include "ShipTextureReplacementDialog.h"
 #include "ShipTBLViewer.h"
 #include "ShipPathsDialog.h"
+#include "ShipCustomWarpDialog.h"
 
 #include <QAbstractButton>
 #include <QtWidgets/QDialog>

--- a/qtfred/ui/ShipCustomWarpDialog.ui
+++ b/qtfred/ui/ShipCustomWarpDialog.ui
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>fso::fred::dialogs::ShipCustomWarpDialog</class>
+ <widget class="QDialog" name="fso::fred::dialogs::ShipCustomWarpDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>333</width>
+    <height>356</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Parameters</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="layout">
+   <item>
+    <layout class="QFormLayout" name="form">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelType">
+       <property name="text">
+        <string>Warp Type:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="comboBoxType"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelStartSound">
+       <property name="text">
+        <string>Start Sound:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lineEditStartSound">
+       <property name="maxLength">
+        <number>32</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelEndSound">
+       <property name="text">
+        <string>End Sound:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="lineEditEndSound">
+       <property name="maxLength">
+        <number>32</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelEngageTime">
+       <property name="text">
+        <string>Warpout Engage Time:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxEngage"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelSpeed">
+       <property name="text">
+        <string>Warping Speed</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxSpeed"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelTime">
+       <property name="text">
+        <string>Warping Time</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxTime"/>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="labelExponent">
+       <property name="text">
+        <string>Deceleration Exponent:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxExponent"/>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="labelRadius">
+       <property name="text">
+        <string>Radius:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxRadius"/>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="labelAnim">
+       <property name="text">
+        <string>Animation:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLineEdit" name="lineEditAnim">
+       <property name="maxLength">
+        <number>32</number>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="labelSupercap">
+       <property name="text">
+        <string>Supercap Warp Physics:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QCheckBox" name="checkBoxSupercap">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="labelPlayerSpeed">
+       <property name="text">
+        <string>Player Warpout Speed:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QDoubleSpinBox" name="doubleSpinBoxPlayerSpeed"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../resources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/qtfred/ui/ShipCustomWarpDialog.ui
+++ b/qtfred/ui/ShipCustomWarpDialog.ui
@@ -179,5 +179,38 @@
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>fso::fred::dialogs::ShipCustomWarpDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>206</x>
+     <y>331</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>94</x>
+     <y>329</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>fso::fred::dialogs::ShipCustomWarpDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>251</x>
+     <y>333</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>37</x>
+     <y>326</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/qtfred/ui/ShipCustomWarpDialog.ui
+++ b/qtfred/ui/ShipCustomWarpDialog.ui
@@ -23,7 +23,10 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Note: All these parameters are optional.</string>
+      <string>All of these parameters are optional, and a mission designer will usually not need to override more than one or two. These parameters are the same as those found in ships.tbl.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/qtfred/ui/ShipCustomWarpDialog.ui
+++ b/qtfred/ui/ShipCustomWarpDialog.ui
@@ -21,131 +21,138 @@
   </property>
   <layout class="QVBoxLayout" name="layout">
    <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Note: All these parameters are optional.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QFormLayout" name="form">
-     <item row="0" column="0">
+     <item row="1" column="0">
       <widget class="QLabel" name="labelType">
        <property name="text">
         <string>Warp Type:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="1" column="1">
       <widget class="QComboBox" name="comboBoxType"/>
      </item>
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="labelStartSound">
        <property name="text">
         <string>Start Sound:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QLineEdit" name="lineEditStartSound">
        <property name="maxLength">
         <number>32</number>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="labelEndSound">
        <property name="text">
         <string>End Sound:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QLineEdit" name="lineEditEndSound">
        <property name="maxLength">
         <number>32</number>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="labelEngageTime">
        <property name="text">
         <string>Warpout Engage Time:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QDoubleSpinBox" name="doubleSpinBoxEngage"/>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="labelSpeed">
        <property name="text">
         <string>Warping Speed</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QDoubleSpinBox" name="doubleSpinBoxSpeed"/>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="labelTime">
        <property name="text">
         <string>Warping Time</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QDoubleSpinBox" name="doubleSpinBoxTime"/>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QLabel" name="labelExponent">
        <property name="text">
         <string>Deceleration Exponent:</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="7" column="1">
       <widget class="QDoubleSpinBox" name="doubleSpinBoxExponent"/>
      </item>
-     <item row="7" column="0">
+     <item row="8" column="0">
       <widget class="QLabel" name="labelRadius">
        <property name="text">
         <string>Radius:</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
+     <item row="8" column="1">
       <widget class="QDoubleSpinBox" name="doubleSpinBoxRadius"/>
      </item>
-     <item row="8" column="0">
+     <item row="9" column="0">
       <widget class="QLabel" name="labelAnim">
        <property name="text">
         <string>Animation:</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="9" column="1">
       <widget class="QLineEdit" name="lineEditAnim">
        <property name="maxLength">
         <number>32</number>
        </property>
       </widget>
      </item>
-     <item row="9" column="0">
+     <item row="10" column="0">
       <widget class="QLabel" name="labelSupercap">
        <property name="text">
         <string>Supercap Warp Physics:</string>
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="10" column="1">
       <widget class="QCheckBox" name="checkBoxSupercap">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
+     <item row="11" column="0">
       <widget class="QLabel" name="labelPlayerSpeed">
        <property name="text">
         <string>Player Warpout Speed:</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="11" column="1">
       <widget class="QDoubleSpinBox" name="doubleSpinBoxPlayerSpeed"/>
      </item>
     </layout>

--- a/qtfred/ui/ShipCustomWarpDialog.ui
+++ b/qtfred/ui/ShipCustomWarpDialog.ui
@@ -3,7 +3,7 @@
  <class>fso::fred::dialogs::ShipCustomWarpDialog</class>
  <widget class="QDialog" name="fso::fred::dialogs::ShipCustomWarpDialog">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::NonModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -193,22 +193,6 @@
     <hint type="destinationlabel">
      <x>94</x>
      <y>329</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::ShipCustomWarpDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>251</x>
-     <y>333</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>37</x>
-     <y>326</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Not much to say on this one. Functions almost exactly the same as the oldFRED one. 

Only changes are not showing lines irrelevant to the selected warp type and additional warnings if game sounds don't not exist.

Also visually shows the Hyperspace warp type as "Star Wars" for clearer useability but does not change the backend.