### PR TITLE
Mod Specific Visual Culling Size for Lasers

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -133,6 +133,8 @@ float Min_pixel_size_beam;
 float Min_pizel_size_muzzleflash;
 float Min_pixel_size_trail;
 float Min_pixel_size_laser;
+float Visually_cull_lasers_below_length;
+float Visually_cull_lasers_below_radius;
 bool Supernova_hits_at_zero;
 bool Show_subtitle_uses_pixels;
 int Show_subtitle_screen_base_res[2];
@@ -930,6 +932,14 @@ void parse_mod_table(const char *filename)
 				stuff_float(&Min_pixel_size_laser);
 			}
 
+			if (optional_string("Visually Cull Lasers Below Length:")) {
+				stuff_float(&Visually_cull_lasers_below_length);
+			}
+
+			if (optional_string("Visually Cull Lasers Below Radius:")) {
+				stuff_float(&Visually_cull_lasers_below_radius);
+			}
+
 			if (optional_string("$Thruster easing value:")) {
 				stuff_float(&Thruster_easing);
 				if (Thruster_easing <= 0.0f) {
@@ -1692,6 +1702,8 @@ void mod_table_reset()
 	Min_pizel_size_muzzleflash = 0.0f;
 	Min_pixel_size_trail = 0.0f;
 	Min_pixel_size_laser = 0.0f;
+	Visually_cull_lasers_below_length = 0.0001f;
+	Visually_cull_lasers_below_radius = 0.0001f;
 	Supernova_hits_at_zero = false;
 	Show_subtitle_uses_pixels = false;
 	Show_subtitle_screen_base_res[0] = -1;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -146,6 +146,8 @@ extern float Min_pixel_size_beam;
 extern float Min_pizel_size_muzzleflash;
 extern float Min_pixel_size_trail;
 extern float Min_pixel_size_laser;
+extern float Visually_cull_lasers_below_length;
+extern float Visually_cull_lasers_below_radius;
 extern bool Supernova_hits_at_zero;
 extern bool Show_subtitle_uses_pixels;
 extern int Show_subtitle_screen_base_res[];

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -9215,17 +9215,17 @@ void weapon_render(object* obj, model_draw_list *scene)
 			head_radius *= head_radius_mult * radius_mult;
 			tail_radius *= tail_radius_mult * radius_mult;
 
-			if (laser_length < 0.0001f)
+			if (laser_length < Visually_cull_lasers_below_length)
 				return;
 
-			if (head_radius < 0.0001f && tail_radius < 0.0001f)
+			if (head_radius < Visually_cull_lasers_below_radius && tail_radius < Visually_cull_lasers_below_radius)
 				return;
 
-			if (head_radius <= 0.0001f) {
-				head_radius = 0.0001f;
+			if (head_radius <= Visually_cull_lasers_below_radius) {
+				head_radius = Visually_cull_lasers_below_radius;
 			}
-			if (tail_radius <= 0.0001f) {
-				tail_radius = 0.0001f;
+			if (tail_radius <= Visually_cull_lasers_below_radius) {
+				tail_radius = Visually_cull_lasers_below_radius;
 			}
 
 


### PR DESCRIPTION
Currently, lasers will not render if the length or both head and tail radii are < `0.0001`. This is very small, and in many mods the smallest visual size is `0.01`, so this PR exposes that culling size value to allow mods to optimize and tune visual culling of lasers, which can be quite useful especially in laser heavy missions.