### PR TITLE
follow-up to probability curves

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -845,10 +845,10 @@ void parse_gamesnd_soundset(game_snd* gs, bool no_create) {
 	}
 
 	if (optional_string("+Pitch:")) {
-		gs->pitch_range = util::UniformFloatRange(0.0001f);
+		gs->pitch_range = util::ParsedRandomFloatRange::parseRandomRange(0.0001f);
 	} else if (!no_create) {
 		// Default pitch is 1.0
-		gs->pitch_range = util::ParsedRandomFloatRange::parseRandomRange(1.0f);
+		gs->pitch_range = util::UniformFloatRange(1.0f);
 	}
 }
 

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -235,7 +235,7 @@ float Curve::GetValue(float x_val) const {
 			return kframe->pos.y + out * (next_pos->y - kframe->pos.y);
 		case CurveInterpFunction::Curve:
 			// add 0.5 to ensure this behaves like rounding
-			out = Curves[(int)(kframe->param1 + 0.5f)].GetValue(t);
+			out = Curves[fl2i(kframe->param1 + 0.5f)].GetValue(t);
 			return kframe->pos.y + out * (next_pos->y - kframe->pos.y);
 		default:
 			UNREACHABLE("Unrecognized curve function");
@@ -286,7 +286,7 @@ float Curve::GetValueIntegrated(float x_val) const
 			break;
 		case CurveInterpFunction::Curve:
 			// add 0.5 to ensure this behaves like rounding
-			integrated_value += m * (Curves[(int)(kframe->param1 + 0.5f)].GetValueIntegrated(t) - Curves[(int)(kframe->param1 + 0.5f)].GetValueIntegrated(0.f));
+			integrated_value += m * (Curves[fl2i(kframe->param1 + 0.5f)].GetValueIntegrated(t) - Curves[fl2i(kframe->param1 + 0.5f)].GetValueIntegrated(0.f));
 			break;
 		default:
 			UNREACHABLE("Unrecognized curve function");
@@ -298,4 +298,4 @@ float Curve::GetValueIntegrated(float x_val) const
 	}
 
 	return integrated_value;
-	}
+}

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -49,6 +49,5 @@ public :
 extern SCP_vector<Curve> Curves;
 
 extern int curve_get_by_name(const SCP_string& in_name);
-extern int pdf_to_cdf(int curve);
 extern void curves_init();
 

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -82,9 +82,9 @@ typedef struct poof_info {
 	float fade_multiplier;	// the current multiplier for a poof's alpha transparency used to render the poofs of this type
 
 	poof_info() : 
-		scale(::util::UniformFloatRange(175.f, 175.f)),
+		scale(::util::UniformFloatRange(175.f)),
 		rotation(::util::UniformFloatRange(-3.7f, 3.7f)),
-		alpha(::util::UniformFloatRange(0.8f, 0.8f))
+		alpha(::util::UniformFloatRange(0.8f))
 	{
 		bitmap_filename[0] = '\0';
 		generic_anim_init(&bitmap);

--- a/code/particle/effects/GenericShapeEffect.h
+++ b/code/particle/effects/GenericShapeEffect.h
@@ -34,7 +34,7 @@ class GenericShapeEffect : public ParticleEffect {
 
 	ConeDirection m_direction = ConeDirection::Incoming;
 	::util::ParsedRandomFloatRange m_velocity;
-	::util::ParsedRandomRange<uint> m_particleNum;
+	::util::ParsedRandomUintRange m_particleNum;
 	float m_particleChance = 1.0f;
 	::util::ParsedRandomFloatRange m_particleRoll;
 	ParticleEffectHandle m_particleTrail = ParticleEffectHandle::invalid();
@@ -179,7 +179,7 @@ class GenericShapeEffect : public ParticleEffect {
 		}
 
 		if (internal::required_string_if_new("+Number:", nocreate)) {
-			m_particleNum = ::util::ParsedRandomRange<uint>::parseRandomRange();
+			m_particleNum = ::util::ParsedRandomUintRange::parseRandomRange();
 		}
 		if (!nocreate) {
 			m_particleChance = 1.0f;

--- a/code/particle/effects/VolumeEffect.cpp
+++ b/code/particle/effects/VolumeEffect.cpp
@@ -100,7 +100,7 @@ namespace particle {
 			}
 
 			if (internal::required_string_if_new("+Number:", nocreate)) {
-				m_particleNum = ::util::ParsedRandomRange<uint>::parseRandomRange();
+				m_particleNum = ::util::ParsedRandomUintRange::parseRandomRange();
 			}
 
 			if (!nocreate) {

--- a/code/particle/effects/VolumeEffect.h
+++ b/code/particle/effects/VolumeEffect.h
@@ -23,7 +23,7 @@ namespace particle {
 			float m_stretch = 1.0f;
 			util::EffectTiming m_timing;
 
-			::util::ParsedRandomRange<uint> m_particleNum;
+			::util::ParsedRandomUintRange m_particleNum;
 			float m_particleChance = 1.0f;
 			::util::ParsedRandomFloatRange m_particleRoll;
 


### PR DESCRIPTION
Fix the inadvertent swapping of the two utility functions for parsing sounds.  While we're at it, streamline a few lines, remove a few C-style casts, and remove an unused function prototype.

Follow-up to #6314.  Fixes a crash encountered by Inferno on 24.2-RC1.