### PR TITLE
Particle effects for asteroid death

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1704,37 +1704,57 @@ static void asteroid_do_area_effect(object *asteroid_objp)
  */
 void asteroid_hit( object * pasteroid_obj, object * other_obj, vec3d * hitpos, float damage, vec3d* force )
 {
-	float		explosion_life;
-	asteroid	*asp;
-
-	asp = &Asteroids[pasteroid_obj->instance];
-
+	asteroid	*asp = &Asteroids[pasteroid_obj->instance];
+	asteroid_info *asip = &Asteroid_info[Asteroids[pasteroid_obj->instance].asteroid_type];
+	
 	if (pasteroid_obj->flags[Object::Object_Flags::Should_be_dead]){
 		return;
 	}
-
+	
 	if ( MULTIPLAYER_MASTER ){
 		send_asteroid_hit( pasteroid_obj, other_obj, hitpos, damage, force );
 	}
-
+	
 	if (hitpos && force && The_mission.ai_profile->flags[AI::Profile_Flags::Whackable_asteroids]) {
 		vec3d rel_hit_pos = *hitpos - pasteroid_obj->pos;
 		physics_calculate_and_apply_whack(force, &rel_hit_pos, &pasteroid_obj->phys_info, &pasteroid_obj->orient, &pasteroid_obj->phys_info.I_body_inv);
 		pasteroid_obj->phys_info.desired_vel = pasteroid_obj->phys_info.vel;
 	}
-
+	
 	pasteroid_obj->hull_strength -= damage;
-
+	
 	if (pasteroid_obj->hull_strength < 0.0f) {
 		if ( !asp->final_death_time.isValid() ) {
 			int play_loud_collision = 0;
+			
+			float explosion_life;
+			int breakup_timestamp;
+			
+			Assertion(!asip->end_particles.isValid() || asip->breakup_delay.has_value(), "Asteroid %s has end particles but no breakup delay. Parsing should not have allowed this!", asip->name);
 
-			explosion_life = asteroid_create_explosion(pasteroid_obj);
+			if (asip->end_particles.isValid()) {
+				auto source = particle::ParticleManager::get()->createSource(asip->end_particles);
+
+				// Use the position since the asteroid is going to be invalid soon
+				auto host = std::make_unique<EffectHostVector>(pasteroid_obj->pos, pasteroid_obj->orient, pasteroid_obj->phys_info.vel);
+				host->setRadius(pasteroid_obj->radius);
+				source->setHost(std::move(host));
+				source->setNormal(pasteroid_obj->orient.vec.uvec);
+				source->finishCreation();
+			} else {
+				explosion_life = asteroid_create_explosion(pasteroid_obj);
+			}
+
+			if (asip->breakup_delay.has_value()) {
+				breakup_timestamp = fl2i(*asip->breakup_delay * MILLISECONDS_PER_SECOND);
+			} else {
+				breakup_timestamp = fl2i((explosion_life * MILLISECONDS_PER_SECOND) / 5.f);
+			}
 
 			asteroid_explode_sound(pasteroid_obj, asp->asteroid_type, play_loud_collision);
 			asteroid_do_area_effect(pasteroid_obj);
 
-			asp->final_death_time = _timestamp( fl2i(explosion_life*MILLISECONDS_PER_SECOND)/5 );	// Wait till 30% of vclip time before breaking the asteroid up.
+			asp->final_death_time = _timestamp( breakup_timestamp );	// Wait till 20% of vclip time before breaking the asteroid up, or use the specified delay
 			if ( hitpos ) {
 				asp->death_hit_pos = *hitpos;
 			} else {
@@ -2334,10 +2354,20 @@ static void asteroid_parse_section()
 	
 	if(optional_string("$Explosion Animations:")){
 		stuff_fireball_index_list(asteroid_p->explosion_bitmap_anims, asteroid_p->name);
+
+		if (optional_string("$Explosion Radius Mult:")) {
+			stuff_float(&asteroid_p->fireball_radius_multiplier);
+		}
+	} else if (optional_string("$Explosion Effect:")) {
+		asteroid_p->end_particles = particle::util::parseEffect(asteroid_p->name);
 	}
 
-	if (optional_string("$Explosion Radius Mult:")) {
-		stuff_float(&asteroid_p->fireball_radius_multiplier);
+	if (optional_string("$Breakup Delay:")) {
+		stuff_float(&asteroid_p->breakup_delay.emplace());
+	}
+
+	if (asteroid_p->end_particles.isValid() && !asteroid_p->breakup_delay.has_value()) {
+		error_display(0, "Asteroid %s has an explosion effect but no breakup delay!", asteroid_p->name);
 	}
 
 	if (optional_string("$Expl inner rad:")){

--- a/code/asteroid/asteroid.h
+++ b/code/asteroid/asteroid.h
@@ -16,6 +16,7 @@
 #include "globalincs/pstypes.h"
 #include "object/object_flags.h"
 #include "io/timer.h"
+#include "particle/ParticleEffect.h"
 
 class object;
 class polymodel;
@@ -79,7 +80,9 @@ public:
 	float		initial_asteroid_strength;						// starting strength of asteroid
 	SCP_vector< asteroid_split_info > split_info;
 	SCP_vector<int> explosion_bitmap_anims;
-	float		fireball_radius_multiplier;						// the model radius is multiplied by this to determine the fireball size
+	float fireball_radius_multiplier;						// the model radius is multiplied by this to determine the fireball size
+	particle::ParticleEffectHandle end_particles;
+	std::optional<float> breakup_delay;
 	SCP_string	display_name;									// only used for hud targeting display and for debris
 	float		spawn_weight;									// debris only, relative proportion to spawn compared to other types in its asteroid field
 	float		gravity_const;									// multiplier for mission gravity
@@ -90,7 +93,7 @@ public:
 		  rotational_vel_multiplier(1), damage_type_idx(0),
 		  damage_type_idx_sav( -1 ), inner_rad( 0 ), outer_rad( 0 ),
 		  damage( 0 ), blast( 0 ), initial_asteroid_strength( 0 ),
-		  fireball_radius_multiplier( -1 ), spawn_weight( 1 ), gravity_const( 0 )
+		  fireball_radius_multiplier( -1 ), end_particles( particle::ParticleEffectHandle::invalid() ), breakup_delay( std::nullopt ), spawn_weight( 1 ), gravity_const( 0 )
 	{
 		name[ 0 ] = 0;
 		display_name = "";


### PR DESCRIPTION
Adds ability to spawn particle effects when an asteroid dies, mutually exclusive with the default fireball. Also, because the retail code was determining the breakup time of the asteroid based on the fireball animation length, which can't be done very sensibly with particle effects (and is also very ugly in general), adds a `breakup_delay` parameter which must be used if death particles are in use, and can optionally be used if spawning a fireball.