### PR TITLE
fix bogus direction vector in particle code

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -470,7 +470,8 @@ float vm_vec_copy_normalize(vec3d *dest, const vec3d *src)
 	m = vm_vec_mag(src);
 
 	//	Mainly here to trap attempts to normalize a null vector.
-	if (m <= 0.0f) {
+	if (fl_near_zero(m)) {
+		// Since vectors are not expected to be null in this function, this really ought to be a Warning, as in the original release.
 		nprintf(("Network", "Null vec3d in vec3d normalize.\n"
 			"Trace out of vecmat.cpp and find offending code.\n"));
 		dest->xyz.x = 1.0f;
@@ -492,37 +493,43 @@ float vm_vec_copy_normalize(vec3d *dest, const vec3d *src)
 //normalize a vector. returns mag of source vec (always greater than zero)
 float vm_vec_normalize(vec3d *v)
 {
-	float t;
-	t = vm_vec_copy_normalize(v,v);
-	return t;
+	return vm_vec_copy_normalize(v,v);
 }
 
 // Normalize a vector.
-// If vector is 0,0,0, return 1.0f, and change v to 1,0,0.  
+// If vector is 0,0,0, return 1.0f, and change v to 1,0,0.
 // Otherwise return the magnitude.
-// No warning() generated for null vector.
-float vm_vec_normalize_safe(vec3d *v)
+// No warning() generated for null vector, as it is expected that some vectors may be null.
+float vm_vec_copy_normalize_safe(vec3d *dest, const vec3d *src)
 {
 	float m;
 
-	m = vm_vec_mag(v);
+	m = vm_vec_mag(src);
 
 	//	Mainly here to trap attempts to normalize a null vector.
-	if (m <= 0.0f) {
-		v->xyz.x = 1.0f;
-		v->xyz.y = 0.0f;
-		v->xyz.z = 0.0f;
+	if (fl_near_zero(m)) {
+		dest->xyz.x = 1.0f;
+		dest->xyz.y = 0.0f;
+		dest->xyz.z = 0.0f;
 		return 1.0f;
 	}
 
 	float im = 1.0f / m;
 
-	v->xyz.x *= im;
-	v->xyz.y *= im;
-	v->xyz.z *= im;
+	dest->xyz.x = src->xyz.x * im;
+	dest->xyz.y = src->xyz.y * im;
+	dest->xyz.z = src->xyz.z * im;
 
 	return m;
+}
 
+// Normalize a vector.
+// If vector is 0,0,0, return 1.0f, and change v to 1,0,0.
+// Otherwise return the magnitude.
+// No warning() generated for null vector.
+float vm_vec_normalize_safe(vec3d *v)
+{
+	return vm_vec_copy_normalize_safe(v,v);
 }
 
 //return the normalized direction vector between two points

--- a/code/math/vecmat.h
+++ b/code/math/vecmat.h
@@ -229,7 +229,8 @@ float vm_vec_copy_normalize(vec3d *dest, const vec3d *src);
 float vm_vec_normalize(vec3d *v);
 
 //	This version of vector normalize checks for the null vector before normalization.
-//	If it is detected, it generates a Warning() and returns the vector 1, 0, 0.
+//	If it is detected, it returns the vector 1, 0, 0.
+float vm_vec_copy_normalize_safe(vec3d *dest, const vec3d *src);
 float vm_vec_normalize_safe(vec3d *v);
 
 //return the normalized direction vector between two points

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -220,7 +220,7 @@ void ParticleEffect::processSource(float interp, const ParticleSource& source, s
 			// info.vel and sourceDir) That should produce good looking directions where the maximum velocity is
 			// only achieved when the particle travels directly on the normal/reflect vector
 			vec3d normalizedVelocity;
-			vm_vec_copy_normalize(&normalizedVelocity, &velocity);
+			vm_vec_copy_normalize_safe(&normalizedVelocity, &velocity);
 			float dot = vm_vec_dot(&normalizedVelocity, &orientation.vec.fvec);
 			vm_vec_scale(&velocity,
 				m_velocity_directional_scaling == VelocityScaling::DOT ? dot : 1.f / std::max(0.001f, dot));

--- a/code/particle/hosts/EffectHostParticle.cpp
+++ b/code/particle/hosts/EffectHostParticle.cpp
@@ -27,13 +27,9 @@ std::pair<vec3d, matrix> EffectHostParticle::getPositionAndOrientation(bool /*re
 	}
 
 	// find the particle direction (normalized vector)
-	// note: this can't be computed for particles with 0 velocity, so arbitrarily pick the global Z vector
+	// note: this can't be computed for particles with 0 velocity, so use the safe version
 	vec3d particle_dir;
-	float mag = vm_vec_mag(&particle->velocity);
-	if (fl_near_zero(mag))
-		particle_dir = vmd_z_vector;
-	else
-		particle_dir = particle->velocity / mag;
+	vm_vec_copy_normalize_safe(&particle_dir, &particle->velocity);
 
 	if (tabled_offset)
 		pos += particle_dir * tabled_offset->xyz.z;

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -427,7 +427,7 @@ namespace particle
 			vec3d p0 = part->pos;
 
 			vec3d p1;
-			vm_vec_copy_normalize(&p1, &part->velocity);
+			vm_vec_copy_normalize_safe(&p1, &part->velocity);
 			p1 *= part->length;
 			p1 += part->pos;
 


### PR DESCRIPTION
This was discovered thanks to the new assertions from #6596.  For particles with 0 velocity, the code would attempt to normalize a 0,0,0 vector with predictably undesirable results.  So, pick the global `z` vector in these cases, while normalizing in the usual case.