### PR TITLE
Get, set, browse team colors with Lua

### DIFF
--- a/code/scripting/api/libs/tables.cpp
+++ b/code/scripting/api/libs/tables.cpp
@@ -8,6 +8,7 @@
 #include "scripting/api/objs/intelentry.h"
 #include "scripting/api/objs/shipclass.h"
 #include "scripting/api/objs/shiptype.h"
+#include "scripting/api/objs/team_colors.h"
 #include "scripting/api/objs/weaponclass.h"
 #include "scripting/api/objs/wingformation.h"
 
@@ -338,6 +339,38 @@ ADE_FUNC(__len, l_Tables_WingFormations, nullptr, "Number of wing formations", "
 {
 	// add 1 since "Default" is always first
 	return ade_set_args(L, "i", static_cast<int>(Wing_formations.size()) + 1);
+}
+
+//*****SUBLIBRARY: Tables/TeamColors
+ADE_LIB_DERIV(l_Tables_TeamColors, "TeamColors", nullptr, nullptr, l_Tables);
+
+ADE_INDEXER(l_Tables_TeamColors, "number/string IndexOrName", "Array of team colors", "teamcolor", "Team color handle, or invalid handle if name is invalid")
+{
+	const char* name;
+	if (!ade_get_args(L, "*s", &name))
+		return ade_set_error(L, "o", l_TeamColor.Set(-1));
+
+	// look up by name
+	for (int i = 0; i < static_cast<int>(Team_Names.size()); ++i) {
+		if (!stricmp(Team_Names[i].c_str(), name)) {
+			return ade_set_args(L, "o", l_TeamColor.Set(i));
+		}
+	}
+
+	// look up by number
+	int idx = atoi(name);
+	if (idx > 0) {
+		idx--; // Lua --> C/C++
+	} else {
+		return ade_set_args(L, "o", l_TeamColor.Set(-1));
+	}
+
+	return ade_set_args(L, "o", l_TeamColor.Set(idx));
+}
+
+ADE_FUNC(__len, l_Tables_TeamColors, nullptr, "Number of  team colors", "number", "Number of team colors")
+{
+	return ade_set_args(L, "i", static_cast<int>(Team_Names.size()));
 }
 
 }

--- a/code/scripting/api/objs/ship.cpp
+++ b/code/scripting/api/objs/ship.cpp
@@ -15,6 +15,7 @@
 #include "shipclass.h"
 #include "subsystem.h"
 #include "team.h"
+#include "team_colors.h"
 #include "texture.h"
 #include "vecmath.h"
 #include "weaponclass.h"
@@ -865,6 +866,39 @@ ADE_VIRTVAR(Team, l_Ship, "team", "Ship's team", "team", "Ship team, or invalid 
 	}
 
 	return ade_set_args(L, "o", l_Team.Set(shipp->team));
+}
+
+ADE_VIRTVAR(TeamColor, l_Ship, "teamcolor", "The team color. Note that setting the team color here is instant. If you need a fade, then use the sexp.", "teamcolor", "The team color handle or nil if not set or invalid.")
+{
+	object_h* oh = nullptr;
+	int idx = -1;
+	if (!ade_get_args(L, "o|o", l_Ship.GetPtr(&oh), l_TeamColor.Get(&idx)))
+		return ADE_RETURN_NIL;
+
+	if (!oh->isValid())
+		return ADE_RETURN_NIL;
+
+	ship* shipp = &Ships[oh->objp()->instance];
+
+	//Set team color
+	if (ADE_SETTING_VAR && SCP_vector_inbounds(Team_Names, idx)) {
+		// Verify
+		const auto& it = Team_Colors.find(Team_Names[idx]);
+		if (it == Team_Colors.end()) {
+			mprintf(("Invalid team color specified in mission file for ship %s. Not setting!\n", shipp->ship_name));
+		} else {
+			shipp->team_name = Team_Names[idx];
+		}
+	}
+
+	// look up by name
+	for (int i = 0; i < static_cast<int>(Team_Names.size()); ++i) {
+		if (lcase_equal(Team_Names[i], shipp->team_name)) {
+			return ade_set_args(L, "o", l_TeamColor.Set(i));
+		}
+	}
+
+	return ADE_RETURN_NIL;
 }
 
 ADE_VIRTVAR_DEPRECATED(PersonaIndex, l_Ship, "number", "Persona index", "number", "The index of the persona from messages.tbl, 0 if no persona is set", gameversion::version(25, 0), "Deprecated in favor of Persona")

--- a/code/scripting/api/objs/team_colors.cpp
+++ b/code/scripting/api/objs/team_colors.cpp
@@ -1,0 +1,134 @@
+//
+//
+
+#include "team_colors.h"
+#include "globalincs/alphacolors.h"
+#include "scripting/api/objs/color.h"
+
+namespace scripting {
+namespace api {
+
+//**********HANDLE: TeamColor
+ADE_OBJ(l_TeamColor, int, "teamcolor", "Team color handle");
+
+ADE_FUNC(__tostring, l_TeamColor, nullptr, "Team color name", "string", "Team color name, or an empty string if handle is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_TeamColor.Get(&idx)))
+		return ade_set_error(L, "s", "");
+
+	if (!SCP_vector_inbounds(Team_Names, idx))
+		return ade_set_error(L, "s", "");
+
+	return ade_set_args(L, "s", Team_Names[idx].c_str());
+}
+
+ADE_FUNC(__eq, l_TeamColor, "teamcolor, teamcolor", "Checks if the two team colors are equal", "boolean", "true if equal, false otherwise")
+{
+	int idx1, idx2;
+	if (!ade_get_args(L, "oo", l_TeamColor.Get(&idx1), l_TeamColor.Get(&idx2)))
+		return ade_set_error(L, "b", false);
+
+	if (!SCP_vector_inbounds(Team_Names, idx1))
+		return ade_set_error(L, "b", false);
+
+	if (!SCP_vector_inbounds(Team_Names, idx2))
+		return ade_set_error(L, "b", false);
+
+	return ade_set_args(L, "b", idx1 == idx2);
+}
+
+ADE_VIRTVAR(Name, l_TeamColor, nullptr, "The team color name", "string", "Team color name, or empty string if handle is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_TeamColor.Get(&idx)))
+		return ade_set_error(L, "s", "");
+
+	if (!SCP_vector_inbounds(Team_Names, idx))
+		return ade_set_error(L, "s", "");
+
+	const auto& it = Team_Colors.find(Team_Names[idx]);
+	if (it == Team_Colors.end()) {
+		return ade_set_error(L, "s", "");
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "Setting Team Color Name is not supported");
+	}
+
+	return ade_set_args(L, "s", Team_Names[idx].c_str());
+}
+
+ADE_VIRTVAR(BaseColor, l_TeamColor, nullptr, "Team color base color", "color", "Team color base color, or nil if handle is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_TeamColor.Get(&idx)))
+		return ADE_RETURN_NIL;
+
+	if (!SCP_vector_inbounds(Team_Names, idx))
+		return ADE_RETURN_NIL;
+
+	const auto& it = Team_Colors.find(Team_Names[idx]);
+	if (it == Team_Colors.end()) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "Setting Team Color Base is not supported");
+	}
+
+	const auto& color_values = it->second.base;
+
+	color cur;
+
+	gr_init_alphacolor(&cur, static_cast<int>(color_values.r), static_cast<int>(color_values.g), static_cast<int>(color_values.b), 255);
+
+	return ade_set_args(L, "o", l_Color.Set(cur));
+}
+
+ADE_VIRTVAR(StripeColor, l_TeamColor, nullptr, "Team color stripe color", "color", "Team color stripe color, or nil if handle is invalid")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_TeamColor.Get(&idx)))
+		return ADE_RETURN_NIL;
+
+	if (!SCP_vector_inbounds(Team_Names, idx))
+		return ADE_RETURN_NIL;
+
+	const auto& it = Team_Colors.find(Team_Names[idx]);
+	if (it == Team_Colors.end()) {
+		return ADE_RETURN_NIL;
+	}
+
+	if (ADE_SETTING_VAR) {
+		LuaError(L, "Setting Team Color Stripe is not supported");
+	}
+
+	const auto& color_values = it->second.stripe;
+
+	color cur;
+
+	gr_init_alphacolor(&cur, static_cast<int>(color_values.r), static_cast<int>(color_values.g), static_cast<int>(color_values.b), 255);
+
+	return ade_set_args(L, "o", l_Color.Set(cur));
+}
+
+ADE_FUNC(isValid, l_TeamColor, nullptr, "Detects whether handle is valid", "boolean", "true if valid, false if handle is invalid, nil if a syntax/type error occurs")
+{
+	int idx;
+	if (!ade_get_args(L, "o", l_TeamColor.Get(&idx)))
+		return ADE_RETURN_NIL;
+
+	if (!SCP_vector_inbounds(Team_Names, idx))
+		return ADE_RETURN_FALSE;
+
+	const auto& it = Team_Colors.find(Team_Names[idx]);
+	if (it == Team_Colors.end()) {
+		return ADE_RETURN_FALSE;
+	}
+
+	return ADE_RETURN_TRUE;
+}
+
+}
+}

--- a/code/scripting/api/objs/team_colors.h
+++ b/code/scripting/api/objs/team_colors.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include "scripting/ade.h"
+#include "scripting/ade_api.h"
+
+namespace scripting {
+namespace api {
+
+DECLARE_ADE_OBJ(l_TeamColor, int);
+
+}
+} // namespace scripting

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1499,6 +1499,8 @@ add_file_folder("Scripting\\\\Api\\\\Objs"
 	scripting/api/objs/subsystem.h
 	scripting/api/objs/team.cpp
 	scripting/api/objs/team.h
+	scripting/api/objs/team_colors.cpp
+	scripting/api/objs/team_colors.h
 	scripting/api/objs/techroom.cpp
 	scripting/api/objs/techroom.h
 	scripting/api/objs/texture.cpp


### PR DESCRIPTION
Proper follow-up to #6802 which was a quick and dirty way to get the basic features BtA wanted in 25.0.0. Since the feature freeze still hasn't started and I'm back from 2 weeks of vacation, here's a proper follow-up that fully implements Team Colors in Lua. Browse available colors in `tb.TeamColors` with the following members.

- Name (string)
- BaseColor (color object)
- StripeColor (color object)

ParsedObjects and Ships can get and set the team color (the latter is instant. A FUNC would be needed to allow the fade, but there's already a SEXP for that so I opted to skip it for now).

The render methods now take a team color object rather than a team color string name. Since this has only been in the API for a few days, I'm thinking this is an ok change.