### PR TITLE
Add 'direct fire lead target' beam flag

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -2239,7 +2239,9 @@ int beam_start_firing(beam *b)
 	// re-aim direct fire and antifighter beam weapons here, otherwise they tend to miss		
 	case BeamType::DIRECT_FIRE:
 	case BeamType::ANTIFIGHTER:
-		beam_aim(b);
+		// ...unless it's intentional they sometimes miss
+		if (!Weapon_info[b->weapon_info_index].b_info.flags[Weapon::Beam_Info_Flags::Direct_fire_lead_target])
+			beam_aim(b);
 		break;
 	
 	case BeamType::SLASHING:
@@ -2916,6 +2918,9 @@ void beam_aim(beam *b)
 
 			// after pointing, jitter based on shot_aim (if we have a target object)
 			if (!(b->flags & BF_TARGETING_COORDS)) {
+				if (Weapon_info[b->weapon_info_index].b_info.flags[Weapon::Beam_Info_Flags::Direct_fire_lead_target])
+					b->last_shot += b->target->phys_info.vel * ((float)Weapon_info[b->weapon_info_index].b_info.beam_warmup * 0.001f);
+
 				beam_jitter_aim(b, b->binfo.shot_aim[b->shot_index]);
 			}
 		}

--- a/code/weapon/weapon_flags.h
+++ b/code/weapon/weapon_flags.h
@@ -145,6 +145,7 @@ namespace Weapon {
 	FLAG_LIST(Beam_Info_Flags) {
 		Burst_share_random,
 		Track_own_texture_tiling,
+		Direct_fire_lead_target,
 
 		NUM_VALUES
 	};

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -125,7 +125,8 @@ const size_t Num_burst_fire_flags = sizeof(Burst_fire_flags)/sizeof(flag_def_lis
 
 flag_def_list_new<Weapon::Beam_Info_Flags> Beam_info_flags[] = {
 	{ "burst shares random target",		Weapon::Beam_Info_Flags::Burst_share_random,		        true, false },
-	{ "track own texture tiling",       Weapon::Beam_Info_Flags::Track_own_texture_tiling,          true, false }
+	{ "track own texture tiling",       Weapon::Beam_Info_Flags::Track_own_texture_tiling,          true, false },
+	{ "direct fire lead target",        Weapon::Beam_Info_Flags::Direct_fire_lead_target,           true, false }
 };
 
 const size_t Num_beam_info_flags = sizeof(Beam_info_flags) / sizeof(flag_def_list_new<Weapon::Beam_Info_Flags>);


### PR DESCRIPTION
This makes it so that direct fire beams aim only once when warming up, and lead their target when doing so, this way you can sort of 'dodge' a beam. I thought of various ways of parameterizing all of this, the lead scalar, different kinds of beams, but it would it a lot more complicated, doesn't really make any sense on certain beams, and even if so, having a single simple flag to enable this sort of thing is still useful.