### PR TITLE
Fix QtFRED weapon quantities

### DIFF
--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -186,7 +186,6 @@ void Editor::maybeUseAutosave(std::string& filepath)
 bool Editor::loadMission(const std::string& mission_name, int flags) {
 	char name[512], * old_name;
 	int i, j, k, ob;
-	int used_pool[MAX_WEAPON_TYPES];
 	object* objp;
 
 	// activate the localizer hash table
@@ -334,6 +333,10 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 			}
 		}
 	}
+
+	int used_pool[MAX_WEAPON_TYPES] = {};
+	for (auto& pool : used_pool)
+		pool = 0; 
 
 	for (i = 0; i < Num_teams; i++) {
 		generate_team_weaponry_usage_list(i, _weapon_usage[i]);


### PR DESCRIPTION
This fixes #6470 by initializing the `use_pool` variable with zero'd data.

I'm not sure if this whole loop with `used_pool` is unfinished code or not. I couldn't find a sister function in FRED, though I may have simply missed it. I don't expect this whole thing is working as intended but I'll untangle it when I get to the loadout editor dialog. For now this fixes QtFRED loading/saving by making sure we aren't `-=` the loadout values with garbage data.