### PR TITLE
replace waypoint pointers with waypoint indexes

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -276,8 +276,8 @@ typedef struct ai_info {
 	int		ai_class;				//	Class.  Might be override of default.
 
 	//	Probably become obsolete, to be replaced by path_start, path_cur, etc.
-	waypoint_list	*wp_list;		// waypoint list being followed
-	int				 wp_index;		// waypoint index in list
+	int		wp_list_index;			// index of waypoint list being followed
+	int		wp_index;				// index of waypoint in list
 	int		wp_flags;				//	waypoint flags, see WPF_xxxx
 	int		waypoint_speed_cap;		// -1 no cap, otherwise cap - changed to int by Goober5000
 
@@ -533,7 +533,7 @@ extern void ai_ignore_wing(object *ignorer, int wingnum);
 extern void ai_dock_with_object(object *docker, int docker_index, object *dockee, int dockee_index, int dock_type);
 extern void ai_stay_still(object *still_objp, vec3d *view_pos);
 extern void ai_do_default_behavior(object *obj);
-extern void ai_start_waypoints(object *objp, waypoint_list *wp_list, int wp_flags, int start_index);
+extern void ai_start_waypoints(object *objp, int wl_index, int wp_flags, int start_index);
 extern void ai_ship_hit(object *objp_ship, object *hit_objp, vec3d *hit_normal);
 extern void ai_ship_destroy(int shipnum);
 extern vec3d ai_get_acc_limit(vec3d* vel_limit, const object* objp);

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -166,7 +166,7 @@ void ai_goal_reset(ai_goal *aigp, bool adding_goal, int ai_mode, int ai_submode,
 	aigp->target_name = nullptr;
 	aigp->target_name_index = -1;
 
-	aigp->wp_list = nullptr;
+	aigp->wp_list_index = -1;
 
 	aigp->target_instance = -1;
 	aigp->target_signature = -1;
@@ -738,8 +738,8 @@ void ai_add_goal_sub_player(int type, int mode, int submode, const char *target_
 
 	if ( mode == AI_GOAL_WARP ) {
 		if (submode >= 0) {
-			aigp->wp_list = find_waypoint_list_at_index(submode);
-			Assert(aigp->wp_list != NULL);
+			aigp->wp_list_index = submode;
+			Assert(find_waypoint_list_at_index(aigp->wp_list_index) != nullptr);
 		}
 	}
 
@@ -1605,10 +1605,10 @@ ai_achievability ai_mission_goal_achievable( int objnum, ai_goal *aigp )
 	// check to see if we have a valid list.  If not, then try to set one up.  If that
 	// fails, then we must pitch this order
 	if ( (aigp->ai_mode == AI_GOAL_WAYPOINTS_ONCE) || (aigp->ai_mode == AI_GOAL_WAYPOINTS) ) {
-		if ( aigp->wp_list == NULL ) {
-			aigp->wp_list = find_matching_waypoint_list(aigp->target_name);
+		if ( aigp->wp_list_index < 0 ) {
+			aigp->wp_list_index = find_matching_waypoint_list_index(aigp->target_name);
 
-			if ( aigp->wp_list == NULL ) {
+			if ( aigp->wp_list_index < 0 ) {
 				Warning(LOCATION, "Unknown waypoint list %s - not found in mission file.  Killing ai goal", aigp->target_name );
 				return ai_achievability::NOT_ACHIEVABLE;
 			}
@@ -2344,7 +2344,7 @@ void ai_process_mission_orders( int objnum, ai_info *aip )
 			flags |= WPF_REPEAT;
 		if (current_goal->flags[AI::Goal_Flags::Waypoints_in_reverse])
 			flags |= WPF_BACKTRACK;
-		ai_start_waypoints(objp, current_goal->wp_list, flags, current_goal->int_data);
+		ai_start_waypoints(objp, current_goal->wp_list_index, flags, current_goal->int_data);
 		break;
 	}
 

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -119,7 +119,7 @@ typedef struct ai_goal {
 
 	const char *target_name;	// name of the thing that this goal acts upon
 	int		target_name_index;	// index of goal_target_name in Goal_target_names[][]
-	waypoint_list *wp_list;		// waypoints that this ship might fly.
+	int wp_list_index;			// waypoints that this ship might fly.
 	int target_instance;		// instance of thing this ship might be chasing (currently only used for weapons; note, not the same as objnum!)
 	int	target_signature;		// signature of object this ship might be chasing (currently only used for weapons; paired with above value to confirm target)
 

--- a/code/autopilot/autopilot.h
+++ b/code/autopilot/autopilot.h
@@ -34,7 +34,7 @@ public:
 	ubyte normal_color[3] = { 0x80, 0x80, 0xFF };
 	ubyte visited_color[3] = { 0xFF, 0xFF, 0x00 };
 
-	const void *target_obj = nullptr;
+	int target_index = -1; //waypoint list index if NP_WAYPOINT, otherwise object index
 	int waypoint_num = -1; //only used when flags & NP_WAYPOINT
 
 	const vec3d *GetPosition();
@@ -53,7 +53,7 @@ public:
 		visited_color[1] = 0xFF;
 		visited_color[2] = 0x00;
 
-		target_obj = nullptr;
+		target_index = -1;
 		waypoint_num = -1;
 	}
 };

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -92,7 +92,7 @@ int	Training_context_speed_set;
 int	Training_context_speed_min;
 int	Training_context_speed_max;
 TIMESTAMP	Training_context_speed_timestamp;
-waypoint_list *Training_context_path;
+int Training_context_waypoint_path;
 int Training_context_goal_waypoint;
 int Training_context_at_waypoint;
 float	Training_context_distance;
@@ -398,7 +398,7 @@ void training_mission_init()
 	Training_context = 0;
 	Training_context_speed_set = 0;
 	Training_context_speed_timestamp = TIMESTAMP::invalid();
-	Training_context_path = nullptr;
+	Training_context_waypoint_path = -1;
 
 	Players_target = UNINITIALIZED;
 	Players_mlocked = UNINITIALIZED;

--- a/code/mission/missiontraining.h
+++ b/code/mission/missiontraining.h
@@ -25,7 +25,7 @@ extern int Training_context_speed_min;
 extern int Training_context_speed_max;
 extern int Training_context_speed_set;
 extern TIMESTAMP Training_context_speed_timestamp;
-extern waypoint_list *Training_context_path;
+extern int Training_context_waypoint_path;
 extern int Training_context_goal_waypoint;
 extern int Training_context_at_waypoint;
 extern float Training_context_distance;

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1493,8 +1493,9 @@ int multi_oo_pack_data(net_player *pl, object *objp, ushort oo_flags, ubyte *dat
 		// either send out the waypoint they are trying to get to *or* their current target
 		if (umode == AIM_WAYPOINTS) {
 			// if it's already started pointing to a waypoint, grab its net_signature and send that instead
-			if ((aip->wp_list != nullptr) && (aip->wp_index >= 0 && aip->wp_index < static_cast<int>(aip->wp_list->get_waypoints().size()))) {
-				target_signature = Objects[aip->wp_list->get_waypoints().at(aip->wp_index).get_objnum()].net_signature;
+			waypoint* wp;
+			if ((wp = find_waypoint_at_indexes(aip->wp_list_index, aip->wp_index)) != nullptr) {
+				target_signature = Objects[wp->get_objnum()].net_signature;
 			}
 		} // send the target signature. 2021 Version!
 		else if ((aip->goals[0].target_name != nullptr) && strlen(aip->goals[0].target_name) != 0) {
@@ -2124,12 +2125,14 @@ int multi_oo_unpack_data(net_player* pl, ubyte* data, int seq_num, int time_delt
 					Ai_info[shipp->ai_index].goals[0].target_name = nullptr;
 				// set their waypoints if in waypoint mode.
 				} else if (umode == AIM_WAYPOINTS) {
-					waypoint* destination = find_waypoint_with_instance(target_objp->instance);
-					if (destination != nullptr) {
-						Ai_info[shipp->ai_index].wp_list = destination->get_parent_list();
-						Ai_info[shipp->ai_index].wp_index = find_index_of_waypoint(Ai_info[shipp->ai_index].wp_list, destination);
+					int wp_list_index = calc_waypoint_list_index(target_objp->instance);
+					int wp_index = calc_waypoint_index(target_objp->instance);
+					if (find_waypoint_at_indexes(wp_list_index, wp_index) != nullptr) {
+						Ai_info[shipp->ai_index].wp_list_index = wp_list_index;
+						Ai_info[shipp->ai_index].wp_index = wp_index;
 					} else {
-						Ai_info[shipp->ai_index].wp_list = nullptr;
+						Ai_info[shipp->ai_index].wp_list_index = -1;
+						Ai_info[shipp->ai_index].wp_index = INVALID_WAYPOINT_POSITION;
 					}
 				} else {
 					Ai_info[shipp->ai_index].target_objnum = OBJ_INDEX(target_objp);

--- a/code/object/waypoint.h
+++ b/code/object/waypoint.h
@@ -72,6 +72,7 @@ void waypoint_create_game_objects();
 
 // Find a waypoint list with the specified name
 waypoint_list *find_matching_waypoint_list(const char *name);
+int find_matching_waypoint_list_index(const char *name);
 
 // Find a waypoint with the specified name (e.g. Path:1)
 waypoint *find_matching_waypoint(const char *name);
@@ -84,6 +85,7 @@ waypoint *find_waypoint_with_instance(int waypoint_instance);
 // Find something at the specified index
 waypoint_list *find_waypoint_list_at_index(int index);
 waypoint *find_waypoint_at_index(waypoint_list *list, int index);
+waypoint *find_waypoint_at_indexes(int list_index, int index);
 int find_index_of_waypoint_list(const waypoint_list *wp_list);
 int find_index_of_waypoint(const waypoint_list *wp_list, const waypoint *wpt);
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -9296,7 +9296,7 @@ void multi_sexp_set_object_position()
 	objp = multi_get_network_object(obj_sig);
 	if (objp->type == OBJ_WAYPOINT) {
 		objp->pos = wp_vec;
-		waypoint *wpt = find_waypoint_with_objnum(OBJ_INDEX(objp));
+		waypoint *wpt = find_waypoint_with_instance(objp->instance);
 		wpt->set_pos(&wp_vec);
 	}
 }
@@ -20065,12 +20065,8 @@ int sexp_facing2(int node)
 		return SEXP_CANT_EVAL;
 	}
 
-	// get waypoint name
-	auto waypoint_name = CTEXT(node);
-
 	// get position of first waypoint
-	waypoint_list *wp_list = find_matching_waypoint_list(waypoint_name);
-
+	waypoint_list *wp_list = find_matching_waypoint_list(CTEXT(node));
 	if (wp_list == nullptr) {
 		return SEXP_KNOWN_FALSE;
 	}
@@ -20215,7 +20211,8 @@ int sexp_waypoint_twice()
 int sexp_path_flown()
 {
 	if (Training_context & TRAINING_CONTEXT_FLY_PATH) {
-		if ((uint) Training_context_goal_waypoint == Training_context_path->get_waypoints().size()){
+		auto wp_list = find_waypoint_list_at_index(Training_context_waypoint_path);
+		if (wp_list && (Training_context_goal_waypoint == static_cast<int>(wp_list->get_waypoints().size()))) {
 			return SEXP_TRUE;
 		}
 	}
@@ -24990,8 +24987,8 @@ void sexp_set_training_context_fly_path(int node)
 		return;
 
 	Training_context |= TRAINING_CONTEXT_FLY_PATH;
-	Training_context_path = wp_list;
-	Training_context_distance = (float)distance;
+	Training_context_waypoint_path = find_index_of_waypoint_list(wp_list);
+	Training_context_distance = static_cast<float>(distance);
 	Training_context_goal_waypoint = 0;
 	Training_context_at_waypoint = -1;
 }

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1269,8 +1269,8 @@ ADE_FUNC(createWaypoint, l_Mission, "[vector Position, waypointlist List]",
 	int waypoint_instance = -1;
 	if (wlh && wlh->isValid())
 	{
-		int wp_list_index = find_index_of_waypoint_list(wlh->wlp);
-		int wp_index = (int) wlh->wlp->get_waypoints().size() - 1;
+		int wp_list_index = find_index_of_waypoint_list(wlh->getList());
+		int wp_index = static_cast<int>(wlh->getList()->get_waypoints().size()) - 1;
 		waypoint_instance = calc_waypoint_instance(wp_list_index, wp_index);
 	}
 	int obj_idx = waypoint_add(v3 != NULL ? v3 : &vmd_zero_vector, waypoint_instance);

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -147,7 +147,7 @@ ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)"
 	if(ADE_SETTING_VAR && v3 != NULL) {
 		objh->objp()->pos = *v3;
 		if (objh->objp()->type == OBJ_WAYPOINT) {
-			waypoint *wpt = find_waypoint_with_objnum(objh->objnum);
+			waypoint *wpt = find_waypoint_with_instance(objh->objp()->instance);
 			wpt->set_pos(v3);
 		}
 

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -243,7 +243,7 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 									flags |= WPF_REPEAT;
 								if (ohp->aigp->flags[AI::Goal_Flags::Waypoints_in_reverse])
 									flags |= WPF_BACKTRACK;
-								ai_start_waypoints(ohp->objh.objp(), wpl, flags, ohp->aigp->int_data);
+								ai_start_waypoints(ohp->objh.objp(), find_index_of_waypoint_list(wpl), flags, ohp->aigp->int_data);
 							}
 						}
 					}
@@ -303,9 +303,9 @@ ADE_VIRTVAR(Target, l_Order, "object", "Target of the order. Value may also be a
 		case AI_GOAL_WAYPOINTS:
 		case AI_GOAL_WAYPOINTS_ONCE:
 			// check if waypoint order is the current goal (ohp->odx == 0) and if it is valid
-			if ( (ohp->odx == 0) && (aip->wp_index != INVALID_WAYPOINT_POSITION) &&
-				(aip->wp_index >= 0 && aip->wp_index < static_cast<int>(aip->wp_list->get_waypoints().size())) ) {
-				objnum = aip->wp_list->get_waypoints()[aip->wp_index].get_objnum();
+			waypoint* wp;
+			if ( (ohp->odx == 0) && (aip->wp_index != INVALID_WAYPOINT_POSITION) && ((wpl = find_waypoint_list_at_index(aip->wp_list_index)) != nullptr) && ((wp = find_waypoint_at_index(wpl, aip->wp_index)) != nullptr) ) {
+				objnum = wp->get_objnum();
 			} else {
 				wpl = find_matching_waypoint_list(ohp->aigp->target_name);
 				if (wpl != nullptr) {

--- a/code/scripting/api/objs/waypoint.cpp
+++ b/code/scripting/api/objs/waypoint.cpp
@@ -13,43 +13,41 @@ ADE_OBJ_DERIV(l_Waypoint, object_h, "waypoint", "waypoint handle", l_Object);
 ADE_FUNC(getList, l_Waypoint, NULL, "Returns the waypoint list", "waypointlist", "waypointlist handle or invalid handle if waypoint was invalid")
 {
 	object_h *oh = NULL;
-	waypointlist_h wpl;
 	waypoint_list *wp_list = NULL;
 	if(!ade_get_args(L, "o", l_Waypoint.GetPtr(&oh)))
 		return ade_set_error(L, "o", l_WaypointList.Set(waypointlist_h()));
 
 	if(oh->isValid() && oh->objp()->type == OBJ_WAYPOINT) {
 		wp_list = find_waypoint_list_with_instance(oh->objp()->instance);
-		if(wp_list != NULL)
-			wpl = waypointlist_h(wp_list);
-	}
-
-	if (wpl.isValid()) {
-		return ade_set_args(L, "o", l_WaypointList.Set(wpl));
+		return ade_set_args(L, "o", l_WaypointList.Set(waypointlist_h(wp_list)));
 	}
 
 	return ade_set_error(L, "o", l_WaypointList.Set(waypointlist_h()));
 }
 
-waypointlist_h::waypointlist_h() {wlp=NULL;name[0]='\0';}
-waypointlist_h::waypointlist_h(waypoint_list* n_wlp) {
-	wlp = n_wlp;
-	if(n_wlp != NULL) {
-		strcpy_s(name, wlp->get_name());
-	} else {
-		memset(name, 0, sizeof(name));
-	}
-}
-waypointlist_h::waypointlist_h(const char* wlname)
+waypointlist_h::waypointlist_h()
+	: wl_index(-1)
+{}
+waypointlist_h::waypointlist_h(int _wl_index)
 {
-	wlp = NULL;
-	if ( wlname != NULL ) {
-		strcpy_s(name, wlname);
-		wlp = find_matching_waypoint_list(wlname);
-	}
+	if (SCP_vector_inbounds(Waypoint_lists, _wl_index))
+		wl_index = _wl_index;
+	else
+		wl_index = -1;
 }
-bool waypointlist_h::isValid() const {
-	return (wlp != NULL && !strcmp(wlp->get_name(), name));
+waypointlist_h::waypointlist_h(waypoint_list* _wlp)
+	: waypointlist_h((_wlp == nullptr) ? -1 : find_index_of_waypoint_list(_wlp))
+{}
+waypointlist_h::waypointlist_h(const char* wlname)
+	: waypointlist_h((wlname == nullptr) ? nullptr : find_matching_waypoint_list(wlname))
+{}
+bool waypointlist_h::isValid() const
+{
+	return SCP_vector_inbounds(Waypoint_lists, wl_index);
+}
+waypoint_list* waypointlist_h::getList() const
+{
+	return isValid() ? &Waypoint_lists[wl_index] : nullptr;
 }
 
 //**********HANDLE: WaypointList
@@ -58,23 +56,20 @@ ADE_OBJ(l_WaypointList, waypointlist_h, "waypointlist", "waypointlist handle");
 ADE_INDEXER(l_WaypointList, "number Index", "Array of waypoints that are part of the waypoint list", "waypoint", "Waypoint, or invalid handle if the index or waypointlist handle is invalid")
 {
 	int idx = -1;
-	waypointlist_h* wlh = NULL;
-	char wpname[128];
+	waypointlist_h* wlh = nullptr;
 	if( !ade_get_args(L, "oi", l_WaypointList.GetPtr( &wlh ), &idx))
 		return ade_set_error( L, "o", l_Waypoint.Set( object_h() ) );
 
-	if(!wlh->isValid())
+	if(!wlh || !wlh->isValid())
 		return ade_set_error( L, "o", l_Waypoint.Set( object_h() ) );
 
 	//Lua-->FS2
 	idx--;
 
-	//Get waypoint name
-	sprintf(wpname, "%s:%d", wlh->wlp->get_name(), calc_waypoint_index(idx) + 1);
-	waypoint *wpt = find_matching_waypoint( wpname );
-	if( (idx >= 0) && ((uint) idx < wlh->wlp->get_waypoints().size()) && (wpt != NULL) && (wpt->get_objnum() >= 0) ) {
-		return ade_set_args(L, "o", l_Waypoint.Set(object_h(&Objects[wpt->get_objnum()])));
-	}
+	//Get waypoint
+	auto wp = find_waypoint_at_index(wlh->getList(), idx);
+	if (wp)
+		return ade_set_args(L, "o", l_Waypoint.Set(object_h(wp->get_objnum())));
 
 	return ade_set_error(L, "o", l_Waypoint.Set( object_h() ) );
 }
@@ -86,11 +81,15 @@ ADE_FUNC(__len, l_WaypointList,
 		 "number",
 		 "Number of waypoints in the list, or 0 if handle is invalid")
 {
-	waypointlist_h* wlh = NULL;
+	waypointlist_h* wlh = nullptr;
 	if ( !ade_get_args(L, "o", l_WaypointList.GetPtr(&wlh)) ) {
-		return ade_set_error( L, "o", l_Waypoint.Set( object_h() ) );
+		return ade_set_error(L, "i", 0);
 	}
-	return ade_set_args(L, "i", wlh->wlp->get_waypoints().size());
+	if (!wlh || !wlh->isValid()) {
+		return ade_set_error(L, "i", 0);
+	}
+
+	return ade_set_args(L, "i", wlh->getList()->get_waypoints().size());
 }
 
 ADE_VIRTVAR(Name, l_WaypointList, "string", "Name of WaypointList", "string", "Waypointlist name, or empty string if handle is invalid")
@@ -100,13 +99,15 @@ ADE_VIRTVAR(Name, l_WaypointList, "string", "Name of WaypointList", "string", "W
 	if ( !ade_get_args(L, "o|s", l_WaypointList.GetPtr(&wlh), &s) ) {
 		return ade_set_error(L, "s", "");
 	}
-
-	if(ADE_SETTING_VAR && s != NULL) {
-		wlh->wlp->set_name(s);
-		strcpy_s(wlh->name,s);
+	if (!wlh || !wlh->isValid()) {
+		return ade_set_error(L, "s", "");
 	}
 
-	return ade_set_args( L, "s", wlh->name);
+	if(ADE_SETTING_VAR && s != NULL) {
+		wlh->getList()->set_name(s);
+	}
+
+	return ade_set_args( L, "s", wlh->getList()->get_name());
 }
 
 ADE_FUNC(isValid, l_WaypointList, NULL, "Return if this waypointlist handle is valid", "boolean", "true if valid false otherwise")

--- a/code/scripting/api/objs/waypoint.h
+++ b/code/scripting/api/objs/waypoint.h
@@ -12,12 +12,13 @@ DECLARE_ADE_OBJ(l_Waypoint, object_h);
 
 struct waypointlist_h
 {
-	waypoint_list *wlp;
-	char name[NAME_LENGTH];
+	int wl_index;
 	waypointlist_h();
-	explicit waypointlist_h(waypoint_list *n_wlp);
+	explicit waypointlist_h(int _wl_index);
+	explicit waypointlist_h(waypoint_list* _wlp);
 	explicit waypointlist_h(const char* wlname);
 	bool isValid() const;
+	waypoint_list* getList() const;
 };
 
 DECLARE_ADE_OBJ(l_WaypointList, waypointlist_h);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17140,9 +17140,10 @@ int ship_return_seconds_to_goal(ship *sp)
 	if ( aip->mode == AIM_WAYPOINTS ) {
 		// Is traveling a waypoint path
 		min_speed = 0.9f * max_speed;
-		if (aip->wp_list != NULL) {
+		auto wp_list = find_waypoint_list_at_index(aip->wp_list_index);
+		if (wp_list != nullptr) {
 			Assert(aip->wp_index != INVALID_WAYPOINT_POSITION);
-			auto& waypoints = aip->wp_list->get_waypoints();
+			auto& waypoints = wp_list->get_waypoints();
 
 			// distance to current waypoint
 			dist += vm_vec_dist_quick(&objp->pos, waypoints[aip->wp_index].get_pos());

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7042,7 +7042,7 @@ void game_do_training_checks()
 	}
 
 	if (Training_context & TRAINING_CONTEXT_FLY_PATH) {
-		wplp = Training_context_path;
+		wplp = find_waypoint_list_at_index(Training_context_waypoint_path);
 		if (wplp->get_waypoints().size() > (uint) Training_context_goal_waypoint) {
 			i = Training_context_goal_waypoint;
 			do {


### PR DESCRIPTION
Several locations in the code (notably `ai_info` and `waypoint_h`) previously stored pointers for waypoints and waypoint lists that need to be valid for more than one frame.  Since both waypoint lists and waypoint paths may change size, resulting in vector reallocation, the information should be stored as indexes instead.

Fixes #6353.