### PR TITLE
Fix mini-shield custom filename

### DIFF
--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -136,9 +136,12 @@ void hud_shield_level_init()
 		Hud_shield_inited = 1;
 	}
 
-	Shield_mini_gauge.first_frame = bm_load_animation("targhit1", &Shield_mini_gauge.num_frames);
+	// the shield mini gauge is loaded in HudGaugeShieldMini::pageIn()
+	// though it wouldn't hurt to keep this old failsafe code here
+	// since we are setting the status of if the mini shield was loaded
+	// --wookieejedi
 	if ( Shield_mini_gauge.first_frame == -1 ) {
-		Warning(LOCATION, "Could not load in the HUD shield ani: targhit1\n");
+		Warning(LOCATION, "Could not load in the HUD shield ani \n");
 		return;
 	}
 	Shield_mini_loaded = 1;


### PR DESCRIPTION
The HUD table allows modders to set a filename for the HUD Mini Shields Gauge. FSO will parse this and load in the bitmap on game initiation, but this custom named animation ends up not being used b/c there is another `bm_load_animation` call within `hud_shield_level_init`. It seems back in 2010 "Antipodes 7 Merge: HUD Overhaul" Swifty set this as a hardcoded name. Ultimately though, the HUD gauges have been updated since then, specifically with `HudGaugeShieldMini::pageIn()`, and there is no longer a need to page in bitmaps at the start of each level (other gauges also no longer do this properly). This PR removes that relic page-in call, adds a comment for clarification.

Tested and works as expected.