### PR TITLE
Minor Particle Fixes

### DIFF
--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -17,7 +17,12 @@ namespace particle {
 		static void parseBitmaps(ParticleEffect &effect) {
 			if (internal::required_string_if_new("+Filename:", false)) {
 				effect.m_bitmap_list = internal::parseAnimationList(true);
-				effect.m_bitmap_range = ::util::UniformRange<size_t>(0, effect.m_bitmap_list.size() - 1);
+
+				if (effect.m_bitmap_list.empty()) {
+					error_display(1, "No bitmap defined for particle effect!");
+				} else {
+					effect.m_bitmap_range = ::util::UniformRange<size_t>(0, effect.m_bitmap_list.size() - 1);
+				}
 			}
 		}
 

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -2212,10 +2212,10 @@ particle::ParticleEffectHandle getLegacyScriptingParticleEffect(int bitmap, bool
 		::util::UniformFloatRange(), //No duration
 		::util::UniformFloatRange (-1.f), //Single particle only
 		particle::ParticleEffect::ShapeDirection::ALIGNED, //Particle direction
-		::util::UniformFloatRange(), //Velocity Inherit
+		::util::UniformFloatRange(1.f), //Velocity Inherit
 		false, //Velocity Inherit absolute?
-		std::make_unique<particle::ConeVolume>(::util::ParsedRandomFloatRange(), 1.f), //Velocity volume
-		::util::UniformFloatRange(1.f), //Velocity volume multiplier
+		nullptr, //Velocity volume
+		::util::UniformFloatRange(), //Velocity volume multiplier
 		particle::ParticleEffect::VelocityScaling::NONE, //Velocity directional scaling
 		std::nullopt, //Orientation-based velocity
 		std::nullopt, //Position-based velocity


### PR DESCRIPTION
1. Change some settings for the scripted particles to ensure that lua-provided velocity is properly forwarded to the particle system
2. Error out when no bitmap is tabled. This happens for example when the string list is malformed, and will later cause invalid accesses into the bitmap list.