### PR TITLE
enhance utility functions

### DIFF
--- a/code/globalincs/utility.h
+++ b/code/globalincs/utility.h
@@ -7,6 +7,7 @@
 #include "globalincs/globals.h"
 #include "globalincs/toolchain.h"
 
+inline static constexpr size_t MAX_ITEMS_SENTINEL = i2sz(-1);
 
 // Goober5000
 // A sort for use with small or almost-sorted lists.  Iteration time is O(n) for a fully-sorted list.
@@ -162,11 +163,15 @@ typename T::size_type stringcost(const T& op, const T& input, typename T::size_t
 }
 
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
-int count_items_with_string(const VECTOR_T& item_vector, FIELD_T* ITEM_T::* field, const char* str)
+size_t count_items_with_string(const VECTOR_T& item_vector, FIELD_T* ITEM_T::* field, const char* str, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	int count = 0;
-	for (const ITEM_T& item : item_vector)
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	int end = (num_items == MAX_ITEMS_SENTINEL) ? sz2i(item_vector.size()) : sz2i(std::min(i2sz(start_index) + num_items, item_vector.size()));
+	size_t count = 0;
+	for (int index = start_index; index < end; ++index)
 	{
+		const ITEM_T& item = item_vector[index];
 		if (str == nullptr && item.*field == nullptr)
 			++count;
 		else if (str == nullptr || item.*field == nullptr)
@@ -179,11 +184,15 @@ int count_items_with_string(const VECTOR_T& item_vector, FIELD_T* ITEM_T::* fiel
 }
 
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
-int count_items_with_ptr_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const char* str)
+size_t count_items_with_ptr_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const char* str, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	int count = 0;
-	for (const ITEM_T& item : item_vector)
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	int end = (num_items == MAX_ITEMS_SENTINEL) ? sz2i(item_vector.size()) : sz2i(std::min(i2sz(start_index) + num_items, item_vector.size()));
+	size_t count = 0;
+	for (int index = start_index; index < end; ++index)
 	{
+		const ITEM_T& item = item_vector[index];
 		if (str == nullptr && (item.*field).get() == nullptr)
 			++count;
 		else if (str == nullptr || (item.*field).get() == nullptr)
@@ -196,12 +205,15 @@ int count_items_with_ptr_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* f
 }
 
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
-int count_items_with_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const SCP_string& str)
+size_t count_items_with_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const SCP_string& str, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	int count = 0;
-	for (const ITEM_T& item : item_vector)
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	int end = (num_items == MAX_ITEMS_SENTINEL) ? sz2i(item_vector.size()) : sz2i(std::min(i2sz(start_index) + num_items, item_vector.size()));
+	size_t count = 0;
+	for (int index = start_index; index < end; ++index)
 	{
-		if (lcase_equal(item.*field, str))
+		if (lcase_equal(item_vector[index].*field, str))
 			++count;
 	}
 
@@ -209,21 +221,26 @@ int count_items_with_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field
 }
 
 template <typename VECTOR_T, typename ITEM_T>
-int count_items_with_string(const VECTOR_T& item_vector, SCP_string ITEM_T::* field, const char* str)
+size_t count_items_with_string(const VECTOR_T& item_vector, SCP_string ITEM_T::* field, const char* str, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (str == nullptr)
 		return 0;
 
-	return count_items_with_string(item_vector, field, SCP_string(str));
+	return count_items_with_string(item_vector, field, SCP_string(str), start_index, num_items);
 }
 
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
-int count_items_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const FIELD_T& search)
+size_t count_items_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const FIELD_T& search, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	int count = 0;
-	for (const ITEM_T& item : item_vector)
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	int end = (num_items == MAX_ITEMS_SENTINEL) ? sz2i(item_vector.size()) : sz2i(std::min(i2sz(start_index) + num_items, item_vector.size()));
+	size_t count = 0;
+	for (int index = start_index; index < end; ++index)
 	{
-		if (item.*field == search)
+		if (item_vector[index].*field == search)
 			++count;
 	}
 
@@ -231,13 +248,15 @@ int count_items_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field,
 }
 
 template <typename ITEM_T, typename FIELD_T>
-int count_items_with_string(const ITEM_T* item_array, int num_items, FIELD_T* ITEM_T::* field, const char* str)
+size_t count_items_with_string(const ITEM_T* item_array, size_t num_items, FIELD_T* ITEM_T::* field, const char* str, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr)
 		return 0;
 
-	int count = 0;
-	for (int i = 0; i < num_items; ++i)
+	size_t count = 0;
+	for (size_t i = i2sz(start_index); i < num_items; ++i)
 	{
 		if (str == nullptr && item_array[i].*field == nullptr)
 			++count;
@@ -251,13 +270,15 @@ int count_items_with_string(const ITEM_T* item_array, int num_items, FIELD_T* IT
 }
 
 template <typename ITEM_T, typename FIELD_T>
-int count_items_with_ptr_string(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const char* str)
+size_t count_items_with_ptr_string(const ITEM_T* item_array, size_t num_items, FIELD_T ITEM_T::* field, const char* str, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr)
 		return 0;
 
-	int count = 0;
-	for (int i = 0; i < num_items; ++i)
+	size_t count = 0;
+	for (size_t i = i2sz(start_index); i < num_items; ++i)
 	{
 		if (str == nullptr && (item_array[i].*field).get() == nullptr)
 			++count;
@@ -271,13 +292,15 @@ int count_items_with_ptr_string(const ITEM_T* item_array, int num_items, FIELD_T
 }
 
 template <typename ITEM_T, typename FIELD_T>
-int count_items_with_string(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const SCP_string& str)
+size_t count_items_with_string(const ITEM_T* item_array, size_t num_items, FIELD_T ITEM_T::* field, const SCP_string& str, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr)
 		return 0;
 
-	int count = 0;
-	for (int i = 0; i < num_items; ++i)
+	size_t count = 0;
+	for (size_t i = i2sz(start_index); i < num_items; ++i)
 		if (lcase_equal(item_array[i].*field, str))
 			++count;
 
@@ -285,22 +308,26 @@ int count_items_with_string(const ITEM_T* item_array, int num_items, FIELD_T ITE
 }
 
 template <typename ITEM_T>
-int count_items_with_string(const ITEM_T* item_array, int num_items, SCP_string ITEM_T::* field, const char* str)
+size_t count_items_with_string(const ITEM_T* item_array, size_t num_items, SCP_string ITEM_T::* field, const char* str, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr || str == nullptr)
 		return 0;
 
-	return count_items_with_string(item_array, num_items, field, SCP_string(str));
+	return count_items_with_string(item_array, num_items, field, SCP_string(str), start_index);
 }
 
 template <typename ITEM_T, typename FIELD_T>
-int count_items_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const FIELD_T& search)
+size_t count_items_with_field(const ITEM_T* item_array, size_t num_items, FIELD_T ITEM_T::* field, const FIELD_T& search, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr)
 		return 0;
 
-	int count = 0;
-	for (int i = 0; i < num_items; ++i)
+	size_t count = 0;
+	for (size_t i = i2sz(start_index); i < num_items; ++i)
 		if (item_array[i].*field == search)
 			++count;
 
@@ -308,158 +335,176 @@ int count_items_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM
 }
 
 template <typename VECTOR_T>
-size_t count_items_with_value(const VECTOR_T& item_vector)
+size_t count_items_with_value(const VECTOR_T& item_vector, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	return std::count_if(item_vector.begin(), item_vector.end(),
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	auto begin_it = std::next(item_vector.begin(), start_index);
+	auto end_it = (num_items == MAX_ITEMS_SENTINEL) ? item_vector.end() : std::next(item_vector.begin(), static_cast<ptrdiff_t>(std::min(i2sz(start_index) + num_items, item_vector.size())));
+	return std::count_if(begin_it, end_it,
 		[](const typename VECTOR_T::value_type& element) { return element.has_value(); });
 }
 
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
-int find_item_with_string(const VECTOR_T& item_vector, FIELD_T* ITEM_T::* field, const char* str)
+int find_item_with_string(const VECTOR_T& item_vector, FIELD_T* ITEM_T::* field, const char* str, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	int index = 0;
-	for (const ITEM_T& item : item_vector)
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	int end = (num_items == MAX_ITEMS_SENTINEL) ? sz2i(item_vector.size()) : sz2i(std::min(i2sz(start_index) + num_items, item_vector.size()));
+	for (int index = start_index; index < end; ++index)
 	{
+		const ITEM_T& item = item_vector[index];
 		if (str == nullptr && item.*field == nullptr)
 			return index;
 		else if (str == nullptr || item.*field == nullptr)
-			++index;
+			;
 		else if (!stricmp(item.*field, str))
 			return index;
-		else
-			++index;
 	}
 
 	return -1;
 }
 
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
-int find_item_with_ptr_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const char* str)
+int find_item_with_ptr_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const char* str, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	int index = 0;
-	for (const ITEM_T& item : item_vector)
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	int end = (num_items == MAX_ITEMS_SENTINEL) ? sz2i(item_vector.size()) : sz2i(std::min(i2sz(start_index) + num_items, item_vector.size()));
+	for (int index = start_index; index < end; ++index)
 	{
+		const ITEM_T& item = item_vector[index];
 		if (str == nullptr && (item.*field).get() == nullptr)
 			return index;
 		else if (str == nullptr || (item.*field).get() == nullptr)
-			++index;
+			;
 		else if (!stricmp((item.*field).get(), str))
 			return index;
-		else
-			++index;
 	}
 
 	return -1;
 }
 
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
-int find_item_with_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const SCP_string& str)
+int find_item_with_string(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const SCP_string& str, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	int index = 0;
-	for (const ITEM_T& item : item_vector)
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	int end = (num_items == MAX_ITEMS_SENTINEL) ? sz2i(item_vector.size()) : sz2i(std::min(i2sz(start_index) + num_items, item_vector.size()));
+	for (int index = start_index; index < end; ++index)
 	{
-		if (lcase_equal(item.*field, str))
+		if (lcase_equal(item_vector[index].*field, str))
 			return index;
-		else
-			++index;
 	}
 
 	return -1;
 }
 
 template <typename VECTOR_T, typename ITEM_T>
-int find_item_with_string(const VECTOR_T& item_vector, SCP_string ITEM_T::* field, const char* str)
+int find_item_with_string(const VECTOR_T& item_vector, SCP_string ITEM_T::* field, const char* str, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (str == nullptr)
 		return -1;
 
-	return find_item_with_string(item_vector, field, SCP_string(str));
+	return find_item_with_string(item_vector, field, SCP_string(str), start_index, num_items);
 }
 
 template <typename VECTOR_T, typename ITEM_T, typename FIELD_T>
-int find_item_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const FIELD_T& search)
+int find_item_with_field(const VECTOR_T& item_vector, FIELD_T ITEM_T::* field, const FIELD_T& search, int start_index = 0, size_t num_items = MAX_ITEMS_SENTINEL)
 {
-	int index = 0;
-	for (const ITEM_T& item : item_vector)
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
+	int end = (num_items == MAX_ITEMS_SENTINEL) ? sz2i(item_vector.size()) : sz2i(std::min(i2sz(start_index) + num_items, item_vector.size()));
+	for (int index = start_index; index < end; ++index)
 	{
-		if (item.*field == search)
+		if (item_vector[index].*field == search)
 			return index;
-		else
-			++index;
 	}
 
 	return -1;
 }
 
 template <typename ITEM_T, typename FIELD_T>
-int find_item_with_string(const ITEM_T* item_array, int num_items, FIELD_T* ITEM_T::* field, const char* str)
+int find_item_with_string(const ITEM_T* item_array, size_t num_items, FIELD_T* ITEM_T::* field, const char* str, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr)
 		return -1;
 
-	for (int i = 0; i < num_items; ++i)
+	for (size_t i = i2sz(start_index); i < num_items; ++i)
 	{
 		if (str == nullptr && item_array[i].*field == nullptr)
-			return i;
+			return sz2i(i);
 		else if (str == nullptr || item_array[i].*field == nullptr)
 			;
 		else if (!stricmp(item_array[i].*field, str))
-			return i;
+			return sz2i(i);
 	}
 
 	return -1;
 }
 
 template <typename ITEM_T, typename FIELD_T>
-int find_item_with_ptr_string(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const char* str)
+int find_item_with_ptr_string(const ITEM_T* item_array, size_t num_items, FIELD_T ITEM_T::* field, const char* str, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr)
 		return -1;
 
-	for (int i = 0; i < num_items; ++i)
+	for (size_t i = i2sz(start_index); i < num_items; ++i)
 	{
 		if (str == nullptr && (item_array[i].*field).get() == nullptr)
-			return i;
+			return sz2i(i);
 		else if (str == nullptr || (item_array[i].*field).get() == nullptr)
 			;
 		else if (!stricmp((item_array[i].*field).get(), str))
-			return i;
+			return sz2i(i);
 	}
 
 	return -1;
 }
 
 template <typename ITEM_T, typename FIELD_T>
-int find_item_with_string(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const SCP_string& str)
+int find_item_with_string(const ITEM_T* item_array, size_t num_items, FIELD_T ITEM_T::* field, const SCP_string& str, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr)
 		return -1;
 
-	for (int i = 0; i < num_items; ++i)
+	for (size_t i = i2sz(start_index); i < num_items; ++i)
 		if (lcase_equal(item_array[i].*field, str))
-			return i;
+			return sz2i(i);
 
 	return -1;
 }
 
 template <typename ITEM_T>
-int find_item_with_string(const ITEM_T* item_array, int num_items, SCP_string ITEM_T::* field, const char* str)
+int find_item_with_string(const ITEM_T* item_array, size_t num_items, SCP_string ITEM_T::* field, const char* str, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr || str == nullptr)
 		return -1;
 
-	return find_item_with_string(item_array, num_items, field, str);
+	return find_item_with_string(item_array, num_items, field, SCP_string(str), start_index);
 }
 
 template <typename ITEM_T, typename FIELD_T>
-int find_item_with_field(const ITEM_T* item_array, int num_items, FIELD_T ITEM_T::* field, const FIELD_T& search)
+int find_item_with_field(const ITEM_T* item_array, size_t num_items, FIELD_T ITEM_T::* field, const FIELD_T& search, int start_index = 0)
 {
+	Assertion(start_index >= 0, "start_index cannot be negative!");
+
 	if (item_array == nullptr)
 		return -1;
 
-	for (int i = 0; i < num_items; ++i)
+	for (size_t i = i2sz(start_index); i < num_items; ++i)
 		if (item_array[i].*field == search)
-			return i;
+			return sz2i(i);
 
 	return -1;
 }

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -59,6 +59,16 @@ bool SCP_vector_contains(const SCP_vector<T>& vector, const T& item) {
 }
 
 template <typename T>
+bool SCP_vector_contains_lcase(const SCP_vector<T>& vector, const T& item) {
+	return std::find_if(vector.begin(), vector.end(), [&item](const T& iterator_item) { return lcase_equal(iterator_item, item); }) != vector.end();
+}
+
+template <typename T>
+bool SCP_vector_contains_lcase(const SCP_vector<T>& vector, const char* item) {
+	return std::find_if(vector.begin(), vector.end(), [&item](const T& iterator_item) { return !stricmp(iterator_item.c_str(), item); }) != vector.end();
+}
+
+template <typename T>
 inline bool SCP_vector_inbounds(const SCP_vector<T>& vector, int idx) {
 	return ((idx >= 0) && (static_cast<size_t>(idx) < vector.size()));
 }

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -4400,18 +4400,10 @@ bool can_construe_as_integer(const char *text)
 
 // Goober5000
 // yoinked gratefully from dbugfile.cpp
-void vsprintf(SCP_string &dest, const char *format, va_list ap)
+void vsprintf(SCP_string &dest, const char *format, va_list ap, size_t write_offset)
 {
 	va_list copy;
-
-#if defined(_MSC_VER) && _MSC_VER < 1800
-	// Only Visual Studio >= 2013 supports va_copy
-	// This isn't portable but should work for Visual Studio
-	copy = ap;
-#else
 	va_copy(copy, ap);
-#endif
-
 	int needed_length = vsnprintf(nullptr, 0, format, copy);
 	va_end(copy);
 
@@ -4420,15 +4412,23 @@ void vsprintf(SCP_string &dest, const char *format, va_list ap)
 		return;
 	}
 
-	dest.resize(static_cast<size_t>(needed_length));
-	vsnprintf(&dest[0], dest.size() + 1, format, ap);
+	dest.resize(write_offset + i2sz(needed_length));
+	vsnprintf(&dest[write_offset], i2sz(needed_length) + 1, format, ap);
 }
 
-void sprintf(SCP_string &dest, const char *format, ...)
+void sprintf(SCP_string &dest, SCP_FORMAT_STRING const char *format, ...)
 {
 	va_list args;
 	va_start(args, format);
 	vsprintf(dest, format, args);
+	va_end(args);
+}
+
+void sprintf_concat(SCP_string &dest, SCP_FORMAT_STRING const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	vsprintf(dest, format, args, dest.size());
 	va_end(args);
 }
 

--- a/code/parse/parselo.h
+++ b/code/parse/parselo.h
@@ -415,8 +415,9 @@ extern char *stristr(char *str, const char *substr);
 extern bool can_construe_as_integer(const char *text);
 
 // Goober5000 (ditto for C++)
-extern void vsprintf(SCP_string &dest, const char *format, va_list ap);
+extern void vsprintf(SCP_string &dest, const char *format, va_list ap, size_t write_offset = 0);
 extern void sprintf(SCP_string &dest, SCP_FORMAT_STRING const char *format, ...) SCP_FORMAT_STRING_ARGS(2, 3);
+extern void sprintf_concat(SCP_string &dest, SCP_FORMAT_STRING const char *format, ...) SCP_FORMAT_STRING_ARGS(2, 3);
 
 // Goober5000
 extern int subsystem_stricmp(const char *str1, const char *str2);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -2143,7 +2143,8 @@ bool is_special_sender(const char* name) {
  */
 int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, sexp_mode mode)
 {
-	int i = 0, z, type, argnum = 0, count, op, type2 = 0, op2;
+	int i = 0, z, type, argnum = 0, op, type2 = 0, op2;
+	size_t count;
 	int op_node;
 	int var_index = -1;
 	size_t st;
@@ -2195,7 +2196,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 
 	count = query_sexp_args_count(op_node);
 
-	if (!check_operator_argument_count(count, op))
+	if (!check_operator_argument_count(sz2i(count), op))
 		return SEXP_CHECK_BAD_ARG_COUNT;  // incorrect number of arguments
 
 	node = Sexp_nodes[op_node].rest;
@@ -3323,7 +3324,7 @@ int check_sexp_syntax(int node, int return_type, int recursive, int *bad_node, s
 					}
 
 					// look for mission
-					count = count_items_with_string(Campaign.missions, Campaign.num_missions, &cmission::name, CTEXT(z));
+					count = count_items_with_string(Campaign.missions, i2sz(Campaign.num_missions), &cmission::name, CTEXT(z));
 
 					// only check for a missing mission -- it's ok if the same mission appears multiple times in the campaign
 					if (count == 0) {


### PR DESCRIPTION
1. Add optional `start_index` and `num_items` parameters to the find/count functions in utility.h.
2. Fix an accidental recursion bug.
3. Change appropriate parameters to `size_t` and cast appropriately.
4. Add two forms of `SCP_vector_contains_lcase`.
5. Enhance `sprintf` and add `sprintf_concat` for `SCP_string`.