### PR TITLE
Fix particle name assignment when using legacy-type composite effects that address child effects by name

### DIFF
--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -378,7 +378,12 @@ namespace particle {
 					error_display(0, "Unknown particle effect name '%s' encountered!", newName.c_str());
 				}
 
-				return ParticleManager::get()->getEffect(index);
+				auto effect = ParticleManager::get()->getEffect(index);
+				if (!effect.empty()) {
+					effect.front().m_name = name;
+				}
+
+				return effect;
 			}
 
 			ParticleEffectLegacyType type = parseLegacyEffectType();


### PR DESCRIPTION
Turns out, in this specific case, the name of the main (i.e. front) particle wasn't correctly set (but rather taken from the source effect), as such giving the particle an incorrect name in this case.
Followup to #6465.