### PR TITLE
upgrade line parsing and end-of-line checks

### DIFF
--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -38,6 +38,8 @@ extern int Token_found_flag;
 #define	EOLN			(char)0x0a
 #define CARRIAGE_RETURN (char)0x0d
 
+enum class LineEndingType { UNKNOWN, CR, CRLF, LF };
+
 #define	F_NAME					1
 #define	F_DATE					2
 #define	F_NOTES					3


### PR DESCRIPTION
Upgrade `parse_get_line` to detect all three EOL types: CR, LF, and CRLF.  The function is now more robust against line ending mismatches and will now also warn the modder if a file contains mixed line endings.

Fixes #6395.  Tested with various strings, files, line endings, and lengths; all cases work as expected.