### PR TITLE
fix normalized vector handling

### DIFF
--- a/code/actions/types/ParticleEffectAction.cpp
+++ b/code/actions/types/ParticleEffectAction.cpp
@@ -59,7 +59,7 @@ ActionResult ParticleEffectAction::execute(ProgramLocals& locals) const
 
 	auto direction = locals.variables.getValue({"locals", "direction"}).getVector();
 	matrix orientation;
-	vm_vector_2_matrix_norm(&orientation, &direction);
+	vm_vector_2_matrix_norm(&orientation, &direction);	// direction is normalized in SetDirectionAction::execute
 
 	source->setHost(make_unique<EffectHostObject>(locals.host.objp(), local_pos, orientation, true));
 	source->finishCreation();

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9729,7 +9729,7 @@ void set_goal_dock_orient(matrix *dom, matrix *docker_dock_orient, matrix *docke
 	vm_vec_rotate(&uvec, &dockee_dock_orient->vec.uvec, dockee_orient);
 
 	// create a rotation matrix
-	vm_vector_2_matrix_norm(&m1, &fvec, &uvec, nullptr);
+	vm_vector_2_matrix(&m1, &fvec, &uvec, nullptr);	// we need to normalize the input vectors here to prevent floating point errors from compounding
 
 	// get the global orientation
 	vm_matrix_x_matrix(&m3, dockee_orient, &m1);
@@ -9743,7 +9743,7 @@ void set_goal_dock_orient(matrix *dom, matrix *docker_dock_orient, matrix *docke
 	vm_vec_rotate(&uvec, &docker_dock_orient->vec.uvec, docker_orient);
 
 	// create a rotation matrix
-	vm_vector_2_matrix_norm(&m2, &fvec, &uvec, nullptr);
+	vm_vector_2_matrix(&m2, &fvec, &uvec, nullptr);	// we need to normalize the input vectors here to prevent floating point errors from compounding
 
 	//	Pre-multiply the orientation of the source object (docker_orient) by the transpose
 	//	of the docking bay's orientation, ie unrotate the source object's matrix.

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1223,6 +1223,7 @@ void ship_get_global_turret_gun_info(const object *objp, const ship_subsys *ssp,
 
 	if (use_angles) {
 		model_instance_local_to_global_dir(gvec, &tp->turret_norm, pm, pmi, tp->turret_gun_sobj, &objp->orient);
+		vm_vec_normalize(gvec);
 	} else {
 		Assertion(targetp != nullptr, "The targetp parameter must not be null here!");
 		vm_vec_normalized_dir(gvec, targetp, gpos);

--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -1085,13 +1085,6 @@ int cam_get_next_sig()
 	return next_sig++;
 }
 
-camid cam_create(const char *n_name, vec3d *n_pos, vec3d *n_norm, object *n_object, int n_object_host_submodel)
-{
-	matrix ori;
-	vm_vector_2_matrix_norm(&ori, n_norm);
-	return cam_create(n_name, n_pos, &ori, n_object, n_object_host_submodel);
-}
-
 camid cam_create(const char *n_name, vec3d *n_pos, matrix *n_ori, object *n_object, int n_object_host_submodel)
 {
 	camera *cam = NULL;
@@ -1235,7 +1228,7 @@ void subtitles_do_frame_post_shaded(float frametime)
 	}
 }
 
-vec3d normal_cache;
+static vec3d normal_cache;
 
 void get_turret_cam_pos(camera *cam, vec3d *pos)
 {

--- a/code/camera/camera.h
+++ b/code/camera/camera.h
@@ -179,7 +179,6 @@ void cam_init();
 void cam_close();
 void cam_do_frame(float frametime);
 camid cam_create(const char *n_name=NULL, vec3d *n_pos=NULL, matrix *n_ori=NULL, object *n_object=NULL, int n_submodel_parent=-1);
-camid cam_create(const char *n_name, vec3d *n_pos, vec3d *n_norm, object *n_object=NULL, int n_submodel_parent=-1);
 void cam_delete(camid cid);
 bool cam_set_camera(camid cid);
 void cam_reset_camera();

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -4382,9 +4382,6 @@ void HudGaugeLeadIndicator::renderLeadQuick(vec3d *target_world_pos, object *tar
 	} else {
 		rel_pos = nullptr;
 	}
-//							vec3d firing_vec;
-//							vm_vec_unrotate(&firing_vec, &po->gun_banks[bank_to_fire].norm[pt], &obj->orient);
-//							vm_vector_2_matrix_norm(&firing_orient, &firing_vec, NULL, NULL);
 
 	// source_pos will contain the world coordinate of where to base the lead indicator prediction
 	// from.  Normally, this will be the world pos of the gun turret of the currently selected primary

--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -637,8 +637,8 @@ void HudGaugeTargetBox::renderTargetShip(object *target_objp, bool config)
 			vec3d tempv;
 			object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
-			vec3d up_vector = camera_orient.vec.uvec;
-			vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
+			auto up_vector = &camera_orient.vec.uvec;
+			vm_vector_2_matrix_norm(&camera_orient, &orient_vec, up_vector, nullptr);
 
 			// normalize the vector from the player to the current target, and scale by a factor to calculate
 			// the objects position
@@ -807,7 +807,6 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 	vec3d	camera_eye = ZERO_VECTOR;
 	matrix	camera_orient = IDENTITY_MATRIX;
 	debris	*debrisp;
-	vec3d	orient_vec, up_vector;
 	float		factor;	
 	uint64_t flags = 0;
 
@@ -815,6 +814,7 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 
 	if ( Detail.targetview_model )	{
 		// take the forward orientation to be the vector from the player to the current target
+		vec3d orient_vec;
 		vm_vec_normalized_dir(&orient_vec, &target_objp->pos, &Player_obj->pos);
 
 		factor = 2*target_objp->radius;
@@ -823,8 +823,8 @@ void HudGaugeTargetBox::renderTargetDebris(object *target_objp)
 		vec3d tempv;
 		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
-		up_vector = camera_orient.vec.uvec;
-		vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
+		auto up_vector = &camera_orient.vec.uvec;
+		vm_vector_2_matrix_norm(&camera_orient, &orient_vec, up_vector, nullptr);
 
 		// normalize the vector from the player to the current target, and scale by a factor to calculate
 		// the objects position
@@ -919,8 +919,6 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 	vec3d		obj_pos = ZERO_VECTOR;
 	vec3d		camera_eye = ZERO_VECTOR;
 	matrix		camera_orient = IDENTITY_MATRIX;
-	vec3d		orient_vec, up_vector;
-	vec3d		projection_vec;
 	weapon_info	*target_wip = NULL;
 	weapon		*wp = NULL;
 	object		*viewer_obj, *viewed_obj;
@@ -971,22 +969,18 @@ void HudGaugeTargetBox::renderTargetWeapon(object *target_objp)
 			replacement_textures = model_get_instance(pmi_id)->texture_replace;
 
 		// take the forward orientation to be the vector from the player to the current target
-		vm_vec_normalized_dir(&orient_vec, &viewed_obj->pos, &viewer_obj->pos);
-
-		if (missile_view == TRUE) {
-			vm_vec_normalized_dir(&projection_vec, &wp->homing_pos, &viewer_obj->pos);
-		}
+		vec3d orient_vec;
+		if (missile_view == FALSE)
+			vm_vec_normalized_dir(&orient_vec, &viewed_obj->pos, &viewer_obj->pos);
+		else
+			vm_vec_normalized_dir(&orient_vec, &wp->homing_pos, &viewer_obj->pos);
 
 		// use the viewer's up vector, and construct the viewer's orientation matrix
 		vec3d tempv;
 		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
-		up_vector = camera_orient.vec.uvec;
-
-		if (missile_view == FALSE)
-			vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
-		else
-			vm_vector_2_matrix_norm(&camera_orient, &projection_vec, &up_vector, nullptr);
+		auto up_vector = &camera_orient.vec.uvec;
+		vm_vector_2_matrix_norm(&camera_orient, &orient_vec, up_vector, nullptr);
 
 		// normalize the vector from the viewer to the viwed target, and scale by a factor to calculate
 		// the objects position
@@ -1189,7 +1183,6 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 	vec3d		camera_eye = ZERO_VECTOR;
 	matrix		camera_orient = IDENTITY_MATRIX;
 	asteroid		*asteroidp;
-	vec3d		orient_vec, up_vector;
 	float			time_to_impact, factor;	
 	int			pof;
 
@@ -1202,6 +1195,7 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 
 	if ( Detail.targetview_model )	{
 		// take the forward orientation to be the vector from the player to the current target
+		vec3d orient_vec;
 		vm_vec_normalized_dir(&orient_vec, &target_objp->pos, &Player_obj->pos);
 
 		factor = 2*target_objp->radius;
@@ -1210,8 +1204,8 @@ void HudGaugeTargetBox::renderTargetAsteroid(object *target_objp)
 		vec3d tempv;
 		object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
-		up_vector = camera_orient.vec.uvec;
-		vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
+		auto up_vector = &camera_orient.vec.uvec;
+		vm_vector_2_matrix_norm(&camera_orient, &orient_vec, up_vector, nullptr);
 
 		// normalize the vector from the player to the current target, and scale by a factor to calculate
 		// the objects position
@@ -1322,7 +1316,6 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 	vec3d		obj_pos = ZERO_VECTOR;
 	vec3d		camera_eye = ZERO_VECTOR;
 	matrix		camera_orient = IDENTITY_MATRIX;
-	vec3d		orient_vec, up_vector;
 	float			factor, dist;
 	int			hx = 0, hy = 0, w, h;
 	SCP_list<CJumpNode>::iterator jnp;
@@ -1338,6 +1331,7 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 
 		if ( Detail.targetview_model )	{
 			// take the forward orientation to be the vector from the player to the current target
+			vec3d orient_vec;
 			vm_vec_normalized_dir(&orient_vec, &target_objp->pos, &Player_obj->pos);
 
 			factor = target_objp->radius*4.0f;
@@ -1346,8 +1340,8 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 			vec3d tempv;
 			object_get_eye(&tempv, &camera_orient, Player_obj, false);
 
-			up_vector = camera_orient.vec.uvec;
-			vm_vector_2_matrix_norm(&camera_orient, &orient_vec, &up_vector, nullptr);
+			auto up_vector = &camera_orient.vec.uvec;
+			vm_vector_2_matrix_norm(&camera_orient, &orient_vec, up_vector, nullptr);
 
 			// normalize the vector from the player to the current target, and scale by a factor to calculate
 			// the objects position

--- a/code/math/staticrand.cpp
+++ b/code/math/staticrand.cpp
@@ -142,6 +142,7 @@ void static_rand_cone(int num, vec3d *out, const vec3d* const in, float max_angl
 	if(orient != nullptr){
 		rot = orient;
 	} else {
+		Assertion(in != nullptr && vm_vec_is_normalized(in), "input vector must be normalized!");
 		vm_vector_2_matrix_norm(&m, in, nullptr, nullptr);
 		rot = &m;
 	}
@@ -171,8 +172,8 @@ void static_rand_cone(int num, vec3d* out, const vec3d* const in, float min_angl
 	// get an orientation matrix
 	if (orient != nullptr) {
 		rot = orient;
-	}
-	else {
+	} else {
+		Assertion(in != nullptr && vm_vec_is_normalized(in), "input vector must be normalized!");
 		vm_vector_2_matrix_norm(&m, in, nullptr, nullptr);
 		rot = &m;
 	}

--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -1378,6 +1378,8 @@ void vm_vec_rand_vec(vec3d *rvec)
 // Returns the rotated point in "out".
 void vm_rot_point_around_line(vec3d *out, const vec3d *in, float angle, const vec3d *line_point, const vec3d *line_dir)
 {
+	Assertion(line_dir != nullptr && vm_vec_is_normalized(line_dir), "line_dir vector must be normalized!");
+
 	vec3d tmp, tmp1;
 	matrix m, r;
 	angles ta;
@@ -2321,6 +2323,7 @@ void vm_vec_random_cone(vec3d *out, const vec3d *in, float max_angle, const matr
 	if(orient != NULL){
 		rot = orient;
 	} else {
+		Assertion(in != nullptr && vm_vec_is_normalized(in), "input vector must be normalized!");
 		vm_vector_2_matrix_norm(&m, in, nullptr, nullptr);
 		rot = &m;
 	}
@@ -2348,6 +2351,7 @@ void vm_vec_random_cone(vec3d *out, const vec3d *in, float min_angle, float max_
 	if(orient != NULL){
 		rot = orient;
 	} else {
+		Assertion(in != nullptr && vm_vec_is_normalized(in), "input vector must be normalized!");
 		vm_vector_2_matrix_norm(&m, in, nullptr, nullptr);
 		rot = &m;
 	}

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2374,7 +2374,7 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 							if (vm_vec_mag(&(bay->norm[j])) <= 0.0f) {
 								Warning(LOCATION, "Model '%s' dock point '%s' has a null normal.  Generating a normal in the forward Z direction.", filename, bay->name);
 								bay->norm[j] = vmd_z_vector;
-							} else if (!vm_vec_is_normalized(&(bay->norm[j]))) {
+							} else {
 								vm_vec_normalize(&(bay->norm[j]));
 							}
 						}

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -2326,6 +2326,7 @@ camid player_get_cam()
 		} else if (Viewer_mode & VM_EXTERNAL) {
 			Assert(viewer_obj != NULL);
 			matrix	tm, tm2;
+			vec3d uvec;
 
 			vm_angles_2_matrix(&tm2, &Viewer_external_info.angles);
 			vm_matrix_x_matrix(&tm, &viewer_obj->orient, &tm2);
@@ -2335,7 +2336,8 @@ camid player_get_cam()
 			vm_vec_scale_add(&eye_pos, &viewer_obj->pos, &tm.vec.fvec, Viewer_external_info.current_distance);
 
 			vm_vec_normalized_dir(&tmp_dir, &viewer_obj->pos, &eye_pos);
-			vm_vector_2_matrix_norm(&eye_orient, &tmp_dir, &viewer_obj->orient.vec.uvec, nullptr);
+			vm_vec_copy_normalize(&uvec, &viewer_obj->orient.vec.uvec);	// out of an abundance of caution
+			vm_vector_2_matrix_norm(&eye_orient, &tmp_dir, &uvec, nullptr);
  			viewer_obj = NULL;
 
 			//	Modify the orientation based on head orientation.
@@ -2372,12 +2374,12 @@ camid player_get_cam()
 			Warp_camera.get_info(&eye_pos, NULL);
 
 			ship * shipp = &Ships[Player_obj->instance];
-
-
-			vec3d warp_pos = Player_obj->pos;
+			vec3d uvec, warp_pos = Player_obj->pos;
 			shipp->warpout_effect->getWarpPosition(&warp_pos);
+
 			vm_vec_normalized_dir(&tmp_dir, &warp_pos, &eye_pos);
-			vm_vector_2_matrix_norm(&eye_orient, &tmp_dir, &Player_obj->orient.vec.uvec, nullptr);
+			vm_vec_copy_normalize(&uvec, &Player_obj->orient.vec.uvec);	// out of an abundance of caution
+			vm_vector_2_matrix_norm(&eye_orient, &tmp_dir, &uvec, nullptr);
 			viewer_obj = NULL;
 		} else {
 			// get an eye position for the player object

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -500,6 +500,8 @@ void g3_render_rect_oriented(material* mat_info, vec3d *pos, matrix *ori, float 
 
 void g3_render_rect_oriented(material* mat_info, vec3d *pos, vec3d *norm, float width, float height)
 {
+	Assertion(norm != nullptr && vm_vec_is_normalized(norm), "input vector must be normalized!");
+
 	matrix m;
 	vm_vector_2_matrix_norm(&m, norm, nullptr, nullptr);
 

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -889,7 +889,7 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRan
 
 	ship_get_global_turret_gun_info(sso->objh.objp(), sso->ss, &gpos, false, &gvec, true, nullptr);
 	if (override_gvec != nullptr)
-		gvec = *override_gvec;
+		vm_vec_copy_normalize(&gvec, override_gvec);
 
 	bool rtn = turret_fire_weapon(wnum, sso->ss, sso->objh.objnum, &gpos, &gvec, NULL, flak_range);
 


### PR DESCRIPTION
Although normalized vectors in FSO are supposed to stay normalized, occasionally small floating point errors can pop up.  In most cases these do not cause a problem, but in certain cases these errors can rapidly accumulate and corrupt an otherwise well-behaved matrix.  This can most easily be seen with daisy-chained dock sequences or docked ships with angled dockpoints.

This PR audits the usage of `vm_vector_2_matrix_norm` to re-normalize vectors in cases where floating point errors could accumulate.  There are also a few new Assertions for extra vigilance.

Follow-up to #6596.  Fixes #6634.