### PR TITLE
remove "safe" versions of FD_SET/FD_ISSET

### DIFF
--- a/code/network/gtrack.cpp
+++ b/code/network/gtrack.cpp
@@ -382,7 +382,7 @@ void IdleGameTracker()
 
 	//Check for incoming
 	FD_ZERO(&read_fds);	// NOLINT
-	FD_SET_SAFE(Psnet_socket, &read_fds);
+	FD_SET(Psnet_socket, &read_fds);
 
 	if(SELECT(static_cast<int>(Psnet_socket+1),&read_fds,nullptr,nullptr,&timeout, PSNET_TYPE_GAME_TRACKER))
 	{

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -810,7 +810,7 @@ int psnet_send(net_addr *who_to_addr, void *data, int len, int np_index)	// NOLI
 	}
 
 	FD_ZERO(&wfds);
-	FD_SET_SAFE(Psnet_socket, &wfds);
+	FD_SET(Psnet_socket, &wfds);
 
 	timeout.tv_sec = 0;
 	timeout.tv_usec = 0;
@@ -821,7 +821,7 @@ int psnet_send(net_addr *who_to_addr, void *data, int len, int np_index)	// NOLI
 	}
 
 	// if the write file descriptor is not set, then bail!
-	if ( !FD_ISSET_SAFE(Psnet_socket, &wfds) ) {
+	if ( !FD_ISSET(Psnet_socket, &wfds) ) {
 		return 0;
 	}
 
@@ -1997,14 +1997,14 @@ void psnet_rel_connect_to_server(PSNET_SOCKET *socket, net_addr *server_addr)
 		timeout.tv_usec = 0;
 
 		FD_ZERO(&read_fds);
-		FD_SET_SAFE(Psnet_socket, &read_fds);
+		FD_SET(Psnet_socket, &read_fds);
 
 		if ( SELECT(static_cast<int>(Psnet_socket+1), &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE) == SOCKET_ERROR ) {
 			break;
 		}
 
 		// if the file descriptor is not set, then bail!
-		if ( !FD_ISSET_SAFE(Psnet_socket, &read_fds) ) {
+		if ( !FD_ISSET(Psnet_socket, &read_fds) ) {
 			break;
 		}
 
@@ -2042,14 +2042,14 @@ void psnet_rel_connect_to_server(PSNET_SOCKET *socket, net_addr *server_addr)
 		timeout.tv_usec = 0;
 
 		FD_ZERO(&read_fds);
-		FD_SET_SAFE(Psnet_socket, &read_fds);
+		FD_SET(Psnet_socket, &read_fds);
 
 		if ( SELECT(static_cast<int>(Psnet_socket+1), &read_fds, nullptr, nullptr, &timeout, PSNET_TYPE_RELIABLE) == SOCKET_ERROR ) {
 			break;
 		}
 
 		// if the file descriptor is not set, then bail!
-		if ( !FD_ISSET_SAFE(Psnet_socket, &read_fds) ) {
+		if ( !FD_ISSET(Psnet_socket, &read_fds) ) {
 			continue;
 		}
 

--- a/code/network/psnet2.h
+++ b/code/network/psnet2.h
@@ -107,9 +107,6 @@ extern unsigned int Serverconn;
 #define PSNET_IP_MODE_V6		(1<<1)
 #define PSNET_IP_MODE_DUAL		(PSNET_IP_MODE_V4|PSNET_IP_MODE_V6)
 
-#define FD_SET_SAFE(bit, set) FD_SET((bit < 0 || bit >= FD_SETSIZE ? 0 : bit), set)
-#define FD_ISSET_SAFE(bit, set) FD_ISSET((bit < 0 || bit >= FD_SETSIZE ? 0 : bit), set)
-
 // -------------------------------------------------------------------------------------------------------
 // PSNET 2 TOP LAYER FUNCTIONS - these functions simply buffer and store packets based upon type (see PSNET_TYPE_* defines)
 //

--- a/code/network/ptrack.cpp
+++ b/code/network/ptrack.cpp
@@ -623,7 +623,7 @@ void PollPTrackNet()
 	timeout.tv_usec=0;
 	
 	FD_ZERO(&read_fds);	// NOLINT
-	FD_SET_SAFE(Psnet_socket, &read_fds);
+	FD_SET(Psnet_socket, &read_fds);
 
 	if(SELECT(static_cast<int>(Psnet_socket+1), &read_fds,nullptr,nullptr,&timeout, PSNET_TYPE_USER_TRACKER)){
 		int bytesin;

--- a/code/network/valid.cpp
+++ b/code/network/valid.cpp
@@ -306,7 +306,7 @@ int ValidateUser(validate_id_request *valid_id, char *trackerid)
 			timeout.tv_usec=0;
 			
 			FD_ZERO(&read_fds);	// NOLINT
-			FD_SET_SAFE(Psnet_socket, &read_fds);
+			FD_SET(Psnet_socket, &read_fds);
 
 			while(SELECT(static_cast<int>(Psnet_socket+1),&read_fds,nullptr,nullptr,&timeout, PSNET_TYPE_VALIDATION))
 			{
@@ -357,7 +357,7 @@ void ValidIdle()
 	timeout.tv_usec=0;
 	
 	FD_ZERO(&read_fds);	// NOLINT
-	FD_SET_SAFE(Psnet_socket, &read_fds);
+	FD_SET(Psnet_socket, &read_fds);
 
 	if(SELECT(static_cast<int>(Psnet_socket+1),&read_fds,nullptr,nullptr,&timeout, PSNET_TYPE_VALIDATION)){
 		int bytesin;
@@ -385,7 +385,7 @@ void ValidIdle()
 		}
 
 		FD_ZERO(&read_fds);	// NOLINT
-		FD_SET_SAFE(Psnet_socket, &read_fds);
+		FD_SET(Psnet_socket, &read_fds);
 
 		//Check to make sure the packets ok
 		if ( (bytesin > 0) && (bytesin == inpacket.len) ) {
@@ -614,7 +614,7 @@ int ValidateMission(vmt_validate_mission_req_struct *valid_msn)
 				udp_packet_header inpacket;
 
 				FD_ZERO(&read_fds);	// NOLINT
-				FD_SET_SAFE(Psnet_socket, &read_fds);
+				FD_SET(Psnet_socket, &read_fds);
 
 				addrsize = sizeof(fromaddr);
 				RECVFROM(Psnet_socket, reinterpret_cast<char *>(&inpacket), sizeof(udp_packet_header), 0,
@@ -700,7 +700,7 @@ int ValidateSquadWar(squad_war_request *sw_req, squad_war_response *sw_resp)
 				udp_packet_header inpacket;
 
 				FD_ZERO(&read_fds);	// NOLINT
-				FD_SET_SAFE(Psnet_socket, &read_fds);
+				FD_SET(Psnet_socket, &read_fds);
 
 				addrsize = sizeof(fromaddr);
 				RECVFROM(Psnet_socket, reinterpret_cast<char *>(&inpacket), sizeof(udp_packet_header), 0,
@@ -794,7 +794,7 @@ int ValidateData(const vmt_valid_data_req_struct *vreq)
 				udp_packet_header inpacket;
 
 				FD_ZERO(&read_fds);	// NOLINT
-				FD_SET_SAFE(Psnet_socket, &read_fds);
+				FD_SET(Psnet_socket, &read_fds);
 
 				addrsize = sizeof(fromaddr);
 				RECVFROM(Psnet_socket, reinterpret_cast<char *>(&inpacket), sizeof(udp_packet_header), 0,


### PR DESCRIPTION
The socket is a value to be assigned, not an index to be used. As such there is no safety check to be done here and doing so just breaks things.

Fixes networking on Windows.