### PR TITLE
refactor ship_get_eye

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -568,7 +568,7 @@ warp_camera::warp_camera(object *objp)
 
 	vec3d object_pos = objp->pos;
 	matrix tmp;
-	ship_get_eye(&object_pos, &tmp, objp);
+	object_get_eye(&object_pos, &tmp, objp);
 
 	vm_vec_scale_add2( &object_pos, &Player_obj->orient.vec.rvec, 0.0f );
 	vm_vec_scale_add2( &object_pos, &Player_obj->orient.vec.uvec, 0.952f );

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -578,13 +578,9 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp)
 
 		factor = -target_sip->closeup_pos_targetbox.xyz.z;
 
-		// use the player's up vector, and construct the viewers orientation matrix
-		if (Player_obj->type == OBJ_SHIP) {
-			vec3d tempv;
-			ship_get_eye(&tempv, &camera_orient, Player_obj, false, false);
-		} else {
-			camera_orient = Player_obj->orient;
-		}
+		// use the player's up vector, and construct the viewer's orientation matrix
+		vec3d tempv;
+		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 		up_vector = camera_orient.vec.uvec;
 		vm_vector_2_matrix(&camera_orient,&orient_vec,&up_vector,NULL);
@@ -757,13 +753,9 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 
 		factor = 2*target_objp->radius;
 
-		// use the player's up vector, and construct the viewers orientation matrix
-		if (Player_obj->type == OBJ_SHIP) {
-			vec3d tempv;
-			ship_get_eye(&tempv, &camera_orient, Player_obj, false, false);
-		} else {
-			camera_orient = Player_obj->orient;
-		}
+		// use the player's up vector, and construct the viewer's orientation matrix
+		vec3d tempv;
+		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 		up_vector = camera_orient.vec.uvec;
 		vm_vector_2_matrix(&camera_orient,&orient_vec,&up_vector,NULL);
@@ -921,13 +913,9 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 			vm_vec_normalize(&projection_vec);
 		}
 
-		// use the viewer's up vector, and construct the viewers orientation matrix
-		if (viewer_obj == Player_obj && Player_obj->type == OBJ_SHIP) {
-			vec3d tempv;
-			ship_get_eye(&tempv, &camera_orient, Player_obj, false, false);
-		} else {
-			camera_orient = viewer_obj->orient;
-		}
+		// use the viewer's up vector, and construct the viewer's orientation matrix
+		vec3d tempv;
+		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 		up_vector = camera_orient.vec.uvec;
 
@@ -1155,13 +1143,9 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 
 		factor = 2*target_objp->radius;
 
-		// use the player's up vector, and construct the viewers orientation matrix
-		if (Player_obj->type == OBJ_SHIP) {
-			vec3d tempv;
-			ship_get_eye(&tempv, &camera_orient, Player_obj, false, false);
-		} else {
-			camera_orient = Player_obj->orient;
-		}
+		// use the player's up vector, and construct the viewer's orientation matrix
+		vec3d tempv;
+		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 		up_vector = camera_orient.vec.uvec;
 		vm_vector_2_matrix(&camera_orient,&orient_vec,&up_vector,NULL);
@@ -1296,13 +1280,9 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 
 			factor = target_objp->radius*4.0f;
 
-			// use the player's up vector, and construct the viewers orientation matrix
-			if (Player_obj->type == OBJ_SHIP) {
-				vec3d tempv;
-				ship_get_eye(&tempv, &camera_orient, Player_obj, false, false);
-			} else {
-				camera_orient = Player_obj->orient;
-			}
+			// use the player's up vector, and construct the viewer's orientation matrix
+			vec3d tempv;
+			object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
 			up_vector = camera_orient.vec.uvec;
 			vm_vector_2_matrix(&camera_orient,&orient_vec,&up_vector,NULL);

--- a/code/observer/observer.cpp
+++ b/code/observer/observer.cpp
@@ -95,11 +95,3 @@ void observer_delete(object *obj)
 	Observers[num].target_objnum = -1;
 	Observers[num].flags = 0;           // mark it as being free
 }
-
-// get the eye position and orientation for the passed observer object
-void observer_get_eye(vec3d *eye_pos, matrix *eye_orient, object *obj)
-{
-	// copy in the observer position and orientation
-	memcpy(eye_pos,&obj->pos,sizeof(vec3d));
-	memcpy(eye_orient,&obj->orient,sizeof(matrix));
-}

--- a/code/observer/observer.h
+++ b/code/observer/observer.h
@@ -37,7 +37,4 @@ void observer_init();
 int observer_create(matrix *orient, vec3d *pos);  // returns objnum
 void observer_delete(object *obj);
 
-// get the eye position and orientation for the passed observer object
-void observer_get_eye(vec3d *eye_pos, matrix *eye_orient, object *obj);
-
 #endif

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -492,7 +492,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 
 	// If Framerate_independent_turning is on, AI don't use CI to turn
 	if (!Framerate_independent_turning || IS_MAT_NULL(&pi->ai_desired_orient)){
-		if (!Flight_controls_follow_eyepoint_orientation || (Player_obj == nullptr) || (Player_obj->type != OBJ_SHIP)) {
+		if (!Flight_controls_follow_eyepoint_orientation || (Player_obj == nullptr)) {
 			// Default behavior; eyepoint orientation has no effect on controls
 			pi->desired_rotvel.xyz.x = ci->pitch * pi->max_rotvel.xyz.x;
 			pi->desired_rotvel.xyz.y = ci->heading * pi->max_rotvel.xyz.y;
@@ -502,7 +502,7 @@ void physics_read_flying_controls( matrix * orient, physics_info * pi, control_i
 			vec3d tmp_vec, new_rotvel;
 			matrix tmp_mat, eyemat, rotvelmat;
 
-			ship_get_eye(&tmp_vec, &eyemat, Player_obj, false);
+			object_get_eye(&tmp_vec, &eyemat, Player_obj, false);
 
 			vm_copy_transpose(&tmp_mat, &Player_obj->orient);
 			vm_matrix_x_matrix(&rotvelmat, &tmp_mat, &eyemat);

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -2268,10 +2268,8 @@ camid player_get_cam()
 			if (Viewer_mode & VM_OTHER_SHIP) {
 				//	View from target.
 				viewer_obj = &Objects[Player_ai->target_objnum];
-				if ( viewer_obj->type == OBJ_SHIP ) {
-					ship_get_eye( &eye_pos, &eye_orient, viewer_obj );
-					view_from_player = 0;
-				}
+				object_get_eye( &eye_pos, &eye_orient, viewer_obj );
+				view_from_player = 0;
 			}
 
 			if ( view_from_player ) {
@@ -2385,20 +2383,8 @@ camid player_get_cam()
 			vm_vector_2_matrix(&eye_orient, &tmp_dir, &Player_obj->orient.vec.uvec, NULL);
 			viewer_obj = NULL;
 		} else {
-			// get an eye position based upon the correct type of object
-			switch(viewer_obj->type)
-			{
-				case OBJ_SHIP:
-					// make a call to get the eye point for the player object
-					ship_get_eye( &eye_pos, &eye_orient, viewer_obj );
-					break;
-				case OBJ_OBSERVER:
-					// make a call to get the eye point for the player object
-					observer_get_eye( &eye_pos, &eye_orient, viewer_obj );				
-					break;
-				default :
-					Int3();
-			}			
+			// get an eye position for the player object
+			object_get_eye( &eye_pos, &eye_orient, viewer_obj );
 		}
 	}
 

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -245,11 +245,7 @@ void radar_plot_object( object *objp )
 
 	// Retrieve the eye orientation so we can position the blips relative to it
 	matrix eye_orient;
-
-	if (Player_obj->type == OBJ_SHIP) 
-		ship_get_eye(&tempv, &eye_orient, Player_obj, false , false);
-	else
-		eye_orient = Player_obj->orient;
+	object_get_eye(&tempv, &eye_orient, Player_obj, false);
 
 	// JAS -- new way of getting the rotated point that doesn't require this to be
 	// in a g3_start_frame/end_frame block.

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8169,7 +8169,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 
 	vec3d eye_pos, eye_offset, leaning_backup = leaning_position;
 	matrix eye_orient;
-	ship_get_eye(&eye_pos, &eye_orient, objp, true, true);
+	object_get_eye(&eye_pos, &eye_orient, objp, true, true, false);
 	if (cam_offset != nullptr) {
 		vec3d offset_local;
 		vm_vec_unrotate(&offset_local, cam_offset, &eye_orient);
@@ -15203,7 +15203,7 @@ static void ship_set_eye( object *obj, int eye_index)
 // The position of the eye is returned in the parameter 'eye_pos'.  The orientation of the
 // eye is returned in 'eye_orient'.  (NOTE: this is kind of bogus for now since non 0th element
 // eyes have no defined up vector)
-void ship_get_eye(vec3d *eye_pos, matrix *eye_orient, const object *obj, bool do_slew, bool local_pos, bool local_orient)
+void object_get_eye(vec3d *eye_pos, matrix *eye_orient, const object *obj, bool do_slew, bool local_pos, bool local_orient)
 {
 	auto pmi = object_get_model_instance(obj);
 	auto pm = object_get_model(obj);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8169,7 +8169,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 
 	vec3d eye_pos, eye_offset, leaning_backup = leaning_position;
 	matrix eye_orient;
-	ship_get_eye_local(&eye_pos, &eye_orient, objp);
+	ship_get_eye(&eye_pos, &eye_orient, objp, true, true);
 	if (cam_offset != nullptr) {
 		vec3d offset_local;
 		vm_vec_unrotate(&offset_local, cam_offset, &eye_orient);
@@ -15197,83 +15197,34 @@ static void ship_set_eye( object *obj, int eye_index)
 	shipp->current_viewpoint = eye_index;
 }
 
-// calculates the eye position for this ship in the global reference frame.  Uses the
+// Calculates the eye position for this object (which is usually a ship, but doesn't have to be)
+// in the global (by default), partial local, or full local reference frame.  Uses the
 // view_positions array in the model.  The 0th element is the normal viewing position.
-// the vector of the eye is returned in the parameter 'eye'.  The orientation of the
-// eye is returned in orient.  (NOTE: this is kind of bogus for now since non 0th element
+// The position of the eye is returned in the parameter 'eye_pos'.  The orientation of the
+// eye is returned in 'eye_orient'.  (NOTE: this is kind of bogus for now since non 0th element
 // eyes have no defined up vector)
-void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew , bool from_origin)
+void ship_get_eye(vec3d *eye_pos, matrix *eye_orient, const object *obj, bool do_slew, bool local_pos, bool local_orient)
 {
-	Assertion(obj->type == OBJ_SHIP, "Only ships can have eye positions!");
+	auto pmi = object_get_model_instance(obj);
+	auto pm = object_get_model(obj);
 
-	ship *shipp = &Ships[obj->instance];
-	auto pmi = model_get_instance(shipp->model_instance_num);
-	auto pm = model_get(pmi->model_num);
+	int current_viewpoint = (obj->type == OBJ_SHIP) ? Ships[obj->instance].current_viewpoint : 0;
 
-	// check to be sure that we have a view eye to look at.....spit out nasty debug message
-	if ( shipp->current_viewpoint < 0 || pm->n_view_positions == 0 || shipp->current_viewpoint > pm->n_view_positions) {
-		*eye_pos = obj->pos;
-		*eye_orient = obj->orient;
+	// if no viewpoints, or invalid viewpoint, return the origin
+	if (!pm || (pm->n_view_positions <= 0) || (current_viewpoint < 0) || (current_viewpoint >= pm->n_view_positions)) {
+		*eye_pos = local_pos ? vmd_zero_vector : obj->pos;
+		*eye_orient = local_orient ? vmd_identity_matrix : obj->orient;
 		return;
 	}
 
-	// eye points are stored in an array -- the normal viewing position for a ship is the current_eye_index
-	// element.
-	eye *ep = &(pm->view_positions[shipp->current_viewpoint]);
+	// eye points are stored in an array -- the normal viewing position for a ship is the current_eye_index (now current_viewpoint) element.
+	auto &ep = pm->view_positions[current_viewpoint];
 
-	if (ep->parent >= 0 && ep->parent < pm->n_models && pm->submodel[ep->parent].flags[Model::Submodel_flags::Can_move]) {
-		model_instance_local_to_global_point_orient(eye_pos, eye_orient, &ep->pnt, &vmd_identity_matrix, pm, pmi, ep->parent);
-		vec3d tvec = *eye_pos;
-		vm_vec_unrotate(eye_pos, &tvec, &obj->orient);
-		vm_vec_add2(eye_pos, &obj->pos);
-
-		matrix tempmat = *eye_orient;
-		vm_matrix_x_matrix(eye_orient, &obj->orient, &tempmat);
-	} else {
-		model_instance_local_to_global_point( eye_pos, &ep->pnt, shipp->model_instance_num, ep->parent, &obj->orient, from_origin ? &vmd_zero_vector : &obj->pos );
-		*eye_orient = obj->orient;
-	}
+	matrix eye_local_orient;
+	vm_vector_2_matrix_norm(&eye_local_orient, &ep.norm);
+	model_instance_local_to_global_point_orient(eye_pos, eye_orient, &ep.pnt, &eye_local_orient, pm, pmi, ep.parent, local_orient ? &vmd_identity_matrix : &obj->orient, local_pos ? &vmd_zero_vector : &obj->pos);
 
 	//	Modify the orientation based on head orientation.
-	if ( Viewer_obj == obj && do_slew) {
-		// Add the cockpit leaning translation offset
-		vm_vec_add2(eye_pos,&leaning_position);
-		compute_slew_matrix(eye_orient, &Viewer_slew_angles);
-	}
-}
-
-// calculates the eye position for this ship in the ships reference frame, but rotated along.  Uses the
-// view_positions array in the model.  The 0th element is the normal viewing position.
-// the vector of the eye is returned in the parameter 'eye'.  The orientation of the
-// eye is returned in orient.
-void ship_get_eye_local(vec3d* eye_pos, matrix* eye_orient, object* obj, bool do_slew)
-{
-	Assertion(obj->type == OBJ_SHIP, "Only ships can have eye positions!");
-
-	ship* shipp = &Ships[obj->instance];
-	auto pmi = model_get_instance(shipp->model_instance_num);
-	auto pm = model_get(pmi->model_num);
-
-	// check to be sure that we have a view eye to look at.....spit out nasty debug message
-	if (shipp->current_viewpoint < 0 || pm->n_view_positions == 0 || shipp->current_viewpoint > pm->n_view_positions) {
-		*eye_pos = ZERO_VECTOR;
-		*eye_orient = IDENTITY_MATRIX;
-		return;
-	}
-
-	// eye points are stored in an array -- the normal viewing position for a ship is
-	// the current_eye_index element.
-	eye* ep = &(pm->view_positions[shipp->current_viewpoint]);
-
-	if (ep->parent >= 0 && pm->submodel[ep->parent].flags[Model::Submodel_flags::Can_move]) {
-		model_instance_local_to_global_point_orient(eye_pos, eye_orient, &ep->pnt, &vmd_identity_matrix, pm, pmi, ep->parent, &obj->orient, &vmd_zero_vector);
-	}
-	else {
-		model_local_to_global_point(eye_pos, &ep->pnt, Ship_info[shipp->ship_info_index].model_num, ep->parent, &obj->orient, &vmd_zero_vector);
-		*eye_orient = obj->orient;
-	}
-
-	// Modify the orientation based on head orientation.
 	if (Viewer_obj == obj && do_slew) {
 		// Add the cockpit leaning translation offset
 		vm_vec_add2(eye_pos, &leaning_position);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1784,8 +1784,7 @@ extern int ship_find_num_crewpoints(object *objp);
 extern int ship_find_num_turrets(object *objp);
 
 extern void compute_slew_matrix(matrix *orient, angles *a);
-extern void ship_get_eye( vec3d *eye_pos, matrix *eye_orient, object *obj, bool do_slew = true, bool from_origin = false);		// returns in eye the correct viewing position for the given object
-extern void ship_get_eye_local(vec3d* eye_pos, matrix* eye_orient, object* obj, bool do_slew = true);		// returns the eye data, local to the ship
+extern void ship_get_eye(vec3d *eye_pos, matrix *eye_orient, const object *obj, bool do_slew = true, bool local_pos = false, bool local_orient = false);
 
 extern ship_subsys *ship_find_first_subsys(ship *sp, int subsys_type, const vec3d *attacker_pos = nullptr);
 extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns index'th subsystem of this ship

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1784,7 +1784,7 @@ extern int ship_find_num_crewpoints(object *objp);
 extern int ship_find_num_turrets(object *objp);
 
 extern void compute_slew_matrix(matrix *orient, angles *a);
-extern void ship_get_eye(vec3d *eye_pos, matrix *eye_orient, const object *obj, bool do_slew = true, bool local_pos = false, bool local_orient = false);
+extern void object_get_eye(vec3d *eye_pos, matrix *eye_orient, const object *obj, bool do_slew = true, bool local_pos = false, bool local_orient = false);
 
 extern ship_subsys *ship_find_first_subsys(ship *sp, int subsys_type, const vec3d *attacker_pos = nullptr);
 extern ship_subsys *ship_get_indexed_subsys(ship *sp, int index);	// returns index'th subsystem of this ship

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -862,7 +862,7 @@ bool shipfx_eye_in_shadow( vec3d *eye_pos, object * src_obj, int light_n )
 				vm_vec_scale_add( &rp1, &rp0, &light_dir, Viewer_obj->radius*2.0f );
 				vec3d pos,eye_posi;
 				matrix eye_ori;
-				ship_get_eye(&eye_posi, &eye_ori, Viewer_obj, false);
+				object_get_eye(&eye_posi, &eye_ori, Viewer_obj, false);
 				vm_vec_unrotate(&pos, &sip->cockpit_offset, &eye_ori);
 				vm_vec_add2(&pos, &eye_posi);
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3202,11 +3202,8 @@ camid game_render_frame_setup()
 			if (Viewer_mode & VM_OTHER_SHIP) {
 				//	View from target.
 				Viewer_obj = &Objects[Player_ai->target_objnum];
-
-				if ( Viewer_obj->type == OBJ_SHIP ) {
-					ship_get_eye( &eye_pos, &eye_orient, Viewer_obj );
-					view_from_player = 0;
-				}
+				object_get_eye( &eye_pos, &eye_orient, Viewer_obj );
+				view_from_player = 0;
 			}
 
 			if(Viewer_obj)
@@ -3313,13 +3310,13 @@ camid game_render_frame_setup()
 
 			} else if ( Viewer_mode & VM_CHASE ) {
 				if (Viewer_obj->type != OBJ_SHIP)
-					observer_get_eye(&eye_pos, &eye_orient, Viewer_obj);
+					object_get_eye(&eye_pos, &eye_orient, Viewer_obj);
 				else {
 					vec3d aim_pt;
 
 					vec3d tmp_up;
 					matrix eyemat;
-					ship_get_eye(&tmp_up, &eyemat, Viewer_obj, false, false);
+					object_get_eye(&tmp_up, &eyemat, Viewer_obj, false);	// slew is computed at the bottom of the block
 
 					eye_pos = Viewer_obj->pos;
 
@@ -3406,19 +3403,8 @@ camid game_render_frame_setup()
 					vm_angles_2_matrix(&eye_orient, &rot_angles);
 					Viewer_obj = nullptr;
 			} else {
-				// get an eye position based upon the correct type of object
-				switch(Viewer_obj->type){
-				case OBJ_SHIP:
-					// make a call to get the eye point for the player object
-					ship_get_eye( &eye_pos, &eye_orient, Viewer_obj );
-					break;
-				case OBJ_OBSERVER:
-					// make a call to get the eye point for the player object
-					observer_get_eye( &eye_pos, &eye_orient, Viewer_obj );					
-					break;
-				default :
-					Error(LOCATION, "Invalid Value for Viewer_obj->type. Expected values are OBJ_SHIP (1) and OBJ_OBSERVER (12), we encountered %d. Please tell a coder.\n", Viewer_obj->type);
-				}
+				// get an eye position for the player object
+				object_get_eye( &eye_pos, &eye_orient, Viewer_obj );
 			}
 		}
 	}


### PR DESCRIPTION
1. Allow `ship_get_eye` to be used for any objects, not just ships
2. Remove the unused `from_origin` parameter and change it to `local_reference_frame`
3. Simplify the implementation and take advantage of upgrades to `model_instance_local_to_global_*` functions
4. Consolidate `ship_get_eye_local` into `ship_get_eye`

This is a prerequisite to an upcoming PR by LuytenKy.