### PR TITLE
Make FSO not crash if invalid options get displayed

### DIFF
--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -192,8 +192,13 @@ class Option : public OptionBase {
 			try {
 				return ValueDescription(_displayFunc(val), json_str);
 			} catch (const std::exception& e) {
+				static bool rel_warning_triggered = false;
+				if (!rel_warning_triggered) {
+					rel_warning_triggered = true;
+					ReleaseWarning(LOCATION, "Option %s has an invalid value %s! Please change the value!", _title.c_str(), json_str.c_str());
+				}
 				//This will logspam once a frame, but it's super rare, so it should be fine
-				mprintf(("Tried to show an invalid options value! Likely due to a malformed ini: %s\n", e.what()));
+				mprintf(("Tried to show an invalid options value %s for option %s! Likely due to a malformed ini: %s\n", json_str.c_str(), _title.c_str(), e.what()));
 				return ValueDescription(json_str, json_str);
 			}
 		} else {


### PR DESCRIPTION
DisplayFuncs _can_ throw, so make sure to actually handle that.
Fixes #7095