### PR TITLE
Fix gr.createParticle with parent velocity

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -2309,7 +2309,6 @@ static int spawnParticles(lua_State *L, bool persistent) {
 	std::unique_ptr<EffectHost> host;
 	if (objh != nullptr && objh->isValid()) {
 		host = std::make_unique<EffectHostObject>(objh->objp(), pos);
-		vel += objh->objp()->phys_info.vel;
 	}
 	else {
 		host = std::make_unique<EffectHostVector>(pos, vmd_identity_matrix, vmd_zero_vector);


### PR DESCRIPTION
#6884 fixed a bug with `gr.createParticle` but fixing that revealed another bug that needs fixing. That bug is using `gr.createParticle` with assigning the particle to a ship results in the particle not remaining fully parented with regards to velocity/orientation, and noticed that  it only occurred after this PR if the parent ship changes direction or speed after the particle was created but while the particle is alive.

Thanks for lafiel for the fix. Just waiting on one additional test to ensure uses of `gr.createParticle` still work as expected in Scroll.