### PR TITLE
fix issue with turret/flak multi packets

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3433,7 +3433,8 @@ void process_turret_fired_packet( ubyte *data, header *hinfo )
 	}
 
 	// make an orientation matrix from the o_fvec
-	vm_vector_2_matrix_norm(&orient, &o_fvec, nullptr, nullptr);
+	// NOTE: o_fvec is NOT normalized due to pack/unpack altering values!
+	vm_vector_2_matrix(&orient, &o_fvec, nullptr, nullptr);
 
 	// find this turret, and set the position of the turret that just fired to be where it fired.  Quite a
 	// hack, but should be suitable.
@@ -8740,7 +8741,8 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 	}
 
 	// make an orientation matrix from the o_fvec
-	vm_vector_2_matrix_norm(&orient, &o_fvec, nullptr, nullptr);
+	// NOTE: o_fvec is NOT normalized due to pack/unpack altering values!
+	vm_vector_2_matrix(&orient, &o_fvec, nullptr, nullptr);
 
 	// find this turret, and set the position of the turret that just fired to be where it fired.  Quite a
 	// hack, but should be suitable.


### PR DESCRIPTION
Normalized vectors sent over multi are never guaranteed to still be normalized on the other side.