### PR TITLE
add additional double quote conversion to FRED and qtFRED

### DIFF
--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -467,6 +467,7 @@ void briefing_editor_dlg::update_data(int update)
 			ptr->icons[m_last_icon].id = m_id;
 
 			string_copy(buf, m_icon_label, MAX_LABEL_LEN - 1);
+			lcl_fred_replace_stuff(buf, MAX_LABEL_LEN - 1);
 			if (stricmp(ptr->icons[m_last_icon].label, buf) && !m_change_local) {
 				set_modified();
 				reset_icon_loop(m_last_stage);
@@ -476,6 +477,7 @@ void briefing_editor_dlg::update_data(int update)
 			strcpy_s(ptr->icons[m_last_icon].label, buf);
 
 			string_copy(buf, m_icon_closeup_label, MAX_LABEL_LEN - 1);
+			lcl_fred_replace_stuff(buf, MAX_LABEL_LEN - 1);
 			if (stricmp(ptr->icons[m_last_icon].closeup_label, buf) && !m_change_local) {
 				set_modified();
 				reset_icon_loop(m_last_stage);

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -911,6 +911,8 @@ void event_editor::save_event(int e)
 	}
 
 	// handle objective text
+	lcl_fred_replace_stuff(m_obj_text);
+	lcl_fred_replace_stuff(m_obj_key_text);
 	m_events[e].objective_text = (LPCTSTR)m_obj_text;
 	m_events[e].objective_key_text = (LPCTSTR)m_obj_key_text;
 

--- a/fred2/initialstatus.cpp
+++ b/fred2/initialstatus.cpp
@@ -599,6 +599,7 @@ void initial_status::change_subsys()
 
 		// update cargo name
 		if (strlen(m_cargo_name) > 0) { //-V805
+			lcl_fred_replace_stuff(m_cargo_name);
 			cargo_index = string_lookup(m_cargo_name, Cargo_names, Num_cargo);
 			if (cargo_index == -1) {
 				if (Num_cargo < MAX_CARGO);

--- a/fred2/jumpnodedlg.cpp
+++ b/fred2/jumpnodedlg.cpp
@@ -303,7 +303,9 @@ int jumpnode_dlg::update_data()
 			m_name = _T(jnp->GetName());
 			UpdateData(FALSE);
 		}
-		
+
+		lcl_fred_replace_stuff(m_display);
+
 		strcpy_s(old_name, jnp->GetName());
 		jnp->SetName((LPCSTR) m_name);
 		jnp->SetDisplayName((m_display.CompareNoCase("<none>") == 0) ? m_name : m_display);

--- a/fred2/missiongoalsdlg.cpp
+++ b/fred2/missiongoalsdlg.cpp
@@ -436,6 +436,7 @@ void CMissionGoalsDlg::OnChangeGoalDesc()
 	}
 
 	UpdateData(TRUE);
+	lcl_fred_replace_stuff(m_goal_desc);
 	string_copy(m_goals[cur_goal].message, m_goal_desc);
 }
 

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3624,12 +3624,22 @@ int CFred_mission_save::save_objects()
 
 		// optional alternate type name
 		if (strlen(Fred_alt_names[i])) {
-			fout("\n$Alt: %s\n", Fred_alt_names[i]);
+			if (optional_string_fred("$Alt:", "$Team:")) {
+				parse_comments();
+			} else {
+				fout("\n$Alt:");
+			}
+			fout(" %s", Fred_alt_names[i]);
 		}
 
 		// optional callsign
 		if (Mission_save_format != FSO_FORMAT_RETAIL && strlen(Fred_callsigns[i])) {
-			fout("\n$Callsign: %s\n", Fred_callsigns[i]);
+			if (optional_string_fred("$Callsign:", "$Team:")) {
+				parse_comments();
+			} else {
+				fout("\n$Callsign:");
+			}
+			fout(" %s", Fred_callsigns[i]);
 		}
 
 		required_string_fred("$Team:");

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -1291,6 +1291,8 @@ int CShipEditorDlg::update_ship(int ship)
 	CComboBox *box;
 	int persona;
 
+	lcl_fred_replace_stuff(m_ship_display_name);
+
 	// the display name was precalculated, so now just assign it
 	if (m_ship_display_name == m_ship_name || m_ship_display_name.CompareNoCase("<none>") == 0)
 	{
@@ -1332,6 +1334,7 @@ int CShipEditorDlg::update_ship(int ship)
 		MODIFY(Ships[ship].weapons.ai_class, m_ai_class);
 	}
 	if (strlen(m_cargo1)) {
+		lcl_fred_replace_stuff(m_cargo1);
 		z = string_lookup(m_cargo1, Cargo_names, Num_cargo);
 		if (z == -1) {
 			if (Num_cargo < MAX_CARGO) {

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
@@ -2,6 +2,7 @@
 
 #include "globalincs/linklist.h"
 #include <jumpnode/jumpnode.h>
+#include <localization/localize.h>
 #include <mission/missionparse.h>
 #include <mission/object.h>
 #include <model/model.h>
@@ -38,6 +39,8 @@ bool JumpNodeEditorDialogModel::apply()
 	char old_name_buf[NAME_LENGTH];
 	std::strncpy(old_name_buf, jnp->GetName(), NAME_LENGTH - 1);
 	old_name_buf[NAME_LENGTH - 1] = '\0';
+
+	lcl_fred_replace_stuff(_display);
 
 	jnp->SetName(_name.c_str());
 	jnp->SetDisplayName(lcase_equal(_display, "<none>") ? _name.c_str() : _display.c_str());

--- a/qtfred/src/mission/dialogs/MissionGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionGoalsDialogModel.cpp
@@ -1,3 +1,4 @@
+#include <localization/localize.h>
 #include "MissionGoalsDialogModel.h"
 
 
@@ -167,6 +168,7 @@ mission_goal& MissionGoalsDialogModel::createNewGoal() {
 void MissionGoalsDialogModel::setCurrentGoalMessage(const char* text) {
 	Assertion(isCurrentGoalValid(), "Current goal is not valid!");
 	getCurrentGoal().message = text;
+	lcl_fred_replace_stuff(getCurrentGoal().message);
 
 	set_modified();
 	modelChanged();

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
@@ -14,6 +14,7 @@
 #include "mission/missionmessage.h"
 
 #include <globalincs/linklist.h>
+#include <localization/localize.h>
 #include <mission/object.h>
 
 #include <QtWidgets>
@@ -636,6 +637,8 @@ namespace fso {
 				int z, d;
 				SCP_string str;
 
+				lcl_fred_replace_stuff(_m_ship_display_name);
+
 				// the display name was precalculated, so now just assign it
 				if (_m_ship_display_name == _m_ship_name || stricmp(_m_ship_display_name.c_str(), "<none>") == 0)
 				{
@@ -671,6 +674,7 @@ namespace fso {
 					Ships[ship].weapons.ai_class = _m_ai_class;
 				}
 				if (!_m_cargo1.empty()) {
+					lcl_fred_replace_stuff(_m_cargo1);
 					z = string_lookup(_m_cargo1.c_str(), Cargo_names, Num_cargo);
 					if (z == -1) {
 						if (Num_cargo < MAX_CARGO) {

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
@@ -3,6 +3,7 @@
 #include "mission/object.h"
 
 #include <globalincs/linklist.h>
+#include <localization/localize.h>
 
 #include <QtWidgets>
 #include <object/objectdock.cpp>
@@ -795,6 +796,7 @@ void ShipInitialStatusDialogModel::change_subsys(const int new_subsys)
 
 		// update cargo name
 		if (!m_cargo_name.empty()) { //-V805
+			lcl_fred_replace_stuff(m_cargo_name);
 			cargo_index = string_lookup(m_cargo_name.c_str(), Cargo_names, Num_cargo);
 			if (cargo_index == -1) {
 				if (Num_cargo < MAX_CARGO) {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3538,12 +3538,22 @@ int CFred_mission_save::save_objects()
 
 		// optional alternate type name
 		if (strlen(Fred_alt_names[i])) {
-			fout("\n$Alt: %s\n", Fred_alt_names[i]);
+			if (optional_string_fred("$Alt:", "$Team:")) {
+				parse_comments();
+			} else {
+				fout("\n$Alt:");
+			}
+			fout(" %s", Fred_alt_names[i]);
 		}
 
 		// optional callsign
 		if (save_format != MissionFormat::RETAIL && strlen(Fred_callsigns[i])) {
-			fout("\n$Callsign: %s\n", Fred_callsigns[i]);
+			if (optional_string_fred("$Callsign:", "$Team:")) {
+				parse_comments();
+			} else {
+				fout("\n$Callsign:");
+			}
+			fout(" %s", Fred_callsigns[i]);
 		}
 
 		required_string_fred("$Team:");

--- a/qtfred/src/ui/dialogs/EventEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/EventEditorDialog.cpp
@@ -130,6 +130,7 @@ void EventEditorDialog::initEventWidgets() {
 			return;
 		}
 		m_events[cur_event].objective_text = value.toUtf8().constData();
+		lcl_fred_replace_stuff(m_events[cur_event].objective_text);
 
 		updateEventBitmap();
 	});
@@ -138,6 +139,7 @@ void EventEditorDialog::initEventWidgets() {
 			return;
 		}
 		m_events[cur_event].objective_key_text = value.toUtf8().constData();
+		lcl_fred_replace_stuff(m_events[cur_event].objective_key_text);
 	});
 	connectLogState(ui->checkLogTrue, MLF_SEXP_TRUE);
 	connectLogState(ui->checkLogFalse, MLF_SEXP_FALSE);


### PR DESCRIPTION
Any place in FRED that uses XSTR is susceptible to double quotes interfering with the standard XSTR format, not just the expected briefing, debriefing, messages, etc.  This PR adds `lcl_fred_replace_stuff()` - which handles not only quotes but semicolons and slashes as well - to the other places where XSTR is used.

(Note that quotes are handled just fine in non-XSTR fields.  Semicolons will still truncate non-XSTR fields, but addressing that is beyond the scope of this PR as it would require editing every text field in FRED.  Fortunately, errant semicolons merely modify the text as opposed to corrupting the mission file.)

Fixes #7005 in both FRED and qtFRED; tested in both.  Caveat aedificator: the briefing editor is not yet implemented in qtFRED, so the relevant fixes to briefing icon labels and closeup labels cannot yet be ported over.