### PR TITLE
gracefully fail if volumetrics model is not found

### DIFF
--- a/code/nebula/volumetrics.cpp
+++ b/code/nebula/volumetrics.cpp
@@ -280,7 +280,11 @@ void volumetric_nebula::renderVolumeBitmap() {
 	int nSample = (n << (oversampling - 1)) + 1;
 	auto volumeSampleCache = make_unique<bool[]>(nSample * nSample * nSample);
 
-	int modelnum = model_load(hullPof.c_str(), 0, nullptr);
+	int modelnum = model_load(hullPof.c_str(), 0, nullptr, -1);
+	if (modelnum < 0) {
+		Warning(LOCATION, "Could not load model '%s'.  Unable to render volume bitmap!", hullPof.c_str());
+		return;
+	}
 
 	const polymodel* pm = model_get(modelnum);
 	//Scale up by 2% to ensure that the 3d volume texture does not end on an axis aligned edge with full opacity.


### PR DESCRIPTION
If the volumetrics model cannot be loaded, fail gracefully by warning and not generating volumetrics.  This prevents a hard exit in the event of a model problem, particularly when a mission is being edited in FRED.