### PR TITLE
Allow VFNTs to auto scale and disallow auto scaling in FRED

### DIFF
--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -590,22 +590,10 @@ static void gr_string_old(float sx,
 	float scale_factor = (canScale && !Fred_running) ? get_font_scale_factor() : 1.0f;
 
 	if (canAutoScale && !Fred_running) {
-		// Lambda to calculate font size based on screen resolution
-		auto calculateAutoSize = [height]() -> float {
-			int vmin = std::min(gr_screen.max_w, gr_screen.max_h);
-
-			// Base size calculation (similar to ~Npx font at 1080p)
-			// Use 1080p because that's generally what font sizes have been targeting for years
-			// And should provide a fairly close out-of-the-box solution
-			float baseSize = vmin * (height / 1080.0f);
-			return std::round(baseSize);
-		};
+		float autoSizedFont = calculate_auto_font_size(height);
 
 		// Calculate the auto scale factor
-		float autoSizedFont = calculateAutoSize();
 		float auto_scale_factor = autoSizedFont / height;
-
-		// Incorporate the auto_scale_factor
 		scale_factor *= auto_scale_factor;
 	}
 

--- a/code/graphics/render.cpp
+++ b/code/graphics/render.cpp
@@ -538,6 +538,7 @@ static void gr_string_old(float sx,
 	const char* end,
 	font::font* fontData,
 	float height,
+	bool canAutoScale,
 	bool canScale,
 	int resize_mode,
 	float scaleMultiplier)
@@ -587,6 +588,27 @@ static void gr_string_old(float sx,
 	gr_set_2d_matrix();
 
 	float scale_factor = (canScale && !Fred_running) ? get_font_scale_factor() : 1.0f;
+
+	if (canAutoScale && !Fred_running) {
+		// Lambda to calculate font size based on screen resolution
+		auto calculateAutoSize = [height]() -> float {
+			int vmin = std::min(gr_screen.max_w, gr_screen.max_h);
+
+			// Base size calculation (similar to ~Npx font at 1080p)
+			// Use 1080p because that's generally what font sizes have been targeting for years
+			// And should provide a fairly close out-of-the-box solution
+			float baseSize = vmin * (height / 1080.0f);
+			return std::round(baseSize);
+		};
+
+		// Calculate the auto scale factor
+		float autoSizedFont = calculateAutoSize();
+		float auto_scale_factor = autoSizedFont / height;
+
+		// Incorporate the auto_scale_factor
+		scale_factor *= auto_scale_factor;
+	}
+
 	scale_factor *= scaleMultiplier;
 
 	int letter;
@@ -784,7 +806,7 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, float scaleMu
 		VFNTFont* fnt = static_cast<VFNTFont*>(currentFont);
 		fo::font* fontData = fnt->getFontData();
 
-		gr_string_old(sx, sy, s, s + length, fontData, fnt->getHeight(), currentFont->getScaleBehavior(), resize_mode, scaleMultiplier);
+		gr_string_old(sx, sy, s, s + length, fontData, fnt->getHeight(), currentFont->getAutoScaleBehavior(), currentFont->getScaleBehavior(), resize_mode, scaleMultiplier);
 	} else if (currentFont->getType() == NVG_FONT) {
 		GR_DEBUG_SCOPE("Render TTF string");
 
@@ -882,6 +904,7 @@ void gr_string(float sx, float sy, const char* s, int resize_mode, float scaleMu
 									  text + 1,
 									  nvgFont->getSpecialCharacterFont(),
 									  nvgFont->getHeight(),
+							          nvgFont->getAutoScaleBehavior(),
 									  nvgFont->getScaleBehavior(),
 									  resize_mode,
 									  scaleMultiplier);

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -29,9 +29,9 @@ float get_font_scale_factor()
 namespace font
 {
 
-	void FSFont::setAutoScaleBehavior(bool auto)
+	void FSFont::setAutoScaleBehavior(bool auto_scale)
 	{
-		this->autoScale = auto;
+		this->autoScale = auto_scale;
 	}
 
 	void FSFont::setScaleBehavior(bool scale)

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -26,6 +26,17 @@ float get_font_scale_factor()
 	return FontScaleFactor->getValue();
 }
 
+// Calculate the font size based on the current screen resolution to provide a similar size on all resolutions
+// The returned size will be roughly similar to the size of the font at 1080p
+// Use 1080p because that's generally what font sizes have been targeting for years
+// And should provide a fairly close out-of-the-box solution
+float calculate_auto_font_size(float current_size)
+{
+	int vmin = std::min(gr_screen.max_w, gr_screen.max_h);
+	float baseSize = vmin * (current_size / 1080.0f);
+	return std::round(baseSize);
+}
+
 namespace font
 {
 

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -29,6 +29,11 @@ float get_font_scale_factor()
 namespace font
 {
 
+	void FSFont::setAutoScaleBehavior(bool autoScale)
+	{
+		this->autoScale = autoScale;
+	}
+
 	void FSFont::setScaleBehavior(bool scale)
 	{
 		this->canScale = scale;
@@ -52,6 +57,11 @@ namespace font
 	void FSFont::setFilename(const SCP_string& newName) 
 	{
 		this->filename = newName;
+	}
+
+	[[nodiscard]] bool FSFont::getAutoScaleBehavior() const
+	{
+		return this->autoScale;
 	}
 
 	[[nodiscard]] bool FSFont::getScaleBehavior() const

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -29,9 +29,9 @@ float get_font_scale_factor()
 namespace font
 {
 
-	void FSFont::setAutoScaleBehavior(bool autoScale)
+	void FSFont::setAutoScaleBehavior(bool auto)
 	{
-		this->autoScale = autoScale;
+		this->autoScale = auto;
 	}
 
 	void FSFont::setScaleBehavior(bool scale)

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -39,6 +39,7 @@ namespace font
 		SCP_string filename;			//!< The file name used to retrieve this font
 
 	protected:
+		bool autoScale = false;			//!< If the font is allowed to auto scale. Only used for VFNT fonts as NVG fonts do the auto scale calculation during parse time
 		bool canScale = false;			//!< If the font is allowed to scale with the user font multiplier
 		float offsetTop = 0.0f;			//!< The offset at the top of a line of text
 		float offsetBottom = 0.0f;		//!< The offset at the bottom of a line of text
@@ -149,6 +150,15 @@ namespace font
 								   int resize_mode = -1, float *width = nullptr, float *height = nullptr, float scaleMultiplier = 1.0f) const = 0;
 
 		/**
+		* @brief    Gets the auto scaling behavior of this font
+		*
+		* @date     24.1.2025
+		*
+		* @return   The auto scaling behavior
+		*/
+		[[nodiscard]] bool getAutoScaleBehavior() const;
+
+		/**
 		 * @brief	Gets the scaling behavior of this font
 		 *
 		 * @date	28.8.2024
@@ -174,6 +184,15 @@ namespace font
 		* @return	The bottom offset.
 		*/
 		float getBottomOffset() const;
+
+		/**
+		* @brief    Sets the auto scaling behavior for VFNTs
+		*
+		* @date     24.1.2025
+		*
+		* @param    autoScale whether or not this font can auto scale with screen resolution
+		*/
+		void setAutoScaleBehavior(bool autoScale);
 
 		/**
 		 * @brief	Sets the scaling behavior

--- a/code/graphics/software/FSFont.h
+++ b/code/graphics/software/FSFont.h
@@ -10,6 +10,8 @@ void removeFontMultiplierOption();
 
 float get_font_scale_factor();
 
+float calculate_auto_font_size(float current_size);
+
 namespace font
 {
 	/**

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -98,7 +98,6 @@ namespace
 		// This must happen before the font is loaded to set the size
 		bool autoSize = false;
 		if (optional_string("+Auto Size:")) {
-			bool autoSize;
 			stuff_boolean(&autoSize);
 
 			if (autoSize && !Fred_running) {

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -95,11 +95,13 @@ namespace
 			}
 		}
 
+		// This must happen before the font is loaded to set the size
+		bool autoSize = false;
 		if (optional_string("+Auto Size:")) {
 			bool autoSize;
 			stuff_boolean(&autoSize);
 
-			if (autoSize) {
+			if (autoSize && !Fred_running) {
 				// Lambda to calculate font size based on screen resolution
 				auto calculateAutoSize = [size]() -> float {
 					int vmin = std::min(gr_screen.max_w, gr_screen.max_h);
@@ -144,6 +146,9 @@ namespace
 
 		auto nvgPair = FontManager::loadNVGFont(fontFilename, size);
 		auto nvgFont = nvgPair.first;
+
+		// Now we can set the auto size behavior which is used for special character rendering
+		nvgFont->setAutoScaleBehavior(autoSize);
 
 		if (nvgFont == NULL)
 		{
@@ -393,6 +398,14 @@ namespace
 
 				Lcl_languages[lang_idx].special_char_indexes[font_id] = (ubyte)special_char_index;
 			}
+		}
+
+		if (optional_string("+Auto Size")) {
+			bool temp;
+
+			stuff_boolean(&temp);
+
+			font->setAutoScaleBehavior(temp);
 		}
 
 		if (optional_string("+Can Scale:")) {

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -101,19 +101,7 @@ namespace
 			stuff_boolean(&autoSize);
 
 			if (autoSize && !Fred_running) {
-				// Lambda to calculate font size based on screen resolution
-				auto calculateAutoSize = [size]() -> float {
-					int vmin = std::min(gr_screen.max_w, gr_screen.max_h);
-
-					// Base size calculation (similar to ~Npx font at 1080p)
-					// Use 1080p because that's generally what font sizes have been targeting for years
-					// And should provide a fairly close out-of-the-box solution
-					float baseSize = vmin * (size / 1080.0f);
-					return std::round(baseSize);
-				};
-
-				// Set the font size based on the result of the lambda
-				size = calculateAutoSize();
+				size = calculate_auto_font_size(size);
 			}
 		}
 


### PR DESCRIPTION
Further align functionality between Volition fonts and TrueType fonts with auto scaling. VFNTs don't save their size in quite the same way as TTFs so we have to calculate the auto scale at draw time instead.

Also make sure that fonts do not auto scale in FRED.