### PR TITLE
Fix Select All HUD Color Slider

### DIFF
--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -1873,7 +1873,7 @@ void hud_config_green_slider()
 		for(const auto& gauge_pair : HC_gauge_map){
             const SCP_string& gauge_id = gauge_pair.first;
             if (!gauge_id.empty()) {                
-                gr_init_alphacolor(&HUD_config.gauge_colors[gauge_id], pos, HUD_config.gauge_colors[gauge_id].green, HUD_config.gauge_colors[gauge_id].blue, HUD_config.gauge_colors[gauge_id].alpha);
+                gr_init_alphacolor(&HUD_config.gauge_colors[gauge_id], HUD_config.gauge_colors[gauge_id].red, pos, HUD_config.gauge_colors[gauge_id].blue, HUD_config.gauge_colors[gauge_id].alpha);
             }
         }
 	}
@@ -1897,7 +1897,7 @@ void hud_config_blue_slider()
 		for(const auto& gauge_pair : HC_gauge_map){
             const SCP_string& gauge_id = gauge_pair.first;
             if (!gauge_id.empty()) {                
-                gr_init_alphacolor(&HUD_config.gauge_colors[gauge_id], pos, HUD_config.gauge_colors[gauge_id].green, HUD_config.gauge_colors[gauge_id].blue, HUD_config.gauge_colors[gauge_id].alpha);
+                gr_init_alphacolor(&HUD_config.gauge_colors[gauge_id], HUD_config.gauge_colors[gauge_id].red, HUD_config.gauge_colors[gauge_id].green, pos, HUD_config.gauge_colors[gauge_id].alpha);
             }
         }
 	}


### PR DESCRIPTION
#6670 added support for custom gauges and also cleaned up the color setting of hud gauges when using 'Select All'. It seems two copy paste bug slipped through the cracks (ie the order of colors was copied from red to blue/green, when really the order should have been updated).

This PR restores the proper order and fixes the bug.