### PR TITLE
Ttf font scaling option

### DIFF
--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -814,12 +814,26 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, size_t in_len
 		GR_DEBUG_SCOPE("Render TTF string");
 
 		auto path = beginDrawing(resize_mode);
-		path->translate(sx, sy);
 
 		auto nvgFont = static_cast<NVGFont*>(currentFont);
 
+		float scale_factor = Font_Scale_Factor;
+		if (!nvgFont->getScaleBehavior()) {
+			scale_factor = 1.0f;
+		}
+
+		float originalSize = nvgFont->getSize();
+		float scaledSize = originalSize * scale_factor;
+
+		// Calculate the offset to center the text
+		float offsetX = 0.0f;
+		// Not sure if we should do this.. kinda depends on if the text is drawn at the top of the screen or the bottom
+		float offsetY = (scaledSize - originalSize) * 0.5f;
+
+		path->translate(sx - offsetX, sy - offsetY);
+
 		path->fontFaceId(nvgFont->getHandle());
-		path->fontSize(nvgFont->getSize());
+		path->fontSize(scaledSize);
 		path->textLetterSpacing(nvgFont->getLetterSpacing());
 		path->textAlign(static_cast<TextAlign>(ALIGN_TOP | ALIGN_LEFT));
 

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -827,7 +827,8 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, size_t in_len
 
 		// Calculate the offset to center the text
 		float offsetX = 0.0f;
-		// Not sure if we should do this.. kinda depends on if the text is drawn at the top of the screen or the bottom
+		// This is a compromise to try and size the text around center to minimize text offsets during scaling behavior.
+		// TODO Update this if multiline text is found to be negatively affected or a proper method of setting text anchors is added
 		float offsetY = (scaledSize - originalSize) * 0.5f;
 
 		path->translate(sx - offsetX, sy - offsetY);

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -28,7 +28,7 @@ namespace font
 		this->filename = newName;
 	}
 
-	bool FSFont::getScaleBehavior() const
+	[[nodiscard]] bool FSFont::getScaleBehavior() const
 	{
 		return this->canScale;
 	}

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -2,6 +2,12 @@
 
 namespace font
 {
+
+	void FSFont::setScaleBehavior(bool scale)
+	{
+		this->canScale = scale;
+	}
+
 	void FSFont::setBottomOffset(float offset)
 	{
 		this->offsetBottom = offset;
@@ -20,6 +26,11 @@ namespace font
 	void FSFont::setFilename(const SCP_string& newName) 
 	{
 		this->filename = newName;
+	}
+
+	bool FSFont::getScaleBehavior() const
+	{
+		return this->canScale;
 	}
 
 	float FSFont::getBottomOffset() const

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -150,7 +150,7 @@ namespace font
 		 *
 		 * @return	The scaling behavior
 		 */
-		bool getScaleBehavior() const;
+		[[nodiscard]] bool getScaleBehavior() const;
 
 		/**
 		* @brief	Gets the offset of this font from the top of the drawing line

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -35,6 +35,7 @@ namespace font
 		SCP_string filename;			//!< The file name used to retrieve this font
 
 	protected:
+		bool canScale = false;			//!< If the font is allowed to scale with the user font multiplier
 		float offsetTop = 0.0f;			//!< The offset at the top of a line of text
 		float offsetBottom = 0.0f;		//!< The offset at the bottom of a line of text
 
@@ -143,6 +144,15 @@ namespace font
 								   int resize_mode = -1, float *width = NULL, float *height = NULL) const = 0;
 
 		/**
+		 * @brief	Gets the scaling behavior of this font
+		 *
+		 * @date	28.8.2024
+		 *
+		 * @return	The scaling behavior
+		 */
+		bool getScaleBehavior() const;
+
+		/**
 		* @brief	Gets the offset of this font from the top of the drawing line
 		*
 		* @date	27.11.2012
@@ -159,6 +169,15 @@ namespace font
 		* @return	The bottom offset.
 		*/
 		float getBottomOffset() const;
+
+		/**
+		 * @brief	Sets the scaling behavior
+		 *
+		 * @date	28.8.2024
+		 *
+		 * @param	scale whether or not this font can scale with the font multiplier
+		 */
+		void setScaleBehavior(bool scale);
 
 
 		/**

--- a/code/graphics/software/FontManager.cpp
+++ b/code/graphics/software/FontManager.cpp
@@ -94,14 +94,10 @@ namespace font
 
 	bool FontManager::hasScalingFonts()
 	{
-		for (auto& font : fonts) {
+		return std::any_of(fonts.begin(), fonts.end(), [](const std::unique_ptr<FSFont>& font) {
 			const auto& thisFont = font.get();
-			if (thisFont->getType() == NVG_FONT && thisFont->getScaleBehavior()) {
-				return true;
-			}
-		}
-
-		return false;
+			return thisFont->getType() == NVG_FONT && thisFont->getScaleBehavior();
+		});
 	}
 
 	int FontManager::numberOfFonts()

--- a/code/graphics/software/FontManager.cpp
+++ b/code/graphics/software/FontManager.cpp
@@ -11,6 +11,7 @@
 #include "bmpman/bmpman.h"
 #include "cfile/cfile.h"
 #include "localization/localize.h"
+#include "options/Option.h"
 
 namespace font
 {
@@ -89,6 +90,18 @@ namespace font
 		}
 
 		return -1;
+	}
+
+	bool FontManager::hasScalingFonts()
+	{
+		for (auto& font : fonts) {
+			const auto& thisFont = font.get();
+			if (thisFont->getType() == NVG_FONT && thisFont->getScaleBehavior()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	int FontManager::numberOfFonts()

--- a/code/graphics/software/FontManager.h
+++ b/code/graphics/software/FontManager.h
@@ -125,6 +125,11 @@ namespace font {
 		static int getFontIndexByFilename(const SCP_string &filename);
 
 		/**
+		 * @brief Checks if we have any Scaling TTF fonts loaded. If not it disables the font scaling option
+		 */
+		static bool hasScalingFonts();
+
+		/**
 		* @brief Returns the number of fonts currently saved in the manager
 		* @return The number of fonts
 		*/

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -12,8 +12,8 @@
 float Font_Scale_Factor = 1.0;
 
 static auto FontScaleFactor __UNUSED = options::OptionBuilder<float>("Game.FontScaleFactor",
-										   std::pair<const char*, int>{"Font Scale Factor", 1859}, // Update localize.cpp!! If this is still here, do not pass review
-										   std::pair<const char*, int>{"Sets a multipler to scale fonts by. Only works on fonts the mod has explicitely allowed", 1860})
+										   std::pair<const char*, int>{"Font Scale Factor", 1862},
+										   std::pair<const char*, int>{"Sets a multipler to scale fonts by. Only works on fonts the mod has explicitely allowed", 1863})
 										   .category(std::make_pair("Game", 1824))
 										   .range(0.2f, 4.0f) // Upper limit is somewhat arbitrary
 										   .level(options::ExpertLevel::Advanced)

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -3,10 +3,24 @@
 #include "graphics/paths/PathRenderer.h"
 
 #include "mod_table/mod_table.h"
+#include "options/Option.h"
 
 #include "localization/localize.h"
 
 #include <limits>
+
+float Font_Scale_Factor = 1.0;
+
+static auto FontScaleFactor __UNUSED = options::OptionBuilder<float>("Game.FontScaleFactor",
+										   std::pair<const char*, int>{"Font Scale Factor", 1859}, // Update localize.cpp!! If this is still here, do not pass review
+										   std::pair<const char*, int>{"Sets a multipler to scale fonts by. Only works on fonts the mod has explicitely allowed", 1860})
+										   .category(std::make_pair("Game", 1824))
+										   .range(0.2f, 4.0f) // Upper limit is somewhat arbitrary
+										   .level(options::ExpertLevel::Advanced)
+										   .default_val(1.0)
+										   .bind_to(&Font_Scale_Factor)
+										   .importance(55)
+										   .finish();
 
 namespace
 {
@@ -120,8 +134,13 @@ namespace font
 		path->saveState();
 		path->resetState();
 
+		float scale_factor = Font_Scale_Factor;
+		if (!canScale) {
+			scale_factor = 1.0f;
+		}
+
 		path->fontFaceId(m_handle);
-		path->fontSize(m_size);
+		path->fontSize(m_size * scale_factor);
 		path->textLetterSpacing(m_letterSpacing);
 		path->textAlign(static_cast<TextAlign>(ALIGN_TOP | ALIGN_LEFT));
 

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -22,6 +22,10 @@ static auto FontScaleFactor __UNUSED = options::OptionBuilder<float>("Game.FontS
 										   .importance(55)
 										   .finish();
 
+void removeFontMultiplierOption() {
+	options::OptionsManager::instance()->removeOption(FontScaleFactor);
+}
+
 namespace
 {
 	const char* const TOKEN_SEPARATORS = "\n\t\r";

--- a/code/graphics/software/NVGFont.h
+++ b/code/graphics/software/NVGFont.h
@@ -3,6 +3,8 @@
 #include "globalincs/pstypes.h"
 #include "graphics/software/FSFont.h"
 
+extern float Font_Scale_Factor;
+
 namespace font
 {
 	struct font;

--- a/code/graphics/software/VFNTFont.h
+++ b/code/graphics/software/VFNTFont.h
@@ -3,6 +3,8 @@
 #include "globalincs/pstypes.h"
 #include "graphics/software/FSFont.h"
 
+void removeFontMultiplierOption();
+
 namespace font
 {
 	struct font;

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -514,6 +514,12 @@ namespace font
 		font_initialized = true;
 	}
 
+	void checkFontOptions() {
+		if (!FontManager::hasScalingFonts()) {
+			removeFontMultiplierOption();
+		}
+	}
+
 	void close()
 	{
 		if (!font_initialized) {

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -151,6 +151,14 @@ namespace
 			return;
 		}
 
+		if (optional_string("+Can Scale:")) {
+			bool temp;
+			
+			stuff_boolean(&temp);
+
+			nvgFont->setScaleBehavior(temp);
+		}
+
 		if (optional_string("+Top offset:"))
 		{
 			float temp;

--- a/code/graphics/software/font.h
+++ b/code/graphics/software/font.h
@@ -42,6 +42,13 @@ namespace font
 	void init();
 
 	/**
+	 * @brief Verifies which font options should be available
+	 *
+	 * Removes options if they are not valid for the current font definitions,
+	 */
+	void checkFontOptions();
+
+	/**
 	* @brief Closes the Font system
 	*
 	* Deallocates all allocated memory for the fonts and the respective font data.

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1862 // This is the next available ID
+// #define XSTR_SIZE	1864 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1877,6 +1877,7 @@ void game_init()
 #endif
 
 	font::init();					// loads up all fonts
+	font::checkFontOptions();
 	
 	// add title screen
 	game_title_screen_display();


### PR DESCRIPTION
Adds an in-game option to scale the internal fonts. Only works with TTF fonts so after the font table is parsed we check. If there are no scaling-allowed TTF fonts then we remove the option.

Scaling fonts is explicitly opt-in so that mods can control what can scale.. thinking mostly of HUDs with this. I have a plan of attack for allowing HUDs to scale in a later PR.