### PR TITLE
Add metatable to correctly handle FSO objects

### DIFF
--- a/code/def_files/data/scripts/forwarders.lua
+++ b/code/def_files/data/scripts/forwarders.lua
@@ -88,11 +88,11 @@ Globals.FSOObjectsTableMetatable = {
         __newindex = function(tbl, key, value)
             for k, v in pairs(tbl) do
                 if k == key then
-                    tbl[k] = value
+                    rawset(tbl, k, value)
                     return
                 end
             end
-            tbl[key] = value
+            rawset(tbl, key, value)
         end,
         __index = function(tbl, key)
             for k, v in pairs(tbl) do


### PR DESCRIPTION
Consider the following script:

```lua
table = {mn.Teams["Friendly"] = 0}
print(table[mn.Teams["Friendly"]]) -- will print nil
```

This rather unintuitive behaviour is because lua table lookups are by rawequal. As teams, and basically all FSO objects, are userdata, their rawequal check _does not_ call metamethods, and thus does not respect the built-in equality operators for FSO userdata. Instead, userdata is just checked against same instance, which is not the case for the example script.
This PR adds a metatable which changes this by explicitly calling `==` instead, overwriting or querying entries that are semantically equal but not rawequal.
When using FSO-userdata as table keys, this is _almost always_ the intended behaviour (though with correct design in some circumstances rawequal _can_ suffice as well, but semantically equal would work just as well).

So with this PR, the upper example could be made to work as follows:

```lua
table = {mn.Teams["Friendly"] = 0}
setmetatable(table, Globals.FSOObjectsTableMetatable)
print(table[mn.Teams["Friendly"]]) -- will print 0
```

Of course, a user could write / paste the entire metatable and not need this PR, but its such a common usecase and footgun that I'd like to include it in our globals.