### PR TITLE
Add FSO_BUILD_WITH_OPENXR cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,17 @@ OPTION(FSO_BUILD_WITH_OPENGL_DEBUG "Enables debug option for OpenGL" OFF)
 
 OPTION(FSO_BUILD_WITH_VULKAN "Enable compilation of the Vulkan renderer" OFF)
 
+IF(NOT APPLE)
+	SET(OPENXR_BUILD_DEFAULT ON)
+ELSE()
+	SET(OPENXR_BUILD_DEFAULT OFF)
+ENDIF()
+OPTION(FSO_BUILD_WITH_OPENXR "Build with OpenXR support" ${OPENXR_BUILD_DEFAULT})
+IF(FSO_BUILD_WITH_OPENXR AND APPLE)
+	MESSAGE(WARNING "FSO_BUILD_WITH_OPENXR is ON. Not supported on macOS - setting to OFF.")
+	SET(FSO_BUILD_WITH_OPENXR OFF CACHE BOOL "" FORCE)
+ENDIF()
+
 OPTION(FSO_BUILD_WITH_OPENXR_DEBUG "Enables debug option for OpenXR" OFF)
 
 OPTION(FSO_USE_LTO "Build using LTO (only for release builds)" ON)
@@ -144,6 +155,7 @@ mark_as_advanced(FORCE FSO_BUILD_WITH_FFMPEG)
 mark_as_advanced(FORCE FSO_BUILD_WITH_OPENGL)
 mark_as_advanced(FORCE FSO_BUILD_WITH_OPENGL_DEBUG)
 mark_as_advanced(FORCE FSO_BUILD_WITH_VULKAN)
+mark_as_advanced(FORCE FSO_BUILD_WITH_OPENXR)
 mark_as_advanced(FORCE FSO_BUILD_WITH_OPENXR_DEBUG)
 
 # Include cotire file from https://github.com/sakra/cotire/
@@ -233,3 +245,4 @@ message(STATUS "Release logging: ${FSO_RELEASE_LOGGING}")
 message(STATUS "With FFmpeg: ${FSO_BUILD_WITH_FFMPEG}")
 message(STATUS "With OpenGL: ${FSO_BUILD_WITH_OPENGL}")
 message(STATUS "With Vulkan: ${FSO_BUILD_WITH_VULKAN}")
+message(STATUS "With OpenXR: ${FSO_BUILD_WITH_OPENXR}")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -25,7 +25,11 @@ if (FSO_BUILD_WITH_OPENGL)
 	endif()
 endif()
 
-if(FSO_BUILD_WITH_OPENXR_DEBUG)
+if(FSO_BUILD_WITH_OPENXR)
+	add_definitions(-DFS_OPENXR)
+endif()
+
+if(FSO_BUILD_WITH_OPENXR_DEBUG AND FSO_BUILD_WITH_OPENXR)
 	add_definitions(-DFS_OPENXR_DEBUG)
 endif()
 
@@ -79,7 +83,7 @@ target_link_libraries(code PUBLIC hidapi::hidapi)
 
 target_link_libraries(code PUBLIC imgui)
 
-IF(NOT APPLE)
+IF(FSO_BUILD_WITH_OPENXR)
 	target_link_libraries(code PUBLIC OpenXR::openxr_loader)
 	target_include_directories(code PUBLIC OpenXR::Headers)
 ENDIF()

--- a/code/graphics/opengl/gropenglopenxr.cpp
+++ b/code/graphics/opengl/gropenglopenxr.cpp
@@ -21,7 +21,7 @@
 #include "graphics/opengl/ShaderProgram.h"
 #include "osapi/osapi.h"
 
-#if defined __APPLE_CC__
+#ifndef FS_OPENXR
 
 //Not supported
 
@@ -38,7 +38,7 @@
 
 #include <SDL_syswm.h>
 
-#ifndef __APPLE_CC__
+#ifdef FS_OPENXR
 
 //SETUP FUNCTIONS OGL
 SCP_vector<const char*> gr_opengl_openxr_get_extensions() {

--- a/code/graphics/openxr.cpp
+++ b/code/graphics/openxr.cpp
@@ -9,7 +9,7 @@
 
 std::unique_ptr<star[]> Stars_XRBuffer;
 
-#ifndef __APPLE_CC__
+#ifdef FS_OPENXR
 
 #define XR_MAKE_VERSION_SHORT(major, minor, patch) \
     ((((major) & 0x3ffU) << 20) | (((minor) & 0x3ffU) << 10) | ((patch) & 0x3ffU))
@@ -522,12 +522,13 @@ void openxr_start_frame() {
 }
 
 #else
-//Stubs for Mac, as linking with OpenXR causes issues there.
+// Stubs for when building without OpenXR support.
+// NOTE: macOS has issues linking with OpenXR.
 
 void openxr_prepare(float hudscale) {}
 
 float openxr_preinit(float req_ar, float scale) {
-	mprintf(("Cannot create OpenXR session on macOS.\n"));
+	mprintf(("Cannot create OpenXR session. Not built with OpenXR support.\n"));
 	return 0.0f;
 }
 

--- a/code/graphics/openxr_internal.h
+++ b/code/graphics/openxr_internal.h
@@ -7,7 +7,7 @@
 #include <type_traits>
 #include <tl/optional.hpp>
 
-#ifndef __APPLE_CC__
+#ifdef FS_OPENXR
 
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,6 +61,6 @@ add_subdirectory(hidapi)
 
 ADD_SUBDIRECTORY(imgui)
 
-if(NOT APPLE)
+if(FSO_BUILD_WITH_OPENXR)
 	add_subdirectory(openxr)
 endif()


### PR DESCRIPTION
* Windows and Linux default to ON
* macOS defaults to OFF
* User can override default on the command line

Example usage:
```
cmake -DFSO_BUILD_WITH_OPENXR=OFF
```