### PR TITLE
Fix Thread Count Detection on Windows

### DIFF
--- a/code/utils/threading.cpp
+++ b/code/utils/threading.cpp
@@ -68,7 +68,7 @@ namespace threading {
 		SCP_vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> infoBuffer(length / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
 		DWORD error = glpi(infoBuffer.data(), &length);
 
-		if (error != 0)
+		if (error == 0)
 			return get_number_of_physical_cores_fallback();
 
 		size_t num_cores = 0;


### PR DESCRIPTION
Turns out, properly reading the docs helps.
We have to check against the error code being false for an error, and not check it for being non-zero.