### PR TITLE
fix multi-line display in mission log

### DIFF
--- a/code/mission/missionlog.h
+++ b/code/mission/missionlog.h
@@ -75,6 +75,7 @@ struct log_text_seg {
 	SCP_vm_unique_ptr<char> text; // the text
 	int color;                    // color text should be displayed in
 	int x;                        // x offset to display text at
+	int line_offset;              // if this is part of an entry that spans multiple lines
 	int flags;                    // used to possibly print special characters when displaying the log
 };
 


### PR DESCRIPTION
At some point the mission log became unable to display entries that wrapped around to subsequent lines.  Fix that by keeping track of how many lines each entry occupies and adjusting the display accordingly.

This will correctly display mission log segments on multiple lines, but it uses the current string splitting technique which does not split properly in all cases.  The splitting will work properly once the `split_str_once` refactor is merged.