### PR TITLE
Allow normal, AO, and misc maps at higher detail settings

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1118,7 +1118,7 @@ void model_render_buffers(model_draw_list* scene, model_material *rendering_mate
 				texture_maps[TM_SPEC_GLOSS_TYPE] = model_interp_get_texture(&tmap->textures[TM_SPEC_GLOSS_TYPE], elapsed_time);
 			}
 
-			if (detail_level < 2) {
+			if (detail_level < 2 || Detail.detail_distance > 2) {
 				// likewise, etc.
 				auto norm_map = &tmap->textures[TM_NORMAL_TYPE];
 				auto height_map = &tmap->textures[TM_HEIGHT_TYPE];


### PR DESCRIPTION
Previously, FSO did not show normal, AO, or misc maps at LODs 3 or higher. This was  a relic from original retail days, so this PR allows players to see those textures if the model detail level is at 3 or 4. I put this under the model slider because it is related to LODs, and b/c changing the model slider is something folks actually use compared to the other hardware tex slider which really makes things look ancient if turned to anything other than the max.

Fixes maps having a visual pop effect when changing between LODs and overall helps improved visuals of distant ships since all maps are being used. 