### PR TITLE
Preload asteroids and debris when config-field SEXPs are used

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2542,23 +2542,20 @@ int get_asteroid_index(const char* asteroid_name)
 	return -1;
 }
 
-// For FRED. Gets a list of unique asteroid subtype names
-SCP_vector<SCP_string> get_list_valid_asteroid_subtypes()
+// Returns the list of unique asteroid subtype names.
+// List is cached after the first call since Asteroid_info cannot change during an engine instance.
+const SCP_vector<SCP_string>& get_list_valid_asteroid_subtypes()
 {
-	SCP_vector<SCP_string> list;
+	static SCP_vector<SCP_string> list;
 
-	for (const auto& this_asteroid : Asteroid_info) {
-		if (this_asteroid.type != ASTEROID_TYPE_DEBRIS) {
-			for (const auto& subtype : this_asteroid.subtypes) {
-				bool exists = false;
-				for (const auto& entry : list) {
-					if (subtype.type_name == entry) {
-						exists = true;
+	if (list.empty()) {
+		for (const auto& this_asteroid : Asteroid_info) {
+			if (this_asteroid.type != ASTEROID_TYPE_DEBRIS) {
+				for (const auto& subtype : this_asteroid.subtypes) {
+					// Only add unique names
+					if (std::find(list.begin(), list.end(), subtype.type_name) == list.end()) {
+						list.push_back(subtype.type_name);
 					}
-				}
-
-				if (!exists) {
-					list.push_back(subtype.type_name);
 				}
 			}
 		}
@@ -2566,6 +2563,7 @@ SCP_vector<SCP_string> get_list_valid_asteroid_subtypes()
 
 	return list;
 }
+
 
 static void verify_asteroid_splits() 
 {

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -179,7 +179,8 @@ void	asteroid_show_brackets();
 void	asteroid_target_closest_danger();
 void asteroid_add_target(object* objp);
 int get_asteroid_index(const char* asteroid_name);
-SCP_vector<SCP_string> get_list_valid_asteroid_subtypes();
+const SCP_vector<SCP_string>& get_list_valid_asteroid_subtypes();
+int get_asteroid_subtype_index_by_name(const SCP_string& name, int asteroid_idx);
 
 // extern for the lab
 void asteroid_load(int asteroid_info_index, int asteroid_subtype);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4426,6 +4426,32 @@ void preload_change_ship_class(const char *text)
 		model_page_in_textures(sip->model_num, idx);
 }
 
+// MjnMixael
+void preload_asteroid_class(const char* text)
+{
+	const auto& list = get_list_valid_asteroid_subtypes();
+
+	bool valid = std::any_of(list.begin(), list.end(), [&](const SCP_string& item) { return !stricmp(text, item.c_str()); });
+
+	if (!valid)
+		return;
+
+	asteroid_load(ASTEROID_TYPE_SMALL, get_asteroid_subtype_index_by_name(text, ASTEROID_TYPE_SMALL));
+	asteroid_load(ASTEROID_TYPE_MEDIUM, get_asteroid_subtype_index_by_name(text, ASTEROID_TYPE_MEDIUM));
+	asteroid_load(ASTEROID_TYPE_LARGE, get_asteroid_subtype_index_by_name(text, ASTEROID_TYPE_LARGE));
+
+}	
+
+// MjnMixael
+void preload_debris_class(const char* text)
+{
+	auto idx = get_asteroid_index(text);
+	if (idx < 0)
+		return;
+
+	asteroid_load(idx, 0);
+}
+
 // Goober5000
 void preload_turret_change_weapon(const char *text)
 {
@@ -4844,6 +4870,30 @@ int get_sexp()
 				// model is argument #1
 				n = CDR(start);
 				do_preload_for_arguments(sexp_set_skybox_model_preload, n, arg_handler);
+				break;
+
+			case OP_CONFIG_ASTEROID_FIELD:
+				// asteroid types start at argument #17
+				n = CDDDDDR(start);
+				n = CDDDDDR(n);
+				n = CDDDDDR(n);
+				n = CDDR(n);
+
+				// loop through all remaining arguments
+				for (int arg = n; arg >= 0; arg = CDR(arg)) {
+					do_preload_for_arguments(preload_asteroid_class, arg, arg_handler);
+				}
+				break;
+
+			case OP_CONFIG_DEBRIS_FIELD:
+				// debris types start at argument #10
+				n = CDDDDDR(start);
+				n = CDDDDDR(n);
+				
+				// loop through all remaining arguments
+				for (int arg = n; arg >= 0; arg = CDR(arg)) {
+					do_preload_for_arguments(preload_debris_class, arg, arg_handler);
+				}
 				break;
 
 			case OP_TURRET_CHANGE_WEAPON:


### PR DESCRIPTION
Turns out using config-debris-field or config-asteroid-field with many active types of debris or asteroids can bring missions to a grinding halt so that the models can be loaded. So this PR utilizes the framework other SEXPs use, such as change-ship-class, to preload any asteroids or debris that are listed in one of those sexps.

A bonus optimization is that the list of asteroid subtypes is now a static variable return so we can skip running that the whole function after we've already done it once.