### PR TITLE
Disambiguate `ShockwaveDamage` cases

### DIFF
--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -548,11 +548,11 @@ ADE_VIRTVAR(EnergyConsumed, l_Weaponclass, nullptr, nullptr, "number", "Energy C
 	return ade_set_args(L, "f", Weapon_info[idx].energy_consumed);
 }
 
-ADE_VIRTVAR(ShockwaveDamage, l_Weaponclass, "number", "Damage the shockwave is set to if damage is overriden", "number", "Shockwave Damage, or 0 if weapon shockwave damage is not overriden. Returns nil if handle is invalid")
+ADE_VIRTVAR(ShockwaveDamage, l_Weaponclass, "number", "Damage the shockwave is set to if damage is overriden", "number", "Shockwave Damage if explicitly specified via table, or -1 if unspecified. Returns nil if handle is invalid")
 {
 	int idx;
 	if(!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
-		return ade_set_error(L, "f", 0.0f);
+		return ade_set_error(L, "f", -1.0f);
 
 	if(idx < 0 || idx >= weapon_info_size())
 		return ADE_RETURN_NIL;
@@ -564,7 +564,7 @@ ADE_VIRTVAR(ShockwaveDamage, l_Weaponclass, "number", "Damage the shockwave is s
 	if (Weapon_info[idx].shockwave.damage_overidden) {
 		return ade_set_args(L, "f", Weapon_info[idx].shockwave.damage);
 	} else {
-		return ade_set_args(L, "f", 0.0f);
+		return ade_set_args(L, "f", -1.0f);
 	}
 }
 

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -548,7 +548,7 @@ ADE_VIRTVAR(EnergyConsumed, l_Weaponclass, nullptr, nullptr, "number", "Energy C
 	return ade_set_args(L, "f", Weapon_info[idx].energy_consumed);
 }
 
-ADE_VIRTVAR(ShockwaveDamage, l_Weaponclass, "number", "Damage the shockwave is set to if damage is overriden", "number", "Shockwave Damage if explicitly specified via table, or -1 if unspecified. Returns nil if handle is invalid")
+ADE_VIRTVAR(ShockwaveDamage, l_Weaponclass, "number", "Damage the shockwave is set to if damage is overridden", "number", "Shockwave Damage if explicitly specified via table, or -1 if unspecified. Returns nil if handle is invalid")
 {
 	int idx;
 	if(!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
@@ -561,7 +561,7 @@ ADE_VIRTVAR(ShockwaveDamage, l_Weaponclass, "number", "Damage the shockwave is s
 		LuaError(L, "Setting Shockwave Damage is not supported");
 	}
 
-	if (Weapon_info[idx].shockwave.damage_overidden) {
+	if (Weapon_info[idx].shockwave.damage_overridden) {
 		return ade_set_args(L, "f", Weapon_info[idx].shockwave.damage);
 	} else {
 		return ade_set_args(L, "f", -1.0f);

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -774,7 +774,7 @@ void shockwave_create_info_init(shockwave_create_info *sci)
 	sci->rot_angles.p = sci->rot_angles.b = sci->rot_angles.h = 0.0f;
 	sci->rot_defined = false;
 	sci->damage_type_idx = sci->damage_type_idx_sav = -1;
-	sci->damage_overidden = false;
+	sci->damage_overridden = false;
 
 	sci->blast_sound_id = GameSounds::SHOCKWAVE_IMPACT;
 }

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -83,7 +83,7 @@ typedef struct shockwave_create_info {
 	int radius_curve_idx;   // curve for shockwave radius over time
 	angles rot_angles;
 	bool rot_defined;		// if the modder specified rot_angles
-	bool damage_overidden;  // did this have shockwave damage specifically set or not
+	bool damage_overridden;  // did this have shockwave damage specifically set or not
 
 	int damage_type_idx;
 	int damage_type_idx_sav;	// stored value from table used to reset damage_type_idx

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -775,6 +775,8 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 	sprintf(buf, "%sShockwave damage:", pre_char);
 	if(optional_string(buf.c_str())) {
 		stuff_float(&sci->damage);
+		if (sci->damage < 0.0f)
+			sci->damage = 0.0f;
 		sci->damage_overidden = true;
 	}
 
@@ -1321,6 +1323,12 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 	if(optional_string("$Damage:")) {
 		stuff_float(&wip->damage);
+
+		if (wip->damage < 0.0f) {
+			Warning(LOCATION, "$Damage in weapon '%s' should not be negative.\nConsider the 'heals' flag instead if this is intentional. ", wip->name);
+			wip->damage = 0.0f;
+		}
+
 		//WMC - now that shockwave damage can be set for them individually,
 		//do this automagically
 		if(!wip->shockwave.damage_overidden) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -777,7 +777,7 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 		stuff_float(&sci->damage);
 		if (sci->damage < 0.0f)
 			sci->damage = 0.0f;
-		sci->damage_overidden = true;
+		sci->damage_overridden = true;
 	}
 
 	sprintf(buf, "%sShockwave damage type:", pre_char);
@@ -1331,7 +1331,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 		//WMC - now that shockwave damage can be set for them individually,
 		//do this automagically
-		if(!wip->shockwave.damage_overidden) {
+		if(!wip->shockwave.damage_overridden) {
 			wip->shockwave.damage = wip->damage;
 		}
 	}


### PR DESCRIPTION
If a weapon's shockwave damage has not been specified via table, `ShockwaveDamage` should return -1 instead of 0, and otherwise return the value set via table, allowing scripts to disambiguate explicitly 0 and unspecified. Additionally, a few parsing changes to ensure shockwave damage can never genuinely be negative (all damage handling is already doing this so this will have no gameplay effects). 

This is an explicit, unflagged change to the specification of this script value, but it's really not worth a flag, and a very niche case for which backwards compatibility concerns would surely be negligible.