### PR TITLE
Allows mods to fully disable energy transfering

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -172,6 +172,7 @@ namespace AI {
 		Guards_ignore_protected_attackers,
 		Standard_strafe_used_more,
 		Unify_usage_ai_shield_manage_delay,
+		Disable_ai_transferring_energy,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -699,6 +699,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$unify usage of AI Shield Manage Delay:", AI::Profile_Flags::Unify_usage_ai_shield_manage_delay);
 
+				set_flag(profile, "$disable AI transferring energy:", AI::Profile_Flags::Disable_ai_transferring_energy);
+
 				// end of options ----------------------------------------
 
 				// if we've been through once already and are at the same place, force a move

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -289,7 +289,7 @@ void ai_manage_ets(object* obj)
 	}
 
 	// emergency check for ships with shields
-	if (!(obj->flags[Object::Object_Flags::No_shields])) {
+	if (!(obj->flags[Object::Object_Flags::No_shields]) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Disable_ai_transferring_energy])) {
 		float shield_left_percent = get_shield_pct(obj);
 		if ( shield_left_percent < SHIELDS_EMERG_LEVEL_PERCENT ) {
 			if (ship_p->target_shields_delta == 0.0f)

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -289,14 +289,16 @@ void ai_manage_ets(object* obj)
 	}
 
 	// emergency check for ships with shields
-	if (!(obj->flags[Object::Object_Flags::No_shields]) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Disable_ai_transferring_energy])) {
+	if (!(obj->flags[Object::Object_Flags::No_shields])) {
 		float shield_left_percent = get_shield_pct(obj);
-		if ( shield_left_percent < SHIELDS_EMERG_LEVEL_PERCENT ) {
-			if (ship_p->target_shields_delta == 0.0f)
-				transfer_energy_to_shields(obj);
-		} else if ( weapon_left_percent < WEAPONS_EMERG_LEVEL_PERCENT ) {
-			if ( shield_left_percent > SHIELDS_MIN_LEVEL_PERCENT || weapon_left_percent <= 0.01 )	// dampen ai enthusiasm for sucking energy to weapons
-				transfer_energy_to_weapons(obj);
+		if (!(The_mission.ai_profile->flags[AI::Profile_Flags::Disable_ai_transferring_energy])) {
+			if ( shield_left_percent < SHIELDS_EMERG_LEVEL_PERCENT ) {
+				if (ship_p->target_shields_delta == 0.0f)
+					transfer_energy_to_shields(obj);
+			} else if ( weapon_left_percent < WEAPONS_EMERG_LEVEL_PERCENT ) {
+				if ( shield_left_percent > SHIELDS_MIN_LEVEL_PERCENT || weapon_left_percent <= 0.01 )	// dampen ai enthusiasm for sucking energy to weapons
+					transfer_energy_to_weapons(obj);
+			}
 		}
 	
 		// check for return to normal values


### PR DESCRIPTION
Mods such as FotG disable the controls for transferring energy between the shields and weapons for multiple reasons (such as being very difficult to balance, especially with varying weapon recharge rates). Even with the player having that ability disabled, the AI still currently is able to do this.

This PR creates a AI profiles flag to also prevent the AI from using the energy transfer ability. Note, it is set as a AI profiles flag since it's a higher order option related to if mods overall allow this ability or not.