### PR TITLE
Another particle fix for standalones

### DIFF
--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -29,6 +29,9 @@ bool ParticleSource::isValid() const {
 }
 
 void ParticleSource::finishCreation() {
+	if (Is_standalone)
+		return;
+
 	m_host->setupProcessing();
 
 	for (const auto& effect : ParticleManager::get()->getEffect(m_effect)) {

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -88,7 +88,7 @@ class ParticleSource {
 	const SCP_vector<ParticleEffect>& getEffect() const;
 
 	inline void setEffect(ParticleEffectHandle eff) {
-		Assert(eff.isValid());
+		Assert(eff.isValid() || Is_standalone);
 		m_effect = eff;
 	}
 

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "globalincs/pstypes.h"
+#include "globalincs/systemvars.h"
 #include "object/object.h"
 #include "particle/particle.h"
 #include "io/timer.h"


### PR DESCRIPTION
Fix more standalone crashes from particles by "allowing the code to create particles, and just silently quit if in standalone. I.e., accept an invalid effect handle if in standalone and that'll just quit out the source on its first frame of processing." Thanks to @Bmagnu for the fix! Putting here to allow taylor and chief to more easily test.