### PR TITLE
fix various issues with DDS decompression

### DIFF
--- a/code/ddsutils/bcdec.h
+++ b/code/ddsutils/bcdec.h
@@ -1,4 +1,4 @@
-﻿/* bcdec.h - v0.96
+/* bcdec.h - v0.97
    provides functions to decompress blocks of BC compressed images
    written by Sergii "iOrange" Kudlai in 2022
 
@@ -23,12 +23,21 @@
 
    For more info, issues and suggestions please visit https://github.com/iOrange/bcdec
 
+   Configuration:
+      #define BCDEC_BC4BC5_PRECISE:
+         enables more precise but slower BC4/BC5 decoding + signed/unsigned mode
+
    CREDITS:
       Aras Pranckevicius (@aras-p)      - BC1/BC3 decoders optimizations (up to 3x the speed)
                                         - BC6H/BC7 bits pulling routines optimizations
                                         - optimized BC6H by moving unquantize out of the loop
                                         - Split BC6H decompression function into 'half' and
                                           'float' variants
+
+      Michael Schmidt (@RunDevelopment) - Found better "magic" coefficients for integer interpolation
+                                          of reference colors in BC1 color block, that match with
+                                          the floating point interpolation. This also made it faster
+                                          than integer division by 3!
 
    bugfixes:
       @linkmauve
@@ -38,6 +47,9 @@
 
 #ifndef BCDEC_HEADER_INCLUDED
 #define BCDEC_HEADER_INCLUDED
+
+#define BCDEC_VERSION_MAJOR 0
+#define BCDEC_VERSION_MINOR 98
 
 /* if BCDEC_STATIC causes problems, try defining BCDECDEF to 'inline' or 'static inline' */
 #ifndef BCDECDEF
@@ -90,12 +102,20 @@
 BCDECDEF void bcdec_bc1(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
 BCDECDEF void bcdec_bc2(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
 BCDECDEF void bcdec_bc3(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
+#ifndef BCDEC_BC4BC5_PRECISE
 BCDECDEF void bcdec_bc4(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
 BCDECDEF void bcdec_bc5(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
+#else
+BCDECDEF void bcdec_bc4(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned);
+BCDECDEF void bcdec_bc5(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned);
+BCDECDEF void bcdec_bc4_float(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned);
+BCDECDEF void bcdec_bc5_float(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned);
+#endif
 BCDECDEF void bcdec_bc6h_float(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned);
 BCDECDEF void bcdec_bc6h_half(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned);
 BCDECDEF void bcdec_bc7(const void* compressedBlock, void* decompressedBlock, int destinationPitch);
 
+#endif /* BCDEC_HEADER_INCLUDED */
 
 #ifdef BCDEC_IMPLEMENTATION
 
@@ -110,35 +130,44 @@ static void bcdec__color_block(const void* compressedBlock, void* decompressedBl
     c0 = ((unsigned short*)compressedBlock)[0];
     c1 = ((unsigned short*)compressedBlock)[1];
 
-    /* Expand 565 ref colors to 888 */
-    r0 = (((c0 >> 11) & 0x1F) * 527 + 23) >> 6;
-    g0 = (((c0 >> 5)  & 0x3F) * 259 + 33) >> 6;
-    b0 =  ((c0        & 0x1F) * 527 + 23) >> 6;
-    refColors[0] = 0xFF000000 | (b0 << 16) | (g0 << 8) | r0;
+    /* Unpack 565 ref colors */
+    r0 = (c0 >> 11) & 0x1F;
+    g0 = (c0 >> 5)  & 0x3F;
+    b0 =  c0        & 0x1F;
 
-    r1 = (((c1 >> 11) & 0x1F) * 527 + 23) >> 6;
-    g1 = (((c1 >> 5)  & 0x3F) * 259 + 33) >> 6;
-    b1 =  ((c1        & 0x1F) * 527 + 23) >> 6;
-    refColors[1] = 0xFF000000 | (b1 << 16) | (g1 << 8) | r1;
+    r1 = (c1 >> 11) & 0x1F;
+    g1 = (c1 >> 5)  & 0x3F;
+    b1 =  c1        & 0x1F;
+
+    /* Expand 565 ref colors to 888 */
+    r = (r0 * 527 + 23) >> 6;
+    g = (g0 * 259 + 33) >> 6;
+    b = (b0 * 527 + 23) >> 6;
+    refColors[0] = 0xFF000000 | (b << 16) | (g << 8) | r;
+
+    r = (r1 * 527 + 23) >> 6;
+    g = (g1 * 259 + 33) >> 6;
+    b = (b1 * 527 + 23) >> 6;
+    refColors[1] = 0xFF000000 | (b << 16) | (g << 8) | r;
 
     if (c0 > c1 || onlyOpaqueMode) {    /* Standard BC1 mode (also BC3 color block uses ONLY this mode) */
         /* color_2 = 2/3*color_0 + 1/3*color_1
            color_3 = 1/3*color_0 + 2/3*color_1 */
-        r = (2 * r0 + r1 + 1) / 3;
-        g = (2 * g0 + g1 + 1) / 3;
-        b = (2 * b0 + b1 + 1) / 3;
+        r = ((2 * r0 + r1) *  351 +   61) >>  7;
+        g = ((2 * g0 + g1) * 2763 + 1039) >> 11;
+        b = ((2 * b0 + b1) *  351 +   61) >>  7;
         refColors[2] = 0xFF000000 | (b << 16) | (g << 8) | r;
 
-        r = (r0 + 2 * r1 + 1) / 3;
-        g = (g0 + 2 * g1 + 1) / 3;
-        b = (b0 + 2 * b1 + 1) / 3;
+        r = ((r0 + r1 * 2) *  351 +   61) >>  7;
+        g = ((g0 + g1 * 2) * 2763 + 1039) >> 11;
+        b = ((b0 + b1 * 2) *  351 +   61) >>  7;
         refColors[3] = 0xFF000000 | (b << 16) | (g << 8) | r;
     } else {                            /* Quite rare BC1A mode */
         /* color_2 = 1/2*color_0 + 1/2*color_1;
            color_3 = 0;                         */
-        r = (r0 + r1 + 1) >> 1;
-        g = (g0 + g1 + 1) >> 1;
-        b = (b0 + b1 + 1) >> 1;
+        r = ((r0 + r1) * 1053 +  125) >>  8;
+        g = ((g0 + g1) * 4145 + 1019) >> 11;
+        b = ((b0 + b1) * 1053 +  125) >>  8;
         refColors[2] = 0xFF000000 | (b << 16) | (g << 8) | r;
 
         refColors[3] = 0x00000000;
@@ -190,19 +219,19 @@ static void bcdec__smooth_alpha_block(const void* compressedBlock, void* decompr
 
     if (alpha[0] > alpha[1]) {
         /* 6 interpolated alpha values. */
-        alpha[2] = (6 * alpha[0] +     alpha[1] + 1) / 7;   /* 6/7*alpha_0 + 1/7*alpha_1 */
-        alpha[3] = (5 * alpha[0] + 2 * alpha[1] + 1) / 7;   /* 5/7*alpha_0 + 2/7*alpha_1 */
-        alpha[4] = (4 * alpha[0] + 3 * alpha[1] + 1) / 7;   /* 4/7*alpha_0 + 3/7*alpha_1 */
-        alpha[5] = (3 * alpha[0] + 4 * alpha[1] + 1) / 7;   /* 3/7*alpha_0 + 4/7*alpha_1 */
-        alpha[6] = (2 * alpha[0] + 5 * alpha[1] + 1) / 7;   /* 2/7*alpha_0 + 5/7*alpha_1 */
-        alpha[7] = (    alpha[0] + 6 * alpha[1] + 1) / 7;   /* 1/7*alpha_0 + 6/7*alpha_1 */
+        alpha[2] = (6 * alpha[0] +     alpha[1]) / 7;   /* 6/7*alpha_0 + 1/7*alpha_1 */
+        alpha[3] = (5 * alpha[0] + 2 * alpha[1]) / 7;   /* 5/7*alpha_0 + 2/7*alpha_1 */
+        alpha[4] = (4 * alpha[0] + 3 * alpha[1]) / 7;   /* 4/7*alpha_0 + 3/7*alpha_1 */
+        alpha[5] = (3 * alpha[0] + 4 * alpha[1]) / 7;   /* 3/7*alpha_0 + 4/7*alpha_1 */
+        alpha[6] = (2 * alpha[0] + 5 * alpha[1]) / 7;   /* 2/7*alpha_0 + 5/7*alpha_1 */
+        alpha[7] = (    alpha[0] + 6 * alpha[1]) / 7;   /* 1/7*alpha_0 + 6/7*alpha_1 */
     }
     else {
         /* 4 interpolated alpha values. */
-        alpha[2] = (4 * alpha[0] +     alpha[1] + 1) / 5;   /* 4/5*alpha_0 + 1/5*alpha_1 */
-        alpha[3] = (3 * alpha[0] + 2 * alpha[1] + 1) / 5;   /* 3/5*alpha_0 + 2/5*alpha_1 */
-        alpha[4] = (2 * alpha[0] + 3 * alpha[1] + 1) / 5;   /* 2/5*alpha_0 + 3/5*alpha_1 */
-        alpha[5] = (    alpha[0] + 4 * alpha[1] + 1) / 5;   /* 1/5*alpha_0 + 4/5*alpha_1 */
+        alpha[2] = (4 * alpha[0] +     alpha[1]) / 5;   /* 4/5*alpha_0 + 1/5*alpha_1 */
+        alpha[3] = (3 * alpha[0] + 2 * alpha[1]) / 5;   /* 3/5*alpha_0 + 2/5*alpha_1 */
+        alpha[4] = (2 * alpha[0] + 3 * alpha[1]) / 5;   /* 2/5*alpha_0 + 3/5*alpha_1 */
+        alpha[5] = (    alpha[0] + 4 * alpha[1]) / 5;   /* 1/5*alpha_0 + 4/5*alpha_1 */
         alpha[6] = 0x00;
         alpha[7] = 0xFF;
     }
@@ -217,6 +246,117 @@ static void bcdec__smooth_alpha_block(const void* compressedBlock, void* decompr
         decompressed += destinationPitch;
     }
 }
+
+#ifdef BCDEC_BC4BC5_PRECISE
+static void bcdec__bc4_block(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int pixelSize, int isSigned) {
+    signed char* sblock;
+    unsigned char* ublock;
+    int alpha[8];
+    int i, j;
+    unsigned long long block, indices;
+
+    static int aWeights4[4] = { 13107, 26215, 39321, 52429 };
+    static int aWeights6[6] = { 9363, 18724, 28086, 37450, 46812, 56173 };
+
+    block = *(unsigned long long*)compressedBlock;
+
+    if (isSigned) {
+        alpha[0] = (char)(block & 0xFF);
+        alpha[1] = (char)((block >> 8) & 0xFF);
+        if (alpha[0] < -127) alpha[0] = -127;     /* -128 clamps to -127 */
+        if (alpha[1] < -127) alpha[1] = -127;     /* -128 clamps to -127 */
+    } else {
+        alpha[0] = block & 0xFF;
+        alpha[1] = (block >> 8) & 0xFF;
+    }
+
+    if (alpha[0] > alpha[1]) {
+        /* 6 interpolated alpha values. */
+        alpha[2] = (aWeights6[5] * alpha[0] + aWeights6[0] * alpha[1] + 32768) >> 16;   /* 6/7*alpha_0 + 1/7*alpha_1 */
+        alpha[3] = (aWeights6[4] * alpha[0] + aWeights6[1] * alpha[1] + 32768) >> 16;   /* 5/7*alpha_0 + 2/7*alpha_1 */
+        alpha[4] = (aWeights6[3] * alpha[0] + aWeights6[2] * alpha[1] + 32768) >> 16;   /* 4/7*alpha_0 + 3/7*alpha_1 */
+        alpha[5] = (aWeights6[2] * alpha[0] + aWeights6[3] * alpha[1] + 32768) >> 16;   /* 3/7*alpha_0 + 4/7*alpha_1 */
+        alpha[6] = (aWeights6[1] * alpha[0] + aWeights6[4] * alpha[1] + 32768) >> 16;   /* 2/7*alpha_0 + 5/7*alpha_1 */
+        alpha[7] = (aWeights6[0] * alpha[0] + aWeights6[5] * alpha[1] + 32768) >> 16;   /* 1/7*alpha_0 + 6/7*alpha_1 */
+    } else {
+        /* 4 interpolated alpha values. */
+        alpha[2] = (aWeights4[3] * alpha[0] + aWeights4[0] * alpha[1] + 32768) >> 16;   /* 4/5*alpha_0 + 1/5*alpha_1 */
+        alpha[3] = (aWeights4[2] * alpha[0] + aWeights4[1] * alpha[1] + 32768) >> 16;   /* 3/5*alpha_0 + 2/5*alpha_1 */
+        alpha[4] = (aWeights4[1] * alpha[0] + aWeights4[2] * alpha[1] + 32768) >> 16;   /* 2/5*alpha_0 + 3/5*alpha_1 */
+        alpha[5] = (aWeights4[0] * alpha[0] + aWeights4[3] * alpha[1] + 32768) >> 16;   /* 1/5*alpha_0 + 4/5*alpha_1 */
+        alpha[6] = isSigned ? -127 :   0;
+        alpha[7] = isSigned ?  127 : 255;
+    }
+
+    indices = block >> 16;
+    if (isSigned) {
+        sblock = (char*)decompressedBlock;
+        for (i = 0; i < 4; ++i) {
+            for (j = 0; j < 4; ++j) {
+                sblock[j * pixelSize] = (char)alpha[indices & 0x07];
+                indices >>= 3;
+            }
+            sblock += destinationPitch;
+        }
+    } else {
+        ublock = (unsigned char*)decompressedBlock;
+        for (i = 0; i < 4; ++i) {
+            for (j = 0; j < 4; ++j) {
+                ublock[j * pixelSize] = (unsigned char)alpha[indices & 0x07];
+                indices >>= 3;
+            }
+            ublock += destinationPitch;
+        }
+    }
+}
+
+static void bcdec__bc4_block_float(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int pixelSize, int isSigned) {
+    float* decompressed;
+    float alpha[8];
+    int i, j;
+    unsigned long long block, indices;
+
+    block = *(unsigned long long*)compressedBlock;
+    decompressed = (float*)decompressedBlock;
+
+    if (isSigned) {
+        alpha[0] = (float)((char)(block & 0xFF)) / 127.0f;
+        alpha[1] = (float)((char)((block >> 8) & 0xFF)) / 127.0f;
+        if (alpha[0] < -1.0f) alpha[0] = -1.0f;     /* -128 clamps to -127 */
+        if (alpha[1] < -1.0f) alpha[1] = -1.0f;     /* -128 clamps to -127 */
+    } else {
+        alpha[0] = (float)(block & 0xFF) / 255.0f;
+        alpha[1] = (float)((block >> 8) & 0xFF) / 255.0f;
+    }
+
+    if (alpha[0] > alpha[1]) {
+        /* 6 interpolated alpha values. */
+        alpha[2] = (6.0f * alpha[0] +        alpha[1]) / 7.0f;   /* 6/7*alpha_0 + 1/7*alpha_1 */
+        alpha[3] = (5.0f * alpha[0] + 2.0f * alpha[1]) / 7.0f;   /* 5/7*alpha_0 + 2/7*alpha_1 */
+        alpha[4] = (4.0f * alpha[0] + 3.0f * alpha[1]) / 7.0f;   /* 4/7*alpha_0 + 3/7*alpha_1 */
+        alpha[5] = (3.0f * alpha[0] + 4.0f * alpha[1]) / 7.0f;   /* 3/7*alpha_0 + 4/7*alpha_1 */
+        alpha[6] = (2.0f * alpha[0] + 5.0f * alpha[1]) / 7.0f;   /* 2/7*alpha_0 + 5/7*alpha_1 */
+        alpha[7] = (       alpha[0] + 6.0f * alpha[1]) / 7.0f;   /* 1/7*alpha_0 + 6/7*alpha_1 */
+    } else {
+        /* 4 interpolated alpha values. */
+        alpha[2] = (4.0f * alpha[0] +        alpha[1]) / 5.0f;   /* 4/5*alpha_0 + 1/5*alpha_1 */
+        alpha[3] = (3.0f * alpha[0] + 2.0f * alpha[1]) / 5.0f;   /* 3/5*alpha_0 + 2/5*alpha_1 */
+        alpha[4] = (2.0f * alpha[0] + 3.0f * alpha[1]) / 5.0f;   /* 2/5*alpha_0 + 3/5*alpha_1 */
+        alpha[5] = (       alpha[0] + 4.0f * alpha[1]) / 5.0f;   /* 1/5*alpha_0 + 4/5*alpha_1 */
+        alpha[6] = isSigned ? -1.0f : 0.0f;
+        alpha[7] = 1.0f;
+    }
+
+    indices = block >> 16;
+    for (i = 0; i < 4; ++i) {
+        for (j = 0; j < 4; ++j) {
+            decompressed[j * pixelSize] = alpha[indices & 0x07];
+            indices >>= 3;
+        }
+        decompressed += destinationPitch;
+    }
+}
+#endif /* BCDEC_BC4BC5_PRECISE */
 
 typedef struct bcdec__bitstream {
     unsigned long long low;
@@ -270,14 +410,36 @@ BCDECDEF void bcdec_bc3(const void* compressedBlock, void* decompressedBlock, in
     bcdec__smooth_alpha_block(compressedBlock, ((char*)decompressedBlock) + 3, destinationPitch, 4);
 }
 
+#ifndef BCDEC_BC4BC5_PRECISE
 BCDECDEF void bcdec_bc4(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
     bcdec__smooth_alpha_block(compressedBlock, decompressedBlock, destinationPitch, 1);
+#else
+BCDECDEF void bcdec_bc4(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned) {
+    bcdec__bc4_block(compressedBlock, decompressedBlock, destinationPitch, 1, isSigned);
+#endif
 }
 
+#ifndef BCDEC_BC4BC5_PRECISE
 BCDECDEF void bcdec_bc5(const void* compressedBlock, void* decompressedBlock, int destinationPitch) {
     bcdec__smooth_alpha_block(compressedBlock, decompressedBlock, destinationPitch, 2);
     bcdec__smooth_alpha_block(((char*)compressedBlock) + 8, ((char*)decompressedBlock) + 1, destinationPitch, 2);
+#else
+BCDECDEF void bcdec_bc5(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned) {
+    bcdec__bc4_block(compressedBlock, decompressedBlock, destinationPitch, 2, isSigned);
+    bcdec__bc4_block(((char*)compressedBlock) + 8, ((char*)decompressedBlock) + 1, destinationPitch, 2, isSigned);
+#endif
 }
+
+#ifdef BCDEC_BC4BC5_PRECISE
+BCDECDEF void bcdec_bc4_float(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned) {
+    bcdec__bc4_block_float(compressedBlock, decompressedBlock, destinationPitch, 1, isSigned);
+}
+
+BCDECDEF void bcdec_bc5_float(const void* compressedBlock, void* decompressedBlock, int destinationPitch, int isSigned) {
+    bcdec__bc4_block_float(compressedBlock, decompressedBlock, destinationPitch, 2, isSigned);
+    bcdec__bc4_block_float(((char*)compressedBlock) + 8, ((float*)decompressedBlock) + 1, destinationPitch, 2, isSigned);
+}
+#endif /* BCDEC_BC4BC5_PRECISE */
 
 /* http://graphics.stanford.edu/~seander/bithacks.html#VariableSignExtend */
 static int bcdec__extend_sign(int val, int bits) {
@@ -1268,8 +1430,6 @@ BCDECDEF void bcdec_bc7(const void* compressedBlock, void* decompressedBlock, in
 }
 
 #endif /* BCDEC_IMPLEMENTATION */
-
-#endif /* BCDEC_HEADER_INCLUDED */
 
 /* LICENSE:
 

--- a/code/ddsutils/ddsutils.cpp
+++ b/code/ddsutils/ddsutils.cpp
@@ -96,6 +96,11 @@ static uint conversion_resize(DDS_HEADER &dds_header)
 	// drop levels until we get to an appropriate size, but make sure we have
 	// at least 1 mipmap level remaining at the end (in case there's not a full chain)
 	while (((width > MAX_SIZE) || (height > MAX_SIZE)) && (offset < dds_header.dwMipMapCount-1)) {
+		// this shouldn't happen, but catch the obscure case (like 8192x4)
+		if ((width <= 4) || (height <= 4)) {
+			break;
+		}
+
 		width >>= 1;
 		height >>= 1;
 		depth >>= 1;
@@ -194,9 +199,9 @@ static int _dds_read_header(CFILE *ddsfile, DDS_HEADER &dds_header, DDS_HEADER_D
 	return DDS_ERROR_NONE;
 }
 
-static size_t compute_dds_size(const DDS_HEADER &dds_header)
+static size_t compute_dds_size(const DDS_HEADER &dds_header, bool converting = false)
 {
-	uint d_width, d_height, d_depth;
+	uint d_width = 0, d_height = 0, d_depth = 0;
 	size_t d_size = 0;
 
 	for (uint i = 0; i < dds_header.dwMipMapCount; i++) {
@@ -216,6 +221,22 @@ static size_t compute_dds_size(const DDS_HEADER &dds_header)
 	if (dds_header.dwCaps2 & DDSCAPS2_CUBEMAP) {
 		// the previously computed size is just per face, mult by 6 for full size
 		d_size *= 6;
+	}
+
+	// When converting we need to pad a bit to compensate for the decompression
+	// size on smaller mipmap levels. We need to ensure there is always enough
+	// space to decode an entire 4x4 block in rgba space
+	if (converting) {
+		auto last_layer_size = d_width * d_height * d_width * 4;
+
+		// 72 = 4x4 block * 4 bytes color + additional 8 bytes for DXT3 (??)
+		const uint MIN_PAD = 72;
+		// not sure what the extra 8 bytes is for exactly, but there's heap
+		// corruption without it, and only for DXT3 - taylor
+
+		if (last_layer_size < MIN_PAD) {
+			d_size += MIN_PAD - last_layer_size;
+		}
 	}
 
 	Assertion(d_size > 0, "ERROR: DDS size computed to 0!!");
@@ -247,6 +268,7 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 	int retval = DDS_ERROR_NONE;
 	int ct = DDS_UNCOMPRESSED;
 	int is_cubemap = 0;
+	bool convert = false;
 
 
 	if (img_cfp == NULL) {
@@ -337,7 +359,9 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 	}
 
 	// maybe do conversion if format not supported
-	if (conversion_needed(dds_header)) {
+	convert = conversion_needed(dds_header);
+
+	if (convert) {
 		// switch to uncompressed format and reset vars
 		dds_header.ddspf.dwFlags &= ~DDPF_FOURCC;
 		dds_header.ddspf.dwFlags |= DDPF_RGB;
@@ -359,7 +383,7 @@ int dds_read_header(const char *filename, CFILE *img_cfp, int *width, int *heigh
 
 	// stuff important info
 	if (size)
-		*size = compute_dds_size(dds_header);
+		*size = compute_dds_size(dds_header, convert);
 
 	if (bpp)
 		*bpp = get_bit_count(dds_header);
@@ -385,6 +409,9 @@ Done:
 
 	return retval;
 }
+
+static void (*decompress_dds)(const void *in, void *out, int pitch) = nullptr;
+static uint32_t BLOCK_SIZE = 0;
 
 //reads pixel info from a dds file
 int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
@@ -423,7 +450,7 @@ int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
 
 	cfseek(cfp, (dds_header.ddspf.dwFourCC == FOURCC_DX10) ? DX10_OFFSET : DDS_OFFSET, CF_SEEK_SET);
 
-	size = compute_dds_size(dds_header);
+	size = compute_dds_size(dds_header);	// don't add padding on this one!!
 
 	// read in the data
 	if ( !conversion_needed(dds_header) ) {
@@ -447,6 +474,28 @@ int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
 		const int num_faces = (dds_header.dwCaps2 & DDSCAPS2_CUBEMAP) ? 6 : 1;
 		const bool has_depth = (dds_header.dwFlags & DDSD_DEPTH) == DDSD_DEPTH;
 
+		switch (dds_header.ddspf.dwFourCC) {
+			case FOURCC_DX10:
+				decompress_dds = bcdec_bc7;
+				BLOCK_SIZE = BCDEC_BC7_BLOCK_SIZE;
+				break;
+			case FOURCC_DXT5:
+				decompress_dds = bcdec_bc3;
+				BLOCK_SIZE = BCDEC_BC3_BLOCK_SIZE;
+				break;
+			case FOURCC_DXT1:
+				decompress_dds = bcdec_bc1;
+				BLOCK_SIZE = BCDEC_BC1_BLOCK_SIZE;
+				break;
+			case FOURCC_DXT3:
+				decompress_dds = bcdec_bc2;
+				BLOCK_SIZE = BCDEC_BC2_BLOCK_SIZE;
+				break;
+			default:
+				Error(LOCATION, "Invalid FourCC (%d) for DDS decompression!", dds_header.ddspf.dwFourCC);
+				break;
+		}
+
 		for (int f = 0; f < num_faces; ++f) {
 			// if we resized then skip over all of that data (altering values to match pre-resize)
 			for (uint x = 0; x < mipmap_offset; ++x) {
@@ -454,7 +503,8 @@ int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
 				d_height = std::max(1U, dds_header.dwHeight << (mipmap_offset - x));
 				d_depth = has_depth ? std::max(1U, dds_header.dwDepth << (mipmap_offset - x)) : 1U;
 
-				src += (d_width * d_height * d_depth);
+				// NOTE: this is a specific use case and isn't safe to use elsewhere
+				src += std::max(1U, d_width >> 2) * std::max(1U, d_height >> 2) * d_depth * BLOCK_SIZE;
 			}
 
 			for (uint m = mipmap_offset; m < dds_header.dwMipMapCount; ++m) {
@@ -464,23 +514,14 @@ int dds_read_bitmap(const char *filename, ubyte *data, ubyte *bpp, int cf_type)
 				d_depth = std::max(1U, dds_header.dwDepth >> (m - mipmap_offset));
 
 				for (uint d = 0; d < d_depth; ++d) {
+					auto depth_offset = d * d_height * d_width * 4;
+
 					for (uint i = 0; i < d_height; i += 4) {
 						for (uint j = 0; j < d_width; j += 4) {
-							dst = data + data_offset + ((i * d_width + j) * 4);
+							dst = data + data_offset + depth_offset + ((i * d_width + j) * 4);
 
-							if (dds_header.ddspf.dwFourCC == FOURCC_DX10) {
-								bcdec_bc7(src, dst, d_width * 4);
-								src += BCDEC_BC7_BLOCK_SIZE;
-							} else if (dds_header.ddspf.dwFourCC == FOURCC_DXT5) {
-								bcdec_bc3(src, dst, d_width * 4);
-								src += BCDEC_BC3_BLOCK_SIZE;
-							} else if (dds_header.ddspf.dwFourCC == FOURCC_DXT1) {
-								bcdec_bc1(src, dst, d_width * 4);
-								src += BCDEC_BC1_BLOCK_SIZE;
-							} else if (dds_header.ddspf.dwFourCC == FOURCC_DXT3) {
-								bcdec_bc2(src, dst, d_width * 4);
-								src += BCDEC_BC2_BLOCK_SIZE;
-							}
+							decompress_dds(src, dst, d_width * 4);
+							src += BLOCK_SIZE;
 						}
 					}
 				}


### PR DESCRIPTION
Fix numerous heap corruption bugs. Size was calculated incorrectly for DXT1, depth wasn't factored into offsets, and data size didn't account for always needing to decode into a 4x4x4 block.

Also update bcdec to 0.98