### PR TITLE
proper fix for fighter/bomber

### DIFF
--- a/code/def_files/data/tables/objecttypes.tbl
+++ b/code/def_files/data/tables/objecttypes.tbl
@@ -8,9 +8,9 @@ $Fog:
 	+Start dist:			10.0										
 	+Compl dist:			500.0										
 $AI:																	
-	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Turrets attack this:	YES											
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Skip Death Roll Percent Chance: 0.0											
 
 $Name:					Sentry Gun										
@@ -28,10 +28,10 @@ $Fog:
 $AI:																	
 	+Accept Player Orders:	NO											
 	+Auto attacks:			YES											
-	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Guards attack this:	YES											
 	+Turrets attack this:	YES											
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Skip Death Roll Percent Chance: 0.0											
 
 $Name:					Escape Pod										
@@ -48,9 +48,9 @@ $Fog:
 	+Compl dist:			600.0										
 $AI:																	
 	+Valid goals:			( "fly to ship" "attack ship" "attack wing" "dock" "waypoints" "waypoints once" "depart" "undock" "stay still" "play dead" "play dead (persistent)" "stay near ship" )	
-	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Turrets attack this:	YES											
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Skip Death Roll Percent Chance: 0.0											
 
 $Name:					Cargo											
@@ -87,11 +87,11 @@ $AI:
 	+Accept Player Orders:	YES											
 	+Player orders:			( "rearm me" "abort rearm" "depart" )																	
 	+Auto attacks:			YES											
-	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Guards attack this:	YES											
 	+Turrets attack this:	YES											
 	+Active docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Skip Death Roll Percent Chance: 0.0											
 
 $Name:					Fighter											
@@ -114,12 +114,12 @@ $AI:
 	+Accept Player Orders:	YES											
 	+Player Orders:			( "attack ship" "disable ship" "disable ship (tactical)" "disarm ship" "disarm ship (tactical)" "guard ship" "ignore ship" "ignore ship (new)" "form on wing" "cover me" "attack any" "attack ship class" "depart" "disable subsys" )		
 	+Auto attacks:			YES											
-	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )																
+	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )																
 	+Guards attack this:	YES											
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Skip Death Roll Percent Chance: 0.0											
 
 $Name:					Bomber											
@@ -142,40 +142,12 @@ $AI:
 	+Accept Player Orders:	YES											
 	+Player Orders:			( "attack ship" "disable ship" "disable ship (tactical)" "disarm ship" "disarm ship (tactical)" "guard ship" "ignore ship" "ignore ship (new)" "form on wing" "cover me" "attack any" "attack ship class" "depart" "disable subsys" )		
 	+Auto attacks:			YES											
-	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )																
+	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )																
 	+Guards attack this:	YES											
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
-$Skip Death Roll Percent Chance: 0.0											
-
-;;WMC - This fighter/bomber type doesn't seem to be used anywhere, because no ship is set as both fighter and bomber
-$Name:					Fighter/bomber									
-$Counts for Alone:		YES												
-$Praise Destruction:	YES												
-$On Hotkey List:		YES												
-$Target as Threat:		YES												
-$Show Attack Direction:	YES												
-$Warp Pushable:			YES												
-$Max Debris Speed:		200												
-$FF Multiplier:			1.0												
-$EMP Multiplier:		4.0												
-$Protected on cripple:	YES												
-$Fog:																	
-	+Start dist:			10.0										
-	+Compl dist:			500.0										
-$AI:																	
-	+Valid goals:			( "fly to ship" "attack ship" "waypoints" "waypoints once" "depart" "attack subsys" "attack wing" "guard ship" "disable ship" "disable ship (tactical)" "disarm ship" "disarm ship (tactical)" "attack any" "attack ship class" "ignore ship" "ignore ship (new)" "guard wing" "evade ship" "stay still" "play dead" "play dead (persistent)" "stay near ship" "keep safe dist" "form on wing" )	
-	+Accept Player Orders:	YES											
-	+Player Orders:			( "attack ship" "disable ship" "disable ship (tactical)" "disarm ship" "disarm ship (tactical)" "guard ship" "ignore ship" "ignore ship (new)" "form on wing" "cover me" "attack any" "attack ship class" "depart" "disable subsys" )		
-	+Auto attacks:			YES											
-	+Actively Pursues:		( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )																
-	+Guards attack this:	YES											
-	+Turrets attack this:	YES											
-	+Can Form Wing:			YES											
-	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 $Skip Death Roll Percent Chance: 0.0											
 
 $Name:					Transport										
@@ -204,7 +176,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -236,7 +208,7 @@ $AI:
 	+Can Form Wing:			YES											
 	+Active docks:			( "cargo" )								
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -266,7 +238,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -296,7 +268,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES	
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -326,7 +298,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -356,7 +328,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -386,7 +358,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -414,7 +386,7 @@ $AI:
 	+Turrets attack this:	YES											
 	+Can Form Wing:			YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -440,7 +412,7 @@ $AI:
 	+Guards attack this:	YES											
 	+Turrets attack this:	YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 
@@ -464,7 +436,7 @@ $AI:
 	+Guards attack this:	YES											
 	+Turrets attack this:	YES											
 	+Passive docks:			( "support" )								
-	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "fighter/bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
+	+Ignored on cripple by:	( "navbuoy" "sentry gun" "escape pod" "cargo" "support" "fighter" "bomber" "transport" "freighter" "awacs" "gas miner" "cruiser" "corvette" "capital" "super cap" "drydock" "knossos device" )	
 	+Targeted by 'Huge' weapons and Ignored by 'small only' weapons: YES
 $Skip Death Roll Percent Chance: 0.0											
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3167,18 +3167,25 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 				break;
 			}
 
-			case OPF_SHIP_TYPE:
+			case OPF_SHIP_TYPE: {
 				if (type2 != SEXP_ATOM_STRING){
 					return SEXP_CHECK_TYPE_MISMATCH;
 				}
 
-				i = ship_type_name_lookup(CTEXT(node));
+				auto type_name = CTEXT(node);
+				i = ship_type_name_lookup(type_name);
 
 				if (i < 0){
+					if (Fighter_bomber_valid && !stricmp(type_name, Fighter_bomber_type_name)) {
+						// this is allowed even though it's not an explicit type
+						break;
+					}
+
 					return SEXP_CHECK_INVALID_SHIP_TYPE;
 				}
 
 				break;
+			}
 
 			case OPF_WAYPOINT_PATH:
 				if (find_matching_waypoint_list(CTEXT(node)) == nullptr) {
@@ -7724,21 +7731,35 @@ int sexp_ship_type_destroyed(int n)
 		return SEXP_KNOWN_FALSE;
 
 	auto shiptype = CTEXT(CDR(n));
-
 	int type = ship_type_name_lookup(shiptype);
 
-	// bogus if we reach the end of this array!!!!
-	if ( type < 0 ) {
-		Warning(LOCATION, "Invalid shiptype passed to ship-type-destroyed");
+	if (type < 0 && Fighter_bomber_valid && !stricmp(shiptype, Fighter_bomber_type_name))
+		type = Ship_type_fighter_bomber;
+	else if (!SCP_vector_inbounds(Ship_types, type))
+	{
+		// bogus if we reach the end of this array!!!!
+		Warning(LOCATION, "Invalid shiptype '%s' passed to ship-type-destroyed", shiptype);
 		return SEXP_FALSE;
 	}
 
-	if ( type >= (int)Ship_type_counts.size() || Ship_type_counts[type].total == 0 )
+	int killed, total;
+	if (type == Ship_type_fighter_bomber)
+	{
+		killed = Ship_type_counts[Ship_type_fighter].killed + Ship_type_counts[Ship_type_bomber].killed;
+		total = Ship_type_counts[Ship_type_fighter].total + Ship_type_counts[Ship_type_bomber].total;
+	}
+	else
+	{
+		//We are safe from array indexing probs b/c of previous if.
+		killed = Ship_type_counts[type].killed;
+		total = Ship_type_counts[type].total;
+	}
+
+	if (total == 0)
 		return SEXP_FALSE;
 
-	//We are safe from array indexing probs b/c of previous if.
 	// determine if the percentage of killed/total is >= percentage given in the expression
-	if ( (Ship_type_counts[type].killed * 100 / Ship_type_counts[type].total) >= percent)
+	if ((killed * 100 / total) >= percent)
 		return SEXP_KNOWN_TRUE;
 	
 	return SEXP_FALSE;
@@ -11686,6 +11707,8 @@ int eval_for_ship_collection(int arg_handler_node, int condition_node, int op_co
 				break;
 			case OP_FOR_SHIP_TYPE:
 				constraint_index = ship_type_name_lookup(constraint);
+				if (constraint_index < 0 && Fighter_bomber_valid && !stricmp(constraint, Fighter_bomber_type_name))
+					constraint_index = Ship_type_fighter_bomber;
 				break;
 			case OP_FOR_SHIP_TEAM:
 				constraint_index = iff_lookup(constraint);
@@ -11724,7 +11747,13 @@ int eval_for_ship_collection(int arg_handler_node, int condition_node, int op_co
 					break;
 			}
 
-			if (constraint_index == ship_index)
+			bool constraint_matches;
+			if (op_const == OP_FOR_SHIP_TYPE && constraint_index == Ship_type_fighter_bomber)
+				constraint_matches = (ship_index == Ship_type_fighter || ship_index == Ship_type_bomber);
+			else
+				constraint_matches = (ship_index == constraint_index);
+
+			if (constraint_matches)
 			{
 				if (just_count)
 					num_valid_arguments++;
@@ -12704,12 +12733,21 @@ int sexp_is_ship_class_or_type(int n, bool ship_class)
 	Assert( n >= 0 );
 
 	// get class or type
-	int index;
+	auto name = CTEXT(n);
+	int constraint_index;
 	if (ship_class)
-		index = ship_info_lookup(CTEXT(n));
+		constraint_index = ship_info_lookup(name);
 	else
-		index = ship_type_name_lookup(CTEXT(n));
+	{
+		constraint_index = ship_type_name_lookup(name);
+		if (constraint_index < 0 && Fighter_bomber_valid && !stricmp(name, Fighter_bomber_type_name))
+			constraint_index = Ship_type_fighter_bomber;
+	}
 	n = CDR(n);
+
+	// not valid; no need to check
+	if (constraint_index < 0)
+		return SEXP_FALSE;
 
 	// eval ships
 	while (n != -1)
@@ -12719,29 +12757,37 @@ int sexp_is_ship_class_or_type(int n, bool ship_class)
 		if (!ship_entry)
 			return SEXP_NAN;
 
-		int other_index;
+		int ship_index;
 		if (ship_entry->status == ShipStatus::NOT_YET_PRESENT)
 		{
-			other_index = ship_entry->p_objp()->ship_class;
+			ship_index = ship_entry->p_objp()->ship_class;
 		}
 		else if (ship_entry->exited_index >= 0)
 		{
-			other_index = Ships_exited[ship_entry->exited_index].ship_class;
+			ship_index = Ships_exited[ship_entry->exited_index].ship_class;
 		}
 		else if (ship_entry->has_shipp())
 		{
-			other_index = ship_entry->shipp()->ship_info_index;
+			ship_index = ship_entry->shipp()->ship_info_index;
 		}
 		else
 			return SEXP_NAN_FOREVER;
 
 		// maybe convert from class to type
 		if (!ship_class)
-			other_index = ship_class_query_general_type(other_index);
+			ship_index = ship_class_query_general_type(ship_index);
 
 		// if it doesn't match, return false
-		if (index != other_index)
-			return SEXP_FALSE;
+		if (!ship_class && constraint_index == Ship_type_fighter_bomber)
+		{
+			if (ship_index != Ship_type_fighter && ship_index != Ship_type_bomber)
+				return SEXP_FALSE;
+		}
+		else
+		{
+			if (ship_index != constraint_index)
+				return SEXP_FALSE;
+		}
 
 		// increment
 		n = CDR(n);
@@ -24147,22 +24193,41 @@ int sexp_return_player_data(int node, int type)
 int sexp_num_type_kills(int node)
 {
 	auto p = get_player_from_ship_node(node, true);
-	if (!p) {
+	if (!p)
 		return 0;
-	}
 
-	// lookup ship type name
-	int st_index = ship_type_name_lookup(CTEXT(CDR(node)));
-	if (st_index < 0) {
-		return 0;
+	// look up ship type name
+	auto name = CTEXT(CDR(node));
+	int constraint_type = ship_type_name_lookup(name);
+	if (constraint_type < 0)
+	{
+		if (Fighter_bomber_valid && !stricmp(name, Fighter_bomber_type_name))
+			constraint_type = Ship_type_fighter_bomber;
+		else
+			return 0;
 	}
 
 	// look stuff up	
 	int total = 0;
-	for (int idx = 0; idx < ship_info_size(); idx++) {
-		if ((p->stats.m_okKills[idx] > 0) && ship_class_query_general_type(idx) == st_index) {
-			total += p->stats.m_okKills[idx];
+	for (int idx = 0; idx < ship_info_size(); idx++)
+	{
+		if (p->stats.m_okKills[idx] <= 0)
+			continue;
+
+		int ship_type = ship_class_query_general_type(idx);
+
+		if (constraint_type == Ship_type_fighter_bomber)
+		{
+			if (ship_type != Ship_type_fighter && ship_type != Ship_type_bomber)
+				continue;
 		}
+		else
+		{
+			if (ship_type != constraint_type)
+				continue;
+		}
+
+		total += p->stats.m_okKills[idx];
 	}
 
 	// total
@@ -37708,9 +37773,10 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\t4:\tHow many times the ship has completed the waypoint path (optional)." },
 
 	{ OP_SHIP_TYPE_DESTROYED, "Ship Type Destroyed (Boolean operator)\r\n"
-		"\tBecomes true when the specified percentage of ship types in this mission (including ships not yet in-mission) "
-		"have been destroyed.  The ship type is a generic type such as fighter/bomber, "
-		"transport, etc.  Fighters and bombers count as the same type.\r\n\r\n"
+		"\tBecomes true when the specified percentage of ship types in this mission (including ships not yet in-mission) have been destroyed.  The "
+		"ship type is a generic type such as fighter, bomber, transport, etc.  Note that the percentage is updated when a ship finishes exploding, "
+		"in contrast to the mission log and the *-destroyed-delay SEXPs which are updated when a ship starts exploding.  Note also that player ships "
+		"and ships with the \"Ignore for counting goals\" flag are not included in the calculation.\r\n\r\n"
 		"Returns a boolean value.  Takes 2 arguments...\r\n"
 		"\t1:\tPercentage of ships that must be destroyed.\r\n"
 		"\t2:\tShip type to check for." },

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -58,7 +58,7 @@ enum sexp_opf_t : int {
 	OPF_SHIP_WING_SHIPONTEAM_POINT,	// name of a ship, wing, any ship on a team, or a point
 	OPF_SHIP_WING_POINT,
 	OPF_SHIP_WING_POINT_OR_NONE,	// WMC - Ship, wing, point or none
-	OPF_SHIP_TYPE,					// type of ship (fighter/bomber/etc)
+	OPF_SHIP_TYPE,					// type of ship (fighter/bomber/etc)... NOTE: the type "fighter/bomber" is allowed even though it's not a real ship type; SEXPs must account for this
 	OPF_KEYPRESS,					// a default key
 	OPF_EVENT_NAME,					// name of an event
 	OPF_AI_ORDER,					// a squadmsg order player can give to a ship

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1051,6 +1051,9 @@ typedef struct ship_type_info {
 } ship_type_info;
 
 extern SCP_vector<ship_type_info> Ship_types;
+extern bool Fighter_bomber_valid;				// Whether "fighter/bomber" can be used as a union of "fighter" and "bomber"
+extern const char *Fighter_bomber_type_name;
+extern int Ship_type_fighter, Ship_type_bomber, Ship_type_fighter_bomber;
 
 class rcs_thruster_info {
     public:

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -7061,6 +7061,9 @@ sexp_list_item *sexp_tree::get_listing_opf_ship_type()
 	for (i=0; i<Ship_types.size(); i++){
 		head.add_data(Ship_types[i].name);
 	}
+	if (Fighter_bomber_valid) {
+		head.add_data(Fighter_bomber_type_name);
+	}
 
 	return head.next;
 }

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4690,6 +4690,9 @@ sexp_list_item* sexp_tree::get_listing_opf_ship_type() {
 	for (i = 0; i < Ship_types.size(); i++) {
 		head.add_data(Ship_types[i].name);
 	}
+	if (Fighter_bomber_valid) {
+		head.add_data(Fighter_bomber_type_name);
+	}
 
 	return head.next;
 }


### PR DESCRIPTION
This fixes the fighter/bomber type which had been broken ever since the objecttypes.tbl upgrade in https://github.com/scp-fs2open/fs2open.github.com/commit/246cfcfa655ae58159161011ff1f95dd79d68357: the fighter/bomber type is again treated as a union of fighters and bombers, not a unique type of its own.  This requires special handling for the `OPF_SHIP_TYPE` SEXP argument type, and all four SEXPs that use `OPF_SHIP_TYPE` have been modified to check for the special case.  The explicit fighter/bomber type has again been removed from the built-in objecttypes.tbl.

The requirements for "fighter/bomber" to be valid are 1) there is no explicit "fighter/bomber" type in the mod; 2) a "fighter" type exists; 3) a "bomber" type exists.  If any of these conditions is not met, the special case behavior is not enabled.

Follow-up to https://github.com/scp-fs2open/fs2open.github.com/pull/6390.  Properly fixes https://github.com/scp-fs2open/fs2open.github.com/issues/6388.  All four SEXPs have been tested with both fighter/bomber and non-fighter/bomber types.