### PR TITLE
handle starting shipname mismatch

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6391,6 +6391,10 @@ bool post_process_mission(mission *pm)
 
 	// the player_start_shipname had better exist at this point!
 	auto player_start_entry = ship_registry_get(Player_start_shipname);
+	if (!player_start_entry) {
+		Warning(LOCATION, "Player start ship '%s' does not exist!", Player_start_shipname);		// maybe the mission was hand-edited :P
+		return false;
+	}
 	Player_start_shipnum = player_start_entry->shipnum;
 	Assert( Player_start_shipnum != -1 );
 	Player_start_pobject = player_start_entry->p_objp();


### PR DESCRIPTION
If the player starting ship name does not refer to an actual ship, gracefully fail to load the mission instead of crashing.