### PR TITLE
slight fix to "Always save display names"

### DIFF
--- a/fred2/fredrender.h
+++ b/fred2/fredrender.h
@@ -22,7 +22,9 @@ extern int Show_coordinates;        //!< Bool. If nonzero, draw the coordinates 
 extern int Show_outlines;           //!< Bool. If nonzero, draw each object's mesh. If models are shown, highlight them in white.
 extern bool Draw_outlines_on_selected_ships;	// If a ship is selected, draw mesh lines
 extern bool Draw_outline_at_warpin_position;	// Project an outline at the place where the ship will arrive after warping in
-extern bool Always_save_display_names;	// When saving a mission, always write display names to the mission file even if the display name is not set
+extern bool Always_save_display_names;	// When saving a mission, always write display names to the mission file even if the display name is not set.
+										// But ships in wings are excepted, because a display name will cause a ship to have the same name in every wave.
+										// In the future, a display name feature could be added to the wing dialog to handle this case.
 extern bool Error_checker_checks_potential_issues;	// Error checker checks not only outright errors but also potential issues
 extern bool Error_checker_checks_potential_issues_once;	// Same as above, but only once, and independent of the selected option
 extern int Show_stars;              //!< Bool. If nonzero, draw the starfield, nebulas, and suns. Might also handle skyboxes

--- a/fred2/missionsave.cpp
+++ b/fred2/missionsave.cpp
@@ -3589,13 +3589,13 @@ int CFred_mission_save::save_objects()
 
 		// Display name
 		// The display name is only written if there was one at the start to avoid introducing inconsistencies
-		if (Mission_save_format != FSO_FORMAT_RETAIL && (Always_save_display_names || shipp->has_display_name())) {
+		if (Mission_save_format != FSO_FORMAT_RETAIL && ((Always_save_display_names && shipp->wingnum < 0) || shipp->has_display_name())) {
 			char truncated_name[NAME_LENGTH];
 			strcpy_s(truncated_name, shipp->ship_name);
 			end_string_at_first_hash_symbol(truncated_name);
 
 			// Also, the display name is not written if it's just the truncation of the name at the hash
-			if (Always_save_display_names || strcmp(shipp->get_display_name(), truncated_name) != 0) {
+			if ((Always_save_display_names && shipp->wingnum < 0) || strcmp(shipp->get_display_name(), truncated_name) != 0) {
 				if (optional_string_fred("$Display name:", "$Class:")) {
 					parse_comments();
 				} else {

--- a/qtfred/src/mission/missionsave.cpp
+++ b/qtfred/src/mission/missionsave.cpp
@@ -3502,13 +3502,13 @@ int CFred_mission_save::save_objects()
 
 		// Display name
 		// The display name is only written if there was one at the start to avoid introducing inconsistencies
-		if (save_format != MissionFormat::RETAIL && (_viewport->Always_save_display_names || shipp->has_display_name())) {
+		if (save_format != MissionFormat::RETAIL && ((_viewport->Always_save_display_names && shipp->wingnum < 0) || shipp->has_display_name())) {
 			char truncated_name[NAME_LENGTH];
 			strcpy_s(truncated_name, shipp->ship_name);
 			end_string_at_first_hash_symbol(truncated_name);
 
 			// Also, the display name is not written if it's just the truncation of the name at the hash
-			if (_viewport->Always_save_display_names || strcmp(shipp->get_display_name(), truncated_name) != 0) {
+			if ((_viewport->Always_save_display_names && shipp->wingnum < 0) || strcmp(shipp->get_display_name(), truncated_name) != 0) {
 				if (optional_string_fred("$Display name:", "$Class:")) {
 					parse_comments();
 				} else {


### PR DESCRIPTION
A ship which has a display name and belongs to a wing will display that name no matter what wave it appears in.  Since this should only be done when the mission designer deliberately wants it to be done, omit this case from the cases covered by the "Always save display names" feature.  (To always save a display name in this case would require saving one for the wing, but a wing display name feature does not yet exist.)

Fixes #7140.  Followup to #6810.