### PR TITLE
Make sure we actually set old_class when changing classes

### DIFF
--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -612,8 +612,10 @@ static void build_ship_table_info_txtbox(ship_info* sip)
 		static SCP_string table_text;
 		static int old_class = getLabManager()->CurrentClass;
 
-		if (table_text.length() == 0 || old_class != getLabManager()->CurrentClass)
+		if (table_text.length() == 0 || old_class != getLabManager()->CurrentClass) {
 			table_text = get_ship_table_text(sip);
+			old_class = getLabManager()->CurrentClass;
+		}
 
 		InputTextMultiline("##table_text",
 			const_cast<char*>(table_text.c_str()),
@@ -633,6 +635,7 @@ static void build_weapon_table_info_txtbox(weapon_info* wip)
 
 		if (table_text.length() == 0 || old_class != getLabManager()->CurrentClass) {
 			table_text = get_weapon_table_text(wip);
+			old_class = getLabManager()->CurrentClass;
 		}
 
 		InputTextMultiline("##weapon_table_text",


### PR DESCRIPTION
Fix a minor issue that causes table entry information to not always update with the selected class