### PR TITLE
Add missed popup for on dialog frame and add text hook var

### DIFF
--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -950,6 +950,7 @@ int popup_do(popup_info *pi, int flags)
 					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals) ? 1 : 0;
 					return luacpp::LuaValueList{};
 					})),
+				scripting::hook_param("Text", 's', pi->raw_text),
 				scripting::hook_param("IsDeathPopup", 'b', false));
 
 			scripting::hooks::OnDialogFrame->run(paramList);
@@ -1020,10 +1021,12 @@ int popup_do_with_condition(popup_info *pi, int flags, int(*condition)())
 				scripting::hook_param("Submit", 'u', luacpp::LuaFunction::createFromStdFunction(Script_system.GetLuaSession(), [&done, &choice, pi](lua_State* L, const luacpp::LuaValueList& resolveVals) {
 					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals) ? 1 : 0;
 					return luacpp::LuaValueList{};
-					})));
+					})),
+				scripting::hook_param("Text", 's', pi->raw_text));
 
 			scripting::hooks::OnDialogFrame->run(paramList);
 			isScriptingOverride = scripting::hooks::OnDialogFrame->isOverride(paramList);
+			gr_flip();
 		}
 
 		if (!isScriptingOverride) {
@@ -1384,32 +1387,52 @@ int popup_conditional_do(int (*condition)(), const char *text)
 		game_do_state_common(gameseq_get_state());	// do stuff common to all states
 		gr_restore_screen(Popup_screen_id);
 
-		// draw one frame first
-		Popup_window.draw();
-		popup_force_draw_buttons(&Popup_info);
-		popup_draw_msg_text(&Popup_info, Popup_flags);
-		popup_draw_button_text(&Popup_info, Popup_flags);
-		gr_flip();
+		bool isScriptingOverride = false;
+		if (scripting::hooks::OnDialogFrame->isActive()) {
+			auto pi = &Popup_info;
+			auto paramList = scripting::hook_param_list(
+				scripting::hook_param("Submit", 'u', luacpp::LuaFunction::createFromStdFunction(Script_system.GetLuaSession(), [&done, &choice, pi](lua_State* L, const luacpp::LuaValueList& resolveVals) {
+					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals) ? 1 : 0;
+					return luacpp::LuaValueList{};
+					})),
+				scripting::hook_param("Text", 's', pi->raw_text));
 
-		// test the condition function or process for the window
-		if ((test = condition()) > 0) {
-			done = true;
-			choice = test;
-		} else {
-			k = Popup_window.process();						// poll for input, handle mouse
-			choice = popup_process_keys(&Popup_info, k, Popup_flags);
+			scripting::hooks::OnDialogFrame->run(paramList);
+			isScriptingOverride = scripting::hooks::OnDialogFrame->isOverride(paramList);
+			gr_flip();
+		}
 
-			if (choice != POPUP_NOCHANGE) {
+		if (!isScriptingOverride) {
+			// draw one frame first
+			Popup_window.draw();
+			popup_force_draw_buttons(&Popup_info);
+			popup_draw_msg_text(&Popup_info, Popup_flags);
+			popup_draw_button_text(&Popup_info, Popup_flags);
+			gr_flip();
+
+			// test the condition function or process for the window
+			if ((test = condition()) > 0) {
 				done = true;
-			}
-
-			if ( !done ) {
-				choice = popup_check_buttons(&Popup_info);
+				choice = test;
+			} else {
+				k = Popup_window.process(); // poll for input, handle mouse
+				choice = popup_process_keys(&Popup_info, k, Popup_flags);
 
 				if (choice != POPUP_NOCHANGE) {
 					done = true;
 				}
+
+				if (!done) {
+					choice = popup_check_buttons(&Popup_info);
+
+					if (choice != POPUP_NOCHANGE) {
+						done = true;
+					}
+				}
 			}
+		} else if ((test = condition()) > 0) {
+			done = 1;
+			choice = test;
 		}
 	}
 

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -1392,7 +1392,7 @@ int popup_conditional_do(int (*condition)(), const char *text)
 			auto pi = &Popup_info;
 			auto paramList = scripting::hook_param_list(
 				scripting::hook_param("Submit", 'u', luacpp::LuaFunction::createFromStdFunction(Script_system.GetLuaSession(), [&done, &choice, pi](lua_State* L, const luacpp::LuaValueList& resolveVals) {
-					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals) ? 1 : 0;
+					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals) ? true : false;
 					return luacpp::LuaValueList{};
 					})),
 				scripting::hook_param("Text", 's', pi->raw_text));
@@ -1431,7 +1431,7 @@ int popup_conditional_do(int (*condition)(), const char *text)
 				}
 			}
 		} else if ((test = condition()) > 0) {
-			done = 1;
+			done = true;
 			choice = test;
 		}
 	}

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -1392,7 +1392,7 @@ int popup_conditional_do(int (*condition)(), const char *text)
 			auto pi = &Popup_info;
 			auto paramList = scripting::hook_param_list(
 				scripting::hook_param("Submit", 'u', luacpp::LuaFunction::createFromStdFunction(Script_system.GetLuaSession(), [&done, &choice, pi](lua_State* L, const luacpp::LuaValueList& resolveVals) {
-					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals) ? true : false;
+					done = popup_resolve_scripting(L, choice, pi->input_text, resolveVals);
 					return luacpp::LuaValueList{};
 					})),
 				scripting::hook_param("Text", 's', pi->raw_text));

--- a/code/popup/popupdead.cpp
+++ b/code/popup/popupdead.cpp
@@ -491,6 +491,7 @@ int popupdead_do_frame(float  /*frametime*/)
 				popupdead_resolve_scripting(L, choice, resolveVals);
 				return luacpp::LuaValueList{};
 				})),
+			scripting::hook_param("Text", 's', ""), // Don't send a nil string
 			scripting::hook_param("IsDeathPopup", 'b', true),
 			scripting::hook_param("Freeze", 'b', static_cast<bool>(popup_active())));
 

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -421,7 +421,8 @@ const std::shared_ptr<OverridableHook<>> OnDialogFrame = OverridableHook<>::Fact
 	{
 		{"Submit", "function(number | string | nil result) -> nil", "A callback function that should be called if the popup resolves. Should be string only if it is an input popup. Pass nil to abort."},
 		{"IsDeathPopup", "boolean", "True if this popup is an in-mission death popup and should be styled as such."},
-		{"Freeze", "boolean", "If not nil and true, the popup should not process any inputs but just render."}
+		{"Freeze", "boolean", "If not nil and true, the popup should not process any inputs but just render."},
+		{"Text", "string", "The dialog text as it may have been updated this frame"}
 	});
 
 const std::shared_ptr<Hook<>> OnDialogClose = Hook<>::Factory("On Dialog Close",


### PR DESCRIPTION
There was one conditional popup that did not work with the `OnDialogFrame` hook and this fixes that. This one is most easily tested by going to the PXO lobby. This also adds the `Text` HV variable to `OnDialogFrame` because the text can change each frame here.

Additionally it adds `gr_flip()` to the conditional dialog frame hooks because otherwise they will never render until the hook is completed and the game renders the frame after that.