### PR TITLE
Debris Cleanup

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -37,7 +37,6 @@
 #include "utils/Random.h"
 #include "weapon/weapon.h"
 
-constexpr int MIN_RADIUS_FOR_PERSISTENT_DEBRIS = 50;	// ship radius at which debris from it becomes persistant
 constexpr int DEBRIS_SOUND_DELAY = 2000;				// time to start debris sound after created
 
 int Num_hull_pieces;	// number of hull pieces in existence
@@ -567,22 +566,9 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 	}
 
 	// Create Debris piece n!
-	if ( hull_flag ) {
-		if (Random::next() < (Random::MAX_VALUE/6))	// Make some pieces blow up shortly after explosion.
-			db->lifeleft = 2.0f * (frand()) + 0.5f;
-		else {
-			db->flags.set(Debris_Flags::DoNotExpire);
-			db->lifeleft = -1.0f;		// large hull pieces stay around forever
-		}
-	} else {
-		// small non-hull pieces should stick around longer the larger they are
-		// sqrtf should make sure its never too crazy long
-		db->lifeleft = (frand() * 2.0f + 0.1f) * sqrtf(radius);
-	}
-
-	//WMC - Oh noes, we may need to change lifeleft
 	if(hull_flag)
 	{
+		// WMC - set lifeleft based on tabeled entries if they are not negative
 		if(sip->debris_min_lifetime >= 0.0f && sip->debris_max_lifetime >= 0.0f)
 		{
 			db->lifeleft = (( sip->debris_max_lifetime - sip->debris_min_lifetime ) * frand()) + sip->debris_min_lifetime;
@@ -597,6 +583,22 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 			if(db->lifeleft > sip->debris_max_lifetime)
 				db->lifeleft = sip->debris_max_lifetime;
 		}
+		// By default, make some pieces blow up shortly after explosion.
+		else if (Random::next() < (Random::MAX_VALUE / 6)) 
+		{
+			db->lifeleft = 2.0f * (frand()) + 0.5f;
+		}
+		else 
+		{
+			db->flags.set(Debris_Flags::DoNotExpire);
+			db->lifeleft = -1.0f; // large hull pieces stay around forever
+		}
+	} 
+	else 
+	{
+		// small non-hull pieces should stick around longer the larger they are
+		// sqrtf should make sure its never too crazy long
+		db->lifeleft = (frand() * 2.0f + 0.1f) * sqrtf(radius);
 	}
 
 	// increase lifetime for vaporized debris
@@ -698,7 +700,7 @@ object *debris_create_only(int parent_objnum, int parent_ship_class, int alt_typ
 			db->arc_timeout = TIMESTAMP::immediate();
 		}
 
-		if (parent_objnum >= 0 && Objects[parent_objnum].radius >= MIN_RADIUS_FOR_PERSISTENT_DEBRIS) {
+		if (parent_objnum >= 0 && Objects[parent_objnum].radius >= Min_radius_for_persistent_debris) {
 			db->flags.set(Debris_Flags::DoNotExpire);
 		} else {
 			debris_add_to_hull_list(db);

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -173,6 +173,7 @@ bool Disable_intro_movie;
 bool Show_locked_status_scramble_missions;
 bool Disable_expensive_turret_target_check;
 float Shield_percent_skips_damage;
+float Min_radius_for_persistent_debris;
 
 
 #ifdef WITH_DISCORD
@@ -1551,6 +1552,10 @@ void parse_mod_table(const char *filename)
 				}
 			}
 
+			if (optional_string("$Minimum ship radius for persistent debris:")) {
+				stuff_float(&Min_radius_for_persistent_debris);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1788,6 +1793,7 @@ void mod_table_reset()
 	Show_locked_status_scramble_missions = false;
 	Disable_expensive_turret_target_check = false;
 	Shield_percent_skips_damage = 0.1f;
+	Min_radius_for_persistent_debris = 50.0f;
 }
 
 void mod_table_set_version_flags()

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -188,6 +188,7 @@ extern bool Disable_intro_movie;
 extern bool Show_locked_status_scramble_missions;
 extern bool Disable_expensive_turret_target_check;
 extern float Shield_percent_skips_damage;
+extern float Min_radius_for_persistent_debris;
 
 void mod_table_init();
 void mod_table_post_process();


### PR DESCRIPTION
In current master the debris creation logic was really showing some rust, which resulted in inconsistent behavior when using `Lifetime Min` and `Lifetime Max` for debris in the `ships.tbl`. Specifically, by default debris can randomly be set as `DoNotExpire` if the check `(Random::next() < (Random::MAX_VALUE / 6))` is false. This was set *before* the code that set the lifetimes from `Min` and `Max` from the table though, which could randomly result in debris with infinite lifetimes even if a min and max were specified (and the ship was small, since large ships trigger infinite debris by default always).

Also, by default, ships with a radius larger than 50 meters always had infinite debris lifetimes because of `MIN_RADIUS_FOR_PERSISTENT_DEBRIS`. Thus, this PR also allows modders to set that value in the game settings table.

Tested and works as expected.