### PR TITLE
Fix `gr.drawOffscreenIndicator`

### DIFF
--- a/code/scripting/api/libs/graphics.cpp
+++ b/code/scripting/api/libs/graphics.cpp
@@ -1319,6 +1319,7 @@ ADE_FUNC(drawOffscreenIndicator, l_Graphics, "object Object, [boolean draw=true,
 			int dir;
 			float tri_separation;
 
+			offscreengauge->resetClip();
 			offscreengauge->calculatePosition(&target_point, &targetp->pos, &outpoint, &dir, &tri_separation);
 
 			if (draw) {


### PR DESCRIPTION
The scripted `gr.drawOffscreenIndicator` was missing a critical `resetClip();` which meant it was using whatever the previous stack's clipping distance was, and thus not draw in the actual correct location.

This 1 line PR fixes that and the fix works as intended.