### PR TITLE
QtFRED Background Editor Dialog

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -42,6 +42,8 @@ add_file_folder("Source/Mission/Dialogs"
     src/mission/dialogs/AbstractDialogModel.h
 	src/mission/dialogs/AsteroidEditorDialogModel.cpp
 	src/mission/dialogs/AsteroidEditorDialogModel.h
+	src/mission/dialogs/BackgroundEditorDialogModel.h
+	src/mission/dialogs/BackgroundEditorDialogModel.cpp
 	src/mission/dialogs/CampaignEditorDialogModel.cpp
 	src/mission/dialogs/CampaignEditorDialogModel.h
 	src/mission/dialogs/CommandBriefingDialogModel.cpp

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -674,28 +674,6 @@ void BackgroundEditorDialogModel::setSunPitch(int deg)
 	refreshBackgroundPreview();
 }
 
-int BackgroundEditorDialogModel::getSunBank() const
-{
-	// Bank is not used for suns but this is added for consistency
-	/*auto* s = getActiveSun();
-	if (!s)
-		return 0;
-
-	return fl2ir(fl_degrees(s->ang.b) + delta);*/
-}
-
-void BackgroundEditorDialogModel::setSunBank(int deg)
-{
-	// Bank is not used for suns but this is added for consistency
-	/*auto* s = getActiveSun();
-	if (!s)
-		return;
-
-	CLAMP(deg, getOrientLimit().first, getOrientLimit().second);
-	modify(s->ang.b, fl_radians(deg));
-	refreshBackgroundPreview();*/
-}
-
 int BackgroundEditorDialogModel::getSunHeading() const
 {
 	auto* s = getActiveSun();
@@ -859,7 +837,7 @@ void BackgroundEditorDialogModel::setSelectedPoofs(const SCP_vector<SCP_string>&
 	clear_all_bits(Neb2_poof_flags.get(), Poof_info.size());
 	for (const auto& want : names) {
 		for (size_t i = 0; i < Poof_info.size(); ++i) {
-			if (!_stricmp(Poof_info[i].name, want.c_str())) {
+			if (!stricmp(Poof_info[i].name, want.c_str())) {
 				set_bit(Neb2_poof_flags.get(), i);
 				break;
 			}

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -48,6 +48,8 @@ void BackgroundEditorDialogModel::reject()
 void BackgroundEditorDialogModel::refreshBackgroundPreview()
 {
 	stars_load_background(Cur_background); // rebuild instances from Backgrounds[]
+	stars_set_background_model(The_mission.skybox_model, nullptr, The_mission.skybox_flags); // rebuild skybox
+	stars_set_background_orientation(&The_mission.skybox_orientation);
 	_editor->missionChanged();
 }
 
@@ -914,6 +916,196 @@ void BackgroundEditorDialogModel::setAmbientB(int b)
 
 	gr_set_ambient_light(r, g, b);
 	refreshBackgroundPreview();
+}
+
+std::string BackgroundEditorDialogModel::getSkyboxModelName() const
+{
+	return The_mission.skybox_model;
+}
+void BackgroundEditorDialogModel::setSkyboxModelName(const std::string& name)
+{
+	// empty string = no skybox
+	if (std::strncmp(The_mission.skybox_model, name.c_str(), NAME_LENGTH) != 0) {
+		std::memset(The_mission.skybox_model, 0, sizeof(The_mission.skybox_model));
+		std::strncpy(The_mission.skybox_model, name.c_str(), NAME_LENGTH - 1);
+	}
+
+	set_modified();
+	refreshBackgroundPreview();
+}
+
+bool BackgroundEditorDialogModel::getSkyboxNoLighting() const
+{
+	return (The_mission.skybox_flags & MR_NO_LIGHTING) != 0;
+}
+
+void BackgroundEditorDialogModel::setSkyboxNoLighting(bool on)
+{
+	if (on) {
+		The_mission.skybox_flags |= MR_NO_LIGHTING;
+	} else {
+		The_mission.skybox_flags &= ~MR_NO_LIGHTING;
+	}
+
+	set_modified();
+}
+
+bool BackgroundEditorDialogModel::getSkyboxAllTransparent() const
+{
+	return (The_mission.skybox_flags & MR_ALL_XPARENT) != 0;
+}
+
+void BackgroundEditorDialogModel::setSkyboxAllTransparent(bool on)
+{
+	if (on) {
+		The_mission.skybox_flags |= MR_ALL_XPARENT;
+	} else {
+		The_mission.skybox_flags &= ~MR_ALL_XPARENT;
+	}
+
+	set_modified();
+}
+
+bool BackgroundEditorDialogModel::getSkyboxNoZbuffer() const
+{
+	return (The_mission.skybox_flags & MR_NO_ZBUFFER) != 0;
+}
+
+void BackgroundEditorDialogModel::setSkyboxNoZbuffer(bool on)
+{
+	if (on) {
+		The_mission.skybox_flags |= MR_NO_ZBUFFER;
+	} else {
+		The_mission.skybox_flags &= ~MR_NO_ZBUFFER;
+	}
+
+	set_modified();
+}
+
+bool BackgroundEditorDialogModel::getSkyboxNoCull() const
+{
+	return (The_mission.skybox_flags & MR_NO_CULL) != 0;
+}
+
+void BackgroundEditorDialogModel::setSkyboxNoCull(bool on)
+{
+	if (on) {
+		The_mission.skybox_flags |= MR_NO_CULL;
+	} else {
+		The_mission.skybox_flags &= ~MR_NO_CULL;
+	}
+
+	set_modified();
+}
+
+bool BackgroundEditorDialogModel::getSkyboxNoGlowmaps() const
+{
+	return (The_mission.skybox_flags & MR_NO_GLOWMAPS) != 0;
+}
+
+void BackgroundEditorDialogModel::setSkyboxNoGlowmaps(bool on)
+{
+	if (on) {
+		The_mission.skybox_flags |= MR_NO_GLOWMAPS;
+	} else {
+		The_mission.skybox_flags &= ~MR_NO_GLOWMAPS;
+	}
+
+	set_modified();
+}
+
+bool BackgroundEditorDialogModel::getSkyboxForceClamp() const
+{
+	return (The_mission.skybox_flags & MR_FORCE_CLAMP) != 0;
+}
+
+void BackgroundEditorDialogModel::setSkyboxForceClamp(bool on)
+{
+	if (on) {
+		The_mission.skybox_flags |= MR_FORCE_CLAMP;
+	} else {
+		The_mission.skybox_flags &= ~MR_FORCE_CLAMP;
+	}
+
+	set_modified();
+}
+
+int BackgroundEditorDialogModel::getSkyboxPitch() const
+{
+	angles a;
+	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
+	int d = static_cast<int>(fl2ir(fl_degrees(a.p)));
+	if (d < 0)
+		d += 360;
+	if (d >= 360)
+		d -= 360;
+	return d;
+}
+
+void BackgroundEditorDialogModel::setSkyboxPitch(int deg)
+{
+	CLAMP(deg, 0, 359);
+	angles a;
+	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
+	const int cur = static_cast<int>(fl2ir(fl_degrees(a.p)));
+	if (cur != deg) {
+		a.p = fl_radians(static_cast<float>(deg));
+		vm_angles_2_matrix(&The_mission.skybox_orientation, &a);
+		set_modified();
+		refreshBackgroundPreview();
+	}
+}
+
+int BackgroundEditorDialogModel::getSkyboxBank() const
+{
+	angles a;
+	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
+	int d = static_cast<int>(fl2ir(fl_degrees(a.b)));
+	if (d < 0)
+		d += 360;
+	if (d >= 360)
+		d -= 360;
+	return d;
+}
+
+void BackgroundEditorDialogModel::setSkyboxBank(int deg)
+{
+	CLAMP(deg, 0, 359);
+	angles a;
+	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
+	const int cur = static_cast<int>(fl2ir(fl_degrees(a.b)));
+	if (cur != deg) {
+		a.b = fl_radians(static_cast<float>(deg));
+		vm_angles_2_matrix(&The_mission.skybox_orientation, &a);
+		set_modified();
+		refreshBackgroundPreview();
+	}
+}
+
+int BackgroundEditorDialogModel::getSkyboxHeading() const
+{
+	angles a;
+	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
+	int d = static_cast<int>(fl2ir(fl_degrees(a.h)));
+	if (d < 0)
+		d += 360;
+	if (d >= 360)
+		d -= 360;
+	return d;
+}
+
+void BackgroundEditorDialogModel::setSkyboxHeading(int deg)
+{
+	CLAMP(deg, 0, 359);
+	angles a;
+	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
+	const int cur = static_cast<int>(fl2ir(fl_degrees(a.h)));
+	if (cur != deg) {
+		a.h = fl_radians(static_cast<float>(deg));
+		vm_angles_2_matrix(&The_mission.skybox_orientation, &a);
+		set_modified();
+		refreshBackgroundPreview();
+	}
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -300,7 +300,7 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableBitmapNames()
 	return out;
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getMissionBitmapNames() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getMissionBitmapNames()
 {
 	SCP_vector<SCP_string> out;
 	const auto& vec = getActiveBackground().bitmaps;

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -53,6 +53,7 @@ void BackgroundEditorDialogModel::refreshBackgroundPreview()
 	stars_load_background(Cur_background); // rebuild instances from Backgrounds[]
 	stars_set_background_model(The_mission.skybox_model, nullptr, The_mission.skybox_flags); // rebuild skybox
 	stars_set_background_orientation(&The_mission.skybox_orientation);
+	// TODO make this actually show the stars in the background
 	_editor->missionChanged();
 }
 
@@ -85,14 +86,8 @@ starfield_list_entry* BackgroundEditorDialogModel::getActiveSun() const
 	return &list[_selectedSunIndex];
 }
 
-int BackgroundEditorDialogModel::getNumBackgrounds() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getBackgroundNames()
 {
-	return static_cast<int>(Backgrounds.size());
-}
-
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getBackgroundNames() const
-{
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
 	
 	SCP_vector<SCP_string> out;
 	out.reserve(Backgrounds.size());
@@ -115,10 +110,8 @@ void BackgroundEditorDialogModel::setActiveBackgroundIndex(int idx)
 	refreshBackgroundPreview();
 }
 
-int BackgroundEditorDialogModel::getActiveBackgroundIndex() const
+int BackgroundEditorDialogModel::getActiveBackgroundIndex()
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	return Cur_background < 0 ? 0 : Cur_background;
 }
 
@@ -154,10 +147,8 @@ void BackgroundEditorDialogModel::removeActiveBackground()
 	}
 }
 
-int BackgroundEditorDialogModel::getImportableBackgroundCount(const SCP_string& fs2Path) const
+int BackgroundEditorDialogModel::getImportableBackgroundCount(const SCP_string& fs2Path)
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	// Normalize the filepath to use the current platform's directory separator
 	SCP_string path = fs2Path;
 	std::replace(path.begin(), path.end(), '/', DIR_SEPARATOR_CHAR);
@@ -275,7 +266,7 @@ void BackgroundEditorDialogModel::setSwapWithIndex(int idx)
 	_swapIndex = idx;
 }
 
-bool BackgroundEditorDialogModel::getSaveAnglesCorrectFlag() const
+bool BackgroundEditorDialogModel::getSaveAnglesCorrectFlag()
 {
 	const auto& bg = getActiveBackground();
 	return bg.flags[Starfield::Background_Flags::Corrected_angles_in_mission_file];
@@ -296,10 +287,8 @@ void BackgroundEditorDialogModel::setSaveAnglesCorrectFlag(bool on)
 	set_modified();
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableBitmapNames() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableBitmapNames()
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	SCP_vector<SCP_string> out;
 	const int count = stars_get_num_entries(/*is_a_sun=*/false, /*bitmap_count=*/true);
 	out.reserve(count);
@@ -313,8 +302,6 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableBitmapNames() co
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getMissionBitmapNames() const
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	SCP_vector<SCP_string> out;
 	const auto& vec = getActiveBackground().bitmaps;
 	out.reserve(vec.size());
@@ -564,10 +551,8 @@ void BackgroundEditorDialogModel::setBitmapDivY(int v)
 	refreshBackgroundPreview();
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableSunNames() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableSunNames()
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	SCP_vector<SCP_string> out;
 	const int count = stars_get_num_entries(/*is_a_sun=*/true, /*bitmap_count=*/true);
 	out.reserve(count);
@@ -579,10 +564,8 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableSunNames() const
 	return out;
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getMissionSunNames() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getMissionSunNames()
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	SCP_vector<SCP_string> out;
 	const auto& vec = getActiveBackground().suns;
 	out.reserve(vec.size());
@@ -732,10 +715,8 @@ void BackgroundEditorDialogModel::setSunScale(float v)
 	refreshBackgroundPreview();
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightningNames() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightningNames()
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	SCP_vector<SCP_string> out;
 	out.emplace_back("<None>"); // legacy default
 	for (const auto& st : Storm_types) {
@@ -744,10 +725,8 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightningNames() const
 	return out;
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getNebulaPatternNames() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getNebulaPatternNames()
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	SCP_vector<SCP_string> out;
 	out.emplace_back("<None>"); // matches legacy combo where index 0 = none
 	for (const auto& neb : Neb2_bitmap_filenames) {
@@ -756,10 +735,8 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getNebulaPatternNames() cons
 	return out;
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getPoofNames() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getPoofNames()
 {
-	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
-	
 	SCP_vector<SCP_string> out;
 	out.reserve(Poof_info.size());
 	for (const auto& p : Poof_info) {
@@ -1333,7 +1310,7 @@ void BackgroundEditorDialogModel::setNumStars(int n)
 {
 	CLAMP(n, getStarsLimit().first, getStarsLimit().second);
 	modify(Num_stars, n);
-	refreshBackgroundPreview(); // TODO make this actually show the stars in the background
+	refreshBackgroundPreview();
 }
 
 bool BackgroundEditorDialogModel::getTakesPlaceInSubspace()
@@ -1354,7 +1331,7 @@ void BackgroundEditorDialogModel::setTakesPlaceInSubspace(bool on)
 
 SCP_string BackgroundEditorDialogModel::getEnvironmentMapName()
 {
-	return SCP_string(The_mission.envmap_name);
+	return {The_mission.envmap_name};
 }
 
 void BackgroundEditorDialogModel::setEnvironmentMapName(const SCP_string& name)

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -7,6 +7,7 @@
 #include "nebula/neb.h"
 #include "nebula/neblightning.h"
 #include "starfield/nebula.h"
+#include "lighting/lighting_profiles.h" 
 
 // TODO move this to common for both FREDs. Do not pass review if this is not done
 const static float delta = .00001f;
@@ -918,11 +919,11 @@ void BackgroundEditorDialogModel::setAmbientB(int b)
 	refreshBackgroundPreview();
 }
 
-std::string BackgroundEditorDialogModel::getSkyboxModelName() const
+SCP_string BackgroundEditorDialogModel::getSkyboxModelName() const
 {
 	return The_mission.skybox_model;
 }
-void BackgroundEditorDialogModel::setSkyboxModelName(const std::string& name)
+void BackgroundEditorDialogModel::setSkyboxModelName(const SCP_string& name)
 {
 	// empty string = no skybox
 	if (std::strncmp(The_mission.skybox_model, name.c_str(), NAME_LENGTH) != 0) {
@@ -1106,6 +1107,69 @@ void BackgroundEditorDialogModel::setSkyboxHeading(int deg)
 		set_modified();
 		refreshBackgroundPreview();
 	}
+}
+
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightingProfileOptions() const
+{
+	SCP_vector<SCP_string> out;
+	auto profiles = lighting_profiles::list_profiles(); // returns a vector of names
+	out.reserve(profiles.size());
+	for (const auto& p : profiles)
+		out.emplace_back(p.c_str());
+	return out;
+}
+
+int BackgroundEditorDialogModel::getNumStars() const
+{
+	return Num_stars;
+}
+
+void BackgroundEditorDialogModel::setNumStars(int n)
+{
+	CLAMP(n, getStarsLimit().first, getStarsLimit().second);
+	modify(Num_stars, n);
+	refreshBackgroundPreview(); // TODO make this actually show the stars in the background
+}
+
+bool BackgroundEditorDialogModel::getTakesPlaceInSubspace() const
+{
+	return The_mission.flags[Mission::Mission_Flags::Subspace];
+}
+
+void BackgroundEditorDialogModel::setTakesPlaceInSubspace(bool on)
+{
+	auto before = The_mission.flags[Mission::Mission_Flags::Subspace];
+	if (before == on)
+		return;
+
+	The_mission.flags.set(Mission::Mission_Flags::Subspace, on);
+
+	set_modified();
+}
+
+SCP_string BackgroundEditorDialogModel::getEnvironmentMapName() const
+{
+	return SCP_string(The_mission.envmap_name);
+}
+
+void BackgroundEditorDialogModel::setEnvironmentMapName(const SCP_string& name)
+{
+	if (name == The_mission.envmap_name)
+		return;
+
+	strcpy_s(The_mission.envmap_name, name.c_str());
+
+	set_modified();
+}
+
+SCP_string BackgroundEditorDialogModel::getLightingProfileName() const
+{
+	return The_mission.lighting_profile_name;
+}
+
+void BackgroundEditorDialogModel::setLightingProfileName(const SCP_string& name)
+{
+	modify(The_mission.lighting_profile_name, name);
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -1218,10 +1218,7 @@ int BackgroundEditorDialogModel::getSkyboxPitch()
 	angles a;
 	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
 	int d = static_cast<int>(fl2ir(fl_degrees(a.p)));
-	if (d < 0)
-		d += 360;
-	if (d >= 360)
-		d -= 360;
+	d = (d % 360 + 360) % 360; // wrap to [0, 359]
 	return d;
 }
 
@@ -1244,10 +1241,7 @@ int BackgroundEditorDialogModel::getSkyboxBank()
 	angles a;
 	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
 	int d = static_cast<int>(fl2ir(fl_degrees(a.b)));
-	if (d < 0)
-		d += 360;
-	if (d >= 360)
-		d -= 360;
+	d = (d % 360 + 360) % 360; // wrap to [0, 359]
 	return d;
 }
 
@@ -1270,10 +1264,7 @@ int BackgroundEditorDialogModel::getSkyboxHeading()
 	angles a;
 	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
 	int d = static_cast<int>(fl2ir(fl_degrees(a.h)));
-	if (d < 0)
-		d += 360;
-	if (d >= 360)
-		d -= 360;
+	d = (d % 360 + 360) % 360; // wrap to [0, 359]
 	return d;
 }
 

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -1,6 +1,7 @@
 #include "FredApplication.h"
 #include "BackgroundEditorDialogModel.h"
 
+#include "graphics/light.h"
 #include "math/bitarray.h"
 #include "mission/missionparse.h"
 #include "nebula/neb.h"
@@ -748,7 +749,7 @@ void BackgroundEditorDialogModel::setFogB(int b)
 {
 	CLAMP(b, 0, 255)
 	const ubyte v = static_cast<ubyte>(b);
-	modify(Neb2_fog_color[0], v);
+	modify(Neb2_fog_color[2], v);
 }
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getOldNebulaPatternOptions() const
@@ -859,6 +860,60 @@ void BackgroundEditorDialogModel::setOldNebulaHeading(int deg)
 		Nebula_heading = deg;
 		modify(Nebula_heading, deg);
 	}
+}
+
+int BackgroundEditorDialogModel::getAmbientR() const
+{
+	return The_mission.ambient_light_level & 0xff;
+}
+
+void BackgroundEditorDialogModel::setAmbientR(int r)
+{
+	CLAMP(r, 1, 255);
+	
+	const int g = getAmbientG(), b = getAmbientB();
+	const int newCol = (r) | (g << 8) | (b << 16);
+	
+	modify(The_mission.ambient_light_level, newCol);
+
+	gr_set_ambient_light(r, g, b);
+	refreshBackgroundPreview();
+}
+
+int BackgroundEditorDialogModel::getAmbientG() const
+{
+	return (The_mission.ambient_light_level >> 8) & 0xff;
+}
+
+void BackgroundEditorDialogModel::setAmbientG(int g)
+{
+	CLAMP(g, 1, 255);
+
+	const int r = getAmbientR(), b = getAmbientB();
+	const int newCol = (r) | (g << 8) | (b << 16);
+
+	modify(The_mission.ambient_light_level, newCol);
+
+	gr_set_ambient_light(r, g, b);
+	refreshBackgroundPreview();
+}
+
+int BackgroundEditorDialogModel::getAmbientB() const
+{
+	return (The_mission.ambient_light_level >> 16) & 0xff;
+}
+
+void BackgroundEditorDialogModel::setAmbientB(int b)
+{
+	CLAMP(b, 1, 255);
+
+	const int r = getAmbientR(), g = getAmbientG();
+	const int newCol = (r) | (g << 8) | (b << 16);
+
+	modify(The_mission.ambient_light_level, newCol);
+
+	gr_set_ambient_light(r, g, b);
+	refreshBackgroundPreview();
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -138,6 +138,11 @@ void BackgroundEditorDialogModel::removeActiveBackground()
 	set_modified();
 
 	setActiveBackgroundIndex(newIdx);
+
+	// Ensure the swap index is still valid
+	if (!SCP_vector_inbounds(Backgrounds, _swapIndex)) {
+		_swapIndex = 0;
+	}
 }
 
 int BackgroundEditorDialogModel::getImportableBackgroundCount(const SCP_string& fs2Path) const

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -9,7 +9,7 @@
 #include "starfield/nebula.h"
 #include "lighting/lighting_profiles.h" 
 
-// TODO move this to common for both FREDs. Do not pass review if this is not done
+// TODO move this to common for both FREDs.
 const static float delta = .00001f;
 const static float default_nebula_range = 3000.0f;
 
@@ -56,7 +56,7 @@ void BackgroundEditorDialogModel::refreshBackgroundPreview()
 	_editor->missionChanged();
 }
 
-background_t& BackgroundEditorDialogModel::getActiveBackground() const
+background_t& BackgroundEditorDialogModel::getActiveBackground()
 {
 	if (!SCP_vector_inbounds(Backgrounds, Cur_background)) {
 		// Fall back to first background if Cur_background isn’t set
@@ -85,8 +85,15 @@ starfield_list_entry* BackgroundEditorDialogModel::getActiveSun() const
 	return &list[_selectedSunIndex];
 }
 
+int BackgroundEditorDialogModel::getNumBackgrounds() const
+{
+	return static_cast<int>(Backgrounds.size());
+}
+
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getBackgroundNames() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	SCP_vector<SCP_string> out;
 	out.reserve(Backgrounds.size());
 	for (size_t i = 0; i < Backgrounds.size(); ++i)
@@ -110,6 +117,8 @@ void BackgroundEditorDialogModel::setActiveBackgroundIndex(int idx)
 
 int BackgroundEditorDialogModel::getActiveBackgroundIndex() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	return Cur_background < 0 ? 0 : Cur_background;
 }
 
@@ -147,6 +156,8 @@ void BackgroundEditorDialogModel::removeActiveBackground()
 
 int BackgroundEditorDialogModel::getImportableBackgroundCount(const SCP_string& fs2Path) const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	// Normalize the filepath to use the current platform's directory separator
 	SCP_string path = fs2Path;
 	std::replace(path.begin(), path.end(), '/', DIR_SEPARATOR_CHAR);
@@ -248,7 +259,6 @@ void BackgroundEditorDialogModel::swapBackgrounds()
 	set_modified();
 
 	refreshBackgroundPreview();
-	return;
 }
 
 int BackgroundEditorDialogModel::getSwapWithIndex() const
@@ -288,6 +298,8 @@ void BackgroundEditorDialogModel::setSaveAnglesCorrectFlag(bool on)
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableBitmapNames() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	SCP_vector<SCP_string> out;
 	const int count = stars_get_num_entries(/*is_a_sun=*/false, /*bitmap_count=*/true);
 	out.reserve(count);
@@ -301,6 +313,8 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableBitmapNames() co
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getMissionBitmapNames() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	SCP_vector<SCP_string> out;
 	const auto& vec = getActiveBackground().bitmaps;
 	out.reserve(vec.size());
@@ -552,6 +566,8 @@ void BackgroundEditorDialogModel::setBitmapDivY(int v)
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableSunNames() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	SCP_vector<SCP_string> out;
 	const int count = stars_get_num_entries(/*is_a_sun=*/true, /*bitmap_count=*/true);
 	out.reserve(count);
@@ -565,6 +581,8 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableSunNames() const
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getMissionSunNames() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	SCP_vector<SCP_string> out;
 	const auto& vec = getActiveBackground().suns;
 	out.reserve(vec.size());
@@ -716,6 +734,8 @@ void BackgroundEditorDialogModel::setSunScale(float v)
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightningNames() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	SCP_vector<SCP_string> out;
 	out.emplace_back("<None>"); // legacy default
 	for (const auto& st : Storm_types) {
@@ -726,6 +746,8 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightningNames() const
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getNebulaPatternNames() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	SCP_vector<SCP_string> out;
 	out.emplace_back("<None>"); // matches legacy combo where index 0 = none
 	for (const auto& neb : Neb2_bitmap_filenames) {
@@ -736,6 +758,8 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getNebulaPatternNames() cons
 
 SCP_vector<SCP_string> BackgroundEditorDialogModel::getPoofNames() const
 {
+	Assertion(getNumBackgrounds() > 0, "There should always be at least one background");
+	
 	SCP_vector<SCP_string> out;
 	out.reserve(Poof_info.size());
 	for (const auto& p : Poof_info) {
@@ -744,7 +768,7 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getPoofNames() const
 	return out;
 }
 
-bool BackgroundEditorDialogModel::getFullNebulaEnabled() const
+bool BackgroundEditorDialogModel::getFullNebulaEnabled()
 {
 	return The_mission.flags[Mission::Mission_Flags::Fullneb];
 }
@@ -772,7 +796,7 @@ void BackgroundEditorDialogModel::setFullNebulaEnabled(bool enabled)
 	set_modified();
 }
 
-float BackgroundEditorDialogModel::getFullNebulaRange() const
+float BackgroundEditorDialogModel::getFullNebulaRange()
 {
 	// May be -1 if full nebula is disabled
 	return Neb2_awacs;
@@ -783,7 +807,7 @@ void BackgroundEditorDialogModel::setFullNebulaRange(float range)
 	modify(Neb2_awacs, range);
 }
 
-SCP_string BackgroundEditorDialogModel::getNebulaFullPattern() const
+SCP_string BackgroundEditorDialogModel::getNebulaFullPattern()
 {
 	return (Neb2_texture_name[0] != '\0') ? SCP_string(Neb2_texture_name) : SCP_string("<None>");
 }
@@ -799,7 +823,7 @@ void BackgroundEditorDialogModel::setNebulaFullPattern(const SCP_string& name)
 	set_modified();
 }
 
-SCP_string BackgroundEditorDialogModel::getLightning() const
+SCP_string BackgroundEditorDialogModel::getLightning()
 {
 	// Return "<none>" when engine stores "none" or empty
 	if (Mission_parse_storm_name[0] == '\0')
@@ -821,7 +845,7 @@ void BackgroundEditorDialogModel::setLightning(const SCP_string& name)
 	set_modified();
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getSelectedPoofs() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getSelectedPoofs()
 {
 	SCP_vector<SCP_string> out;
 	for (size_t i = 0; i < Poof_info.size(); ++i) {
@@ -847,7 +871,7 @@ void BackgroundEditorDialogModel::setSelectedPoofs(const SCP_vector<SCP_string>&
 	set_modified();
 }
 
-bool BackgroundEditorDialogModel::getShipTrailsToggled() const
+bool BackgroundEditorDialogModel::getShipTrailsToggled()
 {
 	return The_mission.flags[Mission::Mission_Flags::Toggle_ship_trails];
 }
@@ -858,7 +882,7 @@ void BackgroundEditorDialogModel::setShipTrailsToggled(bool on)
 	set_modified();
 }
 
-float BackgroundEditorDialogModel::getFogNearMultiplier() const
+float BackgroundEditorDialogModel::getFogNearMultiplier()
 {
 	return Neb2_fog_near_mult;
 }
@@ -868,7 +892,7 @@ void BackgroundEditorDialogModel::setFogNearMultiplier(float v)
 	modify(Neb2_fog_near_mult, v);
 }
 
-float BackgroundEditorDialogModel::getFogFarMultiplier() const
+float BackgroundEditorDialogModel::getFogFarMultiplier()
 {
 	return Neb2_fog_far_mult;
 }
@@ -878,7 +902,7 @@ void BackgroundEditorDialogModel::setFogFarMultiplier(float v)
 	modify(Neb2_fog_far_mult, v);
 }
 
-bool BackgroundEditorDialogModel::getDisplayBackgroundBitmaps() const
+bool BackgroundEditorDialogModel::getDisplayBackgroundBitmaps()
 {
 	return The_mission.flags[Mission::Mission_Flags::Fullneb_background_bitmaps];
 }
@@ -889,7 +913,7 @@ void BackgroundEditorDialogModel::setDisplayBackgroundBitmaps(bool on)
 	set_modified();
 }
 
-bool BackgroundEditorDialogModel::getFogPaletteOverride() const
+bool BackgroundEditorDialogModel::getFogPaletteOverride()
 {
 	return The_mission.flags[Mission::Mission_Flags::Neb2_fog_color_override];
 }
@@ -900,7 +924,7 @@ void BackgroundEditorDialogModel::setFogPaletteOverride(bool on)
 	set_modified();
 }
 
-int BackgroundEditorDialogModel::getFogR() const
+int BackgroundEditorDialogModel::getFogR()
 {
 	return Neb2_fog_color[0];
 }
@@ -908,11 +932,11 @@ int BackgroundEditorDialogModel::getFogR() const
 void BackgroundEditorDialogModel::setFogR(int r)
 {
 	CLAMP(r, 0, 255)
-	const ubyte v = static_cast<ubyte>(r);
+	const auto v = static_cast<ubyte>(r);
 	modify(Neb2_fog_color[0], v);
 }
 
-int BackgroundEditorDialogModel::getFogG() const
+int BackgroundEditorDialogModel::getFogG()
 {
 	return Neb2_fog_color[1];
 }
@@ -920,11 +944,11 @@ int BackgroundEditorDialogModel::getFogG() const
 void BackgroundEditorDialogModel::setFogG(int g)
 {
 	CLAMP(g, 0, 255)
-	const ubyte v = static_cast<ubyte>(g);
+	const auto v = static_cast<ubyte>(g);
 	modify(Neb2_fog_color[1], v);
 }
 
-int BackgroundEditorDialogModel::getFogB() const
+int BackgroundEditorDialogModel::getFogB()
 {
 	return Neb2_fog_color[2];
 }
@@ -932,11 +956,11 @@ int BackgroundEditorDialogModel::getFogB() const
 void BackgroundEditorDialogModel::setFogB(int b)
 {
 	CLAMP(b, 0, 255)
-	const ubyte v = static_cast<ubyte>(b);
+	const auto v = static_cast<ubyte>(b);
 	modify(Neb2_fog_color[2], v);
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getOldNebulaPatternOptions() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getOldNebulaPatternOptions()
 {
 	SCP_vector<SCP_string> out;
 	out.emplace_back("<None>");
@@ -946,7 +970,7 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getOldNebulaPatternOptions()
 	return out;
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getOldNebulaColorOptions() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getOldNebulaColorOptions()
 {
 	SCP_vector<SCP_string> out;
 	out.reserve(NUM_NEBULA_COLORS);
@@ -956,7 +980,7 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getOldNebulaColorOptions() c
 	return out;
 }
 
-SCP_string BackgroundEditorDialogModel::getOldNebulaPattern() const
+SCP_string BackgroundEditorDialogModel::getOldNebulaPattern()
 {
 	if (Nebula_index < 0)
 		return "<None>";
@@ -983,7 +1007,7 @@ void BackgroundEditorDialogModel::setOldNebulaPattern(const SCP_string& name)
 	modify(Nebula_index, newIndex);
 }
 
-SCP_string BackgroundEditorDialogModel::getOldNebulaColorName() const
+SCP_string BackgroundEditorDialogModel::getOldNebulaColorName()
 {
 	if (Mission_palette >= 0 && Mission_palette < NUM_NEBULA_COLORS) {
 		return Nebula_colors[Mission_palette];
@@ -1004,7 +1028,7 @@ void BackgroundEditorDialogModel::setOldNebulaColorName(const SCP_string& name)
 	// name not found: ignore
 }
 
-int BackgroundEditorDialogModel::getOldNebulaPitch() const
+int BackgroundEditorDialogModel::getOldNebulaPitch()
 {
 	return Nebula_pitch;
 }
@@ -1018,7 +1042,7 @@ void BackgroundEditorDialogModel::setOldNebulaPitch(int deg)
 	}
 }
 
-int BackgroundEditorDialogModel::getOldNebulaBank() const
+int BackgroundEditorDialogModel::getOldNebulaBank()
 {
 	return Nebula_bank;
 }
@@ -1032,7 +1056,7 @@ void BackgroundEditorDialogModel::setOldNebulaBank(int deg)
 	}
 }
 
-int BackgroundEditorDialogModel::getOldNebulaHeading() const
+int BackgroundEditorDialogModel::getOldNebulaHeading()
 {
 	return Nebula_heading;
 }
@@ -1046,7 +1070,7 @@ void BackgroundEditorDialogModel::setOldNebulaHeading(int deg)
 	}
 }
 
-int BackgroundEditorDialogModel::getAmbientR() const
+int BackgroundEditorDialogModel::getAmbientR()
 {
 	return The_mission.ambient_light_level & 0xff;
 }
@@ -1064,7 +1088,7 @@ void BackgroundEditorDialogModel::setAmbientR(int r)
 	refreshBackgroundPreview();
 }
 
-int BackgroundEditorDialogModel::getAmbientG() const
+int BackgroundEditorDialogModel::getAmbientG()
 {
 	return (The_mission.ambient_light_level >> 8) & 0xff;
 }
@@ -1082,7 +1106,7 @@ void BackgroundEditorDialogModel::setAmbientG(int g)
 	refreshBackgroundPreview();
 }
 
-int BackgroundEditorDialogModel::getAmbientB() const
+int BackgroundEditorDialogModel::getAmbientB()
 {
 	return (The_mission.ambient_light_level >> 16) & 0xff;
 }
@@ -1100,7 +1124,7 @@ void BackgroundEditorDialogModel::setAmbientB(int b)
 	refreshBackgroundPreview();
 }
 
-SCP_string BackgroundEditorDialogModel::getSkyboxModelName() const
+SCP_string BackgroundEditorDialogModel::getSkyboxModelName()
 {
 	return The_mission.skybox_model;
 }
@@ -1116,7 +1140,7 @@ void BackgroundEditorDialogModel::setSkyboxModelName(const SCP_string& name)
 	refreshBackgroundPreview();
 }
 
-bool BackgroundEditorDialogModel::getSkyboxNoLighting() const
+bool BackgroundEditorDialogModel::getSkyboxNoLighting()
 {
 	return (The_mission.skybox_flags & MR_NO_LIGHTING) != 0;
 }
@@ -1132,7 +1156,7 @@ void BackgroundEditorDialogModel::setSkyboxNoLighting(bool on)
 	set_modified();
 }
 
-bool BackgroundEditorDialogModel::getSkyboxAllTransparent() const
+bool BackgroundEditorDialogModel::getSkyboxAllTransparent()
 {
 	return (The_mission.skybox_flags & MR_ALL_XPARENT) != 0;
 }
@@ -1148,7 +1172,7 @@ void BackgroundEditorDialogModel::setSkyboxAllTransparent(bool on)
 	set_modified();
 }
 
-bool BackgroundEditorDialogModel::getSkyboxNoZbuffer() const
+bool BackgroundEditorDialogModel::getSkyboxNoZbuffer()
 {
 	return (The_mission.skybox_flags & MR_NO_ZBUFFER) != 0;
 }
@@ -1164,7 +1188,7 @@ void BackgroundEditorDialogModel::setSkyboxNoZbuffer(bool on)
 	set_modified();
 }
 
-bool BackgroundEditorDialogModel::getSkyboxNoCull() const
+bool BackgroundEditorDialogModel::getSkyboxNoCull()
 {
 	return (The_mission.skybox_flags & MR_NO_CULL) != 0;
 }
@@ -1180,7 +1204,7 @@ void BackgroundEditorDialogModel::setSkyboxNoCull(bool on)
 	set_modified();
 }
 
-bool BackgroundEditorDialogModel::getSkyboxNoGlowmaps() const
+bool BackgroundEditorDialogModel::getSkyboxNoGlowmaps()
 {
 	return (The_mission.skybox_flags & MR_NO_GLOWMAPS) != 0;
 }
@@ -1196,7 +1220,7 @@ void BackgroundEditorDialogModel::setSkyboxNoGlowmaps(bool on)
 	set_modified();
 }
 
-bool BackgroundEditorDialogModel::getSkyboxForceClamp() const
+bool BackgroundEditorDialogModel::getSkyboxForceClamp()
 {
 	return (The_mission.skybox_flags & MR_FORCE_CLAMP) != 0;
 }
@@ -1212,7 +1236,7 @@ void BackgroundEditorDialogModel::setSkyboxForceClamp(bool on)
 	set_modified();
 }
 
-int BackgroundEditorDialogModel::getSkyboxPitch() const
+int BackgroundEditorDialogModel::getSkyboxPitch()
 {
 	angles a;
 	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
@@ -1238,7 +1262,7 @@ void BackgroundEditorDialogModel::setSkyboxPitch(int deg)
 	}
 }
 
-int BackgroundEditorDialogModel::getSkyboxBank() const
+int BackgroundEditorDialogModel::getSkyboxBank()
 {
 	angles a;
 	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
@@ -1264,7 +1288,7 @@ void BackgroundEditorDialogModel::setSkyboxBank(int deg)
 	}
 }
 
-int BackgroundEditorDialogModel::getSkyboxHeading() const
+int BackgroundEditorDialogModel::getSkyboxHeading()
 {
 	angles a;
 	vm_extract_angles_matrix(&a, &The_mission.skybox_orientation);
@@ -1290,7 +1314,7 @@ void BackgroundEditorDialogModel::setSkyboxHeading(int deg)
 	}
 }
 
-SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightingProfileOptions() const
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightingProfileOptions()
 {
 	SCP_vector<SCP_string> out;
 	auto profiles = lighting_profiles::list_profiles(); // returns a vector of names
@@ -1300,7 +1324,7 @@ SCP_vector<SCP_string> BackgroundEditorDialogModel::getLightingProfileOptions() 
 	return out;
 }
 
-int BackgroundEditorDialogModel::getNumStars() const
+int BackgroundEditorDialogModel::getNumStars()
 {
 	return Num_stars;
 }
@@ -1312,7 +1336,7 @@ void BackgroundEditorDialogModel::setNumStars(int n)
 	refreshBackgroundPreview(); // TODO make this actually show the stars in the background
 }
 
-bool BackgroundEditorDialogModel::getTakesPlaceInSubspace() const
+bool BackgroundEditorDialogModel::getTakesPlaceInSubspace()
 {
 	return The_mission.flags[Mission::Mission_Flags::Subspace];
 }
@@ -1328,7 +1352,7 @@ void BackgroundEditorDialogModel::setTakesPlaceInSubspace(bool on)
 	set_modified();
 }
 
-SCP_string BackgroundEditorDialogModel::getEnvironmentMapName() const
+SCP_string BackgroundEditorDialogModel::getEnvironmentMapName()
 {
 	return SCP_string(The_mission.envmap_name);
 }
@@ -1343,7 +1367,7 @@ void BackgroundEditorDialogModel::setEnvironmentMapName(const SCP_string& name)
 	set_modified();
 }
 
-SCP_string BackgroundEditorDialogModel::getLightingProfileName() const
+SCP_string BackgroundEditorDialogModel::getLightingProfileName()
 {
 	return The_mission.lighting_profile_name;
 }

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -1,0 +1,336 @@
+#include "FredApplication.h"
+#include "BackgroundEditorDialogModel.h"
+
+//#include "mission/missionparse.h"
+
+// TODO move this to common for both FREDs. Do not pass review if this is not done
+const static float delta = .00001f;
+
+namespace fso::fred::dialogs {
+BackgroundEditorDialogModel::BackgroundEditorDialogModel(QObject* parent, EditorViewport* viewport)
+	: AbstractDialogModel(parent, viewport)
+{
+	// may not need these because I don't think anything else can modify data that this dialog works with
+	connect(_editor, &Editor::currentObjectChanged, this, &BackgroundEditorDialogModel::onEditorSelectionChanged);
+	connect(_editor, &Editor::missionChanged, this, &BackgroundEditorDialogModel::onEditorMissionChanged);
+
+	auto& bg = getActiveBackground();
+	auto& list = bg.bitmaps;
+	if (!list.empty()) {
+		_selectedBitmapIndex = 0;
+	}
+}
+
+bool BackgroundEditorDialogModel::apply()
+{
+	// do the OnClose stuff here
+	return true;
+}
+
+void BackgroundEditorDialogModel::reject()
+{
+	// do nothing?
+}
+
+void BackgroundEditorDialogModel::onEditorSelectionChanged(int)
+{
+	// reload?
+}
+
+void BackgroundEditorDialogModel::onEditorMissionChanged()
+{
+	// reload?
+}
+
+background_t& BackgroundEditorDialogModel::getActiveBackground() const
+{
+	if (!SCP_vector_inbounds(Backgrounds, Cur_background)) {
+		// Fall back to first background if Cur_background isn’t set
+		Cur_background = 0;
+	}
+	return Backgrounds[Cur_background];
+}
+
+starfield_list_entry* BackgroundEditorDialogModel::getActiveBitmap() const
+{
+	auto& bg = getActiveBackground();
+	auto& list = bg.bitmaps;
+	if (!SCP_vector_inbounds(list, _selectedBitmapIndex)) {
+		return nullptr;
+	}
+	return &list[_selectedBitmapIndex];
+}
+
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getAvailableBitmapNames() const
+{
+	SCP_vector<SCP_string> out;
+	const int count = stars_get_num_entries(/*is_a_sun=*/false, /*bitmap_count=*/true);
+	out.reserve(count);
+	for (int i = 0; i < count; ++i) {
+		if (const char* name = stars_get_name_FRED(i, /*is_a_sun=*/false)) {
+			out.emplace_back(name);
+		}
+	}
+	return out;
+}
+
+SCP_vector<SCP_string> BackgroundEditorDialogModel::getMissionBitmapNames() const
+{
+	SCP_vector<SCP_string> out;
+	const auto& vec = getActiveBackground().bitmaps;
+	out.reserve(vec.size());
+	for (const auto& sle : vec) {
+		out.emplace_back(sle.filename);
+	}
+	return out;
+}
+
+void BackgroundEditorDialogModel::refreshBackgroundPreview()
+{
+	stars_load_background(Cur_background); // rebuild instances from Backgrounds[]
+	if (_viewport) {
+		_viewport->needsUpdate();          // schedule a repaint
+	}
+}
+
+void BackgroundEditorDialogModel::setSelectedBitmapIndex(int index)
+{
+	const auto& bg = getActiveBackground();
+	const auto& list = bg.bitmaps;
+	if (!SCP_vector_inbounds(list, index)) {
+		_selectedBitmapIndex = -1;
+		return;
+	}
+	_selectedBitmapIndex = index;
+}
+
+int BackgroundEditorDialogModel::getSelectedBitmapIndex() const
+{
+	return _selectedBitmapIndex;
+}
+
+void BackgroundEditorDialogModel::addMissionBitmapByName(const SCP_string& name)
+{
+	if (name.empty())
+		return;
+
+	// Must exist in tables
+	if (stars_find_bitmap(name.c_str()) < 0)
+		return;
+
+	starfield_list_entry sle{};
+	std::strncpy(sle.filename, name.c_str(), MAX_FILENAME_LEN - 1);
+	sle.ang.p = 0.0f;
+	sle.ang.b = 0.0f;
+	sle.ang.h = 0.0f;
+	sle.scale_x = 1.0f;
+	sle.scale_y = 1.0f;
+	sle.div_x = 1;
+	sle.div_y = 1;
+
+	auto& list = getActiveBackground().bitmaps;
+	list.push_back(sle);
+
+	_selectedBitmapIndex = static_cast<int>(list.size()) - 1;
+
+	set_modified();
+	refreshBackgroundPreview();
+}
+
+void BackgroundEditorDialogModel::removeMissionBitmap()
+{
+	auto& list = getActiveBackground().bitmaps;
+
+	// Make sure we have an active bitmap
+	if (getActiveBitmap() == nullptr) {
+		return;
+	}
+
+	list.erase(list.begin() + _selectedBitmapIndex);
+	
+	// choose a sensible new selection
+	if (list.empty()) {
+		_selectedBitmapIndex = -1;
+	} else {
+		_selectedBitmapIndex = std::min(_selectedBitmapIndex, static_cast<int>(list.size()) - 1);
+	}
+
+	set_modified();
+	refreshBackgroundPreview();
+}
+
+SCP_string BackgroundEditorDialogModel::getBitmapName() const
+{
+	auto bm = getActiveBitmap();
+	if (bm == nullptr) {
+		return "";
+	}
+
+	return bm->filename;
+}
+
+void BackgroundEditorDialogModel::setBitmapName(const SCP_string& name)
+{
+	if (name.empty())
+		return;
+
+	// Must exist in tables
+	if (stars_find_bitmap(name.c_str()) < 0)
+		return;
+
+	auto bm = getActiveBitmap();
+	if (bm != nullptr) {
+		strcpy_s(bm->filename, name.c_str());
+		set_modified();
+		refreshBackgroundPreview();
+	}
+}
+
+int BackgroundEditorDialogModel::getBitmapPitch() const
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return -1;
+
+	return fl2ir(fl_degrees(bm->ang.p) + delta);
+}
+
+void BackgroundEditorDialogModel::setBitmapPitch(int deg)
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return;
+
+	CLAMP(deg, getOrientLimit().first, getOrientLimit().second);
+	modify(bm->ang.p, fl_radians(deg));
+
+	refreshBackgroundPreview();
+}
+
+int BackgroundEditorDialogModel::getBitmapBank() const
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return -1;
+
+	return fl2ir(fl_degrees(bm->ang.b) + delta);
+}
+
+void BackgroundEditorDialogModel::setBitmapBank(int deg)
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return;
+
+	CLAMP(deg, getOrientLimit().first, getOrientLimit().second);
+	modify(bm->ang.b, fl_radians(deg));
+
+	refreshBackgroundPreview();
+}
+
+int BackgroundEditorDialogModel::getBitmapHeading() const
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return -1;
+
+	return fl2ir(fl_degrees(bm->ang.h) + delta);
+}
+
+void BackgroundEditorDialogModel::setBitmapHeading(int deg)
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return;
+
+	CLAMP(deg, getOrientLimit().first, getOrientLimit().second);
+	modify(bm->ang.h, fl_radians(deg));
+
+	refreshBackgroundPreview();
+}
+
+float BackgroundEditorDialogModel::getBitmapScaleX() const
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return -1.0f;
+
+	return bm->scale_x;
+}
+
+void BackgroundEditorDialogModel::setBitmapScaleX(float v)
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return;
+
+	CLAMP(v, getScaleLimit().first, getScaleLimit().second);
+	modify(bm->scale_x, v);
+
+	refreshBackgroundPreview();
+}
+
+float BackgroundEditorDialogModel::getBitmapScaleY() const
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return -1.0f;
+
+	return bm->scale_y;
+}
+
+void BackgroundEditorDialogModel::setBitmapScaleY(float v)
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return;
+
+	CLAMP(v, getScaleLimit().first, getScaleLimit().second);
+	modify(bm->scale_y, v);
+
+	refreshBackgroundPreview();
+}
+
+int BackgroundEditorDialogModel::getBitmapDivX() const
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return -1;
+
+	return bm->div_x;
+}
+
+void BackgroundEditorDialogModel::setBitmapDivX(int v)
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return;
+
+	CLAMP(v, getDivisionLimit().first, getDivisionLimit().second);
+	modify(bm->div_x, v);
+
+	refreshBackgroundPreview();
+}
+
+int BackgroundEditorDialogModel::getBitmapDivY() const
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return -1;
+
+	return bm->div_y;
+}
+
+void BackgroundEditorDialogModel::setBitmapDivY(int v)
+{
+	auto* bm = getActiveBitmap();
+	if (!bm)
+		return;
+
+	CLAMP(v, getDivisionLimit().first, getDivisionLimit().second);
+	modify(bm->div_y, v);
+
+	refreshBackgroundPreview();
+}
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -122,6 +122,28 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	int getAmbientB() const;
 	void setAmbientB(int b);
 
+	// skybox group
+	std::string getSkyboxModelName() const;
+	void setSkyboxModelName(const std::string& name);
+	bool getSkyboxNoLighting() const;
+	void setSkyboxNoLighting(bool on);
+	bool getSkyboxAllTransparent() const;
+	void setSkyboxAllTransparent(bool on);
+	bool getSkyboxNoZbuffer() const;
+	void setSkyboxNoZbuffer(bool on);
+	bool getSkyboxNoCull() const;
+	void setSkyboxNoCull(bool on);
+	bool getSkyboxNoGlowmaps() const;
+	void setSkyboxNoGlowmaps(bool on);
+	bool getSkyboxForceClamp() const;
+	void setSkyboxForceClamp(bool on);
+	int getSkyboxPitch() const;
+	void setSkyboxPitch(int deg);
+	int getSkyboxBank() const;
+	void setSkyboxBank(int deg);
+	int getSkyboxHeading() const;
+	void setSkyboxHeading(int deg);
+
   private:
 	void refreshBackgroundPreview();
 	background_t& getActiveBackground() const;

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -69,7 +69,52 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	float getSunScale() const; // uses scale_x for both x and y
 	void setSunScale(float v);
 
-  private: // NOLINT(readability-redundant-access-specifiers)
+	// nebula group
+	SCP_vector<SCP_string> getLightningNames() const;
+	SCP_vector<SCP_string> getNebulaPatternNames() const;
+	SCP_vector<SCP_string> getPoofNames() const;
+	bool getFullNebulaEnabled() const;
+	void setFullNebulaEnabled(bool enabled);
+	float getFullNebulaRange() const;
+	void setFullNebulaRange(float range);
+	SCP_string getNebulaFullPattern() const;
+	void setNebulaFullPattern(const SCP_string& name);
+	SCP_string getLightning() const;
+	void setLightning(const SCP_string& name);
+	SCP_vector<SCP_string> getSelectedPoofs() const;
+	void setSelectedPoofs(const SCP_vector<SCP_string>& names);
+	bool getShipTrailsToggled() const;
+	void setShipTrailsToggled(bool on);
+	float getFogNearMultiplier() const;
+	void setFogNearMultiplier(float v);
+	float getFogFarMultiplier() const;
+	void setFogFarMultiplier(float v);
+	bool getDisplayBackgroundBitmaps() const;
+	void setDisplayBackgroundBitmaps(bool on);
+	bool getFogPaletteOverride() const;
+	void setFogPaletteOverride(bool on);
+	int getFogR() const;
+	void setFogR(int r);
+	int getFogG() const;
+	void setFogG(int g);
+	int getFogB() const;
+	void setFogB(int b);
+
+	// old nebula group
+	SCP_vector<SCP_string> getOldNebulaPatternOptions() const;
+	SCP_vector<SCP_string> getOldNebulaColorOptions() const;
+	SCP_string getOldNebulaColorName() const;
+	void setOldNebulaColorName(const SCP_string& name);
+	SCP_string getOldNebulaPattern() const;
+	void setOldNebulaPattern(const SCP_string& name);
+	int getOldNebulaPitch() const;
+	void setOldNebulaPitch(int deg);
+	int getOldNebulaBank() const;
+	void setOldNebulaBank(int deg);
+	int getOldNebulaHeading() const;
+	void setOldNebulaHeading(int deg);
+
+  private:
 	void refreshBackgroundPreview();
 	background_t& getActiveBackground() const;
 	starfield_list_entry* getActiveBitmap() const;

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -77,8 +77,6 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	void setSunName(const SCP_string& name);
 	int getSunPitch() const;
 	void setSunPitch(int deg);
-	int getSunBank() const; // unused for suns but added for consistency
-	void setSunBank(int deg); // unused for suns but added for consistency
 	int getSunHeading() const;
 	void setSunHeading(int deg);
 	float getSunScale() const; // uses scale_x for both x and y

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -23,10 +23,11 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 
 	// limits
 	std::pair<int, int> getOrientLimit() const { return {0, 359}; }
-	std::pair<float, float> getScaleLimit() const { return {0.001f, 18.0f}; }
+	std::pair<float,float> getBitmapScaleLimit() const   { return {0.001f, 18.0f}; }
+	std::pair<float,float> getSunScaleLimit() const{ return {0.1f,   50.0f}; }
 	std::pair<int, int> getDivisionLimit() const { return {1, 5}; }
 
-	// bitmap group box
+	// bitmap group
 	SCP_vector<SCP_string> getAvailableBitmapNames() const;
 	SCP_vector<SCP_string> getMissionBitmapNames() const;
 	void setSelectedBitmapIndex(int index);
@@ -50,16 +51,32 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	int getBitmapDivY() const;
 	void setBitmapDivY(int v);
 
-  private slots:
-	void onEditorSelectionChanged(int); // currentObjectChanged
-	void onEditorMissionChanged();      // missionChanged
+	// sun group
+	SCP_vector<SCP_string> getAvailableSunNames() const;
+	SCP_vector<SCP_string> getMissionSunNames() const;
+	void setSelectedSunIndex(int index);
+	int getSelectedSunIndex() const;
+	void addMissionSunByName(const SCP_string& name);
+	void removeMissionSun();
+	SCP_string getSunName() const;
+	void setSunName(const SCP_string& name);
+	int getSunPitch() const;
+	void setSunPitch(int deg);
+	int getSunBank() const; // unused for suns but added for consistency
+	void setSunBank(int deg); // unused for suns but added for consistency
+	int getSunHeading() const;
+	void setSunHeading(int deg);
+	float getSunScale() const; // uses scale_x for both x and y
+	void setSunScale(float v);
 
   private: // NOLINT(readability-redundant-access-specifiers)
 	void refreshBackgroundPreview();
 	background_t& getActiveBackground() const;
 	starfield_list_entry* getActiveBitmap() const;
+	starfield_list_entry* getActiveSun() const;
 
 	int _selectedBitmapIndex = -1; // index into Backgrounds[Cur_background].bitmaps
+	int _selectedSunIndex = -1;    // index into Backgrounds[Cur_background].suns
 
 };
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -44,7 +44,7 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 
 	// bitmap group
 	static SCP_vector<SCP_string> getAvailableBitmapNames();
-	SCP_vector<SCP_string> getMissionBitmapNames() const;
+	static SCP_vector<SCP_string> getMissionBitmapNames();
 	void setSelectedBitmapIndex(int index);
 	int getSelectedBitmapIndex() const;
 	void addMissionBitmapByName(const SCP_string& name);

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -26,6 +26,7 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	std::pair<float,float> getBitmapScaleLimit() const   { return {0.001f, 18.0f}; }
 	std::pair<float,float> getSunScaleLimit() const{ return {0.1f,   50.0f}; }
 	std::pair<int, int> getDivisionLimit() const { return {1, 5}; }
+	std::pair<int, int> getStarsLimit() const { return {0, MAX_STARS}; }
 
 	// bitmap group
 	SCP_vector<SCP_string> getAvailableBitmapNames() const;
@@ -123,8 +124,8 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	void setAmbientB(int b);
 
 	// skybox group
-	std::string getSkyboxModelName() const;
-	void setSkyboxModelName(const std::string& name);
+	SCP_string getSkyboxModelName() const;
+	void setSkyboxModelName(const SCP_string& name);
 	bool getSkyboxNoLighting() const;
 	void setSkyboxNoLighting(bool on);
 	bool getSkyboxAllTransparent() const;
@@ -143,6 +144,17 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	void setSkyboxBank(int deg);
 	int getSkyboxHeading() const;
 	void setSkyboxHeading(int deg);
+
+	// misc group
+	SCP_vector<SCP_string> getLightingProfileOptions() const;
+	int getNumStars() const;
+	void setNumStars(int n);
+	bool getTakesPlaceInSubspace() const;
+	void setTakesPlaceInSubspace(bool on);
+	SCP_string getEnvironmentMapName() const;
+	void setEnvironmentMapName(const SCP_string& name);
+	SCP_string getLightingProfileName() const;
+	void setLightingProfileName(const SCP_string& name);
 
   private:
 	void refreshBackgroundPreview();

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include "AbstractDialogModel.h"
+
+#include "starfield/starfield.h"
+#include <globalincs/linklist.h>
+
+namespace fso::fred::dialogs {
+
+/**
+ * @brief QTFred's Wing Editor's Model
+ */
+class BackgroundEditorDialogModel : public AbstractDialogModel {
+	Q_OBJECT
+
+  public:
+	BackgroundEditorDialogModel(QObject* parent, EditorViewport* viewport);
+
+	bool apply() override;
+	void reject() override;
+
+	// limits
+	std::pair<int, int> getOrientLimit() const { return {0, 359}; }
+	std::pair<float, float> getScaleLimit() const { return {0.001f, 18.0f}; }
+	std::pair<int, int> getDivisionLimit() const { return {1, 5}; }
+
+	// bitmap group box
+	SCP_vector<SCP_string> getAvailableBitmapNames() const;
+	SCP_vector<SCP_string> getMissionBitmapNames() const;
+	void setSelectedBitmapIndex(int index);
+	int getSelectedBitmapIndex() const;
+	void addMissionBitmapByName(const SCP_string& name);
+	void removeMissionBitmap();
+	SCP_string getBitmapName() const;
+	void setBitmapName(const SCP_string& name);
+	int getBitmapPitch() const;
+	void setBitmapPitch(int deg);
+	int getBitmapBank() const;
+	void setBitmapBank(int deg);
+	int getBitmapHeading() const;
+	void setBitmapHeading(int deg);
+	float getBitmapScaleX() const;
+	void setBitmapScaleX(float v);
+	float getBitmapScaleY() const;
+	void setBitmapScaleY(float v);
+	int getBitmapDivX() const;
+	void setBitmapDivX(int v);
+	int getBitmapDivY() const;
+	void setBitmapDivY(int v);
+
+  private slots:
+	void onEditorSelectionChanged(int); // currentObjectChanged
+	void onEditorMissionChanged();      // missionChanged
+
+  private: // NOLINT(readability-redundant-access-specifiers)
+	void refreshBackgroundPreview();
+	background_t& getActiveBackground() const;
+	starfield_list_entry* getActiveBitmap() const;
+
+	int _selectedBitmapIndex = -1; // index into Backgrounds[Cur_background].bitmaps
+
+};
+} // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -29,21 +29,21 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	static std::pair<int, int> getStarsLimit() { return {0, MAX_STARS}; }
 
 	// backgrounds group
-	SCP_vector<SCP_string> getBackgroundNames() const;
+	static SCP_vector<SCP_string> getBackgroundNames();
 	void setActiveBackgroundIndex(int idx); 
-	int getActiveBackgroundIndex() const;
+	static int getActiveBackgroundIndex();
 	void addBackground();
 	void removeActiveBackground();
-	int getImportableBackgroundCount(const SCP_string& fs2Path) const;
+	static int getImportableBackgroundCount(const SCP_string& fs2Path);
 	bool importBackgroundFromMission(const SCP_string& fs2Path, int whichIndex);
 	void swapBackgrounds();
 	void setSwapWithIndex(int idx);
 	int getSwapWithIndex() const;
 	void setSaveAnglesCorrectFlag(bool on);
-	bool getSaveAnglesCorrectFlag() const;
+	static bool getSaveAnglesCorrectFlag();
 
 	// bitmap group
-	SCP_vector<SCP_string> getAvailableBitmapNames() const;
+	static SCP_vector<SCP_string> getAvailableBitmapNames();
 	SCP_vector<SCP_string> getMissionBitmapNames() const;
 	void setSelectedBitmapIndex(int index);
 	int getSelectedBitmapIndex() const;
@@ -67,8 +67,8 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	void setBitmapDivY(int v);
 
 	// sun group
-	SCP_vector<SCP_string> getAvailableSunNames() const;
-	SCP_vector<SCP_string> getMissionSunNames() const;
+	static SCP_vector<SCP_string> getAvailableSunNames();
+	static SCP_vector<SCP_string> getMissionSunNames();
 	void setSelectedSunIndex(int index);
 	int getSelectedSunIndex() const;
 	void addMissionSunByName(const SCP_string& name);
@@ -83,9 +83,9 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	void setSunScale(float v);
 
 	// nebula group
-	SCP_vector<SCP_string> getLightningNames() const;
-	SCP_vector<SCP_string> getNebulaPatternNames() const;
-	SCP_vector<SCP_string> getPoofNames() const;
+	static SCP_vector<SCP_string> getLightningNames();
+	static SCP_vector<SCP_string> getNebulaPatternNames();
+	static SCP_vector<SCP_string> getPoofNames();
 	static bool getFullNebulaEnabled();
 	void setFullNebulaEnabled(bool enabled);
 	static float getFullNebulaRange();
@@ -173,7 +173,6 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	static background_t& getActiveBackground();
 	starfield_list_entry* getActiveBitmap() const;
 	starfield_list_entry* getActiveSun() const;
-	int getNumBackgrounds() const;
 
 	int _selectedBitmapIndex = -1; // index into Backgrounds[Cur_background].bitmaps
 	int _selectedSunIndex = -1;    // index into Backgrounds[Cur_background].suns

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -22,11 +22,11 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	void reject() override;
 
 	// limits
-	std::pair<int, int> getOrientLimit() const { return {0, 359}; }
-	std::pair<float,float> getBitmapScaleLimit() const   { return {0.001f, 18.0f}; }
-	std::pair<float,float> getSunScaleLimit() const{ return {0.1f,   50.0f}; }
-	std::pair<int, int> getDivisionLimit() const { return {1, 5}; }
-	std::pair<int, int> getStarsLimit() const { return {0, MAX_STARS}; }
+	static std::pair<int, int> getOrientLimit() { return {0, 359}; }
+	static std::pair<float,float> getBitmapScaleLimit() { return {0.001f, 18.0f}; }
+	static std::pair<float,float> getSunScaleLimit() { return {0.1f,   50.0f}; }
+	static std::pair<int, int> getDivisionLimit() { return {1, 5}; }
+	static std::pair<int, int> getStarsLimit() { return {0, MAX_STARS}; }
 
 	// backgrounds group
 	SCP_vector<SCP_string> getBackgroundNames() const;
@@ -86,97 +86,98 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	SCP_vector<SCP_string> getLightningNames() const;
 	SCP_vector<SCP_string> getNebulaPatternNames() const;
 	SCP_vector<SCP_string> getPoofNames() const;
-	bool getFullNebulaEnabled() const;
+	static bool getFullNebulaEnabled();
 	void setFullNebulaEnabled(bool enabled);
-	float getFullNebulaRange() const;
+	static float getFullNebulaRange();
 	void setFullNebulaRange(float range);
-	SCP_string getNebulaFullPattern() const;
+	static SCP_string getNebulaFullPattern();
 	void setNebulaFullPattern(const SCP_string& name);
-	SCP_string getLightning() const;
+	static SCP_string getLightning();
 	void setLightning(const SCP_string& name);
-	SCP_vector<SCP_string> getSelectedPoofs() const;
+	static SCP_vector<SCP_string> getSelectedPoofs();
 	void setSelectedPoofs(const SCP_vector<SCP_string>& names);
-	bool getShipTrailsToggled() const;
+	static bool getShipTrailsToggled();
 	void setShipTrailsToggled(bool on);
-	float getFogNearMultiplier() const;
+	static float getFogNearMultiplier();
 	void setFogNearMultiplier(float v);
-	float getFogFarMultiplier() const;
+	static float getFogFarMultiplier();
 	void setFogFarMultiplier(float v);
-	bool getDisplayBackgroundBitmaps() const;
+	static bool getDisplayBackgroundBitmaps();
 	void setDisplayBackgroundBitmaps(bool on);
-	bool getFogPaletteOverride() const;
+	static bool getFogPaletteOverride();
 	void setFogPaletteOverride(bool on);
-	int getFogR() const;
+	static int getFogR();
 	void setFogR(int r);
-	int getFogG() const;
+	static int getFogG();
 	void setFogG(int g);
-	int getFogB() const;
+	static int getFogB();
 	void setFogB(int b);
 
 	// old nebula group
-	SCP_vector<SCP_string> getOldNebulaPatternOptions() const;
-	SCP_vector<SCP_string> getOldNebulaColorOptions() const;
-	SCP_string getOldNebulaColorName() const;
+	static SCP_vector<SCP_string> getOldNebulaPatternOptions();
+	static SCP_vector<SCP_string> getOldNebulaColorOptions();
+	static SCP_string getOldNebulaColorName();
 	void setOldNebulaColorName(const SCP_string& name);
-	SCP_string getOldNebulaPattern() const;
+	static SCP_string getOldNebulaPattern();
 	void setOldNebulaPattern(const SCP_string& name);
-	int getOldNebulaPitch() const;
+	static int getOldNebulaPitch();
 	void setOldNebulaPitch(int deg);
-	int getOldNebulaBank() const;
+	static int getOldNebulaBank();
 	void setOldNebulaBank(int deg);
-	int getOldNebulaHeading() const;
+	static int getOldNebulaHeading();
 	void setOldNebulaHeading(int deg);
 
 	// ambient light group
-	int getAmbientR() const;
+	static int getAmbientR();
 	void setAmbientR(int r);
-	int getAmbientG() const;
+	static int getAmbientG();
 	void setAmbientG(int g);
-	int getAmbientB() const;
+	static int getAmbientB();
 	void setAmbientB(int b);
 
 	// skybox group
-	SCP_string getSkyboxModelName() const;
+	static SCP_string getSkyboxModelName();
 	void setSkyboxModelName(const SCP_string& name);
-	bool getSkyboxNoLighting() const;
+	static bool getSkyboxNoLighting();
 	void setSkyboxNoLighting(bool on);
-	bool getSkyboxAllTransparent() const;
+	static bool getSkyboxAllTransparent();
 	void setSkyboxAllTransparent(bool on);
-	bool getSkyboxNoZbuffer() const;
+	static bool getSkyboxNoZbuffer();
 	void setSkyboxNoZbuffer(bool on);
-	bool getSkyboxNoCull() const;
+	static bool getSkyboxNoCull();
 	void setSkyboxNoCull(bool on);
-	bool getSkyboxNoGlowmaps() const;
+	static bool getSkyboxNoGlowmaps();
 	void setSkyboxNoGlowmaps(bool on);
-	bool getSkyboxForceClamp() const;
+	static bool getSkyboxForceClamp();
 	void setSkyboxForceClamp(bool on);
-	int getSkyboxPitch() const;
+	static int getSkyboxPitch();
 	void setSkyboxPitch(int deg);
-	int getSkyboxBank() const;
+	static int getSkyboxBank();
 	void setSkyboxBank(int deg);
-	int getSkyboxHeading() const;
+	static int getSkyboxHeading();
 	void setSkyboxHeading(int deg);
 
 	// misc group
-	SCP_vector<SCP_string> getLightingProfileOptions() const;
-	int getNumStars() const;
+	static SCP_vector<SCP_string> getLightingProfileOptions();
+	static int getNumStars();
 	void setNumStars(int n);
-	bool getTakesPlaceInSubspace() const;
+	static bool getTakesPlaceInSubspace();
 	void setTakesPlaceInSubspace(bool on);
-	SCP_string getEnvironmentMapName() const;
+	static SCP_string getEnvironmentMapName();
 	void setEnvironmentMapName(const SCP_string& name);
-	SCP_string getLightingProfileName() const;
+	static SCP_string getLightingProfileName();
 	void setLightingProfileName(const SCP_string& name);
 
   private:
 	void refreshBackgroundPreview();
-	background_t& getActiveBackground() const;
+	static background_t& getActiveBackground();
 	starfield_list_entry* getActiveBitmap() const;
 	starfield_list_entry* getActiveSun() const;
+	int getNumBackgrounds() const;
 
 	int _selectedBitmapIndex = -1; // index into Backgrounds[Cur_background].bitmaps
 	int _selectedSunIndex = -1;    // index into Backgrounds[Cur_background].suns
-	int _swapIndex = 0;           // index of background to swap with
+	int _swapIndex = 0;            // index of background to swap with
 
 };
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -28,6 +28,20 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	std::pair<int, int> getDivisionLimit() const { return {1, 5}; }
 	std::pair<int, int> getStarsLimit() const { return {0, MAX_STARS}; }
 
+	// backgrounds group
+	SCP_vector<SCP_string> getBackgroundNames() const;
+	void setActiveBackgroundIndex(int idx); 
+	int getActiveBackgroundIndex() const;
+	void addBackground();
+	void removeActiveBackground();
+	int getImportableBackgroundCount(const SCP_string& fs2Path) const;
+	bool importBackgroundFromMission(const SCP_string& fs2Path, int whichIndex);
+	void swapBackgrounds();
+	void setSwapWithIndex(int idx);
+	int getSwapWithIndex() const;
+	void setSaveAnglesCorrectFlag(bool on);
+	bool getSaveAnglesCorrectFlag() const;
+
 	// bitmap group
 	SCP_vector<SCP_string> getAvailableBitmapNames() const;
 	SCP_vector<SCP_string> getMissionBitmapNames() const;
@@ -164,6 +178,7 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 
 	int _selectedBitmapIndex = -1; // index into Backgrounds[Cur_background].bitmaps
 	int _selectedSunIndex = -1;    // index into Backgrounds[Cur_background].suns
+	int _swapIndex = 0;           // index of background to swap with
 
 };
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -114,6 +114,14 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	int getOldNebulaHeading() const;
 	void setOldNebulaHeading(int deg);
 
+	// ambient light group
+	int getAmbientR() const;
+	void setAmbientR(int r);
+	int getAmbientG() const;
+	void setAmbientG(int g);
+	int getAmbientB() const;
+	void setAmbientB(int b);
+
   private:
 	void refreshBackgroundPreview();
 	background_t& getActiveBackground() const;

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
@@ -40,6 +40,9 @@ void BackgroundEditorDialog::initializeUi()
 	ui->bitmapScaleYDoubleSpinBox->setRange(_model->getBitmapScaleLimit().first, _model->getBitmapScaleLimit().second);
 	ui->bitmapDivXSpinBox->setRange(_model->getDivisionLimit().first, _model->getDivisionLimit().second);
 	ui->bitmapDivYSpinBox->setRange(_model->getDivisionLimit().first, _model->getDivisionLimit().second);
+	ui->skyboxPitchSpin->setRange(_model->getOrientLimit().first, _model->getOrientLimit().second);
+	ui->skyboxBankSpin->setRange(_model->getOrientLimit().first, _model->getOrientLimit().second);
+	ui->skyboxHeadingSpin->setRange(_model->getOrientLimit().first, _model->getOrientLimit().second);
 
 	const auto& names = _model->getAvailableBitmapNames();
 
@@ -836,7 +839,7 @@ void BackgroundEditorDialog::updateAmbientSwatch()
 			.arg(b));
 }
 
-void BackgroundEditorDialog::on_skyboxButton_clicked()
+void BackgroundEditorDialog::on_skyboxModelButton_clicked()
 {
 	QSettings settings("QtFRED", "BackgroundEditor");
 	const QString lastDir = settings.value("skybox/lastDir", QDir::homePath()).toString();
@@ -858,6 +861,7 @@ void BackgroundEditorDialog::on_skyboxButton_clicked()
 void BackgroundEditorDialog::on_skyboxEdit_textChanged(const QString& arg1)
 {
 	_model->setSkyboxModelName(arg1.toUtf8().constData());
+	updateSkyboxControls();
 }
 
 void BackgroundEditorDialog::on_skyboxPitchSpin_valueChanged(int arg1)

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
@@ -1,23 +1,226 @@
 #include "BackgroundEditorDialog.h"
-
+#include "ui/util/SignalBlockers.h"
+#include "ui/dialogs/General/ImagePickerDialog.h"
 #include "ui_BackgroundEditor.h"
 
-namespace fso {
-namespace fred {
-namespace dialogs {
+#include <QMessageBox>
 
-BackgroundEditorDialog::BackgroundEditorDialog(FredView* parent, EditorViewport* viewport) :
-	QDialog(parent), ui(new Ui::BackgroundEditor()),
-	_viewport(viewport) {
-    ui->setupUi(this);
+namespace fso::fred::dialogs {
+
+BackgroundEditorDialog::BackgroundEditorDialog(FredView* parent, EditorViewport* viewport) : QDialog(parent), 
+	ui(new Ui::BackgroundEditor()), _model(new BackgroundEditorDialogModel(this, viewport)), _viewport(viewport) {
+    
+	ui->setupUi(this);
+
+	initializeUi();
 	
 	// Resize the dialog to the minimum size
 	resize(QDialog::sizeHint());
 }
 
-BackgroundEditorDialog::~BackgroundEditorDialog() {
-}
+BackgroundEditorDialog::~BackgroundEditorDialog() = default;
+
+void BackgroundEditorDialog::initializeUi()
+{
+	util::SignalBlockers blockers(this);
+
+	// Backgrounds
+	// TODO
+
+	// Bitmaps
+	ui->bitmapPitchSpin->setRange(_model->getOrientLimit().first, _model->getOrientLimit().second);
+	ui->bitmapBankSpin->setRange(_model->getOrientLimit().first, _model->getOrientLimit().second);
+	ui->bitmapHeadingSpin->setRange(_model->getOrientLimit().first, _model->getOrientLimit().second);
+	ui->bitmapScaleXDoubleSpinBox->setRange(_model->getScaleLimit().first, _model->getScaleLimit().second);
+	ui->bitmapScaleYDoubleSpinBox->setRange(_model->getScaleLimit().first, _model->getScaleLimit().second);
+	ui->bitmapDivXSpinBox->setRange(_model->getDivisionLimit().first, _model->getDivisionLimit().second);
+	ui->bitmapDivYSpinBox->setRange(_model->getDivisionLimit().first, _model->getDivisionLimit().second);
+	refreshBitmapList();
+
+	const auto& names = _model->getAvailableBitmapNames();
+	for (const auto& s : names){
+		ui->bitmapTypeCombo->addItem(QString::fromStdString(s));
+	}
 
 }
+
+void BackgroundEditorDialog::updateUi()
+{
+	util::SignalBlockers blockers(this);
+	// Backgrounds
+	// TODO
+	// Bitmaps
+	refreshBitmapList();
 }
+
+void BackgroundEditorDialog::refreshBitmapList()
+{
+	util::SignalBlockers blockers(this);
+	
+	const auto names = _model->getMissionBitmapNames();
+
+	const int oldRow = ui->bitmapListWidget->currentRow();
+	ui->bitmapListWidget->setUpdatesEnabled(false);
+	ui->bitmapListWidget->clear();
+
+	QStringList items;
+	items.reserve(static_cast<int>(names.size()));
+	for (const auto& s : names)
+		items << QString::fromStdString(s);
+	ui->bitmapListWidget->addItems(items);
+
+	if (!items.isEmpty()) {
+		const int clamped = qBound(0, oldRow, ui->bitmapListWidget->count() - 1);
+		ui->bitmapListWidget->setCurrentRow(clamped);
+	}
+
+	ui->bitmapListWidget->setUpdatesEnabled(true);
+
+	updateBitmapControls();
 }
+
+void BackgroundEditorDialog::updateBitmapControls()
+{
+	util::SignalBlockers blockers(this);
+	
+	bool enabled = (_model->getSelectedBitmapIndex() >= 0);
+	
+	ui->changeBitmapButton->setEnabled(enabled);
+	ui->deleteBitmapButton->setEnabled(enabled);
+	ui->bitmapTypeCombo->setEnabled(enabled);
+	ui->bitmapPitchSpin->setEnabled(enabled);
+	ui->bitmapBankSpin->setEnabled(enabled);
+	ui->bitmapHeadingSpin->setEnabled(enabled);
+	ui->bitmapScaleXDoubleSpinBox->setEnabled(enabled);
+	ui->bitmapScaleYDoubleSpinBox->setEnabled(enabled);
+	ui->bitmapDivXSpinBox->setEnabled(enabled);
+	ui->bitmapDivYSpinBox->setEnabled(enabled);
+
+	const int index = ui->bitmapTypeCombo->findText(QString::fromStdString(_model->getBitmapName()));
+	ui->bitmapTypeCombo->setCurrentIndex(index);
+
+	ui->bitmapPitchSpin->setValue(_model->getBitmapPitch());
+	ui->bitmapBankSpin->setValue(_model->getBitmapBank());
+	ui->bitmapHeadingSpin->setValue(_model->getBitmapHeading());
+	ui->bitmapScaleXDoubleSpinBox->setValue(_model->getBitmapScaleX());
+	ui->bitmapScaleYDoubleSpinBox->setValue(_model->getBitmapScaleY());
+	ui->bitmapDivXSpinBox->setValue(_model->getBitmapDivX());
+	ui->bitmapDivYSpinBox->setValue(_model->getBitmapDivY());
+}
+
+void BackgroundEditorDialog::on_bitmapListWidget_currentRowChanged(int row)
+{
+	_model->setSelectedBitmapIndex(row);
+	updateBitmapControls();
+}
+
+void BackgroundEditorDialog::on_bitmapTypeCombo_currentIndexChanged(int index)
+{
+	if (index < 0)
+		return;
+
+	const QString text = ui->bitmapTypeCombo->itemText(index);
+	_model->setBitmapName(text.toUtf8().constData());
+	refreshBitmapList();
+}
+
+void BackgroundEditorDialog::on_bitmapPitchSpin_valueChanged(int arg1)
+{
+	_model->setBitmapPitch(arg1);
+}
+
+void BackgroundEditorDialog::on_bitmapBankSpin_valueChanged(int arg1)
+{
+	_model->setBitmapBank(arg1);
+}
+
+void BackgroundEditorDialog::on_bitmapHeadingSpin_valueChanged(int arg1)
+{
+	_model->setBitmapHeading(arg1);
+}
+
+void BackgroundEditorDialog::on_bitmapScaleXDoubleSpinBox_valueChanged(double arg1)
+{
+	_model->setBitmapScaleX(static_cast<float>(arg1));
+}
+
+void BackgroundEditorDialog::on_bitmapScaleYDoubleSpinBox_valueChanged(double arg1)
+{
+	_model->setBitmapScaleY(static_cast<float>(arg1));
+}
+
+void BackgroundEditorDialog::on_bitmapDivXSpinBox_valueChanged(int arg1)
+{
+	_model->setBitmapDivX(arg1);
+}
+
+void BackgroundEditorDialog::on_bitmapDivYSpinBox_valueChanged(int arg1)
+{
+	_model->setBitmapDivY(arg1);
+}
+
+void BackgroundEditorDialog::on_addBitmapButton_clicked()
+{
+	const auto files = _model->getAvailableBitmapNames();
+	if (files.empty()) {
+		QMessageBox::information(this, "Select Background Bitmap", "No bitmaps found.");
+		return;
+	}
+
+	QStringList qnames;
+	qnames.reserve(static_cast<int>(files.size()));
+	for (const auto& s : files)
+		qnames << QString::fromStdString(s);
+
+	ImagePickerDialog dlg(this);
+	dlg.setWindowTitle("Select Background Bitmap");
+	dlg.setImageFilenames(qnames);
+
+	// Optional: preselect current
+	//dlg.setInitialSelection(QString::fromStdString(_model->getSquadLogo()));
+
+	if (dlg.exec() != QDialog::Accepted)
+		return;
+
+	const SCP_string chosen = dlg.selectedFile().toUtf8().constData();
+	_model->addMissionBitmapByName(chosen);
+
+	refreshBitmapList();
+}
+
+void BackgroundEditorDialog::on_changeBitmapButton_clicked()
+{
+	const auto files = _model->getAvailableBitmapNames();
+	if (files.empty()) {
+		QMessageBox::information(this, "Select Background Bitmap", "No bitmaps found.");
+		return;
+	}
+
+	QStringList qnames;
+	qnames.reserve(static_cast<int>(files.size()));
+	for (const auto& s : files)
+		qnames << QString::fromStdString(s);
+
+	ImagePickerDialog dlg(this);
+	dlg.setWindowTitle("Select Background Bitmap");
+	dlg.setImageFilenames(qnames);
+
+	// preselect current
+	dlg.setInitialSelection(QString::fromStdString(_model->getBitmapName()));
+
+	if (dlg.exec() != QDialog::Accepted)
+		return;
+
+	const SCP_string chosen = dlg.selectedFile().toUtf8().constData();
+	_model->setBitmapName(chosen);
+
+	refreshBitmapList();
+}
+
+void BackgroundEditorDialog::on_deleteBitmapButton_clicked()
+{
+	_model->removeMissionBitmap();
+	refreshBitmapList();
+}
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
@@ -4,6 +4,9 @@
 #include "ui_BackgroundEditor.h"
 
 #include <QMessageBox>
+#include <QSettings>
+#include <QFileDialog>
+#include <QFileInfo>
 
 namespace fso::fred::dialogs {
 
@@ -93,6 +96,10 @@ void BackgroundEditorDialog::initializeUi()
 	ui->ambientSwatch->setFrameShape(QFrame::Box);
 
 	updateAmbientLightControls();
+
+	// Skybox
+
+	updateSkyboxControls();
 
 }
 
@@ -306,6 +313,34 @@ void BackgroundEditorDialog::updateAmbientLightControls()
 	ui->ambientLightBlueLabel->setText(blueText);
 
 	updateAmbientSwatch();
+}
+
+void BackgroundEditorDialog::updateSkyboxControls()
+{
+	util::SignalBlockers blockers(this);
+	
+	bool enabled = !_model->getSkyboxModelName().empty();
+
+	ui->skyboxPitchSpin->setEnabled(enabled);
+	ui->skyboxBankSpin->setEnabled(enabled);
+	ui->skyboxHeadingSpin->setEnabled(enabled);
+	ui->noLightingCheckBox->setEnabled(enabled);
+	ui->transparentCheckBox->setEnabled(enabled);
+	ui->forceClampCheckBox->setEnabled(enabled);
+	ui->noZBufferCheckBox->setEnabled(enabled);
+	ui->noCullCheckBox->setEnabled(enabled);
+	ui->noGlowMapsCheckBox->setEnabled(enabled);
+
+	ui->skyboxEdit->setText(QString::fromStdString(_model->getSkyboxModelName()));
+	ui->skyboxPitchSpin->setValue(_model->getSkyboxPitch());
+	ui->skyboxBankSpin->setValue(_model->getSkyboxBank());
+	ui->skyboxHeadingSpin->setValue(_model->getSkyboxHeading());
+	ui->noLightingCheckBox->setChecked(_model->getSkyboxNoLighting());
+	ui->transparentCheckBox->setChecked(_model->getSkyboxAllTransparent());
+	ui->forceClampCheckBox->setChecked(_model->getSkyboxForceClamp());
+	ui->noZBufferCheckBox->setChecked(_model->getSkyboxNoZbuffer());
+	ui->noCullCheckBox->setChecked(_model->getSkyboxNoCull());
+	ui->noGlowMapsCheckBox->setChecked(_model->getSkyboxNoGlowmaps());
 }
 
 void BackgroundEditorDialog::on_bitmapListWidget_currentRowChanged(int row)
@@ -668,6 +703,80 @@ void BackgroundEditorDialog::updateAmbientSwatch()
 			.arg(r)
 			.arg(g)
 			.arg(b));
+}
+
+void BackgroundEditorDialog::on_skyboxButton_clicked()
+{
+	QSettings settings("QtFRED", "BackgroundEditor");
+	const QString lastDir = settings.value("skybox/lastDir", QDir::homePath()).toString();
+
+	const QString path =
+		QFileDialog::getOpenFileName(this, tr("Select Skybox Model"), lastDir, tr("FS2 Models (*.pof);;All Files (*)"));
+	if (path.isEmpty())
+		return;
+
+	const QFileInfo fi(path);
+	settings.setValue("skybox/lastDir", fi.absolutePath());
+
+	const QString baseName = fi.completeBaseName();
+	_model->setSkyboxModelName(baseName.toStdString());
+
+	updateSkyboxControls();
+}
+
+void BackgroundEditorDialog::on_skyboxEdit_textChanged(const QString& arg1)
+{
+	_model->setSkyboxModelName(arg1.toUtf8().constData());
+}
+
+void BackgroundEditorDialog::on_skyboxPitchSpin_valueChanged(int arg1)
+{
+	_model->setSkyboxPitch(arg1);
+}
+
+void BackgroundEditorDialog::on_skyboxBankSpin_valueChanged(int arg1)
+{
+	_model->setSkyboxBank(arg1);
+}
+
+void BackgroundEditorDialog::on_skyboxHeadingSpin_valueChanged(int arg1)
+{
+	_model->setSkyboxHeading(arg1);
+}
+
+void BackgroundEditorDialog::on_skyboxNoLightingCheckBox_toggled(bool checked)
+{
+	_model->setSkyboxNoLighting(checked);
+}
+
+void BackgroundEditorDialog::on_noLightingCheckBox_toggled(bool checked)
+{
+	_model->setSkyboxNoLighting(checked);
+}
+
+void BackgroundEditorDialog::on_transparentCheckBox_toggled(bool checked)
+{
+	_model->setSkyboxAllTransparent(checked);
+}
+
+void BackgroundEditorDialog::on_forceClampCheckBox_toggled(bool checked)
+{
+	_model->setSkyboxForceClamp(checked);
+}
+
+void BackgroundEditorDialog::on_noZBufferCheckBox_toggled(bool checked)
+{
+	_model->setSkyboxNoZbuffer(checked);
+}
+
+void BackgroundEditorDialog::on_noCullCheckBox_toggled(bool checked)
+{
+	_model->setSkyboxNoCull(checked);
+}
+
+void BackgroundEditorDialog::on_noGlowmapsCheckBox_toggled(bool checked)
+{
+	_model->setSkyboxNoGlowmaps(checked);
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
@@ -71,6 +71,8 @@ void BackgroundEditorDialog::initializeUi()
 		ui->poofsListWidget->addItem(QString::fromStdString(s));
 	}
 
+	ui->fogSwatch->setFrameShape(QFrame::Box);
+
 	updateNebulaControls();
 
 	// Old nebula
@@ -85,6 +87,12 @@ void BackgroundEditorDialog::initializeUi()
 	}
 
 	updateOldNebulaControls();
+
+	// Ambient light
+	ui->ambientSwatch->setMinimumSize(28, 28);
+	ui->ambientSwatch->setFrameShape(QFrame::Box);
+
+	updateAmbientLightControls();
 
 }
 
@@ -240,7 +248,21 @@ void BackgroundEditorDialog::updateNebulaControls()
 	ui->fogOverrideGreenSpinBox->setValue(_model->getFogG());
 	ui->fogOverrideBlueSpinBox->setValue(_model->getFogB());
 
+	updateFogSwatch();
+
 	updateOldNebulaControls();
+}
+
+void BackgroundEditorDialog::updateFogSwatch()
+{
+	const int r = _model->getFogR();
+	const int g = _model->getFogG();
+	const int b = _model->getFogB();
+	ui->fogSwatch->setStyleSheet(QString("background: rgb(%1,%2,%3);"
+											 "border: 1px solid #444; border-radius: 3px;")
+			.arg(r)
+			.arg(g)
+			.arg(b));
 }
 
 void BackgroundEditorDialog::updateOldNebulaControls()
@@ -261,6 +283,29 @@ void BackgroundEditorDialog::updateOldNebulaControls()
 	ui->oldNebulaPitchSpinBox->setValue(_model->getOldNebulaPitch());
 	ui->oldNebulaBankSpinBox->setValue(_model->getOldNebulaBank());
 	ui->oldNebulaHeadingSpinBox->setValue(_model->getOldNebulaHeading());
+}
+
+void BackgroundEditorDialog::updateAmbientLightControls()
+{
+	util::SignalBlockers blockers(this);
+	
+	const int r = _model->getAmbientR();
+	const int g = _model->getAmbientG();
+	const int b = _model->getAmbientB();
+
+	ui->ambientLightRedSlider->setValue(r);
+	ui->ambientLightGreenSlider->setValue(g);
+	ui->ambientLightBlueSlider->setValue(b);
+
+	QString redText = "R: " + QString::number(r);
+	QString greenText = "G: " + QString::number(g);
+	QString blueText = "B: " + QString::number(b);
+
+	ui->ambientLightRedLabel->setText(redText);
+	ui->ambientLightGreenLabel->setText(greenText);
+	ui->ambientLightBlueLabel->setText(blueText);
+
+	updateAmbientSwatch();
 }
 
 void BackgroundEditorDialog::on_bitmapListWidget_currentRowChanged(int row)
@@ -539,16 +584,19 @@ void BackgroundEditorDialog::on_overrideFogPaletteCheckBox_toggled(bool checked)
 void BackgroundEditorDialog::on_fogOverrideRedSpinBox_valueChanged(int arg1)
 {
 	_model->setFogR(arg1);
+	updateFogSwatch();
 }
 
 void BackgroundEditorDialog::on_fogOverrideGreenSpinBox_valueChanged(int arg1)
 {
 	_model->setFogG(arg1);
+	updateFogSwatch();
 }
 
 void BackgroundEditorDialog::on_fogOverrideBlueSpinBox_valueChanged(int arg1)
 {
 	_model->setFogB(arg1);
+	updateFogSwatch();
 }
 
 void BackgroundEditorDialog::on_oldNebulaPatternCombo_currentIndexChanged(int index)
@@ -581,6 +629,45 @@ void BackgroundEditorDialog::on_oldNebulaBankSpinBox_valueChanged(int arg1)
 void BackgroundEditorDialog::on_oldNebulaHeadingSpinBox_valueChanged(int arg1)
 {
 	_model->setOldNebulaHeading(arg1);
+}
+
+void BackgroundEditorDialog::on_ambientLightRedSlider_valueChanged(int value)
+{
+	_model->setAmbientR(value);
+	
+	QString text = "R: " + QString::number(value);
+	ui->ambientLightRedLabel->setText(text);
+	updateAmbientSwatch();
+}
+
+void BackgroundEditorDialog::on_ambientLightGreenSlider_valueChanged(int value)
+{
+	_model->setAmbientG(value);
+	
+	QString text = "G: " + QString::number(value);
+	ui->ambientLightGreenLabel->setText(text);
+	updateAmbientSwatch();
+}
+
+void BackgroundEditorDialog::on_ambientLightBlueSlider_valueChanged(int value)
+{
+	_model->setAmbientB(value);
+
+	QString text = "B: " + QString::number(value);
+	ui->ambientLightBlueLabel->setText(text);
+	updateAmbientSwatch();
+}
+
+void BackgroundEditorDialog::updateAmbientSwatch()
+{
+	const int r = _model->getAmbientR();
+	const int g = _model->getAmbientG();
+	const int b = _model->getAmbientB();
+	ui->ambientSwatch->setStyleSheet(QString("background: rgb(%1,%2,%3);"
+											 "border: 1px solid #444; border-radius: 3px;")
+			.arg(r)
+			.arg(g)
+			.arg(b));
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -71,6 +71,20 @@ private slots:
 	void on_ambientLightGreenSlider_valueChanged(int value);
 	void on_ambientLightBlueSlider_valueChanged(int value);
 
+	// Skybox
+	void on_skyboxButton_clicked();
+	void on_skyboxEdit_textChanged(const QString& arg1);
+	void on_skyboxPitchSpin_valueChanged(int arg1);
+	void on_skyboxBankSpin_valueChanged(int arg1);
+	void on_skyboxHeadingSpin_valueChanged(int arg1);
+	void on_skyboxNoLightingCheckBox_toggled(bool checked);
+	void on_noLightingCheckBox_toggled(bool checked);
+	void on_transparentCheckBox_toggled(bool checked);
+	void on_forceClampCheckBox_toggled(bool checked);
+	void on_noZBufferCheckBox_toggled(bool checked);
+	void on_noCullCheckBox_toggled(bool checked);
+	void on_noGlowmapsCheckBox_toggled(bool checked);
+
 private: // NOLINT(readability-redundant-access-specifiers)
     std::unique_ptr<Ui::BackgroundEditor> ui;
 	std::unique_ptr<BackgroundEditorDialogModel> _model;
@@ -87,6 +101,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	void updateOldNebulaControls();
 	void updateAmbientLightControls();
 	void updateAmbientSwatch();
+	void updateSkyboxControls();
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -20,6 +20,15 @@ public:
 
 private slots:
 
+	// Backgrounds
+	void on_backgroundSelectionCombo_currentIndexChanged(int index);
+	void on_addButton_clicked();
+	void on_removeButton_clicked();
+	void on_importButton_clicked();
+	void on_swapWithButton_clicked();
+	void on_swapWithCombo_currentIndexChanged(int index);
+	void on_useCorrectAngleFormatCheckBox_toggled(bool checked);
+
 	// Bitmaps
 	void on_bitmapListWidget_currentRowChanged(int row);
 	void on_bitmapTypeCombo_currentIndexChanged(int index);
@@ -99,6 +108,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 
 	void initializeUi();
 	void updateUi();
+	void updateBackgroundControls();
 	void refreshBitmapList();
 	void updateBitmapControls();
 	void refreshSunList();
@@ -110,6 +120,8 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	void updateAmbientSwatch();
 	void updateSkyboxControls();
 	void updateMiscControls();
+
+	int pickBackgroundIndexDialog(QWidget* parent, int count, int defaultIndex = 0);
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -121,7 +121,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	void updateSkyboxControls();
 	void updateMiscControls();
 
-	int pickBackgroundIndexDialog(QWidget* parent, int count, int defaultIndex = 0);
+	static int pickBackgroundIndexDialog(QWidget* parent, int count, int defaultIndex = 0);
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -1,32 +1,48 @@
 #pragma once
 
+#include "mission/dialogs/BackgroundEditorDialogModel.h"
 #include <QtWidgets/QDialog>
 
 #include <ui/FredView.h>
 
-namespace fso {
-namespace fred {
-namespace dialogs {
+namespace fso::fred::dialogs {
 
 namespace Ui {
 class BackgroundEditor;
 }
 
-class BackgroundEditorDialog : public QDialog
-{
+class BackgroundEditorDialog : public QDialog {
     Q_OBJECT
 
 public:
     explicit BackgroundEditorDialog(FredView* parent, EditorViewport* viewport);
-	// TODO shouldn't all QDialog subclasses have a virtual destructor?
 	~BackgroundEditorDialog() override;
 
-private:
+private slots:
+
+	// Bitmaps
+	void on_bitmapListWidget_currentRowChanged(int row);
+	void on_bitmapTypeCombo_currentIndexChanged(int index);
+	void on_bitmapPitchSpin_valueChanged(int arg1);
+	void on_bitmapBankSpin_valueChanged(int arg1);
+	void on_bitmapHeadingSpin_valueChanged(int arg1);
+	void on_bitmapScaleXDoubleSpinBox_valueChanged(double arg1);
+	void on_bitmapScaleYDoubleSpinBox_valueChanged(double arg1);
+	void on_bitmapDivXSpinBox_valueChanged(int arg1);
+	void on_bitmapDivYSpinBox_valueChanged(int arg1);
+	void on_addBitmapButton_clicked();
+	void on_changeBitmapButton_clicked();
+	void on_deleteBitmapButton_clicked();
+
+private: // NOLINT(readability-redundant-access-specifiers)
     std::unique_ptr<Ui::BackgroundEditor> ui;
-	//std::unique_ptr<BackgroundEditorDialogModel> _model;
-	EditorViewport* _viewport;	
+	std::unique_ptr<BackgroundEditorDialogModel> _model;
+	EditorViewport* _viewport;
+
+	void initializeUi();
+	void updateUi();
+	void refreshBitmapList();
+	void updateBitmapControls();
 };
 
-}
-}
-}
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -34,6 +34,16 @@ private slots:
 	void on_changeBitmapButton_clicked();
 	void on_deleteBitmapButton_clicked();
 
+	// Suns
+	void on_sunListWidget_currentRowChanged(int row);
+	void on_sunSelectionCombo_currentIndexChanged(int index);
+	void on_sunPitchSpin_valueChanged(int arg1);
+	void on_sunHeadingSpin_valueChanged(int arg1);
+	void on_sunScaleDoubleSpinBox_valueChanged(double arg1);
+	void on_addSunButton_clicked();
+	void on_changeSunButton_clicked();
+	void on_deleteSunButton_clicked();
+
 private: // NOLINT(readability-redundant-access-specifiers)
     std::unique_ptr<Ui::BackgroundEditor> ui;
 	std::unique_ptr<BackgroundEditorDialogModel> _model;
@@ -43,6 +53,8 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	void updateUi();
 	void refreshBitmapList();
 	void updateBitmapControls();
+	void refreshSunList();
+	void updateSunControls();
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -66,6 +66,11 @@ private slots:
 	void on_oldNebulaBankSpinBox_valueChanged(int arg1);
 	void on_oldNebulaHeadingSpinBox_valueChanged(int arg1);
 
+	// Ambient Light
+	void on_ambientLightRedSlider_valueChanged(int value);
+	void on_ambientLightGreenSlider_valueChanged(int value);
+	void on_ambientLightBlueSlider_valueChanged(int value);
+
 private: // NOLINT(readability-redundant-access-specifiers)
     std::unique_ptr<Ui::BackgroundEditor> ui;
 	std::unique_ptr<BackgroundEditorDialogModel> _model;
@@ -78,7 +83,10 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	void refreshSunList();
 	void updateSunControls();
 	void updateNebulaControls();
+	void updateFogSwatch();
 	void updateOldNebulaControls();
+	void updateAmbientLightControls();
+	void updateAmbientSwatch();
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -85,6 +85,13 @@ private slots:
 	void on_noCullCheckBox_toggled(bool checked);
 	void on_noGlowmapsCheckBox_toggled(bool checked);
 
+	// Misc
+	void on_numStarsSlider_valueChanged(int value);
+	void on_subspaceCheckBox_toggled(bool checked);
+	void on_envMapButton_clicked();
+	void on_envMapEdit_textChanged(const QString& arg1);
+	void on_lightingProfileCombo_currentIndexChanged(int index);
+
 private: // NOLINT(readability-redundant-access-specifiers)
     std::unique_ptr<Ui::BackgroundEditor> ui;
 	std::unique_ptr<BackgroundEditorDialogModel> _model;
@@ -102,6 +109,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	void updateAmbientLightControls();
 	void updateAmbientSwatch();
 	void updateSkyboxControls();
+	void updateMiscControls();
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -81,7 +81,7 @@ private slots:
 	void on_ambientLightBlueSlider_valueChanged(int value);
 
 	// Skybox
-	void on_skyboxButton_clicked();
+	void on_skyboxModelButton_clicked();
 	void on_skyboxEdit_textChanged(const QString& arg1);
 	void on_skyboxPitchSpin_valueChanged(int arg1);
 	void on_skyboxBankSpin_valueChanged(int arg1);

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -44,6 +44,28 @@ private slots:
 	void on_changeSunButton_clicked();
 	void on_deleteSunButton_clicked();
 
+	// Nebula
+	void on_fullNebulaCheckBox_toggled(bool checked);
+	void on_rangeSpinBox_valueChanged(int arg1);
+	void on_nebulaPatternCombo_currentIndexChanged(int index);
+	void on_nebulaLightningCombo_currentIndexChanged(int index);
+	void on_poofsListWidget_itemSelectionChanged();
+	void on_shipTrailsCheckBox_toggled(bool checked);
+	void on_fogNearDoubleSpinBox_valueChanged(double arg1);
+	void on_fogFarDoubleSpinBox_valueChanged(double arg1);
+	void on_displayBgsInNebulaCheckbox_toggled(bool checked);
+	void on_overrideFogPaletteCheckBox_toggled(bool checked);
+	void on_fogOverrideRedSpinBox_valueChanged(int arg1);
+	void on_fogOverrideGreenSpinBox_valueChanged(int arg1);
+	void on_fogOverrideBlueSpinBox_valueChanged(int arg1);
+
+	// Old Nebula
+	void on_oldNebulaPatternCombo_currentIndexChanged(int index);
+	void on_oldNebulaColorCombo_currentIndexChanged(int index);
+	void on_oldNebulaPitchSpinBox_valueChanged(int arg1);
+	void on_oldNebulaBankSpinBox_valueChanged(int arg1);
+	void on_oldNebulaHeadingSpinBox_valueChanged(int arg1);
+
 private: // NOLINT(readability-redundant-access-specifiers)
     std::unique_ptr<Ui::BackgroundEditor> ui;
 	std::unique_ptr<BackgroundEditorDialogModel> _model;
@@ -55,6 +77,8 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	void updateBitmapControls();
 	void refreshSunList();
 	void updateSunControls();
+	void updateNebulaControls();
+	void updateOldNebulaControls();
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/ui/BackgroundEditor.ui
+++ b/qtfred/ui/BackgroundEditor.ui
@@ -930,14 +930,14 @@
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QCheckBox" name="NoCullCheckBox">
+             <widget class="QCheckBox" name="noCullCheckBox">
               <property name="text">
                <string>No cull</string>
               </property>
              </widget>
             </item>
             <item row="1" column="2">
-             <widget class="QCheckBox" name="NoGlowMapsCheckBox">
+             <widget class="QCheckBox" name="noGlowMapsCheckBox">
               <property name="text">
                <string>No glow maps</string>
               </property>

--- a/qtfred/ui/BackgroundEditor.ui
+++ b/qtfred/ui/BackgroundEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>981</width>
-    <height>814</height>
+    <width>1041</width>
+    <height>862</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -93,174 +93,331 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="mainHorizontalLayout">
+    <layout class="QHBoxLayout" name="backgroundHorizontalLayout">
      <item>
-      <layout class="QVBoxLayout" name="leftLayout">
-       <item>
-        <widget class="QGroupBox" name="bitmapsGroupBox">
-         <property name="title">
-          <string>Bitmaps</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_12" stretch="5,3">
+      <widget class="QGroupBox" name="bitmapsGroupBox">
+       <property name="title">
+        <string>Bitmaps</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_12" stretch="5,3">
+        <item>
+         <layout class="QVBoxLayout" name="bitmapLeftLayout">
           <item>
-           <layout class="QVBoxLayout" name="bitmapLeftLayout">
-            <item>
-             <widget class="QListWidget" name="bitmapListWidget"/>
-            </item>
-            <item>
-             <layout class="QHBoxLayout" name="bitmapButtonsLayout">
-              <item>
-               <widget class="QPushButton" name="addBitmapButton">
-                <property name="text">
-                 <string>Add</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="changeBitmapButton">
-                <property name="text">
-                 <string>Change</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="deleteBitmapButton">
-                <property name="text">
-                 <string>Delete</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
+           <widget class="QListWidget" name="bitmapListWidget"/>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="bitmapRightLayout">
+           <layout class="QHBoxLayout" name="bitmapButtonsLayout">
             <item>
-             <widget class="QComboBox" name="bitmapTypeCombo"/>
-            </item>
-            <item>
-             <layout class="QFormLayout" name="bitmapOrientForm">
-              <item row="0" column="0">
-               <widget class="QLabel" name="bitmapPitchLabel">
-                <property name="text">
-                 <string>Pitch</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QSpinBox" name="bitmapPitchSpin">
-                <property name="wrapping">
-                 <bool>true</bool>
-                </property>
-                <property name="maximum">
-                 <number>16777215</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="bitmapBankLabel">
-                <property name="text">
-                 <string>Bank</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="bitmapBankSpin">
-                <property name="wrapping">
-                 <bool>true</bool>
-                </property>
-                <property name="maximum">
-                 <number>16777215</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="bitmapHeadingLabel">
-                <property name="text">
-                 <string>Heading</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="bitmapHeadingSpin">
-                <property name="wrapping">
-                 <bool>true</bool>
-                </property>
-                <property name="maximum">
-                 <number>16777215</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="QLabel" name="bitmapScaleLabel">
+             <widget class="QPushButton" name="addBitmapButton">
               <property name="text">
-               <string>Scale (x/y)</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
+               <string>Add</string>
               </property>
              </widget>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="bitmapScaleLayout">
-              <item>
-               <widget class="QDoubleSpinBox" name="bitmapScaleXDoubleSpinBox">
-                <property name="maximum">
-                 <double>16777215.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QDoubleSpinBox" name="bitmapScaleYDoubleSpinBox">
-                <property name="maximum">
-                 <double>16777215.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="QLabel" name="bitmapDivisionLabel">
+             <widget class="QPushButton" name="changeBitmapButton">
               <property name="text">
-               <string># divisions (x/y)</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
+               <string>Change</string>
               </property>
              </widget>
             </item>
             <item>
-             <layout class="QHBoxLayout" name="bitmapDivisionLayout">
-              <item>
-               <widget class="QSpinBox" name="bitmapDivXSpinBox">
-                <property name="maximum">
-                 <number>16777215</number>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QSpinBox" name="bitmapDivYSpinBox">
-                <property name="maximum">
-                 <number>16777215</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
+             <widget class="QPushButton" name="deleteBitmapButton">
+              <property name="text">
+               <string>Delete</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
          </layout>
-        </widget>
-       </item>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="bitmapRightLayout">
+          <item>
+           <widget class="QComboBox" name="bitmapTypeCombo"/>
+          </item>
+          <item>
+           <layout class="QFormLayout" name="bitmapOrientForm">
+            <item row="0" column="0">
+             <widget class="QLabel" name="bitmapPitchLabel">
+              <property name="text">
+               <string>Pitch</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="bitmapPitchSpin">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="bitmapBankLabel">
+              <property name="text">
+               <string>Bank</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="bitmapBankSpin">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="bitmapHeadingLabel">
+              <property name="text">
+               <string>Heading</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QSpinBox" name="bitmapHeadingSpin">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="bitmapScaleLabel">
+            <property name="text">
+             <string>Scale (x/y)</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="bitmapScaleLayout">
+            <item>
+             <widget class="QDoubleSpinBox" name="bitmapScaleXDoubleSpinBox">
+              <property name="maximum">
+               <double>16777215.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="bitmapScaleYDoubleSpinBox">
+              <property name="maximum">
+               <double>16777215.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QLabel" name="bitmapDivisionLabel">
+            <property name="text">
+             <string># divisions (x/y)</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="bitmapDivisionLayout">
+            <item>
+             <widget class="QSpinBox" name="bitmapDivXSpinBox">
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="bitmapDivYSpinBox">
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="sunsGroupBox">
+       <property name="title">
+        <string>Suns</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_16">
+        <item>
+         <layout class="QVBoxLayout" name="sunLeftLayout">
+          <item>
+           <widget class="QListWidget" name="sunsListWidget"/>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="sunsButtonsLayout">
+            <item>
+             <widget class="QPushButton" name="addSunButton">
+              <property name="text">
+               <string>Add</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="changeSunButton">
+              <property name="text">
+               <string>Change</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="deleteSunButton">
+              <property name="text">
+               <string>Delete</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="sunRightLayout">
+          <item>
+           <widget class="QComboBox" name="sunSelectionCombo"/>
+          </item>
+          <item>
+           <layout class="QFormLayout" name="sunsFormLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="sunsPitchLabel">
+              <property name="text">
+               <string>Pitch</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="sunPitchSpin">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="sunsHeadingLabel">
+              <property name="text">
+               <string>Heading</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="sunHeadingSpin">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="sunScaleLabel">
+              <property name="text">
+               <string>Scale</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QDoubleSpinBox" name="sunScaleDoubleSpinBox">
+              <property name="minimumSize">
+               <size>
+                <width>75</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximum">
+               <double>16777215.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="backgroundFooterLayout">
+     <item>
+      <spacer name="checkboxCenteringLeft">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="useCorrectAngleFormatCheckBox">
+       <property name="text">
+        <string>Save sun/bitmap angles to mission in correct format</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="checkboxCenteringRight">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="mainHorizontalLayout">
+     <item>
+      <layout class="QVBoxLayout" name="leftLayout">
        <item>
         <widget class="QGroupBox" name="nebulaGroupBox">
          <property name="title">
@@ -310,6 +467,9 @@
                 <property name="maximum">
                  <number>16777215</number>
                 </property>
+                <property name="value">
+                 <number>3000</number>
+                </property>
                </widget>
               </item>
              </layout>
@@ -345,6 +505,9 @@
                 <property name="singleStep">
                  <double>0.100000000000000</double>
                 </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
+                </property>
                </widget>
               </item>
               <item row="1" column="1">
@@ -354,6 +517,9 @@
                 </property>
                 <property name="singleStep">
                  <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -437,7 +603,11 @@
              </widget>
             </item>
             <item>
-             <widget class="QListWidget" name="poofsListWidget"/>
+             <widget class="QListWidget" name="poofsListWidget">
+              <property name="selectionMode">
+               <enum>QAbstractItemView::MultiSelection</enum>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -567,115 +737,6 @@
      </item>
      <item>
       <layout class="QVBoxLayout" name="rightLayout">
-       <item>
-        <widget class="QGroupBox" name="sunsGroupBox">
-         <property name="title">
-          <string>suns</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_16">
-          <item>
-           <layout class="QVBoxLayout" name="sunLeftLayout">
-            <item>
-             <widget class="QListWidget" name="sunsListWidget"/>
-            </item>
-            <item>
-             <layout class="QHBoxLayout" name="sunsButtonsLayout">
-              <item>
-               <widget class="QPushButton" name="addSunButton">
-                <property name="text">
-                 <string>Add</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="changeSunButton">
-                <property name="text">
-                 <string>Change</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="deleteSunButton">
-                <property name="text">
-                 <string>Delete</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="sunRightLayout">
-            <item>
-             <widget class="QComboBox" name="sunSelectionCombo"/>
-            </item>
-            <item>
-             <layout class="QFormLayout" name="sunsFormLayout">
-              <item row="0" column="0">
-               <widget class="QLabel" name="sunsPitchLabel">
-                <property name="text">
-                 <string>Pitch</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QSpinBox" name="sunPitchSpin">
-                <property name="wrapping">
-                 <bool>true</bool>
-                </property>
-                <property name="maximum">
-                 <number>16777215</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="sunsHeadingLabel">
-                <property name="text">
-                 <string>Heading</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="sunHeadingSpin">
-                <property name="wrapping">
-                 <bool>true</bool>
-                </property>
-                <property name="maximum">
-                 <number>16777215</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="sunScaleLabel">
-                <property name="text">
-                 <string>Scale</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QDoubleSpinBox" name="sunScaleDoubleSpinBox">
-                <property name="minimumSize">
-                 <size>
-                  <width>75</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="maximum">
-                 <double>16777215.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item>
         <widget class="QGroupBox" name="ambientLightGroupBox">
          <property name="title">

--- a/qtfred/ui/BackgroundEditor.ui
+++ b/qtfred/ui/BackgroundEditor.ui
@@ -540,6 +540,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QLabel" name="fogSwatch">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
              <layout class="QHBoxLayout" name="fogPaletteOverrideLayout" stretch="0,1,0,1,0,1">
               <item>
                <widget class="QLabel" name="fogOverrideRLabel">
@@ -745,13 +752,6 @@
          <layout class="QHBoxLayout" name="horizontalLayout_17">
           <item>
            <layout class="QGridLayout" name="ambientSlidersGrid">
-            <item row="2" column="2">
-             <widget class="QLabel" name="ambientLightBlueLabel">
-              <property name="text">
-               <string>B: 0</string>
-              </property>
-             </widget>
-            </item>
             <item row="1" column="2">
              <widget class="QLabel" name="ambientLightGreenLabel">
               <property name="text">
@@ -772,16 +772,17 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="0" colspan="2">
-             <widget class="QSlider" name="ambientLightBlueSlider">
-              <property name="minimum">
-               <number>1</number>
+            <item row="2" column="2">
+             <widget class="QLabel" name="ambientLightBlueLabel">
+              <property name="text">
+               <string>B: 0</string>
               </property>
-              <property name="maximum">
-               <number>255</number>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="ambientLightRedLabel">
+              <property name="text">
+               <string>R: 0</string>
               </property>
              </widget>
             </item>
@@ -798,10 +799,23 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="2">
-             <widget class="QLabel" name="ambientLightRedLabel">
+            <item row="0" column="3" rowspan="3">
+             <widget class="QLabel" name="ambientSwatch">
               <property name="text">
-               <string>R: 0</string>
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <widget class="QSlider" name="ambientLightBlueSlider">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
               </property>
              </widget>
             </item>

--- a/qtfred/ui/BackgroundEditor.ui
+++ b/qtfred/ui/BackgroundEditor.ui
@@ -541,6 +541,9 @@
             </item>
             <item>
              <widget class="QLabel" name="fogSwatch">
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
+              </property>
               <property name="text">
                <string/>
               </property>
@@ -781,8 +784,17 @@
             </item>
             <item row="0" column="2">
              <widget class="QLabel" name="ambientLightRedLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>R: 0</string>
+              </property>
+              <property name="scaledContents">
+               <bool>false</bool>
               </property>
              </widget>
             </item>
@@ -801,6 +813,9 @@
             </item>
             <item row="0" column="3" rowspan="3">
              <widget class="QLabel" name="ambientSwatch">
+              <property name="frameShape">
+               <enum>QFrame::Box</enum>
+              </property>
               <property name="text">
                <string/>
               </property>

--- a/qtfred/ui/BackgroundEditor.ui
+++ b/qtfred/ui/BackgroundEditor.ui
@@ -150,6 +150,9 @@
               </item>
               <item row="0" column="1">
                <widget class="QSpinBox" name="bitmapPitchSpin">
+                <property name="wrapping">
+                 <bool>true</bool>
+                </property>
                 <property name="maximum">
                  <number>16777215</number>
                 </property>
@@ -164,6 +167,9 @@
               </item>
               <item row="1" column="1">
                <widget class="QSpinBox" name="bitmapBankSpin">
+                <property name="wrapping">
+                 <bool>true</bool>
+                </property>
                 <property name="maximum">
                  <number>16777215</number>
                 </property>
@@ -178,6 +184,9 @@
               </item>
               <item row="2" column="1">
                <widget class="QSpinBox" name="bitmapHeadingSpin">
+                <property name="wrapping">
+                 <bool>true</bool>
+                </property>
                 <property name="maximum">
                  <number>16777215</number>
                 </property>
@@ -202,12 +211,18 @@
                 <property name="maximum">
                  <double>16777215.000000000000000</double>
                 </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
                </widget>
               </item>
               <item>
                <widget class="QDoubleSpinBox" name="bitmapScaleYDoubleSpinBox">
                 <property name="maximum">
                  <double>16777215.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
                 </property>
                </widget>
               </item>
@@ -327,12 +342,18 @@
                 <property name="maximum">
                  <double>16777215.000000000000000</double>
                 </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
                </widget>
               </item>
               <item row="1" column="1">
                <widget class="QDoubleSpinBox" name="fogFarDoubleSpinBox">
                 <property name="maximum">
                  <double>16777215.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
                 </property>
                </widget>
               </item>
@@ -484,6 +505,9 @@
                 <height>0</height>
                </size>
               </property>
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
               <property name="maximum">
                <number>16777215</number>
               </property>
@@ -497,6 +521,9 @@
                 <height>0</height>
                </size>
               </property>
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
               <property name="maximum">
                <number>16777215</number>
               </property>
@@ -509,6 +536,9 @@
                 <width>100</width>
                 <height>0</height>
                </size>
+              </property>
+              <property name="wrapping">
+               <bool>true</bool>
               </property>
               <property name="maximum">
                <number>16777215</number>
@@ -558,17 +588,11 @@
                </widget>
               </item>
               <item>
-               <spacer name="sunsButtonsSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+               <widget class="QPushButton" name="changeSunButton">
+                <property name="text">
+                 <string>Change</string>
                 </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
+               </widget>
               </item>
               <item>
                <widget class="QPushButton" name="deleteSunButton">
@@ -597,47 +621,39 @@
               </item>
               <item row="0" column="1">
                <widget class="QSpinBox" name="sunPitchSpin">
+                <property name="wrapping">
+                 <bool>true</bool>
+                </property>
                 <property name="maximum">
                  <number>16777215</number>
                 </property>
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="sunsBankLabel">
-                <property name="text">
-                 <string>Bank</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="sunBankSpin">
-                <property name="maximum">
-                 <number>16777215</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
                <widget class="QLabel" name="sunsHeadingLabel">
                 <property name="text">
                  <string>Heading</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="1">
+              <item row="1" column="1">
                <widget class="QSpinBox" name="sunHeadingSpin">
+                <property name="wrapping">
+                 <bool>true</bool>
+                </property>
                 <property name="maximum">
                  <number>16777215</number>
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
+              <item row="2" column="0">
                <widget class="QLabel" name="sunScaleLabel">
                 <property name="text">
                  <string>Scale</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="1">
+              <item row="2" column="1">
                <widget class="QDoubleSpinBox" name="sunScaleDoubleSpinBox">
                 <property name="minimumSize">
                  <size>
@@ -647,6 +663,9 @@
                 </property>
                 <property name="maximum">
                  <double>16777215.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
                 </property>
                </widget>
               </item>
@@ -681,6 +700,12 @@
             </item>
             <item row="0" column="0" colspan="2">
              <widget class="QSlider" name="ambientLightRedSlider">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -688,6 +713,12 @@
             </item>
             <item row="2" column="0" colspan="2">
              <widget class="QSlider" name="ambientLightBlueSlider">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -695,6 +726,12 @@
             </item>
             <item row="1" column="0" colspan="2">
              <widget class="QSlider" name="ambientLightGreenSlider">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>255</number>
+              </property>
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -743,6 +780,9 @@
             </item>
             <item>
              <widget class="QSpinBox" name="skyboxPitchSpin">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
               <property name="maximum">
                <number>16777215</number>
               </property>
@@ -757,6 +797,9 @@
             </item>
             <item>
              <widget class="QSpinBox" name="skyboxBankSpin">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
               <property name="maximum">
                <number>16777215</number>
               </property>
@@ -771,6 +814,9 @@
             </item>
             <item>
              <widget class="QSpinBox" name="skyboxHeadingSpin">
+              <property name="wrapping">
+               <bool>true</bool>
+              </property>
               <property name="maximum">
                <number>16777215</number>
               </property>
@@ -842,6 +888,9 @@
           </item>
           <item>
            <widget class="QSlider" name="numStarsSlider">
+            <property name="maximum">
+             <number>2000</number>
+            </property>
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>

--- a/qtfred/ui/BackgroundEditor.ui
+++ b/qtfred/ui/BackgroundEditor.ui
@@ -6,877 +6,895 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>639</width>
-    <height>681</height>
+    <width>981</width>
+    <height>814</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Background Editor</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <layout class="QVBoxLayout" name="leftLayout">
+    <layout class="QHBoxLayout" name="backgroundButtonsLayout">
      <item>
-      <layout class="QHBoxLayout" name="topLeftLayout">
-       <item>
-        <widget class="QComboBox" name="backgroundSelectionCombo"/>
-       </item>
-       <item>
-        <widget class="QPushButton" name="importButton">
-         <property name="text">
-          <string>Import...</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>Bitmaps</string>
+      <widget class="QComboBox" name="backgroundSelectionCombo">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
-        <item>
-         <layout class="QVBoxLayout" name="bitmapLeftLayout_2">
-          <item>
-           <widget class="QListView" name="bitmapListView"/>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_11">
-            <item>
-             <widget class="QPushButton" name="addBitmapButton">
-              <property name="text">
-               <string>Add</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_18">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="deleteBitmapButton">
-              <property name="text">
-               <string>Delete</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="bitmapRightLayout_2">
-          <item>
-           <widget class="QComboBox" name="bitmapSelectionCombo"/>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="gridLayout_2">
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_8">
-              <property name="text">
-               <string>Heading</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QSpinBox" name="bitmapHeadingSpin"/>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_4">
-              <property name="text">
-               <string>Pitch</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_7">
-              <property name="text">
-               <string>Bank</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QSpinBox" name="bitmapPitchSpin"/>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="bitmapBankSpin"/>
-            </item>
-            <item row="0" column="2">
-             <spacer name="horizontalSpacer_12">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="2" column="2">
-             <spacer name="horizontalSpacer_11">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="2">
-             <spacer name="horizontalSpacer_13">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_7">
-            <item>
-             <spacer name="horizontalSpacer_14">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_9">
-              <property name="text">
-               <string>Scale (x/y)</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_15">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_8">
-            <item>
-             <widget class="QLineEdit" name="bitmapScaleXEdit"/>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="bitmapScaleYEdit"/>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_9">
-            <item>
-             <spacer name="horizontalSpacer_16">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_10">
-              <property name="text">
-               <string># divisions (x/y)</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_17">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_10">
-            <item>
-             <widget class="QLineEdit" name="bitmapDivisionsXEdit"/>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="bitmapDivisionsYEdit"/>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-       </layout>
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_2">
-       <property name="title">
-        <string>Nebula</string>
+      <widget class="QPushButton" name="addButton">
+       <property name="text">
+        <string>Add</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_13">
-        <item>
-         <layout class="QVBoxLayout" name="nebulaLeftLayout">
-          <item>
-           <widget class="QCheckBox" name="fullNebulaCheckBox">
-            <property name="text">
-             <string>Full Nebula</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QFormLayout" name="formLayout">
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_12">
-              <property name="text">
-               <string>Range</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="nebulaRangeEdit"/>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_13">
-              <property name="text">
-               <string>Pattern</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QComboBox" name="nebulaPatternCombo"/>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_14">
-              <property name="text">
-               <string>Lightning storm</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QComboBox" name="nebulaLightningCombo"/>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="shipTrailsCheckBox">
-            <property name="text">
-             <string>Toggle ship trails</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QFormLayout" name="formLayout_2">
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_15">
-              <property name="text">
-               <string>Fog Near</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="fogNearEdit"/>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_35">
-              <property name="text">
-               <string>Fog Far Multiplier</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="fogFarMultiplierEdit"/>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="nebulaRightLayout">
-          <item>
-           <widget class="QLabel" name="label_11">
-            <property name="text">
-             <string>Poofs</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="poofGreen1CheckBox">
-            <property name="text">
-             <string>PoofGreen01</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="poofGreen2CheckBox">
-            <property name="text">
-             <string>PoofGreen02</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="poofRed1CheckBox">
-            <property name="text">
-             <string>PoofRed01</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="poofRed2CheckBox">
-            <property name="text">
-             <string>PoofRed02</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="poofPurple1CheckBox">
-            <property name="text">
-             <string>PoofPurp01</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="poofPurple2CheckBox">
-            <property name="text">
-             <string>PoofPurp02</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-       </layout>
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_3">
-       <property name="title">
-        <string>Old Nebula</string>
+      <widget class="QPushButton" name="removeButton">
+       <property name="text">
+        <string>Remove</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_14">
-        <item>
-         <layout class="QFormLayout" name="oldNebulaLeftLayout">
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_17">
-            <property name="text">
-             <string>Pattern</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="oldNebulaPatternCombo"/>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_18">
-            <property name="text">
-             <string>Color</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="oldNebulaColorCombo"/>
-          </item>
-          <item row="0" column="1">
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QFormLayout" name="oldNebulaRightLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_19">
-            <property name="text">
-             <string>Pitch</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="oldNebulaPitchEdit"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_20">
-            <property name="text">
-             <string>Bank</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="oldNebulaBankEdit"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_21">
-            <property name="text">
-             <string>Heading</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="oldNebulaHeadingEdit"/>
-          </item>
-         </layout>
-        </item>
-       </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="bgButtonSpacer_1">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="importButton">
+       <property name="text">
+        <string>Import...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="bgButtonSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="swapWithButton">
+       <property name="text">
+        <string>Swap With</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="swapWithCombo">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="rightLayout">
+    <layout class="QHBoxLayout" name="mainHorizontalLayout">
      <item>
-      <layout class="QHBoxLayout" name="topRightLayout">
+      <layout class="QVBoxLayout" name="leftLayout">
        <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+        <widget class="QGroupBox" name="bitmapsGroupBox">
+         <property name="title">
+          <string>Bitmaps</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="swapWithButton">
-         <property name="text">
-          <string>Swap With</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="swapWithCombo"/>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_4">
-       <property name="title">
-        <string>suns</string>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_16">
-        <item>
-         <layout class="QVBoxLayout" name="sunLeftLayout">
+         <layout class="QHBoxLayout" name="horizontalLayout_12" stretch="5,3">
           <item>
-           <widget class="QListView" name="sunListView"/>
+           <layout class="QVBoxLayout" name="bitmapLeftLayout">
+            <item>
+             <widget class="QListWidget" name="bitmapListWidget"/>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="bitmapButtonsLayout">
+              <item>
+               <widget class="QPushButton" name="addBitmapButton">
+                <property name="text">
+                 <string>Add</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="changeBitmapButton">
+                <property name="text">
+                 <string>Change</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="deleteBitmapButton">
+                <property name="text">
+                 <string>Delete</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_15">
+           <layout class="QVBoxLayout" name="bitmapRightLayout">
             <item>
-             <widget class="QPushButton" name="addSunButton">
+             <widget class="QComboBox" name="bitmapTypeCombo"/>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="bitmapOrientForm">
+              <item row="0" column="0">
+               <widget class="QLabel" name="bitmapPitchLabel">
+                <property name="text">
+                 <string>Pitch</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QSpinBox" name="bitmapPitchSpin">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="bitmapBankLabel">
+                <property name="text">
+                 <string>Bank</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QSpinBox" name="bitmapBankSpin">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="bitmapHeadingLabel">
+                <property name="text">
+                 <string>Heading</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QSpinBox" name="bitmapHeadingSpin">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="bitmapScaleLabel">
               <property name="text">
-               <string>Add</string>
+               <string>Scale (x/y)</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
               </property>
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_19">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
+             <layout class="QHBoxLayout" name="bitmapScaleLayout">
+              <item>
+               <widget class="QDoubleSpinBox" name="bitmapScaleXDoubleSpinBox">
+                <property name="maximum">
+                 <double>16777215.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QDoubleSpinBox" name="bitmapScaleYDoubleSpinBox">
+                <property name="maximum">
+                 <double>16777215.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="QPushButton" name="deleteSunButton">
+             <widget class="QLabel" name="bitmapDivisionLabel">
               <property name="text">
-               <string>Delete</string>
+               <string># divisions (x/y)</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
               </property>
              </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="bitmapDivisionLayout">
+              <item>
+               <widget class="QSpinBox" name="bitmapDivXSpinBox">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="bitmapDivYSpinBox">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </item>
          </layout>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="sunRightLayout">
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="nebulaGroupBox">
+         <property name="title">
+          <string>Nebula</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_13" stretch="0,1">
           <item>
-           <widget class="QComboBox" name="sunSelectionCombo"/>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="gridLayout_3">
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_22">
+           <layout class="QVBoxLayout" name="nebulaLeftLayout">
+            <item>
+             <widget class="QCheckBox" name="fullNebulaCheckBox">
               <property name="text">
-               <string>Heading</string>
+               <string>Full Nebula</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
-             <widget class="QSpinBox" name="sunHeadingSpin"/>
+            <item>
+             <layout class="QFormLayout" name="nebulaTopForm">
+              <item row="0" column="0">
+               <widget class="QLabel" name="nebulaRangeLabel">
+                <property name="text">
+                 <string>Range</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="nebulaPatternLabel">
+                <property name="text">
+                 <string>Pattern</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QComboBox" name="nebulaPatternCombo"/>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="nebulaLightningLabel">
+                <property name="text">
+                 <string>Lightning storm</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QComboBox" name="nebulaLightningCombo"/>
+              </item>
+              <item row="0" column="1">
+               <widget class="QSpinBox" name="rangeSpinBox">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
+            <item>
+             <widget class="QCheckBox" name="shipTrailsCheckBox">
+              <property name="text">
+               <string>Toggle ship trails</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="nebulaBottomForm">
+              <item row="0" column="0">
+               <widget class="QLabel" name="fogNearLabel">
+                <property name="text">
+                 <string>Fog Near Multiplier</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="fogFarLabel">
+                <property name="text">
+                 <string>Fog Far Multiplier</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QDoubleSpinBox" name="fogNearDoubleSpinBox">
+                <property name="maximum">
+                 <double>16777215.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="fogFarDoubleSpinBox">
+                <property name="maximum">
+                 <double>16777215.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="displayBgsInNebulaCheckbox">
+              <property name="text">
+               <string>Display background bitmaps in nebula</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="overrideFogPaletteCheckBox">
+              <property name="text">
+               <string>Override Nebula Fog Palette</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="fogPaletteOverrideLayout" stretch="0,1,0,1,0,1">
+              <item>
+               <widget class="QLabel" name="fogOverrideRLabel">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>R</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="fogOverrideRedSpinBox">
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="fogOverrideGLabel">
+                <property name="text">
+                 <string>G</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="fogOverrideGreenSpinBox">
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="fogOverrideBLabel">
+                <property name="text">
+                 <string>B</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="fogOverrideBlueSpinBox">
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="nebulaRightLayout">
+            <item>
+             <widget class="QLabel" name="poofsLabel">
+              <property name="text">
+               <string>Poofs</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QListWidget" name="poofsListWidget"/>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="oldNebulaGroupBox">
+         <property name="title">
+          <string>Old Nebula</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="0,0">
+          <item>
+           <layout class="QFormLayout" name="oldNebulaLeftForm">
             <item row="0" column="0">
-             <widget class="QLabel" name="label_23">
+             <widget class="QLabel" name="oldNebPatternLabel">
+              <property name="text">
+               <string>Pattern</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="oldNebulaPatternCombo"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="oldNebColorLabel">
+              <property name="text">
+               <string>Color</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="oldNebulaColorCombo"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QFormLayout" name="oldNebulaRightForm">
+            <item row="0" column="0">
+             <widget class="QLabel" name="oldNebPitchLabel">
               <property name="text">
                <string>Pitch</string>
               </property>
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_24">
+             <widget class="QLabel" name="oldNebBankLabel">
               <property name="text">
                <string>Bank</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
-             <widget class="QSpinBox" name="sunPitchSpin"/>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="sunBankSpin"/>
-            </item>
-            <item row="0" column="2">
-             <spacer name="horizontalSpacer_20">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="2" column="2">
-             <spacer name="horizontalSpacer_21">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="2">
-             <spacer name="horizontalSpacer_22">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="sunScaleLabel">
+            <item row="2" column="0">
+             <widget class="QLabel" name="oldNebHeadingLabel">
               <property name="text">
-               <string>Scale</string>
+               <string>Heading</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="1">
-             <widget class="QLineEdit" name="sunScaleEdit"/>
-            </item>
-            <item row="3" column="2">
-             <spacer name="sunScaleSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
+            <item row="0" column="1">
+             <widget class="QSpinBox" name="oldNebulaPitchSpinBox">
+              <property name="minimumSize">
                <size>
-                <width>40</width>
-                <height>20</height>
+                <width>100</width>
+                <height>0</height>
                </size>
               </property>
-             </spacer>
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="oldNebulaBankSpinBox">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QSpinBox" name="oldNebulaHeadingSpinBox">
+              <property name="minimumSize">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
          </layout>
-        </item>
-       </layout>
-      </widget>
+        </widget>
+       </item>
+       <item>
+        <spacer name="leftSideVerticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_7">
-       <property name="title">
-        <string>Ambient light</string>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_17">
-        <item>
-         <layout class="QGridLayout" name="gridLayout_4">
-          <item row="0" column="0" colspan="2">
-           <widget class="QSlider" name="ambientLightRedSlider">
+      <layout class="QVBoxLayout" name="rightLayout">
+       <item>
+        <widget class="QGroupBox" name="sunsGroupBox">
+         <property name="title">
+          <string>suns</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_16">
+          <item>
+           <layout class="QVBoxLayout" name="sunLeftLayout">
+            <item>
+             <widget class="QListWidget" name="sunsListWidget"/>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="sunsButtonsLayout">
+              <item>
+               <widget class="QPushButton" name="addSunButton">
+                <property name="text">
+                 <string>Add</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="sunsButtonsSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="deleteSunButton">
+                <property name="text">
+                 <string>Delete</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="sunRightLayout">
+            <item>
+             <widget class="QComboBox" name="sunSelectionCombo"/>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="sunsFormLayout">
+              <item row="0" column="0">
+               <widget class="QLabel" name="sunsPitchLabel">
+                <property name="text">
+                 <string>Pitch</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QSpinBox" name="sunPitchSpin">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="sunsBankLabel">
+                <property name="text">
+                 <string>Bank</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QSpinBox" name="sunBankSpin">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="sunsHeadingLabel">
+                <property name="text">
+                 <string>Heading</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QSpinBox" name="sunHeadingSpin">
+                <property name="maximum">
+                 <number>16777215</number>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="sunScaleLabel">
+                <property name="text">
+                 <string>Scale</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QDoubleSpinBox" name="sunScaleDoubleSpinBox">
+                <property name="minimumSize">
+                 <size>
+                  <width>75</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximum">
+                 <double>16777215.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="ambientLightGroupBox">
+         <property name="title">
+          <string>Ambient light</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_17">
+          <item>
+           <layout class="QGridLayout" name="ambientSlidersGrid">
+            <item row="2" column="2">
+             <widget class="QLabel" name="ambientLightBlueLabel">
+              <property name="text">
+               <string>B: 0</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QLabel" name="ambientLightGreenLabel">
+              <property name="text">
+               <string>G: 0</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0" colspan="2">
+             <widget class="QSlider" name="ambientLightRedSlider">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <widget class="QSlider" name="ambientLightBlueSlider">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0" colspan="2">
+             <widget class="QSlider" name="ambientLightGreenSlider">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="ambientLightRedLabel">
+              <property name="text">
+               <string>R: 0</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="skyboxGroupBox">
+         <property name="title">
+          <string>Skybox</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="skyboxModelLayout">
+            <item>
+             <widget class="QPushButton" name="skyboxModelButton">
+              <property name="text">
+               <string>Skybox Model</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="skyboxEdit"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="skyboxOrientLayout">
+            <item>
+             <widget class="QLabel" name="skyboxPitchLabel">
+              <property name="text">
+               <string>Pitch</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="skyboxPitchSpin">
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="skyboxBankLabel">
+              <property name="text">
+               <string>Bank</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="skyboxBankSpin">
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="skyboxHeadingLabel">
+              <property name="text">
+               <string>Heading</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="skyboxHeadingSpin">
+              <property name="maximum">
+               <number>16777215</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="skyboxFlagsGrid">
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="noLightingCheckBox">
+              <property name="text">
+               <string>No lighting</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="transparentCheckBox">
+              <property name="text">
+               <string>Transparent</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QCheckBox" name="forceClampCheckBox">
+              <property name="text">
+               <string>Force clamp</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="noZBufferCheckBox">
+              <property name="text">
+               <string>No z-buffer</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="NoCullCheckBox">
+              <property name="text">
+               <string>No cull</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QCheckBox" name="NoGlowMapsCheckBox">
+              <property name="text">
+               <string>No glow maps</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="miscGroupBox">
+         <property name="title">
+          <string>Misc</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QLabel" name="numStarsLabel">
+            <property name="text">
+             <string>Number of stars: </string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSlider" name="numStarsSlider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="ambientLightRedLabel">
+          <item>
+           <widget class="QCheckBox" name="subspaceCheckBox">
             <property name="text">
-             <string>Red: 0</string>
+             <string>Takes place inside subspace</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QSlider" name="ambientLightGreenSlider">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="ambientLightGreenLabel">
-            <property name="text">
-             <string>Green: 0</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QSlider" name="ambientLightBlueSlider">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QLabel" name="ambientLightBlueLabel">
-            <property name="text">
-             <string>Blue: 0</string>
-            </property>
-           </widget>
+          <item>
+           <layout class="QFormLayout" name="miscForm">
+            <item row="0" column="0">
+             <widget class="QPushButton" name="envMapButton">
+              <property name="text">
+               <string>Environment Map</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="envMapEdit"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lightingProfileLabel">
+              <property name="text">
+               <string>Lighting Profile</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="lightingProfileCombo"/>
+            </item>
+           </layout>
           </item>
          </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_5">
-       <property name="title">
-        <string>Skybox</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_18">
-          <item>
-           <widget class="QPushButton" name="skyboxModelButton">
-            <property name="text">
-             <string>Skybox Model</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="skyboxEdit"/>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_19">
-          <item>
-           <widget class="QLabel" name="label_31">
-            <property name="text">
-             <string>Pitch</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="skyboxPitchSpin"/>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_32">
-            <property name="text">
-             <string>Bank</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="skyboxBankSpin"/>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_33">
-            <property name="text">
-             <string>Heading</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="skyboxHeadingSpin"/>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <item row="0" column="0">
-           <widget class="QCheckBox" name="noLightingCheckBox">
-            <property name="text">
-             <string>No lighting</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QCheckBox" name="transparentCheckBox">
-            <property name="text">
-             <string>Transparent</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QCheckBox" name="forceClampCheckBox">
-            <property name="text">
-             <string>Force clamp</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="noZBufferCheckBox">
-            <property name="text">
-             <string>No z-buffer</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="NoCullCheckBox">
-            <property name="text">
-             <string>No cull</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QCheckBox" name="NoGlowMapsCheckBox">
-            <property name="text">
-             <string>No glow maps</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_6">
-       <property name="title">
-        <string>Misc</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_34">
-          <property name="text">
-           <string>Number of stars: 500</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSlider" name="numStarsSlider">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="subspaceCheckBox">
-          <property name="text">
-           <string>Takes place inside subspace</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_20">
-          <item>
-           <widget class="QPushButton" name="envMapButton">
-            <property name="text">
-             <string>Environment Map</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="envMapEdit"/>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
+        </widget>
+       </item>
+       <item>
+        <spacer name="rightSideVerticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Fully implements the background editor with updating backgrounds and everything. There's a couple remaining TODOs that I will handle in a follow up once we know the main render view is working properly.

Another note is that while FRED does use intermediary variables and saves everything on close, the Background Editor does not come with standard OK/Cancel buttons so I chose to fire the middle man for simplicity. The model works directly on the mission data.

Fixes #1688 
Fixes #2963