### PR TITLE
Display scrollback with even one message

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -616,7 +616,7 @@ int hud_query_scrollback_size()
 	int count = 0, y_add = 0;
 	int font_height = gr_get_font_height();
 
-	if (Msg_scrollback_lines.size() <= 1 || !HUD_msg_inited)
+	if (Msg_scrollback_lines.size() <= 0 || !HUD_msg_inited)
 		return 0;
 
 	for (int i = 0; i < (int)Msg_scrollback_lines.size(); i++) {
@@ -677,7 +677,7 @@ int hud_get_scroll_max_pos()
 		// number of pixels in excess of what can be displayed
 		int excess = Scroll_max - Hud_mission_log_list_coords[gr_screen.res][3];
 
-		if (Msg_scrollback_lines.size() <= 1 || !HUD_msg_inited) {
+		if (Msg_scrollback_lines.size() <= 0 || !HUD_msg_inited) {
 			max = 0;
 		} else {
 
@@ -746,7 +746,7 @@ void hud_goto_pos(int delta)
 	if (Scrollback_mode == SCROLLBACK_MODE_MSGS_LOG) {
 		int count = 0, y = 0;
 
-		if (Msg_scrollback_lines.size() <= 1 || !HUD_msg_inited)
+		if (Msg_scrollback_lines.size() <= 0 || !HUD_msg_inited)
 			return;
 
 		for (int i = 0; i < (int)Msg_scrollback_lines.size(); i++) {
@@ -1068,7 +1068,7 @@ void hud_scrollback_do_frame(float  /*frametime*/)
 		Buttons[gr_screen.res][SHOW_MSGS_BUTTON].button.draw_forced(2);
 
 		int y = 0;
-		if (!(Msg_scrollback_lines.size() <= 1) && HUD_msg_inited) {
+		if (!(Msg_scrollback_lines.size() <= 0) && HUD_msg_inited) {
 			int i = 0;
 			for (int j = 0; j < (int)Msg_scrollback_lines.size(); j++) {
 				line_node node_msg = Msg_scrollback_lines[j];

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -616,7 +616,7 @@ int hud_query_scrollback_size()
 	int count = 0, y_add = 0;
 	int font_height = gr_get_font_height();
 
-	if (Msg_scrollback_lines.size() <= 0 || !HUD_msg_inited)
+	if (Msg_scrollback_lines.empty() || !HUD_msg_inited)
 		return 0;
 
 	for (int i = 0; i < (int)Msg_scrollback_lines.size(); i++) {
@@ -677,7 +677,7 @@ int hud_get_scroll_max_pos()
 		// number of pixels in excess of what can be displayed
 		int excess = Scroll_max - Hud_mission_log_list_coords[gr_screen.res][3];
 
-		if (Msg_scrollback_lines.size() <= 0 || !HUD_msg_inited) {
+		if (Msg_scrollback_lines.empty() || !HUD_msg_inited) {
 			max = 0;
 		} else {
 
@@ -746,7 +746,7 @@ void hud_goto_pos(int delta)
 	if (Scrollback_mode == SCROLLBACK_MODE_MSGS_LOG) {
 		int count = 0, y = 0;
 
-		if (Msg_scrollback_lines.size() <= 0 || !HUD_msg_inited)
+		if (Msg_scrollback_lines.empty() || !HUD_msg_inited)
 			return;
 
 		for (int i = 0; i < (int)Msg_scrollback_lines.size(); i++) {
@@ -1068,7 +1068,7 @@ void hud_scrollback_do_frame(float  /*frametime*/)
 		Buttons[gr_screen.res][SHOW_MSGS_BUTTON].button.draw_forced(2);
 
 		int y = 0;
-		if (!(Msg_scrollback_lines.size() <= 0) && HUD_msg_inited) {
+		if (!Msg_scrollback_lines.empty() && HUD_msg_inited) {
 			int i = 0;
 			for (int j = 0; j < (int)Msg_scrollback_lines.size(); j++) {
 				line_node node_msg = Msg_scrollback_lines[j];


### PR DESCRIPTION
Fixes #6679 by making sure scrollback renders even if the msg vector size is 1. The code specifically checked against 1 instead of 0 which must have been a specific choice I made but I can't remember why. Maybe I was trying to avoid rendering debug's `Game difficulty set to *medium*` message that's always added? I honestly can't remember and that wouldn't have really worked anyway. So just set this to 0 to make sure log works even with 1 message in the list.