### PR TITLE
Two Sound Updates

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1788,6 +1788,5 @@ void mod_table_set_version_flags()
 		Use_model_eyepoint_for_set_camera_host = true;
 		Use_model_eyepoint_normals = true;
 		Fix_asteroid_bounding_box_check = true;
-		Unify_minimum_engine_sound = true;
 	}
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -152,6 +152,8 @@ bool SCPUI_loads_hi_res_animations;
 bool Auto_assign_personas;
 bool Countermeasures_use_capacity;
 bool Play_thruster_sounds_for_player;
+bool Unify_minimum_engine_sound;
+bool Disabled_engines_are_silent;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
 bool Disable_shield_effects;
@@ -1043,6 +1045,14 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Play_thruster_sounds_for_player);
 			}
 
+			if (optional_string("$Unify minimum engine sound:")) {
+				stuff_boolean(&Unify_minimum_engine_sound);
+			}
+
+			if (optional_string("$Disabled engines are silent:")) {
+				stuff_boolean(&Disabled_engines_are_silent);
+			}
+
 			optional_string("#FRED SETTINGS");
 
 			if (optional_string("$Disable Hard Coded Message Head Ani Files:")) {
@@ -1728,6 +1738,8 @@ void mod_table_reset()
 	Auto_assign_personas = true;
 	Countermeasures_use_capacity = false;
 	Play_thruster_sounds_for_player = false;
+	Unify_minimum_engine_sound = false;
+	Disabled_engines_are_silent = false;
 	Fred_spacemouse_nonlinearity = std::array<std::tuple<float, float>, 6>{{
 			std::tuple<float, float>{ 1.0f, 1.0f },
 			std::tuple<float, float>{ 1.0f, 1.0f },
@@ -1782,5 +1794,7 @@ void mod_table_set_version_flags()
 		Use_model_eyepoint_for_set_camera_host = true;
 		Use_model_eyepoint_normals = true;
 		Fix_asteroid_bounding_box_check = true;
+		Unify_minimum_engine_sound = true;
+		Disabled_engines_are_silent = true;
 	}
 }

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -153,7 +153,6 @@ bool Auto_assign_personas;
 bool Countermeasures_use_capacity;
 bool Play_thruster_sounds_for_player;
 bool Unify_minimum_engine_sound;
-bool Disabled_engines_are_silent;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
 bool Disable_shield_effects;
@@ -1049,10 +1048,6 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Unify_minimum_engine_sound);
 			}
 
-			if (optional_string("$Disabled engines are silent:")) {
-				stuff_boolean(&Disabled_engines_are_silent);
-			}
-
 			optional_string("#FRED SETTINGS");
 
 			if (optional_string("$Disable Hard Coded Message Head Ani Files:")) {
@@ -1739,7 +1734,6 @@ void mod_table_reset()
 	Countermeasures_use_capacity = false;
 	Play_thruster_sounds_for_player = false;
 	Unify_minimum_engine_sound = false;
-	Disabled_engines_are_silent = false;
 	Fred_spacemouse_nonlinearity = std::array<std::tuple<float, float>, 6>{{
 			std::tuple<float, float>{ 1.0f, 1.0f },
 			std::tuple<float, float>{ 1.0f, 1.0f },
@@ -1795,6 +1789,5 @@ void mod_table_set_version_flags()
 		Use_model_eyepoint_normals = true;
 		Fix_asteroid_bounding_box_check = true;
 		Unify_minimum_engine_sound = true;
-		Disabled_engines_are_silent = true;
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -167,6 +167,8 @@ extern bool SCPUI_loads_hi_res_animations;
 extern bool Auto_assign_personas;
 extern bool Countermeasures_use_capacity;
 extern bool Play_thruster_sounds_for_player;
+extern bool Unify_minimum_engine_sound;
+extern bool Disabled_engines_are_silent;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
 extern bool Disable_shield_effects;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -168,7 +168,6 @@ extern bool Auto_assign_personas;
 extern bool Countermeasures_use_capacity;
 extern bool Play_thruster_sounds_for_player;
 extern bool Unify_minimum_engine_sound;
-extern bool Disabled_engines_are_silent;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
 extern bool Disable_shield_effects;

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -517,7 +517,7 @@ void obj_snd_do_frame()
 
 			// we don't want to start the engine sound unless the ship is
 			// moving (unless flag SIF_BIG_SHIP is set)
-			if ( (osp->flags & OS_ENGINE) && !(sip->is_big_or_huge()) ) {
+			if ( (osp->flags & OS_ENGINE) && (!(sip->is_big_or_huge()) || Unify_minimum_engine_sound) ) {
 				if ( objp->phys_info.max_vel.xyz.z <= 0.0f ) {
 					percent_max = 0.0f;
 				}
@@ -666,7 +666,8 @@ void obj_snd_do_frame()
 		channel = ds_get_channel(osp->instance);
 		// for DirectSound3D sounds, re-establish the maximum speed based on the
 		//	speed_vol_multiplier
-		if ( (sp == nullptr) || !(osp->flags & OS_ENGINE) || (sp->flags[Ship::Ship_Flags::Engines_on]) ) {
+		if ( (sp == nullptr) || !(osp->flags & OS_ENGINE) || 
+			(sp->flags[Ship::Ship_Flags::Engine_sound_on] && !(sp->flags[Ship::Ship_Flags::Disabled] && Disabled_engines_are_silent)) ) {
 			snd_set_volume( osp->instance, gs->volume_range.next() *speed_vol_multiplier*rot_vol_mult*alive_vol_mult );
 		}
 		else {

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -667,7 +667,7 @@ void obj_snd_do_frame()
 		// for DirectSound3D sounds, re-establish the maximum speed based on the
 		//	speed_vol_multiplier
 		if ( (sp == nullptr) || !(osp->flags & OS_ENGINE) || 
-			(sp->flags[Ship::Ship_Flags::Engine_sound_on] && !(sp->flags[Ship::Ship_Flags::Disabled] && Disabled_engines_are_silent)) ) {
+		     ((sp->flags[Ship::Ship_Flags::Engine_sound_on]) && !(sp->flags[Ship::Ship_Flags::Disabled])) ) {
 			snd_set_volume( osp->instance, gs->volume_range.next() *speed_vol_multiplier*rot_vol_mult*alive_vol_mult );
 		}
 		else {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7370,7 +7370,7 @@ static void ship_set(int ship_index, int objnum, int ship_type)
 
 	ets_init_ship(objp);	// init ship fields that are used for the ETS
 
-	shipp->flags.set(Ship_Flags::Engines_on);
+	shipp->flags.set(Ship_Flags::Engine_sound_on);
 
 	// set certain flags that used to be in ship_info - Goober5000
 	if (sip->flags[Ship::Info_Flags::Stealth])
@@ -9561,7 +9561,7 @@ static void ship_dying_frame(object *objp, int ship_num)
 		// If a ship is dying (and not a capital or big ship) then stutter the engine sound
 		if ( timestamp_elapsed(shipp->next_engine_stutter) ) {
 			if ( !(sip->is_big_or_huge()) ) {
-				shipp->flags.toggle(Ship_Flags::Engines_on);			// toggle state of engines
+				shipp->flags.toggle(Ship_Flags::Engine_sound_on); // toggle state of engines
 				shipp->next_engine_stutter = timestamp_rand(50, 250);
 			}
 		}

--- a/code/ship/ship_flags.h
+++ b/code/ship/ship_flags.h
@@ -65,7 +65,7 @@ namespace Ship {
 		Arriving_stage_1_dock_follower,		// "Arriving but Not the Dock Leader"; these guys need some warp stuff done but not all
 		Arriving_stage_2,			// ship is arriving. In other words, doing warp in effect, stage 2             
 		Arriving_stage_2_dock_follower,		// "Arriving but Not the Dock Leader"; these guys need some warp stuff done but not all
-		Engines_on,					// engines sound should play if set
+		Engine_sound_on,                // engines sound should play if set
 		Dock_leader,				// Goober5000 - this guy is in charge of everybody he's docked to
 		Cargo_revealed,				// ship's cargo is revealed to all friendly ships
 		From_player_wing,			// set for ships that are members of any player starting wing


### PR DESCRIPTION
On current master, destroyed engines still make noise and the `Engine Minimum Volume` is not used by big ships. This PR makes two new game settings flags which allow mods to mitigate those issues (`$Unify minimum engine sound:` and `$Disabled engines are silent:`).

Tested and works as expected. Note, I also renamed `Engines_on` flag to `Engine_sound_on` to better reflect what it does (it is only used by engine noised when the ship dies and stutters). I did evaluate using that flag and always setting it with `Disabled` but that would introduce maintaining two separate flags that overly complicated the code IMO. 

I also added both of these to the 25.0 default, but happy to alter however.