### PR TITLE
fix(model): capture driver inputs by value

### DIFF
--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -1487,7 +1487,7 @@ namespace animation {
 						curve = Curves[curve_id];
 				}
 
-				driver = [&remap_driver_source, &curve](ModelAnimation &, ModelAnimation::instance_data &instance, polymodel_instance *pmi, float) {
+				driver = [remap_driver_source, curve](ModelAnimation &, ModelAnimation::instance_data &instance, polymodel_instance *pmi, float) {
 					float oldFrametime = instance.time;
 					instance.time = curve ? curve->GetValue(remap_driver_source(pmi)) : remap_driver_source(pmi);
 					CLAMP(instance.time, 0.0f, instance.duration);


### PR DESCRIPTION
uaf: switches the time remap driver lambda to capture its inputs by value to avoid dangling references when the stored lambda runs later