### PR TITLE
fix(graphics): measure ellipsis before shrinking in force_fit_string

### DIFF
--- a/code/graphics/software/font.cpp
+++ b/code/graphics/software/font.cpp
@@ -590,7 +590,7 @@ namespace font
 				str[len] = ellipsis_char;
 			}
 
-			// measure with ellipsis before shrinking further
+			// measure with ellipsis before shrinking further (the ellipsis characters could be narrower than the characters they replaced)
 			gr_get_string_size(&w, nullptr, str, scale, len + ellipsis_len);
 
 			// move the ellipsis back until the whole string fits


### PR DESCRIPTION
Follow up to #7161
obo: Strings were getting cut one letter shorter than they needed to be.