### PR TITLE
fix engine wash

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2788,7 +2788,7 @@ void ai_turret_execute_behavior(const ship *shipp, ship_subsys *ss)
 		{
 			//something did fire, get the lowest valid timestamp
 			// don't do this if we already set a turret timestamp previously in the function
-			if (timestamp_since(ss->turret_next_fire_stamp) > 0)
+			if (timestamp_since(ss->turret_next_fire_stamp) >= 0)
 			{
 				int minimum_stamp = -1;
 
@@ -2797,7 +2797,7 @@ void ai_turret_execute_behavior(const ship *shipp, ship_subsys *ss)
 					int stamp = (i < MAX_SHIP_PRIMARY_BANKS) ? swp->next_primary_fire_stamp[i] : swp->next_secondary_fire_stamp[i - MAX_SHIP_PRIMARY_BANKS];
 
 					// valid timestamps start at 2; stamp must be in the future
-					if (stamp < 2 || timestamp_since(stamp) > 0)
+					if (stamp < 2 || timestamp_since(stamp) >= 0)
 						continue;
 
 					// find minimum

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2685,7 +2685,7 @@ void engine_wash_ship_process(ship *shipp)
 
 	// is it time to check for engine wash 
 	int time_to_next_hit = timestamp_until(shipp->wash_timestamp);
-	if (time_to_next_hit < 0) {
+	if (time_to_next_hit <= 0) {
 		if (time_to_next_hit < -ENGINE_WASH_CHECK_INTERVAL) {
 			time_to_next_hit = 0;
 		}


### PR DESCRIPTION
An idiosyncrasy of the original implementation of `timestamp_until()` is that "immediate" timestamps that expired would be negative.  Only one remaining spot in the codebase relied on this: engine wash.  When #6258 fixed `timestamp_until()` to return 0 for immediate timestamps, engine wash broke.  Changing the comparison from `<` to `<=` fixes it.  I searched the code and there are no similar uses of `timestamp_until()` or `timestamp_since()`.

In the process of searching, though, I found two uses of `timestamp_since()` that were converted from `timestamp_until()` in PR #4286.  These particular conversions more properly include the 0 rather than exclude it, so I changed these as well.