### PR TITLE
add is-true-for-duration sexp

### DIFF
--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -315,6 +315,7 @@ enum : int {
 	OP_PERFORM_ACTIONS_BOOL_FIRST,	// Goober5000
 	OP_PERFORM_ACTIONS_BOOL_LAST,	// Goober5000
 	OP_HAS_TIME_ELAPSED_MSECS,	// Goober5000
+	OP_IS_TRUE_FOR_DURATION,	// Goober5000
 
 	// OP_CATEGORY_GOAL_EVENT
 	
@@ -1360,7 +1361,9 @@ typedef struct sexp_node {
 	int flags;					// Goober5000
 
 	sexp_cached_data *cache;	// Goober5000
-	int cached_variable_index;	// Goober5000
+	int cached_variable_index;	// Goober5000 - note, this can be used for special-arg nodes, not just variable nodes
+
+	int duration_index;			// Goober5000 - only used if node is the is-true-for-duration operator
 } sexp_node;
 
 // Goober5000


### PR DESCRIPTION
This adds a sexp to allow any boolean condition, or series of conditions, to be evaluated not only instantaneously, but also for a period of time.  For example, this can be used with `is-facing` to check if a ship has been facing another ship for a specified duration.  Previously this had to be done through scripting or through a group of sexps.

Implements #5754.