### PR TITLE
Model eyepoint for set camera host flag

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -210,24 +210,34 @@ void camera::set_object_host(object *objp, int n_object_host_submodel)
 	object_host_submodel = n_object_host_submodel;
 	set_custom_position_function(NULL);
 	set_custom_orientation_function(NULL);
-	if(n_object_host_submodel > 0)
+
+	if (n_object_host_submodel >= 0 && objp != nullptr && objp->type == OBJ_SHIP) 
 	{
-		if(objp != nullptr && objp->type == OBJ_SHIP)
+		ship_subsys* ssp = GET_FIRST(&Ships[objp->instance].subsys_list);
+		while (ssp != END_OF_LIST(&Ships[objp->instance].subsys_list)) 
 		{
-			ship_subsys* ssp = GET_FIRST(&Ships[objp->instance].subsys_list);
-			while ( ssp != END_OF_LIST( &Ships[objp->instance].subsys_list ) )
+			if (ssp->system_info->subobj_num == n_object_host_submodel) 
 			{
-				if(ssp->system_info->subobj_num == n_object_host_submodel)
+				if (ssp->system_info->type == SUBSYSTEM_TURRET) 
 				{
-					if(ssp->system_info->type == SUBSYSTEM_TURRET)
-					{
-						set_custom_position_function(get_turret_cam_pos);
-						set_custom_orientation_function(get_turret_cam_orient);
-					}
+					set_custom_position_function(get_turret_cam_pos);
+					set_custom_orientation_function(get_turret_cam_orient);
 				}
-				ssp = GET_NEXT( ssp );
 			}
+			ssp = GET_NEXT(ssp);
 		}
+	}
+	else if (Use_model_eyepoint_for_set_camera_host && object_host.isValid()) 
+	{
+		const object* host = object_host.objp();
+
+		vec3d eye_pos;
+		matrix eye_orient;
+
+		object_get_eye(&eye_pos, &eye_orient, host, false, true, true);
+
+		set_position(&eye_pos);
+		set_rotation(&eye_orient);
 	}
 }
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -34,6 +34,7 @@ bool Cutscene_camera_displays_hud;
 bool Alternate_chaining_behavior;
 bool Fixed_chaining_to_repeat;
 bool Use_host_orientation_for_set_camera_facing;
+bool Use_model_eyepoint_for_set_camera_host;
 bool Always_show_directive_value_count;
 bool Use_3d_ship_select;
 bool Use_3d_ship_icons;
@@ -160,6 +161,7 @@ bool Fix_scripted_velocity;
 color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 bool Preload_briefing_icon_models;
 EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
+
 
 #ifdef WITH_DISCORD
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Game.Discord",
@@ -503,6 +505,13 @@ void parse_mod_table(const char *filename)
 				} else {
 					mprintf(("Game Settings Table: Using identity orientation for set-camera-facing\n"));
 				}
+			}
+
+			if (optional_string("$Use model eyepoint for set-camera-host:")) 
+			{
+				stuff_boolean(&Use_model_eyepoint_for_set_camera_host);
+				if (Use_model_eyepoint_for_set_camera_host)
+					mprintf(("Game Settings Table: Use model eyepoint for set-camera-host\n"));
 			}
 
 			if (optional_string("$Show-subtitle uses pixels:")) {
@@ -1561,6 +1570,7 @@ void mod_table_reset()
 	Alternate_chaining_behavior = false;
 	Fixed_chaining_to_repeat = false;
 	Use_host_orientation_for_set_camera_facing = false;
+	Use_model_eyepoint_for_set_camera_host = false;
 	Always_show_directive_value_count = false;
 	Default_ship_select_effect = 2;
 	Default_weapon_select_effect = 2;
@@ -1714,5 +1724,8 @@ void mod_table_set_version_flags()
 	}
 	if (mod_supports_version(24, 2, 0)) {
 		Fix_scripted_velocity = true;		// more sensical behavior
+	}
+	if (mod_supports_version(25, 0, 0)) {
+		Use_model_eyepoint_for_set_camera_host = true;
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -48,6 +48,7 @@ extern bool Cutscene_camera_displays_hud;
 extern bool Alternate_chaining_behavior;
 extern bool Fixed_chaining_to_repeat;
 extern bool Use_host_orientation_for_set_camera_facing;
+extern bool Use_model_eyepoint_for_set_camera_host;
 extern bool Always_show_directive_value_count;
 extern bool Use_3d_ship_select;
 extern int Default_ship_select_effect;


### PR DESCRIPTION
Original issue post https://github.com/scp-fs2open/fs2open.github.com/issues/6509. This flag controls if set-camera-host sexp uses the model's eyepoint for the camera position and orientation when no submodel is specified.
Without the flag, the camera will use the model's origin position and orientation.