### PR TITLE
fix ai behavior when avoiding ship and weapon shockwaves

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -101,6 +101,10 @@ namespace AI {
         Fix_heat_seeker_stealth_bug,
         Fix_linked_primary_bug,
 		Fix_ramming_stationary_targets_bug,
+		Fix_avoid_shockwave_bugs,   // a) waiting until a homing weapon actually homes before evading;
+		                            // b) picking the correct expected impact position for capships;
+		                            // c) not clearing shockwave_object for ships;
+		                            // d) checking the explosion damage of the correct ship
         Force_beam_turret_fov,
 		Free_afterburner_use,
         Glide_decay_requires_thrust,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -653,6 +653,8 @@ void parse_ai_profiles_tbl(const char *filename)
 					stuff_float(&profile->rot_fac_multiplier_ply_collisions);
 				}
 
+				set_flag(profile, "$fix avoid-shockwave bugs:", AI::Profile_Flags::Fix_avoid_shockwave_bugs);
+
 				// end of options ----------------------------------------
 
 				// if we've been through once already and are at the same place, force a move
@@ -855,5 +857,8 @@ void ai_profile_t::reset()
 		flags.set(AI::Profile_Flags::Debris_respects_big_damage);
 		flags.set(AI::Profile_Flags::Force_beam_turret_fov);
 		flags.set(AI::Profile_Flags::Guards_ignore_protected_attackers);
+	}
+	if (mod_supports_version(25, 0, 0)) {
+		flags.set(AI::Profile_Flags::Fix_avoid_shockwave_bugs);
 	}
 }

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -90,6 +90,7 @@ struct homing_cache_info {
 	TIMESTAMP next_update;
 	vec3d expected_pos;
 	bool valid;
+	bool skip_future_refinements;
 };
 
 typedef struct weapon {

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -86,6 +86,12 @@ constexpr int BANK_SWITCH_DELAY = 250;	// after switching banks, 1/4 second dela
 // range. Check the comment in weapon_set_tracking_info() for more details
 #define LOCKED_HOMING_EXTENDED_LIFE_FACTOR			1.2f
 
+struct homing_cache_info {
+	TIMESTAMP next_update;
+	vec3d expected_pos;
+	bool valid;
+};
+
 typedef struct weapon {
 	int		weapon_info_index;			// index into weapon_info array
 	int		objnum;							// object number for this weapon
@@ -124,6 +130,8 @@ typedef struct weapon {
 
 	int		pick_big_attack_point_timestamp;	//	Timestamp at which to pick a new point to attack.
 	vec3d	big_attack_point;				//	Target-relative location of attack point.
+
+	std::unique_ptr<homing_cache_info> homing_cache_ptr;
 
 	SCP_vector<int>* cmeasure_ignore_list;
 	int		cmeasure_timer;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4842,8 +4842,12 @@ void weapon_delete(object *obj)
 
 	Assert(wp->weapon_info_index >= 0);
 	wp->weapon_info_index = -1;
+
 	if (wp->swarm_info_ptr != nullptr)
 		wp->swarm_info_ptr.reset();
+
+	if (wp->homing_cache_ptr != nullptr)
+		wp->homing_cache_ptr.reset();
 
 	if(wp->cscrew_index >= 0) {
 		cscrew_delete(wp->cscrew_index);
@@ -5681,7 +5685,6 @@ void weapon_home(object *obj, int num, float frame_time)
 			vel = vm_vec_mag(&obj->phys_info.desired_vel);
 
 			vm_vec_copy_scale(&obj->phys_info.desired_vel, &obj->orient.vec.fvec, vel);
-
 		}
 	}
 }


### PR DESCRIPTION
The FreeSpace AI includes behavior to run away from shockwaves to try to avoid explosion damage.  This is implemented for both ships and missiles, although the missile implementation has been buggy ever since retail.  There are several issues:

1. The AI attempts to evade a weapon immediately upon launch.  Many missiles have a period of free flight before they start homing on their target.  During the free flight period, the homing position is not set.  Consequently, the AI will not know the position to avoid and will make assumptions.
2. The AI assumes the shockwave-producing weapon will detonate at the center of the ship it is targeting, although missiles detonate on the surface.  A capital ship is likely to be significantly larger than the weapon's blast radius, leading the AI to believe the detonation will be much farther away than it actually is.
3. When avoiding ship shockwaves, the `shockwave_object` field is not cleared when avoiding is complete.  This can result in stale references (though not crashes, due to object type checks), causing AI to not avoid future explosions in certain cases.
4. When avoiding ship shockwaves, the code does not check the correct ship for the amount of damage caused by the shockwave.

All of these issues are now fixed.  Since this is a change in AI behavior, these fixes are tied to a new AI profiles flag.

~~Already tested, but in draft pending additional tests.~~ Tested with both ship and weapon shockwaves.