### PR TITLE
Fix p-spew with homing weapons

### DIFF
--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -6076,6 +6076,19 @@ static void weapon_set_state(weapon_info* wip, weapon* wp, WeaponState state)
 		source->setHost(make_unique<EffectHostObject>(&Objects[wp->objnum], vmd_zero_vector));
 		source->finishCreation();
 	}
+
+	if (wip->wi_flags[Weapon::Info_Flags::Particle_spew]) {
+		for (const auto& effect : wip->particle_spewers) {
+			if (!effect.isValid())
+				continue;
+
+			auto source = particle::ParticleManager::get()->createSource(effect);
+			auto host = std::make_unique<EffectHostObject>(&Objects[wp->objnum], vmd_zero_vector);
+			source->setHost(std::move(host));
+			source->finishCreation();
+		}
+	}
+
 }
 
 static void weapon_update_state(weapon* wp)


### PR DESCRIPTION
#6808 converted all Pspews to use the new particle effects, though that in turn lead to a fun little visual bug. Overall, particles on weapons will only be rendered if they are valid, and the is valid check included a `weapon_state == m_weaponstate` check (IE states had to match between what the weapon object held and what the particle held. When a weapon switches to homing that particle state was never updated, b/c before 6808 it never needed to be. This lead to the particle effects from pspews not rendering when a missile was in homing mode.

This PR fixes that issue by also updating the particle host status whenever the weapon state changes (uses the same logic as when the particle spawns the first time).

Tested and works as expected.