### PR TITLE
Add underlining as a custom decorator

### DIFF
--- a/code/scpui/RocketDecorators.cpp
+++ b/code/scpui/RocketDecorators.cpp
@@ -1,0 +1,248 @@
+#include "RocketDecorators.h"
+
+#include <Rocket/Core/RenderInterface.h>
+#include <Rocket/Core/Vertex.h>
+
+namespace scpui {
+namespace decorators {
+
+// ================================
+// Element Underline Implementation
+// ================================
+
+DecoratorUnderline::DecoratorUnderline(float thickness, LineStyle style, float length, float space, Rocket::Core::Colourb color, bool element_color)
+	: line_thickness(thickness), line_style(style), line_length(length), line_space(space), line_color(color), use_element_color(element_color)
+{
+}
+
+DecoratorUnderline::~DecoratorUnderline() = default;
+
+// Generate per-element data, if needed (return NULL if not needed)
+Rocket::Core::DecoratorDataHandle DecoratorUnderline::GenerateElementData(Rocket::Core::Element* /*element*/)
+{
+	return 0; // No per-element data needed
+}
+
+// Release any element-specific data
+void DecoratorUnderline::ReleaseElementData(Rocket::Core::DecoratorDataHandle /*element_data*/)
+{
+	// No element-specific data to release in this case
+}
+
+void DecoratorUnderline::RenderElement(Rocket::Core::Element* element,
+	Rocket::Core::DecoratorDataHandle /*element_data*/)
+{
+	// Get the size of the element's content area
+	Rocket::Core::Vector2f element_size = element->GetBox().GetSize(Rocket::Core::Box::CONTENT);
+
+	// Determine line rendering properties based on style
+	float dash_length = 5.0f;
+	float space_length = 3.0f;
+
+	switch (line_style) {
+	case LineStyle::Dotted:
+		dash_length = line_thickness; // Dotted lines are small circles
+		space_length = line_space;
+		break;
+	case LineStyle::Dashed:
+		space_length = line_space;
+		dash_length = line_length;
+		break;
+	case LineStyle::Solid:
+	default:
+		space_length = 0; // No space for solid lines
+		break;
+	}
+
+	// Calculate the starting position (bottom-left of the content area)
+	Rocket::Core::Vector2f start = element->GetAbsoluteOffset(Rocket::Core::Box::CONTENT);
+	float x_position = start.x;
+	float y_position = start.y + element_size.y - (line_thickness * 2); // Adjusted y-position using the thickness
+
+	Rocket::Core::RenderInterface* render_interface = element->GetRenderInterface();
+
+	// Create space for vertices and indices for all dashes
+	std::vector<Rocket::Core::Vertex> vertices;
+	std::vector<int> indices;
+
+	int vertex_count = 0;
+
+	Rocket::Core::Colourb render_color = line_color;
+	if (use_element_color) {
+		render_color = element->GetProperty<Rocket::Core::Colourb>("color");
+	}
+
+	// Loop through to create each dash as a rectangle (or dot)
+	while (x_position < start.x + element_size.x) {
+		float dash_end_x = std::min(x_position + dash_length, start.x + element_size.x);
+
+		// Create four vertices for the rectangle (two triangles)
+		Rocket::Core::Vertex top_left, top_right, bottom_left, bottom_right;
+
+		// Set vertex positions
+		top_left.position = Rocket::Core::Vector2f(x_position, y_position);
+		top_right.position = Rocket::Core::Vector2f(dash_end_x, y_position);
+		bottom_left.position = Rocket::Core::Vector2f(x_position, y_position + line_thickness);
+		bottom_right.position = Rocket::Core::Vector2f(dash_end_x, y_position + line_thickness);
+
+		// Set the color
+		top_left.colour = render_color;
+		top_right.colour = render_color;
+		bottom_left.colour = render_color;
+		bottom_right.colour = render_color;
+
+		// Set texture coordinates to 0 since we have no texture
+		top_left.tex_coord = Rocket::Core::Vector2f(0, 0);
+		top_right.tex_coord = Rocket::Core::Vector2f(0, 0);
+		bottom_left.tex_coord = Rocket::Core::Vector2f(0, 0);
+		bottom_right.tex_coord = Rocket::Core::Vector2f(0, 0);
+
+		// Add the vertices to the list
+		vertices.push_back(top_left);
+		vertices.push_back(top_right);
+		vertices.push_back(bottom_left);
+		vertices.push_back(bottom_right);
+
+		// Add indices for two triangles
+		indices.push_back(vertex_count); // First triangle
+		indices.push_back(vertex_count + 1);
+		indices.push_back(vertex_count + 2);
+
+		indices.push_back(vertex_count + 1); // Second triangle
+		indices.push_back(vertex_count + 3);
+		indices.push_back(vertex_count + 2);
+
+		// Move to the next dash position
+		x_position += dash_length + space_length;
+
+		// Increment vertex count for the next set of triangles
+		vertex_count += 4;
+	}
+
+	// Render the geometry
+	render_interface->RenderGeometry(vertices.data(),
+		(int)vertices.size(),
+		indices.data(),
+		(int)indices.size(),
+		0,
+		Rocket::Core::Vector2f(0, 0));
+}
+
+// =============================
+// Corner Borders Implementation
+// =============================
+
+DecoratorCornerBorders::DecoratorCornerBorders(float thickness, float length_h, float length_v, Rocket::Core::Colourb color)
+	: border_thickness(thickness), border_length_h(length_h), border_length_v(length_v), border_color(color)
+{
+}
+
+DecoratorCornerBorders::~DecoratorCornerBorders() = default;
+
+// Generate per-element data, if needed (return NULL if not needed)
+Rocket::Core::DecoratorDataHandle DecoratorCornerBorders::GenerateElementData(Rocket::Core::Element* /*element*/)
+{
+	return 0; // No per-element data needed
+}
+
+// Release any element-specific data
+void DecoratorCornerBorders::ReleaseElementData(Rocket::Core::DecoratorDataHandle /*element_data*/)
+{
+	// No element-specific data to release in this case
+}
+
+void DecoratorCornerBorders::RenderElement(Rocket::Core::Element* element,
+	Rocket::Core::DecoratorDataHandle /*element_data*/)
+{
+	// Get the size of the element's content area
+	Rocket::Core::Vector2f element_size = element->GetBox().GetSize(Rocket::Core::Box::CONTENT);
+	Rocket::Core::Vector2f start = element->GetAbsoluteOffset(Rocket::Core::Box::CONTENT);
+
+	Rocket::Core::RenderInterface* render_interface = element->GetRenderInterface();
+
+	// Create space for vertices and indices for the corner borders
+	std::vector<Rocket::Core::Vertex> vertices;
+	std::vector<int> indices;
+
+	int vertex_count = 0;
+
+	// Define the four corner positions, moved inward by thickness
+	Rocket::Core::Vector2f top_left = start + Rocket::Core::Vector2f(border_thickness, border_thickness);
+	Rocket::Core::Vector2f top_right =
+		start + Rocket::Core::Vector2f(element_size.x - border_thickness, border_thickness);
+	Rocket::Core::Vector2f bottom_left =
+		start + Rocket::Core::Vector2f(border_thickness, element_size.y - border_thickness);
+	Rocket::Core::Vector2f bottom_right =
+		start + Rocket::Core::Vector2f(element_size.x - border_thickness, element_size.y - border_thickness);
+
+	// Function to add a line segment as two triangles
+	auto add_line_segment = [&](const Rocket::Core::Vector2f& start_pos, const Rocket::Core::Vector2f& end_pos, float thickness) {
+			// Vector direction of the line
+			Rocket::Core::Vector2f direction = end_pos - start_pos;
+			// Normalize direction and calculate the perpendicular vector for thickness
+			Rocket::Core::Vector2f perpendicular =
+				Rocket::Core::Vector2f(-direction.y, direction.x).Normalise() * thickness;
+
+			// Define the four vertices of the line as a rectangle (two triangles)
+			Rocket::Core::Vertex v1, v2, v3, v4;
+			v1.position = start_pos - perpendicular;
+			v2.position = start_pos + perpendicular;
+			v3.position = end_pos - perpendicular;
+			v4.position = end_pos + perpendicular;
+
+			// Set color
+			v1.colour = border_color;
+			v2.colour = border_color;
+			v3.colour = border_color;
+			v4.colour = border_color;
+
+			// Add vertices
+			vertices.push_back(v1);
+			vertices.push_back(v2);
+			vertices.push_back(v3);
+			vertices.push_back(v4);
+
+			// Add indices for two triangles
+			indices.push_back(vertex_count);
+			indices.push_back(vertex_count + 1);
+			indices.push_back(vertex_count + 2);
+
+			indices.push_back(vertex_count + 1);
+			indices.push_back(vertex_count + 3);
+			indices.push_back(vertex_count + 2);
+
+			vertex_count += 4;
+		};
+
+	// Define the lengths for horizontal and vertical borders
+	Rocket::Core::Vector2f horizontal(border_length_h, 0);
+	Rocket::Core::Vector2f vertical(0, border_length_v);
+
+	// Add corner borders by adding two line segments for each corner, moved inward by thickness
+	// Top-left corner
+	add_line_segment(top_left, top_left + horizontal, border_thickness); // Horizontal line
+	add_line_segment(top_left, top_left + vertical, border_thickness);   // Vertical line
+
+	// Top-right corner
+	add_line_segment(top_right, top_right - horizontal, border_thickness); // Horizontal line
+	add_line_segment(top_right, top_right + vertical, border_thickness);   // Vertical line
+
+	// Bottom-left corner
+	add_line_segment(bottom_left, bottom_left + horizontal, border_thickness); // Horizontal line
+	add_line_segment(bottom_left, bottom_left - vertical, border_thickness);   // Vertical line
+
+	// Bottom-right corner
+	add_line_segment(bottom_right, bottom_right - horizontal, border_thickness); // Horizontal line
+	add_line_segment(bottom_right, bottom_right - vertical, border_thickness);   // Vertical line
+
+	// Render the geometry
+	render_interface->RenderGeometry(vertices.data(),
+		(int)vertices.size(),
+		indices.data(),
+		(int)indices.size(),
+		0,
+		Rocket::Core::Vector2f(0, 0));
+}
+
+} // namespace decorators
+} // namespace scpui

--- a/code/scpui/RocketDecorators.h
+++ b/code/scpui/RocketDecorators.h
@@ -1,0 +1,81 @@
+#pragma once
+
+// Our Assert conflicts with the definitions inside libRocket
+#pragma push_macro("Assert")
+#undef Assert
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
+#include <Rocket/Core.h>
+#include <Rocket/Core/Decorator.h>
+#include <Rocket/Core/Element.h>
+#include <Rocket/Core/Geometry.h>
+#include <Rocket/Core/GeometryUtilities.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#pragma pop_macro("Assert")
+
+namespace scpui {
+namespace decorators {
+
+enum class LineStyle {
+	Solid,
+	Dashed,
+	Dotted,
+	Num_styles
+};
+
+class DecoratorUnderline : public Rocket::Core::Decorator {
+  public:
+	// Constructor to accept properties
+	DecoratorUnderline(float line_thickness, LineStyle line_style, float line_length, float line_space, Rocket::Core::Colourb line_color, bool use_element_color);
+	~DecoratorUnderline() override;
+
+	// Called to generate per-element data for newly decorated elements.
+	Rocket::Core::DecoratorDataHandle GenerateElementData(Rocket::Core::Element* element) override;
+
+	// Called to release element-specific data.
+	void ReleaseElementData(Rocket::Core::DecoratorDataHandle element_data) override;
+
+	// Called to render the decorator on an element.
+	void RenderElement(Rocket::Core::Element* element, Rocket::Core::DecoratorDataHandle element_data) override;
+
+  private:
+	float line_thickness;
+	LineStyle line_style;
+	float line_length;
+	float line_space;
+	Rocket::Core::Colourb line_color;
+	bool use_element_color;
+};
+
+class DecoratorCornerBorders : public Rocket::Core::Decorator {
+  public:
+	// Constructor to accept properties
+	DecoratorCornerBorders(float border_thickness, float border_length_h, float border_length_v, Rocket::Core::Colourb border_color);
+	~DecoratorCornerBorders() override;
+
+	// Called to generate per-element data for newly decorated elements.
+	Rocket::Core::DecoratorDataHandle GenerateElementData(Rocket::Core::Element* element) override;
+
+	// Called to release element-specific data.
+	void ReleaseElementData(Rocket::Core::DecoratorDataHandle element_data) override;
+
+	// Called to render the decorator on an element.
+	void RenderElement(Rocket::Core::Element* element, Rocket::Core::DecoratorDataHandle element_data) override;
+
+  private:
+	float border_thickness;
+	float border_length_h;
+	float border_length_v;
+	Rocket::Core::Colourb border_color;
+};
+
+} // namespace decorators
+} // namespace scpui

--- a/code/scpui/RocketDecoratorsInstancer.cpp
+++ b/code/scpui/RocketDecoratorsInstancer.cpp
@@ -1,0 +1,99 @@
+#include "RocketDecoratorsInstancer.h"
+
+#include <Rocket/Core/Colour.h>
+#include <Rocket/Core/PropertyParser.h>
+#include <Rocket/Core/StyleSheetSpecification.h>
+
+namespace scpui {
+namespace decorators {
+
+// UnderlineDecoratorInstancer Implementation
+UnderlineDecoratorInstancer::UnderlineDecoratorInstancer() : Rocket::Core::DecoratorInstancer()
+{
+	RegisterProperty("thickness", "1.0").AddParser("number");
+	RegisterProperty("style", "solid").AddParser("keyword", "solid, dashed, dotted");
+	RegisterProperty("length", "5.0").AddParser("number");
+	RegisterProperty("space", "3.0").AddParser("number");
+	RegisterProperty("color-setting", "default").AddParser("keyword", "default, element");
+	RegisterProperty("color", "rgb(-1,-1,-1,-1)").AddParser("color");
+
+	RegisterShorthand("shorthand", "style, thickness, length, space");
+}
+
+Rocket::Core::Decorator* UnderlineDecoratorInstancer::InstanceDecorator(const Rocket::Core::String& name,
+	const Rocket::Core::PropertyDictionary& prop_dict)
+{
+	// librocket documentation says the best way to get a keyword is by index so get
+	// that and convert it for readability to an enum for downstream methods	
+	int style_idx = prop_dict.GetProperty("style")->Get<int>();
+	LineStyle style;
+	if (style_idx < 0 || style_idx >= static_cast<int>(LineStyle::Num_styles)) {
+		style = LineStyle::Solid;
+	} else {
+		style = static_cast<LineStyle>(style_idx);
+	}
+
+	float thickness = prop_dict.GetProperty("thickness")->Get<float>();
+	float length = prop_dict.GetProperty("length")->Get<float>();
+	float space = prop_dict.GetProperty("space")->Get<float>();
+	Rocket::Core::Colourb color = prop_dict.GetProperty("color")->Get<Rocket::Core::Colourb>();
+	bool use_element_color = prop_dict.GetProperty("color-setting")->Get<int>();
+
+	return new DecoratorUnderline(thickness, style, length, space, color, use_element_color);
+}
+
+void UnderlineDecoratorInstancer::ReleaseDecorator(Rocket::Core::Decorator* decorator)
+{
+	delete decorator;
+}
+
+void UnderlineDecoratorInstancer::Release()
+{
+	delete this;
+}
+
+// BorderDecoratorInstancer Implementation
+BorderDecoratorInstancer::BorderDecoratorInstancer() : Rocket::Core::DecoratorInstancer()
+{
+	// Register border properties
+	RegisterProperty("thickness", "1.0").AddParser("number");
+	RegisterProperty("length", "10.0").AddParser("number");
+	RegisterProperty("length-h", "10.0").AddParser("number");
+	RegisterProperty("length-v", "10.0").AddParser("number");
+	RegisterProperty("color", "white").AddParser("color");
+
+	RegisterShorthand("shorthand", "thickness, length-h, length-v");
+}
+
+Rocket::Core::Decorator* BorderDecoratorInstancer::InstanceDecorator(const Rocket::Core::String& name,
+	const Rocket::Core::PropertyDictionary& prop_dict)
+{
+	float thickness = prop_dict.GetProperty("thickness")->Get<float>();
+
+	// Check if horizontal or vertical lengths are defined, and fallback to "length" if needed
+	float length_h = prop_dict.GetProperty("length-h")
+								? prop_dict.GetProperty("length-h")->Get<float>()
+								: prop_dict.GetProperty("length")->Get<float>();
+	float length_v = prop_dict.GetProperty("length-v")
+								? prop_dict.GetProperty("length-v")->Get<float>()
+								: prop_dict.GetProperty("length")->Get<float>();
+
+	// Fetch the border color, defaults to white if not set
+	Rocket::Core::Colourb color = prop_dict.GetProperty("color")->Get<Rocket::Core::Colourb>();
+
+	return new DecoratorCornerBorders(thickness, length_h, length_v, color);
+}
+
+
+void BorderDecoratorInstancer::ReleaseDecorator(Rocket::Core::Decorator* decorator)
+{
+	delete decorator;
+}
+
+void BorderDecoratorInstancer::Release()
+{
+	delete this;
+}
+
+} // namespace decorators
+} // namespace scpui

--- a/code/scpui/RocketDecoratorsInstancer.cpp
+++ b/code/scpui/RocketDecoratorsInstancer.cpp
@@ -8,7 +8,7 @@ namespace scpui {
 namespace decorators {
 
 // UnderlineDecoratorInstancer Implementation
-UnderlineDecoratorInstancer::UnderlineDecoratorInstancer() : Rocket::Core::DecoratorInstancer()
+UnderlineDecoratorInstancer::UnderlineDecoratorInstancer()
 {
 	RegisterProperty("thickness", "1.0").AddParser("number");
 	RegisterProperty("style", "solid").AddParser("keyword", "solid, dashed, dotted");
@@ -33,9 +33,9 @@ Rocket::Core::Decorator* UnderlineDecoratorInstancer::InstanceDecorator(const Ro
 		style = static_cast<LineStyle>(style_idx);
 	}
 
-	float thickness = prop_dict.GetProperty("thickness")->Get<float>();
-	float length = prop_dict.GetProperty("length")->Get<float>();
-	float space = prop_dict.GetProperty("space")->Get<float>();
+	auto thickness = prop_dict.GetProperty("thickness")->Get<float>();
+	auto length = prop_dict.GetProperty("length")->Get<float>();
+	auto space = prop_dict.GetProperty("space")->Get<float>();
 	Rocket::Core::Colourb color = prop_dict.GetProperty("color")->Get<Rocket::Core::Colourb>();
 	bool use_element_color = prop_dict.GetProperty("color-setting")->Get<int>();
 
@@ -53,7 +53,7 @@ void UnderlineDecoratorInstancer::Release()
 }
 
 // BorderDecoratorInstancer Implementation
-BorderDecoratorInstancer::BorderDecoratorInstancer() : Rocket::Core::DecoratorInstancer()
+BorderDecoratorInstancer::BorderDecoratorInstancer()
 {
 	// Register border properties
 	RegisterProperty("thickness", "1.0").AddParser("number");
@@ -68,7 +68,7 @@ BorderDecoratorInstancer::BorderDecoratorInstancer() : Rocket::Core::DecoratorIn
 Rocket::Core::Decorator* BorderDecoratorInstancer::InstanceDecorator(const Rocket::Core::String& /*name*/,
 	const Rocket::Core::PropertyDictionary& prop_dict)
 {
-	float thickness = prop_dict.GetProperty("thickness")->Get<float>();
+	auto thickness = prop_dict.GetProperty("thickness")->Get<float>();
 
 	// Check if horizontal or vertical lengths are defined, and fallback to "length" if needed
 	float length_h = prop_dict.GetProperty("length-h")

--- a/code/scpui/RocketDecoratorsInstancer.cpp
+++ b/code/scpui/RocketDecoratorsInstancer.cpp
@@ -15,12 +15,12 @@ UnderlineDecoratorInstancer::UnderlineDecoratorInstancer() : Rocket::Core::Decor
 	RegisterProperty("length", "5.0").AddParser("number");
 	RegisterProperty("space", "3.0").AddParser("number");
 	RegisterProperty("color-setting", "default").AddParser("keyword", "default, element");
-	RegisterProperty("color", "rgb(-1,-1,-1,-1)").AddParser("color");
+	RegisterProperty("color", "white").AddParser("color");
 
 	RegisterShorthand("shorthand", "style, thickness, length, space");
 }
 
-Rocket::Core::Decorator* UnderlineDecoratorInstancer::InstanceDecorator(const Rocket::Core::String& name,
+Rocket::Core::Decorator* UnderlineDecoratorInstancer::InstanceDecorator(const Rocket::Core::String& /*name*/,
 	const Rocket::Core::PropertyDictionary& prop_dict)
 {
 	// librocket documentation says the best way to get a keyword is by index so get
@@ -65,7 +65,7 @@ BorderDecoratorInstancer::BorderDecoratorInstancer() : Rocket::Core::DecoratorIn
 	RegisterShorthand("shorthand", "thickness, length-h, length-v");
 }
 
-Rocket::Core::Decorator* BorderDecoratorInstancer::InstanceDecorator(const Rocket::Core::String& name,
+Rocket::Core::Decorator* BorderDecoratorInstancer::InstanceDecorator(const Rocket::Core::String& /*name*/,
 	const Rocket::Core::PropertyDictionary& prop_dict)
 {
 	float thickness = prop_dict.GetProperty("thickness")->Get<float>();

--- a/code/scpui/RocketDecoratorsInstancer.h
+++ b/code/scpui/RocketDecoratorsInstancer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "RocketDecorators.h"
+
+#include <Rocket/Core/DecoratorInstancer.h>
+
+namespace scpui {
+namespace decorators {
+
+class UnderlineDecoratorInstancer : public Rocket::Core::DecoratorInstancer {
+  public:
+	UnderlineDecoratorInstancer();
+	~UnderlineDecoratorInstancer() override = default;
+
+	// Instances the underline decorator
+	Rocket::Core::Decorator* InstanceDecorator(const Rocket::Core::String& name,
+		const Rocket::Core::PropertyDictionary& properties) override;
+
+	// Releases the underline decorator
+	void ReleaseDecorator(Rocket::Core::Decorator* decorator) override;
+
+	// Releases the instancer itself
+	void Release() override;
+};
+
+class BorderDecoratorInstancer : public Rocket::Core::DecoratorInstancer {
+  public:
+	BorderDecoratorInstancer();
+	~BorderDecoratorInstancer() override = default;
+
+	// Instances the border decorator
+	Rocket::Core::Decorator* InstanceDecorator(const Rocket::Core::String& name,
+		const Rocket::Core::PropertyDictionary& properties) override;
+
+	// Releases the border decorator
+	void ReleaseDecorator(Rocket::Core::Decorator* decorator) override;
+
+	// Releases the instancer itself
+	void Release() override;
+};
+
+} // namespace decorators
+} // namespace scpui

--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -16,6 +16,7 @@
 #include "mod_table/mod_table.h"
 #include "osapi/osapi.h"
 #include "scpui/IncludeNodeHandler.h"
+#include "scpui/RocketDecoratorsInstancer.h"
 #include "scpui/RocketFileInterface.h"
 #include "scpui/RocketLuaSystemInterface.h"
 #include "scpui/RocketRenderingInterface.h"
@@ -577,6 +578,18 @@ void initialize()
 		->RemoveReference();
 
 	XMLParser::RegisterNodeHandler("include", new IncludeNodeHandler())->RemoveReference();
+
+	// Register custom underline decorator with its own instancer
+	Rocket::Core::DecoratorInstancer* underline_instancer = new scpui::decorators::UnderlineDecoratorInstancer();
+	Rocket::Core::Factory::RegisterDecoratorInstancer("underline", underline_instancer);
+
+	// Register custom corner-borders decorator with its own instancer
+	Rocket::Core::DecoratorInstancer* corner_borders_instancer = new scpui::decorators::BorderDecoratorInstancer();
+	Rocket::Core::Factory::RegisterDecoratorInstancer("corner-borders", corner_borders_instancer);
+
+	// Decrease the reference counts (as it is managed by libRocket after registration)
+	underline_instancer->RemoveReference();
+	corner_borders_instancer->RemoveReference();
 
 	// Setup the plugin a style sheet properties for the sound support
 	Rocket::Core::RegisterPlugin(new SoundPlugin());

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1218,6 +1218,10 @@ add_file_folder("ScpUi"
 	scpui/IncludeNodeHandler.h
 	scpui/rocket_ui.cpp
 	scpui/rocket_ui.h
+	scpui/RocketDecorators.cpp
+	scpui/RocketDecorators.h
+	scpui/RocketDecoratorsInstancer.cpp
+	scpui/RocketDecoratorsInstancer.h
 	scpui/RocketFileInterface.cpp
 	scpui/RocketFileInterface.h
 	scpui/RocketLuaSystemInterface.cpp


### PR DESCRIPTION
Adds two new custom decorators for librocket/scpui.

The first adds the ability to underline RML elements in SCPUI which is a workable solution to font underlining which neither the internal FSO font system or librocket's font system officially support. To be clear, this underlines an element, not a line of text. It's meant for short bits of underlining special words similar to how colors are used in briefings. Implementing full underlining would take significant work and modifications to the librocket library itself so I've decided to forgo that effort in hopes of maybe converting to RmlGUI sometime in the future. See #5364 .
```
.underlined-element {
    test-decorator: underline;
    test-thickness: 2.0px;
    test-style: dashed;
    test-length: 10.0px;
    test-space: 5.0px;
    test-color-setting: element;
    test-color: rgb(255, 0, 0);
}

.underlined-element-shorthand {
    test-decorator: underline;
    test-shorthand: solid 1.5px 8.0px 4.0px;
}
```

The second adds corner borders.
```
.corner-borders-element {
    test-decorator: corner-borders;
    test-thickness: 2.0px;
    test-length-h: 15.0px;
    test-length-v: 20.0px;
    test-color: rgb(0, 128, 255);
}

.corner-borders-element-shorthand {
    test-decorator: corner-borders;
    shorthand: 3.0px 12.0px 18.0px;
}
```

![image](https://github.com/user-attachments/assets/0ca0975e-b2d2-42c3-8f57-f1798ee5fea5)
![image](https://github.com/user-attachments/assets/ce287fe9-990c-43e0-a057-45ab719fed36)
