### PR TITLE
Create scripting hooks HUD and Control Config Close

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1365,6 +1365,11 @@ bool control_config_accept(bool API_Access)
 		}
 	}
 	
+	// adds scripting hook for 'On Control Config Menu Closed' --wookieejedi
+	if (scripting::hooks::OnControlConfigMenuClosed->isActive()) {
+		scripting::hooks::OnControlConfigMenuClosed->run(scripting::hook_param_list(scripting::hook_param("OptionsAccepted", 'b', true)));
+	}
+
 	if (!API_Access) {
 		gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 		gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
@@ -1401,6 +1406,11 @@ void control_config_cancel_exit(bool API_Access)
 
 	// Restore all bindings with the backup
 	std::move(Control_config_backup.begin(), Control_config_backup.end(), Control_config.begin());
+
+	// adds scripting hook for 'On Control Config Menu Closed' --wookieejedi
+	if (scripting::hooks::OnControlConfigMenuClosed->isActive()) {
+		scripting::hooks::OnControlConfigMenuClosed->run(scripting::hook_param_list(scripting::hook_param("OptionsAccepted", 'b', false)));
+	}
 
 	if (!API_Access) {
 		gameseq_post_event(GS_EVENT_PREVIOUS_STATE);

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -22,6 +22,8 @@
 #include "parse/parselo.h"
 #include "playerman/player.h"
 #include "popup/popup.h"
+#include "scripting/scripting.h"
+#include "scripting/global_hooks.h"
 #include "ship/ship.h"
 #include "ui/ui.h"
 
@@ -1132,6 +1134,11 @@ void hud_config_cancel(bool change_state)
 {
 	hud_config_restore();
 
+	// adds scripting hook for 'On HUD Config Menu Closed' --wookieejedi
+	if (scripting::hooks::OnHUDConfigMenuClosed->isActive()) {
+		scripting::hooks::OnHUDConfigMenuClosed->run(scripting::hook_param_list(scripting::hook_param("OptionsAccepted", 'b', false)));
+	}
+
 	if (change_state) {
 		gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 	}
@@ -1139,6 +1146,11 @@ void hud_config_cancel(bool change_state)
 
 void hud_config_commit()
 {
+	// adds scripting hook for 'On HUD Config Menu Closed' --wookieejedi
+	if (scripting::hooks::OnHUDConfigMenuClosed->isActive()) {
+		scripting::hooks::OnHUDConfigMenuClosed->run(scripting::hook_param_list(scripting::hook_param("OptionsAccepted", 'b', true)));
+	}
+
 	gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -34,7 +34,19 @@ const std::shared_ptr<Hook<>> OnOptionsTabChanged = Hook<>::Factory("On Options 
 	});
 
 const std::shared_ptr<Hook<>> OnOptionsMenuClosed = Hook<>::Factory("On Options Menu Closed",
-	"Executed whenever a tab Options Menu is closed.",
+	"Executed whenever the Options Menu is closed.",
+	{
+		{"OptionsAccepted", "boolean", "Whether or not the options are being accepted and saved. Value is true if the options are accepted/saved, false if the options are discarded and not accepted/saved. "},
+	});
+
+const std::shared_ptr<Hook<>> OnHUDConfigMenuClosed = Hook<>::Factory("On HUD Config Menu Closed",
+	"Executed whenever the HUD Config Menu is closed.",
+	{
+		{"OptionsAccepted", "boolean", "Whether or not the options are being accepted and saved. Value is true if the options are accepted/saved, false if the options are discarded and not accepted/saved. "},
+	});
+
+const std::shared_ptr<Hook<>> OnControlConfigMenuClosed = Hook<>::Factory("On Controls Config Menu Closed",
+	"Executed whenever the Control Config Menu is closed.",
 	{
 		{"OptionsAccepted", "boolean", "Whether or not the options are being accepted and saved. Value is true if the options are accepted/saved, false if the options are discarded and not accepted/saved. "},
 	});

--- a/code/scripting/global_hooks.h
+++ b/code/scripting/global_hooks.h
@@ -11,6 +11,8 @@ extern const std::shared_ptr<OverridableHook<>>							OnIntroAboutToPlay;
 extern const std::shared_ptr<OverridableHook<>>							OnMovieAboutToPlay;
 extern const std::shared_ptr<Hook<>>									OnOptionsTabChanged;
 extern const std::shared_ptr<Hook<>>									OnOptionsMenuClosed;
+extern const std::shared_ptr<Hook<>>									OnHUDConfigMenuClosed;
+extern const std::shared_ptr<Hook<>>									OnControlConfigMenuClosed;
 //The On State Start hook previously used to pass OldState to the conditions, but no semantically sensible condition read the value, so we pretend it has no local condition
 extern const std::shared_ptr<OverridableHook<>>							OnStateStart;
 


### PR DESCRIPTION
Completes the full set of options screens with regards to scripting hooks by adding `On HUD Config Menu Close` and `On Control Config Menu Close`. Complements #6604.