### PR TITLE
Fix inverted piercing impact logic

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7973,7 +7973,7 @@ void maybe_play_conditional_impacts(const std::array<std::optional<ConditionData
 		particleSource->finishCreation();
 	}
 
-	if (impacted_objp != nullptr && !impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)].has_value() && (!valid_conditional_impact && wip->piercing_impact_effect.isValid() && armed_weapon)) {
+	if (impacted_objp != nullptr && (impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)].has_value() || impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SUBSYS)].has_value()) && (!valid_conditional_impact && wip->piercing_impact_effect.isValid() && armed_weapon)) {
 		if ((impacted_objp->type == OBJ_SHIP) || (impacted_objp->type == OBJ_DEBRIS)) {
 
 			int ok_to_draw = 1;


### PR DESCRIPTION
https://github.com/scp-fs2open/fs2open.github.com/pull/6785 introduced a bug that caused piercing impact effects to only happen on shield impacts, not on hull and subsystem impacts as is proper. Simple to fix.