### PR TITLE
Fix changes to Options not properly discarding when escape key pressed

### DIFF
--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -239,6 +239,11 @@ static float Backup_sound_volume;
 static float Backup_music_volume;
 static float Backup_voice_volume;
 
+static int Backup_mouse_sensitivity;
+static int Backup_joy_sensitivity;
+static int Backup_joy_deadzone;
+static float Backup_gamma;
+
 static bool Backup_briefing_voice_enabled;
 static bool Backup_use_mouse_to_fly;
 
@@ -674,6 +679,11 @@ void options_cancel_exit()
 	event_music_set_volume(Backup_music_volume);
 	snd_set_voice_volume(Backup_voice_volume);
 
+	Mouse_sensitivity = Backup_mouse_sensitivity ;
+	Joy_sensitivity = Backup_joy_sensitivity ;
+	Joy_dead_zone_size = Backup_joy_deadzone * 5;
+	gr_set_gamma(Backup_gamma);
+
 	if(!(Game_mode & GM_MULTIPLAYER)){
 		Game_skill_level = Backup_skill_level;
 	}
@@ -1049,6 +1059,11 @@ void options_menu_init()
 	Backup_voice_volume = Master_voice_volume;
 	Backup_briefing_voice_enabled = Briefing_voice_enabled;
 	Backup_use_mouse_to_fly = Use_mouse_to_fly;
+
+	Backup_mouse_sensitivity = Mouse_sensitivity;
+	Backup_joy_sensitivity = Joy_sensitivity;
+	Backup_joy_deadzone = Joy_dead_zone_size / 5;
+	Backup_gamma = Gr_gamma;
 	
 	// create slider	
 	for ( i = 0; i < NUM_OPTIONS_SLIDERS; i++ ) {
@@ -1226,6 +1241,7 @@ void options_menu_do_frame(float  /*frametime*/)
 			if (Tab == OPTIONS_TAB) {
 				gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 				gameseq_post_event(GS_EVENT_CONTROL_CONFIG);
+				return;
 			}
 
 			break;
@@ -1234,6 +1250,7 @@ void options_menu_do_frame(float  /*frametime*/)
 			if (Tab == OPTIONS_TAB) {
 				gamesnd_play_iface(InterfaceSounds::SWITCH_SCREENS);
 				gameseq_post_event(GS_EVENT_HUD_CONFIG);
+				return;
 			}
 
 			break;
@@ -1241,13 +1258,16 @@ void options_menu_do_frame(float  /*frametime*/)
 		case KEY_ESC:
 			if (escape_key_behavior_in_options == EscapeKeyBehaviorInOptions::SAVE) {
 				options_accept();
+				return;
 			} else {
 				options_cancel_exit();
+				return;
 			}
 			break;
 
 		case KEY_CTRLED | KEY_ENTER:
 			options_accept();
+			return;
 			break;
 
 		case KEY_DELETE:
@@ -1266,6 +1286,7 @@ void options_menu_do_frame(float  /*frametime*/)
 
 				gamesnd_play_iface(InterfaceSounds::IFACE_MOUSE_CLICK);
 				gameseq_post_event(GS_EVENT_INGAME_OPTIONS);
+				return;
 			}
 			break;
 	}	

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -257,7 +257,7 @@ char Options_notify_string[200];
 
 // Called whenever the options menu state is accepted, either via 
 // clicking the accept button or when navigating to the Controls or HUD screen.
-// The reasoning is thta clicking a button means 'accept and move on' if it leads to a new state.
+// The reasoning is that clicking a button means 'accept and move on' if it leads to a new state.
 // This behavior has always been the case for the main options and detail tabs, 
 // and now it is the same for the multi tab, too. --wookieejedi 
 void options_accept();
@@ -956,17 +956,19 @@ void options_detail_sliders_in_game_update()
 void options_accept()
 {
 	// apply the selected multiplayer options
-	// commenting out, as we are using the new streamlined method
-	// --wookieejedi and confirmed with taylor
-	//if ( Options_multi_inited ) {
-		// if we've failed to provide a PXO password or username but have turned on PXO, we don't want to quit
+	if ( Options_multi_inited ) {
+		// commenting out old method, as we are using the new streamlined method
+		// which is justified via comment in the function itself
+		// --wookieejedi and confirmed with taylor
+
 		//if (!options_multi_accept()) {
 			//gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 			//popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, "PXO is selected but password or username is missing");
 			//return false;
 		//}
-	//}
-	options_multi_accept();
+
+		options_multi_accept();
+	}
 
 	// We have to save in game options here
 	if (Using_in_game_options) {

--- a/code/menuui/optionsmenumulti.cpp
+++ b/code/menuui/optionsmenumulti.cpp
@@ -865,7 +865,7 @@ void options_multi_protocol_do(int key)
 		// otherwise quit the options screen altogether
 		else {
 			// reaching this section is unlikely because
-			// escape key detection is already exectued 
+			// escape key detection is already executed 
 			// within options_menu_do_frame(),
 			// which runs before options_multi_do()
 			// --wookieejedi
@@ -951,15 +951,9 @@ void options_multi_protocol_accept()
 		Om_tracker_squad_name.get_text(Multi_tracker_squad_name);
 
 		// write out the tracker login, passwd, and PXO squad name values to the registry
-		if (strlen(Multi_tracker_login) > 0) {
-			os_config_write_string( "PXO", "Login", Multi_tracker_login );
-		}
-		if (strlen(Multi_tracker_passwd) > 0) {
-			os_config_write_string( "PXO", "Password", Multi_tracker_passwd );
-		}
-		if (strlen(Multi_tracker_squad_name) > 0) {
-			os_config_write_string( "PXO", "SquadName", Multi_tracker_squad_name );
-		}
+		os_config_write_string( "PXO", "Login", Multi_tracker_login );
+		os_config_write_string( "PXO", "Password", Multi_tracker_passwd );
+		os_config_write_string( "PXO", "SquadName", Multi_tracker_squad_name );
 	}
 
 	// save the ip address list
@@ -2214,12 +2208,12 @@ bool options_multi_ok_to_accept()
 
 /**
 * Called if the accept button on the main options screen was hit. 
-* Returns false if the multi option screen is not in a legal state
+* Also allows saving PXO credentials as "".
 **/
 void options_multi_accept()
 {	
 	// is it legal to leave this screen?
-	// The folowing check has been commented out for the following reasons:
+	// The following check has been commented out for the following reasons:
 	//   1) Retail never had such a check,
 	//   2) when starting PXO in multiplayer, the PXO lobby screen 
 	//      displays a warning if the login values are actually valid or not,

--- a/code/menuui/optionsmenumulti.cpp
+++ b/code/menuui/optionsmenumulti.cpp
@@ -243,8 +243,8 @@ UI_BUTTON Om_ip_button;										// button for detecting clicks on the ip addres
 UI_INPUTBOX Om_ip_input;									// input box for adding new ip addresses
 
 // setting vars
-int Om_local_broadcast;										// whether the player has local broadcast selected or not
-bool Om_tracker_flag;											// if the guy has the tracker selected
+bool Om_local_broadcast;										// whether the player has local broadcast selected or not
+bool Om_tracker_flag;											// whether the player has the PXO tracker selected
 int Om_protocol;												// protocol in use
 
 // load all the controls for the protocol section
@@ -378,9 +378,9 @@ UI_XSTR Om_gen_text[GR_NUM_RESOLUTIONS][OM_GEN_NUM_TEXT] = {
 
 // setting vars
 int Om_gen_obj_update;								// object update level
-int Om_gen_pix;										// accept pilot pix or not
-int Om_gen_xfer_multidata;							// xfer missions to multidata or not
-int Om_gen_flush_cache;								// flush multidata directory before every game
+bool Om_gen_pix;									// accept pilot pix or not
+bool Om_gen_xfer_multidata;							// xfer missions to multidata or not
+bool Om_gen_flush_cache;							// flush multidata directory before every game
 
 // load all the general tab controls
 void options_multi_load_gen_controls();
@@ -794,7 +794,7 @@ void options_multi_init_protocol_vars()
 	Om_protocol = Multi_options_g.protocol;
 
 	// whether or not the user has the local broadcast button selected
-	Om_local_broadcast = (Player->m_local_options.flags & MLO_FLAG_LOCAL_BROADCAST) ? 1 : 0;
+	Om_local_broadcast = (Player->m_local_options.flags & MLO_FLAG_LOCAL_BROADCAST);
 
 	// whether or not we're playing on the tracker
 	Om_tracker_flag = Multi_options_g.pxo;
@@ -864,7 +864,13 @@ void options_multi_protocol_do(int key)
 		}
 		// otherwise quit the options screen altogether
 		else {
+			// reaching this section is unlikely because
+			// escape key detection is already exectued 
+			// within options_menu_do_frame(),
+			// which runs before options_multi_do()
+			// --wookieejedi
 			options_cancel_exit();
+			return;
 		}
 		break;
 
@@ -926,28 +932,36 @@ void options_multi_protocol_accept()
 {
 	// if the user has selected local broadcast write it into his options struct
 	Player->m_local_options.flags &= ~(MLO_FLAG_LOCAL_BROADCAST);
-	if(Om_local_broadcast){
+	if (Om_local_broadcast) {
 		Player->m_local_options.flags |= MLO_FLAG_LOCAL_BROADCAST;
 	}	
+	options::OptionsManager::instance()->set_ingame_binary_option("Multi.LocalBroadcast", Om_local_broadcast);
 
 	// active protocol
 	Multi_options_g.protocol = Om_protocol;
 
 	// VMT status
 	Multi_options_g.pxo = Om_tracker_flag;
+	options::OptionsManager::instance()->set_ingame_binary_option("Multi.TogglePXO", Om_tracker_flag);
 
-	// copy the VMT login and password data
-	Om_tracker_login.get_text(Multi_tracker_login);
-	Om_tracker_passwd.get_text(Multi_tracker_passwd);
-	Om_tracker_squad_name.get_text(Multi_tracker_squad_name);
+	if (Multi_options_g.pxo) {
+		// copy the VMT login, password and PXO squad name data
+		Om_tracker_login.get_text(Multi_tracker_login);
+		Om_tracker_passwd.get_text(Multi_tracker_passwd);
+		Om_tracker_squad_name.get_text(Multi_tracker_squad_name);
 
-	// write out the tracker login and passwd values to the registry
-	os_config_write_string( "PXO", "Login", Multi_tracker_login );
-	os_config_write_string( "PXO", "Password", Multi_tracker_passwd );
+		// write out the tracker login, passwd, and PXO squad name values to the registry
+		if (strlen(Multi_tracker_login) > 0) {
+			os_config_write_string( "PXO", "Login", Multi_tracker_login );
+		}
+		if (strlen(Multi_tracker_passwd) > 0) {
+			os_config_write_string( "PXO", "Password", Multi_tracker_passwd );
+		}
+		if (strlen(Multi_tracker_squad_name) > 0) {
+			os_config_write_string( "PXO", "SquadName", Multi_tracker_squad_name );
+		}
+	}
 
-	// write out the PXO squad name and passwd values to the registry
-	os_config_write_string( "PXO", "SquadName", Multi_tracker_squad_name );
-	
 	// save the ip address list
 	options_multi_protocol_save_ip_file();
 }
@@ -1004,13 +1018,7 @@ void options_multi_protocol_button_pressed(int n)
 			break;
 		}
 
-		if(!Om_local_broadcast){			
-			Om_local_broadcast = 1;
-			options::OptionsManager::instance()->set_ingame_binary_option("Multi.LocalBroadcast", true);
-		} else {
-			Om_local_broadcast = 0;
-			options::OptionsManager::instance()->set_ingame_binary_option("Multi.LocalBroadcast", false);
-		}
+		Om_local_broadcast = !Om_local_broadcast;
 
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		break;
@@ -1051,12 +1059,10 @@ void options_multi_protocol_button_pressed(int n)
 			Om_tracker_login.enable();
 			Om_tracker_passwd.enable();
 			Om_tracker_squad_name.enable();
-			options::OptionsManager::instance()->set_ingame_binary_option("Multi.TogglePXO", true);
 		} else {
 			Om_tracker_login.disable();
 			Om_tracker_passwd.disable();
 			Om_tracker_squad_name.disable();
-			options::OptionsManager::instance()->set_ingame_binary_option("Multi.TogglePXO", false);
 		}
 
 		// play a sound
@@ -1369,25 +1375,13 @@ void options_multi_init_gen_vars()
 	Om_gen_obj_update = Player->m_local_options.obj_update_level;
 
 	// initialize the accept pix var	
-	if(Player->m_local_options.flags & MLO_FLAG_ACCEPT_PIX){
-		Om_gen_pix = 1;
-	} else {
-		Om_gen_pix = 0;
-	}
+	Om_gen_pix = (Player->m_local_options.flags & MLO_FLAG_ACCEPT_PIX);
 
 	// initialize the xfer_multidata var
-	if(Player->m_local_options.flags & MLO_FLAG_XFER_MULTIDATA){
-		Om_gen_xfer_multidata = 1;
-	} else {
-		Om_gen_xfer_multidata = 0;
-	}
+	Om_gen_xfer_multidata = (Player->m_local_options.flags & MLO_FLAG_XFER_MULTIDATA);
 
 	// initialize the flush cache var
-	if(Player->m_local_options.flags & MLO_FLAG_FLUSH_CACHE){
-		Om_gen_flush_cache = 1;
-	} else {
-		Om_gen_flush_cache = 0;
-	}
+	Om_gen_flush_cache = (Player->m_local_options.flags & MLO_FLAG_FLUSH_CACHE);
 }
 
 // accept function for the general tab
@@ -1407,12 +1401,14 @@ void options_multi_gen_accept()
 	if(Om_gen_xfer_multidata){
 		Player->m_local_options.flags |= MLO_FLAG_XFER_MULTIDATA;
 	} 
+	options::OptionsManager::instance()->set_ingame_binary_option("Multi.TransferMissions", Om_gen_xfer_multidata);
 
 	// apply the flush cache var
 	Player->m_local_options.flags &= ~(MLO_FLAG_FLUSH_CACHE);
 	if(Om_gen_flush_cache){
 		Player->m_local_options.flags |= MLO_FLAG_FLUSH_CACHE;
 	}
+	options::OptionsManager::instance()->set_ingame_binary_option("Multi.FlushCache", Om_gen_flush_cache);
 }
 
 // do frame for the general tab
@@ -1523,7 +1519,7 @@ void options_multi_gen_button_pressed(int n)
 	case OM_GEN_PIX_YES:
 		if(!Om_gen_pix){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-			Om_gen_pix = 1;
+			Om_gen_pix = true;
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -1533,7 +1529,7 @@ void options_multi_gen_button_pressed(int n)
 	case OM_GEN_PIX_NO:
 		if(Om_gen_pix){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-			Om_gen_pix = 0;
+			Om_gen_pix = false;
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -1543,8 +1539,7 @@ void options_multi_gen_button_pressed(int n)
 	case OM_GEN_XFER_MULTIDATA_YES:
 		if(!Om_gen_xfer_multidata){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-			Om_gen_xfer_multidata = 1;
-			options::OptionsManager::instance()->set_ingame_binary_option("Multi.TransferMissions", true);
+			Om_gen_xfer_multidata = true;
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -1554,8 +1549,7 @@ void options_multi_gen_button_pressed(int n)
 	case OM_GEN_XFER_MULTIDATA_NO:
 		if(Om_gen_xfer_multidata){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-			Om_gen_xfer_multidata = 0;
-			options::OptionsManager::instance()->set_ingame_binary_option("Multi.TransferMissions", false);
+			Om_gen_xfer_multidata = false;
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -1565,8 +1559,7 @@ void options_multi_gen_button_pressed(int n)
 	case OM_GEN_FLUSH_YES:
 		if(!Om_gen_flush_cache){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-			Om_gen_flush_cache = 1;
-			options::OptionsManager::instance()->set_ingame_binary_option("Multi.FlushCache", true);
+			Om_gen_flush_cache = true;
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -1576,8 +1569,7 @@ void options_multi_gen_button_pressed(int n)
 	case OM_GEN_FLUSH_NO:
 		if(Om_gen_flush_cache){
 			gamesnd_play_iface(InterfaceSounds::USER_SELECT);
-			Om_gen_flush_cache = 0;
-			options::OptionsManager::instance()->set_ingame_binary_option("Multi.FlushCache", false);
+			Om_gen_flush_cache = false;
 		} else {
 			gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 		}
@@ -2224,15 +2216,22 @@ bool options_multi_ok_to_accept()
 * Called if the accept button on the main options screen was hit. 
 * Returns false if the multi option screen is not in a legal state
 **/
-bool options_multi_accept()
+void options_multi_accept()
 {	
+	// is it legal to leave this screen?
+	// The folowing check has been commented out for the following reasons:
+	//   1) Retail never had such a check,
+	//   2) when starting PXO in multiplayer, the PXO lobby screen 
+	//      displays a warning if the login values are actually valid or not,
+	//   3) and not having this function be a bool allows for 
+	//      much more streamlined option managment, especially with in-game options.
+	// --wookieejedi and confirmed with taylor
+	//if (!options_multi_ok_to_accept()) {
+		//return false;
+	//}
+
 	// accept function for the protocol section
 	options_multi_protocol_accept();
-
-	// is it legal to leave this screen?
-	if (!options_multi_ok_to_accept()) {
-		return false;
-	}
 
 	// accept function for the general tab
 	options_multi_gen_accept();
@@ -2251,7 +2250,7 @@ bool options_multi_accept()
 		multi_options_update_local();
 	}
 
-	return true;
+	// recall that in-game option values get persisted/saved to file within options_accept() in optionsmenu.cpp
 }
 
 // called when the multiplayer tab is hit - initializes/switches all necessary data.

--- a/code/menuui/optionsmenumulti.cpp
+++ b/code/menuui/optionsmenumulti.cpp
@@ -944,17 +944,15 @@ void options_multi_protocol_accept()
 	Multi_options_g.pxo = Om_tracker_flag;
 	options::OptionsManager::instance()->set_ingame_binary_option("Multi.TogglePXO", Om_tracker_flag);
 
-	if (Multi_options_g.pxo) {
-		// copy the VMT login, password and PXO squad name data
-		Om_tracker_login.get_text(Multi_tracker_login);
-		Om_tracker_passwd.get_text(Multi_tracker_passwd);
-		Om_tracker_squad_name.get_text(Multi_tracker_squad_name);
+	// copy the VMT login, password and PXO squad name data
+	Om_tracker_login.get_text(Multi_tracker_login);
+	Om_tracker_passwd.get_text(Multi_tracker_passwd);
+	Om_tracker_squad_name.get_text(Multi_tracker_squad_name);
 
-		// write out the tracker login, passwd, and PXO squad name values to the registry
-		os_config_write_string( "PXO", "Login", Multi_tracker_login );
-		os_config_write_string( "PXO", "Password", Multi_tracker_passwd );
-		os_config_write_string( "PXO", "SquadName", Multi_tracker_squad_name );
-	}
+	// write out the tracker login, passwd, and PXO squad name values to the registry
+	os_config_write_string( "PXO", "Login", Multi_tracker_login );
+	os_config_write_string( "PXO", "Password", Multi_tracker_passwd );
+	os_config_write_string( "PXO", "SquadName", Multi_tracker_squad_name );
 
 	// save the ip address list
 	options_multi_protocol_save_ip_file();

--- a/code/menuui/optionsmenumulti.h
+++ b/code/menuui/optionsmenumulti.h
@@ -26,7 +26,7 @@ void options_multi_do(int key);
 void options_multi_close();
 
 // called if the accept button on the main options screen was hit
-bool options_multi_accept();
+void options_multi_accept();
 
 // called when the multiplayer tab is hit - initializes/switches all necessary data.
 // NOTE : this is different from the initialization function, which is called only when the options menu is started

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -56,7 +56,7 @@ auto TogglePXOOption __UNUSED = options::OptionBuilder<bool>("Multi.TogglePXO",
 									std::pair<const char*, int>{"Whether or not to play games on the local network or on PXO", 1809})
 									.category(std::make_pair("Multi", 1828))
 									.level(options::ExpertLevel::Beginner)
-									.default_val(true)
+									.default_val(false)  // false to match FSO defaults, will set to default when loading new pilots anyway
 									.bind_to(&Multi_options_g.pxo)
 									.importance(10)
 									.flags({options::OptionFlags::RetailBuiltinOption})
@@ -83,7 +83,7 @@ static bool local_broadcast_change(bool val, bool initial)
 		} else {
 			Player->m_local_options.flags |= MLO_FLAG_LOCAL_BROADCAST;
 		}
-		BroadcastGamesLocally = (Player->m_local_options.flags & MLO_FLAG_LOCAL_BROADCAST) ? 1 : 0;
+		BroadcastGamesLocally = (Player->m_local_options.flags & MLO_FLAG_LOCAL_BROADCAST);
 		return true;
 	}
 }
@@ -93,7 +93,7 @@ auto LocalBroadcastOption __UNUSED = options::OptionBuilder<bool>("Multi.LocalBr
 									std::pair<const char*, int>{"Whether or not to broadcast games on the local network", 1808})
 									.category(std::make_pair("Multi", 1828))
 									.level(options::ExpertLevel::Beginner)
-									.default_val(false)
+									.default_val(true) // true to match FSO defaults, will set to default when loading new pilots anyway
                                     .bind_to(&BroadcastGamesLocally)
 									.change_listener(local_broadcast_change)
 									.importance(10)
@@ -112,12 +112,12 @@ static bool flush_cache_change(bool val, bool initial)
 		} else {
 			Player->m_local_options.flags |= MLO_FLAG_FLUSH_CACHE;
 		}
-		AlwaysFlushCache = (Player->m_local_options.flags & MLO_FLAG_FLUSH_CACHE) ? 1 : 0;
+		AlwaysFlushCache = (Player->m_local_options.flags & MLO_FLAG_FLUSH_CACHE);
 		return true;
 	}
 }
 
-static SCP_string flush_cache_display(bool mode) { return mode ? XSTR("Never", 1400) : XSTR("Before Game", 1401); }
+static SCP_string flush_cache_display(bool mode) { return mode ? XSTR("Before Game", 1401) : XSTR("Never", 1400); }
 
 auto FlushCacheOption __UNUSED = options::OptionBuilder<bool>("Multi.FlushCache",
 									std::pair<const char*, int>{"Flush Cache", 1399},
@@ -144,7 +144,7 @@ static bool transfer_missions_change(bool val, bool initial)
 		} else {
 			Player->m_local_options.flags |= MLO_FLAG_XFER_MULTIDATA;
 		}
-		CacheMissionsToMultidata = (Player->m_local_options.flags & MLO_FLAG_XFER_MULTIDATA) ? 1 : 0;
+		CacheMissionsToMultidata = (Player->m_local_options.flags & MLO_FLAG_XFER_MULTIDATA);
 		return true;
 	}
 }
@@ -486,9 +486,9 @@ void multi_options_local_load(multi_local_options *options, net_player *pxo_pl)
 // fill out the in-game options local globals using the player data
 void multi_options_init_globals()
 {
-	BroadcastGamesLocally = (Player->m_local_options.flags & MLO_FLAG_LOCAL_BROADCAST) ? 1 : 0;
-	AlwaysFlushCache = (Player->m_local_options.flags & MLO_FLAG_FLUSH_CACHE) ? 1 : 0;
-	CacheMissionsToMultidata = (Player->m_local_options.flags & MLO_FLAG_XFER_MULTIDATA) ? 1 : 0;
+	BroadcastGamesLocally = (Player->m_local_options.flags & MLO_FLAG_LOCAL_BROADCAST);
+	AlwaysFlushCache = (Player->m_local_options.flags & MLO_FLAG_FLUSH_CACHE);
+	CacheMissionsToMultidata = (Player->m_local_options.flags & MLO_FLAG_XFER_MULTIDATA);
 }
 
 // add data from a multi_server_options struct

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -37,6 +37,7 @@
 #include "io/timer.h"
 #include "inetfile/inetgetfile.h"
 #include "cfile/cfilesystem.h"
+#include "options/OptionsManager.h"
 #include "osapi/osregistry.h"
 #include "parse/parselo.h"
 #include "stats/scoring.h"
@@ -1350,8 +1351,14 @@ void multi_pxo_do_normal(bool api_access)
 					case 0:
 						nprintf(("Network","PXO CANCEL\n"));
 
-						// flip his "pxo" bit temporarily and push him to the join game screen
+						// flip player "pxo" off and push to the join game screen,
+						// they will have to follow the instructions above to toggle PXO back on
+						// and since player is accepting, we need to persist changes
 						Multi_options_g.pxo = false;
+						options::OptionsManager::instance()->set_ingame_binary_option("Multi.TogglePXO", false);
+						if (Using_in_game_options) {
+							options::OptionsManager::instance()->persistChanges();
+						}
 						// Net_game_tcp_mode = NET_TCP;
 						gameseq_post_event(GS_EVENT_MULTI_JOIN_GAME);
 						break;

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -416,8 +416,10 @@ void pilotfile::plr_read_multiplayer()
 	p->m_local_options.flags = handler->readInt("local_flags");
 	p->m_local_options.obj_update_level = handler->readInt("obj_update_level");
 
-	//Make sure the local games multi option is reflected by the OptionsManager
-	options::OptionsManager::instance()->set_ingame_binary_option("Multi.LocalBroadcast", (p->m_local_options.flags & MLO_FLAG_LOCAL_BROADCAST) != 0);
+	// Make sure multi options from player file are reflected by the OptionsManager
+	options::OptionsManager::instance()->set_ingame_binary_option("Multi.LocalBroadcast", (p->m_local_options.flags & MLO_FLAG_LOCAL_BROADCAST));
+	options::OptionsManager::instance()->set_ingame_binary_option("Multi.FlushCache", (p->m_local_options.flags & MLO_FLAG_FLUSH_CACHE));
+	options::OptionsManager::instance()->set_ingame_binary_option("Multi.TransferMissions", (p->m_local_options.flags & MLO_FLAG_XFER_MULTIDATA));
 
 	// netgame protocol
 	Multi_options_g.protocol = handler->readInt("protocol");
@@ -425,6 +427,8 @@ void pilotfile::plr_read_multiplayer()
 	if (Multi_options_g.protocol == NET_VMT) {
 		Multi_options_g.protocol = NET_TCP;
 		Multi_options_g.pxo = true;
+		// also update PXO in-game value
+		options::OptionsManager::instance()->set_ingame_binary_option("Multi.TogglePXO", Multi_options_g.pxo);
 	} else if (Multi_options_g.protocol != NET_TCP) {
 		Multi_options_g.protocol = NET_TCP;
 	}


### PR DESCRIPTION
Follow-up to #6595. 
Currently there are many options that do not get discarded/reverted when pressing the escape button while in the options menu (all other screens I tested properly discarded changes when pressing escape). I had thought I would have to make a backup function for every slider and value that was not getting properly discard, but it turns out the reason they were not getting properly discarded is b/c the rest of the on frame function was setting them after the escape button section.

Tested and works as expected. 

EDIT: This PR does a few things

1) Makes all discard behavior consistent with the options tabs using the following protocols: Escape will close the screen and discard changes by default (just as it has been for most options). Pressing a button to navigate to any other screen, such as Controls or HUD, saves the options (which is also what FSO did before, but this PR makes it consistent for all options, mainly the multi tab). 

2) Clean-up the options and multi options values to be properly synced with their in-game option counterparts, including accounting for the discarding protocols stated above. The bulk of these updates were in the multi options, but the detail and main options got fixes, too. 