### PR TITLE
Remove rocket ani assertion

### DIFF
--- a/code/scpui/RocketRenderingInterface.cpp
+++ b/code/scpui/RocketRenderingInterface.cpp
@@ -335,7 +335,9 @@ int RocketRenderingInterface::getBitmapNum(Rocket::Core::TextureHandle handle)
 void RocketRenderingInterface::advanceAnimation(Rocket::Core::TextureHandle handle, float advanceTime)
 {
 	Assertion(handle != 0, "Invalid handle for setAnimationFrame");
-	Assertion(get_texture(handle)->is_animation, "Tried to use advanceAnimation with a non-animation!");
+	if (!get_texture(handle)->is_animation) {
+		return;
+	}
 
 	auto tex = get_texture(handle);
 


### PR DESCRIPTION
Downgrade this assertion to an early return. All this function does is advance the frame. If this isn't an animation there's no need to throw up roadblocks here. Simply don't try to advance the frame.

Allows element types "ani" to work with both static images and animations simultaneously which is important because we don't have a way to distinguish between png and apng since we don't work with 4 char extensions fundamentally in cfile.

Fixes an issue in SCPUI for Event Horizon.