### PR TITLE
fix series of bugs due to improper multi targeting

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3044,14 +3044,13 @@ void process_cargo_hidden_packet( ubyte *data, header *hinfo )
 #define SFPF_TARGET_LOCKED		(1<<5)
 
 // send a packet indicating a secondary weapon was fired
-void send_secondary_fired_packet( ship *shipp, ushort starting_sig, int  /*starting_count*/, int num_fired, int allow_swarm )
+void send_secondary_fired_packet( ship *shipp, ushort starting_sig, tracking_info &tinfo, int num_fired, int allow_swarm )
 {
 	int packet_size, net_player_num;
 	ubyte data[MAX_PACKET_SIZE], sinfo, current_bank;
 	object *objp;
 	ushort target_net_signature;
 	int s_index;
-	ai_info *aip;
 
 	// Assert ( starting_count < UCHAR_MAX );
 
@@ -3063,8 +3062,6 @@ void send_secondary_fired_packet( ship *shipp, ushort starting_sig, int  /*start
 			return;
 		}
 	}
-
-	aip = &Ai_info[shipp->ai_index];
 
 	current_bank = (ubyte)shipp->weapons.current_secondary_bank;
 	Assert( (current_bank < MAX_SHIP_SECONDARY_BANKS) );
@@ -3086,7 +3083,7 @@ void send_secondary_fired_packet( ship *shipp, ushort starting_sig, int  /*start
 		sinfo |= SFPF_DUAL_FIRE;
 	}
 
-	if ( aip->current_target_is_locked ){
+	if ( tinfo.locked ){
 		sinfo |= SFPF_TARGET_LOCKED;
 	}
 
@@ -3095,14 +3092,14 @@ void send_secondary_fired_packet( ship *shipp, ushort starting_sig, int  /*start
 	// add the ship's target and any targeted subsystem
 	target_net_signature = 0;
 	s_index = -1;
-	if ( aip->target_objnum != -1) {
-		target_net_signature = Objects[aip->target_objnum].net_signature;
-		if ( (Objects[aip->target_objnum].type == OBJ_SHIP) && (aip->targeted_subsys != NULL) ) {
-			s_index = ship_get_subsys_index( aip->targeted_subsys );
+	if (tinfo.objnum != -1) {
+		target_net_signature = Objects[tinfo.objnum].net_signature;
+		if ( (Objects[tinfo.objnum].type == OBJ_SHIP) && (tinfo.subsys != nullptr) ) {
+			s_index = ship_get_subsys_index( tinfo.subsys );
 		}
 
-		if ( Objects[aip->target_objnum].type == OBJ_WEAPON ) {
-			Assert(Weapon_info[Weapons[Objects[aip->target_objnum].instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Bomb]);
+		if ( Objects[tinfo.objnum].type == OBJ_WEAPON ) {
+			Assert(Weapon_info[Weapons[Objects[tinfo.objnum].instance].weapon_info_index].wi_flags[Weapon::Info_Flags::Bomb]);
 		}
 
 	}

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -30,6 +30,7 @@ class ship_subsys;
 struct log_entry;
 struct beam_fire_info;
 namespace animation { enum class ModelAnimationDirection; }
+struct tracking_info;
 
 // macros for building up packets -- to save on time and typing.  Important to note that local variables
 // must be named correctly
@@ -270,7 +271,7 @@ void send_game_info_packet( void );
 void send_leave_game_packet(short player_id = -1,int kicked_reason = -1,net_player *target = NULL);
 
 // send a packet indicating a secondary weapon was fired
-void send_secondary_fired_packet( ship *shipp, ushort starting_sig, int starting_count, int num_fired, int allow_swarm );
+void send_secondary_fired_packet( ship *shipp, ushort starting_sig, tracking_info &tinfo, int num_fired, int allow_swarm );
 
 // send a packet indicating a countermeasure was fired
 void send_countermeasure_fired_packet( object *objp, int cmeasure_count, int rand_val );

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -938,6 +938,13 @@ extern SCP_vector<int> Player_weapon_precedence;	// Vector of weapon types, prec
 
 #define WEAPON_INDEX(wp)			(int)(wp-Weapons)
 
+typedef struct tracking_info {
+	ship_subsys *subsys;
+	int objnum;
+	bool locked;
+
+	tracking_info() : subsys(nullptr), objnum(-1), locked(false) {}
+} tracking_info;
 
 int weapon_info_lookup(const char *name);
 int weapon_info_get_index(const weapon_info *wip);
@@ -989,6 +996,11 @@ int weapon_create( const vec3d *pos,
 		0.f
 	});
 void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, int target_objnum, int target_is_locked = 0, ship_subsys *target_subsys = NULL);
+
+inline void weapon_set_tracking_info(int weapon_objnum, int parent_objnum, tracking_info &tinfo)
+{
+	weapon_set_tracking_info(weapon_objnum, parent_objnum, tinfo.objnum, tinfo.locked, tinfo.subsys);
+}
 
 // gets the substitution pattern pointer for a given weapon
 // src_turret may be null


### PR DESCRIPTION
Multiple issues were discovered to be from improper targeting data in multi tracing back to the addition of multi-lock. This was due to differences in how targeting works in single/multi and de-sync of this info between server and client. Collecting accurate targeting data on the server and making sure that the client will use that data resolves the tracking and sync issues.