### PR TITLE
Make Shockwaves in-game option force multi-value selection.

### DIFF
--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -66,6 +66,7 @@ static auto Shockwave3DMode = options::OptionBuilder<bool>("Graphics.3DShockwave
                      })
                      .level(options::ExpertLevel::Advanced)
                      .importance(66)
+                     .flags({options::OptionFlags::ForceMultiValueSelection})
                      .finish();
 
 /**


### PR DESCRIPTION
This makes it so that the "3D"/"2D" display is actually respected in the in-game options menu, rather than just having an ambiguous checkbox labelled "Shockwaves".

It gave it the "fix" tag because it makes the in-game options menu actually respect the option's display function, the lack of which was causing users some confusion.