### PR TITLE
Make Cockpit Deferred an In-game Option

### DIFF
--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -133,7 +133,7 @@ static void parse_deferredcockpit_lighting_func()
 
 static auto DeferredCockpitLightingOption = options::OptionBuilder<bool>("Graphics.DeferredCockpitLighting",
                   std::pair<const char*, int>{"Deferred Cockpit Lighting", 1864},
-                  std::pair<const char*, int>{"Enables or disables deferred lighting in cockpits", 1865})
+                  std::pair<const char*, int>{"Enables or disables deferred lighting in cockpits (requires Deferred Lighting to be enabled)", 1865})
                   .category(std::make_pair("Graphics", 1825))
                   .default_func([]() { return DeferredCockpitLightingEnabled;})
                   .level(options::ExpertLevel::Advanced)
@@ -142,16 +142,15 @@ static auto DeferredCockpitLightingOption = options::OptionBuilder<bool>("Graphi
                   .parser(parse_deferredcockpit_lighting_func)
                   .finish();
 
-
-// These deferred enabled functions used to get the value of the option object itself,
-// however that is not a free operation and changing it requires a restart anyway.
-// If the restart requirement is lifted, then care should be taken to cache this value
-// and never look it up more than once a frame;
-// otherwise the performance footprint is measurable enough to worry about.
 bool light_deferred_enabled()
 {
 	if (Using_in_game_options) {
 		static bool isToggledOn = DeferredLightingOption->getValue();
+		// This used to get the value of the option object itself,
+		// however that is not a free operation and changing it requires a restart anyway
+		// if the restart requirement is lifted care should be taken to cache this value
+		// and never look it up more than once a frame
+		// otherwise the performance footprint is measurable enough to worry about.
 		return isToggledOn;
 	} else {
 		return !Cmdline_no_deferred_lighting;
@@ -162,6 +161,8 @@ bool light_deferredcockpit_enabled()
 {
 	if (Using_in_game_options) {
 		static bool isToggledOn = DeferredCockpitLightingOption->getValue();
+		// Note, the above comment within light_deferred_enabled()
+		// about caching the value also applies here.
 		return isToggledOn;
 	} else {
 		return Cmdline_deferred_lighting_cockpit;

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -122,19 +122,49 @@ static auto DeferredLightingOption = options::OptionBuilder<bool>("Graphics.Defe
                   .parser(parse_deferred_lighting_func)
                   .finish();
 
+static bool DeferredCockpitLightingEnabled = true;
 
+static void parse_deferredcockpit_lighting_func()
+{
+	bool enabled;
+	stuff_boolean(&enabled);
+	DeferredCockpitLightingEnabled = enabled;
+}
+
+static auto DeferredCockpitLightingOption = options::OptionBuilder<bool>("Graphics.DeferredCockpitLighting",
+                  std::pair<const char*, int>{"Deferred Cockpit Lighting", 1864},
+                  std::pair<const char*, int>{"Enables or disables deferred lighting in cockpits", 1865})
+                  .category(std::make_pair("Graphics", 1825))
+                  .default_func([]() { return DeferredCockpitLightingEnabled;})
+                  .level(options::ExpertLevel::Advanced)
+                  .bind_to_once(&DeferredCockpitLightingEnabled)
+                  .importance(60)
+                  .parser(parse_deferredcockpit_lighting_func)
+                  .finish();
+
+
+// These deferred enabled functions used to get the value of the option object itself,
+// however that is not a free operation and changing it requires a restart anyway.
+// If the restart requirement is lifted, then care should be taken to cache this value
+// and never look it up more than once a frame;
+// otherwise the performance footprint is measurable enough to worry about.
 bool light_deferred_enabled()
 {
 	if (Using_in_game_options) {
 		static bool isToggledOn = DeferredLightingOption->getValue();
-		// This used to be getting the value of the option object itself,
-		// however that is not a free operation and changing it requires a restart anyway
-		// if the restart requirement is lifted care should be taken to cache this value
-		// and never look it up more than once a frame
-		// otherwise the performance footprint is measurable enough to worry about.
 		return isToggledOn;
 	} else {
 		return !Cmdline_no_deferred_lighting;
+	}
+}
+
+bool light_deferredcockpit_enabled()
+{
+	if (Using_in_game_options) {
+		static bool isToggledOn = DeferredCockpitLightingOption->getValue();
+		return isToggledOn;
+	} else {
+		return Cmdline_deferred_lighting_cockpit;
 	}
 }
 

--- a/code/lighting/lighting.h
+++ b/code/lighting/lighting.h
@@ -126,4 +126,6 @@ extern int light_find_for_sun(int sun_index);
 bool light_compare_by_type(const light &a, const light &b);
 
 bool light_deferred_enabled();
+
+bool light_deferredcockpit_enabled();
 #endif

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1864 // This is the next available ID
+// #define XSTR_SIZE	1866 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8275,7 +8275,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 
 	Shadow_view_matrix_render = gr_view_matrix;
 
-	if (Cmdline_deferred_lighting_cockpit) {
+	if (light_deferredcockpit_enabled()) {
 		gr_deferred_lighting_begin(true);
 
 		//When MSAA is enabled, we've just switched to the MS buffer. These still have the Z-Buffer we saved earlier, so clear that too
@@ -8316,7 +8316,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, MODEL_RENDER_OPAQUE);
 	}
 
-	if (Cmdline_deferred_lighting_cockpit) {
+	if (light_deferredcockpit_enabled()) {
 
 		gr_end_view_matrix();
 		gr_end_proj_matrix();
@@ -8348,7 +8348,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 		model_render_immediate(&cockpit_render_info, sip->cockpit_model_num, shipp->cockpit_model_instance, &objp->orient, &cockpit_offset, MODEL_RENDER_TRANS);
 	}
 
-	if (Cmdline_deferred_lighting_cockpit) {
+	if (light_deferredcockpit_enabled()) {
 		gr_set_lighting();
 	}
 


### PR DESCRIPTION
After testing and consideration, this PR adds the Cockpit Deferred setting to the in-game options. Also adds a parser to the new default_settings.tbl.