### PR TITLE
fix required_string_either bug

### DIFF
--- a/code/globalincs/alphacolors.cpp
+++ b/code/globalincs/alphacolors.cpp
@@ -388,7 +388,7 @@ void parse_everything_else(const char *filename)
 					Warning(LOCATION, "Team color in '%s' defined with a name of '%s'; this won't be usable due to 'None' being used for a lack of a team color by the engine.\n", filename, temp2);
 				}
 
-				if (required_string_either("$Team Stripe Color:", "$Team Stripe Colour:") >= 0) {
+				if (required_string_either("$Team Stripe Color:", "$Team Stripe Colour:", true) >= 0) {
 					int rgb[3];
 					stuff_int_list(rgb, 3, ParseLookupType::RAW_INTEGER_TYPE);
 					for (i = 0; i < 3; i++) {
@@ -400,7 +400,7 @@ void parse_everything_else(const char *filename)
 					temp_color.stripe.b = rgb[2] / 255.0f;
 				}
 
-				if (required_string_either("$Team Base Color:", "$Team Base Colour:") >= 0) {
+				if (required_string_either("$Team Base Color:", "$Team Base Colour:", true) >= 0) {
 					int rgb[3];
 					stuff_int_list(rgb, 3, ParseLookupType::RAW_INTEGER_TYPE);
 					for (i = 0; i < 3; i++) {

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -305,7 +305,7 @@ void parse_hud_gauges_tbl(const char *filename)
 					required_string("+XSTR ID:");
 					stuff_int(&preset.xstr);
 
-					required_string_either("+Color:", "+Colour:");
+					required_string_either("+Color:", "+Colour:", true);
 					int rgb[3] = {255, 255, 255};
 					stuff_int_list(rgb, 3);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -5332,7 +5332,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 			WarningEx(LOCATION, "%s '%s'\nIFF colour when IFF is \"%s\" invalid!", info_type_name, sip->name, iff_2);
 
 		// Set the color
-		required_string_either("+As Color:", "+As Colour:");
+		required_string_either("+As Color:", "+As Colour:", true);
 		stuff_int_list(iff_color_data, 3, ParseLookupType::RAW_INTEGER_TYPE);
 		sip->ship_iff_info[{iff_data[0],iff_data[1]}] = iff_init_color(iff_color_data[0], iff_color_data[1], iff_color_data[2]);
 	}


### PR DESCRIPTION
`optional_string_either` advances the parser by default, but `required_string_either` does not advance the parser by default.  So be sure to advance the parser here.

Followup to #7069.