### PR TITLE
Fix QtFRED crash on startup in FastDebug

### DIFF
--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[]) {
 	qGuiApp->processEvents();
 	std::unique_ptr<Editor> fred(new Editor());
 
-	auto baseDir = QDir::toNativeSeparators(QDir::current().absolutePath());
+	auto baseDir = QDir::toNativeSeparators(QDir::current().absolutePath()).toStdString();
 
 	typedef std::unordered_map<SubSystem, QString> SubsystemMap;
 
@@ -174,7 +174,7 @@ int main(int argc, char* argv[]) {
 								 { SubSystem::ScriptingInitHook, app.tr("Running game init scripting hook") },
 	};
 
-	auto initSuccess = fso::fred::initialize(baseDir.toStdString(), argc, argv, fred.get(), [&](const SubSystem& which) {
+	auto initSuccess = fso::fred::initialize(baseDir, argc, argv, fred.get(), [&](const SubSystem& which) {
 		if (initializers.count(which)) {
 			splash.showMessage(initializers.at(which), Qt::AlignHCenter | Qt::AlignBottom, Qt::white);
 		}


### PR DESCRIPTION
This one got deeper into memory allocation and deallocation than I'm generally comfortable with but the crash happened while trying to deallocate the temporary string created by `baseDir.toStdString()` when `initialize()` cleans up after itself. I'm not sure if something during initialization is writing writing past the buffer or not (I think we'd have seen evidence of that elsewhere, so I'm inclined to think not) or perhaps the way the QString allocates the std::string is doing something unexpected. Either way, passing a full variable and letting our `main()` method handle deallocation gets QtFRED up and running in Release, FastDebug, and Debug.

Fixes #3919
Fixes #4181