### PR TITLE
QtFRED Flag List Widget

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -190,6 +190,8 @@ add_file_folder("Source/UI/Util"
 add_file_folder("Source/UI/Widgets"
     src/ui/widgets/ColorComboBox.cpp
     src/ui/widgets/ColorComboBox.h
+	src/ui/widgets/FlagList.cpp
+	src/ui/widgets/FlagList.h
     src/ui/widgets/renderwidget.cpp
     src/ui/widgets/renderwidget.h
 	src/ui/widgets/sexp_tree.cpp

--- a/qtfred/src/ui/widgets/FlagList.cpp
+++ b/qtfred/src/ui/widgets/FlagList.cpp
@@ -1,0 +1,249 @@
+#include "ui/widgets/FlagList.h"
+
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QListView>
+#include <QRegularExpression>
+#include <QScrollBar>
+#include <QSortFilterProxyModel>
+#include <QStandardItem>
+#include <QStandardItemModel>
+#include <QToolButton>
+#include <QVBoxLayout>
+
+namespace fso::fred {
+
+FlagListWidget::FlagListWidget(QWidget* parent) : QWidget(parent)
+{
+	buildUi();
+	connectSignals();
+
+	setFilterVisible(true);
+	setToolbarVisible(true);
+}
+
+FlagListWidget::~FlagListWidget() = default;
+
+void FlagListWidget::buildUi()
+{
+	auto* outer = new QVBoxLayout(this);
+	outer->setContentsMargins(0, 0, 0, 0);
+	outer->setSpacing(6);
+
+	// filter row
+	auto* filterRow = new QHBoxLayout();
+	filterRow->setContentsMargins(0, 0, 0, 0);
+	filterRow->setSpacing(6);
+
+	_filter = new QLineEdit(this);
+	_filter->setPlaceholderText(tr("Filter flags..."));
+	filterRow->addWidget(_filter, /*stretch*/ 1);
+
+	// toolbar
+	_btnAll = new QToolButton(this);
+	_btnAll->setText(tr("All"));
+	_btnAll->setToolTip(tr("Select all"));
+
+	_btnNone = new QToolButton(this);
+	_btnNone->setText(tr("None"));
+	_btnNone->setToolTip(tr("Clear all"));
+
+	filterRow->addWidget(_btnAll);
+	filterRow->addWidget(_btnNone);
+
+	outer->addLayout(filterRow);
+
+	// list view and setup
+	_model = new QStandardItemModel(this);
+
+	_proxy = new QSortFilterProxyModel(this);
+	_proxy->setSourceModel(_model);
+	_proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
+	_proxy->setFilterRole(Qt::DisplayRole);
+	_proxy->setSortRole(Qt::DisplayRole);
+	_proxy->setDynamicSortFilter(true);
+
+	_list = new QListView(this);
+	_list->setModel(_proxy);
+	_list->setUniformItemSizes(true);
+	_list->setSelectionMode(QAbstractItemView::NoSelection);
+	_list->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	_list->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+
+	outer->addWidget(_list, /*stretch*/ 1);
+
+	setLayout(outer);
+}
+
+void FlagListWidget::connectSignals()
+{
+	// React to user toggles
+	connect(_model, &QStandardItemModel::itemChanged, this, &FlagListWidget::onItemChanged);
+	// Filter field
+	connect(_filter, &QLineEdit::textChanged, this, &FlagListWidget::onFilterTextChanged);
+	// Toolbar actions
+	connect(_btnAll, &QToolButton::clicked, this, &FlagListWidget::onSelectAll);
+	connect(_btnNone, &QToolButton::clicked, this, &FlagListWidget::onClearAll);
+}
+
+void FlagListWidget::setFlags(const QVector<std::pair<QString, bool>>& flags)
+{
+	rebuildModel(flags);
+}
+
+void FlagListWidget::setFlagDescriptions(const QVector<std::pair<QString, QString>>& descriptions)
+{
+	_descByName.clear();
+	_descByName.reserve(descriptions.size());
+	for (const auto& p : descriptions) {
+		_descByName.insert(p.first, p.second);
+	}
+	applyTooltipsToItems(); // apply immediately if items already exist
+}
+
+void FlagListWidget::rebuildModel(const QVector<std::pair<QString, bool>>& flags)
+{
+	_updating = true;
+
+	_model->clear();
+	_model->setColumnCount(1);
+
+	_model->setHorizontalHeaderLabels({tr("Flag")});
+
+	_model->insertRows(0, flags.size());
+	for (int i = 0; i < flags.size(); ++i) {
+		const auto& name = flags[i].first;
+		const bool checked = flags[i].second;
+
+		auto* item = new QStandardItem(name);
+		item->setCheckable(true);
+		item->setCheckState(checked ? Qt::Checked : Qt::Unchecked);
+		item->setData(name, KeyRole);
+
+		// If we have a description for this flag, set it as tooltip
+		const auto it = _descByName.constFind(name);
+		if (it != _descByName.constEnd())
+			item->setToolTip(*it);
+
+		_model->setItem(i, 0, item);
+	}
+
+	// Reapply filter text so a rebuild respects current filter
+	onFilterTextChanged(_filter->text());
+
+	_updating = false;
+
+	Q_EMIT flagsChanged(snapshot());
+}
+
+void FlagListWidget::applyTooltipsToItems()
+{
+	// Apply descriptions to existing items (used when descriptions are set after setFlags)
+	for (int r = 0; r < _model->rowCount(); ++r) {
+		if (auto* it = _model->item(r, 0)) {
+			const auto key = it->data(KeyRole).toString();
+			const auto dIt = _descByName.constFind(key);
+			it->setToolTip(dIt != _descByName.constEnd() ? *dIt : QString());
+		}
+	}
+}
+
+QVector<std::pair<QString, bool>> FlagListWidget::getFlags() const
+{
+	return snapshot();
+}
+
+void FlagListWidget::clear()
+{
+	_updating = true;
+	_model->clear();
+	_updating = false;
+	Q_EMIT flagsChanged({});
+}
+
+void FlagListWidget::setFilterVisible(bool visible)
+{
+	_filterVisible = visible;
+	if (_filter)
+		_filter->setVisible(visible);
+}
+
+bool FlagListWidget::filterVisible() const
+{
+	return _filterVisible;
+}
+
+void FlagListWidget::setToolbarVisible(bool visible)
+{
+	_toolbarVisible = visible;
+	if (_btnAll)
+		_btnAll->setVisible(visible);
+	if (_btnNone)
+		_btnNone->setVisible(visible);
+}
+
+bool FlagListWidget::toolbarVisible() const
+{
+	return _toolbarVisible;
+}
+
+void FlagListWidget::onItemChanged(QStandardItem* item)
+{
+	if (_updating || !item)
+		return;
+
+	const auto name = item->data(KeyRole).toString();
+	const bool checked = (item->checkState() == Qt::Checked);
+
+	Q_EMIT flagToggled(name, checked);
+	Q_EMIT flagsChanged(snapshot());
+}
+
+void FlagListWidget::onFilterTextChanged(const QString& text)
+{
+	// Use a simple contains filter
+	QRegularExpression re(QRegularExpression::escape(text), QRegularExpression::CaseInsensitiveOption);
+	// Convert to text to emulate substring
+	const QString pattern = QStringLiteral(".*%1.*").arg(re.pattern());
+	_proxy->setFilterRegularExpression(QRegularExpression(pattern, QRegularExpression::CaseInsensitiveOption));
+}
+
+void FlagListWidget::onSelectAll()
+{
+	_updating = true;
+	for (int r = 0; r < _model->rowCount(); ++r) {
+		if (auto* it = _model->item(r, 0)) {
+			it->setCheckState(Qt::Checked);
+		}
+	}
+	_updating = false;
+	Q_EMIT flagsChanged(snapshot());
+}
+
+void FlagListWidget::onClearAll()
+{
+	_updating = true;
+	for (int r = 0; r < _model->rowCount(); ++r) {
+		if (auto* it = _model->item(r, 0)) {
+			it->setCheckState(Qt::Unchecked);
+		}
+	}
+	_updating = false;
+	Q_EMIT flagsChanged(snapshot());
+}
+
+QVector<std::pair<QString, bool>> FlagListWidget::snapshot() const
+{
+	QVector<std::pair<QString, bool>> out;
+	out.reserve(_model->rowCount());
+	for (int r = 0; r < _model->rowCount(); ++r) {
+		if (auto* it = _model->item(r, 0)) {
+			const auto key = it->data(KeyRole).toString();
+			const bool checked = (it->checkState() == Qt::Checked);
+			out.append({key, checked});
+		}
+	}
+	return out;
+}
+
+} // namespace fso::fred

--- a/qtfred/src/ui/widgets/FlagList.h
+++ b/qtfred/src/ui/widgets/FlagList.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <QString>
+#include <QVector>
+#include <QWidget>
+#include <QHash>
+#include <string>
+#include <vector>
+
+class QLineEdit;
+class QToolButton;
+class QListView;
+class QStandardItemModel;
+class QSortFilterProxyModel;
+class QStandardItem;
+
+namespace fso::fred {
+
+class FlagListWidget final : public QWidget {
+	Q_OBJECT
+	Q_PROPERTY(bool filterVisible READ filterVisible WRITE setFilterVisible)
+	Q_PROPERTY(bool toolbarVisible READ toolbarVisible WRITE setToolbarVisible)
+
+  public:
+	explicit FlagListWidget(QWidget* parent = nullptr);
+	~FlagListWidget() override;
+
+	void setFlags(const QVector<std::pair<QString, bool>>& flags);
+
+	// Optionally set descriptions
+	void setFlagDescriptions(const QVector<std::pair<QString, QString>>& descriptions);
+
+	// Read back the entire list and their checked states
+	QVector<std::pair<QString, bool>> getFlags() const;
+
+	// Optional UI controls
+	void setFilterVisible(bool visible);
+	bool filterVisible() const;
+
+	void setToolbarVisible(bool visible);
+	bool toolbarVisible() const;
+
+	// Clear all items
+	void clear();
+
+  signals:
+	// Emitted whenever a checkbox is toggled
+	void flagToggled(const QString& name, bool checked);
+	// Emitted after any change that alters the entire set
+	void flagsChanged(const QVector<std::pair<QString, bool>>& flags);
+
+  private slots:
+	void onItemChanged(QStandardItem* item);
+	void onFilterTextChanged(const QString& text);
+	void onSelectAll();
+	void onClearAll();
+
+  private:
+	enum Roles : int {
+		KeyRole = Qt::UserRole + 1
+	};
+
+	void buildUi();
+	void connectSignals();
+	void rebuildModel(const QVector<std::pair<QString, bool>>& flags);
+	void applyTooltipsToItems();
+	QVector<std::pair<QString, bool>> snapshot() const;
+
+	QLineEdit* _filter = nullptr;
+	QToolButton* _btnAll = nullptr;
+	QToolButton* _btnNone = nullptr;
+	QListView* _list = nullptr;
+	QStandardItemModel* _model = nullptr;
+	QSortFilterProxyModel* _proxy = nullptr;
+
+	QHash<QString, QString> _descByName;
+
+	bool _updating = false; // guards against emitting signals during programmatic changes
+	bool _filterVisible = true;
+	bool _toolbarVisible = true;
+};
+
+} // namespace fso::fred


### PR DESCRIPTION
Adds a re-usable widget for easy display and handling of lists of flags. Will allow the UI to automatically show all relevant flags without any coder interaction with the UI code. Intended for places such as the Mission flags, ship flags, wing flags, and others.

Intentionally works with a vector of pairs (string, bool) to be flag type agnostic. The calling data model can translate between the flagset and the pair vector.

See this video for an example.

https://github.com/user-attachments/assets/ff5f19e2-cc69-4bfd-88b4-9162f6e05058