### PR TITLE
Allow mods to cap rotational velocity from collisions

### DIFF
--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -749,11 +749,11 @@ void calculate_ship_ship_collision_physics(collision_info_struct *ship_ship_hit_
 	if (should_collide){
 		vm_vec_scale(&impulse, impulse_mag);
 		vm_vec_scale(&delta_rotvel_light, impulse_mag);	
-		physics_collide_whack(&impulse, &delta_rotvel_light, &lighter->phys_info, &lighter->orient, ship_ship_hit_info->is_landing);
+		physics_collide_whack(&impulse, &delta_rotvel_light, &lighter->phys_info, &lighter->orient, ship_ship_hit_info->is_landing, light_sip->collision_physics.rotation_mag_max);
 
 		vm_vec_negate(&impulse);
 		vm_vec_scale(&delta_rotvel_heavy, -impulse_mag);
-		physics_collide_whack(&impulse, &delta_rotvel_heavy, &heavy->phys_info, &heavy->orient, true);
+		physics_collide_whack(&impulse, &delta_rotvel_heavy, &heavy->phys_info, &heavy->orient, true, heavy_sip->collision_physics.rotation_mag_max);
 	}
 
 	// If within certain bounds, we want to add some more rotation towards the "resting orientation" of the ship

--- a/code/physics/physics.cpp
+++ b/code/physics/physics.cpp
@@ -1084,7 +1084,7 @@ void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi,
 // Warning:  Do not change ROTVEL_COLLIDE_WHACK_CONST.  This will mess up collision physics.
 // If you need to change the rotation, change  COLLISION_ROTATION_FACTOR in collide_ship_ship.
 #define ROTVEL_COLLIDE_WHACK_CONST 1.0
-void physics_collide_whack( vec3d *impulse, vec3d *world_delta_rotvel, physics_info *pi, matrix *orient, bool is_landing )
+void physics_collide_whack( vec3d *impulse, vec3d *world_delta_rotvel, physics_info *pi, matrix *orient, bool is_landing, float max_rotvel )
 {
 	vec3d	body_delta_rotvel;
 
@@ -1095,6 +1095,13 @@ void physics_collide_whack( vec3d *impulse, vec3d *world_delta_rotvel, physics_i
 	vm_vec_rotate( &body_delta_rotvel, world_delta_rotvel, orient );
 //	vm_vec_scale( &body_delta_rotvel, (float)	ROTVEL_COLLIDE_WHACK_CONST );
 	vm_vec_add2( &pi->rotvel, &body_delta_rotvel );
+
+	if (max_rotvel > 0.0f) {
+		float rotvel_mag = vm_vec_mag(&pi->rotvel);
+		if (rotvel_mag > max_rotvel) {
+			vm_vec_scale(&pi->rotvel, max_rotvel / rotvel_mag);
+		}
+	}
 
 	pi->flags |= PF_REDUCED_DAMP;
 	update_reduced_damp_timestamp( pi, vm_vec_mag(impulse) );

--- a/code/physics/physics.h
+++ b/code/physics/physics.h
@@ -164,7 +164,7 @@ extern bool whack_below_limit(float impulse);
 extern void physics_calculate_and_apply_whack(const vec3d *force, const vec3d *pos, physics_info *pi, const matrix *orient, const matrix *inv_moi);
 extern void physics_apply_whack(float orig_impulse, physics_info* pi, const vec3d *delta_rotvel, const vec3d* delta_vel, const matrix* orient);
 extern void physics_apply_shock(vec3d *direction_vec, float pressure, physics_info *pi, matrix *orient, vec3d *min, vec3d *max, float radius);
-extern void physics_collide_whack(vec3d *impulse, vec3d *delta_rotvel, physics_info *pi, matrix *orient, bool is_landing);
+extern void physics_collide_whack(vec3d *impulse, vec3d *delta_rotvel, physics_info *pi, matrix *orient, bool is_landing, float max_rotvel = -1.0f);
 int check_rotvel_limit( physics_info *pi );
 extern void physics_add_point_mass_moi(matrix *moi, float mass, vec3d *pos);
 extern bool physics_lead_ballistic_trajectory(const vec3d* start, const vec3d* end_pos, const vec3d* target_vel, float weapon_speed, const vec3d* gravity, vec3d* out_direction);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1757,6 +1757,7 @@ ship_info::ship_info()
 	collision_physics.bounce = 5.0;
 	collision_physics.friction = COLLISION_FRICTION_FACTOR;
 	collision_physics.rotation_factor = COLLISION_ROTATION_FACTOR;
+	collision_physics.rotation_mag_max = -1.0f;
 	collision_physics.reorient_mult = 1.0f;
 	collision_physics.landing_sound_idx = gamesnd_id();
 	collision_physics.collision_sound_light_idx = gamesnd_id();
@@ -3331,6 +3332,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		}
 		if(optional_string("+Rotation Factor:")) {
 			stuff_float(&sip->collision_physics.rotation_factor);
+		}
+		if (optional_string("+Rotation Magnitude Maximum:")) {
+			stuff_float(&sip->collision_physics.rotation_mag_max);
+			sip->collision_physics.rotation_mag_max *= PI / 180.0f;
 		}
 		if(optional_string("+Landing Max Forward Vel:")) {
 			stuff_float(&sip->collision_physics.landing_max_z);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1082,6 +1082,7 @@ typedef struct ship_collision_physics {
 	float bounce{};				// Bounce factor for all other cases
 	float friction{};				// Controls lateral velocity lost when colliding with a large ship
 	float rotation_factor{};		// Affects the rotational energy of collisions... TBH not sure how.
+	float rotation_mag_max{};		// Maximum value of the final rotational velocity resulting from a collision --wookieejedi
 
 	// Speed & angle constraints for a smooth landing
 	// Note that all angles are stored as a dotproduct between normalized vectors instead. This saves us from having


### PR DESCRIPTION
The `+Rotation Factor:` value in the ship collide section of the ships table has been around for many years, but raising that value beyond the default of 0.2 results in ship collisions that can result in the colliding ship spinning at ludicrous rotational velocities that last for over 10 seconds (this is especially evident with long ships with high speeds).

This PR adds a field after `+Rotation Factor:` called `+Rotation Magnitude Maximum:` which serves as a maximum for the resulting rotational velocity from a ship collision in degrees per second. By default this is -1 and thus disabled.

Tested and works as expected, and now properly allows mods to have ships spin out if they have collision while not spinning out at wild speeds that look immersion breaking.