### PR TITLE
Particle effect hooks for subsystem destruction

### DIFF
--- a/code/model/model.h
+++ b/code/model/model.h
@@ -23,6 +23,7 @@
 #include "model/model_flags.h"
 #include "object/object.h"
 #include "ship/ship_flags.h"
+#include "particle/ParticleEffect.h"
 
 class object;
 class ship_info;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -293,6 +293,8 @@ public:
 
 	float density;
 
+	particle::ParticleEffectHandle death_effect;
+
     void reset();
 
     model_subsystem();

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -85,6 +85,7 @@ bool ParticleSource::process() {
 }
 
 void ParticleSource::setNormal(const vec3d& normal) {
+	Assertion(vm_vec_is_normalized(&normal), "Particle source normal must be normalized!");
 	m_normal = normal;
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1347,6 +1347,8 @@ void ship_info::clone(const ship_info& other)
 	ship_passive_arcs = other.ship_passive_arcs;
 
 	glowpoint_bank_override_map = other.glowpoint_bank_override_map;
+
+	default_subsys_death_effect = other.default_subsys_death_effect; 
 }
 
 void ship_info::move(ship_info&& other)
@@ -1688,6 +1690,8 @@ void ship_info::move(ship_info&& other)
 
 	animations = std::move(other.animations);
 	cockpit_animations = std::move(other.cockpit_animations);
+
+	default_subsys_death_effect = std::move(other.default_subsys_death_effect);
 }
 
 ship_info &ship_info::operator= (ship_info&& other) noexcept
@@ -2076,6 +2080,8 @@ ship_info::ship_info()
 	glowpoint_bank_override_map.clear();
 
 	ship_passive_arcs.clear();
+
+	default_subsys_death_effect = particle::ParticleEffectHandle::invalid();
 }
 
 ship_info::~ship_info()
@@ -5559,6 +5565,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				sp->turret_max_bomb_ownage = -1;
 				sp->turret_max_target_ownage = -1;
 				sp->density = 1.0f;
+				sp->death_effect = particle::ParticleEffectHandle::invalid();
 			}
 			sfo_return = stuff_float_optional(&percentage_of_hits);
 			if(sfo_return==2)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1691,7 +1691,7 @@ void ship_info::move(ship_info&& other)
 	animations = std::move(other.animations);
 	cockpit_animations = std::move(other.cockpit_animations);
 
-	default_subsys_death_effect = std::move(other.default_subsys_death_effect);
+	default_subsys_death_effect = other.default_subsys_death_effect;
 }
 
 ship_info &ship_info::operator= (ship_info&& other) noexcept

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5458,6 +5458,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		required_string("$end_custom_strings");
 	}
 
+	if (optional_string("$Default Subsystem Death Effect:")) {
+		sip->default_subsys_death_effect = particle::util::parseEffect(sip->name);
+	}
+
 	int n_subsystems = 0;
 	int n_excess_subsystems = 0;
 	int cont_flag = 1;
@@ -5739,6 +5743,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 						Warning(LOCATION, "RoF multiplier not set for subsystem\n'%s' in %s '%s'.", sp->subobj_name, info_type_name, sip->name);
 					}
 				}
+			}
+
+			if (optional_string("$Subsystem Death Effect:")) {
+				sp->death_effect = particle::util::parseEffect(sip->name);
 			}
 
 			if (optional_string("$Debris Density:")) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5496,6 +5496,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 	if (optional_string("$Default Subsystem Death Effect:")) {
 		sip->default_subsys_death_effect = particle::util::parseEffect(sip->name);
+	}
 
 	if(optional_string("$Default Subsystem Debris Flame Effect:"))
 	{

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1257,6 +1257,7 @@ public:
 	// subsystem information
 	int		n_subsystems;						// this number comes from ships.tbl
     model_subsystem *subsystems;				// see model.h for structure definition
+	particle::ParticleEffectHandle default_subsys_death_effect;
 
 	// Energy Transfer System fields
 	float		power_output;					// power output of ships reactor (EU/s)

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -90,7 +90,7 @@ void model_get_rotating_submodel_axis(vec3d *model_axis, vec3d *world_axis, cons
  *
  * DKA: 5/26/99 make velocity of debris scale according to size of debris subobject (at least for large subobjects)
  */
-static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, const ship *ship_p, const ship_subsys *subsys, const vec3d *exp_center, float exp_mag)
+static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, const ship *ship_p, const ship_subsys *subsys, const vec3d *exp_center, float exp_mag, bool no_fireballs = false)
 {
 	// initializations
 	ship *shipp = &Ships[ship_objp->instance];
@@ -146,8 +146,11 @@ static void shipfx_subsystem_maybe_create_live_debris(object *ship_objp, const s
 		if(fireball_type < 0) {
 			fireball_type = FIREBALL_EXPLOSION_MEDIUM;
 		}
-		// create fireball here.
-		fireball_create(&end_world_pos, fireball_type, FIREBALL_MEDIUM_EXPLOSION, OBJ_INDEX(ship_objp), pm->submodel[live_debris_submodel].rad);
+
+		if (!no_fireballs) {
+			// create fireball here.
+			fireball_create(&end_world_pos, fireball_type, FIREBALL_MEDIUM_EXPLOSION, OBJ_INDEX(ship_objp), pm->submodel[live_debris_submodel].rad);
+		}
 
 		// create debris
 		live_debris_obj = debris_create(ship_objp, pm->id, live_debris_submodel, &end_world_pos, exp_center, 1, exp_mag, subsys);
@@ -269,7 +272,7 @@ static void shipfx_maybe_create_live_debris_at_ship_death( object *ship_objp )
 	}
 }
 
-void shipfx_blow_off_subsystem(object *ship_objp, ship *ship_p, const ship_subsys *subsys, const vec3d *exp_center, bool no_explosion)
+void shipfx_blow_off_subsystem(object *ship_objp, ship *ship_p, const ship_subsys *subsys, const vec3d *exp_center, bool no_explosion, bool no_fireballs)
 {
 	vec3d subobj_pos;
 
@@ -286,14 +289,16 @@ void shipfx_blow_off_subsystem(object *ship_objp, ship *ship_p, const ship_subsy
 
 		// create live debris objects, if any
 		// TODO:  some MULTIPLAYER implcations here!!
-		shipfx_subsystem_maybe_create_live_debris(ship_objp, ship_p, subsys, exp_center, 1.0f);
+		shipfx_subsystem_maybe_create_live_debris(ship_objp, ship_p, subsys, exp_center, 1.0f, no_fireballs);
 		
-		int fireball_type = fireball_ship_explosion_type(&Ship_info[ship_p->ship_info_index]);
-		if(fireball_type < 0) {
-			fireball_type = FIREBALL_EXPLOSION_MEDIUM;
+		if (!no_fireballs) {
+			int fireball_type = fireball_ship_explosion_type(&Ship_info[ship_p->ship_info_index]);
+			if(fireball_type < 0) {
+				fireball_type = FIREBALL_EXPLOSION_MEDIUM;
+			}
+			// create first fireball
+			fireball_create( &subobj_pos, fireball_type, FIREBALL_MEDIUM_EXPLOSION, OBJ_INDEX(ship_objp), psub->radius );
 		}
-		// create first fireball
-		fireball_create( &subobj_pos, fireball_type, FIREBALL_MEDIUM_EXPLOSION, OBJ_INDEX(ship_objp), psub->radius );
 	}
 }
 

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -32,7 +32,7 @@ struct matrix;
 void shipfx_emit_spark( int n, int sn );
 
 // Does the special effects to blow a subsystem off a ship
-extern void shipfx_blow_off_subsystem(object *ship_obj, ship *ship_p, const ship_subsys *subsys, const vec3d *exp_center, bool no_explosion = false);
+extern void shipfx_blow_off_subsystem(object *ship_obj, ship *ship_p, const ship_subsys *subsys, const vec3d *exp_center, bool no_explosion = false, bool no_fireballs = false);
 
 // Creates "ndebris" pieces of debris on random verts of the "submodel" in the 
 // ship's model.

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -176,11 +176,13 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d* 
 			} else {
 				subsys_local_pos = psub->pnt;
 			}
+			vec3d normalized_center_to_subsys = center_to_subsys;
+			vm_vec_normalize(&normalized_center_to_subsys);
 			// spawn particle effect
 			auto source = particle::ParticleManager::get()->createSource(death_effect);
-			source->setHost(make_unique<EffectHostObject>(ship_objp, subsys_local_pos, ship_objp->orient));
+			source->setHost(make_unique<EffectHostObject>(ship_objp, subsys_local_pos, vmd_identity_matrix));
 			source->setTriggerRadius(psub->radius);
-			source->setNormal(center_to_subsys);
+			source->setNormal(normalized_center_to_subsys);
 			source->finishCreation();
 		} else if (ship_objp->radius > 100.0f) {
 			// number of fireballs determined by radius of subsys

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -157,7 +157,32 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d* 
 
 	// create fireballs when subsys destroy for large ships.
 	if (!(subsys->flags[Ship::Subsystem_Flags::Vanished, Ship::Subsystem_Flags::No_disappear]) && !no_explosion) {
-		if (ship_objp->radius > 100.0f) {
+		vec3d center_to_subsys;
+		vm_vec_sub(&center_to_subsys, &g_subobj_pos, &ship_objp->pos);
+
+		particle::ParticleEffectHandle death_effect;
+
+		if (psub->death_effect.isValid()) {
+			death_effect = psub->death_effect;
+		} else {
+			death_effect = sip->default_subsys_death_effect;
+		}
+
+		if (death_effect.isValid()) {
+			vec3d subsys_local_pos;
+			if (psub->subobj_num >= 0) {
+				// the vmd_zero_vector here should probably be psub->pnt instead, but this matches the behavior of get_subsystem_world_pos
+				model_instance_local_to_global_point(&subsys_local_pos, &vmd_zero_vector, ship_p->model_instance_num, psub->subobj_num);
+			} else {
+				subsys_local_pos = psub->pnt;
+			}
+			// spawn particle effect
+			auto source = particle::ParticleManager::get()->createSource(death_effect);
+			source->setHost(make_unique<EffectHostObject>(&ship_objp, subsys_local_pos));
+			source->setTriggerRadius(psub->radius);
+			source->setNormal(center_to_subsys);
+			source->finishCreation();
+		} else if (ship_objp->radius > 100.0f) {
 			// number of fireballs determined by radius of subsys
 			int num_fireballs;
 			if ( psub->radius < 3 ) {
@@ -166,8 +191,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d* 
 				 num_fireballs = 5;
 			}
 
-			vec3d temp_vec, center_to_subsys, rand_vec;
-			vm_vec_sub(&center_to_subsys, &g_subobj_pos, &ship_objp->pos);
+			vec3d temp_vec, rand_vec;
 			for (i=0; i<num_fireballs; i++) {
 				if (i==0) {
 					// make first fireball at hitpos

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -178,7 +178,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d* 
 			}
 			// spawn particle effect
 			auto source = particle::ParticleManager::get()->createSource(death_effect);
-			source->setHost(make_unique<EffectHostObject>(&ship_objp, subsys_local_pos));
+			source->setHost(make_unique<EffectHostObject>(ship_objp, subsys_local_pos, ship_objp->orient));
 			source->setTriggerRadius(psub->radius);
 			source->setNormal(center_to_subsys);
 			source->finishCreation();
@@ -332,9 +332,11 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d* 
 			));
 	}
 
+	bool no_fireballs = psub->death_effect.isValid() || sip->default_subsys_death_effect.isValid();
+
 	if (!(subsys->flags[Ship::Subsystem_Flags::No_disappear])) {
 		if (psub->subobj_num > -1) {
-			shipfx_blow_off_subsystem(ship_objp, ship_p, subsys, &g_subobj_pos, no_explosion);
+			shipfx_blow_off_subsystem(ship_objp, ship_p, subsys, &g_subobj_pos, no_explosion, no_fireballs);
 			subsys->submodel_instance_1->blown_off = true;
 		}
 


### PR DESCRIPTION
Adds the ability to spawn particle effects when a ship subsystem is destroyed. A default can be set for the entire ship, and subsystem-specific effects can also be defined. If a subsystem's death is spawning a particle effect, none of the retail fireballs for it will be spawned.