### PR TITLE
add Zero_radius_explosions_skip_fireballs

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1607,8 +1607,13 @@ static float asteroid_create_explosion(object *objp)
 	}
 
 	fireball_scale_multiplier = asteroid_get_fireball_scale_multiplier(objp->instance);
+	auto fireball_radius = objp->radius * fireball_scale_multiplier;
 
-	fireball_objnum = fireball_create( &objp->pos, fireball_type, FIREBALL_LARGE_EXPLOSION, OBJ_INDEX(objp), objp->radius*fireball_scale_multiplier, false, &objp->phys_info.vel );
+	if (Zero_radius_explosions_skip_fireballs && fl_near_zero(fireball_radius))
+		fireball_objnum = -1;
+	else
+		fireball_objnum = fireball_create( &objp->pos, fireball_type, FIREBALL_LARGE_EXPLOSION, OBJ_INDEX(objp), fireball_radius, false, &objp->phys_info.vel );
+
 	if ( fireball_objnum > -1 )	{
 		explosion_life = fireball_lifeleft(&Objects[fireball_objnum]);
 	} else {

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -182,6 +182,7 @@ bool Show_locked_status_scramble_missions;
 bool Disable_expensive_turret_target_check;
 float Shield_percent_skips_damage;
 float Min_radius_for_persistent_debris;
+bool Zero_radius_explosions_skip_fireballs;
 
 
 #ifdef WITH_DISCORD
@@ -1638,6 +1639,10 @@ void parse_mod_table(const char *filename)
 				stuff_float(&Min_radius_for_persistent_debris);
 			}
 
+			if (optional_string("$Zero-radius explosions skip fireballs:")) {
+				stuff_boolean(&Zero_radius_explosions_skip_fireballs);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1884,6 +1889,7 @@ void mod_table_reset()
 	Disable_expensive_turret_target_check = false;
 	Shield_percent_skips_damage = 0.1f;
 	Min_radius_for_persistent_debris = 50.0f;
+	Zero_radius_explosions_skip_fireballs = false;
 }
 
 void mod_table_set_version_flags()
@@ -1911,5 +1917,8 @@ void mod_table_set_version_flags()
 		Fix_asteroid_bounding_box_check = true;
 		Disable_expensive_turret_target_check = true;
 		Skybox_internal_depth_consistency = true;
+	}
+	if (mod_supports_version(26, 0, 0)) {
+		Zero_radius_explosions_skip_fireballs = true;
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -204,6 +204,7 @@ extern bool Show_locked_status_scramble_missions;
 extern bool Disable_expensive_turret_target_check;
 extern float Shield_percent_skips_damage;
 extern float Min_radius_for_persistent_debris;
+extern bool Zero_radius_explosions_skip_fireballs;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9802,7 +9802,12 @@ static void ship_dying_frame(object *objp, int ship_num)
 				if(fireball_type < 0) {
 					fireball_type = default_fireball_type;
 				}
-				fireball_objnum = fireball_create( &objp->pos, fireball_type, FIREBALL_LARGE_EXPLOSION, OBJ_INDEX(objp), big_rad, false, &objp->phys_info.vel );
+
+				if (Zero_radius_explosions_skip_fireballs && fl_near_zero(big_rad))
+					fireball_objnum = -1;
+				else
+					fireball_objnum = fireball_create( &objp->pos, fireball_type, FIREBALL_LARGE_EXPLOSION, OBJ_INDEX(objp), big_rad, false, &objp->phys_info.vel );
+
 				if ( fireball_objnum >= 0 )	{
 					explosion_life = fireball_lifeleft(&Objects[fireball_objnum]);
 				} else {


### PR DESCRIPTION
Addresses a behavior idiosyncrasy encountered by Solaris.  If this flag is enabled, explosions with a visual radius of 0 do not have fireballs created, and do not have the fireball lifetime added to the explosion lifetime.