### PR TITLE
miscellaneous fixes

### DIFF
--- a/code/lab/renderer/lab_renderer.cpp
+++ b/code/lab/renderer/lab_renderer.cpp
@@ -422,6 +422,8 @@ void LabRenderer::useBackground(const SCP_string& mission_name) {
 		ltp_name = ltp::default_name();
 		if(optional_string("$Lighting Profile:")){
 			stuff_string(ltp_name,F_NAME);
+			if (ltp_name.empty())
+				ltp_name = ltp::default_name();
 		}
 		if (ltp_name != ltp::current()->name) {
 				ltp::switch_to(ltp_name);

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -2647,8 +2647,13 @@ bool add_message(const char* name, const char* message, int persona_index, int m
 	strcpy_s(msg.message, message);
 	msg.persona_index = persona_index;
 	msg.multi_team = multi_team;
-	msg.avi_info.index = -1;
-	msg.wave_info.index = -1;
+	if (Fred_running) {
+		msg.avi_info.name = nullptr;
+		msg.wave_info.name = nullptr;
+	} else {
+		msg.avi_info.index = -1;
+		msg.wave_info.index = -1;
+	}
 	Messages.push_back(msg);
 	Num_messages++;
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -1002,6 +1002,8 @@ void parse_mission_info(mission *pm, bool basic = false)
 	if (optional_string("$Lighting Profile:"))
 	{
 		stuff_string(The_mission.lighting_profile_name, F_NAME);
+		if (The_mission.lighting_profile_name.empty())
+			The_mission.lighting_profile_name = lighting_profiles::default_name();
 	}
 	else
 		The_mission.lighting_profile_name = lighting_profiles::default_name();

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -208,8 +208,6 @@ typedef struct mission {
 	int		skybox_flags;
 	int		contrail_threshold;
 	int		ambient_light_level;
-	float	neb_far_multi;
-	float	neb_near_multi;
 	std::optional<volumetric_nebula> volumetrics;
 	sound_env	sound_environment;
 	vec3d   gravity;

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -2977,7 +2977,7 @@ int Fred_mission_save::save_mission_info()
 	fso_comment_pop();
 
 	// EatThePath's lighting profiles
-	if (The_mission.lighting_profile_name != lighting_profiles::default_name()) {
+	if (!The_mission.lighting_profile_name.empty() && The_mission.lighting_profile_name != lighting_profiles::default_name()) {
 		fso_comment_push(";;FSO 23.1.0;;");
 		if (optional_string_fred("$Lighting Profile:")) {
 			parse_comments(2);


### PR DESCRIPTION
1. When loading and saving lighting profiles, treat an empty string as equivalent to the default name
2. Remove unused fields from the mission struct
3. Properly guard union initialization in `add_message`