### PR TITLE
Handle impacts for obscure code paths

### DIFF
--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -418,7 +418,7 @@ typedef struct {
 // fundamentally similar to do_subobj_hit_stuff, but without many checks inherent to damaging instead of healing
 // most notably this does NOT return "remaining healing" (healing always carries), this is will NOT subtract from hull healing
 
-void do_subobj_heal_stuff(const object* ship_objp, const object* other_obj, const vec3d* hitpos, int submodel_num, float healing)
+std::pair<std::optional<ConditionData>, float> do_subobj_heal_stuff(const object* ship_objp, const object* other_obj, const vec3d* hitpos, int submodel_num, float healing)
 {
 	vec3d			g_subobj_pos;
 	float			healing_left;
@@ -433,6 +433,8 @@ void do_subobj_heal_stuff(const object* ship_objp, const object* other_obj, cons
 	Assertion(other_obj, "do_subobj_heal_stuff wasn't given a healing object! (weapon/beam/shockwave)");
 
 	ship_p = &Ships[ship_objp->instance];
+
+	std::optional<ConditionData> subsys_impact = std::nullopt;
 
 	if (other_obj->type == OBJ_SHOCKWAVE)
 	{
@@ -602,6 +604,16 @@ void do_subobj_heal_stuff(const object* ship_objp, const object* other_obj, cons
 				// Nuke: this will finally factor it in to heal_to_apply and i wont need to factor it in anywhere after this
 				heal_to_apply = Armor_types[subsystem->armor_type_idx].GetDamage(heal_to_apply, dmg_type_idx, 1.0f, other_obj->type == OBJ_BEAM);
 
+			if (j == 0) {
+				subsys_impact = ConditionData {
+					ImpactCondition(subsystem->armor_type_idx),
+					HitType::SUBSYS,
+					heal_to_apply,
+					subsystem->current_hits,
+					subsystem->max_hits,
+				};
+			}
+
 			subsystem->current_hits += heal_to_apply;
 
 			float* agg_hits = &ship_p->subsys_info[subsystem->system_info->type].aggregate_current_hits;
@@ -626,6 +638,7 @@ void do_subobj_heal_stuff(const object* ship_objp, const object* other_obj, cons
 				break;
 		}
 	}
+	return std::make_pair(subsys_impact, healing);
 }
 
 // do_subobj_hit_stuff() is called when a collision is detected between a ship and something
@@ -2361,9 +2374,14 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 
 	MONITOR_INC( ShipHits, 1 );
 
+	std::array<std::optional<ConditionData>, NumHitTypes> impact_data = {};
+
 	//	Don't damage player ship in the process of warping out.
 	if ( Player->control_mode >= PCM_WARPOUT_STAGE2 )	{
 		if ( ship_objp == Player_obj ){
+			if (!global_damage) {
+				maybe_play_conditional_impacts(impact_data, other_obj, ship_objp, true, submodel_num, hitpos, local_hitpos, hit_normal);
+			}
 			return;
 		}
 	}
@@ -2410,10 +2428,12 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 		}
 	}
 
-	std::array<std::optional<ConditionData>, NumHitTypes> impact_data = {};
 
 	// If the ship is invulnerable, do nothing
 	if (ship_objp->flags[Object::Object_Flags::Invulnerable])	{
+		if (!global_damage) {
+			maybe_play_conditional_impacts(impact_data, other_obj, ship_objp, true, submodel_num, hitpos, local_hitpos, hit_normal);
+		}
 		return;
 	}
 
@@ -2705,7 +2725,7 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 	}
 }
 
-static void ship_do_healing(object* ship_objp, const object* other_obj, const vec3d* hitpos, float healing, int submodel_num, int damage_type_idx = -1)
+static void ship_do_healing(object* ship_objp, const object* other_obj, const vec3d* hitpos, float healing, int quadrant, int submodel_num, int damage_type_idx = -1, const vec3d* hit_normal = nullptr, const vec3d* local_hitpos = nullptr)
 {
 	// multiplayer clients dont do healing
 	if (MULTIPLAYER_CLIENT)
@@ -2732,8 +2752,13 @@ static void ship_do_healing(object* ship_objp, const object* other_obj, const ve
 	
 	MONITOR_INC(ShipHits, 1);
 
+	std::array<std::optional<ConditionData>, NumHitTypes> impact_data = {};
+
 	//	Don't heal player ship in the process of warping out.
 	if ((Player->control_mode >= PCM_WARPOUT_STAGE2) && (ship_objp == Player_obj)) {
+		if (!global_damage) {
+			maybe_play_conditional_impacts(impact_data, other_obj, ship_objp, true, submodel_num, hitpos, local_hitpos, hit_normal);
+		}
 		return;
 	}
 
@@ -2749,22 +2774,44 @@ static void ship_do_healing(object* ship_objp, const object* other_obj, const ve
 		return;
 	weapon_info* wip = &Weapon_info[wip_index];
 
+	float shield_health;
+	if (quadrant >= 0) {
+		shield_health = MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp)));
+	} else {
+		//if we haven't hit a shield, assume the shield is fully depleted, because we have no way of knowing what the relevant quadrant would be
+		shield_health = 0.f;
+	}
+
 	// handle shield healing
 	if (!(ship_objp->flags[Object::Object_Flags::No_shields])) {
+		auto shield_impact = ConditionData {
+			ImpactCondition(shipp->shield_armor_type_idx),
+			HitType::SHIELD,
+			0.0f,
+			shield_health,
+			shield_get_max_quad(ship_objp) - MAX(2.0f, 0.1f * shield_get_max_quad(ship_objp)),
+		};
+
 		float shield_healing = healing * wip->shield_factor;
 
 		if (shield_healing > 0.0f) {
 			if (shipp->shield_armor_type_idx != -1)
 				shield_healing = Armor_types[shipp->shield_armor_type_idx].GetDamage(shield_healing, damage_type_idx, 1.0f, other_obj_is_beam);
 
+			shield_impact.damage = shield_healing;
 			shield_apply_healing(ship_objp, shield_healing);
 		}
+		impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)] = shield_impact;
 	}
 
 	// now for subsystems and hull
 	if ((healing > 0.0f)) {
 
-		do_subobj_heal_stuff(ship_objp, other_obj, hitpos, submodel_num, healing);
+		auto healing_pair = do_subobj_heal_stuff(ship_objp, other_obj, hitpos, submodel_num, healing);
+
+		healing = healing_pair.second;
+
+		impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SUBSYS)] = healing_pair.first;
 
 		//Do armor stuff
 		if (shipp->armor_type_idx != -1)
@@ -2775,10 +2822,20 @@ static void ship_do_healing(object* ship_objp, const object* other_obj, const ve
 
 		healing *= wip->armor_factor;
 
+		impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
+			ImpactCondition(shipp->armor_type_idx),
+			HitType::HULL,
+			healing,
+			ship_objp->hull_strength,
+			shipp->ship_max_hull_strength,
+		};
+
 		ship_objp->hull_strength += healing;
 		if (ship_objp->hull_strength > shipp->ship_max_hull_strength)
 			ship_objp->hull_strength = shipp->ship_max_hull_strength;
 	}
+
+	maybe_play_conditional_impacts(impact_data, other_obj, ship_objp, true, submodel_num, hitpos, local_hitpos, hit_normal);
 
 	// fix up the ship's sparks :)
 	// turn off a random spark, if its a beam, do this on average twice a second
@@ -2942,7 +2999,7 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, const vec3d *
 
 	global_damage = false;
 	if (wip_index >= 0 && Weapon_info[wip_index].wi_flags[Weapon::Info_Flags::Heals]) {
-		ship_do_healing(ship_objp, other_obj, hitpos, damage, submodel_num);
+		ship_do_healing(ship_objp, other_obj, hitpos, damage, quadrant, submodel_num, -1, hit_normal, local_hitpos);
 		create_sparks = false;
 	} else {
 		ship_do_damage(ship_objp, other_obj, hitpos, damage, quadrant, submodel_num, damage_type_idx, false, hit_dot, hit_normal, local_hitpos);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7949,7 +7949,7 @@ void maybe_play_conditional_impacts(const std::array<std::optional<ConditionData
 	}
 	
 	if (!valid_conditional_impact && wip->impact_weapon_expl_effect.isValid() && armed_weapon) {
-              		auto particleSource = particle::ParticleManager::get()->createSource(wip->impact_weapon_expl_effect);
+    	auto particleSource = particle::ParticleManager::get()->createSource(wip->impact_weapon_expl_effect);
 
 		particleSource->setHost(weapon_hit_make_effect_host(weapon_objp, impacted_objp, submodel, hitpos, local_hitpos));
 		particleSource->setTriggerRadius(weapon_objp->radius * radius_mult);
@@ -7973,7 +7973,7 @@ void maybe_play_conditional_impacts(const std::array<std::optional<ConditionData
 		particleSource->finishCreation();
 	}
 
-	if (impacted_objp != nullptr && impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)].has_value() && (!valid_conditional_impact && wip->piercing_impact_effect.isValid() && armed_weapon)) {
+	if (impacted_objp != nullptr && !impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::SHIELD)].has_value() && (!valid_conditional_impact && wip->piercing_impact_effect.isValid() && armed_weapon)) {
 		if ((impacted_objp->type == OBJ_SHIP) || (impacted_objp->type == OBJ_DEBRIS)) {
 
 			int ok_to_draw = 1;


### PR DESCRIPTION
More #6785 followup. I realized that impacts wouldn't be played in the case of healing weapons (and a couple other edge cases), where they would have been before, so I fixed that.