### PR TITLE
HUD Config Rendering Methods PR 7/7

### DIFF
--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -96,10 +96,21 @@ void HudGaugeRadarStd::blipDrawFlicker(blip *b, int x, int y)
 
 	drawContactCircle(x + xdiff, y + ydiff, b->rad);
 }
-void HudGaugeRadarStd::blitGauge()
+void HudGaugeRadarStd::blitGauge(bool config)
 {
+	int x = position[0];
+	int y = position[1];
+	float scale = 1.0;
+
+	if (config) {
+		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
+		int bmw, bmh;
+		bm_get_info(Radar_gauge.first_frame + 1, &bmw, &bmh);
+		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+	}
+	
 	if (Radar_gauge.first_frame + 1 >= 0)
-		renderBitmap(Radar_gauge.first_frame+1, position[0], position[1] );
+		renderBitmap(Radar_gauge.first_frame+1, x, y, scale, config);
 }
 void HudGaugeRadarStd::drawBlips(int blip_type, int bright, int distort)
 {
@@ -279,77 +290,78 @@ void HudGaugeRadarStd::drawContactImage( int x, int y, int rad, int idx, int clr
 	gr_screen.clip_right_unscaled = old_right_unscaled;
 }
 
-void HudGaugeRadarStd::render(float  /*frametime*/, bool /*config*/)
+void HudGaugeRadarStd::render(float  /*frametime*/, bool config)
 {
 	//WMC - This strikes me as a bit hackish
 	bool g3_yourself = !g3_in_frame();
 	if(g3_yourself)
 		g3_start_frame(1);
 
-	float	sensors_str;
-	int ok_to_blit_radar;
+	int ok_to_blit_radar = 1;
 
-	ok_to_blit_radar = 1;
+	if (!config) {
+		float sensors_str = ship_get_subsystem_strength(Player_ship, SUBSYSTEM_SENSORS);
 
-	sensors_str = ship_get_subsystem_strength( Player_ship, SUBSYSTEM_SENSORS );
-
-	if ( ship_subsys_disrupted(Player_ship, SUBSYSTEM_SENSORS) ) {
-		sensors_str = MIN_SENSOR_STR_TO_RADAR-1;
-	}
-
-	// note that on lowest skill level, there is no radar effects due to sensors damage
-	if ( ((Game_skill_level == 0) || (sensors_str > SENSOR_STR_RADAR_NO_EFFECTS)) && !Sensor_static_forced ) {
-		Radar_static_playing = false;
-		Radar_static_next = TIMESTAMP::never();
-		Radar_death_timer = TIMESTAMP::never();
-		Radar_avail_prev_frame = true;
-	} else if ( sensors_str < MIN_SENSOR_STR_TO_RADAR ) {
-		if ( Radar_avail_prev_frame ) {
-			Radar_death_timer = _timestamp(2000);
-			Radar_static_next = TIMESTAMP::immediate();
+		if (ship_subsys_disrupted(Player_ship, SUBSYSTEM_SENSORS)) {
+			sensors_str = MIN_SENSOR_STR_TO_RADAR - 1;
 		}
-		Radar_avail_prev_frame = false;
-	} else {
-		Radar_death_timer = TIMESTAMP::never();
-		if ( Radar_static_next.isNever() )
-			Radar_static_next = TIMESTAMP::immediate();
+
+		// note that on lowest skill level, there is no radar effects due to sensors damage
+		if (((Game_skill_level == 0) || (sensors_str > SENSOR_STR_RADAR_NO_EFFECTS)) && !Sensor_static_forced) {
+			Radar_static_playing = false;
+			Radar_static_next = TIMESTAMP::never();
+			Radar_death_timer = TIMESTAMP::never();
+			Radar_avail_prev_frame = true;
+		} else if (sensors_str < MIN_SENSOR_STR_TO_RADAR) {
+			if (Radar_avail_prev_frame) {
+				Radar_death_timer = _timestamp(2000);
+				Radar_static_next = TIMESTAMP::immediate();
+			}
+			Radar_avail_prev_frame = false;
+		} else {
+			Radar_death_timer = TIMESTAMP::never();
+			if (Radar_static_next.isNever())
+				Radar_static_next = TIMESTAMP::immediate();
+		}
+
+		if (timestamp_elapsed(Radar_death_timer)) {
+			ok_to_blit_radar = 0;
+		}
 	}
 
-	if ( timestamp_elapsed(Radar_death_timer) ) {
-		ok_to_blit_radar = 0;
-	}
-
-	setGaugeColor();
-	blitGauge();
-	drawRange();
+	setGaugeColor(HUD_C_NONE, config);
+	blitGauge(config);
+	drawRange(config);
 
 	if ( timestamp_elapsed(Radar_static_next) ) {
 		Radar_static_playing = !Radar_static_playing;
 		Radar_static_next = _timestamp_rand(50, 750);
 	}
 
-	// if the emp effect is active, always draw the radar wackily
-	if(emp_active_local()){
-		Radar_static_playing = true;
-	}
+	if (!config) {
+		// if the emp effect is active, always draw the radar wackily
+		if (emp_active_local()) {
+			Radar_static_playing = true;
+		}
 
-	if ( ok_to_blit_radar ) {
-		if ( Radar_static_playing ) {
-			drawBlipsSorted(1);	// passing 1 means to draw distorted
-			if (!Radar_static_looping.isValid()) {
-				Radar_static_looping = snd_play_looping(gamesnd_get_game_sound(GameSounds::STATIC));
+		if (ok_to_blit_radar) {
+			if (Radar_static_playing) {
+				drawBlipsSorted(1); // passing 1 means to draw distorted
+				if (!Radar_static_looping.isValid()) {
+					Radar_static_looping = snd_play_looping(gamesnd_get_game_sound(GameSounds::STATIC));
+				}
+			} else {
+				drawBlipsSorted(0);
+				if (Radar_static_looping.isValid()) {
+					snd_stop(Radar_static_looping);
+					Radar_static_looping = sound_handle::invalid();
+				}
 			}
 		} else {
-			drawBlipsSorted(0);
 			if (Radar_static_looping.isValid()) {
 				snd_stop(Radar_static_looping);
 				Radar_static_looping = sound_handle::invalid();
 			}
-		}
-	} else {
-		if (Radar_static_looping.isValid()) {
-			snd_stop(Radar_static_looping);
-			Radar_static_looping = sound_handle::invalid();
 		}
 	}
 

--- a/code/radar/radar.h
+++ b/code/radar/radar.h
@@ -58,7 +58,7 @@ public:
 
 	void blipDrawDistorted(blip *b, int x, int y);
 	void blipDrawFlicker(blip *b, int x, int y);
-	void blitGauge();
+	void blitGauge(bool config);
 	void drawBlips(int blip_type, int bright, int distort);
 	void drawBlipsSorted(int distort);
 	void drawContactCircle( int x, int y, int rad );

--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -452,8 +452,13 @@ void HudGaugeRadarDradis::drawBlipsSorted(int distort)
 }
 
 
-void HudGaugeRadarDradis::render(float  /*frametime*/, bool /*config*/)
+void HudGaugeRadarDradis::render(float  /*frametime*/, bool config)
 {
+	// Not yet supported in config
+	if (config) {
+		return;
+	}
+	
 	float sensors_str;
 	int   ok_to_blit_radar;
 	

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -380,49 +380,54 @@ void HudGaugeRadarOrb::drawOutlinesHtl()
     g3_done_instance(true);
 }
 
-void HudGaugeRadarOrb::render(float  /*frametime*/, bool /*config*/)
+void HudGaugeRadarOrb::render(float  /*frametime*/, bool config)
 {
-	float	sensors_str;
-	int ok_to_blit_radar;
-
 	//WMC - This strikes me as a bit hackish
 	bool g3_yourself = !g3_in_frame();
 	if(g3_yourself)
 		g3_start_frame(1);
 
-	ok_to_blit_radar = 1;
+	int ok_to_blit_radar = 1;
 
-	sensors_str = ship_get_subsystem_strength( Player_ship, SUBSYSTEM_SENSORS );
+	if (!config) {
+		float sensors_str = ship_get_subsystem_strength(Player_ship, SUBSYSTEM_SENSORS);
 
-	if ( ship_subsys_disrupted(Player_ship, SUBSYSTEM_SENSORS) ) {
-		sensors_str = MIN_SENSOR_STR_TO_RADAR-1;
-	}
-
-	// note that on lowest skill level, there is no radar effects due to sensors damage
-	if (((Game_skill_level == 0) || (sensors_str > SENSOR_STR_RADAR_NO_EFFECTS)) && !Sensor_static_forced) {
-		Radar_static_playing = false;
-		Radar_static_next = TIMESTAMP::never();
-		Radar_death_timer = TIMESTAMP::never();
-		Radar_avail_prev_frame = true;
-	} else if ( sensors_str < MIN_SENSOR_STR_TO_RADAR ) {
-		if ( Radar_avail_prev_frame ) {
-			Radar_death_timer = _timestamp(2000);
-			Radar_static_next = TIMESTAMP::immediate();
+		if (ship_subsys_disrupted(Player_ship, SUBSYSTEM_SENSORS)) {
+			sensors_str = MIN_SENSOR_STR_TO_RADAR - 1;
 		}
-		Radar_avail_prev_frame = false;
-	} else {
-		Radar_death_timer = TIMESTAMP::never();
-		if ( Radar_static_next.isNever() )
-			Radar_static_next = TIMESTAMP::immediate();
+
+		// note that on lowest skill level, there is no radar effects due to sensors damage
+		if (((Game_skill_level == 0) || (sensors_str > SENSOR_STR_RADAR_NO_EFFECTS)) && !Sensor_static_forced) {
+			Radar_static_playing = false;
+			Radar_static_next = TIMESTAMP::never();
+			Radar_death_timer = TIMESTAMP::never();
+			Radar_avail_prev_frame = true;
+		} else if (sensors_str < MIN_SENSOR_STR_TO_RADAR) {
+			if (Radar_avail_prev_frame) {
+				Radar_death_timer = _timestamp(2000);
+				Radar_static_next = TIMESTAMP::immediate();
+			}
+			Radar_avail_prev_frame = false;
+		} else {
+			Radar_death_timer = TIMESTAMP::never();
+			if (Radar_static_next.isNever())
+				Radar_static_next = TIMESTAMP::immediate();
+		}
+
+		if (timestamp_elapsed(Radar_death_timer)) {
+			ok_to_blit_radar = 0;
+		}
 	}
 
-	if ( timestamp_elapsed(Radar_death_timer) ) {
-		ok_to_blit_radar = 0;
-	}
+	setGaugeColor(HUD_C_NONE, config);
+	blitGauge(config);
+	drawRange(config);
 
-	setGaugeColor();
-	blitGauge();
-	drawRange();
+	// For now config view stops here but it should be doable to have
+	// this render the orb outlines using the next two functions eventually
+	if (config) {
+		return;
+	}
 
     setupViewHtl();
     drawOutlinesHtl();
@@ -463,10 +468,21 @@ void HudGaugeRadarOrb::render(float  /*frametime*/, bool /*config*/)
 		g3_end_frame();
 }
 
-void HudGaugeRadarOrb::blitGauge()
+void HudGaugeRadarOrb::blitGauge(bool config)
 {
+	int x = position[0];
+	int y = position[1];
+	float scale = 1.0;
+
+	if (config) {
+		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
+		int bmw, bmh;
+		bm_get_info(Radar_gauge.first_frame + 1, &bmw, &bmh);
+		hud_config_set_mouse_coords(gauge_config, x, x + static_cast<int>(bmw * scale), y, y + static_cast<int>(bmh * scale));
+	}
+	
 	if (Radar_gauge.first_frame + 1 >= 0)
-		renderBitmap(Radar_gauge.first_frame+1, position[0], position[1] );
+		renderBitmap(Radar_gauge.first_frame+1, x, y, scale, config );
 }
 
 void HudGaugeRadarOrb::pageIn()

--- a/code/radar/radarorb.h
+++ b/code/radar/radarorb.h
@@ -44,7 +44,7 @@ public:
 
 	void blipDrawDistorted(blip *b, vec3d *pos);
 	void blipDrawFlicker(blip *b, vec3d *pos);
-	void blitGauge();
+	void blitGauge(bool config);
 	void drawBlips(int blip_type, int bright, int distort);
 	void drawBlipsSorted(int distort);
 	void drawContact(vec3d *pnt, int rad);

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -463,27 +463,37 @@ void HudGaugeRadar::initialize()
 	HudGauge::initialize();
 }
 
-void HudGaugeRadar::drawRange()
+void HudGaugeRadar::drawRange(bool config)
 {
 	// hud_set_bright_color();
-	setGaugeColor(HUD_C_BRIGHT);
+	setGaugeColor(HUD_C_BRIGHT, config);
 
-	switch ( HUD_config.rp_dist ) {
+	int x = position[0];
+	int y = position[1];
+	float scale = 1.0;
+
+	if (config) {
+		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
+	}
+
+	int range = config ? RR_INFINITY : HUD_config.rp_dist;
+
+	switch ( range ) {
 
 	case RR_SHORT:
-		renderPrintf(position[0] + Radar_dist_offsets[RR_SHORT][0], position[1] + Radar_dist_offsets[RR_SHORT][1], 1.0f, false, "%s", XSTR( "2k", 467));
+		renderPrintf(x + fl2i(Radar_dist_offsets[RR_SHORT][0] * scale), y + fl2i(Radar_dist_offsets[RR_SHORT][1] * scale), scale, config, "%s", XSTR( "2k", 467));
 		break;
 
 	case RR_LONG:
-		renderPrintf(position[0] + Radar_dist_offsets[RR_LONG][0], position[1] + Radar_dist_offsets[RR_LONG][1], 1.0f, false, "%s", XSTR( "10k", 468));
+		renderPrintf(x + fl2i(Radar_dist_offsets[RR_LONG][0] * scale), y + fl2i(Radar_dist_offsets[RR_LONG][1] * scale), scale, config, "%s", XSTR( "10k", 468));
 		break;
 
 	case RR_INFINITY:
 		if (Unicode_text_mode) {
 			// This escape sequence is the UTF-8 encoding of the infinity symbol. We can't use u8 yet since VS2013 doesn't support it
-			renderPrintf(position[0] + Radar_dist_offsets[RR_INFINITY][0], position[1] + Radar_dist_offsets[RR_INFINITY][1], 1.0f, false, "\xE2\x88\x9E");
+			renderPrintf(x + fl2i(Radar_dist_offsets[RR_INFINITY][0] * scale), y + fl2i(Radar_dist_offsets[RR_INFINITY][1] * scale), scale, config, "\xE2\x88\x9E");
 		} else {
-			renderPrintf(position[0] + Radar_dist_offsets[RR_INFINITY][0], position[1] + Radar_dist_offsets[RR_INFINITY][1], 1.0f, false, "%c", Radar_infinity_icon);
+			renderPrintf(x + fl2i(Radar_dist_offsets[RR_INFINITY][0] * scale), y + fl2i(Radar_dist_offsets[RR_INFINITY][1] * scale), scale, config, "%c", Radar_infinity_icon);
 		}
 		break;
 

--- a/code/radar/radarsetup.h
+++ b/code/radar/radarsetup.h
@@ -125,7 +125,7 @@ public:
 	void initDistanceInfinityOffsets(int x, int y);
 	void initInfinityIcon();
 
-	void drawRange();
+	void drawRange(bool config);
 	void render(float frametime, bool config = false) override;
 	void initialize() override;
 	void pageIn() override;


### PR DESCRIPTION
Adds config rendering methods to the orb and standard radar gauges.

The general process for config rendering:

1. Convert the gauge coordinates and scale to the hud config coordinate system (which can be any coords and scale with the lua API rendering methods).
2. Use those values to get the size of the gauge, often from the assigned bitmap info, and pass that to HUD Config to check when the mouse is over that particular gauge.
3. Adjust the rendering method to skip code that requires a valid mission to be running and/or a valid mission object and instead fill in the various data with stand-in values.
4. Pass everything to the render methods.

Some gauges got commented out updates in case HUD Config is upgraded in the future to allow configuration of more than the base 30 or so gauges that HUD Config currently supports. This is on my to-do after this overhaul anyway.

I have also taken this opportunity to clean up some of the gauge rendering code in a few places. Happy to do more if you notice anything as this is a great opportunity to look for ways to optimize it all.