### PR TITLE
fix chaotic player targeting in rare situations

### DIFF
--- a/code/autopilot/autopilot.cpp
+++ b/code/autopilot/autopilot.cpp
@@ -30,7 +30,7 @@
 #include <map>
 
 // Extern functions/variables
-extern int		Player_use_ai;
+extern bool Player_use_ai;
 extern int get_wing_index(object *objp, int wingnum);
 extern object * get_wing_leader(int wingnum);
 extern int Cmdline_autopilot_interruptable;
@@ -270,7 +270,7 @@ bool StartAutopilot()
 		LockAPConv = _timestamp(); // lock convergence instantly
 	else
 		LockAPConv = _timestamp(3 * MILLISECONDS_PER_SECOND); // 3 seconds before we lock convergence
-	Player_use_ai = 1;
+	Player_use_ai = true;
 	set_time_compression(1);
 	lock_time_compression(true);
 
@@ -858,7 +858,7 @@ void EndAutoPilot()
 
 	set_time_compression(1);
 	lock_time_compression(false);
-	Player_use_ai = 0;
+	Player_use_ai = false;
 	//Clear AI Goals
 
 	if (CinematicStarted) // clear cinematic if we need to

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6421,7 +6421,7 @@ bool post_process_mission(mission *pm)
 
 	// Kazan - player use AI at start?
 	if (pm->flags[Mission::Mission_Flags::Player_start_ai])
-		Player_use_ai = 1;
+		Player_use_ai = true;
 
 	// Assign squadron information
 	if (!Fred_running && (Player != nullptr) && (pm->squad_name[0] != '\0') && (Game_mode & GM_CAMPAIGN_MODE) && !(Game_mode & GM_MULTIPLAYER)) {

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13749,11 +13749,12 @@ void sexp_set_squadron_wings(int node)
 /**
  * Trigger whether player uses the game AI for stuff
  */
-void sexp_player_use_ai(int flag)
+void sexp_player_use_ai(bool use_ai)
 {
-	Player_use_ai = flag ? 1 : 0;
+	Player_use_ai = use_ai;
 
-	if (!flag) {
+	if (!use_ai)
+	{
 		Player_ai->ai_override_flags.reset();
 		Player_obj->phys_info.flags &= ~PF_MANEUVER_NO_DAMP;
 	}

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13751,6 +13751,14 @@ void sexp_set_squadron_wings(int node)
  */
 void sexp_player_use_ai(bool use_ai)
 {
+	// if turning off player AI, clean up the AI to prevent any stale state from causing trouble later
+	if (Player_use_ai && !use_ai)
+	{
+		ai_clear_ship_goals(Player_ai);
+		Player_ai->mode = AIM_NONE;
+		set_target_objnum(Player_ai, -1);
+	}
+
 	Player_use_ai = use_ai;
 
 	if (!use_ai)

--- a/code/playerman/player.h
+++ b/code/playerman/player.h
@@ -223,7 +223,7 @@ extern player Players[MAX_PLAYERS];
 extern int Player_num;								// player num of person playing on this machine
 extern player *Player;								// pointer to my information
 
-extern int Player_use_ai;
+extern bool Player_use_ai;
 extern angles chase_slew_angles;					// The viewing angles in which viewer_slew_angles will chase to.
 
 extern angles Player_flight_cursor;

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -53,7 +53,7 @@ int		Player_num;
 player	*Player = NULL;
 
 // Goober5000
-int		Player_use_ai = 0;
+bool	Player_use_ai = false;
 
 int		lua_game_control = 0;
 
@@ -1461,7 +1461,7 @@ void player_level_init()
 	Player_ship = NULL;
 	Player_ai = NULL;
 
-	Player_use_ai = 0;	// Goober5000
+	Player_use_ai = false;	// Goober5000
 
 	if(Player == NULL)
 		return;


### PR DESCRIPTION
When the player's ship is under AI control and assigned a guard goal, this information would persist when the ship was returned to player control.  This would cause the player's target to be randomly reassigned.  To fix this, the AI state should be cleared when player AI is turned off.

Also change the `Player_use_ai` variable from `int` to `bool`.

Fixes a bug in Series Resurrecta, as well as potentially other bugs with other AI modes.