### PR TITLE
Small particle copy-paste fixes

### DIFF
--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -337,10 +337,8 @@ auto ParticleEffect::processSourceInternal(float interp, const ParticleSource& s
 		info.length = m_length.next() * lengthMultiplier;
 
 		int fps = 1;
-		if (info.nframes < 0) {
-			Assertion(bm_is_valid(info.bitmap), "Invalid bitmap handle passed to particle create.");
-			bm_get_info(info.bitmap, nullptr, nullptr, nullptr, &info.nframes, &fps);
-		}
+		Assertion(bm_is_valid(info.bitmap), "Invalid bitmap handle passed to particle create.");
+		bm_get_info(info.bitmap, nullptr, nullptr, nullptr, &info.nframes, &fps);
 
 		if (m_hasLifetime) {
 			if (m_keep_anim_length_if_available && info.nframes > 1) {

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -444,7 +444,7 @@ namespace particle
 
 		Assert( (cur_frame < part->nframes) || (part->nframes == 0 && cur_frame == 0) );
 
-		float radius = part->radius * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::VELOCITY_MULT, curve_input);
+		float radius = part->radius * source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::RADIUS_MULT, curve_input);
 
 		if (part->length != 0.0f) {
 			vec3d p0 = p_pos;


### PR DESCRIPTION
Particle bitmaps weren't correctly initialized in the last few nightlies because the init was gated behind an if-check that relied on particle_info default values that now no longer exist. But since that check was always true since the particle rework, just remove it now.

Also, fix a copy-paste error with the wrong curve being picked for the new radius curve implementation