### PR TITLE
Hide Disabled Controls in the F1 Screen

### DIFF
--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -130,6 +130,11 @@ void gameplay_help_init_control_line(int id, gameplay_help_section &thisHelp)
 
 	auto ci = &Control_config[id];
 
+	// do not draw if a mod has disabled this control --wookieejedi
+	if (ci->disabled) {
+		return;
+	}
+
 	buf[0] = 0;
 
 	strcpy_s(buf, ci->first.textify().c_str());


### PR DESCRIPTION
If a control is disabled it does not appear to players in the Controls Configure screen, thus it should also not appear to players in the F1 Gameplay Help screen.  This PR adds a simple early return within `gameplay_help_init_control_line` to fix this issue.

Tested and works as expected.