### PR TITLE
Expose value of idle circling with 'attack-any'

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -699,8 +699,8 @@ void parse_ai_profiles_tbl(const char *filename)
 					}
 				}
 
-				if (optional_string("$attack-any idle movement radius:")) {
-					stuff_float(&profile->attack_any_idle_movement_radius);
+				if (optional_string("$attack-any idle circle distance:")) {
+					stuff_float(&profile->attack_any_idle_circle_distance);
 				}
 
 				set_flag(profile, "$unify usage of AI Shield Manage Delay:", AI::Profile_Flags::Unify_usage_ai_shield_manage_delay);
@@ -819,7 +819,7 @@ void ai_profile_t::reset()
 
 	guard_big_orbit_above_target_radius = 500.0f;
 	guard_big_orbit_max_speed_percent = 1.0f;
-	attack_any_idle_movement_radius = 200.0f;
+	attack_any_idle_circle_distance = 100.0f;
 
     for (int i = 0; i < NUM_SKILL_LEVELS; ++i) {
         max_incoming_asteroids[i] = 0;

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -699,6 +699,10 @@ void parse_ai_profiles_tbl(const char *filename)
 					}
 				}
 
+				if (optional_string("$attack-any idle movement radius:")) {
+					stuff_float(&profile->attack_any_idle_movement_radius);
+				}
+
 				set_flag(profile, "$unify usage of AI Shield Manage Delay:", AI::Profile_Flags::Unify_usage_ai_shield_manage_delay);
 
 				set_flag(profile, "$fix AI shield management bug:", AI::Profile_Flags::Fix_AI_shield_management_bug);
@@ -815,6 +819,7 @@ void ai_profile_t::reset()
 
 	guard_big_orbit_above_target_radius = 500.0f;
 	guard_big_orbit_max_speed_percent = 1.0f;
+	attack_any_idle_movement_radius = 200.0f;
 
     for (int i = 0; i < NUM_SKILL_LEVELS; ++i) {
         max_incoming_asteroids[i] = 0;

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -145,7 +145,7 @@ public:
 	float guard_big_orbit_max_speed_percent;   // Max percent of forward speed that is used in ai_big_guard() 
 
 	// AI attack any option --wookieejedi
-	float attack_any_idle_movement_radius; // Radius that AI circles around a point while waiting for new enemies in attack-any mode
+	float attack_any_idle_circle_distance; // Radius that AI circles around a point while waiting for new enemies in attack-any mode
 
     void reset();
 };

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -144,6 +144,9 @@ public:
 	float guard_big_orbit_above_target_radius; // Radius of guardee that triggers ai_big_guard() 
 	float guard_big_orbit_max_speed_percent;   // Max percent of forward speed that is used in ai_big_guard() 
 
+	// AI attack any option --wookieejedi
+	float attack_any_idle_movement_radius; // Radius that AI circles around a point while waiting for new enemies in attack-any mode
+
     void reset();
 };
 

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13244,8 +13244,6 @@ static void ai_preprocess_ignore_objnum(ai_info *aip)
 		aip->target_objnum = -1;
 }
 
-#define	CHASE_CIRCLE_DIST		100.0f
-
 void ai_chase_circle(object *objp)
 {
 	float		dist_to_goal;
@@ -13266,11 +13264,11 @@ void ai_chase_circle(object *objp)
 	if (aip->ignore_objnum == UNUSED_OBJNUM) {
 		dist_to_goal = vm_vec_dist_quick(&aip->goal_point, &objp->pos);
 
-		if (dist_to_goal > 2*CHASE_CIRCLE_DIST) {
+		if (dist_to_goal > 2 * The_mission.ai_profile->attack_any_idle_movement_radius) {
 			vec3d	vec_to_goal;
 			//	Too far from circle goal, create a new goal point.
 			vm_vec_normalized_dir(&vec_to_goal, &aip->goal_point, &objp->pos);
-			vm_vec_scale_add(&aip->goal_point, &objp->pos, &vec_to_goal, CHASE_CIRCLE_DIST);
+			vm_vec_scale_add(&aip->goal_point, &objp->pos, &vec_to_goal, The_mission.ai_profile->attack_any_idle_movement_radius);
 		}
 
 		goal_point = aip->goal_point;

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13264,11 +13264,11 @@ void ai_chase_circle(object *objp)
 	if (aip->ignore_objnum == UNUSED_OBJNUM) {
 		dist_to_goal = vm_vec_dist_quick(&aip->goal_point, &objp->pos);
 
-		if (dist_to_goal > 2 * The_mission.ai_profile->attack_any_idle_movement_radius) {
+		if (dist_to_goal > 2 * The_mission.ai_profile->attack_any_idle_circle_distance) {
 			vec3d	vec_to_goal;
 			//	Too far from circle goal, create a new goal point.
 			vm_vec_normalized_dir(&vec_to_goal, &aip->goal_point, &objp->pos);
-			vm_vec_scale_add(&aip->goal_point, &objp->pos, &vec_to_goal, The_mission.ai_profile->attack_any_idle_movement_radius);
+			vm_vec_scale_add(&aip->goal_point, &objp->pos, &vec_to_goal, The_mission.ai_profile->attack_any_idle_circle_distance);
 		}
 
 		goal_point = aip->goal_point;


### PR DESCRIPTION
The attack-any order is extremely useful and utilized order, and there was one aspect that was ripe for exposure to modders: the `CHASE_CIRCLE_DIST` that was used to determine how big of a circle to fly around while the AI waited for new hostiles to arrive. For ships with high speeds, like FotG and others, the default radius of 200 m was a bit on the small side, which lead to ships flying in tight circles. This was was counterproductive to goals of tuning the AI to have a more cinematic style, such as where AI would fly around in large distances while waiting for enemies to arrive. Fortunately, this value is easy to expose with just a few lines, and overall it allows modders the ability to tune the already useful 'attack-any' order while idling with just a single new ai_profiles value.

Tested and works as expected.