### PR TITLE
Fix asteroids spawning outside active fields

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -161,6 +161,7 @@ bool Fix_scripted_velocity;
 color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 bool Preload_briefing_icon_models;
 EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
+bool Fix_asteroid_bounding_box_check;
 
 
 #ifdef WITH_DISCORD
@@ -1479,6 +1480,10 @@ void parse_mod_table(const char *filename)
 				}
 			}
 
+			if (optional_string("$Fix asteroid/debris field bounding box checks:")) {
+				stuff_boolean(&Fix_asteroid_bounding_box_check);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1704,6 +1709,7 @@ void mod_table_reset()
 	gr_init_alphacolor(&Overhead_line_colors[3], 100, 100, 100, 255);
 	Preload_briefing_icon_models = false;
 	escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
+	Fix_asteroid_bounding_box_check = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -176,6 +176,7 @@ extern bool Fix_scripted_velocity;
 extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 extern bool Preload_briefing_icon_models;
 extern EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
+extern bool Fix_asteroid_bounding_box_check;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
Found an interesting edge case bug with active asteroid fields that has been present since retail:  if a large ship is just outside an active asteroid field, that field will end up spawning asteroids outside the field bounds. This is because the game thinks that the large ship is within the asteroid field when it is actually not. Specifically, the check `asteroid_is_ship_inside_field` does not properly account for the ship the addition of the ship's diameter to the bounding box check.

This PR adds a flag to fix that bounding box check and fix the bug of spawing asteroids outside the asteroid field bounds. Note, `asteroid_is_ship_inside_field` is used twice in the code, once within `set_asteroid_throw_objnum` and once following that call within `maybe_throw_asteroid`. Also note, `asteroid_in_inner_bound` uses a delta of 0 in all cases except when being called within `asteroid_is_ship_inside_field`.

Tested and this fixes the bug while still having asteroid fields work as expected. (Also took this chance to rename a local variable for newly create asteroids to more descriptive name).