### PR TITLE
Let the model decide if the apply was successful and should close

### DIFF
--- a/qtfred/src/mission/util.cpp
+++ b/qtfred/src/mission/util.cpp
@@ -108,8 +108,7 @@ bool rejectOrCloseHandler(__UNUSED QDialog* dialog,
 		}
 
 		if (button == fso::fred::DialogButton::Yes) {
-			model->apply();
-			return true;
+			return model->apply(); // only close if apply was successful
 		}
 		if (button == fso::fred::DialogButton::No) {
 			model->reject();


### PR DESCRIPTION
This allows the model to decide on the workflow based on the results of any internal validator.

Cancel -> Yes Keep Changes -> Validator warns of a problem -> Do not close the dialog (return false)
Cancel -> Yes Keep Changes -> Validator does not return issues -> Close dialog (return true)

Note that _model->apply() already has a function signature that returns a bool. Some dialogs may not make use of this yet but I'll fix that as I go down the list.