### PR TITLE
fix event editor modification check

### DIFF
--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -43,6 +43,21 @@ event_editor *Event_editor_dlg = NULL; // global reference needed by event tree 
 // this is just useful for comparing modified EAs to unmodified ones
 static event_annotation default_ea;
 
+int safe_stricmp(const char* one, const char* two)
+{
+	if (!one && !two)
+		return 0;
+
+	if (!one)
+		return -1;
+
+	if (!two)
+		return 1;
+
+	return stricmp(one, two);
+}
+
+
 /////////////////////////////////////////////////////////////////////////////
 // event_editor dialog
 
@@ -448,17 +463,15 @@ void event_editor::OnOK()
 
 int event_editor::query_modified()
 {
-	int i;
-	char *ptr, buf[MESSAGE_LENGTH];
-
 	UpdateData(TRUE);
+
 	if (modified)
 		return 1;
 
 	if (Mission_events.size() != m_events.size())
 		return 1;
 
-	for (i=0; i<(int)m_events.size(); i++) {
+	for (size_t i = 0; i < m_events.size(); ++i) {
 		if (!lcase_equal(m_events[i].name, Mission_events[i].name))
 			return 1;
 		if (m_events[i].repeat_count != Mission_events[i].repeat_count)
@@ -481,46 +494,29 @@ int event_editor::query_modified()
 			return 1;
 	}
 
-	if (m_cur_msg < 0)
-		return 0;
-
-	if ((int)m_messages.size() != Num_messages - Num_builtin_messages)
+	if (static_cast<int>(m_messages.size()) != Num_messages - Num_builtin_messages) {
 		return 1;
-
-	ptr = (char *) (LPCTSTR) m_message_name;
-	for (i=0; i<Num_builtin_messages; i++)
-		if (!stricmp(ptr, Messages[i].name))
-			return 1;
-
-	for (i=0; i<(int)m_messages.size(); i++) {
-
-		if ((i != m_cur_msg) && (!stricmp(ptr, m_messages[m_cur_msg].name)))
-			return 1;
 	}
 
-	if (stricmp(ptr, m_messages[m_cur_msg].name))
-		return 1;  // name is different and allowed to update
+	for (size_t i = 0; i < m_messages.size(); ++i) {
+		auto& local = m_messages[i];
+		auto& ref = Messages[Num_builtin_messages + i];
 
-	string_copy(buf, m_message_text, MESSAGE_LENGTH - 1);
-	if (stricmp(buf, m_messages[m_cur_msg].message))
-		return 1;
-
-	string_copy(buf, m_message_note, MESSAGE_LENGTH - 1);
-	if (stricmp(buf, m_messages[m_cur_msg].note.c_str()))
-		return 1;
-
-	ptr = (char *) (LPCTSTR) m_avi_filename;
-	if (advanced_stricmp(ptr, m_messages[m_cur_msg].avi_info.name))
-		return 1;
-
-	ptr = (char *) (LPCTSTR) m_wave_filename;
-	if (advanced_stricmp(ptr, m_messages[m_cur_msg].wave_info.name))
-		return 1;
-
-	// check to see if persona changed.  use -1 since we stuck a "None" for persona
-	// at the beginning of the list.
-	if ( (m_persona - 1 ) != m_messages[m_cur_msg].persona_index )
-		return 1;
+		if (stricmp(local.name, ref.name) != 0)
+			return 1;
+		if (stricmp(local.message, ref.message) != 0)
+			return 1;
+		if (!lcase_equal(local.note, ref.note))
+			return 1;
+		if (local.persona_index != ref.persona_index)
+			return 1;
+		if (local.multi_team != ref.multi_team)
+			return 1;
+		if (safe_stricmp(local.avi_info.name, ref.avi_info.name) != 0)
+			return 1;
+		if (safe_stricmp(local.wave_info.name, ref.avi_info.name) != 0)
+			return 1;
+	}
 
 	return 0;
 }

--- a/qtfred/src/ui/dialogs/EventEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/EventEditorDialog.cpp
@@ -674,7 +674,7 @@ bool EventEditorDialog::query_modified() {
 		return true;
 	}
 
-	for (auto i = 0; i < (int)m_events.size(); i++) {
+	for (size_t i = 0; i < m_events.size(); ++i) {
 		if (!lcase_equal(m_events[i].name, Mission_events[i].name)) {
 			return true;
 		}
@@ -699,23 +699,29 @@ bool EventEditorDialog::query_modified() {
 		if (!lcase_equal(m_events[i].objective_key_text, Mission_events[i].objective_key_text)) {
 			return true;
 		}
+		if (m_events[i].flags != Mission_events[i].flags) {
+			return true;
+		}
 		if (m_events[i].mission_log_flags != Mission_events[i].mission_log_flags) {
 			return true;
 		}
 	}
 
-	if ((int)m_messages.size() != Num_messages - Num_builtin_messages) {
+	if (static_cast<int>(m_messages.size()) != Num_messages - Num_builtin_messages) {
 		return true;
 	}
 
-	for (auto i = 0; i < (int)m_messages.size(); ++i) {
+	for (size_t i = 0; i < m_messages.size(); ++i) {
 		auto& local = m_messages[i];
-		auto& ref = Messages[i];
+		auto& ref = Messages[Num_builtin_messages + i];
 
 		if (stricmp(local.name, ref.name) != 0) {
 			return true;
 		}
 		if (stricmp(local.message, ref.message) != 0) {
+			return true;
+		}
+		if (!lcase_equal(local.note, ref.note)) {
 			return true;
 		}
 		if (local.persona_index != ref.persona_index) {
@@ -724,10 +730,10 @@ bool EventEditorDialog::query_modified() {
 		if (local.multi_team != ref.multi_team) {
 			return true;
 		}
-		if (safe_stricmp(local.avi_info.name, ref.avi_info.name)) {
+		if (safe_stricmp(local.avi_info.name, ref.avi_info.name) != 0) {
 			return true;
 		}
-		if (safe_stricmp(local.wave_info.name, ref.avi_info.name)) {
+		if (safe_stricmp(local.wave_info.name, ref.avi_info.name) != 0) {
 			return true;
 		}
 	}


### PR DESCRIPTION
The `query_modified()` function in FRED did not correctly check whether messages were modified, although interestingly, it did so in qtFRED.  Even in qtFRED, there were a few minor omissions.  Overall, this fixes FRED and syncs up the FRED and qtFRED versions.

Fixes #6528.