### PR TITLE
Fix misplaced fireballs when subsystems are destroyed by area-of-effect damage

### DIFF
--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -786,7 +786,7 @@ std::pair<std::optional<ConditionData>, float> do_subobj_hit_stuff(object *ship_
 					}
 				}
 				subsys->current_hits = 0.0f;
-				do_subobj_destroyed_stuff( ship_p, subsys, hitpos );
+				do_subobj_destroyed_stuff( ship_p, subsys, global_damage ? nullptr : hitpos );
 				continue;
 			} else {
 				continue;
@@ -1032,7 +1032,7 @@ std::pair<std::optional<ConditionData>, float> do_subobj_hit_stuff(object *ship_
 
 			// multiplayer clients never blow up subobj stuff on their own
 			if ( (subsystem->current_hits <= 0.0f) && !MULTIPLAYER_CLIENT) {
-				do_subobj_destroyed_stuff( ship_p, subsystem, hitpos );
+				do_subobj_destroyed_stuff( ship_p, subsystem, global_damage ? nullptr : hitpos );
 			}
 
 			if (damage_left <= 0)	{ // no more damage to distribute, so stop checking


### PR DESCRIPTION
When a large subsystem is destroyed, several fireballs are spawned. Most are spawned near the subsystem's position, but one is spawned at the hit position. However, when a subsystem is destroyed by global damage, such as a shockwave, we don't have a well-defined hit position, and the fireball ends up being spawned at a location far from the subsystem.

This is likely an old behavior, and may go back to retail.

To fix it, we just check in `do_subobj_hit_stuff()` whether we're doing local or global damage, and if it's global, we don't pass in the malformed hitpos.