### PR TITLE
reduce magic numbers in missionweaponchoice

### DIFF
--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -32,14 +32,15 @@
 // ---------------------------------------------------------------------------------------------------------------------------------------
 // MISSION FICTION VIEWER DEFINES/VARS
 //
-#define NUM_FVW_SETTINGS	2
-const char *Fiction_viewer_ui_names[NUM_FVW_SETTINGS] =
+constexpr int NUM_FVW_LAYOUTS = 2;
+
+const char *Fiction_viewer_ui_names[NUM_FVW_LAYOUTS] =
 {
 	"FS2",	// FreeSpace 2
 	"WCS"	// Wing Commander Saga
 };
 
-const char *Fiction_viewer_screen_filename[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS] =
+const char *Fiction_viewer_screen_filename[NUM_FVW_LAYOUTS][GR_NUM_RESOLUTIONS] =
 {
 	{
 		"FictionViewer",		// GR_640
@@ -51,7 +52,7 @@ const char *Fiction_viewer_screen_filename[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS]
 	}
 };
 
-const char *Fiction_viewer_screen_mask[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS] =
+const char *Fiction_viewer_screen_mask[NUM_FVW_LAYOUTS][GR_NUM_RESOLUTIONS] =
 {
 	{
 		"FictionViewer-m",		// GR_640
@@ -63,7 +64,7 @@ const char *Fiction_viewer_screen_mask[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS] =
 	}
 };
 
-int Fiction_viewer_text_coordinates[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS][4] =
+int Fiction_viewer_text_coordinates[NUM_FVW_LAYOUTS][GR_NUM_RESOLUTIONS][4] =
 {
 	// standard FS2-style interface
 	{
@@ -93,7 +94,7 @@ int Fiction_viewer_text_coordinates[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS][4] =
 // the xt and yt fields aren't normally used for width and height,
 // but the fields would go unused here and this is more
 // convenient for initialization
-ui_button_info Fiction_viewer_buttons[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS][NUM_FVW_BUTTONS] =
+ui_button_info Fiction_viewer_buttons[NUM_FVW_LAYOUTS][GR_NUM_RESOLUTIONS][NUM_FVW_BUTTONS] =
 {
 	// standard FS2-style interface
 	{
@@ -124,7 +125,7 @@ ui_button_info Fiction_viewer_buttons[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS][NUM_
 	}
 };
 
-const char *Fiction_viewer_slider_filename[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS] =
+const char *Fiction_viewer_slider_filename[NUM_FVW_LAYOUTS][GR_NUM_RESOLUTIONS] =
 {
 	// standard FS2-style interface
 	{
@@ -138,7 +139,7 @@ const char *Fiction_viewer_slider_filename[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS]
 	}
 };
 
-int Fiction_viewer_slider_coordinates[NUM_FVW_SETTINGS][GR_NUM_RESOLUTIONS][4] =
+int Fiction_viewer_slider_coordinates[NUM_FVW_LAYOUTS][GR_NUM_RESOLUTIONS][4] =
 {
 	// standard FS2-style interface
 	{
@@ -314,7 +315,7 @@ void fiction_viewer_init()
 		if (Fiction_viewer_ui < 0)
 		{
 			// no UI specified; use the last UI in the array that has an available background bitmap
-			for (Fiction_viewer_ui = NUM_FVW_SETTINGS - 1; Fiction_viewer_ui >= 0; Fiction_viewer_ui--)
+			for (Fiction_viewer_ui = NUM_FVW_LAYOUTS - 1; Fiction_viewer_ui >= 0; Fiction_viewer_ui--)
 			{
 				Fiction_viewer_bitmap = bm_load(Fiction_viewer_screen_filename[Fiction_viewer_ui][gr_screen.res]);
 				if (Fiction_viewer_bitmap >= 0)
@@ -514,7 +515,7 @@ bool mission_has_fiction()
 int fiction_viewer_ui_name_to_index(const char *ui_name)
 {
 	int i;
-	for (i = 0; i < NUM_FVW_SETTINGS; i++)
+	for (i = 0; i < NUM_FVW_LAYOUTS; i++)
 	{
 		if (!stricmp(ui_name, Fiction_viewer_ui_names[i]))
 		{

--- a/code/missionui/missioncmdbrief.cpp
+++ b/code/missionui/missioncmdbrief.cpp
@@ -36,10 +36,9 @@
 #include "ui/uidefs.h"
 
 
+constexpr int NUM_CBRIEF_LAYOUTS = 2;
 
-#define NUM_CMD_SETTINGS	2
-
-const char *Cmd_brief_fname[NUM_CMD_SETTINGS][GR_NUM_RESOLUTIONS] =
+const char *Cmd_brief_fname[NUM_CBRIEF_LAYOUTS][GR_NUM_RESOLUTIONS] =
 {
 	{
 		"CommandBrief",
@@ -52,7 +51,7 @@ const char *Cmd_brief_fname[NUM_CMD_SETTINGS][GR_NUM_RESOLUTIONS] =
 };
 
 
-const char *Cmd_brief_mask[NUM_CMD_SETTINGS][GR_NUM_RESOLUTIONS] =
+const char *Cmd_brief_mask[NUM_CBRIEF_LAYOUTS][GR_NUM_RESOLUTIONS] =
 {
 	{
 		"CommandBrief-m",
@@ -71,7 +70,7 @@ const char *Cmd_brief_mask[NUM_CMD_SETTINGS][GR_NUM_RESOLUTIONS] =
 #define CMD_W_COORD 2
 #define CMD_H_COORD 3
 
-int Cmd_text_wnd_coords[NUM_CMD_SETTINGS][GR_NUM_RESOLUTIONS][4] =
+int Cmd_text_wnd_coords[NUM_CBRIEF_LAYOUTS][GR_NUM_RESOLUTIONS][4] =
 {
 	// original
 	{

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -77,8 +77,7 @@ typedef struct wl_bitmap_group
 #define WEAPON_ICON_FRAME_SELECTED			2
 #define WEAPON_ICON_FRAME_DISABLED			3
 
-
-#define NUM_WEAPON_SETTINGS	2
+constexpr int NUM_WL_LAYOUTS = 2;
 
 #define MAX_WEAPON_BUTTONS	8
 #define MIN_WEAPON_BUTTONS	7
@@ -132,7 +131,7 @@ static wl_buttons Buttons[GR_NUM_RESOLUTIONS][MAX_WEAPON_BUTTONS] = {
 };
 
 
-static const char *Wl_mask_single[NUM_WEAPON_SETTINGS][GR_NUM_RESOLUTIONS] = {
+static const char *Wl_mask_single[NUM_WL_LAYOUTS][GR_NUM_RESOLUTIONS] = {
 	{
 		"weaponloadout-m",
 		"2_weaponloadout-m"
@@ -143,7 +142,7 @@ static const char *Wl_mask_single[NUM_WEAPON_SETTINGS][GR_NUM_RESOLUTIONS] = {
 	}
 };
 
-static const char *Wl_mask_multi[NUM_WEAPON_SETTINGS][GR_NUM_RESOLUTIONS] = {
+static const char *Wl_mask_multi[NUM_WL_LAYOUTS][GR_NUM_RESOLUTIONS] = {
 	{
 		"weaponloadoutmulti-m",
 		"2_weaponloadoutmulti-m"
@@ -155,7 +154,7 @@ static const char *Wl_mask_multi[NUM_WEAPON_SETTINGS][GR_NUM_RESOLUTIONS] = {
 	}
 };
 
-static const char *Wl_loadout_select_mask[NUM_WEAPON_SETTINGS][GR_NUM_RESOLUTIONS] = {
+static const char *Wl_loadout_select_mask[NUM_WL_LAYOUTS][GR_NUM_RESOLUTIONS] = {
 	{
 		"weaponloadout-m",
 		"2_weaponloadout-m"
@@ -167,7 +166,7 @@ static const char *Wl_loadout_select_mask[NUM_WEAPON_SETTINGS][GR_NUM_RESOLUTION
 };
 
 
-static const char *Weapon_select_background_fname[NUM_WEAPON_SETTINGS][GR_NUM_RESOLUTIONS] = {
+static const char *Weapon_select_background_fname[NUM_WL_LAYOUTS][GR_NUM_RESOLUTIONS] = {
 	{
 		"WeaponLoadout",
 		"2_WeaponLoadout"
@@ -178,7 +177,7 @@ static const char *Weapon_select_background_fname[NUM_WEAPON_SETTINGS][GR_NUM_RE
 	}
 };
 
-static const char *Weapon_select_multi_background_fname[NUM_WEAPON_SETTINGS][GR_NUM_RESOLUTIONS] = {
+static const char *Weapon_select_multi_background_fname[NUM_WL_LAYOUTS][GR_NUM_RESOLUTIONS] = {
 	{
 		"WeaponLoadoutMulti",
 		"2_WeaponLoadoutMulti"

--- a/code/missionui/missionweaponchoice.h
+++ b/code/missionui/missionweaponchoice.h
@@ -17,25 +17,6 @@ struct wss_unit;
 class ship_weapon;
 struct team_data;
 
-// mask regions for icons in the scrollable lists
-#define ICON_PRIMARY_0				28
-#define ICON_PRIMARY_1				29
-#define ICON_PRIMARY_2				30
-#define ICON_PRIMARY_3				31
-#define ICON_SECONDARY_0			10
-#define ICON_SECONDARY_1			11
-#define ICON_SECONDARY_2			12
-#define ICON_SECONDARY_3			13
-
-// mask regions for icons that sit above the ship
-#define ICON_SHIP_PRIMARY_0		32
-#define ICON_SHIP_PRIMARY_1		33
-#define ICON_SHIP_PRIMARY_2		34
-#define ICON_SHIP_SECONDARY_0		35
-#define ICON_SHIP_SECONDARY_1		36
-#define ICON_SHIP_SECONDARY_2		37
-#define ICON_SHIP_SECONDARY_3		38
-
 #define WEAPON_DESC_MAX_LINES			7				// max lines in the description incl. title
 #define WEAPON_DESC_MAX_LENGTH		50				// max chars per line of description text
 


### PR DESCRIPTION
Use the existing definitions to improve code readability.

Also rename _SETTINGS to _LAYOUTS for some definitions as it's more descriptive.