### PR TITLE
Fix forever flashing threat gauge

### DIFF
--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -1037,7 +1037,7 @@ void HudGaugeThreatIndicator::renderLaserThreat(bool config)
 	}
 
 	int frame_offset;
-	if ( Player->threat_flags & THREAT_DUMBFIRE ) {
+	if (!config && Player->threat_flags & THREAT_DUMBFIRE) {
 		if ( timestamp_elapsed(laser_warn_timer) ) {
 			laser_warn_timer = timestamp(THREAT_DUMBFIRE_FLASH);
 			laser_warn_frame++;
@@ -1072,7 +1072,7 @@ void HudGaugeThreatIndicator::renderLockThreat(bool config)
 	}
 
 	int frame_offset;
-	if ( Player->threat_flags & (THREAT_LOCK | THREAT_ATTEMPT_LOCK) ) {
+	if (!config && Player->threat_flags & (THREAT_LOCK | THREAT_ATTEMPT_LOCK)) {
 		if ( timestamp_elapsed(lock_warn_timer) ) {
 			if ( Player->threat_flags & THREAT_LOCK )  {
 				lock_warn_timer = timestamp(fl2i(THREAT_LOCK_FLASH/2.0f));


### PR DESCRIPTION
This one would be good for the upcoming point release, as on Stable 25.0, if your threat gauge is flashing during a mission and then you quit the mission and go to the HUD Config screen, then the gauge remains flashing.

This PR fixes that by simply not flashing the gauge while in configure mode. Tested and fixes the bug as expected.