### PR TITLE
Don't bother doing the work to add weapon lights if deferred lighting is off

### DIFF
--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1305,7 +1305,7 @@ void obj_move_all_post(object *objp, float frametime)
 				weapon_process_post( objp, frametime );
 
 			// Cast light
-			if ( Detail.lighting > 3 ) {
+			if ( Deferred_lighting && Detail.lighting > 3 ) {
 				// Weapons cast light
 
 				int group_id = Weapons[objp->instance].group_id;


### PR DESCRIPTION
Tiny check to make sure that if deferred lighting is off (which will mean that object lights don't do anything), we don't execute the code block that adds point lights to weapons, since, with modular curves, it can potentially have significant performance impact.