### PR TITLE
Add new option for 'better combat collision avoidance'

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -142,6 +142,7 @@ namespace AI {
 		Fightercraft_nonshielded_ships_can_manage_ets,
 		Ships_playing_dead_dont_manage_ets,
 		Better_combat_collision_avoidance,
+		Better_combat_collision_avoid_includes_target,
 		Better_guard_collision_avoidance,
 		Require_exact_los,
 		Improved_missile_avoidance,

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -588,6 +588,8 @@ void parse_ai_profiles_tbl(const char *filename)
 					stuff_float(&profile->better_collision_avoid_aggression_combat);
 				}
 
+				set_flag(profile, "+combat collision avoidance for fightercraft includes target:", AI::Profile_Flags::Better_combat_collision_avoid_includes_target);
+
 				set_flag(profile, "$better guard collision avoidance for fightercraft:", AI::Profile_Flags::Better_guard_collision_avoidance);
 
 				if (optional_string("+guard collision avoidance aggression for fightercraft:")) {

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -7711,7 +7711,7 @@ bool maybe_avoid_big_ship(object *objp, object *ignore_objp, ai_info *aip, vec3d
 			aip->ai_flags.remove(AI::AI_Flags::Avoiding_small_ship);
 			aip->avoid_ship_num = -1;
 			next_check_time = (int) (1500 * time_scale);
-			aip->avoid_check_timestamp = timestamp(1500);
+			aip->avoid_check_timestamp = timestamp(next_check_time);
 		}
 	}
 	
@@ -7737,7 +7737,7 @@ bool maybe_avoid_big_ship(object *objp, object *ignore_objp, ai_info *aip, vec3d
  * Return true if small ship and it will likely collide with large ship
  * developed by Asteroth
  */
-bool better_collision_avoidance_triggered(bool flag_to_check, float avoidance_aggression, object* pl_objp, object* en_objp)
+bool better_collision_avoidance_triggered(bool flag_to_check, float avoidance_aggression, object* pl_objp, object* ignore_objp)
 {
 	ship* shipp = &Ships[pl_objp->instance];
 	ship_info* sip = &Ship_info[shipp->ship_info_index];
@@ -7748,7 +7748,7 @@ bool better_collision_avoidance_triggered(bool flag_to_check, float avoidance_ag
 		collide_vec *= radius_contribution;
 
 		collide_vec += pl_objp->pos;
-		return (maybe_avoid_big_ship(pl_objp, en_objp, &Ai_info[shipp->ai_index], &collide_vec, 0.f, 0.1f));
+		return (maybe_avoid_big_ship(pl_objp, ignore_objp, &Ai_info[shipp->ai_index], &collide_vec, 0.f, 0.1f));
 	}
 	return false;
 }
@@ -8978,7 +8978,8 @@ void ai_chase()
 	if (better_collision_avoidance_triggered(
 			The_mission.ai_profile->flags[AI::Profile_Flags::Better_combat_collision_avoidance],
 			The_mission.ai_profile->better_collision_avoid_aggression_combat,
-			Pl_objp, En_objp)) {
+			Pl_objp, 
+			The_mission.ai_profile->flags[AI::Profile_Flags::Better_combat_collision_avoid_includes_target] ? nullptr : En_objp)) {
 		return;
 	}
 
@@ -10896,7 +10897,8 @@ void ai_guard()
 	if (better_collision_avoidance_triggered(
 			The_mission.ai_profile->flags[AI::Profile_Flags::Better_guard_collision_avoidance],
 			The_mission.ai_profile->better_collision_avoid_aggression_guard,
-			Pl_objp, En_objp)) {
+			Pl_objp, 
+			En_objp)) {
 		return;
 	}
 
@@ -14190,7 +14192,8 @@ void ai_execute_behavior(ai_info *aip)
 			if (!(better_collision_avoidance_triggered(
 					The_mission.ai_profile->flags[AI::Profile_Flags::Better_combat_collision_avoidance],
 					The_mission.ai_profile->better_collision_avoid_aggression_combat,
-					Pl_objp, En_objp))) {
+					Pl_objp, 
+					The_mission.ai_profile->flags[AI::Profile_Flags::Better_combat_collision_avoid_includes_target] ? nullptr : En_objp))) {
 				ai_big_strafe();	// strafe a big ship
 			}
 		} else {


### PR DESCRIPTION
The `$better combat collision avoidance for fightercraft:` flag is incredibly useful in preventing AI from hitting large ships while attacking, and the ability to tune the collision avoidance aggression factor further helps mods tune behavior based on their ship speeds (tuning that value is via `+combat collision avoidance aggression for fightercraft:` ). Nevertheless, the improve collision avoidance still is not performed for that actual fightercraft's actual target, so there can be situations where a fast fighter attacks a large ship with high speed, and then when that fighter break off from the attack they turn directly into the large ship's hull. Allowing the target to be incorporated into the `better_collision_avoidance_triggered` check prevents this from happening. To allow the target to be a part of the checks we just simply need to not pass an 'ignor_ship` argument to `maybe_avoid_big_ship`.

This PR adds that ability via flag. This new flag is tested and works as expected. For example, without the flag a squadron of TIEs in FotG would literally ram themselves to death attacking some of our larger capital ships because they would break off attack too late, but with this flag they no longer accidentally collide at all. In discussion with Asteroth it was decided to make this enhanced behavior behind a flag, too.

This PR also fixes a small oversight from the original #2810 where `next_check_time` was never actually used within the `else` block of `maybe_avoid_big_ship`.