### PR TITLE
fix a FRED2 crash

### DIFF
--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -562,5 +562,6 @@ void jumpnode_render_all()
  */
 void jumpnode_level_close()
 {
+	// Clear all jump nodes.  Note that this can happen either before or after objects are cleaned up.
 	Jump_nodes.clear();
 }

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6551,7 +6551,7 @@ bool parse_mission(mission *pm, int flags)
 	Warned_about_team_out_of_range = false;
 
 	reset_parse();
-	mission_init(pm);
+	mission_init(pm, (flags & MPF_ONLY_MISSION_INFO) != 0);
 
 	parse_mission_info(pm);
 
@@ -7107,7 +7107,7 @@ void mission::Reset()
 /**
  * Initialize the mission and related data structures.
  */
-void mission_init(mission *pm)
+void mission_init(mission *pm, bool quick_init)
 {
 	pm->Reset();
 
@@ -7118,6 +7118,11 @@ void mission_init(mission *pm)
 
 	Mission_all_attack = 0;
 	Num_teams = 1;				// assume 1
+
+	// sometimes we don't need to run through the entire initialization,
+	// e.g. if we're just checking mission info
+	if (quick_init)
+		return;
 
 	init_sexp();
 	mission_goals_and_events_init();

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -575,7 +575,7 @@ extern p_object *Arriving_support_ship;
 extern char Neb2_texture_name[MAX_FILENAME_LEN];
 
 
-void mission_init(mission *pm);
+void mission_init(mission *pm, bool quick_init = false);
 bool parse_main(const char *mission_name, int flags = 0);
 p_object *mission_parse_get_arrival_ship(ushort net_signature);
 p_object *mission_parse_get_arrival_ship(const char *name);

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -672,9 +672,6 @@ void obj_delete_all()
 		obj_delete(i);
 	}
 
-	// If we've removed all objects then we can safely clear the Props vector
-	Props.clear();
-
 	mprintf(("Cleanup: Deleted %i objects\n", counter));
 }
 

--- a/code/object/waypoint.cpp
+++ b/code/object/waypoint.cpp
@@ -140,6 +140,7 @@ void waypoint_list::set_name(const char *name)
 //********************FUNCTIONS********************
 void waypoint_level_close()
 {
+	// Clear all waypoint lists and all their waypoints.  Note that this can happen either before or after objects are cleaned up.
 	Waypoint_lists.clear();
 }
 

--- a/code/prop/prop.cpp
+++ b/code/prop/prop.cpp
@@ -823,19 +823,14 @@ void prop_render(object* obj, model_draw_list* scene)
 	}
 }*/
 
-void props_level_init() {
+void props_level_init()
+{
 	Props.clear();
 }
 
 void props_level_close()
 {
-	for (auto& opt_prop : Props) {
-		if (opt_prop.has_value()) {
-			prop_delete(&Objects[opt_prop->objnum]);
-		}
-	}
-
-	// Clear all props and empty prop slots
+	// Clear all props and empty prop slots.  Note that this can happen either before or after objects are cleaned up.
 	Props.clear();
 }
 

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -108,10 +108,7 @@ bool CFREDDoc::autoload() {
 		return 0;
 	fclose(fp);
 
-	if (Briefing_dialog) {
-		// clean things up first
-		Briefing_dialog->icon_select(-1);
-	}
+	clean_up_selections();
 
 	// Load Backup.002
 	r = load_mission(name, MPF_FAST_RELOAD);
@@ -482,10 +479,6 @@ void CFREDDoc::OnFileImportFSM() {
 	if (*dest_directory == '\0')
 		return;
 
-	// clean things up first
-	if (Briefing_dialog)
-		Briefing_dialog->icon_select(-1);
-
 	clear_mission(true);
 
 	int num_files = 0;
@@ -611,8 +604,8 @@ BOOL CFREDDoc::OnNewDocument() {
 
 BOOL CFREDDoc::OnOpenDocument(LPCTSTR pathname)
 {
-	if (Briefing_dialog)
-		Briefing_dialog->icon_select(-1);  // clean things up first
+	// don't process any objects if the window focus is lost and reacquired
+	clean_up_selections();
 
 	auto sep_ch = strrchr(pathname, '\\');
 	auto filename = (sep_ch != nullptr) ? (sep_ch + 1) : pathname;

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -1250,11 +1250,10 @@ void CFREDView::OnSetFocus(CWnd* pOldWnd)
 		Update_wing = 0;
 	}
 
-/*	if (Wing_editor_dialog.verify() == -1)
-		return;  // abort
-
-	if (Ship_editor_dialog.verify() == -1)
-		return;  // abort*/
+	if (Update_prop) {
+		Prop_editor_dialog.initialize_data(1);
+		Update_prop = 0;
+	}
 
 	if (update_dialog_boxes()) {
 		nprintf(("Fred routing", "OnSetFocus() returned (error occured)\n"));
@@ -1398,7 +1397,7 @@ void select_objects()
 		}
 	}
 
-	Update_ship = Update_wing = 1;
+	Update_ship = Update_wing = Update_prop = 1;
 }
 
 LRESULT CFREDView::OnMenuPopupShips(WPARAM wParam, LPARAM lParam)

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -865,6 +865,7 @@ void clear_mission(bool fast_reload)
 	CTime t;
 
 	// clean up everything we need to before we reset back to defaults.
+	clean_up_selections();
 	if (Briefing_dialog){
 		Briefing_dialog->reset_editor();
 	}
@@ -1543,6 +1544,14 @@ void unmark_all()
 		Update_window = 1;
 		set_cur_object_index(-1);
 	}
+}
+
+void clean_up_selections()
+{
+	if (Briefing_dialog)
+		Briefing_dialog->icon_select(-1);
+
+	unmark_all();
 }
 
 void clear_menu(CMenu *ptr)

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -90,6 +90,7 @@ void clear_menu(CMenu* ptr);
 void generate_wing_popup_menu(CMenu* mptr, int first_id, int state);
 void generate_ship_popup_menu(CMenu* mptr, int first_id, int state, int filter = 0);
 int string_lookup(const CString& str1, char* strlist[], int max);
+void clean_up_selections();
 int update_dialog_boxes();
 void set_cur_wing(int wing);
 int gray_menu_tree(CMenu* base);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -412,6 +412,14 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 
 	return true;
 }
+void Editor::clean_up_selections() {
+#if 0
+	if (Briefing_dialog)
+		Briefing_dialog->icon_select(-1);
+#endif
+
+	unmark_all();
+}
 void Editor::unmark_all() {
 	if (numMarked > 0) {
 		for (auto i = 0; i < MAX_OBJECTS; i++) {
@@ -470,6 +478,7 @@ void Editor::unmarkObject(int obj) {
 
 void Editor::clearMission(bool fast_reload) {
 	// clean up everything we need to before we reset back to defaults.
+	clean_up_selections();
 #if 0
     if (Briefing_dialog){
         Briefing_dialog->reset_editor();

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -55,6 +55,8 @@ class Editor : public QObject {
   public:
 	Editor();
 
+	void clean_up_selections();
+
 	void unmark_all();
 
 	void createNewMission();

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -153,6 +153,9 @@ void FredView::loadMissionFile(const QString& pathName) {
 	try {
 		QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
+		// probably good to clear selections in qtFRED too
+		fred->clean_up_selections();
+
 		auto pathToLoad = pathName.toStdString();
 		fred->maybeUseAutosave(pathToLoad);
 


### PR DESCRIPTION
Fix a crash caused in part by some missing UI calls in FRED2 and in part by subtle object life cycle issues.  Depending on whether FRED receives the focus during mission load (which can happen if the autosave dialog appears) it could access props that were in the process of being cleaned up but were still referenced.  This isn't specifically a props issue; it could happen to any FSO object stored in a SCP_vector, since the vector can be cleared.

The quick mission init is to prevent a whole bunch of unnecessary and risky processing during a transient loading state, but it has the nice side effect of making mission list loading noticeably faster.