### PR TITLE
Fix odd-looking hull impacts spawning when the shield is hit

### DIFF
--- a/code/ship/shiphit.h
+++ b/code/ship/shiphit.h
@@ -35,7 +35,7 @@ constexpr float DEATHROLL_ROTVEL_CAP = 6.3f;    // maximum added deathroll rotve
 // function to destroy a subsystem.  Called internally and from multiplayer messaging code
 extern void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d *hitpos, bool no_explosion = false );
 
-std::pair<std::optional<ConditionData>, float> do_subobj_hit_stuff(object *ship_obj, const object *other_obj, const vec3d *hitpos, int submodel_num, float damage, bool *hull_should_apply_armor, float hit_dot = 1.f);
+std::pair<std::optional<ConditionData>, float> do_subobj_hit_stuff(object *ship_obj, const object *other_obj, const vec3d *hitpos, int submodel_num, float damage, bool *hull_should_apply_armor, float hit_dot = 1.f, bool shield_hit = false);
 
 // Goober5000
 // (it might be possible to make `target` const, but that would set off another const-cascade)


### PR DESCRIPTION
If a ship's shield is hit with more than enough damage to deplete it completely, the remaining damage will be sent to the hull. This triggers hull conditional impacts, which then proceed to spawn at the location of the shield impact and potentially look very strange, if they were designed specifically for hull impacts. Previously, this would have been very rare, because the 10% shield skip percentage meant that a shot hitting the shield and doing overkill damage would have been difficult. However, setting the skip percentage to 0 via #6847, as FotG has recently done, reveals the issue dramatically, as shields on certain ships begin regenerating immediately after depletion and therefore most hits are against shields with very little health.

To fix this, we simply make sure not to pass in conditional impact data for hull or subsystems if we know the hit is a shield hit.