### PR TITLE
Fix overlappig XSTRs

### DIFF
--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -37,7 +37,7 @@ bool Shadow_quality_uses_mod_option = false;
 auto ShadowQualityOption = options::OptionBuilder<ShadowQuality>("Graphics.Shadows",
                      std::pair<const char*, int>{"Shadow Quality", 1750},
                      std::pair<const char*, int>{"The quality of the shadows", 1751})
-                     .values({{ShadowQuality::Disabled, {"Disabled", 1779}},
+                     .values({{ShadowQuality::Disabled, {"Disabled", 413}},
                               {ShadowQuality::Low, {"Low", 1160}},
                               {ShadowQuality::Medium, {"Medium", 1161}},
                               {ShadowQuality::High, {"High", 1162}},


### PR DESCRIPTION
The XSTR entry 1779 (strings.tbl) is used for two different texts:

"Disabled" in shadows.cpp;
"Toggle Auto Pilot" in controlsconfigcommon.cpp;

"Disabled" is already assigned to XSTR 413. ATM I have this set to shadow's usage (even though 413 is related to Disabled ships). Alternatively I would be happy to use `"Off", 1693`, which is what the other graphic settings use (though the actual value in the code would still remain `Disabled` of course).

Fixes #6380. 