### PR TITLE
fix multi crash loading campaigns

### DIFF
--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -213,7 +213,7 @@ extern void mission_campaign_save_persistent( int type, int index );
 // execute the corresponding mission_campaign_savefile functions.
 
 // get name and type of specified campaign file
-int mission_campaign_get_info(const char *filename, char *name, int *type, int *max_players, char **desc = nullptr, char **first_mission = nullptr);
+bool mission_campaign_get_info(const char *filename, SCP_string &name, int *type, int *max_players, char **desc = nullptr, char **first_mission = nullptr);
 
 // get a listing of missions in a campaign
 int mission_campaign_get_mission_list(const char *filename, char **list, int max);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6675,7 +6675,11 @@ int get_mission_info(const char *filename, mission *mission_p, bool basic, bool 
 {
 	static SCP_string real_fname_buf;
 	const char *real_fname = nullptr;
-	
+
+	if ( !filename || !strlen(filename) ) {
+		return -1;
+	}
+
 	if (filename_is_full_path) {
 		real_fname = filename;
 	} else {

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -750,7 +750,7 @@ void multi_options_process_packet(unsigned char *data, header *hinfo)
 	// get mission choice options
 	case MULTI_OPTION_MISSION: {
 		netgame_info ng;
-		char title[NAME_LENGTH+1];
+		SCP_string title;
 		int campaign_type,max_players;
 
 		Assert(Game_mode & GM_STANDALONE_SERVER);
@@ -779,7 +779,6 @@ void multi_options_process_packet(unsigned char *data, header *hinfo)
 
 			// set the netgame max players here if the filename has changed
 			if(strcmp(Netgame.campaign_name,ng.campaign_name) != 0){				
-				memset(title,0,NAME_LENGTH+1);			
 				if(!mission_campaign_get_info(ng.campaign_name,title,&campaign_type,&max_players)){
 					Netgame.max_players = 0;
 				} else {

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -4535,7 +4535,7 @@ void multi_create_list_load_campaigns()
 {
 	int idx, file_count;
 	int campaign_type,max_players;
-	char title[255];
+	SCP_string title;
 	char wild_card[10];
 	char **file_list = NULL;
 
@@ -4717,13 +4717,13 @@ void multi_create_list_do()
 // so we can set the data without bothering to check the UI anymore
 void multi_create_list_set_item(int abs_index, int mode) {
 
-	int campaign_type, max_players;
-	char title[NAME_LENGTH + 1];
+	int campaign_type = -1, max_players = 0;
+	SCP_string title;
 	netgame_info ng_temp;
 	netgame_info* ng;
 	multi_create_info* mcip = NULL;
 
-	char* campaign_desc;
+	char* campaign_desc = nullptr;
 
 	// if not on the standalone server
 	if (Net_player->flags & NETINFO_FLAG_AM_MASTER) {
@@ -4738,7 +4738,7 @@ void multi_create_list_set_item(int abs_index, int mode) {
 	if (mode == MULTI_CREATE_SHOW_MISSIONS) {
 		strcpy(ng->mission_name, Multi_create_mission_list[abs_index].filename);
 	} else {
-		strcpy(ng->mission_name, Multi_create_campaign_list[abs_index].filename);
+		strcpy(ng->campaign_name, Multi_create_campaign_list[abs_index].filename);
 	}
 
 	// make sure the netgame type is properly set
@@ -4819,23 +4819,21 @@ void multi_create_list_set_item(int abs_index, int mode) {
 
 		// if not on the standalone server
 		if (Net_player->flags & NETINFO_FLAG_AM_MASTER) {
-			memset(title, 0, sizeof(title));
 			// get the campaign info
 			if (!mission_campaign_get_info(ng->campaign_name,
 					title,
 					&campaign_type,
 					&max_players,
 					&campaign_desc,
-					&first_mission)) {
+					&first_mission))
+			{
+				nprintf(("Network", "MC: Failed to get campaign info for '%s'!\n", ng->campaign_name));
 				memset(ng->campaign_name, 0, sizeof(ng->campaign_name));
-				ng->max_players = 0;
 			}
-			// if we successfully got the info
-			else {
-				memset(ng->title, 0, NAME_LENGTH + 1);
-				strcpy_s(ng->title, title);
-				ng->max_players = max_players;
-			}
+
+			memset(ng->title, 0, sizeof(ng->title));
+			strcpy_s(ng->title, title.c_str());
+			ng->max_players = max_players;
 
 			nprintf(("Network", "MC MAX PLAYERS : %d\n", ng->max_players));
 

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -170,26 +170,17 @@ int local_num_campaigns = 0;
 
 int campaign_file_list_filter(const char *filename)
 {
-	char name[NAME_LENGTH];
-	char *desc = NULL;
+	SCP_string name;
 	int type, max_players;
 
-	if ( mission_campaign_get_info( filename, name, &type, &max_players, &desc) ) {
+	if ( mission_campaign_get_info( filename, name, &type, &max_players) ) {
 		if ( type == CAMPAIGN_TYPE_SINGLE) {
-			Campaign_names[local_num_campaigns] = vm_strdup(name);
+			Campaign_names[local_num_campaigns] = vm_strdup(name.c_str());
 			local_num_campaigns++;
-
-			// here we *do* free the campaign description because we are not saving the pointer.
-			if (desc != NULL)
-				vm_free(desc);
-
 			return 1;
 		}
 	}
 
-	if (desc != NULL)
-		vm_free(desc);
- 
 	return 0;
 }
 

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -1847,7 +1847,9 @@ ADE_FUNC(loadMission, l_Mission, "string missionName", "Loads a mission", "boole
 	gr_post_process_set_defaults();
 
 	//NOW do the loading stuff
-	get_mission_info(s, &The_mission, false);
+	if (get_mission_info(s, &The_mission, false))
+		return ADE_RETURN_FALSE;
+
 	game_level_init();
 
 	if(!mission_load(s))


### PR DESCRIPTION
A minor bug in #6077 resulted in a crash loading campaigns on the multi ui. The bug itself was not fatal, however it triggered a cascade of poor error handling which led to a crash. A lot of these issues date back to retail. This fixes the minor bug, and hopefully adds enough error handling to preemptively squash a repeat of the crash problem.