### PR TITLE
Beam cycle fix

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12876,6 +12876,9 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				} else if (firing_pattern != FiringPattern::STANDARD) {
 					shot_count = winfo_p->cycle_multishot;
 					point_count = MIN(num_slots, winfo_p->shots);
+				} else if (winfo_p->b_info.beam_shots) {
+					shot_count = winfo_p->shots;
+					point_count = MIN(winfo_p->b_info.beam_shots, num_slots);
 				} else {
 					shot_count = winfo_p->shots;
 					point_count = num_slots;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12898,37 +12898,44 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 				for (int pt_count = 0; pt_count < point_count; pt_count++) {
 					int pt;
-					switch (firing_pattern) {
-						case FiringPattern::CYCLE_FORWARD: {
-							pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]++;
-							if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
-								swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
+					if (!sip->flags[Ship::Info_Flags::Dyn_primary_linking] && winfo_p->b_info.beam_shots) {
+						pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]++;
+						if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
+							swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
+						}
+					} else {
+						switch (firing_pattern) {
+							case FiringPattern::CYCLE_FORWARD: {
+								pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]++;
+								if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
+									swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
+								}
+								break;
 							}
-							break;
-						}
-						case FiringPattern::CYCLE_REVERSE: {
-							pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]--;
-							if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] < 0) {
-								swp->primary_firepoint_next_to_fire_index[bank_to_fire] = num_slots - 1;
+							case FiringPattern::CYCLE_REVERSE: {
+								pt = swp->primary_firepoint_next_to_fire_index[bank_to_fire]--;
+								if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] < 0) {
+									swp->primary_firepoint_next_to_fire_index[bank_to_fire] = num_slots - 1;
+								}
+								break;
 							}
-							break;
-						}
-						case FiringPattern::RANDOM_EXHAUSTIVE: {
-							pt = swp->primary_firepoint_indices[bank_to_fire][swp->primary_firepoint_next_to_fire_index[bank_to_fire]++];
-							if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
-								swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
+							case FiringPattern::RANDOM_EXHAUSTIVE: {
+								pt = swp->primary_firepoint_indices[bank_to_fire][swp->primary_firepoint_next_to_fire_index[bank_to_fire]++];
+								if (swp->primary_firepoint_next_to_fire_index[bank_to_fire] >= num_slots) {
+									swp->primary_firepoint_next_to_fire_index[bank_to_fire] = 0;
+								}
+								break;
 							}
-							break;
-						}
-						case FiringPattern::RANDOM_NONREPEATING: // behaves the same as random repeating here
-						case FiringPattern::RANDOM_REPEATING: {
-							pt = swp->primary_firepoint_indices[bank_to_fire][pt_count];
-							break;
-						}
-						default:
-						case FiringPattern::STANDARD: {
-							pt = pt_count;
-							break;
+							case FiringPattern::RANDOM_NONREPEATING: // behaves the same as random repeating here
+							case FiringPattern::RANDOM_REPEATING: {
+								pt = swp->primary_firepoint_indices[bank_to_fire][pt_count];
+								break;
+							}
+							default:
+							case FiringPattern::STANDARD: {
+								pt = pt_count;
+								break;
+							}
 						}
 					}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12873,12 +12873,12 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 				if (sip->flags[Ship::Info_Flags::Dyn_primary_linking]) {
 					shot_count = winfo_p->cycle_multishot;
 					point_count = MIN(num_slots, swp->primary_bank_slot_count[bank_to_fire] );
-				} else if (firing_pattern != FiringPattern::STANDARD) {
-					shot_count = winfo_p->cycle_multishot;
-					point_count = MIN(num_slots, winfo_p->shots);
 				} else if (winfo_p->b_info.beam_shots) {
 					shot_count = winfo_p->shots;
 					point_count = MIN(winfo_p->b_info.beam_shots, num_slots);
+				} else if (firing_pattern != FiringPattern::STANDARD) {
+					shot_count = winfo_p->cycle_multishot;
+					point_count = MIN(num_slots, winfo_p->shots);
 				} else {
 					shot_count = winfo_p->shots;
 					point_count = num_slots;


### PR DESCRIPTION
In #6364, I overlooked a behavior where type 3 beams do firepoint cycling automatically. This is now fixed. Dynamic primary linking will now override type 3 (where before #6364, I believe, it just didn't work for beams at all), but type 3 will override firing patterns, to remain consistent with the previous behavior where type 3 was higher priority than the 'cycle' flag.

As it stands this is a bit ugly. I might want to come back later and clean up some of the control flow, for example by making it so that a type 3 beam will have firing pattern CYCLE FORWARD by default, and we can ditch some of the special casing. But this'll fix the problem for now.