### PR TITLE
allow ambient sound to be specified on a per-main-hall basis

### DIFF
--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -462,9 +462,10 @@ gamesnd_id parse_game_sound_inline()
  * @param tag Tag
  * @param idx_dest Sound index destination
  * @param flags See the parse_sound_flags enum
- *
+ * @return whether the tag was found and a parse was attempted
  */
-void parse_iface_sound(const char* tag, interface_snd_id* idx_dest) {
+bool parse_iface_sound(const char* tag, interface_snd_id* idx_dest)
+{
 	Assert( Snds_iface.size() == Snds_iface_handle.size() );
 
 	if(optional_string(tag))
@@ -478,7 +479,11 @@ void parse_iface_sound(const char* tag, interface_snd_id* idx_dest) {
 		if (!idx_dest->isValid() && buf != "-1") {
 			error_display(0, "Could not find interface sound with name '%s'!", buf.c_str());
 		}
+
+		return true;
 	}
+
+	return false;
 }
 
 /**
@@ -491,9 +496,9 @@ void parse_iface_sound(const char* tag, interface_snd_id* idx_dest) {
  * @param tag Tag
  * @param object_name Name of object being parsed
  * @param flags See the parse_sound_flags enum
- *
+ * @return whether the tag was found and a parse was attempted
  */
-void parse_iface_sound_list(const char* tag, SCP_vector<interface_snd_id>& destination, const char* object_name, bool scp_list)
+bool parse_iface_sound_list(const char* tag, SCP_vector<interface_snd_id>& destination, const char* object_name, bool scp_list)
 {
 	if(optional_string(tag))
 	{
@@ -529,7 +534,11 @@ void parse_iface_sound_list(const char* tag, SCP_vector<interface_snd_id>& desti
 		{
 			mprintf(("%s in '%s' has " SIZE_T_ARG " entries. This does not match entered size of %i.\n", tag, object_name, destination.size(), check));
 		}
+
+		return true;
 	}
+
+	return false;
 }
 
 /**

--- a/code/gamesnd/gamesnd.h
+++ b/code/gamesnd/gamesnd.h
@@ -262,7 +262,7 @@ enum class InterfaceSounds {
 	GENERAL_FAIL            =10,//!< general failure sound for any event
 	SHIP_ICON_CHANGE        =11,//!< ship animation starts (ie text and ship first appear)
 	MAIN_HALL_AMBIENT       =12,//!< ambient sound for the Terran main hall (looping)
-	BTN_SLIDE               =13,//!< ambient sound for the Vasudan main hall (looping)
+	MAIN_HALL_AMBIENT_V     =13,//!< ambient sound for the Vasudan main hall (looping); in FS1, SND_BTN_SLIDE which was used for the briefing button slide-in
 	BRIEF_STAGE_CHG         =14,//!< brief stage change
 	BRIEF_STAGE_CHG_FAIL    =15,//!< brief stage change fail
 	BRIEF_ICON_SELECT       =16,//!< selet brief icon
@@ -381,8 +381,8 @@ bool parse_game_sound(const char* tag, gamesnd_id* idx_dest);
 
 gamesnd_id parse_game_sound_inline();
 
-void parse_iface_sound(const char* tag, interface_snd_id* idx_dest);
-void parse_iface_sound_list(const char* tag, SCP_vector<interface_snd_id>& destination, const char* object_name, bool scp_list = false);
+bool parse_iface_sound(const char* tag, interface_snd_id* idx_dest);
+bool parse_iface_sound_list(const char* tag, SCP_vector<interface_snd_id>& destination, const char* object_name, bool scp_list = false);
 
 // this is a callback, so it needs to be a real function
 void common_play_highlight_sound();

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -506,7 +506,7 @@ void main_hall_init(const SCP_string &main_hall_name)
 	}
 
 	// if we're switching to a different mainhall, stop the ambient (it will be started again promptly)
-	if (Main_hall && Main_hall->name != main_hall_to_load) {
+	if (!Main_hall || Main_hall->name != main_hall_to_load) {
 		main_hall_stop_ambient();
 	}
 
@@ -1726,22 +1726,17 @@ void main_hall_notify_do()
  */
 void main_hall_start_ambient()
 {
-	int play_ambient_loop = 0;
-
 	if (Main_hall_paused) {
 		return;
 	}
 
-	if (!Main_hall_ambient_loop.isValid()) {
-		play_ambient_loop = 1;
-	} else {
-		if (!snd_is_playing(Main_hall_ambient_loop)) {
-			play_ambient_loop = 1;
-		}
-	}
+	if (!Main_hall_ambient_loop.isValid() || !snd_is_playing(Main_hall_ambient_loop)) {
+		// if no main hall (e.g. on pilot select screen) use the default
+		auto sound = Main_hall ? Main_hall->ambient_sound : InterfaceSounds::MAIN_HALL_AMBIENT;
 
-	if (play_ambient_loop) {
-		Main_hall_ambient_loop = snd_play_looping(gamesnd_get_interface_sound(InterfaceSounds::MAIN_HALL_AMBIENT));
+		if (sound.isValid()) {
+			Main_hall_ambient_loop = snd_play_looping(gamesnd_get_interface_sound(sound));
+		}
 	}
 
 	// no need to restart the intercom, since the game will set the timestamp for a new one
@@ -1792,7 +1787,12 @@ void main_hall_stop_ambient()
 void main_hall_reset_ambient_vol()
 {
 	if (Main_hall_ambient_loop.isValid()) {
-		snd_set_volume(Main_hall_ambient_loop, gamesnd_get_interface_sound(InterfaceSounds::MAIN_HALL_AMBIENT)->volume_range.next());
+		// if no main hall (e.g. on pilot select screen) use the default
+		auto sound = Main_hall ? Main_hall->ambient_sound : InterfaceSounds::MAIN_HALL_AMBIENT;
+
+		if (sound.isValid()) {
+			snd_set_volume(Main_hall_ambient_loop, gamesnd_get_interface_sound(sound)->volume_range.next());
+		}
 	}
 }
 
@@ -2437,6 +2437,9 @@ void parse_one_main_hall(bool replace, int num_resolutions, int &hall_idx, int &
 	if (optional_string("+Render FSO Version:")) {
 		stuff_boolean(&m->render_version);
 	}
+
+	// ambient sound
+	parse_iface_sound("+Ambient Sound:", &m->ambient_sound);
 
 	// intercom sounds
 	if (optional_string("+Num Intercom Sounds:")) {

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -2439,7 +2439,9 @@ void parse_one_main_hall(bool replace, int num_resolutions, int &hall_idx, int &
 	}
 
 	// ambient sound
-	parse_iface_sound("+Ambient Sound:", &m->ambient_sound);
+	bool ambient_found = parse_iface_sound("+Ambient Sound:", &m->ambient_sound);
+	if (!ambient_found && first_time && main_hall_is_vasudan(m))
+		m->ambient_sound = InterfaceSounds::MAIN_HALL_AMBIENT_V;	// default to using Vasudan ambient sound in a Vasudan hall
 
 	// intercom sounds
 	if (optional_string("+Num Intercom Sounds:")) {
@@ -2737,11 +2739,19 @@ void main_hall_vasudan_funny()
 }
 
 /**
- * Lookup if Vasudan main hall, based upon background graphics
+ * Check if Vasudan main hall, based upon background graphics
  */
-bool main_hall_is_vasudan()
+bool main_hall_is_vasudan(const main_hall_defines *hall)
 {
-	return !stricmp(Main_hall->bitmap.c_str(), "vhall") || !stricmp(Main_hall->bitmap.c_str(), "2_vhall");
+	if (!hall)
+	{
+		if (Main_hall)
+			hall = Main_hall;	// default to the current main hall
+		else
+			return false;
+	}
+
+	return !stricmp(hall->bitmap.c_str(), "vhall") || !stricmp(hall->bitmap.c_str(), "2_vhall");
 }
 
 /**

--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -69,6 +69,8 @@ public:
 	bool render_title = true;
 	bool render_version = true;
 
+	interface_snd_id ambient_sound = InterfaceSounds::MAIN_HALL_AMBIENT;
+
 	// intercom defines -------------------
 
 	// # of intercom sounds

--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -210,7 +210,8 @@ int main_hall_get_overlay_resolution_index();
 int main_hall_id();
 
 // Vasudan?
-bool main_hall_is_vasudan();
+// (defaults to the current main hall, but now allows checking another specified main hall)
+bool main_hall_is_vasudan(const main_hall_defines *hall = nullptr);
 
 // start the ambient sounds playing in the main hall
 void main_hall_start_ambient();


### PR DESCRIPTION
Adds a new `+Ambient Sound:` field to mainhall.tbl, allowing any interface sound (or even no interface sound) to be used for the main hall ambient sound.  The default ambient sound, as well as the sound played on the pilot select screen, is interface sound 12.

Implements #6421.