### PR TITLE
Enhanced functionality for conditional impacts

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -686,6 +686,8 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 		}
 	}
 
+	db->max_hull = obj->hull_strength;
+
 	if (hull_flag) {
 		MONITOR_INC(NumHullDebris,1);
 	} else {

--- a/code/debris/debris.h
+++ b/code/debris/debris.h
@@ -45,6 +45,7 @@ typedef struct debris {
 	int		submodel_num;			// What submodel this uses
 	TIMESTAMP	next_fireball;		// When to start a fireball
 	bool	is_hull;				// indicates whether this is a collideable, destructable piece of debris from the model, or just a generic debris fragment
+	float	max_hull;
 	int		species;				// What species this is from.  -1 if don't care.
 	TIMESTAMP	fire_timeout;		// timestamp that holds time for fireballs to stop appearing
 	TIMESTAMP	sound_delay;		// timestamp to signal when sound should start

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -6997,7 +6997,8 @@ void process_asteroid_info( ubyte *data, header *hinfo )
 		
 		// if we know the other object is a weapon, then do a weapon hit to kill the weapon
 		if ( other_objp && (other_objp->type == OBJ_WEAPON) ){
-			weapon_hit( other_objp, objp, &hitpos );
+			bool armed = weapon_hit( other_objp, objp, &hitpos );
+			maybe_play_conditional_impacts({}, other_objp, objp, armed, -1, &hitpos);
 		}
 		break;
 	}

--- a/code/object/collidedebrisweapon.cpp
+++ b/code/object/collidedebrisweapon.cpp
@@ -70,15 +70,14 @@ int collide_debris_weapon( obj_pair * pair )
 			vec3d force = weapon_obj->phys_info.vel * Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].mass;
 			bool armed = weapon_hit( weapon_obj, pdebris, &hitpos, -1 );
 			float damage = Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].damage;
-			std::array<const ConditionData*, NumHitTypes> impact_data = {};
-			ConditionData debris_impact = ConditionData {
+			std::array<std::optional<ConditionData>, NumHitTypes> impact_data = {};
+			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
 				SpecialImpactCondition::DEBRIS,
 				HitType::HULL,
 				damage,
 				pdebris->hull_strength,
 				Debris[pdebris->instance].max_hull,
 			};
-			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &debris_impact;
 			maybe_play_conditional_impacts(impact_data, weapon_obj, pdebris, armed, -1, &hitpos, nullptr, &hitnormal);
 			debris_hit( pdebris, weapon_obj, &hitpos, damage , &force);
 		}
@@ -160,15 +159,14 @@ int collide_asteroid_weapon( obj_pair * pair )
 			vec3d force = weapon_obj->phys_info.vel * Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].mass;
 			bool armed = weapon_hit( weapon_obj, pasteroid, &hitpos, -1);
 			float damage = Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].damage;
-			std::array<const ConditionData*, NumHitTypes> impact_data = {};
-			ConditionData asteroid_impact = ConditionData {
+			std::array<std::optional<ConditionData>, NumHitTypes> impact_data = {};
+			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
 				SpecialImpactCondition::DEBRIS,
 				HitType::HULL,
 				damage,
 				pasteroid->hull_strength,
 				Asteroid_info[Asteroids[pasteroid->instance].asteroid_type].initial_asteroid_strength,
 			};
-			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &asteroid_impact;
 			maybe_play_conditional_impacts(impact_data, weapon_obj, pasteroid, armed, -1, &hitpos, nullptr, &hitnormal);
 			asteroid_hit( pasteroid, weapon_obj, &hitpos, damage, &force );
 		}

--- a/code/object/collidedebrisweapon.cpp
+++ b/code/object/collidedebrisweapon.cpp
@@ -68,8 +68,19 @@ int collide_debris_weapon( obj_pair * pair )
 		if(!weapon_override && !debris_override)
 		{
 			vec3d force = weapon_obj->phys_info.vel * Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].mass;
-			weapon_hit( weapon_obj, pdebris, &hitpos, -1, &hitnormal );
-			debris_hit( pdebris, weapon_obj, &hitpos, Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].damage , &force);
+			bool armed = weapon_hit( weapon_obj, pdebris, &hitpos, -1 );
+			float damage = Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].damage;
+			std::array<const ConditionData*, NumHitTypes> impact_data = {};
+			ConditionData debris_impact = ConditionData {
+				SpecialImpactCondition::DEBRIS,
+				HitType::HULL,
+				damage,
+				pdebris->hull_strength,
+				Debris[pdebris->instance].max_hull,
+			};
+			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &debris_impact;
+			maybe_play_conditional_impacts(impact_data, weapon_obj, pdebris, armed, -1, &hitpos, nullptr, &hitnormal);
+			debris_hit( pdebris, weapon_obj, &hitpos, damage , &force);
 		}
 
 		if (scripting::hooks::OnDebrisCollision->isActive() && !(debris_override && !weapon_override))
@@ -147,8 +158,19 @@ int collide_asteroid_weapon( obj_pair * pair )
 		if(!weapon_override && !asteroid_override)
 		{
 			vec3d force = weapon_obj->phys_info.vel * Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].mass;
-			weapon_hit( weapon_obj, pasteroid, &hitpos, -1, &hitnormal);
-			asteroid_hit( pasteroid, weapon_obj, &hitpos, Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].damage, &force );
+			bool armed = weapon_hit( weapon_obj, pasteroid, &hitpos, -1);
+			float damage = Weapon_info[Weapons[weapon_obj->instance].weapon_info_index].damage;
+			std::array<const ConditionData*, NumHitTypes> impact_data = {};
+			ConditionData asteroid_impact = ConditionData {
+				SpecialImpactCondition::DEBRIS,
+				HitType::HULL,
+				damage,
+				pasteroid->hull_strength,
+				Asteroid_info[Asteroids[pasteroid->instance].asteroid_type].initial_asteroid_strength,
+			};
+			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &asteroid_impact;
+			maybe_play_conditional_impacts(impact_data, weapon_obj, pasteroid, armed, -1, &hitpos, nullptr, &hitnormal);
+			asteroid_hit( pasteroid, weapon_obj, &hitpos, damage, &force );
 		}
 
 		if (scripting::hooks::OnAsteroidCollision->isActive() && !(asteroid_override && !weapon_override))

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -135,7 +135,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, cons
 		}
 	}	
 
-	ship_apply_local_damage(pship_obj, weapon_obj, world_hitpos, damage, wip->damage_type_idx, quadrant_num, CREATE_SPARKS, submodel_num, nullptr, dot, hitpos);
+	ship_apply_local_damage(pship_obj, weapon_obj, world_hitpos, damage, wip->damage_type_idx, quadrant_num, CREATE_SPARKS, submodel_num, &worldNormal, dot, hitpos);
 
 	// let the hud shield gauge know when Player or Player target is hit
 	hud_shield_quadrant_hit(pship_obj, quadrant_num);

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -131,11 +131,11 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, cons
 
 		// if this is a player ship
 		if((np_index >= 0) && (np_index != MY_NET_PLAYER_NUM) && (wip->subtype == WP_LASER)){
-			send_player_pain_packet(&Net_players[np_index], wp->weapon_info_index, wip->damage * weapon_get_damage_scale(wip, weapon_obj, pship_obj), &force, world_hitpos, quadrant_num); //NOLINT(readability-suspicious-call-argument)
+			send_player_pain_packet(&Net_players[np_index], wp->weapon_info_index, wip->damage * weapon_get_damage_scale(wip, weapon_obj, pship_obj), &force, world_hitpos, quadrant_num);
 		}
 	}	
 
-	ship_apply_local_damage(pship_obj, weapon_obj, world_hitpos, damage, wip->damage_type_idx, quadrant_num, CREATE_SPARKS, submodel_num, &worldNormal, dot, hitpos);
+	ship_apply_local_damage(pship_obj, weapon_obj, world_hitpos, damage, wip->damage_type_idx, quadrant_num, CREATE_SPARKS, submodel_num, &worldNormal, dot, hitpos); //NOLINT(readability-suspicious-call-argument)
 
 	// let the hud shield gauge know when Player or Player target is hit
 	hud_shield_quadrant_hit(pship_obj, quadrant_num);

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -82,7 +82,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, cons
 	model_instance_local_to_global_dir(&worldNormal, hit_dir, pm, pmi, submodel_num, &pship_obj->orient);
 
 	// Apply hit & damage & stuff to weapon
-	weapon_hit(weapon_obj, pship_obj, world_hitpos, quadrant_num, &worldNormal, hitpos, submodel_num); //NOLINT(readability-suspicious-call-argument)
+	weapon_hit(weapon_obj, pship_obj, world_hitpos, quadrant_num); //NOLINT(readability-suspicious-call-argument)
 
 	if (wip->damage_time >= 0.0f && wp->lifeleft <= wip->damage_time) {
 		if (wip->atten_damage >= 0.0f) {
@@ -135,7 +135,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, cons
 		}
 	}	
 
-	ship_apply_local_damage(pship_obj, weapon_obj, world_hitpos, damage, wip->damage_type_idx, quadrant_num, CREATE_SPARKS, submodel_num, nullptr, dot);
+	ship_apply_local_damage(pship_obj, weapon_obj, world_hitpos, damage, wip->damage_type_idx, quadrant_num, CREATE_SPARKS, submodel_num, nullptr, dot, hitpos);
 
 	// let the hud shield gauge know when Player or Player target is hit
 	hud_shield_quadrant_hit(pship_obj, quadrant_num);

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -131,7 +131,7 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, cons
 
 		// if this is a player ship
 		if((np_index >= 0) && (np_index != MY_NET_PLAYER_NUM) && (wip->subtype == WP_LASER)){
-			send_player_pain_packet(&Net_players[np_index], wp->weapon_info_index, wip->damage * weapon_get_damage_scale(wip, weapon_obj, pship_obj), &force, world_hitpos, quadrant_num);
+			send_player_pain_packet(&Net_players[np_index], wp->weapon_info_index, wip->damage * weapon_get_damage_scale(wip, weapon_obj, pship_obj), &force, world_hitpos, quadrant_num); //NOLINT(readability-suspicious-call-argument)
 		}
 	}	
 

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -139,9 +139,29 @@ int collide_weapon_weapon( obj_pair * pair )
 				if (wipB->weapon_hitpoints > 0) {		//	Two bombs collide, detonate both.
 					if ((wipA->wi_flags[Weapon::Info_Flags::Bomb]) && (wipB->wi_flags[Weapon::Info_Flags::Bomb])) {
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						weapon_hit(A, B, &A->pos, -1, nullptr);
+						std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
+						ConditionData weapon_impact_b = ConditionData {
+							ImpactCondition(wipB->armor_type_idx),
+							HitType::HULL,
+							aDamage,
+							B->hull_strength,
+							i2fl(wipB->weapon_hitpoints),
+						};
+						impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_b;
+						bool a_armed = weapon_hit(A, B, &A->pos, -1);
+						maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 						wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						weapon_hit(B, A, &B->pos, -1, nullptr);
+						std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
+						ConditionData weapon_impact_a = ConditionData {
+							ImpactCondition(wipA->armor_type_idx),
+							HitType::HULL,
+							bDamage,
+							A->hull_strength,
+							i2fl(wipA->weapon_hitpoints),
+						};
+						impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_a;
+						bool b_armed = weapon_hit(B, A, &B->pos, -1);
+						maybe_play_conditional_impacts(impact_data_a, B, A, b_armed, -1, &B->pos);
 					} else {
 						A->hull_strength -= bDamage;
 						B->hull_strength -= aDamage;
@@ -157,29 +177,89 @@ int collide_weapon_weapon( obj_pair * pair )
 						
 						if (A->hull_strength < 0.0f) {
 							wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-							weapon_hit(A, B, &A->pos, -1, nullptr);
+							std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
+							ConditionData weapon_impact_b = ConditionData {
+								ImpactCondition(wipB->armor_type_idx),
+								HitType::HULL,
+								aDamage,
+								B->hull_strength,
+								i2fl(wipB->weapon_hitpoints),
+							};
+							impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_b;
+							bool a_armed = weapon_hit(A, B, &A->pos, -1);
+							maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 						}
 						if (B->hull_strength < 0.0f) {
 							wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-							weapon_hit(B, A, &B->pos, -1, nullptr);
+							std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
+							ConditionData weapon_impact_a = ConditionData {
+								ImpactCondition(wipA->armor_type_idx),
+								HitType::HULL,
+								bDamage,
+								A->hull_strength,
+								i2fl(wipA->weapon_hitpoints),
+							};
+							impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_a;
+							bool b_armed = weapon_hit(B, A, &B->pos, -1);
+							maybe_play_conditional_impacts(impact_data_a, B, A, b_armed, -1, &B->pos);
 						}
 					}
 				} else {
 					A->hull_strength -= bDamage;
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-					weapon_hit(B, A, &B->pos, -1, nullptr);
+					std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
+					ConditionData weapon_impact_a = ConditionData {
+						ImpactCondition(wipA->armor_type_idx),
+						HitType::HULL,
+						bDamage,
+						A->hull_strength,
+						i2fl(wipA->weapon_hitpoints),
+					};
+					impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_a;
+					bool b_armed = weapon_hit(B, A, &B->pos, -1);
+					maybe_play_conditional_impacts(impact_data_a, B, A, b_armed, -1, &B->pos);
 					if (A->hull_strength < 0.0f) {
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						weapon_hit(A, B, &A->pos, -1, nullptr);
+						std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
+						ConditionData weapon_impact_b = ConditionData {
+							ImpactCondition(wipB->armor_type_idx),
+							HitType::HULL,
+							aDamage,
+							B->hull_strength,
+							i2fl(wipB->weapon_hitpoints),
+						};
+						impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_b;
+						bool a_armed = weapon_hit(A, B, &A->pos, -1);
+						maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 					}
 				}
 			} else if (wipB->weapon_hitpoints > 0) {
 				B->hull_strength -= aDamage;
 				wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-				weapon_hit(A, B, &A->pos, -1, nullptr);
+				std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
+				ConditionData weapon_impact_b = ConditionData {
+					ImpactCondition(wipB->armor_type_idx),
+					HitType::HULL,
+					aDamage,
+					B->hull_strength,
+					i2fl(wipB->weapon_hitpoints),
+				};
+				impact_data_b[0] = &weapon_impact_b;
+				bool a_armed = weapon_hit(A, B, &A->pos, -1);
+				maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 				if (B->hull_strength < 0.0f) {
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-					weapon_hit(B, A, &B->pos, -1, nullptr);
+					std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
+					ConditionData weapon_impact_a = ConditionData {
+						ImpactCondition(wipA->armor_type_idx),
+						HitType::HULL,
+						bDamage,
+						A->hull_strength,
+						i2fl(wipA->weapon_hitpoints),
+					};
+					impact_data_a[0] = &weapon_impact_a;
+					bool b_armed = weapon_hit(B, A, &B->pos, -1);
+					maybe_play_conditional_impacts(impact_data_a, B, A, b_armed, -1, &B->pos);
 				}
 			}
 

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -140,7 +140,7 @@ int collide_weapon_weapon( obj_pair * pair )
 					if ((wipA->wi_flags[Weapon::Info_Flags::Bomb]) && (wipB->wi_flags[Weapon::Info_Flags::Bomb])) {
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 						std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
-						ConditionData weapon_impact_b = ConditionData {
+						auto weapon_impact_b = ConditionData {
 							ImpactCondition(wipB->armor_type_idx),
 							HitType::HULL,
 							aDamage,
@@ -152,7 +152,7 @@ int collide_weapon_weapon( obj_pair * pair )
 						maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 						wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 						std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
-						ConditionData weapon_impact_a = ConditionData {
+						auto weapon_impact_a = ConditionData {
 							ImpactCondition(wipA->armor_type_idx),
 							HitType::HULL,
 							bDamage,
@@ -178,7 +178,7 @@ int collide_weapon_weapon( obj_pair * pair )
 						if (A->hull_strength < 0.0f) {
 							wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 							std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
-							ConditionData weapon_impact_b = ConditionData {
+							auto weapon_impact_b = ConditionData {
 								ImpactCondition(wipB->armor_type_idx),
 								HitType::HULL,
 								aDamage,
@@ -192,7 +192,7 @@ int collide_weapon_weapon( obj_pair * pair )
 						if (B->hull_strength < 0.0f) {
 							wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 							std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
-							ConditionData weapon_impact_a = ConditionData {
+							auto weapon_impact_a = ConditionData {
 								ImpactCondition(wipA->armor_type_idx),
 								HitType::HULL,
 								bDamage,
@@ -208,7 +208,7 @@ int collide_weapon_weapon( obj_pair * pair )
 					A->hull_strength -= bDamage;
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 					std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
-					ConditionData weapon_impact_a = ConditionData {
+					auto weapon_impact_a = ConditionData {
 						ImpactCondition(wipA->armor_type_idx),
 						HitType::HULL,
 						bDamage,
@@ -221,7 +221,7 @@ int collide_weapon_weapon( obj_pair * pair )
 					if (A->hull_strength < 0.0f) {
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 						std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
-						ConditionData weapon_impact_b = ConditionData {
+						auto weapon_impact_b = ConditionData {
 							ImpactCondition(wipB->armor_type_idx),
 							HitType::HULL,
 							aDamage,
@@ -237,7 +237,7 @@ int collide_weapon_weapon( obj_pair * pair )
 				B->hull_strength -= aDamage;
 				wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 				std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
-				ConditionData weapon_impact_b = ConditionData {
+				auto weapon_impact_b = ConditionData {
 					ImpactCondition(wipB->armor_type_idx),
 					HitType::HULL,
 					aDamage,
@@ -250,7 +250,7 @@ int collide_weapon_weapon( obj_pair * pair )
 				if (B->hull_strength < 0.0f) {
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
 					std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
-					ConditionData weapon_impact_a = ConditionData {
+					auto weapon_impact_a = ConditionData {
 						ImpactCondition(wipA->armor_type_idx),
 						HitType::HULL,
 						bDamage,

--- a/code/object/collideweaponweapon.cpp
+++ b/code/object/collideweaponweapon.cpp
@@ -139,27 +139,25 @@ int collide_weapon_weapon( obj_pair * pair )
 				if (wipB->weapon_hitpoints > 0) {		//	Two bombs collide, detonate both.
 					if ((wipA->wi_flags[Weapon::Info_Flags::Bomb]) && (wipB->wi_flags[Weapon::Info_Flags::Bomb])) {
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
-						auto weapon_impact_b = ConditionData {
+						std::array<std::optional<ConditionData>, NumHitTypes> impact_data_b = {};
+						impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
 							ImpactCondition(wipB->armor_type_idx),
 							HitType::HULL,
 							aDamage,
 							B->hull_strength,
 							i2fl(wipB->weapon_hitpoints),
 						};
-						impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_b;
 						bool a_armed = weapon_hit(A, B, &A->pos, -1);
 						maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 						wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
-						auto weapon_impact_a = ConditionData {
+						std::array<std::optional<ConditionData>, NumHitTypes> impact_data_a = {};
+						impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
 							ImpactCondition(wipA->armor_type_idx),
 							HitType::HULL,
 							bDamage,
 							A->hull_strength,
 							i2fl(wipA->weapon_hitpoints),
 						};
-						impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_a;
 						bool b_armed = weapon_hit(B, A, &B->pos, -1);
 						maybe_play_conditional_impacts(impact_data_a, B, A, b_armed, -1, &B->pos);
 					} else {
@@ -177,29 +175,27 @@ int collide_weapon_weapon( obj_pair * pair )
 						
 						if (A->hull_strength < 0.0f) {
 							wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-							std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
-							auto weapon_impact_b = ConditionData {
+							std::array<std::optional<ConditionData>, NumHitTypes> impact_data_b = {};
+							impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
 								ImpactCondition(wipB->armor_type_idx),
 								HitType::HULL,
 								aDamage,
 								B->hull_strength,
 								i2fl(wipB->weapon_hitpoints),
 							};
-							impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_b;
 							bool a_armed = weapon_hit(A, B, &A->pos, -1);
 							maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 						}
 						if (B->hull_strength < 0.0f) {
 							wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-							std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
-							auto weapon_impact_a = ConditionData {
+							std::array<std::optional<ConditionData>, NumHitTypes> impact_data_a = {};
+							impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
 								ImpactCondition(wipA->armor_type_idx),
 								HitType::HULL,
 								bDamage,
 								A->hull_strength,
 								i2fl(wipA->weapon_hitpoints),
 							};
-							impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_a;
 							bool b_armed = weapon_hit(B, A, &B->pos, -1);
 							maybe_play_conditional_impacts(impact_data_a, B, A, b_armed, -1, &B->pos);
 						}
@@ -207,28 +203,26 @@ int collide_weapon_weapon( obj_pair * pair )
 				} else {
 					A->hull_strength -= bDamage;
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-					std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
-					auto weapon_impact_a = ConditionData {
+					std::array<std::optional<ConditionData>, NumHitTypes> impact_data_a = {};
+					impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
 						ImpactCondition(wipA->armor_type_idx),
 						HitType::HULL,
 						bDamage,
 						A->hull_strength,
 						i2fl(wipA->weapon_hitpoints),
 					};
-					impact_data_a[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_a;
 					bool b_armed = weapon_hit(B, A, &B->pos, -1);
 					maybe_play_conditional_impacts(impact_data_a, B, A, b_armed, -1, &B->pos);
 					if (A->hull_strength < 0.0f) {
 						wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
-						auto weapon_impact_b = ConditionData {
+						std::array<std::optional<ConditionData>, NumHitTypes> impact_data_b = {};
+						impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
 							ImpactCondition(wipB->armor_type_idx),
 							HitType::HULL,
 							aDamage,
 							B->hull_strength,
 							i2fl(wipB->weapon_hitpoints),
 						};
-						impact_data_b[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = &weapon_impact_b;
 						bool a_armed = weapon_hit(A, B, &A->pos, -1);
 						maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 					}
@@ -236,28 +230,26 @@ int collide_weapon_weapon( obj_pair * pair )
 			} else if (wipB->weapon_hitpoints > 0) {
 				B->hull_strength -= aDamage;
 				wpA->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-				std::array<const ConditionData*, NumHitTypes> impact_data_b = {};
-				auto weapon_impact_b = ConditionData {
+				std::array<std::optional<ConditionData>, NumHitTypes> impact_data_b = {};
+				impact_data_b[0] = ConditionData {
 					ImpactCondition(wipB->armor_type_idx),
 					HitType::HULL,
 					aDamage,
 					B->hull_strength,
 					i2fl(wipB->weapon_hitpoints),
 				};
-				impact_data_b[0] = &weapon_impact_b;
 				bool a_armed = weapon_hit(A, B, &A->pos, -1);
 				maybe_play_conditional_impacts(impact_data_b, A, B, a_armed, -1, &A->pos);
 				if (B->hull_strength < 0.0f) {
 					wpB->weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-					std::array<const ConditionData*, NumHitTypes> impact_data_a = {};
-					auto weapon_impact_a = ConditionData {
+					std::array<std::optional<ConditionData>, NumHitTypes> impact_data_a = {};
+					impact_data_a[0] = ConditionData {
 						ImpactCondition(wipA->armor_type_idx),
 						HitType::HULL,
 						bDamage,
 						A->hull_strength,
 						i2fl(wipA->weapon_hitpoints),
 					};
-					impact_data_a[0] = &weapon_impact_a;
 					bool b_armed = weapon_hit(B, A, &B->pos, -1);
 					maybe_play_conditional_impacts(impact_data_a, B, A, b_armed, -1, &B->pos);
 				}

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2460,10 +2460,10 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 				shipp->ship_max_shield_strength,
 			};
 			
+			shield_impact.damage = shield_damage * shield_factor;
+			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)] = &shield_impact;
 			// apply shield damage
 			float remaining_damage = shield_apply_damage(ship_objp, quadrant, shield_damage * shield_factor);
-			shield_impact.damage = (shield_damage * shield_factor) - remaining_damage;
-			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)] = &shield_impact;
 			// remove the shield factor, since the overflow will no longer be thrown at shields
 			remaining_damage /= shield_factor;
 

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2425,8 +2425,9 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 				ImpactCondition(shipp->shield_armor_type_idx),
 				HitType::SHIELD,
 				0.0f,
-				ship_objp->shield_quadrant[quadrant],
-				shipp->ship_max_shield_strength,
+				// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last ten percent of a shield doesn't matter
+				MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp))),
+				shield_get_max_quad(ship_objp) - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp)),
 			};
 			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)] = &shield_impact;
 		} else {
@@ -2457,8 +2458,9 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 			ImpactCondition(shipp->shield_armor_type_idx),
 			HitType::SHIELD,
 			0.0f,
-			ship_objp->shield_quadrant[quadrant],
-			shipp->ship_max_shield_strength,
+			// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last ten percent of a shield doesn't matter
+			MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp))),
+			shield_get_max_quad(ship_objp) - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp)),
 		};
 
 		if ( damage > 0.0f ) {
@@ -2876,8 +2878,9 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, const vec3d *
 						ImpactCondition(ship_p->shield_armor_type_idx),
 						HitType::SHIELD,
 						0.0f,
-						ship_objp->shield_quadrant[quadrant],
-						ship_p->ship_max_shield_strength,
+						// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last ten percent of a shield doesn't matter
+						MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp))),
+						shield_get_max_quad(ship_objp) - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp)),
 					};
 					impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)] = &shield_impact;
 				} else {

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1004,7 +1004,7 @@ std::pair<ConditionData*, float> do_subobj_hit_stuff(object *ship_objp, const ob
 			}
 
 			if (j == 0) {
-				ConditionData subsys_impact_real = ConditionData {
+				auto subsys_impact_real = ConditionData {
 					ImpactCondition(subsystem->armor_type_idx),
 					HitType::SUBSYS,
 					damage_to_apply,
@@ -2452,7 +2452,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 			if (weapon_info_index >= 0 && (!other_obj_is_beam || Beams_use_damage_factors))
 				shield_factor = Weapon_info[weapon_info_index].shield_factor;
 
-			ConditionData shield_impact = ConditionData {
+			auto shield_impact = ConditionData {
 				ImpactCondition(shipp->shield_armor_type_idx),
 				HitType::SHIELD,
 				0.0f,
@@ -2541,7 +2541,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 				}
 			}
 
-			ConditionData hull_impact = ConditionData {
+			auto hull_impact = ConditionData {
 				ImpactCondition(shipp->armor_type_idx),
 				HitType::HULL,
 				damage,

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -7,6 +7,7 @@
  *
 */
 
+#include "weapon/weapon.h"
 
 
 #ifndef _SHIPHIT_H
@@ -34,7 +35,7 @@ constexpr float DEATHROLL_ROTVEL_CAP = 6.3f;    // maximum added deathroll rotve
 // function to destroy a subsystem.  Called internally and from multiplayer messaging code
 extern void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d *hitpos, bool no_explosion = false );
 
-float do_subobj_hit_stuff(object *ship_obj, const object *other_obj, const vec3d *hitpos, int submodel_num, float damage, bool *hull_should_apply_armor, float hit_dot = 1.f);
+std::pair<ConditionData*, float> do_subobj_hit_stuff(object *ship_obj, const object *other_obj, const vec3d *hitpos, int submodel_num, float damage, bool *hull_should_apply_armor, float hit_dot = 1.f);
 
 // Goober5000
 // (it might be possible to make `target` const, but that would set off another const-cascade)
@@ -45,7 +46,7 @@ extern void ship_apply_tag(ship *ship_p, int tag_level, float tag_time, object *
 // hitpos is in world coordinates.
 // if quadrant is not -1, then that part of the shield takes damage properly.
 // (it might be possible to make `other_obj` const, but that would set off another const-cascade)
-void ship_apply_local_damage(object *ship_obj, object *other_obj, const vec3d *hitpos, float damage, int damage_type_idx, int quadrant, bool create_spark=true, int submodel_num=-1, const vec3d *hit_normal=nullptr, float hit_dot = 1.f);
+void ship_apply_local_damage(object *ship_obj, object *other_obj, const vec3d *hitpos, float damage, int damage_type_idx, int quadrant, bool create_spark=true, int submodel_num=-1, const vec3d *hit_normal=nullptr, float hit_dot = 1.f, const vec3d* local_hitpos = nullptr);
 
 // This gets called to apply damage when a damaging force hits a ship, but at no 
 // point in particular.  Like from a shockwave.   This routine will see if the
@@ -79,8 +80,6 @@ int get_max_sparks(const object* ship_obj);
 
 // player pain
 void ship_hit_pain(float damage, int quadrant);
-
-void maybe_play_conditional_impacts(object* weapon_objp, object* impacted_objp, int submodel, vec3d* hitpos, float hull_damage = 0.0f, float subsys_damage = 0.0f, float shield_damage = 0.0f);
 
 
 #endif //_SHIPHIT_H

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -80,5 +80,7 @@ int get_max_sparks(const object* ship_obj);
 // player pain
 void ship_hit_pain(float damage, int quadrant);
 
+void maybe_play_conditional_impacts(object* weapon_objp, object* impacted_objp, int submodel, vec3d* hitpos, float hull_damage = 0.0f, float subsys_damage = 0.0f, float shield_damage = 0.0f);
+
 
 #endif //_SHIPHIT_H

--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -35,7 +35,7 @@ constexpr float DEATHROLL_ROTVEL_CAP = 6.3f;    // maximum added deathroll rotve
 // function to destroy a subsystem.  Called internally and from multiplayer messaging code
 extern void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d *hitpos, bool no_explosion = false );
 
-std::pair<ConditionData*, float> do_subobj_hit_stuff(object *ship_obj, const object *other_obj, const vec3d *hitpos, int submodel_num, float damage, bool *hull_should_apply_armor, float hit_dot = 1.f);
+std::pair<std::optional<ConditionData>, float> do_subobj_hit_stuff(object *ship_obj, const object *other_obj, const vec3d *hitpos, int submodel_num, float damage, bool *hull_should_apply_armor, float hit_dot = 1.f);
 
 // Goober5000
 // (it might be possible to make `target` const, but that would set off another const-cascade)

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -4120,13 +4120,13 @@ void beam_handle_collisions(beam *b)
 
 							if (trgt->hull_strength < 0) {
 								Weapons[trgt->instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-								bool armed = weapon_hit(trgt, NULL, &trgt->pos);
+								bool armed = weapon_hit(trgt, nullptr, &trgt->pos);
 								maybe_play_conditional_impacts({}, trgt, nullptr, armed, -1, &trgt->pos);
 							}
 						} else {
 							if (!(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER) {
 								Weapons[trgt->instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-								bool armed = weapon_hit(trgt, NULL, &trgt->pos);
+								bool armed = weapon_hit(trgt, nullptr, &trgt->pos);
 								maybe_play_conditional_impacts({}, trgt, nullptr, armed, -1, &trgt->pos);
 							}
 						}
@@ -4139,7 +4139,7 @@ void beam_handle_collisions(beam *b)
 
 					if (!(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER) {
 						Weapons[Objects[target].instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						bool armed = weapon_hit(&Objects[target], NULL, &Objects[target].pos);
+						bool armed = weapon_hit(&Objects[target], nullptr, &Objects[target].pos);
 						maybe_play_conditional_impacts({}, &Objects[target], nullptr, armed, -1, &Objects[target].pos);
 					}
 				}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -4120,12 +4120,14 @@ void beam_handle_collisions(beam *b)
 
 							if (trgt->hull_strength < 0) {
 								Weapons[trgt->instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-								weapon_hit(trgt, NULL, &trgt->pos);
+								bool armed = weapon_hit(trgt, NULL, &trgt->pos);
+								maybe_play_conditional_impacts({}, trgt, nullptr, armed, -1, &trgt->pos);
 							}
 						} else {
 							if (!(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER) {
 								Weapons[trgt->instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-								weapon_hit(&Objects[target], NULL, &Objects[target].pos);
+								bool armed = weapon_hit(trgt, NULL, &trgt->pos);
+								maybe_play_conditional_impacts({}, trgt, nullptr, armed, -1, &trgt->pos);
 							}
 						}
 						
@@ -4137,7 +4139,8 @@ void beam_handle_collisions(beam *b)
 
 					if (!(Game_mode & GM_MULTIPLAYER) || MULTIPLAYER_MASTER) {
 						Weapons[Objects[target].instance].weapon_flags.set(Weapon::Weapon_Flags::Destroyed_by_weapon);
-						weapon_hit(&Objects[target], NULL, &Objects[target].pos);
+						bool armed = weapon_hit(&Objects[target], NULL, &Objects[target].pos);
+						maybe_play_conditional_impacts({}, &Objects[target], nullptr, armed, -1, &Objects[target].pos);
 					}
 				}
 				break;

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -90,6 +90,7 @@ constexpr int BANK_SWITCH_DELAY = 250;	// after switching banks, 1/4 second dela
 // range. Check the comment in weapon_set_tracking_info() for more details
 #define LOCKED_HOMING_EXTENDED_LIFE_FACTOR			1.2f
 
+
 struct homing_cache_info {
 	TIMESTAMP next_update;
 	vec3d expected_pos;
@@ -324,12 +325,25 @@ enum class HomingAcquisitionType {
 	RANDOM,
 };
 
+enum class SpecialImpactCondition {
+	NO_ARMOR,
+	ASTEROID,
+	EMPTY_SPACE,
+	LASER_POKETHROUGH,
+};
+
+using ImpactCondition = std::variant<int, SpecialImpactCondition>;
+
 struct ConditionalImpact {
 	particle::ParticleEffectHandle effect;
-	float min_health_threshold; //factor, 0-1
-	float max_health_threshold; //factor, 0-1
-	float min_angle_threshold; //in degrees
-	float max_angle_threshold; //in degrees
+	bool disable_when_subsys_also_hit;
+	::util::ParsedRandomFloatRange min_health_threshold; // factor, 0-1
+	::util::ParsedRandomFloatRange max_health_threshold; // factor, 0-1
+	::util::ParsedRandomFloatRange min_damage_hits_ratio; // factor
+	::util::ParsedRandomFloatRange max_damage_hits_ratio; // factor
+	::util::ParsedRandomFloatRange min_angle_threshold; // in degrees
+	::util::ParsedRandomFloatRange max_angle_threshold; // in degrees
+	float laser_pokethrough_threshold; // factor, 0-1
 	bool dinky;
 };
 
@@ -546,7 +560,7 @@ struct weapon_info
 	particle::ParticleEffectHandle piercing_impact_effect;
 	particle::ParticleEffectHandle piercing_impact_secondary_effect;
 
-	SCP_map<int, SCP_vector<ConditionalImpact>> conditional_impacts;
+	SCP_map<ImpactCondition, SCP_vector<ConditionalImpact>> conditional_impacts;
 
 	particle::ParticleEffectHandle muzzle_effect;
 

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -1071,7 +1071,7 @@ size_t* get_pointer_to_weapon_fire_pattern_index(int weapon_type, int ship_idx, 
 void weapon_maybe_spew_particle(object *obj);
 
 bool weapon_armed(weapon *wp, bool hit_target);
-void maybe_play_conditional_impacts(std::array<const ConditionData*, NumHitTypes> impact_data, const object* weapon_objp, const object* impacted_objp, bool armed_weapon, int submodel, const vec3d* hitpos, const vec3d* local_hitpos = nullptr, const vec3d* hit_normal = nullptr);
+void maybe_play_conditional_impacts(const std::array<std::optional<ConditionData>, NumHitTypes>& impact_data, const object* weapon_objp, const object* impacted_objp, bool armed_weapon, int submodel, const vec3d* hitpos, const vec3d* local_hitpos = nullptr, const vec3d* hit_normal = nullptr);
 bool weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, int quadrant = -1 );
 void spawn_child_weapons( object *objp, int spawn_index_override = -1);
 

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -338,7 +338,6 @@ enum class SpecialImpactCondition {
 	DEBRIS,
 	ASTEROID,
 	EMPTY_SPACE,
-	LASER_POKETHROUGH,
 };
 
 using ImpactCondition = std::variant<int, SpecialImpactCondition>;
@@ -353,7 +352,7 @@ struct ConditionData {
 
 struct ConditionalImpact {
 	particle::ParticleEffectHandle effect;
-	bool disable_on_subsys_passthrough;
+	std::optional<particle::ParticleEffectHandle> pokethrough_effect;
 	::util::ParsedRandomFloatRange min_health_threshold; // factor, 0-1
 	::util::ParsedRandomFloatRange max_health_threshold; // factor, 0-1
 	::util::ParsedRandomFloatRange min_damage_hits_ratio; // factor
@@ -362,6 +361,9 @@ struct ConditionalImpact {
 	::util::ParsedRandomFloatRange max_angle_threshold; // in degrees
 	float laser_pokethrough_threshold; // factor, 0-1
 	bool dinky;
+	bool disable_if_player_parent;
+	bool disable_on_subsys_passthrough;
+	bool disable_main_on_pokethrough;
 };
 
 enum class FiringPattern {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7823,8 +7823,8 @@ const ConditionData* process_conditional_impact(
 		float damage_hits_fraction = entry->damage / entry->health;
 		for (const auto& ci : conditional_impact_it->second) {
 			if (((!armed_weapon) == ci.dinky)
-				&& !(ci.disable_if_player_parent && (&Objects[weapon_objp->parent] == Player_obj))
-				&& !((entry->hit_type == HitType::HULL && subsys_hit) && ci.disable_on_subsys_passthrough)
+				&& (!ci.disable_if_player_parent || (&Objects[weapon_objp->parent] != Player_obj))
+				&& ((entry->hit_type != HitType::HULL || !subsys_hit) || !ci.disable_on_subsys_passthrough)
 				&& health_fraction >= ci.min_health_threshold.next()
 				&& health_fraction <= ci.max_health_threshold.next()
 				&& damage_hits_fraction >= ci.min_damage_hits_ratio.next()
@@ -8059,8 +8059,8 @@ void maybe_play_conditional_impacts(std::array<const ConditionData*, NumHitTypes
  */
 bool weapon_hit( object* weapon_obj, object* impacted_obj, const vec3d* hitpos, int quadrant)
 {
-	Assert(weapon_obj != NULL);
-	if(weapon_obj == NULL){
+	Assert(weapon_obj != nullptr);
+	if(weapon_obj == nullptr){
 		return false;
 	}
 	Assert((weapon_obj->type == OBJ_WEAPON) && (weapon_obj->instance >= 0) && (weapon_obj->instance < MAX_WEAPONS));
@@ -8226,10 +8226,10 @@ void weapon_detonate(object *objp)
 	// call weapon hit
 	// Wanderer - use last frame pos for the corkscrew missiles
 	if ( (Weapon_info[Weapons[objp->instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Corkscrew]) ) {
-		bool armed = weapon_hit(objp, NULL, &objp->last_pos);
+		bool armed = weapon_hit(objp, nullptr, &objp->last_pos);
 		maybe_play_conditional_impacts({}, objp, nullptr, armed, -1, &objp->pos);
 	} else {
-		bool armed = weapon_hit(objp, NULL, &objp->pos);
+		bool armed = weapon_hit(objp, nullptr, &objp->pos);
 		maybe_play_conditional_impacts({}, objp, nullptr, armed, -1, &objp->pos);
 	}
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2446,7 +2446,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 		ci.max_damage_hits_ratio = ::util::UniformFloatRange(std::numeric_limits<float>::max());
 		ci.min_angle_threshold = ::util::UniformFloatRange(0.f);
 		ci.max_angle_threshold = ::util::UniformFloatRange(180.f);
-		ci.laser_pokethrough_threshold = 0.1;
+		ci.laser_pokethrough_threshold = 0.1f;
 		ci.dinky = false;
 		ci.disable_if_player_parent = false;
 		ci.disable_on_subsys_passthrough = false;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7869,7 +7869,7 @@ const ConditionData* process_conditional_impact(
 }
 
 void maybe_play_conditional_impacts(std::array<const ConditionData*, NumHitTypes> impact_data, const object* weapon_objp, const object* impacted_objp, bool armed_weapon, int submodel, const vec3d* hitpos, const vec3d* local_hitpos, const vec3d* hitnormal) {
-	if (weapon_objp->type != OBJ_WEAPON) {
+	if (weapon_objp == nullptr || weapon_objp->type != OBJ_WEAPON) {
 		return;
 	}
 	auto wp = &Weapons[weapon_objp->instance];
@@ -7889,11 +7889,6 @@ void maybe_play_conditional_impacts(std::array<const ConditionData*, NumHitTypes
 	float radius_mult = 1.0f;
 	if (wip->render_type == WRT_LASER) {
 		radius_mult = wip->weapon_curves.get_output(weapon_info::WeaponCurveOutputs::LASER_RADIUS_MULT, *wp, &wp->modular_curves_instance);
-	}
-
-	std::array<const ConditionData*, NumHitTypes + 1> full_impact_data = {};
-	for (int i = 0; i < 3; i++) {
-		full_impact_data[i] = impact_data[i];
 	}
 
 	float laser_pokethrough_amount = 0.0f;
@@ -7941,7 +7936,7 @@ void maybe_play_conditional_impacts(std::array<const ConditionData*, NumHitTypes
 			&valid_conditional_impact,
 			&prev_nonnull_entry
 		);
-		if (entry_result != nullptr) {
+		if (entry_result != nullptr && !prev_nonnull_entry) {
 			first_nonnull_entry = *entry_result;
 		}
 	}
@@ -7994,8 +7989,7 @@ void maybe_play_conditional_impacts(std::array<const ConditionData*, NumHitTypes
 		particleSource->finishCreation();
 	}
 
-	// impact_data[0] is the shield entry
-	if (impacted_objp != nullptr && impact_data[0] == nullptr && (!valid_conditional_impact && wip->piercing_impact_effect.isValid() && armed_weapon)) {
+	if (impacted_objp != nullptr && impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)] == nullptr && (!valid_conditional_impact && wip->piercing_impact_effect.isValid() && armed_weapon)) {
 		if ((impacted_objp->type == OBJ_SHIP) || (impacted_objp->type == OBJ_DEBRIS)) {
 
 			int ok_to_draw = 1;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -9372,7 +9372,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 					wp->laser_bitmap_frame += flFrametime;
 
 					if (anim_has_curve) {
-						framenum = fl2i(i2fl(wip->laser_glow_bitmap.num_frames - 1) * (anim_state)) + anim_state_add;
+						framenum = fl2i((i2fl(wip->laser_glow_bitmap.num_frames - 1) * anim_state) + anim_state_add);
 					} else {
 						framenum = bm_get_anim_frame(wip->laser_bitmap.first_frame, wp->laser_bitmap_frame, wip->laser_bitmap.total_time, true);
 					}
@@ -9384,7 +9384,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 					wp->laser_headon_bitmap_frame += flFrametime;
 
 					if (anim_has_curve) {
-						headon_framenum = fl2i(i2fl(wip->laser_glow_bitmap.num_frames - 1) * (anim_state)) + anim_state_add;
+						headon_framenum = fl2i((i2fl(wip->laser_glow_bitmap.num_frames - 1) * anim_state) + anim_state_add);
 					} else {
 						headon_framenum = bm_get_anim_frame(wip->laser_headon_bitmap.first_frame, wp->laser_headon_bitmap_frame, wip->laser_headon_bitmap.total_time, true);
 					}
@@ -9469,7 +9469,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 						wp->laser_glow_bitmap_frame -= wip->laser_glow_bitmap.total_time;
 
 					if (anim_has_curve) {
-						framenum = fl2i(i2fl(wip->laser_glow_bitmap.num_frames - 1) * (anim_state)) + anim_state_add;
+						framenum = fl2i((i2fl(wip->laser_glow_bitmap.num_frames - 1) * anim_state) + anim_state_add);
 					} else {
 						framenum = fl2i( (wp->laser_glow_bitmap_frame * wip->laser_glow_bitmap.num_frames) / wip->laser_glow_bitmap.total_time );
 					}
@@ -9490,7 +9490,7 @@ void weapon_render(object* obj, model_draw_list *scene)
 						wp->laser_glow_headon_bitmap_frame -= wip->laser_glow_headon_bitmap.total_time;
 
 					if (anim_has_curve) {
-						headon_framenum = fl2i(i2fl(wip->laser_glow_bitmap.num_frames - 1) * (anim_state)) + anim_state_add;
+						headon_framenum = fl2i((i2fl(wip->laser_glow_bitmap.num_frames - 1) * anim_state) + anim_state_add);
 					} else {
 						headon_framenum = fl2i((wp->laser_glow_headon_bitmap_frame * wip->laser_glow_headon_bitmap.num_frames) / wip->laser_glow_headon_bitmap.total_time);
 					}


### PR DESCRIPTION
This PR adds a suite of new options to the conditional impacts system, including:
- support for subsystem armor as a condition
- special cases for asteroids, debris, and empty space
- a system to detect cases where a long laser is overpenetrating its impact point, and spawn an additional effect at the laser's head to help conceal the overpenetration
- options for conditioning an effect on the ratio between damage dealt and hitpoints left
- a few other boolean options for controlling when effects can or can't play

This required a certain amount of moving things around, but I'm pretty sure I got all the code paths and behavior will not be changed given the same tables.