### PR TITLE
Build in the common z load first methods and forwarders

### DIFF
--- a/code/def_files/data/scripts/cfile_include.lua
+++ b/code/def_files/data/scripts/cfile_include.lua
@@ -1,0 +1,78 @@
+-- A version of include for lua. Originally written by Nuke
+
+local chunck_cache = {}
+--- function to load and run lua files
+-- takes string filename and boolean cacheonly
+-- cfile will try to find filename in all accesible locations and load it only if it hasnt done so already
+-- if cacheonly flag is set, code will be cached but not executed, good for inits. however it is ignored when calling an already cached chunk.
+-- returns true on success or nil on failure to find/load file
+function execute_lua_file(filename, cacheonly)
+    --dont reload chunks from file if they have already been loaded. because faster == better
+    if (type(chunck_cache[filename]) == "table" and type(chunck_cache[filename][1]) == "function") then
+        if (not chunck_cache[filename][2] and not chunck_cache[filename][3]) then
+            chunck_cache[filename][2] = true
+            local val, err = pcall(chunck_cache[filename][1])
+            if (err) then
+                -- Add an boolean to indicate that this function has caused an error
+                chunck_cache[filename][3] = true
+
+                return false, string.format("Error while executing external lua file %q:\n%s", filename, err)
+            end
+            return true
+        else
+            return false
+        end
+    else
+        if (cf.fileExists(filename, "", true)) then
+            --open the file
+            local file = cf.openFile(filename, "r", "")
+            local fstring = file:read("*a") --load it all into a string
+            file:close()
+            if (fstring and type(fstring) == "string") then
+                --use the string as a code chunk and convert it to function
+                local func, error = loadstring(fstring, filename)
+                if (not func) then -- Compile error
+                    return false, string.format("Error while processing file %q. Errormessage:\n%s", filename, error)
+                end
+                chunck_cache[filename] = {}
+                chunck_cache[filename][1] = func
+                chunck_cache[filename][2] = false
+                --maybe execute
+                if (not cacheonly) then
+                    chunck_cache[filename][2] = true
+                    local val, err = xpcall(chunck_cache[filename][1], function(err)
+                    -- Add an boolean to indicate that this function has caused an error
+                        chunck_cache[filename][3] = true
+
+                        return string.format("Error while executing external lua file %q:\n%s\n\n%s", filename, err, debug.traceback())
+                    end)
+
+                    if (err) then
+                        return false, err
+                    end
+                end
+                return true
+            end
+        else
+            return false, string.format("Couldn't find external lua file %q!", filename)
+        end
+    end
+end
+
+
+
+function include(fileName)
+    if (fileName == nil) then
+        stackErrorf("Invalid argument for 'include'!")
+    else
+        if (not fileName:ends(".lua")) then
+             fileName = fileName .. ".lua"
+        end
+
+        local succ, err = execute_lua_file(fileName)
+
+        if (not succ and err) then
+           error(err)
+        end
+    end
+end

--- a/code/def_files/data/scripts/cfile_include.lua
+++ b/code/def_files/data/scripts/cfile_include.lua
@@ -6,7 +6,7 @@ local chunck_cache = {}
 -- cfile will try to find filename in all accesible locations and load it only if it hasnt done so already
 -- if cacheonly flag is set, code will be cached but not executed, good for inits. however it is ignored when calling an already cached chunk.
 -- returns true on success or nil on failure to find/load file
-function execute_lua_file(filename, cacheonly)
+local function execute_lua_file(filename, cacheonly)
     --dont reload chunks from file if they have already been loaded. because faster == better
     if (type(chunck_cache[filename]) == "table" and type(chunck_cache[filename][1]) == "function") then
         if (not chunck_cache[filename][2] and not chunck_cache[filename][3]) then

--- a/code/def_files/data/scripts/forwarders.lua
+++ b/code/def_files/data/scripts/forwarders.lua
@@ -1,0 +1,64 @@
+-- Basic forwarders for common lua methods
+function error(str)
+    ba.error(str)
+end
+
+function warning(str)
+    ba.warning(str)
+end
+
+function print(str)
+    ba.print(str)
+end
+
+function stackError(str, level)
+    if (level == nil) then
+        level = 2
+    else
+        level = level + 1
+    end
+
+    error(debug.traceback(tostring(str) .. "\n", level) .. "\n")
+end
+
+function warningf(str, ...)
+    warning(string.format(str, ...))
+end
+
+function errorf(str, ...)
+    error(string.format(str, ...))
+end
+
+function printf(str, ...)
+    print(string.format(str, ...))
+end
+
+function stackErrorf(str, ...)
+    stackError(string.format(str, ...), 2)
+end
+
+-- Global table that can hold variables that should not be able to be changed
+Globals = {}
+Globals.values = {}
+
+local mt = {}
+
+function mt.__newindex(t, index, value)
+    if (index == "values") then
+        stackErrorf("Cannot set value to index %q. Index is forbidden!", tostring(index))
+    elseif (rawget(t.values, index) ~= nil) then
+        stackErrorf("Cannot set value to index %q. Index already used!", tostring(index))
+    else
+        rawset(t.values, index, value)
+    end
+end
+
+function mt.__index(t, index)
+    if (index == "values") then
+        stackErrorf("Trying to access forbidden value %q!", index)
+    else
+        return rawget(t.values, index)
+    end
+end
+
+setmetatable(Globals, mt)

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -254,7 +254,9 @@ int script_state::CreateLuaState()
 
 	//***** LOAD DEFAULT SCRIPTS
 	mprintf(("ADE: Loading default scripts...\n"));
+	load_default_script(L, "forwarders.lua");
 	load_default_script(L, "cfile_require.lua");
+	load_default_script(L, "cfile_include.lua");
 	load_default_script(L, "dkjson.lua");
 
 	return 1;

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -288,8 +288,10 @@ add_file_folder("Default files\\\\data\\\\maps"
 )
 
 add_file_folder("Default files\\\\data\\\\scripts"
+	def_files/data/scripts/cfile_include.lua
 	def_files/data/scripts/cfile_require.lua
 	def_files/data/scripts/dkjson.lua
+	def_files/data/scripts/forwarders.lua
 )
 
 add_file_folder("Default files\\\\data\\\\tables"


### PR DESCRIPTION
Most mods that have used scripting in the last decade have included the same z_load_first-sct.tbm file. I honestly forgot about that file, but even BtA uses it. So I took and look and thought we should really just build all this in to increase the QoL of our scripters.

The basic forwarders like `print()` -> `ba.print()` just make too much sense not to have. I could take or leave the Globals table but it's nice to have.

I then also added Nuke's `include()` method. I'm not sure that's really necessary since we have m!m's built-in `require()` forwarder that forwards Lua's require to our cfile system already. But it can't really hurt to have it and it's likely some mods have used it.