### PR TITLE
Fix two small visual-based bugs

### DIFF
--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -1268,7 +1268,7 @@ void fireball_render(object* obj, model_draw_list *scene)
 				flare_rad,
 				fi->flicker_magnitude,
 				obj->radius,
-				fi->use_3d_warp || (fb->flags & FBF_WARP_3D) != 0,
+				!Is_standalone && (fi->use_3d_warp || (fb->flags & FBF_WARP_3D) != 0),
 				fi->warp_glow_bitmap,
 				fi->warp_ball_bitmap,
 				fi->warp_model_id,

--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -298,6 +298,8 @@ void HudGaugeReticle::render(float  /*frametime*/, bool config)
 				}
 				has_autoaim_lock = false;
 			}
+		} else {
+			has_autoaim_lock = false;
 		}
 	}
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1811,8 +1811,6 @@ void game_init()
 		Cmdline_load_all_weapons = 0;
 
 		// Force some ingame options to off
-		options::OptionsManager::instance()->set_ingame_binary_option("Graphics.WarpFlash", false);
-
 		Use_3D_shockwaves = false;
 		options::OptionsManager::instance()->set_ingame_binary_option("Graphics.3DShockwaves", false);
 


### PR DESCRIPTION
PR fixes/cleans up two small visual bugs/clean-up aspects.

1) If a mod uses the autoaim frame feature of the center reticle (IE the center reticle switches to a second bitmap if a target is within the autoaim cone), then there is currently an edge case bug where if the player's target dies while in the autoaim cone, the value tracking whether or not to use the autoaim frame is never reset to false. This results in the autoaim frame remaining even when the target is dead and long destroyed. This PR properly resets the autoaim bool to false if the target is not valid, and overall works now as expected.

2) #6555 moved warp options to tables instead of via in-game options, but there was a line of code that still referenced `WarpFlash`, where that option was forced off in standalones. This PR properly removes that line and instead puts the standalone check as part of the input warp queue function.