### PR TITLE
improve bank-compatibility check

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -20840,7 +20840,7 @@ void sexp_set_weapon(int node, bool primary)
 			return;
 
 		// Be sure it's a valid type
-		if (Weapon_info[windex].subtype != WP_LASER && Weapon_info[windex].subtype != WP_BEAM)
+		if (!Weapon_info[windex].is_primary())
 			return;
 	}
 	else
@@ -20850,7 +20850,7 @@ void sexp_set_weapon(int node, bool primary)
 			return;
 
 		// Be sure it's a valid type
-		if (Weapon_info[windex].subtype != WP_MISSILE)
+		if (!Weapon_info[windex].is_secondary())
 			return;
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10722,7 +10722,7 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 		for ( i = sip->num_primary_banks; i < pm->n_guns; i++ ) {
 			// Make unspecified weapon for bank be a laser
 			for (const auto &weapon_id : Player_weapon_precedence) {
-				if ( (Weapon_info[weapon_id].subtype == WP_LASER) || (Weapon_info[weapon_id].subtype == WP_BEAM) ) {
+				if (Weapon_info[weapon_id].is_primary()) {
 					swp->primary_bank_weapons[i] = weapon_id;
 					break;
 				}
@@ -10743,7 +10743,7 @@ static void ship_set_default_weapons(ship *shipp, ship_info *sip)
 		for ( i = sip->num_secondary_banks; i < pm->n_missiles; i++ ) {
 			// Make unspecified weapon for bank be a missile
 			for (const auto &weapon_id : Player_weapon_precedence) {
-				if (Weapon_info[weapon_id].subtype == WP_MISSILE) {
+				if (Weapon_info[weapon_id].is_secondary()) {
 					swp->secondary_bank_weapons[i] = weapon_id;
 					break;
 				}

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -665,10 +665,13 @@ struct weapon_info
 public:
 	weapon_info();
 
-    inline bool is_homing()        const { return wi_flags[Weapon::Info_Flags::Homing_heat, Weapon::Info_Flags::Homing_aspect, Weapon::Info_Flags::Homing_javelin]; }
-    inline bool is_locked_homing() const { return wi_flags[Weapon::Info_Flags::Homing_aspect, Weapon::Info_Flags::Homing_javelin]; }
-    inline bool hurts_big_ships()  const { return wi_flags[Weapon::Info_Flags::Bomb, Weapon::Info_Flags::Beam, Weapon::Info_Flags::Huge, Weapon::Info_Flags::Big_only]; }
-    inline bool is_interceptable() const { return wi_flags[Weapon::Info_Flags::Fighter_Interceptable, Weapon::Info_Flags::Turret_Interceptable]; }
+    inline bool is_primary()            const { return subtype == WP_LASER || subtype == WP_BEAM; } // either of these is allowed in a primary bank
+    inline bool is_secondary()          const { return subtype == WP_MISSILE; }
+
+    inline bool is_homing()             const { return wi_flags[Weapon::Info_Flags::Homing_heat, Weapon::Info_Flags::Homing_aspect, Weapon::Info_Flags::Homing_javelin]; }
+    inline bool is_locked_homing()      const { return wi_flags[Weapon::Info_Flags::Homing_aspect, Weapon::Info_Flags::Homing_javelin]; }
+    inline bool hurts_big_ships()       const { return wi_flags[Weapon::Info_Flags::Bomb, Weapon::Info_Flags::Beam, Weapon::Info_Flags::Huge, Weapon::Info_Flags::Big_only]; }
+    inline bool is_interceptable()      const { return wi_flags[Weapon::Info_Flags::Fighter_Interceptable, Weapon::Info_Flags::Turret_Interceptable]; }
 
 	const char* get_display_name() const;
 	bool has_display_name() const;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -9768,7 +9768,7 @@ void weapon_spew_stats(WeaponSpewType type)
 	mprintf(("Name,Type,Velocity,Range,Damage Hull,DPS Hull,Damage Shield,DPS Shield,Damage Subsystem,DPS Subsystem,Power Use,Fire Wait,ROF,Reload,1/Reload,Area Effect,Shockwave%s\n", all_weapons ? ",Player Allowed" : ""));
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.subtype != WP_LASER && wi.subtype != WP_BEAM)
+		if (!wi.is_primary())
 			continue;
 
 		if (all_weapons || wi.wi_flags[Weapon::Info_Flags::Player_allowed])
@@ -9852,7 +9852,7 @@ void weapon_spew_stats(WeaponSpewType type)
 	}
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.subtype != WP_MISSILE)
+		if (!wi.is_secondary())
 			continue;
 
 		if (all_weapons || wi.wi_flags[Weapon::Info_Flags::Player_allowed] || wi.wi_flags[Weapon::Info_Flags::Child])
@@ -9912,7 +9912,7 @@ void weapon_spew_stats(WeaponSpewType type)
 	mprintf(("\n"));
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.subtype != WP_LASER && wi.subtype != WP_BEAM)
+		if (!wi.is_primary())
 			continue;
 
 		if (all_weapons || wi.wi_flags[Weapon::Info_Flags::Player_allowed])
@@ -9993,7 +9993,7 @@ void weapon_spew_stats(WeaponSpewType type)
 	}
 	for (auto &wi : Weapon_info)
 	{
-		if (wi.subtype != WP_MISSILE)
+		if (!wi.is_secondary())
 			continue;
 
 		if (all_weapons || wi.wi_flags[Weapon::Info_Flags::Player_allowed] || wi.wi_flags[Weapon::Info_Flags::Child])


### PR DESCRIPTION
1. Don't set the `can_use_for_bank` flag to FALSE if the bank is primary but the weapon is secondary, or vice versa
2. Make sure to only restrict the weapons by bank if the ship has per-bank restrictions

In support of this, add `is_primary()` and `is_secondary()` helper functions to `weapon_info` and use them in logical places.

Follow-up to #6434.  Fixes a few subtle bugs from that PR.