### PR TITLE
add subsystemname scripted sexp type

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -574,6 +574,23 @@ int check_for_string_raw(const char *pstr)
 	return 0;
 }
 
+int string_lookup(const char* str1, const SCP_vector<SCP_string>& strlist, const char* description, bool say_errors)
+{
+	return string_lookup(SCP_string(str1), strlist, description, say_errors);
+}
+
+int string_lookup(const SCP_string& str1, const SCP_vector<SCP_string>& strlist, const char* description, bool say_errors)
+{
+	for (size_t i = 0; i < strlist.size(); i++)
+		if (lcase_equal(str1, strlist[i]))
+			return static_cast<int>(i);
+
+	if (say_errors)
+		error_display(0, "Unable to find [%s] in %s list.\n", str1.c_str(), description ? description : "unnamed");
+
+	return -1;
+}
+
 // Find an optional string.
 //	If found, return 1, else return 0.
 //	If found, point past string, else don't update pointer.

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -285,7 +285,7 @@ int string_lookup(const char* str1, T strlist, size_t max, const char* descripti
 		Assert(strlen(strlist[i]) != 0); //-V805
 
 		if (!stricmp(str1, strlist[i]))
-			return (int)i;
+			return static_cast<int>(i);
 	}
 
 	if (say_errors)
@@ -293,6 +293,9 @@ int string_lookup(const char* str1, T strlist, size_t max, const char* descripti
 
 	return -1;
 }
+
+int string_lookup(const char* str1, const SCP_vector<SCP_string>& strlist, const char* description = nullptr, bool say_errors = false);
+int string_lookup(const SCP_string& str1, const SCP_vector<SCP_string>& strlist, const char* description = nullptr, bool say_errors = false);
 
 template<class Flags, class Flagset>
 void stuff_boolean_flag(Flagset& destination, Flags flag, bool a_to_eol = true)


### PR DESCRIPTION
This type for subsystems is analogous to the shipname type for ships.  Sometimes it is useful to refer to a subsystem even if its parent ship is not present.  Whereas the subsystem object would be invalid, the subsystemname string still contains the string that the mission designer specified.

Relatedly, upgrade the parsing of `+Parent Parameter Index:` to be checked on both parented and non-parented parameters.  This will help both modders who put the field in the wrong place and programmers who may want to add a parented parameter in the future.

Tested and works as expected.