### PR TITLE
Very small debug log cleanup

### DIFF
--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -122,7 +122,7 @@ public:
 	int		num_missions;							// number of missions in the campaign
 	int		num_missions_completed;					// number of missions in the campaign that have been flown
 	int		current_mission;						// the current mission that the player is playing.  Only valid during the mission
-	int		next_mission;							// number of the next mission to fly when comtinuing the campaign.  Always valid
+	int		next_mission;							// number of the next mission to fly when continuing the campaign.  Always valid
 	int		prev_mission;							// mission that we just came from.  Always valid
 	int		loop_enabled;							// whether mission loop is chosen - true during a loop, false otherwise
 	int		loop_mission;							// mission number of misssion loop (if any)

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1747,7 +1747,7 @@ void start_ship_animation(int ship_class, int  /*play_sound*/)
 		// page in ship textures properly (takes care of nondimming pixels)
 		model_page_in_textures(ShipSelectModelNum, ship_class);
 		
-		if (sip->model_num < 0) {
+		if (ShipSelectModelNum < 0) {
 			mprintf(("Couldn't load model file %s in missionshipchoice.cpp\n", sip->pof_file));
 		}
 	} else {

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -143,7 +143,8 @@ void pilotfile::csg_read_info()
 	Campaign.next_mission = cfread_int(cfp);
 
 	// check that the next mission won't be greater than the total number of missions
-	if (Campaign.next_mission >= Campaign.num_missions) {
+	// though ensure we only flag if campaign exists and has been loaded
+	if (Campaign.num_missions > 0 && Campaign.next_mission >= Campaign.num_missions) {
 		Campaign.next_mission = 0; // Prevent trying to load from invalid mission data downstream
 		m_data_invalid = true; // Causes a warning popup to be displayed
 	}

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -175,7 +175,7 @@ void script_init()
 	parse_modular_table(NOX("*-sct.tbm"), script_parse_table);
 	mprintf(("SCRIPTING: Parsing pure Lua scripts\n"));
 	parse_modular_table(NOX("*-sct.lua"), script_parse_lua_script);
-	mprintf(("SCRIPTING: Inititialization complete.\n"));
+	mprintf(("SCRIPTING: Initialization complete.\n"));
 }
 /*
 //WMC - Doesn't work as debug console interferes with any non-alphabetic chars.


### PR DESCRIPTION
Fix spelling of `Initialization` in debug log and also mitigate the log complaining about invalid pilot data if it has not loaded an actual campaign yet.

EDIT: also fix erroneous debug log when selecting ships in the loadout view. `Couldn't load model file in missionshipchoice.cpp ... `Found it was line 1750 missionshipchoice.cpp. From looking through the code paths it appears `ship->model_num` has not yet been loaded but is rather loaded later, so it's supposed to be `ShipSelectModelNum `. The code did originally set `sip->model_num` but it was changed to using the `ShipSelectModelNum` variable instead and that debug message check didn't get updated (been that way since 2003 :D ).

Everything works as expected.