### PR TITLE
Fix a bug with `vm_interpolate_matrices`

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -2988,7 +2988,7 @@ void vm_interpolate_matrices(matrix* out_orient, const matrix* curr_orient, cons
 	matrix rot_matrix;
 
 	vm_quaternion_rotate(&rot_matrix, t * theta, &rot_axis); // get the matrix that rotates current to our interpolated matrix
-	vm_matrix_x_matrix(out_orient, &rot_matrix, curr_orient); // do the final rotation
+	vm_matrix_x_matrix(out_orient, curr_orient, &rot_matrix); // do the final rotation
 	
 }
 


### PR DESCRIPTION
Fixes a bug noticed by wookieejedi which affects the `rotationalInterpolate` script function, and some multi rollback code apparently, but this function is not used elsewhere.

Note the order of these arguments in `vm_angular_move_matrix`, where this code is derived from:
https://github.com/scp-fs2open/fs2open.github.com/blob/master/code/math/vecmat.cpp#L2056
```
	// otherwise rotate orient by theta along rot_axis
	vm_quaternion_rotate(&Mtemp1, theta, &rot_axis);
	Assert(is_valid_matrix(&Mtemp1));
	vm_matrix_x_matrix(next_orient, curr_orient, &Mtemp1);
```