### PR TITLE
Fix Vulkan build issues, enable Vulkan build in CI

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -21,7 +21,7 @@ jobs:
             arch: arm64
     name: Linux
     runs-on: ${{ matrix.os }}
-    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
+    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -50,7 +50,7 @@ jobs:
     name: Linux
     needs: create_release   # Don't run this job until create_release is done and successful
     runs-on: ${{ matrix.os }}
-    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
+    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
       - uses: actions/checkout@v1
         # checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -15,7 +15,7 @@ jobs:
         configuration: [FastDebug, Release]
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
+    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -25,7 +25,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
+    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -20,6 +20,12 @@ jobs:
           - configuration: Release
             compiler: gcc-13
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
+          - configuration: Debug
+            compiler: gcc-13
+            cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=ON
+          - configuration: Release
+            compiler: gcc-13
+            cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=ON
     name: Linux
     runs-on: ubuntu-latest
     container: ghcr.io/scp-fs2open/linux_build:sha-71099c9

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -22,7 +22,7 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
+    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
       - uses: actions/checkout@v1
         name: Checkout

--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Build FSO With Coverity Wrapper
     if: github.repository == 'scp-fs2open/fs2open.github.com'
     runs-on: ${{ matrix.config.os }}
-    container: ghcr.io/scp-fs2open/linux_build:sha-1ff82e8
+    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     strategy:
       fail-fast: false
       matrix:

--- a/ci/linux/clang_tidy.sh
+++ b/ci/linux/clang_tidy.sh
@@ -18,8 +18,13 @@ fi
 # branch
 BASE_COMMIT=$(git merge-base $1 $2)
 
+# Note: Manually passing in the Vulkan flags that are normally provided by cmake (but are not so, here), to ensure
+# that the source files are checked with the actual configuration used.
 echo "Running clang-tidy on changed files"
 git diff -U0 --no-color "$BASE_COMMIT..$2" | \
     $HERE/clang-tidy-diff.py -path "$(pwd)/build" -p1 \
+    -extra-arg="-DWITH_VULKAN" \
+    -extra-arg="-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1" \
+    -extra-arg="-DVK_NO_PROTOTYPES" \
     -regex '(code(?!((\/graphics\/shaders\/compiled)|(\/globalincs\/windebug)))|freespace2|qtfred|test|build|tools)\/.*\.(cpp|h)' \
     -clang-tidy-binary /usr/bin/clang-tidy-16 -j$(nproc) -export-fixes "$(pwd)/clang-fixes.yaml"

--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -581,7 +581,8 @@ bool VulkanRenderer::createSwapChain(const PhysicalDeviceValues& deviceValues)
 
 	m_swapChain = m_device->createSwapchainKHRUnique(createInfo);
 
-	m_swapChainImages = m_device->getSwapchainImagesKHR(m_swapChain.get());
+	std::vector<vk::Image> swapChainImages = m_device->getSwapchainImagesKHR(m_swapChain.get());
+	m_swapChainImages = SCP_vector<vk::Image>(swapChainImages.begin(), swapChainImages.end());
 	m_swapChainImageFormat = surfaceFormat.format;
 	m_swapChainExtent = createInfo.imageExtent;
 


### PR DESCRIPTION
In 133b033ea0083c7c8115ee4b55c3e4abc063ee63, `SCP_vector` was made into a subclass, so direct assignment from the vulkan-hpp result isn't possible anymore. Use an intermediate vector.