### PR TITLE
attempt to fix Coverity

### DIFF
--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -66,4 +66,4 @@ jobs:
       - name: Upload to Coverity
         run: |
           cd build
-          curl --form token=${{ env.coverity_token }} --form email=${{ env.coverity_email }} --form file=@cov-scan.tgz --form version="$(git rev-parse HEAD)" --form description="Automatic GHA scan" 'https://scan.coverity.com/builds?project=scp-fs2open/fs2open.github.com'
+          curl --form token=${{ env.coverity_token }} --form email=${{ env.coverity_email }} --form file=@cov-scan.tgz --form version=${{ github.ref }} --form description="Automatic GHA scan" 'https://scan.coverity.com/builds?project=scp-fs2open/fs2open.github.com'


### PR DESCRIPTION
Coverity hasn't run since September 27.  A close look at the log shows that the workflow makes it almost all the way through but fails on the "Upload to Coverity" step:
`fatal: detected dubious ownership in repository at '/__w/fs2open.github.com/fs2open.github.com'`

There are various questionable ways that people have tried to fix this, but it might be possible to completely avoid the issue by not using `git` in that step.  So let's try to get the commit hash from GitHub context rather than by running `git rev-parse HEAD`.