### PR TITLE
Fix issue where QtFred could have multiple Ship Dialogs open

### DIFF
--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -743,9 +743,18 @@ void FredView::on_actionWaypoint_Paths_triggered(bool) {
 }
 void FredView::on_actionShips_triggered(bool)
 {
-	auto editorDialog = new dialogs::ShipEditorDialog(this, _viewport);
-	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
-	editorDialog->show();
+	if (!_shipEditorDialog) {
+		_shipEditorDialog = new dialogs::ShipEditorDialog(this, _viewport);
+		_shipEditorDialog->setAttribute(Qt::WA_DeleteOnClose);
+		// When the user closes it, reset our pointer so we can open a new one later
+		connect(_shipEditorDialog, &QObject::destroyed, this, [this]() {
+			_shipEditorDialog = nullptr;
+		});
+		_shipEditorDialog->show();
+	} else {
+		_shipEditorDialog->raise();
+		_shipEditorDialog->activateWindow();
+	}
 
 }
 void FredView::on_actionCampaign_triggered(bool) {

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -19,6 +19,10 @@ namespace fred {
 class Editor;
 class RenderWidget;
 
+namespace dialogs {
+class ShipEditorDialog;
+}
+
 namespace Ui {
 class FredView;
 }
@@ -205,6 +209,8 @@ class FredView: public QMainWindow, public IDialogProvider {
 
 	Editor* fred = nullptr;
 	EditorViewport* _viewport = nullptr;
+
+	fso::fred::dialogs::ShipEditorDialog* _shipEditorDialog = nullptr;
 
 	bool _inKeyPressHandler = false;
 	bool _inKeyReleaseHandler = false;


### PR DESCRIPTION
Only one dialog allowed is a fundamental design of the current ShipEditorDialog so this enforces it.