### PR TITLE
Fix screenToBlob with Regards to Current RTT State

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -337,10 +337,21 @@ SCP_string gr_opengl_blob_screen()
 	GLuint pbo = 0;
 
 	GL_state.PushFramebufferState();
-	GL_state.BindFrameBuffer(Cmdline_window_res ? Back_framebuffer : 0, GL_FRAMEBUFFER);
+
+	GLuint source_fbo = 0;
+
+	GLuint render_target = opengl_get_rtt_framebuffer();
+	if (render_target != 0) {
+		source_fbo = render_target;
+	}
+	else if (Cmdline_window_res) {
+		source_fbo = Back_framebuffer;
+	}
+
+	GL_state.BindFrameBuffer(source_fbo, GL_FRAMEBUFFER);
 
 	//Reading from the front buffer here seems to no longer work correctly; that just reads back all zeros
-	glReadBuffer(Cmdline_window_res ? GL_COLOR_ATTACHMENT0 : GL_FRONT);
+	glReadBuffer(source_fbo != 0 ? GL_COLOR_ATTACHMENT0 : GL_FRONT);
 
 	// now for the data
 	if (Use_PBOs) {


### PR DESCRIPTION
Fixes #6846.

This now explicitly checks and correctly processes the current RTT state when calling screenToBlob.
The problem was originally caused due to #6753 no longer being able to rely on the current implicit OpenGL state and had to explicitly set FBO's. This, if not considered, would effectively "unbind" the current RTT texture, and thus just blob the main screen rather than the current RTT target.

With proper FBO and Color attachment settings for RTT, this also fixes #5436 properly.
