### PR TITLE
Fix SoundDuring animation segments with the loop flag set

### DIFF
--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -326,7 +326,7 @@ namespace animation {
 		}
 	}
 
-	void ModelAnimation::stop(polymodel_instance* pmi, bool cleanup) {
+	void ModelAnimation::stop(polymodel_instance* pmi, bool cleanup, bool forceStop) {
 		//If inaccuracies occur, this needs to reset again, but only if no other animation is running on this submodel
 		/*for (const auto& animation : m_submodelAnimation) {
 			animation->reset(pmi);
@@ -334,6 +334,9 @@ namespace animation {
 
 		if (!pmi)
 			return;
+
+		if (forceStop)
+			m_animation->forceStopAnimation(pmi->id);
 
 		instance_data& instanceData = m_instances[pmi->id];
 		instanceData.time = 0.0f;
@@ -748,14 +751,14 @@ namespace animation {
 	void ModelAnimationSet::stopAnimations(polymodel_instance* pmi) {
 		if (pmi != nullptr) {
 			for (const auto& anim : s_runningAnimations[pmi->id].animationList) {
-				anim->stop(pmi, false);
+				anim->stop(pmi, false, true);
 			}
 			s_runningAnimations.erase(pmi->id);
 		}
 		else {
 			for (const auto& animList : s_runningAnimations) {
 				for (const auto& anim : animList.second.animationList) {
-					anim->stop(model_get_instance(animList.first), false);
+					anim->stop(model_get_instance(animList.first), false, true);
 				}
 			}
 

--- a/code/model/animation/modelanimation.h
+++ b/code/model/animation/modelanimation.h
@@ -202,6 +202,8 @@ namespace animation {
 		virtual void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) = 0;
 		//This function must exchange all held submodel pointers of itself and children with ones acquired from replaceWith.
 		virtual void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) = 0;
+		//This function must tidy up animation side-effects when the animation is stopped immediately, such as by ship death or departure
+		virtual void forceStopAnimation(int /*pmi_id*/) { }
 	};
 
 	class ModelAnimation : public std::enable_shared_from_this <ModelAnimation> {
@@ -260,7 +262,7 @@ namespace animation {
 		//Start playing the animation. Will stop other animations that have components running on the same submodels. instant always requires force
 		void start(polymodel_instance* pmi, ModelAnimationDirection direction, bool force = false, bool instant = false, bool pause = false, const float* multiOverrideTime = nullptr);
 		//Stops the animation. If cleanup is set, it will remove the animation from the list of running animations. Don't call without cleanup unless you know what you are doing
-		void stop(polymodel_instance* pmi, bool cleanup = true);
+		void stop(polymodel_instance* pmi, bool cleanup = true, bool forceStop = false);
 
 		float getTime(int pmi_id) const;
 		

--- a/code/model/animation/modelanimation_segments.cpp
+++ b/code/model/animation/modelanimation_segments.cpp
@@ -62,6 +62,11 @@ namespace animation {
 			segment->exchangeSubmodelPointers(replaceWith);
 	}
 
+	void ModelAnimationSegmentSerial::forceStopAnimation(int pmi_id) {
+		for (const auto& segment : m_segments)
+			segment->forceStopAnimation(pmi_id);
+	}
+
 	void ModelAnimationSegmentSerial::addSegment(std::shared_ptr<ModelAnimationSegment> segment) {
 		m_segments.push_back(std::move(segment));
 	}
@@ -129,6 +134,11 @@ namespace animation {
 	void ModelAnimationSegmentParallel::exchangeSubmodelPointers(ModelAnimationSet& replaceWith) {
 		for (const auto& segment : m_segments)
 			segment->exchangeSubmodelPointers(replaceWith);
+	}
+
+	void ModelAnimationSegmentParallel::forceStopAnimation(int pmi_id) {
+		for (const auto& segment : m_segments)
+			segment->forceStopAnimation(pmi_id);
 	}
 
 	void ModelAnimationSegmentParallel::addSegment(std::shared_ptr<ModelAnimationSegment> segment) {
@@ -1252,8 +1262,7 @@ namespace animation {
 		}
 
 		if (0.0f < timeboundLower && timeboundUpper < m_duration.at(pmi_id)) {
-			if (m_during.isValid() && (!m_instances[pmi_id].currentlyPlaying.isValid() || !snd_is_playing(m_instances[pmi_id].currentlyPlaying)))
-				m_instances[pmi_id].currentlyPlaying = playSnd(pmi, m_during, true);
+			playLoopSnd(pmi);
 		}
 
 		if (timeboundLower <= m_duration.at(pmi_id) && m_duration.at(pmi_id) <= timeboundUpper) {
@@ -1269,19 +1278,48 @@ namespace animation {
 		m_segment->exchangeSubmodelPointers(replaceWith);
 	}
 
-	void ModelAnimationSegmentSoundDuring::playStartSnd(polymodel_instance* pmi) {
-		if (m_abortSoundIfRunning && snd_is_playing(m_instances[pmi->id].currentlyPlaying))
-			snd_stop(m_instances[pmi->id].currentlyPlaying);
-		
-		if(m_start.isValid())
-			m_instances[pmi->id].currentlyPlaying = playSnd(pmi, m_start, false);
-	}
-	void ModelAnimationSegmentSoundDuring::playEndSnd(polymodel_instance* pmi) {
-		if (m_abortSoundIfRunning && snd_is_playing(m_instances[pmi->id].currentlyPlaying))
-			snd_stop(m_instances[pmi->id].currentlyPlaying);
+	void ModelAnimationSegmentSoundDuring::forceStopAnimation(int pmi_id) {
+		auto& instance = m_instances[pmi_id];
 
-		if (m_end.isValid()) 
-			m_instances[pmi->id].currentlyPlaying = playSnd(pmi, m_end, false);
+		if (instance.currentlyPlaying.isValid() && snd_is_playing(instance.currentlyPlaying)) {
+			snd_stop(instance.currentlyPlaying);
+			instance.interruptableSound = false;
+			instance.currentlyPlaying = sound_handle::invalid();
+		}
+	}
+
+	void ModelAnimationSegmentSoundDuring::playLoopSnd(polymodel_instance* pmi) {
+		auto& instance = m_instances[pmi->id];
+
+		if (m_during.isValid() && (!instance.currentlyPlaying.isValid() || !snd_is_playing(instance.currentlyPlaying))) {
+			instance.currentlyPlaying = playSnd(pmi, m_during, true);
+			instance.interruptableSound = true;
+		}
+	}
+
+	//TODO: We stop interruptableSound here. Ideally, these should be set from looping to non-looping and then have the next sound queued, but the sound system currently seems to not allow that (even though snd_chg_loop_status exists, it's unimplemented)
+	void ModelAnimationSegmentSoundDuring::playStartSnd(polymodel_instance* pmi) {
+		auto& instance = m_instances[pmi->id];
+
+		if ((m_abortSoundIfRunning || instance.interruptableSound) && snd_is_playing(instance.currentlyPlaying))
+			snd_stop(instance.currentlyPlaying);
+
+		if (m_start.isValid()) {
+			instance.currentlyPlaying = playSnd(pmi, m_start, false);
+			instance.interruptableSound = false;
+		}
+	}
+
+	void ModelAnimationSegmentSoundDuring::playEndSnd(polymodel_instance* pmi) {
+		auto& instance = m_instances[pmi->id];
+
+		if ((m_abortSoundIfRunning || instance.interruptableSound) && snd_is_playing(instance.currentlyPlaying))
+			snd_stop(instance.currentlyPlaying);
+
+		if (m_end.isValid()) {
+			instance.currentlyPlaying = playSnd(pmi, m_end, false);
+			instance.interruptableSound = false;
+		}
 	}
 
 	sound_handle ModelAnimationSegmentSoundDuring::playSnd(polymodel_instance* pmi, const gamesnd_id& sound, bool loop) {

--- a/code/model/animation/modelanimation_segments.cpp
+++ b/code/model/animation/modelanimation_segments.cpp
@@ -1281,7 +1281,8 @@ namespace animation {
 	void ModelAnimationSegmentSoundDuring::forceStopAnimation(int pmi_id) {
 		auto& instance = m_instances[pmi_id];
 
-		if (instance.currentlyPlaying.isValid() && snd_is_playing(instance.currentlyPlaying)) {
+		//If don't interrupt playing sounds is set, just do the stop here if it's looping, otherwise it'll finish soon anyways
+		if ((m_abortSoundIfRunning || instance.interruptableSound) && instance.currentlyPlaying.isValid() && snd_is_playing(instance.currentlyPlaying)) {
 			snd_stop(instance.currentlyPlaying);
 			instance.interruptableSound = false;
 			instance.currentlyPlaying = sound_handle::invalid();

--- a/code/model/animation/modelanimation_segments.h
+++ b/code/model/animation/modelanimation_segments.h
@@ -16,6 +16,7 @@ namespace animation {
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
+		void forceStopAnimation(int pmi_id) override;
 
 	public:
 		ModelAnimationSegment* copy() const override;
@@ -35,6 +36,7 @@ namespace animation {
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
+		void forceStopAnimation(int pmi_id) override;
 
 	public:
 		ModelAnimationSegment* copy() const override;
@@ -251,6 +253,7 @@ namespace animation {
 
 		struct instance_data {
 			sound_handle currentlyPlaying;
+			bool interruptableSound;
 		};
 
 		//PMI ID -> Instance Data
@@ -274,8 +277,10 @@ namespace animation {
 		void calculateAnimation(ModelAnimationSubmodelBuffer& base, float time, int pmi_id) const override;
 		void executeAnimation(const ModelAnimationSubmodelBuffer& state, float timeboundLower, float timeboundUpper, ModelAnimationDirection direction, int pmi_id) override;
 		void exchangeSubmodelPointers(ModelAnimationSet& replaceWith) override;
+		void forceStopAnimation(int pmi_id) override;
 
 		sound_handle playSnd(polymodel_instance* pmi, const gamesnd_id& sound, bool loop);
+		void playLoopSnd(polymodel_instance* pmi);
 		void playStartSnd(polymodel_instance* pmi);
 		void playEndSnd(polymodel_instance* pmi);
 

--- a/code/utils/id.h
+++ b/code/utils/id.h
@@ -29,10 +29,10 @@ public:
 	typedef Tag tag_type;
 	typedef Impl impl_type;
 
-	static ID invalid() { return ID(); }
+	static constexpr ID invalid() { return ID(); }
 
 	// Defaults to ID::invalid()
-	ID() : m_val(default_value) { }
+	constexpr ID() : m_val(default_value) { }
 
 	// Explicit constructor:
 	explicit ID(Impl val) : m_val(val) { }


### PR DESCRIPTION
So, turns out not stopping a sound for the next one if its set to loop indefinitely is a bad idea.
This fix is kinda hacky in the sense that we'd really like to "stop the sound after the next loop", but that seems like we currently cannot reasonably do so.
But this can be a todo for another time.
