### PR TITLE
Extra Visual Indication for `Scramble` Missions

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1882 // This is the next available ID
+// #define XSTR_SIZE	1883 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -283,7 +283,9 @@ void common_buttons_init(UI_WINDOW *ui_window)
 	if ( brief_only_allow_briefing() ) {
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_SS_REGION].button.disable();
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_REGION].button.disable();
-		ui_window->add_XSTR("Ships/Weapons Locked", 749, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].xt, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].yt + 30, &Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].button, UI_XSTR_COLOR_GREEN);
+		if (Show_locked_status_scramble_missions) {
+			ui_window->add_XSTR("Ships/Weapons Are Locked For This Mission", 1882, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].xt, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].yt + 30, &Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].button, UI_XSTR_COLOR_GREEN);
+		}
 	}
 }
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -283,6 +283,8 @@ void common_buttons_init(UI_WINDOW *ui_window)
 	if ( brief_only_allow_briefing() ) {
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_SS_REGION].button.disable();
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_REGION].button.disable();
+		ui_window->add_XSTR("Ships/Weapons Locked", 749, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].xt, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].yt + 30, &Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].button, UI_XSTR_COLOR_GREEN);
+
 	}
 }
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -284,7 +284,6 @@ void common_buttons_init(UI_WINDOW *ui_window)
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_SS_REGION].button.disable();
 		Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_REGION].button.disable();
 		ui_window->add_XSTR("Ships/Weapons Locked", 749, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].xt, Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].yt + 30, &Common_buttons[Current_screen-1][gr_screen.res][COMMON_WEAPON_BUTTON].button, UI_XSTR_COLOR_GREEN);
-
 	}
 }
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -165,6 +165,7 @@ bool Preload_briefing_icon_models;
 EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
 bool Fix_asteroid_bounding_box_check;
 bool Disable_intro_movie;
+bool Show_locked_status_scramble_missions;
 
 
 #ifdef WITH_DISCORD
@@ -1504,6 +1505,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Disable_intro_movie);
 			}
 
+			if (optional_string("$Show locked status for scramble missions:")) {
+				stuff_boolean(&Show_locked_status_scramble_missions);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1733,6 +1738,7 @@ void mod_table_reset()
 	escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
 	Fix_asteroid_bounding_box_check = false;
 	Disable_intro_movie = false;
+	Show_locked_status_scramble_missions = false;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -180,6 +180,7 @@ extern bool Preload_briefing_icon_models;
 extern EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
 extern bool Fix_asteroid_bounding_box_check;
 extern bool Disable_intro_movie;
+extern bool Show_locked_status_scramble_missions;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
Currently, if a mission is set as scramble then there is no visual way for the player to see that the Ship Selection and Weapon Loadout screens are locked, instead the player has to click on the buttons and hear the fail sounds or assess that the hover states are not triggering. This PR adds a text line right below the words Weapons Loadout that states "Ships/Weapons Locked" (XSTR 749) if the mission is scramble thus the player can easily see this right away and not have to check the buttons on every mission.

Tested and works as expected. Happy to put behind a flag if desired.