### PR TITLE
add linked loop firing sounds

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -513,6 +513,7 @@ struct weapon_info
 	gamesnd_id	ambient_snd;
 	gamesnd_id  start_firing_snd;
 	gamesnd_id  loop_firing_snd;
+	gamesnd_id  linked_loop_firing_snd;
 	gamesnd_id  end_firing_snd;
 	
 	gamesnd_id hud_tracking_snd; // Sound played when the player is tracking a target with this weapon

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -1939,6 +1939,8 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 	parse_game_sound("$LoopFiringSnd:", &wip->loop_firing_snd);
 
+	parse_game_sound("$LinkedLoopFiringSnd:", &wip->linked_loop_firing_snd);
+
 	parse_game_sound("$EndFiringSnd:", &wip->end_firing_snd);
 
 	parse_game_sound("$TrackingSnd:", &wip->hud_tracking_snd);


### PR DESCRIPTION
Follow-up to #5803. Adds another firing loop sound specifically for when primaries are linked. Requires a few extra cases in `ship_primary_changed` to handle linkage status changing while firing.