### PR TITLE
Remove unused enum in particle code

### DIFF
--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -21,15 +21,6 @@ namespace particle {
 /**
  * The origin type
  */
-enum class SourceOriginType {
-	NONE, //!< Invalid origin
-	VECTOR, //!< World-space offset
-	BEAM, //!< A beam
-	OBJECT, //!< An object
-	SUBOBJECT, //!< A subobject
-	TURRET, //!< A turret
-	PARTICLE //!< A particle
-};
 
 class ParticleEffect;
 struct particle_effect_tag {


### PR DESCRIPTION
This bit of code is no longer used post-rework, but it seems that I forgot to delete it at the time.
This enum specifically has been superceded by the EffectHost class.