### PR TITLE
Some minor Control Config UI changes for SCPUI

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1758,7 +1758,7 @@ bool control_config_delete_preset(CC_preset preset) {
 	return delete_preset_file(preset);
 }
 
-bool control_config_create_new_preset(SCP_string newName)
+bool control_config_create_new_preset(SCP_string newName, bool overwrite)
 {
 
 	// Check if a hardcoded preset with name already exists. If so, complain to user and force retry
@@ -1771,7 +1771,7 @@ bool control_config_create_new_preset(SCP_string newName)
 	}
 
 	// Check if a preset file with name already exists.
-	if ((cf_exists_full((newName + ".json").c_str(), CF_TYPE_PLAYER_BINDS)) != 0) {
+	if (!overwrite && ((cf_exists_full((newName + ".json").c_str(), CF_TYPE_PLAYER_BINDS)) != 0)) {
 		return false;
 	}
 
@@ -1806,7 +1806,7 @@ bool control_config_create_new_preset(SCP_string newName)
 	return false; //should be unreachable, but just in case
 }
 
-bool control_config_clone_preset(CC_preset preset, SCP_string newName) {
+bool control_config_clone_preset(CC_preset preset, SCP_string newName, bool overwrite) {
 
 	// Check if a hardcoded preset with name already exists. If so, complain to user and force retry
 	auto it = std::find_if(Control_config_presets.begin(), Control_config_presets.end(), [newName](CC_preset& p) {
@@ -1818,7 +1818,7 @@ bool control_config_clone_preset(CC_preset preset, SCP_string newName) {
 	}
 
 	// Check if a preset file with name already exists.
-	if ((cf_exists_full((newName + ".json").c_str(), CF_TYPE_PLAYER_BINDS)) != 0) {
+	if (!overwrite && ((cf_exists_full((newName + ".json").c_str(), CF_TYPE_PLAYER_BINDS)) != 0)) {
 		return false;
 	}
 

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1758,7 +1758,7 @@ bool control_config_delete_preset(CC_preset preset) {
 	return delete_preset_file(preset);
 }
 
-bool control_config_create_new_preset(SCP_string newName, bool overwrite)
+bool control_config_create_new_preset(const SCP_string& newName, bool overwrite)
 {
 
 	// Check if a hardcoded preset with name already exists. If so, complain to user and force retry
@@ -1806,7 +1806,7 @@ bool control_config_create_new_preset(SCP_string newName, bool overwrite)
 	return false; //should be unreachable, but just in case
 }
 
-bool control_config_clone_preset(CC_preset preset, SCP_string newName, bool overwrite) {
+bool control_config_clone_preset(const CC_preset& preset, const SCP_string& newName, bool overwrite) {
 
 	// Check if a hardcoded preset with name already exists. If so, complain to user and force retry
 	auto it = std::find_if(Control_config_presets.begin(), Control_config_presets.end(), [newName](CC_preset& p) {

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -845,7 +845,7 @@ bool control_config_delete_preset(CC_preset preset);
  * @returns TRUE if successful
  * @returns FALSE if the preset already exists with that name
  */
-bool control_config_clone_preset(CC_preset preset, SCP_string name);
+bool control_config_clone_preset(CC_preset preset, SCP_string name, bool overwrite);
 
 /*!
  * @brief Saves a preset with the current controls
@@ -853,7 +853,7 @@ bool control_config_clone_preset(CC_preset preset, SCP_string name);
  * @returns TRUE if successful
  * @returns FALSE if the preset already exists with that name
  */
-bool control_config_create_new_preset(SCP_string name);
+bool control_config_create_new_preset(SCP_string name, bool overwrite);
 
 /*!
  * Returns the IoActionId (index within Control_config[]) of a control bound to the given key

--- a/code/controlconfig/controlsconfig.h
+++ b/code/controlconfig/controlsconfig.h
@@ -845,7 +845,7 @@ bool control_config_delete_preset(CC_preset preset);
  * @returns TRUE if successful
  * @returns FALSE if the preset already exists with that name
  */
-bool control_config_clone_preset(CC_preset preset, SCP_string name, bool overwrite);
+bool control_config_clone_preset(const CC_preset& preset, const SCP_string& name, bool overwrite);
 
 /*!
  * @brief Saves a preset with the current controls
@@ -853,7 +853,7 @@ bool control_config_clone_preset(CC_preset preset, SCP_string name, bool overwri
  * @returns TRUE if successful
  * @returns FALSE if the preset already exists with that name
  */
-bool control_config_create_new_preset(SCP_string name, bool overwrite);
+bool control_config_create_new_preset(const SCP_string& name, bool overwrite);
 
 /*!
  * Returns the IoActionId (index within Control_config[]) of a control bound to the given key

--- a/code/controlconfig/presets.cpp
+++ b/code/controlconfig/presets.cpp
@@ -1,7 +1,9 @@
 #include "controlconfig/controlsconfig.h"
 #include "controlconfig/presets.h"
+#include "gamesequence/gamesequence.h"
 #include "libs/jansson.h"
 #include "parse/parselo.h"
+#include "popup/popup.h"
 
 #include <jansson.h>
 
@@ -133,8 +135,12 @@ void load_preset_files(SCP_string clone) {
 			Control_config_presets.push_back(preset);
 
 		} else if ((it->name != preset.name) || (it->type != Preset_t::pst)) {
-			// Complain and ignore if the preset names or the type differs
-			Warning(LOCATION, "PST => Preset '%s' is a duplicate of an existing preset, ignoring", preset.name.c_str());
+			if (gameseq_get_state() == GS_STATE_CONTROL_CONFIG) {
+				popup(PF_TITLE_WHITE, 1, POPUP_OK, "Preset '%s' is a duplicate of an existing preset, ignoring", preset.name.c_str());
+			} else {
+				// Complain and ignore if the preset names or the type differs
+				Warning(LOCATION, "PST => Preset '%s' is a duplicate of an existing preset, ignoring", preset.name.c_str());
+			}
 		
 		} // else, silent ignore
 	}

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2229,17 +2229,18 @@ ADE_FUNC(usePreset,
 
 ADE_FUNC(createPreset,
 	l_UserInterface_ControlConfig,
-	"string Name",
+	"string Name, [boolean overwrite]",
 	"Creates a new preset with the given name. Returns true if successful, false otherwise.",
 	"boolean",
 	"The return status")
 {
 	const char* preset;
-	ade_get_args(L, "s", &preset);
+	bool overwrite = false;
+	ade_get_args(L, "s|b", &preset, &overwrite);
 
 	SCP_string name = preset;
 
-	return ade_set_args(L, "b", std::move(control_config_create_new_preset(name)));
+	return ade_set_args(L, "b", std::move(control_config_create_new_preset(name, overwrite)));
 }
 
 ADE_FUNC(undoLastChange,

--- a/code/scripting/api/objs/control_config.cpp
+++ b/code/scripting/api/objs/control_config.cpp
@@ -52,18 +52,19 @@ ADE_VIRTVAR(Name, l_Preset, nullptr, "The name of the preset", "string", "The na
 
 ADE_FUNC(clonePreset,
 	l_Preset,
-	"string Name",
+	"string Name, [boolean overwrite]",
 	"Clones the preset into a new preset with the specified name. Sets it as the active preset",
 	"boolean",
 	"Returns true if successful, false otherwise")
 {
 	preset_h current;
 	const char* newName;
-	if (!ade_get_args(L, "os", l_Preset.Get(&current), &newName)) {
+	bool overwrite = false;
+	if (!ade_get_args(L, "os|b", l_Preset.Get(&current), &newName, &overwrite)) {
 		return ADE_RETURN_FALSE;
 	}
 
-	return ade_set_args(L, "b", control_config_clone_preset(*current.getPreset(), newName));
+	return ade_set_args(L, "b", control_config_clone_preset(*current.getPreset(), newName, overwrite));
 }
 
 ADE_FUNC(deletePreset,


### PR DESCRIPTION
First, add a boolean to allow SCPUI to overwrite presets.

Second change the warning about duplicate presets to an in-ui popup if we're actually in the control config game state. The popup is also triggered during the FSO splash screen, so that's why it checks the game state first.