### PR TITLE
skipmemymissionyo fixes

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1877 // This is the next available ID
+// #define XSTR_SIZE	1878 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -407,11 +407,16 @@ void main_hall_blit_table_status()
  */
 void main_hall_campaign_cheat()
 {
-	char *ret = popup_input(0, XSTR("Enter mission name.\n\n* This will destroy all legitimate progress in this campaign. *", 1605));
+	const char *filename = popup_input(0, XSTR("Enter mission filename.\n\n* This will destroy all legitimate progress in this campaign. *", 1605), -1, "", POPUP_DEFAULT_PLUS_SPACE);
 
 	// yay
-	if (ret != nullptr) {
-		mission_campaign_jump_to_mission(ret);
+	if (filename != nullptr) {
+		bool success = mission_campaign_jump_to_mission(filename);
+
+		// noo
+		if (!success) {
+			popup(PF_USE_AFFIRMATIVE_ICON, 1, POPUP_OK, XSTR("Could not find the mission filename in the current campaign.", 1877));
+		}
 	}
 }
 

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -246,7 +246,7 @@ void mission_campaign_skip_to_next();
 void mission_campaign_exit_loop();
 
 // jump to specified mission
-void mission_campaign_jump_to_mission(const char* name, bool no_skip = false);
+bool mission_campaign_jump_to_mission(const char* filename, bool no_skip = false);
 
 // stuff for the end of the campaign of the single player game
 void mission_campaign_end_init();

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -1246,7 +1246,7 @@ char *popup_input(int flags, const char *caption, int max_output_len, const char
 	Assert(strlen(Popup_info.raw_text) < POPUP_MAX_CHARS );
 
 	// set input text length
-	if((max_output_len > POPUP_INPUT_MAX_CHARS) || (max_output_len == -1)){
+	if((max_output_len >= POPUP_INPUT_MAX_CHARS) || (max_output_len == -1)){
 		Popup_info.max_input_text_len = POPUP_INPUT_MAX_CHARS - 1;
 	} else {
 		Popup_info.max_input_text_len = max_output_len;

--- a/code/popup/popup.h
+++ b/code/popup/popup.h
@@ -19,7 +19,8 @@
 #define POPUP_YES						XSTR("&Yes", 505)
 #define POPUP_NO						XSTR("&No", 506)
 
-#define POPUP_DEFAULT_VALID_CHARS "_.-"	// Default string of valid non-alphanumeric characters that popup_input may accept
+#define POPUP_DEFAULT_VALID_CHARS "_.-"		// Default string of valid non-alphanumeric characters that popup_input may accept
+#define POPUP_DEFAULT_PLUS_SPACE  "_.- "	// The above, plus a space
 
 ///////////////////////////////////////////////////
 // flags

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -2786,16 +2786,15 @@ ADE_FUNC(getPrevMissionFilename, l_Campaign, NULL, "Gets previous mission filena
 }
 
 // DahBlount - This jumps to a mission, the reason it accepts a boolean value is so that players can return to campaign maps
-ADE_FUNC(jumpToMission, l_Campaign, "string filename, [boolean hub]", "Jumps to a mission based on the filename. Optionally, the player can be sent to a hub mission without setting missions to skipped.", "boolean", "Jumps to a mission, or returns nil.")
+ADE_FUNC(jumpToMission, l_Campaign, "string filename, [boolean hub]", "Jumps to a mission based on the filename. Optionally, the player can be sent to a hub mission without setting missions to skipped.", "boolean", "Jumps to a mission, returning true if successful, false if unsuccessful (e.g. the mission could not be found in the campaign), or nil if no mission was specified.")
 {
 	const char* filename = nullptr;
 	bool hub = false;
 	if (!ade_get_args(L, "s|b", &filename, &hub))
 		return ADE_RETURN_NIL;
 
-	mission_campaign_jump_to_mission(filename, hub);
-
-	return ADE_RETURN_TRUE;
+	bool success = mission_campaign_jump_to_mission(filename, hub);
+	return ade_set_args(L, "b", success);
 }
 
 // TODO: add a proper indexer type that returns a handle


### PR DESCRIPTION
Improve skipmemymissionyo in several ways, based on RedMageJoe's recent experience:
1. Allow spaces to be accepted in the mission prompt
2. If the requested mission can't be found, just abort rather than restarting the entire campaign
3. Clarify that the prompt needs a filename and add a message if the mission can't be found
4. Improve handling of the .fs2 extension
5. Fix a bounds check in `popup_input`