### PR TITLE
Prevent crash with missing retail particle graphics

### DIFF
--- a/code/particle/ParticleManager.cpp
+++ b/code/particle/ParticleManager.cpp
@@ -123,6 +123,21 @@ ParticleEffectHandle ParticleManager::addEffect(SCP_vector<ParticleEffect>&& eff
 
 	Assert(!effect.empty());
 
+	for (const auto& subeffect : effect) {
+		for (const auto& bitmap : subeffect.m_bitmap_list) {
+			if (bitmap < 0) {
+				if (effect.front().getName().empty()) {
+					mprintf(("Internal legacy particle effect did not have a valid bitmap. Check particleexp01, particlesmoke01, and particlesmoke02!\n"));
+				}
+				else {
+					// I suspect we cannot get here. Parsing systems should prevent creation of named particles with invalid bitmaps, but just to be safe...
+					Warning(LOCATION, "Particle effect with name '%s' contains invalid bitmaps!", effect.front().getName().c_str());
+				}
+				return ParticleEffectHandle::invalid();
+			}
+		}
+	}
+
 #ifndef NDEBUG
 	if (!effect.front().getName().empty()) {
 		// This check is a bit expensive and will only be used in debug

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -90,21 +90,27 @@ namespace particle
 		}
 
 		// FIRE!!!
-		if (Anim_bitmap_id_fire == -1)
+		if (Anim_bitmap_id_fire < 0)
 		{
 			Anim_bitmap_id_fire = bm_load_animation("particleexp01", &Anim_num_frames_fire, nullptr, NULL, 0);
+			if (Anim_bitmap_id_fire < 0)
+				Warning(LOCATION, "Could not load legacy fire particle bitmap (particleexp01)!");
 		}
 
 		// Cough, cough
-		if (Anim_bitmap_id_smoke == -1)
+		if (Anim_bitmap_id_smoke < 0)
 		{
 			Anim_bitmap_id_smoke = bm_load_animation("particlesmoke01", &Anim_num_frames_smoke, nullptr, NULL, 0);
+			if (Anim_bitmap_id_smoke < 0)
+				Warning(LOCATION, "Could not load legacy smoke particle bitmap (particlesmoke01)!");
 		}
 
 		// wheeze
-		if (Anim_bitmap_id_smoke2 == -1)
+		if (Anim_bitmap_id_smoke2 < 0)
 		{
 			Anim_bitmap_id_smoke2 = bm_load_animation("particlesmoke02", &Anim_num_frames_smoke2, nullptr, NULL, 0);
+			if (Anim_bitmap_id_fire < 0)
+				Warning(LOCATION, "Could not load legacy smoke2 particle bitmap (particlesmoke02)!");
 		}
 	}
 


### PR DESCRIPTION
Some TCs don't supply all base particle graphics that FSO expects.
Since the particle rework, this would cause problems, since the modern particle system wasn't equipped to handle missing bitmaps at runtime.
This PR adds a check, filtering out any particles with missing graphics at creation time, either warning the user or logging, depending on the type of particle that was found to be faulty.
Furthermore, add warnings to notify modders if base particle graphics are missing.