### PR TITLE
add safeguards to the "immobile" flag migration

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -167,6 +167,8 @@ SCP_vector<SCP_string> Parse_names;
 
 SCP_vector<texture_replace> Fred_texture_replacements;
 
+SCP_unordered_set<int> Fred_migrated_immobile_ships;
+
 int Num_path_restrictions;
 path_restriction_t Path_restrictions[MAX_PATH_RESTRICTIONS];
 
@@ -2863,6 +2865,9 @@ void resolve_parse_flags(object *objp, flagset<Mission::Parse_Object_Flags> &par
         {
             objp->flags.set(Object::Object_Flags::Dont_change_position);
             objp->flags.set(Object::Object_Flags::Dont_change_orientation);
+
+            // keep track of migrated ships
+            Fred_migrated_immobile_ships.insert(objp->instance);
         }
         else
             objp->flags.set(Object::Object_Flags::Immobile);

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -332,6 +332,9 @@ typedef struct texture_replace {
 
 extern SCP_vector<texture_replace> Fred_texture_replacements;
 
+// which ships have had the "immobile" flag migrated to "don't-change-position" and "don't-change-orientation"
+extern SCP_unordered_set<int> Fred_migrated_immobile_ships;
+
 typedef struct alt_class {
 	int ship_class;				
 	int variable_index;			// if set allows the class to be set by a variable

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -266,6 +266,23 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 		Fred_view_wnd->MessageBox(msg.c_str());
 	}
 
+	// message 4: check for "immobile" flag migration
+	if (!Fred_migrated_immobile_ships.empty()) {
+		SCP_string msg = "The \"immobile\" ship flag has been superseded by the \"don't-change-position\", and \"don't-change-orientation\" flags.  "
+			"All ships which previously had \"Does Not Move\" checked in the ship flags editor will now have both \"Does Not Change Position\" and "
+			"\"Does Not Change Orientation\" checked.  After you close this dialog, the error checker will check for any potential issues, including "
+			"issues involving these flags.\n\nThe following ships have been migrated:";
+
+		for (int shipnum : Fred_migrated_immobile_ships) {
+			msg += "\n\t";
+			msg += Ships[shipnum].ship_name;
+		}
+
+		truncate_message_lines(msg, 30);
+		Fred_view_wnd->MessageBox(msg.c_str());
+		Error_checker_checks_potential_issues_once = true;
+	}
+
 	obj_merge_created_list();
 	objp = GET_FIRST(&obj_used_list);
 	while (objp != END_OF_LIST(&obj_used_list)) {

--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -103,6 +103,7 @@ int Show_outlines = 0;
 bool Draw_outlines_on_selected_ships = true;
 bool Draw_outline_at_warpin_position = false;
 bool Error_checker_checks_potential_issues = true;
+bool Error_checker_checks_potential_issues_once = false;
 int Show_stars = 1;
 int Single_axis_constraint = 0;
 int True_rw, True_rh;

--- a/fred2/fredrender.h
+++ b/fred2/fredrender.h
@@ -23,6 +23,7 @@ extern int Show_outlines;           //!< Bool. If nonzero, draw each object's me
 extern bool Draw_outlines_on_selected_ships;	// If a ship is selected, draw mesh lines
 extern bool Draw_outline_at_warpin_position;	// Project an outline at the place where the ship will arrive after warping in
 extern bool Error_checker_checks_potential_issues;	// Error checker checks not only outright errors but also potential issues
+extern bool Error_checker_checks_potential_issues_once;	// Same as above, but only once, and independent of the selected option
 extern int Show_stars;              //!< Bool. If nonzero, draw the starfield, nebulas, and suns. Might also handle skyboxes
 extern int Single_axis_constraint;  //!< Bool. If nonzero, constrain movement to one axis
 extern int Show_distances;          //!< Bool. If nonzero, draw lines between each object and display their distance on the middle of each line

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -3406,7 +3406,7 @@ int CFREDView::fred_check_sexp(int sexp, int type, const char *location, ...)
 			return 1;
 	}
 
-	if (Error_checker_checks_potential_issues)
+	if (Error_checker_checks_potential_issues || Error_checker_checks_potential_issues_once)
 		z = check_sexp_potential_issues(sexp, &faulty_node, issue_msg);
 	if (z)
 	{
@@ -3417,11 +3417,12 @@ int CFREDView::fred_check_sexp(int sexp, int type, const char *location, ...)
 		if (!bad_node_str.empty())		// the previous function adds a space at the end
 			bad_node_str.pop_back();
 
-		sprintf(error_buf, "Potential issue detected in %s:\n%s\n\n%s\n\n(Suspect node appears to be: %s)", location_buf.c_str(), issue_msg.c_str(), sexp_buf.c_str(), bad_node_str.c_str());
+		sprintf(error_buf, "Potential issue detected in %s:\n\n%s\n\n%s\n\n(Suspect node appears to be: %s)", location_buf.c_str(), issue_msg.c_str(), sexp_buf.c_str(), bad_node_str.c_str());
 
 		if (Fred_main_wnd->MessageBox(error_buf.c_str(), "Warning", MB_OKCANCEL | MB_ICONINFORMATION) != IDOK)
 			return 1;
 	}
+	Error_checker_checks_potential_issues_once = false;
 
 	return 0;
 }

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -873,6 +873,7 @@ void clear_mission(bool fast_reload)
 	set_physics_controls();
 
 	Event_annotations.clear();
+	Fred_migrated_immobile_ships.clear();
 
 	// free memory from all parsing so far -- see also the stop_parse() in player_select_close() which frees all tbls found during game_init()
 	stop_parse();

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -19,6 +19,7 @@
 #include <starfield/nebula.h>
 #include <object/objectdock.h>
 #include <localization/fhash.h>
+#include <scripting/global_hooks.h>
 
 #include "iff_defs/iff_defs.h" // iff_init
 #include "object/object.h" // obj_init
@@ -380,6 +381,12 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 	stars_post_level_init();
 
 	missionLoaded(filepath);
+
+	// This hook will allow for scripts to know when a mission has been loaded
+	// which will then allow them to update any LuaEnums that may be related to sexps
+	if (scripting::hooks::FredOnMissionLoad->isActive()) {
+		scripting::hooks::FredOnMissionLoad->run();
+	}
 
 	return true;
 }

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -164,6 +164,7 @@ class EditorViewport {
 	bool Lookat_mode = false;
 	bool Move_ships_when_undocking = true;
 	bool Error_checker_checks_potential_issues = true;
+	bool Error_checker_checks_potential_issues_once = false;
 
 	Editor* editor = nullptr;
 	FredRenderer* renderer = nullptr;


### PR DESCRIPTION
When a mission is loaded in FRED the "immobile" flag is migrated to "don't-change-position" and "don't-change-orientation".  So, notify the FREDder that this is happening, and add checks to the "potential issues" checker to guard against mixing the old and new flags.

Follow-up to #6304.  Resolves #6489.