### PR TITLE
Add an ingame setting to disable sunglare

### DIFF
--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -442,7 +442,7 @@ void opengl_post_lightshafts()
 	float x, y;
 
 	// should we even be here?
-	if ( !Game_subspace_effect && gr_lightshafts_enabled() ) {
+	if ( !Game_subspace_effect && gr_sunglare_enabled() && gr_lightshafts_enabled() ) {
 		int n_lights = light_get_global_count();
 
 		for ( int idx = 0; idx<n_lights; idx++ ) {

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -47,7 +47,17 @@ void parse_lightshafts_func()
 	Post_processing_enable_lightshafts = enabled;
 }
 
-static auto LightshaftsOption __UNUSED = options::OptionBuilder<bool>("Graphics.Lightshafts",
+// used by In-Game Options menu
+bool Post_processing_enable_sunglare = true;
+
+void parse_sunglare_func()
+{
+	bool enabled;
+	stuff_boolean(&enabled);
+	Post_processing_enable_sunglare = enabled;
+}
+
+auto LightshaftsOption = options::OptionBuilder<bool>("Graphics.Lightshafts",
                      std::pair<const char*, int>{"Lightshafts", 1724},
                      std::pair<const char*, int>{"Enables or disables lightshafts (requires post-processing)", 1725})
                      .category(std::make_pair("Graphics", 1825))
@@ -57,6 +67,17 @@ static auto LightshaftsOption __UNUSED = options::OptionBuilder<bool>("Graphics.
                      .importance(60)
                      .parser(parse_lightshafts_func)
                      .finish();
+
+auto SunglareOption = options::OptionBuilder<bool>("Graphics.Sunglare",
+					std::pair<const char*, int>{"Sunglare", 1877},
+					std::pair<const char*, int>{"Enables or disables glare from suns", 1878})
+			.category(std::make_pair("Graphics", 1825))
+			.default_func([]() { return Post_processing_enable_sunglare;})
+			.level(options::ExpertLevel::Advanced)
+			.bind_to(&Post_processing_enable_sunglare)
+			.importance(61)
+			.parser(parse_sunglare_func)
+			.finish();
 
 int Post_processing_bloom_intensity = 25; // using default value of Cmdline_bloom_intensity
 
@@ -232,7 +253,7 @@ bool gr_lightshafts_enabled()
 		return false;
 	}
 
-	// supernova glare should disable lightshafts
+	// supernova glare should switch to legacy lightshafts
 	if (supernova_stage() >= SUPERNOVA_STAGE::CLOSE) {
 		return false;
 	}
@@ -242,6 +263,20 @@ bool gr_lightshafts_enabled()
 	}
 
 	return graphics::LightshaftsOption->getValue();
+}
+
+bool gr_sunglare_enabled()
+{
+	if (gr_screen.mode == GR_STUB) {
+		return false;
+	}
+
+	// supernova glare gets to override this and actually display glare
+	if (supernova_stage() >= SUPERNOVA_STAGE::CLOSE) {
+		return true;
+	}
+
+	return graphics::SunglareOption->getValue();
 }
 
 int gr_bloom_intensity()

--- a/code/graphics/post_processing.h
+++ b/code/graphics/post_processing.h
@@ -69,6 +69,7 @@ class PostProcessingManager {
 } // namespace graphics
 
 bool gr_lightshafts_enabled();
+bool gr_sunglare_enabled();
 int gr_bloom_intensity();
 // used by lab
 void gr_set_bloom_intensity(int intensity);

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1877 // This is the next available ID
+// #define XSTR_SIZE	1879 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -879,7 +879,7 @@ static void game_flash_diminish(float frametime)
 		g = fl2i( Game_flash_green*128.0f );   
 		b = fl2i( Game_flash_blue*128.0f );  
 
-		if ( Sun_spot > 0.0f && !gr_lightshafts_enabled()) {
+		if ( Sun_spot > 0.0f && gr_sunglare_enabled() && !gr_lightshafts_enabled()) {
 			r += fl2i(Sun_spot*128.0f);
 			g += fl2i(Sun_spot*128.0f);
 			b += fl2i(Sun_spot*128.0f);


### PR DESCRIPTION
This adds sunglare as a separate option, especially since among players (and devs), there seems to be confusion about lightshafts and glares.

Lightshafts now _only_ control whether or not the glare is drawn with the legacy screen tint or the modern lightshaft shader.
Sunglare on the other hand can completely disable any sunglare, except for the supernova.
