### PR TITLE
Threading Framework & Threaded Collisions

### DIFF
--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -534,6 +534,7 @@ cmdline_parm luadev_arg("-luadev", "Make lua errors non-fatal", AT_NONE);	// Cmd
 cmdline_parm override_arg("-override_data", "Enable override directory", AT_NONE);	// Cmdline_override_data
 cmdline_parm imgui_debug_arg("-imgui_debug", nullptr, AT_NONE);
 cmdline_parm vulkan("-vulkan", nullptr, AT_NONE);
+cmdline_parm multithreading("-threads", nullptr, AT_INT);
 
 char *Cmdline_start_mission = NULL;
 int Cmdline_dis_collisions = 0;
@@ -572,6 +573,7 @@ bool Cmdline_lua_devmode = false;
 bool Cmdline_override_data = false;
 bool Cmdline_show_imgui_debug = false;
 bool Cmdline_vulkan = false;
+int Cmdline_multithreading = 1;
 
 // Other
 cmdline_parm get_flags_arg(GET_FLAGS_STRING, "Output the launcher flags file", AT_STRING);
@@ -2404,6 +2406,14 @@ bool SetCmdlineParams()
 		}
 		else {
 			Warning(LOCATION,"-seed must be an integer greater than 0. Invalid input seed will be disregarded.");
+		}
+	}
+
+	if (multithreading.found()) {
+		Cmdline_multithreading = abs(multithreading.get_int());
+		if (Cmdline_multithreading < 1) {
+			Cmdline_multithreading = 1;
+			Warning(LOCATION,"-threads must be an integer greater or equal to 1. Invalid thread count will be disregarded.");
 		}
 	}
 

--- a/code/cmdline/cmdline.h
+++ b/code/cmdline/cmdline.h
@@ -159,6 +159,7 @@ extern bool Cmdline_lua_devmode;
 extern bool Cmdline_override_data;
 extern bool Cmdline_show_imgui_debug;
 extern bool Cmdline_vulkan;
+extern int Cmdline_multithreading;
 
 enum class WeaponSpewType { NONE = 0, STANDARD, ALL };
 extern WeaponSpewType Cmdline_spew_weapon_stats;

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -30,25 +30,24 @@
 // checking a collision rather than passing a bunch of parameters around. These are
 // not persistant between calls to model_collide
 
-static mc_info		*Mc;				// The mc_info passed into model_collide
-	
-static polymodel	*Mc_pm;			// The polygon model we're checking
-static int			Mc_submodel;	// The current submodel we're checking
+thread_local static mc_info		*Mc;				// The mc_info passed into model_collide
 
-static polymodel_instance *Mc_pmi;
+thread_local static polymodel	*Mc_pm;			// The polygon model we're checking
+thread_local static int			Mc_submodel;	// The current submodel we're checking
 
-static matrix		Mc_orient;		// A matrix to rotate a world point into the current
+thread_local static polymodel_instance *Mc_pmi;
+
+thread_local static matrix		Mc_orient;		// A matrix to rotate a world point into the current
 											// submodel's frame of reference.
-static vec3d		Mc_base;			// A point used along with Mc_orient.
+thread_local static vec3d		Mc_base;			// A point used along with Mc_orient.
 
-static vec3d		Mc_p0;			// The ray origin rotated into the current submodel's frame of reference
-static vec3d		Mc_p1;			// The ray end rotated into the current submodel's frame of reference
-static float		Mc_mag;			// The length of the ray
-static vec3d		Mc_direction;	// A vector from the ray's origin to its end, in the current submodel's frame of reference
+thread_local static vec3d		Mc_p0;			// The ray origin rotated into the current submodel's frame of reference
+thread_local static vec3d		Mc_p1;			// The ray end rotated into the current submodel's frame of reference
+thread_local static float		Mc_mag;			// The length of the ray
+thread_local static vec3d		Mc_direction;	// A vector from the ray's origin to its end, in the current submodel's frame of reference
 
-static vec3d 		**Mc_point_list = NULL;		// A pointer to the current submodel's vertex list
+thread_local static vec3d 		**Mc_point_list = NULL;		// A pointer to the current submodel's vertex list
 
-static float		Mc_edge_time;
 
 
 void model_collide_free_point_list()
@@ -1135,7 +1134,6 @@ int model_collide(mc_info *mc_info_obj)
 	Mc_orient = *Mc->orient;
 	Mc_base = *Mc->pos;
 	Mc_mag = vm_vec_dist( Mc->p0, Mc->p1 );
-	Mc_edge_time = FLT_MAX;
 
 	if ( Mc->model_instance_num >= 0 ) {
 		Mc_pmi = model_get_instance(Mc->model_instance_num);

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -867,10 +867,14 @@ extern void hud_start_text_flash(char *txt, int t, int interval);
  * Procss player_ship:planet damage.
  *	If within range of planet, apply damage to ship.
  */
-static void mcp_1(object *player_objp, object *planet_objp)
+static void mcp_1(obj_pair * pair, const std::any& data)
 {
 	float	planet_radius;
 	float	dist;
+
+	bool ship_is_first = std::any_cast<bool>(data);
+	object* planet_objp = ship_is_first ? pair->b : pair->a;
+	object* player_objp = ship_is_first ? pair->a : pair->b;
 
 	planet_radius = planet_objp->radius;
 	dist = vm_vec_dist_quick(&player_objp->pos, &planet_objp->pos);
@@ -900,9 +904,9 @@ static int is_planet(object *objp)
 
 /**
  * If exactly one of these is a planet and the other is a player ship, do something special.
- * @return true if this was a ship:planet (or planet_ship) collision and we processed it. Else return false.
+ * @return true if this was a ship:planet (or planet_ship) collision (planet involved / bool is ship first) and we processed it. Else return false.
  */
-static int maybe_collide_planet (object *obj1, object *obj2)
+static std::pair<bool, bool> maybe_collide_planet (object *obj1, object *obj2)
 {
 	ship_info	*sip1, *sip2;
 
@@ -911,17 +915,15 @@ static int maybe_collide_planet (object *obj1, object *obj2)
 
 	if (sip1->flags[Ship::Info_Flags::Player_ship]) {
 		if (is_planet(obj2)) {
-			mcp_1(obj1, obj2);
-			return 1;
+			return {true, true};
 		}
 	} else if (sip2->flags[Ship::Info_Flags::Player_ship]) {
 		if (is_planet(obj1)) {
-			mcp_1(obj2, obj1);
-			return 1;
+			return {true, false};
 		}
 	}
 
-	return 0;
+	return {false, false};
 }
 
 /**
@@ -1100,31 +1102,340 @@ static void maybe_push_little_ship_from_fast_big_ship(object *big_obj, object *s
 	}
 }
 
+void collide_ship_ship_process(obj_pair * pair, const std::any& collision_data) {
+	auto ship_ship_hit_info = std::any_cast<collision_info_struct>(collision_data);
+
+	object *A = pair->a;
+	object *B = pair->b;
+
+	bool a_override = false, b_override = false;
+
+	// get world hitpos - do it here in case the override hooks need it
+	vec3d world_hit_pos;
+	vm_vec_add(&world_hit_pos, &ship_ship_hit_info.heavy->pos, &ship_ship_hit_info.hit_pos);
+
+	// get submodel handle if scripting needs it
+	bool has_submodel = (ship_ship_hit_info.heavy_submodel_num >= 0);
+	scripting::api::submodel_h smh(ship_ship_hit_info.heavy_model_num, ship_ship_hit_info.heavy_submodel_num);
+
+	if (scripting::hooks::OnShipCollision->isActive()) {
+		a_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{ {A, B} },
+																   scripting::hook_param_list(scripting::hook_param("Self", 'o', A),
+																							  scripting::hook_param("Object", 'o', B),
+																							  scripting::hook_param("Ship", 'o', A),
+																							  scripting::hook_param("ShipB", 'o', B),
+																							  scripting::hook_param("Hitpos", 'o', world_hit_pos),
+																							  scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A)),
+																							  scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B))));
+
+		// Yes, this should be reversed.
+		b_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{ {A, B} },
+																   scripting::hook_param_list(scripting::hook_param("Self", 'o', B),
+																							  scripting::hook_param("Object", 'o', A),
+																							  scripting::hook_param("Ship", 'o', B),
+																							  scripting::hook_param("ShipB", 'o', A),
+																							  scripting::hook_param("Hitpos", 'o', world_hit_pos),
+																							  scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B)),
+																							  scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A))));
+	}
+
+	object* heavy_obj = ship_ship_hit_info.heavy;
+	object* light_obj = ship_ship_hit_info.light;
+
+	if(!a_override && !b_override)
+	{
+		//
+		// Start of a codeblock that was originally taken from ship_ship_check_collision
+		// Moved here to properly handle ship-ship collision overrides and not process their physics when overridden by lua
+		//
+
+		ship *light_shipp = &Ships[ship_ship_hit_info.light->instance];
+		ship *heavy_shipp = &Ships[ship_ship_hit_info.heavy->instance];
+
+		const ship_info* light_sip = &Ship_info[light_shipp->ship_info_index];
+		const ship_info* heavy_sip = &Ship_info[heavy_shipp->ship_info_index];
+
+		// Update ai to deal with collisions
+		if (OBJ_INDEX(heavy_obj) == Ai_info[light_shipp->ai_index].target_objnum) {
+			Ai_info[light_shipp->ai_index].ai_flags.set(AI::AI_Flags::Target_collision);
+		}
+		if (OBJ_INDEX(light_obj) == Ai_info[heavy_shipp->ai_index].target_objnum) {
+			Ai_info[heavy_shipp->ai_index].ai_flags.set(AI::AI_Flags::Target_collision);
+		}
+
+		// SET PHYSICS PARAMETERS
+		// already have (hitpos - heavy) and light_cm_pos
+
+		// get r_heavy and r_light
+		ship_ship_hit_info.r_heavy = ship_ship_hit_info.hit_pos;
+		vm_vec_sub(&ship_ship_hit_info.r_light, &ship_ship_hit_info.hit_pos, &ship_ship_hit_info.light_collision_cm_pos);
+
+		// set normal for edge hit
+		if (ship_ship_hit_info.edge_hit) {
+			vm_vec_copy_normalize(&ship_ship_hit_info.collision_normal, &ship_ship_hit_info.r_light);
+			vm_vec_negate(&ship_ship_hit_info.collision_normal);
+		}
+
+		// do physics
+		calculate_ship_ship_collision_physics(&ship_ship_hit_info);
+
+		// Provide some separation for the case of same team
+		if (heavy_shipp->team == light_shipp->team) {
+			//	If a couple of small ships, just move them apart.
+
+			if ((heavy_sip->is_small_ship()) && (light_sip->is_small_ship())) {
+				if ((heavy_obj->flags[Object::Object_Flags::Player_ship]) || (light_obj->flags[Object::Object_Flags::Player_ship])) {
+					vec3d h_to_l_vec;
+					vec3d rel_vel_h;
+					vec3d perp_rel_vel;
+
+					vm_vec_sub(&h_to_l_vec, &heavy_obj->pos, &light_obj->pos);
+					vm_vec_sub(&rel_vel_h, &heavy_obj->phys_info.vel, &light_obj->phys_info.vel);
+					float mass_sum = light_obj->phys_info.mass + heavy_obj->phys_info.mass;
+
+					// get comp of rel_vel perp to h_to_l_vec;
+					float mag = vm_vec_dot(&h_to_l_vec, &rel_vel_h) / vm_vec_mag_squared(&h_to_l_vec);
+					vm_vec_scale_add(&perp_rel_vel, &rel_vel_h, &h_to_l_vec, -mag);
+					vm_vec_normalize(&perp_rel_vel);
+
+					vm_vec_scale_add2(&heavy_obj->phys_info.vel, &perp_rel_vel,
+									  heavy_sip->collision_physics.both_small_bounce * light_obj->phys_info.mass / mass_sum);
+					vm_vec_scale_add2(&light_obj->phys_info.vel, &perp_rel_vel,
+									  -(light_sip->collision_physics.both_small_bounce) * heavy_obj->phys_info.mass / mass_sum);
+
+					vm_vec_rotate(&heavy_obj->phys_info.prev_ramp_vel, &heavy_obj->phys_info.vel, &heavy_obj->orient);
+					vm_vec_rotate(&light_obj->phys_info.prev_ramp_vel, &light_obj->phys_info.vel, &light_obj->orient);
+				}
+			}
+			else {
+				// add extra velocity to separate the two objects, backing up the direction we came in.
+				// TODO: add effect of velocity from rotating submodel
+				float rel_vel = vm_vec_mag_quick(&ship_ship_hit_info.light_rel_vel);
+				if (rel_vel < 1) {
+					rel_vel = 1.0f;
+				}
+				float		mass_sum = heavy_obj->phys_info.mass + light_obj->phys_info.mass;
+				vm_vec_scale_add2(&heavy_obj->phys_info.vel, &ship_ship_hit_info.light_rel_vel,
+								  heavy_sip->collision_physics.bounce * light_obj->phys_info.mass / (mass_sum * rel_vel));
+				vm_vec_rotate(&heavy_obj->phys_info.prev_ramp_vel, &heavy_obj->phys_info.vel, &heavy_obj->orient);
+				vm_vec_scale_add2(&light_obj->phys_info.vel, &ship_ship_hit_info.light_rel_vel,
+								  -(light_sip->collision_physics.bounce) * heavy_obj->phys_info.mass / (mass_sum * rel_vel));
+				vm_vec_rotate(&light_obj->phys_info.prev_ramp_vel, &light_obj->phys_info.vel, &light_obj->orient);
+			}
+		}
+
+		//
+		// End of the codeblock that was originally taken from ship_ship_check_collision
+		//
+
+		float		damage;
+
+		if ( ship_ship_hit_info.player_involved && (Player->control_mode == PCM_WARPOUT_STAGE1) )	{
+			gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_STOP );
+			HUD_printf("%s", XSTR( "Warpout sequence aborted.", 466));
+		}
+
+		damage = 0.005f * ship_ship_hit_info.impulse;	//	Cut collision-based damage in half.
+		//	Decrease heavy damage by 2x.
+		if (damage > 5.0f){
+			damage = 5.0f + (damage - 5.0f)/2.0f;
+		}
+
+		do_kamikaze_crash(A, B);
+
+		if (ship_ship_hit_info.impulse > 0) {
+			//Only flash the "Collision" text if not landing
+			if ( ship_ship_hit_info.player_involved && !ship_ship_hit_info.is_landing) {
+				hud_start_text_flash(XSTR("Collision", 1431), 2000);
+			}
+		}
+
+		//If this is a landing, play a different sound
+		if (ship_ship_hit_info.is_landing) {
+			if (vm_vec_mag(&ship_ship_hit_info.light_rel_vel) > MIN_LANDING_SOUND_VEL) {
+				if ( ship_ship_hit_info.player_involved ) {
+					if ( !snd_is_playing(Player_collide_sound) ) {
+						Player_collide_sound = snd_play_3d( gamesnd_get_game_sound(light_sip->collision_physics.landing_sound_idx), &world_hit_pos, &View_position );
+					}
+				} else {
+					if ( !snd_is_playing(AI_collide_sound) ) {
+						AI_collide_sound = snd_play_3d( gamesnd_get_game_sound(light_sip->collision_physics.landing_sound_idx), &world_hit_pos, &View_position );
+					}
+				}
+			}
+		}
+		else {
+			collide_ship_ship_do_sound(&world_hit_pos, A, B, ship_ship_hit_info.player_involved);
+		}
+
+		// check if we should do force feedback stuff
+		if (ship_ship_hit_info.player_involved && (ship_ship_hit_info.impulse > 0)) {
+			float scaler;
+			vec3d v;
+
+			scaler = -ship_ship_hit_info.impulse / Player_obj->phys_info.mass * 300;
+			vm_vec_copy_normalize(&v, &world_hit_pos);
+			joy_ff_play_vector_effect(&v, scaler);
+		}
+
+#ifndef NDEBUG
+		if ( !Collide_friendly ) {
+					if ( Ships[A->instance].team == Ships[B->instance].team ) {
+						vec3d	collision_vec, right_angle_vec;
+						vm_vec_normalized_dir(&collision_vec, &ship_ship_hit_info.hit_pos, &A->pos);
+						if (vm_vec_dot(&collision_vec, &A->orient.vec.fvec) > 0.999f){
+							right_angle_vec = A->orient.vec.rvec;
+						} else {
+							vm_vec_cross(&right_angle_vec, &A->orient.vec.uvec, &collision_vec);
+						}
+
+						vm_vec_scale_add2( &A->phys_info.vel, &right_angle_vec, +2.0f);
+						vm_vec_scale_add2( &B->phys_info.vel, &right_angle_vec, -2.0f);
+
+						return 0;
+					}
+				}
+#endif
+
+		//Only do damage if not a landing
+		if (!ship_ship_hit_info.is_landing) {
+			//	Scale damage based on skill level for player.
+			if ((light_obj->flags[Object::Object_Flags::Player_ship]) || (heavy_obj->flags[Object::Object_Flags::Player_ship])) {
+
+				// Cyborg17 - Pretty hackish, but it's our best option, limit the amount of times a collision can
+				// happen to multiplayer clients, because otherwise the server can kill clients far too quickly.
+				// So here it goes, first only do this on the master (has an intrinsic multiplayer check)
+				if (MULTIPLAYER_MASTER) {
+					// check to see if both colliding ships are player ships
+					bool second_player_check = false;
+					if ((light_obj->flags[Object::Object_Flags::Player_ship]) && (heavy_obj->flags[Object::Object_Flags::Player_ship]))
+						second_player_check = true;
+
+					// iterate through each player
+					for (net_player & current_player : Net_players) {
+						// check that this player's ship is valid, and that it's not the server ship.
+						if ((current_player.m_player != nullptr) && !(current_player.flags & NETINFO_FLAG_AM_MASTER) && (current_player.m_player->objnum > 0) && current_player.m_player->objnum < MAX_OBJECTS) {
+							// check that one of the colliding ships is this player's ship
+							if ((light_obj == &Objects[current_player.m_player->objnum]) || (heavy_obj == &Objects[current_player.m_player->objnum])) {
+								// finally if the host is also a player, ignore making these adjustments for him because he is in a pure simulation.
+								if (&Ships[Objects[current_player.m_player->objnum].instance] != Player_ship) {
+									Assertion(Interp_info.find(current_player.m_player->objnum) != Interp_info.end(), "Somehow the collision code thinks there is not a player ship interp record in multi when there really *should* be.  This is a coder mistake, please report!");
+
+									// temp set this as an uninterpolated ship, to make the collision look more natural until the next update comes in.
+									Interp_info[current_player.m_player->objnum].force_interpolation_mode();
+
+									// check to see if it has been long enough since the last collision, if not, negate the damage
+									if (!timestamp_elapsed(current_player.s_info.player_collision_timestamp)) {
+										damage = 0.0f;
+									} else {
+										// make the usual adjustments
+										damage *= (float)(Game_skill_level * Game_skill_level + 1) / (NUM_SKILL_LEVELS + 1);
+										// if everything is good to go, set the timestamp for the next collision
+										current_player.s_info.player_collision_timestamp = _timestamp(PLAYER_COLLISION_TIMESTAMP);
+									}
+								}
+
+								// did we find the player we were looking for?
+								if (!second_player_check) {
+									break;
+									// if we found one of the players we were looking for, set this to false so that the next one breaks the loop
+								} else {
+									second_player_check = false;
+								}
+							}
+						}
+					}
+					// if not in multiplayer, just do the damage adjustment.
+				} else {
+					damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
+				}
+			} else if (Ships[light_obj->instance].team == Ships[heavy_obj->instance].team) {
+				//	Decrease damage if non-player ships and not large.
+				//	Looks dumb when fighters are taking damage from bumping into each other.
+				if ((light_obj->radius < 50.0f) && (heavy_obj->radius <50.0f)) {
+					damage /= 4.0f;
+				}
+			}
+
+			int	quadrant_num = -1;
+			if (!The_mission.ai_profile->flags[AI::Profile_Flags::No_shield_damage_from_ship_collisions] && !(ship_ship_hit_info.heavy->flags[Object::Object_Flags::No_shields])) {
+				quadrant_num = get_ship_quadrant_from_global(&world_hit_pos, ship_ship_hit_info.heavy);
+				if (!ship_is_shield_up(ship_ship_hit_info.heavy, quadrant_num))
+					quadrant_num = -1;
+			}
+
+			float damage_heavy = (100.0f * damage / heavy_obj->phys_info.mass);
+			ship_apply_local_damage(ship_ship_hit_info.heavy, ship_ship_hit_info.light, &world_hit_pos, damage_heavy, light_shipp->collision_damage_type_idx,
+									quadrant_num, CREATE_SPARKS, ship_ship_hit_info.heavy_submodel_num, &ship_ship_hit_info.collision_normal);
+
+			hud_shield_quadrant_hit(ship_ship_hit_info.heavy, quadrant_num);
+
+			// don't draw sparks (using sphere hitpos)
+			float damage_light = (100.0f * damage / heavy_obj->phys_info.mass);
+			ship_apply_local_damage(ship_ship_hit_info.light, ship_ship_hit_info.heavy, &world_hit_pos, damage_light, heavy_shipp->collision_damage_type_idx,
+									MISS_SHIELDS, NO_SPARKS, -1, &ship_ship_hit_info.collision_normal);
+
+			hud_shield_quadrant_hit(ship_ship_hit_info.light, -1);
+
+			maybe_push_little_ship_from_fast_big_ship(ship_ship_hit_info.heavy, ship_ship_hit_info.light, ship_ship_hit_info.impulse, &ship_ship_hit_info.collision_normal);
+		}
+	}
+
+	if (!scripting::hooks::OnShipCollision->isActive()) {
+		return;
+	}
+
+	if(!(b_override && !a_override))
+	{
+		scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{ {A, B} },
+											   scripting::hook_param_list(scripting::hook_param("Self", 'o', A),
+																		  scripting::hook_param("Object", 'o', B),
+																		  scripting::hook_param("Ship", 'o', A),
+																		  scripting::hook_param("ShipB", 'o', B),
+																		  scripting::hook_param("Hitpos", 'o', world_hit_pos),
+																		  scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A)),
+																		  scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B))));
+	}
+	if((b_override && !a_override) || (!b_override && !a_override))
+	{
+		// Yes, this should be reversed.
+		scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{ {A, B} },
+											   scripting::hook_param_list(scripting::hook_param("Self", 'o', B),
+																		  scripting::hook_param("Object", 'o', A),
+																		  scripting::hook_param("Ship", 'o', B),
+																		  scripting::hook_param("ShipB", 'o', A),
+																		  scripting::hook_param("Hitpos", 'o', world_hit_pos),
+																		  scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B)),
+																		  scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A))));
+	}
+}
+
 /**
  * Checks ship-ship collisions.  
  * @return 1 if all future collisions between these can be ignored because pair->a or pair->b aren't ships
  * @return Otherwise always returns 0, since two ships can always collide unless one (1) dies or (2) warps out.
  */
-int collide_ship_ship( obj_pair * pair )
+//returns never_hits, process_data
+collision_result collide_ship_ship_check( obj_pair * pair )
 {
 	int	player_involved;
 	float dist;
 	object *A = pair->a;
 	object *B = pair->b;
 
-	if ( A->type == OBJ_WAYPOINT ) return 1;
-	if ( B->type == OBJ_WAYPOINT ) return 1;
+	if ( A->type == OBJ_WAYPOINT ) return { true, std::any(), &collide_ship_ship_process };
+	if ( B->type == OBJ_WAYPOINT ) return { true, std::any(), &collide_ship_ship_process };
 	
 	Assert( A->type == OBJ_SHIP );
 	Assert( B->type == OBJ_SHIP );
 
 	// Cyborg17 - no ship-ship collisions when doing multiplayer rollback
 	if ( (Game_mode & GM_MULTIPLAYER) && multi_ship_record_get_rollback_wep_mode() ) {
-		return 0;
+		return { false, std::any(), &collide_ship_ship_process };
 	}
 
 	if (reject_due_collision_groups(A,B))
-		return 0;
+		return { false, std::any(), &collide_ship_ship_process };
 
 	// If the player is one of the two colliding ships, flag this... it is used in
 	// several places this function.
@@ -1137,20 +1448,21 @@ int collide_ship_ship( obj_pair * pair )
 		// collision related.  Yes, from time to time that will look strange, but there are too many
 		// side effects if we allow it.
 		if (MULTIPLAYER_CLIENT){
-			return 0;
+			return { false, std::any(), &collide_ship_ship_process };
 		}
 	}
 
 	// Don't check collisions for warping out player if past stage 1.
 	if ( player_involved && (Player->control_mode > PCM_WARPOUT_STAGE1) )	{
-		return 0;
+		return { false, std::any(), &collide_ship_ship_process };
 	}
 
 	dist = vm_vec_dist( &A->pos, &B->pos );
 
 	//	If one of these is a planet, do special stuff.
-	if (maybe_collide_planet(A, B))
-		return 0;
+	const auto& [planet_collision, planet_collision_data] = maybe_collide_planet(A, B);
+	if (planet_collision)
+		return { false, planet_collision_data, &mcp_1 };
 
 	if ( dist < A->radius + B->radius )	{
 		int		hit;
@@ -1183,6 +1495,7 @@ int collide_ship_ship( obj_pair * pair )
 
 		ship_ship_hit_info.heavy = HeavyOne;		// heavy object, generally slower moving
 		ship_ship_hit_info.light = LightOne;		// light object, generally faster moving
+		ship_ship_hit_info.player_involved = player_involved;
 
 		hit = ship_ship_check_collision(&ship_ship_hit_info);
 
@@ -1190,304 +1503,7 @@ int collide_ship_ship( obj_pair * pair )
 
 		if ( hit )
 		{
-			bool a_override = false, b_override = false;
-
-			// get world hitpos - do it here in case the override hooks need it
-			vec3d world_hit_pos;
-			vm_vec_add(&world_hit_pos, &ship_ship_hit_info.heavy->pos, &ship_ship_hit_info.hit_pos);
-
-			// get submodel handle if scripting needs it
-			bool has_submodel = (ship_ship_hit_info.heavy_submodel_num >= 0);
-			scripting::api::submodel_h smh(ship_ship_hit_info.heavy_model_num, ship_ship_hit_info.heavy_submodel_num);
-
-			if (scripting::hooks::OnShipCollision->isActive()) {
-				a_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{ {A, B} },
-					scripting::hook_param_list(scripting::hook_param("Self", 'o', A),
-						scripting::hook_param("Object", 'o', B),
-						scripting::hook_param("Ship", 'o', A),
-						scripting::hook_param("ShipB", 'o', B),
-						scripting::hook_param("Hitpos", 'o', world_hit_pos),
-						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A)),
-						scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B))));
-
-				// Yes, this should be reversed.
-				b_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{ {A, B} },
-					scripting::hook_param_list(scripting::hook_param("Self", 'o', B),
-						scripting::hook_param("Object", 'o', A),
-						scripting::hook_param("Ship", 'o', B),
-						scripting::hook_param("ShipB", 'o', A),
-						scripting::hook_param("Hitpos", 'o', world_hit_pos),
-						scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B)),
-						scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A))));
-			}
-
-			if(!a_override && !b_override)
-			{
-				//
-				// Start of a codeblock that was originally taken from ship_ship_check_collision
-				// Moved here to properly handle ship-ship collision overrides and not process their physics when overridden by lua
-				//
-
-				ship *light_shipp = &Ships[ship_ship_hit_info.light->instance];
-				ship *heavy_shipp = &Ships[ship_ship_hit_info.heavy->instance];
-
-				object* heavy_obj = ship_ship_hit_info.heavy;
-				object* light_obj = ship_ship_hit_info.light;
-				// Update ai to deal with collisions
-				if (OBJ_INDEX(heavy_obj) == Ai_info[light_shipp->ai_index].target_objnum) {
-					Ai_info[light_shipp->ai_index].ai_flags.set(AI::AI_Flags::Target_collision);
-				}
-				if (OBJ_INDEX(light_obj) == Ai_info[heavy_shipp->ai_index].target_objnum) {
-					Ai_info[heavy_shipp->ai_index].ai_flags.set(AI::AI_Flags::Target_collision);
-				}
-
-				// SET PHYSICS PARAMETERS
-				// already have (hitpos - heavy) and light_cm_pos
-
-				// get r_heavy and r_light
-				ship_ship_hit_info.r_heavy = ship_ship_hit_info.hit_pos;
-				vm_vec_sub(&ship_ship_hit_info.r_light, &ship_ship_hit_info.hit_pos, &ship_ship_hit_info.light_collision_cm_pos);
-
-				// set normal for edge hit
-				if (ship_ship_hit_info.edge_hit) {
-					vm_vec_copy_normalize(&ship_ship_hit_info.collision_normal, &ship_ship_hit_info.r_light);
-					vm_vec_negate(&ship_ship_hit_info.collision_normal);
-				}
-
-				// do physics
-				calculate_ship_ship_collision_physics(&ship_ship_hit_info);
-
-				// Provide some separation for the case of same team
-				if (heavy_shipp->team == light_shipp->team) {
-					//	If a couple of small ships, just move them apart.
-
-					if ((heavy_sip->is_small_ship()) && (light_sip->is_small_ship())) {
-						if ((heavy_obj->flags[Object::Object_Flags::Player_ship]) || (light_obj->flags[Object::Object_Flags::Player_ship])) {
-							vec3d h_to_l_vec;
-							vec3d rel_vel_h;
-							vec3d perp_rel_vel;
-
-							vm_vec_sub(&h_to_l_vec, &heavy_obj->pos, &light_obj->pos);
-							vm_vec_sub(&rel_vel_h, &heavy_obj->phys_info.vel, &light_obj->phys_info.vel);
-							float mass_sum = light_obj->phys_info.mass + heavy_obj->phys_info.mass;
-
-							// get comp of rel_vel perp to h_to_l_vec;
-							float mag = vm_vec_dot(&h_to_l_vec, &rel_vel_h) / vm_vec_mag_squared(&h_to_l_vec);
-							vm_vec_scale_add(&perp_rel_vel, &rel_vel_h, &h_to_l_vec, -mag);
-							vm_vec_normalize(&perp_rel_vel);
-
-							vm_vec_scale_add2(&heavy_obj->phys_info.vel, &perp_rel_vel,
-								heavy_sip->collision_physics.both_small_bounce * light_obj->phys_info.mass / mass_sum);
-							vm_vec_scale_add2(&light_obj->phys_info.vel, &perp_rel_vel,
-								-(light_sip->collision_physics.both_small_bounce) * heavy_obj->phys_info.mass / mass_sum);
-
-							vm_vec_rotate(&heavy_obj->phys_info.prev_ramp_vel, &heavy_obj->phys_info.vel, &heavy_obj->orient);
-							vm_vec_rotate(&light_obj->phys_info.prev_ramp_vel, &light_obj->phys_info.vel, &light_obj->orient);
-						}
-					}
-					else {
-						// add extra velocity to separate the two objects, backing up the direction we came in.
-						// TODO: add effect of velocity from rotating submodel
-						float rel_vel = vm_vec_mag_quick(&ship_ship_hit_info.light_rel_vel);
-						if (rel_vel < 1) {
-							rel_vel = 1.0f;
-						}
-						float		mass_sum = heavy_obj->phys_info.mass + light_obj->phys_info.mass;
-						vm_vec_scale_add2(&heavy_obj->phys_info.vel, &ship_ship_hit_info.light_rel_vel,
-							heavy_sip->collision_physics.bounce * light_obj->phys_info.mass / (mass_sum * rel_vel));
-						vm_vec_rotate(&heavy_obj->phys_info.prev_ramp_vel, &heavy_obj->phys_info.vel, &heavy_obj->orient);
-						vm_vec_scale_add2(&light_obj->phys_info.vel, &ship_ship_hit_info.light_rel_vel,
-							-(light_sip->collision_physics.bounce) * heavy_obj->phys_info.mass / (mass_sum * rel_vel));
-						vm_vec_rotate(&light_obj->phys_info.prev_ramp_vel, &light_obj->phys_info.vel, &light_obj->orient);
-					}
-				}
-
-				//
-				// End of the codeblock that was originally taken from ship_ship_check_collision
-				//
-
-				float		damage;
-
-				if ( player_involved && (Player->control_mode == PCM_WARPOUT_STAGE1) )	{
-					gameseq_post_event( GS_EVENT_PLAYER_WARPOUT_STOP );
-					HUD_printf("%s", XSTR( "Warpout sequence aborted.", 466));
-				}
-
-				damage = 0.005f * ship_ship_hit_info.impulse;	//	Cut collision-based damage in half.
-				//	Decrease heavy damage by 2x.
-				if (damage > 5.0f){
-					damage = 5.0f + (damage - 5.0f)/2.0f;
-				}
-
-				do_kamikaze_crash(A, B);
-
-				if (ship_ship_hit_info.impulse > 0) {
-					//Only flash the "Collision" text if not landing
-					if ( player_involved && !ship_ship_hit_info.is_landing) {					
-						hud_start_text_flash(XSTR("Collision", 1431), 2000);
-					}
-				}
-
-				//If this is a landing, play a different sound
-				if (ship_ship_hit_info.is_landing) {
-					if (vm_vec_mag(&ship_ship_hit_info.light_rel_vel) > MIN_LANDING_SOUND_VEL) {
-						if ( player_involved ) {
-							if ( !snd_is_playing(Player_collide_sound) ) {
-								Player_collide_sound = snd_play_3d( gamesnd_get_game_sound(light_sip->collision_physics.landing_sound_idx), &world_hit_pos, &View_position );
-							}
-						} else {
-							if ( !snd_is_playing(AI_collide_sound) ) {
-								AI_collide_sound = snd_play_3d( gamesnd_get_game_sound(light_sip->collision_physics.landing_sound_idx), &world_hit_pos, &View_position );
-							}
-						}
-					}
-				}
-				else {
-					collide_ship_ship_do_sound(&world_hit_pos, A, B, player_involved);
-				}
-
-				// check if we should do force feedback stuff
-				if (player_involved && (ship_ship_hit_info.impulse > 0)) {
-					float scaler;
-					vec3d v;
-
-					scaler = -ship_ship_hit_info.impulse / Player_obj->phys_info.mass * 300;
-					vm_vec_copy_normalize(&v, &world_hit_pos);
-					joy_ff_play_vector_effect(&v, scaler);
-				}
-
-				#ifndef NDEBUG
-				if ( !Collide_friendly ) {
-					if ( Ships[A->instance].team == Ships[B->instance].team ) {
-						vec3d	collision_vec, right_angle_vec;
-						vm_vec_normalized_dir(&collision_vec, &ship_ship_hit_info.hit_pos, &A->pos);
-						if (vm_vec_dot(&collision_vec, &A->orient.vec.fvec) > 0.999f){
-							right_angle_vec = A->orient.vec.rvec;
-						} else {
-							vm_vec_cross(&right_angle_vec, &A->orient.vec.uvec, &collision_vec);
-						}
-
-						vm_vec_scale_add2( &A->phys_info.vel, &right_angle_vec, +2.0f);
-						vm_vec_scale_add2( &B->phys_info.vel, &right_angle_vec, -2.0f);
-
-						return 0;
-					}
-				}
-				#endif
-
-				//Only do damage if not a landing
-				if (!ship_ship_hit_info.is_landing) {
-					//	Scale damage based on skill level for player.
-					if ((LightOne->flags[Object::Object_Flags::Player_ship]) || (HeavyOne->flags[Object::Object_Flags::Player_ship])) {
-
-						// Cyborg17 - Pretty hackish, but it's our best option, limit the amount of times a collision can
-						// happen to multiplayer clients, because otherwise the server can kill clients far too quickly.
-						// So here it goes, first only do this on the master (has an intrinsic multiplayer check) 
-						if (MULTIPLAYER_MASTER) {
-							// check to see if both colliding ships are player ships
-							bool second_player_check = false;
-							if ((LightOne->flags[Object::Object_Flags::Player_ship]) && (HeavyOne->flags[Object::Object_Flags::Player_ship]))
-								second_player_check = true;
-
-							// iterate through each player
-							for (net_player & current_player : Net_players) {
-								// check that this player's ship is valid, and that it's not the server ship.
-								if ((current_player.m_player != nullptr) && !(current_player.flags & NETINFO_FLAG_AM_MASTER) && (current_player.m_player->objnum > 0) && current_player.m_player->objnum < MAX_OBJECTS) {
-									// check that one of the colliding ships is this player's ship
-									if ((LightOne == &Objects[current_player.m_player->objnum]) || (HeavyOne == &Objects[current_player.m_player->objnum])) {
-										// finally if the host is also a player, ignore making these adjustments for him because he is in a pure simulation.
-										if (&Ships[Objects[current_player.m_player->objnum].instance] != Player_ship) {
-											Assertion(Interp_info.find(current_player.m_player->objnum) != Interp_info.end(), "Somehow the collision code thinks there is not a player ship interp record in multi when there really *should* be.  This is a coder mistake, please report!");
-
-											// temp set this as an uninterpolated ship, to make the collision look more natural until the next update comes in.
-											Interp_info[current_player.m_player->objnum].force_interpolation_mode();
-
-											// check to see if it has been long enough since the last collision, if not, negate the damage
-											if (!timestamp_elapsed(current_player.s_info.player_collision_timestamp)) {
-												damage = 0.0f;
-											} else {
-												// make the usual adjustments
-												damage *= (float)(Game_skill_level * Game_skill_level + 1) / (NUM_SKILL_LEVELS + 1);
-												// if everything is good to go, set the timestamp for the next collision
-												current_player.s_info.player_collision_timestamp = _timestamp(PLAYER_COLLISION_TIMESTAMP);
-											}
-										}
-
-										// did we find the player we were looking for?
-										if (!second_player_check) {
-											break;
-										// if we found one of the players we were looking for, set this to false so that the next one breaks the loop
-										} else {
-											second_player_check = false;
-										}
-									}
-								}
-							}
-						// if not in multiplayer, just do the damage adjustment.
-						} else {
-							damage *= (float) (Game_skill_level*Game_skill_level+1)/(NUM_SKILL_LEVELS+1);
-						}
-					} else if (Ships[LightOne->instance].team == Ships[HeavyOne->instance].team) {
-						//	Decrease damage if non-player ships and not large.
-						//	Looks dumb when fighters are taking damage from bumping into each other.
-						if ((LightOne->radius < 50.0f) && (HeavyOne->radius <50.0f)) {
-							damage /= 4.0f;
-						}
-					}					
-
-					int	quadrant_num = -1;					
-					if (!The_mission.ai_profile->flags[AI::Profile_Flags::No_shield_damage_from_ship_collisions] && !(ship_ship_hit_info.heavy->flags[Object::Object_Flags::No_shields])) {
-						quadrant_num = get_ship_quadrant_from_global(&world_hit_pos, ship_ship_hit_info.heavy);
-						if (!ship_is_shield_up(ship_ship_hit_info.heavy, quadrant_num))
-							quadrant_num = -1;
-					}
-
-					float damage_heavy = (100.0f * damage / HeavyOne->phys_info.mass);
-					ship_apply_local_damage(ship_ship_hit_info.heavy, ship_ship_hit_info.light, &world_hit_pos, damage_heavy, light_shipp->collision_damage_type_idx, 
-						quadrant_num, CREATE_SPARKS, ship_ship_hit_info.heavy_submodel_num, &ship_ship_hit_info.collision_normal);
-
-					hud_shield_quadrant_hit(ship_ship_hit_info.heavy, quadrant_num);
-
-					// don't draw sparks (using sphere hitpos)
-					float damage_light = (100.0f * damage / LightOne->phys_info.mass);
-					ship_apply_local_damage(ship_ship_hit_info.light, ship_ship_hit_info.heavy, &world_hit_pos, damage_light, heavy_shipp->collision_damage_type_idx, 
-						MISS_SHIELDS, NO_SPARKS, -1, &ship_ship_hit_info.collision_normal);
-
-					hud_shield_quadrant_hit(ship_ship_hit_info.light, -1);
-
-					maybe_push_little_ship_from_fast_big_ship(ship_ship_hit_info.heavy, ship_ship_hit_info.light, ship_ship_hit_info.impulse, &ship_ship_hit_info.collision_normal);
-				}
-			}
-
-			if (!scripting::hooks::OnShipCollision->isActive()) {
-				return 0;
-			}
-
-			if(!(b_override && !a_override))
-			{
-				scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{ {A, B} },
-					scripting::hook_param_list(scripting::hook_param("Self", 'o', A),
-														   scripting::hook_param("Object", 'o', B),
-														   scripting::hook_param("Ship", 'o', A),
-														   scripting::hook_param("ShipB", 'o', B),
-														   scripting::hook_param("Hitpos", 'o', world_hit_pos),
-														   scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A)),
-														   scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B))));
-			}
-			if((b_override && !a_override) || (!b_override && !a_override))
-			{
-				// Yes, this should be reversed.
-				scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{ {A, B} },
-					scripting::hook_param_list(scripting::hook_param("Self", 'o', B),
-														   scripting::hook_param("Object", 'o', A),
-														   scripting::hook_param("Ship", 'o', B),
-														   scripting::hook_param("ShipB", 'o', A),
-														   scripting::hook_param("Hitpos", 'o', world_hit_pos),
-														   scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == B)),
-														   scripting::hook_param("ShipBSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel && (ship_ship_hit_info.heavy == A))));
-			}
-
-			return 0;
+			return { false, ship_ship_hit_info, &collide_ship_ship_process };
 		}					
     }
     else {
@@ -1500,7 +1516,7 @@ int collide_ship_ship( obj_pair * pair )
         if (((Ships[A->instance].is_arriving(ship::warpstage::STAGE1, false)) && (Ship_info[Ships[A->instance].ship_info_index].is_big_or_huge()))
 			|| ((Ships[B->instance].is_arriving(ship::warpstage::STAGE1, false)) && (Ship_info[Ships[B->instance].ship_info_index].is_big_or_huge())) ) {
 			pair->next_check_time = timestamp(0);	// check next time
-			return 0;
+			return { false, std::any(), &collide_ship_ship_process };
 		}
 
 		// get max of (1) max_vel.z, (2) 10, (3) afterburner_max_vel.z, (4) vel.z (for warping in ships exceeding expected max vel)
@@ -1537,6 +1553,16 @@ int collide_ship_ship( obj_pair * pair )
 			pair->next_check_time = timestamp(0);	// check next time
 		}
 	}
-	
-	return 0;
+
+	return { false, std::any(), &collide_ship_ship_process };
+}
+
+int collide_ship_ship( obj_pair * pair ) {
+	const auto& [never_check_again, collision_data, process_fnc] = collide_ship_ship_check(pair);
+
+	if (collision_data.has_value()) {
+		process_fnc(pair, collision_data);
+	}
+
+	return never_check_again ? 1 : 0;
 }

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -31,7 +31,7 @@
 
 extern int Game_skill_level;
 extern float ai_endangered_time(const object *ship_objp, const object *weapon_objp);
-static int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pair *pair );
+static std::tuple<bool, bool, std::any> check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pair *pair );
 extern float flFrametime;
 
 
@@ -176,7 +176,11 @@ static void ship_weapon_do_hit_stuff(object *pship_obj, object *weapon_obj, cons
 
 extern int Framecount;
 
-static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float time_limit = 0.0f, int *next_hit = nullptr)
+//mc, notify_ai_shield_down, shield_collision, quadrant_num
+using ship_weapon_collision_data = std::tuple<std::optional<mc_info>, int, bool, int>;
+
+//need_postproc, recheck, do collision?
+static std::tuple<bool, bool, ship_weapon_collision_data> ship_weapon_check_collision(object *ship_objp, object *weapon_objp, float time_limit = 0.0f, int *next_hit = nullptr)
 {
 	mc_info mc_hull, mc_shield, *mc;
 	ship	*shipp;
@@ -202,7 +206,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	Assert( shipp->objnum == OBJ_INDEX(ship_objp));
 
 	// Make ships that are warping in not get collision detection done
-	if ( shipp->is_arriving() ) return 0;
+	if ( shipp->is_arriving() ) return {false, true, {std::nullopt, -1, false, -1}};
 	
 	//	Return information for AI to detect incoming fire.
 	//	Could perhaps be done elsewhere at lower cost --MK, 11/7/97
@@ -440,6 +444,8 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 			shield_collision = 0;
 	}
 
+	int notify_ai_shield_down = -1;
+
 	if (shield_collision) {
 		// pick out the shield quadrant
 		quadrant_num = get_quadrant(&mc_shield.hit_point, ship_objp);
@@ -450,7 +456,7 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 			// so that the AI can put energy torwards repairing that shield segement (but put behind a flag)
 			// --wookieejedi
 			if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_AI_shield_management_bug] && SCP_vector_inbounds(ship_objp->shield_quadrant, quadrant_num)) {
-				Ai_info[Ships[ship_objp->instance].ai_index].danger_shield_quadrant = quadrant_num;
+				notify_ai_shield_down = quadrant_num;
 			}
 			quadrant_num = -1;
 			shield_collision = 0;
@@ -477,24 +483,68 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 	{
 		mc = &mc_shield;
 		Assert(quadrant_num >= 0);
-		valid_hit_occurred = 1;
+		valid_hit_occurred = 1; //Hit
 	}
 	else if (hull_collision)
 	{
 		mc = &mc_hull;
-		valid_hit_occurred = 1;
+		valid_hit_occurred = 1; //Hit
 	}
 	else
-		mc = nullptr;
+		mc = nullptr; //No hit, maybe stop checking
 
 	// deal with predictive collisions.  Find their actual hit time and see if they occured in current frame
 	if (next_hit && valid_hit_occurred) {
 		// find hit time
 		*next_hit = (int) (1000.0f * (mc->hit_dist*(flFrametime + time_limit) - flFrametime) );
 		if (*next_hit > 0)
-			// if hit occurs outside of this frame, do not do damage 
-			return 1;
+			// if hit occurs outside of this frame, do not do damage
+			return { false, false, {std::nullopt, -1, false, -1} }; //No hit, but continue checking
 	}
+
+	bool postproc = valid_hit_occurred || notify_ai_shield_down >= 0;
+	ship_weapon_collision_data collision_data {
+		valid_hit_occurred ? std::optional(*mc) : std::nullopt, notify_ai_shield_down, postproc, quadrant_num
+	};
+
+	// when the $Fixed Missile Detonation: flag is active, skip this whole block, as it's redundant to a similar check in weapon_home()
+	if (!valid_hit_occurred && !Fixed_missile_detonation && (Missiontime - wp->creation_time > F1_0/2) && (wip->is_homing()) && (wp->homing_object == ship_objp)) {
+		if (dist < wip->shockwave.inner_rad) {
+			vec3d	vec_to_ship;
+			vm_vec_normalized_dir(&vec_to_ship, &ship_objp->pos, &weapon_objp->pos);
+
+			// this causes the weapon to detonate if it has flown past the center of the ship
+			if (vm_vec_dot(&vec_to_ship, &weapon_objp->orient.vec.fvec) < 0.0f) {
+				// check if we're colliding against "invisible" ship
+				if (!(shipp->flags[Ship::Ship_Flags::Dont_collide_invis])) {
+					wp->lifeleft = 0.001f;
+					wp->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
+
+					if (ship_objp == Player_obj)
+						nprintf(("Jim", "Frame %i: Weapon %d set to detonate, dist = %7.3f.\n", Framecount, OBJ_INDEX(weapon_objp), dist));
+					valid_hit_occurred = 1; //No hit, continue checking
+				}
+			}
+		}
+	}
+
+	return { postproc, !static_cast<bool>(valid_hit_occurred), collision_data} ;
+}
+
+void ship_weapon_process_collision(obj_pair* pair, const std::any& collision_data) {
+	object *ship_objp = pair->a;
+	object *weapon_objp = pair->b;
+	weapon* wp = &Weapons[weapon_objp->instance];
+	ship* shipp = &Ships[ship_objp->instance];
+	const weapon_info* wip = &Weapon_info[wp->weapon_info_index];
+	const ship_info* sip = &Ship_info[shipp->ship_info_index];
+
+	const auto& [mc_opt, notify_ai_shield_down, shield_collision, quadrant_num] = std::any_cast<ship_weapon_collision_data>(collision_data);
+	bool valid_hit_occurred = mc_opt.has_value();
+	auto mc = valid_hit_occurred ? &(*mc_opt) : nullptr;
+
+	if (notify_ai_shield_down >= 0)
+		Ai_info[Ships[ship_objp->instance].ai_index].danger_shield_quadrant = notify_ai_shield_down;
 
 	if ( valid_hit_occurred )
 	{
@@ -509,20 +559,20 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 
 		if (scripting::hooks::OnWeaponCollision->isActive()) {
 			ship_override = scripting::hooks::OnWeaponCollision->isOverride(scripting::hooks::CollisionConditions{ {ship_objp, weapon_objp} },
-				scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
-					scripting::hook_param("Object", 'o', weapon_objp),
-					scripting::hook_param("Ship", 'o', ship_objp),
-					scripting::hook_param("Weapon", 'o', weapon_objp),
-					scripting::hook_param("Hitpos", 'o', mc->hit_point_world)));
+																			scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
+																									   scripting::hook_param("Object", 'o', weapon_objp),
+																									   scripting::hook_param("Ship", 'o', ship_objp),
+																									   scripting::hook_param("Weapon", 'o', weapon_objp),
+																									   scripting::hook_param("Hitpos", 'o', mc->hit_point_world)));
 		}
 		if (scripting::hooks::OnShipCollision->isActive()) {
 			weapon_override = scripting::hooks::OnShipCollision->isOverride(scripting::hooks::CollisionConditions{ {ship_objp, weapon_objp} },
-				scripting::hook_param_list(scripting::hook_param("Self", 'o', weapon_objp),
-					scripting::hook_param("Object", 'o', ship_objp),
-					scripting::hook_param("Ship", 'o', ship_objp),
-					scripting::hook_param("Weapon", 'o', weapon_objp),
-					scripting::hook_param("Hitpos", 'o', mc->hit_point_world),
-					scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel)));
+																			scripting::hook_param_list(scripting::hook_param("Self", 'o', weapon_objp),
+																									   scripting::hook_param("Object", 'o', ship_objp),
+																									   scripting::hook_param("Ship", 'o', ship_objp),
+																									   scripting::hook_param("Weapon", 'o', weapon_objp),
+																									   scripting::hook_param("Hitpos", 'o', mc->hit_point_world),
+																									   scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel)));
 		}
 
 		if(!ship_override && !weapon_override) {
@@ -536,44 +586,22 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
 
 		if (scripting::hooks::OnWeaponCollision->isActive() && !(weapon_override && !ship_override)) {
 			scripting::hooks::OnWeaponCollision->run(scripting::hooks::CollisionConditions{ {ship_objp, weapon_objp} },
-				scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
-					scripting::hook_param("Object", 'o', weapon_objp),
-					scripting::hook_param("Ship", 'o', ship_objp),
-					scripting::hook_param("Weapon", 'o', weapon_objp),
-					scripting::hook_param("Hitpos", 'o', mc->hit_point_world)));
+													 scripting::hook_param_list(scripting::hook_param("Self", 'o', ship_objp),
+																				scripting::hook_param("Object", 'o', weapon_objp),
+																				scripting::hook_param("Ship", 'o', ship_objp),
+																				scripting::hook_param("Weapon", 'o', weapon_objp),
+																				scripting::hook_param("Hitpos", 'o', mc->hit_point_world)));
 		}
 		if (scripting::hooks::OnShipCollision->isActive() && !ship_override) {
 			scripting::hooks::OnShipCollision->run(scripting::hooks::CollisionConditions{ {ship_objp, weapon_objp} },
-				scripting::hook_param_list(scripting::hook_param("Self", 'o', weapon_objp),
-					scripting::hook_param("Object", 'o', ship_objp),
-					scripting::hook_param("Ship", 'o', ship_objp),
-					scripting::hook_param("Weapon", 'o', weapon_objp),
-					scripting::hook_param("Hitpos", 'o', mc->hit_point_world),
-					scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel)));
+												   scripting::hook_param_list(scripting::hook_param("Self", 'o', weapon_objp),
+																			  scripting::hook_param("Object", 'o', ship_objp),
+																			  scripting::hook_param("Ship", 'o', ship_objp),
+																			  scripting::hook_param("Weapon", 'o', weapon_objp),
+																			  scripting::hook_param("Hitpos", 'o', mc->hit_point_world),
+																			  scripting::hook_param("ShipSubmodel", 'o', scripting::api::l_Submodel.Set(smh), has_submodel)));
 		}
 	}
-	// when the $Fixed Missile Detonation: flag is active, skip this whole block, as it's redundant to a similar check in weapon_home()
-	else if (!Fixed_missile_detonation && (Missiontime - wp->creation_time > F1_0/2) && (wip->is_homing()) && (wp->homing_object == ship_objp)) {
-		if (dist < wip->shockwave.inner_rad) {
-			vec3d	vec_to_ship;
-			vm_vec_normalized_dir(&vec_to_ship, &ship_objp->pos, &weapon_objp->pos);
-
-			// this causes the weapon to detonate if it has flown past the center of the ship
-			if (vm_vec_dot(&vec_to_ship, &weapon_objp->orient.vec.fvec) < 0.0f) {
-				// check if we're colliding against "invisible" ship
-				if (!(shipp->flags[Ship::Ship_Flags::Dont_collide_invis])) {
-					wp->lifeleft = 0.001f;
-					wp->weapon_flags.set(Weapon::Weapon_Flags::Begun_detonation);
-
-					if (ship_objp == Player_obj)
-						nprintf(("Jim", "Frame %i: Weapon %d set to detonate, dist = %7.3f.\n", Framecount, OBJ_INDEX(weapon_objp), dist));
-					valid_hit_occurred = 1;
-				}
-			}
-		}
-	}
-
-	return valid_hit_occurred;
 }
 
 
@@ -584,7 +612,6 @@ static int ship_weapon_check_collision(object *ship_objp, object *weapon_objp, f
  */
 int collide_ship_weapon( obj_pair * pair )
 {
-	int		did_hit;
 	object *ship = pair->a;
 	object *weapon_obj = pair->b;
 	
@@ -618,19 +645,71 @@ int collide_ship_weapon( obj_pair * pair )
 		// Note: culling ships with auto spread shields seems to waste more performance than it saves,
 		// so we're not doing that here
 		if ( !(sip->flags[Ship::Info_Flags::Auto_spread_shields]) && vm_vec_dist_squared(&ship->pos, &weapon_obj->pos) < (1.2f*ship->radius*ship->radius) ) {
-			return check_inside_radius_for_big_ships( ship, weapon_obj, pair );
+			const auto& [do_postproc, never_hits, collision_data] = check_inside_radius_for_big_ships( ship, weapon_obj, pair );
+			if (do_postproc)
+				ship_weapon_process_collision(pair, collision_data);
+			return never_hits;
 		}
 	}
 
-	did_hit = ship_weapon_check_collision( ship, weapon_obj );
+	const auto& [do_postproc, check_if_never_hits, collision_data] = ship_weapon_check_collision( ship, weapon_obj );
+	if (do_postproc)
+		ship_weapon_process_collision(pair, collision_data);
 
-	if ( !did_hit )	{
+	if ( check_if_never_hits )	{
 		// Since we didn't hit, check to see if we can disable all future collisions
 		// between these two.
 		return weapon_will_never_hit( weapon_obj, ship, pair );
 	}
 
 	return 0;
+}
+
+//returns never_hits, process_data
+collision_result collide_ship_weapon_check( obj_pair * pair )
+{
+	object *ship = pair->a;
+	object *weapon_obj = pair->b;
+
+	Assert( ship->type == OBJ_SHIP );
+	Assert( weapon_obj->type == OBJ_WEAPON );
+
+	ship_info *sip = &Ship_info[Ships[ship->instance].ship_info_index];
+
+	// Cyborg17 - no ship-ship collisions when doing multiplayer rollback
+	if ( (Game_mode & GM_MULTIPLAYER) && multi_ship_record_get_rollback_wep_mode() && (weapon_obj->parent_sig == OBJ_INDEX(ship)) ) {
+		return {0, std::nullopt, &ship_weapon_process_collision};
+	}
+
+	// Don't check collisions for player if past first warpout stage.
+	if ( Player->control_mode > PCM_WARPOUT_STAGE1)	{
+		if ( ship == Player_obj )
+			return {0, std::nullopt, &ship_weapon_process_collision};
+	}
+
+	if (reject_due_collision_groups(ship, weapon_obj))
+		return {0, std::nullopt, &ship_weapon_process_collision};
+
+	// Cull lasers within big ship spheres by casting a vector forward for (1) exit sphere or (2) lifetime of laser
+	// If it does hit, don't check the pair until about 200 ms before collision.
+	// If it does not hit and is within error tolerance, cull the pair.
+
+	if ( (sip->is_big_or_huge()) && (weapon_obj->phys_info.flags & PF_CONST_VEL) ) {
+		// Check when within ~1.1 radii.
+		// This allows good transition between sphere checking (leaving the laser about 200 ms from radius) and checking
+		// within the sphere with little time between.  There may be some time for "small" big ships
+		// Note: culling ships with auto spread shields seems to waste more performance than it saves,
+		// so we're not doing that here
+		if ( !(sip->flags[Ship::Info_Flags::Auto_spread_shields]) && vm_vec_dist_squared(&ship->pos, &weapon_obj->pos) < (1.2f*ship->radius*ship->radius) ) {
+			const auto& [do_postproc, never_hits, collision_data] = check_inside_radius_for_big_ships( ship, weapon_obj, pair );
+			return {never_hits, do_postproc ? std::optional(collision_data) : std::nullopt,  &ship_weapon_process_collision};
+		}
+	}
+
+	const auto& [do_postproc, check_if_never_hits, collision_data] = ship_weapon_check_collision( ship, weapon_obj );
+	bool never_hits = check_if_never_hits ? weapon_will_never_hit( weapon_obj, ship, pair ) : false;
+
+	return {never_hits, do_postproc ? std::optional(collision_data) : std::nullopt, &ship_weapon_process_collision};
 }
 
 /**
@@ -664,7 +743,7 @@ static float estimate_ship_speed_upper_limit( object *ship, float time )
  * @return 1 if pair can be culled
  * @return 0 if pair can not be culled
  */
-static int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pair *pair )
+static std::tuple<bool, bool, std::any> check_inside_radius_for_big_ships( object *ship, object *weapon_obj, obj_pair *pair )
 {
 	vec3d error_vel;		// vel perpendicular to laser
 	float error_vel_mag;	// magnitude of error_vel
@@ -702,20 +781,21 @@ static int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, 
 	// Note:  when estimated hit time is less than 200 ms, look at every frame
 	int hit_time;	// estimated time of hit in ms
 
+	const auto& [do_postproc, does_not_hit, collision_data] = ship_weapon_check_collision( ship, weapon_obj, limit_time, &hit_time );
 	// modify ship_weapon_check_collision to do damage if hit_time is negative (ie, hit occurs in this frame)
-	if ( ship_weapon_check_collision( ship, weapon_obj, limit_time, &hit_time ) ) {
+	if ( !does_not_hit ) {
 		// hit occured in while in sphere
 		if (hit_time < 0) {
 			// hit occured in the frame
-			return 1;
+			return {do_postproc, true, collision_data};
 		} else if (hit_time > 200) {
 			pair->next_check_time = timestamp(hit_time - 200);
-			return 0;
+			return {do_postproc, false, collision_data};
 			// set next check time to time - 200
 		} else {
 			// set next check time to next frame
 			pair->next_check_time = 1;
-			return 0;
+			return {do_postproc, false, collision_data};
 		}
 	} else {
 		if (limit_time > time_to_max_error) {
@@ -725,10 +805,10 @@ static int check_inside_radius_for_big_ships( object *ship, object *weapon_obj, 
 			} else {
 				pair->next_check_time = 1;
 			}
-			return 0;
+			return {do_postproc, false, collision_data};
 		} else {
 			// no hit and within error tolerance
-			return 1;
+			return {do_postproc, true, collision_data};
 		}
 	}
 }

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -688,17 +688,17 @@ collision_result collide_ship_weapon_check( obj_pair * pair )
 
 	// Cyborg17 - no ship-ship collisions when doing multiplayer rollback
 	if ( (Game_mode & GM_MULTIPLAYER) && multi_ship_record_get_rollback_wep_mode() && (weapon_obj->parent_sig == OBJ_INDEX(ship)) ) {
-		return {0, std::nullopt, &ship_weapon_process_collision};
+		return {0, std::any(), &ship_weapon_process_collision};
 	}
 
 	// Don't check collisions for player if past first warpout stage.
 	if ( Player->control_mode > PCM_WARPOUT_STAGE1)	{
 		if ( ship == Player_obj )
-			return {0, std::nullopt, &ship_weapon_process_collision};
+			return {0, std::any(), &ship_weapon_process_collision};
 	}
 
 	if (reject_due_collision_groups(ship, weapon_obj))
-		return {0, std::nullopt, &ship_weapon_process_collision};
+		return {0, std::any(), &ship_weapon_process_collision};
 
 	// Cull lasers within big ship spheres by casting a vector forward for (1) exit sphere or (2) lifetime of laser
 	// If it does hit, don't check the pair until about 200 ms before collision.

--- a/code/object/objcollide.cpp
+++ b/code/object/objcollide.cpp
@@ -894,6 +894,10 @@ void obj_collide_pair(object *A, object *B)
             break;
         case COLLISION_OF(OBJ_SHIP,OBJ_SHIP):
             check_collision = collide_ship_ship;
+#ifdef NDEBUG
+			//This is, due to debug prints, unfortunately only safe in release builds...
+			support_mp = true;
+#endif
             break;
 
         case COLLISION_OF(OBJ_SHIP, OBJ_BEAM):
@@ -1151,9 +1155,12 @@ void collide_mp_worker_thread(size_t threadIdx) {
 				collision_result (*check_collision)( obj_pair *pair ) = nullptr;
 
 				switch( collision_check.ctype )	{
-					case COLLISION_OF(OBJ_WEAPON,OBJ_SHIP):
+					case COLLISION_OF(OBJ_WEAPON, OBJ_SHIP):
 					case COLLISION_OF(OBJ_SHIP, OBJ_WEAPON):
 						check_collision = collide_ship_weapon_check;
+						break;
+					case COLLISION_OF(OBJ_SHIP, OBJ_SHIP):
+						check_collision = collide_ship_ship_check;
 						break;
 					default:
 						UNREACHABLE("Got non MP-compatible collision type!");

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -62,7 +62,7 @@ struct obj_pair	{
 };
 
 //Never check again | data for collision post-processing | collision post-proc function
-using collision_result = std::tuple<bool, std::optional<std::any>, void (*)(obj_pair *, const std::any& collision_data)>;
+using collision_result = std::tuple<bool, std::any, void (*)(obj_pair *, const std::any& collision_data)>;
 
 extern SCP_vector<int> Collision_sort_list;
 

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -38,6 +38,7 @@ struct collision_info_struct {
 	bool	edge_hit;				// if edge is hit, need to change collision normal
 	bool	submodel_move_hit;		// if collision is against a moving submodel
 	bool	is_landing;			//SUSHI: Maybe treat current collision as a landing
+	bool 	player_involved;
 };
 
 //Collision physics constants
@@ -126,6 +127,8 @@ int collide_asteroid_weapon(obj_pair *pair);
 // Returns 1 if all future collisions between these can be ignored
 // CODE is locatated in CollideShipShip.cpp
 int collide_ship_ship( obj_pair * pair );
+//Same as above, but for deferred collision processing / usage in multithreading
+collision_result collide_ship_ship_check( obj_pair * pair );
 
 void collide_mp_worker_thread(size_t threadIdx);
 

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -13,6 +13,8 @@
 #define _COLLIDESTUFF_H
 
 #include "globalincs/pstypes.h"
+#include <optional>
+#include <any>
 
 class object;
 struct CFILE;
@@ -57,8 +59,10 @@ struct obj_pair	{
 	object *a;
 	object *b;
 	int	next_check_time;	// a timestamp that when elapsed means to check for a collision
-	struct obj_pair *next;
 };
+
+//Never check again | data for collision post-processing | collision post-proc function
+using collision_result = std::tuple<bool, std::optional<std::any>, void (*)(obj_pair *, const std::any& collision_data)>;
 
 extern SCP_vector<int> Collision_sort_list;
 
@@ -86,6 +90,7 @@ int weapon_will_never_hit( object *weapon, object *other, obj_pair * current_pai
 // CODE is locatated in CollideGeneral.cpp
 int collide_subdivide(vec3d *p0, vec3d *p1, float prad, vec3d *q0, vec3d *q1, float qrad);
 
+void collide_init();
 
 //===============================================================================
 // SPECIFIC COLLISION DETECTION FUNCTIONS 
@@ -100,6 +105,9 @@ int collide_weapon_weapon( obj_pair * pair );
 // Returns 1 if all future collisions between these can be ignored
 // CODE is locatated in CollideShipWeapon.cpp
 int collide_ship_weapon( obj_pair * pair );
+
+//Same as above, but for deferred collision processing / usage in multithreading
+collision_result collide_ship_weapon_check( obj_pair * pair );
 
 // Checks debris-weapon collisions.  pair->a is debris and pair->b is weapon.
 // Returns 1 if all future collisions between these can be ignored

--- a/code/object/objcollide.h
+++ b/code/object/objcollide.h
@@ -127,6 +127,8 @@ int collide_asteroid_weapon(obj_pair *pair);
 // CODE is locatated in CollideShipShip.cpp
 int collide_ship_ship( obj_pair * pair );
 
+void collide_mp_worker_thread(size_t threadIdx);
+
 //	Predictive functions.
 //	Returns true if vector from curpos to goalpos with radius radius will collide with object goalobjp
 int pp_collide(vec3d *curpos, vec3d *goalpos, object *goalobjp, float radius);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -456,8 +456,6 @@ void obj_init()
 	obj_reset_colliders();
 
 	Script_system.OnStateDestroy.add(on_script_state_destroy);
-
-	collide_init();
 }
 
 void obj_shutdown()

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -456,6 +456,8 @@ void obj_init()
 	obj_reset_colliders();
 
 	Script_system.OnStateDestroy.add(on_script_state_destroy);
+
+	collide_init();
 }
 
 void obj_shutdown()

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -808,7 +808,7 @@ MONITOR(NumShieldHits)
 /**
  * Add data for a shield hit.
  */
-void add_shield_point(int objnum, int tri_num, vec3d *hit_pos, float radius_override)
+void add_shield_point(int objnum, int tri_num, const vec3d *hit_pos, float radius_override)
 {
 	if (Num_shield_points >= MAX_SHIELD_POINTS)
 		return;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1765,7 +1765,7 @@ extern void create_shield_explosion(int objnum, int model_num, matrix *orient, v
 extern void shield_hit_init();
 extern void create_shield_explosion_all(object *objp);
 extern void shield_frame_init();
-extern void add_shield_point(int objnum, int tri_num, vec3d *hit_pos, float radius_override);
+extern void add_shield_point(int objnum, int tri_num, const vec3d *hit_pos, float radius_override);
 extern void add_shield_point_multi(int objnum, int tri_num, vec3d *hit_pos);
 extern void shield_point_multi_setup();
 extern void shield_hit_close();

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1700,6 +1700,8 @@ add_file_folder("Utils"
 	utils/string_utils.cpp
 	utils/string_utils.h
 	utils/strings.h
+	utils/threading.cpp
+	utils/threading.h
 	utils/tuples.h
 	utils/unicode.cpp
 	utils/unicode.h

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -77,6 +77,8 @@ class RandomRange {
 	ValueType m_minValue;
 	ValueType m_maxValue;
 
+	//TODO make rr seeder thread local, just for safety...
+
   public:
 	template <typename T, typename... Ts, typename = typename std::enable_if<(sizeof... (Ts) >=1 || !std::is_convertible<T, ValueType>::value) && !std::is_same_v<std::decay_t<T>, RandomRange>, int>::type>
 	explicit RandomRange(T&& distributionFirstParameter, Ts&&... distributionParameters)

--- a/code/utils/threading.cpp
+++ b/code/utils/threading.cpp
@@ -1,0 +1,78 @@
+#include "threading.h"
+
+#include "cmdline/cmdline.h"
+#include "object/objcollide.h"
+#include "globalincs/pstypes.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace threading {
+	std::condition_variable wait_for_task;
+	std::mutex wait_for_task_mutex;
+	bool wait_for_task_condition;
+	std::atomic<WorkerThreadTask> worker_task;
+
+	SCP_vector<std::thread> worker_threads;
+
+	//Internal Functions
+	static void mp_worker_thread_main(size_t threadIdx) {
+		while(true) {
+			{
+				std::unique_lock<std::mutex> lk(wait_for_task_mutex);
+				wait_for_task.wait(lk, []() { return wait_for_task_condition; });
+			}
+
+			switch (worker_task.load(std::memory_order_acquire)) {
+				case WorkerThreadTask::EXIT:
+					return;
+				case WorkerThreadTask::COLLISION:
+					collide_mp_worker_thread(threadIdx);
+					break;
+				default:
+					UNREACHABLE("Invalid threaded worker task!");
+			}
+		}
+	}
+
+	//External Functions
+
+	void spin_up_threaded_task(WorkerThreadTask task) {
+		worker_task.store(task);
+		{
+			std::scoped_lock lock {wait_for_task_mutex};
+			wait_for_task_condition = true;
+			wait_for_task.notify_all();
+		}
+	}
+
+	void spin_down_threaded_task() {
+		std::scoped_lock lock {wait_for_task_mutex};
+		wait_for_task_condition = false;
+	}
+
+	void init_task_pool() {
+		if (!is_threading())
+			return;
+
+		mprintf(("Spinning up threadpool with %d threads...\n", Cmdline_multithreading - 1));
+
+		for (size_t i = 0; i < static_cast<size_t>(Cmdline_multithreading - 1); i++) {
+			worker_threads.emplace_back([i](){ mp_worker_thread_main(i); });
+		}
+	}
+
+	void shut_down_task_pool() {
+		spin_up_threaded_task(WorkerThreadTask::EXIT);
+	}
+
+	bool is_threading() {
+		return Cmdline_multithreading > 1;
+	}
+
+	size_t get_num_workers() {
+		return worker_threads.size();
+	}
+}

--- a/code/utils/threading.cpp
+++ b/code/utils/threading.cpp
@@ -66,6 +66,10 @@ namespace threading {
 
 	void shut_down_task_pool() {
 		spin_up_threaded_task(WorkerThreadTask::EXIT);
+
+		for(auto& thread : worker_threads) {
+			thread.join();
+		}
 	}
 
 	bool is_threading() {

--- a/code/utils/threading.h
+++ b/code/utils/threading.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace threading {
+	enum class WorkerThreadTask : uint8_t { EXIT, COLLISION };
+
+	//Call this to start a task on the task pool. Note that task-specific data must be set up before calling this.
+	void spin_up_threaded_task(WorkerThreadTask task);
+
+	//This _must_ be called BEFORE a task completes on a thread of the task pool.
+	void spin_down_threaded_task();
+
+	void init_task_pool();
+	void shut_down_task_pool();
+
+	bool is_threading();
+	size_t get_num_workers();
+}

--- a/code/utils/threading.h
+++ b/code/utils/threading.h
@@ -8,7 +8,7 @@ namespace threading {
 	//Call this to start a task on the task pool. Note that task-specific data must be set up before calling this.
 	void spin_up_threaded_task(WorkerThreadTask task);
 
-	//This _must_ be called BEFORE a task completes on a thread of the task pool.
+	//This _must_ be called on the main thread BEFORE a task completes on a thread of the task pool.
 	void spin_down_threaded_task();
 
 	void init_task_pool();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -2008,7 +2008,8 @@ void game_init()
 	// Initialize SEXPs. Must happen before ship init for LuaAI
 	sexp_startup();
 
-	obj_init();	
+	obj_init();
+	collide_init();
 	mflash_game_init();	
 	armor_init();
 	ai_init();

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -193,6 +193,7 @@
 #include "tracing/Monitor.h"
 #include "tracing/tracing.h"
 #include "utils/Random.h"
+#include "utils/threading.h"
 #include "weapon/beam.h"
 #include "weapon/emp.h"
 #include "weapon/flak.h"
@@ -1758,6 +1759,8 @@ void game_init()
 
 	// init os stuff next
 	os_init( Osreg_class_name, Window_title.c_str(), Osreg_app_name );
+
+	threading::init_task_pool();
 
 #ifndef NDEBUG
 	mprintf(("FreeSpace 2 Open version: %s\n", FS_VERSION_FULL));
@@ -7026,6 +7029,8 @@ void game_shutdown(void)
 	}
 
 	lcl_xstr_close();
+
+	threading::shut_down_task_pool();
 }
 
 // game_stop_looped_sounds()


### PR DESCRIPTION
This PR adds a somewhat generic system to manage helper threads for FSO.

For now, it is gated behind the CLI flag `-threads <n>`, where n has to be 2 or larger to activate threading. Note that due to this being heterogeneous multithreading with a main thread and n-1 helper threads, only 2 threads will likely not see much improvement at all. 

To achieve that, FSO will manage an arbitrarily large helper thread pool that can be spun up for specific tasks, such as collision. In the future, AI turret behaviour or model load could be parallelized as well, but that's out of scope for this for now.

Performance-wise, a 4-thread FSO can achieve almost 1.8 times speedup compared to singlethreaded FSO in CPU-heavy but still reasonable missions:
![benchmark heavy mission](https://github.com/user-attachments/assets/5cf0dd78-ccd5-4f30-9dbc-85ef705b0639)
In missions that are not CPU-bound (i.e. they have only very few collisions, in this case the performance cost is almost entirely GPU-latency based), like Icarus, the PR at least doesn't reduce performance, and can cause small uplifts in heavy sections:
![benchmark icarus](https://github.com/user-attachments/assets/b92cc9eb-8984-466d-aa52-29630bbb99df)

For collisions specifically, the flow diagram looks approximately like this:
![fso threading](https://github.com/user-attachments/assets/d13f6a12-ab36-4b01-a4ba-d7d6d5705b1b)
