### PR TITLE
fix qtfred memory corruption

### DIFF
--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -130,18 +130,18 @@ void Editor::update() {
 	}
 }
 
-std::string Editor::maybeUseAutosave(const std::string& filepath)
+void Editor::maybeUseAutosave(std::string& filepath)
 {
 	// first, just grab the info of this mission
 	if (!parse_main(filepath.c_str(), MPF_ONLY_MISSION_INFO))
-		return filepath;
+		return;
 	SCP_string created = The_mission.created;
 	CFileLocation res = cf_find_file_location(filepath.c_str(), CF_TYPE_ANY);
 	time_t modified = res.m_time;
 	if (!res.found)
 	{
 		UNREACHABLE("Couldn't find path '%s' even though parse_main() succeeded!", filepath.c_str());
-		return filepath;	// just load the actual specified file
+		return;
 	}
 
 	// now check all the autosaves
@@ -179,10 +179,8 @@ std::string Editor::maybeUseAutosave(const std::string& filepath)
 																	prompt.c_str(),
 																	{ DialogButton::Yes, DialogButton::No });
 		if (z == DialogButton::Yes)
-			return backup_res.full_name.c_str();
+			filepath = backup_res.full_name;	// replace the specified file with the autosave file
 	}
-
-	return filepath;
 }
 
 bool Editor::loadMission(const std::string& mission_name, int flags) {

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -39,7 +39,7 @@ class Editor : public QObject {
 
 	void createNewMission();
 
-	std::string maybeUseAutosave(const std::string& filepath);
+	void maybeUseAutosave(std::string& filepath);
 
 	/*! Load a mission. */
 	bool loadMission(const std::string& filepath, int flags = 0);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -143,7 +143,8 @@ void FredView::loadMissionFile(const QString& pathName) {
 	try {
 		QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
-		auto pathToLoad = fred->maybeUseAutosave(pathName.toStdString());
+		auto pathToLoad = pathName.toStdString();
+		fred->maybeUseAutosave(pathToLoad);
 
 		fred->loadMission(pathToLoad);
 


### PR DESCRIPTION
Fix a qtFRED memory access bug when checking for autosaved files.  Passing a temporary variable to a function as a reference, then returning it, led to a dangling reference access.  Rewrite the `maybeUseAutosave` function to avoid this.