### PR TITLE
Support custom preferences path

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1580,6 +1580,12 @@ bool SetCmdlineParams()
 {
 	//getcwd(FreeSpace_Directory, 256); // set the directory to our fs2 root
 
+	// DO THIS BEFORE get_flags, as portable_mode can change the value of pref_path printed in the json
+	if (portable_mode.found())
+	{
+		Cmdline_portable_mode = true;
+	}
+
 	// DO THIS FIRST to avoid unrecognized flag warnings when just getting flag file
 	if ( get_flags_arg.found() ) {
 		write_flags();
@@ -2079,11 +2085,6 @@ bool SetCmdlineParams()
 	if (noshadercache_arg.found())
 	{
 		Cmdline_noshadercache = true;
-	}
-
-	if (portable_mode.found())
-	{
-		Cmdline_portable_mode = true;
 	}
 
 	if (lang_arg.found()) 

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -45,8 +45,15 @@ namespace
 	{
 		// Lazily initialize the preferences path
 		if (!preferencesPath) {
-		    preferencesPath = SDL_GetPrefPath(ORGANIZATION_NAME, APPLICATION_NAME);
-			
+			//Check for a custom path set by env variable
+			auto envPreferencesPath = getenv("FSO_PREFERENCES_PATH");
+			if (envPreferencesPath != nullptr && strlen(envPreferencesPath) > 0) {
+				preferencesPath = envPreferencesPath;
+			}
+			else {
+				preferencesPath = SDL_GetPrefPath(ORGANIZATION_NAME, APPLICATION_NAME);
+			}
+
 			// this section will at least tell the user if something is seriously wrong instead of just crashing without a message or debug log.
 			// It may crash later, especially when trying to load sound. But let's let it *try* to run in the current directory at least.
 		    if (preferencesPath == nullptr) {
@@ -799,12 +806,6 @@ SCP_string os_get_config_path(const SCP_string& subpath)
 		return ss.str();
 	}
 
-	//Check for a custom path set by env variable
-	const auto envPreferencesPath = getenv("FSO_PREFERENCES_PATH");
-	if (envPreferencesPath != nullptr && strlen(envPreferencesPath) > 0) {
-		ss << envPreferencesPath << DIR_SEPARATOR_CHAR << compatiblePath;
-		return ss.str();
-	}
 
 	// Avoid infinite recursion when checking legacy mode
 	if (os_is_legacy_mode()) {

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -806,7 +806,6 @@ SCP_string os_get_config_path(const SCP_string& subpath)
 		return ss.str();
 	}
 
-
 	// Avoid infinite recursion when checking legacy mode
 	if (os_is_legacy_mode()) {
 #ifdef WIN32

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -799,6 +799,13 @@ SCP_string os_get_config_path(const SCP_string& subpath)
 		return ss.str();
 	}
 
+	//Check for a custom path set by env variable
+	const auto envPreferencesPath = getenv("FSO_PREFERENCES_PATH");
+	if (envPreferencesPath != nullptr && strlen(envPreferencesPath) > 0) {
+		ss << envPreferencesPath << DIR_SEPARATOR_CHAR << compatiblePath;
+		return ss.str();
+	}
+
 	// Avoid infinite recursion when checking legacy mode
 	if (os_is_legacy_mode()) {
 #ifdef WIN32


### PR DESCRIPTION
The idea is to truly allow FSO to be portable along with Knet launcher, with being able to set a custom folder for the pilots and settings it is possible to have a folder stucture where the knossos library is portable along with the the knossos executable and still reading the pilots and saving settings to a portable location inside the library itself instead of the appdata folder.

The older portable mode is not enoght for this (i was wrong, it still works, it just that due to the argument parsing order the wrong pref_path is printed on "-get_flags json_v1", but this should not affect functionallity).
But it is not adecuate for this as the old portable mode will use the current working folder to save pilots, settings and pickup the inis, so it dosent work in the same way as the appdata folder.

I did test it by setting a env variable in windows FSO_PREFERENCES_PATH to "D:\test dir\ " (without quotes), and the data folder was succesfully saved inside that folder along with graphical settings and new pilots.

I would like advise on the env variable name, if it feels right, and offcourse, anything i need to change to add.

Note: this does not overrides portable mode, if -portable_mode is set the executable location will be used instead.

~Note2: There is a bug on os_is_legacy_mode() line 523 as auto old_config_exists = true; defaults to true and it is never changed anywhere, FSO never searchs for the old file or registry settings on windows, resulting in defaulting the legacy mode to ON if the fs2_open.ini is not present on the preferences path, overriding it to ".//".~

~This also needs to be investigated on linux as i seem to remember the message of legacy mode being printed all the time there.~

~I belive this should be addresed on a separated PR if thats not the intended behaviour.~