### PR TITLE
io: Fix crash on SDL joystick disconnect

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -558,7 +558,7 @@ bool device_event_handler(const SDL_Event &evt)
 		// Else, Find if any of our joysticks were lost
 		for (short i = CID_JOY0; i < CID_JOY_MAX; ++i)
 		{
-			if (joyDeviceEvent.which == pJoystick[i]->getID())
+			if (pJoystick[i] != nullptr && joyDeviceEvent.which == pJoystick[i]->getID())
 			{
 				// We just lost our joystick, reset the data
 				mprintf(("Joystick %i disconnected\n", i));


### PR DESCRIPTION
Fix a crash on joystick disconnection by checking that `pJoystick[i]` is non-null before dereferencing it.

(im running into this regularly while disconnecting the session in moonlight/sunshine, which removes a bunch of virtual libevent devices)