### PR TITLE
std::unique_ptr refactoring

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -36,7 +36,7 @@ typedef struct ai_flag_name {
 
 typedef struct ai_flag_description {
 	AI::AI_Flags flag;
-	SCP_string flag_desc;
+	const char *flag_desc;
 } ai_flag_description;
 
 extern ai_flag_name Ai_flag_names[];

--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -469,7 +469,7 @@ public:
 //  - is not "none"
 //  - is not "<none>"
 inline bool VALID_FNAME(const char* x) {
-	return (x[0] != '\0') && stricmp(x, "none") != 0 && stricmp(x, "<none>") != 0;
+	return (x != nullptr) && (x[0] != '\0') && stricmp(x, "none") != 0 && stricmp(x, "<none>") != 0;
 }
 /**
  * @brief Checks if the specified string may be a valid file name

--- a/code/globalincs/utility.h
+++ b/code/globalincs/utility.h
@@ -433,8 +433,8 @@ int find_item_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T
 	return -1;
 }
 
-template <typename NULLISH_T>
-NULLISH_T coalesce(NULLISH_T possibly_null, NULLISH_T value_if_null)
+template <typename T>
+const T* coalesce(const T* possibly_null, const T* value_if_null)
 {
 	Assertion(value_if_null != nullptr, "value_if_null can never be null itself!");
 

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -57,7 +57,7 @@ static void parse_texture_filtering_func()
 	stuff_string(mode, F_NAME);
 
 	// Convert to lowercase once
-	std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
+	SCP_tolower(mode);
 
 	// Use a map to associate strings with their respective actions
 	static const std::unordered_map<std::string, std::function<void()>> effectActions = {

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -40,7 +40,7 @@ static void parse_shadow_quality_func()
 	stuff_string(mode, F_NAME);
 
 	// Convert to lowercase once
-	std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
+	SCP_tolower(mode);
 
 	// Use a map to associate strings with their respective actions
 	static const std::unordered_map<std::string, std::function<void()>> effectActions = {

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -848,7 +848,7 @@ void techroom_change_tab(int num)
 						// this ship should be displayed, fill out the entry struct
 						temp_entry.index = (int)std::distance(Ship_info.begin(), it);
 						temp_entry.name = *it->tech_title ? it->tech_title : it->get_display_name();
-						temp_entry.desc = it->tech_desc;
+						temp_entry.desc = it->tech_desc.get();
 
                         Ship_list.push_back(temp_entry);
                     }
@@ -890,7 +890,7 @@ void techroom_change_tab(int num)
 					{ 
 						// we have a weapon that should be in the tech db, so fill out specific info
 						temp_entry.index = i;
-						temp_entry.desc = wi.tech_desc;
+						temp_entry.desc = wi.tech_desc.get();
 						temp_entry.name = wi.tech_title[0] ? wi.tech_title : wi.get_display_name();
 						// copy the weapon animation filename
 						strncpy(temp_entry.tech_anim_filename, wi.tech_anim_filename, MAX_FILENAME_LEN - 1);

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -141,7 +141,7 @@ typedef struct custom_string {
 template <class T>
 struct parse_object_flag_description {
 	T def;
-	SCP_string flag_desc;
+	const char *flag_desc;
 };
 
 typedef struct mission {

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -344,22 +344,22 @@ const char *ss_tooltip_handler(const char *str)
 		return Ship_info[Selected_ss_class].name;
 
 	} else if (!stricmp(str, NOX("@ship_type"))) {
-		return Ship_info[Selected_ss_class].type_str;
+		return Ship_info[Selected_ss_class].type_str.get();
 
 	} else if (!stricmp(str, NOX("@ship_maneuverability"))) {
-		return Ship_info[Selected_ss_class].maneuverability_str;
+		return Ship_info[Selected_ss_class].maneuverability_str.get();
 
 	} else if (!stricmp(str, NOX("@ship_armor"))) {
-		return Ship_info[Selected_ss_class].armor_str;
+		return Ship_info[Selected_ss_class].armor_str.get();
 
 	} else if (!stricmp(str, NOX("@ship_manufacturer"))) {
-		return Ship_info[Selected_ss_class].manufacturer_str;
+		return Ship_info[Selected_ss_class].manufacturer_str.get();
 
 	} else if (!stricmp(str, NOX("@ship_desc"))) {
 		char *str2;
 		int x, y, w, h;
 
-		str2 = Ship_info[Selected_ss_class].desc;
+		str2 = Ship_info[Selected_ss_class].desc.get();
 		if (str2 == NULL)
 			return NULL;
 
@@ -940,8 +940,8 @@ void ship_select_blit_ship_info()
 	gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD], y_start, XSTR("Type",740), GR_RESIZE_MENU);
 	y_start += line_height;
 	gr_set_color_fast(text);
-	if((sip->type_str != NULL) && strlen(sip->type_str)){
-		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->type_str, GR_RESIZE_MENU);
+	if(sip->type_str){
+		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->type_str.get(), GR_RESIZE_MENU);
 	}
 	else
 	{
@@ -954,15 +954,15 @@ void ship_select_blit_ship_info()
 	gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD], y_start, XSTR("Length",741), GR_RESIZE_MENU);
 	y_start += line_height;
 	gr_set_color_fast(text);
-	if((sip->ship_length != NULL) && strlen(sip->ship_length)){
+	if(sip->ship_length){
 		if (Lcl_gr || Lcl_pl) {
 			// in german and polish, drop the s from Meters and make sure M is caps
-			char *sp = strstr(sip->ship_length, "Meters");
+			char *sp = strstr(sip->ship_length.get(), "Meters");
 			if (sp) {
 				sp[5] = ' ';		// make the old s a space now
 			}
 		}
-		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->ship_length, GR_RESIZE_MENU);
+		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->ship_length.get(), GR_RESIZE_MENU);
 	}
 	else if(ShipSelectModelNum >= 0)
 	{
@@ -991,8 +991,8 @@ void ship_select_blit_ship_info()
 	gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD], y_start, XSTR("Maneuverability",744), GR_RESIZE_MENU);
 	y_start += line_height;
 	gr_set_color_fast(text);
-	if((sip->maneuverability_str != NULL) && strlen(sip->maneuverability_str)){
-		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->maneuverability_str, GR_RESIZE_MENU);
+	if(sip->maneuverability_str){
+		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->maneuverability_str.get(), GR_RESIZE_MENU);
 	}
 	else if(ShipSelectModelNum >= 0)
 	{
@@ -1025,8 +1025,8 @@ void ship_select_blit_ship_info()
 	gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD], y_start, XSTR("Armor",745), GR_RESIZE_MENU);
 	y_start += line_height;
 	gr_set_color_fast(text);
-	if((sip->armor_str != NULL) && strlen(sip->armor_str)){
-		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->armor_str, GR_RESIZE_MENU);
+	if(sip->armor_str){
+		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->armor_str.get(), GR_RESIZE_MENU);
 	}
 	else
 	{
@@ -1061,12 +1061,12 @@ void ship_select_blit_ship_info()
 
 	// blit the gun mounts 
 	gr_set_color_fast(header_clr);
-	if((sip->gun_mounts != NULL) && strlen(sip->gun_mounts))
+	if(sip->gun_mounts)
 	{
 		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD], y_start, XSTR("Gun Mounts",746), GR_RESIZE_MENU);
 		y_start += line_height;
 		gr_set_color_fast(text);
-		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->gun_mounts, GR_RESIZE_MENU);
+		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->gun_mounts.get(), GR_RESIZE_MENU);
 	}
 	else if(ShipSelectModelNum >= 0)
 	{
@@ -1109,8 +1109,8 @@ void ship_select_blit_ship_info()
 	gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD], y_start, XSTR("Missile Banks",747), GR_RESIZE_MENU);
 	y_start += line_height;
 	gr_set_color_fast(text);
-	if((sip->missile_banks != NULL) && strlen(sip->missile_banks)){
-		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->missile_banks, GR_RESIZE_MENU);
+	if(sip->missile_banks){
+		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->missile_banks.get(), GR_RESIZE_MENU);
 	}
 	else
 	{
@@ -1174,8 +1174,8 @@ void ship_select_blit_ship_info()
 	gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD], y_start, XSTR("Manufacturer",748), GR_RESIZE_MENU);
 	y_start += line_height;
 	gr_set_color_fast(text);
-	if((sip->manufacturer_str != NULL) && strlen(sip->manufacturer_str)){
-		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->manufacturer_str, GR_RESIZE_MENU);
+	if(sip->manufacturer_str){
+		gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD]+4, y_start, sip->manufacturer_str.get(), GR_RESIZE_MENU);
 	}
 	else
 	{
@@ -1186,14 +1186,12 @@ void ship_select_blit_ship_info()
 	// blit the _short_ text description, if it exists
 	// split the text info up	
 	
-	if (sip->desc == NULL)
+	if (!sip->desc || !sip->desc[0])
 		return;
 
 	gr_set_color_fast(header_clr);
 	gr_string(Ship_info_coords[gr_screen.res][SHIP_SELECT_X_COORD], y_start, XSTR("Description",1571), GR_RESIZE_MENU);
 	y_start += line_height;
-
-	Assert(strlen(sip->desc));
 
 	int n_lines;
 	int n_chars[MAX_BRIEF_LINES];
@@ -1202,7 +1200,7 @@ void ship_select_blit_ship_info()
 	char Ship_select_ship_info_lines[MAX_NUM_SHIP_DESC_LINES][SHIP_SELECT_SHIP_INFO_MAX_LINE_LEN];
 	int Ship_select_ship_info_line_count;
 
-	strcpy_s(Ship_select_ship_info_text, sip->desc);
+	strcpy_s(Ship_select_ship_info_text, sip->desc.get());
 	
 	if(Ship_select_ship_info_text[0] != '\0'){
 		// split the string into multiple lines

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -15,6 +15,7 @@
 #include "gamehelp/contexthelp.h"
 #include "gamesnd/gamesnd.h"
 #include "globalincs/alphacolors.h"
+#include "globalincs/utility.h"
 #include "graphics/shadows.h"
 #include "graphics/matrix.h"
 #include "hud/hudbrackets.h"
@@ -486,10 +487,10 @@ const char *wl_tooltip_handler(const char *str)
 		return NULL;
 
 	if (!stricmp(str, "@weapon_desc")) {
-		char *str2;
+		const char *str2;
 		int x, y, w, h;
 
-		str2 = Weapon_info[Selected_wl_class].desc;
+		str2 = coalesce(Weapon_info[Selected_wl_class].desc.get(), "");
 		gr_get_string_size(&w, &h, str2);
 		x = Wl_weapon_desc_coords[gr_screen.res][0] - w / 2;
 		y = Wl_weapon_desc_coords[gr_screen.res][1] - h / 2;
@@ -2526,9 +2527,10 @@ void wl_weapon_desc_start_wipe()
 	
 	// break current description into lines (break at the /n's)
 	currchar_src = 0;
-	if (Weapon_info[Selected_wl_class].desc != NULL) {
-		while (Weapon_info[Selected_wl_class].desc[currchar_src] != '\0') {
-			if (Weapon_info[Selected_wl_class].desc[currchar_src] == '\n') {
+	if (Weapon_info[Selected_wl_class].desc) {
+		auto desc = Weapon_info[Selected_wl_class].desc.get();
+		while (desc[currchar_src] != '\0') {
+			if (desc[currchar_src] == '\n') {
 				// break here
 				if (currchar_src != 0) {					// protect against leading /n's
 					Weapon_desc_lines[currline_dest][currchar_dest] = '\0';
@@ -2537,7 +2539,7 @@ void wl_weapon_desc_start_wipe()
 				}
 			} else {
 				// straight copy
-				Weapon_desc_lines[currline_dest][currchar_dest] = Weapon_info[Selected_wl_class].desc[currchar_src];
+				Weapon_desc_lines[currline_dest][currchar_dest] = desc[currchar_src];
 				currchar_dest++;
 			}
 

--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -11,31 +11,32 @@
 
 
 #include "network/multiteamselect.h"
-#include "network/multi.h"
-#include "missionui/chatbox.h"
-#include "gamesnd/gamesnd.h"
-#include "io/key.h"
-#include "globalincs/linklist.h"
 #include "gamesequence/gamesequence.h"
+#include "gamesnd/gamesnd.h"
+#include "globalincs/alphacolors.h"
+#include "globalincs/linklist.h"
 #include "graphics/font.h"
-#include "network/multiutil.h"
+#include "io/key.h"
+#include "io/mouse.h"
+#include "menuui/snazzyui.h"
+#include "mission/missionparse.h"
+#include "missionui/chatbox.h"
 #include "missionui/missionscreencommon.h"
 #include "missionui/missionshipchoice.h"
 #include "missionui/missionweaponchoice.h"
 #include "missionui/missionbrief.h"
-#include "network/multimsgs.h"
-#include "menuui/snazzyui.h"
-#include "io/mouse.h"
-#include "popup/popup.h"
-#include "network/multiui.h"
+#include "network/multi.h"
 #include "network/multi_endgame.h"
-#include "globalincs/alphacolors.h"
-#include "playerman/player.h"
-#include "ship/ship.h"
-#include "weapon/weapon.h"
+#include "network/multimsgs.h"
+#include "network/multiui.h"
+#include "network/multiutil.h"
 #include "object/object.h"
 #include "parse/parselo.h"
-#include "mission/missionparse.h"
+#include "playerman/player.h"
+#include "popup/popup.h"
+#include "ship/ship.h"
+#include "utils/string_utils.h"
+#include "weapon/weapon.h"
 
 
 // ------------------------------------------------------------------------------------------------------
@@ -1528,18 +1529,18 @@ void multi_ts_blit_ship_info()
 	// blit the ship type
 	gr_set_color_fast(&Color_normal);
 	gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD], y_start, XSTR("Type",740), GR_RESIZE_MENU);
-	if((sip->type_str != NULL) && strlen(sip->type_str)){
+	if(sip->type_str){
 		gr_set_color_fast(&Color_bright);
-		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->type_str, GR_RESIZE_MENU);
+		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->type_str.get(), GR_RESIZE_MENU);
 	}
 	y_start += line_height;
 
 	// blit the ship length
 	gr_set_color_fast(&Color_normal);
 	gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD], y_start, XSTR("Length",741), GR_RESIZE_MENU);
-	if((sip->ship_length != NULL) && strlen(sip->ship_length)){
+	if(sip->ship_length){
 		gr_set_color_fast(&Color_bright);
-		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->ship_length, GR_RESIZE_MENU);
+		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->ship_length.get(), GR_RESIZE_MENU);
 	}
 	y_start += line_height;
 
@@ -1554,45 +1555,45 @@ void multi_ts_blit_ship_info()
 	// blit the maneuverability
 	gr_set_color_fast(&Color_normal);
 	gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD], y_start, XSTR("Maneuverability",744), GR_RESIZE_MENU);
-	if((sip->maneuverability_str != NULL) && strlen(sip->maneuverability_str)){
+	if(sip->maneuverability_str){
 		gr_set_color_fast(&Color_bright);
-		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->maneuverability_str, GR_RESIZE_MENU);
+		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->maneuverability_str.get(), GR_RESIZE_MENU);
 	}
 	y_start += line_height;
 
 	// blit the armor
 	gr_set_color_fast(&Color_normal);
 	gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD], y_start, XSTR("Armor",745), GR_RESIZE_MENU);
-	if((sip->armor_str != NULL) && strlen(sip->armor_str)){
+	if(sip->armor_str){
 		gr_set_color_fast(&Color_bright);
-		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->armor_str, GR_RESIZE_MENU);
+		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->armor_str.get(), GR_RESIZE_MENU);
 	}
 	y_start += line_height;
 
 	// blit the gun mounts 
 	gr_set_color_fast(&Color_normal);
 	gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD], y_start, XSTR("Gun Mounts",746), GR_RESIZE_MENU);
-	if((sip->gun_mounts != NULL) && strlen(sip->gun_mounts)){
+	if(sip->gun_mounts){
 		gr_set_color_fast(&Color_bright);
-		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->gun_mounts, GR_RESIZE_MENU);
+		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->gun_mounts.get(), GR_RESIZE_MENU);
 	}
 	y_start += line_height;
 
 	// blit the missile banke
 	gr_set_color_fast(&Color_normal);
 	gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD], y_start, XSTR("Missile Banks",747), GR_RESIZE_MENU);
-	if((sip->missile_banks != NULL) && strlen(sip->missile_banks)){
+	if(sip->missile_banks){
 		gr_set_color_fast(&Color_bright);
-		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->missile_banks, GR_RESIZE_MENU);
+		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->missile_banks.get(), GR_RESIZE_MENU);
 	}
 	y_start += line_height;
 
 	// blit the manufacturer
 	gr_set_color_fast(&Color_normal);
 	gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD], y_start, XSTR("Manufacturer",748), GR_RESIZE_MENU);
-	if((sip->manufacturer_str != NULL) && strlen(sip->manufacturer_str)){
+	if(sip->manufacturer_str){
 		gr_set_color_fast(&Color_bright);
-		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->manufacturer_str, GR_RESIZE_MENU);
+		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD] + 150, y_start, sip->manufacturer_str.get(), GR_RESIZE_MENU);
 	}
 	y_start += line_height;
 
@@ -1604,7 +1605,6 @@ void multi_ts_blit_ship_info()
 		gr_string(Multi_ts_ship_info_coords[gr_screen.res][MULTI_TS_X_COORD], y_start, Multi_ts_ship_info_lines[idx], GR_RESIZE_MENU);
 		y_start += line_height;
 	}
-	
 }
 
 
@@ -2567,7 +2567,6 @@ void multi_ts_select_ship()
 {
 	int n_lines;
 	int n_chars[MAX_BRIEF_LINES];
-	char ship_desc[1000];
 	const char *p_str[MAX_BRIEF_LINES];
 	char *token;
 	
@@ -2599,14 +2598,11 @@ void multi_ts_select_ship()
 	// split the text info up	
 	
 	Assert(Multi_ts_select_ship_class >= 0);
-//	Assert((Ship_info[Multi_ts_select_ship_class].desc != NULL) && strlen(Ship_info[Multi_ts_select_ship_class].desc));
-	if (Ship_info[Multi_ts_select_ship_class].desc != NULL)
+	if (Ship_info[Multi_ts_select_ship_class].desc)
 	{
-
 		// strip out newlines
-		memset(ship_desc,0,1000);
-		strcpy_s(ship_desc,Ship_info[Multi_ts_select_ship_class].desc);
-		token = strtok(ship_desc,"\n");
+		auto ship_desc = util::unique_copy(Ship_info[Multi_ts_select_ship_class].desc.get(), true);
+		token = strtok(ship_desc.get(), "\n");
 		if(token != NULL){
 			strcpy_s(Multi_ts_ship_info_text,token);
 			while(token != NULL){

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -112,7 +112,7 @@ typedef struct obj_flag_name {
 
 typedef struct obj_flag_description {
 	Object::Object_Flags flag;
-	SCP_string flag_desc;
+	const char *flag_desc;
 } obj_flag_description;
 
 extern obj_flag_name Object_flag_names[];

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -49,7 +49,8 @@ extern int Token_found_flag;
 #define	F_MESSAGE				9	// this is now obsolete for mission messages - all messages in missions should now use $MessageNew and stuff strings as F_MULTITEXT
 #define	F_MULTITEXT				10
 #define F_RAW					11	// for any internal parsing use. Just strips whitespace and copies the text.
-#define F_LNAME					12	//Filenames
+#define F_LNAME					12	// Filenames
+#define F_TRIMMED				13	// Like F_NAME etc., but without leading and trailing whitespace
 
 #define PARSE_BUF_SIZE			4096
 
@@ -152,6 +153,8 @@ extern char* alloc_block(const char* startstr, const char* endstr, int extra_cha
 // the default string length if using the F_NAME case.
 extern char *stuff_and_malloc_string(int type, const char *terminators = nullptr);
 extern void stuff_malloc_string(char **dest, int type, const char *terminators = nullptr);
+extern void stuff_string(std::unique_ptr<char[]> &outstr, int type, bool null_if_empty, const char *terminators = nullptr);
+extern void stuff_string(SCP_vm_unique_ptr<char> &outstr, int type, bool null_if_empty, const char *terminators = nullptr);
 extern bool check_first_non_whitespace_char(const char *str, char ch_to_look_for, char **after_ch = nullptr);
 extern bool check_first_non_grayspace_char(const char *str, char ch_to_look_for, char **after_ch = nullptr);
 extern int stuff_float(float *f, bool optional = false);

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -73,7 +73,7 @@ static void parse_flight_mode_func()
 	stuff_string(mode, F_NAME);
 
 	// Convert to lowercase once
-	std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
+	SCP_tolower(mode);
 
 	// Use a map to associate strings with their respective actions
 	static const std::unordered_map<std::string, std::function<void()>> effectActions =

--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -18,6 +18,7 @@
 #include "missionui/missionscreencommon.h"
 #include "scripting/api/objs/weaponclass.h"
 #include "model/modelrender.h"
+#include "utils/string_utils.h"
 
 namespace scripting {
 namespace api {
@@ -177,182 +178,58 @@ ADE_VIRTVAR(ShortName, l_Shipclass, "string", "Ship class short name", "string",
 	return ade_set_args(L, "s", Ship_info[idx].short_name);
 }
 
-ADE_VIRTVAR(TypeString, l_Shipclass, "string", "Ship class type string", "string", "Type string, or empty string if handle is invalid")
+int handle_ship_class_optional_string(lua_State *L, std::unique_ptr<char[]> ship_info::*optional_string_field)
 {
 	int idx;
 	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
+	if (!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
 		return ade_set_error(L, "s", "");
 
-	if(idx < 0 || idx >= ship_info_size())
+	if (!SCP_vector_inbounds(Ship_info, idx))
 		return ade_set_error(L, "s", "");
 
-	ship_info *sip = &Ship_info[idx];
+	auto sip = &Ship_info[idx];
 
 	if(ADE_SETTING_VAR) {
-		vm_free(sip->type_str);
-		if(s != NULL) {
-			sip->type_str = (char*)vm_malloc(strlen(s)+1);
-			strcpy(sip->type_str, s);
-		} else {
-			sip->type_str = NULL;
-		}
+		sip->*optional_string_field = util::unique_copy(s, true);
 	}
 
-	if(sip->type_str != NULL)
-		return ade_set_args(L, "s", sip->type_str);
-	else
-		return ade_set_args(L, "s", "");
+	return ade_set_args(L, "s", coalesce(sip->type_str.get(), ""));
+}
+
+ADE_VIRTVAR(TypeString, l_Shipclass, "string", "Ship class type string", "string", "Type string, or empty string if handle is invalid")
+{
+	return handle_ship_class_optional_string(L, &ship_info::type_str);
 }
 
 ADE_VIRTVAR(ManeuverabilityString, l_Shipclass, "string", "Ship class maneuverability string", "string", "Maneuverability string, or empty string if handle is invalid")
 {
-	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
-		return ade_set_error(L, "s", "");
-
-	if(idx < 0 || idx >= ship_info_size())
-		return ade_set_error(L, "s", "");
-
-	ship_info *sip = &Ship_info[idx];
-
-	if(ADE_SETTING_VAR) {
-		vm_free(sip->maneuverability_str);
-		if(s != NULL) {
-			sip->maneuverability_str = (char*)vm_malloc(strlen(s)+1);
-			strcpy(sip->maneuverability_str, s);
-		} else {
-			sip->maneuverability_str = NULL;
-		}
-	}
-
-	if(sip->maneuverability_str != NULL)
-		return ade_set_args(L, "s", sip->maneuverability_str);
-	else
-		return ade_set_args(L, "s", "");
+	return handle_ship_class_optional_string(L, &ship_info::maneuverability_str);
 }
 
 ADE_VIRTVAR(ArmorString, l_Shipclass, "string", "Ship class armor string", "string", "Armor string, or empty string if handle is invalid")
 {
-	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
-		return ade_set_error(L, "s", "");
-
-	if(idx < 0 || idx >= ship_info_size())
-		return ade_set_error(L, "s", "");
-
-	ship_info *sip = &Ship_info[idx];
-
-	if(ADE_SETTING_VAR) {
-		vm_free(sip->armor_str);
-		if(s != NULL) {
-			sip->armor_str = (char*)vm_malloc(strlen(s)+1);
-			strcpy(sip->armor_str, s);
-		} else {
-			sip->armor_str = NULL;
-		}
-	}
-
-	if(sip->armor_str != NULL)
-		return ade_set_args(L, "s", sip->armor_str);
-	else
-		return ade_set_args(L, "s", "");
+	return handle_ship_class_optional_string(L, &ship_info::armor_str);
 }
 
 ADE_VIRTVAR(ManufacturerString, l_Shipclass, "string", "Ship class manufacturer", "string", "Manufacturer, or empty string if handle is invalid")
 {
-	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
-		return ade_set_error(L, "s", "");
-
-	if(idx < 0 || idx >= ship_info_size())
-		return ade_set_error(L, "s", "");
-
-	ship_info *sip = &Ship_info[idx];
-
-	if(ADE_SETTING_VAR) {
-		vm_free(sip->manufacturer_str);
-		if(s != NULL) {
-			sip->manufacturer_str = (char*)vm_malloc(strlen(s)+1);
-			strcpy(sip->manufacturer_str, s);
-		} else {
-			sip->manufacturer_str = NULL;
-		}
-	}
-
-	if(sip->manufacturer_str != NULL)
-		return ade_set_args(L, "s", sip->manufacturer_str);
-	else
-		return ade_set_args(L, "s", "");
+	return handle_ship_class_optional_string(L, &ship_info::manufacturer_str);
 }
 
 ADE_VIRTVAR(LengthString, l_Shipclass, "string", "Ship class length", "string", "Length, or empty string if handle is invalid")
 {
-	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
-		return ade_set_error(L, "s", "");
-
-	if(idx < 0 || idx >= ship_info_size())
-		return ade_set_error(L, "s", "");
-
-	ship_info *sip = &Ship_info[idx];
-
-	if (ADE_SETTING_VAR) {
-		LuaError(L, "Setting Length is not supported");
-	}
-
-	if (sip->ship_length != nullptr)
-		return ade_set_args(L, "s", sip->ship_length);
-	else
-		return ade_set_args(L, "s", "");
+	return handle_ship_class_optional_string(L, &ship_info::ship_length);
 }
 
 ADE_VIRTVAR(GunMountsString, l_Shipclass, "string", "Ship class gun mounts", "string", "Gun mounts, or empty string if handle is invalid")
 {
-	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
-		return ade_set_error(L, "s", "");
-
-	if(idx < 0 || idx >= ship_info_size())
-		return ade_set_error(L, "s", "");
-
-	ship_info *sip = &Ship_info[idx];
-
-	if (ADE_SETTING_VAR) {
-		LuaError(L, "Setting Gun mounts is not supported");
-	}
-
-	if (sip->gun_mounts != nullptr)
-		return ade_set_args(L, "s", sip->gun_mounts);
-	else
-		return ade_set_args(L, "s", "");
+	return handle_ship_class_optional_string(L, &ship_info::gun_mounts);
 }
 
 ADE_VIRTVAR(MissileBanksString, l_Shipclass, "string", "Ship class missile banks", "string", "Missile banks, or empty string if handle is invalid")
 {
-	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
-		return ade_set_error(L, "s", "");
-
-	if(idx < 0 || idx >= ship_info_size())
-		return ade_set_error(L, "s", "");
-
-	ship_info *sip = &Ship_info[idx];
-
-	if (ADE_SETTING_VAR) {
-		LuaError(L, "Setting Missile banks is not supported");
-	}
-
-	if (sip->missile_banks != nullptr)
-		return ade_set_args(L, "s", sip->missile_banks);
-	else
-		return ade_set_args(L, "s", "");
+	return handle_ship_class_optional_string(L, &ship_info::missile_banks);
 }
 
 ADE_VIRTVAR(VelocityString, l_Shipclass, "string", "Ship class velocity", "string", "velocity, or empty string if handle is invalid")
@@ -368,7 +245,7 @@ ADE_VIRTVAR(VelocityString, l_Shipclass, "string", "Ship class velocity", "strin
 	ship_info *sip = &Ship_info[idx];
 
 	if (ADE_SETTING_VAR) {
-		LuaError(L, "Setting Missile banks is not supported");
+		LuaError(L, "Setting Velocity is not supported");
 	}
 
 	char str[100];
@@ -377,33 +254,9 @@ ADE_VIRTVAR(VelocityString, l_Shipclass, "string", "Ship class velocity", "strin
 	return ade_set_args(L, "s", str);
 }
 
-
 ADE_VIRTVAR(Description, l_Shipclass, "string", "Ship class description", "string", "Description, or empty string if handle is invalid")
 {
-	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
-		return ade_set_error(L, "s", "");
-
-	if(idx < 0 || idx >= ship_info_size())
-		return ade_set_error(L, "s", "");
-
-	ship_info *sip = &Ship_info[idx];
-
-	if(ADE_SETTING_VAR) {
-		vm_free(sip->desc);
-		if(s != NULL) {
-			sip->desc = (char*)vm_malloc(strlen(s)+1);
-			strcpy(sip->desc, s);
-		} else {
-			sip->desc = NULL;
-		}
-	}
-
-	if(sip->desc != NULL)
-		return ade_set_args(L, "s", sip->desc);
-	else
-		return ade_set_args(L, "s", "");
+	return handle_ship_class_optional_string(L, &ship_info::desc);
 }
 
 ADE_VIRTVAR(SelectIconFilename, l_Shipclass, "string", "Ship class select icon filename", "string", "Filename, or empty string if handle is invalid")
@@ -459,30 +312,7 @@ ADE_VIRTVAR(SelectOverheadFilename, l_Shipclass, "string", "Ship class select ov
 
 ADE_VIRTVAR(TechDescription, l_Shipclass, "string", "Ship class tech description", "string", "Tech description, or empty string if handle is invalid")
 {
-	int idx;
-	const char* s = nullptr;
-	if(!ade_get_args(L, "o|s", l_Shipclass.Get(&idx), &s))
-		return ade_set_error(L, "s", "");
-
-	if(idx < 0 || idx >= ship_info_size())
-		return ade_set_error(L, "s", "");
-
-	ship_info *sip = &Ship_info[idx];
-
-	if(ADE_SETTING_VAR) {
-		vm_free(sip->tech_desc);
-		if(s != NULL) {
-			sip->tech_desc = (char*)vm_malloc(strlen(s)+1);
-			strcpy(sip->tech_desc, s);
-		} else {
-			sip->tech_desc = NULL;
-		}
-	}
-
-	if(sip->tech_desc != NULL)
-		return ade_set_args(L, "s", sip->tech_desc);
-	else
-		return ade_set_args(L, "s", "");
+	return handle_ship_class_optional_string(L, &ship_info::tech_desc);
 }
 
 ADE_VIRTVAR(numPrimaryBanks,

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -9,6 +9,7 @@
 #include "mission/missioncampaign.h"
 #include "missionui/missionscreencommon.h"
 #include "model/modelrender.h"
+#include "utils/string_utils.h"
 
 namespace scripting {
 namespace api {
@@ -134,17 +135,11 @@ ADE_VIRTVAR(Description, l_Weaponclass, "string", "Weapon class description stri
 	weapon_info *wip = &Weapon_info[idx];
 
 	if(ADE_SETTING_VAR) {
-		vm_free(wip->desc);
-		if(s != nullptr) {
-			wip->desc = (char*)vm_malloc(strlen(s)+1);
-			strcpy(wip->desc, s);
-		} else {
-			wip->desc = nullptr;
-		}
+		wip->desc = util::unique_copy(s, true);
 	}
 
 	if(wip->desc != nullptr)
-		return ade_set_args(L, "s", wip->desc);
+		return ade_set_args(L, "s", wip->desc.get());
 	else
 		return ade_set_args(L, "s", "");
 }
@@ -234,17 +229,11 @@ ADE_VIRTVAR(TechDescription, l_Weaponclass, "string", "Weapon class tech descrip
 	weapon_info *wip = &Weapon_info[idx];
 
 	if(ADE_SETTING_VAR) {
-		vm_free(wip->tech_desc);
-		if(s != nullptr) {
-			wip->tech_desc = (char*)vm_malloc(strlen(s)+1);
-			strcpy(wip->tech_desc, s);
-		} else {
-			wip->tech_desc = nullptr;
-		}
+		wip->tech_desc = util::unique_copy(s, true);
 	}
 
 	if(wip->tech_desc != nullptr)
-		return ade_set_args(L, "s", wip->tech_desc);
+		return ade_set_args(L, "s", wip->tech_desc.get());
 	else
 		return ade_set_args(L, "s", "");
 }

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1148,17 +1148,17 @@ public:
 	int			species;								// which species this craft belongs to
 	int			class_type;						//For type table
 
-	char		*type_str;							// type string used by tooltips
-	char		*maneuverability_str;			// string used by tooltips
-	char		*armor_str;							// string used by tooltips
-	char		*manufacturer_str;				// string used by tooltips
-	char		*desc;								// string used by tooltips
-	char		*tech_desc;							// string used by tech database
+	std::unique_ptr<char[]> type_str;							// type string used by tooltips
+	std::unique_ptr<char[]> maneuverability_str;			// string used by tooltips
+	std::unique_ptr<char[]> armor_str;							// string used by tooltips
+	std::unique_ptr<char[]> manufacturer_str;				// string used by tooltips
+	std::unique_ptr<char[]> desc;								// string used by tooltips
+	std::unique_ptr<char[]> tech_desc;							// string used by tech database
 	char		tech_title[NAME_LENGTH];			// ship's name (in tech database)
 
-	char     *ship_length;						// string used by multiplayer ship desc
-	char     *gun_mounts;			         // string used by multiplayer ship desc
-	char     *missile_banks;					// string used by multiplayer ship desc
+	std::unique_ptr<char[]> ship_length;						// string used by multiplayer ship desc
+	std::unique_ptr<char[]> gun_mounts;			         // string used by multiplayer ship desc
+	std::unique_ptr<char[]> missile_banks;					// string used by multiplayer ship desc
 
 	char		cockpit_pof_file[MAX_FILENAME_LEN];	// POF file for cockpit view
 	vec3d		cockpit_offset;
@@ -1494,8 +1494,6 @@ public:
 	ship_info(ship_info&& other) noexcept;
 
 	ship_info &operator=(ship_info&& other) noexcept;
-
-	void free_strings();
 
     //Helper functions
     

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -467,7 +467,7 @@ typedef struct ship_flag_name {
 
 typedef struct ship_flag_description {
 	Ship::Ship_Flags flag;
-	SCP_string flag_desc;
+	const char *flag_desc;
 } ship_flag_description;
 
 extern ship_flag_name Ship_flag_names[];
@@ -481,7 +481,7 @@ typedef struct wing_flag_name {
 
 typedef struct wing_flag_description {
 	Ship::Wing_Flags flag;
-	SCP_string flag_desc;
+	const char *flag_desc;
 } wing_flag_description;
 
 extern wing_flag_name Wing_flag_names[];

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -357,7 +357,7 @@ struct weapon_info
 	char	name[NAME_LENGTH];				// name of this weapon
 	char	display_name[NAME_LENGTH];		// display name of this weapon
 	char	title[WEAPON_TITLE_LEN];		// official title of weapon (used by tooltips)
-	char	*desc;								// weapon's description (used by tooltips)
+	std::unique_ptr<char[]> desc;				// weapon's description (used by tooltips)
 	char	altSubsysName[NAME_LENGTH];        // rename turret to this if this is the turrets first weapon
 
 	char	pofbitmap_name[MAX_FILENAME_LEN];	// Name of the pof representing this if POF, or bitmap filename if bitmap
@@ -365,7 +365,7 @@ struct weapon_info
 	char	external_model_name[MAX_FILENAME_LEN];					//the model rendered on the weapon points of a ship
 	int		external_model_num;					//the model rendered on the weapon points of a ship
 
-	char	*tech_desc;								// weapon's description (in tech database)
+	std::unique_ptr<char[]> tech_desc;		// weapon's description (in tech database)
 	char	tech_anim_filename[MAX_FILENAME_LEN];	// weapon's tech room animation
 	char	tech_title[NAME_LENGTH];			// weapon's name (in tech database)
 	char	tech_model[MAX_FILENAME_LEN];		//Image to display in the techroom (TODO) or the weapon selection screen if the ANI isn't specified/missing
@@ -656,7 +656,7 @@ struct weapon_info
 
 	// Optional weapon failures
 	float failure_rate;
-	SCP_string failure_sub_name;
+	std::unique_ptr<char[]> failure_sub_name;
 	int failure_sub;
 
 	// the optional pattern of weapons that this weapon will fire


### PR DESCRIPTION
Use `std::unique_ptr` rather than `vm_malloc` and `vm_free` to handle optional strings in ship classes.  This makes the code more robust and increases memory safety.  This also allows several string variables to be consolidated in the ship class and weapon class script APIs.

Also add new `stuff_string()` overloads and a new `F_TRIMMED` string parsing type to handle the new fields and the string trimming done inside `stuff_malloc_string()`.