### PR TITLE
Hud config upgrades

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -550,6 +550,11 @@ bool HudGauge::getConfigUseTagColor() const
 	return use_tag_color;
 }
 
+bool HudGauge::getVisibleInConfig() const
+{
+	return visible_in_config;
+}
+
 int HudGauge::getFont() const
 {
 	return font_num;
@@ -812,6 +817,11 @@ void HudGauge::initChase_view_only(bool chase_view_only)
 void HudGauge::initCockpit_view_choice(int cockpit_view_choice)
 {
 	render_for_cockpit_toggle = cockpit_view_choice;
+}
+
+void HudGauge::initVisible_in_config(bool visible)
+{
+	visible_in_config = visible;
 }
 
 bool HudGauge::isOffbyDefault() const

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -302,7 +302,7 @@ texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 	flash_next = timestamp(1);
 	flash_status = false;
 
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	gauge_config_id = ""; //gauge_map.get_string_id_from_numeric_id(_gauge_config);
 	can_popup = hud_config_can_popup(gauge_map.get_numeric_id_from_string_id(gauge_config_id));
@@ -347,7 +347,7 @@ canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 
 	texture_target_fname[0] = '\0';
 
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	gauge_config_id = gauge_map.get_string_id_from_numeric_id(_gauge_config);
 	config_name = gauge_map.get_hcf_name_from_string_id(gauge_config_id);
@@ -383,7 +383,7 @@ render_for_cockpit_toggle(0), custom_gauge(true), textoffset_x(txtoffset_x), tex
 	flash_next = timestamp(1);
 	flash_status = false;
 
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	gauge_config_id = ""; // gauge_map.get_string_id_from_numeric_id(_gauge_config);
 	can_popup = hud_config_can_popup(gauge_map.get_numeric_id_from_string_id(gauge_config_id));
@@ -585,7 +585,7 @@ void HudGauge::setGaugeColor(int bright_index, bool config)
 		color use_color;
 		if (custom_gauge) {
 			// Custom gauges currently use the color based on their gauge type
-			HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+			const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 			use_color = HUD_config.get_gauge_color(gauge_map.get_string_id_from_numeric_id(gauge_type));
 		} else {
 			use_color = HUD_config.get_gauge_color(gauge_config_id);
@@ -3532,7 +3532,7 @@ int hud_gauge_active(int gauge_index)
 		return 0;
 	}
 
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	return HUD_config.is_gauge_visible(gauge_map.get_string_id_from_numeric_id(gauge_index));
 }
@@ -3543,7 +3543,7 @@ int hud_gauge_active(int gauge_index)
 int hud_gauge_is_popup(int gauge_index)
 {
 	Assert(gauge_index >=0 && gauge_index < NUM_HUD_GAUGES);
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 	SCP_string gauge = gauge_map.get_string_id_from_numeric_id(gauge_index);
 	return HUD_config.is_gauge_popup(gauge);
 }
@@ -3613,7 +3613,7 @@ void hud_gauge_start_flash(int gauge_index)
  */
 void hud_set_gauge_color(int gauge_index, int bright_index)
 {
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	int flash_status = hud_gauge_maybe_flash(gauge_index);
 	color use_color = HUD_config.get_gauge_color(gauge_map.get_string_id_from_numeric_id(gauge_index));

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -241,6 +241,12 @@ protected:
 	bool message_gauge;
 	int disabled_views;
 
+	// Config stuff
+	SCP_string config_name;
+	bool can_popup;
+	bool use_iff_color;
+	bool use_tag_color;
+
 	int flash_duration;
 	int flash_next;
 	bool flash_status;
@@ -294,6 +300,13 @@ public:
 	void getPosition(int *x, int *y) const;
 	bool isOffbyDefault() const;
 	bool isActive() const;
+
+	// Config getters
+	SCP_string getConfigName() const;
+	int getConfigId() const;
+	bool getConfigUseIffColor() const;
+	bool getConfigCanPopup() const;
+	bool getConfigUseTagColor() const;
 
 	int getFont() const;
 	void getOriginAndOffset(float *originX, float *originY, int *offsetX, int *offsetY) const;

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -246,6 +246,7 @@ protected:
 	bool can_popup;
 	bool use_iff_color;
 	bool use_tag_color;
+	bool visible_in_config;
 
 	int flash_duration;
 	int flash_next;
@@ -307,6 +308,7 @@ public:
 	bool getConfigUseIffColor() const;
 	bool getConfigCanPopup() const;
 	bool getConfigUseTagColor() const;
+	bool getVisibleInConfig() const;
 
 	int getFont() const;
 	void getOriginAndOffset(float *originX, float *originY, int *offsetX, int *offsetY) const;
@@ -321,6 +323,7 @@ public:
 	void updateSexpOverride(bool sexp);
 	void initChase_view_only(bool chase_view_only);
 	void initCockpit_view_choice(int cockpit_view_choice);
+	void initVisible_in_config(bool visible);
 
 	// SEXP interfacing functions
 	// For flashing gauges in training missions

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -217,8 +217,9 @@ protected:
 	int position[2];
 	int base_w, base_h;
 	color gauge_color;
-	int gauge_config;
+	int gauge_type; // Used to be the gauge_config numeric ID but now more accurately is used as the type. Will be one of the HUD_ defines from hudgauges.h
 	int gauge_object;
+	SCP_string gauge_config_id;
 
 	int font_num;
 
@@ -304,7 +305,7 @@ public:
 
 	// Config getters
 	SCP_string getConfigName() const;
-	int getConfigId() const;
+	SCP_string getConfigId() const;
 	bool getConfigUseIffColor() const;
 	bool getConfigCanPopup() const;
 	bool getConfigUseTagColor() const;

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -75,111 +75,58 @@ const char *Radar_range_text(int n)
 	return NULL;
 }
 
-// default flags for observer HUD
-int HUD_observer_default_flags = 
-{
-	(1<<HUD_CENTER_RETICLE)			|	
-	(1<<HUD_OFFSCREEN_INDICATOR)	|
-	(1<<HUD_MESSAGE_LINES)			|
-	(1<<HUD_HOSTILE_TRIANGLE)		|
-	(1<<HUD_TARGET_TRIANGLE)		|
-	(1<<HUD_TARGET_MINI_ICON)		|
-	(1<<HUD_TARGET_MONITOR)			 	
+// Default enabled HUD gauges (Observer Mode)
+SCP_vector<SCP_string> observer_visible_gauges = {
+	"Builtin::CenterOfReticle",
+	"Builtin::OffscreenIndicator",
+	"Builtin::MessageOutput",
+	"Builtin::ClosestAttackingHostile",
+	"Builtin::CurrentTargetDirection",
+	"Builtin::TargetHullShieldIcon",
+	"Builtin::TargetMonitor",
+	"Builtin::OffscreenRange"
 };
 
-int HUD_observer_default_flags2 = {
-	(1<<(HUD_OFFSCREEN_RANGE - 32))
-};
-
-// default flags for regular HUD
-int HUD_config_default_flags = 
-{
-	(1<<HUD_LEAD_INDICATOR) |
-	(1<<HUD_ORIENTATION_TEE) |
-	(1<<HUD_HOSTILE_TRIANGLE) |
-	(1<<HUD_TARGET_TRIANGLE) |
-	(1<<HUD_MISSION_TIME) |
-	(1<<HUD_RETICLE_CIRCLE) |
-	(1<<HUD_THROTTLE_GAUGE) |
-	(1<<HUD_RADAR) |
-	(1<<HUD_TARGET_MONITOR) |
-	(1<<HUD_CENTER_RETICLE) |
-	(1<<HUD_TARGET_MONITOR_EXTRA_DATA) |
-	(1<<HUD_TARGET_SHIELD_ICON) |
-	(1<<HUD_PLAYER_SHIELD_ICON) |
-	(1<<HUD_ETS_GAUGE) |
-	(1<<HUD_AUTO_TARGET) |
-	(1<<HUD_AUTO_SPEED) |
-	(1<<HUD_WEAPONS_GAUGE) |
-	(1<<HUD_ESCORT_VIEW) |
-	(1<<HUD_DIRECTIVES_VIEW) |
-	(1<<HUD_THREAT_GAUGE) |
-	(1<<HUD_AFTERBURNER_ENERGY) |
-	(1<<HUD_WEAPONS_ENERGY) |
-	(1<<HUD_WEAPON_LINKING_GAUGE) |
-	(1<<HUD_TARGET_MINI_ICON) |
-	(1<<HUD_OFFSCREEN_INDICATOR) |
-	(1<<HUD_TALKING_HEAD) |
-	(1<<HUD_DAMAGE_GAUGE) |
-	(1<<HUD_MESSAGE_LINES) |
-	(1<<HUD_MISSILE_WARNING_ARROW) |
-	(1<<HUD_CMEASURE_GAUGE) |
-	(1<<HUD_OBJECTIVES_NOTIFY_GAUGE) |
-	(1<<HUD_WINGMEN_STATUS)
-};
-
-int HUD_config_default_flags2 = 
-{
-	(1<<(HUD_OFFSCREEN_RANGE-32)) |
-	(1<<(HUD_KILLS_GAUGE-32)) |
-	(1<<(HUD_ATTACKING_TARGET_COUNT-32)) | 
-	(1<<(HUD_SUPPORT_GAUGE-32)) | 
-	(1<<(HUD_LAG_GAUGE-32)) |
-	(1<<(HUD_TEXT_FLASH-32)) |
-	(1<<(HUD_MESSAGE_BOX-32))
-};
-
-// bits to tell whether a given gauge should be treated as pop-up or not
-int HUD_default_popup_mask =
-{
-	0	|											// (1<<HUD_LEAD_INDICATOR) | //-V578
-	0	|											// (1<<HUD_ORIENTATION_TEE) |
-	0	|											//	(1<<HUD_HOSTILE_TRIANGLE) |
-	0	|											// (1<<HUD_TARGET_TRIANGLE) |
-	0	|											//	(1<<HUD_MISSION_TIME) |
-	0	|											//	(1<<HUD_RETICLE_CIRCLE) |
-	0	|											//	(1<<HUD_THROTTLE_GAUGE) |
-	0	|											//	(1<<HUD_RADAR) |
-	0	|											//	(1<<HUD_TARGET_MONITOR) |
-	0	|											//	(1<<HUD_CENTER_RETICLE) |
-	0	|											//	(1<<HUD_TARGET_MONITOR_EXTRA_DATA) |
-	0	|											//	(1<<HUD_TARGET_SHIELD_ICON) |
-	0	|											//	(1<<HUD_PLAYER_SHIELD_ICON) |
-	0	|											//	(1<<HUD_ETS_GAUGE) |
-	0	|											//	(1<<HUD_AUTO_TARGET) |
-	0	|											//	(1<<HUD_AUTO_SPEED) |
-	0	|											//	(1<<HUD_WEAPONS_GAUGE) |
-	0	|											//	(1<<HUD_ESCORT_VIEW) |
-	0	|											//	(1<<HUD_DIRECTIVES_VIEW) |
-	0	|											//	(1<<HUD_THREAT_GAUGE) |
-	0	|											//	(1<<HUD_AFTERBURNER_ENERGY) |
-	0	|											//	(1<<HUD_WEAPONS_ENERGY) |
-	0	|											//	(1<<HUD_WEAPON_LINKING_GAUGE) |
-	0	|											//	(1<<HUD_TARGET_MINI_ICON) |
-	0	|											//(1<<HUD_OFFSCREEN_INDICATOR)
-	0   |											// talking head
-	0	|											// damage gauge
-	0	|											// message lines				
-	0	|											// missile warning arrow
-	0	|											// countermeasures
-	0												// wingman status
-};
-
-int HUD_default_popup_mask2 =
-{
-	0   |											// offscreen indicator range //-V578
-	0	|
-	0											// kills gauge
+SCP_vector<SCP_string> default_visible_gauges = {
+    "Builtin::LeadIndicator",
+    "Builtin::TargetOrientation",
+    "Builtin::ClosestAttackingHostile",
+    "Builtin::CurrentTargetDirection",
+    "Builtin::MissionTime",
+    "Builtin::Reticle",
+    "Builtin::Throttle",
+    "Builtin::Radar",
+    "Builtin::TargetMonitor",
+    "Builtin::CenterOfReticle",
+    "Builtin::ExtraTargetInfo",
+    "Builtin::TargetShield",
+    "Builtin::PlayerShield",
+    "Builtin::PowerManagement",
+    "Builtin::AutoTargetIcon",
+    "Builtin::AutoSpeedMatchIcon",
+    "Builtin::WeaponsDisplay",
+    "Builtin::MonitoringView",
+    "Builtin::DirectivesView",
+    "Builtin::ThreatGauge",
+    "Builtin::AfterburnerEnergy",
+    "Builtin::WeaponsEnergy",
+    "Builtin::WeaponLinking",
+    "Builtin::TargetHullShieldIcon",
+    "Builtin::OffscreenIndicator",
+    "Builtin::CommVideo",
+    "Builtin::DamageDisplay",
+    "Builtin::MessageOutput",
+    "Builtin::LockedMissileDirection",
+    "Builtin::Countermeasures",
+    "Builtin::ObjectiveNotify",
+    "Builtin::WingmenStatus",
+    "Builtin::OffscreenRange",
+    "Builtin::KillsGauge",
+    "Builtin::AttackingTargetCount",
+    "Builtin::SupportGauge",
+    "Builtin::LagGauge",
+    "Builtin::WarningFlash",
+    "Builtin::CommMenu"
 };
 
 // Can be customized in hud_gauges.tbl
@@ -208,7 +155,7 @@ const char *Hud_config_mask_fname[GR_NUM_RESOLUTIONS] = {
 };
 
 // keep a list of gauge pointers so we can easily get information from them
-std::unordered_map<int, HudGauge*> HC_gauge_map;
+SCP_vector<std::pair<SCP_string, HudGauge*>> HC_gauge_map;
 bool HC_gauge_list_clear = true;
 
 int HC_gauge_description_coords[GR_NUM_RESOLUTIONS][3] = {
@@ -247,92 +194,6 @@ std::pair<int, int> HC_arrow_coords[2][2] = {
 	}
 };
 int HC_arrow_hot = -1;
-
-// This is here for the short term. The next upgrade will remove the hud preset file saving/loading's reliance on this switch statement.
-const char *HC_gauge_descriptions(int n)
-{
-	switch(n)	{
-	case 0:
-		return XSTR( "lead indicator", 249);
-	case 1:
-		return XSTR( "target orientation", 250);
-	case 2:
-		return XSTR( "closest attacking hostile", 251);
-	case 3:
-		return XSTR( "current target direction", 252);
-	case 4:
-		return XSTR( "mission time", 253);
-	case 5:
-		return XSTR( "reticle", 254);
-	case 6:
-		return XSTR( "throttle", 255);
-	case 7:
-		return XSTR( "radar", 256);
-	case 8:
-		return XSTR( "target monitor", 257);
-	case 9:
-		return XSTR( "center of reticle", 258);
-	case 10:
-		return XSTR( "extra target info", 259);
-	case 11:
-		return XSTR( "target shield", 260);
-	case 12:
-		return XSTR( "player shield", 261);
-	case 13:
-		return XSTR( "power management", 262);
-	case 14:
-		return XSTR( "auto-target icon", 263);
-	case 15:
-		return XSTR( "auto-speed-match icon", 264);
-	case 16:
-		return XSTR( "weapons display", 265);
-	case 17:
-		return XSTR( "monitoring view", 266);
-	case 18:
-		return XSTR( "directives view", 267);
-	case 19:
-		return XSTR( "threat gauge", 268);
-	case 20:
-		return XSTR( "afterburner energy", 269);
-	case 21:
-		return XSTR( "weapons energy", 270);
-	case 22:
-		return XSTR( "weapon linking", 271);
-	case 23:
-		return XSTR( "target hull/shield icon", 272);
-	case 24:
-		return XSTR( "offscreen indicator", 273);
-	case 25:
-		return XSTR( "comm video", 274);
-	case 26:
-		return XSTR( "damage display", 275);
-	case 27:
-		return XSTR( "message output", 276);
-	case 28:
-		return XSTR( "locked missile direction", 277);
-	case 29:
-		return XSTR( "countermeasures", 278);
-	case 30:
-		return XSTR( "objective notify", 279);
-	case 31:
-		return XSTR( "wingmen status", 280);
-	case 32:
-		return XSTR( "offscreen range", 281);
-	case 33:
-		return XSTR( "kills gauge", 282);
-	case 34:
-		return XSTR( "attacking target count", 283);
-	case 35: 
-		return XSTR("warning flash", 1459);
-	case 36:
-		return XSTR("comm menu", 1460);
-	case 37: 
-		return XSTR("support gauge", 1461);
-	case 38:
-		return XSTR("lag gauge", 1462);
-	}
-	return NULL;
-}
 
 #define NUM_HUD_BUTTONS   20
 
@@ -448,10 +309,10 @@ static int							HC_background_bitmap;
 static int							HC_background_bitmap_mask;
 static UI_WINDOW					HC_ui_window;
 
-int							HC_gauge_hot;			// mouse is over this gauge
-int							HC_gauge_selected;	// gauge is selected
+SCP_string							HC_gauge_hot;			// mouse is over this gauge
+SCP_string							HC_gauge_selected;	// gauge is selected
 int HC_gauge_coordinates[6]; // x1, x2, y1, y1, w, h of the example HUD render area. Used for calculating new gauge coordinates
-SCP_vector<std::pair<int, BoundingBox>> HC_gauge_mouse_coords;
+SCP_vector<std::pair<SCP_string, BoundingBox>> HC_gauge_mouse_coords;
 
 // HUD colors
 typedef struct hc_col {
@@ -503,20 +364,28 @@ const char *HC_slider_fname[GR_NUM_RESOLUTIONS] = {
 	"2_slider"
 };
 
-HudGauge* hud_config_get_gauge_pointer(int gauge_index)
+// Used throughout this file to map from retail gauge ids (numeric or HCF) to the newer internal string format
+const auto& gauge_map = HC_gauge_mappings::get_instance();
+
+HudGauge* hud_config_get_gauge_pointer(const SCP_string& gauge_id)
 {
-	auto it = HC_gauge_map.find(gauge_index);
-	return (it != HC_gauge_map.end()) ? it->second : nullptr;
+	for (auto& pair : HC_gauge_map) {
+		if (pair.first == gauge_id) {
+			return pair.second;
+		}
+	}
+	return nullptr;
 }
 
 // sync sliders
-void hud_config_synch_sliders(int i)
+void hud_config_synch_sliders(const SCP_string& gauge)
 {
-	if(i >= 0){
-		HC_color_sliders[HCS_RED].force_currentItem( HCS_CONV(HUD_config.clr[i].red) );
-		HC_color_sliders[HCS_GREEN].force_currentItem( HCS_CONV(HUD_config.clr[i].green) );
-		HC_color_sliders[HCS_BLUE].force_currentItem( HCS_CONV(HUD_config.clr[i].blue) );
-		HC_color_sliders[HCS_ALPHA].force_currentItem( HCS_CONV(HUD_config.clr[i].alpha) );
+	if(!gauge.empty()){
+		color clr = HUD_config.get_gauge_color(gauge);
+		HC_color_sliders[HCS_RED].force_currentItem( HCS_CONV(clr.red) );
+		HC_color_sliders[HCS_GREEN].force_currentItem(HCS_CONV(clr.green));
+		HC_color_sliders[HCS_BLUE].force_currentItem(HCS_CONV(clr.blue));
+		HC_color_sliders[HCS_ALPHA].force_currentItem(HCS_CONV(clr.alpha));
 	}
 }
 
@@ -701,72 +570,10 @@ void hud_config_init_ui(bool API_Access, int x, int y, int w, int h)
 			UI_INPUTBOX_FLAG_INVIS | UI_INPUTBOX_FLAG_ESC_FOC);
 		HC_fname_input.set_text("");
 
-		HC_gauge_hot = -1;
-		HC_gauge_selected = -1;
+		HC_gauge_hot.clear();
+		HC_gauge_selected.clear();
 
 		HC_select_all = false;
-	}
-}
-
-int hud_config_show_flag_is_set(int i)
-{
-	int show_flag_set;
-
-	if ( i < 32 ) {
-		show_flag_set = HUD_config.show_flags & (1<<i);
-	} else {
-		show_flag_set = HUD_config.show_flags2 & (1<<(i-32));
-	}
-
-	return show_flag_set;
-}
-
-void hud_config_show_flag_set(int i)
-{
-	if ( i < 32 ) {
-		HUD_config.show_flags |= (1<<i);
-	} else {
-		HUD_config.show_flags2 |= (1<<(i-32));
-	}
-}
-
-void hud_config_show_flag_clear(int i)
-{
-	if ( i < 32 ) {
-		HUD_config.show_flags &= ~(1<<i);
-	} else {
-		HUD_config.show_flags2 &= ~(1<<(i-32));
-	}
-}
-
-int hud_config_popup_flag_is_set(int i)
-{
-	int popup_flag_set;
-
-	if ( i < 32 ) {
-		popup_flag_set = HUD_config.popup_flags & (1<<i);
-	} else {
-		popup_flag_set = HUD_config.popup_flags2 & (1<<(i-32));
-	}
-
-	return popup_flag_set;
-}
-
-void hud_config_popup_flag_set(int i)
-{
-	if ( i < 32 ) {
-		HUD_config.popup_flags |= (1<<i);
-	} else {
-		HUD_config.popup_flags2 |= (1<<(i-32));
-	}
-}
-
-void hud_config_popup_flag_clear(int i)
-{
-	if ( i < 32 ) {
-		HUD_config.popup_flags &= ~(1<<i);
-	} else {
-		HUD_config.popup_flags2 &= ~(1<<(i-32));
 	}
 }
 
@@ -779,7 +586,7 @@ void hud_config_draw_box(int x1, int x2, int y1, int y2)
 	gr_line(x1, y2, x2, y2, HC_resize_mode); // Bottom horizontal line
 }
 
-void hud_config_set_mouse_coords(int gauge_config, int x1, int x2, int y1, int y2)
+void hud_config_set_mouse_coords(const SCP_string& gauge_id, int x1, int x2, int y1, int y2)
 {
 	BoundingBox newBox(x1, x2, y1, y2);
 
@@ -801,7 +608,7 @@ void hud_config_set_mouse_coords(int gauge_config, int x1, int x2, int y1, int y
 	// changed to enforce only 1 set of mouse coords per gauge. - Mjn
 	auto it = std::find_if(HC_gauge_mouse_coords.begin(),
 		HC_gauge_mouse_coords.end(),
-		[gauge_config](const std::pair<int, BoundingBox>& item) { return item.first == gauge_config; });
+		[gauge_id](const std::pair<SCP_string, BoundingBox>& item) { return item.first == gauge_id; });
 
 	if (it != HC_gauge_mouse_coords.end()) {
 		if (it->second == newBox) {
@@ -811,7 +618,7 @@ void hud_config_set_mouse_coords(int gauge_config, int x1, int x2, int y1, int y
 		return;
 	}
 
-	HC_gauge_mouse_coords.emplace_back(std::make_pair(gauge_config, newBox));
+	HC_gauge_mouse_coords.emplace_back(std::make_pair(gauge_id, newBox));
 }
 
 std::pair<int, int> hud_config_convert_coords(int x, int y, float scale)
@@ -875,7 +682,7 @@ std::pair<float, float> hud_config_calc_coords_from_angle(float angle_degrees, i
 	return {screenX, screenY};
 }
 
-float hud_config_find_valid_angle(int gauge_index, float initial_angle, int centerX, int centerY, float radius)
+float hud_config_find_valid_angle(SCP_string gauge, float initial_angle, int centerX, int centerY, float radius)
 {
 	const int max_iterations = 360; // Prevent infinite loops
 	float angle = initial_angle;
@@ -893,7 +700,7 @@ float hud_config_find_valid_angle(int gauge_index, float initial_angle, int cent
 		BoundingBox newBox = {x1, x2, y1, y2};
 
 		// Check for overlap
-		if (!BoundingBox::isOverlappingAny(HC_gauge_mouse_coords, newBox, gauge_index)) {
+		if (!BoundingBox::isOverlappingAny(HC_gauge_mouse_coords, newBox, gauge)) {
 			return angle;
 		}
 
@@ -927,7 +734,7 @@ void hud_config_render_gauges(bool API_Access)
 				gauge->render(0, true);
 			}
 			if (HC_gauge_list_clear) {
-				HC_gauge_map[gauge->getConfigId()] = gauge.get();
+				HC_gauge_map.emplace_back(std::make_pair(gauge->getConfigId(), gauge.get()));
 			}
 		}
 	} else {
@@ -940,7 +747,7 @@ void hud_config_render_gauges(bool API_Access)
 				gauge->render(0, true);
 			}
 			if (HC_gauge_list_clear) {
-				HC_gauge_map[gauge->getConfigId()] = gauge.get();
+				HC_gauge_map.emplace_back(std::make_pair(gauge->getConfigId(), gauge.get()));
 			}
 		}
 	}
@@ -1017,11 +824,11 @@ void hud_config_check_regions_by_mouse(int mx, int my)
 void hud_config_check_regions(int mx, int my)
 {
 	if (hud_config_check_mouse_in_hud_area(mx, my)) {
-		HC_gauge_hot = -2;
+		HC_gauge_hot = "-2";
 	}
 
-	if (HC_gauge_hot == -2 && mouse_down(MOUSE_LEFT_BUTTON)) {
-		HC_gauge_selected = -1;
+	if (HC_gauge_hot == "-2" && mouse_down(MOUSE_LEFT_BUTTON)) {
+		HC_gauge_selected.clear();
 		HC_color_sliders[HCS_RED].hide();
 		HC_color_sliders[HCS_GREEN].hide();
 		HC_color_sliders[HCS_BLUE].hide();
@@ -1046,7 +853,7 @@ void hud_config_check_regions(int mx, int my)
 
 	hud_config_check_regions_by_mouse(mx, my);
 
-	if (HC_gauge_hot >= 0 && mouse_down(MOUSE_LEFT_BUTTON)) {
+	if (!HC_gauge_hot.empty() && mouse_down(MOUSE_LEFT_BUTTON)) {
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		HC_gauge_selected = HC_gauge_hot;
 
@@ -1077,10 +884,12 @@ void hud_config_check_regions(int mx, int my)
 			HC_color_sliders[HCS_BLUE].unhide();
 			HC_color_sliders[HCS_ALPHA].unhide();
 
-			HC_color_sliders[HCS_RED].force_currentItem(HCS_CONV(HUD_config.clr[HC_gauge_selected].red));
-			HC_color_sliders[HCS_GREEN].force_currentItem(HCS_CONV(HUD_config.clr[HC_gauge_selected].green));
-			HC_color_sliders[HCS_BLUE].force_currentItem(HCS_CONV(HUD_config.clr[HC_gauge_selected].blue));
-			HC_color_sliders[HCS_ALPHA].force_currentItem(HCS_CONV(HUD_config.clr[HC_gauge_selected].alpha));
+			color clr = HUD_config.get_gauge_color(HC_gauge_selected);
+
+			HC_color_sliders[HCS_RED].force_currentItem(HCS_CONV(clr.red));
+			HC_color_sliders[HCS_GREEN].force_currentItem(HCS_CONV(clr.green));
+			HC_color_sliders[HCS_BLUE].force_currentItem(HCS_CONV(clr.blue));
+			HC_color_sliders[HCS_ALPHA].force_currentItem(HCS_CONV(clr.alpha));
 		}
 
 		// recalc alpha slider
@@ -1090,19 +899,10 @@ void hud_config_check_regions(int mx, int my)
 }
 
 // set the display flags for a HUD gauge
-void hud_config_set_gauge_flags(int gauge_index, int on_flag, int popup_flag)
+void hud_config_set_gauge_flags(SCP_string gauge, bool on_flag, bool popup_flag)
 {
-	if ( on_flag ) {
-		hud_config_show_flag_set(gauge_index);
-	} else {
-		hud_config_show_flag_clear(gauge_index);
-	}
-
-	if ( popup_flag ) {
-		hud_config_popup_flag_set(gauge_index);
-	} else {
-		hud_config_popup_flag_clear(gauge_index);
-	}
+	HUD_config.set_gauge_visibility(gauge, on_flag);
+	HUD_config.set_gauge_popup(gauge, popup_flag);
 }
 
 void hud_config_record_color(int in_color)
@@ -1116,25 +916,28 @@ void hud_config_record_color(int in_color)
 // Set the HUD color
 void hud_config_set_color(int in_color)
 {
-	int idx;	
-
 	hud_config_record_color(in_color);
 
 	HUD_init_hud_color_array();
 
 	// apply the color to all gauges
-	for(idx=0; idx<NUM_HUD_GAUGES; idx++){
-		gr_init_alphacolor(&HUD_config.clr[idx], HC_colors[in_color].r, HC_colors[in_color].g, HC_colors[in_color].b, (HUD_color_alpha+1)*16);
+	for(int idx=0; idx<NUM_HUD_GAUGES; idx++){
+		color clr;
+		gr_init_alphacolor(&clr, HC_colors[in_color].r, HC_colors[in_color].g, HC_colors[in_color].b, (HUD_color_alpha+1)*16);
+		SCP_string gauge = gauge_map.get_string_id_from_numeric_id(idx);
+		HUD_config.set_gauge_color(gauge, clr);
 	}
 }
 
 void hud_config_stuff_colors(int r, int g, int b)
 {
-	int idx;
+	color clr;
+	gr_init_alphacolor(&clr, r, g, b, 255);
 
 	// apply the color to all gauges
-	for(idx=0; idx<NUM_HUD_GAUGES; idx++){
-		gr_init_alphacolor(&HUD_config.clr[idx], r, g, b, 255);
+	for(int idx=0; idx<NUM_HUD_GAUGES; idx++){
+		SCP_string gauge = gauge_map.get_string_id_from_numeric_id(idx);
+		HUD_config.set_gauge_color(gauge, clr);
 	}
 }
 
@@ -1166,29 +969,29 @@ void hud_config_commit()
 // move gauge state from on->off->popup
 void hud_cycle_gauge_status()
 {
-	if ( HC_gauge_selected < 0 ) {
+	if ( !HC_gauge_selected.empty() ) {
 		return;
 	}
 
 	// gauge is off, move to popup
-	if ( !(hud_config_show_flag_is_set(HC_gauge_selected)) ) {
+	if ( !(HUD_config.is_gauge_visible(HC_gauge_selected)) ) {
 		const auto gauge = hud_config_get_gauge_pointer(HC_gauge_selected);
 		if (gauge != nullptr && gauge->getConfigCanPopup()) {
-			hud_config_set_gauge_flags(HC_gauge_selected, 1, 1);	
+			hud_config_set_gauge_flags(HC_gauge_selected, true, true);	
 		} else {
-			hud_config_set_gauge_flags(HC_gauge_selected, 1, 0);	
+			hud_config_set_gauge_flags(HC_gauge_selected, true, false);	
 		}
 		return;
 	}
 
 	// if gauge is popup, move to on
-	if ( hud_config_popup_flag_is_set(HC_gauge_selected) ) {
-		hud_config_set_gauge_flags(HC_gauge_selected, 1, 0);
+	if ( HUD_config.is_gauge_popup(HC_gauge_selected) ) {
+		hud_config_set_gauge_flags(HC_gauge_selected, true, false);
 		return;
 	}
 	
 	// gauge must be on, move to off
-	hud_config_set_gauge_flags(HC_gauge_selected, 0, 0);
+	hud_config_set_gauge_flags(HC_gauge_selected, false, false);
 }
 
 // handle keyboard input while in hud config
@@ -1238,25 +1041,25 @@ void hud_config_button_do(int n)
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
 	case HCB_ON:
-		if ( HC_gauge_selected < 0 ) {
+		if (HC_gauge_selected.empty()) {
 			break;
 		}
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-		hud_config_set_gauge_flags(HC_gauge_selected,1,0);
+		hud_config_set_gauge_flags(HC_gauge_selected,true,false);
 		break;
 	case HCB_OFF:
-		if ( HC_gauge_selected < 0 ) {
+		if (HC_gauge_selected.empty()) {
 			break;
 		}
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-		hud_config_set_gauge_flags(HC_gauge_selected,0,0);
+		hud_config_set_gauge_flags(HC_gauge_selected,false,false);
 		break;
 	case HCB_POPUP:
-		if ( HC_gauge_selected < 0 ) {
+		if (HC_gauge_selected.empty()) {
 			break;
 		}
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-		hud_config_set_gauge_flags(HC_gauge_selected,1,1);
+		hud_config_set_gauge_flags(HC_gauge_selected,true,true);
 		break;
 	case HCB_RESET:
 		gamesnd_play_iface(InterfaceSounds::RESET_PRESSED);
@@ -1465,7 +1268,7 @@ void hud_config_draw_color_status()
 // set the status (on/off/popup) for the selected gauge
 void hud_config_draw_gauge_status()
 {
-	if ( HC_gauge_selected < 0 ) {
+	if (HC_gauge_selected.empty()) {
 		return;
 	}
 
@@ -1474,19 +1277,19 @@ void hud_config_draw_gauge_status()
 	}
 
 	// check if off
-	if ( !(hud_config_show_flag_is_set(HC_gauge_selected)) ) {
+	if (!(HUD_config.is_gauge_visible(HC_gauge_selected))) {
 		HC_buttons[gr_screen.res][HCB_OFF].button.draw_forced(2);
 		return;
 	}
 
 	// check if popup
-	if ( hud_config_popup_flag_is_set(HC_gauge_selected) ) {
+	if (HUD_config.is_gauge_popup(HC_gauge_selected)) {
 		HC_buttons[gr_screen.res][HCB_POPUP].button.draw_forced(2);
 		return;
 	}
 
 	// check if on
-	if ( hud_config_show_flag_is_set(HC_gauge_selected) ) {
+	if (HUD_config.is_gauge_visible(HC_gauge_selected)) {
 		HC_buttons[gr_screen.res][HCB_ON].button.draw_forced(2);
 		return;
 	}
@@ -1511,7 +1314,7 @@ void hud_config_button_enable(int index)
 // determine if on/off/popup buttons should be shown
 void hud_config_set_button_state()
 {
-	if ( HC_gauge_selected < 0 ) {
+	if (HC_gauge_selected.empty()) {
 		hud_config_button_disable(HCB_ON);
 		hud_config_button_disable(HCB_OFF);
 		hud_config_button_disable(HCB_POPUP);
@@ -1536,7 +1339,7 @@ void hud_config_render_description()
 {
 	int w,h,sx,sy;
 
-	if ( HC_gauge_selected >= 0 ) {
+	if (!HC_gauge_selected.empty()) {
 		const auto gauge = hud_config_get_gauge_pointer(HC_gauge_selected);
 
 		if (gauge != nullptr) {
@@ -1642,7 +1445,7 @@ void hud_config_do_frame(float /*frametime*/, bool API_Access, int mx, int my)
 		return;
 	}
 
-	HC_gauge_hot = -1;
+	HC_gauge_hot.clear();
 
 	if (!API_Access) {
 		hud_config_set_button_state();
@@ -1734,16 +1537,21 @@ void hud_set_default_hud_config(player * /*p*/, const char* filename)
 	HUD_color_green = HC_colors[HUD_config.main_color].g;
 	HUD_color_blue = HC_colors[HUD_config.main_color].b;
 
+	color clr;
+	gr_init_alphacolor(&clr, HUD_color_red, HUD_color_green, HUD_color_blue, (HUD_color_alpha + 1) * 16);
+
 	for(idx=0; idx<NUM_HUD_GAUGES; idx++){
-		gr_init_alphacolor(&HUD_config.clr[idx], HUD_color_red, HUD_color_green, HUD_color_blue, (HUD_color_alpha+1)*16);
+		SCP_string gauge = gauge_map.get_string_id_from_numeric_id(idx);
+		HUD_config.set_gauge_color(gauge, clr);
 	}
 
-	HUD_config.show_flags = HUD_config_default_flags;
-	HUD_config.show_flags2 = HUD_config_default_flags2;
-	HUD_config.popup_flags = HUD_default_popup_mask;
-	HUD_config.popup_flags2 = HUD_default_popup_mask2;
-	HUD_config.num_msg_window_lines			= 4;	// one more than is actually visible
-	HUD_config.rp_flags = RP_DEFAULT;
+	HUD_config.show_flags_map.clear();
+	HUD_config.popup_flags_map.clear();
+
+	for (const auto& gauge_id : default_visible_gauges) {
+		HUD_config.show_flags_map[gauge_id] = true;
+	}
+
 	HUD_config.rp_dist = RR_INFINITY;
 	HUD_config.is_observer = 0;
 
@@ -1787,27 +1595,61 @@ void hud_config_as_player()
 // RGB color stuff
 //
 
-void hud_config_color_save(const char *name)
+void hud_config_color_save(const char *name, int version)
 {
-	int idx;
 	CFILE* out     = cfopen(name, "wt", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
                         CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
-	char vals[255] = "";
 
-	// bad
-	if(out == NULL){
-		Int3();
+	try {
+
+		if (out == nullptr) {
+			char message[256];
+			sprintf(message, "Unable to open file: %s", name);
+			throw parse::ParseException(message);
+		}
+
+		switch (version) {
+			case 1: {
+				for (int idx = 0; idx < NUM_HUD_GAUGES; idx++) {
+					// Get the gauge string ID from numeric ID
+					SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(idx);
+					// If the gauge isn't found, default to white
+					color clr = HUD_config.get_gauge_color(gauge_id);
+
+					cfputs("+Gauge: ", out);
+					cfputs(gauge_map.get_hcf_name_from_string_id(gauge_id).c_str(), out);
+					cfputs("\n", out);
+					cfputs("+RGBA: ", out);
+					char vals[255] = "";
+					sprintf(vals, "%d %d %d %d\n\n", clr.red, clr.green, clr.blue, clr.alpha);
+					cfputs(vals, out);
+				}
+				break;
+			}
+			case 2: {
+				cfputs("+VERSION 2\n\n", out);
+				for (const auto& gauge : HUD_config.gauge_colors) {
+					if (gauge.first.empty()) {
+						continue;
+					}
+					cfputs("+Gauge: ", out);
+					cfputs(gauge.first.c_str(), out);
+					cfputs("\n", out);
+					cfputs("+RGBA: ", out);
+					char vals[255] = "";
+					sprintf(vals, "%d %d %d %d\n\n", gauge.second.red, gauge.second.green, gauge.second.blue, gauge.second.alpha);
+					cfputs(vals, out);
+				}
+				break;
+			}
+			default: {
+				throw parse::ParseException("Unknown HUD config version: " + std::to_string(version));
+			}
+		}
+	
+	} catch (const parse::ParseException& e) {
+		mprintf(("HUDCONFIG: Unable to save '%s'!  Error message = %s.\n", name, e.what()));
 		return;
-	}
-
-	// write out all gauges
-	for(idx=0; idx<NUM_HUD_GAUGES; idx++){
-		cfputs("+Gauge: ", out);
-		cfputs(HC_gauge_descriptions(idx), out);	
-		cfputs("\n", out);
-		cfputs("+RGBA: ", out);
-		sprintf(vals, "%d %d %d %d\n\n", HUD_config.clr[idx].red, HUD_config.clr[idx].green, HUD_config.clr[idx].blue, HUD_config.clr[idx].alpha);
-		cfputs(vals, out);
 	}
 	
 	// close the file
@@ -1816,10 +1658,6 @@ void hud_config_color_save(const char *name)
 
 void hud_config_color_load(const char *name)
 {
-	int idx;
-	char str[1024];
-	ubyte r, g, b, a;
-
 	const char *fname = cf_add_ext(name, ".hcf");
 
 	try
@@ -1827,28 +1665,46 @@ void hud_config_color_load(const char *name)
 		read_file_text(fname);
 		reset_parse();
 
-		// First, set all gauges to the current main color
-		for (idx = 0; idx < NUM_HUD_GAUGES; idx++){
-			gr_init_alphacolor(&HUD_config.clr[idx], HUD_color_red, HUD_color_green, HUD_color_blue, (HUD_color_alpha + 1) * 16);
+		HUD_config.gauge_colors.clear();
+		for (const auto& gauge : HC_gauge_map) {
+			color clr;
+			gr_init_alphacolor(&clr, HUD_color_red, HUD_color_green, HUD_color_blue, (HUD_color_alpha + 1) * 16);
+			HUD_config.set_gauge_color(gauge.first, clr);
 		}
 
 		// Now read in the color values for the gauges
+		int version = 1;
+		if (optional_string("+VERSION 2")) {
+			version = 2;
+		}
 		while (optional_string("+Gauge:")) {
-			stuff_string(str, F_NAME, sizeof(str));
+			SCP_string str;
+			stuff_string(str, F_NAME);
 
 			required_string("+RGBA:");
+			ubyte r, g, b, a;
 			stuff_ubyte(&r);
 			stuff_ubyte(&g);
 			stuff_ubyte(&b);
 			stuff_ubyte(&a);
 
-			for (idx = 0; idx < NUM_HUD_GAUGES; idx++) {
-				if (!stricmp(str, HC_gauge_descriptions(idx))) {
-					HUD_config.clr[idx].red = r;
-					HUD_config.clr[idx].green = g;
-					HUD_config.clr[idx].blue = b;
-					HUD_config.clr[idx].alpha = a;
+			color clr;
+			gr_init_alphacolor(&clr, r, g, b, a);
+
+			switch (version) {
+				case 1: {
+					SCP_string gauge = gauge_map.get_string_id_from_hcf_id(str);
+					if (!gauge.empty()) {
+						HUD_config.set_gauge_color(gauge, clr);
+					}
 					break;
+				}
+				case 2: {
+					HUD_config.set_gauge_color(str, clr);
+					break;
+				}
+				default: {
+					throw parse::ParseException("Unknown HUD config version: " + std::to_string(version));
 				}
 			}
 		}
@@ -1879,8 +1735,10 @@ void hud_config_alpha_slider_up()
 	// apply -- Cyborg17 -- Unless you have nothing to apply it to!
 	if(HC_select_all){
 		hud_config_stuff_colors( HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()) );
-	} else if (HC_gauge_selected >= 0) {
-		gr_init_alphacolor(&HUD_config.clr[HC_gauge_selected], HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()), 255);
+	} else if (!HC_gauge_selected.empty()) {
+		color clr;
+		gr_init_alphacolor(&clr, HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()), 255);
+		HUD_config.set_gauge_color(HC_gauge_selected, clr);
 	}
 }
 
@@ -1903,8 +1761,10 @@ void hud_config_alpha_slider_down()
 	// apply -- Cyborg17 -- Unless you have nothing to apply it to!
 	if(HC_select_all){
 		hud_config_stuff_colors( HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()) );
-	} else if (HC_gauge_selected >= 0) {
-		gr_init_alphacolor(&HUD_config.clr[HC_gauge_selected], HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()), 255);
+	} else if (!HC_gauge_selected.empty()) {
+		color clr;
+		gr_init_alphacolor(&clr, HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem()), HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem()), 255);
+		HUD_config.set_gauge_color(HC_gauge_selected, clr);
 	}
 }
 
@@ -1923,17 +1783,18 @@ void hud_config_red_slider()
 	// select all ?
 	if(HC_select_all){
 		for(idx=0; idx<NUM_HUD_GAUGES; idx++){
-			gr_init_alphacolor(&HUD_config.clr[idx], pos, HUD_config.clr[idx].green, HUD_config.clr[idx].blue, HUD_config.clr[idx].alpha);
+			SCP_string gauge = gauge_map.get_string_id_from_numeric_id(idx);
+			gr_init_alphacolor(&HUD_config.gauge_colors[gauge], pos, HUD_config.gauge_colors[gauge].green, HUD_config.gauge_colors[gauge].blue, HUD_config.gauge_colors[gauge].alpha);
 		}
 	}
 	// individual gauge
 	else {
-		if(HC_gauge_selected < 0){
+		if(HC_gauge_selected.empty()){
 			return;
 		}
 
 		// get slider position	
-		gr_init_alphacolor(&HUD_config.clr[HC_gauge_selected], pos, HUD_config.clr[HC_gauge_selected].green, HUD_config.clr[HC_gauge_selected].blue, HUD_config.clr[HC_gauge_selected].alpha);
+		gr_init_alphacolor(&HUD_config.gauge_colors[HC_gauge_selected], pos, HUD_config.gauge_colors[HC_gauge_selected].green, HUD_config.gauge_colors[HC_gauge_selected].blue, HUD_config.gauge_colors[HC_gauge_selected].alpha);
 	}	
 
 	hud_config_recalc_alpha_slider();
@@ -1947,17 +1808,18 @@ void hud_config_green_slider()
 	// select all ?
 	if(HC_select_all){
 		for(idx=0; idx<NUM_HUD_GAUGES; idx++){
-			gr_init_alphacolor(&HUD_config.clr[idx], HUD_config.clr[idx].red, pos, HUD_config.clr[idx].blue, HUD_config.clr[idx].alpha);
+			SCP_string gauge = gauge_map.get_string_id_from_numeric_id(idx);
+			gr_init_alphacolor(&HUD_config.gauge_colors[gauge], HUD_config.gauge_colors[gauge].red, pos, HUD_config.gauge_colors[gauge].blue, HUD_config.gauge_colors[gauge].alpha);
 		}
 	}
 	// individual gauge
 	else {
-		if(HC_gauge_selected < 0){
+		if(HC_gauge_selected.empty()){
 			return;
 		}
 
 		// get slider position	
-		gr_init_alphacolor(&HUD_config.clr[HC_gauge_selected], HUD_config.clr[HC_gauge_selected].red, pos, HUD_config.clr[HC_gauge_selected].blue, HUD_config.clr[HC_gauge_selected].alpha);
+		gr_init_alphacolor(&HUD_config.gauge_colors[HC_gauge_selected], HUD_config.gauge_colors[HC_gauge_selected].red, pos, HUD_config.gauge_colors[HC_gauge_selected].blue, HUD_config.gauge_colors[HC_gauge_selected].alpha);
 	}	
 
 	hud_config_recalc_alpha_slider();
@@ -1971,17 +1833,18 @@ void hud_config_blue_slider()
 	// select all ?
 	if(HC_select_all){
 		for(idx=0; idx<NUM_HUD_GAUGES; idx++){
-			gr_init_alphacolor(&HUD_config.clr[idx], HUD_config.clr[idx].red, HUD_config.clr[idx].green, pos, HUD_config.clr[idx].alpha);
+			SCP_string gauge = gauge_map.get_string_id_from_numeric_id(idx);
+			gr_init_alphacolor(&HUD_config.gauge_colors[gauge], HUD_config.gauge_colors[gauge].red, HUD_config.gauge_colors[gauge].green, pos, HUD_config.gauge_colors[gauge].alpha);
 		}
 	}
 	// individual gauge
 	else {
-		if(HC_gauge_selected < 0){
+		if(HC_gauge_selected.empty()){
 			return;
 		}
 
 		// get slider position	
-		gr_init_alphacolor(&HUD_config.clr[HC_gauge_selected], HUD_config.clr[HC_gauge_selected].red, HUD_config.clr[HC_gauge_selected].green, pos, HUD_config.clr[HC_gauge_selected].alpha);
+		gr_init_alphacolor(&HUD_config.gauge_colors[HC_gauge_selected], HUD_config.gauge_colors[HC_gauge_selected].red, HUD_config.gauge_colors[HC_gauge_selected].green, pos, HUD_config.gauge_colors[HC_gauge_selected].alpha);
 	}	
 
 	hud_config_recalc_alpha_slider();
@@ -2022,7 +1885,7 @@ void hud_config_delete_preset(SCP_string filename)
 void hud_config_select_none()
 {
 	HC_select_all = false;
-	HC_gauge_selected = -1;
+	HC_gauge_selected.clear();
 }
 
 void hud_config_select_hud(bool next)
@@ -2060,21 +1923,22 @@ void hud_config_select_all_toggle(bool toggle, bool API_Access)
 		hud_config_synch_ui(API_Access);
 		
 		// if we had a gauge previously selected, use its color everywhere
-		if(HC_gauge_selected < 0){
-			r = HUD_config.clr[HUD_RADAR].red;
-			g = HUD_config.clr[HUD_RADAR].green;
-			b = HUD_config.clr[HUD_RADAR].blue;			
-			a = HUD_config.clr[HUD_RADAR].alpha;
+		if(HC_gauge_selected.empty()){
+			SCP_string gauge = gauge_map.get_string_id_from_numeric_id(HUD_RADAR);
+			r = HUD_config.gauge_colors[gauge].red;
+			g = HUD_config.gauge_colors[gauge].green;
+			b = HUD_config.gauge_colors[gauge].blue;			
+			a = HUD_config.gauge_colors[gauge].alpha;
 		} else {
-			r = HUD_config.clr[HC_gauge_selected].red;
-			g = HUD_config.clr[HC_gauge_selected].green;
-			b = HUD_config.clr[HC_gauge_selected].blue;			
-			a = HUD_config.clr[HC_gauge_selected].alpha;
+			r = HUD_config.gauge_colors[HC_gauge_selected].red;
+			g = HUD_config.gauge_colors[HC_gauge_selected].green;
+			b = HUD_config.gauge_colors[HC_gauge_selected].blue;			
+			a = HUD_config.gauge_colors[HC_gauge_selected].alpha;
 		}
 		hud_config_stuff_colors(r, g, b);
 
 		// no gauge selected
-		HC_gauge_selected = -1;		
+		HC_gauge_selected.clear();		
 
 		// enable all sliders
 		if (!API_Access) {

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -682,7 +682,7 @@ std::pair<float, float> hud_config_calc_coords_from_angle(float angle_degrees, i
 	return {screenX, screenY};
 }
 
-float hud_config_find_valid_angle(SCP_string gauge, float initial_angle, int centerX, int centerY, float radius)
+float hud_config_find_valid_angle(const SCP_string& gauge, float initial_angle, int centerX, int centerY, float radius)
 {
 	const int max_iterations = 360; // Prevent infinite loops
 	float angle = initial_angle;
@@ -899,7 +899,7 @@ void hud_config_check_regions(int mx, int my)
 }
 
 // set the display flags for a HUD gauge
-void hud_config_set_gauge_flags(SCP_string gauge, bool on_flag, bool popup_flag)
+void hud_config_set_gauge_flags(const SCP_string& gauge, bool on_flag, bool popup_flag)
 {
 	HUD_config.set_gauge_visibility(gauge, on_flag);
 	HUD_config.set_gauge_popup(gauge, popup_flag);

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -922,8 +922,10 @@ void hud_config_render_gauges(bool API_Access)
 
 		for (const std::unique_ptr<HudGauge>& gauge : sip->hud_gauges) {
 			GR_DEBUG_SCOPE("Render HUD gauge");
-			gauge->setFont();
-			gauge->render(0, true);
+			if (gauge->getVisibleInConfig()) {
+				gauge->setFont();
+				gauge->render(0, true);
+			}
 			if (HC_gauge_list_clear) {
 				HC_gauge_map[gauge->getConfigId()] = gauge.get();
 			}
@@ -933,8 +935,10 @@ void hud_config_render_gauges(bool API_Access)
 
 		for (const std::unique_ptr<HudGauge>& gauge : default_hud_gauges) {
 			GR_DEBUG_SCOPE("Render HUD gauge");
-			gauge->setFont();
-			gauge->render(0, true);
+			if (gauge->getVisibleInConfig()) {
+				gauge->setFont();
+				gauge->render(0, true);
+			}
 			if (HC_gauge_list_clear) {
 				HC_gauge_map[gauge->getConfigId()] = gauge.get();
 			}

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -19,6 +19,7 @@
 #include "hud/hudobserver.h"
 #include "iff_defs/iff_defs.h"
 #include "io/key.h"
+#include "io/mouse.h"
 #include "parse/parselo.h"
 #include "playerman/player.h"
 #include "popup/popup.h"
@@ -35,7 +36,6 @@
 int HC_current_file = -1;					// current hcf file
 SCP_vector<SCP_string> HC_preset_filenames;
 
-char HC_fname[MAX_FILENAME_LEN+1] = "";
 UI_INPUTBOX HC_fname_input;
 int HC_fname_coords[GR_NUM_RESOLUTIONS][4] = {
 	{ // GR_640
@@ -167,7 +167,7 @@ int HUD_default_popup_mask =
 	0	|											//	(1<<HUD_WEAPON_LINKING_GAUGE) |
 	0	|											//	(1<<HUD_TARGET_MINI_ICON) |
 	0	|											//(1<<HUD_OFFSCREEN_INDICATOR)
-	0  |											// talking head
+	0   |											// talking head
 	0	|											// damage gauge
 	0	|											// message lines				
 	0	|											// missile warning arrow
@@ -177,7 +177,7 @@ int HUD_default_popup_mask =
 
 int HUD_default_popup_mask2 =
 {
-	0  |											// offscreen indicator range //-V578
+	0   |											// offscreen indicator range //-V578
 	0	|
 	0											// kills gauge
 };
@@ -185,12 +185,17 @@ int HUD_default_popup_mask2 =
 // Can be customized in hud_gauges.tbl
 char HC_wingam_gauge_status_names[MAX_SQUADRON_WINGS][32] = {"Alpha", "Beta", "Gamma", "Delta", "Epsilon"};
 
-int HC_select_all = 0;
+bool HC_select_all = false;
 
 //////////////////////////////////////////////////////////////////////////////
 // Module Globals
 //////////////////////////////////////////////////////////////////////////////
 
+// Coordinates for the new HUD configuration menu
+const int HC_gauge_config_coords[GR_NUM_RESOLUTIONS][4] = {
+	{121, 615, 6, 371}, // Coordinates for 640x480
+	{195, 985, 10, 595} // Coordinates for 1024x768
+};
 
 const char *Hud_config_fname[GR_NUM_RESOLUTIONS] = {
 	"HUDConfig",
@@ -202,109 +207,9 @@ const char *Hud_config_mask_fname[GR_NUM_RESOLUTIONS] = {
 	"2_HUDConfig-m"
 };
 
-// hud config gauges
-struct HC_gauge_region	HC_gauge_regions[GR_NUM_RESOLUTIONS][NUM_HUD_GAUGES] =
-{
-	{ // GR_640
-	//XSTR:OFF
-		HC_gauge_region("HCB_35",	407,	69,	35,	1,	0,	-1, 0,	2),			// lead indicator
-		HC_gauge_region("HCB_36",	305,	119,	36,	1,	0,	-1, 0,	2),			// orientation tee
-		HC_gauge_region("none",		1,		1,		-1,	1,	0,	-1, 0,	0),			// hostile triangle
-		HC_gauge_region("HCB_37",	391,	107,	37,	1,	0,	-1, 0,	2),			// target triangle
-		HC_gauge_region("HCB_63",	575,	352,	63,	0,	0,	-1, 0,	0),			// mission time
-		HC_gauge_region("none",		1,		1,		1,		0,	0,	-1, 0,	0),			// reticle circle?
-		HC_gauge_region("HCB_40",	285,	146,	40,	0,	0,	-1, 0,	0),			// throttle gauge
-		HC_gauge_region("HCB_50",	317,	291,	50,	0,	0,	-1, 0,	0),			// radar
-		HC_gauge_region("HCB_31",	123,	249,	31,	0,	0,	-1, 0,	0),			// target monitor
-		HC_gauge_region("HCB_41",	361,	188,	41,	0,	0,	-1, 0,	0),			// center of reticle
-		HC_gauge_region("HCB_30",	123,	221,	30,	0,	0,	-1, 0,	0),			// extra target data
-		HC_gauge_region("HCB_49",	237,	303,	49,	0,	0,	-1, 0,	0),			// target shield icon
-		HC_gauge_region("HCB_51",	435,	304,	51,	0,	0,	-1, 0,	0),			// player shield icon
-		HC_gauge_region("HCB_58",	524,	299,	58,	0,	1, -1, 0,	0),			// ets gauge
-		HC_gauge_region("HCB_61",	566,	299,	61,	0,	1, -1, 0,	0),			// auto target
-		HC_gauge_region("HCB_62",	566,	317,	62,	0,	1, -1, 0,	0),			// auto speed
-		HC_gauge_region("HCB_55",	504,	216,	55,	0,	1, -1, 0,	0),			// weapons gauge
-		HC_gauge_region("HCB_54",	496,	166,	54,	0,	1, -1, 0,	0),			// escort view
-		HC_gauge_region("HCB_29",	123,	142,	29,	0,	0, -1, 0,	0),			// directives view
-		HC_gauge_region("HCB_43",	398,	147,	43,	0,	0, -1, 0,	0),			// threat gauge
-		HC_gauge_region("HCB_39",	250,	212,	39,	0,	0, -1, 0,	0),			// afterburner energy
-		HC_gauge_region("HCB_44",	449,	212,	44,	0,	0, -1, 0,	0),			// weapons energy
-		HC_gauge_region("none",		1,		1,		-1,	0,	0, -1, 0,	0),			// weapon linking
-		HC_gauge_region("HCB_42",	356,	232,	42,	0,	1, -1, 0,	0),			// target mini icon (shield)
-		HC_gauge_region("HCB_34",	438,	5,		34,	1,	0, -1, 0,	2),			// offscreen indicator
-		HC_gauge_region("HCB_28",	123,	31,	28,	0,	0, -1, 0,	0),			// talking head
-		HC_gauge_region("HCB_32",	309,	33,	32,	0,	1, -1, 0,	0),			// damage gauge
-		HC_gauge_region("HCB_27",	124,	19,	27,	0,	0, -1, 0,	0),			// message lines
-		HC_gauge_region("HCB_45",	307,	249,	45,	1,	0, -1, 0,	1),			// missile warnings
-		HC_gauge_region("HCB_56",	505,	271,	56,	0,	1,	-1, 0,	0),			// cmeasure gauge
-		HC_gauge_region("HCB_33",	309,	87,	33,	0,	0,	-1, 0,	0),			// objectives notify gauge
-		HC_gauge_region("HCB_53",	546,	117,	53,	0,	0,	-1, 0,	0),			// wingman status gauge
-		HC_gauge_region("none",		1,		1,		-1,	0,	0,	-1, 0,	0),			// offscreen indicator range
-		HC_gauge_region("HCB_57",	505,	285,	57,	0,	1,	-1, 0,	0),			// kills gauge
-		HC_gauge_region("none",		1,		1,		-1,	0,	0,	-1, 0,	0),			// attacking target count
-		HC_gauge_region("HCB_38",	342,	138,	38,	0,	0,	-1, 0,	0),			// text flash gauge
-		HC_gauge_region("HCB_52",	465,	8,		52,	0,	0,	-1, 0,	0),			// comm menu
-		HC_gauge_region("HCB_46",	324,	264,	46,	0,	0,	-1, 0,	0),			// support view gauge
-		HC_gauge_region("HCB_47",	418,	262,	47,	0,	0,	-1, 0,	0),			// netlag icon gauge
-	//XSTR:ON
-	},
-	{ // GR_1024
-	//XSTR:OFF
-		HC_gauge_region("2_HCB_35",	652,	112,	35,	1,	0,	-1, 0,	2),			// lead indicator
-		HC_gauge_region("2_HCB_36",	489,	191,	36,	1,	0,	-1, 0,	2),			// orientation tee
-		HC_gauge_region("none",			1,		1,		-1,	1,	0,	-1, 0,	0),			// hostile triangle
-		HC_gauge_region("2_HCB_37",	626,	173,	37,	1,	0,	-1, 0,	2),			// target triangle
-		HC_gauge_region("2_HCB_63",	920,	564,	63,	0,	0,	-1, 0,	0),			// mission time
-		HC_gauge_region("none",			1,		1,		1,		0,	0,	-1, 0,	0),			// reticle circle?
-		HC_gauge_region("2_HCB_40",	456,	235,	40,	0,	0,	-1, 0,	0),			// throttle gauge
-		HC_gauge_region("2_HCB_50",	508,	466,	50,	0,	0,	-1, 0,	0),			// radar
-		HC_gauge_region("2_HCB_31",	198,	399,	31,	0,	0,	-1, 0,	0),			// target monitor
-		HC_gauge_region("2_HCB_41",	578,	302,	41,	0,	0,	-1, 0,	0),			// center of reticle
-		HC_gauge_region("2_HCB_30",	198,	354,	30,	0,	0,	-1, 0,	0),			// extra target data
-		HC_gauge_region("2_HCB_49",	380,	485,	49,	0,	0,	-1, 0,	0),			// target shield icon
-		HC_gauge_region("2_HCB_51",	696,	486,	51,	0,	0,	-1, 0,	0),			// player shield icon
-		HC_gauge_region("2_HCB_58",	839,	479,	58,	0,	1, -1, 0,	0),			// ets gauge
-		HC_gauge_region("2_HCB_61",	906,	479,	61,	0,	1, -1, 0,	0),			// auto target
-		HC_gauge_region("2_HCB_62",	906,	508,	62,	0,	1, -1, 0,	0),			// auto speed
-		HC_gauge_region("2_HCB_55",	807,	346,	55,	0,	1, -1, 0,	0),			// weapons gauge
-		HC_gauge_region("2_HCB_54",	794,	265,	54,	0,	1, -1, 0,	0),			// escort view
-		HC_gauge_region("2_HCB_29",	198,	228,	29,	0,	0, -1, 0,	0),			// directives view
-		HC_gauge_region("2_HCB_43",	637,	237,	43,	0,	0, -1, 0,	0),			// threat gauge
-		HC_gauge_region("2_HCB_39",	403,	339,	39,	0,	0, -1, 0,	0),			// afterburner energy
-		HC_gauge_region("2_HCB_44",	719,	339,	44,	0,	0, -1, 0,	0),			// weapons energy
-		HC_gauge_region("none",			1,		1,		-1,	0,	0, -1, 0,	0),			// weapon linking
-		HC_gauge_region("2_HCB_42",	569,	371,	42,	0,	1, -1, 0,	0),			// target mini icon (shield)
-		HC_gauge_region("2_HCB_34",	701,	9,		34,	1,	0, -1, 0,	2),			// offscreen indicator
-		HC_gauge_region("2_HCB_28",	198,	50,	28,	0,	0, -1, 0,	0),			// talking head
-		HC_gauge_region("2_HCB_32",	495,	55,	32,	0,	1, -1, 0,	0),			// damage gauge
-		HC_gauge_region("2_HCB_27",	199,	30,	27,	0,	0, -1, 0,	0),			// message lines
-		HC_gauge_region("2_HCB_45",	491,	399,	45,	1,	0, -1, 0,	1),			// missile warnings
-		HC_gauge_region("2_HCB_56",	808,	433,	56,	0,	1,	-1, 0,	0),			// cmeasure gauge
-		HC_gauge_region("2_HCB_33",	495,	141,	33,	0,	0,	-1, 0,	0),			// objectives notify gauge
-		HC_gauge_region("2_HCB_53",	873,	188,	53,	0,	0,	-1, 0,	0),			// wingman status gauge
-		HC_gauge_region("none",			1,		1,		-1,	0,	0,	-1, 0,	0),			// offscreen indicator range
-		HC_gauge_region("2_HCB_57",	808,	456,	57,	0,	1,	-1, 0,	0),			// kills gauge
-		HC_gauge_region("none",			1,		1,		-1,	0,	0,	-1, 0,	0),			// attacking target count
-		HC_gauge_region("2_HCB_38",	548,	222,	38,	0,	0,	-1, 0,	0),			// text flash gauge
-		HC_gauge_region("2_HCB_52",	744,	14,	52,	0,	0,	-1, 0,	0),			// comm menu
-		HC_gauge_region("2_HCB_46",	520,	422,	46,	0,	0,	-1, 0,	0),			// support view gauge
-		HC_gauge_region("2_HCB_47",	670,	419,	47,	0,	0,	-1, 0,	0),			// netlag icon gauge
-	//XSTR:ON
-	}
-};
-
-/**
- * @brief x y coordinates of gauges for hud preview display
- * 
- * @note used for scaling the positions properly when the preview display is scaled
- */
-struct gauge_coords {
-	int x; // x coordinate position
-	int y; // y coordinate position
-};
-
-SCP_vector<gauge_coords> HC_gauge_coords;
-
+// keep a list of gauge pointers so we can easily get information from them
+std::unordered_map<int, HudGauge*> HC_gauge_map;
+bool HC_gauge_list_clear = true;
 
 int HC_gauge_description_coords[GR_NUM_RESOLUTIONS][3] = {
 	{	// GR_640
@@ -318,8 +223,15 @@ int HC_gauge_description_coords[GR_NUM_RESOLUTIONS][3] = {
 int HC_talking_head_frame = -1;
 SCP_string HC_head_anim_filename;
 SCP_string HC_shield_gauge_ship;
+bool HC_show_default_hud = true;
+std::unordered_set<SCP_string> HC_ignored_huds;
 
 int HC_resize_mode = GR_RESIZE_MENU;
+
+SCP_vector<std::pair<size_t, SCP_string>> HC_available_huds;
+int HC_chosen_hud = -1;
+
+// This is here for the short term. The next upgrade will remove the hud preset file saving/loading's reliance on this switch statement.
 const char *HC_gauge_descriptions(int n)
 {
 	switch(n)	{
@@ -405,114 +317,114 @@ const char *HC_gauge_descriptions(int n)
 	return NULL;
 }
 
-#define NUM_HUD_BUTTONS			20
+#define NUM_HUD_BUTTONS   20
 
-#define HCB_RED_UP				0
-#define HCB_GREEN_UP				1
-#define HCB_BLUE_UP				2
-#define HCB_I_UP					3
-#define HCB_RED_DOWN				4
-#define HCB_GREEN_DOWN			5
-#define HCB_BLUE_DOWN			6
-#define HCB_I_DOWN				7
-#define HCB_ON						8
-#define HCB_OFF					9
-#define HCB_POPUP					10
-#define HCB_SAVE_HCF				11
-#define HCB_PREV_HCF				12
-#define HCB_NEXT_HCF				13
-#define HCB_AMBER					14
-#define HCB_BLUE					15
-#define HCB_GREEN					16
-#define HCB_SELECT_ALL			17
-#define HCB_RESET					18
-#define HCB_ACCEPT				19
+#define HCB_RED_UP        0
+#define HCB_GREEN_UP      1
+#define HCB_BLUE_UP       2
+#define HCB_I_UP          3
+#define HCB_RED_DOWN      4
+#define HCB_GREEN_DOWN    5
+#define HCB_BLUE_DOWN     6
+#define HCB_I_DOWN        7
+#define HCB_ON            8
+#define HCB_OFF           9
+#define HCB_POPUP         10
+#define HCB_SAVE_HCF      11
+#define HCB_PREV_HCF      12
+#define HCB_NEXT_HCF      13
+#define HCB_AMBER         14
+#define HCB_BLUE          15
+#define HCB_GREEN         16
+#define HCB_SELECT_ALL    17
+#define HCB_RESET         18
+#define HCB_ACCEPT        19
 
 
 ui_button_info HC_buttons[GR_NUM_RESOLUTIONS][NUM_HUD_BUTTONS] = {
-	{ // GR_640
-		ui_button_info("HCB_00",		6,		27,	-1,	-1,	0),
-		ui_button_info("HCB_01",		30,	27,	-1,	-1,	1),
-		ui_button_info("HCB_02",		55,	27,	-1,	-1,	2),
-		ui_button_info("HCB_03",		80,	27,	-1,	-1,	3),
-		ui_button_info("HCB_08",		6,		291,	-1,	-1,	8),
-		ui_button_info("HCB_09",		30,	291,	-1,	-1,	9),
-		ui_button_info("HCB_10",		55,	291,	-1,	-1,	10),
-		ui_button_info("HCB_11",		80,	291,	-1,	-1,	11),
-		ui_button_info("HCB_12",		4,		329,	-1,	-1,	12),
-		ui_button_info("HCB_13",		4,		348,	-1,	-1,	13),
-		ui_button_info("HCB_14",		4,		367,	-1,	-1,	14),
-		ui_button_info("HCB_15",		2,		439,	-1,	-1,	15),
-		ui_button_info("HCB_16",		266,	456,	-1,	-1,	16),
-		ui_button_info("HCB_17",		292,	456,	-1,	-1,	17),
-		ui_button_info("HCB_18",		327,	421,	-1,	-1,	18),
-		ui_button_info("HCB_19",		327,	440,	-1,	-1,	19),
-		ui_button_info("HCB_20",		327,	459,	-1,	-1,	20),
-		ui_button_info("HCB_24",		472,	436,	-1,	-1,	24),
-		ui_button_info("HCB_25",		523,	433,	-1,	-1,	25),
-		ui_button_info("HCB_26",		576,	434,	-1,	-1,	26),
-	},
-	{ // GR_1024
-		ui_button_info("2_HCB_00",		9,		44,	-1,	-1,	0),
-		ui_button_info("2_HCB_01",		48,	44,	-1,	-1,	1),
-		ui_button_info("2_HCB_02",		88,	44,	-1,	-1,	2),
-		ui_button_info("2_HCB_03",		127,	44,	-1,	-1,	3),
-		ui_button_info("2_HCB_08",		9,		466,	-1,	-1,	8),
-		ui_button_info("2_HCB_09",		48,	466,	-1,	-1,	9),
-		ui_button_info("2_HCB_10",		88,	466,	-1,	-1,	10),
-		ui_button_info("2_HCB_11",		127,	466,	-1,	-1,	11),
-		ui_button_info("2_HCB_12",		6,		526,	-1,	-1,	12),
-		ui_button_info("2_HCB_13",		6,		556,	-1,	-1,	13),
-		ui_button_info("2_HCB_14",		6,		586,	-1,	-1,	14),
-		ui_button_info("2_HCB_15",		3,		703,	-1,	-1,	15),
-		ui_button_info("2_HCB_16",		426,	730,	-1,	-1,	16),
-		ui_button_info("2_HCB_17",		467,	730,	-1,	-1,	17),
-		ui_button_info("2_HCB_18",		524,	674,	-1,	-1,	18),
-		ui_button_info("2_HCB_19",		524,	704,	-1,	-1,	19),
-		ui_button_info("2_HCB_20",		524,	734,	-1,	-1,	20),
-		ui_button_info("2_HCB_24",		755,	698,	-1,	-1,	24),
-		ui_button_info("2_HCB_25",		837,	693,	-1,	-1,	25),
-		ui_button_info("2_HCB_26",		922,	695,	-1,	-1,	26),
-	},
+    { // GR_640
+        ui_button_info("HCB_00",    6,    27,   -1, -1, 0),
+        ui_button_info("HCB_01",    30,   27,   -1, -1, 1),
+        ui_button_info("HCB_02",    55,   27,   -1, -1, 2),
+        ui_button_info("HCB_03",    80,   27,   -1, -1, 3),
+        ui_button_info("HCB_08",    6,    291,  -1, -1, 8),
+        ui_button_info("HCB_09",    30,   291,  -1, -1, 9),
+        ui_button_info("HCB_10",    55,   291,  -1, -1, 10),
+        ui_button_info("HCB_11",    80,   291,  -1, -1, 11),
+        ui_button_info("HCB_12",    4,    329,  -1, -1, 12),
+        ui_button_info("HCB_13",    4,    348,  -1, -1, 13),
+        ui_button_info("HCB_14",    4,    367,  -1, -1, 14),
+        ui_button_info("HCB_15",    2,    439,  -1, -1, 15),
+        ui_button_info("HCB_16",    266,  456,  -1, -1, 16),
+        ui_button_info("HCB_17",    292,  456,  -1, -1, 17),
+        ui_button_info("HCB_18",    327,  421,  -1, -1, 18),
+        ui_button_info("HCB_19",    327,  440,  -1, -1, 19),
+        ui_button_info("HCB_20",    327,  459,  -1, -1, 20),
+        ui_button_info("HCB_24",    472,  436,  -1, -1, 24),
+        ui_button_info("HCB_25",    523,  433,  -1, -1, 25),
+        ui_button_info("HCB_26",    576,  434,  -1, -1, 26),
+    },
+    { // GR_1024
+        ui_button_info("2_HCB_00",  9,    44,   -1, -1, 0),
+        ui_button_info("2_HCB_01",  48,   44,   -1, -1, 1),
+        ui_button_info("2_HCB_02",  88,   44,   -1, -1, 2),
+        ui_button_info("2_HCB_03",  127,  44,   -1, -1, 3),
+        ui_button_info("2_HCB_08",  9,    466,  -1, -1, 8),
+        ui_button_info("2_HCB_09",  48,   466,  -1, -1, 9),
+        ui_button_info("2_HCB_10",  88,   466,  -1, -1, 10),
+        ui_button_info("2_HCB_11",  127,  466,  -1, -1, 11),
+        ui_button_info("2_HCB_12",  6,    526,  -1, -1, 12),
+        ui_button_info("2_HCB_13",  6,    556,  -1, -1, 13),
+        ui_button_info("2_HCB_14",  6,    586,  -1, -1, 14),
+        ui_button_info("2_HCB_15",  3,    703,  -1, -1, 15),
+        ui_button_info("2_HCB_16",  426,  730,  -1, -1, 16),
+        ui_button_info("2_HCB_17",  467,  730,  -1, -1, 17),
+        ui_button_info("2_HCB_18",  524,  674,  -1, -1, 18),
+        ui_button_info("2_HCB_19",  524,  704,  -1, -1, 19),
+        ui_button_info("2_HCB_20",  524,  734,  -1, -1, 20),
+        ui_button_info("2_HCB_24",  755,  698,  -1, -1, 24),
+        ui_button_info("2_HCB_25",  837,  693,  -1, -1, 25),
+        ui_button_info("2_HCB_26",  922,  695,  -1, -1, 26),
+    },
 };
 
 // text
 #define NUM_HUD_TEXT					15
 UI_XSTR HC_text[GR_NUM_RESOLUTIONS][NUM_HUD_TEXT] = {
-	{ // GR_640
-		{ "R",				1512,	14,	8,		UI_XSTR_COLOR_GREEN,	-1, NULL },
-		{ "G",				1513,	37,	8,		UI_XSTR_COLOR_GREEN,	-1, NULL },
-		{ "B",				1514,	62,	8,		UI_XSTR_COLOR_GREEN,	-1, NULL },
-		{ "I",				1515,	90,	8,		UI_XSTR_COLOR_GREEN,	-1, NULL },
-		{ "On",				1285,	36,	334,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_ON].button },
-		{ "Off",				1286,	36,	353,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_OFF].button },
-		{ "Popup",			1453,	36,	372,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_POPUP].button },
-		{ "Save",			1454,	51,	428,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_SAVE_HCF].button },
-		{ "Amber",			1455,	364,	426,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_AMBER].button },
-		{ "Blue",			1456,	364,	445,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_BLUE].button },
-		{ "Green",			1457,	364,	464,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_GREEN].button },		
-		{ "Select",			1550,	442,	413,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_SELECT_ALL].button },
-		{ "All",				1551,	442,	424,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_SELECT_ALL].button },
-		{ "Reset",			1337,	515,	413,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[0][HCB_RESET].button },
-		{ "Accept",			1035,	573,	413,	UI_XSTR_COLOR_PINK,	-1, &HC_buttons[0][HCB_ACCEPT].button },
-	},
-	{ // GR_1024
-		{ "R",				1512,	23,	14,	UI_XSTR_COLOR_GREEN,	-1, NULL },
-		{ "G",				1513,	60,	14,	UI_XSTR_COLOR_GREEN,	-1, NULL },
-		{ "B",				1514,	100,	14,	UI_XSTR_COLOR_GREEN,	-1, NULL },
-		{ "I",				1515,	144,	14,	UI_XSTR_COLOR_GREEN,	-1, NULL },
-		{ "On",				1285,	58,	536,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_ON].button },
-		{ "Off",				1286,	58,	566,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_OFF].button },
-		{ "Popup",			1453,	58,	596,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_POPUP].button },
-		{ "Save",			1454,	82,	688,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_SAVE_HCF].button },
-		{ "Amber",			1455,	582,	685,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_AMBER].button },
-		{ "Blue",			1456,	582,	715,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_BLUE].button },
-		{ "Green",			1457,	582,	745,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_GREEN].button },		
-		{ "Select",			1550,	760,	671,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_SELECT_ALL].button },
-		{ "All",				1551,	760,	682,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_SELECT_ALL].button },
-		{ "Reset",			1337,	850,	669,	UI_XSTR_COLOR_GREEN,	-1, &HC_buttons[1][HCB_RESET].button },
-		{ "Accept",			1035,	930,	670,	UI_XSTR_COLOR_PINK,	-1, &HC_buttons[1][HCB_ACCEPT].button },
-	}
+    { // GR_640
+        { "R",              1512,   14,     8,      UI_XSTR_COLOR_GREEN,    -1, nullptr },
+        { "G",              1513,   37,     8,      UI_XSTR_COLOR_GREEN,    -1, nullptr },
+        { "B",              1514,   62,     8,      UI_XSTR_COLOR_GREEN,    -1, nullptr },
+        { "I",              1515,   90,     8,      UI_XSTR_COLOR_GREEN,    -1, nullptr },
+        { "On",             1285,   36,     334,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_ON].button },
+        { "Off",            1286,   36,     353,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_OFF].button },
+        { "Popup",          1453,   36,     372,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_POPUP].button },
+        { "Save",           1454,   51,     428,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_SAVE_HCF].button },
+        { "Amber",          1455,   364,    426,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_AMBER].button },
+        { "Blue",           1456,   364,    445,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_BLUE].button },
+        { "Green",          1457,   364,    464,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_GREEN].button },     
+        { "Select",         1550,   442,    413,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_SELECT_ALL].button },
+        { "All",            1551,   442,    424,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_SELECT_ALL].button },
+        { "Reset",          1337,   515,    413,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[0][HCB_RESET].button },
+        { "Accept",         1035,   573,    413,    UI_XSTR_COLOR_PINK,     -1, &HC_buttons[0][HCB_ACCEPT].button },
+    },
+    { // GR_1024
+        { "R",              1512,   23,     14,     UI_XSTR_COLOR_GREEN,    -1, nullptr },
+        { "G",              1513,   60,     14,     UI_XSTR_COLOR_GREEN,    -1, nullptr },
+        { "B",              1514,   100,    14,     UI_XSTR_COLOR_GREEN,    -1, nullptr },
+        { "I",              1515,   144,    14,     UI_XSTR_COLOR_GREEN,    -1, nullptr },
+        { "On",             1285,   58,     536,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_ON].button },
+        { "Off",            1286,   58,     566,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_OFF].button },
+        { "Popup",          1453,   58,     596,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_POPUP].button },
+        { "Save",           1454,   82,     688,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_SAVE_HCF].button },
+        { "Amber",          1455,   582,    685,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_AMBER].button },
+        { "Blue",           1456,   582,    715,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_BLUE].button },
+        { "Green",          1457,   582,    745,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_GREEN].button },     
+        { "Select",         1550,   760,    671,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_SELECT_ALL].button },
+        { "All",            1551,   760,    682,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_SELECT_ALL].button },
+        { "Reset",          1337,   850,    669,    UI_XSTR_COLOR_GREEN,    -1, &HC_buttons[1][HCB_RESET].button },
+        { "Accept",         1035,   930,    670,    UI_XSTR_COLOR_PINK,     -1, &HC_buttons[1][HCB_ACCEPT].button },
+    }
 };
 
 static int							HC_background_bitmap;
@@ -521,9 +433,8 @@ static UI_WINDOW					HC_ui_window;
 
 int							HC_gauge_hot;			// mouse is over this gauge
 int							HC_gauge_selected;	// gauge is selected
-float						HC_gauge_scale; // scale used for drawing the hud gauges
 int HC_gauge_coordinates[6]; // x1, x2, y1, y1, w, h of the example HUD render area. Used for calculating new gauge coordinates
-BoundingBox HC_gauge_mouse_coords[NUM_HUD_GAUGES];
+SCP_vector<std::pair<int, BoundingBox>> HC_gauge_mouse_coords;
 
 // HUD colors
 typedef struct hc_col {
@@ -538,7 +449,7 @@ hc_col HC_colors[HUD_COLOR_SIZE] =
 };
 
 static HUD_CONFIG_TYPE	HUD_config_backup;		// backup HUD config, used to restore old config if changes not applied
-static int					HUD_config_inited = 0;
+static int				HUD_config_inited = 0;
 
 // rgba slider stuff
 void hud_config_red_slider();
@@ -556,10 +467,10 @@ void hud_config_process_colors();
 UI_SLIDER2 HC_color_sliders[NUM_HC_SLIDERS];
 int HC_slider_coords[GR_NUM_RESOLUTIONS][NUM_HC_SLIDERS][4] = {
 	{ // GR_640
-		{ 8,	53,	15, 225 },
-		{ 33, 53,	15, 225 },
-		{ 58, 53,	15, 225 },
-		{ 83, 53,	15, 225 },
+		{ 8,    53,	15, 225 },
+		{ 33,   53,	15, 225 },
+		{ 58,   53,	15, 225 },
+		{ 83,   53,	15, 225 },
 	},
 	{ // GR_1024
 		{ 13,	85, 32, 350 },
@@ -574,6 +485,12 @@ const char *HC_slider_fname[GR_NUM_RESOLUTIONS] = {
 	"slider",
 	"2_slider"
 };
+
+HudGauge* hud_config_get_gauge_pointer(int gauge_index)
+{
+	auto it = HC_gauge_map.find(gauge_index);
+	return (it != HC_gauge_map.end()) ? it->second : nullptr;
+}
 
 // sync sliders
 void hud_config_synch_sliders(int i)
@@ -602,6 +519,50 @@ void hud_config_synch_ui(bool API_Access)
 	}
 }
 
+void hud_config_init_dimensions(int x1, int x2, int y1, int y2)
+{
+	// Calculate the menu width and height
+	int menuWidth = x2 - x1;
+	int menuHeight = y2 - y1;
+
+	HC_gauge_coordinates[0] = x1;
+	HC_gauge_coordinates[1] = x2;
+	HC_gauge_coordinates[2] = y1;
+	HC_gauge_coordinates[3] = y2;
+	HC_gauge_coordinates[4] = menuWidth;
+	HC_gauge_coordinates[5] = menuHeight;
+}
+
+void hud_config_get_unique_huds()
+{
+	std::unordered_set<SCP_string> seenHuds; // Tracks HUDs we've already encountered
+
+	for (const auto& pair : Hud_parsed_ships) {
+		const auto& hudName = pair.first; // Extract the HUD name
+		if (seenHuds.find(hudName) == seenHuds.end()) {
+			// If this HUD hasn't been encountered, maybe add it to the result
+			if (HC_ignored_huds.find(hudName) != HC_ignored_huds.end()) {
+				// Skip ignored HUDs
+				continue;
+			}
+
+			std::pair<size_t, SCP_string> newPair;
+			newPair.second = hudName;
+
+			// Get the ship index associated
+			for (size_t i = 0; i < Ship_info.size(); i++) {
+				if (!stricmp(Ship_info[i].name, pair.second.c_str())) {
+					newPair.first = i;
+					break;
+				}
+			}
+
+			HC_available_huds.push_back(newPair);
+			seenHuds.insert(hudName);
+		}
+	}
+}
+
 /*!
  * @brief init the UI components
  *
@@ -610,53 +571,39 @@ void hud_config_synch_ui(bool API_Access)
  * param[in] y				the y coord to render the preview display
  * param[in] w				the width of the preview display
  */
-void hud_config_init_ui(bool API_Access, int x, int y, int w)
+void hud_config_init_ui(bool API_Access, int x, int y, int w, int h)
 {
 	int i;
 	struct ui_button_info			*hb;
 
-	HC_gauge_coords.clear();
-	HC_gauge_coords.resize(NUM_HUD_GAUGES);
+	HC_gauge_mouse_coords.clear();
 
-	// Clear the mouse coords array
-	for (auto& coord : HC_gauge_mouse_coords) {
-		coord = {-1, -1, -1, -1};
+	hud_config_get_unique_huds();
+
+	if (!HC_show_default_hud) {
+		if (HC_available_huds.empty()) {
+			HC_show_default_hud = true;
+			HC_chosen_hud = -1;
+		} else {
+			HC_chosen_hud = 0;
+		}
 	}
 
-	if (w < 0) {
-		HC_gauge_scale = 1.0f;
+	if (!HC_show_default_hud && HC_available_huds.empty()) {
+		HC_show_default_hud = true;
+	}
+
+	if (w < 0 || h < 0) {
+		hud_config_init_dimensions(HC_gauge_config_coords[gr_screen.res][0],
+			HC_gauge_config_coords[gr_screen.res][1],
+			HC_gauge_config_coords[gr_screen.res][2],
+			HC_gauge_config_coords[gr_screen.res][3]);
+		HC_resize_mode = GR_RESIZE_MENU;
 	} else {
 
-		float sw = 0; // will be highest w value
-
-		// this is probably not the most efficient way to do this, but I
-		// can't find a better one. Need to get the furthest right and bottom
-		// pixels to be rendered to calculate the percent change. That is then
-		// used to rescale each gauge correctly for the rendering size and position. - Mjn
-		for (const auto& gauge : HC_gauge_regions[gr_screen.res]) {
-			if (!stricmp(gauge.filename, NOX("none"))) {
-				continue;
-			}
-
-			int bm = bm_load(gauge.filename);
-
-			int bw;
-			bm_get_info(bm, &bw);
-			bm_release(bm);
-
-			bw += gauge.x;
-
-			if (bw > sw) {
-				sw = (float)bw;
-			}
-		}
-
-		// calculate the percent change
-		HC_gauge_scale = (float)w / sw;
-
-		// we don't work with negative scales here, so reverse if it is
-		if (HC_gauge_scale < 0) {
-			HC_gauge_scale *= -1;
+		hud_config_init_dimensions(x, x + w, y, y + h);
+		if (API_Access) {
+			HC_resize_mode = GR_RESIZE_NONE;
 		}
 	}
 
@@ -679,61 +626,6 @@ void hud_config_init_ui(bool API_Access, int x, int y, int w)
 		}
 	}
 
-	// this is kinda dumb, but the retail gauge coords are hardcoded to
-	// to offset from the left and top of the screen. This exists
-	// for the api to render the gauge view at 0,0 without having to compensate
-	// for this dumb hardcoded way of doing things.
-	int x_offset = 0 + x;
-	int y_offset = 0 + y;
-	if (API_Access) {
-		int sx = HC_gauge_regions[gr_screen.res][0].x; // will be lowest x value
-		int sy = HC_gauge_regions[gr_screen.res][0].y; // will be lowest y value
-		for (auto gauge : HC_gauge_regions[gr_screen.res]) {
-			if (!stricmp(gauge.filename, NOX("none"))) {
-				continue;
-			}
-			if (gauge.x < sx) {
-				sx = gauge.x;
-			}
-			if (gauge.y < sy) {
-				sy = gauge.y;
-			}
-		}
-
-		// now add the offsets with the correct scaling
-		x_offset += ((int)(sx * HC_gauge_scale) * -1); // the furthest left gauge
-		y_offset += ((int)(sy * HC_gauge_scale) * -1); // the furthest top gauge
-	}
-
-	for (i=0; i<NUM_HUD_GAUGES; i++) {
-		struct HC_gauge_region* hg;
-		hg = &HC_gauge_regions[gr_screen.res][i];
-		if (!stricmp(hg->filename, NOX("none"))) {
-			continue;
-		}
-
-		// scale the x/y coords
-		int gx = (int)(hg->x * HC_gauge_scale);
-		int gy = (int)(hg->y * HC_gauge_scale);
-
-		// apply the offset
-		gx += x_offset;
-		gy += y_offset;
-
-		// save the values and drop the decimals
-		HC_gauge_coords[i] = {gx, gy};
-
-		hg->button.create(&HC_ui_window, "", gx, gy, 60, 30, 0, 1);
-		// set up callback for when a mouse first goes over a button
-		//		hg->button.set_highlight_action(common_play_highlight_sound);
-		hg->button.hide();
-		hg->button.link_hotspot(hg->hotspot);
-
-		hg->bitmap = bm_load(hg->filename);
-		hg->nframes = 1;
-
-	}
-
 	if (!API_Access){
 		// add text
 		for(i=0; i<NUM_HUD_TEXT; i++){
@@ -751,7 +643,18 @@ void hud_config_init_ui(bool API_Access, int x, int y, int w)
 											255, HC_slider_fname[gr_screen.res], hud_config_blue_slider, hud_config_blue_slider, hud_config_blue_slider);
 
 		HC_color_sliders[HCS_ALPHA].create(&HC_ui_window, HC_slider_coords[gr_screen.res][HCS_ALPHA][0], HC_slider_coords[gr_screen.res][HCS_ALPHA][1], HC_slider_coords[gr_screen.res][HCS_ALPHA][2], HC_slider_coords[gr_screen.res][HCS_ALPHA][3],
-											255, HC_slider_fname[gr_screen.res], hud_config_alpha_slider_up, hud_config_alpha_slider_down, NULL);
+											255, HC_slider_fname[gr_screen.res], hud_config_alpha_slider_up, hud_config_alpha_slider_down, nullptr);
+
+		// now disable them until the player clicks on something
+		HC_color_sliders[HCS_RED].hide();
+		HC_color_sliders[HCS_GREEN].hide();
+		HC_color_sliders[HCS_BLUE].hide();
+		HC_color_sliders[HCS_ALPHA].hide();
+
+		HC_color_sliders[HCS_RED].disable();
+		HC_color_sliders[HCS_GREEN].disable();
+		HC_color_sliders[HCS_BLUE].disable();
+		HC_color_sliders[HCS_ALPHA].disable();
 	}
 	
 	hud_config_preset_init();
@@ -776,33 +679,10 @@ void hud_config_init_ui(bool API_Access, int x, int y, int w)
 			UI_INPUTBOX_FLAG_INVIS | UI_INPUTBOX_FLAG_ESC_FOC);
 		HC_fname_input.set_text("");
 
-		/*
-		for (i=0; i<NUM_HC_SPECIAL_BITMAPS; i++) {
-			HC_special_bitmaps[i].bitmap = bm_load(HC_special_bitmaps[i].filename);
-		}
-		*/
-
-		// create sliders
-		/*
-		for(i=0; i<HC_NUM_SLIDERS; i++){
-			HC_sliders[gr_screen.res][i].slider.create(&HC_ui_window, HC_sliders[gr_screen.res][i].x,
-		HC_sliders[gr_screen.res][i].y, HC_sliders[gr_screen.res][i].dots, HC_sliders[gr_screen.res][i].filename,
-																			HC_sliders[gr_screen.res][i].hotspot,
-		HC_sliders[gr_screen.res][i].right_filename, HC_sliders[gr_screen.res][i].right_mask,
-		HC_sliders[gr_screen.res][i].right_x, HC_sliders[gr_screen.res][i].right_y,
-																			HC_sliders[gr_screen.res][i].left_filename,
-		HC_sliders[gr_screen.res][i].left_mask, HC_sliders[gr_screen.res][i].left_x,
-		HC_sliders[gr_screen.res][i].left_y, HC_sliders[gr_screen.res][i].dot_w);
-		}
-		HC_sliders[gr_screen.res][HC_BRIGHTNESS_SLIDER].slider.pos = HUD_color_alpha - 3;
-		*/
-
 		HC_gauge_hot = -1;
 		HC_gauge_selected = -1;
 
-		HC_select_all = 0;
-
-		strcpy_s(HC_fname, "");
+		HC_select_all = false;
 	}
 }
 
@@ -868,39 +748,22 @@ void hud_config_popup_flag_clear(int i)
 	}
 }
 
+// Used for debugging. Remove before merge!
+void hud_config_draw_box(int x1, int x2, int y1, int y2)
+{
+	gr_line(x1, y1, x1, y2, HC_resize_mode); // Left vertical line
+	gr_line(x1, y1, x2, y1, HC_resize_mode); // Top horizontal line
+	gr_line(x2, y1, x2, y2, HC_resize_mode); // Right vertical line
+	gr_line(x1, y2, x2, y2, HC_resize_mode); // Bottom horizontal line
+}
+
 void hud_config_set_mouse_coords(int gauge_config, int x1, int x2, int y1, int y2) {
-	HC_gauge_mouse_coords[gauge_config] = {x1, x2, y1, y2};
-}
-
-bool hud_config_set_mouse_coords_no_overlap(int gauge_config, int x1, int x2, int y1, int y2)
-{
-	BoundingBox newBox(x1, x2, y1, y2);
-
-	if (BoundingBox::isOverlappingAny(HC_gauge_mouse_coords, newBox, gauge_config)) {
-		return false;
-	} else {
-		HC_gauge_mouse_coords[gauge_config] = newBox;
-		return true;
+	// List is built on first frame only
+	if (!HC_gauge_list_clear) {
+		return;
 	}
-}
-
-// ETS gauge can render as one unified gauge or as three separate gauges using separate drawing functions
-// So this function provides a way to min/max the coords to make sure no matter what method is used, the
-// mouse box inclues all the relevant areas
-void hud_config_set_mouse_coords_ets(int gauge_config, int x1, int x2, int y1, int y2)
-{
-	HC_gauge_mouse_coords[gauge_config].x1 = std::min(HC_gauge_mouse_coords[gauge_config].x1, x1);
-	HC_gauge_mouse_coords[gauge_config].x2 = std::max(HC_gauge_mouse_coords[gauge_config].x2, x2);
-	HC_gauge_mouse_coords[gauge_config].y1 = std::min(HC_gauge_mouse_coords[gauge_config].y1, y1);
-	HC_gauge_mouse_coords[gauge_config].y2 = std::max(HC_gauge_mouse_coords[gauge_config].y2, y2);
-
-	// temporary stuff to show boxes
-	color clr = gr_screen.current_color;
-	color thisColor;
-	gr_init_alphacolor(&thisColor, 255, 255, 255, 80);
-	gr_set_color_fast(&thisColor);
-	// hud_config_draw_box(x1, x2, y1, y2);
-	gr_set_color_fast(&clr);
+	BoundingBox newBox(x1, x2, y1, y2);
+	HC_gauge_mouse_coords.emplace_back(std::make_pair(gauge_config, newBox));
 }
 
 std::pair<int, int> hud_config_convert_coords(int x, int y, float scale)
@@ -1003,142 +866,70 @@ float hud_config_find_valid_angle(int gauge_index, float initial_angle, int cent
  */
 void hud_config_render_gauges(bool API_Access)
 {
-	int i;
+	// Check if this ship has its own HUD gauges.
+	SCP_string hud_name;
+	if (SCP_vector_inbounds(HC_available_huds, HC_chosen_hud)) {
+		ship_info* sip = &Ship_info[HC_available_huds[HC_chosen_hud].first];
+		hud_name = HC_available_huds[HC_chosen_hud].second;
 
-	for ( i=0; i<NUM_HUD_GAUGES; i++ ) {
-		color *use_color;
-		int alpha;
-		if ( (hud_config_show_flag_is_set(i)) ) {
-			// set the correct color
-			if(!HC_gauge_regions[gr_screen.res][i].use_iff){
-				use_color = &HUD_config.clr[i];			
-			} else {
-				if(HC_gauge_regions[gr_screen.res][i].color == 1){
-					use_color = iff_get_color(IFF_COLOR_TAGGED, 0);
-				} else {
-					use_color = &Color_bright_red;
-				}
-			}
-
-			if ( (HC_gauge_selected == i) || HC_select_all ) {
-				alpha = 255;				
-			} else if ( HC_gauge_hot == i ) {
-				alpha = 200;				
-			} else {			
-				alpha = 150;				
-			}
-			gr_init_alphacolor(use_color, use_color->red, use_color->green, use_color->blue, alpha);
-			gr_set_color_fast(use_color);			
-		} else {
-			// if its off, make it dark gray
-			use_color = &HUD_config.clr[i];
-			gr_init_alphacolor(use_color, 127, 127, 127, 64);
-			gr_set_color_fast(use_color);			
-		}
-
-		// draw
-		if ( HC_gauge_regions[gr_screen.res][i].bitmap >= 0 ) {
-			gr_set_bitmap(HC_gauge_regions[gr_screen.res][i].bitmap);
-
-			int resize = GR_RESIZE_MENU;
-			if (API_Access) {
-				resize = GR_RESIZE_NONE;
-			}
-
-			gr_aabitmap(HC_gauge_coords[i].x, HC_gauge_coords[i].y, resize, false, HC_gauge_scale);
-		}
-		
-		/*
-		else {
-
-			int offset=0;
-				// set correct frame if using iff
-			if ( HC_gauge_regions[i].use_iff ) {
-				if ( HC_gauge_selected == i ) {
-					offset=2;
-				} else if ( HC_gauge_hot == i ) {
-					offset=1;
-				}
-
-				// If gauge is disabled, then draw disabled frame
-				if ( !(hud_config_show_flag_is_set(i)) ) {
-					offset=3;
-				}
-			}
-
-			if ( HC_gauge_regions[i].bitmap >= 0 ) {
-				Assert(offset < HC_gauge_regions[i].nframes);
-				gr_set_bitmap(HC_gauge_regions[i].bitmap+offset);
-				gr_bitmap(HC_gauge_regions[i].x, HC_gauge_regions[i].y, GR_RESIZE_MENU);
+		for (const std::unique_ptr<HudGauge>& gauge : sip->hud_gauges) {
+			GR_DEBUG_SCOPE("Render HUD gauge");
+			gauge->setFont();
+			gauge->render(0, true);
+			if (HC_gauge_list_clear) {
+				HC_gauge_map[gauge->getConfigId()] = gauge.get();
 			}
 		}
-		*/
+	} else {
+		hud_name = "Default HUD"; // Do not pass review if this is not XSTR'd!
+
+		for (const std::unique_ptr<HudGauge>& gauge : default_hud_gauges) {
+			GR_DEBUG_SCOPE("Render HUD gauge");
+			gauge->setFont();
+			gauge->render(0, true);
+			if (HC_gauge_list_clear) {
+				HC_gauge_map[gauge->getConfigId()] = gauge.get();
+			}
+		}
 	}
+
+	HC_gauge_list_clear = false;
+
+	// Render the name of the HUD
+	if (!API_Access) {
+		gr_set_color_fast(&Color_normal);
+		int w;
+		gr_get_string_size(&w, nullptr, hud_name.c_str());
+		int x = HC_gauge_coordinates[0] + ((HC_gauge_coordinates[4] / 2) - (w / 2));
+		gr_string(x, HC_gauge_coordinates[3] + 10, hud_name.c_str(), GR_RESIZE_MENU);
+	}
+
+	hud_name.clear();
 }
 
-void hud_config_init(bool API_Access, int x, int y, int w)
+void hud_config_init(bool API_Access, int x, int y, int w, int h)
 {
-	hud_config_init_ui(API_Access, x, y, w);
+	hud_config_init_ui(API_Access, x, y, w, h);
 	hud_config_backup(); // save the HUD configuration in case the player decides to cancel changes
 	HUD_config_inited = 1;
 }
 
-/*!
- * @brief check mouse position against all ui buttons using the ui mask
- *
- */
-void hud_config_check_regions()
+bool hud_config_check_mouse_in_hud_area(int mx, int my)
 {
-	int			i;
-	UI_BUTTON	*b;
-
-	for ( i=0; i<NUM_HUD_GAUGES; i++ ) {
-		b = &HC_gauge_regions[gr_screen.res][i].button;
-
-		// check for mouse over gauges
-		if ( b->button_hilighted() ) {
-			HC_gauge_hot = i;
-		}
-
-		if ( b->pressed() ) {
-			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-			HC_gauge_selected = i;
-
-			// turn off select all
-			hud_config_select_all_toggle(0);			
-			
-			// maybe setup rgb sliders
-			if(HC_gauge_regions[gr_screen.res][i].use_iff){
-				HC_color_sliders[HCS_RED].hide();
-				HC_color_sliders[HCS_GREEN].hide();
-				HC_color_sliders[HCS_BLUE].hide();
-				HC_color_sliders[HCS_ALPHA].hide();
-
-				HC_color_sliders[HCS_RED].disable();
-				HC_color_sliders[HCS_GREEN].disable();
-				HC_color_sliders[HCS_BLUE].disable();
-				HC_color_sliders[HCS_ALPHA].disable();
-			} else {
-				HC_color_sliders[HCS_RED].enable();
-				HC_color_sliders[HCS_GREEN].enable();
-				HC_color_sliders[HCS_BLUE].enable();
-				HC_color_sliders[HCS_ALPHA].enable();			
-
-				HC_color_sliders[HCS_RED].unhide();
-				HC_color_sliders[HCS_GREEN].unhide();
-				HC_color_sliders[HCS_BLUE].unhide();
-				HC_color_sliders[HCS_ALPHA].unhide();				
-
-				HC_color_sliders[HCS_RED].force_currentItem( HCS_CONV(HUD_config.clr[i].red) );
-				HC_color_sliders[HCS_GREEN].force_currentItem( HCS_CONV(HUD_config.clr[i].green) );
-				HC_color_sliders[HCS_BLUE].force_currentItem( HCS_CONV(HUD_config.clr[i].blue) );
-				HC_color_sliders[HCS_ALPHA].force_currentItem( HCS_CONV(HUD_config.clr[i].alpha) );
-			}
-
-			// recalc alpha slider
-			hud_config_recalc_alpha_slider();
-		}
+	if (mx < HC_gauge_config_coords[gr_screen.res][0]) {
+		return false;
 	}
+	if (mx > HC_gauge_config_coords[gr_screen.res][1]) {
+		return false;
+	}
+	if (my < HC_gauge_config_coords[gr_screen.res][2]) {
+		return false;
+	}
+	if (my > HC_gauge_config_coords[gr_screen.res][3]) {
+		return false;
+	}
+
+	return true;
 }
 
 /*!
@@ -1147,26 +938,85 @@ void hud_config_check_regions()
  */
 void hud_config_check_regions_by_mouse(int mx, int my)
 {
-	for (int i = 0; i < NUM_HUD_GAUGES; i++) {
-		HC_gauge_region *bi = &HC_gauge_regions[gr_screen.res][i];
-		int iw = 0;
-		int ih = 0;
-		if (bi->bitmap > 0) {
-			bm_get_info(bi->bitmap, &iw, &ih, nullptr);
-			iw = (int)(iw * HC_gauge_scale);
-			ih = (int)(ih * HC_gauge_scale);
-			if (mx < HC_gauge_coords[i].x)
-				continue;
-			if (mx > (HC_gauge_coords[i].x + iw))
-				continue;
-			if (my < HC_gauge_coords[i].y)
-				continue;
-			if (my > (HC_gauge_coords[i].y + ih))
-				continue;
-			// if we've got here, must be a hit
-			HC_gauge_hot = i;
-			break;
+	for (const auto& coords : HC_gauge_mouse_coords) {
+		if (coords.second.x1 < 0)
+			continue;
+
+		if (mx < coords.second.x1 || mx > coords.second.x2 || my < coords.second.y1 || my > coords.second.y2) {
+			continue;
 		}
+
+		// If we've got here, it's a hit
+		HC_gauge_hot = coords.first;
+		return; // Stop checking once we find the first match
+	}
+}
+
+/*!
+ * @brief check mouse position against all ui buttons using the ui mask
+ *
+ */
+void hud_config_check_regions(int mx, int my)
+{
+	if (hud_config_check_mouse_in_hud_area(mx, my)) {
+		HC_gauge_hot = -2;
+	}
+
+	if (HC_gauge_hot == -2 && mouse_down(MOUSE_LEFT_BUTTON)) {
+		HC_gauge_selected = -1;
+		HC_color_sliders[HCS_RED].hide();
+		HC_color_sliders[HCS_GREEN].hide();
+		HC_color_sliders[HCS_BLUE].hide();
+		HC_color_sliders[HCS_ALPHA].hide();
+
+		HC_color_sliders[HCS_RED].disable();
+		HC_color_sliders[HCS_GREEN].disable();
+		HC_color_sliders[HCS_BLUE].disable();
+		HC_color_sliders[HCS_ALPHA].disable();
+	}
+
+	hud_config_check_regions_by_mouse(mx, my);
+
+	if (HC_gauge_hot >= 0 && mouse_down(MOUSE_LEFT_BUTTON)) {
+		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
+		HC_gauge_selected = HC_gauge_hot;
+
+		// turn off select all
+		hud_config_select_all_toggle(false);
+
+		const auto gauge = hud_config_get_gauge_pointer(HC_gauge_selected);
+
+		// maybe setup rgb sliders
+		if (gauge != nullptr && gauge->getConfigUseIffColor()) {
+			HC_color_sliders[HCS_RED].hide();
+			HC_color_sliders[HCS_GREEN].hide();
+			HC_color_sliders[HCS_BLUE].hide();
+			HC_color_sliders[HCS_ALPHA].hide();
+
+			HC_color_sliders[HCS_RED].disable();
+			HC_color_sliders[HCS_GREEN].disable();
+			HC_color_sliders[HCS_BLUE].disable();
+			HC_color_sliders[HCS_ALPHA].disable();
+		} else {
+			HC_color_sliders[HCS_RED].enable();
+			HC_color_sliders[HCS_GREEN].enable();
+			HC_color_sliders[HCS_BLUE].enable();
+			HC_color_sliders[HCS_ALPHA].enable();
+
+			HC_color_sliders[HCS_RED].unhide();
+			HC_color_sliders[HCS_GREEN].unhide();
+			HC_color_sliders[HCS_BLUE].unhide();
+			HC_color_sliders[HCS_ALPHA].unhide();
+
+			HC_color_sliders[HCS_RED].force_currentItem(HCS_CONV(HUD_config.clr[HC_gauge_selected].red));
+			HC_color_sliders[HCS_GREEN].force_currentItem(HCS_CONV(HUD_config.clr[HC_gauge_selected].green));
+			HC_color_sliders[HCS_BLUE].force_currentItem(HCS_CONV(HUD_config.clr[HC_gauge_selected].blue));
+			HC_color_sliders[HCS_ALPHA].force_currentItem(HCS_CONV(HUD_config.clr[HC_gauge_selected].alpha));
+		}
+
+		// recalc alpha slider
+		hud_config_recalc_alpha_slider();
+		mouse_flush();
 	}
 }
 
@@ -1253,7 +1103,8 @@ void hud_cycle_gauge_status()
 
 	// gauge is off, move to popup
 	if ( !(hud_config_show_flag_is_set(HC_gauge_selected)) ) {
-		if ( HC_gauge_regions[gr_screen.res][HC_gauge_selected].can_popup ) {
+		const auto gauge = hud_config_get_gauge_pointer(HC_gauge_selected);
+		if (gauge != nullptr && gauge->getConfigCanPopup()) {
 			hud_config_set_gauge_flags(HC_gauge_selected, 1, 1);	
 		} else {
 			hud_config_set_gauge_flags(HC_gauge_selected, 1, 0);	
@@ -1288,6 +1139,12 @@ void hud_config_handle_keypresses(int k)
 	case KEY_TAB:
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		hud_cycle_gauge_status();
+		break;
+	case KEY_RIGHT:
+		hud_config_select_hud(true);
+		break;
+	case KEY_LEFT:
+		hud_config_select_hud(false);
 		break;
 	}
 }
@@ -1506,10 +1363,9 @@ void hud_config_button_do(int n)
 // Check if any buttons have been pressed
 void hud_config_check_buttons()
 {
-	int			i;
 	UI_BUTTON	*b;
 
-	for ( i=0; i<NUM_HUD_BUTTONS; i++ ) {
+	for (int i=0; i<NUM_HUD_BUTTONS; i++ ) {
 		b = &HC_buttons[gr_screen.res][i].button;
 		if ( b->pressed() ) {
 			hud_config_button_do(i);
@@ -1597,8 +1453,10 @@ void hud_config_set_button_state()
 	hud_config_button_enable(HCB_ON);
 	hud_config_button_enable(HCB_OFF);
 
+	const auto gauge = hud_config_get_gauge_pointer(HC_gauge_selected);
+
 	// popup is maybe available
-	if ( HC_gauge_regions[gr_screen.res][HC_gauge_selected].can_popup ) {
+	if (gauge != nullptr && gauge->getConfigCanPopup()) {
 		hud_config_button_enable(HCB_POPUP);
 	} else {
 		hud_config_button_disable(HCB_POPUP);
@@ -1610,12 +1468,16 @@ void hud_config_render_description()
 	int w,h,sx,sy;
 
 	if ( HC_gauge_selected >= 0 ) {
-		gr_set_color_fast(&Color_normal);
+		const auto gauge = hud_config_get_gauge_pointer(HC_gauge_selected);
 
-		gr_get_string_size(&w, &h, HC_gauge_descriptions(HC_gauge_selected));
-		sx = fl2i(HC_gauge_description_coords[gr_screen.res][0] + (HC_gauge_description_coords[gr_screen.res][2] - w)/2.0f);
-		sy = HC_gauge_description_coords[gr_screen.res][1];
-		gr_string(sx, sy, HC_gauge_descriptions(HC_gauge_selected), GR_RESIZE_MENU);
+		if (gauge != nullptr) {
+			gr_set_color_fast(&Color_normal);
+
+			gr_get_string_size(&w, &h, gauge->getConfigName().c_str());
+			sx = fl2i(HC_gauge_description_coords[gr_screen.res][0] + (HC_gauge_description_coords[gr_screen.res][2] - w) / 2.0f);
+			sy = HC_gauge_description_coords[gr_screen.res][1];
+			gr_string(sx, sy, gauge->getConfigName().c_str(), GR_RESIZE_MENU);
+		}
 	}
 }
 
@@ -1677,8 +1539,10 @@ void hud_config_do_frame(float /*frametime*/, bool API_Access, int mx, int my)
 
 		k = HC_ui_window.process();
 
+		mouse_get_pos_unscaled(&mx, &my);
+
 		hud_config_handle_keypresses(k);
-		hud_config_check_regions();
+		hud_config_check_regions(mx, my);
 		hud_config_check_buttons();
 		hud_config_update_brightness();
 
@@ -1698,15 +1562,6 @@ void hud_config_do_frame(float /*frametime*/, bool API_Access, int mx, int my)
 		hud_config_draw_gauge_status();
 		hud_config_draw_color_status();
 
-		/*
-		if (HC_special_bitmaps[HC_SPECIAL_RETICLE].bitmap >= 0) {
-			hud_set_default_color();
-			gr_set_bitmap(HC_special_bitmaps[HC_SPECIAL_RETICLE].bitmap);
-			gr_aabitmap(HC_special_bitmaps[HC_SPECIAL_RETICLE].x, HC_special_bitmaps[HC_SPECIAL_RETICLE].y,
-		GR_RESIZE_MENU);
-		}
-		*/
-
 		// maybe force draw the select all button
 		if (HC_select_all) {
 			HC_buttons[gr_screen.res][HCB_SELECT_ALL].button.draw_forced(2);
@@ -1725,30 +1580,10 @@ void hud_config_do_frame(float /*frametime*/, bool API_Access, int mx, int my)
 	}
 }
 
-void hud_config_unload_gauges()
-{
-	int					i;
-	HC_gauge_region	*hg;
-
-	for (i=0; i<NUM_HUD_GAUGES; i++) {
-		hg = &HC_gauge_regions[gr_screen.res][i];
-
-		if ( hg->bitmap >= 0 ) {
-			bm_release(hg->bitmap);
-		}
-
-		hg->bitmap=-1;
-		hg->nframes=0;
-	}
-}
-
 // hud_config_close() is called when the player leaves the hud configuration screen
 //
 void hud_config_close(bool API_Access)
 {
-//	common_free_interface_palette();		// restore game palette
-	hud_config_unload_gauges();
-
 	HC_preset_filenames.clear();
 
 	if (!API_Access) {
@@ -1762,6 +1597,9 @@ void hud_config_close(bool API_Access)
 			bm_release(HC_background_bitmap_mask);
 		}
 	}
+
+	bm_unload(HC_talking_head_frame);
+	HC_talking_head_frame = -1;
 
 	HUD_config_inited = 0;
 }
@@ -1841,12 +1679,12 @@ void hud_config_color_save(const char *name)
 	if(out == NULL){
 		Int3();
 		return;
-	}	
+	}
 
 	// write out all gauges
 	for(idx=0; idx<NUM_HUD_GAUGES; idx++){
 		cfputs("+Gauge: ", out);
-		cfputs(HC_gauge_descriptions(idx), out);		
+		cfputs(HC_gauge_descriptions(idx), out);	
 		cfputs("\n", out);
 		cfputs("+RGBA: ", out);
 		sprintf(vals, "%d %d %d %d\n\n", HUD_config.clr[idx].red, HUD_config.clr[idx].green, HUD_config.clr[idx].blue, HUD_config.clr[idx].alpha);
@@ -2030,6 +1868,16 @@ void hud_config_blue_slider()
 	hud_config_recalc_alpha_slider();
 }
 
+void hud_config_get_sliders_color(color & clr)
+{
+	int r = HCS_CONV(HC_color_sliders[HCS_RED].get_currentItem());
+	int g = HCS_CONV(HC_color_sliders[HCS_GREEN].get_currentItem());
+	int b = HCS_CONV(HC_color_sliders[HCS_BLUE].get_currentItem());
+	int a = HCS_CONV(HC_color_sliders[HCS_ALPHA].get_currentItem());
+
+	gr_init_alphacolor(&clr, r, g, b, a);
+}
+
 void hud_config_process_colors()
 {	
 }
@@ -2052,7 +1900,31 @@ void hud_config_delete_preset(SCP_string filename)
 	hud_config_preset_init();
 }
 
-void hud_config_select_all_toggle(int toggle, bool API_Access)
+void hud_config_select_none()
+{
+	HC_select_all = false;
+	HC_gauge_selected = -1;
+}
+
+void hud_config_select_hud(bool next)
+{
+	if (next) {
+		HC_chosen_hud++;
+		if (HC_chosen_hud >= static_cast<int>(HC_available_huds.size())) {
+			HC_chosen_hud = HC_show_default_hud ? -1 : 0;
+		}
+	} else {
+		HC_chosen_hud--;
+		if (HC_chosen_hud < (HC_show_default_hud ? -1 : 0)) {
+			HC_chosen_hud = static_cast<int>(HC_available_huds.size()) - 1;
+		}
+	}
+	HC_gauge_map.clear();
+	HC_gauge_mouse_coords.clear();
+	HC_gauge_list_clear = true;
+}
+
+void hud_config_select_all_toggle(bool toggle, bool API_Access)
 {	
 	int r, g, b, a;
 
@@ -2063,7 +1935,7 @@ void hud_config_select_all_toggle(int toggle, bool API_Access)
 			hud_config_set_button_state();
 		}
 
-		HC_select_all = 0;
+		HC_select_all = false;
 	} else {
 		// synch stuff up
 		hud_config_synch_ui(API_Access);
@@ -2109,6 +1981,6 @@ void hud_config_select_all_toggle(int toggle, bool API_Access)
 			hud_config_button_disable(HCB_POPUP);
 		}
 
-		HC_select_all = 1;
+		HC_select_all = true;
 	}
 }

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -99,6 +99,12 @@ class BoundingBox {
 	// Constructor
 	constexpr BoundingBox(int nx1, int nx2, int ny1, int ny2) : x1(nx1), x2(nx2), y1(ny1), y2(ny2) {}
 
+	// Equality operator
+	bool operator==(const BoundingBox& other) const
+	{
+		return x1 == other.x1 && x2 == other.x2 && y1 == other.y1 && y2 == other.y2;
+	}
+
 	bool isOverlapping(const BoundingBox& other) const
 	{
 		return (x2 >= other.x1 && // Not completely to the left
@@ -116,18 +122,13 @@ class BoundingBox {
 	// Static function to check if any bounding box in an array overlaps with a new one
 	static bool isOverlappingAny(const SCP_vector<std::pair<int, BoundingBox>>& mouse_coords, const BoundingBox& newBox, int self_index)
 	{
-		for (const auto& [gauge_id, bbox_list] : mouse_coords) {
+		return std::any_of(mouse_coords.begin(), mouse_coords.end(), [&](const std::pair<int, BoundingBox>& item) {
+			const auto& [gauge_id, bbox] = item;
 			if (gauge_id == self_index) {
-				continue; // Skip checking against itself
+				return false; // Skip checking against itself
 			}
-
-			for (const auto& bbox : mouse_coords) { // Check each bounding box for the gauge
-				if (bbox.second.isValid() && bbox.second.isOverlapping(newBox)) {
-					return true;
-				}
-			}
-		}
-		return false;
+			return bbox.isValid() && bbox.isOverlapping(newBox);
+		});
 	}
 };
 

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -34,24 +34,13 @@ struct ai_info;
 extern float Radar_ranges[RR_MAX_RANGES];
 extern const char *Radar_range_text(int range_num);
 
-#define RP_SHOW_DEBRIS						(1<<0)
-#define RP_SHOW_FRIENDLY_MISSILES		(1<<1)
-#define RP_SHOW_HOSTILE_MISSILES			(1<<2)
-
-#define RP_DEFAULT ( RP_SHOW_DEBRIS | RP_SHOW_FRIENDLY_MISSILES | RP_SHOW_HOSTILE_MISSILES )
-
 /*!
  * @brief Vector for storing the filenames of hud preset files
  * @note main definition in hudconfig.cpp
  */
 extern SCP_vector<SCP_string> HC_preset_filenames;
 
-extern int HUD_observer_default_flags;
-extern int HUD_observer_default_flags2;
-extern int HUD_default_popup_mask;
-extern int HUD_default_popup_mask2;
-extern int HUD_config_default_flags;
-extern int HUD_config_default_flags2;
+extern SCP_vector<SCP_string> observer_visible_gauges;
 
 extern const int HC_gauge_config_coords[GR_NUM_RESOLUTIONS][4];
 extern int HC_resize_mode;
@@ -60,18 +49,60 @@ extern int HC_resize_mode;
  * @brief Contains core HUD configuration data
  * @note Is not default init'd.  Assumes new player, PLR, or CSG reads will correctly set data.
  */
-typedef struct HUD_CONFIG_TYPE {		
-	int show_flags;				//!< bitfield, whether to show gauge (0 ~ 31)
-	int show_flags2;			//!< bitfield, whether to show gauge (32 ~ 63)
-	int popup_flags;			//!< bitfield, whether gauge is popup (0 ~ 31)
-	int popup_flags2;			//!< bitfield, whether gauge is popup (32 ~ 63)
-	int rp_flags;				//!< one of RP_ #defines in hudconfig.h;  Chiefly shows/hides non-ship objects
+typedef struct HUD_CONFIG_TYPE {
 	int rp_dist;				//!< one of RR_ #defines above; Is the maxium radar view distance setting
 	int is_observer;			//!< 1 or 0, observer mode or not, respectively
 	int main_color;				//!< the default HUD_COLOR selection for all gauges; each gauge may override this with a custom RGB
-	ubyte num_msg_window_lines;	//!< Number of message lines. (Deprecated by HudGaugeMessages::Max_lines)
 
-	color clr[NUM_HUD_GAUGES];	//!< colors for all the gauges
+	// Maps for HUD gauge configuration
+	std::unordered_map<std::string, color> gauge_colors;   //!< Gauge-specific colors
+	std::unordered_map<std::string, bool> show_flags_map;  //!< Show/hide state for gauges
+	std::unordered_map<std::string, bool> popup_flags_map; //!< Popup state for gauges
+
+	static color default_white_color()
+	{
+		color white;
+		gr_init_alphacolor(&white, 255, 255, 255, 255);
+		return white;
+	}
+
+	// Methods for setting and getting gauge properties where getting will return a default value
+
+	void set_gauge_color(const std::string& gauge_id, const color& col)
+	{
+		gauge_colors[gauge_id] = col;
+	}
+
+	// Get the gauge color or white if the gauge is not found
+	color get_gauge_color(const std::string& gauge_id) const
+	{
+		auto it = gauge_colors.find(gauge_id);
+		return (it != gauge_colors.end()) ? it->second : default_white_color();
+	}
+
+	void set_gauge_visibility(const std::string& gauge_id, bool visible)
+	{
+		show_flags_map[gauge_id] = visible;
+	}
+
+	// Get the gauge config visibility setting or false (invisible) if not found
+	bool is_gauge_visible(const std::string& gauge_id) const
+	{
+		auto it = show_flags_map.find(gauge_id);
+		return (it != show_flags_map.end()) ? it->second : false; // Default to invisible
+	}
+
+	void set_gauge_popup(const std::string& gauge_id, bool popup)
+	{
+		popup_flags_map[gauge_id] = popup;
+	}
+
+	// Get the gauge config popup setting or false if not found
+	bool is_gauge_popup(const std::string& gauge_id) const
+	{
+		auto it = popup_flags_map.find(gauge_id);
+		return (it != popup_flags_map.end()) ? it->second : false; // Default to not a popup
+	}
 } HUD_CONFIG_TYPE;
 
 extern HUD_CONFIG_TYPE HUD_config;
@@ -120,11 +151,11 @@ class BoundingBox {
 	}
 
 	// Static function to check if any bounding box in an array overlaps with a new one
-	static bool isOverlappingAny(const SCP_vector<std::pair<int, BoundingBox>>& mouse_coords, const BoundingBox& newBox, int self_index)
+	static bool isOverlappingAny(const SCP_vector<std::pair<SCP_string, BoundingBox>>& mouse_coords, const BoundingBox& newBox, SCP_string self_id)
 	{
-		return std::any_of(mouse_coords.begin(), mouse_coords.end(), [&](const std::pair<int, BoundingBox>& item) {
+		return std::any_of(mouse_coords.begin(), mouse_coords.end(), [&](const std::pair<SCP_string, BoundingBox>& item) {
 			const auto& [gauge_id, bbox] = item;
-			if (gauge_id == self_index) {
+			if (gauge_id == self_id) {
 				return false; // Skip checking against itself
 			}
 			return bbox.isValid() && bbox.isOverlapping(newBox);
@@ -134,15 +165,14 @@ class BoundingBox {
 
 extern char HC_wingam_gauge_status_names[MAX_SQUADRON_WINGS][32];
 
-extern int HC_gauge_hot;
-extern int HC_gauge_selected;
+extern SCP_vector<std::pair<SCP_string, HudGauge*>> HC_gauge_map;
+extern SCP_string HC_gauge_hot;
+extern SCP_string HC_gauge_selected;
 extern SCP_vector<std::pair<size_t, SCP_string>> HC_available_huds;
 extern int HC_chosen_hud;
 extern bool HC_select_all;
 extern int HC_gauge_coordinates[6]; // x1, x2, y1, y2, w, h for gauge rendering
-extern SCP_vector<std::pair<int, BoundingBox>> HC_gauge_mouse_coords;
-
-const char* HC_gauge_descriptions(int n);
+extern SCP_vector<std::pair<SCP_string, BoundingBox>> HC_gauge_mouse_coords;
 
 extern int HC_talking_head_frame;
 extern SCP_string HC_head_anim_filename;
@@ -150,10 +180,110 @@ extern SCP_string HC_shield_gauge_ship;
 extern bool HC_show_default_hud;
 extern std::unordered_set<SCP_string> HC_ignored_huds;
 
+class HC_gauge_mappings {
+public:
+    static HC_gauge_mappings& get_instance() {
+        static HC_gauge_mappings instance;
+        return instance;
+    }
+
+    // Prevent copying
+    HC_gauge_mappings(const HC_gauge_mappings&) = delete;
+    HC_gauge_mappings& operator=(const HC_gauge_mappings&) = delete;
+
+    // Numeric ID -> New String ID
+    SCP_string get_string_id_from_numeric_id(int numeric_id) const {
+        auto it = gauge_map.find(numeric_id);
+        return (it != gauge_map.end()) ? it->second.second : "";
+    }
+
+   // HCF String Name -> New String ID
+	SCP_string get_string_id_from_hcf_id(const SCP_string& hcf_name) const
+	{
+		for (const auto& [id, mapping] : gauge_map) {
+			if (XSTR(mapping.first.first.c_str(), mapping.first.second) == hcf_name) {
+				return mapping.second;
+			}
+		}
+		return "";
+	}
+
+    // New String ID -> Numeric ID (for saving to player file)
+    int get_numeric_id_from_string_id(const SCP_string& string_id) const {
+        for (const auto& [id, mapping] : gauge_map) {
+            if (mapping.second == string_id) {
+                return id;
+            }
+        }
+        return -1;
+    }
+
+    // New String ID -> HCF String Name (for saving HCF files)
+	SCP_string get_hcf_name_from_string_id(const SCP_string& string_id) const
+	{
+		for (const auto& [id, mapping] : gauge_map) {
+			if (mapping.second == string_id) {
+				return XSTR(mapping.first.first.c_str(), mapping.first.second);
+			}
+		}
+		return "";
+	}
+
+private:
+	HC_gauge_mappings() {
+		// Map the old gauge_config numeric IDs, the HCF file IDs (which, yes, were translated...), and the newer string IDs
+		// for the retail built-in gauges. Custom gauges will only have a string ID and do not need to be mapped.
+        gauge_map = {
+            {0, {{"lead indicator", 249}, "Builtin::LeadIndicator"}},
+            {1, {{"target orientation", 250}, "Builtin::TargetOrientation"}},
+            {2, {{"closest attacking hostile", 251}, "Builtin::ClosestAttackingHostile"}},
+            {3, {{"current target direction", 252}, "Builtin::CurrentTargetDirection"}},
+            {4, {{"mission time", 253}, "Builtin::MissionTime"}},
+            {5, {{"reticle", 254}, "Builtin::Reticle"}},
+            {6, {{"throttle", 255}, "Builtin::Throttle"}},
+            {7, {{"radar", 256}, "Builtin::Radar"}},
+            {8, {{"target monitor", 257}, "Builtin::TargetMonitor"}},
+            {9, {{"center of reticle", 258}, "Builtin::CenterOfReticle"}},
+            {10, {{"extra target info", 259}, "Builtin::ExtraTargetInfo"}},
+            {11, {{"target shield", 260}, "Builtin::TargetShield"}},
+            {12, {{"player shield", 261}, "Builtin::PlayerShield"}},
+            {13, {{"power management", 262}, "Builtin::PowerManagement"}},
+            {14, {{"auto-target icon", 263}, "Builtin::AutoTargetIcon"}},
+            {15, {{"auto-speed-match icon", 264}, "Builtin::AutoSpeedMatchIcon"}},
+            {16, {{"weapons display", 265}, "Builtin::WeaponsDisplay"}},
+            {17, {{"monitoring view", 266}, "Builtin::MonitoringView"}},
+            {18, {{"directives view", 267}, "Builtin::DirectivesView"}},
+            {19, {{"threat gauge", 268}, "Builtin::ThreatGauge"}},
+            {20, {{"afterburner energy", 269}, "Builtin::AfterburnerEnergy"}},
+            {21, {{"weapons energy", 270}, "Builtin::WeaponsEnergy"}},
+            {22, {{"weapon linking", 271}, "Builtin::WeaponLinking"}},
+            {23, {{"target hull/shield icon", 272}, "Builtin::TargetHullShieldIcon"}},
+            {24, {{"offscreen indicator", 273}, "Builtin::OffscreenIndicator"}},
+            {25, {{"comm video", 274}, "Builtin::CommVideo"}},
+            {26, {{"damage display", 275}, "Builtin::DamageDisplay"}},
+            {27, {{"message output", 276}, "Builtin::MessageOutput"}},
+            {28, {{"locked missile direction", 277}, "Builtin::LockedMissileDirection"}},
+            {29, {{"countermeasures", 278}, "Builtin::Countermeasures"}},
+            {30, {{"objective notify", 279}, "Builtin::ObjectiveNotify"}},
+            {31, {{"wingmen status", 280}, "Builtin::WingmenStatus"}},
+            {32, {{"offscreen range", 281}, "Builtin::OffscreenRange"}},
+            {33, {{"kills gauge", 282}, "Builtin::KillsGauge"}},
+            {34, {{"attacking target count", 283}, "Builtin::AttackingTargetCount"}},
+            {35, {{"warning flash", 1459}, "Builtin::WarningFlash"}},
+            {36, {{"comm menu", 1460}, "Builtin::CommMenu"}},
+            {37, {{"support gauge", 1461}, "Builtin::SupportGauge"}},
+            {38, {{"lag gauge", 1462}, "Builtin::LagGauge"}}
+        };
+    }
+
+    SCP_unordered_map<int, std::pair<std::pair<SCP_string, int>, SCP_string>> gauge_map;
+};
+
+
 /*!
  * @brief get the gauge pointer for the given gauge index
  */
-HudGauge* hud_config_get_gauge_pointer(int gauge_index);
+HudGauge* hud_config_get_gauge_pointer(const SCP_string& gauge_id);
 
 /*!
  * @brief init hud config screen, setting up the hud preview display
@@ -225,7 +355,7 @@ void hud_config_delete_preset(SCP_string filename);
  * param[in] on_flag		if the gauge is on or off, 1 for on, 0 for off
  * param[in] popup_flag		if the gauge is set to popup, 1 for popup, 0 otherwise
  */
-void hud_config_set_gauge_flags(int gauge_index, int on_flag, int popup_flag);
+void hud_config_set_gauge_flags(SCP_string gauge, bool on_flag, bool popup_flag);
 
 void hud_config_restore();
 void hud_config_backup();
@@ -243,14 +373,6 @@ void hud_config_cancel(bool change_state = true);
  */
 void hud_config_commit();
 
-// flag access/manipulation routines
-int	hud_config_show_flag_is_set(int i);
-void	hud_config_show_flag_set(int i);
-void	hud_config_show_flag_clear(int i);
-int	hud_config_popup_flag_is_set(int i);
-void	hud_config_popup_flag_set(int i);
-void	hud_config_popup_flag_clear(int i);
-
 void hud_config_record_color(int color);
 void hud_config_set_color(int color);
 
@@ -262,7 +384,7 @@ void hud_config_color_load(const char *name);
 /*!
  * @brief save the current hud gauges settings to a preset file
  */
-void hud_config_color_save(const char* name);
+void hud_config_color_save(const char* name, int version = 2);
 
 /*!
  * @brief same as hud_config_covert_coords but only returns the scale and doesn't convert any coords
@@ -294,7 +416,7 @@ std::tuple<float, float, float> hud_config_convert_coord_sys(float x, float y, i
 /*!
  * @brief save gauge coords during rendering time so hud config can check if the mouse is hovering over the gauge
  */
-void hud_config_set_mouse_coords(int gauge_config, int x1, int x2, int y1, int y2);
+void hud_config_set_mouse_coords(const SCP_string& gauge_id, int x1, int x2, int y1, int y2);
 
 /*!
  * @brief Function to calculate screen coordinates based on angle. Used for radial positioning gauges
@@ -304,7 +426,7 @@ std::pair<float, float> hud_config_calc_coords_from_angle(float angle_degrees, i
 /*!
  * @brief try to find an angle with no overlapping mouse coordinates for target-related gauges
  */
-float hud_config_find_valid_angle(int gauge_index, float initial_angle, int centerX, int centerY, float radius);
+float hud_config_find_valid_angle(SCP_string gauge, float initial_angle, int centerX, int centerY, float radius);
 
 #endif
 

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -355,7 +355,7 @@ void hud_config_delete_preset(SCP_string filename);
  * param[in] on_flag		if the gauge is on or off, 1 for on, 0 for off
  * param[in] popup_flag		if the gauge is set to popup, 1 for popup, 0 otherwise
  */
-void hud_config_set_gauge_flags(SCP_string gauge, bool on_flag, bool popup_flag);
+void hud_config_set_gauge_flags(const SCP_string& gauge, bool on_flag, bool popup_flag);
 
 void hud_config_restore();
 void hud_config_backup();
@@ -426,7 +426,7 @@ std::pair<float, float> hud_config_calc_coords_from_angle(float angle_degrees, i
 /*!
  * @brief try to find an angle with no overlapping mouse coordinates for target-related gauges
  */
-float hud_config_find_valid_angle(SCP_string gauge, float initial_angle, int centerX, int centerY, float radius);
+float hud_config_find_valid_angle(const SCP_string& gauge, float initial_angle, int centerX, int centerY, float radius);
 
 #endif
 

--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -286,7 +286,7 @@ void HudGaugeEscort::render(float  /*frametime*/, bool config)
 	if (config) {
 		int bmw, bmh;
 		bm_get_info(Escort_gauges[2].first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, lx + fl2i(bmw * scale), y, ly + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, lx + fl2i(bmw * scale), y, ly + fl2i(bmh * scale));
 	}
 }
 

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -1102,7 +1102,7 @@ void HudGaugeEtsRetail::render(float  /*frametime*/, bool config)
 		auto coords1 = hud_config_convert_coords(Gauge_positions[0], position[1], scale);
 		auto coords2 = hud_config_convert_coords(Gauge_positions[initial_position - 1] + bmw, position[1] + (bmh * 2), scale);
 
-		hud_config_set_mouse_coords(gauge_config, coords1.first, coords2.first, coords1.second, coords2.second);
+		hud_config_set_mouse_coords(gauge_config_id, coords1.first, coords2.first, coords1.second, coords2.second);
 	}
 }
 
@@ -1193,7 +1193,7 @@ void HudGaugeEtsWeapons::render(float  /*frametime*/, bool config)
 		int bmw, bmh;
 		bm_get_info(Ets_bar.first_frame, &bmw, &bmh);
 
-		hud_config_set_mouse_coords(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2));
+		hud_config_set_mouse_coords(gauge_config_id, rx, rx + bmw, ry, ry + (bmh * 2));
 	}
 }
 
@@ -1263,7 +1263,7 @@ void HudGaugeEtsShields::render(float  /*frametime*/, bool config)
 		int bmw, bmh;
 		bm_get_info(Ets_bar.first_frame, &bmw, &bmh);
 
-		hud_config_set_mouse_coords(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2));
+		hud_config_set_mouse_coords(gauge_config_id, rx, rx + bmw, ry, ry + (bmh * 2));
 	}
 }
 
@@ -1333,6 +1333,6 @@ void HudGaugeEtsEngines::render(float  /*frametime*/, bool config)
 		int bmw, bmh;
 		bm_get_info(Ets_bar.first_frame, &bmw, &bmh);
 
-		hud_config_set_mouse_coords(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2));
+		hud_config_set_mouse_coords(gauge_config_id, rx, rx + bmw, ry, ry + (bmh * 2));
 	}
 }

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -1100,7 +1100,7 @@ void HudGaugeEtsRetail::render(float  /*frametime*/, bool config)
 		bm_get_info(Ets_bar.first_frame, &bmw, &bmh);
 
 		auto coords1 = hud_config_convert_coords(Gauge_positions[0], position[1], scale);
-		auto coords2 = hud_config_convert_coords(Gauge_positions[initial_position - 1] + bmw, position[1] + (bmh * 2) + 10, scale);
+		auto coords2 = hud_config_convert_coords(Gauge_positions[initial_position - 1] + bmw, position[1] + (bmh * 2), scale);
 
 		hud_config_set_mouse_coords(gauge_config, coords1.first, coords2.first, coords1.second, coords2.second);
 	}
@@ -1193,7 +1193,7 @@ void HudGaugeEtsWeapons::render(float  /*frametime*/, bool config)
 		int bmw, bmh;
 		bm_get_info(Ets_bar.first_frame, &bmw, &bmh);
 
-		hud_config_set_mouse_coords_ets(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2) + 10);
+		hud_config_set_mouse_coords(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2));
 	}
 }
 
@@ -1263,7 +1263,7 @@ void HudGaugeEtsShields::render(float  /*frametime*/, bool config)
 		int bmw, bmh;
 		bm_get_info(Ets_bar.first_frame, &bmw, &bmh);
 
-		hud_config_set_mouse_coords_ets(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2) + 10);
+		hud_config_set_mouse_coords(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2));
 	}
 }
 
@@ -1333,6 +1333,6 @@ void HudGaugeEtsEngines::render(float  /*frametime*/, bool config)
 		int bmw, bmh;
 		bm_get_info(Ets_bar.first_frame, &bmw, &bmh);
 
-		hud_config_set_mouse_coords_ets(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2) + 10);
+		hud_config_set_mouse_coords(gauge_config, rx, rx + bmw, ry, ry + (bmh * 2));
 	}
 }

--- a/code/hud/hudlock.cpp
+++ b/code/hud/hudlock.cpp
@@ -293,7 +293,7 @@ void HudGaugeLock::render(float frametime, bool config)
 		int w;
 		int h;
 		// Will need actual coords for the below if we activate this gauge in config
-		hud_config_set_mouse_coords(gauge_config, x, x + w, y, y + h);
+		hud_config_set_mouse_coords(gauge_config_id, x, x + w, y, y + h);
 
 		setGaugeColor(HUD_C_NONE, config);*/
 

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -450,7 +450,7 @@ void HudGaugeMessages::render(float  /*frametime*/, bool config)
         int bmw, bmh;
 		SCP_string msg = XSTR("Terran Fighter: HUD Message Display", 1874);
 		gr_get_string_size(&bmw, &bmh, msg.c_str(), scale);
-		hud_config_set_mouse_coords(gauge_config, x, x + bmw, y, y + bmh);
+		hud_config_set_mouse_coords(gauge_config_id, x, x + bmw, y, y + bmh);
 		setGaugeColor(HUD_C_NONE, config);
 		renderPrintf(x, y, scale, config, "%s", msg.c_str());
 
@@ -1206,7 +1206,7 @@ void HudGaugeTalkingHead::render(float frametime, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Head_frame.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 
 		// Talking head is complex enough that we can do all the config rendering right here and exit early
 		setGaugeColor(HUD_C_NONE, config);
@@ -1398,7 +1398,7 @@ void HudGaugeFixedMessages::render(float  /*frametime*/, bool config) {
 	// That may change in the future, in which case the code below can be restored.
 	if (config) {
 		/*std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
-		hud_config_set_mouse_coords(gauge_config, x - fl2i(w * scale), x + fl2i(w * scale), y, y + fl2i(h * scale));*/
+		hud_config_set_mouse_coords(gauge_config_id, x - fl2i(w * scale), x + fl2i(w * scale), y, y + fl2i(h * scale));*/
 		return;
 	}
 

--- a/code/hud/hudobserver.cpp
+++ b/code/hud/hudobserver.cpp
@@ -44,11 +44,12 @@ void hud_observer_init(ship *shipp, ai_info *aip)
 	Hud_obs_ship.weapons = shipp->weapons;
 
 	HUD_config.is_observer = 1;
-	HUD_config.show_flags = HUD_observer_default_flags;
-	HUD_config.show_flags2 = HUD_observer_default_flags2;
+	HUD_config.show_flags_map.clear();
+	HUD_config.popup_flags_map.clear();
 
-	HUD_config.popup_flags = 0x0;
-	HUD_config.popup_flags2 = 0x0;
+	for (const auto& gauge_id : observer_visible_gauges) {
+		HUD_config.show_flags_map[gauge_id] = true;
+	}
 
 	// shutdown any playing static animations
 	hud_init_target_static();

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -786,38 +786,44 @@ void init_hud() {
 
 		for(i = 0; i < num_gauges; i++) {
 			config_type = Ship_info[Player_ship->ship_info_index].hud_gauges[i]->getConfigType();
+			SCP_string config_id = Ship_info[Player_ship->ship_info_index].hud_gauges[i]->getConfigId();
 
-			if ( !Ship_info[Player_ship->ship_info_index].hud_gauges[i]->isOffbyDefault() && hud_config_show_flag_is_set(config_type) )
+			if ( !Ship_info[Player_ship->ship_info_index].hud_gauges[i]->isOffbyDefault() && HUD_config.is_gauge_visible(config_id) )
 				Ship_info[Player_ship->ship_info_index].hud_gauges[i]->updateActive(true);
 			else
 				Ship_info[Player_ship->ship_info_index].hud_gauges[i]->updateActive(false);
 
-			Ship_info[Player_ship->ship_info_index].hud_gauges[i]->updatePopUp(hud_config_popup_flag_is_set(config_type) ? true : false);
-			Ship_info[Player_ship->ship_info_index].hud_gauges[i]->updateColor(
-				HUD_config.clr[config_type].red, 
-				HUD_config.clr[config_type].green, 
-				HUD_config.clr[config_type].blue, 
-				HUD_config.clr[config_type].alpha
-				);
+			Ship_info[Player_ship->ship_info_index].hud_gauges[i]->updatePopUp(HUD_config.is_gauge_popup(config_id));
+			color clr;
+			if (config_id.empty()) {
+				HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+				clr = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(config_type)];
+			} else {
+				clr = HUD_config.get_gauge_color(config_id);
+			}
+			Ship_info[Player_ship->ship_info_index].hud_gauges[i]->updateColor(clr.red, clr.green, clr.blue, clr.alpha);
 		}
 	} else {
 		num_gauges = default_hud_gauges.size();
 
 		for(i = 0; i < num_gauges; i++) {
 			config_type = default_hud_gauges[i]->getConfigType();
+			SCP_string config_id = default_hud_gauges[i]->getConfigId();
 
-			if ( !default_hud_gauges[i]->isOffbyDefault() && hud_config_show_flag_is_set(config_type) )
+			if ( !default_hud_gauges[i]->isOffbyDefault() && HUD_config.is_gauge_visible(config_id) )
 				default_hud_gauges[i]->updateActive(true);
 			else
 				default_hud_gauges[i]->updateActive(false);
 
-			default_hud_gauges[i]->updatePopUp(hud_config_popup_flag_is_set(config_type) ? true : false);
-			default_hud_gauges[i]->updateColor(
-				HUD_config.clr[config_type].red, 
-				HUD_config.clr[config_type].green, 
-				HUD_config.clr[config_type].blue, 
-				HUD_config.clr[config_type].alpha
-				);
+			default_hud_gauges[i]->updatePopUp(HUD_config.is_gauge_popup(config_id));
+			color clr;
+			if (config_id.empty()) {
+				HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+				clr = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(config_type)];
+			} else {
+				clr = HUD_config.get_gauge_color(config_id);
+			}
+			default_hud_gauges[i]->updateColor(clr.red, clr.green, clr.blue, clr.alpha);
 		}
 	}
 }
@@ -839,40 +845,46 @@ void set_current_hud()
 		for(i = 0; i < num_gauges; i++) {
 			HudGauge* hgp = Ship_info[Player_ship->ship_info_index].hud_gauges[i].get();
 			config_type = hgp->getConfigType();
+			SCP_string config_id = hgp->getConfigId();
 
-			if ( ( (!hgp->isOffbyDefault() || hgp->isActive()) && hud_config_show_flag_is_set(config_type)) )
+			if ( ( (!hgp->isOffbyDefault() || hgp->isActive()) && HUD_config.is_gauge_visible(config_id)) )
 				hgp->updateActive(true);
 			else
 				hgp->updateActive(false);
 
 			//hgp->updateActive(hud_config_show_flag_is_set(config_type) ? true : false);
-			hgp->updatePopUp(hud_config_popup_flag_is_set(config_type) ? true : false);
-			hgp->updateColor(
-				HUD_config.clr[config_type].red, 
-				HUD_config.clr[config_type].green, 
-				HUD_config.clr[config_type].blue, 
-				HUD_config.clr[config_type].alpha
-				);
+			hgp->updatePopUp(HUD_config.is_gauge_popup(config_id));
+			color clr;
+			if (config_id.empty()) {
+				HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+				clr = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(config_type)];
+			} else {
+				clr = HUD_config.get_gauge_color(config_id);
+			}
+			hgp->updateColor(clr.red, clr.green, clr.blue, clr.alpha);
 		}
 	} else {
 		num_gauges = default_hud_gauges.size();
 
 		for(i = 0; i < num_gauges; i++) {
 			config_type = default_hud_gauges[i]->getConfigType();
+			SCP_string config_id = default_hud_gauges[i]->getConfigId();
 
-			if ( ( (!default_hud_gauges[i]->isOffbyDefault() || default_hud_gauges[i]->isActive()) && hud_config_show_flag_is_set(config_type)) )
+			if ( ( (!default_hud_gauges[i]->isOffbyDefault() || default_hud_gauges[i]->isActive()) &&HUD_config.is_gauge_visible(config_id)) )
 				default_hud_gauges[i]->updateActive(true);
 			else
 				default_hud_gauges[i]->updateActive(false);
 
 			//default_hud_gauges[i]->updateActive(hud_config_show_flag_is_set(config_type) ? true : false);
-			default_hud_gauges[i]->updatePopUp(hud_config_popup_flag_is_set(config_type) ? true : false);
-			default_hud_gauges[i]->updateColor(
-				HUD_config.clr[config_type].red, 
-				HUD_config.clr[config_type].green, 
-				HUD_config.clr[config_type].blue, 
-				HUD_config.clr[config_type].alpha
-				);
+			default_hud_gauges[i]->updatePopUp(HUD_config.is_gauge_popup(config_id));
+			color clr;
+			if (config_id.empty()) {
+				HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+				clr = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(config_type)];
+			} else {
+				clr = HUD_config.get_gauge_color(config_id);
+			}
+			default_hud_gauges[i]->updateColor(clr.red, clr.green, clr.blue, clr.alpha);
 		}
 	}
 }

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -1314,6 +1314,7 @@ std::unique_ptr<T> gauge_load_common(gauge_settings* settings, T* preAllocated =
 	int display_size[2] = {0, 0};
 	int display_offset[2] = {0, 0};
 	int canvas_size[2] = {0, 0};
+	bool visible_in_config = true;
 
 	if(check_base_res(settings->base_res)) {
 		if (settings->set_position) {
@@ -1445,6 +1446,10 @@ std::unique_ptr<T> gauge_load_common(gauge_settings* settings, T* preAllocated =
 		}
 	}
 
+	if (optional_string("Config:")) {
+		stuff_boolean(&visible_in_config);
+	}
+
 	std::unique_ptr<T> instance(preAllocated);
 
 	if (instance == NULL)
@@ -1473,6 +1478,7 @@ std::unique_ptr<T> gauge_load_common(gauge_settings* settings, T* preAllocated =
 		//In this case, we must always slew every hud gauge, no matter what.
 		instance->initSlew(true);
 	}
+	instance->initVisible_in_config(visible_in_config);
 
 	return instance;
 }
@@ -1510,6 +1516,7 @@ void load_gauge_custom(gauge_settings* settings)
 	int display_size[2] = {0, 0};
 	int display_offset[2] = {0, 0};
 	int canvas_size[2] = {0, 0};
+	bool visible_in_config = true;
 
 	if(check_base_res(settings->base_res)) {
 		if(optional_string("Position:")) {
@@ -1636,6 +1643,10 @@ void load_gauge_custom(gauge_settings* settings)
 			stuff_boolean(&settings->slew);
 		}
 
+		if (optional_string("Config:")) {
+			stuff_boolean(&visible_in_config);
+		}
+
 		if(optional_string("Active by default:")) {
 			stuff_boolean(&active_by_default);
 		}
@@ -1665,6 +1676,7 @@ void load_gauge_custom(gauge_settings* settings)
 	hud_gauge->initCockpitTarget(display_name, display_offset[0], display_offset[1], display_size[0], display_size[1], canvas_size[0], canvas_size[1]);
 	hud_gauge->initChase_view_only(settings->chase_view_only);
 	hud_gauge->initCockpit_view_choice(settings->cockpit_view_choice);
+	hud_gauge->initVisible_in_config(visible_in_config);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -796,7 +796,7 @@ void init_hud() {
 			Ship_info[Player_ship->ship_info_index].hud_gauges[i]->updatePopUp(HUD_config.is_gauge_popup(config_id));
 			color clr;
 			if (config_id.empty()) {
-				HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+				const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 				clr = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(config_type)];
 			} else {
 				clr = HUD_config.get_gauge_color(config_id);
@@ -818,7 +818,7 @@ void init_hud() {
 			default_hud_gauges[i]->updatePopUp(HUD_config.is_gauge_popup(config_id));
 			color clr;
 			if (config_id.empty()) {
-				HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+				const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 				clr = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(config_type)];
 			} else {
 				clr = HUD_config.get_gauge_color(config_id);
@@ -856,7 +856,7 @@ void set_current_hud()
 			hgp->updatePopUp(HUD_config.is_gauge_popup(config_id));
 			color clr;
 			if (config_id.empty()) {
-				HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+				const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 				clr = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(config_type)];
 			} else {
 				clr = HUD_config.get_gauge_color(config_id);
@@ -879,7 +879,7 @@ void set_current_hud()
 			default_hud_gauges[i]->updatePopUp(HUD_config.is_gauge_popup(config_id));
 			color clr;
 			if (config_id.empty()) {
-				HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+				const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 				clr = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(config_type)];
 			} else {
 				clr = HUD_config.get_gauge_color(config_id);

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -238,6 +238,9 @@ void parse_hud_gauges_tbl(const char *filename)
 		reset_parse();
 
 		if (optional_string("#HUD Config Settings")) {
+			if (optional_string("$Show Default HUD:")) {
+				stuff_boolean(&HC_show_default_hud);
+			}
 			if (optional_string("$Head Animation:")) {
 				stuff_string(HC_head_anim_filename, F_NAME);
 			}
@@ -459,6 +462,15 @@ void parse_hud_gauges_tbl(const char *filename)
 			case 2:
 				stuff_string(name, F_NAME);
 
+				if (optional_string("$Show in HUD Config:")) {
+					bool show = true;
+					stuff_boolean(&show);
+
+					if (!show) {
+						HC_ignored_huds.insert(name);
+					}
+				}
+
 				if (optional_string("$Load Retail Configuration:")) {
 					stuff_boolean(&retail_config);
 				}
@@ -648,8 +660,6 @@ void hud_positions_init()
 
 	// load missing retail gauges for the default and ship-specific HUDs
 	load_missing_retail_gauges();
-
-	Hud_parsed_ships.clear();
 }
 
 void load_missing_retail_gauges()

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -264,7 +264,7 @@ void HudGaugeReticle::render(float  /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(crosshair.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	ship_info* sip = nullptr;
@@ -687,7 +687,7 @@ void HudGaugeThrottle::render(float  /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(throttle_frames.first_frame + 1, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	int desired_y_pos = y + fl2i(Bottom_offset_y * scale) - fl2i(std::lround(fl2i(throttle_h * scale) * desired_speed / max_speed)) - 1;
@@ -999,7 +999,11 @@ void HudGaugeThreatIndicator::render(float  /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
         int bmw, bmh;
 		bm_get_info(threat_arc.first_frame + 1, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + static_cast<int>(bmw * scale), y, y + static_cast<int>(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id,
+			x,
+			x + static_cast<int>(bmw * scale),
+			y,
+			y + static_cast<int>(bmh * scale));
 	}
 
 	setGaugeColor(HUD_C_NONE, config);
@@ -1178,7 +1182,7 @@ void HudGaugeWeaponLinking::render(float  /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(arc.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	setGaugeColor(HUD_C_NONE, config);

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -767,7 +767,7 @@ void HudGaugeShield::showShields(const object *objp, int mode, bool config)
 				if (config) {
 					int bmw, bmh;
 					bm_get_info(sgp->first_frame, &bmw, &bmh);
-					hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+					hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 				}
 
 			}
@@ -782,7 +782,7 @@ void HudGaugeShield::showShields(const object *objp, int mode, bool config)
 
 				// If this comment is here then I have not tested this
 				if (config) {
-					hud_config_set_mouse_coords(gauge_config, x, x + BAR_LENGTH, y, y + BAR_HEIGHT);
+					hud_config_set_mouse_coords(gauge_config_id, x, x + BAR_LENGTH, y, y + BAR_HEIGHT);
 				}
 
 				switch(i)
@@ -1031,7 +1031,7 @@ void HudGaugeShieldMini::showMiniShields(const object *objp, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Shield_mini_gauge.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + static_cast<int>(bmw * scale), y, y + static_cast<int>(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + static_cast<int>(bmw * scale), y, y + static_cast<int>(bmh * scale));
 	}
 
 	setGaugeColor(HUD_C_NONE, config);

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2812,7 +2812,7 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 	if (config) {
 		int bmw, bmh;
 		bm_get_info(Mbox_gauge[2].first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, bx + fl2i(bmw * scale), y, by + fl2i((bmh + bottom_bg_offset) * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, bx + fl2i(bmw * scale), y, by + fl2i((bmh + bottom_bg_offset) * scale));
 	}
 
 }

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -2776,7 +2776,7 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 		// Rotate the angle so that 0 is on top
 		angle -= 180.0f;
 
-		angle = hud_config_find_valid_angle(gauge_config, angle, x + fl2i(HUD_nose_x * scale), y + fl2i(HUD_nose_y * scale), Radius * scale);
+		angle = hud_config_find_valid_angle(gauge_config_id, angle, x + fl2i(HUD_nose_x * scale), y + fl2i(HUD_nose_y * scale), Radius * scale);
 
 		// Convert angle to radians
 		float angle_radians = angle * static_cast<float>(M_PI) / 180.0f;
@@ -2821,7 +2821,7 @@ void HudGaugeOrientationTee::renderOrientation(object *from_objp, object *to_obj
 		float y_min = std::min({y1, y2, y3, y4});
 		float y_max = std::max({y1, y2, y3, y4});
 
-		hud_config_set_mouse_coords(gauge_config, fl2i(x_min), fl2i(x_max), fl2i(y_min), fl2i(y_max));
+		hud_config_set_mouse_coords(gauge_config_id, fl2i(x_min), fl2i(x_max), fl2i(y_min), fl2i(y_max));
 	}
 
 	// HACK! Should be antialiased!
@@ -3025,7 +3025,7 @@ void HudGaugeReticleTriangle::renderTriangleMissileTail(float ang, float xpos, f
 		float min_y = std::min({ypos, y1, y2, ytail});
 		float max_y = std::max({ypos, y1, y2, ytail});
 
-		hud_config_set_mouse_coords(gauge_config, fl2i(min_x), fl2i(max_x), fl2i(min_y), fl2i(max_y));
+		hud_config_set_mouse_coords(gauge_config_id, fl2i(min_x), fl2i(max_x), fl2i(min_y), fl2i(max_y));
 	}
 	gr_reset_screen_scale();
 }
@@ -3175,7 +3175,7 @@ void HudGaugeReticleTriangle::renderTriangle(vec3d *hostile_pos, int aspect_flag
 			float min_y = std::min({ypos, y1, y2});
 			float max_y = std::max({ypos, y1, y2});
 
-			hud_config_set_mouse_coords(gauge_config, fl2i(min_x), fl2i(max_x), fl2i(min_y), fl2i(max_y));
+			hud_config_set_mouse_coords(gauge_config_id, fl2i(min_x), fl2i(max_x), fl2i(min_y), fl2i(max_y));
 		}
 	}
 }
@@ -3255,7 +3255,7 @@ void HudGaugeMissileTriangles::render(float /*frametime*/, bool config)
 		float scale;
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 
-		angle = hud_config_find_valid_angle(gauge_config, angle, x + fl2i(HUD_nose_x * scale), y + fl2i(HUD_nose_y * scale), Radius * scale);
+		angle = hud_config_find_valid_angle(gauge_config_id, angle, x + fl2i(HUD_nose_x * scale), y + fl2i(HUD_nose_y * scale), Radius * scale);
 
 		auto pair = hud_config_calc_coords_from_angle(angle,
 			x + fl2i(HUD_nose_x * scale),
@@ -3797,7 +3797,7 @@ void HudGaugeHostileTriangle::render(float /*frametime*/, bool config)
 		float scale;
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 
-		angle = hud_config_find_valid_angle(gauge_config, angle, x + fl2i(HUD_nose_x * scale), y + fl2i(HUD_nose_y * scale), Radius * scale);
+		angle = hud_config_find_valid_angle(gauge_config_id, angle, x + fl2i(HUD_nose_x * scale), y + fl2i(HUD_nose_y * scale), Radius * scale);
 
 		auto pair = hud_config_calc_coords_from_angle(angle,
 			x + fl2i(HUD_nose_x * scale),
@@ -4113,7 +4113,7 @@ void HudGaugeLeadIndicator::renderIndicator(int frame_offset, object *targetp, v
 					int max_attempts = 100; // Limit to avoid infinite loops
 					int attempts = 0;
 
-					while (BoundingBox::isOverlappingAny(HC_gauge_mouse_coords, newBox, gauge_config)) {
+					while (BoundingBox::isOverlappingAny(HC_gauge_mouse_coords, newBox, gauge_config_id)) {
 						if (++attempts > max_attempts) {
 							break; // Safety net
 						}
@@ -4141,7 +4141,7 @@ void HudGaugeLeadIndicator::renderIndicator(int frame_offset, object *targetp, v
 					int mx = fl2i(x - i2fl(Lead_indicator_half[0] * scale));
 					int my = fl2i(y - i2fl(Lead_indicator_half[1] * scale));
 
-					hud_config_set_mouse_coords(gauge_config, mx, mx + fl2i(bmw * scale), my, my + fl2i(bmh * scale));
+					hud_config_set_mouse_coords(gauge_config_id, mx, mx + fl2i(bmw * scale), my, my + fl2i(bmh * scale));
 				} else {
 					unsize(&x, &y);
 				}
@@ -4847,7 +4847,7 @@ void HudGaugeTargetTriangle::render(float /*frametime*/, bool config)
 		float scale;
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 
-		angle = hud_config_find_valid_angle(gauge_config, angle, x + fl2i(HUD_nose_x * scale), y + fl2i(HUD_nose_y * scale), Radius * scale);
+		angle = hud_config_find_valid_angle(gauge_config_id, angle, x + fl2i(HUD_nose_x * scale), y + fl2i(HUD_nose_y * scale), Radius * scale);
 
 		auto pair = hud_config_calc_coords_from_angle(angle,
 			x + fl2i(HUD_nose_x * scale),
@@ -5104,7 +5104,7 @@ void HudGaugeAutoTarget::render(float /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Toggle_frame.first_frame + frame_offset, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	// draw the box background
@@ -5202,7 +5202,7 @@ void HudGaugeAutoSpeed::render(float /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Toggle_frame.first_frame + frame_offset, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	setGaugeColor(HUD_C_NONE, config);
@@ -5818,7 +5818,7 @@ void HudGaugeCmeasures::render(float /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Cmeasure_gauge.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	// hud_set_default_color();
@@ -5885,7 +5885,7 @@ void HudGaugeAfterburner::render(float /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Energy_bar.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	clip_h = fl2i(std::lround((1.0f - percent_left) * Energy_h));
@@ -6001,7 +6001,7 @@ void HudGaugeWeaponEnergy::render(float /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Energy_bar.first_frame+2, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	if(use_new_gauge)
@@ -6750,7 +6750,7 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 	if (config) {
 		int bmw, bmh;
 		bm_get_info(secondary_bottom[ballistic_hud_index].first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i((bmw + frame_offset_x[ballistic_hud_index]) * scale), y, ty + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i((bmw + frame_offset_x[ballistic_hud_index]) * scale), y, ty + fl2i(bmh * scale));
 	}
 }
 
@@ -7200,7 +7200,7 @@ void HudGaugeOffscreen::renderOffscreenIndicator(vec2d *coords, int dir, float d
 	}
 
 	if (config) {
-		hud_config_set_mouse_coords(gauge_config, fl2i(xpos - w), fl2i(xpos + w), fl2i(ypos), fl2i(ypos + h * 2.0f));
+		hud_config_set_mouse_coords(gauge_config_id, fl2i(xpos - w), fl2i(xpos + w), fl2i(ypos), fl2i(ypos + h * 2.0f));
 	}
 
 	gr_reset_screen_scale();

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -402,7 +402,7 @@ void HudGaugeTargetBox::render(float frametime, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Monitor_frame.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 
 	setGaugeColor(HUD_C_NONE, config);
@@ -1569,7 +1569,7 @@ void HudGaugeExtraTargetData::render(float  /*frametime*/, bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(bracket.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(order_max_w * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(order_max_w * scale), y, y + fl2i(bmh * scale));
 	}
 
 	setGaugeColor(HUD_C_NONE, config);

--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -413,7 +413,7 @@ void HudGaugeWingmanStatus::renderBackground(int num_wings_to_draw, bool config)
 	if (config) {
 		int bmw, bmh;
 		bm_get_info(Wingman_status_right.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, actual_origin[0], sx + fl2i(bmw * scale), actual_origin[1], sy + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, actual_origin[0], sx + fl2i(bmw * scale), actual_origin[1], sy + fl2i(bmh * scale));
 	}
 }
 

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1876 // This is the next available ID
+// #define XSTR_SIZE	1877 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -219,7 +219,7 @@ bool HudGaugeDirectives::canRender() const
 		}
 	}
 
-	if (gauge_config == HUD_ETS_GAUGE) {
+	if (gauge_type == HUD_ETS_GAUGE) {
 		if (Ships[Player_obj->instance].flags[Ship::Ship_Flags::No_ets]) {
 			return false;
 		}
@@ -397,7 +397,7 @@ void HudGaugeDirectives::render(float  /*frametime*/, bool config)
 	if (config) {
 		int bmw, bmh;
 		bm_get_info(directives_bottom.first_frame, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, bx + fl2i(bmw * scale), y, by + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, bx + fl2i(bmw * scale), y, by + fl2i(bmh * scale));
 	}
 }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13560,7 +13560,8 @@ void sexp_hud_reset_color(int n)
 				WarningEx(LOCATION, "HUD gauge %s does not have a built-in configured color!", gaugename);
 			} else {
 				// use the color as specified in the HUD config
-				auto& c = HUD_config.clr[std::distance(std::begin(Legacy_HUD_gauges), ii)];
+				auto id = hg->getConfigId();
+				auto& c = HUD_config.gauge_colors[id];
 
 				hg->sexpLockConfigColor(false);
 				hg->updateColor(c.red, c.green, c.blue, (HUD_color_alpha + 1) * 16);

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1013,20 +1013,41 @@ void pilotfile::csg_write_redalert()
 
 void pilotfile::csg_read_hud()
 {
-	int idx;
+	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	
 	int strikes = 0;
 
 	// flags
-	HUD_config.show_flags = cfread_int(cfp);
-	HUD_config.show_flags2 = cfread_int(cfp);
+	int show_flags = cfread_int(cfp);
+	int show_flags2 = cfread_int(cfp);
 
-	HUD_config.popup_flags = cfread_int(cfp);
-	HUD_config.popup_flags2 = cfread_int(cfp);
+	int popup_flags = cfread_int(cfp);
+	int popup_flags2 = cfread_int(cfp);
+
+	// Convert show_flags (0-31) and show_flags2 (32-63)
+	for (int i = 0; i < 64; i++) {
+		bool is_set = (i < 32) ? (show_flags & (1 << i)) : (show_flags2 & (1 << (i - 32)));
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(i);
+
+		if (!gauge_id.empty()) {
+			HUD_config.set_gauge_visibility(gauge_id, is_set);
+		}
+	}
+
+	// Convert popup_flags (0-31) and popup_flags2 (32-63)
+	for (int i = 0; i < 64; i++) {
+		bool is_set = (i < 32) ? (popup_flags & (1 << i)) : (popup_flags2 & (1 << (i - 32)));
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(i);
+
+		if (!gauge_id.empty()) {
+			HUD_config.set_gauge_popup(gauge_id, is_set);
+		}
+	}
 
 	// settings
-	HUD_config.num_msg_window_lines = cfread_ubyte(cfp);
+	SCP_UNUSED(cfread_ubyte(cfp));// Deprecated but still read for file compatibility 3/7/2025
+	SCP_UNUSED(cfread_int(cfp));// Deprecated but still read for file compatibility 3/7/2025
 
-	HUD_config.rp_flags = cfread_int(cfp);
 	HUD_config.rp_dist = cfread_int(cfp);
 	if (HUD_config.rp_dist < 0 || HUD_config.rp_dist >= RR_MAX_RANGES) {
 		ReleaseWarning(LOCATION, "Campaign file has invalid radar range %d, setting to default.\n", HUD_config.rp_dist);
@@ -1058,7 +1079,7 @@ void pilotfile::csg_read_hud()
 	// gauge-specific colors
 	int num_gauges = cfread_int(cfp);
 
-	for (idx = 0; idx < num_gauges; idx++) {
+	for (int idx = 0; idx < num_gauges; idx++) {
 		ubyte red = cfread_ubyte(cfp);
 		ubyte green = cfread_ubyte(cfp);
 		ubyte blue = cfread_ubyte(cfp);
@@ -1068,30 +1089,61 @@ void pilotfile::csg_read_hud()
 			continue;
 		}
 
-		HUD_config.clr[idx].red = red;
-		HUD_config.clr[idx].green = green;
-		HUD_config.clr[idx].blue = blue;
-		HUD_config.clr[idx].alpha = alpha;
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(idx);
+		if (!gauge_id.empty()) {
+			color clr;
+			gr_init_alphacolor(&clr, red, green, blue, alpha);
+			HUD_config.set_gauge_color(gauge_id, clr);
+		}
 	}
 }
 
 void pilotfile::csg_write_hud()
 {
-	int idx;
-
 	startSection(Section::HUD);
 
-	// flags
-	cfwrite_int(HUD_config.show_flags, cfp);
-	cfwrite_int(HUD_config.show_flags2, cfp);
+	// Get gauge mappings instance
+	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
-	cfwrite_int(HUD_config.popup_flags, cfp);
-	cfwrite_int(HUD_config.popup_flags2, cfp);
+	// Initialize bitfields
+	int show_flags = 0, show_flags2 = 0;
+	int popup_flags = 0, popup_flags2 = 0;
+
+	// Convert show_flags_map to bitfield
+	for (int i = 0; i < 64; i++) {
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(i);
+		if (!gauge_id.empty() && HUD_config.is_gauge_visible(gauge_id)) {
+			if (i < 32) {
+				show_flags |= (1 << i);
+			} else {
+				show_flags2 |= (1 << (i - 32));
+			}
+		}
+	}
+
+	// Convert popup_flags_map to bitfield
+	for (int i = 0; i < 64; i++) {
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(i);
+		if (!gauge_id.empty() && HUD_config.is_gauge_popup(gauge_id)) {
+			if (i < 32) {
+				popup_flags |= (1 << i);
+			} else {
+				popup_flags2 |= (1 << (i - 32));
+			}
+		}
+	}
+
+	// flags
+	cfwrite_int(show_flags, cfp);
+	cfwrite_int(show_flags2, cfp);
+
+	cfwrite_int(popup_flags, cfp);
+	cfwrite_int(popup_flags2, cfp);
 
 	// settings
-	cfwrite_ubyte(HUD_config.num_msg_window_lines, cfp);
+	cfwrite_ubyte(0, cfp);// Deprecated but still written for file compatibility 3/7/2025
+	cfwrite_int(0, cfp);// Deprecated but still written for file compatibility 3/7/2025
 
-	cfwrite_int(HUD_config.rp_flags, cfp);
 	cfwrite_int(HUD_config.rp_dist, cfp);
 
 	// basic colors
@@ -1101,11 +1153,15 @@ void pilotfile::csg_write_hud()
 	// gauge-specific colors
 	cfwrite_int(NUM_HUD_GAUGES, cfp);
 
-	for (idx = 0; idx < NUM_HUD_GAUGES; idx++) {
-		cfwrite_ubyte(HUD_config.clr[idx].red, cfp);
-		cfwrite_ubyte(HUD_config.clr[idx].green, cfp);
-		cfwrite_ubyte(HUD_config.clr[idx].blue, cfp);
-		cfwrite_ubyte(HUD_config.clr[idx].alpha, cfp);
+	for (int idx = 0; idx < NUM_HUD_GAUGES; idx++) {
+		// Get the gauge string ID from numeric ID
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(idx);
+		color clr = HUD_config.get_gauge_color(gauge_id);
+
+		cfwrite_ubyte(clr.red, cfp);
+		cfwrite_ubyte(clr.green, cfp);
+		cfwrite_ubyte(clr.blue, cfp);
+		cfwrite_ubyte(clr.alpha, cfp);
 	}
 
 	endSection();

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1013,7 +1013,7 @@ void pilotfile::csg_write_redalert()
 
 void pilotfile::csg_read_hud()
 {
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 	
 	int strikes = 0;
 
@@ -1103,7 +1103,7 @@ void pilotfile::csg_write_hud()
 	startSection(Section::HUD);
 
 	// Get gauge mappings instance
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	// Initialize bitfields
 	int show_flags = 0, show_flags2 = 0;

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -182,7 +182,7 @@ void pilotfile::plr_write_info()
 
 void pilotfile::plr_read_hud()
 {
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	int strikes = 0;
 	// flags
@@ -272,7 +272,7 @@ void pilotfile::plr_write_hud()
 	handler->startSectionWrite(Section::HUD);
 
 	// Get gauge mappings instance
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	// Initialize bitfields
 	int show_flags = 0, show_flags2 = 0;

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -182,18 +182,40 @@ void pilotfile::plr_write_info()
 
 void pilotfile::plr_read_hud()
 {
+	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+
 	int strikes = 0;
 	// flags
-	HUD_config.show_flags = handler->readInt("show_flags");
-	HUD_config.show_flags2 = handler->readInt("show_flags2");
+	int show_flags = handler->readInt("show_flags");
+	int show_flags2 = handler->readInt("show_flags2");
 
-	HUD_config.popup_flags = handler->readInt("popup_flags");
-	HUD_config.popup_flags2 = handler->readInt("popup_flags2");
+	int popup_flags = handler->readInt("popup_flags");
+	int popup_flags2 = handler->readInt("popup_flags2");
+
+	// Convert show_flags (0-31) and show_flags2 (32-63)
+	for (int i = 0; i < 64; i++) {
+		bool is_set = (i < 32) ? (show_flags & (1 << i)) : (show_flags2 & (1 << (i - 32)));
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(i);
+
+		if (!gauge_id.empty()) {
+			HUD_config.set_gauge_visibility(gauge_id, is_set);
+		}
+	}
+
+	// Convert popup_flags (0-31) and popup_flags2 (32-63)
+	for (int i = 0; i < 64; i++) {
+		bool is_set = (i < 32) ? (popup_flags & (1 << i)) : (popup_flags2 & (1 << (i - 32)));
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(i);
+
+		if (!gauge_id.empty()) {
+			HUD_config.set_gauge_popup(gauge_id, is_set);
+		}
+	}
 
 	// settings
-	HUD_config.num_msg_window_lines = handler->readUByte("num_msg_window_lines");
+	SCP_UNUSED(handler->readUByte("num_msg_window_lines"));// Deprecated but still read for file compatibility 3/7/2025
+	SCP_UNUSED(handler->readInt("rp_flags"));// Deprecated but still read for file compatibility 3/7/2025
 
-	HUD_config.rp_flags = handler->readInt("rp_flags");
 	HUD_config.rp_dist = handler->readInt("rp_dist");
 	if (HUD_config.rp_dist < 0 || HUD_config.rp_dist >= RR_MAX_RANGES) {
 		ReleaseWarning(LOCATION, "Player file has invalid radar range %d, setting to default.\n", HUD_config.rp_dist);
@@ -224,7 +246,7 @@ void pilotfile::plr_read_hud()
 
 	// gauge-specific colors
 	auto num_gauges = handler->startArrayRead("hud_gauges");
-	for (size_t idx = 0; idx < num_gauges; idx++, handler->nextArraySection()) {
+	for (int idx = 0; idx < static_cast<int>(num_gauges); idx++, handler->nextArraySection()) {
 		ubyte red = handler->readUByte("red");
 		ubyte green = handler->readUByte("green");
 		ubyte blue = handler->readUByte("blue");
@@ -235,31 +257,62 @@ void pilotfile::plr_read_hud()
 			continue;
 		}
 
-		HUD_config.clr[idx].red = red;
-		HUD_config.clr[idx].green = green;
-		HUD_config.clr[idx].blue = blue;
-		HUD_config.clr[idx].alpha = alpha;
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(idx);
+		if (!gauge_id.empty()) {
+			color clr;
+			gr_init_alphacolor(&clr, red, green, blue, alpha);
+			HUD_config.set_gauge_color(gauge_id, clr);
+		}
 	}
 	handler->endArrayRead();
 }
 
 void pilotfile::plr_write_hud()
 {
-	int idx;
-
 	handler->startSectionWrite(Section::HUD);
 
-	// flags
-	handler->writeInt("show_flags", HUD_config.show_flags);
-	handler->writeInt("show_flags2", HUD_config.show_flags2);
+	// Get gauge mappings instance
+	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
-	handler->writeInt("popup_flags", HUD_config.popup_flags);
-	handler->writeInt("popup_flags2", HUD_config.popup_flags2);
+	// Initialize bitfields
+	int show_flags = 0, show_flags2 = 0;
+	int popup_flags = 0, popup_flags2 = 0;
+
+	// Convert show_flags_map to bitfield
+	for (int i = 0; i < 64; i++) {
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(i);
+		if (!gauge_id.empty() && HUD_config.is_gauge_visible(gauge_id)) {
+			if (i < 32) {
+				show_flags |= (1 << i);
+			} else {
+				show_flags2 |= (1 << (i - 32));
+			}
+		}
+	}
+
+	// Convert popup_flags_map to bitfield
+	for (int i = 0; i < 64; i++) {
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(i);
+		if (!gauge_id.empty() && HUD_config.is_gauge_popup(gauge_id)) {
+			if (i < 32) {
+				popup_flags |= (1 << i);
+			} else {
+				popup_flags2 |= (1 << (i - 32));
+			}
+		}
+	}
+
+	// Write converted bitfields
+	handler->writeInt("show_flags", show_flags);
+	handler->writeInt("show_flags2", show_flags2);
+
+	handler->writeInt("popup_flags", popup_flags);
+	handler->writeInt("popup_flags2", popup_flags2);
 
 	// settings
-	handler->writeUByte("num_msg_window_lines", HUD_config.num_msg_window_lines);
+	handler->writeUByte("num_msg_window_lines", 0);// Deprecated but still written for file compatibility 3/7/2025
+	handler->writeInt("rp_flags", 0);// Deprecated but still written for file compatibility 3/7/2025
 
-	handler->writeInt("rp_flags", HUD_config.rp_flags);
 	handler->writeInt("rp_dist", HUD_config.rp_dist);
 
 	// basic colors
@@ -268,13 +321,17 @@ void pilotfile::plr_write_hud()
 
 	// gauge-specific colors
 	handler->startArrayWrite("hud_gauges", NUM_HUD_GAUGES);
-	for (idx = 0; idx < NUM_HUD_GAUGES; idx++) {
+	for (int idx = 0; idx < NUM_HUD_GAUGES; idx++) {
 		handler->startSectionWrite(Section::Unnamed);
 
-		handler->writeUByte("red", HUD_config.clr[idx].red);
-		handler->writeUByte("green", HUD_config.clr[idx].green);
-		handler->writeUByte("blue", HUD_config.clr[idx].blue);
-		handler->writeUByte("alpha", HUD_config.clr[idx].alpha);
+		// Get the gauge string ID from numeric ID
+		SCP_string gauge_id = gauge_map.get_string_id_from_numeric_id(idx);
+		color clr = HUD_config.get_gauge_color(gauge_id);
+
+		handler->writeUByte("red", clr.red);
+		handler->writeUByte("green", clr.green);
+		handler->writeUByte("blue", clr.blue);
+		handler->writeUByte("alpha", clr.alpha);
 
 		handler->endSectionWrite();
 	}

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -106,7 +106,7 @@ void HudGaugeRadarStd::blitGauge(bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Radar_gauge.first_frame + 1, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + fl2i(bmw * scale), y, y + fl2i(bmh * scale));
 	}
 	
 	if (Radar_gauge.first_frame + 1 >= 0)

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -478,7 +478,7 @@ void HudGaugeRadarOrb::blitGauge(bool config)
 		std::tie(x, y, scale) = hud_config_convert_coord_sys(position[0], position[1], base_w, base_h);
 		int bmw, bmh;
 		bm_get_info(Radar_gauge.first_frame + 1, &bmw, &bmh);
-		hud_config_set_mouse_coords(gauge_config, x, x + static_cast<int>(bmw * scale), y, y + static_cast<int>(bmh * scale));
+		hud_config_set_mouse_coords(gauge_config_id, x, x + static_cast<int>(bmw * scale), y, y + static_cast<int>(bmh * scale));
 	}
 	
 	if (Radar_gauge.first_frame + 1 >= 0)

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -111,7 +111,7 @@ ADE_FUNC(getHUDConfigShowStatus, l_HUD, "number|string gaugeNameOrIndex", "Gets 
 	if ((idx < 0) || (idx >= (int)default_hud_gauges.size()))
 		return ADE_RETURN_NIL;
 
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	if (HUD_config.is_gauge_visible(gauge_map.get_string_id_from_numeric_id(idx)))
 		return ADE_RETURN_TRUE;
@@ -151,7 +151,7 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
 		return ADE_RETURN_FALSE;
 
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	gr_init_alphacolor(&HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(idx)], r, g, b, a);
 
@@ -173,7 +173,7 @@ ADE_FUNC(getHUDGaugeColor,
 	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
 		return ADE_RETURN_NIL;
 
-	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+	const HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
 
 	color cur = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(idx)];
 

--- a/code/scripting/api/libs/hud.cpp
+++ b/code/scripting/api/libs/hud.cpp
@@ -111,7 +111,9 @@ ADE_FUNC(getHUDConfigShowStatus, l_HUD, "number|string gaugeNameOrIndex", "Gets 
 	if ((idx < 0) || (idx >= (int)default_hud_gauges.size()))
 		return ADE_RETURN_NIL;
 
-	if (hud_config_show_flag_is_set(idx))
+	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+
+	if (HUD_config.is_gauge_visible(gauge_map.get_string_id_from_numeric_id(idx)))
 		return ADE_RETURN_TRUE;
 	else
 		return ADE_RETURN_FALSE;
@@ -149,7 +151,9 @@ ADE_FUNC(setHUDGaugeColor, l_HUD,
 	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
 		return ADE_RETURN_FALSE;
 
-	gr_init_alphacolor(&HUD_config.clr[idx], r, g, b, a);
+	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+
+	gr_init_alphacolor(&HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(idx)], r, g, b, a);
 
 	return ADE_RETURN_TRUE;
 }
@@ -169,7 +173,9 @@ ADE_FUNC(getHUDGaugeColor,
 	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
 		return ADE_RETURN_NIL;
 
-	color cur = HUD_config.clr[idx];
+	HC_gauge_mappings& gauge_map = HC_gauge_mappings::get_instance();
+
+	color cur = HUD_config.gauge_colors[gauge_map.get_string_id_from_numeric_id(idx)];
 
 	if (!rc) {
 		return ade_set_args(L, "iiii", (int)cur.red, (int)cur.green, (int)cur.blue, (int)cur.alpha);

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2402,7 +2402,7 @@ ADE_FUNC(initHudConfig,
 	"[number X, number Y, number Width, number height]",
 	"Initializes the HUD Configuration data. Must be used before HUD Configuration data accessed. "
 	"X and Y are the coordinates where the HUD preview will be drawn when drawHudConfig is used. "
-	"Width is the pixel width to draw the gauges preview. Height is hte pixel height to draw the gauges preview.",
+	"Width is the pixel width to draw the gauges preview. Height is the pixel height to draw the gauges preview.",
 	nullptr,
 	nullptr)
 {
@@ -2451,7 +2451,7 @@ ADE_FUNC(drawHudConfig,
 
 	hud_config_do_frame(0.0f, true, mx, my);
 
-	if (HC_gauge_hot >= 0) {
+	if (!HC_gauge_hot.empty()) {
 		return ade_set_args(L, "o", l_Gauge_Config.Set(gauge_config_h(HC_gauge_hot)));
 	} else {
 		return ade_set_error(L, "o", l_Gauge_Config.Set(gauge_config_h()));
@@ -2589,15 +2589,15 @@ ADE_INDEXER(l_HUD_Gauges,
 		return ade_set_error(L, "o", l_Gauge_Config.Set(gauge_config_h()));
 	idx--; // Convert from Lua's 1 based index system
 
-	if ((idx < 0) || (idx >= NUM_HUD_GAUGES))
+	if ((idx < 0) || (idx >= static_cast<int>(HC_gauge_map.size())))
 		return ade_set_error(L, "o", l_Gauge_Config.Set(gauge_config_h()));
 
-	return ade_set_args(L, "o", l_Gauge_Config.Set(gauge_config_h(idx)));
+	return ade_set_args(L, "o", l_Gauge_Config.Set(gauge_config_h(HC_gauge_map[idx].first)));
 }
 
 ADE_FUNC(__len, l_HUD_Gauges, nullptr, "The number of gauge configs", "number", "The number of gauge configs.")
 {
-	return ade_set_args(L, "i", NUM_HUD_GAUGES);
+	return ade_set_args(L, "i", static_cast<int>(HC_gauge_map.size()));
 }
 
 ADE_LIB_DERIV(l_HUD_Presets, "GaugePresets", nullptr, nullptr, l_UserInterface_HUDConfig);

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2399,19 +2399,20 @@ ADE_LIB_DERIV(l_UserInterface_HUDConfig,
 
 ADE_FUNC(initHudConfig,
 	l_UserInterface_HUDConfig,
-	"[number X, number Y, number Width]",
+	"[number X, number Y, number Width, number height]",
 	"Initializes the HUD Configuration data. Must be used before HUD Configuration data accessed. "
 	"X and Y are the coordinates where the HUD preview will be drawn when drawHudConfig is used. "
-	"Width is the pixel width to draw the gauges preview.",
+	"Width is the pixel width to draw the gauges preview. Height is hte pixel height to draw the gauges preview.",
 	nullptr,
 	nullptr)
 {
 	int x = 0;
 	int y = 0;
 	int w = 0;
-	ade_get_args(L, "|iii", &x, &y, &w);
+	int h = 0;
+	ade_get_args(L, "|iiii", &x, &y, &w, &h);
 
-	hud_config_init(true, x, y, w);
+	hud_config_init(true, x, y, w, h);
 
 	return ADE_RETURN_NIL;
 }
@@ -2457,6 +2458,22 @@ ADE_FUNC(drawHudConfig,
 	}
 }
 
+ADE_FUNC(getCurrentHudName,
+	l_UserInterface_HUDConfig,
+	nullptr,
+	"Returns the name of the current HUD configuration.",
+	"string",
+	"The name of the current HUD configuration.")
+{
+	SCP_UNUSED(L);
+
+	if (SCP_vector_inbounds(HC_available_huds, HC_chosen_hud)) {
+		return ade_set_args(L, "s", HC_available_huds[HC_chosen_hud].second.c_str());
+	} else {
+		return ade_set_args(L, "s", "Default Hud");
+	}
+}
+
 ADE_FUNC(selectAllGauges,
 	l_UserInterface_HUDConfig,
 	"boolean Toggle",
@@ -2468,6 +2485,33 @@ ADE_FUNC(selectAllGauges,
 	ade_get_args(L, "|b", &toggle);
 
 	hud_config_select_all_toggle(toggle, true);
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(selectNoGauges, l_UserInterface_HUDConfig, nullptr, "Sets no gauges as selected.", nullptr, nullptr)
+{
+	SCP_UNUSED(L);
+
+	hud_config_select_none();
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(selectNextHud, l_UserInterface_HUDConfig, nullptr, "Selects the next available HUD", nullptr, nullptr)
+{
+	SCP_UNUSED(L);
+
+	hud_config_select_hud(true);
+
+	return ADE_RETURN_NIL;
+}
+
+ADE_FUNC(selectPrevHud, l_UserInterface_HUDConfig, nullptr, "Selects the previous available HUD", nullptr, nullptr)
+{
+	SCP_UNUSED(L);
+
+	hud_config_select_hud(false);
 
 	return ADE_RETURN_NIL;
 }

--- a/code/scripting/api/objs/hudconfig.cpp
+++ b/code/scripting/api/objs/hudconfig.cpp
@@ -9,8 +9,7 @@
 namespace scripting {
 namespace api {
 
-gauge_config_h::gauge_config_h() : gauge() {}
-gauge_config_h::gauge_config_h(SCP_string l_gauge) : gauge(l_gauge) {}
+gauge_config_h::gauge_config_h(SCP_string l_gauge) : gauge(std::move(l_gauge)) {}
 
 HudGauge* gauge_config_h::getGauge() const
 {

--- a/code/scripting/api/objs/hudconfig.cpp
+++ b/code/scripting/api/objs/hudconfig.cpp
@@ -12,27 +12,18 @@ namespace api {
 gauge_config_h::gauge_config_h() : gauge(-1) {}
 gauge_config_h::gauge_config_h(int l_gauge) : gauge(l_gauge) {}
 
-HC_gauge_region* gauge_config_h::getGauge() const
+HudGauge* gauge_config_h::getGauge() const
 {
 	if (!isValid()) {
 		return nullptr;
 	}
 
-	return &HC_gauge_regions[GR_1024][gauge];
+	return hud_config_get_gauge_pointer(gauge);
 }
 
 int gauge_config_h::getIndex() const
 {
 	return gauge;
-}
-
-const char* gauge_config_h::getName() const
-{
-	if (!isValid()) {
-		return nullptr;
-	}
-
-	return HC_gauge_descriptions(gauge);
 }
 
 bool gauge_config_h::isValid() const
@@ -126,7 +117,7 @@ ADE_VIRTVAR(Name, l_Gauge_Config, nullptr, "The name of this gauge", "string", "
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current.getName());
+	return ade_set_args(L, "s", current.getGauge()->getConfigName().c_str());
 }
 
 ADE_VIRTVAR(CurrentColor,
@@ -147,17 +138,17 @@ ADE_VIRTVAR(CurrentColor,
 	}
 
 	if (ADE_SETTING_VAR) {
-		if (!current.getGauge()->use_iff) {
+		if (!current.getGauge()->getConfigUseIffColor()) {
 			HUD_config.clr[current.getIndex()] = newColor;
 		}
 	}
 
 	const color *thisColor;
 	
-	if (!current.getGauge()->use_iff) {
+	if (!current.getGauge()->getConfigUseIffColor()) {
 		thisColor = &HUD_config.clr[current.getIndex()];
 	} else {
-		if (current.getGauge()->color == 1) {
+		if (current.getGauge()->getConfigUseTagColor()) {
 			thisColor = iff_get_color(IFF_COLOR_TAGGED, 0);
 		} else {
 			thisColor = &Color_bright_red;
@@ -220,7 +211,7 @@ ADE_VIRTVAR(PopupGaugeFlag,
 		}
 	}
 
-	if (current.getGauge()->can_popup == 0) {
+	if (!current.getGauge()->getConfigCanPopup()) {
 		return ADE_RETURN_FALSE;
 	}
 
@@ -247,7 +238,7 @@ ADE_VIRTVAR(CanPopup,
 		LuaError(L, "This property is read only.");
 	}
 
-	if (current.getGauge()->can_popup == 0) {
+	if (!current.getGauge()->getConfigCanPopup()) {
 		return ADE_RETURN_FALSE;
 	}
 
@@ -274,7 +265,7 @@ ADE_VIRTVAR(UsesIffForColor,
 		LuaError(L, "This property is read only.");
 	}
 
-	if (current.getGauge()->use_iff == 0) {
+	if (!current.getGauge()->getConfigUseIffColor()) {
 		return ADE_RETURN_FALSE;
 	}
 

--- a/code/scripting/api/objs/hudconfig.h
+++ b/code/scripting/api/objs/hudconfig.h
@@ -8,11 +8,10 @@ namespace api {
 
 struct gauge_config_h {
 	SCP_string gauge;
-	gauge_config_h();
+	gauge_config_h() = default;
 	explicit gauge_config_h(SCP_string l_gauge);
 	HudGauge* getGauge() const;
 	SCP_string getId() const;
-	const char* getName() const;
 	bool isValid() const;
 };
 

--- a/code/scripting/api/objs/hudconfig.h
+++ b/code/scripting/api/objs/hudconfig.h
@@ -7,11 +7,11 @@ namespace scripting {
 namespace api {
 
 struct gauge_config_h {
-	int gauge;
+	SCP_string gauge;
 	gauge_config_h();
-	explicit gauge_config_h(int l_gauge);
+	explicit gauge_config_h(SCP_string l_gauge);
 	HudGauge* getGauge() const;
-	int getIndex() const;
+	SCP_string getId() const;
 	const char* getName() const;
 	bool isValid() const;
 };

--- a/code/scripting/api/objs/hudconfig.h
+++ b/code/scripting/api/objs/hudconfig.h
@@ -10,7 +10,7 @@ struct gauge_config_h {
 	int gauge;
 	gauge_config_h();
 	explicit gauge_config_h(int l_gauge);
-	HC_gauge_region* getGauge() const;
+	HudGauge* getGauge() const;
 	int getIndex() const;
 	const char* getName() const;
 	bool isValid() const;


### PR DESCRIPTION
This is the final step of the HUD Config Overhaul. This sets up the HUD Config menu to render the gauges using their native draw methods rather than the built-in placeholders. Much of the old hardcoded data has been removed. This comes with upgrades to the UI API as well.

This is a bare-bones overhaul for the moment. No new features other than utilizing the native rendering code with the exception of being able to preview multiple HUDs with the LEFT and RIGHT keys. A later follow-up PR is planned that will allow custom coloring individual custom gauges and possibly unique coloring per-HUD for each player.

Setting as draft because this PR relies on #6573, #6574, #6575, #6576, #6577, #6578, #6579 . No sense in reviewing this until those are merged.