### PR TITLE
update script API for AI orders

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -534,7 +534,7 @@ extern void ai_ignore_wing(object *ignorer, int wingnum);
 extern void ai_dock_with_object(object *docker, int docker_index, object *dockee, int dockee_index, int dock_type);
 extern void ai_stay_still(object *still_objp, vec3d *view_pos);
 extern void ai_do_default_behavior(object *obj);
-extern void ai_start_waypoints(object *objp, int wl_index, int wp_flags, int start_index);
+extern void ai_start_waypoints(object *objp, int wl_index, int wp_flags, int start_index, bool force = false);
 extern void ai_ship_hit(object *objp_ship, object *hit_objp, const vec3d *hit_normal);
 extern void ai_ship_destroy(int shipnum);
 extern vec3d ai_get_acc_limit(vec3d* vel_limit, const object* objp);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -3515,7 +3515,7 @@ void ai_dock_with_object(object *docker, int docker_index, object *dockee, int d
 //	flags tells:
 //		WPF_REPEAT		Set -> repeat waypoints.
 //		WPF_BACKTRACK	Go in reverse.
-void ai_start_waypoints(object *objp, int wp_list_index, int wp_flags, int start_index)
+void ai_start_waypoints(object *objp, int wp_list_index, int wp_flags, int start_index, bool force)
 {
 	auto aip = &Ai_info[Ships[objp->instance].ai_index];
 
@@ -3541,7 +3541,7 @@ void ai_start_waypoints(object *objp, int wp_list_index, int wp_flags, int start
 		start_index = (wp_flags & WPF_BACKTRACK) ? (int)wp_list->get_waypoints().size() - 1 : 0;
 	}
 
-	if ( (aip->mode == AIM_WAYPOINTS) && (aip->wp_list_index == wp_list_index) )
+	if ( (aip->mode == AIM_WAYPOINTS) && (aip->wp_list_index == wp_list_index) && !force )
 	{
 		if (aip->wp_index == INVALID_WAYPOINT_POSITION)
 		{

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -822,7 +822,7 @@ int ai_goal_num(ai_goal *goals)
 }
 
 
-void ai_add_goal_sub_scripting(ai_goal_type type, ai_goal_mode mode, int submode, int priority, const char *target_name, ai_goal *aigp )
+void ai_add_goal_sub_scripting(ai_goal_type type, ai_goal_mode mode, int submode, int priority, const char *target_name, ai_goal *aigp, int int_data, float float_data)
 {
 	Assert ( (type == ai_goal_type::PLAYER_WING) || (type == ai_goal_type::PLAYER_SHIP) );
 
@@ -837,16 +837,18 @@ void ai_add_goal_sub_scripting(ai_goal_type type, ai_goal_mode mode, int submode
 		aigp->target_name = ai_get_goal_target_name( target_name, &aigp->target_name_index );
 
 	aigp->priority = priority;
+	aigp->int_data = int_data;
+	aigp->float_data = float_data;
 }
 
-void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, const char *shipname, ai_info *aip)
+void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, const char *shipname, ai_info *aip, int int_data, float float_data)
 {
 	int empty_index;
 	ai_goal *aigp;
 
 	empty_index = ai_goal_find_empty_slot(aip->goals, aip->active_goal);
 	aigp = &aip->goals[empty_index];
-	ai_add_goal_sub_scripting(ai_goal_type::PLAYER_SHIP, mode, submode, priority, shipname, aigp);
+	ai_add_goal_sub_scripting(ai_goal_type::PLAYER_SHIP, mode, submode, priority, shipname, aigp, int_data, float_data);
 
 	//WMC - hack to get docking setup correctly
 	if ( mode == AI_GOAL_DOCK ) {

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -176,7 +176,7 @@ extern void ai_process_mission_orders( int objnum, ai_info *aip );
 extern int ai_goal_num(ai_goal *goals);
 
 // adds goals to ships/wing through sexpressions
-extern void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, const char *shipname, ai_info *aip);
+extern void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, const char *shipname, ai_info *aip, int int_data, float float_data);
 extern void ai_add_ship_goal_sexp(int sexp, ai_goal_type type, ai_info *aip);
 extern void ai_add_wing_goal_sexp(int sexp, ai_goal_type type, wing *wingp);
 extern void ai_add_goal_sub_sexp(int sexp, ai_goal_type type, ai_info *aip, ai_goal *aigp, const char *actor_name);

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -1554,6 +1554,8 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 	ai_goal_mode ai_mode = AI_GOAL_NONE;
 	int ai_submode = -1234567;
 	const char *ai_shipname = NULL;
+	int int_data = 0;
+	float float_data = 0.0f;
 	switch(eh->index)
 	{
 		case LE_ORDER_ATTACK:
@@ -1585,24 +1587,18 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 			break;
 		}
 		case LE_ORDER_WAYPOINTS:
-		{
-			if(tgh_valid && tgh->objp()->type == OBJ_WAYPOINT)
-			{
-				ai_mode = AI_GOAL_WAYPOINTS;
-				waypoint_list *wp_list = find_waypoint_list_with_instance(tgh->objp()->instance);
-				if(wp_list != NULL)
-					ai_shipname = wp_list->get_name();
-			}
-			break;
-		}
 		case LE_ORDER_WAYPOINTS_ONCE:
 		{
 			if(tgh_valid && tgh->objp()->type == OBJ_WAYPOINT)
 			{
-				ai_mode = AI_GOAL_WAYPOINTS_ONCE;
-				waypoint_list *wp_list = find_waypoint_list_with_instance(tgh->objp()->instance);
-				if(wp_list != NULL)
-					ai_shipname = wp_list->get_name();
+				ai_mode = eh->index == LE_ORDER_WAYPOINTS_ONCE ? AI_GOAL_WAYPOINTS_ONCE : AI_GOAL_WAYPOINTS;
+				int wp_list_index, wp_index;
+				calc_waypoint_indexes(tgh->objp()->instance, wp_list_index, wp_index);
+				if (wp_list_index >= 0 && wp_index >= 0)
+				{
+					ai_shipname = Waypoint_lists[wp_list_index].get_name();
+					int_data = wp_index;
+				}
 			}
 			break;
 		}
@@ -1797,7 +1793,7 @@ ADE_FUNC(giveOrder, l_Ship, "enumeration Order, [object Target=nil, subsystem Ta
 		return ade_set_error(L, "b", false);
 
 	//Fire off the goal
-	ai_add_ship_goal_scripting(ai_mode, ai_submode, (int)(priority*100.0f), ai_shipname, &Ai_info[Ships[objh->objp()->instance].ai_index]);
+	ai_add_ship_goal_scripting(ai_mode, ai_submode, (int)(priority*100.0f), ai_shipname, &Ai_info[Ships[objh->objp()->instance].ai_index], int_data, float_data);
 
 	return ADE_RETURN_TRUE;
 }

--- a/code/scripting/api/objs/waypoint.cpp
+++ b/code/scripting/api/objs/waypoint.cpp
@@ -25,6 +25,19 @@ ADE_FUNC(getList, l_Waypoint, NULL, "Returns the waypoint list", "waypointlist",
 	return ade_set_error(L, "o", l_WaypointList.Set(waypointlist_h()));
 }
 
+ADE_FUNC(getIndex, l_Waypoint, nullptr, "Returns the index of this waypoint in its list", "number", "waypoint index or 0 if waypoint was invalid")
+{
+	object_h *oh = nullptr;
+	if(!ade_get_args(L, "o", l_Waypoint.GetPtr(&oh)))
+		return ade_set_error(L, "i", 0);
+
+	if(!oh->isValid() || oh->objp()->type != OBJ_WAYPOINT)
+		return ade_set_error(L, "i", 0);
+
+	int wp_index = calc_waypoint_index(oh->objp()->instance);
+	return ade_set_args(L, "i", wp_index + 1);
+}
+
 waypointlist_h::waypointlist_h()
 	: wl_index(-1)
 {}


### PR DESCRIPTION
Allow waypoint orders to target a specific waypoint and go in reverse.  Add script access to waypoints and waypoint lists belonging to orders.

Fix assignment of targets and goal start times.  Assign targets when they are different (and thus need to be assigned), not when they are the same.