### PR TITLE
fix issues with imgui backend/renderer cleanup

### DIFF
--- a/freespace2/SDLGraphicsOperations.cpp
+++ b/freespace2/SDLGraphicsOperations.cpp
@@ -154,13 +154,18 @@ SDLGraphicsOperations::SDLGraphicsOperations() {
 	}
 }
 SDLGraphicsOperations::~SDLGraphicsOperations() {
-	SDL_QuitSubSystem(SDL_INIT_VIDEO);
-	
-	ImGui_ImplSDL2_Shutdown();
+	// make sure imgui stuff is initialized before trying to shut it down
+	if (ImGui::GetCurrentContext()) {
+		if (ImGui::GetIO().BackendPlatformUserData) {
+			ImGui_ImplSDL2_Shutdown();
+		}
 
-	if (!Cmdline_vulkan) {
-		ImGui_ImplOpenGL3_Shutdown();
+		if ( !Cmdline_vulkan && ImGui::GetIO().BackendRendererUserData ) {
+			ImGui_ImplOpenGL3_Shutdown();
+		}
 	}
+
+	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 }
 std::unique_ptr<os::Viewport> SDLGraphicsOperations::createViewport(const os::ViewPortProperties& props)
 {
@@ -267,7 +272,8 @@ std::unique_ptr<os::OpenGLContext> SDLGraphicsOperations::createOpenGLContext(os
 	mprintf(("  Actual SDL Video values    = R: %d, G: %d, B: %d, depth: %d, stencil: %d, double-buffer: %d, FSAA: %d\n",
 		r, g, b, depth, stencil, db, fsaa_samples));
 
-	
+	Assertion(ImGui::GetCurrentContext() != nullptr, "Can't use ImGui without a valid context!");
+
 	ImGui_ImplSDL2_InitForOpenGL(viewport->toSDLWindow(), ctx);
 	ImGui_ImplOpenGL3_Init();
 


### PR DESCRIPTION
If the graphics system fails to fully init for some reason then it's possible for the imgui backend and/or renderer to not be initialized. Those subsystems *must* be initialized before being shut down so we need to check for that to avoid hitting assertions inside of imgui.

Also add a safety check for making sure that an imgui context exists before attempting to initialize the backend/renderer. A simple assertion should work for this as it would take a coder messing something up in order to trip it.