### PR TITLE
enhance the add-goal and remove-goal sexps

### DIFF
--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -1151,7 +1151,11 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 		}
 	}
 
-	if ( aigp->priority > MAX_GOAL_PRIORITY || priority_is_nan || priority_is_nan_forever ) {
+	if ( priority_is_nan || priority_is_nan_forever ) {
+		Warning(LOCATION, "add-goal tried to add %s with a NaN priority; aborting...", Sexp_nodes[CAR(sexp)].text);
+		ai_goal_reset(aigp);
+		return;
+	} else if ( aigp->priority > MAX_GOAL_PRIORITY ) {
 		nprintf (("AI", "bashing add-goal sexpression priority of goal %s from %d to %d.\n", Sexp_nodes[CAR(sexp)].text, aigp->priority, MAX_GOAL_PRIORITY));
 		aigp->priority = MAX_GOAL_PRIORITY;
 	}
@@ -1255,7 +1259,12 @@ int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp, bool &remove_more )
 		int _priority = (n >= 0) ? eval_num(n, _priority_is_nan, _priority_is_nan_forever) : priority_if_no_n;
 		n = CDR(sexp);	// we want the first node after the goal sub-tree
 
-		if (_priority > MAX_GOAL_PRIORITY || _priority_is_nan || _priority_is_nan_forever)
+		if (_priority_is_nan || _priority_is_nan_forever)
+		{
+			Warning(LOCATION, "remove-goal tried to remove %s with a NaN priority; the priority will not be used for goal comparison", Sexp_nodes[CAR(sexp)].text);
+			_priority = -1;
+		}
+		else if (_priority > MAX_GOAL_PRIORITY)
 		{
 			nprintf(("AI", "bashing remove-goal sexpression priority of goal %s from %d to %d.\n", Sexp_nodes[CAR(sexp)].text, _priority, MAX_GOAL_PRIORITY));
 			_priority = MAX_GOAL_PRIORITY;

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -907,6 +907,7 @@ void ai_add_wing_goal_player( int type, int mode, int submode, const char *shipn
 void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, const char *actor_name )
 {
 	int node, dummy, op;
+	bool priority_is_nan = false, priority_is_nan_forever = false;
 
 	Assert ( Sexp_nodes[sexp].first != -1 );
 	node = Sexp_nodes[sexp].first;
@@ -932,7 +933,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 		aigp->target_name = ai_get_goal_target_name(CTEXT(CDR(node)), &aigp->target_name_index);  // waypoint path name;
 
 
-		aigp->priority = atoi( CTEXT(CDR(CDR(node))) );
+		aigp->priority = eval_num(CDDR(node), priority_is_nan, priority_is_nan_forever);
 		aigp->ai_mode = AI_GOAL_WAYPOINTS;
 		if ( op == OP_AI_WAYPOINTS_ONCE )
 			aigp->ai_mode = AI_GOAL_WAYPOINTS_ONCE;
@@ -950,9 +951,9 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 		aigp->target_name = ai_get_goal_target_name( CTEXT(CDR(node)), &aigp->target_name_index );
 		// store the name of the subsystem in the docker.name field for now -- this field must get
 		// fixed up when the goal is valid since we need to locate the subsystem on the ship's model
-		aigp->docker.name = ai_get_goal_target_name(CTEXT(CDR(CDR(node))), &dummy);
+		aigp->docker.name = ai_get_goal_target_name(CTEXT(CDDR(node)), &dummy);
 		aigp->flags.set(AI::Goal_Flags::Subsys_needs_fixup);
-		aigp->priority = atoi( CTEXT(CDR(CDR(CDR(node)))) );
+		aigp->priority = eval_num(CDDDR(node), priority_is_nan, priority_is_nan_forever);
 		break;
 
 	case OP_AI_DISABLE_SHIP:
@@ -960,7 +961,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 		aigp->ai_mode = (op == OP_AI_DISABLE_SHIP) ? AI_GOAL_DISABLE_SHIP : AI_GOAL_DISABLE_SHIP_TACTICAL;
 		aigp->target_name = ai_get_goal_target_name( CTEXT(CDR(node)), &aigp->target_name_index );
 		aigp->ai_submode = -SUBSYSTEM_ENGINE;
-		aigp->priority = atoi( CTEXT(CDR(CDR(node))) );
+		aigp->priority = eval_num(CDDR(node), priority_is_nan, priority_is_nan_forever);
 		break;
 
 	case OP_AI_DISARM_SHIP:
@@ -968,27 +969,27 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 		aigp->ai_mode = (op == OP_AI_DISARM_SHIP) ? AI_GOAL_DISARM_SHIP : AI_GOAL_DISARM_SHIP_TACTICAL;
 		aigp->target_name = ai_get_goal_target_name( CTEXT(CDR(node)), &aigp->target_name_index );
 		aigp->ai_submode = -SUBSYSTEM_TURRET;
-		aigp->priority = atoi( CTEXT(CDR(CDR(node))) );
+		aigp->priority = eval_num(CDDR(node), priority_is_nan, priority_is_nan_forever);
 		break;
 
 	case OP_AI_WARP_OUT:
 		aigp->ai_mode = AI_GOAL_WARP;
-		aigp->priority = atoi( CTEXT(CDR(node)) );
+		aigp->priority = eval_num(CDR(node), priority_is_nan, priority_is_nan_forever);
 		break;
 
 		// the following goal is obsolete, but here for compatibility
 	case OP_AI_WARP:
 		aigp->ai_mode = AI_GOAL_WARP;
 		aigp->target_name = ai_get_goal_target_name(CTEXT(CDR(node)), &aigp->target_name_index);  // waypoint path name;
-		aigp->priority = atoi( CTEXT(CDR(CDR(node))) );
+		aigp->priority = eval_num(CDDR(node), priority_is_nan, priority_is_nan_forever);
 		break;
 
 	case OP_AI_UNDOCK:
-		aigp->priority = atoi( CTEXT(CDR(node)) );
+		aigp->priority = eval_num(CDR(node), priority_is_nan, priority_is_nan_forever);
 
 		// Goober5000 - optional undock with something
-		if (CDR(CDR(node)) != -1)
-			aigp->target_name = ai_get_goal_target_name( CTEXT(CDR(CDR(node))), &aigp->target_name_index );
+		if (CDDR(node) != -1)
+			aigp->target_name = ai_get_goal_target_name( CTEXT(CDDR(node)), &aigp->target_name_index );
 
 		aigp->ai_mode = AI_GOAL_UNDOCK;
 		aigp->ai_submode = AIS_UNDOCK_0;
@@ -998,7 +999,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 	{
 		aigp->ai_mode = AI_GOAL_REARM_REPAIR;
 		aigp->target_name = ai_get_goal_target_name(CTEXT(CDR(node)), &aigp->target_name_index);
-		aigp->priority = atoi( CTEXT(CDR(CDR(node))) );
+		aigp->priority = eval_num(CDDR(node), priority_is_nan, priority_is_nan_forever);
 
 		// this goal needs some extra setup
 		// if this doesn't work, the goal will be immediately removed
@@ -1016,36 +1017,36 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 	case OP_AI_STAY_STILL:
 		aigp->ai_mode = AI_GOAL_STAY_STILL;
 		aigp->target_name = ai_get_goal_target_name(CTEXT(CDR(node)), &aigp->target_name_index);  // waypoint path name;
-		aigp->priority = atoi( CTEXT(CDR(CDR(node))) );
+		aigp->priority = eval_num(CDDR(node), priority_is_nan, priority_is_nan_forever);
 		break;
 
 	case OP_AI_DOCK:
 		aigp->target_name = ai_get_goal_target_name( CTEXT(CDR(node)), &aigp->target_name_index );
-		aigp->docker.name = ai_add_dock_name(CTEXT(CDR(CDR(node))));
-		aigp->dockee.name = ai_add_dock_name(CTEXT(CDR(CDR(CDR(node)))));
-		aigp->priority = atoi( CTEXT(CDR(CDR(CDR(CDR(node))))) );
+		aigp->docker.name = ai_add_dock_name(CTEXT(CDDR(node)));
+		aigp->dockee.name = ai_add_dock_name(CTEXT(CDDDR(node)));
+		aigp->priority = eval_num(CDDDDR(node), priority_is_nan, priority_is_nan_forever);
 
 		aigp->ai_mode = AI_GOAL_DOCK;
 		aigp->ai_submode = AIS_DOCK_0;		// be sure to set the submode
 		break;
 
 	case OP_AI_CHASE_ANY:
-		aigp->priority = atoi( CTEXT(CDR(node)) );
+		aigp->priority = eval_num(CDR(node), priority_is_nan, priority_is_nan_forever);
 		aigp->ai_mode = AI_GOAL_CHASE_ANY;
 		break;
 
 	case OP_AI_PLAY_DEAD:
-		aigp->priority = atoi( CTEXT(CDR(node)) );
+		aigp->priority = eval_num(CDR(node), priority_is_nan, priority_is_nan_forever);
 		aigp->ai_mode = AI_GOAL_PLAY_DEAD;
 		break;
 
 	case OP_AI_PLAY_DEAD_PERSISTENT:
-		aigp->priority = atoi( CTEXT(CDR(node)) );
+		aigp->priority = eval_num(CDR(node), priority_is_nan, priority_is_nan_forever);
 		aigp->ai_mode = AI_GOAL_PLAY_DEAD_PERSISTENT;
 		break;
 
 	case OP_AI_KEEP_SAFE_DISTANCE:
-		aigp->priority = atoi( CTEXT(CDR(node)) );
+		aigp->priority = eval_num(CDR(node), priority_is_nan, priority_is_nan_forever);
 		aigp->ai_mode = AI_GOAL_KEEP_SAFE_DISTANCE;
 		break;
 
@@ -1055,7 +1056,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 		bool is_nan, is_nan_forever;
 
 		aigp->target_name = ai_get_goal_target_name( CTEXT(CDR(node)), &aigp->target_name_index );
-		aigp->priority = atoi( CTEXT(CDDR(node)) );
+		aigp->priority = eval_num(CDDR(node), priority_is_nan, priority_is_nan_forever);
 
 		// distance from ship
 		if ( CDDDR(node) < 0 )
@@ -1091,7 +1092,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 	case OP_AI_IGNORE:
 	case OP_AI_IGNORE_NEW:
 		aigp->target_name = ai_get_goal_target_name( CTEXT(CDR(node)), &aigp->target_name_index );
-		aigp->priority = atoi( CTEXT(CDR(CDR(node))) );
+		aigp->priority = eval_num(CDDR(node), priority_is_nan, priority_is_nan_forever);
 
 		if ( op == OP_AI_CHASE ) {
 			aigp->ai_mode = AI_GOAL_CHASE;
@@ -1141,7 +1142,7 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 				localnode = CDR(localnode);
 			}
 
-			aigp->priority = atoi( CTEXT(localnode) );
+			aigp->priority = eval_num(localnode, priority_is_nan, priority_is_nan_forever);
 
 			aigp->lua_ai_target = { std::move(target), luaAIMode->sexp.getSEXPArgumentList(CDR(localnode)) };
 		}
@@ -1150,8 +1151,8 @@ void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, cons
 		}
 	}
 
-	if ( aigp->priority > MAX_GOAL_PRIORITY ) {
-		nprintf (("AI", "bashing sexpression priority of goal %s from %d to %d.\n", CTEXT(node), aigp->priority, MAX_GOAL_PRIORITY));
+	if ( aigp->priority > MAX_GOAL_PRIORITY || priority_is_nan || priority_is_nan_forever ) {
+		nprintf (("AI", "bashing add-goal sexpression priority of goal %s from %d to %d.\n", Sexp_nodes[CAR(sexp)].text, aigp->priority, MAX_GOAL_PRIORITY));
 		aigp->priority = MAX_GOAL_PRIORITY;
 	}
 
@@ -1227,9 +1228,10 @@ int ai_find_goal_index( ai_goal* aigp, int mode, int submode, int priority )
 
 /* Remove a goal from the given goals structure
  * Returns the index of the goal that it clears out.
- * This is important so that if active_goal == index you can set AI_GOAL_NONE
+ * This is important so that if active_goal == index you can set AI_GOAL_NONE.
+ * NOTE: Callers should check the value of remove_more.  If it is true, the function should be called again.
  */
-int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp )
+int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp, bool &remove_more )
 {
 	/* Sanity check */
 	Assert( Sexp_nodes[ sexp ].first != -1 );
@@ -1245,115 +1247,145 @@ int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp )
 	/* The operator to use */
 	int op = get_operator_const( node );
 
+	// since this logic is common to all goals removed by the remove-goal sexp
+	auto eval_priority_et_seq = [sexp, &remove_more](int n, int priority_if_no_n = -1)->int
+	{
+		bool _priority_is_nan = false, _priority_is_nan_forever = false;
+
+		int _priority = (n >= 0) ? eval_num(n, _priority_is_nan, _priority_is_nan_forever) : priority_if_no_n;
+		n = CDR(sexp);	// we want the first node after the goal sub-tree
+
+		if (_priority > MAX_GOAL_PRIORITY || _priority_is_nan || _priority_is_nan_forever)
+		{
+			nprintf(("AI", "bashing remove-goal sexpression priority of goal %s from %d to %d.\n", Sexp_nodes[CAR(sexp)].text, _priority, MAX_GOAL_PRIORITY));
+			_priority = MAX_GOAL_PRIORITY;
+		}
+
+		if (n >= 0)
+		{
+			remove_more = is_sexp_true(n);
+			n = CDR(n);
+		}
+
+		if (n >= 0)
+		{
+			if (is_sexp_true(n))
+				_priority = -1;
+			n = CDR(n);
+		}
+
+		return _priority;
+	};
+
 	/* We now need to determine what the mode and submode values are*/
 	switch( op )
 	{
 	case OP_AI_WAYPOINTS_ONCE:
 		goalmode = AI_GOAL_WAYPOINTS_ONCE;
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		break;
 	case OP_AI_WAYPOINTS:
 		goalmode = AI_GOAL_WAYPOINTS;
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		break;
 	case OP_AI_DESTROY_SUBSYS:
 		goalmode = AI_GOAL_DESTROY_SUBSYSTEM;
-		priority = ( CDR( CDR( CDR(node) ) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( CDR( node ) ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDDR(node));
 		break;
 	case OP_AI_DISABLE_SHIP:
 	case OP_AI_DISABLE_SHIP_TACTICAL:
 		goalmode = (op == OP_AI_DISABLE_SHIP) ? AI_GOAL_DISABLE_SHIP : AI_GOAL_DISABLE_SHIP_TACTICAL;
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		break;
 	case OP_AI_DISARM_SHIP:
 	case OP_AI_DISARM_SHIP_TACTICAL:
 		goalmode = (op == OP_AI_DISARM_SHIP) ? AI_GOAL_DISARM_SHIP : AI_GOAL_DISARM_SHIP_TACTICAL;
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		break;
 	case OP_AI_WARP_OUT:
 		goalmode = AI_GOAL_WARP;
-		priority = ( CDR(node) >= 0 ) ? atoi( CTEXT( CDR( node ) ) ) : -1;
+		priority = eval_priority_et_seq(CDR(node));
 		break;
 	case OP_AI_WARP:
 		goalmode = AI_GOAL_WARP;
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		break;
 	case OP_AI_UNDOCK:
 		goalmode = AI_GOAL_UNDOCK;
 		goalsubmode = AIS_UNDOCK_0;
-		priority = ( CDR(node) >= 0 ) ? atoi( CTEXT( CDR( node ) ) ) : -1;
+		priority = eval_priority_et_seq(CDR(node));
 		break;
 	case OP_AI_STAY_STILL:
 		goalmode = AI_GOAL_STAY_STILL;
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		break;
 	case OP_AI_DOCK:
 		goalmode = AI_GOAL_DOCK;
 		goalsubmode = AIS_DOCK_0;
-		priority = ( CDR( CDR( CDR( CDR(node) ) ) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( CDR( CDR( node ) ) ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDDDR(node));
 		break;
 	case OP_AI_CHASE_ANY:
 		goalmode = AI_GOAL_CHASE_ANY;
-		priority = ( CDR(node) >= 0 ) ? atoi( CTEXT( CDR( node ) ) ) : -1;
+		priority = eval_priority_et_seq(CDR(node));
 		break;
 	case OP_AI_PLAY_DEAD:
 	case OP_AI_PLAY_DEAD_PERSISTENT:
 		goalmode = (op == OP_AI_PLAY_DEAD) ? AI_GOAL_PLAY_DEAD : AI_GOAL_PLAY_DEAD_PERSISTENT;
-		priority = ( CDR(node) >= 0 ) ? atoi( CTEXT( CDR( node ) ) ) : -1;
+		priority = eval_priority_et_seq(CDR(node));
 		break;
 	case OP_AI_KEEP_SAFE_DISTANCE:
-		priority = ( CDR(node) >= 0 ) ? atoi( CTEXT( CDR( node ) ) ) : -1;
+		priority = eval_priority_et_seq(CDR(node));
 		goalmode = AI_GOAL_KEEP_SAFE_DISTANCE;
 		break;
 	case OP_AI_CHASE:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		if ( wing_name_lookup( CTEXT( CDR( node ) ), 1 ) != -1 )
 			goalmode = AI_GOAL_CHASE_WING;
 		else
 			goalmode = AI_GOAL_CHASE;
 		break;
 	case OP_AI_GUARD:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		if ( wing_name_lookup( CTEXT( CDR( node ) ), 1 ) != -1 )
 			goalmode = AI_GOAL_GUARD_WING;
 		else
 			goalmode = AI_GOAL_GUARD;
 		break;
 	case OP_AI_GUARD_WING:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		goalmode = AI_GOAL_GUARD_WING;
 		break;
 	case OP_AI_CHASE_WING:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		goalmode = AI_GOAL_CHASE_WING;
 		break;
 	case OP_AI_CHASE_SHIP_CLASS:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		goalmode = AI_GOAL_CHASE_SHIP_CLASS;
 		break;
 	case OP_AI_EVADE_SHIP:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		goalmode = AI_GOAL_EVADE_SHIP;
 		break;
 	case OP_AI_STAY_NEAR_SHIP:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		goalmode = AI_GOAL_STAY_NEAR_SHIP;
 		break;
 	case OP_AI_IGNORE:
 	case OP_AI_IGNORE_NEW:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		goalmode = (op == OP_AI_IGNORE) ? AI_GOAL_IGNORE : AI_GOAL_IGNORE_NEW;
 		break;
 	case OP_AI_FORM_ON_WING:
-		priority = 99;
+		priority = eval_priority_et_seq(-1, 99);
 		goalmode = AI_GOAL_FORM_ON_WING;
 		break;
 	case OP_AI_FLY_TO_SHIP:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		goalmode = AI_GOAL_FLY_TO_SHIP;
 		break;
 	case OP_AI_REARM_REPAIR:
-		priority = ( CDR( CDR(node) ) >= 0 ) ? atoi( CTEXT( CDR( CDR( node ) ) ) ) : -1;
+		priority = eval_priority_et_seq(CDDR(node));
 		goalmode = AI_GOAL_REARM_REPAIR;
 		break;
 	default:
@@ -1369,7 +1401,7 @@ int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp )
 				localnode = CDR(localnode);
 			}
 
-			priority = localnode >= 0 ? atoi( CTEXT(localnode) ) : -1;
+			priority = eval_priority_et_seq(localnode);
 		}
 		else {
 			UNREACHABLE("Invalid SEXP-OP %s (number %d) for an AI goal!", Sexp_nodes[node].text, op);
@@ -1381,7 +1413,10 @@ int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp )
 	int goalindex = ai_find_goal_index( aigp, goalmode, goalsubmode, priority );
 
 	if ( goalindex == -1 )
+	{
+		remove_more = false;
 		return -1; /* no more to do; */
+	}
 
 	/* Clear out the contents of the goal. We can't use ai_remove_ship_goal since it needs ai_info and
 	 * we've only got ai_goals */
@@ -1395,6 +1430,7 @@ void ai_remove_wing_goal_sexp(int sexp, wing *wingp)
 {
 	int i;
 	int goalindex = -1;
+	bool remove_more = false;
 
 	// remove the ai goal for any ship that is currently arrived in the game (only if fred isn't running)
 	if ( !Fred_running ) {
@@ -1402,9 +1438,13 @@ void ai_remove_wing_goal_sexp(int sexp, wing *wingp)
 			int num = wingp->ship_index[i];
 			if ( num == -1 )			// ship must have been destroyed or departed
 				continue;
-			goalindex = ai_remove_goal_sexp_sub( sexp, Ai_info[Ships[num].ai_index].goals );
-			if ( Ai_info[Ships[num].ai_index].active_goal == goalindex )
-				Ai_info[Ships[num].ai_index].active_goal = AI_GOAL_NONE;
+			auto aip = &Ai_info[Ships[num].ai_index];
+
+			do {
+				goalindex = ai_remove_goal_sexp_sub(sexp, aip->goals, remove_more);
+				if (aip->active_goal == goalindex)
+					aip->active_goal = AI_GOAL_NONE;
+			} while (remove_more);
 		}
 	}
 
@@ -1412,7 +1452,9 @@ void ai_remove_wing_goal_sexp(int sexp, wing *wingp)
 	// there are more waves to come
 	if ((wingp->num_waves - wingp->current_wave > 0) || Fred_running) 
 	{
-		ai_remove_goal_sexp_sub( sexp, wingp->ai_goals );
+		do {
+			ai_remove_goal_sexp_sub(sexp, wingp->ai_goals, remove_more);
+		} while (remove_more);
 	}
 }
 

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -173,7 +173,7 @@ extern void ai_add_ship_goal_sexp( int sexp, int type, ai_info *aip );
 extern void ai_add_wing_goal_sexp( int sexp, int type, wing *wingp );
 extern void ai_add_goal_sub_sexp( int sexp, int type, ai_info *aip, ai_goal *aigp, const char *actor_name);
 
-extern int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp );
+extern int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp, bool &remove_more );
 extern void ai_remove_wing_goal_sexp( int sexp, wing *wingp );
 
 // adds goals to ships/sings through player orders

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -433,7 +433,7 @@ SCP_vector<sexp_oper> Operators = {
 
 	//AI Control Sub-Category
 	{ "add-goal",						OP_ADD_GOAL,							2,	2,			SEXP_ACTION_OPERATOR,	},
-	{ "remove-goal",					OP_REMOVE_GOAL,							2,	2,			SEXP_ACTION_OPERATOR,	},	// Goober5000
+	{ "remove-goal",					OP_REMOVE_GOAL,							2,	4,			SEXP_ACTION_OPERATOR,	},	// Goober5000
 	{ "add-ship-goal",					OP_ADD_SHIP_GOAL,						2,	2,			SEXP_ACTION_OPERATOR,	},
 	{ "add-wing-goal",					OP_ADD_WING_GOAL,						2,	2,			SEXP_ACTION_OPERATOR,	},
 	{ "clear-goals",					OP_CLEAR_GOALS,							1,	INT_MAX,	SEXP_ACTION_OPERATOR,	},
@@ -13139,12 +13139,16 @@ void sexp_remove_goal(int n)
 		if (!ship_entry->has_shipp())
 			return;										// ship not around anymore???? then forget it!
 
-		int goalindex = ai_remove_goal_sexp_sub(goal_node, Ai_info[ship_entry->shipp()->ai_index].goals);
-		if (goalindex >= 0)
-		{
-			if (Ai_info[ship_entry->shipp()->ai_index].active_goal == goalindex)
-				Ai_info[ship_entry->shipp()->ai_index].active_goal = AI_GOAL_NONE;
-		}
+		bool remove_more = false;
+		auto aip = &Ai_info[ship_entry->shipp()->ai_index];
+		do {
+			int goalindex = ai_remove_goal_sexp_sub(goal_node, aip->goals, remove_more);
+			if (goalindex >= 0)
+			{
+				if (aip->active_goal == goalindex)
+					aip->active_goal = AI_GOAL_NONE;
+			}
+		} while (remove_more);
 		return;
 	}
 
@@ -32167,11 +32171,18 @@ int query_operator_argument_type(int op, int argnum)
 				return OPF_AI_GOAL;
 
 		case OP_ADD_GOAL:
-		case OP_REMOVE_GOAL:
 			if ( argnum == 0 )
 				return OPF_SHIP_WING;
 			else
 				return OPF_AI_GOAL;
+
+		case OP_REMOVE_GOAL:
+			if ( argnum == 0 )
+				return OPF_SHIP_WING;
+			else if ( argnum == 1 )
+				return OPF_AI_GOAL;
+			else
+				return OPF_BOOL;
 
 		case OP_COND:
 		case OP_WHEN:
@@ -38609,10 +38620,14 @@ SCP_vector<sexp_help_struct> Sexp_help = {
 
 	// Goober5000
 	{ OP_REMOVE_GOAL, "Remove goal (Action operator)\r\n"
-		"\tRemoves a goal from a ship or wing.\r\n\r\n"
-		"Takes 2 arguments...\r\n"
+		"\tRemoves a goal from a ship or wing.  Note that, by default, only the type of goal and the priority are matched.  This operator "
+		"does not distinguish between, for example, two different waypoint goals.\r\n\r\n"
+		"Takes 2 to 4 arguments...\r\n"
 		"\t1:\tName of ship or wing to remove goal from (ship/wing must be in-mission).\r\n"
-		"\t2:\tGoal to remove." },
+		"\t2:\tGoal to remove.\r\n"
+		"\t3:\tWhether to remove all matching goals (optional; defaults to false; if false, only the first matching goal will be removed).\r\n"
+		"\t4:\tWhether to ignore the priority when matching a goal (optional).\r\n"
+	},
 
 	{ OP_SABOTAGE_SUBSYSTEM, "Sabotage subystem (Action operator)\r\n"
 		"\tReduces the specified subsystem integrity by the specified percentage."

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1086,7 +1086,7 @@ void game_level_init()
 	Campaign_ending_via_supernova = 0;
 
 	load_gl_init = (time(nullptr) - load_gl_init);
-	mprintf(("Game_level_init took %ld seconds", load_gl_init));
+	mprintf(("Game_level_init took %ld seconds\n", load_gl_init));
 
 	//WMC - Init multi players for level
 	if (Game_mode & GM_MULTIPLAYER && Player != nullptr) {


### PR DESCRIPTION
1. Allow the goal priority to be an evaluated number, not just a literal number.  This allows the goal priority to be obtained from operators or calculations.
2. Since the priority can now be evaluated, it can be NaN.  In that case, default to the max priority.
3. Consolidate `CDR(CDR(...))` to `CDDR()` in the aigoal implementation
4. Clarify that `remove-goal` removes the first goal of a given type and priority, not necessarily the first fully matching goal.
5. Enhance `remove-goal` to remove all goals matching the constraints, not just the first goal.
6. Allow `remove-goal` to disregard priority when checking for matching goals.