### PR TITLE
Fix window_res related bugs and harden OpenGL state

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -130,6 +130,8 @@ void gr_opengl_flip()
 	if (Cmdline_gl_finish)
 		glFinish();
 
+	Assertion(GL_state.ValidForFlip(), "OpenGL state is invalid!");
+
 	current_viewport->swapBuffers();
 
 	opengl_tcache_frame();
@@ -278,7 +280,11 @@ void gr_opengl_print_screen(const char *filename)
 
     _mkdir(os_get_config_path("screenshots").c_str());
 
-//	glReadBuffer(GL_FRONT);
+	GL_state.PushFramebufferState();
+	GL_state.BindFrameBuffer(Cmdline_window_res ? Back_framebuffer : 0, GL_FRAMEBUFFER);
+
+	//Reading from the front buffer here seems to no longer work correctly; that just reads back all zeros
+	glReadBuffer(Cmdline_window_res ? GL_COLOR_ATTACHMENT0 : GL_FRONT);
 
 	// now for the data
 	if (Use_PBOs) {
@@ -292,7 +298,6 @@ void gr_opengl_print_screen(const char *filename)
 		glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
 		glBufferData(GL_PIXEL_PACK_BUFFER, (gr_screen.max_w * gr_screen.max_h * 4), NULL, GL_STATIC_READ);
 
-		glReadBuffer(GL_FRONT);
 		glReadPixels(0, 0, gr_screen.max_w, gr_screen.max_h, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
 
 		// map the image data so that we can save it to file
@@ -319,6 +324,8 @@ void gr_opengl_print_screen(const char *filename)
 		glDeleteBuffers(1, &pbo);
 	}
 
+	GL_state.PopFramebufferState();
+
 	if (pixels != NULL) {
 		vm_free(pixels);
 	}
@@ -328,6 +335,12 @@ SCP_string gr_opengl_blob_screen()
 {
 	GLubyte* pixels = nullptr;
 	GLuint pbo = 0;
+
+	GL_state.PushFramebufferState();
+	GL_state.BindFrameBuffer(Cmdline_window_res ? Back_framebuffer : 0, GL_FRAMEBUFFER);
+
+	//Reading from the front buffer here seems to no longer work correctly; that just reads back all zeros
+	glReadBuffer(Cmdline_window_res ? GL_COLOR_ATTACHMENT0 : GL_FRONT);
 
 	// now for the data
 	if (Use_PBOs) {
@@ -341,7 +354,6 @@ SCP_string gr_opengl_blob_screen()
 		glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo);
 		glBufferData(GL_PIXEL_PACK_BUFFER, (gr_screen.max_w * gr_screen.max_h * 4), NULL, GL_STATIC_READ);
 
-		glReadBuffer(GL_FRONT);
 		glReadPixels(0, 0, gr_screen.max_w, gr_screen.max_h, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, NULL);
 
 		// map the image data so that we can save it to file
@@ -366,6 +378,8 @@ SCP_string gr_opengl_blob_screen()
 		glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 		glDeleteBuffers(1, &pbo);
 	}
+
+	GL_state.PopFramebufferState();
 
 	if (pixels != nullptr) {
 		vm_free(pixels);
@@ -618,7 +632,7 @@ void gr_opengl_get_region(int  /*front*/, int w, int h, ubyte *data)
 
 }
 
-int gr_opengl_save_screen()
+int  gr_opengl_save_screen()
 {
 	int i;
 	ubyte *sptr = NULL, *dptr = NULL;
@@ -640,7 +654,12 @@ int gr_opengl_save_screen()
 	}
 
 	GLboolean save_state = GL_state.DepthTest(GL_FALSE);
-	glReadBuffer(GL_FRONT_LEFT);
+
+	GL_state.PushFramebufferState();
+	GL_state.BindFrameBuffer(Cmdline_window_res ? Back_framebuffer : 0, GL_FRAMEBUFFER);
+
+	//Reading from the front buffer here seems to no longer work correctly; that just reads back all zeros
+	glReadBuffer(Cmdline_window_res ? GL_COLOR_ATTACHMENT0 : GL_FRONT);
 
 	if ( Use_PBOs ) {
 		GLubyte *pixels = NULL;
@@ -713,6 +732,7 @@ int gr_opengl_save_screen()
 		GL_saved_screen_id = bm_create(32, gr_screen.max_w, gr_screen.max_h, GL_saved_screen, 0);
 	}
 
+	GL_state.PopFramebufferState();
 	GL_state.DepthTest(save_state);
 
 	return GL_saved_screen_id;

--- a/code/graphics/opengl/gropenglstate.h
+++ b/code/graphics/opengl/gropenglstate.h
@@ -241,9 +241,9 @@ class opengl_state
 
 		GLuint current_program;
 
-		// The framebuffer state actually consists of draw and read buffers but we only use both at the same time
-		GLuint current_framebuffer;
-		SCP_vector<GLuint> framebuffer_stack;
+		// The first is the read buffer, the second is the draw buffer
+		std::pair<GLuint, GLuint> current_framebuffer;
+		SCP_vector<std::pair<GLuint, GLuint>> framebuffer_stack;
 
 		GLuint current_vao = 0;
 	public:
@@ -291,11 +291,14 @@ class opengl_state
 		bool IsCurrentProgram(GLuint program);
 
 		void BindFrameBuffer(GLuint name, GLenum mode = GL_FRAMEBUFFER);
+		void BindFrameBufferBoth(GLuint read, GLuint draw);
 
 		void PushFramebufferState();
 		void PopFramebufferState();
 
 		void BindVertexArray(GLuint vao);
+
+		bool ValidForFlip() const;
 };
 
 inline GLenum opengl_state::FrontFaceValue(GLenum new_val)


### PR DESCRIPTION
As it turns out, a few things were trying to read from incorrect buffers when window_res was active, causing OpenGL error messages and possibly unintended behaviour in some parts.
Fix these by reading from the correct buffer when window_res is used.
This is especially important as it appears that newer SDL versions (SDL3 through SDL2compat is definitely affected, possibly older versions as well) exhibit some sort of cleanup effect on the front buffer, which results in bad reads and incorrect rendering of pause frames and other dialogs. To fix this, a followup PR should likely enable window_res at all times (as is done for fullscreen at the momemt), and for that, window_res needs to function reliably and without OpenGL errors.

Also harden the GL state handling, by querying whether the GL state is valid for the buffer flip, as SDL will exhibit undefined behaviour if it is not set correctly.
