### PR TITLE
Fix regression from #7051

### DIFF
--- a/code/io/keycontrol.cpp
+++ b/code/io/keycontrol.cpp
@@ -2640,7 +2640,7 @@ int button_function(int n)
 
 			// target the next hostile target
 			case TARGET_NEXT_CLOSEST_HOSTILE:
-				hud_target_next_list(1,0);
+				hud_target_next_list(1,1);
 				break;
 
 			// target the previous closest hostile


### PR DESCRIPTION
#7051 cleaned up the bomb/bomber targeting function, but also specified arguments for `TARGET_NEXT_CLOSEST_HOSTILE` to make it internally consistent with `TARGET_PREV_CLOSEST_HOSTILE`. There was a typo though, and the second argument needs to be `1` and not `0`. Having it be `0` makes 'Target Next Hostile' not work correctly.

Tested fix and confirms this restores proper behavior.