### PR TITLE
Fix maneuvering thruster initialization

### DIFF
--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1076,19 +1076,14 @@ class rcs_thruster_info {
 
 	vec3d pos, norm;
 
-    void reset() {
-        length = 0;
+    rcs_thruster_info() : length(0), radius (0.0f), tex_fps(0), tex_nframes(0), tex_id(-1) {
         norm.xyz.x = norm.xyz.y = norm.xyz.z = 0.0f; // I wanted to do norm = ZERO_VECTOR here, but apparently that breaks the MSVC 2015 compiler....
         pos.xyz.x = pos.xyz.y = pos.xyz.z = 0.0f;
-        radius = 0.0f;
-        tex_fps = 0;
-        tex_nframes = 0;
         use_flags.reset();
 
         start_snd = gamesnd_id();
         loop_snd = gamesnd_id();
         stop_snd = gamesnd_id();
-        tex_id = -1;
     }
 };
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1076,7 +1076,7 @@ class rcs_thruster_info {
 
 	vec3d pos, norm;
 
-    rcs_thruster_info() : length(0), radius (0.0f), tex_fps(0), tex_nframes(0), tex_id(-1) {
+    rcs_thruster_info() : tex_id(-1), tex_nframes(0), tex_fps(0), length(0), radius (0.0f) {
         norm.xyz.x = norm.xyz.y = norm.xyz.z = 0.0f; // I wanted to do norm = ZERO_VECTOR here, but apparently that breaks the MSVC 2015 compiler....
         pos.xyz.x = pos.xyz.y = pos.xyz.z = 0.0f;
         use_flags.reset();


### PR DESCRIPTION
This reset function was not actually used anywhere, so declaring and emplacing back these things, they were getting `tex_id`s of 0, not -1. So if the texture parsing failed, the rendering would later try to render tex_id 0 (since it only skips rendering if the id is < 0) and corrupt everything. So I just turned the reset into a constructor.