### PR TITLE
fix decal shader compile error

### DIFF
--- a/code/def_files/data/effects/decal-f.sdr
+++ b/code/def_files/data/effects/decal-f.sdr
@@ -10,11 +10,11 @@ out vec4 fragOut0; // Diffuse buffer
 out vec4 fragOut1; // Normal buffer
 out vec4 fragOut2; // Emissive buffer
 
-in flat mat4 invModelMatrix;
-in flat vec3 decalDirection;
-in flat float normal_angle_cutoff;
-in flat float angle_fade_start;
-in flat float alpha_scale;
+flat in mat4 invModelMatrix;
+flat in vec3 decalDirection;
+flat in float normal_angle_cutoff;
+flat in float angle_fade_start;
+flat in float alpha_scale;
 
 uniform sampler2D gDepthBuffer;
 uniform sampler2D gNormalBuffer;

--- a/code/def_files/data/effects/decal-v.sdr
+++ b/code/def_files/data/effects/decal-v.sdr
@@ -2,11 +2,11 @@
 in vec4 vertPosition;
 in mat4 vertModelMatrix;
 
-out flat mat4 invModelMatrix;
-out flat vec3 decalDirection;
-out flat float normal_angle_cutoff;
-out flat float angle_fade_start;
-out flat float alpha_scale;
+flat out mat4 invModelMatrix;
+flat out vec3 decalDirection;
+flat out float normal_angle_cutoff;
+flat out float angle_fade_start;
+flat out float alpha_scale;
 
 layout (std140) uniform decalGlobalData {
 	mat4 viewMatrix;


### PR DESCRIPTION
On macOS the new decal shaders (#6813) fail to compile with the following message: "interpolation qualifier 'flat' must precede storage qualifiers".