### PR TITLE
update workflows to accommodate actions/cache deprecation

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -120,7 +120,7 @@ jobs:
           # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
           # aqtversion: ==0.8
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
@@ -240,7 +240,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -176,7 +176,7 @@ jobs:
           # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
           # aqtversion: ==0.8
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
@@ -316,7 +316,7 @@ jobs:
           fetch-depth: 0
           ref: '${{ github.ref }}'
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -133,7 +133,7 @@ jobs:
           # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
           # aqtversion: ==0.8
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
@@ -254,7 +254,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -107,7 +107,7 @@ jobs:
           # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
           # aqtversion: ==0.8
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader
@@ -202,7 +202,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}-${{ matrix.arch }}
           save: false # Caches are created by a separate job and only restored for PRs
       - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
           vulkan-query-version: 1.3.204.0
           vulkan-components: Vulkan-Headers, Vulkan-Loader


### PR DESCRIPTION
As reported by MjnMixael and tracked down by qazwsxal, actions/cache V2 is being removed at the end of the month: <https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down>

Quoting qazwsxal:
> It's being hit inside humbletim/setup-vulkan-sdk@v1.2.0 as that's the last line before the error was hit. I've investigated that repo and a version bump to 1.2.1 should fix it as humbletim has updated the actions/cache version.

So, this bumps all the relevant humbletim repository references to 1.2.1.