### PR TITLE
fix sound initialization

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -1018,7 +1018,8 @@ void gamesnd_parse_entry(game_snd *gs, bool &orig_no_create, SCP_vector<game_snd
 			if (existing_gs->sound_entries.empty() || existing_gs->sound_entries[0].filename[0] == '\0')
 			{
 				gs = existing_gs;
-				no_create = orig_no_create = true;
+				orig_no_create = true;	// prevent sound from being appended in parse_sound_table
+										// (leave no_create as false because we are creating a new sound and we need all the fields to be filled out)
 			}
 			else
 			{
@@ -1033,7 +1034,7 @@ void gamesnd_parse_entry(game_snd *gs, bool &orig_no_create, SCP_vector<game_snd
 		if (vectorIndex < 0)
 		{
 			error_display(0, "No existing sound entry with name \"%s\" found!", name.c_str());
-			no_create = false;
+			no_create = false;			// this is a new sound, so we need all the fields to be filled out
 			gs->name = std::move(name);
 		}
 		else


### PR DESCRIPTION
Fix a small oversight from #6112.  In the empty/placeholder indexed sound situation, although the sound should not be appended (since it indexed), it should still be treated as a new sound, in order for all the first-parse and first-initialize logic to run properly.  Set the right value and add some comments to illuminate the logic.