### PR TITLE
Fix build issues with Vulkan SDK 1.3.301+

### DIFF
--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -25,8 +25,14 @@ const char* EngineName = "FreeSpaceOpen";
 
 const gameversion::version MinVulkanVersion(1, 1, 0, 0);
 
-VkBool32 VKAPI_PTR debugReportCallback(VkDebugReportFlagsEXT /*flags*/,
+VkBool32 VKAPI_PTR debugReportCallback(
+#if VK_HEADER_VERSION >= 304
+	vk::DebugReportFlagsEXT /*flags*/,
+	vk::DebugReportObjectTypeEXT /*objectType*/,
+#else
+	VkDebugReportFlagsEXT /*flags*/,
 	VkDebugReportObjectTypeEXT /*objectType*/,
+#endif
 	uint64_t /*object*/,
 	size_t /*location*/,
 	int32_t /*messageCode*/,
@@ -457,7 +463,11 @@ bool VulkanRenderer::initializeSurface()
 		return false;
 	}
 
+#if VK_HEADER_VERSION >= 301
+	const vk::detail::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> deleter(*m_vkInstance,
+#else
 	const vk::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> deleter(*m_vkInstance,
+#endif
 		nullptr,
 		VULKAN_HPP_DEFAULT_DISPATCHER);
 	m_vkSurface = vk::UniqueSurfaceKHR(vk::SurfaceKHR(surface), deleter);


### PR DESCRIPTION
This fixes two build issues:

- `vk::PFN_DebugReportCallbackEXT` takes `vk::DebugReport*EXT` not C type `VkDebugReport*EXT` since version 1.3.304. (KhronosGroup/Vulkan-Hpp@d5a18dc87efbcc291bbd50a892187af4cbb60285)
- `vk::ObjectDestroy` was moved to namespace `vk::detail` in version 1.3.301. (KhronosGroup/Vulkan-Hpp@6e5489fcd96ba1e2cf994ebe3e4d1f5f4f690f4b)

Guard them with version checks, so that compiling with older verions of the Vulkan-Hpp headers keeps working.

Closes #6416.