### PR TITLE
fix a few bugs in the Vasudan heads cheat

### DIFF
--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -141,7 +141,7 @@ public:
 	SCP_vector<SCP_vector<int> > door_anim_coords;
 
 	// sounds for each region (open/close)
-	SCP_vector<SCP_vector<interface_snd_id> > door_sounds;
+	SCP_vector<std::pair<interface_snd_id, interface_snd_id>> door_sounds;
 
 	// pan values for the door sounds
 	SCP_vector<float> door_sound_pan;


### PR DESCRIPTION
There were several bugs and design issues in the Vasudan headz cheat, probably due to being coded in a hurry right before release:
1. Although the cheat activated on the main hall, it was not immediately apparent, requiring the player to switch screens and come back
2. The detection of whether the main hall is Vasudan did not work after the cheat was activated, due to the background filename changing (this one is actually not Volition's fault)
3. The implementation of the cheat was actually in the wrong section of code, resulting in some confusion

These are now fixed.  The cheat can be enabled or disabled from one function, the graphics are reloaded properly, and the main hall detection includes the cheat-active version of the main hall.  Also, the door sounds have been slightly refactored to use a `std::pair` rather than a vector, since there are exactly two sounds, an open and a close.