### PR TITLE
Add Mod Option to Limit 'Show Ship' when Toggling Cockpits

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -123,6 +123,7 @@ std::tuple<float, float, float, float> Shadow_distances;
 std::tuple<float, float, float, float> Shadow_distances_cockpit;
 bool Show_ship_casts_shadow;
 bool Cockpit_shares_coordinate_space;
+bool Show_ship_only_if_cockpits_enabled;
 bool Custom_briefing_icons_always_override_standard_icons;
 float Min_pixel_size_thruster;
 float Min_pixel_size_beam;
@@ -872,6 +873,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Cockpit_shares_coordinate_space);
 			}
 
+			if (optional_string("$Show Ship enabled only if Cockpits enabled:")) {
+				stuff_boolean(&Show_ship_only_if_cockpits_enabled);
+			}
+
 			if (optional_string("$Minimum Pixel Size Thrusters:")) {
 				stuff_float(&Min_pixel_size_thruster);
 			}
@@ -1604,6 +1609,7 @@ void mod_table_reset()
 	Shadow_distances_cockpit = std::make_tuple(0.25f, 0.75f, 1.5f, 3.0f); // Default values tuned by wookieejedi and added here by Lafiel
 	Show_ship_casts_shadow = false;
 	Cockpit_shares_coordinate_space = false;
+	Show_ship_only_if_cockpits_enabled = false;
 	Custom_briefing_icons_always_override_standard_icons = false;
 	Min_pixel_size_thruster = 0.0f;
 	Min_pixel_size_beam = 0.0f;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -130,6 +130,7 @@ extern std::tuple<float, float, float, float> Shadow_distances;
 extern std::tuple<float, float, float, float> Shadow_distances_cockpit;
 extern bool Show_ship_casts_shadow;
 extern bool Cockpit_shares_coordinate_space;
+extern bool Show_ship_only_if_cockpits_enabled;
 extern bool Custom_briefing_icons_always_override_standard_icons;
 extern float Min_pixel_size_thruster;
 extern float Min_pixel_size_beam;

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -236,7 +236,7 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 			&& (obj->type == OBJ_SHIP)
 			&& c_viewer
 			&& (Ship_info[Ships[obj->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model])
-			&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active)) )
+			&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active) )
 		{
 			(*draw_viewer_last) = true;
 			continue;

--- a/code/object/objectsort.cpp
+++ b/code/object/objectsort.cpp
@@ -235,7 +235,8 @@ void obj_render_all(const std::function<void(object*)>& render_function, bool *d
 		if ( (obj == Viewer_obj)
 			&& (obj->type == OBJ_SHIP)
 			&& c_viewer
-			&& (Ship_info[Ships[obj->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model]) )
+			&& (Ship_info[Ships[obj->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model])
+			&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active)) )
 		{
 			(*draw_viewer_last) = true;
 			continue;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8030,7 +8030,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
 	const bool renderShipModel = ( 
 		sip->flags[Ship::Info_Flags::Show_ship_model])
-		&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active))
+		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active))
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK)
 			|| !(Viewer_mode & VM_EXTERNAL));
 	Cockpit_active = renderCockpitModel;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8028,7 +8028,9 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	const bool hasCockpitModel = sip->cockpit_model_num >= 0;
 
 	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
-	const bool renderShipModel = (sip->flags[Ship::Info_Flags::Show_ship_model])
+	const bool renderShipModel = ( 
+		sip->flags[Ship::Info_Flags::Show_ship_model])
+		&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active))
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK)
 			|| !(Viewer_mode & VM_EXTERNAL));
 	Cockpit_active = renderCockpitModel;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8030,7 +8030,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	const bool renderCockpitModel = (Viewer_mode != VM_TOPDOWN) && hasCockpitModel && !Disable_cockpits;
 	const bool renderShipModel = ( 
 		sip->flags[Ship::Info_Flags::Show_ship_model])
-		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active))
+		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active)
 		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK)
 			|| !(Viewer_mode & VM_EXTERNAL));
 	Cockpit_active = renderCockpitModel;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -912,7 +912,8 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int light_n )
 				}
 			}
 
-			if ( sip->flags[Ship::Info_Flags::Show_ship_model] ) {
+			if ( sip->flags[Ship::Info_Flags::Show_ship_model] 
+				&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active)) ) {
 				vm_vec_scale_add( &rp1, &rp0, &light_dir, Viewer_obj->radius*10.0f );
 
 				mc.model_instance_num = -1;
@@ -1051,8 +1052,10 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 	// HACK - let the flak guns do this on their own since they fire so quickly
 	// Also don't create if its the player in the cockpit unless he's also got show_ship_model, provided render_player_mflash isnt on
 	bool in_cockpit_view = (Viewer_mode & (VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP | VM_WARP_CHASE)) == 0;
-	bool player_show_ship_model =
-		objp == Player_obj && Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
+	bool player_show_ship_model = (
+		objp == Player_obj 
+		&& Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model]
+		&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active)));
 	if (!(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak]) &&
 		(objp != Player_obj || Render_player_mflash || (!in_cockpit_view || player_show_ship_model))) {
 			// if there's a muzzle effect entry, we use that

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -913,7 +913,7 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int light_n )
 			}
 
 			if ( sip->flags[Ship::Info_Flags::Show_ship_model] 
-				&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active)) ) {
+				&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active) ) {
 				vm_vec_scale_add( &rp1, &rp0, &light_dir, Viewer_obj->radius*10.0f );
 
 				mc.model_instance_num = -1;
@@ -1055,7 +1055,7 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 	bool player_show_ship_model = (
 		objp == Player_obj 
 		&& Ship_info[Ships[objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model]
-		&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active)));
+		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active));
 	if (!(Weapon_info[weapon_info_index].wi_flags[Weapon::Info_Flags::Flak]) &&
 		(objp != Player_obj || Render_player_mflash || (!in_cockpit_view || player_show_ship_model))) {
 			// if there's a muzzle effect entry, we use that

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1674,7 +1674,7 @@ void beam_render_muzzle_glow(beam *b)
 	bool player_show_ship_model = (
 		b->objp == Player_obj  
 		&& Ship_info[Ships[b->objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model] 
-		&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active)));
+		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active));
 	if ((b->flags & BF_IS_FIGHTER_BEAM) && (b->objp == Player_obj && !Render_player_mflash && in_cockpit_view && !player_show_ship_model)) {
 		return;
 	}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -1671,7 +1671,10 @@ void beam_render_muzzle_glow(beam *b)
 
 	// don't show the muzzle glow for players in the cockpit unless show_ship_model is on, provided Render_player_mflash isn't on
 	bool in_cockpit_view = (Viewer_mode & (VM_EXTERNAL | VM_CHASE | VM_OTHER_SHIP | VM_WARP_CHASE)) == 0;
-	bool player_show_ship_model = b->objp == Player_obj && Ship_info[Ships[b->objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model];
+	bool player_show_ship_model = (
+		b->objp == Player_obj  
+		&& Ship_info[Ships[b->objp->instance].ship_info_index].flags[Ship::Info_Flags::Show_ship_model] 
+		&& (!Show_ship_only_if_cockpits_enabled || (Show_ship_only_if_cockpits_enabled && Cockpit_active)));
 	if ((b->flags & BF_IS_FIGHTER_BEAM) && (b->objp == Player_obj && !Render_player_mflash && in_cockpit_view && !player_show_ship_model)) {
 		return;
 	}


### PR DESCRIPTION
FotG uses cockpits and 'show ship', and also provides a way for players to toggle off cockpits. Unfortunately, if the player disables cockpits, 'show ship' still appears and looks very odd (since it appears the player is flying a ship with a hole in the center where the cockpit would be). Other mods have made entire ships with their cockpits, but FotG needs to use 'show ship' to match team colors and moving external ship animations.

This PR adds a game_settings option that allows mods to set to only use 'show ship' if cockpits are enabled.

Tested and works as expected.