### PR TITLE
Ensure that Ext Game Popup sends Affirmative and Negative Flags

### DIFF
--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -695,7 +695,7 @@ void main_hall_exit_game()
 	// stop music first
 	main_hall_stop_music(true);
 	main_hall_stop_ambient();
-	choice = popup( PF_NO_NETWORKING | PF_BODY_BIG, 2, POPUP_NO, POPUP_YES, XSTR( "Exit Game?", 365));
+	choice = popup( PF_NO_NETWORKING | PF_BODY_BIG | PF_USE_NEGATIVE_ICON | PF_USE_AFFIRMATIVE_ICON, 2, POPUP_NO, POPUP_YES, XSTR( "Exit Game?", 365));
 	if (choice == 1) {
 		gameseq_post_event(GS_EVENT_QUIT_GAME);
 	} else {


### PR DESCRIPTION
`On Dialog Start` (used in SCPUI and within `popup_init`) reads popup options by affirmative or negative flags, and the popup for exiting the Mainhall did not set these flags. Notably, most popups that use `POPUP_NO` or `POPUP_YES`  already, so this PR sets those flags for this popup. Now `On Dialog Start` within `popup_init` has access to the correct flags.

PR tested and works as expected, both in retail UI and SCPUI