### PR TITLE
Fix antlr4 CMake deprecation warnings

### DIFF
--- a/lib/antlr4-cpp-runtime/CMakeLists.txt
+++ b/lib/antlr4-cpp-runtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 # -*- mode:cmake -*-
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.7)
 # 2.8 needed because of ExternalProject
 
 # Detect build type, fallback to release and throw a warning if use didn't specify any
@@ -25,20 +25,6 @@ option(WITH_STATIC_CRT "(Visual C++) Enable to statically link CRT, which avoids
 
 project(LIBANTLR4)
 
-if(CMAKE_VERSION VERSION_EQUAL "3.0.0" OR
-   CMAKE_VERSION VERSION_GREATER "3.0.0")
-  CMAKE_POLICY(SET CMP0026 NEW)
-  CMAKE_POLICY(SET CMP0054 OLD)
-  CMAKE_POLICY(SET CMP0045 OLD)
-  CMAKE_POLICY(SET CMP0042 OLD)
-endif()
-
-if(CMAKE_VERSION VERSION_EQUAL "3.3.0" OR
-   CMAKE_VERSION VERSION_GREATER "3.3.0")
-  CMAKE_POLICY(SET CMP0059 OLD)
-  CMAKE_POLICY(SET CMP0054 OLD)
-endif()
-
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   #find_package(PkgConfig REQUIRED)
   #pkg_check_modules(UUID REQUIRED uuid)
@@ -57,7 +43,7 @@ if(WITH_DEMO)
     message(FATAL_ERROR "Missing antlr4.jar location. You can specify it's path using: -DANTLR_JAR_LOCATION=<path>")
   else()
     get_filename_component(ANTLR_NAME ${ANTLR_JAR_LOCATION} NAME_WE)
-    if(NOT EXISTS "${ANTLR_JAR_LOCATION}")
+    if(NOT EXISTS ANTLR_JAR_LOCATION)
       message(FATAL_ERROR "Unable to find ${ANTLR_NAME} in ${ANTLR_JAR_LOCATION}")
     else()
       message(STATUS "Found ${ANTLR_NAME}: ${ANTLR_JAR_LOCATION}")
@@ -73,8 +59,9 @@ else()
   set(MY_CXX_WARNING_FLAGS "  -Wall -pedantic -W")
 endif()
 
+
 # Initialize CXXFLAGS.
-if("${CMAKE_VERSION}" VERSION_GREATER 3.1.0)
+if(CMAKE_VERSION VERSION_GREATER 3.1.0)
   set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 else()
@@ -99,20 +86,20 @@ else()
 endif()
 
 # Compiler-specific C++11 activation.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     execute_process(
         COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
     # Just g++-5.0 and greater contain <codecvt> header. (test in ubuntu)
     if(NOT (GCC_VERSION VERSION_GREATER 5.0 OR GCC_VERSION VERSION_EQUAL 5.0))
         message(FATAL_ERROR "${PROJECT_NAME} requires g++ 5.0 or greater.")
     endif ()
-elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND ANDROID) 
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND ANDROID)
 	# Need -Os cflag and cxxflags here to work with exception handling on armeabi.
 	# see  https://github.com/android-ndk/ndk/issues/573
 	# and without -stdlib=libc++ cxxflags
-elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND APPLE)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
-elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND ( CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD") )
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND ( CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "FreeBSD") )
     execute_process(
         COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE CLANG_VERSION)
     if(NOT (CLANG_VERSION VERSION_GREATER 4.2.1 OR CLANG_VERSION VERSION_EQUAL 4.2.1))

--- a/lib/antlr4-cpp-runtime/runtime/CMakeLists.txt
+++ b/lib/antlr4-cpp-runtime/runtime/CMakeLists.txt
@@ -45,7 +45,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   #target_link_libraries(antlr4_static ${UUID_LIBRARIES})
 elseif(APPLE)
 #  target_link_libraries(antlr4_shared ${COREFOUNDATION_LIBRARY})
-  target_link_libraries(antlr4_static ${COREFOUNDATION_LIBRARY})
+  target_link_libraries(antlr4_static PRIVATE ${COREFOUNDATION_LIBRARY})
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
@@ -55,9 +55,9 @@ else()
 endif()
 
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(disabled_compile_warnings "${disabled_compile_warnings} -Wno-dollar-in-identifier-extension -Wno-four-char-constants")
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Intel")
   set(disabled_compile_warnings "${disabled_compile_warnings} -Wno-multichar")
 endif()
 


### PR DESCRIPTION
The deprecation warning that required changes:

* [CMP0054: Only interpret `if()` arguments as variables or keywords when unquoted.](https://cmake.org/cmake/help/latest/policy/CMP0054.html)

The deprecation warnings that did NOT require changes as those features were not used:

* [CMP0026: Disallow use of the `LOCATION` property for build targets.](https://cmake.org/cmake/help/latest/policy/CMP0026.html)
* [CMP0042: `MACOSX_RPATH` is enabled by default.](https://cmake.org/cmake/help/latest/policy/CMP0042.html)
* [CMP0045: Error on non-existent target in `get_target_property`.](https://cmake.org/cmake/help/latest/policy/CMP0045.html)
* [CMP0059: Do not treat `DEFINITIONS` as a built-in directory property.](https://cmake.org/cmake/help/latest/policy/CMP0059.html)

Output of deprecation warnings:

```
CMake Deprecation Warning at lib/antlr4-cpp-runtime/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

CMake Deprecation Warning at lib/antlr4-cpp-runtime/CMakeLists.txt:31 (CMAKE_POLICY):
  The OLD behavior for policy CMP0054 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.

CMake Deprecation Warning at lib/antlr4-cpp-runtime/CMakeLists.txt:32 (CMAKE_POLICY):
  The OLD behavior for policy CMP0045 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.

CMake Deprecation Warning at lib/antlr4-cpp-runtime/CMakeLists.txt:33 (CMAKE_POLICY):
  The OLD behavior for policy CMP0042 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.

CMake Deprecation Warning at lib/antlr4-cpp-runtime/CMakeLists.txt:38 (CMAKE_POLICY):
  The OLD behavior for policy CMP0059 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.

CMake Deprecation Warning at lib/antlr4-cpp-runtime/CMakeLists.txt:39 (CMAKE_POLICY):
  The OLD behavior for policy CMP0054 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```