### PR TITLE
Cleanup of Shield Hitpoint Threshold

### DIFF
--- a/code/ship/shield.cpp
+++ b/code/ship/shield.cpp
@@ -904,26 +904,37 @@ void create_shield_explosion_all(object *objp)
 }
 
 /**
+ * Returns the lowest threshold of shield hitpoints that triggers a shield hit
+ *
+ * @return If all_quadrants is true, looks at entire shield, otherwise just one quadrant
+ */
+float ship_shield_hitpoint_threshold(const object* obj, bool all_quadrants = false) 
+{
+	if (all_quadrants) {
+		// All quadrants
+		float num_quads = static_cast<float>(obj->shield_quadrant.size());
+		return MAX(2.0f * num_quads, Shield_percent_skips_damage * shield_get_max_strength(obj));
+	} else {
+		// Just one quadrant
+		return MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(obj));
+	}
+}
+
+/**
  * Returns true if the shield presents any opposition to something trying to force through it.
  *
  * @return If quadrant is -1, looks at entire shield, otherwise just one quadrant
  */
-int ship_is_shield_up( const object *obj, int quadrant )
+bool ship_is_shield_up(const object *obj, int quadrant)
 {
 	if ( (quadrant >= 0) && (quadrant < static_cast<int>(obj->shield_quadrant.size())))	{
 		// Just check one quadrant
-		if (shield_get_quad(obj, quadrant) > MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(obj))) {
-			return 1;
-		}
+		return ( shield_get_quad(obj, quadrant) > ship_shield_hitpoint_threshold(obj, false) );
 	} else {
 		// Check all quadrants
-		float strength = shield_get_strength(obj);
-
-		if ( strength > MAX(2.0f*4.0f, Shield_percent_skips_damage * shield_get_max_strength(obj)) )	{
-			return 1;
-		}
+		return ( shield_get_strength(obj) > ship_shield_hitpoint_threshold(obj, true) );
 	}
-	return 0;	// no shield strength
+	return false;	// no shield strength
 }
 
 //	return quadrant containing hit_pnt.

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1771,11 +1771,8 @@ extern void add_shield_point_multi(int objnum, int tri_num, vec3d *hit_pos);
 extern void shield_point_multi_setup();
 extern void shield_hit_close();
 
-// Returns true if the shield presents any opposition to something 
-// trying to force through it.
-// If quadrant is -1, looks at entire shield, otherwise
-// just one quadrant
-int ship_is_shield_up( const object *obj, int quadrant );
+float ship_shield_hitpoint_threshold(const object* obj, bool all_quadrants = false);
+bool ship_is_shield_up(const object *obj, int quadrant);
 
 //=================================================
 void ship_model_replicate_submodels(object *objp);

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -2425,8 +2425,8 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 				HitType::SHIELD,
 				0.0f,
 				// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last X percent of a shield doesn't matter
-				MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp))),
-				shield_get_max_quad(ship_objp) - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp)),
+				MAX(0.0f, ship_objp->shield_quadrant[quadrant] - ship_shield_hitpoint_threshold(ship_objp)),
+				shield_get_max_quad(ship_objp) - ship_shield_hitpoint_threshold(ship_objp)),
 			};
 		} else {
 			impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {
@@ -2458,8 +2458,8 @@ static void ship_do_damage(object *ship_objp, object *other_obj, const vec3d *hi
 			HitType::SHIELD,
 			0.0f,
 			// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last X percent of a shield doesn't matter
-			MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp))),
-			shield_get_max_quad(ship_objp) - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp)),
+			MAX(0.0f, ship_objp->shield_quadrant[quadrant] - ship_shield_hitpoint_threshold(ship_objp)),
+			shield_get_max_quad(ship_objp) - ship_shield_hitpoint_threshold(ship_objp)),
 		};
 
 		if ( damage > 0.0f ) {
@@ -2878,8 +2878,8 @@ void ship_apply_local_damage(object *ship_objp, object *other_obj, const vec3d *
 						HitType::SHIELD,
 						0.0f,
 						// we have to do this annoying thing where we reduce the shield health a bit because it turns out the last X percent of a shield doesn't matter
-						MAX(0.0f, ship_objp->shield_quadrant[quadrant] - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp))),
-						shield_get_max_quad(ship_objp) - MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp)),
+						MAX(0.0f, ship_objp->shield_quadrant[quadrant] - ship_shield_hitpoint_threshold(ship_objp)),
+						shield_get_max_quad(ship_objp) - ship_shield_hitpoint_threshold(ship_objp)),
 					};
 				} else {
 					impact_data[static_cast<std::underlying_type_t<HitType>>(HitType::HULL)] = ConditionData {


### PR DESCRIPTION
Overall cleanup that does a few things:

1) Changes `ship_is_shield_up` from integer to bool.

2) `ship_is_shield_up` was only ever called to look at one quadrant, never for all quadrants, so took the opportunity to update the 'all-quadrant' block to account for ships with a non-standard number of shield quadrants.

3) ` MAX(2.0f, Shield_percent_skips_damage * shield_get_max_quad(ship_objp)` was used many times throughout the code (and will be used at least 2 more times with #6848), so simply consolidated all of those uses into a new function called `ship_shield_hitpoint_threshold`. Happy to edit the name however.

4) Removed un-needed redundant comments from `ship_is_shield_up` definition in `ship.h` since those comments were already present in the actual function within `shield.cpp`, and all the other functions used comments in that file instead.

Again happy to tune or edit with any other choices.