### PR TITLE
Default settings tbl

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -377,7 +377,7 @@ void parse_ai_profiles_tbl(const char *filename)
 				}
 
 				if (optional_string("$Detail Distance Multiplier:"))
-					parse_float_list(profile->detail_distance_mult, MAX_DETAIL_LEVEL + 1);
+					parse_float_list(profile->detail_distance_mult, MAX_DETAIL_VALUE + 1);
 
 				set_flag(profile, "$big ships can attack beam turrets on untargeted ships:", AI::Profile_Flags::Big_ships_can_attack_beam_turrets_on_untargeted_ships);
 
@@ -804,7 +804,7 @@ void ai_profile_t::reset()
         player_autoaim_fov[i] = 0;
     }
 
-    for (int i = 0; i <= MAX_DETAIL_LEVEL; ++i) {
+    for (int i = 0; i <= MAX_DETAIL_VALUE; ++i) {
         detail_distance_mult[i] = 0;
     }
 

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -99,7 +99,7 @@ public:
 	// Player-specific autoaim FOV override
 	float player_autoaim_fov[NUM_SKILL_LEVELS];
 
-	float detail_distance_mult[MAX_DETAIL_LEVEL + 1];	//MAX_DETAIL_LEVEL really needs to be 4
+	float detail_distance_mult[MAX_DETAIL_VALUE + 1];	//MAX_DETAIL_VALUE really needs to be 4
 
 	// minimum radius for the line-of-sight (los) detection --wookieejedi
 	float los_min_detection_radius;

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -629,7 +629,7 @@ void asteroid_create_all()
 		return;
 	}
 
-	int max_asteroids = Asteroid_field.num_initial_asteroids; // * (1.0f - 0.1f*(MAX_DETAIL_LEVEL-Detail.asteroid_density)));
+	int max_asteroids = Asteroid_field.num_initial_asteroids; // * (1.0f - 0.1f*(MAX_DETAIL_VALUE-Detail.asteroid_density)));
 
 	int num_debris_types = 0;
 

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -155,88 +155,84 @@ void game_busy(const char *filename)
 	}
 }
 
-#if MAX_DETAIL_LEVEL != 4
-#error MAX_DETAIL_LEVEL is assumed to be 4 in SystemVars.cpp
-#endif
+static_assert(MAX_DETAIL_VALUE == 4, "MAX_DETAIL_VALUE is assumed to be 4 in SystemVars.cpp");
 
-#if NUM_DEFAULT_DETAIL_LEVELS != 4
-#error NUM_DEFAULT_DETAIL_LEVELS is assumed to be 4 in SystemVars.cpp
-#endif
+static_assert(static_cast<int>(DefaultDetailLevel::Num_detail_levels) == 4, "Code in ManagePilot assumes NUM_DEFAULT_DETAIL_LEVELS = 4");
 
 // Detail level stuff
-detail_levels Detail_defaults[NUM_DEFAULT_DETAIL_LEVELS] = {
+detail_levels Detail_defaults[static_cast<int>(DefaultDetailLevel::Num_detail_levels)] = {
 	{				// Low
 		0,			// setting
-					// ===== Analogs (0-MAX_DETAIL_LEVEL) ====
-		0,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_LEVEL=highest detail
-		0,			// detail_distance;			// 0=lowest MAX_DETAIL_LEVEL=highest		
-		0,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_LEVEL=no culling
-		0,			//	num_small_debris;			// 0=min number, MAX_DETAIL_LEVEL=max number
-		0,			//	num_particles;				// 0=min number, MAX_DETAIL_LEVEL=max number
-		0,			//	num_stars;					// 0=min number, MAX_DETAIL_LEVEL=max number
-		0,			//	shield_effects;			// 0=min, MAX_DETAIL_LEVEL=max
-		2,			// lighting;					// 0=min, MAX_DETAIL_LEVEL=max		
+					// ===== Analogs (0-MAX_DETAIL_VALUE) ====
+		0,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+		0,			// detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest		
+		0,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_VALUE=no culling
+		0,			//	num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
+		0,			//	num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
+		0,			//	num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
+		0,			//	shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
+		2,			// lighting;					// 0=min, MAX_DETAIL_VALUE=max		
 
 					// ====  Booleans ====
-		0,			//	targetview_model;			// 0=off, 1=on		
-		0,			//	planets_suns;				// 0=off, 1=on		
-		0,			// weapon_extras
+		false,			//	targetview_model;			// 0=off, 1=on		
+		false,			//	planets_suns;				// 0=off, 1=on		
+		false,			// weapon_extras
 	},
 	{				// Medium
 		1,			// setting
-					// ===== Analogs (0-MAX_DETAIL_LEVEL) ====
-		2,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_LEVEL=highest detail
-		2,			// detail_distance;			// 0=lowest MAX_DETAIL_LEVEL=highest		
-		2,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_LEVEL=no culling
-		2,			//	num_small_debris;			// 0=min number, MAX_DETAIL_LEVEL=max number
-		2,			//	num_particles;				// 0=min number, MAX_DETAIL_LEVEL=max number
-		2,			//	num_stars;					// 0=min number, MAX_DETAIL_LEVEL=max number
-		2,			//	shield_effects;			// 0=min, MAX_DETAIL_LEVEL=max
-		3,			// lighting;					// 0=min, MAX_DETAIL_LEVEL=max		
+					// ===== Analogs (0-MAX_DETAIL_VALUE) ====
+		2,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+		2,			// detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest		
+		2,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_VALUE=no culling
+		2,			//	num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
+		2,			//	num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
+		2,			//	num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
+		2,			//	shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
+		3,			// lighting;					// 0=min, MAX_DETAIL_VALUE=max		
 
 		// ====  Booleans ====
-		1,			//	targetview_model;			// 0=off, 1=on		
-		1,			//	planets_suns;				// 0=off, 1=on
-		1,			// weapon extras				
+		true,			//	targetview_model;			// 0=off, 1=on		
+		true,			//	planets_suns;				// 0=off, 1=on
+		true,			// weapon extras				
 	},
 	{				// High level
 		2,			// setting
-					// ===== Analogs (0-MAX_DETAIL_LEVEL) ====
-		2,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_LEVEL=highest detail
-		2,			// detail_distance;			// 0=lowest MAX_DETAIL_LEVEL=highest		
-		3,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_LEVEL=no culling
-		3,			//	num_small_debris;			// 0=min number, MAX_DETAIL_LEVEL=max number
-		3,			//	num_particles;				// 0=min number, MAX_DETAIL_LEVEL=max number
-		4,			//	num_stars;					// 0=min number, MAX_DETAIL_LEVEL=max number
-		3,			//	shield_effects;			// 0=min, MAX_DETAIL_LEVEL=max
-		4,			// lighting;					// 0=min, MAX_DETAIL_LEVEL=max		
+					// ===== Analogs (0-MAX_DETAIL_VALUE) ====
+		2,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+		2,			// detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest		
+		3,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_VALUE=no culling
+		3,			//	num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
+		3,			//	num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
+		4,			//	num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
+		3,			//	shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
+		4,			// lighting;					// 0=min, MAX_DETAIL_VALUE=max		
 
 										// ====  Booleans ====
-		1,			//	targetview_model;			// 0=off, 1=on		
-		1,			//	planets_suns;				// 0=off, 1=on
-		1,			// weapon_extras
+		true,			//	targetview_model;			// 0=off, 1=on		
+		true,			//	planets_suns;				// 0=off, 1=on
+		true,			// weapon_extras
 	},
 	{				// Highest level
 		3,			// setting
-					// ===== Analogs (0-MAX_DETAIL_LEVEL) ====
-		4,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_LEVEL=highest detail
-		4,			// detail_distance;			// 0=lowest MAX_DETAIL_LEVEL=highest		
-		4,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_LEVEL=no culling
-		4,			//	num_small_debris;			// 0=min number, MAX_DETAIL_LEVEL=max number
-		4,			//	num_particles;				// 0=min number, MAX_DETAIL_LEVEL=max number
-		4,			//	num_stars;					// 0=min number, MAX_DETAIL_LEVEL=max number
-		4,			//	shield_effects;			// 0=min, MAX_DETAIL_LEVEL=max
-		4,			// lighting;					// 0=min, MAX_DETAIL_LEVEL=max		
+					// ===== Analogs (0-MAX_DETAIL_VALUE) ====
+		4,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+		4,			// detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest		
+		4,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_VALUE=no culling
+		4,			//	num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
+		4,			//	num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
+		4,			//	num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
+		4,			//	shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
+		4,			// lighting;					// 0=min, MAX_DETAIL_VALUE=max		
 
 										// ====  Booleans ====
-		1,			//	targetview_model;			// 0=off, 1=on		
-		1,			//	planets_suns;				// 0=off, 1=on
-		1,			// weapon_extras
+		true,			//	targetview_model;			// 0=off, 1=on		
+		true,			//	planets_suns;				// 0=off, 1=on
+		true,			// weapon_extras
 	},
 };
 
 // Global used to access detail levels in game and libs
-detail_levels Detail = Detail_defaults[NUM_DEFAULT_DETAIL_LEVELS - 1];
+detail_levels Detail = Detail_defaults[static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1];
 
 const SCP_vector<std::pair<int, std::pair<const char*, int>>> DetailLevelValues = {{ 0, {"Minimum", 1680}},
                                                                                    { 1, {"Low", 1160}},
@@ -250,7 +246,7 @@ const auto ModelDetailOption __UNUSED = options::OptionBuilder<int>("Graphics.De
                      .importance(8)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_LEVEL)
+                     .default_val(MAX_DETAIL_VALUE)
                      .change_listener([](int val, bool) {
                           Detail.detail_distance = val;
                           return true;
@@ -264,7 +260,7 @@ const auto TexturesOption __UNUSED = options::OptionBuilder<int>("Graphics.Textu
                      .importance(6)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_LEVEL)
+                     .default_val(MAX_DETAIL_VALUE)
                      .change_listener([](int val, bool) {
                           Detail.hardware_textures = val;
                           return true;
@@ -278,7 +274,7 @@ const auto ParticlesOption __UNUSED = options::OptionBuilder<int>("Graphics.Part
                      .importance(5)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_LEVEL)
+                     .default_val(MAX_DETAIL_VALUE)
                      .change_listener([](int val, bool) {
                           Detail.num_particles = val;
                           return true;
@@ -291,7 +287,7 @@ const auto SmallDebrisOption __UNUSED = options::OptionBuilder<int>("Graphics.Sm
                      std::pair<const char*, int>{"Level of detail of impact effects", 1743})
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_LEVEL)
+                     .default_val(MAX_DETAIL_VALUE)
                      .importance(4)
                      .change_listener([](int val,bool) {
                           Detail.num_small_debris = val;
@@ -306,7 +302,7 @@ const auto ShieldEffectsOption __UNUSED = options::OptionBuilder<int>("Graphics.
                      .importance(3)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_LEVEL)
+                     .default_val(MAX_DETAIL_VALUE)
                      .change_listener([](int val, bool) {
                           Detail.shield_effects = val;
                           return true;
@@ -320,7 +316,7 @@ const auto StarsOption __UNUSED = options::OptionBuilder<int>("Graphics.Stars",
                      .importance(2)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_LEVEL)
+                     .default_val(MAX_DETAIL_VALUE)
                      .change_listener([](int val, bool) {
                           Detail.num_stars = val;
                           return true;
@@ -332,59 +328,64 @@ const auto StarsOption __UNUSED = options::OptionBuilder<int>("Graphics.Stars",
 // 0 - lowest
 // NUM_DETAIL_LEVELS - highest
 // To set the parameters in Detail to some set of defaults
-void detail_level_set(int level)
+void detail_level_set(DefaultDetailLevel level)
 {
-	if ( level < 0 )	{
+	if ( level == DefaultDetailLevel::Custom )	{
 		Detail.setting = -1;
 		return;
 	}
-	Assert( level >= 0 );
-	Assert( level < NUM_DEFAULT_DETAIL_LEVELS );
 
-	Detail = Detail_defaults[level];
+	Detail = Detail_defaults[static_cast<int>(level)];
 }
 
-void change_default_detail_level(int level, DetailSetting  selection, int value) {
-	if (level < 0 || level >= NUM_DEFAULT_DETAIL_LEVELS) {
-		throw std::out_of_range("Invalid detail level: " + std::to_string(level));
-	}
-
-	Assertion(level >= 0 && level < NUM_DEFAULT_DETAIL_LEVELS, "Invalid detail level selected. Get a coder!");
+// Change detail values 0 - MAX_DETAIL_VALUE
+void change_default_detail_level(DefaultDetailLevel level, DetailSetting  selection, int value) {
 
 	// Use a switch statement for more readable access to the struct members
 	switch (selection) {
 	case DetailSetting::NebulaDetail:
-		Detail_defaults[level].nebula_detail = value;
+		Detail_defaults[static_cast<int>(level)].nebula_detail = value;
 		break;
 	case DetailSetting::DetailDistance:
-		Detail_defaults[level].detail_distance = value;
+		Detail_defaults[static_cast<int>(level)].detail_distance = value;
 		break;
 	case DetailSetting::HardwareTextures:
-		Detail_defaults[level].hardware_textures = value;
+		Detail_defaults[static_cast<int>(level)].hardware_textures = value;
 		break;
 	case DetailSetting::NumSmallDebris:
-		Detail_defaults[level].num_small_debris = value;
+		Detail_defaults[static_cast<int>(level)].num_small_debris = value;
 		break;
 	case DetailSetting::NumParticles:
-		Detail_defaults[level].num_particles = value;
+		Detail_defaults[static_cast<int>(level)].num_particles = value;
 		break;
 	case DetailSetting::NumStars:
-		Detail_defaults[level].num_stars = value;
+		Detail_defaults[static_cast<int>(level)].num_stars = value;
 		break;
 	case DetailSetting::ShieldEffects:
-		Detail_defaults[level].shield_effects = value;
+		Detail_defaults[static_cast<int>(level)].shield_effects = value;
 		break;
 	case DetailSetting::Lighting:
-		Detail_defaults[level].lighting = value;
+		Detail_defaults[static_cast<int>(level)].lighting = value;
 		break;
+	default:
+		Assertion(false, "Invalid detail level selection. Get a coder!");
+	}
+}
+
+// Change detail values bool overload
+void change_default_detail_level(DefaultDetailLevel level, DetailSetting selection, bool value)
+{
+
+	// Use a switch statement for more readable access to the struct members
+	switch (selection) {
 	case DetailSetting::TargetViewModel:
-		Detail_defaults[level].targetview_model = value;
+		Detail_defaults[static_cast<int>(level)].targetview_model = value;
 		break;
 	case DetailSetting::PlanetsSuns:
-		Detail_defaults[level].planets_suns = value;
+		Detail_defaults[static_cast<int>(level)].planets_suns = value;
 		break;
 	case DetailSetting::WeaponExtras:
-		Detail_defaults[level].weapon_extras = value;
+		Detail_defaults[static_cast<int>(level)].weapon_extras = value;
 		break;
 	default:
 		Assertion(false, "Invalid detail level selection. Get a coder!");
@@ -397,7 +398,7 @@ int current_detail_level()
 //	return Detail.setting;
 	int i;
 
-	for (i=0; i<NUM_DEFAULT_DETAIL_LEVELS; i++ )	{
+	for (i = 0; i < static_cast<int>(DefaultDetailLevel::Num_detail_levels); i++) {
 		if ( memcmp( &Detail, &Detail_defaults[i], sizeof(detail_levels) )==0 )	{
 			return i;
 		}

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -157,82 +157,82 @@ void game_busy(const char *filename)
 
 static_assert(MAX_DETAIL_VALUE == 4, "MAX_DETAIL_VALUE is assumed to be 4 in SystemVars.cpp");
 
-static_assert(static_cast<int>(DefaultDetailLevel::Num_detail_levels) == 4, "Code in ManagePilot assumes NUM_DEFAULT_DETAIL_LEVELS = 4");
+static_assert(static_cast<int>(DefaultDetailPreset::Num_detail_presets) == 4, "Code in ManagePilot assumes Num_detail_presets = 4");
 
-// Detail level stuff
-detail_levels Detail_defaults[static_cast<int>(DefaultDetailLevel::Num_detail_levels)] = {
-	{				// Low
-		0,			// setting
-					// ===== Analogs (0-MAX_DETAIL_VALUE) ====
-		0,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
-		0,			// detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest		
-		0,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_VALUE=no culling
-		0,			//	num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
-		0,			//	num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
-		0,			//	num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
-		0,			//	shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
-		2,			// lighting;					// 0=min, MAX_DETAIL_VALUE=max		
+// Detail preset stuff
+detail_levels Detail_defaults[static_cast<int>(DefaultDetailPreset::Num_detail_presets)] = {
+	{
+		DefaultDetailPreset::Low,              // setting
+                    // ================== Analogs ==================
+		0,          // nebula_detail;          // 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+		0,          // detail_distance;        // 0=lowest MAX_DETAIL_VALUE=highest			
+		0,          // hardware_textures;      // 0=max culling, MAX_DETAIL_VALUE=no culling
+		0,          // num_small_debris;       // 0=min number, MAX_DETAIL_VALUE=max number
+		0,          // num_particles;          // 0=min number, MAX_DETAIL_VALUE=max number
+		0,          // num_stars;              // 0=min number, MAX_DETAIL_VALUE=max number
+		0,          // shield_effects;         // 0=min, MAX_DETAIL_VALUE=max
+		2,          // lighting;               // 0=min, MAX_DETAIL_VALUE=max		
 
-					// ====  Booleans ====
-		false,			//	targetview_model;			// 0=off, 1=on		
-		false,			//	planets_suns;				// 0=off, 1=on		
-		false,			// weapon_extras
+                    // ================== Booleans ==================
+		false,       // targetview_model;       // false=off, true=on		
+		false,       // planets_suns;           // false=off, true=on		
+		false,       // weapon_extras           // false=off, true=on
 	},
-	{				// Medium
-		1,			// setting
-					// ===== Analogs (0-MAX_DETAIL_VALUE) ====
-		2,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
-		2,			// detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest		
-		2,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_VALUE=no culling
-		2,			//	num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
-		2,			//	num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
-		2,			//	num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
-		2,			//	shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
-		3,			// lighting;					// 0=min, MAX_DETAIL_VALUE=max		
+	{
+		DefaultDetailPreset::Medium,           // setting
+                    // ================== Analogs ==================
+		2,          // nebula_detail;          // 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+		2,          // detail_distance;        // 0=lowest MAX_DETAIL_VALUE=highest				
+		2,          // hardware_textures;      // 0=max culling, MAX_DETAIL_VALUE=no culling
+		2,          // num_small_debris;       // 0=min number, MAX_DETAIL_VALUE=max number
+		2,          // num_particles;          // 0=min number, MAX_DETAIL_VALUE=max number
+		2,          // num_stars;              // 0=min number, MAX_DETAIL_VALUE=max number
+		2,          // shield_effects;         // 0=min, MAX_DETAIL_VALUE=max
+		3,          // lighting;               // 0=min, MAX_DETAIL_VALUE=max		
 
-		// ====  Booleans ====
-		true,			//	targetview_model;			// 0=off, 1=on		
-		true,			//	planets_suns;				// 0=off, 1=on
-		true,			// weapon extras				
+                    // ================== Booleans ==================
+		true,       // targetview_model;       // false=off, true=on		
+		true,       // planets_suns;           // false=off, true=on
+		true,       // weapon_extras           // false=off, true=on		
 	},
-	{				// High level
-		2,			// setting
-					// ===== Analogs (0-MAX_DETAIL_VALUE) ====
-		2,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
-		2,			// detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest		
-		3,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_VALUE=no culling
-		3,			//	num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
-		3,			//	num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
-		4,			//	num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
-		3,			//	shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
-		4,			// lighting;					// 0=min, MAX_DETAIL_VALUE=max		
+	{
+		DefaultDetailPreset::High,             // setting
+                    // ================== Analogs ==================
+		2,          // nebula_detail;          // 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+		2,          // detail_distance;        // 0=lowest MAX_DETAIL_VALUE=highest			
+		3,          // hardware_textures;      // 0=max culling, MAX_DETAIL_VALUE=no culling
+		3,          // num_small_debris;       // 0=min number, MAX_DETAIL_VALUE=max number
+		3,          // num_particles;          // 0=min number, MAX_DETAIL_VALUE=max number
+		4,          // num_stars;              // 0=min number, MAX_DETAIL_VALUE=max number
+		3,          // shield_effects;         // 0=min, MAX_DETAIL_VALUE=max
+		4,          // lighting;               // 0=min, MAX_DETAIL_VALUE=max		
 
-										// ====  Booleans ====
-		true,			//	targetview_model;			// 0=off, 1=on		
-		true,			//	planets_suns;				// 0=off, 1=on
-		true,			// weapon_extras
+                    // ================== Booleans ==================
+		true,       // targetview_model;       // false=off, true=on	
+		true,       // planets_suns;           // false=off, true=on
+		true,       // weapon_extras           // false=off, true=on
 	},
-	{				// Highest level
-		3,			// setting
-					// ===== Analogs (0-MAX_DETAIL_VALUE) ====
-		4,			// nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
-		4,			// detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest		
-		4,			//	hardware_textures;			// 0=max culling, MAX_DETAIL_VALUE=no culling
-		4,			//	num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
-		4,			//	num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
-		4,			//	num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
-		4,			//	shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
-		4,			// lighting;					// 0=min, MAX_DETAIL_VALUE=max		
+	{
+		DefaultDetailPreset::VeryHigh,         // setting
+                    // ================== Analogs ==================
+		4,          // nebula_detail;          // 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+		4,          // detail_distance;        // 0=lowest MAX_DETAIL_VALUE=highest		
+		4,          // hardware_textures;      // 0=max culling, MAX_DETAIL_VALUE=no culling
+		4,          // num_small_debris;       // 0=min number, MAX_DETAIL_VALUE=max number
+		4,          // num_particles;          // 0=min number, MAX_DETAIL_VALUE=max number
+		4,          // num_stars;              // 0=min number, MAX_DETAIL_VALUE=max number
+		4,          // shield_effects;         // 0=min, MAX_DETAIL_VALUE=max
+		4,          // lighting;               // 0=min, MAX_DETAIL_VALUE=max		
 
-										// ====  Booleans ====
-		true,			//	targetview_model;			// 0=off, 1=on		
-		true,			//	planets_suns;				// 0=off, 1=on
-		true,			// weapon_extras
+                    // ================== Booleans ==================
+		true,       // targetview_model;       // false=off, true=on		
+		true,       // planets_suns;           // false=off, true=on
+		true,       // weapon_extras           // false=off, true=on
 	},
 };
 
-// Global used to access detail levels in game and libs
-detail_levels Detail = Detail_defaults[static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1];
+// Global used to access detail presets in game and libs
+detail_levels Detail = Detail_defaults[static_cast<int>(DefaultDetailPreset::Num_detail_presets) - 1];
 
 const SCP_vector<std::pair<int, std::pair<const char*, int>>> DetailLevelValues = {{ 0, {"Minimum", 1680}},
                                                                                    { 1, {"Low", 1160}},
@@ -326,84 +326,85 @@ const auto StarsOption __UNUSED = options::OptionBuilder<int>("Graphics.Stars",
 
 // Call this with:
 // 0 - lowest
-// NUM_DETAIL_LEVELS - highest
+// Num_detail_presets - highest
 // To set the parameters in Detail to some set of defaults
-void detail_level_set(DefaultDetailLevel level)
+void detail_level_set(DefaultDetailPreset preset)
 {
-	if ( level == DefaultDetailLevel::Custom )	{
-		Detail.setting = -1;
+	if (preset == DefaultDetailPreset::Custom) {
+		Detail.setting = DefaultDetailPreset::Custom;
 		return;
 	}
 
-	Detail = Detail_defaults[static_cast<int>(level)];
+	Detail = Detail_defaults[static_cast<int>(preset)];
 }
 
 // Change detail values 0 - MAX_DETAIL_VALUE
-void change_default_detail_level(DefaultDetailLevel level, DetailSetting  selection, int value) {
+void change_default_detail_level(DefaultDetailPreset preset, DetailSetting selection, int value)
+{
 
 	// Use a switch statement for more readable access to the struct members
 	switch (selection) {
 	case DetailSetting::NebulaDetail:
-		Detail_defaults[static_cast<int>(level)].nebula_detail = value;
+		Detail_defaults[static_cast<int>(preset)].nebula_detail = value;
 		break;
 	case DetailSetting::DetailDistance:
-		Detail_defaults[static_cast<int>(level)].detail_distance = value;
+		Detail_defaults[static_cast<int>(preset)].detail_distance = value;
 		break;
 	case DetailSetting::HardwareTextures:
-		Detail_defaults[static_cast<int>(level)].hardware_textures = value;
+		Detail_defaults[static_cast<int>(preset)].hardware_textures = value;
 		break;
 	case DetailSetting::NumSmallDebris:
-		Detail_defaults[static_cast<int>(level)].num_small_debris = value;
+		Detail_defaults[static_cast<int>(preset)].num_small_debris = value;
 		break;
 	case DetailSetting::NumParticles:
-		Detail_defaults[static_cast<int>(level)].num_particles = value;
+		Detail_defaults[static_cast<int>(preset)].num_particles = value;
 		break;
 	case DetailSetting::NumStars:
-		Detail_defaults[static_cast<int>(level)].num_stars = value;
+		Detail_defaults[static_cast<int>(preset)].num_stars = value;
 		break;
 	case DetailSetting::ShieldEffects:
-		Detail_defaults[static_cast<int>(level)].shield_effects = value;
+		Detail_defaults[static_cast<int>(preset)].shield_effects = value;
 		break;
 	case DetailSetting::Lighting:
-		Detail_defaults[static_cast<int>(level)].lighting = value;
+		Detail_defaults[static_cast<int>(preset)].lighting = value;
 		break;
 	default:
-		Assertion(false, "Invalid detail level selection. Get a coder!");
+		Assertion(false, "Invalid detail selection. Get a coder!");
 	}
 }
 
 // Change detail values bool overload
-void change_default_detail_level(DefaultDetailLevel level, DetailSetting selection, bool value)
+void change_default_detail_level(DefaultDetailPreset preset, DetailSetting selection, bool value)
 {
 
 	// Use a switch statement for more readable access to the struct members
 	switch (selection) {
 	case DetailSetting::TargetViewModel:
-		Detail_defaults[static_cast<int>(level)].targetview_model = value;
+		Detail_defaults[static_cast<int>(preset)].targetview_model = value;
 		break;
 	case DetailSetting::PlanetsSuns:
-		Detail_defaults[static_cast<int>(level)].planets_suns = value;
+		Detail_defaults[static_cast<int>(preset)].planets_suns = value;
 		break;
 	case DetailSetting::WeaponExtras:
-		Detail_defaults[static_cast<int>(level)].weapon_extras = value;
+		Detail_defaults[static_cast<int>(preset)].weapon_extras = value;
 		break;
 	default:
-		Assertion(false, "Invalid detail level selection. Get a coder!");
+		Assertion(false, "Invalid detail selection. Get a coder!");
 	}
 }
 
-// Returns the current detail level or -1 if custom.
-int current_detail_level()
+// Returns the current detail preset or -1 if custom.
+DefaultDetailPreset current_detail_preset()
 {
 //	return Detail.setting;
 	int i;
 
-	for (i = 0; i < static_cast<int>(DefaultDetailLevel::Num_detail_levels); i++) {
+	for (i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
 		if ( memcmp( &Detail, &Detail_defaults[i], sizeof(detail_levels) )==0 )	{
-			return i;
+			return static_cast<DefaultDetailPreset>(i);
 		}
 	}
-	return -1;
+	return DefaultDetailPreset::Custom;
 }
 
 #ifndef NDEBUG

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -344,6 +344,53 @@ void detail_level_set(int level)
 	Detail = Detail_defaults[level];
 }
 
+void change_default_detail_level(int level, DetailSetting  selection, int value) {
+	if (level < 0 || level >= NUM_DEFAULT_DETAIL_LEVELS) {
+		throw std::out_of_range("Invalid detail level: " + std::to_string(level));
+	}
+
+	Assertion(level >= 0 && level < NUM_DEFAULT_DETAIL_LEVELS, "Invalid detail level selected. Get a coder!");
+
+	// Use a switch statement for more readable access to the struct members
+	switch (selection) {
+	case DetailSetting::NebulaDetail:
+		Detail_defaults[level].nebula_detail = value;
+		break;
+	case DetailSetting::DetailDistance:
+		Detail_defaults[level].detail_distance = value;
+		break;
+	case DetailSetting::HardwareTextures:
+		Detail_defaults[level].hardware_textures = value;
+		break;
+	case DetailSetting::NumSmallDebris:
+		Detail_defaults[level].num_small_debris = value;
+		break;
+	case DetailSetting::NumParticles:
+		Detail_defaults[level].num_particles = value;
+		break;
+	case DetailSetting::NumStars:
+		Detail_defaults[level].num_stars = value;
+		break;
+	case DetailSetting::ShieldEffects:
+		Detail_defaults[level].shield_effects = value;
+		break;
+	case DetailSetting::Lighting:
+		Detail_defaults[level].lighting = value;
+		break;
+	case DetailSetting::TargetViewModel:
+		Detail_defaults[level].targetview_model = value;
+		break;
+	case DetailSetting::PlanetsSuns:
+		Detail_defaults[level].planets_suns = value;
+		break;
+	case DetailSetting::WeaponExtras:
+		Detail_defaults[level].weapon_extras = value;
+		break;
+	default:
+		Assertion(false, "Invalid detail level selection. Get a coder!");
+	}
+}
+
 // Returns the current detail level or -1 if custom.
 int current_detail_level()
 {

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -141,12 +141,23 @@ extern bool Trail_render_override;
 // or bad things will happen, I promise.
 //====================================================================================
 
+// This refers to the total number of default levels as defined in Detail_defaults[]. Should only be 4.
+enum class DefaultDetailPreset {
+	Custom = -1, // Special level used only in certain cases
+	Low,
+	Medium,
+	High,
+	VeryHigh,
+
+	Num_detail_presets
+};
+
 #define MAX_DETAIL_VALUE 4			// The highest valid value for the "analog" detail level settings. Lowest is 0.
 
 // If you change this, update player file in ManagePilot.cpp
 typedef struct detail_levels {
 
-	int		setting;						// Which default setting this was created from.   0=lowest... DefaultDetailLevel::Num_detail_levels-1, -1=Custom
+	DefaultDetailPreset		setting;						// Which default setting this was created from.   0=lowest... DefaultDetailPreset::Num_detail_presets-1, -1=Custom
 
 	// "Analogs"
 	int		nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
@@ -182,32 +193,21 @@ enum class DetailSetting {
 	Num_detail_settings
 };
 
-// This refers to the total number of default levels as defined in Detail_defaults[]. Should only be 4.
-enum class DefaultDetailLevel {
-	Custom = -1, // Special level used only in certain cases
-	Low,
-	Medium,
-	High,
-	Highest,
-
-	Num_detail_levels
-};
-
 // Global values used to access detail levels in game and libs
 extern detail_levels Detail;
 
 // Call this with:
 // 0 - lowest
-// NUM_DEFAULT_DETAIL_LEVELS - highest
+// Num_detail_presets - highest
 // To set the parameters in Detail to some set of defaults
-void detail_level_set(DefaultDetailLevel level);
+void detail_level_set(DefaultDetailPreset preset);
 
-// level is 0 - lowest, NUM_DEFAULT_DETAIL_LEVELS - hights
-void change_default_detail_level(DefaultDetailLevel level, DetailSetting selection, int value);
-void change_default_detail_level(DefaultDetailLevel level, DetailSetting selection, bool value);
+// level is 0 - lowest, Num_detail_presets - hights
+void change_default_detail_level(DefaultDetailPreset preset, DetailSetting selection, int value);
+void change_default_detail_level(DefaultDetailPreset preset, DetailSetting selection, bool value);
 
-// Returns the current detail level or -1 if custom.
-int current_detail_level();
+// Returns the current detail preset or -1 if custom.
+DefaultDetailPreset current_detail_preset();
 
 #define safe_kill(a) if(a)vm_free(a)
 

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -141,29 +141,31 @@ extern bool Trail_render_override;
 // or bad things will happen, I promise.
 //====================================================================================
 
-#define MAX_DETAIL_LEVEL 4			// The highest valid value for the "analog" detail level settings
+#define MAX_DETAIL_VALUE 4			// The highest valid value for the "analog" detail level settings. Lowest is 0.
 
 // If you change this, update player file in ManagePilot.cpp
 typedef struct detail_levels {
 
-	int		setting;						// Which default setting this was created from.   0=lowest... NUM_DEFAULT_DETAIL_LEVELS-1, -1=Custom
+	int		setting;						// Which default setting this was created from.   0=lowest... DefaultDetailLevel::Num_detail_levels-1, -1=Custom
 
 	// "Analogs"
-	int		nebula_detail;				// 0=lowest detail, MAX_DETAIL_LEVEL=highest detail
-	int		detail_distance;			// 0=lowest MAX_DETAIL_LEVEL=highest
-	int		hardware_textures;		// 0=max culling, MAX_DETAIL_LEVEL=no culling
-	int		num_small_debris;			// 0=min number, MAX_DETAIL_LEVEL=max number
-	int		num_particles;				// 0=min number, MAX_DETAIL_LEVEL=max number
-	int		num_stars;					// 0=min number, MAX_DETAIL_LEVEL=max number
-	int		shield_effects;			// 0=min, MAX_DETAIL_LEVEL=max
-	int		lighting;					// 0=min, MAX_DETAIL_LEVEL=max
+	int		nebula_detail;				// 0=lowest detail, MAX_DETAIL_VALUE=highest detail
+	int		detail_distance;			// 0=lowest MAX_DETAIL_VALUE=highest
+	int		hardware_textures;		// 0=max culling, MAX_DETAIL_VALUE=no culling
+	int		num_small_debris;			// 0=min number, MAX_DETAIL_VALUE=max number
+	int		num_particles;				// 0=min number, MAX_DETAIL_VALUE=max number
+	int		num_stars;					// 0=min number, MAX_DETAIL_VALUE=max number
+	int		shield_effects;			// 0=min, MAX_DETAIL_VALUE=max
+	int		lighting;					// 0=min, MAX_DETAIL_VALUE=max
 
 	// Booleans
-	int		targetview_model;			// 0=off, 1=on
-	int		planets_suns;				// 0=off, 1=on
-	int		weapon_extras;				// extra weapon details. trails, glows
+	bool		targetview_model;			// 0=off, 1=on
+	bool		planets_suns;				// 0=off, 1=on
+	bool		weapon_extras;				// extra weapon details. trails, glows
 } detail_levels;
 
+// Used for the newer options system to set the above values in more readable and safe way.
+// This enum class should always match the above struct
 enum class DetailSetting {
 	NebulaDetail,
 	DetailDistance,
@@ -180,19 +182,29 @@ enum class DetailSetting {
 	Num_detail_settings
 };
 
+// This refers to the total number of default levels as defined in Detail_defaults[]. Should only be 4.
+enum class DefaultDetailLevel {
+	Custom = -1, // Special level used only in certain cases
+	Low,
+	Medium,
+	High,
+	Highest,
+
+	Num_detail_levels
+};
+
 // Global values used to access detail levels in game and libs
 extern detail_levels Detail;
-
-#define NUM_DEFAULT_DETAIL_LEVELS	4	// How many "predefined" detail levels there are
 
 // Call this with:
 // 0 - lowest
 // NUM_DEFAULT_DETAIL_LEVELS - highest
 // To set the parameters in Detail to some set of defaults
-void detail_level_set(int level);
+void detail_level_set(DefaultDetailLevel level);
 
 // level is 0 - lowest, NUM_DEFAULT_DETAIL_LEVELS - hights
-void change_default_detail_level(int level, DetailSetting selection, int value);
+void change_default_detail_level(DefaultDetailLevel level, DetailSetting selection, int value);
+void change_default_detail_level(DefaultDetailLevel level, DetailSetting selection, bool value);
 
 // Returns the current detail level or -1 if custom.
 int current_detail_level();

--- a/code/globalincs/systemvars.h
+++ b/code/globalincs/systemvars.h
@@ -164,6 +164,22 @@ typedef struct detail_levels {
 	int		weapon_extras;				// extra weapon details. trails, glows
 } detail_levels;
 
+enum class DetailSetting {
+	NebulaDetail,
+	DetailDistance,
+	HardwareTextures,
+	NumSmallDebris,
+	NumParticles,
+	NumStars,
+	ShieldEffects,
+	Lighting,
+	TargetViewModel,
+	PlanetsSuns,
+	WeaponExtras,
+
+	Num_detail_settings
+};
+
 // Global values used to access detail levels in game and libs
 extern detail_levels Detail;
 
@@ -174,6 +190,9 @@ extern detail_levels Detail;
 // NUM_DEFAULT_DETAIL_LEVELS - highest
 // To set the parameters in Detail to some set of defaults
 void detail_level_set(int level);
+
+// level is 0 - lowest, NUM_DEFAULT_DETAIL_LEVELS - hights
+void change_default_detail_level(int level, DetailSetting selection, int value);
 
 // Returns the current detail level or -1 if custom.
 int current_detail_level();

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -146,7 +146,7 @@ static void parse_gamma_func()
 	constexpr float EPSILON = 0.0001f;
 
 	if (value < 0.1f - EPSILON || value > 5.0f + EPSILON) {
-		Warning(LOCATION, "%f is not a valid gamma value! (Out of range)", value);
+		error_display(0, "%f is not a valid gamma value! (Out of range)", value);
 		return;
 	}
 
@@ -158,7 +158,7 @@ static void parse_gamma_func()
 		return;
 	}
 
-	Warning(LOCATION, "%f is not a valid gamma value! (Invalid increment)", value);
+	error_display(0, "%f is not a valid gamma value! (Invalid increment)", value);
 }
 
 static auto GammaOption __UNUSED = options::OptionBuilder<float>("Graphics.Gamma",
@@ -181,7 +181,7 @@ static void parse_lighting_func()
 	for (int i = 0; i < static_cast<int>(DefaultDetailLevel::Num_detail_levels); i++) {
 
 		if (value[i] < 0 || value[i] > static_cast<int>(DefaultDetailLevel::Num_detail_levels)) {
-			Warning(LOCATION, "%i is an invalid detail level value!", value[i]);
+			error_display(0, "%i is an invalid detail level value!", value[i]);
 		} else {
 			change_default_detail_level(static_cast<DefaultDetailLevel>(i), DetailSetting::Lighting, value[i]);
 		}
@@ -243,7 +243,7 @@ static bool mode_change_func(os::ViewportState state, bool initial)
 	} else if (lcase_equal(value, "fullscreen")) {
 		Gr_configured_window_state = os::ViewportState::Fullscreen;
 	} else {
-		Warning(LOCATION, "%s is an invalide window mode", value.c_str());
+		error_display(0, "%s is an invalide window mode", value.c_str());
 	}
 }*/
 
@@ -515,7 +515,7 @@ static void parse_framebuffer_func() {
 			Gr_framebuffer_effects.set(FramebufferEffects::Thrusters);
 		} // No need for "none" case
 	} else {
-		Warning(LOCATION, "%s is not a valid framebuffer effect setting", value.c_str());
+		error_display(0, "%s is not a valid framebuffer effect setting", value.c_str());
 	}
 }
 
@@ -563,7 +563,7 @@ static void parse_anti_aliasing_func() {
 			Gr_aa_mode = AntiAliasMode::SMAA_Ultra;
 		}
 	} else {
-		Warning(LOCATION, "%s is not a valid anti aliasing setting", value.c_str());
+		error_display(0, "%s is not a valid anti aliasing setting", value.c_str());
 	}
 }
 
@@ -607,7 +607,7 @@ static void parse_msaa_func()
 			Cmdline_msaa_enabled = 16;
 		}
 	} else {
-		Warning(LOCATION, "%s is not a valid MSAA setting", value.c_str());
+		error_display(0, "%s is not a valid MSAA setting", value.c_str());
 	}
 }
 

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -183,8 +183,7 @@ static void parse_lighting_func()
 		if (value[i] < 0 || value[i] > static_cast<int>(DefaultDetailLevel::Num_detail_levels)) {
 			Warning(LOCATION, "%i is an invalid detail level value!", value[i]);
 		} else {
-			DefaultDetailLevel level = static_cast<DefaultDetailLevel>(i);
-			change_default_detail_level(level, DetailSetting::Lighting, value[i]);
+			change_default_detail_level(static_cast<DefaultDetailLevel>(i), DetailSetting::Lighting, value[i]);
 		}
 	}
 }

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -474,7 +474,7 @@ static auto ResolutionOption = options::OptionBuilder<ResolutionInfo>("Graphics.
                      .importance(100)
                      .finish();
 
-bool Gr_enable_soft_particles = false;
+bool Gr_enable_soft_particles = true;
 
 static void parse_soft_particle_func() {
 	bool value;

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -175,15 +175,15 @@ static auto GammaOption __UNUSED = options::OptionBuilder<float>("Graphics.Gamma
 
 static void parse_lighting_func()
 {
-	int value[static_cast<int>(DefaultDetailLevel::Num_detail_levels)];
-	stuff_int_list(value, static_cast<int>(DefaultDetailLevel::Num_detail_levels), RAW_INTEGER_TYPE);
+	int value[static_cast<int>(DefaultDetailPreset::Num_detail_presets)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailPreset::Num_detail_presets), RAW_INTEGER_TYPE);
 
-	for (int i = 0; i < static_cast<int>(DefaultDetailLevel::Num_detail_levels); i++) {
+	for (int i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
 
-		if (value[i] < 0 || value[i] > static_cast<int>(DefaultDetailLevel::Num_detail_levels)) {
+		if (value[i] < 0 || value[i] > MAX_DETAIL_VALUE) {
 			error_display(0, "%i is an invalid detail level value!", value[i]);
 		} else {
-			change_default_detail_level(static_cast<DefaultDetailLevel>(i), DetailSetting::Lighting, value[i]);
+			change_default_detail_level(static_cast<DefaultDetailPreset>(i), DetailSetting::Lighting, value[i]);
 		}
 	}
 }

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -165,7 +165,7 @@ static auto GammaOption __UNUSED = options::OptionBuilder<float>("Graphics.Gamma
                      std::pair<const char*, int>{"Brightness", 1375},
                      std::pair<const char*, int>{"The brightness value used for the game window", 1738})
                      .category(std::make_pair("Graphics", 1825))
-                     .default_func([&]() { return Gr_gamma; })
+                     .default_func([]() { return Gr_gamma; })
                      .enumerator(gamma_value_enumerator)
                      .display(gamma_display)
                      .change_listener(gamma_change_listener)
@@ -201,7 +201,7 @@ const auto LightingOption __UNUSED = options::OptionBuilder<int>("Graphics.Light
                      .importance(1)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_func([&]() { return Detail.lighting; })
+                     .default_func([]() { return Detail.lighting; })
                      .change_listener([](int val, bool initial) {
                           Detail.lighting = val;
                           if (!initial) {
@@ -260,7 +260,7 @@ static auto WindowModeOption __UNUSED = options::OptionBuilder<os::ViewportState
                               {os::ViewportState::Borderless, {"Borderless", 1675}},
                               {os::ViewportState::Windowed, {"Windowed", 1676}}})
                      .importance(98)
-                     .default_func([&]() { return Gr_configured_window_state; })
+                     .default_func([]() { return Gr_configured_window_state; })
                      .change_listener(mode_change_func)
                      //.parser(parse_window_mode_func)
                      .finish();
@@ -489,13 +489,13 @@ static auto SoftParticlesOption __UNUSED = options::OptionBuilder<bool>("Graphic
                      std::pair<const char*, int>{"Enable or disable soft particle rendering", 1762})
                      .category(std::make_pair("Graphics", 1825))
                      .level(options::ExpertLevel::Advanced)
-                     .default_func([&]() { return Gr_enable_soft_particles; })
+                     .default_func([]() { return Gr_enable_soft_particles; })
                      .bind_to_once(&Gr_enable_soft_particles)
                      .importance(68)
                      .parser(parse_soft_particle_func)
                      .finish();
 
-flagset<FramebufferEffects> Gr_framebuffer_effects;
+flagset<FramebufferEffects> Gr_framebuffer_effects{};
 
 static void parse_framebuffer_func() {
 	SCP_string value;
@@ -529,7 +529,7 @@ static auto FramebufferEffectsOption __UNUSED = options::OptionBuilder<flagset<F
                               {{FramebufferEffects::Shockwaves}, {"Shockwaves", 1688}},
                               {{FramebufferEffects::Thrusters}, {"Thrusters", 1689}},
                               {{FramebufferEffects::Shockwaves, FramebufferEffects::Thrusters}, {"All", 1690}}})
-                     .default_func([&]() { return flagset<FramebufferEffects>(); } )
+                     .default_func([]() { return Gr_framebuffer_effects; } )
                      .bind_to_once(&Gr_framebuffer_effects)
                      .importance(77)
                      .parser(parse_framebuffer_func)
@@ -581,7 +581,7 @@ static auto AAOption __UNUSED = options::OptionBuilder<AntiAliasMode>("Graphics.
                               {AntiAliasMode::SMAA_Medium, {"SMAA Medium", 1685}},
                               {AntiAliasMode::SMAA_High, {"SMAA High", 1686}},
                               {AntiAliasMode::SMAA_Ultra, {"SMAA Ultra", 1687}}})
-                     .default_func([&]() { return AntiAliasMode::None; } )
+                     .default_func([]() { return Gr_aa_mode; } )
                      .bind_to(&Gr_aa_mode)
                      .importance(79)
                      .parser(parse_anti_aliasing_func)
@@ -621,7 +621,7 @@ static auto MSAAOption __UNUSED = options::OptionBuilder<int>("Graphics.MSAASamp
                               {4, {"4 Samples", 1694}},
                               {8, {"8 Samples", 1695}},
                               {16, {"16 Samples", 1696}}})
-                     .default_func([&]() { return Cmdline_msaa_enabled; } )
+                     .default_func([]() { return Cmdline_msaa_enabled; } )
                      .bind_to_once(&Cmdline_msaa_enabled)
                      .importance(78)
                      .parser(parse_msaa_func)
@@ -650,7 +650,7 @@ static auto PostProcessOption __UNUSED = options::OptionBuilder<bool>("Graphics.
                      std::pair<const char*, int>{"Controls whether post processing is enabled in the engine.", 1727})
                      .category(std::make_pair("Graphics", 1825))
                      .level(options::ExpertLevel::Advanced)
-                     .default_func([&]() { return Gr_post_processing_enabled; })
+                     .default_func([]() { return Gr_post_processing_enabled; })
                      .bind_to_once(&Gr_post_processing_enabled)
                      .importance(69)
                      .parser(parse_post_processing_func)        
@@ -671,7 +671,7 @@ static auto VSyncOption __UNUSED = options::OptionBuilder<bool>("Graphics.VSync"
                      std::pair<const char*, int>{"Controls how the engine does vertical synchronization", 1767})
                      .category(std::make_pair("Graphics", 1825))
                      .level(options::ExpertLevel::Advanced)
-                     .default_func([&]() { return Gr_enable_vsync; })
+                     .default_func([]() { return Gr_enable_vsync; })
                      .bind_to_once(&Gr_enable_vsync)
                      .importance(70)
                      .parser(parse_vsync_func)  

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -175,15 +175,16 @@ static auto GammaOption __UNUSED = options::OptionBuilder<float>("Graphics.Gamma
 
 static void parse_lighting_func()
 {
-	int value[MAX_DETAIL_LEVEL];
-	stuff_int_list(value, MAX_DETAIL_LEVEL, RAW_INTEGER_TYPE);
+	int value[static_cast<int>(DefaultDetailLevel::Num_detail_levels)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailLevel::Num_detail_levels), RAW_INTEGER_TYPE);
 
-	for (int i = 0; i < MAX_DETAIL_LEVEL; i++) {
+	for (int i = 0; i < static_cast<int>(DefaultDetailLevel::Num_detail_levels); i++) {
 
-		if (value[i] < 0 || value[i] > MAX_DETAIL_LEVEL) {
+		if (value[i] < 0 || value[i] > static_cast<int>(DefaultDetailLevel::Num_detail_levels)) {
 			Warning(LOCATION, "%i is an invalid detail level value!", value[i]);
 		} else {
-			change_default_detail_level(i, DetailSetting::Lighting, value[i]);
+			DefaultDetailLevel level = static_cast<DefaultDetailLevel>(i);
+			change_default_detail_level(level, DetailSetting::Lighting, value[i]);
 		}
 	}
 }

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -351,7 +351,7 @@ void options_detail_init();
 void options_detail_hide_stuff();
 void options_detail_unhide_stuff();
 void options_detail_do_frame();
-void options_detail_set_level(int level);
+void options_detail_set_level(DefaultDetailLevel level);
 
 // text
 #define OPTIONS_NUM_TEXT				49
@@ -772,59 +772,59 @@ void options_button_pressed(int n)
 
 			// Target View Rendering is currently not handled by in-game options, assumes "On"
 		case HUD_TARGETVIEW_RENDER_ON:
-			Detail.targetview_model = 1;
+			Detail.targetview_model = true;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case HUD_TARGETVIEW_RENDER_OFF:
-			Detail.targetview_model = 0;
+			Detail.targetview_model = false;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 			// Planets is currently not handled by in-game options, assumes "On"
 		case PLANETS_ON:
-			Detail.planets_suns = 1;
+			Detail.planets_suns = true;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case PLANETS_OFF:
-			Detail.planets_suns = 0;
+			Detail.planets_suns = false;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 			// Weapon extras is currently not handled by in-game options, assumes "On"
 		case WEAPON_EXTRAS_ON:
-			Detail.weapon_extras = 1;
+			Detail.weapon_extras = true;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case WEAPON_EXTRAS_OFF:
-			Detail.weapon_extras = 0;
+			Detail.weapon_extras = false;
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;		
 
 		case LOW_DETAIL_N:
-			options_detail_set_level(0);
+			options_detail_set_level(DefaultDetailLevel::Low);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case MEDIUM_DETAIL_N:
-			options_detail_set_level(1);
+			options_detail_set_level(DefaultDetailLevel::Medium);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case HIGH_DETAIL_N:
-			options_detail_set_level(2);
+			options_detail_set_level(DefaultDetailLevel::High);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case VERY_HIGH_DETAIL_N:
-			options_detail_set_level(3);
+			options_detail_set_level(DefaultDetailLevel::Highest);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case CUSTOM_DETAIL_N:
-			options_detail_set_level(-1);
+			options_detail_set_level(DefaultDetailLevel::Custom);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 			// END - detail level tab buttons
@@ -1529,7 +1529,7 @@ void options_detail_do_frame()
 		options_force_button_frame(HUD_TARGETVIEW_RENDER_ON, 0);
 	}
 
-	if ( Detail.planets_suns == 1 ) {
+	if ( Detail.planets_suns) {
 		options_force_button_frame(PLANETS_ON, 2);
 		options_force_button_frame(PLANETS_OFF, 0);
 	} else {
@@ -1580,7 +1580,7 @@ void options_detail_do_frame()
 }
 
 // Set all the detail settings to a predefined level
-void options_detail_set_level(int level)
+void options_detail_set_level(DefaultDetailLevel level)
 {
 	detail_level_set(level);
 	options_detail_synch_sliders();

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -1571,6 +1571,9 @@ void options_detail_do_frame()
 	case DefaultDetailPreset::VeryHigh:
 		options_force_button_frame(VERY_HIGH_DETAIL_N, 2);
 		break;
+	default:
+		Assertion(false, "Invalid preset called for in Options menu");
+		break;
 	}
 }
 

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -351,7 +351,7 @@ void options_detail_init();
 void options_detail_hide_stuff();
 void options_detail_unhide_stuff();
 void options_detail_do_frame();
-void options_detail_set_level(DefaultDetailLevel level);
+void options_detail_set_level(DefaultDetailPreset preset);
 
 // text
 #define OPTIONS_NUM_TEXT				49
@@ -804,27 +804,27 @@ void options_button_pressed(int n)
 			break;		
 
 		case LOW_DETAIL_N:
-			options_detail_set_level(DefaultDetailLevel::Low);
+			options_detail_set_level(DefaultDetailPreset::Low);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case MEDIUM_DETAIL_N:
-			options_detail_set_level(DefaultDetailLevel::Medium);
+			options_detail_set_level(DefaultDetailPreset::Medium);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case HIGH_DETAIL_N:
-			options_detail_set_level(DefaultDetailLevel::High);
+			options_detail_set_level(DefaultDetailPreset::High);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case VERY_HIGH_DETAIL_N:
-			options_detail_set_level(DefaultDetailLevel::Highest);
+			options_detail_set_level(DefaultDetailPreset::VeryHigh);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 
 		case CUSTOM_DETAIL_N:
-			options_detail_set_level(DefaultDetailLevel::Custom);
+			options_detail_set_level(DefaultDetailPreset::Custom);
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 			break;
 			// END - detail level tab buttons
@@ -1545,14 +1545,9 @@ void options_detail_do_frame()
 		options_force_button_frame(WEAPON_EXTRAS_ON, 0);
 	}	
 
-	int current_detail;
+	DefaultDetailPreset current_preset = (Detail.setting != DefaultDetailPreset::Custom) ? current_detail_preset() : DefaultDetailPreset::Custom;
 
-	if ( Detail.setting >= 0 ) {
-		current_detail = current_detail_level();
-		Detail.setting = current_detail;
-	} else {
-		current_detail = -1;
-	}
+	Detail.setting = current_preset;
 
 	options_force_button_frame(LOW_DETAIL_N, 0);
 	options_force_button_frame(MEDIUM_DETAIL_N, 0);
@@ -1560,29 +1555,29 @@ void options_detail_do_frame()
 	options_force_button_frame(VERY_HIGH_DETAIL_N, 0);
 	options_force_button_frame(CUSTOM_DETAIL_N, 0);
 
-	switch ( current_detail ) {
-	case -1:
+	switch (current_preset) {
+	case DefaultDetailPreset::Custom:
 		options_force_button_frame(CUSTOM_DETAIL_N, 2);
 		break;
-	case 0:
+	case DefaultDetailPreset::Low:
 		options_force_button_frame(LOW_DETAIL_N, 2);
 		break;
-	case 1:
+	case DefaultDetailPreset::Medium:
 		options_force_button_frame(MEDIUM_DETAIL_N, 2);
 		break;
-	case 2:
+	case DefaultDetailPreset::High:
 		options_force_button_frame(HIGH_DETAIL_N, 2);
 		break;
-	case 3:
+	case DefaultDetailPreset::VeryHigh:
 		options_force_button_frame(VERY_HIGH_DETAIL_N, 2);
 		break;
 	}
 }
 
 // Set all the detail settings to a predefined level
-void options_detail_set_level(DefaultDetailLevel level)
+void options_detail_set_level(DefaultDetailPreset preset)
 {
-	detail_level_set(level);
+	detail_level_set(preset);
 	options_detail_synch_sliders();
 }
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -45,7 +45,7 @@ int Default_weapon_select_effect;
 int Default_fiction_viewer_ui;
 bool Enable_external_shaders;
 bool Enable_external_default_scripts;
-int Default_detail_level;
+DefaultDetailLevel Default_detail_level;
 bool Full_color_head_anis;
 bool Dont_automatically_select_turret_when_targeting_ship;
 bool Automatically_select_subsystem_under_reticle_when_targeting_same_ship;
@@ -556,13 +556,13 @@ void parse_mod_table(const char *filename)
 
 				stuff_int(&detail_level);
 
-				mprintf(("Game Settings Table: Setting default detail level to %i of %i-%i\n", detail_level, 0, NUM_DEFAULT_DETAIL_LEVELS - 1));
+				mprintf(("Game Settings Table: Setting default detail level to %i of %i-%i\n", detail_level, 0, static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1));
 
-				if (detail_level < 0 || detail_level > NUM_DEFAULT_DETAIL_LEVELS - 1) {
-					error_display(0, "Invalid detail level: %i, setting to %i", detail_level, Default_detail_level);
+				if (detail_level < 0 || detail_level > static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1) {
+					error_display(0, "Invalid detail level: %i, setting to %i", detail_level, static_cast<int>(Default_detail_level));
 				}
 				else {
-					Default_detail_level = detail_level;
+					Default_detail_level = static_cast<DefaultDetailLevel>(detail_level);
 				}
 			}
 
@@ -1528,7 +1528,7 @@ void mod_table_reset()
 	Default_fiction_viewer_ui = -1;
 	Enable_external_shaders = false;
 	Enable_external_default_scripts = false;
-	Default_detail_level = 3; // "very high" seems a reasonable default in 2012 -zookeeper
+	Default_detail_level = DefaultDetailLevel::High; // "high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Dont_automatically_select_turret_when_targeting_ship = false;
 	Automatically_select_subsystem_under_reticle_when_targeting_same_ship = false;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1528,7 +1528,7 @@ void mod_table_reset()
 	Default_fiction_viewer_ui = -1;
 	Enable_external_shaders = false;
 	Enable_external_default_scripts = false;
-	Default_detail_level = DefaultDetailLevel::High; // "high" seems a reasonable default in 2012 -zookeeper
+	Default_detail_level = DefaultDetailLevel::Highest; // "highest" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Dont_automatically_select_turret_when_targeting_ship = false;
 	Automatically_select_subsystem_under_reticle_when_targeting_same_ship = false;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -45,7 +45,7 @@ int Default_weapon_select_effect;
 int Default_fiction_viewer_ui;
 bool Enable_external_shaders;
 bool Enable_external_default_scripts;
-DefaultDetailLevel Default_detail_level;
+DefaultDetailPreset Default_detail_preset;
 bool Full_color_head_anis;
 bool Dont_automatically_select_turret_when_targeting_ship;
 bool Automatically_select_subsystem_under_reticle_when_targeting_same_ship;
@@ -551,18 +551,18 @@ void parse_mod_table(const char *filename)
 				}
 			}
 
-			if (optional_string("$Default Detail Level:")) {
-				int detail_level;
+			if (optional_string_either("$Default Detail Level:", "$Default Detail Preset:") != -1) {
+				int detail_preset;
 
-				stuff_int(&detail_level);
+				stuff_int(&detail_preset);
 
-				mprintf(("Game Settings Table: Setting default detail level to %i of %i-%i\n", detail_level, 0, static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1));
+				mprintf(("Game Settings Table: Setting default detail preset to %i of %i-%i\n", detail_preset, 0, static_cast<int>(DefaultDetailPreset::Num_detail_presets) - 1));
 
-				if (detail_level < 0 || detail_level > static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1) {
-					error_display(0, "Invalid detail level: %i, setting to %i", detail_level, static_cast<int>(Default_detail_level));
+				if (detail_preset < 0 || detail_preset > static_cast<int>(DefaultDetailPreset::Num_detail_presets) - 1) {
+					error_display(0, "Invalid detail preset: %i, setting to %i", detail_preset, static_cast<int>(Default_detail_preset));
 				}
 				else {
-					Default_detail_level = static_cast<DefaultDetailLevel>(detail_level);
+					Default_detail_preset = static_cast<DefaultDetailPreset>(detail_preset);
 				}
 			}
 
@@ -1528,7 +1528,7 @@ void mod_table_reset()
 	Default_fiction_viewer_ui = -1;
 	Enable_external_shaders = false;
 	Enable_external_default_scripts = false;
-	Default_detail_level = DefaultDetailLevel::Highest; // "highest" seems a reasonable default in 2012 -zookeeper
+	Default_detail_preset = DefaultDetailPreset::VeryHigh; // "very high" seems a reasonable default in 2012 -zookeeper
 	Full_color_head_anis = false;
 	Dont_automatically_select_turret_when_targeting_ship = false;
 	Automatically_select_subsystem_under_reticle_when_targeting_same_ship = false;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -53,7 +53,7 @@ extern overhead_style Default_overhead_ship_style;
 extern int Default_fiction_viewer_ui;
 extern bool Enable_external_shaders;
 extern bool Enable_external_default_scripts;
-extern int Default_detail_level;
+extern DefaultDetailLevel Default_detail_level;
 extern bool Full_color_head_anis;
 extern bool Dont_automatically_select_turret_when_targeting_ship;
 extern bool Automatically_select_subsystem_under_reticle_when_targeting_same_ship;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -53,7 +53,7 @@ extern overhead_style Default_overhead_ship_style;
 extern int Default_fiction_viewer_ui;
 extern bool Enable_external_shaders;
 extern bool Enable_external_default_scripts;
-extern DefaultDetailLevel Default_detail_level;
+extern DefaultDetailPreset Default_detail_preset;
 extern bool Full_color_head_anis;
 extern bool Dont_automatically_select_turret_when_targeting_ship;
 extern bool Automatically_select_subsystem_under_reticle_when_targeting_same_ship;

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -1009,9 +1009,7 @@ DCF(model_darkening,"Makes models darker with distance")
 // 3
 // 4 - None
 
-#if MAX_DETAIL_LEVEL != 4
-#error MAX_DETAIL_LEVEL is assumed to be 4 in ModelInterp.cpp
-#endif
+static_assert(MAX_DETAIL_VALUE == 4, "MAX_DETAIL_VALUE is assumed to be 4 in SystemVars.cpp");
 
 
 /**

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -945,9 +945,8 @@ int model_render_determine_detail(float depth, int model_num, int detail_level_l
 			i = detail_level_locked+1;
 		} else {
 
-#if MAX_DETAIL_LEVEL != 4
-#error Code in modelrender.cpp assumes MAX_DETAIL_LEVEL == 4
-#endif
+			static_assert(MAX_DETAIL_VALUE == 4, "MAX_DETAIL_VALUE is assumed to be 4 in SystemVars.cpp");
+
 			for ( i = 0; i < pm->n_detail_levels; i++ )	{
 				if ( depth <= pm->detail_depth[i] ) {
 					break;

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -140,7 +140,7 @@ const auto NebulaDetailOption __UNUSED = options::OptionBuilder<int>("Graphics.N
                      std::pair<const char*, int>{"Detail level of nebulas", 1697})
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_LEVEL)
+                     .default_val(MAX_DETAIL_VALUE)
                      .importance(7)
                      .change_listener([](int val, bool) {
                           Detail.nebula_detail = val;
@@ -412,7 +412,7 @@ void neb2_poof_setup() {
 		}
 	}
 	Poof_density_multiplier = Poof_density_sum_square / (Poof_density_sum * Poof_density_sum);
-	Poof_density_multiplier *= (Detail.nebula_detail + 0.5f) / (MAX_DETAIL_LEVEL + 0.5f); // scale the poofs down based on detail level
+	Poof_density_multiplier *= (Detail.nebula_detail + 0.5f) / (MAX_DETAIL_VALUE + 0.5f); // scale the poofs down based on detail level
 }
 
 void neb2_generate_fog_color(const char *fog_color_palette, ubyte fog_color[])

--- a/code/nebula/volumetrics.cpp
+++ b/code/nebula/volumetrics.cpp
@@ -156,7 +156,7 @@ const std::tuple<float, float, float>& volumetric_nebula::getNebulaColor() const
 }
 
 bool volumetric_nebula::getEdgeSmoothing() const {
-	return Detail.nebula_detail == MAX_DETAIL_LEVEL || doEdgeSmoothing; //Only for highest setting, or when the lab has an override.
+	return Detail.nebula_detail == MAX_DETAIL_VALUE || doEdgeSmoothing; //Only for highest setting, or when the lab has an override.
 }
 
 int volumetric_nebula::getSteps() const {
@@ -164,7 +164,7 @@ int volumetric_nebula::getSteps() const {
 		return 8;
 
 	//Minimal setting (if not hard-set to 8) is steps / 2, max settings is steps.  Ensure it doesn't drop below 8, 10, 12, 14, 16.
-	return std::max(steps * (MAX_DETAIL_LEVEL + 1) / (2 * (MAX_DETAIL_LEVEL + 1) - Detail.nebula_detail), 8 + 2 * Detail.nebula_detail);
+	return std::max(steps * (MAX_DETAIL_VALUE + 1) / (2 * (MAX_DETAIL_VALUE + 1) - Detail.nebula_detail), 8 + 2 * Detail.nebula_detail);
 }
 
 int volumetric_nebula::getGlobalLightSteps() const {
@@ -172,7 +172,7 @@ int volumetric_nebula::getGlobalLightSteps() const {
 		return 4;
 
 	//Minimal setting (if not hard-set to 4) is globalLightSteps / 2, max settings is globalLightSteps. Ensure it doesn't drop below 4, 5, 6, 7, 8.
-	return std::max(globalLightSteps * (MAX_DETAIL_LEVEL + 1) / (2 * (MAX_DETAIL_LEVEL + 1) - Detail.nebula_detail), 4 + Detail.nebula_detail);
+	return std::max(globalLightSteps * (MAX_DETAIL_VALUE + 1) / (2 * (MAX_DETAIL_VALUE + 1) - Detail.nebula_detail), 4 + Detail.nebula_detail);
 }
 
 float volumetric_nebula::getOpacityDistance() const {

--- a/code/network/multi_pinfo.cpp
+++ b/code/network/multi_pinfo.cpp
@@ -312,7 +312,7 @@ void multi_pinfo_popup_init(net_player *np)
 
 	// backup hardware textures setting and bash to max
 	Multi_pinfo_hardware_texture_backup = Detail.hardware_textures;
-	Detail.hardware_textures = MAX_DETAIL_LEVEL;
+	Detail.hardware_textures = MAX_DETAIL_VALUE;
 
 	// zero bitmap info
 	Mp_pilot.bitmap = -1;

--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -5,6 +5,7 @@
 #include "libs/jansson.h"
 #include "options/OptionsManager.h"
 #include "localization/localize.h"
+#include "parse/parselo.h"
 
 #include <functional>
 #include <utility>
@@ -120,6 +121,8 @@ class OptionBase {
 	virtual void setValueDescription(const ValueDescription& desc) const = 0;
 
 	virtual OptionType getType() const = 0;
+	
+	virtual void parseDefaultSetting() const = 0;
 
 	virtual SCP_vector<ValueDescription> getValidValues() const = 0;
 
@@ -151,6 +154,7 @@ template <typename T>
 using ValueInterpolator = std::function<T(float)>;
 template <typename T>
 using ValueDeinterpolator = std::function<float(const T&)>;
+using ValueParser = std::function<void()>;
 
 template <typename T>
 class ValueFunctor {
@@ -174,6 +178,9 @@ class Option : public OptionBase {
 	ValueChangeListener<T> _changeListener;
 	ValueInterpolator<T> _interpolator;
 	ValueDeinterpolator<T> _deinterpolator;
+	ValueParser _parser;
+
+	bool _hasCustomDefaultFunc = false;
 
 	OptionType _type = OptionType::Selection; // By default the generic type is always a selection
 
@@ -207,6 +214,17 @@ class Option : public OptionBase {
 
 	OptionType getType() const override { return _type; }
 	void setType(OptionType type) { _type = type; }
+
+	void parseDefaultSetting() const override
+	{
+		if (!_parser) {
+			Warning(LOCATION, "%s cannot set default values", _config_key.c_str());
+			skip_to_start_of_string_either("$Option Key:", "#END");
+		} else {
+			Assertion(_hasCustomDefaultFunc, "Option must have a default value function in order to use parser!");
+			_parser();
+		}
+	}
 
 	SCP_vector<ValueDescription> getValidValues() const override
 	{
@@ -305,6 +323,8 @@ class Option : public OptionBase {
 	const DefaultValueFunctor<T>& getDefaultValueFunc() const { return _defaultValueFunc; }
 	void setDefaultValueFunc(const DefaultValueFunctor<T>& defaultValueFunc) { _defaultValueFunc = defaultValueFunc; }
 
+	void setHasCustomDefaultFunc(bool value) { _hasCustomDefaultFunc = value; }
+
 	const ValueDeserializer<T>& getDeserializer() const { return _deserializer; }
 	void setDeserializer(const ValueDeserializer<T>& converter) { _deserializer = converter; }
 
@@ -323,6 +343,8 @@ class Option : public OptionBase {
 
 	const ValueChangeListener<T>& getChangeListener() const { return _changeListener; }
 	void setChangeListener(const ValueChangeListener<T>& changeListener) { _changeListener = changeListener; }
+
+	void setParser(ValueParser parser) { _parser = std::move(parser); }
 
 	const ValueInterpolator<T>& getInterpolator() const { return _interpolator; }
 	const ValueDeinterpolator<T>& getDeinterpolator() const { return _deinterpolator; }
@@ -456,16 +478,18 @@ class OptionBuilder {
 		_instance.setExpertLevel(level);
 		return *this;
 	}
-	//Directly set the default value of an option
+	//Causes the default value of the option to be permanently set to a specific value
 	OptionBuilder& default_val(const T& val)
 	{
 		_instance.setDefaultValueFunc(ValueFunctor<T>(val));
+		_instance.setHasCustomDefaultFunc(false);
 		return *this;
 	}
-	//Function to find the default value of the option
+	//Causes the default value of the option to be set dynamically using a function
 	OptionBuilder& default_func(const DefaultValueFunctor<T>& func)
 	{
 		_instance.setDefaultValueFunc(func);
+		_instance.setHasCustomDefaultFunc(true);
 		return *this;
 	}
 	//Deserialize an option for persisting changes
@@ -480,7 +504,7 @@ class OptionBuilder {
 		_instance.setSerializer(serializer);
 		return *this;
 	}
-	//Builds an enum list of values for the optoin
+	//Builds an enum list of values for the option
 	OptionBuilder& enumerator(const ValueEnumerator<T>& enumerator)
 	{
 		_instance.setValueEnumerator(enumerator);
@@ -511,6 +535,12 @@ class OptionBuilder {
 	OptionBuilder& change_listener(const ValueChangeListener<T>& listener)
 	{
 		_instance.setChangeListener(listener);
+		return *this;
+	}
+	//The code to run in order to parse the default setting. Option must use default_func instead of defaul_val!
+	OptionBuilder& parser(const ValueParser& parser)
+	{
+		_instance.setParser(parser);
 		return *this;
 	}
 	//The global variable to bind the option to immediately.

--- a/code/options/OptionsManager.h
+++ b/code/options/OptionsManager.h
@@ -19,6 +19,9 @@ class OptionsManager {
 
 	SCP_unordered_map<SCP_string, const OptionBase*> _optionsMapping;
 
+	// Enforced options are hidden from the player and do not load values from user settings
+	SCP_unordered_set<SCP_string> _enforcedOptions;
+
 	SCP_vector<std::shared_ptr<const OptionBase>> _options;
 	bool _optionsSorted = false;
 
@@ -38,6 +41,12 @@ class OptionsManager {
 	void removeOption(const std::shared_ptr<const OptionBase>& option);
 
 	const OptionBase* getOptionByKey(SCP_string name);
+
+	void enforceOption(const SCP_string& key);
+
+	void unenforceOption(const SCP_string& key);
+
+	bool isOptionEnforced(const SCP_string& key) const;
 
 	const SCP_vector<std::shared_ptr<const options::OptionBase>>& getOptions();
 

--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -47,7 +47,7 @@ void parse_default_settings_table(const char* filename)
 					if (!(thisOpt->getFlags()[options::OptionFlags::RetailBuiltinOption])) {
 						options::OptionsManager::instance()->enforceOption(name);
 					} else {
-						error_display(0, LOCATION, "%s is a retail builtin option and cannot be enforced!", name.c_str());
+						error_display(0, "%s is a retail builtin option and cannot be enforced!", name.c_str());
 					}
 				}
 			} else {

--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -58,7 +58,7 @@ void parse_default_settings_table(const char* filename)
 		required_string("#END");
 	} catch (const parse::ParseException& e) {
 		mprintf(("TABLES: Unable to parse '%s'!  Error message = %s.\n",
-			(filename) ? filename : "<default default_settings.tbl>",
+			(filename) ? filename : "<default_settings.tbl>",
 			e.what()));
 		return;
 	}

--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -23,38 +23,36 @@ void parse_default_settings_table(const char* filename)
 		// start parsing
 		optional_string("#DEFAULT SETTINGS");
 
-		// allow settings to be in any order, just as in parse_ai_profiles_tbl
+		// allow settings to be in any order
 		while (!check_for_string("#END")) {
 
-			//while (check_for_string("$Option Key:")) {
-				if (optional_string("$Option Key:")) {
-					SCP_string name;
-					stuff_string(name, F_NAME);
+			if (optional_string("$Option Key:")) {
+				SCP_string name;
+				stuff_string(name, F_NAME);
 
-					const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey(name);
+				const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey(name);
 
-					if (thisOpt == nullptr) {
-						Warning(LOCATION, "%s is not a valid option!", name.c_str());
-						skip_to_start_of_string_either("$Option Key:", "#END");
-						continue;
-					}
-					required_string("+Value:");
-					thisOpt->parseDefaultSetting();
-
-					// If an option is enforced and not retail we set the flag so that the default value is set
-					// later during initialization, the option will be hidden from the options menu
-					// Retail options cannot be hidden because we can't really hide them from the menu
-					if ((optional_string_one_of(2, "+Enforce", "+Enforced")) != -1) {
-						if (!(thisOpt->getFlags()[options::OptionFlags::RetailBuiltinOption])) {
-							options::OptionsManager::instance()->enforceOption(name);
-						} else {
-							Warning(LOCATION, "%s is a retail builtin option and cannot be enforced!", name.c_str());
-						}
-					}
-				} else {
-					break;
+				if (thisOpt == nullptr) {
+					Warning(LOCATION, "%s is not a valid option!", name.c_str());
+					skip_to_start_of_string_either("$Option Key:", "#END");
+					continue;
 				}
-			//}
+				required_string("+Value:");
+				thisOpt->parseDefaultSetting();
+
+				// If an option is enforced and not retail we set the flag so that the default value is set
+				// later during initialization, the option will be hidden from the options menu
+				// Retail options cannot be hidden because we can't really hide them from the menu
+				if ((optional_string_one_of(2, "+Enforce", "+Enforced")) != -1) {
+					if (!(thisOpt->getFlags()[options::OptionFlags::RetailBuiltinOption])) {
+						options::OptionsManager::instance()->enforceOption(name);
+					} else {
+						Warning(LOCATION, "%s is a retail builtin option and cannot be enforced!", name.c_str());
+					}
+				}
+			} else {
+				break;
+			}
 		}
 
 		required_string("#END");

--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -26,8 +26,6 @@ void parse_default_settings_table(const char* filename)
 		// allow settings to be in any order, just as in parse_ai_profiles_tbl
 		while (!check_for_string("#END")) {
 
-			int check = check_for_string("$Option Key:");
-
 			//while (check_for_string("$Option Key:")) {
 				if (optional_string("$Option Key:")) {
 					SCP_string name;

--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -35,6 +35,7 @@ void parse_default_settings_table(const char* filename)
 					skip_to_start_of_string_either("$Option Key:", "#END");
 					continue;
 				}
+				required_string("+Value:");
 				thisOpt->parseDefaultSetting();
 			}
 		}

--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -33,7 +33,7 @@ void parse_default_settings_table(const char* filename)
 				const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey(name);
 
 				if (thisOpt == nullptr) {
-					Warning(LOCATION, "%s is not a valid option!", name.c_str());
+					error_display(0, "%s is not a valid option!", name.c_str());
 					skip_to_start_of_string_either("$Option Key:", "#END");
 					continue;
 				}
@@ -47,7 +47,7 @@ void parse_default_settings_table(const char* filename)
 					if (!(thisOpt->getFlags()[options::OptionFlags::RetailBuiltinOption])) {
 						options::OptionsManager::instance()->enforceOption(name);
 					} else {
-						Warning(LOCATION, "%s is a retail builtin option and cannot be enforced!", name.c_str());
+						error_display(0, LOCATION, "%s is a retail builtin option and cannot be enforced!", name.c_str());
 					}
 				}
 			} else {

--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -45,7 +45,7 @@ void parse_default_settings_table(const char* filename)
 					// later during initialization, the option will be hidden from the options menu
 					// Retail options cannot be hidden because we can't really hide them from the menu
 					if (!(thisOpt->getFlags()[options::OptionFlags::RetailBuiltinOption])) {
-						if (optional_string_one_of(2, "+Enforce", "+Enforced")) {
+						if ((optional_string_one_of(2, "+Enforce", "+Enforced")) != -1) {
 							options::OptionsManager::instance()->enforceOption(name);
 						}
 					}

--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -44,9 +44,11 @@ void parse_default_settings_table(const char* filename)
 					// If an option is enforced and not retail we set the flag so that the default value is set
 					// later during initialization, the option will be hidden from the options menu
 					// Retail options cannot be hidden because we can't really hide them from the menu
-					if (!(thisOpt->getFlags()[options::OptionFlags::RetailBuiltinOption])) {
-						if ((optional_string_one_of(2, "+Enforce", "+Enforced")) != -1) {
+					if ((optional_string_one_of(2, "+Enforce", "+Enforced")) != -1) {
+						if (!(thisOpt->getFlags()[options::OptionFlags::RetailBuiltinOption])) {
 							options::OptionsManager::instance()->enforceOption(name);
+						} else {
+							Warning(LOCATION, "%s is a retail builtin option and cannot be enforced!", name.c_str());
 						}
 					}
 				} else {

--- a/code/options/default_settings_table.h
+++ b/code/options/default_settings_table.h
@@ -1,0 +1,12 @@
+#pragma once
+/*
+ * Created by Mike "MjnMixael" Nelson for the FreeSpace2 Source Code Project.
+ * You may not sell or otherwise commercially exploit the source or things you
+ * create based on the source.
+ *
+ * This file is in charge of the "default_settings.tbl", and allows games and mods
+ * to define default options settings that will be used on first launch or if a player
+ * has not chosen and saved a specific option value.
+ */
+
+void default_settings_init();

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -153,7 +153,7 @@ namespace particle
 			world_pos += Objects[info->attached_objnum].pos;
 		}
 		// treat particles on lower detail levels as 'further away' for the purposes of culling
-		float adjusted_dist = vm_vec_dist(&Eye_position, &world_pos) * powf(2.5f, (float)(static_cast<int>(DefaultDetailLevel::Num_detail_levels) - Detail.num_particles));
+		float adjusted_dist = vm_vec_dist(&Eye_position, &world_pos) * powf(2.5f, (float)(static_cast<int>(DefaultDetailPreset::Num_detail_presets) - Detail.num_particles));
 		// treat bigger particles as 'closer'
 		adjusted_dist /= info->rad;
 		float cull_start_dist = 1000.f;

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -153,7 +153,7 @@ namespace particle
 			world_pos += Objects[info->attached_objnum].pos;
 		}
 		// treat particles on lower detail levels as 'further away' for the purposes of culling
-		float adjusted_dist = vm_vec_dist(&Eye_position, &world_pos) * powf(2.5f, (float)(NUM_DEFAULT_DETAIL_LEVELS - Detail.num_particles));
+		float adjusted_dist = vm_vec_dist(&Eye_position, &world_pos) * powf(2.5f, (float)(static_cast<int>(DefaultDetailLevel::Num_detail_levels) - Detail.num_particles));
 		// treat bigger particles as 'closer'
 		adjusted_dist /= info->rad;
 		float cull_start_dist = 1000.f;

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -842,8 +842,9 @@ void pilotfile::plr_read_settings()
 
 	// detail
 	//Preset not handled by OptionsManager
-	Detail.setting           = handler->readInt("setting");
-	clamp_value_with_warn(&Detail.setting, -1, static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1, "Detail Level Preset");
+	int setting_value           = handler->readInt("setting");
+	clamp_value_with_warn(&setting_value, -1, static_cast<int>(DefaultDetailPreset::Num_detail_presets) - 1, "Detail Level Preset");
+	Detail.setting = static_cast<DefaultDetailPreset>(setting_value);
 
 	Detail.nebula_detail     = handler->readInt("nebula_detail");
 	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_VALUE, "Nebula Detail");
@@ -916,8 +917,11 @@ void pilotfile::plr_write_settings()
 	handler->writeInt("joy_dead_zone_size", Joy_dead_zone_size);
 
 	// detail
-	clamp_value_with_warn(&Detail.setting, -1, static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1, "Detail Level Preset");
-	handler->writeInt("setting", Detail.setting);
+	int setting_value = static_cast<int>(Detail.setting); // Convert enum to int for clamping
+	clamp_value_with_warn(&setting_value, -1, static_cast<int>(DefaultDetailPreset::Num_detail_presets) - 1, "Detail Level Preset");
+	Detail.setting = static_cast<DefaultDetailPreset>(setting_value); // Convert back to enum
+	handler->writeInt("setting", setting_value);
+
 	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_VALUE, "Nebula Detail");
 	handler->writeInt("nebula_detail", Detail.nebula_detail);
 	clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_VALUE, "Model Detail");

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -843,38 +843,38 @@ void pilotfile::plr_read_settings()
 	// detail
 	//Preset not handled by OptionsManager
 	Detail.setting           = handler->readInt("setting");
-	clamp_value_with_warn(&Detail.setting, -1, NUM_DEFAULT_DETAIL_LEVELS - 1, "Detail Level Preset");
+	clamp_value_with_warn(&Detail.setting, -1, static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1, "Detail Level Preset");
 
 	Detail.nebula_detail     = handler->readInt("nebula_detail");
-	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_LEVEL, "Nebula Detail");
+	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_VALUE, "Nebula Detail");
 	options::OptionsManager::instance()->set_ingame_multi_option("Graphics.NebulaDetail", Detail.nebula_detail);
 
 	Detail.detail_distance   = handler->readInt("detail_distance");
-	clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_LEVEL, "Model Detail");
+	clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_VALUE, "Model Detail");
 	options::OptionsManager::instance()->set_ingame_multi_option("Graphics.Detail", Detail.detail_distance);
 
 	Detail.hardware_textures = handler->readInt("hardware_textures");
-	clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_LEVEL, "3D Hardware Textures");
+	clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_VALUE, "3D Hardware Textures");
 	options::OptionsManager::instance()->set_ingame_multi_option("Graphics.Texture", Detail.hardware_textures);
 
 	Detail.num_small_debris  = handler->readInt("num_small_debris");
-	clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_LEVEL, "Impact Effects");
+	clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_VALUE, "Impact Effects");
 	options::OptionsManager::instance()->set_ingame_multi_option("Graphics.SmallDebris", Detail.num_small_debris);
 
 	Detail.num_particles     = handler->readInt("num_particles");
-	clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_LEVEL, "Particles");
+	clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_VALUE, "Particles");
 	options::OptionsManager::instance()->set_ingame_multi_option("Graphics.Particles", Detail.num_particles);
 
 	Detail.num_stars         = handler->readInt("num_stars");
-	clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_LEVEL, "Stars");
+	clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_VALUE, "Stars");
 	options::OptionsManager::instance()->set_ingame_multi_option("Graphics.Stars", Detail.num_stars);
 
 	Detail.shield_effects    = handler->readInt("shield_effects");
-	clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_LEVEL, "Shield Hit Effects");
+	clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_VALUE, "Shield Hit Effects");
 	options::OptionsManager::instance()->set_ingame_multi_option("Graphics.ShieldEffects", Detail.shield_effects);
 
 	Detail.lighting          = handler->readInt("lighting");
-	clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "Lighting");
+	clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_VALUE, "Lighting");
 	options::OptionsManager::instance()->set_ingame_multi_option("Graphics.Lighting", Detail.lighting);
 
 	//Rest not handled by OptionsManager
@@ -916,23 +916,23 @@ void pilotfile::plr_write_settings()
 	handler->writeInt("joy_dead_zone_size", Joy_dead_zone_size);
 
 	// detail
-	clamp_value_with_warn(&Detail.setting, -1, NUM_DEFAULT_DETAIL_LEVELS - 1, "Detail Level Preset");
+	clamp_value_with_warn(&Detail.setting, -1, static_cast<int>(DefaultDetailLevel::Num_detail_levels) - 1, "Detail Level Preset");
 	handler->writeInt("setting", Detail.setting);
-	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_LEVEL, "Nebula Detail");
+	clamp_value_with_warn(&Detail.nebula_detail, 0, MAX_DETAIL_VALUE, "Nebula Detail");
 	handler->writeInt("nebula_detail", Detail.nebula_detail);
-	clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_LEVEL, "Model Detail");
+	clamp_value_with_warn(&Detail.detail_distance, 0, MAX_DETAIL_VALUE, "Model Detail");
 	handler->writeInt("detail_distance", Detail.detail_distance);
-	clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_LEVEL, "3D Hardware Textures");
+	clamp_value_with_warn(&Detail.hardware_textures, 0, MAX_DETAIL_VALUE, "3D Hardware Textures");
 	handler->writeInt("hardware_textures", Detail.hardware_textures);
-	clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_LEVEL, "Impact Effects");
+	clamp_value_with_warn(&Detail.num_small_debris, 0, MAX_DETAIL_VALUE, "Impact Effects");
 	handler->writeInt("num_small_debris", Detail.num_small_debris);
-	clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_LEVEL, "Particles");
+	clamp_value_with_warn(&Detail.num_particles, 0, MAX_DETAIL_VALUE, "Particles");
 	handler->writeInt("num_particles", Detail.num_particles);
-	clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_LEVEL, "Stars");
+	clamp_value_with_warn(&Detail.num_stars, 0, MAX_DETAIL_VALUE, "Stars");
 	handler->writeInt("num_stars", Detail.num_stars);
-	clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_LEVEL, "Shield Hit Effects");
+	clamp_value_with_warn(&Detail.shield_effects, 0, MAX_DETAIL_VALUE, "Shield Hit Effects");
 	handler->writeInt("shield_effects", Detail.shield_effects);
-	clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_LEVEL, "Lighting");
+	clamp_value_with_warn(&Detail.lighting, 0, MAX_DETAIL_VALUE, "Lighting");
 	handler->writeInt("lighting", Detail.lighting);
 	handler->writeInt("targetview_model", Detail.targetview_model);
 	handler->writeInt("planets_suns", Detail.planets_suns);

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -90,10 +90,10 @@ void init_new_pilot(player *p, int reset)
 		control_config_use_preset(Control_config_presets[0]);		// get a default keyboard config
 		player_set_pilot_defaults(p);			// set up any player struct defaults
 
-		// set the default detail level based on tabling rather than the above method
-		DefaultDetailLevel cur_speed = Default_detail_level;
+		// set the default detail preset based on tabling rather than the above method
+		DefaultDetailPreset cur_speed = Default_detail_preset;
 
-		static_assert(static_cast<int>(DefaultDetailLevel::Num_detail_levels) == 4, "Code in ManagePilot assumes NUM_DEFAULT_DETAIL_LEVELS = 4");
+		static_assert(static_cast<int>(DefaultDetailPreset::Num_detail_presets) == 4, "Code in ManagePilot assumes Num_detail_presets = 4");
 
 		detail_level_set(cur_speed);
 

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -99,7 +99,7 @@ void init_new_pilot(player *p, int reset)
 
 		Game_skill_level = game_get_default_skill_level();
 
-		mprintf(( "Setting detail level to %d because of new pilot\n", cur_speed ));
+		mprintf(( "Setting detail level to %d because of new pilot\n", static_cast<int>(cur_speed) ));
 		Use_mouse_to_fly = true;
 		Mouse_sensitivity = 4;
 		if (!Using_in_game_options) {

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -84,8 +84,6 @@ bool delete_pilot_file(const char *pilot_name)
 // this works on barracks and player_select interface screens
 void init_new_pilot(player *p, int reset)
 {
-	int cur_speed;
-
 	if (reset) {
 		hud_set_default_hud_config(p);		// use a default hud config
 
@@ -93,11 +91,9 @@ void init_new_pilot(player *p, int reset)
 		player_set_pilot_defaults(p);			// set up any player struct defaults
 
 		// set the default detail level based on tabling rather than the above method
-		cur_speed = Default_detail_level;
+		DefaultDetailLevel cur_speed = Default_detail_level;
 
-#if NUM_DEFAULT_DETAIL_LEVELS != 4
-#error Code in ManagePilot assumes NUM_DEFAULT_DETAIL_LEVELS = 4
-#endif
+		static_assert(static_cast<int>(DefaultDetailLevel::Num_detail_levels) == 4, "Code in ManagePilot assumes NUM_DEFAULT_DETAIL_LEVELS = 4");
 
 		detail_level_set(cur_speed);
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1034,6 +1034,8 @@ add_file_folder("Observer"
 )
 
 add_file_folder("Options"
+	options/default_settings_table.cpp
+	options/default_settings_table.h
 	options/Ingame_Options.cpp
 	options/Ingame_Options.h
 	options/Ingame_Options_internal.h

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1762,7 +1762,7 @@ void stars_draw_stars()
 
 	int tmp_num_stars = 0;
 
-	tmp_num_stars = (Detail.num_stars * Num_stars) / MAX_DETAIL_LEVEL;
+	tmp_num_stars = (Detail.num_stars * Num_stars) / MAX_DETAIL_VALUE;
 	CLAMP(tmp_num_stars, 0, Num_stars);
 
 	auto path = graphics::paths::PathRenderer::instance();

--- a/code/utils/string_utils.cpp
+++ b/code/utils/string_utils.cpp
@@ -12,4 +12,11 @@ std::vector<std::string> split_string(const std::string& s, char delim) {
 	return elems;
 }
 
+bool isStringOneOf(const std::string& value, const std::vector<std::string>& candidates)
+{
+	return std::any_of(candidates.begin(), candidates.end(), [&value](const std::string& candidate) {
+		return !lcase_equal(value, candidate);
+	});
+}
+
 }

--- a/code/utils/string_utils.cpp
+++ b/code/utils/string_utils.cpp
@@ -15,7 +15,7 @@ std::vector<std::string> split_string(const std::string& s, char delim) {
 bool isStringOneOf(const std::string& value, const std::vector<std::string>& candidates)
 {
 	return std::any_of(candidates.begin(), candidates.end(), [&value](const std::string& candidate) {
-		return !lcase_equal(value, candidate);
+		return lcase_equal(value, candidate);
 	});
 }
 

--- a/code/utils/string_utils.h
+++ b/code/utils/string_utils.h
@@ -18,6 +18,8 @@ void split_string(const SCP_string& s, char delim, Out result)
 
 std::vector<std::string> split_string(const std::string& s, char delim);
 
+bool isStringOneOf(const std::string& value, const std::vector<std::string>& candidates);
+
 // get a filename minus any leading path
 template <typename T>
 T *get_file_part(T *path)

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -147,6 +147,7 @@
 #include "object/objectsnd.h"
 #include "object/waypoint.h"
 #include "observer/observer.h"
+#include "options/default_settings_table.h"
 #include "options/Ingame_Options.h"
 #include "options/Option.h"
 #include "options/OptionsManager.h"
@@ -1755,8 +1756,11 @@ void game_init()
 
 	mod_table_init();		// load in all the mod dependent settings
 
-	// This needs to be delayed until we know if the new options are actually going to be used
+	// Must be run after mod table is parsed so we know the value of Using_in_game_options
+	// Must be run before everything else inits so we can init those with the correct
+	// default values or user preferences
 	if (Using_in_game_options) {
+		default_settings_init(); // load in current preferred default options values, if any
 		options::OptionsManager::instance()->loadInitialValues();
 	}
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1759,7 +1759,7 @@ void game_init()
 	// Must be run after mod table is parsed so we know the value of Using_in_game_options
 	// Must be run before everything else inits so we can init those with the correct
 	// default values or user preferences
-	if (Using_in_game_options) {
+ 	if (Using_in_game_options) {
 		default_settings_init(); // load in current preferred default options values, if any
 		options::OptionsManager::instance()->loadInitialValues();
 	}


### PR DESCRIPTION
Implements an FR from the FOTG team; specifically it creates a `default_settings.tbl` that changes the default settings that various options will have before trying to load the player's values from the player file or INI file. Parsing is relatively straightforward.

Many thanks to @wookieejedi for testing and finding the right insert point during game initialization that this can be done safely.

The following example (not recommended for use) will set PostProcessing to default OFF instead of ON. Additionally it will enforce the value to always be false. More on that below.
```
+Option Key: Graphics.PostProcessing
+Value: false
+Enforce
```

The idea is to give game creators using FSO the ability to set reasonable default values for settings based on their mod's data. In some cases it may be ideal to entirely enforce an option for the game. The main example I have, though it won't work with this system for reasons described below, is SCHMUPSpace that required a specific resolution to run correctly.

`+Enforce` causes an option to be set to a specific value. The player's setting for that option, if it exists, will not be read and the option itself will be removed from the options system, effectively hidden from the player. As more and more games made for FSO are not FS and increasingly TC this allows a way for games to specify certain requirements for their games. I don't expect `+Enforce` to be used much but it's nice to have it there for game creators that really need it.

**A couple additional notes:**

- In-Game Options must be enabled for this table to do anything.
- Retail Built-In Options cannot be +Enforced mostly because they can't be removed from view and that's a poor player experience. A follow-up could get around that by disabling their UI elements in the retail Options UI with a popup warning that the value is enforced if someone really needed... but those options do so little anymore I doubt it's worth the effort.
- Defaults are set by changing the global value that the option is tied to BEFORE user preferences are read from disk. If a user preference does not exist then the new default will, of course, be used instead. User preferences have higher priority always with the exception of `+Enforce`.
- Options that handle hardware either cannot or should not be given a parser. In most cases they cannot because this runs before audio and graphics subsystems are initialized so there's no way to validate any potential values. But also.. I can't see a reason a game creator needs to set a particular monitor, audio device, or window mode. SCHMUPSpace provided a reason to require a specific resolution but there's no way to do that here, since we can't validate the resolution against available resolutions without the graphics subsystem. But also that feels dangerous. If a mod enforces a resolution that the player doesn't support then I'm not sure what happens. So we just won't add that capability since we can't very easily anyway.

**Finally**

This PR only adds the options in 2d.cpp to the `default_settings.tbl` parser for now to keep this PR smaller and more about the framework. A follow-up PR after this one is merged will handle the rest of the options. For a bit of documentation the method to do so is explained here.

_An option using a parser must use `default_func()` in place of `default_val()` because the latter will create an internal func that returns a literal. In other words, with `default_val()`, the default value can never be changed. `default_func()` will grab whatever the most recent value is. Most cases this can be a small inline change with a lambda. From there you add a parser with `.parser(your_parse_func)`. The parser assumes `optional_string("+Value:")` has already succeeded and is ready for `stuff_whatever()` and should follow up with appropriate value validation before setting the global variable the option is ultimately tied to._

As part of this enhancement, this PR also modernizes the Default Options structs and methods for better type safety and easier calling. I came across this need while creating a parser for lighting settings and will be used for the other settings as well in later PRs.