### PR TITLE
Per-hud config weapons and shield gauge ship

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -169,9 +169,11 @@ int HC_gauge_description_coords[GR_NUM_RESOLUTIONS][3] = {
 
 int HC_talking_head_frame = -1;
 SCP_string HC_head_anim_filename;
-SCP_string HC_shield_gauge_ship;
 bool HC_show_default_hud = true;
 std::unordered_set<SCP_string> HC_ignored_huds;
+SCP_map<SCP_string, SCP_string> HC_hud_ships;
+SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_primary_weapons;
+SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_secondary_weapons;
 
 int HC_resize_mode = GR_RESIZE_MENU;
 

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -176,9 +176,11 @@ extern SCP_vector<std::pair<SCP_string, BoundingBox>> HC_gauge_mouse_coords;
 
 extern int HC_talking_head_frame;
 extern SCP_string HC_head_anim_filename;
-extern SCP_string HC_shield_gauge_ship;
 extern bool HC_show_default_hud;
 extern std::unordered_set<SCP_string> HC_ignored_huds;
+extern SCP_map<SCP_string, SCP_string> HC_hud_ships;
+extern SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_primary_weapons;
+extern SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_secondary_weapons;
 
 class HC_gauge_mappings {
 public:

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -253,7 +253,7 @@ void parse_hud_gauges_tbl(const char *filename)
 
 				for (auto& ship : Ship_info) {
 					if (!stricmp(ship.name, temp.c_str())) {
-						HC_shield_gauge_ship = ship.name;
+						HC_hud_ships["default"] = ship.name;
 						found = true;
 						break;
 					}
@@ -262,6 +262,14 @@ void parse_hud_gauges_tbl(const char *filename)
 				if (!found) {
 					Warning(LOCATION, "Shield gauge ship \"%s\" not found in ships.tbl!", temp.c_str());
 				}
+			}
+
+			if (optional_string("$Primary Weapons:")) {
+				stuff_string_list(HC_hud_primary_weapons["default"]);
+			}
+
+			if (optional_string("$Secondary Weapons:")) {
+				stuff_string_list(HC_hud_secondary_weapons["default"]);
 			}
 
 			if (optional_string("$Example Wing Names:")) {
@@ -469,6 +477,21 @@ void parse_hud_gauges_tbl(const char *filename)
 					if (!show) {
 						HC_ignored_huds.insert(name);
 					}
+				}
+
+				if (optional_string("$Shield Gauge Ship:")) {
+					SCP_string ship;
+					stuff_string(ship, F_NAME);
+
+					HC_hud_ships[name] = ship;
+				}
+
+				if (optional_string("$Primary Weapons:")) {
+					stuff_string_list(HC_hud_primary_weapons[name]);
+				}
+
+				if (optional_string("$Secondary Weapons:")) {
+					stuff_string_list(HC_hud_secondary_weapons[name]);
 				}
 
 				if (optional_string("$Load Retail Configuration:")) {

--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -569,7 +569,20 @@ void HudGaugeShield::showShields(const object *objp, int mode, bool config)
 		sp = &Ships[objp->instance];
 		sip = &Ship_info[sp->ship_info_index];
 	} else {
-		SCP_string ship_name = HC_shield_gauge_ship.empty() ? "gtf myrmidon" : HC_shield_gauge_ship;
+		SCP_string ship_name = "gtf myrmidon";
+
+		// Check if the mod specifies a differnt default
+		if (auto it = HC_hud_ships.find("default"); it != HC_hud_ships.end()) {
+			ship_name = it->second;
+		}
+
+		// Now check if the current HUD specifies a different ship
+		if (SCP_vector_inbounds(HC_available_huds, HC_chosen_hud)) {
+			SCP_string hud = HC_available_huds[HC_chosen_hud].second;
+			if (auto it = HC_hud_ships.find(hud); it != HC_hud_ships.end()) {
+				ship_name = it->second;
+			}
+		}
 
 		// Try to find the ship with the name specified in the config
 		for (ship_info& ship : Ship_info) {

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6513,6 +6513,9 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 	ship_weapon	*sw = nullptr;
 	int np, ns;		// np == num primary, ns == num secondary
 
+	std::optional<std::reference_wrapper<const SCP_vector<SCP_string>>> primary_list;
+	std::optional<std::reference_wrapper<const SCP_vector<SCP_string>>> secondary_list;
+
 	if(!config && Player_obj->type == OBJ_OBSERVER)
 		return;
 
@@ -6524,8 +6527,27 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 		np = sw->num_primary_banks;
 		ns = sw->num_secondary_banks;
 	} else {
-		np = MAX_SHIP_PRIMARY_BANKS;
-		ns = MAX_SHIP_SECONDARY_BANKS;
+		auto get_weapon_list = [](const SCP_map<SCP_string, SCP_vector<SCP_string>>& weapon_map)
+			-> std::optional<std::reference_wrapper<const SCP_vector<SCP_string>>> {
+			if (SCP_vector_inbounds(HC_available_huds, HC_chosen_hud)) {
+				const SCP_string& hud = HC_available_huds[HC_chosen_hud].second;
+
+				if (auto it_spec = weapon_map.find(hud); it_spec != weapon_map.end()) {
+					return it_spec->second;
+				} else if (auto it_def = weapon_map.find("default"); it_def != weapon_map.end()) {
+					return it_def->second;
+				}
+			}
+			return std::nullopt;
+		};
+
+		primary_list = get_weapon_list(HC_hud_primary_weapons);
+		secondary_list = get_weapon_list(HC_hud_secondary_weapons);
+
+		// Get weapon counts
+		np = primary_list ? static_cast<int>(primary_list->get().size()) : MAX_SHIP_PRIMARY_BANKS;
+		ns = secondary_list ? static_cast<int>(secondary_list->get().size()) : MAX_SHIP_SECONDARY_BANKS;
+
 	}
 
 	int x = position[0];
@@ -6545,7 +6567,7 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 	// render the header of this gauge
 	renderString(x + fl2i(Weapon_header_offsets[ballistic_hud_index][0] * scale), y + fl2i(Weapon_header_offsets[ballistic_hud_index][1] * scale), EG_WEAPON_TITLE, XSTR( "weapons", 328), scale, config);
 
-	const char* weapon_name = "";
+	SCP_string weapon_name;
 	char	ammo_str[32];
 	int		i, w, h;
 	int ty = y + fl2i(top_primary_h * scale);
@@ -6573,21 +6595,39 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 		}
 
 		weapon_info* wip = nullptr;
+		weapon_name.clear();
 
 		if (!config) {
 			wip = &Weapon_info[sw->primary_bank_weapons[i]];
 			weapon_name = wip->get_display_name();
 		} else {
-			// In config mode let's get the first 3 player allowed primaries
-			int match_count = 0;
-			for (weapon_info &wep : Weapon_info) {
-				if (wep.subtype == WP_LASER && wep.wi_flags[Weapon::Info_Flags::Player_allowed]) {
-					if (match_count == i) {
+			// Use the tabled config weapon
+			if (primary_list) {
+				const SCP_vector<SCP_string>& weapon_list = primary_list->get();
+				if (SCP_vector_inbounds(weapon_list, i)) {
+					weapon_name = weapon_list[i];
+				}
+
+				for (weapon_info& wep : Weapon_info) {
+					if (wep.name == weapon_name && wep.subtype == WP_LASER &&
+						wep.wi_flags[Weapon::Info_Flags::Player_allowed]) {
 						wip = &wep;
 						weapon_name = wip->get_display_name();
 						break;
 					}
-					match_count++;
+				}
+			} else {
+				// If we still don't have a name, try to get one from the weapon_info
+				int match_count = 0;
+				for (weapon_info& wep : Weapon_info) {
+					if (wep.subtype == WP_LASER && wep.wi_flags[Weapon::Info_Flags::Player_allowed]) {
+						if (match_count == i) {
+							wip = &wep;
+							weapon_name = wip->get_display_name();
+							break;
+						}
+						match_count++;
+					}
 				}
 			}
 			// Just in case
@@ -6614,7 +6654,7 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 		if(wip != nullptr && wip->hud_image_index != -1) {
 			renderBitmap(wip->hud_image_index, x + fl2i(Weapon_pname_offset_x * scale), name_y, scale, config);
 		} else {
-			renderPrintfWithGauge(x + fl2i(Weapon_pname_offset_x * scale), name_y, EG_WEAPON_P2, scale, config, "%s", weapon_name);
+			renderPrintfWithGauge(x + fl2i(Weapon_pname_offset_x * scale), name_y, EG_WEAPON_P2, scale, config, "%s", weapon_name.c_str());
 		}
 
 		// if this is a ballistic primary with ammo, render the ammo count
@@ -6647,18 +6687,34 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 	{
 		setGaugeColor(HUD_C_NONE, config);
 		weapon_info* wip = nullptr;
+		weapon_name.clear();
 		if (!config) {
 			wip = &Weapon_info[sw->secondary_bank_weapons[i]];
 		} else {
-			// In config mode let's get the first 3 player allowed primaries
-			int match_count = 0;
-			for (weapon_info &wep : Weapon_info) {
-				if (wep.subtype == WP_MISSILE && wep.wi_flags[Weapon::Info_Flags::Player_allowed]) {
-					if (match_count == i) {
+			//Use the tabled config weapon
+			if (secondary_list) {
+				const SCP_vector<SCP_string>& weapon_list = secondary_list->get();
+				if (SCP_vector_inbounds(weapon_list, i)) {
+					weapon_name = weapon_list[i];
+				}
+				for (weapon_info& wep : Weapon_info) {
+					if (wep.name == weapon_name && wep.subtype == WP_MISSILE &&
+						wep.wi_flags[Weapon::Info_Flags::Player_allowed]) {
 						wip = &wep;
 						break;
 					}
-					match_count++;
+				}
+			} else {
+				// If we still don't have a name, try to get one from the weapon_info
+				int match_count = 0;
+				for (weapon_info& wep : Weapon_info) {
+					if (wep.subtype == WP_MISSILE && wep.wi_flags[Weapon::Info_Flags::Player_allowed]) {
+						if (match_count == i) {
+							wip = &wep;
+							break;
+						}
+						match_count++;
+					}
 				}
 			}
 		}
@@ -6704,7 +6760,7 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 			if(wip != nullptr && wip->hud_image_index != -1) {
 				renderBitmap(wip->hud_image_index, x + fl2i(Weapon_sname_offset_x * scale), name_y, scale, config);
 			} else {
-				renderString(x + fl2i(Weapon_sname_offset_x * scale), name_y, i ? EG_WEAPON_S1 : EG_WEAPON_S2, weapon_name, scale, config);
+				renderString(x + fl2i(Weapon_sname_offset_x * scale), name_y, i ? EG_WEAPON_S1 : EG_WEAPON_S2, weapon_name.c_str(), scale, config);
 			}
 
 			// show the cooldown time
@@ -6716,11 +6772,11 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 			}
 		} else {
 			// just print the weapon's name since this isn't armed
-			renderString(x + fl2i(Weapon_sname_offset_x * scale), name_y, i ? EG_WEAPON_S1 : EG_WEAPON_S2, weapon_name, scale, config);
+			renderString(x + fl2i(Weapon_sname_offset_x * scale), name_y, i ? EG_WEAPON_S1 : EG_WEAPON_S2, weapon_name.c_str(), scale, config);
 		}
 
-		if (!config && !Weapon_info[sw->secondary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo]) {
-			int ammo=sw->secondary_bank_ammo[i];
+		if (config || !Weapon_info[sw->secondary_bank_weapons[i]].wi_flags[Weapon::Info_Flags::SecondaryNoAmmo]) {
+			int ammo = config ? 13 : sw->secondary_bank_ammo[i];
 
 			// print out the ammo right justified
 			sprintf(ammo_str, "%d", ammo);


### PR DESCRIPTION
Now that HUD Config is fully upgraded I can start to add some further enhancements. Starting small, this one allows defining which ship is used for the shield gauge and which weapons show up in the weapons gauge on a per-HUD basis. This is a convenience feature that can allow mods to do things like make sure the Vasudan HUD shows Vasudan ships and weapons while Terran HUDs show Terran ships and weapons.