### PR TITLE
refine intrinsic_no_shields behavior

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -11512,6 +11512,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	swp = &sp->weapons;
 	sip = &(Ship_info[ship_type]);
 	sip_orig = &Ship_info[sp->ship_info_index];
+	float orig_sp_max_shield_strength = sp->ship_max_shield_strength;
 	objp = &Objects[objnum];
 	p_objp = ship_entry ? ship_entry->p_objp_or_null() : nullptr;
 	ph_inf = objp->phys_info;
@@ -11618,7 +11619,7 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 			shield_pct = shield_get_strength(objp) / shield_get_max_strength(sp);
 		} else if (Ship_info[sp->ship_info_index].max_shield_strength > 0.0f) {
 			shield_pct = shield_get_strength(objp) / (sip_orig->max_shield_strength * sip_orig->max_shield_recharge);
-		} else if (sip_orig->flags[Info_Flags::Intrinsic_no_shields]) {
+		} else if (sip_orig->flags[Info_Flags::Intrinsic_no_shields] || orig_sp_max_shield_strength == 0.0f) {
 			// Recall, this flag is used to allow switching between both shielded and unshielded craft in loadout,
 			// so if that flag is on, then treat shield percent as full instead of empty.
 			// This ensures that switching to a ship with shields in loadout
@@ -11811,12 +11812,12 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 		}
 		else if ((p_objp != nullptr && p_objp->flags[Mission::Parse_Object_Flags::OF_No_shields]) || (sp->ship_max_shield_strength == 0.0f)) {
 			objp->flags.set(Object::Object_Flags::No_shields);
-			// Since there's not a mission flag set to be adjusting this, see if there was a change from a ship that normally has shields to one that doesn't, and vice versa
 		}
+		// Since there's not a mission flag set to be adjusting this, see if there was a change from a ship that normally has shields to one that doesn't, and vice versa
 		else if (!(sip_orig->flags[Info_Flags::Intrinsic_no_shields]) && (sip->flags[Info_Flags::Intrinsic_no_shields])) {
 			objp->flags.set(Object::Object_Flags::No_shields);
 		}
-		else if ((sip_orig->flags[Info_Flags::Intrinsic_no_shields]) && !(sip->flags[Info_Flags::Intrinsic_no_shields]) && (sp->ship_max_shield_strength > 0.0f)) {
+		else if (((sip_orig->flags[Info_Flags::Intrinsic_no_shields]) || (orig_sp_max_shield_strength == 0.0f)) && !(sip->flags[Info_Flags::Intrinsic_no_shields]) && (sp->ship_max_shield_strength > 0.0f)) {
 			objp->flags.remove(Object::Object_Flags::No_shields);
 		}
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12513,6 +12513,8 @@ bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj)
 
 	swp = &shipp->weapons;
 	int weapon_idx = swp->primary_bank_weapons[bank_to_fire];
+	if (weapon_idx < 0)
+		return false;
 	weapon_info* winfo_p = &Weapon_info[weapon_idx];
 
 	// First check our ship/weapon flags

--- a/fred2/fredstubs.cpp
+++ b/fred2/fredstubs.cpp
@@ -223,7 +223,7 @@ void game_feature_disabled_popup() {}
 void game_pause() {}
 void game_unpause() {}
 
-bool Pre_player_entry;
+bool Pre_player_entry = false;
 bool game_actually_playing() { return false; }
 
 //Time stuff

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3805,7 +3805,7 @@ int CFred_mission_save::save_objects()
 			fout(" \"protect-ship\"");
 		if (shipp->flags[Ship::Ship_Flags::Reinforcement])
 			fout(" \"reinforcement\"");
-		if (objp->flags[Object::Object_Flags::No_shields])
+		if (objp->flags[Object::Object_Flags::No_shields] && !sip->flags[Ship::Info_Flags::Intrinsic_no_shields])	// don't save no-shields for intrinsic-no-shields ships
 			fout(" \"no-shields\"");
 		if (shipp->flags[Ship::Ship_Flags::Escort])
 			fout(" \"escort\"");

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -390,7 +390,7 @@ int Test_begin = 0;
 extern int	Player_attacking_enabled;
 int Show_net_stats;
 
-bool Pre_player_entry;
+bool Pre_player_entry = false;
 
 int	Fred_running = 0;
 bool running_unittests = false;

--- a/qtfred/src/fredstubs.cpp
+++ b/qtfred/src/fredstubs.cpp
@@ -227,7 +227,7 @@ void game_feature_disabled_popup() {}
 void game_pause() {}
 void game_unpause() {}
 
-bool Pre_player_entry;
+bool Pre_player_entry = false;
 bool game_actually_playing() { return false; }
 
 //Time stuff

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3449,6 +3449,7 @@ int CFred_mission_save::save_objects()
 	int i, z;
 	object* objp;
 	ship* shipp;
+	ship_info* sip;
 
 	required_string_fred("#Objects");
 	parse_comments(2);
@@ -3466,6 +3467,7 @@ int CFred_mission_save::save_objects()
 
 		shipp = &Ships[i];
 		objp = &Objects[shipp->objnum];
+		sip = &Ship_info[shipp->ship_info_index];
 		required_string_either_fred("$Name:", "#Wings");
 		required_string_fred("$Name:");
 		parse_comments(z ? 2 : 1);
@@ -3731,7 +3733,7 @@ int CFred_mission_save::save_objects()
 		if (shipp->flags[Ship::Ship_Flags::Reinforcement]) {
 			fout(" \"reinforcement\"");
 		}
-		if (objp->flags[Object::Object_Flags::No_shields]) {
+		if (objp->flags[Object::Object_Flags::No_shields] && !sip->flags[Ship::Info_Flags::Intrinsic_no_shields]) {	// don't save no-shields for intrinsic-no-shields ships
 			fout(" \"no-shields\"");
 		}
 		if (shipp->flags[Ship::Ship_Flags::Escort]) {

--- a/test/src/test_stubs.cpp
+++ b/test/src/test_stubs.cpp
@@ -232,7 +232,7 @@ void game_feature_disabled_popup() {}
 void game_pause() {}
 void game_unpause() {}
 
-bool Pre_player_entry;
+bool Pre_player_entry = false;
 bool game_actually_playing() { return false; }
 
 //Time stuff


### PR DESCRIPTION
Enhance shield checks to consider shield strength in addition to the `Intrinsic_no_shields` ship flag.  Avoid saving the no-shields flag if a ship has intrinsic no-shields.

Also make sure `Pre_player_entry` is initialized and fix a negative array access in autoaim.