### PR TITLE
Wingmen and Squad Message QoL Updates

### DIFF
--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -3521,6 +3521,7 @@ void load_gauge_squad_message(gauge_settings* settings)
 	char fname_top[MAX_FILENAME_LEN] = "message1";
 	char fname_middle[MAX_FILENAME_LEN] = "message2";
 	char fname_bottom[MAX_FILENAME_LEN] = "message3";
+	int ship_name_max_w = 200;
 	
 	settings->origin[0] = 1.0f;
 	settings->origin[1] = 0.0f;
@@ -3586,6 +3587,9 @@ void load_gauge_squad_message(gauge_settings* settings)
 	if(optional_string("Page Down Offsets:")) {
 		stuff_int_list(Pgdn_offsets, 2);
 	}
+	if (optional_string("Ship Name Max Width:")) {
+		stuff_int(&ship_name_max_w);
+	}
 
 	hud_gauge->initBitmaps(fname_top, fname_middle, fname_bottom);
 	hud_gauge->initHiRes(fname_top);
@@ -3597,6 +3601,7 @@ void load_gauge_squad_message(gauge_settings* settings)
 	hud_gauge->initItemOffsetX(Item_offset_x);
 	hud_gauge->initPgUpOffsets(Pgup_offsets[0], Pgup_offsets[1]);
 	hud_gauge->initPgDnOffsets(Pgdn_offsets[0], Pgdn_offsets[1]);
+	hud_gauge->initShipNameMaxWidth(ship_name_max_w);
 
 	gauge_assign_common(settings, std::move(hud_gauge));
 }
@@ -4268,12 +4273,20 @@ void load_gauge_wingman_status(gauge_settings* settings)
 	}
 	
 	int grow_mode = 0; //By default, expand the gauge to the left (in -x direction)
+	int wingname_align_mode = 0; //By default, center wingnames when rendering
 
 	if(optional_string("Expansion Mode:")) {
 		if(optional_string("Right")) 
 			grow_mode = 1;
 		else if(optional_string("Down"))
 			grow_mode = 2;
+	}
+
+	if (optional_string("Wingname Align Mode:")) {
+		if (optional_string("Left"))
+			wingname_align_mode = 1;
+		else if (optional_string("Right"))
+			wingname_align_mode = 2;
 	}
 
 	bool use_full_wingnames = false;
@@ -4303,6 +4316,7 @@ void load_gauge_wingman_status(gauge_settings* settings)
 	hud_gauge->initWingWidth(wing_width);
 	hud_gauge->initRightBgOffset(right_bg_offset);
 	hud_gauge->initGrowMode(grow_mode);
+	hud_gauge->initWingnameAlignMode(wingname_align_mode);
 	hud_gauge->initUseFullWingnames(use_full_wingnames);
 	hud_gauge->initUseExpandedColors(use_expanded_colors);
 

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -4283,7 +4283,7 @@ void load_gauge_wingman_status(gauge_settings* settings)
 		else if (optional_string("Down"))
 			grow_mode = 2;
 		else
-			error_display(0, "\"Expansion Mode:\" is invalid!  Discarding and using default Left mode.");
+			error_display(0, "\"Expansion Mode:\" is invalid, must be either Left, Right, or Down!  Discarding value.");
 	}
 
 	if (optional_string("Wingname Align Mode:")) {
@@ -4294,7 +4294,7 @@ void load_gauge_wingman_status(gauge_settings* settings)
 		else if (optional_string("Right"))
 			wingname_align_mode = 2;
 		else
-			error_display(0, "\"Wingname Align Mode:\" is invalid!  Discarding and using default Center Alignment.");
+			error_display(0, "\"Wingname Align Mode:\" is invalid, must be either Center, Left, or Right!  Discarding value.");
 	}
 
 	bool use_full_wingnames = false;

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -4275,18 +4275,26 @@ void load_gauge_wingman_status(gauge_settings* settings)
 	int grow_mode = 0; //By default, expand the gauge to the left (in -x direction)
 	int wingname_align_mode = 0; //By default, center wingnames when rendering
 
-	if(optional_string("Expansion Mode:")) {
-		if(optional_string("Right")) 
+	if (optional_string("Expansion Mode:")) {
+		if (optional_string("Left"))
+			grow_mode = 0;
+		else if (optional_string("Right"))
 			grow_mode = 1;
-		else if(optional_string("Down"))
+		else if (optional_string("Down"))
 			grow_mode = 2;
+		else
+			error_display(0, "\"Expansion Mode:\" is invalid!  Discarding and using default Left mode.");
 	}
 
 	if (optional_string("Wingname Align Mode:")) {
-		if (optional_string("Left"))
+		if (optional_string("Center"))
+			wingname_align_mode = 0;
+		else if (optional_string("Left"))
 			wingname_align_mode = 1;
 		else if (optional_string("Right"))
 			wingname_align_mode = 2;
+		else
+			error_display(0, "\"Wingname Align Mode:\" is invalid!  Discarding and using default Center Alignment.");
 	}
 
 	bool use_full_wingnames = false;

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2869,7 +2869,7 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 		renderPrintfWithGauge(sx, sy, EG_SQ1 + i, scale, config, NOX("%1d."), item_num);
 
 		// then the text
-		const int w = font::force_fit_string(text, 255, fl2i(Ship_name_max_width * scale), scale);
+		font::force_fit_string(text, 255, fl2i(Ship_name_max_width * scale), scale);
 
 		renderString(sx + fl2i(Item_offset_x * scale), sy, EG_SQ1 + i, text, scale, config);
 

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2838,7 +2838,7 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 		char text[255];
 
 		if (!config) {
-			strcpy(text, MsgItems[First_menu_item + i].text.c_str());
+			strcpy_s(text, MsgItems[First_menu_item + i].text.c_str());
 		} else {
 			// in config mode, so create just the first page of the Comms Menu
 			// as other functions, such as hud_squadmsg_type_select() will not be run in config mode
@@ -2849,7 +2849,7 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 				XSTR("Rearm/Repair Subsys", 297),
 				XSTR("Abort Rearm", 298)
 			};
-			strcpy(text, temp_comm_order_types[i]);
+			strcpy_s(text, temp_comm_order_types[i]);
 			if (Hide_main_rearm_items_in_comms_gauge && (i == TYPE_REPAIR_REARM_ITEM || i == TYPE_REPAIR_REARM_ABORT_ITEM)) {
 				MsgItems[First_menu_item + i].active = -1;
 			}

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2698,6 +2698,11 @@ void HudGaugeSquadMessage::initPgDnOffsets(int x, int y)
 	Pgdn_offsets[1] = y;
 }
 
+void HudGaugeSquadMessage::initShipNameMaxWidth(int w)
+{
+	Ship_name_max_width = w;
+}
+
 void HudGaugeSquadMessage::initBitmaps(char *fname_top, char *fname_middle, char *fname_bottom)
 {
 	Mbox_gauge[0].first_frame = bm_load_animation(fname_top, &Mbox_gauge[0].num_frames);
@@ -2830,10 +2835,10 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 
 	for (int i = 0; i < nitems; i++ ) {
 		int item_num;
-		const char *text;
+		char text[255];
 
 		if (!config) {
-			text = MsgItems[First_menu_item + i].text.c_str();
+			strcpy(text, MsgItems[First_menu_item + i].text.c_str());
 		} else {
 			const char* temp_comm_order_types[] = {XSTR("Ships", 293),
 				XSTR("Wings", 294),
@@ -2842,7 +2847,7 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 				XSTR("Rearm/Repair Subsys", 297),
 				XSTR("Abort Rearm", 298)
 			};
-			text = temp_comm_order_types[i];
+			strcpy(text, temp_comm_order_types[i]);
 		}
 
 		// blit the background
@@ -2864,6 +2869,8 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 		renderPrintfWithGauge(sx, sy, EG_SQ1 + i, scale, config, NOX("%1d."), item_num);
 
 		// then the text
+		const int w = font::force_fit_string(text, 255, fl2i(Ship_name_max_width * scale), scale);
+
 		renderString(sx + fl2i(Item_offset_x * scale), sy, EG_SQ1 + i, text, scale, config);
 
 		sy += fl2i(Item_h * scale);

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2874,8 +2874,8 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 			item_num = (i+1) % MAX_MENU_DISPLAY;
 			renderPrintfWithGauge(sx, sy, EG_SQ1 + i, scale, config, NOX("%1d."), item_num);
 
-		  // then the text
-		  font::force_fit_string(text, 255, fl2i(Ship_name_max_width * scale), scale);
+			// then the text
+			font::force_fit_string(text, 255, fl2i(Ship_name_max_width * scale), scale);
    
 			renderString(sx + fl2i(Item_offset_x * scale), sy, EG_SQ1 + i, text, scale, config);
 

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -209,6 +209,7 @@ protected:
 
 	int Pgup_offsets[2];
 	int Pgdn_offsets[2];
+	int Ship_name_max_width;
 
 	int flash_timer[2];
 	bool flash_flag;
@@ -223,6 +224,7 @@ public:
 	void initItemOffsetX(int x);
 	void initPgUpOffsets(int x, int y);
 	void initPgDnOffsets(int x, int y);
+	void initShipNameMaxWidth(int w);
 
 	void render(float frametime, bool config = false) override;
 	bool canRender() const override;

--- a/code/hud/hudwingmanstatus.cpp
+++ b/code/hud/hudwingmanstatus.cpp
@@ -320,6 +320,11 @@ void HudGaugeWingmanStatus::initGrowMode(int mode) {
 	grow_mode = mode;
 }
 
+void HudGaugeWingmanStatus::initWingnameAlignMode(int mode)
+{
+	wingname_align_mode = mode;
+}
+
 void HudGaugeWingmanStatus::initUseFullWingnames(bool usefullname)
 {
 	use_full_wingnames = usefullname;
@@ -591,10 +596,17 @@ void HudGaugeWingmanStatus::renderDots(int wing_index, int screen_index, int num
 		strncpy(wingstr, abbrev, 4);
 	}
 
-	// Goober5000 - center it (round the offset rather than truncate it)
 	int wingstr_width;
 	gr_get_string_size(&wingstr_width, nullptr, wingstr, scale);
-	renderString(sx - fl2i(std::lround((float)wingstr_width / 2.0f)), sy, wingstr, scale, config);
+
+	if (wingname_align_mode == ALIGN_LEFT) {
+		renderString(sx, sy, wingstr, scale, config);
+	} else if (wingname_align_mode == ALIGN_RIGHT) {
+		renderString(sx - wingstr_width, sy, wingstr, scale, config);
+	} else {
+		// Goober5000 - center it (round the offset rather than truncate it)
+		renderString(sx - fl2i(std::lround((float)wingstr_width / 2.0f)), sy, wingstr, scale, config);
+	}
 
 }
 

--- a/code/hud/hudwingmanstatus.h
+++ b/code/hud/hudwingmanstatus.h
@@ -51,7 +51,9 @@ protected:
 	int wing_name_offsets[2];
 
 	enum {GROW_LEFT, GROW_RIGHT, GROW_DOWN};
+	enum {ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT};
 	int grow_mode;
+	int wingname_align_mode;
 	bool use_full_wingnames;
 	bool use_expanded_colors;
 
@@ -77,6 +79,7 @@ public:
 	void initWingmate5Offsets(int x, int y);
 	void initWingmate6Offsets(int x, int y);
 	void initGrowMode(int mode);
+	void initWingnameAlignMode(int mode);
 	void initUseFullWingnames(bool usefullname);
 	void initUseExpandedColors(bool useexpandedcolors);
 	void pageIn() override;


### PR DESCRIPTION
This PR adds a few assorted HUD updates/quality of life enhancements. FotG will be using these, though they are relatively general and are likely useful to most other mods, too.

1) Adds a `Ship Name Max Width:` to the Squad Message Gauge (following the same logic as the Escort Gauge). The Escort Gauge will truncate display names of ships if they are too long, that way all the text fits in the gauge without spilling over. It would also be very useful to do this with the Squad Message Gauge, as long display names can overflow out of the gauge's boundaries currently.

2) Adds `Wingname Align Mode:` to the Wingmen Gauge, which allows modders to set how the wing names are aligned. Currently they are centered on the calculated x-position, though this PR also adds right and left justification options (which is useful especially if displaying the full wing names).

All options are tested and work as expected.