### PR TITLE
Fix texture slot 0 incorrectly being considered invalid in a lot of cases

### DIFF
--- a/code/graphics/material.cpp
+++ b/code/graphics/material.cpp
@@ -768,19 +768,19 @@ int model_material::get_shader_runtime_flags() const {
 		flags |= MODEL_SDR_FLAG_DEFERRED;
 	if (is_hdr())
 		flags |= MODEL_SDR_FLAG_HDR;
-	if (get_texture_map(TM_BASE_TYPE) > 0)
+	if (get_texture_map(TM_BASE_TYPE) >= 0)
 		flags |= MODEL_SDR_FLAG_DIFFUSE;
-	if (get_texture_map(TM_GLOW_TYPE) > 0)
+	if (get_texture_map(TM_GLOW_TYPE) >= 0)
 		flags |= MODEL_SDR_FLAG_GLOW;
-	if (get_texture_map(TM_SPECULAR_TYPE) > 0 || get_texture_map(TM_SPEC_GLOSS_TYPE) > 0)
+	if (get_texture_map(TM_SPECULAR_TYPE) >= 0 || get_texture_map(TM_SPEC_GLOSS_TYPE) >= 0)
 		flags |= MODEL_SDR_FLAG_SPEC;
-	if (get_texture_map(TM_NORMAL_TYPE) > 0)
+	if (get_texture_map(TM_NORMAL_TYPE) >= 0)
 		flags |= MODEL_SDR_FLAG_NORMAL;
-	if (get_texture_map(TM_AMBIENT_TYPE) > 0)
+	if (get_texture_map(TM_AMBIENT_TYPE) >= 0)
 		flags |= MODEL_SDR_FLAG_AMBIENT;
-	if (get_texture_map(TM_MISC_TYPE) > 0)
+	if (get_texture_map(TM_MISC_TYPE) >= 0)
 		flags |= MODEL_SDR_FLAG_MISC;
-	if (get_texture_map(TM_MISC_TYPE) > 0 && is_team_color_set())
+	if (get_texture_map(TM_MISC_TYPE) >= 0 && is_team_color_set())
 		flags |= MODEL_SDR_FLAG_TEAMCOLOR;
 	if (is_fogged())
 		flags |= MODEL_SDR_FLAG_FOG;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -871,7 +871,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 		//No shader ever defines this, so don't push it.
 		//Current_shader->program->Uniforms.setTextureUniform("sHeightmap", 5);
 
-		if (material_info->get_texture_map(TM_BASE_TYPE) > 0) {
+		if (material_info->get_texture_map(TM_BASE_TYPE) >= 0) {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_BASE_TYPE),
 				TCACHE_TYPE_NORMAL,
 				&u_scale,
@@ -880,7 +880,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 				0);
 		}
 
-		if (material_info->get_texture_map(TM_GLOW_TYPE) > 0) {
+		if (material_info->get_texture_map(TM_GLOW_TYPE) >= 0) {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_GLOW_TYPE),
 				TCACHE_TYPE_NORMAL,
 				&u_scale,
@@ -889,9 +889,9 @@ void opengl_tnl_set_model_material(model_material *material_info)
 				1);
 		}
 
-		if (material_info->get_texture_map(TM_SPECULAR_TYPE) > 0 ||
-			material_info->get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) {
-			if (material_info->get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) {
+		if (material_info->get_texture_map(TM_SPECULAR_TYPE) >= 0 ||
+			material_info->get_texture_map(TM_SPEC_GLOSS_TYPE) >= 0) {
+			if (material_info->get_texture_map(TM_SPEC_GLOSS_TYPE) >= 0) {
 				gr_opengl_tcache_set(material_info->get_texture_map(TM_SPEC_GLOSS_TYPE),
 					TCACHE_TYPE_NORMAL,
 					&u_scale,
@@ -908,7 +908,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 			}
 		}
 
-		if (material_info->get_texture_map(TM_NORMAL_TYPE) > 0) {
+		if (material_info->get_texture_map(TM_NORMAL_TYPE) >= 0) {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_NORMAL_TYPE),
 				TCACHE_TYPE_NORMAL,
 				&u_scale,
@@ -917,7 +917,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 				4);
 		}
 
-		if (material_info->get_texture_map(TM_HEIGHT_TYPE) > 0) {
+		if (material_info->get_texture_map(TM_HEIGHT_TYPE) >= 0) {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_HEIGHT_TYPE),
 				TCACHE_TYPE_NORMAL,
 				&u_scale,
@@ -926,7 +926,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 				5);
 		}
 
-		if (material_info->get_texture_map(TM_AMBIENT_TYPE) > 0) {
+		if (material_info->get_texture_map(TM_AMBIENT_TYPE) >= 0) {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_AMBIENT_TYPE),
 				TCACHE_TYPE_NORMAL,
 				&u_scale,
@@ -935,7 +935,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 				6);
 		}
 
-		if (material_info->get_texture_map(TM_MISC_TYPE) > 0) {
+		if (material_info->get_texture_map(TM_MISC_TYPE) >= 0) {
 			gr_opengl_tcache_set(material_info->get_texture_map(TM_MISC_TYPE),
 				TCACHE_TYPE_NORMAL,
 				&u_scale,
@@ -948,7 +948,7 @@ void opengl_tnl_set_model_material(model_material *material_info)
 			GL_state.Texture.Enable(8, GL_TEXTURE_2D_ARRAY, Shadow_map_texture);
 		}
 
-		if (material_info->get_animated_effect() > 0) {
+		if (material_info->get_animated_effect() >= 0) {
 			if (Scene_framebuffer_in_frame) {
 				GL_state.Texture.Enable(9, GL_TEXTURE_2D, Scene_composite_texture);
 				glDrawBuffer(GL_COLOR_ATTACHMENT0);

--- a/code/graphics/uniforms.cpp
+++ b/code/graphics/uniforms.cpp
@@ -109,7 +109,7 @@ void convert_model_material(model_uniform_data* data_out,
 	}
 	data_out->defaultGloss = 0.6f;
 
-	if (material.get_texture_map(TM_BASE_TYPE) > 0) {
+	if (material.get_texture_map(TM_BASE_TYPE) >= 0) {
 		if (material.is_desaturated()) {
 			data_out->desaturate = 1;
 		} else {
@@ -132,12 +132,12 @@ void convert_model_material(model_uniform_data* data_out,
 		data_out->sBasemapIndex = bm_get_array_index(material.get_texture_map(TM_BASE_TYPE));
 	}
 
-	if (material.get_texture_map(TM_GLOW_TYPE) > 0) {
+	if (material.get_texture_map(TM_GLOW_TYPE) >= 0) {
 		data_out->sGlowmapIndex = bm_get_array_index(material.get_texture_map(TM_GLOW_TYPE));
 	}
 
 
-	if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) > 0) {
+	if (material.get_texture_map(TM_SPEC_GLOSS_TYPE) >= 0) {
 		data_out->sSpecmapIndex = bm_get_array_index(material.get_texture_map(TM_SPEC_GLOSS_TYPE));
 
 		data_out->gammaSpec = 1;
@@ -145,22 +145,22 @@ void convert_model_material(model_uniform_data* data_out,
 
 	} 
 
-	if (material.get_texture_map(TM_SPECULAR_TYPE) > 0) {
+	if (material.get_texture_map(TM_SPECULAR_TYPE) >= 0) {
 		data_out->sSpecmapIndex = bm_get_array_index(material.get_texture_map(TM_SPECULAR_TYPE));
 
 		data_out->gammaSpec = 0;
 		data_out->alphaGloss = 0;
 	}
 	
-	if (material.get_texture_map(TM_NORMAL_TYPE) > 0) {
+	if (material.get_texture_map(TM_NORMAL_TYPE) >= 0) {
 		data_out->sNormalmapIndex = bm_get_array_index(material.get_texture_map(TM_NORMAL_TYPE));
 	}
 
-	if (material.get_texture_map(TM_AMBIENT_TYPE) > 0) {
+	if (material.get_texture_map(TM_AMBIENT_TYPE) >= 0) {
 		data_out->sAmbientmapIndex = bm_get_array_index(material.get_texture_map(TM_AMBIENT_TYPE));
 	}
 
-	if (material.get_texture_map(TM_MISC_TYPE) > 0) {
+	if (material.get_texture_map(TM_MISC_TYPE) >= 0) {
 		data_out->sMiscmapIndex = bm_get_array_index(material.get_texture_map(TM_MISC_TYPE));
 	}
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1121,7 +1121,7 @@ void model_render_buffers(model_draw_list* scene, model_material *rendering_mate
 					texture_maps[TM_BASE_TYPE] = model_interp_get_texture(&tmap->textures[TM_BASE_TYPE], elapsed_time);
 				}
 
-				if ( texture_maps[TM_BASE_TYPE] <= 0 ) {
+				if ( texture_maps[TM_BASE_TYPE] < 0 ) {
 					continue;
 				}
 			}


### PR DESCRIPTION
Fixes #7105.

This bug is closely related to #6794.
Notably, I suspect that the path how the bug manifests is exactly the same.
In large chunks of the FSO render path (specifically in the model render path), texture id's were checked against > 0, considering 0 and negative numbers to be invalid, thus never rendering any texture that occupies slot 0.
This was only very, very rarely relevant until now, because in most cases, slot 0 is and will stay occupied by a font texture atlas, which does not use the affected render path. Of course, as described in #6794, some mods like FotG exhibit a set of properties that regularly cause texture 0 to be occupied by other textures, like in this case the RTT cockpit gauges.