### PR TITLE
Fix calculation of apparent size

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -2049,17 +2049,17 @@ void model_render_glow_points(const polymodel *pm, const polymodel_instance *pmi
 
 // These scaling functions were adapted from Elecman's code.
 // https://forum.unity.com/threads/this-script-gives-you-objects-screen-size-in-pixels.48966/#post-2107126
-float convert_pixel_size_and_distance_to_diameter(float pixelsize, float distance, float field_of_view_deg, int screen_height)
+float convert_pixel_size_and_distance_to_diameter(float pixelsize, float distance, float field_of_view, int screen_width)
 {
-	float diameter = (pixelsize * distance * field_of_view_deg) / (fl_degrees(screen_height));
+	float diameter = (pixelsize * distance * tanf(field_of_view)) / (screen_width);
 	return diameter;
 }
 
 // These scaling functions were adapted from Elecman's code.
 // https://forum.unity.com/threads/this-script-gives-you-objects-screen-size-in-pixels.48966/#post-2107126
-float convert_distance_and_diameter_to_pixel_size(float distance, float diameter, float field_of_view_deg, int screen_height)
+float convert_distance_and_diameter_to_pixel_size(float distance, float diameter, float field_of_view, int screen_width)
 {
-	float pixel_size = (diameter * fl_degrees(screen_height)) / (distance * field_of_view_deg);
+	float pixel_size = (diameter * screen_width) / (distance * tanf(field_of_view));
 	return pixel_size;
 }
 
@@ -2073,16 +2073,16 @@ float model_render_get_diameter_clamped_to_min_pixel_size(const vec3d* pos, floa
 	float current_pixel_size = convert_distance_and_diameter_to_pixel_size(
 		distance_to_eye,
 		diameter,
-		fl_degrees(g3_get_hfov(Eye_fov)),
-		gr_screen.max_h);
+		g3_get_hfov(Eye_fov),
+		gr_screen.max_w);
 
 	float scaled_diameter = diameter;
 	if (current_pixel_size < min_pixel_size) {
 		scaled_diameter = convert_pixel_size_and_distance_to_diameter(
 			min_pixel_size,
 			distance_to_eye,
-			fl_degrees(g3_get_hfov(Eye_fov)),
-			gr_screen.max_h);
+			g3_get_hfov(Eye_fov),
+			gr_screen.max_w);
 	}
 
 	return scaled_diameter;

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -311,7 +311,7 @@ void model_render_arc(const vec3d* v1, const vec3d* v2, const SCP_vector<vec3d> 
 void model_render_set_wireframe_color(const color* clr);
 bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, const matrix* orient, const SCP_string& pof_filename = "", float closeup_zoom = 0, const vec3d* closeup_pos = &vmd_zero_vector, const SCP_string& tcolor = "");
 
-float convert_distance_and_diameter_to_pixel_size(float distance, float diameter, float field_of_view_deg, int screen_height);
+float convert_distance_and_diameter_to_pixel_size(float distance, float diameter, float field_of_view, int screen_width);
 
 float model_render_get_diameter_clamped_to_min_pixel_size(const vec3d* pos, float diameter, float min_pixel_size);
 

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -130,8 +130,8 @@ float ParticleEffect::getApproximateVisualSize(const vec3d& pos) const {
 	return convert_distance_and_diameter_to_pixel_size(
 		distance_to_eye,
 		m_radius.avg() * 2.f,
-		fl_degrees(g3_get_hfov(Eye_fov)),
-		gr_screen.max_h);
+		g3_get_hfov(Eye_fov),
+		gr_screen.max_w);
 }
 
 float ParticleEffect::getCurrentFrequencyMult(decltype(modular_curves_definition)::input_type_t source) const {

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -144,6 +144,9 @@ class RandomRange {
 	 */
 	ValueType avg() const
 	{
+		if (m_constant)
+			return m_minValue;
+
 		if constexpr (has_member(DistributionType, avg())) {
 			return m_distribution.avg();
 		}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -10200,7 +10200,7 @@ float weapon_get_apparent_size(const weapon& wp) {
 	
 	return convert_distance_and_diameter_to_pixel_size(
 		dist,
-		wep_objp->radius,
-		fl_degrees(g3_get_hfov(Eye_fov)),
-		gr_screen.max_h) / i2fl(gr_screen.max_h);
+		wep_objp->radius * 2.0f,
+		g3_get_hfov(Eye_fov),
+		gr_screen.max_w) / i2fl(gr_screen.max_w);
 }


### PR DESCRIPTION
This fixes two things:
1. The general `convert_distance_and_diameter_to_pixel_size` function, which conflagrated horizontal fov with screen height and seemed to be missing a tan in the trigonometry (which I redid from scratch just to be safe).
2. RandomRange reporting of the expected value when in constant value mode, which was what caused the radius of the muzzleflashes to be reported incorrectly to the scaling curves.

OVerall, this PR fixes the oversized muzzleflashes in exile.