### PR TITLE
adds getBreedName() in a few places

### DIFF
--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -337,7 +337,7 @@ ADE_FUNC(isExpiring, l_Object, nullptr, "Checks whether the object has the shoul
 	return ade_set_args(L, "b", oh->objp()->flags[Object::Object_Flags::Should_be_dead]);
 }
 
-ADE_FUNC(getBreedName, l_Object, NULL, "Gets object type", "string", "Object type name, or empty string if handle is invalid")
+ADE_FUNC(getBreedName, l_Object, nullptr, "Gets the FreeSpace type name", "string", "FreeSpace type name ('Ship', 'Weapon', etc.), or empty string if handle is invalid")
 {
 	object_h *objh;
 	if(!ade_get_args(L, "o", l_Object.GetPtr(&objh)))

--- a/code/scripting/api/objs/parse_object.cpp
+++ b/code/scripting/api/objs/parse_object.cpp
@@ -98,6 +98,18 @@ ADE_FUNC(isValid, l_ParseObject, nullptr, "Detect whether the parsed ship handle
 	return ade_set_args(L, "b", poh->isValid());
 }
 
+ADE_FUNC(getBreedName, l_ParseObject, nullptr, "Gets the FreeSpace type name", "string", "'Parse Object', or empty string if handle is invalid")
+{
+	parse_object_h* poh = nullptr;
+	if (!ade_get_args(L, "o", l_ParseObject.GetPtr(&poh)))
+		return ade_set_error(L, "s", "");
+
+	if (!poh->isValid())
+		return ade_set_error(L, "s", "");
+
+	return ade_set_args(L, "s", "Parse Object");
+}
+
 ADE_FUNC(isPlayer, l_ParseObject, nullptr, "Checks whether the parsed ship is a player ship", "boolean", "Whether the parsed ship is a player ship")
 {
 	parse_object_h *poh = nullptr;

--- a/code/scripting/api/objs/team.cpp
+++ b/code/scripting/api/objs/team.cpp
@@ -28,7 +28,7 @@ ADE_VIRTVAR(Name, l_Team, "string", "Team name", "string", "Team name, or empty 
 	if(!ade_get_args(L, "o|s", l_Team.Get(&tdx), &s))
 		return ade_set_error(L, "s", "");
 
-	if(tdx < 0 || tdx >= (int)Iff_info.size())
+	if(!SCP_vector_inbounds(Iff_info, tdx))
 		return ade_set_error(L, "s", "");
 
 	if(ADE_SETTING_VAR && s != nullptr) {
@@ -52,7 +52,7 @@ ADE_FUNC(getColor,
 	if(!ade_get_args(L, "o|b", l_Team.Get(&idx), &rc))
 		return ADE_RETURN_NIL;
 
-	if(idx < 0 || idx >= (int)Iff_info.size())
+	if(!SCP_vector_inbounds(Iff_info, idx))
 		return ADE_RETURN_NIL;
 
 	color* cur = iff_get_color_by_team(idx, 0, 0);
@@ -70,10 +70,22 @@ ADE_FUNC(isValid, l_Team, NULL, "Detects whether handle is valid", "boolean", "t
 	if(!ade_get_args(L, "o", l_Team.Get(&idx)))
 		return ADE_RETURN_NIL;
 
-	if(idx < 0 || idx >= (int)Iff_info.size())
+	if(!SCP_vector_inbounds(Iff_info, idx))
 		return ADE_RETURN_FALSE;
 
 	return ADE_RETURN_TRUE;
+}
+
+ADE_FUNC(getBreedName, l_Team, nullptr, "Gets the FreeSpace type name", "string", "'Team', or empty string if handle is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_Team.Get(&idx)))
+		return ade_set_error(L, "s", "");
+
+	if (!SCP_vector_inbounds(Iff_info, idx))
+		return ade_set_error(L, "s", "");
+
+	return ade_set_args(L, "s", "Team");
 }
 
 ADE_FUNC(attacks, l_Team, "team", "Checks the IFF status of another team", "boolean", "True if this team attacks the specified team")

--- a/code/scripting/api/objs/wing.cpp
+++ b/code/scripting/api/objs/wing.cpp
@@ -75,6 +75,18 @@ ADE_FUNC(isValid, l_Wing, NULL, "Detects whether handle is valid", "boolean", "t
 	return ADE_RETURN_TRUE;
 }
 
+ADE_FUNC(getBreedName, l_Wing, nullptr, "Gets the FreeSpace type name", "string", "'Wing', or empty string if handle is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_Wing.Get(&idx)))
+		return ade_set_error(L, "s", "");
+
+	if (idx < 0 || idx >= Num_wings)
+		return ade_set_error(L, "s", "");
+
+	return ade_set_args(L, "s", "Wing");
+}
+
 ADE_FUNC(setFlag, l_Wing, "boolean set_it, string flag_name", "Sets or clears one or more flags - this function can accept an arbitrary number of flag arguments.  The flag names are currently limited to the arrival and departure parseable flags.", nullptr, "Returns nothing")
 {
 	int wingnum;


### PR DESCRIPTION
There are a few places in the Lua script API where a variable could be some type of "object" or something that is not an "object" but is still useful - one example is the return value from oswpt:get().  With this function, scripts will be able to tell what the variable is without risking an exception.