### PR TITLE
Cycle expansion

### DIFF
--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -297,6 +297,8 @@ enum IoActionId : int {
 
 	TOGGLE_HUD_SHADOWS,
 
+	CYCLE_PRIMARY_WEAPON_PATTERN,
+
 	/*!
 	 * This must always be below the last defined item
 	 */

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -178,6 +178,7 @@ void control_config_common_init_bindings() {
 	(CYCLE_NEXT_PRIMARY,                             KEY_PERIOD, -1, WEAPON_TAB, 1, "Cycle Primary Weapon Forward",           CC_TYPE_TRIGGER)
 	(CYCLE_PREV_PRIMARY,                              KEY_COMMA, -1, WEAPON_TAB, 1, "Cycle Primary Weapon Backward",          CC_TYPE_TRIGGER)
 	(CYCLE_PRIMARY_WEAPON_SEQUENCE,                       KEY_O, -1, WEAPON_TAB, 1776, "Cycle Primary Weapon Firing Rate",       CC_TYPE_TRIGGER)
+	(CYCLE_PRIMARY_WEAPON_PATTERN,			  KEY_ALTED | KEY_O, -1, WEAPON_TAB, 0, "Cycle Primary Weapon Firing Pattern",	  CC_TYPE_TRIGGER) // need to get help from someone to track down what the next free number is
 	(CYCLE_SECONDARY,                                KEY_DIVIDE, -1, WEAPON_TAB, 1, "Cycle Secondary Weapon Forward",         CC_TYPE_TRIGGER)
 	(CYCLE_NUM_MISSLES,                KEY_SHIFTED | KEY_DIVIDE, -1, WEAPON_TAB, 1, "Cycle Secondary Weapon Firing Rate",     CC_TYPE_TRIGGER)
 	(LAUNCH_COUNTERMEASURE,                               KEY_X,  3, WEAPON_TAB, 1, "Launch Countermeasure",                  CC_TYPE_TRIGGER)
@@ -431,6 +432,7 @@ SCP_unordered_map<SCP_string, IoActionId> old_text = {
 	{"Cycle Nav Points",                        NAV_CYCLE},
 	{"Toggle Gliding",                          TOGGLE_GLIDING},
 	{"Cycle Primary Weapon Firing Rate",        CYCLE_PRIMARY_WEAPON_SEQUENCE},
+	{"Cycle Primary Weapon Firing Pattern",		CYCLE_PRIMARY_WEAPON_PATTERN},
 	{"Custom Control 1",                        CUSTOM_CONTROL_1},
 	{"Custom Control 2",                        CUSTOM_CONTROL_2},
 	{"Custom Control 3",                        CUSTOM_CONTROL_3},
@@ -1154,6 +1156,7 @@ void LoadEnumsIntoActionMap() {
 	ADD_ENUM_TO_ACTION_MAP(TOGGLE_GLIDING)
 
 	ADD_ENUM_TO_ACTION_MAP(CYCLE_PRIMARY_WEAPON_SEQUENCE)
+	ADD_ENUM_TO_ACTION_MAP(CYCLE_PRIMARY_WEAPON_PATTERN)
 
 	ADD_ENUM_TO_ACTION_MAP(CUSTOM_CONTROL_1)
 	ADD_ENUM_TO_ACTION_MAP(CUSTOM_CONTROL_2)

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -417,18 +417,63 @@ void HudGaugeReticle::getFirepointStatus() {
 					}
 
 					int num_slots = pm->gun_banks[i].num_slots;
+					int point_count = 0;
+					FiringPattern firing_pattern;
+					if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+						firing_pattern = sip->dyn_firing_patterns_allowed[shipp->weapons.current_primary_bank][swp->dynamic_firing_pattern[shipp->weapons.current_primary_bank]];
+					} else {
+						firing_pattern = Weapon_info[swp->primary_bank_weapons[i]].firing_pattern;
+					}
+
+					if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+						point_count = MIN(num_slots, swp->primary_bank_slot_count[shipp->weapons.current_primary_bank] );
+					} else if (firing_pattern != FiringPattern::STANDARD) {
+						point_count = MIN(num_slots, Weapon_info[swp->primary_bank_weapons[i]].shots);
+					} else {
+						point_count = num_slots;
+					}
+					
 					for (int j = 0; j < num_slots; j++) {
 						int fpactive = bankactive;
 
-						if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+						fpactive--;
+
+						for (int q = 0; q < point_count; q++) {
 							// If this firepoint is not among the next shot(s) to be fired, dim it one step
-							if ( !( (j >= (shipp->last_fired_point[i]+1) % num_slots) && (j <= (shipp->last_fired_point[i]+swp->primary_bank_slot_count[i]) % num_slots) ) ) {
-								fpactive--;
+							switch (firing_pattern) {
+								case FiringPattern::CYCLE_FORWARD: {
+									if (j == (swp->primary_firepoint_used_index[i] + q) % num_slots) {
+										fpactive++;
+									}
+									break;
+								}
+								case FiringPattern::CYCLE_REVERSE: {
+									if (j == ((swp->primary_firepoint_used_index[i] - (q + 1)) % num_slots + num_slots) % num_slots) {
+										fpactive++;
+									}
+									break;
+								}
+								case FiringPattern::RANDOM_EXHAUSTIVE: {
+									if (j == swp->primary_firepoint_indices[i][(swp->primary_firepoint_used_index[i] + q) % num_slots]) {
+										fpactive++;
+									}
+									break;
+								}
+								case FiringPattern::RANDOM_NONREPEATING:
+								case FiringPattern::RANDOM_REPEATING: {
+									if (j == swp->primary_firepoint_indices[i][q]) {
+										fpactive++;
+									}
+									break;
+								}
+								default:
+								case FiringPattern::STANDARD: {
+									fpactive++;
+									break;
+								}
 							}
-						} else if (Weapon_info[swp->primary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::Cycle]) {
-							// If this firepoint is not the next one to be fired, dim it one step
-							if (j != (shipp->last_fired_point[i]+1) % num_slots) {
-								fpactive--;
+							if (fpactive == bankactive) {
+								break;
 							}
 						}
 

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -1818,6 +1818,7 @@ int button_function_critical(int n, net_player *p = NULL)
 					polymodel *pm = model_get( sip->model_num );
 					count = (int)ftables.getNext( pm->gun_banks[ swp->current_primary_bank ].num_slots, swp->primary_bank_slot_count[ swp->current_primary_bank ] );
 					swp->primary_bank_slot_count[ swp->current_primary_bank ] = count;
+					swp->primary_firepoint_used_index[swp->current_primary_bank] = 0;
 				}
 			}
 			break;

--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -337,6 +337,7 @@ int Normal_key_set[] = {
 
 	TOGGLE_GLIDING,
 	CYCLE_PRIMARY_WEAPON_SEQUENCE,
+	CYCLE_PRIMARY_WEAPON_PATTERN,
 	CUSTOM_CONTROL_1,
     CUSTOM_CONTROL_2,
     CUSTOM_CONTROL_3,
@@ -1817,12 +1818,20 @@ int button_function_critical(int n, net_player *p = NULL)
 					polymodel *pm = model_get( sip->model_num );
 					count = (int)ftables.getNext( pm->gun_banks[ swp->current_primary_bank ].num_slots, swp->primary_bank_slot_count[ swp->current_primary_bank ] );
 					swp->primary_bank_slot_count[ swp->current_primary_bank ] = count;
-					shipp->last_fired_point[ swp->current_primary_bank ] += count - ( shipp->last_fired_point[ swp->current_primary_bank ] % count);
-					shipp->last_fired_point[ swp->current_primary_bank ] -= 1;
-					shipp->last_fired_point[ swp->current_primary_bank ] %= swp->primary_bank_slot_count[ swp->current_primary_bank ];
 				}
 			}
 			break;
+
+		case CYCLE_PRIMARY_WEAPON_PATTERN: {
+				ship* shipp = &Ships[objp->instance];
+				ship_weapon* swp = &shipp->weapons;
+				ship_info* sip = &Ship_info[shipp->ship_info_index];
+				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+					int new_pattern = (swp->dynamic_firing_pattern[swp->current_primary_bank] + 1) % (sip->dyn_firing_patterns_allowed[swp->current_primary_bank].size());
+					swp->dynamic_firing_pattern[swp->current_primary_bank] = new_pattern;
+					swp->primary_firepoint_used_index[swp->current_primary_bank] = 0;
+				}
+			} break;
 
 		// cycle to next primary weapon
 		case CYCLE_NEXT_PRIMARY:
@@ -2373,6 +2382,7 @@ int button_function(int n)
 	 */
 	switch (n) {
 		case CYCLE_PRIMARY_WEAPON_SEQUENCE:
+		case CYCLE_PRIMARY_WEAPON_PATTERN:
 		case CYCLE_NEXT_PRIMARY:	// cycle to next primary weapon
 		case CYCLE_PREV_PRIMARY:	// cycle to previous primary weapon
 		case CYCLE_SECONDARY:		// cycle to next secondary weapon

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -540,7 +540,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
     { "ballistic",					Weapon::Info_Flags::Ballistic,							true, false },
     { "default in tech database",	Weapon::Info_Flags::Default_in_tech_database,			true, false },
     { "tagged only",				Weapon::Info_Flags::Tagged_only,						true, false },
-    { "cycle",						Weapon::Info_Flags::Cycle,								true, false },
+    //{ "cycle",					Weapon::Info_Flags::Cycle,								true, false },
     { "small only",					Weapon::Info_Flags::Small_only,					    	true, false },
     { "same turret cooldown",		Weapon::Info_Flags::Same_turret_cooldown,				true, false },
     { "apply no light",				Weapon::Info_Flags::Mr_no_lighting,				    	true, false },
@@ -1156,6 +1156,9 @@ void ship_info::clone(const ship_info& other)
 	max_hull_strength = other.max_hull_strength;
 	ship_recoil_modifier = other.ship_recoil_modifier;
 	ship_shudder_modifier = other.ship_shudder_modifier;
+	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++) {
+		dyn_firing_patterns_allowed[i] = other.dyn_firing_patterns_allowed[i];
+	}
 	max_shield_strength = other.max_shield_strength;
 	max_shield_recharge = other.max_shield_recharge;
 	auto_shield_spread = other.auto_shield_spread;
@@ -1491,6 +1494,9 @@ void ship_info::move(ship_info&& other)
 	max_hull_strength = other.max_hull_strength;
 	ship_recoil_modifier = other.ship_recoil_modifier;
 	ship_shudder_modifier = other.ship_shudder_modifier;
+	for (int i = 0; i < MAX_SHIP_PRIMARY_BANKS; i++) {
+		dyn_firing_patterns_allowed[i] = other.dyn_firing_patterns_allowed[i];
+	}
 	max_shield_strength = other.max_shield_strength;
 	max_shield_recharge = other.max_shield_recharge;
 	auto_shield_spread = other.auto_shield_spread;
@@ -1911,6 +1917,8 @@ ship_info::ship_info()
 		primary_bank_weapons[i] = -1;
 		draw_primary_models[i] = false;
 		primary_bank_ammo_capacity[i] = 0;
+		dyn_firing_patterns_allowed[i].clear();
+		dyn_firing_patterns_allowed[i].push_back(FiringPattern::CYCLE_FORWARD);
 	}
 	
 	num_secondary_banks = 0;
@@ -3865,6 +3873,39 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 	if (optional_string("$Ship Shudder Modifier:")) {
 		stuff_float(&sip->ship_shudder_modifier);
+	}
+
+	int pattern_index = 0;
+	SCP_vector<SCP_string> temp_string_list;
+
+	while (optional_string("$Allowed Firing Patterns for Dynamic Primary Linking:")) {
+		if (pattern_index > MAX_SHIP_PRIMARY_BANKS) {
+			Error(LOCATION, "Firing pattern lists for ship %s defined more than %i times!", sip->name, MAX_SHIP_PRIMARY_BANKS);
+		}
+		temp_string_list.clear();
+		stuff_string_list(temp_string_list);
+		sip->dyn_firing_patterns_allowed[pattern_index].clear();
+		FiringPattern pattern;
+		for (auto &entry : temp_string_list) {
+			if (entry == "CYCLE FORWARD") {
+				pattern = FiringPattern::CYCLE_FORWARD;
+			} else if (entry == "CYCLE REVERSE") {
+				pattern = FiringPattern::CYCLE_REVERSE;
+			} else if (entry == "RANDOM EXHAUSTIVE") {
+				pattern = FiringPattern::RANDOM_EXHAUSTIVE;
+			} else if (entry == "RANDOM NONREPEATING") {
+				pattern = FiringPattern::RANDOM_NONREPEATING;
+			} else if (entry == "RANDOM REPEATING") {
+				pattern = FiringPattern::RANDOM_REPEATING;
+			} else {
+				Warning(LOCATION, "%s is not a valid firing pattern!", entry.c_str());
+				continue;
+			}
+			sip->dyn_firing_patterns_allowed[pattern_index].push_back(pattern);
+		}
+		if (sip->dyn_firing_patterns_allowed[pattern_index].size() == 0) {
+			sip->dyn_firing_patterns_allowed[pattern_index].push_back(FiringPattern::CYCLE_FORWARD);
+		}
 	}
 
 	if(optional_string("$Shields:")) {
@@ -6810,7 +6851,6 @@ void ship::clear()
 		// not part of weapons!
 		primary_rotate_rate[i] = 0.0f;
 		primary_rotate_ang[i] = 0.0f;
-		last_fired_point[i] = 0;
 		// for fighter beams
 		was_firing_last_frame[i] = 0;
 	}
@@ -7043,6 +7083,9 @@ void ship_weapon::clear()
         burst_counter[i] = 0;
 		burst_seed[i] = Random::next();
         external_model_fp_counter[i] = 0;
+
+		primary_firepoint_indices[i].clear();
+		primary_firepoint_used_index[i] = 0;
 
 		firing_loop_sounds[i] = -1;
     }
@@ -10707,6 +10750,14 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 		}
 
 		swp->primary_bank_capacity[i] = sip->primary_bank_ammo_capacity[i];
+
+		SCP_vector<int> fpi;
+		for (int fp = 0; fp < pm->gun_banks[i].num_slots; fp++) {
+			fpi.emplace_back(fp);
+		}
+		swp->primary_firepoint_indices[i] = fpi;
+		std::random_device rd;
+		std::shuffle(swp->primary_firepoint_indices[i].begin(), swp->primary_firepoint_indices[i].end(), std::mt19937(rd()));
 	}
 
 	swp->num_secondary_banks = sip->num_secondary_banks;
@@ -11070,6 +11121,10 @@ int ship_create(matrix* orient, vec3d* pos, int ship_type, const char* ship_name
 	ship_set_default_weapons(shipp, sip);	//	Moved up here because ship_set requires that weapon info be valid.  MK, 4/28/98
 	ship_set(shipnum, objnum, ship_type);
 
+	for (auto& fpu : shipp->weapons.primary_firepoint_used_index) {
+		fpu = 0;
+	}
+
 	init_ai_object(objnum);
 	ai_clear_ship_goals( &Ai_info[shipp->ai_index] );		// only do this one here.  Can't do it in init_ai because it might wipe out goals in mission file
 
@@ -11282,6 +11337,20 @@ static void ship_model_change(int n, int ship_type)
 
 	// reset texture animations
 	sp->base_texture_anim_timestamp = _timestamp();
+
+	for (int bank_i = 0; bank_i < MAX_SHIP_PRIMARY_BANKS; bank_i++) {
+		sp->weapons.primary_firepoint_indices[bank_i].clear();
+		sp->weapons.primary_firepoint_used_index[bank_i] = 0;
+		SCP_vector<int> fpi;
+		for (int fp = 0; fp < pm->gun_banks[bank_i].num_slots; fp++) {
+			fpi.emplace_back(fp);
+		}
+		sp->weapons.primary_firepoint_indices[bank_i] = fpi;
+		std::random_device rd;
+		std::shuffle(sp->weapons.primary_firepoint_indices[bank_i].begin(),
+			sp->weapons.primary_firepoint_indices[bank_i].end(),
+			std::mt19937(rd()));
+	}
 
 	model_delete_instance(sp->model_instance_num);
 
@@ -12403,7 +12472,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 	ship_weapon	*swp;
 	ship_info	*sip;
 	ai_info		*aip;
-	int			weapon_idx = -1, i, j, w, v, weapon_objnum;
+	int			weapon_idx = -1, i, weapon_objnum;
 	int			bank_to_fire, num_fired = 0;	
 	int			banks_fired;				// used for multiplayer to help determine whether or not to send packet
 	banks_fired = 0;			// used in multiplayer -- bitfield of banks that were fired
@@ -12679,7 +12748,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			Assert(pm->gun_banks[bank_to_fire].num_slots != 0);
 			swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay * ( swp->primary_bank_slot_count[ bank_to_fire ] ) / pm->gun_banks[bank_to_fire].num_slots ) );
 			swp->last_primary_fire_stamp[bank_to_fire] = timestamp();
-		} else if (winfo_p->wi_flags[Weapon::Info_Flags::Cycle]) {
+		} else if (winfo_p->firing_pattern != FiringPattern::STANDARD) {
 			Assert(pm->gun_banks[bank_to_fire].num_slots != 0);
 			swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay / pm->gun_banks[bank_to_fire].num_slots));
 			swp->last_primary_fire_stamp[bank_to_fire] = timestamp();
@@ -12764,19 +12833,28 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			
 			if(winfo_p->wi_flags[Weapon::Info_Flags::Beam]){		// the big change I made for fighter beams, if there beams fill out the Fire_Info for a targeting laser then fire it, for each point in the weapon bank -Bobboau				
 
-				int points = 0, numtimes = 1;
-				if (winfo_p->b_info.beam_shots){
-					numtimes = winfo_p->shots;
-					points = MIN(winfo_p->b_info.beam_shots, num_slots);
-				} else if (winfo_p->wi_flags[Weapon::Info_Flags::Cycle]) {
-					numtimes = 1;
-					points = MIN(num_slots, winfo_p->shots);
+				int point_count = 0, shot_count = 1;
+				FiringPattern firing_pattern;
+				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+					firing_pattern = sip->dyn_firing_patterns_allowed[bank_to_fire][swp->dynamic_firing_pattern[bank_to_fire]];
 				} else {
-					numtimes = winfo_p->shots;
-					points = num_slots;
+					firing_pattern = winfo_p->firing_pattern;
 				}
 
-				bool no_energy = shipp->weapon_energy < points * numtimes * winfo_p->energy_consumed * flFrametime;
+				// ok if this is a cycling weapon use shots as the number of points to fire from at a time
+				// otherwise shots is the number of times all points will be fired (used mostly for the 'shotgun' effect)
+				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+					shot_count = winfo_p->cycle_multishot;
+					point_count = MIN(num_slots, swp->primary_bank_slot_count[bank_to_fire] );
+				} else if (firing_pattern != FiringPattern::STANDARD) {
+					shot_count = winfo_p->cycle_multishot;
+					point_count = MIN(num_slots, winfo_p->shots);
+				} else {
+					shot_count = winfo_p->shots;
+					point_count = num_slots;
+				}
+
+				bool no_energy = shipp->weapon_energy < point_count * shot_count * winfo_p->energy_consumed * flFrametime;
 				if (no_energy || (winfo_p->wi_flags[Weapon::Info_Flags::Ballistic] && shipp->weapons.primary_bank_ammo[bank_to_fire] <= 0))
 				{
 					swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay));
@@ -12788,49 +12866,78 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					continue;
 				}			
 
-				for ( v = 0; v < points; v++ ){
-					if(winfo_p->b_info.beam_shots || winfo_p->wi_flags[Weapon::Info_Flags::Cycle]){
-						j = (shipp->last_fired_point[bank_to_fire]+1)%num_slots;
-						shipp->last_fired_point[bank_to_fire] = j;
-					}else{
-						j=v;
+				for (int pt_count = 0; pt_count < point_count; pt_count++) {
+					int pt;
+					switch (firing_pattern) {
+						case FiringPattern::CYCLE_FORWARD: {
+							pt = swp->primary_firepoint_used_index[bank_to_fire]++;
+							if (swp->primary_firepoint_used_index[bank_to_fire] >= num_slots) {
+								swp->primary_firepoint_used_index[bank_to_fire] = 0;
+							}
+							break;
+						}
+						case FiringPattern::CYCLE_REVERSE: {
+							if (--swp->primary_firepoint_used_index[bank_to_fire] < 0) {
+								swp->primary_firepoint_used_index[bank_to_fire] = num_slots - 1;
+							}
+							pt = swp->primary_firepoint_used_index[bank_to_fire];
+							break;
+						}
+						case FiringPattern::RANDOM_EXHAUSTIVE: {
+							pt = swp->primary_firepoint_indices[bank_to_fire][swp->primary_firepoint_used_index[bank_to_fire]++];
+							if (swp->primary_firepoint_used_index[bank_to_fire] >= num_slots) {
+								swp->primary_firepoint_used_index[bank_to_fire] = 0;
+							}
+							break;
+						}
+						case FiringPattern::RANDOM_NONREPEATING: // behaves the same as random repeating here
+						case FiringPattern::RANDOM_REPEATING: {
+							pt = swp->primary_firepoint_indices[bank_to_fire][pt_count];
+							break;
+						}
+						default:
+						case FiringPattern::STANDARD: {
+							pt = pt_count;
+							break;
+						}
 					}
-					for ( w = 0; w < numtimes; w++ ) {
+
+					for (int w = 0; w < shot_count; w++) {
 						beam_fire_info fbfire_info;
 						shipp->beam_sys_info.turret_norm.xyz.x = 0.0f;
-				    shipp->beam_sys_info.turret_norm.xyz.y = 0.0f;
-    				shipp->beam_sys_info.turret_norm.xyz.z = 1.0f;
-		    		shipp->beam_sys_info.model_num = sip->model_num;
-				    shipp->beam_sys_info.turret_gun_sobj = pm->detail[0];
-    				shipp->beam_sys_info.turret_num_firing_points = 1;  // dummy turret info is used per firepoint
-		    		shipp->beam_sys_info.turret_fov = -1.0f;
+				    	shipp->beam_sys_info.turret_norm.xyz.y = 0.0f;
+    					shipp->beam_sys_info.turret_norm.xyz.z = 1.0f;
+		    			shipp->beam_sys_info.model_num = sip->model_num;
+				    	shipp->beam_sys_info.turret_gun_sobj = pm->detail[0];
+    					shipp->beam_sys_info.turret_num_firing_points = 1;  // dummy turret info is used per firepoint
+		    			shipp->beam_sys_info.turret_fov = -1.0f;
 
-				    shipp->fighter_beam_turret_data.disruption_timestamp = timestamp(0);
-    				shipp->fighter_beam_turret_data.turret_next_fire_pos = 0;
-		    		shipp->fighter_beam_turret_data.current_hits = 1.0;
-				    shipp->fighter_beam_turret_data.system_info = &shipp->beam_sys_info;
-				
-    				fbfire_info.target_subsys = Ai_info[shipp->ai_index].targeted_subsys;
-    				fbfire_info.beam_info_index = shipp->weapons.primary_bank_weapons[bank_to_fire];
-    				fbfire_info.beam_info_override = NULL;
-    				fbfire_info.shooter = &Objects[shipp->objnum];
-				
-	    			if (aip->target_objnum >= 0) {
-    					fbfire_info.target = &Objects[aip->target_objnum];
-    				} else {
-    					fbfire_info.target = NULL;
-	    			}
-	    			fbfire_info.turret = &shipp->fighter_beam_turret_data;
-    				fbfire_info.bfi_flags = BFIF_IS_FIGHTER_BEAM;
-    				fbfire_info.bank = bank_to_fire;
-    				fbfire_info.burst_index = old_burst_counter;
-	    			fbfire_info.burst_seed = old_burst_seed;
-	    			fbfire_info.per_burst_rotation = swp->per_burst_rot;
+				    	shipp->fighter_beam_turret_data.disruption_timestamp = timestamp(0);
+    					shipp->fighter_beam_turret_data.turret_next_fire_pos = 0;
+		    			shipp->fighter_beam_turret_data.current_hits = 1.0;
+				    	shipp->fighter_beam_turret_data.system_info = &shipp->beam_sys_info;
 
-						fbfire_info.local_fire_postion = pm->gun_banks[bank_to_fire].pnt[j];
-						shipp->beam_sys_info.pnt = pm->gun_banks[bank_to_fire].pnt[j];
-						shipp->beam_sys_info.turret_firing_point[0] = pm->gun_banks[bank_to_fire].pnt[j];
-						fbfire_info.point = j;
+    					fbfire_info.target_subsys = Ai_info[shipp->ai_index].targeted_subsys;
+    					fbfire_info.beam_info_index = shipp->weapons.primary_bank_weapons[bank_to_fire];
+    					fbfire_info.beam_info_override = NULL;
+    					fbfire_info.shooter = &Objects[shipp->objnum];
+
+	    				if (aip->target_objnum >= 0) {
+    						fbfire_info.target = &Objects[aip->target_objnum];
+    					} else {
+    						fbfire_info.target = NULL;
+	    				}
+	    				fbfire_info.turret = &shipp->fighter_beam_turret_data;
+    					fbfire_info.bfi_flags = BFIF_IS_FIGHTER_BEAM;
+    					fbfire_info.bank = bank_to_fire;
+    					fbfire_info.burst_index = old_burst_counter;
+	    				fbfire_info.burst_seed = old_burst_seed;
+	    				fbfire_info.per_burst_rotation = swp->per_burst_rot;
+
+						fbfire_info.local_fire_postion = pm->gun_banks[bank_to_fire].pnt[pt];
+						shipp->beam_sys_info.pnt = pm->gun_banks[bank_to_fire].pnt[pt];
+						shipp->beam_sys_info.turret_firing_point[0] = pm->gun_banks[bank_to_fire].pnt[pt];
+						fbfire_info.point = pt;
 						fbfire_info.fire_method = BFM_FIGHTER_FIRED;
 						beam_fire(&fbfire_info);
 						has_fired = true;
@@ -12840,19 +12947,35 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 			}
 			else	//if this isn't a fighter beam, do it normally -Bobboau
 			{
-				int points = 0, numtimes = 1;
+				int point_count = 0, shot_count = 1;
+				FiringPattern firing_pattern;
+				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+					firing_pattern = sip->dyn_firing_patterns_allowed[bank_to_fire][swp->dynamic_firing_pattern[bank_to_fire]];
+				} else {
+					firing_pattern = winfo_p->firing_pattern;
+				}
 
 				// ok if this is a cycling weapon use shots as the number of points to fire from at a time
 				// otherwise shots is the number of times all points will be fired (used mostly for the 'shotgun' effect)
-				if ( sip->flags[Ship::Info_Flags::Dyn_primary_linking] ) {
-					numtimes = 1;
-					points = MIN( num_slots, swp->primary_bank_slot_count[ bank_to_fire ] );
-				} else if ( winfo_p->wi_flags[Weapon::Info_Flags::Cycle] ) {
-					numtimes = 1;
-					points = MIN(num_slots, winfo_p->shots);
+				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
+					shot_count = winfo_p->cycle_multishot;
+					point_count = MIN(num_slots, swp->primary_bank_slot_count[ bank_to_fire ] );
+				} else if (firing_pattern != FiringPattern::STANDARD) {
+					shot_count = winfo_p->cycle_multishot;
+					point_count = MIN(num_slots, winfo_p->shots);
 				} else {
-					numtimes = winfo_p->shots;
-					points = num_slots;
+					shot_count = winfo_p->shots;
+					point_count = num_slots;
+				}
+
+				if (swp->primary_firepoint_indices[bank_to_fire].empty()) {
+					SCP_vector<int> fpi;
+					for (int fp = 0; fp < num_slots; fp++) {
+						fpi.emplace_back(fp);
+					}
+					swp->primary_firepoint_indices[bank_to_fire] = fpi;
+					std::random_device rd;
+					std::shuffle(swp->primary_firepoint_indices[bank_to_fire].begin(), swp->primary_firepoint_indices[bank_to_fire].end(), std::mt19937(rd()));
 				}
 
 				// The energy-consumption code executes even for ballistic primaries, because
@@ -12861,7 +12984,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				// the weapon's energy_consumed to 0 and it'll work just fine. - Goober5000
 
 				// fail unless we're forcing (energy based primaries)
-				bool no_energy = shipp->weapon_energy < points * numtimes * winfo_p->energy_consumed; //was num_slots
+				bool no_energy = shipp->weapon_energy < point_count * shot_count * winfo_p->energy_consumed; //was num_slots
 				if ( no_energy && !force ) {
 
 					swp->next_primary_fire_stamp[bank_to_fire] = timestamp((int)(next_fire_delay));
@@ -12911,7 +13034,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					// deplete ammo
 					if ( !Weapon_energy_cheat )
 					{
-						swp->primary_bank_ammo[bank_to_fire] -= points*numtimes;
+						swp->primary_bank_ammo[bank_to_fire] -= point_count*shot_count;
 
 						// make sure we don't go below zero; any such error is excusable
 						// because it only happens when the bank is depleted in one shot
@@ -12925,7 +13048,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				// now handle the energy as usual
 				// deplete the weapon reserve energy by the amount of energy used to fire the weapon	
 				// Only subtract the energy amount required for equipment operation once
-				shipp->weapon_energy -= points*numtimes * winfo_p->energy_consumed;
+				shipp->weapon_energy -= point_count*shot_count * winfo_p->energy_consumed;
 				// note for later: option for fuel!
 				
 				// Mark all these weapons as in the same group
@@ -12936,28 +13059,56 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				size_t current_firepoint = 0;
 
 				if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){
-					firepoint_list = new vec3d[numtimes * points];
+					firepoint_list = new vec3d[shot_count * point_count];
 					vm_vec_zero(&total_impulse);
 				} else {
 					firepoint_list = nullptr;
 				}
 
-				for ( w = 0; w < numtimes; w++ ) {
-					polymodel *weapon_model = NULL;
-					if (sip->draw_primary_models[bank_to_fire] && (winfo_p->external_model_num >= 0)) 
-						weapon_model = model_get(winfo_p->external_model_num);
+				polymodel *weapon_model = NULL;
+				if (sip->draw_primary_models[bank_to_fire] && (winfo_p->external_model_num >= 0)) 
+					weapon_model = model_get(winfo_p->external_model_num);
 
-					if (weapon_model)
-						if ((weapon_model->n_guns <= swp->external_model_fp_counter[bank_to_fire]) || (swp->external_model_fp_counter[bank_to_fire] < 0))
-							swp->external_model_fp_counter[bank_to_fire] = 0;
-
-					for ( j = 0; j < points; j++ ) {
-						int pt; //point
-						if ( (winfo_p->wi_flags[Weapon::Info_Flags::Cycle]) || (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) ){
-							pt = (shipp->last_fired_point[bank_to_fire]+1)%num_slots;
-						}else{
-							pt = j;
+				for (int pt_count = 0; pt_count < point_count; pt_count++) {
+					int pt;
+					switch (firing_pattern) {
+						case FiringPattern::CYCLE_FORWARD: {
+							pt = swp->primary_firepoint_used_index[bank_to_fire]++;
+							if (swp->primary_firepoint_used_index[bank_to_fire] >= num_slots) {
+								swp->primary_firepoint_used_index[bank_to_fire] = 0;
+							}
+							break;
 						}
+						case FiringPattern::CYCLE_REVERSE: {
+							if (--swp->primary_firepoint_used_index[bank_to_fire] < 0) {
+								swp->primary_firepoint_used_index[bank_to_fire] = num_slots - 1;
+							}
+							pt = swp->primary_firepoint_used_index[bank_to_fire];
+							break;
+						}
+						case FiringPattern::RANDOM_EXHAUSTIVE: {
+							pt = swp->primary_firepoint_indices[bank_to_fire][swp->primary_firepoint_used_index[bank_to_fire]++];
+							if (swp->primary_firepoint_used_index[bank_to_fire] >= num_slots) {
+								swp->primary_firepoint_used_index[bank_to_fire] = 0;
+							}
+							break;
+						}
+						case FiringPattern::RANDOM_NONREPEATING: // behaves the same as random repeating here
+						case FiringPattern::RANDOM_REPEATING: {
+							pt = swp->primary_firepoint_indices[bank_to_fire][pt_count];
+							break;
+						}
+						default:
+						case FiringPattern::STANDARD: {
+							pt = pt_count;
+							break;
+						}
+					}
+
+					for (int j = 0; j < shot_count; j++) {
+						if (weapon_model)
+							if ((weapon_model->n_guns <= swp->external_model_fp_counter[bank_to_fire]) || (swp->external_model_fp_counter[bank_to_fire] < 0))
+								swp->external_model_fp_counter[bank_to_fire] = 0;
 
 						int sub_shots = 1;
 						// Use 0 instead of bank_to_fire as index when checking the number of external weapon model firingpoints
@@ -12980,7 +13131,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 							vm_vec_unrotate(&gun_point, &pnt, &obj->orient);
 							vm_vec_add(&firing_pos, &gun_point, &obj->pos);
-							
+
 							/*	I AIM autoaim convergence
 								II AIM autoaim
 								III AIM auto convergence
@@ -13005,7 +13156,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 							} else if (std_convergence_flagged || (auto_convergence_flagged && (aip->target_objnum != -1))) {
 								// std & auto convergence
 								vec3d target_vec, firing_vec, convergence_offset;
-								
+
 								// make sure vector is of the set length
 								vm_vec_copy_normalize(&target_vec, &firing_orient.vec.fvec);
 								if (auto_convergence_flagged && (aip->target_objnum != -1)) {
@@ -13017,7 +13168,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 									const float convergence_distance = std::max(sip->convergence_distance, winfo_p->convergence_distance);
 									vm_vec_scale(&target_vec, convergence_distance);
 								}
-								
+
 								// if there is convergence offset then make use of it)
 								if (sip->aiming_flags[Object::Aiming_Flags::Convergence_offset]) {
 									vm_vec_unrotate(&convergence_offset, &sip->convergence_offset, &obj->orient);
@@ -13035,10 +13186,10 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								vm_vec_unrotate(&firing_vec, &pm->gun_banks[bank_to_fire].norm[pt], &obj->orient);
 								vm_vector_2_matrix(&firing_orient, &firing_vec, NULL, NULL);
 							}
-							
+
 							if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){	// Function to add recoil functionality - DahBlount
 								vec3d local_impulse = firing_orient.vec.fvec;
-								
+
 								float recoil_force = (winfo_p->mass * winfo_p->max_speed * winfo_p->recoil_modifier * sip->ship_recoil_modifier);
 
 								firepoint_list[current_firepoint++] = firing_pos;
@@ -13106,16 +13257,43 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 							}
 
 							num_fired++;
-							shipp->last_fired_point[bank_to_fire] = (shipp->last_fired_point[bank_to_fire] + 1) % num_slots;				
 
 							// maybe add this weapon to the list of those we need to roll forward
 							if ((Game_mode & (GM_MULTIPLAYER | GM_STANDALONE_SERVER )) && rollback_shot) {
 								multi_ship_record_add_rollback_wep(weapon_objnum);
 							}
 						}
+						swp->external_model_fp_counter[bank_to_fire]++;
 					}
-					swp->external_model_fp_counter[bank_to_fire]++;
 				}
+
+				switch (firing_pattern) {
+					case FiringPattern::RANDOM_EXHAUSTIVE: {
+						if (num_slots < (swp->primary_firepoint_used_index[bank_to_fire] + point_count)) {
+							std::random_device rd;
+							std::shuffle(&swp->primary_firepoint_indices[bank_to_fire][0], &swp->primary_firepoint_indices[bank_to_fire][swp->primary_firepoint_used_index[bank_to_fire]-1], std::mt19937(rd()));
+						} else if (swp->primary_firepoint_used_index[bank_to_fire] < point_count) {
+							std::random_device rd;
+							std::shuffle(swp->primary_firepoint_indices[bank_to_fire].begin(), swp->primary_firepoint_indices[bank_to_fire].end(), std::mt19937(rd()));
+						}
+						break;
+					}
+					case FiringPattern::RANDOM_NONREPEATING: {
+						int shuffle_start = MIN(point_count, num_slots - point_count);
+						std::random_device rd;
+						auto middle_iterator = swp->primary_firepoint_indices[bank_to_fire].begin();
+						std::advance(middle_iterator, shuffle_start);
+						std::shuffle(middle_iterator, swp->primary_firepoint_indices[bank_to_fire].end(), std::mt19937(rd()));
+						std::rotate(swp->primary_firepoint_indices[bank_to_fire].begin(), middle_iterator, swp->primary_firepoint_indices[bank_to_fire].end());
+						break;
+					}
+					case FiringPattern::RANDOM_REPEATING: {
+						std::random_device rd;
+						std::shuffle(swp->primary_firepoint_indices[bank_to_fire].begin(), swp->primary_firepoint_indices[bank_to_fire].end(), std::mt19937(rd()));
+						break;
+					}
+				}
+
 				if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){
 					vec3d avg_firepoint;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7078,7 +7078,7 @@ void ship_weapon::clear()
 
         primary_animation_position[i] = EModelAnimationPosition::MA_POS_NOT_SET;
 
-        primary_bank_pattern_index[i] = 0;
+        primary_bank_substitution_pattern_index[i] = 0;
 
         burst_counter[i] = 0;
 		burst_seed[i] = Random::next();
@@ -7107,7 +7107,7 @@ void ship_weapon::clear()
 
 		secondary_animation_position[i] = EModelAnimationPosition::MA_POS_NOT_SET;
 
-		secondary_bank_pattern_index[i] = 0;
+		secondary_bank_substitution_pattern_index[i] = 0;
 
         burst_counter[i + MAX_SHIP_PRIMARY_BANKS] = 0;
         external_model_fp_counter[i + MAX_SHIP_PRIMARY_BANKS] = 0;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -31,6 +31,7 @@
 #include "weapon/trails.h"
 #include "ship/ship_flags.h"
 #include "weapon/weapon_flags.h"
+#include "weapon/weapon.h"
 #include "ai/ai.h"
 
 #include <string>
@@ -131,6 +132,7 @@ public:
 
 	// dynamic weapon linking - by RSAXVC
 	int primary_bank_slot_count[MAX_SHIP_PRIMARY_BANKS];	// Fire this many slots at a time
+	int dynamic_firing_pattern[MAX_SHIP_PRIMARY_BANKS];		// Index into ship_info's dyn_firing_patterns_allowed
 	// end dynamic weapon linking
 
 	int secondary_bank_ammo[MAX_SHIP_SECONDARY_BANKS];			// Number of missiles left in secondary bank
@@ -163,7 +165,10 @@ public:
 	int	burst_seed[MAX_SHIP_PRIMARY_BANKS + MAX_SHIP_SECONDARY_BANKS];    // A random seed, recalculated only when the weapon's burst resets
 	int external_model_fp_counter[MAX_SHIP_PRIMARY_BANKS + MAX_SHIP_SECONDARY_BANKS];
 
-	size_t primary_bank_pattern_index[MAX_SHIP_PRIMARY_BANKS];
+	SCP_vector<int> primary_firepoint_indices[MAX_SHIP_PRIMARY_BANKS];
+	int primary_firepoint_used_index[MAX_SHIP_PRIMARY_BANKS];
+
+	size_t primary_bank_pattern_index[MAX_SHIP_PRIMARY_BANKS];    // so that future people are not confused like I was, these fields deal with weapon substitution, not anything else
 	size_t secondary_bank_pattern_index[MAX_SHIP_SECONDARY_BANKS];
 
 	// for type5 beams, keeps track of accumulated per burst rotation, added to with each shot (or burst)
@@ -783,7 +788,6 @@ public:
 
 	float alpha_mult;
 
-	int last_fired_point[MAX_SHIP_PRIMARY_BANKS]; //for fire point cylceing
 	ship_subsys *last_fired_turret; // which turret has fired last
 
 	// fighter bay door stuff, parent side
@@ -1319,6 +1323,8 @@ public:
 
 	// Shudder modifier for the ship
 	float ship_shudder_modifier;
+
+	SCP_vector<FiringPattern> dyn_firing_patterns_allowed[MAX_SHIP_PRIMARY_BANKS];
 
 	float	max_hull_strength;				// Max hull strength of this class of ship.
 	float	max_shield_strength;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -168,8 +168,8 @@ public:
 	SCP_vector<int> primary_firepoint_indices[MAX_SHIP_PRIMARY_BANKS];
 	int primary_firepoint_used_index[MAX_SHIP_PRIMARY_BANKS];
 
-	size_t primary_bank_pattern_index[MAX_SHIP_PRIMARY_BANKS];    // so that future people are not confused like I was, these fields deal with weapon substitution, not anything else
-	size_t secondary_bank_pattern_index[MAX_SHIP_SECONDARY_BANKS];
+	size_t primary_bank_substitution_pattern_index[MAX_SHIP_PRIMARY_BANKS];
+	size_t secondary_bank_substitution_pattern_index[MAX_SHIP_SECONDARY_BANKS];
 
 	// for type5 beams, keeps track of accumulated per burst rotation, added to with each shot (or burst)
 	float per_burst_rot;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -318,6 +318,16 @@ struct ConditionalImpact {
 	bool dinky;
 };
 
+enum class FiringPattern {
+	STANDARD,
+	CYCLE_FORWARD,
+	CYCLE_REVERSE,
+	RANDOM_EXHAUSTIVE,
+	RANDOM_NONREPEATING,
+	RANDOM_REPEATING,
+	MAX_VALUE,
+};
+
 struct weapon_info
 {
 	char	name[NAME_LENGTH];				// name of this weapon
@@ -539,9 +549,11 @@ struct weapon_info
 	float fof_spread_rate;			//How quickly the FOF will spread for each shot (primary weapons only, this doesn't really make sense for turrets)
 	float fof_reset_rate;			//How quickly the FOF spread will reset over time (primary weapons only, this doesn't really make sense for turrets)
 	float max_fof_spread;			//The maximum fof increase that the shots can spread to
+	FiringPattern firing_pattern;
 	int	  shots;					//the number of shots that will be fired at a time, 
 									//only realy usefull when used with FOF to make a shot gun effect
 									//now also used for weapon point cycleing
+	int   cycle_multishot;			//ugly hack -- used to control multishot if the weapon uses any non-standard firing pattern, since $shots is used for fire point number
 
 	// Corkscrew info - phreak 11/9/02
 	int cs_num_fired;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -325,7 +325,6 @@ enum class FiringPattern {
 	RANDOM_EXHAUSTIVE,
 	RANDOM_NONREPEATING,
 	RANDOM_REPEATING,
-	MAX_VALUE,
 };
 
 struct weapon_info

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -44,7 +44,6 @@ namespace Weapon {
 		Default_in_tech_database,			// this entry's default tech database status, as specified in weapons.tbl; used when the tech db is "reset to default" - Goober5000
 		Local_ssm,							// localized ssm. ship that fires ssm is in mission.  ssms also warp back in during mission
 		Tagged_only,						// can only fire if target is tagged
-		Cycle,								// will only fire from (shots (defalts to 1)) points at a time
 		Small_only,							// can only be used against small ships like fighters or bombers
 		Same_turret_cooldown,				// the weapon has the same cooldown time on turrets
 		Mr_no_lighting,						// don't render with lighting, regardless of user options

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6403,12 +6403,12 @@ size_t* get_pointer_to_weapon_fire_pattern_index(int weapon_type, int ship_idx, 
 	// the weapon to the wrong bank.  Hopefully this isn't a problem.
 	for ( int pi = 0; pi < MAX_SHIP_PRIMARY_BANKS; pi++ ) {
 		if ( ship_weapon_p->primary_bank_weapons[pi] == weapon_type ) {
-			return &(ship_weapon_p->primary_bank_pattern_index[pi]);
+			return &(ship_weapon_p->primary_bank_substitution_pattern_index[pi]);
 		}
 	}
 	for ( int si = 0; si < MAX_SHIP_SECONDARY_BANKS; si++ ) {
 		if ( ship_weapon_p->secondary_bank_weapons[si] == weapon_type ) {
-			return &(ship_weapon_p->secondary_bank_pattern_index[si]);
+			return &(ship_weapon_p->secondary_bank_substitution_pattern_index[si]);
 		}
 	}
 	return NULL;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -196,7 +196,9 @@ special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info
 		Warning(LOCATION, "The \"beam no whack\" flag has been deprecated.  Set the beam's mass to 0 instead.  This has been done for you.\n");
 		weaponp->mass = 0.0f;
 	}}, //special case
-    { "cycle",							Weapon::Info_Flags::Cycle,								true },
+    { "cycle",							Weapon::Info_Flags::NUM_VALUES,							false, [](const SCP_string& /*spawn*/, weapon_info* weaponp, flagset<Weapon::Info_Flags>& /*flags*/) {
+		weaponp->firing_pattern = FiringPattern::CYCLE_FORWARD;
+	}}, //special case
     { "small only",						Weapon::Info_Flags::Small_only,							true },
     { "same turret cooldown",			Weapon::Info_Flags::Same_turret_cooldown,				true },
     { "apply no light",					Weapon::Info_Flags::Mr_no_lighting,						true },
@@ -3578,9 +3580,27 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}		
 	}
 
+	if(optional_string("$Firing Pattern:")) {
+		stuff_string(fname, F_NAME, NAME_LENGTH);
+		if (!stricmp(fname, "CYCLE FORWARD")) {
+			wip->firing_pattern = FiringPattern::CYCLE_FORWARD;
+		} else if (!stricmp(fname, "CYCLE REVERSE")) {
+			wip->firing_pattern = FiringPattern::CYCLE_REVERSE;
+		} else if (!stricmp(fname, "RANDOM EXHAUSTIVE")) {
+			wip->firing_pattern = FiringPattern::RANDOM_EXHAUSTIVE;
+		} else if (!stricmp(fname, "RANDOM NONREPEATING")) {
+			wip->firing_pattern = FiringPattern::RANDOM_NONREPEATING;
+		} else if (!stricmp(fname, "RANDOM REPEATING")) {
+			wip->firing_pattern = FiringPattern::RANDOM_REPEATING;
+		}
+	}
 
 	if( optional_string("$Shots:")){
 		stuff_int(&wip->shots);
+	}
+
+	if( optional_string("$Cycle Multishot:")){
+		stuff_int(&wip->cycle_multishot);
 	}
 
 	//Left in for compatibility
@@ -9541,7 +9561,9 @@ void weapon_info::reset()
 	this->fof_spread_rate = 0.0f;
 	this->fof_reset_rate = 0.0f;
 	this->max_fof_spread = 0.0f;
+	this->firing_pattern = FiringPattern::STANDARD;
 	this->shots = 1;
+	this->cycle_multishot = 1;
 
 	//customizeable corkscrew stuff
 	this->cs_num_fired = 4;


### PR DESCRIPTION
Overhaul to the "cycle" weapon flag. Establishes the following firing pattern options for weapons:
1. STANDARD: fires all bank firepoints simultaneously. Retail behavior.
2. CYCLE FORWARD: fires `$shots` firepoints at a time, starting at firepoint 0 and incrementing from there. Same behavior as old "cycle" flag.
3. CYCLE REVERSE: same as cycle-forward, but backwards.
4. RANDOM EXHAUSTIVE: fires each firepoint in the bank once, in a random order, `$shots` at a time, then starts over.
5. RANDOM NONREPEATING: fires `$shots` randomly-selected firepoints at a time, with the restriction that the same firepoint will never fire twice in a row (unless that's unavoidable because `$shots` is greater than number-of-firepoints/2).
6. RANDOM REPEATING: fires `$shots` randomly-selected firepoints at a time, no restrictions.

The "cycle" flag still exists and functions (sets weapon to use CYCLE FORWARD), but should probably be deprecated. A "cycle multishot" optional parameter is added, which allows weapons using non-standard firing patterns to exhibit shotgun behavior.

On a ship that has the "dynamic primary linking" flag, any combination of firing patterns can be listed as allowed for that ship. A new control allows the player to cycle through firing patterns, same as how an existing one allows cycling through fire rates. By default, only CYCLE FORWARD is allowed, preserving the existing dyn-primary-linking behavior.

If firepoints are rendered on the HUD, the brightening of the next firepoints to fire works correctly, even for random patterns. Unfortunately, there is no HUD element indicating which pattern is active. That should probably be fixed, but is outside the scope of this PR.