### PR TITLE
fix deletion of looping sounds

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10360,11 +10360,10 @@ void update_firing_sounds(object* objp, ship* shipp)
 				end_snd_played = wip->end_firing_snd;
 			}
 
-			if (wip->loop_firing_snd.isValid()) {
+			if (swp->firing_loop_sounds[i] >= 0) {
 				obj_snd_delete(objp, swp->firing_loop_sounds[i]);
-				swp->firing_loop_sounds[i] = -1;
-			} else
-				swp->firing_loop_sounds[i] = -1;
+			}
+			swp->firing_loop_sounds[i] = -1;
 		}
 	}
 }


### PR DESCRIPTION
Per the comment earlier in this function, both -1 and -2 are expected values for sound indexes.  Update the sound validity check accordingly.  Fixes an assertion in `obj_snd_delete()` encountered by FotG when a sound index was -2.