### PR TITLE
fix null vector assertion in slash beam collisions

### DIFF
--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3962,7 +3962,9 @@ void beam_handle_collisions(beam *b)
 			if (wi->flash_impact_weapon_expl_effect.isValid()) {
 				auto particleSource = particle::ParticleManager::get()->createSource(wi->flash_impact_weapon_expl_effect);
 				particleSource->setHost(beam_hit_make_effect_host(b, &Objects[target], b->f_collisions[idx].cinfo.hit_submodel, &b->f_collisions[idx].cinfo.hit_point_world, &b->f_collisions[idx].cinfo.hit_point));
-				particleSource->setNormal(worldNormal);
+// TODO: Commenting out until the collision code can be enhanced to return a valid normal when a beam collides with an edge.
+// (This can happen when a slash beam moves off the edge of a model; edge_hit will be true and hit_normal will be 0,0,0.)
+//				particleSource->setNormal(worldNormal);
 				particleSource->setTriggerRadius(width);
 				particleSource->finishCreation();
 			}
@@ -3970,7 +3972,8 @@ void beam_handle_collisions(beam *b)
 			if(do_expl){
 				auto particleSource = particle::ParticleManager::get()->createSource(wi->impact_weapon_expl_effect);
 				particleSource->setHost(beam_hit_make_effect_host(b, &Objects[target], b->f_collisions[idx].cinfo.hit_submodel, &b->f_collisions[idx].cinfo.hit_point_world, &b->f_collisions[idx].cinfo.hit_point));
-				particleSource->setNormal(worldNormal);
+// TODO: see comment above
+//				particleSource->setNormal(worldNormal);
 				particleSource->setTriggerRadius(width);
 				particleSource->finishCreation();
 			}
@@ -4026,7 +4029,8 @@ void beam_handle_collisions(beam *b)
 						auto particleSource = particle::ParticleManager::get()->createSource(wi->piercing_impact_effect);
 
 						particleSource->setHost(beam_hit_make_effect_host(b, &Objects[target], b->f_collisions[idx].cinfo.hit_submodel, &b->f_collisions[idx].cinfo.hit_point_world, &b->f_collisions[idx].cinfo.hit_point));
-						particleSource->setNormal(worldNormal);
+// TODO: see comment above
+//						particleSource->setNormal(worldNormal);
 						particleSource->setTriggerRadius(width);
 						particleSource->finishCreation();
 					}


### PR DESCRIPTION
Beams in general, and slash beams most likely, can collide with the edge of a model, which will cause a non-normalized vector assertion when particle effects are created.  So comment out the normal assignment until a more comprehensive fix can be coded.