### PR TITLE
fix random sidethrust call

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1887,7 +1887,7 @@ void ai_big_strafe()
 	{
 		//Re-roll for random sidethrust every 2 seconds
 		if (static_randf((Missiontime + static_rand(aip->shipnum)) >> 17) < aip->ai_random_sidethrust_percent) {
-			do_random_sidethrust(aip, &Ship_info[Ships[Objects[aip->target_objnum].instance].ship_info_index]);
+			do_random_sidethrust(aip, &Ship_info[Ships[aip->shipnum].ship_info_index]);
 		}
 	}
 }


### PR DESCRIPTION
This function call checked the acceleration of the targeted object, rather than the active object as it should have.  Fix it to check the active object.  For mods that use `$Random Sidethrust Percent:` (such as Inferno), this fixes a bug that could cause an invalid memory access in situations where the targeted object is -1.