### PR TITLE
follow-up to BWO crash fix

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1908,7 +1908,7 @@ int control_config_draw_list(int select_tease_line) {
 	char buf[256];  // c_str buffer
 	int font_height = gr_get_font_height();
 
-	for (line = Scroll_offset; cc_line_query_visible(line); ++line) {
+	for (line = Scroll_offset; cc_line_query_visible(line) && (line - Scroll_offset < LIST_BUTTONS_MAX); ++line) {
 		z = Cc_lines[line].cc_index;
 
 		// screen coordinate y = list box origin y + (this item's relative y - topmost item's relative y)

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -67,6 +67,7 @@ int Campaign_list_coords[GR_NUM_RESOLUTIONS][4] = {
 #define MODE_CAMPAIGNS	0
 #define MODE_MISSIONS	1
 
+#define MAX_LINES					200		// NOLINT(modernize-macro-to-enum)
 #define NUM_BUTTONS				11
 #define LIST_BUTTONS_MAX		42
 
@@ -194,7 +195,7 @@ static struct {
 	int x;						// X coordinate of line
 	int y;						// Y coordinate of line
 	int flags;					// special flags, see READYROOM_FLAG_* defines above
-} sim_room_lines[LIST_BUTTONS_MAX];
+} sim_room_lines[MAX_LINES];
 
 static char Cur_campaign[MAX_FILENAME_LEN];
 static char *Mission_filenames[MAX_MISSIONS] = { NULL };
@@ -403,7 +404,7 @@ void campaign_mission_hash_table_delete()
 // add a line of sim_room smuck to end of list
 int sim_room_line_add(int type, const char *name, const char *filename, int x, int y, int flags)
 {
-	if (Num_lines >= LIST_BUTTONS_MAX)
+	if (Num_lines >= MAX_LINES)
 		return 0;
 
 	sim_room_lines[Num_lines].type = type;
@@ -1378,7 +1379,7 @@ void sim_room_do_frame(float  /*frametime*/)
 	}
 
 	line = Scroll_offset;
-	while (sim_room_line_query_visible(line)) {
+	while (sim_room_line_query_visible(line) && (line - Scroll_offset < LIST_BUTTONS_MAX)) {
 		y = list_y + sim_room_lines[line].y - sim_room_lines[Scroll_offset].y;
 
 		if (sim_room_lines[line].type != READYROOM_LINE_CAMPAIGN) {
@@ -1928,7 +1929,7 @@ void campaign_room_do_frame(float  /*frametime*/)
 	font::set_font(font::FONT1);
 	int font_height = gr_get_font_height();
 	line = Scroll_offset;
-	while (sim_room_line_query_visible(line)) {
+	while (sim_room_line_query_visible(line) && (line - Scroll_offset < LIST_BUTTONS_MAX)) {
 		y = Cr_list_coords[gr_screen.res][1] + sim_room_lines[line].y - sim_room_lines[Scroll_offset].y;
 
 		List_buttons[line - Scroll_offset].update_dimensions(Cr_list_coords[gr_screen.res][0], y, Cr_list_coords[gr_screen.res][2], font_height);

--- a/code/mission/missionhotkey.cpp
+++ b/code/mission/missionhotkey.cpp
@@ -1217,7 +1217,7 @@ void mission_hotkey_do_frame(float  /*frametime*/)
 
 	font::set_font(font::FONT1);
 	int line = Scroll_offset;
-	while (hotkey_line_query_visible(line)) {
+	while (hotkey_line_query_visible(line) && (line - Scroll_offset < LIST_BUTTONS_MAX)) {
 		//int z = Hotkey_lines[line].index;
 		int y = Hotkey_list_coords[gr_screen.res][1] + Hotkey_lines[line].y - Hotkey_lines[Scroll_offset].y;
 		int hotkeys = 0;


### PR DESCRIPTION
The BWO fix in PR #6317 was not quite the correct fix.  The `sim_room_lines` array contains the maximum number of scrollable lines, not the maximum number of lines on the screen at one time.  This partially reverts commit 20338ff28b0f483491a7bd297eb4d6293d083ef8 and implements a new fix that allows the full `MAX_LINES` but also properly checks the list button limit.  Additionally, this adds the list button limit check to other vulnerable code sections.

Fixes the tech room being limited to a single page of missions after #6317.  Testing confirms that the BWO crash is still fixed with this update.