### PR TITLE
Fix highlighting color discrepancy for player ship in loadout screen

### DIFF
--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -283,7 +283,6 @@ void common_buttons_init(UI_WINDOW *ui_window)
 	if ( brief_only_allow_briefing() ) {
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_SS_REGION].button.disable();
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_REGION].button.disable();
-		ui_window->add_XSTR("Ships/Weapons Locked", 749, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].xt, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].yt + 30, &Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].button, UI_XSTR_COLOR_GREEN);
 	}
 }
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -283,6 +283,7 @@ void common_buttons_init(UI_WINDOW *ui_window)
 	if ( brief_only_allow_briefing() ) {
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_SS_REGION].button.disable();
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_REGION].button.disable();
+		ui_window->add_XSTR("Ships/Weapons Locked", 749, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].xt, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].yt + 30, &Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].button, UI_XSTR_COLOR_GREEN);
 	}
 }
 

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1475,7 +1475,7 @@ void ship_select_do(float frametime)
 
 		draw_ship_icons();
 		for ( int i = 0; i < MAX_WING_BLOCKS; i++ ) {
-			draw_wing_block(i, Hot_ss_slot, -1, Selected_ss_class);
+			draw_wing_block(i, Hot_ss_slot, -1, Selected_ss_class, true, false);
 		}		
 	}
 	
@@ -2142,7 +2142,7 @@ void pick_from_wing(int wb_num, int ws_num)
 //				hot_slot	=>		index of slot that mouse is over
 //				selected_slot	=>	index of slot that is selected
 //				class_select	=>	all ships of this class are drawn selected (send -1 to not use)
-void draw_wing_block(int wb_num, int hot_slot, int selected_slot, int class_select, bool ship_selection )
+void draw_wing_block(int wb_num, int hot_slot, int selected_slot, int class_select, bool ship_selection, bool always_highlight_ply )
 {
 	GR_DEBUG_SCOPE("Wing block");
 
@@ -2259,7 +2259,7 @@ void draw_wing_block(int wb_num, int hot_slot, int selected_slot, int class_sele
 					}
 				}
 
-				if ( ws->status & WING_SLOT_IS_PLAYER && (selected_slot != slot_index) )
+				if ( ws->status & WING_SLOT_IS_PLAYER && (always_highlight_ply || (selected_slot != slot_index)) )
 				{
 					if(icon->model_index == -1)
 						bitmap_to_draw = icon->icon_bmaps[ICON_FRAME_PLAYER];

--- a/code/missionui/missionshipchoice.h
+++ b/code/missionui/missionshipchoice.h
@@ -82,7 +82,7 @@ typedef struct ss_wing_info {
 extern ss_wing_info Ss_wings_teams[MAX_TVT_TEAMS][MAX_WING_BLOCKS];
 extern ss_wing_info* Ss_wings;
 
-void draw_wing_block(int wb_num, int hot_slot, int selected_slot, int class_select, bool ship_selection = true);
+void draw_wing_block(int wb_num, int hot_slot, int selected_slot, int class_select, bool ship_selection = true, bool always_highlight_ply = false);
 void ship_select_init();
 void ship_select_do(float frametime);
 void ship_select_close();

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -2836,7 +2836,7 @@ void weapon_select_do(float frametime)
 		wl_render_overhead_view(frametime);
 		wl_draw_ship_weapons(Selected_wl_slot);
 		for ( int i = 0; i < MAX_WING_BLOCKS; i++ ) {
-			draw_wing_block(i, Hot_wl_slot, Selected_wl_slot, -1, false);
+			draw_wing_block(i, Hot_wl_slot, Selected_wl_slot, -1, false, true);
 		}
 		common_render_selected_screen_button();
 	}


### PR DESCRIPTION
This PR fixes a loadout screen icon highlighting issue.

Currently there is a nice orange coloration of the player ship icon in the Ship Selection wing loadout. This immediately shows the player which ship is theirs, but this usefulness does not translate to the Weapon Loadout screen.  The player must select another ship, besides the player ship, to have the player ship show up as orange. This PR adds a bool `always_highlight_ply` which is specifically for the weapon `draw_wing_block` function when called as as part of the weapon loadout routine.

Tested and works as expected. 