### PR TITLE
fix error in error reporting routine

### DIFF
--- a/code/globalincs/mspdb_callstack.cpp
+++ b/code/globalincs/mspdb_callstack.cpp
@@ -105,7 +105,7 @@ BOOL SCP_mspdbcs_ResolveSymbol( HANDLE hProcess, UINT_PTR dwAddress, SCP_mspdbcs
 
 			if ( siSymbol.dwOffset != 0 )
 			{
-				sprintf_s( szWithOffset, SCP_MSPDBCS_MAX_SYMBOL_LENGTH, "%s + %lld bytes", pszSymbol, siSymbol.dwOffset );
+				snprintf( szWithOffset, SCP_MSPDBCS_MAX_SYMBOL_LENGTH, "%s + %lld bytes", pszSymbol, siSymbol.dwOffset );
 				szWithOffset[ SCP_MSPDBCS_MAX_SYMBOL_LENGTH - 1 ] = '\0'; /* Because sprintf doesn't guarantee NULL terminating */
 				pszSymbol = szWithOffset;
 			}


### PR DESCRIPTION
The `_s` functions throw an exception if the string's length is exceeded.  But in an error reporting routine, we are far more interested in the string than the exception, and we'd rather get a partial error message than a crash.  Plus this bit of code is already set up to truncate the string anyway.