### PR TITLE
Fix VR sun popups

### DIFF
--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -236,7 +236,7 @@ void g3_render_laser_2d(material *mat_params, vec3d *headp, float head_width, ve
 void g3_render_rect_screen_aligned_rotated(material *mat_params, vertex *pnt, float angle, float rad);
 
 void g3_render_rect_screen_aligned(material *mat_params, vertex *pnt, int orient, float rad, float depth = 0.0f);
-void g3_render_rect_screen_aligned_2d(material *mat_params, vertex *pnt, int orient, float rad);
+void g3_render_rect_screen_aligned_2d(material *mat_params, vertex *pnt, int orient, float rad, bool isFaraway = false);
 
 void g3_render_rect_oriented(material* mat_info, vec3d *pos, matrix *ori, float width, float height);
 void g3_render_rect_oriented(material* mat_info, vec3d *pos, vec3d *norm, float width, float height);

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -674,7 +674,7 @@ void g3_render_rect_scaler(material *mat_params, vertex *va, vertex *vb)
 
 // adapted from g3_draw_bitmap()
 //void render_oriented_bitmap_2d(int texture, float alpha, bool blending, vertex *pnt, int orient, float rad)
-void g3_render_rect_screen_aligned_2d(material *mat_params, vertex *pnt, int orient, float rad)
+void g3_render_rect_screen_aligned_2d(material *mat_params, vertex *pnt, int orient, float rad, bool isFaraway)
 {
 	vertex va, vb;
 	float t, w, h;
@@ -705,14 +705,18 @@ void g3_render_rect_screen_aligned_2d(material *mat_params, vertex *pnt, int ori
 	if ( pnt->flags & PF_OVERFLOW )
 		return;
 
-	t = (width * gr_screen.clip_width * 0.5f) / pnt->world.xyz.z;
+	t = width * gr_screen.clip_width * 0.5f;
+	if (!isFaraway)
+		t /= pnt->world.xyz.z;
 	w = t*Matrix_scale.xyz.x;
 
-	t = (height * gr_screen.clip_height * 0.5f) / pnt->world.xyz.z;
+	t = height * gr_screen.clip_height * 0.5f;
+	if (!isFaraway)
+		t /= pnt->world.xyz.z;
 	h = t*Matrix_scale.xyz.y;
 
 	float z, sw;
-	z = pnt->world.xyz.z - rad / 2.0f;
+	z = isFaraway ? 100000 : pnt->world.xyz.z - rad / 2.0f;
 	if ( z <= 0.0f ) {
 		z = 0.0f;
 		sw = 0.0f;

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -1342,7 +1342,7 @@ void stars_draw_sun(int show_sun)
 
 		material mat_params;
 		material_set_unlit(&mat_params, bitmap_id, 0.999f, true, false);
-		g3_render_rect_screen_aligned_2d(&mat_params, &sun_vex, 0, 0.05f * Suns[idx].scale_x * local_scale);
+		g3_render_rect_screen_aligned_2d(&mat_params, &sun_vex, 0, 0.05f * Suns[idx].scale_x * local_scale, true);
 		Sun_drew++;
 
 // 		if ( !g3_draw_bitmap(&sun_vex, 0, 0.05f * Suns[idx].scale_x * local_scale, TMAP_FLAG_TEXTURED) )
@@ -1463,7 +1463,7 @@ void stars_draw_sun_glow(int sun_n)
 	//g3_draw_bitmap(&sun_vex, 0, 0.10f * Suns[sun_n].scale_x * local_scale, TMAP_FLAG_TEXTURED);
 	material mat_params;
 	material_set_unlit(&mat_params, bitmap_id, 0.5f, true, false);
-	g3_render_rect_screen_aligned_2d(&mat_params, &sun_vex, 0, 0.10f * Suns[sun_n].scale_x * local_scale);
+	g3_render_rect_screen_aligned_2d(&mat_params, &sun_vex, 0, 0.10f * Suns[sun_n].scale_x * local_scale, true);
 
 	if (bm->flare) {
 		vec3d light_dir;
@@ -1732,13 +1732,13 @@ void subspace_render()
 
 	g3_rotate_faraway_vertex(&glow_vex, &glow_pos);
 	//g3_draw_bitmap(&glow_vex, 0, 17.0f + 0.5f * Noise[framenum], TMAP_FLAG_TEXTURED);
-	g3_render_rect_screen_aligned_2d(&mat_params, &glow_vex, 0, 17.0f + 0.5f * Noise[framenum]);
+	g3_render_rect_screen_aligned_2d(&mat_params, &glow_vex, 0, 17.0f + 0.5f * Noise[framenum], true);
 
 	glow_pos.xyz.z = -100.0f;
 
 	g3_rotate_faraway_vertex(&glow_vex, &glow_pos);
 	//g3_draw_bitmap(&glow_vex, 0, 17.0f + 0.5f * Noise[framenum], TMAP_FLAG_TEXTURED);
-	g3_render_rect_screen_aligned_2d(&mat_params, &glow_vex, 0, 17.0f + 0.5f * Noise[framenum]);
+	g3_render_rect_screen_aligned_2d(&mat_params, &glow_vex, 0, 17.0f + 0.5f * Noise[framenum], true);
 
 	Interp_subspace = 0;
 	gr_zbuffer_set(saved_gr_zbuffering);


### PR DESCRIPTION
Fixes #5990.

This was caused because when rendering the sun, we used a function for 2d billboard rendering.
This function would adjust the size based on z-distance to the camera.
While possibly sensible for true billboard particles, when rendering the sun, we don't want it to appear larger as it approaches the screen edge (where it has a lower z distance, as it's always a unit-vector far away, including x and y measured from the screen center). Especially not since we don't actually check whether it's offscreen (so that the sun can go slightly offscreen, but have parts of the bitmap still shown), so when it's just shy of 90° it'll be rendered at a very large size which can cover the entire screen. Not sure why this is not happening in non-VR gameplay, but oh well.

To fix this, for objects that are considered infinitely far away by the engine, never scale them when billboard rendering, and also give them a render z-distance of 100000 in case they're ever used for z-buffer checks (which is currently not the case).

