### PR TITLE
Spare future modders

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -490,7 +490,7 @@ void get_user_prop_value(char *buf, char *value)
 	char *p, *p1, c;
 
 	p = buf;
-	while ( isspace(*p) || (*p == '=') )		// skip white space and equal sign
+	while ( isspace(*p) || (*p == '=') || (*p == ':') )		// skip white space, equal sign, and colon
 		p++;
 	p1 = p;
 	while ( !iscntrl(*p1) )						// copy until we get to a control character


### PR DESCRIPTION
Fields like `uvec` and `fvec` allow for properly parsing colons, so ensure that fields like `fov` do as well. That way entries like '$fov:190' work as expected. Doing this since I spent far too long trying to figure out why a ship's turrets were not firing...