### PR TITLE
Mission goals hook

### DIFF
--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -33,6 +33,7 @@
 #include "parse/parselo.h"
 #include "parse/sexp.h"
 #include "playerman/player.h"
+#include "scripting/global_hooks.h"
 #include "tracing/tracing.h"
 #include "ui/ui.h"
 
@@ -739,27 +740,46 @@ void mission_goal_status_change( int goal_num, int new_status)
 	}
 
 	type = Mission_goals[goal_num].type & GOAL_TYPE_MASK;
+
+	bool isOverride = false;
+
+	if (scripting::hooks::OnMissionObjectivesChanged->isActive()) {
+		auto paramList = scripting::hook_param_list(scripting::hook_param("Name", 's', Mission_goals[goal_num].name),
+			scripting::hook_param("Description", 's', Mission_goals[goal_num].message),
+			scripting::hook_param("Type", 'i', type + 1),
+			scripting::hook_param("State", 'b', new_status == GOAL_COMPLETE));
+		if (scripting::hooks::OnMissionObjectivesChanged->isOverride(paramList)) {
+			isOverride = true; // Override here only prevents displaying the goals and playing the music. Everything
+							   // else still runs.
+		}
+		scripting::hooks::OnMissionObjectivesChanged->run(paramList);
+	}
+
 	Mission_goals[goal_num].satisfied = new_status;
 	if ( new_status == GOAL_FAILED ) {
 		// don't display bonus goal failure
-		if ( type != BONUS_GOAL ) {
+		if (type != BONUS_GOAL ) {
 
-			// only do HUD and music is goals are my teams goals.
+			// only do HUD and music if goals are my teams goals.
 			if ( (Game_mode & GM_NORMAL) || ((Net_player != NULL) && (Net_player->p_info.team == Mission_goals[goal_num].team)) ) {
-				hud_add_objective_messsage(type, new_status);
-				if ( !( Mission_goals[goal_num].flags & MGF_NO_MUSIC ) ) {	// maybe play event music
-					event_music_primary_goal_failed();
+				if (!isOverride) {
+					hud_add_objective_messsage(type, new_status);
+					if (!(Mission_goals[goal_num].flags & MGF_NO_MUSIC)) { // maybe play event music
+						event_music_primary_goal_failed();
+					}
 				}
 			}
 		}
 		mission_log_add_entry( LOG_GOAL_FAILED, Mission_goals[goal_num].name.c_str(), nullptr, goal_num );
 	} else if ( new_status == GOAL_COMPLETE ) {
 		if ( (Game_mode & GM_NORMAL) || ((Net_player != NULL) && (Net_player->p_info.team == Mission_goals[goal_num].team))) {
-			hud_add_objective_messsage(type, new_status);
-			// cue for Event Music
-			if ( !(Mission_goals[goal_num].flags & MGF_NO_MUSIC) ) {
-				event_music_primary_goals_met();
-			}			
+			if (!isOverride) {
+				hud_add_objective_messsage(type, new_status);
+				// cue for Event Music
+				if (!(Mission_goals[goal_num].flags & MGF_NO_MUSIC)) {
+					event_music_primary_goals_met();
+				}
+			}
 			mission_log_add_entry( LOG_GOAL_SATISFIED, Mission_goals[goal_num].name.c_str(), nullptr, goal_num );
 		}	
 		

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -743,16 +743,16 @@ void mission_goal_status_change( int goal_num, int new_status)
 
 	bool isOverride = false;
 
-	if (scripting::hooks::OnMissionObjectivesChanged->isActive()) {
+	if (scripting::hooks::OnMissionGoalStatusChanged->isActive()) {
 		auto paramList = scripting::hook_param_list(scripting::hook_param("Name", 's', Mission_goals[goal_num].name),
 			scripting::hook_param("Description", 's', Mission_goals[goal_num].message),
 			scripting::hook_param("Type", 'i', type + 1),
 			scripting::hook_param("State", 'b', new_status == GOAL_COMPLETE));
-		if (scripting::hooks::OnMissionObjectivesChanged->isOverride(paramList)) {
+		if (scripting::hooks::OnMissionGoalStatusChanged->isOverride(paramList)) {
 			isOverride = true; // Override here only prevents displaying the goals and playing the music. Everything
 							   // else still runs.
 		}
-		scripting::hooks::OnMissionObjectivesChanged->run(paramList);
+		scripting::hooks::OnMissionGoalStatusChanged->run(paramList);
 	}
 
 	Mission_goals[goal_num].satisfied = new_status;

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -437,8 +437,8 @@ const std::shared_ptr<Hook<>> OnCheat = Hook<>::Factory("On Cheat",
 		{ "Cheat", "string", "The cheat code the user typed" },
 	});
 
-const std::shared_ptr<OverridableHook<>> OnMissionObjectivesChanged = scripting::OverridableHook<>::Factory(
-	"On Mission Objectives Changed", "Called when a goal is marked as failed or completed.",
+const std::shared_ptr<OverridableHook<>> OnMissionGoalStatusChanged = scripting::OverridableHook<>::Factory(
+	"On Mission Goal Status Changed", "Called when a goal is marked as failed or completed.",
 	{
 		{"Name", "string", "The name of the objective."},
 		{"Description", "string", "The description of the objective."},

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -440,9 +440,9 @@ const std::shared_ptr<Hook<>> OnCheat = Hook<>::Factory("On Cheat",
 const std::shared_ptr<OverridableHook<>> OnMissionGoalStatusChanged = scripting::OverridableHook<>::Factory(
 	"On Mission Goal Status Changed", "Called when a goal is marked as failed or completed.",
 	{
-		{"Name", "string", "The name of the objective."},
-		{"Description", "string", "The description of the objective."},
-		{"Type", "number", "The Objective type. 1 for Primary, 2 for secondary, 3 for bonus."},
+		{"Name", "string", "The name of the goal."},
+		{"Description", "string", "The description of the goal."},
+		{"Type", "number", "The goal type. 1 for Primary, 2 for secondary, 3 for bonus."},
 		{"State", "boolean", "True if the goal was completed, false if it was failed."},
 	});
 

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -437,6 +437,15 @@ const std::shared_ptr<Hook<>> OnCheat = Hook<>::Factory("On Cheat",
 		{ "Cheat", "string", "The cheat code the user typed" },
 	});
 
+const std::shared_ptr<OverridableHook<>> OnMissionObjectivesChanged = scripting::OverridableHook<>::Factory(
+	"On Mission Objectives Changed", "Called when a goal is marked as failed or completed.",
+	{
+		{"Name", "string", "The name of the objective."},
+		{"Description", "string", "The description of the objective."},
+		{"Type", "number", "The Objective type. 1 for Primary, 2 for secondary, 3 for bonus."},
+		{"State", "boolean", "True if the goal was completed, false if it was failed."},
+	});
+
 const std::shared_ptr<Hook<>> OnMissionAboutToEndHook = Hook<>::Factory("On Mission About To End",
 	"Called when a mission is about to end but has not run any mission-ending logic",
 	{});

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -81,6 +81,8 @@ extern const std::shared_ptr<Hook<>>									OnDialogClose;
 
 extern const std::shared_ptr<Hook<>>									OnCheat;
 
+extern const std::shared_ptr<OverridableHook<>>                         OnMissionObjectivesChanged;
+
 extern const std::shared_ptr<Hook<>>									OnMissionAboutToEndHook;
 extern const std::shared_ptr<OverridableHook<>>							OnMissionEndHook;
 extern const std::shared_ptr<Hook<>>									OnStateAboutToEndHook;

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -81,7 +81,7 @@ extern const std::shared_ptr<Hook<>>									OnDialogClose;
 
 extern const std::shared_ptr<Hook<>>									OnCheat;
 
-extern const std::shared_ptr<OverridableHook<>>                         OnMissionObjectivesChanged;
+extern const std::shared_ptr<OverridableHook<>>                         OnMissionGoalStatusChanged;
 
 extern const std::shared_ptr<Hook<>>									OnMissionAboutToEndHook;
 extern const std::shared_ptr<OverridableHook<>>							OnMissionEndHook;


### PR DESCRIPTION
Adds an overridable On Mission Objectives Changed hook that runs when an objective is failed or completed. Overriding the hook only overrides display and music methods. The objective state still gets added to the mission log and all background logic continues.