### PR TITLE
fix custom mouse cursors

### DIFF
--- a/code/ui/button.cpp
+++ b/code/ui/button.cpp
@@ -445,8 +445,8 @@ void UI_BUTTON::maybe_show_custom_cursor()
 
 void UI_BUTTON::restore_previous_cursor()
 {
-	if (previous_cursor != NULL) {
+	if (previous_cursor != nullptr && !is_mouse_on()) {
 		io::mouse::CursorManager::get()->setCurrentCursor(previous_cursor);
-		previous_cursor = NULL;
+		previous_cursor = nullptr;
 	}
 }


### PR DESCRIPTION
UI elements with custom mouse cursors wouldn't show them due to the cursor being reset at the start of each frame. To fix this we need to be sure that we only reset when the element is no longer active.