### PR TITLE
Create scripting hook: 'On Options Menu Closed'

### DIFF
--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -703,6 +703,11 @@ void options_cancel_exit()
 		options::OptionsManager::instance()->discardChanges();
 	}
 
+	// adds scripting hook for 'On Options Menu Closed' --wookieejedi
+	if (scripting::hooks::OnOptionsMenuClosed->isActive()) {
+		scripting::hooks::OnOptionsMenuClosed->run(scripting::hook_param_list(scripting::hook_param("OptionsAccepted", 'b', false)));
+	}
+
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }
 
@@ -990,6 +995,11 @@ void options_accept()
 
 	// run posting events outside this function, 
 	// since they will vary depending on what button was clicked --wookieejedi
+
+	// adds scripting hook for 'On Options Menu Closed' --wookieejedi
+	if (scripting::hooks::OnOptionsMenuClosed->isActive()) {
+		scripting::hooks::OnOptionsMenuClosed->run(scripting::hook_param_list(scripting::hook_param("OptionsAccepted", 'b', true)));
+	}
 }
 
 void options_load_background_and_mask(int tab)

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -33,6 +33,12 @@ const std::shared_ptr<Hook<>> OnOptionsTabChanged = Hook<>::Factory("On Options 
 		{"TabNumber", "number", "The number of the tab that has been changed to, with 0 = Options Tab, 1 = Multi Tab, and 2 = Details Tab. "},
 	});
 
+const std::shared_ptr<Hook<>> OnOptionsMenuClosed = Hook<>::Factory("On Options Menu Closed",
+	"Executed whenever a tab Options Menu is closed.",
+	{
+		{"OptionsAccepted", "boolean", "Whether or not the options are being accepted and saved. Value is true if the options are accepted/saved, false if the options are discarded and not accepted/saved. "},
+	});
+
 const std::shared_ptr<OverridableHook<>> OnStateStart = OverridableHook<>::Factory("On State Start",
 	"Executed whenever a new state is entered.",
 	{

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -10,6 +10,7 @@ extern const std::shared_ptr<Hook<>>									OnSplashEnd;
 extern const std::shared_ptr<OverridableHook<>>							OnIntroAboutToPlay;
 extern const std::shared_ptr<OverridableHook<>>							OnMovieAboutToPlay;
 extern const std::shared_ptr<Hook<>>									OnOptionsTabChanged;
+extern const std::shared_ptr<Hook<>>									OnOptionsMenuClosed;
 //The On State Start hook previously used to pass OldState to the conditions, but no semantically sensible condition read the value, so we pretend it has no local condition
 extern const std::shared_ptr<OverridableHook<>>							OnStateStart;
 


### PR DESCRIPTION
Complements #6591. This PR creates a hook, 'On Options Menu Closed' that provides a hook variable of `hv.OptionsAccepted` which is true if the options are accepted/saved, false if the options are discarded and not accepted/saved.

Happy to refine text/names however folks might want. 