### PR TITLE
a few minor fixes

### DIFF
--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -68,7 +68,7 @@ const float UPKEEP_DIST_MULT = 1.2f;
 const float PROBABLY_TOO_MANY_POOFS = 100000.0f;
 
 // bit array of neb2 poofs
-std::unique_ptr<ubyte> Neb2_poof_flags;
+std::unique_ptr<ubyte[]> Neb2_poof_flags;
 
 // array of neb2 bitmaps
 SCP_vector<SCP_string> Neb2_bitmap_filenames;
@@ -359,7 +359,7 @@ void neb2_init()
 	Poof_accum.resize(Poof_info.size());
 
 	// set up bit string
-	Neb2_poof_flags.reset(new ubyte[calculate_num_bytes(Poof_info.size())]);
+	Neb2_poof_flags = std::make_unique<ubyte[]>(calculate_num_bytes(Poof_info.size()));
 	clear_all_bits(Neb2_poof_flags.get(), Poof_info.size());
 }
 

--- a/code/nebula/neb.h
+++ b/code/nebula/neb.h
@@ -55,7 +55,7 @@ extern float Neb2_fog_visibility_shockwave;
 extern float Neb2_fog_visibility_fireball_const;
 extern float Neb2_fog_visibility_fireball_scaled_factor;
 
-extern std::unique_ptr<ubyte> Neb2_poof_flags;
+extern std::unique_ptr<ubyte[]> Neb2_poof_flags;
 
 // pof texture filenames
 extern SCP_vector<SCP_string> Neb2_bitmap_filenames;

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2409,6 +2409,19 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 			fout(" %d", flags_to_save | ((! cm.main_hall.empty()) ? CMISSION_FLAG_BASTION : 0));
 		}
 
+		if (!cm.substitute_main_hall.empty()) {
+			fso_comment_push(";;FSO 3.7.2;;");
+			if (optional_string_fred("+Substitute Main Hall:")) {
+				parse_comments(1);
+				fout(" %s", cm.substitute_main_hall.c_str());
+			} else {
+				fout_version("\n+Substitute Main Hall: %s", cm.substitute_main_hall.c_str());
+			}
+			fso_comment_pop();
+		} else {
+			bypass_comment(";;FSO 3.7.2;; +Substitute Main Hall:");
+		}
+
 		if (cm.debrief_persona_index > 0) {
 			fso_comment_push(";;FSO 3.6.8;;");
 			if (optional_string_fred("+Debriefing Persona Index:")) {


### PR DESCRIPTION
1. `Neb2_poof_flags` is a ubyte array, and so should be of type ubyte[], not ubyte
2. Save the substitute main hall in qtFRED