### PR TITLE
Prevent lua from Garbage Collecting possibly-stale Subframes

### DIFF
--- a/code/scripting/api/objs/texture.h
+++ b/code/scripting/api/objs/texture.h
@@ -9,9 +9,10 @@ namespace api {
 
 struct texture_h {
 	int handle = -1;
+	int parent_handle = -1;
 
 	texture_h();
-	explicit texture_h(int bm, bool refcount = true);
+	explicit texture_h(int bm, bool refcount = true, int parent_handle = -1);
 
 	~texture_h();
 


### PR DESCRIPTION
The bug that was observed before this fix abbreviates to roughly the following sequence of events.

A lua variable is held, containing an animated texture.
A `gr.drawImage` call is used to draw a specific frame of that animation by indexing into the above variable.
This leaves the temporary returned from indexing with a newer last-used timestamp than the actual animation-holding variable.
It is now possible that the animation-holding variable is unloaded or garbage collected. This frees the according slots in bmpman, allowing them to be filled with other data.
At the same time, the temporary is not yet garbage collected. Once that happens (e.g. in the forced garbage collection pass during mission load) the subframe temporary will try to deallocate itself in bmpman. But now, that slot is already used for a different, unrelated texture (which, in the mission load case, has a good chance of being the mission loading bar animation), which'll be deleted incorrectly, causing problems down the road where other parts of the code now hold a bmpman handle that's no longer valid.

The fix to this is that lua textures which are not first-class citizens in bmpman, but are rather just subtextures of a parent texture should not try to alloc / dealloc themselves, but their parent container texture. Not only does this fix incorrect deallocations, but it also prevents a texture that's held in lua only to be deallocated, even if we still have references to some frames of this texture.