### PR TITLE
Disable unneccesary raycast in turret target acquisition

### DIFF
--- a/code/ai/aibig.cpp
+++ b/code/ai/aibig.cpp
@@ -146,6 +146,10 @@ done_1:
 
 	*attack_point = best_point;
 
+	//The following raycast tends to make up 10%(!) of total AI-frametime for basically no benefit, especially in the common case for turrets where the normal isn't even queried.
+	if (surface_normal == nullptr && Disable_expensive_turret_target_check)
+		return;
+
 	// Cast from attack_objp_pos to local_attack_pos and check for nearest collision.
 	// If no collision, cast to (0,0,0) [center of big ship]**  [best_point initialized to 000]
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -171,6 +171,7 @@ EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
 bool Fix_asteroid_bounding_box_check;
 bool Disable_intro_movie;
 bool Show_locked_status_scramble_missions;
+bool Disable_expensive_turret_target_check;
 
 
 #ifdef WITH_DISCORD
@@ -1534,6 +1535,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Show_locked_status_scramble_missions);
 			}
 
+			if (optional_string("$Disable expensive turret target check:")) {
+				stuff_boolean(&Disable_expensive_turret_target_check);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1769,6 +1774,7 @@ void mod_table_reset()
 	Fix_asteroid_bounding_box_check = false;
 	Disable_intro_movie = false;
 	Show_locked_status_scramble_missions = false;
+	Disable_expensive_turret_target_check = false;
 }
 
 void mod_table_set_version_flags()
@@ -1794,5 +1800,6 @@ void mod_table_set_version_flags()
 		Use_model_eyepoint_for_set_camera_host = true;
 		Use_model_eyepoint_normals = true;
 		Fix_asteroid_bounding_box_check = true;
+		Disable_expensive_turret_target_check = true;
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -186,6 +186,7 @@ extern EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
 extern bool Fix_asteroid_bounding_box_check;
 extern bool Disable_intro_movie;
 extern bool Show_locked_status_scramble_missions;
+extern bool Disable_expensive_turret_target_check;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
Turns out, turret target acquisition was spending a lot of time doing a raycast, the result of which was barely used at all.
If we don't need the target normal, all it does is get a target point slightly more accurate, but in practice it really isn't noticeable at all whether the target point of the turret is actually on the surface of the ship, or maybe on the other side of the ship.
As it _is_ a behaviour change, even if likely not noticeable, it's flag gated, but the flag is auto-enabled for 25.0-targeting mods, as it does save some frametime.