### PR TITLE
fix broken newline behavior when FRED saves missions

### DIFF
--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -398,6 +398,28 @@ int CFred_mission_save::fout_version(char *format, ...)
 	return 0;
 }
 
+void CFred_mission_save::fout_raw_comment(const char *comment_start)
+{
+	Assertion(comment_start <= raw_ptr, "This function assumes the beginning of the comment precedes the current raw pointer!");
+
+	// the current character is \n, so either set it to 0, or set the preceding \r (if there is one) to 0
+	if (*(raw_ptr - 1) == '\r') {
+		*(raw_ptr - 1) = '\0';
+	} else {
+		*raw_ptr = '\0';
+	}
+
+	// save the comment, which will write all characters up to the 0 we just set
+	fout("%s\n", comment_start);
+
+	// restore the overwritten character
+	if (*(raw_ptr - 1) == '\0') {
+		*(raw_ptr - 1) = '\r';
+	} else {
+		*raw_ptr = '\n';
+	}
+}
+
 void CFred_mission_save::parse_comments(int newlines)
 {
 	char *comment_start = NULL;
@@ -497,29 +519,14 @@ void CFred_mission_save::parse_comments(int newlines)
 				if (state == 2) {
 					if (first_comment && !flag)
 						fout("\t\t");
+					fout_raw_comment(comment_start);
 
-					*raw_ptr = 0;
-					fout("%s\n", comment_start);
-					*raw_ptr = '\n';
 					state = first_comment = same_line = flag = 0;
 				} else if (state == 4) {
 					same_line = newlines - 2 + same_line;
 					while (same_line-- > 0)
 						fout("\n");
-
-					if (*(raw_ptr - 1) == '\r') {
-						*(raw_ptr - 1) = '\0';
-					} else {
-						*raw_ptr = 0;
-					}
-
-					fout("%s\n", comment_start);
-
-					if (*(raw_ptr - 1) == '\0') {
-						*(raw_ptr - 1) = '\r';
-					} else {
-						*raw_ptr = '\n';
-					}
+					fout_raw_comment(comment_start);
 
 					state = first_comment = same_line = flag = 0;
 				}

--- a/fred2/missionsave.h
+++ b/fred2/missionsave.h
@@ -505,10 +505,15 @@ private:
 	 */
 	int save_wings();
 
-	char *raw_ptr;
+	/**
+	 * @brief Utility function to save a raw comment, the start of which precedes the current raw_ptr, to a file while handling newlines properly
+	 */
+	void fout_raw_comment(const char *comment_start);
+
+	char *raw_ptr = nullptr;
 	SCP_vector<SCP_string> fso_ver_comment;
-	int err;
-	CFILE *fp;
+	int err = 0;
+	CFILE *fp = nullptr;
 };
 
 #endif	// _MISSION_SAVE_H

--- a/qtfred/src/mission/missionsave.h
+++ b/qtfred/src/mission/missionsave.h
@@ -516,6 +516,11 @@ class CFred_mission_save {
 	 */
 	int save_wings();
 
+	/**
+	 * @brief Utility function to save a raw comment, the start of which precedes the current raw_ptr, to a file while handling newlines properly
+	 */
+	void fout_raw_comment(const char *comment_start);
+
 	char* raw_ptr = nullptr;
 	SCP_vector<SCP_string> fso_ver_comment;
 	int err = 0;


### PR DESCRIPTION
Ever since retail, when encountering a comment, FRED would add an extra newline and mix `\r` with `\r\n`, often causing other bugs.  The reason for this is subtle.  C and C++ library functions will automatically convert `\n` to `\r\n` and back again when reading and writing in text mode, but FRED mission files are read in binary mode and written in text mode.  Normally the parsing code can accommodate reading raw newlines of any type, but comments are copied verbatim from what is read to what is written.  A comment ending in `\r\n` will therefore be written as `\r\r\n` which will add an extra incompatible newline.

At one point (in commit a988f5eab22b2c2316bce389e24c5eee4aad7903) a fix was made for this, but it only applied to multiline comments, not all comments.  Therefore, this PR moves the fix to a common function and uses it for all comment styles.