### PR TITLE
Limit the number of threads spawned

### DIFF
--- a/code/utils/threading.cpp
+++ b/code/utils/threading.cpp
@@ -139,7 +139,7 @@ namespace threading {
 			//At least given the current collision-detection threading, 8 cores (if available) seems like a sweetspot, with more cores adding too much overhead.
 			//This could be improved in the future.
 			//This could also be made task-dependant, if stuff like parallelized loading benefits from more cores.
-			num_threads = std::min(get_number_of_physical_cores() - 1, 7UL);
+			num_threads = std::min(get_number_of_physical_cores() - 1, static_cast<size_t>(7));
 		}
 		else {
 			num_threads = Cmdline_multithreading - 1;

--- a/code/utils/threading.cpp
+++ b/code/utils/threading.cpp
@@ -136,7 +136,10 @@ namespace threading {
 
 	void init_task_pool() {
 		if (Cmdline_multithreading == 0) {
-			num_threads = get_number_of_physical_cores() - 1;
+			//At least given the current collision-detection threading, 8 cores (if available) seems like a sweetspot, with more cores adding too much overhead.
+			//This could be improved in the future.
+			//This could also be made task-dependant, if stuff like parallelized loading benefits from more cores.
+			num_threads = std::min(get_number_of_physical_cores() - 1, 7UL);
 		}
 		else {
 			num_threads = Cmdline_multithreading - 1;


### PR DESCRIPTION
Based on my tests with up to 16 threads and informal testing by @MjnMixael using 64 threads, there seems to be a current sweetspot between work sharing and overhead around 8-ish cores.
So limit the autodetected threadcount to 8.
Note that it is still possible to manually specific a larger threadcount. This is intended, both for testing purposes as well as if this assumption might not hold true for all CPU's or architectures.