### PR TITLE
Fix fade icons not matching parent

### DIFF
--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -1910,7 +1910,7 @@ int brief_set_move_list(int new_stage, int current_stage, float time)
 			Fading_icons[Num_fade_icons].fade_anim = bii->fade;
 			Fading_icons[Num_fade_icons].pos = cb->icons[i].pos;
 			Fading_icons[Num_fade_icons].scale_factor = cb->icons[i].scale_factor;
-			Fading_icons[Num_fade_icons].mirror = (cb->icons[i].flags & BI_MIRROR_ICON) ? true : false;
+			Fading_icons[Num_fade_icons].mirror = (cb->icons[i].flags & BI_MIRROR_ICON) != 0;
 			Fading_icons[Num_fade_icons].team = cb->icons[i].team;
 			Num_fade_icons++;
 		}

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -888,12 +888,6 @@ void brief_render_fade_outs(float frametime)
 	for (i=0; i<Num_fade_icons; i++) {
 		fi = &Fading_icons[i];
 
-		float scale_factor = 1.0f;
-
-		if (fi->scale_factor != 1.0f) {
-			scale_factor *= fi->scale_factor;
-		}
-
 		g3_rotate_vertex(&tv, &fi->pos);
 
 		if (!(tv.flags & PF_PROJECTED))
@@ -919,22 +913,17 @@ void brief_render_fade_outs(float frametime)
 			}
 			gr_unsize_screen_posf(&screenX, &screenY, nullptr, nullptr, this_resize);
 
-			scaled_w = w * scale_factor;
-			scaled_h = h * scale_factor;
+			scaled_w = w * fi->scale_factor;
+			scaled_h = h * fi->scale_factor;
 			bxf = screenX - scaled_w / 2.0f + 0.5f;
 			byf = screenY - scaled_h / 2.0f + 0.5f;
-			bx = fl2i(bxf);
-			by = fl2i(byf);
-
-			bxf = screenX - w / 2.0f + 0.5f;
-			byf = screenY - h / 2.0f + 0.5f;
 			bx = fl2i(bxf);
 			by = fl2i(byf);
 
 			if ( fi->fade_anim.first_frame >= 0 ) {
 				fi->fade_anim.sx = bx;
 				fi->fade_anim.sy = by;
-				hud_anim_render(&fi->fade_anim, frametime, 1, 0, 0, 0, bscreen.resize, fi->mirror, scale_factor);
+				hud_anim_render(&fi->fade_anim, frametime, 1, 0, 0, 0, bscreen.resize, fi->mirror, fi->scale_factor);
 			}
 		}
 	}


### PR DESCRIPTION
Fade icons did not always match the scaling or mirror setting of their parent icon, so let's fix that.

Yes I know I add `float scale_factor` here that's not strictly necessary. However that will be used in my next PR that will create a user setting to arbitrarily scale icons up or down.