### PR TITLE
change several vm_strdup strings to std::unique_ptr

### DIFF
--- a/code/globalincs/globals.h
+++ b/code/globalincs/globals.h
@@ -16,15 +16,11 @@
 #define	DATE_LENGTH				32
 #define	TIME_LENGTH				16
 #define	DATE_TIME_LENGTH		48
-#define	NOTES_LENGTH			1024
 #define	MULTITEXT_LENGTH		4096
 #define	FILESPEC_LENGTH			64
 #define	MESSAGE_LENGTH			512
 #define TRAINING_MESSAGE_LENGTH	512
 #define CONDITION_LENGTH		64
-
-// from missionparse.h
-#define MISSION_DESC_LENGTH		512
 
 // from player.h
 #define CALLSIGN_LEN					(MAX_FILENAME_LEN - 4 - 1)		//	shortened from 32 to allow .json to be attached without exceeding MAX_FILENAME_LEN

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -1932,7 +1932,7 @@ main_hall_defines* main_hall_get_pointer(const SCP_string &name_to_find)
 	unsigned int i;
 
 	for (i = 0; i < Main_hall_defines.size(); i++) {
-		if (!stricmp(Main_hall_defines.at(i).at(0).name.c_str(), name_to_find.c_str())) {
+		if (lcase_equal(Main_hall_defines.at(i).at(0).name, name_to_find)) {
 			return &Main_hall_defines.at(i).at(main_hall_get_resolution_index(i));
 		}
 	}
@@ -1952,7 +1952,7 @@ int main_hall_get_index(const SCP_string &name_to_find)
 	unsigned int i;
 
 	for (i = 0; i < Main_hall_defines.size(); i++) {
-		if (!stricmp(Main_hall_defines.at(i).at(0).name.c_str(), name_to_find.c_str())) {
+		if (lcase_equal(Main_hall_defines.at(i).at(0).name, name_to_find)) {
 			return i;
 		}
 	}

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -502,7 +502,7 @@ int build_standalone_mission_list_do_frame(bool API_Access)
 					sim_mission api_mission;
 					api_mission.name = The_mission.name;
 					api_mission.filename = filename;
-					api_mission.mission_desc = The_mission.mission_desc;
+					api_mission.mission_desc = coalesce(The_mission.mission_desc.get(), "");
 					api_mission.author = The_mission.author;
 					api_mission.visible = 1;
 
@@ -574,7 +574,7 @@ int build_campaign_mission_list_do_frame(bool API_Access)
 				sim_mission api_mission;
 				api_mission.name = The_mission.name;
 				api_mission.filename = filename;
-				api_mission.mission_desc = The_mission.mission_desc;
+				api_mission.mission_desc = coalesce(The_mission.mission_desc.get(), "");
 				api_mission.author = The_mission.author;
 				api_mission.visible = Campaign.missions[Num_campaign_missions_with_info].completed;
 

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -91,17 +91,17 @@ class cmission
 {
 public:
 	char				*name;					// name of the mission
-	char				*notes;					// mission notes for mission (used by Fred)
-	char				briefing_cutscene[NAME_LENGTH];	// name of the cutscene to be played before this mission
+	std::unique_ptr<char[]> notes;			// mission notes for mission (used by Fred)
+	std::unique_ptr<char[]> briefing_cutscene;	// name of the cutscene to be played before this mission
 	int				formula;					// sexpression used to determine mission branching.
-	int				completed;				// has the player completed this mission
+	bool			completed;				// has the player completed this mission
 	SCP_vector<mgoal> goals;				// vector of mgoals which has the goal completion status
 	SCP_vector<mevent> events;				// vector of mevents which has the event completion status
 	SCP_vector<sexp_variable> variables;	// vector of sexp_variables (of num_variables size) containing mission-persistent variables - Goober5000
 	int				mission_loop_formula;	// formula to determine whether to allow a side loop
-	char			*mission_branch_desc;	// message in popup
-	char			*mission_branch_brief_anim;
-	char			*mission_branch_brief_sound;
+	std::unique_ptr<char[]> mission_branch_desc;	// message in popup
+	std::unique_ptr<char[]> mission_branch_brief_anim;
+	std::unique_ptr<char[]> mission_branch_brief_sound;
 	int				level;					// what level of the tree it's on (Fred)
 	int				pos;					// what x position on level it's on (Fred)
 	int				flags;
@@ -148,9 +148,9 @@ public:
 extern campaign Campaign;
 
 // campaign wasn't ended
-extern int Campaign_ending_via_supernova;
+extern bool Campaign_ending_via_supernova;
 
-// extern'ed so the mission loading can get a list of campains.  Only use this
+// extern'ed so the mission loading can get a list of campaigns.  Only use this
 // data after mission_campaign_build_list() is called
 #define MAX_CAMPAIGNS	128
 extern char *Campaign_names[MAX_CAMPAIGNS];

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -560,10 +560,10 @@ void parse_mission_info(mission *pm, bool basic = false)
 	stuff_string(pm->modified, F_DATE, DATE_TIME_LENGTH);
 
 	required_string("$Notes:");
-	stuff_string(pm->notes, F_NOTES, NOTES_LENGTH);
+	stuff_string(pm->notes, F_NOTES, true);
 
 	if (optional_string("$Mission Desc:"))
-		stuff_string(pm->mission_desc, F_MULTITEXT, MISSION_DESC_LENGTH);		
+		stuff_string(pm->mission_desc, F_MULTITEXT, true);
 
 	if ( optional_string("+Game Type:")) {
 		// HACK HACK HACK -- stuff_string was changed to *not* ignore carriage returns.  Since the
@@ -6734,8 +6734,8 @@ void mission::Reset()
 	required_fso_version = LEGACY_MISSION_VERSION;
 	created[ 0 ] = '\0';
 	modified[ 0 ] = '\0';
-	notes[ 0 ] = '\0';
-	mission_desc[ 0 ] = '\0';
+	notes.reset();
+	mission_desc.reset();
 	game_type = MISSION_TYPE_SINGLE;				// default to single player only
 	flags.reset();
 

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -150,8 +150,8 @@ typedef struct mission {
 	gameversion::version	required_fso_version;
 	char	created[DATE_TIME_LENGTH];
 	char	modified[DATE_TIME_LENGTH];
-	char	notes[NOTES_LENGTH];
-	char	mission_desc[MISSION_DESC_LENGTH];
+	std::unique_ptr<char[]> notes;
+	std::unique_ptr<char[]> mission_desc;
 	int	game_type;
     flagset<Mission::Mission_Flags> flags;
 	int	num_players;									// valid in multiplayer missions -- number of players supported

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -1258,7 +1258,7 @@ void debrief_kick_selected_player()
 
 
 // get optional mission popup text 
-void debrief_assemble_optional_mission_popup_text(char *buffer, char *mission_loop_desc)
+void debrief_assemble_optional_mission_popup_text(char *buffer, const char *mission_loop_desc)
 {
 	Assert(buffer != NULL);
 	// base message
@@ -1340,7 +1340,7 @@ void debrief_accept(int ok_to_post_start_game_event, bool API_Access)
 				if ( (Campaign.missions[cur].flags & CMISSION_FLAG_HAS_LOOP) && (Campaign.loop_mission != -1) && !require_repeat_mission ) {
 					/*
 					char buffer[512];
-					debrief_assemble_optional_mission_popup_text(buffer, Campaign.missions[cur].mission_loop_desc);
+					debrief_assemble_optional_mission_popup_text(buffer, Campaign.missions[cur].mission_loop_desc.get());
 
 					int choice = popup(0 , 2, POPUP_NO, POPUP_YES, buffer);
 					if (choice == 1) {

--- a/code/missionui/missiondebrief.h
+++ b/code/missionui/missiondebrief.h
@@ -33,7 +33,7 @@ void debrief_handle_player_drop();
 
 void debrief_maybe_auto_accept();
 void debrief_disable_accept();
-void debrief_assemble_optional_mission_popup_text(char *buffer, char *mission_loop_desc);
+void debrief_assemble_optional_mission_popup_text(char *buffer, const char *mission_loop_desc);
 
 int debrief_select_music();
 void debrief_choose_medal_variant(char* buf, int medal_earned, int zero_based_version_index);

--- a/code/missionui/missionloopbrief.cpp
+++ b/code/missionui/missionloopbrief.cpp
@@ -150,13 +150,8 @@ void loop_brief_init()
 		Loop_brief_window.add_XSTR(&Loop_text[gr_screen.res][idx]);
 	}
 
-	const char* anim_name;
 	// load animation if any
-	if(Campaign.missions[Campaign.current_mission].mission_branch_brief_anim != NULL){
-		anim_name = Campaign.missions[Campaign.current_mission].mission_branch_brief_anim;
-	} else {
-		anim_name = "CB_default";
-	}
+	auto anim_name = coalesce(Campaign.missions[Campaign.current_mission].mission_branch_brief_anim.get(), "CB_default");
 
 	int stream_result = generic_anim_init_and_stream(&Loop_anim, anim_name, bm_get_type(Loop_brief_bitmap), true);
 	// we've failed to load any animation
@@ -169,16 +164,15 @@ void loop_brief_init()
 	}
 
 	// init brief text
-	if(Campaign.missions[Campaign.current_mission].mission_branch_desc != NULL){
-		brief_color_text_init(Campaign.missions[Campaign.current_mission].mission_branch_desc, Loop_brief_text_coords[gr_screen.res][2], default_loop_briefing_color);
+	if (Campaign.missions[Campaign.current_mission].mission_branch_desc) {
+		brief_color_text_init(Campaign.missions[Campaign.current_mission].mission_branch_desc.get(), Loop_brief_text_coords[gr_screen.res][2], default_loop_briefing_color);
 	}
 
 	bool sound_played = false;
 
-
 	// open sound
-	if(Campaign.missions[Campaign.current_mission].mission_branch_brief_sound != NULL){
-		Loop_sound = audiostream_open(Campaign.missions[Campaign.current_mission].mission_branch_brief_sound, ASF_VOICE);
+	if (Campaign.missions[Campaign.current_mission].mission_branch_brief_sound) {
+		Loop_sound = audiostream_open(Campaign.missions[Campaign.current_mission].mission_branch_brief_sound.get(), ASF_VOICE);
 
 		if(Loop_sound != -1){
 			audiostream_play(Loop_sound, Master_voice_volume, 0);
@@ -186,10 +180,8 @@ void loop_brief_init()
 		}
 	}
 
-	if(sound_played == false) {
-		fsspeech_play(FSSPEECH_FROM_BRIEFING, 
-			Campaign.missions[Campaign.current_mission].mission_branch_desc);
-
+	if (!sound_played) {
+		fsspeech_play(FSSPEECH_FROM_BRIEFING, coalesce(Campaign.missions[Campaign.current_mission].mission_branch_desc.get(), ""));
 	}
 
 	// music

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -70,6 +70,7 @@
 #include "menuui/mainhallmenu.h"
 #include "debugconsole/console.h"
 #include "network/multi_mdns.h"
+#include "globalincs/utility.h"
 
 #include <algorithm>
 
@@ -4787,7 +4788,7 @@ void multi_create_list_set_item(int abs_index, int mode) {
 			strcpy_s(ng->title, The_mission.name);
 
 			// set the information area text
-			Multi_netgame_common_description = The_mission.mission_desc;
+			Multi_netgame_common_description = coalesce(The_mission.mission_desc.get(), "");
 			multi_common_set_text(Multi_netgame_common_description.c_str());
 		}
 		// if we're on the standalone, send a request for the description
@@ -4854,8 +4855,8 @@ void multi_create_list_set_item(int abs_index, int mode) {
 
 			int rc = get_mission_info(first_mission, mp, true);
 
-			if (!rc && strlen(mp->mission_desc)) {
-				Multi_netgame_common_description += mp->mission_desc;
+			if (!rc && mp->mission_desc) {
+				Multi_netgame_common_description += mp->mission_desc.get();
 			} else {
 				Multi_netgame_common_description += "No description available.";
 			}
@@ -8709,7 +8710,7 @@ void multi_maybe_set_mission_loop()
 	if ( (Campaign.missions[cur].flags & CMISSION_FLAG_HAS_LOOP) && (Campaign.loop_mission != -1) && !require_repeat_mission ) {
 
 		char buffer[512];
-		debrief_assemble_optional_mission_popup_text(buffer, Campaign.missions[cur].mission_branch_desc);
+		debrief_assemble_optional_mission_popup_text(buffer, Campaign.missions[cur].mission_branch_desc.get());
 
 		int choice = popup(0 , 2, POPUP_NO, POPUP_YES, buffer);
 		if (choice == 1) {

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -15475,7 +15475,7 @@ void sexp_end_campaign(int n)
 	// code needs special time to execute and will post GS_EVENT_END_CAMPAIGN with Game_mode check
 	// or show death-popup when it's done - taylor
 	if (supernova_active() /*&& !stricmp(Campaign.filename, "freespace2")*/) {
-		Campaign_ending_via_supernova = 1;
+		Campaign_ending_via_supernova = true;
 	} else {
 		// post and event to move us to the end-of-campaign state
 		gameseq_post_event(GS_EVENT_END_CAMPAIGN);

--- a/code/scripting/api/objs/loop_brief.cpp
+++ b/code/scripting/api/objs/loop_brief.cpp
@@ -36,7 +36,7 @@ ADE_VIRTVAR(Text,
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current.getStage()->mission_branch_desc);
+	return ade_set_args(L, "s", coalesce(current.getStage()->mission_branch_desc.get(), ""));
 }
 
 ADE_VIRTVAR(AniFilename,
@@ -55,7 +55,7 @@ ADE_VIRTVAR(AniFilename,
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current.getStage()->mission_branch_brief_anim);
+	return ade_set_args(L, "s", coalesce(current.getStage()->mission_branch_brief_anim.get(), ""));
 }
 
 ADE_VIRTVAR(AudioFilename,
@@ -74,7 +74,7 @@ ADE_VIRTVAR(AudioFilename,
 		LuaError(L, "This property is read only.");
 	}
 
-	return ade_set_args(L, "s", current.getStage()->mission_branch_brief_sound);
+	return ade_set_args(L, "s", coalesce(current.getStage()->mission_branch_brief_sound.get(), ""));
 }
 
 } // namespace api

--- a/fred2/campaigntreeview.h
+++ b/fred2/campaigntreeview.h
@@ -30,9 +30,9 @@ typedef struct campaign_tree_link {
 	int to_pos;	// to link drawing offset
 	bool is_mission_loop;	// whether link leads to mission loop
 	bool is_mission_fork;	// whether link leads to mission fork
-	char *mission_branch_txt;	// text describing mission loop
-	char *mission_branch_brief_anim;	// filename of anim to play in the brief
-	char *mission_branch_brief_sound;	// filename of anim to play in the brief
+	std::unique_ptr<char[]> mission_branch_txt;	// text describing mission loop
+	std::unique_ptr<char[]> mission_branch_brief_anim;	// filename of anim to play in the brief
+	std::unique_ptr<char[]> mission_branch_brief_sound;	// filename of anim to play in the brief
 	CPoint p1;	// coordinates of line last draw for link, from p1 to p2
 	CPoint p2;
 } campaign_tree_link;

--- a/fred2/campaigntreewnd.cpp
+++ b/fred2/campaigntreewnd.cpp
@@ -21,6 +21,7 @@
 #include "InitialShips.h"
 #include "mission/missionparse.h"
 #include "parse/parselo.h"
+#include "utils/string_utils.h"
 
 #ifdef _DEBUG
 #undef THIS_FILE

--- a/fred2/dumpstats.cpp
+++ b/fred2/dumpstats.cpp
@@ -141,10 +141,10 @@ void DumpStats::get_mission_stats(CString &buffer)
 	temp.Format("Author: %s\r\n", The_mission.author.c_str());
 	buffer += temp;
 
-	temp.Format("Description: %s\r\n", The_mission.mission_desc);
+	temp.Format("Description: %s\r\n", coalesce(The_mission.mission_desc.get(), ""));
 	buffer += temp;
 
-	temp.Format("Notes: %s\r\n", The_mission.notes);
+	temp.Format("Notes: %s\r\n", coalesce(The_mission.notes.get(), ""));
 	buffer += temp;
 
 	if (The_mission.game_type & MISSION_TYPE_SINGLE) {

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -51,7 +51,7 @@ extern char Voice_abbrev_debriefing[NAME_LENGTH];
 extern char Voice_abbrev_message[NAME_LENGTH];
 extern char Voice_abbrev_mission[NAME_LENGTH];
 extern bool Voice_no_replace_filenames;
-extern char Voice_script_entry_format[NOTES_LENGTH];
+extern SCP_string Voice_script_entry_format;
 extern int Voice_export_selection;
 
 // Goober5000
@@ -64,9 +64,10 @@ void string_copy(SCP_string& dest, const CString& src, bool modify = false);
 void convert_multiline_string(CString& dest, const SCP_string& src);
 void convert_multiline_string(CString& dest, const char* src);
 void deconvert_multiline_string(char* dest, const CString& str, size_t max_len);
+void deconvert_multiline_string(std::unique_ptr<char[]> &dest, const CString &str);
 void deconvert_multiline_string(SCP_string& dest, const CString& str);
 void strip_quotation_marks(CString& str);
-void pad_with_newline(CString& str, int max_size);
+void pad_with_newline(CString& str, size_t max_size = std::numeric_limits<size_t>::max());
 void lcl_fred_replace_stuff(CString& text);
 
 bool fred_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps);

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -318,14 +318,14 @@ void CMissionNotesDlg::OnOK()
 	lcl_fred_replace_stuff(m_squad_name);
 
 	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
-	pad_with_newline(m_mission_notes, NOTES_LENGTH - 1);
+	pad_with_newline(m_mission_notes);
 
 	string_copy(The_mission.name, m_mission_title, NAME_LENGTH - 1, 1);
-	string_copy(The_mission.author, m_designer_name, true);
+	The_mission.author = m_designer_name;
 	string_copy(The_mission.loading_screen[GR_640], m_loading_640, NAME_LENGTH - 1, 1);
 	string_copy(The_mission.loading_screen[GR_1024], m_loading_1024, NAME_LENGTH - 1, 1);
-	deconvert_multiline_string(The_mission.notes, m_mission_notes, NOTES_LENGTH - 1);
-	deconvert_multiline_string(The_mission.mission_desc, m_mission_desc, MISSION_DESC_LENGTH - 1);
+	deconvert_multiline_string(The_mission.notes, m_mission_notes);
+	deconvert_multiline_string(The_mission.mission_desc, m_mission_desc);
 
 	// copy squad stuff
 	if(m_squad_name == CString(NO_SQUAD)){
@@ -392,10 +392,10 @@ BOOL CMissionNotesDlg::OnInitDialog()
 	m_designer_name_orig = m_designer_name = _T(The_mission.author.c_str());
 	m_created = _T(The_mission.created);
 	m_modified = _T(The_mission.modified);
-	convert_multiline_string(m_mission_notes_orig, The_mission.notes);
-	convert_multiline_string(m_mission_notes, The_mission.notes);
-	convert_multiline_string(m_mission_desc_orig, The_mission.mission_desc);
-	convert_multiline_string(m_mission_desc, The_mission.mission_desc);
+	convert_multiline_string(m_mission_notes_orig, The_mission.notes.get());
+	convert_multiline_string(m_mission_notes, The_mission.notes.get());
+	convert_multiline_string(m_mission_desc_orig, The_mission.mission_desc.get());
+	convert_multiline_string(m_mission_desc, The_mission.mission_desc.get());
 	m_red_alert = (The_mission.flags[Mission::Mission_Flags::Red_alert]) ? 1 : 0;
 	m_scramble = (The_mission.flags[Mission::Mission_Flags::Scramble]) ? 1 : 0;
 	m_full_war = Mission_all_attack;

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1363,25 +1363,26 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 	fred_parse_flag = 0;
 	for (i = 0; i < Campaign.num_missions; i++) {
 		m = Sorted[i];
+		cmission &cm = Campaign.missions[m];
 		required_string_either_fred("$Mission:", "#End");
 		required_string_fred("$Mission:");
 		parse_comments(2);
-		fout(" %s", Campaign.missions[m].name);
+		fout(" %s", cm.name);
 
-		if (strlen(Campaign.missions[i].briefing_cutscene)) {
+		if (cm.briefing_cutscene) {
 			if (optional_string_fred("+Briefing Cutscene:", "$Mission"))
 				parse_comments();
 			else
 				fout("\n+Briefing Cutscene:");
 
-			fout(" %s", Campaign.missions[i].briefing_cutscene);
+			fout(" %s", cm.briefing_cutscene.get());
 		}
 
 		required_string_fred("+Flags:", "$Mission:");
 		parse_comments();
 
 		// don't save any internal flags
-		auto flags_to_save = Campaign.missions[m].flags & CMISSION_EXTERNAL_FLAG_MASK;
+		auto flags_to_save = cm.flags & CMISSION_EXTERNAL_FLAG_MASK;
 
 		// Goober5000
 		if (Mission_save_format != FSO_FORMAT_RETAIL) {
@@ -1394,32 +1395,32 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 			else
 				fout("\n+Main Hall:");
 
-			fout(" %s", Campaign.missions[m].main_hall.c_str());
+			fout(" %s", cm.main_hall.c_str());
 		} else {
 			// save Bastion flag properly
-			fout(" %d", flags_to_save | ((Campaign.missions[m].main_hall != "") ? CMISSION_FLAG_BASTION : 0));
+			fout(" %d", flags_to_save | (!cm.main_hall.empty() ? CMISSION_FLAG_BASTION : 0));
 		}
 
-		if (!Campaign.missions[m].substitute_main_hall.empty()) {
+		if (!cm.substitute_main_hall.empty()) {
 			fso_comment_push(";;FSO 3.7.2;;");
 			if (optional_string_fred("+Substitute Main Hall:")) {
 				parse_comments(1);
-				fout(" %s", Campaign.missions[m].substitute_main_hall.c_str());
+				fout(" %s", cm.substitute_main_hall.c_str());
 			} else {
-				fout_version("\n+Substitute Main Hall: %s", Campaign.missions[m].substitute_main_hall.c_str());
+				fout_version("\n+Substitute Main Hall: %s", cm.substitute_main_hall.c_str());
 			}
 			fso_comment_pop();
 		} else {
 			bypass_comment(";;FSO 3.7.2;; +Substitute Main Hall:");
 		}
 
-		if (Campaign.missions[m].debrief_persona_index > 0) {
+		if (cm.debrief_persona_index > 0) {
 			fso_comment_push(";;FSO 3.6.8;;");
 			if (optional_string_fred("+Debriefing Persona Index:")) {
 				parse_comments(1);
-				fout(" %d", Campaign.missions[m].debrief_persona_index);
+				fout(" %d", cm.debrief_persona_index);
 			} else {
-				fout_version("\n+Debriefing Persona Index: %d", Campaign.missions[m].debrief_persona_index);
+				fout_version("\n+Debriefing Persona Index: %d", cm.debrief_persona_index);
 			}
 			fso_comment_pop();
 		} else {
@@ -1477,7 +1478,7 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 						else
 							required_string_fred("+Mission Fork Text:");
 						parse_comments();
-						fout_ext("\n", "%s", Links[j].mission_branch_txt);
+						fout_ext("\n", "%s", Links[j].mission_branch_txt.get());
 						fout("\n$end_multi_text");
 					}
 
@@ -1487,7 +1488,7 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 						else
 							required_string_fred("+Mission Fork Brief Anim:");
 						parse_comments();
-						fout_ext("\n", "%s", Links[j].mission_branch_brief_anim);
+						fout_ext("\n", "%s", Links[j].mission_branch_brief_anim.get());
 						fout("\n$end_multi_text");
 					}
 
@@ -1497,7 +1498,7 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 						else
 							required_string_fred("+Mission Fork Brief Sound:");
 						parse_comments();
-						fout_ext("\n", "%s", Links[j].mission_branch_brief_sound);
+						fout_ext("\n", "%s", Links[j].mission_branch_brief_sound.get());
 						fout("\n$end_multi_text");
 					}
 
@@ -2706,7 +2707,7 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Notes:");
 	parse_comments();
-	fout("\n%s", The_mission.notes);
+	fout("\n%s", coalesce(The_mission.notes.get(), ""));
 
 	required_string_fred("$End Notes:");
 	parse_comments(0);
@@ -2714,7 +2715,7 @@ int CFred_mission_save::save_mission_info()
 	// XSTR
 	required_string_fred("$Mission Desc:");
 	parse_comments(2);
-	fout_ext("\n", "%s", The_mission.mission_desc);
+	fout_ext("\n", "%s", coalesce(The_mission.mission_desc.get(), ""));
 	fout("\n");
 
 	required_string_fred("$end_multi_text");

--- a/fred2/voiceactingmanager.cpp
+++ b/fred2/voiceactingmanager.cpp
@@ -32,7 +32,7 @@ char Voice_abbrev_debriefing[NAME_LENGTH];
 char Voice_abbrev_message[NAME_LENGTH];
 char Voice_abbrev_mission[NAME_LENGTH];
 bool Voice_no_replace_filenames;
-char Voice_script_entry_format[NOTES_LENGTH];
+SCP_string Voice_script_entry_format;
 int Voice_export_selection;
 bool Voice_group_messages;
 
@@ -161,7 +161,7 @@ BOOL VoiceActingManager::OnInitDialog()
 	m_no_replace = Voice_no_replace_filenames;
 
 	// load saved data for script
-	m_script_entry_format = _T(Voice_script_entry_format);
+	m_script_entry_format = _T(Voice_script_entry_format.c_str());
 	m_export_everything = m_export_command_briefings = m_export_briefings = m_export_debriefings = m_export_messages = FALSE;
 	if (Voice_export_selection == 1)
 		m_export_command_briefings = TRUE;
@@ -204,7 +204,7 @@ void VoiceActingManager::OnClose()
 	Voice_no_replace_filenames = (m_no_replace == TRUE) ? true : false;
 
 	// save data for script
-	strcpy_s(Voice_script_entry_format, m_script_entry_format);
+	Voice_script_entry_format = (LPCTSTR)m_script_entry_format;
 	if (m_export_command_briefings)
 		Voice_export_selection = 1;
 	else if (m_export_briefings)

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1112,7 +1112,7 @@ void game_level_init()
 	Last_view_target = nullptr;
 
 	// campaign wasn't ended
-	Campaign_ending_via_supernova = 0;
+	Campaign_ending_via_supernova = false;
 
 	load_gl_init = (time(nullptr) - load_gl_init);
 	mprintf(("Game_level_init took %ld seconds\n", load_gl_init));

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -29,6 +29,7 @@
 #include "starfield/starfield.h" // stars_init, stars_pre_level_init, stars_post_level_init
 #include "hud/hudsquadmsg.h"
 #include "globalincs/linklist.h"
+#include "utils/string_utils.h"
 
 #include "ui/QtGraphicsOperations.h"
 
@@ -509,8 +510,8 @@ void Editor::clearMission(bool fast_reload) {
 	The_mission.author = userName;
 	time_to_mission_info_string(timeinfo, The_mission.created, DATE_TIME_LENGTH - 1);
 	strcpy_s(The_mission.modified, The_mission.created);
-	strcpy_s(The_mission.notes, "This is a FRED2_OPEN created mission.");
-	strcpy_s(The_mission.mission_desc, "Put mission description here");
+	The_mission.notes = util::unique_copy("This is a FRED2_OPEN created mission.", true);
+	The_mission.mission_desc = util::unique_copy("Put mission description here", true);
 
 	// reset alternate name & callsign stuff
 	for (auto i = 0; i < MAX_SHIPS; i++) {

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -186,7 +186,7 @@ class Editor : public QObject {
 	void normalizeShieldSysData();
 
 	static void strip_quotation_marks(SCP_string& str);
-	static void pad_with_newline(SCP_string& str, size_t max_size);
+	static void pad_with_newline(SCP_string& str, size_t max_size = std::numeric_limits<size_t>::max());
 	static void lcl_fred_replace_stuff(QString& text);
 
 	SCP_vector<int> getStartingWingLoadoutUseCounts();

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -13,6 +13,7 @@
 #include "cfile/cfile.h"
 #include "localization/localize.h"
 #include "mission/missionmessage.h"
+#include "utils/string_utils.h"
 
 #include <QtWidgets>
 
@@ -30,8 +31,8 @@ void MissionSpecDialogModel::initializeData() {
 	_m_designer_name = The_mission.author;
 	_m_created = The_mission.created;
 	_m_modified = The_mission.modified;
-	_m_mission_notes = The_mission.notes;
-	_m_mission_desc = The_mission.mission_desc;
+	_m_mission_notes = coalesce(The_mission.notes.get(), "");
+	_m_mission_desc = coalesce(The_mission.mission_desc.get(), "");
 
 	_m_full_war = Mission_all_attack;
 	_m_disallow_support = (The_mission.support_ships.max_support_ships == 0);
@@ -112,14 +113,14 @@ bool MissionSpecDialogModel::apply() {
 	lcl_fred_replace_stuff(_m_squad_name);
 
 	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
-	Editor::pad_with_newline(_m_mission_notes, NOTES_LENGTH - 1);
+	Editor::pad_with_newline(_m_mission_notes);
 
 	strncpy(The_mission.name, _m_mission_title.c_str(), NAME_LENGTH-1);
 	The_mission.author = _m_designer_name;
 	strncpy(The_mission.loading_screen[GR_640], _m_loading_640.c_str(), NAME_LENGTH-1);
 	strncpy(The_mission.loading_screen[GR_1024], _m_loading_1024.c_str(), NAME_LENGTH-1);
-	strncpy(The_mission.notes, _m_mission_notes.c_str(), NOTES_LENGTH);
-	strncpy(The_mission.mission_desc, _m_mission_desc.c_str(), MISSION_DESC_LENGTH);
+	The_mission.notes = util::unique_copy(_m_mission_notes.c_str(), true);
+	The_mission.mission_desc = util::unique_copy(_m_mission_desc.c_str(), true);
 
 	// copy squad stuff
 	if (_m_squad_name == NO_SQUAD) {
@@ -352,7 +353,7 @@ int MissionSpecDialogModel::getAIProfileIndex() const {
 }
 
 void MissionSpecDialogModel::setMissionDescText(const SCP_string& m_mission_desc) {
-	modify(_m_mission_desc, m_mission_desc.substr(0, MIN(static_cast<size_t>(MISSION_DESC_LENGTH), m_mission_desc.length())));
+	modify(_m_mission_desc, m_mission_desc);
 }
 
 SCP_string MissionSpecDialogModel::getMissionDescText() {
@@ -360,7 +361,7 @@ SCP_string MissionSpecDialogModel::getMissionDescText() {
 }
 
 void MissionSpecDialogModel::setDesignerNoteText(const SCP_string& m_mission_notes) {
-	modify(_m_mission_notes, m_mission_notes.substr(0, MIN(static_cast<size_t>(NOTES_LENGTH), m_mission_notes.length())));
+	modify(_m_mission_notes, m_mission_notes);
 }
 
 SCP_string MissionSpecDialogModel::getDesignerNoteText() {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2375,14 +2375,14 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 		parse_comments(2);
 		fout(" %s", cm.name);
 
-		if (strlen(cm.briefing_cutscene)) {
+		if (cm.briefing_cutscene) {
 			if (optional_string_fred("+Briefing Cutscene:", "$Mission")) {
 				parse_comments();
 			} else {
 				fout("\n+Briefing Cutscene:");
 			}
 
-			fout(" %s", cm.briefing_cutscene);
+			fout(" %s", coalesce(cm.briefing_cutscene.get(), ""));
 		}
 
 		required_string_fred("+Flags:", "$Mission:");
@@ -2406,7 +2406,7 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 			fout(" %s", cm.main_hall.c_str());
 		} else {
 			// save Bastion flag properly
-			fout(" %d", flags_to_save | ((! cm.main_hall.empty()) ? CMISSION_FLAG_BASTION : 0));
+			fout(" %d", flags_to_save | (!cm.main_hall.empty() ? CMISSION_FLAG_BASTION : 0));
 		}
 
 		if (!cm.substitute_main_hall.empty()) {
@@ -2459,21 +2459,21 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 			if (cm.mission_branch_desc) {
 				required_string_fred("+Mission Loop Text:");
 				parse_comments();
-				fout_ext("\n", "%s", cm.mission_branch_desc);
+				fout_ext("\n", "%s", cm.mission_branch_desc.get());
 				fout("\n$end_multi_text");
 			}
 
 			if (cm.mission_branch_brief_anim) {
 				required_string_fred("+Mission Loop Brief Anim:");
 				parse_comments();
-				fout_ext("\n", "%s", cm.mission_branch_brief_anim);
+				fout_ext("\n", "%s", cm.mission_branch_brief_anim.get());
 				fout("\n$end_multi_text");
 			}
 
 			if (cm.mission_branch_brief_sound) {
 				required_string_fred("+Mission Loop Brief Sound:");
 				parse_comments();
-				fout_ext("\n", "%s", cm.mission_branch_brief_sound);
+				fout_ext("\n", "%s", cm.mission_branch_brief_sound.get());
 				fout("\n$end_multi_text");
 			}
 
@@ -2601,7 +2601,7 @@ int CFred_mission_save::save_mission_info()
 
 	required_string_fred("$Notes:");
 	parse_comments();
-	fout("\n%s", The_mission.notes);
+	fout("\n%s", coalesce(The_mission.notes.get(), ""));
 
 	required_string_fred("$End Notes:");
 	parse_comments(0);
@@ -2609,7 +2609,7 @@ int CFred_mission_save::save_mission_info()
 	// XSTR
 	required_string_fred("$Mission Desc:");
 	parse_comments(2);
-	fout_ext("\n", "%s", The_mission.mission_desc);
+	fout_ext("\n", "%s", coalesce(The_mission.mission_desc.get(), ""));
 	fout("\n");
 
 	required_string_fred("$end_multi_text");


### PR DESCRIPTION
As in #6607, use `std::unique_ptr` rather than `vm_malloc` and `vm_free` to handle optional strings in the mission structure.