### PR TITLE
Fix for 2d mission camera

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3159,7 +3159,7 @@ camid game_render_frame_setup()
 	//These replace the normal player in-cockpit view with a topdown view.
 	if(The_mission.flags[Mission::Mission_Flags::Mission_2d])
 	{
-		if(!Viewer_mode)
+		if(!(Viewer_mode & ~VM_CAMERA_LOCKED))
 		{
 			Viewer_mode = VM_TOPDOWN;
 		}


### PR DESCRIPTION
`VM_CAMERA_LOCKED` is true by default (i.e. primary controls move the ship, not the camera), and so should not be considered 'special' and kick the player out of top down mode. Fixes #6485 