### PR TITLE
Fix rendertargets being incorrectly invalidated

### DIFF
--- a/code/scripting/api/objs/texture.cpp
+++ b/code/scripting/api/objs/texture.cpp
@@ -145,8 +145,6 @@ ADE_FUNC(destroyRenderTarget, l_Texture, nullptr, "Destroys a texture's render t
 
 	bm_release_rendertarget(th->handle);
 
-	th->handle = -1;
-
 	return ADE_RETURN_NIL;
 }
 


### PR DESCRIPTION
Fixes a bug added in #6866.
Of course, we don't need to clear textures just cause the rendertarget was freed... Instead, we should keep them for actual read-only use.
This fixes missing radar icons in the radaricon script and likely other scripted rendering scripts.