### PR TITLE
fix scannable ship types

### DIFF
--- a/code/def_files/data/tables/objecttypes.tbl
+++ b/code/def_files/data/tables/objecttypes.tbl
@@ -156,6 +156,7 @@ $Praise Destruction:	YES
 $On Hotkey List:		YES												
 $Target as Threat:		YES												
 $Show Attack Direction:	YES												
+$Scannable:				YES												
 $Max Debris Speed:		150												
 $FF Multiplier:			1.0												
 $EMP Multiplier:		2.0												
@@ -186,7 +187,6 @@ $Praise Destruction:	YES
 $On Hotkey List:		YES												
 $Target as Threat:		YES												
 $Show Attack Direction:	YES												
-$Scannable:				YES												
 $Max Debris Speed:		150												
 $FF Multiplier:			1.0												
 $EMP Multiplier:		1.75											


### PR DESCRIPTION
The `$Scannable` field in objecttypes.tbl controls whether a ship can be targeted by the "target unscanned ship" key.  In retail, these were cargo containers and freighters.  This is independent of which ship types can actually be *scanned*, which in retail were cargo containers and *transports*.  Since the targetability is meaningless without the ability to scan, this fixes the retail inconsistency by moving the targetability from Freighter to Transport.

Note that this is only relevant for legacy scanning behavior.  Mods which use `$Unify scanning behavior:` do not experience the inconsistency.