### PR TITLE
Extend particle interpolation to lifetime

### DIFF
--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -339,18 +339,16 @@ auto ParticleEffect::processSourceInternal(float interp, const ParticleSource& s
 		info.length = m_length.next() * lengthMultiplier;
 		if (m_hasLifetime) {
 			if (m_parentLifetime)
-				// if we were spawned by a particle, parentLifetime is the parent's remaining liftime and m_lifetime is a factor of that
+				// if we were spawned by a particle, parentLifetime is the parent's remaining lifetime and m_lifetime is a factor of that
 				info.lifetime = parentLifetime * m_lifetime.next() * lifetimeMultiplier;
 			else
 				info.lifetime = m_lifetime.next() * lifetimeMultiplier;
 
-			info.lifetime -= (interp * f2fl(Frametime));
-			// I do not want to feed zeroes into this thing, because we're going to be dividing by it a lot later
-			if (fl_near_zero(info.lifetime))
-				info.lifetime = -1.f;
-
 			info.lifetime_from_animation = m_keep_anim_length_if_available;
 		}
+		
+		info.starting_age = interp * f2fl(Frametime);
+		
 		info.size_lifetime_curve = m_size_lifetime_curve;
 		info.vel_lifetime_curve = m_vel_lifetime_curve;
 

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -159,7 +159,7 @@ namespace particle
 
 		part->pos = info->pos;
 		part->velocity = info->vel;
-		part->age = 0.0f;
+		part->age = info->starting_age;
 		part->max_life = info->lifetime;
 		part->radius = info->rad;
 		part->bitmap = info->bitmap;

--- a/code/particle/particle.h
+++ b/code/particle/particle.h
@@ -62,6 +62,7 @@ namespace particle
 		vec3d pos = vmd_zero_vector;
 		vec3d vel = vmd_zero_vector;
 		float lifetime = -1.0f;
+		float starting_age = 0.0f;
 		float rad = -1.0f;
 		int bitmap = -1;
 		int nframes = -1;


### PR DESCRIPTION
Interpolate the starting age of particles, granting millisecond precision to lifetime curves and animations.