### PR TITLE
Fix Edge-case with `$Preload briefing icon models:`

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6661,7 +6661,8 @@ bool post_process_mission(mission *pm)
 		for (i = 0; i < Briefings[team].num_stages; i++) {
 			const auto &stage = br[i];
 			for (int j = 0; j < stage.num_icons; j++) {
-				stage.icons[j].modelnum = model_load(Ship_info[stage.icons[j].ship_class].pof_file);
+				ship_info *sip = &Ship_info[stage.icons[j].ship_class];
+				stage.icons[j].modelnum = model_load(sip->pof_file, sip);
 			}
 		}
 	}


### PR DESCRIPTION
Found a very interesting edge case bug with `$Preload briefing icon models:.`

Situation: Mission 1 has a briefing which has a ship class A as the class (and thus loads the model), but the ship class A is not actually in that mission so no subsystems are loaded. Then in mission 2, the ship class A is actually in the mission but FSO tries to reuse the slot that was loaded, but realizes no subsystems were loaded and makes an error message. I that is because the preload code for the briefing icons on `missionparse.cpp` line 6664 just calls `model_load` but does not specify the subsystem argument.

 I've also attached a retail mod reproducible campaign (2 missions, first is 5 seconds long). When the second mission loads the incorrect subsystem warning appears. [data.zip](https://github.com/user-attachments/files/21334899/data.zip)

This PR properly loads the subsystems and fixes the bug. Tested and works as expected.