### PR TITLE
AI Cleanup and Flag Fixes

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -170,6 +170,7 @@ namespace AI {
 		Debris_respects_big_damage,
 		Dont_limit_change_in_speed_due_to_physics_whack,
 		Guards_ignore_protected_attackers,
+		Fix_standard_strafe,
 		Standard_strafe_used_more,
 		Unify_usage_ai_shield_manage_delay,
 		Fix_AI_shield_management_bug,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -604,10 +604,6 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$improved subsystem attack pathing:", AI::Profile_Flags::Improved_subsystem_attack_pathing);
 
-				if (optional_string("+subsystem attack pathing extra distance:")) {
-					stuff_float(&profile->Improved_subsystem_attack_extra_distance);
-				}
-
 				set_flag(profile, "$fixed ship-weapon collisions:", AI::Profile_Flags::Fixed_ship_weapon_collision);
 
 				//Intention is to expand this feature to include a preference for close or long range weapons
@@ -812,8 +808,6 @@ void ai_profile_t::reset()
 
 	better_collision_avoid_aggression_combat = 3.5f;
 	better_collision_avoid_aggression_guard = 3.5f;
-
-	Improved_subsystem_attack_extra_distance = 2000.0f;
 
 	standard_strafe_when_below_speed = 3.0f;
 	strafe_retreat_box_dist = 300.0f;

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -604,6 +604,10 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$improved subsystem attack pathing:", AI::Profile_Flags::Improved_subsystem_attack_pathing);
 
+				if (optional_string("+subsystem attack pathing extra distance:")) {
+					stuff_float(&profile->Improved_subsystem_attack_extra_distance);
+				}
+
 				set_flag(profile, "$fixed ship-weapon collisions:", AI::Profile_Flags::Fixed_ship_weapon_collision);
 
 				//Intention is to expand this feature to include a preference for close or long range weapons
@@ -668,6 +672,8 @@ void parse_ai_profiles_tbl(const char *filename)
 				}
 
 				set_flag(profile, "$fix avoid-shockwave bugs:", AI::Profile_Flags::Fix_avoid_shockwave_bugs);
+
+				set_flag(profile, "$fix standard strafe:", AI::Profile_Flags::Fix_standard_strafe);
 
 				set_flag(profile, "$standard strafe used more:", AI::Profile_Flags::Standard_strafe_used_more);
 
@@ -806,6 +812,8 @@ void ai_profile_t::reset()
 
 	better_collision_avoid_aggression_combat = 3.5f;
 	better_collision_avoid_aggression_guard = 3.5f;
+
+	Improved_subsystem_attack_extra_distance = 2000.0f;
 
 	standard_strafe_when_below_speed = 3.0f;
 	strafe_retreat_box_dist = 300.0f;

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -135,6 +135,9 @@ public:
 	float better_collision_avoid_aggression_combat;
 	float better_collision_avoid_aggression_guard;
 
+	// AI improved subsystem attack option  --wookieejedi
+	float Improved_subsystem_attack_extra_distance;
+
 	// AI strafing options  --wookieejedi
 	float standard_strafe_when_below_speed; // Speed at which standard strafing large ships is possibly triggered
 	float strafe_retreat_box_dist;          // Distance beyond the bounding box to retreat to strafing point 

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -135,9 +135,6 @@ public:
 	float better_collision_avoid_aggression_combat;
 	float better_collision_avoid_aggression_guard;
 
-	// AI improved subsystem attack option  --wookieejedi
-	float Improved_subsystem_attack_extra_distance;
-
 	// AI strafing options  --wookieejedi
 	float standard_strafe_when_below_speed; // Speed at which standard strafing large ships is possibly triggered
 	float strafe_retreat_box_dist;          // Distance beyond the bounding box to retreat to strafing point 

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -525,8 +525,7 @@ bool ai_new_maybe_reposition_attack_subsys() {
 	object* target_objp = &Objects[aip->target_objnum];
 
 	// dont bother with this if you're still far away
-	if (vm_vec_dist(&Pl_objp->pos, &target_objp->pos) >
-		target_objp->radius * 2.0f + The_mission.ai_profile->Improved_subsystem_attack_extra_distance)
+	if (vm_vec_dist(&Pl_objp->pos, &target_objp->pos) > target_objp->radius * 2.0f + 2000.0f)
 		return false;
 
 	vec3d		geye, gsubpos;

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -1434,9 +1434,9 @@ static bool ai_big_strafe_maybe_retreat(const vec3d *target_pos)
 	bool collide_distance;
 	if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_standard_strafe]) {
 		// check if ship facing target, as likely will only collide if facing
-		vec3d vec_to_cargo;
-		vm_vec_normalized_dir(&vec_to_cargo, target_pos, &Pl_objp->pos);
-		float dot = vm_vec_dot(&vec_to_cargo, &Pl_objp->orient.vec.fvec);
+		vec3d vec_to_tpos;
+		vm_vec_normalized_dir(&vec_to_tpos, target_pos, &Pl_objp->pos);
+		float dot = vm_vec_dot(&vec_to_tpos, &Pl_objp->orient.vec.fvec);
 		if (dot <= 0.0f) {
 			collide_time = false;
 			collide_distance = false;

--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -62,9 +62,9 @@
 void	ai_big_evade_ship();
 void	ai_big_chase_attack(ai_info *aip, ship_info *sip, vec3d *enemy_pos, float dist_to_enemy, int modelnum);
 void	ai_big_avoid_ship();
-int	ai_big_maybe_follow_subsys_path(int do_dot_check=1);
+bool	ai_big_maybe_follow_subsys_path(bool do_dot_check=true);
 void ai_big_strafe_position();
-static int ai_big_strafe_maybe_retreat(const vec3d *target_pos);
+static bool ai_big_strafe_maybe_retreat(const vec3d *target_pos);
 
 extern void compute_desired_rvec(vec3d *rvec, const vec3d *goal_pos, const vec3d *cur_pos);
 extern void big_ship_collide_recover_start(const object *objp, const object *big_objp, const vec3d *collision_normal);
@@ -347,10 +347,10 @@ void ai_big_subsys_path_cleanup(ai_info *aip)
 }
 
 // Maybe Pl_objp needs to follow a path to get in line-of-sight to a subsystem
-// input:	do_dot_check	=>	default value 0, flag to indicate whether check should be done to ensure
+// input:	do_dot_check	=>	default value true, flag to indicate whether check should be done to ensure
 //										subsystem is within certain field of view.  We don't want to check fov when
 //										strafing, since ship is weaving to avoid turret fire
-int ai_big_maybe_follow_subsys_path(int do_dot_check)
+bool ai_big_maybe_follow_subsys_path(bool do_dot_check)
 {
 	ai_info	*aip;
 	float		dot = 1.0f, min_dot;
@@ -525,7 +525,8 @@ bool ai_new_maybe_reposition_attack_subsys() {
 	object* target_objp = &Objects[aip->target_objnum];
 
 	// dont bother with this if you're still far away
-	if (vm_vec_dist(&Pl_objp->pos, &target_objp->pos) > target_objp->radius * 2.0f + 2000.0f)
+	if (vm_vec_dist(&Pl_objp->pos, &target_objp->pos) >
+		target_objp->radius * 2.0f + The_mission.ai_profile->Improved_subsystem_attack_extra_distance)
 		return false;
 
 	vec3d		geye, gsubpos;
@@ -1416,7 +1417,7 @@ void ai_big_attack_get_data(vec3d *enemy_pos, float *dist_to_enemy, float *dot_t
 
 // check to see if Pl_objp has gotten too close to attacking point.. if so, break off by entering
 // AIS_STRAFE_RETREAT
-static int ai_big_strafe_maybe_retreat(const vec3d *target_pos)
+static bool ai_big_strafe_maybe_retreat(const vec3d *target_pos)
 {
 	ai_info	*aip;
 	aip = &Ai_info[Ships[Pl_objp->instance].ai_index];
@@ -1424,25 +1425,42 @@ static int ai_big_strafe_maybe_retreat(const vec3d *target_pos)
 	vec3d vec_to_target;
 	vm_vec_sub(&vec_to_target, target_pos, &Pl_objp->pos);
 
-	float dist_to_target, dist_normal_to_target, time_to_target;
-	dist_to_target = vm_vec_mag_quick(&vec_to_target);
-	if (vm_vec_mag_quick(&aip->big_attack_surface_normal) > 0.9) {
-		dist_normal_to_target = -vm_vec_dot(&vec_to_target, &aip->big_attack_surface_normal);
-	} else {
-		dist_normal_to_target = 0.2f * vm_vec_mag_quick(&vec_to_target);
-	}
-
-	dist_normal_to_target = MAX(0.2f*dist_to_target, dist_normal_to_target);
-	time_to_target = dist_normal_to_target / Pl_objp->phys_info.speed;
+	float dist_to_target = vm_vec_mag(&vec_to_target);
 
 	// add distance penalty for going too fast
 	float speed_to_dist_penalty = MAX(0.0f, (Pl_objp->phys_info.speed-50));
+
+	bool collide_time;
+	bool collide_distance;
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_standard_strafe]) {
+		// check if ship facing target, as likely will only collide if facing
+		vec3d vec_to_cargo;
+		vm_vec_normalized_dir(&vec_to_cargo, target_pos, &Pl_objp->pos);
+		float dot = vm_vec_dot(&vec_to_cargo, &Pl_objp->orient.vec.fvec);
+		if (dot <= 0.0f) {
+			collide_time = false;
+			collide_distance = false;
+		} else {
+			collide_time = (dist_to_target / Pl_objp->phys_info.speed) < STRAFE_RETREAT_COLLIDE_TIME;
+			collide_distance = dist_to_target < (STRAFE_RETREAT_COLLIDE_DIST + speed_to_dist_penalty);
+		}
+	} else {
+		float dist_normal_to_target;
+		if (vm_vec_mag(&aip->big_attack_surface_normal) > 0.9) {
+			dist_normal_to_target =
+				MAX(0.2f * dist_to_target, -vm_vec_dot(&vec_to_target, &aip->big_attack_surface_normal));
+		} else {
+			dist_normal_to_target = 0.2f * dist_to_target;
+		}
+		collide_time = (dist_normal_to_target / Pl_objp->phys_info.speed) < STRAFE_RETREAT_COLLIDE_TIME;
+		collide_distance = dist_normal_to_target < (STRAFE_RETREAT_COLLIDE_DIST + speed_to_dist_penalty);
+	}
 
 	//if ((dot_to_enemy > 1.0f - 0.1f * En_objp->radius/(dist_to_enemy + 1.0f)) && (Pl_objp->phys_info.speed > dist_to_enemy/5.0f))
 
 	// Inside 2 sec retreat, setting goal point to box point + strafe_retreat_box_dist
 	// If collision, use std collision resolution.
-	if ( !(aip->ai_flags[AI::AI_Flags::Kamikaze]) && ((aip->ai_flags[AI::AI_Flags::Target_collision]) || (time_to_target < STRAFE_RETREAT_COLLIDE_TIME) || (dist_normal_to_target < STRAFE_RETREAT_COLLIDE_DIST + speed_to_dist_penalty)) ) {
+	if ( !(aip->ai_flags[AI::AI_Flags::Kamikaze]) && ((aip->ai_flags[AI::AI_Flags::Target_collision]) || (collide_time) || (collide_distance)) ) {
 		if (aip->ai_flags[AI::AI_Flags::Target_collision]) {
 			// use standard collision resolution
 			aip->ai_flags.remove(AI::AI_Flags::Target_collision);
@@ -1486,7 +1504,7 @@ void ai_big_strafe_attack()
 	if (aip->ai_profile_flags[AI::Profile_Flags::Improved_subsystem_attack_pathing]) {
 		if (ai_new_maybe_reposition_attack_subsys())
 			return;
-	} else if (ai_big_maybe_follow_subsys_path(0))
+	} else if (ai_big_maybe_follow_subsys_path(false))
 		return;
 
 	ai_big_attack_get_data(&target_pos, &target_dist, &target_dot);
@@ -1606,7 +1624,7 @@ void ai_big_strafe_glide_attack()
 	if (aip->ai_profile_flags[AI::Profile_Flags::Improved_subsystem_attack_pathing]) {
 		if (ai_new_maybe_reposition_attack_subsys())
 			return;
-	} else if (ai_big_maybe_follow_subsys_path(0))
+	} else if (ai_big_maybe_follow_subsys_path(false))
 		return;
 
 	//Gets a point on the target ship to attack, as well as distance and the angle between the nose of the attacker and that point.

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -16977,7 +16977,7 @@ int ship_return_subsys_path_normal(const ship *shipp, const ship_subsys *ss, con
 //				subsys	=>		pointer to the subsystem of interest
 //				eye_pos	=>		world coord for the eye looking at the subsystem
 //				subsys_pos			=>	world coord for the center of the subsystem of interest
-//				do_facing_check	=>	OPTIONAL PARAMETER (default value is 1), do a dot product check to see if subsystem fvec is facing
+//				do_facing_check	=>	OPTIONAL PARAMETER (default value is true), do a dot product check to see if subsystem fvec is facing
 //											towards the eye position	
 //				dot_out	=>		OPTIONAL PARAMETER, output parameter, will return dot between subsys fvec and subsys_to_eye_vec
 //									(only filled in if do_facing_check is true)
@@ -16988,7 +16988,7 @@ bool ship_subsystem_in_sight(const object *objp, const ship_subsys *subsys, cons
 	vec3d	terminus, eye_to_pos, subsys_fvec, subsys_to_eye_vec;
 
 	if (objp->type != OBJ_SHIP)
-		return 0;
+		return false;
 
 	// See if we are at least facing the subsystem
 	if ( do_facing_check ) {
@@ -17008,8 +17008,8 @@ bool ship_subsystem_in_sight(const object *objp, const ship_subsys *subsys, cons
 			vm_vec_negate(vec_out);
 		}
 
-		if ( dot < 0 )
-			return 0;
+		if ( dot <= 0 )
+			return false;
 	}
 
 	// See if ray from eye to subsystem actually hits close enough to the subsystem position
@@ -17028,17 +17028,17 @@ bool ship_subsystem_in_sight(const object *objp, const ship_subsys *subsys, cons
 	model_collide(&mc);
 
 	if ( !mc.num_hits ) {
-		return 0;
+		return false;
 	}	
 
 	// determine if hitpos is close enough to subsystem
 	dist = vm_vec_dist(&mc.hit_point_world, subsys_pos);
 
 	if ( dist <= subsys->system_info->radius ) {
-		return 1;
+		return true;
 	}
 	
-	return 0;
+	return false;
 }
 
 /**

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17034,11 +17034,7 @@ bool ship_subsystem_in_sight(const object *objp, const ship_subsys *subsys, cons
 	// determine if hitpos is close enough to subsystem
 	dist = vm_vec_dist(&mc.hit_point_world, subsys_pos);
 
-	if ( dist <= subsys->system_info->radius ) {
-		return true;
-	}
-	
-	return false;
+	return (dist <= subsys->system_info->radius);
 }
 
 /**


### PR DESCRIPTION
This PR does 2 things.

1) Cleanup `ship_subsystem_in_sight` so it properly returns a bool, which is the return type of the function. Also update `ai_big_maybe_follow_subsys_path` to be a bool instead of int.

~~2) Adds `+subsystem attack pathing extra distance:` for use within `"$improved subsystem attack pathing:"`. FotG found, especially with the new strafing values we use, could really use the ability to set at what distance `ai_new_maybe_reposition_attack_subsys()` determines if it wants to pick a new point or not. By default the value was 2000.~~ (Turns out this is not needed, per discussion below). 

3) In FotG we started using the `standard_strafe` mode more now thanks to #6511, but we have now discovered some inherit issues with it, namely that it will prematurely trigger `ai_big_strafe_maybe_retreat` because the distance it uses for determining if a collision is going to occur is `dist_normal_to_target`, which commonly resulted in the AI flying to a point to start a strafe, then thinking it would collide with the target and then retreating from strafe mode, only to realize it was now far enough to re-engage strafe mode, which commonly resulted in AI just flying around not accomplishing much. This PR adds a flag which instead uses the `distance_to_target` and a check to see if the ship is even facing the target.

Overall all are tested and work as expected. Happy to change or tune however requested, especially regarding point 3.