### PR TITLE
Fix two HUD Config preset issues

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1709,6 +1709,8 @@ void hud_config_color_load(const char *name)
 			HUD_config.set_gauge_color(gauge.first, clr);
 		}
 
+		SCP_vector<std::pair<SCP_string, color>> gauge_color_list;
+
 		// Now read in the color values for the gauges
 		int version = 1;
 		if (optional_string("+VERSION 2")) {
@@ -1732,16 +1734,43 @@ void hud_config_color_load(const char *name)
 				case 1: {
 					SCP_string gauge = gauge_map.get_string_id_from_hcf_id(str);
 					if (!gauge.empty()) {
-						HUD_config.set_gauge_color(gauge, clr);
+						gauge_color_list.emplace_back(gauge, clr);
 					}
 					break;
 				}
 				case 2: {
-					HUD_config.set_gauge_color(str, clr);
+					gauge_color_list.emplace_back(str, clr);
 					break;
 				}
 				default: {
 					throw parse::ParseException("Unknown HUD config version: " + std::to_string(version));
+				}
+			}
+		}
+
+		auto is_builtin = [](auto const& p) {
+			return p.first.rfind("Builtin::", 0) == 0;
+		};
+
+		// Move all builtin:: items to the front, keeping original order
+		std::stable_partition(gauge_color_list.begin(), gauge_color_list.end(), is_builtin);
+
+		// Add the colors to the HUD_config
+		for (const auto& gauge_color : gauge_color_list) {
+			HUD_config.set_gauge_color(gauge_color.first, gauge_color.second);
+
+			// If this is a builtin gauge, we also need to set the color for all other gauges of the same type
+			// Builtin gauges are handled first so that any defintions for custom gauges will override the builtin ones later
+			if (is_builtin(gauge_color)) {
+				int type = gauge_map.get_numeric_id_from_string_id(gauge_color.first);
+
+				for (const auto& this_gauge : HC_gauge_map) {
+					if (this_gauge.first == gauge_color.first) {
+						continue;
+					}
+					if (this_gauge.second->getConfigType() == type) {
+						HUD_config.set_gauge_color(this_gauge.first, gauge_color.second);
+					}
 				}
 			}
 		}

--- a/code/hud/hudconfig.h
+++ b/code/hud/hudconfig.h
@@ -182,13 +182,12 @@ typedef struct HUD_CONFIG_TYPE {
 	}
 
 	// Get the gauge color, the color based on its type, or white if the gauge is not found
-	color get_gauge_color(const SCP_string& gauge_id, bool check_exact_match = true) const
+	color get_gauge_color(const SCP_string& gauge_id) const
 	{
 		auto it = gauge_colors.find(gauge_id);
 
 		// Got a match? Return it
-		// but only if we are using the exact match
-		if (check_exact_match && it != gauge_colors.end()) {
+		if (it != gauge_colors.end()) {
 			return it->second;
 		}
 

--- a/code/pilotfile/plr_hudprefs.cpp
+++ b/code/pilotfile/plr_hudprefs.cpp
@@ -49,7 +49,7 @@ void hud_config_save_player_prefs(const char* callsign)
 		if (HUD_config.is_gauge_shown_in_config(gauge_id)) {
 			clr = pair.second;
 		} else {
-			clr = HUD_config.get_gauge_color(gauge_id, false);
+			clr = HUD_config.get_gauge_color(gauge_id);
 			HUD_config.set_gauge_color(gauge_id, clr);
 		}
 


### PR DESCRIPTION
Fixes 2 issues with gauge color config presets

1. Resolve issue where user colors would be overwritten by default white when loading a player or campaign file. The `use_exact_match` bool was necessary before Custom Gauges could be individually colored and should now be removed.

2. Make sure when loading a HUD Preset file that we set colors for custom gauges of matching types first and then any specific custom gauge colors after that. This makes it so, for example, if Reticle Circle has a defined color in the preset then all custom gauges of type "reticle circle" also get that same color.