### PR TITLE
Fix CTD from recent cycle expansion

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -866,8 +866,8 @@ public:
 
 	// linked lists for special polygon types on this model.  Most ships I think will have most
 	// of these.  (most ships however, probably won't have approach points).
-	int			n_guns;								// number of primary gun points (not counting turrets)
-	int			n_missiles;							// number of secondary missile points (not counting turrets)
+	int			n_guns;								// number of primary weapon banks (not counting turrets)
+	int			n_missiles;							// number of secondary weapon banks (not counting turrets)
 	int			n_docks;								// number of docking points
 	int			n_thrusters;						// number of thrusters on this ship.
 	w_bank		*gun_banks;							// array of gun banks

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11362,7 +11362,7 @@ static void ship_model_change(int n, int ship_type)
 	// reset texture animations
 	sp->base_texture_anim_timestamp = _timestamp();
 
-	for (int bank_i = 0; bank_i < MAX_SHIP_PRIMARY_BANKS; bank_i++) {
+	for (int bank_i = 0; bank_i < pm->n_guns; bank_i++) {
 		sp->weapons.primary_firepoint_indices[bank_i].clear();
 		sp->weapons.primary_firepoint_next_to_fire_index[bank_i] = 0;
 		SCP_vector<int> fpi;


### PR DESCRIPTION
The recent cycle expansion PR (#6364) causes a CTD when change-ship-type is used. This PR fixes that crash by using `pm->n_guns` instead of 'MAX_SHIP_PRIMARY_BANKS' and clarifies the definition comment for the `pm->n_guns` to help avoid this kind of quandary in the future (thanks @Baezon!).

Tested and works as expected.

Note, renaming the `n_guns` variable would touch so many files that this PR was focused more on applying the CTD hotfix. 