### PR TITLE
Mod setting to disable shield effects

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -154,6 +154,7 @@ bool Countermeasures_use_capacity;
 bool Play_thruster_sounds_for_player;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
+bool Disable_shield_effects;
 bool Calculate_subsystem_hitpoints_after_parsing;
 bool Disable_internal_loadout_restoration_system;
 bool Contrails_use_absolute_speed;
@@ -980,6 +981,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Randomize_particle_rotation);
 			}
 
+			if (optional_string("$Disable shield effects:")) {
+				stuff_boolean(&Disable_shield_effects);
+			}
+
 			optional_string("#NETWORK SETTINGS");
 
 			if (optional_string("$FS2NetD port:")) {
@@ -1732,6 +1737,7 @@ void mod_table_reset()
 			std::tuple<float, float>{ 1.0f, 1.0f }
 		}};
 	Randomize_particle_rotation = false;
+	Disable_shield_effects = false;
 	Calculate_subsystem_hitpoints_after_parsing = false;
 	Disable_internal_loadout_restoration_system = false;
 	Contrails_use_absolute_speed = false;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -169,6 +169,7 @@ extern bool Countermeasures_use_capacity;
 extern bool Play_thruster_sounds_for_player;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
+extern bool Disable_shield_effects;
 extern bool Calculate_subsystem_hitpoints_after_parsing;
 extern bool Disable_internal_loadout_restoration_system;
 extern bool Contrails_use_absolute_speed;

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -546,7 +546,7 @@ void render_shields()
 
 	int	i;
 
-	if (Detail.shield_effects == 0){
+	if (Detail.shield_effects == 0 || Disable_shield_effects) {
 		return;	//	No shield effect rendered at lowest detail level.
 	}
 
@@ -870,15 +870,15 @@ void shield_point_multi_setup()
  */
 void create_shield_explosion_all(object *objp)
 {
+	if (Detail.shield_effects == 0 || Disable_shield_effects) {
+		return;	
+	}
+
 	int	i;
 	int	num;
 	int	count;
 	int	objnum;
 	ship	*shipp;
-
-	if (Detail.shield_effects == 0){
-		return;	
-	}
 
 	num = objp->instance;
 	shipp = &Ships[num];


### PR DESCRIPTION
Mods like FotG do not use the FS style shield hit effects, and simply disabling the shield rendering and checking is useful with one simple global variable.

Tested and works as expected.