### PR TITLE
enable audio in movie files with this one simple trick

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -2176,20 +2176,20 @@ ADE_FUNC(resetClip, l_Graphics, NULL, "Resets the clipping region that might hav
 	return ADE_RETURN_TRUE;
 }
 
-ADE_FUNC(openMovie, l_Graphics, "string name, boolean looping = false",
+ADE_FUNC(openMovie, l_Graphics, "string name, [boolean looping = false, boolean withAudio = false]",
          "Opens the movie with the specified name. If the name has an extension it will be removed. This function will "
          "try all movie formats supported by the engine and use the first that is found.",
          "movie_player", "The cutscene player handle or invalid handle if cutscene could not be opened.")
 {
 	const char* name = nullptr;
 	bool looping = false;
-	if (!ade_get_args(L, "s|b", &name, &looping)) {
+	bool with_audio = false;
+	if (!ade_get_args(L, "s|bb", &name, &looping, &with_audio)) {
 		return ade_set_error(L, "o", l_MoviePlayer.Set(movie_player_h()));
 	}
 
-	// Audio is disabled for scripted movies at the moment
 	cutscene::PlaybackProperties props;
-	props.with_audio = false;
+	props.with_audio = with_audio;
 	props.looping = looping;
 
 	auto player = cutscene::Player::newPlayer(name, props);


### PR DESCRIPTION
Turns out, audio works in scripted movies just fine.  So, add a parameter to the Lua API to allow movies to play audio.