### PR TITLE
Properly adapt the other workflow runs as well

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -155,13 +155,13 @@ jobs:
                 -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
                 -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
                 -DFSO_INSTALL_DEBUG_FILES="ON" -DFSO_BUILD_WITH_VULKAN="OFF" -A "$ARCHITECTURE" \
-                -G "Visual Studio 16 2019" -T "v142" ..
+                -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
           else
               cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
                 -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
                 -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
                 -DFSO_INSTALL_DEBUG_FILES="ON" -A "$ARCHITECTURE" \
-                -G "Visual Studio 16 2019" -T "v142" ..
+                -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
           fi
       - name: Compile
         working-directory: ./build

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -211,13 +211,13 @@ jobs:
                   -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
                   -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
                   -DFSO_INSTALL_DEBUG_FILES="ON" -DFSO_BUILD_WITH_VULKAN="OFF" -A "$ARCHITECTURE" \
-                  -G "Visual Studio 16 2019" -T "v142" ..
+                  -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
           else
               cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
                   -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
                   -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
                   -DFSO_INSTALL_DEBUG_FILES="ON" -A "$ARCHITECTURE" \
-                  -G "Visual Studio 16 2019" -T "v142" ..
+                  -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
           fi
       - name: Compile
         working-directory: ./build

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -153,13 +153,13 @@ jobs:
                 -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
                 -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
                 -DFSO_INSTALL_DEBUG_FILES="ON" -DFSO_BUILD_WITH_VULKAN="OFF" -A "$ARCHITECTURE" \
-                -G "Visual Studio 16 2019" -T "v142" ..
+                -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
           else
               cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
                 -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
                 -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
                 -DFSO_INSTALL_DEBUG_FILES="ON" -A "$ARCHITECTURE" \
-                -G "Visual Studio 16 2019" -T "v142" ..
+                -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
           fi
       - name: Compile
         working-directory: ./build


### PR DESCRIPTION
Followup to #6766.
Other than the test run, the nightly and release runs need to be adapted as well to generate build files for the correct IDE.