### PR TITLE
Fix offset dialog option image with controls preset confirmation

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1335,11 +1335,11 @@ bool control_config_accept(bool API_Access)
 				cfclose(fp);
 				int n = popup(flags,
 					2,
-					POPUP_OK,
 					POPUP_CANCEL,
+					POPUP_OK,
 					"'%s'\n Already exists!\n Press OK to overwrite existing preset, or CANCEL to input another name",
 					str.c_str());
-				if ((n == 1) || (n == -1)) {
+				if ((n == 0) || (n == -1)) {
 					// If Cancel button was pressed, or popup dismissed:
 					// retry
 					gamesnd_play_iface(InterfaceSounds::USER_SELECT);


### PR DESCRIPTION
The Popup Dialog for `Confirm Control Preset Overwrite` has the Yes and No buttons order switched compared to what they are usually set as. This means the images appear offset and do not look sharp against the background of the dialog box image. This PR switches the order to match and remove that visual bug. Albeit a very minor bug, but one I have heard from a few folks and noticed myself as well.

PR is tested and works as expected.