### PR TITLE
Fix weapon object options menu in F3 Lab

### DIFF
--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -1426,7 +1426,7 @@ void LabUi::show_object_options() const
 			{
 				build_weapon_options(shipp);
 			}
-		} else if (getLabManager()->CurrentMode == LabMode::Weapon && getLabManager()->isSafeForWeapons()) {
+		} else if (getLabManager()->CurrentMode == LabMode::Weapon && getLabManager()->CurrentClass >= 0) {
 			auto wip = &Weapon_info[getLabManager()->CurrentClass];
 
 			with_CollapsingHeader("Weapon Info")


### PR DESCRIPTION
Fixes #7178 by making the menu builder for weapons less stringent. None of the options, currently, need the lab to be safe for weapons as they simple toggle lab bools or show class data. Like asteroids below it, if controls are added in the future that need a weapon-safe environment they can add the check specifically before adding those menu items.

What is happening here that's causing the bug is that isSafeForWeapons() checks that the current object is either OBJ_WEAPON or OBJ_BEAM but tech models are OBJ_RAW_POF. IIRC the upcoming Props PR also uses OBJ_RAW_POF for things so adding that object type to isSafeForWeapons() would only be a temporary fix anyway.