### PR TITLE
Fix haloing in cockpit shadows

### DIFF
--- a/code/def_files/data/effects/shadows.sdr
+++ b/code/def_files/data/effects/shadows.sdr
@@ -79,7 +79,6 @@ float samplePoissonPCF(sampler2DArray shadow_map, float shadowDepth, int cascade
 		return computeShadowFactor(shadowDepth, sum*(1.0f/16.0f), 0.1f);
 	}
 
-	return computeShadowFactor(shadowDepth, sum, 0.1);
 }
 
 float getShadowValue(sampler2DArray shadow_map, float depth, float shadowDepth, vec4 shadowUV[4], float fardist,


### PR DESCRIPTION
Cockpits can use shadows, but the small geometry of cockpits and the current shadow pass methods result in bad looking shadow halos and poor quality. The issue is that small scale geometry, like cockpit struts/pillars, cast overlapping shadows--and these overlapping shadows need to use a different shadowing method then the default larger external shadows.

I made a small edit the to the shadows file to fix it for small scale shadows (external shadows, IE those at longer ranges, remain using their method since that method works better at longer ranges). In FotG we have been using this update for years and it works very well.

KamiGaAtaeta was having these halo issues on the FS Ship Interiors project, and this shader update fixed those issues. Thus, per suggestion from Lafiel, I'm PRing this fix so everyone can easily use it.