### PR TITLE
Allow using seeded noise for particle velocity and spawn position offset

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -500,7 +500,7 @@ float vm_vec_normalize(vec3d *v)
 // If vector is 0,0,0, return 1.0f, and change v to 1,0,0.
 // Otherwise return the magnitude.
 // No warning() generated for null vector, as it is expected that some vectors may be null.
-float vm_vec_copy_normalize_safe(vec3d *dest, const vec3d *src)
+float vm_vec_copy_normalize_safe(vec3d *dest, const vec3d *src, bool fallbackToZeroVec)
 {
 	float m;
 
@@ -508,10 +508,18 @@ float vm_vec_copy_normalize_safe(vec3d *dest, const vec3d *src)
 
 	//	Mainly here to trap attempts to normalize a null vector.
 	if (fl_near_zero(m)) {
-		dest->xyz.x = 1.0f;
-		dest->xyz.y = 0.0f;
-		dest->xyz.z = 0.0f;
-		return 1.0f;
+		if (fallbackToZeroVec) {
+			dest->xyz.x = 0.0f;
+			dest->xyz.y = 0.0f;
+			dest->xyz.z = 0.0f;
+			return 0.0f;
+		}
+		else {
+			dest->xyz.x = 1.0f;
+			dest->xyz.y = 0.0f;
+			dest->xyz.z = 0.0f;
+			return 1.0f;
+		}
 	}
 
 	float im = 1.0f / m;
@@ -527,9 +535,9 @@ float vm_vec_copy_normalize_safe(vec3d *dest, const vec3d *src)
 // If vector is 0,0,0, return 1.0f, and change v to 1,0,0.
 // Otherwise return the magnitude.
 // No warning() generated for null vector.
-float vm_vec_normalize_safe(vec3d *v)
+float vm_vec_normalize_safe(vec3d *v, bool fallbackToZeroVec)
 {
-	return vm_vec_copy_normalize_safe(v,v);
+	return vm_vec_copy_normalize_safe(v,v, fallbackToZeroVec);
 }
 
 //return the normalized direction vector between two points

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -229,9 +229,9 @@ float vm_vec_copy_normalize(vec3d *dest, const vec3d *src);
 float vm_vec_normalize(vec3d *v);
 
 //	This version of vector normalize checks for the null vector before normalization.
-//	If it is detected, it returns the vector 1, 0, 0.
-float vm_vec_copy_normalize_safe(vec3d *dest, const vec3d *src);
-float vm_vec_normalize_safe(vec3d *v);
+//	If it is detected, it returns the vector 1, 0, 0 (or 0, 0, 0 if fallbackToZeroVec is true)..
+float vm_vec_copy_normalize_safe(vec3d *dest, const vec3d *src, bool fallbackToZeroVec = false);
+float vm_vec_normalize_safe(vec3d *v, bool fallbackToZeroVec = false);
 
 //return the normalized direction vector between two points
 //dest = normalized(end - start).  Returns mag of direction vector

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -5,6 +5,8 @@
 
 #include "render/3d.h"
 
+#include <anl.h>
+
 namespace particle {
 
 ParticleEffect::ParticleEffect(SCP_string name)
@@ -36,6 +38,8 @@ ParticleEffect::ParticleEffect(SCP_string name)
 	  m_vel_inherit_from_position(std::nullopt),
 	  m_velocityVolume(nullptr),
 	  m_spawnVolume(nullptr),
+	  m_velocityNoise(nullptr),
+	  m_spawnNoise(nullptr),
 	  m_manual_offset (std::nullopt),
 	  m_particleTrail(ParticleEffectHandle::invalid()),
 	  m_size_lifetime_curve(-1),
@@ -91,6 +95,8 @@ ParticleEffect::ParticleEffect(SCP_string name,
 	  m_vel_inherit_from_position(vel_inherit_from_position),
 	  m_velocityVolume(std::move(velocityVolume)),
 	  m_spawnVolume(std::move(spawnVolume)),
+	  m_velocityNoise(nullptr),
+	  m_spawnNoise(nullptr),
 	  m_manual_offset (std::nullopt),
 	  m_particleTrail(particleTrail),
 	  m_size_lifetime_curve(-1),
@@ -134,15 +140,33 @@ matrix ParticleEffect::getNewDirection(const matrix& hostOrientation, const std:
 	}
 }
 
-void ParticleEffect::processSource(float interp, const ParticleSource& source, size_t effectNumber, const vec3d& vel, int parent, int parent_sig, float parentLifetime, float parentRadius, float particle_percent) const {
-	const auto& [pos, hostOrientation] = source.m_host->getPositionAndOrientation(m_parent_local, interp, m_manual_offset);
+void ParticleEffect::sampleNoise(vec3d& noiseTarget, const matrix* orientation, std::pair<anl::CKernel, anl::CInstructionIndex>& noise, const std::tuple<const ParticleSource&, const size_t&>& source, ParticleCurvesOutput noiseMult, ParticleCurvesOutput noiseTimeMult, ParticleCurvesOutput noiseSeed) const {
+	auto& [kernel, instruction] = noise;
+	anl::CNoiseExecutor executor(kernel);
+	const auto& color = executor.evaluateColor(
+		ParticleSource::getEffectRunningTime(source)
+			* m_modular_curves.get_output(noiseTimeMult, source)
+			, m_modular_curves.get_output(noiseSeed, source), instruction);
 
+	vec3d noiseSampleLocal{{{ color.r, color.g, color.b }}};
+	noiseSampleLocal *= m_modular_curves.get_output(noiseMult, source);
+
+	vm_vec_unrotate(&noiseTarget, &noiseSampleLocal, orientation);
+}
+
+void ParticleEffect::processSource(float interp, const ParticleSource& source, size_t effectNumber, const vec3d& velParent, int parent, int parent_sig, float parentLifetime, float parentRadius, float particle_percent) const {
 	if (m_affectedByDetail){
 		if (Detail.num_particles > 0)
 			particle_percent *= (0.5f + (0.25f * static_cast<float>(Detail.num_particles - 1)));
 		else
 			return; //Will not emit on current detail settings, but may in the future.
 	}
+
+	auto modularCurvesInput = std::forward_as_tuple(source, effectNumber);
+
+	const auto& [pos, hostOrientation] = source.m_host->getPositionAndOrientation(m_parent_local, interp, m_manual_offset);
+
+	const auto& orientation = getNewDirection(hostOrientation, source.m_normal);
 
 	if (m_distanceCulled > 0.f) {
 		float min_dist = 125.0f;
@@ -151,9 +175,6 @@ void ParticleEffect::processSource(float interp, const ParticleSource& source, s
 			particle_percent *= min_dist / dist;
 	}
 
-	const auto& orientation = getNewDirection(hostOrientation, source.m_normal);
-
-	auto modularCurvesInput = std::forward_as_tuple(source, effectNumber);
 	particle_percent *= m_particleChance * m_modular_curves.get_output(ParticleCurvesOutput::PARTICLE_NUM_MULT, modularCurvesInput);
 	float radiusMultiplier = m_modular_curves.get_output(ParticleCurvesOutput::RADIUS_MULT, modularCurvesInput);
 	float lengthMultiplier = m_modular_curves.get_output(ParticleCurvesOutput::LENGTH_MULT, modularCurvesInput);
@@ -162,6 +183,16 @@ void ParticleEffect::processSource(float interp, const ParticleSource& source, s
 	float inheritVelocityMultiplier = m_modular_curves.get_output(ParticleCurvesOutput::INHERIT_VELOCITY_MULT, modularCurvesInput);
 	float positionInheritVelocityMultiplier = m_modular_curves.get_output(ParticleCurvesOutput::POSITION_INHERIT_VELOCITY_MULT, modularCurvesInput);
 	float orientationInheritVelocityMultiplier = m_modular_curves.get_output(ParticleCurvesOutput::ORIENTATION_INHERIT_VELOCITY_MULT, modularCurvesInput);
+
+	vec3d velNoise = ZERO_VECTOR;
+	if (m_velocityNoise != nullptr) {
+		sampleNoise(velNoise, &orientation, *m_velocityNoise, modularCurvesInput, ParticleCurvesOutput::VELOCITY_NOISE_MULT, ParticleCurvesOutput::VELOCITY_NOISE_TIME_MULT, ParticleCurvesOutput::VELOCITY_NOISE_SEED);
+	}
+
+	vec3d posNoise = ZERO_VECTOR;
+	if (m_spawnNoise != nullptr) {
+		sampleNoise(posNoise, &orientation, *m_spawnNoise, modularCurvesInput, ParticleCurvesOutput::SPAWN_POSITION_NOISE_MULT, ParticleCurvesOutput::SPAWN_POSITION_NOISE_TIME_MULT, ParticleCurvesOutput::SPAWN_POSITION_NOISE_SEED);
+	}
 
 	float num = m_particleNum.next() * particle_percent;
 	unsigned int num_spawn;
@@ -177,7 +208,7 @@ void ParticleEffect::processSource(float interp, const ParticleSource& source, s
 		particle_info info;
 
 		info.pos = pos;
-		info.vel = vel;
+		info.vel = velParent;
 
 		if (m_parent_local) {
 			info.attached_objnum = parent;
@@ -193,41 +224,41 @@ void ParticleEffect::processSource(float interp, const ParticleSource& source, s
 
 		info.vel *= m_vel_inherit.next() * inheritVelocityMultiplier;
 
-		vec3d velocity = ZERO_VECTOR;
-		vec3d localPos = ZERO_VECTOR;
+		vec3d localVelocity = velNoise;
+		vec3d localPos = posNoise;
 
 		if (m_spawnVolume != nullptr) {
 			localPos += m_spawnVolume->sampleRandomPoint(orientation, modularCurvesInput);
 		}
 
 		if (m_velocityVolume != nullptr) {
-			velocity += m_velocityVolume->sampleRandomPoint(orientation, modularCurvesInput) * (m_velocity_scaling.next() * velocityVolumeMultiplier);
+			localVelocity += m_velocityVolume->sampleRandomPoint(orientation, modularCurvesInput) * (m_velocity_scaling.next() * velocityVolumeMultiplier);
 		}
 
 		if (m_vel_inherit_from_orientation.has_value()) {
-			velocity += orientation.vec.fvec * (m_vel_inherit_from_orientation->next() * orientationInheritVelocityMultiplier);
+			localVelocity += orientation.vec.fvec * (m_vel_inherit_from_orientation->next() * orientationInheritVelocityMultiplier);
 		}
 
 		if (m_vel_inherit_from_position.has_value()) {
 			vec3d velFromPos = localPos;
 			if (m_vel_inherit_from_position_absolute)
 				vm_vec_normalize_safe(&velFromPos);
-			velocity += velFromPos * (m_vel_inherit_from_position->next() * positionInheritVelocityMultiplier);
+			localVelocity += velFromPos * (m_vel_inherit_from_position->next() * positionInheritVelocityMultiplier);
 		}
 
 		if (m_velocity_directional_scaling != VelocityScaling::NONE) {
-			// Scale the vector with a random velocity sample and also multiply that with cos(angle between
-			// info.vel and sourceDir) That should produce good looking directions where the maximum velocity is
+			// Scale the vector with a random localVelocity sample and also multiply that with cos(angle between
+			// info.vel and sourceDir) That should produce good looking directions where the maximum localVelocity is
 			// only achieved when the particle travels directly on the normal/reflect vector
 			vec3d normalizedVelocity;
-			vm_vec_copy_normalize_safe(&normalizedVelocity, &velocity);
+			vm_vec_copy_normalize_safe(&normalizedVelocity, &localVelocity);
 			float dot = vm_vec_dot(&normalizedVelocity, &orientation.vec.fvec);
-			vm_vec_scale(&velocity,
+			vm_vec_scale(&localVelocity,
 				m_velocity_directional_scaling == VelocityScaling::DOT ? dot : 1.f / std::max(0.001f, dot));
 		}
 
 		info.pos += localPos;
-		info.vel += velocity;
+		info.vel += localVelocity;
 
 		info.bitmap = m_bitmap_list[m_bitmap_range.next()];
 

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -33,7 +33,9 @@ ParticleEffect::ParticleEffect(SCP_string name)
 	  m_lifetime(::util::UniformFloatRange(0.0f)),
 	  m_length(::util::UniformFloatRange(0.0f)),
 	  m_vel_inherit(::util::UniformFloatRange(0.0f)),
-	  m_velocity_scaling(::util::UniformFloatRange(0.0f)),
+	  m_velocity_scaling(::util::UniformFloatRange(1.0f)),
+	  m_velocity_noise_scaling(::util::UniformFloatRange(1.0f)),
+	  m_position_noise_scaling(::util::UniformFloatRange(1.0f)),
 	  m_vel_inherit_from_orientation(std::nullopt),
 	  m_vel_inherit_from_position(std::nullopt),
 	  m_velocityVolume(nullptr),
@@ -91,6 +93,8 @@ ParticleEffect::ParticleEffect(SCP_string name,
 	  m_length(::util::UniformFloatRange(0.0f)),
 	  m_vel_inherit(vel_inherit),
 	  m_velocity_scaling(velocity_scaling),
+	  m_velocity_noise_scaling(::util::UniformFloatRange(1.0f)),
+	  m_position_noise_scaling(::util::UniformFloatRange(1.0f)),
 	  m_vel_inherit_from_orientation(vel_inherit_from_orientation),
 	  m_vel_inherit_from_position(vel_inherit_from_position),
 	  m_velocityVolume(std::move(velocityVolume)),
@@ -187,11 +191,13 @@ void ParticleEffect::processSource(float interp, const ParticleSource& source, s
 	vec3d velNoise = ZERO_VECTOR;
 	if (m_velocityNoise != nullptr) {
 		sampleNoise(velNoise, &orientation, *m_velocityNoise, modularCurvesInput, ParticleCurvesOutput::VELOCITY_NOISE_MULT, ParticleCurvesOutput::VELOCITY_NOISE_TIME_MULT, ParticleCurvesOutput::VELOCITY_NOISE_SEED);
+		velNoise *= m_velocity_noise_scaling.next();
 	}
 
 	vec3d posNoise = ZERO_VECTOR;
 	if (m_spawnNoise != nullptr) {
 		sampleNoise(posNoise, &orientation, *m_spawnNoise, modularCurvesInput, ParticleCurvesOutput::SPAWN_POSITION_NOISE_MULT, ParticleCurvesOutput::SPAWN_POSITION_NOISE_TIME_MULT, ParticleCurvesOutput::SPAWN_POSITION_NOISE_SEED);
+		posNoise *= m_position_noise_scaling.next();
 	}
 
 	float num = m_particleNum.next() * particle_percent;

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -226,7 +226,7 @@ void ParticleEffect::processSource(float interp, const ParticleSource& source, s
 		}
 
 		if (m_vel_inherit_absolute)
-			vm_vec_normalize_quick(&info.vel);
+			vm_vec_normalize_safe(&info.vel, true);
 
 		info.vel *= m_vel_inherit.next() * inheritVelocityMultiplier;
 

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -16,6 +16,11 @@ class EffectHost;
 //Due to parsing shenanigans in weapons, this needs a forward-declare here
 int parse_weapon(int, bool, const char*);
 
+namespace anl {
+	class CKernel;
+	class CInstructionIndex;
+}
+
 namespace particle {
 
 /**
@@ -64,6 +69,12 @@ public:
 		INHERIT_VELOCITY_MULT,
 		POSITION_INHERIT_VELOCITY_MULT,
 		ORIENTATION_INHERIT_VELOCITY_MULT,
+		VELOCITY_NOISE_MULT,
+		VELOCITY_NOISE_TIME_MULT,
+		VELOCITY_NOISE_SEED,
+		SPAWN_POSITION_NOISE_MULT,
+		SPAWN_POSITION_NOISE_TIME_MULT,
+		SPAWN_POSITION_NOISE_SEED,
 
 		NUM_VALUES
 	};
@@ -108,6 +119,9 @@ public:
 	std::shared_ptr<::particle::ParticleVolume> m_velocityVolume;
 	std::shared_ptr<::particle::ParticleVolume> m_spawnVolume;
 
+	std::shared_ptr<std::pair<anl::CKernel, anl::CInstructionIndex>> m_velocityNoise;
+	std::shared_ptr<std::pair<anl::CKernel, anl::CInstructionIndex>> m_spawnNoise;
+
 	std::optional<vec3d> m_manual_offset;
 
 	ParticleEffectHandle m_particleTrail;
@@ -119,6 +133,7 @@ public:
 	float m_distanceCulled; //Kinda deprecated. Only used by the oldest of legacy effects.
 
 	matrix getNewDirection(const matrix& hostOrientation, const std::optional<vec3d>& normal) const;
+	void sampleNoise(vec3d& noiseTarget, const matrix* orientation, std::pair<anl::CKernel, anl::CInstructionIndex>& noise, const std::tuple<const ParticleSource&, const size_t&>& source, ParticleCurvesOutput noiseMult, ParticleCurvesOutput noiseTimeMult, ParticleCurvesOutput noiseSeed) const;
  public:
 	/**
 	 * @brief Initializes the base ParticleEffect
@@ -173,7 +188,13 @@ public:
 			std::pair {"Velocity Volume Mult", ParticleCurvesOutput::VOLUME_VELOCITY_MULT},
 			std::pair {"Velocity Inherit Mult", ParticleCurvesOutput::INHERIT_VELOCITY_MULT},
 			std::pair {"Velocity Position Inherit Mult", ParticleCurvesOutput::POSITION_INHERIT_VELOCITY_MULT},
-			std::pair {"Velocity Orientation Inherit Mult", ParticleCurvesOutput::ORIENTATION_INHERIT_VELOCITY_MULT}
+			std::pair {"Velocity Orientation Inherit Mult", ParticleCurvesOutput::ORIENTATION_INHERIT_VELOCITY_MULT},
+			std::pair {"Velocity Noise Mult", ParticleCurvesOutput::VELOCITY_NOISE_MULT},
+			std::pair {"Velocity Noise Time Mult", ParticleCurvesOutput::VELOCITY_NOISE_TIME_MULT},
+			std::pair {"Velocity Noise Seed", ParticleCurvesOutput::VELOCITY_NOISE_SEED},
+			std::pair {"Spawn Position Noise Mult", ParticleCurvesOutput::SPAWN_POSITION_NOISE_MULT},
+			std::pair {"Spawn Position Noise Time Mult", ParticleCurvesOutput::SPAWN_POSITION_NOISE_TIME_MULT},
+			std::pair {"Spawn Position Noise Seed", ParticleCurvesOutput::SPAWN_POSITION_NOISE_SEED}
 		},
 		std::pair {"Trigger Radius", modular_curves_submember_input<&ParticleSource::m_triggerRadius>{}},
 		std::pair {"Trigger Velocity", modular_curves_submember_input<&ParticleSource::m_triggerVelocity>{}},
@@ -185,7 +206,8 @@ public:
 			modular_curves_submember_input<&ParticleSource::getEffect, &SCP_vector<ParticleEffect>::size>,
 			ModularCurvesMathOperators::division>{}})
 	.derive_modular_curves_input_only_subset<size_t>(
-		std::pair {"Spawntime Left", modular_curves_functional_full_input<&ParticleSource::getEffectRemainingTime>{}}
+		std::pair {"Spawntime Left", modular_curves_functional_full_input<&ParticleSource::getEffectRemainingTime>{}},
+		std::pair {"Time Running", modular_curves_functional_full_input<&ParticleSource::getEffectRunningTime>{}}
 		);
 
 	MODULAR_CURVE_SET(m_modular_curves, modular_curves_definition);

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -112,6 +112,8 @@ public:
 	::util::ParsedRandomFloatRange m_length;
 	::util::ParsedRandomFloatRange m_vel_inherit;
 	::util::ParsedRandomFloatRange m_velocity_scaling;
+	::util::ParsedRandomFloatRange m_velocity_noise_scaling;
+	::util::ParsedRandomFloatRange m_position_noise_scaling;
 
 	std::optional<::util::ParsedRandomFloatRange> m_vel_inherit_from_orientation;
 	std::optional<::util::ParsedRandomFloatRange> m_vel_inherit_from_position;

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -3,6 +3,8 @@
 #include "particle/volumes/ConeVolume.h"
 #include "particle/volumes/SpheroidVolume.h"
 
+#include <anl.h>
+
 namespace particle {
 
 	//
@@ -141,6 +143,17 @@ namespace particle {
 			}
 		}
 
+		static void parseVelocityNoise(ParticleEffect &effect) {
+			if (optional_string("+Velocity Noise:")) {
+				SCP_string func;
+				stuff_string(func, F_RAW);
+				anl::CKernel kernel;
+				anl::CExpressionBuilder builder(kernel);
+				anl::CInstructionIndex instruction = builder.eval(func);
+				effect.m_velocityNoise = std::make_shared<std::pair<anl::CKernel, anl::CInstructionIndex>>(std::move(kernel), std::move(instruction));
+			}
+		}
+
 		template<bool modern = true> static void parseVelocityVolumeScale(ParticleEffect &effect) {
 			if (internal::required_string_if_new(modern ? "+Velocity Volume Scale:" : "+Velocity:", false)) {
 				effect.m_velocity_scaling = ::util::ParsedRandomFloatRange::parseRandomRange();
@@ -167,6 +180,17 @@ namespace particle {
 		static void parsePositionVolume(ParticleEffect &effect) {
 			if (optional_string("+Spawn Position Volume:")) {
 				effect.m_spawnVolume = parseVolume();
+			}
+		}
+
+		static void parsePositionNoise(ParticleEffect &effect) {
+			if (optional_string("+Spawn Position Noise:")) {
+				SCP_string func;
+				stuff_string(func, F_RAW);
+				anl::CKernel kernel;
+				anl::CExpressionBuilder builder(kernel);
+				anl::CInstructionIndex instruction = builder.eval(func);
+				effect.m_spawnNoise = std::make_shared<std::pair<anl::CKernel, anl::CInstructionIndex>>(std::move(kernel), std::move(instruction));
 			}
 		}
 
@@ -283,8 +307,10 @@ namespace particle {
 			parseDirection(effect);
 			parseOffset(effect);
 			parsePositionVolume(effect);
+			parsePositionNoise(effect);
 			parseVelocityVolume(effect);
 			parseVelocityVolumeScale(effect);
+			parseVelocityNoise(effect);
 			parseVelocityDirectionScale(effect);
 			parseVelocityInheritFromPosition(effect);
 			parseVelocityInheritFromOrientation(effect);

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -152,11 +152,21 @@ namespace particle {
 				anl::CInstructionIndex instruction = builder.eval(func);
 				effect.m_velocityNoise = std::make_shared<std::pair<anl::CKernel, anl::CInstructionIndex>>(std::move(kernel), std::move(instruction));
 			}
+			if (optional_string("+Velocity Noise Scale:")) {
+				effect.m_velocity_noise_scaling = ::util::ParsedRandomFloatRange::parseRandomRange();
+			}
 		}
 
 		template<bool modern = true> static void parseVelocityVolumeScale(ParticleEffect &effect) {
-			if (internal::required_string_if_new(modern ? "+Velocity Volume Scale:" : "+Velocity:", false)) {
-				effect.m_velocity_scaling = ::util::ParsedRandomFloatRange::parseRandomRange();
+			if constexpr (modern) {
+				if (optional_string("+Velocity Volume Scale:")) {
+					effect.m_velocity_scaling = ::util::ParsedRandomFloatRange::parseRandomRange();
+				}
+			}
+			else {
+				if (internal::required_string_if_new("+Velocity:", false)) {
+					effect.m_velocity_scaling = ::util::ParsedRandomFloatRange::parseRandomRange();
+				}
 			}
 		}
 
@@ -191,6 +201,9 @@ namespace particle {
 				anl::CExpressionBuilder builder(kernel);
 				anl::CInstructionIndex instruction = builder.eval(func);
 				effect.m_spawnNoise = std::make_shared<std::pair<anl::CKernel, anl::CInstructionIndex>>(std::move(kernel), std::move(instruction));
+			}
+			if (optional_string("+Spawn Position Noise Scale:")) {
+				effect.m_position_noise_scaling = ::util::ParsedRandomFloatRange::parseRandomRange();
 			}
 		}
 

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -33,7 +33,7 @@ void ParticleSource::finishCreation() {
 
 	for (const auto& effect : ParticleManager::get()->getEffect(m_effect)) {
 		const auto& [begin, end] = effect.getEffectDuration();
-		m_timing.emplace_back(SourceTiming{begin, end});
+		m_timing.emplace_back(SourceTiming{begin, begin, end});
 	}
 }
 
@@ -100,5 +100,9 @@ void ParticleSource::setHost(std::unique_ptr<EffectHost> host) {
 
 float ParticleSource::getEffectRemainingTime(const std::tuple<const ParticleSource&, const size_t&>& source) {
 	return i2fl(timestamp_until(std::get<0>(source).m_timing[std::get<1>(source)].m_endTimestamp)) / i2fl(MILLISECONDS_PER_SECOND);
+}
+
+float ParticleSource::getEffectRunningTime(const std::tuple<const ParticleSource&, const size_t&>& source) {
+	return i2fl(timestamp_since(std::get<0>(source).m_timing[std::get<1>(source)].m_startTimestamp)) / i2fl(MILLISECONDS_PER_SECOND);
 }
 }

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -33,7 +33,7 @@ void ParticleSource::finishCreation() {
 
 	for (const auto& effect : ParticleManager::get()->getEffect(m_effect)) {
 		const auto& [begin, end] = effect.getEffectDuration();
-		m_timing.emplace_back(SourceTiming{begin, begin, end});
+		m_timing.emplace_back(SourceTiming{timestamp_delta(begin, 0), begin, end});
 	}
 }
 

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -54,6 +54,7 @@ using ParticleEffectHandle = ::util::ID<particle_effect_tag, ptrdiff_t, -1>;
  * 
  */
 struct SourceTiming {
+	TIMESTAMP m_startTimestamp;
 	TIMESTAMP m_nextCreation;
 	TIMESTAMP m_endTimestamp;
 };
@@ -87,6 +88,8 @@ class ParticleSource {
 	friend class ParticleEffect;
 
 	static float getEffectRemainingTime(const std::tuple<const ParticleSource&, const size_t&>& source);
+
+	static float getEffectRunningTime(const std::tuple<const ParticleSource&, const size_t&>& source);
  public:
 	ParticleSource();
 


### PR DESCRIPTION
Exposes the noise framework FSO uses for volumetrics to the particle system.
This allows particles to behave in noised-but-not-frame-independent-random ways.

As with volumetrics, it uses the DSL of the noise library to parse noise definitions.
While very flexible, this is also quite cumbersome and hard to visualize. I intend to eventually build a small utility program that can quickly visualize these noise patterns.

As an example, the following is a table that uses the new noise:
```
#Particle Effects
$Effect: NoiseTest
+Filename: AVMuzzle
+Radius: 1
+Lifetime: 8
+Duration: 20
+Spawns per second: 10
+Particle Count Per Spawn: 1
+Velocity Noise: color(scale(valueBasis(3,0),6), scale(valueBasis(3,1),6),0, 0)
+Velocity Noise Scale: 10
+Velocity Inherit: 0.9
#End
```