### PR TITLE
make hitpoint sexps safer to use in debriefing

### DIFF
--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -98,7 +98,7 @@ void update_ets(object* objp, float fl_frametime)
 	}
 
 	float shield_delta;
-	max_new_shield_energy = fl_frametime * ship_p->max_shield_regen_per_second * shield_get_max_strength(objp, true); // recharge rate is unaffected by $Max Shield Recharge
+	max_new_shield_energy = fl_frametime * ship_p->max_shield_regen_per_second * shield_get_max_strength(ship_p, true); // recharge rate is unaffected by $Max Shield Recharge
 	if ( objp->flags[Object::Object_Flags::Player_ship] ) {
 		shield_delta = Energy_levels[ship_p->shield_recharge_index] * max_new_shield_energy * The_mission.ai_profile->shield_energy_scale[Game_skill_level];
 	} else {
@@ -111,7 +111,7 @@ void update_ets(object* objp, float fl_frametime)
 	shield_add_strength(objp, shield_delta);
 
 	// if strength now exceeds max, scale back segments proportionally
-	float max_shield = shield_get_max_strength(objp);
+	float max_shield = shield_get_max_strength(ship_p);
 	if ( (_ss = shield_get_strength(objp)) > max_shield ){
 		for (int i=0; i<objp->n_quadrants; i++){
 			objp->shield_quadrant[i] *= max_shield / _ss;
@@ -679,7 +679,7 @@ void transfer_energy_to_shields(object* obj)
 		return;
 	}
 
-	transfer_energy_weapon_common(obj, ship_p->weapon_energy, shield_get_strength(obj), &ship_p->target_weapon_energy_delta, &ship_p->target_shields_delta, sinfo_p->max_weapon_reserve, shield_get_max_strength(obj), sinfo_p->weap_shield_amount, sinfo_p->weap_shield_efficiency);
+	transfer_energy_weapon_common(obj, ship_p->weapon_energy, shield_get_strength(obj), &ship_p->target_weapon_energy_delta, &ship_p->target_shields_delta, sinfo_p->max_weapon_reserve, shield_get_max_strength(ship_p), sinfo_p->weap_shield_amount, sinfo_p->weap_shield_efficiency);
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -704,7 +704,7 @@ void transfer_energy_to_weapons(object* obj)
 		return;
 	}
 
-	transfer_energy_weapon_common(obj, shield_get_strength(obj), ship_p->weapon_energy, &ship_p->target_shields_delta, &ship_p->target_weapon_energy_delta, shield_get_max_strength(obj), sinfo_p->max_weapon_reserve, sinfo_p->shield_weap_amount, sinfo_p->shield_weap_efficiency);
+	transfer_energy_weapon_common(obj, shield_get_strength(obj), ship_p->weapon_energy, &ship_p->target_shields_delta, &ship_p->target_weapon_energy_delta, shield_get_max_strength(ship_p), sinfo_p->max_weapon_reserve, sinfo_p->shield_weap_amount, sinfo_p->shield_weap_efficiency);
 }
 
 /**

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -288,9 +288,18 @@ int objects_will_collide(object *A, object *B, float duration, float radius_scal
 void obj_init_all_ships_physics();
 
 // Goober5000
-float get_hull_pct(const object *objp);
-float get_sim_hull_pct(const object *objp);
+float get_hull_pct(const object *objp, bool allow_negative = false);
+float get_sim_hull_pct(const object *objp, bool allow_negative = false);
 float get_shield_pct(const object *objp);
+
+struct ship_registry_entry;
+
+// SEXPs evaluated during debriefing are susceptible to a "use-after-free" problem where the object and ship have been deleted but still
+// contain information useful for debriefing.  Since the ship registry still contains object and ship indexes, use this rather than the
+// instance and objnum indexes in the object and ship structures themselves.
+float get_hull_pct(const ship_registry_entry *ship_entry, bool allow_negative = false);
+float get_sim_hull_pct(const ship_registry_entry *ship_entry, bool allow_negative = false);
+float get_shield_pct(const ship_registry_entry *ship_entry);
 
 // returns the average 3-space position of all ships.  useful to find "center" of battle (sort of)
 void obj_get_average_ship_pos(vec3d *pos);

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -8,8 +8,11 @@
 
 
 
+#include "globalincs/globals.h"
+#include "globalincs/pstypes.h"
 #include "math/staticrand.h"
 #include "network/multi.h"
+#include "object/object.h"
 #include "object/objectshield.h"
 #include "ship/ship.h"
 #include "ship/subsysdamage.h"
@@ -273,10 +276,16 @@ float shield_get_max_strength(const object *objp, bool no_msr) {
 	if (objp->type != OBJ_SHIP && objp->type != OBJ_START)
 		return 0.0f;
 
-	if (no_msr == true)
-		return Ships[objp->instance].ship_max_shield_strength;
+	return shield_get_max_strength(&Ships[objp->instance], no_msr);
+}
+
+float shield_get_max_strength(const ship *shipp, bool no_msr) {
+	Assert(shipp);
+
+	if (no_msr)
+		return shipp->ship_max_shield_strength;
 	else
-		return Ships[objp->instance].ship_max_shield_strength * Ships[objp->instance].max_shield_recharge;
+		return shipp->ship_max_shield_strength * shipp->max_shield_recharge;
 }
 
 float shield_get_quad(const object *objp, int quadrant_num) {

--- a/code/object/objectshield.h
+++ b/code/object/objectshield.h
@@ -10,14 +10,13 @@
 #ifndef _OBJECTSHIELD_H
 #define _OBJECTSHIELD_H
 
-#include "globalincs/globals.h"
-#include "globalincs/pstypes.h"
-#include "object/object.h"
-
 #define	FRONT_QUAD	1
 #define	REAR_QUAD	2
 #define	LEFT_QUAD	3
 #define	RIGHT_QUAD	0
+
+class object;
+class ship;
 
 /**
  * @brief Balances/Equalizes the shield
@@ -104,6 +103,15 @@ void shield_add_quad(object *objp, int quadrant_num, float strength);
  * @author Goober5000
  */
 float shield_get_max_strength(const object *objp, bool no_msr = false);
+
+/**
+ * @brief Gets the max shield HP of the given ship
+ *
+ * @note $Max Shield Recharge is not intended to affect max strength of individual shield segments
+ *
+ * @author Goober5000
+ */
+float shield_get_max_strength(const ship *shipp, bool no_msr = false);
 
 /**
  * @brief Sets the max shield HP of the given object. Use this to init or override a ship's default shield HP

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8202,7 +8202,7 @@ void sexp_set_energy_pct (int node, int op_num)
 					continue;
 				}	
 
-				shield_set_strength(&Objects[shipp->objnum], (shield_get_max_strength(&Objects[shipp->objnum]) * new_pct));
+				shield_set_strength(ship_entry->objp(), (shield_get_max_strength(shipp) * new_pct));
 				break;
 		}
 
@@ -8238,7 +8238,7 @@ void multi_sexp_set_energy_pct()
 				break; 
 
 			case OP_SET_SHIELD_ENERGY:
-				shield_set_strength(&Objects[shipp->objnum], (shield_get_max_strength(&Objects[shipp->objnum]) * new_pct));
+				shield_set_strength(&Objects[shipp->objnum], (shield_get_max_strength(shipp) * new_pct));
 				break;
 		}
 	}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -8295,7 +8295,7 @@ int sexp_shields_left(int node)
 	}
 
 	// now return the amount of shields left as a percentage of the whole.
-	int percent = (int)std::lround(get_shield_pct(ship_entry->objp()) * 100.0f);
+	int percent = (int)std::lround(get_shield_pct(ship_entry) * 100.0f);
 	return percent;
 }
 
@@ -8313,8 +8313,7 @@ int sexp_hits_left(int node, bool sim_hull)
 	if (ship_entry->status == ShipStatus::DEATH_ROLL || ship_entry->status == ShipStatus::EXITED)
 		return SEXP_NAN_FOREVER;
 
-	auto objp = ship_entry->objp();
-	float hull_pct = sim_hull ? get_sim_hull_pct(objp) : get_hull_pct(objp);
+	float hull_pct = sim_hull ? get_sim_hull_pct(ship_entry) : get_hull_pct(ship_entry);
 
 	// now return the amount of hits left as a percentage of the whole.
 	int percent = (int)std::lround(hull_pct * 100.0f);
@@ -8442,7 +8441,8 @@ int sexp_hits_left_subsystem(int n)
 
 			// we reached end of ship subsys list without finding subsys_name
 			if (ship_class_unchanged(ship_entry)) {
-				Warning(LOCATION, "Invalid subsystem '%s' passed to hits-left-subsystem", subsys_name);
+				auto problem = (Game_mode & GM_IN_MISSION) ? "subsystem was not found" : "subsystem information is not available when not in-mission";
+				Warning(LOCATION, "Attempted to check subsystem '%s' on ship '%s' in hits-left-subsystem -- %s", subsys_name, ship_entry->name, problem);
 			}
 			return SEXP_NAN;
 
@@ -8509,7 +8509,8 @@ int sexp_hits_left_subsystem_specific(int node)
 
 	// we reached end of ship subsys list without finding subsys_name
 	if (ship_class_unchanged(ship_entry)) {
-		Warning(LOCATION, "Invalid subsystem '%s' passed to hits-left-subsystem", subsys_name);
+		auto problem = (Game_mode & GM_IN_MISSION) ? "subsystem was not found" : "subsystem information is not available when not in-mission";
+		Warning(LOCATION, "Attempted to check subsystem '%s' on ship '%s' in hits-left-subsystem-specific -- %s", subsys_name, ship_entry->name, problem);
 	}
 	return SEXP_NAN;
 }
@@ -21210,13 +21211,12 @@ void multi_sexp_change_ship_class()
 }
 
 // Goober5000
-void ship_copy_damage(ship *target_shipp, ship *source_shipp)
+void ship_copy_damage(const ship_registry_entry *target, const ship_registry_entry *source)
 {
-	int i;
-	object *target_objp = &Objects[target_shipp->objnum];
-	object *source_objp = &Objects[source_shipp->objnum];
-	ship_subsys *source_ss;
-	ship_subsys *target_ss;
+	auto target_shipp = target->shipp();
+	auto target_objp = target->objp();
+	auto source_shipp = source->shipp();
+	auto source_objp = source->objp();
 
 	if (target_shipp->ship_info_index != source_shipp->ship_info_index)
 	{
@@ -21232,15 +21232,15 @@ void ship_copy_damage(ship *target_shipp, ship *source_shipp)
 	// ...and shields
 	target_shipp->special_shield = source_shipp->special_shield;
 	target_shipp->ship_max_shield_strength = source_shipp->ship_max_shield_strength;
-	for (i = 0; i < MIN(target_objp->n_quadrants, source_objp->n_quadrants); i++)
+	for (int i = 0; i < MIN(target_objp->n_quadrants, source_objp->n_quadrants); i++)
 		target_objp->shield_quadrant[i] = source_objp->shield_quadrant[i];
 
 
 	// search through all subsystems on source ship and map them onto target ship
-	for (source_ss = GET_FIRST(&source_shipp->subsys_list); source_ss != GET_LAST(&source_shipp->subsys_list); source_ss = GET_NEXT(source_ss))
+	for (auto source_ss: list_range(&source_shipp->subsys_list))
 	{
 		// find subsystem to configure
-		target_ss = ship_get_subsys(target_shipp, source_ss->system_info->subobj_name);
+		auto target_ss = ship_get_subsys(target_shipp, source_ss->system_info->subobj_name);
 		if (target_ss == nullptr)
 			continue;
 
@@ -21434,33 +21434,33 @@ void sexp_set_alphamult(int n)
 extern int insert_subsys_status(p_object *pobjp);
 
 // Goober5000
-void parse_copy_damage(p_object *target_pobjp, ship *source_shipp)
+void parse_copy_damage(const ship_registry_entry *target, const ship_registry_entry *source_entry)
 {
-	object *source_objp = &Objects[source_shipp->objnum];
-	ship_subsys *source_ss;
-	subsys_status *target_sssp;
+	auto target_pobjp = target->p_objp();
+	auto source_shipp = source_entry->shipp();
 
 	if (target_pobjp->ship_class != source_shipp->ship_info_index)
 	{
 		nprintf(("SEXP", "Copying damage of ship %s to ship %s which has a different ship class.  Strange results might occur.\n", source_shipp->ship_name, target_pobjp->name));
 	}
 
+
 	// copy hull...
 	target_pobjp->special_hitpoints = source_shipp->special_hitpoints;
 	target_pobjp->ship_max_hull_strength = source_shipp->ship_max_hull_strength;
-	target_pobjp->initial_hull = fl2i(get_hull_pct(source_objp) * 100.0f);
+	target_pobjp->initial_hull = fl2i(get_hull_pct(source_entry) * 100.0f);
 
 	// ...and shields
 	target_pobjp->ship_max_shield_strength = source_shipp->ship_max_shield_strength;
-	target_pobjp->initial_shields = fl2i(get_shield_pct(source_objp) * 100.0f);
+	target_pobjp->initial_shields = fl2i(get_shield_pct(source_entry) * 100.0f);
 	target_pobjp->max_shield_recharge = source_shipp->max_shield_recharge;
 
 
 	// search through all subsystems on source ship and map them onto target ship
-	for (source_ss = GET_FIRST(&source_shipp->subsys_list); source_ss != GET_LAST(&source_shipp->subsys_list); source_ss = GET_NEXT(source_ss))
+	for (auto source_ss: list_range(&source_shipp->subsys_list))
 	{
 		// find subsystem to configure
-		target_sssp = parse_get_subsys_status(target_pobjp, source_ss->system_info->subobj_name);
+		auto target_sssp = parse_get_subsys_status(target_pobjp, source_ss->system_info->subobj_name);
 
 		// gak... none allocated; we need to allocate one!
 		if (target_sssp == nullptr)
@@ -21504,14 +21504,14 @@ void sexp_ship_copy_damage(int node)
 		// maybe it's present in-mission
 		if (target->has_shipp())
 		{
-			ship_copy_damage(target->shipp(), source->shipp());
+			ship_copy_damage(target, source);
 			continue;
 		}
 
 		// maybe it's on the arrival list
 		if (target->status == ShipStatus::NOT_YET_PRESENT)
 		{
-			parse_copy_damage(target->p_objp(), source->shipp());
+			parse_copy_damage(target, source);
 			continue;
 		}
 
@@ -23220,7 +23220,7 @@ void sexp_damage_escort_list(int node)
 			continue;
 
 		//calc hull integrity and compare
-		current_hull_pct = get_hull_pct(ship_entry->objp());
+		current_hull_pct = get_hull_pct(ship_entry);
 
 		if (current_hull_pct < smallest_hull_pct)
 		{

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1316,7 +1316,9 @@ ADE_FUNC(kill, l_Ship, "[object Killer, vector Hitpos]", "Kills the ship. Set \"
 
 	// use the current hull percentage for damage-after-death purposes
 	// (note that this does not actually affect scoring)
-	float percent_killed = get_hull_pct(victim->objp());
+	float percent_killed = -get_hull_pct(victim->objp(), true);
+	if (percent_killed > 1.0f)
+		percent_killed = 1.0f;
 
 	ship_hit_kill(victim->objp(), killer ? killer->objp() : nullptr, hitpos, percent_killed, (killer && victim->sig == killer->sig), true);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7265,7 +7265,7 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 		objp->shield_quadrant[0] = 100.0f;
 	} else {
 		shipp->ship_max_shield_strength = sip->max_shield_strength;
-		shield_set_strength(objp, shield_get_max_strength(objp));
+		shield_set_strength(objp, shield_get_max_strength(shipp));
 	}
 
 	shipp->orders_accepted = ship_get_default_orders_accepted( sip );
@@ -11559,7 +11559,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 
 		// shield
 		if (sp->special_shield > 0) {
-			shield_pct = shield_get_strength(objp) / shield_get_max_strength(objp);
+			shield_pct = shield_get_strength(objp) / shield_get_max_strength(sp);
 		} else if (Ship_info[sp->ship_info_index].max_shield_strength > 0.0f) {
 			shield_pct = shield_get_strength(objp) / (sip_orig->max_shield_strength * sip_orig->max_shield_recharge);
 		} else {
@@ -11728,7 +11728,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 			sp->ship_max_shield_strength = sip->max_shield_strength;
 		}
 
-		shield_set_strength(objp, shield_pct * shield_get_max_strength(objp));
+		shield_set_strength(objp, shield_pct * shield_get_max_strength(sp));
 	}
 
 	// Goober5000: div-0 checks
@@ -15506,7 +15506,7 @@ float ship_calculate_rearm_duration( object *objp )
 	sip = &Ship_info[sp->ship_info_index];
 
 	//find out time to repair shields
-	float max_shields = shield_get_max_strength(objp);
+	float max_shields = shield_get_max_strength(sp);
 	if(sip->sup_shield_repair_rate > 0.0f && max_shields > 0.0f)
 		shield_rep_time = (max_shields - shield_get_strength(objp)) / (max_shields * sip->sup_shield_repair_rate);
 	
@@ -15651,7 +15651,7 @@ int ship_do_rearm_frame( object *objp, float frametime )
 	if ( !(objp->flags[Object::Object_Flags::No_shields]) )
 	{
 		shield_str = shield_get_strength(objp);
-		max_shield_str = shield_get_max_strength(objp);
+		max_shield_str = shield_get_max_strength(shipp);
 		if ( shield_str < (max_shield_str) ) {
 			if ( objp == Player_obj ) {
 				player_maybe_start_repair_sound();
@@ -17840,7 +17840,7 @@ void ship_maybe_ask_for_help(ship* sp, ship* attacker)
 		return;	// no shields on ship, no don't check shield levels
 	}
 
-	if (shield_get_strength(objp) > (sip->ask_help_shield_percent * shield_get_max_strength(objp))) {
+	if (shield_get_strength(objp) > (sip->ask_help_shield_percent * shield_get_max_strength(sp))) {
 		return;
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15372,7 +15372,7 @@ bool ship_subsystems_blown(const ship* shipp, int type, bool skip_dying_check)
 	Assertion( (type >= 0) && (type < SUBSYSTEM_MAX), "ship_subsystems_blown() subsystem type %d is out of range!", type );
 
 	//	For a dying ship, all subsystem strengths are zero.
-	if (Objects[shipp->objnum].hull_strength <= 0.0f && !skip_dying_check)
+	if (shipp->flags[Ship::Ship_Flags::Dying] && !skip_dying_check)
 		return true;
 
 	// short circuit 1
@@ -15399,7 +15399,7 @@ float ship_get_subsystem_strength(const ship *shipp, int type, bool skip_dying_c
 	Assertion( (type >= 0) && (type < SUBSYSTEM_MAX), "ship_get_subsystem_strength() subsystem type %d is out of range!", type );
 
 	//	For a dying ship, all subsystem strengths are zero.
-	if (Objects[shipp->objnum].hull_strength <= 0.0f && !skip_dying_check)
+	if (shipp->flags[Ship::Ship_Flags::Dying] && !skip_dying_check)
 		return 0.0f;
 
 	// short circuit 1

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2610,7 +2610,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 					shipp->wash_killed = 1;
 				}
 
-				float percent_killed = -get_hull_pct(ship_objp);
+				float percent_killed = -get_hull_pct(ship_objp, true);
 				if (percent_killed > 1.0f){
 					percent_killed = 1.0f;
 				}


### PR DESCRIPTION
There is a rather large design flaw in FreeSpace debriefings... debriefing SEXPs can refer to in-mission ship data, while all ships (and all objects) are deleted as soon as the mission completes.  Specifically, `obj_delete()` is called which sets all objects to `OBJ_NONE` and marks them as freed, although the data still exists in the various arrays.  This is the use-after-free problem, but applied to the in-game object system, rather than memory accessed by pointers.

It's probably best to defer fixes to an as-needed basis.  As for hitpoint SEXPs, this change updates them to use the object and ship references from the ship registry, since the ship registry is not cleared by the time the debriefing is loaded.  (Using `objp->instance` and `shipp->objnum` at this point would be problematic.)  Since subsystems are also cleared at this point, this also updates the warning messages in those functions.

Fixes an Assert seen in debug mode in Inferno.

Relatedly, fix the calculation of `percent_killed`.  This has been broken ever since commit 6c17ef09ab3cbe893f6d6dd60897e8bce765c9a5 in 2005.  Since `get_hull_pct()` did not return negative values, `percent_killed` was always 0.  Allow negative values in this case.