### PR TITLE
Update to #7023

### DIFF
--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -368,7 +368,7 @@ namespace particle
 
 		framenum = part->bitmap;
 
-		Assert( cur_frame < part->nframes );
+		Assert( (cur_frame < part->nframes) || (part->nframes == 0 && cur_frame == 0) );
 
 		float radius = part->radius * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::VELOCITY_MULT, curve_input);
 


### PR DESCRIPTION
From Sept 15 onward in fast debug I hit this error when using weapon create ASSERTION: "cur_frame < part->nframes" at particle.cpp:371

Assert: "cur_frame < part->nframes"
File: particle.cpp
Line: 371

Thanks to lafiel, `that assert should have an `|| (part->nframes == 0 && cur_frame == 0) appended beaause while we need to stay inbounds for animations, frame 0 for both is valid for static images`