### PR TITLE
fix ship:warpIn() behavior for docked ships

### DIFF
--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -844,6 +844,15 @@ void object_remove_arriving_stage2_ndl_flag_helper(object *objp, dock_function_i
 		Ships[objp->instance].flags.remove(Ship::Ship_Flags::Arriving_stage_2_dock_follower);
 }
 
+void dock_find_dock_leader_helper(object *objp, dock_function_info *infop)
+{
+	if (Ships[objp->instance].flags[Ship::Ship_Flags::Dock_leader])
+	{
+		infop->maintained_variables.objp_value = objp;
+		infop->early_return_condition = true;
+	}
+}
+
 void dock_calc_total_moi_helper(object* objp, dock_function_info* infop)
 {
 	matrix local_moi, unorient, temp, world_moi;

--- a/code/object/objectdock.h
+++ b/code/object/objectdock.h
@@ -152,4 +152,7 @@ void object_remove_arriving_stage1_ndl_flag_helper(object *objp, dock_function_i
 void object_set_arriving_stage2_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ );
 void object_remove_arriving_stage2_ndl_flag_helper(object *objp, dock_function_info * /*infop*/ );
 
+// find any ship in this group that is the dock leader
+void dock_find_dock_leader_helper(object *objp, dock_function_info *infop);
+
 #endif	// _OBJECT_DOCK_H

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -2104,6 +2104,17 @@ ADE_FUNC(warpIn, l_Ship, NULL, "Warps ship in", "boolean", "True if successful, 
 	if(!objh->isValid())
 		return ADE_RETURN_NIL;
 
+	if (object_is_docked(objh->objp()))
+	{
+		// Ships that are docked need a designated dock leader to bring the entire group in.  The dock leader is, de facto, the arriving ship;
+		// so by scripting a certain ship to warp in, the script author has designated it as the leader.  That being said, if the script
+		// calls warpIn() multiple times on the same docked group, only set the flag on the first ship.
+		dock_function_info dfi;
+		dock_evaluate_all_docked_objects(objh->objp(), &dfi, dock_find_dock_leader_helper);
+		if (!dfi.maintained_variables.objp_value)
+			Ships[objh->objp()->instance].flags.set(Ship::Ship_Flags::Dock_leader);
+	}
+
 	shipfx_warpin_start(objh->objp());
 
 	return ADE_RETURN_TRUE;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -480,10 +480,11 @@ void shipfx_actually_warpin(ship *shipp, object *objp)
 
 	// dock leader needs to handle dockees
 	if (object_is_docked(objp)) {
-		Assertion(shipp->flags[Ship::Ship_Flags::Dock_leader], "The docked ship warping in (%s) should only be the dock leader at this point!\n", shipp->ship_name);
+		Assertion(shipp->flags[Ship::Ship_Flags::Dock_leader], "The docked ship warping in (%s) should be the dock leader at this point!\n", shipp->ship_name);
 		dock_function_info dfi;
 		dock_evaluate_all_docked_objects(objp, &dfi, object_remove_arriving_stage1_ndl_flag_helper);
 		dock_evaluate_all_docked_objects(objp, &dfi, object_remove_arriving_stage2_ndl_flag_helper);
+		shipp->flags.remove(Ship::Ship_Flags::Dock_leader);	// the dock leader flag is only used for arrival and could interfere with future scripted warpIn() calls
 	}
 
 	// let physics in on it too.
@@ -527,7 +528,6 @@ void shipfx_warpin_start( object *objp )
 	if (shipp->is_arriving())
 	{
 		mprintf(( "Ship '%s' is already arriving!\n", shipp->ship_name ));
-		Int3();
 		return;
 	}
 


### PR DESCRIPTION
As described in #6445, the `warpIn()` script function did not work correctly for docked ships because the dock leader flag was not set.  So, set the flag, but make sure to set it only for the first ship for which `warpIn()` is called.  And make sure the flag is removed after the ship finishes arriving.

Also remove an `Int3()` in `shipfx_warpin_start()`.  (This Int3() was not actually in the original Volition source code release.)

Fixes #6445.