### PR TITLE
HUD Config Rendering Methods PR 2/7

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -863,6 +863,25 @@ void hud_config_set_mouse_coords(int gauge_config, int x1, int x2, int y1, int y
 	HC_gauge_mouse_coords[gauge_config] = {x1, x2, y1, y2};
 }
 
+// ETS gauge can render as one unified gauge or as three separate gauges using separate drawing functions
+// So this function provides a way to min/max the coords to make sure no matter what method is used, the
+// mouse box inclues all the relevant areas
+void hud_config_set_mouse_coords_ets(int gauge_config, int x1, int x2, int y1, int y2)
+{
+	HC_gauge_mouse_coords[gauge_config].x1 = std::min(HC_gauge_mouse_coords[gauge_config].x1, x1);
+	HC_gauge_mouse_coords[gauge_config].x2 = std::max(HC_gauge_mouse_coords[gauge_config].x2, x2);
+	HC_gauge_mouse_coords[gauge_config].y1 = std::min(HC_gauge_mouse_coords[gauge_config].y1, y1);
+	HC_gauge_mouse_coords[gauge_config].y2 = std::max(HC_gauge_mouse_coords[gauge_config].y2, y2);
+
+	// temporary stuff to show boxes
+	color clr = gr_screen.current_color;
+	color thisColor;
+	gr_init_alphacolor(&thisColor, 255, 255, 255, 80);
+	gr_set_color_fast(&thisColor);
+	// hud_config_draw_box(x1, x2, y1, y2);
+	gr_set_color_fast(&clr);
+}
+
 std::pair<int, int> hud_config_convert_coords(int x, int y, float scale)
 {
 	int outX = HC_gauge_coordinates[0] + static_cast<int>(x * scale);

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -279,5 +279,11 @@ std::tuple<float, float, float> hud_config_convert_coord_sys(float x, float y, i
  */
 void hud_config_set_mouse_coords(int gauge_config, int x1, int x2, int y1, int y2);
 
+/*!
+ * @brief save gauge coords during rendering time so hud config can check if the mouse is hovering over the gauge
+ * @brief this one is specific to the ETS gauge's individual rendering method
+ */
+void hud_config_set_mouse_coords_ets(int gauge_config, int x1, int x2, int y1, int y2);
+
 #endif
 

--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -234,174 +234,240 @@ int HudGaugeEscort::setGaugeColorEscort(int index, int team)
 	return is_flashing;
 }
 
-void HudGaugeEscort::render(float  /*frametime*/, bool /*config*/)
+void HudGaugeEscort::render(float  /*frametime*/, bool config)
 {
-	int	i = 0;
-
 	if (Escort_gauges[0].first_frame < 0)
 		return;
 
-	if ( !Show_escort_view ) {
+	if (!config && !Show_escort_view ) {
 		return;
 	}
 
-	if ( Escort_ships.empty() ) {
+	if (!config && Escort_ships.empty() ) {
 		return;
+	}
+
+	int x = position[0];
+	int y = position[1];
+	float scale = 1.0;
+
+	if (config) {
+		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 	}
 
 	// hud_set_default_color();
-	setGaugeColor();
+	setGaugeColor(HUD_C_NONE, config);
 
 	// draw the top of the escort view
-	renderBitmap(Escort_gauges[0].first_frame, position[0], position[1]);	
-	renderString(position[0] + header_text_offsets[0], position[1] + header_text_offsets[1], header_text);
+	renderBitmap(Escort_gauges[0].first_frame, x, y, scale, config);	
+	renderString(x + fl2i(header_text_offsets[0] * scale), y + fl2i(header_text_offsets[1] * scale), header_text, scale, config);
 
-	int x = position[0] + list_start_offsets[0];
-	int y = position[1] + list_start_offsets[1];
+	int lx = x + fl2i(list_start_offsets[0] * scale);
+	int ly = y + fl2i(list_start_offsets[1] * scale);
 
-	//This is temporary
-	int num_escort_ships = std::min(hud_escort_num_ships_on_list(), Max_escort_ships) - 1;
-	i=0;
+	//This is temporary. Oh really?
+	int num_escort_ships = config ? 2 : std::min(hud_escort_num_ships_on_list(), Max_escort_ships) - 1;
+	if (num_escort_ships > 0) {
+		for (int i = 0; i < num_escort_ships; i++) {
+			renderBitmap(Escort_gauges[1].first_frame, lx, ly, scale, config);
+			renderIcon(lx, ly, i, scale, config);
 
-	if(num_escort_ships > 0)
-	{
-		for(; i < num_escort_ships; i++)
-		{
-			if(i != 0)
-			{
-				x += entry_stagger_w;
-				y += entry_h;
-			}
-			renderBitmap(Escort_gauges[1].first_frame, x, y);
-			
-			//Now we just show the ships info
-			renderIcon(x, y, i);
+			// Apply offset for next entry
+			lx += fl2i(entry_stagger_w * scale);
+			ly += fl2i(entry_h * scale);
 		}
-
-		//Increment for last entry
-		x += entry_stagger_w;
-		y += entry_h;
 	}
 
-	//Show the last escort entry
-	renderBitmap(Escort_gauges[2].first_frame, x, y + bottom_bg_offset);
-	renderIcon(x, y, i);
+	// Show the last escort entry (already positioned correctly)
+	renderBitmap(Escort_gauges[2].first_frame, lx, ly + fl2i(bottom_bg_offset * scale), scale, config);
+	renderIcon(lx, ly, num_escort_ships, scale, config);
+
+	// Now that we know the height of the list, we can send the coords to hud config
+	if (config) {
+		int bmw, bmh;
+		bm_get_info(Escort_gauges[2].first_frame, &bmw, &bmh);
+		hud_config_set_mouse_coords(gauge_config, x, lx + fl2i(bmw * scale), y, ly + fl2i(bmh * scale));
+	}
 }
 
 // draw the shield icon and integrity for the escort ship
-void HudGaugeEscort::renderIcon(int x, int y, int index)
+void HudGaugeEscort::renderIcon(int x, int y, int index, float scale, bool config)
 {
-	if(MULTI_DOGFIGHT && index <= 2)
+	if(!config && MULTI_DOGFIGHT && index <= 2)
 	{
 		renderIconDogfight(x, y, index);
 		return;
 	}
 
-	float	shields, integrity;
-	int		screen_integrity, offset, objnum = -1;
-	char	buf[255];
-
 	auto eship = get_escort_entry_from_index(index);
 
-	if (eship == Escort_ships.end()) {
+	if (!config && eship == Escort_ships.end()) {
 		return;
 	}
 
-	if ( (Game_mode & GM_MULTIPLAYER) && (eship->np_id >= 0) ) {
-		int np_index = find_player_index(eship->np_id);
+	int objnum = -1;
+	if (!config) {
+		if ((Game_mode & GM_MULTIPLAYER) && (eship->np_id >= 0)) {
+			int np_index = find_player_index(eship->np_id);
 
-		if (np_index >= 0) {
-			objnum = Net_players[np_index].m_player->objnum;
+			if (np_index >= 0) {
+				objnum = Net_players[np_index].m_player->objnum;
 
-			// this can occassionally happen in multi when a player still needs to respawn.
-			if (objnum < 0 || Objects[objnum].type != OBJ_SHIP){
-				return;
+				// this can occassionally happen in multi when a player still needs to respawn.
+				if (objnum < 0 || Objects[objnum].type != OBJ_SHIP) {
+					return;
+				}
 			}
-			
+
+		} else {
+			objnum = eship->objnum;
 		}
 
+		if (objnum < 0) {
+			return;
+		}
+	}
+
+	object* objp = nullptr;
+	ship* sp = nullptr;
+
+	if (!config) {
+		objp = &Objects[objnum];
+		sp = &Ships[objp->instance];
+
+		// determine if its "friendly" or not
+		// Goober5000 - changed in favor of just passing the team
+		setGaugeColorEscort(index, sp->team);
 	} else {
-		objnum = eship->objnum;
+		// For config we do friendly, friendly disable, and hostile in that order
+		// But try to find defined IFFs that match, else just use red and green
+		bool found;
+		switch (index) {
+		case 2:
+			// Try to find hostile
+			found = false;
+			for (iff_info& iff : Iff_info) {
+				if (!stricmp(iff.iff_name, "hostile")) {
+					gr_set_color_fast(iff_get_color(iff.color_index, false));
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				gr_set_color_fast(&Color_bright_red);
+			}
+			break;
+		default:
+			// Try to find friendly
+			found = false;
+			for (iff_info& iff : Iff_info) {
+				if (!stricmp(iff.iff_name, "friendly")) {
+					gr_set_color_fast(iff_get_color(iff.color_index, false));
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				gr_set_color_fast(&Color_bright_green);
+			}
+			break;
+		}
 	}
-
-	if (objnum < 0) {
-		return;
-	}
-
-	object	*objp	= &Objects[objnum];
-	ship	*sp		= &Ships[objp->instance];
-
-	// determine if its "friendly" or not	
-	// Goober5000 - changed in favor of just passing the team
-	setGaugeColorEscort(index, sp->team);
-	/*
-	if(Player_ship != NULL){
-		hud_escort_set_gauge_color(index, (sp->team == Player_ship->team) ? 1 : 0);
-	} else {
-		hud_escort_set_gauge_color(index, 1);
-	}
-	*/
 
 	// draw a 'D' if a ship is disabled
-	if ( (sp->flags[Ship::Ship_Flags::Disabled]) || (ship_subsys_disrupted(sp, SUBSYSTEM_ENGINE)) ) {		
-		renderString( x + ship_status_offsets[0], y + ship_status_offsets[1], EG_NULL, XSTR( "D", 284));				
+	if ((config && index == 1) || (!config && (( (sp->flags[Ship::Ship_Flags::Disabled]) || (ship_subsys_disrupted(sp, SUBSYSTEM_ENGINE)) )))) {		
+		renderString( x + fl2i(ship_status_offsets[0] * scale), y + fl2i(ship_status_offsets[1] * scale), EG_NULL, XSTR( "D", 284), scale, config);				
 	}
 
 	// print out ship name
 	// original behavior replaced with similar logic to hudtargetbox.cpp, except
 	// if the name is hidden, it's replaced with the class name.
-	if (((Iff_info[sp->team].flags & IFFF_WING_NAME_HIDDEN) && (sp->wingnum != -1)) || (sp->flags[Ship::Ship_Flags::Hide_ship_name]))
-	{
-		// If we're hiding the ship name, we probably shouldn't append the callsign either
-		hud_stuff_ship_class(buf, sp);
-	}
-	else
-	{
-		hud_stuff_ship_name(buf, sp);
+	char buf[255];
+	if (!config) {
+		if (((Iff_info[sp->team].flags & IFFF_WING_NAME_HIDDEN) && (sp->wingnum != -1)) ||
+			(sp->flags[Ship::Ship_Flags::Hide_ship_name])) {
+			// If we're hiding the ship name, we probably shouldn't append the callsign either
+			hud_stuff_ship_class(buf, sp);
+		} else {
+			hud_stuff_ship_name(buf, sp);
 
-		if (!Dont_show_callsigns_in_escort_list)
-		{
-			// maybe concatenate the callsign
-			if (*buf)
-			{
-				char callsign[NAME_LENGTH];
+			if (!Dont_show_callsigns_in_escort_list) {
+				// maybe concatenate the callsign
+				if (*buf) {
+					char callsign[NAME_LENGTH];
 
-				hud_stuff_ship_callsign(callsign, sp);
-				if (*callsign)
-					sprintf(&buf[strlen(buf)], " (%s)", callsign);
+					hud_stuff_ship_callsign(callsign, sp);
+					if (*callsign)
+						sprintf(&buf[strlen(buf)], " (%s)", callsign);
+				}
+				// maybe substitute the callsign
+				else {
+					hud_stuff_ship_callsign(buf, sp);
+				}
 			}
-			// maybe substitute the callsign
-			else
-			{
-				hud_stuff_ship_callsign(buf, sp);
-			}
+		}
+	} else {
+		switch (index) {
+		case 0:
+			strcpy(buf, "Friendly Ship");
+			break;
+		case 1:
+			strcpy(buf, "Friendly Disabled Ship");
+			break;
+		case 2:
+			strcpy(buf, "Hostile Ship");
+			break;
+		default:
+			strcpy(buf, "Escort Ship");
+			break;
 		}
 	}
 
-	const int w = font::force_fit_string(buf, 255, ship_name_max_width);
+	const int w = font::force_fit_string(buf, 255, fl2i(ship_name_max_width * scale), scale);
 	
 	if (right_align_names) {
-		renderString( x + ship_name_offsets[0] + ship_name_max_width - w, y + ship_name_offsets[1], EG_ESCORT1 + index, buf);
+		renderString( x + fl2i(ship_name_offsets[0] * scale) + fl2i(ship_name_max_width * scale) - w, y + fl2i(ship_name_offsets[1] * scale), EG_ESCORT1 + index, buf, scale, config);
 	} else {
-		renderString( x + ship_name_offsets[0], y + ship_name_offsets[1], EG_ESCORT1 + index, buf);
+		renderString( x + fl2i(ship_name_offsets[0] * scale), y + fl2i(ship_name_offsets[1] * scale), EG_ESCORT1 + index, buf, scale, config);
 	}
 
+	int screen_integrity;
+
 	// show ship integrity
-	hud_get_target_strength(objp, &shields, &integrity);
-	screen_integrity = (int)std::lround(integrity * 100);
-	offset = 0;
-	if ( screen_integrity < 100 ) {
+	float integrity = 0.0f;
+	if (!config) {
+		float shields;
+		hud_get_target_strength(objp, &shields, &integrity);
+		screen_integrity = fl2i(std::lround(integrity * 100));
+	} else {
+		switch (index) {
+		case 1:
+			screen_integrity = 25;
+			break;
+		case 2:
+			screen_integrity = 50;
+			break;
+		default:
+			screen_integrity = 100;
+			break;
+		}
+	}
+
+	// set offsets based on integrity
+	int offset = 0;
+	if (screen_integrity < 100) {
 		offset = 2;
-		if ( screen_integrity == 0 ) {
-			if ( integrity > 0 ) {
+		if (screen_integrity == 0) {
+			if (integrity > 0) {
 				screen_integrity = 1;
 			}
 		}
 	}
-	renderPrintfWithGauge( x+ship_integrity_offsets[0] + offset, y+ship_integrity_offsets[1], EG_NULL, 1.0f, false, "%d", screen_integrity);
+
+	renderPrintfWithGauge( x+fl2i(ship_integrity_offsets[0] * scale) + offset, y+fl2i(ship_integrity_offsets[1] * scale), EG_NULL, scale, config, "%d", screen_integrity);
 
 	//Let's be nice.
-	setGaugeColor();
+	setGaugeColor(HUD_C_NONE, config);
 }
 
 // multiplayer dogfight

--- a/code/hud/hudescort.h
+++ b/code/hud/hudescort.h
@@ -31,9 +31,9 @@ void	hud_escort_ship_hit(const object *objp, int quadrant);
 void	hud_escort_target_next();
 void	hud_escort_cull_list();
 void	hud_add_ship_to_escort(int objnum, int supress_feedback);
-void  hud_remove_ship_from_escort(int objnum);
-int	hud_escort_num_ships_on_list();
-int	hud_escort_return_objnum(int index);
+void    hud_remove_ship_from_escort(int objnum);
+int     hud_escort_num_ships_on_list();
+int     hud_escort_return_objnum(int index);
 void	hud_escort_add_player(short id);
 void	hud_escort_remove_player(short id);
 
@@ -70,7 +70,7 @@ public:
 	int setGaugeColorEscort(int index, int team);
 	void render(float frametime, bool config = false) override;
 	void pageIn() override;
-	void renderIcon(int x, int y, int index);
+	void renderIcon(int x, int y, int index, float scale, bool config);
 	void renderIconDogfight(int x, int y, int index);
 };
 

--- a/code/hud/hudets.h
+++ b/code/hud/hudets.h
@@ -79,7 +79,7 @@ public:
 	void initLetter(char _letter);	// obligatory PC Load Letter joke. (Swifty)
 	void initBarHeight(int _ets_bar_h);
 	void initBitmaps(char *fname);
-	void blitGauge(int index);
+	void blitGauge(int index, int ix, int iy, float scale, bool config);
 	void render(float frametime, bool config = false) override;
 	void pageIn() override;
 };

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -279,13 +279,26 @@ void HudGaugeLock::renderOld(float frametime)
 // lock_point_pos should be the world coordinates of the target being locked. Assuming all the 
 // necessary locking calculations are done for this frame, this function will compute 
 // where the indicator should be relative to the player's viewpoint and will render accordingly.
-void HudGaugeLock::render(float frametime, bool /*config*/)
+void HudGaugeLock::render(float frametime, bool config)
 {
-	size_t i;
-	lock_info *current_lock;
+	float scale = 1.0;
 
-	vertex lock_point;
-	int sx, sy;
+	// This gauge does not accept config settings so we don't have to render it right now.
+	// That may change in the future, in which case the code below can be restored.
+	if (config) {
+		// The coords don't really get converted here but we still get scale based on the screen size which we need
+		/* int x = 0, y = 0;
+		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
+
+		int w;
+		int h;
+		// Will need actual coords for the below if we activate this gauge in config
+		hud_config_set_mouse_coords(gauge_config, x, x + w, y, y + h);
+
+		setGaugeColor(HUD_C_NONE, config);*/
+
+		return;
+	}
 
 	// check to see if there are any missile to fire.. we don't want to show the 
 	// lock indicator if there are missiles to fire.
@@ -299,58 +312,59 @@ void HudGaugeLock::render(float frametime, bool /*config*/)
 	gr_set_screen_scale(base_w, base_h);
 
 	// go through all present lock indicators
-	for ( i = 0; i < Player_ship->missile_locks.size(); ++i ) {
-		current_lock = &Player_ship->missile_locks[i];
+	for (auto& current_lock : Player_ship->missile_locks){
 
-		if ( !current_lock->indicator_visible ) {
+		if ( !current_lock.indicator_visible ) {
 			continue;
 		}
 
 		// Get the target's current position on the screen. If he's not on there,
 		// we're not going to draw the lock indicator even if he's in front 
 		// of our ship, so bail out. 
-		g3_rotate_vertex(&lock_point, &current_lock->world_pos); 
+		vertex lock_point;
+		g3_rotate_vertex(&lock_point, &current_lock.world_pos); 
 		g3_project_vertex(&lock_point);
 
 		if (lock_point.codes & PF_OVERFLOW) {
 			continue;
 		}
 
-		hud_set_iff_color(current_lock->obj);
+		hud_set_iff_color(current_lock.obj);
 
 		// We have the coordinates of the lock indicator relative to the target in our "virtual frame" 
 		// so, we calculate where it should be drawn based on the player's viewpoint.
-		if ( current_lock->locked ) {
+		int sx, sy;
+		if ( current_lock.locked ) {
 			sx = fl2i(lock_point.screen.xyw.x); 
 			sy = fl2i(lock_point.screen.xyw.y);
 			gr_unsize_screen_pos(&sx, &sy);
 
 			// show the rotating triangles if target is locked
-			renderLockTrianglesNew(sx, sy, frametime, current_lock);
+			renderLockTrianglesNew(sx, sy, frametime, &current_lock);
 		} else {
 			const float scaling_factor = (gr_screen.clip_center_x < gr_screen.clip_center_y)
 											 ? (gr_screen.clip_center_x / VIRTUAL_FRAME_HALF_WIDTH)
 											 : (gr_screen.clip_center_y / VIRTUAL_FRAME_HALF_HEIGHT);
-			sx = fl2i(lock_point.screen.xyw.x) - fl2i(i2fl(current_lock->current_target_sx - current_lock->indicator_x) * scaling_factor);
-			sy = fl2i(lock_point.screen.xyw.y) - fl2i(i2fl(current_lock->current_target_sy - current_lock->indicator_y) * scaling_factor);
+			sx = fl2i(lock_point.screen.xyw.x) - fl2i(i2fl(current_lock.current_target_sx - current_lock.indicator_x) * scaling_factor);
+			sy = fl2i(lock_point.screen.xyw.y) - fl2i(i2fl(current_lock.current_target_sy - current_lock.indicator_y) * scaling_factor);
 			gr_unsize_screen_pos(&sx, &sy);
 		}
 
-		Lock_gauge.sx = sx - Lock_gauge_half_w;
-		Lock_gauge.sy = sy - Lock_gauge_half_h;
-		if( current_lock->locked ){
-			current_lock->lock_gauge_time_elapsed = 0.0f;
-			Lock_gauge.time_elapsed = current_lock->lock_gauge_time_elapsed;
-			hud_anim_render(&Lock_gauge, 0.0f, 1);
+		Lock_gauge.sx = sx - fl2i(Lock_gauge_half_w * scale);
+		Lock_gauge.sy = sy - fl2i(Lock_gauge_half_h * scale);
+		if( current_lock.locked ){
+			current_lock.lock_gauge_time_elapsed = 0.0f;
+			Lock_gauge.time_elapsed = current_lock.lock_gauge_time_elapsed;
+			hud_anim_render(&Lock_gauge, 0.0f, 1, 1, 0, 0, GR_RESIZE_FULL, false, scale);
 		} else {
 			// manually track the animation time, since we may have more than one lock
-			current_lock->lock_gauge_time_elapsed += frametime;
-			if (current_lock->lock_gauge_time_elapsed > Lock_gauge.total_time) {
-				current_lock->lock_gauge_time_elapsed = 0.0f;
+			current_lock.lock_gauge_time_elapsed += frametime;
+			if (current_lock.lock_gauge_time_elapsed > Lock_gauge.total_time) {
+				current_lock.lock_gauge_time_elapsed = 0.0f;
 			}
-			Lock_gauge.time_elapsed = current_lock->lock_gauge_time_elapsed;
+			Lock_gauge.time_elapsed = current_lock.lock_gauge_time_elapsed;
 
-			hud_anim_render(&Lock_gauge, 0.0f, 1);
+			hud_anim_render(&Lock_gauge, 0.0f, 1, 1, 0, 0, GR_RESIZE_FULL, false, scale);
 		}
 	}
 


### PR DESCRIPTION
Adds config rendering methods to the escort and est gauges; preliminary support for the lock gauge.

The general process for config rendering:

1. Convert the gauge coordinates and scale to the hud config coordinate system (which can be any coords and scale with the lua API rendering methods).
2. Use those values to get the size of the gauge, often from the assigned bitmap info, and pass that to HUD Config to check when the mouse is over that particular gauge.
3. Adjust the rendering method to skip code that requires a valid mission to be running and/or a valid mission object and instead fill in the various data with stand-in values.
4. Pass everything to the render methods.

Some gauges got commented out updates in case HUD Config is upgraded in the future to allow configuration of more than the base 30 or so gauges that HUD Config currently supports. This is on my to-do after this overhaul anyway.

I have also taken this opportunity to clean up some of the gauge rendering code in a few places. Happy to do more if you notice anything as this is a great opportunity to look for ways to optimize it all.