### PR TITLE
Allow mods to set threshold at which shield stops taking damage

### DIFF
--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -390,7 +390,7 @@ void hud_shield_show_mini(const object *objp, int x_force, int y_force, int x_hu
 		else
 			num = i;
 
-		if (objp->shield_quadrant[num] < 0.1f ) {
+		if ( (max_shield > 0.0f) && (objp->shield_quadrant[num]/max_shield < Shield_percent_skips_damage) ) {
 			continue;
 		}
 
@@ -738,12 +738,12 @@ void HudGaugeShield::showShields(const object *objp, ShieldGaugeType mode, bool 
 			break;
 		}
 
-		if (!config) {
+		if ( (!config) && (max_shield > 0.0f) ) {
 			if (!(sip->flags[Ship::Info_Flags::Model_point_shields])) {
-				if (objp->shield_quadrant[Quadrant_xlate[i]] < 0.1f)
+				if (objp->shield_quadrant[Quadrant_xlate[i]]/max_shield < Shield_percent_skips_damage)
 					continue;
 			} else {
-				if (objp->shield_quadrant[i] < 0.1f)
+				if (objp->shield_quadrant[i]/max_shield < Shield_percent_skips_damage)
 					continue;
 			}
 		}
@@ -1085,7 +1085,7 @@ void HudGaugeShieldMini::showMiniShields(const object *objp, bool config)
 		else
 			num = i;
 
-		if (!config && objp->shield_quadrant[num] < 0.1f ) {
+		if ( (!config) && (max_shield > 0.0f) && (objp->shield_quadrant[num]/max_shield < Shield_percent_skips_damage) ) {
 			continue;
 		}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -172,6 +172,7 @@ bool Fix_asteroid_bounding_box_check;
 bool Disable_intro_movie;
 bool Show_locked_status_scramble_missions;
 bool Disable_expensive_turret_target_check;
+float Shield_percent_skips_damage;
 
 
 #ifdef WITH_DISCORD
@@ -1539,6 +1540,16 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Disable_expensive_turret_target_check);
 			}
 
+			if (optional_string("$Threshold at which shield skips damage:")) {
+				float threshold;
+				stuff_float(&threshold);
+				if ((threshold >= 0.0f) && (threshold <= 1.0f)) {
+					Shield_percent_skips_damage = threshold;
+				} else {
+					mprintf(("Game Settings Table: '$Threshold at which shield skips damage' value of %.2f is not between 0 and 1. Using default value of 0.10.\n", threshold));
+				}
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1775,6 +1786,7 @@ void mod_table_reset()
 	Disable_intro_movie = false;
 	Show_locked_status_scramble_missions = false;
 	Disable_expensive_turret_target_check = false;
+	Shield_percent_skips_damage = 0.1f;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1540,13 +1540,14 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Disable_expensive_turret_target_check);
 			}
 
-			if (optional_string("$Threshold at which shield skips damage:")) {
+			if (optional_string("$Threshold below which shield skips damage:")) {
 				float threshold;
 				stuff_float(&threshold);
 				if ((threshold >= 0.0f) && (threshold <= 1.0f)) {
 					Shield_percent_skips_damage = threshold;
 				} else {
-					mprintf(("Game Settings Table: '$Threshold at which shield skips damage' value of %.2f is not between 0 and 1. Using default value of 0.10.\n", threshold));
+					mprintf(("Game Settings Table: '$Threshold below which shield skips damage' value of %.2f is not between 0 and 1. Using default value of 0.10.\n", threshold));
+					Shield_percent_skips_damage = 0.01f;
 				}
 			}
 

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1547,7 +1547,7 @@ void parse_mod_table(const char *filename)
 					Shield_percent_skips_damage = threshold;
 				} else {
 					mprintf(("Game Settings Table: '$Threshold below which shield skips damage' value of %.2f is not between 0 and 1. Using default value of 0.10.\n", threshold));
-					Shield_percent_skips_damage = 0.01f;
+					Shield_percent_skips_damage = 0.1f;
 				}
 			}
 

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -187,6 +187,7 @@ extern bool Fix_asteroid_bounding_box_check;
 extern bool Disable_intro_movie;
 extern bool Show_locked_status_scramble_missions;
 extern bool Disable_expensive_turret_target_check;
+extern float Shield_percent_skips_damage;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -178,7 +178,7 @@ void shield_apply_healing(object* objp, float healing)
 	}
 
 	// if the shields are approximately equal give to all quads equally
-	if (max_shield - min_shield < shield_get_max_strength(objp) * 0.1f) {
+	if (max_shield - min_shield < shield_get_max_strength(objp) * Shield_percent_skips_damage) {
 		for (int i = 0; i < n_quadrants; i++)
 			shield_add_quad(objp, i, healing / n_quadrants);
 	} else { // else give to weakest

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -353,6 +353,16 @@ float shield_get_quad(const object *objp, int quadrant_num)
 	return objp->shield_quadrant[quadrant_num];
 }
 
+float shield_get_quad_percent(const object* objp, int quadrant_num) 
+{
+	float max_quad = shield_get_max_quad(objp);
+	if (max_quad > 0) {
+		return shield_get_quad(objp, quadrant_num) / max_quad;
+	} else {
+		return 0.0f;
+	}
+}
+
 float shield_get_strength(const object *objp)
 {
 	Assert(objp);

--- a/code/object/objectshield.cpp
+++ b/code/object/objectshield.cpp
@@ -356,7 +356,7 @@ float shield_get_quad(const object *objp, int quadrant_num)
 float shield_get_quad_percent(const object* objp, int quadrant_num) 
 {
 	float max_quad = shield_get_max_quad(objp);
-	if (max_quad > 0) {
+	if (max_quad > 0.0f) {
 		return shield_get_quad(objp, quadrant_num) / max_quad;
 	} else {
 		return 0.0f;

--- a/code/object/objectshield.h
+++ b/code/object/objectshield.h
@@ -76,6 +76,15 @@ void shield_add_strength(object *objp, float delta);
 float shield_get_quad(const object *objp, int quadrant_num);
 
 /**
+ * Return the shield strength of the specified quadrant on hit_objp
+ *
+ * @param hit_objp object pointer to ship getting hit
+ * @param quadrant_num shield quadrant that was hit
+ * @return strength of shields in the quadrant that was hit as a percentage, between 0 and 1.0
+ */
+float shield_get_quad_percent(const object* objp, int quadrant_num);
+
+/**
  * @brief Sets the strength (in HP) of a shield quadrant/sector
  *
  * @param[in] quadrant_num Index of the quadrant/sector to set.

--- a/code/object/objectshield.h
+++ b/code/object/objectshield.h
@@ -78,9 +78,9 @@ float shield_get_quad(const object *objp, int quadrant_num);
 /**
  * Return the shield strength of the specified quadrant on hit_objp
  *
- * @param hit_objp object pointer to ship getting hit
- * @param quadrant_num shield quadrant that was hit
- * @return strength of shields in the quadrant that was hit as a percentage, between 0 and 1.0
+ * @param objp object pointer to ship object
+ * @param quadrant_num shield quadrant to check
+ * @return strength of shields in the checked quadrant as a percentage, between 0 and 1.0
  */
 float shield_get_quad_percent(const object* objp, int quadrant_num);
 

--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -912,14 +912,14 @@ int ship_is_shield_up( const object *obj, int quadrant )
 {
 	if ( (quadrant >= 0) && (quadrant < static_cast<int>(obj->shield_quadrant.size())))	{
 		// Just check one quadrant
-		if (shield_get_quad(obj, quadrant) > MAX(2.0f, 0.1f * shield_get_max_quad(obj)))	{
+		if (shield_get_quad(obj, quadrant) > MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(obj))) {
 			return 1;
 		}
 	} else {
 		// Check all quadrants
 		float strength = shield_get_strength(obj);
 
-		if ( strength > MAX(2.0f*4.0f, 0.1f * shield_get_max_strength(obj)) )	{
+		if ( strength > MAX(2.0f*4.0f, Shield_percent_skips_damage * shield_get_max_strength(obj)) )	{
 			return 1;
 		}
 	}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17266,40 +17266,6 @@ const char *ship_subsys_get_canonical_name(const ship_subsys *ss)
 	return ss->system_info->subobj_name;
 }
 
-/**
- * Return the shield strength of the specified quadrant on hit_objp
- *
- * @param hit_objp object pointer to ship getting hit
- * @param quadrant_num shield quadrant that was hit
- * @return strength of shields in the quadrant that was hit as a percentage, between 0 and 1.0
- */
-float ship_quadrant_shield_percent(const object* hit_objp, int quadrant_num)
-{
-	float			max_quadrant;
-
-	// If ship doesn't have shield mesh, then return
-	if ( hit_objp->flags[Object::Object_Flags::No_shields] ) {
-		return 0.0f;
-	}
-
-	// If shields weren't hit, return 0
-	if ( quadrant_num < 0 )
-		return 0.0f;
-
-	max_quadrant = shield_get_max_quad(hit_objp);
-	if ( max_quadrant <= 0 ) {
-		return 0.0f;
-	}
-
-	Assertion(quadrant_num < static_cast<int>(hit_objp->shield_quadrant.size()), "ship_quadrant_shield_percent() called with a quadrant of %d on a ship with " SIZE_T_ARG " quadrants; get a coder!\n", quadrant_num, hit_objp->shield_quadrant.size());
-
-	if(hit_objp->shield_quadrant[quadrant_num] > max_quadrant)
-		mprintf(("Warning: \"%s\" has shield quadrant strength of %f out of %f\n",
-				Ships[hit_objp->instance].ship_name, hit_objp->shield_quadrant[quadrant_num], max_quadrant));
-
-	return hit_objp->shield_quadrant[quadrant_num]/max_quadrant;
-}
-
 // Determine if a ship is threatened by any dumbfire projectiles (laser or missile)
 // input:	sp	=>	pointer to ship that might be threatened
 // exit:		0 =>	no dumbfire threats

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -17273,7 +17273,7 @@ const char *ship_subsys_get_canonical_name(const ship_subsys *ss)
  * @param quadrant_num shield quadrant that was hit
  * @return strength of shields in the quadrant that was hit as a percentage, between 0 and 1.0
  */
-float ship_quadrant_shield_strength(const object *hit_objp, int quadrant_num)
+float ship_quadrant_shield_percent(const object* hit_objp, int quadrant_num)
 {
 	float			max_quadrant;
 
@@ -17291,7 +17291,7 @@ float ship_quadrant_shield_strength(const object *hit_objp, int quadrant_num)
 		return 0.0f;
 	}
 
-	Assertion(quadrant_num < static_cast<int>(hit_objp->shield_quadrant.size()), "ship_quadrant_shield_strength() called with a quadrant of %d on a ship with " SIZE_T_ARG " quadrants; get a coder!\n", quadrant_num, hit_objp->shield_quadrant.size());
+	Assertion(quadrant_num < static_cast<int>(hit_objp->shield_quadrant.size()), "ship_quadrant_shield_percent() called with a quadrant of %d on a ship with " SIZE_T_ARG " quadrants; get a coder!\n", quadrant_num, hit_objp->shield_quadrant.size());
 
 	if(hit_objp->shield_quadrant[quadrant_num] > max_quadrant)
 		mprintf(("Warning: \"%s\" has shield quadrant strength of %f out of %f\n",

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -20715,7 +20715,7 @@ void ArmorType::ParseData()
 			no_content = false;
 		}
 
-		adt.piercing_start_pct = 0.1f;
+		adt.piercing_start_pct = Shield_percent_skips_damage;
 		adt.piercing_type = -1;
 
 		if(optional_string("+Weapon Piercing Effect Start Limit:")) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1868,8 +1868,6 @@ extern int Show_shield_mesh;
 extern int Ship_auto_repair;	// flag to indicate auto-repair of subsystem should occur
 #endif
 
-float ship_quadrant_shield_percent(const object* hit_objp, int quadrant_num);
-
 int ship_dumbfire_threat(ship *sp);
 int ship_lock_threat(ship *sp);
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1868,8 +1868,7 @@ extern int Show_shield_mesh;
 extern int Ship_auto_repair;	// flag to indicate auto-repair of subsystem should occur
 #endif
 
-void ship_subsystem_delete(ship *shipp);
-float ship_quadrant_shield_strength(const object *hit_objp, int quadrant_num);
+float ship_quadrant_shield_percent(const object* hit_objp, int quadrant_num);
 
 int ship_dumbfire_threat(ship *sp);
 int ship_lock_threat(ship *sp);

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2424,9 +2424,9 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 				ImpactCondition(shipp->shield_armor_type_idx),
 				HitType::SHIELD,
 				0.0f,
-				// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last ten percent of a shield doesn't matter
-				MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp))),
-				shield_get_max_quad(ship_objp) - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp)),
+				// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last X percent of a shield doesn't matter
+				MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp))),
+				shield_get_max_quad(ship_objp) - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp)),
 			};
 		} else {
 			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
@@ -2455,9 +2455,9 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 			ImpactCondition(shipp->shield_armor_type_idx),
 			HitType::SHIELD,
 			0.0f,
-			// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last ten percent of a shield doesn't matter
-			MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp))),
-			shield_get_max_quad(ship_objp) - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp)),
+			// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last X percent of a shield doesn't matter
+			MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp))),
+			shield_get_max_quad(ship_objp) - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp)),
 		};
 
 		if ( damage > 0.0f ) {
@@ -2873,9 +2873,9 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, const vec3d *
 						ImpactCondition(ship_p->shield_armor_type_idx),
 						HitType::SHIELD,
 						0.0f,
-						// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last ten percent of a shield doesn't matter
-						MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp))),
-						shield_get_max_quad(ship_objp) - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp)),
+						// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last X percent of a shield doesn't matter
+						MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp))),
+						shield_get_max_quad(ship_objp) - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp)),
 					};
 				} else {
 					impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7367,7 +7367,7 @@ void weapon_hit_do_sound(const object *hit_obj, const weapon_info *wip, const ve
 		float shield_percent;
 
 		if ( hit_obj->type == OBJ_SHIP && quadrant >= 0 ) {
-			shield_percent = ship_quadrant_shield_strength(hit_obj, quadrant);
+			shield_percent = ship_quadrant_shield_percent(hit_obj, quadrant);
 		} else {
 			shield_percent = 0.0f;
 		}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7373,7 +7373,7 @@ void weapon_hit_do_sound(const object *hit_obj, const weapon_info *wip, const ve
 		}
 
 		// play a shield hit if shields are above 10% max in this quadrant
-		if ( shield_str > 0.1f ) {
+		if ( shield_str > Shield_percent_skips_damage ) {
 			// Play a shield impact sound effect
 			if ( !(Use_weapon_class_sounds_for_hits_to_player) && (hit_obj == Player_obj)) {
 				snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIELD_HIT_YOU), hitpos, &Eye_position );

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7328,8 +7328,6 @@ void weapon_play_impact_sound(const weapon_info *wip, const vec3d *hitpos, bool 
  */
 void weapon_hit_do_sound(const object *hit_obj, const weapon_info *wip, const vec3d *hitpos, bool is_armed, int quadrant)
 {
-	float shield_str;
-
 	// If non-missiles (namely lasers) expire without hitting a ship, don't play impact sound
 	if	( wip->subtype != WP_MISSILE ) {		
 		if ( !hit_obj ) {
@@ -7366,14 +7364,16 @@ void weapon_hit_do_sound(const object *hit_obj, const weapon_info *wip, const ve
 
 	if ( timestamp_elapsed(Weapon_impact_timer) ) {
 
+		float shield_percent;
+
 		if ( hit_obj->type == OBJ_SHIP && quadrant >= 0 ) {
-			shield_str = ship_quadrant_shield_strength(hit_obj, quadrant);
+			shield_percent = ship_quadrant_shield_strength(hit_obj, quadrant);
 		} else {
-			shield_str = 0.0f;
+			shield_percent = 0.0f;
 		}
 
-		// play a shield hit if shields are above 10% max in this quadrant
-		if ( shield_str > Shield_percent_skips_damage ) {
+		// play a shield hit if shields are above X% max in this quadrant
+		if ( shield_percent > Shield_percent_skips_damage ) {
 			// Play a shield impact sound effect
 			if ( !(Use_weapon_class_sounds_for_hits_to_player) && (hit_obj == Player_obj)) {
 				snd_play_3d( gamesnd_get_game_sound(GameSounds::SHIELD_HIT_YOU), hitpos, &Eye_position );

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -38,6 +38,7 @@
 #include "network/multiutil.h"
 #include "object/objcollide.h"
 #include "object/objectdock.h"
+#include "object/objectshield.h"
 #include "object/objectsnd.h"
 #include "parse/parsehi.h"
 #include "parse/parselo.h"
@@ -7367,7 +7368,7 @@ void weapon_hit_do_sound(const object *hit_obj, const weapon_info *wip, const ve
 		float shield_percent;
 
 		if ( hit_obj->type == OBJ_SHIP && quadrant >= 0 ) {
-			shield_percent = ship_quadrant_shield_percent(hit_obj, quadrant);
+			shield_percent = shield_get_quad_percent(hit_obj, quadrant);
 		} else {
 			shield_percent = 0.0f;
 		}


### PR DESCRIPTION
FSO logic dictates that shields collisions and any related sound or visuals related to shields are skipped if the shields are under 10%. This is rather unintuitive especially for mods, so this PR creates a game setting value that allows mods to set this value.

Also, this PR fixes a bug where the HUD shield gauge would try and incorporate this feature but did not do it correctly. Specifically, the gauge skips shield segment rendering if the raw shield strength was 0.1 not the percent. Incorrectly using the raw value results in HUD shields being rendered (albeit faintly) even if the damage was skipping the shield and directly damaging the hull. In other words, if the shield segment was 8%, the shield segment would show faintly even the shield is skipping damage.

Tested and works as expected. Also happy to discuss or answer any questions!