### PR TITLE
fix DDV_ validation in FRED, especially DDV_MaxChars

### DIFF
--- a/fred2/addvariabledlg.cpp
+++ b/fred2/addvariabledlg.cpp
@@ -44,9 +44,9 @@ void CAddVariableDlg::DoDataExchange(CDataExchange* pDX) {
 	CDialog::DoDataExchange(pDX);
 	//{{AFX_DATA_MAP(CAddVariableDlg)
 	DDX_Text(pDX, IDC_ADD_VARIABLE_DEFAULT_VALUE, m_default_value);
-	DDV_MaxChars(pDX, m_default_value, 31);
+	DDV_MaxChars(pDX, m_default_value, TOKEN_LENGTH - 1);
 	DDX_Text(pDX, IDC_ADD_VARIABLE_NAME, m_variable_name);
-	DDV_MaxChars(pDX, m_variable_name, 31);
+	DDV_MaxChars(pDX, m_variable_name, TOKEN_LENGTH - 1);
 	//}}AFX_DATA_MAP
 }
 

--- a/fred2/bgbitmapdlg.cpp
+++ b/fred2/bgbitmapdlg.cpp
@@ -121,7 +121,8 @@ void bg_bitmap_dlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Text(pDX, IDC_SBITMAP_B, b_bank);
 	DDV_MinMaxInt(pDX, b_bank, 0, 359);
 	DDX_Text(pDX, IDC_SBITMAP_H, b_heading);
-	DDV_MinMaxInt(pDX, b_heading, 0, 359);	DDX_Text(pDX, IDC_SBITMAP_SCALE_X, b_scale_x);
+	DDV_MinMaxInt(pDX, b_heading, 0, 359);
+	DDX_Text(pDX, IDC_SBITMAP_SCALE_X, b_scale_x);
 	DDV_MinMaxFloat(pDX, b_scale_x, .001f, 18.0f);
 	DDX_Text(pDX, IDC_SBITMAP_SCALE_Y, b_scale_y);
 	DDV_MinMaxFloat(pDX, b_scale_y, .001f, 18.0f);

--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -100,12 +100,15 @@ void briefing_editor_dlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_HILIGHT, m_hilight);
 	DDX_CBIndex(pDX, IDC_ICON_IMAGE, m_icon_image);
 	DDX_Text(pDX, IDC_ICON_LABEL, m_icon_label);
+	DDV_MaxChars(pDX, m_icon_label, MAX_LABEL_LEN - 1);
 	DDX_Text(pDX, IDC_ICON_CLOSEUP_LABEL, m_icon_closeup_label);
+	DDV_MaxChars(pDX, m_icon_closeup_label, MAX_LABEL_LEN - 1);
 	DDX_Text(pDX, IDC_ICON_SCALE, m_icon_scale);
 	DDX_Text(pDX, IDC_STAGE_TITLE, m_stage_title);
 	DDX_Text(pDX, IDC_TEXT, m_text);
 	DDX_Text(pDX, IDC_TIME, m_time);
 	DDX_Text(pDX, IDC_VOICE, m_voice);
+	DDV_MaxChars(pDX, m_voice, MAX_FILENAME_LEN - 1);
 	DDX_CBIndex(pDX, IDC_TEAM, m_icon_team);
 	DDX_CBIndex(pDX, IDC_SHIP_TYPE, m_ship_type);
 	DDX_Check(pDX, IDC_LOCAL, m_change_local);
@@ -119,10 +122,6 @@ void briefing_editor_dlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_USE_WING_ICON, m_use_wing);
 	DDX_Check(pDX, IDC_USE_CARGO_ICON, m_use_cargo);
 	//}}AFX_DATA_MAP
-
-	DDV_MaxChars(pDX, m_voice, MAX_FILENAME_LEN - 1);
-	DDV_MaxChars(pDX, m_icon_label, MAX_LABEL_LEN - 1);
-	DDV_MaxChars(pDX, m_icon_closeup_label, MAX_LABEL_LEN - 1);
 }
 
 BEGIN_MESSAGE_MAP(briefing_editor_dlg, CDialog)

--- a/fred2/campaigneditordlg.cpp
+++ b/fred2/campaigneditordlg.cpp
@@ -73,14 +73,13 @@ void campaign_editor::DoDataExchange(CDataExchange* pDX)
 	DDX_CBIndex(pDX, IDC_CAMPAIGN_TYPE, m_type);
 	DDX_Text(pDX, IDC_NUM_PLAYERS, m_num_players);
 	DDX_Text(pDX, IDC_DESC2, m_desc);
+	DDV_MaxChars(pDX, m_desc, MISSION_DESC_LENGTH - 1);
 	DDX_Text(pDX, IDC_MISSISON_LOOP_DESC, m_branch_desc);
+	DDV_MaxChars(pDX, m_branch_desc, MISSION_DESC_LENGTH - 1);
 	DDX_Text(pDX, IDC_LOOP_BRIEF_ANIM, m_branch_brief_anim);
 	DDX_Text(pDX, IDC_LOOP_BRIEF_SOUND, m_branch_brief_sound);
 	DDX_Check(pDX, IDC_CUSTOM_TECH_DB, m_custom_tech_db);
 	//}}AFX_DATA_MAP
-
-	DDV_MaxChars(pDX, m_desc, MISSION_DESC_LENGTH - 1);
-	DDV_MaxChars(pDX, m_branch_desc, MISSION_DESC_LENGTH - 1);	
 }
 
 BEGIN_MESSAGE_MAP(campaign_editor, CFormView)

--- a/fred2/cmdbrief.cpp
+++ b/fred2/cmdbrief.cpp
@@ -43,13 +43,12 @@ void cmd_brief_dlg::DoDataExchange(CDataExchange* pDX)
 	CDialog::DoDataExchange(pDX);
 	//{{AFX_DATA_MAP(cmd_brief_dlg)
 	DDX_Text(pDX, IDC_ANI_FILENAME, m_ani_filename);
+	DDV_MaxChars(pDX, m_ani_filename, MAX_FILENAME_LEN - 1);
 	DDX_Text(pDX, IDC_TEXT, m_text);
 	DDX_Text(pDX, IDC_STAGE_TITLE, m_stage_title);
 	DDX_Text(pDX, IDC_WAVE_FILENAME, m_wave_filename);
-	//}}AFX_DATA_MAP
-
-	DDV_MaxChars(pDX, m_ani_filename, MAX_FILENAME_LEN - 1);
 	DDV_MaxChars(pDX, m_wave_filename, MAX_FILENAME_LEN - 1);
+	//}}AFX_DATA_MAP
 }
 
 BEGIN_MESSAGE_MAP(cmd_brief_dlg, CDialog)

--- a/fred2/createwingdlg.cpp
+++ b/fred2/createwingdlg.cpp
@@ -40,9 +40,8 @@ void create_wing_dlg::DoDataExchange(CDataExchange* pDX)
 	CDialog::DoDataExchange(pDX);
 	//{{AFX_DATA_MAP(create_wing_dlg)
 	DDX_Text(pDX, IDC_NAME, m_name);
-	//}}AFX_DATA_MAP
-
 	DDV_MaxChars(pDX, m_name, NAME_LENGTH - 4);
+	//}}AFX_DATA_MAP
 }
 
 BEGIN_MESSAGE_MAP(create_wing_dlg, CDialog)

--- a/fred2/debriefingeditordlg.cpp
+++ b/fred2/debriefingeditordlg.cpp
@@ -60,14 +60,13 @@ void debriefing_editor_dlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_TREE, m_tree);
 	DDX_Text(pDX, IDC_TEXT, m_text);
 	DDX_Text(pDX, IDC_VOICE, m_voice);
+	DDV_MaxChars(pDX, m_voice, MAX_FILENAME_LEN - 1);
 	DDX_Text(pDX, IDC_STAGE_TITLE, m_stage_title);
 	DDX_Text(pDX, IDC_REC_TEXT, m_rec_text);
 	DDX_CBIndex(pDX, IDC_SUCCESSFUL_MISSION_TRACK, m_debriefPass_music);
 	DDX_CBIndex(pDX, IDC_DEBRIEFING_TRACK, m_debriefAvg_music);
 	DDX_CBIndex(pDX, IDC_FAILED_MISSION_TRACK, m_debriefFail_music);
 	//}}AFX_DATA_MAP
-
-	DDV_MaxChars(pDX, m_voice, MAX_FILENAME_LEN - 1);
 }
 
 BEGIN_MESSAGE_MAP(debriefing_editor_dlg, CDialog)

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -102,12 +102,18 @@ void event_editor::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_CHAINED, m_chained);
 	DDX_Check(pDX, IDC_USE_MSECS, m_use_msecs);
 	DDX_Text(pDX, IDC_OBJ_TEXT, m_obj_text);
+	DDV_MaxChars(pDX, m_obj_text, NAME_LENGTH - 1);
 	DDX_Text(pDX, IDC_OBJ_KEY_TEXT, m_obj_key_text);
+	DDV_MaxChars(pDX, m_obj_key_text, NAME_LENGTH - 1);
 	DDX_CBString(pDX, IDC_AVI_FILENAME, m_avi_filename);
+	DDV_MaxChars(pDX, m_avi_filename, MAX_FILENAME_LEN - 1);
 	DDX_Text(pDX, IDC_MESSAGE_NAME, m_message_name);
+	DDV_MaxChars(pDX, m_message_name, NAME_LENGTH - 1);
 	DDX_Text(pDX, IDC_MESSAGE_TEXT, m_message_text);
+	DDV_MaxChars(pDX, m_message_text, MESSAGE_LENGTH - 1);
 	DDX_CBIndex(pDX, IDC_PERSONA_NAME, m_persona);
 	DDX_CBString(pDX, IDC_WAVE_FILENAME, m_wave_filename);
+	DDV_MaxChars(pDX, m_wave_filename, MAX_FILENAME_LEN - 1);
 	DDX_LBIndex(pDX, IDC_MESSAGE_LIST, m_cur_msg);
 	DDX_Check(pDX, IDC_MISSION_LOG_TRUE, m_log_true);
 	DDX_Check(pDX, IDC_MISSION_LOG_FALSE, m_log_false);
@@ -131,13 +137,6 @@ void event_editor::DoDataExchange(CDataExchange* pDX)
 	}
 	DDX_CBIndex(pDX, IDC_MESSAGE_TEAM, m_message_team);
 	//}}AFX_DATA_MAP
-
-	DDV_MaxChars(pDX, m_obj_text, NAME_LENGTH - 1);
-	DDV_MaxChars(pDX, m_obj_key_text, NAME_LENGTH - 1);
-	DDV_MaxChars(pDX, m_message_name, NAME_LENGTH - 1);
-	DDV_MaxChars(pDX, m_message_text, MESSAGE_LENGTH - 1);
-	DDV_MaxChars(pDX, m_avi_filename, MAX_FILENAME_LEN - 1);
-	DDV_MaxChars(pDX, m_wave_filename, MAX_FILENAME_LEN - 1);
 }
 
 BEGIN_MESSAGE_MAP(event_editor, CDialog)

--- a/fred2/messageeditordlg.cpp
+++ b/fred2/messageeditordlg.cpp
@@ -54,18 +54,18 @@ void CMessageEditorDlg::DoDataExchange(CDataExchange* pDX)
 	//{{AFX_DATA_MAP(CMessageEditorDlg)
 	DDX_Control(pDX, IDC_TREE, m_tree);
 	DDX_CBString(pDX, IDC_AVI_FILENAME, m_avi_filename);
+	DDV_MaxChars(pDX, m_avi_filename, MAX_FILENAME_LEN - 1);
 	DDX_CBString(pDX, IDC_WAVE_FILENAME, m_wave_filename);
+	DDV_MaxChars(pDX, m_wave_filename, MAX_FILENAME_LEN - 1);
 	DDX_Text(pDX, IDC_MESSAGE_TEXT, m_message_text);
+	DDV_MaxChars(pDX, m_message_text, MESSAGE_LENGTH - 1);
 	DDX_Text(pDX, IDC_NAME, m_message_name);
+	DDV_MaxChars(pDX, m_message_name, NAME_LENGTH - 1);
 	DDX_LBIndex(pDX, IDC_MESSAGE_LIST, m_cur_msg);
 	DDX_CBIndex(pDX, IDC_PRIORITY, m_priority);
 	DDX_CBIndex(pDX, IDC_SENDER, m_sender);
 	DDX_CBIndex(pDX, IDC_PERSONA_NAME, m_persona);
 	//}}AFX_DATA_MAP
-	DDV_MaxChars(pDX, m_message_name, NAME_LENGTH - 1);
-	DDV_MaxChars(pDX, m_message_text, MESSAGE_LENGTH - 1);
-	DDV_MaxChars(pDX, m_avi_filename, MAX_FILENAME_LEN - 1);
-	DDV_MaxChars(pDX, m_wave_filename, MAX_FILENAME_LEN - 1);
 }
 
 BEGIN_MESSAGE_MAP(CMessageEditorDlg, CDialog)

--- a/fred2/missioncutscenesdlg.cpp
+++ b/fred2/missioncutscenesdlg.cpp
@@ -94,9 +94,9 @@ void CMissionCutscenesDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_CBIndex(pDX, IDC_CUTSCENE_TYPE_DROP, m_cutscene_type);
 	DDX_CBIndex(pDX, IDC_DISPLAY_CUTSCENE_TYPES_DROP, m_display_cutscene_types);
 	DDX_Text(pDX, IDC_CUTSCENE_NAME, m_name);
+	DDV_MaxChars(pDX, m_name, NAME_LENGTH - 1);
 	DDX_Text(pDX, IDC_CUTSCENE_HELP_BOX, m_desc);
 	//}}AFX_DATA_MAP
-	DDV_MaxChars(pDX, m_name, NAME_LENGTH - 1);
 }
 
 BEGIN_MESSAGE_MAP(CMissionCutscenesDlg, CDialog)

--- a/fred2/missiongoalsdlg.cpp
+++ b/fred2/missiongoalsdlg.cpp
@@ -94,12 +94,12 @@ void CMissionGoalsDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_CBIndex(pDX, IDC_GOAL_TYPE_DROP, m_goal_type);
 	DDX_CBIndex(pDX, IDC_DISPLAY_GOAL_TYPES_DROP, m_display_goal_types);
 	DDX_Text(pDX, IDC_GOAL_NAME, m_name);
+	DDV_MaxChars(pDX, m_name, NAME_LENGTH - 1);
 	DDX_Check(pDX, IDC_GOAL_INVALID, m_goal_invalid);
 	DDX_Text(pDX, IDC_GOAL_SCORE, m_goal_score);
 	DDX_Check(pDX, IDC_NO_MUSIC, m_no_music);
 	DDX_CBIndex(pDX, IDC_OBJ_TEAM, m_team);
 	//}}AFX_DATA_MAP
-	DDV_MaxChars(pDX, m_name, NAME_LENGTH - 1);
 }
 
 BEGIN_MESSAGE_MAP(CMissionGoalsDlg, CDialog)

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -109,8 +109,8 @@ void CMissionNotesDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_RED_ALERT, m_red_alert);
 	DDX_Check(pDX, IDC_SCRAMBLE, m_scramble);
 	DDX_Text(pDX, IDC_RESPAWNS, m_num_respawns);
-	DDX_Text(pDX, IDC_MAX_RESPAWN_DELAY, m_max_respawn_delay);
 	DDV_MinMaxUInt(pDX, m_num_respawns, 0, 99);
+	DDX_Text(pDX, IDC_MAX_RESPAWN_DELAY, m_max_respawn_delay);
 	DDV_MinMaxInt(pDX, m_max_respawn_delay, -1, 999);
 	DDX_Check(pDX, IDC_SUPPORT_ALLOWED, m_disallow_support);
 	DDX_Check(pDX, IDC_NO_PROMOTION, m_no_promotion);

--- a/fred2/modifyvariabledlg.cpp
+++ b/fred2/modifyvariabledlg.cpp
@@ -42,9 +42,9 @@ void CModifyVariableDlg::DoDataExchange(CDataExchange* pDX)
 	CDialog::DoDataExchange(pDX);
 	//{{AFX_DATA_MAP(CModifyVariableDlg)
 	DDX_Text(pDX, IDC_MODIFY_DEFAULT_VALUE, m_default_value);
-	DDV_MaxChars(pDX, m_default_value, 31);
+	DDV_MaxChars(pDX, m_default_value, TOKEN_LENGTH - 1);
 	DDX_CBString(pDX, IDC_MODIFY_VARIABLE_NAME, m_cur_variable_name);
-	DDV_MaxChars(pDX, m_cur_variable_name, 31);
+	DDV_MaxChars(pDX, m_cur_variable_name, TOKEN_LENGTH - 1);
 	//}}AFX_DATA_MAP
 }
 

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -158,7 +158,9 @@ void CShipEditorDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_Control(pDX, IDC_DEPARTURE_TREE, m_departure_tree);
 	DDX_Control(pDX, IDC_PLAYER_SHIP, m_player_ship);
 	DDX_Text(pDX, IDC_SHIP_NAME, m_ship_name);
+	DDV_MaxChars(pDX, m_ship_name, NAME_LENGTH - 1);
 	DDX_CBString(pDX, IDC_SHIP_CARGO1, m_cargo1);
+	DDV_MaxChars(pDX, m_cargo1, NAME_LENGTH - 1);
 	DDX_CBIndex(pDX, IDC_SHIP_CLASS, m_ship_class_combo_index);
 	DDX_CBIndex(pDX, IDC_SHIP_TEAM, m_team);
 	DDX_CBIndex(pDX, IDC_ARRIVAL_LOCATION, m_arrival_location);
@@ -171,8 +173,6 @@ void CShipEditorDlg::DoDataExchange(CDataExchange* pDX)
 	DDX_CBIndex(pDX, IDC_DEPARTURE_TARGET, m_departure_target);
 	DDX_CBIndex(pDX, IDC_SHIP_PERSONA, m_persona);	
 	//}}AFX_DATA_MAP
-	DDV_MaxChars(pDX, m_ship_name, NAME_LENGTH - 1);
-	DDV_MaxChars(pDX, m_cargo1, NAME_LENGTH - 1);
 
 	if (pDX->m_bSaveAndValidate) {  // get dialog control values
 		GetDlgItem(IDC_ARRIVAL_DELAY)->GetWindowText(str);


### PR DESCRIPTION
Any DDV (Dialog Data Validation) routine must appear immediately after the field it validates in order for the enforcement to work in real-time.  If the DDV_ routine is not linked to the field, it will perform validation after-the-fact by displaying a dialog box and returning an error.  This is an alternate way of handling validation, but in order for the dialog box not to generate an endless loop, it would be necessary to check the return value of every `UpdateData(TRUE)` call in the FRED codebase (or at least the first `UpdateData(TRUE)` in a pair of them) and then, if the return value is `FALSE`, doing an early return from the enclosing function.

Fixes #6427 as well as all similar cases in FRED.