### PR TITLE
remove the splodeing code

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -118,10 +118,6 @@ static int Num_ship_subsystems_allocated = 0;
 static SCP_vector<ship_subsys*> Ship_subsystems;
 ship_subsys ship_subsys_free_list;
 
-extern bool splodeing;
-extern float splode_level;
-extern int splodeingtexture;
-
 // The minimum required fuel to engage afterburners
 static const float DEFAULT_MIN_AFTERBURNER_FUEL_TO_ENGAGE = 10.0f;
 
@@ -1279,9 +1275,6 @@ void ship_info::clone(const ship_info& other)
 
 	draw_distortion = other.draw_distortion;
 
-	splodeing_texture = other.splodeing_texture;
-	strcpy_s(splodeing_texture_name, other.splodeing_texture_name);
-
 	replacement_textures = other.replacement_textures;
 
 	armor_type_idx = other.armor_type_idx;
@@ -1633,9 +1626,6 @@ void ship_info::move(ship_info&& other)
 	thruster_glow_noise_mult = other.thruster_glow_noise_mult;
 
 	draw_distortion = other.draw_distortion;
-
-	splodeing_texture = other.splodeing_texture;
-	std::swap(splodeing_texture_name, other.splodeing_texture_name);
 
 	std::swap(replacement_textures, other.replacement_textures);
 
@@ -2036,9 +2026,6 @@ ship_info::ship_info()
 	thruster_glow_noise_mult = 1.0f;
 
 	draw_distortion = true;
-
-	splodeing_texture = -1;
-	strcpy_s(splodeing_texture_name, "boom");
 
 	replacement_textures.clear();
 
@@ -7120,8 +7107,6 @@ void ship::clear()
 	next_corkscrew_fire = timestamp(0);
 
 	final_death_time = timestamp(-1);
-	death_time = timestamp(-1);
-	end_death_time = timestamp(-1);
 	really_final_death_time = timestamp(-1);
 	deathroll_rotvel = vmd_zero_vector;
 
@@ -9717,7 +9702,6 @@ static void ship_dying_frame(object *objp, int ship_num)
 		}
 
 		if ( timestamp_elapsed(shipp->final_death_time))	{
-			shipp->death_time = shipp->final_death_time;
 			shipp->final_death_time = timestamp(-1);	// never time out again
 			
 			// play ship explosion sound effect, pick appropriate explosion sound
@@ -9780,8 +9764,6 @@ static void ship_dying_frame(object *objp, int ship_num)
 				shipfx_large_blowup_init(shipp);
 				// need to timeout immediately to keep physics in sync
 				shipp->really_final_death_time = timestamp(0);
-				polymodel *pm = model_get(sip->model_num);
-				shipp->end_death_time = timestamp((int) pm->core_radius);
 			} else {
 				// else, just a single big fireball
 				float big_rad;
@@ -9816,7 +9798,8 @@ static void ship_dying_frame(object *objp, int ship_num)
 				// ship, so instead of just taking this code out, since we might need
 				// it in the future, I disabled it.   You can reenable it by changing
 				// the commenting on the following two lines.
-				shipp->end_death_time = shipp->really_final_death_time = timestamp( fl2i(explosion_life*1000.0f)/5 );	// Wait till 30% of vclip time before breaking the ship up.
+				shipp->really_final_death_time = timestamp( fl2i(explosion_life*1000.0f)/5 );	// Wait till 30% of vclip time before breaking the ship up.
+				//sp->really_final_death_time = timestamp(0);	// Make ship break apart the instant the explosion starts
 			}
 
 			shipp->flags.set(Ship_Flags::Exploded);
@@ -19273,12 +19256,6 @@ void ship_page_in_textures(int ship_index)
 	if ( !generic_bitmap_load(&sip->thruster_tertiary_glow_info.afterburn) )
 		bm_page_in_texture(sip->thruster_tertiary_glow_info.afterburn.bitmap_id);
  
-	// splodeing bitmap
-	if ( VALID_FNAME(sip->splodeing_texture_name) ) {
-		sip->splodeing_texture = bm_load(sip->splodeing_texture_name);
-		bm_page_in_texture(sip->splodeing_texture);
-	}
-
 	// thruster/particle bitmaps
 	for (i = 0; i < (int)sip->normal_thruster_particles.size(); i++) {
 		generic_anim_load(&sip->normal_thruster_particles[i].thruster_bitmap);
@@ -19329,9 +19306,6 @@ void ship_page_out_textures(int ship_index, bool release)
 	PAGE_OUT_TEXTURE(sip->thruster_secondary_glow_info.afterburn.bitmap_id);
 	PAGE_OUT_TEXTURE(sip->thruster_tertiary_glow_info.normal.bitmap_id);
 	PAGE_OUT_TEXTURE(sip->thruster_tertiary_glow_info.afterburn.bitmap_id);
-
-	// slodeing bitmap
-	PAGE_OUT_TEXTURE(sip->splodeing_texture);
 
 	// thruster/particle bitmaps
 	for (i = 0; i < (int)sip->normal_thruster_particles.size(); i++)

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -587,8 +587,6 @@ public:
 	// END PACK
 
 	int	final_death_time;				// Time until big fireball starts
-	int	death_time;				// Time until big fireball starts
-	int	end_death_time;				// Time until big fireball starts
 	int	really_final_death_time;	// Time until ship breaks up and disappears
 	vec3d	deathroll_rotvel;			// Desired death rotational velocity
 
@@ -1428,9 +1426,6 @@ public:
 	float		thruster_glow_noise_mult;
 
 	bool		draw_distortion;
-
-	int splodeing_texture;
-	char splodeing_texture_name[MAX_FILENAME_LEN];
 
 	// Goober5000
 	SCP_vector<texture_replace> replacement_textures;

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1747,7 +1747,7 @@ void ship_generic_kill_stuff( object *objp, float percent_killed )
 			delta_time = 2;
 	}
 
-	sp->death_time = sp->final_death_time = timestamp(delta_time);	// Give him 3 secs to explode
+	sp->final_death_time = timestamp(delta_time);	// Give him 3 secs to explode
 
 	//SUSHI: What are the chances of an instant explosion? Check the ship type (objecttypes.tbl) as well as the ship (ships.tbl)
 	float skipChance;


### PR DESCRIPTION
This dates back to commit `300d5fc2c1`.  It probably did something at some point, but with various upgrades over the years, it no longer has any effect.

It looks like a lot of the model interp code (e.g. `model_interp_defpoints`, which isn't called anywhere) can be removed as well, but that's a bit more involved.