### PR TITLE
Prevent Potential Memory Problems with squadmsg hook function

### DIFF
--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -991,10 +991,11 @@ bool hud_squadmsg_run_order_issued_hook(int command, ship* sendingShip, ship* re
 			recipient = recipientWing;
 		}
 
+		auto sendingObject = (sendingShip == nullptr) ? nullptr : &Objects[sendingShip->objnum];
 		auto targetObject = (targetShip == nullptr) ? nullptr : &Objects[targetShip->objnum];
 
 		auto paramList = scripting::hook_param_list(
-				scripting::hook_param("Sender", 'o', &Objects[sendingShip->objnum]),
+				scripting::hook_param("Sender", 'o', sendingObject),
 				scripting::hook_param("Recipient", 'o', scripting::api::l_OSWPT.Set(recipient)),
 				scripting::hook_param("Target", 'o', targetObject),
 				scripting::hook_param("Subsystem", 'o', scripting::api::l_Subsystem.Set(scripting::api::ship_subsys_h(targetObject, subsys))),


### PR DESCRIPTION
Within `hud_squadmsg_run_order_issued_hook` it is possible for the calling code to pass `nullptr` as the target parameter, which would cause memory problems with the several instances of `Objects[target->objnum]`. This PR mitigates that potential while testing of  `hud_squadmsg_run_order_issued_hook` still works as expected.