### PR TITLE
One fix and one enhancement to AI shield behavior

### DIFF
--- a/code/ai/ai.h
+++ b/code/ai/ai.h
@@ -330,7 +330,7 @@ typedef struct ai_info {
 	float	time_enemy_near;					//	SUSHI: amount of time enemy continuously "near" the player
 	fix		last_attack_time;					//	Missiontime of last time this ship attacked its enemy.
 	fix		last_hit_time;						//	Missiontime of last time this ship was hit by anyone.
-	int		last_hit_quadrant;				//	Shield section of last hit.
+	int		danger_shield_quadrant;				//	Shield section AI will prefer to prioritize for recharging, it if possible.
 	fix		last_hit_target_time;			//	Missiontime of last time this ship successfully hit target.
 	int		hitter_objnum;						//	Object index of ship that hit this ship last time.
 	int		hitter_signature;					//	Signature of hitter.  Prevents stupidity if hitter gets killed.

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -172,6 +172,8 @@ namespace AI {
 		Guards_ignore_protected_attackers,
 		Standard_strafe_used_more,
 		Unify_usage_ai_shield_manage_delay,
+		Fix_AI_shield_management_bug,
+		AI_balances_shields_when_attacked,
 		Disable_ai_transferring_energy,
 		Freespace_1_missile_behavior,
 		ETS_uses_power_output,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -701,7 +701,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix AI shield management bug:", AI::Profile_Flags::Fix_AI_shield_management_bug);
 
-				set_flag(profile, "$AI balances shields instead of directs if attacked:", AI::Profile_Flags::AI_balances_shields_when_attacked);
+				set_flag(profile, "$AI balances shields instead of directs when attacked:", AI::Profile_Flags::AI_balances_shields_when_attacked);
 
 				set_flag(profile, "$disable AI transferring energy:", AI::Profile_Flags::Disable_ai_transferring_energy);
 

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -699,6 +699,10 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$unify usage of AI Shield Manage Delay:", AI::Profile_Flags::Unify_usage_ai_shield_manage_delay);
 
+				set_flag(profile, "$fix AI shield management bug:", AI::Profile_Flags::Fix_AI_shield_management_bug);
+
+				set_flag(profile, "$AI balances shields instead of directs if attacked:", AI::Profile_Flags::AI_balances_shields_when_attacked);
+
 				set_flag(profile, "$disable AI transferring energy:", AI::Profile_Flags::Disable_ai_transferring_energy);
 
 				set_flag(profile, "$enable freespace 1 style missile behavior:", AI::Profile_Flags::Freespace_1_missile_behavior);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -924,6 +924,8 @@ void parse_ai_class()
 	set_aic_flag(aicp, "$use actual primary range:", AI::Profile_Flags::Use_actual_primary_range);
 
 	set_aic_flag(aicp, "$firing requires exact los:", AI::Profile_Flags::Require_exact_los);
+
+	set_aic_flag(aicp, "$AI balances shields instead of directs when attacked:", AI::Profile_Flags::AI_balances_shields_when_attacked);
 }
 
 void reset_ai_class_names()
@@ -13320,7 +13322,7 @@ void ai_manage_shield(object *objp, ai_info *aip)
 		aip->shield_manage_timestamp = timestamp((int) (delay * 1000.0f));
 
 		if (sip->is_small_ship() || (aip->ai_profile_flags[AI::Profile_Flags::All_ships_manage_shields])) {
-			if ((Missiontime - aip->last_hit_time < F1_0 * 10) && !(The_mission.ai_profile->flags[AI::Profile_Flags::AI_balances_shields_when_attacked]))
+			if ((Missiontime - aip->last_hit_time < F1_0 * 10) && !((aip->ai_profile_flags[AI::Profile_Flags::AI_balances_shields_when_attacked])))
 				ai_transfer_shield(objp, aip->danger_shield_quadrant);
 			else
 				ai_balance_shield(objp);

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13321,7 +13321,7 @@ void ai_manage_shield(object *objp, ai_info *aip)
 
 		if (sip->is_small_ship() || (aip->ai_profile_flags[AI::Profile_Flags::All_ships_manage_shields])) {
 			if ((Missiontime - aip->last_hit_time < F1_0 * 10) && !(The_mission.ai_profile->flags[AI::Profile_Flags::AI_balances_shields_when_attacked]))
-				ai_transfer_shield(objp, aip->last_hit_quadrant);
+				ai_transfer_shield(objp, aip->danger_shield_quadrant);
 			else
 				ai_balance_shield(objp);
 		}
@@ -15559,7 +15559,7 @@ void init_ai_object(int objnum)
 	aip->time_enemy_near = 0.0f;
 	aip->last_attack_time = 0;
 	aip->last_hit_time = 0;
-	aip->last_hit_quadrant = 0;
+	aip->danger_shield_quadrant = 0;
 	aip->hitter_objnum = -1;
 	aip->hitter_signature = -1;
 	aip->resume_goal_time = -1;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13320,7 +13320,7 @@ void ai_manage_shield(object *objp, ai_info *aip)
 		aip->shield_manage_timestamp = timestamp((int) (delay * 1000.0f));
 
 		if (sip->is_small_ship() || (aip->ai_profile_flags[AI::Profile_Flags::All_ships_manage_shields])) {
-			if (Missiontime - aip->last_hit_time < F1_0*10)
+			if ((Missiontime - aip->last_hit_time < F1_0 * 10) && !(The_mission.ai_profile->flags[AI::Profile_Flags::AI_balances_shields_when_attacked]))
 				ai_transfer_shield(objp, aip->last_hit_quadrant);
 			else
 				ai_balance_shield(objp);

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -446,6 +446,12 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 
 		// make sure that the shield is active in that quadrant
 		if (shipp->flags[Ship::Ship_Flags::Dying] || !ship_is_shield_up(ship_objp, quadrant_num)) {
+			// if the shield is down in the quadrant we still want the AI to record that the shield was hit here
+			// so that the AI can put energy torwards repairing that shield segement (but put behind a flag)
+			// --wookieejedi
+			if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_AI_shield_management_bug] || true && SCP_vector_inbounds(ship_objp->shield_quadrant, quadrant_num)) {
+				Ai_info[Ships[ship_objp->instance].ai_index].last_hit_quadrant = quadrant_num;
+			}
 			quadrant_num = -1;
 			shield_collision = 0;
 		}

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -449,7 +449,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 			// if the shield is down in the quadrant we still want the AI to record that the shield was hit here
 			// so that the AI can put energy torwards repairing that shield segement (but put behind a flag)
 			// --wookieejedi
-			if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_AI_shield_management_bug] || true && SCP_vector_inbounds(ship_objp->shield_quadrant, quadrant_num)) {
+			if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_AI_shield_management_bug] && SCP_vector_inbounds(ship_objp->shield_quadrant, quadrant_num)) {
 				Ai_info[Ships[ship_objp->instance].ai_index].last_hit_quadrant = quadrant_num;
 			}
 			quadrant_num = -1;

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -450,7 +450,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 			// so that the AI can put energy torwards repairing that shield segement (but put behind a flag)
 			// --wookieejedi
 			if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_AI_shield_management_bug] && SCP_vector_inbounds(ship_objp->shield_quadrant, quadrant_num)) {
-				Ai_info[Ships[ship_objp->instance].ai_index].last_hit_quadrant = quadrant_num;
+				Ai_info[Ships[ship_objp->instance].ai_index].danger_shield_quadrant = quadrant_num;
 			}
 			quadrant_num = -1;
 			shield_collision = 0;

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -204,7 +204,7 @@ float shield_apply_damage(object *objp, int quadrant_num, float damage)
 
 	if (objp->type != OBJ_SHIP && objp->type != OBJ_START)
 		return damage;
-	Ai_info[Ships[objp->instance].ai_index].last_hit_quadrant = quadrant_num;
+	Ai_info[Ships[objp->instance].ai_index].danger_shield_quadrant = quadrant_num;
 
 	remaining_damage = damage - objp->shield_quadrant[quadrant_num];
 	if (remaining_damage > 0.0f) {


### PR DESCRIPTION
This PR adds one fix and one enhancement to AI shield behavior.

1) Fix: Testing, especially in FotG, revealed an edge-case bug with shield management where the AI will not direct shield energy to a quadrant if it was hit when that quadrant was down. In other words, if a shield quadrant is knocked down to 0 and continues to be shot the AI will not realize it needs to direct energy to that quadrant. This is because `quadrant` is set to -1 if a shield segment is down. This ensures that the resulting effects and damage calculations properly ignore that quadrant downstream, but it also results in `aip->last_hit_quadrant` being set to -1. This PR adds a fix to properly record which shield was actually hit, so that the AI knows to direct energy to that quadrant.

2) Enhancement: In combat situations with fire coming from many directions, it is good practice to keep shields equalized, so this PR adds a flag for the AI to always attempt to balance shields, even if it is being fired upon (instead of the current behavior to always direct energy to the hit shield quadrant).

Both flags are tested and work as expected.