### PR TITLE
Make sure drop shadows don't pollute the color context

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -915,9 +915,10 @@ void HudGauge::renderString(int x, int y, const char *str, float scale, bool con
 	}
 
 	if (HUD_shadows) {
+		color cur = gr_screen.current_color;
 		gr_set_color_fast(&Color_black);
 		gr_string(x + nx + 1, y + ny + 1, str, resize, scale);
-		gr_set_color_fast(&gauge_color);
+		gr_set_color_fast(&cur);
 	}
 
 	gr_string(x + nx, y + ny, str, resize, scale);
@@ -951,16 +952,18 @@ void HudGauge::renderString(int x, int y, int gauge_id, const char *str, float s
 
 	if ( gauge_id > -2 ) {
 		if (HUD_shadows) {
+			color cur = gr_screen.current_color;
 			gr_set_color_fast(&Color_black);
 			emp_hud_string(x + nx + 1, y + ny + 1, gauge_id, str, resize, scale);
-			gr_set_color_fast(&gauge_color);
+			gr_set_color_fast(&cur);
 		}
 		emp_hud_string(x + nx, y + ny, gauge_id, str, resize, scale);
 	} else {
 		if (HUD_shadows) {
+			color cur = gr_screen.current_color;
 			gr_set_color_fast(&Color_black);
 			gr_string(x + nx + 1, y + ny + 1, str, resize, scale);
-			gr_set_color_fast(&gauge_color);
+			gr_set_color_fast(&cur);
 		}
 		gr_string(x + nx, y + ny, str, resize, scale);
 	}

--- a/code/hud/hudets.cpp
+++ b/code/hud/hudets.cpp
@@ -914,6 +914,7 @@ void HudGaugeEts::blitGauge(int index, int ix, int iy, float scale, bool config)
 
 	int x, y;
 	if (HUD_shadows) {
+		color cur = gr_screen.current_color;
 		// These act more as a backing black layer.
 
 		gr_set_color_fast(&Color_black);
@@ -930,7 +931,7 @@ void HudGaugeEts::blitGauge(int index, int ix, int iy, float scale, bool config)
 		renderBitmapEx(Ets_bar.first_frame, x, y, w, y + ETS_bar_h, 0, 0, scale, config);
 
 		if (!config) {
-			gr_set_color_fast(&gauge_color);
+			gr_set_color_fast(&cur);
 		} else {
 			setGaugeColor(HUD_C_NONE, config);
 		}

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -329,12 +329,13 @@ void HudGaugeReticle::render(float  /*frametime*/, bool config)
 
 	if (fixed_reticle >= 0) {
 		if (HUD_shadows) {
+			color cur = gr_screen.current_color;
 			gr_set_color_fast(&Color_black);
 
 			// Render the shadow twice to increase visibility
 			renderBitmap(fixed_reticle, x + 1, y + 1, scale, config);
 			renderBitmap(fixed_reticle, x + 1, y + 1, scale, config);
-			gr_set_color_fast(&gauge_color);
+			gr_set_color_fast(&cur);
 		}
 
 		renderBitmap(fixed_reticle, x, y, scale, config);


### PR DESCRIPTION
Drop shadow rendering would pollute the color context by setting the color to `gauge_color` rather than the previously calculated color. This PR saves the current color before setting it to black to render the drop shadow and then sets it back to the saved color.

Fixes #6680

Further context copied from the issue:

> Basically, each gauge's render method sets up everything for the render call and that includes setting the color using a special function to select the color based on gauge settings and that's where using IFF color comes in. Sometime after that is when the gauge will call the render method in hud.cpp, for example HudGauge::renderString().
> 
> In the render method is where the dropshadow is handled by first setting the color to black, rendering the string, and then here is where the bug is. It sets the color to gauge_color rather than using the original function to reset the color or some other method of saving the previously set color before flipping to black.