### PR TITLE
Fix broken rendering after instanced decals

### DIFF
--- a/code/graphics/opengl/ShaderProgram.cpp
+++ b/code/graphics/opengl/ShaderProgram.cpp
@@ -183,17 +183,15 @@ void opengl::ShaderProgram::linkProgram() {
 	freeCompiledShaders();
 }
 
-void opengl::ShaderProgram::initAttribute(const SCP_string& name, opengl_vert_attrib::attrib_id attr_id, const vec4& default_value)
+void opengl::ShaderProgram::initAttribute(const SCP_string& name, const vec4& default_value)
 {
 	auto attrib_loc = glGetAttribLocation(_program_id, name.c_str());
 
 	if (attrib_loc == -1)
 	{
-		// Not available, ignore
+		// Not available or optimized out, ignore
 		return;
 	}
-
-	_attribute_locations.insert(std::make_pair(attr_id, attrib_loc));
 
 	// The shader needs to be in use before glVertexAttrib can be used
 	use();
@@ -204,14 +202,6 @@ void opengl::ShaderProgram::initAttribute(const SCP_string& name, opengl_vert_at
 		default_value.xyzw.z,
 		default_value.xyzw.w
 	);
-}
-GLint opengl::ShaderProgram::getAttributeLocation(opengl_vert_attrib::attrib_id attribute) {
-	auto iter = _attribute_locations.find(attribute);
-	if (iter == _attribute_locations.end()) {
-		return -1;
-	} else {
-		return iter->second;
-	}
 }
 
 opengl::ShaderUniforms::ShaderUniforms(ShaderProgram* shaderProgram) : _program(shaderProgram) {

--- a/code/graphics/opengl/ShaderProgram.h
+++ b/code/graphics/opengl/ShaderProgram.h
@@ -67,9 +67,7 @@ class ShaderProgram {
 
 	void linkProgram();
 
-	void initAttribute(const SCP_string& name, opengl_vert_attrib::attrib_id attr_id, const vec4& default_value);
-
-	GLint getAttributeLocation(opengl_vert_attrib::attrib_id attribute);
+	void initAttribute(const SCP_string& name, const vec4& default_value);
 
 	GLuint getShaderHandle();
 };

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -57,7 +57,6 @@ SCP_vector<opengl_vert_attrib> GL_vertex_attrib_info =
 		{ opengl_vert_attrib::MODEL_ID,		"vertModelID",		{{{ 0.0f, 0.0f, 0.0f, 0.0f }}} },
 		{ opengl_vert_attrib::RADIUS,		"vertRadius",		{{{ 1.0f, 0.0f, 0.0f, 0.0f }}} },
 		{ opengl_vert_attrib::UVEC,			"vertUvec",			{{{ 0.0f, 1.0f, 0.0f, 0.0f }}} },
-		{ opengl_vert_attrib::WORLD_MATRIX,	"vertWorldMatrix",	{{{ 1.0f, 0.0f, 0.0f, 0.0f }}} },
 		{ opengl_vert_attrib::MODEL_MATRIX,	"vertModelMatrix",	{{{ 1.0f, 0.0f, 0.0f, 0.0f }}} },
 	};
 
@@ -885,7 +884,7 @@ void opengl_compile_shader_actual(shader_type sdr, const uint &flags, opengl_sha
 
 	// initialize the attributes
 	for (auto& attr : sdr_info->attributes) {
-		new_shader.program->initAttribute(GL_vertex_attrib_info[attr].name, GL_vertex_attrib_info[attr].attribute_id, GL_vertex_attrib_info[attr].default_value);
+		new_shader.program->initAttribute(GL_vertex_attrib_info[attr].name, GL_vertex_attrib_info[attr].default_value);
 	}
 
 	for (auto& uniform_block : GL_uniform_blocks) {
@@ -905,7 +904,7 @@ void opengl_compile_shader_actual(shader_type sdr, const uint &flags, opengl_sha
 		if (sdr_info->type_id == variant.type_id && variant.flag & flags) {
 			for (auto& attr : variant.attributes) {
 				auto& attr_info = GL_vertex_attrib_info[attr];
-				new_shader.program->initAttribute(attr_info.name, attr_info.attribute_id, attr_info.default_value);
+				new_shader.program->initAttribute(attr_info.name, attr_info.default_value);
 			}
 
 			nprintf(("shaders","	%s\n", variant.description));
@@ -1075,19 +1074,6 @@ void opengl_shader_init()
 	gr_opengl_maybe_create_shader(SDR_TYPE_PASSTHROUGH_RENDER, 0);
 
 	nprintf(("shaders","\n"));
-}
-
-/**
- * Get the internal OpenGL location for a given attribute. Requires that the Current_shader global variable is valid
- *
- * @param attribute_text	Name of the attribute
- * @return					Internal OpenGL location for the attribute
- */
-GLint opengl_shader_get_attribute(opengl_vert_attrib::attrib_id attribute)
-{
-	Assertion(Current_shader != nullptr, "Current shader may not be null!");
-
-	return Current_shader->program->getAttributeLocation(attribute);
 }
 
 void opengl_shader_set_passthrough(bool textured, bool hdr)

--- a/code/graphics/opengl/gropenglshader.h
+++ b/code/graphics/opengl/gropenglshader.h
@@ -35,7 +35,6 @@ struct opengl_vert_attrib {
 		MODEL_ID,
 		RADIUS,
 		UVEC,
-		WORLD_MATRIX,
 		MODEL_MATRIX,
 		NUM_ATTRIBS,
 	};
@@ -151,8 +150,6 @@ void opengl_shader_init();
 void opengl_shader_shutdown();
 
 int opengl_compile_shader(shader_type sdr, uint flags);
-
-GLint opengl_shader_get_attribute(opengl_vert_attrib::attrib_id attribute);
 
 void opengl_shader_set_passthrough(bool textured, bool hdr);
 

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -1190,7 +1190,7 @@ void opengl_bind_vertex_component(const vertex_format_data &vert_component, size
 
 	if ( Current_shader != NULL ) {
 		// grabbing a vertex attribute is dependent on what current shader has been set. i hope no one calls opengl_bind_vertex_layout before opengl_set_current_shader
-		GLint index = opengl_shader_get_attribute(attrib_info.attribute_id);
+		GLint index = attrib_info.attribute_id;
 
 		if ( index >= 0 ) {
 			GL_state.Array.EnableVertexAttrib(index);
@@ -1232,7 +1232,7 @@ void opengl_bind_vertex_array(const vertex_layout& layout) {
 		auto& bind_info = GL_array_binding_data[component->format_type];
 		auto& attrib_info = GL_vertex_attrib_info[bind_info.attribute_id];
 
-		auto attribIndex = static_cast<GLuint>(opengl_shader_get_attribute(attrib_info.attribute_id));
+		auto attribIndex = attrib_info.attribute_id;
 
 		GLuint add_val_index = 0;
 		for (GLint size = bind_info.size; size > 0; size -=4) {


### PR DESCRIPTION
Followup to #6813.

Turns out, using `opengl_shader_get_attribute` was incredibly unsafe.
Depending on the model being rendered and the shaders being used, it's possible that some vertex attributes can be optimized away by the compiler.
FSO will still try to bind these (legal), but to do that, it queries its system as to what ID the given vertex attribute has.
This ID is queried from the driver at shader compile time. Now, if the attribute is optimized away, this will fail and return -1, and binding to -1 (wrapping around to 2^32-1) is then illegal and will cause the shader to fail to render.
However, querying the ID here is completely unnecessary. FSO _tells_ the driver what ID it should use for any given vertex attribute, so we already know the ID and don't have to keep a mapping of FSO's ID to the driver's ID, as they will be identical.