### PR TITLE
Cleanup few In-game Defaults

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1296,7 +1296,7 @@ bool control_config_accept(bool API_Access)
 		retry:;
 			SCP_string default_string = (Current_preset_name.empty()) ? Player->callsign : Current_preset_name;
 			cstr = popup_input(flags,
-				"Confirm new custom preset name.\n\nThe name must not be empty.\n\n Press [Enter] to accept, [Esc] to "
+				"Confirm new custom preset name.\n\nThe name must not be empty or a default preset.\n\n Press [Enter] to accept, [Esc] to "
 				"abort to config menu.",
 				32 - 6,
 				default_string.c_str());

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -232,7 +232,7 @@ static bool mode_change_func(os::ViewportState state, bool initial)
 	return true;
 }
 
-/*static void parse_window_mode_func()
+static void parse_window_mode_func()
 {
 	SCP_string value;
 	stuff_string(value, F_NAME);
@@ -245,11 +245,8 @@ static bool mode_change_func(os::ViewportState state, bool initial)
 	} else {
 		error_display(0, "%s is an invalide window mode", value.c_str());
 	}
-}*/
+}
 
-// Window mode can support default settings but I'm not sure if there would
-// ever be a reason to and this should probably remain a user-only setting
-// similar to other graphics hardware settings
 static auto WindowModeOption __UNUSED = options::OptionBuilder<os::ViewportState>("Graphics.WindowMode",
                      std::pair<const char*, int>{"Window Mode", 1772},
                      std::pair<const char*, int>{"Controls how the game window is created", 1773})
@@ -261,7 +258,7 @@ static auto WindowModeOption __UNUSED = options::OptionBuilder<os::ViewportState
                      .importance(98)
                      .default_func([]() { return Gr_configured_window_state; })
                      .change_listener(mode_change_func)
-                     //.parser(parse_window_mode_func)
+                     .parser(parse_window_mode_func)
                      .finish();
 
 const std::shared_ptr<scripting::OverridableHook<>> OnFrameHook = scripting::OverridableHook<>::Factory(
@@ -603,7 +600,7 @@ static void parse_msaa_func()
 		{"off", 0},
 		{"4 samples", 4},
 		{"8 samples", 8},
-		{"16 samples", 16},
+		//{"16 samples", 16},
 	};
 
 	// Look up the value in the map
@@ -622,8 +619,7 @@ static auto MSAAOption __UNUSED = options::OptionBuilder<int>("Graphics.MSAASamp
                      .level(options::ExpertLevel::Advanced)
                      .values({{0, {"Off", 1693}},
                               {4, {"4 Samples", 1694}},
-                              {8, {"8 Samples", 1695}},
-                              {16, {"16 Samples", 1696}}})
+                              {8, {"8 Samples", 1695}}})
                      .default_func([]() { return Cmdline_msaa_enabled; } )
                      .bind_to_once(&Cmdline_msaa_enabled)
                      .importance(78)

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -57,7 +57,7 @@ static auto TextureFilteringOption __UNUSED = options::OptionBuilder<int>("Graph
                      .importance(1)
                      .category(std::make_pair("Graphics", 1825))
                      .values(TextureFilteringValues)
-                     .default_val(0)
+                     .default_val(1)
                      .bind_to_once(&GL_mipmap_filter)
                      .flags({options::OptionFlags::ForceMultiValueSelection})
                      .finish();


### PR DESCRIPTION
This PR does a few very minor but useful cleanups to defaults. (Alas, a lot of text for very simple PR)

1) In Controls Config, the text asking users to type a new preset name specifies early on that the name should not be a default preset (this is just an extra 4 works in the string message, but useful and still easily fits in the box).

2) Allows the new `default_settings.tbl` to parse `WindowMode`. Overall this just means mods can set defaults for windowmode themselves if using the new in-game options and the new `default_settings.tbl`. This option was previously commented out, but it was found quite useful to have it actually be accessible to modders.

3) Set the defaults for the new in-game options to Trilinear instead of Bilinear and do now allow the MSAA to be 16x since even on powerful machines that 16x value makes missions nearly single FPS. (Note, this 16x value was added when the new-ish MSAA feature as added, and as such had note hit these large scale testings yet, so this is mainly a tuneup).