### PR TITLE
some ship utility enhancements

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -8814,7 +8814,7 @@ void check_anchor_for_hangar_bay(SCP_string &message, SCP_set<int> &anchor_shipn
 		return;
 	anchor_shipnums_checked.insert(anchor_shipnum);
 
-	if (!ship_has_dock_bay(anchor_shipnum))
+	if (!ship_has_hangar_bay(anchor_shipnum))
 	{
 		auto shipp = &Ships[anchor_shipnum];
 		sprintf(message, "%s (%s) is used as a%s anchor by %s %s (and possibly elsewhere too), but it does not have a hangar bay!", shipp->ship_name,

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1260,6 +1260,7 @@ int model_get_dock_types(int modelnum);
 // Goober5000
 // returns index in [0, MAX_SHIP_BAY_PATHS)
 int model_find_bay_path(int modelnum, char *bay_path_name);
+bool model_has_hangar_bay(int modelnum);
 
 // Returns number of polygons in a submodel;
 int submodel_get_num_polys(int model_num, int submodel_num);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5376,6 +5376,14 @@ int model_find_bay_path(int modelnum, char *bay_path_name)
 	return -1;
 }
 
+bool model_has_hangar_bay(int modelnum)
+{
+	auto pm = model_get(modelnum);
+	Assertion(pm, "modelnum %d does not exist!", modelnum);
+
+	return ( pm->ship_bay && (pm->ship_bay->num_paths > 0) );
+}
+
 int model_create_bsp_collision_tree()
 {
 	// first find an open slot

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -3047,8 +3047,8 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 
 				// ship exists at this point
 
-				// now determine if this ship has a docking bay
-				if (!ship_has_dock_bay(shipnum))
+				// now determine if this ship has a hangar bay
+				if (!ship_has_hangar_bay(shipnum))
 					return SEXP_CHECK_INVALID_SHIP_WITH_BAY;
 
 				break;

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -954,6 +954,8 @@ struct ship_registry_entry
 	p_object* p_objp_or_null() const;
 	object* objp_or_null() const;
 	ship* shipp_or_null() const;
+
+	ship_info* sip() const;
 };
 
 extern SCP_vector<ship_registry_entry> Ship_registry;
@@ -963,8 +965,10 @@ extern int ship_registry_get_index(const char *name);
 extern int ship_registry_get_index(const SCP_string &name);
 extern bool ship_registry_exists(const char *name);
 extern bool ship_registry_exists(const SCP_string &name);
+extern bool ship_registry_exists(int index);
 extern const ship_registry_entry *ship_registry_get(const char *name);
 extern const ship_registry_entry *ship_registry_get(const SCP_string &name);
+extern const ship_registry_entry *ship_registry_get(int index);
 
 #define REGULAR_WEAPON	(1<<0)
 #define DOGFIGHT_WEAPON (1<<1)
@@ -2013,7 +2017,7 @@ extern void ship_subsystem_set_new_ai_class(ship_subsys *ss, int new_ai_class);
 extern void wing_load_squad_bitmap(wing *w);
 
 // Goober5000 - needed by new hangar depart code
-extern bool ship_has_dock_bay(int shipnum);
+extern bool ship_has_hangar_bay(int shipnum);
 extern bool ship_useful_for_departure(int shipnum, int path_mask = 0);
 extern int ship_get_ship_for_departure(int team);
 

--- a/fred2/sexp_tree.cpp
+++ b/fred2/sexp_tree.cpp
@@ -6599,8 +6599,8 @@ sexp_list_item *sexp_tree::get_listing_opf_ship_with_bay()
 	{
 		if ( (objp->type == OBJ_SHIP) || (objp->type == OBJ_START) )
 		{
-			// determine if this ship has a docking bay
-			if (ship_has_dock_bay(objp->instance))
+			// determine if this ship has a hangar bay
+			if (ship_has_hangar_bay(objp->instance))
 			{
 				head.add_data(Ships[objp->instance].ship_name);
 			}

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -2496,7 +2496,7 @@ void CShipEditorDlg::OnRestrictArrival()
 
 	arrive_from_ship = (int)box->GetItemData(m_arrival_target);
 
-	if (!ship_has_dock_bay(arrive_from_ship))
+	if (!ship_has_hangar_bay(arrive_from_ship))
 	{
 		Int3();
 		return;
@@ -2540,7 +2540,7 @@ void CShipEditorDlg::OnRestrictDeparture()
 
 	depart_to_ship = (int)box->GetItemData(m_departure_target);
 
-	if (!ship_has_dock_bay(depart_to_ship))
+	if (!ship_has_hangar_bay(depart_to_ship))
 	{
 		Int3();
 		return;

--- a/fred2/wing_editor.cpp
+++ b/fred2/wing_editor.cpp
@@ -1388,7 +1388,7 @@ void wing_editor::OnRestrictArrival()
 
 	arrive_from_ship = (int)box->GetItemData(m_arrival_target);
 
-	if (!ship_has_dock_bay(arrive_from_ship))
+	if (!ship_has_hangar_bay(arrive_from_ship))
 	{
 		Int3();
 		return;
@@ -1423,7 +1423,7 @@ void wing_editor::OnRestrictDeparture()
 
 	depart_to_ship = (int)box->GetItemData(m_departure_target);
 
-	if (!ship_has_dock_bay(depart_to_ship))
+	if (!ship_has_hangar_bay(depart_to_ship))
 	{
 		Int3();
 		return;

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
@@ -69,7 +69,7 @@ std::vector<std::pair<SCP_string, bool>> WingEditorDialogModel::getDockBayPathsF
 {
 	std::vector<std::pair<SCP_string, bool>> out;
 
-	if (anchorShipnum < 0 || !ship_has_dock_bay(anchorShipnum))
+	if (anchorShipnum < 0 || !ship_has_hangar_bay(anchorShipnum))
 		return out;
 
 	const int sii = Ships[anchorShipnum].ship_info_index;
@@ -974,7 +974,7 @@ void WingEditorDialogModel::setArrivalPaths(const std::vector<std::pair<SCP_stri
 		return;
 
 	const int anchor = w->arrival_anchor;
-	if (anchor < 0 || !ship_has_dock_bay(anchor))
+	if (anchor < 0 || !ship_has_hangar_bay(anchor))
 		return;
 
 	// Rebuild mask in the same order we produced the list
@@ -1213,7 +1213,7 @@ void WingEditorDialogModel::setDeparturePaths(const std::vector<std::pair<SCP_st
 		return;
 
 	const int anchor = w->departure_anchor;
-	if (anchor < 0 || !ship_has_dock_bay(anchor))
+	if (anchor < 0 || !ship_has_hangar_bay(anchor))
 		return;
 
 	// Rebuild mask in the same order we produced the list

--- a/qtfred/src/ui/widgets/sexp_tree.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree.cpp
@@ -4488,8 +4488,8 @@ sexp_list_item* sexp_tree::get_listing_opf_ship_with_bay() {
 
 	for (objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
 		if ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) {
-			// determine if this ship has a docking bay
-			if (ship_has_dock_bay(objp->instance)) {
+			// determine if this ship has a hangar bay
+			if (ship_has_hangar_bay(objp->instance)) {
 				head.add_data(Ships[objp->instance].ship_name);
 			}
 		}


### PR DESCRIPTION
Add a useful function for getting a ship_info pointer from a ship registry entry.  Also rename `ship_has_dock_bay` to `ship_has_hangar_bay` for clarity, since docking bays and docking points are not the same thing.  Finally, add a `model_has_hangar_bay` function.