### PR TITLE
assorted `const` fixes

### DIFF
--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -812,7 +812,7 @@ void ai_profiles_init()
 	Ai_profiles_initted = 1;
 }
 
-int ai_profile_lookup(char *name)
+int ai_profile_lookup(const char *name)
 {
 	for (int i = 0; i < Num_ai_profiles; i++)
 		if (!stricmp(name, Ai_profiles[i].profile_name))

--- a/code/ai/ai_profiles.h
+++ b/code/ai/ai_profiles.h
@@ -164,6 +164,6 @@ extern ai_profile_t Ai_profiles[MAX_AI_PROFILES];
 
 void ai_profiles_init();
 
-int ai_profile_lookup(char *name);
+int ai_profile_lookup(const char *name);
 
 #endif

--- a/code/graphics/software/NVGFont.cpp
+++ b/code/graphics/software/NVGFont.cpp
@@ -32,8 +32,8 @@ namespace font
 				return 1;
 		}
 
-		const char *nullPtr = strchr(const_cast<char*>(string), '\0');
-		const char *nextToken = strpbrk(const_cast<char*>(string), TOKEN_SEPARATORS);
+		const char *nullPtr = strchr(string, '\0');
+		const char *nextToken = strpbrk(string, TOKEN_SEPARATORS);
 
 		// WOHOO! Pointer arithmetic!!!
 		if (nullPtr != NULL && (nextToken == NULL || nullPtr < nextToken))

--- a/code/lab/dialogs/lab_ui.cpp
+++ b/code/lab/dialogs/lab_ui.cpp
@@ -660,7 +660,7 @@ static void build_ship_table_info_txtbox(ship_info* sip)
 		}
 
 		InputTextMultiline("##table_text",
-			const_cast<char*>(table_text.c_str()),
+			table_text.data(),
 			table_text.length(),
 			ImVec2(-FLT_MIN, GetTextLineHeight() * 16),
 			ImGuiInputTextFlags_ReadOnly);
@@ -681,7 +681,7 @@ static void build_weapon_table_info_txtbox(weapon_info* wip)
 		}
 
 		InputTextMultiline("##weapon_table_text",
-			const_cast<char*>(table_text.c_str()),
+			table_text.data(),
 			table_text.length(),
 			ImVec2(-FLT_MIN, GetTextLineHeight() * 16),
 			ImGuiInputTextFlags_ReadOnly);
@@ -1506,7 +1506,7 @@ void LabUi::show_object_options() const
 				}
 
 				InputTextMultiline("##asteroid_table_text",
-					const_cast<char*>(table_text.c_str()),
+					table_text.data(),
 					table_text.length(),
 					ImVec2(-FLT_MIN, GetTextLineHeight() * 16),
 					ImGuiInputTextFlags_ReadOnly);
@@ -1544,7 +1544,7 @@ void LabUi::show_object_options() const
 				}
 
 				InputTextMultiline("##prop_table_text",
-					const_cast<char*>(table_text.c_str()),
+					table_text.data(),
 					table_text.length(),
 					ImVec2(-FLT_MIN, GetTextLineHeight() * 16),
 					ImGuiInputTextFlags_ReadOnly);

--- a/code/missioneditor/campaignsave.h
+++ b/code/missioneditor/campaignsave.h
@@ -8,9 +8,9 @@ typedef struct campaign_link {
 	int node;                         // node tracker when link is in sexp tree window
 	bool is_mission_loop;             // whether link leads to mission loop
 	bool is_mission_fork;             // whether link leads to mission fork
-	char* mission_branch_txt;         // text describing mission loop
-	char* mission_branch_brief_anim;  // filename of anim to play in the brief
-	char* mission_branch_brief_sound; // filename of anim to play in the brief
+	const char* mission_branch_txt;         // text describing mission loop
+	const char* mission_branch_brief_anim;  // filename of anim to play in the brief
+	const char* mission_branch_brief_sound; // filename of anim to play in the brief
 } campaign_link;
 
 class Fred_campaign_save : public Fred_mission_save {

--- a/code/network/multi_xfer.cpp
+++ b/code/network/multi_xfer.cpp
@@ -450,7 +450,7 @@ int multi_xfer_get_flags(int handle)
 }
 
 // if the passed filename is being xferred, return the xfer handle, otherwise return -1
-int multi_xfer_lookup(char *filename)
+int multi_xfer_lookup(const char *filename)
 {
 	int idx;
 

--- a/code/network/multi_xfer.h
+++ b/code/network/multi_xfer.h
@@ -87,7 +87,7 @@ void multi_xfer_xor_flags(int handle,int flags);
 int multi_xfer_get_flags(int handle);
 
 // if the passed filename is being xferred, return the xfer handle, otherwise return -1
-int multi_xfer_lookup(char *filename);
+int multi_xfer_lookup(const char *filename);
 
 // get the % of completion of the passed file handle, return < 0 if invalid
 float multi_xfer_pct_complete(int handle);

--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -185,7 +185,7 @@ ADE_INDEXER(l_Graphics_Posteffects, "number index", "Gets the name of the specif
 	if (index >= (int) names.size())
 		return ade_set_error(L, "s", "");
 
-	return ade_set_args(L, "s", const_cast<char*>(names[index].c_str()));
+	return ade_set_args(L, "s", names[index].c_str());
 }
 
 ADE_FUNC(__len, l_Graphics_Posteffects, nullptr, "Gets the number of available post-processing effects", "number", "number of post-processing effects or 0 on error")

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7553,7 +7553,7 @@ int detect_lang()
 
 	// try and open the file to verify
 	font::stuff_first(first_font);
-	CFILE *detect = cfopen(const_cast<char*>(first_font.c_str()), "rb");
+	CFILE *detect = cfopen(first_font.c_str(), "rb");
 
 	// will use default setting if something went wrong
 	if (!detect)

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -507,13 +507,9 @@ void CampaignEditorDialogModel::saveCampaign(const SCP_string& filename)
 
 			// The descriptive text fields only apply to special (loop/fork) branches.
 			if (branch.is_loop || branch.is_fork) {
-				link.mission_branch_txt =
-					branch.loop_description.empty() ? nullptr : const_cast<char*>(branch.loop_description.c_str());
-				link.mission_branch_brief_anim =
-					branch.loop_briefing_anim.empty() ? nullptr : const_cast<char*>(branch.loop_briefing_anim.c_str());
-				link.mission_branch_brief_sound = branch.loop_briefing_sound.empty()
-													  ? nullptr
-													  : const_cast<char*>(branch.loop_briefing_sound.c_str());
+				link.mission_branch_txt = branch.loop_description.empty() ? nullptr : branch.loop_description.c_str();
+				link.mission_branch_brief_anim = branch.loop_briefing_anim.empty() ? nullptr : branch.loop_briefing_anim.c_str();
+				link.mission_branch_brief_sound = branch.loop_briefing_sound.empty() ? nullptr : branch.loop_briefing_sound.c_str();
 			} else {
 				link.mission_branch_txt = nullptr;
 				link.mission_branch_brief_anim = nullptr;

--- a/test/src/util/FSTestFixture.cpp
+++ b/test/src/util/FSTestFixture.cpp
@@ -113,13 +113,13 @@ void test::FSTestFixture::addCommandlineArg(const SCP_string& arg) {
 	_cmdlineArgs.push_back(arg);
 }
 void test::FSTestFixture::init_cmdline() {
-	std::unique_ptr<char* []> parts(new char* [_cmdlineArgs.size()]);
+	std::vector<char*> parts(_cmdlineArgs.size());
 
 	for (size_t i = 0; i < _cmdlineArgs.size(); ++i) {
-		parts[i] = const_cast<char*>(_cmdlineArgs[i].c_str());
+		parts[i] = _cmdlineArgs[i].data();
 	}
 
-	parse_cmdline((int) _cmdlineArgs.size(), parts.get());
+	parse_cmdline(sz2i(_cmdlineArgs.size()), parts.data());
 }
 void test::FSTestFixture::pushModDir(const SCP_string& mod) {
 	if (!_currentModDir.empty()) {


### PR DESCRIPTION
1. Change `ai_profile_lookup` and `multi_xfer_lookup` to use `const char *`, since all the other lookup functions do
2. Remove several unneeded `const_cast`s, some of which are now made possible by the non-const `data()` overload in C++17
3. Change `campaign_link` to use `const char*`
4. Use better string management in `test::FSTestFixture::init_cmdline()`