### PR TITLE
Tune how the `default_settings.tbl` handles options it cannot find

### DIFF
--- a/code/options/default_settings_table.cpp
+++ b/code/options/default_settings_table.cpp
@@ -33,7 +33,9 @@ void parse_default_settings_table(const char* filename)
 				const options::OptionBase* thisOpt = options::OptionsManager::instance()->getOptionByKey(name);
 
 				if (thisOpt == nullptr) {
-					error_display(0, "%s is not a valid option!", name.c_str());
+					// keep this just a debug print, as options may be removed but still valid for the table
+					// such as VR mode removing the Window option --Mjn and wookieejedi 
+					mprintf(("Warning: %s is not a valid option for the default_settings table!\n", name.c_str()));
 					skip_to_start_of_string_either("$Option Key:", "#END");
 					continue;
 				}


### PR DESCRIPTION
In-game options may be removed/inaccessible, such as VR mode removing the Window, but still valid for listing in the `default_settings.tbl` table.

In other words, we don't want error messages displaying if a player is playing  in VR mode (which will remove the Window option for that instance) but the window option is listed in the table.

Thus, downgrade the error to a debug print for options within the `default_settings.tbl`. As MJN stated, the table itself controls the parser here, so downgrading the warning is the best choice.