### PR TITLE
schroedinger AI goals

### DIFF
--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -47,7 +47,7 @@ enum class ai_goal_type
 enum ai_goal_mode : uint8_t
 {
 	AI_GOAL_NONE = 0,
-	AI_GOAL_PLACEHOLDER_1,
+	AI_GOAL_SCHROEDINGER,		// used for FRED when multiple ships are selected with different orders
 
 	AI_GOAL_CHASE,              // per the original #define list, AI_GOAL_CHASE started at 2 (1<<1)
 	AI_GOAL_DOCK,               // used for undocking as well

--- a/code/scripting/api/objs/order.cpp
+++ b/code/scripting/api/objs/order.cpp
@@ -91,7 +91,7 @@ ADE_FUNC(getType, l_Order, NULL, "Gets the type of the order.", "enumeration", "
 
 	switch(ohp->aigp->ai_mode){
 		case AI_GOAL_NONE:
-		case AI_GOAL_PLACEHOLDER_1:
+		case AI_GOAL_SCHROEDINGER:
 		case AI_GOAL_NUM_VALUES:
 			break;
 		case AI_GOAL_DESTROY_SUBSYSTEM:

--- a/fred2/shipgoalsdlg.cpp
+++ b/fred2/shipgoalsdlg.cpp
@@ -378,6 +378,10 @@ ai_goal_mode ShipGoalsDlg::get_first_mode_from_combo_box(int which_item)
 	// which_item indicates initial goal 1 through MAX_AI_GOALS, so find that behavior...
 	int behavior_index = m_behavior[which_item];
 
+	// if we have a superposition of behaviors, bail here
+	if (behavior_index < 0)
+		return ai_goal_mode::AI_GOAL_SCHROEDINGER;
+
 	// the behavior is the index into the combo box that contains a subset of goals from Ai_goal_list
 	const auto &set = m_ai_goal_combo_data[behavior_index].second;
 
@@ -996,6 +1000,10 @@ void ShipGoalsDlg::update_item(int item, int multi)
 			MODIFY(goalp[item].ai_mode, mode);
 			return;
 
+		case AI_GOAL_SCHROEDINGER:
+			// return, but don't set the goal
+			return;
+
 		case AI_GOAL_WAYPOINTS:
 		case AI_GOAL_WAYPOINTS_ONCE:
 		case AI_GOAL_DISABLE_SHIP:
@@ -1163,7 +1171,7 @@ void ShipGoalsDlg::OnOK()
 
 	for (i=0; i<ED_MAX_GOALS; i++) {
 		auto mode = get_first_mode_from_combo_box(i);
-		if ((mode != AI_GOAL_NONE) && (mode != AI_GOAL_CHASE_ANY) && (mode != AI_GOAL_UNDOCK) && (mode != AI_GOAL_KEEP_SAFE_DISTANCE) && (mode != AI_GOAL_PLAY_DEAD) && (mode != AI_GOAL_PLAY_DEAD_PERSISTENT) && (mode != AI_GOAL_WARP) ) {
+		if ((mode != AI_GOAL_NONE) && (mode != AI_GOAL_SCHROEDINGER) && (mode != AI_GOAL_CHASE_ANY) && (mode != AI_GOAL_UNDOCK) && (mode != AI_GOAL_KEEP_SAFE_DISTANCE) && (mode != AI_GOAL_PLAY_DEAD) && (mode != AI_GOAL_PLAY_DEAD_PERSISTENT) && (mode != AI_GOAL_WARP) ) {
 			if (!m_object_box[i] -> GetCount())  // no valid objects?
 				m_behavior[i] = 0;
 			else

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
@@ -55,6 +55,10 @@ namespace fso {
 				// which_item indicates initial goal 1 through MAX_AI_GOALS, so find that behavior...
 				int behavior_index = m_behavior[which_item];
 
+				// if we have a superposition of behaviors, bail here
+				if (behavior_index < 0)
+					return ai_goal_mode::AI_GOAL_SCHROEDINGER;
+
 				// the behavior is the index into the combo box that contains a subset of goals from Ai_goal_list
 				const auto &set = m_ai_goal_combo_data[behavior_index].second;
 
@@ -154,6 +158,10 @@ namespace fso {
 					// these goals do not have a target in the dialog box, so let's set the goal and return immediately
 					// so that we don't run afoul of the "doesn't have a valid target" code at the bottom of the function
 					modify(goalp[item].ai_mode, mode);
+					return;
+
+				case AI_GOAL_SCHROEDINGER:
+					// return, but don't set the goal
 					return;
 
 				case AI_GOAL_WAYPOINTS:


### PR DESCRIPTION
The new enum class collection of AI goal modes did not handle the superposition of states that could occur when multiple ships were selected in FRED.  Add a special FRED-only state for this purpose.

EDIT: Tested with @LuytenKy's original bug scenario, as well as the usual single-set and multi-set scenarios with and without the superposition