### PR TITLE
Add apparent size input for particle source curve

### DIFF
--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -124,7 +124,7 @@ ParticleEffect::ParticleEffect(SCP_string name,
 	  m_particleChance(particleChance),
 	  m_distanceCulled(distanceCulled) {}
 
-float ParticleEffect::getApproximateVisualSize(const vec3d& pos) const {
+float ParticleEffect::getApproximatePixelSize(const vec3d& pos) const {
 	float distance_to_eye = vm_vec_dist(&Eye_position, &pos);
 
 	return convert_distance_and_diameter_to_pixel_size(

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -9,6 +9,7 @@
 #include "utils/RandomRange.h"
 #include "utils/id.h"
 #include "utils/modular_curves.h"
+#include "graphics/2d.h"
 
 #include <optional>
 
@@ -244,7 +245,10 @@ public:
 		std::pair {"Time Running", modular_curves_functional_full_input<&ParticleSource::getEffectRunningTime>{}})
 	.derive_modular_curves_input_only_subset<vec3d>( //Sampled spawn position
 		std::pair {"Pixel Size At Emitter", modular_curves_functional_full_input<&ParticleSource::getEffectPixelSize>{}},
-		std::pair {"Apparent Size At Emitter", modular_curves_functional_full_input<&ParticleSource::getEffectApparentSize>{}}
+		std::pair {"Apparent Size At Emitter", modular_curves_math_input<
+			modular_curves_functional_full_input<&ParticleSource::getEffectPixelSize>,
+			modular_curves_global_submember_input<gr_screen, &screen::max_w>,
+			ModularCurvesMathOperators::division>{}}
 		);
 
 	MODULAR_CURVE_SET(m_modular_curves, modular_curves_definition);

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -201,7 +201,7 @@ public:
 
 	bool isOnetime() const { return m_duration == Duration::ONETIME; }
 
-	float getApproximateVisualSize(const vec3d& pos) const;
+	float getApproximatePixelSize(const vec3d& pos) const;
 
 	constexpr static auto modular_curves_definition = make_modular_curve_definition<ParticleSource, ParticleCurvesOutput>(
 		std::array {
@@ -243,7 +243,8 @@ public:
 		std::pair {"Spawntime Left", modular_curves_functional_full_input<&ParticleSource::getEffectRemainingTime>{}},
 		std::pair {"Time Running", modular_curves_functional_full_input<&ParticleSource::getEffectRunningTime>{}})
 	.derive_modular_curves_input_only_subset<vec3d>( //Sampled spawn position
-		std::pair {"Apparent Visual Size At Emitter", modular_curves_functional_full_input<&ParticleSource::getEffectVisualSize>{}}
+		std::pair {"Pixel Size At Emitter", modular_curves_functional_full_input<&ParticleSource::getEffectPixelSize>{}},
+		std::pair {"Apparent Size At Emitter", modular_curves_functional_full_input<&ParticleSource::getEffectApparentSize>{}}
 		);
 
 	MODULAR_CURVE_SET(m_modular_curves, modular_curves_definition);

--- a/code/particle/ParticleSource.cpp
+++ b/code/particle/ParticleSource.cpp
@@ -110,7 +110,11 @@ float ParticleSource::getEffectRunningTime(const std::tuple<const ParticleSource
 	return i2fl(timestamp_get_delta(timing.m_startTimestamp, timing.m_nextCreation)) / i2fl(MILLISECONDS_PER_SECOND);
 }
 
-float ParticleSource::getEffectVisualSize(const std::tuple<const ParticleSource&, const size_t&, const vec3d&>& source) {
-	return std::get<0>(source).getEffect()[std::get<1>(source)].getApproximateVisualSize(std::get<2>(source));
+float ParticleSource::getEffectPixelSize(const std::tuple<const ParticleSource&, const size_t&, const vec3d&>& source) {
+	return std::get<0>(source).getEffect()[std::get<1>(source)].getApproximatePixelSize(std::get<2>(source));
+}
+
+float ParticleSource::getEffectApparentSize(const std::tuple<const ParticleSource&, const size_t&, const vec3d&>& source) {
+	return i2fl(std::get<0>(source).getEffect()[std::get<1>(source)].getApproximatePixelSize(std::get<2>(source))) / i2fl(gr_screen.max_w);
 }
 }

--- a/code/particle/ParticleSource.h
+++ b/code/particle/ParticleSource.h
@@ -80,7 +80,9 @@ class ParticleSource {
 
 	static float getEffectRunningTime(const std::tuple<const ParticleSource&, const size_t&>& source);
 
-	static float getEffectVisualSize(const std::tuple<const ParticleSource&, const size_t&, const vec3d&>& source);
+	static float getEffectPixelSize(const std::tuple<const ParticleSource&, const size_t&, const vec3d&>& source);
+
+	static float getEffectApparentSize(const std::tuple<const ParticleSource&, const size_t&, const vec3d&>& source);
  public:
 	ParticleSource();
 


### PR DESCRIPTION
Adds a particle source curve input that is the particle's width as a fraction of the screen's width. Also, renames the existing "Apparent Visual Size At Emitter" input to "Pixel Size At Emitter", for disambiguation and clarity.