### PR TITLE
tweak object model/instance convenience functions

### DIFF
--- a/code/actions/types/MoveToSubmodel.cpp
+++ b/code/actions/types/MoveToSubmodel.cpp
@@ -26,10 +26,8 @@ ActionResult MoveToSubmodel::execute(ProgramLocals& locals) const
 	// The calling code should ensure that this never happens
 	Assertion(locals.hostSubobject >= 0, "Did not have a valid host subobject.");
 
-	auto instance = object_get_model_instance(locals.host.objp());
-	Assertion(instance != -1, "Model instances are required if a host subobject is specified.");
-
-	auto pmi = model_get_instance(instance);
+	auto pmi = object_get_model_instance(locals.host.objp());
+	Assertion(pmi != nullptr, "Model instances are required if a host subobject is specified.");
 	auto pm = model_get(pmi->model_num);
 
 	const auto destinationSubObject = m_subObjectExpression.execute(locals.variables);

--- a/code/actions/types/ParticleEffectAction.cpp
+++ b/code/actions/types/ParticleEffectAction.cpp
@@ -37,10 +37,8 @@ ActionResult ParticleEffectAction::execute(ProgramLocals& locals) const
 	vec3d local_pos;
 	matrix local_orient;
 	if (locals.hostSubobject != -1) {
-		auto instance = object_get_model_instance(locals.host.objp());
-		Assertion(instance != -1, "Model instances are required if a host subobject is specified.");
-
-		auto pmi = model_get_instance(instance);
+		auto pmi = object_get_model_instance(locals.host.objp());
+		Assertion(pmi != nullptr, "Model instances are required if a host subobject is specified.");
 		auto pm = model_get(pmi->model_num);
 
 		model_instance_local_to_global_point_orient(&local_pos,

--- a/code/actions/types/PlaySoundAction.cpp
+++ b/code/actions/types/PlaySoundAction.cpp
@@ -26,10 +26,8 @@ ActionResult PlaySoundAction::execute(ProgramLocals& locals) const
 	vec3d local_pos;
 	matrix local_orient;
 	if (locals.hostSubobject != -1) {
-		auto instance = object_get_model_instance(locals.host.objp());
-		Assertion(instance != -1, "Model instances are required if a host subobject is specified.");
-
-		auto pmi = model_get_instance(instance);
+		auto pmi = object_get_model_instance(locals.host.objp());
+		Assertion(pmi != nullptr, "Model instances are required if a host subobject is specified.");
 		auto pm = model_get(pmi->model_num);
 
 		model_instance_local_to_global_point_orient(&local_pos,

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -419,16 +419,8 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 		if(object_host.isValid())
 		{
 			object *objp = object_host.objp();
-			int model_num = object_get_model(objp);
-			polymodel *pm = nullptr;
-			polymodel_instance *pmi = nullptr;
-			
-			if(model_num >= 0)
-			{
-				pm = model_get(model_num);
-				if (objp->type == OBJ_SHIP)
-					pmi = model_get_instance(Ships[objp->instance].model_instance_num);
-			}
+			polymodel *pm = object_get_model(objp);
+			polymodel_instance *pmi = object_get_model_instance(objp);
 
 			if(object_host_submodel < 0 || pm == NULL)
 			{
@@ -483,18 +475,9 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 			if(object_target.isValid())
 			{
 				object *target_objp = object_target.objp();
-				int model_num = object_get_model(target_objp);
-				polymodel *target_pm = nullptr;
-				polymodel_instance *target_pmi = nullptr;
+				polymodel *target_pm = object_get_model(target_objp);
+				polymodel_instance *target_pmi = object_get_model_instance(target_objp);
 				vec3d target_pos = vmd_zero_vector;
-				
-				//See if we can get the model
-				if(model_num >= 0)
-				{
-					target_pm = model_get(model_num);
-					if (target_objp->type == OBJ_SHIP)
-						target_pmi = model_get_instance(Ships[target_objp->instance].model_instance_num);
-				}
 
 				//If we don't have a submodel or don't have the model use object pos
 				//Otherwise, find the submodel pos as it is rotated
@@ -1297,8 +1280,7 @@ float cam_get_bbox_dist(const object* viewer_obj, float preferred_distance, cons
 	if (preferred_distance > (viewer_obj->radius * EXTERN_CAM_BBOX_MULTIPLIER_PADDING + EXTERN_CAM_BBOX_CONSTANT_PADDING) * 1.5f) 
 		return preferred_distance;
 	
-	int modelnum = object_get_model(viewer_obj);
-	polymodel* pm = model_get(modelnum);
+	polymodel* pm = object_get_model(viewer_obj);
 	vec3d adjusted_bbox;
 	const vec3d* cam_vec = &cam_orient->vec.fvec;
 

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -611,8 +611,9 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 	db->model_instance_num = hull_flag ? model_create_instance(objnum, db->model_num) : -1;
 
 	// ensure that any texture replace on parent ship gets copied to debris --wookieejedi
-	if (db->model_instance_num >= 0 && parent_objnum >= 0)
-		model_get_instance(db->model_instance_num)->texture_replace = model_get_instance(object_get_model_instance(&Objects[parent_objnum]))->texture_replace;
+	int parent_model_instance_num;
+	if ((db->model_instance_num >= 0) && (parent_objnum >= 0) && ((parent_model_instance_num = object_get_model_instance_num(&Objects[parent_objnum])) >= 0))
+		model_get_instance(db->model_instance_num)->texture_replace = model_get_instance(parent_model_instance_num)->texture_replace;
 
 	// assign the network signature.  The signature will be 0 for non-hull pieces, but since that
 	// is our invalid signature, it should be okay.

--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -246,7 +246,7 @@ struct Decal {
 			auto shipp = &Ships[objp->instance];
 			auto model_instance = model_get_instance(shipp->model_instance_num);
 
-			Assertion(submodel >= 0 && submodel < model_get(object_get_model(objp))->n_models,
+			Assertion(submodel >= 0 && submodel < object_get_model(objp)->n_models,
 					  "Invalid submodel number detected!");
 			auto smi = &model_instance->submodel[submodel];
 

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -908,7 +908,7 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 			hud_target_lod		= homing_sip->hud_target_lod;
 		}
 
-		int pmi_id = object_get_model_instance(viewed_obj);
+		int pmi_id = object_get_model_instance_num(viewed_obj);
 		if (pmi_id >= 0)
 			replacement_textures = model_get_instance(pmi_id)->texture_replace;
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5126,7 +5126,7 @@ void model_do_intrinsic_motions(object *objp)
 	// we are handling a specific object
 	if (objp)
 	{
-		int model_instance_num = object_get_model_instance(objp);
+		int model_instance_num = object_get_model_instance_num(objp);
 		if (model_instance_num >= 0)
 		{
 			auto obj_it = Intrinsic_motions.find(model_instance_num);

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2731,7 +2731,7 @@ void model_render_queue(const model_render_params* interp, model_draw_list* scen
 			tentative_num = shipp->model_instance_num;
 		}
 		else {
-			tentative_num = object_get_model_instance(objp);
+			tentative_num = object_get_model_instance_num(objp);
 		}
 
 		if (tentative_num >= 0) {
@@ -3033,7 +3033,7 @@ void model_render_only_glowpoint_lights(const model_render_params* interp, int m
 			tentative_num = shipp->model_instance_num;
 		}
 		else {
-			tentative_num = object_get_model_instance(objp);
+			tentative_num = object_get_model_instance_num(objp);
 		}
 
 		if (tentative_num >= 0) {

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8079,8 +8079,8 @@ void process_animation_triggered_packet(ubyte* data, header* hinfo) {
 	if (animation != animation::ModelAnimationSet::s_animationById.end()) {
 		if (special_mode == 0) {
 			//with the above exit condition, this guarantees a non-null objp
-			int model_instance_num = object_get_model_instance(objp);
-			if(model_instance_num > -1)
+			int model_instance_num = object_get_model_instance_num(objp);
+			if (model_instance_num >= 0)
 				animation->second->start(model_get_instance(model_instance_num), direction, forced, instant, pause, &delay);
 		}
 		else {

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1601,8 +1601,8 @@ void obj_move_all(float frametime)
 			ship_move_subsystems(objp);
 
 		// do animation on this object
-		int model_instance_num = object_get_model_instance(objp);
-		if (model_instance_num > -1) {
+		int model_instance_num = object_get_model_instance_num(objp);
+		if (model_instance_num >= 0) {
 			polymodel_instance* pmi = model_get_instance(model_instance_num);
 			animation::ModelAnimation::stepAnimations(frametime, pmi);
 		}
@@ -2046,9 +2046,9 @@ int obj_get_by_signature(int sig)
 }
 
 /**
- * Gets object model
+ * Gets the model number for this object, or -1 if none
  */
-int object_get_model(const object *objp)
+int object_get_model_num(const object *objp)
 {
 	switch(objp->type)
 	{
@@ -2079,7 +2079,19 @@ int object_get_model(const object *objp)
 	return -1;
 }
 
-int object_get_model_instance(const object *objp)
+/**
+ * Gets the model for this object, or nullptr if none
+ */
+polymodel *object_get_model(const object *objp)
+{
+	int model_num = object_get_model_num(objp);
+	return model_num >= 0 ? model_get(model_num) : nullptr;
+}
+
+/**
+ * Gets the model instance number for this object, or -1 if none
+ */
+int object_get_model_instance_num(const object *objp)
 {
 	if (objp == nullptr)
 		return -1;
@@ -2117,6 +2129,15 @@ int object_get_model_instance(const object *objp)
 	}
 
 	return -1;
+}
+
+/**
+ * Gets the model instance for this object, or nullptr if none
+ */
+polymodel_instance *object_get_model_instance(const object *objp)
+{
+	int model_instance_num = object_get_model_instance_num(objp);
+	return model_instance_num >= 0 ? model_get_instance(model_instance_num) : nullptr;
 }
 
 bool obj_compare(object* left, object* right) {

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -15,7 +15,6 @@
 #include "globalincs/globals.h"
 #include "globalincs/pstypes.h"
 #include "math/vecmat.h"
-#include "object/object.h"
 #include "object/object_flags.h"
 #include "physics/physics.h"
 #include "physics/physics_state.h"
@@ -122,6 +121,8 @@ extern const int Num_object_flag_names;
 
 struct dock_instance;
 class model_draw_list;
+class polymodel;
+struct polymodel_instance;
 
 class object
 {
@@ -356,8 +357,11 @@ void object_set_gliding(object *objp, bool enable=true, bool force = false);
 bool object_get_gliding(object *objp);
 bool object_glide_forced(object* objp);
 int obj_get_by_signature(int sig);
-int object_get_model(const object *objp);
-int object_get_model_instance(const object *objp);
+
+int object_get_model_num(const object *objp);
+polymodel *object_get_model(const object *objp);
+int object_get_model_instance_num(const object *objp);
+polymodel_instance *object_get_model_instance(const object *objp);
 
 void obj_render_queue_all();
 

--- a/code/object/objectdock.cpp
+++ b/code/object/objectdock.cpp
@@ -633,13 +633,11 @@ void dock_check_find_docked_object_helper(object *objp, dock_function_info *info
 
 void dock_calc_docked_mins_maxs_helper(object *objp, dock_function_info *infop)
 {
-	polymodel *pm;
 	vec3d parent_relative_mins, parent_relative_maxs;
 
 	// find the model used by this object
-	int modelnum = object_get_model(objp);
-	Assert(modelnum >= 0);
-	pm = model_get(modelnum);
+	auto pm = object_get_model(objp);
+	Assert(pm);
 
 	// special case: we are already in the correct frame of reference
 	if (objp == infop->parameter_variables.objp_value)

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -224,7 +224,7 @@ ADE_VIRTVAR(ModelInstance, l_Object, nullptr, "model instance used by this objec
 	if (ADE_SETTING_VAR)
 		LuaError(L, "Assigning model instances is not implemented");
 
-	int id = object_get_model_instance(objh->objp());
+	int id = object_get_model_instance_num(objh->objp());
 	if (id < 0)
 		return ADE_RETURN_NIL;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -18744,7 +18744,7 @@ void ship_page_in()
 		// is this a valid ship?
 		if (Ships[i].objnum >= 0)
 		{
-			polymodel_instance* pmi = model_get_instance(object_get_model_instance(&Objects[Ships[i].objnum]));
+			polymodel_instance* pmi = object_get_model_instance(&Objects[Ships[i].objnum]);
 			// do we have any textures?
 			if (pmi->texture_replace != nullptr)
 			{

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7440,7 +7440,6 @@ int weapon_area_calc_damage(const object *objp, const vec3d *pos, float inner_ra
 void weapon_area_apply_blast(const vec3d * /*force_apply_pos*/, object *objp, const vec3d *blast_pos, float blast, bool make_shockwave)
 {
 	vec3d		force, vec_blast_to_ship, vec_ship_to_impact;
-	polymodel		*pm;
 
 	Assertion(objp->type == OBJ_SHIP || objp->type == OBJ_ASTEROID || objp->type == OBJ_DEBRIS, "weapon_area_apply_blast can only be called on ships, asteroids, or debris");
 	if (!(objp->type == OBJ_SHIP || objp->type == OBJ_ASTEROID || objp->type == OBJ_DEBRIS))
@@ -7457,8 +7456,7 @@ void weapon_area_apply_blast(const vec3d * /*force_apply_pos*/, object *objp, co
 
 	vm_vec_sub(&vec_ship_to_impact, blast_pos, &objp->pos);
 
-	int model_num = object_get_model(objp);
-	pm = model_get(model_num);
+	auto pm = object_get_model(objp);
 	Assert ( pm != NULL );
 	if (!pm)
 		return;


### PR DESCRIPTION
Make these convenient functions even more convenient:
1. Change `object_get_model()` to `object_get_model_num()` and `object_get_model_instance()` to `object_get_model_instance_num()` to more accurately reflect what they do
2. Add new `object_get_model()` and `object_get_model_instance()` functions to return `polymodel*` and `polymodel_instance*` values.