### PR TITLE
remove old os_sleep() hack for Mac

### DIFF
--- a/code/osapi/osapi.cpp
+++ b/code/osapi/osapi.cpp
@@ -451,16 +451,7 @@ bool os_foreground()
 // Sleeps for n milliseconds or until app becomes active.
 void os_sleep(uint ms)
 {
-#ifdef __APPLE__
-	// ewwww, I hate this!!  SDL_Delay() is causing issues for us though and this
-	// basically matches Apple examples of the same thing.  Same as SDL_Delay() but
-	// we aren't hitting up the system for anything during the process
-	uint then = SDL_GetTicks() + ms;
-
-	while (then > SDL_GetTicks());
-#else
 	SDL_Delay(ms);
-#endif
 }
 
 static bool file_exists(const SCP_string& path) {


### PR DESCRIPTION
SDL 1.2 had an issue using SDL_Delay() on Mac where it caused bad stuttering and freezes. A hack was added to avoid this, but it causes 100% CPU usage when it should be a sleep state, so it wasn't ideal.

With SDL 2 this issue was resolved with the underlying code being unified for all *NIX variants and that problematic Mac-specific code was removed. So now we can remove the hack to offer a little better performance on Macs.