### PR TITLE
fix handling of invalid arrival/departure anchors

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -7654,6 +7654,8 @@ int mission_set_arrival_location(int anchor, ArrivalLocation location, int dist,
 		return -1;
 
 	Assert(anchor >= 0);
+	if (anchor < 0)
+		return -1;	// should never happen, but if it does, fail gracefully
 
 	// this ship might possibly arrive at another location.  The location is based on the
 	// proximity of some ship (and some other special tokens)
@@ -8281,7 +8283,9 @@ int mission_do_departure(object *objp, bool goal_is_to_warp)
 	if (location == DepartureLocation::TO_DOCK_BAY)
 	{
 		Assert(anchor >= 0);
-		auto anchor_ship_entry = ship_registry_get(Parse_names[anchor]);
+		auto anchor_ship_entry = (anchor >= 0)
+			? ship_registry_get(Parse_names[anchor])
+			: nullptr;	// should never happen, but if it does, fail gracefully
 
 		// see if ship is yet to arrive.  If so, then warp.
 		if (!anchor_ship_entry || anchor_ship_entry->status == ShipStatus::NOT_YET_PRESENT)

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3722,17 +3722,17 @@ int CFred_mission_save::save_objects()
 			}
 
 			z = shipp->arrival_anchor;
-			if (z & SPECIAL_ARRIVAL_ANCHOR_FLAG) {
+			if (z < 0) {
+				fout(" <error>");
+			} else if (z & SPECIAL_ARRIVAL_ANCHOR_FLAG) {
 				// get name
 				char tmp[NAME_LENGTH + 15];
 				stuff_special_arrival_anchor_name(tmp, z, Mission_save_format == FSO_FORMAT_RETAIL ? 1 : 0);
 
 				// save it
 				fout(" %s", tmp);
-			} else if (z >= 0) {
-				fout(" %s", Ships[z].ship_name);
 			} else {
-				fout(" <error>");
+				fout(" %s", Ships[z].ship_name);
 			}
 		}
 
@@ -5073,17 +5073,17 @@ int CFred_mission_save::save_wings()
 				fout("\n$Arrival Anchor:");
 
 			z = Wings[i].arrival_anchor;
-			if (z & SPECIAL_ARRIVAL_ANCHOR_FLAG) {
+			if (z < 0) {
+				fout(" <error>");
+			} else if (z & SPECIAL_ARRIVAL_ANCHOR_FLAG) {
 				// get name
 				char tmp[NAME_LENGTH + 15];
 				stuff_special_arrival_anchor_name(tmp, z, Mission_save_format == FSO_FORMAT_RETAIL ? 1 : 0);
 
 				// save it
 				fout(" %s", tmp);
-			} else if (z >= 0) {
-				fout(" %s", Ships[z].ship_name);
 			} else {
-				fout(" <error>");
+				fout(" %s", Ships[z].ship_name);
 			}
 		}
 

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3637,17 +3637,17 @@ int CFred_mission_save::save_objects()
 			}
 
 			z = shipp->arrival_anchor;
-			if (z & SPECIAL_ARRIVAL_ANCHOR_FLAG) {
+			if (z < 0) {
+				fout(" <error>");
+			} else if (z & SPECIAL_ARRIVAL_ANCHOR_FLAG) {
 				// get name
 				char tmp[NAME_LENGTH + 15];
 				stuff_special_arrival_anchor_name(tmp, z, save_format == MissionFormat::RETAIL);
 
 				// save it
 				fout(" %s", tmp);
-			} else if (z >= 0) {
-				fout(" %s", Ships[z].ship_name);
 			} else {
-				fout(" <error>");
+				fout(" %s", Ships[z].ship_name);
 			}
 		}
 
@@ -5250,17 +5250,17 @@ int CFred_mission_save::save_wings()
 			}
 
 			z = Wings[i].arrival_anchor;
-			if (z & SPECIAL_ARRIVAL_ANCHOR_FLAG) {
+			if (z < 0) {
+				fout(" <error>");
+			} else if (z & SPECIAL_ARRIVAL_ANCHOR_FLAG) {
 				// get name
 				char tmp[NAME_LENGTH + 15];
 				stuff_special_arrival_anchor_name(tmp, z, save_format == MissionFormat::RETAIL);
 
 				// save it
 				fout(" %s", tmp);
-			} else if (z >= 0) {
-				fout(" %s", Ships[z].ship_name);
 			} else {
-				fout(" <error>");
+				fout(" %s", Ships[z].ship_name);
 			}
 		}
 


### PR DESCRIPTION
Missions with invalid anchors would previously cause crashes, so update the anchor code to fail gracefully:
1. Negative anchors (especially -1) could trip up the bitwise-AND in the mission saving code, so check for negative anchors *before* checking the special-anchor flag
2. In the event a mission runs with a negative anchor (which shouldn't happen because even `<error>` is added as a recognized anchor), handle the situation with if()s as well as Asserts