### PR TITLE
Fix script setting of subsystem hitpoints max

### DIFF
--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -243,7 +243,7 @@ ADE_VIRTVAR(HitpointsMax, l_Subsystem, "number", "Subsystem hitpoints max", "num
 
 	if(ADE_SETTING_VAR)
 	{
-		sso->ss->max_hits = MIN(0.0f, f);
+		sso->ss->max_hits = MAX(0.0f, f);
 
 		ship_recalc_subsys_strength(&Ships[sso->objh.objp()->instance]);
 	}


### PR DESCRIPTION
Currently if you try to set a subsystem's hit points via scripting it only sets the value to 0 b/c of what was likely a copy paste bug. This 1 line PR fixes that. Tested and fix works as expected.