### PR TITLE
Fix more Popup Button Alignments

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1320,7 +1320,7 @@ bool control_config_accept(bool API_Access)
 			});
 
 			if (it != Control_config_presets.end()) {
-				popup(flags, 1, POPUP_OK, "You may not overwrite a default preset.  Please choose another name.");
+				popup(flags | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "You may not overwrite a default preset.  Please choose another name.");
 				goto retry;
 			}
 

--- a/code/controlconfig/presets.cpp
+++ b/code/controlconfig/presets.cpp
@@ -136,7 +136,7 @@ void load_preset_files(SCP_string clone) {
 
 		} else if ((it->name != preset.name) || (it->type != Preset_t::pst)) {
 			if (gameseq_get_state() == GS_STATE_CONTROL_CONFIG) {
-				popup(PF_TITLE_WHITE, 1, POPUP_OK, "Preset '%s' is a duplicate of an existing preset, ignoring", preset.name.c_str());
+				popup(PF_TITLE_WHITE | PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "Preset '%s' is a duplicate of an existing preset, ignoring", preset.name.c_str());
 			} else {
 				// Complain and ignore if the preset names or the type differs
 				Warning(LOCATION, "PST => Preset '%s' is a duplicate of an existing preset, ignoring", preset.name.c_str());


### PR DESCRIPTION
There were 2 popup dialogs that were missing an `Affirmative` flag, which mean the button was not in the right position and thus showed a visual misalignment. This PR fixes that and in tests works as expected. Follow up to #6502 .