### PR TITLE
Fix Message Line Positioning

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -475,7 +475,7 @@ void HudGaugeMessages::render(float  /*frametime*/, bool config)
 					setGaugeColor();
 				}
 				// print the message out
-				renderString(x + active_message.msg.x, y + active_message.y, active_message.msg.text.c_str(), scale);
+				renderString(active_message.msg.x, active_message.y, active_message.msg.text.c_str(), scale);
 			}
 		}
 	}


### PR DESCRIPTION
Message Lines were not being rendered to the proper position for certain resolutions and fixes #7143.

#6575 seemed to be the commit it broke on, and looking at that commit it showed that code added `x` and `y` to the render string positions, even though `x` and `y` did not exist there before.
<img width="1009" height="149" alt="image" src="https://github.com/user-attachments/assets/7b98ffc3-863d-4252-b5f1-e55d90d0441b" />


This 1-line PR fixes that issue, and it is confirmed to fix the issue by KamiGaAtaeta. Also I checked and on more standard resolutions the message lines still display as expected in both mission and the HUD Config screen.