### PR TITLE
fix portfwd issue when dealing with server response failures

### DIFF
--- a/lib/libpcpnatpmp/src/pcp_event_handler.c
+++ b/lib/libpcpnatpmp/src/pcp_event_handler.c
@@ -756,6 +756,7 @@ static int get_first_flow_iter(pcp_flow_t *f, void *data) {
     case pfs_idle:
     case pfs_wait_for_server_init:
     case pfs_send:
+    case pfs_failed:
         d->msg = f;
         return 1;
     default:


### PR DESCRIPTION
An upstream bug in libpcpnatpmp caused it to not pass along ping failure messages in the internal state which then triggered multiple issues with both the library itself and FSO. This fixes the bug in the pcp library and takes care of the portfwd log spam issues in FSO as well.