### PR TITLE
Add many options to default settings table

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -55,7 +55,7 @@ APPLY_TO_FOV_T(+, add)
 APPLY_TO_FOV_T(-, sub)
 
 // Used to set the default value for in-game options
-static constexpr float fov_default = DEFAULT_FOV;
+static float fov_default = DEFAULT_FOV;
 
 static SCP_string fov_display(float val)
 {
@@ -64,6 +64,15 @@ static SCP_string fov_display(float val)
 	sprintf(out, u8"%.1f\u00B0", degrees);
 	return out;
 }
+
+static void parse_fov_func()
+{
+	float value;
+	stuff_float(&value);
+	CLAMP(value, 0.436332f, 1.5708f);
+	fov_default = value;
+}
+
 auto FovOption = options::OptionBuilder<float>("Graphics.FOV",
 					 std::pair<const char*, int>{"Field Of View", 1703},
 					 std::pair<const char*, int>{"The vertical field of view", 1704})
@@ -74,9 +83,10 @@ auto FovOption = options::OptionBuilder<float>("Graphics.FOV",
 					      return true;
 					 })
 					 .display(fov_display)
-					 .default_val(fov_default)
+					 .default_func([]() { return fov_default; })
 					 .level(options::ExpertLevel::Advanced)
 					 .importance(60)
+					 .parser(parse_fov_func)
 					 .finish();
 
 bool Use_cockpit_fov = false;
@@ -85,7 +95,7 @@ auto CockpitFOVToggleOption = options::OptionBuilder<bool>("Graphics.CockpitFOVT
 					 std::pair<const char*, int>{"Cockpit FOV Toggle", 1838},
 					 std::pair<const char*, int>{"Whether or not to use a different FOV for cockpit rendering from normal rendering", 1839})
 					 .category(std::make_pair("Graphics", 1825))
-					 .default_val(false)
+					 .default_func(false)
 					 .change_listener([](bool val, bool) {
 					      if (!val) {
 					           COCKPIT_ZOOM_DEFAULT = VIEWER_ZOOM_DEFAULT;

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -95,7 +95,7 @@ auto CockpitFOVToggleOption = options::OptionBuilder<bool>("Graphics.CockpitFOVT
 					 std::pair<const char*, int>{"Cockpit FOV Toggle", 1838},
 					 std::pair<const char*, int>{"Whether or not to use a different FOV for cockpit rendering from normal rendering", 1839})
 					 .category(std::make_pair("Graphics", 1825))
-					 .default_func(false)
+					 .default_val(false)
 					 .change_listener([](bool val, bool) {
 					      if (!val) {
 					           COCKPIT_ZOOM_DEFAULT = VIEWER_ZOOM_DEFAULT;

--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -45,15 +45,24 @@ static bool music_volume_change_listener(float new_val, bool /*initial*/)
 	return true;
 }
 
+static void parse_music_volume_func()
+{
+	float volume;
+	stuff_float(&volume);
+	CLAMP(volume, 0.0f, 1.0f);
+	Default_music_volume = volume;
+}
+
 static auto MusicVolumeOption __UNUSED = options::OptionBuilder<float>("Audio.Music",
                      std::pair<const char*, int>{"Music", 1371},
                      std::pair<const char*, int>{"Volume used for playing music", 1760})
                      .category(std::make_pair("Audio", 1826))
-                     .default_val(Default_music_volume)
+                     .default_func([]() { return Default_music_volume;})
                      .range(0.0f, 1.0f)
                      .change_listener(music_volume_change_listener)
                      .importance(1)
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_music_volume_func)
                      .finish();
 
 typedef struct tagSNDPATTERN {

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -240,19 +240,50 @@ const SCP_vector<std::pair<int, std::pair<const char*, int>>> DetailLevelValues 
                                                                                    { 3, {"High", 1162}},
                                                                                    { 4, {"Ultra", 1721}}};
 
+static void parse_model_detail_func()
+{
+	int value[static_cast<int>(DefaultDetailPreset::Num_detail_presets)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailPreset::Num_detail_presets), RAW_INTEGER_TYPE);
+
+	for (int i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
+
+		if (value[i] < 0 || value[i] > MAX_DETAIL_VALUE) {
+			error_display(0, "%i is an invalid detail level value!", value[i]);
+		} else {
+			change_default_detail_level(static_cast<DefaultDetailPreset>(i), DetailSetting::DetailDistance, value[i]);
+		}
+	}
+}
+
 const auto ModelDetailOption __UNUSED = options::OptionBuilder<int>("Graphics.Detail",
                      std::pair<const char*, int>{"Model Detail", 1739},
                      std::pair<const char*, int>{"Detail level of models", 1740})
                      .importance(8)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_VALUE)
+                     .default_func([](){return Detail.detail_distance;})
                      .change_listener([](int val, bool) {
                           Detail.detail_distance = val;
                           return true;
                      })
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_model_detail_func)
                      .finish();
+
+static void parse_texture_detail_func()
+{
+	int value[static_cast<int>(DefaultDetailPreset::Num_detail_presets)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailPreset::Num_detail_presets), RAW_INTEGER_TYPE);
+
+	for (int i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
+
+		if (value[i] < 0 || value[i] > MAX_DETAIL_VALUE) {
+			error_display(0, "%i is an invalid detail level value!", value[i]);
+		} else {
+			change_default_detail_level(static_cast<DefaultDetailPreset>(i), DetailSetting::HardwareTextures, value[i]);
+		}
+	}
+}
 
 const auto TexturesOption __UNUSED = options::OptionBuilder<int>("Graphics.Texture",
                      std::pair<const char*, int>{"3D Hardware Textures", 1362},
@@ -260,13 +291,29 @@ const auto TexturesOption __UNUSED = options::OptionBuilder<int>("Graphics.Textu
                      .importance(6)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_VALUE)
+                     .default_func([](){return Detail.hardware_textures;})
                      .change_listener([](int val, bool) {
                           Detail.hardware_textures = val;
                           return true;
                      })
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_texture_detail_func)
                      .finish();
+
+static void parse_particles_detail_func()
+{
+	int value[static_cast<int>(DefaultDetailPreset::Num_detail_presets)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailPreset::Num_detail_presets), RAW_INTEGER_TYPE);
+
+	for (int i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
+
+		if (value[i] < 0 || value[i] > MAX_DETAIL_VALUE) {
+			error_display(0, "%i is an invalid detail level value!", value[i]);
+		} else {
+			change_default_detail_level(static_cast<DefaultDetailPreset>(i), DetailSetting::NumParticles, value[i]);
+		}
+	}
+}
 
 const auto ParticlesOption __UNUSED = options::OptionBuilder<int>("Graphics.Particles",
                      std::pair<const char*, int>{"Particles", 1363},
@@ -274,27 +321,59 @@ const auto ParticlesOption __UNUSED = options::OptionBuilder<int>("Graphics.Part
                      .importance(5)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_VALUE)
+                     .default_func([](){return Detail.num_particles;})
                      .change_listener([](int val, bool) {
                           Detail.num_particles = val;
                           return true;
                      })
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_particles_detail_func)
                      .finish();
+
+static void parse_debris_detail_func()
+{
+	int value[static_cast<int>(DefaultDetailPreset::Num_detail_presets)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailPreset::Num_detail_presets), RAW_INTEGER_TYPE);
+
+	for (int i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
+
+		if (value[i] < 0 || value[i] > MAX_DETAIL_VALUE) {
+			error_display(0, "%i is an invalid detail level value!", value[i]);
+		} else {
+			change_default_detail_level(static_cast<DefaultDetailPreset>(i), DetailSetting::NumSmallDebris, value[i]);
+		}
+	}
+}
 
 const auto SmallDebrisOption __UNUSED = options::OptionBuilder<int>("Graphics.SmallDebris", 
                      std::pair<const char*, int>{"Impact Effects", 1364}, 
                      std::pair<const char*, int>{"Level of detail of impact effects", 1743})
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_VALUE)
+                     .default_func([](){return Detail.num_small_debris;})
                      .importance(4)
                      .change_listener([](int val,bool) {
                           Detail.num_small_debris = val;
                           return true;
                      })
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_debris_detail_func)
                      .finish();
+
+static void parse_shield_detail_func()
+{
+	int value[static_cast<int>(DefaultDetailPreset::Num_detail_presets)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailPreset::Num_detail_presets), RAW_INTEGER_TYPE);
+
+	for (int i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
+
+		if (value[i] < 0 || value[i] > MAX_DETAIL_VALUE) {
+			error_display(0, "%i is an invalid detail level value!", value[i]);
+		} else {
+			change_default_detail_level(static_cast<DefaultDetailPreset>(i), DetailSetting::ShieldEffects, value[i]);
+		}
+	}
+}
 
 const auto ShieldEffectsOption __UNUSED = options::OptionBuilder<int>("Graphics.ShieldEffects",
                      std::pair<const char*, int>{"Shield Hit Effects", 1718},
@@ -302,13 +381,29 @@ const auto ShieldEffectsOption __UNUSED = options::OptionBuilder<int>("Graphics.
                      .importance(3)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_VALUE)
+                     .default_func([](){return Detail.shield_effects;})
                      .change_listener([](int val, bool) {
                           Detail.shield_effects = val;
                           return true;
                      })
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_shield_detail_func)
                      .finish();
+
+static void parse_stars_detail_func()
+{
+	int value[static_cast<int>(DefaultDetailPreset::Num_detail_presets)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailPreset::Num_detail_presets), RAW_INTEGER_TYPE);
+
+	for (int i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
+
+		if (value[i] < 0 || value[i] > MAX_DETAIL_VALUE) {
+			error_display(0, "%i is an invalid detail level value!", value[i]);
+		} else {
+			change_default_detail_level(static_cast<DefaultDetailPreset>(i), DetailSetting::NumStars, value[i]);
+		}
+	}
+}
 
 const auto StarsOption __UNUSED = options::OptionBuilder<int>("Graphics.Stars", 
                      std::pair<const char*, int>{"Stars", 1366}, 
@@ -316,12 +411,13 @@ const auto StarsOption __UNUSED = options::OptionBuilder<int>("Graphics.Stars",
                      .importance(2)
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_VALUE)
+                     .default_func([](){return Detail.num_stars;})
                      .change_listener([](int val, bool) {
                           Detail.num_stars = val;
                           return true;
                      })
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_stars_detail_func)
                      .finish();
 
 // Call this with:

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -40,17 +40,33 @@ PostEffectUniformType mapUniformNameToType(const SCP_string& uniform_name)
 // used by In-Game Options menu
 bool Post_processing_enable_lightshafts = true;
 
+static void parse_lightshafts_func()
+{
+	bool enabled;
+	stuff_boolean(&enabled);
+	Post_processing_enable_lightshafts = enabled;
+}
+
 static auto LightshaftsOption __UNUSED = options::OptionBuilder<bool>("Graphics.Lightshafts",
                      std::pair<const char*, int>{"Lightshafts", 1724},
                      std::pair<const char*, int>{"Enables or disables lightshafts (requires post-processing)", 1725})
                      .category(std::make_pair("Graphics", 1825))
-                     .default_val(true)
+                     .default_func([]() { return Post_processing_enable_lightshafts;})
                      .level(options::ExpertLevel::Advanced)
                      .bind_to(&Post_processing_enable_lightshafts)
                      .importance(60)
+                     .parser(parse_lightshafts_func)
                      .finish();
 
 int Post_processing_bloom_intensity = 25; // using default value of Cmdline_bloom_intensity
+
+static void parse_bloom_intensity_func()
+{
+	int value;
+	stuff_int(&value);
+	CLAMP(value, 0, 200);
+	Post_processing_bloom_intensity = value;
+}
 
 static auto BloomIntensityOption __UNUSED = options::OptionBuilder<int>("Graphics.BloomIntensity",
                      std::pair<const char*, int>{"Bloom intensity", 1701},
@@ -58,10 +74,11 @@ static auto BloomIntensityOption __UNUSED = options::OptionBuilder<int>("Graphic
                      .category(std::make_pair("Graphics", 1825))
                      .range(0, 200)
                      .level(options::ExpertLevel::Advanced)
-                     .default_val(25)
+                     .default_func([](){return Post_processing_bloom_intensity;})
                      .bind_to(&Post_processing_bloom_intensity)
                      .importance(55)
                      .flags({options::OptionFlags::RangeTypeInteger})
+                     .parser(parse_bloom_intensity_func)
                      .finish();
 } // namespace
 

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -40,7 +40,7 @@ PostEffectUniformType mapUniformNameToType(const SCP_string& uniform_name)
 // used by In-Game Options menu
 bool Post_processing_enable_lightshafts = true;
 
-static void parse_lightshafts_func()
+void parse_lightshafts_func()
 {
 	bool enabled;
 	stuff_boolean(&enabled);
@@ -60,7 +60,7 @@ static auto LightshaftsOption __UNUSED = options::OptionBuilder<bool>("Graphics.
 
 int Post_processing_bloom_intensity = 25; // using default value of Cmdline_bloom_intensity
 
-static void parse_bloom_intensity_func()
+void parse_bloom_intensity_func()
 {
 	int value;
 	stuff_int(&value);

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -104,14 +104,22 @@ DCF(light,"Changes lighting parameters")
 // used by In-Game Options menu
 static bool DeferredLightingEnabled = true;
 
+static void parse_deferred_lighting_func()
+{
+	bool enabled;
+	stuff_boolean(&enabled);
+	DeferredLightingEnabled = enabled;
+}
+
 static auto DeferredLightingOption = options::OptionBuilder<bool>("Graphics.DeferredLighting",
                   std::pair<const char*, int>{"Deferred Lighting", 1782},
                   std::pair<const char*, int>{"Enables or disables deferred lighting", 1783})
                   .category(std::make_pair("Graphics", 1825))
-                  .default_val(true)
+                  .default_func([]() { return DeferredLightingEnabled;})
                   .level(options::ExpertLevel::Advanced)
                   .bind_to_once(&DeferredLightingEnabled)
                   .importance(60)
+                  .parser(parse_deferred_lighting_func)
                   .finish();
 
 

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -135,18 +135,34 @@ const SCP_vector<std::pair<int, std::pair<const char*, int>>> DetailLevelValues 
                                                                                    { 3, {"High", 1162}},
                                                                                    { 4, {"Ultra", 1721}}};
 
+static void parse_nebula_detail_func()
+{
+	int value[static_cast<int>(DefaultDetailPreset::Num_detail_presets)];
+	stuff_int_list(value, static_cast<int>(DefaultDetailPreset::Num_detail_presets), RAW_INTEGER_TYPE);
+
+	for (int i = 0; i < static_cast<int>(DefaultDetailPreset::Num_detail_presets); i++) {
+
+		if (value[i] < 0 || value[i] > MAX_DETAIL_VALUE) {
+			error_display(0, "%i is an invalid detail level value!", value[i]);
+		} else {
+			change_default_detail_level(static_cast<DefaultDetailPreset>(i), DetailSetting::NebulaDetail, value[i]);
+		}
+	}
+}
+
 const auto NebulaDetailOption __UNUSED = options::OptionBuilder<int>("Graphics.NebulaDetail",
                      std::pair<const char*, int>{"Nebula Detail", 1361},
                      std::pair<const char*, int>{"Detail level of nebulas", 1697})
                      .category(std::make_pair("Graphics", 1825))
                      .values(DetailLevelValues)
-                     .default_val(MAX_DETAIL_VALUE)
+                     .default_func([]() { return Detail.nebula_detail; })
                      .importance(7)
                      .change_listener([](int val, bool) {
                           Detail.nebula_detail = val;
                           return true;
                      })
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_nebula_detail_func)
                      .finish();
 
 // --------------------------------------------------------------------------------------------------------

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -67,6 +67,29 @@ FlightMode Player_flight_mode = FlightMode::ShipLocked;
 bool Perspective_locked = false;
 bool Slew_locked = false;
 
+static void parse_flight_mode_func()
+{
+	SCP_string mode;
+	stuff_string(mode, F_NAME);
+
+	// Convert to lowercase once
+	std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
+
+	// Use a map to associate strings with their respective actions
+	static const std::unordered_map<std::string, std::function<void()>> effectActions =
+	{ 
+		{"ship locked", []() { Player_flight_mode = FlightMode::ShipLocked; }},
+		{"flight cursor", []() { Player_flight_mode = FlightMode::FlightCursor; }}
+	};
+
+	auto it = effectActions.find(mode);
+	if (it != effectActions.end()) {
+		it->second(); // Execute the corresponding action
+	} else {
+		error_display(0, "%s is not a valid flight mode setting", mode.c_str());
+	}
+}
+
 auto FlightModeOption = options::OptionBuilder<FlightMode>("Game.FlightMode",
 	std::pair<const char*, int>{"Flight Mode", 1842},
 	std::pair<const char*, int>{"Choose the flying style to use during gameplay.", 1843})
@@ -74,10 +97,11 @@ auto FlightModeOption = options::OptionBuilder<FlightMode>("Game.FlightMode",
 	.level(options::ExpertLevel::Beginner)
 	.values({ {FlightMode::ShipLocked, {"Ship Locked", 1844}},
 			{FlightMode::FlightCursor, {"Flight Cursor", 1845}} })
-	.default_val(FlightMode::ShipLocked)
+		.default_func([]() { return FlightMode::ShipLocked; })
 	.bind_to(&Player_flight_mode)
 	.flags({ options::OptionFlags::ForceMultiValueSelection })
 	.importance(45)
+	.parser(parse_flight_mode_func)
 	.finish();
 
 static SCP_string degrees_display(float val)
@@ -90,19 +114,36 @@ static SCP_string degrees_display(float val)
 
 float Flight_cursor_extent;
 
+static void parse_flight_cursor_extent_func()
+{
+	float value;
+	stuff_float(&value);
+	CLAMP(value, 0.0f, 0.698f);
+	Flight_cursor_extent = value;
+}
+
 auto FlightCursorExtentOption = options::OptionBuilder<float>("Game.FlightCursorExtent",
 	std::pair<const char*, int>{"Flight Cursor Extent", 1846},
 	std::pair<const char*, int>{"How far from the center the cursor can go.", 1847})
 	.category(std::make_pair("Game", 1824))
 	.range(0.0f, 0.698f)
 	.display(degrees_display)
-	.default_val(0.348f)
+	.default_func([]() { return 0.348f; })
 	.level(options::ExpertLevel::Beginner)
 	.bind_to(&Flight_cursor_extent)
 	.importance(44)
+	.parser(parse_flight_cursor_extent_func)
 	.finish();
 
 float Flight_cursor_deadzone;
+
+static void parse_cursor_deadzone_func()
+{
+	float value;
+	stuff_float(&value);
+	CLAMP(value, 0.0f, 0.349f);
+	Flight_cursor_deadzone = value;
+}
 
 auto FlightCursorDeadzoneOption = options::OptionBuilder<float>("Game.FlightCursorDeadzone",
 	std::pair<const char*, int>{"Flight Cursor Deadzone", 1848},
@@ -110,10 +151,11 @@ auto FlightCursorDeadzoneOption = options::OptionBuilder<float>("Game.FlightCurs
 	.category(std::make_pair("Game", 1824))
 	.range(0.0f, 0.349f)
 	.display(degrees_display)
-	.default_val(0.02f)
+	.default_func([]() { return 0.02f; })
 	.level(options::ExpertLevel::Beginner)
 	.bind_to(&Flight_cursor_deadzone)
 	.importance(43)
+	.parser(parse_cursor_deadzone_func)
 	.finish();
 
 int toggle_glide = 0;

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -62,15 +62,24 @@ static bool effects_volume_change_listener(float new_val, bool /*initial*/)
 	return true;
 }
 
+static void parse_effect_volume_func()
+{
+	float volume;
+	stuff_float(&volume);
+	CLAMP(volume, 0.0f, 1.0f);
+	Default_sound_volume = volume;
+}
+
 static auto EffectVolumeOption __UNUSED = options::OptionBuilder<float>("Audio.Effects",
                      std::pair<const char*, int>{"Effects", 1370},
                      std::pair<const char*, int>{"Volume used for playing in-game effects", 1734})
                      .category(std::make_pair("Audio", 1826))
-                     .default_val(Default_sound_volume)
+                     .default_func([](){ return Default_sound_volume; })
                      .range(0.0f, 1.0f)
                      .change_listener(effects_volume_change_listener)
                      .importance(2)
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_effect_volume_func)
                      .finish();
 
 float Default_voice_volume = 0.7f; // range is 0 -> 1, used for all voice playback
@@ -85,15 +94,24 @@ static bool voice_volume_change_listener(float new_val, bool /*initial*/)
 	return true;
 }
 
+static void parse_voice_volume_func()
+{
+	float volume;
+	stuff_float(&volume);
+	CLAMP(volume, 0.0f, 1.0f);
+	Default_voice_volume = volume;
+}
+
 static auto VoiceVolumeOption __UNUSED = options::OptionBuilder<float>("Audio.Voice",
                      std::pair<const char*, int>{"Voice", 1372},
                      std::pair<const char*, int>{"Volume used for playing voice audio", 1735})
                      .category(std::make_pair("Audio", 1826))
-                     .default_val(Default_voice_volume)
+                     .default_func([]() { return Default_voice_volume; })
                      .range(0.0f, 1.0f)
                      .change_listener(voice_volume_change_listener)
                      .importance(0)
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_voice_volume_func)
                      .finish();
 
 unsigned int SND_ENV_DEFAULT = 0;

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -162,14 +162,22 @@ bool Dynamic_environment = false;
 bool Motion_debris_override = false;
 bool Motion_debris_enabled = true;
 
+static void parse_motion_debris_func()
+{
+	bool enabled;
+	stuff_boolean(&enabled);
+	Motion_debris_enabled = enabled;
+}
+
 auto MotionDebrisOption = options::OptionBuilder<bool>("Graphics.MotionDebris",
                      std::pair<const char*, int>{"Motion Debris", 1713},
                      std::pair<const char*, int>{"Enable or disable visible motion debris", 1714})
                      .category(std::make_pair("Graphics", 1825))
                      .bind_to(&Motion_debris_enabled)
-                     .default_val(true)
+                     .default_func([]() { return Motion_debris_enabled;})
                      .level(options::ExpertLevel::Advanced)
                      .importance(67)
+                     .parser(parse_motion_debris_func)
                      .finish();
 
 static int Default_env_map = -1;

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -53,12 +53,19 @@ static SCP_string shockwave_mode_display(bool mode) { return mode ? XSTR("3D", 1
 
 bool Use_3D_shockwaves = true;
 
+static void parse_shockwaves_func()
+{
+	bool enabled;
+	stuff_boolean(&enabled);
+	Use_3D_shockwaves = enabled;
+}
+
 static auto Shockwave3DMode = options::OptionBuilder<bool>("Graphics.3DShockwaves",
                      std::pair<const char*, int>{"Shockwaves", 1722},
                      std::pair<const char*, int>{"The way shockwaves are displayed. Changes will be reflected in the next loaded mission.", 1723})
                      .category(std::make_pair("Graphics", 1825))
                      .display(shockwave_mode_display)
-                     .default_val(true)
+                     .default_func([]() { return Use_3D_shockwaves;})
                      .bind_to(&Use_3D_shockwaves)
                      .change_listener([](float, bool) {
                          Default_shockwave_loaded = 0; // If we change then we have to force shockwave reload
@@ -67,6 +74,7 @@ static auto Shockwave3DMode = options::OptionBuilder<bool>("Graphics.3DShockwave
                      .level(options::ExpertLevel::Advanced)
                      .importance(66)
                      .flags({options::OptionFlags::ForceMultiValueSelection})
+                     .parser(parse_shockwaves_func)
                      .finish();
 
 /**

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -260,44 +260,72 @@ static SCP_string skill_level_display(int value)
 	return SCP_string(Skill_level_names(value, true));
 }
 
+static void parse_skill_func()
+{
+	int value;
+	stuff_int(&value);
+
+	value -= 1; // Parse 1-5 for the skill levels but convert to our internal 0-4
+	CLAMP(value, 0, 4);
+
+	Game_skill_level = value;
+}
+
 static auto GameSkillOption __UNUSED = options::OptionBuilder<int>("Game.SkillLevel",
                      std::pair<const char*, int>{"Skill Level", 1284},
                      std::pair<const char*, int>{"The skill level for the game.", 1700})
                      .category(std::make_pair("Game", 1824))
                      .range(0, 4)
                      .level(options::ExpertLevel::Beginner)
-                     .default_val(DEFAULT_SKILL_LEVEL)
+                     .default_func([]() { return DEFAULT_SKILL_LEVEL; })
                      .bind_to(&Game_skill_level)
                      .display(skill_level_display)
                      .importance(1)
                      .flags({options::OptionFlags::RetailBuiltinOption})
+                     .parser(parse_skill_func)
                      .finish();
 
 bool Screenshake_enabled = true;
+
+static void parse_screenshake_func()
+{
+	bool enabled;
+	stuff_boolean(&enabled);
+	Screenshake_enabled = enabled;
+}
 
 auto ScreenShakeOption = options::OptionBuilder<bool>("Graphics.ScreenShake",
                      std::pair<const char*, int>{"Screen Shudder Effect", 1812}, // do xstr
                      std::pair<const char*, int>{"Toggles the screen shake effect for weapons, afterburners, and shockwaves", 1813})
                      .category(std::make_pair("Graphics", 1825))
-                     .default_val(Screenshake_enabled)
+                     .default_func([]() { return Screenshake_enabled; })
                      .level(options::ExpertLevel::Advanced)
                      .importance(55)
                      .bind_to(&Screenshake_enabled)
+                     .parser(parse_screenshake_func)
                      .finish();
 
 bool Allow_unfocused_pause = true;
 
 static SCP_string unfocused_pause_display(bool mode) { return mode ? XSTR("Yes", 1394) : XSTR("No", 1395); }
 
+static void parse_unfocused_pause_func()
+{
+	bool enabled;
+	stuff_boolean(&enabled);
+	Allow_unfocused_pause = enabled;
+}
+
 auto UnfocusedPauseOption = options::OptionBuilder<bool>("Game.UnfocusedPause",
                      std::pair<const char*, int>{"Pause If Unfocused", 1814}, // do xstr
                      std::pair<const char*, int>{"Whether or not the game automatically pauses if it loses focus", 1815})
                      .category(std::make_pair("Game", 1824))
-                     .default_val(Allow_unfocused_pause)
+                     .default_func([]() { return Allow_unfocused_pause; })
                      .level(options::ExpertLevel::Advanced)
                      .display(unfocused_pause_display) 
                      .importance(55)
                      .bind_to(&Allow_unfocused_pause)
+                     .parser(parse_unfocused_pause_func)
                      .finish();
 
 #define EXE_FNAME			("fs2.exe")


### PR DESCRIPTION
Now that default_settings.tbl is merged, this PR adds parsers to many of the in-game options so that they can be set by it. There are a few others that could probably be added in the future if anyone wants them, but these are the important ones, I think.