### PR TITLE
Per Request add flag for `$Disabled engines are silent:`

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -153,6 +153,7 @@ bool Auto_assign_personas;
 bool Countermeasures_use_capacity;
 bool Play_thruster_sounds_for_player;
 bool Unify_minimum_engine_sound;
+bool Disabled_engines_are_silent;
 std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 bool Randomize_particle_rotation;
 bool Disable_shield_effects;
@@ -1048,6 +1049,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Unify_minimum_engine_sound);
 			}
 
+			if (optional_string("$Disabled engines are silent:")) {
+				stuff_boolean(&Disabled_engines_are_silent);
+			}
+
 			optional_string("#FRED SETTINGS");
 
 			if (optional_string("$Disable Hard Coded Message Head Ani Files:")) {
@@ -1734,6 +1739,7 @@ void mod_table_reset()
 	Countermeasures_use_capacity = false;
 	Play_thruster_sounds_for_player = false;
 	Unify_minimum_engine_sound = false;
+	Disabled_engines_are_silent = false;
 	Fred_spacemouse_nonlinearity = std::array<std::tuple<float, float>, 6>{{
 			std::tuple<float, float>{ 1.0f, 1.0f },
 			std::tuple<float, float>{ 1.0f, 1.0f },

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -168,6 +168,7 @@ extern bool Auto_assign_personas;
 extern bool Countermeasures_use_capacity;
 extern bool Play_thruster_sounds_for_player;
 extern bool Unify_minimum_engine_sound;
+extern bool Disabled_engines_are_silent;
 extern std::array<std::tuple<float, float>, 6> Fred_spacemouse_nonlinearity;
 extern bool Randomize_particle_rotation;
 extern bool Disable_shield_effects;

--- a/code/object/objectsnd.cpp
+++ b/code/object/objectsnd.cpp
@@ -446,7 +446,6 @@ void obj_snd_do_frame()
 	obj_snd			*osp;
 	object			*objp, *closest_objp;
 	game_snd			*gs;
-	ship				*sp;
 	int				channel;
 	vec3d			source_pos;
 	float				add_distance;
@@ -487,6 +486,8 @@ void obj_snd_do_frame()
 			continue;
 		}
 
+		bool obj_is_ship = (objp->type == OBJ_SHIP);
+
 		obj_snd_source_pos(&source_pos, osp);
 		distance = vm_vec_dist_quick( &source_pos, &View_position );
 
@@ -502,7 +503,7 @@ void obj_snd_do_frame()
 		}
 
 		// save closest distance (used for flyby sound) if this is a small ship (and not the observer)
-		if ( (objp->type == OBJ_SHIP) && (distance < closest_dist) && (objp != observer_obj) ) {
+		if ( (obj_is_ship) && (distance < closest_dist) && (objp != observer_obj) ) {
 			if ( Ship_info[Ships[objp->instance].ship_info_index].is_small_ship() ) {
 				closest_dist = distance;
 				closest_objp = objp;
@@ -512,7 +513,7 @@ void obj_snd_do_frame()
 		speed_vol_multiplier = 1.0f;
 		rot_vol_mult = 1.0f;
 		alive_vol_mult = 1.0f;
-		if ( objp->type == OBJ_SHIP ) {
+		if ( obj_is_ship ) {
 			ship_info *sip = &Ship_info[Ships[objp->instance].ship_info_index];
 
 			// we don't want to start the engine sound unless the ship is
@@ -658,16 +659,20 @@ void obj_snd_do_frame()
 		if (!osp->instance.isValid())
 			continue;
 
-		sp = nullptr;
-		if ( objp->type == OBJ_SHIP )
-			sp = &Ships[objp->instance];
-
+		bool sound_allowed = true;
+		if (obj_is_ship) {
+			ship* sp = &Ships[objp->instance];
+			if (osp->flags & OS_ENGINE) {
+				bool disabled_and_silent = Disabled_engines_are_silent && 
+				                           (sp->flags[Ship::Ship_Flags::Disabled] || ship_subsys_disrupted(sp, SUBSYSTEM_ENGINE));
+				sound_allowed = (sp->flags[Ship::Ship_Flags::Engine_sound_on]) && !disabled_and_silent;
+			}
+		}
 
 		channel = ds_get_channel(osp->instance);
 		// for DirectSound3D sounds, re-establish the maximum speed based on the
 		//	speed_vol_multiplier
-		if ( (sp == nullptr) || !(osp->flags & OS_ENGINE) || 
-		     ((sp->flags[Ship::Ship_Flags::Engine_sound_on]) && !(sp->flags[Ship::Ship_Flags::Disabled])) ) {
+		if ( sound_allowed ) {
 			snd_set_volume( osp->instance, gs->volume_range.next() *speed_vol_multiplier*rot_vol_mult*alive_vol_mult );
 		}
 		else {


### PR DESCRIPTION
Follow-up to #6781 as there are modders who use engine sound as ambient sound. Also cleans up the sound engine disabled logic.