### PR TITLE
add flag to automatically cancel future waves if a mothership is destroyed

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -188,6 +188,7 @@ namespace AI {
 		Do_not_clear_goals_when_running_stay_still,
 		Do_not_set_override_when_assigning_form_on_wing,
 		Purge_player_issued_form_on_wing_after_subsequent_order,
+		Cancel_future_waves_of_any_wing_launched_from_an_exited_ship,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -742,6 +742,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$purge player-issued form-on-wing after subsequent order:", AI::Profile_Flags::Purge_player_issued_form_on_wing_after_subsequent_order);
 
+				set_flag(profile, "$cancel future waves of any wing launched from an exited ship:", AI::Profile_Flags::Cancel_future_waves_of_any_wing_launched_from_an_exited_ship);
+
 
 				// end of options ----------------------------------------
 
@@ -963,5 +965,6 @@ void ai_profile_t::reset()
 	if (mod_supports_version(25, 0, 0)) {
 		flags.set(AI::Profile_Flags::Fix_avoid_shockwave_bugs);
 		flags.set(AI::Profile_Flags::Purge_player_issued_form_on_wing_after_subsequent_order);
+		flags.set(AI::Profile_Flags::Cancel_future_waves_of_any_wing_launched_from_an_exited_ship);
 	}
 }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -4218,19 +4218,23 @@ int check_sexp_potential_issues(int node, int *bad_node, SCP_string &issue_msg)
 			case OP_IS_DESTROYED:
 			case OP_TIME_WING_DESTROYED:
 			{
-				for (int n = first_arg_node; n >= 0; n = CDR(n))
+				if (!The_mission.ai_profile->flags[AI::Profile_Flags::Cancel_future_waves_of_any_wing_launched_from_an_exited_ship])
 				{
-					int wingnum = wing_lookup(CTEXT(n));
-					if (wingnum >= 0)
+					for (int n = first_arg_node; n >= 0; n = CDR(n))
 					{
-						auto wingp = &Wings[wingnum];
-						if (wingp->num_waves > 1 && wingp->arrival_location == ArrivalLocation::FROM_DOCK_BAY)
+						int wingnum = wing_lookup(CTEXT(n));
+						if (wingnum >= 0)
 						{
-							issue_msg = "Wing ";
-							issue_msg += wingp->name;
-							issue_msg += " has more than one wave and arrives from a docking bay.  Be careful when checking for this wing's destruction.  If the "
-								"mothership is destroyed before all waves have arrived, the wing will not be considered destroyed.";
-							return SEXP_CHECK_POTENTIAL_ISSUE;
+							auto wingp = &Wings[wingnum];
+							if (wingp->num_waves > 1 && wingp->arrival_location == ArrivalLocation::FROM_DOCK_BAY)
+							{
+								issue_msg = "Wing ";
+								issue_msg += wingp->name;
+								issue_msg += " has more than one wave and arrives from a docking bay.  Be careful when checking for this wing's destruction.  If the "
+									"mothership is destroyed before all waves have arrived, the wing will not be considered destroyed.  Note that the "
+									"$cancel future waves of any wing launched from an exited ship: flag can be used to fix this.";
+								return SEXP_CHECK_POTENTIAL_ISSUE;
+							}
 						}
 					}
 				}

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9267,6 +9267,20 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 		ship_wing_cleanup(shipnum, wingp);
 	}
 
+	// maybe clean up any wings that arrived from this ship
+	if (The_mission.ai_profile->flags[AI::Profile_Flags::Cancel_future_waves_of_any_wing_launched_from_an_exited_ship]) {
+		for (int child_wingnum = 0; child_wingnum < Num_wings; ++child_wingnum) {
+			auto child_wingp = &Wings[child_wingnum];
+			if (child_wingp->arrival_location == ArrivalLocation::FROM_DOCK_BAY && child_wingp->arrival_anchor == shipnum) {
+				// prevent any more waves from arriving by marking this as the last wave
+				child_wingp->num_waves = child_wingp->current_wave;
+
+				// we might need to clean up this wing if there are no ships currently in the mission
+				wing_maybe_cleanup(child_wingp);
+			}
+		}
+	}
+
 	// Note, this call to ai_ship_destroy() must come after ship_wing_cleanup for guarded wings to
 	// properly note the destruction of a ship in their wing.
 	ai_ship_destroy(shipnum);	// Do AI stuff for destruction/leave of ship.


### PR DESCRIPTION
Infamously, in FSO, a wing whose mothership is destroyed will not, itself, be considered destroyed if it has more waves remaining, because wing cleanup and logging typically only happen when the last ship in the last wave exits the mission.  Instead, with no mothership to arrive from, waves will simply no longer arrive.  Events that check to see if the wing is destroyed or departed will never fire.

This PR fixes that behavior, ensuring that the wing is cleaned up and logged properly, by using the same logic as the enhanced `cancel-future-waves` SEXP operator.  This is tied to a new `$cancel future waves of any wing launched from an exited ship:` AI profiles flag which is enabled by default on 25.0+.

The changes in sexp.cpp are best viewed while ignoring whitespace changes.