### PR TITLE
QtFRED Briefing Dialog

### DIFF
--- a/qtfred/src/mission/dialogs/BriefingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BriefingEditorDialogModel.cpp
@@ -1,0 +1,310 @@
+#include "BriefingEditorDialogModel.h"
+
+#include "gamesnd/eventmusic.h"
+#include "mission/missionparse.h"      //TODO remove?
+#include "missionui/missioncmdbrief.h" //TODO remove?
+#include "sound/audiostr.h"
+
+#include <QMessageBox>
+
+namespace fso::fred::dialogs {
+
+BriefingEditorDialogModel::BriefingEditorDialogModel(QObject* parent, EditorViewport* viewport)
+	: AbstractDialogModel(parent, viewport)
+{
+	initializeData();
+}
+
+bool BriefingEditorDialogModel::apply()
+{
+	stopSpeech();
+
+	for (int i = 0; i < MAX_TVT_TEAMS; i++) {
+		Debriefings[i] = _wipDebriefing[i];
+	}
+
+	Mission_music[SCORE_DEBRIEFING_SUCCESS] = _successMusic;
+	Mission_music[SCORE_DEBRIEFING_AVERAGE] = _averageMusic;
+	Mission_music[SCORE_DEBRIEFING_FAILURE] = _failureMusic;
+
+	return true;
+}
+
+void BriefingEditorDialogModel::reject()
+{
+	stopSpeech();
+}
+
+void BriefingEditorDialogModel::initializeData()
+{
+	initializeTeamList();
+
+	// Make a working copy
+	for (int i = 0; i < MAX_TVT_TEAMS; i++) {
+		_wipDebriefing[i] = Debriefings[i];
+	}
+
+	_successMusic = Mission_music[SCORE_DEBRIEFING_SUCCESS];
+	_averageMusic = Mission_music[SCORE_DEBRIEFING_AVERAGE];
+	_failureMusic = Mission_music[SCORE_DEBRIEFING_FAILURE];
+
+	_currentTeam = 0;
+	_currentStage = 0;
+}
+
+void BriefingEditorDialogModel::gotoPreviousStage()
+{
+	if (_currentStage <= 0) {
+		_currentStage = 0;
+		return;
+	}
+
+	stopSpeech();
+	_currentStage--;
+}
+
+void BriefingEditorDialogModel::gotoNextStage()
+{
+	if (_currentStage >= MAX_DEBRIEF_STAGES - 1) {
+		_currentStage = MAX_DEBRIEF_STAGES - 1;
+		return;
+	}
+
+	if (_currentStage >= _wipDebriefing[_currentTeam].num_stages - 1) {
+		_currentStage = _wipDebriefing[_currentTeam].num_stages - 1;
+		return;
+	}
+
+	_currentStage++;
+	stopSpeech();
+}
+
+void BriefingEditorDialogModel::addStage()
+{
+	stopSpeech();
+
+	if (_wipDebriefing[_currentTeam].num_stages >= MAX_DEBRIEF_STAGES) {
+		_wipDebriefing[_currentTeam].num_stages = MAX_DEBRIEF_STAGES;
+		_currentStage = _wipDebriefing[_currentTeam].num_stages - 1;
+		return;
+	}
+
+	_wipDebriefing[_currentTeam].num_stages++;
+	_currentStage = _wipDebriefing[_currentTeam].num_stages - 1;
+	_wipDebriefing[_currentTeam].stages[_currentStage].text = "<Text here>";
+	_wipDebriefing[_currentTeam].stages[_currentStage].recommendation_text = "<Recommendation text here>";
+	strcpy_s(_wipDebriefing[_currentTeam].stages[_currentStage].voice,
+		"none.wav"); // Really? Seeding with none.wav is gross
+	_wipDebriefing[_currentTeam].stages[_currentStage].formula = -1;
+
+	set_modified();
+}
+
+// copies the current stage as the next stage and then moves the rest of the stages over.
+void BriefingEditorDialogModel::insertStage()
+{
+	stopSpeech();
+
+	if (_wipDebriefing[_currentTeam].num_stages >= MAX_DEBRIEF_STAGES) {
+		_wipDebriefing[_currentTeam].num_stages = MAX_DEBRIEF_STAGES;
+		set_modified();
+		return;
+	}
+
+	_wipDebriefing[_currentTeam].num_stages++;
+
+	for (int i = _wipDebriefing[_currentTeam].num_stages - 1; i > _currentStage; i--) {
+		_wipDebriefing[_currentTeam].stages[i] = _wipDebriefing[_currentTeam].stages[i - 1];
+	}
+
+	// Future TODO: Add a QtFRED Option to clear the inserted stage instead of copying the current one.
+
+	set_modified();
+}
+
+void BriefingEditorDialogModel::deleteStage()
+{
+	stopSpeech();
+
+	// Clear everything if we were on the last stage.
+	if (_wipDebriefing[_currentTeam].num_stages <= 1) {
+		_wipDebriefing[_currentTeam].num_stages = 0;
+		_wipDebriefing[_currentTeam].stages[0].text.clear();
+		_wipDebriefing[_currentTeam].stages[0].recommendation_text.clear();
+		memset(_wipDebriefing[_currentTeam].stages[0].voice, 0, CF_MAX_FILENAME_LENGTH);
+		_wipDebriefing[_currentTeam].stages[0].formula = -1;
+		set_modified();
+		return;
+	}
+
+	// copy the stages backwards until we get to the stage we're on
+	for (int i = _currentStage; i + 1 < _wipDebriefing[_currentTeam].num_stages; i++) {
+		_wipDebriefing[_currentTeam].stages[i] = _wipDebriefing[_currentTeam].stages[i + 1];
+	}
+
+	_wipDebriefing[_currentTeam].num_stages--;
+
+	// Clear the tail
+	const int tail = _wipDebriefing[_currentTeam].num_stages; // index of the old last element
+	_wipDebriefing[_currentTeam].stages[tail].text.clear();
+	_wipDebriefing[_currentTeam].stages[tail].recommendation_text.clear();
+	std::memset(_wipDebriefing[_currentTeam].stages[tail].voice, 0, CF_MAX_FILENAME_LENGTH);
+	_wipDebriefing[_currentTeam].stages[tail].formula = -1;
+
+	// make sure that the current stage is valid.
+	if (_wipDebriefing[_currentTeam].num_stages <= _currentStage) {
+		_currentStage = _wipDebriefing[_currentTeam].num_stages - 1;
+	}
+
+	set_modified();
+}
+
+void BriefingEditorDialogModel::testSpeech()
+{
+	// May cause unloading/reloading but it's just the mission editor
+	// we don't need to keep all the waves loaded only to have to unload them
+	// later anyway. This ensures we have one wave loaded and stopSpeech always unloads it
+
+	stopSpeech();
+
+	_waveId = audiostream_open(_wipDebriefing[_currentTeam].stages[_currentStage].voice, ASF_EVENTMUSIC);
+	audiostream_play(_waveId, 1.0f, 0);
+}
+
+void BriefingEditorDialogModel::copyToOtherTeams()
+{
+	stopSpeech();
+
+	for (int i = 0; i < MAX_TVT_TEAMS; i++) {
+		if (i != _currentTeam) {
+			_wipDebriefing[i] = _wipDebriefing[_currentTeam];
+		}
+	}
+	set_modified();
+}
+
+const SCP_vector<std::pair<SCP_string, int>>& BriefingEditorDialogModel::getTeamList()
+{
+	return _teamList;
+}
+
+bool BriefingEditorDialogModel::getMissionIsMultiTeam()
+{
+	return The_mission.game_type & MISSION_TYPE_MULTI_TEAMS;
+}
+
+void BriefingEditorDialogModel::stopSpeech()
+{
+	if (_waveId >= -1) {
+		audiostream_close_file(_waveId, false);
+		_waveId = -1;
+	}
+}
+
+void BriefingEditorDialogModel::initializeTeamList()
+{
+	_teamList.clear();
+	for (auto& team : Mission_event_teams_tvt) {
+		_teamList.emplace_back(team.first, team.second);
+	}
+}
+
+int BriefingEditorDialogModel::getCurrentTeam() const
+{
+	return _currentTeam;
+}
+
+void BriefingEditorDialogModel::setCurrentTeam(int teamIn)
+{
+	modify(_currentTeam, teamIn);
+};
+
+int BriefingEditorDialogModel::getCurrentStage() const
+{
+	return _currentStage;
+}
+
+int BriefingEditorDialogModel::getTotalStages()
+{
+	return _wipDebriefing[_currentTeam].num_stages;
+}
+
+SCP_string BriefingEditorDialogModel::getStageText()
+{
+	return _wipDebriefing[_currentTeam].stages[_currentStage].text;
+}
+
+void BriefingEditorDialogModel::setStageText(const SCP_string& text)
+{
+	modify(_wipDebriefing[_currentTeam].stages[_currentStage].text, text);
+}
+
+SCP_string BriefingEditorDialogModel::getRecommendationText()
+{
+	return _wipDebriefing[_currentTeam].stages[_currentStage].recommendation_text;
+}
+
+void BriefingEditorDialogModel::setRecommendationText(const SCP_string& text)
+{
+	modify(_wipDebriefing[_currentTeam].stages[_currentStage].recommendation_text, text);
+}
+
+SCP_string BriefingEditorDialogModel::getSpeechFilename()
+{
+	return _wipDebriefing[_currentTeam].stages[_currentStage].voice;
+}
+
+void BriefingEditorDialogModel::setSpeechFilename(const SCP_string& speechFilename)
+{
+	strcpy_s(_wipDebriefing[_currentTeam].stages[_currentStage].voice, speechFilename.c_str());
+	set_modified();
+}
+
+int BriefingEditorDialogModel::getFormula() const
+{
+	return _wipDebriefing[_currentTeam].stages[_currentStage].formula;
+}
+
+void BriefingEditorDialogModel::setFormula(int formula)
+{
+	modify(_wipDebriefing[_currentTeam].stages[_currentStage].formula, formula);
+}
+
+SCP_vector<SCP_string> BriefingEditorDialogModel::getMusicList()
+{
+	SCP_vector<SCP_string> music_list;
+	music_list.emplace_back("None");
+
+	for (const auto& sm : Spooled_music) {
+		music_list.emplace_back(sm.name);
+	}
+
+	return music_list;
+}
+
+int BriefingEditorDialogModel::getSuccessMusicTrack() const
+{
+	return _successMusic;
+}
+void BriefingEditorDialogModel::setSuccessMusicTrack(int trackIndex)
+{
+	modify(_successMusic, trackIndex);
+}
+int BriefingEditorDialogModel::getAverageMusicTrack() const
+{
+	return _averageMusic;
+}
+void BriefingEditorDialogModel::setAverageMusicTrack(int trackIndex)
+{
+	modify(_averageMusic, trackIndex);
+}
+int BriefingEditorDialogModel::getFailureMusicTrack() const
+{
+	return _failureMusic;
+}
+void BriefingEditorDialogModel::setFailureMusicTrack(int trackIndex)
+{
+	modify(_failureMusic, trackIndex);
+}
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BriefingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BriefingEditorDialogModel.cpp
@@ -4,6 +4,7 @@
 #include "mission/missionparse.h"      //TODO remove?
 #include "missionui/missioncmdbrief.h" //TODO remove?
 #include "sound/audiostr.h"
+#include "iff_defs/iff_defs.h"
 
 #include <QMessageBox>
 
@@ -23,6 +24,9 @@ bool BriefingEditorDialogModel::apply()
 		Briefings[i] = _wipBriefings[i];
 	}
 
+	Mission_music[SCORE_BRIEFING] = _briefingMusicIndex - 1;
+	strcpy_s(The_mission.substitute_briefing_music_name, _subBriefingMusic.c_str());
+
 	return true;
 }
 
@@ -40,9 +44,77 @@ void BriefingEditorDialogModel::initializeData()
 		_wipBriefings[i] = Briefings[i];
 	}
 
+	_briefingMusicIndex = Mission_music[SCORE_BRIEFING] + 1;
+	if (_briefingMusicIndex < 0)
+		_briefingMusicIndex = 0;
+	const int maxIdx = static_cast<int>(Spooled_music.size());
+	if (_briefingMusicIndex > maxIdx)
+		_briefingMusicIndex = maxIdx;
+
+	_subBriefingMusic = The_mission.substitute_briefing_music_name;
+
 	_currentTeam = 0;
 	_currentStage = 0;
-	_currentIcon = 0;
+	_currentIcon = -1;
+}
+
+void BriefingEditorDialogModel::stopSpeech()
+{
+	if (_waveId >= 0) {
+		audiostream_close_file(_waveId, false);
+		_waveId = -1;
+	}
+}
+
+void BriefingEditorDialogModel::initializeTeamList()
+{
+	_teamList.clear();
+	for (auto& team : Mission_event_teams_tvt) {
+		_teamList.emplace_back(team.first, team.second);
+	}
+}
+
+bool BriefingEditorDialogModel::valid_icon_index(const brief_stage& s, int idx)
+{
+	return idx >= 0 && idx < s.num_icons;
+}
+bool BriefingEditorDialogModel::same_line_unordered(int a0, int a1, int b0, int b1)
+{
+	return (a0 == b0 && a1 == b1) || (a0 == b1 && a1 == b0);
+}
+
+void BriefingEditorDialogModel::applyToIconCurrentAndForward(const std::function<void(brief_icon&)>& mutator)
+{
+	auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages)
+		return;
+
+	auto& s = briefing.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	const int targetId = s.icons[_currentIcon].id;
+
+	// Always mutate the icon in the current stage
+	mutator(s.icons[_currentIcon]);
+
+	if (_changeLocally) {
+		set_modified();
+		return;
+	}
+
+	// Propagate forward: for each later stage in this team, if an icon with the same id exists, mutate it too.
+	for (int st = _currentStage + 1; st < briefing.num_stages; ++st) {
+		auto& stg = briefing.stages[st];
+		for (int i = 0; i < stg.num_icons; ++i) {
+			if (stg.icons[i].id == targetId) {
+				mutator(stg.icons[i]);
+				// do not break: multiple instances with same id in a stage should all receive the change if present
+			}
+		}
+	}
+
+	set_modified();
 }
 
 void BriefingEditorDialogModel::gotoPreviousStage()
@@ -68,8 +140,8 @@ void BriefingEditorDialogModel::gotoNextStage()
 		return;
 	}
 
-	_currentStage++;
 	stopSpeech();
+	_currentStage++;
 }
 
 void BriefingEditorDialogModel::addStage()
@@ -84,10 +156,32 @@ void BriefingEditorDialogModel::addStage()
 
 	_wipBriefings[_currentTeam].num_stages++;
 	_currentStage = _wipBriefings[_currentTeam].num_stages - 1;
-	_wipBriefings[_currentTeam].stages[_currentStage].text = "<Text here>";
-	strcpy_s(_wipBriefings[_currentTeam].stages[_currentStage].voice,
-		"none.wav"); // Really? Seeding with none.wav is gross
-	_wipBriefings[_currentTeam].stages[_currentStage].formula = -1;
+	_currentIcon = -1;
+
+	// Seed from previous stage if available, otherwise from sane defaults.
+	brief_stage& dst = _wipBriefings[_currentTeam].stages[_currentStage];
+
+	if (_currentStage > 0) {
+		const brief_stage& prev = _wipBriefings[_currentTeam].stages[_currentStage - 1];
+
+		dst = prev; // start by copying everything…
+		// …then clear fields that should not carry over by default
+		dst.text = "<Text here>";
+		dst.voice[0] = '\0';
+	} else {
+		// First stage in an empty briefing
+		dst.text = "<Text here>";
+		dst.voice[0] = '\0';
+		dst.camera_pos = vmd_zero_vector;
+		dst.camera_orient = vmd_identity_matrix;
+		dst.camera_time = 500;
+		dst.flags = 0;
+		dst.draw_grid = true;
+		dst.grid_color = Color_briefing_grid;
+		dst.formula = -1;
+		dst.num_icons = 0;
+		dst.num_lines = 0;
+	}
 
 	set_modified();
 }
@@ -108,6 +202,8 @@ void BriefingEditorDialogModel::insertStage()
 	for (int i = _wipBriefings[_currentTeam].num_stages - 1; i > _currentStage; i--) {
 		_wipBriefings[_currentTeam].stages[i] = _wipBriefings[_currentTeam].stages[i - 1];
 	}
+
+	_currentIcon = -1;
 
 	// Future TODO: Add a QtFRED Option to clear the inserted stage instead of copying the current one.
 
@@ -146,7 +242,63 @@ void BriefingEditorDialogModel::deleteStage()
 		_currentStage = _wipBriefings[_currentTeam].num_stages - 1;
 	}
 
+	_currentIcon = -1;
+
 	set_modified();
+}
+
+// Eventually the Ui will pass in the data from the render view
+void BriefingEditorDialogModel::saveStageView(const vec3d& pos, const matrix& orient)
+{
+	auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages) {
+		return;
+	}
+
+	brief_stage& s = briefing.stages[_currentStage];
+	modify(s.camera_pos, pos);
+	modify(s.camera_orient, orient);
+}
+
+// Returns the camera position and orientation for the current stage so the UI can tell the render camera to move there
+std::pair<vec3d, matrix> BriefingEditorDialogModel::getStageView() const
+{
+	const auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages) {
+		return {vmd_zero_vector, vmd_identity_matrix};
+	}
+
+	const brief_stage& s = briefing.stages[_currentStage];
+	return {s.camera_pos, s.camera_orient};
+}
+
+void BriefingEditorDialogModel::copyStageViewToClipboard()
+{
+	const auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages) {
+		_viewClipboardSet = false;
+		return;
+	}
+
+	const brief_stage& s = briefing.stages[_currentStage];
+	_viewClipboardPos = s.camera_pos;
+	_viewClipboardOri = s.camera_orient;
+	_viewClipboardSet = true;
+}
+
+void BriefingEditorDialogModel::pasteClipboardViewToStage()
+{
+	if (!_viewClipboardSet)
+		return;
+
+	auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages) {
+		return;
+	}
+
+	brief_stage& s = briefing.stages[_currentStage];
+	modify(s.camera_pos, _viewClipboardPos);
+	modify(s.camera_orient, _viewClipboardOri);
 }
 
 void BriefingEditorDialogModel::testSpeech()
@@ -181,22 +333,6 @@ const SCP_vector<std::pair<SCP_string, int>>& BriefingEditorDialogModel::getTeam
 bool BriefingEditorDialogModel::getMissionIsMultiTeam()
 {
 	return The_mission.game_type & MISSION_TYPE_MULTI_TEAMS;
-}
-
-void BriefingEditorDialogModel::stopSpeech()
-{
-	if (_waveId >= -1) {
-		audiostream_close_file(_waveId, false);
-		_waveId = -1;
-	}
-}
-
-void BriefingEditorDialogModel::initializeTeamList()
-{
-	_teamList.clear();
-	for (auto& team : Mission_event_teams_tvt) {
-		_teamList.emplace_back(team.first, team.second);
-	}
 }
 
 int BriefingEditorDialogModel::getCurrentTeam() const
@@ -250,6 +386,803 @@ void BriefingEditorDialogModel::setFormula(int formula)
 	modify(_wipBriefings[_currentTeam].stages[_currentStage].formula, formula);
 }
 
+int BriefingEditorDialogModel::getCameraTransitionTime() const
+{
+	const auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages) {
+		return 0;
+	}
+	return briefing.stages[_currentStage].camera_time;
+}
+
+void BriefingEditorDialogModel::setCameraTransitionTime(int ms)
+{
+	auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages) {
+		return;
+	}
+	modify(briefing.stages[_currentStage].camera_time, ms);
+}
+
+vec3d BriefingEditorDialogModel::getCameraPosition() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return vmd_zero_vector;
+	const auto& s = b.stages[_currentStage];
+	return s.camera_pos;
+}
+
+matrix BriefingEditorDialogModel::getCameraOrientation() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return vmd_identity_matrix;
+	const auto& s = b.stages[_currentStage];
+	return s.camera_orient;
+}
+
+void BriefingEditorDialogModel::setCameraPosition(const vec3d& pos)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+	modify(s.camera_pos, pos);
+}
+
+void BriefingEditorDialogModel::setCameraOrientation(const matrix& orient)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+	modify(s.camera_orient, orient);
+}
+
+bool BriefingEditorDialogModel::getCutToNext() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return false;
+	return (b.stages[_currentStage].flags & BS_FORWARD_CUT) != 0;
+}
+
+void BriefingEditorDialogModel::setCutToNext(bool enabled)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+
+	int flags = s.flags;
+	if (enabled)
+		flags |= BS_FORWARD_CUT;
+	else
+		flags &= ~BS_FORWARD_CUT;
+
+	modify(s.flags, flags);
+}
+
+bool BriefingEditorDialogModel::getCutFromPrev() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return false;
+	return (b.stages[_currentStage].flags & BS_BACKWARD_CUT) != 0;
+}
+
+void BriefingEditorDialogModel::setCutFromPrev(bool enabled)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+
+	int flags = s.flags;
+	if (enabled)
+		flags |= BS_BACKWARD_CUT;
+	else
+		flags &= ~BS_BACKWARD_CUT;
+	
+	modify(s.flags, flags);
+}
+
+bool BriefingEditorDialogModel::getDisableGrid() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return false;
+	// disable = !draw_grid
+	return !b.stages[_currentStage].draw_grid;
+}
+
+void BriefingEditorDialogModel::setDisableGrid(bool disabled)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+
+	modify(b.stages[_currentStage].draw_grid, !disabled);
+}
+
+int BriefingEditorDialogModel::getCurrentIconIndex() const
+{
+	return _currentIcon; // -1 means no icon selected
+}
+
+void BriefingEditorDialogModel::setCurrentIconIndex(int idx)
+{
+	const auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages) {
+		_currentIcon = -1;
+		return;
+	}
+
+	const auto& stage = briefing.stages[_currentStage];
+	if (idx < 0) {
+		_currentIcon = -1;
+	} else if (idx >= stage.num_icons) {
+		_currentIcon = (stage.num_icons > 0) ? (stage.num_icons - 1) : -1;
+	} else {
+		_currentIcon = idx;
+	}
+}
+
+vec3d BriefingEditorDialogModel::getIconPosition() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return vmd_zero_vector;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return vmd_zero_vector;
+	return s.icons[_currentIcon].pos;
+}
+
+void BriefingEditorDialogModel::setIconPosition(const vec3d& pos)
+{
+	// Honors Change Locally: current stage only if enabled, else propagate forward by icon id
+	applyToIconCurrentAndForward([&](brief_icon& ic) { modify(ic.pos, pos); });
+}
+
+int BriefingEditorDialogModel::getIconId() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return -1;
+
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return -1;
+
+	return s.icons[_currentIcon].id;
+}
+
+void BriefingEditorDialogModel::setIconId(int id)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+
+	auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	modify(s.icons[_currentIcon].id, id);
+}
+
+SCP_string BriefingEditorDialogModel::getIconLabel() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return {};
+
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return {};
+
+	return s.icons[_currentIcon].label;
+}
+
+void BriefingEditorDialogModel::setIconLabel(const SCP_string& text)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+
+	auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	SCP_string oldLabel = s.icons[_currentIcon].label;
+	modify(oldLabel, text);
+
+	strcpy_s(s.icons[_currentIcon].label, oldLabel.c_str());
+}
+
+SCP_string BriefingEditorDialogModel::getIconCloseupLabel() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return {};
+
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return {};
+
+	return s.icons[_currentIcon].closeup_label;
+}
+
+void BriefingEditorDialogModel::setIconCloseupLabel(const SCP_string& text)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+
+	auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	SCP_string oldLabel = s.icons[_currentIcon].closeup_label;
+	modify(oldLabel, text);
+
+	strcpy_s(s.icons[_currentIcon].closeup_label, oldLabel.c_str());
+}
+
+int BriefingEditorDialogModel::getIconTypeIndex() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return -1;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return -1;
+	return s.icons[_currentIcon].type; // 0..MIN_BRIEF_ICONS-1
+}
+
+void BriefingEditorDialogModel::setIconTypeIndex(int idx)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	modify(s.icons[_currentIcon].type, idx);
+}
+
+int BriefingEditorDialogModel::getIconShipTypeIndex() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return -1;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return -1;
+	return s.icons[_currentIcon].ship_class; // may be -1 for “unset” depending on icon type
+}
+
+void BriefingEditorDialogModel::setIconShipTypeIndex(int idx)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	modify(s.icons[_currentIcon].ship_class, idx);
+}
+
+int BriefingEditorDialogModel::getIconTeamIndex() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return -1;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return -1;
+	return s.icons[_currentIcon].team;
+}
+
+void BriefingEditorDialogModel::setIconTeamIndex(int idx)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	modify(s.icons[_currentIcon].team, idx);
+}
+
+float BriefingEditorDialogModel::getIconScaleFactor() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return 1.0f;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return 1.0f;
+
+	return s.icons[_currentIcon].scale_factor;
+}
+
+void BriefingEditorDialogModel::setIconScaleFactor(float factor)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	// basic clamp for sanity
+	if (factor < 0.01f)
+		factor = 0.01f;
+	if (factor > 10.0f)
+		factor = 10.0f;
+
+	modify(s.icons[_currentIcon].scale_factor, factor);
+}
+
+void BriefingEditorDialogModel::setLineSelection(const SCP_vector<int>& indices)
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages) {
+		_lineSelection.clear();
+		return;
+	}
+	const auto& s = b.stages[_currentStage];
+
+	SCP_vector<int> cleaned;
+	cleaned.reserve(indices.size());
+	for (int idx : indices) {
+		if (!valid_icon_index(s, idx))
+			continue;
+		if (std::find(cleaned.begin(), cleaned.end(), idx) == cleaned.end())
+			cleaned.push_back(idx);
+	}
+	
+	_lineSelection = std::move(cleaned);
+}
+
+void BriefingEditorDialogModel::clearLineSelection()
+{
+	_lineSelection.clear();
+}
+
+BriefingEditorDialogModel::DrawLinesState BriefingEditorDialogModel::getDrawLinesState() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return DrawLinesState::None;
+	const auto& s = b.stages[_currentStage];
+
+	if (_lineSelection.size() < 2)
+		return DrawLinesState::None;
+
+	// Count how many unordered pairs exist as lines
+	int connected = 0, totalPairs = 0;
+
+	for (size_t i = 0; i + 1 < _lineSelection.size(); ++i) {
+		int a = _lineSelection[i];
+		if (!valid_icon_index(s, a))
+			continue;
+
+		for (size_t j = i + 1; j < _lineSelection.size(); ++j) {
+			int bidx = _lineSelection[j];
+			if (!valid_icon_index(s, bidx))
+				continue;
+
+			++totalPairs;
+			bool exists = false;
+			for (int l = 0; l < s.num_lines; ++l) {
+				if (same_line_unordered(s.lines[l].start_icon, s.lines[l].end_icon, a, bidx)) {
+					exists = true;
+					break;
+				}
+			}
+			if (exists)
+				++connected;
+		}
+	}
+
+	if (totalPairs == 0)
+		return DrawLinesState::None;
+	if (connected == 0)
+		return DrawLinesState::None;
+	if (connected == totalPairs)
+		return DrawLinesState::All;
+	return DrawLinesState::Partial;
+}
+
+
+void BriefingEditorDialogModel::applyDrawLines(bool checked)
+{
+	auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	auto& s = b.stages[_currentStage];
+
+	if (_lineSelection.size() < 2)
+		return;
+
+	// Build a valid, deduped selection snapshot against current stage
+	SCP_vector<int> sel;
+	sel.reserve(_lineSelection.size());
+	for (int idx : _lineSelection) {
+		if (valid_icon_index(s, idx) && std::find(sel.begin(), sel.end(), idx) == sel.end()) {
+			sel.push_back(idx);
+		}
+	}
+	if (sel.size() < 2)
+		return;
+
+	bool changed = false;
+
+	if (checked) {
+		// Add missing lines for every unordered pair
+		for (size_t i = 0; i + 1 < sel.size(); ++i) {
+			for (size_t j = i + 1; j < sel.size(); ++j) {
+				const int a = sel[i], bidx = sel[j];
+
+				bool exists = false;
+				for (int l = 0; l < s.num_lines; ++l) {
+					if (same_line_unordered(s.lines[l].start_icon, s.lines[l].end_icon, a, bidx)) {
+						exists = true;
+						break;
+					}
+				}
+				if (!exists && s.num_lines < MAX_BRIEF_STAGE_LINES) {
+					s.lines[s.num_lines].start_icon = a;
+					s.lines[s.num_lines].end_icon = bidx;
+					s.num_lines++;
+					changed = true;
+				}
+			}
+		}
+	} else {
+		// Remove any lines whose endpoints are both in the selection
+		for (int i = s.num_lines - 1; i >= 0; --i) {
+			const int a = s.lines[i].start_icon;
+			const int bidx = s.lines[i].end_icon;
+			const bool aSel = std::find(sel.begin(), sel.end(), a) != sel.end();
+			const bool bSel = std::find(sel.begin(), sel.end(), bidx) != sel.end();
+			if (aSel && bSel) {
+				// delete by shifting down
+				for (int k = i; k + 1 < s.num_lines; ++k) {
+					s.lines[k] = s.lines[k + 1];
+				}
+				s.num_lines--;
+				changed = true;
+			}
+		}
+	}
+
+	// Clean any broken lines just in case
+	for (int i = s.num_lines - 1; i >= 0; --i) {
+		const int a = s.lines[i].start_icon;
+		const int bidx = s.lines[i].end_icon;
+		if (!valid_icon_index(s, a) || !valid_icon_index(s, bidx)) {
+			for (int k = i; k + 1 < s.num_lines; ++k) {
+				s.lines[k] = s.lines[k + 1];
+			}
+			s.num_lines--;
+			changed = true;
+		}
+	}
+
+	if (changed)
+		set_modified();
+}
+
+bool BriefingEditorDialogModel::getChangeLocally() const
+{
+	return _changeLocally;
+}
+
+void BriefingEditorDialogModel::setChangeLocally(bool enabled)
+{
+	// Editor-only; do not mark modified
+	modify(_changeLocally, enabled);
+}
+
+bool BriefingEditorDialogModel::getIconHighlighted() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return false;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return false;
+	return (s.icons[_currentIcon].flags & BI_HIGHLIGHT) != 0;
+}
+
+void BriefingEditorDialogModel::setIconHighlighted(bool enabled)
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	auto ic = s.icons[_currentIcon];
+	int newFlags = ic.flags;
+	if (enabled) {
+		newFlags |= BI_HIGHLIGHT;
+	} else {
+		newFlags &= ~BI_HIGHLIGHT;
+	}
+	modify(ic.flags, newFlags);
+}
+
+bool BriefingEditorDialogModel::getIconFlipped() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return false;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return false;
+	return (s.icons[_currentIcon].flags & BI_MIRROR_ICON) != 0;
+}
+
+void BriefingEditorDialogModel::setIconFlipped(bool enabled)
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	auto ic = s.icons[_currentIcon];
+	int newFlags = ic.flags;
+	if (enabled) {
+		newFlags |= BI_MIRROR_ICON;
+	} else {
+		newFlags &= ~BI_MIRROR_ICON;
+	}
+	modify(ic.flags, newFlags);
+}
+
+bool BriefingEditorDialogModel::getIconUseWing() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return false;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return false;
+	return (s.icons[_currentIcon].flags & BI_USE_WING_ICON) != 0;
+}
+
+void BriefingEditorDialogModel::setIconUseWing(bool enabled)
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	auto ic = s.icons[_currentIcon];
+	int newFlags = ic.flags;
+	if (enabled) {
+		newFlags |= BI_USE_WING_ICON;
+	} else {
+		newFlags &= ~BI_USE_WING_ICON;
+	}
+	modify(ic.flags, newFlags);
+}
+
+bool BriefingEditorDialogModel::getIconUseCargo() const
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return false;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return false;
+	return (s.icons[_currentIcon].flags & BI_USE_CARGO_ICON) != 0;
+}
+
+void BriefingEditorDialogModel::setIconUseCargo(bool enabled)
+{
+	const auto& b = _wipBriefings[_currentTeam];
+	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
+		return;
+	const auto& s = b.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= s.num_icons)
+		return;
+
+	auto ic = s.icons[_currentIcon];
+	int newFlags = ic.flags;
+	if (enabled) {
+		newFlags |= BI_USE_CARGO_ICON;
+	} else {
+		newFlags &= ~BI_USE_CARGO_ICON;
+	}
+	modify(ic.flags, newFlags);
+}
+
+void BriefingEditorDialogModel::makeIcon(const SCP_string& label, int typeIndex, int teamIndex, int shipClassIndex)
+{
+	auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages)
+		return;
+
+	auto& s = briefing.stages[_currentStage];
+	if (s.num_icons >= MAX_STAGE_ICONS)
+		return; // at capacity
+
+	// Small scoped helpers
+	auto clamp = [](int v, int lo, int hi) { return (v < lo) ? lo : (v > hi ? hi : v); };
+	auto copy_cstr = [&](char* dst, size_t cap, const SCP_string& src) {
+		if (cap == 0)
+			return;
+		const size_t n = std::min(cap - 1, src.size());
+		if (n)
+			std::memcpy(dst, src.data(), n);
+		dst[n] = '\0';
+	};
+	auto next_icon_id = [&]() {
+		int maxId = -1;
+		for (int st = 0; st < briefing.num_stages; ++st) {
+			const auto& bs = briefing.stages[st];
+			for (int i = 0; i < bs.num_icons; ++i)
+				maxId = std::max(maxId, bs.icons[i].id);
+		}
+		return maxId + 1; // unique within this team’s briefing
+	};
+
+	// Clamp incoming indices to safe ranges
+	const int safeType = clamp(typeIndex, 0, MIN_BRIEF_ICONS - 1);
+	const int safeTeam = clamp(teamIndex, 0, (int)Iff_info.size() - 1);
+	const int safeClass = (shipClassIndex < 0) ? -1 : clamp(shipClassIndex, 0, (int)Ship_info.size() - 1);
+
+	// Allocate slot
+	const int idx = s.num_icons;
+	brief_icon& ic = s.icons[idx];
+
+	// Minimal identity/classification
+	ic.id = next_icon_id();
+	ic.type = safeType;
+	ic.team = safeTeam;
+	ic.ship_class = safeClass;
+
+	// Labels
+	copy_cstr(ic.label, MAX_LABEL_LEN, label);
+	copy_cstr(ic.closeup_label, MAX_LABEL_LEN, SCP_string()); // empty by default
+
+	// Defaults
+	ic.pos = vmd_zero_vector; // renderer can move it after creation
+	ic.scale_factor = 1.0f;   // 100%
+	ic.flags = 0;             // not flipped/highlighted/wing/cargo
+	ic.modelnum = -1;
+	ic.model_instance_num = -1;
+
+	// Commit
+	s.num_icons++;
+	_currentIcon = idx;
+	_lineSelection.clear();
+	set_modified();
+}
+
+void BriefingEditorDialogModel::deleteCurrentIcon()
+{
+	auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages)
+		return;
+
+	auto& s = briefing.stages[_currentStage];
+	const int del = _currentIcon;
+	if (del < 0 || del >= s.num_icons)
+		return;
+
+	// Remove any lines that reference the icon being deleted
+	for (int i = s.num_lines - 1; i >= 0; --i) {
+		const int a = s.lines[i].start_icon;
+		const int b = s.lines[i].end_icon;
+		if (a == del || b == del) {
+			for (int k = i; k + 1 < s.num_lines; ++k) {
+				s.lines[k] = s.lines[k + 1];
+			}
+			--s.num_lines;
+		}
+	}
+
+	// Reindex remaining line endpoints
+	for (int i = 0; i < s.num_lines; ++i) {
+		if (s.lines[i].start_icon > del)
+			--s.lines[i].start_icon;
+		if (s.lines[i].end_icon > del)
+			--s.lines[i].end_icon;
+	}
+
+	// Shift icons down to fill the gap
+	for (int i = del; i + 1 < s.num_icons; ++i) {
+		s.icons[i] = s.icons[i + 1];
+	}
+	--s.num_icons;
+
+	// Update selection
+	_lineSelection.clear();
+	_currentIcon = -1;
+
+	set_modified();
+}
+
+void BriefingEditorDialogModel::propagateCurrentIconForward()
+{
+	auto& briefing = _wipBriefings[_currentTeam];
+	if (briefing.num_stages <= 0 || _currentStage < 0 || _currentStage >= briefing.num_stages)
+		return;
+
+	auto& curStage = briefing.stages[_currentStage];
+	if (_currentIcon < 0 || _currentIcon >= curStage.num_icons)
+		return;
+
+	const brief_icon src = curStage.icons[_currentIcon]; // snapshot of current icon
+	bool changed = false;
+
+	for (int st = _currentStage + 1; st < briefing.num_stages; ++st) {
+		auto& s = briefing.stages[st];
+
+		// Find all icons with the same id in this later stage
+		int foundCount = 0;
+		for (int i = 0; i < s.num_icons; ++i) {
+			if (s.icons[i].id == src.id) {
+				// Overwrite the existing icon with current state
+				s.icons[i] = src;
+				++foundCount;
+				changed = true;
+			}
+		}
+
+		// If none found, append a copy (if capacity allows)
+		if (foundCount == 0 && s.num_icons < MAX_STAGE_ICONS) {
+			s.icons[s.num_icons] = src;
+			s.num_icons++;
+			changed = true;
+		}
+		// If at capacity and missing, we silently skip that stage.
+	}
+
+	if (changed)
+		set_modified();
+}
+
+int BriefingEditorDialogModel::getBriefingMusicIndex() const
+{
+	return _briefingMusicIndex;
+}
+
+void BriefingEditorDialogModel::setBriefingMusicIndex(int idx)
+{
+	const int maxIdx = static_cast<int>(Spooled_music.size());
+	if (idx < 0)
+		idx = 0;
+	if (idx > maxIdx)
+		idx = maxIdx;
+	modify(_briefingMusicIndex, idx);
+}
+
+SCP_string BriefingEditorDialogModel::getSubstituteBriefingMusicName() const
+{
+	return _subBriefingMusic;
+}
+
+void BriefingEditorDialogModel::setSubstituteBriefingMusicName(const SCP_string& name)
+{
+	modify(_subBriefingMusic, name);
+}
+
 SCP_vector<SCP_string> BriefingEditorDialogModel::getMusicList()
 {
 	SCP_vector<SCP_string> music_list;
@@ -260,6 +1193,37 @@ SCP_vector<SCP_string> BriefingEditorDialogModel::getMusicList()
 	}
 
 	return music_list;
+}
+
+SCP_vector<std::pair<int, SCP_string>> BriefingEditorDialogModel::getIconList()
+{
+	SCP_vector<std::pair<int, SCP_string>> out;
+	out.reserve(MIN_BRIEF_ICONS);
+	for (int i = 0; i < MIN_BRIEF_ICONS; ++i) {
+		out.emplace_back(i, Icon_names[i]);
+	}
+	return out;
+}
+
+SCP_vector<std::pair<int, SCP_string>> BriefingEditorDialogModel::getShipList()
+{
+	SCP_vector<std::pair<int, SCP_string>> out;
+	out.reserve((int)Ship_info.size());
+	int idx = 0;
+	for (auto it = Ship_info.cbegin(); it != Ship_info.cend(); ++it, ++idx) {
+		out.emplace_back(idx, it->name);
+	}
+	return out;
+}
+
+SCP_vector<std::pair<int, SCP_string>> BriefingEditorDialogModel::getIffList()
+{
+	SCP_vector<std::pair<int, SCP_string>> out;
+	out.reserve((int)Iff_info.size());
+	for (int i = 0; i < (int)Iff_info.size(); ++i) {
+		out.emplace_back(i, Iff_info[i].iff_name);
+	}
+	return out;
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BriefingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BriefingEditorDialogModel.cpp
@@ -256,8 +256,9 @@ void BriefingEditorDialogModel::saveStageView(const vec3d& pos, const matrix& or
 	}
 
 	brief_stage& s = briefing.stages[_currentStage];
-	modify(s.camera_pos, pos);
-	modify(s.camera_orient, orient);
+	s.camera_pos = pos; //TODO make modify() support these
+	s.camera_orient = orient;
+	set_modified();
 }
 
 // Returns the camera position and orientation for the current stage so the UI can tell the render camera to move there
@@ -297,8 +298,9 @@ void BriefingEditorDialogModel::pasteClipboardViewToStage()
 	}
 
 	brief_stage& s = briefing.stages[_currentStage];
-	modify(s.camera_pos, _viewClipboardPos);
-	modify(s.camera_orient, _viewClipboardOri);
+	s.camera_pos = _viewClipboardPos; // TODO make modify() support these
+	s.camera_orient = _viewClipboardOri;
+	set_modified();
 }
 
 void BriefingEditorDialogModel::testSpeech()
@@ -428,7 +430,8 @@ void BriefingEditorDialogModel::setCameraPosition(const vec3d& pos)
 	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
 		return;
 	auto& s = b.stages[_currentStage];
-	modify(s.camera_pos, pos);
+	s.camera_pos = pos; // TODO make modify() support these
+	set_modified();
 }
 
 void BriefingEditorDialogModel::setCameraOrientation(const matrix& orient)
@@ -437,7 +440,8 @@ void BriefingEditorDialogModel::setCameraOrientation(const matrix& orient)
 	if (b.num_stages <= 0 || _currentStage < 0 || _currentStage >= b.num_stages)
 		return;
 	auto& s = b.stages[_currentStage];
-	modify(s.camera_orient, orient);
+	s.camera_orient = orient; // TODO make modify() support these
+	set_modified();
 }
 
 bool BriefingEditorDialogModel::getCutToNext() const

--- a/qtfred/src/mission/dialogs/BriefingEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BriefingEditorDialogModel.h
@@ -5,13 +5,18 @@
 #include "AbstractDialogModel.h"
 
 #include "mission/missionbriefcommon.h"
-#include "missionui/missioncmdbrief.h" //TODO remove this?
 
 namespace fso::fred::dialogs {
 
 class BriefingEditorDialogModel : public AbstractDialogModel {
   public:
 	BriefingEditorDialogModel(QObject* parent, EditorViewport* viewport);
+
+	enum class DrawLinesState {
+		None,    // no lines between any selected pairs
+		Partial, // some pairs connected, some not
+		All      // every pair connected
+	};
 
 	bool apply() override;
 	void reject() override;
@@ -33,25 +38,107 @@ class BriefingEditorDialogModel : public AbstractDialogModel {
 	void addStage();
 	void insertStage();
 	void deleteStage();
+
+	void saveStageView(const vec3d& pos, const matrix& orient);
+	std::pair<vec3d, matrix> getStageView() const;
+	void copyStageViewToClipboard();
+	void pasteClipboardViewToStage();
+
 	void testSpeech();
 	void copyToOtherTeams();
 	const SCP_vector<std::pair<SCP_string, int>>& getTeamList();
 	static bool getMissionIsMultiTeam();
 
+	int getCameraTransitionTime() const;
+	void setCameraTransitionTime(int ms);
+
+	vec3d getCameraPosition() const;
+	matrix getCameraOrientation() const;
+	void setCameraPosition(const vec3d& pos);
+	void setCameraOrientation(const matrix& orient);
+
+	bool getCutToNext() const;
+	void setCutToNext(bool enabled);
+	bool getCutFromPrev() const;
+	void setCutFromPrev(bool enabled);
+	bool getDisableGrid() const;
+	void setDisableGrid(bool disabled);	
+
+	int getCurrentIconIndex() const;
+	void setCurrentIconIndex(int idx);
+	vec3d getIconPosition() const;
+	void setIconPosition(const vec3d& pos);
+	int getIconId() const;
+	void setIconId(int id);
+	SCP_string getIconLabel() const;
+	void setIconLabel(const SCP_string& text);
+	SCP_string getIconCloseupLabel() const;
+	void setIconCloseupLabel(const SCP_string& text);
+
+	int getIconTypeIndex() const;
+	void setIconTypeIndex(int idx);
+	int getIconShipTypeIndex() const;
+	void setIconShipTypeIndex(int idx);
+	int getIconTeamIndex() const;
+	void setIconTeamIndex(int idx);
+	float getIconScaleFactor() const;
+	void setIconScaleFactor(float factor);
+
+	void setLineSelection(const SCP_vector<int>& indices);
+	void clearLineSelection();
+	DrawLinesState getDrawLinesState() const;
+	void applyDrawLines(bool checked);
+
+	bool getChangeLocally() const;
+	void setChangeLocally(bool enabled);
+
+	bool getIconHighlighted() const;
+	void setIconHighlighted(bool enabled);
+	bool getIconFlipped() const;
+	void setIconFlipped(bool enabled);
+	bool getIconUseWing() const;
+	void setIconUseWing(bool enabled);
+	bool getIconUseCargo() const;
+	void setIconUseCargo(bool enabled);
+
+	void makeIcon(const SCP_string& label, int typeIndex, int teamIndex, int shipClassIndex);
+	void deleteCurrentIcon();
+	void propagateCurrentIconForward();
+
+	int getBriefingMusicIndex() const;
+	void setBriefingMusicIndex(int idx);
+	SCP_string getSubstituteBriefingMusicName() const;
+	void setSubstituteBriefingMusicName(const SCP_string& name);
+
 	static SCP_vector<SCP_string> getMusicList();
+	static SCP_vector<std::pair<int, SCP_string>> getIconList();
+	static SCP_vector<std::pair<int, SCP_string>> getShipList();
+	static SCP_vector<std::pair<int, SCP_string>> getIffList();
 
   private:
 	void initializeData();
 	void stopSpeech();
 	void initializeTeamList();
+	static bool valid_icon_index(const brief_stage& s, int idx);
+	static bool same_line_unordered(int a0, int a1, int b0, int b1);
+	void applyToIconCurrentAndForward(const std::function<void(brief_icon&)>& mutator);
 
 	briefing _wipBriefings[MAX_TVT_TEAMS];
+	int _briefingMusicIndex;
+	SCP_string _subBriefingMusic;
 
 	int _currentTeam;
 	int _currentStage;
 	int _currentIcon;
 	int _waveId;
 	SCP_vector<std::pair<SCP_string, int>> _teamList;
+
+	bool _viewClipboardSet = false;
+	vec3d _viewClipboardPos = vmd_zero_vector;
+	matrix _viewClipboardOri = vmd_identity_matrix;
+
+	SCP_vector<int> _lineSelection;
+	bool _changeLocally = false;
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/BriefingEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BriefingEditorDialogModel.h
@@ -23,8 +23,6 @@ class BriefingEditorDialogModel : public AbstractDialogModel {
 
 	SCP_string getStageText();
 	void setStageText(const SCP_string& text);
-	SCP_string getRecommendationText();
-	void setRecommendationText(const SCP_string& text);
 	SCP_string getSpeechFilename();
 	void setSpeechFilename(const SCP_string& speechFilename);
 	int getFormula() const;
@@ -41,25 +39,17 @@ class BriefingEditorDialogModel : public AbstractDialogModel {
 	static bool getMissionIsMultiTeam();
 
 	static SCP_vector<SCP_string> getMusicList();
-	int getSuccessMusicTrack() const;
-	void setSuccessMusicTrack(int trackIndex);
-	int getAverageMusicTrack() const;
-	void setAverageMusicTrack(int trackIndex);
-	int getFailureMusicTrack() const;
-	void setFailureMusicTrack(int trackIndex);
 
   private:
 	void initializeData();
 	void stopSpeech();
 	void initializeTeamList();
 
-	debriefing _wipDebriefing[MAX_TVT_TEAMS];
-	int _successMusic;
-	int _averageMusic;
-	int _failureMusic;
+	briefing _wipBriefings[MAX_TVT_TEAMS];
 
 	int _currentTeam;
 	int _currentStage;
+	int _currentIcon;
 	int _waveId;
 	SCP_vector<std::pair<SCP_string, int>> _teamList;
 };

--- a/qtfred/src/mission/dialogs/BriefingEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BriefingEditorDialogModel.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "globalincs/pstypes.h"
+
+#include "AbstractDialogModel.h"
+
+#include "mission/missionbriefcommon.h"
+#include "missionui/missioncmdbrief.h" //TODO remove this?
+
+namespace fso::fred::dialogs {
+
+class BriefingEditorDialogModel : public AbstractDialogModel {
+  public:
+	BriefingEditorDialogModel(QObject* parent, EditorViewport* viewport);
+
+	bool apply() override;
+	void reject() override;
+
+	int getCurrentTeam() const;
+	void setCurrentTeam(int teamIn);
+	int getCurrentStage() const;
+	int getTotalStages();
+
+	SCP_string getStageText();
+	void setStageText(const SCP_string& text);
+	SCP_string getRecommendationText();
+	void setRecommendationText(const SCP_string& text);
+	SCP_string getSpeechFilename();
+	void setSpeechFilename(const SCP_string& speechFilename);
+	int getFormula() const;
+	void setFormula(int formula);
+
+	void gotoPreviousStage();
+	void gotoNextStage();
+	void addStage();
+	void insertStage();
+	void deleteStage();
+	void testSpeech();
+	void copyToOtherTeams();
+	const SCP_vector<std::pair<SCP_string, int>>& getTeamList();
+	static bool getMissionIsMultiTeam();
+
+	static SCP_vector<SCP_string> getMusicList();
+	int getSuccessMusicTrack() const;
+	void setSuccessMusicTrack(int trackIndex);
+	int getAverageMusicTrack() const;
+	void setAverageMusicTrack(int trackIndex);
+	int getFailureMusicTrack() const;
+	void setFailureMusicTrack(int trackIndex);
+
+  private:
+	void initializeData();
+	void stopSpeech();
+	void initializeTeamList();
+
+	debriefing _wipDebriefing[MAX_TVT_TEAMS];
+	int _successMusic;
+	int _averageMusic;
+	int _failureMusic;
+
+	int _currentTeam;
+	int _currentStage;
+	int _waveId;
+	SCP_vector<std::pair<SCP_string, int>> _teamList;
+};
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -746,7 +746,7 @@ void FredView::on_actionVolumetric_Nebula_triggered(bool)
 	volumetricNebulaEditor->show();
 }
 void FredView::on_actionBriefing_triggered(bool) {
-	auto eventEditor = new dialogs::BriefingEditorDialog(this);
+	auto eventEditor = new dialogs::BriefingEditorDialog(this, _viewport);
 	eventEditor->setAttribute(Qt::WA_DeleteOnClose);
 	eventEditor->show();
 }

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
@@ -2,33 +2,13 @@
 #include "ui_BriefingEditorDialog.h"
 #include <QtWidgets/QMenuBar>
 
-namespace fso {
-namespace fred {
-namespace dialogs {
+namespace fso::fred::dialogs {
 
-BriefingEditorDialog::BriefingEditorDialog(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::BriefingEditorDialog)
+BriefingEditorDialog::BriefingEditorDialog(QWidget* parent) : QDialog(parent), ui(new Ui::BriefingEditorDialog)
 {
-    ui->setupUi(this);
-
-    QMenuBar *menubar = new QMenuBar();
-    QMenu *teamMenu = new QMenu("Select Team");
-    teamMenu->addAction("Team 1");
-    teamMenu->addAction("Team 2");
-    QMenu *optionsMenu = new QMenu("Options");
-    optionsMenu->addAction("Balance Teams");
-    menubar->addMenu(teamMenu);
-    menubar->addMenu(optionsMenu);
-
-    ui->mainLayout->insertWidget(0,menubar);
+	ui->setupUi(this);
 }
 
-BriefingEditorDialog::~BriefingEditorDialog()
-{
-    delete ui;
-}
+BriefingEditorDialog::~BriefingEditorDialog() = default;
 
-}
-}
-}
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
@@ -1,14 +1,213 @@
 #include "BriefingEditorDialog.h"
 #include "ui_BriefingEditorDialog.h"
-#include <QtWidgets/QMenuBar>
+
+#include "mission/util.h"
+
+#include <globalincs/linklist.h>
+#include <ui/util/SignalBlockers.h>
+
+#include <QCloseEvent>
+#include <QFileDialog>
 
 namespace fso::fred::dialogs {
 
-BriefingEditorDialog::BriefingEditorDialog(QWidget* parent) : QDialog(parent), ui(new Ui::BriefingEditorDialog)
+BriefingEditorDialog::BriefingEditorDialog(FredView* parent, EditorViewport* viewport)
+	: QDialog(parent), SexpTreeEditorInterface(flagset<TreeFlags>()), ui(new Ui::BriefingEditorDialog()),
+	  _model(new BriefingEditorDialogModel(this, viewport)), _viewport(viewport)
 {
+	this->setFocus();
 	ui->setupUi(this);
+
+	initializeUi();
+	updateUi();
+
+	resize(QDialog::sizeHint());
 }
 
 BriefingEditorDialog::~BriefingEditorDialog() = default;
+
+void BriefingEditorDialog::accept()
+{
+	// If apply() returns true, close the dialog
+	if (_model->apply()) {
+		QDialog::accept();
+	}
+	// else: validation failed, don’t close
+}
+
+void BriefingEditorDialog::reject()
+{
+	// Asks the user if they want to save changes, if any
+	// If they do, it runs _model->apply() and returns the success value
+	// If they don't, it runs _model->reject() and returns true
+	if (rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		QDialog::reject(); // actually close
+	}
+	// else: do nothing, don't close
+}
+
+void BriefingEditorDialog::closeEvent(QCloseEvent* e)
+{
+	reject();
+	e->ignore(); // Don't let the base class close the window
+}
+
+void BriefingEditorDialog::initializeUi()
+{
+	util::SignalBlockers blockers(this);
+
+	auto list = _model->getTeamList();
+
+	ui->teamComboBox->clear();
+
+	for (const auto& team : list) {
+		ui->teamComboBox->addItem(QString::fromStdString(team.first), team.second);
+	}
+
+	// Initialize the formula tree editor
+	ui->formulaTreeView->initializeEditor(_viewport->editor, this);
+}
+
+void BriefingEditorDialog::updateUi()
+{
+
+	util::SignalBlockers blockers(this);
+
+	ui->teamComboBox->setCurrentIndex(ui->teamComboBox->findData(_model->getCurrentTeam()));
+
+	ui->stageTextPlainTextEdit->setPlainText(QString::fromStdString(_model->getStageText()));
+	ui->voiceFileLineEdit->setText(QString::fromStdString(_model->getSpeechFilename()));
+
+	SCP_string stages = "No Stages";
+	int total = _model->getTotalStages();
+	int current = _model->getCurrentStage() + 1; // internal is 0 based, ui is 1 based
+	if (total > 0) {
+		stages = "Stage ";
+		stages += std::to_string(current);
+		stages += " of ";
+		stages += std::to_string(total);
+	}
+	ui->currentStageLabel->setText(stages.c_str());
+
+	// SEXP tree formula
+	ui->formulaTreeView->load_tree(_model->getFormula());
+	if (ui->formulaTreeView->select_sexp_node != -1) {
+		ui->formulaTreeView->hilite_item(ui->formulaTreeView->select_sexp_node);
+	}
+
+	enableDisableControls();
+}
+
+void BriefingEditorDialog::enableDisableControls()
+{
+	int total_stages = _model->getTotalStages();
+	int current = _model->getCurrentStage();
+	const bool stage_exists = total_stages > 0 && current >= 0;
+
+	ui->prevStageButton->setEnabled(stage_exists && current > 0);
+	ui->nextStageButton->setEnabled(stage_exists && current < total_stages - 1);
+	ui->addStageButton->setEnabled(total_stages < MAX_DEBRIEF_STAGES);
+	ui->insertStageButton->setEnabled(stage_exists && total_stages < MAX_DEBRIEF_STAGES);
+	ui->deleteStageButton->setEnabled(stage_exists);
+
+	ui->teamComboBox->setEnabled(_model->getMissionIsMultiTeam());
+	ui->copyToOtherTeamsButton->setEnabled(_model->getMissionIsMultiTeam());
+
+	ui->stageTextPlainTextEdit->setEnabled(stage_exists);
+	ui->voiceFileLineEdit->setEnabled(stage_exists);
+	ui->voiceFileBrowseButton->setEnabled(stage_exists);
+	ui->voiceFilePlayButton->setEnabled(stage_exists && !_model->getSpeechFilename().empty());
+	ui->formulaTreeView->setEnabled(stage_exists);
+}
+
+void BriefingEditorDialog::on_okAndCancelButtons_accepted()
+{
+	accept();
+}
+
+void BriefingEditorDialog::on_okAndCancelButtons_rejected()
+{
+	reject();
+}
+
+void BriefingEditorDialog::on_prevStageButton_clicked()
+{
+	_model->gotoPreviousStage();
+	updateUi();
+}
+
+void BriefingEditorDialog::on_nextStageButton_clicked()
+{
+	_model->gotoNextStage();
+	updateUi();
+}
+
+void BriefingEditorDialog::on_addStageButton_clicked()
+{
+	_model->addStage();
+	updateUi();
+}
+
+void BriefingEditorDialog::on_insertStageButton_clicked()
+{
+	_model->insertStage();
+	updateUi();
+}
+
+void BriefingEditorDialog::on_deleteStageButton_clicked()
+{
+	_model->deleteStage();
+	updateUi();
+}
+
+void BriefingEditorDialog::on_copyToOtherTeamsButton_clicked()
+{
+	_model->copyToOtherTeams();
+}
+
+void BriefingEditorDialog::on_teamComboBox_currentIndexChanged(int index)
+{
+	_model->setCurrentTeam(ui->teamComboBox->itemData(index).toInt());
+	updateUi();
+}
+
+void BriefingEditorDialog::on_stageTextPlainTextEdit_textChanged()
+{
+	_model->setStageText(ui->stageTextPlainTextEdit->toPlainText().toUtf8().constData());
+}
+
+void BriefingEditorDialog::on_voiceFileLineEdit_textChanged(const QString& string)
+{
+	_model->setSpeechFilename(string.toUtf8().constData());
+}
+
+void BriefingEditorDialog::on_voiceFileBrowseButton_clicked()
+{
+	int dir_pushed = cfile_push_chdir(CF_TYPE_VOICE_DEBRIEFINGS);
+
+	QFileDialog dlg(this, "Select Voice File", "", "Voice Files (*.ogg *.wav)");
+	if (dlg.exec() == QDialog::Accepted) {
+		QStringList files = dlg.selectedFiles();
+		if (!files.isEmpty()) {
+			QFileInfo fileInfo(files.first());
+			_model->setSpeechFilename(fileInfo.fileName().toUtf8().constData());
+			updateUi();
+		}
+	}
+
+	if (dir_pushed) {
+		cfile_pop_dir();
+	}
+}
+
+void BriefingEditorDialog::on_voiceFilePlayButton_clicked()
+{
+	_model->testSpeech();
+}
+
+void BriefingEditorDialog::on_formulaTreeView_nodeChanged(int newTree)
+{
+	_model->setFormula(newTree);
+}
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.h
@@ -1,30 +1,22 @@
-#ifndef BRIEFINGEDITORDIALOG_H
-#define BRIEFINGEDITORDIALOG_H
+#pragma once
 
 #include <QDialog>
 
-namespace fso {
-namespace fred {
-namespace dialogs {
+namespace fso::fred::dialogs {
 
 namespace Ui {
 class BriefingEditorDialog;
 }
 
-class BriefingEditorDialog : public QDialog
-{
-    Q_OBJECT
+class BriefingEditorDialog : public QDialog {
+	Q_OBJECT
 
-public:
-    explicit BriefingEditorDialog(QWidget *parent = 0);
-    ~BriefingEditorDialog() override;
+  public:
+	explicit BriefingEditorDialog(QWidget* parent = 0);
+	~BriefingEditorDialog() override;
 
-private:
-    Ui::BriefingEditorDialog *ui;
+  private:
+	Ui::BriefingEditorDialog* ui;
 };
 
-}
-}
-}
-
-#endif // BRIEFINGEDITORDIALOG_H
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.h
@@ -38,14 +38,46 @@ class BriefingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	void on_insertStageButton_clicked();
 	void on_deleteStageButton_clicked();
 
+	void on_saveViewButton_clicked();
+	void on_gotoViewButton_clicked();
+	void on_copyViewButton_clicked();
+	void on_pasteViewButton_clicked();
+
 	void on_copyToOtherTeamsButton_clicked();
 	void on_teamComboBox_currentIndexChanged(int index);
+
+	void on_cameraTransitionTimeSpinBox_valueChanged(int arg1);
+	void on_cutToNextStageCheckBox_toggled(bool checked);
+	void on_cutToPrevStageCheckBox_toggled(bool checked);
+	void on_disableGridCheckBox_toggled(bool checked);
+
+	void on_iconIdSpinBox_valueChanged(int arg1);
+	void on_iconLabelLineEdit_textChanged(const QString& string);
+	void on_iconCloseupLabelLineEdit_textChanged(const QString& string);
+	void on_iconImageComboBox_currentIndexChanged(int index);
+	void on_iconShipTypeComboBox_currentIndexChanged(int index);
+	void on_iconTeamComboBox_currentIndexChanged(int index);
+	void on_iconScaleDoubleSpinBox_valueChanged(double arg1);
+
+	void on_drawLinesCheckBox_toggled(bool checked);
+	void on_changeLocallyCheckBox_toggled(bool checked);
+	void on_flipIconCheckBox_toggled(bool checked);
+	void on_highlightCheckBox_toggled(bool checked);
+	void on_useWingCheckBox_toggled(bool checked);
+	void on_useCargoCheckBox_toggled(bool checked);
+
+	void on_makeIconButton_clicked();
+	void on_deleteIconButton_clicked();
+	void on_propagateIconButton_clicked();
 
 	void on_stageTextPlainTextEdit_textChanged();
 	void on_voiceFileLineEdit_textChanged(const QString& string);
 	void on_voiceFileBrowseButton_clicked();
 	void on_voiceFilePlayButton_clicked();
 	void on_formulaTreeView_nodeChanged(int newTree);
+
+	void on_defaultMusicComboBox_currentIndexChanged(int index);
+	void on_musicPackComboBox_currentIndexChanged(int index);
 
   private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::BriefingEditorDialog> ui;

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.h
@@ -1,6 +1,12 @@
 #pragma once
 
-#include <QDialog>
+#include "ui/widgets/sexp_tree.h"
+
+#include <mission/dialogs/BriefingEditorDialogModel.h>
+#include <ui/FredView.h>
+
+#include <QAbstractButton>
+#include <QtWidgets/QDialog>
 
 namespace fso::fred::dialogs {
 
@@ -8,15 +14,46 @@ namespace Ui {
 class BriefingEditorDialog;
 }
 
-class BriefingEditorDialog : public QDialog {
+class BriefingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	Q_OBJECT
 
   public:
-	explicit BriefingEditorDialog(QWidget* parent = 0);
+	explicit BriefingEditorDialog(FredView* parent, EditorViewport* viewport);
 	~BriefingEditorDialog() override;
 
-  private:
-	Ui::BriefingEditorDialog* ui;
-};
+	void accept() override;
+	void reject() override;
 
+  protected:
+	void closeEvent(QCloseEvent* e) override; // funnel all Window X presses through reject()
+
+  private slots:
+	// dialog controls
+	void on_okAndCancelButtons_accepted();
+	void on_okAndCancelButtons_rejected();
+
+	void on_prevStageButton_clicked();
+	void on_nextStageButton_clicked();
+	void on_addStageButton_clicked();
+	void on_insertStageButton_clicked();
+	void on_deleteStageButton_clicked();
+
+	void on_copyToOtherTeamsButton_clicked();
+	void on_teamComboBox_currentIndexChanged(int index);
+
+	void on_stageTextPlainTextEdit_textChanged();
+	void on_voiceFileLineEdit_textChanged(const QString& string);
+	void on_voiceFileBrowseButton_clicked();
+	void on_voiceFilePlayButton_clicked();
+	void on_formulaTreeView_nodeChanged(int newTree);
+
+  private: // NOLINT(readability-redundant-access-specifiers)
+	std::unique_ptr<Ui::BriefingEditorDialog> ui;
+	std::unique_ptr<BriefingEditorDialogModel> _model;
+	EditorViewport* _viewport;
+
+	void initializeUi();
+	void updateUi();
+	void enableDisableControls();
+};
 } // namespace fso::fred::dialogs

--- a/qtfred/ui/BriefingEditorDialog.ui
+++ b/qtfred/ui/BriefingEditorDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>622</width>
-    <height>732</height>
+    <width>1505</width>
+    <height>725</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -25,541 +25,615 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="mainLayout">
-   <property name="spacing">
-    <number>0</number>
-   </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
+  <layout class="QHBoxLayout" name="horizontalLayout_8">
    <item>
-    <layout class="QGridLayout" name="contentLayout">
-     <property name="leftMargin">
-      <number>11</number>
-     </property>
-     <property name="topMargin">
-      <number>11</number>
-     </property>
-     <property name="rightMargin">
-      <number>11</number>
-     </property>
-     <property name="bottomMargin">
-      <number>11</number>
-     </property>
-     <item row="2" column="0" colspan="2">
-      <widget class="QPlainTextEdit" name="stageText"/>
+    <layout class="QVBoxLayout" name="leftPaneLayout">
+     <item>
+      <layout class="QHBoxLayout" name="leftPaneControlsLayout">
+       <item>
+        <layout class="QVBoxLayout" name="stageControlsLayout">
+         <item>
+          <widget class="QLabel" name="stageLabel">
+           <property name="text">
+            <string>Stage</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QGridLayout" name="stageButtons" columnstretch="0,0,0">
+           <property name="spacing">
+            <number>5</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QPushButton" name="prevStageButton">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Prev</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QPushButton" name="nextStageButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Next</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QPushButton" name="gotoViewButton">
+             <property name="text">
+              <string>Goto View</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QPushButton" name="pasteViewButton">
+             <property name="text">
+              <string>Paste View</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QPushButton" name="saveViewButton">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Save View</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QPushButton" name="addStageButton">
+             <property name="text">
+              <string>Add Stage</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0" colspan="2">
+            <widget class="QPushButton" name="deleteStageButton">
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Delete Stage</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <widget class="QPushButton" name="insertStageButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Insert Stage</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QPushButton" name="copyViewButton">
+             <property name="text">
+              <string>Copy View</string>
+             </property>
+             <property name="autoDefault">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="cameraTransitionTimeGroupBox">
+           <property name="title">
+            <string>Camera Transition Time (ms)</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="rightMargin">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QSpinBox" name="cameraTransitionTimeSpinBox"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="stageFlagsLayout">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QCheckBox" name="cutToNextStageCheckbox">
+             <property name="text">
+              <string>Cut to next stage</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cutToPrevStageCheckbox">
+             <property name="text">
+              <string>Cut to previous stage</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="disableGridCheckBox">
+             <property name="text">
+              <string>Disable grid rendering</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <spacer name="stageControlsSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="currentIconInfoGroupBox">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>300</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Current Icon Info</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_15">
+          <item>
+           <layout class="QHBoxLayout" name="iconDetailsLayout" stretch="0,1">
+            <item>
+             <layout class="QFormLayout" name="iconLabelsForm">
+              <property name="labelAlignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="iconIdLabel">
+                <property name="text">
+                 <string>ID</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLineEdit" name="iconIdLineEdit"/>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="iconLabelLabel">
+                <property name="text">
+                 <string>Label</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLineEdit" name="iconLabelLineEdit"/>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="iconCloseupLabelLabel">
+                <property name="text">
+                 <string>Closeup Label</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLineEdit" name="iconCloseupLabelLineEdit"/>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="iconVisualsLayout">
+              <property name="labelAlignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="iconImageLabel">
+                <property name="text">
+                 <string>Icon Image</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="iconImageComboBox"/>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="iconShipTypeLabel">
+                <property name="text">
+                 <string>Ship Type</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QComboBox" name="iconShipTypeComboBox"/>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="iconTeamLabel">
+                <property name="text">
+                 <string>Team</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QComboBox" name="iconTeamComboBox"/>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="iconScaleLabel">
+                <property name="text">
+                 <string>Scale</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QSpinBox" name="scaleSpinBox"/>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="iconCheckboxesLayout">
+            <item row="0" column="0" colspan="2">
+             <widget class="QCheckBox" name="drawLinesCheckBox">
+              <property name="text">
+               <string>Draw lines between marked icons</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="changeLocallyCheckBox">
+              <property name="text">
+               <string>Change locally</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="highlightCheckBox">
+              <property name="text">
+               <string>Highlight</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="flipIconCheckBox">
+              <property name="text">
+               <string>Flip Icon</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="iconSetupButtonsLayout">
+            <item>
+             <widget class="QPushButton" name="makeIconButton">
+              <property name="text">
+               <string>Make Icon</string>
+              </property>
+              <property name="autoDefault">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="deleteIconButton">
+              <property name="text">
+               <string>Delete Icon</string>
+              </property>
+              <property name="autoDefault">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="propagateIconButton">
+              <property name="text">
+               <string>Propagate</string>
+              </property>
+              <property name="autoDefault">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="iconInfoSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
      </item>
-     <item row="3" column="1">
-      <widget class="QGroupBox" name="iconInfoBox">
-       <property name="title">
-        <string>Current Icon Info</string>
+     <item>
+      <widget class="QWidget" name="mapView" native="true">
+       <property name="enabled">
+        <bool>true</bool>
        </property>
-       <layout class="QGridLayout" name="iconInfoBoxLayout">
-        <item row="0" column="0">
-         <layout class="QGridLayout" name="iconButtons">
-          <item row="0" column="0">
-           <widget class="QPushButton" name="makeIconButton">
-            <property name="text">
-             <string>Make Icon</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QPushButton" name="deleteIconButton">
-            <property name="text">
-             <string>Delete Icon</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QPushButton" name="propagateIconButton">
-            <property name="text">
-             <string>Propagate</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <layout class="QGridLayout" name="iconInfo">
-          <item row="3" column="0">
-           <widget class="QLabel" name="iconImage">
-            <property name="text">
-             <string>Icon Image</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="iconID">
-            <property name="text">
-             <string>ID</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="iconIDEdit"/>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="iconTeam">
-            <property name="text">
-             <string>Team</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="iconShipType">
-            <property name="text">
-             <string>Ship Type</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="iconImageCombo"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="iconLabel">
-            <property name="text">
-             <string>Label</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="iconLabelEdit"/>
-          </item>
-          <item row="5" column="1">
-           <widget class="QComboBox" name="iconTeamCombo"/>
-          </item>
-          <item row="4" column="1">
-           <widget class="QComboBox" name="iconShipTypeCombo"/>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="iconcloseupLabel"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="closeup">
-            <property name="text">
-             <string>Closeup Label</string>
-            </property>
-           </widget>
-          </item>
-		  <item row="0" column="0">
-		   <widget class="QLabel" name="iconScale">
-		    <property name="text">
-		     <string>Scale</string>
-		    </property>
-		   </widget>
-		  </item>
-         </layout>
-        </item>
-        <item row="2" column="0">
-         <layout class="QVBoxLayout" name="iconText">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>888</width>
+         <height>371</height>
+        </size>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QWidget {
+    background-color: #333333;
+    border: 1px solid #555555;
+}</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="rightPaneLayout">
+     <item>
+      <layout class="QHBoxLayout" name="stageSubControlsLayout">
+       <item>
+        <widget class="QGroupBox" name="usageFormulaGroupBox">
+         <property name="title">
+          <string>Usage Formula</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <widget class="QLabel" name="iconTextLabel">
-            <property name="text">
-             <string>Text</string>
+           <widget class="QTreeView" name="usageFormulaView">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPlainTextEdit" name="iconTextEdit">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="frameShape">
              <enum>QFrame::StyledPanel</enum>
             </property>
            </widget>
           </item>
          </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="stageAudioControlsLayout">
+         <item>
+          <widget class="QGroupBox" name="briefingMusicLayout">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="sizeIncrement">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Briefing Music</string>
+           </property>
+           <layout class="QFormLayout" name="formLayout">
+            <property name="labelAlignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="verticalSpacing">
+             <number>3</number>
+            </property>
+            <property name="leftMargin">
+             <number>6</number>
+            </property>
+            <property name="topMargin">
+             <number>3</number>
+            </property>
+            <property name="rightMargin">
+             <number>6</number>
+            </property>
+            <property name="bottomMargin">
+             <number>3</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="defaultMusicLabel">
+              <property name="text">
+               <string>Default</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="defaultMusicComboBox">
+              <property name="editable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="musicPackLabel">
+              <property name="text">
+               <string>If music pack is present</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="musicPackComboBox"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="voiceFileGroupBox">
+           <property name="title">
+            <string>Voice File</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_13">
+            <item>
+             <widget class="QLineEdit" name="voiceFileLineEdit">
+              <property name="text">
+               <string>none.wav</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="voiceFileButtonsLayout">
+              <item>
+               <widget class="QPushButton" name="browseVoiceFileButton">
+                <property name="text">
+                 <string>Browse</string>
+                </property>
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="playVoiceFileButton">
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../resources/resources.qrc">
+                  <normaloff>:/images/bmp00001.png</normaloff>:/images/bmp00001.png</iconset>
+                </property>
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="audioControlsSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="stageTextGroupBox">
+       <property name="title">
+        <string>Stage Text</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_6">
+        <item>
+         <widget class="QPlainTextEdit" name="stageTextPlainTextEdit"/>
         </item>
-        <item row="3" column="0">
-         <layout class="QGridLayout" name="iconInfoCheckboxes">
-          <item row="0" column="0" colspan="2">
-           <widget class="QCheckBox" name="drawLinesCheck">
-            <property name="text">
-             <string>Draw lines between marked icons</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="changeLocallyCheck">
-            <property name="text">
-             <string>Change locally</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="highlightCheck">
-            <property name="text">
-             <string>Highlight</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="flipIconCheck">
-            <property name="text">
-             <string>Flip Icon</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
+        <item>
+         <widget class="QDialogButtonBox" name="okAndCancelButtons">
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="standardButtons">
+           <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+          </property>
+         </widget>
         </item>
        </layout>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <layout class="QGridLayout" name="voiceInfo">
-       <item row="0" column="0">
-        <layout class="QHBoxLayout" name="voiceFileLayout">
-         <property name="spacing">
-          <number>5</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="voiceFileLabel">
-           <property name="text">
-            <string>Voice Wave File</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="voiceFileLine">
-           <property name="text">
-            <string>none.wav</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="browseVoiceFileButton">
-           <property name="text">
-            <string>Browse</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="playVoiceFileButton">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="../resources/resources.qrc">
-             <normaloff>:/images/bmp00001.png</normaloff>:/images/bmp00001.png</iconset>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="usageFormulaLabel">
-         <property name="text">
-          <string>Usage Formula</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QTreeView" name="usageFormulaView">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="0" column="0" colspan="2">
-      <layout class="QGridLayout" name="stageInfo">
-       <item row="0" column="0">
-        <widget class="QLabel" name="stageLabel">
-         <property name="text">
-          <string>Stage</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1" rowspan="3">
-        <widget class="QGroupBox" name="briefingMusicBox">
-         <property name="minimumSize">
-          <size>
-           <width>200</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="sizeIncrement">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Briefing Music</string>
-         </property>
-         <layout class="QGridLayout" name="musicBoxLayout">
-          <property name="leftMargin">
-           <number>6</number>
-          </property>
-          <property name="topMargin">
-           <number>3</number>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>3</number>
-          </property>
-          <property name="verticalSpacing">
-           <number>3</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="defaultMusicLabel">
-            <property name="text">
-             <string>Default</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="defaultMusicCombo">
-            <property name="editable">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="musicPackLabel">
-            <property name="text">
-             <string>If music pack is present</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QComboBox" name="musicPackCombo"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="2" rowspan="4">
-        <layout class="QGridLayout" name="stageButtons" columnstretch="0,0,0">
-         <property name="spacing">
-          <number>5</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QPushButton" name="prevStageButton">
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Prev</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QPushButton" name="nextStageButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Next</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QPushButton" name="saveViewButton">
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Save View</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QPushButton" name="addStageButton">
-           <property name="text">
-            <string>Add Stage</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QPushButton" name="insertStageButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Insert Stage</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0" colspan="2">
-          <widget class="QPushButton" name="deleteStageButton">
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Delete Stage</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="QPushButton" name="copyViewButton">
-           <property name="text">
-            <string>Copy View</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2">
-          <widget class="QPushButton" name="pasteViewButton">
-           <property name="text">
-            <string>Paste View</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QPushButton" name="gotoViewButton">
-           <property name="text">
-            <string>Goto View</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="1" column="0">
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <property name="rightMargin">
-          <number>6</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="transitionLabel">
-           <property name="text">
-            <string>Camera Transition Time (ms)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="transitionTime"/>
-         </item>
-        </layout>
-       </item>
-       <item row="2" column="0">
-        <layout class="QVBoxLayout" name="cutStage">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="nextStage">
-           <property name="text">
-            <string>Cut to next stage</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="prevStage">
-           <property name="text">
-            <string>Cut to previous stage</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-	   <item>
-		<widget class="QCheckBox" name="disableGrid">
-		 <property name="text">
-		  <string>Disable grid rendering</string>
-		</property>
-	   </widget>
-	  </item>
-      </layout>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="textLabel">
-       <property name="text">
-        <string>Text</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
-       </property>
       </widget>
      </item>
     </layout>

--- a/qtfred/ui/BriefingEditorDialog.ui
+++ b/qtfred/ui/BriefingEditorDialog.ui
@@ -33,9 +33,9 @@
        <item>
         <layout class="QVBoxLayout" name="stageControlsLayout">
          <item>
-          <widget class="QLabel" name="stageLabel">
+          <widget class="QLabel" name="currentStageLabel">
            <property name="text">
-            <string>Stage</string>
+            <string>No Stages</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -240,186 +240,224 @@
         </layout>
        </item>
        <item>
-        <widget class="QGroupBox" name="currentIconInfoGroupBox">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>300</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Current Icon Info</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_15">
-          <item>
-           <layout class="QHBoxLayout" name="iconDetailsLayout" stretch="0,1">
+        <layout class="QVBoxLayout" name="stageSubControlsLayout_2">
+         <item>
+          <layout class="QHBoxLayout" name="teamControlsLayout">
+           <item>
+            <widget class="QLabel" name="teamLabel">
+             <property name="text">
+              <string>Teams</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="teamComboBox"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="copyToOtherTeamsButton">
+             <property name="text">
+              <string>Copy To Other Teams</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="teamSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="currentIconInfoGroupBox">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>300</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>Current Icon Info</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_15">
             <item>
-             <layout class="QFormLayout" name="iconLabelsForm">
-              <property name="labelAlignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="iconIdLabel">
-                <property name="text">
-                 <string>ID</string>
+             <layout class="QHBoxLayout" name="iconDetailsLayout" stretch="0,1">
+              <item>
+               <layout class="QFormLayout" name="iconLabelsForm">
+                <property name="labelAlignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-               </widget>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="iconIdLabel">
+                  <property name="text">
+                   <string>ID</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QLineEdit" name="iconIdLineEdit"/>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="iconLabelLabel">
+                  <property name="text">
+                   <string>Label</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QLineEdit" name="iconLabelLineEdit"/>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="iconCloseupLabelLabel">
+                  <property name="text">
+                   <string>Closeup Label</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QLineEdit" name="iconCloseupLabelLineEdit"/>
+                </item>
+               </layout>
               </item>
-              <item row="0" column="1">
-               <widget class="QLineEdit" name="iconIdLineEdit"/>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="iconLabelLabel">
-                <property name="text">
-                 <string>Label</string>
+              <item>
+               <layout class="QFormLayout" name="iconVisualsLayout">
+                <property name="labelAlignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLineEdit" name="iconLabelLineEdit"/>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="iconCloseupLabelLabel">
-                <property name="text">
-                 <string>Closeup Label</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QLineEdit" name="iconCloseupLabelLineEdit"/>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="iconImageLabel">
+                  <property name="text">
+                   <string>Icon Image</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QComboBox" name="iconImageComboBox"/>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QLabel" name="iconShipTypeLabel">
+                  <property name="text">
+                   <string>Ship Type</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QComboBox" name="iconShipTypeComboBox"/>
+                </item>
+                <item row="2" column="0">
+                 <widget class="QLabel" name="iconTeamLabel">
+                  <property name="text">
+                   <string>Team</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="1">
+                 <widget class="QComboBox" name="iconTeamComboBox"/>
+                </item>
+                <item row="3" column="0">
+                 <widget class="QLabel" name="iconScaleLabel">
+                  <property name="text">
+                   <string>Scale</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="1">
+                 <widget class="QSpinBox" name="scaleSpinBox"/>
+                </item>
+               </layout>
               </item>
              </layout>
             </item>
             <item>
-             <layout class="QFormLayout" name="iconVisualsLayout">
-              <property name="labelAlignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="iconImageLabel">
+             <layout class="QGridLayout" name="iconCheckboxesLayout">
+              <item row="0" column="0" colspan="2">
+               <widget class="QCheckBox" name="drawLinesCheckBox">
                 <property name="text">
-                 <string>Icon Image</string>
+                 <string>Draw lines between marked icons</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="iconImageComboBox"/>
-              </item>
               <item row="1" column="0">
-               <widget class="QLabel" name="iconShipTypeLabel">
+               <widget class="QCheckBox" name="changeLocallyCheckBox">
                 <property name="text">
-                 <string>Ship Type</string>
+                 <string>Change locally</string>
                 </property>
                </widget>
               </item>
               <item row="1" column="1">
-               <widget class="QComboBox" name="iconShipTypeComboBox"/>
+               <widget class="QCheckBox" name="highlightCheckBox">
+                <property name="text">
+                 <string>Highlight</string>
+                </property>
+               </widget>
               </item>
               <item row="2" column="0">
-               <widget class="QLabel" name="iconTeamLabel">
+               <widget class="QCheckBox" name="flipIconCheckBox">
                 <property name="text">
-                 <string>Team</string>
+                 <string>Flip Icon</string>
                 </property>
                </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QComboBox" name="iconTeamComboBox"/>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="iconScaleLabel">
-                <property name="text">
-                 <string>Scale</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QSpinBox" name="scaleSpinBox"/>
               </item>
              </layout>
             </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="iconCheckboxesLayout">
-            <item row="0" column="0" colspan="2">
-             <widget class="QCheckBox" name="drawLinesCheckBox">
-              <property name="text">
-               <string>Draw lines between marked icons</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="changeLocallyCheckBox">
-              <property name="text">
-               <string>Change locally</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QCheckBox" name="highlightCheckBox">
-              <property name="text">
-               <string>Highlight</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QCheckBox" name="flipIconCheckBox">
-              <property name="text">
-               <string>Flip Icon</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="iconSetupButtonsLayout">
             <item>
-             <widget class="QPushButton" name="makeIconButton">
-              <property name="text">
-               <string>Make Icon</string>
-              </property>
-              <property name="autoDefault">
-               <bool>false</bool>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="iconSetupButtonsLayout">
+              <item>
+               <widget class="QPushButton" name="makeIconButton">
+                <property name="text">
+                 <string>Make Icon</string>
+                </property>
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="deleteIconButton">
+                <property name="text">
+                 <string>Delete Icon</string>
+                </property>
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="propagateIconButton">
+                <property name="text">
+                 <string>Propagate</string>
+                </property>
+                <property name="autoDefault">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="QPushButton" name="deleteIconButton">
-              <property name="text">
-               <string>Delete Icon</string>
+             <spacer name="iconInfoSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
               </property>
-              <property name="autoDefault">
-               <bool>false</bool>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
               </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="propagateIconButton">
-              <property name="text">
-               <string>Propagate</string>
-              </property>
-              <property name="autoDefault">
-               <bool>false</bool>
-              </property>
-             </widget>
+             </spacer>
             </item>
            </layout>
-          </item>
-          <item>
-           <spacer name="iconInfoSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </item>
@@ -461,7 +499,7 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <widget class="QTreeView" name="usageFormulaView">
+           <widget class="fso::fred::sexp_tree" name="formulaTreeView">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -566,7 +604,7 @@
             <item>
              <layout class="QHBoxLayout" name="voiceFileButtonsLayout">
               <item>
-               <widget class="QPushButton" name="browseVoiceFileButton">
+               <widget class="QPushButton" name="voiceFileBrowseButton">
                 <property name="text">
                  <string>Browse</string>
                 </property>
@@ -576,7 +614,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QPushButton" name="playVoiceFileButton">
+               <widget class="QPushButton" name="voiceFilePlayButton">
                 <property name="text">
                  <string/>
                 </property>
@@ -620,20 +658,20 @@
         <item>
          <widget class="QPlainTextEdit" name="stageTextPlainTextEdit"/>
         </item>
-        <item>
-         <widget class="QDialogButtonBox" name="okAndCancelButtons">
-          <property name="layoutDirection">
-           <enum>Qt::LeftToRight</enum>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="standardButtons">
-           <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-          </property>
-         </widget>
-        </item>
        </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="okAndCancelButtons">
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
       </widget>
      </item>
     </layout>
@@ -641,6 +679,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>fso::fred::sexp_tree</class>
+   <extends>QTreeView</extends>
+   <header>ui/widgets/sexp_tree.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/BriefingEditorDialog.ui
+++ b/qtfred/ui/BriefingEditorDialog.ui
@@ -301,9 +301,6 @@
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="1">
-                 <widget class="QLineEdit" name="iconIdLineEdit"/>
-                </item>
                 <item row="1" column="0">
                  <widget class="QLabel" name="iconLabelLabel">
                   <property name="text">
@@ -323,6 +320,16 @@
                 </item>
                 <item row="2" column="1">
                  <widget class="QLineEdit" name="iconCloseupLabelLineEdit"/>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QSpinBox" name="iconIdSpinBox">
+                  <property name="buttonSymbols">
+                   <enum>QAbstractSpinBox::NoButtons</enum>
+                  </property>
+                  <property name="maximum">
+                   <number>16777215</number>
+                  </property>
+                 </widget>
                 </item>
                </layout>
               </item>
@@ -369,7 +376,7 @@
                  </widget>
                 </item>
                 <item row="3" column="1">
-                 <widget class="QSpinBox" name="scaleSpinBox"/>
+                 <widget class="QDoubleSpinBox" name="scaleDoubleSpinBox"/>
                 </item>
                </layout>
               </item>
@@ -377,31 +384,48 @@
             </item>
             <item>
              <layout class="QGridLayout" name="iconCheckboxesLayout">
-              <item row="0" column="0" colspan="2">
-               <widget class="QCheckBox" name="drawLinesCheckBox">
-                <property name="text">
-                 <string>Draw lines between marked icons</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QCheckBox" name="changeLocallyCheckBox">
-                <property name="text">
-                 <string>Change locally</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
+              <item row="3" column="1">
                <widget class="QCheckBox" name="highlightCheckBox">
                 <property name="text">
                  <string>Highlight</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
+              <item row="4" column="1">
+               <widget class="QCheckBox" name="useWingIconCheckBox">
+                <property name="text">
+                 <string>Use Wing Icon</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QCheckBox" name="changeLocallyCheckBox">
+                <property name="text">
+                 <string>Change locally</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QCheckBox" name="drawLinesCheckBox">
+                <property name="text">
+                 <string>Draw lines between marked icons</string>
+                </property>
+                <property name="tristate">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
                <widget class="QCheckBox" name="flipIconCheckBox">
                 <property name="text">
                  <string>Flip Icon</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QCheckBox" name="useCargoIconCheckBox">
+                <property name="text">
+                 <string>Use Cargo Icon</string>
                 </property>
                </widget>
               </item>

--- a/qtfred/ui/BriefingEditorDialog.ui
+++ b/qtfred/ui/BriefingEditorDialog.ui
@@ -202,14 +202,14 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QCheckBox" name="cutToNextStageCheckbox">
+            <widget class="QCheckBox" name="cutToNextStageCheckBox">
              <property name="text">
               <string>Cut to next stage</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="cutToPrevStageCheckbox">
+            <widget class="QCheckBox" name="cutToPrevStageCheckBox">
              <property name="text">
               <string>Cut to previous stage</string>
              </property>

--- a/qtfred/ui/BriefingEditorDialog.ui
+++ b/qtfred/ui/BriefingEditorDialog.ui
@@ -597,7 +597,7 @@
             <item>
              <widget class="QLineEdit" name="voiceFileLineEdit">
               <property name="text">
-               <string>none.wav</string>
+               <string/>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Completes the briefing dialog model and implements the UI with the exception of the sexp tree and the briefing view. The plan is to write a custom renderer for the briefing view in the window itself. This allows two major advantages; first is we can make the dialog modal and thus allow a traditional ok/cancel setup for easy back outs of changes and second we can make this renderer actual show stage transitions. All of that will be in a follow-up.

Fixes #6980 or at least enough of it that I'm good with calling that ticket completed. The renderers and sexp tree are much bigger refactors to follow soon.