### PR TITLE
Render reorder

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -3513,7 +3513,7 @@ void game_render_frame( camid cid, const vec3d* offset, const matrix* rot_offset
 
 	shadows_render_all(Proj_fov, &Eye_matrix, &Eye_position);
 	obj_render_queue_all();
-	
+
 	// render all ships with shader effects on them
 	auto obji = effect_ships.begin();
 	for(;obji != effect_ships.end();++obji)
@@ -3521,20 +3521,20 @@ void game_render_frame( camid cid, const vec3d* offset, const matrix* rot_offset
 		obj_render(*obji);
 	}
 	effect_ships.clear();
-	
+
 	render_shields();
-	
+
 	if (!Trail_render_override) trail_render_all();						// render missilie trails after everything else.
 	particle::render_all();					// render particles after everything else.
-	
+
 	beam_render_all();						// render all beam weapons
-	
+
 	// render nebula lightning
 	nebl_render_all();
-	
+
 	// render local player nebula
 	neb2_render_poofs();
-	
+
 	batching_render_all(false);
 
 	gr_copy_effect_texture();


### PR DESCRIPTION
Move the rendering of ships with effects to immediately after rendering of ships. This fixes rendering in several edge cases where, currently, additively-rendered items, among others, are incorrectly obscured by ships with effects. This affects anything that doesn't render to the depth buffer -- nebula poofs, particles, lasers, beams, engine glows, etc.

Forward-rendered objects (due to transparency) still interact incorrectly with full nebula fog, but that's out of scope for this PR.