### PR TITLE
fix array index bug in ship_get_subsys_index

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15574,6 +15574,9 @@ int ship_get_subsys_index(const ship_subsys *subsys)
 	if (subsys == nullptr)
 		return -1;
 
+	if (subsys->parent_objnum < 0)
+		return -1;
+
 	// might need to refresh the cache
 	auto sp = &Ships[Objects[subsys->parent_objnum].instance];
 	if (!sp->flags[Ship::Ship_Flags::Subsystem_cache_valid])


### PR DESCRIPTION
Fix OOB when parent object isn't set. This was seen during multi testing, and might have been revealed due to a recent multi fix (targeting bug). It does appear to be pretty rare but the safety check should be present regardless.