### PR TITLE
Allow preloading briefing icons

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6649,6 +6649,20 @@ bool post_process_mission(mission *pm)
 
 	apply_default_custom_data(pm);
 
+	if (Preload_briefing_icon_models) {
+		int team = 0;
+		if (MULTI_TEAM) {
+			team = Net_player->p_info.team;
+		}
+		auto br = Briefings[team].stages;
+		for (i = 0; i < Briefings[team].num_stages; i++) {
+			auto stage = br[i];
+			for (int j = 0; j < stage.num_icons; j++) {
+				stage.icons[j].modelnum = model_load(Ship_info[stage.icons[j].ship_class].pof_file, 0, NULL);
+			}
+		}
+	}
+
 	// success
 	return true;
 }

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6658,7 +6658,7 @@ bool post_process_mission(mission *pm)
 		for (i = 0; i < Briefings[team].num_stages; i++) {
 			auto stage = br[i];
 			for (int j = 0; j < stage.num_icons; j++) {
-				stage.icons[j].modelnum = model_load(Ship_info[stage.icons[j].ship_class].pof_file, 0, nullptr);
+				stage.icons[j].modelnum = model_load(Ship_info[stage.icons[j].ship_class].pof_file);
 			}
 		}
 	}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6658,7 +6658,7 @@ bool post_process_mission(mission *pm)
 		for (i = 0; i < Briefings[team].num_stages; i++) {
 			auto stage = br[i];
 			for (int j = 0; j < stage.num_icons; j++) {
-				stage.icons[j].modelnum = model_load(Ship_info[stage.icons[j].ship_class].pof_file, nullptr);
+				stage.icons[j].modelnum = model_load(Ship_info[stage.icons[j].ship_class].pof_file, 0, nullptr);
 			}
 		}
 	}

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6658,7 +6658,7 @@ bool post_process_mission(mission *pm)
 		for (i = 0; i < Briefings[team].num_stages; i++) {
 			auto stage = br[i];
 			for (int j = 0; j < stage.num_icons; j++) {
-				stage.icons[j].modelnum = model_load(Ship_info[stage.icons[j].ship_class].pof_file, 0, NULL);
+				stage.icons[j].modelnum = model_load(Ship_info[stage.icons[j].ship_class].pof_file, nullptr);
 			}
 		}
 	}

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -157,6 +157,7 @@ bool Lua_API_returns_nil_instead_of_invalid_object;
 bool Dont_show_callsigns_in_escort_list;
 bool Fix_scripted_velocity;
 color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
+bool Preload_briefing_icon_models;
 
 #ifdef WITH_DISCORD
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Game.Discord",
@@ -1436,6 +1437,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Fix_scripted_velocity);
 			}
 
+			if (optional_string("$Preload briefing icon models:")) {
+				stuff_boolean(&Preload_briefing_icon_models);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1657,6 +1662,7 @@ void mod_table_reset()
 	gr_init_alphacolor(&Overhead_line_colors[1], 192, 128, 64, 255);
 	gr_init_alphacolor(&Overhead_line_colors[2], 175, 175, 175, 255);
 	gr_init_alphacolor(&Overhead_line_colors[3], 100, 100, 100, 255);
+	Preload_briefing_icon_models = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -166,6 +166,7 @@ extern bool Lua_API_returns_nil_instead_of_invalid_object;
 extern bool Dont_show_callsigns_in_escort_list;
 extern bool Fix_scripted_velocity;
 extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
+extern bool Preload_briefing_icon_models;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
Adds a game_settings.tbl flag to force preloading models used for briefing icons. This runs in mission post-process so it only loads models used for icons that haven't already been loaded for the mission.

This is useful for SCPUI's where hovering over an icon shows the model without having to click on it and the stutter when it loads models not used in mission is super obvious and a poor player experience.