### PR TITLE
fix play-sound-from-file with multiple variable-controlled streams

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -14059,17 +14059,19 @@ void sexp_load_music(const char *filename, int type = -1, int sexp_var = -1)
 	if (Sexp_music_handles.empty())
 		Sexp_music_handles.push_back(-1);
 
-	int index = sexp_find_music_handle_index(sexp_var);
-
-	// since we know the default index 0 exists, this means we have a variable without an index
-	if (index < 0)
+	// if a variable is supplied, we'll be creating a new handle to be stored in the variable
+	int index;
+	if (sexp_var >= 0)
 	{
-		index = (int)Sexp_music_handles.size();
+		index = static_cast<int>(Sexp_music_handles.size());
 		Sexp_music_handles.push_back(-1);
 	}
-
-	// if we were previously playing music on this handle, stop it
-	audiostream_close_file(Sexp_music_handles[index]);
+	// otherwise we'll be reusing the default handle, so close anything that's already playing
+	else
+	{
+		index = 0;
+		audiostream_close_file(Sexp_music_handles[index]);
+	}
 
 	// open the stream and save the handle in our list
 	Sexp_music_handles[index] = audiostream_open(filename, type);


### PR DESCRIPTION
Since this sexp was implemented, there has been a bug that prevented multiple variable-controlled audio streams from working.  One default and one variable-controlled stream could coexist, but any subsequent variable-controlled stream would reuse a previous stream's handle if the variable's current value was a valid handle.  This adjusts the code to properly create a new handle for every invocation of the sexp with a variable.

The following cases have been tested and now all work properly:
1. The default handle by itself
2. One variable handle by itself
3. One variable handle with one default handle
4. Multiple variable handles
5. Multiple variable handles with one default handle

Follow-up to #2115.