### PR TITLE
Better color preset handling

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -314,11 +314,12 @@ SCP_string							HC_gauge_selected;	// gauge is selected
 int HC_gauge_coordinates[6]; // x1, x2, y1, y1, w, h of the example HUD render area. Used for calculating new gauge coordinates
 SCP_vector<std::pair<SCP_string, BoundingBox>> HC_gauge_mouse_coords;
 
+// Names and XSTR IDs for these come from HC_text above
 hc_col HC_colors[NUM_HUD_COLOR_PRESETS] =
 {
-	{0, 255, 0},      // Green
-	{67, 123, 203},   // Blue
-	{255, 197, 0},    // Amber
+	{0, 255, 0, "", -1},    // Green
+	{67, 123, 203, "", -1}, // Blue
+	{255, 197, 0, "", -1},  // Amber
 };
 
 int HC_default_color = HUD_COLOR_PRESET_1;

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -110,7 +110,7 @@ extern HUD_CONFIG_TYPE HUD_config;
 // HUD Color presets
 typedef struct hc_col {
 	int r, g, b;
-	SCP_string name = "";
+	SCP_string name;
 	int xstr = -1;
 } hc_col;
 

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -19,10 +19,10 @@ class player;
 class ship;
 struct ai_info;
 
-#define HUD_COLOR_GREEN		0
-#define HUD_COLOR_BLUE		1
-#define HUD_COLOR_AMBER		2
-#define HUD_COLOR_SIZE		3	// Number of default colors.  Keep this up to date.
+#define HUD_COLOR_PRESET_1		0
+#define HUD_COLOR_PRESET_2		1
+#define HUD_COLOR_PRESET_3		2
+#define NUM_HUD_COLOR_PRESETS		3	// Number of default colors.  Keep this up to date.
 
 // specify the max distance that the radar should detect objects
 // Index in Radar_ranges[] array to get values
@@ -106,6 +106,19 @@ typedef struct HUD_CONFIG_TYPE {
 } HUD_CONFIG_TYPE;
 
 extern HUD_CONFIG_TYPE HUD_config;
+
+// HUD Color presets
+typedef struct hc_col {
+	int r, g, b;
+	SCP_string name = "";
+	int xstr = -1;
+} hc_col;
+
+extern hc_col HC_colors[NUM_HUD_COLOR_PRESETS];
+
+extern int HC_default_color;
+extern SCP_string HC_default_preset_file;
+
 
 /**
  * @struct HC_gauge_setting
@@ -341,7 +354,7 @@ void hud_config_preset_init();
  * 
  * param[in] filename	the preset filename to use as the default
  */
-void hud_set_default_hud_config(player* p, const char* filename = "hud_3.hcf");
+void hud_set_default_hud_config(player* p, const SCP_string& filename);
 
 /*!
  * @brief delete a preset file and remove it from the preset vector

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -220,7 +220,6 @@ SCP_vector<std::pair<SCP_string, SCP_string>> Hud_parsed_ships;
 
 void parse_hud_gauges_tbl(const char *filename)
 {
-	int i;
 	char *saved_Mp = NULL;
 
 	int colors[3] = {255, 255, 255};
@@ -266,6 +265,39 @@ void parse_hud_gauges_tbl(const char *filename)
 
 			if (optional_string("$Example Wing Names:")) {
 				stuff_string_list(HC_wingam_gauge_status_names, MAX_SQUADRON_WINGS);
+			}
+
+			for (int i = 0; i < NUM_HUD_COLOR_PRESETS; i++) {
+				SCP_string colorPresetString = "$Color Preset " + std::to_string(i + 1) + ":";
+				if (optional_string(colorPresetString.c_str())) {
+					hc_col preset;
+					required_string("+Name:");
+					stuff_string(preset.name, F_NAME);
+
+					required_string("+XSTR ID:");
+					stuff_int(&preset.xstr);
+
+					required_string("+Color:");
+					int rgb[3] = {255, 255, 255};
+					stuff_int_list(rgb, 3);
+					
+					for (int c = 0; c < 3; c++) {
+						CLAMP(rgb[c], 0, 255);
+					}
+
+					preset.r = rgb[0];
+					preset.g = rgb[1];
+					preset.b = rgb[2];
+
+					HC_colors[i] = preset;
+					if (optional_string("+Default")) {
+						HC_default_color = i;
+					}
+				}
+			}
+
+			if (optional_string("$Default Preset File:")) {
+				stuff_string(HC_default_preset_file, F_NAME);
 			}
 		}
 
@@ -438,7 +470,7 @@ void parse_hud_gauges_tbl(const char *filename)
 					stuff_boolean(&retail_config);
 				}
 
-				for (i = 0; i < n_ships; ++i) {
+				for (int i = 0; i < n_ships; ++i) {
 					ship_classes.push_back(shiparray[i]);
 					Ship_info[shiparray[i]].hud_enabled = true;
 					Ship_info[shiparray[i]].hud_retail = retail_config;

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -280,9 +280,9 @@ void parse_hud_gauges_tbl(const char *filename)
 					required_string("+Color:");
 					int rgb[3] = {255, 255, 255};
 					stuff_int_list(rgb, 3);
-					
-					for (int c = 0; c < 3; c++) {
-						CLAMP(rgb[c], 0, 255);
+
+					for (auto& c : rgb) {
+						CLAMP(c, 0, 255);
 					}
 
 					preset.r = rgb[0];

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1057,9 +1057,9 @@ void pilotfile::csg_read_hud()
 
 	// basic colors
 	HUD_config.main_color = cfread_int(cfp);
-	if (HUD_config.main_color < 0 || HUD_config.main_color >= HUD_COLOR_SIZE) {
+	if (HUD_config.main_color < 0 || HUD_config.main_color >= NUM_HUD_COLOR_PRESETS) {
 		ReleaseWarning(LOCATION, "Campaign file has invalid main color selection %i, setting to default.\n", HUD_config.main_color);
-		HUD_config.main_color = HUD_COLOR_GREEN;
+		HUD_config.main_color = HUD_COLOR_PRESET_1;
 		strikes++;
 	}
 

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -225,9 +225,9 @@ void pilotfile::plr_read_hud()
 
 	// basic colors
 	HUD_config.main_color = handler->readInt("main_color");
-	if (HUD_config.main_color < 0 || HUD_config.main_color >= HUD_COLOR_SIZE) {
+	if (HUD_config.main_color < 0 || HUD_config.main_color >= NUM_HUD_COLOR_PRESETS) {
 		ReleaseWarning(LOCATION, "Player file has invalid main color selection %i, setting to default.\n", HUD_config.main_color);
-		HUD_config.main_color = HUD_COLOR_GREEN;
+		HUD_config.main_color = HUD_COLOR_PRESET_1;
 		strikes++;
 	}
 

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -85,7 +85,7 @@ bool delete_pilot_file(const char *pilot_name)
 void init_new_pilot(player *p, int reset)
 {
 	if (reset) {
-		hud_set_default_hud_config(p);		// use a default hud config
+		hud_set_default_hud_config(p, HC_default_preset_file); // use a default hud config
 
 		control_config_use_preset(Control_config_presets[0]);		// get a default keyboard config
 		player_set_pilot_defaults(p);			// set up any player struct defaults

--- a/code/scripting/api/libs/ui.cpp
+++ b/code/scripting/api/libs/ui.cpp
@@ -2523,7 +2523,7 @@ ADE_FUNC(setToDefault,
 	nullptr,
 	nullptr)
 {
-	const char* filename = "hud_3.hcf";
+	const char* filename = HC_default_preset_file.c_str();
 	ade_get_args(L, "|s", &filename);
 
 	hud_config_select_all_toggle(0, true);
@@ -2621,6 +2621,29 @@ ADE_INDEXER(l_HUD_Presets,
 ADE_FUNC(__len, l_HUD_Presets, nullptr, "The number of hud presets", "number", "The number of hud presets.")
 {
 	return ade_set_args(L, "i", HC_preset_filenames.size());
+}
+
+ADE_LIB_DERIV(l_HUD_Color_Presets, "GaugeColorPresets", nullptr, nullptr, l_UserInterface_HUDConfig);
+ADE_INDEXER(l_HUD_Color_Presets,
+	"number Index",
+	"Array of HUD Color Presets",
+	"hud_color_preset",
+	"hud_color_preset handle, or invalid handle if index is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "*i", &idx))
+		return ade_set_error(L, "o", l_HUD_Color_Preset.Set(hud_color_preset_h()));
+	idx--; // Convert from Lua's 1 based index system
+
+	if ((idx < 0) || (idx >= NUM_HUD_COLOR_PRESETS))
+		return ade_set_error(L, "o", l_HUD_Color_Preset.Set(hud_color_preset_h()));
+
+	return ade_set_args(L, "o", l_HUD_Color_Preset.Set(hud_color_preset_h(idx)));
+}
+
+ADE_FUNC(__len, l_HUD_Color_Presets, nullptr, "The number of hud color presets", "number", "The number of hud color presets.")
+{
+	return ade_set_args(L, "i", NUM_HUD_COLOR_PRESETS);
 }
 
 //**********SUBLIBRARY: UserInterface/PauseScreen

--- a/code/scripting/api/objs/hudconfig.cpp
+++ b/code/scripting/api/objs/hudconfig.cpp
@@ -52,6 +52,86 @@ bool hud_preset_h::isValid() const
 	return preset >= 0 && preset < (int)HC_preset_filenames.size();
 }
 
+hud_color_preset_h::hud_color_preset_h() : preset(-1) {}
+hud_color_preset_h::hud_color_preset_h(int l_preset) : preset(l_preset) {}
+
+int hud_color_preset_h::getIndex() const
+{
+	return preset;
+}
+
+SCP_string hud_color_preset_h::getName() const
+{
+	if (!isValid()) {
+		return "";
+	}
+
+	return XSTR(HC_colors[preset].name.c_str(), HC_colors[preset].xstr);
+}
+
+bool hud_color_preset_h::isValid() const
+{
+	return preset >= 0 && preset < (int)HC_preset_filenames.size();
+}
+
+//**********HANDLE: hud color preset
+ADE_OBJ(l_HUD_Color_Preset, hud_color_preset_h, "hud_color_preset", "Hud preset handle");
+
+ADE_VIRTVAR(Name, l_HUD_Color_Preset, nullptr, "The name of this preset", "string", "The name")
+{
+	hud_color_preset_h current;
+	if (!ade_get_args(L, "o", l_HUD_Color_Preset.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (!current.isValid()) {
+		return ade_set_error(L, "s", "");
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "s", current.getName().c_str());
+}
+
+ADE_VIRTVAR(Color, l_HUD_Color_Preset, nullptr, "The name of this preset", "color", "color")
+{
+	hud_color_preset_h current;
+	if (!ade_get_args(L, "o", l_HUD_Color_Preset.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (!current.isValid()) {
+		return ade_set_error(L, "s", "");
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	auto preset = HC_colors[current.getIndex()];
+
+	color c;
+	gr_init_color(&c, preset.r, preset.g, preset.b);
+
+	return ade_set_args(L, "o", l_Color.Set(c));
+}
+
+ADE_FUNC(isValid,
+	l_HUD_Color_Preset,
+	nullptr,
+	"Detects whether handle is valid",
+	"boolean",
+	"true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+{
+	hud_color_preset_h current;
+	if (!ade_get_args(L, "o", l_HUD_Color_Preset.Get(&current)))
+		return ADE_RETURN_NIL;
+
+	return ade_set_args(L, "b", current.isValid());
+}
+
 //**********HANDLE: hud preset
 ADE_OBJ(l_HUD_Preset, hud_preset_h, "hud_preset", "Hud preset handle");
 

--- a/code/scripting/api/objs/hudconfig.cpp
+++ b/code/scripting/api/objs/hudconfig.cpp
@@ -49,7 +49,7 @@ SCP_string hud_preset_h::getName() const
 
 bool hud_preset_h::isValid() const
 {
-	return preset >= 0 && preset < (int)HC_preset_filenames.size();
+	return preset >= 0 && preset < static_cast<int>(HC_preset_filenames.size());
 }
 
 hud_color_preset_h::hud_color_preset_h() : preset(-1) {}
@@ -71,7 +71,7 @@ SCP_string hud_color_preset_h::getName() const
 
 bool hud_color_preset_h::isValid() const
 {
-	return preset >= 0 && preset < (int)HC_preset_filenames.size();
+	return preset >= 0 && preset < static_cast<int>(HC_preset_filenames.size());
 }
 
 //**********HANDLE: hud color preset

--- a/code/scripting/api/objs/hudconfig.h
+++ b/code/scripting/api/objs/hudconfig.h
@@ -24,8 +24,18 @@ struct hud_preset_h {
 	bool isValid() const;
 };
 
+struct hud_color_preset_h {
+	int preset;
+	hud_color_preset_h();
+	explicit hud_color_preset_h(int l_preset);
+	int getIndex() const;
+	SCP_string getName() const;
+	bool isValid() const;
+};
+
 DECLARE_ADE_OBJ(l_Gauge_Config, gauge_config_h);
 DECLARE_ADE_OBJ(l_HUD_Preset, hud_preset_h);
+DECLARE_ADE_OBJ(l_HUD_Color_Preset, hud_color_preset_h);
 
 } // namespace api
 } // namespace scripting


### PR DESCRIPTION
Instead of hardcoding the Config color presets to Green, Blue, and Amber this PR makes them definable via table and also adds a way for SCPUI to know what the colors are and what they are named.

Small change to also not hardcode the default preset file that will be used if found, also allowing it to be set via a table flag.