### PR TITLE
No need to display debris label on objects in the Debris list

### DIFF
--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -144,9 +144,8 @@ void LabUi::build_debris_list()
 				sprintf(node_label, "##DebrisClassIndex%i_%i", debris_idx, subtype_idx);
 				TreeNodeEx(node_label.c_str(),
 					ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen,
-					"%s (%s)",
-					info.name,
-					subtype.type_name.c_str());
+					"%s",
+					info.name);
 
 				if (IsItemClicked() && !IsItemToggledOpen()) {
 					getLabManager()->changeDisplayedObject(LabMode::Asteroid, debris_idx, subtype_idx);


### PR DESCRIPTION
Debris type asteroids in the Debris list always have a subtype name of "Debris" so there's no need to append the subtype name like we do for Asteroids where the subtype name is actually meaningful.