### PR TITLE
Stop select model rendering destroyed subsystems

### DIFF
--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -235,7 +235,7 @@ int restore_wss_data(ubyte *data);
 
 class ship_info;
 void draw_model_icon(int model_id, uint64_t flags, float closeup_zoom, int x1, int x2, int y1, int y2, ship_info* sip = NULL, int resize_mode = GR_RESIZE_FULL, const vec3d *closeup_pos = &vmd_zero_vector);
-void draw_model_rotating(model_render_params *render_info, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, const vec3d *closeup_pos=nullptr, float closeup_zoom = .65f, float rev_rate = REVOLUTION_RATE, uint64_t flags = MR_AUTOCENTER | MR_NO_FOGGING, int resize_mode=GR_RESIZE_FULL, select_effect_params effect_params = select_effect_params{});
+void draw_model_rotating(model_render_params *render_info, int ship_class, int model_id, int x1, int y1, int x2, int y2, float *rotation_buffer, const vec3d *closeup_pos=nullptr, float closeup_zoom = .65f, float rev_rate = REVOLUTION_RATE, uint64_t flags = MR_AUTOCENTER | MR_NO_FOGGING, int resize_mode=GR_RESIZE_FULL, select_effect_params effect_params = select_effect_params{});
 
 void common_set_team_pointers(int team);
 void common_reset_team_pointers();

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -1461,6 +1461,7 @@ void ship_select_do(float frametime)
 
 			draw_model_rotating(
 				&render_info, 
+				Selected_ss_class,
 				ShipSelectModelNum,
 				Ship_anim_coords[gr_screen.res][0],
 				Ship_anim_coords[gr_screen.res][1],

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -823,6 +823,10 @@ void draw_3d_overhead_view(int model_num,
 		Glowpoint_use_depth_buffer = false;
 
 		model_clear_instance(model_num);
+		int model_instance = model_create_instance(model_objnum_special::OBJNUM_NONE, model_num);
+		if (model_instance >= 0) {
+			model_set_up_techroom_instance(sip, model_instance);
+		}
 		polymodel* pm = model_get(model_num);
 
 		if (sip->replacement_textures.size() > 0) {
@@ -842,7 +846,7 @@ void draw_3d_overhead_view(int model_num,
 
 			render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING | MR_AUTOCENTER);
 
-			model_render_immediate(&render_info, model_num, &object_orient, &vmd_zero_vector);
+			model_render_immediate(&render_info, model_num, model_instance, &object_orient, &vmd_zero_vector);
 			shadows_end_render();
 			gr_set_clip(x1, y1, x2, y2, resize_mode);
 		}
@@ -857,13 +861,16 @@ void draw_3d_overhead_view(int model_num,
 			render_info.set_team_color(tc, "none", 0, 0);
 		}
 
-		model_render_immediate(&render_info, model_num, &object_orient, &vmd_zero_vector);
+		model_render_immediate(&render_info, model_num, model_instance, &object_orient, &vmd_zero_vector);
 
 		Glowpoint_use_depth_buffer = true;
 
 		batching_render_all();
 
 		shadow_end_frame();
+		if (model_instance >= 0) {
+			model_delete_instance(model_instance);
+		}
 
 		// NOW render the lines for weapons
 		gr_reset_clip();
@@ -2832,6 +2839,7 @@ void weapon_select_do(float frametime)
 
 		model_render_params render_info;
 		draw_model_rotating(&render_info, 
+			-1,
 			modelIdx,
 			weapon_ani_coords[0],
 			weapon_ani_coords[1],

--- a/code/scripting/api/objs/shipclass.cpp
+++ b/code/scripting/api/objs/shipclass.cpp
@@ -1270,6 +1270,7 @@ ADE_FUNC(renderSelectModel,
 	params.fs2_wireframe_color = sip->fs2_effect_wireframe_color;
 
 	draw_model_rotating(&render_info,
+		idx,
 		modelNum,
 		x1,
 		y1,

--- a/code/scripting/api/objs/weaponclass.cpp
+++ b/code/scripting/api/objs/weaponclass.cpp
@@ -1159,6 +1159,7 @@ ADE_FUNC(renderSelectModel,
 	params.fs2_wireframe_color = wip->fs2_effect_wireframe_color;
 
 	draw_model_rotating(&render_info,
+		-1,
 		modelNum,
 		x1,
 		y1,


### PR DESCRIPTION
Fixes #7158 where destroyed submodels were being rendered simultaneously with regular submodels for ship/weapon select rotating and overhead model rendering.

This was likely caused when these render methods were converted to be more independent so the Lua API could call them arbitrarily for SCPUI. Or maybe it was always like this, I can't really remember.

The root cause was that these methods were using a shorthand method for render calls that did not require a model instance. Without the model instance the subsystem data never gets setup so all submodels are just rendered without concern. I first thought a simple fix would be a new MR_ flag to skip -destroyed rendering and that did work. But further research revealed that tech model rendering prefers a full instance create/delete every frame specifically to avoid this issue. It's more churn every frame than the flag but I opted for consistency in this case especially since in the UI we don't have all that much going on anyway.