### PR TITLE
Func to get a ship's persona directly

### DIFF
--- a/code/scripting/api/objs/message.cpp
+++ b/code/scripting/api/objs/message.cpp
@@ -32,6 +32,25 @@ ADE_VIRTVAR(Name, l_Persona, "string", "The name of the persona", "string", "The
 	return ade_set_args(L, "s", Personas[idx].name);
 }
 
+ADE_VIRTVAR(Index, l_Persona, nullptr, nullptr, "number", "The index of the persona")
+{
+	int idx = -1;
+
+	if (!ade_get_args(L, "o", l_Persona.Get(&idx)))
+		return ade_set_args(L, "i", -1);
+
+	if (Personas.empty())
+		return ade_set_args(L, "i", -1);
+
+	if (!SCP_vector_inbounds(Personas, idx))
+		return ade_set_args(L, "i", -1);
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting index is not supported");
+
+	return ade_set_args(L, "i", idx);
+}
+
 ADE_FUNC(isValid, l_Persona, NULL, "Detect if the handle is valid", "boolean", "true if valid, false otherwise")
 {
 	int idx = -1;

--- a/code/scripting/api/objs/message.cpp
+++ b/code/scripting/api/objs/message.cpp
@@ -48,7 +48,7 @@ ADE_VIRTVAR(Index, l_Persona, nullptr, nullptr, "number", "The index of the pers
 	if (ADE_SETTING_VAR)
 		LuaError(L, "Setting index is not supported");
 
-	return ade_set_args(L, "i", idx);
+	return ade_set_args(L, "i", idx + 1);
 }
 
 ADE_FUNC(isValid, l_Persona, NULL, "Detect if the handle is valid", "boolean", "true if valid, false otherwise")

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -832,7 +832,7 @@ ADE_VIRTVAR(Team, l_Ship, "team", "Ship's team", "team", "Ship team, or invalid 
 	return ade_set_args(L, "o", l_Team.Set(shipp->team));
 }
 
-ADE_VIRTVAR(PersonaIndex, l_Ship, "number", "Persona index", "number", "The index of the persona from messages.tbl, 0 if no persona is set")
+ADE_VIRTVAR_DEPRECATED(PersonaIndex, l_Ship, "number", "Persona index", "number", "The index of the persona from messages.tbl, 0 if no persona is set", gameversion::version(25, 0), "Deprecated in favor of Persona")
 {
 	object_h *objh;
 	int p_index = -1;
@@ -850,16 +850,21 @@ ADE_VIRTVAR(PersonaIndex, l_Ship, "number", "Persona index", "number", "The inde
 	return ade_set_args(L, "i", shipp->persona_index + 1);
 }
 
-ADE_FUNC(getPersona, l_Ship, nullptr, "Gets the persona of the ship, if any", "persona", "Persona handle or invalid handle on error")
+ADE_VIRTVAR(Persona, l_Ship, "persona", "The persona of the ship, if any", "persona", "Persona handle or invalid handle on error")
 {
 	object_h* objh;
-	if (!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
+	int idx = -1;
+	if (!ade_get_args(L, "o|o", l_Ship.GetPtr(&objh), l_Persona.Get(&idx)))
 		return ade_set_error(L, "o", l_Persona.Set(-1));
 
 	if (!objh->isValid())
 		return ade_set_error(L, "o", l_Persona.Set(-1));
 
 	ship* shipp = &Ships[objh->objp()->instance];
+
+	if (ADE_SETTING_VAR && idx > -1) {
+		shipp->persona_index = idx;
+	}
 
 	if (!SCP_vector_inbounds(Personas, shipp->persona_index))
 		return ade_set_args(L, "o", l_Persona.Set(-1));

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -32,6 +32,7 @@
 #include "object/objectdock.h"
 #include "parse/parselo.h"
 #include "playerman/player.h"
+#include "scripting/api/objs/message.h"
 #include "ship/ship.h"
 #include "ship/shipfx.h"
 #include "ship/shiphit.h"
@@ -847,6 +848,23 @@ ADE_VIRTVAR(PersonaIndex, l_Ship, "number", "Persona index", "number", "The inde
 		shipp->persona_index = p_index - 1;
 
 	return ade_set_args(L, "i", shipp->persona_index + 1);
+}
+
+ADE_FUNC(getPersona, l_Ship, nullptr, "Gets the persona of the ship, if any", "persona", "Persona handle or invalid handle on error")
+{
+	object_h* objh;
+	if (!ade_get_args(L, "o", l_Ship.GetPtr(&objh)))
+		return ade_set_error(L, "o", l_Persona.Set(-1));
+
+	if (!objh->isValid())
+		return ade_set_error(L, "o", l_Persona.Set(-1));
+
+	ship* shipp = &Ships[objh->objp()->instance];
+
+	if (!SCP_vector_inbounds(Personas, shipp->persona_index))
+		return ade_set_args(L, "o", l_Persona.Set(-1));
+	else
+		return ade_set_args(L, "o", l_Persona.Set(shipp->persona_index));
 }
 
 ADE_VIRTVAR(Textures, l_Ship, "modelinstancetextures", "Gets ship textures", "modelinstancetextures", "Ship textures, or invalid shiptextures handle if ship handle is invalid")


### PR DESCRIPTION
Adds a lua func to get a ship's persona as a persona handle. Pretty straightfoward.

There is already a virtvar to get a ship's persona index which can used to iterate through the mission's personas but this is faster and simpler. I thought about deprecating the virtvar but if anyone is using it to set a ship's persona then I'd have to add a setShipPersona() func and we're back to having two functions again.

I also considered having the virtvar optionally return the persona directly but it's specifically called PersonaIndex which I felt confused the matter a bit.

Open to opinions if there's a better way to organize this.