### PR TITLE
A couple of particle-related fixes

### DIFF
--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -80,7 +80,7 @@ void parse_curve_table(const char* filename) {
 			SCP_string name;
 			stuff_string(name, F_NAME);
 
-			if (name.find("(") != SCP_string::npos || name.find(")") != SCP_string::npos) {
+			if (name.find('(') != SCP_string::npos || name.find(')') != SCP_string::npos) {
 				error_display(0, "Curve name %s contains parentheses, which are not permitted.", name.c_str());
 			}
 

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -59,7 +59,7 @@ int curve_parse(const char *err_msg) {
 	}
 	else {
 		SCP_string curve_name;
-		stuff_string(curve_name, F_NAME);
+		stuff_string(curve_name, F_NAME, "()");
 		int curve_id = curve_get_by_name(curve_name);
 		if (curve_id < 0) {
 			error_display(0, "Curve %s not found!%s", curve_name.c_str(), err_msg);
@@ -79,6 +79,10 @@ void parse_curve_table(const char* filename) {
 		while (optional_string("$Name:")) {
 			SCP_string name;
 			stuff_string(name, F_NAME);
+
+			if (name.find("(") != SCP_string::npos || name.find(")") != SCP_string::npos) {
+				error_display(0, "Curve name %s contains parentheses, which are not permitted.", name.c_str());
+			}
 
 			int index = curve_get_by_name(name);
 

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -130,10 +130,9 @@ matrix ParticleEffect::getNewDirection(const matrix& hostOrientation, const std:
 			// Compute reflect vector as R = V - 2*(V dot N)*N where N
 			// is the normal and V is the incoming direction
 
-			return vm_matrix_new(1.f - 2.f * normal->xyz.x * normal->xyz.x, -2.f * normal->xyz.x * normal->xyz.y, -2.f * normal->xyz.x * normal->xyz.z,
+			return hostOrientation * vm_matrix_new(1.f - 2.f * normal->xyz.x * normal->xyz.x, -2.f * normal->xyz.x * normal->xyz.y, -2.f * normal->xyz.x * normal->xyz.z,
 								 -2.f * normal->xyz.x * normal->xyz.y, 1.f - 2.f * normal->xyz.y * normal->xyz.y, -2.f * normal->xyz.y * normal->xyz.z,
-								 -2.f * normal->xyz.x * normal->xyz.z, -2.f * normal->xyz.y * normal->xyz.z, 1.f - 2.f * normal->xyz.z * normal->xyz.z)
-								 * hostOrientation;
+								 -2.f * normal->xyz.x * normal->xyz.z, -2.f * normal->xyz.y * normal->xyz.z, 1.f - 2.f * normal->xyz.z * normal->xyz.z);
 		}
 		case ShapeDirection::REVERSE: {
 			return vm_matrix_new(hostOrientation.vec.rvec * -1.f, hostOrientation.vec.uvec * -1.f, hostOrientation.vec.fvec * -1.f);


### PR DESCRIPTION
Make it so that curve-based random ranges will properly detect the optional min and max values, rather than interpreting them as part of the curve name. Also, fix the 'reflected' direction for particle effects.