### PR TITLE
Upgrade head ani handling

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1275,10 +1275,16 @@ void HudGaugeTalkingHead::render(float frametime)
 	for (int i = 0; i < Num_messages_playing; i++ ) {
 		if(Playing_messages[i].play_anim && Playing_messages[i].id != msg_id ) {
 			msg_id = Playing_messages[i].id;
-			if (Playing_messages[i].anim_data)
-				head_anim = Playing_messages[i].anim_data;	
-			else
+			if (Playing_messages[i].anim_data) {
+				head_anim = Playing_messages[i].anim_data;
+				// If we're using the newer setup then choose a random starting frame
+				if (Use_newer_head_ani_suffix && head_anim->num_frames > 0) {
+					int random_frame = rand() % head_anim->num_frames; // Generate random frame to start with
+					head_anim->anim_time = (float)random_frame * head_anim->total_time / head_anim->num_frames;
+				}
+			} else {
 				head_anim = nullptr;
+			}
 
 			return;
 		}

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1197,7 +1197,7 @@ void HudGaugeTalkingHead::render(float frametime)
 		bool play_frame = false;
 		if (head_anim != nullptr) {
 			// New method loops until the message audio is done
-			if (Always_loop_head_anis && cur_message != nullptr) {
+			if (Always_loop_head_anis && cur_message != nullptr && (cur_message->builtin_type != MESSAGE_WINGMAN_SCREAM)) {
 				play_frame = cur_message->play_anim;
 				// Old method only plays once
 			} else if (head_anim != nullptr) {
@@ -1278,7 +1278,7 @@ void HudGaugeTalkingHead::render(float frametime)
 			if (Playing_messages[i].anim_data) {
 				head_anim = Playing_messages[i].anim_data;
 				// If we're using the newer setup then choose a random starting frame
-				if (Use_newer_head_ani_suffix && head_anim->num_frames > 0) {
+				if (Use_newer_head_ani_suffix && (Playing_messages[i].builtin_type != MESSAGE_WINGMAN_SCREAM) && head_anim->num_frames > 0) {
 					int random_frame = rand() % head_anim->num_frames; // Generate random frame to start with
 					head_anim->anim_time = (float)random_frame * head_anim->total_time / head_anim->num_frames;
 				}

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1140,7 +1140,7 @@ HudGauge(HUD_OBJECT_TALKING_HEAD, HUD_TALKING_HEAD, false, true, (VM_DEAD_VIEW |
 
 void HudGaugeTalkingHead::initialize()
 {
-	head_anim = NULL;
+	head_anim = nullptr;
 	msg_id = -1;
 
 	HudGauge::initialize();
@@ -1242,7 +1242,7 @@ void HudGaugeTalkingHead::render(float frametime)
 				}
 			}
 			msg_id = -1;    // allow repeated messages to display a new head ani
-			head_anim = NULL; // Nothing to see here anymore, move along
+			head_anim = nullptr; // Nothing to see here anymore, move along
 		}
 	}
 	// check playing messages to see if we have any messages with talking animations that need to be created.
@@ -1252,7 +1252,7 @@ void HudGaugeTalkingHead::render(float frametime)
 			if (Playing_messages[i].anim_data)
 				head_anim = Playing_messages[i].anim_data;	
 			else
-				head_anim = NULL;
+				head_anim = nullptr;
 
 			return;
 		}

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -42,6 +42,7 @@
 #include "utils/Random.h"
 
 bool Allow_generic_backup_messages = false;
+bool Always_loop_head_anis = false;
 float Command_announces_enemy_arrival_chance = 0.25;
 
 #define DEFAULT_MOOD 0
@@ -757,6 +758,9 @@ void parse_msgtbl(const char* filename)
 		// now we can start parsing
 		parse_custom_message_types(false); // Already parsed, so skip it
 		if (optional_string("#Message Settings")) {
+			if (optional_string("$Always loop head anis:")) {
+				stuff_boolean(&Always_loop_head_anis);
+			}
 			if (optional_string("$Allow Any Ship To Send Backup Messages:")) {
 				stuff_boolean(&Allow_generic_backup_messages);
 			}
@@ -1462,7 +1466,9 @@ void message_play_anim( message_q *q )
 			return;
 		}
 		
-		anim_info->anim_data.direction = GENERIC_ANIM_DIRECTION_NOLOOP;
+		if (!Always_loop_head_anis) {
+			anim_info->anim_data.direction = GENERIC_ANIM_DIRECTION_NOLOOP;
+		}
 		Playing_messages[Num_messages_playing].anim_data = &anim_info->anim_data;
 		message_calc_anim_start_frame(Message_wave_duration, &anim_info->anim_data, is_death_scream);
 		Playing_messages[Num_messages_playing].play_anim = true;

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -43,6 +43,7 @@
 
 bool Allow_generic_backup_messages = false;
 bool Always_loop_head_anis = false;
+bool Use_newer_head_ani_suffix = false;
 float Command_announces_enemy_arrival_chance = 0.25;
 
 #define DEFAULT_MOOD 0
@@ -761,6 +762,9 @@ void parse_msgtbl(const char* filename)
 			if (optional_string("$Always loop head anis:")) {
 				stuff_boolean(&Always_loop_head_anis);
 			}
+			if (optional_string("$Use newer head ani suffix features:")) {
+				stuff_boolean(&Use_newer_head_ani_suffix);
+			}
 			if (optional_string("$Allow Any Ship To Send Backup Messages:")) {
 				stuff_boolean(&Allow_generic_backup_messages);
 			}
@@ -1396,41 +1400,63 @@ void message_play_anim( message_q *q )
 		// assigned, the logic will drop down below like it's supposed to
 		if (persona_index >= 0)
 		{
-			if ( Personas[persona_index].flags & (PERSONA_FLAG_WINGMAN | PERSONA_FLAG_SUPPORT) ) {
-				// get a random head
-				if ( q->builtin_type == MESSAGE_WINGMAN_SCREAM ) {
-					rand_index = MAX_WINGMAN_HEADS;		// [0,MAX) are regular heads; MAX is always death head
-					is_death_scream = 1;
-				} else {
-					rand_index = ((int) Missiontime % MAX_WINGMAN_HEADS);
-				}
-				strcpy_s(temp, ani_name);
-				sprintf_safe(ani_name, "%s%c", temp, 'a'+rand_index);
-				subhead_selected = TRUE;
-			} else if ( Personas[persona_index].flags & (PERSONA_FLAG_COMMAND | PERSONA_FLAG_LARGE) ) {
-				// get a random head
-				// Goober5000 - *sigh*... if mission designers assign a command persona
-				// to a wingman head, they risk having the death ani play
-				if ( !strnicmp(ani_name, "Head-TP", 7) || !strnicmp(ani_name, "Head-VP", 7) ) {
-					mprintf(("message '%s' incorrectly assigns a command/largeship persona to a wingman animation!\n", m->name));
-					rand_index = ((int) Missiontime % MAX_WINGMAN_HEADS);
-				} else {
-					rand_index = ((int) Missiontime % MAX_COMMAND_HEADS);
-				}
+			if (!Use_newer_head_ani_suffix) {
+				if (Personas[persona_index].flags & (PERSONA_FLAG_WINGMAN | PERSONA_FLAG_SUPPORT)) {
+					// get a random head
+					if (q->builtin_type == MESSAGE_WINGMAN_SCREAM) {
+						rand_index = MAX_WINGMAN_HEADS; // [0,MAX) are regular heads; MAX is always death head
+						is_death_scream = 1;
+					} else {
+						rand_index = ((int)Missiontime % MAX_WINGMAN_HEADS);
+					}
+					strcpy_s(temp, ani_name);
+					sprintf_safe(ani_name, "%s%c", temp, 'a' + rand_index);
+					subhead_selected = TRUE;
+				} else if (Personas[persona_index].flags & (PERSONA_FLAG_COMMAND | PERSONA_FLAG_LARGE)) {
+					// get a random head
+					// Goober5000 - *sigh*... if mission designers assign a command persona
+					// to a wingman head, they risk having the death ani play
+					if (!strnicmp(ani_name, "Head-TP", 7) || !strnicmp(ani_name, "Head-VP", 7)) {
+						mprintf(("message '%s' incorrectly assigns a command/largeship persona to a wingman animation!\n", m->name));
+						rand_index = ((int)Missiontime % MAX_WINGMAN_HEADS);
+					} else {
+						rand_index = ((int)Missiontime % MAX_COMMAND_HEADS);
+					}
 
-				strcpy_s(temp, ani_name);
-				sprintf_safe(ani_name, "%s%c", temp, 'a'+rand_index);
-				subhead_selected = TRUE;
+					strcpy_s(temp, ani_name);
+					sprintf_safe(ani_name, "%s%c", temp, 'a' + rand_index);
+					subhead_selected = TRUE;
+				} else {
+					mprintf(("message '%s' uses an unrecognized persona type\n", m->name));
+				}
 			} else {
-				mprintf(("message '%s' uses an unrecognized persona type\n", m->name));
+				// Explicitely allow death anims for large ships now. Only command can't have a death message.
+				if (!(Personas[persona_index].flags & PERSONA_FLAG_COMMAND) && q->builtin_type == MESSAGE_WINGMAN_SCREAM) {
+					strcpy_s(temp, ani_name);
+					sprintf_safe(ani_name, "%s-death", temp);
+					subhead_selected = TRUE;
+				} else {
+					strcpy_s(temp, ani_name);
+					sprintf_safe(ani_name, "%s-reg", temp);
+					subhead_selected = TRUE;
+				}
+			}
+		} else {
+			// In suffix mode if we don't have a persona AND the anim doesn't exist then append -reg
+			if (Use_newer_head_ani_suffix) {
+				strcpy_s(temp, ani_name);
+				sprintf_safe(ani_name, "%s-reg", temp);
+				subhead_selected = TRUE;
 			}
 		}
 
 		if (!subhead_selected) {
-			// choose between a and b
-			rand_index = ((int) Missiontime % MAX_WINGMAN_HEADS);
-			strcpy_s(temp, ani_name);
-			sprintf_safe(ani_name, "%s%c", temp, 'a'+rand_index);
+			if (!Use_newer_head_ani_suffix) {
+				// choose between a and b
+				rand_index = ((int)Missiontime % MAX_WINGMAN_HEADS);
+				strcpy_s(temp, ani_name);
+				sprintf_safe(ani_name, "%s%c", temp, 'a' + rand_index);
+			}
 			mprintf(("message '%s' with invalid head.  Fix by assigning persona to the message.\n", m->name));
 		}
 		nprintf(("Messaging", "playing head %s for %s\n", ani_name, q->who_from));

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -60,6 +60,7 @@ extern SCP_vector<SCP_string> Builtin_moods;
 extern int Current_mission_mood;
 extern float Command_announces_enemy_arrival_chance;
 extern bool Always_loop_head_anis;
+extern bool Use_newer_head_ani_suffix;
 
 // Builtin messages
 

--- a/code/mission/missionmessage.h
+++ b/code/mission/missionmessage.h
@@ -59,6 +59,7 @@ extern SCP_vector<message_extra> Message_waves;
 extern SCP_vector<SCP_string> Builtin_moods;
 extern int Current_mission_mood;
 extern float Command_announces_enemy_arrival_chance;
+extern bool Always_loop_head_anis;
 
 // Builtin messages
 


### PR DESCRIPTION
This adds two new features to head anis to simplify and expand their handling.

First it adds `$Always loop head anis:` option to messages.tbl. This will cause all heads to loop until the message audio is finished. It doesn't look great with the retail anims because they aren't meant to loop so your mileage may vary. It's meant to be used with the new feature below but was simple enough to make it be its own flag for better customization.

Second it adds `$Use newer head ani suffix features:` which abandons the old `a`, `b`, `c` method of selecting heads in favor of `-reg` and `-death`. In this mode all heads will have `-reg` appended to the filename unless they are a death scream and not command. (This explicitly allows large ship personas to have death screams, btw) in which case `-death` will be appended to the filename. In this mode `-reg` messages will start at a random frame which will provide the same level of variance as the `a`, `b`, method provided that the anim itself is sufficiently long enough. `-death` messages will always start at frame 0 and will not loop.

The idea here is that instead of having 3 versions of a head animation that play until the animation ends, there are only 2 versions; one that plays until the audio is completed (and can loop seamlessly if the audio is longer than the anim) and one that plays on death from start to end.