### PR TITLE
allow explicitly empty sounds

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -651,7 +651,7 @@ void parse_gamesnd_old(game_snd* gs)
 	{
 		entry.filename[0] = 0;
 		advance_to_eoln(nullptr);
-		gs->flags |= GAME_SND_NOT_VALID;
+		gs->flags |= (GAME_SND_NOT_VALID | GAME_SND_EXPLICITLY_EMPTY);
 		return;
 	}
 	Mp++;
@@ -880,7 +880,7 @@ void parse_gamesnd_new(game_snd* gs, bool no_create)
 	if (!stricmp(name, NOX("empty")) || !stricmp(name, NOX("none")))
 	{
 		entry->filename[0] = 0;
-		gs->flags |= GAME_SND_NOT_VALID;
+		gs->flags |= (GAME_SND_NOT_VALID | GAME_SND_EXPLICITLY_EMPTY);
 		return;
 	}
 
@@ -962,7 +962,7 @@ void parse_gamesnd_new(game_snd* gs, bool no_create)
 
 bool gamesnd_is_placeholder(const game_snd& gs)
 {
-	return gs.sound_entries.empty() || gs.sound_entries[0].filename[0] == '\0';
+	return (gs.sound_entries.empty() || gs.sound_entries[0].filename[0] == '\0') && !(gs.flags & GAME_SND_EXPLICITLY_EMPTY);
 }
 
 void gamesnd_parse_entry(game_snd *gs, bool &orig_no_create, SCP_vector<game_snd> *lookupVector, size_t lookupVectorMaxIndexableSize, bool (*is_reserved_index)(int))

--- a/code/sound/sound.h
+++ b/code/sound/sound.h
@@ -26,6 +26,7 @@
 #define GAME_SND_NOT_VALID			(1<<2)
 #define GAME_SND_PRELOAD			(1<<3)	//!< preload sound (ie read from disk before mission starts)
 #define GAME_SND_RETAIL_STYLE		(1<<4)
+#define GAME_SND_EXPLICITLY_EMPTY	(1<<5)	// a sound that has been parsed as empty
 
 // Priorities that can be passed to snd_play() functions to limit how many concurrent sounds of a 
 // given type are played.


### PR DESCRIPTION
Make sounds that are specified as "empty" or "none" in sounds.tbl ineligible for treatment as placeholder sounds.  Resolves #6350.