### PR TITLE
HUD Config Rendering Methods PR 1/7

### DIFF
--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -463,9 +463,9 @@ public:
 	void render(float frametime, bool config = false) override;
 	void startFlashNotify(int duration = 1400);
 	bool maybeFlashNotify(bool flash_fast = false);
-	void renderObjective();
-	void renderRedAlert();
-	void renderSubspace();
+	void renderObjective(bool config);
+	void renderRedAlert(bool config);
+	void renderSubspace(bool config);
 	void pageIn() override;
 	void initialize() override;
 };


### PR DESCRIPTION
Adds config rendering methods to the gauges contained in hud.cpp.

The general process for config rendering:

1. Convert the gauge coordinates and scale to the hud config coordinate system (which can be any coords and scale with the lua API rendering methods).
2. Use those values to get the size of the gauge, often from the assigned bitmap info, and pass that to HUD Config to check when the mouse is over that particular gauge.
3. Adjust the rendering method to skip code that requires a valid mission to be running and/or a valid mission object and instead fill in the various data with stand-in values.
4. Pass everything to the render methods.

Some gauges got commented out updates in case HUD Config is upgraded in the future to allow configuration of more than the base 30 or so gauges that HUD Config currently supports. This is on my to-do after this overhaul anyway.

I have also taken this opportunity to clean up some of the gauge rendering code in a few places. Happy to do more if you notice anything as this is a great opportunity to look for ways to optimize it all.