### PR TITLE
Create scripting hook: 'On Options Menu Tab Changed'

### DIFF
--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -35,6 +35,7 @@
 #include "pilotfile/pilotfile.h"
 #include "popup/popup.h"
 #include "popup/popupdead.h"
+#include "scripting/global_hooks.h"
 #include "sound/audiostr.h"
 #include "weapon/weapon.h"
 
@@ -660,6 +661,11 @@ void options_change_tab(int n)
 	Tab = n;
 	options_tab_setup(1);
 	gamesnd_play_iface(InterfaceSounds::SCREEN_MODE_PRESSED);
+
+	// adds scripting hook for 'On Options Tab Changed' --wookieejedi
+	if (scripting::hooks::OnOptionsTabChanged->isActive()) {
+		scripting::hooks::OnOptionsTabChanged->run(scripting::hook_param_list(scripting::hook_param("TabNumber", 'i', Tab)));
+	}
 }
 
 void options_cancel_exit()

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -28,7 +28,7 @@ const std::shared_ptr<OverridableHook<>> OnMovieAboutToPlay = OverridableHook<>:
 	});
 
 const std::shared_ptr<Hook<>> OnOptionsTabChanged = Hook<>::Factory("On Options Menu Tab Changed",
-	"Executed whenever a the tab is changed within the Options Menu.",
+	"Executed whenever a tab is changed within the Options Menu.",
 	{
 		{"TabNumber", "number", "The number of the tab that has been changed to, with 0 = Options Tab, 1 = Multi Tab, and 2 = Details Tab. "},
 	});

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -27,6 +27,12 @@ const std::shared_ptr<OverridableHook<>> OnMovieAboutToPlay = OverridableHook<>:
 		{"ViaTechRoom", "boolean", "Whether the movie player was invoked through the tech room."},
 	});
 
+const std::shared_ptr<Hook<>> OnOptionsTabChanged = Hook<>::Factory("On Options Menu Tab Changed",
+	"Executed whenever a the tab is changed within the Options Menu.",
+	{
+		{"TabNumber", "number", "The number of the tab that has been changed to, with 0 = Options Tab, 1 = Multi Tab, and 2 = Details Tab. "},
+	});
+
 const std::shared_ptr<OverridableHook<>> OnStateStart = OverridableHook<>::Factory("On State Start",
 	"Executed whenever a new state is entered.",
 	{

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -9,6 +9,7 @@ extern const std::shared_ptr<Hook<>>									OnGameInit;
 extern const std::shared_ptr<Hook<>>									OnSplashEnd;
 extern const std::shared_ptr<OverridableHook<>>							OnIntroAboutToPlay;
 extern const std::shared_ptr<OverridableHook<>>							OnMovieAboutToPlay;
+extern const std::shared_ptr<Hook<>>									OnOptionsTabChanged;
 //The On State Start hook previously used to pass OldState to the conditions, but no semantically sensible condition read the value, so we pretend it has no local condition
 extern const std::shared_ptr<OverridableHook<>>							OnStateStart;
 


### PR DESCRIPTION
It would be very useful to know which options tab is active (IE Options, Multi, Detail) but it's all under one single Game State `GS_STATE_OPTIONS_MENU`.

This PR creates a hook,  'On Options Menu Tab Changed'  that returns the value of the newly switched to options tab. Lafiel and I both discussed making this an ENUM, but the ENUM list is already quite bloated and this integer value seems like the cleanest solution.

Tested and works as expected.