### PR TITLE
Add Z-Compression shader to better use position buffer's FP16

### DIFF
--- a/code/def_files/data/effects/deferred-f.sdr
+++ b/code/def_files/data/effects/deferred-f.sdr
@@ -2,6 +2,7 @@
 #include "lighting.sdr" //! #include "lighting.sdr"
 #include "gamma.sdr" //! #include "gamma.sdr"
 #include "shadows.sdr" //! #include "shadows.sdr"
+#include "z-compress.sdr" //! #include "z-compress.sdr"
 
 out vec4 fragOut0;
 
@@ -219,7 +220,7 @@ void main()
 {
 	vec2 screenPos = gl_FragCoord.xy * vec2(invScreenWidth, invScreenHeight);
 	vec4 position_buffer = texture(PositionBuffer, screenPos);
-	vec3 position = position_buffer.xyz;
+	vec3 position = vec3(position_buffer.xy, uncompress_depth_value(position_buffer.z));
 
 	if(abs(dot(position, position)) < nearPlane * nearPlane)
 		discard;

--- a/code/def_files/data/effects/effect-f.sdr
+++ b/code/def_files/data/effects/effect-f.sdr
@@ -1,5 +1,6 @@
 
 #include "gamma.sdr"
+#include "z-compress.sdr"
 
 in float fragRadius;
 in vec4 fragPosition;
@@ -38,7 +39,7 @@ void main()
 	float sceneDepthLinear;
 	float fragDepthLinear;
 	if ( linear_depth == 1 ) {
-		sceneDepthLinear = -sceneDepth.z;
+		sceneDepthLinear = -uncompress_depth_value(sceneDepth.z);
 		fragDepthLinear = -fragPosition.z;
 	} else {
 		sceneDepthLinear = ( 2.0 * farZ * nearZ ) / ( farZ + nearZ - sceneDepth.x * (farZ-nearZ) );

--- a/code/def_files/data/effects/main-f.sdr
+++ b/code/def_files/data/effects/main-f.sdr
@@ -2,6 +2,7 @@
 #include "shadows.sdr" //! #include "shadows.sdr"
 #include "lighting.sdr" //! #include "lighting.sdr"
 #include "gamma.sdr" //! #include "gamma.sdr"
+#include "z-compress.sdr" //! #include "z-compress.sdr"
 
 #conditional_include +"LARGE_SHADER" "main_large.sdr"
 #conditional_include -"LARGE_SHADER" "main_small.sdr"
@@ -428,7 +429,7 @@ void main()
 	fragOut0 = baseColor;
 
 	#prereplace IF_FLAG MODEL_SDR_FLAG_DEFERRED
-		fragOut1 = vec4(vertIn.position.xyz, aoFactors.x);
+		fragOut1 = vec4(vertIn.position.xy, compress_depth_value(vertIn.position.z), aoFactors.x);
 		fragOut2 = vec4(normal, glossData);
 		fragOut3 = vec4(specColor.rgb, fresnelFactor);
 		fragOut4 = emissiveColor;

--- a/code/def_files/data/effects/msaa-f.sdr
+++ b/code/def_files/data/effects/msaa-f.sdr
@@ -1,3 +1,5 @@
+#include "z-compress.sdr"
+
 in vec4 fragTexCoord;
 out vec4 fragOut0;
 out vec4 fragOut1;
@@ -32,7 +34,7 @@ float getMedianDist(ivec2 texel) {
 	float dists[4];
 
 	for(int i = 0; i < 4; i++) {
-		dists[i] = texelFetch(texPos, texel, i).z;
+		dists[i] = uncompress_depth_value(texelFetch(texPos, texel, i).z);
 	}
 
 	SORT(0, 2)
@@ -51,7 +53,7 @@ float getMedianDist(ivec2 texel) {
 	float dists[8];
 
 	for(int i = 0; i < 8; i++) {
-		dists[i] = texelFetch(texPos, texel, i).z;
+		dists[i] = uncompress_depth_value(texelFetch(texPos, texel, i).z);
 	}
 
 	SORT(0, 4)
@@ -82,7 +84,7 @@ float getMedianDist(ivec2 texel) {
 	float dists[16];
 
 	for(int i = 0; i < 16; i++) {
-		dists[i] = texelFetch(texPos, texel, i).z;
+		dists[i] = uncompress_depth_value(texelFetch(texPos, texel, i).z);
 	}
 
 	SORT(0, 1)
@@ -145,7 +147,7 @@ float getMedianDist(ivec2 texel) {
 float getMedianDist(ivec2 texel) {
 	float minDist = -1000000;
 	for(int i = 0; i < samples; i++) {
-		minDist = max(minDist, texelFetch(texPos, texel, i).z);
+		minDist = max(minDist, uncompress_depth_value(texelFetch(texPos, texel, i).z));
 	}
 	return minDist;
 }
@@ -173,6 +175,7 @@ void main()
 
 	for(int i = 0; i < samples; i++) {
 		vec4 localPos = texelFetch(texPos, texel, i);
+		localPos.z = uncompress_depth_value(localPos.z);
 		//Calculate local weight from distance Voxel, but if the distance is 0 (i.e. no model at all), set weight to 1 to allow stuff like background emissive
 		//However, if the median distance is 0, only deal with current texel if it's local distance is 0 as well
 		float localWeight = max(step(-0.001, dist) * step(-0.001, localPos.z),
@@ -189,8 +192,11 @@ void main()
 		weight += localWeight;
 	}
 
+    pos /= weight;
+    pos.z = compress_depth_value(pos.z);
+
 	fragOut0 = color / weight;
-	fragOut1 = pos / weight;
+	fragOut1 = pos;
 	fragOut2 = vec4(normalize(normal.xyz), normal.a / weight);
 	fragOut3 = specular / weight;
 	fragOut4 = emissive / weight;

--- a/code/def_files/data/effects/z-compress.sdr
+++ b/code/def_files/data/effects/z-compress.sdr
@@ -1,0 +1,89 @@
+float compress_depth_value(float linear) {
+	float linear_mult;
+	float exponent_mult;	
+	float offset;
+
+	linear = max(-linear, 0.0);
+
+	if(linear < 10.0) {
+		linear_mult = 0.00000999908;
+		exponent_mult = 1.32878452580;
+		offset = 0.0;
+	}
+	else if (linear < 100.0) {
+		linear_mult = 0.05550473078;
+		exponent_mult = 0.08493173544;
+		offset = 0.0;
+	}
+	else if (linear < 1570.0) {
+		linear_mult = 11.53589613947;
+		exponent_mult = 0.00793869919;
+		offset = 0.0;
+	}
+	else if (linear < 3000.0) {
+		linear_mult = -0.10000000000;
+		exponent_mult = 0.00928910863;
+		offset = 3000.0;
+	}
+	else if (linear < 10000.0) {
+		linear_mult = -0.10000000000;
+		exponent_mult = 0.00094912231;
+		offset = 3000.0;
+	}
+	else if (linear < 100000.0) {
+		linear_mult = -6.98947320727;
+		exponent_mult = 0.00007382062;
+		offset = 3000.0;
+	}
+	else {
+		linear_mult = -1000.0;
+		exponent_mult = log2(1000.0 / 65000.0) / (100000.0 - GLOBAL_FAR_Z);
+		offset = 100000.0;
+	}
+
+	return linear_mult * pow(2.0, (linear - offset) * exponent_mult);
+}
+
+float uncompress_depth_value(float compressed) {
+	float linear_mult;
+	float exponent_mult;	
+	float offset;
+
+	if(compressed < -1000.0) {
+		linear_mult = -1000.0;
+		exponent_mult = log2(1000.0 / 65000.0) / (100000.0 - GLOBAL_FAR_Z);
+		offset = 100000.0;
+	}
+	else if (compressed < -10.0) {
+		linear_mult = -6.98947320727;
+		exponent_mult = 0.00007382062;
+		offset = 3000.0;
+	}
+	else if (compressed < -0.1) {
+		linear_mult = -0.10000000000;
+		exponent_mult = 0.00094912231;
+		offset = 3000.0;
+	}
+	else if (compressed < 0.0) {
+		linear_mult = -0.10000000000;
+		exponent_mult = 0.00928910863;
+		offset = 3000.0;
+	}
+	else if (compressed < 0.1) {
+		linear_mult = 0.00000999908;
+		exponent_mult = 1.32878452580;
+		offset = 0.0;
+	}
+	else if (compressed < 20.0) {
+		linear_mult = 0.05550473078;
+		exponent_mult = 0.08493173544;
+		offset = 0.0;
+	}
+	else {
+		linear_mult = 11.53589613947;
+		exponent_mult = 0.00793869919;
+		offset = 0.0;
+	}
+
+	return -(log2(compressed / linear_mult) / exponent_mult + offset);
+}

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -283,7 +283,8 @@ int gr_stencil_mode = 0;
 
 // Default clipping distances
 const float Default_min_draw_distance = 1.0f;
-const float Default_max_draw_distance = 1e10;
+// Reduced from 1e10 to 1e6, as beyond that FSO's physics precision is horrendous anyways, and it allows reasonable lighting and particle clipping all the way out until that point, unlike 1e7 or above where the depth precision just is not enough
+const float Default_max_draw_distance = 1e6f;
 float Min_draw_distance_cockpit = 0.02f;
 float Min_draw_distance = Default_min_draw_distance;
 float Max_draw_distance = Default_max_draw_distance;

--- a/code/graphics/opengl/gropenglshader.cpp
+++ b/code/graphics/opengl/gropenglshader.cpp
@@ -503,6 +503,9 @@ static SCP_string handle_predefines(const char* filename, const SCP_string& orig
 	SCP_stringstream output;
 	SCP_unordered_map<SCP_string, SCP_string> defines;
 
+	//In any shader, define GLOBAL_FAR_Z
+	output << "#define GLOBAL_FAR_Z " << std::fixed << std::setprecision(2) << Max_draw_distance << std::defaultfloat << '\n';
+
 	const char* PREDEFINE_STRING = "#predefine";
 	const char* PREREPLACE_STRING = "#prereplace";
 

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -278,6 +278,7 @@ add_file_folder("Default files\\\\data\\\\effects"
 	def_files/data/effects/video-f.sdr
 	def_files/data/effects/video-v.sdr
 	def_files/data/effects/volumetric-f.sdr
+	def_files/data/effects/z-compress.sdr
 )
 
 add_file_folder("Default files\\\\data\\\\maps"


### PR DESCRIPTION
FSO stores the position G-Buffer using an FP16 format.
FP16's can store values within +-65504. That is not enough to encapsulate the entire region of space in which things happen in FSO, especially when dealing with huge ships far away from the action.
Specifically, if anything exceeds 65km away from the camera, deferred lighting will just stop working, and soft particles will disappear entirely.
In addition, at these high values, FP16's are incredibly inaccurate. There's just about 1500 discrete values it can express between 10000m and 65504m, leading to highly inaccurate deferred lighting at these distances.
To visualize this, consider the following. It shows where the possible values of a floating point type are, and how it correlates to FSO:
![z-compress](https://github.com/user-attachments/assets/9db942ea-8522-455c-adaf-932d0db300d3)
What we can see is basically threefold.
1. The FP16 range _does not_ cover all the required distance for typical FSO combat scenes.
2. There's a whole bunch more accuracy in cockpits and even closer ranges. Floats, by design, have effectively the same number of discrete values between 0 and 1 as they do between 1 and their maximum value. And there isn't much in FSO that's closer than 1 meter, so we're basically wasting half of the float's accuracy. And even if we do have cockpits, we don't need nearly as much precision there.
3. We don't need the negative values entirely, as things behind the camera don't matter for rendering

As such, we can see that we effectively waste three quarters of the precision of the FP16.
Wouldn't it be nice if we could just use this wasted precision to increase the regions where we don't have enough accuracy, and to overall increase the range we can store?
This is exactly what this PR does. It adds a bit of math before storing the distance, remapping the values in such a way that we can make use of the entirety of the FP16, rather than just a quarter. It also does it in a way that compensates for the precision loss over distance, so that certain regions of space have constant spatial accuracy for deferred lighting.
See the following chart for details, where the yellow line is spatial accuracy previously, and the orange line is spatial accuracy with this PR. Lower is better.
<img width="952" height="536" alt="z-compress" src="https://github.com/user-attachments/assets/8d578ae4-8206-4388-9557-9c23ab879feb" />
We can see that in most regions, especially in the actually FSO-relevant regions, the accuracy with this PR is better. Notably also, the orange graph extends further rightwards, showing that with this PR, objects further out can even be rendered with proper lighting _at all_ unlike with current master. There is a very small region at around 100m to 150m of distance where the new accuracy is lowered, but not by a significant amount. Furthermore, the accuracy in the cockpit-relevant distances is much lower, but no cockpit actually needs micrometer or even nanometer precision so we do not care about the precision loss in that region.
Overall, with this PR, the resulting accuracy ranges are as follows:
| Distance Start  | Distance End | Spatial Resolution |
| ------------- | ------------- | ------- |
| 0.1mm  | 10m | 0.8mm |
| 10m  | 100m  | 1.1cm |
| 100m | 3km | 12cm |
| 3km | 10km | 1m |
| 10km | 100km | 13m |
| 100km | max render distance | variable |

The last chunk here is variable, as it depends on the table-configured max render distance. At the (new) max render distance of 1000km, the resolution is 145m, which is absolutely enough to display the affected stuff, such as huge particles of a ginormous and distant muzzle or engine. At, for example, 10000km max render distance, the resolution drops to 1.6km, which is still preferrable to stuff not being visible or lit at all at distances >65km, but clipping _can_ be observed, so it's recommended to not increase the render distance unless necessary (though in none of my tests I was able to construct a scenario where something visible past 1000km was sensible, as our physics accuracy at these distances is unusably horrible anyways for most usecases)
