### PR TITLE
Launch curves followup

### DIFF
--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -1555,8 +1555,9 @@ void turret_set_next_fire_timestamp(int weapon_num, const weapon_info *wip, ship
 	Assert(weapon_num < MAX_SHIP_WEAPONS);
 	float wait = 1000.0f;
 	// should subtract 1 from firepoints to match behavior of wip->burst_shots
-	int burst_shots = (wip->burst_flags[Weapon::Burst_Flags::Num_firepoints_burst_shots] ? turret->system_info->turret_num_firing_points - 1 : wip->burst_shots);
-	burst_shots = fl2i(i2fl(burst_shots) * wip->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::BURST_SHOTS_MULT, launch_curve_data));
+	int base_burst_shots = (wip->burst_flags[Weapon::Burst_Flags::Num_firepoints_burst_shots] ? turret->system_info->turret_num_firing_points - 1 : wip->burst_shots) + 1;
+	float burst_shots_mult = wip->weapon_launch_curves.get_output(weapon_info::WeaponLaunchCurveOutputs::BURST_SHOTS_MULT, launch_curve_data);
+	int burst_shots = MAX(fl2i(i2fl(base_burst_shots) * burst_shots_mult) - 1, 0);
 
 	if (burst_shots > turret->weapons.burst_counter[weapon_num]) {
 		wait *= wip->burst_delay;

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3315,7 +3315,7 @@ void process_countermeasure_fired_packet( ubyte *data, header *hinfo )
 }
 
 // send a packet indicating that a turret has been fired
-void send_turret_fired_packet( int ship_objnum, int subsys_index, int weapon_objnum, float dist_to_target )
+void send_turret_fired_packet( int ship_objnum, int subsys_index, int weapon_objnum, float dist_to_target, float target_radius )
 {
 	int packet_size;
 	ushort pnet_signature;
@@ -3372,6 +3372,8 @@ void send_turret_fired_packet( int ship_objnum, int subsys_index, int weapon_obj
 	}
 
 	ADD_FLOAT(dist_to_target);
+
+	ADD_FLOAT(target_radius);
 	
 	multi_io_send_to_all(data, packet_size);
 
@@ -3393,6 +3395,7 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	ship *shipp;
 	float angle1, angle2;
 	float dist_to_target;
+	float target_radius;
 
 	// get the data for the turret fired packet
 	offset = HEADER_LENGTH;	
@@ -3409,6 +3412,7 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	GET_FLOAT( angle1 );
 	GET_FLOAT( angle2 );
 	GET_FLOAT( dist_to_target );
+	GET_FLOAT( target_radius );
 	PACKET_SET_SIZE();				// move our counter forward the number of bytes we have read
 
 	// if we don't have a valid weapon index then bail
@@ -3455,6 +3459,7 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	auto launch_curve_data = WeaponLaunchCurveData {
 		ssp->system_info->turret_num_firing_points,
 		dist_to_target,
+		target_radius,
 	};
 
 	// create the weapon object
@@ -8629,7 +8634,7 @@ void process_weapon_detonate_packet(ubyte *data, header *hinfo)
 }	
 
 // flak fired packet
-void send_flak_fired_packet(int ship_objnum, int subsys_index, int weapon_objnum, float flak_range, float dist_to_target)
+void send_flak_fired_packet(int ship_objnum, int subsys_index, int weapon_objnum, float flak_range, float dist_to_target, float target_radius)
 {
 	int packet_size;
 	ushort pnet_signature;
@@ -8679,6 +8684,8 @@ void send_flak_fired_packet(int ship_objnum, int subsys_index, int weapon_objnum
 	ADD_FLOAT( flak_range );
 
 	ADD_FLOAT( dist_to_target );
+
+	ADD_FLOAT( target_radius );
 	
 	multi_io_send_to_all(data, packet_size);
 
@@ -8699,6 +8706,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	float angle1, angle2;
 	float flak_range;
 	float dist_to_target;
+	float target_radius;
 
 	// get the data for the turret fired packet
 	offset = HEADER_LENGTH;		
@@ -8755,6 +8763,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	auto launch_curve_data = WeaponLaunchCurveData {
 		ssp->system_info->turret_num_firing_points,
 		dist_to_target,
+		target_radius,
 	};
 
 	// create the weapon object	

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -530,11 +530,11 @@ void send_weapon_detonate_packet(object *objp);
 void process_weapon_detonate_packet(ubyte *data, header *hinfo);
 
 // turret fired packet
-void send_turret_fired_packet( int objnum, int subsys_index, int weapon_objnum, float dist_to_target );
+void send_turret_fired_packet( int objnum, int subsys_index, int weapon_objnum, float dist_to_target, float target_radius );
 void process_turret_fired_packet( ubyte *data, header *hinfo );
 
 // flak fired packet
-void send_flak_fired_packet(int ship_objnum, int subsys_index, int weapon_objnum, float flak_range, float dist_to_target);
+void send_flak_fired_packet(int ship_objnum, int subsys_index, int weapon_objnum, float flak_range, float dist_to_target, float target_radius );
 void process_flak_fired_packet(ubyte *data, header *hinfo);
 
 // player pain packet

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -891,9 +891,10 @@ ADE_FUNC(fireWeapon, l_Subsystem, "[number TurretWeaponIndex = 1, number FlakRan
 	if (override_gvec != nullptr)
 		vm_vec_copy_normalize(&gvec, override_gvec);
 
-	// we don't have a target, so just set the range to 0
+	// we don't have a target, so just set the range and radius to 0
 	auto launch_curve_data = WeaponLaunchCurveData {
 		sso->ss->system_info->turret_num_firing_points,
+		0.f,
 		0.f,
 	};
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12789,10 +12789,16 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 		}
 
 		int num_slots = pm->gun_banks[bank_to_fire].num_slots;
+		float target_radius = 0.f;
+
+		if (aip->target_objnum >= 0) {
+			target_radius = Objects[aip->target_objnum].radius;
+		}
 
 		auto launch_curve_data = WeaponLaunchCurveData {
 			num_slots,
 			dist_to_target,
+			target_radius,
 		};
 
 		// do timestamp stuff for next firing time
@@ -14065,10 +14071,16 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 		}
 
 		num_slots = pm->missile_banks[bank].num_slots;
+		float target_radius = 0.f;
+
+		if (target_objnum >= 0) {
+			target_radius = Objects[target_objnum].radius;
+		}
 
 		auto launch_curve_data = WeaponLaunchCurveData {
 			num_slots,
 			dist_to_target,
+			target_radius,
 		};
 
 		// determine if there is enough ammo left to fire weapons on this bank.  As with primary

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -354,6 +354,7 @@ float beam_get_warmdown_age(const beam& wp);
 struct WeaponLaunchCurveData {
 	int num_firepoints;
 	float distance_to_target;
+	float target_radius;
 };
 
 struct weapon_info;
@@ -711,7 +712,8 @@ struct weapon_info
 					std::pair {"FoF Mult", WeaponLaunchCurveOutputs::FOF_MULT},
 			},
 			std::pair {"Num Firepoints", modular_curves_submember_input<&WeaponLaunchCurveData::num_firepoints>{}},
-			std::pair {"Distance to Target", modular_curves_submember_input<&WeaponLaunchCurveData::distance_to_target>{}}
+			std::pair {"Distance to Target", modular_curves_submember_input<&WeaponLaunchCurveData::distance_to_target>{}},
+			std::pair {"Target Radius", modular_curves_submember_input<&WeaponLaunchCurveData::target_radius>{}}
 	);
 
   public:
@@ -1020,6 +1022,7 @@ int weapon_create( const vec3d *pos,
 	ship_subsys *src_turret = nullptr,
 	const WeaponLaunchCurveData& launch_curve_data = WeaponLaunchCurveData {
 		0,
+		0.f,
 		0.f
 	});
 void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, int target_objnum, int target_is_locked = 0, ship_subsys *target_subsys = NULL);


### PR DESCRIPTION
Fixes a bug that caused the burst shots multiplier to not function correctly, as well as an oversight with the distance-to-target input, which needs to _not_ subtract the radius of the target ship (the way turrets do by default) or else we'll get very unintuitive behavior. Also, adds target radius as an input, which allows weapons to e.g. behave differently depending on whether they're shooting at fighters or capital ships.