### PR TITLE
tweak ship_cleanup

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -663,7 +663,7 @@ MONITOR(NumShipArrivals)
 MONITOR(NumShipDepartures)
 
 const std::shared_ptr<scripting::Hook<scripting::hooks::ShipDepartConditions>> OnDepartureStartedHook = scripting::Hook<scripting::hooks::ShipDepartConditions>::Factory(
-	"On Departure Started", "Called when a ship starts the departure process.",
+	"On Departure Started", "Called when a ship initiates a departure (acquires a hangar bay path or begins to warp) but is not actually exiting the mission yet.",
 	{
 		{"Self", "ship", "An alias for Ship."},
 		{"Ship", "ship", "The ship that has begun the departure process."},

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -486,7 +486,7 @@ ADE_INDEXER(l_Mission_Ships, "number/string IndexOrName", "Gets ship", "ship", "
 	auto entry = ship_registry_get(name);
 	if (entry)
 	{
-		if (entry->has_shipp())
+		if (entry->has_objp())
 			objnum = entry->objnum;
 	}
 	else

--- a/code/scripting/global_hooks.cpp
+++ b/code/scripting/global_hooks.cpp
@@ -304,7 +304,7 @@ const std::shared_ptr<Hook<ShipDepartConditions>> OnShipDepart = Hook<ShipDepart
 	"Invoked when a ship departs the mission without being destroyed.",
 	{
 		{"Ship", "ship", "The ship departing the mission"},
-		{"JumpNode", "string", "The name of the jump node the ship jumped out of. Can be nil."},
+		{"JumpNode", "string", "The name of the jump node the ship was in when it departed. Can be nil."},
 		{"Method", "ship", "The name of the method the ship used to depart. One of: 'SHIP_DEPARTED', 'SHIP_DEPARTED_WARP', 'SHIP_DEPARTED_BAY', 'SHIP_VANISHED', 'SHIP_DEPARTED_REDALERT'."},
 	});
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -9134,11 +9134,9 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	// this should never happen
 	Assertion(Ship_registry_map.find(shipp->ship_name) != Ship_registry_map.end(), "Ship %s was destroyed, but was never stored in the ship registry!", shipp->ship_name);
 
-	// Goober5000 - handle ship registry
+	// Goober5000 - handle ship registry, part 1
 	auto entry = &Ship_registry[Ship_registry_map[shipp->ship_name]];
 	entry->status = ShipStatus::EXITED;
-	entry->objnum = -1;
-	entry->shipnum = -1;
 	entry->cleanup_mode = cleanup_mode;
 
 	// add the information to the exited ship list
@@ -9289,6 +9287,10 @@ void ship_cleanup(int shipnum, int cleanup_mode)
 	// (for exploding ships, this list should have already been cleared by now, via
 	// do_dying_undock_physics, except in the case of the destroy-instantly sexp)
 	dock_dead_undock_all(objp);
+
+	// Goober5000 - handle ship registry, part 2
+	entry->objnum = -1;
+	entry->shipnum = -1;
 }
 
 /**


### PR DESCRIPTION
The object and ship indexes held by the ship registry do not actually need to be cleared until `ship_cleanup` completes.  This will allow the ship to be referenced in any functions (via script hooks or otherwise) that are called during cleanup.

Tweak related script documentation while we're at it.

Follow-up to #7120.  Fixes #7122.