### PR TITLE
change `objsnd_num` to use std::unique_ptr

### DIFF
--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -195,8 +195,6 @@ object::object()
 
 object::~object()
 {
-	objsnd_num.clear();
-
 	dock_free_dock_list(this);
 	dock_free_dead_dock_list(this);
 }
@@ -213,7 +211,7 @@ void object::clear()
 	radius = hull_strength = sim_hull_strength = 0.0f;
 	physics_init( &phys_info );
 	shield_quadrant.clear();
-	objsnd_num.clear();
+	objsnd_num.reset();
 	net_signature = 0;
 
 	pre_move_event.clear();

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -144,7 +144,7 @@ public:
 	SCP_vector<float>	shield_quadrant;	//	Shield is broken into components, quadrants by default.
 	float			hull_strength;	//	Remaining hull strength.
 	float			sim_hull_strength;	// Simulated hull strength - used with training weapons.
-	SCP_vector<int> objsnd_num;		// Index of persistant sound struct.
+	std::unique_ptr<SCP_vector<int>> objsnd_num;		// Index of persistent sound struct.
 	ushort			net_signature;
 	int				num_pairs;		// How many object pairs this is associated with.  When 0 then there are no more.
 

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -671,7 +671,7 @@ ADE_FUNC(removeSoundByIndex, l_Object, "number index", "Removes an assigned soun
 	auto objp = objh->objp();
 	snd_idx--;	// Lua -> C++
 
-	if (snd_idx < 0 || snd_idx >= (int)objp->objsnd_num.size())
+	if (!objp->objsnd_num || !SCP_vector_inbounds(*objp->objsnd_num, snd_idx))
 	{
 		LuaError(L, "Sound index is out of range for object %d!", OBJ_INDEX(objp));
 		return ADE_RETURN_NIL;
@@ -696,7 +696,7 @@ ADE_FUNC(getNumAssignedSounds,
 
 	auto objp = objh->objp();
 
-	return ade_set_args(L, "i", static_cast<int>(objp->objsnd_num.size()));
+	return ade_set_args(L, "i", !objp->objsnd_num ? 0 : static_cast<int>(objp->objsnd_num->size()));
 }
 
 ADE_FUNC(removeSound, l_Object, "soundentry GameSnd, [subsystem Subsys=nil]",

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -16252,8 +16252,6 @@ void ship_assign_sound(ship *sp)
 void ship_assign_sound_all()
 {
 	object *objp;
-	size_t idx;
-	int has_sounds;
 
 	if ( !Sound_enabled )
 		return;
@@ -16263,14 +16261,16 @@ void ship_assign_sound_all()
 			continue;
 
 		if ( objp->type == OBJ_SHIP && Player_obj != objp) {
-			has_sounds = 0;
+			bool has_sounds = false;
 
 			// check to make sure this guy hasn't got sounds already assigned to him
-			for(idx=0; idx<objp->objsnd_num.size(); idx++){
-				if(objp->objsnd_num[idx] != -1){
-					// skip
-					has_sounds = 1;
-					break;
+			if (objp->objsnd_num) {
+				for (const auto &num: *objp->objsnd_num) {
+					if (num != -1) {
+						// skip
+						has_sounds = true;
+						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
The vast majority of objects do not have or need sounds associated with them.  By moving the `objsnd_num` vector to `std::unique_ptr`, we can save space.