### PR TITLE
Alternative to #7019 (Mouse Wheel Cleanup Option)

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2888,17 +2888,10 @@ int check_control_used(int id, int key)
 
 	// special case to allow actual mouse wheel to work with trigger controls --wookieejedi
 	if (item.type == CC_TYPE_TRIGGER) {
-
-		int first_btn = 1 << item.first.get_btn();
-		int second_btn = 1 << item.second.get_btn();
-
-		if ( (first_btn >= LOWEST_MOUSE_WHEEL && first_btn <= HIGHEST_MOUSE_WHEEL) ||
-			 (second_btn >= LOWEST_MOUSE_WHEEL && second_btn <= HIGHEST_MOUSE_WHEEL) ) {
-			if ( mouse_down(item.first) || mouse_down(item.second) ) {
-				// Mouse wheel bound to this trigger control was pressed, control activated
-				control_used(id);
-				return 1;
-			}
+		if ( mouse_down(item.first, true) || mouse_down(item.second, true) ) {
+			// Mouse wheel bound to this trigger control was pressed, control activated
+			control_used(id);
+			return 1;
 		}
 	}
 

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -459,7 +459,7 @@ int mouse_up_count(int n) {
 
 // returns 1 if mouse button btn is down, 0 otherwise
 
-int mouse_down(const CC_bind &bind)
+int mouse_down(const CC_bind &bind, bool must_be_wheel)
 {
 	// Bail if the incoming bind is not the right CID according to mouse-fly mode
 	auto CID = bind.get_cid();
@@ -483,20 +483,21 @@ int mouse_down(const CC_bind &bind)
 
 	btn = 1 << btn;
 
-	return mouse_down(btn);
+	return mouse_down(btn, must_be_wheel);
 }
 
-int mouse_down(int btn) {
-	int tmp;
+int mouse_down(int btn, bool must_be_wheel) {
 	if ( !mouse_inited ) return 0;
 
 	// Bail if not a button or wheel direction
 	if ((btn < LOWEST_MOUSE_BUTTON) || (btn > HIGHEST_MOUSE_WHEEL)) return 0;
 
+	if (must_be_wheel && !(btn >= LOWEST_MOUSE_WHEEL && btn <= HIGHEST_MOUSE_WHEEL)) return 0;
+
 
 	SDL_LockMutex( mouse_lock );
 
-
+	int tmp;
 	if (mouse_flags & btn) {
 		tmp = 1;
 		if ((btn >= LOWEST_MOUSE_WHEEL) && (btn <= HIGHEST_MOUSE_WHEEL)) {

--- a/code/io/mouse.h
+++ b/code/io/mouse.h
@@ -98,12 +98,12 @@ void mouse_flush();
  * @note Calls mousewheel_decay() if the mousewheel direction is "down".  
  *       Please ensure mouse_down() is called only once per frame.
  */
-int mouse_down(const CC_bind &bind);
+int mouse_down(const CC_bind& bind, bool must_be_wheel = false);
 
 /**
  * Returns 1 if any of the given mouse buttons are down. 0 otherwise
  */
-int mouse_down(int btn);
+int mouse_down(int btn, bool must_be_wheel = false);
 
 void mouse_reset_deltas();
 void mouse_get_delta(int *dx = NULL, int *dy = NULL, int *dz = NULL);


### PR DESCRIPTION
Regarding the dicussion in #7019, here is an alternative method for consideration which adds an optional bool to `mouse_down` for `must_be_mousewheel`. Ideally it's a tad simpler, but we shall see what folks think