### PR TITLE
restore inadvertently deleted code

### DIFF
--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -3080,6 +3080,11 @@ void ship_apply_global_damage(object *ship_objp, object *other_obj, const vec3d 
 		// shield_quad = quadrant facing the force_center
 		shield_quad = get_quadrant(&local_hitpos, ship_objp);
 
+		// world_hitpos use force_center for shockwave
+		// Goober5000 check for NULL
+		if (other_obj && (other_obj->type == OBJ_SHOCKWAVE) && (Ship_info[Ships[ship_objp->instance].ship_info_index].is_huge_ship()))
+			world_hitpos = *force_center;
+
 		int wip_index = -1;
 		if(other_obj != nullptr && other_obj->type == OBJ_SHOCKWAVE)
 			wip_index = shockwave_get_weapon_index(other_obj->instance);


### PR DESCRIPTION
This has an interesting history.  In the original Volition source release, global damage was set to originate from the shockwave position, which would have avoided the fireball issue fixed by #6882.  (Technically, though, this was only done for huge ships which would have still left the problem for smaller ships.)  In c2716d4ee879e22671971d6be5a165d21bccef4b, this code was changed to run in non-HTL mode in an attempt to fix a bug.  Then in 70529dbd5a2e64c188675fbec086c5e7d5fa05ea, as part of the removal of non-HTL mode, the code was entirely deleted.  So, this restores the code.

The #6882 fix is still valid, both because it works for non-huge ships, and because shockwaves may not necessarily originate from the subobject being destroyed.  The #6882 fix also subsumes the effect of the restored code, but it's still good to restore the code in case future development may depend on it.