### PR TITLE
fix double dumbfire missiles for multi clients

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3140,6 +3140,11 @@ void send_secondary_fired_packet( ship *shipp, ushort starting_sig, int  /*start
 		return;
 	}
 
+	// if this is a dumbfire weapon then skip it since it's client fired
+	if ( !Weapon_info[shipp->weapons.secondary_bank_weapons[current_bank]].is_homing() ) {
+		return;
+	}
+
 	// now build up the packet to send to the player who actually fired.
 	BUILD_HEADER( SECONDARY_FIRED_PLR );
 	ADD_USHORT(starting_sig);


### PR DESCRIPTION
Dumbfire missiles are client fired for rollback purposes. However players would see their missiles fire twice due to the server also sending a fire packet back to the player. So we need to prevent the player that fired the missile in question from getting that extra packet.