### PR TITLE
Lab asteroid viewer

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2241,7 +2241,7 @@ static void asteroid_parse_section()
 	auto insert_or_replace_subtype_pof = [](SCP_vector<asteroid_subtype_info>& subtypes, const asteroid_subtype_info& new_subtype) {
 		for (auto& subtype : subtypes) {
 			if (lcase_equal(subtype.type_name, new_subtype.type_name)) {
-				strncpy(subtype.pof_filename, new_subtype.pof_filename, MAX_FILENAME_LEN);
+				strcpy_s(subtype.pof_filename, new_subtype.pof_filename);
 				return;
 			}
 		}

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -14,6 +14,7 @@
 
 #include "globalincs/globals.h"		// for NAME_LENGTH
 #include "globalincs/pstypes.h"
+#include "object/object_flags.h"
 #include "io/timer.h"
 
 class object;
@@ -102,6 +103,7 @@ public:
 
 typedef	struct asteroid {
 	int		flags;
+	flagset<Object::Raw_Pof_Flags> render_flags; // Render flags
 	int		objnum;
 	int		model_instance_num;
 	int		asteroid_type;		// 0..MAX_DEBRIS_TYPES
@@ -178,6 +180,9 @@ void	asteroid_target_closest_danger();
 void asteroid_add_target(object* objp);
 int get_asteroid_index(const char* asteroid_name);
 SCP_vector<SCP_string> get_list_valid_asteroid_subtypes();
+
+// extern for the lab
+void asteroid_load(int asteroid_info_index, int asteroid_subtype);
 
 // need to extern for keycontrol debug commands
 object *asteroid_create(asteroid_field *asfieldp, int asteroid_type, int asteroid_subtype, bool check_visibility = false);

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -115,7 +115,7 @@ void LabUi::build_asteroid_list()
 					subtype.type_name.c_str());
 
 				if (IsItemClicked() && !IsItemToggledOpen()) {
-					getLabManager()->changeDisplayedObject(LabMode::Object, asteroid_idx, subtype_idx);
+					getLabManager()->changeDisplayedObject(LabMode::Asteroid, asteroid_idx, subtype_idx);
 				}
 
 				subtype_idx++;
@@ -149,7 +149,7 @@ void LabUi::build_debris_list()
 					subtype.type_name.c_str());
 
 				if (IsItemClicked() && !IsItemToggledOpen()) {
-					getLabManager()->changeDisplayedObject(LabMode::Object, debris_idx, subtype_idx);
+					getLabManager()->changeDisplayedObject(LabMode::Asteroid, debris_idx, subtype_idx);
 				}
 
 				subtype_idx++;
@@ -424,7 +424,7 @@ void LabUi::show_render_options()
 				Checkbox("Rotate/Translate Subsystems", &animate_subsystems);
 			}
 			Checkbox("Show full detail", &show_full_detail);
-			if (getLabManager()->CurrentMode != LabMode::Object) {
+			if (getLabManager()->CurrentMode != LabMode::Asteroid) {
 				Checkbox("Show thrusters", &show_thrusters);
 				if (getLabManager()->CurrentMode == LabMode::Ship) {
 					Checkbox("Show afterburners", &show_afterburners);
@@ -1266,7 +1266,7 @@ void LabUi::show_object_options() const
 					}
 				}
 			}
-		} else if (getLabManager()->CurrentMode == LabMode::Object && getLabManager()->CurrentClass >= 0) {
+		} else if (getLabManager()->CurrentMode == LabMode::Asteroid && getLabManager()->CurrentClass >= 0) {
 			const auto& info = Asteroid_info[getLabManager()->CurrentClass];
 
 			with_CollapsingHeader("Object Info")

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -170,7 +170,7 @@ void LabUi::build_weapon_list() const
 
 void LabUi::build_object_list()
 {
-	with_TreeNode("Object Classes")
+	with_TreeNode("Asteroid/Debris Types")
 	{
 		build_asteroid_list();
 		build_debris_list();

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -3,6 +3,7 @@
 
 #include "lab_ui_helpers.h"
 
+#include "asteroid/asteroid.h"
 #include "graphics/debug_sphere.h"
 #include "graphics/matrix.h"
 #include "lab/labv2_internal.h"
@@ -91,13 +92,88 @@ void LabUi::build_weapon_subtype_list() const
 	}
 }
 
+void LabUi::build_asteroid_list()
+{
+	with_TreeNode("Asteroids")
+	{
+		int asteroid_idx = 0;
+
+		for (const auto& info : Asteroid_info) {
+			if (info.type == ASTEROID_TYPE_DEBRIS) {
+				asteroid_idx++;
+				continue;
+			}
+
+			int subtype_idx = 0;
+			for (const auto& subtype : info.subtypes) {
+				SCP_string node_label;
+				sprintf(node_label, "##AsteroidClassIndex%i_%i", asteroid_idx, subtype_idx);
+				TreeNodeEx(node_label.c_str(),
+					ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen,
+					"%s (%s)",
+					info.name,
+					subtype.type_name.c_str());
+
+				if (IsItemClicked() && !IsItemToggledOpen()) {
+					getLabManager()->changeDisplayedObject(LabMode::Object, asteroid_idx, subtype_idx);
+				}
+
+				subtype_idx++;
+			}
+
+			asteroid_idx++;
+		}
+	}
+}
+
+void LabUi::build_debris_list()
+{
+	with_TreeNode("Debris")
+	{
+		int debris_idx = 0;
+
+		for (const auto& info : Asteroid_info) {
+			if (info.type != ASTEROID_TYPE_DEBRIS) {
+				debris_idx++;
+				continue;
+			}
+
+			int subtype_idx = 0;
+			for (const auto& subtype : info.subtypes) {
+				SCP_string node_label;
+				sprintf(node_label, "##DebrisClassIndex%i_%i", debris_idx, subtype_idx);
+				TreeNodeEx(node_label.c_str(),
+					ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen,
+					"%s (%s)",
+					info.name,
+					subtype.type_name.c_str());
+
+				if (IsItemClicked() && !IsItemToggledOpen()) {
+					getLabManager()->changeDisplayedObject(LabMode::Object, debris_idx, subtype_idx);
+				}
+
+				subtype_idx++;
+			}
+
+			debris_idx++;
+		}
+	}
+}
+
 void LabUi::build_weapon_list() const
 {
-	//weapon display needs to be rethought
-
 	with_TreeNode("Weapon Classes")
 	{
 		build_weapon_subtype_list();
+	}
+}
+
+void LabUi::build_object_list()
+{
+	with_TreeNode("Object Classes")
+	{
+		build_asteroid_list();
+		build_debris_list();
 	}
 }
 
@@ -201,6 +277,8 @@ void LabUi::show_object_selector() const
 			build_ship_list();
 
 			build_weapon_list();
+
+			build_object_list();
 		}
 	}
 }
@@ -346,12 +424,14 @@ void LabUi::show_render_options()
 				Checkbox("Rotate/Translate Subsystems", &animate_subsystems);
 			}
 			Checkbox("Show full detail", &show_full_detail);
-			Checkbox("Show thrusters", &show_thrusters);
-			if (getLabManager()->CurrentMode == LabMode::Ship) {
-				Checkbox("Show afterburners", &show_afterburners);
-				Checkbox("Show weapons", &show_weapons);
-				Checkbox("Show Insignia", &show_insignia);
-				Checkbox("Show damage lightning", &show_damage_lightning);
+			if (getLabManager()->CurrentMode != LabMode::Object) {
+				Checkbox("Show thrusters", &show_thrusters);
+				if (getLabManager()->CurrentMode == LabMode::Ship) {
+					Checkbox("Show afterburners", &show_afterburners);
+					Checkbox("Show weapons", &show_weapons);
+					Checkbox("Show Insignia", &show_insignia);
+					Checkbox("Show damage lightning", &show_damage_lightning);
+				}
 			}
 			Checkbox("No glowpoints", &no_glowpoints);
 		}
@@ -1183,6 +1263,44 @@ void LabUi::show_object_options() const
 				if (VALID_FNAME(wip->tech_model)) {
 					if (Checkbox("Show Tech Model", &getLabManager()->ShowingTechModel)) {
 						getLabManager()->changeDisplayedObject(LabMode::Weapon, getLabManager()->CurrentClass);
+					}
+				}
+			}
+		} else if (getLabManager()->CurrentMode == LabMode::Object && getLabManager()->CurrentClass >= 0) {
+			const auto& info = Asteroid_info[getLabManager()->CurrentClass];
+
+			with_CollapsingHeader("Object Info")
+			{
+				static SCP_string table_text;
+				static int old_class = -1;
+
+				if (table_text.empty() || old_class != getLabManager()->CurrentClass) {
+					table_text = get_asteroid_table_text(&info);
+					old_class = getLabManager()->CurrentClass;
+				}
+
+				InputTextMultiline("##asteroid_table_text",
+					const_cast<char*>(table_text.c_str()),
+					table_text.length(),
+					ImVec2(-FLT_MIN, GetTextLineHeight() * 16),
+					ImGuiInputTextFlags_ReadOnly);
+			}
+
+			with_CollapsingHeader("Object actions")
+			{
+				if (getLabManager()->isSafeForAsteroids()) {
+					if (Button("Destroy object")) {
+						if (Objects[getLabManager()->CurrentObject].type == OBJ_ASTEROID) {
+							auto obj = &Objects[getLabManager()->CurrentObject];
+
+							if (obj->type == OBJ_ASTEROID) {
+								vec3d dummy_pos = obj->pos;
+								vec3d dummy_force = ZERO_VECTOR;
+
+								// Apply full asteroid health to guarantee destruction
+								asteroid_hit(obj, nullptr, &dummy_pos, obj->hull_strength + 1.0f, &dummy_force);
+							}
+						}
 					}
 				}
 			}

--- a/code/lab/dialogs/lab_ui.h
+++ b/code/lab/dialogs/lab_ui.h
@@ -24,6 +24,9 @@ class LabUi {
 	void build_species_entry(const species_info &species_def, int species_idx) const;
 	void build_weapon_list() const;
 	void build_weapon_subtype_list() const;
+	static void build_object_list();
+	static void build_asteroid_list();
+	static void build_debris_list();
 	void build_background_list() const;
 	void show_render_options();
 	void show_object_options() const;

--- a/code/lab/dialogs/lab_ui_helpers.cpp
+++ b/code/lab/dialogs/lab_ui_helpers.cpp
@@ -257,6 +257,128 @@ SCP_string get_weapon_table_text(weapon_info* wip)
 	return result;
 }
 
+SCP_string get_asteroid_table_text(const asteroid_info* aip)
+{
+	char line[256], line2[256], file_text[82];
+	int i, j, n, found = 0, comment = 0, num_files = 0;
+	SCP_vector<SCP_string> tbl_file_names;
+	SCP_string result;
+
+	auto fp = cfopen("asteroid.tbl", "r");
+	if (!fp)
+		return "No asteroids.tbl found.\r\n";
+
+	while (cfgets(line, 255, fp)) {
+		while (line[strlen(line) - 1] == '\n')
+			line[strlen(line) - 1] = 0;
+
+		for (i = j = 0; line[i]; i++) {
+			if (line[i] == '/' && line[i + 1] == '/')
+				break;
+			if (line[i] == '/' && line[i + 1] == '*') {
+				comment = 1;
+				i++;
+				continue;
+			}
+			if (line[i] == '*' && line[i + 1] == '/') {
+				comment = 0;
+				i++;
+				continue;
+			}
+			if (!comment)
+				line2[j++] = line[i];
+		}
+
+		line2[j] = 0;
+		if (!strnicmp(line2, "$Name:", 6)) {
+			drop_trailing_white_space(line2);
+			found = 0;
+			i = 6;
+
+			while (line2[i] == ' ' || line2[i] == '\t' || line2[i] == '@')
+				i++;
+
+			if (!stricmp(line2 + i, aip->name)) {
+				result += "-- asteroid.tbl -------------------------------\r\n";
+				found = 1;
+			}
+		}
+
+		if (found) {
+			result += line;
+			result += "\r\n";
+		}
+	}
+
+	cfclose(fp);
+
+	num_files = cf_get_file_list(tbl_file_names, CF_TYPE_TABLES, NOX("*-ast.tbm"), CF_SORT_REVERSE);
+
+	for (n = 0; n < num_files; n++) {
+		tbl_file_names[n] += ".tbm";
+
+		fp = cfopen(tbl_file_names[n].c_str(), "r");
+		if (!fp)
+			continue;
+
+		memset(line, 0, sizeof(line));
+		memset(line2, 0, sizeof(line2));
+		found = 0;
+		comment = 0;
+
+		while (cfgets(line, 255, fp)) {
+			while (line[strlen(line) - 1] == '\n')
+				line[strlen(line) - 1] = 0;
+
+			for (i = j = 0; line[i]; i++) {
+				if (line[i] == '/' && line[i + 1] == '/')
+					break;
+				if (line[i] == '/' && line[i + 1] == '*') {
+					comment = 1;
+					i++;
+					continue;
+				}
+				if (line[i] == '*' && line[i + 1] == '/') {
+					comment = 0;
+					i++;
+					continue;
+				}
+				if (!comment)
+					line2[j++] = line[i];
+			}
+
+			line2[j] = 0;
+			if (!strnicmp(line2, "$Name:", 6)) {
+				drop_trailing_white_space(line2);
+				found = 0;
+				i = 6;
+
+				while (line2[i] == ' ' || line2[i] == '\t' || line2[i] == '@')
+					i++;
+
+				if (!stricmp(line2 + i, aip->name)) {
+					memset(file_text, 0, sizeof(file_text));
+					snprintf(file_text,
+						sizeof(file_text) - 1,
+						"--  %s  -------------------------------\r\n",
+						tbl_file_names[n].c_str());
+					result += file_text;
+					found = 1;
+				}
+			}
+
+			if (found) {
+				result += line;
+				result += "\r\n";
+			}
+		}
+
+		cfclose(fp);
+	}
+
+	return result;
+}
+
 SCP_string get_directory_or_vp(const char* path)
 {
 	SCP_string result(path);

--- a/code/lab/dialogs/lab_ui_helpers.h
+++ b/code/lab/dialogs/lab_ui_helpers.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include "asteroid/asteroid.h"
 #include "ship/ship.h"
 
 SCP_string get_ship_table_text(ship_info* sip);
 
 SCP_string get_weapon_table_text(weapon_info* wip);
+
+SCP_string get_asteroid_table_text(const asteroid_info* aip);
 
 SCP_string get_directory_or_vp(const char* path);
 

--- a/code/lab/labv2.h
+++ b/code/lab/labv2.h
@@ -1,7 +1,7 @@
 #pragma once
 
 enum class LabMode {
-	Object,
+	Asteroid,
 	Ship,
 	Weapon,
 	None

--- a/code/lab/labv2.h
+++ b/code/lab/labv2.h
@@ -1,6 +1,7 @@
 #pragma once
 
 enum class LabMode {
+	Object,
 	Ship,
 	Weapon,
 	None

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -2,7 +2,6 @@
 #include "lab/manager/lab_manager.h"
 #include "lab/renderer/lab_renderer.h"
 #include "io/key.h"
-#include "asteroid/asteroid.h"
 #include "math/staticrand.h"
 #include "missionui/missionscreencommon.h"
 #include "object/object.h"
@@ -17,7 +16,6 @@
 
 #include "extensions/ImGuizmo.h"
 #include "io/mouse.h"
-#include "weapon/weapon.h"
 
 //Turret firing forward declarations
 void ai_turret_execute_behavior(const ship* shipp, ship_subsys* ss);
@@ -382,6 +380,7 @@ void LabManager::cleanup() {
 		// Reset lab variables
 		CurrentMode = LabMode::None;
 		CurrentObject = -1;
+		CurrentSubtype = -1;
 		CurrentClass = -1;
 		CurrentPosition = vmd_zero_vector;
 		CurrentOrientation = vmd_identity_matrix;
@@ -389,7 +388,7 @@ void LabManager::cleanup() {
 	}
 }
 
-void LabManager::changeDisplayedObject(LabMode mode, int info_index) {
+void LabManager::changeDisplayedObject(LabMode mode, int info_index, int subtype) {
 	// Removing this allows reseting by clicking on the object again,
 	// making it easier to respawn destroyed objects
 	// If this is re-enabled then it will need to be modified so that
@@ -411,6 +410,9 @@ void LabManager::changeDisplayedObject(LabMode mode, int info_index) {
 
 	CurrentMode = mode;
 	CurrentClass = info_index;
+
+	if (CurrentMode == LabMode::Object)
+		CurrentSubtype = subtype;
 
 	switch (CurrentMode) {
 	case LabMode::Ship:
@@ -453,6 +455,24 @@ void LabManager::changeDisplayedObject(LabMode mode, int info_index) {
 			}
 		}
 		break;
+	case LabMode::Object: {
+		// Ensure model is loaded before creating asteroid
+		asteroid_load(CurrentClass, CurrentSubtype);
+		object* objp = asteroid_create(&Asteroid_field, CurrentClass, CurrentSubtype, false);
+		if (objp != nullptr) {
+			CurrentObject = OBJ_INDEX(objp);
+
+			// Zero out asteroid velocity
+			vm_vec_zero(&objp->phys_info.rotvel);
+			vm_vec_zero(&objp->phys_info.desired_rotvel);
+			objp->flags.remove(Object::Object_Flags::Physics);
+		} else {
+			CurrentObject = -1;
+			mprintf(("LabManager: Failed to create asteroid for index %d, subtype %d\n", CurrentClass, CurrentSubtype));
+		}
+
+		break;
+	}
 	default:
 		UNREACHABLE("Unhandled lab mode %d", (int)mode);
 		ModelFilename = "";

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -411,7 +411,7 @@ void LabManager::changeDisplayedObject(LabMode mode, int info_index, int subtype
 	CurrentMode = mode;
 	CurrentClass = info_index;
 
-	if (CurrentMode == LabMode::Object)
+	if (CurrentMode == LabMode::Asteroid)
 		CurrentSubtype = subtype;
 
 	switch (CurrentMode) {
@@ -455,7 +455,7 @@ void LabManager::changeDisplayedObject(LabMode mode, int info_index, int subtype
 			}
 		}
 		break;
-	case LabMode::Object: {
+	case LabMode::Asteroid: {
 		// Ensure model is loaded before creating asteroid
 		asteroid_load(CurrentClass, CurrentSubtype);
 		object* objp = asteroid_create(&Asteroid_field, CurrentClass, CurrentSubtype, false);

--- a/code/lab/manager/lab_manager.h
+++ b/code/lab/manager/lab_manager.h
@@ -71,12 +71,12 @@ public:
 	}
 
 	bool isSafeForWeapons() {
-		bool valid = (Objects[CurrentObject].type == OBJ_WEAPON || Objects[CurrentObject].type == OBJ_BEAM);
-		return CurrentMode == LabMode::Weapon && CurrentObject != -1 && valid;
+		bool valid = CurrentObject != -1 && (Objects[CurrentObject].type == OBJ_WEAPON || Objects[CurrentObject].type == OBJ_BEAM);
+		return CurrentMode == LabMode::Weapon && valid;
 	}
 
 	bool isSafeForAsteroids() const {
-		return CurrentMode == LabMode::Object && CurrentObject != -1 && Objects[CurrentObject].type == OBJ_ASTEROID;
+		return CurrentMode == LabMode::Asteroid && CurrentObject != -1 && Objects[CurrentObject].type == OBJ_ASTEROID;
 	}
 
 	void loadWeapons() {

--- a/code/lab/manager/lab_manager.h
+++ b/code/lab/manager/lab_manager.h
@@ -8,7 +8,9 @@
 
 #include <gamesequence/gamesequence.h>
 #include "osapi/osapi.h"
+#include "asteroid/asteroid.h"
 #include "ship/ship.h"
+#include "weapon/weapon.h"
 
 
 enum class LabRotationMode { Both, Yaw, Pitch, Roll };
@@ -32,7 +34,7 @@ public:
 	
 	// Creates a new object of the passed type, using the respective class definition found at info_index and replaces the currently
 	// displayed object
-	void changeDisplayedObject(LabMode type, int info_index);
+	void changeDisplayedObject(LabMode type, int info_index, int subtype = -1);
 
 	void close() {
 		animation::ModelAnimationSet::stopAnimations();
@@ -40,6 +42,12 @@ public:
 		cleanup();
 
 		LabRenderer::close();
+
+		// Unload any asteroids that were loaded
+		asteroid_level_close();
+
+		// Lab can only be entered from the Mainhall so this should be safe
+		model_free_all();
 
 		Game_mode &= ~GM_LAB;
 
@@ -52,17 +60,23 @@ public:
 
 	LabMode CurrentMode = LabMode::None;
 	int CurrentObject = -1;
+	int CurrentSubtype = -1;
 	int CurrentClass = -1;
 	vec3d CurrentPosition = vmd_zero_vector;
 	matrix CurrentOrientation = vmd_identity_matrix;
 	SCP_string ModelFilename;	
 
 	bool isSafeForShips() {
-		return CurrentMode == LabMode::Ship && CurrentObject != -1;
+		return CurrentMode == LabMode::Ship && CurrentObject != -1 && Objects[CurrentObject].type == OBJ_SHIP;
 	}
 
 	bool isSafeForWeapons() {
-		return CurrentMode == LabMode::Weapon && CurrentObject != -1;
+		bool valid = (Objects[CurrentObject].type == OBJ_WEAPON || Objects[CurrentObject].type == OBJ_BEAM);
+		return CurrentMode == LabMode::Weapon && CurrentObject != -1 && valid;
+	}
+
+	bool isSafeForAsteroids() const {
+		return CurrentMode == LabMode::Object && CurrentObject != -1 && Objects[CurrentObject].type == OBJ_ASTEROID;
 	}
 
 	void loadWeapons() {

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -1,4 +1,5 @@
 #include "freespace.h"
+#include "asteroid/asteroid.h"
 #include "globalincs/vmallocator.h"
 #include "graphics/2d.h"
 #include "graphics/light.h"
@@ -74,8 +75,8 @@ void LabRenderer::renderModel(float frametime) {
 
 	object* obj = &Objects[getLabManager()->CurrentObject];
 
-	// Ships stay put. Weapons are allowed to move so particle effects look correct
-	if (obj->type == OBJ_SHIP) {
+	// Ships && Objects stay put. Weapons are allowed to move so particle effects look correct
+	if (obj->type == OBJ_SHIP || obj->type == OBJ_ASTEROID) {
 		obj->pos = getLabManager()->CurrentPosition;
 	}
 	obj->orient = getLabManager()->CurrentOrientation;
@@ -137,6 +138,20 @@ void LabRenderer::renderModel(float frametime) {
 		Pof_objects[obj->instance].flags.set(Object::Raw_Pof_Flags::Render_without_reflectmap, renderFlags[LabRenderFlag::NoReflectMap]);
 		Pof_objects[obj->instance].flags.set(Object::Raw_Pof_Flags::Render_without_heightmap, renderFlags[LabRenderFlag::NoHeightMap]);
 		Pof_objects[obj->instance].flags.set(Object::Raw_Pof_Flags::Render_without_ambientmap, renderFlags[LabRenderFlag::NoAOMap]);
+	}
+
+	if (obj->type == OBJ_ASTEROID) {
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Draw_as_wireframe, renderFlags[LabRenderFlag::ShowWireframe]);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_full_detail, renderFlags[LabRenderFlag::ShowFullDetail]);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_without_light,
+			renderFlags[LabRenderFlag::NoLighting] || currentMissionBackground == LAB_MISSION_NONE_STRING);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_without_diffuse, renderFlags[LabRenderFlag::NoDiffuseMap]);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_without_glowmap, renderFlags[LabRenderFlag::NoGlowMap]);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_without_normalmap, renderFlags[LabRenderFlag::NoNormalMap]);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_without_specmap, renderFlags[LabRenderFlag::NoSpecularMap]);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_without_reflectmap, renderFlags[LabRenderFlag::NoReflectMap]);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_without_heightmap, renderFlags[LabRenderFlag::NoHeightMap]);
+		Asteroids[obj->instance].render_flags.set(Object::Raw_Pof_Flags::Render_without_ambientmap, renderFlags[LabRenderFlag::NoAOMap]);
 	}
 
 	if (renderFlags[LabRenderFlag::ShowWireframe])


### PR DESCRIPTION
Adds the ability to view asteroids/debris in the F3 lab. Depends on #6704 but wanted to get it up so that it can be accounted for heading into RC.

I should say this includes a small fix to an asteroid parsing bug I found to prevent duplicate asteroids from being created as asteroid subtypes.