### PR TITLE
several small fixes

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -266,11 +266,11 @@ void parse_hud_gauges_tbl(const char *filename)
 			stuff_int(&Max_escort_ships);
 		}
 
-		if (optional_string("$Length Unit Multiplier:"))	{
+		if (optional_string("$Distance Unit Multiplier:") || optional_string("$Length Unit Multiplier:"))	{
 			stuff_float(&Hud_unit_multiplier);
 
 			if (Hud_unit_multiplier <= 0.0f) {
-				Warning(LOCATION, "\"$Length Unit Multiplier:\" value of \"%f\" is invalid!  Resetting to default.", Hud_unit_multiplier);
+				Warning(LOCATION, "\"$Distance Unit Multiplier:\" (aka \"$Length Unit Multiplier:\") value of \"%f\" is invalid!  Resetting to default.", Hud_unit_multiplier);
 				Hud_unit_multiplier = 1.0f;
 			}
 		}

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1516,13 +1516,10 @@ void brief_check_for_anim(bool api_access, int api_x, int api_y)
 		brief_common_get_icon_dimensions(&iw, &ih, bi);
 
 		// could be a scaled icon
-		if (bi->scale_factor != 1.0f) {
-			iw = static_cast<int>(iw * bi->scale_factor);
-			ih = static_cast<int>(ih * bi->scale_factor);
+		if (bi->scale_factor != 1.0f || Briefing_Icon_Scale_Factor != 1.0f) {
+			iw = static_cast<int>(iw * bi->scale_factor * Briefing_Icon_Scale_Factor);
+			ih = static_cast<int>(ih * bi->scale_factor * Briefing_Icon_Scale_Factor);
 		}
-
-		iw *= Briefing_Icon_Scale_Factor;
-		ih *= Briefing_Icon_Scale_Factor;
 
 		if ( mx < bi->x ) continue;
 		if ( mx > (bi->x + iw) ) continue;

--- a/code/nebula/neblightning.cpp
+++ b/code/nebula/neblightning.cpp
@@ -289,19 +289,20 @@ void parse_lightning_table(const char* filename)
 			// texture
 			if (optional_string("+b_texture:")) {
 				stuff_string(name, F_NAME, sizeof(name));
-				if (!Fred_running) {
+				if (!Fred_running && stricmp(name, "none") && stricmp(name, "<none>")) {
 					bolt_p->texture = bm_load(name);
+					if (bolt_p->texture < 0)
+						error_display(0, "Unable to load texture %s for bolt %s.", name, bolt_p->name);
 				}
 			}
-
-			if (!Fred_running && (bolt_p->texture < 0))
-				error_display(1, "Bolt %s has no texture defined.", bolt_p->name);
 
 			// glow
 			if (optional_string("+b_glow:")) {
 				stuff_string(name, F_NAME, sizeof(name));
-				if (!Fred_running) {
+				if (!Fred_running && stricmp(name, "none") && stricmp(name, "<none>")) {
 					bolt_p->glow = bm_load(name);
+					if (bolt_p->glow < 0)
+						error_display(0, "Unable to load glow %s for bolt %s.", name, bolt_p->name);
 				}
 			}
 

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -1172,7 +1172,7 @@ ADE_FUNC(getWeaponClassIndex, l_Weaponclass, NULL, "Gets the index value of the 
 	return ade_set_args(L, "i", idx + 1);
 }
 
-ADE_FUNC(isLaser, l_Weaponclass, NULL, "Return true if the weapon is a primary weapon (this includes Beams). This function is deprecated, use isPrimary instead.", "boolean", "true if the weapon is a primary, false otherwise")
+ADE_FUNC(isLaser, l_Weaponclass, nullptr, "Return true if the weapon is a 'laser' weapon, which also includes ballistic (ammo-based) weapons.  This also includes most beams, but not necessarily all of them.  See also isPrimary().", "boolean", "true if the weapon is a laser weapon, false otherwise")
 {
 	int idx;
 	if(!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
@@ -1187,7 +1187,7 @@ ADE_FUNC(isLaser, l_Weaponclass, NULL, "Return true if the weapon is a primary w
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(isMissile, l_Weaponclass, NULL, "Return true if the weapon is a secondary weapon. This function is deprecated, use isSecondary instead.", "boolean", "true if the weapon is a secondary, false otherwise")
+ADE_FUNC(isMissile, l_Weaponclass, nullptr, "Return true if the weapon is a 'missile' weapon.  See also isSecondary().", "boolean", "true if the weapon is a missile weapon, false otherwise")
 {
 	int idx;
 	if(!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
@@ -1202,7 +1202,7 @@ ADE_FUNC(isMissile, l_Weaponclass, NULL, "Return true if the weapon is a seconda
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(isPrimary, l_Weaponclass, NULL, "Return true if the weapon is a primary weapon (this includes Beams)", "boolean", "true if the weapon is a primary, false otherwise")
+ADE_FUNC(isPrimary, l_Weaponclass, nullptr, "Return true if the weapon is a primary weapon.  This also includes most beams, but not necessarily all of them.  This function is equivalent to isLaser().", "boolean", "true if the weapon is a primary, false otherwise")
 {
 	int idx;
 	if(!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
@@ -1217,7 +1217,7 @@ ADE_FUNC(isPrimary, l_Weaponclass, NULL, "Return true if the weapon is a primary
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(isSecondary, l_Weaponclass, NULL, "Return true if the weapon is a secondary weapon", "boolean", "true if the weapon is a secondary, false otherwise")
+ADE_FUNC(isSecondary, l_Weaponclass, nullptr, "Return true if the weapon is a secondary weapon.  This function is equivalent to isMissile().", "boolean", "true if the weapon is a secondary, false otherwise")
 {
 	int idx;
 	if(!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
@@ -1232,7 +1232,7 @@ ADE_FUNC(isSecondary, l_Weaponclass, NULL, "Return true if the weapon is a secon
 		return ADE_RETURN_FALSE;
 }
 
-ADE_FUNC(isBeam, l_Weaponclass, NULL, "Return true if the weapon is a beam", "boolean", "true if the weapon is a beam, false otherwise")
+ADE_FUNC(isBeam, l_Weaponclass, nullptr, "Return true if the weapon is a beam", "boolean", "true if the weapon is a beam, false otherwise")
 {
 	int idx;
 	if(!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -971,7 +971,7 @@ ADE_VIRTVAR(BeamLife, l_Weaponclass, "number", "The time in seconds that a beam 
 	if (ADE_SETTING_VAR)
 		LuaError(L, "Setting BeamLife is not supported");
 
-	if (Weapon_info[idx].wi_flags[Weapon::Info_Flags::Beam] || Weapon_info[idx].subtype == WP_BEAM)
+	if (Weapon_info[idx].is_beam())
 		return ade_set_args(L, "f", Weapon_info[idx].b_info.beam_life);
 
 	return ade_set_args(L, "f", 0.0f);
@@ -989,7 +989,7 @@ ADE_VIRTVAR(BeamWarmup, l_Weaponclass, "number", "The time in seconds that a bea
 	if (ADE_SETTING_VAR)
 		LuaError(L, "Setting BeamWarmup is not supported");
 
-	if (Weapon_info[idx].wi_flags[Weapon::Info_Flags::Beam] || Weapon_info[idx].subtype == WP_BEAM)
+	if (Weapon_info[idx].is_beam())
 		return ade_set_args(L, "f", i2fl(Weapon_info[idx].b_info.beam_warmup) / MILLISECONDS_PER_SECOND);
 
 	return ade_set_args(L, "f", 0.0f);
@@ -1007,7 +1007,7 @@ ADE_VIRTVAR(BeamWarmdown, l_Weaponclass, "number", "The time in seconds that a b
 	if (ADE_SETTING_VAR)
 		LuaError(L, "Setting BeamWarmdown is not supported");
 
-	if (Weapon_info[idx].wi_flags[Weapon::Info_Flags::Beam] || Weapon_info[idx].subtype == WP_BEAM)
+	if (Weapon_info[idx].is_beam())
 		return ade_set_args(L, "f", i2fl(Weapon_info[idx].b_info.beam_warmdown) / MILLISECONDS_PER_SECOND);
 
 	return ade_set_args(L, "f", 0.0f);
@@ -1217,6 +1217,21 @@ ADE_FUNC(isPrimary, l_Weaponclass, nullptr, "Return true if the weapon is a prim
 		return ADE_RETURN_FALSE;
 }
 
+ADE_FUNC(isNonBeamPrimary, l_Weaponclass, nullptr, "Return true if the weapon is a primary weapon that is not a beam.", "boolean", "true if the weapon is a non-beam primary, false otherwise")
+{
+	int idx;
+	if(!ade_get_args(L, "o", l_Weaponclass.Get(&idx)))
+		return ADE_RETURN_NIL;
+
+	if(idx < 0 || idx >= weapon_info_size())
+		return ADE_RETURN_FALSE;
+
+	if (Weapon_info[idx].is_non_beam_primary())
+		return ADE_RETURN_TRUE;
+	else
+		return ADE_RETURN_FALSE;
+}
+
 ADE_FUNC(isSecondary, l_Weaponclass, nullptr, "Return true if the weapon is a secondary weapon.  This function is equivalent to isMissile().", "boolean", "true if the weapon is a secondary, false otherwise")
 {
 	int idx;
@@ -1241,7 +1256,7 @@ ADE_FUNC(isBeam, l_Weaponclass, nullptr, "Return true if the weapon is a beam", 
 	if(idx < 0 || idx >= weapon_info_size())
 		return ADE_RETURN_FALSE;
 
-	if (Weapon_info[idx].wi_flags[Weapon::Info_Flags::Beam] || Weapon_info[idx].subtype == WP_BEAM)
+	if (Weapon_info[idx].is_beam())
 		return ADE_RETURN_TRUE;
 	else
 		return ADE_RETURN_FALSE;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14574,7 +14574,8 @@ int get_available_secondary_weapons(object *objp, int *outlist, int *outbanklist
 				weapon_range_max = wepp->weapon_range;
 				//If weapon range is not set in the weapon info, derive it
 				if (weapon_range_max >= WEAPON_DEFAULT_TABLED_MAX_RANGE) {
-					if (wepp->subtype == WP_BEAM) {
+					if (wepp->is_beam()) {
+						UNREACHABLE("Since when do we have a beam that is a secondary weapon?");
 						weapon_range_max = wepp->b_info.range;
 					}
 					else {

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -36,10 +36,12 @@
 class object;
 class ship_subsys;
 
-#define	WP_UNUSED			-1
-#define	WP_LASER			0		// PLEASE NOTE that this flag specifies ballistic primaries as well - Goober5000
-#define	WP_MISSILE			1
-#define	WP_BEAM				2
+#define WP_UNUSED    -1
+#define WP_LASER     0		// PLEASE NOTE that this flag specifies ballistic primaries as well - Goober5000
+#define WP_MISSILE   1
+#define WP_BEAM      2		// This is only set for beams in the #Beam Weapons section.  Many beams are found in the #Primary Weapons section and therefore have the subtype WP_LASER.
+                      		// Use the Weapon_Info::Beam flag or .is_beam() to properly check whether a weapon is a beam.
+
 extern const char *Weapon_subtype_names[];
 extern int Num_weapon_subtypes;
 
@@ -667,6 +669,8 @@ public:
 
     inline bool is_primary()            const { return subtype == WP_LASER || subtype == WP_BEAM; } // either of these is allowed in a primary bank
     inline bool is_secondary()          const { return subtype == WP_MISSILE; }
+    inline bool is_beam()               const { return subtype == WP_BEAM || wi_flags[Weapon::Info_Flags::Beam]; }
+    inline bool is_non_beam_primary()   const { return subtype == WP_LASER && !wi_flags[Weapon::Info_Flags::Beam]; }
 
     inline bool is_homing()             const { return wi_flags[Weapon::Info_Flags::Homing_heat, Weapon::Info_Flags::Homing_aspect, Weapon::Info_Flags::Homing_javelin]; }
     inline bool is_locked_homing()      const { return wi_flags[Weapon::Info_Flags::Homing_aspect, Weapon::Info_Flags::Homing_javelin]; }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -4060,48 +4060,41 @@ void weapon_sort_by_type()
 	// allocate the buckets
 	if (num_lasers) {
 		lasers = new weapon_info[num_lasers];
-		Verify( lasers != NULL );
 		num_lasers = 0;
 	}
 
 	if (num_big_lasers) {
 		big_lasers = new weapon_info[num_big_lasers];
-		Verify( big_lasers != NULL );
 		num_big_lasers = 0;
 	}
 
 	if (num_beams) {
 		beams = new weapon_info[num_beams];
-		Verify( beams != NULL );
 		num_beams = 0;
 	}
 
 	if (num_missiles) {
 		missiles = new weapon_info[num_missiles];
-		Verify( missiles != NULL );
 		num_missiles = 0;
 	}
 
 	if (num_big_missiles) {
 		big_missiles = new weapon_info[num_big_missiles];
-		Verify( big_missiles != NULL );
 		num_big_missiles = 0;
 	}
 
 	if (num_child_primaries) {
 		child_primaries = new weapon_info[num_child_primaries];
-		Verify( child_primaries != NULL );
 		num_child_primaries = 0;
 	}
 
 	if (num_child_secondaries) {
 		child_secondaries = new weapon_info[num_child_secondaries];
-		Verify( child_secondaries != NULL );
 		num_child_secondaries = 0;
 	}
 
 	// fill the buckets
-	for (const auto& wi : Weapon_info) {
+	for (auto& wi : Weapon_info) {
 		switch (wi.subtype)
 		{
 			case WP_UNUSED:
@@ -4109,26 +4102,26 @@ void weapon_sort_by_type()
 
 			case WP_LASER:
 				if (wi.wi_flags[Weapon::Info_Flags::Beam])      // many beams are found in the laser section
-					beams[num_beams++] = wi;
+					beams[num_beams++] = std::move(wi);
 				else if (wi.wi_flags[Weapon::Info_Flags::Child])
-					child_primaries[num_child_primaries++] = wi;
+					child_primaries[num_child_primaries++] = std::move(wi);
 				else if (wi.wi_flags[Weapon::Info_Flags::Big_only])
-					big_lasers[num_big_lasers++] = wi;
+					big_lasers[num_big_lasers++] = std::move(wi);
 				else
-					lasers[num_lasers++] = wi;
+					lasers[num_lasers++] = std::move(wi);
 				break;
 		
 			case WP_BEAM:
-				beams[num_beams++] = wi;
+				beams[num_beams++] = std::move(wi);
 				break;
 
 			case WP_MISSILE:
 				if (wi.wi_flags[Weapon::Info_Flags::Child])
-					child_secondaries[num_child_secondaries++] = wi;
+					child_secondaries[num_child_secondaries++] = std::move(wi);
 				else if (wi.wi_flags[Weapon::Info_Flags::Big_only])
-					big_missiles[num_big_missiles++] = wi;
+					big_missiles[num_big_missiles++] = std::move(wi);
 				else
-					missiles[num_missiles++] = wi;
+					missiles[num_missiles++] = std::move(wi);
 				break;
 
 			default:
@@ -4140,28 +4133,28 @@ void weapon_sort_by_type()
 
 	// reorder the weapon_info structure according to our rules defined above
 	for (size_t i = 0; i < num_lasers; i++, weapon_index++)
-		Weapon_info[weapon_index] = lasers[i];
+		Weapon_info[weapon_index] = std::move(lasers[i]);
 
 	for (size_t i = 0; i < num_big_lasers; i++, weapon_index++)
-		Weapon_info[weapon_index] = big_lasers[i];
+		Weapon_info[weapon_index] = std::move(big_lasers[i]);
 
 	for (size_t i = 0; i < num_beams; i++, weapon_index++)
-		Weapon_info[weapon_index] = beams[i];
+		Weapon_info[weapon_index] = std::move(beams[i]);
 
 	for (size_t i = 0; i < num_child_primaries; i++, weapon_index++)
-		Weapon_info[weapon_index] = child_primaries[i];
+		Weapon_info[weapon_index] = std::move(child_primaries[i]);
 
 	// designate start of secondary weapons so that we'll have the correct offset later on
 	First_secondary_index = weapon_index;
 
 	for (size_t i = 0; i < num_missiles; i++, weapon_index++)
-		Weapon_info[weapon_index] = missiles[i];
+		Weapon_info[weapon_index] = std::move(missiles[i]);
 
 	for (size_t i = 0; i < num_big_missiles; i++, weapon_index++)
-		Weapon_info[weapon_index] = big_missiles[i];
+		Weapon_info[weapon_index] = std::move(big_missiles[i]);
 
 	for (size_t i = 0; i < num_child_secondaries; i++, weapon_index++)
-		Weapon_info[weapon_index] = child_secondaries[i];
+		Weapon_info[weapon_index] = std::move(child_secondaries[i]);
 
 
 	if (lasers)			delete [] lasers;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2204,6 +2204,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			using namespace particle;
 
 			// Only beams do this randomization
+			// NOTE: in practice, most beams are WP_LASER and do not do this
 			if (subtype == WP_BEAM)
 			{
 				// The original formula is (1.2f + 0.007f * (float)(rand() % 100)) which generates values within [1.2, 1.9)
@@ -2268,6 +2269,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 				using namespace particle;
 
 				// Only beams do this randomization
+				// NOTE: in practice, most beams are WP_LASER and do not do this
 				if (subtype == WP_BEAM)
 				{
 					// The original formula is (1.2f + 0.007f * (float)(rand() % 100)) which generates values within [1.2, 1.9)
@@ -4026,7 +4028,9 @@ void weapon_sort_by_type()
 				continue;
 
 			case WP_LASER:
-				if (wi.wi_flags[Weapon::Info_Flags::Child])
+				if (wi.wi_flags[Weapon::Info_Flags::Beam])      // many beams are found in the laser section
+					num_beams++;
+				else if (wi.wi_flags[Weapon::Info_Flags::Child])
 					num_child_primaries++;
 				else if (wi.wi_flags[Weapon::Info_Flags::Big_only])
 					num_big_lasers++;
@@ -4104,7 +4108,9 @@ void weapon_sort_by_type()
 				continue;
 
 			case WP_LASER:
-				if (wi.wi_flags[Weapon::Info_Flags::Child])
+				if (wi.wi_flags[Weapon::Info_Flags::Beam])      // many beams are found in the laser section
+					beams[num_beams++] = wi;
+				else if (wi.wi_flags[Weapon::Info_Flags::Child])
 					child_primaries[num_child_primaries++] = wi;
 				else if (wi.wi_flags[Weapon::Info_Flags::Big_only])
 					big_lasers[num_big_lasers++] = wi;


### PR DESCRIPTION
A potpourri of tweaks based on several recent requests for mod support.

1. allow `$Distance Unit Multiplier:` as a synonym for `$Length Unit Multiplier:`
2. enhance help text for script functions that do weapon category checks
3. fix distinction between lasers and beams in several places
4. clean up `weapon_sort_by_type()` by removing unnecessary `Verify`s and using `std::move` for sorting
5. fix compile warnings for briefing icon scaling
6. fix lightning bolt texture checks, needed for TBP

Each item is self-contained in its own commit.