### PR TITLE
Add scaling for vfnts and scale multipler to gr_string()

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -788,7 +788,7 @@ subtitle::subtitle(int in_x_pos, int in_y_pos, const char* in_text, const char* 
 		//Get text size
 		for(int i = 0; i < num_text_lines; i++)
 		{
-			gr_get_string_size(&w, &h, text_line_ptrs[i], static_cast<size_t>(text_line_lens[i]));
+			gr_get_string_size(&w, &h, text_line_ptrs[i], 1.0f, static_cast<size_t>(text_line_lens[i]));
 
 			if(w > tw)
 				tw = w;

--- a/code/gamehelp/contexthelp.cpp
+++ b/code/gamehelp/contexthelp.cpp
@@ -499,7 +499,7 @@ void help_overlay_blit(int overlay_id, int resolution_index)
 	font::set_font(help_overlaylist[overlay_id].fontlist.at(resolution_index));
 	for (idx = 0; idx < textcount; idx++) {
 		gr_set_color_fast(&Color_black);
-		gr_get_string_size(&width, &height, help_overlaylist[overlay_id].textlist.at(0).at(idx).string, strlen(help_overlaylist[overlay_id].textlist.at(0).at(idx).string));
+		gr_get_string_size(&width, &height, help_overlaylist[overlay_id].textlist.at(0).at(idx).string, 1.0f, strlen(help_overlaylist[overlay_id].textlist.at(0).at(idx).string));
 		gr_rect(help_overlaylist[overlay_id].textlist.at(resolution_index).at(idx).x_coord-2*HELP_PADDING, help_overlaylist[overlay_id].textlist.at(resolution_index).at(idx).y_coord-3*HELP_PADDING, width+4*HELP_PADDING, height+4*HELP_PADDING, GR_RESIZE_MENU);
 		gr_set_color_fast(&Color_bright_white);
 		gr_printf_menu(help_overlaylist[overlay_id].textlist.at(resolution_index).at(idx).x_coord, help_overlaylist[overlay_id].textlist.at(resolution_index).at(idx).y_coord,

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1008,7 +1008,7 @@ extern void gr_printf_menu_zoomed( int x, int y, const char * format, SCP_FORMAT
 extern void gr_printf_no_resize( int x, int y, const char * format, SCP_FORMAT_STRING ... )  SCP_FORMAT_STRING_ARGS(3, 4);
 
 // Returns the size of the string in pixels in w and h
-extern void gr_get_string_size( int *w, int *h, const char * text, size_t len = std::string::npos );
+extern void gr_get_string_size( int *w, int *h, const char * text, float scaleMultiplier = 1.0f, size_t len = std::string::npos);
 
 // Returns the height of the current font
 extern int gr_get_font_height();

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -510,16 +510,20 @@ extern int get_char_width_old(font* fnt, ubyte c1, ubyte c2, int* width, int* sp
 }
 
 static void gr_string_old(float sx,
-						  float sy,
-						  const char* s,
-						  const char* end,
-						  font::font* fontData,
-						  float height,
-						  int resize_mode) {
+	float sy,
+	const char* s,
+	const char* end,
+	font::font* fontData,
+	float height,
+	bool canScale,
+	int resize_mode,
+	float scaleMultiplier)
+{
 	GR_DEBUG_SCOPE("Render VFNT string");
 
-	int width, spacing, letter;
-	float x, y;
+	int letter;
+	float x = sx;
+	float y = sy;
 	bool do_resize;
 	float bw, bh;
 	float u0, u1, v0, v1;
@@ -530,9 +534,9 @@ static void gr_string_old(float sx,
 	render_mat.set_depth_mode(ZBUFFER_TYPE_NONE);
 	render_mat.set_texture_map(TM_BASE_TYPE, fontData->bitmap_id);
 	render_mat.set_color(gr_screen.current_color.red,
-						 gr_screen.current_color.green,
-						 gr_screen.current_color.blue,
-						 gr_screen.current_color.alpha);
+		gr_screen.current_color.green,
+		gr_screen.current_color.blue,
+		gr_screen.current_color.alpha);
 	render_mat.set_cull_mode(false);
 	render_mat.set_texture_type(material::TEX_TYPE_AABITMAP);
 
@@ -545,7 +549,6 @@ static void gr_string_old(float sx,
 	bw = i2fl(ibw);
 	bh = i2fl(ibh);
 
-	//	if ( (gr_screen.custom_size && resize) || (gr_screen.rendering_to_texture != -1) ) {
 	if (resize_mode != GR_RESIZE_NONE && (gr_screen.custom_size || (gr_screen.rendering_to_texture != -1))) {
 		do_resize = true;
 	} else {
@@ -557,25 +560,25 @@ static void gr_string_old(float sx,
 	int clip_top = ((do_resize) ? gr_screen.clip_top_unscaled : gr_screen.clip_top);
 	int clip_bottom = ((do_resize) ? gr_screen.clip_bottom_unscaled : gr_screen.clip_bottom);
 
-	x = sx;
-	y = sy;
-
-	spacing = 0;
-
 	vertex_layout vert_def;
 
-	vert_def.add_vertex_component(vertex_format_data::POSITION2, sizeof(v4), (int) offsetof(v4, x));
-	vert_def.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(v4), (int) offsetof(v4, u));
+	vert_def.add_vertex_component(vertex_format_data::POSITION2, sizeof(v4), (int)offsetof(v4, x));
+	vert_def.add_vertex_component(vertex_format_data::TEX_COORD2, sizeof(v4), (int)offsetof(v4, u));
 
 	gr_set_2d_matrix();
 
-	// pick out letter coords, draw it, goto next letter and do the same
-	while (s < end) {
-		x += spacing;
+	float scale_factor = Font_Scale_Factor;
+	if (!canScale) {
+		scale_factor = 1.0f;
+	}
 
+	scale_factor *= scaleMultiplier;
+
+	while (s < end) {
+		// Handle line breaks
 		while (*s == '\n') {
 			s++;
-			y += height;
+			y += height * scale_factor;
 			x = sx;
 		}
 
@@ -583,139 +586,93 @@ static void gr_string_old(float sx,
 			break;
 		}
 
-		letter = font::get_char_width_old(fontData, (ubyte)s[0], (ubyte)s[1], &width, &spacing);
+		// Get character width and spacing
+		int raw_width = 0, raw_spacing = 0;
+		letter = font::get_char_width_old(fontData,
+			(ubyte)s[0],
+			(ubyte)s[1],
+			&raw_width,
+			&raw_spacing);
 		s++;
 
-		// not in font, draw as space
+		// Not in font, draw as space
 		if (letter < 0) {
+			x += raw_spacing * scale_factor;
 			continue;
 		}
 
-		float xd, yd, xc, yc;
-		float wc, hc;
-
-		// Check if this character is totally clipped
-		if ((x + width) < clip_left) {
-			continue;
-		}
-
-		if ((y + height) < clip_top) {
-			continue;
-		}
-
-		if (x > clip_right) {
-			continue;
-		}
-
-		if (y > clip_bottom) {
-			continue;
-		}
-
-		xd = yd = 0;
-
-		if (x < clip_left) {
-			xd = clip_left - x;
-		}
-
-		if (y < clip_top) {
-			yd = clip_top - y;
-		}
-
-		xc = x + xd;
-		yc = y + yd;
-
-		wc = width - xd;
-		hc = height - yd;
-
-		if ((xc + wc) > clip_right) {
-			wc = clip_right - xc;
-		}
-
-		if ((yc + hc) > clip_bottom) {
-			hc = clip_bottom - yc;
-		}
-
-		if ((wc < 1) || (hc < 1)) {
-			continue;
-		}
-
+		// UV coordinates
 		int u = fontData->bm_u[letter];
 		int v = fontData->bm_v[letter];
+		float char_width = i2fl(raw_width);
+		float char_height = i2fl(height);
 
+		u0 = u / bw;
+		v0 = v / bh;
+		u1 = (u + char_width) / bw;
+		v1 = (v + char_height) / bh;
+
+		// Scale output dimensions and positions
+		float xc = x; // Keep the X position unscaled
+		float yc = y; // Keep the Y position unscaled
+		float wc = char_width * scale_factor; // Scale width
+		float hc = char_height * scale_factor; // Scale height
+
+		// Apply offsets
 		x1 = xc + ((do_resize) ? gr_screen.offset_x_unscaled : gr_screen.offset_x);
 		y1 = yc + ((do_resize) ? gr_screen.offset_y_unscaled : gr_screen.offset_y);
 		x2 = x1 + wc;
 		y2 = y1 + hc;
 
+		// Check clipping
+		if ((x1 >= clip_right) || (x2 <= clip_left) || (y1 >= clip_bottom) || (y2 <= clip_top)) {
+			x += raw_spacing * scale_factor;
+			continue;
+		}
+
+		// Resize screen positions
 		if (do_resize) {
 			gr_resize_screen_posf(&x1, &y1, NULL, NULL, resize_mode);
 			gr_resize_screen_posf(&x2, &y2, NULL, NULL, resize_mode);
 		}
 
-		u0 = (i2fl(u + xd) / bw);
-		v0 = (i2fl(v + yd) / bh);
+		// Add vertices for the character
+		String_render_buff[buffer_offset++] = {x1, y1, u0, v0};
+		String_render_buff[buffer_offset++] = {x1, y2, u0, v1};
+		String_render_buff[buffer_offset++] = {x2, y1, u1, v0};
+		String_render_buff[buffer_offset++] = {x1, y2, u0, v1};
+		String_render_buff[buffer_offset++] = {x2, y1, u1, v0};
+		String_render_buff[buffer_offset++] = {x2, y2, u1, v1};
 
-		u1 = (i2fl((u + xd) + wc) / bw);
-		v1 = (i2fl((v + yd) + hc) / bh);
-
+		// If the buffer is full, render it now
 		if (buffer_offset == MAX_VERTS_PER_DRAW) {
 			gr_render_primitives_immediate(&render_mat,
-										   PRIM_TYPE_TRIS,
-										   &vert_def,
-										   buffer_offset,
-										   String_render_buff,
-										   sizeof(v4) * buffer_offset);
+				PRIM_TYPE_TRIS,
+				&vert_def,
+				buffer_offset,
+				String_render_buff,
+				sizeof(v4) * buffer_offset);
 			buffer_offset = 0;
 		}
 
-		String_render_buff[buffer_offset].x = x1;
-		String_render_buff[buffer_offset].y = y1;
-		String_render_buff[buffer_offset].u = u0;
-		String_render_buff[buffer_offset].v = v0;
-		buffer_offset++;
-
-		String_render_buff[buffer_offset].x = x1;
-		String_render_buff[buffer_offset].y = y2;
-		String_render_buff[buffer_offset].u = u0;
-		String_render_buff[buffer_offset].v = v1;
-		buffer_offset++;
-
-		String_render_buff[buffer_offset].x = x2;
-		String_render_buff[buffer_offset].y = y1;
-		String_render_buff[buffer_offset].u = u1;
-		String_render_buff[buffer_offset].v = v0;
-		buffer_offset++;
-
-		String_render_buff[buffer_offset].x = x1;
-		String_render_buff[buffer_offset].y = y2;
-		String_render_buff[buffer_offset].u = u0;
-		String_render_buff[buffer_offset].v = v1;
-		buffer_offset++;
-
-		String_render_buff[buffer_offset].x = x2;
-		String_render_buff[buffer_offset].y = y1;
-		String_render_buff[buffer_offset].u = u1;
-		String_render_buff[buffer_offset].v = v0;
-		buffer_offset++;
-
-		String_render_buff[buffer_offset].x = x2;
-		String_render_buff[buffer_offset].y = y2;
-		String_render_buff[buffer_offset].u = u1;
-		String_render_buff[buffer_offset].v = v1;
-		buffer_offset++;
+		// Advance x for the next character
+		x += raw_spacing * scale_factor;
 	}
 
+	// Render remaining vertices in the buffer
 	if (buffer_offset) {
 		gr_render_primitives_immediate(&render_mat,
-									   PRIM_TYPE_TRIS,
-									   &vert_def,
-									   buffer_offset,
-									   String_render_buff,
-									   sizeof(v4) * buffer_offset);
+			PRIM_TYPE_TRIS,
+			&vert_def,
+			buffer_offset,
+			String_render_buff,
+			sizeof(v4) * buffer_offset);
 	}
 
 	gr_end_2d_matrix();
 }
+
+
 
 namespace {
 bool buffering_nanovg = false; //!< flag for when NanoVG buffering is enabled
@@ -779,7 +736,8 @@ void endDrawing(graphics::paths::PathRenderer* path) {
 }
 }
 
-void gr_string(float sx, float sy, const char* s, int resize_mode, size_t in_length) {
+void gr_string(float sx, float sy, const char* s, int resize_mode, float scaleMultiplier, size_t in_length)
+{
 	if (gr_screen.mode == GR_STUB) {
 		return;
 	}
@@ -809,7 +767,7 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, size_t in_len
 		VFNTFont* fnt = static_cast<VFNTFont*>(currentFont);
 		fo::font* fontData = fnt->getFontData();
 
-		gr_string_old(sx, sy, s, s + length, fontData, fnt->getHeight(), resize_mode);
+		gr_string_old(sx, sy, s, s + length, fontData, fnt->getHeight(), currentFont->getScaleBehavior(), resize_mode, scaleMultiplier);
 	} else if (currentFont->getType() == NVG_FONT) {
 		GR_DEBUG_SCOPE("Render TTF string");
 
@@ -821,6 +779,8 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, size_t in_len
 		if (!nvgFont->getScaleBehavior()) {
 			scale_factor = 1.0f;
 		}
+
+		scale_factor *= scaleMultiplier;
 
 		float originalSize = nvgFont->getSize();
 		float scaledSize = originalSize * scale_factor;
@@ -909,7 +869,9 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, size_t in_len
 									  text + 1,
 									  nvgFont->getSpecialCharacterFont(),
 									  nvgFont->getHeight(),
-									  resize_mode);
+									  nvgFont->getScaleBehavior(),
+									  resize_mode,
+									  scaleMultiplier);
 					}
 
 					int width;

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -567,11 +567,7 @@ static void gr_string_old(float sx,
 
 	gr_set_2d_matrix();
 
-	float scale_factor = Font_Scale_Factor;
-	if (!canScale) {
-		scale_factor = 1.0f;
-	}
-
+	float scale_factor = (canScale && !Fred_running) ? Font_Scale_Factor : 1.0f;
 	scale_factor *= scaleMultiplier;
 
 	while (s < end) {
@@ -775,11 +771,7 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, float scaleMu
 
 		auto nvgFont = static_cast<NVGFont*>(currentFont);
 
-		float scale_factor = Font_Scale_Factor;
-		if (!nvgFont->getScaleBehavior()) {
-			scale_factor = 1.0f;
-		}
-
+		float scale_factor = (nvgFont->getScaleBehavior() && !Fred_running) ? Font_Scale_Factor : 1.0f;
 		scale_factor *= scaleMultiplier;
 
 		float originalSize = nvgFont->getSize();

--- a/code/graphics/render.h
+++ b/code/graphics/render.h
@@ -58,20 +58,22 @@ void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode = 
  * @param y The y-coordinate
  * @param string The string to draw to the screen
  * @param resize_mode The mode for translating the screen positions
+ * @param scaleMultiplier The scale to use to apply scaling in addition to user settings
  * @param length The number of bytes in the string to render. -1 will render the whole string.
  */
-void gr_string(float x, float y, const char* string, int resize_mode = GR_RESIZE_FULL, size_t length = std::string::npos);
+void gr_string(float x, float y, const char* string, int resize_mode = GR_RESIZE_FULL, float scaleMultiplier = 1.0f, size_t length = std::string::npos);
 /**
  * @brief Renders the specified string to the screen using the current font and color
  * @param x The x-coordinate
  * @param y The y-coordinate
  * @param string The string to draw to the screen
  * @param resize_mode The mode for translating the screen positions
+ * @param scaleMultiplier The scale to use to apply scaling in addition to user settings
  * @param length The number of bytes in the string to render. -1 will render the whole string.
  */
-inline void gr_string(int x, int y, const char* string, int resize_mode = GR_RESIZE_FULL, size_t length = std::string::npos)
+inline void gr_string(int x, int y, const char* string, int resize_mode = GR_RESIZE_FULL, float scaleMultiplier = 1.0f, size_t length = std::string::npos)
 {
-	gr_string(i2fl(x), i2fl(y), string, resize_mode, length);
+	gr_string(i2fl(x), i2fl(y), string, resize_mode, scaleMultiplier, length);
 }
 
 /**

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -1,4 +1,25 @@
 #include "graphics/software/FSFont.h"
+#include "options/Option.h"
+
+float Font_Scale_Factor = 1.0;
+
+static auto FontScaleFactor __UNUSED = options::OptionBuilder<float>("Game.FontScaleFactor",
+	std::pair<const char*, int>{"Font Scale Factor", 1862},
+	std::pair<const char*, int>{
+		"Sets a multipler to scale fonts by. Only works on fonts the mod has explicitely allowed",
+		1863})
+										   .category(std::make_pair("Game", 1824))
+										   .range(0.2f, 4.0f) // Upper limit is somewhat arbitrary
+										   .level(options::ExpertLevel::Advanced)
+										   .default_val(1.0)
+										   .bind_to(&Font_Scale_Factor)
+										   .importance(55)
+										   .finish();
+
+void removeFontMultiplierOption()
+{
+	options::OptionsManager::instance()->removeOption(FontScaleFactor);
+}
 
 namespace font
 {

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -6,6 +6,8 @@
 
 #include <limits>
 
+extern float Font_Scale_Factor;
+
 namespace font
 {
 	/**
@@ -139,9 +141,10 @@ namespace font
 		* @param textLen		Length of the text. Use -1 if the string should be checked until the next \0 character.
 		* @param [out]	width 	If non-null, the width.
 		* @param [out]	height	If non-null, the height.
+		* @param scaleMultiplier The scale to use to apply scaling in addition to user settings
 		*/
 		virtual void getStringSize(const char *text, size_t textLen = std::numeric_limits<size_t>::max(),
-								   int resize_mode = -1, float *width = NULL, float *height = NULL) const = 0;
+								   int resize_mode = -1, float *width = nullptr, float *height = nullptr, float scaleMultiplier = 1.0f) const = 0;
 
 		/**
 		 * @brief	Gets the scaling behavior of this font

--- a/code/graphics/software/FontManager.cpp
+++ b/code/graphics/software/FontManager.cpp
@@ -96,7 +96,7 @@ namespace font
 	{
 		return std::any_of(fonts.begin(), fonts.end(), [](const std::unique_ptr<FSFont>& font) {
 			const auto& thisFont = font.get();
-			return thisFont->getType() == NVG_FONT && thisFont->getScaleBehavior();
+			return thisFont->getScaleBehavior();
 		});
 	}
 

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -9,23 +9,6 @@
 
 #include <limits>
 
-float Font_Scale_Factor = 1.0;
-
-static auto FontScaleFactor __UNUSED = options::OptionBuilder<float>("Game.FontScaleFactor",
-										   std::pair<const char*, int>{"Font Scale Factor", 1862},
-										   std::pair<const char*, int>{"Sets a multipler to scale fonts by. Only works on fonts the mod has explicitely allowed", 1863})
-										   .category(std::make_pair("Game", 1824))
-										   .range(0.2f, 4.0f) // Upper limit is somewhat arbitrary
-										   .level(options::ExpertLevel::Advanced)
-										   .default_val(1.0)
-										   .bind_to(&Font_Scale_Factor)
-										   .importance(55)
-										   .finish();
-
-void removeFontMultiplierOption() {
-	options::OptionsManager::instance()->removeOption(FontScaleFactor);
-}
-
 namespace
 {
 	const char* const TOKEN_SEPARATORS = "\n\t\r";
@@ -129,7 +112,7 @@ namespace font
 	}
 
 	extern int get_char_width_old(font* fnt, ubyte c1, ubyte c2, int *width, int* spacing);
-	void NVGFont::getStringSize(const char *text, size_t textLen, int resize_mode, float *width, float *height) const
+	void NVGFont::getStringSize(const char *text, size_t textLen, int resize_mode, float *width, float *height, float scaleMultiplier) const
 	{
 		using namespace graphics::paths;
 
@@ -142,6 +125,7 @@ namespace font
 		if (!canScale) {
 			scale_factor = 1.0f;
 		}
+		scale_factor *= scaleMultiplier;
 
 		path->fontFaceId(m_handle);
 		path->fontSize(m_size * scale_factor);

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -121,10 +121,7 @@ namespace font
 		path->saveState();
 		path->resetState();
 
-		float scale_factor = Font_Scale_Factor;
-		if (!canScale) {
-			scale_factor = 1.0f;
-		}
+		float scale_factor = (canScale && !Fred_running) ? Font_Scale_Factor : 1.0f;
 		scale_factor *= scaleMultiplier;
 
 		path->fontFaceId(m_handle);

--- a/code/graphics/software/NVGFont.h
+++ b/code/graphics/software/NVGFont.h
@@ -3,8 +3,6 @@
 #include "globalincs/pstypes.h"
 #include "graphics/software/FSFont.h"
 
-extern float Font_Scale_Factor;
-
 namespace font
 {
 	struct font;
@@ -41,7 +39,7 @@ namespace font
 		float getTextHeight() const override;
 
 		void getStringSize(const char *text, size_t textLen, int resize_mode,
-			float *width, float *height) const override;
+			float *width, float *height, float scaleMultiplier = 1.0f) const override;
 
 		void computeFontMetrics() override;
 

--- a/code/graphics/software/VFNTFont.cpp
+++ b/code/graphics/software/VFNTFont.cpp
@@ -94,10 +94,7 @@ namespace font
 			}
 		}
 
-		float scale_factor = Font_Scale_Factor;
-		if (!canScale) {
-			scale_factor = 1.0f;
-		}
+		float scale_factor = (canScale && !Fred_running) ? Font_Scale_Factor : 1.0f;
 		scale_factor *= scaleMultiplier;
 
 		if (h1)

--- a/code/graphics/software/VFNTFont.cpp
+++ b/code/graphics/software/VFNTFont.cpp
@@ -34,7 +34,7 @@ namespace font
 	}
 
 	extern int get_char_width_old(font* fnt, ubyte c1, ubyte c2, int *width, int* spacing);
-	void VFNTFont::getStringSize(const char *text, size_t textSize, int /* resize_mode */, float *w1, float *h1) const
+	void VFNTFont::getStringSize(const char *text, size_t textSize, int /* resize_mode */, float *w1, float *h1, float scaleMultiplier) const
 	{
 		int longest_width;
 		int width, spacing;
@@ -94,11 +94,17 @@ namespace font
 			}
 		}
 
+		float scale_factor = Font_Scale_Factor;
+		if (!canScale) {
+			scale_factor = 1.0f;
+		}
+		scale_factor *= scaleMultiplier;
+
 		if (h1)
-			*h1 = i2fl(h);
+			*h1 = i2fl(h) * scale_factor;
 
 		if (w1)
-			*w1 = i2fl(longest_width);
+			*w1 = i2fl(longest_width) * scale_factor;
 	}
 
 	font::font() : kern_data(NULL),

--- a/code/graphics/software/VFNTFont.h
+++ b/code/graphics/software/VFNTFont.h
@@ -65,8 +65,9 @@ namespace font
 		* @param	resize_mode		The used resize mode
 		* @param [out]	width 	If non-null, the width.
 		* @param [out]	height	If non-null, the height.
+		* @param scaleMultiplier The scale to use to apply scaling in addition to user settings
 		*/
 		void
-		getStringSize(const char* text, size_t textLen, int resize_mode, float* width, float* height) const override;
+		getStringSize(const char* text, size_t textLen, int resize_mode, float* width, float* height, float scaleMultiplier = 1.0f) const override;
 	};
 }

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -539,11 +539,11 @@ namespace font
 		font_initialized = false;
 	}
 
-	int force_fit_string(char *str, int max_str, int max_width)
+	int force_fit_string(char *str, int max_str, int max_width, float scale)
 	{
 		int w;
 
-		gr_get_string_size(&w, NULL, str);
+		gr_get_string_size(&w, nullptr, str, scale);
 		if (w > max_width) {
 			if ((int)strlen(str) > max_str - 3) {
 				Assert(max_str >= 3);
@@ -551,11 +551,11 @@ namespace font
 			}
 
 			strcpy(str + strlen(str) - 1, "...");
-			gr_get_string_size(&w, NULL, str);
+			gr_get_string_size(&w, nullptr, str, scale);
 			while (w > max_width) {
 				Assert(strlen(str) >= 4);  // if this is hit, a bad max_width was passed in and the calling function needs fixing.
 				strcpy(str + strlen(str) - 4, "...");
-				gr_get_string_size(&w, NULL, str);
+				gr_get_string_size(&w, nullptr, str, scale);
 			}
 		}
 

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -395,6 +395,14 @@ namespace
 			}
 		}
 
+		if (optional_string("+Can Scale:")) {
+			bool temp;
+
+			stuff_boolean(&temp);
+
+			font->setScaleBehavior(temp);
+		}
+
 		if (optional_string("+Top offset:"))
 		{
 			float temp;
@@ -705,7 +713,7 @@ int gr_get_dynamic_font_lines(int number_default_lines) {
 	return fl2i((number_default_lines * 10) / (gr_get_font_height() + 1));
 }
 
-void gr_get_string_size(int *w1, int *h1, const char *text, size_t len)
+void gr_get_string_size(int* w1, int* h1, const char* text, float scaleMultiplier, size_t len)
 {
 	if (!FontManager::isReady())
 	{
@@ -721,7 +729,7 @@ void gr_get_string_size(int *w1, int *h1, const char *text, size_t len)
 	float w = 0.0f;
 	float h = 0.0f;
 
-	FontManager::getCurrentFont()->getStringSize(text, len, -1, &w, &h);
+	FontManager::getCurrentFont()->getStringSize(text, len, -1, &w, &h, scaleMultiplier);
 
 	if (w1)
 	{

--- a/code/graphics/software/font.h
+++ b/code/graphics/software/font.h
@@ -31,7 +31,7 @@ namespace font
 	* @param max_width number of pixels to limit string to (less than or equal to).
 	* @return			The width of the string
 	*/
-	int force_fit_string(char *str, int max_str, int max_width);
+	int force_fit_string(char *str, int max_str, int max_width, float scale = 1.0f);
 
 	/**
 	* @brief Inites the font system

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -305,7 +305,7 @@ void HudGaugeMessages::processMessageBuffer()
 		ptr = strstr(msg, NOX(": "));
 		if ( ptr ) {
 			int sw;
-			gr_get_string_size(&sw, nullptr, msg, (ptr + 2 - msg));
+			gr_get_string_size(&sw, nullptr, msg, 1.0f, (ptr + 2 - msg));
 			offset = sw;
 		}
 
@@ -641,7 +641,7 @@ void hud_add_msg_to_scrollback(const char *text, int source, int t)
 
 	// determine the length of the sender's name for underlining
 	if (ptr) {
-		gr_get_string_size(&w, nullptr, buf, (ptr - buf));
+		gr_get_string_size(&w, nullptr, buf, 1.0f, (ptr - buf));
 	}
 
 	// create the new node for the vector
@@ -843,7 +843,7 @@ void hud_initialize_scrollback_lines()
 
 			int width = 0;
 			int height = 0;
-			gr_get_string_size(&width, &height, node_msg.text.c_str(), node_msg.text.length());
+			gr_get_string_size(&width, &height, node_msg.text.c_str(), 1.0f, node_msg.text.length());
 
 			int max_width = Hud_mission_log_list2_coords[gr_screen.res][2];
 			if (width > max_width) {

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -654,7 +654,7 @@ void credits_init()
 
 	for (iter = Credit_text_parts.begin(); iter != Credit_text_parts.end(); ++iter)
 	{
-		gr_get_string_size(NULL, &temp_h, iter->c_str(), iter->length());
+		gr_get_string_size(NULL, &temp_h, iter->c_str(), 1.0f, iter->length());
 
 		h = h + temp_h;
 	}
@@ -870,12 +870,12 @@ void credits_do_frame(float  /*frametime*/)
 				length = std::numeric_limits<size_t>::max();
 			}
 
-			gr_get_string_size(&width, &height, iter->c_str() + currentPos, length);
+			gr_get_string_size(&width, &height, iter->c_str() + currentPos, 1.0f, length);
 			// Check if the text part is actually visible
 			if (Credit_position + y_offset + height > 0.0f)
 			{
 				float x = static_cast<float>((gr_screen.clip_width_unscaled - width) / 2);
-				gr_string(x, Credit_position + y_offset, iter->c_str() + currentPos, GR_RESIZE_MENU, length);
+				gr_string(x, Credit_position + y_offset, iter->c_str() + currentPos, GR_RESIZE_MENU, 1.0f, length);
 			}
 
 			y_offset += height;

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -654,7 +654,7 @@ void credits_init()
 
 	for (iter = Credit_text_parts.begin(); iter != Credit_text_parts.end(); ++iter)
 	{
-		gr_get_string_size(NULL, &temp_h, iter->c_str(), 1.0f, iter->length());
+		gr_get_string_size(nullptr, &temp_h, iter->c_str(), 1.0f, iter->length());
 
 		h = h + temp_h;
 	}

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -457,7 +457,7 @@ void techroom_render_desc(int xo, int yo, int ho)
 		int more_txt_x = Tech_desc_coords[gr_screen.res][0] + (Tech_desc_coords[gr_screen.res][2]/2) - 10;	// FIXME should move these to constants since they don't move
 		int more_txt_y = Tech_desc_coords[gr_screen.res][1] + Tech_desc_coords[gr_screen.res][3];				// located below brief text, centered
 		int w, h;
-		gr_get_string_size(&w, &h, XSTR("more", 1469), static_cast<int>(strlen(XSTR("more", 1469))));
+		gr_get_string_size(&w, &h, XSTR("more", 1469), 1.0f, static_cast<int>(strlen(XSTR("more", 1469))));
 		gr_set_color_fast(&Color_black);
 		gr_rect(more_txt_x-2, more_txt_y, w+3, h, GR_RESIZE_MENU);
 		gr_set_color_fast(&Color_more_indicator);

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -475,7 +475,7 @@ void fiction_viewer_do_frame(float frametime)
 		int more_txt_x = Fiction_viewer_text_coordinates[Fiction_viewer_ui][gr_screen.res][0] + (Fiction_viewer_text_coordinates[Fiction_viewer_ui][gr_screen.res][2]/2) - 10;
 		int more_txt_y = Fiction_viewer_text_coordinates[Fiction_viewer_ui][gr_screen.res][1] + Fiction_viewer_text_coordinates[Fiction_viewer_ui][gr_screen.res][3];				// located below text, centered
 
-		gr_get_string_size(&w, &h, XSTR("more", 1469), (int)strlen(XSTR("more", 1469)));
+		gr_get_string_size(&w, &h, XSTR("more", 1469), 1.0f, (int)strlen(XSTR("more", 1469)));
 		gr_set_color_fast(&Color_black);
 		gr_rect(more_txt_x-2, more_txt_y, w+3, h, GR_RESIZE_MENU);
 		gr_set_color_fast(&Color_more_indicator);

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -1230,7 +1230,7 @@ void brief_render(float frametime)
 			int more_txt_x = Brief_text_coords[gr_screen.res][0] + (Brief_max_line_width[gr_screen.res]/2) - 10;
 			int more_txt_y = Brief_text_coords[gr_screen.res][1] + Brief_text_coords[gr_screen.res][3] - 2;				// located below brief text, centered
 
-			gr_get_string_size(&w, &h, XSTR("more", 1469), (int)strlen(XSTR("more", 1469)));
+			gr_get_string_size(&w, &h, XSTR("more", 1469), 1.0f, (int)strlen(XSTR("more", 1469)));
 			gr_set_color_fast(&Color_black);
 			gr_rect(more_txt_x-2, more_txt_y, w+3, h, GR_RESIZE_MENU);
 			gr_set_color_fast(&Color_more_indicator);

--- a/code/missionui/missioncmdbrief.cpp
+++ b/code/missionui/missioncmdbrief.cpp
@@ -763,7 +763,7 @@ void cmd_brief_do_frame(float frametime)
 		int more_txt_x = Cmd_text_wnd_coords[Uses_scroll_buttons][gr_screen.res][CMD_X_COORD] + (Cmd_text_wnd_coords[Uses_scroll_buttons][gr_screen.res][CMD_W_COORD]/2) - 10;
 		int more_txt_y = Cmd_text_wnd_coords[Uses_scroll_buttons][gr_screen.res][CMD_Y_COORD] + Cmd_text_wnd_coords[Uses_scroll_buttons][gr_screen.res][CMD_H_COORD] - 2;				// located below brief text, centered
 
-		gr_get_string_size(&w, &h, XSTR("more", 1469), static_cast<int>(strlen(XSTR("more", 1469))));
+		gr_get_string_size(&w, &h, XSTR("more", 1469), 1.0f, static_cast<int>(strlen(XSTR("more", 1469))));
 		gr_set_color_fast(&Color_black);
 		gr_rect(more_txt_x-2, more_txt_y, w+3, h, GR_RESIZE_MENU);
 		gr_set_color_fast(&Color_more_indicator);

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2387,7 +2387,7 @@ void wl_render_weapon_desc(float frametime)
 
 				// draw the bright letters
 				gr_set_color_fast(&Color_bright_white);
-				gr_get_string_size(&w, &h, Weapon_desc_lines[i], curr_len);
+				gr_get_string_size(&w, &h, Weapon_desc_lines[i], 1.0f, curr_len);
 				gr_printf_menu(weapon_title_coords[0]+w, weapon_title_coords[1]+(line_height*i), "%c", bright_char[i]);
 
 				// restore the bright char to the string
@@ -2415,7 +2415,7 @@ void wl_render_weapon_desc(float frametime)
 
 				// draw the bright letters
 				gr_set_color_fast(&Color_bright_white);
-				gr_get_string_size(&w, &h, Weapon_desc_lines[i], curr_len);
+				gr_get_string_size(&w, &h, Weapon_desc_lines[i], 1.0f, curr_len);
 				gr_printf_menu(weapon_desc_coords[0]+w, weapon_desc_coords[1]+(line_height*(i-2)), "%c", bright_char[i]);
 
 				// restore the bright char to the string
@@ -2467,7 +2467,7 @@ void wl_weapon_desc_start_wipe()
 
 	// break title into two lines if too long
 	strcpy_s(Weapon_desc_lines[0], Weapon_info[Selected_wl_class].title);
-	gr_get_string_size(&w, &h, Weapon_info[Selected_wl_class].title, title_len);
+	gr_get_string_size(&w, &h, Weapon_info[Selected_wl_class].title, 1.0f, title_len);
 	if (w > Weapon_title_max_width[gr_screen.res]) {
 		// split
 		currchar_src = (size_t)(((float)title_len / (float)w) * Weapon_title_max_width[gr_screen.res]);			// char to start space search at
@@ -2979,7 +2979,7 @@ void wl_render_icon_count(int num, int x, int y)
 	Assert(number_to_draw >= 0);
 
 	sprintf(buf, "%d", number_to_draw);
-	gr_get_string_size(&num_w, &num_h, buf, strlen(buf));
+	gr_get_string_size(&num_w, &num_h, buf, 1.0f, strlen(buf));
 
 	// render
 	gr_set_color_fast(&Color_white);

--- a/code/osapi/DebugWindow.cpp
+++ b/code/osapi/DebugWindow.cpp
@@ -145,7 +145,7 @@ float DebugWindow::print_line(float bottom_y, const LineInfo& line) {
 	gr_set_color_fast(&Color_white);
 
 	for (size_t i = 0; i < split_lines.size(); ++i) {
-		gr_string(max_category_width + 18.f, y_pos, split_lines[i], GR_RESIZE_NONE, static_cast<size_t>(line_lengths[i]));
+		gr_string(max_category_width + 18.f, y_pos, split_lines[i], GR_RESIZE_NONE, 1.0f, static_cast<size_t>(line_lengths[i]));
 
 		y_pos += font::get_current_font()->getHeight();
 	}

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3506,7 +3506,7 @@ char *split_str_once(char *src, int max_pixel_w)
 	size_t i;
 	size_t len = strlen(src);
 	for (i=0; i<len; i++) {
-		gr_get_string_size(&w, nullptr, src, i + 1);
+		gr_get_string_size(&w, nullptr, src, 1.0f, i + 1);
 
 		if (w <= max_pixel_w) {
 			if (src[i] == '\n') {  // reached natural end of line
@@ -3878,7 +3878,7 @@ SCP_vector<std::pair<size_t, size_t>> str_wrap_to_width(const SCP_string& source
 		// no newlines found, check length.
 		size_t stringlen = pos_end - pos_start;
 		int line_width = 0;
-		gr_get_string_size(&line_width, nullptr, source_string.c_str() + pos_start, stringlen);
+		gr_get_string_size(&line_width, nullptr, source_string.c_str() + pos_start, 1.0f, stringlen);
 		if (stringlen <= 1) {
 			// in this case checking is pointless, single-character strings can't wrap.
 			// copy into the return vector and then bail.
@@ -3895,7 +3895,7 @@ SCP_vector<std::pair<size_t, size_t>> str_wrap_to_width(const SCP_string& source
 			size_t center = 0;
 			while ((search_max - search_min) > 0) {
 				center = search_min + ((search_max - search_min) / 2);
-				gr_get_string_size(&line_width, nullptr, source_string.c_str() + pos_start, center);
+				gr_get_string_size(&line_width, nullptr, source_string.c_str() + pos_start, 1.0f, center);
 				if (line_width == max_pixel_width) {
 					search_max = center;
 					search_min = center;
@@ -3981,7 +3981,7 @@ SCP_vector<std::pair<size_t, size_t>> str_wrap_to_width(const char* source_strin
 		// no newlines found, check length.
 		size_t stringlen = ch_end - ch_start;
 		int line_width = 0;
-		gr_get_string_size(&line_width, nullptr, ch_start, stringlen);
+		gr_get_string_size(&line_width, nullptr, ch_start, 1.0f, stringlen);
 		if (stringlen <= 1) {
 			// in this case checking is pointless, single-character strings can't wrap.
 			// copy into the return vector and then bail.
@@ -3998,7 +3998,7 @@ SCP_vector<std::pair<size_t, size_t>> str_wrap_to_width(const char* source_strin
 			size_t center = 0;
 			while ((search_max - search_min) > 0) {
 				center = search_min + ((search_max - search_min) / 2);
-				gr_get_string_size(&line_width, nullptr, ch_start, center);
+				gr_get_string_size(&line_width, nullptr, ch_start, 1.0f, center);
 				if (line_width == max_pixel_width) {
 					search_max = center;
 					search_min = center;

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3487,7 +3487,7 @@ void display_parse_diagnostics()
 // terminator is placed where required to make the first line <= max_pixel_w.  The remaining
 // text is returned (leading whitespace removed).  If the line doesn't need to be split,
 // NULL is returned.
-char *split_str_once(char *src, int max_pixel_w)
+char *split_str_once(char *src, int max_pixel_w, float scale)
 {
 	char *brk = nullptr;
 	bool last_was_white = false;
@@ -3498,7 +3498,7 @@ char *split_str_once(char *src, int max_pixel_w)
 		return src;  // if there's no width, skip everything else
 
 	int w;
-	gr_get_string_size(&w, nullptr, src);
+	gr_get_string_size(&w, nullptr, src, scale);
 	if ( (w <= max_pixel_w) && !strstr(src, "\n") ) {
 		return nullptr;  // string doesn't require a cut
 	}
@@ -3506,7 +3506,7 @@ char *split_str_once(char *src, int max_pixel_w)
 	size_t i;
 	size_t len = strlen(src);
 	for (i=0; i<len; i++) {
-		gr_get_string_size(&w, nullptr, src, 1.0f, i + 1);
+		gr_get_string_size(&w, nullptr, src, scale, i + 1);
 
 		if (w <= max_pixel_w) {
 			if (src[i] == '\n') {  // reached natural end of line

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -337,7 +337,7 @@ extern size_t maybe_convert_foreign_characters(const char *in, char *out, bool a
 extern void maybe_convert_foreign_characters(SCP_string &text);
 extern size_t get_converted_string_length(const char *text);
 extern size_t get_converted_string_length(const SCP_string &text);
-char *split_str_once(char *src, int max_pixel_w);
+char *split_str_once(char *src, int max_pixel_w, float scale = 1.0f);
 int split_str(const char* src,
 			  int max_pixel_w,
 			  int* n_chars,

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1404,7 +1404,7 @@ static int drawString_sub(lua_State *L, bool use_resize_arg)
 		for(const auto &line: lines)
 		{
 			//Draw the string
-			gr_string(x, curr_y, s + line.first, resize_mode, line.second);
+			gr_string(x, curr_y, s + line.first, resize_mode, 1.0f, line.second);
 
 			//Increment line height
 			curr_y += line_ht;


### PR DESCRIPTION
Adds two features for string handling:

First it adds scaling ability to Volition fonts which brings them into parity with TTF fonts. In doing so it made sense to move the font scale option out of the TTF font cpp file and into the general font cpp file. Notably, allowing players to scale fonts is currently opt-in. Now that all font types can scale, there's possibly an argument to make them opt-out. I could go either way, personally.

Second it adds a scale multiplier to gr_string(). This will be used for the HUD Config upgrade and it basically allows a gr_string() call to multiply the user's font scale up or down by a percentage. Think of it like a C++ version of CSS's `em` font size capability. This did change the signature of gr_string() because I felt `scaleMultiplier` had more utility than the `length` parameter and there were only a handful of places where `length` was used so it was fairly trivial to update them.