### PR TITLE
Allow Trigger Radius curve input to work with muzzle effects

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2019,6 +2019,7 @@ bool turret_fire_weapon(int weapon_num, ship_subsys *turret, int parent_objnum, 
 						//spawn particle effect
 						auto particleSource = particle::ParticleManager::get()->createSource(wip->muzzle_effect);
 						particleSource->setHost(make_unique<EffectHostTurret>(&Objects[parent_ship->objnum], turret->system_info->turret_gun_sobj, turret->turret_next_fire_pos));
+						particleSource->setTriggerRadius(objp->radius);
 						particleSource->finishCreation();
 					}
 					else if (wip->muzzle_flash >= 0) {
@@ -2135,6 +2136,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 			//spawn particle effect
 			auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[tsi->weapon_class].muzzle_effect);
 			particleSource->setHost(make_unique<EffectHostTurret>(&Objects[tsi->parent_objnum], tsi->turret->system_info->turret_gun_sobj, tsi->turret->turret_next_fire_pos - 1));
+			particleSource->setTriggerRadius(Objects[weapon_objnum].radius);
 			particleSource->finishCreation();
 		}
 		else if (Weapon_info[tsi->weapon_class].muzzle_flash >= 0) {

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1066,6 +1066,16 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 				auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[weapon_info_index].muzzle_effect);
 				//This should probably end up attached to the subobject, not the object, but it's not that much of a problem since primaries / secondaries rarely move.
 				particleSource->setHost(make_unique<EffectHostObject>(objp, *gun_pos, gunOrient, true));
+
+				// set radius manually following logic in weapon_create function --wookieejedi
+				if (Weapon_info[weapon_info_index].collision_radius_override > 0.0f)
+					particleSource->setTriggerRadius(Weapon_info[weapon_info_index].collision_radius_override);
+				else if (Weapon_info[weapon_info_index].render_type == WRT_POF) {
+					particleSource->setTriggerRadius(model_get_radius(Weapon_info[weapon_info_index].model_num));
+				} else if (Weapon_info[weapon_info_index].render_type == WRT_LASER) {
+					particleSource->setTriggerRadius(Weapon_info[weapon_info_index].laser_head_radius);
+				}
+
 				particleSource->finishCreation();
 			// if there's a muzzle flash entry and no muzzle effect entry, we use the mflash
 			} else if (Weapon_info[weapon_info_index].muzzle_flash >= 0) {


### PR DESCRIPTION
The Input of `Trigger Radius` for curves within new particle effects was never hooked up for muzzle flashes, so this PR adds in the necessary lines to get it working. This allows modders to make a muzzle effect that can scale to the weapon radius through curves, and thus modders can simply make one curve scaled muzzle flash and avoid making a many muzzle flashes for each sized weapon that uses the same base effect.

Tested and works as expected.