### PR TITLE
Return false if skip to string can't find the string

### DIFF
--- a/code/scripting/api/libs/parse.cpp
+++ b/code/scripting/api/libs/parse.cpp
@@ -95,13 +95,17 @@ ADE_FUNC(skipToString, l_Parsing, "string token", "Search for specified string, 
 	}
 
 	try {
-		skip_to_string(str);
+		int found = skip_to_string(str);
+
+		if (found == 1) {
+			return ADE_RETURN_TRUE;
+		} else {
+			return ADE_RETURN_FALSE;
+		}
 	} catch (const parse::ParseException& e) {
 		mprintf(("PARSE: Error while parsing: %s\n", e.what()));
 		return ADE_RETURN_FALSE;
 	}
-
-	return ADE_RETURN_TRUE;
 }
 
 ADE_FUNC(requiredString, l_Parsing, "string token", "Require that a string appears at the current position.", "boolean",


### PR DESCRIPTION
Skip to string's Lua API is currently not really usable because it returns true both if the string is found and if the string is not found. So this makes it so we only return true if it's found, otherwise return false.