### PR TITLE
fix end-mission sexp in multi

### DIFF
--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -3952,22 +3952,6 @@ void process_ingame_nak(ubyte *data, header *hinfo)
 	}	
 }
 
-// If the end_mission SEXP has been used tell clients to skip straight to the debrief screen
-void send_force_end_mission_packet()
-{
-	ubyte data[MAX_PACKET_SIZE];
-	int packet_size;
-	
-	packet_size = 0;
-	BUILD_HEADER(FORCE_MISSION_END);	
-
-	if (Net_player->flags & NETINFO_FLAG_AM_MASTER)
-	{	
-		// tell everyone to leave the game		
-		multi_io_send_to_all_reliable(data, packet_size);
-	}
-}
-
 // process a packet indicating that we should jump straight to the debrief screen
 void process_force_end_mission_packet(ubyte * /*data*/, header *hinfo)
 {
@@ -3977,13 +3961,13 @@ void process_force_end_mission_packet(ubyte * /*data*/, header *hinfo)
  	
 	PACKET_SET_SIZE();
 
-	ml_string("Receiving force end mission packet");
-
-	// Since only the server sends out these packets it should never receive one
-	Assert (!(Net_player->flags & NETINFO_FLAG_AM_MASTER)); 
-	
-	multi_handle_sudden_mission_end();
-	send_debrief_event();
+	// TODO: Obsolete packet - Remove on next multi bump
+	//
+	// This method of ending a mission was horribly broken and skipped over a
+	// lot of necessary state changes resulting in broken standalone net traffic
+	//
+	// We need to support receiving this packet for compatibility sake, but it
+	// should be removed on the next multi bump (as noted in #6927)
 }
 
 // send a packet telling players to end the mission

--- a/code/network/multimsgs.h
+++ b/code/network/multimsgs.h
@@ -360,9 +360,6 @@ void send_new_player_packet(int new_player_num,net_player *target);
 // send a packet telling players to end the mission
 void send_endgame_packet(net_player *pl = NULL);
 
-// send a skip to debrief item packet
-void send_force_end_mission_packet();
-
 // send a position/orientation update for myself (if I'm an observer)
 void send_observer_update_packet();
 

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -17064,12 +17064,16 @@ void sexp_end_mission(int n)
 		send_debrief_event();
 	}
 
-	// Karajorma - callback all the clients here. 
-	if (MULTIPLAYER_MASTER)
-	{
-		multi_handle_sudden_mission_end();
-		send_force_end_mission_packet();
-	}
+	Current_sexp_network_packet.do_callback();
+}
+
+void multi_sexp_end_mission()
+{
+	// This is a bit of hack, but when in a debrief state clients will skip the
+	// warp out sequence when the endgame packet is processed.
+	send_debrief_event();
+	// Standard way to end mission (equivalent to Alt-J)
+	multi_handle_end_mission_request();
 }
 
 // Goober5000
@@ -30676,6 +30680,10 @@ void multi_sexp_eval()
 
 			case OP_RED_ALERT:
 				multi_sexp_red_alert();
+				break;
+
+			case OP_END_MISSION:
+				multi_sexp_end_mission();
 				break;
 
 			// bad sexp in the packet


### PR DESCRIPTION
A previous attempt to fix the end-mission sexp in multi such that it wouldn't trigger the jump out sequence was horribly broken. Notable safety checks, state changes and server/client syncing was skipped over. This caused, as one particular bug, a standalone server to stop communicating with the game host. When this happened stats couldn't be accepted/tossed and you were stuck at the debrief screen, being forced to disconnect from the standalone in order to continue.

A proper fix for this is to use multi sexps to tell clients to enter a debrief state before the standard end mission request is handled. This will allow it the bypass the actual warp out animation for players while still doing the normal end of mission handling.

NOTE: This is a breaking, but not fatal, multi change and should be safe considering the recent version bump in early June. As such an additional version bump is not required with this for 25.0.