### PR TITLE
Allow defining custom overhead line colors

### DIFF
--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -854,7 +854,7 @@ void draw_3d_overhead_view(int model_num,
 		for (x = 0; x < pm->n_guns; x++) {
 			if ((weapon_array[x] == selected_weapon_class && hovered_weapon_slot < 0) ||
 				x == hovered_weapon_slot) {
-				Assert(num_found < NUM_ICON_FRAMES);
+				Assert(num_found < MAX_SHIP_SECONDARY_BANKS);
 				gr_set_color_fast(&Overhead_line_colors[num_found]);
 				gr_circle(bank_coords[x][0] + bank_prim_offset, bank_coords[x][1] + bank_y_offset, 5, resize_mode);
 				for (y = 0; y < pm->gun_banks[x].num_slots; y++) {
@@ -926,7 +926,7 @@ void draw_3d_overhead_view(int model_num,
 			if ((weapon_array[x + MAX_SHIP_PRIMARY_BANKS] == selected_weapon_class &&
 					hovered_weapon_slot < 0) ||
 				x + MAX_SHIP_PRIMARY_BANKS == hovered_weapon_slot) {
-				Assert(num_found < NUM_ICON_FRAMES);
+				Assert(num_found < MAX_SHIP_PRIMARY_BANKS);
 				gr_set_color_fast(&Overhead_line_colors[num_found]);
 				gr_circle(bank_coords[x + MAX_SHIP_PRIMARY_BANKS][0] + bank_sec_offset,
 					bank_coords[x + MAX_SHIP_PRIMARY_BANKS][1] + bank_y_offset,

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -838,7 +838,7 @@ void draw_3d_overhead_view(int model_num,
 		vec3d subobj_pos;
 		int x, y;
 		int xc, yc;
-		int num_found = 2;
+		int num_found = 0;
 
 		int bank_coords[MAX_SHIP_WEAPONS][2] = {
 			{bank1_x, bank1_y},
@@ -855,7 +855,7 @@ void draw_3d_overhead_view(int model_num,
 			if ((weapon_array[x] == selected_weapon_class && hovered_weapon_slot < 0) ||
 				x == hovered_weapon_slot) {
 				Assert(num_found < NUM_ICON_FRAMES);
-				gr_set_color_fast(&Icon_colors[ICON_FRAME_NORMAL + num_found]);
+				gr_set_color_fast(&Overhead_line_colors[num_found]);
 				gr_circle(bank_coords[x][0] + bank_prim_offset, bank_coords[x][1] + bank_y_offset, 5, resize_mode);
 				for (y = 0; y < pm->gun_banks[x].num_slots; y++) {
 					// Stuff
@@ -920,14 +920,14 @@ void draw_3d_overhead_view(int model_num,
 			}
 		}
 
-		num_found = 2;
+		num_found = 0;
 		// Render selected secondary lines
 		for (x = 0; x < pm->n_missiles; x++) {
 			if ((weapon_array[x + MAX_SHIP_PRIMARY_BANKS] == selected_weapon_class &&
 					hovered_weapon_slot < 0) ||
 				x + MAX_SHIP_PRIMARY_BANKS == hovered_weapon_slot) {
 				Assert(num_found < NUM_ICON_FRAMES);
-				gr_set_color_fast(&Icon_colors[ICON_FRAME_NORMAL + num_found]);
+				gr_set_color_fast(&Overhead_line_colors[num_found]);
 				gr_circle(bank_coords[x + MAX_SHIP_PRIMARY_BANKS][0] + bank_sec_offset,
 					bank_coords[x + MAX_SHIP_PRIMARY_BANKS][1] + bank_y_offset,
 					5,

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -155,6 +155,7 @@ bool Use_new_scanning_behavior;
 bool Lua_API_returns_nil_instead_of_invalid_object;
 bool Dont_show_callsigns_in_escort_list;
 bool Fix_scripted_velocity;
+color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Game.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
@@ -1157,6 +1158,30 @@ void parse_mod_table(const char *filename)
 				}
 			}
 
+			if (optional_string("+Overhead Line Color 1:")) {
+				int rgba[4] = {0, 0, 0, 0};
+				stuff_int_list(rgba, 4, RAW_INTEGER_TYPE);
+				gr_init_alphacolor(&Overhead_line_colors[0], rgba[0], rgba[1], rgba[2], rgba[3]);
+			}
+
+			if (optional_string("+Overhead Line Color 2:")) {
+				int rgba[4] = {0, 0, 0, 0};
+				stuff_int_list(rgba, 4, RAW_INTEGER_TYPE);
+				gr_init_alphacolor(&Overhead_line_colors[1], rgba[0], rgba[1], rgba[2], rgba[3]);
+			}
+
+			if (optional_string("+Overhead Line Color 3:")) {
+				int rgba[4] = {0, 0, 0, 0};
+				stuff_int_list(rgba, 4, RAW_INTEGER_TYPE);
+				gr_init_alphacolor(&Overhead_line_colors[2], rgba[0], rgba[1], rgba[2], rgba[3]);
+			}
+
+			if (optional_string("+Overhead Line Color 4:")) {
+				int rgba[4] = {0, 0, 0, 0};
+				stuff_int_list(rgba, 4, RAW_INTEGER_TYPE);
+				gr_init_alphacolor(&Overhead_line_colors[3], rgba[0], rgba[1], rgba[2], rgba[3]);
+			}
+
 			if (optional_string("$Always refresh selected weapon when viewing loadout:")) {
 				stuff_boolean(&Always_reset_selected_wep_on_loadout_open);
 			}
@@ -1618,6 +1643,12 @@ void mod_table_reset()
 	Lua_API_returns_nil_instead_of_invalid_object = false;
 	Dont_show_callsigns_in_escort_list = false;
 	Fix_scripted_velocity = false;
+	// These colors were taken from missionscreencommon.cpp line 591 which
+	// were the original colors used by the overhead ship loadout lines
+	gr_init_alphacolor(&Overhead_line_colors[0], 64, 192, 192, 255);
+	gr_init_alphacolor(&Overhead_line_colors[1], 192, 128, 64, 255);
+	gr_init_alphacolor(&Overhead_line_colors[2], 175, 175, 175, 255);
+	gr_init_alphacolor(&Overhead_line_colors[3], 100, 100, 100, 255);
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -164,6 +164,7 @@ extern bool Use_new_scanning_behavior;
 extern bool Lua_API_returns_nil_instead_of_invalid_object;
 extern bool Dont_show_callsigns_in_escort_list;
 extern bool Fix_scripted_velocity;
+extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
As requested by Woolie Wool. Default colors are set, copying the colors they were originally set to from `Icon_colors`.