### PR TITLE
Fix 'show-ship` not working

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8185,7 +8185,7 @@ void ship_render_player_ship(object* objp, const vec3d* cam_offset, const matrix
 	const bool renderShipModel = ( 
 		sip->flags[Ship::Info_Flags::Show_ship_model])
 		&& (!Show_ship_only_if_cockpits_enabled || Cockpit_active)
-		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK));
+		&& (!Viewer_mode || (Viewer_mode & VM_PADLOCK_ANY) || (Viewer_mode & VM_OTHER_SHIP) || (Viewer_mode & VM_TRACK) || !(Viewer_mode & VM_EXTERNAL));
 	Cockpit_active = renderCockpitModel;
 
 	//Nothing to do


### PR DESCRIPTION
Small one-line fix that follows up #6849. That PR removed the `!(Viewer_mode & VM_EXTERNAL))` check within a section of `ship_render_player_ship` to optimize insignia rendering, but turns out that check is needed to ensure `show-ship` properly works. This PR restores that check to fix this bug, and ideally the thoughts about slightly optimizing insignias can be considered later.

Tested and works as expected.