### PR TITLE
A flag that checks if set-camera-host sexp should use the model's eyepoint for the camera position when no submodel is specified

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -314,6 +314,24 @@ void camera::set_rotation_facing(vec3d *in_target, float in_rotation_time, float
 		matrix orient_buf;
 		matrix *orient = nullptr;
 
+		if (Use_model_eyepoint_for_set_camera_facing) {
+			if (object_host.isValid()) {
+				object* host = object_host.objp();
+
+				if (host->type == OBJ_SHIP) {
+					ship_info* sip;
+					polymodel* pm;
+
+					ship* shipmodel = &Ships[host->instance];
+					sip = &Ship_info[shipmodel->ship_info_index];
+					pm = model_get(sip->model_num);
+					const eye& eyepoint = pm->view_positions[shipmodel->current_viewpoint];
+
+					model_instance_local_to_global_point(&position, &eyepoint.pnt, shipmodel->model_instance_num, eyepoint.parent, &host->orient, &host->pos);
+				}
+			}
+		}
+
 		if (Use_host_orientation_for_set_camera_facing)
 		{
 			// we want to retrieve the camera's orientation, so provide a buffer for it

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -34,6 +34,7 @@ bool Cutscene_camera_displays_hud;
 bool Alternate_chaining_behavior;
 bool Fixed_chaining_to_repeat;
 bool Use_host_orientation_for_set_camera_facing;
+bool Use_model_eyepoint_for_set_camera_facing;
 bool Use_3d_ship_select;
 bool Use_3d_ship_icons;
 bool Use_3d_weapon_select;
@@ -500,6 +501,12 @@ void parse_mod_table(const char *filename)
 				} else {
 					mprintf(("Game Settings Table: Using identity orientation for set-camera-facing\n"));
 				}
+			}
+
+			if (optional_string("$Use model eyepoint for set-camera-facing:")) {
+				stuff_boolean(&Use_model_eyepoint_for_set_camera_facing);
+				if (Use_model_eyepoint_for_set_camera_facing) {
+					mprintf(("Game Settings Table: Using model eyepoint for set-camera-facing\n"));
 			}
 
 			if (optional_string("$Show-subtitle uses pixels:")) {
@@ -1527,6 +1534,7 @@ void mod_table_reset()
 	Alternate_chaining_behavior = false;
 	Fixed_chaining_to_repeat = false;
 	Use_host_orientation_for_set_camera_facing = false;
+	Use_model_eyepoint_for_set_camera_facing = false;
 	Default_ship_select_effect = 2;
 	Default_weapon_select_effect = 2;
 	Default_overhead_ship_style = OH_TOP_VIEW;
@@ -1667,6 +1675,7 @@ void mod_table_set_version_flags()
 		Shockwaves_damage_all_obj_types_once = true;
 		Framerate_independent_turning = true;					// this is already true, but let's re-emphasize it
 		Use_host_orientation_for_set_camera_facing = true;		// this is essentially a bugfix
+		Use_model_eyepoint_for_set_camera_facing = true;
 	}
 	if (mod_supports_version(23, 0, 0)) {
 		Shockwaves_inherit_parent_damage_type = true;	// people intuitively expect shockwaves to default to the damage type of the weapon that spawned them

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -42,6 +42,7 @@ extern bool Cutscene_camera_displays_hud;
 extern bool Alternate_chaining_behavior;
 extern bool Fixed_chaining_to_repeat;
 extern bool Use_host_orientation_for_set_camera_facing;
+extern bool Use_model_eyepoint_for_set_camera_facing;
 extern bool Use_3d_ship_select;
 extern int Default_ship_select_effect;
 extern bool Use_3d_ship_icons;


### PR DESCRIPTION
For https://github.com/scp-fs2open/fs2open.github.com/issues/6509