### PR TITLE
Fix/cleanup using `intrinsic no shields` and ship loadout switching

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11618,6 +11618,12 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 			shield_pct = shield_get_strength(objp) / shield_get_max_strength(sp);
 		} else if (Ship_info[sp->ship_info_index].max_shield_strength > 0.0f) {
 			shield_pct = shield_get_strength(objp) / (sip_orig->max_shield_strength * sip_orig->max_shield_recharge);
+		} else if (sip_orig->flags[Info_Flags::Intrinsic_no_shields]) {
+			// Recall, this flag is used to allow switching between both shielded and unshielded craft in loadout,
+			// so if that flag is on, then treat shield percent as full instead of empty.
+			// This ensures that switching to a ship with shields in loadout
+			// will begin the mission with full shield strength (instead of 0).
+			shield_pct = 1.0f;
 		} else {
 			shield_pct = 0.0f;
 		}


### PR DESCRIPTION
The flag `intrinsic no shields` is used to allow switching between both shielded and unshielded craft in loadout. There is one edge case that was not accounted for though, which is that if a ship has no shields, and is switched to a ship with shields, the mission will start with that ship having a current shield strength of 0 and only slow get it's shield strength up via shield recharge.

This is not expected behavior, so this PR adds the extra conditional check that if that flag is on, then treat shield percent as full instead of empty. This ensures that switching to a ship with shields in loadout will begin the mission with full shield strength (instead of 0 and waiting for a full recharge).

Tested and works as expected. If desired I can put this behind a game settings flag, but I figured this was the expected behavior (and I'm not even sure how many mods besides FotG uses `intrinsic no shields`.