### PR TITLE
Add scaling features to additional bitmap drawing methods

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -1896,7 +1896,7 @@ void gr_set_shader(shader *shade)
 }
 
 // new bitmap functions
-void gr_bitmap(int _x, int _y, int resize_mode)
+void gr_bitmap(int _x, int _y, int resize_mode, bool mirror, float scale_factor)
 {
 	GR_DEBUG_SCOPE("2D Bitmap");
 
@@ -1909,6 +1909,11 @@ void gr_bitmap(int _x, int _y, int resize_mode)
 	}
 
 	bm_get_info(gr_screen.current_bitmap, &_w, &_h, NULL, NULL, NULL);
+
+	if (scale_factor != 1.0f) {
+		_w = static_cast<int>(_w * scale_factor);
+		_h = static_cast<int>(_h * scale_factor);
+	}
 
 	x = i2fl(_x);
 	y = i2fl(_y);
@@ -1924,22 +1929,22 @@ void gr_bitmap(int _x, int _y, int resize_mode)
 
 	verts[0].screen.xyw.x = x;
 	verts[0].screen.xyw.y = y;
-	verts[0].texture_position.u = 0.0f;
+	verts[0].texture_position.u = mirror ? 1.0f : 0.0f;
 	verts[0].texture_position.v = 0.0f;
 
 	verts[1].screen.xyw.x = x + w;
 	verts[1].screen.xyw.y = y;
-	verts[1].texture_position.u = 1.0f;
+	verts[1].texture_position.u = mirror ? 0.0f : 1.0f;
 	verts[1].texture_position.v = 0.0f;
 
 	verts[2].screen.xyw.x = x + w;
 	verts[2].screen.xyw.y = y + h;
-	verts[2].texture_position.u = 1.0f;
+	verts[2].texture_position.u = mirror ? 0.0f : 1.0f;
 	verts[2].texture_position.v = 1.0f;
 
 	verts[3].screen.xyw.x = x;
 	verts[3].screen.xyw.y = y + h;
-	verts[3].texture_position.u = 0.0f;
+	verts[3].texture_position.u = mirror ? 1.0f : 0.0f;
 	verts[3].texture_position.v = 1.0f;
 
 	// turn off zbuffering

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -1317,7 +1317,7 @@ void gr_create_shader(shader *shade, ubyte r, ubyte g, ubyte b, ubyte c);
 void gr_set_shader(shader *shade);
 
 // new bitmap functions
-void gr_bitmap(int x, int y, int resize_mode = GR_RESIZE_FULL);
+void gr_bitmap(int x, int y, int resize_mode = GR_RESIZE_FULL, bool mirror = false, float scale_factor = 1.0f);
 void gr_bitmap_uv(int _x, int _y, int _w, int _h, float _u0, float _v0, float _u1, float _v1, int resize_mode = GR_RESIZE_FULL);
 
 // special function for drawing polylines. this function is specifically intended for

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -245,25 +245,36 @@ void gr_aabitmap(int x, int y, int resize_mode, bool mirror, float scale_factor)
 					   &gr_screen.current_color,
 					   scale_factor);
 }
-void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode, bool mirror) {
+void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode, bool mirror, float scale_factor) {
 	if (gr_screen.mode == GR_STUB) {
 		return;
 	}
-
 
 	int reclip;
 #ifndef NDEBUG
 	int count = 0;
 #endif
 
+	int bw, bh, do_resize;
+
+	bm_get_info(gr_screen.current_bitmap, &bw, &bh);
+
+	if (scale_factor != 1.0f) {
+		bw = fl2i(bw * scale_factor);
+		bh = fl2i(bh * scale_factor);
+
+		// If we're scaling then we need to scale these to make sure the right and bottom clip planes are scaled as well
+		w = fl2i(w * scale_factor);
+		h = fl2i(h * scale_factor);
+
+		sx = fl2i(sx * scale_factor);
+		sy = fl2i(sy * scale_factor);
+	}
+
 	int dx1 = x;
 	int dx2 = x + w - 1;
 	int dy1 = y;
 	int dy2 = y + h - 1;
-
-	int bw, bh, do_resize;
-
-	bm_get_info(gr_screen.current_bitmap, &bw, &bh);
 
 	if (resize_mode != GR_RESIZE_NONE && (gr_screen.custom_size || (gr_screen.rendering_to_texture != -1))) {
 		do_resize = 1;
@@ -312,7 +323,6 @@ void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode,
 		if (dy2 > clip_bottom) {
 			dy2 = clip_bottom;
 		}
-
 
 		if (sx < 0) {
 			dx1 -= sx;
@@ -365,18 +375,19 @@ void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode,
 
 	// We now have dx1,dy1 and dx2,dy2 and sx, sy all set validly within clip regions.
 	bitmap_ex_internal(dx1,
-					   dy1,
-					   (dx2 - dx1 + 1),
-					   (dy2 - dy1 + 1),
-					   sx,
-					   sy,
-					   resize_mode,
-					   true,
-					   mirror,
-					   &gr_screen.current_color);
+		dy1,
+		(dx2 - dx1 + 1),
+		(dy2 - dy1 + 1),
+		sx,
+		sy,
+		resize_mode,
+		true,
+		mirror,
+		&gr_screen.current_color,
+		scale_factor);
 }
 //these are penguins bitmap functions
-void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode) {
+void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode, bool mirror, float scale_factor) {
 	if (gr_screen.mode == GR_STUB) {
 		return;
 	}
@@ -386,14 +397,26 @@ void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode) {
 	int count = 0;
 #endif
 
+	int bw, bh, do_resize;
+
+	bm_get_info(gr_screen.current_bitmap, &bw, &bh);
+
+	if (scale_factor != 1.0f) {
+		bw = fl2i(bw * scale_factor);
+		bh = fl2i(bh * scale_factor);
+
+		// If we're scaling then we need to scale these to make sure the right and bottom clip planes are scaled as well
+		w = fl2i(w * scale_factor);
+		h = fl2i(h * scale_factor);
+
+		sx = fl2i(sx * scale_factor);
+		sy = fl2i(sy * scale_factor);
+	}
+
 	int dx1 = x;
 	int dx2 = x + w - 1;
 	int dy1 = y;
 	int dy2 = y + h - 1;
-
-	int bw, bh, do_resize;
-
-	bm_get_info(gr_screen.current_bitmap, &bw, &bh);
 
 	if (resize_mode != GR_RESIZE_NONE && (gr_screen.custom_size || (gr_screen.rendering_to_texture != -1))) {
 		do_resize = 1;
@@ -496,7 +519,7 @@ void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode) {
 	gr_init_alphacolor(&clr, 255, 255, 255, fl2i(gr_screen.current_alpha * 255.0f));
 
 	// We now have dx1,dy1 and dx2,dy2 and sx, sy all set validly within clip regions.
-	bitmap_ex_internal(dx1, dy1, (dx2 - dx1 + 1), (dy2 - dy1 + 1), sx, sy, resize_mode, false, false, &clr);
+	bitmap_ex_internal(dx1, dy1, (dx2 - dx1 + 1), (dy2 - dy1 + 1), sx, sy, resize_mode, false, mirror, &clr, scale_factor);
 }
 
 #define MAX_VERTS_PER_DRAW 300

--- a/code/graphics/render.h
+++ b/code/graphics/render.h
@@ -32,25 +32,28 @@ void gr_aabitmap(int x, int y, int resize_mode = GR_RESIZE_FULL, bool mirror = f
  * @brief Draws a grey-scale bitmap multiplied with the current color
  * @param x The x-coordinate of the draw call
  * @param y The y-coordinate of the draw call
- * @param w
- * @param h
- * @param sx
- * @param sy
+ * @param w Resolves to the x axis right clip plane, usually <= bitmap width
+ * @param h Resolves to the y axis right clip plane, usually <= bitmap height
+ * @param sx The bitmap source x coordinate to start rendering from at the x 0 coordinate
+ * @param sy The bitmap source y coordinate to start rendering from at the y 0 coordinate
  * @param resize_mode The resize mode for translating the coordinated
  * @param mirror @c true to mirror the image
+ * @param scale_factor a multipler for the width and height of the bitmap. Note that w, h, sx, and sy should be unscaled source bitmap values
  */
-void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode = GR_RESIZE_FULL, bool mirror = false);
+void gr_aabitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode = GR_RESIZE_FULL, bool mirror = false, float scale_factor = 1.0f);
 /**
  * @brief Draws a normal-colored bitmap to the screen
  * @param x The x-coordinate of the draw call
  * @param y The y-coordinate of the draw call
- * @param w
- * @param h
- * @param sx
- * @param sy
+ *@param w Resolves to the x axis right clip plane, usually <= bitmap width
+ * @param h Resolves to the y axis right clip plane, usually <= bitmap height
+ * @param sx The bitmap source x coordinate to start rendering from at the x 0 coordinate
+ * @param sy The bitmap source y coordinate to start rendering from at the y 0 coordinate
  * @param resize_mode The resize mode for translating the coordinated
+ * @param mirror @c true to mirror the image
+ * @param scale_factor a multipler for the width and height of the bitmap. Note that w, h, sx, and sy should be unscaled source bitmap values
  */
-void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode = GR_RESIZE_FULL);
+void gr_bitmap_ex(int x, int y, int w, int h, int sx, int sy, int resize_mode = GR_RESIZE_FULL, bool mirror = false, float scale_factor = 1.0f);
 
 /**
  * @brief Renders the specified string to the screen using the current font and color


### PR DESCRIPTION
This PR adds scaling and mirror parameters to a few more bitmap drawing methods. These are required for the upcoming HUD Config overhaul.

I also took the opportunity to document what the parameters of some of these functions do after I spent a lot of time figuring it out the hard way.