### PR TITLE
make malformed XSTR a release warning

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -1040,9 +1040,9 @@ bool lcl_ext_localize_sub(const char *in, char *text_str, char *out, size_t max_
 	if (id != nullptr)
 		*id = xstr_id;
 
-	// if we made an attempt but failed, let the modder know
+	// if we made an attempt but failed, let the modder know (using a ReleaseWarning)
 	if (xstr_id == -2 && attempted_xstr)
-		error_display(0, "Malformed XSTR detected:\n\n%s\n", in);
+		error_display(2, "Malformed XSTR detected:\n\n%s\n", in);
 
 	// copy the entire string (or as much as we can)
 	auto str_len = strlen(xstr_str);
@@ -1202,9 +1202,9 @@ bool lcl_ext_localize_sub(const SCP_string &in, SCP_string &text_str, SCP_string
 	if (id != nullptr)
 		*id = xstr_id;
 
-	// if we made an attempt but failed, let the modder know
+	// if we made an attempt but failed, let the modder know (using a ReleaseWarning)
 	if (xstr_id == -2 && attempted_xstr)
-		error_display(0, "Malformed XSTR detected:\n\n%s\n", in.c_str());
+		error_display(2, "Malformed XSTR detected:\n\n%s\n", in.c_str());
 
 	// copy the entire string
 	out = xstr_str;

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -290,21 +290,24 @@ int get_line_num()
 
 //	Call this function to display an error message.
 //	error_level == 0 means this is just a warning.
-//	!0 means it's an error message.
+//	            == 1 means this is an error message.
+//	            == 2 means this is a release warning.
 //	Prints line number and other useful information.
-extern int Cmdline_noparseerrors;
 void error_display(int error_level, const char *format, ...)
 {
 	char type[8];
 	SCP_string error_text;
 	va_list args;
 
-	if (error_level == 0) {
+	if (error_level == 0 || error_level == 2) {
 		strcpy_s(type, "Warning");
 		Warning_count++;
-	} else {
+	} else if (error_level == 1) {
 		strcpy_s(type, "Error");
 		Error_count++;
+	} else {
+		Warning(LOCATION, "Invalid error level %d passed to error_display!", error_level);
+		error_level = 1;
 	}
 
 	va_start(args, format);
@@ -313,8 +316,10 @@ void error_display(int error_level, const char *format, ...)
 
 	nprintf((type, "%s(line %i): %s: %s\n", Current_filename, get_line_num(), type, error_text.c_str()));
 
-	if(error_level == 0 || Cmdline_noparseerrors)
+	if (error_level == 0 || Cmdline_noparseerrors)
 		Warning(LOCATION, "%s(line %i):\n%s: %s", Current_filename, get_line_num(), type, error_text.c_str());
+	else if (error_level == 2)
+		ReleaseWarning(LOCATION, "%s(line %i):\n%s: %s", Current_filename, get_line_num(), type, error_text.c_str());
 	else
 		Error(LOCATION, "%s(line %i):\n%s: %s", Current_filename, get_line_num(), type, error_text.c_str());
 }


### PR DESCRIPTION
1. Tweak the API of `error_display` so that an error level of 2 displays a `ReleaseWarning`.
2. Use this error level for the malformed XSTR warnings in the localization code.

Resolves #6374.