### PR TITLE
Fix anim executables when animations wrap around

### DIFF
--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -240,7 +240,15 @@ namespace animation {
 			}
 
 			m_animation->calculateAnimation(applyBuffer, instanceData.time, pmi->id);
-			m_animation->executeAnimation(applyBuffer, MIN(prevTime, instanceData.time), MAX(prevTime, instanceData.time), instanceData.canonicalDirection, pmi->id);
+
+			if ((prevTime > instanceData.time && instanceData.canonicalDirection == ModelAnimationDirection::FWD) || (prevTime < instanceData.time && instanceData.canonicalDirection == ModelAnimationDirection::RWD)) {
+				//We _should_ have been going FWD, but we appear to have gone backwards (or we _should_ have been going FWD, but we appear to have gone forwards).
+				//This indicates that we looped around, or that we did a hard reset. Unfortunately, we can't quite differentiate that.
+				m_animation->executeAnimation(applyBuffer, 0.0f, MIN(prevTime, instanceData.time), instanceData.canonicalDirection, pmi->id);
+				m_animation->executeAnimation(applyBuffer, MAX(prevTime, instanceData.time), instanceData.duration, instanceData.canonicalDirection, pmi->id);
+			}
+			else
+				m_animation->executeAnimation(applyBuffer, MIN(prevTime, instanceData.time), MAX(prevTime, instanceData.time), instanceData.canonicalDirection, pmi->id);
 			break;
 
 		case ModelAnimationState::PAUSED:


### PR DESCRIPTION
Anim executables need to respect wraparounds properly, otherwise that'll incorrectly trigger the entire animation on wraparound