### PR TITLE
fix the size parameter of snprintf and vsnprintf

### DIFF
--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -2480,7 +2480,7 @@ void cfile_spew_pack_file_crcs()
 	my_time = time(NULL);
 
 	memset( datetime, 0, sizeof(datetime) );
-	snprintf(datetime, sizeof(datetime)-1, "%s", ctime(&my_time));
+	snprintf(datetime, sizeof(datetime), "%s", ctime(&my_time));
 	// ctime() adds a newline char, so we have to strip it off
 	datetime[strlen(datetime)-1] = '\0';
 

--- a/code/fireball/fireballs.cpp
+++ b/code/fireball/fireballs.cpp
@@ -107,7 +107,7 @@ void fireball_play_warphole_close_sound(fireball *fb)
 	snd_play_3d(gamesnd_get_game_sound(sound_index), &fireball_objp->pos, &Eye_position, fireball_objp->radius, NULL, 0, 1.0F, SND_PRIORITY_SINGLE_INSTANCE, NULL, fb->warp_sound_range_multiplier); // play warp sound effect
 }
 
-static void fireball_generate_unique_id(char *unique_id, int buffer_len, int fireball_index)
+static void fireball_generate_unique_id(char *unique_id, size_t buffer_size, int fireball_index)
 {
 	Assertion(SCP_vector_inbounds(Fireball_info, fireball_index), "fireball_index is out of bounds!");
 
@@ -115,37 +115,37 @@ static void fireball_generate_unique_id(char *unique_id, int buffer_len, int fir
 	{
 		// use sensible names for the fireball.tbl default entries
 		case FIREBALL_EXPLOSION_MEDIUM:
-			strncpy(unique_id, "Medium Explosion", buffer_len);
+			strncpy(unique_id, "Medium Explosion", buffer_size-1);
 			break;
 
 		case FIREBALL_WARP:
-			strncpy(unique_id, "Warp Effect", buffer_len);
+			strncpy(unique_id, "Warp Effect", buffer_size-1);
 			break;
 
 		case FIREBALL_KNOSSOS:
-			strncpy(unique_id, "Knossos Effect", buffer_len);
+			strncpy(unique_id, "Knossos Effect", buffer_size-1);
 			break;
 
 		case FIREBALL_ASTEROID:
-			strncpy(unique_id, "Asteroid Explosion", buffer_len);
+			strncpy(unique_id, "Asteroid Explosion", buffer_size-1);
 			break;
 
 		case FIREBALL_EXPLOSION_LARGE1:
-			strncpy(unique_id, "Large Explosion 1", buffer_len);
+			strncpy(unique_id, "Large Explosion 1", buffer_size-1);
 			break;
 
 		case FIREBALL_EXPLOSION_LARGE2:
-			strncpy(unique_id, "Large Explosion 2", buffer_len);
+			strncpy(unique_id, "Large Explosion 2", buffer_size-1);
 			break;
 
 		// base the id on the index
 		default:
-			snprintf(unique_id, buffer_len, "Custom Fireball %d", fireball_index - NUM_DEFAULT_FIREBALLS + 1);
+			snprintf(unique_id, buffer_size, "Custom Fireball %d", fireball_index - NUM_DEFAULT_FIREBALLS + 1);
 			break;
 	}
 
 	// null-terminate
-	unique_id[buffer_len - 1] = '\0';
+	unique_id[buffer_size-1] = '\0';
 }
 
 /**

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -276,7 +276,7 @@ void gr_opengl_print_screen(const char *filename)
 	GLuint pbo = 0;
 
 	// save to a "screenshots" directory and tack on the filename
-	snprintf(tmp, MAX_PATH_LEN-1, "screenshots/%s.png", filename);
+	snprintf(tmp, MAX_PATH_LEN, "screenshots/%s.png", filename);
 
     _mkdir(os_get_config_path("screenshots").c_str());
 
@@ -436,7 +436,7 @@ void gr_opengl_dump_envmap(const char* filename)
 	glBindTexture(sphere_tex->texture_target, sphere_tex->texture_id);
 	pixels = (GLubyte*)vm_malloc(sphere_width * sphere_height * 4, memory::quiet_alloc);
 	glGetTexImage(sphere_tex->texture_target, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-	snprintf(tmp, MAX_PATH_LEN - 1, "envmaps/%s.png", filename);
+	snprintf(tmp, MAX_PATH_LEN, "envmaps/%s.png", filename);
 	if (!png_write_bitmap(os_get_config_path(tmp).c_str(), 4 * width, 2 * height, true, pixels)) {
 		ReleaseWarning(LOCATION, "Failed to write envmap to \"%s\".", os_get_config_path(tmp).c_str());
 	}

--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -777,7 +777,7 @@ void gr_printf(int x, int y, const char * format, ...)
 	if (!FontManager::isReady()) return;
 
 	va_start(args, format);
-	vsnprintf(grx_printf_text, sizeof(grx_printf_text) - 1, format, args);
+	vsnprintf(grx_printf_text, sizeof(grx_printf_text), format, args);
 	va_end(args);
 	grx_printf_text[sizeof(grx_printf_text) - 1] = '\0';
 
@@ -791,7 +791,7 @@ void gr_printf_menu(int x, int y, const char * format, ...)
 	if (!FontManager::isReady()) return;
 
 	va_start(args, format);
-	vsnprintf(grx_printf_text, sizeof(grx_printf_text) - 1, format, args);
+	vsnprintf(grx_printf_text, sizeof(grx_printf_text), format, args);
 	va_end(args);
 	grx_printf_text[sizeof(grx_printf_text) - 1] = '\0';
 
@@ -805,7 +805,7 @@ void gr_printf_menu_zoomed(int x, int y, const char * format, ...)
 	if (!FontManager::isReady()) return;
 
 	va_start(args, format);
-	vsnprintf(grx_printf_text, sizeof(grx_printf_text) - 1, format, args);
+	vsnprintf(grx_printf_text, sizeof(grx_printf_text), format, args);
 	va_end(args);
 	grx_printf_text[sizeof(grx_printf_text) - 1] = '\0';
 
@@ -819,7 +819,7 @@ void gr_printf_no_resize(int x, int y, const char * format, ...)
 	if (!FontManager::isReady()) return;
 
 	va_start(args, format);
-	vsnprintf(grx_printf_text, sizeof(grx_printf_text) - 1, format, args);
+	vsnprintf(grx_printf_text, sizeof(grx_printf_text), format, args);
 	va_end(args);
 	grx_printf_text[sizeof(grx_printf_text) - 1] = '\0';
 

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -992,7 +992,7 @@ void HudGauge::renderPrintf(int x, int y, float scale, bool config, const char* 
 	
 	// format the text
 	va_start(args, format);
-	vsnprintf(tmp, sizeof(tmp)-1, format, args);
+	vsnprintf(tmp, sizeof(tmp), format, args);
 	va_end(args);
 	tmp[sizeof(tmp)-1] = '\0';
 
@@ -1006,7 +1006,7 @@ void HudGauge::renderPrintfWithGauge(int x, int y, int gauge_id, float scale, bo
 	
 	// format the text
 	va_start(args, format);
-	vsnprintf(tmp, sizeof(tmp)-1, format, args);
+	vsnprintf(tmp, sizeof(tmp), format, args);
 	va_end(args);
 	tmp[sizeof(tmp)-1] = '\0';
 

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -497,7 +497,7 @@ void HUD_fixed_printf(float duration, color col, const char *format, ...)
 	}
 
 	va_start(args, format);
-	vsnprintf(tmp, sizeof(tmp)-1, format, args);
+	vsnprintf(tmp, sizeof(tmp), format, args);
 	va_end(args);
 	tmp[sizeof(tmp)-1] = '\0';
 
@@ -553,7 +553,7 @@ void HUD_printf(const char *format, ...)
 	}
 
 	va_start(args, format);
-	vsnprintf(tmp, sizeof(tmp)-1, format, args);
+	vsnprintf(tmp, sizeof(tmp), format, args);
 	va_end(args);
 	tmp[sizeof(tmp)-1] = '\0';
 
@@ -579,7 +579,7 @@ void HUD_sourced_printf(int source, const char *format, ...)
 	}
 	
 	va_start(args, format);
-	vsnprintf(tmp, sizeof(tmp)-1, format, args);
+	vsnprintf(tmp, sizeof(tmp), format, args);
 	va_end(args);
 	tmp[sizeof(tmp)-1] = '\0';
 

--- a/code/lab/dialogs/lab_ui_helpers.cpp
+++ b/code/lab/dialogs/lab_ui_helpers.cpp
@@ -143,7 +143,7 @@ SCP_string get_ship_table_text(ship_info* sip)
 				if (!stricmp(line2 + i, sip->name)) {
 					memset(file_text, 0, sizeof(file_text));
 					snprintf(file_text,
-						sizeof(file_text) - 1,
+						sizeof(file_text),
 						"--  %s  -------------------------------\r\n",
 						tbl_file_names[n].c_str());
 					result += file_text;
@@ -269,7 +269,7 @@ SCP_string get_weapon_table_text(weapon_info* wip)
 				if (!stricmp(line2 + i, wip->name)) {
 					memset(file_text, 0, sizeof(file_text));
 					snprintf(file_text,
-						sizeof(file_text) - 1,
+						sizeof(file_text),
 						"--  %s  -------------------------------\r\n",
 						tbl_file_names[n].c_str());
 					result += file_text;
@@ -391,7 +391,7 @@ SCP_string get_asteroid_table_text(const asteroid_info* aip)
 				if (!stricmp(line2 + i, aip->name)) {
 					memset(file_text, 0, sizeof(file_text));
 					snprintf(file_text,
-						sizeof(file_text) - 1,
+						sizeof(file_text),
 						"--  %s  -------------------------------\r\n",
 						tbl_file_names[n].c_str());
 					result += file_text;

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -4457,7 +4457,7 @@ void multi_create_list_load_missions()
 	Multi_create_mission_list.clear();
 
 	memset( wild_card, 0, sizeof(wild_card) );
-	snprintf(wild_card, sizeof(wild_card) - 1, "*%s", FS_MISSION_FILE_EXT);
+	snprintf(wild_card, sizeof(wild_card), "*%s", FS_MISSION_FILE_EXT);
 
 	file_list = (char**) vm_malloc( sizeof(char*) * 1024 );
 
@@ -4550,7 +4550,7 @@ void multi_create_list_load_campaigns()
 	Multi_create_campaign_list.clear();
 
 	memset( wild_card, 0, sizeof(wild_card) );
-	snprintf(wild_card, sizeof(wild_card) - 1, "*%s", FS_CAMPAIGN_FILE_EXT);
+	snprintf(wild_card, sizeof(wild_card), "*%s", FS_CAMPAIGN_FILE_EXT);
 
 	file_list = (char**) vm_malloc( sizeof(char*) * 1024 );
 

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -1052,7 +1052,7 @@ static HWND Player_stats[MAX_PLAYER_STAT_FIELDS];		// text boxes for player allt
 static HWND Player_mstats[MAX_PLAYER_STAT_FIELDS];		// text boxes for player mission statistics info
 
 // sprintf and set window text to the passed int
-#define STD_ADDSTRING(hwnd,val) { snprintf(txt,sizeof(txt)-1,"%d",(int)val); SetWindowText(hwnd,txt); }
+#define STD_ADDSTRING(hwnd,val) { snprintf(txt,sizeof(txt),"%d",sz2i(val)); SetWindowText(hwnd,txt); }
 
 // intialize all the controls in the player info tab
 void std_pinfo_init_player_info_controls();
@@ -2036,17 +2036,17 @@ void std_build_title_string(char *str)
 	memset(ver_str, 0, sizeof(ver_str));
 
 	if (FS_VERSION_BUILD == 0 && FS_VERSION_HAS_REVIS == 0) { //-V547
-		snprintf(ver_str, sizeof(ver_str)-1, "%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR);
+		snprintf(ver_str, sizeof(ver_str), "%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR);
 	} else if (FS_VERSION_HAS_REVIS == 0) {
-		snprintf(ver_str, sizeof(ver_str)-1, "%i.%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD);
+		snprintf(ver_str, sizeof(ver_str), "%i.%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD);
 	} else {
-		snprintf(ver_str, sizeof(ver_str)-1, "%i.%i.%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS);
+		snprintf(ver_str, sizeof(ver_str), "%i.%i.%i.%i", FS_VERSION_MAJOR, FS_VERSION_MINOR, FS_VERSION_BUILD, FS_VERSION_REVIS);
 	}
 
 	// now build the title
 	memset(temp, 0, 256);
 
-	snprintf(temp, sizeof(temp)-1, "%s %s", XSTR("FreeSpace Standalone", 935), ver_str);
+	snprintf(temp, sizeof(temp), "%s %s", XSTR("FreeSpace Standalone", 935), ver_str);
 
 	// output first part
 	strcpy(str, temp);
@@ -2105,22 +2105,22 @@ static HMENU std_create_systray_menu()
 	HMENU stdPopup = CreatePopupMenu();
 
 	// Type of connection:
-	snprintf(tstr, sizeof(tstr)-1, "Connection Type: %s", MULTI_IS_TRACKER_GAME ? "PXO" : "Local/IP");
+	snprintf(tstr, sizeof(tstr), "Connection Type: %s", MULTI_IS_TRACKER_GAME ? "PXO" : "Local/IP");
 	AppendMenu(stdPopup, MF_STRING | MF_GRAYED, 0, tstr);
 
 	// ----------------------------------------------
 	AppendMenu(stdPopup, MF_SEPARATOR, 0, NULL);
 
 	// Game name:
-	snprintf(tstr, sizeof(tstr)-1, "Name: %s", Netgame.name);
+	snprintf(tstr, sizeof(tstr), "Name: %s", Netgame.name);
 	AppendMenu(stdPopup, MF_STRING | MF_GRAYED, 0, tstr);
 
 	// Mission name:
-	snprintf(tstr, sizeof(tstr)-1, "Mission: %s", strlen(Netgame.mission_name) ? Netgame.mission_name : "<none>");
+	snprintf(tstr, sizeof(tstr), "Mission: %s", strlen(Netgame.mission_name) ? Netgame.mission_name : "<none>");
 	AppendMenu(stdPopup, MF_STRING | MF_GRAYED, 0, tstr);
 
 	// Number of players:
-	snprintf(tstr, sizeof(tstr)-1, "Num Players: %d", multi_num_players());
+	snprintf(tstr, sizeof(tstr), "Num Players: %d", multi_num_players());
 	AppendMenu(stdPopup, MF_STRING | MF_GRAYED, 0, tstr);
 
 	// ----------------------------------------------

--- a/code/osapi/osregistry.cpp
+++ b/code/osapi/osregistry.cpp
@@ -1108,7 +1108,7 @@ void os_config_write_uint(const char* section, const char* name, unsigned int va
 
 	char buf[21];
 
-	snprintf(buf, 20, "%u", value);
+	snprintf(buf, 21, "%u", value);
 
 	profile = profile_update(profile, section, name, buf);
 	profile_save(profile, file);

--- a/code/popup/popup.cpp
+++ b/code/popup/popup.cpp
@@ -1145,7 +1145,7 @@ int popup(int flags, int nchoices, ... )
 
 	// get msg text
 	format = va_arg( args, char * );
-	vsnprintf(Popup_info.raw_text, sizeof(Popup_info.raw_text)-1, format, args);
+	vsnprintf(Popup_info.raw_text, sizeof(Popup_info.raw_text), format, args);
 	va_end(args);
 	Popup_info.raw_text[sizeof(Popup_info.raw_text)-1] = '\0';
 	
@@ -1202,7 +1202,7 @@ int popup_till_condition(int (*condition)(), ...)
 
 	// get msg text
 	format = va_arg( args, char * );
-	vsnprintf(Popup_info.raw_text, sizeof(Popup_info.raw_text)-1, format, args);
+	vsnprintf(Popup_info.raw_text, sizeof(Popup_info.raw_text), format, args);
 	va_end(args);
 	Popup_info.raw_text[sizeof(Popup_info.raw_text)-1] = '\0';
 
@@ -1333,7 +1333,7 @@ bool popup_conditional_create(int flags, ...)
 
 	// get msg text
 	format = va_arg( args, char * );
-	vsnprintf(Popup_info.raw_text, sizeof(Popup_info.raw_text)-1, format, args);
+	vsnprintf(Popup_info.raw_text, sizeof(Popup_info.raw_text), format, args);
 	Popup_info.raw_text[sizeof(Popup_info.raw_text)-1] = '\0';
 
 	va_end(args);

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -2870,7 +2870,7 @@ public:
 	int getInt(int *output);
 	//Returns handle, or < 0 on failure/wrong type
 	gamesnd_id getSound();
-	//Returns 1 if buffer was successfully written to
+	//Returns 1 if buffer was successfully written to (output_max includes the null terminator)
 	int getString(char *output, size_t output_max);
 
 	//Returns true if TYPE_NONE
@@ -3065,7 +3065,7 @@ void parse_combined_variable_list(CombinedVariable *dest, flag_def_list *src, si
 		sp = &src[i];
 		dp = &dest[i];
 
-		snprintf(buf, sizeof(buf)-1, "+%s:", sp->name);
+		snprintf(buf, sizeof(buf), "+%s:", sp->name);
 		if(optional_string(buf))
 		{
 			switch(sp->var)


### PR DESCRIPTION
These functions accept a size parameter that *includes* the null terminator, so tweak function calls accordingly.