### PR TITLE
Add freespace 1 style missile behavior

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -173,6 +173,7 @@ namespace AI {
 		Standard_strafe_used_more,
 		Unify_usage_ai_shield_manage_delay,
 		Disable_ai_transferring_energy,
+		Freespace_1_missile_behavior,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -701,6 +701,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$disable AI transferring energy:", AI::Profile_Flags::Disable_ai_transferring_energy);
 
+				set_flag(profile, "$enable freespace 1 style missile behavior:", AI::Profile_Flags::Freespace_1_missile_behavior);
+
 				// end of options ----------------------------------------
 
 				// if we've been through once already and are at the same place, force a move

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -590,6 +590,7 @@ flag_def_list_new<Weapon::Info_Flags> ai_tgt_weapon_flags[] = {
 	{ "require exact los",			Weapon::Info_Flags::Require_exact_los,					true, false },
 	{ "multilock target dead subsys", Weapon::Info_Flags::Multilock_target_dead_subsys,		true, false },
 	{ "ignores countermeasures",	Weapon::Info_Flags::Ignores_countermeasures,			true, false },
+	{ "freespace 1 missile behavior",Weapon::Info_Flags::Freespace_1_missile_behavior,		true, false },
 };
 
 const int num_ai_tgt_weapon_info_flags = sizeof(ai_tgt_weapon_flags) / sizeof(flag_def_list_new<Weapon::Info_Flags>);

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -95,6 +95,7 @@ namespace Weapon {
 		No_fred,							// not available in fred
 		Detonate_on_expiration,				// Secondary weapons always detonate when their lifetime runs out, but now primary weapons can too
 		Ignores_countermeasures,			// The weapon will never be affected by countermeasures
+		Freespace_1_missile_behavior,		// Bundles several observed behaviors missiles had in the freespace 1 release
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5404,10 +5404,15 @@ void weapon_home(object *obj, int num, float frame_time)
 	else
 		max_speed=wip->max_speed;
 
+	float free_flight_time = wip->free_flight_time / 2.0f;
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Freespace_1_missile_behavior]) {
+		free_flight_time = wip->free_flight_time;
+	}
+
 	//	If not [free-flight-time] gone by, don't home yet.
 	// Goober5000 - this has been fixed back to more closely follow the original logic.  Remember, the retail code
 	// had 0.5 second of free flight time, the first half of which was spent ramping up to full speed.
-	if ((hobjp == &obj_used_list) || ( f2fl(Missiontime - wp->creation_time) < (wip->free_flight_time / 2) )) {
+	if ((hobjp == &obj_used_list) || ( f2fl(Missiontime - wp->creation_time) < free_flight_time)) {
 		if (f2fl(Missiontime - wp->creation_time) > wip->free_flight_time) {
 			// If this is a heat seeking homing missile and [free-flight-time] has elapsed since firing
 			// and we don't have a target (else we wouldn't be inside the IF), find a new target.
@@ -5749,13 +5754,17 @@ void weapon_home(object *obj, int num, float frame_time)
 			return;
         }
 
-		//	Only lead target if more than one second away.  Otherwise can miss target.  I think this
-		//	is what's causing Harbingers to miss the super destroyer. -- MK, 4/15/98
-		if ((old_dot > 0.1f) && (time_to_target > 0.1f)) {
-			if (wip->wi_flags[Weapon::Info_Flags::Variable_lead_homing]) {
-				vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, (0.33f * wip->target_lead_scaler * MIN(time_to_target, 6.0f)));
-			} else if (wip->is_locked_homing()) {
-				vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, MIN(time_to_target, 2.0f));
+		float pure_pursuit_time = The_mission.ai_profile->flags[AI::Profile_Flags::Freespace_1_missile_behavior] ? 1.0f : 0.1f;
+		if ((old_dot > 0.1f)) {
+			if ((time_to_target > pure_pursuit_time)) {
+				if (wip->wi_flags[Weapon::Info_Flags::Variable_lead_homing]) {
+					vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, (0.33f * wip->target_lead_scaler * MIN(time_to_target, 6.0f)));
+				}
+				else if (wip->is_locked_homing()) {
+					vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, MIN(time_to_target, 2.0f));
+				} 
+			} else if (The_mission.ai_profile->flags[AI::Profile_Flags::Freespace_1_missile_behavior]) {
+				vm_vec_scale_add2(&target_pos, &hobjp->phys_info.vel, MIN(time_to_target, 2.0f) * -1.0);
 			}
 		}
 
@@ -5780,9 +5789,16 @@ void weapon_home(object *obj, int num, float frame_time)
 		//	at max speed, else move slower based on how far from ahead.
 		//	Asteroth - but not for homing primaries
 		if (old_dot < 0.90f && wip->subtype != WP_LASER) {
-			obj->phys_info.speed = MAX(0.2f, old_dot* (float) fabs(old_dot));
-			if (obj->phys_info.speed < max_speed*0.75f)
-				obj->phys_info.speed = max_speed*0.75f;
+			if (The_mission.ai_profile->flags[AI::Profile_Flags::Freespace_1_missile_behavior]) {
+				obj->phys_info.speed = max_speed * MAX(0.2f, fabs(old_dot));
+				if (obj->phys_info.speed < max_speed * 0.25f)
+					obj->phys_info.speed = max_speed * 0.25f;
+			}
+			else {
+				obj->phys_info.speed = MAX(0.2f, old_dot * fabs(old_dot));
+				if (obj->phys_info.speed < max_speed * 0.75f)
+					obj->phys_info.speed = max_speed * 0.75f;
+			}
 		} else
 			obj->phys_info.speed = max_speed;
 
@@ -5813,6 +5829,11 @@ void weapon_home(object *obj, int num, float frame_time)
 			vel = vm_vec_mag(&obj->phys_info.desired_vel);
 
 			vm_vec_copy_scale(&obj->phys_info.desired_vel, &obj->orient.vec.fvec, vel);
+		}
+
+		if (The_mission.ai_profile->flags[AI::Profile_Flags::Freespace_1_missile_behavior] && (old_dot < 0.0f) && (dist_to_target < 50.0f)) {
+			if (wp->lifeleft > 0.01f)
+				wp->lifeleft = 0.01f;
 		}
 	}
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5840,7 +5840,7 @@ void weapon_home(object *obj, int num, float frame_time)
 		}
 
 		// (likely) fs1 code to early detonate if still nearby the target but not pointing at it
-		if (fs1_behavior && (old_dot < 0.0f) && (dist_to_target < 50.0f) && !wp->weapon_flags[Weapon::Weapon_Flags::Begun_detonation]) {
+		if (fs1_behavior && (old_dot < 0.0f) && (dist_to_target < 50.0f)) {
 			if (wp->lifeleft > 0.01f)
 				wp->lifeleft = 0.01f;
 			wp->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);


### PR DESCRIPTION
Though the source code for freespace 1 is not available, using some comments and lots of testing by Goober, a fairly convincing facsimile of it can be approximated. The main eventual algorithm (-1x lag pursuit, starting at 1 second out) ended up both quite close to the observed behavior and is rather simple and involves minimal changes from the existing code, making it a likely contender for what they used.

Also included are a few other observed miscellaneous changes to free flight time, the missile's speed, and early detonation conditions.

Freespace 1:

https://github.com/user-attachments/assets/d1f9f9a5-02b4-4d7d-92a3-3cf95e11f1cf

FSO, with this flag active:

https://github.com/user-attachments/assets/86c79c80-3d64-437d-934a-75766a7f9657

For reference, by default in Freespace 2, aspect seekers fly a nearly dead-on straight path, following a 1x lead pursuit the whole time, none of this wiggling S shape.

