### PR TITLE
Set old_config_exists to false in Windows if the registry key are not present

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -520,6 +520,11 @@ bool os_is_legacy_mode()
 		path_stream.str("");
 		path_stream << "." << DIR_SEPARATOR_CHAR << "data" << DIR_SEPARATOR_CHAR << "cmdline_fso.cfg";
 		old_config_time = std::max(old_config_time, get_file_modification_time(path_stream.str()));
+
+		// If the registry key and cmdline_fso.cfg does not exist old_config_time will be zero
+		if (old_config_time == 0) {
+			old_config_exists = false;
+		}
 #endif
 
 		if (new_config_exists && old_config_exists) {

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -529,7 +529,11 @@ bool os_is_legacy_mode()
 			// Both config files exists so we need to decide which to use based on their last modification times
 			// if the old config was modified more recently than the new config then we use the legacy mode since the
 			// user probably used an outdated launcher after using a more recent one
+#ifdef SCP_UNIX
+			legacyMode = old_config_time > new_config_time;
+#else
 			legacyMode = old_config_time.value() > new_config_time;
+#endif
 
 			if (legacyMode) {
 				Osapi_legacy_mode_reason = "Legacy mode enabled since the old config location was used more recently than the new location.";

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -512,16 +512,19 @@ bool os_is_legacy_mode()
 					<< "cmdline_fso.cfg";
 		old_config_time = std::max(old_config_time, get_file_modification_time(path_stream.str()));
 #else
-		tl::optional<time_t> old_config_time = os_registry_get_last_modification_time();
+		tl::optional<time_t> optional_old_config_time = os_registry_get_last_modification_time();
+		time_t old_config_time = 0;
+
 		//Check if the registry key exists
-		auto old_config_exists = old_config_time.has_value();
+		auto old_config_exists = optional_old_config_time.has_value();
 
 		if (old_config_exists) {
+			old_config_time = optional_old_config_time.value();
 			// On Windows the cmdline_fso file was stored in the game root directory which should be in the current directory
 			// Only get this if the old config exists
 			path_stream.str("");
 			path_stream << "." << DIR_SEPARATOR_CHAR << "data" << DIR_SEPARATOR_CHAR << "cmdline_fso.cfg";
-			old_config_time = std::max(old_config_time.value(), get_file_modification_time(path_stream.str()));
+			old_config_time = std::max(old_config_time, get_file_modification_time(path_stream.str()));
 		}
 #endif
 
@@ -529,11 +532,7 @@ bool os_is_legacy_mode()
 			// Both config files exists so we need to decide which to use based on their last modification times
 			// if the old config was modified more recently than the new config then we use the legacy mode since the
 			// user probably used an outdated launcher after using a more recent one
-#ifdef SCP_UNIX
 			legacyMode = old_config_time > new_config_time;
-#else
-			legacyMode = old_config_time.value() > new_config_time;
-#endif
 
 			if (legacyMode) {
 				Osapi_legacy_mode_reason = "Legacy mode enabled since the old config location was used more recently than the new location.";

--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -516,14 +516,15 @@ bool os_is_legacy_mode()
 		auto old_config_exists = true;
 		time_t old_config_time = os_registry_get_last_modification_time();
 
-		// On Windows the cmdline_fso file was stored in the game root directory which should be in the current directory
-		path_stream.str("");
-		path_stream << "." << DIR_SEPARATOR_CHAR << "data" << DIR_SEPARATOR_CHAR << "cmdline_fso.cfg";
-		old_config_time = std::max(old_config_time, get_file_modification_time(path_stream.str()));
-
-		// If the registry key and cmdline_fso.cfg does not exist old_config_time will be zero
-		if (old_config_time == 0) {
+		// If the registry key does not exist old_config_time will be -1
+		if (old_config_time == -1) {
 			old_config_exists = false;
+		} else {
+			// On Windows the cmdline_fso file was stored in the game root directory which should be in the current directory
+			// Only get this if the old config exists
+			path_stream.str("");
+			path_stream << "." << DIR_SEPARATOR_CHAR << "data" << DIR_SEPARATOR_CHAR << "cmdline_fso.cfg";
+			old_config_time = std::max(old_config_time, get_file_modification_time(path_stream.str()));
 		}
 #endif
 

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -414,6 +414,9 @@ static time_t key_mod_time(bool alternate_path) {
 
 	if (lResult != ERROR_SUCCESS) {
 		::RegCloseKey(hKey);
+		if (lResult == ERROR_FILE_NOT_FOUND) {
+			return -1;
+		}
 		return 0;
 	}
 

--- a/code/osapi/osregistry.h
+++ b/code/osapi/osregistry.h
@@ -12,7 +12,7 @@
 
 
 #include <cstdlib>
-
+#include <tl/optional.hpp>
 // ------------------------------------------------------------------------------------------------------------
 // REGISTRY DEFINES/VARS
 //
@@ -32,7 +32,7 @@ extern bool Ingame_options_save_found;
 //
 
 #ifdef WIN32
-time_t os_registry_get_last_modification_time();
+tl::optional<time_t> os_registry_get_last_modification_time();
 #endif
 
 // initialize the registry. setup default keys to use


### PR DESCRIPTION
As i commented in #6392 in Windows during a completely new install on a clean pc FSO will default to legacy config this is because old_config_exists is set to true and never checked, contrary to linux were it checks if there is a config file name or not.

What i found is that if neither the registry keys and cmdline_fso.cfg exists the old_config_time will be 0 as thats is the default "not found" error value for both get_file_modification_time() and os_registry_get_last_modification_time().

But it is not perfect because if you install Freespace 2 from Steam and try to run it, even trought it dosent work, it creates the registry entries, this may be true with the retail cds as well. But it is not the case for the gog version.

But technically the registry entry is there so i dont think i can do anything about it.