### PR TITLE
hide variable -index SEXP operators in FRED

### DIFF
--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -995,7 +995,14 @@ void sexp_tree::right_clicked(int mode)
 							case OP_TECH_REMOVE_INTEL_XSTR:
 							case OP_TECH_RESET_TO_DEFAULT:
 #endif*/
-							// unlike the above operators, these are deprecated 
+
+							// hide these operators per GitHub issue #6400
+							case OP_GET_VARIABLE_BY_INDEX:
+							case OP_SET_VARIABLE_BY_INDEX:
+							case OP_COPY_VARIABLE_FROM_INDEX:
+							case OP_COPY_VARIABLE_BETWEEN_INDEXES:
+
+							// unlike the various campaign operators, these are deprecated
 							case OP_HITS_LEFT_SUBSYSTEM:
 							case OP_CUTSCENES_SHOW_SUBTITLE:
 							case OP_ORDER:
@@ -1053,7 +1060,14 @@ void sexp_tree::right_clicked(int mode)
 							case OP_TECH_REMOVE_INTEL_XSTR:
 							case OP_TECH_RESET_TO_DEFAULT:
 #endif*/
-							// unlike the above operators, these are deprecated 
+
+							// hide these operators per GitHub issue #6400
+							case OP_GET_VARIABLE_BY_INDEX:
+							case OP_SET_VARIABLE_BY_INDEX:
+							case OP_COPY_VARIABLE_FROM_INDEX:
+							case OP_COPY_VARIABLE_BETWEEN_INDEXES:
+
+							// unlike the various campaign operators, these are deprecated
 							case OP_HITS_LEFT_SUBSYSTEM:
 							case OP_CUTSCENES_SHOW_SUBTITLE:
 							case OP_ORDER:

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -6104,7 +6104,14 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 						case OP_TECH_REMOVE_INTEL_XSTR:
 						case OP_TECH_RESET_TO_DEFAULT:
 #endif*/
-						// unlike the above operators, these are deprecated
+
+					// hide these operators per GitHub issue #6400
+					case OP_GET_VARIABLE_BY_INDEX:
+					case OP_SET_VARIABLE_BY_INDEX:
+					case OP_COPY_VARIABLE_FROM_INDEX:
+					case OP_COPY_VARIABLE_BETWEEN_INDEXES:
+
+					// unlike the various campaign operators, these are deprecated
 					case OP_HITS_LEFT_SUBSYSTEM:
 					case OP_CUTSCENES_SHOW_SUBTITLE:
 					case OP_ORDER:
@@ -6179,7 +6186,14 @@ std::unique_ptr<QMenu> sexp_tree::buildContextMenu(QTreeWidgetItem* h) {
 						case OP_TECH_REMOVE_INTEL_XSTR:
 						case OP_TECH_RESET_TO_DEFAULT:
 #endif*/
-						// unlike the above operators, these are deprecated
+
+					// hide these operators per GitHub issue #6400
+					case OP_GET_VARIABLE_BY_INDEX:
+					case OP_SET_VARIABLE_BY_INDEX:
+					case OP_COPY_VARIABLE_FROM_INDEX:
+					case OP_COPY_VARIABLE_BETWEEN_INDEXES:
+
+					// unlike the various campaign operators, these are deprecated
 					case OP_HITS_LEFT_SUBSYSTEM:
 					case OP_CUTSCENES_SHOW_SUBTITLE:
 					case OP_ORDER:


### PR DESCRIPTION
Hide these SEXP operators to reduce confusion for FREDders.  They still work, but using them properly requires a certain amount of knowledge of the inner workings of variables, and the operators can break if new variables are added causing the list to be re-indexed.

Implements half of #6400.