### PR TITLE
fix text input crash on Linux, and plug memory leak

### DIFF
--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -529,14 +529,14 @@ bool text_input_handler(const SDL_Event& evt)
 	const char *tocode = "UCS-2LE";
 #endif
 
-	auto text = (uint16_t *)SDL_iconv_string(tocode, "UTF-8", evt.text.text, SDL_strlen(evt.text.text)+1);
+	auto text = (char16_t *)SDL_iconv_string(tocode, "UTF-8", evt.text.text, SDL_strlen(evt.text.text)+1);
 
 	if ( !text ) {
 		// encoding failed
 		return false;
 	}
 
-	auto ucs2String = std::basic_string<unsigned short>(text);
+	auto ucs2String = std::u16string(text);
 
 	SDL_free(text);
 

--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -522,7 +522,23 @@ bool text_input_handler(const SDL_Event& evt)
 	}
 
 	// libRocket expects UCS-2 so we first need to convert to that
-	auto ucs2String = std::basic_string<unsigned short>(SDL_iconv_utf8_ucs2(evt.text.text));
+	// NOTE: not using SDL_iconv_utf8_ucs2() macro here due to Linux compatiblity issue
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	const char *tocode = "UCS-2BE";
+#else
+	const char *tocode = "UCS-2LE";
+#endif
+
+	auto text = (uint16_t *)SDL_iconv_string(tocode, "UTF-8", evt.text.text, SDL_strlen(evt.text.text)+1);
+
+	if ( !text ) {
+		// encoding failed
+		return false;
+	}
+
+	auto ucs2String = std::basic_string<unsigned short>(text);
+
+	SDL_free(text);
 
 	bool consumed = true;
 	for (auto& c : ucs2String) {

--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -529,7 +529,7 @@ bool text_input_handler(const SDL_Event& evt)
 	const char *tocode = "UCS-2LE";
 #endif
 
-	auto text = (char16_t *)SDL_iconv_string(tocode, "UTF-8", evt.text.text, SDL_strlen(evt.text.text)+1);
+	auto text = reinterpret_cast<char16_t *>(SDL_iconv_string(tocode, "UTF-8", evt.text.text, SDL_strlen(evt.text.text)+1));
 
 	if ( !text ) {
 		// encoding failed


### PR DESCRIPTION
Linux iconv does not support "UCS-2-INTERNAL" and conversion will fail if SDL is compiled with native iconv support. SDL version 2.32.2 fixed this by changing the macro to use "UCS-2" instead. Unfortunately in my tests this worked perfectly in Linux but was broken on Mac in the rocket_ui code. However simply using proper endianess appears to work on all test platforms.

Additionally this fixes a bad memory leak as SDL_iconv_string() allocates it's return string and this was never free'd before. So every character of text input resulted in a memory leak of 6+ bytes.