### PR TITLE
Show current detail level in the lab

### DIFF
--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -4,6 +4,7 @@
 #include "io/key.h"
 #include "math/staticrand.h"
 #include "missionui/missionscreencommon.h"
+#include "model/modelrender.h"
 #include "object/object.h"
 #include "object/objectdock.h"
 #include "debris/debris.h"
@@ -419,6 +420,8 @@ void LabManager::cleanup() {
 		CurrentOrientation = vmd_identity_matrix;
 		ModelFilename = "";
 		Player_ship = nullptr;
+
+		Lab_object_detail_level = -1;
 	}
 
 	Cmdline_dis_collisions = Saved_cmdline_collisions_value;

--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -7,6 +7,7 @@
 #include "lab/renderer/lab_renderer.h"
 #include "lighting/lighting_profiles.h"
 #include "math/bitarray.h"
+#include "model/modelrender.h"
 #include "nebula/neb.h"
 #include "parse/parselo.h"
 #include "particle/particle.h"
@@ -32,10 +33,11 @@ void LabRenderer::onFrame(float frametime) {
 
 		// print out the current pof filename, to help with... something
 		if (strlen(getLabManager()->ModelFilename.c_str())) {
-			gr_get_string_size(&w, &h, getLabManager()->ModelFilename.c_str());
+			SCP_string lab_text = "POF File: " + getLabManager()->ModelFilename + " Detail Level: " + std::to_string(Lab_object_detail_level);
+			gr_get_string_size(&w, &h, lab_text.c_str());
 			gr_set_color_fast(&Color_white);
-			gr_string(gr_screen.center_offset_x + gr_screen.center_w - w,
-				gr_screen.center_offset_y + gr_screen.center_h - h, getLabManager()->ModelFilename.c_str(), GR_RESIZE_NONE);
+			gr_string(gr_screen.center_offset_x + gr_screen.center_w - w - 20, // add a little padding to the right
+				gr_screen.center_offset_y + gr_screen.center_h - h, lab_text.c_str(), GR_RESIZE_NONE);
 		}
 	}
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -43,6 +43,8 @@ extern float model_radius;
 extern bool Scene_framebuffer_in_frame;
 color Wireframe_color;
 
+int Lab_object_detail_level = -1; // Used to display the detail level in the lab
+
 extern void interp_generate_arc_segment(SCP_vector<vec3d> &arc_segment_points, const vec3d *v1, const vec3d *v2, ubyte depth_limit, ubyte depth);
 
 int model_render_determine_elapsed_time(int objnum, uint64_t flags);
@@ -2666,6 +2668,11 @@ void model_render_queue(const model_render_params* interp, model_draw_list* scen
 
 	float depth = model_render_determine_depth(objnum, model_num, orient, pos, interp->get_detail_level_lock());
 	int detail_level = model_render_determine_detail(depth, model_num, interp->get_detail_level_lock());
+
+	// Send the detail level to the lab for displaying
+	if (gameseq_get_state() == GS_STATE_LAB) {
+		Lab_object_detail_level = detail_level;
+	}
 
 	// If we're rendering attached weapon models, check against the ships' tabled Weapon Model Draw Distance (which defaults to 200)
 	if ( model_flags & MR_ATTACHED_MODEL && shipp != NULL ) {

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -27,6 +27,8 @@ extern vec3d Object_position;
 
 extern color Wireframe_color;
 
+extern int Lab_object_detail_level;
+
 typedef enum {
 	TECH_SHIP,
 	TECH_WEAPON,


### PR DESCRIPTION
Draws the current detail level being rendered to the screen. Very useful for testing and debugging detail distance settings.

I tried to do this with a member var of the lab with a setter but it caused build issues with FRED as including any methods from the lab in modelrender started requiring symbols that FRED doesn't have but FSO does. So in the end I decided this was the simplest way to do this.