### PR TITLE
Allow per-stage briefing grid colors

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1878,18 +1878,18 @@ void gr_set_color_fast(const color *dst)
 }
 
 //Compares the RGBA values of two colors. Returns true if the colors are identical
-bool gr_compare_color_values(color* clr1, color* clr2)
+bool gr_compare_color_values(const color& clr1, const color& clr2)
 {
-	if (clr1->red != clr2->red) {
+	if (clr1.red != clr2.red) {
 		return false;
 	}
-	if (clr1->green != clr2->green) {
+	if (clr1.green != clr2.green) {
 		return false;
 	}
-	if (clr1->blue != clr2->blue) {
+	if (clr1.blue != clr2.blue) {
 		return false;
 	}
-	if (clr1->alpha != clr2->alpha) {
+	if (clr1.alpha != clr2.alpha) {
 		return false;
 	}
 	return true;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1877,6 +1877,24 @@ void gr_set_color_fast(const color *dst)
 	gr_screen.current_color = *dst;
 }
 
+//Compares the RGBA values of two colors. Returns true if the colors are identical
+bool gr_compare_color_values(color* clr1, color* clr2)
+{
+	if (clr1->red != clr2->red) {
+		return false;
+	}
+	if (clr1->green != clr2->green) {
+		return false;
+	}
+	if (clr1->blue != clr2->blue) {
+		return false;
+	}
+	if (clr1->alpha != clr2->alpha) {
+		return false;
+	}
+	return true;
+}
+
 // shader functions
 void gr_create_shader(shader *shade, ubyte r, ubyte g, ubyte b, ubyte c )
 {

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1311,7 +1311,7 @@ void gr_init_color(color *c, int r, int g, int b);
 void gr_init_alphacolor( color *clr, int r, int g, int b, int alpha, int type = AC_TYPE_HUD );
 void gr_set_color( int r, int g, int b );
 void gr_set_color_fast(const color *dst);
-bool gr_compare_color_values(color* clr1, color* clr2);
+bool gr_compare_color_values(const color& clr1, const color& clr2);
 
 // shader functions
 void gr_create_shader(shader *shade, ubyte r, ubyte g, ubyte b, ubyte c);

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1311,6 +1311,7 @@ void gr_init_color(color *c, int r, int g, int b);
 void gr_init_alphacolor( color *clr, int r, int g, int b, int alpha, int type = AC_TYPE_HUD );
 void gr_set_color( int r, int g, int b );
 void gr_set_color_fast(const color *dst);
+bool gr_compare_color_values(color* clr1, color* clr2);
 
 // shader functions
 void gr_create_shader(shader *shade, ubyte r, ubyte g, ubyte b, ubyte c);

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -2281,13 +2281,13 @@ grid *brief_create_default_grid(void)
 /**
  * Rotate and project points and draw a line.
  */
-void brief_rpd_line(vec3d *v0, vec3d *v1, color* color)
+void brief_rpd_line(vec3d *v0, vec3d *v1, color* clr)
 {
 	vertex	tv0, tv1;
 	g3_rotate_vertex(&tv0, v0);
 	g3_rotate_vertex(&tv1, v1);
 
-	gr_set_color_fast(color);
+	gr_set_color_fast(clr);
 	g3_draw_line(&tv0, &tv1);
 }
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -284,9 +284,9 @@ void	brief_render_icons(int stage_num, float frametime);
 void	brief_maybe_create_new_grid(grid *gridp, vec3d *pos, matrix *orient, int force = 0);
 grid	*brief_create_grid(grid *gridp, vec3d *forward, vec3d *right, vec3d *center, int nrows, int ncols, float square_size);
 grid	*brief_create_default_grid(void);
-void	brief_render_grid(grid *gridp, color* color);
+void	brief_render_grid(grid *gridp, const color& color);
 void	brief_modify_grid(grid *gridp);
-void	brief_rpd_line(vec3d *v0, vec3d *v1, color* color);
+void	brief_rpd_line(vec3d *v0, vec3d *v1, const color& color);
 void	brief_set_text_color(char color_tag);
 extern void get_camera_limits(const matrix *start_camera, const matrix *end_camera, float time, vec3d *acc_max, vec3d *w_max);
 int brief_text_wipe_finished();
@@ -1319,7 +1319,7 @@ void brief_render_map(int stage_num, float frametime)
 	brief_maybe_create_new_grid(The_grid, &Current_cam_pos, &Current_cam_orient);
 
 	if (Briefing->stages[stage_num].draw_grid)
-		brief_render_grid(The_grid, &Briefing->stages[stage_num].grid_color);
+		brief_render_grid(The_grid, Briefing->stages[stage_num].grid_color);
 
 	brief_render_fade_outs(frametime);
 
@@ -2281,13 +2281,13 @@ grid *brief_create_default_grid(void)
 /**
  * Rotate and project points and draw a line.
  */
-void brief_rpd_line(vec3d *v0, vec3d *v1, color* clr)
+void brief_rpd_line(vec3d *v0, vec3d *v1, const color& clr)
 {
 	vertex	tv0, tv1;
 	g3_rotate_vertex(&tv0, v0);
 	g3_rotate_vertex(&tv1, v1);
 
-	gr_set_color_fast(clr);
+	gr_set_color_fast(&clr);
 	g3_draw_line(&tv0, &tv1);
 }
 
@@ -2296,7 +2296,7 @@ void brief_rpd_line(vec3d *v0, vec3d *v1, color* clr)
  *
  * @param gridp Grid defined in a grid struct to render
  */
-void brief_render_grid(grid *gridp, color* gridc)
+void brief_render_grid(grid *gridp, const color& gridc)
 {
 	int	i, ncols, nrows;
 

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -284,9 +284,9 @@ void	brief_render_icons(int stage_num, float frametime);
 void	brief_maybe_create_new_grid(grid *gridp, vec3d *pos, matrix *orient, int force = 0);
 grid	*brief_create_grid(grid *gridp, vec3d *forward, vec3d *right, vec3d *center, int nrows, int ncols, float square_size);
 grid	*brief_create_default_grid(void);
-void	brief_render_grid(grid *gridp);
+void	brief_render_grid(grid *gridp, color* color);
 void	brief_modify_grid(grid *gridp);
-void	brief_rpd_line(vec3d *v0, vec3d *v1);
+void	brief_rpd_line(vec3d *v0, vec3d *v1, color* color);
 void	brief_set_text_color(char color_tag);
 extern void get_camera_limits(const matrix *start_camera, const matrix *end_camera, float time, vec3d *acc_max, vec3d *w_max);
 int brief_text_wipe_finished();
@@ -1319,7 +1319,7 @@ void brief_render_map(int stage_num, float frametime)
 	brief_maybe_create_new_grid(The_grid, &Current_cam_pos, &Current_cam_orient);
 
 	if (Briefing->stages[stage_num].draw_grid)
-		brief_render_grid(The_grid);
+		brief_render_grid(The_grid, &Briefing->stages[stage_num].grid_color);
 
 	brief_render_fade_outs(frametime);
 
@@ -2281,13 +2281,13 @@ grid *brief_create_default_grid(void)
 /**
  * Rotate and project points and draw a line.
  */
-void brief_rpd_line(vec3d *v0, vec3d *v1)
+void brief_rpd_line(vec3d *v0, vec3d *v1, color* color)
 {
 	vertex	tv0, tv1;
 	g3_rotate_vertex(&tv0, v0);
 	g3_rotate_vertex(&tv1, v1);
 
-	gr_set_color_fast(&Color_briefing_grid);
+	gr_set_color_fast(color);
 	g3_draw_line(&tv0, &tv1);
 }
 
@@ -2296,7 +2296,7 @@ void brief_rpd_line(vec3d *v0, vec3d *v1)
  *
  * @param gridp Grid defined in a grid struct to render
  */
-void brief_render_grid(grid *gridp)
+void brief_render_grid(grid *gridp, color* gridc)
 {
 	int	i, ncols, nrows;
 
@@ -2312,11 +2312,11 @@ void brief_render_grid(grid *gridp)
 
 	//	Draw the column lines.
 	for (i=0; i<=ncols; i++)
-		brief_rpd_line(&gridp->gpoints1[i], &gridp->gpoints2[i]);
+		brief_rpd_line(&gridp->gpoints1[i], &gridp->gpoints2[i], gridc);
 
 	//	Draw the row lines.
 	for (i=0; i<=nrows; i++)
-		brief_rpd_line(&gridp->gpoints3[i], &gridp->gpoints4[i]);
+		brief_rpd_line(&gridp->gpoints3[i], &gridp->gpoints4[i], gridc);
 }
 
 void brief_modify_grid(grid *gridp)

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -164,7 +164,7 @@ public:
 	color		grid_color;
 
 	brief_stage( ) 
-		: text( ), camera_time( 0 ), flags( 0 ), formula( -1 ), num_icons(0), icons(nullptr), num_lines(0), lines(nullptr),
+		: camera_time( 0 ), flags( 0 ), formula( -1 ), num_icons(0), icons(nullptr), num_lines(0), lines(nullptr),
 		  draw_grid(true)
 	{ 
 		voice[ 0 ] = 0;

--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -13,6 +13,7 @@
 #define __MISSIONBRIEFCOMMON_H__
 
 #include "globalincs/globals.h"
+#include "globalincs/alphacolors.h"
 
 #include "anim/packunpack.h"
 #include "graphics/generic.h"
@@ -160,14 +161,16 @@ public:
 	int			num_lines;
 	brief_line	*lines;
 	bool		draw_grid;
+	color		grid_color;
 
 	brief_stage( ) 
-		: text( ), camera_time( 0 ), flags( 0 ), formula( -1 ), num_icons(0), icons(NULL), num_lines(0), lines(NULL),
-		  draw_grid( true )
+		: text( ), camera_time( 0 ), flags( 0 ), formula( -1 ), num_icons(0), icons(nullptr), num_lines(0), lines(nullptr),
+		  draw_grid(true)
 	{ 
 		voice[ 0 ] = 0;
 		camera_pos = vmd_zero_vector;
 		camera_orient = vmd_identity_matrix;
+		grid_color = Color_briefing_grid;
 	}
 };
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -9063,3 +9063,15 @@ bool check_for_24_1_data()
 
 	return false;
 }
+
+bool check_for_25_0_data()
+{
+	for (int i = 0; i < Num_teams; i++) {
+		for (int j = 0; j < Briefings[i].num_stages; i++) {
+			if (!gr_compare_color_values(Briefings[i].stages[j].grid_color, Color_briefing_grid)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -9064,7 +9064,7 @@ bool check_for_24_1_data()
 	return false;
 }
 
-bool check_for_25_0_data()
+bool check_for_24_3_data()
 {
 	for (int i = 0; i < Num_teams; i++) {
 		for (int j = 0; j < Briefings[i].num_stages; i++) {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -9057,17 +9057,14 @@ bool check_for_24_1_data()
 		}
 	}
 
-	if ((Asteroid_field.debris_genre == DG_DEBRIS && !Asteroid_field.field_debris_type.empty()) ||
-		(Asteroid_field.debris_genre == DG_ASTEROID && !Asteroid_field.field_asteroid_type.empty()))
-		return true;
-
-	return false;
+	return (Asteroid_field.debris_genre == DG_DEBRIS && !Asteroid_field.field_debris_type.empty()) ||
+		   (Asteroid_field.debris_genre == DG_ASTEROID && !Asteroid_field.field_asteroid_type.empty());
 }
 
 bool check_for_24_3_data()
 {
 	for (int i = 0; i < Num_teams; i++) {
-		for (int j = 0; j < Briefings[i].num_stages; i++) {
+		for (int j = 0; j < Briefings[i].num_stages; j++) {
 			if (!gr_compare_color_values(Briefings[i].stages[j].grid_color, Color_briefing_grid)) {
 				return true;
 			}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1516,6 +1516,14 @@ void parse_briefing(mission * /*pm*/, int flags)
 			if (optional_string("$no_grid"))
 				bs->draw_grid = false;
 
+			if (optional_string("$grid_color:")) {
+				int rgba[4] = {0, 0, 0, 0};
+				stuff_int_list(rgba, 4, RAW_INTEGER_TYPE);
+				gr_init_alphacolor(&bs->grid_color, rgba[0], rgba[1], rgba[2], rgba[3]);
+			} else {
+				bs->grid_color = Color_briefing_grid;
+			}
+
 			if ( optional_string("$num_lines:") ) {
 				stuff_int(&bs->num_lines);
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -57,7 +57,7 @@ extern const gameversion::version LEGACY_MISSION_VERSION;
 // a "soft version bump" rather than a hard bump because not all missions are affected.
 extern bool check_for_23_3_data();
 extern bool check_for_24_1_data();
-extern bool check_for_25_0_data();
+extern bool check_for_24_3_data();
 
 #define WING_PLAYER_BASE	0x80000  // used by Fred to tell ship_index in a wing points to a player
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -57,6 +57,7 @@ extern const gameversion::version LEGACY_MISSION_VERSION;
 // a "soft version bump" rather than a hard bump because not all missions are affected.
 extern bool check_for_23_3_data();
 extern bool check_for_24_1_data();
+extern bool check_for_25_0_data();
 
 #define WING_PLAYER_BASE	0x80000  // used by Fred to tell ship_index in a wing points to a player
 

--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -17,6 +17,7 @@
 #include "mission/missionparse.h"
 #include "FredRender.h"
 #include "Management.h"
+#include "globalincs/alphacolors.h"
 #include "globalincs/linklist.h"
 #include "MainFrm.h"
 #include "bmpman/bmpman.h"
@@ -934,6 +935,7 @@ void briefing_editor_dlg::copy_stage(int from, int to)
 		Briefing->stages[to].camera_time = 500;
 		Briefing->stages[to].num_icons = 0;
 		Briefing->stages[to].formula = Locked_sexp_true;
+		Briefing->stages[to].grid_color = Color_briefing_grid;
 		return;
 	}
 
@@ -947,6 +949,8 @@ void briefing_editor_dlg::copy_stage(int from, int to)
 	Briefing->stages[to].num_icons = Briefing->stages[from].num_icons;
 	Briefing->stages[to].num_lines = Briefing->stages[from].num_lines;
 	Briefing->stages[to].formula = Briefing->stages[from].formula;
+	// For now let's just always set this back to default. Eventually when we have a UI color picker in qtFRED, we can copy from stage to stage
+	Briefing->stages[to].grid_color = Color_briefing_grid;
 
 	memmove( Briefing->stages[to].icons, Briefing->stages[from].icons, sizeof(brief_icon)*MAX_STAGE_ICONS );
 	memmove( Briefing->stages[to].lines, Briefing->stages[from].lines, sizeof(brief_line)*MAX_BRIEF_STAGE_LINES );

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3158,16 +3158,16 @@ void CFred_mission_save::save_mission_internal(const char *pathname)
 	// Additional incremental version update for some features
 	auto version_23_3 = gameversion::version(23, 3);
 	auto version_24_1 = gameversion::version(24, 1);
-	auto version_25_0 = gameversion::version(25, 0);
-	if (MISSION_VERSION >= version_25_0)
+	auto version_24_3 = gameversion::version(24, 3);
+	if (MISSION_VERSION >= version_24_3)
 	{
-		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 25.0, the check_for_25_0_data(), the check_for_24_1_data() and check_for_23_3_data() code can be removed");
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 24.3, the check_for_24_3_data(), the check_for_24_1_data() and check_for_23_3_data() code can be removed");
 	}
-	else if (check_for_25_0_data())
+	else if (check_for_24_3_data())
 	{
-		The_mission.required_fso_version = version_25_0;
+		The_mission.required_fso_version = version_24_3;
 	}
-	if (MISSION_VERSION >= version_24_1)
+	else if (MISSION_VERSION >= version_24_1)
 	{
 		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 24.1, the check_for_24_1_data() and check_for_23_3_data() code can be removed");
 	}

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1135,7 +1135,7 @@ int CFred_mission_save::save_briefing()
 				}
 			}
 
-			if (!gr_compare_color_values(&bs->grid_color, &Color_briefing_grid)) {
+			if (!gr_compare_color_values(bs->grid_color, Color_briefing_grid)) {
 				if (Mission_save_format != FSO_FORMAT_RETAIL) {
 					fout("\n$grid_color:");
 					fout("(%d, %d, %d, %d)", bs->grid_color.red, bs->grid_color.green, bs->grid_color.blue, bs->grid_color.alpha);

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -25,6 +25,7 @@
 #include "asteroid/asteroid.h"
 #include "cfile/cfile.h"
 #include "gamesnd/eventmusic.h"
+#include "globalincs/alphacolors.h"
 #include "globalincs/linklist.h"
 #include "globalincs/version.h"
 #include "hud/hudsquadmsg.h"
@@ -1131,6 +1132,13 @@ int CFred_mission_save::save_briefing()
 			if (!bs->draw_grid) {
 				if (Mission_save_format != FSO_FORMAT_RETAIL) {
 					fout("\n$no_grid");
+				}
+			}
+
+			if (!gr_compare_color_values(&bs->grid_color, &Color_briefing_grid)) {
+				if (Mission_save_format != FSO_FORMAT_RETAIL) {
+					fout("\n$grid_color:");
+					fout("(%d, %d, %d, %d)", bs->grid_color.red, bs->grid_color.green, bs->grid_color.blue, bs->grid_color.alpha);
 				}
 			}
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3158,6 +3158,15 @@ void CFred_mission_save::save_mission_internal(const char *pathname)
 	// Additional incremental version update for some features
 	auto version_23_3 = gameversion::version(23, 3);
 	auto version_24_1 = gameversion::version(24, 1);
+	auto version_25_0 = gameversion::version(25, 0);
+	if (MISSION_VERSION >= version_25_0)
+	{
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 25.0, the check_for_25_0_data(), the check_for_24_1_data() and check_for_23_3_data() code can be removed");
+	}
+	else if (check_for_25_0_data())
+	{
+		The_mission.required_fso_version = version_25_0;
+	}
 	if (MISSION_VERSION >= version_24_1)
 	{
 		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 24.1, the check_for_24_1_data() and check_for_23_3_data() code can be removed");

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -15,6 +15,7 @@
 #include <cfile/cfile.h>
 #include <hud/hudsquadmsg.h>
 #include <gamesnd/eventmusic.h>
+#include <globalincs/alphacolors.h>
 #include <globalincs/linklist.h>
 #include <globalincs/version.h>
 #include <iff_defs/iff_defs.h>
@@ -1155,6 +1156,13 @@ int CFred_mission_save::save_briefing()
 			if (!bs->draw_grid) {
 				if (save_format != MissionFormat::RETAIL) {
 					fout("\n$no_grid");
+				}
+			}
+
+			if (!gr_compare_color_values(&bs->grid_color, &Color_briefing_grid)) {
+				if (save_format != MissionFormat::RETAIL) {
+					fout("\n$grid_color:");
+					fout("(%d, %d, %d, %d)", bs->grid_color.red, bs->grid_color.green, bs->grid_color.blue, bs->grid_color.alpha);
 				}
 			}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3067,16 +3067,16 @@ void CFred_mission_save::save_mission_internal(const char* pathname)
 	// Additional incremental version update for some features
 	auto version_23_3 = gameversion::version(23, 3);
 	auto version_24_1 = gameversion::version(24, 1);
-	auto version_25_0 = gameversion::version(25, 0);
-	if (MISSION_VERSION >= version_25_0)
+	auto version_24_3 = gameversion::version(24, 3);
+	if (MISSION_VERSION >= version_24_3)
 	{
-		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 25.0, the check_for_25_0_data(), the check_for_24_1_data() and check_for_23_3_data() code can be removed");
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 24.3, the check_for_24_3_data(), the check_for_24_1_data() and check_for_23_3_data() code can be removed");
 	}
-	else if (check_for_25_0_data())
+	else if (check_for_24_3_data())
 	{
-		The_mission.required_fso_version = version_25_0;
+		The_mission.required_fso_version = version_24_3;
 	}
-	if (MISSION_VERSION >= version_24_1)
+	else if (MISSION_VERSION >= version_24_1)
 	{
 		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 24.1, the check_for_24_1_data() and check_for_23_3_data() code can be removed");
 	}

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -1159,7 +1159,7 @@ int CFred_mission_save::save_briefing()
 				}
 			}
 
-			if (!gr_compare_color_values(&bs->grid_color, &Color_briefing_grid)) {
+			if (!gr_compare_color_values(bs->grid_color, Color_briefing_grid)) {
 				if (save_format != MissionFormat::RETAIL) {
 					fout("\n$grid_color:");
 					fout("(%d, %d, %d, %d)", bs->grid_color.red, bs->grid_color.green, bs->grid_color.blue, bs->grid_color.alpha);

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3067,6 +3067,15 @@ void CFred_mission_save::save_mission_internal(const char* pathname)
 	// Additional incremental version update for some features
 	auto version_23_3 = gameversion::version(23, 3);
 	auto version_24_1 = gameversion::version(24, 1);
+	auto version_25_0 = gameversion::version(25, 0);
+	if (MISSION_VERSION >= version_25_0)
+	{
+		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 25.0, the check_for_25_0_data(), the check_for_24_1_data() and check_for_23_3_data() code can be removed");
+	}
+	else if (check_for_25_0_data())
+	{
+		The_mission.required_fso_version = version_25_0;
+	}
 	if (MISSION_VERSION >= version_24_1)
 	{
 		Warning(LOCATION, "Notify an SCP coder: now that the required mission version is at least 24.1, the check_for_24_1_data() and check_for_23_3_data() code can be removed");


### PR DESCRIPTION
Allows setting a custom grid color for each briefing stage with
```$grid_color: (r, g, b, a)```

For now there's no UI because this is decidedly niche and would be much easier to do in qt with a full color picker.