### PR TITLE
Fix type mismatch

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5822,12 +5822,12 @@ void weapon_home(object *obj, int num, float frame_time)
 		//	Asteroth - but not for homing primaries
 		if (old_dot < 0.90f && wip->subtype != WP_LASER) {
 			if (fs1_behavior) {
-				obj->phys_info.speed = max_speed * MAX(0.2f, fabs(old_dot));
+				obj->phys_info.speed = max_speed * MAX(0.2f, fabsf(old_dot));
 				if (obj->phys_info.speed < max_speed * 0.25f)
 					obj->phys_info.speed = max_speed * 0.25f;
 			}
 			else {
-				obj->phys_info.speed = MAX(0.2f, old_dot * fabs(old_dot));
+				obj->phys_info.speed = MAX(0.2f, old_dot * fabsf(old_dot));
 				if (obj->phys_info.speed < max_speed * 0.75f)
 					obj->phys_info.speed = max_speed * 0.75f;
 			}


### PR DESCRIPTION
Followup to #6652.
Since that PR branched, there was a change to master which caused a type mismatch in the max function, failing the cross-compile build again.
No idea why it didn't fail the normal builds, as it at least should have complained about a loss of precision in a warning.