### PR TITLE
Fix engine not updating with change-ship

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2174,6 +2174,7 @@ void hud_stop_looped_engine_sounds()
 	if (Player_engine_snd_loop.isValid()) {
 		snd_stop(Player_engine_snd_loop);
 		Player_engine_snd_loop = sound_handle::invalid();
+		throttle_sound_check_id = timestamp(0);
 	}
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12198,8 +12198,12 @@ void change_ship_type(int n, int ship_type, int by_sexp)
 	animation::anim_set_initial_states(sp);
 
 	//Reassign sound stuff
-	if (!Fred_running)
+	if (!Fred_running) {
+		if (objp == Player_obj) {
+			hud_stop_looped_engine_sounds();
+		}
 		ship_assign_sound(sp);
+	}
 	
 	// Valathil - Reinitialize collision checks
 	obj_remove_collider(OBJ_INDEX(objp));
@@ -16311,6 +16315,9 @@ void ship_assign_sound(ship *sp)
 
 	objp = &Objects[sp->objnum];
 	sip = &Ship_info[sp->ship_info_index];
+
+	// clear out any existing assigned sounds --wookieejedi
+	obj_snd_delete_type(OBJ_INDEX(objp));
 
 	// Do subsystem sounds	
 	moveup = GET_FIRST(&sp->subsys_list);


### PR DESCRIPTION
Yet another caveat of the change-ship function was discovered by Darius, who found that that both the 3D assigned engine sounds and the 2D throttle/cockpit engine sounds do not properly updated when a ship type is changed via sexp/script.

This PR fixes this by properly calling the respective clearing functions and it also resets the throttle sound check timestamp to ensure the 2D sounds are indeed updated on the next frame.

Tested and works as expected. Fixes #6892.