### PR TITLE
Misc hud config fixes

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -847,10 +847,12 @@ void hud_config_check_regions_by_mouse(int mx, int my)
  */
 void hud_config_check_regions(int mx, int my)
 {
+	// "-2" is a special mark that we're in the HUD area but may or may not be over a gauge
 	if (hud_config_check_mouse_in_hud_area(mx, my)) {
 		HC_gauge_hot = "-2";
 	}
 
+	// If we click inside the HUD area then reset the UI
 	if (HC_gauge_hot == "-2" && mouse_down(MOUSE_LEFT_BUTTON)) {
 		HC_gauge_selected.clear();
 		HC_color_sliders[HCS_RED].hide();
@@ -862,8 +864,12 @@ void hud_config_check_regions(int mx, int my)
 		HC_color_sliders[HCS_GREEN].disable();
 		HC_color_sliders[HCS_BLUE].disable();
 		HC_color_sliders[HCS_ALPHA].disable();
+
+		// turn off select all
+		hud_config_select_all_toggle(false);
 	}
 
+	// If we click on one of the new arrows the try to select a new HUD
 	if (HC_arrow_hot >= 0 && mouse_down(MOUSE_LEFT_BUTTON)) {
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		if (HC_arrow_hot == 0) {
@@ -877,14 +883,15 @@ void hud_config_check_regions(int mx, int my)
 
 	hud_config_check_regions_by_mouse(mx, my);
 
-	if (!HC_gauge_hot.empty() && mouse_down(MOUSE_LEFT_BUTTON)) {
+	const auto gauge = hud_config_get_gauge_pointer(HC_gauge_hot);
+
+	// If we clicked on a gauge then set the UI up for managing that gauge
+	if (gauge && mouse_down(MOUSE_LEFT_BUTTON)) {
 		gamesnd_play_iface(InterfaceSounds::USER_SELECT);
 		HC_gauge_selected = HC_gauge_hot;
 
 		// turn off select all
 		hud_config_select_all_toggle(false);
-
-		const auto gauge = hud_config_get_gauge_pointer(HC_gauge_selected);
 
 		// maybe setup rgb sliders
 		if (gauge != nullptr && gauge->getConfigUseIffColor()) {
@@ -918,8 +925,9 @@ void hud_config_check_regions(int mx, int my)
 
 		// recalc alpha slider
 		hud_config_recalc_alpha_slider();
-		mouse_flush();
 	}
+
+	mouse_flush();
 }
 
 // set the display flags for a HUD gauge

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -6519,10 +6519,15 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 
 				if (auto it_spec = weapon_map.find(hud); it_spec != weapon_map.end()) {
 					return it_spec->second;
-				} else if (auto it_def = weapon_map.find("default"); it_def != weapon_map.end()) {
-					return it_def->second;
 				}
 			}
+			
+			// Nothing found, try default
+			if (auto it_def = weapon_map.find("default"); it_def != weapon_map.end()) {
+				return it_def->second;
+			}
+
+			// No specialized settings, return null and pick some weapons later
 			return std::nullopt;
 		};
 
@@ -6606,6 +6611,12 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 				int match_count = 0;
 				for (weapon_info& wep : Weapon_info) {
 					if (wep.subtype == WP_LASER && wep.wi_flags[Weapon::Info_Flags::Player_allowed]) {
+
+						// Skip the retail dogfight weapons
+						if (wep.wi_flags[Weapon::Info_Flags::Dogfight_weapon]) {
+							continue;
+						}
+
 						if (match_count == i) {
 							wip = &wep;
 							weapon_name = wip->get_display_name();
@@ -6694,6 +6705,12 @@ void HudGaugeWeapons::render(float /*frametime*/, bool config)
 				int match_count = 0;
 				for (weapon_info& wep : Weapon_info) {
 					if (wep.subtype == WP_MISSILE && wep.wi_flags[Weapon::Info_Flags::Player_allowed]) {
+
+						// Skip the retail dogfight weapons
+						if (wep.wi_flags[Weapon::Info_Flags::Dogfight_weapon]) {
+							continue;
+						}
+
 						if (match_count == i) {
 							wip = &wep;
 							break;

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -96,6 +96,7 @@ namespace Weapon {
 		Detonate_on_expiration,				// Secondary weapons always detonate when their lifetime runs out, but now primary weapons can too
 		Ignores_countermeasures,			// The weapon will never be affected by countermeasures
 		Freespace_1_missile_behavior,		// Bundles several observed behaviors missiles had in the freespace 1 release
+		Dogfight_weapon,                    // Dogfight weapons are intended as balanced variants for multiplayer. This flag can be used to filter them out when necessary.
 
         NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -257,6 +257,7 @@ special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info
 			flags.remove(Weapon::Info_Flags::Freespace_1_missile_behavior);
 		}
 	}}, //special case
+	{"dogfight variant",                Weapon::Info_Flags::Dogfight_weapon,                    true},
 };
 
 const size_t num_weapon_info_flags = sizeof(Weapon_Info_Flags) / sizeof(special_flag_def_list_new<Weapon::Info_Flags, weapon_info*, flagset<Weapon::Info_Flags>&>);
@@ -2065,6 +2066,26 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 	}
 
 	parse_wi_flags(wip);
+
+	// List of retail dogfight weapons to enforce dogfight flag on
+	static const SCP_unordered_set<SCP_string> retailDogfightWeapons = {
+		"Subach HL-D",
+		"Mekhu HL-7D",
+		"MorningStar D",
+		"Prometheus D",
+		"Maxim D",
+		"UD-D Kayser",
+		"Rockeye D",
+		"Tempest D",
+		"Hornet D",
+		"Tornado D",
+		"Harpoon D"
+	};
+
+	// If we're a retail dogfight weapon then mark it
+	if (retailDogfightWeapons.contains(wip->name)) {
+		wip->wi_flags.set(Weapon::Info_Flags::Dogfight_weapon);
+	}
 
 	// be friendly; make sure ballistic flags are synchronized - Goober5000
 	// primary


### PR DESCRIPTION
Fix #6707 to properly use the parsed weapons for the default hud.

Fix crash when clicking in the HUD area but not on a gauge

Add a "dogfight variant" weapon flag to filter out dogfight weapons from the HUD Config auto-generated weapons list. I have wanted a way to filter these weapons in other cases as well so the flag seemed like the best way to go here. Hardcode adding the flag to retail dogfight weapons.