### PR TITLE
Optional icon scaling

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1857 // This is the next available ID
+// #define XSTR_SIZE	1859 // This is the next available ID
 
 
 // struct to allow for strings.tbl-determined x offset

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -49,6 +49,19 @@ brief_screen bscreen;
 #define BRIEF_CUPINFO_X2	639
 #define BRIEF_CUPINFO_Y2	438
 
+float Briefing_Icon_Scale_Factor = 1.0;
+
+static auto IconScaleFactor __UNUSED = options::OptionBuilder<float>("Game.BriefIconScaleFactor",
+                     std::pair<const char*, int>{"Briefing Icon Scale Factor", 1857},
+                     std::pair<const char*, int>{"Scales the size of the briefing icons", 1858})
+                     .category(std::make_pair("Game", 1824))
+                     .range(0.2f, 4.0f) //Upper limit is somewhat arbitrary
+                     .level(options::ExpertLevel::Advanced)
+                     .default_val(1.0)
+                     .bind_to(&Briefing_Icon_Scale_Factor)
+                     .importance(55)
+                     .finish();
+
 const char *Brief_static_name[GR_NUM_RESOLUTIONS] = {
 	"BriefMap",
 	"2_BriefMap"
@@ -888,6 +901,16 @@ void brief_render_fade_outs(float frametime)
 	for (i=0; i<Num_fade_icons; i++) {
 		fi = &Fading_icons[i];
 
+		float scale_factor = 1.0f;
+
+		if (fi->scale_factor != 1.0f) {
+			scale_factor *= fi->scale_factor;
+		}
+
+		if (!Fred_running) {
+			scale_factor *= Briefing_Icon_Scale_Factor;
+		}
+
 		g3_rotate_vertex(&tv, &fi->pos);
 
 		if (!(tv.flags & PF_PROJECTED))
@@ -1040,6 +1063,10 @@ void brief_render_icon(int stage_num, int icon_num, float frametime, int selecte
 	mirror_icon = (bi->flags & BI_MIRROR_ICON) ? true : false;
 	if (bi->scale_factor != 1.0f) {
 		scale_factor *= bi->scale_factor;
+	}
+
+	if (!Fred_running) {
+		scale_factor *= Briefing_Icon_Scale_Factor;
 	}
 
 	icon_move_info *mi, *next;

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -901,11 +901,7 @@ void brief_render_fade_outs(float frametime)
 	for (i=0; i<Num_fade_icons; i++) {
 		fi = &Fading_icons[i];
 
-		float scale_factor = 1.0f;
-
-		if (fi->scale_factor != 1.0f) {
-			scale_factor *= fi->scale_factor;
-		}
+		float scale_factor = fi->scale_factor;
 
 		if (!Fred_running) {
 			scale_factor *= Briefing_Icon_Scale_Factor;

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -932,8 +932,8 @@ void brief_render_fade_outs(float frametime)
 			}
 			gr_unsize_screen_posf(&screenX, &screenY, nullptr, nullptr, this_resize);
 
-			scaled_w = w * fi->scale_factor;
-			scaled_h = h * fi->scale_factor;
+			scaled_w = w * scale_factor;
+			scaled_h = h * scale_factor;
 			bxf = screenX - scaled_w / 2.0f + 0.5f;
 			byf = screenY - scaled_h / 2.0f + 0.5f;
 			bx = fl2i(bxf);
@@ -942,7 +942,7 @@ void brief_render_fade_outs(float frametime)
 			if ( fi->fade_anim.first_frame >= 0 ) {
 				fi->fade_anim.sx = bx;
 				fi->fade_anim.sy = by;
-				hud_anim_render(&fi->fade_anim, frametime, 1, 0, 0, 0, bscreen.resize, fi->mirror, fi->scale_factor);
+				hud_anim_render(&fi->fade_anim, frametime, 1, 0, 0, 0, bscreen.resize, fi->mirror, scale_factor);
 			}
 		}
 	}

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -65,6 +65,8 @@
 
 #define BRIEF_ICON_TYPES					3
 
+extern float Briefing_Icon_Scale_Factor;
+
 //If any types are added here then be sure to update BRIEF_ICON_TYPES
 typedef struct briefing_icon_info {
 	generic_anim	regular;

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1521,6 +1521,9 @@ void brief_check_for_anim(bool api_access, int api_x, int api_y)
 			ih = static_cast<int>(ih * bi->scale_factor);
 		}
 
+		iw *= Briefing_Icon_Scale_Factor;
+		ih *= Briefing_Icon_Scale_Factor;
+
 		if ( mx < bi->x ) continue;
 		if ( mx > (bi->x + iw) ) continue;
 		if ( my < bi->y ) continue;


### PR DESCRIPTION
Adds a user option to scale icons down to as small as 0.2* the current size or as large as 4*. Includes the code in #6328 .