### PR TITLE
Weapon light bugfix

### DIFF
--- a/code/graphics/color.cpp
+++ b/code/graphics/color.cpp
@@ -71,6 +71,16 @@ void hdr_color::set_rgb(int new_r, int new_g, int new_b)
 }
 
 /**
+ * @brief Sets RGB values from three 0.0-1.0 floats
+ */
+void hdr_color::set_rgb(float new_r, float new_g, float new_b)
+{
+	this->red = new_r;
+	this->green = new_g;
+	this->blue = new_b;
+}
+
+/**
  * @brief Sets RGBA values from an old style color object
  */
 void hdr_color::set_rgb(const color* const new_color)

--- a/code/graphics/color.h
+++ b/code/graphics/color.h
@@ -18,6 +18,7 @@ public:
 	void set_vecf(const SCP_vector<float>& input);
 
 	void set_rgb(const int new_r,const int new_g,const int new_b);
+	void set_rgb(const float new_r,const float new_g,const float new_b);
 	void set_rgb(const color* const new_rgb);
 	void set_rgb(const int* const new_rgb);
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1272,12 +1272,12 @@ void obj_move_all_post(object *objp, float frametime)
 						color c;
 						weapon_get_laser_color(&c, objp);
 						light_color.set_rgb(&c);
-						light_color.set_rgb(fl2i(i2fl(light_color.r()) * r_mult), fl2i(i2fl(light_color.g()) * g_mult), fl2i(i2fl(light_color.b()) * b_mult));
+						light_color.set_rgb(i2fl(light_color.r()) * r_mult, i2fl(light_color.g()) * g_mult, i2fl(light_color.b()) * b_mult);
 						light_color.i(light_color.i() * intensity_mult);
 					} else {
 						// If not a laser then all default information needed is stored in the weapon light color
 						light_color = hdr_color(&wi->light_color);
-						light_color.set_rgb(fl2i(i2fl(light_color.r()) * r_mult), fl2i(i2fl(light_color.g()) * g_mult), fl2i(i2fl(light_color.b()) * b_mult));
+						light_color.set_rgb(i2fl(light_color.r()) * r_mult, i2fl(light_color.g()) * g_mult, i2fl(light_color.b()) * b_mult);
 					}
 					//handles both defaults and adjustments.
 					float light_radius = wi->light_radius;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1266,17 +1266,15 @@ void obj_move_all_post(object *objp, float frametime)
 
 					// If there is no specific color set in the table, laser render weapons have a dynamic color.
 					if (!wi->light_color_set && wi->render_type == WRT_LASER) {
-						// intensity is stored in the light color even if no user setting is done.
-						light_color = hdr_color(&wi->light_color);
 						// Classic dynamic laser color is handled with an old color object
 						color c;
 						weapon_get_laser_color(&c, objp);
 						light_color.set_rgb((c.red/255.f) * r_mult, (c.green/255.f) * g_mult, (c.blue/255.f) * b_mult);
-						light_color.i(light_color.i() * intensity_mult);
+						// intensity is stored in the light color even if no user setting is done.
+						light_color.i(wi->light_color.i() * intensity_mult);
 					} else {
 						// If not a laser then all default information needed is stored in the weapon light color
-						light_color = hdr_color(&wi->light_color);
-						light_color.set_rgb(light_color.r() * r_mult, light_color.g() * g_mult, light_color.b() * b_mult);
+						light_color.set_rgb(wi->light_color.r() * r_mult, wi->light_color.g() * g_mult, wi->light_color.b() * b_mult);
 					}
 					//handles both defaults and adjustments.
 					float light_radius = wi->light_radius;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1271,8 +1271,7 @@ void obj_move_all_post(object *objp, float frametime)
 						// Classic dynamic laser color is handled with an old color object
 						color c;
 						weapon_get_laser_color(&c, objp);
-						light_color.set_rgb(&c);
-						light_color.set_rgb(i2fl(light_color.r()) * r_mult, i2fl(light_color.g()) * g_mult, i2fl(light_color.b()) * b_mult);
+						light_color.set_rgb((i2fl(c.red)/255.f) * r_mult, (i2fl(c.green)/255.f) * g_mult, (i2fl(c.blue)/255.f) * b_mult);
 						light_color.i(light_color.i() * intensity_mult);
 					} else {
 						// If not a laser then all default information needed is stored in the weapon light color

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1276,7 +1276,7 @@ void obj_move_all_post(object *objp, float frametime)
 					} else {
 						// If not a laser then all default information needed is stored in the weapon light color
 						light_color = hdr_color(&wi->light_color);
-						light_color.set_rgb(i2fl(light_color.r()) * r_mult, i2fl(light_color.g()) * g_mult, i2fl(light_color.b()) * b_mult);
+						light_color.set_rgb(light_color.r() * r_mult, light_color.g() * g_mult, light_color.b() * b_mult);
 					}
 					//handles both defaults and adjustments.
 					float light_radius = wi->light_radius;
@@ -1289,7 +1289,7 @@ void obj_move_all_post(object *objp, float frametime)
 						source_radius *= 0.05f;
 						light_radius = lp->missile_light_radius.handle(light_radius) * radius_mult;
 						light_color.i(lp->missile_light_brightness.handle(light_color.i()) * intensity_mult);
-						light_color.set_rgb(i2fl(light_color.r() * r_mult), i2fl(light_color.g()) * g_mult, i2fl(light_color.b()) * b_mult);
+						light_color.set_rgb(light_color.r() * r_mult, light_color.g() * g_mult, light_color.b() * b_mult);
 					}
 					if(light_radius > 0.0f && intensity_mult > 0.0f && light_color.i() > 0.0f)
 						light_add_point(&objp->pos, light_radius, light_radius, &light_color, source_radius);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1271,7 +1271,7 @@ void obj_move_all_post(object *objp, float frametime)
 						// Classic dynamic laser color is handled with an old color object
 						color c;
 						weapon_get_laser_color(&c, objp);
-						light_color.set_rgb((i2fl(c.red)/255.f) * r_mult, (i2fl(c.green)/255.f) * g_mult, (i2fl(c.blue)/255.f) * b_mult);
+						light_color.set_rgb((c.red/255.f) * r_mult, (c.green/255.f) * g_mult, (c.blue/255.f) * b_mult);
 						light_color.i(light_color.i() * intensity_mult);
 					} else {
 						// If not a laser then all default information needed is stored in the weapon light color

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1289,7 +1289,7 @@ void obj_move_all_post(object *objp, float frametime)
 						source_radius *= 0.05f;
 						light_radius = lp->missile_light_radius.handle(light_radius) * radius_mult;
 						light_color.i(lp->missile_light_brightness.handle(light_color.i()) * intensity_mult);
-						light_color.set_rgb(fl2i(i2fl(light_color.r()) * r_mult), fl2i(i2fl(light_color.g()) * g_mult), fl2i(i2fl(light_color.b()) * b_mult));
+						light_color.set_rgb(i2fl(light_color.r() * r_mult), i2fl(light_color.g()) * g_mult, i2fl(light_color.b()) * b_mult);
 					}
 					if(light_radius > 0.0f && intensity_mult > 0.0f && light_color.i() > 0.0f)
 						light_add_point(&objp->pos, light_radius, light_radius, &light_color, source_radius);


### PR DESCRIPTION
Fixes an error with converting between 0.0-1.0 floats and 0-255 ints, introduced in #6319, that caused weapon lights to have a color of 0, 0, 0.