### PR TITLE
Allow curves to be tabled inline

### DIFF
--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -53,14 +53,18 @@ static int curve_inline_def(){
 	return resulting_curve;
 }
 
-int curve_parse() {
+int curve_parse(const char *err_msg) {
 	if(optional_string("(")) {
 		return curve_inline_def();
 	}
 	else {
 		SCP_string curve_name;
 		stuff_string(curve_name, F_NAME);
-		return curve_get_by_name(curve_name);
+		int curve_id = curve_get_by_name(curve_name);
+		if (curve_id < 0) {
+			error_display(0, "Curve %s not found!%s", curve_name.c_str(), err_msg);
+		}
+		return curve_id;
 	}
 }
 

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -9,6 +9,62 @@ int curve_get_by_name(const SCP_string& in_name) {
 	return find_item_with_field(Curves, &Curve::name, in_name);
 }
 
+static int curve_inline_def(){
+	//The curve needs a unique identifier. Build this with semicolon + filename + semicolon + character in file
+	SCP_string curve_name = ';' + SCP_string(Current_filename) + ';' + std::to_string(Mp - Parse_text);
+
+	int resulting_curve = Curves.size();
+	Curve& new_curve = Curves.emplace_back(curve_name);
+
+	do {
+		curve_keyframe& new_keyframe = new_curve.keyframes.emplace_back();
+		stuff_float(&new_keyframe.pos.x);
+		required_string(",");
+		stuff_float(&new_keyframe.pos.y);
+		required_string(")");
+
+		bool found_interpolation = true;
+		int interpolation_mode = optional_string_one_of(4, "--", "-|", "-/", "/-");
+		switch (interpolation_mode) {
+		case 0:
+			new_keyframe.interp_func = CurveInterpFunction::Linear;
+			break;
+		case 1:
+			new_keyframe.interp_func = CurveInterpFunction::Constant;
+			break;
+		case 2:
+			new_keyframe.interp_func = CurveInterpFunction::Polynomial;
+			new_keyframe.param1 = 2.0f;
+			new_keyframe.param2 = 1.0f;
+			break;
+		case 3:
+			new_keyframe.interp_func = CurveInterpFunction::Polynomial;
+			new_keyframe.param1 = 2.0f;
+			new_keyframe.param2 = -1.0f;
+			break;
+		default:
+			new_keyframe.interp_func = CurveInterpFunction::Linear;
+			found_interpolation = false;
+			break;
+		}
+		if (!found_interpolation)
+			break;
+	} while (optional_string("("));
+
+	return resulting_curve;
+}
+
+int curve_parse() {
+	if(optional_string("(")) {
+		return curve_inline_def();
+	}
+	else {
+		SCP_string curve_name;
+		stuff_string(curve_name, F_NAME);
+		return curve_get_by_name(curve_name);
+	}
+}
+
 void parse_curve_table(const char* filename) {
 	try
 	{

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -13,7 +13,7 @@ static int curve_inline_def(){
 	//The curve needs a unique identifier. Build this with semicolon + filename + semicolon + character in file
 	SCP_string curve_name = ';' + SCP_string(Current_filename) + ';' + std::to_string(Mp - Parse_text);
 
-	int resulting_curve = Curves.size();
+	int resulting_curve = static_cast<int>(Curves.size());
 	Curve& new_curve = Curves.emplace_back(curve_name);
 
 	do {

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -19,7 +19,6 @@ static int curve_inline_def(){
 	do {
 		curve_keyframe& new_keyframe = new_curve.keyframes.emplace_back();
 		stuff_float(&new_keyframe.pos.x);
-		required_string(",");
 		stuff_float(&new_keyframe.pos.y);
 		required_string(")");
 

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -49,6 +49,6 @@ public :
 extern SCP_vector<Curve> Curves;
 
 extern int curve_get_by_name(const SCP_string& in_name);
-extern int curve_parse();
+extern int curve_parse(const char* err_msg);
 extern void curves_init();
 

--- a/code/math/curve.h
+++ b/code/math/curve.h
@@ -49,5 +49,6 @@ public :
 extern SCP_vector<Curve> Curves;
 
 extern int curve_get_by_name(const SCP_string& in_name);
+extern int curve_parse();
 extern void curves_init();
 

--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -1474,10 +1474,8 @@ namespace animation {
 
 				std::optional<Curve> curve = std::nullopt;
 				if (optional_string("+Curve:")) {
-					int curve_id = curve_parse();
-					if (curve_id < 0) 
-						error_display(0, "Unknown curve specified! The driver will not use a curve.");
-					else
+					int curve_id = curve_parse(" The driver will not use a curve.");
+					if (curve_id >= 0)
 						curve = Curves[curve_id];
 				}
 
@@ -1501,10 +1499,8 @@ namespace animation {
 
 				std::optional<Curve> curve = std::nullopt;
 				if (optional_string("+Curve:")) {
-					int curve_id = curve_parse();
-					if (curve_id < 0)
-						error_display(0, "Unknown curve specified! The driver will not use a curve.");
-					else
+					int curve_id = curve_parse(" The driver will not use a curve.");
+					if (curve_id >= 0)
 						curve = Curves[curve_id];
 				}
 
@@ -1529,10 +1525,8 @@ namespace animation {
 
 				std::optional<Curve> curve = std::nullopt;
 				if (optional_string("+Curve:")) {
-					int curve_id = curve_parse();
-					if (curve_id < 0)
-						error_display(0, "Unknown curve specified! The driver will not use a curve.");
-					else
+					int curve_id = curve_parse(" The driver will not use a curve.");
+					if (curve_id >= 0)
 						curve = Curves[curve_id];
 				}
 

--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -1474,9 +1474,7 @@ namespace animation {
 
 				std::optional<Curve> curve = std::nullopt;
 				if (optional_string("+Curve:")) {
-					SCP_string curve_name;
-					stuff_string(curve_name, F_NAME);
-					int curve_id = curve_get_by_name(curve_name);
+					int curve_id = curve_parse();
 					if (curve_id < 0) 
 						error_display(0, "Unknown curve specified! The driver will not use a curve.");
 					else
@@ -1503,9 +1501,7 @@ namespace animation {
 
 				std::optional<Curve> curve = std::nullopt;
 				if (optional_string("+Curve:")) {
-					SCP_string curve_name;
-					stuff_string(curve_name, F_NAME);
-					int curve_id = curve_get_by_name(curve_name);
+					int curve_id = curve_parse();
 					if (curve_id < 0)
 						error_display(0, "Unknown curve specified! The driver will not use a curve.");
 					else
@@ -1533,9 +1529,7 @@ namespace animation {
 
 				std::optional<Curve> curve = std::nullopt;
 				if (optional_string("+Curve:")) {
-					SCP_string curve_name;
-					stuff_string(curve_name, F_NAME);
-					int curve_id = curve_get_by_name(curve_name);
+					int curve_id = curve_parse();
 					if (curve_id < 0)
 						error_display(0, "Unknown curve specified! The driver will not use a curve.");
 					else

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -756,17 +756,19 @@ int optional_string_fred(const char *pstr, const char *end, const char *end2)
  * @details Advances the Mp until a string is found or exceeds RS_MAX_TRIES. Once a string is found, Mp is located at
  * the start of the found string.
  */
-int required_string_either(const char *str1, const char *str2)
+int required_string_either(const char *str1, const char *str2, bool advance)
 {
 	ignore_white_space();
 
 	for (int count = 0; count < RS_MAX_TRIES; ++count) {
 		if (strnicmp(str1, Mp, strlen(str1)) == 0) {
-			// Mp += strlen(str1);
+			if (advance)
+				Mp += strlen(str1);
 			diag_printf("Found required string [%s]\n", token_found = str1);
 			return 0;
 		} else if (strnicmp(str2, Mp, strlen(str2)) == 0) {
-			// Mp += strlen(str2);
+			if (advance)
+				Mp += strlen(str2);
 			diag_printf("Found required string [%s]\n", token_found = str2);
 			return 1;
 		}

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -128,7 +128,7 @@ extern int optional_string_one_of(int arg_count, ...);
 
 // required
 extern int required_string(const char *pstr);
-extern int required_string_either(const char *str1, const char *str2);
+extern int required_string_either(const char *str1, const char *str2, bool advance = false);
 extern int required_string_one_of(int arg_count, ...);
 
 // stuff

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -228,12 +228,8 @@ namespace particle {
 				required_string(output == 0 ? "Radius" : "Velocity");
 				int& curve = output == 0 ? effect.m_size_lifetime_curve : effect.m_vel_lifetime_curve;
 
-				required_string("+Curve Name:");
-				curve = curve_parse();
-
-				if (curve < 0) {
-					error_display(0, "Could not find curve");
-				}
+				required_string_either("+Curve Name:", "+Curve:");
+				curve = curve_parse(" Unknown curve requested for modular curves!");
 			}
 		}
 
@@ -303,21 +299,13 @@ namespace particle {
 
 		static void parseSizeLifetimeCurve(ParticleEffect &effect) {
 			if (optional_string("+Size over lifetime curve:")) {
-				effect.m_size_lifetime_curve = curve_parse();
-
-				if (effect.m_size_lifetime_curve < 0) {
-					error_display(0, "Could not find curve");
-				}
+				effect.m_size_lifetime_curve = curve_parse("");
 			}
 		}
 
 		static void parseVelocityLifetimeCurve(ParticleEffect &effect) {
 			if (optional_string("+Velocity scalar over lifetime curve:")) {
-				effect.m_vel_lifetime_curve = curve_parse();
-
-				if (effect.m_vel_lifetime_curve < 0) {
-					error_display(0, "Could not find curve");
-				}
+				effect.m_vel_lifetime_curve = curve_parse("");
 			}
 		}
 

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -229,12 +229,10 @@ namespace particle {
 				int& curve = output == 0 ? effect.m_size_lifetime_curve : effect.m_vel_lifetime_curve;
 
 				required_string("+Curve Name:");
-				SCP_string buf;
-				stuff_string(buf, F_NAME);
-				curve = curve_get_by_name(buf);
+				curve = curve_parse();
 
 				if (curve < 0) {
-					error_display(0, "Could not find curve '%s'", buf.c_str());
+					error_display(0, "Could not find curve");
 				}
 			}
 		}
@@ -305,24 +303,20 @@ namespace particle {
 
 		static void parseSizeLifetimeCurve(ParticleEffect &effect) {
 			if (optional_string("+Size over lifetime curve:")) {
-				SCP_string buf;
-				stuff_string(buf, F_NAME);
-				effect.m_size_lifetime_curve = curve_get_by_name(buf);
+				effect.m_size_lifetime_curve = curve_parse();
 
 				if (effect.m_size_lifetime_curve < 0) {
-					error_display(0, "Could not find curve '%s'", buf.c_str());
+					error_display(0, "Could not find curve");
 				}
 			}
 		}
 
 		static void parseVelocityLifetimeCurve(ParticleEffect &effect) {
 			if (optional_string("+Velocity scalar over lifetime curve:")) {
-				SCP_string buf;
-				stuff_string(buf, F_NAME);
-				effect.m_vel_lifetime_curve = curve_get_by_name(buf);
+				effect.m_vel_lifetime_curve = curve_parse();
 
 				if (effect.m_vel_lifetime_curve < 0) {
-					error_display(0, "Could not find curve '%s'", buf.c_str());
+					error_display(0, "Could not find curve");
 				}
 			}
 		}

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -228,7 +228,7 @@ namespace particle {
 				required_string(output == 0 ? "Radius" : "Velocity");
 				int& curve = output == 0 ? effect.m_size_lifetime_curve : effect.m_vel_lifetime_curve;
 
-				required_string_either("+Curve Name:", "+Curve:");
+				required_string_either("+Curve Name:", "+Curve:", true);
 				curve = curve_parse(" Unknown curve requested for modular curves!");
 			}
 		}

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -469,7 +469,7 @@ using CurveFloatRange = RandomRange<float, CurveNumberDistribution, std::minstd_
 inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<float>::lowest()/2.1f, float max = std::numeric_limits<float>::max()/2.1f) {
 	CurveNumberDistribution::param_type curve_params;
 
-	curve_params.curve = curve_parse();
+	curve_params.curve = curve_parse(" Random distributions using this curve will return 0.");
 
 	optional_string("(");
 	stuff_float_optional(&curve_params.min);
@@ -477,7 +477,6 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 	optional_string(")");
 
 	if (curve_params.curve < 0) {
-		error_display(0, "Curve not found! Random distributions using this curve will return 0.");
 		return CurveFloatRange{curve_params};
 	} else {
 		bool y_below_0 = false;

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -469,9 +469,7 @@ using CurveFloatRange = RandomRange<float, CurveNumberDistribution, std::minstd_
 inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<float>::lowest()/2.1f, float max = std::numeric_limits<float>::max()/2.1f) {
 	CurveNumberDistribution::param_type curve_params;
 
-	SCP_string curve_name;
-	stuff_string(curve_name, F_NAME);
-	curve_params.curve = curve_get_by_name(curve_name);
+	curve_params.curve = curve_parse();
 
 	optional_string("(");
 	stuff_float_optional(&curve_params.min);
@@ -479,7 +477,7 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 	optional_string(")");
 
 	if (curve_params.curve < 0) {
-		error_display(0, "Curve %s not found! Random distributions using this curve will return 0.", curve_name.c_str());
+		error_display(0, "Curve not found! Random distributions using this curve will return 0.");
 		return CurveFloatRange{curve_params};
 	} else {
 		bool y_below_0 = false;
@@ -496,13 +494,13 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 
 		if (y_below_0) {
 			error_display(0,
-				"Curve %s goes below zero along the Y axis. Random distributions using this curve will return 0.", curve_name.c_str());
+				"Curve %s goes below zero along the Y axis. Random distributions using this curve will return 0.", Curves[curve_params.curve].name.c_str());
 			curve_params.curve = -1;
 			return CurveFloatRange{curve_params};
 		}
 		if (no_y_above_0) {
 			error_display(0,
-				"Curve %s has no values above zero along the Y axis. Random distributions using this curve will return 0.", curve_name.c_str());
+				"Curve %s has no values above zero along the Y axis. Random distributions using this curve will return 0.", Curves[curve_params.curve].name.c_str());
 			curve_params.curve = -1;
 			return CurveFloatRange{curve_params};
 		}
@@ -510,7 +508,7 @@ inline CurveFloatRange parseCurveFloatRange(float min = std::numeric_limits<floa
 
 	if (fl_is_nan(curve_params.min) || fl_is_nan(curve_params.max)) {
 		if (!fl_is_nan(curve_params.min)) {
-			error_display(0, "Minimum value but no maximum value specified for curve distribution %s!", curve_name.c_str());
+			error_display(0, "Minimum value but no maximum value specified for curve distribution %s!", Curves[curve_params.curve].name.c_str());
 		}
 		curve_params.min = Curves[curve_params.curve].keyframes.front().pos.x;
 		curve_params.max = Curves[curve_params.curve].keyframes.back().pos.x;

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -338,7 +338,7 @@ struct modular_curves_definition {
 
 			modular_curves_entry curve_entry;
 
-			required_string_either("+Curve Name:", "+Curve:");
+			required_string_either("+Curve Name:", "+Curve:", true);
 			curve_entry.curve_idx = curve_parse(" Unknown curve requested for modular curves!");
 			if (curve_entry.curve_idx < 0){
 				error_display(1, "Unknown curve requested for modular curves!");

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -338,8 +338,8 @@ struct modular_curves_definition {
 
 			modular_curves_entry curve_entry;
 
-			required_string("+Curve Name:");
-			curve_entry.curve_idx = curve_parse();
+			required_string_either("+Curve Name:", "+Curve:");
+			curve_entry.curve_idx = curve_parse(" Unknown curve requested for modular curves!");
 			if (curve_entry.curve_idx < 0){
 				error_display(1, "Unknown curve requested for modular curves!");
 			}

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -105,7 +105,7 @@ struct modular_curves_submember_input {
 	template<typename result_type>
 	static inline float number_to_float(const result_type& number) {
 		// if constexpr(std::is_same_v<std::decay_t<result_type>, fix>) // TODO: Make sure we can differentiate fixes from ints.
-		//	return f2fl(number);
+		// 	return f2fl(number);
 		// else
 		if constexpr(std::is_integral_v<std::decay_t<result_type>>)
 			return static_cast<float>(number);
@@ -339,11 +339,9 @@ struct modular_curves_definition {
 			modular_curves_entry curve_entry;
 
 			required_string("+Curve Name:");
-			SCP_string curve;
-			stuff_string(curve, F_NAME);
-			curve_entry.curve_idx = curve_get_by_name(curve);
+			curve_entry.curve_idx = curve_parse();
 			if (curve_entry.curve_idx < 0){
-				error_display(1, "Unknown curve %s requested for modular curves!", curve.c_str());
+				error_display(1, "Unknown curve requested for modular curves!");
 			}
 
 			if (optional_string("+Random Scaling Factor:")) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -811,11 +811,9 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 
 	sprintf(buf, "%sShockwave Radius Multiplier over Lifetime Curve:", pre_char);
 	if (optional_string(buf.c_str())) {
-		SCP_string curve_name;
-		stuff_string(curve_name, F_NAME);
-		sci->radius_curve_idx = curve_get_by_name(curve_name);
+		sci->radius_curve_idx = curve_parse();
 		if (sci->radius_curve_idx < 0)
-			Warning(LOCATION, "Unrecognized shockwave radius curve '%s'", curve_name.c_str());
+			Warning(LOCATION, "Unrecognized shockwave radius curve");
 	}
 
 	sprintf(buf, "%sShockwave Speed:", pre_char);
@@ -1225,9 +1223,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 
 	if (optional_string("@Laser Length Multiplier over Lifetime Curve:")) {
-		SCP_string curve_name;
-		stuff_string(curve_name, F_NAME);
-		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_LENGTH_MULT, modular_curves_entry{curve_get_by_name(curve_name)});
+		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_LENGTH_MULT, modular_curves_entry{curve_parse()});
 	}
 	
 	if(optional_string("@Laser Head Radius:")) {
@@ -1239,9 +1235,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 
 	if (optional_string("@Laser Radius Multiplier over Lifetime Curve:")) {
-		SCP_string curve_name;
-		stuff_string(curve_name, F_NAME);
-		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_RADIUS_MULT, modular_curves_entry{curve_get_by_name(curve_name)});
+		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_RADIUS_MULT, modular_curves_entry{curve_parse()});
 	}
 	if (optional_string("@Laser Glow Length Scale:")) {
 		stuff_float(&wip->laser_glow_length_scale);
@@ -1262,9 +1256,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
   parse_optional_float_into("@Laser Min Pixel Size:", &wip->laser_min_pixel_size);
 
 	if (optional_string("@Laser Opacity over Lifetime Curve:")) {
-		SCP_string curve_name;
-		stuff_string(curve_name, F_NAME);
-		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_ALPHA_MULT, modular_curves_entry{curve_get_by_name(curve_name)});
+		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_ALPHA_MULT, modular_curves_entry{curve_parse()});
 	}
 
 	if (parse_optional_color3i_into("$Light color:", &wip->light_color)) {
@@ -1355,11 +1347,9 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 	if (optional_string("$Damage Multiplier over Lifetime Curve:")) {
 		//Legacy table. Just populates the modular curve set!
-		SCP_string curve_name;
-		stuff_string(curve_name, F_NAME);
-		int curve = curve_get_by_name(curve_name);
+		int curve = curve_parse();
 		if (curve < 0)
-			Warning(LOCATION, "Unrecognized damage curve '%s' for weapon %s", curve_name.c_str(), wip->name);
+			Warning(LOCATION, "Unrecognized damage curve for weapon %s", wip->name);
 
 		damage_mult_curve.emplace(modular_curves_entry{curve});
 	}
@@ -1591,9 +1581,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 
 			if (optional_string("+Turn Rate Multiplier over Lifetime Curve:")) {
-				SCP_string curve_name;
-				stuff_string(curve_name, F_NAME);
-				wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::TURN_RATE_MULT, modular_curves_entry{curve_get_by_name(curve_name)});
+				wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::TURN_RATE_MULT, modular_curves_entry{curve_parse()});
 			}
 
 			if(optional_string("+View Cone:")) {
@@ -1650,9 +1638,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 
 			if (optional_string("+Turn Rate Multiplier over Lifetime Curve:")) {
-				SCP_string curve_name;
-				stuff_string(curve_name, F_NAME);
-				wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::TURN_RATE_MULT, modular_curves_entry{curve_get_by_name(curve_name)});
+				wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::TURN_RATE_MULT, modular_curves_entry{curve_parse()});
 			}
 
 			if(optional_string("+View Cone:")) {
@@ -2959,9 +2945,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 
 		if (optional_string("+Opacity over Lifetime Curve:")) {
-			SCP_string curve_name;
-			stuff_string(curve_name, F_NAME);
-			wip->beam_curves.add_curve("Beam Lifetime", weapon_info::BeamCurveOutputs::BEAM_ALPHA_MULT, modular_curves_entry{curve_get_by_name(curve_name)});
+			wip->beam_curves.add_curve("Beam Lifetime", weapon_info::BeamCurveOutputs::BEAM_ALPHA_MULT, modular_curves_entry{curve_parse()});
 		}
 
 		// # of shots (only used for type D beams)
@@ -3259,11 +3243,9 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 
 			if (optional_string("+Slash position over beam lifetime curve:")) {
-				SCP_string curve_name;
-				stuff_string(curve_name, F_NAME);
-				t5info->slash_pos_curve_idx = curve_get_by_name(curve_name);
+				t5info->slash_pos_curve_idx = curve_parse();
 				if (t5info->slash_pos_curve_idx < 0)
-					Warning(LOCATION, "Unrecognized slash position curve '%s' for weapon %s", curve_name.c_str(), wip->name);
+					Warning(LOCATION, "Unrecognized slash position curve for weapon %s", wip->name);
 				if (t5info->no_translate)
 					Warning(LOCATION, "Beam weapon %s has a slash position curve defined, but doesn't slash!", wip->name);
 			}
@@ -3282,11 +3264,9 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 
 			if (optional_string("+Rotation over beam lifetime curve:")) {
-				SCP_string curve_name;
-				stuff_string(curve_name, F_NAME);
-				t5info->rot_curve_idx = curve_get_by_name(curve_name);
+				t5info->rot_curve_idx = curve_parse();
 				if (t5info->rot_curve_idx < 0)
-					Warning(LOCATION, "Unrecognized rotation curve '%s' for weapon %s", curve_name.c_str(), wip->name);
+					Warning(LOCATION, "Unrecognized rotation curve for weapon %s", wip->name);
 			}
 
 			if (optional_string("+Continuous Rotation Axis:")) {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -811,9 +811,7 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 
 	sprintf(buf, "%sShockwave Radius Multiplier over Lifetime Curve:", pre_char);
 	if (optional_string(buf.c_str())) {
-		sci->radius_curve_idx = curve_parse();
-		if (sci->radius_curve_idx < 0)
-			Warning(LOCATION, "Unrecognized shockwave radius curve");
+		sci->radius_curve_idx = curve_parse(" Shockwave will not use a curve.");
 	}
 
 	sprintf(buf, "%sShockwave Speed:", pre_char);
@@ -1223,7 +1221,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 
 	if (optional_string("@Laser Length Multiplier over Lifetime Curve:")) {
-		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_LENGTH_MULT, modular_curves_entry{curve_parse()});
+		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_LENGTH_MULT, modular_curves_entry{curve_parse(" Laser Length will not be modified.")});
 	}
 	
 	if(optional_string("@Laser Head Radius:")) {
@@ -1235,7 +1233,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 
 	if (optional_string("@Laser Radius Multiplier over Lifetime Curve:")) {
-		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_RADIUS_MULT, modular_curves_entry{curve_parse()});
+		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_RADIUS_MULT, modular_curves_entry{curve_parse(" Laser Radius will not be modified.")});
 	}
 	if (optional_string("@Laser Glow Length Scale:")) {
 		stuff_float(&wip->laser_glow_length_scale);
@@ -1256,7 +1254,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
   parse_optional_float_into("@Laser Min Pixel Size:", &wip->laser_min_pixel_size);
 
 	if (optional_string("@Laser Opacity over Lifetime Curve:")) {
-		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_ALPHA_MULT, modular_curves_entry{curve_parse()});
+		wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::LASER_ALPHA_MULT, modular_curves_entry{curve_parse(" Laser Opacity will not be modified.")});
 	}
 
 	if (parse_optional_color3i_into("$Light color:", &wip->light_color)) {
@@ -1347,11 +1345,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 
 	if (optional_string("$Damage Multiplier over Lifetime Curve:")) {
 		//Legacy table. Just populates the modular curve set!
-		int curve = curve_parse();
-		if (curve < 0)
-			Warning(LOCATION, "Unrecognized damage curve for weapon %s", wip->name);
-
-		damage_mult_curve.emplace(modular_curves_entry{curve});
+		damage_mult_curve.emplace(modular_curves_entry{curve_parse(" Weapon Damage will not be modified.")});
 	}
 	
 	if(optional_string("$Damage Type:")) {
@@ -1581,7 +1575,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 
 			if (optional_string("+Turn Rate Multiplier over Lifetime Curve:")) {
-				wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::TURN_RATE_MULT, modular_curves_entry{curve_parse()});
+				wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::TURN_RATE_MULT, modular_curves_entry{curve_parse(" Turn Rate will not be modified.")});
 			}
 
 			if(optional_string("+View Cone:")) {
@@ -1638,7 +1632,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 
 			if (optional_string("+Turn Rate Multiplier over Lifetime Curve:")) {
-				wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::TURN_RATE_MULT, modular_curves_entry{curve_parse()});
+				wip->weapon_curves.add_curve("Lifetime", weapon_info::WeaponCurveOutputs::TURN_RATE_MULT, modular_curves_entry{curve_parse(" Turn Rate will not be modified.")});
 			}
 
 			if(optional_string("+View Cone:")) {
@@ -2945,7 +2939,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		}
 
 		if (optional_string("+Opacity over Lifetime Curve:")) {
-			wip->beam_curves.add_curve("Beam Lifetime", weapon_info::BeamCurveOutputs::BEAM_ALPHA_MULT, modular_curves_entry{curve_parse()});
+			wip->beam_curves.add_curve("Beam Lifetime", weapon_info::BeamCurveOutputs::BEAM_ALPHA_MULT, modular_curves_entry{curve_parse(" Beam Lifetime will not be modified.")});
 		}
 
 		// # of shots (only used for type D beams)
@@ -3243,11 +3237,9 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 
 			if (optional_string("+Slash position over beam lifetime curve:")) {
-				t5info->slash_pos_curve_idx = curve_parse();
-				if (t5info->slash_pos_curve_idx < 0)
-					Warning(LOCATION, "Unrecognized slash position curve for weapon %s", wip->name);
+				t5info->slash_pos_curve_idx = curve_parse(" Slash Position will not be modified.");
 				if (t5info->no_translate)
-					Warning(LOCATION, "Beam weapon %s has a slash position curve defined, but doesn't slash!", wip->name);
+					error_display(0, "Beam weapon %s has a slash position curve defined, but doesn't slash!", wip->name);
 			}
 
 			if (optional_string("+Orient Offsets to Target:")) {
@@ -3264,9 +3256,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 			}
 
 			if (optional_string("+Rotation over beam lifetime curve:")) {
-				t5info->rot_curve_idx = curve_parse();
-				if (t5info->rot_curve_idx < 0)
-					Warning(LOCATION, "Unrecognized rotation curve for weapon %s", wip->name);
+				t5info->rot_curve_idx = curve_parse(" Beam Rotation will not be modified.");
 			}
 
 			if (optional_string("+Continuous Rotation Axis:")) {


### PR DESCRIPTION
This allows simple curves to be tabled inline wherever they are used, instead of forcing individual curve table entries.
Inline curves notably support only a much smaller subset of features, but that is perfectly sufficient for a large number of curves.
This can be used everywhere where curves are currently addressed by name in parsing.
An example table with inline curves would look as follows:
```
#Primary Weapons

$Name:                            @Subach HL-7
+nocreate
$Lifetime Curve:
+Input: Lifetime
+Output: Laser Radius Mult
+Curve Name: (0,0) -- (0.5,1000) -- (1,0)
$Lifetime Curve:
+Input: Lifetime
+Output: Laser Glow R Mult
+Curve Name: (0,0) -- (0.5,1000) -- (1,0)

#End
```
Note, that this will prevent curves from having a name that starts with an opening parenthesis.

For now, possible interpolations in inline mode are: `--`: Linear, `-|`: Constant, `-/`: Square with ease-in, `/-`: Square with ease-out.