### PR TITLE
Cleanup mouse wheel trigger control check

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2889,8 +2889,8 @@ int check_control_used(int id, int key)
 	// special case to allow actual mouse wheel to work with trigger controls --wookieejedi
 	if (item.type == CC_TYPE_TRIGGER) {
 
-		int first_btn = 1 << item.first.get_btn();
-		int second_btn = 1 << item.second.get_btn();
+		int first_btn = mouse_get_btn_down(item.first);
+		int second_btn = mouse_get_btn_down(item.second);
 
 		if ( (first_btn >= LOWEST_MOUSE_WHEEL && first_btn <= HIGHEST_MOUSE_WHEEL) ||
 			 (second_btn >= LOWEST_MOUSE_WHEEL && second_btn <= HIGHEST_MOUSE_WHEEL) ) {

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -457,9 +457,9 @@ int mouse_up_count(int n) {
 	return tmp;
 }
 
-// returns 1 if mouse button btn is down, 0 otherwise
+// returns 1 << mouse button used, 0 otherwise
 
-int mouse_down(const CC_bind &bind)
+int mouse_get_btn_down(const CC_bind& bind)
 {
 	// Bail if the incoming bind is not the right CID according to mouse-fly mode
 	auto CID = bind.get_cid();
@@ -481,9 +481,19 @@ int mouse_down(const CC_bind &bind)
 		return 0;
 	}
 
-	btn = 1 << btn;
+	return 1 << btn;
+}
 
-	return mouse_down(btn);
+// returns 1 if mouse button btn is down, 0 otherwise
+
+int mouse_down(const CC_bind &bind)
+{
+	int btn = mouse_get_btn_down(bind);
+	if (btn) {
+		return mouse_down(btn);
+	} else {
+		return 0;
+	}
 }
 
 int mouse_down(int btn) {

--- a/code/io/mouse.h
+++ b/code/io/mouse.h
@@ -86,6 +86,18 @@ int mouse_up_count(int n);
 void mouse_flush();
 
 /**
+ * Gets what the given mouse button is down, if any
+ *
+ * @returns 0 if the CC_bind is not CID_MOUSE when Use_mouse_to_fly == false, or
+ * @returns 0 if the CC_bind is not CID_JOY0 when Use_mouse_to_fly == true, or
+ * @returns 0 if the button id >= NUM_MOUSE_BUTTONS, or
+ * @returns 0 if the button is not down, or
+ *
+ * @returns button << 1 if the given button is down
+ */
+int mouse_get_btn_down(const CC_bind& bind);
+
+/**
  * Checks if the given mouse button is down
  * 
  * @returns 0 if the CC_bind is not CID_MOUSE when Use_mouse_to_fly == false, or


### PR DESCRIPTION
Cleans up special case that allows actual mouse wheel to work with trigger controls. Does not change any functionality but prevents possibly undefined behavior. Tested and fixes as expected.  