### PR TITLE
Fix bmpman corruption for > 1080p resolutions

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2095,7 +2095,7 @@ void hud_render_gauges(int cockpit_display_num, float frametime)
 
 		render_target = ship_start_render_cockpit_display(cockpit_display_num);
 
-		if ( render_target <= 0 ) {
+		if ( render_target < 0 ) {
 			return;
 		}
 	} else {


### PR DESCRIPTION
Fixes #6774.
For posterity as to what happened here:

The first thing the graphics API initializes is NanoVG, the thing that also renders fonts.
NanoVG creates a texture on slot 0 that it uses for font storage and so on.
If you scale a font large enough (which typically happens for screens of a sufficient resolution), this texture is no longer sufficiently large.
As such, NanoVG will allocate a new texture that's larger, and free the old texture afterwards.
This happens usually a second or so into the first mission that uses the larger font, leaving texture slot 0 unoccupied.
The next call requesting a new (single) texture will end up in that slot. If the next mission you load in a campaign uses no other ship textures, this means that this slot will stay open.
Cockpit RTT textures are initialized on every mission start. As such, given a mission with a cockpit, this _will_ allocate this slot 0 texture if it's still free.
Unfortunately, the hud code specifically had a wrong check for "is this gauge RTT", causing it to set the texture as a render target, but never use or unset it, causing the remainder of the frame to be rendered incorrectly, with projection matrices and flags set for RTT instead of onto the screen.
Changing this check to properly accept slot 0 textures as valid RTT textures fixes this bug.