### PR TITLE
misceallaneous small fixes and tweaks

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -182,7 +182,6 @@ void hud_init_comm_orders()
 	std::sort(Player_orders.begin(), Player_orders.end(), [](const player_order& o1, const player_order& o2) {
 		return o1.legacy_id < o2.legacy_id;
 	});
-
 }
 
 // Text to display on the messaging menu when using the shortcut keys

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -945,8 +945,7 @@ void ship_select_blit_ship_info()
 	}
 	else
 	{
-		ship_get_type(str, sip);
-		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, str, GR_RESIZE_MENU);
+		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, ship_get_type(sip), GR_RESIZE_MENU);
 	}
 	y_start+=line_height;
 

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -236,12 +236,15 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum, int parent_node) const
 		auto text = CTEXT(node);
 		return LuaValue::createValue(_action.getLuaState(), text);
 	}
+	case OPF_POINT: {
+		auto wpt = find_matching_waypoint(CTEXT(node));
+		return LuaValue::createValue(_action.getLuaState(), l_Waypoint.Set(object_h(wpt->get_objnum())));
+	}
 	case OPF_SHIP_POINT:
 	case OPF_SHIP_WING:
 	case OPF_SHIP_WING_WHOLETEAM:
 	case OPF_SHIP_WING_SHIPONTEAM_POINT:
 	case OPF_SHIP_WING_POINT:
-	case OPF_POINT:
 	case OPF_SHIP_WING_POINT_OR_NONE: {
 		object_ship_wing_point_team oswpt;
 		eval_object_ship_wing_point_team(&oswpt, node);

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -14,6 +14,7 @@
 
 #include "asteroid/asteroid.h"
 #include "debris/debris.h"
+#include "jumpnode/jumpnode.h"
 #include "object/objcollide.h"
 #include "object/objectshield.h"
 #include "object/objectsnd.h"
@@ -70,7 +71,8 @@ ADE_FUNC(__tostring, l_Object, NULL, "Returns name of object (if any)", "string"
 	if(!objh->isValid())
 		return ade_set_error(L, "s", "");
 
-	char buf[512];
+	SCP_string buf;
+	int wp_list, wp_index;
 
 	switch(objh->objp()->type)
 	{
@@ -78,13 +80,37 @@ ADE_FUNC(__tostring, l_Object, NULL, "Returns name of object (if any)", "string"
 			sprintf(buf, "%s", Ships[objh->objp()->instance].ship_name);
 			break;
 		case OBJ_WEAPON:
-			sprintf(buf, "%s projectile", Weapon_info[Weapons[objh->objp()->instance].weapon_info_index].get_display_name());
+			sprintf(buf, "%s projectile", Weapon_info[Weapons[objh->objp()->instance].weapon_info_index].name);
+			break;
+		case OBJ_FIREBALL:
+			sprintf(buf, "%s fireball", Fireball_info[Fireballs[objh->objp()->instance].fireball_info_index].unique_id);
+			break;
+		case OBJ_WAYPOINT:
+			calc_waypoint_indexes(objh->objp()->instance, wp_list, wp_index);
+			sprintf(buf, "waypoint %d of list %s", wp_index + 1, Waypoint_lists[wp_list].get_name());
+			break;
+		case OBJ_DEBRIS:
+			wp_index = Debris[objh->objp()->instance].ship_info_index;
+			if (wp_index >= 0)
+				sprintf(buf, "debris from %s", Ship_info[wp_index].name);
+			else
+				sprintf(buf, "debris fragment");
+			break;
+		case OBJ_ASTEROID:
+			sprintf(buf, "asteroid type=%d subtype=%d", Asteroids[objh->objp()->instance].asteroid_type, Asteroids[objh->objp()->instance].asteroid_subtype);
+			break;
+		case OBJ_JUMP_NODE:
+			sprintf(buf, "%s jump node", jumpnode_get_by_objnum(objh->objnum)->GetName());
+			break;
+		case OBJ_BEAM:
+			sprintf(buf, "%s beam", Weapon_info[Beams[objh->objp()->instance].weapon_info_index].name);
 			break;
 		default:
-			sprintf(buf, "Object %d [%d]", objh->objnum, objh->sig);
+			sprintf(buf, "object num=%d sig=%d type=%d instance=%d", objh->objnum, objh->sig, objh->objp()->type, objh->objp()->instance);
+			break;
 	}
 
-	return ade_set_args(L, "s", buf);
+	return ade_set_args(L, "s", buf.c_str());
 }
 
 ADE_VIRTVAR(Parent, l_Object, "object", "Parent of the object. Value may also be a deriviative of the 'object' class, such as 'ship'.", "object", "Parent handle, or invalid handle if object is invalid")

--- a/code/scripting/api/objs/waypoint.cpp
+++ b/code/scripting/api/objs/waypoint.cpp
@@ -92,6 +92,19 @@ ADE_FUNC(__len, l_WaypointList,
 	return ade_set_args(L, "i", wlh->getList()->get_waypoints().size());
 }
 
+ADE_FUNC(__tostring, l_WaypointList, nullptr, "Returns name of waypoint list (if any)", "string", "Waypoint list name, or empty string if handle is invalid")
+{
+	waypointlist_h* wlh = nullptr;
+	if ( !ade_get_args(L, "o", l_WaypointList.GetPtr(&wlh)) ) {
+		return ade_set_error(L, "s", "");
+	}
+	if (!wlh || !wlh->isValid()) {
+		return ade_set_error(L, "s", "");
+	}
+
+	return ade_set_args(L, "s", wlh->getList()->get_name());
+}
+
 ADE_VIRTVAR(Name, l_WaypointList, "string", "Name of WaypointList", "string", "Waypointlist name, or empty string if handle is invalid")
 {
 	waypointlist_h* wlh = NULL;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6821,15 +6821,13 @@ void physics_ship_init(object *objp)
 /**
  * Get the type of the given ship as a string
  */
-int ship_get_type(char* output, ship_info *sip)
+const char *ship_get_type(const ship_info *sip)
 {
 	if(sip->class_type < 0) {
-		strcpy(output, "Unknown");
-		return 0;
+		return XSTR("Unknown", 497);
 	}
 
-	strcpy(output, Ship_types[sip->class_type].name);
-	return 1;
+	return Ship_types[sip->class_type].name;
 }
 
 /**

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1824,7 +1824,7 @@ extern void ship_assign_sound(ship *sp);
 extern void ship_clear_ship_type_counts();
 extern void ship_add_ship_type_count( int ship_info_index, int num );
 
-extern int ship_get_type(char* output, ship_info* sip);
+extern const char *ship_get_type(const ship_info *sip);
 extern const SCP_set<size_t>& ship_get_default_orders_accepted( ship_info *sip );
 extern SCP_set<size_t> ship_get_default_orders_against();
 extern int ship_query_general_type(int ship);


### PR DESCRIPTION
1. Change `ship_get_type` to return its string directly, to avoid the need for a temporary variable
2. Add `tostring()` functionality for additional objects besides ships and weapons, to aid in script debugging
3. For an `OPF_POINT` scripted parameter, return it directly.  Since it is always a single specific type, it should not be wrapped in OSWPT.

Item 3 is a minor breaking change, as scripts now access the waypoint directly rather than unwrapping it with a `:get()` call.