### PR TITLE
Fix some minor HUD config color errors

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -320,9 +320,9 @@ SCP_vector<std::pair<SCP_string, BoundingBox>> HC_gauge_mouse_coords;
 // Names and XSTR IDs for these come from HC_text above
 hc_col HC_colors[NUM_HUD_COLOR_PRESETS] =
 {
-	{0, 255, 0, "", -1},    // Green
-	{67, 123, 203, "", -1}, // Blue
-	{255, 197, 0, "", -1},  // Amber
+	{0, 255, 0, "Green", 1457}, // Green
+	{67, 123, 203, "Blue", 1456}, // Blue
+	{255, 197, 0, "Amber", 1455}, // Ambers
 };
 
 int HC_default_color = HUD_COLOR_PRESET_1;

--- a/code/scripting/api/objs/hudconfig.cpp
+++ b/code/scripting/api/objs/hudconfig.cpp
@@ -71,7 +71,7 @@ SCP_string hud_color_preset_h::getName() const
 
 bool hud_color_preset_h::isValid() const
 {
-	return preset >= 0 && preset < static_cast<int>(HC_preset_filenames.size());
+	return preset >= 0 && preset < NUM_HUD_COLOR_PRESETS;
 }
 
 //**********HANDLE: hud color preset


### PR DESCRIPTION
First, return the proper number of hud color presets then also actually set the name and XSTR of the built-in presets to match retail's UI strings and xstrs.