### PR TITLE
allow stringcost to be case-insensitive

### DIFF
--- a/code/globalincs/utility.h
+++ b/code/globalincs/utility.h
@@ -104,9 +104,23 @@ typename T::size_type GeneralizedLevenshteinDistance(const T &source,
 	return lev_dist[min_size];
 }
 
-// Lafiel
 template<typename T>
-typename T::size_type stringcost(const T& op, const T& input, typename T::size_type max_expected_length = NAME_LENGTH) {
+bool stringcost_equal(const T& a, const T& b)
+{
+	return a == b;
+}
+
+template<typename charT>
+bool stringcost_tolower_equal(const charT& a, const charT& b)
+{
+	return SCP_tolower(a) == SCP_tolower(b);
+}
+
+// Lafiel
+template<typename T, typename charT = typename T::value_type>
+typename T::size_type stringcost(const T& op, const T& input, typename T::size_type max_expected_length = NAME_LENGTH,
+	bool (*equal_check)(const charT&a, const charT&b) = stringcost_equal<charT>)
+{
 	using TSizeType = typename T::size_type;
 
     if(input.empty())
@@ -123,7 +137,7 @@ typename T::size_type stringcost(const T& op, const T& input, typename T::size_t
     for (TSizeType i = 0; i < op.length(); i++) {
 		std::vector<string_search_it> insert;
         for (auto& it : iterators) {
-            if (it.count < input.length() && op[i] == input[it.count]) {
+            if (it.count < input.length() && equal_check(op[i], input[it.count])) {
                 //We found something. There may be a better match for this later, so only make a copy.
                 insert.emplace_back(string_search_it{it.count + 1, i, i - it.lastpos <= 1 ? it.cost : max_expected_length + i - it.lastpos - 1});
             }
@@ -131,7 +145,7 @@ typename T::size_type stringcost(const T& op, const T& input, typename T::size_t
 
         iterators.insert(iterators.end(), insert.begin(), insert.end());
 
-        if (op[i] == input[0])
+        if (equal_check(op[i], input[0]))
             iterators.emplace_back(string_search_it{1, i, i});
     }
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -34621,7 +34621,7 @@ int sexp_match_closest_operator(const SCP_string &str, int opf)
 
 		if (sexp_query_type_match(opf, opr))
 		{
-			size_t cost = stringcost(op_text, str, Max_operator_length);
+			size_t cost = stringcost(op_text, str, Max_operator_length, stringcost_tolower_equal);
 			if (best < 0 || cost < min)
 			{
 				min = cost;

--- a/fred2/OperatorComboBox.cpp
+++ b/fred2/OperatorComboBox.cpp
@@ -154,7 +154,7 @@ void OperatorComboBox::filter_popup_operators(const SCP_string &filter_string)
 	for (int op_index : Sorted_operator_indexes)
 	{
 		const auto &op_text = Operators[op_index].text;
-		size_t cost = stringcost(op_text, filter_string, Max_operator_length);
+		size_t cost = stringcost(op_text, filter_string, Max_operator_length, stringcost_tolower_equal);
 		if (cost < threshold)
 			filtered_operators.emplace_back(op_index, cost);
 	}


### PR DESCRIPTION
Allow `stringcost()` to use a specified function to check equality, and provide both case-sensitive and case-insensitive sample functions.  Use case-insensitive checks for sexp operator lookup.