### PR TITLE
QtFRED Fix variables heap corruption crash

### DIFF
--- a/qtfred/src/ui/dialogs/VariableDialog.cpp
+++ b/qtfred/src/ui/dialogs/VariableDialog.cpp
@@ -676,7 +676,8 @@ void VariableDialog::onDeleteVariableButtonPressed()
 	}	
 
 	// Because of the text update we'll need, this needs an applyModel, whether it fails or not.
-	if (ui->deleteVariableButton->text().toUtf8().constData() == "Restore") {
+	SCP_string btn_text = ui->deleteVariableButton->text().toUtf8().constData();
+	if (btn_text == "Restore") {
 		_model->removeVariable(currentRow, false);
 		applyModel();
 	} else {
@@ -853,7 +854,8 @@ void VariableDialog::onDeleteContainerButtonPressed()
 	}
 
 	// Because of the text update we'll need, this needs an applyModel, whether it fails or not.
-	if (ui->deleteContainerButton->text().toUtf8().constData() == "Restore"){
+	SCP_string btn_text = ui->deleteContainerButton->text().toUtf8().constData();
+	if (btn_text == "Restore"){
 		_model->removeContainer(row, false);
 	} else {
 		_model->removeContainer(row, true);


### PR DESCRIPTION
This is a really quick and dirty pass to remove the `.toStdString()` refs and replace them with `.toUtf8().constData()` which resolves the Qt heap corruption when the temp std::strings are deallocated. This gets the variables dialog opening again.