### PR TITLE
Update conditional check for wingmen dots

### DIFF
--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -657,7 +657,7 @@ void HudGaugeWingmanStatus::render(float  /*frametime*/, bool config)
 
 	int count = 0;
 	for (int i = 0; i < MAX_SQUADRON_WINGS; i++) {
-		if (!config && !((HUD_wingman_status[i].used) || (HUD_wingman_status[i].ignore)) ) {
+		if (!config && ( !(HUD_wingman_status[i].used) || (HUD_wingman_status[i].ignore) )) {
 			continue;
 		}
 


### PR DESCRIPTION
Fixes wingmen conditional check, thanks for Goober for catching this.

For reference, original check was
```
for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
    if ( !(HUD_wingman_status[i].used) || (HUD_wingman_status[i].ignore) ) {
        continue;
    }

    renderDots(i, count, num_wings_to_draw);
    count++;
}
```