### PR TITLE
audio QoL update

### DIFF
--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -343,16 +343,30 @@ void event_music_init()
 			// (since event music specifies samples and measures, the audio format is important; so we don't want to assume any format will work)
 			if (!cf_exists_full(filename, CF_TYPE_MUSIC))
 			{
-#ifndef NDEBUG
-				// see if the file exists with a different extension
-				auto res = cf_find_file_location_ext(filename, NUM_AUDIO_EXT, audio_ext_list, CF_TYPE_MUSIC);
-				if (res.found)
-					Warning(LOCATION, "Soundtrack file %s was not found with its specified extension, but another file %s exists in the modpack.  Please update the extension and adjust audio specifications if necessary.", filename, res.name_ext.c_str());
-#endif
+				static SCP_unordered_map<SCP_string, SCP_string, SCP_string_lcase_hash, SCP_string_lcase_equal_to> filename_substitutions;
+				CFileLocationExt res;
 
-				Warning(LOCATION, "Soundtrack file %s was not found.  The soundtrack '%s' will not be used.", filename, soundtrack.name);
-				all_patterns_valid = false;
-				break;
+				// see if we ran into this file already (case-insensitive)
+				auto pair = filename_substitutions.find(filename);
+				if (pair != filename_substitutions.end())
+				{
+					// don't warn, since we warned for this file name when we added it to the map
+					strcpy_s(soundtrack.patterns[i].fname, pair->second.c_str());
+				}
+				// see if the file exists with a different extension
+				else if (res = cf_find_file_location_ext(filename, NUM_AUDIO_EXT, audio_ext_list, CF_TYPE_MUSIC), res.found)
+				{
+					Warning(LOCATION, "Soundtrack file %s was not found with its specified extension, but another file %s exists in the modpack.  Please update the extension and adjust audio specifications if necessary.", filename, res.name_ext.c_str());
+					filename_substitutions.emplace(filename, res.name_ext);
+					strcpy_s(soundtrack.patterns[i].fname, res.name_ext.c_str());
+				}
+				// file does not exist
+				else
+				{
+					Warning(LOCATION, "Soundtrack file %s was not found.  The soundtrack '%s' will not be used.", filename, soundtrack.name);
+					all_patterns_valid = false;
+					break;
+				}
 			}
 		}
 

--- a/code/gamesnd/gamesnd.cpp
+++ b/code/gamesnd/gamesnd.cpp
@@ -1367,7 +1367,7 @@ void parse_sound_table(const char* filename)
 
 						// retail sounds with numeric names must match their indexes
 						if ((tempSound.flags & GAME_SND_RETAIL_STYLE) && (atoi(tempSound.name.c_str()) != tempIndex) && !gamesnd_is_placeholder(tempSound))
-							error_display(0, "Retail-style sound %s has a name that does not match its index %d!", tempSound.name.c_str(), tempIndex);
+							error_display(0, "Retail-style game sound %s has a name that does not match its index %d!", tempSound.name.c_str(), tempIndex);
 
 						// prevent new named sounds from colliding with reserved indexes
 						tempIndex = gamesnd_find_nonreserved_last_index(Snds, gamesnd_is_reserved_game_index);
@@ -1397,7 +1397,7 @@ void parse_sound_table(const char* filename)
 
 						// retail sounds with numeric names must match their indexes
 						if ((tempSound.flags & GAME_SND_RETAIL_STYLE) && (atoi(tempSound.name.c_str()) != tempIndex) && !gamesnd_is_placeholder(tempSound))
-							error_display(0, "Retail-style sound %s has a name that does not match its index %d!", tempSound.name.c_str(), tempIndex);
+							error_display(0, "Retail-style interface sound %s has a name that does not match its index %d!", tempSound.name.c_str(), tempIndex);
 
 						// prevent new named sounds from colliding with reserved indexes
 						tempIndex = gamesnd_find_nonreserved_last_index(Snds_iface, gamesnd_is_reserved_interface_index);


### PR DESCRIPTION
When searching to see if there is an extension mismatch for a soundtrack audio file, go ahead and substitute the mismatched extension if found.  Matching extensions is important, so continue to display a Warning; but for the benefit of players and out-of-maintenance mods, it is more friendly to play the mismatched file even if the audio data is inaccurate.

Also clarify which sound type is being parsed when warning about retail-style sounds.