### PR TITLE
audit move semantics in the codebase

### DIFF
--- a/code/decals/decals.cpp
+++ b/code/decals/decals.cpp
@@ -26,28 +26,6 @@ DecalDefinition::~DecalDefinition() {
 	}
 }
 
-DecalDefinition::DecalDefinition(DecalDefinition&& other) noexcept {
-	*this = std::move(other); // Use operator implementation
-}
-
-DecalDefinition& DecalDefinition::operator=(DecalDefinition&& other) noexcept {
-	std::swap(_name, other._name);
-
-	std::swap(_diffuseFilename, other._diffuseFilename);
-	std::swap(_glowFilename, other._glowFilename);
-	std::swap(_normalMapFilename, other._normalMapFilename);
-
-	std::swap(_diffuseBitmap, other._diffuseBitmap);
-	std::swap(_glowBitmap, other._glowBitmap);
-	std::swap(_normalBitmap, other._normalBitmap);
-
-	std::swap(_loopDiffuse, other._loopDiffuse);
-	std::swap(_loopGlow, other._loopGlow);
-	std::swap(_loopNormal, other._loopNormal);
-
-	return *this;
-}
-
 void DecalDefinition::parse() {
 	if (optional_string("+Diffuse:")) {
 		stuff_string(_diffuseFilename, F_FILESPEC);

--- a/code/decals/decals.h
+++ b/code/decals/decals.h
@@ -33,8 +33,8 @@ class DecalDefinition {
 	DecalDefinition& operator=(const DecalDefinition&) = delete;
 
 	// Move constructor and operator
-	DecalDefinition(DecalDefinition&& other) noexcept;
-	DecalDefinition& operator=(DecalDefinition&& other) noexcept;
+	DecalDefinition(DecalDefinition&& other) noexcept = default;
+	DecalDefinition& operator=(DecalDefinition&& other) noexcept = default;
 
 	void parse();
 	void loadBitmaps();

--- a/code/graphics/opengl/ShaderProgram.cpp
+++ b/code/graphics/opengl/ShaderProgram.cpp
@@ -157,16 +157,6 @@ opengl::ShaderProgram::~ShaderProgram() {
 	}
 }
 
-opengl::ShaderProgram::ShaderProgram(ShaderProgram&& other) noexcept : _program_id(0), Uniforms(this) {
-	*this = std::move(other);
-}
-
-opengl::ShaderProgram& opengl::ShaderProgram::operator=(ShaderProgram&& other) noexcept {
-	std::swap(_program_id, other._program_id);
-	std::swap(Uniforms, other.Uniforms);
-
-	return *this;
-}
 void opengl::ShaderProgram::use() {
 	GL_state.UseProgram(_program_id);
 }

--- a/code/graphics/opengl/ShaderProgram.h
+++ b/code/graphics/opengl/ShaderProgram.h
@@ -58,8 +58,8 @@ class ShaderProgram {
 	ShaderProgram(const ShaderProgram&) = delete;
 	ShaderProgram& operator=(const ShaderProgram&) = delete;
 
-	ShaderProgram(ShaderProgram&& other) noexcept;
-	ShaderProgram& operator=(ShaderProgram&& other) noexcept;
+	ShaderProgram(ShaderProgram&& other) noexcept = default;
+	ShaderProgram& operator=(ShaderProgram&& other) noexcept = default;
 
 	void use();
 

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -218,22 +218,7 @@ static const int GL_num_shader_variants = sizeof(GL_shader_variants) / sizeof(op
 opengl_shader_t *Current_shader = NULL;
 
 opengl_shader_t::opengl_shader_t() : shader(SDR_TYPE_NONE), flags(0), flags2(0)
-{
-}
-opengl_shader_t::opengl_shader_t(opengl_shader_t&& other) noexcept {
-	*this = std::move(other);
-}
-// NOLINTNEXTLINE(misc-unconventional-assign-operator)
-opengl_shader_t& opengl_shader_t::operator=(opengl_shader_t&& other) noexcept {
-	// VS2013 doesn't support implicit move constructors so we need to explicitly declare it
-	shader = other.shader;
-	flags = other.flags;
-	flags2 = other.flags2;
-
-	program = std::move(other.program);
-
-	return *this;
-}
+{}
 
 /**
  * Set the currently active shader

--- a/code/graphics/opengl/gropenglshader.h
+++ b/code/graphics/opengl/gropenglshader.h
@@ -129,8 +129,8 @@ typedef struct opengl_shader_t {
 
 	opengl_shader_t();
 
-	opengl_shader_t(opengl_shader_t&& other) noexcept;
-	opengl_shader_t& operator=(opengl_shader_t&& other) noexcept;
+	opengl_shader_t(opengl_shader_t&& other) noexcept = default;
+	opengl_shader_t& operator=(opengl_shader_t&& other) noexcept = default;
 
 	opengl_shader_t(const opengl_shader_t&) = delete;
 	opengl_shader_t& operator=(const opengl_shader_t&) = delete;

--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -73,6 +73,9 @@ namespace io
 		
 		Cursor& Cursor::operator=(Cursor&& other) noexcept
 		{
+			if (this == &other)
+				return *this;
+
 			std::swap(this->mAnimationFrames, other.mAnimationFrames);
 			
 			this->mBitmapHandle = other.mBitmapHandle;

--- a/code/io/cursor.h
+++ b/code/io/cursor.h
@@ -30,9 +30,10 @@ namespace io
 			UI_TIMESTAMP mBeginTimeStamp; //!< The UI timestamp when the animation was started, unused when not animated
 			size_t mLastFrame; //!< The last frame which was set
 			
-			Cursor(const Cursor&); // Not implemented
-			Cursor& operator=(const Cursor&); // Not implemented
 		public:
+			Cursor(const Cursor&) = delete; // Not implemented
+			Cursor& operator=(const Cursor&) = delete; // Not implemented
+
 			/**
 			 * @brief Default constructor
 			 * @param bitmap The bitmap handle of the cursor. The cursor takes ownership over this handle

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -599,6 +599,9 @@ namespace joystick
 
 	Joystick &Joystick::operator=(Joystick &&other) noexcept
 	{
+		if (this == &other)
+			return *this;
+
 		std::swap(_device_id, other._device_id);
 		std::swap(_joystick, other._joystick);
 

--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -641,7 +641,14 @@ namespace animation {
 		operator=(other);
 	}
 
+	ModelAnimationSet::ModelAnimationSet(ModelAnimationSet&& other) noexcept {
+		*this = std::move(other);
+	}
+
 	ModelAnimationSet& ModelAnimationSet::operator=(ModelAnimationSet&& other) noexcept {
+		if (this == &other)
+			return *this;
+
 		std::swap(m_submodels, other.m_submodels);
 		std::swap(m_animationSet, other.m_animationSet);
 		std::swap(m_moveableSet, other.m_moveableSet);
@@ -655,8 +662,6 @@ namespace animation {
 				}
 			}
 		}
-
-
 
 		return *this;
 	}

--- a/code/model/animation/modelanimation.h
+++ b/code/model/animation/modelanimation.h
@@ -321,6 +321,7 @@ namespace animation {
 	public:
 		ModelAnimationSet(SCP_string SIPname = "");
 		ModelAnimationSet(const ModelAnimationSet& other);
+		ModelAnimationSet(ModelAnimationSet&& other) noexcept;
 		ModelAnimationSet& operator=(ModelAnimationSet&& other) noexcept;
 		ModelAnimationSet& operator=(const ModelAnimationSet& other);
 

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -187,16 +187,15 @@ checkobject::checkobject()
 
 // all we need to set are the pointers, but type, parent, and instance are useful to set as well
 object::object()
-	: next(nullptr), prev(nullptr), type(OBJ_NONE), parent(-1), instance(-1), hull_strength(0.0), sim_hull_strength(0.0),
-	net_signature(0), num_pairs(0), dock_list(nullptr), dead_dock_list(nullptr), collision_group_id(0)
+	: next(nullptr), prev(nullptr), signature(0), type(OBJ_NONE), parent(-1), parent_sig(0), instance(-1), pos(vmd_zero_vector), orient(vmd_identity_matrix),
+	radius(0.0f), last_pos(vmd_zero_vector), last_orient(vmd_identity_matrix), hull_strength(0.0f), sim_hull_strength(0.0f), net_signature(0), num_pairs(0),
+	dock_list(nullptr), dead_dock_list(nullptr), collision_group_id(0)
 {
 	memset(&(this->phys_info), 0, sizeof(physics_info));
 }
 
 object::~object()
 {
-	objsnd_num.clear();
-
 	dock_free_dock_list(this);
 	dock_free_dead_dock_list(this);
 }

--- a/code/object/object.h
+++ b/code/object/object.h
@@ -155,14 +155,19 @@ public:
 	util::event<void, object*> pre_move_event;
 	util::event<void, object*> post_move_event;
 
-	object();
-	~object();
 	void clear();
 
-private:
+
+	object();
+	~object();
+
 	// An object should never be copied; there are allocated pointers, and linked list shenanigans.
-	object(const object& other); // no implementation
-	object& operator= (const object & other); // no implementation
+	object(const object& other) = delete;
+	object& operator=(const object& other) = delete;
+
+	// Eventually we want to allow an object to be moved, especially when we get around to making Objects[] dynamic
+	object(object&& other) noexcept = delete;
+	object& operator=(object&& other) noexcept = delete;
 };
 
 struct lua_State;

--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -37,15 +37,28 @@ player* player_h::get() { return _plr; }
 player_h::~player_h()
 {
 	if (_owned)
-	{
 		delete _plr;
-	}
-	_plr = nullptr;
 }
-player_h::player_h(player_h&& other) noexcept { *this = std::move(other); }
+player_h::player_h(player_h&& other) noexcept
+	: _owned(other._owned), _plr(other._plr)
+{
+	other._owned = false;
+	other._plr = nullptr;
+}
 player_h& player_h::operator=(player_h&& other) noexcept
 {
-	std::swap(_plr, other._plr);
+	if (this != &other)
+	{
+		if (_owned)
+			delete _plr;
+
+		_owned = other._owned;
+		_plr = other._plr;
+
+		other._owned = false;
+		other._plr = nullptr;
+	}
+
 	return *this;
 }
 

--- a/code/scripting/api/objs/streaminganim.cpp
+++ b/code/scripting/api/objs/streaminganim.cpp
@@ -31,14 +31,16 @@ streaminganim_h::~streaminganim_h() {
 	// generic_anim_unload has safety checks
 	generic_anim_unload(&ga);
 }
-streaminganim_h::streaminganim_h(streaminganim_h&& other) noexcept {
-	// Copy the other data over to us
-	ga = other.ga;
-
+streaminganim_h::streaminganim_h(streaminganim_h&& other) noexcept
+	: ga(other.ga)
+{
 	// Reset the other instance so that we own the only instance
 	generic_anim_init(&other.ga, nullptr);
 }
 streaminganim_h& streaminganim_h::operator=(streaminganim_h&& other) noexcept {
+	if (this == &other)
+		return *this;
+
 	generic_anim_unload(&ga);
 
 	ga = other.ga;

--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -35,7 +35,8 @@ texture_h::texture_h(texture_h&& other) noexcept {
 	*this = std::move(other);
 }
 texture_h& texture_h::operator=(texture_h&& other) noexcept {
-	std::swap(handle, other.handle);
+	if (this != &other)
+		std::swap(handle, other.handle);
 	return *this;
 }
 

--- a/code/scripting/lua/LuaReference.cpp
+++ b/code/scripting/lua/LuaReference.cpp
@@ -45,8 +45,10 @@ UniqueLuaReference::UniqueLuaReference(UniqueLuaReference&& other) noexcept : _l
 	*this = std::move(other);
 }
 UniqueLuaReference& UniqueLuaReference::operator=(UniqueLuaReference&& other) noexcept {
-	std::swap(_luaState, other._luaState);
-	std::swap(_reference, other._reference);
+	if (this != &other) {
+		std::swap(_luaState, other._luaState);
+		std::swap(_reference, other._reference);
+	}
 	return *this;
 }
 

--- a/code/utils/event.h
+++ b/code/utils/event.h
@@ -14,6 +14,14 @@ class event final {
 	event()  = default;
 	~event() = default;
 
+	// no copies
+	event(const event<Ret, Args...>& other) = delete;
+	event<Ret, Args...>& operator=(const event<Ret, Args...>& other) = delete;
+
+	// moves allowed
+	event(event<Ret, Args...>&& other) noexcept = default;
+	event<Ret, Args...>& operator=(event<Ret, Args...>&& other) noexcept = default;
+
 	void add(callback_type func) { _listeners.push_back(func); }
 
 	void clear() { _listeners.clear(); }


### PR DESCRIPTION
For every move and move-assignment constructor, do the following:
1. Make it default if possible
2. Add or delete where appropriate
3. Check for move-onto-self
4. Apply `std::move` where needed

Also fix problematic moves in `player_h`