### PR TITLE
add arm64 Linux builds to workflow

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -13,8 +13,14 @@ jobs:
     strategy:
       matrix:
         configuration: [FastDebug, Release]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: arm64
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     steps:
       - uses: actions/checkout@v1
@@ -47,13 +53,16 @@ jobs:
       - name: Upload build result
         uses: actions/upload-artifact@v4
         with:
-          name: linux-${{ matrix.configuration }}
+          name: linux-${{ matrix.configuration }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/build/install/*.AppImage
   linux_zip:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
     container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
     steps:
       - uses: actions/checkout@v1
         name: Checkout
@@ -63,15 +72,21 @@ jobs:
       - name: Download Release builds
         uses: actions/download-artifact@v4
         with:
-          name: linux-Release
+          name: linux-Release-${{ matrix.arch }}
           path: builds
       - name: Download FastDebug builds
         uses: actions/download-artifact@v4
         with:
-          name: linux-FastDebug
+          name: linux-FastDebug-${{ matrix.arch }}
           path: builds
+      - name: Fix permissions
+        working-directory: ./builds
+        shell: bash
+        run: chmod 755 *.AppImage
       - name: Create Distribution package
         working-directory: ./builds
+        env:
+          ARCH: ${{ matrix.arch }}
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Linux
       - name: Upload result package
         working-directory: ./builds

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -41,9 +41,15 @@ jobs:
         # Run this job for each configuration
         # The current config running is accesible with `matrix.configuration`
         configuration: [FastDebug, Release]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: arm64
     name: Linux
     needs: create_release   # Don't run this job until create_release is done and successful
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
     steps:
       - uses: actions/checkout@v1
@@ -87,13 +93,16 @@ jobs:
         #       0     Use default retention policy of the repo
         #       1~90  Min 1, Max 90 days to keep the artifact unless changed by repo settings page
         with:
-          name: linux-${{ matrix.configuration }}
+          name: linux-${{ matrix.configuration }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/build/install/*.AppImage
   linux_zip:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
     container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
     steps:
       - uses: actions/checkout@v1
         name: Checkout
@@ -105,18 +114,24 @@ jobs:
         # Grab the release builds
         uses: actions/download-artifact@v4
         with:
-          name: linux-Release
+          name: linux-Release-${{ matrix.arch }}
           path: builds
       - name: Download FastDebug builds
         # Grab the debug builds
         uses: actions/download-artifact@v4
         with:
-          name: linux-FastDebug
+          name: linux-FastDebug-${{ matrix.arch }}
           path: builds
+      - name: Fix permissions
+        working-directory: ./builds
+        shell: bash
+        run: chmod 755 *.AppImage
       - name: Create Distribution package
         # Zip both builds together
         id: generate_package
         working-directory: ./builds
+        env:
+          ARCH: ${{ matrix.arch }}
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Linux
       - name: Upload result package
         # Stash the result to artifact filespace

--- a/ci/linux/create_dist_pack.sh
+++ b/ci/linux/create_dist_pack.sh
@@ -8,11 +8,11 @@ OS="$1"
 source $HERE/dist_functions.sh
 
 if [ "$OS" = "Linux" ]; then
-    tar -cvzf "$(get_package_name)-builds-Linux.tar.gz" *
+    tar -cvzf "$(get_package_name)-builds-Linux-$ARCH.tar.gz" *
 
-    echo "package_path=$(pwd)/$(get_package_name)-builds-Linux.tar.gz" >> $GITHUB_OUTPUT
-    echo "package_name=$(get_package_name)-builds-Linux.tar.gz" >> $GITHUB_OUTPUT
-    echo "package_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-Linux.tar.gz")" >> $GITHUB_OUTPUT
+    echo "package_path=$(pwd)/$(get_package_name)-builds-Linux-$ARCH.tar.gz" >> $GITHUB_OUTPUT
+    echo "package_name=$(get_package_name)-builds-Linux-$ARCH.tar.gz" >> $GITHUB_OUTPUT
+    echo "package_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-Linux-$ARCH.tar.gz")" >> $GITHUB_OUTPUT
 elif [ "$OS" = "Windows" ]; then
     7z a -xr'!*.pdb' "$(get_package_name)-builds-$ARCH-$SIMD.zip" "*"
 

--- a/ci/post/nebula.py
+++ b/ci/post/nebula.py
@@ -7,7 +7,8 @@ import requests
 from file_list import ReleaseFile
 from util import retry_multi, GLOBAL_TIMEOUT
 
-LINUX_KEY = "Linux"
+LINUX_X64_KEY = "Linux-x86_64"
+LINUX_ARM64_KEY = "Linux-arm64"
 MACOSX_X64_KEY = "Mac-x86_64"
 MACOSX_ARM64_KEY = "Mac-arm64"
 WIN32_SSE2_KEY = "Win32-SSE2"
@@ -34,7 +35,8 @@ metadata = {
 }
 
 platforms = {
-    LINUX_KEY: 'linux',
+    LINUX_X64_KEY: 'linux',
+    LINUX_ARM64_KEY: 'linux',
     MACOSX_X64_KEY: 'macosx',
     MACOSX_ARM64_KEY: 'macosx',
     WIN32_SSE2_KEY: 'windows',
@@ -44,7 +46,8 @@ platforms = {
 }
 
 envs = {
-    LINUX_KEY: 'linux && x86_64',  # Linux only has 64bit builds
+    LINUX_X64_KEY: 'linux && x86_64',
+    LINUX_ARM64_KEY: 'linux && arm64',
     MACOSX_X64_KEY: 'macosx && x86_64',
     MACOSX_ARM64_KEY: 'macosx && arm64',
     WIN32_SSE2_KEY: 'windows',
@@ -113,7 +116,7 @@ def render_nebula_release(version, stability, files, config):
                 'filename': dest_fn
             })
 
-            if group == LINUX_KEY and fn.endswith('.AppImage'):
+            if group.startswith('Linux') and fn.endswith('.AppImage'):
                 if 'qtfred' in fn:
                     if '-FASTDBG' in fn:
                         label = 'QtFRED Debug'
@@ -127,7 +130,8 @@ def render_nebula_release(version, stability, files, config):
                         label = None
 
                 props = {
-                    "x64": True,  # All Linux builds are 64-bit
+                    "arm64": "arm64" in fn,
+                    "x64": "x64" in fn,
                     "sse2": True,  # Linux builds are forced to compile with SSE2 but not AVX
                     "avx": False,
                     "avx2": False,

--- a/ci/post/release.mako
+++ b/ci/post/release.mako
@@ -44,9 +44,10 @@ Linux:  [url=https://www.hard-light.net/forums/index.php/topic,53206.0.html]YAL[
 Don't want to deal with that? Use [url=https://knossosnet.github.io/Knossos-Release-Page/]Knossos.NET[/url] and it will download the best build specifically for your PC!
 [/hidden]
 
-[img]https://scp.indiegames.us/img/linux-icon.png[/img] [color=green][size=12pt]Linux 64-bit[/size][/color]
-[size=8pt]Compiled with Ubuntu 16.04 LTS 64-bit, GCC 5[/size]
-${build(groups["Linux"].mainFile)}
+[img]https://scp.indiegames.us/img/linux-icon.png[/img] [color=green][size=12pt]Linux[/size][/color]
+[size=8pt]Compiled with Ubuntu 20.04 LTS, GCC 9[/size]
+[b]x86_64:[/b] ${build(groups["Linux"].subFiles["x86_64"])}
+[b]arm64:[/b] ${build(groups["Linux"].subFiles["arm64"])}
 
 These builds use a mechanism called [url=https://appimage.org/]AppImage[/url] which should allow these builds to run on most Linux distributions. However, we recommend that you compile your own builds which will result in less issues.
 Alternatively, if there is a package in your software repository then you should use that. If you are the maintainer of such a package for a distribution then let us know and we will include that here.


### PR DESCRIPTION
Github runners for Linux arm64 are now in public beta with the same free limits as normal github runners. Our Linux build images already have arm64 support so this finally enables it as part of the official workflow.