### PR TITLE
Small fix for turret swarm stuff

### DIFF
--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -337,7 +337,6 @@ void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weap
 	if(!no_tracking_object && ((turret->turret_enemy_objnum < 0) || (turret->turret_enemy_objnum >= MAX_OBJECTS))){
 		return;
 	}
-	target_obj = &Objects[turret->turret_enemy_objnum];
 
 	// valid swarm weapon
 	Assert(((wip->wi_flags[Weapon::Info_Flags::Swarm]) && (wip->swarm_count > 0)) || ((wip->wi_flags[Weapon::Info_Flags::Corkscrew]) && (wip->cs_num_fired > 0)));
@@ -399,7 +398,7 @@ void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weap
 	tsi->parent_objnum = parent_objnum;
 	tsi->parent_sig    = parent_obj->signature;
 	tsi->target_objnum = turret->turret_enemy_objnum;
-	tsi->target_sig    = target_obj->signature;
+	tsi->target_sig    = turret->turret_enemy_objnum >= 0 ? Objects[turret->turret_enemy_objnum].signature : 0;
 	tsi->turret = turret;
 	tsi->target_subsys = turret->targeted_subsys;
 	tsi->time_to_fire = 1;	// first missile next frame

--- a/code/weapon/swarm.cpp
+++ b/code/weapon/swarm.cpp
@@ -312,7 +312,7 @@ void turret_swarm_delete(int i)
 void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weapon_info *wip, int weapon_num, bool no_tracking_object)
 {
 	turret_swarm_info	*tsi;
-	object *parent_obj, *target_obj;
+	object *parent_obj;
 	ship *shipp;
 	int tsi_index;
 
@@ -334,9 +334,10 @@ void turret_swarm_set_up_info(int parent_objnum, ship_subsys *turret, const weap
 	Assert(parent_obj->type == OBJ_SHIP);
 	shipp = &Ships[parent_obj->instance];
 	Assert(turret->turret_enemy_objnum < MAX_OBJECTS);
-	if(!no_tracking_object && ((turret->turret_enemy_objnum < 0) || (turret->turret_enemy_objnum >= MAX_OBJECTS))){
+	if (turret->turret_enemy_objnum < 0 && !no_tracking_object)
 		return;
-	}
+	if (turret->turret_enemy_objnum >= MAX_OBJECTS)
+		return;
 
 	// valid swarm weapon
 	Assert(((wip->wi_flags[Weapon::Info_Flags::Swarm]) && (wip->swarm_count > 0)) || ((wip->wi_flags[Weapon::Info_Flags::Corkscrew]) && (wip->cs_num_fired > 0)));


### PR DESCRIPTION
Missed this in #6703. If there is no target (in the `no_tracking_object` case), don't make a pointer and try to get the signature. In terms of final behavior it's still fine because it only ever checks the signature if it actually has a >= 0 `enemy_objnum`