### PR TITLE
Fix for single segment trails

### DIFF
--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -159,6 +159,7 @@ void trail_render( trail * trailp )
 
 		float speed = vm_vec_mag(&trailp->vel[front]);
 
+		float total_len = speed * ti->max_life;
 		float f_alpha, b_alpha, f_width, b_width;
 
 		float t_front = trailp->val[front] - trailp->val[back];
@@ -185,9 +186,7 @@ void trail_render( trail * trailp )
 		verts[2].world = bbot;
 		verts[3].world = btop;
 
-		float total_len = speed * ti->max_life;
 		float uv_scale = (total_len / speed / (i2fl(ti->spew_duration) / MILLISECONDS_PER_SECOND)) / ti->texture_stretch;
-		uv_scale *= 0.5;
 
 		verts[0].texture_position.u = trailp->val[front] * uv_scale;
 		verts[1].texture_position.u = trailp->val[front] * uv_scale;

--- a/code/weapon/trails.cpp
+++ b/code/weapon/trails.cpp
@@ -161,26 +161,13 @@ void trail_render( trail * trailp )
 
 		float f_alpha, b_alpha, f_width, b_width;
 
-		float t = trailp->val[front] - trailp->val[back];
+		float t_front = trailp->val[front] - trailp->val[back];
+		float t_back = MAX(0.0f, -trailp->val[back]);
 
-		if (trailp->object_died) {
-			if (trailp->val[0] < 0.0f) {
-				f_alpha = t * (ti->a_start - ti->a_end) + ti->a_end;
-				b_alpha = -trailp->val[back] * (ti->a_start - ti->a_end) + ti->a_end;
-				f_width = t * (ti->w_start - ti->w_end) + ti->w_end;
-				b_width = -trailp->val[back] * (ti->w_start - ti->w_end) + ti->w_end;
-			} else {
-				f_alpha = t * (ti->a_start - ti->a_end) + ti->a_end;
-				b_alpha = ti->a_end;
-				f_width = t * (ti->w_start - ti->w_end) + ti->w_end;
-				b_width = ti->w_end;
-			}
-		} else {
-			f_alpha = ti->a_start;
-			b_alpha = -trailp->val[back] * (ti->a_start - ti->a_end) + ti->a_end;
-			f_width = ti->w_start;
-			b_width = -trailp->val[back] * (ti->w_start - ti->w_end) + ti->w_end;
-		}
+		f_alpha = t_front * (ti->a_start - ti->a_end) + ti->a_end;
+		b_alpha = t_back * (ti->a_start - ti->a_end) + ti->a_end;
+		f_width = t_front * (ti->w_start - ti->w_end) + ti->w_end;
+		b_width = t_back * (ti->w_start - ti->w_end) + ti->w_end;
 
 		vec3d trail_direction, ftop, fbot, btop, bbot;
 		vm_vec_normalized_dir(&trail_direction, &trailp->pos[back], &trailp->pos[front]);


### PR DESCRIPTION
Handles a previously unhandled case where a single segment trail could be interrupted on both ends at once, not yet finished 'unfurling' from being fired, and also the trail object has died. The math here is a little confusing perhaps... but this involves having the back end's `val` start at -1.0 and start incrementing right away, rather than waiting at 0.0 to finish unfurling, which gives enough information to reason about the correct alpha, width, uv etc in any state.