### PR TITLE
Fix Briefing Icons at 4K in SCPUI

### DIFF
--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1118,7 +1118,6 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 		if ( ( (bx < 0) || (bx > gr_screen.max_w_unscaled) || (by < 0) || (by > gr_screen.max_h_unscaled) ) && !Fred_running ) {
 			bi->x = bx;
 			bi->y = by;
-			return;
 		}
 
 		// render highlight anim frame

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1115,11 +1115,6 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 		by = fl2i(byf);
 		bc = fl2i(sx);
 
-		if ( ( (bx < 0) || (bx > gr_screen.max_w_unscaled) || (by < 0) || (by > gr_screen.max_h_unscaled) ) && !Fred_running ) {
-			bi->x = bx;
-			bi->y = by;
-		}
-
 		// render highlight anim frame
 		if ( (bi->flags & BI_SHOWHIGHLIGHT) && (bi->flags & BI_HIGHLIGHT) ) {
 			hud_anim *ha = &bi->highlight_anim;


### PR DESCRIPTION
I'm honestly not sure if this code was meant to cull icons outside the screen from being rendered or what, exactly. However at 4k resolution in SCPUI it's possible to validly have icons well outside the `gr_screen.max_w_unscaled` boundaries so we shouldn't return here in that case or those icons won't be rendered.

In fact, I don't think we should ever try and cull icons in this step because `gr_aa_bitmap()` already does that when it checks for clipping.

This may not be the right fix.. we could compare to the actual screen width and height but a lot of this code is uncommented and I'm not sure what it's all doing other than trying to scale the icon coordinates. That said, I tested this in both SCPUI and retail with icons in the middle of the map, all 4 corners and outside the map bounds in all directions and everything seemed to render as expected.