### PR TITLE
Fix map container mutation issues

### DIFF
--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -90,7 +90,7 @@ namespace {
 			log_printf(LOGFILE_EVENT_LOG, "%s", msg.c_str());
 		}
 #endif
-		map_data.emplace(key, data);
+		map_data[key] = data;
 	}
 
 	// Containers should not be modified if the game is simply checking the syntax. 
@@ -1321,7 +1321,7 @@ void sexp_remove_from_map(int node)
 		if (container.map_data.erase(key_to_remove) == 0) {
 			const SCP_string msg =
 				"Remove-from-map couldn't find key " + key_to_remove + " inside map container " + container_name;
-			Warning(LOCATION, "%s", msg.c_str());
+			mprintf(("%s\n", msg.c_str()));
 			log_printf(LOGFILE_EVENT_LOG, "%s", msg.c_str());
 		}
 

--- a/code/parse/sexp_container.cpp
+++ b/code/parse/sexp_container.cpp
@@ -1274,12 +1274,9 @@ void sexp_add_to_map(int node)
 		const SCP_string key = CTEXT(node);
 
 		if (container.is_being_used_in_special_arg()) {
-			// modifying existing keys' data is ok, but adding new keys is not
-			if (container.map_data.find(key) == container.map_data.end()) {
-				report_container_used_in_special_arg("Add-to-map", container_name);
-				node = CDDR(node); // skip to next key-data pair
-				continue;
-			}
+			report_container_used_in_special_arg("Add-to-map", container_name);
+			node = CDDR(node); // skip to next key-data pair
+			continue;
 		}
 
 		const SCP_string data = CTEXT(CDR(node));


### PR DESCRIPTION
Fix a few issues with map containers:
1. `add-to-map` wasn't replacing data if the key already existed in the map, despite the documentation saying that it would.
2. `remove-from-map` displays a warning if the key isn't in the map, when printing to the log would be sufficient.
3. Disallow all attempts to use `add-to-map` on a map container while it is being used in a special argument SEXP.

Fixes Issue #6549.