### PR TITLE
fix(math): correct xvec calculation in vm_vector_2_matrix_gen_vectors

### DIFF
--- a/code/math/vecmat.cpp
+++ b/code/math/vecmat.cpp
@@ -855,7 +855,7 @@ void vm_vector_2_matrix_gen_vectors_uvec(matrix* m)
 	}
 	else { 		//not straight up or down
 
-		xvec->xyz.x = yvec->xyz.y;
+		xvec->xyz.x = yvec->xyz.z;
 		xvec->xyz.y = 0.0f;
 		xvec->xyz.z = -yvec->xyz.x;
 
@@ -973,6 +973,8 @@ matrix* vm_vector_2_matrix_uvec_norm(matrix* m, const vec3d* fvec, const vec3d* 
 		*zvec = *fvec;
 
 		if (rvec != nullptr) { // use rvec
+			*xvec = *rvec;
+
 			vm_vec_cross(yvec, zvec, xvec);
 
 			//normalize new perpendicular vector


### PR DESCRIPTION
Follow-up for #7157
xvec fix: When computing a perpendicular vector in the XZ plane, the x component should use yvec.z, not yvec.y. The old code produced non-orthogonal results for vectors not aligned with an axis.

rvec fix: When fvec is provided as primary and rvec is also given, the code never actually assigned rvec to xvec before using it in the cross product.