### PR TITLE
Allow beams to do energy leeching

### DIFF
--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2713,7 +2713,7 @@ static void ship_do_healing(object* ship_objp, object* other_obj, vec3d* hitpos,
 			spark.end_time = timestamp(0);
 	}
 
-	// if the hitting object is a weapon, maybe do some fun stuff here
+	// handle weapon and afterburner leeching here
 	if (other_obj_is_weapon || other_obj_is_beam) {
 		float mult = 1.0f;
 		if (other_obj_is_beam)

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2722,11 +2722,11 @@ static void ship_do_healing(object* ship_objp, object* other_obj, vec3d* hitpos,
 		// if its a leech weapon - NOTE - unknownplayer: Perhaps we should do something interesting like direct the leeched energy into the attacker ?
 		if (wip->wi_flags[Weapon::Info_Flags::Energy_suck]) {
 			// reduce afterburner fuel
-			shipp->afterburner_fuel -= wip->afterburner_reduce;
+			shipp->afterburner_fuel -= wip->afterburner_reduce * mult;
 			shipp->afterburner_fuel = (shipp->afterburner_fuel < 0.0f) ? 0.0f : shipp->afterburner_fuel;
 
 			// reduce weapon energy
-			shipp->weapon_energy -= wip->weapon_reduce;
+			shipp->weapon_energy -= wip->weapon_reduce * mult;
 			shipp->weapon_energy = (shipp->weapon_energy < 0.0f) ? 0.0f : shipp->weapon_energy;
 		}
 	}


### PR DESCRIPTION
I considered having shockwaves do this too, but having "esuck" missiles suddenly start draining double the amount is probably not a good idea... so a problem for later.

Additionally, this removes the `Beams_use_damage_factors` check from `shiphit_get_damage_weapon`, the purpose of that function is to return the wip_index of the provided object, not to withhold it based on a specific usage. All locations in the code where this would be relevant already check this flag, or have been made to do so by this PR (indeed some unrelated feature, like "vampiric" have been inadvertently trapped behind this flag as a result).