### PR TITLE
Unify Particle Attachment

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -813,8 +813,9 @@ void debris_hit(object *debris_obj, object * /*other_obj*/, vec3d *hitpos, float
 		vm_vector_2_matrix_norm(&orient, &tmp_norm);
 
 		auto source = particle::ParticleManager::get()->createSource(Debris_hit_particle);
-
-		source->setHost(make_unique<EffectHostVector>(*hitpos, orient, debris_obj->phys_info.vel));
+		auto host = std::make_unique<EffectHostVector>(*hitpos, orient, debris_obj->phys_info.vel);
+		host->setRadius(debris_obj->radius);
+		source->setHost(std::move(host));
 		source->finishCreation();
 	}
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4755,7 +4755,7 @@ void model_instance_global_to_local_point(vec3d* outpnt, const vec3d* mpnt, cons
 
 	*outpnt = resultPnt;
 
-	if (pm->submodel[submodel_num].depth > preallocatedStackDepth)
+	if (submodel_num >= 0 && pm->submodel[submodel_num].depth > preallocatedStackDepth)
 		delete[] submodelStack;
 }
 
@@ -4800,7 +4800,7 @@ void model_instance_global_to_local_dir(vec3d* out_dir, const vec3d* in_dir, con
 
 	*out_dir = resultDir;
 
-	if (pm->submodel[submodel_num].depth > preallocatedStackDepth)
+	if (submodel_num >= 0 && pm->submodel[submodel_num].depth > preallocatedStackDepth)
 		delete[] submodelStack;
 }
 
@@ -4845,7 +4845,7 @@ void model_instance_global_to_local_point_orient(vec3d* outpnt, matrix* outorien
 	*outpnt = resultPnt;
 	*outorient = resultMat;
 
-	if (pm->submodel[submodel_num].depth > preallocatedStackDepth)
+	if (submodel_num >= 0 && pm->submodel[submodel_num].depth > preallocatedStackDepth)
 		delete[] submodelStack;
 }
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -4718,7 +4718,7 @@ void model_instance_global_to_local_point(vec3d* outpnt, const vec3d* mpnt, cons
 	constexpr int preallocatedStackDepth = 5;
 	std::tuple<const matrix*, const vec3d*, const vec3d*> preallocatedStack[preallocatedStackDepth];
 
-	auto submodelStack = pm->submodel[submodel_num].depth <= preallocatedStackDepth ? preallocatedStack : new std::tuple<const matrix*, const vec3d*, const vec3d*>[pm->submodel[submodel_num].depth];
+	auto submodelStack = submodel_num < 0 || pm->submodel[submodel_num].depth <= preallocatedStackDepth ? preallocatedStack : new std::tuple<const matrix*, const vec3d*, const vec3d*>[pm->submodel[submodel_num].depth];
 	int stackCounter = 0;
 
 	int mn = submodel_num;
@@ -4771,7 +4771,7 @@ void model_instance_global_to_local_dir(vec3d* out_dir, const vec3d* in_dir, con
 	constexpr int preallocatedStackDepth = 5;
 	const matrix* preallocatedStack[preallocatedStackDepth];
 
-	auto submodelStack = pm->submodel[submodel_num].depth <= preallocatedStackDepth ? preallocatedStack : new const matrix*[pm->submodel[submodel_num].depth];
+	auto submodelStack = submodel_num < 0 || pm->submodel[submodel_num].depth <= preallocatedStackDepth ? preallocatedStack : new const matrix*[pm->submodel[submodel_num].depth];
 	int stackCounter = 0;
 
 	int mn = submodel_num;
@@ -4810,7 +4810,7 @@ void model_instance_global_to_local_point_orient(vec3d* outpnt, matrix* outorien
 	constexpr int preallocatedStackDepth = 5;
 	std::tuple<const matrix*, const vec3d*, const vec3d*> preallocatedStack[preallocatedStackDepth];
 
-	auto submodelStack = pm->submodel[submodel_num].depth <= preallocatedStackDepth ? preallocatedStack : new std::tuple<const matrix*, const vec3d*, const vec3d*>[pm->submodel[submodel_num].depth];
+	auto submodelStack = submodel_num < 0 || pm->submodel[submodel_num].depth <= preallocatedStackDepth ? preallocatedStack : new std::tuple<const matrix*, const vec3d*, const vec3d*>[pm->submodel[submodel_num].depth];
 	int stackCounter = 0;
 
 	int mn = submodel_num;

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2232,7 +2232,7 @@ void model_queue_render_thrusters(const model_render_params *interp, const polym
 			glow_point *gpt = &bank->points[j];
 			vec3d loc_offset = gpt->pnt;
 			vec3d loc_norm = gpt->norm;
-			vec3d world_pnt;
+			vec3d world_pnt = loc_offset;
 			vec3d world_norm;
 
 			if ( submodel_rotation ) {

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2422,8 +2422,8 @@ void model_queue_render_thrusters(const model_render_params *interp, const polym
 					vm_vector_2_matrix_norm(&orientParticle, &normal);
 
 					auto host = std::make_unique<EffectHostVector>(npnt, orientParticle, Objects[shipp->objnum].phys_info.desired_vel);
-					host->setRadiusOverride(gpt->radius);
 					source->setHost(std::move(host));
+					source->setTriggerRadius(gpt->radius);
 					source->finishCreation();
 				}
 			}

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2241,16 +2241,17 @@ void model_queue_render_thrusters(const model_render_params *interp, const polym
 				if (pmi == nullptr)
 					pmi = model_get_instance(shipp->model_instance_num);
 
-				tempv = loc_offset;
+
 				if (IS_VEC_NULL(&loc_norm)) {	// zero vectors are allowed for glowpoint norms
-					model_instance_local_to_global_point(&loc_offset, &tempv, pm, pmi, bank->submodel_num);
+					model_instance_local_to_global_point(&world_pnt, &tempv, pm, pmi, bank->submodel_num);
 				} else {
 					vec3d tempn = loc_norm;
-					model_instance_local_to_global_point_dir(&loc_offset, &loc_norm, &tempv, &tempn, pm, pmi, bank->submodel_num);
+					model_instance_local_to_global_point_dir(&world_pnt, &loc_norm, &tempv, &tempn, pm, pmi, bank->submodel_num);
 				}
 			}
 
-			vm_vec_unrotate(&world_pnt, &loc_offset, orient);
+			tempv = world_pnt;
+			vm_vec_unrotate(&world_pnt, &tempv, orient);
 			vm_vec_add2(&world_pnt, pos);
 
 			if (shipp) {
@@ -2409,21 +2410,19 @@ void model_queue_render_thrusters(const model_render_params *interp, const polym
 					else
 						tp = &sip->normal_thruster_particles[k];
 
-					vm_vec_unrotate(&npnt, &gpt->pnt, orient);
-					vm_vec_add2(&npnt, pos);
-
-					// What normal the particle emit around
-					vec3d normal = orient->vec.fvec;
-					vm_vec_negate(&normal);
-
 					auto source = particle::ParticleManager::get()->createSource(tp->particle_handle);
 
-					matrix orientParticle;
-					vm_vector_2_matrix_norm(&orientParticle, &normal);
+					//This is a 180° flip around y matrix
+					matrix orientParticle = { { { { { { -1.0f, 0.0f, 0.0f } } }, { { { 0.0f, 1.0f, 0.0f } } }, { { { 0.0f, 0.0f, -1.0f } } } } } };
 
-					auto host = std::make_unique<EffectHostVector>(npnt, orientParticle, Objects[shipp->objnum].phys_info.desired_vel);
+					std::unique_ptr<EffectHost> host;
+					if (bank->submodel_num < 0)
+						host = std::make_unique<EffectHostObject>(&Objects[shipp->objnum], loc_offset, orientParticle);
+					else
+						host = std::make_unique<EffectHostSubmodel>(&Objects[shipp->objnum], bank->submodel_num, loc_offset, orientParticle);
 					source->setHost(std::move(host));
 					source->setTriggerRadius(gpt->radius);
+					source->setTriggerVelocity(vm_vec_mag_quick(&Objects[shipp->objnum].phys_info.desired_vel));
 					source->finishCreation();
 				}
 			}

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -82,7 +82,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, cons
 	model_instance_local_to_global_dir(&worldNormal, hit_dir, pm, pmi, submodel_num, &pship_obj->orient);
 
 	// Apply hit & damage & stuff to weapon
-	weapon_hit(weapon_obj, pship_obj,  world_hitpos, quadrant_num, &worldNormal);
+	weapon_hit(weapon_obj, pship_obj,  world_hitpos, quadrant_num, &worldNormal, hitpos, submodel_num);
 
 	if (wip->damage_time >= 0.0f && wp->lifeleft <= wip->damage_time) {
 		if (wip->atten_damage >= 0.0f) {

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -82,7 +82,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, cons
 	model_instance_local_to_global_dir(&worldNormal, hit_dir, pm, pmi, submodel_num, &pship_obj->orient);
 
 	// Apply hit & damage & stuff to weapon
-	weapon_hit(weapon_obj, pship_obj,  world_hitpos, quadrant_num, &worldNormal, hitpos, submodel_num);
+	weapon_hit(weapon_obj, pship_obj, world_hitpos, quadrant_num, &worldNormal, hitpos, submodel_num); //NOLINT(readability-suspicious-call-argument)
 
 	if (wip->damage_time >= 0.0f && wp->lifeleft <= wip->damage_time) {
 		if (wip->atten_damage >= 0.0f) {

--- a/code/particle/EffectHost.h
+++ b/code/particle/EffectHost.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "object/object.h"
 #include "globalincs/pstypes.h"
 #include "math/vecmat.h"
 
@@ -38,5 +39,4 @@ public:
 	virtual bool isValid() const { return true; }
 
 	virtual void setupProcessing() {}
-
 };

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -175,6 +175,7 @@ public:
 			std::pair {"Velocity Position Inherit Mult", ParticleCurvesOutput::POSITION_INHERIT_VELOCITY_MULT},
 			std::pair {"Velocity Orientation Inherit Mult", ParticleCurvesOutput::ORIENTATION_INHERIT_VELOCITY_MULT}
 		},
+		std::pair {"Trigger Radius", modular_curves_submember_input<&ParticleSource::m_triggerRadius>{}},
 		std::pair {"Host Radius", modular_curves_submember_input<&ParticleSource::m_host, &EffectHost::getHostRadius>{}},
 		std::pair {"Host Velocity", modular_curves_submember_input<&ParticleSource::m_host, &EffectHost::getVelocityMagnitude>{}},
 		//TODO Long term, this should have access to a lot of interesting host properties, especially also those that change during gameplay like current hitpoints

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -176,6 +176,7 @@ public:
 			std::pair {"Velocity Orientation Inherit Mult", ParticleCurvesOutput::ORIENTATION_INHERIT_VELOCITY_MULT}
 		},
 		std::pair {"Trigger Radius", modular_curves_submember_input<&ParticleSource::m_triggerRadius>{}},
+		std::pair {"Trigger Velocity", modular_curves_submember_input<&ParticleSource::m_triggerVelocity>{}},
 		std::pair {"Host Radius", modular_curves_submember_input<&ParticleSource::m_host, &EffectHost::getHostRadius>{}},
 		std::pair {"Host Velocity", modular_curves_submember_input<&ParticleSource::m_host, &EffectHost::getVelocityMagnitude>{}},
 		//TODO Long term, this should have access to a lot of interesting host properties, especially also those that change during gameplay like current hitpoints

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -58,7 +58,7 @@ bool ParticleSource::process() {
 		if (m_effect_is_running[i]) {
 			bool needs_to_continue_running = true;
 
-			while(timestamp_elapsed(timing.m_nextCreation)) {
+			while(timestamp_elapsed(timing.m_nextCreation) && needs_to_continue_running) {
 				//Find "time" in last frame where particle spawned
 				float interp = static_cast<float>(timestamp_since(timing.m_nextCreation)) / (f2fl(Frametime) * 1000.0f);
 

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -86,6 +86,10 @@ void ParticleSource::setNormal(const vec3d& normal) {
 	m_normal = normal;
 }
 
+void ParticleSource::setTriggerRadius(float radius) {
+	m_triggerRadius = radius;
+}
+
 void ParticleSource::setHost(std::unique_ptr<EffectHost> host) {
 	m_host = std::move(host);
 }

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -90,6 +90,10 @@ void ParticleSource::setTriggerRadius(float radius) {
 	m_triggerRadius = radius;
 }
 
+void ParticleSource::setTriggerVelocity(float velocity) {
+	m_triggerVelocity = velocity;
+}
+
 void ParticleSource::setHost(std::unique_ptr<EffectHost> host) {
 	m_host = std::move(host);
 }

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -74,6 +74,7 @@ class ParticleSource {
 	std::optional<vec3d> m_normal;
 
 	std::optional<float> m_triggerRadius;
+	std::optional<float> m_triggerVelocity;
 
 	SCP_vector<SourceTiming> m_timing; //!< The time informations of the particle source
 
@@ -120,6 +121,7 @@ class ParticleSource {
 	void setNormal(const vec3d& normal);
 
 	void setTriggerRadius(float radius);
+	void setTriggerVelocity(float velocity);
 
 	void setHost(std::unique_ptr<EffectHost> host);
 };

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -73,6 +73,8 @@ class ParticleSource {
 
 	std::optional<vec3d> m_normal;
 
+	std::optional<float> m_triggerRadius;
+
 	SCP_vector<SourceTiming> m_timing; //!< The time informations of the particle source
 
 	ParticleEffectHandle m_effect; //!< The effect that is assigned to this source
@@ -116,6 +118,8 @@ class ParticleSource {
 	bool isValid() const;
 
 	void setNormal(const vec3d& normal);
+
+	void setTriggerRadius(float radius);
 
 	void setHost(std::unique_ptr<EffectHost> host);
 };

--- a/code/particle/hosts/EffectHostObject.cpp
+++ b/code/particle/hosts/EffectHostObject.cpp
@@ -15,7 +15,7 @@ static inline WeaponState getWeaponStateOrInvalid(const object* objp) {
 	}
 }
 
-EffectHostObject::EffectHostObject(object* objp, vec3d offset, matrix orientationOverride, bool orientationOverrideRelative) :
+EffectHostObject::EffectHostObject(const object* objp, vec3d offset, matrix orientationOverride, bool orientationOverrideRelative) :
 	EffectHost(orientationOverride, orientationOverrideRelative), m_offset(offset), m_objnum(OBJ_INDEX(objp)),
 	m_objsig(objp->signature), m_weaponState(getWeaponStateOrInvalid(objp)) {}
 

--- a/code/particle/hosts/EffectHostObject.h
+++ b/code/particle/hosts/EffectHostObject.h
@@ -11,7 +11,7 @@ class EffectHostObject : public EffectHost {
 
 	WeaponState m_weaponState;
 public:
-	EffectHostObject(object* objp, vec3d offset, matrix orientationOverride = vmd_identity_matrix, bool orientationOverrideRelative = true);
+	EffectHostObject(const object* objp, vec3d offset, matrix orientationOverride = vmd_identity_matrix, bool orientationOverrideRelative = true);
 
 	std::pair<vec3d, matrix> getPositionAndOrientation(bool relativeToParent, float interp, const std::optional<vec3d>& tabled_offset) const override;
 

--- a/code/particle/hosts/EffectHostSubmodel.cpp
+++ b/code/particle/hosts/EffectHostSubmodel.cpp
@@ -4,7 +4,7 @@
 #include "model/model.h"
 #include "ship/ship.h"
 
-EffectHostSubmodel::EffectHostSubmodel(object* objp, int submodel, vec3d offset, matrix orientationOverride, bool orientationOverrideRelative) :
+EffectHostSubmodel::EffectHostSubmodel(const object* objp, int submodel, vec3d offset, matrix orientationOverride, bool orientationOverrideRelative) :
 	EffectHost(orientationOverride, orientationOverrideRelative), m_offset(offset), m_objnum(OBJ_INDEX(objp)), m_objsig(objp->signature), m_submodel(submodel) {}
 
 std::pair<vec3d, matrix> EffectHostSubmodel::getPositionAndOrientation(bool relativeToParent, float interp, const std::optional<vec3d>& tabled_offset) const {

--- a/code/particle/hosts/EffectHostSubmodel.h
+++ b/code/particle/hosts/EffectHostSubmodel.h
@@ -9,7 +9,7 @@ class EffectHostSubmodel : public EffectHost {
 
 	int m_objnum, m_objsig, m_submodel;
 public:
-	EffectHostSubmodel(object* objp, int submodel, vec3d offset, matrix orientationOverride = vmd_identity_matrix, bool orientationOverrideRelative = true);
+	EffectHostSubmodel(const object* objp, int submodel, vec3d offset, matrix orientationOverride = vmd_identity_matrix, bool orientationOverrideRelative = true);
 
 	std::pair<vec3d, matrix> getPositionAndOrientation(bool relativeToParent, float interp, const std::optional<vec3d>& tabled_offset) const override;
 

--- a/code/particle/hosts/EffectHostVector.cpp
+++ b/code/particle/hosts/EffectHostVector.cpp
@@ -32,8 +32,8 @@ float EffectHostVector::getVelocityMagnitude() const {
 }
 
 float EffectHostVector::getHostRadius() const {
-	if (m_radiusOverride)
-		return *m_radiusOverride;
+	if (m_radius)
+		return *m_radius;
 	else
 		return EffectHost::getHostRadius();
 };
@@ -42,6 +42,6 @@ void EffectHostVector::setVelocityMagnitudeOverride(float velocityMagnitudeOverr
 	m_velocityMagnitudeOverride.emplace(velocityMagnitudeOverride);
 }
 
-void EffectHostVector::setRadiusOverride(float radiusOverride) {
-	m_radiusOverride.emplace(radiusOverride);
+void EffectHostVector::setRadius(float radius) {
+	m_radius.emplace(radius);
 }

--- a/code/particle/hosts/EffectHostVector.h
+++ b/code/particle/hosts/EffectHostVector.h
@@ -11,7 +11,7 @@ class EffectHostVector : public EffectHost {
 	matrix m_orientation;
 	vec3d m_velocity;
   	std::optional<float> m_velocityMagnitudeOverride;
-	std::optional<float> m_radiusOverride;
+	std::optional<float> m_radius;
 public:
 	EffectHostVector(vec3d position, matrix orientation, vec3d velocity, matrix orientationOverride = vmd_identity_matrix, bool orientationOverrideRelative = true);
 
@@ -25,5 +25,5 @@ public:
 
 	void setVelocityMagnitudeOverride(float velocityMagnitudeOverride);
 
-	void setRadiusOverride(float velocityMagnitudeOverride);
+	void setRadius(float radius);
 };

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -4900,7 +4900,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			}();
 
 			particle.m_modular_curves.add_curve("Host Velocity", particle::ParticleEffect::ParticleCurvesOutput::VOLUME_VELOCITY_MULT, modular_curves_entry{thruster_particle_curve});
-			particle.m_modular_curves.add_curve("Host Radius", particle::ParticleEffect::ParticleCurvesOutput::RADIUS_MULT, modular_curves_entry{thruster_particle_curve});
+			particle.m_modular_curves.add_curve("Trigger Radius", particle::ParticleEffect::ParticleCurvesOutput::RADIUS_MULT, modular_curves_entry{thruster_particle_curve});
 
 			tpart.particle_handle = particle::ParticleManager::get()->addEffect(std::move(particle));
 		}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2499,18 +2499,18 @@ particle::ParticleEffectHandle create_ship_legacy_particle_effect(LegacyShipPart
 
 		if (particle_num.max() <= 1.f) {
 			particle_num = ::util::UniformFloatRange(20.f, 50.f);
-			part_number_curve.emplace(modular_curves_entry{damage_spew_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 		}
+		part_number_curve.emplace(modular_curves_entry{damage_spew_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 
 		if (normal_variance <= 0.f) {
 			normal_variance = 0.2f;
-			variance_curve.emplace(modular_curves_entry{damage_spew_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 		}
+		variance_curve.emplace(modular_curves_entry{damage_spew_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 
 		if (lifetime.max() <= 0.f) {
 			lifetime = ::util::UniformFloatRange(0.7f, 1.5f);
-			lifetime_curve.emplace(modular_curves_entry{damage_spew_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 		}
+		lifetime_curve.emplace(modular_curves_entry{damage_spew_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 
 		break;
 	}
@@ -2539,18 +2539,20 @@ particle::ParticleEffectHandle create_ship_legacy_particle_effect(LegacyShipPart
 
 		if (lifetime.max() <= 0.f) {
 			lifetime = ::util::UniformFloatRange(0.5f, 6.f);
-			lifetime_curve.emplace(modular_curves_entry{split_particles_lifetime_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 		}
+		lifetime_curve.emplace(modular_curves_entry{split_particles_lifetime_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 
 		if (radius.max() <= 0.f) {
 			radius = ::util::UniformFloatRange(0.5f, 1.5f);
-			radius_curve.emplace(modular_curves_entry{split_particles_radius_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 		}
+		radius_curve.emplace(modular_curves_entry{split_particles_radius_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 
 		if (velocity.max() <= 0.f) {
 			velocity = ::util::UniformFloatRange(0.f, 1.f);
-			velocity_curve.emplace(modular_curves_entry{split_particles_velocity_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
 		}
+		velocity_curve.emplace(modular_curves_entry{split_particles_velocity_curve, ::util::UniformFloatRange(1.f), ::util::UniformFloatRange(0.f), false});
+
+		break;
 	}
 	default:
 		break;

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -128,7 +128,16 @@ struct modular_curves_submember_input {
 				return 1.0f;
 		}
 		else if constexpr (is_instance_of_v<std::decay_t<decltype(result)>, std::reference_wrapper>) {
-			return number_to_float(result.get());
+			//We could also be returned not a temporary optional from a check, but a true optional stored somewhere, so check for this here
+			if constexpr (is_optional_v<typename std::decay_t<typename std::decay_t<decltype(result)>::type>>) {
+				const auto& inner_result = result.get();
+				if (inner_result.has_value())
+					return number_to_float(*inner_result);
+				else
+					return 1.0f;
+			}
+			else
+				return number_to_float(result.get());
 		}
 		else {
 			return number_to_float(result);

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -975,7 +975,7 @@ size_t* get_pointer_to_weapon_fire_pattern_index(int weapon_type, int ship_idx, 
 void weapon_maybe_spew_particle(object *obj);
 
 bool weapon_armed(weapon *wp, bool hit_target);
-void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, int quadrant = -1, const vec3d* hitnormal = nullptr );
+void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, int quadrant = -1, const vec3d* hitnormal = nullptr, const vec3d* local_hitpos = nullptr, int submodel = -1 );
 void spawn_child_weapons( object *objp, int spawn_index_override = -1);
 
 // call to detonate a weapon. essentially calls weapon_hit() with other_obj as NULL, and sends a packet in multiplayer

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6116,8 +6116,7 @@ void weapon_process_post(object * obj, float frame_time)
 				// do the spawn effect
 				if (wip->spawn_info[i].spawn_effect.isValid()) {
 					auto particleSource = particle::ParticleManager::get()->createSource(wip->spawn_info[i].spawn_effect);
-
-					particleSource->setHost(make_unique<EffectHostVector>(obj->pos, obj->orient, obj->phys_info.vel));
+					particleSource->setHost(std::make_unique<EffectHostObject>(obj, vmd_zero_vector));
 					particleSource->finishCreation();
 				}
 
@@ -7720,12 +7719,36 @@ bool weapon_armed(weapon *wp, bool hit_target)
 	return true;
 }
 
+static std::unique_ptr<EffectHost> weapon_hit_make_effect_host(const object* weapon_obj, const object* impacted_obj, int impacted_submodel, const vec3d* hitpos, const vec3d* local_hitpos) {
+	if (impacted_obj == nullptr || impacted_obj->type != OBJ_SHIP || local_hitpos == nullptr) {
+		//Fall back to Vector. Since we don't have a ship, it's quite likely whatever we're hitting will immediately die, so don't try to attach a particle source.
+		auto vector_host = std::make_unique<EffectHostVector>(*hitpos, weapon_obj->last_orient, weapon_obj->phys_info.vel);
+		vector_host->setRadius(impacted_obj == nullptr ? weapon_obj->radius : impacted_obj->radius);
+		return vector_host;
+	}
+	else {
+		vec3d local_norm;
+		model_instance_global_to_local_dir(&local_norm, &weapon_obj->last_orient.vec.fvec, object_get_model(impacted_obj), object_get_model_instance(impacted_obj), impacted_submodel, &impacted_obj->orient);
+
+		matrix orient;
+		vm_vector_2_matrix_norm(&orient, &local_norm);
+
+		if (impacted_submodel < 0) {
+			//Fall back to object
+			return std::make_unique<EffectHostObject>(impacted_obj, *local_hitpos, orient);
+		}
+		else {
+			//Full subobject
+			return std::make_unique<EffectHostSubmodel>(impacted_obj, impacted_submodel, *local_hitpos, orient);
+		}
+	}
+}
 
 /**
  * Called when a weapon hits something (or, in the case of
  * missiles explodes for any particular reason)
  */
-void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, int quadrant, const vec3d* hitnormal )
+void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, int quadrant, const vec3d* hitnormal, const vec3d* local_hitpos, int submodel)
 {
 	Assert(weapon_obj != NULL);
 	if(weapon_obj == NULL){
@@ -7819,7 +7842,8 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 					&& hit_angle <= fl_radians(ci.max_angle_threshold)
 				) {
 					auto particleSource = particle::ParticleManager::get()->createSource(ci.effect);
-					particleSource->setHost(make_unique<EffectHostVector>(*hitpos, weapon_obj->last_orient, weapon_obj->phys_info.vel));
+					particleSource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
+					particleSource->setTriggerRadius(weapon_obj->radius);
 
 					if (hitnormal)
 					{
@@ -7837,7 +7861,8 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 	if (!valid_conditional_impact && wip->impact_weapon_expl_effect.isValid() && armed_weapon) {
               		auto particleSource = particle::ParticleManager::get()->createSource(wip->impact_weapon_expl_effect);
 
-		particleSource->setHost(make_unique<EffectHostVector>(*hitpos, weapon_obj->last_orient, weapon_obj->phys_info.vel));
+		particleSource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
+		particleSource->setTriggerRadius(weapon_obj->radius);
 
 		if (hitnormal)
 		{
@@ -7846,7 +7871,8 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 		particleSource->finishCreation();
 	} else if (!valid_conditional_impact && wip->dinky_impact_weapon_expl_effect.isValid() && !armed_weapon) {
 		auto particleSource = particle::ParticleManager::get()->createSource(wip->dinky_impact_weapon_expl_effect);
-		particleSource->setHost(make_unique<EffectHostVector>(*hitpos, weapon_obj->last_orient, weapon_obj->phys_info.vel));
+		particleSource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
+		particleSource->setTriggerRadius(weapon_obj->radius);
 
 		if (hitnormal)
 		{
@@ -7887,7 +7913,8 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 				using namespace particle;
 
 				auto primarySource = ParticleManager::get()->createSource(wip->piercing_impact_effect);
-				primarySource->setHost(make_unique<EffectHostVector>(*hitpos, weapon_obj->last_orient, weapon_obj->phys_info.vel));
+				primarySource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
+				primarySource->setTriggerRadius(weapon_obj->radius);
 
 				if (hitnormal)
 				{
@@ -7897,7 +7924,8 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 
 				if (wip->piercing_impact_secondary_effect.isValid()) {
 					auto secondarySource = ParticleManager::get()->createSource(wip->piercing_impact_secondary_effect);
-					secondarySource->setHost(make_unique<EffectHostVector>(*hitpos, weapon_obj->last_orient, weapon_obj->phys_info.vel));
+					secondarySource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
+					secondarySource->setTriggerRadius(weapon_obj->radius);
 
 					if (hitnormal)
 					{

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7844,6 +7844,7 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 					auto particleSource = particle::ParticleManager::get()->createSource(ci.effect);
 					particleSource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
 					particleSource->setTriggerRadius(weapon_obj->radius);
+					particleSource->setTriggerVelocity(vm_vec_mag_quick(&weapon_obj->phys_info.vel));
 
 					if (hitnormal)
 					{
@@ -7863,6 +7864,7 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 
 		particleSource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
 		particleSource->setTriggerRadius(weapon_obj->radius);
+		particleSource->setTriggerVelocity(vm_vec_mag_quick(&weapon_obj->phys_info.vel));
 
 		if (hitnormal)
 		{
@@ -7873,6 +7875,7 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 		auto particleSource = particle::ParticleManager::get()->createSource(wip->dinky_impact_weapon_expl_effect);
 		particleSource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
 		particleSource->setTriggerRadius(weapon_obj->radius);
+		particleSource->setTriggerVelocity(vm_vec_mag_quick(&weapon_obj->phys_info.vel));
 
 		if (hitnormal)
 		{
@@ -7915,6 +7918,7 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 				auto primarySource = ParticleManager::get()->createSource(wip->piercing_impact_effect);
 				primarySource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
 				primarySource->setTriggerRadius(weapon_obj->radius);
+				primarySource->setTriggerVelocity(vm_vec_mag_quick(&weapon_obj->phys_info.vel));
 
 				if (hitnormal)
 				{
@@ -7926,6 +7930,7 @@ void weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, 
 					auto secondarySource = ParticleManager::get()->createSource(wip->piercing_impact_secondary_effect);
 					secondarySource->setHost(weapon_hit_make_effect_host(weapon_obj, impacted_obj, submodel, hitpos, local_hitpos));
 					secondarySource->setTriggerRadius(weapon_obj->radius);
+					secondarySource->setTriggerVelocity(vm_vec_mag_quick(&weapon_obj->phys_info.vel));
 
 					if (hitnormal)
 					{


### PR DESCRIPTION
A followup to #6465.
Note: This is _not_ a behavioural change wrt. to 24.2, but it is a small change to current nightly. As such, it'd be great to include it in 25.0 as to avoid needing a flag to guard the behaviour change.

The main change, apart from a few tiny bugfixes, is that this PR will properly "parent" particle sources to things.
For example, impact spew and other similar particles were just anchored in space, rather than at the ship that was spewing. This has multiple detrimental effects:
1. Modular curves don't have access to the ship data
2. If your particle source has a lifetime > 0, your particles are in  the wrong place as the emitting ship will have moved (this also applies to rotating submodels, which'll now be accounted for when a spawner is attached to one)
4. You cannot parent the particle to the ship itself (glowing hull blobs as currently used in the MVPS for impact flashes of beams for example would greatly benefit from this).

Additionally, some particle sources that could _not_ be parented (for example because the parent is dying) are being supplied the radius of the ship manually to allow access from modular curves.

Furthermore, modular curves are now supplied "trigger radius" and "trigger velocity".
This means, for example on weapon impact, a modder has access to both the velocity and radius of the particle host (the ship being hit), and the velocity and radius of the triggering object (in this case, the weapons radius and velocity) in modular curves.