### PR TITLE
two HUD fixes

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -3908,7 +3908,9 @@ void hud_page_in()
 
 HudGauge* hud_get_custom_gauge(const char* name, bool check_all_gauges)
 {
-	auto player_sip = Player_ship->ship_info_index < 0 ? nullptr : &Ship_info[Player_ship->ship_info_index];
+	ship_info *player_sip = nullptr;
+	if (Player_ship && Player_ship->ship_info_index >= 0)
+		player_sip = &Ship_info[Player_ship->ship_info_index];
 
 	// go through all gauges for all ships and defaults
 	if (check_all_gauges) {

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -302,7 +302,7 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum, int parent_node) const
   }
 	case OPF_ANY_HUD_GAUGE: {
 		auto name = CTEXT(node);
-		return LuaValue::createValue(_action.getLuaState(), l_HudGauge.Set(hud_get_gauge(name)));
+		return LuaValue::createValue(_action.getLuaState(), l_HudGauge.Set(hud_get_gauge(name, true)));
 	}
 	case OPF_EVENT_NAME: {
 		auto name = CTEXT(node);

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -21,7 +21,7 @@ ADE_FUNC(isCustom, l_HudGauge, nullptr, "Custom HUD Gauge status", "boolean", "R
 	return ade_set_args(L, "b", gauge->isCustom());
 }
 
-ADE_VIRTVAR(Name, l_HudGauge, "string", "Custom HUD Gauge name", "string", "Custom HUD Gauge name, or blank if this is a default gauge, or nil if handle is invalid")
+ADE_VIRTVAR(Name, l_HudGauge, "string", "Custom HUD Gauge name", "string", "Custom HUD Gauge name, or nil if this is a default gauge or the handle is invalid")
 {
 	HudGauge* gauge;
 
@@ -37,7 +37,7 @@ ADE_VIRTVAR(Name, l_HudGauge, "string", "Custom HUD Gauge name", "string", "Cust
 	return ade_set_args(L, "s", gauge->getCustomGaugeName());
 }
 
-ADE_VIRTVAR(Text, l_HudGauge, "string", "Custom HUD Gauge text", "string", "Custom HUD Gauge text, or blank if this is a default gauge, or nil if handle is invalid")
+ADE_VIRTVAR(Text, l_HudGauge, "string", "Custom HUD Gauge text", "string", "Custom HUD Gauge text, or nil if this is a default gauge or the handle is invalid")
 {
 	HudGauge* gauge;
 	const char* text = nullptr;


### PR DESCRIPTION
1. The `Player_ship` variable can sometimes be NULL, especially in FRED, so revise the conditional to check for this.
2. Since the `OPF_ANY_HUD_GAUGE` type checks for any default or custom HUD gauge in regular SEXP operators, it should do so in scripted SEXP operators as well.