### PR TITLE
Fix outputs being not passed along in input-only derive case

### DIFF
--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -412,10 +412,10 @@ public:
 		return modular_curves_definition<
 				new_input_type,
 				output_enum,
-				0,
+				output_names,
 				new_input_tuple_index,
 				input_grabbers..., additional_input_grabbers...>(
-				std::array<std::pair<const char*, output_enum>, 0> {}, std::tuple_cat(inputs, std::make_tuple(std::move(additional_inputs)...))
+				outputs, std::tuple_cat(inputs, std::make_tuple(std::move(additional_inputs)...))
 		);
 	}
 


### PR DESCRIPTION
Followup to #6465:
Turns out, one of the modular curve derivation functions was not passing on the outputs the way it should to the derived set.
This resulted in one of the modular curve sets of the particle rework not having some of the outputs it should have had.
