### PR TITLE
Add a few hud lua methods

### DIFF
--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -241,6 +241,7 @@ protected:
 	int popup_timer;
 	bool message_gauge;
 	int disabled_views;
+	bool scripting_render_override;
 
 	// Config stuff
 	SCP_string config_name;
@@ -322,6 +323,8 @@ public:
 	void updateActive(bool show);
 	void updatePopUp(bool pop_up_flag);
 	void updateSexpOverride(bool sexp);
+	bool getScriptingOverride() const;
+	void updateScriptingOverride(bool toggle);
 	void initChase_view_only(bool chase_view_only);
 	void initCockpit_view_choice(int cockpit_view_choice);
 	void initVisible_in_config(bool visible);

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2770,6 +2770,10 @@ bool HudGaugeSquadMessage::canRender() const
 		return false;
 	}
 
+	if (scripting_render_override) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/code/scripting/api/objs/hudconfig.cpp
+++ b/code/scripting/api/objs/hudconfig.cpp
@@ -199,6 +199,24 @@ ADE_VIRTVAR(Name, l_Gauge_Config, nullptr, "The name of this gauge", "string", "
 	return ade_set_args(L, "s", current.getGauge()->getConfigName().c_str());
 }
 
+ADE_VIRTVAR(isCustom, l_Gauge_Config, nullptr, "If the gauge is custom or builtin", "boolean", "True if custom, false otherwise")
+{
+	gauge_config_h current;
+	if (!ade_get_args(L, "o", l_Gauge_Config.Get(&current))) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (!current.isValid()) {
+		return ade_set_error(L, "b", false);
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "This property is read only.");
+	}
+
+	return ade_set_args(L, "b", current.getGauge()->isCustom());
+}
+
 ADE_VIRTVAR(CurrentColor,
 	l_Gauge_Config,
 	"color",

--- a/code/scripting/api/objs/hudgauge.cpp
+++ b/code/scripting/api/objs/hudgauge.cpp
@@ -256,6 +256,23 @@ ADE_FUNC(setColor,
 	return ADE_RETURN_NIL;
 }
 
+ADE_FUNC(setRenderOverride,
+	l_HudGauge,
+	"boolean",
+	"Sets a rendering override to enable or disable rendering of this gauge. This takes precedence over all other gauge toggles!",
+	"boolean",
+	"True to enable the override and stop the gauge from rendering, false otherwise")
+{
+	HudGauge* gauge;
+	bool override = false;
+	if (!ade_get_args(L, "o|b", l_HudGauge.Get(&gauge), &override))
+		return ADE_RETURN_NIL;
+
+	gauge->updateScriptingOverride(override);
+
+	return ade_set_args(L, "b", gauge->getScriptingOverride());
+}
+
 ADE_VIRTVAR(RenderFunction,
             l_HudGauge,
             "function (HudGaugeDrawFunctions gauge_handle) => void",


### PR DESCRIPTION
I needed a way to stop the comm menu hud gauge from rendering from Lua and it, notably, does not respect the enable/disable gauge sexp. So this adds a full scripting override boolean to gauges that the comm menu does respect. It's a fairly niche use-case but whatever method I came up with to handle this would be niche and this is at least generalized enough to maybe be more broadly useful.

This also includes a slight fix to the hud gange handle getter. BtA's HUD setup is fully ship based so `default_hud_gauges` array is empty which meant we had no way to get the comm menu gauge handle from lua, so this adds a way to get the player ship's hud gauges if all else fails to try and find the requested gauge. Honestly I hate the way we store gauges as part of the Ship_Info. HUDs and their gauges should probably be their own stored object but that's a problem for another time.

Finally, I needed to know if a gauge was custom in HUD Config so I included that, too.