### PR TITLE
disable compiler optimizations on Mac debug builds

### DIFF
--- a/cmake/toolchain-apple-clang.cmake
+++ b/cmake/toolchain-apple-clang.cmake
@@ -15,4 +15,4 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
 
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wno-unused-variable -Wno-unused-parameter")
 
-set(CMAKE_CXX_FLAGS_DEBUG "-Og -g -Wshadow")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -Wshadow")


### PR DESCRIPTION
Clang treats -Og the same as -O1, which prevents the viewing of many variables while debugging, so we need to use -O0 directly.