### PR TITLE
memory safety for model parsing

### DIFF
--- a/code/globalincs/pstypes.h
+++ b/code/globalincs/pstypes.h
@@ -308,6 +308,20 @@ constexpr bool LoggingEnabled = false;
 		ASSUME( expr );\
 	} while (false)
 #endif
+
+template <typename T>
+bool CallAssert(bool val, const char *msg, const char *filename, int linenum, T assertMsgFunc)
+{
+	if (!val)
+		assertMsgFunc(msg, filename, linenum, nullptr);
+	ASSUME(val);
+	return true;
+}
+#if defined(NDEBUG)
+#	define AssertExpr(expr) (true)
+#else
+#	define AssertExpr(expr) CallAssert(expr, #expr, __FILE__, __LINE__, os::dialogs::AssertMessage)
+#endif
 /*******************NEVER COMMENT Assert ************************************************/
 
 // Goober5000 - define Verify for use in both release and debug mode

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1366,7 +1366,7 @@ typedef struct mc_info {
 */
 
 int model_collide(mc_info *mc_info_obj);
-void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int version);
+void model_collide_parse_bsp(bsp_collision_tree *tree, ubyte *bsp_data, int version);
 
 bsp_collision_tree *model_get_bsp_collision_tree(int tree_index);
 void model_remove_bsp_collision_tree(int tree_index);

--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -577,11 +577,11 @@ void model_collide_parse_bsp_flatpoly(bsp_collision_leaf *leaf, SCP_vector<model
 	}
 }
 
-void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int version)
+void model_collide_parse_bsp(bsp_collision_tree *tree, ubyte *bsp_data, int version)
 {
 	TRACE_SCOPE(tracing::ModelParseBSPTree);
 
-	ubyte *p = (ubyte *)model_ptr;
+	ubyte *p = bsp_data;
 	ubyte *next_p;
 
 	int chunk_type = w(p);
@@ -712,7 +712,7 @@ void model_collide_parse_bsp(bsp_collision_tree *tree, void *model_ptr, int vers
 			}
 
 			next_p = p + chunk_size;
-			next_chunk_type = w(next_p);
+			next_chunk_type = OP_EOF;	// should not continue after this chunk
 
 			++i;
 			break;

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -60,16 +60,18 @@ class polymodel;
 #define ID_SLDC 0x43444c53				// CDLS (SLDC): Shield Collision Tree
 #define ID_SLC2 0x32434c53				// 2CLS (SLC2): Shield Collision Tree with ints instead of char - ShivanSpS
 
-#define us(p)	(*reinterpret_cast<ushort*>(p))
-#define cus(p)  (*reinterpret_cast<const ushort*>(p))
-#define uw(p)	(*reinterpret_cast<uint*>(p))
-#define cuw(p)  (*reinterpret_cast<const uint*>(p))
-#define w(p)	(*reinterpret_cast<int*>(p))
-#define cw(p)   (*reinterpret_cast<const int*>(p))
-#define wp(p)	(reinterpret_cast<int*>(p)
-#define vp(p)	(reinterpret_cast<vec3d*>(p))
-#define fl(p)	(*reinterpret_cast<float*>(p))
-#define cfl(p)  (*reinterpret_cast<const float*>(p))
+extern const ubyte* Macro_ubyte_bounds;
+
+#define us(p)	(AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<ushort*>(p))
+#define cus(p)  (AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<const ushort*>(p))
+#define uw(p)	(AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<uint*>(p))
+#define cuw(p)  (AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<const uint*>(p))
+#define w(p)	(AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<int*>(p))
+#define cw(p)   (AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<const int*>(p))
+#define wp(p)	(AssertExpr(p < Macro_ubyte_bounds), reinterpret_cast<int*>(p)
+#define vp(p)	(AssertExpr(p < Macro_ubyte_bounds), reinterpret_cast<vec3d*>(p))
+#define fl(p)	(AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<float*>(p))
+#define cfl(p)  (AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<const float*>(p))
 
 void model_calc_bound_box(vec3d *box, const vec3d *big_mn, const vec3d *big_mx);
 

--- a/code/model/modelsinc.h
+++ b/code/model/modelsinc.h
@@ -62,6 +62,7 @@ class polymodel;
 
 extern const ubyte* Macro_ubyte_bounds;
 
+#ifndef NDEBUG
 #define us(p)	(AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<ushort*>(p))
 #define cus(p)  (AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<const ushort*>(p))
 #define uw(p)	(AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<uint*>(p))
@@ -72,6 +73,18 @@ extern const ubyte* Macro_ubyte_bounds;
 #define vp(p)	(AssertExpr(p < Macro_ubyte_bounds), reinterpret_cast<vec3d*>(p))
 #define fl(p)	(AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<float*>(p))
 #define cfl(p)  (AssertExpr(p < Macro_ubyte_bounds), *reinterpret_cast<const float*>(p))
+#else
+#define us(p)	(*reinterpret_cast<ushort*>(p))
+#define cus(p)  (*reinterpret_cast<const ushort*>(p))
+#define uw(p)	(*reinterpret_cast<uint*>(p))
+#define cuw(p)  (*reinterpret_cast<const uint*>(p))
+#define w(p)	(*reinterpret_cast<int*>(p))
+#define cw(p)   (*reinterpret_cast<const int*>(p))
+#define wp(p)	(reinterpret_cast<int*>(p)
+#define vp(p)	(reinterpret_cast<vec3d*>(p))
+#define fl(p)	(*reinterpret_cast<float*>(p))
+#define cfl(p)  (*reinterpret_cast<const float*>(p))
+#endif
 
 void model_calc_bound_box(vec3d *box, const vec3d *big_mn, const vec3d *big_mx);
 

--- a/code/render/3d.h
+++ b/code/render/3d.h
@@ -287,7 +287,7 @@ public:
 	}
 
 	void initialize(uint number, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
-	void initialize(ubyte *bsp_data, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
+	void initialize(ubyte *bsp_data, int bsp_data_size, float min_ray_width, float max_ray_width = 0, const vec3d* dir = &vmd_zero_vector, const vec3d* pcenter = &vmd_zero_vector, float outer = PI2, float inner = 0.0f, ubyte max_r = 255, ubyte max_g = 255, ubyte max_b = 255, ubyte min_r = 255, ubyte min_g = 255, ubyte min_b = 255);
 	void render(int texture, float rad, float intinsity, float life);
 };
 #endif

--- a/code/render/3ddraw.cpp
+++ b/code/render/3ddraw.cpp
@@ -1333,12 +1333,15 @@ void flash_ball::parse_bsp(int offset, ubyte *bsp_data){
 	}
 }
 
+extern const ubyte* Macro_ubyte_bounds;
 
-void flash_ball::initialize(ubyte *bsp_data, float min_ray_width, float max_ray_width, const vec3d* dir, const vec3d* pcenter, float outer, float inner, ubyte max_r, ubyte max_g, ubyte max_b, ubyte min_r, ubyte min_g, ubyte min_b)
+void flash_ball::initialize(ubyte *bsp_data, int bsp_data_size, float min_ray_width, float max_ray_width, const vec3d* dir, const vec3d* pcenter, float outer, float inner, ubyte max_r, ubyte max_g, ubyte max_b, ubyte min_r, ubyte min_g, ubyte min_b)
 {
 	center = *pcenter;
 	vm_vec_negate(&center);
-	parse_bsp(0,bsp_data);
+	Macro_ubyte_bounds = bsp_data + bsp_data_size;
+	parse_bsp(0, bsp_data);
+	Macro_ubyte_bounds = nullptr;
 	center = vmd_zero_vector;
 
 	uint i;


### PR DESCRIPTION
Add assertions to the model parsing macros to guard against accessing out-of-bounds memory.  Patch the model parsing routines to avoid going out of bounds, even if the out of bounds situations are temporary and benign.