### PR TITLE
Stationary jump types should not try to avoid collision

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14447,10 +14447,12 @@ void ai_warp_out(object *objp)
 		aip->submode_start_time = Missiontime;
 		break;
 	case AIS_WARP_2:			//	Make sure won't collide with any object.
+		bool clear_path = Warp_params[shipp->warpout_params_index].warp_type == WT_HYPERSPACE ? 
+			!collide_predict_large_ship(objp, 100000.0f) : !collide_predict_large_ship(objp, objp->radius * 2.0f + 100.0f);
+
 		if (timestamp_elapsed(aip->force_warp_time)
-			|| (!collide_predict_large_ship(objp, objp->radius*2.0f + 100.0f)
-			|| (Warp_params[shipp->warpout_params_index].warp_type == WT_HYPERSPACE
-				&& !collide_predict_large_ship(objp, 100000.0f)))) {
+			|| (Warp_params[shipp->warpout_params_index].warp_type == WT_SWEEPER)
+			|| clear_path) {
 			aip->submode = AIS_WARP_3;
 			aip->submode_start_time = Missiontime;
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14440,7 +14440,6 @@ void ai_warp_out(object *objp)
 	// Goober5000 - make sure the flag is clear (if it was previously set)
 	aip->ai_flags.remove(AI::AI_Flags::Trying_unsuccessfully_to_warp);
 
-	bool clear_path = false;
 	WarpParams* warp_params = &Warp_params[shipp->warpout_params_index];
 
 	switch (aip->submode) {
@@ -14450,13 +14449,10 @@ void ai_warp_out(object *objp)
 		aip->submode_start_time = Missiontime;
 		break;
 	case AIS_WARP_2:			//	Make sure won't collide with any object.
-		clear_path = warp_params->warp_type == WT_HYPERSPACE ?
-			!collide_predict_large_ship(objp, 100000.0f) : !collide_predict_large_ship(objp, objp->radius * 2.0f + 100.0f);
-
 		if (timestamp_elapsed(aip->force_warp_time)
 			|| (warp_params->warp_type == WT_SWEEPER)
 			|| (warp_params->warp_type == WT_IN_PLACE_ANIM)
-			|| clear_path) {
+			|| (!collide_predict_large_ship(objp, objp->radius * 2.0f + 100.0f))) {
 			aip->submode = AIS_WARP_3;
 			aip->submode_start_time = Missiontime;
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -14440,6 +14440,9 @@ void ai_warp_out(object *objp)
 	// Goober5000 - make sure the flag is clear (if it was previously set)
 	aip->ai_flags.remove(AI::AI_Flags::Trying_unsuccessfully_to_warp);
 
+	bool clear_path = false;
+	WarpParams* warp_params = &Warp_params[shipp->warpout_params_index];
+
 	switch (aip->submode) {
 	case AIS_WARP_1:
 		aip->force_warp_time = timestamp(10*1000);	//	Try to avoid a collision for up to ten seconds.
@@ -14447,11 +14450,12 @@ void ai_warp_out(object *objp)
 		aip->submode_start_time = Missiontime;
 		break;
 	case AIS_WARP_2:			//	Make sure won't collide with any object.
-		bool clear_path = Warp_params[shipp->warpout_params_index].warp_type == WT_HYPERSPACE ? 
+		clear_path = warp_params->warp_type == WT_HYPERSPACE ?
 			!collide_predict_large_ship(objp, 100000.0f) : !collide_predict_large_ship(objp, objp->radius * 2.0f + 100.0f);
 
 		if (timestamp_elapsed(aip->force_warp_time)
-			|| (Warp_params[shipp->warpout_params_index].warp_type == WT_SWEEPER)
+			|| (warp_params->warp_type == WT_SWEEPER)
+			|| (warp_params->warp_type == WT_IN_PLACE_ANIM)
 			|| clear_path) {
 			aip->submode = AIS_WARP_3;
 			aip->submode_start_time = Missiontime;
@@ -14494,7 +14498,7 @@ void ai_warp_out(object *objp)
 		break;
 	case AIS_WARP_4: {
 		// Only lets the ship warp after waiting for the warpout engage time
-		if ( (Missiontime / 100) >= (aip->submode_start_time / 100 + Warp_params[shipp->warpout_params_index].warpout_engage_time) ) {
+		if ( (Missiontime / 100) >= (aip->submode_start_time / 100 + warp_params->warpout_engage_time) ) {
 			shipfx_warpout_start(objp);
 			aip->submode = AIS_WARP_5;
 			aip->submode_start_time = Missiontime;


### PR DESCRIPTION
A.k.a. homeworld-style jumps, bsg-style jumps, etc. They do not need to move, so there is no need to try and avoid any collisions.

~~Also rearranges the star wars hypserspace collision check (previously, if the 'short distance' check succeeded, then it would've skipped the 'long distance' check for hyperspace).~~ Since this check did not work, and some mods may be relying on it not working, we've opted to simply remove it.