### PR TITLE
use vm_vector_2_matrix_norm on normalized vectors

### DIFF
--- a/code/actions/types/ParticleEffectAction.cpp
+++ b/code/actions/types/ParticleEffectAction.cpp
@@ -59,7 +59,7 @@ ActionResult ParticleEffectAction::execute(ProgramLocals& locals) const
 
 	auto direction = locals.variables.getValue({"locals", "direction"}).getVector();
 	matrix orientation;
-	vm_vector_2_matrix(&orientation, &direction);
+	vm_vector_2_matrix_norm(&orientation, &direction);
 
 	source->setHost(make_unique<EffectHostObject>(locals.host.objp(), local_pos, orientation, true));
 	source->finishCreation();

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1616,11 +1616,11 @@ void ai_big_strafe_glide_attack()
 	//If we haven't chosen the goal point yet, do so now
 	if (aip->submode_parm1 == 0) {
 		//Pick goal point. This should be a random point that passes through the circle whose normal is the vector between attacker and target
-		vec3d targetToAttacker;
-		vec3d tangentPoint;
-		vm_vec_sub(&targetToAttacker, &Pl_objp->pos, &target_objp->pos);
+		vec3d targetToAttackerDir;
+		vm_vec_normalized_dir(&targetToAttackerDir, &Pl_objp->pos, &target_objp->pos);
 		matrix orient;
-		vm_vector_2_matrix(&orient, &targetToAttacker, NULL, NULL);
+		vm_vector_2_matrix_norm(&orient, &targetToAttackerDir, nullptr, nullptr);
+		vec3d tangentPoint;
 		vm_vec_random_in_circle(&tangentPoint, &target_objp->pos, &orient, target_objp->radius + GLIDE_STRAFE_DISTANCE, true);
 		//Get tangent point in coords relative to ship, scale it up so the actual goal point is far away, then put back in world coords
 		vm_vec_sub2(&tangentPoint, &Pl_objp->pos);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -1482,7 +1482,7 @@ void ai_turn_towards_vector(const vec3d* dest, object* objp, const vec3d* slide_
 	if (rvec != NULL) {
 		matrix	goal_orient;
 
-		vm_vector_2_matrix(&goal_orient, &desired_fvec, NULL, rvec);
+		vm_vector_2_matrix_norm(&goal_orient, &desired_fvec, nullptr, rvec);
 		vm_angular_move_matrix(&goal_orient, &curr_orient, &vel_in, delta_time,
 			&out_orient, &vel_out, &vel_limit, &acc_limit, The_mission.ai_profile->flags[AI::Profile_Flags::No_turning_directional_bias]);
 	} else {
@@ -4652,7 +4652,7 @@ void ai_fly_to_target_position(const vec3d* target_pos, bool* pl_done_p=NULL, bo
 	// this needs to be done for ALL SHIPS not just capships STOP CHANGING THIS
 	// ----------------------------------------------
 
-	vec3d perp, goal_point;
+	vec3d goal_point;
 
 	bool carry_flag = ((shipp->flags[Ship::Ship_Flags::Navpoint_carry]) || ((shipp->wingnum >= 0) && (Wings[shipp->wingnum].flags[Ship::Wing_Flags::Nav_carry])));
 
@@ -4675,6 +4675,7 @@ void ai_fly_to_target_position(const vec3d* target_pos, bool* pl_done_p=NULL, bo
 		&& carry_flag
 		&& ((The_mission.flags[Mission::Mission_Flags::Use_ap_cinematics]) || (Pl_objp != Autopilot_flight_leader)) )
 	{
+		vec3d perp;
 		Assertion( Autopilot_flight_leader != NULL, "When under autopilot there must be a flight leader" );
 		// snap wings into formation
 		if (The_mission.flags[Mission::Mission_Flags::Use_ap_cinematics]) {
@@ -4709,8 +4710,8 @@ void ai_fly_to_target_position(const vec3d* target_pos, bool* pl_done_p=NULL, bo
 				Pl_objp->pos = goal_point;
 			}
 
-			vm_vec_sub(&perp, Navs[CurrentNav].GetPosition(), &Autopilot_flight_leader->pos);
-			vm_vector_2_matrix(&Pl_objp->orient, &perp, NULL, NULL);
+			vm_vec_normalized_dir(&perp, Navs[CurrentNav].GetPosition(), &Autopilot_flight_leader->pos);
+			vm_vector_2_matrix_norm(&Pl_objp->orient, &perp, nullptr, nullptr);
 		} else {
 			vm_vec_scale_add(&perp, &Pl_objp->pos, &Autopilot_flight_leader->phys_info.vel, 1000.0f);
 			ai_turn_towards_vector(&perp, Pl_objp, slop_vec, nullptr, 0.0f, 0, nullptr, &turnrate_mod);
@@ -6265,7 +6266,7 @@ int ai_fire_primary_weapon(object *objp)
 			vm_vec_normalized_dir(&v2t, &G_predicted_pos, &G_fire_pos);
 			dot = vm_vec_dot(&v2t, &objp->orient.vec.fvec);
 			if (dot > .998629534f){	//	if within 3.0 degrees of desired heading, bash
-				vm_vector_2_matrix(&objp->orient, &v2t, &objp->orient.vec.uvec, NULL);
+				vm_vector_2_matrix_norm(&objp->orient, &v2t, &objp->orient.vec.uvec, nullptr);
 			}
 		}
 	}
@@ -7596,7 +7597,7 @@ void mabs_pick_goal_point(object *objp, object *big_objp, vec3d *collision_point
 	vec3d	v2b;
 
 	vm_vec_normalized_dir(&v2b, collision_point, &objp->pos);
-	vm_vector_2_matrix(&mat1, &v2b, NULL, NULL);
+	vm_vector_2_matrix_norm(&mat1, &v2b, nullptr, nullptr);
 
 	int	found = 0;
 
@@ -7710,6 +7711,8 @@ void compute_desired_rvec(vec3d *rvec, const vec3d *goal_pos, const vec3d *cur_p
 	rvec->xyz.z = -v2e.xyz.x;
 	if (vm_vec_mag_squared(rvec) < 0.001f)
 		rvec->xyz.y = 1.0f;
+
+	vm_vec_normalize_safe(rvec);	// since messing with the bank will make it un-normalized
 }
 
 /**
@@ -9726,7 +9729,7 @@ void set_goal_dock_orient(matrix *dom, matrix *docker_dock_orient, matrix *docke
 	vm_vec_rotate(&uvec, &dockee_dock_orient->vec.uvec, dockee_orient);
 
 	// create a rotation matrix
-	vm_vector_2_matrix(&m1, &fvec, &uvec, NULL);
+	vm_vector_2_matrix_norm(&m1, &fvec, &uvec, nullptr);
 
 	// get the global orientation
 	vm_matrix_x_matrix(&m3, dockee_orient, &m1);
@@ -9740,7 +9743,7 @@ void set_goal_dock_orient(matrix *dom, matrix *docker_dock_orient, matrix *docke
 	vm_vec_rotate(&uvec, &docker_dock_orient->vec.uvec, docker_orient);
 
 	// create a rotation matrix
-	vm_vector_2_matrix(&m2, &fvec, &uvec, NULL);
+	vm_vector_2_matrix_norm(&m2, &fvec, &uvec, nullptr);
 
 	//	Pre-multiply the orientation of the source object (docker_orient) by the transpose
 	//	of the docking bay's orientation, ie unrotate the source object's matrix.
@@ -9823,7 +9826,7 @@ void find_adjusted_dockpoint_info(vec3d *global_dock_point, matrix *global_dock_
 		// find the normal of the first dockpoint
 		model_instance_local_to_global_dir(&fvec, &pm->docking_bays[dock_index].norm[0], pm, pmi, submodel, &objp->orient);
 
-		vm_vector_2_matrix(global_dock_orient, &fvec, &uvec);
+		vm_vector_2_matrix_norm(global_dock_orient, &fvec, &uvec);
 	}
 	// use the static dockpoints
 	else
@@ -9838,7 +9841,7 @@ void find_adjusted_dockpoint_info(vec3d *global_dock_point, matrix *global_dock_
 		vm_vec_unrotate(&fvec, &local_fvec, &objp->orient);
 
 		vm_vec_add2(global_dock_point, &objp->pos);
-		vm_vector_2_matrix(global_dock_orient, &fvec, &uvec);
+		vm_vector_2_matrix_norm(global_dock_orient, &fvec, &uvec);
 	}
 }
 
@@ -13746,7 +13749,7 @@ int ai_acquire_emerge_path(object *pl_objp, int parent_objnum, int allowed_path_
 		rvec = parent_objp->orient.vec.rvec;
 	}
 
-	vm_vector_2_matrix(&pl_objp->orient, &fvec, IS_VEC_NULL(&uvec) ? nullptr : &uvec, IS_VEC_NULL(&rvec) ? nullptr : &rvec);
+	vm_vector_2_matrix_norm(&pl_objp->orient, &fvec, IS_VEC_NULL(&uvec) ? nullptr : &uvec, IS_VEC_NULL(&rvec) ? nullptr : &rvec);
 
 	return 0;	
 }

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1758,7 +1758,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 			firing_vec = &firing_vec_buf;
 		}
 
-		vm_vector_2_matrix(&firing_orient, firing_vec, nullptr, nullptr);
+		vm_vector_2_matrix_norm(&firing_orient, firing_vec, nullptr, nullptr);
 
 		// grab and set some burst data before turret_set_next_fire_timestamp wipes it
 		int old_burst_seed = swp->burst_seed[weapon_num];
@@ -2078,7 +2078,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 	}
 
 	// make firing_orient from turret_fvec -- turret->turret_last_fire_direction
-	vm_vector_2_matrix(&firing_orient, &turret_fvec, NULL, NULL);
+	vm_vector_2_matrix_norm(&firing_orient, &turret_fvec, nullptr, nullptr);
 
 	// create weapon and homing info
 	weapon_objnum = weapon_create(&turret_pos, &firing_orient, tsi->weapon_class, tsi->parent_objnum, -1, 1, 0, 0.0f, tsi->turret);
@@ -2618,8 +2618,7 @@ void ai_turret_execute_behavior(const ship *shipp, ship_subsys *ss)
 
 			// Fire in the direction the turret is facing, not right at the target regardless of turret dir.
 			// [Yet this retail comment precedes the calculation of vector-to-enemy...]
-			vm_vec_sub(&v2e, &predicted_enemy_pos, &global_gun_pos);
-			dist_to_enemy = vm_vec_normalize(&v2e);
+			dist_to_enemy = vm_vec_normalized_dir(&v2e, &predicted_enemy_pos, &global_gun_pos);
 			float dot = vm_vec_dot(&v2e, &global_gun_vec);
 
 			// (flak jitter moved to after we obtain shoot_vector below)

--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -300,15 +300,16 @@ bool StartAutopilot()
 	autopilot_wings.clear();
 
 	// vars for usage w/ cinematic
-	vec3d pos, norm1, perp, tpos, rpos = Player_obj->pos, zero;
+	vec3d pos, perp, tpos, rpos = Player_obj->pos, zero;
 	memset(&zero, 0, sizeof(vec3d));
 
 
 	// instantly turn player toward tpos
 	if (The_mission.flags[Mission::Mission_Flags::Use_ap_cinematics])
 	{
-		vm_vec_sub(&norm1, Navs[CurrentNav].GetPosition(), &Player_obj->pos);
-		vm_vector_2_matrix(&Player_obj->orient, &norm1, NULL, NULL);
+		vec3d norm1;
+		vm_vec_normalized_dir(&norm1, Navs[CurrentNav].GetPosition(), &Player_obj->pos);
+		vm_vector_2_matrix_norm(&Player_obj->orient, &norm1, nullptr, nullptr);
 	}
 
 	for (i = 0; i < MAX_SHIPS; i++)
@@ -395,10 +396,12 @@ bool StartAutopilot()
 				radius = Objects[Ships[i].objnum].radius;
 			}
 
+			// instantly turn the ship to match the direction player is looking
 			if (The_mission.flags[Mission::Mission_Flags::Use_ap_cinematics])
-			{// instantly turn the ship to match the direction player is looking
-				//vm_vec_sub(&norm1, Navs[CurrentNav].GetPosition(), &Player_obj->pos);
-				vm_vector_2_matrix(&Objects[Ships[i].objnum].orient, &norm1, NULL, NULL);
+			{
+				vec3d norm1;
+				vm_vec_normalized_dir(&norm1, Navs[CurrentNav].GetPosition(), &Player_obj->pos);
+				vm_vector_2_matrix_norm(&Objects[Ships[i].objnum].orient, &norm1, nullptr, nullptr);
 			}
 
 			// snap wings into formation

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -357,7 +357,7 @@ void camera::set_rotation_facing(vec3d *in_target, float in_rotation_time, float
 		if (Use_host_orientation_for_set_camera_facing)
 		{
 			// point along the target vector, but using the host orient's roll
-			vm_vector_2_matrix(&temp_matrix, &targetvec, &orient->vec.uvec, nullptr);
+			vm_vector_2_matrix_norm(&temp_matrix, &targetvec, &orient->vec.uvec, nullptr);
 
 			// if we have a host, we need the difference between the camera's current orient and the orient we want
 			// if not, we will later set the absolute orientation, rather than the orientation relative to the host
@@ -370,7 +370,7 @@ void camera::set_rotation_facing(vec3d *in_target, float in_rotation_time, float
 		else
 		{
 			// point directly along the target vector
-			vm_vector_2_matrix(&temp_matrix, &targetvec, nullptr, nullptr);
+			vm_vector_2_matrix_norm(&temp_matrix, &targetvec, nullptr, nullptr);
 		}
 	}
 
@@ -515,14 +515,14 @@ void camera::get_info(vec3d *position, matrix *orientation, bool apply_camera_or
 
 				vec3d targetvec;
 				vm_vec_normalized_dir(&targetvec, &target_pos, &c_pos);
-				vm_vector_2_matrix(&c_ori, &targetvec, NULL, NULL);
+				vm_vector_2_matrix_norm(&c_ori, &targetvec, nullptr, nullptr);
 				target_set = true;
 			}
 			else if(object_host.isValid())
 			{
 				if(eyep)
 				{
-					vm_vector_2_matrix(&c_ori, &host_normal, vm_vec_same(&host_normal, &object_host.objp()->orient.vec.uvec)?NULL:&object_host.objp()->orient.vec.uvec, NULL);
+					vm_vector_2_matrix_norm(&c_ori, &host_normal, vm_vec_same(&host_normal, &object_host.objp()->orient.vec.uvec) ? nullptr : &object_host.objp()->orient.vec.uvec, nullptr);
 					target_set = true;
 				}
 				else if (use_host_orient)
@@ -1263,7 +1263,7 @@ void get_turret_cam_orient(camera *cam, matrix *ori)
 	object_h obj(cam->get_object_host());
 	if(!obj.isValid())
 		return;
-	vm_vector_2_matrix(ori, &normal_cache, vm_vec_same(&normal_cache, &cam->get_object_host()->orient.vec.uvec)?NULL:&cam->get_object_host()->orient.vec.uvec, NULL);
+	vm_vector_2_matrix_norm(ori, &normal_cache, vm_vec_same(&normal_cache, &cam->get_object_host()->orient.vec.uvec) ? nullptr : &cam->get_object_host()->orient.vec.uvec, nullptr);
 }
 
 eye* get_submodel_eye(polymodel *pm, int submodel_num)

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -473,7 +473,7 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 			// non-hull debris has no relation to its parent orientation
 			vec3d rand;
 			vm_vec_rand_vec(&rand);
-			vm_vector_2_matrix(&orient_buf, &rand);
+			vm_vector_2_matrix_norm(&orient_buf, &rand);
 			orient = &orient_buf;
 		}
 	}

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -402,12 +402,11 @@ void gr_opengl_deferred_lighting_finish()
 			auto matrix_data = matrix_uniform_aligner.addTypedElement<graphics::matrix_uniforms>();
 			vec3d dir, newPos;
 			matrix orient;
-			vm_vec_sub(&dir, &l.vec, &l.vec2);
-			vm_vector_2_matrix(&orient, &dir, nullptr, nullptr);
+			vm_vec_normalized_dir(&dir, &l.vec, &l.vec2);
+			vm_vector_2_matrix_norm(&orient, &dir, nullptr, nullptr);
 			// Tube light volumes must be extended past the length of their requested light vector
 			// to allow smooth fall-off from all angles. Since the light volume starts at the mesh
 			// origin we must extend it, which has been done above, and then move it backwards one radius.
-			vm_vec_normalize(&dir);
 			vm_vec_scale_sub(&newPos, &l.vec2, &dir, l.radb);
 
 			g3_start_instance_matrix(&newPos, &orient, true);

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -434,7 +434,7 @@ matrix shadows_start_render(matrix *eye_orient, vec3d *eye_pos, fov_t fov, float
 	matrix light_matrix;
 
 	vm_vec_copy_normalize(&light_dir, &lp.vec);
-	vm_vector_2_matrix(&light_matrix, &light_dir, &eye_orient->vec.uvec, NULL);
+	vm_vector_2_matrix_norm(&light_matrix, &light_dir, &eye_orient->vec.uvec, nullptr);
 
 	shadows_construct_light_frustum(&Shadow_frustums[0], &light_matrix, eye_orient, eye_pos, fov, aspect, 0.0f, veryneardist);
 	shadows_construct_light_frustum(&Shadow_frustums[1], &light_matrix, eye_orient, eye_pos, fov, aspect, veryneardist - (veryneardist - 0.0f)* 0.2f, neardist);

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -341,10 +341,8 @@ void ssm_create(object *target, const vec3d *start, size_t ssm_index, const ssm_
 		// forward orientation
 		vec3d temp;
 
-		vm_vec_sub(&temp, &target->pos, start);
-		vm_vec_normalize(&temp);
-
-		vm_vector_2_matrix(&dir, &temp, NULL, NULL);
+		vm_vec_normalized_dir(&temp, &target->pos, start);
+		vm_vector_2_matrix_norm(&dir, &temp, nullptr, nullptr);
 
 		// stuff info
 		ssm.sinfo.count = count;
@@ -431,9 +429,8 @@ void ssm_process()
 						vec3d temp;
 						matrix orient;
 
-						vm_vec_sub(&temp, &moveup->sinfo.target->pos, &moveup->sinfo.start_pos[idx]);
-						vm_vec_normalize(&temp);
-						vm_vector_2_matrix(&orient, &temp, nullptr, nullptr);
+						vm_vec_normalized_dir(&temp, &moveup->sinfo.target->pos, &moveup->sinfo.start_pos[idx]);
+						vm_vector_2_matrix_norm(&orient, &temp, nullptr, nullptr);
 
 						// are we a beam? -MageKing17
 						if (wip->wi_flags[Weapon::Info_Flags::Beam]) {
@@ -485,9 +482,8 @@ void ssm_process()
 					vec3d temp;
 					matrix orient;
 
-                    vm_vec_sub(&temp, &moveup->sinfo.target->pos, &moveup->sinfo.start_pos[idx]);
-					vm_vec_normalize(&temp);
-					vm_vector_2_matrix(&orient, &temp, NULL, NULL);
+                    vm_vec_normalized_dir(&temp, &moveup->sinfo.target->pos, &moveup->sinfo.start_pos[idx]);
+					vm_vector_2_matrix_norm(&orient, &temp, nullptr, nullptr);
 					moveup->fireballs[idx] = fireball_create(&moveup->sinfo.start_pos[idx], si->fireball_type, FIREBALL_WARP_EFFECT, -1, si->warp_radius, false, &vmd_zero_vector, si->warp_time, 0, &orient);
 				}
 			}

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4196,7 +4196,7 @@ void HudGaugeLeadIndicator::renderLeadQuick(vec3d *target_world_pos, object *tar
 	}
 //							vec3d firing_vec;
 //							vm_vec_unrotate(&firing_vec, &po->gun_banks[bank_to_fire].norm[pt], &obj->orient);
-//							vm_vector_2_matrix(&firing_orient, &firing_vec, NULL, NULL);
+//							vm_vector_2_matrix_norm(&firing_orient, &firing_vec, NULL, NULL);
 
 	// source_pos will contain the world coordinate of where to base the lead indicator prediction
 	// from.  Normally, this will be the world pos of the gun turret of the currently selected primary

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -627,8 +627,7 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp, bool config)
 		if (Detail.targetview_model) {
 			// take the forward orientation to be the vector from the player to the current target
 			vec3d orient_vec;
-			vm_vec_sub(&orient_vec, &target_objp->pos, &Player_obj->pos);
-			vm_vec_normalize(&orient_vec);
+			vm_vec_normalized_dir(&orient_vec, &target_objp->pos, &Player_obj->pos);
 
 			float factor = -target_sip->closeup_pos_targetbox.xyz.z;
 
@@ -639,7 +638,7 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp, bool config)
 			object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 			vec3d up_vector = camera_orient.vec.uvec;
-			vm_vector_2_matrix(&camera_orient, &orient_vec, &up_vector, nullptr);
+			vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
 
 			// normalize the vector from the player to the current target, and scale by a factor to calculate
 			// the objects position
@@ -816,8 +815,7 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 
 	if ( Detail.targetview_model )	{
 		// take the forward orientation to be the vector from the player to the current target
-		vm_vec_sub(&orient_vec, &target_objp->pos, &Player_obj->pos);
-		vm_vec_normalize(&orient_vec);
+		vm_vec_normalized_dir(&orient_vec, &target_objp->pos, &Player_obj->pos);
 
 		factor = 2*target_objp->radius;
 
@@ -826,7 +824,7 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 		up_vector = camera_orient.vec.uvec;
-		vm_vector_2_matrix(&camera_orient,&orient_vec,&up_vector,NULL);
+		vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
 
 		// normalize the vector from the player to the current target, and scale by a factor to calculate
 		// the objects position
@@ -973,12 +971,10 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 			replacement_textures = model_get_instance(pmi_id)->texture_replace;
 
 		// take the forward orientation to be the vector from the player to the current target
-		vm_vec_sub(&orient_vec, &viewed_obj->pos, &viewer_obj->pos);
-		vm_vec_normalize(&orient_vec);
+		vm_vec_normalized_dir(&orient_vec, &viewed_obj->pos, &viewer_obj->pos);
 
 		if (missile_view == TRUE) {
-			vm_vec_sub(&projection_vec, &wp->homing_pos, &viewer_obj->pos);
-			vm_vec_normalize(&projection_vec);
+			vm_vec_normalized_dir(&projection_vec, &wp->homing_pos, &viewer_obj->pos);
 		}
 
 		// use the viewer's up vector, and construct the viewer's orientation matrix
@@ -988,9 +984,9 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 		up_vector = camera_orient.vec.uvec;
 
 		if (missile_view == FALSE)
-			vm_vector_2_matrix(&camera_orient,&orient_vec,&up_vector,NULL);
+			vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
 		else
-			vm_vector_2_matrix(&camera_orient,&projection_vec,&up_vector,NULL);
+			vm_vector_2_matrix_norm(&camera_orient, &projection_vec, &up_vector, nullptr);
 
 		// normalize the vector from the viewer to the viwed target, and scale by a factor to calculate
 		// the objects position
@@ -1206,8 +1202,7 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 
 	if ( Detail.targetview_model )	{
 		// take the forward orientation to be the vector from the player to the current target
-		vm_vec_sub(&orient_vec, &target_objp->pos, &Player_obj->pos);
-		vm_vec_normalize(&orient_vec);
+		vm_vec_normalized_dir(&orient_vec, &target_objp->pos, &Player_obj->pos);
 
 		factor = 2*target_objp->radius;
 
@@ -1216,7 +1211,7 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 		up_vector = camera_orient.vec.uvec;
-		vm_vector_2_matrix(&camera_orient,&orient_vec,&up_vector,NULL);
+		vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
 
 		// normalize the vector from the player to the current target, and scale by a factor to calculate
 		// the objects position
@@ -1343,8 +1338,7 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 
 		if ( Detail.targetview_model )	{
 			// take the forward orientation to be the vector from the player to the current target
-			vm_vec_sub(&orient_vec, &target_objp->pos, &Player_obj->pos);
-			vm_vec_normalize(&orient_vec);
+			vm_vec_normalized_dir(&orient_vec, &target_objp->pos, &Player_obj->pos);
 
 			factor = target_objp->radius*4.0f;
 
@@ -1353,7 +1347,7 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 			object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 			up_vector = camera_orient.vec.uvec;
-			vm_vector_2_matrix(&camera_orient,&orient_vec,&up_vector,NULL);
+			vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
 
 			// normalize the vector from the player to the current target, and scale by a factor to calculate
 			// the objects position

--- a/code/math/staticrand.cpp
+++ b/code/math/staticrand.cpp
@@ -142,7 +142,7 @@ void static_rand_cone(int num, vec3d *out, const vec3d* const in, float max_angl
 	if(orient != nullptr){
 		rot = orient;
 	} else {
-		vm_vector_2_matrix(&m, in, nullptr, nullptr);
+		vm_vector_2_matrix_norm(&m, in, nullptr, nullptr);
 		rot = &m;
 	}
 	
@@ -173,7 +173,7 @@ void static_rand_cone(int num, vec3d* out, const vec3d* const in, float min_angl
 		rot = orient;
 	}
 	else {
-		vm_vector_2_matrix(&m, in, nullptr, nullptr);
+		vm_vector_2_matrix_norm(&m, in, nullptr, nullptr);
 		rot = &m;
 	}
 

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -458,7 +458,8 @@ float vm_vec_dist(const vec3d *v0, const vec3d *v1)
 bool vm_vec_is_normalized(const vec3d *v)
 {
 	// By the standards of FSO, it is sufficient to check that the magnitude is close to 1.
-	return vm_vec_mag(v) > 0.999f && vm_vec_mag(v) < 1.001f;
+	float mag = vm_vec_mag(v);
+	return mag > 0.999f && mag < 1.001f;
 }
 
 //normalize a vector. returns mag of source vec (always greater than zero)
@@ -827,6 +828,11 @@ matrix *vm_vector_2_matrix(matrix *m, const vec3d *fvec, const vec3d *uvec, cons
 
 matrix *vm_vector_2_matrix_norm(matrix *m, const vec3d *fvec, const vec3d *uvec, const vec3d *rvec)
 {
+	// sanity
+	Assertion(fvec == nullptr || vm_vec_is_normalized(fvec), "if fvec is provided, it must be normalized!");
+	Assertion(uvec == nullptr || vm_vec_is_normalized(uvec), "if uvec is provided, it must be normalized!");
+	Assertion(rvec == nullptr || vm_vec_is_normalized(rvec), "if rvec is provided, it must be normalized!");
+
 	matrix temp = vmd_identity_matrix;
 
 	vec3d *xvec=&temp.vec.rvec;
@@ -2315,7 +2321,7 @@ void vm_vec_random_cone(vec3d *out, const vec3d *in, float max_angle, const matr
 	if(orient != NULL){
 		rot = orient;
 	} else {
-		vm_vector_2_matrix(&m, in, NULL, NULL);
+		vm_vector_2_matrix_norm(&m, in, nullptr, nullptr);
 		rot = &m;
 	}
 
@@ -2342,7 +2348,7 @@ void vm_vec_random_cone(vec3d *out, const vec3d *in, float min_angle, float max_
 	if(orient != NULL){
 		rot = orient;
 	} else {
-		vm_vector_2_matrix(&m, in, NULL, NULL);
+		vm_vector_2_matrix_norm(&m, in, nullptr, nullptr);
 		rot = &m;
 	}
 	

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -317,7 +317,7 @@ matrix *vm_vector_2_matrix(matrix *m, const vec3d *fvec, const vec3d *uvec = nul
  *
  * @sa vm_vector_2_matrix
  */
-matrix *vm_vector_2_matrix_norm(matrix *m, const vec3d *fvec, const vec3d *uvec = NULL, const vec3d *rvec = NULL);
+matrix *vm_vector_2_matrix_norm(matrix *m, const vec3d *fvec, const vec3d *uvec = nullptr, const vec3d *rvec = nullptr);
 
 //rotates a vector through a matrix. returns ptr to dest vector
 vec3d *vm_vec_rotate(vec3d *dest, const vec3d *src, const matrix *m);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -7594,8 +7594,8 @@ int mission_set_arrival_location(int anchor, ArrivalLocation location, int dist,
 		//
 		// calculate the new fvec of the ship arriving and use only that to get the matrix.  isn't a big
 		// deal not getting bank.
-		vm_vec_sub(&new_fvec, &anchor_pos, &Objects[objnum].pos );
-		vm_vector_2_matrix( &orient, &new_fvec, NULL, NULL );
+		vm_vec_normalized_dir(&new_fvec, &anchor_pos, &Objects[objnum].pos );
+		vm_vector_2_matrix_norm( &orient, &new_fvec, nullptr, nullptr );
 		Objects[objnum].orient = orient;
 	}
 

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2370,8 +2370,12 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 						for (j = 0; j < bay->num_slots; j++) {
 							cfread_vector( &(bay->pnt[j]), fp );
 							cfread_vector( &(bay->norm[j]), fp );
-							if(vm_vec_mag(&(bay->norm[j])) <= 0.0f) {
-								Warning(LOCATION, "Model '%s' dock point '%s' has a null normal. ", filename, bay->name);
+
+							if (vm_vec_mag(&(bay->norm[j])) <= 0.0f) {
+								Warning(LOCATION, "Model '%s' dock point '%s' has a null normal.  Generating a normal in the forward Z direction.", filename, bay->name);
+								bay->norm[j] = vmd_z_vector;
+							} else if (!vm_vec_is_normalized(&(bay->norm[j]))) {
+								vm_vec_normalize(&(bay->norm[j]));
 							}
 						}
 

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -1015,7 +1015,7 @@ void neb2_render_poofs()
 
 			vm_vec_normalize(&view_pos);
 
-			vm_vector_2_matrix(&orient, &view_pos, &pf.up_vec, nullptr);
+			vm_vector_2_matrix_norm(&orient, &view_pos, &pf.up_vec, nullptr);
 		}
 
 		// update the poof's up vector to be perpindicular to the camera and also rotated by however much its rotating

--- a/code/nebula/neblightning.cpp
+++ b/code/nebula/neblightning.cpp
@@ -781,7 +781,7 @@ bool nebl_bolt(int type, vec3d *start, vec3d *strike, bool play_sound)
 	vm_vec_scale_add(&bolt->midpoint, &Nebl_bolt_start, &dir, 0.5f);
 
 	bolt_len = vm_vec_normalize(&dir);
-	vm_vector_2_matrix(&Nebl_bolt_dir, &dir, NULL, NULL);
+	vm_vector_2_matrix_norm(&Nebl_bolt_dir, &dir, nullptr, nullptr);
 
 	// global type for generating the bolt
 	Nebl_type = bi;
@@ -1073,7 +1073,6 @@ void nebl_render_section(bolt_type *bi, l_section *a, l_section *b)
 // generate a section
 void nebl_generate_section(bolt_type *bi, float width, l_node *a, l_node *b, l_section *c, l_section *cap, int pinch_a, int pinch_b)
 {
-	vec3d dir;
 	vec3d dir_normal;
 	matrix m;
 	size_t idx;	
@@ -1082,9 +1081,8 @@ void nebl_generate_section(bolt_type *bi, float width, l_node *a, l_node *b, l_s
 	vertex tempv;
 
 	// direction matrix
-	vm_vec_sub(&dir, &a->pos, &b->pos);
-	vm_vec_copy_normalize(&dir_normal, &dir);
-	vm_vector_2_matrix(&m, &dir_normal, NULL, NULL);
+	vm_vec_normalized_dir(&dir_normal, &a->pos, &b->pos);
+	vm_vector_2_matrix_norm(&m, &dir_normal, nullptr, nullptr);
 
 	// distance to player
 	float bang_dist = vm_vec_dist_quick(&Eye_position, &a->pos);
@@ -1229,9 +1227,8 @@ void nebl_jitter(l_bolt *b)
 	bi = &Bolt_types[b->type];
 
 	// get the bolt direction
-	vm_vec_sub(&temp, &b->strike, &b->start);
-	length = vm_vec_normalize_quick(&temp);
-	vm_vector_2_matrix(&m, &temp, NULL, NULL);
+	length = vm_vec_normalized_dir(&temp, &b->strike, &b->start);
+	vm_vector_2_matrix_norm(&m, &temp, nullptr, nullptr);
 
 	// jitter all nodes on the main trunk
 	moveup = b->head;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3425,7 +3425,7 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	}
 
 	// make an orientation matrix from the o_fvec
-	vm_vector_2_matrix(&orient, &o_fvec, NULL, NULL);
+	vm_vector_2_matrix_norm(&orient, &o_fvec, nullptr, nullptr);
 
 	// find this turret, and set the position of the turret that just fired to be where it fired.  Quite a
 	// hack, but should be suitable.
@@ -8718,7 +8718,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	}
 
 	// make an orientation matrix from the o_fvec
-	vm_vector_2_matrix(&orient, &o_fvec, NULL, NULL);
+	vm_vector_2_matrix_norm(&orient, &o_fvec, nullptr, nullptr);
 
 	// find this turret, and set the position of the turret that just fired to be where it fired.  Quite a
 	// hack, but should be suitable.

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -108,7 +108,7 @@ matrix ParticleEffect::getNewDirection(const matrix& hostOrientation, const std:
 			}
 
 			matrix normalOrient;
-			vm_vector_2_matrix(&normalOrient, &*normal);
+			vm_vector_2_matrix_norm(&normalOrient, &*normal);
 
 			return normalOrient;
 		}

--- a/code/particle/hosts/EffectHostTurret.cpp
+++ b/code/particle/hosts/EffectHostTurret.cpp
@@ -28,7 +28,7 @@ std::pair<vec3d, matrix> EffectHostTurret::getPositionAndOrientation(bool relati
 												 &Objects[m_objnum].orient, &global_pos);
 
 		if (m_orientationOverrideRelative) {
-			vm_vector_2_matrix(&orientation, &gvec, &gun_frame_of_reference.vec.uvec);
+			vm_vector_2_matrix_norm(&orientation, &gvec, &gun_frame_of_reference.vec.uvec);
 			vm_matrix_x_matrix(&orientation, &orientation, &m_orientationOverride);
 		}
 		else {
@@ -40,7 +40,7 @@ std::pair<vec3d, matrix> EffectHostTurret::getPositionAndOrientation(bool relati
 		model_instance_local_to_global_point_dir(&pos, &gvec, gun_pos, &tp->turret_norm, pm, pmi, tp->turret_gun_sobj);
 
 		if (m_orientationOverrideRelative) {
-			vm_vector_2_matrix(&orientation, &gvec, &gun_frame_of_reference.vec.uvec);
+			vm_vector_2_matrix_norm(&orientation, &gvec, &gun_frame_of_reference.vec.uvec);
 			vm_matrix_x_matrix(&orientation, &orientation, &m_orientationOverride);
 		}
 		else {

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -2278,7 +2278,7 @@ camid player_get_cam()
 				eye_pos = Player_obj->pos;
 
 				vm_vec_normalized_dir(&tmp_dir, &Objects[Player_ai->target_objnum].pos, &eye_pos);
-				vm_vector_2_matrix(&eye_orient, &tmp_dir, NULL, NULL);
+				vm_vector_2_matrix_norm(&eye_orient, &tmp_dir, nullptr, nullptr);
 			}
 		} else {
 			dist = vm_vec_normalized_dir(&vec_to_deader, &Player_obj->pos, &Dead_camera_pos);
@@ -2305,7 +2305,7 @@ camid player_get_cam()
 
 			vm_vec_normalized_dir(&tmp_dir, &Player_obj->pos, &eye_pos);
 
-			vm_vector_2_matrix(&eye_orient, &tmp_dir, NULL, NULL);
+			vm_vector_2_matrix_norm(&eye_orient, &tmp_dir, nullptr, nullptr);
 			viewer_obj = NULL;
 		}
 	} 
@@ -2334,9 +2334,8 @@ camid player_get_cam()
 
 			vm_vec_scale_add(&eye_pos, &viewer_obj->pos, &tm.vec.fvec, Viewer_external_info.current_distance);
 
-			vm_vec_sub(&tmp_dir, &viewer_obj->pos, &eye_pos);
-			vm_vec_normalize(&tmp_dir);
-			vm_vector_2_matrix(&eye_orient, &tmp_dir, &viewer_obj->orient.vec.uvec, NULL);
+			vm_vec_normalized_dir(&tmp_dir, &viewer_obj->pos, &eye_pos);
+			vm_vector_2_matrix_norm(&eye_orient, &tmp_dir, &viewer_obj->orient.vec.uvec, nullptr);
  			viewer_obj = NULL;
 
 			//	Modify the orientation based on head orientation.
@@ -2353,8 +2352,7 @@ camid player_get_cam()
 
 			vm_vec_scale_add(&eye_pos, &viewer_obj->pos, &move_dir, -3.0f * viewer_obj->radius - Viewer_chase_info.distance);
 			vm_vec_scale_add2(&eye_pos, &viewer_obj->orient.vec.uvec, 0.75f * viewer_obj->radius);
-			vm_vec_sub(&tmp_dir, &viewer_obj->pos, &eye_pos);
-			vm_vec_normalize(&tmp_dir);
+			vm_vec_normalized_dir(&tmp_dir, &viewer_obj->pos, &eye_pos);
 
 			// JAS: I added the following code because if you slew up using
 			// Descent-style physics, eye_dir and Viewer_obj->orient.vec.uvec are
@@ -2378,9 +2376,8 @@ camid player_get_cam()
 
 			vec3d warp_pos = Player_obj->pos;
 			shipp->warpout_effect->getWarpPosition(&warp_pos);
-			vm_vec_sub(&tmp_dir, &warp_pos, &eye_pos);
-			vm_vec_normalize(&tmp_dir);
-			vm_vector_2_matrix(&eye_orient, &tmp_dir, &Player_obj->orient.vec.uvec, NULL);
+			vm_vec_normalized_dir(&tmp_dir, &warp_pos, &eye_pos);
+			vm_vector_2_matrix_norm(&eye_orient, &tmp_dir, &Player_obj->orient.vec.uvec, nullptr);
 			viewer_obj = NULL;
 		} else {
 			// get an eye position for the player object

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -501,7 +501,7 @@ void g3_render_rect_oriented(material* mat_info, vec3d *pos, matrix *ori, float 
 void g3_render_rect_oriented(material* mat_info, vec3d *pos, vec3d *norm, float width, float height)
 {
 	matrix m;
-	vm_vector_2_matrix(&m, norm, NULL, NULL);
+	vm_vector_2_matrix_norm(&m, norm, nullptr, nullptr);
 
 	g3_render_rect_oriented_internal(mat_info, pos, &m, width, height);
 }

--- a/code/scripting/api/libs/base.cpp
+++ b/code/scripting/api/libs/base.cpp
@@ -220,11 +220,11 @@ ADE_FUNC(createRandomOrientation, l_Base, nullptr, "Creates a random orientation
 	matrix fvec_orient, final_orient;
 
 	vm_vec_random_in_sphere(&fvec, &vmd_zero_vector, 1.0f, true);
-	vm_vector_2_matrix(&fvec_orient, &fvec, nullptr, nullptr);
+	vm_vector_2_matrix_norm(&fvec_orient, &fvec, nullptr, nullptr);
 
 	vm_vec_random_in_circle(&uvec, &vmd_zero_vector, &fvec_orient, 1.0f, true);
 
-	vm_vector_2_matrix(&final_orient, &fvec, &uvec);
+	vm_vector_2_matrix_norm(&final_orient, &fvec, &uvec);
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&final_orient)));
 }

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -1267,10 +1267,10 @@ ADE_FUNC(computeDocker, l_Dockingbay, "dockingbay",
 	vm_vec_avg(&docker_dock_pos_local, &docker_bay->pnt[0], &docker_bay->pnt[1]);
 
 	// Get the up-vector of the docking bay
-	vm_vec_sub(&dock_up_dir, &dockee_bay->pnt[1], &dockee_bay->pnt[0]);
+	vm_vec_normalized_dir(&dock_up_dir, &dockee_bay->pnt[1], &dockee_bay->pnt[0]);
 
 	// Compute the orientation
-	vm_vector_2_matrix(&final_orient, &dockee_bay->norm[0], &dock_up_dir, NULL);
+	vm_vector_2_matrix_norm(&final_orient, &dockee_bay->norm[0], &dock_up_dir, nullptr);
 
 	// Rotate the docker position into the right orientation
 	vm_vec_unrotate(&docker_dock_pos, &docker_dock_pos_local, &final_orient);

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -1001,7 +1001,7 @@ ADE_FUNC(getTurretMatrix, l_Subsystem, nullptr, "Returns current subsystems turr
 	model_subsystem *tp = sso->ss->system_info;
 
 	// we have to fake a turret matrix because that field is no longer part of model_subsystem
-	vm_vector_2_matrix(&m, &tp->turret_norm, nullptr, nullptr);
+	vm_vector_2_matrix_norm(&m, &tp->turret_norm, nullptr, nullptr);
 
 	return ade_set_args(L, "o", l_Matrix.Set(matrix_h(&m)));
 }

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -738,7 +738,7 @@ void create_shield_low_detail(int objnum, int  /*model_num*/, matrix * /*orient*
 		Shield_hits[shnum].rgb[2] = sip->shield_color[2];
 	}
 
-	vm_vector_2_matrix(&tom, &shieldp->tris[tr0].norm, NULL, NULL);
+	vm_vector_2_matrix_norm(&tom, &shieldp->tris[tr0].norm, nullptr, nullptr);
 
 	create_low_detail_poly(gi, tcp, &tom.vec.rvec, &tom.vec.uvec);
 }
@@ -792,7 +792,7 @@ void create_shield_explosion(int objnum, int model_num, vec3d *tcp, int tr0, flo
 	//	normals from the vertices to get a smoothly changing normal across the face.
 	//	I had tried using the vector from the impact point to the center, which
 	//	changes smoothly, but this looked surprisingly bad.
-	vm_vector_2_matrix(&tom, &shieldp->tris[tr0].norm, NULL, NULL);
+	vm_vector_2_matrix_norm(&tom, &shieldp->tris[tr0].norm, nullptr, nullptr);
 
 	//	Create the shield from the current triangle, as well as its neighbors.
 	create_shield_from_triangle(tr0, &objp->orient, shieldp, tcp, &objp->pos, objp->radius, &tom.vec.rvec, &tom.vec.uvec);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13289,13 +13289,13 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 
 								if (has_converging_autoaim) {
 									// converging autoaim
-									vm_vec_sub(&firing_vec, &predicted_target_pos, &firing_pos);
+									vm_vec_normalized_dir(&firing_vec, &predicted_target_pos, &firing_pos);
 								} else {
 									// autoaim
-									vm_vec_sub(&firing_vec, &predicted_target_pos, &obj->pos);
+									vm_vec_normalized_dir(&firing_vec, &predicted_target_pos, &obj->pos);
 								}
 
-								vm_vector_2_matrix(&firing_orient, &firing_vec, NULL, NULL);
+								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, nullptr, nullptr);
 							} else if (std_convergence_flagged || (auto_convergence_flagged && (aip->target_objnum != -1))) {
 								// std & auto convergence
 								vec3d target_vec, firing_vec, convergence_offset;
@@ -13319,15 +13319,15 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								}
 
 								vm_vec_add2(&target_vec, &obj->pos);
-								vm_vec_sub(&firing_vec, &target_vec, &firing_pos);
+								vm_vec_normalized_dir(&firing_vec, &target_vec, &firing_pos);
 
 								// set orientation
-								vm_vector_2_matrix(&firing_orient, &firing_vec, NULL, NULL);
+								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, nullptr, nullptr);
 							} else if (sip->flags[Ship::Info_Flags::Gun_convergence]) {
 								// model file defined convergence
 								vec3d firing_vec;
 								vm_vec_unrotate(&firing_vec, &pm->gun_banks[bank_to_fire].norm[pt], &obj->orient);
-								vm_vector_2_matrix(&firing_orient, &firing_vec, NULL, NULL);
+								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, nullptr, nullptr);
 							}
 
 							if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){	// Function to add recoil functionality - DahBlount
@@ -14142,7 +14142,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 			{
 				vec3d firing_vec;
 				vm_vec_unrotate(&firing_vec, &pm->missile_banks[bank].norm[pnt_index-1], &obj->orient);
-				vm_vector_2_matrix(&firing_orient, &firing_vec, NULL, NULL);
+				vm_vector_2_matrix_norm(&firing_orient, &firing_vec, nullptr, nullptr);
 			}
 
 			// create the weapon -- for multiplayer, the net_signature is assigned inside

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1060,7 +1060,7 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 			// if there's a muzzle effect entry, we use that
 			if (Weapon_info[weapon_info_index].muzzle_effect.isValid()) {
 				matrix gunOrient;
-				vm_vector_2_matrix(&gunOrient, gun_dir);
+				vm_vector_2_matrix_norm(&gunOrient, gun_dir);
 
 				// spawn particle effect
 				auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[weapon_info_index].muzzle_effect);
@@ -3619,11 +3619,11 @@ int WE_Default::getWarpOrientation(matrix* output) const
 	auto objp = &Objects[m_objnum];
 
 	if (this->m_direction == WarpDirection::WARP_IN)
-		vm_vector_2_matrix(output, &objp->orient.vec.fvec, nullptr, nullptr);
+		vm_vector_2_matrix_norm(output, &objp->orient.vec.fvec, nullptr, nullptr);
 	else {
 		vec3d backwards = objp->orient.vec.fvec;
 		vm_vec_negate(&backwards);
-		vm_vector_2_matrix(output, &backwards, nullptr, nullptr);
+		vm_vector_2_matrix_norm(output, &backwards, nullptr, nullptr);
 	}
     return 1;
 }
@@ -4007,7 +4007,7 @@ int WE_BSG::getWarpOrientation(matrix* output) const
 
 	auto objp = &Objects[m_objnum];
 
-	vm_vector_2_matrix(output, &objp->orient.vec.fvec, NULL, NULL);
+	vm_vector_2_matrix_norm(output, &objp->orient.vec.fvec, nullptr, nullptr);
 	return 1;
 }
 
@@ -4296,7 +4296,7 @@ int WE_Homeworld::getWarpOrientation(matrix* output) const
 	else {
 		vec3d backwards = objp->orient.vec.fvec;
 		vm_vec_negate(&backwards);
-		vm_vector_2_matrix(output, &backwards, &objp->orient.vec.uvec, nullptr);
+		vm_vector_2_matrix_norm(output, &backwards, &objp->orient.vec.uvec, nullptr);
 	}
 
 	return 1;

--- a/code/starfield/supernova.cpp
+++ b/code/starfield/supernova.cpp
@@ -341,9 +341,8 @@ void supernova_get_eye(vec3d *eye_pos, matrix *eye_orient)
 		float pct = ((SUPERNOVA_HIT_TIME - Supernova_time_left) / SUPERNOVA_CAMERA_MOVE_DURATION);
 		vm_vec_scale_add2(&at, &move, sn_distance * pct);
 
-		vm_vec_sub(&view, &at, &Supernova_camera_pos);
-		vm_vec_normalize(&view);
-		vm_vector_2_matrix(&Supernova_camera_orient, &view, NULL, NULL);
+		vm_vec_normalized_dir(&view, &at, &Supernova_camera_pos);
+		vm_vector_2_matrix_norm(&Supernova_camera_orient, &view, nullptr, nullptr);
 		//cam->set_rotation(&Supernova_camera_orient);
 		*eye_orient = Supernova_camera_orient;
 	}

--- a/code/weapon/corkscrew.cpp
+++ b/code/weapon/corkscrew.cpp
@@ -241,9 +241,8 @@ void cscrew_process_post(object *objp)
 	
 		// compute a "fake" orient and store the old one for safekeeping
 		ci->real_orient = objp->orient;
-		vm_vec_sub(&dir, &objp->pos, &ci->last_corkscrew_pos);
-		vm_vec_normalize(&dir);
-		vm_vector_2_matrix(&objp->orient, &dir, NULL, NULL);	
+		vm_vec_normalized_dir(&dir, &objp->pos, &ci->last_corkscrew_pos);
+		vm_vector_2_matrix_norm(&objp->orient, &dir, nullptr, nullptr);
 		
 		// mark down this position so we can orient nicely _next_ frame
 		ci->last_corkscrew_pos = objp->pos;

--- a/code/weapon/flak.cpp
+++ b/code/weapon/flak.cpp
@@ -91,7 +91,7 @@ void flak_jitter_aim(vec3d *dir, float dist_to_target, float weapon_subsys_stren
 	float error_val;
 	
 	// get the matrix needed to rotate the base direction to the actual direction		
-	vm_vector_2_matrix(&temp, dir, NULL, NULL);
+	vm_vector_2_matrix_norm(&temp, dir, nullptr, nullptr);
 
 	// error value	
 	error_val = wip->flak_targeting_accuracy + (wip->flak_targeting_accuracy * 0.65f * (1.0f - weapon_subsys_strength));

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6314,8 +6314,8 @@ void weapon_process_post(object * obj, float frame_time)
 			vm_vec_random_in_circle(&warpin, &wp->lssm_target_pos, &target_objp->orient, wip->lssm_warpin_radius + target_objp->radius, true);
 	
 			//orient the missile properly
-			vm_vec_sub(&fvec,&wp->lssm_target_pos, &warpin);
-			vm_vector_2_matrix(&orient,&fvec,NULL,NULL);
+			vm_vec_normalized_dir(&fvec, &wp->lssm_target_pos, &warpin);
+			vm_vector_2_matrix_norm(&orient, &fvec, nullptr, nullptr);
 
 			//get the size of the warp, directly using the model if possible
 			float warp_size = obj->radius;
@@ -6682,8 +6682,7 @@ int weapon_create( const vec3d *pos, const matrix *porient, int weapon_type, int
 	if(combined_fof > 0.0f){
 		vec3d f;
 		vm_vec_random_cone(&f, &orient->vec.fvec, combined_fof);
-		vm_vec_normalize(&f);
-		vm_vector_2_matrix( orient, &f, NULL, NULL);
+		vm_vector_2_matrix_norm(orient, &f, nullptr, nullptr);
 	}
 
 	Weapons_created++;
@@ -7204,7 +7203,7 @@ void spawn_child_weapons(object *objp, int spawn_index_override)
 				// fire the beam
 				beam_fire(&fire_info);
 			} else {
-				vm_vector_2_matrix(&orient, &tvec, nullptr, nullptr);
+				vm_vector_2_matrix_norm(&orient, &tvec, nullptr, nullptr);
 				weapon_objnum = weapon_create(&pos, &orient, child_id, parent_num, -1, wp->weapon_flags[Weapon::Weapon_Flags::Locked_when_fired], 1);
 
 				//if the child inherits parent target, do it only if the parent weapon was locked to begin with


### PR DESCRIPTION
Most places in the code that use `vm_vector_2_matrix` do so on already-normalized vectors.  Changing these to `vm_vector_2_matrix_norm` avoids redundant normalization.