### PR TITLE
Add disable intro movie flag

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -163,6 +163,7 @@ color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 bool Preload_briefing_icon_models;
 EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
 bool Fix_asteroid_bounding_box_check;
+bool Disable_intro_movie;
 
 
 #ifdef WITH_DISCORD
@@ -1489,6 +1490,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Fix_asteroid_bounding_box_check);
 			}
 
+			if (optional_string("$Disable intro cutscene:")) {
+				stuff_boolean(&Disable_intro_movie);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1716,6 +1721,7 @@ void mod_table_reset()
 	Preload_briefing_icon_models = false;
 	escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
 	Fix_asteroid_bounding_box_check = false;
+	Disable_intro_movie = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -178,6 +178,7 @@ extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 extern bool Preload_briefing_icon_models;
 extern EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
 extern bool Fix_asteroid_bounding_box_check;
+extern bool Disable_intro_movie;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6874,7 +6874,7 @@ int game_main(int argc, char *argv[])
 		output_sexps("sexps.html");
 	}
 
-	bool skip_intro = false;
+	bool skip_intro = Disable_intro_movie;
 	if (scripting::hooks::OnIntroAboutToPlay->isActive()) {
 		skip_intro = scripting::hooks::OnIntroAboutToPlay->isOverride();
 		scripting::hooks::OnIntroAboutToPlay->run();


### PR DESCRIPTION
Fixes #6685 . Game boolean flags are super lightweight and easy to code. Two minutes of effort makes this feature accessible to modders who don't know Lua and/or FSO's scripting API.