### PR TITLE
Assume beam and shockwave creation is fallible

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -14021,7 +14021,6 @@ void ship_process_targeting_lasers()
 
 			// hmm, why didn't it fire?
 			if(shipp->targeting_laser_objnum < 0){
-				Int3();
 				ship_stop_targeting_laser(shipp);
 			}
 		}

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -698,7 +698,6 @@ int beam_fire_targeting(fighter_beam_fire_info *fire_info)
 	if(objnum < 0){
 		beam_delete(new_item);
 		nprintf(("General", "obj_create() failed for beam weapon! bah!\n"));
-		Int3();
 		return -1;
 	}
 	new_item->objnum = objnum;	

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -181,7 +181,8 @@ int shockwave_create(int parent_objnum, const vec3d* pos, const shockwave_create
 	objnum = obj_create( OBJ_SHOCKWAVE, real_parent, i, &orient, &sw->pos, sw->outer_radius, tmp_flags + Object::Object_Flags::Renders, false );
 
 	if ( objnum == -1 ){
-		Int3();
+		mprintf(("Couldn't create shockwave object -- out of object slots\n"));
+		return -1;
 	}
 
 	sw->objnum = objnum;


### PR DESCRIPTION
"why didn't it fire?" Because object creation should always be assumed fallible, the designer can throw a million things around; there may be not slots available despite the code's best efforts.

Nothing cares about `shockwave_create`'s return, and only the single spot which was edited cares about `beam_fire_targeting()`'s return, so the relevant Int3's were removed. In both cases the problem is logged if the designer/coder wants to investigate further, but it's no reason to bring debug builds to a halt.

Other object creations, such as ships, are assumed infallible but it would be a larger effort to ensure the rest of the code is properly prepared for its fallibility.