### PR TITLE
add ai_profiles flag to disable form-on-wing at mission start

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -180,6 +180,7 @@ namespace AI {
 		Freespace_1_missile_behavior,
 		ETS_uses_power_output,
 		ETS_energy_same_regardless_of_system_presence,
+		Dont_form_on_wing_at_mission_start,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -719,6 +719,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$ETS energy same regardless of system presence:", AI::Profile_Flags::ETS_energy_same_regardless_of_system_presence);
 
+				set_flag(profile, "$don't issue form-on-wing goals at mission start:", AI::Profile_Flags::Dont_form_on_wing_at_mission_start);
+
 
 				// end of options ----------------------------------------
 

--- a/code/ai/aigoals.cpp
+++ b/code/ai/aigoals.cpp
@@ -197,6 +197,11 @@ void ai_maybe_add_form_goal(wing* wingp)
 		return;
 	}
 
+	// we may simply not want the mission to do this
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Dont_form_on_wing_at_mission_start]) {
+		return;
+	}
+
 	int j;
 
 	// iterate through the ship_index list of this wing and check for orders.  We will do


### PR DESCRIPTION
By default, the player's wing will be issued a form-on-wing order at the beginning of the mission if the wing has no other initial goals.  Wings in the "starting wings" list that are not the player's wing will also be issued this goal if they arrive after mission start and have no other initial goals.  This PR adds a flag to disable this behavior.