### PR TITLE
Fix asteroids toggling

### DIFF
--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -1427,6 +1427,11 @@ void game_post_level_init()
 #endif
 
 	training_mission_init();
+
+	// the asteroids enabled variable can be set via sexp 
+	// so ensure it is resets to the default value before creating asteroids 
+	// --wookieejedi
+	Asteroids_enabled = 1;
 	asteroid_create_all();
 
 	// set ambient light for level


### PR DESCRIPTION
`Asteroids_enabled` is a global variable that determines if an asteroid or debris field can be used at all. Notably, it is set once when the game first runs (set to a default of 1) and then never set automatically again. #https://github.com/scp-fs2open/fs2open.github.com/pull/4857/files did add the ability to set this value via SEXP though, which we discovered lead to asteroid fields being disabled if a previous mission used the sexp to disable them (b/c the `Asteroids_enabled` variable is global and was never reset).

Perhaps `Asteroids_enabled` should be called something else, but if folks want we can discuss new names. 

In any case, this PR fixes this issue by ensuring that `Asteroids_enabled` is reset to the default value at the start of each mission, therefore preventing the asteroid toggle sexp from bleeding over into other missions.

Tested and works as expected.