### PR TITLE
upgrade Unicode `text_iterator` for C++17

### DIFF
--- a/code/utils/unicode.cpp
+++ b/code/utils/unicode.cpp
@@ -51,7 +51,17 @@ text_iterator& text_iterator::operator--() {
 
 	return *this;
 }
-text_iterator::value_type text_iterator::operator*() {
+text_iterator text_iterator::operator++(int) {
+	auto copy{*this};
+	this->operator++();
+	return copy;
+}
+text_iterator text_iterator::operator--(int) {
+	auto copy{*this};
+	this->operator--();
+	return copy;
+}
+text_iterator::value_type text_iterator::operator*() const {
 	if (Unicode_text_mode) {
 		try {
 			return utf8::peek_next(current_byte, range_end_byte);

--- a/code/utils/unicode.h
+++ b/code/utils/unicode.h
@@ -39,17 +39,25 @@ class text_iterator {
 	const char* range_start_byte = nullptr;
 
 	bool is_from_same_range(const text_iterator& other) const;
+
  public:
 	explicit text_iterator(const char* current_byte, const char* range_start_byte, const char* range_end_byte = nullptr);
 
-	typedef codepoint_t value_type;
+	using difference_type = std::ptrdiff_t;
+	using value_type = codepoint_t;
+	using pointer = codepoint_t const *;
+	using reference = codepoint_t const &;
+	using iterator_category = std::bidirectional_iterator_tag;
 
 	const char* pos() const;
 
 	text_iterator& operator++();
 	text_iterator& operator--();
 
-	value_type operator*();
+	text_iterator operator++(int);
+	text_iterator operator--(int);
+
+	value_type operator*() const;
 
 	bool operator==(const text_iterator& rhs) const;
 	bool operator!=(const text_iterator& rhs) const;


### PR DESCRIPTION
Add member types, tweak function signatures, and add a couple functions