### PR TITLE
Lua set mainhall

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -72,6 +72,8 @@ bool Main_hall_poll_key = true;
 
 SCP_string Main_hall_cheat = "";
 
+SCP_string Enforced_main_hall = "";
+
 // ----------------------------------------------------------------------------
 // MISC interface data
 //
@@ -472,6 +474,11 @@ void main_hall_init(const SCP_string &main_hall_name)
 		return;
 	}
 
+	SCP_string requested_hall = main_hall_name;
+	if (!Enforced_main_hall.empty()) {
+		requested_hall = Enforced_main_hall;
+	}
+
 	extern bool Campaign_room_no_campaigns;
 
 	// Log if we don't have a campaign set yet.
@@ -492,14 +499,14 @@ void main_hall_init(const SCP_string &main_hall_name)
 	// sanity checks
 	if (Main_hall_defines.empty()) {
 		Error(LOCATION, "No main halls were loaded to initialize.");
-	} else if (main_hall_name == "") {
+	} else if (requested_hall == "") {
 		// we were passed a blank main hall name, so load the first available main hall
 		main_hall_get_name(main_hall_to_load, 0);
-	} else if (main_hall_get_pointer(main_hall_name) == nullptr) {
-		Warning(LOCATION, "Tried to load a main hall called '%s', but it does not exist; loading first available main hall.", main_hall_name.c_str());
+	} else if (main_hall_get_pointer(requested_hall) == nullptr) {
+		Warning(LOCATION, "Tried to load a main hall called '%s', but it does not exist; loading first available main hall.", requested_hall.c_str());
 		main_hall_get_name(main_hall_to_load, 0);
 	} else {
-		main_hall_to_load = main_hall_name;
+		main_hall_to_load = requested_hall;
 	}
 
 	// if we're switching to a different mainhall, stop the ambient (it will be started again promptly)

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -72,7 +72,7 @@ bool Main_hall_poll_key = true;
 
 SCP_string Main_hall_cheat = "";
 
-SCP_string Enforced_main_hall = "";
+SCP_string Enforced_main_hall;
 
 // ----------------------------------------------------------------------------
 // MISC interface data
@@ -499,7 +499,7 @@ void main_hall_init(const SCP_string &main_hall_name)
 	// sanity checks
 	if (Main_hall_defines.empty()) {
 		Error(LOCATION, "No main halls were loaded to initialize.");
-	} else if (requested_hall == "") {
+	} else if (requested_hall.empty()) {
 		// we were passed a blank main hall name, so load the first available main hall
 		main_hall_get_name(main_hall_to_load, 0);
 	} else if (main_hall_get_pointer(requested_hall) == nullptr) {

--- a/code/menuui/mainhallmenu.h
+++ b/code/menuui/mainhallmenu.h
@@ -170,6 +170,7 @@ extern SCP_vector< SCP_vector<main_hall_defines> > Main_hall_defines;
 
 extern bool Main_hall_poll_key;
 
+extern SCP_string Enforced_main_hall;
 
 // initialize the main hall proper 
 void main_hall_init(const SCP_string &main_hall_name);

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -487,7 +487,7 @@ ADE_FUNC(toggleHelp,
 	return ADE_RETURN_NIL;
 }
 
-ADE_FUNC(setMainhall, l_UserInterface_MainHall, "string mainhall, bool enforce", "The name of the mainhall to try to set. Will immediately change if the player is currently in the mainhall menu. "
+ADE_FUNC(setMainhall, l_UserInterface_MainHall, "string mainhall, boolean enforce", "The name of the mainhall to try to set. Will immediately change if the player is currently in the mainhall menu. "
 	"Use enforce to set this as the mainhall on next mainhall load if setting from outside the mainhall menu. NOTE: If enforce is true then the player will always return back to this mainhall forever. "
 	"Call this with a blank string and enforce false to unset enforce without changing the current mainhall that is loaded.", nullptr, "nothing")
 {

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -487,6 +487,32 @@ ADE_FUNC(toggleHelp,
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(setMainhall, l_UserInterface_MainHall, "string mainhall, bool enforce", "The name of the mainhall to try to set. Will immediately change if the player is currently in the mainhall menu. "
+	"Use enforce to set this as the mainhall on next mainhall load if setting from outside the mainhall menu. NOTE: If enforce is true then the player will always return back to this mainhall forever. "
+	"Call this with a blank string and enforce false to unset enforce without changing the current mainhall that is loaded.", nullptr, "nothing")
+{
+	const char* name = nullptr;
+	bool enforce = false;
+	if (!ade_get_args(L, "s|b", &name, &enforce)) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (enforce) {
+		Enforced_main_hall = name;
+	} else {
+		Enforced_main_hall.clear();
+	}
+
+	if (gameseq_get_state() == GS_STATE_MAIN_MENU) {
+		if (name[0] != '\0') {
+			main_hall_close();
+			main_hall_init(name);
+		}
+	}
+
+	return ADE_RETURN_NIL;
+}
+
 //**********SUBLIBRARY: UserInterface/Barracks
 ADE_LIB_DERIV(l_UserInterface_Barracks, "Barracks", nullptr,
               "API for accessing values specific to the Barracks UI.",


### PR DESCRIPTION
Provides a method for lua to set the current mainhall. If used in the mainhall menu then the menu will change immediately. If used outside the mainhall menu then enforce must be set to true to make sure the request is honored. As a bonus you can enforce a mainhall indefinitely if desired.