### PR TITLE
Allow shockwave orientations to be relative to their parents

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13408,7 +13408,7 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 									vm_vec_normalized_dir(&firing_vec, &predicted_target_pos, &obj->pos);
 								}
 
-								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, nullptr, nullptr);
+								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, &obj->orient.vec.uvec, &obj->orient.vec.rvec);
 							} else if (std_convergence_flagged || (auto_convergence_flagged && (aip->target_objnum != -1))) {
 								// std & auto convergence
 								vec3d target_vec, firing_vec, convergence_offset;
@@ -13435,12 +13435,12 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								vm_vec_normalized_dir(&firing_vec, &target_vec, &firing_pos);
 
 								// set orientation
-								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, nullptr, nullptr);
+								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, &obj->orient.vec.uvec, &obj->orient.vec.rvec);
 							} else if (sip->flags[Ship::Info_Flags::Gun_convergence]) {
 								// model file defined convergence
 								vec3d firing_vec;
 								vm_vec_unrotate(&firing_vec, &pm->gun_banks[bank_to_fire].norm[pt], &obj->orient);
-								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, nullptr, nullptr);
+								vm_vector_2_matrix_norm(&firing_orient, &firing_vec, &obj->orient.vec.uvec, &obj->orient.vec.rvec);
 							}
 
 							if (winfo_p->wi_flags[Weapon::Info_Flags::Apply_Recoil]){	// Function to add recoil functionality - DahBlount
@@ -14281,7 +14281,7 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 			{
 				vec3d firing_vec;
 				vm_vec_unrotate(&firing_vec, &pm->missile_banks[bank].norm[pnt_index-1], &obj->orient);
-				vm_vector_2_matrix_norm(&firing_orient, &firing_vec, nullptr, nullptr);
+				vm_vector_2_matrix_norm(&firing_orient, &firing_vec, &obj->orient.vec.uvec, &obj->orient.vec.rvec);
 			}
 
 			// create the weapon -- for multiplayer, the net_signature is assigned inside

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -173,6 +173,10 @@ int shockwave_create(int parent_objnum, const vec3d* pos, const shockwave_create
 
 	orient = vmd_identity_matrix;
 	vm_angles_2_matrix(&orient, &sw->rot_angles);
+	if (sci->rot_parent_relative) {
+		
+	}
+
     flagset<Object::Object_Flags> tmp_flags;
 	objnum = obj_create( OBJ_SHOCKWAVE, real_parent, i, &orient, &sw->pos, sw->outer_radius, tmp_flags + Object::Object_Flags::Renders, false );
 

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -174,7 +174,7 @@ int shockwave_create(int parent_objnum, const vec3d* pos, const shockwave_create
 	orient = vmd_identity_matrix;
 	vm_angles_2_matrix(&orient, &sw->rot_angles);
 	if (sci->rot_parent_relative) {
-		
+		orient = orient * Objects[parent_objnum].orient;
 	}
 
     flagset<Object::Object_Flags> tmp_flags;

--- a/code/weapon/shockwave.h
+++ b/code/weapon/shockwave.h
@@ -83,6 +83,7 @@ typedef struct shockwave_create_info {
 	int radius_curve_idx;   // curve for shockwave radius over time
 	angles rot_angles;
 	bool rot_defined;		// if the modder specified rot_angles
+	bool rot_parent_relative = false;
 	bool damage_overridden;  // did this have shockwave damage specifically set or not
 
 	int damage_type_idx;

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -618,6 +618,11 @@ void parse_shockwave_info(shockwave_create_info *sci, const char *pre_char)
 		sci->rot_defined = true;
 	}
 
+	sprintf(buf, "%sShockwave Rotation Is Relative To Parent:", pre_char);
+	if(optional_string(buf.c_str())) {
+		stuff_boolean(&sci->rot_parent_relative);
+	}
+
 	sprintf(buf, "%sShockwave Model:", pre_char);
 	if(optional_string(buf.c_str())) {
 		stuff_string(sci->pof_name, F_NAME, MAX_FILENAME_LEN);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -7270,7 +7270,7 @@ void spawn_child_weapons(object *objp, int spawn_index_override)
 				// fire the beam
 				beam_fire(&fire_info);
 			} else {
-				vm_vector_2_matrix_norm(&orient, &tvec, nullptr, nullptr);
+				vm_vector_2_matrix_norm(&orient, &tvec, &objp->orient.vec.uvec, &objp->orient.vec.rvec);
 				weapon_objnum = weapon_create(&pos, &orient, child_id, parent_num, -1, wp->weapon_flags[Weapon::Weapon_Flags::Locked_when_fired], true);
 
 				//if the child inherits parent target, do it only if the parent weapon was locked to begin with


### PR DESCRIPTION
Add a weapon parameter to make it so that the shockwave's orientation will be oriented locally rather than globally. The manual orientation offset still works, but is now relative. Also, fix some issues with weapons not inheriting as much parent orientation as they could under a few different circumstances.