### PR TITLE
Add Lua global variables library

### DIFF
--- a/code/scripting/api/libs/globals.cpp
+++ b/code/scripting/api/libs/globals.cpp
@@ -1,0 +1,72 @@
+//
+//
+
+#include "globalincs/version.h"
+
+#include "globals.h"
+
+#include "missionui/missionscreencommon.h"
+#include "playerman/managepilot.h"
+
+namespace scripting {
+namespace api {
+
+//**********LIBRARY: Globals
+ADE_LIB(l_GlobalVariables, "GlobalVariables", "gl", "Library of global values");
+
+ADE_VIRTVAR(MAX_PILOTS,
+	l_GlobalVariables,
+	nullptr,
+	"Gets the maximum number of possible pilots.",
+	"number",
+            "The maximum number of pilots")
+{
+	return ade_set_args(L, "i", MAX_PILOTS);
+}
+
+ADE_VIRTVAR(MAX_WING_SLOTS,
+	l_GlobalVariables,
+	nullptr,
+	"The maximum ships that can be in a loadout wing",
+	"number",
+	"A maximum number of ships")
+{
+
+	return ade_set_args(L, "i", MAX_WING_SLOTS);
+}
+
+ADE_VIRTVAR(MAX_WING_BLOCKS,
+	l_GlobalVariables,
+	nullptr,
+	"The maximum wings that can be in a loadout",
+	"number",
+	"A maximum number of wings")
+{
+
+	return ade_set_args(L, "i", MAX_WING_BLOCKS);
+}
+
+ADE_VIRTVAR(MAX_SHIP_PRIMARY_BANKS,
+	l_GlobalVariables,
+	nullptr,
+	"The maximum primary banks a ship can have",
+	"number",
+	"A maximum number of primary banks")
+{
+
+	return ade_set_args(L, "i", MAX_SHIP_PRIMARY_BANKS);
+}
+
+ADE_VIRTVAR(MAX_SHIP_SECONDARY_BANKS,
+	l_GlobalVariables,
+	nullptr,
+	"The maximum secondary banks a ship can have",
+	"number",
+	"A maximum number of secondary banks")
+{
+
+	return ade_set_args(L, "i", MAX_SHIP_SECONDARY_BANKS);
+}
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/libs/globals.cpp
+++ b/code/scripting/api/libs/globals.cpp
@@ -8,8 +8,7 @@
 #include "missionui/missionscreencommon.h"
 #include "playerman/managepilot.h"
 
-namespace scripting {
-namespace api {
+namespace scripting::api {
 
 //**********LIBRARY: Globals
 ADE_LIB(l_GlobalVariables, "GlobalVariables", "gl", "Library of global values");
@@ -68,5 +67,4 @@ ADE_VIRTVAR(MAX_SHIP_SECONDARY_BANKS,
 	return ade_set_args(L, "i", MAX_SHIP_SECONDARY_BANKS);
 }
 
-} // namespace api
-} // namespace scripting
+} // namespace scripting::api

--- a/code/scripting/api/libs/globals.h
+++ b/code/scripting/api/libs/globals.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+DECLARE_ADE_LIB(l_GlobalVariables);
+
+} // namespace api
+} // namespace scripting

--- a/code/scripting/api/libs/globals.h
+++ b/code/scripting/api/libs/globals.h
@@ -2,10 +2,8 @@
 
 #include "scripting/ade_api.h"
 
-namespace scripting {
-namespace api {
+namespace scripting::api {
 
 DECLARE_ADE_LIB(l_GlobalVariables);
 
-} // namespace api
-} // namespace scripting
+} // namespace scripting::api

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -301,8 +301,10 @@ ADE_LIB_DERIV(l_UserInterface_PilotSelect, "PilotSelect", nullptr,
               "API for accessing values specific to the Pilot Select UI.",
               l_UserInterface);
 
-ADE_VIRTVAR(MAX_PILOTS, l_UserInterface_PilotSelect, nullptr, "Gets the maximum number of possible pilots.", "number",
-            "The maximum number of pilots")
+ADE_VIRTVAR_DEPRECATED(MAX_PILOTS, l_UserInterface_PilotSelect, nullptr, "Gets the maximum number of possible pilots.", "number",
+	"The maximum number of pilots",
+	gameversion::version(25, 0, 0, 0),
+	"This variable has moved to the GlobalVariabls library.")
 {
 	return ade_set_args(L, "i", MAX_PILOTS);
 }

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -77,6 +77,7 @@ extern "C" {
 #include "scripting/api/libs/cfile.h"
 #include "scripting/api/libs/controls.h"
 #include "scripting/api/libs/engine.h"
+#include "scripting/api/libs/globals.h"
 #include "scripting/api/libs/graphics.h"
 #include "scripting/api/libs/hookvars.h"
 #include "scripting/api/libs/hud.h"

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1302,6 +1302,8 @@ add_file_folder("Scripting\\\\Api\\\\Libs"
 	scripting/api/libs/controls.h
 	scripting/api/libs/engine.cpp
 	scripting/api/libs/engine.h
+	scripting/api/libs/globals.cpp
+	scripting/api/libs/globals.h
 	scripting/api/libs/graphics.cpp
 	scripting/api/libs/graphics.h
 	scripting/api/libs/hookvars.cpp


### PR DESCRIPTION
Adds a new library for access global variables and defines.

I wanted max ship primary and secondary banks and couldn't decide if that should go in base, ui, tables, or somewhere else. Having it accessible as part of ShipClasses wasn't great because you'd need to access it as part of an existing ship class.

I also wanted access to a couple other global defines and so I decided a global variables library made sense. I could take or leave it if there's a better place to put these, though, as this is purely an organizational question. Actual code access to these values is trivial... they just needed a home.