### PR TITLE
Fix/enhance skybox submodel rendering

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -27,6 +27,7 @@
 
 int Directive_wait_time;
 bool True_loop_argument_sexps;
+bool Skybox_internal_depth_consistency;
 bool Fixed_turret_collisions;
 bool Fixed_missile_detonation;
 bool Damage_impacted_subsystem_first;
@@ -1137,6 +1138,10 @@ void parse_mod_table(const char *filename)
 
 			}
 
+			if (optional_string("$Skybox internal depth consistency:")) {
+				stuff_boolean(&Skybox_internal_depth_consistency);
+			}
+
 			optional_string("#OTHER SETTINGS");
 
 			if (optional_string("$Fixed Turret Collisions:")) {
@@ -1640,6 +1645,7 @@ void mod_table_reset()
 {
 	Directive_wait_time = 3000;
 	True_loop_argument_sexps = false;
+	Skybox_internal_depth_consistency = false;
 	Fixed_turret_collisions = false;
 	Fixed_missile_detonation = false;
 	Damage_impacted_subsystem_first = false;
@@ -1820,5 +1826,6 @@ void mod_table_set_version_flags()
 		Use_model_eyepoint_normals = true;
 		Fix_asteroid_bounding_box_check = true;
 		Disable_expensive_turret_target_check = true;
+		Skybox_internal_depth_consistency = true;
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -41,6 +41,7 @@ struct splash_screen {
 
 extern int Directive_wait_time;
 extern bool True_loop_argument_sexps;
+extern bool Skybox_internal_depth_consistency;
 extern bool Fixed_turret_collisions;
 extern bool Fixed_missile_detonation;
 extern bool Damage_impacted_subsystem_first;

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2322,7 +2322,19 @@ void stars_draw_background()
 	if (Nmodel_instance_num >= 0)
 		render_info.set_replacement_textures(model_get_instance(Nmodel_instance_num)->texture_replace);
 
+	// if No Z-Buffer is on in FRED then check mod flag to see 
+	// if skybox submodels should still have proper z-sorting
+	// wookieejedi
+	bool special_z_buff = ((Nmodel_flags & MR_NO_ZBUFFER) && Skybox_internal_depth_consistency);
+	if (special_z_buff) {
+		render_info.set_flags(Nmodel_flags & ~MR_NO_ZBUFFER);
+	}
+
 	model_render_immediate(&render_info, Nmodel_num, Nmodel_instance_num, &Nmodel_orient, &Eye_position, MODEL_RENDER_ALL, false);
+
+	if (special_z_buff) {
+		gr_zbuffer_clear(TRUE);
+	}
 }
 
 void stars_set_background_model(int new_model, int new_bitmap, uint64_t flags, float alpha)


### PR DESCRIPTION
Background:
Currently, skybox models can be set in FRED to have `No Z-Buffer` on or off. It is off by default, which is good because it ensures ships and other game objects cannot be rendered behind a skybox. Critically though, skybox models may have sub-models, especially now that animated sub-models are a feature (thanks to BMagnu!). If a skybox is using sub-models and `No Z-Buffer` is turned off, then there will be no proper model occlusion for the skybox and there will be ugly z fighting. Overall, BMangu stated "we could clear the depth buffer after the skybox with another flag".

Update
This PR fixes that issue by adding a new FRED game settings flag, `$Skybox internal depth consistency:` which when set to yes properly ensures there is internally consistency z-sorting with the skybox and any submodels it may have while at the same time ensuring that if `No Z-Buffer` is set in FRED that the skybox still correctly is always drawn behind mission objects like ships/debris.

Many thanks to @Bmagnu for the discussion and help in identifying and creating a proper fix for this issue that is clean, surgical, and supports all existing uses of `No Z-Buffer`.

Tested and works as expected. Fixes #6913.