### PR TITLE
subsystem scripting enhancements

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1012,6 +1012,7 @@ SCP_set<int> model_get_textures_used(const polymodel* pm, int submodel);
 // Returns a pointer to the polymodel structure for model 'n'
 polymodel *model_get(int model_num);
 
+int num_model_instances();
 polymodel_instance* model_get_instance(int model_instance_num);
 
 // routine to copy subsystems.  Must be called when subsystems sets are the same -- see ship.cpp

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3895,6 +3895,11 @@ polymodel * model_get(int model_num)
 	return Polygon_models[num];
 }
 
+int num_model_instances()
+{
+	return static_cast<int>(Polygon_model_instances.size());
+}
+
 polymodel_instance* model_get_instance(int model_instance_num)
 {
 	Assert( model_instance_num >= 0 );

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -63,6 +63,34 @@ bool submodel_h::isValid() const
 }
 
 
+ADE_FUNC(__eq, l_Model, "model, model", "Checks if two model handles refer to the same model", "boolean", "True if models are equal")
+{
+	model_h* mdl1;
+	model_h* mdl2;
+
+	if (!ade_get_args(L, "oo", l_Model.GetPtr(&mdl1), l_Model.GetPtr(&mdl2)))
+		return ADE_RETURN_NIL;
+
+	if (mdl1->GetID() == mdl2->GetID())
+		return ADE_RETURN_TRUE;
+
+	return ADE_RETURN_FALSE;
+}
+
+ADE_FUNC(__eq, l_Submodel, "submodel, submodel", "Checks if two submodel handles refer to the same submodel", "boolean", "True if submodels are equal")
+{
+	submodel_h* smh1;
+	submodel_h* smh2;
+
+	if (!ade_get_args(L, "oo", l_Submodel.GetPtr(&smh1), l_Submodel.GetPtr(&smh2)))
+		return ADE_RETURN_NIL;
+
+	if (smh1->GetModelID() == smh2->GetModelID() && smh1->GetSubmodelIndex() == smh2->GetSubmodelIndex())
+		return ADE_RETURN_TRUE;
+
+	return ADE_RETURN_FALSE;
+}
+
 ADE_VIRTVAR(Submodels, l_Model, nullptr, "Model submodels", "submodels", "Model submodels, or an invalid submodels handle if the model handle is invalid")
 {
 	model_h *mdl = nullptr;

--- a/code/scripting/api/objs/model.cpp
+++ b/code/scripting/api/objs/model.cpp
@@ -23,7 +23,7 @@ int model_h::GetID() const
 }
 bool model_h::isValid() const
 {
-	return (model_num >= 0) && (model_get(model_num) != nullptr);
+	return (model_num >= 0) && (model_get(model_num) != nullptr);	// note: the model ID can exceed MAX_POLYGON_MODELS because the modulo is taken
 }
 model_h::model_h(int n_modelnum)
 	: model_num(n_modelnum)
@@ -56,8 +56,8 @@ bool submodel_h::isValid() const
 	if (model_num >= 0 && submodel_num >= 0)
 	{
 		auto model = model_get(model_num);
-		if (model != nullptr)
-			return submodel_num < model->n_models;
+		if (model != nullptr && submodel_num < model->n_models)
+			return true;
 	}
 	return false;
 }

--- a/code/scripting/api/objs/modelinstance.h
+++ b/code/scripting/api/objs/modelinstance.h
@@ -10,14 +10,18 @@ namespace api {
 class modelinstance_h
 {
  protected:
-	polymodel_instance *_pmi;
+	int _pmi_id;
 
  public:
 	explicit modelinstance_h(int pmi_id);
 	explicit modelinstance_h(polymodel_instance *pmi);
 	modelinstance_h();
 
-	polymodel_instance *Get();
+	polymodel_instance *Get() const;
+	int GetID() const;
+
+	polymodel *GetModel() const;
+	int GetModelID() const;
 
 	bool isValid() const;
 };
@@ -27,8 +31,7 @@ DECLARE_ADE_OBJ(l_ModelInstance, modelinstance_h);
 class submodelinstance_h
 {
 protected:
-	polymodel_instance *_pmi;
-	polymodel *_pm;
+	int _pmi_id;
 	int _submodel_num;
 
 public:
@@ -36,12 +39,15 @@ public:
 	explicit submodelinstance_h(polymodel_instance *pmi, int submodel_num);
 	submodelinstance_h();
 
-	polymodel_instance *GetModelInstance();
-	submodel_instance *Get();
+	polymodel_instance *GetModelInstance() const;
+	int GetModelInstanceID() const;
 
-	polymodel *GetModel();
-	bsp_info *GetSubmodel();
-	int GetSubmodelIndex();
+	polymodel *GetModel() const;
+	int GetModelID() const;
+
+	submodel_instance *Get() const;
+	bsp_info *GetSubmodel() const;
+	int GetSubmodelIndex() const;
 
 	bool isValid() const;
 };

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -2,6 +2,7 @@
 //
 
 #include "subsystem.h"
+#include "model.h"
 #include "model_path.h"
 #include "object.h"
 #include "ship.h"
@@ -119,6 +120,21 @@ ADE_VIRTVAR(AWACSRadius, l_Subsystem, "number", "Subsystem AWACS radius", "numbe
 		sso->ss->awacs_radius = f;
 
 	return ade_set_args(L, "f", sso->ss->awacs_radius);
+}
+
+ADE_VIRTVAR(Submodel, l_Subsystem, "submodel", "The submodel corresponding to this subsystem, if one exists", "submodel", "Submodel handle, or invalid submodel handle if this subsystem does not have a submodel, or if the subsystem handle is invalid")
+{
+	ship_subsys_h *sso;
+	if (!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	if (!sso->isValid())
+		return ade_set_error(L, "o", l_Submodel.Set(submodel_h()));
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting the Submodel is not allowed!");
+
+	return ade_set_args(L, "o", l_Submodel.Set(submodel_h(sso->ss->system_info->model_num, sso->ss->system_info->subobj_num)));
 }
 
 ADE_VIRTVAR(Orientation, l_Subsystem, "orientation", "Orientation of subobject or turret base", "orientation", "Subsystem orientation, or identity orientation if handle is invalid")
@@ -345,6 +361,22 @@ ADE_VIRTVAR(NameOnHUD, l_Subsystem, "string", "Subsystem name as it would be dis
 	return ade_set_args(L, "s", ship_subsys_get_name_on_hud(sso->ss));
 }
 
+ADE_VIRTVAR(CanonicalName, l_Subsystem, "string", "Canonical subsystem name that can be used to reference this subsystem in a SEXP or script", "string", "Canonical subsystem name, or an empty string if handle is invalid")
+{
+	ship_subsys_h *sso;
+
+	if (!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
+		return ade_set_error(L, "s", "");
+
+	if (!sso->isValid())
+		return ade_set_error(L, "s", "");
+
+	if (ADE_SETTING_VAR)
+		LuaError(L, "Setting the CanonicalName is not allowed!");
+
+	return ade_set_args(L, "s", ship_subsys_get_canonical_name(sso->ss));
+}
+
 ADE_VIRTVAR(NumFirePoints, l_Subsystem, "number", "Number of firepoints", "number", "Number of fire points, or 0 if handle is invalid")
 {
 	ship_subsys_h* sso;
@@ -384,7 +416,7 @@ ADE_VIRTVAR(FireRateMultiplier, l_Subsystem, "number", "Factor by which turret's
 	return ade_set_args(L, "f", sso->ss->rof_scaler);
 }
 
-ADE_FUNC(getModelName, l_Subsystem, NULL, "Returns the original name of the subsystem in the model file", "string", "name or empty string on error")
+ADE_FUNC(getModelName, l_Subsystem, NULL, "Returns the original name of the subsystem as defined in the ship class, which could possibly correspond to a submodel in the model file.  This is the same as CanonicalName.", "string", "name or empty string on error")
 {
 	ship_subsys_h *sso;
 	if(!ade_get_args(L, "o", l_Subsystem.GetPtr(&sso)))
@@ -393,7 +425,7 @@ ADE_FUNC(getModelName, l_Subsystem, NULL, "Returns the original name of the subs
 	if (!sso->isValid())
 		return ade_set_error(L, "s", "");
 
-	return ade_set_args(L, "s", sso->ss->system_info->subobj_name);
+	return ade_set_args(L, "s", ship_subsys_get_canonical_name(sso->ss));
 }
 
 ADE_VIRTVAR(PrimaryBanks, l_Subsystem, "weaponbanktype", "Array of primary weapon banks", "weaponbanktype", "Primary banks, or invalid weaponbanktype handle if subsystem handle is invalid")

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17189,6 +17189,11 @@ const char *ship_subsys_get_name_on_hud(const ship_subsys *ss)
 		return ship_subsys_get_name(ss);
 }
 
+const char *ship_subsys_get_canonical_name(const ship_subsys *ss)
+{
+	return ss->system_info->subobj_name;
+}
+
 /**
  * Return the shield strength of the specified quadrant on hit_objp
  *

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1803,6 +1803,7 @@ bool ship_subsys_has_instance_name(const ship_subsys *ss);
 void ship_subsys_set_name(ship_subsys* ss, const char* n_name);
 
 const char *ship_subsys_get_name_on_hud(const ship_subsys *ss);
+const char *ship_subsys_get_canonical_name(const ship_subsys *ss);
 
 // subsys disruption
 extern int ship_subsys_disrupted(const ship_subsys *ss);


### PR DESCRIPTION
Add several API features to improve scripting support for subsystems.

1. A `CanonicalName` virtvar to provide a clear way to get subsystem names for indexing and referencing
2. `Submodel` and `SubmodelInstance` virtvars to get the submodel information associated with the subsystem, if it exists
3. A `getSubsystemList()` function to provide a subsystem iterator
4. `__eq` functions for models and submodels
5. Store model and submodel IDs, not pointers

All tested and work as expected.