### PR TITLE
default the connection speed to Fast even if it has been set to None

### DIFF
--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -2948,8 +2948,10 @@ int multi_get_connection_speed()
 		cspeed = CONNECTION_SPEED_CABLE;
 	} else if ( !stricmp(connection_speed, NOX("Fast")) ) {
 		cspeed = CONNECTION_SPEED_T1;
+	} else if (!stricmp(connection_speed, NOX("None"))) {
+		cspeed = CONNECTION_SPEED_T1;	// default to Fast, per the os_config_read_string() call; per #define in multi.h, None doesn't really mean anything
 	} else {
-		cspeed = CONNECTION_SPEED_NONE;
+		cspeed = CONNECTION_SPEED_NONE;	// this will now no longer be returned unless the connection speed string is invalid
 	}
 
 	return cspeed;


### PR DESCRIPTION
A connection speed of "None" is really just the default used by launchers if the user hasn't explicitly set the speed yet.  Additionally, `CONNECTION_SPEED_NONE` isn't really used by the engine except for error checking.  So, fall back to the default connection speed even when the speed has been set to "None".

Follow-up to #6402.