### PR TITLE
Fix Unlit Materials in Deferred Pipeline

### DIFF
--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -413,6 +413,18 @@ void main()
 		baseColor.rgb += emissiveColor.rgb;
 	#prereplace ENDIF_FLAG //MODEL_SDR_FLAG_DEFERRED
 
+	#prereplace IF_FLAG MODEL_SDR_FLAG_DEFERRED
+		#prereplace IF_NOT_FLAG MODEL_SDR_FLAG_LIGHT
+			#prereplace IF_FLAG MODEL_SDR_FLAG_SPEC
+				baseColor.rgb += pow(1.0 - clamp(dot(eyeDir, normal), 0.0, 1.0), 5.0 * clamp(glossData, 0.01, 1.0)) * specColor.rgb;
+				glossData = 0;
+			#prereplace ENDIF_FLAG //MODEL_SDR_FLAG_SPEC
+			// If there is no lighting then we copy the color data so far into the emissive.
+			emissiveColor.rgb += baseColor.rgb;
+			aoFactors.x = 0;
+		#prereplace ENDIF_FLAG //MODEL_SDR_FLAG_LIGHT
+	#prereplace ENDIF_FLAG //MODEL_SDR_FLAG_DEFERRED
+
 	fragOut0 = baseColor;
 
 	#prereplace IF_FLAG MODEL_SDR_FLAG_DEFERRED


### PR DESCRIPTION
#6849 accidentally got rid of properly handling the flag for unlit materials. This PR restores the behavior, and adjusts it to the new ambient lighting (notably making sure that unlit materials don't get additionally backlit, i.e. have an AO-factor of 0, and don't glint in the sun, i.e. have a glossData of 0)