### PR TITLE
QT Fred Boillerplate Removal and Memory Safety

### DIFF
--- a/qtfred/src/mission/dialogs/AbstractDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/AbstractDialogModel.cpp
@@ -6,11 +6,21 @@
 namespace fso {
 namespace fred {
 namespace dialogs {
-
-
 AbstractDialogModel::AbstractDialogModel(QObject* parent,
 										 EditorViewport* viewport) :
 	QObject(parent), _editor(viewport->editor), _viewport(viewport) {
+}
+
+bool AbstractDialogModel::query_modified() const
+{
+	return _modified;
+}
+
+void AbstractDialogModel::set_modified()
+{
+	if (!_modified) {
+		_modified = true;
+	}
 }
 
 }

--- a/qtfred/src/mission/dialogs/AbstractDialogModel.h
+++ b/qtfred/src/mission/dialogs/AbstractDialogModel.h
@@ -25,6 +25,15 @@ class AbstractDialogModel: public QObject {
 	Editor* _editor = nullptr;
 	EditorViewport* _viewport = nullptr;
 
+	template <typename T>
+	/**
+	 * @brief Copies rvalue to the lvalue while setting the modified variable.
+	 */
+	void modify(T& a, const T& b);
+
+	bool _modified = false;
+	void set_modified();
+
  public:
 	AbstractDialogModel(QObject* parent, EditorViewport* viewport);
 
@@ -42,6 +51,10 @@ class AbstractDialogModel: public QObject {
 	 */
 	virtual void reject() = 0;
 
+
+	bool query_modified() const;
+
+
  signals:
 	/**
 	 * @brief Signal emitted when the model has changed caused by an update operation
@@ -50,6 +63,16 @@ class AbstractDialogModel: public QObject {
 	 */
 	void modelChanged();
 };
+
+template <typename T>
+inline void AbstractDialogModel::modify(T& a, const T& b)
+{
+	if (a != b) {
+		a = b;
+		set_modified();
+		modelChanged();
+	}
+}
 
 }
 }

--- a/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
@@ -26,7 +26,6 @@ AsteroidEditorDialogModel::AsteroidEditorDialogModel(QObject* parent, EditorView
 	_field_type(FT_ACTIVE),
 	_debris_genre(DG_ASTEROID),
 	_bypass_errors(false),
-	_modified(false),
 	_cur_field(0),
 	_last_field(-1)
 {
@@ -492,21 +491,6 @@ void AsteroidEditorDialogModel::update_init()
 	_field_debris_type = _a_field.field_debris_type;
 
 	_last_field = _cur_field;
-}
-
-void AsteroidEditorDialogModel::set_modified()
-{
-	_modified = true;
-}
-
-void AsteroidEditorDialogModel::unset_modified()
-{
-	_modified = false;
-}
-
-bool AsteroidEditorDialogModel::get_modified()
-{
-	return _modified;
 }
 
 void AsteroidEditorDialogModel::showErrorDialogNoCancel(const SCP_string& message)

--- a/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.h
@@ -61,13 +61,7 @@ public:
 	void update_init();
 	bool validate_data();
 
-	void set_modified();
-	void unset_modified();
-	bool get_modified();
-
 private:
-	template<typename T>
-	void modify(T &a, const T &b);
 
 	void showErrorDialogNoCancel(const SCP_string& message);
 	void initializeData();
@@ -98,7 +92,6 @@ private:
 	asteroid_field _a_field;      // :v: had unfinished plans for multiple fields?
 
 	bool _bypass_errors;
-	bool _modified;
 	int  _cur_field;
 	int  _last_field;
 
@@ -109,15 +102,6 @@ private:
 	// and the inverse as a map + roids - populate in ctor
 	std::unordered_map<int, int> debris_inverse_idx_lookup;
 };
-
-template<typename T>
-inline void AsteroidEditorDialogModel::modify(T &a, const T &b) {
-	if (a != b) {
-		a = b;
-		set_modified();
-		modelChanged();
-	}
-}
 
 } // namespace dialogs
 } // namespace fred

--- a/qtfred/src/mission/dialogs/CommandBriefingDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CommandBriefingDialogModel.cpp
@@ -144,7 +144,7 @@ void CommandBriefingDialogModel::addStage()
 
 	_wipCommandBrief.num_stages++;
 	_currentStage = _wipCommandBrief.num_stages - 1;
-	
+	set_modified();
 	modelChanged();
 }
 
@@ -155,6 +155,7 @@ void CommandBriefingDialogModel::insertStage()
 
 	if (_wipCommandBrief.num_stages >= CMD_BRIEF_STAGES_MAX) {
 		_wipCommandBrief.num_stages = CMD_BRIEF_STAGES_MAX;
+		set_modified();
 		modelChanged(); // signal that the model has changed, in case of inexplicable invalid index.
 		return;
 	}
@@ -164,6 +165,7 @@ void CommandBriefingDialogModel::insertStage()
 	for (int i = _wipCommandBrief.num_stages - 1; i > _currentStage; i--) {
 		_wipCommandBrief.stage[i] = _wipCommandBrief.stage[i - 1];
 	}
+	set_modified();
 	modelChanged();
 }
 
@@ -181,6 +183,7 @@ void CommandBriefingDialogModel::deleteStage()
 		_wipCommandBrief.stage[0].wave = -1;
 		memset(_wipCommandBrief.stage[0].wave_filename, 0, CF_MAX_FILENAME_LENGTH);
 		memset(_wipCommandBrief.stage[0].ani_filename, 0, CF_MAX_FILENAME_LENGTH);
+		set_modified();
 		modelChanged();
 		return;
 	}
@@ -293,13 +296,15 @@ int CommandBriefingDialogModel::getSpeechInstanceNumber()
 
 void CommandBriefingDialogModel::setBriefingText(const SCP_string& briefingText) 
 { 
-	_wipCommandBrief.stage[_currentStage].text = briefingText; 
+	_wipCommandBrief.stage[_currentStage].text = briefingText;
+	set_modified();
 	modelChanged(); 
 }
 
 void CommandBriefingDialogModel::setAnimationFilename(const SCP_string& animationFilename) 
 { 
-	strcpy_s(_wipCommandBrief.stage[_currentStage].ani_filename, animationFilename.c_str()); 
+	strcpy_s(_wipCommandBrief.stage[_currentStage].ani_filename, animationFilename.c_str());
+	set_modified();
 	modelChanged(); 
 }
 
@@ -307,24 +312,28 @@ void CommandBriefingDialogModel::setSpeechFilename(const SCP_string& speechFilen
 { 
 	_soundTestUpdateRequired = true; 
 	strcpy_s(_wipCommandBrief.stage[_currentStage].wave_filename, speechFilename.c_str());
-	setWaveID(); 
+	setWaveID();
+	set_modified();
 	modelChanged(); 
 }
 
 void CommandBriefingDialogModel::setCurrentTeam(const ubyte& teamIn) 
 { 
 	_currentTeam = teamIn;
+	set_modified();
 }; // not yet fully supported
 
 void CommandBriefingDialogModel::setLowResolutionFilename(const SCP_string& lowResolutionFilename) 
 { 
 	strcpy_s(_wipCommandBrief.background[0], lowResolutionFilename.c_str()); 
+	set_modified();
 	modelChanged();  
 }
 
 void CommandBriefingDialogModel::setHighResolutionFilename(const SCP_string& highResolutionFilename) 
 { 
 	strcpy_s(_wipCommandBrief.background[1], highResolutionFilename.c_str()); 
+	set_modified();
 	modelChanged(); 
 }
 

--- a/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.h
+++ b/qtfred/src/mission/dialogs/CustomWingNamesDialogModel.h
@@ -24,21 +24,11 @@ public:
 private:
 	void initializeData();
 
-	template<typename T>
-	void modify(T &a, T &b);
 
 	SCP_string _m_starting[3];
 	SCP_string _m_squadron[5];
 	SCP_string _m_tvt[2];
 };
-
-template<typename T>
-inline void CustomWingNamesDialogModel::modify(T & a, T & b) {
-	if (a != b) {
-		a = b;
-		modelChanged();
-	}
-}
 
 }
 }

--- a/qtfred/src/mission/dialogs/FictionViewerDialogModel.h
+++ b/qtfred/src/mission/dialogs/FictionViewerDialogModel.h
@@ -47,8 +47,6 @@ class FictionViewerDialogModel: public AbstractDialogModel {
  private:
 	void initializeData();
 
-	template<typename T>
-	void modify(T &a, const T &b);
 
 	SCP_string _storyFile;
 	SCP_string _fontFile;
@@ -58,15 +56,6 @@ class FictionViewerDialogModel: public AbstractDialogModel {
 
 	int _maxStoryFileLength, _maxFontFileLength, _maxVoiceFileLength;
 };
-
-
-template<typename T>
-inline void FictionViewerDialogModel::modify(T &a, const T &b) {
-	if (a != b) {
-		a = b;
-		modelChanged();
-	}
-}
 
 }
 }

--- a/qtfred/src/mission/dialogs/LoadoutEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/LoadoutEditorDialogModel.cpp
@@ -233,6 +233,7 @@ void LoadoutDialogModel::setPlayerEntryDelay(float delay)
 {
 	_playerEntryDelay = delay;
 	modelChanged();
+	set_modified();
 
 }
 
@@ -721,7 +722,7 @@ void LoadoutDialogModel::setShipEnabled(const SCP_vector<SCP_string>& list, bool
 			}
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -754,7 +755,7 @@ void LoadoutDialogModel::setShipVariableEnabled(const SCP_vector<SCP_string>& li
 				item);
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -780,7 +781,7 @@ void LoadoutDialogModel::setWeaponEnabled(const SCP_vector<SCP_string>& list, bo
 			}
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -813,7 +814,7 @@ void LoadoutDialogModel::setWeaponVariableEnabled(const SCP_vector<SCP_string>& 
 				item);
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -828,7 +829,7 @@ void LoadoutDialogModel::setExtraAllocatedShipCount(const SCP_vector<SCP_string>
 			}
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -842,7 +843,7 @@ void LoadoutDialogModel::setExtraAllocatedForShipVariablesCount(const SCP_vector
 			}
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -856,7 +857,7 @@ void LoadoutDialogModel::setExtraAllocatedWeaponCount(const SCP_vector<SCP_strin
 			}
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -870,7 +871,7 @@ void LoadoutDialogModel::setExtraAllocatedForWeaponVariablesCount(const SCP_vect
 			}
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -916,7 +917,7 @@ void LoadoutDialogModel::setExtraAllocatedViaVariable(const SCP_vector<SCP_strin
 			}
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -930,7 +931,7 @@ void LoadoutDialogModel::setRequiredWeapon(const SCP_vector<SCP_string>& list, c
 			}
 		}
 	}
-
+	set_modified();
 	buildCurrentLists();
 }
 
@@ -942,6 +943,7 @@ void LoadoutDialogModel::setSkipValidation(const bool skipIt) {
 	// this is designed to be a global control, so turn this off in TvT, until we hear from someone otherwise.
 	for (auto& team : _teams) {
 		team.skipValidation = skipIt;
+		set_modified();
 	}
 }
 

--- a/qtfred/src/mission/dialogs/LoadoutEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/LoadoutEditorDialogModel.cpp
@@ -933,6 +933,7 @@ void LoadoutDialogModel::setRequiredWeapon(const SCP_vector<SCP_string>& list, c
 	}
 	set_modified();
 	buildCurrentLists();
+	modelChanged();
 }
 
 bool LoadoutDialogModel::getSkipValidation() {

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -367,16 +367,6 @@ SCP_string MissionSpecDialogModel::getDesignerNoteText() {
 	return _m_mission_notes;
 }
 
-void MissionSpecDialogModel::set_modified() {
-	if (!_modified) {
-		_modified = true;
-	}
-}
-
-bool MissionSpecDialogModel::query_modified() {
-	return _modified;
-}
-
 }
 }
 }

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.h
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.h
@@ -16,10 +16,6 @@ class MissionSpecDialogModel : public AbstractDialogModel {
 private:
 	void initializeData();
 
-	template<typename T> 
-	void modify(T &a, const T &b);
-
-	bool _modified = false;
 
 	SCP_string _m_created;
 	SCP_string _m_modified;
@@ -48,8 +44,6 @@ private:
 	flagset<Mission::Mission_Flags> _m_flags;
 
 	int _m_type;
-
-	void set_modified();
 
 public:
 	MissionSpecDialogModel(QObject* parent, EditorViewport* viewport);
@@ -122,17 +116,7 @@ public:
 	void setDesignerNoteText(const SCP_string&);
 	SCP_string getDesignerNoteText();
 
-	bool query_modified();
 };
-
-template<typename T>
-inline void MissionSpecDialogModel::modify(T &a, const T &b) {
-	if (a != b) {
-		a = b;
-		set_modified();
-		modelChanged();
-	}
-}
 
 }
 }

--- a/qtfred/src/mission/dialogs/ReinforcementsEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ReinforcementsEditorDialogModel.cpp
@@ -147,6 +147,7 @@ void ReinforcementsDialogModel::addToReinforcements(const SCP_vector<SCP_string>
 	_listUpdateRequired = true;
 	_numberLineEditUpdateRequired = true;
 	modelChanged();
+	set_modified();
 }
 
 void ReinforcementsDialogModel::removeFromReinforcements(const SCP_vector<SCP_string>& namesIn) 
@@ -170,6 +171,7 @@ void ReinforcementsDialogModel::removeFromReinforcements(const SCP_vector<SCP_st
 	_listUpdateRequired = true;
 	_numberLineEditUpdateRequired = true;
 	modelChanged();
+	set_modified();
 }
 
 // remember to call this and getReinforcementList together
@@ -250,6 +252,7 @@ void ReinforcementsDialogModel::selectReinforcement(const SCP_vector<SCP_string>
 
 	_numberLineEditUpdateRequired = true;
 	modelChanged();
+	set_modified();
 }
 
 void ReinforcementsDialogModel::setUseCount(int count) 
@@ -257,6 +260,7 @@ void ReinforcementsDialogModel::setUseCount(int count)
 	for (auto& reinforcement : _selectedReinforcementIndices) {
 		std::get<1>(_reinforcementList[reinforcement]) = count;
 	}
+	set_modified();
 }
 
 void ReinforcementsDialogModel::setBeforeArrivalDelay(int delay) 
@@ -264,6 +268,7 @@ void ReinforcementsDialogModel::setBeforeArrivalDelay(int delay)
 	for (auto& reinforcement : _selectedReinforcementIndices) {
 		std::get<2>(_reinforcementList[reinforcement]) = delay;
 	}
+	set_modified();
 }
 
 void ReinforcementsDialogModel::moveReinforcementsUp()
@@ -284,6 +289,7 @@ void ReinforcementsDialogModel::moveReinforcementsUp()
 		updateSelectedIndices();
 		_listUpdateRequired = true;
 		modelChanged();
+		set_modified();
 	}
 }
 
@@ -303,6 +309,7 @@ void ReinforcementsDialogModel::moveReinforcementsDown()
 		updateSelectedIndices();
 		_listUpdateRequired = true;
 		modelChanged();
+		set_modified();
 	}
 }
 

--- a/qtfred/src/mission/dialogs/ReinforcementsEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ReinforcementsEditorDialogModel.cpp
@@ -260,6 +260,7 @@ void ReinforcementsDialogModel::setUseCount(int count)
 	for (auto& reinforcement : _selectedReinforcementIndices) {
 		std::get<1>(_reinforcementList[reinforcement]) = count;
 	}
+	modelChanged();
 	set_modified();
 }
 
@@ -268,6 +269,7 @@ void ReinforcementsDialogModel::setBeforeArrivalDelay(int delay)
 	for (auto& reinforcement : _selectedReinforcementIndices) {
 		std::get<2>(_reinforcementList[reinforcement]) = delay;
 	}
+	modelChanged();
 	set_modified();
 }
 

--- a/qtfred/src/mission/dialogs/SelectionDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/SelectionDialogModel.cpp
@@ -263,13 +263,14 @@ void SelectionDialogModel::setFilterWaypoints(bool filter_waypoints) {
 	}
 }
 
-bool SelectionDialogModel::isFilterIFFTeam(int team) const {
-	Assertion(team >= 0 && team < (int)Iff_info.size(), "Team index %d is invalid!", team);
+bool SelectionDialogModel::isFilterIFFTeam(size_t team) const {
+	Assertion(team >= 0 && team < Iff_info.size(), "Team index %d is invalid!", team);
 
 	return _filter_iff[team];
 }
-void SelectionDialogModel::setFilterIFFTeam(int team, bool filter) {
-	Assertion(team >= 0 && team < (int)Iff_info.size(), "Team index %d is invalid!", team);
+void SelectionDialogModel::setFilterIFFTeam(size_t team, bool filter)
+{
+	Assertion(team >= 0 && team < Iff_info.size(), "Team index %d is invalid!", team);
 
 	if (filter != _filter_iff[team]) {
 		_filter_iff[team] = filter;

--- a/qtfred/src/mission/dialogs/SelectionDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/SelectionDialogModel.cpp
@@ -263,14 +263,13 @@ void SelectionDialogModel::setFilterWaypoints(bool filter_waypoints) {
 	}
 }
 
-bool SelectionDialogModel::isFilterIFFTeam(size_t team) const {
-	Assertion(team >= 0 && team < Iff_info.size(), "Team index %d is invalid!", team);
+bool SelectionDialogModel::isFilterIFFTeam(int team) const {
+	Assertion(team >= 0 && team < (int)Iff_info.size(), "Team index %d is invalid!", team);
 
 	return _filter_iff[team];
 }
-void SelectionDialogModel::setFilterIFFTeam(size_t team, bool filter)
-{
-	Assertion(team >= 0 && team < Iff_info.size(), "Team index %d is invalid!", team);
+void SelectionDialogModel::setFilterIFFTeam(int team, bool filter) {
+	Assertion(team >= 0 && team < (int)Iff_info.size(), "Team index %d is invalid!", team);
 
 	if (filter != _filter_iff[team]) {
 		_filter_iff[team] = filter;

--- a/qtfred/src/mission/dialogs/SelectionDialogModel.h
+++ b/qtfred/src/mission/dialogs/SelectionDialogModel.h
@@ -72,8 +72,8 @@ signals:
 	bool isFilterWaypoints() const;
 	void setFilterWaypoints(bool filter_waypoints);
 
-	bool isFilterIFFTeam(int team) const;
-	void setFilterIFFTeam(int team, bool filter);
+	bool isFilterIFFTeam(size_t team) const;
+	void setFilterIFFTeam(size_t team, bool filter);
 
 	/**
 	 * @brief Updates the selection status of the objects in the list

--- a/qtfred/src/mission/dialogs/SelectionDialogModel.h
+++ b/qtfred/src/mission/dialogs/SelectionDialogModel.h
@@ -72,8 +72,8 @@ signals:
 	bool isFilterWaypoints() const;
 	void setFilterWaypoints(bool filter_waypoints);
 
-	bool isFilterIFFTeam(size_t team) const;
-	void setFilterIFFTeam(size_t team, bool filter);
+	bool isFilterIFFTeam(int team) const;
+	void setFilterIFFTeam(int team, bool filter);
 
 	/**
 	 * @brief Updates the selection status of the objects in the list

--- a/qtfred/src/mission/dialogs/ShieldSystemDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShieldSystemDialogModel.h
@@ -34,8 +34,6 @@ class ShieldSystemDialogModel: public AbstractDialogModel {
  private:
 	void initializeData();
 
-	template<typename T>
-	void modify(T &a, const T &b);
 
 	std::vector<SCP_string> _shipTypeOptions;
 	std::vector<SCP_string> _teamOptions;
@@ -44,14 +42,6 @@ class ShieldSystemDialogModel: public AbstractDialogModel {
 	int		_currTeam;
 	int		_currType;
 };
-
-template<typename T>
-inline void ShieldSystemDialogModel::modify(T &a, const T &b) {
-	if (a != b) {
-		a = b;
-		modelChanged();
-	}
-}
 
 }
 }

--- a/qtfred/src/mission/dialogs/ShipEditor/PlayerOrdersDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/PlayerOrdersDialogModel.cpp
@@ -53,11 +53,6 @@ namespace fso {
 			{
 			}
 
-			 bool PlayerOrdersDialogModel::query_modified() const
-			{
-				return _modified;
-			}
-
 			 SCP_vector<size_t> PlayerOrdersDialogModel::getAcceptedOrders() const
 			{
 				return acceptedOrders;
@@ -155,12 +150,6 @@ namespace fso {
 					}
 				}
 				modelChanged();
-			}
-			void PlayerOrdersDialogModel::set_modified()
-			{
-				if (!_modified) {
-					_modified = true;
-				}
 			}
 		}
 	}

--- a/qtfred/src/mission/dialogs/ShipEditor/PlayerOrdersDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/PlayerOrdersDialogModel.h
@@ -9,13 +9,6 @@ namespace fso {
 			class PlayerOrdersDialogModel : public AbstractDialogModel {
 			private:
 
-				template<typename T>
-				void modify(T& a, const T& b);
-
-				bool _modified = false;
-
-				void set_modified();
-
 				bool m_multi;
 
 				int m_num_checks_active;
@@ -31,22 +24,11 @@ namespace fso {
 				bool apply() override;
 				void reject() override;
 
-				 bool query_modified() const;
-
 				 SCP_vector<size_t> getAcceptedOrders() const;
 				 SCP_vector<SCP_string> getOrderNames() const;
 				 SCP_vector<int> getCurrentOrders() const;
 				 void setCurrentOrder(const int, const size_t);
 			};
-			template<typename T>
-			inline void PlayerOrdersDialogModel::modify(T& a, const T& b)
-			{
-				if (a != b) {
-					a = b;
-					set_modified();
-					modelChanged();
-				}
-			}
 		}
 	}
 }

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
@@ -207,17 +207,6 @@ void ShipCustomWarpDialogModel::initializeData()
 	}
 }
 
-void ShipCustomWarpDialogModel::set_modified()
-{
-	if (!_modified) {
-		_modified = true;
-	}
-}
-
-bool ShipCustomWarpDialogModel::query_modified() const
-{
-	return _modified;
-}
 void ShipCustomWarpDialogModel::setType(const int index)
 {
 	modify(_m_warp_type, index);

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.h
@@ -10,12 +10,6 @@ class ShipCustomWarpDialogModel : public AbstractDialogModel {
 	 * @brief Initialises data for the model
 	 */
 	void initializeData();
-	template <typename T>
-	/**
-	 * @brief Copies rvalue to the lvalue while setting the modified variable.
-	 */
-	void modify(T& a, const T& b);
-	bool _modified = false;
 	bool _m_departure;
 
 	int _m_warp_type;
@@ -34,7 +28,6 @@ class ShipCustomWarpDialogModel : public AbstractDialogModel {
 	/**
 	 * @brief Marks the model as modifed
 	 */
-	void set_modified();
 
   public:
 	/**
@@ -113,11 +106,6 @@ class ShipCustomWarpDialogModel : public AbstractDialogModel {
 	 * @return If the model is working on a player.
 	 */
 	bool isPlayer() const;
-	/**
-	 * @brief Getter
-	 * @return If the model has been modified.
-	 */
-	bool query_modified() const;
 
 	// Setters
 	void setType(const int index);
@@ -132,15 +120,5 @@ class ShipCustomWarpDialogModel : public AbstractDialogModel {
 	void setSupercap(const bool);
 	void setPlayerSpeed(const double);
 };
-
-template <typename T>
-inline void ShipCustomWarpDialogModel::modify(T& a, const T& b)
-{
-	if (a != b) {
-		a = b;
-		set_modified();
-		modelChanged();
-	}
-}
 
 } // namespace dialogs

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.h
@@ -15,9 +15,6 @@ namespace dialogs {
 class ShipEditorDialogModel : public AbstractDialogModel {
   private:
 
-	template <typename T>
-	void modify(T& a, const T& b);
-
 	int _m_no_departure_warp;
 	int _m_no_arrival_warp;
 	bool _m_player_ship;
@@ -76,7 +73,6 @@ class ShipEditorDialogModel : public AbstractDialogModel {
   public:
 	ShipEditorDialogModel(QObject* parent, EditorViewport* viewport);
 	void initializeData();
-	bool _modified = false;
 	bool apply() override;
 	void reject() override;
 
@@ -232,17 +228,6 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 	 */
 	int getIfPlayerShip() const;
 };
-
-template <typename T>
-inline void ShipEditorDialogModel::modify(T& a, const T& b)
-{
-	if (a != b) {
-		a = b;
-		set_modified();
-		update_data();
-		modelChanged();
-	}
-}
 } // namespace dialogs
 } // namespace fred
 } // namespace fso

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipFlagsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipFlagsDialogModel.cpp
@@ -12,12 +12,6 @@
 namespace fso {
 namespace fred {
 namespace dialogs {
-void ShipFlagsDialogModel::set_modified()
-{
-	if (!_modified) {
-		_modified = true;
-	}
-}
 int ShipFlagsDialogModel::tristate_set(int val, int cur_state)
 {
 	if (val) {
@@ -1125,11 +1119,6 @@ void ShipFlagsDialogModel::setNoSelfDestruct(const int state)
 int ShipFlagsDialogModel::getNoSelfDestruct() const
 {
 	return m_no_disabled_self_destruct;
-}
-
-bool ShipFlagsDialogModel::query_modified()
-{
-	return _modified;
 }
 
 void ShipFlagsDialogModel::initializeData()

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipFlagsDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipFlagsDialogModel.h
@@ -9,11 +9,6 @@ namespace dialogs {
 class ShipFlagsDialogModel : public AbstractDialogModel {
   private:
 
-	template <typename T>
-	void modify(T& a, const T& b);
-
-	bool _modified = false;
-
 	int m_red_alert_carry;
 	int m_scannable;
 	int m_reinforcement;
@@ -61,7 +56,6 @@ class ShipFlagsDialogModel : public AbstractDialogModel {
 	int m_escort_value;
 	int m_respawn_priority;
 
-	void set_modified();
 	static int tristate_set(const int val, const int cur_state);
 	void update_ship(const int);
 
@@ -205,18 +199,7 @@ class ShipFlagsDialogModel : public AbstractDialogModel {
 	void setNoSelfDestruct(const int);
 	int getNoSelfDestruct() const;
 
-	bool query_modified();
 };
-
-template <typename T>
-inline void ShipFlagsDialogModel::modify(T& a, const T& b)
-{
-	if (a != b) {
-		a = b;
-		set_modified();
-		modelChanged();
-	}
-}
 } // namespace dialogs
 } // namespace fred
 } // namespace fso

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
@@ -618,16 +618,6 @@ namespace fso {
 					m_object[i] = data[i];
 				}
 			}
-			void ShipGoalsDialogModel::set_modified()
-			{
-				if (!_modified) {
-					_modified = true;
-				}
-			}
-			 bool ShipGoalsDialogModel::query_modified()
-			{
-				return _modified;
-			}
 			void ShipGoalsDialogModel::setShip(const int ship)
 			{
 				self_ship = ship;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.h
@@ -25,12 +25,7 @@ class ShipGoalsDialogModel : public AbstractDialogModel {
 	void initialize(ai_goal* goals, int ship);
 	void initialize_multi();
 
-	template <typename T>
-	void modify(T& a, const T& b);
 
-	bool _modified = false;
-
-	void set_modified();
 
 	int self_ship, self_wing;
 	int m_behavior[ED_MAX_GOALS];
@@ -53,7 +48,6 @@ class ShipGoalsDialogModel : public AbstractDialogModel {
 	void initializeData(bool multi, int self_ship, int self_wing);
 	bool apply() override;
 	void reject() override;
-	 bool query_modified();
 
 	void setShip(const int);
 	 int getShip() const;
@@ -85,15 +79,7 @@ class ShipGoalsDialogModel : public AbstractDialogModel {
 	void setPriority(const int, const int);
 	 int getPriority(const int) const;
 };
-template <typename T>
-inline void ShipGoalsDialogModel::modify(T& a, const T& b)
-{
-	if (a != b) {
-		a = b;
-		set_modified();
-		modelChanged();
-	}
-}
+
 } // namespace dialogs
 } // namespace fred
 } // namespace fso

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
@@ -633,17 +633,6 @@ bool ShipInitialStatusDialogModel::apply()
 
 void ShipInitialStatusDialogModel::reject() {}
 
-void ShipInitialStatusDialogModel::set_modified()
-{
-	if (!_modified) {
-		_modified = true;
-	}
-}
-
- bool ShipInitialStatusDialogModel::query_modified()
-{
-	return _modified;
-}
 
 void ShipInitialStatusDialogModel::setVelocity(const int value)
 {

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.h
@@ -19,10 +19,7 @@ bool set_cue_to_false(int* cue);
 class ShipInitialStatusDialogModel : public AbstractDialogModel {
 
   private:
-	template <typename T>
-	void modify(T& a, const T& b);
 
-	bool _modified = false;
 
 	int m_ship;
 	int cur_subsys = -1;
@@ -48,7 +45,6 @@ class ShipInitialStatusDialogModel : public AbstractDialogModel {
 
 	dockpoint_information* dockpoint_array;
 
-	void set_modified();
 
 	void update_docking_info();
 	void undock(object*, object*);
@@ -72,7 +68,6 @@ class ShipInitialStatusDialogModel : public AbstractDialogModel {
 
 	bool apply() override;
 	void reject() override;
-	bool query_modified();
 
 	void setVelocity(const int);
 	int getVelocity() const;
@@ -144,15 +139,6 @@ static void handle_inconsistent_flag(flagset<T>& flags, T flag, int value)
 		flags.set(flag);
 	} else if (value == Qt::Unchecked) {
 		flags.remove(flag);
-	}
-}
-template <typename T>
-inline void ShipInitialStatusDialogModel::modify(T& a, const T& b)
-{
-	if (a != b) {
-		a = b;
-		set_modified();
-		modelChanged();
 	}
 }
 } // namespace dialogs

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipPathsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipPathsDialogModel.cpp
@@ -76,10 +76,6 @@ bool ShipPathsDialogModel::modify(const int index, const bool value)
 		return false;
 	}
 }
-bool ShipPathsDialogModel::query_modified() const
-{
-	return _modified;
-}
 SCP_vector<bool> ShipPathsDialogModel::getPathList() const
 {
 	return m_path_list;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipPathsDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipPathsDialogModel.h
@@ -13,7 +13,6 @@ class ShipPathsDialogModel : public AbstractDialogModel {
 	SCP_vector<bool> m_path_list;
 	int m_path_mask;
 	int m_ship;
-	bool _modified = false;
   public:
 	ShipPathsDialogModel(QObject* parent,
 		EditorViewport* viewport,
@@ -22,7 +21,6 @@ class ShipPathsDialogModel : public AbstractDialogModel {
 	bool apply() override;
 	void reject() override;
 	bool modify(const int, const bool);
-	bool query_modified() const;
 	SCP_vector<bool> getPathList() const;
 	polymodel* getModel() const;
 };

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipSpecialStatsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipSpecialStatsDialogModel.cpp
@@ -207,15 +207,6 @@ namespace fso {
 			void ShipSpecialStatsDialogModel::reject()
 			{
 			}
-			void ShipSpecialStatsDialogModel::set_modified()
-			{
-				if (!_modified) {
-					_modified = true;
-				}
-			}
-			bool ShipSpecialStatsDialogModel::query_modified() {
-				return _modified;
-			}
 			bool ShipSpecialStatsDialogModel::getSpecialExp() const
 			{
 				return m_special_exp;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipSpecialStatsDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipSpecialStatsDialogModel.h
@@ -7,9 +7,6 @@ namespace fso {
 		namespace dialogs {
 			class ShipSpecialStatsDialogModel : public AbstractDialogModel {
 			private:
-				template <typename T>
-				void modify(T& a, const T& b);
-				bool _modified = false;
 				int m_ship;
 
 				int num_selected_ships;
@@ -31,14 +28,12 @@ namespace fso {
 				int m_shields;
 				int m_hull;
 
-				void set_modified();
 
 			public:
 				ShipSpecialStatsDialogModel(QObject* parent, EditorViewport* viewport);
 			  void initializeData();
 				bool apply() override;
 				void reject() override;
-				bool query_modified();
 
 				//Exp Get/Setters
 				bool getSpecialExp() const;
@@ -70,15 +65,6 @@ namespace fso {
 				int getHull() const;
 				void setHull(const int);
 			};
-			template <typename T>
-			inline void ShipSpecialStatsDialogModel::modify(T& a, const T& b)
-			{
-				if (a != b) {
-					a = b;
-					set_modified();
-					modelChanged();
-				}
-			}
 		}
 	}
 }

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
@@ -627,17 +627,6 @@ namespace fso {
 				Assert(index < currentTextures.size());
 				modify(inheritMap[index][type], state);
 			}
-			void ShipTextureReplacementDialogModel::set_modified()
-			{
-				if (!_modified) {
-					_modified = true;
-				}
-			}
-
-			bool ShipTextureReplacementDialogModel::query_modified() const
-			{
-				return  _modified;;
-			}
 		}
 	}
 }

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.h
@@ -10,11 +10,6 @@ namespace fso {
 			private:
 				void initSubTypes(polymodel* model, int);
 
-				template<typename T>
-				void modify(T& a, const T& b);
-				bool _modified = false;
-				void set_modified();
-
 				bool m_multi;
 				//Used to dermeine what type of texutre a map has.
 				SCP_vector<SCP_map<SCP_string, bool>> subTypesAvailable;
@@ -50,18 +45,8 @@ namespace fso {
 				void setReplace(const size_t index, const SCP_string& type, const bool state);
 				void setInherit(const size_t index, const SCP_string& type, const bool state);
 
-				bool query_modified() const;
 
 			};
-			template<typename T>
-			inline void ShipTextureReplacementDialogModel::modify(T& a, const T& b)
-			{
-				if (a != b) {
-					a = b;
-					set_modified();
-					modelChanged();
-				}
-			}
 		}
 	}
 }

--- a/qtfred/src/mission/util.cpp
+++ b/qtfred/src/mission/util.cpp
@@ -93,7 +93,7 @@ void time_to_mission_info_string(const std::tm* src, char* dest, size_t dest_max
 	std::strftime(dest, dest_max_len, "%x at %X", src);
 }
 
-bool rejectOrCloseHandler(QDialog* dialog,
+bool rejectOrCloseHandler(__UNUSED QDialog* dialog,
 	fso::fred::dialogs::AbstractDialogModel* model,
 	fso::fred::EditorViewport* viewport)
 {

--- a/qtfred/src/mission/util.cpp
+++ b/qtfred/src/mission/util.cpp
@@ -92,3 +92,32 @@ void time_to_mission_info_string(const std::tm* src, char* dest, size_t dest_max
 {
 	std::strftime(dest, dest_max_len, "%x at %X", src);
 }
+
+bool rejectOrCloseHandler(QDialog* dialog,
+	fso::fred::dialogs::AbstractDialogModel* model,
+	fso::fred::EditorViewport* viewport)
+{
+	if (model->query_modified()) {
+		auto button = viewport->dialogProvider->showButtonDialog(fso::fred::DialogType::Question,
+			"Changes detected",
+			"Do you want to keep your changes?",
+			{fso::fred::DialogButton::Yes, fso::fred::DialogButton::No, fso::fred::DialogButton::Cancel});
+
+		if (button == fso::fred::DialogButton::Cancel) {
+			return false;
+		}
+
+		if (button == fso::fred::DialogButton::Yes) {
+			model->apply();
+			return true;
+		}
+		if (button == fso::fred::DialogButton::No) {
+			model->reject();
+			return true;
+		}
+		return false;
+	} else {
+		model->reject();
+		return true;
+	}
+}

--- a/qtfred/src/mission/util.h
+++ b/qtfred/src/mission/util.h
@@ -1,5 +1,7 @@
 #pragma once
-
+#include <qevent.h>
+#include "dialogs/AbstractDialogModel.h"
+#include "EditorViewport.h"
 
 void stuff_special_arrival_anchor_name(char *buf, int iff_index, int restrict_to_players, int retail_format);
 
@@ -10,3 +12,7 @@ void generate_weaponry_usage_list_team(int team, int *arr);
 void generate_weaponry_usage_list_wing(int wing_num, int *arr);
 
 void time_to_mission_info_string(const std::tm* src, char* dest, size_t dest_max_len);
+
+bool rejectOrCloseHandler(QDialog* dialog,
+	fso::fred::dialogs::AbstractDialogModel* model,
+	fso::fred::EditorViewport* viewport);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -872,7 +872,7 @@ void FredView::orientEditorTriggered() {
 	auto dialog = new dialogs::ObjectOrientEditorDialog(this, _viewport);
 	dialog->setAttribute(Qt::WA_DeleteOnClose);
 	// This is a modal dialog
-	dialog->show();
+	dialog->exec();
 }
 void FredView::onUpdateEditorActions() {
 	ui->actionObjects->setEnabled(query_valid_object(fred->currentObject));
@@ -989,7 +989,7 @@ void FredView::on_actionSelectionList_triggered(bool) {
 	auto dialog = new dialogs::SelectionDialog(this, _viewport);
 	// This is a modal dialog
 	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	dialog->exec();
 }
 void FredView::on_actionOrbitSelected_triggered(bool enabled) {
 	_viewport->Lookat_mode = enabled;

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -721,10 +721,12 @@ void FredView::onShipClassSelected(int ship_class) {
 }
 void FredView::on_actionAsteroid_Field_triggered(bool) {
 	auto asteroidFieldEditor = new dialogs::AsteroidEditorDialog(this, _viewport);
+	asteroidFieldEditor->setAttribute(Qt::WA_DeleteOnClose);
 	asteroidFieldEditor->show();
 }
 void FredView::on_actionBriefing_triggered(bool) {
 	auto eventEditor = new dialogs::BriefingEditorDialog(this);
+	eventEditor->setAttribute(Qt::WA_DeleteOnClose);
 	eventEditor->show();
 }
 void FredView::on_actionMission_Specs_triggered(bool) {
@@ -740,12 +742,14 @@ void FredView::on_actionWaypoint_Paths_triggered(bool) {
 void FredView::on_actionShips_triggered(bool)
 {
 	auto editorDialog = new dialogs::ShipEditorDialog(this, _viewport);
+	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
 	editorDialog->show();
 
 }
 void FredView::on_actionCampaign_triggered(bool) {
 	//TODO: Save if Changes
 	auto editorCampaign = new dialogs::CampaignEditorDialog(this, _viewport);
+	editorCampaign->setAttribute(Qt::WA_DeleteOnClose);
 	editorCampaign->show();
 }
 void FredView::on_actionObjects_triggered(bool) {
@@ -1128,13 +1132,15 @@ void FredView::on_actionError_Checker_triggered(bool) {
 	fred->global_error_check();
 }
 void FredView::on_actionAbout_triggered(bool) {
-	dialogs::AboutDialog dialog(this);
-	dialog.exec();
+	auto dialog = new dialogs::AboutDialog(this);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void FredView::on_actionBackground_triggered(bool) {
-	dialogs::BackgroundEditorDialog dialog(this, _viewport);
-	dialog.exec();
+	auto dialog = new dialogs::BackgroundEditorDialog(this, _viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void FredView::on_actionShield_System_triggered(bool) {
@@ -1144,8 +1150,9 @@ void FredView::on_actionShield_System_triggered(bool) {
 }
 
 void FredView::on_actionVoice_Acting_Manager_triggered(bool) {
-	dialogs::VoiceActingManager dialog(this, _viewport);
-	dialog.exec();
+	auto dialog = new dialogs::VoiceActingManager(this, _viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 void FredView::on_actionMission_Objectives_triggered(bool) {
 	auto dialog = new dialogs::MissionGoalsDialog(this, _viewport);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -704,6 +704,7 @@ void FredView::keyReleaseEvent(QKeyEvent* event) {
 }
 void FredView::on_actionEvents_triggered(bool) {
 	auto eventEditor = new dialogs::EventEditorDialog(this, _viewport);
+	eventEditor->setAttribute(Qt::WA_DeleteOnClose);
 	eventEditor->show();
 }
 void FredView::on_actionSelectionLock_triggered(bool enabled) {
@@ -733,6 +734,7 @@ void FredView::on_actionMission_Specs_triggered(bool) {
 }
 void FredView::on_actionWaypoint_Paths_triggered(bool) {
 	auto editorDialog = new dialogs::WaypointEditorDialog(this, _viewport);
+	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
 	editorDialog->show();
 }
 void FredView::on_actionShips_triggered(bool)
@@ -981,7 +983,8 @@ bool FredView::showModalDialog(IBaseDialog* dlg) {
 void FredView::on_actionSelectionList_triggered(bool) {
 	auto dialog = new dialogs::SelectionDialog(this, _viewport);
 	// This is a modal dialog
-	dialog->exec();
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 void FredView::on_actionOrbitSelected_triggered(bool enabled) {
 	_viewport->Lookat_mode = enabled;

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -755,6 +755,7 @@ void FredView::on_actionCommand_Briefing_triggered(bool) {
 }
 void FredView::on_actionReinforcements_triggered(bool) {
 	auto editorDialog = new dialogs::ReinforcementsDialog(this, _viewport);
+	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
 	editorDialog->show();
 }
 void FredView::on_actionLoadout_triggered(bool) {

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -863,8 +863,9 @@ void FredView::mouseDoubleClickEvent(QMouseEvent* event) {
 }
 void FredView::orientEditorTriggered() {
 	auto dialog = new dialogs::ObjectOrientEditorDialog(this, _viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
 	// This is a modal dialog
-	dialog->exec();
+	dialog->show();
 }
 void FredView::onUpdateEditorActions() {
 	ui->actionObjects->setEnabled(query_valid_object(fred->currentObject));

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -1144,8 +1144,9 @@ void FredView::on_actionMission_Objectives_triggered(bool) {
 }
 
 void FredView::on_actionFiction_Viewer_triggered(bool) {
-	dialogs::FictionViewerDialog dialog(this, _viewport);
-	dialog.exec();
+	auto dialog = new dialogs::FictionViewerDialog(this, _viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 } // namespace fred

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -758,6 +758,7 @@ void FredView::on_actionReinforcements_triggered(bool) {
 }
 void FredView::on_actionLoadout_triggered(bool) {
 	auto editorDialog = new dialogs::LoadoutDialog(this, _viewport);
+	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
 	editorDialog->show();
 }
 DialogButton FredView::showButtonDialog(DialogType type,

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -753,6 +753,7 @@ void FredView::on_actionObjects_triggered(bool) {
 }
 void FredView::on_actionCommand_Briefing_triggered(bool) {
 	auto editorDialog = new dialogs::CommandBriefingDialog(this, _viewport);
+	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
 	editorDialog->show();
 }
 void FredView::on_actionReinforcements_triggered(bool) {

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -728,6 +728,7 @@ void FredView::on_actionBriefing_triggered(bool) {
 }
 void FredView::on_actionMission_Specs_triggered(bool) {
 	auto missionSpecEditor = new dialogs::MissionSpecDialog(this, _viewport);
+	missionSpecEditor->setAttribute(Qt::WA_DeleteOnClose);
 	missionSpecEditor->show();
 }
 void FredView::on_actionWaypoint_Paths_triggered(bool) {

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -1133,8 +1133,9 @@ void FredView::on_actionBackground_triggered(bool) {
 }
 
 void FredView::on_actionShield_System_triggered(bool) {
-	dialogs::ShieldSystemDialog dialog(this, _viewport);
-	dialog.exec();
+	auto dialog = new dialogs::ShieldSystemDialog(this, _viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void FredView::on_actionVoice_Acting_Manager_triggered(bool) {

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -1143,8 +1143,9 @@ void FredView::on_actionVoice_Acting_Manager_triggered(bool) {
 	dialog.exec();
 }
 void FredView::on_actionMission_Objectives_triggered(bool) {
-	dialogs::MissionGoalsDialog dialog(this, _viewport);
-	dialog.exec();
+	auto dialog = new dialogs::MissionGoalsDialog(this, _viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void FredView::on_actionFiction_Viewer_triggered(bool) {

--- a/qtfred/src/ui/dialogs/AsteroidEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/AsteroidEditorDialog.cpp
@@ -331,6 +331,8 @@ void AsteroidEditorDialog::updateUI()
 	ui->lineEdit_ibox_maxZ->setText(_model->AsteroidEditorDialogModel::getBoxText(AsteroidEditorDialogModel::_I_MAX_Z));
 }
 
+
+
 void AsteroidEditorDialog::done(int r)
 {
 	if(QDialog::Accepted == r)  // ok was pressed

--- a/qtfred/src/ui/dialogs/AsteroidEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/AsteroidEditorDialog.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "ui_AsteroidEditorDialog.h"
+#include <mission/util.h>
 
 namespace fso {
 namespace fred {
@@ -22,6 +23,8 @@ AsteroidEditorDialog::AsteroidEditorDialog(FredView *parent, EditorViewport* vie
 	ui(new Ui::AsteroidEditorDialog()),
 	_model(new AsteroidEditorDialogModel(this, viewport))
 {
+	connect(this, &QDialog::accepted, _model.get(), &AsteroidEditorDialogModel::apply);
+	connect(ui->dialogButtonBox, &QDialogButtonBox::rejected, this, &AsteroidEditorDialog::rejectHandler);
 	ui->setupUi(this);
 	_model->update_init();
 
@@ -126,6 +129,18 @@ AsteroidEditorDialog::AsteroidEditorDialog(FredView *parent, EditorViewport* vie
 }
 
 AsteroidEditorDialog::~AsteroidEditorDialog() = default;
+
+void AsteroidEditorDialog::closeEvent(QCloseEvent* e)
+{
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
+}
+
+void AsteroidEditorDialog::rejectHandler()
+{
+	this->close();
+}
 
 QString & AsteroidEditorDialog::getBoxText(AsteroidEditorDialogModel::_box_line_edits type)
 {
@@ -329,48 +344,6 @@ void AsteroidEditorDialog::updateUI()
 	ui->lineEdit_ibox_maxX->setText(_model->AsteroidEditorDialogModel::getBoxText(AsteroidEditorDialogModel::_I_MAX_X));
 	ui->lineEdit_ibox_maxY->setText(_model->AsteroidEditorDialogModel::getBoxText(AsteroidEditorDialogModel::_I_MAX_Y));
 	ui->lineEdit_ibox_maxZ->setText(_model->AsteroidEditorDialogModel::getBoxText(AsteroidEditorDialogModel::_I_MAX_Z));
-}
-
-
-
-void AsteroidEditorDialog::done(int r)
-{
-	if(QDialog::Accepted == r)  // ok was pressed
-	{
-		// TODO consider moving the validation to when values are entered
-		// but just visually indicate that there's a problem at that time
-		// hard fail (by checking status boolean?) here instead
-		// i.e. let FREDers have temp bad values when they're changing stuff
-		// if they know what they're doing
-		if (_model->apply()) {
-			// all ok
-			QDialog::done(r);
-			_model->unset_modified();
-			return;
-		}
-		else {
-			// leave dialog open
-			return;
-		}
-	}
-	else    // cancel, close or exc was pressed
-	{
-		if (_model->get_modified()) {
-			// give FREDer a chance in case they cancelled by mistake
-			// although I wonder if we're better off with always saving & don't prompt
-			// ~philisophical~
-			auto z = _viewport->dialogProvider->showButtonDialog(DialogType::Question,
-				"Question",
-				"You have unsaved changes, do you wish to discard them?",
-				{ DialogButton::Ok, DialogButton::Cancel });
-			if (z == DialogButton::Cancel) {
-				return;
-			}
-		}
-		QDialog::done(r);
-		_model->unset_modified();
-		return;
-	}
 }
 
 } // namespace dialogs

--- a/qtfred/src/ui/dialogs/AsteroidEditorDialog.h
+++ b/qtfred/src/ui/dialogs/AsteroidEditorDialog.h
@@ -18,10 +18,13 @@ class AsteroidEditorDialog : public QDialog
 	Q_OBJECT
 public:
 	AsteroidEditorDialog(FredView* parent, EditorViewport* viewport);
-	~AsteroidEditorDialog() override;
+  ~AsteroidEditorDialog() override;
+
+  protected:
+  void closeEvent(QCloseEvent* e);
+	void rejectHandler();
 
 private:
-	void done(int r) override;
 
 	void toggleEnabled(bool enabled);
 	void toggleInnerBoxEnabled(bool enabled);

--- a/qtfred/src/ui/dialogs/AsteroidEditorDialog.h
+++ b/qtfred/src/ui/dialogs/AsteroidEditorDialog.h
@@ -21,7 +21,7 @@ public:
   ~AsteroidEditorDialog() override;
 
   protected:
-  void closeEvent(QCloseEvent* e);
+  void closeEvent(QCloseEvent* e) override;
 	void rejectHandler();
 
 private:

--- a/qtfred/src/ui/dialogs/CommandBriefingDialog.cpp
+++ b/qtfred/src/ui/dialogs/CommandBriefingDialog.cpp
@@ -1,6 +1,6 @@
 #include "CommandBriefingDialog.h"
 #include "ui_CommandBriefingDialog.h"
-
+#include "mission/util.h"
 #include <globalincs/linklist.h>
 #include <ui/util/SignalBlockers.h>
 #include <QCloseEvent>
@@ -22,7 +22,7 @@ namespace dialogs {
 		connect(this, &QDialog::accepted, _model.get(), &CommandBriefingDialogModel::apply);
 		connect(viewport->editor, &Editor::currentObjectChanged, _model.get(), &CommandBriefingDialogModel::apply);
 		connect(viewport->editor, &Editor::objectMarkingChanged, _model.get(), &CommandBriefingDialogModel::apply);
-		connect(this, &QDialog::rejected, _model.get(), &CommandBriefingDialogModel::reject);
+		connect(ui->okAndCancelButtons, &QDialogButtonBox::rejected, this, &CommandBriefingDialog::rejectHandler);
 
 		connect(ui->actionChangeTeams,
 			static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
@@ -283,8 +283,16 @@ namespace dialogs {
 
 	CommandBriefingDialog::~CommandBriefingDialog() {}; //NOLINT
 
-	void CommandBriefingDialog::closeEvent(QCloseEvent*){}
-
-} // dialogs
+	void CommandBriefingDialog::closeEvent(QCloseEvent* e)
+	{
+		if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+			e->ignore();
+		};
+	}
+	void CommandBriefingDialog::rejectHandler()
+	{
+		this->close();
+	}
+	} // dialogs
 } // fred
 } // fso

--- a/qtfred/src/ui/dialogs/CommandBriefingDialog.h
+++ b/qtfred/src/ui/dialogs/CommandBriefingDialog.h
@@ -29,6 +29,8 @@ public:
 protected:
 	void closeEvent(QCloseEvent*) override;
 
+	void rejectHandler();
+
 private slots: // where the buttons go
 	void on_actionPrevStage_clicked();
 	void on_actionNextStage_clicked();

--- a/qtfred/src/ui/dialogs/CustomWingNamesDialog.cpp
+++ b/qtfred/src/ui/dialogs/CustomWingNamesDialog.cpp
@@ -1,6 +1,7 @@
 #include "CustomWingNamesDialog.h"
 
 #include "ui_CustomWingNamesDialog.h"
+#include <mission/util.h>
 
 namespace fso {
 namespace fred {
@@ -12,7 +13,7 @@ CustomWingNamesDialog::CustomWingNamesDialog(QWidget* parent, EditorViewport* vi
     ui->setupUi(this);
 
 	connect(this, &QDialog::accepted, _model.get(), &CustomWingNamesDialogModel::apply);
-	connect(this, &QDialog::rejected, _model.get(), &CustomWingNamesDialogModel::reject);
+	connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &CustomWingNamesDialog::rejectHandler);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &CustomWingNamesDialog::updateUI);
 	
@@ -41,25 +42,15 @@ CustomWingNamesDialog::CustomWingNamesDialog(QWidget* parent, EditorViewport* vi
 CustomWingNamesDialog::~CustomWingNamesDialog() {
 }
 
-void CustomWingNamesDialog::closeEvent(QCloseEvent * event) {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question, "Changes detected", "Do you want to keep your changes?",
-		{ DialogButton::Yes, DialogButton::No, DialogButton::Cancel });
-
-		if (button == DialogButton::Cancel) {
-			event->ignore();
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-	}
-
-	QDialog::closeEvent(event);
+void CustomWingNamesDialog::closeEvent(QCloseEvent * e) {
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
 }
-
+void CustomWingNamesDialog::rejectHandler()
+{
+	this->close();
+}
 void CustomWingNamesDialog::updateUI() {
 	// Update starting wings
 	ui->startingWing_1->setText(_model->getStartingWing(0).c_str());

--- a/qtfred/src/ui/dialogs/CustomWingNamesDialog.h
+++ b/qtfred/src/ui/dialogs/CustomWingNamesDialog.h
@@ -27,6 +27,8 @@ public:
 protected:
 	void closeEvent(QCloseEvent*) override;
 
+	void rejectHandler();
+
 private:
     std::unique_ptr<Ui::CustomWingNamesDialog> ui;
 	std::unique_ptr<CustomWingNamesDialogModel> _model;

--- a/qtfred/src/ui/dialogs/FictionViewerDialog.cpp
+++ b/qtfred/src/ui/dialogs/FictionViewerDialog.cpp
@@ -3,7 +3,7 @@
 #include "ui/dialogs/FictionViewerDialog.h"
 #include "ui/util/SignalBlockers.h"
 #include "ui_FictionViewerDialog.h"
-
+#include "mission/util.h"
 namespace fso {
 namespace fred {
 namespace dialogs {
@@ -23,7 +23,7 @@ FictionViewerDialog::FictionViewerDialog(FredView* parent, EditorViewport* viewp
 	ui->voiceFileEdit->setMaxLength(_model->getMaxVoiceFileLength());
 
 	connect(this, &QDialog::accepted, _model.get(), &FictionViewerDialogModel::apply);
-	connect(this, &QDialog::rejected, _model.get(), &FictionViewerDialogModel::reject);
+	connect(ui->dialogButtonBox, &QDialogButtonBox::rejected, this, &FictionViewerDialog::rejectHandler);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &FictionViewerDialog::updateUI);
 
@@ -109,25 +109,15 @@ void FictionViewerDialog::keyPressEvent(QKeyEvent* event) {
 	QDialog::keyPressEvent(event);
 }
 
-void FictionViewerDialog::closeEvent(QCloseEvent* event) {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question, "Changes detected", "Do you want to keep your changes?",
-			{ DialogButton::Yes, DialogButton::No, DialogButton::Cancel });
-
-		if (button == DialogButton::Cancel) {
-			event->ignore();
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-	}
-
-	QDialog::closeEvent(event);
+void FictionViewerDialog::closeEvent(QCloseEvent* e) {
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
 }
-
+void FictionViewerDialog::rejectHandler()
+{
+	this->close();
+}
 }
 }
 }

--- a/qtfred/src/ui/dialogs/FictionViewerDialog.h
+++ b/qtfred/src/ui/dialogs/FictionViewerDialog.h
@@ -29,6 +29,7 @@ public:
  protected:
 	void keyPressEvent(QKeyEvent* event) override;
 	void closeEvent(QCloseEvent*) override;
+	void rejectHandler();
  private:
 
 	void updateMusicComboBox();

--- a/qtfred/src/ui/dialogs/LoadoutDialog.cpp
+++ b/qtfred/src/ui/dialogs/LoadoutDialog.cpp
@@ -6,6 +6,7 @@
 #include <qtablewidget.h>
 #include <QListWidget>
 #include <QMessageBox>
+#include <mission/util.h>
 
 constexpr int TABLE_MODE = 0;
 constexpr int VARIABLE_MODE = 1;
@@ -23,7 +24,7 @@ LoadoutDialog::LoadoutDialog(FredView* parent, EditorViewport* viewport)
 	// Major Changes, like Applying the model, rejecting changes and updating the UI.
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &LoadoutDialog::updateUI);
 	connect(this, &QDialog::accepted, _model.get(), &LoadoutDialogModel::apply);
-	connect(this, &QDialog::rejected, _model.get(), &LoadoutDialogModel::reject);
+	connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &LoadoutDialog::rejectHandler);
 
 	// Ship and Weapon lists, selection changed.
 	connect(ui->listShipsNotUsed, 
@@ -237,7 +238,19 @@ LoadoutDialog::LoadoutDialog(FredView* parent, EditorViewport* viewport)
 }
 
 // a result of competing CI requirements
-LoadoutDialog::~LoadoutDialog(){} // NOLINT
+LoadoutDialog::~LoadoutDialog() {} // NOLINT
+
+void LoadoutDialog::closeEvent(QCloseEvent* e)
+{
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
+}
+
+void LoadoutDialog::rejectHandler()
+{
+	this->close();
+}
 
 void LoadoutDialog::onSwitchViewButtonPressed()
 {

--- a/qtfred/src/ui/dialogs/LoadoutDialog.h
+++ b/qtfred/src/ui/dialogs/LoadoutDialog.h
@@ -29,7 +29,15 @@ public:
 	explicit LoadoutDialog(FredView* parent, EditorViewport* viewport);
 	~LoadoutDialog() override;
 
-private:
+  protected:
+	/**
+	 * @brief Overides the Dialogs Close event to add a confermation dialog
+	 * @param [in] *e The event.
+	 */
+	void closeEvent(QCloseEvent*) override;
+	void rejectHandler();
+
+  private:
 	std::unique_ptr<Ui::LoadoutDialog> ui;
 	std::unique_ptr<LoadoutDialogModel> _model;
 	EditorViewport* _viewport;

--- a/qtfred/src/ui/dialogs/MissionGoalsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionGoalsDialog.cpp
@@ -2,7 +2,7 @@
 #include "MissionGoalsDialog.h"
 
 #include "ui/util/SignalBlockers.h"
-
+#include "mission/util.h"
 #include "ui_MissionGoalsDialog.h"
 
 namespace fso {
@@ -26,7 +26,7 @@ MissionGoalsDialog::MissionGoalsDialog(QWidget* parent, EditorViewport* viewport
 	ui->helpTextBox->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 
 	connect(this, &QDialog::accepted, _model.get(), &MissionGoalsDialogModel::apply);
-	connect(this, &QDialog::rejected, _model.get(), &MissionGoalsDialogModel::reject);
+	connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &MissionGoalsDialog::rejectHandler);
 
 	connect(_model.get(), &MissionGoalsDialogModel::modelChanged, this, &MissionGoalsDialog::updateUI);
 
@@ -198,29 +198,15 @@ void MissionGoalsDialog::changeGoalCategory(int type) {
 		recreate_tree();
 	}
 }
-void MissionGoalsDialog::closeEvent(QCloseEvent* event) {
-	if (_model->query_modified()) {
-		auto result = QMessageBox::question(this,
-											"Close",
-											"Do you want to keep your changes?",
-											QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
-											QMessageBox::Cancel);
-
-		if (result == QMessageBox::Cancel) {
-			event->ignore();
-			return;
-		}
-
-		if (result == QMessageBox::Yes) {
-			accept();
-			event->accept();
-			return;
-		}
-	}
-
-	QDialog::closeEvent(event);
+void MissionGoalsDialog::closeEvent(QCloseEvent* e) {
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
 }
-
+void MissionGoalsDialog::rejectHandler()
+{
+	this->close();
+}
 }
 }
 }

--- a/qtfred/src/ui/dialogs/MissionGoalsDialog.h
+++ b/qtfred/src/ui/dialogs/MissionGoalsDialog.h
@@ -28,6 +28,7 @@ public:
 
  protected:
 	void closeEvent(QCloseEvent* event) override;
+   void rejectHandler();
 
  private:
 	void updateUI();

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -3,7 +3,7 @@
 #include "ui_MissionSpecDialog.h"
 
 #include <ui/util/SignalBlockers.h>
-
+#include "mission/util.h"
 #include <QCloseEvent>
 #include <QFileDialog>
 
@@ -17,7 +17,7 @@ MissionSpecDialog::MissionSpecDialog(FredView* parent, EditorViewport* viewport)
     ui->setupUi(this);
 
 	connect(this, &QDialog::accepted, _model.get(), &MissionSpecDialogModel::apply);
-	connect(this, &QDialog::rejected, _model.get(), &MissionSpecDialogModel::reject);
+	connect(ui->dialogButtonBox, &QDialogButtonBox::rejected, _model.get(), &MissionSpecDialogModel::reject);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &MissionSpecDialog::updateUI);
 
@@ -103,23 +103,14 @@ MissionSpecDialog::MissionSpecDialog(FredView* parent, EditorViewport* viewport)
 MissionSpecDialog::~MissionSpecDialog() {
 }
 
-void MissionSpecDialog::closeEvent(QCloseEvent* event) {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question, "Changes detected", "Do you want to keep your changes?",
-		{ DialogButton::Yes, DialogButton::No, DialogButton::Cancel });
-
-		if (button == DialogButton::Cancel) {
-			event->ignore();
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-	}
-
-	QDialog::closeEvent(event);
+void MissionSpecDialog::closeEvent(QCloseEvent* e) {
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
+}
+void MissionSpecDialog::rejectHandler()
+{
+	this->close();
 }
 
 void MissionSpecDialog::updateUI() {

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -299,7 +299,8 @@ void MissionSpecDialog::squadronNameChanged(const QString & string) {
 
 void MissionSpecDialog::on_customWingNameButton_clicked() {
 	CustomWingNamesDialog* dialog = new CustomWingNamesDialog(this, _viewport);
-	dialog->exec();
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void MissionSpecDialog::on_squadronLogoButton_clicked() {

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -300,7 +300,7 @@ void MissionSpecDialog::squadronNameChanged(const QString & string) {
 void MissionSpecDialog::on_customWingNameButton_clicked() {
 	CustomWingNamesDialog* dialog = new CustomWingNamesDialog(this, _viewport);
 	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	dialog->exec();
 }
 
 void MissionSpecDialog::on_squadronLogoButton_clicked() {

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.h
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.h
@@ -27,6 +27,7 @@ public:
 
 protected:
 	void closeEvent(QCloseEvent*) override;
+  void rejectHandler();
 
 private slots:
 	void on_customWingNameButton_clicked();

--- a/qtfred/src/ui/dialogs/ObjectOrientEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ObjectOrientEditorDialog.cpp
@@ -6,7 +6,7 @@
 #include "ui_ObjectOrientationDialog.h"
 
 #include <ui/util/SignalBlockers.h>
-
+#include "mission/util.h"
 #include <QCloseEvent>
 
 namespace fso {
@@ -19,7 +19,7 @@ ObjectOrientEditorDialog::ObjectOrientEditorDialog(FredView* parent, EditorViewp
 	ui->setupUi(this);
 
 	connect(this, &QDialog::accepted, _model.get(), &ObjectOrientEditorDialogModel::apply);
-	connect(this, &QDialog::rejected, _model.get(), &ObjectOrientEditorDialogModel::reject);
+	connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ObjectOrientEditorDialog::rejectHandler);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &ObjectOrientEditorDialog::updateUI);
 
@@ -67,23 +67,15 @@ ObjectOrientEditorDialog::ObjectOrientEditorDialog(FredView* parent, EditorViewp
 ObjectOrientEditorDialog::~ObjectOrientEditorDialog() {
 }
 
-void ObjectOrientEditorDialog::closeEvent(QCloseEvent* event) {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question, "Changes detected", "Do you want to keep your changes?",
-			{ DialogButton::Yes, DialogButton::No, DialogButton::Cancel });
+void ObjectOrientEditorDialog::closeEvent(QCloseEvent* e) {
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
+}
 
-		if (button == DialogButton::Cancel) {
-			event->ignore();
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-	}
-
-	QDialog::closeEvent(event);
+void ObjectOrientEditorDialog::rejectHandler()
+{
+	this->close();
 }
 
 void ObjectOrientEditorDialog::updateUI() {

--- a/qtfred/src/ui/dialogs/ObjectOrientEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ObjectOrientEditorDialog.h
@@ -22,6 +22,7 @@ class ObjectOrientEditorDialog : public QDialog {
 
 protected:
 	void closeEvent(QCloseEvent*) override;
+  void rejectHandler();
 
 private:
 	std::unique_ptr<Ui::ObjectOrientEditorDialog> ui;

--- a/qtfred/src/ui/dialogs/ReinforcementsEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ReinforcementsEditorDialog.cpp
@@ -1,6 +1,6 @@
 #include "ReinforcementsEditorDialog.h"
 #include "ui_ReinforcementsDialog.h"
-
+#include "mission/util.h"
 #include <globalincs/linklist.h>
 #include <ui/util/SignalBlockers.h>
 #include <QCloseEvent>
@@ -22,7 +22,9 @@ namespace dialogs {
 
 		connect(_model.get(), &AbstractDialogModel::modelChanged, this, &ReinforcementsDialog::updateUI);
 		connect(this, &QDialog::accepted, _model.get(), &ReinforcementsDialogModel::apply);
-		connect(this, &QDialog::rejected, _model.get(), &ReinforcementsDialogModel::reject);			
+		connect(ui->okAndCancelButtonBox,
+			&QDialogButtonBox::rejected,
+			this, &ReinforcementsDialog::rejectHandler);			
 
 
 		connect(ui->delayLineEdit,
@@ -197,7 +199,16 @@ namespace dialogs {
 
 	ReinforcementsDialog::~ReinforcementsDialog() {} // NOLINT
 
-	void ReinforcementsDialog::closeEvent(QCloseEvent* ){}
+	void ReinforcementsDialog::closeEvent(QCloseEvent* e){
+		if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+			e->ignore();
+		};
+	}
+
+	void ReinforcementsDialog::rejectHandler()
+	{
+		this->close();
+	}
 
 }
 }

--- a/qtfred/src/ui/dialogs/ReinforcementsEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ReinforcementsEditorDialog.h
@@ -28,6 +28,7 @@ public:
 
 protected:
 	void closeEvent(QCloseEvent*) override;
+  void rejectHandler();
 
 private slots:
 	void on_chosenShipsList_clicked();

--- a/qtfred/src/ui/dialogs/SelectionDialog.cpp
+++ b/qtfred/src/ui/dialogs/SelectionDialog.cpp
@@ -38,7 +38,7 @@ SelectionDialog::SelectionDialog(FredView* parent, EditorViewport* viewport) :
 			[this](int state) { _model->setFilterStarts(state == Qt::Checked); });
 
 	// Initialize IFF check boxes
-	for (auto i = 0; i < (int)Iff_info.size(); ++i) {
+	for (size_t i = 0; i < Iff_info.size(); ++i) {
 		auto checkbox = new QCheckBox(QString::fromUtf8(Iff_info[i].iff_name), this);
 		_iffCheckBoxes.push_back(checkbox);
 		ui->iffSelectionContainer->addWidget(checkbox);
@@ -73,7 +73,7 @@ void SelectionDialog::updateUI() {
 	ui->checkPlayerStarts->setChecked(_model->isFilterStarts());
 	ui->checkWaypoints->setChecked(_model->isFilterWaypoints());
 	ui->checkShips->setChecked(_model->isFilterShips());
-	for (auto i = 0; i < (int)Iff_info.size(); ++i) {
+	for (size_t i = 0; i < Iff_info.size(); ++i) {
 		_iffCheckBoxes[i]->setChecked(_model->isFilterIFFTeam(i));
 		_iffCheckBoxes[i]->setEnabled(_model->isFilterShips());
 	}

--- a/qtfred/src/ui/dialogs/SelectionDialog.cpp
+++ b/qtfred/src/ui/dialogs/SelectionDialog.cpp
@@ -38,7 +38,7 @@ SelectionDialog::SelectionDialog(FredView* parent, EditorViewport* viewport) :
 			[this](int state) { _model->setFilterStarts(state == Qt::Checked); });
 
 	// Initialize IFF check boxes
-	for (size_t i = 0; i < Iff_info.size(); ++i) {
+	for (auto i = 0; i < (int)Iff_info.size(); ++i) {
 		auto checkbox = new QCheckBox(QString::fromUtf8(Iff_info[i].iff_name), this);
 		_iffCheckBoxes.push_back(checkbox);
 		ui->iffSelectionContainer->addWidget(checkbox);
@@ -73,7 +73,7 @@ void SelectionDialog::updateUI() {
 	ui->checkPlayerStarts->setChecked(_model->isFilterStarts());
 	ui->checkWaypoints->setChecked(_model->isFilterWaypoints());
 	ui->checkShips->setChecked(_model->isFilterShips());
-	for (size_t i = 0; i < Iff_info.size(); ++i) {
+	for (auto i = 0; i < (int)Iff_info.size(); ++i) {
 		_iffCheckBoxes[i]->setChecked(_model->isFilterIFFTeam(i));
 		_iffCheckBoxes[i]->setEnabled(_model->isFilterShips());
 	}

--- a/qtfred/src/ui/dialogs/ShieldSystemDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShieldSystemDialog.cpp
@@ -3,7 +3,7 @@
 #include "ShieldSystemDialog.h"
 #include "ui/util/SignalBlockers.h"
 #include "ui_ShieldSystemDialog.h"
-
+#include "mission/util.h"
 
 namespace fso {
 namespace fred {
@@ -17,7 +17,7 @@ ShieldSystemDialog::ShieldSystemDialog(FredView* parent, EditorViewport* viewpor
     ui->setupUi(this);
 	
 	connect(this, &QDialog::accepted, _model.get(), &ShieldSystemDialogModel::apply);
-	connect(this, &QDialog::rejected, _model.get(), &ShieldSystemDialogModel::reject);
+	connect(ui->dialogButtonBox, &QDialogButtonBox::rejected, this, &ShieldSystemDialog::rejectHandler);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &ShieldSystemDialog::updateUI);
 
@@ -113,25 +113,15 @@ void ShieldSystemDialog::keyPressEvent(QKeyEvent* event) {
 	QDialog::keyPressEvent(event);
 }
 
-void ShieldSystemDialog::closeEvent(QCloseEvent* event) {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question, "Changes detected", "Do you want to keep your changes?",
-			{ DialogButton::Yes, DialogButton::No, DialogButton::Cancel });
-
-		if (button == DialogButton::Cancel) {
-			event->ignore();
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-	}
-
-	QDialog::closeEvent(event);
+void ShieldSystemDialog::closeEvent(QCloseEvent* e) {
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
 }
-
+void ShieldSystemDialog::rejectHandler()
+{
+	this->close();
+}
 }
 }
 }

--- a/qtfred/src/ui/dialogs/ShieldSystemDialog.h
+++ b/qtfred/src/ui/dialogs/ShieldSystemDialog.h
@@ -24,7 +24,10 @@ public:
 protected:
 	void keyPressEvent(QKeyEvent* event) override;
 	void closeEvent(QCloseEvent*) override;
-private:
+
+	void rejectHandler();
+
+  private:
 	void updateUI();
 	void updateTeam();
 	void updateType();

--- a/qtfred/src/ui/dialogs/ShipEditor/PlayerOrdersDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/PlayerOrdersDialog.h
@@ -4,7 +4,6 @@
 
 #include <mission/dialogs/ShipEditor/PlayerOrdersDialogModel.h>
 #include <ui/widgets/ShipFlagCheckbox.h>
-#include <ui/dialogs/ShipEditor/ShipEditorDialog.h>
 
 namespace fso {
 	namespace fred {
@@ -13,24 +12,22 @@ namespace fso {
 			namespace Ui {
 				class PlayerOrdersDialog;
 			}
-				class ShipEditorDialog;
 			class PlayerOrdersDialog : public QDialog
 			{
 				Q_OBJECT
 
 			public:
-				explicit PlayerOrdersDialog(QDialog* parent, EditorViewport* viewport);
+				explicit PlayerOrdersDialog(QDialog* parent, EditorViewport* viewport, bool editMultiple);
 				~PlayerOrdersDialog() override;
 
 			protected:
 				void closeEvent(QCloseEvent*) override;
-				void showEvent(QShowEvent*) override;
+				void rejectHandler();
 
 			private:
 				std::unique_ptr<Ui::PlayerOrdersDialog> ui;
 				std::unique_ptr<PlayerOrdersDialogModel> _model;
 				EditorViewport* _viewport;
-				ShipEditorDialog* parentDialog;
 
 				void updateUI();
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
@@ -2,6 +2,8 @@
 
 #include "ui_ShipCustomWarpDialog.h"
 
+#include "mission/util.h"
+
 #include <ship/shipfx.h>
 #include <ui/util/SignalBlockers.h>
 
@@ -67,26 +69,9 @@ ShipCustomWarpDialog::ShipCustomWarpDialog(QDialog* parent, EditorViewport* view
 ShipCustomWarpDialog::~ShipCustomWarpDialog() = default;
 void ShipCustomWarpDialog::closeEvent(QCloseEvent* e)
 {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question,
-			"Changes detected",
-			"Do you want to keep your changes?",
-			{DialogButton::Yes, DialogButton::No, DialogButton::Cancel});
-
-		if (button == DialogButton::Cancel) {
-			e->ignore();
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-		if (button == DialogButton::No) {
-			_model->reject();
-		}
-	}
-	QDialog::closeEvent(e);
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
 }
 void ShipCustomWarpDialog::updateUI(const bool firstrun)
 {
@@ -153,29 +138,9 @@ void ShipCustomWarpDialog::updateUI(const bool firstrun)
 }
 void ShipCustomWarpDialog::rejectHandler()
 {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question,
-			"Changes detected",
-			"Do you want to keep your changes?",
-			{DialogButton::Yes, DialogButton::No, DialogButton::Cancel});
-
-		if (button == DialogButton::Cancel) {
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-		if (button == DialogButton::No) {
-			_model->reject();
-			QDialog::reject();
-		}
-	} else {
-		_model->reject();
-		QDialog::reject();
-	}
+	this->close();
 }
+
 void ShipCustomWarpDialog::startSoundChanged()
 {
 	// String wrangling reqired in order to avoid crashes when directly converting from Qstring to std::string on some

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -203,7 +203,7 @@ void ShipEditorDialog::on_tblInfoButton_clicked()
 void ShipEditorDialog::update()
 {
 	if (this->isVisible()) {
-		if (_model->getNumSelectedObjects() && _model->_modified) {
+		if (_model->getNumSelectedObjects() && _model->query_modified()) {
 			_model->apply();
 		}
 		_model->initializeData();

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -174,35 +174,30 @@ void ShipEditorDialog::showEvent(QShowEvent* e) {
 
 void ShipEditorDialog::on_miscButton_clicked()
 {
-	if (!flagsDialog) {
-		flagsDialog = std::unique_ptr<ShipFlagsDialog>(new dialogs::ShipFlagsDialog(this, _viewport));
-	}
-	flagsDialog->show();
+	auto dialog = new dialogs::ShipFlagsDialog(this, _viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void ShipEditorDialog::on_initialStatusButton_clicked()
 {
-	if (!initialStatusDialog) {
-		initialStatusDialog =
-			std::unique_ptr<ShipInitialStatusDialog>(new dialogs::ShipInitialStatusDialog(this, _viewport));
-	}
-	initialStatusDialog->show();
+	auto dialog = new dialogs::ShipInitialStatusDialog(this, _viewport, getIfMultipleShips());
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void ShipEditorDialog::on_initialOrdersButton_clicked()
 {
-	if (!GoalsDialog) {
-		GoalsDialog = std::unique_ptr<ShipGoalsDialog>(new dialogs::ShipGoalsDialog(this, _viewport));
-	}
-	GoalsDialog->show();
+	auto dialog = new dialogs::ShipGoalsDialog(this, _viewport, getIfMultipleShips(), Ships[getSingleShip()].objnum, -1);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void ShipEditorDialog::on_tblInfoButton_clicked()
 {
-	if (!TBLViewer) {
-		TBLViewer = std::unique_ptr<ShipTBLViewer>(new dialogs::ShipTBLViewer(this, _viewport));
-	}
-	TBLViewer->show();
+	auto dialog = new dialogs::ShipTBLViewer(this, _viewport, getShipClass());
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void ShipEditorDialog::update()
@@ -801,11 +796,9 @@ void ShipEditorDialog::DepartureCueChanged(const bool value)
 
 void ShipEditorDialog::on_textureReplacementButton_clicked()
 {
-	if (!TextureReplacementDialog) {
-		TextureReplacementDialog =
-			std::unique_ptr<ShipTextureReplacementDialog>(new dialogs::ShipTextureReplacementDialog(this, _viewport));
-	}
-	TextureReplacementDialog->show();
+	auto dialog = new dialogs::ShipTextureReplacementDialog(this, _viewport, getIfMultipleShips());
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 
 void ShipEditorDialog::on_playerShipButton_clicked()
@@ -838,18 +831,15 @@ void ShipEditorDialog::on_weaponsButton_clicked()
 }
 void ShipEditorDialog::on_playerOrdersButton_clicked()
 	{
-	if (!playerOrdersDialog) {
-		playerOrdersDialog = std::unique_ptr<PlayerOrdersDialog>(new dialogs::PlayerOrdersDialog(this, _viewport));
-	}
-	playerOrdersDialog->show();
+	auto dialog = new dialogs::PlayerOrdersDialog(this, _viewport, getIfMultipleShips());
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 void ShipEditorDialog::on_specialStatsButton_clicked()
 {
-	if (!specialStatsDialog) {
-		specialStatsDialog =
-			std::unique_ptr<ShipSpecialStatsDialog>(new dialogs::ShipSpecialStatsDialog(this, _viewport));
-	}
-	specialStatsDialog->show();
+	auto dialog = new dialogs::ShipSpecialStatsDialog(this, _viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
 }
 void ShipEditorDialog::on_hideCuesButton_clicked()
 {
@@ -873,6 +863,7 @@ void ShipEditorDialog::on_restrictArrivalPathsButton_clicked()
 {
 	int target_class = Ships[_model->getArrivalTarget()].ship_info_index;
 	auto dialog = new dialogs::ShipPathsDialog(this, _viewport, _model->getSingleShip(), target_class, false);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
 	dialog->show();
 
 
@@ -880,17 +871,20 @@ void ShipEditorDialog::on_restrictArrivalPathsButton_clicked()
 void ShipEditorDialog::on_customWarpinButton_clicked()
 {
 	auto dialog = new dialogs::ShipCustomWarpDialog(this, _viewport, false);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
 	dialog->show();
 }
 void ShipEditorDialog::on_restrictDeparturePathsButton_clicked()
 {
 	int target_class = Ships[_model->getDepartureTarget()].ship_info_index;
 	auto dialog = new dialogs::ShipPathsDialog(this, _viewport, _model->getSingleShip(), target_class, true);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
 	dialog->show();
 }
 void ShipEditorDialog::on_customWarpoutButton_clicked()
 {
 	auto dialog = new dialogs::ShipCustomWarpDialog(this, _viewport, true);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
 	dialog->show();
 }
 } // namespace dialogs

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
@@ -15,7 +15,6 @@
 #include "ShipCustomWarpDialog.h"
 
 #include <QAbstractButton>
-#include <QtWidgets/QDialog>
 
 
 namespace fso {
@@ -25,13 +24,6 @@ namespace dialogs {
 namespace Ui {
 class ShipEditorDialog;
 }
-
-class ShipTBLViewer;
-class ShipGoalsDialog;
-class ShipInitialStatusDialog;
-class ShipFlagsDialog;
-class ShipTextureReplacementDialog;
-class PlayerOrdersDialog;
 
 /**
 * @brief QTFred's Ship Editor
@@ -137,14 +129,6 @@ class ShipEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	void departureDelayChanged(const int);
 	void departureWarpChanged(const bool);
 	void DepartureCueChanged(const bool);
-
-	std::unique_ptr<ShipGoalsDialog> GoalsDialog = nullptr;
-	std::unique_ptr<ShipInitialStatusDialog> initialStatusDialog = nullptr;
-	std::unique_ptr<ShipFlagsDialog> flagsDialog = nullptr;
-	std::unique_ptr<ShipTextureReplacementDialog> TextureReplacementDialog = nullptr;
-	std::unique_ptr<PlayerOrdersDialog> playerOrdersDialog = nullptr;
-	std::unique_ptr<ShipSpecialStatsDialog> specialStatsDialog = nullptr;
-	std::unique_ptr<ShipTBLViewer> TBLViewer = nullptr;
 };
 } // namespace dialogs
 } // namespace fred

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipFlagsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipFlagsDialog.cpp
@@ -3,7 +3,7 @@
 #include "ui_ShipFlagsDialog.h"
 
 #include <ui/util/SignalBlockers.h>
-
+#include<mission/util.h>
 #include <QCloseEvent>
 
 namespace fso {
@@ -17,6 +17,7 @@ ShipFlagsDialog::ShipFlagsDialog(QWidget* parent, EditorViewport* viewport)
 	ui->setupUi(this);
 
 	connect(this, &QDialog::accepted, _model.get(), &ShipFlagsDialogModel::apply);
+	connect(ui->cancelButton, &QPushButton::clicked, this, &ShipFlagsDialog::rejectHandler);
 	connect(this, &QDialog::rejected, _model.get(), &ShipFlagsDialogModel::reject);
 
 
@@ -100,35 +101,16 @@ ShipFlagsDialog::ShipFlagsDialog(QWidget* parent, EditorViewport* viewport)
 
 ShipFlagsDialog::~ShipFlagsDialog() = default;
 
-void ShipFlagsDialog::closeEvent(QCloseEvent* event)
+void ShipFlagsDialog::closeEvent(QCloseEvent* e)
 {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question,
-			"Changes detected",
-			"Do you want to keep your changes?",
-			{DialogButton::Yes, DialogButton::No, DialogButton::Cancel});
-
-		if (button == DialogButton::Cancel) {
-			event->ignore();
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-	}
-
-	QDialog::closeEvent(event);
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
 }
-
-void ShipFlagsDialog::showEvent(QShowEvent* event)
+void ShipFlagsDialog::rejectHandler()
 {
-		_model->initializeData();
-
-	QDialog::showEvent(event);
+	this->close();
 }
-
 void ShipFlagsDialog::updateUI()
 {
 	util::SignalBlockers blockers(this);

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipFlagsDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipFlagsDialog.h
@@ -21,7 +21,8 @@ class ShipFlagsDialog : public QDialog {
 
   protected:
 	void closeEvent(QCloseEvent*) override;
-	void showEvent(QShowEvent*) override;
+
+	void rejectHandler();
 
   private:
 	std::unique_ptr<Ui::ShipFlagsDialog> ui;

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.h
@@ -7,25 +7,23 @@
 #include <QtWidgets/QDialog>
 #include <QtWidgets/QSpinBox>
 
-#include "ShipEditorDialog.h"
-
 namespace fso {
 namespace fred {
 namespace dialogs {
 namespace Ui {
 class ShipGoalsDialog;
 }
-class ShipEditorDialog;
 class ShipGoalsDialog : public QDialog {
 	Q_OBJECT
   public:
-	explicit ShipGoalsDialog(QWidget* parent, EditorViewport* viewport);
+	explicit ShipGoalsDialog(QWidget* parent, EditorViewport* viewport, bool editMultiple, int shipID, int wingID);
 	~ShipGoalsDialog() override;
 
 
   protected:
 	void closeEvent(QCloseEvent*) override;
-	void showEvent(QShowEvent* e) override;
+
+	void rejectHandler();
 
   private:
 	std::unique_ptr<Ui::ShipGoalsDialog> ui;
@@ -39,8 +37,6 @@ class ShipGoalsDialog : public QDialog {
 	QSpinBox* priority[ED_MAX_GOALS];
 
 	void updateUI();
-	bool WingMode;
-	ShipEditorDialog* parentDialog = nullptr;
 };
 } // namespace dialogs
 } // namespace fred

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipInitialStatusDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipInitialStatusDialog.h
@@ -2,7 +2,6 @@
 #define SHIPINITIALSTATUSDIALOG_H
 
 #include <mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.h>
-#include "ShipEditorDialog.h"
 #include <QtWidgets/QDialog>
 #include <QtWidgets/QListWidget>
 
@@ -13,24 +12,22 @@ namespace dialogs {
 namespace Ui {
 class ShipInitialStatusDialog;
 }
-class ShipEditorDialog;
 class ShipInitialStatusDialog : public QDialog {
 	Q_OBJECT
 
   public:
-	explicit ShipInitialStatusDialog(QDialog* parent, EditorViewport* viewport);
+	explicit ShipInitialStatusDialog(QDialog* parent, EditorViewport* viewport, bool editMultiple);
 	~ShipInitialStatusDialog() override;
 
   protected:
 	void closeEvent(QCloseEvent*) override;
-	void showEvent(QShowEvent*) override;
+	void rejectHandler();
 
   private:
 	std::unique_ptr<Ui::ShipInitialStatusDialog> ui;
 	std::unique_ptr<ShipInitialStatusDialogModel> _model;
 	EditorViewport* _viewport;
 
-	ShipEditorDialog* parentDialog;
 
 	void updateUI();
 	void updateFlags();

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipPathsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipPathsDialog.cpp
@@ -3,6 +3,7 @@
 #include <ui/util/SignalBlockers.h>
 
 #include <QCloseEvent>
+#include <mission/util.h>
 namespace fso {
 namespace fred {
 namespace dialogs {
@@ -29,53 +30,14 @@ ShipPathsDialog::ShipPathsDialog(QWidget* parent,
 	resize(QDialog::sizeHint());
 }
 ShipPathsDialog::~ShipPathsDialog() = default;
-void ShipPathsDialog::closeEvent(QCloseEvent* event) {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question,
-			"Changes detected",
-			"Do you want to keep your changes?",
-			{DialogButton::Yes, DialogButton::No, DialogButton::Cancel});
-
-		if (button == DialogButton::Cancel) {
-			event->ignore();
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-		if (button == DialogButton::No) {
-			_model->reject();
-		}
-	}
-
-	QDialog::closeEvent(event);
+void ShipPathsDialog::closeEvent(QCloseEvent* e) {
+	if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		e->ignore();
+	};
 }
 void ShipPathsDialog::rejectHandler()
 {
-	if (_model->query_modified()) {
-		auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question,
-			"Changes detected",
-			"Do you want to keep your changes?",
-			{DialogButton::Yes, DialogButton::No, DialogButton::Cancel});
-
-		if (button == DialogButton::Cancel) {
-			return;
-		}
-
-		if (button == DialogButton::Yes) {
-			accept();
-			return;
-		}
-		if (button == DialogButton::No) {
-			_model->reject();
-			QDialog::reject();
-		}
-	} else {
-		_model->reject();
-		QDialog::reject();
-	}
+	this->close();
 }
 void ShipPathsDialog::updateUI() {
 	util::SignalBlockers blockers(this);

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipSpecialStatsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipSpecialStatsDialog.cpp
@@ -3,7 +3,7 @@
 #include "ui_ShipSpecialStatsDialog.h"
 
 #include <ui/util/SignalBlockers.h>
-
+#include <mission/util.h>
 #include <QCloseEvent>
 
 namespace fso {
@@ -17,7 +17,7 @@ namespace fso {
 				ui->setupUi(this);
 
 				connect(this, &QDialog::accepted, _model.get(), &ShipSpecialStatsDialogModel::apply);
-				connect(this, &QDialog::rejected, _model.get(), &ShipSpecialStatsDialogModel::reject);
+				connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ShipSpecialStatsDialog::rejectHandler);
 				connect(_model.get(), &AbstractDialogModel::modelChanged, this, &ShipSpecialStatsDialog::updateUI);
 
 				connect(ui->explodeCheckBox, &QCheckBox::toggled, _model.get(), &ShipSpecialStatsDialogModel::setSpecialExp);
@@ -43,32 +43,16 @@ namespace fso {
 
 			ShipSpecialStatsDialog::~ShipSpecialStatsDialog() = default;
 
-			void ShipSpecialStatsDialog::closeEvent(QCloseEvent* event)
+			void ShipSpecialStatsDialog::closeEvent(QCloseEvent* e)
 			{
-				if (_model->query_modified()) {
-					auto button = _viewport->dialogProvider->showButtonDialog(DialogType::Question,
-						"Changes detected",
-						"Do you want to keep your changes?",
-						{ DialogButton::Yes, DialogButton::No, DialogButton::Cancel });
-
-					if (button == DialogButton::Cancel) {
-						event->ignore();
-						return;
-					}
-
-					if (button == DialogButton::Yes) {
-						accept();
-						return;
-					}
-				}
-
-				QDialog::closeEvent(event);
+				if (!rejectOrCloseHandler(this, _model.get(), _viewport)) {
+					e->ignore();
+				};
 			}
 
-			void ShipSpecialStatsDialog::showEvent(QShowEvent* event) {
-				_model->initializeData();
-
-				QDialog::showEvent(event);
+			void ShipSpecialStatsDialog::rejectHandler()
+			{
+				this->close();
 			}
 
 			void ShipSpecialStatsDialog::updateUI()

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipSpecialStatsDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipSpecialStatsDialog.h
@@ -21,7 +21,8 @@ namespace fso {
 
 			protected:
 				void closeEvent(QCloseEvent*) override;
-				void showEvent(QShowEvent*) override;
+
+				void rejectHandler();
 
 			private:
 				std::unique_ptr<Ui::ShipSpecialStatsDialog> ui;

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipTBLViewer.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipTBLViewer.cpp
@@ -9,12 +9,10 @@
 namespace fso {
 namespace fred {
 namespace dialogs {
-ShipTBLViewer::ShipTBLViewer(QWidget* parent, EditorViewport* viewport)
-	: QDialog(parent), ui(new Ui::ShipTBLViewer()), _viewport(viewport)
+ShipTBLViewer::ShipTBLViewer(QWidget* parent, EditorViewport* viewport, int shipClass)
+	: QDialog(parent), ui(new Ui::ShipTBLViewer()), _model(new ShipTBLViewerModel(this, viewport, shipClass)),
+	  _viewport(viewport)
 {
-	parentDialog = dynamic_cast<ShipEditorDialog*>(parent);
-	Assert(parentDialog);
-	_model = std::unique_ptr<ShipTBLViewerModel>(new ShipTBLViewerModel(this, viewport, parentDialog->getShipClass()));
 
 	ui->setupUi(this);
 
@@ -30,11 +28,6 @@ ShipTBLViewer::~ShipTBLViewer() = default;
 void ShipTBLViewer::closeEvent(QCloseEvent* event)
 {
 	QDialog::closeEvent(event);
-}
-void ShipTBLViewer::showEvent(QShowEvent* e) {
-	_model->initializeData(parentDialog->getShipClass());
-
-	QDialog::showEvent(e);
 }
 void ShipTBLViewer::updateUI()
 {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipTBLViewer.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipTBLViewer.h
@@ -3,7 +3,6 @@
 #include <mission/dialogs/ShipEditor/ShipTBLViewerModel.h>
 #include <QtWidgets/QDialog>
 
-#include "ShipEditorDialog.h"
 
 namespace fso {
 namespace fred {
@@ -12,24 +11,20 @@ namespace dialogs {
 namespace Ui {
 class ShipTBLViewer;
 }
-class ShipEditorDialog;
 class ShipTBLViewer : public QDialog {
 	Q_OBJECT
 
   public:
-	explicit ShipTBLViewer(QWidget* parent, EditorViewport* viewport);
+	explicit ShipTBLViewer(QWidget* parent, EditorViewport* viewport, int shipClass);
 	~ShipTBLViewer() override;
 
   protected:
 	void closeEvent(QCloseEvent*) override;
-	void showEvent(QShowEvent* e) override;
 
   private:
 	std::unique_ptr<Ui::ShipTBLViewer> ui;
 	std::unique_ptr<ShipTBLViewerModel> _model;
 	EditorViewport* _viewport;
-
-	ShipEditorDialog* parentDialog = nullptr;
 
 	int sc;
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipTextureReplacementDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipTextureReplacementDialog.h
@@ -3,7 +3,6 @@
 #include <QtWidgets/QDialog>
 #include <QAbstractListModel>
 #include <QItemSelectionModel>
-#include "ShipEditorDialog.h"
 #include <mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.h>
 
 namespace fso {
@@ -13,7 +12,6 @@ namespace fso {
 			namespace Ui {
 				class ShipTextureReplacementDialog;
 			}
-				class ShipEditorDialog;
 			//Model for mapping data to listview in Texture Replace dialog
 			class MapModel : public QAbstractListModel
 			{
@@ -30,20 +28,19 @@ namespace fso {
 				Q_OBJECT
 
 			public:
-				explicit ShipTextureReplacementDialog(QDialog* parent, EditorViewport* viewport);
+				explicit ShipTextureReplacementDialog(QDialog* parent, EditorViewport* viewport, bool multiEdit);
 				~ShipTextureReplacementDialog() override;
 			protected:
 				void closeEvent(QCloseEvent*) override;
-			  void showEvent(QShowEvent*) override;
 			private:
 				std::unique_ptr<Ui::ShipTextureReplacementDialog> ui;
 				std::unique_ptr<ShipTextureReplacementDialogModel> _model;
 				EditorViewport* _viewport;
-				ShipEditorDialog* parentDialog;
 				int row = 0;
 				MapModel* listmodel;
 				void updateUI();
 				void updateUIFull();
+				void rejectHandler();
 
 				void setMain();
 				void setMisc();

--- a/qtfred/ui/AsteroidEditorDialog.ui
+++ b/qtfred/ui/AsteroidEditorDialog.ui
@@ -378,22 +378,6 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>dialogButtonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::AsteroidEditorDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>337</x>
-     <y>317</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>337</x>
-     <y>169</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
  <buttongroups>
   <buttongroup name="radioActivePassive"/>

--- a/qtfred/ui/CommandBriefingDialog.ui
+++ b/qtfred/ui/CommandBriefingDialog.ui
@@ -352,21 +352,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>okAndCancelButtons</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::CommandBriefingDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/qtfred/ui/CustomWingNamesDialog.ui
+++ b/qtfred/ui/CustomWingNamesDialog.ui
@@ -138,21 +138,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::CustomWingNamesDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>603</x>
-     <y>50</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>324</x>
-     <y>50</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/qtfred/ui/FictionViewerDialog.ui
+++ b/qtfred/ui/FictionViewerDialog.ui
@@ -100,21 +100,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>dialogButtonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::FictionViewerDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>138</x>
-     <y>134</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>114</x>
-     <y>78</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/qtfred/ui/LoadoutDialog.ui
+++ b/qtfred/ui/LoadoutDialog.ui
@@ -957,21 +957,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::LoadoutDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>309</x>
-     <y>625</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>309</x>
-     <y>321</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/qtfred/ui/MissionGoalsDialog.ui
+++ b/qtfred/ui/MissionGoalsDialog.ui
@@ -257,22 +257,6 @@
  <connections>
   <connection>
    <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::MissionGoalsDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>506</x>
-     <y>119</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
    <signal>accepted()</signal>
    <receiver>fso::fred::dialogs::MissionGoalsDialog</receiver>
    <slot>accept()</slot>

--- a/qtfred/ui/MissionSpecDialog.ui
+++ b/qtfred/ui/MissionSpecDialog.ui
@@ -1053,22 +1053,6 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>dialogButtonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::MissionSpecDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>628</x>
-     <y>19</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>357</x>
-     <y>297</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
  <buttongroups>
   <buttongroup name="m_flagGroup">

--- a/qtfred/ui/ObjectOrientationDialog.ui
+++ b/qtfred/ui/ObjectOrientationDialog.ui
@@ -292,21 +292,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::ObjectOrientEditorDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/qtfred/ui/PlayerOrdersDialog.ui
+++ b/qtfred/ui/PlayerOrdersDialog.ui
@@ -54,13 +54,6 @@
    </item>
   </layout>
  </widget>
-  <customwidgets>
-  <customwidget>
-   <class>fso::fred::ShipFlagCheckbox</class>
-   <extends>QCheckBox</extends>
-   <header>ui/widgets/ShipFlagCheckbox.h</header>
-  </customwidget>
- </customwidgets>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>
@@ -74,22 +67,6 @@
     <hint type="sourcelabel">
      <x>147</x>
      <y>76</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>97</x>
-     <y>118</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>fso::fred::dialogs::PlayerOrdersDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>147</x>
-     <y>159</y>
     </hint>
     <hint type="destinationlabel">
      <x>97</x>

--- a/qtfred/ui/ReinforcementsDialog.ui
+++ b/qtfred/ui/ReinforcementsDialog.ui
@@ -458,21 +458,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>okAndCancelButtonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::ReinforcementsDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/qtfred/ui/ShieldSystemDialog.ui
+++ b/qtfred/ui/ShieldSystemDialog.ui
@@ -130,22 +130,6 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>dialogButtonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::ShieldSystemDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>195</x>
-     <y>132</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>154</x>
-     <y>80</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
  <buttongroups>
   <buttongroup name="typeShieldOptionsButtonGroup"/>

--- a/qtfred/ui/ShipFlagsDialog.ui
+++ b/qtfred/ui/ShipFlagsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>421</width>
-    <height>664</height>
+    <height>745</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -706,22 +706,6 @@
     <hint type="destinationlabel">
      <x>251</x>
      <y>509</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>fso::fred::dialogs::ShipFlagsDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>563</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>375</x>
-     <y>515</y>
     </hint>
    </hints>
   </connection>

--- a/qtfred/ui/ShipGoalsDialog.ui
+++ b/qtfred/ui/ShipGoalsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>597</width>
-    <height>344</height>
+    <height>374</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -322,28 +322,12 @@
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>
-  <connections>
+ <connections>
   <connection>
    <sender>okButton</sender>
    <signal>clicked()</signal>
    <receiver>fso::fred::dialogs::ShipGoalsDialog</receiver>
    <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>628</x>
-     <y>19</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>357</x>
-     <y>297</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cancelButton</sender>
-   <signal>clicked()</signal>
-   <receiver>fso::fred::dialogs::ShipGoalsDialog</receiver>
-   <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>628</x>

--- a/qtfred/ui/ShipInitialStatus.ui
+++ b/qtfred/ui/ShipInitialStatus.ui
@@ -421,21 +421,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>cancelPushButton</sender>
-   <signal>clicked()</signal>
-   <receiver>fso::fred::dialogs::ShipInitialStatusDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>389</x>
-     <y>563</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>375</x>
-     <y>515</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/qtfred/ui/ShipSpecialStatsDialog.ui
+++ b/qtfred/ui/ShipSpecialStatsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>518</width>
-    <height>287</height>
+    <width>542</width>
+    <height>322</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -309,22 +309,6 @@
    <signal>accepted()</signal>
    <receiver>fso::fred::dialogs::ShipSpecialStatsDialog</receiver>
    <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::ShipSpecialStatsDialog</receiver>
-   <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/qtfred/ui/ShipTextureReplacementDialog.ui
+++ b/qtfred/ui/ShipTextureReplacementDialog.ui
@@ -253,21 +253,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>fso::fred::dialogs::ShipTextureReplacementDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>296</x>
-     <y>179</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>200</x>
-     <y>100</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>


### PR DESCRIPTION
Implements #6457 and half of #6458. Adds Qt::WA_deleteonclose to all dialogs. and adds a function in misson/utils for a generic close confirmation. Which has been added to most dialogs which did not have there own custom close checks. 

This did require moving the modified variable into the abstractdialogbox class so this pull request can't be broken up. Fortunately most of this pull request is copy and paste across all dialogs so while the number of files modified is huge the actual changes are rather small.