### PR TITLE
Localize a missing Controls Popup text string

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1296,8 +1296,7 @@ bool control_config_accept(bool API_Access)
 		retry:;
 			SCP_string default_string = (Current_preset_name.empty()) ? Player->callsign : Current_preset_name;
 			cstr = popup_input(flags,
-				"Confirm new custom preset name.\n\nThe name must not be empty or a default preset.\n\n Press [Enter] to accept, [Esc] to "
-				"abort to config menu.",
+				XSTR( "Confirm new custom preset name.\n\nThe name must not be empty or a default preset.\n\n Press [Enter] to accept, [Esc] to abort to config menu.", 1867),
 				32 - 6,
 				default_string.c_str());
 			if (cstr == nullptr) {
@@ -1381,8 +1380,8 @@ void control_config_cancel_exit(bool API_Access)
 	// Check if any changes were made
 	if (!API_Access && (control_config_get_current_preset() == Control_config_presets.end())) {
 		// Changes were made, prompt the user first.
-		int flags = PF_TITLE_WHITE;
-		int choice = popup(flags, 2, POPUP_NO, POPUP_YES, "You have unsaved changes.\n\n\n Do you wish to continue without saving?");
+		int flags = PF_TITLE_WHITE | PF_USE_NEGATIVE_ICON | PF_USE_AFFIRMATIVE_ICON;
+		int choice = popup(flags, 2, POPUP_NO, POPUP_YES, XSTR( "You have unsaved changes.\n\n\n Do you wish to continue without saving?", 1866));
 
 		switch (choice) {
 			case -1:	// Aborted

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1866 // This is the next available ID
+// #define XSTR_SIZE	1868 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default


### PR DESCRIPTION
There were two rather prominent strings shown in popup windows related to the more modern control presets that were never localized. This PR localizes them to allow for proper translation support.

Tested and works as expected.