### PR TITLE
Allow background option to completely work (VR useful)

### DIFF
--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -2305,6 +2305,10 @@ void stars_draw_background()
 		return;
 	}
 
+	// detail settings
+	if (!Detail.planets_suns)
+		return;
+
 	if (Nmodel_num < 0)
 		return;
 


### PR DESCRIPTION
From discussion with VR players, it appears that being able to toggle off the skybox/starfield/planet background is very useful to some players to prevent motion sickness. Currently, FSO has the toggle in the Graphics Options window for `Planets/Backgrounds` but it only turns off planet bitmaps. 

This 3 line PR suggests it should be expanded into an accessibility role for players, and properly turn off all background elements--so planets, plus skybox rendering (especially now since most mods also use skyboxes as backgrounds, whereas in early days this was not primarily the case).

Happy to discuss and/or add as a flag if folks think that would be needed.