### PR TITLE
Allow mods to easily tune 'Target Hostile Bomb or Bomber' control

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1026,7 +1026,7 @@ void hud_config_handle_keypresses(int k)
 {
 	switch(k) {
 	case KEY_ESC:
-		if (escape_key_behavior_in_options == EscapeKeyBehaviorInOptions::SAVE) {
+		if (Escape_key_behavior_in_options == EscapeKeyBehaviorInOptions::SAVE) {
 			hud_config_commit();
 		} else {
 			hud_config_cancel();

--- a/code/menuui/optionsmenu.cpp
+++ b/code/menuui/optionsmenu.cpp
@@ -1281,7 +1281,7 @@ void options_menu_do_frame(float  /*frametime*/)
 			break;
 
 		case KEY_ESC:
-			if (escape_key_behavior_in_options == EscapeKeyBehaviorInOptions::SAVE) {
+			if (Escape_key_behavior_in_options == EscapeKeyBehaviorInOptions::SAVE) {
 				options_accept();
 				gamesnd_play_iface(InterfaceSounds::COMMIT_PRESSED);
 				gameseq_post_event(GS_EVENT_PREVIOUS_STATE);

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -172,7 +172,8 @@ bool Hide_main_rearm_items_in_comms_gauge;
 bool Fix_scripted_velocity;
 color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 bool Preload_briefing_icon_models;
-EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
+EscapeKeyBehaviorInOptions Escape_key_behavior_in_options;
+TargetBomborBomberBehaviorOptions Target_bomb_or_bomber_behavior;
 bool Fix_asteroid_bounding_box_check;
 bool Disable_intro_movie;
 bool Show_locked_status_scramble_missions;
@@ -1559,16 +1560,40 @@ void parse_mod_table(const char *filename)
 
 				if (temp == "default")
 				{
-					escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
+					Escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
 				}
 				else if (temp == "save")
 				{
-					escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::SAVE;
+					Escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::SAVE;
 				}
 				else
 				{
 					Warning(LOCATION, "$Behavior for pressing Escape key in options menu: Invalid selection. Must be value of 'default' or 'save'. Reverting to 'default' value.");
-					escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
+					Escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
+				}
+			}
+
+			if (optional_string("$Behavior for pressing 'Target Hostile Bomb or Bomber' control:")) {
+				SCP_string temp;
+				stuff_string(temp, F_RAW);
+				SCP_tolower(temp);
+
+				if (temp == "default")
+				{
+					Target_bomb_or_bomber_behavior = TargetBomborBomberBehaviorOptions::BOMBS_AND_BOMBERS;
+				}
+				else if (temp == "only bombs")
+				{
+					Target_bomb_or_bomber_behavior = TargetBomborBomberBehaviorOptions::ONLY_BOMBS;
+				}
+				else if (temp == "only bombers")
+				{
+					Target_bomb_or_bomber_behavior = TargetBomborBomberBehaviorOptions::ONLY_BOMBERS;
+				}
+				else
+				{
+					Warning(LOCATION, "$Behavior for pressing 'Target Hostile Bomb or Bomber' control: Invalid selection. Must be value of 'default' or 'only bombs' or 'only bombers'. Reverting to 'default' value.");
+					Target_bomb_or_bomber_behavior = TargetBomborBomberBehaviorOptions::BOMBS_AND_BOMBERS;
 				}
 			}
 
@@ -1839,7 +1864,8 @@ void mod_table_reset()
 	gr_init_alphacolor(&Overhead_line_colors[2], 175, 175, 175, 255);
 	gr_init_alphacolor(&Overhead_line_colors[3], 100, 100, 100, 255);
 	Preload_briefing_icon_models = false;
-	escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
+	Escape_key_behavior_in_options = EscapeKeyBehaviorInOptions::DEFAULT;
+	Target_bomb_or_bomber_behavior = TargetBomborBomberBehaviorOptions::BOMBS_AND_BOMBERS;
 	Fix_asteroid_bounding_box_check = false;
 	Disable_intro_movie = false;
 	Show_locked_status_scramble_missions = false;

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -26,6 +26,13 @@ typedef enum {
 	SAVE
 } EscapeKeyBehaviorInOptions;
 
+// Typedef for 'Target Hostile Bomb or Bomber' control behavior --wookieejedi
+typedef enum {
+	BOMBS_AND_BOMBERS,
+	ONLY_BOMBS,
+	ONLY_BOMBERS
+} TargetBomborBomberBehaviorOptions;
+
 // And one for splash screens
 struct splash_screen {
 	SCP_string filename;
@@ -187,7 +194,8 @@ extern bool Hide_main_rearm_items_in_comms_gauge;
 extern bool Fix_scripted_velocity;
 extern color Overhead_line_colors[MAX_SHIP_SECONDARY_BANKS];
 extern bool Preload_briefing_icon_models;
-extern EscapeKeyBehaviorInOptions escape_key_behavior_in_options;
+extern EscapeKeyBehaviorInOptions Escape_key_behavior_in_options;
+extern TargetBomborBomberBehaviorOptions Target_bomb_or_bomber_behavior;
 extern bool Fix_asteroid_bounding_box_check;
 extern bool Disable_intro_movie;
 extern bool Show_locked_status_scramble_missions;


### PR DESCRIPTION
The `Target Hostile Bomb or Bomber` control targets bombs or bombers, though in mods may want a way to easily set exactly what this control does while still leveraging the utility of the 'bomb' flag for weapons and/or 'bomber' flag for ships (both of which affect AI behavior in various ways).

For example, in Solaris, Darius wants a way a way to allow players to only target bombs, while still allowing ships to be classified as as 'bomber'. In this case, the 'only bombs' option can be used. This PR adds a `$Behavior for pressing 'Target Hostile Bomb or Bomber' control:` to allow mods to set the behavior to `default` `only bombs` or `only bombers`.

For example, in FotG we want to allow players to target just bombers, as bombs themselves are hard to shoot down (critically though we still want the player to be able to manually target a bomb via 'target object in reticle'. This allows players to prioritize and easily target bombers while allowing skilled pilots to retain the option of manually shooting down bombs if they want an extra challenge. In this case the 'only bomber' option can be used.

Tested and works as expected in all cases.