### PR TITLE
Speed up random range creation

### DIFF
--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -77,10 +77,14 @@ class RandomRange {
 	ValueType m_minValue;
 	ValueType m_maxValue;
 
+	//Sampling a random_device is REALLY expensive.
+	//Instead of sampling one for each seed, create a pseudorandom seeder which is initialized ONCE from a random_device.
+	inline static std::mt19937 seeder {std::random_device()()};
+
   public:
 	template <typename T, typename... Ts, typename = typename std::enable_if<(sizeof... (Ts) >=1 || !std::is_convertible<T, ValueType>::value) && !std::is_same_v<std::decay_t<T>, RandomRange>, int>::type>
 	explicit RandomRange(T&& distributionFirstParameter, Ts&&... distributionParameters)
-		: m_generator(std::random_device()()), m_distribution(distributionFirstParameter, distributionParameters...)
+		: m_generator(seeder()), m_distribution(distributionFirstParameter, distributionParameters...)
 	{
 		m_minValue = static_cast<ValueType>(m_distribution.min());
 		m_maxValue = static_cast<ValueType>(m_distribution.max());
@@ -94,7 +98,7 @@ class RandomRange {
 		m_constant = true;
 	}
 
-	RandomRange() : m_generator(std::random_device()()), m_distribution()
+	RandomRange() : m_generator(seeder()), m_distribution()
 	{
 		m_minValue = static_cast<ValueType>(0.0);
 		m_maxValue = static_cast<ValueType>(0.0);


### PR DESCRIPTION
Extracted from #6808.
Originally I thought it's fine to leave it in #6808, as that PR itself introduces a significant reliance on random range performance, but it turns out that random range creation happens during weapon_create, and is thus already quite a performance waste.
