### PR TITLE
Optimize UI model instance

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -33,6 +33,7 @@
 #include "graphics/util/UniformBufferManager.h"
 #include "graphics/shadows.h"
 #include "io/mouse.h"
+#include "model/modelrender.h"
 #include "libs/jansson.h"
 #include "options/Option.h"
 #include "osapi/osapi.h"
@@ -2938,6 +2939,8 @@ void gr_flip(bool execute_scripting)
 			OnFrameHook->run();
 		}
 	}
+
+	model_process_cached_ui_render_instances();
 
 	gr_reset_immediate_buffer();
 

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -26,6 +26,7 @@
 #include "lighting/lighting_profiles.h"
 #include "localization/localize.h"
 #include "menuui/techmenu.h"
+#include "model/modelrender.h"
 #include "missionui/missionscreencommon.h"
 #include "parse/parselo.h"
 #include "playerman/player.h"
@@ -214,7 +215,6 @@ static const char *Text_lines[MAX_TEXT_LINES];
 static int Cur_entry = -1;				// this is the current entry selected, using entry indexing
 static int Cur_entry_index = -1;		// this is the current entry selected, using master list indexing
 static int Techroom_modelnum = -1;
-static int Techroom_model_instance = -1;
 static float Techroom_ship_rot;
 static UI_BUTTON List_buttons[LIST_BUTTONS_MAX];  // buttons for each line of text in list
 
@@ -333,12 +333,6 @@ void techroom_select_new_entry()
 
 		Techroom_modelnum = model_load(sip, true);
 
-		if (Techroom_model_instance >= 0) {
-			model_delete_instance(Techroom_model_instance);
-		}
-		Techroom_model_instance = model_create_instance(model_objnum_special::OBJNUM_NONE, Techroom_modelnum);
-
-		model_set_up_techroom_instance(sip, Techroom_model_instance);
 
 		Current_list->at(Cur_entry).model_num = Techroom_modelnum;
 
@@ -349,10 +343,6 @@ void techroom_select_new_entry()
 	} else {
 		Techroom_modelnum = -1;
 
-		if (Techroom_model_instance >= 0) {
-			model_delete_instance(Techroom_model_instance);
-			Techroom_model_instance = -1;
-		}
 
 		Trackball_mode = 0;
 
@@ -393,11 +383,6 @@ void techroom_select_new_entry()
 
 				if (Techroom_modelnum >= 0) {
 					weaponLoaded = true;
-
-					if (Techroom_model_instance >= 0) {
-						model_delete_instance(Techroom_model_instance);
-					}
-					Techroom_model_instance = model_create_instance(model_objnum_special::OBJNUM_NONE, Techroom_modelnum);
 
 					// If this ends up being needed for weapon models, a weapon version
 					// of this method will need to be created. Should only be necessary
@@ -614,6 +599,12 @@ void techroom_ships_render(float frametime)
 	model_clear_instance(Techroom_modelnum);
 	render_info.set_detail_level_lock(0);
 
+	int model_instance = -1;
+	model_get_cached_ui_render_instance(Techroom_modelnum, &model_instance);
+	if (Tab == SHIPS_DATA_TAB) {
+		model_set_up_techroom_instance(&Ship_info[Cur_entry_index], model_instance);
+	}
+
     if(shadow_maybe_start_frame(Shadow_disable_overrides.disable_techroom))
     {
         gr_reset_clip();
@@ -623,7 +614,7 @@ void techroom_ships_render(float frametime)
 		shadows_start_render(&Eye_matrix, &Eye_position, Proj_fov, gr_screen.clip_aspect, -closeup_pos.xyz.z + pm->rad, -closeup_pos.xyz.z + pm->rad + 200.0f, -closeup_pos.xyz.z + pm->rad + 2000.0f, -closeup_pos.xyz.z + pm->rad + 10000.0f);
         render_info.set_flags(MR_NO_TEXTURING | MR_NO_LIGHTING | MR_AUTOCENTER);
 		
-		model_render_immediate(&render_info, Techroom_modelnum, Techroom_model_instance, &Techroom_ship_orient, &vmd_zero_vector);
+		model_render_immediate(&render_info, Techroom_modelnum, model_instance, &Techroom_ship_orient, &vmd_zero_vector);
         shadows_end_render();
 
 		gr_set_clip(Tech_ship_display_coords[gr_screen.res][SHIP_X_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_Y_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_W_COORD], Tech_ship_display_coords[gr_screen.res][SHIP_H_COORD], GR_RESIZE_MENU);
@@ -639,7 +630,7 @@ void techroom_ships_render(float frametime)
 
 	render_info.set_flags(render_flags);
 
-	model_render_immediate(&render_info, Techroom_modelnum, Techroom_model_instance, &Techroom_ship_orient, &vmd_zero_vector);
+	model_render_immediate(&render_info, Techroom_modelnum, model_instance, &Techroom_ship_orient, &vmd_zero_vector);
 
 	Glowpoint_use_depth_buffer = true;
 
@@ -1317,7 +1308,6 @@ void techroom_lists_reset()
 
 	model_free_all();
 	Techroom_modelnum = -1;
-	Techroom_model_instance = -1;
 
 	// This can be cleared immediately because there are no anims or bitmaps associated.
 	Ship_list.clear();

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -39,6 +39,7 @@
 #include "missionui/missionshipchoice.h"
 #include "missionui/missionweaponchoice.h"
 #include "mod_table/mod_table.h"
+#include "model/modelrender.h"
 #include "network/multi.h"
 #include "network/multi_endgame.h"
 #include "network/multimsgs.h"
@@ -1658,9 +1659,14 @@ void draw_model_icon(int model_id, uint64_t flags, int x, int y, int w, int h, s
 
 	Glowpoint_override = true;
 	model_clear_instance(model_id);
+	int model_instance = -1;
+	model_get_cached_ui_render_instance(model_id, &model_instance);
+	if (sip != nullptr) {
+		model_set_up_techroom_instance(sip, model_instance);
+	}
 
 	render_info.set_flags(flags);
-	model_render_immediate(&render_info, model_id, &object_orient, &vmd_zero_vector);
+	model_render_immediate(&render_info, model_id, model_instance, &object_orient, &vmd_zero_vector);
 	Glowpoint_override = false;
 
 	gr_end_view_matrix();
@@ -1676,7 +1682,8 @@ void draw_model_rotating(model_render_params *render_info, int ship_class, int m
 	if (model_id < 0)
 		return;
 
-	int model_instance = model_create_instance(model_objnum_special::OBJNUM_NONE, model_id);
+	int model_instance = -1;
+	model_get_cached_ui_render_instance(model_id, &model_instance);
 	if (!(flags & MR_IS_MISSILE) && SCP_vector_inbounds(Ship_info, ship_class)) {
 		model_set_up_techroom_instance(&Ship_info[ship_class], model_instance);
 	}
@@ -1962,9 +1969,6 @@ void draw_model_rotating(model_render_params *render_info, int ship_class, int m
 	}
 
 	shadow_end_frame();
-	if (model_instance >= 0) {
-		model_delete_instance(model_instance);
-	}
 }
 
 /**

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -31,6 +31,7 @@
 #include "missionui/missionshipchoice.h"
 #include "missionui/missionweaponchoice.h"
 #include "model/model.h"
+#include "model/modelrender.h"
 #include "mod_table/mod_table.h"
 #include "network/multi.h"
 #include "network/multi_pmsg.h"
@@ -826,10 +827,9 @@ void draw_3d_overhead_view(int model_num,
 		Glowpoint_use_depth_buffer = false;
 
 		model_clear_instance(model_num);
-		int model_instance = model_create_instance(model_objnum_special::OBJNUM_NONE, model_num);
-		if (model_instance >= 0) {
-			model_set_up_techroom_instance(sip, model_instance);
-		}
+		int model_instance = -1;
+		model_get_cached_ui_render_instance(model_num, &model_instance);
+		model_set_up_techroom_instance(sip, model_instance);
 		polymodel* pm = model_get(model_num);
 
 		if (sip->replacement_textures.size() > 0) {
@@ -871,9 +871,6 @@ void draw_3d_overhead_view(int model_num,
 		batching_render_all();
 
 		shadow_end_frame();
-		if (model_instance >= 0) {
-			model_delete_instance(model_instance);
-		}
 
 		// NOW render the lines for weapons
 		gr_reset_clip();

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -30,6 +30,7 @@
 #include "nebula/neb.h"
 #include "particle/particle.h"
 #include "prop/prop.h"
+#include "parse/encrypt.h"
 #include "render/3dinternal.h"
 #include "render/batching.h"
 #include "ship/ship.h"
@@ -53,6 +54,110 @@ int Lab_object_detail_level = -1; // Used to display the detail level in the lab
 extern void interp_generate_arc_segment(SCP_vector<vec3d> &arc_segment_points, const vec3d *v1, const vec3d *v2, ubyte depth_limit, ubyte depth);
 
 int model_render_determine_elapsed_time(int objnum, uint64_t flags);
+
+SCP_unordered_map<cached_ui_render_instance_key, cached_ui_render_instance_entry, cached_ui_render_instance_key_hash> Cached_ui_render_instance_cache;
+UI_TIMESTAMP Ui_render_instance_cache_last_processed_timestamp = UI_TIMESTAMP::invalid();
+constexpr int UI_RENDER_INSTANCE_CACHE_UNUSED_MS_GRACE = 100;
+
+size_t model_hash_subsystem_name_list_for_cache(const SCP_vector<SCP_string>& subsystem_names)
+{
+	if (subsystem_names.empty()) {
+		return 0;
+	}
+
+	SCP_vector<SCP_string> normalized_names;
+	normalized_names.reserve(subsystem_names.size());
+
+	for (const auto& name : subsystem_names) {
+		auto normalized = name;
+		SCP_tolower(normalized);
+		normalized_names.push_back(std::move(normalized));
+	}
+
+	std::sort(normalized_names.begin(), normalized_names.end());
+
+	size_t seed = 0;
+	
+	boost::hash_combine(seed, static_cast<uint32_t>(normalized_names.size()));
+	for (const auto& name : normalized_names) {
+		boost::hash_combine(seed, hash_fnv1a(name));
+	}
+
+	return seed;
+}
+
+// Returns TriStateBool::TRUE_ if a new instance was created, TriStateBool::FALSE_ if an existing instance was returned,
+// or TriStateBool::UNKNOWN_ if there was an error (and model_instance_out will be set to -1 in this case)
+TriStateBool model_get_cached_ui_render_instance(int model_num, int* model_instance_out, size_t instance_data_hash)
+{
+	Assertion(model_instance_out != nullptr, "model_instance_out must not be null!");
+	if (model_instance_out == nullptr) {
+		return TriStateBool::UNKNOWN_;
+	}
+
+	cached_ui_render_instance_key key;
+	key.model_num = model_num;
+	key.state_instance_id = gameseq_get_state_instance_id();
+	key.instance_data_hash = instance_data_hash;
+
+	auto& entry = Cached_ui_render_instance_cache[key];
+
+	auto created_new = false;
+
+	if (entry.model_instance < 0) {
+		entry.model_instance = model_create_instance(model_objnum_special::OBJNUM_NONE, model_num);
+		if (entry.model_instance < 0) {
+			Warning(LOCATION, "Failed to create cached UI render model instance for model id %d.", model_num);
+			Cached_ui_render_instance_cache.erase(key);
+			*model_instance_out = -1;
+			return TriStateBool::UNKNOWN_;
+		}
+		created_new = true;
+	}
+
+	entry.last_used_timestamp = ui_timestamp();
+	*model_instance_out = entry.model_instance;
+	return created_new ? TriStateBool::TRUE_ : TriStateBool::FALSE_;
+}
+
+void model_process_cached_ui_render_instances()
+{
+	const auto now = ui_timestamp();
+	
+	if (Ui_render_instance_cache_last_processed_timestamp.isValid() &&
+		ui_timestamp_get_delta(Ui_render_instance_cache_last_processed_timestamp, now) == 0) {
+		return;
+	}
+
+	Ui_render_instance_cache_last_processed_timestamp = now;
+
+	for (auto it = Cached_ui_render_instance_cache.begin(); it != Cached_ui_render_instance_cache.end();) {
+		// This should never trigger but if it does it means something has gone very wrong with the cache management logic
+		Assertion(it->second.model_instance >= 0, "Corrupted UI render instance cache entry found");
+
+		if (it->second.model_instance < 0 || !it->second.last_used_timestamp.isValid() ||
+			ui_timestamp_get_delta(it->second.last_used_timestamp, now) > UI_RENDER_INSTANCE_CACHE_UNUSED_MS_GRACE) {
+			if (it->second.model_instance >= 0) {
+				model_delete_instance(it->second.model_instance);
+			}
+			it = Cached_ui_render_instance_cache.erase(it);
+		} else {
+			++it;
+		}
+	}
+}
+
+void model_clear_cached_ui_render_instances()
+{
+	for (auto& instance : Cached_ui_render_instance_cache) {
+		if (instance.second.model_instance >= 0) {
+			model_delete_instance(instance.second.model_instance);
+		}
+	}
+
+	Cached_ui_render_instance_cache.clear();
+	Ui_render_instance_cache_last_processed_timestamp = UI_TIMESTAMP::invalid();
+}
 
 model_batch_buffer TransformBufferHandler;
 
@@ -3253,31 +3358,33 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 
 	int model_instance = -1;
 
-	// Create an instance for ships that can be used to clear out destroyed subobjects from rendering
+	// Get a cached UI render instance for ships so repeated UI/Lua renders avoid per-call allocation churn
 	if (model_type == TECH_SHIP) {
 		auto sip = &Ship_info[class_idx];
-		auto pm = model_get(model_num);
-		model_instance = model_create_instance(model_objnum_special::OBJNUM_NONE, model_num);
-		model_set_up_techroom_instance(sip, model_instance);
+		const auto subsystem_hash = model_hash_subsystem_name_list_for_cache(destroyed_subsystems);
+		const auto cache_result = model_get_cached_ui_render_instance(model_num, &model_instance, subsystem_hash);
+		if (cache_result == TriStateBool::TRUE_) {
+			model_set_up_techroom_instance(sip, model_instance);
+			if (!destroyed_subsystems.empty()) {
+				auto pm = model_get(model_num);
+				auto pmi = model_get_instance(model_instance);
+				flagset<Ship::Subsystem_Flags> empty;
 
-		if (!destroyed_subsystems.empty()) {
-			auto pmi = model_get_instance(model_instance);
-			flagset<Ship::Subsystem_Flags> empty;
+				for (int idx = 0; idx < sip->n_subsystems; ++idx) {
+					auto& subsystem = sip->subsystems[idx];
 
-			for (int idx = 0; idx < sip->n_subsystems; ++idx) {
-				auto& subsystem = sip->subsystems[idx];
+					if (subsystem.subobj_num < 0 || subsystem.subobj_num >= pm->n_models ||
+						subsystem.model_num != model_num) {
+						continue;
+					}
 
-				if (subsystem.subobj_num < 0 || subsystem.subobj_num >= pm->n_models ||
-					subsystem.model_num != model_num) {
-					continue;
-				}
-
-				for (auto& destroyed_name : destroyed_subsystems) {
-					if (!stricmp(subsystem.subobj_name, destroyed_name.c_str()) ||
-						!stricmp(subsystem.name, destroyed_name.c_str())) {
-						pmi->submodel[subsystem.subobj_num].blown_off = true;
-						model_replicate_submodel_instance(pm, pmi, subsystem.subobj_num, empty);
-						break;
+					for (auto& destroyed_name : destroyed_subsystems) {
+						if (!stricmp(subsystem.subobj_name, destroyed_name.c_str()) ||
+							!stricmp(subsystem.name, destroyed_name.c_str())) {
+							pmi->submodel[subsystem.subobj_num].blown_off = true;
+							model_replicate_submodel_instance(pm, pmi, subsystem.subobj_num, empty);
+							break;
+						}
 					}
 				}
 			}
@@ -3309,10 +3416,6 @@ bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int 
 	// Bye!!
 	g3_end_frame();
 	gr_reset_clip();
-
-	// Now that we've rendered the frame we can remove the instance if one was created for ships
-	if (model_type == TECH_SHIP)
-		model_delete_instance(model_instance);
 
 	return true;
 }

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -56,8 +56,8 @@ extern void interp_generate_arc_segment(SCP_vector<vec3d> &arc_segment_points, c
 int model_render_determine_elapsed_time(int objnum, uint64_t flags);
 
 SCP_unordered_map<cached_ui_render_instance_key, cached_ui_render_instance_entry, cached_ui_render_instance_key_hash> Cached_ui_render_instance_cache;
-UI_TIMESTAMP Ui_render_instance_cache_last_processed_timestamp = UI_TIMESTAMP::invalid();
-constexpr int UI_RENDER_INSTANCE_CACHE_UNUSED_MS_GRACE = 100;
+int Ui_render_instance_cache_last_processed_framecount = -1;
+constexpr int UI_RENDER_INSTANCE_CACHE_UNUSED_FRAMES_GRACE = 5;
 
 size_t model_hash_subsystem_name_list_for_cache(const SCP_vector<SCP_string>& subsystem_names)
 {
@@ -115,28 +115,25 @@ TriStateBool model_get_cached_ui_render_instance(int model_num, int* model_insta
 		created_new = true;
 	}
 
-	entry.last_used_timestamp = ui_timestamp();
+	entry.last_used_framecount = Framecount;
 	*model_instance_out = entry.model_instance;
 	return created_new ? TriStateBool::TRUE_ : TriStateBool::FALSE_;
 }
 
 void model_process_cached_ui_render_instances()
 {
-	const auto now = ui_timestamp();
-	
-	if (Ui_render_instance_cache_last_processed_timestamp.isValid() &&
-		ui_timestamp_get_delta(Ui_render_instance_cache_last_processed_timestamp, now) == 0) {
+	if (Ui_render_instance_cache_last_processed_framecount == Framecount) {
 		return;
 	}
 
-	Ui_render_instance_cache_last_processed_timestamp = now;
+	Ui_render_instance_cache_last_processed_framecount = Framecount;
 
 	for (auto it = Cached_ui_render_instance_cache.begin(); it != Cached_ui_render_instance_cache.end();) {
 		// This should never trigger but if it does it means something has gone very wrong with the cache management logic
 		Assertion(it->second.model_instance >= 0, "Corrupted UI render instance cache entry found");
 
-		if (it->second.model_instance < 0 || !it->second.last_used_timestamp.isValid() ||
-			ui_timestamp_get_delta(it->second.last_used_timestamp, now) > UI_RENDER_INSTANCE_CACHE_UNUSED_MS_GRACE) {
+		if (it->second.model_instance < 0 || it->second.last_used_framecount < 0 ||
+			(Framecount - it->second.last_used_framecount) > UI_RENDER_INSTANCE_CACHE_UNUSED_FRAMES_GRACE) {
 			if (it->second.model_instance >= 0) {
 				model_delete_instance(it->second.model_instance);
 			}
@@ -156,7 +153,7 @@ void model_clear_cached_ui_render_instances()
 	}
 
 	Cached_ui_render_instance_cache.clear();
-	Ui_render_instance_cache_last_processed_timestamp = UI_TIMESTAMP::invalid();
+	Ui_render_instance_cache_last_processed_framecount = -1;
 }
 
 model_batch_buffer TransformBufferHandler;

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -186,7 +186,7 @@ struct cached_ui_render_instance_key_hash {
 
 struct cached_ui_render_instance_entry {
 	int model_instance = -1;
-	UI_TIMESTAMP last_used_timestamp = UI_TIMESTAMP::invalid();
+	int last_used_framecount = -1;
 };
 
 struct arc_effect

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -16,6 +16,7 @@
 #include "model/model.h"
 #include "mission/missionparse.h"
 #include "graphics/util/UniformBuffer.h"
+#include "utils/boost/hash_combine.h"
 
 extern SCP_vector<light> Lights;
 extern int Num_lights;
@@ -157,6 +158,35 @@ public:
 	const mst_info& get_thruster_info() const;
 	float get_outline_thickness() const;
 	float get_alpha_mult() const;
+};
+
+struct cached_ui_render_instance_key {
+	int model_num;
+	int state_instance_id;
+	size_t instance_data_hash;
+
+	bool operator==(const cached_ui_render_instance_key& other) const
+	{
+		return model_num == other.model_num && state_instance_id == other.state_instance_id &&
+			   instance_data_hash == other.instance_data_hash;
+	}
+};
+
+struct cached_ui_render_instance_key_hash {
+	size_t operator()(const cached_ui_render_instance_key& key) const
+	{
+		size_t seed = 0;
+		
+		boost::hash_combine(seed, key.model_num);
+		boost::hash_combine(seed, key.state_instance_id);
+		boost::hash_combine(seed, key.instance_data_hash);
+		return seed;
+	}
+};
+
+struct cached_ui_render_instance_entry {
+	int model_instance = -1;
+	UI_TIMESTAMP last_used_timestamp = UI_TIMESTAMP::invalid();
 };
 
 struct arc_effect
@@ -318,6 +348,11 @@ void model_render_arc(const vec3d* v1, const vec3d* v2, const SCP_vector<vec3d> 
 void model_render_insignias(const insignia_draw_data* insignia);
 void model_render_set_wireframe_color(const color* clr);
 bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, const matrix* orient, const SCP_string& pof_filename = "", float closeup_zoom = 0, const vec3d* closeup_pos = &vmd_zero_vector, const SCP_string& tcolor = "", const SCP_vector<SCP_string>& destroyed_subsystems = SCP_vector<SCP_string>());
+
+size_t model_hash_subsystem_name_list_for_cache(const SCP_vector<SCP_string>& subsystem_names);
+TriStateBool model_get_cached_ui_render_instance(int model_num, int* model_instance_out, size_t instance_data_hash = 0);
+void model_clear_cached_ui_render_instances();
+void model_process_cached_ui_render_instances();
 
 float convert_distance_and_diameter_to_pixel_size(float distance, float diameter, float field_of_view, int screen_width);
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -122,6 +122,7 @@
 #include "missionui/missionweaponchoice.h"
 #include "missionui/redalert.h"
 #include "mod_table/mod_table.h"
+#include "model/modelrender.h"
 #include "model/modelreplace.h"
 #include "nebula/neb.h"
 #include "nebula/neblightning.h"
@@ -5261,6 +5262,10 @@ static bool going_to_menu_state(int new_state)
 void game_leave_state( int old_state, int new_state )
 {
 	events::GameLeaveState(old_state, new_state);
+
+	// Clear cached UI model instances when changing game states.
+	// New state UI screens can lazily recreate any instances they need.
+	model_clear_cached_ui_render_instances();
 
 	int end_mission = 1;
 


### PR DESCRIPTION
Addresses an issue that came up while reviewing #7225 (Note that this PR branches from that PR, so that one should be merged first) where we really shouldn't be creating instances for UI models every frame.

Here we use some of the model details to create a cache of instances for the UI. Each frame we check for stale instances and clear them as well as clearing all instances between game states.  With this framework, the call sites can lazy load model instances as needed and the engine takes care of keeping things tidy. This is especially useful for the Lua side where any number of models can be rendered and we don't want to have to rely on the script to remember to clean up after itself.

Be aware that the code for using destroyed subsystems as part of the instance key is setting up for supporting #7218 . Additionally the tristatebool return type will allow for that code path to skip some model setup each frame if it returns true.

Also adds model instance support for 3D icons and Fixes #7054