### PR TITLE
Allow mods to Always Show Directive Value Count

### DIFF
--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -990,7 +990,7 @@ void mission_process_event( int event )
 			mission_event_unset_directive_special(event);
 		}
 
-		if (Mission_events[event].count || (Directive_count > 1)){
+		if (Mission_events[event].count || (Always_show_directive_value_count || Directive_count > 1)) {
 			Mission_events[event].count = Directive_count;
 		}
 

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -990,7 +990,7 @@ void mission_process_event( int event )
 			mission_event_unset_directive_special(event);
 		}
 
-		if (Mission_events[event].count || (Always_show_directive_value_count || Directive_count > 1)) {
+		if (Mission_events[event].count || Always_show_directive_value_count || (Directive_count > 1)) {
 			Mission_events[event].count = Directive_count;
 		}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -34,6 +34,7 @@ bool Cutscene_camera_displays_hud;
 bool Alternate_chaining_behavior;
 bool Fixed_chaining_to_repeat;
 bool Use_host_orientation_for_set_camera_facing;
+bool Always_show_directive_value_count;
 bool Use_3d_ship_select;
 bool Use_3d_ship_icons;
 bool Use_3d_weapon_select;
@@ -539,6 +540,13 @@ void parse_mod_table(const char *filename)
 					}
 				} else {
 					Warning(LOCATION, "$HUD-set-coords base resolution: must specify two arguments");
+				}
+			}
+
+			if (optional_string("$Always Show Directive Value Count:")) {
+				stuff_boolean(&Always_show_directive_value_count);
+				if (Always_show_directive_value_count) {
+					mprintf(("Game Settings Table: Using Always Show Directive Value Count\n"));
 				}
 			}
 
@@ -1532,6 +1540,7 @@ void mod_table_reset()
 	Alternate_chaining_behavior = false;
 	Fixed_chaining_to_repeat = false;
 	Use_host_orientation_for_set_camera_facing = false;
+	Always_show_directive_value_count = false;
 	Default_ship_select_effect = 2;
 	Default_weapon_select_effect = 2;
 	Default_overhead_ship_style = OH_TOP_VIEW;

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -546,7 +546,7 @@ void parse_mod_table(const char *filename)
 			if (optional_string("$Always Show Directive Value Count:")) {
 				stuff_boolean(&Always_show_directive_value_count);
 				if (Always_show_directive_value_count) {
-					mprintf(("Game Settings Table: Using Always Show Directive Value Count\n"));
+					mprintf(("Game Settings Table: Always Showing Directive Value Count\n"));
 				}
 			}
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -42,6 +42,7 @@ extern bool Cutscene_camera_displays_hud;
 extern bool Alternate_chaining_behavior;
 extern bool Fixed_chaining_to_repeat;
 extern bool Use_host_orientation_for_set_camera_facing;
+extern bool Always_show_directive_value_count;
 extern bool Use_3d_ship_select;
 extern int Default_ship_select_effect;
 extern bool Use_3d_ship_icons;


### PR DESCRIPTION
Previously, directive counts were not shown if the value was <= 1. This PR adds a flag to always show the value, and tests work as expected. It also fullfills a longstanding statement from Mage

```
given that, aside from directive-value, all the code involving Directive_count seems to be volition:-original, it really is past time for a flag skipping this > 1 check
```