### PR TITLE
fix STAY_NEAR_TARGET_ITEM

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -11476,7 +11476,7 @@ void ai_stay_near()
 	else if (aip->submode_parm0 != 0) {
 		vec3d rand_vec, center_to_goal, center_to_objp;
 		auto goal_objp = &Objects[goal_objnum];
-		float max_dist = aip->submode_float0;
+		float max_dist = std::max(aip->submode_float0, 1.0f);
 
 		// Figure out a goal point to fly to
 		//	Make not all ships pursue same point.
@@ -11507,7 +11507,7 @@ void ai_stay_near()
 	else {
 		vec3d	rand_vec, goal_pos, vec_to_goal;
 		auto goal_objp = &Objects[goal_objnum];
-		float max_dist = aip->submode_float0;
+		float max_dist = std::max(aip->submode_float0, 1.0f);
 
 		//	Make not all ships pursue same point.
 		//	Calculate the seed from both shipnums so the same Pl_objp doesn't always choose the same spot

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -732,12 +732,14 @@ void ai_goal_fixup_dockpoints(ai_info *aip, ai_goal *aigp)
 // from the mission goals (i.e. those goals which come from events) in that we don't
 // use sexpressions for goals from the player...so we enumerate all the parameters
 
-void ai_add_goal_sub_player(ai_goal_type type, ai_goal_mode mode, int submode, const char *target_name, ai_goal *aigp, const ai_lua_parameters& lua_target )
+void ai_add_goal_sub_player(ai_goal_type type, ai_goal_mode mode, int submode, const char *target_name, ai_goal *aigp, int int_data, float float_data, const ai_lua_parameters& lua_target )
 {
 	Assert ( (type == ai_goal_type::PLAYER_WING) || (type == ai_goal_type::PLAYER_SHIP) );
 
 	ai_goal_reset(aigp, true, mode, submode, type);
 
+	aigp->int_data = int_data;
+	aigp->float_data = float_data;
 	aigp->lua_ai_target = lua_target;
 
 	if ( mode == AI_GOAL_WARP ) {
@@ -865,14 +867,14 @@ void ai_add_ship_goal_scripting(ai_goal_mode mode, int submode, int priority, co
 // is issued to ship or wing (from player),  mode is AI_GOAL_*. submode is the submode the
 // ship should go into.  shipname is the object of the action.  aip is the ai_info pointer
 // of the ship receiving the order
-void ai_add_ship_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, const char *shipname, ai_info *aip, const ai_lua_parameters& lua_target)
+void ai_add_ship_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, const char *shipname, ai_info *aip, int int_data, float float_data, const ai_lua_parameters& lua_target)
 {
 	int empty_index;
 	ai_goal *aigp;
 
 	empty_index = ai_goal_find_empty_slot( aip->goals, aip->active_goal );
 	aigp = &aip->goals[empty_index];
-	ai_add_goal_sub_player( type, mode, submode, shipname, aigp, lua_target );
+	ai_add_goal_sub_player( type, mode, submode, shipname, aigp, int_data, float_data, lua_target );
 
 	// if the goal is to dock, then we must determine which dock points on the two ships to use.
 	// If the target of the dock is a cargo type container, then we should use DOCK_TYPE_CARGO
@@ -886,7 +888,7 @@ void ai_add_ship_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, 
 
 // adds a goal from the player to the given wing (which in turn will add it to the proper
 // ships in the wing
-void ai_add_wing_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, const char *shipname, int wingnum, const ai_lua_parameters& lua_target)
+void ai_add_wing_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, const char *shipname, int wingnum, int int_data, float float_data, const ai_lua_parameters& lua_target)
 {
 	int i, empty_index;
 	wing *wingp = &Wings[wingnum];
@@ -897,7 +899,7 @@ void ai_add_wing_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, 
 			int num = wingp->ship_index[i];
 			if ( num == -1 )			// ship must have been destroyed or departed
 				continue;
-			ai_add_ship_goal_player( type, mode, submode, shipname, &Ai_info[Ships[num].ai_index], lua_target );
+			ai_add_ship_goal_player( type, mode, submode, shipname, &Ai_info[Ships[num].ai_index], int_data, float_data, lua_target );
 		}
 	}
 
@@ -905,7 +907,7 @@ void ai_add_wing_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, 
 	// there are more waves to come.  We use the same method here as when adding a goal to
 	// a ship -- find the first empty entry.  If none exists, take the oldest entry and replace it.
 	empty_index = ai_goal_find_empty_slot( wingp->ai_goals, -1 );
-	ai_add_goal_sub_player( type, mode, submode, shipname, &wingp->ai_goals[empty_index], lua_target );
+	ai_add_goal_sub_player( type, mode, submode, shipname, &wingp->ai_goals[empty_index], int_data, float_data, lua_target );
 }
 
 

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -185,8 +185,8 @@ extern int ai_remove_goal_sexp_sub( int sexp, ai_goal* aigp, bool &remove_more )
 extern void ai_remove_wing_goal_sexp( int sexp, wing *wingp );
 
 // adds goals to ships/sings through player orders
-extern void ai_add_ship_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, const char* shipname, ai_info* aip, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), luacpp::LuaValueList{} });
-extern void ai_add_wing_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, const char* shipname, int wingnum, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), luacpp::LuaValueList{} });
+extern void ai_add_ship_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, const char* shipname, ai_info* aip, int int_data = 0, float float_data = 0.0f, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), luacpp::LuaValueList{} });
+extern void ai_add_wing_goal_player(ai_goal_type type, ai_goal_mode mode, int submode, const char* shipname, int wingnum, int int_data = 0, float float_data = 0.0f, const ai_lua_parameters& lua_target = { object_ship_wing_point_team(), luacpp::LuaValueList{} });
 
 extern void ai_remove_ship_goal( ai_info *aip, int index );
 extern void ai_clear_ship_goals( ai_info *aip );

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -147,8 +147,9 @@ SCP_vector<player_order> Player_orders = {
 };
 
 const SCP_set<size_t> default_messages{ ATTACK_TARGET_ITEM , DISABLE_TARGET_ITEM , DISARM_TARGET_ITEM , PROTECT_TARGET_ITEM , IGNORE_TARGET_ITEM , FORMATION_ITEM , COVER_ME_ITEM , ENGAGE_ENEMY_ITEM , DEPART_ITEM , DISABLE_SUBSYSTEM_ITEM };
+// note: STAY_NEAR_TARGET_ITEM appears in both enemy and friendly sets
 const SCP_set<size_t> enemy_target_messages{ ATTACK_TARGET_ITEM , DISABLE_TARGET_ITEM , DISARM_TARGET_ITEM , IGNORE_TARGET_ITEM , STAY_NEAR_TARGET_ITEM , CAPTURE_TARGET_ITEM , DISABLE_SUBSYSTEM_ITEM };
-const SCP_set<size_t> friendly_target_messages{ PROTECT_TARGET_ITEM };
+const SCP_set<size_t> friendly_target_messages{ PROTECT_TARGET_ITEM , STAY_NEAR_TARGET_ITEM };
 const SCP_set<size_t> target_messages = []() {
 	SCP_set<size_t> setunion;
 	std::set_union(enemy_target_messages.cbegin(), enemy_target_messages.cend(), friendly_target_messages.cbegin(), friendly_target_messages.cend(), std::inserter(setunion, setunion.end()));
@@ -1319,11 +1320,6 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 		
 		case STAY_NEAR_ME_ITEM:
 		case STAY_NEAR_TARGET_ITEM:
-
-			// cannot stay near a hostile ship(?)
-			if ( (command == STAY_NEAR_TARGET_ITEM) && (ship_team != target_team) )
-				break;
-
 			ai_mode = AI_GOAL_STAY_NEAR_SHIP;
 			ai_submode = -1;
 			message = MESSAGE_YESSIR;

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1099,6 +1099,8 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 	int ai_submode;					// ...and submode needed for ship commands
 	ship *target = nullptr;
 	char *target_shipname;
+	int int_data = 0;
+	float float_data = 0.0f;
 	ai_lua_parameters lua_target;
 	int message;
 	int target_team, ship_team;				// team id's for the ship getting message and any target the player has
@@ -1322,6 +1324,7 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 		case STAY_NEAR_TARGET_ITEM:
 			ai_mode = AI_GOAL_STAY_NEAR_SHIP;
 			ai_submode = -1;
+			float_data = 300.0f;	// distance from target ship
 			message = MESSAGE_YESSIR;
 			if (command == STAY_NEAR_ME_ITEM) {
 				target_shipname = ordering_shipp->ship_name;
@@ -1351,7 +1354,7 @@ int hud_squadmsg_send_ship_command( int shipnum, int command, int send_message, 
 		// handle case of messaging one ship.  Deal with messaging all fighters next.
 		if (ai_mode != AI_GOAL_NONE) {
 			Assert(ai_submode != -1234567);
-			ai_add_ship_goal_player(ai_goal_type::PLAYER_SHIP, ai_mode, ai_submode, target_shipname, &Ai_info[Ships[shipnum].ai_index], lua_target);
+			ai_add_ship_goal_player(ai_goal_type::PLAYER_SHIP, ai_mode, ai_submode, target_shipname, &Ai_info[Ships[shipnum].ai_index], int_data, float_data, lua_target);
 			if (update_history == SQUADMSG_HISTORY_ADD_ENTRY) {
 				hud_add_issued_order(Ships[shipnum].ship_name, command);
 				hud_update_last_order(target_shipname, player_num, special_index); 
@@ -1391,6 +1394,8 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 	int ai_submode;					// ...and submode needed for ship commands
 	ship *target = nullptr;
 	char *target_shipname;
+	int int_data = 0;
+	float float_data = 0.0f;
 	ai_lua_parameters lua_target;
 	int message_sent, message;
 	int target_team, wing_team;				// team for the wing and the player's target
@@ -1575,7 +1580,7 @@ int hud_squadmsg_send_wing_command( int wingnum, int command, int send_message, 
 
 		if (ai_mode != AI_GOAL_NONE) {
 			Assert(ai_submode != -1234567);
-			ai_add_wing_goal_player(ai_goal_type::PLAYER_WING, ai_mode, ai_submode, target_shipname, wingnum, lua_target);
+			ai_add_wing_goal_player(ai_goal_type::PLAYER_WING, ai_mode, ai_submode, target_shipname, wingnum, int_data, float_data, lua_target);
 
 			if (update_history == SQUADMSG_HISTORY_ADD_ENTRY) {
 				hud_add_issued_order(Wings[wingnum].name, command);


### PR DESCRIPTION
Fixes a few issues in the handling of the stay-near orders:

1. Allow "Stay near me" and "Stay near my target" to work even if the teams do not match
2. Allow "Stay near my target" to be issued regardless of team
3. Avoid divide-by-zero errors when running `ai_stay_near()`

Additionally, when issuing the stay-near-target order via hud squad message, default to a distance of 300, the same as the sexp.

Fixes #6475.