### PR TITLE
Allow mods to hide main Rearm/Repair items in Message Gauge

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -584,11 +584,11 @@ int hud_squadmsg_get_key()
 				return i;
 
 			// play general fail sound if inactive item hit.
-			else if ((i + First_menu_item < Num_menu_items) && !(MsgItems[i + First_menu_item].active)) {
+			else if ((i + First_menu_item < Num_menu_items) && (MsgItems[i + First_menu_item].active == 0)) {
 				gamesnd_play_iface(InterfaceSounds::GENERAL_FAIL);
 			}
 
-			else if ((i + First_menu_item < Num_menu_items) && (MsgItems[i + First_menu_item].active)) {	// only return keys that are associated with menu items
+			else if ((i + First_menu_item < Num_menu_items) && (MsgItems[i + First_menu_item].active > 0)) {	// only return keys that are associated with menu items
 				return i + First_menu_item;
 			}
 
@@ -1727,8 +1727,8 @@ void hud_squadmsg_type_select( )
 		MsgItems[TYPE_REINFORCEMENT_ITEM].active = 0;
 	}
 
-	MsgItems[TYPE_REPAIR_REARM_ITEM].active = 1;				// this item will always be available (I think)
-	MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = 0;
+	MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 1;
+	MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
 
 	for(const auto& cat : lua_cat_list){
 		if (ai_lua_get_general_orders(false, false, cat).size() == 0) {
@@ -1747,7 +1747,7 @@ void hud_squadmsg_type_select( )
 			MsgItems[i].active = 0;
 		}
 
-		MsgItems[TYPE_REPAIR_REARM_ITEM].active = 1;
+		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 1;
 	}
 
 	// check to see if the player is awaiting repair or being repaired.  Active the abort and inactive the repair items
@@ -1762,25 +1762,25 @@ void hud_squadmsg_type_select( )
 	}
 	// if no support available, can't call one in
 	else if ( !is_support_allowed(Player_obj) ) {
-		MsgItems[TYPE_REPAIR_REARM_ITEM].active = 0;
-		MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = 0;
+		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
+		MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
 	}
 
 	// de-activate the rearm/repair item if the player has a full load of missiles and
 	// all subsystems at full strength.  We will only check if this item hasn't been marked
 	// inactive because of some other reason
-	if ( MsgItems[TYPE_REPAIR_REARM_ITEM].active ) {
+	if ( MsgItems[TYPE_REPAIR_REARM_ITEM].active > 0 ) {
 
 		if ( !hud_squadmsg_can_rearm(Player_ship) ){
 			MsgItems[TYPE_REPAIR_REARM_ITEM].active = 0;
 		}
 	}
 
-	// if using keyboard shortcut, these items are always inactive
+	// if using keyboard shortcut, these items are always inactive or hidden
 	if ( Msg_shortcut_command != -1 ) {
-		MsgItems[TYPE_REPAIR_REARM_ITEM].active = 0;
 		MsgItems[TYPE_REINFORCEMENT_ITEM].active = 0;
-		MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = 0;
+		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
+		MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
 	}
 
 do_main_menu:
@@ -1800,9 +1800,9 @@ do_main_menu:
 			if ( k == TYPE_REINFORCEMENT_ITEM ) {
 				hud_squadmsg_do_mode( SM_MODE_REINFORCEMENTS );
 				player_set_next_all_alone_msg_timestamp();
-			} else if ( k == TYPE_REPAIR_REARM_ITEM ){
+			} else if (k == TYPE_REPAIR_REARM_ITEM && !Hide_main_rearm_items_in_message_gauge) {
 				hud_squadmsg_do_mode( SM_MODE_REPAIR_REARM );
-			} else if ( k == TYPE_REPAIR_REARM_ABORT_ITEM ) {
+			} else if (k == TYPE_REPAIR_REARM_ABORT_ITEM && !Hide_main_rearm_items_in_message_gauge) {
 				hud_squadmsg_do_mode( SM_MODE_REPAIR_REARM_ABORT );
 			} else if (k >= NUM_COMM_ORDER_TYPES) {
 				Lua_sqd_msg_cat = lua_cat_list[k - NUM_COMM_ORDER_TYPES];
@@ -2253,7 +2253,7 @@ void hud_squadmsg_wing_command()
 
 		// if no ship in the wing can depart then gray out the departure order
 		if (order_id == DEPART_ITEM) {
-			if (MsgItems[Num_menu_items].active) {
+			if (MsgItems[Num_menu_items].active > 0) {
 				int active = 0;
 				for (int i = 0; i < wingp->current_count; i++) {
 					if (hud_squadmsg_ship_order_valid(wingp->ship_index[i], (int)order_id)) {
@@ -2843,6 +2843,9 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 				XSTR("Abort Rearm", 298)
 			};
 			text = temp_comm_order_types[i];
+			if (Hide_main_rearm_items_in_message_gauge && (i == TYPE_REPAIR_REARM_ITEM || i == TYPE_REPAIR_REARM_ABORT_ITEM)) {
+				MsgItems[First_menu_item + i].active = -1;
+			}
 		}
 
 		// blit the background
@@ -2853,24 +2856,26 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 		by += fl2i(Item_h * scale);
 
 		// set the text color
-		if (!config && MsgItems[First_menu_item+i].active ) {
+		if (!config && (MsgItems[First_menu_item+i].active > 0) ) {
 			setGaugeColor(HUD_C_BRIGHT, config);
 		} else {
 			setGaugeColor(HUD_C_DIM, config);
 		}
 
 		// first do the number
-		item_num = (i+1) % MAX_MENU_DISPLAY;
-		renderPrintfWithGauge(sx, sy, EG_SQ1 + i, scale, config, NOX("%1d."), item_num);
+		if (MsgItems[First_menu_item + i].active >= 0) {
+			item_num = (i+1) % MAX_MENU_DISPLAY;
+			renderPrintfWithGauge(sx, sy, EG_SQ1 + i, scale, config, NOX("%1d."), item_num);
 
-		// then the text
-		renderString(sx + fl2i(Item_offset_x * scale), sy, EG_SQ1 + i, text, scale, config);
+			// then the text
+			renderString(sx + fl2i(Item_offset_x * scale), sy, EG_SQ1 + i, text, scale, config);
 
-		sy += fl2i(Item_h * scale);
+			sy += fl2i(Item_h * scale);
+		}
 
 		// if we have at least one item active, then set the variable so we don't display any
 		// message about no active items
-		if (config || MsgItems[First_menu_item+i].active )
+		if (config || (MsgItems[First_menu_item+i].active > 0) )
 			none_valid = false;
 	}
 

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2835,6 +2835,8 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 		if (!config) {
 			text = MsgItems[First_menu_item + i].text.c_str();
 		} else {
+			// in config mode, so create just the first page of the Comms Menu
+			// as other functions, such as hud_squadmsg_type_select() will not be run in config mode
 			const char* temp_comm_order_types[] = {XSTR("Ships", 293),
 				XSTR("Wings", 294),
 				XSTR("All Fighters", 295),

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1727,8 +1727,8 @@ void hud_squadmsg_type_select( )
 		MsgItems[TYPE_REINFORCEMENT_ITEM].active = 0;
 	}
 
-	MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 1;
-	MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
+	MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_comms_gauge ? -1 : 1;
+	MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_comms_gauge ? -1 : 0;
 
 	for(const auto& cat : lua_cat_list){
 		if (ai_lua_get_general_orders(false, false, cat).size() == 0) {
@@ -1747,7 +1747,7 @@ void hud_squadmsg_type_select( )
 			MsgItems[i].active = 0;
 		}
 
-		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 1;
+		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_comms_gauge ? -1 : 1;
 	}
 
 	// check to see if the player is awaiting repair or being repaired.  Active the abort and inactive the repair items
@@ -1762,8 +1762,8 @@ void hud_squadmsg_type_select( )
 	}
 	// if no support available, can't call one in
 	else if ( !is_support_allowed(Player_obj) ) {
-		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
-		MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
+		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_comms_gauge ? -1 : 0;
+		MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_comms_gauge ? -1 : 0;
 	}
 
 	// de-activate the rearm/repair item if the player has a full load of missiles and
@@ -1779,8 +1779,8 @@ void hud_squadmsg_type_select( )
 	// if using keyboard shortcut, these items are always inactive or hidden
 	if ( Msg_shortcut_command != -1 ) {
 		MsgItems[TYPE_REINFORCEMENT_ITEM].active = 0;
-		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
-		MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_message_gauge ? -1 : 0;
+		MsgItems[TYPE_REPAIR_REARM_ITEM].active = Hide_main_rearm_items_in_comms_gauge ? -1 : 0;
+		MsgItems[TYPE_REPAIR_REARM_ABORT_ITEM].active = Hide_main_rearm_items_in_comms_gauge ? -1 : 0;
 	}
 
 do_main_menu:
@@ -1800,9 +1800,9 @@ do_main_menu:
 			if ( k == TYPE_REINFORCEMENT_ITEM ) {
 				hud_squadmsg_do_mode( SM_MODE_REINFORCEMENTS );
 				player_set_next_all_alone_msg_timestamp();
-			} else if (k == TYPE_REPAIR_REARM_ITEM && !Hide_main_rearm_items_in_message_gauge) {
+			} else if (k == TYPE_REPAIR_REARM_ITEM && !Hide_main_rearm_items_in_comms_gauge) {
 				hud_squadmsg_do_mode( SM_MODE_REPAIR_REARM );
-			} else if (k == TYPE_REPAIR_REARM_ABORT_ITEM && !Hide_main_rearm_items_in_message_gauge) {
+			} else if (k == TYPE_REPAIR_REARM_ABORT_ITEM && !Hide_main_rearm_items_in_comms_gauge) {
 				hud_squadmsg_do_mode( SM_MODE_REPAIR_REARM_ABORT );
 			} else if (k >= NUM_COMM_ORDER_TYPES) {
 				Lua_sqd_msg_cat = lua_cat_list[k - NUM_COMM_ORDER_TYPES];
@@ -2843,7 +2843,7 @@ void HudGaugeSquadMessage::render(float  /*frametime*/, bool config)
 				XSTR("Abort Rearm", 298)
 			};
 			text = temp_comm_order_types[i];
-			if (Hide_main_rearm_items_in_message_gauge && (i == TYPE_REPAIR_REARM_ITEM || i == TYPE_REPAIR_REARM_ABORT_ITEM)) {
+			if (Hide_main_rearm_items_in_comms_gauge && (i == TYPE_REPAIR_REARM_ITEM || i == TYPE_REPAIR_REARM_ABORT_ITEM)) {
 				MsgItems[First_menu_item + i].active = -1;
 			}
 		}

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -77,7 +77,7 @@ class object;
 
 typedef struct mmode_item {
 	int instance;    // instance in Ships/Wings array of this menu item
-	int active;      // active items are in bold text -- inactive items greyed out
+	int active;      // active items are in bold text -- inactive items greyed out -- hidden objects not rendered
 	SCP_string text; // text to display on the menu
 } mmode_item;
 

--- a/code/hud/hudsquadmsg.h
+++ b/code/hud/hudsquadmsg.h
@@ -77,7 +77,7 @@ class object;
 
 typedef struct mmode_item {
 	int instance;    // instance in Ships/Wings array of this menu item
-	int active;      // active items are in bold text -- inactive items greyed out -- hidden objects not rendered
+	int active;      // active items are in bold text (1) -- inactive items greyed out (0) -- hidden objects not rendered (-1)
 	SCP_string text; // text to display on the menu
 } mmode_item;
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -157,6 +157,7 @@ bool Contrails_use_absolute_speed;
 bool Use_new_scanning_behavior;
 bool Lua_API_returns_nil_instead_of_invalid_object;
 bool Dont_show_callsigns_in_escort_list;
+bool Hide_main_rearm_items_in_message_gauge;
 bool Fix_scripted_velocity;
 color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 bool Preload_briefing_icon_models;
@@ -465,6 +466,10 @@ void parse_mod_table(const char *filename)
 
 			if (optional_string("$Don't show callsigns in the escort list:")) {
 				stuff_boolean(&Dont_show_callsigns_in_escort_list);
+			}
+
+			if (optional_string("$Hide main Rearm/Repair items in Message Gauge:")) {
+				stuff_boolean(&Hide_main_rearm_items_in_message_gauge);
 			}
 
 			optional_string("#SEXP SETTINGS");
@@ -1700,6 +1705,7 @@ void mod_table_reset()
 	Use_new_scanning_behavior = false;
 	Lua_API_returns_nil_instead_of_invalid_object = false;
 	Dont_show_callsigns_in_escort_list = false;
+	Hide_main_rearm_items_in_message_gauge = false;
 	Fix_scripted_velocity = false;
 	// These colors were taken from missionscreencommon.cpp line 591 which
 	// were the original colors used by the overhead ship loadout lines

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -157,7 +157,7 @@ bool Contrails_use_absolute_speed;
 bool Use_new_scanning_behavior;
 bool Lua_API_returns_nil_instead_of_invalid_object;
 bool Dont_show_callsigns_in_escort_list;
-bool Hide_main_rearm_items_in_message_gauge;
+bool Hide_main_rearm_items_in_comms_gauge;
 bool Fix_scripted_velocity;
 color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 bool Preload_briefing_icon_models;
@@ -468,8 +468,8 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Dont_show_callsigns_in_escort_list);
 			}
 
-			if (optional_string("$Hide main Rearm/Repair items in Message Gauge:")) {
-				stuff_boolean(&Hide_main_rearm_items_in_message_gauge);
+			if (optional_string("$Hide main Rearm/Repair items in Comms Gauge:")) {
+				stuff_boolean(&Hide_main_rearm_items_in_comms_gauge);
 			}
 
 			optional_string("#SEXP SETTINGS");
@@ -1705,7 +1705,7 @@ void mod_table_reset()
 	Use_new_scanning_behavior = false;
 	Lua_API_returns_nil_instead_of_invalid_object = false;
 	Dont_show_callsigns_in_escort_list = false;
-	Hide_main_rearm_items_in_message_gauge = false;
+	Hide_main_rearm_items_in_comms_gauge = false;
 	Fix_scripted_velocity = false;
 	// These colors were taken from missionscreencommon.cpp line 591 which
 	// were the original colors used by the overhead ship loadout lines

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -172,7 +172,7 @@ extern bool Contrails_use_absolute_speed;
 extern bool Use_new_scanning_behavior;
 extern bool Lua_API_returns_nil_instead_of_invalid_object;
 extern bool Dont_show_callsigns_in_escort_list;
-extern bool Hide_main_rearm_items_in_message_gauge;
+extern bool Hide_main_rearm_items_in_comms_gauge;
 extern bool Fix_scripted_velocity;
 extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 extern bool Preload_briefing_icon_models;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -172,6 +172,7 @@ extern bool Contrails_use_absolute_speed;
 extern bool Use_new_scanning_behavior;
 extern bool Lua_API_returns_nil_instead_of_invalid_object;
 extern bool Dont_show_callsigns_in_escort_list;
+extern bool Hide_main_rearm_items_in_message_gauge;
 extern bool Fix_scripted_velocity;
 extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 extern bool Preload_briefing_icon_models;

--- a/code/scripting/api/objs/comm_order.cpp
+++ b/code/scripting/api/objs/comm_order.cpp
@@ -32,7 +32,7 @@ ADE_VIRTVAR(Active, l_Comm_Item, nullptr, "Whether or not the item is active", "
 		LuaError(L, "This property is read only.");
 	}
 
-	if (MsgItems[current].active) {
+	if (MsgItems[current].active > 0) {
 		return ADE_RETURN_TRUE;
 	}
 


### PR DESCRIPTION
Adds a game_settings option to hide/disable the Rearm/Repair commands in the Squad Message Gauge. FotG does not use repair ships, so it is somewhat confusing to players to always see the `Rearm/Repair` order options (IE 5. Rearm/Repair Subsys and 6. Abort Rearm) and never be able to use them.

I wanted to make this PR as surgical as possible, while still giving some degree of generality, thus I went with the solution to use `active` as a true integer instead of simply an old int in the bool style. Now -1 is hidden, 0 is greyed out, and 1 is bright.

Tested and works as expected.