### PR TITLE
properly initialize cargo titles

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -3775,7 +3775,6 @@ void parse_common_object_data(p_object *p_objp)
 		if (optional_string("$Damage:"))
 			stuff_float(&Subsys_status[i].percent);
 
-		Subsys_status[i].subsys_cargo_name = 0;
 		if (optional_string("+Cargo Name:")) {
 			char cargo_name[NAME_LENGTH];
 			stuff_string(cargo_name, F_NAME, NAME_LENGTH);
@@ -3793,7 +3792,6 @@ void parse_common_object_data(p_object *p_objp)
 			Subsys_status[i].subsys_cargo_name = index;
 		}
 
-		Subsys_status[i].subsys_cargo_title[0] = '\0';
 		if (optional_string("+Cargo Title:")) {
 			stuff_string(Subsys_status[i].subsys_cargo_title, F_NAME, NAME_LENGTH);
 		}
@@ -8266,6 +8264,7 @@ int allocate_subsys_status()
 	Subsys_status[Subsys_index].ai_class = SUBSYS_STATUS_NO_CHANGE;
 
 	Subsys_status[Subsys_index].subsys_cargo_name = 0;	// "Nothing"
+	Subsys_status[Subsys_index].subsys_cargo_title[0] = '\0';
 
 	return Subsys_index++;
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6702,6 +6702,7 @@ void ship::clear()
 	pre_death_explosion_happened = 0;
 	wash_killed = 0;	// serenity lies
 	cargo1 = 0;							// "Nothing"
+	cargo_title[0] = '\0';
 
 	wing_status_wing_index = -1;
 	wing_status_wing_pos = -1;
@@ -7730,6 +7731,7 @@ static int subsys_set(int objnum, int ignore_subsys_info)
 		ship_system->optimum_range = model_system->optimum_range;
 		ship_system->favor_current_facing = model_system->favor_current_facing;
 		ship_system->subsys_cargo_name = 0;
+		ship_system->subsys_cargo_title[0] = '\0';
 		ship_system->time_subsys_cargo_revealed = 0;
 		
 		j = 0;


### PR DESCRIPTION
This adds several missing initializations of cargo titles for both ships and subsystems.  Note that `Subsys_status` initialization needs to happen in `allocate_subsys_status()`, because subsystems can be allocated in red-alert or in the `ship-copy-damage` SEXP, not just parsing.

Follow-up to #6000.  Fixes a rather insidious ERANGE error in Inferno.