### PR TITLE
Fix AI Targeting of Subsystems

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -179,6 +179,7 @@ namespace AI {
 		Freespace_1_missile_behavior,
 		ETS_uses_power_output,
 		ETS_energy_same_regardless_of_system_presence,
+		Fix_AI_aim_targeting_subsystems,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -713,6 +713,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$ETS energy same regardless of system presence:", AI::Profile_Flags::ETS_energy_same_regardless_of_system_presence);
 
+				set_flag(profile, "$Fix AI aim when targeting subsystems:", AI::Profile_Flags::Fix_AI_aim_targeting_subsystems);
 
 				// end of options ----------------------------------------
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -9024,7 +9024,10 @@ void ai_chase()
 		weapon_info* wip = ai_get_weapon(&shipp->weapons);
 		if (wip) {
 			bool ballistic = !IS_VEC_NULL(&The_mission.gravity) && wip->gravity_const != 0.0f;
-			if (aip->targeted_subsys != NULL && get_shield_pct(En_objp) < HULL_DAMAGE_THRESHOLD_PERCENT) {
+			// retail behavior: if AI targeting a subsystem, and the target has shields lower than 0.25, 
+			// aim straight for the subsystem, instead of leading;
+			// or always lead regardless of shield strength if AI flag is enabled --wookieejedi
+			if ( (aip->targeted_subsys != nullptr && get_shield_pct(En_objp) < 0.25f) && !(The_mission.ai_profile->flags[AI::Profile_Flags::Fix_AI_aim_targeting_subsystems]) ) {
 				Assert(En_objp->type == OBJ_SHIP);
 				vec3d target_pos;
 				get_subsystem_pos(&target_pos, En_objp, aip->targeted_subsys);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -51,8 +51,6 @@ extern vec3d	Original_vec_to_deader;
 
 #define SHIP_GUARDIAN_THRESHOLD_DEFAULT	1	// Goober5000
 
-#define	HULL_DAMAGE_THRESHOLD_PERCENT	0.25f	//	Apply damage to hull, not shield if shield < this
-
 // the #defines below are to avoid round-off errors
 #define WEAPON_RESERVE_THRESHOLD		0.01f	// energy threshold where ship is considered to have no weapon energy system
 #define SUBSYS_MAX_HITS_THRESHOLD		0.01f	// max_hits threshold where subsys is considered to take damage


### PR DESCRIPTION
On current master, and ever since retail, if the AI is targeting a subsystem, and the target has shields lower than 0.25, then the AI aims straight for the subsystem, instead of leading the target. This is usually not that noticeable on retail ships where the larger ships with subsystems do not move quickly, but can become quite noticeable on mods where there are small fast shuttles and the AI becomes rather inept at disabling the engines.

Happy to tune variable and/or table entry names however.

Also took the time to cleanup an old define which had a not useful variable name and comment and was only used in one place not at all related to the comment.