### PR TITLE
Slots for custom post processing effects

### DIFF
--- a/code/def_files/data/effects/post-f.sdr
+++ b/code/def_files/data/effects/post-f.sdr
@@ -21,11 +21,11 @@ layout (std140) uniform genericData {
 
 	// these are blank, valid slots for modders to create custom effects 
 	// that can be defined in post_processing.tbl and coded below
-	//float custom_effect_float_a;
-	//float custom_effect_float_b;
+	vec3 custom_effect_vec3_a;
+	float custom_effect_float_a;
 
-	//vec3 custom_effect_vec3_a;
-	//vec3 custom_effect_vec3_b;
+	vec3 custom_effect_vec3_b;
+	float custom_effect_float_b;
 };
 
 void main()

--- a/code/def_files/data/effects/post-f.sdr
+++ b/code/def_files/data/effects/post-f.sdr
@@ -18,6 +18,14 @@ layout (std140) uniform genericData {
 
 	vec3 tint;
 	float dither;
+
+	// these are blank, valid slots for modders to create custom effects 
+	// that can be defined in post_processing.tbl and coded below
+	//float custom_effect_float_a;
+	//float custom_effect_float_b;
+
+	//vec3 custom_effect_vec3_a;
+	//vec3 custom_effect_vec3_b;
 };
 
 void main()

--- a/code/def_files/data/tables/post_processing.tbl
+++ b/code/def_files/data/tables/post_processing.tbl
@@ -63,5 +63,14 @@ $AlwaysOn:		false
 $Default:		0.0								
 $Div:			50								
 $Add:			0								
-												
+
+$Name:			tint
+$Uniform:		tint
+$Define:		FLAG_TINT
+$AlwaysOn: 		false
+$Default:		0.0
+$Div:			1
+$Add:			0
+$RGB:           0.2,0.2,0.2
+									
 #End											

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -597,6 +597,18 @@ void gr_opengl_post_process_end()
 				case graphics::PostEffectUniformType::Tint:
 					data->tint = postEffects[idx].rgb;
 					break;
+				case graphics::PostEffectUniformType::CustomEffectFloatA:
+					data->custom_effect_float_a = value;
+					break;
+				case graphics::PostEffectUniformType::CustomEffectFloatB:
+					data->custom_effect_float_b = value;
+					break;
+				case graphics::PostEffectUniformType::CustomEffectVEC3A:
+					data->custom_effect_vec3_a = postEffects[idx].rgb;
+					break;
+				case graphics::PostEffectUniformType::CustomEffectVEC3B:
+					data->custom_effect_vec3_b = postEffects[idx].rgb;
+					break;
 				}
 			}
 		}

--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -597,17 +597,17 @@ void gr_opengl_post_process_end()
 				case graphics::PostEffectUniformType::Tint:
 					data->tint = postEffects[idx].rgb;
 					break;
-				case graphics::PostEffectUniformType::CustomEffectFloatA:
-					data->custom_effect_float_a = value;
-					break;
-				case graphics::PostEffectUniformType::CustomEffectFloatB:
-					data->custom_effect_float_b = value;
-					break;
 				case graphics::PostEffectUniformType::CustomEffectVEC3A:
 					data->custom_effect_vec3_a = postEffects[idx].rgb;
 					break;
+				case graphics::PostEffectUniformType::CustomEffectFloatA:
+					data->custom_effect_float_a = value;
+					break;
 				case graphics::PostEffectUniformType::CustomEffectVEC3B:
 					data->custom_effect_vec3_b = postEffects[idx].rgb;
+					break;
+				case graphics::PostEffectUniformType::CustomEffectFloatB:
+					data->custom_effect_float_b = value;
 					break;
 				}
 			}

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -30,14 +30,14 @@ PostEffectUniformType mapUniformNameToType(const SCP_string& uniform_name)
 		return PostEffectUniformType::Dither;
 	} else if (!stricmp(uniform_name.c_str(), "tint")) {
 		return PostEffectUniformType::Tint;
-	} else if (!stricmp(uniform_name.c_str(), "custom_effect_float_a")) {
-		return PostEffectUniformType::CustomEffectFloatA;
-	} else if (!stricmp(uniform_name.c_str(), "custom_effect_float_b")) {
-		return PostEffectUniformType::CustomEffectFloatB;
 	} else if (!stricmp(uniform_name.c_str(), "custom_effect_vec3_a")) {
 		return PostEffectUniformType::CustomEffectVEC3A;
+	} else if (!stricmp(uniform_name.c_str(), "custom_effect_float_a")) {
+		return PostEffectUniformType::CustomEffectFloatA;
 	} else if (!stricmp(uniform_name.c_str(), "custom_effect_vec3_b")) {
 		return PostEffectUniformType::CustomEffectVEC3B;
+	} else if (!stricmp(uniform_name.c_str(), "custom_effect_float_b")) {
+		return PostEffectUniformType::CustomEffectFloatB;
 	} else {
 		error_display(0, "Unknown uniform name '%s'!", uniform_name.c_str());
 		return PostEffectUniformType::Invalid;

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -30,6 +30,14 @@ PostEffectUniformType mapUniformNameToType(const SCP_string& uniform_name)
 		return PostEffectUniformType::Dither;
 	} else if (!stricmp(uniform_name.c_str(), "tint")) {
 		return PostEffectUniformType::Tint;
+	} else if (!stricmp(uniform_name.c_str(), "custom_effect_float_a")) {
+		return PostEffectUniformType::CustomEffectFloatA;
+	} else if (!stricmp(uniform_name.c_str(), "custom_effect_float_b")) {
+		return PostEffectUniformType::CustomEffectFloatB;
+	} else if (!stricmp(uniform_name.c_str(), "custom_effect_vec3_a")) {
+		return PostEffectUniformType::CustomEffectVEC3A;
+	} else if (!stricmp(uniform_name.c_str(), "custom_effect_vec3_b")) {
+		return PostEffectUniformType::CustomEffectVEC3B;
 	} else {
 		error_display(0, "Unknown uniform name '%s'!", uniform_name.c_str());
 		return PostEffectUniformType::Invalid;

--- a/code/graphics/post_processing.h
+++ b/code/graphics/post_processing.h
@@ -17,10 +17,10 @@ enum class PostEffectUniformType {
 	Cutoff,
 	Tint,
 	Dither,
-	CustomEffectFloatA,
-	CustomEffectFloatB,
 	CustomEffectVEC3A,
+	CustomEffectFloatA,
 	CustomEffectVEC3B,
+	CustomEffectFloatB,
 };
 
 struct post_effect_t {

--- a/code/graphics/post_processing.h
+++ b/code/graphics/post_processing.h
@@ -17,6 +17,10 @@ enum class PostEffectUniformType {
 	Cutoff,
 	Tint,
 	Dither,
+	CustomEffectFloatA,
+	CustomEffectFloatB,
+	CustomEffectVEC3A,
+	CustomEffectVEC3B,
 };
 
 struct post_effect_t {

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -399,11 +399,11 @@ struct post_data {
 	vec3d tint;
 	float dither;
 
-	float custom_effect_float_a;
-	float custom_effect_float_b;
-
 	vec3d custom_effect_vec3_a;
+	float custom_effect_float_a;
+
 	vec3d custom_effect_vec3_b;
+	float custom_effect_float_b;
 };
 
 struct irrmap_data {

--- a/code/graphics/util/uniform_structs.h
+++ b/code/graphics/util/uniform_structs.h
@@ -398,6 +398,12 @@ struct post_data {
 
 	vec3d tint;
 	float dither;
+
+	float custom_effect_float_a;
+	float custom_effect_float_b;
+
+	vec3d custom_effect_vec3_a;
+	vec3d custom_effect_vec3_b;
 };
 
 struct irrmap_data {


### PR DESCRIPTION
Post processing effects such as tint or dithering have their uniforms hardcoded, which means the only want to create new post-process effects for a mod is to overwrite an existing effect.

Requested for DEM2, this PR creates 4 blank slots for mods to create new post processing effects--2 floats and 2 vec3. This approach to create blank slots for modders follows the successful strategy used for Custom_Controls 1-5.

Note, this PR also adds `tint` to the default `post_processing.tbl` which had it missing (even though tint is a valid effect with a valid uniform buffer already).

Happy to discuss more or edit however (including if this is a bad idea or will result in performance loss, very much want to avoid any 'gotchas' and can close if deemed not feasible).