### PR TITLE
remove support for memory mapped files

### DIFF
--- a/code/anim/animplay.cpp
+++ b/code/anim/animplay.cpp
@@ -667,12 +667,10 @@ void anim_read_header(anim *ptr, CFILE *fp)
  * 
  * @param real_filename Filename of animation
  * @param cf_dir_type 
- * @param file_mapped Whether to use memory-mapped file or not.
- * 
- * @details Memory-mapped files will page in the animation from disk as it is needed, but performance is not as good.
+ *
  * @return Pointer to anim that is loaded if success, NULL if failure.
  */
-anim *anim_load(const char *real_filename, int cf_dir_type, int file_mapped)
+anim *anim_load(const char *real_filename, int cf_dir_type)
 {
 	anim			*ptr;
 	CFILE			*fp;
@@ -697,7 +695,7 @@ anim *anim_load(const char *real_filename, int cf_dir_type, int file_mapped)
 	}
 
 	if (!ptr) {
-		fp = cfopen(name, "rb", CFILE_NORMAL, cf_dir_type);
+		fp = cfopen(name, "rb", cf_dir_type);
 		if ( !fp )
 			return NULL;
 
@@ -743,18 +741,9 @@ anim *anim_load(const char *real_filename, int cf_dir_type, int file_mapped)
 
 		ptr->cfile_ptr = NULL;
 
-		if ( file_mapped == PAGE_FROM_MEM) {
-			// Try mapping the file to memory 
-			ptr->flags |= ANF_MEM_MAPPED;
-			ptr->cfile_ptr = cfopen(name, "rb", CFILE_MEMORY_MAPPED, cf_dir_type);
-		}
-
-		// couldn't memory-map file... must be in a packfile, so stream manually
-		if ( file_mapped == PAGE_FROM_MEM && !ptr->cfile_ptr ) {
-			ptr->flags &= ~ANF_MEM_MAPPED;
-			ptr->flags |= ANF_STREAMED;
-			ptr->cfile_ptr = cfopen(name, "rb", CFILE_NORMAL, cf_dir_type);
-		}
+		// NOTE: mapped files no longer supported!!
+		ptr->flags |= ANF_STREAMED;
+		ptr->cfile_ptr = cfopen(name, "rb", cf_dir_type);
 
 		ptr->cache = NULL;
 

--- a/code/anim/animplay.h
+++ b/code/anim/animplay.h
@@ -38,12 +38,6 @@ typedef struct {
 	int ping_pong;
 } anim_play_struct;
 
-enum
-{
-	PAGE_FROM_DISK		  = 0,
-	PAGE_FROM_MEM		  = 1
-};
-
 extern int Anim_paused;
 
 void				anim_init();
@@ -57,7 +51,7 @@ void				anim_ignore_next_frametime();
 int				anim_show_next_frame(anim_instance *instance, float frametime);
 void				anim_release_all_instances(int screen_id = 0);
 void				anim_release_render_instance(anim_instance* instance);
-anim			  *anim_load(const char *name, int cf_dir_type = CF_TYPE_ANY, int file_mapped = PAGE_FROM_DISK);
+anim			  *anim_load(const char *name, int cf_dir_type = CF_TYPE_ANY);
 int				anim_free(anim *ptr);
 void				anim_read_header(anim *ptr, CFILE *fp);
 void				anim_reverse_direction(anim_instance *ai);						// called automatically for ping-ponging, and can also be called externally

--- a/code/cfile/cfile.h
+++ b/code/cfile/cfile.h
@@ -85,10 +85,6 @@ typedef struct {
 // TRUE if type is specified and valid
 #define CF_TYPE_SPECIFIED(path_type) (((path_type)>CF_TYPE_INVALID) && ((path_type)<CF_MAX_PATH_TYPES))
 
-// #define's for the type parameter in cfopen.  
-#define CFILE_NORMAL				0			// open file normally
-#define CFILE_MEMORY_MAPPED	(1<<0)	//	open file as a memory-mapped file
-
 #define CF_SORT_NONE	0
 #define CF_SORT_NAME 1
 #define CF_SORT_TIME 2
@@ -181,7 +177,7 @@ int cf_get_dir_type(const CFILE *cfile);
 
 // Opens the file.  If no path is given, use the extension to look into the
 // default path.  If mode is NULL, delete the file.
-CFILE* _cfopen(const char* source_file, int line, const char* filename, const char* mode, int type = CFILE_NORMAL,
+CFILE* _cfopen(const char* source_file, int line, const char* filename, const char* mode,
                int dir_type = CF_TYPE_ANY, bool localize = false, uint32_t location_flags = CF_LOCATION_ALL);
 #define cfopen(...) _cfopen(LOCATION, __VA_ARGS__) // Pass source location to the function
 

--- a/code/cfile/cfilearchive.cpp
+++ b/code/cfile/cfilearchive.cpp
@@ -149,9 +149,6 @@ int cfseek( CFILE *cfile, int offset, int where )
 	if (cfile->compression_info.header != 0)
 		return comp_fseek(cfile, offset, where);
 
-	// TODO: seek to offset in memory mapped file
-	Assert( !cfile->mem_mapped );
-	
 	size_t goal_position;
 
 	switch( where )	{

--- a/code/cfile/cfilearchive.h
+++ b/code/cfile/cfilearchive.h
@@ -38,13 +38,6 @@ struct CFILE {
 	int dir_type;        // directory location
 	FILE* fp;                // File pointer if opening an individual file
 	const void* data;            // Pointer for memory-mapped file access.  NULL if not mem-mapped.
-	bool mem_mapped; // Flag for memory mapped files (if data is not null and this is false it means that it's an embedded file)
-#ifdef _WIN32
-	HANDLE	hInFile;			// Handle from CreateFile()
-	HANDLE	hMapFile;		// Handle from CreateFileMapping()
-#else
-	size_t data_length;    // length of data for mmap
-#endif
 	size_t lib_offset;
 	size_t raw_position;
 	size_t size;                // for packed files

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -1326,7 +1326,6 @@ bool control_config_accept(bool API_Access)
 			// Check if a preset file with name already exists.  If so, prompt the user
 			CFILE* fp = cfopen((str + ".json").c_str(),
 				"r",
-				CFILE_NORMAL,
 				CF_TYPE_PLAYER_BINDS,
 				false,
 				CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -1956,7 +1956,7 @@ int control_config_common_write_tbl(bool overwrite = false, bool all = false) {
 		return 1;
 	}
 
-	CFILE* cfile = cfopen("controlconfigdefaults.tbl", "w", CFILE_NORMAL, CF_TYPE_TABLES);
+	CFILE* cfile = cfopen("controlconfigdefaults.tbl", "w", CF_TYPE_TABLES);
 	if (cfile == nullptr) {
 		// Could not open. Bail.
 		return 1;

--- a/code/controlconfig/presets.cpp
+++ b/code/controlconfig/presets.cpp
@@ -45,7 +45,7 @@ void load_preset_files(SCP_string clone) {
 	std::unique_ptr<PresetFileHandler> handler = nullptr;
 
 	for (const auto &file : filelist) {
-		CFILE* fp = cfopen((file + ".json").c_str(), "r", CFILE_NORMAL, CF_TYPE_PLAYER_BINDS, false,
+		CFILE* fp = cfopen((file + ".json").c_str(), "r", CF_TYPE_PLAYER_BINDS, false,
 						   CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 		if (!fp) {
@@ -190,7 +190,7 @@ bool save_preset_file(CC_preset preset, bool overwrite) {
 	std::unique_ptr<PresetFileHandler> handler = nullptr;
 
 	// Check if there's a file already
-	CFILE* fp = cfopen(filename.c_str(), "r", CFILE_NORMAL, CF_TYPE_PLAYER_BINDS, false,
+	CFILE* fp = cfopen(filename.c_str(), "r", CF_TYPE_PLAYER_BINDS, false,
 	                  CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	
 	if ((fp != nullptr) && !overwrite) {
@@ -199,7 +199,7 @@ bool save_preset_file(CC_preset preset, bool overwrite) {
 	}
 
 	// Try opening file for write
-	fp = cfopen(filename.c_str(), "w", CFILE_NORMAL, CF_TYPE_PLAYER_BINDS, false,
+	fp = cfopen(filename.c_str(), "w", CF_TYPE_PLAYER_BINDS, false,
 					   CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if (!fp) {

--- a/code/ddsutils/ddsutils.cpp
+++ b/code/ddsutils/ddsutils.cpp
@@ -405,7 +405,7 @@ int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
 	strcat_s(real_name, ".dds");
 
 	// open it up and go to the data section
-	cfp = cfopen(real_name, "rb", CFILE_NORMAL, cf_type);
+	cfp = cfopen(real_name, "rb", cf_type);
 
 	// just in case
 	if (cfp == nullptr)
@@ -558,7 +558,7 @@ void dds_save_image(int width, int height, int bpp, int num_mipmaps, ubyte *data
 		strcat_s(real_filename, ".dds");
 	}
 
-	CFILE *image = cfopen( real_filename, "wb", CFILE_NORMAL, CF_TYPE_CACHE );
+	CFILE *image = cfopen( real_filename, "wb", CF_TYPE_CACHE );
 
 	if (image == NULL) {
 		mprintf(("Unable to open DDS image for saving!!\n"));

--- a/code/graphics/generic.cpp
+++ b/code/graphics/generic.cpp
@@ -187,7 +187,7 @@ int generic_anim_stream(generic_anim *ga, const bool cache)
 		if(ga->use_hud_color)
 			bpp = 8;
 		if (ga->ani.animation == nullptr) {
-			ga->ani.animation = anim_load(ga->filename, CF_TYPE_ANY, 0);
+			ga->ani.animation = anim_load(ga->filename, CF_TYPE_ANY);
 		}
 		if (ga->ani.instance == nullptr) {
 			ga->ani.instance = init_anim_instance(ga->ani.animation, bpp);

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -345,7 +345,7 @@ static SCP_string opengl_shader_get_header(shader_type type_id, int flags, bool 
 static SCP_string opengl_load_shader(const char* filename) {
 	SCP_string content;
 	if (Enable_external_shaders) {
-		CFILE* cf_shader = cfopen(filename, "rt", CFILE_NORMAL, CF_TYPE_EFFECTS);
+		CFILE* cf_shader = cfopen(filename, "rt", CF_TYPE_EFFECTS);
 
 		if (cf_shader != NULL) {
 			int len = cfilelength(cf_shader);
@@ -646,7 +646,7 @@ static bool load_cached_shader_binary(opengl::ShaderProgram* program, const SCP_
 	auto metadata = base_filename + ".json";
 	auto binary = base_filename + ".bin";
 
-	auto metadata_fp = cfopen(metadata.c_str(), "rb", CFILE_NORMAL, CF_TYPE_CACHE, false,
+	auto metadata_fp = cfopen(metadata.c_str(), "rb", CF_TYPE_CACHE, false,
 	                          CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	if (!metadata_fp) {
 		nprintf(("ShaderCache", "Metadata file does not exist.\n"));
@@ -688,7 +688,7 @@ static bool load_cached_shader_binary(opengl::ShaderProgram* program, const SCP_
 		return false;
 	}
 
-	auto binary_fp = cfopen(binary.c_str(), "rb", CFILE_NORMAL, CF_TYPE_CACHE, false,
+	auto binary_fp = cfopen(binary.c_str(), "rb", CF_TYPE_CACHE, false,
 	                        CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	if (!binary_fp) {
 		nprintf(("ShaderCache", "Binary file does not exist.\n"));
@@ -752,7 +752,7 @@ static void cache_program_binary(GLuint program, const SCP_string& hash) {
 	auto metadata_name = base_filename + ".json";
 	auto binary_name = base_filename + ".bin";
 
-	auto metadata_fp = cfopen(metadata_name.c_str(), "wb", CFILE_NORMAL, CF_TYPE_CACHE, false,
+	auto metadata_fp = cfopen(metadata_name.c_str(), "wb", CF_TYPE_CACHE, false,
 	                          CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	if (!metadata_fp) {
 		mprintf(("Could not open shader cache metadata file!\n"));
@@ -768,7 +768,7 @@ static void cache_program_binary(GLuint program, const SCP_string& hash) {
 	cfclose(metadata_fp);
 	json_decref(metadata);
 
-	auto binary_fp = cfopen(binary_name.c_str(), "wb", CFILE_NORMAL, CF_TYPE_CACHE, false,
+	auto binary_fp = cfopen(binary_name.c_str(), "wb", CF_TYPE_CACHE, false,
 	                        CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	if (!binary_fp) {
 		mprintf(("Could not open shader cache binary file!\n"));

--- a/code/graphics/software/FontManager.cpp
+++ b/code/graphics/software/FontManager.cpp
@@ -139,12 +139,12 @@ namespace font
 
 		lcl_add_dir_to_path_with_filename(typeface_lcl);
 
-		fp = cfopen(typeface_lcl.c_str(), "rb", CFILE_NORMAL, CF_TYPE_ANY);
+		fp = cfopen(typeface_lcl.c_str(), "rb", CF_TYPE_ANY);
 
 		// fallback if not found
 		if ( !fp )
 		{
-			fp = cfopen(typeface.c_str(), "rb", CFILE_NORMAL, CF_TYPE_ANY);
+			fp = cfopen(typeface.c_str(), "rb", CF_TYPE_ANY);
 		}
 
 		if ( !fp )
@@ -309,7 +309,7 @@ namespace font
 		auto iter = allocatedData.find(fileName);
 		if (iter == allocatedData.end())
 		{
-			CFILE *fontFile = cfopen(fileName.c_str(), "rb", CFILE_NORMAL, CF_TYPE_ANY);
+			CFILE *fontFile = cfopen(fileName.c_str(), "rb", CF_TYPE_ANY);
 
 			if (fontFile == nullptr)
 			{

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1635,7 +1635,7 @@ void hud_config_as_player()
 
 void hud_config_color_save(const char *name, int version)
 {
-	CFILE* out     = cfopen(name, "wt", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	CFILE* out     = cfopen(name, "wt", CF_TYPE_PLAYERS, false,
                         CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	try {

--- a/code/jpgutils/jpgutils.cpp
+++ b/code/jpgutils/jpgutils.cpp
@@ -177,7 +177,7 @@ int jpeg_read_bitmap(const char *real_filename, ubyte *image_data, ubyte * /*pal
 	strcat_s( filename, ".jpg" );
 
 
-	img_cfp = cfopen(filename, "rb", CFILE_NORMAL, cf_type);
+	img_cfp = cfopen(filename, "rb", cf_type);
 
 	if (img_cfp == NULL)
 		return JPEG_ERROR_READING;

--- a/code/libs/ffmpeg/FFmpegContext.cpp
+++ b/code/libs/ffmpeg/FFmpegContext.cpp
@@ -207,7 +207,7 @@ std::unique_ptr<FFmpegContext> FFmpegContext::createContextMem(const uint8_t* sn
 }
 
 std::unique_ptr<FFmpegContext> FFmpegContext::createContext(const SCP_string& path, int dir_type) {
-	CFILE* file = cfopen(path.c_str(), "rb", CFILE_NORMAL, dir_type);
+	CFILE* file = cfopen(path.c_str(), "rb", dir_type);
 
 	if (!file) {
 		throw FFmpegException("Failed to open file!");

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6908,7 +6908,7 @@ bool parse_main(const char *mission_name, int flags)
 	do {
 		// don't do this for imports
 		if (!(flags & MPF_IMPORT_FSM)) {
-			CFILE *ftemp = cfopen(mission_name, "rt", CFILE_NORMAL, CF_TYPE_MISSIONS);
+			CFILE *ftemp = cfopen(mission_name, "rt", CF_TYPE_MISSIONS);
 
 			// fail situation.
 			if (!ftemp) {

--- a/code/missionui/fictionviewer.cpp
+++ b/code/missionui/fictionviewer.cpp
@@ -599,7 +599,7 @@ void fiction_viewer_load(int stage)
 	// load up the text
 	SCP_string localized_filename = get_localized_fiction_filename(stagep->story_filename);
 
-	CFILE *fp = cfopen(localized_filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_FICTION);
+	CFILE *fp = cfopen(localized_filename.c_str(), "rb", CF_TYPE_FICTION);
 	if (fp == NULL)
 	{
 		Warning(LOCATION, "Unable to load story file '%s'.", localized_filename.c_str());

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -1614,7 +1614,7 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 
 		_splitpath(filename, NULL, NULL, bname, NULL);
 		sprintf(debug_name, "%s.subsystems", bname);
-		ss_fp = cfopen(debug_name, "wb", CFILE_NORMAL, CF_TYPE_TABLES );
+		ss_fp = cfopen(debug_name, "wb", CF_TYPE_TABLES );
 		if ( !ss_fp )	{
 			mprintf(( "Can't open debug file for writing subsystems for %s\n", filename));
 		} else {

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -185,7 +185,7 @@ void multi_options_read_config()
 	Multi_options_g.log = (Cmdline_multi_log) ? 1 : 0;
 
 	// read in the config file
-	in = cfopen(MULTI_CFG_FILE, "rt", CFILE_NORMAL, CF_TYPE_DATA);
+	in = cfopen(MULTI_CFG_FILE, "rt", CF_TYPE_DATA);
 	
 	// if we failed to open the config file, user default settings
 	if (in == NULL) {

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -3460,7 +3460,7 @@ void multi_pxo_set_end_of_motd()
 	
 	// write out the motd for next time
 	if(strlen(Pxo_motd)){
-		CFILE *out = cfopen("oldmotd.txt", "wb", CFILE_NORMAL, CF_TYPE_DATA);
+		CFILE *out = cfopen("oldmotd.txt", "wb", CF_TYPE_DATA);
 		if(out != NULL){
 			// write all the text
 			cfwrite(&new_chksum, sizeof(new_chksum), 1, out);
@@ -4694,7 +4694,7 @@ void multi_pxo_help_load()
 
 	// read in the text file
 	in = NULL;
-	in = cfopen(MULTI_PXO_HELP_FILE,"rt",CFILE_NORMAL,CF_TYPE_DATA);			
+	in = cfopen(MULTI_PXO_HELP_FILE,"rt",CF_TYPE_DATA);			
 	Assert(in != NULL);
 	if(in == NULL){
 		return;
@@ -5040,7 +5040,7 @@ void multi_pxo_ban_parse_banner_file()
 	char urls[10][512];
 	int num_banners, idx;
 
-	CFILE *in = cfopen(PXO_BANNERS_CONFIG_FILE, "rt", CFILE_NORMAL, CF_TYPE_MULTI_CACHE);
+	CFILE *in = cfopen(PXO_BANNERS_CONFIG_FILE, "rt", CF_TYPE_MULTI_CACHE);
 
 	// bad
 	if(in == NULL){

--- a/code/network/multi_xfer.cpp
+++ b/code/network/multi_xfer.cpp
@@ -238,7 +238,7 @@ int multi_xfer_send_file(PSNET_SOCKET_RELIABLE who, char *filename, int cfile_fl
 
 	// attempt to open the file
 	temp_entry.file = NULL;
-	temp_entry.file = cfopen(filename,"rb",CFILE_NORMAL,cfile_flags);
+	temp_entry.file = cfopen(filename,"rb",cfile_flags);
 	if(temp_entry.file == NULL){
 #ifdef MULTI_XFER_VERBOSE
 		nprintf(("Network","MULTI XFER : Could not open file %s on xfer send!\n",filename));
@@ -972,7 +972,7 @@ void multi_xfer_process_header(ubyte * /*data*/, PSNET_SOCKET_RELIABLE who, usho
 
 	// attempt to open the file (using the prefixed filename)
 	xe->file = NULL;
-	xe->file = cfopen(xe->ex_filename, "wb", CFILE_NORMAL, xe->force_dir);
+	xe->file = cfopen(xe->ex_filename, "wb", xe->force_dir);
 	if(xe->file == NULL){		
 		multi_xfer_send_nak(who, sig);		
 

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -1488,7 +1488,7 @@ void multi_join_read_ip_address_file(SCP_list<SCP_string>& list)
 	CFILE* file = NULL;
 
 	// attempt to open the ip list file
-	file = cfopen(IP_CONFIG_FNAME, "rt", CFILE_NORMAL, CF_TYPE_DATA);
+	file = cfopen(IP_CONFIG_FNAME, "rt", CF_TYPE_DATA);
 	if (file == NULL) {
 		nprintf(("Network", "Error loading tcp.cfg file!\n"));
 		return;
@@ -1525,7 +1525,7 @@ bool multi_join_write_ip_address_file(SCP_list<SCP_string>& list)
 	CFILE* file = NULL;
 
 	// attempt to open the ip list file for writing
-	file = cfopen(IP_CONFIG_FNAME, "wt", CFILE_NORMAL, CF_TYPE_DATA);
+	file = cfopen(IP_CONFIG_FNAME, "wt", CF_TYPE_DATA);
 	if (file == NULL) {
 		nprintf(("Network", "Error loading tcp.cfg file\n"));
 		return false;

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -2996,7 +2996,7 @@ void multi_update_valid_missions()
 	}
 	
 	// attempt to open the valid mission config file
-	in = cfopen(MULTI_VALID_MISSION_FILE, "rt", CFILE_NORMAL, CF_TYPE_DATA);
+	in = cfopen(MULTI_VALID_MISSION_FILE, "rt", CF_TYPE_DATA);
 
 	if (in != nullptr) {
 		// read in all listed missions
@@ -3069,7 +3069,7 @@ void multi_update_valid_missions()
 	}
 
 	// now rewrite the outfile with the new mission info
-	in = cfopen(MULTI_VALID_MISSION_FILE, "wt", CFILE_NORMAL, CF_TYPE_DATA);
+	in = cfopen(MULTI_VALID_MISSION_FILE, "wt", CF_TYPE_DATA);
 	if(in == nullptr){
 		// if we're a standalone, kill the validate dialog
 		if(Game_mode & GM_STANDALONE_SERVER){

--- a/code/parse/generic_log.cpp
+++ b/code/parse/generic_log.cpp
@@ -55,7 +55,7 @@ bool logfile_init(int logfile_type)
 	}
 
 	// attempt to open the file
-	logfiles[logfile_type].log_file = cfopen(logfiles[logfile_type].filename, "wt", CFILE_NORMAL, CF_TYPE_DATA);
+	logfiles[logfile_type].log_file = cfopen(logfiles[logfile_type].filename, "wt", CF_TYPE_DATA);
 
 	if(logfiles[logfile_type].log_file == NULL){
 		nprintf(("Network","Error opening %s for writing!!\n",logfiles[logfile_type].filename));

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2369,7 +2369,7 @@ void read_raw_file_text(const char *filename, int mode, char *raw_text)
 	if (!filename)
 		throw parse::FileOpenException("Filename must not be null!");
 
-	mf = cfopen(filename, "rb", CFILE_NORMAL, mode);
+	mf = cfopen(filename, "rb", mode);
 	if (mf == NULL)
 	{
 		nprintf(("Error", "Wokka!  Error opening file (%s)!\n", filename));
@@ -2646,7 +2646,7 @@ void read_file_bytes(const char *filename, int mode, char *raw_bytes)
 		Error(LOCATION, "ERROR: raw_bytes may not be NULL when parsing is paused!!\n");
 	}
 
-	mf = cfopen(filename, "rb", CFILE_NORMAL, mode);
+	mf = cfopen(filename, "rb", mode);
 	if (mf == nullptr)
 	{
 		nprintf(("Error", "Wokka!  Error opening file (%s)!\n", filename));

--- a/code/pcxutils/pcxutils.cpp
+++ b/code/pcxutils/pcxutils.cpp
@@ -234,7 +234,7 @@ int pcx_read_bitmap( const char * real_filename, ubyte *org_data, ubyte * /*pal*
 	strcat_s( filename, ".pcx" );
 
 	
-	PCXfile = cfopen( filename , "rb", CFILE_NORMAL, cf_type );
+	PCXfile = cfopen( filename , "rb", cf_type );
 	if ( !PCXfile ){
 	
 		return PCX_ERROR_OPENING;

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1692,7 +1692,7 @@ bool pilotfile::load_savefile(player *_p, const char *campaign)
 	m_data_invalid = false;
 
 	// open it, hopefully...
-	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	cfp = cfopen(filename.c_str(), "rb", CF_TYPE_PLAYERS, false,
 	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
@@ -1881,7 +1881,7 @@ bool pilotfile::save_savefile()
 	Assertion(Red_alert_wing_status.size() <= MAX_WINGS, "Invalid number of Red_alert_wing_status entries: " SIZE_T_ARG "\n", Red_alert_wing_status.size());
 
 	// open it, hopefully...
-	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	cfp = cfopen(filename.c_str(), "wb", CF_TYPE_PLAYERS, false,
 	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {
@@ -1963,7 +1963,7 @@ bool pilotfile::get_csg_rank(int *rank)
 	p = &t_csg;
 
 	// filename has already been set
-	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	cfp = cfopen(filename.c_str(), "rb", CF_TYPE_PLAYERS, false,
 	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -1179,7 +1179,7 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 
 	mprintf(("    CS2 => Converting '%s'...\n", filename.c_str()));
 
-	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL);
+	cfp = cfopen(filename.c_str(), "rb");
 
 	if ( !cfp ) {
 		mprintf(("    CS2 => Unable to open '%s' for import!\n", fname));
@@ -1209,7 +1209,7 @@ bool pilotfile_convert::csg_convert(const char *fname, bool inferno)
 	filename.assign(fname);
 	filename.append(".csg");
 
-	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	cfp = cfopen(filename.c_str(), "wb", CF_TYPE_PLAYERS, false,
 	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -1110,7 +1110,7 @@ bool pilotfile::load_player(const char* callsign, player* _p, bool force_binary)
 		return false;
 	}
 
-	auto fp = cfopen(filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	auto fp = cfopen(filename.c_str(), "rb", CF_TYPE_PLAYERS, false,
 	                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 	if ( !fp ) {
 		mprintf(("PLR => Unable to open '%s' for reading!\n", filename.c_str()));
@@ -1288,7 +1288,7 @@ bool pilotfile::save_player(player *_p)
 	filename += ".json";
 
 	// open it, hopefully...
-	auto fp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	auto fp = cfopen(filename.c_str(), "wb", CF_TYPE_PLAYERS, false,
 	                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !fp ) {
@@ -1364,7 +1364,7 @@ bool pilotfile::verify(const char *fname, int *rank, char *valid_language, int* 
 		return false;
 	}
 
-	auto fp = cfopen(filename.c_str(), "rb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	auto fp = cfopen(filename.c_str(), "rb", CF_TYPE_PLAYERS, false,
 	                 CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !fp ) {

--- a/code/pilotfile/plr_convert.cpp
+++ b/code/pilotfile/plr_convert.cpp
@@ -875,7 +875,7 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 
 	mprintf(("  PL2 => Converting '%s'...\n", filename.c_str()));
 
-	cfp = cfopen(filename.c_str(), "rb", CFILE_NORMAL);
+	cfp = cfopen(filename.c_str(), "rb");
 
 	if ( !cfp ) {
 		mprintf(("  PL2 => Unable to open '%s' for import!\n", fname));
@@ -899,7 +899,7 @@ bool pilotfile_convert::plr_convert(const char *fname, bool inferno)
 	filename.assign(fname);
 	filename.append(".plr");
 
-	cfp = cfopen(filename.c_str(), "wb", CFILE_NORMAL, CF_TYPE_PLAYERS, false,
+	cfp = cfopen(filename.c_str(), "wb", CF_TYPE_PLAYERS, false,
 	             CF_LOCATION_ROOT_USER | CF_LOCATION_ROOT_GAME | CF_LOCATION_TYPE_ROOT);
 
 	if ( !cfp ) {

--- a/code/pilotfile/plr_hudprefs.cpp
+++ b/code/pilotfile/plr_hudprefs.cpp
@@ -18,7 +18,7 @@ void hud_config_save_player_prefs(const char* callsign)
 	SCP_string filename = callsign;
 	filename += ".hdp";
 
-	CFILE* file = cfopen(filename.c_str(), "wt", CFILE_NORMAL, CF_TYPE_DATA);
+	CFILE* file = cfopen(filename.c_str(), "wt", CF_TYPE_DATA);
 
 	if (file == nullptr) {
 		mprintf(("HUDPREFS: Unable to open file '%s' for writing player HUD preferences.\n", filename.c_str()));

--- a/code/pngutils/pngutils.cpp
+++ b/code/pngutils/pngutils.cpp
@@ -318,7 +318,7 @@ int png_read_bitmap(const char* real_filename, ubyte* image_data, int* bpp, int 
 	if (p) *p = 0;
 	strcat_s(filename, ".png");
 
-	status.cfp = cfopen(filename, "rb", CFILE_NORMAL, cf_type);
+	status.cfp = cfopen(filename, "rb", cf_type);
 
 	if (status.cfp == NULL)
 		return PNG_ERROR_READING;

--- a/code/scpui/RocketFileInterface.cpp
+++ b/code/scpui/RocketFileInterface.cpp
@@ -35,7 +35,7 @@ FileHandle RocketFileInterface::Open(const String& path)
 		return 0;
 	}
 
-	return (FileHandle)cfopen(name.c_str(), "rb", CFILE_NORMAL, dir_type);
+	return (FileHandle)cfopen(name.c_str(), "rb", dir_type);
 }
 void RocketFileInterface::Close(FileHandle file) { cfclose((CFILE*)file); }
 size_t RocketFileInterface::Read(void* buffer, size_t size, FileHandle file)

--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -1017,7 +1017,7 @@ void load_default_script(lua_State* L, const char* name)
 		// Load from disk (or built-in file)
 		source_name = name;
 
-		auto cfp = cfopen(name, "rb", CFILE_NORMAL, CF_TYPE_SCRIPTS);
+		auto cfp = cfopen(name, "rb", CF_TYPE_SCRIPTS);
 		Assertion(cfp != nullptr, "Failed to open default file!");
 
 		auto length = cfilelength(cfp);

--- a/code/scripting/api/libs/cfile.cpp
+++ b/code/scripting/api/libs/cfile.cpp
@@ -118,8 +118,6 @@ ADE_FUNC(openFile, l_CFile, "string Filename, [string Mode=\"r\", string Path = 
 	if(!ade_get_args(L, "s|ss", &n_filename, &n_mode, &n_path))
 		return ade_set_error(L, "o", l_File.Set(cfile_h()));
 
-	int type = CFILE_NORMAL;
-
 	int path = CF_TYPE_ANY;
 	if(n_path != NULL && strlen(n_path))
 		path = cfile_get_path_type(n_path);
@@ -130,7 +128,7 @@ ADE_FUNC(openFile, l_CFile, "string Filename, [string Mode=\"r\", string Path = 
 	if((path == CF_TYPE_ANY) && (strchr(n_mode,'w') || strchr(n_mode,'+') || strchr(n_mode,'a')))
 		return ade_set_error(L, "o", l_File.Set(cfile_h()));
 
-	CFILE *cfp = cfopen(n_filename, n_mode, type, path);
+	CFILE *cfp = cfopen(n_filename, n_mode, path);
 
 	if(!cf_is_valid(cfp))
 		return ade_set_error(L, "o", l_File.Set(cfile_h()));

--- a/code/scripting/scripting.cpp
+++ b/code/scripting/scripting.cpp
@@ -117,7 +117,7 @@ void script_parse_table(const char* filename)
 void script_parse_lua_script(const char *filename) {
 	using namespace luacpp;
 
-	CFILE *cfp = cfopen(filename, "rb", CFILE_NORMAL, CF_TYPE_TABLES);
+	CFILE *cfp = cfopen(filename, "rb", CF_TYPE_TABLES);
 	if(cfp == nullptr)
 	{
 		Warning(LOCATION, "Could not open lua script file '%s'", filename);
@@ -630,7 +630,7 @@ void script_state::ParseChunkSub(script_function& script_func, const char* debug
 		char *filename = alloc_block("[[", "]]");
 
 		//Load from file
-		CFILE *cfp = cfopen(filename, "rb", CFILE_NORMAL, CF_TYPE_SCRIPTS );
+		CFILE *cfp = cfopen(filename, "rb", CF_TYPE_SCRIPTS );
 
 		//WMC - use filename instead of debug_str so that the filename gets passed.
 		function_name = filename;

--- a/code/tgautils/tgautils.cpp
+++ b/code/tgautils/tgautils.cpp
@@ -509,7 +509,7 @@ int targa_read_bitmap(const char *real_filename, ubyte *image_data, ubyte *palet
 	if ( p ) *p = 0;
 	strcat_s( filename, ".tga" );
 
-	targa_file = cfopen( filename , "rb", CFILE_NORMAL, cf_type );
+	targa_file = cfopen( filename , "rb", cf_type );
 	if ( !targa_file ){
 		return TARGA_ERROR_READING;
 	}		

--- a/fred2/dumpstats.cpp
+++ b/fred2/dumpstats.cpp
@@ -120,7 +120,7 @@ void DumpStats::OnDumpToFile()
 
 	CFILE *fp;
 
-	fp = cfopen((char *)LPCTSTR(dump_filename), "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
+	fp = cfopen((char *)LPCTSTR(dump_filename), "wt", CF_TYPE_MISSIONS);
 	cfputs((char *)LPCTSTR(buffer), fp);
 	cfclose(fp);
 }

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -1307,7 +1307,7 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 	fred_parse_flag = 0;
 
 	pathname = cf_add_ext(pathname, FS_CAMPAIGN_FILE_EXT);
-	fp = cfopen(pathname, "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
+	fp = cfopen(pathname, "wt", CF_TYPE_MISSIONS);
 	if (!fp) {
 		nprintf(("Error", "Can't open campaign file to save.\n"));
 		return -1;
@@ -3194,7 +3194,7 @@ void CFred_mission_save::save_mission_internal(const char *pathname)
 	raw_ptr = Parse_text_raw;
 	fred_parse_flag = 0;
 
-	fp = cfopen(pathname, "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
+	fp = cfopen(pathname, "wt", CF_TYPE_MISSIONS);
 	if (!fp) {
 		nprintf(("Error", "Can't open mission file to save.\n"));
 		err = -1;

--- a/fred2/voiceactingmanager.cpp
+++ b/fred2/voiceactingmanager.cpp
@@ -425,7 +425,7 @@ void VoiceActingManager::OnGenerateScript()
 
 	CString dlgPathName = dlg.GetPathName( );
 	string_copy(pathname, dlgPathName, 256 - 1);
-	fp = cfopen(pathname, "wt", CFILE_NORMAL);
+	fp = cfopen(pathname, "wt");
 	if (!fp)
 	{
 		MessageBox("Can't open file to save.", "Error!");

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6726,7 +6726,7 @@ void game_spew_pof_info()
 	}
 
 	// go
-	CFILE* out = cfopen("pofspew.txt", "wt", CFILE_NORMAL, CF_TYPE_DATA);
+	CFILE* out = cfopen("pofspew.txt", "wt", CF_TYPE_DATA);
 	if(out == nullptr){
 		BAIL();
 	}	

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2304,7 +2304,7 @@ int CFred_mission_save::save_campaign_file(const char *pathname)
 	fred_parse_flag = 0;
 
 	pathname = cf_add_ext(pathname, FS_CAMPAIGN_FILE_EXT);
-	fp = cfopen(pathname, "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
+	fp = cfopen(pathname, "wt", CF_TYPE_MISSIONS);
 	if (!fp) {
 		nprintf(("Error", "Can't open campaign file to save.\n"));
 		return -1;
@@ -3103,7 +3103,7 @@ void CFred_mission_save::save_mission_internal(const char* pathname)
 	raw_ptr = Parse_text_raw;
 	fred_parse_flag = 0;
 
-	fp = cfopen(pathname, "wt", CFILE_NORMAL, CF_TYPE_MISSIONS);
+	fp = cfopen(pathname, "wt", CF_TYPE_MISSIONS);
 	if (!fp) {
 		nprintf(("Error", "Can't open mission file to save.\n"));
 		err = -1;

--- a/test/src/cfile/cfile.cpp
+++ b/test/src/cfile/cfile.cpp
@@ -94,7 +94,7 @@ TEST_F(CFileTest, access_default_file) {
 	// We use the controlconfig file since that should stay relatively stable
 	ASSERT_TRUE(cf_exists("controlconfigdefaults.tbl", CF_TYPE_TABLES));
 
-	auto fp = cfopen("controlconfigdefaults.tbl", "rb", CFILE_NORMAL, CF_TYPE_TABLES);
+	auto fp = cfopen("controlconfigdefaults.tbl", "rb", CF_TYPE_TABLES);
 	ASSERT_TRUE(fp != nullptr);
 
 	ASSERT_EQ(28, cfilelength(fp));
@@ -106,7 +106,7 @@ TEST_F(CFileTest, override_default_file) {
 	// We use the controlconfig file since that should stay relatively stable
 	ASSERT_TRUE(cf_exists("controlconfigdefaults.tbl", CF_TYPE_TABLES));
 
-	auto fp = cfopen("controlconfigdefaults.tbl", "rb", CFILE_NORMAL, CF_TYPE_TABLES);
+	auto fp = cfopen("controlconfigdefaults.tbl", "rb", CF_TYPE_TABLES);
 	ASSERT_TRUE(fp != nullptr);
 
 	ASSERT_EQ(66, cfilelength(fp));

--- a/test/src/scripting/ScriptingTestFixture.cpp
+++ b/test/src/scripting/ScriptingTestFixture.cpp
@@ -26,7 +26,7 @@ void ScriptingTestFixture::TearDown() {
 	FSTestFixture::TearDown();
 }
 void ScriptingTestFixture::EvalTestScript() {
-	auto fp = cfopen("test.lua", "rb", CFILE_NORMAL, CF_TYPE_SCRIPTS);
+	auto fp = cfopen("test.lua", "rb", CF_TYPE_SCRIPTS);
 	if (fp == nullptr) {
 		FAIL() << "Failed to open test file!";
 	}


### PR DESCRIPTION
FSO doesn't appear to use this any longer. And even when it was enabled the requirements made it largely useless anyway. Removing to clean up cfile a bit and so we don't have to keep maintaining it.