### PR TITLE
several fixes to ship sparks

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6920,8 +6920,8 @@ void ship::clear()
 
 	next_fireball = timestamp(-1);
 	next_hit_spark = timestamp(-1);
-	num_hits = 0;
-	memset(sparks, 0, MAX_SHIP_HITS * sizeof(ship_spark));
+	num_sparks = 0;
+	memset(sparks, 0, MAX_SHIP_SPARKS * sizeof(ship_spark));
 
 	use_special_explosion = false;
 	special_exp_damage = -1;
@@ -11589,8 +11589,8 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	if (!(Fred_running) && (Game_mode & GM_IN_MISSION)) {	// Doing this effort only makes sense in the middle of a mission.
 		// Delete ship sparks if the model changed
 		if (sip_orig->model_num != sip->model_num) {
-			memset(sp->sparks, 0, MAX_SHIP_HITS * sizeof(ship_spark));
-			sp->num_hits = 0;
+			memset(sp->sparks, 0, MAX_SHIP_SPARKS * sizeof(ship_spark));
+			sp->num_sparks = 0;
 		}
 
 		for (i = 0; i < MAX_AI_INFO; i++) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -57,8 +57,7 @@ extern vec3d	Original_vec_to_deader;
 #define WEAPON_RESERVE_THRESHOLD		0.01f	// energy threshold where ship is considered to have no weapon energy system
 #define SUBSYS_MAX_HITS_THRESHOLD		0.01f	// max_hits threshold where subsys is considered to take damage
 
-#define	HP_SCALE						1.2			//	1.2 means die when 20% of hits remaining
-#define	MAX_SHIP_HITS				8				// hits to kill a ship
+#define	MAX_SHIP_SPARKS			8				// maximum number of spark emitters on a ship
 #define	MAX_SHIP_DETAIL_LEVELS	5				// maximum detail levels that a ship can render at
 #define	MAX_REINFORCEMENTS		32
 
@@ -594,8 +593,8 @@ public:
 	int	next_fireball;
 
 	int	next_hit_spark;
-	int	num_hits;			//	Note, this is the number of spark emitter positions!
-	ship_spark	sparks[MAX_SHIP_HITS];
+	int	num_sparks;			//	Note, this is the number of spark emitter positions!
+	ship_spark	sparks[MAX_SHIP_SPARKS];
 	
 	bool use_special_explosion; 
 	int special_exp_damage;					// new special explosion/hitpoints system

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -72,11 +72,11 @@ static void shipfx_remove_submodel_ship_sparks(ship* shipp, int submodel_num)
 	Assert(submodel_num != -1);
 
 	// maybe no active sparks on submodel
-	if (shipp->num_hits == 0) {
+	if (shipp->num_sparks == 0) {
 		return;
 	}
 
-	for (int spark_num = 0; spark_num < shipp->num_hits; spark_num++) {
+	for (int spark_num = 0; spark_num < shipp->num_sparks; spark_num++) {
 		if (shipp->sparks[spark_num].submodel_num == submodel_num) {
 			shipp->sparks[spark_num].end_time = timestamp(1);
 		}
@@ -1179,7 +1179,7 @@ void shipfx_emit_spark( int n, int sn )
 	if(sn < 0 && !sip->damage_spew.isValid())
 		return;
 	
-	if ( shipp->num_hits <= 0 )
+	if ( shipp->num_sparks <= 0 )
 		return;
 
 	obj = &Objects[shipp->objnum];
@@ -1195,7 +1195,7 @@ void shipfx_emit_spark( int n, int sn )
 
 	int spark_num;
 	if ( sn == -1 ) {
-		spark_num = Random::next(shipp->num_hits);
+		spark_num = Random::next(shipp->num_sparks);
 	} else {
 		spark_num = sn;
 	}


### PR DESCRIPTION
1. Refactor `num_hits` to `num_sparks` and `MAX_SHIP_HITS` to `MAX_SHIP_SPARKS` to be consistent with their current (since FS1 pre-release) usage.
2. Remove the unused `HP_SCALE`.
3. Always initialize at least one spark pair.  If `choose_next_spark()` was entered when `num_sparks` was 1, `num_spark_pairs` would be 0 and none of the spark pairs would be initialized.  Consequently, accessing the pair at index 0 would return garbage data.
4. Iterate through `num_spark_pairs` when counting the indexes, rather than the hardcoded (and incorrect) magic number 6.

Fixes a crash discovered by Dawnesya that can only occur when a ship has both the "fighter" and "cruiser" flags.  Normally, fighters never enter the `choose_next_spark()` function and 'big' ships always have at least 3 sparks.