### PR TITLE
fix wing creation dialog

### DIFF
--- a/fred2/createwingdlg.cpp
+++ b/fred2/createwingdlg.cpp
@@ -57,7 +57,6 @@ void create_wing_dlg::OnOK()
 {
 	CString msg;
 	int i;
-	object *ptr;
 
 	UpdateData(TRUE);
 	UpdateData(TRUE);
@@ -74,32 +73,37 @@ void create_wing_dlg::OnOK()
 			return;
 		}
 
-	ptr = GET_FIRST(&obj_used_list);
-	while (ptr != END_OF_LIST(&obj_used_list)) {
-		if ((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)){
-			i = ptr->instance;
-			if (!strnicmp(m_name, Ships[i].ship_name, strlen(m_name))) {
-				char *namep;
+	auto len = strlen(m_name);
+	for (auto ptr: list_range(&obj_used_list)) {
+		if ((ptr->type != OBJ_SHIP) && (ptr->type != OBJ_START))
+			continue;
+		i = ptr->instance;
 
-				namep = Ships[i].ship_name + strlen(m_name);
-				if (*namep == ' ') {
-					namep++;
-					while (*namep) {
-						if (!isdigit(*namep))
-							break;
-
-						namep++;
-					}
-				}
-
-				if (!*namep) {
-					MessageBox("This wing name is already being used by a ship");
-					return;
-				}
-			}
+		// if this ship is actually going to be in the wing, and if it *can* be in a wing
+		// (i.e. it will not be taken out later), then skip the name check
+		if (ptr->flags[Object::Object_Flags::Marked]) {
+			int ship_type = ship_query_general_type(i);
+			if (ship_type >= 0 && Ship_types[ship_type].flags[Ship::Type_Info_Flags::AI_can_form_wing])
+				continue;
 		}
 
-		ptr = GET_NEXT(ptr);
+		// see if this ship name matches what a ship in the wing would be
+		if (!strnicmp(m_name, Ships[i].ship_name, len)) {
+			auto namep = Ships[i].ship_name + len;
+			if (*namep == ' ') {
+				namep++;
+				while (*namep) {
+					if (!isdigit(*namep))
+						break;
+					namep++;
+				}
+			}
+
+			if (!*namep) {
+				MessageBox("This wing name is already being used by a ship");
+				return;
+			}
+		}
 	}
 
 	// We don't need to check teams.  "Unknown" is a valid name and also an IFF.

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -1700,12 +1700,16 @@ int get_docking_list(int model_index)
 }
 
 // DA 1/7/99 These ship names are not variables
-int rename_ship(int ship, char *name)
+int rename_ship(int ship, const char *name)
 {
 	int i;
 
 	Assert(ship >= 0);
 	Assert(strlen(name) < NAME_LENGTH);
+
+	// we may not need to rename it
+	if (strcmp(Ships[ship].ship_name, name) == 0)
+		return 0;
 
 	update_sexp_references(Ships[ship].ship_name, name);
 	ai_update_goal_references(sexp_ref_type::SHIP, Ships[ship].ship_name, name);

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -105,7 +105,7 @@ int query_initial_orders_conflict(int wing);
 int query_initial_orders_empty(ai_goal* ai_goals);
 int set_reinforcement(char* name, int state);
 int get_docking_list(int model_index);
-int rename_ship(int ship, char* name);
+int rename_ship(int ship, const char* name);
 void fix_ship_name(int ship);
 int internal_integrity_check();
 void correct_marking();

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -1543,11 +1543,15 @@ void Editor::update_texture_replacements(const char* old_name, const char* new_n
 			strcpy_s(ii->ship_name, new_name);
 	}
 }
-int Editor::rename_ship(int ship, char* name) {
+int Editor::rename_ship(int ship, const char* name) {
 	int i;
 
 	Assert(ship >= 0);
 	Assert(strlen(name) < NAME_LENGTH);
+
+	// we may not need to rename it
+	if (strcmp(Ships[ship].ship_name, name) == 0)
+		return 0;
 
 	update_sexp_references(Ships[ship].ship_name, name);
 	ai_update_goal_references(sexp_ref_type::SHIP, Ships[ship].ship_name, name);

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -236,7 +236,7 @@ class Editor : public QObject {
 	int invalidate_references(const char* name, sexp_ref_type type);
 
 	// DA 1/7/99 These ship names are not variables
-	int rename_ship(int ship, char* name);
+	int rename_ship(int ship, const char* name);
 
 	void delete_reinforcement(int num);
 


### PR DESCRIPTION
When forming a wing, if there is a name conflict but the ship will actually be used in the wing, don't report the conflict.  Fixes #6572.