### PR TITLE
Allow Modders to Tune Strafing

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -169,6 +169,7 @@ namespace AI {
 		Debris_respects_big_damage,
 		Dont_limit_change_in_speed_due_to_physics_whack,
 		Guards_ignore_protected_attackers,
+		Standard_strafe_used_more,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -655,6 +655,20 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix avoid-shockwave bugs:", AI::Profile_Flags::Fix_avoid_shockwave_bugs);
 
+				set_flag(profile, "$standard strafe used more:", AI::Profile_Flags::Standard_strafe_used_more);
+
+				if (optional_string("$standard strafe triggers under this speed:")) {
+					stuff_float(&profile->standard_strafe_when_below_speed);
+				}
+
+				if (optional_string("$strafe distance from target bounding box:")) {
+					stuff_float(&profile->strafe_retreat_box_dist);
+				}
+
+				if (optional_string("$strafe stops after time unhit:")) {
+					stuff_float(&profile->strafe_max_unhit_time);
+				}
+
 				// end of options ----------------------------------------
 
 				// if we've been through once already and are at the same place, force a move
@@ -746,6 +760,10 @@ void ai_profile_t::reset()
 	ai_range_aware_secondary_select_mode = AI_RANGE_AWARE_SEC_SEL_MODE_RETAIL;
 	turret_target_recheck_time = 2000.0f;
 	rot_fac_multiplier_ply_collisions = 0.0f;
+
+	standard_strafe_when_below_speed = 3.0f;
+	strafe_retreat_box_dist = 300.0f;
+	strafe_max_unhit_time = 20.0f;
 
     for (int i = 0; i < NUM_SKILL_LEVELS; ++i) {
         max_incoming_asteroids[i] = 0;

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -126,6 +126,11 @@ public:
 	// Multiplier value so the player can also experience rotational effects from collisions --wookieejedi
 	float rot_fac_multiplier_ply_collisions; 
 
+	// Strafing options  --wookieejedi
+	float standard_strafe_when_below_speed; // Speed at which standard strafing large ships is possibly triggered
+	float strafe_retreat_box_dist;          // Distance beyond the bounding box to retreat to strafing point 
+	float strafe_max_unhit_time;            // Maximum amount of time to stay in strafe mode if not hit
+
     void reset();
 };
 

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1567,8 +1567,7 @@ void ai_big_strafe_attack()
 	accelerate_ship(aip, accel);
 
 	// if haven't been hit in quite a while, leave strafe mode
-	fix long_enough;
-	long_enough = F1_0 * The_mission.ai_profile->strafe_max_unhit_time;
+	fix long_enough = F1_0 * fl2f(The_mission.ai_profile->strafe_max_unhit_time);
 	if ( (last_hit > long_enough) && ( (Missiontime - aip->submode_parm0) > long_enough) ) {
 		ai_big_switch_to_chase_mode(aip);
 	}
@@ -1690,7 +1689,7 @@ void ai_big_strafe_glide_attack()
 
 	// if haven't been hit in quite a while, leave strafe mode
 	// (same as ai_big_strafe_attack)
-	fix long_enough = F1_0 * The_mission.ai_profile->strafe_max_unhit_time;
+	fix long_enough = F1_0 * fl2f(The_mission.ai_profile->strafe_max_unhit_time);
 	if ( (Missiontime - aip->last_hit_time > long_enough) && ( (Missiontime - aip->submode_parm0) > long_enough) ) {
 		ai_big_switch_to_chase_mode(aip);
 	}

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -39,10 +39,9 @@
 #define MIN_DOT_TO_ATTACK_MOVING_SUBSYS	0.97f
 
 // AI BIG MAGIC NUMBERS
+// Select strafing options are now exposed to modders  --wookieejedi
 #define	STRAFE_RETREAT_COLLIDE_TIME	2.0		// when anticipated collision time is less than this, begin retreat
 #define	STRAFE_RETREAT_COLLIDE_DIST	100		// when perpendicular distance to *surface* is less than this, begin retreat
-#define	STRAFE_RETREAT_BOX_DIST			300		// distance beyond the bounding box to retreat
-#define STRAFE_MAX_UNHIT_TIME		20		// Maximum amount of time to stay in strafe mode if not hit
 
 #define	EVADE_BOX_BASE_DISTANCE			300		// standard distance to end evade submode
 #define	EVADE_BOX_MIN_DISTANCE			200		// minimun distance to end evade submode, after long time
@@ -691,7 +690,7 @@ void ai_big_chase_attack(ai_info *aip, ship_info *sip, vec3d *enemy_pos, float d
 		aip->prev_goal_point = En_objp->pos;
 	} else {
 		//	If moving slowly, maybe evade incoming fire.
-		if (Pl_objp->phys_info.speed < 3.0f) {
+		if (Pl_objp->phys_info.speed < The_mission.ai_profile->standard_strafe_when_below_speed) {
 			object *objp;
 			for ( objp = GET_FIRST(&obj_used_list); objp !=END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp) ) {
 				if (objp->flags[Object::Object_Flags::Should_be_dead])
@@ -722,7 +721,7 @@ void ai_big_chase_attack(ai_info *aip, ship_info *sip, vec3d *enemy_pos, float d
 			
 			// Since ship is moving slowly and attacking a large ship, scan if enemy fighters are near, if so
 			// then enter strafe mode
-			if ( ai_big_maybe_start_strafe(aip, sip) ) {
+			if ( The_mission.ai_profile->flags[AI::Profile_Flags::Standard_strafe_used_more] || ai_big_maybe_start_strafe(aip, sip) ) {
 				aip->previous_mode = aip->mode;
 				aip->mode = AIM_STRAFE;
 				aip->submode_parm0 = Missiontime;	// use parm0 as time strafe mode entered (i.e. MODE start time)
@@ -730,7 +729,7 @@ void ai_big_chase_attack(ai_info *aip, ship_info *sip, vec3d *enemy_pos, float d
 				return;
 			}
 
-		} // end if ( Pl_objp->phys_info.speed < 3.0f ) 
+		} // end if ( Pl_objp->phys_info.speed < The_mission.ai_profile->standard_strafe_when_below_speed ) 
 
 		//Maybe enter glide strafe (check every 8 seconds, on a different schedule for each ship)
 		if ((sip->can_glide == true) && !(aip->ai_flags[AI::AI_Flags::Kamikaze]) && static_randf((Missiontime + static_rand(aip->shipnum)) >> 19) < aip->ai_glide_strafe_percent) {
@@ -1439,7 +1438,7 @@ static int ai_big_strafe_maybe_retreat(const vec3d *target_pos)
 
 	//if ((dot_to_enemy > 1.0f - 0.1f * En_objp->radius/(dist_to_enemy + 1.0f)) && (Pl_objp->phys_info.speed > dist_to_enemy/5.0f))
 
-	// Inside 2 sec retreat, setting goal point to box point + 300m
+	// Inside 2 sec retreat, setting goal point to box point + strafe_retreat_box_dist
 	// If collision, use std collision resolution.
 	if ( !(aip->ai_flags[AI::AI_Flags::Kamikaze]) && ((aip->ai_flags[AI::AI_Flags::Target_collision]) || (time_to_target < STRAFE_RETREAT_COLLIDE_TIME) || (dist_normal_to_target < STRAFE_RETREAT_COLLIDE_DIST + speed_to_dist_penalty)) ) {
 		if (aip->ai_flags[AI::AI_Flags::Target_collision]) {
@@ -1447,13 +1446,13 @@ static int ai_big_strafe_maybe_retreat(const vec3d *target_pos)
 			aip->ai_flags.remove(AI::AI_Flags::Target_collision);
 			big_ship_collide_recover_start(Pl_objp, En_objp, nullptr);
 		} else {
-			// too close for comfort so fly to box point + 300
+			// too close for comfort so fly to box point + strafe_retreat_box_dist
 			aip->submode = AIS_STRAFE_RETREAT1;
 			aip->submode_start_time = Missiontime;
 
 			int is_inside;
 			vec3d goal_point;
-			get_world_closest_box_point_with_delta(&goal_point, En_objp, &Pl_objp->pos, &is_inside, STRAFE_RETREAT_BOX_DIST);
+			get_world_closest_box_point_with_delta(&goal_point, En_objp, &Pl_objp->pos, &is_inside, The_mission.ai_profile->strafe_retreat_box_dist);
 
 			// set goal point
 			aip->goal_point = goal_point;
@@ -1569,7 +1568,7 @@ void ai_big_strafe_attack()
 
 	// if haven't been hit in quite a while, leave strafe mode
 	fix long_enough;
-	long_enough = F1_0 * STRAFE_MAX_UNHIT_TIME;
+	long_enough = F1_0 * The_mission.ai_profile->strafe_max_unhit_time;
 	if ( (last_hit > long_enough) && ( (Missiontime - aip->submode_parm0) > long_enough) ) {
 		ai_big_switch_to_chase_mode(aip);
 	}
@@ -1641,7 +1640,7 @@ void ai_big_strafe_glide_attack()
 		//Keep going until we are too far away.
 		//If we are still on approach but too far away, this will still trigger. This will allow us to reposition the target
 		//point and allow for a "jinking" effect.
-		if (target_ship_dist > (STRAFE_RETREAT_BOX_DIST + target_objp->radius) &&
+		if (target_ship_dist > (The_mission.ai_profile->strafe_retreat_box_dist + target_objp->radius) &&
 			Missiontime - aip->submode_start_time > i2f(GLIDE_STRAFE_MIN_TIME)) {
 			//This checks whether we are moving toward the target or away from it.  If moving towards, we reset the stage so that we
 			//pick a new attack vector (jinking). If moving away, we're at the end of a run so do a full reset (possibly allowing a 
@@ -1691,7 +1690,7 @@ void ai_big_strafe_glide_attack()
 
 	// if haven't been hit in quite a while, leave strafe mode
 	// (same as ai_big_strafe_attack)
-	fix long_enough = F1_0 * STRAFE_MAX_UNHIT_TIME;
+	fix long_enough = F1_0 * The_mission.ai_profile->strafe_max_unhit_time;
 	if ( (Missiontime - aip->last_hit_time > long_enough) && ( (Missiontime - aip->submode_parm0) > long_enough) ) {
 		ai_big_switch_to_chase_mode(aip);
 	}


### PR DESCRIPTION
Many mods change ship velocities and damp values, but this commonly leads to poor behaviors attacking large ships within strafe mode (which is the main method for attacking big ships in a sustained way). As an example, FotG has damp and velocity values that are higher than base FS, thus the defined strafe values result in behavior where fighters never can complete a sustained firing pass against a large ship unless they are sitting and parking (which does not fit our goals to match the movie).

The values for dictating how strafe behavior occurs are easily editable by changing some key values, which this PR exposes to modders. Furthermore, mods may give large ships very long range weapons, so being able to set how far away a ship should do a strafe run begins is very valuable.

In testing it was very easy to get desired behavior of having AI do long sustained strafing runs. I estimate other mods will likely be able to leverage these values to tune strafing behavior.

I did numerous tests and evaluations finding the best balance of values to expose. I would be happy to discuss these changes in detail too, as I know this exposes a number of values.