### PR TITLE
Allow setting custom gauges as message gauges

### DIFF
--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -364,9 +364,9 @@ canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 }
 
 // constructor for custom gauges
-HudGauge::HudGauge(int _gauge_config, bool _slew, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y):
+HudGauge::HudGauge(int _gauge_config, bool _slew, bool _message, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y):
 base_w(0), base_h(0), gauge_type(_gauge_config), gauge_object(HUD_OBJECT_CUSTOM), font_num(font::FONT1), lock_color(false), sexp_lock_color(false),
-reticle_follow(_slew), active(false), off_by_default(false), sexp_override(false), pop_up(false), message_gauge(false),
+reticle_follow(_slew), active(false), off_by_default(false), sexp_override(false), pop_up(false), message_gauge(_message),
 disabled_views(VM_EXTERNAL | VM_DEAD_VIEW | VM_WARP_CHASE | VM_PADLOCK_ANY), scripting_render_override(false), can_popup(false), use_iff_color(false), use_tag_color(false), only_render_in_chase_view(false), 
 render_for_cockpit_toggle(0), custom_gauge(true), textoffset_x(txtoffset_x), textoffset_y(txtoffset_y), texture_target(-1), canvas_w(-1), canvas_h(-1), target_w(-1), target_h(-1)
 {

--- a/code/hud/hud.h
+++ b/code/hud/hud.h
@@ -278,7 +278,7 @@ public:
 	HudGauge();
 	HudGauge(int _gauge_object, int _gauge_config, bool _slew, bool _message, int _disabled_views, int r, int g, int b);
 	// constructor for custom gauges
-	HudGauge(int _gauge_config, bool _slew, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y);
+	HudGauge(int _gauge_config, bool _slew, bool _message, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y);
 	virtual ~HudGauge();
 
 	void initPosition(int x, int y);
@@ -393,8 +393,8 @@ public:
 	HudGauge3DAnchor(int _gauge_object, int _gauge_config, bool /*_slew*/, bool _message, int _disabled_views, int r, int g, int b)
 		: HudGauge(_gauge_object, _gauge_config, false, _message, _disabled_views, r, g, b) { }
 	// constructor for custom gauges
-	HudGauge3DAnchor(int _gauge_config, bool /*_slew*/, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y)
-		: HudGauge(_gauge_config, false, r, g, b, _custom_name, _custom_text, frame_fname, txtoffset_x, txtoffset_y) { }
+	HudGauge3DAnchor(int _gauge_config, bool /*_slew*/, bool _message, int r, int g, int b, char* _custom_name, char* _custom_text, char* frame_fname, int txtoffset_x, int txtoffset_y)
+		: HudGauge(_gauge_config, false, _message, r, g, b, _custom_name, _custom_text, frame_fname, txtoffset_x, txtoffset_y) { }
 
 	void initSlew(bool /*slew*/) override {};
 };

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -1761,6 +1761,10 @@ void load_gauge_custom(gauge_settings* settings)
 			stuff_boolean(&settings->slew);
 		}
 
+		if (optional_string("Message Gauge:")) {
+			stuff_boolean(&settings->message_gauge);
+		}
+
 		if (optional_string("Config:")) {
 			stuff_boolean(&visible_in_config);
 		}
@@ -1780,7 +1784,7 @@ void load_gauge_custom(gauge_settings* settings)
 		}
 	}
 
-	std::unique_ptr<HudGauge> hud_gauge(new HudGauge(gauge_type, settings->slew, r, g, b, name, text, filename, txtoffset_x, txtoffset_y));
+	std::unique_ptr<HudGauge> hud_gauge(new HudGauge(gauge_type, settings->slew, settings->message_gauge, r, g, b, name, text, filename, txtoffset_x, txtoffset_y));
 
 	hud_gauge->initBaseResolution(settings->base_res[0], settings->base_res[1], settings->aspect_quotient);
 	hud_gauge->initPosition(settings->coords[0], settings->coords[1]);

--- a/code/hud/hudparse.h
+++ b/code/hud/hudparse.h
@@ -41,12 +41,13 @@ typedef struct gauge_settings {
 	bool set_position;
 	bool set_colour;
 	bool slew;
+	bool message_gauge;
 	bool chase_view_only;
 	int cockpit_view_choice;
 
 	gauge_settings()
 		: font_num(Hud_font), scale_gauge(Scale_retail_gauges), ship_idx(nullptr), use_clr(nullptr), use_coords(false),
-		  set_position(true), set_colour(true), slew(false), chase_view_only(Chase_view_only_ex), cockpit_view_choice(0)
+		  set_position(true), set_colour(true), slew(false), message_gauge(false), chase_view_only(Chase_view_only_ex), cockpit_view_choice(0)
 	{
 		base_res[0] = -1;
 		base_res[1] = -1;


### PR DESCRIPTION
Custom scripted messages gauges are essentially standard now, so we need a way to tell FSO that this gauge should stay enabled when `hud-disabled-except-messages` is called. So this adds a boolean table option to set a custom gauge as a message gauge which were previously always hardcoded to false. 

Fixes #7197