### PR TITLE
Fix Asteroid Table Parsing

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2489,7 +2489,7 @@ static void asteroid_parse_tbl(const char* filename)
 		}
 		else {
 			char impact_ani_file[MAX_FILENAME_LEN] = {0};
-			float Asteroid_impact_explosion_radius;
+			float Asteroid_impact_explosion_radius = 0.0f;
 			int num_frames;
 
 			if (optional_string("$Impact Explosion:")) {

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2488,7 +2488,7 @@ static void asteroid_parse_tbl(const char* filename)
 			Asteroid_impact_explosion_ani = particle::util::parseEffect();
 		}
 		else {
-			char impact_ani_file[MAX_FILENAME_LEN];
+			char impact_ani_file[MAX_FILENAME_LEN] = {0};
 			float Asteroid_impact_explosion_radius;
 			int num_frames;
 


### PR DESCRIPTION
Zero initialize the string so garbage data doesn't accidentally bypass VALID_FNAME().