### PR TITLE
Move warp options to tables

### DIFF
--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -42,18 +42,6 @@ SCP_vector<fireball_info> Fireball_info;
 bool fireballs_inited = false;
 bool fireballs_parsed = false;
 
-bool Fireball_use_3d_warp = false;
-
-static auto WarpOption __UNUSED = options::OptionBuilder<bool>("Graphics.3dWarp",
-                     std::pair<const char*, int>{"3D Warp", 1770},
-                     std::pair<const char*, int>{"Use a 3D model for warp effects", 1771})
-                     .category(std::make_pair("Graphics", 1825))
-                     .default_val(true)
-                     .level(options::ExpertLevel::Advanced)
-                     .bind_to(&Fireball_use_3d_warp)
-                     .importance(65)
-                     .finish();
-
 static float exp_to_line(float t, float start_value, float end_slope, float scale)
 {
 	return -scale * expf(-start_value / scale * t) + end_slope * t + scale;
@@ -210,9 +198,6 @@ static void fireball_set_default_warp_attributes(int idx)
 			strcpy_s(Fireball_info[idx].warp_glow, "warpglow01");
 			strcpy_s(Fireball_info[idx].warp_ball, "warpball01");
 			strcpy_s(Fireball_info[idx].warp_model, "warp.pof");
-
-			if (Fireball_use_3d_warp)
-				Fireball_info[idx].use_3d_warp = true;
 
 			break;
 	}
@@ -377,6 +362,10 @@ static void parse_fireball_tbl(const char *table_filename)
 				// if we are explicitly specifying a model, then we'll want to use it,
 				// rather than just having the default model that might or might not be used
 				fi->use_3d_warp = true;
+			}
+
+			if (optional_string("$Force 3D Warp:")) {
+				stuff_boolean(&fi->use_3d_warp);
 			}
 
 			if (optional_string("$Warp size ratio:")) {

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -351,8 +351,16 @@ static void parse_fireball_tbl(const char *table_filename)
 				stuff_string(fi->warp_glow, F_NAME, NAME_LENGTH);
 
 			// check for custom warp ball
-			if (optional_string("$Warp ball:"))
+			if (optional_string("$Warp ball:")) {
 				stuff_string(fi->warp_ball, F_NAME, NAME_LENGTH);
+
+				// if we are explicitly specifying a ball, then we'll want to use it,
+				// rather than just having the default ball that might or might not be used
+				fi->warp_flash = true;
+			}
+
+			if (optional_string("$Force warp flash:"))
+				stuff_boolean(&fi->warp_flash);
 
 			// check for custom warp model
 			if (optional_string("$Warp model:"))
@@ -1175,7 +1183,7 @@ static float fireball_wormhole_flare_radius(fireball* fb) {
 	return rad;
 }
 
-extern void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float flare_rad, float flicker_magnitude, float max_radius, bool warp_3d, int warp_glow_bitmap, int warp_ball_bitmap, int warp_model_id);
+extern void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float flare_rad, float flicker_magnitude, float max_radius, bool warp_3d, int warp_glow_bitmap, int warp_ball_bitmap, int warp_model_id, bool warp_flash);
 
 void fireball_render(object* obj, model_draw_list *scene)
 {
@@ -1263,7 +1271,8 @@ void fireball_render(object* obj, model_draw_list *scene)
 				fi->use_3d_warp || (fb->flags & FBF_WARP_3D) != 0,
 				fi->warp_glow_bitmap,
 				fi->warp_ball_bitmap,
-				fi->warp_model_id);
+				fi->warp_model_id,
+				fi->warp_flash);
 		}
 		break;
 

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -163,8 +163,6 @@ float fireball_wormhole_intensity( fireball *fb );
 // Goober5000
 extern bool Knossos_warp_ani_used;
 
-extern bool Fireball_use_3d_warp;
-
 extern bool Fireball_warp_flash;
 
 // Cyborg - get a count of how many valid fireballs are in the mission.

--- a/code/fireball/fireballs.h
+++ b/code/fireball/fireballs.h
@@ -62,6 +62,7 @@ typedef struct fireball_info {
 	float				exp_color[3];	// red, green, blue
 
 	bool	use_3d_warp;
+	bool    warp_flash;
 	bool	fireball_used;
 
 	warp_style warp_flare_style;
@@ -162,8 +163,6 @@ float fireball_wormhole_intensity( fireball *fb );
 
 // Goober5000
 extern bool Knossos_warp_ani_used;
-
-extern bool Fireball_warp_flash;
 
 // Cyborg - get a count of how many valid fireballs are in the mission.
 int fireball_get_count();

--- a/code/fireball/warpineffect.cpp
+++ b/code/fireball/warpineffect.cpp
@@ -22,26 +22,6 @@
 #include "render/batching.h"
 #include "ship/ship.h"
 
-bool Fireball_warp_flash = false;
-
-static auto WarpFlashOption __UNUSED = options::OptionBuilder<bool>("Graphics.WarpFlash",
-                     std::pair<const char*, int>{"Warp Flash", 1768},
-                     std::pair<const char*, int>{"Show flash upon warp open or close", 1769})
-                     .category(std::make_pair("Graphics", 1825))
-                     .default_val(true)
-                     .level(options::ExpertLevel::Advanced)
-                     .bind_to(&Fireball_warp_flash)
-                     .importance(65)
-                     .finish();
-
-bool warpin_show_flash() {
-	if (Using_in_game_options) {
-		return WarpFlashOption->getValue();
-	} else {
-		return Fireball_warp_flash;
-	}
-}
-
 void warpin_batch_draw_face( int texture, vertex *v1, vertex *v2, vertex *v3 )
 {
 	vec3d norm;
@@ -62,7 +42,7 @@ void warpin_batch_draw_face( int texture, vertex *v1, vertex *v2, vertex *v3 )
 	batching_add_tri(texture, vertlist); // TODO render as emissive
 }
 
-void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float flare_rad, float flicker_magnitude, float max_radius, bool warp_3d, int warp_glow_bitmap, int warp_ball_bitmap, int warp_model_id)
+void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, vec3d *pos, int texture_bitmap_num, float radius, float life_percent, float flare_rad, float flicker_magnitude, float max_radius, bool warp_3d, int warp_glow_bitmap, int warp_ball_bitmap, int warp_model_id, bool warp_flash)
 {
 	vec3d center;
 	vec3d vecs[5];
@@ -162,7 +142,7 @@ void warpin_queue_render(model_draw_list *scene, object *obj, matrix *orient, ve
 		warpin_batch_draw_face( texture_bitmap_num, &verts[0], &verts[3], &verts[4] );
 	}
 
-	if (warp_ball_bitmap >= 0 && warpin_show_flash()) {
+	if (warp_ball_bitmap >= 0 && warp_flash) {
 		flash_ball warp_ball(20, .1f,.25f, &orient->vec.fvec, pos, 4.0f, 0.5f);
 
 		float adg = (2.0f * life_percent) - 1.0f;

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1783,7 +1783,6 @@ void game_init()
 		Cmdline_load_all_weapons = 0;
 
 		// Force some ingame options to off
-		Fireball_use_3d_warp = false;
 		options::OptionsManager::instance()->set_ingame_binary_option("Graphics.WarpFlash", false);
 
 		Use_3D_shockwaves = false;


### PR DESCRIPTION
With @Gamma39er 's recent enhancements to allow much more customization of how warps look it felt like it was as good a time as any to move these options into the tables for designers to make use of.

Players who want to override designer settings can use the _override folder added in #4711 as it was designed for.