### PR TITLE
Update in-game joystick settings to work without restarting FSO

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -1053,10 +1053,10 @@ namespace joystick
 		if (Using_in_game_options)
 		{
 			// The new options system is in use
-			setPlayerJoystick(JoystickOption->getValue(), 0);
-			setPlayerJoystick(JoystickOption1->getValue(), 1);
-			setPlayerJoystick(JoystickOption2->getValue(), 2);
-			setPlayerJoystick(JoystickOption3->getValue(), 3);
+			setPlayerJoystick(JoystickOption->getValue(), CID_JOY0);
+			setPlayerJoystick(JoystickOption1->getValue(), CID_JOY1);
+			setPlayerJoystick(JoystickOption2->getValue(), CID_JOY2);
+			setPlayerJoystick(JoystickOption3->getValue(), CID_JOY3);
 		}
 		else
 		{

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -186,7 +186,12 @@ Joystick* joystick_deserialize(const json_t* value)
 
 	json_error_t err;
 	if (json_unpack_ex((json_t*)value, &err, 0, "{s:s, s:i}", "guid", &guid, "id", &id) != 0) {
-		throw json_exception(err);
+		// throw json_exception(err);
+		// Changed by wookieejedi.
+		// If errors detected then return nullptr (ie, no joystick),
+		// because if we throw errors instead of returning nullptr
+		// then the listening functions short circuits and does not run.
+		return nullptr;
 	}
 
 	for (auto& test_stick : joysticks) {

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -211,6 +211,30 @@ json_t* joystick_serializer(Joystick* joystick)
 }
 
 /**
+ * Assigns the given cid to the given stick
+ *
+ * @param[in] stick  The stick that is being assigned
+ * @param[in] cid    The cid being assigned, must be a valid short between CID_JOY0 and CID_JOY_MAX
+ */
+void setPlayerJoystick(Joystick* stick, short cid)
+{
+	Assert((cid >= CID_JOY0) && (cid < CID_JOY_MAX));
+	pJoystick[cid] = stick;
+
+	if (pJoystick[cid] != nullptr) {
+		mprintf(("  Using '%s' as Joy-%i\n", pJoystick[cid]->getName().c_str(), cid));
+		mprintf(("\n"));
+		mprintf(("  Number of axes: %d\n", pJoystick[cid]->numAxes()));
+		mprintf(("  Number of buttons: %d\n", pJoystick[cid]->numButtons()));
+		mprintf(("  Number of hats: %d\n", pJoystick[cid]->numHats()));
+		mprintf(("  Number of trackballs: %d\n", pJoystick[cid]->numBalls()));
+		mprintf(("\n"));
+	} else {
+		mprintf((" Joystick %i removed\n", cid));
+	}
+}
+
+/**
  * Scripting callback for displaying the given joystick's name
  */
 SCP_string joystick_display(Joystick* stick)
@@ -250,6 +274,10 @@ auto JoystickOption = options::OptionBuilder<Joystick*>("Input.Joystick",
                      .default_val(nullptr)                 // initial/default value for this option
                      .flags({options::OptionFlags::ForceMultiValueSelection})
                      .importance(3)
+                     .change_listener([](Joystick* joy, bool) {
+                         setPlayerJoystick(joy, CID_JOY0);
+                         return true;
+                     })
                      .finish();
 
 auto JoystickOption1 = options::OptionBuilder<Joystick*>("Input.Joystick1",
@@ -264,6 +292,10 @@ auto JoystickOption1 = options::OptionBuilder<Joystick*>("Input.Joystick1",
                      .default_val(nullptr)
                      .flags({ options::OptionFlags::ForceMultiValueSelection })
                      .importance(3)
+                     .change_listener([](Joystick* joy, bool) {
+                         setPlayerJoystick(joy, CID_JOY1);
+                         return true;
+                     })
                      .finish();
 
 auto JoystickOption2 = options::OptionBuilder<Joystick*>("Input.Joystick2",
@@ -278,6 +310,10 @@ auto JoystickOption2 = options::OptionBuilder<Joystick*>("Input.Joystick2",
                      .default_val(nullptr)
                      .flags({ options::OptionFlags::ForceMultiValueSelection })
                      .importance(3)
+                     .change_listener([](Joystick* joy, bool) {
+                         setPlayerJoystick(joy, CID_JOY2);
+                         return true;
+                     })
                      .finish();
 
 auto JoystickOption3 = options::OptionBuilder<Joystick*>("Input.Joystick3",
@@ -292,6 +328,10 @@ auto JoystickOption3 = options::OptionBuilder<Joystick*>("Input.Joystick3",
                      .default_val(nullptr)
                      .flags({ options::OptionFlags::ForceMultiValueSelection })
                      .importance(3)
+                     .change_listener([](Joystick* joy, bool) {
+                         setPlayerJoystick(joy, CID_JOY3);
+                         return true;
+                     })
                      .finish();
 
 HatPosition convertSDLHat(int val)
@@ -344,33 +384,6 @@ void enumerateJoysticks(SCP_vector<JoystickPtr>& outVec)
 				mprintf(("    %s\n", SDL_GetError()));
 				SDL_ClearError();
 			}
-	}
-}
-
-/**
- * Assigns the given cid to the given stick
- *
- * @param[in] stick  The stick that is being assigned
- * @param[in] cid    The cid being assigned, must be a valid short between CID_JOY0 and CID_JOY_MAX
- */
-void setPlayerJoystick(Joystick *stick, short cid)
-{
-	Assert((cid >= CID_JOY0) && (cid < CID_JOY_MAX));
-	pJoystick[cid] = stick;
-
-	if (pJoystick[cid] != nullptr)
-	{
-		mprintf(("  Using '%s' as Joy-%i\n", pJoystick[cid]->getName().c_str(), cid));
-		mprintf(("\n"));
-		mprintf(("  Number of axes: %d\n", pJoystick[cid]->numAxes()));
-		mprintf(("  Number of buttons: %d\n", pJoystick[cid]->numButtons()));
-		mprintf(("  Number of hats: %d\n", pJoystick[cid]->numHats()));
-		mprintf(("  Number of trackballs: %d\n", pJoystick[cid]->numBalls()));
-		mprintf(("\n"));
-	}
-	else
-	{
-		mprintf((" Joystick %i removed\n", cid));
 	}
 }
 


### PR DESCRIPTION
Are you tired of having to restart FSO each time you change your joystick/controllers in-game? Well be tired no more, because now joysticks/controllers can be set and changed without having to restart FSO! 

Massive thanks to @MjnMixael for all his help collaborating on this quality-of-life enhancement (and to @BMagnu for addressing our questions).  Overall, the ability to set joysticks within FSO not only helps folks tuning controls but also creates a much more streamlined and modern process for new players. Previously, new players would start the game, have to set joysticks, and then restart the game before they could play and use their controls. Now, players can launch the game, setup their controls with as much iteration as they want and directly play the game right away. 

Tested and works as expected. 