### PR TITLE
get proper number of physical cpu cores on macOS

### DIFF
--- a/code/utils/threading.cpp
+++ b/code/utils/threading.cpp
@@ -89,15 +89,19 @@ namespace threading {
 	}
 #elif defined __APPLE__
 	static size_t get_number_of_physical_cores() {
-		int num;
+		int rval = 0;
+		int num = 0;
 		size_t numSize = sizeof(num);
 
 		// apple silicon (performance cores only)
-		if ( !sysctlbyname("hw.perflevel0.physicalcpu", &num, &numSize, nullptr, 0) ) {
-			return num;
-		}
+		rval = sysctlbyname("hw.perflevel0.physicalcpu", &num, &numSize, nullptr, 0);
+
 		// intel
-		else if ( !sysctlbyname("hw.physicalcpu", &num, &numSize, nullptr, 0) ) {
+		if (rval != 0) {
+			rval = sysctlbyname("hw.physicalcpu", &num, &numSize, nullptr, 0);
+		}
+
+		if (rval == 0 && num > 0) {
 			return num;
 		} else {
 			// invalid results, try fallback

--- a/code/utils/threading.cpp
+++ b/code/utils/threading.cpp
@@ -11,6 +11,8 @@
 
 #ifdef WIN32
 #include <windows.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
 #endif
 
 namespace threading {
@@ -83,6 +85,23 @@ namespace threading {
 		}
 		else {
 			return num_cores;
+		}
+	}
+#elif defined __APPLE__
+	static size_t get_number_of_physical_cores() {
+		int num;
+		size_t numSize = sizeof(num);
+
+		// apple silicon (performance cores only)
+		if ( !sysctlbyname("hw.perflevel0.physicalcpu", &num, &numSize, nullptr, 0) ) {
+			return num;
+		}
+		// intel
+		else if ( !sysctlbyname("hw.physicalcpu", &num, &numSize, nullptr, 0) ) {
+			return num;
+		} else {
+			// invalid results, try fallback
+			return get_number_of_physical_cores_fallback();
 		}
 	}
 #elif defined SCP_UNIX


### PR DESCRIPTION
macOS has an easy way to get the physical cpu count so let's use it. Also with Apple Silicon there are performance and efficiency cores so we need to make sure we ignore those low-perf cores when getting the count.