### PR TITLE
Make sure to delete any dead objects in the Lab before processing

### DIFF
--- a/code/lab/manager/lab_manager.cpp
+++ b/code/lab/manager/lab_manager.cpp
@@ -234,6 +234,9 @@ void LabManager::onFrame(float frametime) {
 	float rev_rate;
 	ship_info* sip = nullptr;
 
+	// First delete any dead objects so we don't end up processing them
+	obj_delete_all_that_should_be_dead();
+
 	if (CurrentObject != -1 && (Objects[CurrentObject].type == OBJ_SHIP)) {
 		sip = &Ship_info[Ships[Objects[CurrentObject].instance].ship_info_index];
 
@@ -413,6 +416,10 @@ void LabManager::cleanup() {
 
 		// Remove all objects
 		obj_delete_all();
+
+		// Reset large-ship split explosion state. In the lab we can delete exploding ships while
+		// cycling classes, so clear any lingering Split_ships entries tied to the previous view.
+		shipfx_large_blowup_level_init();
 
 		// Clean up the particles
 		particle::kill_all();


### PR DESCRIPTION
Fixes #6904

This one led me down a whole thing where I had to learn how ship splits happen and I'm still not entirely sure I found the root cause. What was happening here was that the Lab was calling `ship_post_process()` on a ship object that should be dead. The Lab already skips running this stuff on the current object if it's type is not OBJ_SHIP (it becomes OBJ_NONE when deleted in the object code). The assert in the bug wasn't always 100% consistent, though. Sometimes dead ship cleanup seemed to run correctly though I could never quite figure out under what circumstances it did not. 

So while the root cause is somewhere in the path described above, I'm not sure it really matters because the Lab is one big hack anyway. So we really just need to make sure all objects marked for death are cleaned up each frame before we try to do any object processing and that's exactly what this PR does. While we're at it, whenever we change objects we clean up the ship splits in order to keep things tidy.