### PR TITLE
XZ Support

### DIFF
--- a/code/cfile/cfile.cpp
+++ b/code/cfile/cfile.cpp
@@ -105,7 +105,7 @@ static const char *Cfile_cdrom_dir = NULL;
 //
 static int cfget_cfile_block();
 static CFILE *cf_open_fill_cfblock(const char* source, int line, const char* original_filename, FILE * fp, int type);
-static CFILE *cf_open_packed_cfblock(const char* source, int line, const char* original_filename, FILE *fp, int type, size_t offset, size_t size);
+static CFILE *cf_open_packed_cfblock(const char* source, int line, const char* original_filename, FILE *fp, int type, size_t offset, size_t size, COMPRESSION_INFO* pack_ci_ptr);
 static CFILE *cf_open_memory_fill_cfblock(const char* source, int line, const char* original_filename, const void* data, size_t size, int dir_type);
 
 #if defined _WIN32
@@ -812,7 +812,7 @@ CFILE *_cfopen_special(const char* source, int line, const CFileLocation &res, c
 		if (fp) {
 			if (res.offset) {
 				// Found it in a pack file
-				return cf_open_packed_cfblock(source, line, res.name_ext.c_str(), fp, dir_type, res.offset, res.size);
+				return cf_open_packed_cfblock(source, line, res.name_ext.c_str(), fp, dir_type, res.offset, res.size, res.pack_ci_ptr);
 			}
 			else {
 				// Found it in a normal file
@@ -983,7 +983,7 @@ static CFILE *cf_open_fill_cfblock(const char* source, int line, const char* ori
 // returns:   success ==> ptr to CFILE structure.  
 //            error   ==> NULL
 //
-static CFILE *cf_open_packed_cfblock(const char* source, int line, const char* original_filename, FILE *fp, int type, size_t offset, size_t size)
+static CFILE *cf_open_packed_cfblock(const char* source, int line, const char* original_filename, FILE *fp, int type, size_t offset, size_t size, COMPRESSION_INFO* pack_ci_ptr)
 {
 	// Found it in a pack file
 	int cfile_block_index;
@@ -1006,6 +1006,7 @@ static CFILE *cf_open_packed_cfblock(const char* source, int line, const char* o
 		cfp->line_num = line;
 
 		cf_init_lowlevel_read_code(cfp,offset, size, 0 );
+		cfp->pack_ci_ptr = pack_ci_ptr;
 		cf_check_compression(cfp);
 		return cfp;
 	}

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -30,6 +30,9 @@
 // Opaque file handle
 struct CFILE;
 
+// For passing pack compression info pointers to CFILE
+struct COMPRESSION_INFO;
+
 // extra info that can be returned when getting a file listing
 typedef struct {
 	time_t write_time;
@@ -379,7 +382,7 @@ struct CFileLocation {
 	size_t offset        = 0;
 	time_t m_time        = 0;
 	const void* data_ptr = nullptr;
-
+	COMPRESSION_INFO* pack_ci_ptr = nullptr; //Pointer to the pack COMPRESSION_INFO if it has one;
 	explicit CFileLocation(bool found_in = false) : found(found_in) {}
 };
 

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -277,7 +277,7 @@ int cf_chksum_long(const char *filename, uint *chksum, int max_size = -1, int cf
 // NOTE : preserves current file position
 int cf_chksum_long(CFILE *file, uint *chksum, int max_size = -1);
 
-int cf_chksum_pack(const char *filename, uint *chk_long, bool full = false);
+int cf_chksum_pack(const char* filename, uint* chk_long, COMPRESSION_INFO* ci, bool full = false);
 
 // convenient for misc checksumming purposes ------------------------------------------
 

--- a/code/cfile/cfilearchive.cpp
+++ b/code/cfile/cfilearchive.cpp
@@ -87,13 +87,13 @@ void cf_clear_compression_info(CFILE* cfile)
 		cfile->compression_info.last_decoded_block_bytes = 0;
 		cfile->compression_info.uncompressed_size = 0;
 		cfile->compression_info.compressed_size = 0;
-		if (cfile->compression_info.header = COMP_HEADER_IS_LZ41) {
+		if (cfile->compression_info.header == COMP_HEADER_IS_LZ41) {
 			free(cfile->compression_info.offsets);
 			cfile->compression_info.offsets = nullptr;
 			cfile->compression_info.num_offsets = 0;
 		}
 
-		if (cfile->compression_info.header = COMP_HEADER_IS_XZ) {
+		if (cfile->compression_info.header == COMP_HEADER_IS_XZ) {
 			lzma_index_end(cfile->compression_info.xz_block_index, NULL);
 			cfile->compression_info.xz_block_index = nullptr;
 			free(cfile->compression_info.xz_index_iter);

--- a/code/cfile/cfilearchive.h
+++ b/code/cfile/cfilearchive.h
@@ -15,23 +15,13 @@
 #endif
 
 #include "globalincs/pstypes.h"
+#include "cfile/cfilecompression.h"
 
 // The following Cfile_block data is private to cfile.cpp
 // DO NOT MOVE the Cfile_block* information to cfile.h / do not extern this data
 //
 #define CFILE_BLOCK_UNUSED		0
 #define CFILE_BLOCK_USED		1
-
-struct COMPRESSION_INFO {
-	int header = 0;
-	size_t compressed_size = 0;
-	int block_size = 0;
-	int num_offsets = 0;
-	int* offsets = nullptr;
-	char* decoder_buffer = nullptr;
-	int last_decoded_block_pos = 0;
-	int last_decoded_block_bytes = 0;
-};
 
 struct CFILE {
 	int type = CFILE_BLOCK_UNUSED;                // CFILE_BLOCK_UNUSED, CFILE_BLOCK_USED
@@ -54,7 +44,8 @@ struct CFILE {
 	SCP_string original_filename;
 	const char* source_file;
 	int line_num;
-	COMPRESSION_INFO compression_info;
+	COMPRESSION_INFO  compression_info;
+	COMPRESSION_INFO* pack_ci_ptr = nullptr; //This points to the pack COMPRESSION_INFO if this file is inside of a compressed pack
 };
 
 #define MAX_CFILE_BLOCKS	64
@@ -63,7 +54,8 @@ extern std::array<CFILE, MAX_CFILE_BLOCKS> Cfile_block_list;
 // Called once to setup the low-level reading code.
 void cf_init_lowlevel_read_code(CFILE* cfile, size_t lib_offset, size_t size, size_t pos);
 
-// This checks if the file is compressed or not, and creates the proper compression info if so.
+// This checks if the file is compressed or not, and creates the proper compression info if so
+// If the file is in a pack, pass the pointer to the pack compression_info, otherwise use nullptr
 void cf_check_compression(CFILE* cfile);
 
 // Used to clear compression info data and free dynamic memory used by compression

--- a/code/cfile/cfilecompression.cpp
+++ b/code/cfile/cfilecompression.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
+#include <thread>
 
 #ifdef _WIN32
 #include <io.h>
@@ -14,46 +15,105 @@
 #include "lz4.h"
 #include "cfilecompression.h"
 #include "cfilearchive.h"
+#include "liblzma/api/lzma.h"
 
 /*INTERNAL FUNCTIONS*/
 /*LZ41*/
-void lz41_load_offsets(CFILE* cf);
-size_t lz41_stream_random_access(CFILE* cf, char* bytes_out, size_t offset, size_t length);
-void lz41_create_ci(CFILE* cf, int header);
+void lz41_load_offsets(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, size_t file_size);
+size_t lz41_stream_random_access(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, char* bytes_out, size_t offset, size_t length);
+void lz41_create_ci(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, size_t file_size);
+/*XZ*/
+void xz_create_ci(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, size_t file_size);
+// Called by xz_stream_random_access(). Do not use directly!
+// Block decoder intended to be used for multithreaded cases
+int xz_block_decoder(COMPRESSION_INFO *ci, size_t uncompressed_size, size_t input_size, uint8_t* input_buffer, char* bytes_out, size_t offset, size_t copyLength, bool save_to_cache);
+// Called by xz_stream_random_access(). Do not use directly!
+// Single block decoding version for when we are sure we only need to decode one block, use the minimum amount of code as possible
+size_t xz_stream_random_access_single_block_optimised(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, char* bytes_out, size_t offset, size_t length); 
+size_t xz_stream_random_access(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, char* bytes_out, size_t offset, size_t length);
 /*MISC*/
 int fso_fseek(CFILE* cfile, int offset, int where);
+int fso_fseek(FILE* fp, size_t compressed_size, size_t lib_offset, int offset, int where);
 /*END OF INTERNAL FUNCTIONS*/
 
-int comp_check_header(int header)
+int comp_cfile_uses_compression(CFILE* cf)
 {
-	if (LZ41_FILE_HEADER == header)
-		return COMP_HEADER_MATCH;
-
-	return COMP_HEADER_MISMATCH;
+	if (cf->compression_info.header != COMP_HEADER_IS_UNKNOWN || cf->pack_ci_ptr != nullptr)
+		return 1;
+	return 0;
 }
 
-void comp_create_ci(CFILE* cf, int header)
+int comp_get_header(char* header)
 {
+	//XZ
+	if (strncmp(header, XZ_HEADER_MAGIC, sizeof(XZ_HEADER_MAGIC)) == 0)
+		return COMP_HEADER_IS_XZ;
+
+	//LZ41
+	if (strncmp(header, LZ41_HEADER_MAGIC, sizeof(LZ41_HEADER_MAGIC)) == 0)
+		return COMP_HEADER_IS_LZ41;
+
+	return COMP_HEADER_IS_UNKNOWN;
+}
+
+void comp_create_ci(CFILE* cf, int header_id)
+{
+	if (header_id == COMP_HEADER_IS_UNKNOWN)
+		return;
 	//mprintf(("(CI)Compressed File Opened: %s \n", cf->original_filename.c_str()));
 
-	if (LZ41_FILE_HEADER == header)
-		lz41_create_ci(cf, header);
+	comp_create_ci(&cf->compression_info, cf->fp, cf->size, cf->lib_offset, header_id);
+	cf->size = cf->compression_info.uncompressed_size;
 
-	//mprintf(("(CI)Uncompressed FileSize: %d \n", cf->size));
+	//mprintf(("(CI)Uncompressed FileSize: %d \n", cf->compression_info.uncompressed_size));
 	//mprintf(("(CI)Compressed FileSize: %d \n", cf->compression_info.compressed_size));
 	//mprintf(("(CI)Block Size: %d \n", cf->compression_info.block_size));
 }
 
+void comp_create_ci(COMPRESSION_INFO* ci, FILE* fp, size_t file_size, size_t lib_offset, int header_id)
+{
+	if (COMP_HEADER_IS_XZ == header_id) {
+		xz_create_ci(ci, fp, lib_offset, file_size);
+	}
+
+	if (COMP_HEADER_IS_LZ41 == header_id) {
+		lz41_create_ci(ci, fp, lib_offset, file_size);
+	}
+}
+
 size_t comp_fread(CFILE* cf, char* buffer, size_t length)
+{
+	//We need to adapt to the file being a compressed single file, a compressed file inside a uncompressed pack (VPC) or part of a compressed pack
+	COMPRESSION_INFO* ci = cf->pack_ci_ptr != nullptr ? cf->pack_ci_ptr : &cf->compression_info;
+	
+	//lib_offset is the offset of this CFILE in the pack, if it is part of a pack
+	//This is needed to fseek to were the file starts inside of it, in a VPC for example
+	//But for single files and compressed packs this is always 0, we dont need to seek to were the compressed file start,
+	//thats the start of the file itself
+	size_t lib_offset = cf->pack_ci_ptr != nullptr ? 0 : cf->lib_offset;
+	
+	//The offset is like a virtual FILE pointer for compressed files, it helps to track in what position we are in a compressed file
+	//Just like the FILE pointer would move after a fread or fseek, the raw_position moves too
+	//In a compressed pack we need to include the lib_offset of the CFILE during readings 
+	//Because the requested CFILE starts at lib_offset position of the uncompresed data of the compressed pack file
+	size_t offset = cf->pack_ci_ptr != nullptr ? cf->lib_offset + cf->raw_position : cf->raw_position;
+
+	return comp_fread(ci, cf->fp, lib_offset, buffer, offset, length);
+}
+
+size_t comp_fread(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, char* buffer, size_t offset, size_t length)
 {
 	/* Check the request to be at least 1 byte */
 	Assertion(length > 0, "Invalid length requested.");
 
 	/* Check that we are not requesting to read beyond end of file */
-	Assertion(cf->raw_position + length <= cf->size, "Invalid length requested.");
+	Assertion(offset + length <= ci->uncompressed_size, "Invalid length requested.");
 
-	if (LZ41_FILE_HEADER == cf->compression_info.header)
-		return lz41_stream_random_access(cf, buffer, cf->raw_position, length);
+	if (COMP_HEADER_IS_XZ == ci->header)
+		return xz_stream_random_access(ci, fp, lib_offset, buffer, offset, length);
+
+	if (COMP_HEADER_IS_LZ41 == ci->header)
+		return lz41_stream_random_access(ci, fp, lib_offset, buffer, offset, length);
 
 	return 0;
 }
@@ -90,103 +150,113 @@ int comp_fseek(CFILE* cf, int offset, int where)
 }
 
 //Special fseek for compressed files handled by FSO, only SEEK_SET and SEEK_END is supported.
-int fso_fseek(CFILE* cfile, int offset, int where)
+int fso_fseek(FILE *fp, size_t compressed_size, size_t lib_offset, int offset, int where)
 {
 	size_t goal_position;
 
 	switch (where) {
-	case SEEK_SET: goal_position = offset + cfile->lib_offset; break;
-	case SEEK_END: goal_position = cfile->compression_info.compressed_size + offset + cfile->lib_offset; break;
+	case SEEK_SET: goal_position = offset + lib_offset; break;
+	case SEEK_END: goal_position = compressed_size + offset + lib_offset; break;
 	default: return 0;
 	}
 	
 	// Make sure we don't seek beyond the end of the file
-	CAP(goal_position, cfile->lib_offset, cfile->lib_offset + cfile->compression_info.compressed_size);
+	CAP(goal_position, lib_offset, lib_offset + compressed_size);
 	
 	int result = 0;
-	if (cfile->fp)
+	if (fp)
 	{
-		result = fseek(cfile->fp, (long)goal_position, SEEK_SET);
-		Assertion(goal_position >= cfile->lib_offset, "Invalid offset values detected while seeking! Goal was " SIZE_T_ARG ", lib_offset is " SIZE_T_ARG ".", goal_position, cfile->lib_offset);
+		result = fseek(fp, (long)goal_position, SEEK_SET);
+		Assertion(goal_position >= lib_offset,
+			"Invalid offset values detected while seeking! Goal was " SIZE_T_ARG ", lib_offset is " SIZE_T_ARG ".",
+			goal_position,
+			lib_offset);
 	}
 	return result;
 }
 
-void lz41_create_ci(CFILE* cf, int header)
+// Special fseek for compressed files handled by FSO, only SEEK_SET and SEEK_END is supported.
+int fso_fseek(CFILE* cfile, int offset, int where)
 {
-	cf->compression_info.header = header;
-	cf->compression_info.compressed_size = cf->size;
-	fso_fseek(cf, (int)sizeof(int)*-3, SEEK_END);
-	auto fNumoffsets = fread(&cf->compression_info.num_offsets, sizeof(int), 1, cf->fp);
-	auto fSize = fread(&cf->size, sizeof(int), 1, cf->fp);
-	auto fBsize = fread(&cf->compression_info.block_size, sizeof(int), 1, cf->fp);
+	return fso_fseek(cfile->fp, cfile->compression_info.compressed_size, cfile->lib_offset, offset, where);
+}
 
-	Assertion(cf->compression_info.num_offsets > 0, "Invalid number of offsets, compressed file is possibly in the wrong format or corrupted.");
+void lz41_create_ci(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, size_t file_size)
+{
+	ci->header = COMP_HEADER_IS_LZ41;
+	ci->compressed_size = file_size;
+	fso_fseek(fp, file_size, lib_offset, (int)sizeof(int)*-3, SEEK_END);
+	auto fNumoffsets = fread(&ci->num_offsets, sizeof(int), 1, fp);
+	auto fSize = fread(&ci->uncompressed_size, sizeof(int), 1, fp);
+	auto fBsize = fread(&ci->block_size, sizeof(int), 1, fp);
+
+	Assertion(ci->num_offsets > 0, "Invalid number of offsets, compressed file is possibly in the wrong format or corrupted.");
 	#if !defined(NDEBUG)
-	Assertion(cf->size > 4, "Invalid filesize, compressed file is possibly in the wrong format or corrupted.");
-	Assertion(cf->compression_info.block_size > 16, "Invalid block size, compressed file is possibly in the wrong format or corrupted.");
+	Assertion(ci->uncompressed_size > 4, "Invalid filesize, compressed file is possibly in the wrong format or corrupted.");
+	Assertion(ci->block_size > 16, "Invalid block size, compressed file is possibly in the wrong format or corrupted.");
 	Assertion(fNumoffsets == 1, "Error while reading the number of offsets, compressed file is possibly in the wrong format or corrupted.");
 	Assertion(fSize == 1, "Error while reading original filesize, compressed file is possibly in the wrong format or corrupted.");
 	Assertion(fBsize == 1, "Error while reading block size, compressed file is possibly in the wrong format or corrupted.");
 	#endif
 
-	cf->compression_info.decoder_buffer = (char*)malloc(LZ4_compressBound(cf->compression_info.block_size));
-	cf->compression_info.last_decoded_block_pos = 0;
-	cf->compression_info.last_decoded_block_bytes = 0;
-	lz41_load_offsets(cf);
+	ci->decoder_buffer = (char*)malloc(ci->block_size);
+	ci->last_decoded_block_pos = 0;
+	ci->last_decoded_block_bytes = 0;
+	
+	lz41_load_offsets(ci, fp, lib_offset, file_size);
 }
 
-void lz41_load_offsets(CFILE* cf)
+void lz41_load_offsets(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, size_t file_size)
 {
-	cf->compression_info.offsets = (int*)malloc(cf->compression_info.num_offsets * sizeof(int));
+	ci->offsets = (int*)malloc(ci->num_offsets * sizeof(int));
 	int block;
-	int* offsets_ptr = cf->compression_info.offsets;
+	int* offsets_ptr = ci->offsets;
 
 	/* Seek to the first offset position, remember to consider the trailing ints */
-	fso_fseek(cf, ( ( sizeof(int) * cf->compression_info.num_offsets ) * -1 ) - (sizeof(int)*3 ), SEEK_END);
-	for (block = 0; block < cf->compression_info.num_offsets; ++block)
+	fso_fseek(fp, file_size, lib_offset, ((sizeof(int) * ci->num_offsets) * -1) - (sizeof(int) * 3), SEEK_END);
+	for (block = 0; block < ci->num_offsets; ++block)
 	{
-		auto bytes_read = fread(offsets_ptr++, sizeof(int), 1, cf->fp);
+		auto bytes_read = fread(offsets_ptr++, sizeof(int), 1, fp);
 		Assertion(bytes_read == 1, "Error reading offset list.");
 	}
 }
 
-size_t lz41_stream_random_access(CFILE* cf, char* bytes_out, size_t offset, size_t length)
+size_t lz41_stream_random_access(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, char* bytes_out, size_t offset, size_t length)
 {
 	LZ4_streamDecode_t lz4_stream_decode_body;
 	LZ4_streamDecode_t* lz4_stream_decode = &lz4_stream_decode_body;
 	/* The blocks (current_block to end_block) contain the data we want */
-	size_t current_block = offset / cf->compression_info.block_size;
-	size_t end_block = ((offset + length - 1) / cf->compression_info.block_size) + 1;
+	size_t current_block = offset / ci->block_size;
+	size_t end_block = ((offset + length - 1) / ci->block_size) + 1;
 	size_t written_bytes = 0;
 
-	if (cf->compression_info.num_offsets <= (int)end_block)
+	if (ci->num_offsets <= (int)end_block)
 		return (size_t)LZ41_OFFSETS_MISMATCH;
 
 	/* Seek to the first block to read, if it matches the cached block, search the next one instead */
-	if (cf->compression_info.last_decoded_block_pos == cf->compression_info.offsets[current_block] && current_block + 1 <= end_block)
-		fso_fseek(cf, cf->compression_info.offsets[current_block+1], SEEK_SET);
+	if (ci->last_decoded_block_pos == ci->offsets[current_block] && current_block + 1 <= end_block)
+		fso_fseek(fp, ci->compressed_size, lib_offset, ci->offsets[current_block+1], SEEK_SET);
 	else
-		fso_fseek(cf, cf->compression_info.offsets[current_block], SEEK_SET);
+		fso_fseek(fp, ci->compressed_size, lib_offset, ci->offsets[current_block], SEEK_SET);
 	
-	offset = offset % cf->compression_info.block_size;
-	char* cmp_buf = (char*)malloc(LZ4_compressBound(cf->compression_info.block_size));
+	offset = offset % ci->block_size;
+	char* cmp_buf = (char*)malloc(LZ4_compressBound(ci->block_size));
 
 	/* Start decoding */
 	for (; current_block < end_block; ++current_block)
 	{
 		/* Only read and decode if the requested block is not the cached one */
-		if (cf->compression_info.last_decoded_block_pos != cf->compression_info.offsets[current_block])
+		if (ci->last_decoded_block_pos != ci->offsets[current_block])
 		{
-			cf->compression_info.last_decoded_block_pos = cf->compression_info.offsets[current_block];
+			ci->last_decoded_block_pos = ci->offsets[current_block];
 
 			/* The difference in offsets is the size of the block */
-			int cmp_bytes = cf->compression_info.offsets[current_block + 1] - cf->compression_info.offsets[current_block];
-			auto bytes_read = fread(cmp_buf, cmp_bytes, 1, cf->fp);
+			int cmp_bytes = ci->offsets[current_block + 1] - ci->offsets[current_block];
+			auto bytes_read = fread(cmp_buf, cmp_bytes, 1, fp);
 			Assertion(bytes_read == 1, "Error reading from compressed file.");
 
-			cf->compression_info.last_decoded_block_bytes = LZ4_decompress_safe_continue(lz4_stream_decode, cmp_buf, cf->compression_info.decoder_buffer, cmp_bytes, cf->compression_info.block_size);
-			if (cf->compression_info.last_decoded_block_bytes <= 0)
+			ci->last_decoded_block_bytes = LZ4_decompress_safe_continue(lz4_stream_decode, cmp_buf, ci->decoder_buffer, cmp_bytes, ci->block_size);
+			if (ci->last_decoded_block_bytes <= 0)
 			{
 				free(cmp_buf);
 				return (size_t)LZ41_DECOMPRESSION_ERROR;
@@ -194,13 +264,269 @@ size_t lz41_stream_random_access(CFILE* cf, char* bytes_out, size_t offset, size
 		}
 
 		/* Write out the part of the data we care about from buffer */
-		size_t block_length = (length < (cf->compression_info.last_decoded_block_bytes - offset) ? length : (cf->compression_info.last_decoded_block_bytes - offset));
-		memcpy(bytes_out + written_bytes, cf->compression_info.decoder_buffer + offset, (size_t)block_length);
+		size_t block_length = (length < (ci->last_decoded_block_bytes - offset) ? length : (ci->last_decoded_block_bytes - offset));
+		memcpy(bytes_out + written_bytes, ci->decoder_buffer + offset, (size_t)block_length);
 		written_bytes += block_length;
 		offset = 0;
 		length -= block_length;
 	}
 
 	free(cmp_buf);
+	return written_bytes;
+}
+
+/***************************************************************/
+
+void xz_create_ci(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, size_t file_size)
+{
+	ci->header = COMP_HEADER_IS_XZ;
+	ci->compressed_size = file_size;
+
+	lzma_stream strm = LZMA_STREAM_INIT;
+	lzma_ret ret = lzma_file_info_decoder(&strm, &ci->xz_block_index, UINT64_MAX, file_size);
+	if (ret != LZMA_OK) {
+		//TODO
+	}
+	
+	strm.avail_in = 0;
+	uint8_t in[LZMA_BLOCK_HEADER_SIZE_MAX];
+
+	// Decode file info
+	while (1) {
+		if (strm.avail_in == 0) {
+			strm.next_in = in;
+			strm.avail_in = fread(in, 1, sizeof(in), fp);
+		}
+
+		ret = lzma_code(&strm, LZMA_RUN);
+
+		if (ret != LZMA_OK) {
+			if (ret == LZMA_STREAM_END)
+				break;
+
+			if (ret == LZMA_SEEK_NEEDED) {
+				strm.avail_in = 0;
+				fso_fseek(fp, file_size, lib_offset, (long)strm.seek_pos, SEEK_SET);
+			} else {
+				//TODO: Info decoding failed
+			}
+		}
+	}
+
+	lzma_end(&strm);
+
+	// Set index iterator
+	ci->xz_index_iter = (lzma_index_iter*)malloc(sizeof(lzma_index_iter));
+	lzma_index_iter_init(ci->xz_index_iter, ci->xz_block_index);
+
+	//Find the first block, this is needed so it loads data into the iterator
+	lzma_index_iter_locate(ci->xz_index_iter, 0);
+
+	ci->uncompressed_size = ci->xz_index_iter->stream.uncompressed_size;
+	ci->block_size = (int)ci->xz_index_iter->block.uncompressed_size;
+	ci->decoder_buffer = (char*)malloc(ci->block_size);
+	ci->last_decoded_block_pos = 0;
+	ci->last_decoded_block_bytes = 0;
+}
+
+int xz_block_decoder(COMPRESSION_INFO *ci, size_t block_uncompressed_size, size_t input_size, uint8_t* input_buffer, char* bytes_out, size_t offset, size_t copy_length, bool save_to_cache)
+{
+	auto entire_block = copy_length == block_uncompressed_size;
+	/*
+	* If we are saving to cache always use the cache as the output buffer and then memcpy the results to bytes_out.
+	* If not, then check if we need to write the entire block, if so use the bytes_out as the output buffer directly.
+	* Only use local buffer in case of partial block reads that we are not saving to cache.
+	*/
+	auto outbuf = save_to_cache ? (uint8_t*)ci->decoder_buffer : 
+				  entire_block  ? (uint8_t*)bytes_out : (uint8_t*)malloc(block_uncompressed_size);
+
+	//Set block
+	lzma_block block;
+	block.check = ci->xz_index_iter->stream.flags->check;
+	lzma_filter block_filters[LZMA_FILTERS_MAX + 1];
+	block_filters[LZMA_FILTERS_MAX].id = LZMA_VLI_UNKNOWN;
+	block.filters = block_filters;
+	block.header_size = lzma_block_header_size_decode(input_buffer[0]);
+	//TODO: Check header size min/max in debug
+
+	//Decode block Header
+	auto ret_hd = lzma_block_header_decode(&block, nullptr, input_buffer);
+	//TODO Check return in debug
+
+	//Set Decoding stream, we must skip the block header
+	lzma_stream stream = LZMA_STREAM_INIT;
+	stream.next_in = input_buffer + block.header_size;
+	stream.next_out = outbuf;
+	stream.avail_out = block_uncompressed_size;
+	stream.avail_in = input_size - block.header_size;
+	
+	//Set block decoder
+	auto ret_bd = lzma_block_decoder(&stream, &block);
+	//TODO: Check return in debug
+
+	//Decode block data
+	auto ret_code = lzma_code(&stream, LZMA_RUN);
+
+	//Copy decoded data only when saving to cache and partial reads
+	if (save_to_cache || !entire_block)
+		memcpy(bytes_out, outbuf + offset, copy_length);
+
+	//Cleanup
+	lzma_filters_free(block_filters, nullptr);
+	free(input_buffer);
+	lzma_end(&stream);
+	if (!save_to_cache && !entire_block)
+		free(outbuf);
+
+	return 0;
+}
+
+size_t xz_stream_random_access_single_block_optimised(COMPRESSION_INFO *ci, FILE *fp, size_t lib_offset, char* bytes_out, size_t offset, size_t length)
+{
+	// Get the first block we need. Do this before changing the offset
+	auto ret = lzma_index_iter_locate(ci->xz_index_iter, offset);
+
+	// Determines the offset of where the data requested starts at the output the first block to decode
+	if (offset != 0) {
+		offset = offset % ci->block_size;
+	}
+
+	// Determine how much data we need to copy from this block to bytes_out
+	size_t copy_length = (length < (ci->xz_index_iter->block.uncompressed_size - offset) ? length : ci->xz_index_iter->block.uncompressed_size - offset);
+
+	// If the requested block is the same as the last decoded block use the cache, otherwise find and decode the block
+	if (ci->last_decoded_block_pos != ci->xz_index_iter->block.compressed_file_offset) {
+		// Seek to the block to read
+		fso_fseek(fp, ci->compressed_size, lib_offset, ci->xz_index_iter->block.compressed_file_offset, SEEK_SET);
+
+		uint8_t* inbuf = (uint8_t*)malloc(ci->xz_index_iter->block.total_size);
+
+		// Read block into memory
+		fread(inbuf, 1, ci->xz_index_iter->block.total_size, fp);
+
+		// Set block
+		lzma_block block;
+		block.check = ci->xz_index_iter->stream.flags->check;
+		lzma_filter block_filters[LZMA_FILTERS_MAX + 1];
+		block_filters[LZMA_FILTERS_MAX].id = LZMA_VLI_UNKNOWN;
+		block.filters = block_filters;
+		block.header_size = lzma_block_header_size_decode(inbuf[0]);
+		// TODO: Check header size min/max in debug
+
+		// Decode block Header
+		auto ret_hd = lzma_block_header_decode(&block, nullptr, inbuf);
+		// TODO Check return in debug
+
+		// Set Decoding stream, we must skip the block header
+		lzma_stream stream = LZMA_STREAM_INIT;
+		stream.next_in = inbuf + block.header_size;
+		stream.next_out = (uint8_t*)ci->decoder_buffer;
+		stream.avail_out = ci->xz_index_iter->block.uncompressed_size;
+		stream.avail_in = ci->xz_index_iter->block.total_size - block.header_size;
+
+		// Set block decoder
+		auto ret_bd = lzma_block_decoder(&stream, &block);
+		// TODO: Check return in debug
+
+		// Decode block data
+		auto ret_code = lzma_code(&stream, LZMA_RUN);
+		
+		// Save data for cache to use later
+		ci->last_decoded_block_bytes = ci->xz_index_iter->block.uncompressed_size;
+		ci->last_decoded_block_pos = ci->xz_index_iter->block.compressed_file_offset;
+
+		//Cleanup
+		free(inbuf);
+		lzma_end(&stream);
+		lzma_filters_free(block_filters, nullptr);
+	}
+
+	// Copy requested data
+	memcpy(bytes_out, ci->decoder_buffer + offset, copy_length);
+
+	return copy_length;
+}
+
+
+size_t xz_stream_random_access(COMPRESSION_INFO* ci, FILE *fp, size_t lib_offset, char* bytes_out, size_t offset, size_t length)
+{
+	if (length == 0)
+		return 0;
+
+	// Determine the the block number of the first and last block we need to decode
+	size_t start_block = offset / ci->block_size;
+	size_t end_block = (offset + length - 1) / ci->block_size;
+
+	//If we need to decode only one block use the single-block version as it is more efficient
+	if (start_block == end_block) {
+		return xz_stream_random_access_single_block_optimised(ci, fp, lib_offset, bytes_out, offset, length);
+	}
+
+	// Create the thread pool, one thread per block to decode
+	SCP_vector<std::thread> thread_pool;
+	size_t written_bytes = 0;
+
+	// Get the first block we need. Do this before changing the offset
+	auto ret = lzma_index_iter_locate(ci->xz_index_iter, offset);
+	// TODO: Check return in debug
+
+	// Determines the offset of where the data requested starts at the output the first block to decode
+	if (offset != 0) {
+		offset = offset % ci->block_size;
+	}
+
+	while (length > 0) {
+		// Determine how much data we need to copy from this block to bytes_out
+		size_t copy_length = (length < (ci->xz_index_iter->block.uncompressed_size - offset) ? length : ci->xz_index_iter->block.uncompressed_size - offset);
+
+		// Is this is the last block to decode? Is so we will need to save it to the cache
+		auto is_last_block = (length - copy_length) == 0;
+
+		// If the requested block is the same as the last decoded block use the cache, otherwise find and decode the block
+		if (ci->last_decoded_block_pos != ci->xz_index_iter->block.compressed_file_offset) {
+			// Seek to the block to read
+			fso_fseek(fp, ci->compressed_size, lib_offset, ci->xz_index_iter->block.compressed_file_offset, SEEK_SET);
+
+			uint8_t* inbuf = (uint8_t*)malloc(ci->xz_index_iter->block.total_size);
+
+			// Read block into memory
+			auto read_bytes = fread(inbuf, 1, ci->xz_index_iter->block.total_size, fp);
+
+			// Decode block in thread pool
+			thread_pool.emplace_back(xz_block_decoder,
+				ci,
+				ci->xz_index_iter->block.uncompressed_size,
+				ci->xz_index_iter->block.total_size,
+				inbuf,
+				bytes_out + written_bytes,
+				offset,
+				copy_length,
+				is_last_block);
+
+			if (is_last_block) {
+				// Save data for cache to use later
+				ci->last_decoded_block_bytes = ci->xz_index_iter->block.uncompressed_size;
+				ci->last_decoded_block_pos = ci->xz_index_iter->block.compressed_file_offset;
+			}
+
+		} else {
+			// Copy requested data from cache
+			memcpy(bytes_out + written_bytes, ci->decoder_buffer + offset, copy_length);
+		}
+
+		// Look for the next block if we are not finished
+		if (!is_last_block) {
+			lzma_index_iter_next(ci->xz_index_iter, LZMA_INDEX_ITER_BLOCK);
+		}
+
+		written_bytes += copy_length;
+		length -= copy_length;
+		offset = 0;
+	}
+
+	// Wait for all decode threads to finish
+	for (auto &th : thread_pool)
+		th.join();
+
 	return written_bytes;
 }

--- a/code/cfile/cfilecompression.cpp
+++ b/code/cfile/cfilecompression.cpp
@@ -359,7 +359,8 @@ void xz_create_ci(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, size_t file
 
 	ci->uncompressed_size = ci->xz_index_iter->stream.uncompressed_size;
 	ci->block_size = (int)ci->xz_index_iter->block.uncompressed_size;
-	if (ci->block_size <= COMP_MAX_DECODER_BUFFER) {
+	extern bool Cmdline_xz_no_cache_limit;
+	if (ci->block_size <= COMP_MAX_DECODER_BUFFER || Cmdline_xz_no_cache_limit) {
 		ci->decoder_buffer = (char*)malloc(ci->block_size);
 
 	} else {

--- a/code/cfile/cfilecompression.cpp
+++ b/code/cfile/cfilecompression.cpp
@@ -402,6 +402,12 @@ int xz_block_decoder(COMPRESSION_INFO *ci, size_t block_uncompressed_size, size_
 	Assertion(ret_hd == LZMA_OK, "Failed to decode XZ block header, return code is %d.", ret_hd);
 	#endif
 
+	#if defined(NDEBUG)
+	// Skip block integrity check on release
+	block.version = 1;
+	block.ignore_check = true;
+	#endif
+
 	//Set Decoding stream, we must skip the block header
 	lzma_stream stream = LZMA_STREAM_INIT;
 	stream.next_in = input_buffer + block.header_size;

--- a/code/cfile/cfilecompression.h
+++ b/code/cfile/cfilecompression.h
@@ -18,29 +18,68 @@ be used during decompression.
 #define _CFILECOMPRESSION_H
 struct CFILE;
 
+#include "liblzma/api/lzma.h"
+
 /*LZ41*/
-#define LZ41_FILE_HEADER 0x31345A4C // "14ZL" -> "LZ41", inverted
+const char LZ41_HEADER_MAGIC[4] = { 'L', 'Z', '4', '1' };
 #define LZ41_DECOMPRESSION_ERROR -1
 #define LZ41_MAX_BLOCKS_OVERFLOW -2
 #define LZ41_HEADER_MISMATCH -3
 #define LZ41_OFFSETS_MISMATCH -4
+
+/* XZ (liblzma) */
+const char XZ_HEADER_MAGIC[6] = { 0xFD, '7', 'z', 'X', 'Z', 0x00 };
+
 /******/
 
-#define COMP_HEADER_MATCH 1
-#define COMP_HEADER_MISMATCH 0
+struct COMPRESSION_INFO {
+	/* COMMON */
+	int header = 0;
+	size_t compressed_size = 0;
+	size_t uncompressed_size = 0;
+	int block_size = 0;
+	char* decoder_buffer = nullptr;
+	size_t last_decoded_block_pos = 0;
+	size_t last_decoded_block_bytes = 0;
+	/* LZ41 */
+	int num_offsets = 0;
+	int* offsets = nullptr;
+	/* XZ */
+	lzma_index* xz_block_index = nullptr;
+	lzma_index_iter* xz_index_iter = nullptr;
+};
+
+#define COMP_HEADER_IS_XZ 2 // File uses XZ (liblzma) compression type
+#define COMP_HEADER_IS_LZ41 1 // File uses LZ41 compression type
+#define COMP_HEADER_IS_UNKNOWN 0  // File is not compressed or unknown format
+#define COMP_HEADER_MAX_BYTES 8 // Defines the max number of bytes read from the file for header comparison
+#define COMP_FILE_MIN_SIZE 24 // The smallest size a compressed file can be, anything smaller than this will be ignored
 
 /*
-	Returns COMP_HEADER_MATCH if header is a valid compressed file header,
-	returns COMP_HEADER_MISMATCH if it dosent.
+	Check if this CFILE must be handled by cfilecompression "comp_" functions by checking its CI and pack_ci_ptr data
+	Returns 1 if it does, 0 otherwise.
 */
-int comp_check_header(int header);
+int comp_cfile_uses_compression(CFILE* cf);
+
+/*
+	Returns the internal header_id if the file has a compressed file header magic,
+	returns COMP_HEADER_IS_UNKNOWN if it dosent.
+*/
+int comp_get_header(char* header);
 
 /*
 	This is called to generate the correct compression_info data
-	after the file has been indentified as a compressed file.
+	after the file has been indentified as a compressed file by comp_get_header()
 	This must be done before calling any other function.
 */
-void comp_create_ci(CFILE* cf, int header);
+void comp_create_ci(CFILE* cf, int header_id);
+
+/*
+	This is called to generate the correct compression_info data
+	after the file has been indentified as a compressed file by comp_get_header()
+	This must be done before calling any other function.
+*/
+void comp_create_ci(COMPRESSION_INFO* ci, FILE* fp, size_t file_size, size_t lib_offset, int header_id);
 
 /*
 	Read X bytes from the uncompressed file starting from X offset.
@@ -49,6 +88,12 @@ void comp_create_ci(CFILE* cf, int header);
 size_t comp_fread(CFILE* cf, char* buffer, size_t length);
 
 /*
+	Read X bytes from the uncompressed file starting from X offset.
+	Returns the amount of bytes read, and 0 or lower to indicate errors.
+*/
+size_t comp_fread(COMPRESSION_INFO* ci, FILE* fp, size_t lib_offset, char* buffer, size_t offset, size_t length);
+
+	/*
 	Returns the current uncompressed file position.
 */
 size_t comp_ftell(CFILE* cf);

--- a/code/cfile/cfilecompression.h
+++ b/code/cfile/cfilecompression.h
@@ -21,14 +21,14 @@ struct CFILE;
 #include "liblzma/api/lzma.h"
 
 /*LZ41*/
-const char LZ41_HEADER_MAGIC[4] = { 'L', 'Z', '4', '1' };
+const unsigned char LZ41_HEADER_MAGIC[4] = { 'L', 'Z', '4', '1' };
 #define LZ41_DECOMPRESSION_ERROR -1
 #define LZ41_MAX_BLOCKS_OVERFLOW -2
 #define LZ41_HEADER_MISMATCH -3
 #define LZ41_OFFSETS_MISMATCH -4
 
 /* XZ (liblzma) */
-const char XZ_HEADER_MAGIC[6] = { 0xFD, '7', 'z', 'X', 'Z', 0x00 };
+const unsigned char XZ_HEADER_MAGIC[6] = { 0xFD, '7', 'z', 'X', 'Z', 0x00 };
 
 /******/
 
@@ -108,4 +108,19 @@ int comp_feof(CFILE* cf);
 */
 int comp_fseek(CFILE* cf, int offset, int where);
 
+/*
+	Use when you dont know if the file is compressed or not
+	If it is compressed based on CI data, it will use the comp_fread function, if not it will use the regular fread function.
+	Returned value is should be the same on both cases.
+	Requieres an external ptr to size_t variable "file_pos" to keep track of the uncompressed file position as if it where a FILE pointer.
+*/
+
+size_t comp_compatible_fread(void* dest, size_t elem_size, size_t elem_num, FILE* fp, size_t* file_pos, COMPRESSION_INFO* ci);
+/*
+	Use when you dont know if the file is compressed or not
+	If it is compressed based on CI data, it will use the comp_fseek function, if not it will use the regular fseek
+	function. Returned value is should be the same on both cases. Requieres an external ptr to size_t variable "file_pos"
+	to keep track of the uncompressed file position as if it where a FILE pointer.
+*/
+int comp_compatible_fseek(FILE* fp, size_t* file_pos, long offset, int where, COMPRESSION_INFO* ci);
 #endif

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -276,7 +276,8 @@ Flag exe_params[] =
 	{ "-slow_frames_ok",	"Don't adjust timestamps for slow frames",	true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-slow_frames_ok", },
 	{ "-imgui_debug",		"Show imgui debug/demo window in the lab",  true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-imgui_debug", },
 	{ "-luadev",			"Make lua errors non-fatal",				true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-luadev", },
-	{"-vulkan",			"Use vulkan render backend",				true,	0,									  EASY_DEFAULT,				"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-vulkan", },
+	{ "-vulkan",			"Use vulkan render backend",				true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-vulkan", },
+	{ "-xz_no_cache_limit",	"Disable XZ decoder cache limit",			true,	0,									EASY_DEFAULT,					"Dev Tool",		"http://www.hard-light.net/wiki/index.php/Command-Line_Reference#-xz_no_cache_limit", },
 };
 // clang-format on
 
@@ -533,6 +534,7 @@ cmdline_parm luadev_arg("-luadev", "Make lua errors non-fatal", AT_NONE);	// Cmd
 cmdline_parm override_arg("-override_data", "Enable override directory", AT_NONE);	// Cmdline_override_data
 cmdline_parm imgui_debug_arg("-imgui_debug", nullptr, AT_NONE);
 cmdline_parm vulkan("-vulkan", nullptr, AT_NONE);
+cmdline_parm xz_no_cache_limit("-xz_no_cache_limit", nullptr, AT_NONE);
 
 char *Cmdline_start_mission = NULL;
 int Cmdline_dis_collisions = 0;
@@ -571,6 +573,7 @@ bool Cmdline_lua_devmode = false;
 bool Cmdline_override_data = false;
 bool Cmdline_show_imgui_debug = false;
 bool Cmdline_vulkan = false;
+bool Cmdline_xz_no_cache_limit = false;
 
 // Other
 cmdline_parm get_flags_arg(GET_FLAGS_STRING, "Output the launcher flags file", AT_STRING);
@@ -2326,6 +2329,10 @@ bool SetCmdlineParams()
 
 	if (vulkan.found()) {
 		Cmdline_vulkan = true;
+	}
+
+	if (xz_no_cache_limit.found()) {
+		Cmdline_xz_no_cache_limit = true;
 	}
 
 	//Deprecated flags - CommanderDJ

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -159,6 +159,7 @@ extern bool Cmdline_lua_devmode;
 extern bool Cmdline_override_data;
 extern bool Cmdline_show_imgui_debug;
 extern bool Cmdline_vulkan;
+extern bool Cmdline_xz_no_cache_limit;
 
 enum class WeaponSpewType { NONE = 0, STANDARD, ALL };
 extern WeaponSpewType Cmdline_spew_weapon_stats;


### PR DESCRIPTION
This is a WIP. And im not even sure if it is desired or viable yet.

This work adds xz compressed files support, both single files and compressed packs (.vp.xz).

XZ is no anywhere near as fast as LZ4 in ST decompression, so it strongely depends on MT to keep loading times as short as possible.

The idea behind it as i commented on #6718 is that if we could get use the files that are uploaded to nebula directly, this on top of saving disk space (and saving the process of re-compress later for anyone who wants it), it would also remove the need to extract the files after download and maybe even implement something like zsync.

XZ files are also the regular ones, as random access is in its design, there is no need for specialised compressors. The only real requeriment is to use 1MB solid blocks to try to get as much multi-threading as possible.

My tests so far with the current code on MVP 4.7.3:
Nebula Upload (7z) is 7.95GB.

Extracted (with vps): 17.61GB - 
Trailer mission loading time: 0:42 seconds on a NVME

Compressed VPs (.vp.xz) 8.41GB
Trailer mission loading time: 1:01m with my 5800X. (yes speed is more than likely impacted by CPU, a CPU with better ST perf is likely to be faster) Also loading uses multiples threads.

By comparison the VPC version on LZ4 is 10GB and loads on 44s.

Still a lot of to do, still looking if this could be speed up somehow, there are a few warnings to fix and several TODOS around the code, mostly debug checks missings. And this will not compile, i dont know how to include liblzma into the cmake build process, i tried for hours to no avail. One big TODO that will try to commit soon is to disable the decoder buffer optimisation when blocksizes over 4MB are used. What will certanly lead to absurd memory usages.

The corrent most optimised compressor settings are:
1MB solid blocks
1 or 2 MB Dictionary
64 wordsize
Level 9 (Ultra) or Level 8 (max)

So im attaching the header files, the lib and dll needed to compile and run in case anyone wants to try it and im also attaching a script file to compress an entire folder vps with XZ,, you will need to point it to the 7z executable and the folder.
[liblzma.zip](https://github.com/user-attachments/files/20217083/liblzma.zip)
[7z script.zip](https://github.com/user-attachments/files/20217085/7z.script.zip)

Im attaching compiled builds (this is actually a 7z file)
[user_build_202505071036420949.zip](https://github.com/user-attachments/files/20357552/user_build_202505071036420949.zip)
