### PR TITLE
Fixes Debris not inheriting parent ship texture replacements

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -611,11 +611,7 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 	db->model_instance_num = hull_flag ? model_create_instance(objnum, db->model_num) : -1;
 
 	// ensure that any texture replace on parent ship gets copied to debris --wookieejedi
-	polymodel_instance* pmi_parent = model_get_instance(Objects[parent_objnum].instance);
-	polymodel_instance* pmi_debris = model_get_instance(db->model_instance_num);
-	if (pmi_parent->texture_replace != nullptr) {
-		pmi_debris->texture_replace = std::make_shared<model_texture_replace>(*pmi_parent->texture_replace);
-	}
+	model_get_instance(db->model_instance_num)->texture_replace = model_get_instance(Objects[parent_objnum].instance)->texture_replace;
 
 	// assign the network signature.  The signature will be 0 for non-hull pieces, but since that
 	// is our invalid signature, it should be okay.

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -610,6 +610,13 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 
 	db->model_instance_num = hull_flag ? model_create_instance(objnum, db->model_num) : -1;
 
+	// ensure that any texture replace on parent ship gets copied to debris --wookieejedi
+	polymodel_instance* pmi_parent = model_get_instance(Objects[parent_objnum].instance);
+	polymodel_instance* pmi_debris = model_get_instance(db->model_instance_num);
+	if (pmi_parent->texture_replace != nullptr) {
+		pmi_debris->texture_replace = std::make_shared<model_texture_replace>(*pmi_parent->texture_replace);
+	}
+
 	// assign the network signature.  The signature will be 0 for non-hull pieces, but since that
 	// is our invalid signature, it should be okay.
 	obj->net_signature = 0;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -611,7 +611,8 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 	db->model_instance_num = hull_flag ? model_create_instance(objnum, db->model_num) : -1;
 
 	// ensure that any texture replace on parent ship gets copied to debris --wookieejedi
-	model_get_instance(db->model_instance_num)->texture_replace = model_get_instance(Objects[parent_objnum].instance)->texture_replace;
+	model_get_instance(db->model_instance_num)->texture_replace =
+		model_get_instance(object_get_model_instance(&Objects[parent_objnum]))->texture_replace;
 
 	// assign the network signature.  The signature will be 0 for non-hull pieces, but since that
 	// is our invalid signature, it should be okay.

--- a/code/scripting/api/objs/modelinstance.cpp
+++ b/code/scripting/api/objs/modelinstance.cpp
@@ -203,13 +203,7 @@ ADE_VIRTVAR(Textures, l_ModelInstance, "modelinstancetextures", "Gets model inst
 		return ade_set_error(L, "o", l_ModelInstanceTextures.Set(modelinstance_h()));
 
 	if(ADE_SETTING_VAR && sh && sh->isValid()) {
-		polymodel_instance *src = sh->Get();
-		polymodel_instance *dest = dh->Get();
-
-		if (src->texture_replace != nullptr)
-		{
-			dest->texture_replace = std::make_shared<model_texture_replace>(*src->texture_replace);
-		}
+		dh->Get()->texture_replace = sh->Get()->texture_replace;
 	}
 
 	return ade_set_args(L, "o", l_ModelInstanceTextures.Set(modelinstance_h(dh->Get())));

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -885,12 +885,8 @@ ADE_VIRTVAR(Textures, l_Ship, "modelinstancetextures", "Gets ship textures", "mo
 	polymodel_instance *dest = model_get_instance(Ships[dh->objp()->instance].model_instance_num);
 
 	if(ADE_SETTING_VAR && sh && sh->isValid()) {
-		polymodel_instance *src = model_get_instance(Ships[sh->objp()->instance].model_instance_num);
-
-		if (src->texture_replace != nullptr)
-		{
-			dest->texture_replace = std::make_shared<model_texture_replace>(*src->texture_replace);
-		}
+		dest->texture_replace = model_get_instance(Ships[sh->objp()->instance].model_instance_num)->texture_replace;
+		
 	}
 
 	return ade_set_args(L, "o", l_ModelInstanceTextures.Set(modelinstance_h(dest)));


### PR DESCRIPTION
Debris chunks that use the same texture as the actual hull model are not updated when `texture-replace` methods are used. For example, a clean grey base textures that has texture replace via table or FRED is changed to red/brown. But when the ship is destroyed the debris objects are using the original lighter texture instead of the newer darker one.

#6154 provided the groundwork to fix this, but one step fell through the cracks; setting the debris hull textures to what the parent ship used.

This PR sets the debris texture replacements when debris is created to fix this (and fixes #2462).

Fix is tested and works as expected.