### PR TITLE
Make modular curve wraparound default to false

### DIFF
--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -241,7 +241,7 @@ struct modular_curves_entry {
 	int curve_idx = -1;
 	::util::ParsedRandomFloatRange scaling_factor = ::util::UniformFloatRange(1.f);
 	::util::ParsedRandomFloatRange translation = ::util::UniformFloatRange(0.f);
-	bool wraparound = true;
+	bool wraparound = false;
 };
 
 //
@@ -355,7 +355,7 @@ struct modular_curves_definition {
 				curve_entry.translation = ::util::UniformFloatRange(0.0f);
 			}
 
-			curve_entry.wraparound = true;
+			curve_entry.wraparound = false;
 			parse_optional_bool_into("+Wraparound:", &curve_entry.wraparound);
 
 			curves[static_cast<std::underlying_type_t<output_enum>>(output_idx)].emplace_back(input_idx, curve_entry);


### PR DESCRIPTION
When @BMagnu and I were building the modular curves system, we set the wraparound behavior to be on by default. After a few months of using the system, this turns out to have been a _very bad idea_. Between the two of us, I think we've run into four or five very confusing mod misbehaviors that turned out to be a side effect of curve wraparound being on when we weren't expecting it.

So I'm turning it off by default. Modular curves haven't been in stable, so it ought to be fine.