### PR TITLE
Fix parented line sprite particles appearing in the wrong place

### DIFF
--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -432,9 +432,11 @@ namespace particle
 
 			vec3d p1;
 			vm_vec_copy_normalize_safe(&p1, &part->velocity);
-			vm_vec_unrotate(&p1, &p1, &Objects[part->attached_objnum].orient);
+			if (part->attached_objnum >= 0) {
+				vm_vec_unrotate(&p1, &p1, &Objects[part->attached_objnum].orient);
+			}
 			p1 *= part->length;
-			p1 += part->pos;
+			p1 += p_pos;
 
 			batching_add_laser(framenum + cur_frame, &p0, radius, &p1, radius);
 		}


### PR DESCRIPTION
When parented to their host objects, line-sprite particles (ones that have length and are rendered like lasers) get incorrect position data, resulting in them not showing up at the correct location. Fixing this is simple.