### PR TITLE
more FRED fixes when dialogs pop up

### DIFF
--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -1820,6 +1820,10 @@ void render_one_model_htl(object *objp) {
 
 	Assert(objp->type != OBJ_NONE);
 
+	// if this object isn't fully created yet, don't render it
+	if (objp->type == OBJ_SHIP && Ships[objp->instance].create_time == 0)
+		return;
+
 	if (objp->type == OBJ_JUMP_NODE) {
 		return;
 	}

--- a/fred2/jumpnodedlg.cpp
+++ b/fred2/jumpnodedlg.cpp
@@ -166,7 +166,7 @@ void jumpnode_dlg::initialize_data(int full_update)
 	GetDlgItem(IDC_NAME)->EnableWindow(enable);
 }
 
-int jumpnode_dlg::update_data()
+int jumpnode_dlg::update_data(int redraw)
 {
 	const char *str;
 	char old_name[255];
@@ -345,7 +345,8 @@ int jumpnode_dlg::update_data()
 		
 	}
 
-	update_map_window();
+	if (redraw)
+		update_map_window();
 
 	return 0;
 }

--- a/fred2/jumpnodedlg.h
+++ b/fred2/jumpnodedlg.h
@@ -20,7 +20,7 @@ class jumpnode_dlg : public CDialog
 // Construction
 public:
 	int bypass_errors;
-	int update_data();
+	int update_data(int redraw = 1);
 	void initialize_data(int full_update);
 	void OnOK();
 	BOOL Create();

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -1180,7 +1180,7 @@ int update_dialog_boxes()
 		return z;
 	}
 
-	z = Jumpnode_editor_dialog.update_data();
+	z = Jumpnode_editor_dialog.update_data(0);
 	if (z) {
 		nprintf(("Fred routing", "jumpnode dialog save failed\n"));
 		Jumpnode_editor_dialog

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -794,6 +794,10 @@ void FredRenderer::render_one_model_htl(object* objp,
 
 	Assert(objp->type != OBJ_NONE);
 
+	// if this object isn't fully created yet, don't render it
+	if (objp->type == OBJ_SHIP && Ships[objp->instance].create_time == 0)
+		return;
+
 	if (objp->type == OBJ_JUMP_NODE) {
 		return;
 	}


### PR DESCRIPTION
FRED can get into a weird state if a warning appears while a ship is being created, e.g. if the ship has a null moment of inertia.  So, prevent FRED from rendering a ship ~~or prop~~ if the ship ~~or prop~~ hasn't been fully initialized yet.