### PR TITLE
Auto size font for screen resolutions

### DIFF
--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -95,6 +95,27 @@ namespace
 			}
 		}
 
+		if (optional_string("+Auto Size:")) {
+			bool autoSize;
+			stuff_boolean(&autoSize);
+
+			if (autoSize) {
+				// Lambda to calculate font size based on screen resolution
+				auto calculateAutoSize = [size]() -> float {
+					int vmin = std::min(gr_screen.max_w, gr_screen.max_h);
+
+					// Base size calculation (similar to ~Npx font at 1080p)
+					// Use 1080p because that's generally what font sizes have been targeting for years
+					// And should provide a fairly close out-of-the-box solution
+					float baseSize = vmin * (size / 1080.0f);
+					return std::round(baseSize);
+				};
+
+				// Set the font size based on the result of the lambda
+				size = calculateAutoSize();
+			}
+		}
+
 		// Build name from existing values if no name is specified
 		if (!hasName)
 		{


### PR DESCRIPTION
The next step in getting built-in fonts to work for all screen resolutions...

This adds an optional flag for a font to automatically scale for the current screen resolution. The formula here is meant to get a font size for the current screen that'd be roughly equivalent to the defined font size if it were on a 1080p screen (the most popular screen resolution currently, according to Steam, and the one that's pretty close to what FSO has been targeting for years.

This is the same formula that SCPUI uses and with this in place SCPUI can have a single font slider in Options that affects all fonts game-wide should mods setup a compatible font system.

This will only work for TTF/OTF fonts and not the old bitmap fonts.