### PR TITLE
Check for invalid player progress

### DIFF
--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -142,7 +142,7 @@ void pilotfile::csg_read_info()
 	Campaign.next_mission = cfread_int(cfp);
 
 	// check that the next mission won't be greater than the total number of missions
-	if (Campaign.next_mission > Campaign.num_missions) {
+	if (Campaign.next_mission >= Campaign.num_missions) {
 		Campaign.next_mission = 0; // Prevent trying to load from invalid mission data downstream
 		m_data_invalid = true; // Causes a warning popup to be displayed
 	}

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -141,10 +141,10 @@ void pilotfile::csg_read_info()
 	Campaign.prev_mission = cfread_int(cfp);
 	Campaign.next_mission = cfread_int(cfp);
 
-	// check that that the next mission won't be greater than the total number of missions
-	if (Campaign.next_mission >= Campaign.num_missions) {
-		Campaign.next_mission = 0; // Prevent trying to load mission data that doesn't exist
-		m_data_invalid = true;
+	// check that the next mission won't be greater than the total number of missions
+	if (Campaign.next_mission > Campaign.num_missions) {
+		Campaign.next_mission = 0; // Prevent trying to load from invalid mission data downstream
+		m_data_invalid = true; // Causes a warning popup to be displayed
 	}
 
 	// loop state

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -141,6 +141,12 @@ void pilotfile::csg_read_info()
 	Campaign.prev_mission = cfread_int(cfp);
 	Campaign.next_mission = cfread_int(cfp);
 
+	// check that that the next mission won't be greater than the total number of missions
+	if (Campaign.next_mission >= Campaign.num_missions) {
+		Campaign.next_mission = 0; // Prevent trying to load mission data that doesn't exist
+		m_data_invalid = true;
+	}
+
 	// loop state
 	Campaign.loop_reentry = cfread_int(cfp);
 	Campaign.loop_enabled = cfread_int(cfp);

--- a/code/pilotfile/pilotfile.h
+++ b/code/pilotfile/pilotfile.h
@@ -152,7 +152,7 @@ class pilotfile {
 		bool m_have_info;
 
 		// set in case data appears wrong, so we can avoid loading/saving campaign savefile
-		bool m_data_invalid;	// z64: Not used currently
+		bool m_data_invalid;
 
 		// overall content list, can include reference to more than current
 		// mod/campaign provides


### PR DESCRIPTION
I somehow ended up with a player campaign file that had me on mission 29/6. That ended up causing the game to try and load things like the mainhall from an invalid mission reference in the Campaign array. We already have pretty good handling downstream of this issue so this PR simply activates the invalid mission data bool that was previously unused. It will cause a popup warning of bad campaign data, prompting the player to choose a different campaign, a different mod, or reset the campaign.