### PR TITLE
Add '-campaign' cmdline option to set current campaign

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -417,8 +417,10 @@ int Cmdline_no_enhanced_sound = 0;
 
 // MOD related
 cmdline_parm mod_arg("-mod", "List of folders to overwrite/add-to the default data", AT_STRING, true);	// Cmdline_mod  -- DTP modsupport
+cmdline_parm campaign_arg("-campaign", "Set current campaign", AT_STRING);	// Cmdline_campaign
 
 char *Cmdline_mod = NULL; //DTP for mod argument
+char *Cmdline_campaign = nullptr; // for campaign argument
 
 // Multiplayer/Network related
 cmdline_parm almission_arg("-almission", "Autoload multiplayer mission", AT_STRING);		// Cmdline_almission  -- DTP for autoload Multi mission
@@ -1874,6 +1876,14 @@ bool SetCmdlineParams()
 		Cmdline_mod = modlist;
 	}
 
+	if(campaign_arg.found()) {
+		Cmdline_campaign = campaign_arg.str();
+
+		// strip off blank space if it's there
+		if ( Cmdline_campaign[strlen(Cmdline_campaign)-1] == ' ' ) {
+			Cmdline_campaign[strlen(Cmdline_campaign)-1] = '\0';
+		}
+	}
 
 	if (fps_arg.found())
 	{

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -92,6 +92,7 @@ extern int Cmdline_no_enhanced_sound;
 
 // MOD related
 extern char *Cmdline_mod;	 // DTP for mod support
+extern char *Cmdline_campaign;	 // for campaign support
 // Multiplayer/Network related
 extern char *Cmdline_almission;	// DTP for autoload mission (for multi only)
 extern int Cmdline_ingamejoin;


### PR DESCRIPTION
The `-campaign` cmdline option allows the current campaign to be set on FSO launch so that the player isn't interrupted by the "The currently active campaign cannot be found" dialog when changing mods.

Example usage:
```
fs2_open -campaign freespace -mod fsport
```

When `-campaign` is set to a valid campaign name, the following dialog will not pop up when changing mods.

![fso-active-campaign-cannot-be-found](https://github.com/user-attachments/assets/1f462312-b428-43ab-afb7-b0fab0b2e987)
