### PR TITLE
Allow defining separate player and target shield icons for config

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -17,6 +17,7 @@
 #include "globalincs/pstypes.h"
 #include "hud/hudconfig.h"
 #include "hud/hudobserver.h"
+#include "hud/hudshield.h"
 #include "iff_defs/iff_defs.h"
 #include "io/key.h"
 #include "io/mouse.h"
@@ -171,7 +172,7 @@ int HC_talking_head_frame = -1;
 SCP_string HC_head_anim_filename;
 bool HC_show_default_hud = true;
 std::unordered_set<SCP_string> HC_ignored_huds;
-SCP_map<SCP_string, SCP_string> HC_hud_ships;
+SCP_map<SCP_string, SCP_string[num_shield_gauge_types]> HC_hud_shield_ships;
 SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_primary_weapons;
 SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_secondary_weapons;
 

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -172,7 +172,7 @@ int HC_talking_head_frame = -1;
 SCP_string HC_head_anim_filename;
 bool HC_show_default_hud = true;
 std::unordered_set<SCP_string> HC_ignored_huds;
-SCP_map<SCP_string, SCP_string[num_shield_gauge_types]> HC_hud_shield_ships;
+SCP_map<SCP_string, std::array<SCP_string, num_shield_gauge_types>> HC_hud_shield_ships;
 SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_primary_weapons;
 SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_secondary_weapons;
 

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -192,7 +192,7 @@ extern int HC_talking_head_frame;
 extern SCP_string HC_head_anim_filename;
 extern bool HC_show_default_hud;
 extern std::unordered_set<SCP_string> HC_ignored_huds;
-extern SCP_map<SCP_string, SCP_string[num_shield_gauge_types]> HC_hud_shield_ships;
+extern SCP_map<SCP_string, std::array<SCP_string, num_shield_gauge_types>> HC_hud_shield_ships;
 extern SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_primary_weapons;
 extern SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_secondary_weapons;
 

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -13,6 +13,7 @@
 #define _HUDCONFIG_H
 
 #include "hud/hud.h"
+#include "hud/hudshield.h"
 #include "ui/ui.h"
 
 class player;
@@ -191,7 +192,7 @@ extern int HC_talking_head_frame;
 extern SCP_string HC_head_anim_filename;
 extern bool HC_show_default_hud;
 extern std::unordered_set<SCP_string> HC_ignored_huds;
-extern SCP_map<SCP_string, SCP_string> HC_hud_ships;
+extern SCP_map<SCP_string, SCP_string[num_shield_gauge_types]> HC_hud_shield_ships;
 extern SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_primary_weapons;
 extern SCP_map<SCP_string, SCP_vector<SCP_string>> HC_hud_secondary_weapons;
 

--- a/code/hud/hudescort.cpp
+++ b/code/hud/hudescort.cpp
@@ -963,7 +963,7 @@ void hud_escort_ship_hit(const object *objp, int  /*quadrant*/)
 	for (auto &es : Escort_ships) {
 		if (es.objnum == objnum) {
 			hud_gauge_popup_start(HUD_ESCORT_VIEW);
-			es.escort_hit_timer = timestamp(SHIELD_HIT_DURATION);
+			es.escort_hit_timer = timestamp(SHIELD_HIT_FLASH_DURATION);
 			es.escort_hit_next_flash = timestamp(SHIELD_FLASH_INTERVAL);
 			break;
 		}

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -252,7 +252,7 @@ void parse_hud_gauges_tbl(const char *filename)
 
 				for (auto& ship : Ship_info) {
 					if (!stricmp(ship.name, temp.c_str())) {
-						HC_hud_ships["default"] = ship.name;
+						HC_hud_shield_ships["default"][SHIELD_GAUGE_PLAYER] = ship.name;
 						found = true;
 						break;
 					}
@@ -260,6 +260,25 @@ void parse_hud_gauges_tbl(const char *filename)
 
 				if (!found) {
 					Warning(LOCATION, "Shield gauge ship \"%s\" not found in ships.tbl!", temp.c_str());
+				}
+			}
+
+			if (optional_string("$Shield Gauge Target Ship:")) {
+				SCP_string temp;
+				stuff_string(temp, F_NAME);
+
+				bool found = false;
+
+				for (auto& ship : Ship_info) {
+					if (!stricmp(ship.name, temp.c_str())) {
+						HC_hud_shield_ships["default"][SHIELD_GAUGE_TARGET] = ship.name;
+						found = true;
+						break;
+					}
+				}
+
+				if (!found) {
+					Warning(LOCATION, "Shield gauge target ship \"%s\" not found in ships.tbl!", temp.c_str());
 				}
 			}
 
@@ -512,10 +531,41 @@ void parse_hud_gauges_tbl(const char *filename)
 				}
 
 				if (optional_string("$Shield Gauge Ship:")) {
-					SCP_string ship;
-					stuff_string(ship, F_NAME);
+					SCP_string temp;
+					stuff_string(temp, F_NAME);
 
-					HC_hud_ships[name] = ship;
+					bool found = false;
+
+					for (auto& ship : Ship_info) {
+						if (!stricmp(ship.name, temp.c_str())) {
+							HC_hud_shield_ships[name][SHIELD_GAUGE_PLAYER] = temp;
+							found = true;
+							break;
+						}
+					}
+
+					if (!found) {
+						Warning(LOCATION, "Shield gauge ship \"%s\" not found in ships.tbl!", temp.c_str());
+					}
+				}
+
+				if (optional_string("$Shield Gauge Target Ship:")) {
+					SCP_string temp;
+					stuff_string(temp, F_NAME);
+
+					bool found = false;
+
+					for (auto& ship : Ship_info) {
+						if (!stricmp(ship.name, temp.c_str())) {
+							HC_hud_shield_ships[name][SHIELD_GAUGE_TARGET] = ship.name;
+							found = true;
+							break;
+						}
+					}
+
+					if (!found) {
+						Warning(LOCATION, "Shield gauge target ship \"%s\" not found in ships.tbl!", temp.c_str());
+					}
 				}
 
 				if (optional_string("$Primary Weapons:")) {

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -250,7 +250,7 @@ void parse_hud_gauges_tbl(const char *filename)
 
 				bool found = false;
 
-				for (auto& ship : Ship_info) {
+				for (const auto& ship : Ship_info) {
 					if (!stricmp(ship.name, temp.c_str())) {
 						HC_hud_shield_ships["default"][SHIELD_GAUGE_PLAYER] = ship.name;
 						found = true;
@@ -269,7 +269,7 @@ void parse_hud_gauges_tbl(const char *filename)
 
 				bool found = false;
 
-				for (auto& ship : Ship_info) {
+				for (const auto& ship : Ship_info) {
 					if (!stricmp(ship.name, temp.c_str())) {
 						HC_hud_shield_ships["default"][SHIELD_GAUGE_TARGET] = ship.name;
 						found = true;
@@ -536,7 +536,7 @@ void parse_hud_gauges_tbl(const char *filename)
 
 					bool found = false;
 
-					for (auto& ship : Ship_info) {
+					for (const auto& ship : Ship_info) {
 						if (!stricmp(ship.name, temp.c_str())) {
 							HC_hud_shield_ships[name][SHIELD_GAUGE_PLAYER] = temp;
 							found = true;
@@ -555,7 +555,7 @@ void parse_hud_gauges_tbl(const char *filename)
 
 					bool found = false;
 
-					for (auto& ship : Ship_info) {
+					for (const auto& ship : Ship_info) {
 						if (!stricmp(ship.name, temp.c_str())) {
 							HC_hud_shield_ships[name][SHIELD_GAUGE_TARGET] = ship.name;
 							found = true;

--- a/code/hud/hudshield.h
+++ b/code/hud/hudshield.h
@@ -18,6 +18,13 @@
 #define SHIELD_HIT_DURATION	1400	// time a shield quadrant flashes after being hit
 #define SHIELD_FLASH_INTERVAL	200	// time between shield quadrant flashes
 
+enum ShieldGaugeType {
+	SHIELD_GAUGE_PLAYER,
+	SHIELD_GAUGE_TARGET,
+
+	num_shield_gauge_types
+};
+
 typedef struct shield_hit_info
 {
 	int members;
@@ -57,9 +64,9 @@ protected:
 public:
 	HudGaugeShield();
 	HudGaugeShield(int _gauge_object, int _gauge_config);
-	void showShields(const object* objp, int mode, bool config);
+	void showShields(const object* objp, ShieldGaugeType mode, bool config);
 	void render(float frametime, bool config = false) override;
-	int maybeFlashShield(int target_index, int shield_offset);
+	int maybeFlashShield(ShieldGaugeType target_index, int shield_offset);
 	void renderShieldIcon(coord2d coords[6]);
 };
 

--- a/code/hud/hudshield.h
+++ b/code/hud/hudshield.h
@@ -15,7 +15,7 @@
 #include "globalincs/pstypes.h"
 #include "hud/hud.h"
 
-#define SHIELD_HIT_DURATION	1400	// time a shield quadrant flashes after being hit
+#define SHIELD_HIT_FLASH_DURATION	1400	// time a shield quadrant flashes after being hit
 #define SHIELD_FLASH_INTERVAL	200	// time between shield quadrant flashes
 
 enum ShieldGaugeType {


### PR DESCRIPTION
Implement's @wookieejedi 's request to define the player and target shield icons separately for HUD Config.

This updates the logic slightly to ensure a sensible fallback hierarchy in the following priority order:

1. Local HUD-defined ship player or target
2. Global defined default ship layer or target
3. GTF Myrmidon (for retail since Myrmidon is not the first ship in retail)
4. First available shielded ship (If the selected ship can't be found)
5. If we still have nothing then return and don't draw

Finally I changed the SHIELD_HIT_PLAYER and SHIELD_HIT_TARGET defines to an enum for better safety and code clarity rather than passing around raw ints. I also renamed them to better reflect what they represent.