### PR TITLE
Allow Mouse Wheel to work with trigger type controls

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2825,23 +2825,20 @@ int check_control_used(int id, int key)
 
 	short z = item.get_btn(CID_KEYBOARD);	// Get the key that's bound to this control
 
-	// this is awful, need to make a reverse lookup table to do button -> control 
-	// instead of this control -> button nonsense.
-	bool joy_pressed =   (joy_down(item.first) || joy_down_count(item.first, 1)) ||
-	                     (joy_down(item.second) || joy_down_count(item.second, 1));
-	bool mouse_pressed = (mouse_down(item.first) || mouse_down_count(item.first, 1)) ||
-	                     (mouse_down(item.second) || mouse_down_count(item.second, 1));
-
 	if (item.type == CC_TYPE_CONTINUOUS) {
 		
-		if (joy_pressed) {
+		// this is awful, need to make a reverse lookup table to do button -> control instead of this control -> button
+		// nonsense.
+		if ((joy_down(item.first) || joy_down_count(item.first, 1)) ||
+			(joy_down(item.second) || joy_down_count(item.second, 1))) {
 			// Joy button bound to this control was pressed, control activated
 			control_used(id);
 			return 1;
 		}
 
-		if (mouse_pressed) {
-			// Mouse button bound to this control was pressed, control activated
+		if ((mouse_down(item.first) || mouse_down_count(item.first, 1)) ||
+			(mouse_down(item.second) || mouse_down_count(item.second, 1))) {
+			// Joy button bound to this control was pressed, control activated
 			control_used(id);
 			return 1;
 		}
@@ -2879,7 +2876,9 @@ int check_control_used(int id, int key)
 		return 0;
 	}
 
-	if (((z >= 0) && (z == key)) || joy_pressed || mouse_pressed) {
+	if (((z >= 0) && (z == key)) ||
+		joy_down_count(item.first, 1) || joy_down_count(item.second, 1) ||
+		mouse_down_count(item.first, 1) || mouse_down_count(item.second, 1)) {
 		//mprintf(("Key used %d\n", key));
 		control_used(id);
 		return 1;

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2827,8 +2827,8 @@ int check_control_used(int id, int key)
 
 	if (item.type == CC_TYPE_CONTINUOUS) {
 		
-		// this is awful, need to make a reverse lookup table to do button -> control instead of this control -> button
-		// nonsense.
+		// this is awful, need to make a reverse lookup table to do 
+		// button -> control instead of this control -> button nonsense.
 		if ((joy_down(item.first) || joy_down_count(item.first, 1)) ||
 			(joy_down(item.second) || joy_down_count(item.second, 1))) {
 			// Joy button bound to this control was pressed, control activated
@@ -2838,7 +2838,7 @@ int check_control_used(int id, int key)
 
 		if ((mouse_down(item.first) || mouse_down_count(item.first, 1)) ||
 			(mouse_down(item.second) || mouse_down_count(item.second, 1))) {
-			// Joy button bound to this control was pressed, control activated
+			// Mouse button bound to this control was pressed, control activated
 			control_used(id);
 			return 1;
 		}
@@ -2880,6 +2880,16 @@ int check_control_used(int id, int key)
 		joy_down_count(item.first, 1) || joy_down_count(item.second, 1) ||
 		mouse_down_count(item.first, 1) || mouse_down_count(item.second, 1)) {
 		//mprintf(("Key used %d\n", key));
+		control_used(id);
+		return 1;
+	}
+
+	// special case to allow actual mouse wheel to work with trigger controls --wookieejedi
+	if (item.type == CC_TYPE_TRIGGER && !Use_mouse_to_fly && 
+		((1 << item.first.get_btn() >= LOWEST_MOUSE_WHEEL && 1 << item.first.get_btn() <= HIGHEST_MOUSE_WHEEL) || 
+		(1 << item.second.get_btn() >= LOWEST_MOUSE_WHEEL && 1 << item.second.get_btn() <= HIGHEST_MOUSE_WHEEL)) &&
+		(mouse_down(item.first) || mouse_down(item.second)) ) {
+		// Mouse wheel bound to this trigger control was pressed, control activated
 		control_used(id);
 		return 1;
 	}

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2825,20 +2825,23 @@ int check_control_used(int id, int key)
 
 	short z = item.get_btn(CID_KEYBOARD);	// Get the key that's bound to this control
 
+	// this is awful, need to make a reverse lookup table to do button -> control 
+	// instead of this control -> button nonsense.
+	bool joy_pressed =   (joy_down(item.first) || joy_down_count(item.first, 1)) ||
+	                     (joy_down(item.second) || joy_down_count(item.second, 1));
+	bool mouse_pressed = (mouse_down(item.first) || mouse_down_count(item.first, 1)) ||
+	                     (mouse_down(item.second) || mouse_down_count(item.second, 1));
+
 	if (item.type == CC_TYPE_CONTINUOUS) {
 		
-		// this is awful, need to make a reverse lookup table to do button -> control instead of this control -> button
-		// nonsense.
-		if ((joy_down(item.first) || joy_down_count(item.first, 1)) ||
-			(joy_down(item.second) || joy_down_count(item.second, 1))) {
+		if (joy_pressed) {
 			// Joy button bound to this control was pressed, control activated
 			control_used(id);
 			return 1;
 		}
 
-		if ((mouse_down(item.first) || mouse_down_count(item.first, 1)) ||
-			(mouse_down(item.second) || mouse_down_count(item.second, 1))) {
-			// Joy button bound to this control was pressed, control activated
+		if (mouse_pressed) {
+			// Mouse button bound to this control was pressed, control activated
 			control_used(id);
 			return 1;
 		}
@@ -2876,9 +2879,7 @@ int check_control_used(int id, int key)
 		return 0;
 	}
 
-	if (((z >= 0) && (z == key)) ||
-		joy_down_count(item.first, 1) || joy_down_count(item.second, 1) ||
-		mouse_down_count(item.first, 1) || mouse_down_count(item.second, 1)) {
+	if (((z >= 0) && (z == key)) || joy_pressed || mouse_pressed) {
 		//mprintf(("Key used %d\n", key));
 		control_used(id);
 		return 1;

--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2804,6 +2804,8 @@ void control_check_indicate()
 
 int check_control_used(int id, int key)
 {
+	// Make sure mouse_down() is only called once during any logic path, 
+	// or the mousewheel may be decayed multiple times!!
 	int mask;
 	static int last_key = 0;
 	auto & item = Control_config[id];
@@ -2885,13 +2887,19 @@ int check_control_used(int id, int key)
 	}
 
 	// special case to allow actual mouse wheel to work with trigger controls --wookieejedi
-	if (item.type == CC_TYPE_TRIGGER && !Use_mouse_to_fly && 
-		((1 << item.first.get_btn() >= LOWEST_MOUSE_WHEEL && 1 << item.first.get_btn() <= HIGHEST_MOUSE_WHEEL) || 
-		(1 << item.second.get_btn() >= LOWEST_MOUSE_WHEEL && 1 << item.second.get_btn() <= HIGHEST_MOUSE_WHEEL)) &&
-		(mouse_down(item.first) || mouse_down(item.second)) ) {
-		// Mouse wheel bound to this trigger control was pressed, control activated
-		control_used(id);
-		return 1;
+	if (item.type == CC_TYPE_TRIGGER) {
+
+		int first_btn = 1 << item.first.get_btn();
+		int second_btn = 1 << item.second.get_btn();
+
+		if ( (first_btn >= LOWEST_MOUSE_WHEEL && first_btn <= HIGHEST_MOUSE_WHEEL) ||
+			 (second_btn >= LOWEST_MOUSE_WHEEL && second_btn <= HIGHEST_MOUSE_WHEEL) ) {
+			if ( mouse_down(item.first) || mouse_down(item.second) ) {
+				// Mouse wheel bound to this trigger control was pressed, control activated
+				control_used(id);
+				return 1;
+			}
+		}
 	}
 
 	return 0;

--- a/code/io/mouse.h
+++ b/code/io/mouse.h
@@ -94,6 +94,9 @@ void mouse_flush();
  * @returns 0 if the button is not down, or
  * 
  * @returns 1 if the given button is down
+ * 
+ * @note Calls mousewheel_decay() if the mousewheel direction is "down".  
+ *       Please ensure mouse_down() is called only once per frame.
  */
 int mouse_down(const CC_bind &bind);
 


### PR DESCRIPTION
From #6777: Binding the mouse wheel to a control of type `CC_TYPE_TRIGGER`, such as `Cycle Primary Weapon Forward` does not work in game. IE, scroll the mouse wheel up will not trigger then control. The mouse wheel does seem to work for controls with type `CC_TYPE_CONTINUOUS` though.

This is because `mouse_down` and `joy_down` were only checked within the if-block for `item.type == CC_TYPE_CONTINUOUS` within the function `check_control_used`.

This PR fixes #6777 by using `joy_down/mouse_down` and  `joy_down_count/mouse_down_count` for any controls, not just those of `CC_TYPE_CONTINUOUS`.

Tested and everything works as expected, and being able to use the mouse wheel for all controls now greatly enhances the configurable controls and overall gameplay experience IMO as a mainly mouse-keyboard player.

I'd be happy to edit or tune however, or add a specific manual end check for just the mouse wheel if the current checks are too broad.