### PR TITLE
Cockpit-specific light intensity adjustment for lighting profiles

### DIFF
--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -384,6 +384,10 @@ void gr_opengl_deferred_lighting_finish()
 							? lp->cockpit_light_radius_modifier.handle(MAX(l.rada, l.radb))
 							: MAX(l.rada, l.radb);
 			light_data->lightRadius = rad;
+			float intensity = (Lighting_mode == lighting_mode::COCKPIT)
+							? lp->cockpit_light_intensity_modifier.handle(intensity)
+							: intensity;
+			light_data->lightIntensity = intensity;
 			// A small padding factor is added to guard against potentially clipping the edges of the light with facets
 			// of the volume mesh.
 			light_data->scale.xyz.x = rad * 1.05f;
@@ -396,6 +400,11 @@ void gr_opengl_deferred_lighting_finish()
 				(Lighting_mode == lighting_mode::COCKPIT) ? lp->cockpit_light_radius_modifier.handle(l.radb) : l.radb;
 
 			light_data->lightRadius = rad;
+			float intensity =
+				(Lighting_mode == lighting_mode::COCKPIT) ? lp->cockpit_light_intensity_modifier.handle(l.intensity) : l.intensity;
+
+			light_data->lightIntensity = intensity;
+
 			light_data->lightType = LT_TUBE;
 
 			vec3d a;

--- a/code/graphics/opengl/gropengldeferred.cpp
+++ b/code/graphics/opengl/gropengldeferred.cpp
@@ -190,16 +190,19 @@ static bool override_fog = false;
 graphics::deferred_light_data*
 
 // common conversion operations to translate a game light data structure into a render-ready light uniform.
-prepare_light_uniforms(light& l, graphics::util::UniformAligner& uniformAligner)
+prepare_light_uniforms(light& l, graphics::util::UniformAligner& uniformAligner, const ltp::profile* lp)
 {
 	graphics::deferred_light_data* light_data = uniformAligner.addTypedElement<graphics::deferred_light_data>();
 
 	light_data->lightType = static_cast<int>(l.type);
 
+	float intensity =
+		(Lighting_mode == lighting_mode::COCKPIT) ? lp->cockpit_light_intensity_modifier.handle(l.intensity) : l.intensity;
+
 	vec3d diffuse;
-	diffuse.xyz.x = l.r * l.intensity;
-	diffuse.xyz.y = l.g * l.intensity;
-	diffuse.xyz.z = l.b * l.intensity;
+	diffuse.xyz.x = l.r * intensity;
+	diffuse.xyz.y = l.g * intensity;
+	diffuse.xyz.z = l.b * intensity;
 
 	light_data->diffuseLightColor = diffuse;
 
@@ -342,7 +345,7 @@ void gr_opengl_deferred_lighting_finish()
 		bool first_directional = true;
 
 		for (auto& l : full_frame_lights) {
-			auto light_data = prepare_light_uniforms(l, light_uniform_aligner);
+			auto light_data = prepare_light_uniforms(l, light_uniform_aligner, lp);
 
 			if (l.type == Light_Type::Directional ) {
 				if (Shadow_quality != ShadowQuality::Disabled) {
@@ -372,7 +375,7 @@ void gr_opengl_deferred_lighting_finish()
 			}
 		}
 		for (auto& l : sphere_lights) {
-			auto light_data = prepare_light_uniforms(l, light_uniform_aligner);
+			auto light_data = prepare_light_uniforms(l, light_uniform_aligner, lp);
 
 			if (l.type == Light_Type::Cone) {
 				light_data->dualCone = (l.flags & LF_DUAL_CONE) ? 1.0f : 0.0f;
@@ -384,10 +387,7 @@ void gr_opengl_deferred_lighting_finish()
 							? lp->cockpit_light_radius_modifier.handle(MAX(l.rada, l.radb))
 							: MAX(l.rada, l.radb);
 			light_data->lightRadius = rad;
-			float intensity = (Lighting_mode == lighting_mode::COCKPIT)
-							? lp->cockpit_light_intensity_modifier.handle(intensity)
-							: intensity;
-			light_data->lightIntensity = intensity;
+
 			// A small padding factor is added to guard against potentially clipping the edges of the light with facets
 			// of the volume mesh.
 			light_data->scale.xyz.x = rad * 1.05f;
@@ -395,15 +395,11 @@ void gr_opengl_deferred_lighting_finish()
 			light_data->scale.xyz.z = rad * 1.05f;
 		}
 		for (auto& l : cylinder_lights) {
-			auto light_data = prepare_light_uniforms(l, light_uniform_aligner);
+			auto light_data = prepare_light_uniforms(l, light_uniform_aligner, lp);
 			float rad =
 				(Lighting_mode == lighting_mode::COCKPIT) ? lp->cockpit_light_radius_modifier.handle(l.radb) : l.radb;
 
 			light_data->lightRadius = rad;
-			float intensity =
-				(Lighting_mode == lighting_mode::COCKPIT) ? lp->cockpit_light_intensity_modifier.handle(l.intensity) : l.intensity;
-
-			light_data->lightIntensity = intensity;
 
 			light_data->lightType = LT_TUBE;
 

--- a/code/graphics/opengl/gropengldeferred.h
+++ b/code/graphics/opengl/gropengldeferred.h
@@ -4,6 +4,9 @@
 #include "graphics/util/UniformAligner.h"
 #include "graphics/util/uniform_structs.h"
 #include "lighting/lighting.h"
+#include "lighting/lighting_profiles.h"
+namespace ltp = lighting_profiles;
+using namespace ltp; 
 
 void gr_opengl_deferred_init();
 
@@ -12,7 +15,7 @@ void gr_opengl_deferred_lighting_begin(bool clearNonColorBufs = false);
 void gr_opengl_deferred_lighting_msaa();
 void gr_opengl_deferred_lighting_end();
 void gr_opengl_deferred_lighting_finish();
-graphics::deferred_light_data* prepare_light_uniforms(light& l, graphics::util::UniformAligner& uniformAligner);
+graphics::deferred_light_data* prepare_light_uniforms(light& l, graphics::util::UniformAligner& uniformAligner, ltp::profile lp);
 
 void gr_opengl_deferred_light_sphere_init(int rings, int segments);
 void gr_opengl_deferred_light_cylinder_init(int segments);

--- a/code/lighting/lighting_profiles.cpp
+++ b/code/lighting/lighting_profiles.cpp
@@ -385,6 +385,11 @@ void profile::parse(const char* filename, const SCP_string& profile_name, const 
 			profile_name,
 			&cockpit_light_radius_modifier);
 
+		parsed |= adjustment::parse(filename,
+			"$Cockpit light intensity modifier:",
+			profile_name,
+			&cockpit_light_intensity_modifier);
+
 		if (!parsed) {
 			stuff_string(buffer, F_RAW);
 			Warning(LOCATION, "Unhandled line in lighting profile\n\t%s", buffer.c_str());
@@ -445,6 +450,8 @@ void profile::reset()
 
 	cockpit_light_radius_modifier.reset();
 	cockpit_light_radius_modifier.set_multiplier(1.0f);
+	cockpit_light_intensity_modifier.reset();
+	cockpit_light_intensity_modifier.set_multiplier(1.0f);
 }
 
 profile& profile::operator=(const profile& rhs) = default;

--- a/code/lighting/lighting_profiles.h
+++ b/code/lighting/lighting_profiles.h
@@ -72,6 +72,7 @@ class profile {
 	// Strictly speaking this should be handled by postproc but we need something for the non-postproc people.
 	adjustment overall_brightness;
 	adjustment cockpit_light_radius_modifier;
+	adjustment cockpit_light_intensity_modifier;
 
 	void reset();
 	profile& operator=(const profile& rhs);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1305,7 +1305,7 @@ void obj_move_all_post(object *objp, float frametime)
 				weapon_process_post( objp, frametime );
 
 			// Cast light
-			if ( Deferred_lighting && Detail.lighting > 3 ) {
+			if ( light_deferred_enabled() && Detail.lighting > 3 ) {
 				// Weapons cast light
 
 				int group_id = Weapons[objp->instance].group_id;


### PR DESCRIPTION
Adds a set of adjustments to lighting profiles for cockpit light intensity, to match the existing one for cockpit light radius. Also, fixes an incorrect value usage in #6997 which caused weapon lights to never appear no matter what.