### PR TITLE
Still allow subsystem animations in the lab

### DIFF
--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -80,7 +80,7 @@ enum ai_goal_mode : uint8_t
 	AI_GOAL_FLY_TO_SHIP,
 	AI_GOAL_IGNORE_NEW,
 	AI_GOAL_CHASE_SHIP_CLASS,
-	AI_GOAL_PLAY_DEAD_PERSISTENT,
+	AI_GOAL_PLAY_DEAD_PERSISTENT, // Disables subsystem rotation/translation among other things but there is a carveout for that in the lab only in ship_move_subsystems()
 	AI_GOAL_LUA,
 	AI_GOAL_DISARM_SHIP_TACTICAL,
 	AI_GOAL_DISABLE_SHIP_TACTICAL,

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -614,6 +614,7 @@ void LabManager::changeDisplayedObject(LabMode mode, int info_index, int subtype
 			Player_ship = &Ships[Objects[CurrentObject].instance];
 			ai_paused = 0;
 
+			// Set the ship to play dead so it doesn't move. There is a special carveout to still allow subsystem rotations/translations in the lab, though
 			ai_add_ship_goal_scripting(AI_GOAL_PLAY_DEAD_PERSISTENT, -1, 100, nullptr, &Ai_info[Player_ship->ai_index], 0, 0);
 		}
 		break;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -20001,9 +20001,11 @@ void ship_move_subsystems(object *objp)
 	Assertion(objp->type == OBJ_SHIP, "ship_move_subsystems should only be called for ships!  objp type = %d", objp->type);
 	auto shipp = &Ships[objp->instance];
 	
-	// non-player ships that are playing dead do not process subsystems or turrets
-	if ((!(objp->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) && Ai_info[shipp->ai_index].mode == AIM_PLAY_DEAD)
-		return;
+	// non-player ships that are playing dead do not process subsystems or turrets unless we're in the lab
+	if (gameseq_get_state() != GS_STATE_LAB) {
+		if ((!(objp->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) && Ai_info[shipp->ai_index].mode == AIM_PLAY_DEAD)
+			return;
+	}
 
 	for (auto pss = GET_FIRST(&shipp->subsys_list); pss != END_OF_LIST(&shipp->subsys_list); pss = GET_NEXT(pss))
 	{


### PR DESCRIPTION
PR #6715 added the ability to test docking and undocking the lab which required initializing the ai subsystem in the Lab as well. Doing that had a side effect of causing the current ship to move around on it's own. To solve that a Play-Dead order was issued. That had a side effect of causing subsystem rotations/translations to stop running as that is a design of Play-Dead.

Stay-Still didn't really work well on fighters in the Lab because they still wiggled around. So the options were to either constantly reset the current object's orientation every frame or just carve out a special case for the Lab to still run subsystem animations even during Play-Dead. The latter turned out to be the easiest and less hacky.

Fixes #6897