### PR TITLE
Supply normals for edge hits

### DIFF
--- a/code/model/modelcollide.cpp
+++ b/code/model/modelcollide.cpp
@@ -323,6 +323,7 @@ static void mc_check_sphereline_face( int nv, vec3d ** verts, vec3d * plane_pnt,
 				// This is closer than best so far
 				Mc->hit_dist = sphere_time;
 				Mc->hit_point = hit_point;
+				Mc->hit_normal = *plane_norm;
 				Mc->hit_submodel = Mc_submodel;
 				Mc->edge_hit = true;
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3964,7 +3964,7 @@ void beam_handle_collisions(beam *b)
 				particleSource->setHost(beam_hit_make_effect_host(b, &Objects[target], b->f_collisions[idx].cinfo.hit_submodel, &b->f_collisions[idx].cinfo.hit_point_world, &b->f_collisions[idx].cinfo.hit_point));
 // TODO: Commenting out until the collision code can be enhanced to return a valid normal when a beam collides with an edge.
 // (This can happen when a slash beam moves off the edge of a model; edge_hit will be true and hit_normal will be 0,0,0.)
-//				particleSource->setNormal(worldNormal);
+				particleSource->setNormal(worldNormal);
 				particleSource->setTriggerRadius(width);
 				particleSource->finishCreation();
 			}
@@ -3973,7 +3973,7 @@ void beam_handle_collisions(beam *b)
 				auto particleSource = particle::ParticleManager::get()->createSource(wi->impact_weapon_expl_effect);
 				particleSource->setHost(beam_hit_make_effect_host(b, &Objects[target], b->f_collisions[idx].cinfo.hit_submodel, &b->f_collisions[idx].cinfo.hit_point_world, &b->f_collisions[idx].cinfo.hit_point));
 // TODO: see comment above
-//				particleSource->setNormal(worldNormal);
+				particleSource->setNormal(worldNormal);
 				particleSource->setTriggerRadius(width);
 				particleSource->finishCreation();
 			}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3962,8 +3962,6 @@ void beam_handle_collisions(beam *b)
 			if (wi->flash_impact_weapon_expl_effect.isValid()) {
 				auto particleSource = particle::ParticleManager::get()->createSource(wi->flash_impact_weapon_expl_effect);
 				particleSource->setHost(beam_hit_make_effect_host(b, &Objects[target], b->f_collisions[idx].cinfo.hit_submodel, &b->f_collisions[idx].cinfo.hit_point_world, &b->f_collisions[idx].cinfo.hit_point));
-// TODO: Commenting out until the collision code can be enhanced to return a valid normal when a beam collides with an edge.
-// (This can happen when a slash beam moves off the edge of a model; edge_hit will be true and hit_normal will be 0,0,0.)
 				particleSource->setNormal(worldNormal);
 				particleSource->setTriggerRadius(width);
 				particleSource->finishCreation();
@@ -3972,7 +3970,6 @@ void beam_handle_collisions(beam *b)
 			if(do_expl){
 				auto particleSource = particle::ParticleManager::get()->createSource(wi->impact_weapon_expl_effect);
 				particleSource->setHost(beam_hit_make_effect_host(b, &Objects[target], b->f_collisions[idx].cinfo.hit_submodel, &b->f_collisions[idx].cinfo.hit_point_world, &b->f_collisions[idx].cinfo.hit_point));
-// TODO: see comment above
 				particleSource->setNormal(worldNormal);
 				particleSource->setTriggerRadius(width);
 				particleSource->finishCreation();

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -4026,8 +4026,7 @@ void beam_handle_collisions(beam *b)
 						auto particleSource = particle::ParticleManager::get()->createSource(wi->piercing_impact_effect);
 
 						particleSource->setHost(beam_hit_make_effect_host(b, &Objects[target], b->f_collisions[idx].cinfo.hit_submodel, &b->f_collisions[idx].cinfo.hit_point_world, &b->f_collisions[idx].cinfo.hit_point));
-// TODO: see comment above
-//						particleSource->setNormal(worldNormal);
+						particleSource->setNormal(worldNormal);
 						particleSource->setTriggerRadius(width);
 						particleSource->finishCreation();
 					}


### PR DESCRIPTION
Now, you may be asking, "how can an edge have a sensible normal".
In FSO, we have a lot of places that expect to get a valid normal for every collision. So what to do in the case of an edge hit? In most cases, especially for VFX, it's enough to get a normal that's sufficiently close and contiguous compared to surrounding normals. As such, returning the normal of any of the faces that an edge belongs to is likely going to be a sufficient approximation.
There's a few places that still calculate manual normals in case of an edge hit with a different strategy, but as these don't rely on the value returned by the collision code, we can ignore them here.

This fixes several particle related bugs where a proper normal was expected, and restores normal-alignment functionality for beams that was removed in #7038