### PR TITLE
Fix Volumetric Nebula Bugs and Add Smoothing

### DIFF
--- a/code/def_files/data/effects/volumetric-f.sdr
+++ b/code/def_files/data/effects/volumetric-f.sdr
@@ -100,8 +100,6 @@ void main()
 		vec3 sampleposition = position / nebSize + 0.5;
 		vec4 volume_sample = textureGrad(volume_tex, sampleposition, gradX, gradY);
 
-		float stepsize_current = min(max(stepsize, volume_sample.x * udfScale), mintMax - stept);
-
 #ifdef DO_EDGE_SMOOTHING
 		//Average 3D texel with texels on corner, in an attempt to reduce jagged edges.
 		float stepcolor_alpha = volume_sample.a;
@@ -120,6 +118,8 @@ void main()
 #else
 		float stepcolor_alpha = volume_sample.a;
 #endif
+
+		float stepsize_current = min(max(stepsize, step(stepcolor_alpha, 0.01) * volume_sample.x * udfScale), mintMax - stept);
 
 		float stepalpha = -(pow(alphalim, 1.0 / (opacitydistance / stepsize_current)) - 1.0f) * stepcolor_alpha;
 		//All the following computations are just required if we have a stepcoloralpha that is non-zero.
@@ -151,7 +151,7 @@ void main()
 			//Emissive
 			cumnebdist += stepcolor_alpha * stepsize_current;
 			vec3 emissive_lod = textureLod(emissive, fragTexCoord.xy, clamp(cumnebdist * emissiveSpreadFactor, 0, float(textureQueryLevels(emissive) - 1))).rgb;
-			vec3 stepcolor_emissive = emissive_lod.rgb * pow(alphalim, 1.0 / (opacitydistance / ((depth - stept) * emissiveFalloff + 0.01))) * emissiveIntensity;
+			vec3 stepcolor_emissive = clamp(emissive_lod.rgb * pow(alphalim, 1.0 / (opacitydistance / ((depth - stept) * emissiveFalloff + 0.01))) * emissiveIntensity, 0, 1);
 
 			//Step finish
 			vec3 stepcolor = clamp(stepcolor_diffuse + stepcolor_emissive, 0, 1);
@@ -165,7 +165,5 @@ void main()
 			break;
 	}
 
-	cumcolor += cumOMAlpha * color_in.rgb;
-
-	fragOut0 = vec4(cumcolor, 1);
+	fragOut0 = vec4(cumOMAlpha * color_in.rgb + ((1.0 - cumOMAlpha) * cumcolor), 1);
 }

--- a/code/nebula/volumetrics.cpp
+++ b/code/nebula/volumetrics.cpp
@@ -354,15 +354,15 @@ void volumetric_nebula::renderVolumeBitmap() {
 
 	//Sample the nebula values from the binary cubegrid.
 	volumeBitmapData = make_unique<ubyte[]>(n * n * n * 4);
-	int oversamplingCount = (1 << (oversampling - 1)) + 1;
-	float oversamplingDivisor = 255.1f / static_cast<float>(oversamplingCount);
+	int oversamplingCount = (1 << (oversampling - 1));
+	float oversamplingDivisor = 255.1f / (static_cast<float>(oversamplingCount) * static_cast<float>(oversamplingCount) * static_cast<float>(oversamplingCount));
 	for (int x = 0; x < n; x++) {
 		for (int y = 0; y < n; y++) {
 			for (int z = 0; z < n; z++) {
 				int sum = 0;
-				for (int sx = x * oversampling; sx <= (x + 1) * oversampling; sx++) {
-					for (int sy = y * oversampling; sy <= (y + 1) * oversampling; sy++) {
-						for (int sz = z * oversampling; sz <= (z + 1) * oversampling; sz++) {
+				for (int sx = x * oversamplingCount; sx < (x + 1) * oversamplingCount; sx++) {
+					for (int sy = y * oversamplingCount; sy < (y + 1) * oversamplingCount; sy++) {
+						for (int sz = z * oversamplingCount; sz < (z + 1) * oversamplingCount; sz++) {
 							if (volumeSampleCache[sx * nSample * nSample + sy * nSample + sz])
 								sum++;
 						}

--- a/code/nebula/volumetrics.h
+++ b/code/nebula/volumetrics.h
@@ -35,7 +35,7 @@ class volumetric_nebula {
 	//Oversampling of 3D-Texture. Will quadruple loading computation time for each increment, but improves banding especially at lower resolutions. 1 - 3. Mostly Loading time cost.
 	int oversampling = 2;
 	//How much the edge of the POF should be smoothed to be less hard
-	int smoothing = 1;
+	float smoothing = 0.f;
 	//Resolution of Noise 3D-Texture as 2^n. 5 - 8 recommended. Mostly VRAM cost
 	int noiseResolution = 5;
 
@@ -96,6 +96,8 @@ public:
 	const vec3d& getPos() const;
 	const vec3d& getSize() const;
 	const std::tuple<float, float, float>& getNebulaColor() const;
+
+	int getVolumeBitmapSmoothingSteps() const;
 
 	bool getEdgeSmoothing() const;
 	int getSteps() const;

--- a/code/nebula/volumetrics.h
+++ b/code/nebula/volumetrics.h
@@ -34,6 +34,8 @@ class volumetric_nebula {
 	int resolution = 6;
 	//Oversampling of 3D-Texture. Will quadruple loading computation time for each increment, but improves banding especially at lower resolutions. 1 - 3. Mostly Loading time cost.
 	int oversampling = 2;
+	//How much the edge of the POF should be smoothed to be less hard
+	int smoothing = 1;
 	//Resolution of Noise 3D-Texture as 2^n. 5 - 8 recommended. Mostly VRAM cost
 	int noiseResolution = 5;
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -2794,6 +2794,7 @@ int CFred_mission_save::save_mission_info()
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Steps:", 1, ";;FSO 23.1.0;;", 15, " %d", The_mission.volumetrics->steps);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Resolution:", 1, ";;FSO 23.1.0;;", 6, " %d", The_mission.volumetrics->resolution);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Oversampling:", 1, ";;FSO 23.1.0;;", 2, " %d", The_mission.volumetrics->oversampling);
+			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Smoothing:", 1, ";;FSO 25.0.0;;", 0.f, " %f", The_mission.volumetrics->smoothing);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT_F("+Heyney Greenstein Coefficient:", 1, ";;FSO 23.1.0;;", 0.2f, " %f", The_mission.volumetrics->henyeyGreensteinCoeff);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT_F("+Sun Falloff Factor:", 1, ";;FSO 23.1.0;;", 1.0f, " %f", The_mission.volumetrics->globalLightDistanceFactor);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Sun Steps:", 1, ";;FSO 23.1.0;;", 6, " %d", The_mission.volumetrics->globalLightSteps);
@@ -2831,6 +2832,7 @@ int CFred_mission_save::save_mission_info()
 			bypass_comment(";;FSO 23.1.0;; +Steps:");
 			bypass_comment(";;FSO 23.1.0;; +Resolution:");
 			bypass_comment(";;FSO 23.1.0;; +Oversampling:");
+			bypass_comment(";;FSO 25.0.0;; +Smoothing:");
 			bypass_comment(";;FSO 23.1.0;; +Heyney Greenstein Coefficient:");
 			bypass_comment(";;FSO 23.1.0;; +Sun Falloff Factor:");
 			bypass_comment(";;FSO 23.1.0;; +Sun Steps:");

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -2684,6 +2684,7 @@ int CFred_mission_save::save_mission_info()
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Steps:", 1, ";;FSO 23.1.0;;", 15, " %d", The_mission.volumetrics->steps);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Resolution:", 1, ";;FSO 23.1.0;;", 6, " %d", The_mission.volumetrics->resolution);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Oversampling:", 1, ";;FSO 23.1.0;;", 2, " %d", The_mission.volumetrics->oversampling);
+			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Smoothing:", 1, ";;FSO 25.0.0;;", 0.f, " %f", The_mission.volumetrics->smoothing);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT_F("+Heyney Greenstein Coefficient:", 1, ";;FSO 23.1.0;;", 0.2f, " %f", The_mission.volumetrics->henyeyGreensteinCoeff);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT_F("+Sun Falloff Factor:", 1, ";;FSO 23.1.0;;", 1.0f, " %f", The_mission.volumetrics->globalLightDistanceFactor);
 			FRED_ENSURE_PROPERTY_VERSION_WITH_DEFAULT("+Sun Steps:", 1, ";;FSO 23.1.0;;", 6, " %d", The_mission.volumetrics->globalLightSteps);
@@ -2721,6 +2722,7 @@ int CFred_mission_save::save_mission_info()
 			bypass_comment(";;FSO 23.1.0;; +Steps:");
 			bypass_comment(";;FSO 23.1.0;; +Resolution:");
 			bypass_comment(";;FSO 23.1.0;; +Oversampling:");
+			bypass_comment(";;FSO 25.0.0;; +Smoothing:");
 			bypass_comment(";;FSO 23.1.0;; +Heyney Greenstein Coefficient:");
 			bypass_comment(";;FSO 23.1.0;; +Sun Falloff Factor:");
 			bypass_comment(";;FSO 23.1.0;; +Sun Steps:");


### PR DESCRIPTION
This fixes two bugs in volumetrics:
1. Sometimes, volumetric nebulae would suddenly darken a lot when viewed against the sun. This was due to numerical imprecision in emissive handling. Clamping the emissive inputs from 0 to 1 fixes this
2. Oversampling was calculating its indices and divisors incorrectly, causing two resulting symptoms. For one, the nebula's edge was less properly smoothed and more artificially noisy, causing a slightly blocky appearance. Additionally, it would cause the volumetrics UDF to be incorrect within the nebula. This isn't a huge issue in and of itself, but would cause problems if anyone tries to rely on it in the future.

Furthermore, if I'm already touching the oversampling logic, I can also add index-shift logic that allows for smoothing the volume texture rendered from the POF, which allows to have volumetric nebula with less hard edges.

To illustrate this, three screenshots.

1. Old / Broken Behaviour:
<img width="1026" height="780" alt="Screenshot_20250722_151958" src="https://github.com/user-attachments/assets/ecade49d-9359-46b6-af8f-8a13381840a7" />
2. New Behaviour:
<img width="1026" height="780" alt="Screenshot_20250722_151554" src="https://github.com/user-attachments/assets/50fef750-4338-4c10-ac24-97c3213d67e7" />
3. Smoothing set to 1/16th:
<img width="1026" height="780" alt="Screenshot_20250722_151337" src="https://github.com/user-attachments/assets/d2096ee7-7004-45f8-928e-101aced19365" />


While I have added missionsave code for the smoothing property, I currently do not have a machine with VS installed or a compiler setup that would be able to build or test FRED, as such, the new property cannot yet be set through the GUI, but it should persist if added in a text editor.