### PR TITLE
Edge case fix for Always_show_directive_value_count

### DIFF
--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -990,7 +990,7 @@ void mission_process_event( int event )
 			mission_event_unset_directive_special(event);
 		}
 
-		if (Mission_events[event].count || Always_show_directive_value_count || (Directive_count > 1)) {
+		if (Mission_events[event].count || (Directive_count > 1) || (Always_show_directive_value_count && Directive_count != DIRECTIVE_WING_ZERO)) {
 			Mission_events[event].count = Directive_count;
 		}
 


### PR DESCRIPTION
The `Always_show_directive_value_count` flag from #6584 needs to not show the directive if that special `DIRECTIVE_WING_ZERO` value is temporarily being used.