### PR TITLE
Fix deferred lighting Option

### DIFF
--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -123,7 +123,7 @@ bool light_deferred_enabled()
 		// if the restart requirement is lifted care should be taken to cache this value
 		// and never look it up more than once a frame
 		// otherwise the performance footprint is measurable enough to worry about.
-		return DeferredLightingEnabled;
+		return DeferredLightingOption->getValue();
 	} else {
 		return !Cmdline_no_deferred_lighting;
 	}

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -118,12 +118,13 @@ static auto DeferredLightingOption = options::OptionBuilder<bool>("Graphics.Defe
 bool light_deferred_enabled()
 {
 	if (Using_in_game_options) {
+		static bool isToggledOn = DeferredLightingOption->getValue();
 		// This used to be getting the value of the option object itself,
 		// however that is not a free operation and changing it requires a restart anyway
 		// if the restart requirement is lifted care should be taken to cache this value
 		// and never look it up more than once a frame
 		// otherwise the performance footprint is measurable enough to worry about.
-		return DeferredLightingOption->getValue();
+		return isToggledOn;
 	} else {
 		return !Cmdline_no_deferred_lighting;
 	}

--- a/code/options/Option.cpp
+++ b/code/options/Option.cpp
@@ -208,6 +208,14 @@ void OptionBase::setFlags(const flagset<OptionFlags>& flags) {
 	_flags = flags;
 }
 
+bool OptionBase::getIsOnce() const {
+	return _is_once;
+}
+
+void OptionBase::setIsOnce(bool is_once) {
+	_is_once = is_once;
+}
+
 //persists any changes made to this specific option and returns whether or not it was successful
 bool OptionBase::persistChanges() const { return _parent->persistOptionChanges(this); }
 

--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -571,7 +571,7 @@ class OptionBuilder {
 		return *this;
 	}
 	//Finishes building the option and returns a pointer to it
-	const std::shared_ptr<Option<T>> finish()
+	std::shared_ptr<const Option<T>> finish()
 	{
 		for (auto& val : _preset_values) {
 			_instance.setPreset(val.first, json_dump_string_new(_instance.getSerializer()(val.second),

--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -271,7 +271,7 @@ class Option : public OptionBase {
 	}
 	ValueDescription getCurrentValueDescription() const override
 	{
-		auto val = getValue();
+		auto val = fetchValue();
 		return toDescription(val);
 	}
 	void setValueDescription(const ValueDescription& desc) const override

--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -245,7 +245,7 @@ class Option : public OptionBase {
 			return 0.0f;
 		}
 	}
-	T fetchValue() const
+	T getValue() const
 	{
 		try {
 			tl::optional<std::unique_ptr<json_t>> config_value = getConfigValue();
@@ -259,19 +259,9 @@ class Option : public OptionBase {
 			return _defaultValueFunc();
 		}
 	}
-	T getValue() const
-	{
-		if (_is_once) {
-			static T cache = fetchValue();
-			return cache;
-		}
-		else {
-			return fetchValue();
-		}
-	}
 	ValueDescription getCurrentValueDescription() const override
 	{
-		auto val = fetchValue();
+		auto val = getValue();
 		return toDescription(val);
 	}
 	void setValueDescription(const ValueDescription& desc) const override
@@ -307,7 +297,7 @@ class Option : public OptionBase {
 		}
 
 		try {
-			_changeListener(fetchValue(), true);
+			_changeListener(getValue(), true);
 		} catch (const std::exception&) {
 		}
 	}

--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -307,7 +307,7 @@ class Option : public OptionBase {
 		}
 
 		try {
-			_changeListener(getValue(), true);
+			_changeListener(fetchValue(), true);
 		} catch (const std::exception&) {
 		}
 	}

--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -74,6 +74,8 @@ class OptionBase {
 	float _min = 0;
 	float _max = 1;
 
+	bool _is_once = false;
+
 	SCP_unordered_map<PresetKind, SCP_string> _preset_values;
 
 	flagset<OptionFlags> _flags;
@@ -99,6 +101,9 @@ class OptionBase {
 
 	const flagset<OptionFlags>& getFlags() const;
 	void setFlags(const flagset<OptionFlags>& flags);
+
+	bool getIsOnce() const;
+	void setIsOnce(bool is_once);
 
 	const SCP_string& getConfigKey() const;
 	const SCP_string& getTitle() const;
@@ -240,7 +245,7 @@ class Option : public OptionBase {
 			return 0.0f;
 		}
 	}
-	T getValue() const
+	T fetchValue() const
 	{
 		try {
 			tl::optional<std::unique_ptr<json_t>> config_value = getConfigValue();
@@ -252,6 +257,16 @@ class Option : public OptionBase {
 		} catch (const std::exception&) {
 			// deserializers are allowed to throw on error
 			return _defaultValueFunc();
+		}
+	}
+	T getValue() const
+	{
+		if (_is_once) {
+			static T cache = fetchValue();
+			return cache;
+		}
+		else {
+			return fetchValue();
 		}
 	}
 	ValueDescription getCurrentValueDescription() const override
@@ -519,6 +534,7 @@ class OptionBuilder {
 	//The global variable to bind the option to once. Will require game restart to persist changes.
 	OptionBuilder& bind_to_once(T* dest)
 	{
+		_instance.setIsOnce(true);
 		return change_listener([dest](const T& val, bool initial) {
 			if (initial) {
 				*dest = val;
@@ -555,13 +571,13 @@ class OptionBuilder {
 		return *this;
 	}
 	//Finishes building the option and returns a pointer to it
-	const Option<T>* finish()
+	const std::shared_ptr<Option<T>> finish()
 	{
 		for (auto& val : _preset_values) {
 			_instance.setPreset(val.first, json_dump_string_new(_instance.getSerializer()(val.second),
 			                                                    JSON_COMPACT | JSON_ENSURE_ASCII | JSON_ENCODE_ANY));
 		}
-		std::unique_ptr<Option<T>> opt_ptr(new Option<T>(_instance));
+		auto opt_ptr = make_shared<Option<T>>(_instance);
 
 		if (mpark::holds_alternative<std::pair<const char*, int>>(_title)) {
 			const auto& xstr_info = mpark::get<std::pair<const char*, int>>(_title);
@@ -573,9 +589,8 @@ class OptionBuilder {
 			lcl_delayed_xstr(opt_ptr->_description, xstr_info.first, xstr_info.second);
 		}
 
-		auto ptr = opt_ptr.get(); // We need to get the pointer now since we loose the type information otherwise
-		OptionsManager::instance()->addOption(std::unique_ptr<OptionBase>(opt_ptr.release()));
-		return ptr;
+		OptionsManager::instance()->addOption(opt_ptr);
+		return opt_ptr;
 	}
 };
 

--- a/code/options/OptionsManager.cpp
+++ b/code/options/OptionsManager.cpp
@@ -95,7 +95,7 @@ void OptionsManager::setOverride(const SCP_string& key, const SCP_string& json)
 }
 
 //Adds an option to the options vector
-const OptionBase* OptionsManager::addOption(std::unique_ptr<const OptionBase>&& option)
+const OptionBase* OptionsManager::addOption(std::shared_ptr<const OptionBase>&& option)
 {
 	_options.emplace_back(std::move(option));
 	_optionsSorted = false; // Order got invalidated by adding a new option
@@ -106,12 +106,12 @@ const OptionBase* OptionsManager::addOption(std::unique_ptr<const OptionBase>&& 
 }
 
 //Removes an option from the options vector
-void OptionsManager::removeOption(const OptionBase* option)
+void OptionsManager::removeOption(std::shared_ptr<const OptionBase> option)
 {
 	_optionsMapping.erase(option->getConfigKey());
 	_options.erase(
 	    std::remove_if(_options.begin(), _options.end(),
-	                   [option](const std::unique_ptr<const OptionBase>& ptr) { return ptr.get() == option; }));
+	                   [option](const std::shared_ptr<const OptionBase>& ptr) { return ptr == option; }));
 }
 
 // Returns an option with the specified name
@@ -126,13 +126,13 @@ const OptionBase* OptionsManager::getOptionByKey(SCP_string key)
 }
 
 //Returns a table of all built-in options available
-const SCP_vector<std::unique_ptr<const options::OptionBase>>& OptionsManager::getOptions()
+const SCP_vector<std::shared_ptr<const options::OptionBase>>& OptionsManager::getOptions()
 {
 	if (!_optionsSorted) {
 		// Keep options sorted by only sorting them when necessary
 
 		std::sort(_options.begin(), _options.end(),
-		          [](const std::unique_ptr<const OptionBase>& left, const std::unique_ptr<const OptionBase>& right) {
+		          [](const std::shared_ptr<const OptionBase>& left, const std::shared_ptr<const OptionBase>& right) {
 			          return *left < *right;
 		          });
 

--- a/code/options/OptionsManager.cpp
+++ b/code/options/OptionsManager.cpp
@@ -106,7 +106,7 @@ const OptionBase* OptionsManager::addOption(std::shared_ptr<const OptionBase>&& 
 }
 
 //Removes an option from the options vector
-void OptionsManager::removeOption(std::shared_ptr<const OptionBase> option)
+void OptionsManager::removeOption(const std::shared_ptr<const OptionBase>& option)
 {
 	_optionsMapping.erase(option->getConfigKey());
 	_options.erase(

--- a/code/options/OptionsManager.h
+++ b/code/options/OptionsManager.h
@@ -19,7 +19,7 @@ class OptionsManager {
 
 	SCP_unordered_map<SCP_string, const OptionBase*> _optionsMapping;
 
-	SCP_vector<std::unique_ptr<const OptionBase>> _options;
+	SCP_vector<std::shared_ptr<const OptionBase>> _options;
 	bool _optionsSorted = false;
 
   public:
@@ -33,13 +33,13 @@ class OptionsManager {
 
 	void setOverride(const SCP_string& key, const SCP_string& json);
 
-	const OptionBase* addOption(std::unique_ptr<const OptionBase>&& option);
+	const OptionBase* addOption(std::shared_ptr<const OptionBase>&& option);
 
-	void removeOption(const OptionBase* option);
+	void removeOption(std::shared_ptr<const OptionBase> option);
 
 	const OptionBase* getOptionByKey(SCP_string name);
 
-	const SCP_vector<std::unique_ptr<const options::OptionBase>>& getOptions();
+	const SCP_vector<std::shared_ptr<const options::OptionBase>>& getOptions();
 
 	bool persistOptionChanges(const options::OptionBase* option);
 

--- a/code/options/OptionsManager.h
+++ b/code/options/OptionsManager.h
@@ -35,7 +35,7 @@ class OptionsManager {
 
 	const OptionBase* addOption(std::shared_ptr<const OptionBase>&& option);
 
-	void removeOption(std::shared_ptr<const OptionBase> option);
+	void removeOption(const std::shared_ptr<const OptionBase>& option);
 
 	const OptionBase* getOptionByKey(SCP_string name);
 


### PR DESCRIPTION
Similar issue to #5966.
This now provides a way to ask the option for its value instead of relying on a side effect assignment.
At the same time, this is now cached for set-once options, allowing for fast querying.
Furthermore, it gets rid of some really really ugly code throwing around raw pointers and kind of illegally managing memory in favor of shared_ptr's, as there's a good chance that that was part of why the compiler mis-identified the optimization in the first place.

Should fix #6344 

This should probably be tested in release mode by someone with an MSVC compiler.

To be frank, this is a hotfix only.
A more permanent refactor of the ingame options will be needed for 25.0 to a) optimize lookup performance, while b) not relying on side-effect access to variables that the compiler can mess with. Options should store their state fully internally, not giving a user access to the data outside of the option object.