### PR TITLE
Do not reset lab state when going to options

### DIFF
--- a/code/lab/labv2.cpp
+++ b/code/lab/labv2.cpp
@@ -17,8 +17,10 @@ void lab_init() {
 	gr_set_clear_color(0, 0, 0);
 }
 
-void lab_close() {
-	LMGR.reset();
+void lab_close(bool reset) {
+	if (reset) {
+		LMGR.reset();
+	}
 	gameseq_post_event(GS_EVENT_PREVIOUS_STATE);
 }
 

--- a/code/lab/labv2.h
+++ b/code/lab/labv2.h
@@ -8,5 +8,5 @@ enum class LabMode {
 };
 
 void lab_init();
-void lab_close();
+void lab_close(bool reset);
 void lab_do_frame(float frametime);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -5695,7 +5695,7 @@ void game_leave_state( int old_state, int new_state )
 			break;
 
 		case GS_STATE_LAB:
-			lab_close();
+			lab_close(new_state != GS_STATE_OPTIONS_MENU);
 			// restore default cursor and enable it --wookieejedi
 			if (!Is_standalone) {
 				io::mouse::Cursor* cursor = io::mouse::CursorManager::get()->loadCursor("cursor", true);


### PR DESCRIPTION
Fixes #3530 by simply not calling lab reset when going to Options and back.

There's no normal game path that gets around returning to the Lab from Options or any of its child states. If someone uses scripting to do game state shenanigans and jumps around and then we return to the Lab from the mainhall or some other call the worst-case scenario is the Lab resumes that previous state again, so this should be pretty safe.