### PR TITLE
filtered SEXP operator speedup

### DIFF
--- a/fred2/OperatorComboBox.h
+++ b/fred2/OperatorComboBox.h
@@ -62,6 +62,8 @@ protected:
 	afx_msg void OnDestroy();
 	afx_msg BOOL OnEditChange();
 
+	void set_popup_operators(const SCP_vector<int> &operator_indexes);
+
 	const char* (*m_help_callback)(int);
 	bool m_pressed_enter;
 


### PR DESCRIPTION
Improve the speed of the SEXP filter by not redrawing the combo box until the box is fully populated.