### PR TITLE
fix two timestamp bugs

### DIFF
--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -489,6 +489,9 @@ bool timestamp_elapsed(int stamp) {
 	if (stamp == 0) {
 		return false;
 	}
+	if (stamp == 1) {
+		return true;
+	}
 
 	return timestamp_ms() >= stamp;
 }
@@ -539,6 +542,9 @@ bool ui_timestamp_elapsed_last_frame(UI_TIMESTAMP ui_stamp) {
 
 bool timestamp_elapsed_safe(int a, int b) {
 	if (a == 0) {
+		return false;
+	}
+	if (a == 1) {
 		return true;
 	}
 


### PR DESCRIPTION
A timestamp set to 1 means an immediate timestamp, and so the `int` version of `timestamp_elapsed` should account for that, just as it does in the `TIMESTAMP` and `UI_TIMESTAMP` versions.  Normally the number comparison means the check will still work, but during mission initialization the timestamp code is not running.  This caused destroy-before-mission ships to be added to the arrival list when they shouldn't have been.

Also fix logic in `timestamp_elapsed_safe`, where the `TIMESTAMP` and `UI_TIMESTAMP` versions were correct, but the `int` version had a bug dating back to retail that caused it to return true for uninitialized (zero) timestamps rather than false.  Practically speaking, this fix has no effect because the function is only used in multiplayer and none of the instances use integer-0 to indicate uninitialized, but this will at least fix any uses in the future.