### PR TITLE
handle connection speed in a user-friendly way

### DIFF
--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -458,13 +458,8 @@ void multi_options_set_local_defaults(multi_local_options *options)
 	// accept pix by default and broadcast on the local subnet
 	options->flags = (MLO_FLAG_ACCEPT_PIX | MLO_FLAG_LOCAL_BROADCAST);	
 
-	// set the object update level based on the type of network connection specified by the user
-	// at install (or launcher) time.
-	if ( Psnet_connection == NETWORK_CONNECTION_DIALUP ) {
-		options->obj_update_level = OBJ_UPDATE_LOW;
-	} else {
-		options->obj_update_level = Default_multi_object_update_level;
-	}
+	// set the object update level based on the type of network connection specified by the mod
+	options->obj_update_level = Default_multi_object_update_level;
 }
 
 // fill in the passed netgame options struct with the data from my player file data (only host/server should do this)

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -2936,11 +2936,7 @@ int multi_get_connection_speed()
 	int cspeed;
 	const char *connection_speed;
 
-#ifdef _WIN32	
-	connection_speed = os_config_read_string(nullptr, "ConnectionSpeed", "");	
-#else
 	connection_speed = os_config_read_string(nullptr, "ConnectionSpeed", "Fast");
-#endif
 
 	if ( !stricmp(connection_speed, NOX("Slow")) ) {
 		cspeed = CONNECTION_SPEED_288;

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -52,7 +52,6 @@ static bool Psnet_active = false;
 
 static int Network_status;
 int Psnet_failure_code = 0;
-int Psnet_connection;
 
 uint16_t Psnet_default_port;
 
@@ -423,8 +422,6 @@ void psnet_init(uint16_t port_num)
 		return;
 	}
 
-	Psnet_connection = NETWORK_CONNECTION_LAN;
-
 	Network_status = NETWORK_STATUS_NO_PROTOCOL;
 
 #ifdef _WIN32
@@ -660,11 +657,6 @@ bool psnet_init_my_addr()
  */
 int psnet_get_network_status()
 {
-	// first case is when "none" is selected
-	if (Psnet_connection == NETWORK_CONNECTION_NONE) {
-		return NETWORK_ERROR_NO_TYPE;
-	}
-
 	// first, check the connection status of the network
 	if (Network_status == NETWORK_STATUS_NO_WINSOCK) {
 		return NETWORK_ERROR_NO_WINSOCK;

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -64,7 +64,7 @@ typedef uint PSNET_SOCKET_RELIABLE;
 
 // define values for network errors when trying to enter the ready room
 #define NETWORK_ERROR_NONE					0
-#define NETWORK_ERROR_NO_TYPE				-1
+#define NETWORK_ERROR_NO_TYPE				-1	// this is no longer used because we no longer require the user to set the connection type via the launcher
 #define NETWORK_ERROR_NO_WINSOCK			-2
 #define NETWORK_ERROR_NO_PROTOCOL		-3
 #define NETWORK_ERROR_RELIABLE			-4
@@ -87,8 +87,6 @@ extern int Psnet_failure_code;
 #define NETWORK_CONNECTION_NONE			1
 #define NETWORK_CONNECTION_DIALUP		2
 #define NETWORK_CONNECTION_LAN			3
-
-extern int Psnet_connection;
 
 extern ushort Psnet_default_port;
 


### PR DESCRIPTION
1. Use a sensible default for the connection speed
2. Remove the `Psnet_connection` variable which is now obsolete: "its only purpose now is to change the default object update value for a player if it's set to dialup, and that's easily done in-game already"

The "You must define your connection speed" popup will now no longer appear unless it has been explicitly set to an invalid value.

Applies recommendations from, and fixes, #6402.