### PR TITLE
add flag to control model eyepoint normal usage

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -35,6 +35,7 @@ bool Alternate_chaining_behavior;
 bool Fixed_chaining_to_repeat;
 bool Use_host_orientation_for_set_camera_facing;
 bool Use_model_eyepoint_for_set_camera_host;
+bool Use_model_eyepoint_normals;
 bool Always_show_directive_value_count;
 bool Use_3d_ship_select;
 bool Use_3d_ship_icons;
@@ -519,6 +520,15 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Use_model_eyepoint_for_set_camera_host);
 				if (Use_model_eyepoint_for_set_camera_host)
 					mprintf(("Game Settings Table: Use model eyepoint for set-camera-host\n"));
+			}
+
+			if (optional_string("$Use model eyepoint normals:"))
+			{
+				stuff_boolean(&Use_model_eyepoint_normals);
+				if (Use_model_eyepoint_normals)
+					mprintf(("Game Settings Table: Model eyepoints will respect eyepoint normals\n"));
+				else
+					mprintf(("Game Settings Table: Model eyepoints will use the model's orientation\n"));
 			}
 
 			if (optional_string("$Show-subtitle uses pixels:")) {
@@ -1586,6 +1596,7 @@ void mod_table_reset()
 	Fixed_chaining_to_repeat = false;
 	Use_host_orientation_for_set_camera_facing = false;
 	Use_model_eyepoint_for_set_camera_host = false;
+	Use_model_eyepoint_normals = false;
 	Always_show_directive_value_count = false;
 	Default_ship_select_effect = 2;
 	Default_weapon_select_effect = 2;
@@ -1745,6 +1756,7 @@ void mod_table_set_version_flags()
 	}
 	if (mod_supports_version(25, 0, 0)) {
 		Use_model_eyepoint_for_set_camera_host = true;
+		Use_model_eyepoint_normals = true;
 		Fix_asteroid_bounding_box_check = true;
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -49,6 +49,7 @@ extern bool Alternate_chaining_behavior;
 extern bool Fixed_chaining_to_repeat;
 extern bool Use_host_orientation_for_set_camera_facing;
 extern bool Use_model_eyepoint_for_set_camera_host;
+extern bool Use_model_eyepoint_normals;
 extern bool Always_show_directive_value_count;
 extern bool Use_3d_ship_select;
 extern int Default_ship_select_effect;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15195,9 +15195,15 @@ void object_get_eye(vec3d *eye_pos, matrix *eye_orient, const object *obj, bool 
 	// eye points are stored in an array -- the normal viewing position for a ship is the current_eye_index (now current_viewpoint) element.
 	auto &ep = pm->view_positions[current_viewpoint];
 
-	matrix eye_local_orient;
-	vm_vector_2_matrix_norm(&eye_local_orient, &ep.norm);
-	model_instance_local_to_global_point_orient(eye_pos, eye_orient, &ep.pnt, &eye_local_orient, pm, pmi, ep.parent, local_orient ? &vmd_identity_matrix : &obj->orient, local_pos ? &vmd_zero_vector : &obj->pos);
+	matrix eye_local_orient_buf;
+	const matrix *eye_local_orient;
+	if (Use_model_eyepoint_normals) {
+		vm_vector_2_matrix_norm(&eye_local_orient_buf, &ep.norm);
+		eye_local_orient = &eye_local_orient_buf;
+	} else {
+		eye_local_orient = &vmd_identity_matrix;
+	}
+	model_instance_local_to_global_point_orient(eye_pos, eye_orient, &ep.pnt, eye_local_orient, pm, pmi, ep.parent, local_orient ? &vmd_identity_matrix : &obj->orient, local_pos ? &vmd_zero_vector : &obj->pos);
 
 	//	Modify the orientation based on head orientation.
 	if (Viewer_obj == obj && do_slew) {


### PR DESCRIPTION
PR #6598 caused eyepoint normals to be used for viewing direction, whereas previously the host object's orientation was used for viewing direction.  Since this could cause compatibility issues, return to the previous behavior and make the new behavior depend on a flag that is set in post-25.0 builds.  (This only applies to eyepoint normals; eyepoint *positions* were respected both before and after #6598).