### PR TITLE
add set-squadron-wings sexp

### DIFF
--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -182,8 +182,7 @@ void hud_wingman_status_update()
 				continue;
 
 			auto wingp = &Wings[Squadron_wings[wing_index]];
-			for (int j = 0; j < MAX_SHIPS_PER_WING; j++) {
-				int shipnum = wingp->ship_index[j];
+			for (int shipnum: wingp->ship_index) {
 				if (shipnum < 0)
 					continue;
 
@@ -725,9 +724,8 @@ void hud_set_new_squadron_wings(const std::array<int, MAX_SQUADRON_WINGS> &new_s
 {
 	// set up a map to tell where wings are going in the new arrangement
 	SCP_unordered_map<int, int> new_squad_indexes;
-	for (int cur_squad_index = 0; cur_squad_index < MAX_SQUADRON_WINGS; cur_squad_index++)
+	for (int wingnum: Squadron_wings)
 	{
-		int wingnum = Squadron_wings[cur_squad_index];
 		if (wingnum >= 0)
 		{
 			auto loc = std::find(new_squad_wingnums.begin(), new_squad_wingnums.end(), wingnum);
@@ -737,17 +735,15 @@ void hud_set_new_squadron_wings(const std::array<int, MAX_SQUADRON_WINGS> &new_s
 	}
 
 	// clear or reassign the ships that are currently in the squadron wings
-	for (int cur_squad_index = 0; cur_squad_index < MAX_SQUADRON_WINGS; cur_squad_index++)
+	for (int wingnum: Squadron_wings)
 	{
-		int wingnum = Squadron_wings[cur_squad_index];
 		if (wingnum < 0)
 			continue;
 		auto wingp = &Wings[wingnum];
 		auto new_squad_index = new_squad_indexes.find(wingnum);
 
-		for (int j = 0; j < MAX_SHIPS_PER_WING; j++)
+		for (int shipnum: wingp->ship_index)
 		{
-			int shipnum = wingp->ship_index[j];
 			if (shipnum < 0)
 				continue;
 			auto shipp = &Ships[shipnum];
@@ -800,14 +796,13 @@ void hud_set_new_squadron_wings(const std::array<int, MAX_SQUADRON_WINGS> &new_s
 			continue;
 
 		// clear the status before we actually add any wingmen
-		for (int j = 0; j < MAX_SHIPS_PER_WING; j++)
-			HUD_wingman_status[new_squad_index].status[j] = HUD_WINGMAN_STATUS_NONE;
+		for (int &status: HUD_wingman_status[new_squad_index].status)
+			status = HUD_WINGMAN_STATUS_NONE;
 
 		// now add the existing wingmen
 		auto wingp = &Wings[wingnum];
-		for (int j = 0; j < MAX_SHIPS_PER_WING; j++)
+		for (int shipnum: wingp->ship_index)
 		{
-			int shipnum = wingp->ship_index[j];
 			if (shipnum >= 0)
 				hud_wingman_status_set_index(new_squad_index, wingp, &Ships[shipnum], nullptr);
 		}

--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -36,8 +36,8 @@
 
 typedef struct Wingman_status
 {
-	int	ignore;													// set to 1 when we should ignore this item -- used in team v. team
-	int	used;
+	bool	ignore;													// set to true when we should ignore this item -- used in team v. team
+	bool	used;
 	float hull[MAX_SHIPS_PER_WING];			// 0.0 -> 1.0
 	int	status[MAX_SHIPS_PER_WING];		// HUD_WINGMAN_STATUS_* 
 	int dot_anim_override[MAX_SHIPS_PER_WING]; // optional wingmen dot status to use instead of default --wookieejedi
@@ -80,10 +80,10 @@ void hud_set_wingman_status_none( int wing_index, int wing_pos)
 
 	HUD_wingman_status[wing_index].status[wing_pos] = HUD_WINGMAN_STATUS_NONE;
 
-	int used = 0;
+	bool used = false;
 	for ( i = 0; i < MAX_SHIPS_PER_WING; i++ ) {
 		if ( HUD_wingman_status[wing_index].status[i] != HUD_WINGMAN_STATUS_NONE ) {
-			used = 1;
+			used = true;
 			break;
 		}
 	}
@@ -123,7 +123,7 @@ void hud_wingman_kill_multi_teams()
 	if ( wing_index == -1 )
 		return;
 
-	HUD_wingman_status[wing_index].ignore = 1;
+	HUD_wingman_status[wing_index].ignore = true;
 }
 
 
@@ -137,8 +137,8 @@ void hud_init_wingman_status_gauge()
 	HUD_wingman_update_timer=timestamp(0);	// update status right away
 
 	for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
-		HUD_wingman_status[i].ignore = 0;
-		HUD_wingman_status[i].used = 0;
+		HUD_wingman_status[i].ignore = false;
+		HUD_wingman_status[i].used = false;
 		for ( j = 0; j < MAX_SHIPS_PER_WING; j++ ) {
 			HUD_wingman_status[i].status[j] = HUD_WINGMAN_STATUS_NONE;
 			HUD_wingman_status[i].dot_anim_override[j] = -1;
@@ -192,7 +192,7 @@ void hud_wingman_status_update()
 
 			if ( (wing_index >= 0) && (wing_pos >= 0) ) {
 
-				HUD_wingman_status[wing_index].used = 1;
+				HUD_wingman_status[wing_index].used = true;
 				if (!(shipp->is_departing()) ) {
 					HUD_wingman_status[wing_index].status[wing_pos] = HUD_WINGMAN_STATUS_ALIVE;	
 				}
@@ -561,7 +561,7 @@ void HudGaugeWingmanStatus::render(float  /*frametime*/)
 	int i, count, num_wings_to_draw = 0;
 
 	for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
-		if ( (HUD_wingman_status[i].used > 0) && (HUD_wingman_status[i].ignore == 0) ) {
+		if ( (HUD_wingman_status[i].used) && !(HUD_wingman_status[i].ignore) ) {
 			num_wings_to_draw++;
 		}
 	}
@@ -578,7 +578,7 @@ void HudGaugeWingmanStatus::render(float  /*frametime*/)
 
 	count = 0;
 	for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
-		if ( (HUD_wingman_status[i].used <= 0) || (HUD_wingman_status[i].ignore == 1) ) {
+		if ( !(HUD_wingman_status[i].used) || (HUD_wingman_status[i].ignore) ) {
 			continue;
 		}
 

--- a/code/hud/hudwingmanstatus.h
+++ b/code/hud/hudwingmanstatus.h
@@ -29,8 +29,7 @@ void	hud_wingman_status_start_flash(int wing_index, int wing_pos);
 void	hud_wingman_status_set_index(wing *wingp, ship *shipp, p_object *pobjp);
 
 // for resetting the gauge via sexp
-void	hud_wingman_status_set_index(int squad_wing_index, wing *wingp, ship *shipp, p_object *pobjp);
-void	hud_wingman_status_refresh();
+void	hud_set_new_squadron_wings(const std::array<int, MAX_SQUADRON_WINGS> &new_squad_wingnums);
 
 class HudGaugeWingmanStatus: public HudGauge
 {

--- a/code/hud/hudwingmanstatus.h
+++ b/code/hud/hudwingmanstatus.h
@@ -28,6 +28,10 @@ void	hud_set_wingman_status_none( int wing_index, int wing_pos);
 void	hud_wingman_status_start_flash(int wing_index, int wing_pos);
 void	hud_wingman_status_set_index(wing *wingp, ship *shipp, p_object *pobjp);
 
+// for resetting the gauge via sexp
+void	hud_wingman_status_set_index(int squad_wing_index, wing *wingp, ship *shipp, p_object *pobjp);
+void	hud_wingman_status_refresh();
+
 class HudGaugeWingmanStatus: public HudGauge
 {
 protected:

--- a/code/math/floating.h
+++ b/code/math/floating.h
@@ -31,8 +31,10 @@ inline bool fl_is_nan(float fl) {
 #define fl_isqrt(fl) (1.0f/sqrtf(fl))
 #define fl_abs(fl) fabsf(fl)
 #define i2fl(i) (static_cast<float>(i))                                     // int to float
+#define i2ch(i) (static_cast<char>(i))                                      // int to char
 #define l2d(l) (static_cast<double>(l))                                     // long to double
 #define fl2i(fl) (static_cast<int>(fl))                                     // float to int
+#define ch2i(ch) (static_cast<int>(ch))                                     // char to int
 #define d2l(d) (static_cast<long>(d))                                       // double to long
 #define fl2ir(fl) (static_cast<int>(fl + (((fl) < 0.0f) ? -0.5f : 0.5f)))   // float to int, rounding
 #define d2lr(d) (static_cast<long>(d + (((d) < 0.0) ? -0.5 : 0.5)))         // double to long, rounding

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -479,6 +479,9 @@ SCP_vector<sexp_oper> Operators = {
 	{ "ship-untag",						OP_SHIP_UNTAG,							1,	1,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "set-arrival-info",				OP_SET_ARRIVAL_INFO,					2,	8,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "set-departure-info",				OP_SET_DEPARTURE_INFO,					2,	7,			SEXP_ACTION_OPERATOR,	},	// Goober5000
+	{ "alter-ship-flag",				OP_ALTER_SHIP_FLAG,						3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Karajorma
+	{ "alter-wing-flag",				OP_ALTER_WING_FLAG,						2,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
+	{ "cancel-future-waves",			OP_CANCEL_FUTURE_WAVES,					1,	INT_MAX,	SEXP_ACTION_OPERATOR,	}, // naomimyselfandi
 
 	//Shields, Engines and Weapons Sub-Category
 	{ "set-weapon-energy",				OP_SET_WEAPON_ENERGY,					2,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Karajorma
@@ -544,9 +547,6 @@ SCP_vector<sexp_oper> Operators = {
 	{ "ship-subsys-vanish",				OP_SHIP_SUBSYS_VANISHED,				3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// FUBAR
 	{ "ship-subsys-ignore_if_dead",		OP_SHIP_SUBSYS_IGNORE_IF_DEAD,			3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// FUBAR
 	{ "awacs-set-radius",				OP_AWACS_SET_RADIUS,					3,	3,			SEXP_ACTION_OPERATOR,	},
-	{ "alter-ship-flag",				OP_ALTER_SHIP_FLAG,						3,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Karajorma 
-	{ "alter-wing-flag",				OP_ALTER_WING_FLAG,						2,	INT_MAX,	SEXP_ACTION_OPERATOR,	},	// Goober5000
-	{ "cancel-future-waves",			OP_CANCEL_FUTURE_WAVES,					1,	INT_MAX,	SEXP_ACTION_OPERATOR,	}, // naomimyselfandi
 
 	//Cargo Sub-Category
 	{ "transfer-cargo",					OP_TRANSFER_CARGO,						2,	2,			SEXP_ACTION_OPERATOR,	},
@@ -41733,60 +41733,60 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	},
 
 	{OP_FORCE_GLIDE, "force-glide\r\n"
-		"\tForces a given ship into glide mode, provided it is capable of gliding. Note that the player will not be able to leave glide mode, and that a ship in glide mode cannot warp out or enter autopilot."
+		"\tForces a given ship into glide mode, provided it is capable of gliding. Note that the player will not be able to leave glide mode, and that a ship in glide mode cannot warp out or enter autopilot.\r\n"
 		"Takes 2 Arguments...\r\n"
 		"\t1:\tShip to force (ship must be in-mission)\r\n"
 		"\t2:\tTrue to activate glide, False to deactivate\r\n"
 	},
 
 	{OP_HUD_SET_DIRECTIVE, "hud-set-directive\r\n"
-		"\tSets the text of a given custom hud gauge to the provided text."
+		"\tSets the text of a given custom hud gauge to the provided text.\r\n"
 		"Takes 2 Arguments...\r\n"
 		"\t1:\tHUD Gauge name\r\n"
 		"\t2:\tText that will be displayed. This text will be treated as directive text, meaning that references to mapped keys will be replaced with the user's preferences.\r\n"
 	},
 
 	{OP_HUD_GAUGE_SET_ACTIVE, "hud-gauge-set-active (deprecated)\r\n"
-		"\tActivates or deactivates a given hud gauge.  Works for custom and retail gauges."
+		"\tActivates or deactivates a given hud gauge.  Works for custom and retail gauges.\r\n"
 		"Takes 2 Arguments...\r\n"
 		"\t1:\tHUD Gauge name\r\n"
 		"\t2:\tBoolean, whether or not to display this gauge\r\n"
 	},
 
 	{OP_HUD_CLEAR_MESSAGES, "hud-clear-messages\r\n"
-		"\tClears active messages displayed on the HUD."
+		"\tClears active messages displayed on the HUD.\r\n"
 		"Takes no arguments\r\n"
 	},
 
 	{OP_HUD_ACTIVATE_GAUGE_TYPE, "hud-activate-gauge-type (deprecated)\r\n"
-		"\tActivates or deactivates all hud gauges of a given type."
+		"\tActivates or deactivates all hud gauges of a given type.\r\n"
 		"Takes 2 Arguments...\r\n"
 		"\t1:\tGauge Type\r\n"
 		"\t2:\tBoolean, whether or not to display this gauge\r\n"
 	},
 
 	{OP_HUD_SET_CUSTOM_GAUGE_ACTIVE, "hud-set-custom-gauge-active\r\n"
-		"\tActivates or deactivates a custom hud gauge defined in hud_gauges.tbl."
+		"\tActivates or deactivates a custom hud gauge defined in hud_gauges.tbl.\r\n"
 		"Takes 2 Arguments...\r\n"
 		"\t1:\tBoolean, whether or not to display this gauge\r\n"
 		"\tRest:\tHUD Gauge name\r\n"
 	},
 
 	{OP_HUD_SET_BUILTIN_GAUGE_ACTIVE, "hud-set-builtin-gauge-active\r\n"
-		"\tActivates or deactivates a builtin hud gauge grouping."
+		"\tActivates or deactivates a builtin hud gauge grouping.\r\n"
 		"Takes 2 Arguments...\r\n"
 		"\t1:\tBoolean, whether or not to display this gauge\r\n"
 		"\tRest:\tHUD Gauge Group name\r\n"
 	},
 
 	{OP_HUD_FORCE_SENSOR_STATIC, "hud-force-sensor-static\r\n"
-		"\tActivates or deactivates hud static as if sensors are damaged."
+		"\tActivates or deactivates hud static as if sensors are damaged.\r\n"
 		"Takes 1 Argument...\r\n"
 		"\t1:\tBoolean, whether or not to enable sensor static\r\n"
 	},
 
 	{OP_HUD_FORCE_EMP_EFFECT, "hud-force-emp-effect\r\n"
-		"\tActivates or deactivates emp effect for the player."
+		"\tActivates or deactivates emp effect for the player.\r\n"
 		"Takes 2 or more Arguments...\r\n"
 		"\t1:\tNumber, emp intensity (0 to 500)\r\n"
 		"\t2:\tNumber, emp duration in milliseconds\r\n"

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13667,62 +13667,26 @@ void multi_sexp_hud_display_gauge()
 
 void sexp_set_squadron_wings(int node)
 {
-	// clear the ships that are currently in the squadron wings
-	for (int i = 0; i < MAX_SQUADRON_WINGS; i++)
-	{
-		if (Squadron_wings[i] < 0)
-			continue;
-
-		auto wingp = &Wings[Squadron_wings[i]];
-		for (int j = 0; j < MAX_SHIPS_PER_WING; j++)
-		{
-			int shipnum = wingp->ship_index[j];
-			if (shipnum >= 0)
-			{
-				Ships[shipnum].wing_status_wing_index = -1;
-				Ships[shipnum].wing_status_wing_pos = -1;
-			}
-		}
-	}
+	std::array<int, MAX_SQUADRON_WINGS> new_squad_wingnums;
 
 	// get the new set of squadron wings
 	for (int i = 0, n = node; i < MAX_SQUADRON_WINGS; i++)
 	{
-		auto wing_name = "";
-		int wing_num = -1;
+		int wingnum = -1;
 
 		if (n >= 0)
 		{
 			auto wingp = eval_wing(n);
 			if (wingp)
-			{
-				wing_name = wingp->name;
-				wing_num = WING_INDEX(wingp);
-			}
+				wingnum = WING_INDEX(wingp);
+
 			n = CDR(n);
 		}
 
-		strcpy_s(Squadron_wing_names[i], wing_name);
-		Squadron_wings[i] = wing_num;
+		new_squad_wingnums[i] = wingnum;
 	}
 
-	// set the ships in the new squadron wings
-	for (int i = 0; i < MAX_SQUADRON_WINGS; i++)
-	{
-		if (Squadron_wings[i] < 0)
-			continue;
-
-		auto wingp = &Wings[Squadron_wings[i]];
-		for (int j = 0; j < MAX_SHIPS_PER_WING; j++)
-		{
-			int shipnum = wingp->ship_index[j];
-			if (shipnum >= 0)
-				hud_wingman_status_set_index(i, wingp, &Ships[shipnum], nullptr);
-		}
-	}
-
-	// refresh the HUD status
-	hud_wingman_status_refresh();
+	hud_set_new_squadron_wings(new_squad_wingnums);
 }
 
 // Goober5000
@@ -41870,7 +41834,8 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 		"\tSets the wings displayed on the squadron HUD display.  By default these are Alpha, Beta, Gamma, Delta, and Epsilon.  "
 		"The squadron status will be updated to the current status of the wings, but note that if any ships in those wings have "
 		"previously been destroyed, the HUD display may look different than expected.  (Specifically, destroyed ships may be "
-		"indicated as missing or may cause other ships in the same wing to appear in different positions.)\r\n"
+		"indicated as missing or may cause other ships in the same wing to appear in different positions.)  However, any wings "
+		"that are shared between one display and the next will be preserved.\r\n"
 		"Takes 1 to " SCP_TOKEN_TO_STR(MAX_SQUADRON_WINGS) " arguments...\r\n"
 		"\tAll:\tWing to display\r\n"
 	},

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -50,6 +50,7 @@
 #include "hud/hudparse.h"
 #include "hud/hudshield.h"
 #include "hud/hudsquadmsg.h"		// for the order sexp
+#include "hud/hudwingmanstatus.h"
 #include "iff_defs/iff_defs.h"
 #include "io/keycontrol.h"
 #include "io/timer.h"
@@ -13706,10 +13707,22 @@ void sexp_set_squadron_wings(int node)
 	}
 
 	// set the ships in the new squadron wings
-	// TODO
+	for (int i = 0; i < MAX_SQUADRON_WINGS; i++)
+	{
+		if (Squadron_wings[i] < 0)
+			continue;
+
+		auto wingp = &Wings[Squadron_wings[i]];
+		for (int j = 0; j < MAX_SHIPS_PER_WING; j++)
+		{
+			int shipnum = wingp->ship_index[j];
+			if (shipnum >= 0)
+				hud_wingman_status_set_index(i, wingp, &Ships[shipnum], nullptr);
+		}
+	}
 
 	// refresh the HUD status
-	// TODO
+	hud_wingman_status_refresh();
 }
 
 // Goober5000
@@ -41854,7 +41867,10 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 	},
 
 	{OP_SET_SQUADRON_WINGS, "set-squadron-wings\r\n"
-		"\tSets the wings displayed on the squadron HUD display.  By default these are Alpha, Beta, Gamma, Delta, and Epsilon.\r\n"
+		"\tSets the wings displayed on the squadron HUD display.  By default these are Alpha, Beta, Gamma, Delta, and Epsilon.  "
+		"The squadron status will be updated to the current status of the wings, but note that if any ships in those wings have "
+		"previously been destroyed, the HUD display may look different than expected.  (Specifically, destroyed ships may be "
+		"indicated as missing or may cause other ships in the same wing to appear in different positions.)\r\n"
 		"Takes 1 to " SCP_TOKEN_TO_STR(MAX_SQUADRON_WINGS) " arguments...\r\n"
 		"\tAll:\tWing to display\r\n"
 	},

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -923,6 +923,7 @@ enum : int {
 	OP_GOOD_PRIMARY_TIME,	// plieblang
 	OP_SET_SKYBOX_ALPHA,	// Goober5000
 	OP_NEBULA_SET_RANGE,	// Goober5000
+	OP_SET_SQUADRON_WINGS,	// Goober5000
 	
 	// OP_CATEGORY_AI
 	// defined for AI goals


### PR DESCRIPTION
This allows the wingman status gauge to be changed to display new wings or a different set of wings.  Quoting the help description:

> Sets the wings displayed on the squadron HUD display.  By default these are Alpha, Beta, Gamma, Delta, and Epsilon.  The squadron status will be updated to the current status of the wings, but note that if any ships in those wings have previously been destroyed, the HUD display may look different than expected.  (Specifically, destroyed ships may be indicated as missing or may cause other ships in the same wing to appear in different positions.)  However, any wings that are shared between one display and the next will be preserved.

Implements the request in #5872.