### PR TITLE
Particle effect hooks for subsystem debris trails and debris explosions

### DIFF
--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -452,10 +452,18 @@ object *debris_create(object *source_obj, int model_num, int submodel_num, const
 		const auto& sip = Ship_info[Ships[source_obj->instance].ship_info_index];
 		particle::ParticleEffectHandle flame_effect;
 		if (source_subsys != nullptr) {
-			if (hull_flag ? source_subsys->system_info->debris_flame_particles.isValid() : source_subsys->system_info->shrapnel_flame_particles.isValid()) {
-				flame_effect = hull_flag ? source_subsys->system_info->debris_flame_particles : source_subsys->system_info->shrapnel_flame_particles;
+			if (hull_flag) {
+				if (source_subsys->system_info->debris_flame_particles.isValid()) {
+					flame_effect = source_subsys->system_info->debris_flame_particles;
+				} else {
+					flame_effect = sip.default_subsys_debris_flame_particles;
+				}
 			} else {
-				flame_effect = hull_flag ? sip.default_subsys_debris_flame_particles : sip.default_subsys_shrapnel_flame_particles;
+				if (source_subsys->system_info->shrapnel_flame_particles.isValid()) {
+					flame_effect = source_subsys->system_info->shrapnel_flame_particles;
+				} else {
+					flame_effect = sip.default_subsys_shrapnel_flame_particles;
+				}
 			}
 		} else {
 			flame_effect = hull_flag ? sip.debris_flame_particles : sip.shrapnel_flame_particles;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -23,6 +23,7 @@
 #include "model/model_flags.h"
 #include "object/object.h"
 #include "ship/ship_flags.h"
+#include "particle/ParticleEffect.h"
 
 class object;
 class ship_info;
@@ -292,6 +293,8 @@ public:
 	actions::ProgramSet beam_warmdown_program;
 
 	float density;
+
+	particle::ParticleEffectHandle debris_flame_particles;
 
     void reset();
 

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -295,6 +295,7 @@ public:
 	float density;
 
 	particle::ParticleEffectHandle debris_flame_particles;
+	particle::ParticleEffectHandle shrapnel_flame_particles;
 
     void reset();
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1077,8 +1077,11 @@ void ship_info::clone(const ship_info& other)
 	knossos_end_particles = other.knossos_end_particles;
 	regular_end_particles = other.regular_end_particles;
 	debris_flame_particles = other.debris_flame_particles;
+	shrapnel_flame_particles = other.shrapnel_flame_particles;
 	debris_end_particles = other.debris_end_particles;
+	shrapnel_end_particles = other.shrapnel_end_particles;
 	default_subsys_debris_flame_particles = other.default_subsys_debris_flame_particles;
+	default_subsys_shrapnel_flame_particles = other.default_subsys_shrapnel_flame_particles;
 
 	debris_min_lifetime = other.debris_min_lifetime;
 	debris_max_lifetime = other.debris_max_lifetime;
@@ -1440,8 +1443,11 @@ void ship_info::move(ship_info&& other)
 	std::swap(knossos_end_particles, other.knossos_end_particles);
 	std::swap(regular_end_particles, other.regular_end_particles);
 	std::swap(debris_flame_particles, other.debris_flame_particles);
+	std::swap(shrapnel_flame_particles, other.shrapnel_flame_particles);
 	std::swap(debris_end_particles, other.debris_end_particles);
+	std::swap(shrapnel_end_particles, other.shrapnel_end_particles);
 	std::swap(default_subsys_debris_flame_particles, other.default_subsys_debris_flame_particles);
+	std::swap(default_subsys_shrapnel_flame_particles, other.default_subsys_shrapnel_flame_particles);
 
 	debris_min_lifetime = other.debris_min_lifetime;
 	debris_max_lifetime = other.debris_max_lifetime;
@@ -1812,8 +1818,11 @@ ship_info::ship_info()
 	regular_end_particles = default_regular_end_particles;
 
 	debris_flame_particles = particle::ParticleEffectHandle::invalid();
+	shrapnel_flame_particles = particle::ParticleEffectHandle::invalid();
 	debris_end_particles = particle::ParticleEffectHandle::invalid();
+	shrapnel_end_particles = particle::ParticleEffectHandle::invalid();
 	default_subsys_debris_flame_particles = particle::ParticleEffectHandle::invalid();
+	default_subsys_shrapnel_flame_particles = particle::ParticleEffectHandle::invalid();
 
 	debris_min_lifetime = -1.0f;
 	debris_max_lifetime = -1.0f;
@@ -3923,9 +3932,19 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		sip->debris_flame_particles = particle::util::parseEffect(sip->name);
 	}
 
+	if(optional_string("$Shrapnel Flame Effect:"))
+	{
+		sip->shrapnel_flame_particles = particle::util::parseEffect(sip->name);
+	}
+
 	if(optional_string("$Debris Death Effect:"))
 	{
 		sip->debris_end_particles = particle::util::parseEffect(sip->name);
+	}
+
+	if(optional_string("$Shrapnel Death Effect:"))
+	{
+		sip->shrapnel_end_particles = particle::util::parseEffect(sip->name);
 	}
 
 	auto skip_str = "$Skip Death Roll Percent Chance:";
@@ -5471,7 +5490,12 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 	if(optional_string("$Default Subsystem Debris Flame Effect:"))
 	{
-		sip->debris_flame_particles = particle::util::parseEffect(sip->name);
+		sip->default_subsys_debris_flame_particles = particle::util::parseEffect(sip->name);
+	}
+	
+	if(optional_string("$Default Subsystem Shrapnel Flame Effect:"))
+	{
+		sip->default_subsys_shrapnel_flame_particles = particle::util::parseEffect(sip->name);
 	}
 
 	int n_subsystems = 0;
@@ -5572,6 +5596,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				sp->turret_max_target_ownage = -1;
 				sp->density = 1.0f;
 				sp->debris_flame_particles = particle::ParticleEffectHandle::invalid();
+				sp->shrapnel_flame_particles = particle::ParticleEffectHandle::invalid();
 			}
 			sfo_return = stuff_float_optional(&percentage_of_hits);
 			if(sfo_return==2)
@@ -5765,6 +5790,10 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			if(optional_string("$Debris Flame Effect:"))
 			{
 				sp->debris_flame_particles = particle::util::parseEffect(sip->name);
+			}
+			if(optional_string("$Shrapnel Debris Flame Effect:"))
+			{
+				sp->shrapnel_flame_particles = particle::util::parseEffect(sip->name);
 			}
 
 			if (optional_string("$Flags:")) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -1077,6 +1077,8 @@ void ship_info::clone(const ship_info& other)
 	knossos_end_particles = other.knossos_end_particles;
 	regular_end_particles = other.regular_end_particles;
 	debris_flame_particles = other.debris_flame_particles;
+	debris_end_particles = other.debris_end_particles;
+	default_subsys_debris_flame_particles = other.default_subsys_debris_flame_particles;
 
 	debris_min_lifetime = other.debris_min_lifetime;
 	debris_max_lifetime = other.debris_max_lifetime;
@@ -1438,6 +1440,8 @@ void ship_info::move(ship_info&& other)
 	std::swap(knossos_end_particles, other.knossos_end_particles);
 	std::swap(regular_end_particles, other.regular_end_particles);
 	std::swap(debris_flame_particles, other.debris_flame_particles);
+	std::swap(debris_end_particles, other.debris_end_particles);
+	std::swap(default_subsys_debris_flame_particles, other.default_subsys_debris_flame_particles);
 
 	debris_min_lifetime = other.debris_min_lifetime;
 	debris_max_lifetime = other.debris_max_lifetime;
@@ -1808,6 +1812,8 @@ ship_info::ship_info()
 	regular_end_particles = default_regular_end_particles;
 
 	debris_flame_particles = particle::ParticleEffectHandle::invalid();
+	debris_end_particles = particle::ParticleEffectHandle::invalid();
+	default_subsys_debris_flame_particles = particle::ParticleEffectHandle::invalid();
 
 	debris_min_lifetime = -1.0f;
 	debris_max_lifetime = -1.0f;
@@ -3917,6 +3923,11 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		sip->debris_flame_particles = particle::util::parseEffect(sip->name);
 	}
 
+	if(optional_string("$Debris Death Effect:"))
+	{
+		sip->debris_end_particles = particle::util::parseEffect(sip->name);
+	}
+
 	auto skip_str = "$Skip Death Roll Percent Chance:";
 	auto vaporize_str = "$Vaporize Percent Chance:";
 	int which;
@@ -5458,6 +5469,11 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 		required_string("$end_custom_strings");
 	}
 
+	if(optional_string("$Default Subsystem Debris Flame Effect:"))
+	{
+		sip->debris_flame_particles = particle::util::parseEffect(sip->name);
+	}
+
 	int n_subsystems = 0;
 	int n_excess_subsystems = 0;
 	int cont_flag = 1;
@@ -5555,6 +5571,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				sp->turret_max_bomb_ownage = -1;
 				sp->turret_max_target_ownage = -1;
 				sp->density = 1.0f;
+				sp->debris_flame_particles = particle::ParticleEffectHandle::invalid();
 			}
 			sfo_return = stuff_float_optional(&percentage_of_hits);
 			if(sfo_return==2)
@@ -5743,6 +5760,11 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 
 			if (optional_string("$Debris Density:")) {
 				stuff_float(&sp->density);
+			}
+
+			if(optional_string("$Debris Flame Effect:"))
+			{
+				sp->debris_flame_particles = particle::util::parseEffect(sip->name);
 			}
 
 			if (optional_string("$Flags:")) {

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1229,8 +1229,11 @@ public:
 	particle::ParticleEffectHandle		knossos_end_particles;
 	particle::ParticleEffectHandle		regular_end_particles;
 	particle::ParticleEffectHandle 		debris_flame_particles;
+	particle::ParticleEffectHandle 		shrapnel_flame_particles;
 	particle::ParticleEffectHandle 		debris_end_particles;
+	particle::ParticleEffectHandle 		shrapnel_end_particles;
 	particle::ParticleEffectHandle 		default_subsys_debris_flame_particles;
+	particle::ParticleEffectHandle 		default_subsys_shrapnel_flame_particles;
 
 	//Debris stuff
 	float			debris_min_lifetime;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1229,6 +1229,8 @@ public:
 	particle::ParticleEffectHandle		knossos_end_particles;
 	particle::ParticleEffectHandle		regular_end_particles;
 	particle::ParticleEffectHandle 		debris_flame_particles;
+	particle::ParticleEffectHandle 		debris_end_particles;
+	particle::ParticleEffectHandle 		default_subsys_debris_flame_particles;
 
 	//Debris stuff
 	float			debris_min_lifetime;

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -374,7 +374,7 @@ void shipfx_blow_up_model(object *obj, int submodel, int ndebris, const vec3d *e
 		vm_vec_avg( &tmp, &pnt1, &pnt2 );
 		model_instance_local_to_global_point(&outpnt, &tmp, pm, pmi, submodel, &obj->orient, &obj->pos );
 
-		debris_create( obj, use_ship_debris ? Ship_info[Ships[obj->instance].ship_info_index].generic_debris_model_num : -1, -1, &outpnt, exp_center, 0, 1.0f, subsys );
+		debris_create( obj, use_ship_debris ? Ship_info[Ships[obj->instance].ship_info_index].generic_debris_model_num : -1, -1, &outpnt, exp_center, false, 1.0f, subsys );
 	}
 }
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -282,7 +282,7 @@ void shipfx_blow_off_subsystem(object *ship_objp, ship *ship_p, const ship_subsy
 
 	// create debris shards
     if (!(subsys->flags[Ship::Subsystem_Flags::Vanished]) && !no_explosion) {
-		shipfx_blow_up_model(ship_objp, psub->subobj_num, 50, &subobj_pos );
+		shipfx_blow_up_model(ship_objp, psub->subobj_num, 50, &subobj_pos, subsys );
 
 		// create live debris objects, if any
 		// TODO:  some MULTIPLAYER implcations here!!
@@ -343,7 +343,7 @@ static void shipfx_blow_up_hull(object *obj, const polymodel *pm, const polymode
 /**
  * Creates "ndebris" pieces of debris on random verts of the the "submodel" in the ship's model.
  */
-void shipfx_blow_up_model(object *obj, int submodel, int ndebris, const vec3d *exp_center)
+void shipfx_blow_up_model(object *obj, int submodel, int ndebris, const vec3d *exp_center, const ship_subsys *subsys)
 {
 	int i;
 
@@ -374,7 +374,7 @@ void shipfx_blow_up_model(object *obj, int submodel, int ndebris, const vec3d *e
 		vm_vec_avg( &tmp, &pnt1, &pnt2 );
 		model_instance_local_to_global_point(&outpnt, &tmp, pm, pmi, submodel, &obj->orient, &obj->pos );
 
-		debris_create( obj, use_ship_debris ? Ship_info[Ships[obj->instance].ship_info_index].generic_debris_model_num : -1, -1, &outpnt, exp_center, 0, 1.0f );
+		debris_create( obj, use_ship_debris ? Ship_info[Ships[obj->instance].ship_info_index].generic_debris_model_num : -1, -1, &outpnt, exp_center, 0, 1.0f, subsys );
 	}
 }
 

--- a/code/ship/shipfx.h
+++ b/code/ship/shipfx.h
@@ -36,7 +36,7 @@ extern void shipfx_blow_off_subsystem(object *ship_obj, ship *ship_p, const ship
 
 // Creates "ndebris" pieces of debris on random verts of the "submodel" in the 
 // ship's model.
-extern void shipfx_blow_up_model(object *obj, int submodel, int ndebris, const vec3d *exp_center);
+extern void shipfx_blow_up_model(object *obj, int submodel, int ndebris, const vec3d *exp_center, const ship_subsys *subsys = nullptr);
 
 
 // =================================================


### PR DESCRIPTION
Allows modders to define particle effects to be used when debris explodes, disabling the default fireball. Also allows specification of flame-trail effects for subsystem debris, on both a default and a per-subsystem basis. All of these effects, including the preexisting flame trails for normal debris, now distinguish between 'debris' (an actual chunk of the hull) and 'shrapnel' (a generic shard of material), and allow specification of different effects for each.

In order to properly distinguish subsystem-based debris from non-subsystem debris under certain circumstances, it was necessary for me to add a subsystem pointer passed into `shipfx_blow_up_model()`. This produces one change to existing behavior: the velocity of shrapnel spawned during subsystem destruction will now take the subsystem's tabled debris density into account. This isn't a very big change and I think it's arguably an improvement, but it is worth noting. If it's considered a problem, it won't be too difficult to eliminate the extra change.