### PR TITLE
ensure matrices are well-behaved

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3466,6 +3466,9 @@ void stuff_matrix(matrix *mp)
 	stuff_vec3d(&mp->vec.rvec);
 	stuff_vec3d(&mp->vec.uvec);
 	stuff_vec3d(&mp->vec.fvec);
+
+	// Make sure this matrix is well-behaved.
+	vm_fix_matrix(mp);
 }
 
 //	Find a required string (*id), then stuff the text of type f_type that


### PR DESCRIPTION
When an orientation matrix is constructed using one or more vectors, all such vectors must be normalized.  Previously, the code did not enforce this for matrices parsed from a mission or table file.  Although FRED will use correct matrices, it also truncates floating point values to six decimal places, so non-normalized vectors might be written to the mission file as happened in #6632.  And there is always the possibility that someone could manually edit the mission file to corrupt the matrices.

While we're at it, per suggestions from Asteroth and qazwsxal, make sure the matrix is orthogonal as well.  The `vm_fix_matrix` function handles all relevant calculations.

Fixes #6632.  Follow-up to #6596.