### PR TITLE
Misc fixes to start/loop/end sounds

### DIFF
--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -10814,7 +10814,7 @@ void update_firing_sounds(object* objp, ship* shipp)
 			vm_vec_avg_n(&snd_pos, pm->gun_banks[i].num_slots, pm->gun_banks[i].pnt);
 
 			if (wip->end_firing_snd.isValid() && end_snd_played != wip->end_firing_snd) {
-				obj_snd_assign(shipp->objnum, wip->start_firing_snd, &snd_pos, OS_PLAY_ON_PLAYER | OS_LOOPING_DISABLED);
+				obj_snd_assign(shipp->objnum, wip->end_firing_snd, &snd_pos, OS_PLAY_ON_PLAYER | OS_LOOPING_DISABLED);
 
 				end_snd_played = wip->end_firing_snd;
 			}


### PR DESCRIPTION
Related to #7205. Object sounds can only be 3d sounds, so these three sounds should work like $LaunchSnd: all are 3d, and in a follow-up PR I'll add 'cockpit' versions so you can have 2d sounds for them. 

Additionally the loop sound can sound weird and rapidly pan if placed at exactly the view position, so put all the sounds at the average fire point position.