### PR TITLE
QtFRED Campaign Editor

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -242,8 +242,8 @@ add_file_folder("Source/UI/Util"
 )
 
 add_file_folder("Source/UI/Widgets"
-    src/ui/widgets/campaignmissiongraph.cpp
-	src/ui/widgets/campaignmissiongraph.h
+    src/ui/widgets/CampaignMissionGraph.cpp
+	src/ui/widgets/CampaignMissionGraph.h
     src/ui/widgets/ColorComboBox.cpp
     src/ui/widgets/ColorComboBox.h
 	src/ui/widgets/FlagList.cpp

--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -242,6 +242,8 @@ add_file_folder("Source/UI/Util"
 )
 
 add_file_folder("Source/UI/Widgets"
+    src/ui/widgets/campaignmissiongraph.cpp
+	src/ui/widgets/campaignmissiongraph.h
     src/ui/widgets/ColorComboBox.cpp
     src/ui/widgets/ColorComboBox.h
 	src/ui/widgets/FlagList.cpp

--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -258,6 +258,8 @@ add_file_folder("Source/UI/Widgets"
 	src/ui/widgets/sexp_tree.h
 	src/ui/widgets/ShipFlagCheckbox.h
 	src/ui/widgets/ShipFlagCheckbox.cpp
+	src/ui/widgets/SimpleListSelectDialog.cpp
+	src/ui/widgets/SimpleListSelectDialog.h
 	src/ui/widgets/weaponList.cpp
 	src/ui/widgets/weaponList.h
 	src/ui/widgets/bankTree.cpp

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -67,8 +67,8 @@ void CampaignEditorDialogModel::initializeData(const char* filename)
 			dest_mission.level = source_mission.level;
 			dest_mission.position = source_mission.pos;
 			dest_mission.briefing_cutscene = source_mission.briefing_cutscene;
-			dest_mission.main_hall = source_mission.main_hall.c_str();
-			dest_mission.substitute_main_hall = source_mission.substitute_main_hall.c_str();
+			dest_mission.main_hall = source_mission.main_hall;
+			dest_mission.substitute_main_hall = source_mission.substitute_main_hall;
 			dest_mission.debrief_persona_index = source_mission.debrief_persona_index;
 			bool retail_bastion = (source_mission.flags & CMISSION_FLAG_BASTION) != 0;
 
@@ -396,7 +396,7 @@ SCP_vector<SCP_string> CampaignEditorDialogModel::getCampaignTypes()
 {
 	SCP_vector<SCP_string> types;
 	for (auto& type : campaign_types) {
-		types.push_back(type);
+		types.emplace_back(type);
 	}
 	
 	return types;
@@ -436,7 +436,6 @@ void CampaignEditorDialogModel::loadCampaignFromFile(const SCP_string& filename)
 
 	// Immediately clear the global struct again now that we have our safe working copy.
 	clearCampaignGlobal();
-	return;
 }
 
 void CampaignEditorDialogModel::saveCampaign(const SCP_string& filename)
@@ -475,7 +474,6 @@ void CampaignEditorDialogModel::saveCampaign(const SCP_string& filename)
 
 	// Clean up the global struct now that the save is complete.
 	clearCampaignGlobal();
-	return;
 }
 
 bool CampaignEditorDialogModel::checkValidity()
@@ -582,7 +580,7 @@ void CampaignEditorDialogModel::setCurrentMissionSelection(int index)
 	}
 }
 
-int CampaignEditorDialogModel::getCurrentMissionSelection()
+int CampaignEditorDialogModel::getCurrentMissionSelection() const
 {
 	return m_current_mission_index;
 }
@@ -594,7 +592,7 @@ void CampaignEditorDialogModel::setCurrentBranchSelection(int branch_index)
 	m_current_branch_index = branch_index;
 }
 
-int CampaignEditorDialogModel::getCurrentBranchSelection()
+int CampaignEditorDialogModel::getCurrentBranchSelection() const
 {
 	return m_current_branch_index;
 }
@@ -1440,7 +1438,7 @@ CampaignBranchData* CampaignEditorDialogModel::findBranchById(int missionIdx, in
 }
 
 
-const SCP_vector<std::tuple<SCP_string, int, bool>> CampaignEditorDialogModel::getAllowedShips() const
+SCP_vector<std::tuple<SCP_string, int, bool>> CampaignEditorDialogModel::getAllowedShips() const
 {
 	SCP_vector<std::tuple<SCP_string, int, bool>> ship_list;
 	for (int i = 0; i < static_cast<int>(Ship_info.size()); i++) {
@@ -1461,7 +1459,7 @@ void CampaignEditorDialogModel::setAllowedShip(int ship_class_index, bool allowe
 	}
 }
 
-const SCP_vector<std::tuple<SCP_string, int, bool>> CampaignEditorDialogModel::getAllowedWeapons() const
+SCP_vector<std::tuple<SCP_string, int, bool>> CampaignEditorDialogModel::getAllowedWeapons() const
 {
 	SCP_vector<std::tuple<SCP_string, int, bool>> weapon_list;
 	for (int i = 0; i < static_cast<int>(Weapon_info.size()); i++) {
@@ -1504,7 +1502,7 @@ SCP_vector<SCP_string> CampaignEditorDialogModel::getMainhallList() const
 		// De-dupe by name (some mods define multiple resolutions/variants per mainhall)
 		std::unordered_set<SCP_string> seen;
 		for (const auto& mh : Main_hall_defines) {
-			if (mh.size() < 1) { // shouldn't happen but let's be safe
+			if (mh.empty()) { // shouldn't happen but let's be safe
 				continue;
 			}
 			const auto& hall = mh[0];

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -941,6 +941,18 @@ SCP_string CampaignEditorDialogModel::getCurrentMissionFilename() const
 	return m_missions[m_current_mission_index].filename;
 }
 
+void CampaignEditorDialogModel::setMissionAsFirst(int mission_index)
+{
+	if (!SCP_vector_inbounds(m_missions, mission_index)) {
+		return;
+	}
+	// Move the selected mission to the front of the list.
+	auto mission = m_missions[mission_index];
+	m_missions.erase(m_missions.begin() + mission_index);
+	m_missions.insert(m_missions.begin(), mission);
+	set_modified();
+}
+
 // Changing a mission's filename is a complex operation beyond a simple setter,
 // as it's the unique ID for the mission. This would be better handled by a
 // dedicated "replace mission" action, so we will leave this unimplemented for now.

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -10,6 +10,8 @@
 #include "cutscene/cutscenes.h"
 #include "menuui/mainhallmenu.h"
 
+extern int Skip_packfile_search; // from cfilesystem.cpp
+
 namespace fso::fred::dialogs {
 
 CampaignEditorDialogModel::CampaignEditorDialogModel(QObject* parent, fso::fred::EditorViewport* viewport, ICampaignEditorTreeOps& tree_ops)
@@ -184,9 +186,7 @@ void CampaignEditorDialogModel::parseBranchesFromFormula(CampaignMissionData& mi
 }
 
 void CampaignEditorDialogModel::loadAvailableMissions()
-{
-	extern int Skip_packfile_search; // from cfilesystem.cpp
-	
+{	
 	// Compatibility check lambda
 	auto is_mission_compatible = [&](const mission& mission_info) -> bool {
 		if (m_campaign_type == CAMPAIGN_TYPE_SINGLE) {
@@ -209,9 +209,9 @@ void CampaignEditorDialogModel::loadAvailableMissions()
 
 	// Get all editable mission files
 	SCP_vector<SCP_string> editable_files;
-	Skip_packfile_search = 1; // This global flag forces the search to ignore VPs
+	::Skip_packfile_search = 1; // This global flag forces the search to ignore VPs
 	cf_get_file_list(editable_files, CF_TYPE_MISSIONS, search_pattern.c_str(), CF_SORT_NAME);
-	Skip_packfile_search = 0;
+	::Skip_packfile_search = 0;
 
 	// For quick lookups, put the editable filenames into a set
 	std::unordered_set<SCP_string> editable_set(editable_files.begin(), editable_files.end());

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -94,9 +94,8 @@ void CampaignEditorDialogModel::initializeData(const char* filename)
 
 			auto mode = CampaignSpecialMode::Loop;
 
+			// If branches exist, effective mode follows the branch type.
 			if (anyLoop || anyFork) {
-				// If branches exist, effective mode follows the branch type.
-				// If (invalid) mixed types ever appear, prefer Loop (and the UI should block mixing).
 				mode = anyLoop ? CampaignSpecialMode::Loop : CampaignSpecialMode::Fork;
 			}
 

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -933,14 +933,6 @@ void CampaignEditorDialogModel::toggleMissionSpecialMode(int i)
 	modify(m_missions[i].special_mode_hint, mode);
 }
 
-SCP_string CampaignEditorDialogModel::getCurrentMissionFilename() const
-{
-	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
-		return "";
-	}
-	return m_missions[m_current_mission_index].filename;
-}
-
 void CampaignEditorDialogModel::setMissionAsFirst(int mission_index)
 {
 	if (!SCP_vector_inbounds(m_missions, mission_index)) {
@@ -953,10 +945,18 @@ void CampaignEditorDialogModel::setMissionAsFirst(int mission_index)
 	set_modified();
 }
 
+SCP_string CampaignEditorDialogModel::getCurrentMissionFilename() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return "";
+	}
+	return m_missions[m_current_mission_index].filename;
+}
+
 // Changing a mission's filename is a complex operation beyond a simple setter,
 // as it's the unique ID for the mission. This would be better handled by a
 // dedicated "replace mission" action, so we will leave this unimplemented for now.
-void CampaignEditorDialogModel::setCurrentMissionFilename(const SCP_string& filename)
+void CampaignEditorDialogModel::setCurrentMissionFilename(const SCP_string& /*filename*/)
 {
 	// Not implemented.
 }

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -44,7 +44,7 @@ void CampaignEditorDialogModel::initializeData(const char* filename)
 		// LOADING AN EXISTING CAMPAIGN
 
 		// This assumes the global 'Campaign' struct has just been populated by a
-		// call to mission_campaign_load() in our loadCampaignFromFile() method.
+		// call to mission_campaign_load() in the loadCampaignFromFile() method.
 
 		// Copy simple properties from the global Campaign struct
 		m_campaign_filename = Campaign.filename;
@@ -167,7 +167,7 @@ void CampaignEditorDialogModel::parseBranchesFromFormula(CampaignMissionData& mi
 		}
 
 		if (source_cmission) {
-			// In our new model, all branches can have loop data. We apply the single
+			// All branches can have loop data. We apply the single
 			// set of metadata from the file to all of them.
 			for (auto& branch : mission.branches) {
 				if (branch.is_loop) {
@@ -307,7 +307,7 @@ void CampaignEditorDialogModel::commitWorkingCopyToGlobal()
 		dest_mission.substitute_main_hall = sub_hall;
 		dest_mission.debrief_persona_index = source_mission.debrief_persona_index;
 
-		// Convert the flexible CampaignBranchData back into the rigid cmission formula structure
+		// Convert the CampaignBranchData back into the cmission formula structure
 		dest_mission.formula = -1;
 		dest_mission.mission_loop_formula = -1;
 
@@ -910,7 +910,7 @@ CampaignSpecialMode CampaignEditorDialogModel::getMissionSpecialMode(int i) cons
 		if (b.is_fork)
 			return CampaignSpecialMode::Fork;
 	}
-	// Otherwise use the editor hint (default LOOP)
+	// Otherwise use the editor hint
 	return m.special_mode_hint;
 }
 
@@ -1184,7 +1184,7 @@ void CampaignEditorDialogModel::removeBranchByTreeId(int formula_id)
 
 	m_current_branch_index = -1; // set no branch selected
 
-	// Rebuild the visual tree from the model’s authoritative state
+	// Rebuild the visual tree from the model's authoritative state
 	if (SCP_vector_inbounds(m_missions, m_current_mission_index)) {
 		auto& cur = m_missions[m_current_mission_index];
 		m_tree_ops.rebuildBranchTree(cur.branches, cur.filename);
@@ -1268,10 +1268,10 @@ void CampaignEditorDialogModel::addSpecialBranch(int from_mission_index, int to_
 	const bool asLoop = (from.special_mode_hint == CampaignSpecialMode::Loop);
 	const bool asFork = (from.special_mode_hint == CampaignSpecialMode::Fork);
 
-	// No mixing here; UI should enforce, but guard anyway
+	// No mixing here
 	for (const auto& b : from.branches) {
 		if ((b.is_loop || b.is_fork) && (b.is_loop != asLoop || b.is_fork != asFork)) {
-			// Conflicting special types present; refuse new special (optional: log)
+			// Conflicting special types present
 			return;
 		}
 	}
@@ -1305,8 +1305,6 @@ void CampaignEditorDialogModel::removeBranch(int mission_index, int branch_index
 	if (!SCP_vector_inbounds(mission.branches, branch_index)) {
 		return;
 	}
-
-	// Do we need to free sexps here?
 
 	// The model's only job is to update its own data.
 	mission.branches.erase(mission.branches.begin() + branch_index);

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -639,7 +639,30 @@ void CampaignEditorDialogModel::setCampaignNumPlayers(int num_players)
 
 const SCP_vector<std::pair<SCP_string, bool>>& CampaignEditorDialogModel::getAvailableMissionFiles() const
 {
-	return m_available_mission_files;
+	// If there's no filter, return the full list
+	if (m_available_missions_filter.empty()) {
+		return m_available_mission_files;
+	}
+	
+	// Otherwise, build and return a temporary, filtered list.
+	static SCP_vector<std::pair<SCP_string, bool>> filtered_list;
+	filtered_list.clear();
+
+	for (const auto& mission_pair : m_available_mission_files) {
+		const SCP_string& filename = mission_pair.first;
+
+		// Check if the filename contains the filter text
+		if (stristr(filename.c_str(), m_available_missions_filter.c_str())) {
+			filtered_list.push_back(mission_pair);
+		}
+	}
+
+	return filtered_list;
+}
+
+void CampaignEditorDialogModel::setAvailableMissionsFilter(const SCP_string& filter)
+{
+	m_available_missions_filter = filter;
 }
 
 void CampaignEditorDialogModel::addMission(const SCP_string& filename, int level, int pos)

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -234,7 +234,7 @@ void CampaignEditorDialogModel::loadAvailableMissions()
 	// Build the final list of available missions
 	for (const auto& filename : all_files) {
 		// Skip missions already in the campaign
-		if (active_missions.count(filename)) {
+		if (active_missions.count(filename + FS_MISSION_FILE_EXT)) {
 			continue;
 		}
 
@@ -731,6 +731,14 @@ void CampaignEditorDialogModel::setAvailableMissionsFilter(const SCP_string& fil
 
 void CampaignEditorDialogModel::addMission(const SCP_string& filename, int level, int pos)
 {
+	// Check that the mission isn't already in the campaign.
+	for (const auto& mission : m_missions) {
+		if (mission.filename == filename) {
+			// Mission is already in the campaign; do nothing.
+			return;
+		}
+	}
+	
 	// Before adding, check if this is the first mission for a multiplayer campaign.
 	if (m_campaign_type != CAMPAIGN_TYPE_SINGLE && m_missions.empty()) {
 		// If so, this mission's player count sets the standard for the whole campaign.

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -1,886 +1,968 @@
 #include "CampaignEditorDialogModel.h"
+
+#include "cfile/cfile.h"
+#include "mission/missionparse.h"
+#include "../src/mission/missionsave.h"
+#include "parse/sexp.h"
+#include "ship/ship.h"
 #include "weapon/weapon.h"
-#include "cutscene/cutscenes.h"
-#include "menuui/mainhallmenu.h"
-#include "stats/scoring.h"
-#include "mission/missiongoals.h"
-#include "mission/missionsave.h"
+#include "sound/audiostr.h"
 
-#include <QMessageBox>
-#include <QPlainTextDocumentLayout>
+namespace fso::fred::dialogs {
 
-//from cfilesystem.cpp, to find loose (non-vp) mission files, as oldfred did (campaignfilelistbox.cpp:58)
-extern int Skip_packfile_search;
-
-//from missionparse.cpp, to parse relevant parts of available mission files only (parseMnPart)
-extern void parse_mission_info(mission *mn, bool basic);
-extern void parse_events(mission *mn);
-extern void parse_goals(mission *mn);
-
-namespace fso {
-namespace fred {
-namespace dialogs {
-
-namespace  {
-QString loadOrCreateFile(QString file, const QString& campaignType) {
-	if (file.isEmpty()) {
-		mission_campaign_clear();
-		Campaign.type = campaignType.isEmpty() ? CAMPAIGN_TYPE_SINGLE :
-												 CampaignEditorDialogModel::campaignTypes.indexOf(campaignType);
-		return {};
-	}
-	//FRED is to enforce that only on new campaigns a campaign type may be given
-	Assertion(campaignType.isEmpty(), "The editor should only allow setting a campaign type when a new campaign is created. Please report.");
-
-	if (mission_campaign_load(qPrintable(file.replace('/',DIR_SEPARATOR_CHAR)), nullptr, 0))
-		return {};
-
-	return Campaign.filename;
-}
-
-void initShips(const SCP_vector<ship_info>::const_iterator &s_it, CheckedDataListModel<std::ptrdiff_t> &model){
-	Assertion(s_it < Ship_info.cend(), "Attempting to access a value outside of Ship_info. Please report.");
-	std::ptrdiff_t shpIdx{ std::distance(Ship_info.cbegin(), s_it) };
-	if (s_it->flags[Ship::Info_Flags::Player_ship]) {
-		model.initRow(
-				s_it->name,
-				shpIdx,
-				static_cast<bool>(Campaign.ships_allowed[static_cast<size_t>(shpIdx)]));
-	}
-}
-
-void initWeps(const SCP_vector<weapon_info>::const_iterator &w_it, CheckedDataListModel<std::ptrdiff_t> &model){
-	Assertion(w_it < Weapon_info.cend(), "Attempting to access a value outside of Weapon_info. Please report.");
-	std::ptrdiff_t wepIdx{ std::distance(Weapon_info.cbegin(), w_it) };
-	for (const ship_info& shp: Ship_info) {
-		if (shp.flags[Ship::Info_Flags::Player_ship]
-			&& shp.allowed_weapons[static_cast<size_t>(wepIdx)]
-			&& !model.contains(w_it->name)) {
-			model.initRow(
-					w_it->name,
-					wepIdx,
-					static_cast<bool>(Campaign.weapons_allowed[static_cast<size_t>(wepIdx)]));
-		}
-	}
-}
-
-SCP_vector<SCP_string> getMissions(){
-	Skip_packfile_search = 1;
-	SCP_vector<SCP_string> missions;
-	// #8a check: duplicate mission: get loose mission files once
-	cf_get_file_list(missions, CF_TYPE_MISSIONS, "*fs2", CF_SORT_NAME);
-	Skip_packfile_search = 0;
-	return missions;
-}
-
-bool parseMnPart(mission *mn, const char *filename){
-	try {
-		get_mission_info(filename, mn);
-
-		// also get events and goals, since they will be assigned within CampaignMissionData
-		Mission_goals.clear();
-		Mission_events.clear();
-		skip_to_start_of_string("#Events");
-		parse_events(mn);
-		parse_goals(mn);
-	} catch ( const parse::ParseException& ) {
-		return false;
-	}
-	return true;
-}
-} //namespace
-
-CampaignEditorDialogModel::CampaignEditorDialogModel(CampaignEditorDialog* _parent, EditorViewport* viewport, const QString &file, const QString& newCampaignType, int _numPlayers) :
-	AbstractDialogModel(_parent, viewport),
-	campaignFile(loadOrCreateFile(file, newCampaignType)),
-	campaignType(campaignTypes[Campaign.type]),
-	numPlayers(campaignFile.isEmpty() ? (Campaign.num_players = _numPlayers) : Campaign.num_players),
-	parent(_parent),
-	initialShips(Ship_info, &initShips, this),
-	initialWeapons(Weapon_info, &initWeps, this),
-	missionData(getMissions(), &CampaignMissionData::initMissions, this),
-	campaignName(Campaign.name),		//missioncampaign.h globals
-	campaignDescr(Campaign.desc),
-	campaignTechReset(Campaign.flags & CF_CUSTOM_TECH_DATABASE)
+CampaignEditorDialogModel::CampaignEditorDialogModel(QObject* parent, fso::fred::EditorViewport* viewport, ICampaignEditorTreeOps& tree_ops)
+	: AbstractDialogModel(parent, viewport), m_tree_ops(tree_ops)
 {
-	Assertion(_numPlayers == 0 || campaignFile.isEmpty(), "The editor should only allow setting a player number when a new campaign is created. Please report.");
-
-	for (int i=0; i<Campaign.num_missions; i++) {
-		// #8 check: duplicate mission: don't add mission if name already present
-		if (! missionData.contains(Campaign.missions[i].name)) {
-			mission temp{};
-			bool loaded{parseMnPart(&temp, qPrintable(Campaign.missions[i].name))};
-
-			CampaignMissionData* mnDataPtr{ // temporary handle, until the missionData submodel takes ownership
-				new CampaignMissionData{
-					Campaign.missions[i].name, loaded, &temp, &Campaign.missions[i]
-				}
-			};
-
-			mnDataPtr->fredable = false;
-
-			// #11 check: multi player number: skip and warn on load
-			if (campaignTypes.indexOf(campaignType) != CAMPAIGN_TYPE_SINGLE && numPlayers != temp.num_players) {
-				CampaignEditorDialog::uiWarn(tr("Potential Campaign Bug"), tr("Mission %1 of campaign has wrong player number: %2 and was removed.").arg(temp.name, temp.num_players));
-				delete mnDataPtr;
-				continue;
-			}
-
-			missionData.initRow(Campaign.missions[i].name, mnDataPtr, true,
-							   loaded ? Qt::darkYellow : Qt::red);
-		}
-	}
-
-	// #9 check: no first mission: enforced here
-	if (Campaign.num_missions > 0)
-		firstMission = Campaign.missions[0].name;
-
-	//reparse campaign after parsing missions
-	if (!campaignFile.isEmpty()){
-		QString temp = campaignFile;
-		bool reloaded = !mission_campaign_load(qPrintable(temp.replace('/',DIR_SEPARATOR_CHAR)), nullptr, 0);
-		Assertion(reloaded, "Campaign file should still be loadable");
-		connectBranches(false, &Campaign);
-	}
-
-	connect(&campaignDescr, &QTextDocument::contentsChanged, this, &CampaignEditorDialogModel::flagModified);
-	connect(&initialShips, &QAbstractListModel::dataChanged, this, &CampaignEditorDialogModel::flagModified);
-	connect(&initialWeapons, &QAbstractListModel::dataChanged, this, &CampaignEditorDialogModel::flagModified);
-	connect(&missionData, &QAbstractListModel::rowsAboutToBeInserted, this, [&](){mnData_it = nullptr; mnData_idx = QModelIndex();});
-	connect(&missionData, &QAbstractListModel::dataChanged, this, [&](){connectBranches();});
-	connect(&missionData, &QAbstractListModel::dataChanged, this, &CampaignEditorDialogModel::flagModified);
-	connect(&missionData, &QAbstractListModel::dataChanged, this, &CampaignEditorDialogModel::trackMissionUncheck);
+	initializeData();
 }
 
-void CampaignEditorDialogModel::supplySubModels(QListView &ships, QListView &weps, QListView &missions, QPlainTextEdit &descr) {
-	ships.setModel(&initialShips);
-	weps.setModel(&initialWeapons);
-	missions.setModel(&missionData);
-
-	campaignDescr.associateEdit(&descr);
-}
-
-QStringList CampaignEditorDialogModel::getMissionGoals(const QString& /*model knows best*/) {
-	QString reference_name;
-	if (getCurBr())
-		reference_name = Sexp_nodes[CDR(getCurBr()->sexp)].text;
-	else
-		return {};
-	for (auto mn : missionData)
-		if (reference_name == mn.first.filename)
-			return mn.first.goals;
-	return {};
-}
-
-QStringList CampaignEditorDialogModel::getMissionEvents(const QString& /*model knows best*/) {
-	QString reference_name;
-	if (getCurBr())
-		reference_name = Sexp_nodes[CDR(getCurBr()->sexp)].text;
-	else
-		return QStringList{};
-	for (auto mn : missionData)
-		if (reference_name == mn.first.filename)
-			return mn.first.events;
-	return {};
-}
-
-QStringList CampaignEditorDialogModel::getMissionNames() {
-	QStringList ret;
-	ret.reserve(static_cast<int>(missionData.collectCheckedData().size()));
-	for (auto mn : missionData)
-		if (mn.second)
-			ret << mn.first.filename;
-	return ret;
-}
-
-QList<QAction *> CampaignEditorDialogModel::getContextMenuExtras(QObject *menu_parent) {
-	QList<QAction *> ret;
-
-	int curBrIdx = getCurBrIdx();
-	QAction *moveUpAct{new QAction{tr("Move Up"), menu_parent}};
-	moveUpAct->setEnabled(curBrIdx > 0);
-	connect(moveUpAct, &QAction::triggered, this, [this](){moveCurBr(true);});
-	ret << moveUpAct;
-
-	QAction *moveDownAct{new QAction{tr("Move Down"), menu_parent}};
-	moveDownAct->setEnabled(curBrIdx >= 0 && curBrIdx + 1 < getCurMnBrCnt());
-	connect(moveDownAct, &QAction::triggered, this, [this](){moveCurBr(false);});
-	ret << moveDownAct;
-
-	QAction *toggleLoopAct{new QAction{tr("Toggle Loop"), menu_parent}};
-	toggleLoopAct->setEnabled(curBrIdx >= 0);
-	toggleLoopAct->setCheckable(true);
-	toggleLoopAct->setChecked(isCurBrLoop());
-	connect(toggleLoopAct, &QAction::toggled, this, &CampaignEditorDialogModel::setCurBrIsLoop);
-	ret << toggleLoopAct;
-
-	return ret;
-}
-
-bool CampaignEditorDialogModel::fillTree(sexp_tree& sxt) const {
-	if (!mnData_it)
-		return false;
-	int i = 0;
-	for (const CampaignBranchData& br : mnData_it->branches) {
-		NodeImage img;
-		if (br.type == CampaignBranchData::NEXT_NOT_FOUND)
-			img = NodeImage::ROOT_DIRECTIVE;
-		else if (br.loop)
-			img = NodeImage::ROOT;
-		else
-			img = NodeImage::BLACK_DOT;
-		QTreeWidgetItem *h = sxt.insert(CampaignBranchData::branchTexts.at(br.type) + br.next, img);
-		h->setData(0, Qt::UserRole, i++);
-		sxt.add_sub_tree(sxt.load_sub_tree(br.sexp, true, "do-nothing"), h);
-	}
-	mnData_it->brData_it = nullptr;
-	mnData_it->brData_idx = -1;
+bool CampaignEditorDialogModel::apply()
+{
+	stopSpeech();
+	clearCampaignGlobal();
 	return true;
 }
 
-void CampaignEditorDialogModel::supplySubModelLoop(QPlainTextEdit &descr) {
-	if (getCurBr())
-		getCurBr()->loopDescr->associateEdit(&descr);
-	else
-		descr.setDocument(nullptr);
+void CampaignEditorDialogModel::reject()
+{
+	stopSpeech();
+	clearCampaignGlobal();
 }
 
-bool CampaignEditorDialogModel::saveTo(const QString &file) {
-	bool success = _saveTo(file);
-	CampaignEditorDialog::uiWarn(file, success ? tr("Successfully saved") : tr("Error saving"));
-	modified = ! success;
-	return success;
-}
+void CampaignEditorDialogModel::initializeData(const char* filename)
+{
+	// Clear the internal state to ensure a fresh start.
+	m_missions.clear();
+	m_ships_allowed.clear();
+	m_weapons_allowed.clear();
+	m_available_mission_files.clear();
 
-void CampaignEditorDialogModel::missionSelectionChanged(const QItemSelection & selected) {
-	if (mnData_it)
-		mnData_it->brData_it = nullptr;
-	if (selected.empty()) {
-		mnData_it = nullptr;
-		mnData_idx = QPersistentModelIndex();
+	// Decide whether to load from the global struct or set up a new campaign.
+	if (filename) {
+		// LOADING AN EXISTING CAMPAIGN
+
+		// This assumes the global 'Campaign' struct has just been populated by a
+		// call to mission_campaign_load() in our loadCampaignFromFile() method.
+
+		// Copy simple properties from the global Campaign struct
+		m_campaign_filename = Campaign.filename;
+		m_campaign_name = Campaign.name;
+		m_campaign_descr = Campaign.desc ? Campaign.desc : "";
+		m_campaign_type = Campaign.type;
+		m_num_players = Campaign.num_players;
+		m_flags = Campaign.flags;
+
+		// Copy mission data from the global Campaign struct
+		m_missions.reserve(Campaign.num_missions);
+		for (int i = 0; i < Campaign.num_missions; ++i) {
+			const auto& source_mission = Campaign.missions[i];
+			auto& dest_mission = m_missions.emplace_back();
+
+			dest_mission.name = source_mission.name;
+			dest_mission.level = source_mission.level;
+			dest_mission.position = source_mission.pos;
+			dest_mission.briefing_cutscene = source_mission.briefing_cutscene;
+			dest_mission.main_hall = source_mission.main_hall.c_str();
+			dest_mission.substitute_main_hall = source_mission.substitute_main_hall.c_str();
+			dest_mission.debrief_persona_index = source_mission.debrief_persona_index;
+
+			// Parse the SEXP formulas to build the branch data for this mission.
+			parseBranchesFromFormula(dest_mission, source_mission.formula, false);
+			if (source_mission.flags & CMISSION_FLAG_HAS_LOOP) {
+				parseBranchesFromFormula(dest_mission, source_mission.mission_loop_formula, true);
+			}
+		}
+
+		// Copy ship and weapon permissions from the global Campaign struct
+		m_ships_allowed.assign(Campaign.ships_allowed, Campaign.ships_allowed + MAX_SHIP_CLASSES);
+		m_weapons_allowed.assign(Campaign.weapons_allowed, Campaign.weapons_allowed + MAX_WEAPON_TYPES);
+
 	} else {
-		const QPersistentModelIndex &changed = selected.first().topLeft();
-		mnData_it = missionData.managedData(changed);
-		mnData_idx = changed;
-	}
-	parent->updateUIMission();
-}
+		// CREATING A NEW CAMPAIGN
 
-void CampaignEditorDialogModel::setCurMnFirst(){
-	if (! mnData_it)
-		return;
-	QMessageBox::StandardButton resBtn = QMessageBox::Yes;
-	if (! firstMission.isEmpty()) {
-		resBtn = QMessageBox::question( parent, tr("Change first mission?"),
-										tr("Do you want to replace\n%1\nas first mission?").arg(firstMission),
-										QMessageBox::Yes | QMessageBox::No,
-										QMessageBox::Yes );
+		// Set up a clean, default state within the model.
+		m_campaign_filename = "";
+		m_campaign_name = "Unnamed";
+		m_campaign_descr = "";
+		m_campaign_type = CAMPAIGN_TYPE_SINGLE;
+		m_num_players = 0;
+		m_flags = CF_DEFAULT_VALUE;
+
+		m_ships_allowed.assign(MAX_SHIP_CLASSES, false);
+		m_weapons_allowed.assign(MAX_WEAPON_TYPES, false);
 	}
 
-	if (resBtn == QMessageBox::Yes)
-		modify<QString>(firstMission, mnData_it->filename);
+	// Load the list of available mission files from the directory.
+	loadAvailableMissions();
+
+	// Set initial selection states to none.
+	m_current_mission_index = -1;
+	m_current_branch_index = -1;
+
+	// Mark the model as unmodified since this is a fresh load or new state.
+	_modified = false;
 }
 
-int CampaignEditorDialogModel::addCurMnBranchTo(const QModelIndex *other, bool flip) {
-	if (! mnData_it)
-		return -1;
-	if (! other) {
-		mnData_it->branches.emplace_back(this, mnData_it->filename);
-
-		flagModified();
-		return static_cast<int>(mnData_it->branches.size() -1);
-	}
-	CampaignMissionData *otherMn = missionData.managedData(*other);
-	if (! otherMn)
-		return -1;
-	CampaignMissionData &from = flip ? *otherMn : *mnData_it;
-	const CampaignMissionData &to = flip ? *mnData_it : *otherMn;
-	from.branches.emplace_back(this, from.filename, to.filename);
-
-	flagModified();
-	return static_cast<int>(mnData_it->branches.size() -1);
-}
-
-void CampaignEditorDialogModel::delCurMnBranch(int node) {
-	if (! mnData_it)
+void CampaignEditorDialogModel::parseBranchesFromFormula(CampaignMissionData& mission, int formula_index, bool is_loop)
+{
+	if (formula_index < 0 || stricmp(CTEXT(formula_index), "cond")) {
 		return;
-
-	mnData_it->branches.erase(mnData_it->branches.cbegin() + node);
-	flagModified();
-
-	parent->updateUIMission();
-}
-
-void CampaignEditorDialogModel::selectCurBr(const QTreeWidgetItem *selected) {
-	if (! mnData_it)
-		return;
-	mnData_it->brData_it = nullptr;
-	mnData_it->brData_idx = -1;
-
-	if (!selected)
-		return;
-
-	const QTreeWidgetItem *parent_node;
-	while ((parent_node = selected->parent()))
-		selected = parent_node;
-	mnData_it->brData_idx = selected->data(0, Qt::UserRole).toInt();
-	auto idx = static_cast<size_t>(mnData_it->brData_idx);
-	Assert(idx < mnData_it->branches.size());
-	mnData_it->brData_it = &mnData_it->branches[idx];
-
-	parent->updateUIBranch();
-}
-
-int CampaignEditorDialogModel::setCurBrCond(const QString &sexp, const QString &mn, const QString &arg) {
-	if (! getCurBr())
-		return -1;
-
-	mnData_it->brData_it->sexp =
-			alloc_sexp(qPrintable(sexp), SEXP_ATOM, SEXP_ATOM_OPERATOR, -1,
-					   alloc_sexp(qPrintable(mn), SEXP_ATOM, SEXP_ATOM_STRING, -1,
-								  alloc_sexp(qPrintable(arg), SEXP_ATOM, SEXP_ATOM_STRING, -1, -1)));
-	flagModified();
-	return getCurBrIdx();
-}
-
-bool CampaignEditorDialogModel::setCurBrSexp(int sexp) {
-	if (! getCurBr())
-		return false;
-
-	// #5 check: always false branch: reject bad manual edit
-	if (sexp == Locked_sexp_false) {
-		CampaignEditorDialog::uiWarn(tr("Potential Campaign Bug"), tr("Attempt to set campaign branch condition to false rejected"));
-		return false;
 	}
 
-	mnData_it->brData_it->sexp = sexp;
-	flagModified();
-	return true;
-}
+	// The formula is a 'cond' expression. We walk its branches.
+	for (int branch_sexp = CDR(formula_index); branch_sexp != -1; branch_sexp = CDR(branch_sexp)) {
+		auto& new_branch = mission.branches.emplace_back();
+		new_branch.is_loop = is_loop;
 
-void CampaignEditorDialogModel::setCurBrIsLoop(bool isLoop) {
-	if (! getCurBr())
-		return;
-	if (isLoop) {
-		for (auto& br : mnData_it->branches) {
-			if (br.loop) {
-				if (QMessageBox::question(parent, tr("Change loop"), tr("This will make branch to %1 no longer a loop. Continue?").arg(br.next)) == QMessageBox::StandardButton::No)
-					return;
-				modify<bool>(br.loop, false);
+		// The first part of the branch is the condition SEXP.
+		int condition_sexp = CAR(CAR(branch_sexp));
+
+		// The second part is the action
+		int action_sexp = CADR(CAR(branch_sexp));
+		if (!stricmp(CTEXT(action_sexp), "next-mission")) {
+			new_branch.next_mission_name = CTEXT(CDR(action_sexp));
+		} else {
+			// This is an "end-of-campaign" branch, so the name is empty.
+			new_branch.next_mission_name = "";
+		}
+
+		// The model commands the UI's tree to load the SEXP.
+		// The tree returns an internal ID, which we store.
+		new_branch.sexp_formula = m_tree_ops.loadSexp(condition_sexp);
+	}
+
+	// If this was a loop, find the original cmission to copy the descriptive text.
+	if (is_loop) {
+		const cmission* source_cmission = nullptr;
+		for (int i = 0; i < Campaign.num_missions; ++i) {
+			if (mission.name == Campaign.missions[i].name) {
+				source_cmission = &Campaign.missions[i];
+				break;
+			}
+		}
+
+		if (source_cmission) {
+			// In our new model, all branches can have loop data. We apply the single
+			// set of metadata from the file to all of them.
+			for (auto& branch : mission.branches) {
+				if (branch.is_loop) {
+					branch.loop_description =
+						source_cmission->mission_branch_desc ? source_cmission->mission_branch_desc : "";
+					branch.loop_briefing_anim =
+						source_cmission->mission_branch_brief_anim ? source_cmission->mission_branch_brief_anim : "";
+					branch.loop_briefing_sound =
+						source_cmission->mission_branch_brief_sound ? source_cmission->mission_branch_brief_sound : "";
+				}
 			}
 		}
 	}
-
-	modify<bool>(mnData_it->brData_it->loop, isLoop);
-	int idx = getCurBrIdx();
-	parent->updateUIMission(false);
-	parent->updateUIBranch(idx);
 }
 
-void CampaignEditorDialogModel::moveCurBr(bool up) {
-	if (! getCurBr())
-		return;
+void CampaignEditorDialogModel::loadAvailableMissions()
+{
+	extern int Skip_packfile_search; // from cfilesystem.cpp
 
-	auto idx = static_cast<size_t>(mnData_it->brData_idx);
-	if (idx == 0 && up)
-		return;
-
-	size_t other_idx = up ? idx - 1 : idx + 1;
-	auto& brs = mnData_it->branches;
-	if (brs.size() == other_idx)
-		return;
-
-	std::swap(brs[idx], brs[other_idx]);
-	flagModified();
-
-	parent->updateUIMission(false);
-	parent->updateUIBranch(static_cast<int>(other_idx));
-}
-
-void CampaignEditorDialogModel::setCurLoopAnim(const QString &anim) {
-	if (! (mnData_it && mnData_it->brData_it))
-		return;
-	modify<QString>(mnData_it->brData_it->loopAnim, anim);
-	parent->updateUIBranch();
-}
-
-void CampaignEditorDialogModel::setCurLoopVoice(const QString &voice) {
-	if (! (mnData_it && mnData_it->brData_it))
-		return;
-	modify<QString>(mnData_it->brData_it->loopVoice, voice);
-	parent->updateUIBranch();
-}
-
-void CampaignEditorDialogModel::connectBranches(bool uiUpdate, const campaign *cpgn) {
-	for (auto *mn: missionData.collectCheckedData()) {
-		if (cpgn) {
-			const cmission *const cm_it{
-				std::find_if(cpgn->missions, &cpgn->missions[cpgn->num_missions],
-						[&](const cmission &cm){ return mn->filename == cm.name; })};
-			if (cm_it != &cpgn->missions[cpgn->num_missions]) {
-				mn->branchesFromFormula(this, cm_it->formula);
-				mn->branchesFromFormula(this, cm_it->mission_loop_formula, cm_it);
-			}
+	auto is_mission_compatible = [](const mission& mission_info, int campaign_type, int campaign_num_players) -> bool {
+		if (campaign_type == CAMPAIGN_TYPE_SINGLE) {
+			return (mission_info.game_type & (MISSION_TYPE_SINGLE | MISSION_TYPE_TRAINING));
 		}
-		for (auto& br: mn->branches)
-			if (br.type == CampaignBranchData::NEXT || br.type == CampaignBranchData::NEXT_NOT_FOUND)
-				br.connect(const_cast<const CheckedDataListModel<CampaignMissionData>&>(missionData).collectCheckedData());
+		if (campaign_type == CAMPAIGN_TYPE_MULTI_COOP) {
+			return (mission_info.game_type & MISSION_TYPE_MULTI_COOP) &&
+				   (campaign_num_players == -1 || campaign_num_players == mission_info.num_players); // Player count must match, OR be -1
+		}
+		if (campaign_type == CAMPAIGN_TYPE_MULTI_TEAMS) {
+			return (mission_info.game_type & MISSION_TYPE_MULTI_TEAMS) &&
+				   (campaign_num_players == -1 || campaign_num_players == mission_info.num_players); // Player count must match, OR be -1
+		}
+		return false;
+	};
+	
+	m_available_mission_files.clear();
+
+	// Get all loose mission filenames from the game directory
+	SCP_vector<SCP_string> all_mission_files;
+
+	// This global flag tells the engine to find only non-VP, editable missions
+	Skip_packfile_search = 1;
+	cf_get_file_list(all_mission_files, CF_TYPE_MISSIONS, "*.fs2", CF_SORT_NAME);
+	Skip_packfile_search = 0;
+
+	// Build a quick lookup set of missions already in the campaign for efficient checking
+	std::unordered_set<SCP_string> active_missions;
+	for (const auto& mission_data : m_missions) {
+		active_missions.insert(mission_data.name);
 	}
-	if (uiUpdate)
-		parent->updateUIMission();
+
+	// Iterate, filter, and add valid missions
+	m_available_mission_files.reserve(all_mission_files.size());
+	for (const auto& filename : all_mission_files) {
+		// Check if it's already in the campaign
+		if (active_missions.count(filename)) {
+			continue;
+		}
+
+		// Get mission info to check for compatibility
+		mission mission_info;
+		get_mission_info(filename.c_str(), &mission_info);
+
+		// Check if the mission type and player count match the campaign
+		if (is_mission_compatible(mission_info, m_campaign_type, m_num_players)) {
+			m_available_mission_files.push_back(filename);
+		}
+	}
 }
 
-bool CampaignEditorDialogModel::_saveTo(QString file) const {
-	if (file.isEmpty())
-		return false;
+void CampaignEditorDialogModel::clearCampaignGlobal()
+{
+	mission_campaign_clear();
+}
 
+void CampaignEditorDialogModel::commitWorkingCopyToGlobal()
+{
+	// Clear the global struct first
 	mission_campaign_clear();
 
-	// handle special characters
-	QString modified_name = campaignName;
-	QString modified_desc = campaignDescr.toPlainText();
-	_viewport->editor->lcl_fred_replace_stuff(modified_name);
-	_viewport->editor->lcl_fred_replace_stuff(modified_desc);
+	// Copy simple properties
+	strcpy_s(Campaign.name, m_campaign_name.c_str());
+	Campaign.desc = m_campaign_descr.empty() ? nullptr : strdup(m_campaign_descr.c_str());
+	Campaign.type = m_campaign_type;
+	Campaign.num_players = m_num_players;
+	Campaign.flags = m_flags;
+	Campaign.num_missions = static_cast<int>(m_missions.size());
 
-	strncpy(Campaign.name, qPrintable(modified_name), NAME_LENGTH);
-
-	Campaign.type = campaignTypes.indexOf(campaignType);
-
-	if (!modified_desc.isEmpty())
-		Campaign.desc = vm_strdup(qPrintable(modified_desc));
-
-	Campaign.num_players = numPlayers;
-
-	Campaign.flags = CF_DEFAULT_VALUE;
-	if (campaignTechReset)
-		Campaign.flags |= CF_CUSTOM_TECH_DATABASE;
-
-	for (auto shp_idx_ptr : initialShips.collectCheckedData()) {
-		Assertion(shp_idx_ptr, "NULL ship class index in initial ships");
-		Assertion(*shp_idx_ptr < MAX_SHIP_CLASSES, "Illegal ship class index in initial ships: %ld", *shp_idx_ptr);
-		Campaign.ships_allowed[*shp_idx_ptr] = true;
+	// Copy ship and weapon permissions
+	for (int i = 0; i < MAX_SHIP_CLASSES; ++i) {
+		Campaign.ships_allowed[i] = m_ships_allowed[i];
+	}
+	for (int i = 0; i < MAX_WEAPON_TYPES; ++i) {
+		Campaign.weapons_allowed[i] = m_weapons_allowed[i];
 	}
 
-	for (auto wep_idx_ptr : initialWeapons.collectCheckedData()) {
-		Assertion(wep_idx_ptr, "NULL weapon class index in initial weapons");
-		Assertion(*wep_idx_ptr < MAX_WEAPON_TYPES, "Illegal weapon class index in initial weapons: %ld", *wep_idx_ptr);
-		Campaign.weapons_allowed[*wep_idx_ptr] = true;
-	}
+	// Copy mission data
+	for (int i = 0; i < Campaign.num_missions; ++i) {
+		const auto& source_mission = m_missions[i];
+		auto& dest_mission = Campaign.missions[i];
 
-	if (firstMission.length() > 0) {
-		static const QString PAST_BRANCHES{};
-		SCP_unordered_set<const CampaignMissionData*> unsaved{missionData.collectCheckedData()};
-		SCP_queue<const QString*> saveNext{};
-		int i=0, lvl=0, pos=0;
+		dest_mission.name = strdup(source_mission.name.c_str());
+		dest_mission.level = source_mission.level;
+		dest_mission.pos = source_mission.position;
+		strcpy_s(dest_mission.briefing_cutscene, source_mission.briefing_cutscene.c_str());
+		dest_mission.main_hall = source_mission.main_hall;
+		dest_mission.substitute_main_hall = source_mission.substitute_main_hall;
+		dest_mission.debrief_persona_index = source_mission.debrief_persona_index;
 
-		saveNext.push(&firstMission);
-		do {
-			// traversal
-			if (saveNext.empty())
-				saveNext.push(&(*unsaved.cbegin())->filename);
-			while (! saveNext.empty()) {
-				const QString *mnName = saveNext.front();
-				saveNext.pop();
+		// Convert the flexible CampaignBranchData back into the rigid cmission formula structure
+		dest_mission.formula = -1;
+		dest_mission.mission_loop_formula = -1;
 
-				if (mnName == &PAST_BRANCHES) {
-					if (pos > 0) {
-						++lvl;
-						pos = 0;}
-					continue;
-				}
+		// We need to build a 'cond' SEXP for normal branches...
+		int* normal_branch_ptr = &dest_mission.formula;
+		bool normal_branches_exist = false;
 
-				auto it = std::find_if(unsaved.cbegin(), unsaved.cend(),
-									   [&](const CampaignMissionData *mn_ptr) {
-					 return mn_ptr->filename == *mnName;	});
-				const CampaignMissionData *mn;
-				if (it != unsaved.cend()) {
-					mn = *it;
-					unsaved.erase(it);
-				}
-				else {
-					continue;
-				}
+		// ...and another 'cond' SEXP for loop branches
+		int* loop_branch_ptr = &dest_mission.mission_loop_formula;
+		bool loop_branches_exist = false;
 
-				for (const auto &br : mn->branches)
-					saveNext.push(&br.next);
-				saveNext.push(&PAST_BRANCHES);
+		for (const auto& branch : source_mission.branches) {
+			// First, save the branch's SEXP tree to get the final formula index
+			int final_sexp_formula = m_tree_ops.saveSexp(branch.sexp_formula);
 
-				// saving
-				cmission &cm = Campaign.missions[i++];
-
-				cm.name = vm_strdup(qPrintable(*mnName));
-				strncpy(cm.briefing_cutscene, qPrintable(mn->briefingCutscene), NAME_LENGTH);
-				cm.main_hall = mn->mainhall.toStdString();
-
-				//Bastion flag unsupported in missionLoad
-				cm.flags = 0;
-				cm.debrief_persona_index = static_cast<ubyte>(mn->debriefingPersona.toUShort());
-
-				using BranchType = CampaignBranchData::BranchType;
-				cm.formula =
-						alloc_sexp("cond", SEXP_ATOM, SEXP_ATOM_OPERATOR, -1, -1);
-				int *cond_arms_ptr = &Sexp_nodes[cm.formula].rest;
-				bool flag_last_branch = false;
-				for (const auto &br : mn->branches) {
-					Assertion(br.type != BranchType::INVALID, "UI should not let any branch remain invalid");
-					// #2 check: Illegal target mission
-					if (br.type == BranchType::NEXT_NOT_FOUND)
-						CampaignEditorDialog::uiWarn(tr("Potential Campaign Bug"), tr("Saving branch to unknown mission:\n%1 to %2").arg(mn->filename, br.next));
-					if (! br.loop) { //build formula from nonloop branches
-						// #6 check: True middle branch
-						if (flag_last_branch)
-							CampaignEditorDialog::uiWarn(tr("Potential Campaign Bug"), tr("Branch is unreachable due to previous \"true\" condition:\n%1 to %2").arg(mn->filename, br.next));
-						if (br.sexp == Locked_sexp_true)
-							flag_last_branch = true;
-
-						int nextsexp;
-						if (br.type != BranchType::END) {
-							nextsexp = alloc_sexp("next-mission", SEXP_ATOM, SEXP_ATOM_OPERATOR, -1,
-												  alloc_sexp(qPrintable(br.next), SEXP_ATOM, SEXP_ATOM_STRING, -1, -1));
-						} else {
-							nextsexp =  alloc_sexp("end-of-campaign", SEXP_ATOM, SEXP_ATOM_OPERATOR, -1, -1);
-						}
-
-						*cond_arms_ptr =
-								alloc_sexp("", SEXP_LIST, -1,
-										alloc_sexp("", SEXP_LIST, -1, br.sexp,
-												   alloc_sexp("", SEXP_LIST, -1, nextsexp, -1)), -1);
-
-						cond_arms_ptr = &Sexp_nodes[*cond_arms_ptr].rest;
-					} else { //flag & save for loop
-						Assertion(cm.flags ^ CMISSION_FLAG_HAS_LOOP, "UI should have stopped attempt at multiple loops");
-						// #4 check: always true loop
-						if (br.sexp == Locked_sexp_true)
-							CampaignEditorDialog::uiWarn(tr("Potential Campaign Bug"), tr("Loop is always true from mission: %1 to %2").arg(mn->filename, br.next));
-						cm.flags |= CMISSION_FLAG_HAS_LOOP;
-
-						QString descr = br.loopDescr->toPlainText();
-						_viewport->editor->lcl_fred_replace_stuff(descr);
-						if (descr.isEmpty())
-							cm.mission_branch_desc = nullptr;
-						else
-							cm.mission_branch_desc = vm_strdup(qPrintable(descr));
-
-						if (br.loopAnim.isEmpty())
-							cm.mission_branch_brief_anim = nullptr;
-						else
-							cm.mission_branch_brief_anim = vm_strdup(qPrintable(br.loopAnim));
-
-						if (br.loopVoice.isEmpty())
-							cm.mission_branch_brief_sound = nullptr;
-						else
-							cm.mission_branch_brief_sound = vm_strdup(qPrintable(br.loopVoice));
-
-						int nextsexp =
-								alloc_sexp("next-mission", SEXP_ATOM, SEXP_ATOM_OPERATOR, -1,
-										   alloc_sexp(qPrintable(br.next), SEXP_ATOM, SEXP_ATOM_STRING, -1, -1));
-						int cond_arms =
-								alloc_sexp("", SEXP_LIST, -1,
-										alloc_sexp("", SEXP_LIST, -1, br.sexp,
-												   alloc_sexp("", SEXP_LIST, -1, nextsexp, -1)), -1);
-						cm.mission_loop_formula =
-								alloc_sexp("cond", SEXP_ATOM, SEXP_ATOM_OPERATOR, -1, cond_arms);
-					}
-				}
-				// #7 check: not always true last branch
-				if (!flag_last_branch)
-					CampaignEditorDialog::uiWarn(tr("Potential Campaign Bug"), tr("Last branch is not always true from mission: %1").arg(mn->filename));
-
-				cm.level = lvl;
-				cm.pos = pos++;
+			// Create the next-mission part of the branch
+			int action_sexp;
+			if (!branch.next_mission_name.empty()) {
+				action_sexp = alloc_sexp("next-mission",
+					SEXP_ATOM,
+					SEXP_ATOM_OPERATOR,
+					-1,
+					alloc_sexp(branch.next_mission_name.c_str(), SEXP_ATOM, SEXP_ATOM_STRING, -1, -1));
+			} else {
+				action_sexp = alloc_sexp("end-of-campaign", SEXP_ATOM, SEXP_ATOM_OPERATOR, -1, -1);
 			}
-		} while (! unsaved.empty());
-		Campaign.num_missions = i;
-	}
 
-	CFred_mission_save save;
-	return !save.save_campaign_file(qPrintable(file.replace('/',DIR_SEPARATOR_CHAR)));
+			// Create the full arm of the cond
+			int cond_arm = alloc_sexp("",
+				SEXP_LIST,
+				-1,
+				alloc_sexp("", SEXP_LIST, -1, final_sexp_formula, alloc_sexp("", SEXP_LIST, -1, action_sexp, -1)),
+				-1);
+
+			// Add the arm to the correct SEXP list
+			if (branch.is_loop) {
+				if (!loop_branches_exist) {
+					// This is the first loop branch; create the parent 'cond' operator
+					*loop_branch_ptr = alloc_sexp("cond", SEXP_ATOM, SEXP_ATOM_OPERATOR, -1, -1);
+					loop_branch_ptr = &Sexp_nodes[*loop_branch_ptr].rest; // Point to the first argument slot
+					loop_branches_exist = true;
+
+					// Set the single loop properties on the cmission from the first loop branch we find
+					dest_mission.flags |= CMISSION_FLAG_HAS_LOOP;
+					dest_mission.mission_branch_desc = branch.loop_description.empty() ? nullptr : strdup(branch.loop_description.c_str());
+					dest_mission.mission_branch_brief_anim = branch.loop_briefing_anim.empty() ? nullptr : strdup(branch.loop_briefing_anim.c_str());
+					dest_mission.mission_branch_brief_sound = branch.loop_briefing_sound.empty() ? nullptr : strdup(branch.loop_briefing_sound.c_str());
+				}
+				*loop_branch_ptr = cond_arm;
+				loop_branch_ptr = &Sexp_nodes[*loop_branch_ptr].rest;
+			} else {
+				if (!normal_branches_exist) {
+					// This is the first normal branch; create the parent 'cond' operator
+					*normal_branch_ptr = alloc_sexp("cond", SEXP_ATOM, SEXP_ATOM_OPERATOR, -1, -1);
+					normal_branch_ptr = &Sexp_nodes[*normal_branch_ptr].rest; // Point to the first argument slot
+					normal_branches_exist = true;
+				}
+				*normal_branch_ptr = cond_arm;
+				normal_branch_ptr = &Sexp_nodes[*normal_branch_ptr].rest;
+			}
+		}
+	}
 }
 
-bool CampaignEditorDialogModel::deleteLinksTo(const CampaignMissionData &target) {
-	SCP_vector<std::pair<CampaignMissionData *, int>> del;
-	QString msg = tr("The following missions have links to the removed mission (%1):\n").arg(target.filename);
-	for (auto mn_it: missionData) {
-		auto &mn = mn_it.first;
-		if (&mn == &target)
-			continue;
-		for (auto br_it = mn.branches.cbegin(); br_it != mn.branches.cend(); ++br_it) {
-			if (br_it->next == target.filename) {
-				del.emplace_back(&mn, br_it - mn.branches.cbegin());
-				msg.append(mn.filename).append('\n');
+void CampaignEditorDialogModel::sortMissions()
+{
+	std::sort(m_missions.begin(),
+		m_missions.end(),
+		[](const CampaignMissionData& a, const CampaignMissionData& b) -> bool {
+			if (a.level != b.level) {
+				return a.level < b.level;
+			}
+			return a.position < b.position;
+		});
+}
+
+void CampaignEditorDialogModel::stopSpeech()
+{
+	if (_waveId >= -1) {
+		audiostream_close_file(_waveId, false);
+		_waveId = -1;
+	}
+}
+
+void CampaignEditorDialogModel::loadCampaignFromFile(const SCP_string& filename)
+{
+	stopSpeech();
+
+	// First, clear the global state to ensure a clean load.
+	clearCampaignGlobal();
+
+	// Attempt to load the selected file into the global Campaign struct.
+	// We pass the full path via the filename argument now.
+	if (mission_campaign_load(filename.c_str(), filename.c_str(), nullptr, 0) != 0) {
+		// Load failed. Reset the model to a clean "new campaign" state.
+		initializeData(nullptr);
+		clearCampaignGlobal(); // Ensure cleanup after failed load
+		return;
+	}
+
+	// Load was successful. Now, copy the data from the global struct
+	// into our model's private working copy.
+	initializeData(filename.c_str());
+
+	// Immediately clear the global struct again now that we have our safe working copy.
+	clearCampaignGlobal();
+	return;
+}
+
+void CampaignEditorDialogModel::saveCampaign(const SCP_string& filename)
+{
+	stopSpeech();
+	
+	SCP_string target_filename = filename.empty() ? m_campaign_filename : filename;
+
+	// First, validate the filename itself.
+	if (target_filename.empty()) {
+		// Cannot save if there's no filename. The UI should have prompted for one.
+		_viewport->dialogProvider->showButtonDialog(DialogType::Error,
+			"Save Error",
+			"No filename provided.",
+			{DialogButton::Ok});
+		return;
+	}
+
+	if (!checkValidity()) {
+		return;
+	}
+
+	// Copy our working data to the global Campaign struct.
+	commitWorkingCopyToGlobal();
+
+	// Call the global save function.
+	CFred_mission_save mission_saver;
+	if (mission_saver.save_campaign_file(target_filename.c_str())) {
+		// Save failed, clean up the global.
+		clearCampaignGlobal();
+		return;
+	}
+
+	// On success, update our internal state.
+	modify(m_campaign_filename, target_filename);
+
+	// Clean up the global struct now that the save is complete.
+	clearCampaignGlobal();
+	return;
+}
+
+bool CampaignEditorDialogModel::checkValidity()
+{
+	SCP_string error_message;
+
+	// Campaign Name
+	if (m_campaign_name.empty() || m_campaign_name == "Unnamed") { // Checking against "unnamed" is arbitrary and I hate it
+		error_message += "Campaign must have a valid name.\n";
+	}
+
+	// First Mission
+	// TODO: We will need a way to set the first mission. For now, we'll assume the first in the list.
+	if (!m_missions.empty() && m_current_mission_index == -1) { // Assuming first mission is the one at index 0
+		// This logic will need to be updated once we have a way to set the root mission.
+		// For now, we'll check if there's at least one mission.
+	} else if (m_missions.empty()) {
+		error_message += "Campaign must have at least one mission.\n";
+	}
+
+	// Duplicate Mission Names
+	std::unordered_set<SCP_string> mission_names;
+	for (const auto& mission : m_missions) {
+		if (!mission_names.insert(mission.name).second) {
+			error_message += "Mission \"" + mission.name + "\" is included more than once in the campaign.\n";
+		}
+	}
+
+	// Multiplayer Player Count Mismatch
+	if (m_campaign_type != CAMPAIGN_TYPE_SINGLE) {
+		for (const auto& mission_data : m_missions) {
+			mission mission_info;
+			get_mission_info(mission_data.name.c_str(), &mission_info);
+			if (mission_info.num_players != m_num_players) {
+				error_message += "Mission \"" + mission_data.name + "\" has " +
+								 std::to_string(mission_info.num_players) + " players, but the campaign is set to " +
+								 std::to_string(m_num_players) + " players.\n";
 			}
 		}
 	}
 
-	if (del.empty())
-		return true;
-	if (QMessageBox::StandardButton::No ==
-			QMessageBox::question(parent, tr("Remove links to mission?"), msg + tr("Do you want to remove them?")))
-		return false;
+	// Broken Branches
+	for (const auto& mission : m_missions) {
+		for (const auto& branch : mission.branches) {
+			if (!branch.next_mission_name.empty()) {
+				// Check if the target mission actually exists in the campaign
+				auto it = std::find_if(m_missions.begin(), m_missions.end(), [&](const CampaignMissionData& m) {
+					return m.name == branch.next_mission_name;
+				});
 
-	CampaignMissionData *bup_mnData_it = mnData_it;
-	for (auto del_it = del.rbegin(); del_it != del.rend(); ++del_it) {
-		mnData_it = del_it->first;
-		delCurMnBranch(del_it->second);
+				if (it == m_missions.end()) {
+					error_message += "Mission \"" + mission.name +
+									 "\" has a broken branch pointing to a non-existent mission \"" +
+									 branch.next_mission_name + "\".\n";
+				}
+			}
+		}
 	}
-	mnData_it = bup_mnData_it;
+
+	// TODO: Add deeper validation of SEXP logic (e.g., always-false branches, last branch is always true)
+
+	// If we found any errors, display them all and return false.
+	if (!error_message.empty()) {
+		_viewport->dialogProvider->showButtonDialog(DialogType::Error,
+			"Campaign Errors",
+			"Please correct the following issues before saving:\n\n" + error_message,
+			{DialogButton::Ok});
+		return false;
+	}
+
+	// If we get here, everything is valid.
 	return true;
 }
 
-void CampaignEditorDialogModel::trackMissionUncheck(const QModelIndex &idx, const QModelIndex &bottomRight, const QVector<int> &roles) {
-	Assert(idx == bottomRight);
-	Assert(missionData.managedData(idx));
+void CampaignEditorDialogModel::setCurrentMissionSelection(int index)
+{
+	stopSpeech();
+	
+	// Update the model's tracked mission index.
+	m_current_mission_index = index;
 
-	if (roles.contains(Qt::CheckStateRole)) {
-		const auto mn = missionData.managedData(idx);
-		bool checked = missionData.data(idx, Qt::CheckStateRole).toBool();
-
-		if (! missionData.collectCheckedData().empty()) {
-			//must always have first mission, or no missions
-			// #9 check: no first mission: enforced here
-			if (! checked) {
-				if (mn->filename == firstMission) {
-					CampaignEditorDialog::uiWarn(tr("First Mission"), tr("You cannot remove the first mission of a campaign,\nunless it is the only one. Choose another to be first."));
-					missionData.setData(idx, Qt::Checked, Qt::CheckStateRole);
-					return;
-				}
-				// #3 check: illegal target mission: remove illegal links
-				if (! deleteLinksTo(*mn)){
-					CampaignEditorDialog::uiWarn(tr("Target Mission"), tr("A mission cannot be removed unless all links to it are deleted."));
-					missionData.setData(idx, Qt::Checked, Qt::CheckStateRole);
-					return;
-				}
-			} else if (firstMission == "" && missionData.collectCheckedData().size() == 1){
-				firstMission = mn->filename;
-			}
-		} else {
-			firstMission = "";
-		}
-
-		//as unfredable (=packaged/missing) missions are only loaded when specified
-		//in the campaign file, unchecking them will make them unreachable after save/reload.
-		//Warn on save if that happens.
-		if(! mn->fredable) {
-			if (checked) {
-				droppedMissions.removeAll(mn->filename);
-			} else {
-				droppedMissions.append(mn->filename);
-			}
-		}
-	}
+	// When a new mission is selected, any previous branch selection is no longer valid.
+	m_current_branch_index = -1;
 }
 
-namespace { //helpers for CampaignMissionData construction
-	inline QStringList getParsedEvts() {
-		QStringList ret;
-		for (const auto &e : Mission_events)
-			ret << e.name.c_str();
-		return ret;
-	}
-
-	inline QStringList getParsedGoals() {
-		QStringList ret;
-		for (const auto &g : Mission_goals)
-			ret << g.name.c_str();
-		return ret;
-	}
-
-	// #11 check: multi player number: exclude wrong number
-	inline bool isCampaignCompatible(const mission &fsoMission) {
-		return (Campaign.type == CAMPAIGN_TYPE_SINGLE && fsoMission.game_type & (MISSION_TYPE_SINGLE|MISSION_TYPE_TRAINING))
-				|| (Campaign.type == CAMPAIGN_TYPE_MULTI_COOP && fsoMission.game_type & MISSION_TYPE_MULTI_COOP && Campaign.num_players == fsoMission.num_players)
-				|| (Campaign.type == CAMPAIGN_TYPE_MULTI_TEAMS && fsoMission.game_type & MISSION_TYPE_MULTI_TEAMS && Campaign.num_players == fsoMission.num_players);
-	}
-} //namespace
-
-CampaignEditorDialogModel::CampaignMissionData::CampaignMissionData(QString file, bool loaded, const mission *fsoMn, const cmission *cm) :
-	filename(std::move(file)),
-	fredable(loaded),
-	nPlayers(loaded ? fsoMn->num_players : 0),
-	notes(loaded ? fsoMn->notes : ""),
-	events(loaded ? getParsedEvts() : QStringList{}),
-	goals(loaded ? getParsedGoals() : QStringList{}),
-	briefingCutscene(cm ? cm->briefing_cutscene : ""),
-	mainhall(cm ? cm->main_hall.c_str() : ""),
-	debriefingPersona(cm ? QString::number(cm->debrief_persona_index) : "")
+void CampaignEditorDialogModel::setCurrentBranchSelection(int branch_index)
 {
-	if (cm && (cm->flags & CMISSION_FLAG_HAS_FORK))
-		CampaignEditorDialog::uiWarn(tr("Unsupported campaign feature"), tr("This campaign uses scpFork, which is nonfunctional in FSO and unsupported in FRED. Use axemFork instead.\nAffected mission: %1").arg(filename));
-	if (cm && (cm->flags & CMISSION_FLAG_BASTION))
-		CampaignEditorDialog::uiWarn(tr("Unsupported campaign feature"), tr("This campaign uses Bastion mainhall flag, which is outdated. Use explicit mainhall settings.\nAffected mission: %1").arg(filename));
+	stopSpeech();
+	
+	m_current_branch_index = branch_index;
 }
 
-void CampaignEditorDialogModel::CampaignMissionData::initMissions(
-		const SCP_vector<SCP_string>::const_iterator &m_it,
-		CheckedDataListModel<CampaignEditorDialogModel::CampaignMissionData> &model)
+const SCP_string& CampaignEditorDialogModel::getCampaignName() const
 {
-	const QString filename{ QString::fromStdString(*m_it).append(".fs2") };
-	const cmission * cm_it{
-		std::find_if(Campaign.missions, &Campaign.missions[Campaign.num_missions],
-				[&](const cmission &cm){ return filename == cm.name; })};
-	if (cm_it == &Campaign.missions[Campaign.num_missions])
-		cm_it = nullptr;
+	return m_campaign_name;
+}
 
-	mission temp{};
-	bool loaded{parseMnPart(&temp, qPrintable(filename))};
+void CampaignEditorDialogModel::setCampaignName(const SCP_string& name)
+{
+	SCP_string truncated_name = name.substr(0, NAME_LENGTH - 1);
+	modify(m_campaign_name, truncated_name);
+}
 
-	if (! isCampaignCompatible(temp))
+const SCP_string& CampaignEditorDialogModel::getCampaignDescription() const
+{
+	return m_campaign_descr;
+}
+
+void CampaignEditorDialogModel::setCampaignDescription(const SCP_string& descr)
+{
+	SCP_string truncated_descr = descr.substr(0, MISSION_DESC_LENGTH - 1);
+	modify(m_campaign_descr, truncated_descr);
+}
+
+int CampaignEditorDialogModel::getCampaignType() const
+{
+	return m_campaign_type;
+}
+
+void CampaignEditorDialogModel::setCampaignType(int type)
+{
+	// Only proceed if the type has actually changed.
+	if (m_campaign_type == type) {
 		return;
+	}
 
-	CampaignMissionData* data{  // temporary handle, until the missionData submodel takes ownership
-		new CampaignMissionData{ filename, loaded, &temp, cm_it}
-	};
-
-	if (! loaded)
-		CampaignEditorDialog::uiWarn(tr("Error loading mission"), tr("Could not get info from mission: %1\nFile corrupted?").arg(filename));
-
-	model.initRow(filename,	data, cm_it, loaded ? Qt::color0 : Qt::red);
-}
-
-void CampaignEditorDialogModel::CampaignMissionData::branchesFromFormula(CampaignEditorDialogModel *model, int formula, const cmission *loop) {
-	if ( formula < 0 || stricmp(CTEXT(formula), "cond"))
+	// If missions have already been added to the campaign, prevent the type from being changed.
+	if (!m_missions.empty()) {
+		_viewport->dialogProvider->showButtonDialog(DialogType::Error,
+			"Type Locked",
+			"The campaign type cannot be changed after missions have been added.\n"
+			"To change the type, please remove all missions first.",
+			{DialogButton::Ok});
 		return;
+	}
 
-	for (int it_cond_arm = CDR(formula);
-		 it_cond_arm != -1;
-		 it_cond_arm = CDR(it_cond_arm) )
-		branches.emplace_back(model, CAR(it_cond_arm), filename, loop);
+	modify(m_campaign_type, type);
+
+	// Update the number of players based on the new type.
+	if (type == CAMPAIGN_TYPE_SINGLE) {
+		// Single-player campaigns always have 0 players.
+		modify(m_num_players, 0);
+	} else {
+		// For new multiplayer campaigns, reset players to -1.
+		// This will allow the user to set a number or have it be set by the first mission.
+		modify(m_num_players, -1);
+	}
+
+	// Changing the campaign type affects which missions are compatible,
+	// so we must reload the available missions list.
+	loadAvailableMissions();
 }
 
-CampaignEditorDialogModel::CampaignBranchData::CampaignBranchData(CampaignEditorDialogModel *model, int sexp_branch, const QString &from, const cmission *_loop) :
-	sexp(CAR(sexp_branch)),
-	loop(_loop),
-	loopDescr(new AssociatedPlainTextDocument(_loop ? _loop->mission_branch_desc : "", model))
+bool CampaignEditorDialogModel::getCampaignTechReset() const
 {
-		int node_next = CADR(sexp_branch);
-	if (!stricmp(CTEXT(node_next), "end-of-campaign")) {
-		type = END;
-	} else if (!stricmp(CTEXT(node_next), "next-mission")) {
-		next = CTEXT(CDR(node_next));
-		type = (from == next) ? REPEAT : NEXT_NOT_FOUND;
-	}
-
-	// #5a check: always false branch: Warn & prevent on load
-	if (sexp == Locked_sexp_false) {
-		sexp = Locked_sexp_true;
-		CampaignEditorDialog::uiWarn(tr("Potential Campaign Bug"), tr("Branch from %1 to %2 was always false. Set to always true, please fix.").arg(from, next));
-	}
-
-	QObject::connect(loopDescr, &QTextDocument::contentsChanged, model, &CampaignEditorDialogModel::flagModified);
-	if (loop) {
-		loopAnim = _loop->mission_branch_brief_anim;
-		loopVoice = _loop->mission_branch_brief_sound;
-	}
-
+	return (m_flags & CF_CUSTOM_TECH_DATABASE) != 0;
 }
 
-CampaignEditorDialogModel::CampaignBranchData::CampaignBranchData(CampaignEditorDialogModel *model, const QString &from, QString to) :
-	type(to.isEmpty() ? END : to == from ? REPEAT : NEXT),
-	sexp(Locked_sexp_true),
-	next(std::move(to)),
-	loop(false),
-	loopDescr(new AssociatedPlainTextDocument("", model))
+void CampaignEditorDialogModel::setCampaignTechReset(bool reset)
 {
-	QObject::connect(loopDescr, &QTextDocument::contentsChanged, model, &CampaignEditorDialogModel::flagModified);
+	// Create a copy of the current flags to modify.
+	int new_flags = m_flags;
+
+	if (reset) {
+		new_flags |= CF_CUSTOM_TECH_DATABASE;
+	} else {
+		new_flags &= ~CF_CUSTOM_TECH_DATABASE;
+	}
+
+	modify(m_flags, new_flags);
 }
 
-void CampaignEditorDialogModel::CampaignBranchData::connect(const SCP_unordered_set<const CampaignMissionData*>& missions) {
-	if (std::find_if(missions.cbegin(), missions.cend(),
-					 [&](const CampaignMissionData* mn){
-						return next == mn->filename; })
-			== missions.cend())
-		type = NEXT_NOT_FOUND;
-	else
-		type = NEXT;
+int CampaignEditorDialogModel::getCampaignNumPlayers() const
+{
+	return m_num_players;
 }
 
-const SCP_map<CampaignEditorDialogModel::CampaignBranchData::BranchType, QString> CampaignEditorDialogModel::CampaignBranchData::branchTexts{
-	{INVALID, ""}, {REPEAT, "Repeat mission "}, {NEXT, "Branch to "}, {NEXT_NOT_FOUND, "Branch to "}, {END, "End of Campaign"}
-};
+void CampaignEditorDialogModel::setCampaignNumPlayers(int num_players)
+{
+	// Only proceed if the number has actually changed.
+	if (m_num_players == num_players) {
+		return;
+	}
 
-static inline QStringList initCutscenes() {
-	QStringList ret{""};
-	for (auto& cs: Cutscenes)
-		ret << cs.filename;
-	return ret;
+	// If missions have already been added to the campaign, prevent the type from being changed.
+	if (!m_missions.empty()) {
+		_viewport->dialogProvider->showButtonDialog(DialogType::Error,
+			"Players Locked",
+			"The number of players cannot be changed after missions have been added.\n"
+			"To change the number of players, please remove all missions first.",
+			{DialogButton::Ok});
+		return;
+	}
+
+	modify(m_num_players, num_players);
+
+	// If the player count changed, we must reload the available missions list
+	// to apply the new filter.
+	loadAvailableMissions();
 }
 
-const QStringList& CampaignEditorDialogModel::cutscenes() {
-	static QStringList ret{ initCutscenes() };
-	return ret;
+const SCP_vector<SCP_string>& CampaignEditorDialogModel::getAvailableMissionFiles() const
+{
+	return m_available_mission_files;
 }
 
-static inline QStringList initMainhalls() {
-	QStringList ret;
-	for (auto& vec_mh: Main_hall_defines) {
-		for (auto& mh: vec_mh){
-			QString name{ mh.name.c_str() };
-			if (! ret.contains(name))
-				ret << name;
+void CampaignEditorDialogModel::addMission(const SCP_string& filename, int level, int pos)
+{
+	// Before adding, check if this is the first mission for a multiplayer campaign.
+	if (m_campaign_type != CAMPAIGN_TYPE_SINGLE && m_missions.empty()) {
+		// If so, this mission's player count sets the standard for the whole campaign.
+		mission mission_info;
+		get_mission_info(filename.c_str(), &mission_info);
+		modify(m_num_players, mission_info.num_players);
+	}
+
+	// Create and populate the new mission data
+	auto& new_mission = m_missions.emplace_back();
+	new_mission.name = filename;
+	new_mission.level = level;
+	new_mission.position = pos;
+
+	// Adding or removing missions changes the list of available files.
+	loadAvailableMissions();
+	set_modified();
+}
+
+void CampaignEditorDialogModel::removeMission(int mission_index)
+{
+	if (!SCP_vector_inbounds(m_missions, mission_index)) {
+		return;
+	}
+
+	// Check if this is the last mission being removed.
+	const bool was_last_mission = (m_missions.size() == 1);
+
+	m_missions.erase(m_missions.begin() + mission_index);
+
+	// If the last mission was removed from a multiplayer campaign, reset the player count.
+	if (was_last_mission && m_campaign_type != CAMPAIGN_TYPE_SINGLE) {
+		modify(m_num_players, -1);
+	}
+
+	// Adding or removing missions changes the list of available files.
+	loadAvailableMissions();
+	set_modified();
+}
+
+void CampaignEditorDialogModel::updateMissionPosition(int mission_index, int new_level, int new_pos)
+{
+	if (!SCP_vector_inbounds(m_missions, mission_index)) {
+		return;
+	}
+
+	// Get the name of the mission we are moving so we can find it again after the sort.
+	SCP_string mission_name_to_find = m_missions[mission_index].name;
+
+	// Update the mission's position data.
+	auto& mission = m_missions[mission_index];
+	modify(mission.level, new_level);
+	modify(mission.position, new_pos);
+
+	// Sort the entire vector based on the new positions.
+	sortMissions();
+
+	// Find the new index of our mission and update the selection.
+	for (int i = 0; i < static_cast<int>(m_missions.size()); ++i) {
+		if (m_missions[i].name == mission_name_to_find) {
+			setCurrentMissionSelection(i);
+			break;
 		}
 	}
-	return ret;
 }
 
-const QStringList& CampaignEditorDialogModel::mainhalls() {
-	static QStringList ret{ initMainhalls() };
-	return ret;
+SCP_string CampaignEditorDialogModel::getCurrentMissionFilename() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return "";
+	}
+	return m_missions[m_current_mission_index].name;
 }
 
-static inline QStringList initDebriefingPersonas() {
-	QStringList ret{""};
-	for (auto& rn: Ranks) {
-		for (auto& p: rn.promotion_text){
-			QString persona{ QString::number(p.first) };
-			if (p.first >= 0 && ! ret.contains(persona))
-				ret << persona;
+// Changing a mission's filename is a complex operation beyond a simple setter,
+// as it's the unique ID for the mission. This would be better handled by a
+// dedicated "replace mission" action, so we will leave this unimplemented for now.
+void CampaignEditorDialogModel::setCurrentMissionFilename(const SCP_string& filename)
+{
+	// Not implemented.
+}
+
+SCP_string CampaignEditorDialogModel::getCurrentMissionBriefingCutscene() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return "";
+	}
+	return m_missions[m_current_mission_index].briefing_cutscene;
+}
+
+void CampaignEditorDialogModel::setCurrentMissionBriefingCutscene(const SCP_string& cutscene)
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+
+	auto& mission = m_missions[m_current_mission_index];
+	modify(mission.briefing_cutscene, cutscene.substr(0, NAME_LENGTH - 1));
+}
+
+SCP_string CampaignEditorDialogModel::getCurrentMissionMainhall() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return "";
+	}
+	return m_missions[m_current_mission_index].main_hall;
+}
+
+void CampaignEditorDialogModel::setCurrentMissionMainhall(const SCP_string& mainhall)
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+
+	auto& mission = m_missions[m_current_mission_index];
+	modify(mission.main_hall, mainhall);
+}
+
+SCP_string CampaignEditorDialogModel::getCurrentMissionSubstituteMainhall() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return "";
+	}
+	return m_missions[m_current_mission_index].substitute_main_hall;
+}
+
+void CampaignEditorDialogModel::setCurrentMissionSubstituteMainhall(const SCP_string& mainhall)
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+
+	auto& mission = m_missions[m_current_mission_index];
+	modify(mission.substitute_main_hall, mainhall);
+}
+
+int CampaignEditorDialogModel::getCurrentMissionDebriefingPersona() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return 0;
+	}
+	return m_missions[m_current_mission_index].debrief_persona_index;
+}
+
+void CampaignEditorDialogModel::setCurrentMissionDebriefingPersona(int persona_index)
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+
+	auto& mission = m_missions[m_current_mission_index];
+	modify(mission.debrief_persona_index, persona_index);
+}
+
+SCP_string CampaignEditorDialogModel::getCurrentBranchLoopDescription() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return "";
+	}
+	const auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index)) {
+		return "";
+	}
+
+	return mission.branches[m_current_branch_index].loop_description;
+}
+
+void CampaignEditorDialogModel::setCurrentBranchLoopDescription(const SCP_string& descr)
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index)) {
+		return;
+	}
+
+	auto& branch = mission.branches[m_current_branch_index];
+	modify(branch.loop_description, descr.substr(0, MISSION_DESC_LENGTH - 1));
+}
+
+SCP_string CampaignEditorDialogModel::getCurrentBranchLoopAnim() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return "";
+	}
+	const auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index)) {
+		return "";
+	}
+
+	return mission.branches[m_current_branch_index].loop_briefing_anim;
+}
+
+void CampaignEditorDialogModel::setCurrentBranchLoopAnim(const SCP_string& anim)
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index)) {
+		return;
+	}
+
+	auto& branch = mission.branches[m_current_branch_index];
+	modify(branch.loop_briefing_anim, anim.substr(0, NAME_LENGTH - 1));
+}
+
+SCP_string CampaignEditorDialogModel::getCurrentBranchLoopVoice() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return "";
+	}
+	const auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index)) {
+		return "";
+	}
+
+	return mission.branches[m_current_branch_index].loop_briefing_sound;
+}
+
+void CampaignEditorDialogModel::setCurrentBranchLoopVoice(const SCP_string& voice)
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index)) {
+		return;
+	}
+
+	auto& branch = mission.branches[m_current_branch_index];
+	modify(branch.loop_briefing_sound, voice.substr(0, NAME_LENGTH - 1));
+}
+
+void CampaignEditorDialogModel::testCurrentBranchLoopVoice()
+{
+	stopSpeech();
+
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index)) {
+		return;
+	}
+
+	auto& branch = mission.branches[m_current_branch_index];
+
+	_waveId = audiostream_open(branch.loop_briefing_sound.c_str(), ASF_EVENTMUSIC);
+	audiostream_play(_waveId, 1.0f, 0);
+}
+
+const SCP_vector<CampaignMissionData>& CampaignEditorDialogModel::getCampaignMissions() const
+{
+	return m_missions;
+}
+
+void CampaignEditorDialogModel::addBranch(int from_mission_index, int to_mission_index)
+{
+	if (!SCP_vector_inbounds(m_missions, from_mission_index) || !SCP_vector_inbounds(m_missions, to_mission_index)) {
+		return;
+	}
+
+	auto& from_mission = m_missions[from_mission_index];
+	const auto& to_mission_name = m_missions[to_mission_index].name;
+
+	// Prevent creating a duplicate branch to the same mission
+	for (const auto& existing_branch : from_mission.branches) {
+		if (existing_branch.next_mission_name == to_mission_name) {
+			return;
 		}
 	}
-	return ret;
+
+	// Create the new branch data
+	auto& new_branch = from_mission.branches.emplace_back();
+	new_branch.next_mission_name = to_mission_name;
+
+	// Ask the UI's tree to create a default SEXP ("true") for this new branch
+	new_branch.sexp_formula = m_tree_ops.createDefaultSexp();
+
+	set_modified();
+
+	m_tree_ops.rebuildBranchTree(from_mission.branches);
 }
 
-const QStringList& CampaignEditorDialogModel::debriefingPersonas() {
-	static QStringList ret{ initDebriefingPersonas() };
-	return ret;
-}
-
-static inline QStringList initFilelist(const int type) {
-	QStringList ret{""};
-	SCP_vector<SCP_string> fl;
-	cf_get_file_list(fl, type, "*", CF_SORT_NAME, nullptr, CF_LOCATION_TYPE_PRIMARY_MOD);
-	for (auto& f: fl)
-		ret << QString::fromStdString(f);
-	return ret;
-}
-
-const QStringList& CampaignEditorDialogModel::loopAnims() {
-	static QStringList ret{ initFilelist(CF_TYPE_INTERFACE) }; // as per campaigneditordlg.cpp:810
-	return ret;
-}
-
-const QStringList& CampaignEditorDialogModel::loopVoices() {
-	static QStringList ret{ initFilelist(CF_TYPE_VOICE_CMD_BRIEF) }; // as per campaigneditordlg.cpp:832
-	return ret;
-}
-
-static inline QStringList initCampaignTypes() {
-	QStringList ret;
-	for (auto& tp: campaign_types) {  //missioncampaign.h global
-		ret << tp;
+void CampaignEditorDialogModel::removeBranch(int mission_index, int branch_index)
+{
+	if (!SCP_vector_inbounds(m_missions, mission_index)) {
+		return;
 	}
-	return ret;
+	auto& mission = m_missions[mission_index];
+	if (!SCP_vector_inbounds(mission.branches, branch_index)) {
+		return;
+	}
+
+	// Do we need to free sexps here?
+
+	// The model's only job is to update its own data.
+	mission.branches.erase(mission.branches.begin() + branch_index);
+
+	set_modified();
 }
 
-const QStringList CampaignEditorDialogModel::campaignTypes { initCampaignTypes() };
+void CampaignEditorDialogModel::updateCurrentBranch(int internal_node_id)
+{
+	// Ensure a mission and a branch are currently selected.
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index)) {
+		return;
+	}
 
-/*
- * Other campaign checks:
- * #1 check: illegal source mission: does not apply, the mission owns the branch
- * #3 check: branch sexp is assigned results of alloc_sexp (with safe params), sexp_tree::save_tree or loading a file exclusively
- * #10 check: duplicate first mission: does not apply, only one possible value
- *
-*/
+	// Tell the tree to save the specified branch.
+	// The tree will serialize its internal model for that branch into a new SEXP
+	// and return the new formula index.
+	int new_sexp_formula = m_tree_ops.saveSexp(internal_node_id);
 
-} // namespace dialogs
-} // namespace fred
-} // namespace fso
+	// Update the model's data with the new formula.
+	// The 'modify' helper also handles setting the modified flag.
+	auto& branch = mission.branches[m_current_branch_index];
+	modify(branch.sexp_formula, new_sexp_formula);
+
+	m_tree_ops.expandBranch(internal_node_id);
+}
+
+const SCP_vector<bool>& CampaignEditorDialogModel::getAllowedShips() const
+{
+	return m_ships_allowed;
+}
+
+void CampaignEditorDialogModel::setAllowedShip(int ship_class_index, bool allowed)
+{
+	if (SCP_vector_inbounds(m_ships_allowed, ship_class_index)) {
+		if (m_ships_allowed[ship_class_index] != allowed) {
+			m_ships_allowed[ship_class_index] = allowed;
+			set_modified();
+		}
+	}
+}
+
+const SCP_vector<bool>& CampaignEditorDialogModel::getAllowedWeapons() const
+{
+	return m_weapons_allowed;
+}
+
+void CampaignEditorDialogModel::setAllowedWeapon(int weapon_class_index, bool allowed)
+{
+	if (SCP_vector_inbounds(m_weapons_allowed, weapon_class_index)) {
+		if (m_weapons_allowed[weapon_class_index] != allowed) {
+			m_weapons_allowed[weapon_class_index] = allowed;
+			set_modified();
+		}
+	}
+}
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -7,6 +7,8 @@
 #include "ship/ship.h"
 #include "weapon/weapon.h"
 #include "sound/audiostr.h"
+#include "cutscene/cutscenes.h"
+#include "menuui/mainhallmenu.h"
 
 namespace fso::fred::dialogs {
 
@@ -1379,6 +1381,37 @@ void CampaignEditorDialogModel::setAllowedWeapon(int weapon_class_index, bool al
 			set_modified();
 		}
 	}
+}
+
+SCP_vector<SCP_string> CampaignEditorDialogModel::getCutsceneList()
+{
+	SCP_vector<SCP_string> out;
+
+	out.emplace_back("<None>");
+
+	for (const auto& cs : Cutscenes) {
+		out.emplace_back(cs.filename);
+	}
+
+	return out;
+}
+
+SCP_vector<SCP_string> CampaignEditorDialogModel::getMainhallList()
+{
+	SCP_vector<SCP_string> out;
+	out.emplace_back("<None>");
+
+	// De-dupe by name (some mods define multiple resolutions/variants per mainhall)
+	std::unordered_set<SCP_string> seen;
+	for (const auto& mh : Main_hall_defines) {
+		if (mh.size() < 1) { // shouldn't happen but let's be safe
+			continue;
+		}
+		const auto& hall = mh[0];
+		out.emplace_back(hall.name);
+	}
+
+	return out;
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -1196,6 +1196,14 @@ const SCP_vector<CampaignMissionData>& CampaignEditorDialogModel::getCampaignMis
 	return m_missions;
 }
 
+int CampaignEditorDialogModel::getNumBranches() const
+{
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return 0;
+	}
+	return static_cast<int>(m_missions[m_current_mission_index].branches.size());
+}
+
 void CampaignEditorDialogModel::addBranch(int from_mission_index, int to_mission_index)
 {
 	if (!SCP_vector_inbounds(m_missions, from_mission_index) || !SCP_vector_inbounds(m_missions, to_mission_index)) {
@@ -1228,6 +1236,44 @@ void CampaignEditorDialogModel::addBranch(int from_mission_index, int to_mission
 	if (m_current_mission_index == from_mission_index) { // only rebuild if we're on the affected mission
 		m_tree_ops.rebuildBranchTree(from_mission.branches, from_mission.filename);
 	}
+}
+
+void CampaignEditorDialogModel::moveBranchUp()
+{
+	// Ensure a mission and a branch are currently selected.
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index) || m_current_branch_index == 0) {
+		return;
+	}
+	// Swap the selected branch with the one above it.
+	std::swap(mission.branches[m_current_branch_index], mission.branches[m_current_branch_index - 1]);
+	set_modified();
+	
+	m_current_branch_index = -1; // set no branch selected
+	// Rebuild the visual tree from the model's authoritative state
+	m_tree_ops.rebuildBranchTree(mission.branches, mission.filename);
+}
+
+void CampaignEditorDialogModel::moveBranchDown()
+{
+	// Ensure a mission and a branch are currently selected.
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index) || m_current_branch_index == static_cast<int>(mission.branches.size()) - 1) {
+		return;
+	}
+	// Swap the selected branch with the one below it.
+	std::swap(mission.branches[m_current_branch_index], mission.branches[m_current_branch_index + 1]);
+	set_modified();
+	
+	m_current_branch_index = -1; // set no branch selected
+	// Rebuild the visual tree from the model's authoritative state
+	m_tree_ops.rebuildBranchTree(mission.branches, mission.filename);
 }
 
 void CampaignEditorDialogModel::addEndBranch(int from_mission_index)

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -53,6 +53,7 @@ void CampaignEditorDialogModel::initializeData(const char* filename)
 		m_campaign_type = Campaign.type;
 		m_num_players = Campaign.num_players;
 		m_flags = Campaign.flags;
+		m_custom_data = Campaign.custom_data;
 
 		// Copy mission data from the global Campaign struct
 		m_missions.reserve(Campaign.num_missions);
@@ -260,6 +261,7 @@ void CampaignEditorDialogModel::commitWorkingCopyToGlobal()
 	Campaign.num_players = m_num_players;
 	Campaign.flags = m_flags;
 	Campaign.num_missions = static_cast<int>(m_missions.size());
+	Campaign.custom_data = m_custom_data;
 
 	// Copy ship and weapon permissions
 	for (int i = 0; i < MAX_SHIP_CLASSES; ++i) {
@@ -715,6 +717,17 @@ void CampaignEditorDialogModel::setCampaignNumPlayers(int num_players)
 	// If the player count changed, we must reload the available missions list
 	// to apply the new filter.
 	loadAvailableMissions();
+}
+
+void CampaignEditorDialogModel::setCustomData(const SCP_map<SCP_string, SCP_string>& custom_data)
+{
+	modify(m_custom_data, custom_data);
+	set_modified();
+}
+
+SCP_map<SCP_string, SCP_string> CampaignEditorDialogModel::getCustomData() const
+{
+	return m_custom_data;
 }
 
 const SCP_vector<std::pair<SCP_string, bool>>& CampaignEditorDialogModel::getAvailableMissionFiles() const

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -336,6 +336,28 @@ void CampaignEditorDialogModel::stopSpeech()
 	}
 }
 
+SCP_vector<SCP_string> CampaignEditorDialogModel::getCampaignTypes()
+{
+	SCP_vector<SCP_string> types;
+	for (auto& type : campaign_types) {
+		types.push_back(type);
+	}
+	
+	return types;
+}
+
+void CampaignEditorDialogModel::createNewCampaign()
+{
+	stopSpeech();
+
+	// First, clear the global state to ensure a clean load.
+	clearCampaignGlobal();
+
+	// Initialize the model to a clean "new campaign" state.
+	initializeData();
+}
+	
+
 void CampaignEditorDialogModel::loadCampaignFromFile(const SCP_string& filename)
 {
 	stopSpeech();
@@ -488,6 +510,17 @@ void CampaignEditorDialogModel::setCurrentBranchSelection(int branch_index)
 	stopSpeech();
 	
 	m_current_branch_index = branch_index;
+}
+
+const SCP_string& CampaignEditorDialogModel::getCampaignFilename() const
+{
+	return m_campaign_filename;
+}
+
+void CampaignEditorDialogModel::setCampaignFilename(const SCP_string& filename)
+{
+	SCP_string truncated_filename = filename.substr(0, MAX_FILENAME_LEN - 1);
+	modify(m_campaign_filename, truncated_filename);
 }
 
 const SCP_string& CampaignEditorDialogModel::getCampaignName() const
@@ -935,9 +968,15 @@ void CampaignEditorDialogModel::updateCurrentBranch(int internal_node_id)
 	m_tree_ops.expandBranch(internal_node_id);
 }
 
-const SCP_vector<bool>& CampaignEditorDialogModel::getAllowedShips() const
+const SCP_vector<std::tuple<SCP_string, int, bool>> CampaignEditorDialogModel::getAllowedShips() const
 {
-	return m_ships_allowed;
+	SCP_vector<std::tuple<SCP_string, int, bool>> ship_list;
+	for (int i = 0; i < static_cast<int>(Ship_info.size()); i++) {
+		if (Ship_info[i].flags[Ship::Info_Flags::Player_ship]) {
+			ship_list.emplace_back(Ship_info[i].name, i, m_ships_allowed[i]);
+		}
+	}
+	return ship_list;
 }
 
 void CampaignEditorDialogModel::setAllowedShip(int ship_class_index, bool allowed)
@@ -950,9 +989,15 @@ void CampaignEditorDialogModel::setAllowedShip(int ship_class_index, bool allowe
 	}
 }
 
-const SCP_vector<bool>& CampaignEditorDialogModel::getAllowedWeapons() const
+const SCP_vector<std::tuple<SCP_string, int, bool>> CampaignEditorDialogModel::getAllowedWeapons() const
 {
-	return m_weapons_allowed;
+	SCP_vector<std::tuple<SCP_string, int, bool>> weapon_list;
+	for (int i = 0; i < static_cast<int>(Weapon_info.size()); i++) {
+		if (Weapon_info[i].wi_flags[Weapon::Info_Flags::Player_allowed]) {
+			weapon_list.emplace_back(Weapon_info[i].name, i, m_weapons_allowed[i]);
+		}
+	}
+	return weapon_list;
 }
 
 void CampaignEditorDialogModel::setAllowedWeapon(int weapon_class_index, bool allowed)

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -13,6 +13,11 @@ enum class CampaignFormat {
 	FSO
 };
 
+enum class CampaignSpecialMode {
+	Loop,
+	Fork
+};
+
 struct CampaignBranchData {
 	int id = -1;
 	int sexp_formula = -1;
@@ -39,6 +44,8 @@ struct CampaignMissionData {
 	int debrief_persona_index = 0;
 
 	bool retail_bastion = false;
+
+	CampaignSpecialMode special_mode_hint = CampaignSpecialMode::Loop;
 
 	SCP_vector<CampaignBranchData> branches;
 };
@@ -112,6 +119,8 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void setMissionGraphY(int i, int y);
 	int getMissionGraphColor(int i) const; // -1 = unset, else 0xRRGGBB
 	void setMissionGraphColor(int i, int rgb0xRRGGBB);
+	CampaignSpecialMode getMissionSpecialMode(int i) const;
+	void setMissionSpecialMode(int i, CampaignSpecialMode mode); 
 
 	// Current Mission
 	SCP_string getCurrentMissionFilename() const;

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -91,7 +91,9 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void setSaveFormat(CampaignFormat fmt);
 
 	void setCurrentMissionSelection(int index);
+	int getCurrentMissionSelection();
 	void setCurrentBranchSelection(int branch_index);
+	int getCurrentBranchSelection();
 
 	// Base Campaign Data
 	const SCP_string& getCampaignFilename() const;
@@ -146,6 +148,9 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	SCP_string getCurrentBranchLoopVoice() const;
 	void setCurrentBranchLoopVoice(const SCP_string& voice);
 	void testCurrentBranchLoopVoice();
+
+	// Sexp tree
+	void removeBranchByTreeId(int formula_id);
 
 	// Campaign Graph
 	const SCP_vector<CampaignMissionData>& getCampaignMissions() const;

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -8,6 +8,11 @@
 
 namespace fso::fred::dialogs {
 
+enum class CampaignFormat {
+	Retail,
+	FSO
+};
+
 struct CampaignBranchData {
 	int sexp_formula = -1;
 	SCP_string next_mission_name;
@@ -28,6 +33,8 @@ struct CampaignMissionData {
 	SCP_string main_hall;
 	SCP_string substitute_main_hall;
 	int debrief_persona_index = 0;
+
+	bool retail_bastion = false;
 
 	SCP_vector<CampaignBranchData> branches;
 };
@@ -69,6 +76,8 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void loadCampaignFromFile(const SCP_string& filename);
 	void saveCampaign(const SCP_string& filename);
 	bool checkValidity();
+	CampaignFormat getSaveFormat() const;
+	void setSaveFormat(CampaignFormat fmt);
 
 	void setCurrentMissionSelection(int index);
 	void setCurrentBranchSelection(int branch_index);
@@ -105,6 +114,10 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void setCurrentMissionSubstituteMainhall(const SCP_string& mainhall);
 	int getCurrentMissionDebriefingPersona() const;
 	void setCurrentMissionDebriefingPersona(int persona_index);
+
+	// Legacy Retail Data
+	bool getCurrentMissionRetailBastion() const;
+	void setCurrentMissionRetailBastion(bool enabled);
 
 	// Loop Data
 	SCP_string getCurrentBranchLoopDescription() const;
@@ -150,6 +163,8 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	int m_current_branch_index = -1;
 
 	int _waveId;
+
+	CampaignFormat m_save_format = CampaignFormat::FSO;
 
 	void initializeData(const char* filename = nullptr);
 	void parseBranchesFromFormula(CampaignMissionData& mission, int formula_index, bool is_loop);

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -125,9 +125,9 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void toggleMissionSpecialMode(int i); 
 
 	// Current Mission
-	SCP_string getCurrentMissionFilename() const;
 	void setMissionAsFirst(int mission_index);
-	void setCurrentMissionFilename(const SCP_string& filename);
+	SCP_string getCurrentMissionFilename() const;
+	void setCurrentMissionFilename(const SCP_string& /*filename*/);
 	SCP_string getCurrentMissionBriefingCutscene() const;
 	void setCurrentMissionBriefingCutscene(const SCP_string& cutscene);
 	SCP_string getCurrentMissionMainhall() const;

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -89,6 +89,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 
 	// Available Missions
 	const SCP_vector<std::pair<SCP_string, bool>>& getAvailableMissionFiles() const;
+	void setAvailableMissionsFilter(const SCP_string& filter);
 	void addMission(const SCP_string& filename, int level, int pos);
 	void removeMission(int mission_index);
 	void updateMissionPosition(int mission_index, int new_level, int new_pos);
@@ -142,6 +143,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 
 	// List of mission files in the game directory that are not yet in the campaign
 	SCP_vector<std::pair<SCP_string, bool>> m_available_mission_files;
+	SCP_string m_available_missions_filter;
 
 	// Pointers/indices to the currently selected items for context
 	int m_current_mission_index = -1;

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -34,7 +34,7 @@ struct CampaignMissionData {
 	SCP_string filename;
 	int level = 0;
 	int position = 0;
-	int graph_x = INT_MIN; // For UI layout only
+	int graph_x = INT_MIN; // For UI layout only // TODO after missionsave.cpp is refactored, save these to the campaign file
 	int graph_y = INT_MIN; // For UI layout only
 	int graph_color = -1;  // For UI layout only
 
@@ -106,6 +106,8 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void setCampaignTechReset(bool reset);
 	int getCampaignNumPlayers() const;
 	void setCampaignNumPlayers(int num_players);
+	SCP_map<SCP_string, SCP_string> getCustomData() const;
+	void setCustomData(const SCP_map<SCP_string, SCP_string>& custom_data);
 
 	// Available Missions
 	const SCP_vector<std::pair<SCP_string, bool>>& getAvailableMissionFiles() const;
@@ -179,6 +181,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	int m_flags = 0;
 	SCP_vector<bool> m_ships_allowed;
 	SCP_vector<bool> m_weapons_allowed;
+	SCP_map<SCP_string, SCP_string> m_custom_data;
 	SCP_vector<CampaignMissionData> m_missions;
 
 	// List of mission files in the game directory that are not yet in the campaign

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -14,6 +14,7 @@ enum class CampaignFormat {
 };
 
 struct CampaignBranchData {
+	int id = -1;
 	int sexp_formula = -1;
 	SCP_string next_mission_name;
 	bool is_loop = false;
@@ -28,6 +29,9 @@ struct CampaignMissionData {
 	SCP_string name;
 	int level = 0;
 	int position = 0;
+	int graph_x = INT_MIN; // For UI layout only
+	int graph_y = INT_MIN; // For UI layout only
+	int graph_color = -1;  // For UI layout only
 
 	SCP_string briefing_cutscene;
 	SCP_string main_hall;
@@ -102,6 +106,12 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void addMission(const SCP_string& filename, int level, int pos);
 	void removeMission(int mission_index);
 	void updateMissionPosition(int mission_index, int new_level, int new_pos);
+	int getMissionGraphX(int i) const;
+	void setMissionGraphX(int i, int x);
+	int getMissionGraphY(int i) const;
+	void setMissionGraphY(int i, int y);
+	int getMissionGraphColor(int i) const; // -1 = unset, else 0xRRGGBB
+	void setMissionGraphColor(int i, int rgb0xRRGGBB);
 
 	// Current Mission
 	SCP_string getCurrentMissionFilename() const;
@@ -133,6 +143,8 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void addBranch(int from_mission_index, int to_mission_index);
 	void removeBranch(int mission_index, int branch_index);
 	void updateCurrentBranch(int internal_node_id);
+	int addBranchIdIfMissing(CampaignBranchData& b); // assigns a unique id once
+	CampaignBranchData* findBranchById(int missionIdx, int branchId);
 
 	// Tech
 	const SCP_vector<std::tuple<SCP_string, int, bool>> getAllowedShips() const;

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -43,8 +43,6 @@ struct CampaignMissionData {
 	SCP_string substitute_main_hall;
 	int debrief_persona_index = 0;
 
-	bool retail_bastion = false;
-
 	CampaignSpecialMode special_mode_hint = CampaignSpecialMode::Loop;
 
 	SCP_vector<CampaignBranchData> branches;
@@ -136,10 +134,6 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	int getCurrentMissionDebriefingPersona() const;
 	void setCurrentMissionDebriefingPersona(int persona_index);
 
-	// Legacy Retail Data
-	bool getCurrentMissionRetailBastion() const;
-	void setCurrentMissionRetailBastion(bool enabled);
-
 	// Loop Data
 	SCP_string getCurrentBranchLoopDescription() const;
 	void setCurrentBranchLoopDescription(const SCP_string& descr);
@@ -159,6 +153,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void addSpecialBranch(int from_mission_index, int to_mission_index);
 	void removeBranch(int mission_index, int branch_index);
 	void updateCurrentBranch(int internal_node_id);
+	bool getCurrentBranchIsSpecial() const;
 	int addBranchIdIfMissing(CampaignBranchData& b); // assigns a unique id once
 	CampaignBranchData* findBranchById(int missionIdx, int branchId);
 
@@ -170,7 +165,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 
 	// Lists
 	static SCP_vector<SCP_string> getCutsceneList();
-	static SCP_vector<SCP_string> getMainhallList();
+	SCP_vector<SCP_string> getMainhallList() const;
 
   private:
 	// The model's only link to the SEXP tree UI

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -1,276 +1,170 @@
 #pragma once
 
+#include "globalincs/pstypes.h"
+
 #include "mission/dialogs/AbstractDialogModel.h"
-#include "ui/dialogs/CampaignEditorDialog.h"
-#include "AssociatedPlainTextDocument.h"
-#include "CheckedDataListModel.h"
-#include <mission/missioncampaign.h>
-#include <ui/widgets/sexp_tree.h>
+#include "mission/missioncampaign.h"
+#include "mission/missionparse.h"
 
-#include <QTextDocument>
-#include <QPlainTextEdit>
+namespace fso::fred::dialogs {
 
-namespace fso {
-namespace fred {
-namespace dialogs {
-
-//an empty string to return references to
-const QString qstrEmpty{};
-
-class CampaignEditorDialog;
-
-class CampaignEditorDialogModel : public AbstractDialogModel, public SexpTreeEditorInterface
-{
-	class CampaignMissionData;
-	class CampaignBranchData;
-	Q_OBJECT
-
-public:
-	/**
-	 * @brief Create a model from a campaign file or empty of a type
-	 * @param parent The dialog
-	 * @param viewport Unused, required by AbstractDialogModel
-	 * @param file An existing campaign file to open
-	 * @param newCampaignType The type fore a new campaing
-	 * @note Either give an existing file OR a new type.
-	 */
-	CampaignEditorDialogModel(CampaignEditorDialog *parent, EditorViewport *viewport, const QString &file = "", const QString& newCampaignType = "", int numPlayers = 0);
-	~CampaignEditorDialogModel() override = default;
-	/**
-	 * @brief Called by CampaignDialog with references to widgets with complex data
-	 */
-	void supplySubModels(QListView &ships, QListView &weps, QListView &missions, QPlainTextEdit &descr);
-
-// AbstractDialogModel
-	bool apply() override {	return saveTo(campaignFile); }
-	void reject() override {} // nothing to do if the dialog is created each time it's opened
-
-// SexpTreeEditorInterface impl. Responsible for contents of right-click menu on mission branch sexp_tree
-	QStringList getMissionGoals(const QString& reference_name) override;
-	bool hasDefaultGoal(int) override {return true;}
-
-	QStringList getMissionEvents(const QString& reference_name) override;
-	bool hasDefaultEvent(int) override {return true;}
-
-	QStringList getMissionNames() override;
-	bool hasDefaultMissionName() override {return true;}
-
-	bool requireCampaignOperators() const override {return true;}
-
-	QList<QAction *> getContextMenuExtras(QObject *parent = nullptr) override;
-
-// Model state getters
-// Here and in the following, "Mn/mn" are short for a mission (in the context of the campaign),
-// "Br/br" for the branches of a mission (to another or itself)
-// "Cur" refers to the currently selected mission or branch, if any
-	inline bool isFileLoaded() const { return ! campaignFile.isEmpty(); }
-
-	inline const QString& getCampaignName() const { return campaignName; }
-	inline bool getCampaignTechReset() const { return campaignTechReset; }
-
-	inline bool isCurMnSelected() const { return mnData_it; }
-	inline const QString& getCurMnFilename() const { return mnData_it ? mnData_it->filename : qstrEmpty; }
-	inline bool getCurMnIncluded() const {
-		return mnData_idx.isValid() && mnData_idx.data(Qt::CheckStateRole) == Qt::Checked; }
-	inline bool isCurMnFirst() const {
-		return mnData_it && mnData_it->filename == firstMission;
-	}
-	inline bool getCurMnFredable() const { return mnData_it && mnData_it->fredable; }
-	inline const QString& getCurMnDescr() const { return mnData_it ? mnData_it->notes : qstrEmpty; }
-	inline const QString& getCurMnBriefingCutscene() const { return mnData_it ? mnData_it->briefingCutscene : qstrEmpty; }
-	inline const QString& getCurMnMainhall() const { return mnData_it ? mnData_it->mainhall : qstrEmpty; }
-	inline const QString& getCurMnDebriefingPersona() const { return mnData_it ? mnData_it->debriefingPersona : qstrEmpty; }
-	inline int getCurMnBrCnt() const {return mnData_it ? static_cast<int>(mnData_it->branches.size()) : -1; }
-
-	bool fillTree(sexp_tree& sxt) const;
-// Model state getters -- branch
-	inline int getCurBrIdx() const { return getCurBr() ? mnData_it->brData_idx : -1; }
-
-	inline bool isCurBrLoop() const { return getCurBr() && getCurBr()->loop; }
-	inline const QString& getCurBrNext() const { return getCurBr() ? getCurBr()->next : qstrEmpty; }
-
-	void supplySubModelLoop(QPlainTextEdit &descr);
-	inline const QString& getCurLoopAnim() const { return getCurBr() ? getCurBr()->loopAnim : qstrEmpty; }
-	inline const QString& getCurLoopVoice() const {	return getCurBr() ? getCurBr()->loopVoice : qstrEmpty; }
-
-// Model state getters -- branch creation data
-	inline const QString* missionName(const QModelIndex &idx) const {
-		const CampaignMissionData *mn = missionData.managedData(idx);
-		return mn ? &mn->filename : nullptr;
-	}
-	inline const QStringList* missionEvents(const QModelIndex &idx) const {
-		const CampaignMissionData *mn = missionData.managedData(idx);
-		return mn ? &mn->events : nullptr;
-	}
-	inline const QStringList* missionGoals(const QModelIndex &idx) const {
-		const CampaignMissionData *mn = missionData.managedData(idx);
-		return mn ? &mn->goals : nullptr;
-	}
-
-//saving & change checking
-	bool saveTo(const QString &file);
-
-	inline bool query_modified() const { return modified; }
-	inline bool missionDropped() const { return ! droppedMissions.isEmpty(); }
-
-// Model state setters
-public slots:
-	inline void setCampaignName(const QString &name) {
-		modify<QString>(campaignName, name); }
-	inline void setCampaignTechReset(bool techReset) {
-		modify<bool>(campaignTechReset, techReset); }
-
-	void missionSelectionChanged(const QItemSelection &selected);
-
-	void setCurMnFirst();
-	inline void setCurMnBriefingCutscene(const QString &briefingCutscene) {
-		if (! mnData_it) return;
-		modify<QString>(mnData_it->mainhall, briefingCutscene); }
-	inline void setCurMnMainhall(const QString &mainhall) {
-		if (! mnData_it) return;
-		modify<QString>(mnData_it->mainhall, mainhall); }
-	inline void setCurMnDebriefingPersona(const QString &debriefingPersona) {
-		if (! mnData_it) return;
-		modify<QString>(mnData_it->debriefingPersona, debriefingPersona); }
-
-	int addCurMnBranchTo(const QModelIndex *other = nullptr, bool flip = false);
-	void delCurMnBranch(int node);
-
-	void selectCurBr(const QTreeWidgetItem *selected);
-	int setCurBrCond(const QString &sexp, const QString &mn, const QString &arg);
-	bool setCurBrSexp(int sexp);
-	void setCurBrIsLoop(bool isLoop);
-
-	void moveCurBr(bool up);
-
-	void setCurLoopAnim(const QString &anim);
-	void setCurLoopVoice(const QString &voice);
-
-//branch helpers
-private:
-	inline const CampaignBranchData* getCurBr() const {
-		return mnData_it ? mnData_it->brData_it : nullptr; }
-	void connectBranches(bool uiUpdate = true, const campaign *cpgn = nullptr);
-
-	bool _saveTo(QString file) const;
-
-	template<typename T>
-	inline void modify(T &a, const T &b) {
-		if (a != b) {
-			a = b;
-			flagModified();
-		}
-	}
-
-	bool deleteLinksTo(const CampaignMissionData &target);
-
-private slots:
-	void trackMissionUncheck(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);
-	inline void flagModified() { modified = true; }
-
-//Model inner types
-private:
-	class CampaignMissionData {
-	public:
-		CampaignMissionData() = delete;
-		CampaignMissionData(QString file,
-							bool loaded = false,
-							const mission *fsoMn = nullptr,
-							const cmission *cm = nullptr);
-
-		static void initMissions(
-				const SCP_vector<SCP_string>::const_iterator &m_it,
-				CheckedDataListModel<CampaignEditorDialogModel::CampaignMissionData> &model);
-		void branchesFromFormula(CampaignEditorDialogModel *model, int formula, const cmission *loop = nullptr);
-
-	// state
-		const QString filename;
-
-		bool fredable{false};
-
-		const int nPlayers;
-		const QString notes;
-
-		const QStringList events;
-		const QStringList goals;
-
-		QString briefingCutscene;
-		QString mainhall;
-		QString debriefingPersona;
-
-		SCP_vector<CampaignBranchData> branches;
-	// state -- current branch
-		CampaignBranchData *brData_it{nullptr};
-		int brData_idx{-1};
-	};
-
-	class CampaignBranchData {
-	public:
-		explicit CampaignBranchData() = default;
-		CampaignBranchData(CampaignEditorDialogModel *model, int sexp_branch, const QString &from, const cmission *loop = nullptr);
-		CampaignBranchData(CampaignEditorDialogModel *model, const QString &from, QString to = "");
-
-		void connect(const SCP_unordered_set<const CampaignMissionData*>& missions);
-
-	// constants
-		enum BranchType { INVALID, //initial state
-						  REPEAT, //mission branch to self (commonly failure)
-						  NEXT, //branch to different mission (commonly success/progress)
-						  NEXT_NOT_FOUND, //specified mission file does not (yet) exist
-						  END, //branch to end campaign
-						};
-		//how mission names are prefixed in the progress condition sexptree widget
-		static const SCP_map<BranchType, QString> branchTexts;
-
-	// state
-		BranchType type{INVALID};
-		int sexp;
-
-		QString next;
-
-		bool loop;
-
-		AssociatedPlainTextDocument* loopDescr;
-		QString loopAnim;
-		QString loopVoice;
-	};
-
-public:
-// parsed table / cfile data
-	static const QStringList& cutscenes();
-	static const QStringList& mainhalls();
-	static const QStringList& debriefingPersonas();
-	static const QStringList& loopAnims();
-	static const QStringList& loopVoices();
-
-// Model state -- specs
-	const QString campaignFile;
-	static const QStringList campaignTypes;
-	const QString campaignType;
-	const int numPlayers{0};
-
-private:
-	QStringList droppedMissions{};
-	bool modified{false};
-
-// Model state -- current mission
-	CampaignMissionData* mnData_it{nullptr};
-	QPersistentModelIndex mnData_idx{};
-
-	CampaignEditorDialog *const parent;
-// submodels
-	CheckedDataListModel<std::ptrdiff_t> initialShips;
-	CheckedDataListModel<std::ptrdiff_t> initialWeapons;
-	CheckedDataListModel<CampaignMissionData> missionData;
-	QString firstMission{""};
-
-// Model state -- specs
-	QString campaignName;
-	AssociatedPlainTextDocument campaignDescr{""};
-	bool campaignTechReset{false};
+/**
+ * @brief A simple data structure to hold the working copy of a campaign mission's branch.
+ */
+struct CampaignBranchData {
+	int sexp_formula = -1;
+	SCP_string next_mission_name;
+	bool is_loop = false;
+	bool is_fork = false; // Not currently supported by FRED, but good to have
+	SCP_string loop_description;
+	SCP_string loop_briefing_anim;
+	SCP_string loop_briefing_sound;
 };
 
+/**
+ * @brief A simple data structure to hold the working copy of a mission within the campaign.
+ */
+struct CampaignMissionData {
+	SCP_string name;
+	int level = 0;
+	int position = 0;
 
-} // namespace dialogs
-} // namespace fred
-} // namespace fso
+	SCP_string briefing_cutscene;
+	SCP_string main_hall;
+	SCP_string substitute_main_hall;
+	int debrief_persona_index = 0;
+
+	SCP_vector<CampaignBranchData> branches;
+};
+
+/**
+ * @brief An abstract interface that defines the contract for how the model
+ * communicates with the UI's SEXP tree widget. This keeps the model
+ * completely decoupled from any specific UI implementation.
+ */
+struct ICampaignEditorTreeOps {
+	virtual ~ICampaignEditorTreeOps() = default;
+
+	// Asks the tree to load a formula and return its internal ID
+	virtual int loadSexp(int formula_index) = 0;
+
+	// Asks the tree to save an internal branch and return the new formula ID
+	virtual int saveSexp(int internal_node_id) = 0;
+
+	// Asks the tree to create a new, default SEXP (i.e., "true")
+	virtual int createDefaultSexp() = 0;
+
+	// Asks the tree to completely rebuild its view from a list of branches
+	virtual void rebuildBranchTree(const SCP_vector<CampaignBranchData>& branches) = 0;
+
+	// Asks the tree to expand the visual branch for a given internal node ID
+	virtual void expandBranch(int internal_node_id) = 0;
+};
+
+/**
+ * @brief The data model for the Campaign Editor. Manages all campaign data
+ * and business logic in a UI-agnostic way.
+ */
+class CampaignEditorDialogModel : public AbstractDialogModel {
+	Q_OBJECT
+
+  public:
+	// The constructor now takes our abstract interface
+	CampaignEditorDialogModel(QObject* parent, EditorViewport* viewportt, ICampaignEditorTreeOps& tree_ops);
+	~CampaignEditorDialogModel() override = default;
+
+	// AbstractDialogModel implementation
+	bool apply() override;
+	void reject() override;
+
+	void loadCampaignFromFile(const SCP_string& filename);
+	void saveCampaign(const SCP_string& filename);
+	bool checkValidity();
+
+	void setCurrentMissionSelection(int index);
+	void setCurrentBranchSelection(int branch_index);
+
+	// Base Campaign Data
+	const SCP_string& getCampaignName() const;
+	void setCampaignName(const SCP_string& name);
+	const SCP_string& getCampaignDescription() const;
+	void setCampaignDescription(const SCP_string& descr);
+	int getCampaignType() const;
+	void setCampaignType(int type);
+	bool getCampaignTechReset() const;
+	void setCampaignTechReset(bool reset);
+	int getCampaignNumPlayers() const;
+	void setCampaignNumPlayers(int num_players);
+
+	// Available Missions
+	const SCP_vector<SCP_string>& getAvailableMissionFiles() const;
+	void addMission(const SCP_string& filename, int level, int pos);
+	void removeMission(int mission_index);
+	void updateMissionPosition(int mission_index, int new_level, int new_pos);
+
+	// Current Mission
+	SCP_string getCurrentMissionFilename() const;
+	void setCurrentMissionFilename(const SCP_string& filename);
+	SCP_string getCurrentMissionBriefingCutscene() const;
+	void setCurrentMissionBriefingCutscene(const SCP_string& cutscene);
+	SCP_string getCurrentMissionMainhall() const;
+	void setCurrentMissionMainhall(const SCP_string& mainhall);
+	SCP_string getCurrentMissionSubstituteMainhall() const;
+	void setCurrentMissionSubstituteMainhall(const SCP_string& mainhall);
+	int getCurrentMissionDebriefingPersona() const;
+	void setCurrentMissionDebriefingPersona(int persona_index);
+
+	// Loop Data
+	SCP_string getCurrentBranchLoopDescription() const;
+	void setCurrentBranchLoopDescription(const SCP_string& descr);
+	SCP_string getCurrentBranchLoopAnim() const;
+	void setCurrentBranchLoopAnim(const SCP_string& anim);
+	SCP_string getCurrentBranchLoopVoice() const;
+	void setCurrentBranchLoopVoice(const SCP_string& voice);
+	void testCurrentBranchLoopVoice();
+
+	// Campaign Graph
+	const SCP_vector<CampaignMissionData>& getCampaignMissions() const;
+	void addBranch(int from_mission_index, int to_mission_index);
+	void removeBranch(int mission_index, int branch_index);
+	void updateCurrentBranch(int internal_node_id);
+
+	// Tech
+	const SCP_vector<bool>& getAllowedShips() const;
+	void setAllowedShip(int ship_class_index, bool allowed);
+	const SCP_vector<bool>& getAllowedWeapons() const;
+	void setAllowedWeapon(int weapon_class_index, bool allowed);
+
+  private:
+	// The model's only link to the SEXP tree UI
+	ICampaignEditorTreeOps& m_tree_ops;
+
+	SCP_string m_campaign_filename;
+	SCP_string m_campaign_name;
+	SCP_string m_campaign_descr;
+	int m_campaign_type = CAMPAIGN_TYPE_SINGLE;
+	int m_num_players = -1;
+	int m_flags = 0;
+	SCP_vector<bool> m_ships_allowed;
+	SCP_vector<bool> m_weapons_allowed;
+	SCP_vector<CampaignMissionData> m_missions;
+
+	// List of mission files in the game directory that are not yet in the campaign
+	SCP_vector<SCP_string> m_available_mission_files;
+
+	// Pointers/indices to the currently selected items for context
+	int m_current_mission_index = -1;
+	int m_current_branch_index = -1;
+
+	int _waveId;
+
+	void initializeData(const char* filename = nullptr);
+	void parseBranchesFromFormula(CampaignMissionData& mission, int formula_index, bool is_loop);
+	void loadAvailableMissions();
+	static void clearCampaignGlobal();
+	void commitWorkingCopyToGlobal();
+	void sortMissions();
+	void stopSpeech();
+};
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -168,6 +168,10 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	const SCP_vector<std::tuple<SCP_string, int, bool>> getAllowedWeapons() const;
 	void setAllowedWeapon(int weapon_class_index, bool allowed);
 
+	// Lists
+	static SCP_vector<SCP_string> getCutsceneList();
+	static SCP_vector<SCP_string> getMainhallList();
+
   private:
 	// The model's only link to the SEXP tree UI
 	ICampaignEditorTreeOps& m_tree_ops;

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -8,9 +8,6 @@
 
 namespace fso::fred::dialogs {
 
-/**
- * @brief A simple data structure to hold the working copy of a campaign mission's branch.
- */
 struct CampaignBranchData {
 	int sexp_formula = -1;
 	SCP_string next_mission_name;
@@ -21,9 +18,7 @@ struct CampaignBranchData {
 	SCP_string loop_briefing_sound;
 };
 
-/**
- * @brief A simple data structure to hold the working copy of a mission within the campaign.
- */
+
 struct CampaignMissionData {
 	SCP_string name;
 	int level = 0;
@@ -37,11 +32,6 @@ struct CampaignMissionData {
 	SCP_vector<CampaignBranchData> branches;
 };
 
-/**
- * @brief An abstract interface that defines the contract for how the model
- * communicates with the UI's SEXP tree widget. This keeps the model
- * completely decoupled from any specific UI implementation.
- */
 struct ICampaignEditorTreeOps {
 	virtual ~ICampaignEditorTreeOps() = default;
 
@@ -61,10 +51,6 @@ struct ICampaignEditorTreeOps {
 	virtual void expandBranch(int internal_node_id) = 0;
 };
 
-/**
- * @brief The data model for the Campaign Editor. Manages all campaign data
- * and business logic in a UI-agnostic way.
- */
 class CampaignEditorDialogModel : public AbstractDialogModel {
 	Q_OBJECT
 
@@ -77,6 +63,9 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	bool apply() override;
 	void reject() override;
 
+	static SCP_vector<SCP_string> getCampaignTypes();
+
+	void createNewCampaign();
 	void loadCampaignFromFile(const SCP_string& filename);
 	void saveCampaign(const SCP_string& filename);
 	bool checkValidity();
@@ -85,6 +74,8 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void setCurrentBranchSelection(int branch_index);
 
 	// Base Campaign Data
+	const SCP_string& getCampaignFilename() const;
+	void setCampaignFilename(const SCP_string& filename);
 	const SCP_string& getCampaignName() const;
 	void setCampaignName(const SCP_string& name);
 	const SCP_string& getCampaignDescription() const;
@@ -130,9 +121,9 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void updateCurrentBranch(int internal_node_id);
 
 	// Tech
-	const SCP_vector<bool>& getAllowedShips() const;
+	const SCP_vector<std::tuple<SCP_string, int, bool>> getAllowedShips() const;
 	void setAllowedShip(int ship_class_index, bool allowed);
-	const SCP_vector<bool>& getAllowedWeapons() const;
+	const SCP_vector<std::tuple<SCP_string, int, bool>> getAllowedWeapons() const;
 	void setAllowedWeapon(int weapon_class_index, bool allowed);
 
   private:

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -88,7 +88,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void setCampaignNumPlayers(int num_players);
 
 	// Available Missions
-	const SCP_vector<SCP_string>& getAvailableMissionFiles() const;
+	const SCP_vector<std::pair<SCP_string, bool>>& getAvailableMissionFiles() const;
 	void addMission(const SCP_string& filename, int level, int pos);
 	void removeMission(int mission_index);
 	void updateMissionPosition(int mission_index, int new_level, int new_pos);
@@ -141,7 +141,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	SCP_vector<CampaignMissionData> m_missions;
 
 	// List of mission files in the game directory that are not yet in the campaign
-	SCP_vector<SCP_string> m_available_mission_files;
+	SCP_vector<std::pair<SCP_string, bool>> m_available_mission_files;
 
 	// Pointers/indices to the currently selected items for context
 	int m_current_mission_index = -1;

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -89,9 +89,9 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void setSaveFormat(CampaignFormat fmt);
 
 	void setCurrentMissionSelection(int index);
-	int getCurrentMissionSelection();
+	int getCurrentMissionSelection() const;
 	void setCurrentBranchSelection(int branch_index);
-	int getCurrentBranchSelection();
+	int getCurrentBranchSelection() const;
 
 	// Base Campaign Data
 	const SCP_string& getCampaignFilename() const;
@@ -164,9 +164,9 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	CampaignBranchData* findBranchById(int missionIdx, int branchId);
 
 	// Tech
-	const SCP_vector<std::tuple<SCP_string, int, bool>> getAllowedShips() const;
+	SCP_vector<std::tuple<SCP_string, int, bool>> getAllowedShips() const;
 	void setAllowedShip(int ship_class_index, bool allowed);
-	const SCP_vector<std::tuple<SCP_string, int, bool>> getAllowedWeapons() const;
+	SCP_vector<std::tuple<SCP_string, int, bool>> getAllowedWeapons() const;
 	void setAllowedWeapon(int weapon_class_index, bool allowed);
 
 	// Lists

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -126,6 +126,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 
 	// Current Mission
 	SCP_string getCurrentMissionFilename() const;
+	void setMissionAsFirst(int mission_index);
 	void setCurrentMissionFilename(const SCP_string& filename);
 	SCP_string getCurrentMissionBriefingCutscene() const;
 	void setCurrentMissionBriefingCutscene(const SCP_string& cutscene);

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -120,7 +120,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	int getMissionGraphColor(int i) const; // -1 = unset, else 0xRRGGBB
 	void setMissionGraphColor(int i, int rgb0xRRGGBB);
 	CampaignSpecialMode getMissionSpecialMode(int i) const;
-	void setMissionSpecialMode(int i, CampaignSpecialMode mode); 
+	void toggleMissionSpecialMode(int i); 
 
 	// Current Mission
 	SCP_string getCurrentMissionFilename() const;

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -31,7 +31,7 @@ struct CampaignBranchData {
 
 
 struct CampaignMissionData {
-	SCP_string name;
+	SCP_string filename;
 	int level = 0;
 	int position = 0;
 	int graph_x = INT_MIN; // For UI layout only

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -63,7 +63,7 @@ struct ICampaignEditorTreeOps {
 	virtual int createDefaultSexp() = 0;
 
 	// Asks the tree to completely rebuild its view from a list of branches
-	virtual void rebuildBranchTree(const SCP_vector<CampaignBranchData>& branches) = 0;
+	virtual void rebuildBranchTree(const SCP_vector<CampaignBranchData>& branches, const SCP_string& currentMissionName) = 0;
 
 	// Asks the tree to expand the visual branch for a given internal node ID
 	virtual void expandBranch(int internal_node_id) = 0;
@@ -150,6 +150,8 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	// Campaign Graph
 	const SCP_vector<CampaignMissionData>& getCampaignMissions() const;
 	void addBranch(int from_mission_index, int to_mission_index);
+	void addEndBranch(int from_mission_index);
+	void addSpecialBranch(int from_mission_index, int to_mission_index);
 	void removeBranch(int mission_index, int branch_index);
 	void updateCurrentBranch(int internal_node_id);
 	int addBranchIdIfMissing(CampaignBranchData& b); // assigns a unique id once

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -150,10 +150,13 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 
 	// Campaign Graph
 	const SCP_vector<CampaignMissionData>& getCampaignMissions() const;
+	int getNumBranches() const;
 	void addBranch(int from_mission_index, int to_mission_index);
 	void addEndBranch(int from_mission_index);
 	void addSpecialBranch(int from_mission_index, int to_mission_index);
 	void removeBranch(int mission_index, int branch_index);
+	void moveBranchUp();
+	void moveBranchDown();
 	void updateCurrentBranch(int internal_node_id);
 	bool getCurrentBranchIsSpecial() const;
 	int addBranchIdIfMissing(CampaignBranchData& b); // assigns a unique id once

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -535,13 +535,13 @@ void CampaignEditorDialog::on_graphView_missionSelected(int missionIndex) {
 		return;
 	}
 
-	if (mission_info.name) {
+	if (mission_info.name[0] != '\0') {
 		ui->missionNameLineEdit->setText(QString::fromUtf8(mission_info.name));
 	} else {
 		ui->missionNameLineEdit->clear();
 	}
 
-	if (mission_info.notes) {
+	if (mission_info.notes[0] != '\0') {
 		ui->missionDescriptionPlainTextEdit->setPlainText(QString::fromUtf8(mission_info.notes));
 	} else {
 		ui->missionDescriptionPlainTextEdit->clear();

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -5,6 +5,7 @@
 #include "ui/widgets/SimpleListSelectDialog.h"
 #include "ui/util/SignalBlockers.h"
 #include "mission/util.h"
+#include <ui/dialogs/MissionSpecs/CustomDataDialog.h>
 #include <QInputDialog>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -432,6 +433,16 @@ void CampaignEditorDialog::on_typeComboBox_currentIndexChanged(int index)
 void CampaignEditorDialog::on_resetTechAtStartCheckBox_toggled(bool checked)
 {
 	_model->setCampaignTechReset(checked);
+}
+
+void CampaignEditorDialog::on_campaignCustomDataButton_clicked()
+{
+	CustomDataDialog dlg(this, _viewport);
+	dlg.setInitial(_model->getCustomData());
+
+	if (dlg.exec() == QDialog::Accepted) {
+		_model->setCustomData(dlg.items());
+	}
 }
 
 void CampaignEditorDialog::on_descriptionPlainTextEdit_textChanged()

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -395,6 +395,35 @@ void CampaignEditorDialog::on_availableMissionsFilterLineEdit_textChanged(const 
 	updateAvailableMissionsList();
 }
 
+void CampaignEditorDialog::on_availableMissionsListWidget_itemSelectionChanged()
+{
+	// Get the currently selected item
+	QListWidgetItem* selected_item = ui->availableMissionsListWidget->currentItem();
+
+	// Get the filename from the item's text
+	SCP_string filename = selected_item->text().toUtf8().constData();
+
+	mission mission_info;
+	if (get_mission_info(filename.c_str(), &mission_info) != 0) {
+		// Failed to retrieve mission info, clear fields and return
+		ui->missionNameLineEdit->clear();
+		ui->missionDescriptionPlainTextEdit->clear();
+		return;
+	}
+
+	if (mission_info.name) {
+		ui->missionNameLineEdit->setText(QString::fromUtf8(mission_info.name));
+	} else {
+		ui->missionNameLineEdit->clear();
+	}
+
+	if (mission_info.notes) {
+		ui->missionDescriptionPlainTextEdit->setPlainText(QString::fromUtf8(mission_info.notes));
+	} else {
+		ui->missionDescriptionPlainTextEdit->clear();
+	}
+}
+
 /*void CampaignEditorDialog::setModel(CampaignEditorDialogModel* new_model)
 {
 	if (new_model)

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -146,40 +146,6 @@ CampaignEditorDialog::CampaignEditorDialog(QWidget* _parent, EditorViewport* _vi
 		&CampaignEditorDialogModel::updateCurrentBranch,
 		Qt::QueuedConnection);
 
-	// TODO move these to auto slots
-	/*connect(ui->graphView, &CampaignMissionGraph::missionSelected, this, [this](int idx) {
-		_model->setCurrentMissionSelection(idx);
-
-		SCP_string filename = _model->getCurrentMissionFilename();
-		mission mission_info;
-		if (get_mission_info(filename.c_str(), &mission_info) != 0) {
-			// Failed to retrieve mission info, clear fields and return
-			ui->missionNameLineEdit->clear();
-			ui->missionDescriptionPlainTextEdit->clear();
-			return;
-		}
-
-		if (mission_info.name) {
-			ui->missionNameLineEdit->setText(QString::fromUtf8(mission_info.name));
-		} else {
-			ui->missionNameLineEdit->clear();
-		}
-
-		if (mission_info.notes) {
-			ui->missionDescriptionPlainTextEdit->setPlainText(QString::fromUtf8(mission_info.notes));
-		} else {
-			ui->missionDescriptionPlainTextEdit->clear();
-		}
-	});
-
-	connect(ui->graphView, &CampaignMissionGraph::specialModeToggleRequested, this, [this](int idx) {
-		// Only toggle if mission has no special branches (view already enforces)
-		// You can add a tiny setter later; for now just flip your hint if you’ve added it
-		// model->setMissionSpecialMode(idx, ... toggled value ...);
-		// ui refresh after change:
-		ui->graphView->rebuildAll();
-	});*/
-
 	initializeUi();
 	updateUi();
 

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -437,6 +437,12 @@ void CampaignEditorDialog::on_errorCheckerButton_clicked()
 	_model->checkValidity();
 }
 
+void CampaignEditorDialog::on_availableMissionsFilterLineEdit_textChanged(const QString& arg1)
+{
+	_model->setAvailableMissionsFilter(arg1.toUtf8().constData());
+	updateAvailableMissionsList();
+}
+
 /*void CampaignEditorDialog::setModel(CampaignEditorDialogModel* new_model)
 {
 	if (new_model)

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -318,6 +318,10 @@ void CampaignEditorDialog::enableDisableControls()
 	ui->substituteMainhallComboBox->setEnabled(has_mission);
 	ui->debriefingPersonaSpinBox->setEnabled(has_mission);
 
+	bool branch_selected = (_model->getCurrentBranchSelection() >= 0);
+	ui->moveBranchUpButton->setEnabled(branch_selected && _model->getCurrentBranchSelection() > 0);
+	ui->moveBranchDownButton->setEnabled(branch_selected && _model->getCurrentBranchSelection() < _model->getNumBranches() -1);
+
 	bool special_branch_selected = _model->getCurrentBranchIsSpecial();
 	ui->loopDescriptionPlainTextEdit->setEnabled(special_branch_selected);
 	ui->loopAnimBrowseButton->setEnabled(special_branch_selected);
@@ -673,6 +677,26 @@ void CampaignEditorDialog::on_mainhallComboBox_currentIndexChanged(const QString
 void CampaignEditorDialog::on_substituteMainhallComboBox_currentIndexChanged(const QString& arg1)
 {
 	_model->setCurrentMissionSubstituteMainhall(arg1.toUtf8().constData());
+}
+
+void CampaignEditorDialog::on_moveBranchUpButton_clicked()
+{
+	int mission_selection = _model->getCurrentMissionSelection(); // save now because rebuild clears it
+
+	_model->moveBranchUp();
+	ui->graphView->rebuildAll();
+
+	ui->graphView->setSelectedMission(mission_selection);
+}
+
+void CampaignEditorDialog::on_moveBranchDownButton_clicked()
+{
+	int mission_selection = _model->getCurrentMissionSelection(); // save now because rebuild clears it
+	
+	_model->moveBranchDown();
+	ui->graphView->rebuildAll();
+
+	ui->graphView->setSelectedMission(mission_selection);
 }
 
 void CampaignEditorDialog::on_loopDescriptionPlainTextEdit_textChanged()

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -120,6 +120,8 @@ CampaignEditorDialog::CampaignEditorDialog(QWidget* _parent, EditorViewport* _vi
 			// Rebuild the graph view
 			ui->graphView->rebuildAll();
 			ui->graphView->setSelectedMission(mission_selection);
+
+			updateLoopDetails();
 		},
 		Qt::QueuedConnection);
 
@@ -138,69 +140,18 @@ CampaignEditorDialog::CampaignEditorDialog(QWidget* _parent, EditorViewport* _vi
 			} else {
 				_model->setCurrentBranchSelection(-1);
 			}
+
+			updateLoopDetails();
 		});
 
-	connect(ui->sxtBranches,
-		&sexp_tree::nodeChanged,
-		_model.get(),
-		&CampaignEditorDialogModel::updateCurrentBranch,
-		Qt::QueuedConnection);
+	connect(ui->sxtBranches, &sexp_tree::nodeChanged, this, [this](int node) {
+		_model->updateCurrentBranch(node);
+
+		updateLoopDetails();
+	});
 
 	initializeUi();
 	updateUi();
-
-	/*connect(&warnings, &CampaignEditorUtil::WarningVec::gotMsg, this, [&]() {
-		for (auto warn_it = warnings.begin(); warn_it != warnings.end(); warn_it = warnings.erase(warn_it)) {
-			if (warn_it->type.isEmpty()) {
-				QMessageBox::warning(this, warn_it->title, warn_it->msg);
-			}
-		}
-	});
-	warnings.gotMsg();
-
-	QPalette p = ui->lblMissionDescr1->palette();
-	p.setColor(QPalette::WindowText, Qt::darkYellow);
-	ui->lblMissionDescr1->setPalette(p);
-	p = ui->lblMissionDescr2->palette();
-	p.setColor(QPalette::WindowText, Qt::red);
-	ui->lblMissionDescr2->setPalette(p);
-
-	connect(ui->lstMissions, &QListView::clicked, this, &CampaignEditorDialog::lstMissionsClicked);
-
-	setModel();
-
-	connect(ui->lstMissions, &QListView::customContextMenuRequested, this, &CampaignEditorDialog::mnLinkMenu);
-
-	connect(ui->btnErrorChecker, &QPushButton::clicked, []() {
-		uiWarn(tr("Error Checker"), tr("Error checker not implemented. Try saving a copy."));
-	});
-	connect(ui->btnFredMission, &QPushButton::clicked, this, [&]() {
-		reject();
-		if (result() == Rejected)
-			qobject_cast<FredView*>(parent)->loadMissionFile(model->getCurMnFilename());
-	});
-	connect(ui->btnFirstMission, &QPushButton::clicked, this, [&](bool toggledOn) {
-		Assertion(toggledOn, "Should not be able to unset first mission");
-		model->setCurMnFirst();
-		updateUIMission(false);
-	});
-	connect(ui->btnExit, &QPushButton::clicked, this, &CampaignEditorDialog::reject);
-
-	QMenu* menFile{new QMenu(this)};
-	ui->btnMenu->setMenu(menFile);
-	QMenu* menFileNew{menFile->addMenu(tr("&New"))};
-	for (auto& campaignType : model->campaignTypes)
-		menFileNew->addAction(campaignType, this, &CampaignEditorDialog::fileNew);
-	menFile->addSeparator();
-
-	menFile->addAction(tr("&Open..."), this, &CampaignEditorDialog::fileOpen, tr("Ctrl+O"));
-	menFile->addAction(tr("&Save"), this, &CampaignEditorDialog::fileSave, tr("Ctrl+S"));
-	menFile->addAction(tr("Save &as..."), this, &CampaignEditorDialog::fileSaveAs, tr("Ctrl+Shift+S"));
-	menFile->addAction(tr("Save &Copy as..."), this, &CampaignEditorDialog::fileSaveCopyAs);
-	menFile->addSeparator();
-	menFile->addAction(tr("E&xit"), this, &QDialog::reject);
-
-	updateUIAll();*/
 }
 CampaignEditorDialog::~CampaignEditorDialog() = default;
 
@@ -243,6 +194,30 @@ void CampaignEditorDialog::initializeUi()
 	};
 
 	disableDnD(ui->availableMissionsListWidget);
+
+	// setup the cutscene list
+	auto cutscenes = _model->getCutsceneList();
+	QStringList cutsceneList;
+	for (const auto& cs : cutscenes) {
+		cutsceneList.append(QString::fromStdString(cs));
+	}
+
+	ui->briefCutsceneComboBox->clear();
+	ui->briefCutsceneComboBox->addItems(cutsceneList);
+
+	// setup the main hall lists
+	auto mainhalls = _model->getMainhallList();
+	QStringList mainhallList;
+	for (const auto& mh : mainhalls) {
+		mainhallList.append(QString::fromStdString(mh));
+	}
+
+	ui->mainhallComboBox->clear();
+	ui->mainhallComboBox->addItems(mainhallList);
+	ui->substituteMainhallComboBox->clear();
+	ui->substituteMainhallComboBox->addItems(mainhallList);
+
+	ui->fredMissionButton->setHidden(true); // TODO activate this when QtFRED is closer to completion
 }
 
 void CampaignEditorDialog::updateUi()
@@ -253,6 +228,8 @@ void CampaignEditorDialog::updateUi()
 	ui->typeComboBox->setCurrentIndex(_model->getCampaignType());
 	ui->resetTechAtStartCheckBox->setChecked(_model->getCampaignTechReset());
 	ui->descriptionPlainTextEdit->setPlainText(QString::fromStdString(_model->getCampaignDescription()));
+
+	ui->retailFormatCheckbox->setChecked(_model->getSaveFormat() == CampaignFormat::Retail);
 	
 	updateTechLists();
 	updateAvailableMissionsList();
@@ -307,18 +284,48 @@ void CampaignEditorDialog::updateAvailableMissionsList()
 void CampaignEditorDialog::updateMissionDetails()
 {
 	util::SignalBlockers blocker(this);
-	// TODO fill in mission details from model
+	
+	ui->briefCutsceneComboBox->setCurrentIndex(ui->briefCutsceneComboBox->findText(_model->getCurrentMissionBriefingCutscene().c_str(), Qt::MatchFixedString));
+	ui->mainhallComboBox->setCurrentIndex(ui->mainhallComboBox->findText(_model->getCurrentMissionMainhall().c_str(), Qt::MatchFixedString));
+	ui->substituteMainhallComboBox->setCurrentIndex(ui->substituteMainhallComboBox->findText(_model->getCurrentMissionSubstituteMainhall().c_str(), Qt::MatchFixedString));
+	ui->debriefingPersonaSpinBox->setValue(_model->getCurrentMissionDebriefingPersona());
+
+	enableDisableControls();
+}
+
+void CampaignEditorDialog::updateLoopDetails()
+{
+	util::SignalBlockers blocker(this);
+
+	ui->loopDescriptionPlainTextEdit->setPlainText(QString::fromStdString(_model->getCurrentBranchLoopDescription()));
+	ui->loopAnimLineEdit->setText(QString::fromStdString(_model->getCurrentBranchLoopAnim()));
+	ui->loopVoiceLineEdit->setText(QString::fromStdString(_model->getCurrentBranchLoopVoice()));
 
 	enableDisableControls();
 }
 
 void CampaignEditorDialog::enableDisableControls()
 {
-	bool has_mission = (!_model->getCurrentMissionFilename().empty()); // TODO Add an actual validator to the model??
+	bool mission_selected = (_model->getCurrentMissionSelection() >= 0) || (ui->availableMissionsListWidget->currentItem() != nullptr);
+	ui->fredMissionButton->setEnabled(mission_selected);
+
+	bool has_mission = (_model->getCurrentMissionSelection() >= 0);
 
 	ui->sxtBranches->setEnabled(has_mission);
+	ui->briefCutsceneComboBox->setEnabled(has_mission);
+	ui->mainhallComboBox->setEnabled(has_mission);
+	ui->substituteMainhallComboBox->setEnabled(has_mission);
+	ui->debriefingPersonaSpinBox->setEnabled(has_mission);
 
-	// TODO enable/disable other controls based on context
+	bool special_branch_selected = _model->getCurrentBranchIsSpecial();
+	ui->loopDescriptionPlainTextEdit->setEnabled(special_branch_selected);
+	ui->loopAnimBrowseButton->setEnabled(special_branch_selected);
+	ui->loopAnimLineEdit->setEnabled(special_branch_selected);
+	ui->loopVoiceBrowseButton->setEnabled(special_branch_selected);
+	ui->loopVoiceLineEdit->setEnabled(special_branch_selected);
+
+	bool enable_playback = special_branch_selected && !_model->getCurrentBranchLoopVoice().empty();
+	ui->testVoiceButton->setEnabled(enable_playback);
 }
 
 bool CampaignEditorDialog::questionSaveChanges()
@@ -637,353 +644,77 @@ void CampaignEditorDialog::on_graphView_createMissionAtAndConnectRequested(QPoin
 	updateAvailableMissionsList();
 }
 
-/*void CampaignEditorDialog::setModel(CampaignEditorDialogModel* new_model)
+void CampaignEditorDialog::on_briefCutsceneComboBox_currentIndexChanged(const QString& arg1)
 {
-	if (new_model)
-		model = std::unique_ptr<CampaignEditorDialogModel>(new_model);
-
-	ui->cmbBriefingCutscene->setModel(new QStringListModel{CampaignEditorDialogModel::cutscenes(), model.get()});
-	ui->cmbMainhall->setModel(new QStringListModel{CampaignEditorDialogModel::mainhalls(), model.get()});
-	ui->cmbDebriefingPersona->setModel(
-		new QStringListModel{CampaignEditorDialogModel::debriefingPersonas(), model.get()});
-	ui->cmbLoopAnim->setModel(new QStringListModel{CampaignEditorDialogModel::loopAnims(), model.get()});
-	ui->cmbLoopVoice->setModel(new QStringListModel{CampaignEditorDialogModel::loopVoices(), model.get()});
-
-	model->supplySubModels(*(ui->lstShips), *(ui->lstWeapons), *(ui->lstMissions), *(ui->txaDescr));
-
-	connect(ui->lstMissions->selectionModel(),
-		&QItemSelectionModel::selectionChanged,
-		model.get(),
-		&CampaignEditorDialogModel::missionSelectionChanged);
-
-	connect(ui->txtName, &QLineEdit::textChanged, model.get(), &CampaignEditorDialogModel::setCampaignName);
-	connect(ui->chkTechReset, &QCheckBox::stateChanged, model.get(), [&](int changed) {
-		model->setCampaignTechReset(changed == Qt::Checked);
-	});
-
-	connect(ui->cmbBriefingCutscene,
-		&QComboBox::currentTextChanged,
-		model.get(),
-		&CampaignEditorDialogModel::setCurMnBriefingCutscene);
-	connect(ui->cmbMainhall,
-		&QComboBox::currentTextChanged,
-		model.get(),
-		&CampaignEditorDialogModel::setCurMnMainhall);
-	connect(ui->cmbDebriefingPersona,
-		&QComboBox::currentTextChanged,
-		model.get(),
-		&CampaignEditorDialogModel::setCurMnDebriefingPersona);
-
-	ui->sxtBranches->initializeEditor(nullptr, model.get());
-	connect(ui->sxtBranches,
-		&sexp_tree::rootNodeDeleted,
-		model.get(),
-		&CampaignEditorDialogModel::delCurMnBranch,
-		Qt::QueuedConnection); // will call removeBranch()
-	connect(ui->sxtBranches,
-		&QTreeWidget::currentItemChanged,
-		model.get(),
-		&CampaignEditorDialogModel::selectCurBr); // will call setCurrentBranchSelection()
-	connect(
-		ui->sxtBranches,
-		&sexp_tree::nodeChanged,
-		model.get(),
-		[&](int node) { // will call updateCurrentBranch()
-			bool success = model->setCurBrSexp(ui->sxtBranches->save_tree(ui->sxtBranches->get_root(node)));
-			if (!success) {
-				int old = model->getCurBrIdx();
-				restoreBranchOpen(old);
-			}
-		},
-		Qt::QueuedConnection);
-
-	connect(ui->cmbLoopAnim,
-		&QComboBox::currentTextChanged,
-		model.get(),
-		&CampaignEditorDialogModel::setCurLoopAnim);
-	connect(ui->cmbLoopVoice,
-		&QComboBox::currentTextChanged,
-		model.get(),
-		&CampaignEditorDialogModel::setCurLoopVoice);
+	_model->setCurrentMissionBriefingCutscene(arg1.toUtf8().constData());
 }
 
-void CampaignEditorDialog::reject()
-{ // merely means onClose
-	if (!questionSaveChanges())
-		return;
-
-	QDialog::reject();
-	deleteLater();
+void CampaignEditorDialog::on_debriefingPersonaSpinBox_valueChanged(int arg1)
+{
+	_model->setCurrentMissionDebriefingPersona(arg1);
 }
 
-void CampaignEditorDialog::updateUISpec()
+void CampaignEditorDialog::on_mainhallComboBox_currentIndexChanged(const QString& arg1)
 {
-	util::SignalBlockers blockers(this);
-
-	setWindowTitle(model->campaignFile.isEmpty() ? "Untitled" : model->campaignFile + ".fc2");
-
-	ui->txtName->setText(model->getCampaignName());
-	if (CampaignEditorDialogModel::campaignTypes.indexOf(model->campaignType))
-		ui->txtType->setText(model->campaignType + ": " + QString::number(model->numPlayers));
-	else
-		ui->txtType->setText(model->campaignType);
-	ui->chkTechReset->setChecked(model->getCampaignTechReset());
+	_model->setCurrentMissionMainhall(arg1.toUtf8().constData());
 }
 
-void CampaignEditorDialog::updateUIMission(bool updateBranch)
+void CampaignEditorDialog::on_substituteMainhallComboBox_currentIndexChanged(const QString& arg1)
 {
-	util::SignalBlockers blockers(this);
-
-	ui->btnFirstMission->setEnabled(model->getCurMnIncluded() && !model->isCurMnFirst());
-	ui->btnFirstMission->setChecked(model->isCurMnFirst());
-	ui->btnFredMission->setEnabled(model->getCurMnFredable());
-	ui->txbMissionDescr->setText(model->getCurMnDescr());
-
-	ui->cmbBriefingCutscene->setCurrentText(model->getCurMnBriefingCutscene());
-	ui->cmbMainhall->setCurrentText(model->getCurMnMainhall());
-	ui->cmbDebriefingPersona->setCurrentText(model->getCurMnDebriefingPersona());
-
-	bool included{model->getCurMnIncluded()};
-	ui->cmbBriefingCutscene->setEnabled(included);
-	ui->cmbMainhall->setEnabled(included);
-	ui->cmbDebriefingPersona->setEnabled(included);
-
-	ui->sxtBranches->setEnabled(included);
-	ui->sxtBranches->clear_tree("");
-
-	if (included)
-		model->fillTree(*ui->sxtBranches);
-
-	if (updateBranch)
-		updateUIBranch();
+	_model->setCurrentMissionSubstituteMainhall(arg1.toUtf8().constData());
 }
 
-void CampaignEditorDialog::updateUIBranch(int selectedIdx)
+void CampaignEditorDialog::on_loopDescriptionPlainTextEdit_textChanged()
 {
-	util::SignalBlockers blockers(this);
-
-	if (selectedIdx >= 0)
-		model->selectCurBr(ui->sxtBranches->topLevelItem(selectedIdx));
-	else
-		selectedIdx = model->getCurBrIdx();
-
-	bool sel = selectedIdx >= 0;
-
-	if (sel) {
-		ui->sxtBranches->selectionModel()->select(ui->sxtBranches->model()->index(selectedIdx, 0),
-			QItemSelectionModel::Select);
-	}
-
-	bool loop = model->isCurBrLoop();
-
-	model->supplySubModelLoop(*ui->txaLoopDescr);
-	ui->txaLoopDescr->setEnabled(loop);
-
-	ui->cmbLoopAnim->setCurrentText(model->getCurLoopAnim());
-	ui->cmbLoopAnim->setEnabled(loop);
-
-	ui->cmbLoopVoice->setCurrentText(model->getCurLoopVoice());
-	ui->cmbLoopVoice->setEnabled(loop);
+	_model->setCurrentBranchLoopDescription(ui->loopDescriptionPlainTextEdit->toPlainText().toUtf8().constData());
 }
 
-void fso::fred::dialogs::CampaignEditorDialog::restoreBranchOpen(int branch)
+void CampaignEditorDialog::on_loopAnimLineEdit_textChanged(const QString& arg1)
 {
-	updateUIMission(false);
-	updateUIBranch(branch);
-	ui->sxtBranches->expand_branch(ui->sxtBranches->topLevelItem(branch));
+	_model->setCurrentBranchLoopAnim(arg1.toUtf8().constData());
+
+	bool enable_playback = _model->getCurrentBranchIsSpecial() && !_model->getCurrentBranchLoopVoice().empty();
+	ui->testVoiceButton->setEnabled(enable_playback);
 }
 
-bool CampaignEditorDialog::questionSaveChanges()
+void CampaignEditorDialog::on_loopVoiceLineEdit_textChanged(const QString& arg1)
 {
-	QMessageBox::StandardButton resBtn = QMessageBox::Discard;
-	if (model->query_modified()) {
-		QString msg = tr("This campaign has been modified.\n") +
-						(model->missionDropped() ? tr("Additionally, packaged/missing\nmission(s) have been "
-													"removed,\nwhich cannot be added again.\n")
-												: "") +
-						tr("\nSave changes?");
-		resBtn = QMessageBox::question(this,
-			tr("Unsaved changes"),
-			msg,
-			QMessageBox::Cancel | QMessageBox::Discard | QMessageBox::Save,
-			QMessageBox::Save);
-	}
+	_model->setCurrentBranchLoopVoice(arg1.toUtf8().constData());
+}
 
-	switch (resBtn) {
-	case QMessageBox::Discard:
-		model->reject();
-		return true;
-	case QMessageBox::Save:
-		return fileSave();
-	case QMessageBox::Cancel:
-		return false;
-	default:
-		UNREACHABLE("An unhandled button was pressed. A coder must handle the buttons they provide.");
-		return false;
+void CampaignEditorDialog::on_loopAnimBrowseButton_clicked()
+{
+	util::SignalBlockers blocker(this);
+	
+	QString filter = "FSO Animations (*.ani *.eff *.png);;All Files (*.*)";
+	QString fileName = QFileDialog::getOpenFileName(this, "Select Loop Animation", "", filter);
+	if (!fileName.isEmpty()) {
+		ui->loopAnimLineEdit->setText(fileName);
 	}
 }
 
-void CampaignEditorDialog::fileNew()
+void CampaignEditorDialog::on_loopVoiceBrowseButton_clicked()
 {
-	if (!questionSaveChanges())
-		return;
-
-	auto* act = qobject_cast<QAction*>(sender());
-	if (!act)
-		return;
-
-	setModel(new CampaignEditorDialogModel(this,
-		viewport,
-		"",
-		act->text(),
-		act->text().contains("multi")
-			? QInputDialog::getInt(this, "Campaign Player Number", "Enter campaign player number", 2, 2)
-			: 0));
-	updateUIAll();
-}
-
-void CampaignEditorDialog::fileOpen()
-{
-	if (!questionSaveChanges())
-		return;
-
-	QString pathName =
-		QFileDialog::getOpenFileName(this, tr("Load campaign"), model->campaignFile, tr("FS2 campaigns (*.fc2)"));
-
-	if (pathName.isEmpty())
-		return;
-
-	auto newModel = new CampaignEditorDialogModel(this, viewport, pathName);
-	if (newModel->isFileLoaded()) {
-		setModel(newModel);
-	} else {
-		delete newModel;
-		uiWarn(tr("Error opening file"), pathName);
-		setModel(new CampaignEditorDialogModel(this, viewport, ""));
+	util::SignalBlockers blocker(this);
+	
+	QString filter = "Audio Files (*.wav *.ogg);;All Files (*.*)";
+	QString fileName = QFileDialog::getOpenFileName(this, "Select Loop Voice", "", filter);
+	if (!fileName.isEmpty()) {
+		ui->loopVoiceLineEdit->setText(fileName);
 	}
 
-	updateUIAll();
+	bool enable_playback = _model->getCurrentBranchIsSpecial() && !_model->getCurrentBranchLoopVoice().empty();
+	ui->testVoiceButton->setEnabled(enable_playback);
 }
 
-bool CampaignEditorDialog::fileSave()
+void CampaignEditorDialog::on_testVoiceButton_clicked()
 {
-	if (model->campaignFile.isEmpty())
-		return fileSaveAs();
-
-	bool res = model->apply();
-
-	updateUIAll();
-	return res;
+	_model->testCurrentBranchLoopVoice();
 }
 
-bool CampaignEditorDialog::fileSaveAs()
+void CampaignEditorDialog::on_retailFormatCheckbox_toggled(bool checked)
 {
-	QString pathName = QFileDialog::getSaveFileName(this,
-		tr("Save campaign as"),
-		model->campaignFile,
-		tr("FS2 campaigns (*.fc2)"));
-	if (pathName.isEmpty())
-		return false;
-
-	bool res = model->saveTo(pathName);
-	if (res)
-		setModel(new CampaignEditorDialogModel(this, viewport, pathName));
-
-	updateUIAll();
-	return res;
+	_model->setSaveFormat(checked ? CampaignFormat::Retail : CampaignFormat::FSO);
 }
-
-void CampaignEditorDialog::fileSaveCopyAs()
-{
-	QString pathName =
-		QFileDialog::getSaveFileName(this, tr("Save copy as"), model->campaignFile, tr("FS2 campaigns (*.fc2)"));
-	if (pathName.isEmpty())
-		return;
-
-	model->saveTo(pathName);
-}
-
-void CampaignEditorDialog::lstMissionsClicked(const QModelIndex& idx)
-{
-	QItemSelectionModel& sel = *ui->lstMissions->selectionModel();
-	bool same = sel.selectedIndexes().contains(idx);
-	sel.clearSelection();
-	if (!same)
-		sel.select(idx, QItemSelectionModel::Toggle | QItemSelectionModel::Rows);
-}
-
-void CampaignEditorDialog::mnLinkMenu(const QPoint& pos)
-{
-	QModelIndex here = ui->lstMissions->indexAt(pos);
-	if (here.data(Qt::CheckStateRole) != Qt::Checked)
-		return;
-
-	const QString* mnName = model->missionName(here);
-	if (!mnName)
-		return;
-	const QStringList* goals{model->missionGoals(here)};
-	if (!goals)
-		return;
-	const QStringList* evts{model->missionEvents(here)};
-	if (!evts)
-		return;
-
-	QMenu menu{ui->lstMissions};
-
-	QAction* to = menu.addAction(tr("Add branch to ") + mnName);
-	QAction* from = menu.addAction(tr("Add branch from ") + mnName);
-	QAction* end = menu.addAction(tr("Add campaign end"));
-	bool mnSel{model->isCurMnSelected()};
-	to->setEnabled(mnSel);
-	from->setEnabled(mnSel);
-	end->setEnabled(mnSel);
-	if (!mnSel) {
-		menu.exec(ui->lstMissions->mapToGlobal(pos));
-		return;
-	}
-
-	QMenu* par{nullptr};
-
-	if (model->getCurBrIdx() < 0) {
-		menu.addSection(tr("Select a branch to choose conditions!"));
-		menu.addAction("")->setEnabled(false);
-	} else {
-		menu.addSection(tr("Branch Conditions"));
-
-		QMenu* gt = menu.addMenu("is-previous-goal-true");
-		QMenu* gf = menu.addMenu("is-previous-goal-false");
-		for (auto& g : *goals) {
-			gt->addAction(g);
-			gf->addAction(g);
-		}
-		connect(gt, &QMenu::aboutToShow, this, [&]() { par = gt; });
-		connect(gf, &QMenu::aboutToShow, this, [&]() { par = gf; });
-
-		QMenu* et = menu.addMenu("is-previous-event-true");
-		QMenu* ef = menu.addMenu("is-previous-event-false");
-		for (auto& e : *evts) {
-			et->addAction(e);
-			ef->addAction(e);
-		}
-		connect(et, &QMenu::aboutToShow, this, [&]() { par = et; });
-		connect(ef, &QMenu::aboutToShow, this, [&]() { par = ef; });
-	}
-
-	const QAction* choice = menu.exec(ui->lstMissions->mapToGlobal(pos));
-
-	int res_branch{-1};
-	if (choice == to) {
-		res_branch = model->addCurMnBranchTo(&here);
-	} else if (choice == from) {
-		res_branch = model->addCurMnBranchTo(&here, true);
-	} else if (choice == end) {
-		res_branch = model->addCurMnBranchTo(end);
-	} else if (choice && par) {
-		res_branch = model->setCurBrCond(par->title(), *mnName, choice->text());
-	} // else menu was dismissed
-
-	if (res_branch != -1)
-		restoreBranchOpen(res_branch);
-}*/
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -659,6 +659,20 @@ void CampaignEditorDialog::on_graphView_createMissionAtAndConnectRequested(QPoin
 	updateAvailableMissionsList();
 }
 
+void CampaignEditorDialog::on_graphView_setFirstMissionRequested(int missionIndex)
+{
+	int current_selection = _model->getCurrentMissionSelection(); // save now because rebuild clears it
+	_model->setMissionAsFirst(missionIndex);
+	ui->graphView->rebuildAll();
+
+	if (current_selection = missionIndex) {
+		// If we changed the first mission, the selection index changed too
+		current_selection = 0;
+	}
+
+	ui->graphView->setSelectedMission(current_selection);
+}
+
 void CampaignEditorDialog::on_briefCutsceneComboBox_currentIndexChanged(const QString& arg1)
 {
 	_model->setCurrentMissionBriefingCutscene(arg1.toUtf8().constData());

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -131,6 +131,15 @@ CampaignEditorDialog::CampaignEditorDialog(QWidget* _parent, EditorViewport* _vi
 		ui->graphView->rebuildAll();
 	});
 
+	connect(ui->graphView, &CampaignMissionGraph::branchSelected, this, [this](int missionIdx, int branchId) {
+		// find branch by id in missionIdx and select in your forms/sexp_tree
+		if (auto* br = _model->findBranchById(missionIdx, branchId)) {
+			_model->setCurrentMissionSelection(missionIdx);
+			_model->setCurrentBranchSelection(0/* index of br in vector if you need */); // need a way to set by id maybe?
+			// expand formula in sexp_tree, etc.
+		}
+	});
+
 	initializeUi();
 	updateUi();
 

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -14,9 +14,9 @@
 
 namespace fso::fred::dialogs {
 
-CampaignEditorDialog::CampaignEditorDialog(QWidget* _parent, EditorViewport* _viewport)
-	: QMainWindow(_parent), SexpTreeEditorInterface({TreeFlags::LabeledRoot, TreeFlags::RootDeletable}),
-	  ui(new Ui::CampaignEditorDialog), _viewport(_viewport)
+CampaignEditorDialog::CampaignEditorDialog(QWidget* parent, EditorViewport* viewport)
+	: QMainWindow(parent), SexpTreeEditorInterface({TreeFlags::LabeledRoot, TreeFlags::RootDeletable}),
+	  ui(new Ui::CampaignEditorDialog), _viewport(viewport)
 {
 	ui->setupUi(this);
 
@@ -510,13 +510,13 @@ void CampaignEditorDialog::on_availableMissionsListWidget_itemSelectionChanged()
 		return;
 	}
 
-	if (mission_info.name) {
+	if (mission_info.name[0] != '\0') {
 		ui->missionNameLineEdit->setText(QString::fromUtf8(mission_info.name));
 	} else {
 		ui->missionNameLineEdit->clear();
 	}
 
-	if (mission_info.notes) {
+	if (mission_info.notes[0] != '\0') {
 		ui->missionDescriptionPlainTextEdit->setPlainText(QString::fromUtf8(mission_info.notes));
 	} else {
 		ui->missionDescriptionPlainTextEdit->clear();
@@ -665,7 +665,7 @@ void CampaignEditorDialog::on_graphView_setFirstMissionRequested(int missionInde
 	_model->setMissionAsFirst(missionIndex);
 	ui->graphView->rebuildAll();
 
-	if (current_selection = missionIndex) {
+	if (current_selection == missionIndex) {
 		// If we changed the first mission, the selection index changed too
 		current_selection = 0;
 	}

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -64,7 +64,7 @@ CampaignEditorDialog::CampaignEditorDialog(QWidget* _parent, EditorViewport* _vi
 					rootText = QStringLiteral("Branch to %1").arg(QString::fromStdString(branch.next_mission_name));
 				}
 
-				// For self-loops, use a special caption
+				// For selfloops, use a special caption
 				if (!branch.next_mission_name.empty() && branch.next_mission_name == currentMissionName) {
 					rootText = QStringLiteral("Repeat mission");
 				}
@@ -582,7 +582,7 @@ void CampaignEditorDialog::on_graphView_addMissionHereRequested(QPointF sceneTop
 	// add
 	_model->addMission(filename, 0, 0);
 
-	// New mission index is the last element now (or look it up by filename)
+	// New mission index is the last element now
 	const int idx = static_cast<int>(_model->getCampaignMissions().size() - 1);
 
 	// persist graph placement
@@ -613,7 +613,7 @@ void CampaignEditorDialog::on_graphView_addRepeatBranchRequested(int missionInde
 
 void CampaignEditorDialog::on_graphView_createMissionAtAndConnectRequested(QPointF sceneTopLeft, int fromIndex, bool isSpecial)
 {
-	// 1) Ask user via your available-missions listwidget
+	// Ask user via available missions dialog
 	QList<QString> availableMissions;
 	for (const auto& [name, isEditable] : _model->getAvailableMissionFiles()) {
 		availableMissions.append(QString::fromStdString(name));
@@ -631,25 +631,25 @@ void CampaignEditorDialog::on_graphView_createMissionAtAndConnectRequested(QPoin
 	if (picked.empty())
 		return; // user canceled
 
-	// 2) Add the mission to the model
+	// Add the mission to the model
 	_model->addMission(picked, /*level*/ 0, /*position*/ 0);
 
 	// New mission index (last)
 	const auto& ms = _model->getCampaignMissions();
 	const int newIdx = static_cast<int>(ms.size()) - 1;
 
-	// 3) Persist graph placement
+	// Persist graph placement
 	_model->setMissionGraphX(newIdx, static_cast<int>(std::lround(sceneTopLeft.x())));
 	_model->setMissionGraphY(newIdx, static_cast<int>(std::lround(sceneTopLeft.y())));
 
-	// 4) Connect from source to the new mission
+	// Connect from source to the new mission
 	if (isSpecial) {
 		_model->addSpecialBranch(fromIndex, newIdx);
 	} else {
 		_model->addBranch(fromIndex, newIdx);
 	}
 
-	// 5) Rebuild & focus new node
+	// Rebuild
 	ui->graphView->rebuildAll();
 	ui->graphView->setSelectedMission(newIdx);
 	updateAvailableMissionsList();

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -131,15 +131,6 @@ CampaignEditorDialog::CampaignEditorDialog(QWidget* _parent, EditorViewport* _vi
 		ui->graphView->rebuildAll();
 	});
 
-	connect(ui->graphView, &CampaignMissionGraph::branchSelected, this, [this](int missionIdx, int branchId) {
-		// find branch by id in missionIdx and select in your forms/sexp_tree
-		if (auto* br = _model->findBranchById(missionIdx, branchId)) {
-			_model->setCurrentMissionSelection(missionIdx);
-			_model->setCurrentBranchSelection(0/* index of br in vector if you need */); // need a way to set by id maybe?
-			// expand formula in sexp_tree, etc.
-		}
-	});
-
 	initializeUi();
 	updateUi();
 

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -561,7 +561,7 @@ void CampaignEditorDialog::on_graphView_addMissionHereRequested(QPointF sceneTop
 	const auto selections = ui->availableMissionsListWidget->selectedItems();
 	SCP_string filename;
 	// Only one item should be selected
-	if (selections.size() > 0) {
+	if (!selections.empty()) {
 		filename = selections[0]->text().toUtf8().constData();
 	}
 

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -235,15 +235,15 @@ void CampaignEditorDialog::updateAvailableMissionsList()
 
 	ui->availableMissionsListWidget->clear();
 
-	const QColor packagedColor(128, 128, 0); // dark yellow, matches your intent
+	const QColor packagedColor(128, 128, 0); // dark yellow
 
-	// model returns: SCP_vector<std::pair<SCP_string, bool>>
 	for (const auto& [name, isEditable] : _model->getAvailableMissionFiles()) {
 		auto* item = new QListWidgetItem(QString::fromStdString(name));
 		if (!isEditable) {
 			item->setForeground(packagedColor);
+			item->setToolTip("This mission is packaged in a VP and cannot be modified.");
 		}
-		item->setData(Qt::UserRole, isEditable); // stash it if you need it later
+		item->setData(Qt::UserRole, isEditable); // save whether it's editable
 		ui->availableMissionsListWidget->addItem(item);
 	}
 }

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -49,7 +49,7 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void on_graphView_missionSelected(int missionIndex);
 	void on_graphView_specialModeToggleRequested(int missionIndex);
 
-  private:
+  private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::CampaignEditorDialog> ui;
 	std::unique_ptr<ICampaignEditorTreeOps> _treeOps;
 	std::unique_ptr<CampaignEditorDialogModel> _model;

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -59,6 +59,9 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void on_mainhallComboBox_currentIndexChanged(const QString& arg1);
 	void on_substituteMainhallComboBox_currentIndexChanged(const QString& arg1);
 
+	void on_moveBranchUpButton_clicked();
+	void on_moveBranchDownButton_clicked();
+
 	void on_loopDescriptionPlainTextEdit_textChanged();
 	void on_loopAnimLineEdit_textChanged(const QString& arg1);
 	void on_loopVoiceLineEdit_textChanged(const QString& arg1);

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -44,6 +44,7 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void on_errorCheckerButton_clicked();
 
 	void on_availableMissionsFilterLineEdit_textChanged(const QString& arg1);
+	void on_availableMissionsListWidget_itemSelectionChanged();
 
   private:
 	std::unique_ptr<Ui::CampaignEditorDialog> ui;

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -43,8 +43,7 @@ namespace CampaignEditorUtil {
 	};
 } // namespace CampaignEditorUtil
 
-class CampaignEditorDialog : public QDialog
-{
+class CampaignEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	Q_OBJECT
 	static CampaignEditorUtil::WarningVec warnings;
 
@@ -58,7 +57,8 @@ public:
 
 private:
 	std::unique_ptr<Ui::CampaignEditorDialog> ui;
-	std::unique_ptr<CampaignEditorDialogModel> model;
+	std::unique_ptr<ICampaignEditorTreeOps> _treeOps;
+	std::unique_ptr<CampaignEditorDialogModel> _model;
 	// no graphical (tree chart) view implemented
 
 	/**
@@ -66,7 +66,6 @@ private:
 	 */
 	void setModel(CampaignEditorDialogModel *model = nullptr);
 
-	QWidget *const parent;
 	EditorViewport *const viewport;
 
 	/**

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -48,6 +48,10 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 
 	void on_graphView_missionSelected(int missionIndex);
 	void on_graphView_specialModeToggleRequested(int missionIndex);
+	void on_graphView_addMissionHereRequested(QPointF sceneTopLeft);
+	void on_graphView_deleteMissionRequested(int missionIndex);
+	void on_graphView_addRepeatBranchRequested(int missionIndex);
+	void on_graphView_createMissionAtAndConnectRequested(QPointF sceneTopLeft, int fromIndex, bool isSpecial);
 
   private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::CampaignEditorDialog> ui;

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QDialog>
+#include <QMainWindow>
 #include <QtWidgets/QMenuBar>
 #include <QListWidgetItem>
 #include <QTextDocument>
@@ -10,123 +10,51 @@
 #include "mission/dialogs/CampaignEditorDialogModel.h"
 #include "ui/widgets/sexp_tree.h"
 
-namespace fso {
-namespace fred {
-namespace dialogs {
+namespace fso::fred::dialogs {
 
 namespace Ui {
-	class CampaignEditorDialog;
+class CampaignEditorDialog;
 }
 
-class CampaignEditorDialogModel;
-
-namespace CampaignEditorUtil {
-	struct WarningMsg
-	{
-		QString title{};
-		QString msg{};
-		QString type{};
-
-		WarningMsg() = default;
-		WarningMsg(QString &&title, QString &&msg, QString &&type);
-	};
-	class WarningVec : public QObject, public QVector<WarningMsg>
-	{
-		Q_OBJECT
-	signals:
-		void gotMsg();
-	public:
-		inline void addMsg(WarningMsg &&msg){
-			append(msg);
-			gotMsg();
-		}
-	};
-} // namespace CampaignEditorUtil
-
-class CampaignEditorDialog : public QDialog, public SexpTreeEditorInterface {
+class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface {
 	Q_OBJECT
-	static CampaignEditorUtil::WarningVec warnings;
 
-public:
-	explicit CampaignEditorDialog(QWidget *parent, EditorViewport *viewport);
+  public:
+	explicit CampaignEditorDialog(QWidget* parent, EditorViewport* viewport);
 	~CampaignEditorDialog() override;
 
-	static inline void uiWarn(QString title, QString msg, QString type = ""){
-		warnings.addMsg(CampaignEditorUtil::WarningMsg{std::move(title), std::move(msg), std::move(type)});
-	}
+  protected:
+	void closeEvent(QCloseEvent* e) override; // funnel all Window X presses through reject()
 
-private:
+  private slots:
+	void on_actionNew_triggered();
+	void on_actionOpen_triggered();
+	void on_actionSave_triggered();
+	void on_actionSave_As_triggered();
+	void on_actionExit_triggered();
+
+	void on_nameLineEdit_textChanged(const QString& arg1);
+	void on_typeComboBox_currentIndexChanged(int index);
+	void on_resetTechAtStartCheckBox_toggled(bool checked);
+	void on_descriptionPlainTextEdit_textChanged();
+
+	void on_shipsListWidget_itemChanged(QListWidgetItem* item);
+	void on_weaponsListWidget_itemChanged(QListWidgetItem* item);
+
+	void on_errorCheckerButton_clicked();
+
+  private:
 	std::unique_ptr<Ui::CampaignEditorDialog> ui;
 	std::unique_ptr<ICampaignEditorTreeOps> _treeOps;
 	std::unique_ptr<CampaignEditorDialogModel> _model;
-	// no graphical (tree chart) view implemented
+	EditorViewport* const _viewport;
 
-	/**
-	 * @brief takes ownership of a model, sets the UI components to their submodels and connects to model slots
-	 */
-	void setModel(CampaignEditorDialogModel *model = nullptr);
+	void initializeUi();
+	void updateUi();
+	void updateTechLists();
+	void enableDisableControls();
 
-	EditorViewport *const viewport;
-
-	/**
-	 * @brief reopen branch in mission view after changes
-	 * @param branch the branch
-	 */
-	inline void restoreBranchOpen(int branch);
-
-	/**
-	 * @brief shows a save changes dialog (if any) and handles its results
-	 * @return whether it is safe to dismiss or replace the current model
-	 * @returns true if changes were successfully saved, discarded or no changes were made
-	 * @returns false if saving failed or was cancelled
-	 */
 	bool questionSaveChanges();
-        
-public slots:
-	/**
-	 * @brief onClose for dialogs. Checks for changes and prompts to save them.
-	 * @note Dialog will be deleted after closing
-	 */
-	void reject() override;
-
-	// these reset part or all of the view to the model
-	/**
-	 * @brief reset view for general/misc campaign data
-	 */
-	void updateUISpec();
-	/**
-	 * @brief reset view to current mission
-	 * @param updateBranch whether to also reset branch view to mission's first branch
-	 */
-	void updateUIMission(bool updateBranch = true);
-	/**
-	 * @brief reset view to a branch of current mission
-	 * @param idx which branch to display
-	 */
-	void updateUIBranch(int idx = -1);
-
-	inline void updateUIAll(){updateUISpec(); updateUIMission(); updateUIBranch();}
-
-private slots:
-	// handlers for file menu operations
-	void fileNew();
-	void fileOpen();
-	bool fileSave();
-	bool fileSaveAs();
-	void fileSaveCopyAs();
-
-	/**
-	 * @brief changes selection to the clicked mission list item
-	 * @param idx index of the item
-	 */
-	void lstMissionsClicked(const QModelIndex &idx);
-	/**
-	 * @brief opens a right-click menu on a mission list item for creating mission links
-	 * @param pos the clicked position
-	 */
-	void mnLinkMenu(const QPoint &pos);
 };
 
-} // namespace dialogs
-} // namespace fred
-} // namespace fso
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -43,6 +43,8 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 
 	void on_errorCheckerButton_clicked();
 
+	void on_availableMissionsFilterLineEdit_textChanged(const QString& arg1);
+
   private:
 	std::unique_ptr<Ui::CampaignEditorDialog> ui;
 	std::unique_ptr<ICampaignEditorTreeOps> _treeOps;

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -53,6 +53,7 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void on_graphView_deleteMissionRequested(int missionIndex);
 	void on_graphView_addRepeatBranchRequested(int missionIndex);
 	void on_graphView_createMissionAtAndConnectRequested(QPointF sceneTopLeft, int fromIndex, bool isSpecial);
+	void on_graphView_setFirstMissionRequested(int missionIndex);
 
 	void on_briefCutsceneComboBox_currentIndexChanged(const QString& arg1);
 	void on_debriefingPersonaSpinBox_valueChanged(int arg1);

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -52,6 +52,7 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void initializeUi();
 	void updateUi();
 	void updateTechLists();
+	void updateAvailableMissionsList();
 	void enableDisableControls();
 
 	bool questionSaveChanges();

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -46,6 +46,9 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void on_availableMissionsFilterLineEdit_textChanged(const QString& arg1);
 	void on_availableMissionsListWidget_itemSelectionChanged();
 
+	void on_graphView_missionSelected(int missionIndex);
+	void on_graphView_specialModeToggleRequested(int missionIndex);
+
   private:
 	std::unique_ptr<Ui::CampaignEditorDialog> ui;
 	std::unique_ptr<ICampaignEditorTreeOps> _treeOps;
@@ -56,6 +59,7 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void updateUi();
 	void updateTechLists();
 	void updateAvailableMissionsList();
+	void updateMissionDetails();
 	void enableDisableControls();
 
 	bool questionSaveChanges();

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -53,6 +53,20 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void on_graphView_addRepeatBranchRequested(int missionIndex);
 	void on_graphView_createMissionAtAndConnectRequested(QPointF sceneTopLeft, int fromIndex, bool isSpecial);
 
+	void on_briefCutsceneComboBox_currentIndexChanged(const QString& arg1);
+	void on_debriefingPersonaSpinBox_valueChanged(int arg1);
+	void on_mainhallComboBox_currentIndexChanged(const QString& arg1);
+	void on_substituteMainhallComboBox_currentIndexChanged(const QString& arg1);
+
+	void on_loopDescriptionPlainTextEdit_textChanged();
+	void on_loopAnimLineEdit_textChanged(const QString& arg1);
+	void on_loopVoiceLineEdit_textChanged(const QString& arg1);
+	void on_loopAnimBrowseButton_clicked();
+	void on_loopVoiceBrowseButton_clicked();
+	void on_testVoiceButton_clicked();
+
+	void on_retailFormatCheckbox_toggled(bool checked);
+
   private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::CampaignEditorDialog> ui;
 	std::unique_ptr<ICampaignEditorTreeOps> _treeOps;
@@ -64,6 +78,7 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void updateTechLists();
 	void updateAvailableMissionsList();
 	void updateMissionDetails();
+	void updateLoopDetails();
 	void enableDisableControls();
 
 	bool questionSaveChanges();

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -36,6 +36,7 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void on_nameLineEdit_textChanged(const QString& arg1);
 	void on_typeComboBox_currentIndexChanged(int index);
 	void on_resetTechAtStartCheckBox_toggled(bool checked);
+	void on_campaignCustomDataButton_clicked();
 	void on_descriptionPlainTextEdit_textChanged();
 
 	void on_shipsListWidget_itemChanged(QListWidgetItem* item);

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.cpp
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.cpp
@@ -1176,6 +1176,7 @@ void CampaignMissionGraph::contextMenuEvent(QContextMenuEvent* e)
 		const int idx = n->missionIndex();
 
 		QMenu menu(this);
+		QAction* actSetFirst = menu.addAction(tr("Set as First Mission"));
 		QAction* actDelete = menu.addAction(tr("Delete mission"));
 		QAction* actRepeat = menu.addAction(tr("Add Repeat Mission"));
 
@@ -1183,12 +1184,20 @@ void CampaignMissionGraph::contextMenuEvent(QContextMenuEvent* e)
 		const bool canAddRepeat = !hasRepeatBranch(idx);
 		actRepeat->setEnabled(canAddRepeat);
 
+		// Disable "Set as First Mission" if already first
+		actSetFirst->setEnabled(!(idx == 0));
+
 		QAction* chosen = menu.exec(e->globalPos());
 		if (!chosen) {
 			e->ignore();
 			return;
 		}
 
+		if (chosen == actSetFirst) {
+			Q_EMIT setFirstMissionRequested(idx);
+			e->accept();
+			return;
+		}
 		if (chosen == actDelete) {
 			Q_EMIT deleteMissionRequested(idx);
 			e->accept();

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.cpp
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.cpp
@@ -1,0 +1,382 @@
+#include "ui/widgets/campaignmissiongraph.h"
+
+#include "mission/dialogs/CampaignEditorDialogModel.h"
+
+#include <QGraphicsScene>
+#include <QGraphicsSceneMouseEvent>
+#include <QPainter>
+#include <QStyleOptionGraphicsItem>
+#include <QWheelEvent>
+#include <QtMath>
+
+using detail::MissionNodeItem;
+using detail::SpecialMode;
+using fso::fred::dialogs::CampaignEditorDialogModel;
+
+// ----------------------------
+// MissionNodeItem definitions
+// ----------------------------
+
+MissionNodeItem::MissionNodeItem(int missionIndex,
+	const QString& fileLabel,
+	const QString& nameLabel,
+	int graphColorRgb,
+	SpecialMode mode,
+	int mainBranchCount,
+	int specialBranchCount,
+	const CampaignGraphStyle& style,
+	QGraphicsItem* parent)
+	: QGraphicsObject(parent), m_idx(missionIndex), m_file(fileLabel), m_name(nameLabel), m_graphColor(graphColorRgb),
+	  m_mode(mode), m_mainCount(mainBranchCount), m_specCount(specialBranchCount), m_style(style)
+{
+	setFlags(ItemIsSelectable | ItemSendsScenePositionChanges);
+	setAcceptHoverEvents(true);
+	setCursor(Qt::PointingHandCursor);
+	updateGeometry();
+}
+
+QRectF MissionNodeItem::boundingRect() const
+{
+	return m_rect.adjusted(-1, -1, 1, 1);
+}
+
+static inline QPainterPath roundedRectPath(const QRectF& r, qreal rad)
+{
+	QPainterPath path;
+	path.addRoundedRect(r, rad, rad);
+	return path;
+}
+
+void MissionNodeItem::paint(QPainter* p, const QStyleOptionGraphicsItem*, QWidget*)
+{
+	p->setRenderHint(QPainter::Antialiasing, true);
+
+	// Precompute geometry
+	const qreal borderW = isSelected() ? 2.0 : 1.0;
+	const QPen borderPen(m_style.nodeBorder, borderW, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+
+	const qreal topNubY = m_rect.top();       // center exactly on edge -> half visible
+	const qreal bottomNubY = m_rect.bottom(); // center exactly on edge -> half visible
+	const qreal centerX = m_rect.center().x();
+	const QPointF inboundNub(centerX, topNubY);
+	const QPointF mainNub(centerX - m_style.nubOffsetX, bottomNubY);
+	const QPointF specNub(centerX + m_style.nubOffsetX, bottomNubY);
+
+	// --- 1) NUBS FIRST (under the card so only half shows) ---
+	p->setPen(borderPen);
+
+	// Top inbound (green)
+	p->setBrush(m_style.inboundGreen);
+	p->drawEllipse(inboundNub, m_style.nubRadius, m_style.nubRadius);
+
+	// Bottom main (blue)
+	p->setBrush(m_style.mainBlue);
+	p->drawEllipse(mainNub, m_style.nubRadius, m_style.nubRadius);
+
+	// Bottom special (loop/fork color)
+	const QColor specColor = (m_mode == SpecialMode::Loop) ? m_style.loopOrange : m_style.forkPurple;
+	p->setBrush(specColor);
+	p->drawEllipse(specNub, m_style.nubRadius, m_style.nubRadius);
+
+	// --- 2) CARD ON TOP (covers inner halves of the nubs) ---
+	p->setPen(borderPen);
+	p->setBrush(m_style.nodeFill);
+	p->drawPath(roundedRectPath(m_rect, m_style.nodeRadius));
+
+	// 3) User color stripe (on top of card)
+	if (m_graphColor >= 0) {
+		const QColor stripe((m_graphColor >> 16) & 0xFF, (m_graphColor >> 8) & 0xFF, (m_graphColor) & 0xFF);
+		p->fillRect(
+			QRectF(m_rect.left(), m_rect.top() + m_style.padding + m_titleH, m_rect.width(), m_style.stripeHeight),
+			stripe);
+	}
+
+	// 4) Badge (icon pill) in header; disabled if special branches exist
+	const bool badgeDisabled = (m_specCount > 0);
+	const QRectF badgeRect(m_rect.right() - m_style.badgePad - m_style.badgeSize.width(),
+		m_rect.top() + m_style.badgePad,
+		m_style.badgeSize.width(),
+		m_style.badgeSize.height());
+	m_badgeRect = badgeRect;
+
+	QColor badgeCol = (m_mode == SpecialMode::Loop) ? m_style.loopOrange : m_style.forkPurple;
+	if (badgeDisabled)
+		badgeCol = m_style.badgeDisabled;
+
+	p->setBrush(badgeCol);
+	p->setPen(Qt::NoPen);
+	p->drawRoundedRect(badgeRect, badgeRect.height() / 2.0, badgeRect.height() / 2.0);
+
+	// Icon placeholder (swap for your QIcon later)
+	p->setPen(QPen(Qt::white, 2));
+	if (m_mode == SpecialMode::Loop) {
+		const QRectF arcRect = badgeRect.adjusted(4, 2, -4, -2);
+		p->drawArc(arcRect, 45 * 16, 270 * 16);
+		p->drawLine(QPointF(arcRect.center().x(), arcRect.top() + 2),
+			QPointF(arcRect.center().x() + 5, arcRect.top() + 6));
+	} else {
+		const QPointF c = badgeRect.center();
+		p->drawLine(QPointF(c.x(), badgeRect.top() + 3), QPointF(c.x(), badgeRect.bottom() - 3));
+		p->drawLine(QPointF(c.x(), badgeRect.top() + 3), QPointF(c.x() - 6, badgeRect.top() + 8));
+		p->drawLine(QPointF(c.x(), badgeRect.top() + 3), QPointF(c.x() + 6, badgeRect.top() + 8));
+	}
+
+	// 5) Text: filename (top) and mission name (below stripe)
+	p->setPen(Qt::black);
+	QFont f = p->font();
+	// filename (smaller)
+	f.setPointSizeF(f.pointSizeF() - 1);
+	p->setFont(f);
+	const QRectF fileRect = QRectF(m_rect.left() + m_style.padding,
+		m_rect.top() + m_style.padding,
+		m_rect.width() - 2 * m_style.padding - m_style.badgeSize.width() - m_style.badgePad * 2,
+		m_titleH);
+	p->drawText(fileRect, Qt::AlignVCenter | Qt::AlignLeft | Qt::TextSingleLine, m_file);
+
+	// mission name (bold)
+	QFont f2 = p->font();
+	f2.setPointSizeF(f.pointSizeF() + 2);
+	f2.setBold(true);
+	p->setFont(f2);
+
+	const qreal nameTop = fileRect.bottom() + m_style.stripeHeight + m_style.padding;
+	const QRectF nameRect(m_rect.left() + m_style.padding, nameTop, m_rect.width() - 2 * m_style.padding, m_nameH);
+	const QString nameToDraw = (m_name.isEmpty() || m_name == m_file) ? m_file : m_name;
+	p->drawText(nameRect, Qt::AlignTop | Qt::AlignLeft | Qt::TextWordWrap, nameToDraw);
+}
+
+void MissionNodeItem::mousePressEvent(QGraphicsSceneMouseEvent* e)
+{
+	if (m_badgeRect.contains(e->pos())) {
+		if (m_specCount == 0) {
+			Q_EMIT specialModeToggleRequested(m_idx);
+			e->accept();
+			return;
+		}
+	}
+	QGraphicsObject::mousePressEvent(e);
+}
+
+void MissionNodeItem::mouseReleaseEvent(QGraphicsSceneMouseEvent* e)
+{
+	if (e->button() == Qt::LeftButton) {
+		Q_EMIT missionSelected(m_idx);
+	}
+	QGraphicsObject::mouseReleaseEvent(e);
+}
+
+void MissionNodeItem::updateGeometry()
+{
+	m_titleH = 18.0;
+	m_nameH = 24.0;
+	m_rect = QRectF(0, 0, 240.0, 120.0); // sync with CampaignGraphStyle defaults
+}
+
+QPointF MissionNodeItem::inboundNubScenePos() const
+{
+	// Center right on the top edge; only outer half visible
+	return mapToScene(QPointF(m_rect.center().x(), m_rect.top()));
+}
+
+QPointF MissionNodeItem::mainNubScenePos() const
+{
+	// Center right on the bottom edge; only outer half visible
+	return mapToScene(QPointF(m_rect.center().x() - m_style.nubOffsetX, m_rect.bottom()));
+}
+
+QPointF MissionNodeItem::specialNubScenePos() const
+{
+	// Center right on the bottom edge; only outer half visible
+	return mapToScene(QPointF(m_rect.center().x() + m_style.nubOffsetX, m_rect.bottom()));
+}
+
+// ----------------------------
+// CampaignMissionGraph impl
+// ----------------------------
+
+CampaignMissionGraph::CampaignMissionGraph(QWidget* parent) : QGraphicsView(parent)
+{
+	initScene();
+
+	// View behavior
+	setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
+	setViewportUpdateMode(QGraphicsView::BoundingRectViewportUpdate);
+	setDragMode(QGraphicsView::ScrollHandDrag);
+	setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
+	setBackgroundBrush(m_style.bgColor);
+	setFrameShape(QFrame::NoFrame); // optional
+}
+
+void CampaignMissionGraph::initScene()
+{
+	m_scene = new QGraphicsScene(this);
+	setScene(m_scene);
+	m_scene->setSceneRect(QRectF(-4000, -4000, 8000, 8000));
+}
+
+void CampaignMissionGraph::setModel(CampaignEditorDialogModel* model)
+{
+	m_model = model;
+	rebuildAll();
+}
+
+void CampaignMissionGraph::rebuildAll()
+{
+	if (!m_scene)
+		return;
+	m_scene->clear();
+	if (!m_model)
+		return;
+
+	buildMissionNodes();
+}
+
+static detail::SpecialMode deriveMode(const CampaignEditorDialogModel& model, int missionIdx)
+{
+	const auto& missions = model.getCampaignMissions();
+	if (missionIdx < 0 || missionIdx >= (int)missions.size())
+		return detail::SpecialMode::Loop;
+	const auto& m = missions[missionIdx];
+	bool anyLoop = false, anyFork = false;
+	for (const auto& b : m.branches) {
+		anyLoop |= b.is_loop;
+		anyFork |= b.is_fork;
+	}
+	if (anyLoop)
+		return detail::SpecialMode::Loop;
+	if (anyFork)
+		return detail::SpecialMode::Fork;
+	return detail::SpecialMode::Loop; // default when none exist
+}
+
+void CampaignMissionGraph::buildMissionNodes()
+{
+	const auto& missions = m_model->getCampaignMissions();
+	const QPointF fallbackStep(240, 160);
+
+	for (int i = 0; i < (int)missions.size(); ++i) {
+		const auto& m = missions[i];
+
+		// Position
+		QPointF pos;
+		if (m.graph_x != INT_MIN && m.graph_y != INT_MIN) {
+			pos = QPointF(m.graph_x, m.graph_y);
+		} else {
+			pos = QPointF(m.position * fallbackStep.x(), m.level * fallbackStep.y());
+		}
+
+		// Branch counts & special mode
+		int mainCount = 0, specCount = 0;
+		for (const auto& b : m.branches) {
+			(b.is_loop || b.is_fork) ? ++specCount : ++mainCount;
+		}
+		const auto mode = deriveMode(*m_model, i);
+
+		// Labels (filename as primary for now)
+		const QString fileLabel = QString::fromStdString(m.name);
+		const QString nameLabel; // optional mission title later
+
+		auto* item = new MissionNodeItem(i, fileLabel, nameLabel, m.graph_color, mode, mainCount, specCount, m_style);
+		item->setPos(pos);
+		item->setZValue(10);
+
+		connect(item, &MissionNodeItem::missionSelected, this, &CampaignMissionGraph::missionSelected);
+		connect(item,
+			&MissionNodeItem::specialModeToggleRequested,
+			this,
+			&CampaignMissionGraph::specialModeToggleRequested);
+
+		m_scene->addItem(item);
+	}
+}
+
+void CampaignMissionGraph::zoomToFitAll(qreal margin)
+{
+	if (!m_scene || m_scene->items().isEmpty())
+		return;
+	const QRectF itemsRect = m_scene->itemsBoundingRect().adjusted(-margin, -margin, margin, margin);
+	if (!itemsRect.isEmpty()) {
+		fitInView(itemsRect, Qt::KeepAspectRatio);
+		m_currentScale = transform().m11();
+	}
+}
+
+void CampaignMissionGraph::setGridVisible(bool on)
+{
+	if (m_gridVisible == on)
+		return;
+	m_gridVisible = on;
+	viewport()->update();
+}
+
+void CampaignMissionGraph::wheelEvent(QWheelEvent* e)
+{
+	if (!m_zoomEnabled) {
+		QGraphicsView::wheelEvent(e);
+		return;
+	}
+	const QPoint numDeg = e->angleDelta();
+	if (numDeg.isNull()) {
+		e->ignore();
+		return;
+	}
+
+	const qreal step = (numDeg.y() > 0) ? 1.10 : (1.0 / 1.10);
+	const qreal next = qBound(kMinScale, m_currentScale * step, kMaxScale);
+	const qreal factor = next / m_currentScale;
+
+	if (!qFuzzyCompare(factor, 1.0)) {
+		scale(factor, factor);
+		m_currentScale = next;
+	}
+	e->accept();
+}
+
+void CampaignMissionGraph::drawBackground(QPainter* p, const QRectF& rect)
+{
+	Q_UNUSED(rect);
+	if (!m_gridVisible)
+		return;
+
+	p->save();
+	p->setRenderHint(QPainter::Antialiasing, false);
+
+	// Fill bg (in case view brush is transparent)
+	p->fillRect(this->rect(), m_style.bgColor);
+
+	drawGrid(p, mapToScene(this->rect()).boundingRect());
+
+	p->restore();
+}
+
+void CampaignMissionGraph::drawGrid(QPainter* p, const QRectF& sceneRect)
+{
+	const qreal minor = m_style.minorStep;
+	const qreal major = minor * m_style.majorEvery;
+
+	// Align to grid
+	const qreal left = std::floor(sceneRect.left() / minor) * minor;
+	const qreal right = std::ceil(sceneRect.right() / minor) * minor;
+	const qreal top = std::floor(sceneRect.top() / minor) * minor;
+	const qreal bottom = std::ceil(sceneRect.bottom() / minor) * minor;
+
+	QPen penMinor(m_style.gridMinor);
+	penMinor.setCosmetic(true);
+
+	QPen penMajor(m_style.gridMajor);
+	penMajor.setCosmetic(true);
+	penMajor.setWidthF(1.2);
+
+	// Vertical
+	for (qreal x = left; x <= right; x += minor) {
+		const bool isMajor = qFuzzyIsNull(std::fmod(std::abs(x), major));
+		p->setPen(isMajor ? penMajor : penMinor);
+		p->drawLine(QPointF(x, top), QPointF(x, bottom));
+	}
+	// Horizontal
+	for (qreal y = top; y <= bottom; y += minor) {
+		const bool isMajor = qFuzzyIsNull(std::fmod(std::abs(y), major));
+		p->setPen(isMajor ? penMajor : penMinor);
+		p->drawLine(QPointF(left, y), QPointF(right, y));
+	}
+}

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.cpp
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.cpp
@@ -620,10 +620,10 @@ void CampaignMissionGraph::updateSceneRectToContent(bool scrollToTopLeft)
 void CampaignMissionGraph::setModel(CampaignEditorDialogModel* model)
 {
 	m_model = model;
-	rebuildAll();
+	rebuildAll(true);
 }
 
-void CampaignMissionGraph::rebuildAll()
+void CampaignMissionGraph::rebuildAll(bool refocus)
 {
 	if (!m_scene)
 		return;
@@ -644,7 +644,7 @@ void CampaignMissionGraph::rebuildAll()
 
 	if (!m_model) {
 		// Even with no model, give a small usable scene area
-		updateSceneRectToContent(true);
+		updateSceneRectToContent(refocus);
 		return;
 	}
 
@@ -652,12 +652,12 @@ void CampaignMissionGraph::rebuildAll()
 	buildMissionEdges();
 
 	// Size scene to the items and put the view at the top-left
-	updateSceneRectToContent(true);
+	updateSceneRectToContent(refocus);
 
 	applyFocusEmphasis();
 }
 
-void CampaignMissionGraph::setSelectedMission(int missionIndex, bool makeVisible, bool centerOnItem, bool emitSignal)
+void CampaignMissionGraph::setSelectedMission(int missionIndex, bool makeVisible, bool centerOnItem)
 {
 	if (!m_scene)
 		return;
@@ -690,9 +690,7 @@ void CampaignMissionGraph::setSelectedMission(int missionIndex, bool makeVisible
 	applyFocusEmphasis();
 
 	// send the user-selection signal for listeners
-	if (emitSignal) {
-		Q_EMIT missionSelected(missionIndex);
-	}
+	Q_EMIT missionSelected(missionIndex);
 }
 
 void CampaignMissionGraph::clearSelectedMission()
@@ -753,7 +751,7 @@ void CampaignMissionGraph::buildMissionNodes()
 			&CampaignMissionGraph::specialModeToggleRequested);
 		connect(item, &MissionNodeItem::nodeMoved, this, &CampaignMissionGraph::onNodeMoved);
 		connect(item, &detail::MissionNodeItem::missionSelected, this, [this](int idx) {
-			setSelectedMission(idx, /*makeVisible=*/true, /*centerOnItem=*/false, /*emitSignal=*/true);
+			setSelectedMission(idx, /*makeVisible=*/true, /*centerOnItem=*/false);
 		});
 
 		m_scene->addItem(item);

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.cpp
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.cpp
@@ -1,4 +1,4 @@
-#include "ui/widgets/campaignmissiongraph.h"
+#include "ui/widgets/CampaignMissionGraph.h"
 
 #include "mission/missionparse.h"
 

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -72,7 +72,7 @@ struct CampaignGraphStyle {
 	// Edge routing
 	qreal fanoutStart{12.0}; // vertical run from port before spreading
 	qreal fanoutStep{10.0};  // horizontal separation between sibling edges
-	qreal edgeWidth{3.0};
+	qreal edgeWidth{2.0};
 	qreal arrowSize{8.0}; // arrowhead size
 	qreal arrowTargetInset{10.0};
 	qreal arrowInterval{100.0}; // place an arrow every N px along straight segments

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -42,6 +42,8 @@ struct CampaignGraphStyle {
 	qreal nodeRadius{8.0};
 	QSizeF nodeSize{240.0, 120.0}; // base size; can grow later
 	qreal padding{8.0};
+	qreal layoutStepX{240.0}; // default horizontal spacing for fallback layout
+	qreal layoutStepY{200.0}; // default vertical   spacing for fallback layout
 
 	// Stripe (user color)
 	qreal stripeHeight{10.0};
@@ -54,6 +56,15 @@ struct CampaignGraphStyle {
 	qreal nubRadius{6.0};
 	qreal nubSpacingBottom{6.0}; // retained for future
 	qreal nubOffsetX{42.0};
+	bool inboundApproachEnabled{true}; // add a small jog near the inbound nub
+	qreal inboundApproachJog{30.0};    // horizontal jog distance before the final vertical
+	qreal inboundApproachRise{30.0};   // vertical distance above inbound nub
+	bool outboundApproachEnabled{true}; // add a small jog right after the source nub
+	bool outboundDirectionTowardTarget{true}; // if true, outbound jog heads toward dst.x()
+	qreal outboundJogMain{30.0};              // X jog right after source for MAIN
+	qreal outboundJogSpecial{30.0};           // X jog right after source for SPECIAL
+	qreal outboundDropMain{30.0};             // Y drop right after source for MAIN
+	qreal outboundDropSpecial{40.0};          // Y drop right after source for SPECIAL (often a bit larger)
 
 	// Edge routing
 	qreal fanoutStart{12.0}; // vertical run from nub before spreading
@@ -129,13 +140,17 @@ class CampaignMissionGraph final : public QGraphicsView {
 	// Grid background
 	void drawBackground(QPainter* painter, const QRectF& rect) override;
 
-  private:
+  private slots:
+	void onNodeMoved(int missionIndex, QPointF sceneTopLeft);
+
+  private: // NOLINT(readability-redundant-access-specifiers)
 	void initScene();
 	void updateSceneRectToContent(bool scrollToTopLeft);
 	void drawGrid(QPainter* p, const QRectF& rect);
 	void buildMissionNodes();
 	void buildMissionEdges();
 	void ensureEndSink();
+	void rebuildEdgesOnly();
 
 	QGraphicsScene* m_scene{nullptr}; // owned by view (parented)
 	QPointer<fso::fred::dialogs::CampaignEditorDialogModel> m_model;
@@ -188,10 +203,12 @@ class MissionNodeItem final : public QGraphicsObject {
   signals:
 	void missionSelected(int missionIndex);
 	void specialModeToggleRequested(int missionIndex);
+	void nodeMoved(int missionIndex, QPointF sceneTopLeft);
 
   protected:
 	void mousePressEvent(QGraphicsSceneMouseEvent* e) override;
 	void mouseReleaseEvent(QGraphicsSceneMouseEvent* e) override;
+	QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
 
   private:
 	void updateGeometry();

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -1,1 +1,180 @@
 #pragma once
+
+#include <QGraphicsObject>
+#include <QGraphicsView>
+#include <QPointer>
+
+// Forward declaration to avoid coupling for now
+namespace fso::fred::dialogs {
+class CampaignEditorDialogModel;
+} // namespace fso::fred::dialogs
+
+class QGraphicsScene;
+
+/**
+ * Visual style knobs for the graph. Kept public so both the graph and items use the same values.
+ */
+struct CampaignGraphStyle {
+	// Background & grid
+	QColor bgColor{245, 245, 245};
+	QColor gridMinor{230, 230, 230};
+	QColor gridMajor{210, 210, 210};
+	qreal minorStep{32.0};
+	qreal majorEvery{4.0};
+
+	// Node card
+	QColor nodeFill{230, 230, 230}; // Qt grey
+	QColor nodeBorder{20, 20, 20};
+	qreal nodeRadius{8.0};
+	QSizeF nodeSize{240.0, 120.0}; // base size; can grow later
+	qreal padding{8.0};
+
+	// Stripe (user color)
+	qreal stripeHeight{10.0};
+
+	// Ports (nubs)
+	QColor inboundGreen{46, 204, 113}; // top nub (inbound)
+	QColor mainBlue{52, 152, 219};     // main out nub
+	QColor loopOrange{243, 156, 18};   // special out nub when LOOP
+	QColor forkPurple{155, 89, 182};   // special out nub when FORK
+	qreal nubRadius{6.0};
+	qreal nubOffsetX{42.0};      // +/- from node center to place the two bottom nubs
+
+	// Future edge fan-out (used by edges later)
+	qreal fanoutStart{12.0}; // vertical run from nub before spreading
+	qreal fanoutStep{10.0};  // horizontal separation between sibling edges
+
+	// Badge
+	qreal badgePad{6.0};
+	QSizeF badgeSize{34.0, 18.0}; // pill
+	QColor badgeDisabled{180, 180, 180};
+};
+
+/**
+ * @brief Canvas for the campaign mission graph.
+ *
+ * v1 renders mission nodes (no edges yet), supports pan/zoom,
+ * and exposes signals for node selection & special-mode badge toggling.
+ */
+class CampaignMissionGraph final : public QGraphicsView {
+	Q_OBJECT
+  public:
+	explicit CampaignMissionGraph(QWidget* parent = nullptr);
+
+	// Hook up the working campaign data (read-only from the view)
+	void setModel(fso::fred::dialogs::CampaignEditorDialogModel* model);
+
+	// Rebuild/redraw the entire scene from the model
+	void rebuildAll();
+
+	// View helpers
+	void zoomToFitAll(qreal margin = 40.0);
+	void setGridVisible(bool on);
+	bool isGridVisible() const
+	{
+		return m_gridVisible;
+	}
+	void setZoomEnabled(bool on)
+	{
+		m_zoomEnabled = on;
+	}
+
+  signals:
+	// Emitted when a mission node is clicked/selected
+	void missionSelected(int missionIndex);
+	// Emitted when the LOOP/FORK badge is clicked (only when no special branches exist)
+	void specialModeToggleRequested(int missionIndex); // caller toggles in model
+
+  protected:
+	// Pan/zoom
+	void wheelEvent(QWheelEvent* e) override;
+	// Grid background
+	void drawBackground(QPainter* painter, const QRectF& rect) override;
+
+  private:
+	void initScene();
+	void drawGrid(QPainter* p, const QRectF& rect);
+	void buildMissionNodes();
+
+  private:
+	QGraphicsScene* m_scene{nullptr}; // owned by view (parented)
+	QPointer<fso::fred::dialogs::CampaignEditorDialogModel> m_model;
+
+	// Centralized visuals
+	CampaignGraphStyle m_style;
+
+	bool m_gridVisible{true};
+	bool m_zoomEnabled{true};
+	qreal m_currentScale{1.0};
+	const qreal kMinScale{0.2};
+	const qreal kMaxScale{3.0};
+};
+
+// ---------- Internal item that lives only with this widget (Q_OBJECT in header so AUTOMOC runs) ----------
+
+namespace detail {
+
+enum class SpecialMode {
+	Loop,
+	Fork
+};
+
+/**
+ * One mission node item:
+ * - rounded rect, filename/mission labels, user color stripe
+ * - top inbound nub (green)
+ * - two bottom outbound nubs: main (blue) and special (orange/purple)
+ * - clickable badge to toggle LOOP/FORK when unlocked (no special branches yet)
+ *
+ * Exposes nub positions (scene coords) for anchoring edges later.
+ */
+class MissionNodeItem final : public QGraphicsObject {
+	Q_OBJECT
+  public:
+	MissionNodeItem(int missionIndex,
+		const QString& fileLabel,
+		const QString& nameLabel,
+		int graphColorRgb, // -1 = none else 0xRRGGBB
+		SpecialMode mode,
+		int mainBranchCount,
+		int specialBranchCount,
+		const CampaignGraphStyle& style,
+		QGraphicsItem* parent = nullptr);
+
+	QRectF boundingRect() const override;
+	void paint(QPainter* p, const QStyleOptionGraphicsItem* opt, QWidget* w) override;
+
+	// Nub anchor points (scene coordinates), for edges later
+	QPointF inboundNubScenePos() const;
+	QPointF mainNubScenePos() const;
+	QPointF specialNubScenePos() const;
+
+  signals:
+	void missionSelected(int missionIndex);
+	void specialModeToggleRequested(int missionIndex);
+
+  protected:
+	void mousePressEvent(QGraphicsSceneMouseEvent* e) override;
+	void mouseReleaseEvent(QGraphicsSceneMouseEvent* e) override;
+
+  private:
+	void updateGeometry();
+
+  private:
+	int m_idx{-1};
+	QString m_file;
+	QString m_name;
+	int m_graphColor{-1};
+	SpecialMode m_mode{SpecialMode::Loop};
+	int m_mainCount{0};
+	int m_specCount{0};
+
+	const CampaignGraphStyle& m_style;
+
+	QRectF m_rect;
+	QRectF m_badgeRect;
+	qreal m_titleH{18.0};
+	qreal m_nameH{24.0};
+};
+
+} // namespace detail

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -30,7 +30,7 @@ class EndSinkItem;
  */
 struct CampaignGraphStyle {
 	// Global
-	bool forksEnabled{false}; // if true, FORK special branches are allowed (else only LOOP)
+	bool forksEnabled{false}; // if true, FORK special branches are allowed. Disabled for now since the feature is incomplete.
 
 	// Background & grid
 	QColor bgColor{245, 245, 245};
@@ -43,21 +43,20 @@ struct CampaignGraphStyle {
 	QColor nodeFill{230, 230, 230}; // Qt grey
 	QColor nodeBorder{20, 20, 20};
 	qreal nodeRadius{8.0};
-	QSizeF nodeSize{240.0, 120.0}; // base size; can grow later
+	QSizeF nodeSize{240.0, 120.0}; // base size
 	qreal padding{8.0};
-	qreal layoutStepX{240.0}; // default horizontal spacing for fallback layout
-	qreal layoutStepY{200.0}; // default vertical   spacing for fallback layout
+	qreal layoutStepX{240.0}; // default horizontal spacing for fallback layout from position/level
+	qreal layoutStepY{200.0}; // default vertical   spacing for fallback layout from position/level
 
-	// Stripe (user color)
+	// User color stripe
 	qreal stripeHeight{10.0};
 
 	// Ports
-	QColor inboundGreen{46, 204, 113}; // top port (inbound)
+	QColor inboundGreen{46, 204, 113}; // top port
 	QColor mainBlue{52, 152, 219};     // main out port
 	QColor loopOrange{243, 156, 18};   // special out port when LOOP
 	QColor forkPurple{155, 89, 182};   // special out port when FORK
 	qreal portRadius{6.0};
-	qreal portSpacingBottom{6.0}; // retained for future
 	qreal portOffsetX{42.0};
 	bool inboundApproachEnabled{true}; // add a small jog near the inbound port
 	qreal inboundApproachJog{30.0};    // horizontal jog distance before the final vertical
@@ -68,7 +67,7 @@ struct CampaignGraphStyle {
 	qreal outboundJogSpecial{30.0};           // X jog right after source for SPECIAL
 	qreal outboundDropMain{30.0};             // Y drop right after source for MAIN
 	qreal outboundDropSpecial{40.0};          // Y drop right after source for SPECIAL (often a bit larger)
-	qreal portHitExtra{20.0};                   // extra pixels added to port radius for hit-testing
+	qreal portHitExtra{30.0};                 // extra pixels added to port radius for hit-testing
 
 	// Edge routing
 	qreal fanoutStart{12.0}; // vertical run from port before spreading
@@ -79,13 +78,13 @@ struct CampaignGraphStyle {
 	qreal arrowInterval{100.0}; // place an arrow every N px along straight segments
 
 	// Self-loop display
-	bool showSelfLoops{false};
+	bool showSelfLoops{false};  // if true, self-loops are drawn with edges. Disabled because it clutters the view.
 	qreal selfLoopMargin{32.0}; // how far outside the node to wrap
 	qreal selfLoopSpread{10.0}; // per-sibling additional spacing
 
 	// Badge
-	qreal badgePad{6.0};
-	QSizeF badgeSize{34.0, 18.0}; // pill
+	qreal badgePad{6.0}; // Used to toggle between LOOP or FORK
+	QSizeF badgeSize{34.0, 18.0}; // pill size
 	QColor badgeDisabled{180, 180, 180};
 
 	// END sink visuals/placement

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -185,7 +185,7 @@ class CampaignMissionGraph final : public QGraphicsView {
 
 	void initScene();
 	void updateSceneRectToContent(bool scrollToTopLeft);
-	void drawGrid(QPainter* p, const QRectF& rect);
+	void drawGrid(QPainter* p, const QRectF& rect) const;
 	void buildMissionNodes();
 	void buildMissionEdges();
 	void ensureEndSink();
@@ -235,13 +235,13 @@ class MissionNodeItem final : public QGraphicsObject {
 	Q_OBJECT
   public:
 	MissionNodeItem(int missionIndex,
-		const QString& fileLabel,
-		const QString& nameLabel,
+		QString fileLabel,
+		QString nameLabel,
 		int graphColorRgb, // -1 = none else 0xRRGGBB
 		CampaignSpecialMode mode,
 		int mainBranchCount,
 		int specialBranchCount,
-		const CampaignGraphStyle& style,
+		CampaignGraphStyle style,
 		QGraphicsItem* parent = nullptr);
 
 	QRectF boundingRect() const override;
@@ -280,7 +280,6 @@ class MissionNodeItem final : public QGraphicsObject {
   private:
 	void updateGeometry();
 
-  private:
 	int m_idx{-1};
 	QString m_file;
 	QString m_name;
@@ -308,7 +307,7 @@ class EdgeItem final : public QObject, public QGraphicsPathItem {
 		int branchId,
 		bool isSpecial,
 		CampaignSpecialMode mode,
-		const CampaignGraphStyle& style,
+		CampaignGraphStyle style,
 		QGraphicsItem* parent = nullptr);
 
 	// Standard edge
@@ -338,7 +337,6 @@ class EdgeItem final : public QObject, public QGraphicsPathItem {
 	QPainterPath
 	buildSelfLoopPath(const QRectF& nodeRectScene, bool sourceIsRightSide, int siblingIndex, int siblingCount);
 
-  private:
 	int m_missionIndex{-1};
 	int m_branchId{-1};
 	bool m_isSpecial{false};
@@ -364,8 +362,8 @@ class EdgeItem final : public QObject, public QGraphicsPathItem {
 class EndSinkItem final : public QGraphicsObject {
 	Q_OBJECT
   public:
-	explicit EndSinkItem(const CampaignGraphStyle& style, QGraphicsItem* parent = nullptr)
-		: QGraphicsObject(parent), m_style(style)
+	explicit EndSinkItem(CampaignGraphStyle style, QGraphicsItem* parent = nullptr)
+		: QGraphicsObject(parent), m_style(std::move(style))
 	{
 	}
 

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -118,10 +118,10 @@ class CampaignMissionGraph final : public QGraphicsView {
 	void setModel(fso::fred::dialogs::CampaignEditorDialogModel* model);
 
 	// Rebuild/redraw the entire scene from the model
-	void rebuildAll();
+	void rebuildAll(bool refocus = false);
 
 	void
-	setSelectedMission(int missionIndex, bool makeVisible = true, bool centerOnItem = false, bool emitSignal = false);
+	setSelectedMission(int missionIndex, bool makeVisible = false, bool centerOnItem = false);
 	void clearSelectedMission();
 
 	// View helpers

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -154,6 +154,8 @@ class CampaignMissionGraph final : public QGraphicsView {
 	void addRepeatBranchRequested(int missionIndex);
 	// Emitted when an outbound connection drag is started from a node port and ends in empty space
 	void createMissionAtAndConnectRequested(QPointF sceneTopLeft, int fromIndex, bool isSpecial);
+	// Emitted when a request is made to make the current mission the first campaign mission
+	void setFirstMissionRequested(int missionIndex);
 
   protected:
 	// Pan/zoom

--- a/qtfred/src/ui/widgets/CampaignMissionGraph.h
+++ b/qtfred/src/ui/widgets/CampaignMissionGraph.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "globalincs/pstypes.h"
+
+#include "mission/dialogs/CampaignEditorDialogModel.h"
+
 #include <QGraphicsObject>
 #include <QGraphicsPathItem>
 #include <QGraphicsView>
@@ -9,6 +13,7 @@
 // Forward declaration to avoid coupling for now
 namespace fso::fred::dialogs {
 class CampaignEditorDialogModel;
+enum class CampaignSpecialMode;
 } // namespace fso::fred::dialogs
 
 class QGraphicsScene;
@@ -94,6 +99,10 @@ class CampaignMissionGraph final : public QGraphicsView {
 	// Rebuild/redraw the entire scene from the model
 	void rebuildAll();
 
+	void
+	setSelectedMission(int missionIndex, bool makeVisible = true, bool centerOnItem = false, bool emitSignal = false);
+	void clearSelectedMission();
+
 	// View helpers
 	void zoomToFitAll(qreal margin = 40.0);
 	void setGridVisible(bool on);
@@ -135,8 +144,8 @@ class CampaignMissionGraph final : public QGraphicsView {
 	CampaignGraphStyle m_style;
 
 	// Items we create (aligned to model order)
-	std::vector<detail::MissionNodeItem*> m_nodeItems;
-	std::vector<detail::EdgeItem*> m_edgeItems;
+	SCP_vector<detail::MissionNodeItem*> m_nodeItems;
+	SCP_vector<detail::EdgeItem*> m_edgeItems;
 	QPointer<detail::EndSinkItem> m_endSink{nullptr};
 
 	bool m_gridVisible{true};
@@ -150,10 +159,7 @@ class CampaignMissionGraph final : public QGraphicsView {
 
 namespace detail {
 
-enum class SpecialMode {
-	Loop,
-	Fork
-};
+using fso::fred::dialogs::CampaignSpecialMode;
 
 /**
  * One mission node item.
@@ -165,7 +171,7 @@ class MissionNodeItem final : public QGraphicsObject {
 		const QString& fileLabel,
 		const QString& nameLabel,
 		int graphColorRgb, // -1 = none else 0xRRGGBB
-		SpecialMode mode,
+		CampaignSpecialMode mode,
 		int mainBranchCount,
 		int specialBranchCount,
 		const CampaignGraphStyle& style,
@@ -195,7 +201,7 @@ class MissionNodeItem final : public QGraphicsObject {
 	QString m_file;
 	QString m_name;
 	int m_graphColor{-1};
-	SpecialMode m_mode{SpecialMode::Loop};
+	CampaignSpecialMode m_mode{CampaignSpecialMode::Loop};
 	int m_mainCount{0};
 	int m_specCount{0};
 
@@ -217,7 +223,7 @@ class EdgeItem final : public QObject, public QGraphicsPathItem {
 	EdgeItem(int missionIndex,
 		int branchId,
 		bool isSpecial,
-		SpecialMode mode,
+		CampaignSpecialMode mode,
 		const CampaignGraphStyle& style,
 		QGraphicsItem* parent = nullptr);
 
@@ -242,7 +248,7 @@ class EdgeItem final : public QObject, public QGraphicsPathItem {
 	int m_missionIndex{-1};
 	int m_branchId{-1};
 	bool m_isSpecial{false};
-	SpecialMode m_mode{SpecialMode::Loop};
+	CampaignSpecialMode m_mode{CampaignSpecialMode::Loop};
 	const CampaignGraphStyle& m_style;
 
 	QColor m_color;
@@ -252,7 +258,7 @@ class EdgeItem final : public QObject, public QGraphicsPathItem {
 	QPointF m_lastSegmentP1; // second-to-last point
 	QPointF m_lastSegmentP2; // last point (path end)
 
-	std::vector<QPointF> m_points; // cached polyline points for arrow placement
+	SCP_vector<QPointF> m_points; // cached polyline points for arrow placement
 };
 
 /**

--- a/qtfred/src/ui/widgets/SimpleListSelectDialog.cpp
+++ b/qtfred/src/ui/widgets/SimpleListSelectDialog.cpp
@@ -1,0 +1,170 @@
+#include "SimpleListSelectDialog.h"
+
+#include <QHBoxLayout>
+#include <QItemSelectionModel>
+#include <QLineEdit>
+#include <QListView>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QSortFilterProxyModel>
+#include <QStringListModel>
+#include <QVBoxLayout>
+
+SimpleListSelectDialog::SimpleListSelectDialog(const QStringList& items, QWidget* parent) : QDialog(parent)
+{
+	setWindowTitle(QStringLiteral("Select item"));
+	resize(420, 520);
+
+	// --- UI ---
+	m_filter = new QLineEdit(this);
+	m_filter->setPlaceholderText(QStringLiteral("Type to filter..."));
+
+	m_sourceModel = new QStringListModel(items, this);
+
+	m_proxy = new QSortFilterProxyModel(this);
+	m_proxy->setSourceModel(m_sourceModel);
+	m_proxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
+	m_proxy->setDynamicSortFilter(true);
+	m_proxy->setFilterKeyColumn(0);
+
+	m_list = new QListView(this);
+	m_list->setModel(m_proxy);
+	m_list->setSelectionMode(QAbstractItemView::SingleSelection);
+	m_list->setSelectionBehavior(QAbstractItemView::SelectRows);
+	m_list->setEditTriggers(QAbstractItemView::NoEditTriggers);
+	m_list->setUniformItemSizes(true);
+
+	m_okBtn = new QPushButton(QStringLiteral("OK"), this);
+	m_okBtn->setEnabled(false);
+	m_cancelBtn = new QPushButton(QStringLiteral("Cancel"), this);
+
+	auto* btns = new QHBoxLayout();
+	btns->addStretch();
+	btns->addWidget(m_cancelBtn);
+	btns->addWidget(m_okBtn);
+
+	auto* lay = new QVBoxLayout(this);
+	lay->setContentsMargins(10, 10, 10, 10);
+	lay->addWidget(m_filter);
+	lay->addWidget(m_list, 1);
+	lay->addLayout(btns);
+
+	// --- Signals ---
+	connect(m_filter, &QLineEdit::textChanged, this, &SimpleListSelectDialog::onFilterTextChanged);
+	connect(m_filter, &QLineEdit::returnPressed, this, &SimpleListSelectDialog::onFilterReturnPressed);
+	auto* sel = m_list->selectionModel();
+	connect(sel, &QItemSelectionModel::selectionChanged, this, [this](const QItemSelection&, const QItemSelection&) {
+		onSelectionChanged();
+	});
+	connect(m_list, &QListView::activated, this, &SimpleListSelectDialog::onItemActivated); // double-click/Enter
+	connect(m_okBtn, &QPushButton::clicked, this, &QDialog::accept);
+	connect(m_cancelBtn, &QPushButton::clicked, this, &QDialog::reject);
+}
+
+void SimpleListSelectDialog::setTitle(const QString& title)
+{
+	setWindowTitle(title);
+}
+void SimpleListSelectDialog::setPlaceholder(const QString& text)
+{
+	m_filter->setPlaceholderText(text);
+}
+
+QString SimpleListSelectDialog::selectedText() const
+{
+	// Be defensive: any of these can be null/invalid if the model/view changed
+	if (!m_list || !m_proxy || !m_sourceModel)
+		return {};
+
+	auto* sel = m_list->selectionModel();
+	if (!sel)
+		return {};
+
+	// Prefer currentIndex; fall back to first selected
+	QModelIndex proxyIdx = m_list->currentIndex();
+	if (!proxyIdx.isValid()) {
+		const auto idxs = sel->selectedIndexes();
+		if (idxs.isEmpty())
+			return {};
+		proxyIdx = idxs.first();
+	}
+	if (!proxyIdx.isValid())
+		return {};
+
+	const QModelIndex src = m_proxy->mapToSource(proxyIdx);
+	if (!src.isValid())
+		return {};
+
+	const QVariant v = m_sourceModel->data(src, Qt::DisplayRole);
+	return v.isValid() ? v.toString() : QString{};
+}
+
+int SimpleListSelectDialog::selectedRow() const
+{
+	if (!m_list || !m_proxy || !m_sourceModel)
+		return -1;
+
+	auto* sel = m_list->selectionModel();
+	if (!sel)
+		return -1;
+
+	QModelIndex proxyIdx = m_list->currentIndex();
+	if (!proxyIdx.isValid()) {
+		const auto idxs = sel->selectedIndexes();
+		if (idxs.isEmpty())
+			return -1;
+		proxyIdx = idxs.first();
+	}
+	if (!proxyIdx.isValid())
+		return -1;
+
+	const QModelIndex src = m_proxy->mapToSource(proxyIdx);
+	return src.isValid() ? src.row() : -1;
+}
+
+void SimpleListSelectDialog::onFilterTextChanged(const QString& text)
+{
+	const auto escaped = QRegularExpression::escape(text);
+	QRegularExpression rx(QStringLiteral(".*%1.*").arg(escaped), QRegularExpression::CaseInsensitiveOption);
+	m_proxy->setFilterRegularExpression(rx);
+
+	// If filtering cleared selection, disable OK
+	onSelectionChanged();
+}
+
+void SimpleListSelectDialog::onSelectionChanged()
+{
+	if (!m_list) {
+		m_okBtn->setEnabled(false);
+		return;
+	}
+	auto* sel = m_list->selectionModel();
+	m_okBtn->setEnabled(sel && sel->hasSelection());
+}
+
+
+void SimpleListSelectDialog::onItemActivated(const QModelIndex& /*proxyIndex*/)
+{
+	// Double-click/Enter ? accept if something is selected
+	if (!m_list->selectionModel()->selectedIndexes().isEmpty()) {
+		accept();
+	}
+}
+
+void SimpleListSelectDialog::onFilterReturnPressed()
+{
+	// If exactly one row matches, select it and accept
+	if (m_proxy->rowCount() == 1) {
+		const QModelIndex only = m_proxy->index(0, 0);
+		m_list->selectionModel()->select(only, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+		accept();
+	}
+}
+
+int SimpleListSelectDialog::proxyToSourceRow(const QModelIndex& proxyIndex) const
+{
+	if (!proxyIndex.isValid())
+		return -1;
+	const QModelIndex src = m_proxy->mapToSource(proxyIndex);
+	return src.isValid() ? src.row() : -1;
+}

--- a/qtfred/src/ui/widgets/SimpleListSelectDialog.h
+++ b/qtfred/src/ui/widgets/SimpleListSelectDialog.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <QDialog>
+#include <QStringList>
+
+class QLineEdit;
+class QListView;
+class QPushButton;
+class QStringListModel;
+class QSortFilterProxyModel;
+
+class SimpleListSelectDialog final : public QDialog {
+	Q_OBJECT
+  public:
+	explicit SimpleListSelectDialog(const QStringList& items, QWidget* parent = nullptr);
+
+	// Optional cosmetics
+	void setTitle(const QString& title);
+	void setPlaceholder(const QString& text);
+
+	// Results (empty string / -1 if nothing selected or dialog canceled)
+	QString selectedText() const;
+	int selectedRow() const;
+
+  private Q_SLOTS:
+	void onFilterTextChanged(const QString& text);
+	void onSelectionChanged();
+	void onItemActivated(const QModelIndex& proxyIndex); // double-click/Enter
+	void onFilterReturnPressed();
+
+  private:
+	int proxyToSourceRow(const QModelIndex& proxyIndex) const;
+
+  private:
+	QLineEdit* m_filter = nullptr;
+	QListView* m_list = nullptr;
+	QPushButton* m_okBtn = nullptr;
+	QPushButton* m_cancelBtn = nullptr;
+	QStringListModel* m_sourceModel = nullptr;
+	QSortFilterProxyModel* m_proxy = nullptr;
+};

--- a/qtfred/src/ui/widgets/SimpleListSelectDialog.h
+++ b/qtfred/src/ui/widgets/SimpleListSelectDialog.h
@@ -30,7 +30,6 @@ class SimpleListSelectDialog final : public QDialog {
   private: // NOLINT(readability-redundant-access-specifiers)
 	int proxyToSourceRow(const QModelIndex& proxyIndex) const;
 
-  private:
 	QLineEdit* m_filter = nullptr;
 	QListView* m_list = nullptr;
 	QPushButton* m_okBtn = nullptr;

--- a/qtfred/src/ui/widgets/SimpleListSelectDialog.h
+++ b/qtfred/src/ui/widgets/SimpleListSelectDialog.h
@@ -27,7 +27,7 @@ class SimpleListSelectDialog final : public QDialog {
 	void onItemActivated(const QModelIndex& proxyIndex); // double-click/Enter
 	void onFilterReturnPressed();
 
-  private:
+  private: // NOLINT(readability-redundant-access-specifiers)
 	int proxyToSourceRow(const QModelIndex& proxyIndex) const;
 
   private:

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -348,7 +348,7 @@
                 </sizepolicy>
                </property>
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Right click mission list to add or change a branch&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string/>
                </property>
               </widget>
              </item>
@@ -475,7 +475,7 @@
      <x>0</x>
      <y>0</y>
      <width>958</width>
-     <height>26</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -148,11 +148,38 @@
         <item>
          <layout class="QVBoxLayout" name="editorControls" stretch="0,0,0,0,0,0,0,0,0">
           <item>
-           <widget class="QLabel" name="availableMissionsLabel">
-            <property name="text">
-             <string>Available Missions</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="availableMissionsLayout">
+            <item>
+             <widget class="QLabel" name="availableMissionsLabel">
+              <property name="text">
+               <string>Available Missions</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="availableMissionsSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="availableMissionsFilterLabel">
+              <property name="text">
+               <string>Filter</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="availableMissionsFilterLineEdit"/>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QListView" name="availableMissionsListView">
@@ -167,6 +194,9 @@
             </property>
             <property name="toolTip">
              <string/>
+            </property>
+            <property name="styleSheet">
+             <string notr="true"/>
             </property>
             <property name="autoScrollMargin">
              <number>16</number>
@@ -185,6 +215,12 @@
             </property>
             <property name="spacing">
              <number>0</number>
+            </property>
+            <property name="gridSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
             <property name="viewMode">
              <enum>QListView::IconMode</enum>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>815</width>
-    <height>717</height>
+    <width>958</width>
+    <height>915</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,34 +31,24 @@
         <item>
          <layout class="QHBoxLayout" name="spec1">
           <item>
-           <widget class="QLabel" name="lblName">
+           <widget class="QLabel" name="nameLabel">
             <property name="text">
              <string>Campaign Name</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QLineEdit" name="txtName"/>
+           <widget class="QLineEdit" name="nameLineEdit"/>
           </item>
           <item>
-           <widget class="QLabel" name="lblType">
+           <widget class="QLabel" name="typeLabel">
             <property name="text">
              <string>Type</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QLineEdit" name="txtType">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
+           <widget class="QComboBox" name="typeComboBox"/>
           </item>
          </layout>
         </item>
@@ -88,7 +78,7 @@
            </spacer>
           </item>
           <item>
-           <widget class="QCheckBox" name="chkTechReset">
+           <widget class="QCheckBox" name="resetTechAtStartCheckBox">
             <property name="layoutDirection">
              <enum>Qt::LeftToRight</enum>
             </property>
@@ -100,7 +90,7 @@
          </layout>
         </item>
         <item>
-         <widget class="QPlainTextEdit" name="txaDescr">
+         <widget class="QPlainTextEdit" name="descriptionPlainTextEdit">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -110,26 +100,26 @@
          </widget>
         </item>
         <item>
-         <layout class="QGridLayout" name="gridLayout_2">
+         <layout class="QGridLayout" name="techLayout">
           <item row="0" column="0">
-           <widget class="QLabel" name="lblShips">
+           <widget class="QLabel" name="shipsLabel">
             <property name="text">
              <string>Initially Available Ships</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLabel" name="lblWeapons">
+           <widget class="QLabel" name="weaponsLabel">
             <property name="text">
              <string>Initially Available Weapons</string>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QListView" name="lstShips"/>
+           <widget class="QListWidget" name="shipsListWidget"/>
           </item>
           <item row="1" column="1">
-           <widget class="QListView" name="lstWeapons"/>
+           <widget class="QListWidget" name="weaponsListWidget"/>
           </item>
          </layout>
         </item>
@@ -156,16 +146,16 @@
          <number>11</number>
         </property>
         <item>
-         <layout class="QVBoxLayout" name="editorControls" stretch="0,0,0,0,0,0,0,0,0,1">
+         <layout class="QVBoxLayout" name="editorControls" stretch="0,0,0,0,0,0,0,0,0">
           <item>
-           <widget class="QLabel" name="lblMissions">
+           <widget class="QLabel" name="availableMissionsLabel">
             <property name="text">
              <string>Available Missions</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QListView" name="lstMissions">
+           <widget class="QListView" name="availableMissionsListView">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
               <horstretch>0</horstretch>
@@ -190,16 +180,16 @@
            </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="lstMissionDescr">
+           <layout class="QHBoxLayout" name="missionDescriptionLayout">
             <item>
-             <widget class="QLabel" name="lblMissionDescr1">
+             <widget class="QLabel" name="missionDescLabel1">
               <property name="text">
                <string>yellow=uneditable/packaged</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="lblMissionDescr2">
+             <widget class="QLabel" name="missionDescLabel2">
               <property name="text">
                <string>red=not found/loadable, please resolve!</string>
               </property>
@@ -210,7 +200,7 @@
           <item>
            <layout class="QHBoxLayout" name="layoutLoadMission">
             <item>
-             <widget class="QTextBrowser" name="txbMissionDescr">
+             <widget class="QTextBrowser" name="missionDescriptionTextBrowser">
               <property name="enabled">
                <bool>true</bool>
               </property>
@@ -223,7 +213,7 @@
              </widget>
             </item>
             <item>
-             <layout class="QVBoxLayout" name="layoutModMission">
+             <layout class="QVBoxLayout" name="modifyMissionButtonLayout">
               <property name="spacing">
                <number>0</number>
               </property>
@@ -231,7 +221,7 @@
                <enum>QLayout::SetMinimumSize</enum>
               </property>
               <item>
-               <widget class="QPushButton" name="btnFredMission">
+               <widget class="QPushButton" name="fredMissionButton">
                 <property name="enabled">
                  <bool>false</bool>
                 </property>
@@ -241,7 +231,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QPushButton" name="btnFirstMission">
+               <widget class="QPushButton" name="firstMissionButton">
                 <property name="enabled">
                  <bool>false</bool>
                 </property>
@@ -261,7 +251,7 @@
            <widget class="QGroupBox" name="missionOptions">
             <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0,0">
              <item row="0" column="0">
-              <widget class="QLabel" name="lblBriefingCutscene">
+              <widget class="QLabel" name="briefCutsceneLabel">
                <property name="text">
                 <string>Briefing Cutscene</string>
                </property>
@@ -271,7 +261,7 @@
               </widget>
              </item>
              <item row="0" column="2">
-              <widget class="QLabel" name="lblDebriefingPersona">
+              <widget class="QLabel" name="debriefPersonaLabel">
                <property name="text">
                 <string>Debriefing Persona Index</string>
                </property>
@@ -281,7 +271,7 @@
               </widget>
              </item>
              <item row="0" column="4">
-              <widget class="QLabel" name="lblMainhall">
+              <widget class="QLabel" name="mainhallLabel">
                <property name="text">
                 <string>Main Hall Name</string>
                </property>
@@ -291,7 +281,7 @@
               </widget>
              </item>
              <item row="1" column="4">
-              <widget class="QComboBox" name="cmbMainhall">
+              <widget class="QComboBox" name="mainhallComboBox">
                <property name="enabled">
                 <bool>false</bool>
                </property>
@@ -301,7 +291,7 @@
               </widget>
              </item>
              <item row="1" column="2">
-              <widget class="QComboBox" name="cmbDebriefingPersona">
+              <widget class="QComboBox" name="debriefPersonaComboBox">
                <property name="enabled">
                 <bool>false</bool>
                </property>
@@ -311,7 +301,7 @@
               </widget>
              </item>
              <item row="1" column="0">
-              <widget class="QComboBox" name="cmbBriefingCutscene">
+              <widget class="QComboBox" name="briefCutsceneComboBox">
                <property name="enabled">
                 <bool>false</bool>
                </property>
@@ -349,7 +339,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="lblLoopDescr">
+           <widget class="QLabel" name="loopDescriptionLabel">
             <property name="text">
              <string>Mission Loop Description</string>
             </property>
@@ -369,7 +359,7 @@
            </widget>
           </item>
           <item>
-           <layout class="QGridLayout" name="loopBrief">
+           <layout class="QGridLayout" name="loopBriefLayout">
             <item row="0" column="0">
              <widget class="QLabel" name="lblLoopAnim">
               <property name="text">
@@ -406,19 +396,6 @@
             </item>
            </layout>
           </item>
-          <item>
-           <spacer name="spaceBottom">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
          </layout>
         </item>
         <item>
@@ -432,7 +409,7 @@
              <x>0</x>
              <y>0</y>
              <width>416</width>
-             <height>575</height>
+             <height>544</height>
             </rect>
            </property>
           </widget>
@@ -443,9 +420,9 @@
      </widget>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <layout class="QHBoxLayout" name="errorCheckerLayout">
       <item>
-       <spacer name="horizontalSpacer_2">
+       <spacer name="errorCheckerSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -473,7 +450,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>815</width>
+     <width>958</width>
      <height>22</height>
     </rect>
    </property>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="mainTabs">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="campaignSpecs">
        <attribute name="title">
@@ -55,27 +55,11 @@
         <item>
          <layout class="QHBoxLayout" name="spec2">
           <item>
-           <widget class="QLabel" name="lblDescr">
+           <widget class="QLabel" name="campaignDescriptionLabel">
             <property name="text">
              <string>Campaign Description</string>
             </property>
            </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item>
            <widget class="QCheckBox" name="resetTechAtStartCheckBox">
@@ -84,6 +68,13 @@
             </property>
             <property name="text">
              <string>Reset tech db at start of campaign</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="campaignCustomDataButton">
+            <property name="text">
+             <string>Custom Data</string>
             </property>
            </widget>
           </item>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="mainTabs">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="campaignSpecs">
        <attribute name="title">
@@ -123,7 +123,7 @@
        <attribute name="title">
         <string>Campaign Flow</string>
        </attribute>
-       <layout class="QHBoxLayout" name="campaignGraphLayout" stretch="0,1">
+       <layout class="QHBoxLayout" name="campaignGraphLayout" stretch="0,0,0">
         <property name="leftMargin">
          <number>11</number>
         </property>
@@ -181,7 +181,7 @@
              <bool>false</bool>
             </property>
             <property name="dragDropMode">
-             <enum>QAbstractItemView::NoDragDrop</enum>
+             <enum>QAbstractItemView::DragDrop</enum>
             </property>
             <property name="defaultDropAction">
              <enum>Qt::IgnoreAction</enum>
@@ -416,20 +416,20 @@
          </layout>
         </item>
         <item>
-         <widget class="QScrollArea" name="scrFlowCampaign">
-          <property name="widgetResizable">
-           <bool>true</bool>
+         <widget class="Line" name="line">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
           </property>
-          <widget class="QWidget" name="flowCampaign">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>0</y>
-             <width>616</width>
-             <height>773</height>
-            </rect>
-           </property>
-          </widget>
+         </widget>
+        </item>
+        <item>
+         <widget class="CampaignMissionGraph" name="graphView">
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="renderHints">
+           <set>QPainter::Antialiasing|QPainter::TextAntialiasing</set>
+          </property>
          </widget>
         </item>
        </layout>
@@ -475,7 +475,7 @@
      <x>0</x>
      <y>0</y>
      <width>958</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -523,6 +523,11 @@
    <class>fso::fred::sexp_tree</class>
    <extends>QTreeView</extends>
    <header>ui/widgets/sexp_tree.h</header>
+  </customwidget>
+  <customwidget>
+   <class>CampaignMissionGraph</class>
+   <extends>QGraphicsView</extends>
+   <header>ui/widgets/campaignmissiongraph.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="mainTabs">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="campaignSpecs">
        <attribute name="title">
@@ -543,7 +543,7 @@
      <x>0</x>
      <y>0</y>
      <width>958</width>
-     <height>26</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -595,7 +595,7 @@
   <customwidget>
    <class>CampaignMissionGraph</class>
    <extends>QGraphicsView</extends>
-   <header>ui/widgets/campaignmissiongraph.h</header>
+   <header>ui/widgets/CampaignMissionGraph.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -182,30 +182,18 @@
            </layout>
           </item>
           <item>
-           <widget class="QListView" name="availableMissionsListView">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="contextMenuPolicy">
-             <enum>Qt::CustomContextMenu</enum>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="styleSheet">
-             <string notr="true"/>
-            </property>
-            <property name="autoScrollMargin">
-             <number>16</number>
-            </property>
+           <widget class="QListWidget" name="availableMissionsListWidget">
             <property name="editTriggers">
              <set>QAbstractItemView::NoEditTriggers</set>
             </property>
-            <property name="selectionMode">
-             <enum>QAbstractItemView::NoSelection</enum>
+            <property name="showDropIndicator" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="dragDropMode">
+             <enum>QAbstractItemView::NoDragDrop</enum>
+            </property>
+            <property name="defaultDropAction">
+             <enum>Qt::IgnoreAction</enum>
             </property>
             <property name="flow">
              <enum>QListView::TopToBottom</enum>
@@ -213,19 +201,10 @@
             <property name="resizeMode">
              <enum>QListView::Adjust</enum>
             </property>
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="gridSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
             <property name="viewMode">
              <enum>QListView::IconMode</enum>
             </property>
-            <property name="wordWrap">
+            <property name="uniformItemSizes">
              <bool>true</bool>
             </property>
            </widget>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="mainTabs">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="campaignSpecs">
        <attribute name="title">
@@ -166,7 +166,7 @@
              <enum>Qt::CustomContextMenu</enum>
             </property>
             <property name="toolTip">
-             <string>Right click mission list to add or change branches</string>
+             <string/>
             </property>
             <property name="autoScrollMargin">
              <number>16</number>
@@ -177,6 +177,21 @@
             <property name="selectionMode">
              <enum>QAbstractItemView::NoSelection</enum>
             </property>
+            <property name="flow">
+             <enum>QListView::TopToBottom</enum>
+            </property>
+            <property name="resizeMode">
+             <enum>QListView::Adjust</enum>
+            </property>
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="viewMode">
+             <enum>QListView::IconMode</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
           <item>
@@ -185,13 +200,6 @@
              <widget class="QLabel" name="missionDescLabel1">
               <property name="text">
                <string>yellow=uneditable/packaged</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="missionDescLabel2">
-              <property name="text">
-               <string>red=not found/loadable, please resolve!</string>
               </property>
              </widget>
             </item>
@@ -408,8 +416,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>416</width>
-             <height>544</height>
+             <width>561</width>
+             <height>773</height>
             </rect>
            </property>
           </widget>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -254,6 +254,9 @@
           </item>
           <item>
            <layout class="QFormLayout" name="missionSettingsLayout">
+            <property name="labelAlignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
             <item row="0" column="0">
              <widget class="QLabel" name="briefCutsceneLabel">
               <property name="text">
@@ -270,7 +273,7 @@
                <bool>false</bool>
               </property>
               <property name="editable">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
              </widget>
             </item>
@@ -285,12 +288,9 @@
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QComboBox" name="debriefPersonaComboBox">
+             <widget class="QSpinBox" name="debriefingPersonaSpinBox">
               <property name="enabled">
                <bool>false</bool>
-              </property>
-              <property name="editable">
-               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -310,21 +310,21 @@
                <bool>false</bool>
               </property>
               <property name="editable">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
              </widget>
             </item>
             <item row="3" column="0">
-             <widget class="QLabel" name="mainhallBastionFlagLabel">
+             <widget class="QLabel" name="substituteMainhallNameLabel">
               <property name="text">
-               <string>Main Hall Bastion Flag</string>
+               <string>Substitute Main Hall Name</string>
               </property>
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QCheckBox" name="mainhallBastionFlagCheckBox">
-              <property name="text">
-               <string/>
+             <widget class="QComboBox" name="substituteMainhallComboBox">
+              <property name="enabled">
+               <bool>false</bool>
               </property>
              </widget>
             </item>
@@ -363,7 +363,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPlainTextEdit" name="txaLoopDescr">
+           <widget class="QPlainTextEdit" name="loopDescriptionPlainTextEdit">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -376,40 +376,80 @@
            </widget>
           </item>
           <item>
-           <layout class="QGridLayout" name="loopBriefLayout">
+           <layout class="QFormLayout" name="loopDetailsForm">
+            <property name="labelAlignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
             <item row="0" column="0">
-             <widget class="QLabel" name="lblLoopAnim">
+             <widget class="QLabel" name="loopAnimLabel">
               <property name="text">
                <string>Loop brief anim</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
-             <widget class="QComboBox" name="cmbLoopVoice">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="editable">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="lblLoopVoice">
+            <item row="1" column="0">
+             <widget class="QLabel" name="loopVoiceLabel">
               <property name="text">
                <string>Loop brief voice</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="0">
-             <widget class="QComboBox" name="cmbLoopAnim">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="editable">
-               <bool>true</bool>
-              </property>
-             </widget>
+            <item row="0" column="1">
+             <layout class="QHBoxLayout" name="loopAnimControlsLayout">
+              <item>
+               <widget class="QLineEdit" name="loopAnimLineEdit">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="loopAnimBrowseButton">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Browse</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="loopVoiceControlsLayout">
+              <item>
+               <widget class="QLineEdit" name="loopVoiceLineEdit">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="loopVoiceBrowseButton">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Browse</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="testVoiceButton">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <selectedon>:/images/play.png</selectedon>
+                 </iconset>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </item>
@@ -475,7 +515,7 @@
      <x>0</x>
      <y>0</y>
      <width>958</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -530,6 +570,8 @@
    <header>ui/widgets/campaignmissiongraph.h</header>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../resources/resources.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="mainTabs">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="campaignSpecs">
        <attribute name="title">
@@ -351,6 +351,34 @@
                 <string/>
                </property>
               </widget>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <item>
+                <widget class="QPushButton" name="moveBranchUpButton">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <selectedon>:/images/arrow_up.png</selectedon>
+                  </iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="moveBranchDownButton">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <selectedon>:/images/arrow_down.png</selectedon>
+                  </iconset>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
            </widget>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -1,328 +1,384 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>fso::fred::dialogs::CampaignEditorDialog</class>
- <widget class="QDialog" name="fso::fred::dialogs::CampaignEditorDialog">
-  <property name="enabled">
-   <bool>true</bool>
+ <widget class="QMainWindow" name="fso::fred::dialogs::CampaignEditorDialog">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1068</width>
-    <height>1023</height>
+    <width>815</width>
+    <height>717</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Untitled</string>
+   <string>Campaign Editor</string>
   </property>
-  <property name="sizeGripEnabled">
-   <bool>true</bool>
-  </property>
-  <property name="modal">
-   <bool>true</bool>
-  </property>
-  <layout class="QVBoxLayout" name="windowLayout">
-   <item>
-    <widget class="QPushButton" name="btnMenu">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>File...</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QTabWidget" name="mainTabs">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="campaignSpecs">
-      <attribute name="title">
-       <string>Campaign Specs</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <layout class="QHBoxLayout" name="spec1">
-         <item>
-          <widget class="QLabel" name="lblName">
-           <property name="text">
-            <string>Campaign Name</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="txtName"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="lblType">
-           <property name="text">
-            <string>Type</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="txtType">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="spec2">
-         <item>
-          <widget class="QLabel" name="lblDescr">
-           <property name="text">
-            <string>Campaign Description</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="chkTechReset">
-           <property name="layoutDirection">
-            <enum>Qt::LeftToRight</enum>
-           </property>
-           <property name="text">
-            <string>Reset tech db at start of campaign</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QPlainTextEdit" name="txaDescr">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="0" column="0">
-          <widget class="QLabel" name="lblShips">
-           <property name="text">
-            <string>Initially Available Ships</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="lblWeapons">
-           <property name="text">
-            <string>Initially Available Weapons</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QListView" name="lstShips"/>
-         </item>
-         <item row="1" column="1">
-          <widget class="QListView" name="lstWeapons"/>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="campaignFlow">
-      <property name="whatsThis">
-       <string/>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QTabWidget" name="mainTabs">
+      <property name="currentIndex">
+       <number>0</number>
       </property>
-      <attribute name="title">
-       <string>Campaign Flow</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="campaignGraphLayout" stretch="0,1">
-       <property name="leftMargin">
-        <number>11</number>
+      <widget class="QWidget" name="campaignSpecs">
+       <attribute name="title">
+        <string>Campaign Specs</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QHBoxLayout" name="spec1">
+          <item>
+           <widget class="QLabel" name="lblName">
+            <property name="text">
+             <string>Campaign Name</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="txtName"/>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblType">
+            <property name="text">
+             <string>Type</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="txtType">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="spec2">
+          <item>
+           <widget class="QLabel" name="lblDescr">
+            <property name="text">
+             <string>Campaign Description</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="chkTechReset">
+            <property name="layoutDirection">
+             <enum>Qt::LeftToRight</enum>
+            </property>
+            <property name="text">
+             <string>Reset tech db at start of campaign</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPlainTextEdit" name="txaDescr">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="lblShips">
+            <property name="text">
+             <string>Initially Available Ships</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="lblWeapons">
+            <property name="text">
+             <string>Initially Available Weapons</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QListView" name="lstShips"/>
+          </item>
+          <item row="1" column="1">
+           <widget class="QListView" name="lstWeapons"/>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="campaignFlow">
+       <property name="whatsThis">
+        <string/>
        </property>
-       <property name="topMargin">
-        <number>11</number>
-       </property>
-       <property name="rightMargin">
-        <number>11</number>
-       </property>
-       <property name="bottomMargin">
-        <number>11</number>
-       </property>
-       <item>
-        <layout class="QVBoxLayout" name="editorControls" stretch="0,0,0,0,0,0,0,0,0,1">
-         <item>
-          <widget class="QLabel" name="lblMissions">
-           <property name="text">
-            <string>Available Missions</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QListView" name="lstMissions">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="contextMenuPolicy">
-            <enum>Qt::CustomContextMenu</enum>
-           </property>
-           <property name="toolTip">
-            <string>Right click mission list to add or change branches</string>
-           </property>
-           <property name="autoScrollMargin">
-            <number>16</number>
-           </property>
-           <property name="editTriggers">
-            <set>QAbstractItemView::NoEditTriggers</set>
-           </property>
-           <property name="selectionMode">
-            <enum>QAbstractItemView::NoSelection</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="lstMissionDescr">
-           <item>
-            <widget class="QLabel" name="lblMissionDescr1">
-             <property name="text">
-              <string>yellow=uneditable/packaged</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lblMissionDescr2">
-             <property name="text">
-              <string>red=not found/loadable, please resolve!</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="layoutLoadMission">
-           <item>
-            <widget class="QTextBrowser" name="txbMissionDescr">
-             <property name="enabled">
-              <bool>true</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="layoutModMission">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="sizeConstraint">
-              <enum>QLayout::SetMinimumSize</enum>
-             </property>
-             <item>
-              <widget class="QPushButton" name="btnFredMission">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
+       <attribute name="title">
+        <string>Campaign Flow</string>
+       </attribute>
+       <layout class="QHBoxLayout" name="campaignGraphLayout" stretch="0,1">
+        <property name="leftMargin">
+         <number>11</number>
+        </property>
+        <property name="topMargin">
+         <number>11</number>
+        </property>
+        <property name="rightMargin">
+         <number>11</number>
+        </property>
+        <property name="bottomMargin">
+         <number>11</number>
+        </property>
+        <item>
+         <layout class="QVBoxLayout" name="editorControls" stretch="0,0,0,0,0,0,0,0,0,1">
+          <item>
+           <widget class="QLabel" name="lblMissions">
+            <property name="text">
+             <string>Available Missions</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QListView" name="lstMissions">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="contextMenuPolicy">
+             <enum>Qt::CustomContextMenu</enum>
+            </property>
+            <property name="toolTip">
+             <string>Right click mission list to add or change branches</string>
+            </property>
+            <property name="autoScrollMargin">
+             <number>16</number>
+            </property>
+            <property name="editTriggers">
+             <set>QAbstractItemView::NoEditTriggers</set>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::NoSelection</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="lstMissionDescr">
+            <item>
+             <widget class="QLabel" name="lblMissionDescr1">
+              <property name="text">
+               <string>yellow=uneditable/packaged</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblMissionDescr2">
+              <property name="text">
+               <string>red=not found/loadable, please resolve!</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="layoutLoadMission">
+            <item>
+             <widget class="QTextBrowser" name="txbMissionDescr">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QVBoxLayout" name="layoutModMission">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="sizeConstraint">
+               <enum>QLayout::SetMinimumSize</enum>
+              </property>
+              <item>
+               <widget class="QPushButton" name="btnFredMission">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>FRED Mission</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="btnFirstMission">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>First Mission</string>
+                </property>
+                <property name="checkable">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="missionOptions">
+            <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0,0">
+             <item row="0" column="0">
+              <widget class="QLabel" name="lblBriefingCutscene">
                <property name="text">
-                <string>FRED Mission</string>
+                <string>Briefing Cutscene</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
-             <item>
-              <widget class="QPushButton" name="btnFirstMission">
+             <item row="0" column="2">
+              <widget class="QLabel" name="lblDebriefingPersona">
+               <property name="text">
+                <string>Debriefing Persona Index</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <widget class="QLabel" name="lblMainhall">
+               <property name="text">
+                <string>Main Hall Name</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="4">
+              <widget class="QComboBox" name="cmbMainhall">
                <property name="enabled">
                 <bool>false</bool>
                </property>
-               <property name="text">
-                <string>First Mission</string>
+               <property name="editable">
+                <bool>true</bool>
                </property>
-               <property name="checkable">
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QComboBox" name="cmbDebriefingPersona">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="editable">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QComboBox" name="cmbBriefingCutscene">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="editable">
                 <bool>true</bool>
                </property>
               </widget>
              </item>
             </layout>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="missionOptions">
-           <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0,0">
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="missionBranches">
+            <property name="title">
+             <string>Branches</string>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="fso::fred::sexp_tree" name="sxtBranches">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Right click mission list to add or change a branch&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="lblLoopDescr">
+            <property name="text">
+             <string>Mission Loop Description</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPlainTextEdit" name="txaLoopDescr">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="loopBrief">
             <item row="0" column="0">
-             <widget class="QLabel" name="lblBriefingCutscene">
+             <widget class="QLabel" name="lblLoopAnim">
               <property name="text">
-               <string>Briefing Cutscene</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
+               <string>Loop brief anim</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="2">
-             <widget class="QLabel" name="lblDebriefingPersona">
-              <property name="text">
-               <string>Debriefing Persona Index</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="4">
-             <widget class="QLabel" name="lblMainhall">
-              <property name="text">
-               <string>Main Hall Name</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="4">
-             <widget class="QComboBox" name="cmbMainhall">
+            <item row="2" column="1">
+             <widget class="QComboBox" name="cmbLoopVoice">
               <property name="enabled">
                <bool>false</bool>
               </property>
@@ -331,18 +387,15 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="2">
-             <widget class="QComboBox" name="cmbDebriefingPersona">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="editable">
-               <bool>true</bool>
+            <item row="0" column="1">
+             <widget class="QLabel" name="lblLoopVoice">
+              <property name="text">
+               <string>Loop brief voice</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QComboBox" name="cmbBriefingCutscene">
+            <item row="2" column="0">
+             <widget class="QComboBox" name="cmbLoopAnim">
               <property name="enabled">
                <bool>false</bool>
               </property>
@@ -352,162 +405,117 @@
              </widget>
             </item>
            </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="missionBranches">
-           <property name="title">
-            <string>Branches</string>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="fso::fred::sexp_tree" name="sxtBranches">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Right click mission list to add or change a branch&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="lblLoopDescr">
-           <property name="text">
-            <string>Mission Loop Description</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPlainTextEdit" name="txaLoopDescr">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QGridLayout" name="loopBrief">
-           <item row="0" column="0">
-            <widget class="QLabel" name="lblLoopAnim">
-             <property name="text">
-              <string>Loop brief anim</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QComboBox" name="cmbLoopVoice">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="editable">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="lblLoopVoice">
-             <property name="text">
-              <string>Loop brief voice</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QComboBox" name="cmbLoopAnim">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="editable">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <spacer name="spaceBottom">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QScrollArea" name="scrFlowCampaign">
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="flowCampaign">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>607</width>
-            <height>889</height>
-           </rect>
+          </item>
+          <item>
+           <spacer name="spaceBottom">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QScrollArea" name="scrFlowCampaign">
+          <property name="widgetResizable">
+           <bool>true</bool>
           </property>
+          <widget class="QWidget" name="flowCampaign">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>416</width>
+             <height>575</height>
+            </rect>
+           </property>
+          </widget>
          </widget>
-        </widget>
-       </item>
-      </layout>
+        </item>
+       </layout>
+      </widget>
      </widget>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="mainControls">
-     <item>
-      <widget class="QPushButton" name="btnErrorChecker">
-       <property name="text">
-        <string>Error Checker</string>
-       </property>
-       <property name="shortcut">
-        <string>Shift+H</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnExit">
-       <property name="text">
-        <string>Exit</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="errorCheckerButton">
+        <property name="text">
+         <string>Error Checker</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>815</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>File</string>
+    </property>
+    <addaction name="actionNew"/>
+    <addaction name="actionOpen"/>
+    <addaction name="actionSave"/>
+    <addaction name="actionSave_As"/>
+    <addaction name="separator"/>
+    <addaction name="actionExit"/>
+   </widget>
+   <addaction name="menuFile"/>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+  <action name="actionNew">
+   <property name="text">
+    <string>New</string>
+   </property>
+  </action>
+  <action name="actionOpen">
+   <property name="text">
+    <string>Open...</string>
+   </property>
+  </action>
+  <action name="actionSave">
+   <property name="text">
+    <string>Save</string>
+   </property>
+  </action>
+  <action name="actionSave_As">
+   <property name="text">
+    <string>Save As...</string>
+   </property>
+  </action>
+  <action name="actionExit">
+   <property name="text">
+    <string>Exit</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -516,10 +524,6 @@
    <header>ui/widgets/sexp_tree.h</header>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>lstMissions</tabstop>
-  <tabstop>scrFlowCampaign</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -21,7 +21,7 @@
     <item>
      <widget class="QTabWidget" name="mainTabs">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="campaignSpecs">
        <attribute name="title">

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -146,7 +146,7 @@
          <number>11</number>
         </property>
         <item>
-         <layout class="QVBoxLayout" name="editorControls" stretch="0,0,0,0,0,0,0,0,0">
+         <layout class="QVBoxLayout" name="editorControls" stretch="0,0,0,1,0,0,1,0,0">
           <item>
            <layout class="QHBoxLayout" name="availableMissionsLayout">
             <item>
@@ -210,22 +210,46 @@
            </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="missionDescriptionLayout">
+           <widget class="QPushButton" name="fredMissionButton">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Open Selected Mission in Mission Editor</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="missionDetailsLayout">
             <item>
-             <widget class="QLabel" name="missionDescLabel1">
+             <layout class="QHBoxLayout" name="missionNameLayout">
+              <item>
+               <widget class="QLabel" name="missionNameLabel">
+                <property name="text">
+                 <string>Mission Name</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="missionNameLineEdit">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="label">
               <property name="text">
-               <string>yellow=uneditable/packaged</string>
+               <string>Mission Description</string>
               </property>
              </widget>
             </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="layoutLoadMission">
             <item>
-             <widget class="QTextBrowser" name="missionDescriptionTextBrowser">
+             <widget class="QPlainTextEdit" name="missionDescriptionPlainTextEdit">
               <property name="enabled">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -235,106 +259,85 @@
               </property>
              </widget>
             </item>
-            <item>
-             <layout class="QVBoxLayout" name="modifyMissionButtonLayout">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="sizeConstraint">
-               <enum>QLayout::SetMinimumSize</enum>
-              </property>
-              <item>
-               <widget class="QPushButton" name="fredMissionButton">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>FRED Mission</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="firstMissionButton">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>First Mission</string>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
            </layout>
           </item>
           <item>
-           <widget class="QGroupBox" name="missionOptions">
-            <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0,0">
-             <item row="0" column="0">
-              <widget class="QLabel" name="briefCutsceneLabel">
-               <property name="text">
-                <string>Briefing Cutscene</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QLabel" name="debriefPersonaLabel">
-               <property name="text">
-                <string>Debriefing Persona Index</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="4">
-              <widget class="QLabel" name="mainhallLabel">
-               <property name="text">
-                <string>Main Hall Name</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="4">
-              <widget class="QComboBox" name="mainhallComboBox">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="editable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="2">
-              <widget class="QComboBox" name="debriefPersonaComboBox">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="editable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QComboBox" name="briefCutsceneComboBox">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="editable">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
+           <layout class="QFormLayout" name="missionSettingsLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="briefCutsceneLabel">
+              <property name="text">
+               <string>Briefing Cutscene</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="briefCutsceneComboBox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="editable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="debriefPersonaLabel">
+              <property name="text">
+               <string>Debriefing Persona Index</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="debriefPersonaComboBox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="editable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="mainhallLabel">
+              <property name="text">
+               <string>Main Hall Name</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="mainhallComboBox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="editable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="mainhallBastionFlagLabel">
+              <property name="text">
+               <string>Main Hall Bastion Flag</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QCheckBox" name="mainhallBastionFlagCheckBox">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QGroupBox" name="missionBranches">
@@ -431,7 +434,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>561</width>
+             <width>616</width>
              <height>773</height>
             </rect>
            </property>
@@ -444,6 +447,13 @@
     </item>
     <item>
      <layout class="QHBoxLayout" name="errorCheckerLayout">
+      <item>
+       <widget class="QCheckBox" name="retailFormatCheckbox">
+        <property name="text">
+         <string>Use Retail Format for Saving</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <spacer name="errorCheckerSpacer">
         <property name="orientation">


### PR DESCRIPTION
Revises and completes the Campaign Editor dialog. Implements a flexible node graph editing flow that seems to work with all campaigns I've thrown at it so far including BP2 and JAD 2.23. Saving is not accurate as QtFRED's missionsave.cpp is outdated. That will need to be fixed in a follow-up as noted in #7028 .

Fixes #1693 