### PR TITLE
Option to unify setting options with easy flag

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1175,7 +1175,11 @@ void hud_config_handle_keypresses(int k)
 {
 	switch(k) {
 	case KEY_ESC:
-		hud_config_cancel();
+		if (Escape_saves_options) {
+			hud_config_commit();
+		} else {
+			hud_config_cancel();
+		}
 		break;
 	case KEY_CTRLED+KEY_ENTER:
 		hud_config_commit();

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -1239,7 +1239,11 @@ void options_menu_do_frame(float  /*frametime*/)
 			break;
 
 		case KEY_ESC:
-			options_cancel_exit();
+			if (Escape_saves_options) {
+				options_accept();
+			} else {
+				options_cancel_exit();
+			}
 			break;
 
 		case KEY_CTRLED | KEY_ENTER:

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -159,6 +159,7 @@ bool Dont_show_callsigns_in_escort_list;
 bool Fix_scripted_velocity;
 color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 bool Preload_briefing_icon_models;
+bool Escape_saves_options;
 
 #ifdef WITH_DISCORD
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Game.Discord",
@@ -1449,6 +1450,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Preload_briefing_icon_models);
 			}
 
+			if (optional_string("$Escape Key saves options:")) {
+				stuff_boolean(&Escape_saves_options);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1672,6 +1677,7 @@ void mod_table_reset()
 	gr_init_alphacolor(&Overhead_line_colors[2], 175, 175, 175, 255);
 	gr_init_alphacolor(&Overhead_line_colors[3], 100, 100, 100, 255);
 	Preload_briefing_icon_models = false;
+	Escape_saves_options = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -168,6 +168,7 @@ extern bool Dont_show_callsigns_in_escort_list;
 extern bool Fix_scripted_velocity;
 extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 extern bool Preload_briefing_icon_models;
+extern bool Escape_saves_options;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
Most modern UIs, including KNet 1.3, have options that are always set and do not require the user to click save, or on the few cases where options will not be saved automatically, the program shows a popup telling the user the changes are not saved. In addition, the user experience of setting many options then forgetting to press save is far more common and annoying then the opposite. As a last example, even the F3 in-game options menu presents Escape as the leave and save button, not the leave and discard button.

Currently, there are two screens where FSO allows users to press escape after setting options and leave without warning. The main options screen and the HUD screen. As it turns out, half of the options in the main options screen get saved even if the player presses escape (all the detail slider options along with the joystick and mouse sensitivity and dead zone settings), so current behavior is inconsistent to users.

This PR, aimed to be strategic and efficient, creates a game settings table option that allows mods to set so that the escape key for the HUD and Options screen does the same thing as pressing Ctrl-Enter/Accept. This optional setting unifies behavior, so that setting an option sets it whenever the user leaves that screen (whether it is pressing Escape, Ctrl-Enter, or the Accept button). The other screen that involves options and an escape is the control config menu, but that already methods in place to deal with escape in a consistent way.

Tested and everything works as expected.