### PR TITLE
Misc Lab Fixes

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12125,9 +12125,11 @@ void ai_process_subobjects(int objnum)
 
 	bool in_lab = gameseq_get_state() == GS_STATE_LAB;
 
-	// non-player ships that are playing dead do not process subsystems or turrets
-	if ((!(objp->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) && aip->mode == AIM_PLAY_DEAD)
-		return;
+	// non-player ships that are playing dead do not process subsystems or turrets unless we're in the lab
+	if (gameseq_get_state() != GS_STATE_LAB) {
+		if ((!(objp->flags[Object::Object_Flags::Player_ship]) || Player_use_ai) && aip->mode == AIM_PLAY_DEAD)
+			return;
+	}
 
 	polymodel_instance *pmi = model_get_instance(shipp->model_instance_num);
 	polymodel *pm = model_get(pmi->model_num);

--- a/code/ai/aigoals.h
+++ b/code/ai/aigoals.h
@@ -80,7 +80,7 @@ enum ai_goal_mode : uint8_t
 	AI_GOAL_FLY_TO_SHIP,
 	AI_GOAL_IGNORE_NEW,
 	AI_GOAL_CHASE_SHIP_CLASS,
-	AI_GOAL_PLAY_DEAD_PERSISTENT, // Disables subsystem rotation/translation among other things but there is a carveout for that in the lab only in ship_move_subsystems()
+	AI_GOAL_PLAY_DEAD_PERSISTENT, // Disables subsystem rotation/translation among other things but there is a carveout for that in the lab in ship_move_subsystems() and ai_process_subobjects()
 	AI_GOAL_LUA,
 	AI_GOAL_DISARM_SHIP_TACTICAL,
 	AI_GOAL_DISABLE_SHIP_TACTICAL,

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -1029,7 +1029,7 @@ void LabUi::build_secondary_weapon_combobox(SCP_string& text, weapon_info* wip, 
 	}
 }
 
-void LabUi::reset_animations(ship* shipp, ship_info* sip) const
+void LabUi::reset_animations()
 {
 	// With full animation support for docking stages and fighter bays it's honestly just easier to reload the current object
 	getLabManager()->changeDisplayedObject(getLabManager()->CurrentMode, getLabManager()->CurrentClass, getLabManager()->CurrentSubtype);
@@ -1093,7 +1093,7 @@ void LabUi::build_animation_options(ship* shipp, ship_info* sip) const
 		const auto& anim_triggers = sip->animations.getRegisteredTriggers();
 
 		if (Button("Reset animations")) {
-			reset_animations(shipp, sip);
+			reset_animations();
 		}
 
 		if (shipp->weapons.num_primary_banks > 0) {

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -1064,6 +1064,11 @@ void LabUi::maybe_show_animation_category(const SCP_vector<animation::ModelAnima
 					case animation::ModelAnimationTriggerType::Docked:
 						button_label += "Trigger Docked Animation " + std::to_string(count++);
 						break;
+					default:
+						// We really shouldn't be here, but just in case
+						Assertion(false, "Unexpected animation trigger type %d", static_cast<int>(trigger_type));
+						button_label += "Trigger Animation " + std::to_string(count++);
+						break;
 					}
 
 					if (Button(button_label.c_str())) {

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -1031,35 +1031,8 @@ void LabUi::build_secondary_weapon_combobox(SCP_string& text, weapon_info* wip, 
 
 void LabUi::reset_animations(ship* shipp, ship_info* sip) const
 {
-	polymodel_instance* shipp_pmi = model_get_instance(shipp->model_instance_num);
-
-	for (auto i = 0; i < MAX_SHIP_PRIMARY_BANKS; ++i) {
-		if (triggered_primary_banks[i]) {
-			sip->animations.getAll(shipp_pmi, animation::ModelAnimationTriggerType::PrimaryBank, i)
-				.start(animation::ModelAnimationDirection::RWD);
-			triggered_primary_banks[i] = false;
-		}
-	}
-
-	for (auto i = 0; i < MAX_SHIP_SECONDARY_BANKS; ++i) {
-		if (triggered_secondary_banks[i]) {
-			sip->animations.getAll(shipp_pmi, animation::ModelAnimationTriggerType::SecondaryBank, i)
-				.start(animation::ModelAnimationDirection::RWD);
-			triggered_secondary_banks[i] = false;
-		}
-	}
-
-	for (auto& entry : manual_animations) {
-		if (entry.second) {
-			sip->animations.getAll(shipp_pmi, entry.first).start(animation::ModelAnimationDirection::RWD);
-			entry.second = false;
-		}
-	}
-
-	for (const auto& entry : manual_animation_triggers) {
-		auto animation_type = entry.first;
-		sip->animations.getAll(shipp_pmi, animation_type).start(animation::ModelAnimationDirection::RWD);
-	}
+	// With full animation support for docking stages and fighter bays it's honestly just easier to reload the current object
+	getLabManager()->changeDisplayedObject(getLabManager()->CurrentMode, getLabManager()->CurrentClass, getLabManager()->CurrentSubtype);
 }
 
 void LabUi::maybe_show_animation_category(const SCP_vector<animation::ModelAnimationSet::RegisteredTrigger>& anim_triggers,
@@ -1070,10 +1043,30 @@ void LabUi::maybe_show_animation_category(const SCP_vector<animation::ModelAnima
 		})) {
 		with_TreeNode(label.c_str())
 		{
+			int count = 1;
 			for (const auto& anim_trigger : anim_triggers) {
 				if (anim_trigger.type == trigger_type) {
 
-					if (Button(anim_trigger.name.c_str())) {
+					SCP_string button_label = anim_trigger.name;
+					switch (trigger_type) {
+					case animation::ModelAnimationTriggerType::DockBayDoor:
+						button_label += "Trigger Bay Door Animation " + std::to_string(count++);
+						break;
+					case animation::ModelAnimationTriggerType::Docking_Stage1:
+						button_label += "Trigger Docking Stage 1 Animation " + std::to_string(count++);
+						break;
+					case animation::ModelAnimationTriggerType::Docking_Stage2:
+						button_label += "Trigger Docking Stage 2 Animation " + std::to_string(count++);
+						break;
+					case animation::ModelAnimationTriggerType::Docking_Stage3:
+						button_label += "Trigger Docking Stage 3 Animation " + std::to_string(count++);
+						break;
+					case animation::ModelAnimationTriggerType::Docked:
+						button_label += "Trigger Docked Animation " + std::to_string(count++);
+						break;
+					}
+
+					if (Button(button_label.c_str())) {
 						auto& scripted_triggers = manual_animation_triggers[trigger_type];
 						auto direction = scripted_triggers[anim_trigger.name];
 						do_triggered_anim(trigger_type,
@@ -1135,6 +1128,9 @@ void LabUi::build_animation_options(ship* shipp, ship_info* sip) const
 		maybe_show_animation_category(anim_triggers,
 			animation::ModelAnimationTriggerType::Docking_Stage3,
 			"Docking stage 3##anims");
+		maybe_show_animation_category(anim_triggers,
+			animation::ModelAnimationTriggerType::Docked,
+			"Docked animations##anims");
 	}
 }
 

--- a/code/lab/dialogs/lab_ui.h
+++ b/code/lab/dialogs/lab_ui.h
@@ -60,7 +60,7 @@ class LabUi {
 		ship_info* sip) const;
 	void build_model_info_box_actual(ship_info* sip, polymodel* pm) const;
 	void build_team_color_combobox() const;
-	void reset_animations(ship* shipp, ship_info* sip) const;
+	static void reset_animations();
 	void do_triggered_anim(animation::ModelAnimationTriggerType type,
 		const SCP_string& name,
 		bool direction,

--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -421,7 +421,6 @@ void LabManager::cleanup() {
 		Player_ship = nullptr;
 	}
 
-	Cmdline_dis_collisions = Saved_cmdline_collisions_value;
 }
 
 void LabManager::deleteDockerObject() {

--- a/code/lab/manager/lab_manager.h
+++ b/code/lab/manager/lab_manager.h
@@ -53,6 +53,8 @@ public:
 
 		cleanup();
 
+		Cmdline_dis_collisions = Saved_cmdline_collisions_value;
+
 		LabRenderer::close();
 
 		// Unload any asteroids that were loaded


### PR DESCRIPTION
Fixes a handful of things I found while doing another PR.

- Turrets need a similar carveout as #6898 to make sure their animations get reset during test firing
- Only reset the collisions global when we leave the lab not when we run cleaning while changing ships
- Make sure all animation trigger buttons have a string assigned so they can actually be triggered
- Add missing Docked animation trigger
- The reset animations button was trying to undo any triggered animations but with lots of clicks and lots of animations it didn't seem to be fully accurate. I thought it'd be easier to just reload the current ship and call it good.