### PR TITLE
Weapon dot-to-target input

### DIFF
--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -346,7 +346,7 @@ float weapon_get_lifetime_pct(const weapon& wp);
 float weapon_get_age(const weapon& wp);
 float weapon_get_viewing_angle(const weapon& wp);
 float weapon_get_apparent_size(const weapon& wp);
-float weapon_get_target_dot(weapon* wp);
+float weapon_get_target_dot(const weapon& wp);
 
 float beam_get_warmup_lifetime_pct(const beam& wp);
 float beam_get_warmdown_lifetime_pct(const beam& wp);
@@ -799,7 +799,8 @@ struct weapon_info
 			>{}},
 			std::pair {"Parent Radius", modular_curves_submember_input<&weapon::objnum, &Objects, &object::parent, &Objects, &object::radius>{}},
 			std::pair {"Viewing Angle", modular_curves_functional_input<weapon_get_viewing_angle>{}},
-			std::pair {"Apparent Size", modular_curves_functional_input<weapon_get_apparent_size>{}}
+			std::pair {"Apparent Size", modular_curves_functional_input<weapon_get_apparent_size>{}},
+			std::pair {"Dot To Target", modular_curves_functional_input<weapon_get_target_dot>{}}
 	);
 
   public:

--- a/code/weapon/weapon.h
+++ b/code/weapon/weapon.h
@@ -346,6 +346,7 @@ float weapon_get_lifetime_pct(const weapon& wp);
 float weapon_get_age(const weapon& wp);
 float weapon_get_viewing_angle(const weapon& wp);
 float weapon_get_apparent_size(const weapon& wp);
+float weapon_get_target_dot(weapon* wp);
 
 float beam_get_warmup_lifetime_pct(const beam& wp);
 float beam_get_warmdown_lifetime_pct(const beam& wp);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -10284,3 +10284,22 @@ float weapon_get_apparent_size(const weapon& wp) {
 		g3_get_hfov(Eye_fov),
 		gr_screen.max_w) / i2fl(gr_screen.max_w);
 }
+
+float weapon_get_target_dot(weapon* wp) {
+	object* wep_objp = &Objects[wp->objnum];
+
+	vec3d target_pos;
+
+	if((weapon_has_homing_object(wp)) && (wp->homing_object->type != 0))
+	{
+		if (!IS_VEC_NULL(&wp->homing_pos)) {
+			target_pos = wp->homing_pos;
+		}
+	} else if(wp->target_num > -1)
+	{
+		target_pos = Objects[wp->target_num].pos;
+	} else {
+		return 0.f;
+	}
+	return vm_vec_dot(&wep_objp->pos, &target_pos);
+}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -10285,19 +10285,19 @@ float weapon_get_apparent_size(const weapon& wp) {
 		gr_screen.max_w) / i2fl(gr_screen.max_w);
 }
 
-float weapon_get_target_dot(weapon* wp) {
-	object* wep_objp = &Objects[wp->objnum];
+float weapon_get_target_dot(const weapon& wp) {
+	object* wep_objp = &Objects[wp.objnum];
 
 	vec3d target_pos;
 
-	if((weapon_has_homing_object(wp)) && (wp->homing_object->type != 0))
+	if(wp.homing_object != &obj_used_list && (wp.homing_object->type != 0))
 	{
-		if (!IS_VEC_NULL(&wp->homing_pos)) {
-			target_pos = wp->homing_pos;
+		if (!IS_VEC_NULL(&wp.homing_pos)) {
+			target_pos = wp.homing_pos;
 		}
-	} else if(wp->target_num > -1)
+	} else if(wp.target_num > -1)
 	{
-		target_pos = Objects[wp->target_num].pos;
+		target_pos = Objects[wp.target_num].pos;
 	} else {
 		return 0.f;
 	}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -10301,5 +10301,7 @@ float weapon_get_target_dot(const weapon& wp) {
 	} else {
 		return 0.f;
 	}
-	return vm_vec_dot(&wep_objp->pos, &target_pos);
+	vec3d dir;
+	vm_vec_sub(&dir, &wep_objp->pos, &target_pos);
+	return vm_vec_dot(&dir, &wep_objp->orient.vec.fvec);
 }


### PR DESCRIPTION
Adds a weapon lifetime input that consists of the dot product between the vector that points toward the current target and the weapon's forward vector.