### PR TITLE
Fix `Mouse` XSTR Index in In-game options

### DIFF
--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -70,7 +70,7 @@ static auto MouseSensitivityOption __UNUSED = options::OptionBuilder<int>("Input
 
 bool Use_mouse_to_fly = false;
 
-static SCP_string mouse_mode_display(bool mode) { return mode ? XSTR("Joy-0", 1699) : XSTR("Mouse", 1774); }
+static SCP_string mouse_mode_display(bool mode) { return mode ? XSTR("Joy-0", 1699) : XSTR("Mouse", 1373); }
 
 static auto UseMouseOption __UNUSED = options::OptionBuilder<bool>("Input.UseMouse",
                      std::pair<const char*, int>{"Mouse", 1373},


### PR DESCRIPTION
In the In-game options for `mouse_mode` the XSTR index for "Mouse" was set to 1774, which is already used for "Glide When Pressed". Luckily "Mouse" XSTR already exists with Index 1373, so this PR changes it to that.