### PR TITLE
Particles can now emit light

### DIFF
--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -47,6 +47,7 @@ ParticleEffect::ParticleEffect(SCP_string name)
 	  m_spawnNoise(nullptr),
 	  m_manual_offset (std::nullopt),
 	  m_manual_velocity_offset(std::nullopt),
+	  m_light_source(std::nullopt),
 	  m_particleTrail(ParticleEffectHandle::invalid()),
 	  m_particleChance(1.f),
 	  m_distanceCulled(-1.f)
@@ -116,6 +117,7 @@ ParticleEffect::ParticleEffect(SCP_string name,
 	  m_spawnNoise(nullptr),
 	  m_manual_offset(offsetLocal),
 	  m_manual_velocity_offset(velocityOffsetLocal),
+	  m_light_source(std::nullopt),
 	  m_particleTrail(particleTrail),
 	  m_particleChance(particleChance),
 	  m_distanceCulled(distanceCulled) {}

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -93,11 +93,25 @@ public:
 		NUM_VALUES
 	};
 
+	struct LightInformation {
+		float light_radius;
+		float source_radius;
+		float intensity;
+		float r, g, b;
+
+		enum class LightSourceMode : uint8_t {
+			POINT,
+			AS_PARTICLE,
+			TO_LAST_POS
+		} light_source_mode;
+	};
+
  private:
 	friend struct ParticleParse;
 	friend class ParticleManager;
 	friend int ::parse_weapon(int, bool, const char*);
 	friend ParticleEffectHandle scripting::api::getLegacyScriptingParticleEffect(int bitmap, bool reversed);
+	friend bool move_particle(float frametime, particle* part);
 
 	SCP_string m_name; //!< The name of this effect
 
@@ -145,6 +159,8 @@ public:
 
 	std::optional<vec3d> m_manual_offset;
 	std::optional<vec3d> m_manual_velocity_offset;
+
+	std::optional<LightInformation> m_light_source;
 
 	ParticleEffectHandle m_particleTrail;
 

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -95,6 +95,8 @@ public:
 		LIGHT_R_MULT,
 		LIGHT_G_MULT,
 		LIGHT_B_MULT,
+		LIGHT_CONE_ANGLE_MULT,
+		LIGHT_CONE_INNER_ANGLE_MULT,
 
 		NUM_VALUES
 	};
@@ -104,14 +106,16 @@ public:
 		float source_radius;
 		float intensity;
 		float r, g, b;
+		float cone_angle, cone_inner_angle;
 
 		enum class LightSourceMode : uint8_t {
 			POINT,
 			AS_PARTICLE,
-			TO_LAST_POS
+			TO_LAST_POS,
+			CONE
 		} light_source_mode;
 
-		constexpr LightInformation() : light_radius(0.f), source_radius(0.f), intensity(0.f), r(0.f), g(0.f), b(0.f), light_source_mode(LightSourceMode::POINT) {}
+		constexpr LightInformation() : light_radius(0.f), source_radius(0.f), intensity(0.f), r(0.f), g(0.f), b(0.f), cone_angle(0.f), cone_inner_angle(0.f), light_source_mode(LightSourceMode::POINT) {}
 	};
 
  private:
@@ -296,6 +300,8 @@ public:
 			std::pair {"Light R Mult", ParticleLifetimeCurvesOutput::LIGHT_R_MULT},
 			std::pair {"Light G Mult", ParticleLifetimeCurvesOutput::LIGHT_G_MULT},
 			std::pair {"Light B Mult", ParticleLifetimeCurvesOutput::LIGHT_B_MULT},
+			std::pair {"Light Cone Angle Mult", ParticleLifetimeCurvesOutput::LIGHT_CONE_ANGLE_MULT},
+			std::pair {"Light Cone Inner Angle Mult", ParticleLifetimeCurvesOutput::LIGHT_CONE_INNER_ANGLE_MULT},
 		},
 		//Should you ever need to access something from the effect as a modular curve input:
 		//std::pair {"", modular_curves_submember_input<&particle::parent_effect, &ParticleSubeffectHandle::getParticleEffect, &ParticleEffect::>{}}

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -89,6 +89,12 @@ public:
 		RADIUS_MULT,
 		LENGTH_MULT,
 		ANIM_STATE,
+		LIGHT_RADIUS_MULT,
+		LIGHT_SOURCE_RADIUS_MULT,
+		LIGHT_INTENSITY_MULT,
+		LIGHT_R_MULT,
+		LIGHT_G_MULT,
+		LIGHT_B_MULT,
 
 		NUM_VALUES
 	};
@@ -278,10 +284,18 @@ public:
 
 	constexpr static auto modular_curves_lifetime_definition = make_modular_curve_definition<particle, ParticleLifetimeCurvesOutput>(
 		std::array {
-				std::pair {"Radius", ParticleLifetimeCurvesOutput::RADIUS_MULT},
-				std::pair {"Velocity", ParticleLifetimeCurvesOutput::VELOCITY_MULT},
-				std::pair {"Length", ParticleLifetimeCurvesOutput::LENGTH_MULT},
-				std::pair {"Anim State", ParticleLifetimeCurvesOutput::ANIM_STATE},
+			std::pair {"Radius", ParticleLifetimeCurvesOutput::RADIUS_MULT},
+			std::pair {"Velocity", ParticleLifetimeCurvesOutput::VELOCITY_MULT},
+			std::pair {"Radius Mult", ParticleLifetimeCurvesOutput::RADIUS_MULT}, // Modern Naming Alias
+			std::pair {"Velocity Mult", ParticleLifetimeCurvesOutput::VELOCITY_MULT}, // Modern Naming Alias
+			std::pair {"Length Mult", ParticleLifetimeCurvesOutput::LENGTH_MULT},
+			std::pair {"Anim State Mult", ParticleLifetimeCurvesOutput::ANIM_STATE},
+			std::pair {"Light Radius Mult", ParticleLifetimeCurvesOutput::LIGHT_RADIUS_MULT},
+			std::pair {"Light Source Radius Mult", ParticleLifetimeCurvesOutput::LIGHT_SOURCE_RADIUS_MULT},
+			std::pair {"Light Intensity Mult", ParticleLifetimeCurvesOutput::LIGHT_INTENSITY_MULT},
+			std::pair {"Light R Mult", ParticleLifetimeCurvesOutput::LIGHT_R_MULT},
+			std::pair {"Light G Mult", ParticleLifetimeCurvesOutput::LIGHT_G_MULT},
+			std::pair {"Light B Mult", ParticleLifetimeCurvesOutput::LIGHT_B_MULT},
 		},
 		//Should you ever need to access something from the effect as a modular curve input:
 		//std::pair {"", modular_curves_submember_input<&particle::parent_effect, &ParticleSubeffectHandle::getParticleEffect, &ParticleEffect::>{}}

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -104,6 +104,8 @@ public:
 			AS_PARTICLE,
 			TO_LAST_POS
 		} light_source_mode;
+
+		constexpr LightInformation() : light_radius(0.f), source_radius(0.f), intensity(0.f), r(0.f), g(0.f), b(0.f), light_source_mode(LightSourceMode::POINT) {}
 	};
 
  private:

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -287,7 +287,7 @@ namespace particle {
 				ParticleEffect::LightInformation& light = effect.m_light_source.emplace();
 
 				required_string("+Type:");
-				switch(required_string_one_of(3, "Point", "As Particle", "To Last Position")) {
+				switch(required_string_one_of(4, "Point", "As Particle", "To Last Position", "Cone")) {
 					case 0:
 						Mp += 5;
 						light.light_source_mode = ParticleEffect::LightInformation::LightSourceMode::POINT;
@@ -299,6 +299,10 @@ namespace particle {
 					case 2:
 						Mp += 16;
 						light.light_source_mode = ParticleEffect::LightInformation::LightSourceMode::TO_LAST_POS;
+						break;
+					case 3:
+						Mp+=4;
+						light.light_source_mode = ParticleEffect::LightInformation::LightSourceMode::CONE;
 						break;
 				}
 
@@ -316,6 +320,14 @@ namespace particle {
 				stuff_float(&light.r);
 				stuff_float(&light.g);
 				stuff_float(&light.b);
+
+				if (optional_string("+Cone Angle:")) {
+					stuff_float(&light.cone_angle);
+				}
+
+				if (optional_string("+Cone Inner Angle:")) {
+					stuff_float(&light.cone_inner_angle);
+				}
 			}
 		}
 

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -282,6 +282,43 @@ namespace particle {
 			}
 		}
 
+		static void parseLightEmissionSettings(ParticleEffect& effect) {
+			if (optional_string("$Emits Light:")) {
+				ParticleEffect::LightInformation& light = effect.m_light_source.emplace();
+
+				required_string("+Type:");
+				switch(required_string_one_of(3, "Point", "As Particle", "To Last Position")) {
+					case 0:
+						Mp += 5;
+						light.light_source_mode = ParticleEffect::LightInformation::LightSourceMode::POINT;
+						break;
+					case 1:
+						Mp += 11;
+						light.light_source_mode = ParticleEffect::LightInformation::LightSourceMode::AS_PARTICLE;
+						break;
+					case 2:
+						Mp += 16;
+						light.light_source_mode = ParticleEffect::LightInformation::LightSourceMode::TO_LAST_POS;
+						break;
+				}
+
+				required_string("+Light Radius:");
+				stuff_float(&light.light_radius);
+
+				if (optional_string("+Light Source Radius:")) {
+					stuff_float(&light.source_radius);
+				}
+
+				required_string("+Intensity:");
+				stuff_float(&light.intensity);
+
+				required_string("+Color:");
+				stuff_float(&light.r);
+				stuff_float(&light.g);
+				stuff_float(&light.b);
+			}
+		}
+
 		static void parseModularCurvesLifetime(ParticleEffect& effect) {
 			effect.m_lifetime_curves.parse("$Particle Lifetime Curve:");
 		}
@@ -324,6 +361,7 @@ namespace particle {
 			parseLength(effect);
 			parseLifetime(effect);
 			parseParentLocal(effect);
+			parseLightEmissionSettings(effect);
 
 			//Spawner Settings
 			parseTiming(effect);

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -255,8 +255,7 @@ namespace particle
 			{
 				p_pos = part->pos;
 			}
-
-			//TODO: Curvify
+			
 			float light_radius = light_source.light_radius * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_RADIUS_MULT, curve_input);
 			float source_radius = light_source.source_radius * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_SOURCE_RADIUS_MULT, curve_input);
 			float intensity = light_source.intensity * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_INTENSITY_MULT, curve_input);

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -257,12 +257,12 @@ namespace particle
 			}
 
 			//TODO: Curvify
-			float light_radius = light_source.light_radius;
-			float source_radius = light_source.source_radius;
-			float intensity = light_source.intensity;
-			float r = light_source.r;
-			float g = light_source.g;
-			float b = light_source.b;
+			float light_radius = light_source.light_radius * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_RADIUS_MULT, curve_input);
+			float source_radius = light_source.source_radius * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_SOURCE_RADIUS_MULT, curve_input);
+			float intensity = light_source.intensity * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_INTENSITY_MULT, curve_input);
+			float r = light_source.r * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_R_MULT, curve_input);
+			float g = light_source.g * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_G_MULT, curve_input);
+			float b = light_source.b * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_B_MULT, curve_input);
 
 			switch (light_source.light_source_mode) {
 			case ParticleEffect::LightInformation::LightSourceMode::POINT:

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -296,6 +296,18 @@ namespace particle
 					light_add_point(&p_pos, light_radius, light_radius, intensity, r, g, b, source_radius);
 				}
 				break;
+			case ParticleEffect::LightInformation::LightSourceMode::CONE: {
+				float cone_angle = light_source.cone_angle * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_CONE_ANGLE_MULT, curve_input);
+				float cone_inner_angle = light_source.cone_inner_angle * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::LIGHT_CONE_INNER_ANGLE_MULT, curve_input);
+				vec3d p1;
+				vm_vec_copy_normalize_safe(&p1, &part->velocity);
+				if (part->attached_objnum >= 0) {
+					vm_vec_unrotate(&p1, &p1, &Objects[part->attached_objnum].orient);
+				}
+
+				light_add_cone(&p_pos, &p1, cone_angle, cone_inner_angle, false, light_radius, light_radius, intensity, r, g, b, source_radius);
+			}
+			break;
 			}
 		}
 


### PR DESCRIPTION
Closes #3046.
The light has three modes:
1. Point light at the position of the particle
2. Tube light from the particles position last frame to its current position
3. a "particle native" mode, where point particles have a point light source, and where particles with a length have a tube light source along their length