### PR TITLE
use std::move() for local variables that are copied but not reused

### DIFF
--- a/code/actions/BuiltinActionDefinition.h
+++ b/code/actions/BuiltinActionDefinition.h
@@ -30,7 +30,7 @@ class BuiltinActionDefinition : public ActionDefinition {
 		// This should have been caught earlier
 		Assertion(paramIter != parameterExpressions.cend(), "Could not find built-in parameter!");
 
-		return std::unique_ptr<Action>(new TAction(paramIter->second.template asTyped<ActionValueType>()));
+		return std::make_unique<TAction>(paramIter->second.template asTyped<ActionValueType>());
 	}
 };
 

--- a/code/actions/expression/ActionExpression.cpp
+++ b/code/actions/expression/ActionExpression.cpp
@@ -24,7 +24,7 @@ ActionExpression ActionExpression::parseFromTable(ValueType expectedReturnType, 
 
 	stuff_string(expressionText, F_NAME);
 
-	ExpressionParser parser(expressionText);
+	ExpressionParser parser(std::move(expressionText));
 
 	auto expression = parser.parse(context);
 
@@ -45,7 +45,7 @@ ActionExpression ActionExpression::parseFromTable(ValueType expectedReturnType, 
 	}
 
 	// Everything is valid
-	return ActionExpression(expression);
+	return ActionExpression(std::move(expression));
 }
 
 Value ActionExpression::execute(const ProgramVariables& variables) const

--- a/code/actions/expression/ProgramVariables.cpp
+++ b/code/actions/expression/ProgramVariables.cpp
@@ -6,7 +6,7 @@ namespace expression {
 
 ProgramVariablesDefinition& ProgramVariablesDefinition::addScope(const SCP_string& name)
 {
-	auto scope = std::unique_ptr<ProgramVariablesDefinition>(new ProgramVariablesDefinition());
+	auto scope = std::make_unique<ProgramVariablesDefinition>();
 
 	auto scopePtr = scope.get();
 

--- a/code/actions/types/MoveToSubmodel.cpp
+++ b/code/actions/types/MoveToSubmodel.cpp
@@ -70,7 +70,7 @@ ActionResult MoveToSubmodel::execute(ProgramLocals& locals) const
 
 std::unique_ptr<Action> MoveToSubmodel::clone() const
 {
-	return std::unique_ptr<Action>(new MoveToSubmodel(*this));
+	return std::make_unique<MoveToSubmodel>(*this);
 }
 
 } // namespace types

--- a/code/actions/types/ParticleEffectAction.cpp
+++ b/code/actions/types/ParticleEffectAction.cpp
@@ -69,7 +69,7 @@ ActionResult ParticleEffectAction::execute(ProgramLocals& locals) const
 
 std::unique_ptr<Action> ParticleEffectAction::clone() const
 {
-	return std::unique_ptr<Action>(new ParticleEffectAction(*this));
+	return std::make_unique<ParticleEffectAction>(*this);
 }
 
 } // namespace types

--- a/code/actions/types/ParticleEffectAction.cpp
+++ b/code/actions/types/ParticleEffectAction.cpp
@@ -61,7 +61,7 @@ ActionResult ParticleEffectAction::execute(ProgramLocals& locals) const
 	matrix orientation;
 	vm_vector_2_matrix_norm(&orientation, &direction);	// direction is normalized in SetDirectionAction::execute
 
-	source->setHost(make_unique<EffectHostObject>(locals.host.objp(), local_pos, orientation, true));
+	source->setHost(std::make_unique<EffectHostObject>(locals.host.objp(), local_pos, orientation, true));
 	source->finishCreation();
 
 	return ActionResult::Finished;

--- a/code/actions/types/PlaySoundAction.cpp
+++ b/code/actions/types/PlaySoundAction.cpp
@@ -57,7 +57,7 @@ ActionResult PlaySoundAction::execute(ProgramLocals& locals) const
 }
 std::unique_ptr<Action> PlaySoundAction::clone() const
 {
-	return std::unique_ptr<Action>(new PlaySoundAction(*this));
+	return std::make_unique<PlaySoundAction>(*this);
 }
 } // namespace types
 } // namespace actions

--- a/code/actions/types/SetDirectionAction.cpp
+++ b/code/actions/types/SetDirectionAction.cpp
@@ -32,7 +32,7 @@ ActionResult SetDirectionAction::execute(ProgramLocals& locals) const
 
 std::unique_ptr<Action> SetDirectionAction::clone() const
 {
-	return std::unique_ptr<Action>(new SetDirectionAction(*this));
+	return std::make_unique<SetDirectionAction>(*this);
 }
 
 } // namespace types

--- a/code/actions/types/SetPositionAction.cpp
+++ b/code/actions/types/SetPositionAction.cpp
@@ -27,7 +27,7 @@ ActionResult SetPositionAction::execute(ProgramLocals& locals) const
 
 std::unique_ptr<Action> SetPositionAction::clone() const
 {
-	return std::unique_ptr<Action>(new SetPositionAction(*this));
+	return std::make_unique<SetPositionAction>(*this);
 }
 
 } // namespace types

--- a/code/actions/types/WaitAction.cpp
+++ b/code/actions/types/WaitAction.cpp
@@ -41,7 +41,7 @@ ActionResult WaitAction::execute(actions::ProgramLocals& locals) const
 }
 std::unique_ptr<Action> WaitAction::clone() const
 {
-	return std::unique_ptr<Action>(new WaitAction(*this));
+	return std::make_unique<WaitAction>(*this);
 }
 
 } // namespace types

--- a/code/ai/aiturret.cpp
+++ b/code/ai/aiturret.cpp
@@ -2042,7 +2042,7 @@ bool turret_fire_weapon(int weapon_num,
 						}
 						//spawn particle effect
 						auto particleSource = particle::ParticleManager::get()->createSource(wip->muzzle_effect);
-						particleSource->setHost(make_unique<EffectHostTurret>(&Objects[parent_ship->objnum], turret->system_info->turret_gun_sobj, turret->turret_next_fire_pos, false));
+						particleSource->setHost(std::make_unique<EffectHostTurret>(&Objects[parent_ship->objnum], turret->system_info->turret_gun_sobj, turret->turret_next_fire_pos, false));
 						particleSource->setTriggerRadius(objp->radius * radius_mult);
 						particleSource->setTriggerVelocity(vm_vec_mag_quick(&objp->phys_info.vel));
 						particleSource->finishCreation();
@@ -2163,7 +2163,7 @@ void turret_swarm_fire_from_turret(turret_swarm_info *tsi)
 		if (Weapon_info[tsi->weapon_class].muzzle_effect.isValid()) {
 			//spawn particle effect
 			auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[tsi->weapon_class].muzzle_effect);
-			particleSource->setHost(make_unique<EffectHostTurret>(&Objects[tsi->parent_objnum], tsi->turret->system_info->turret_gun_sobj, tsi->turret->turret_next_fire_pos - 1, false));
+			particleSource->setHost(std::make_unique<EffectHostTurret>(&Objects[tsi->parent_objnum], tsi->turret->system_info->turret_gun_sobj, tsi->turret->turret_next_fire_pos - 1, false));
 			particleSource->setTriggerRadius(Objects[weapon_objnum].radius);
 			particleSource->finishCreation();
 		}

--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -2232,7 +2232,7 @@ static void asteroid_parse_section()
 			}
 			return;
 		}
-		asteroid_list.push_back(asteroid_t);
+		asteroid_list.push_back(std::move(asteroid_t));
 		asteroid_p = &asteroid_list[asteroid_list.size() - 1];
 
 	}
@@ -2330,7 +2330,7 @@ static void asteroid_parse_section()
 					thisType.type_name.c_str(),
 					asteroid_p->name);
 			} else {
-				asteroid_p->subtypes.push_back(thisType);
+				asteroid_p->subtypes.push_back(std::move(thisType));
 			}
 		}
 	}
@@ -2619,7 +2619,7 @@ static void verify_asteroid_splits()
 		}
 
 		// Replace splits with only valid splits
-		Asteroid_info[i].split_info = splits_t;
+		Asteroid_info[i].split_info = std::move(splits_t);
 	}
 }
 

--- a/code/cfile/cfilesystem.cpp
+++ b/code/cfile/cfilesystem.cpp
@@ -532,7 +532,7 @@ void cf_build_pack_list( cf_root *root )
 			s_root.roottype = CF_ROOTTYPE_PACK;
 			s_root.cf_type = i;
 
-			temp_roots_sort.push_back(s_root);
+			temp_roots_sort.push_back(std::move(s_root));
 		}
 	}
 
@@ -1083,7 +1083,7 @@ void cf_search_root_pack(int root_index)
 						file.pathtype = path_type;
 						file.offset = find.offset;
 
-						files.push_back(file);
+						files.push_back(std::move(file));
 
 						//mprintf(( "Found pack file '%s'\n", find.filename ));
 					}
@@ -1356,7 +1356,7 @@ CFileLocation cf_find_file_location(const char* filespec, int pathtype, uint32_t
 				fclose(fp);
 
 				res.offset = 0;
-				res.full_name = longname;
+				res.full_name = std::move(longname);
 				res.name_ext = filespec;
 
 				return res;
@@ -1549,8 +1549,8 @@ CFileLocationExt cf_find_file_location_ext(const char *filename, const int ext_n
 				fclose(fp);
 
 				res.offset = 0;
-				res.full_name = longname;
-				res.name_ext = filespec_ext;
+				res.full_name = std::move(longname);
+				res.name_ext = std::move(filespec_ext);
 
 				return res;
 			}

--- a/code/cheats_table/cheats_table.cpp
+++ b/code/cheats_table/cheats_table.cpp
@@ -135,7 +135,7 @@ void parse_cheat_table(const char* filename) {
 			}
 			
 			if (shipSpawn) {
-				std::unique_ptr<CustomCheat> shipCheat(new SpawnShipCheat(code, msg, requireCheats, shipClass, shipName));
+				std::unique_ptr<CustomCheat> shipCheat(new SpawnShipCheat(code, std::move(msg), requireCheats, std::move(shipClass), std::move(shipName)));
 
 				if(customCheats.count(code) == 1) {
 					Warning(LOCATION, "A cheat for code '%s' already exists. It will be replaced.", code.c_str());
@@ -144,7 +144,7 @@ void parse_cheat_table(const char* filename) {
 					customCheats.emplace(code, std::move(shipCheat));
 				}
 			} else {
-				std::unique_ptr<CustomCheat> cheat(new CustomCheat(code, msg, requireCheats));
+				std::unique_ptr<CustomCheat> cheat(new CustomCheat(code, std::move(msg), requireCheats));
 
 				if(customCheats.count(code) == 1) {
 					Warning(LOCATION, "A cheat for code '%s' already exists. It will be replaced.", code.c_str());

--- a/code/cheats_table/cheats_table.h
+++ b/code/cheats_table/cheats_table.h
@@ -35,7 +35,7 @@ class SpawnShipCheat : public CustomCheat {
 	SCP_string shipName;
 	public:
 
-	SpawnShipCheat(SCP_string cheat_code, SCP_string cheat_msg,  bool require_cheats_enabled, SCP_string class_name, SCP_string ship_name) : CustomCheat(cheat_code, cheat_msg, require_cheats_enabled),
+	SpawnShipCheat(SCP_string cheat_code, SCP_string cheat_msg,  bool require_cheats_enabled, SCP_string class_name, SCP_string ship_name) : CustomCheat(std::move(cheat_code), std::move(cheat_msg), require_cheats_enabled),
 		shipClassName(std::move(class_name)),
 		shipName(std::move(ship_name)) { }
 

--- a/code/cmdline/cmdline.cpp
+++ b/code/cmdline/cmdline.cpp
@@ -1322,7 +1322,7 @@ static void handle_unix_modlist(char **modlist, size_t *len)
 
 	for (char *cur_mod = strtok(*modlist, ","); cur_mod != NULL; cur_mod = strtok(NULL, ",")) {
 		SCP_string path = get_real_mod_path(cur_mod);
-		mod_paths.push_back(path);
+		mod_paths.push_back(std::move(path));
 	}
 
 	// create new char[] to replace modlist

--- a/code/cutscene/movie.cpp
+++ b/code/cutscene/movie.cpp
@@ -279,7 +279,7 @@ bool play(const char* filename, bool via_tech_room = false)
 	{
 		auto paramList = scripting::hook_param_list(scripting::hook_param("Filename", 's', filename), scripting::hook_param("ViaTechRoom", 'b', via_tech_room));
 		bool skip = scripting::hooks::OnMovieAboutToPlay->isOverride(paramList);
-		scripting::hooks::OnMovieAboutToPlay->run(paramList);
+		scripting::hooks::OnMovieAboutToPlay->run(std::move(paramList));
 		if (skip)
 			return false;
 	}

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -149,7 +149,7 @@ void debris_init()
 		particle::ParticleEffect::ShapeDirection::ALIGNED, //Particle direction
 		::util::UniformFloatRange(1.f), //Velocity Inherit
 		false, //Velocity Inherit absolute?
-		make_unique<particle::LegacyAACuboidVolume>(0.3f, 1.f, true), //Velocity volume
+		std::make_unique<particle::LegacyAACuboidVolume>(0.3f, 1.f, true), //Velocity volume
 		::util::UniformFloatRange(0.f, 10.f), //Velocity volume multiplier
 		particle::ParticleEffect::VelocityScaling::NONE, //Velocity directional scaling
 		std::nullopt, //Orientation-based velocity

--- a/code/debugconsole/console.cpp
+++ b/code/debugconsole/console.cpp
@@ -467,7 +467,7 @@ void dc_putc(char c)
 		 */
 		temp_str = line_str->substr(lastwhite);
 		line_str->resize(lastwhite);
-		dc_buffer.push_back(temp_str);
+		dc_buffer.push_back(std::move(temp_str));
 		line_str = &dc_buffer.back();
 
 		if ((dc_buffer.size() > DROWS) && (dc_scroll_y < SCROLL_Y_MAX)) {

--- a/code/gamehelp/gameplayhelp.cpp
+++ b/code/gamehelp/gameplayhelp.cpp
@@ -437,7 +437,7 @@ SCP_vector<gameplay_help_section> gameplay_help_init_text()
 
 		}
 
-		complete_help_text.push_back(thisHelp);
+		complete_help_text.push_back(std::move(thisHelp));
 	}
 
 	return complete_help_text;

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -206,7 +206,7 @@ typename std::enable_if<std::is_array<T>::value, std::unique_ptr<T>>::type make_
 
 template <typename T, typename... Args>
 typename std::enable_if<!std::is_array<T>::value, std::shared_ptr<T>>::type make_shared(Args&&... args) {
-	return std::shared_ptr<T>(new T(std::forward<Args>(args)...));
+	return std::make_shared<T>(std::forward<Args>(args)...);
 }
 template <typename T, typename... Args>
 typename std::enable_if<std::is_array<T>::value, std::shared_ptr<T>>::type make_shared(std::size_t n) {

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -197,7 +197,7 @@ public:
 
 template <typename T, typename... Args>
 typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type make_unique(Args&&... args) {
-	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+	return std::make_unique<T>(std::forward<Args>(args)...);
 }
 template <typename T, typename... Args>
 typename std::enable_if<std::is_array<T>::value, std::unique_ptr<T>>::type make_unique(std::size_t n) {

--- a/code/globalincs/vmallocator.h
+++ b/code/globalincs/vmallocator.h
@@ -196,18 +196,10 @@ public:
 };
 
 template <typename T, typename... Args>
-typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type make_unique(Args&&... args) {
-	return std::make_unique<T>(std::forward<Args>(args)...);
-}
-template <typename T, typename... Args>
 typename std::enable_if<std::is_array<T>::value, std::unique_ptr<T>>::type make_unique(std::size_t n) {
 	return std::unique_ptr<T>(new typename std::remove_extent<T>::type[n]());
 }
 
-template <typename T, typename... Args>
-typename std::enable_if<!std::is_array<T>::value, std::shared_ptr<T>>::type make_shared(Args&&... args) {
-	return std::make_shared<T>(std::forward<Args>(args)...);
-}
 template <typename T, typename... Args>
 typename std::enable_if<std::is_array<T>::value, std::shared_ptr<T>>::type make_shared(std::size_t n) {
 	return std::shared_ptr<T>(new typename std::remove_extent<T>::type[n]());

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -3081,9 +3081,9 @@ SCP_vector<DisplayData> gr_enumerate_displays()
 			display.video_modes.push_back(videoMode);
 		}
 
-		data.push_back(display);
+		data.push_back(std::move(display));
 	}
-	
+
 	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
 	return data;

--- a/code/graphics/opengl/ShaderProgram.cpp
+++ b/code/graphics/opengl/ShaderProgram.cpp
@@ -246,7 +246,7 @@ void opengl::ShaderUniforms::setTextureUniform(const SCP_string& name, const int
 		new_bind.name  = name;
 		new_bind.value = texture_unit;
 
-		_uniforms.push_back(new_bind);
+		_uniforms.push_back(std::move(new_bind));
 
 		_uniform_lookup[name] = _uniforms.size() - 1;
 	}

--- a/code/graphics/paths/PathRenderer.cpp
+++ b/code/graphics/paths/PathRenderer.cpp
@@ -15,7 +15,7 @@ namespace paths {
 std::unique_ptr<PathRenderer> PathRenderer::s_instance;
 
 bool PathRenderer::init() {
-	s_instance = std::unique_ptr<PathRenderer>(new PathRenderer());
+	s_instance = std::make_unique<PathRenderer>();
 
 	return true;
 }

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -162,7 +162,7 @@ bool PostProcessingManager::parse_table()
 
 				// Post_effects index is used for flag checks, so we can't have more than 32
 				if (m_postEffects.size() < 32) {
-					m_postEffects.push_back(eff);
+					m_postEffects.push_back(std::move(eff));
 				} else if (!warned) {
 					mprintf(("WARNING: post_processing.tbl can only have a max of 32 effects! Ignoring extra...\n"));
 					warned = true;

--- a/code/hud/hud.cpp
+++ b/code/hud/hud.cpp
@@ -2538,7 +2538,7 @@ void HudGaugeDamage::render(float  /*frametime*/, bool config)
 		by += fl2i(line_h * scale);
 		sy += fl2i(line_h * scale);
 
-		info_lines.push_back(info);
+		info_lines.push_back(std::move(info));
 
 		// Remove it from hud_subsys_list
 		if ( best_index < (num-i-1) ) {
@@ -2584,7 +2584,7 @@ void HudGaugeDamage::render(float  /*frametime*/, bool config)
 		info.value_y = y + fl2i(hull_integ_offsets[1] * scale);
 
 		// Insert at the top since hull is always first
-		info_lines.insert(info_lines.begin(), info);
+		info_lines.insert(info_lines.begin(), std::move(info));
 	}
 
 	if (info_lines.empty()) {

--- a/code/hud/hudartillery.cpp
+++ b/code/hud/hudartillery.cpp
@@ -389,7 +389,7 @@ void ssm_create(object *target, const vec3d *start, size_t ssm_index, const ssm_
 		snd_play(gamesnd_get_game_sound(Ssm_info[ssm_index].sound_index));
 	}
 
-	Ssm_strikes.push_back(ssm);
+	Ssm_strikes.push_back(std::move(ssm));
 }
 
 // delete a finished ssm effect

--- a/code/hud/hudconfig.cpp
+++ b/code/hud/hudconfig.cpp
@@ -445,7 +445,7 @@ void hud_config_get_unique_huds()
 				}
 			}
 
-			HC_available_huds.push_back(newPair);
+			HC_available_huds.push_back(std::move(newPair));
 			seenHuds.insert(hudName);
 		}
 	}

--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -363,7 +363,7 @@ void HudGaugeMessages::scrollMessages()
 			new_active_msg.target_y = new_active_msg.y;
 		}
 
-		active_messages.push_back(new_active_msg);
+		active_messages.push_back(std::move(new_active_msg));
 	}
 
 	Scroll_in_progress = false;
@@ -864,7 +864,7 @@ void hud_initialize_scrollback_lines()
 				}
 			} else {
 				node_msg.y = height / 3;
-				Msg_scrollback_lines.push_back(node_msg);
+				Msg_scrollback_lines.push_back(std::move(node_msg));
 			}
 		}
 	}

--- a/code/hud/hudparse.cpp
+++ b/code/hud/hudparse.cpp
@@ -317,7 +317,7 @@ void parse_hud_gauges_tbl(const char *filename)
 					preset.g = rgb[1];
 					preset.b = rgb[2];
 
-					HC_colors[i] = preset;
+					HC_colors[i] = std::move(preset);
 					if (optional_string("+Default")) {
 						HC_default_color = i;
 					}

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -1014,7 +1014,7 @@ bool hud_squadmsg_run_order_issued_hook(int command, ship* sendingShip, ship* re
 		}
 		scripting::hooks::OnHudCommOrderIssued->run(
 			scripting::hooks::CommOrderConditions{sendingShip, targetObject, &recipient},
-			paramList);
+			std::move(paramList));
 	}
 
 	return isOverride;

--- a/code/math/curve.cpp
+++ b/code/math/curve.cpp
@@ -89,7 +89,7 @@ void parse_curve_table(const char* filename) {
 			if (index < 0) {
 				Curve curv = Curve(std::move(name));
 				curv.ParseData();
-				Curves.push_back(curv);
+				Curves.push_back(std::move(curv));
 			} else {
 				Curves[index].ParseData();
 			}

--- a/code/menuui/credits.cpp
+++ b/code/menuui/credits.cpp
@@ -450,7 +450,7 @@ void credits_parse_table(const char* filename)
 			}
 		}
 
-		Credit_text_parts.push_back(credits_text);
+		Credit_text_parts.push_back(std::move(credits_text));
 
 		Credits_parsed = true;
 	}

--- a/code/menuui/mainhallmenu.cpp
+++ b/code/menuui/mainhallmenu.cpp
@@ -453,7 +453,7 @@ DCF(mainhall, "Temporarily sets the player to be on any main hall.  Can be used 
 		dc_printf("Main hall not currently initialized.  Setting player select override main hall to %s%s%s.\n", quote, name.empty() ? "0" : name.c_str(), quote);
 
 		extern SCP_string Player_select_force_main_hall;
-		Player_select_force_main_hall = name;
+		Player_select_force_main_hall = std::move(name);
 		return;
 	}
 
@@ -512,7 +512,7 @@ void main_hall_init(const SCP_string &main_hall_name)
 		Warning(LOCATION, "Tried to load a main hall called '%s', but it does not exist; loading first available main hall.", requested_hall.c_str());
 		main_hall_get_name(main_hall_to_load, 0);
 	} else {
-		main_hall_to_load = requested_hall;
+		main_hall_to_load = std::move(requested_hall);
 	}
 
 	// if we're switching to a different mainhall, stop the ambient (it will be started again promptly)

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -506,7 +506,7 @@ int build_standalone_mission_list_do_frame(bool API_Access)
 					api_mission.author = The_mission.author;
 					api_mission.visible = 1;
 
-					Sim_Missions.push_back(api_mission);
+					Sim_Missions.push_back(std::move(api_mission));
 				}
 
 				// determine some extra information
@@ -578,7 +578,7 @@ int build_campaign_mission_list_do_frame(bool API_Access)
 				api_mission.author = The_mission.author;
 				api_mission.visible = Campaign.missions[Num_campaign_missions_with_info].completed;
 
-				Sim_CMissions.push_back(api_mission);
+				Sim_CMissions.push_back(std::move(api_mission));
 			}
 
 			// determine some extra information

--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -1123,7 +1123,7 @@ void parse_intel_table(const char* filename)
 				if (intel_p != nullptr) {
 					error_display(0, "Duplicate entry %s in %s!", intel_t.name, filename);
 				}
-				Intel_info.push_back(intel_t);
+				Intel_info.push_back(std::move(intel_t));
 				intel_p = &Intel_info[Intel_info.size() - 1];
 			} else {
 				if (intel_p == nullptr) {

--- a/code/mission/missiongoals.cpp
+++ b/code/mission/missiongoals.cpp
@@ -752,7 +752,7 @@ void mission_goal_status_change( int goal_num, int new_status)
 			isOverride = true; // Override here only prevents displaying the goals and playing the music. Everything
 							   // else still runs.
 		}
-		scripting::hooks::OnMissionGoalStatusChanged->run(paramList);
+		scripting::hooks::OnMissionGoalStatusChanged->run(std::move(paramList));
 	}
 
 	Mission_goals[goal_num].satisfied = new_status;

--- a/code/mission/missionmessage.cpp
+++ b/code/mission/missionmessage.cpp
@@ -646,7 +646,7 @@ void message_parse(MessageFormat format) {
 	}
 
 	Num_messages++;
-	Messages.push_back(msg); 
+	Messages.push_back(std::move(msg));
 }
 
 void message_frequency_parse()
@@ -705,7 +705,7 @@ void message_moods_parse()
 		stuff_string(buf, F_NAME);
 
 		if (!message_moods_check_existing(buf)) {
-			Builtin_moods.push_back(buf);
+			Builtin_moods.push_back(std::move(buf));
 		} else {
 			mprintf(("Message mood %s already exists. Skipping!", buf.c_str()));
 		}
@@ -2248,7 +2248,7 @@ bool filters_match(MessageFilter& filter, ship* it) {
 		return filter_matches(it->ship_name, filter.ship_name)
 	      && filter_matches(hud_get_ship_callsign(it), filter.callsign)
 		    && filter_matches(hud_get_ship_class(it), filter.class_name)
-		    && filter_matches(wing_name, filter.wing_name)
+		    && filter_matches(std::move(wing_name), filter.wing_name)
 		    && filter_matches(Ship_info[it->ship_info_index].species, filter.species_bitfield)
 		    && (Ship_info[it->ship_info_index].class_type < 0 || filter_matches(Ship_info[it->ship_info_index].class_type, filter.type_bitfield))
 		    && filter_matches(it->team, filter.team_bitfield);
@@ -2654,7 +2654,7 @@ bool add_message(const char* name, const char* message, int persona_index, int m
 		msg.avi_info.index = -1;
 		msg.wave_info.index = -1;
 	}
-	Messages.push_back(msg);
+	Messages.push_back(std::move(msg));
 	Num_messages++;
 
 	return true;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6427,7 +6427,7 @@ void parse_asteroid_fields(mission *pm)
 				}
 
 				if (valid){
-					Asteroid_field.field_asteroid_type.push_back(ast_name);
+					Asteroid_field.field_asteroid_type.push_back(std::move(ast_name));
 				} else {
 					WarningEx(LOCATION, "Mission %s\n Invalid asteroid %s!", pm->name, ast_name.c_str());
 				}
@@ -6671,7 +6671,7 @@ void parse_custom_data(mission* pm)
 			required_string("+String:");
 			stuff_string(cs.text, F_MULTITEXT);
 
-			pm->custom_strings.push_back(cs);
+			pm->custom_strings.push_back(std::move(cs));
 		}
 
 		required_string("$end_custom_strings");

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -1401,7 +1401,7 @@ void Fred_mission_save::fso_comment_push(const char* ver)
 	int in_major, in_minor, in_build, in_revis;
 	int elem1, elem2;
 
-	elem1 = scan_fso_version_string(fso_ver_comment.back().c_str(), &major, &minor, &build, &revis);
+	elem1 = scan_fso_version_string(before.c_str(), &major, &minor, &build, &revis);
 	elem2 = scan_fso_version_string(ver, &in_major, &in_minor, &in_build, &in_revis);
 
 	// check consistency
@@ -1415,14 +1415,14 @@ void Fred_mission_save::fso_comment_push(const char* ver)
 		((major > in_major) ||
 			((major == in_major) && ((minor > in_minor) || ((minor == in_minor) && (build > in_build)))))) {
 		// the push'd version is older than our current version, so just push a copy of the previous version
-		fso_ver_comment.push_back(before);
+		fso_ver_comment.push_back(std::move(before));
 	} else if ((elem1 == 4) && ((major > in_major) ||
 								   ((major == in_major) &&
 									   ((minor > in_minor) || ((minor == in_minor) &&
 																  ((build > in_build) || ((build == in_build) ||
 																							 (revis > in_revis)))))))) {
 		// the push'd version is older than our current version, so just push a copy of the previous version
-		fso_ver_comment.push_back(before);
+		fso_ver_comment.push_back(std::move(before));
 	} else {
 		fso_ver_comment.push_back(SCP_string(ver));
 	}

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -1395,7 +1395,7 @@ void Fred_mission_save::fso_comment_push(const char* ver)
 		return;
 	}
 
-	SCP_string before = fso_ver_comment.back();
+	const auto &before = fso_ver_comment.back();
 
 	int major, minor, build, revis;
 	int in_major, in_minor, in_build, in_revis;
@@ -1415,14 +1415,14 @@ void Fred_mission_save::fso_comment_push(const char* ver)
 		((major > in_major) ||
 			((major == in_major) && ((minor > in_minor) || ((minor == in_minor) && (build > in_build)))))) {
 		// the push'd version is older than our current version, so just push a copy of the previous version
-		fso_ver_comment.push_back(std::move(before));
+		fso_ver_comment.push_back(before);
 	} else if ((elem1 == 4) && ((major > in_major) ||
 								   ((major == in_major) &&
 									   ((minor > in_minor) || ((minor == in_minor) &&
 																  ((build > in_build) || ((build == in_build) ||
 																							 (revis > in_revis)))))))) {
 		// the push'd version is older than our current version, so just push a copy of the previous version
-		fso_ver_comment.push_back(std::move(before));
+		fso_ver_comment.push_back(before);
 	} else {
 		fso_ver_comment.push_back(SCP_string(ver));
 	}

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -4171,7 +4171,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 			{
 				SCP_string temp;
 				sprintf(temp, XSTR("%s is unable to carry %s weaponry", 1629), ship_name, wep_display_name);
-				error_messages.push_back(temp);
+				error_messages.push_back(std::move(temp));
 
 				error_flag = true;
 				continue;
@@ -4187,7 +4187,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 						sprintf(temp, XSTR("%s is unable to carry %s weaponry in primary bank %d", 1630), ship_name, wep_display_name, cur_bank+1);
 					else
 						sprintf(temp, XSTR("%s is unable to carry %s weaponry in secondary bank %d", 1631), ship_name, wep_display_name, cur_bank+1-MAX_SHIP_PRIMARY_BANKS);
-					error_messages.push_back(temp);
+					error_messages.push_back(std::move(temp));
 
 					error_flag = true;
 					continue;
@@ -4202,7 +4202,7 @@ void wl_apply_current_loadout_to_all_ships_in_current_wing()
 			{
 				SCP_string temp;
 				sprintf(temp, XSTR("Insufficient %s available to arm %s", 1632), Weapon_info[weapon_type_to_add].get_display_name(), ship_name);
-				error_messages.push_back(temp);
+				error_messages.push_back(std::move(temp));
 
 				error_flag = true;
 				continue;

--- a/code/missionui/redalert.cpp
+++ b/code/missionui/redalert.cpp
@@ -767,8 +767,8 @@ void red_alert_store_ship_status()
 		red_alert_store_weapons(&ras, &shipp->weapons);
 		red_alert_store_subsys_status(&ras, shipp);
 
-		Red_alert_ship_status.push_back( ras );
-		// niffiwan: trying to track down red alert bug creating HUGE pilot files 
+		Red_alert_ship_status.push_back( std::move(ras) );
+		// niffiwan: trying to track down red alert bug creating HUGE pilot files
 		Assert( (Red_alert_ship_status.size() <= MAX_SHIPS) );
 
 		if (shipp->wingnum >= 0) {
@@ -803,8 +803,8 @@ void red_alert_store_ship_status()
 		red_alert_store_weapons(&ras, NULL);
 		red_alert_store_subsys_status(&ras, NULL);
 
-		Red_alert_ship_status.push_back( ras );
-		// niffiwan: trying to track down red alert bug creating HUGE pilot files 
+		Red_alert_ship_status.push_back( std::move(ras) );
+		// niffiwan: trying to track down red alert bug creating HUGE pilot files
 		Assert( (Red_alert_ship_status.size() <= MAX_SHIPS) );
 
 		if (exited.wingnum >= 0) {
@@ -829,7 +829,7 @@ void red_alert_store_ship_status()
 		rws.total_destroyed = wingp->total_destroyed;
 		rws.total_vanished = wingp->total_vanished;
 
-		Red_alert_wing_status.push_back( rws );
+		Red_alert_wing_status.push_back( std::move(rws) );
 		// see comments from niffiwan above
 		Assert( (Red_alert_wing_status.size() <= MAX_WINGS) );
 	}

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -300,7 +300,7 @@ void parse_mod_table(const char *filename)
 						splash.is_default = true;
 					}
 
-					Splash_screens.push_back(splash);
+					Splash_screens.push_back(std::move(splash));
 				}
 			}
 

--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -202,7 +202,7 @@ namespace animation {
 
 				auto thisPtr = shared_from_this();
 
-				animEntry.animationList.push_back(thisPtr);
+				animEntry.animationList.push_back(std::move(thisPtr));
 			}
 
 			/* fall-thru */
@@ -686,7 +686,7 @@ namespace animation {
 		for (const auto& submodel : other.m_submodels) {
 			auto newSubmodel = std::shared_ptr<ModelAnimationSubmodel>(submodel->copy());
 			newSubmodel->m_submodel = {};
-			m_submodels.push_back(newSubmodel);
+			m_submodels.push_back(std::move(newSubmodel));
 		}
 
 		for (const auto& animationTypes : other.m_animationSet) {
@@ -699,7 +699,7 @@ namespace animation {
 					newAnimation->m_animation->exchangeSubmodelPointers(*this);
 					newAnimation->m_set = this;
 
-					newAnimations[oldAnimations.first].push_back(newAnimation);
+					newAnimations[oldAnimations.first].push_back(std::move(newAnimation));
 				}
 			}
 		}
@@ -1490,7 +1490,7 @@ namespace animation {
 						curve = Curves[curve_id];
 				}
 
-				driver = [remap_driver_source, curve](ModelAnimation &, ModelAnimation::instance_data &instance, polymodel_instance *pmi, float) {
+				driver = [remap_driver_source = std::move(remap_driver_source), curve](ModelAnimation &, ModelAnimation::instance_data &instance, polymodel_instance *pmi, float) {
 					float oldFrametime = instance.time;
 					instance.time = curve ? curve->GetValue(remap_driver_source(pmi)) : remap_driver_source(pmi);
 					CLAMP(instance.time, 0.0f, instance.duration);
@@ -1515,7 +1515,7 @@ namespace animation {
 						curve = Curves[curve_id];
 				}
 
-				propertyDrivers.emplace_back([driver_source, curve, target](ModelAnimation &, ModelAnimation::instance_data &instance, polymodel_instance *pmi) {
+				propertyDrivers.emplace_back([driver_source = std::move(driver_source), curve, target](ModelAnimation &, ModelAnimation::instance_data &instance, polymodel_instance *pmi) {
 					float& property = instance.*(target.target);
 					property = curve ? curve->GetValue(driver_source(pmi)) : driver_source(pmi);
 					if(target.clamp) {
@@ -1541,7 +1541,7 @@ namespace animation {
 						curve = Curves[curve_id];
 				}
 
-				startupDrivers.emplace_back([driver_source, curve, target](ModelAnimation &, ModelAnimation::instance_data &instance, polymodel_instance *pmi) {
+				startupDrivers.emplace_back([driver_source = std::move(driver_source), curve, target](ModelAnimation &, ModelAnimation::instance_data &instance, polymodel_instance *pmi) {
 					float& property = instance.*(target.target);
 					property = curve ? curve->GetValue(driver_source(pmi)) : driver_source(pmi);
 					if(target.clamp) {

--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -693,7 +693,7 @@ namespace animation {
 			auto& newAnimations = m_animationSet[animationTypes.first];
 			for (const auto& oldAnimations : animationTypes.second) {
 				for (const auto& oldAnimation : oldAnimations.second) {
-					std::shared_ptr<ModelAnimation> newAnimation = std::shared_ptr<ModelAnimation>(new ModelAnimation(*oldAnimation));
+					std::shared_ptr<ModelAnimation> newAnimation = std::make_shared<ModelAnimation>(*oldAnimation);
 					newAnimation->m_animation = std::shared_ptr<ModelAnimationSegment>(newAnimation->m_animation->copy());
 
 					newAnimation->m_animation->exchangeSubmodelPointers(*this);
@@ -710,7 +710,7 @@ namespace animation {
 	}
 
 	std::shared_ptr<ModelAnimation> ModelAnimationSet::emplace(const std::shared_ptr<ModelAnimation>& animation, const SCP_string& request, const SCP_string& name, ModelAnimationTriggerType type, int subtype, unsigned int uniqueId) {
-		auto newAnim = std::shared_ptr<ModelAnimation>(new ModelAnimation(*animation));
+		auto newAnim = std::make_shared<ModelAnimation>(*animation);
 		newAnim->m_set = this;
 		newAnim->m_animation = std::shared_ptr<ModelAnimationSegment>(animation->m_animation->copy());
 		newAnim->m_animation->exchangeSubmodelPointers(*this);
@@ -1248,11 +1248,11 @@ namespace animation {
 
 		switch (turretStatus) {
 		case 0: //Submodel
-			return std::shared_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodel(name));
+			return std::make_shared<ModelAnimationSubmodel>(name);
 		case 1: //Turret Base
-			return std::shared_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodelTurret(name, false, ""));
+			return std::make_shared<ModelAnimationSubmodelTurret>(name, false, "");
 		case 2: //Turret Arm
-			return std::shared_ptr<ModelAnimationSubmodel>(new ModelAnimationSubmodelTurret(name, true, ""));
+			return std::make_shared<ModelAnimationSubmodelTurret>(name, true, "");
 		default: //Not specified
 			return nullptr;
 		}
@@ -1285,7 +1285,7 @@ namespace animation {
 			return;
 		}
 
-		auto animation = std::shared_ptr<ModelAnimation>(new ModelAnimation(type == ModelAnimationTriggerType::Initial));
+		auto animation = std::make_shared<ModelAnimation>(type == ModelAnimationTriggerType::Initial);
 		
 		int subtype = ModelAnimationSet::SUBTYPE_DEFAULT;
 		SCP_string name;
@@ -1676,7 +1676,7 @@ namespace animation {
 			if (optional_string("+time:"))
 				skip_token();
 
-			auto anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(true));
+			auto anim = std::make_shared<ModelAnimation>(true);
 
 			char namelower[MAX_NAME_LEN];
 			strncpy(namelower, sp->subobj_name, MAX_NAME_LEN);
@@ -1685,12 +1685,12 @@ namespace animation {
 			//sadly, we also need to check for engine and radar, since these take precedent (as in, an engineturret is an engine before a turret type)
 			if (!strstr(namelower, "engine") && !strstr(namelower, "radar") && strstr(namelower, "turret")) {
 				auto subsysBase = sip->animations.getSubmodel(sp->subobj_name, sip->name, false);
-				auto rotBase = std::shared_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(std::move(subsysBase), angle.h));
+				auto rotBase = std::make_shared<ModelAnimationSegmentSetAngle>(std::move(subsysBase), angle.h);
 
 				auto subsysBarrel = sip->animations.getSubmodel(sp->subobj_name, sip->name, true);
-				auto rotBarrel = std::shared_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(std::move(subsysBarrel), angle.p));
+				auto rotBarrel = std::make_shared<ModelAnimationSegmentSetAngle>(std::move(subsysBarrel), angle.p);
 
-				auto rot = std::shared_ptr<ModelAnimationSegmentParallel>(new ModelAnimationSegmentParallel());
+				auto rot = std::make_shared<ModelAnimationSegmentParallel>();
 				rot->addSegment(std::move(rotBase));
 				rot->addSegment(std::move(rotBarrel));
 
@@ -1707,7 +1707,7 @@ namespace animation {
 			sip->animations.emplace(anim, name, name, ModelAnimationTriggerType::Initial, ModelAnimationSet::SUBTYPE_DEFAULT, ModelAnimationParseHelper::getUniqueAnimationID(name + Animation_types.at(ModelAnimationTriggerType::Initial).first + std::to_string(subtype), 'b', sip->name));
 		}
 		else {
-			auto anim = std::shared_ptr<ModelAnimation>(new ModelAnimation());
+			auto anim = std::make_shared<ModelAnimation>();
 			auto subsys = sip->animations.getSubmodel(sp->subobj_name);
 
 			if (type == ModelAnimationTriggerType::TurretFired) {
@@ -1715,12 +1715,12 @@ namespace animation {
 				anim->m_flags += Animation_Flags::Reset_at_completion;
 			}
 
-			auto mainSegment = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
+			auto mainSegment = std::make_shared<ModelAnimationSegmentSerial>();
 
 			if (optional_string("+delay:")) {
 				int delayByMs;
 				stuff_int(&delayByMs);
-				auto delay = std::shared_ptr<ModelAnimationSegmentWait>(new ModelAnimationSegmentWait(((float)delayByMs) * 0.001f));
+				auto delay = std::make_shared<ModelAnimationSegmentWait>(((float)delayByMs) * 0.001f);
 				mainSegment->addSegment(delay);
 			}
 
@@ -1785,14 +1785,14 @@ namespace animation {
 				required_string("+Radius:");
 				stuff_float(&snd_rad);
 
-				auto sound = std::shared_ptr<ModelAnimationSegmentSoundDuring>(new ModelAnimationSegmentSoundDuring(rotation, start_sound, end_sound, loop_sound, true));
+				auto sound = std::make_shared<ModelAnimationSegmentSoundDuring>(rotation, start_sound, end_sound, loop_sound, true);
 				mainSegment->addSegment(sound);
 			}
 			else
 				mainSegment->addSegment(rotation);
 
 			if (delayByMsReverse != -1) {
-				auto delay = std::shared_ptr<ModelAnimationSegmentWait>(new ModelAnimationSegmentWait(((float)delayByMsReverse) * 0.001f));
+				auto delay = std::make_shared<ModelAnimationSegmentWait>(((float)delayByMsReverse) * 0.001f);
 				mainSegment->addSegment(delay);
 			}
 

--- a/code/model/animation/modelanimation_moveables.cpp
+++ b/code/model/animation/modelanimation_moveables.cpp
@@ -32,9 +32,9 @@ namespace animation {
 	void ModelAnimationMoveableOrientation::initialize(ModelAnimationSet* parentSet, polymodel_instance* pmi) {
 		auto& anim = m_instances[pmi->id].animation;
 
-		anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(false, false, true, parentSet));
+		anim = std::make_shared<ModelAnimation>(false, false, true, parentSet);
 
-		anim->setAnimation(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(parentSet->getSubmodel(m_submodel), m_defaultPosOrient, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
+		anim->setAnimation(std::make_shared<ModelAnimationSegmentSetOrientation>(parentSet->getSubmodel(m_submodel), m_defaultPosOrient, ModelAnimationCoordinateRelation::RELATIVE_COORDS));
 
 		anim->start(pmi,ModelAnimationDirection::FWD);
 	}
@@ -48,7 +48,7 @@ namespace animation {
 		if(submodel == nullptr)
 			error_display(1, "Could not create moveable! Moveable Orientation has no target submodel!");
 
-		return std::shared_ptr<ModelAnimationMoveableOrientation>(new ModelAnimationMoveableOrientation(std::move(submodel), angle));
+		return std::make_shared<ModelAnimationMoveableOrientation>(std::move(submodel), angle);
 	}
 
 
@@ -92,16 +92,16 @@ namespace animation {
 	void ModelAnimationMoveableRotation::initialize(ModelAnimationSet* parentSet, polymodel_instance* pmi) {
 		auto& anim = m_instances[pmi->id].animation;
 
-		anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(false, false, true, parentSet));
+		anim = std::make_shared<ModelAnimation>(false, false, true, parentSet);
 
 		matrix orient;
 		vm_angles_2_matrix(&orient, &m_defaultPosOrient);
 		
 		auto submodel = parentSet->getSubmodel(m_submodel);
 		
-		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, orient, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentRotation(std::move(submodel), m_defaultPosOrient, m_velocity, std::nullopt, m_acceleration, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS)));
+		auto sequence = std::make_shared<ModelAnimationSegmentSerial>();
+		sequence->addSegment(std::make_shared<ModelAnimationSegmentSetOrientation>(submodel, orient, ModelAnimationCoordinateRelation::RELATIVE_COORDS));
+		sequence->addSegment(std::make_shared<ModelAnimationSegmentRotation>(std::move(submodel), m_defaultPosOrient, m_velocity, std::nullopt, m_acceleration, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS));
 		
 		anim->setAnimation(sequence);
 
@@ -128,7 +128,7 @@ namespace animation {
 		if(submodel == nullptr)
 			error_display(1, "Could not create moveable! Moveable Rotation has no target submodel!");
 
-		return std::shared_ptr<ModelAnimationMoveableRotation>(new ModelAnimationMoveableRotation(std::move(submodel), angle, velocity, acceleration));
+		return std::make_shared<ModelAnimationMoveableRotation>(std::move(submodel), angle, velocity, acceleration);
 	}
 
 
@@ -172,13 +172,13 @@ namespace animation {
 	void ModelAnimationMoveableTranslation::initialize(ModelAnimationSet* parentSet, polymodel_instance* pmi) {
 		auto& anim = m_instances[pmi->id].animation;
 
-		anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(false, false, true, parentSet));
+		anim = std::make_shared<ModelAnimation>(false, false, true, parentSet);
 
 		auto submodel = parentSet->getSubmodel(m_submodel);
 
-		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOffset(submodel, m_defaultOffset, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentTranslation(std::move(submodel), m_defaultOffset, m_velocity, std::nullopt, m_acceleration, ModelAnimationSegmentTranslation::CoordinateSystem::COORDS_PARENT, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS)));
+		auto sequence = std::make_shared<ModelAnimationSegmentSerial>();
+		sequence->addSegment(std::make_shared<ModelAnimationSegmentSetOffset>(submodel, m_defaultOffset, ModelAnimationCoordinateRelation::RELATIVE_COORDS));
+		sequence->addSegment(std::make_shared<ModelAnimationSegmentTranslation>(std::move(submodel), m_defaultOffset, m_velocity, std::nullopt, m_acceleration, ModelAnimationSegmentTranslation::CoordinateSystem::COORDS_PARENT, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS));
 
 		anim->setAnimation(sequence);
 
@@ -205,7 +205,7 @@ namespace animation {
 		if(submodel == nullptr)
 			error_display(1, "Could not create moveable! Moveable Translation has no target submodel!");
 
-		return std::shared_ptr<ModelAnimationMoveableTranslation>(new ModelAnimationMoveableTranslation(std::move(submodel), angle, velocity, acceleration));
+		return std::make_shared<ModelAnimationMoveableTranslation>(std::move(submodel), angle, velocity, acceleration);
 	}
 
 
@@ -258,13 +258,13 @@ namespace animation {
 	void ModelAnimationMoveableAxisRotation::initialize(ModelAnimationSet* parentSet, polymodel_instance* pmi) {
 		auto& anim = m_instances[pmi->id].animation;
 
-		anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(false, false, true, parentSet));
+		anim = std::make_shared<ModelAnimation>(false, false, true, parentSet);
 
 		auto submodel = parentSet->getSubmodel(m_submodel);
 
-		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, vmd_identity_matrix, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentAxisRotation(std::move(submodel), 0.0f, m_velocity, std::nullopt, m_acceleration, m_axis)));
+		auto sequence = std::make_shared<ModelAnimationSegmentSerial>();
+		sequence->addSegment(std::make_shared<ModelAnimationSegmentSetOrientation>(submodel, vmd_identity_matrix, ModelAnimationCoordinateRelation::RELATIVE_COORDS));
+		sequence->addSegment(std::make_shared<ModelAnimationSegmentAxisRotation>(std::move(submodel), 0.0f, m_velocity, std::nullopt, m_acceleration, m_axis));
 
 		anim->setAnimation(sequence);
 
@@ -292,7 +292,7 @@ namespace animation {
 		if(submodel == nullptr)
 			error_display(1, "Could not create moveable! Moveable Axis Rotation has no target submodel!");
 
-		return std::shared_ptr<ModelAnimationMoveableAxisRotation>(new ModelAnimationMoveableAxisRotation(std::move(submodel), velocity, acceleration, axis));
+		return std::make_shared<ModelAnimationMoveableAxisRotation>(std::move(submodel), velocity, acceleration, axis);
 	}
 
 
@@ -353,17 +353,17 @@ namespace animation {
 	void ModelAnimationMoveableIK::initialize(ModelAnimationSet* parentSet, polymodel_instance* pmi) {
 		auto& anim = m_instances[pmi->id].animation;
 
-		anim = std::shared_ptr<ModelAnimation>(new ModelAnimation(false, false, true, parentSet));
+		anim = std::make_shared<ModelAnimation>(false, false, true, parentSet);
 
-		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
-		auto parallelSetOrient = std::shared_ptr<ModelAnimationSegmentParallel>(new ModelAnimationSegmentParallel());
+		auto sequence = std::make_shared<ModelAnimationSegmentSerial>();
+		auto parallelSetOrient = std::make_shared<ModelAnimationSegmentParallel>();
 		for(const auto& link : m_chain) {
 			auto submodel = parentSet->getSubmodel(link.submodel);
-			parallelSetOrient->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, vmd_identity_matrix, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
+			parallelSetOrient->addSegment(std::make_shared<ModelAnimationSegmentSetOrientation>(submodel, vmd_identity_matrix, ModelAnimationCoordinateRelation::RELATIVE_COORDS));
 		}
 		sequence->addSegment(parallelSetOrient);
 		
-		auto parallelIK = std::shared_ptr<ModelAnimationSegmentParallel>(new ModelAnimationSegmentParallel());
+		auto parallelIK = std::make_shared<ModelAnimationSegmentParallel>();
 		vec3d startPos = ZERO_VECTOR;
 		
 		for(size_t i = 1; i < m_chain.size(); ++i) {
@@ -413,7 +413,7 @@ namespace animation {
 						required_string("Window");
 						required_string("+Window Size:");
 						stuff_angles_deg_phb(&window);
-						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_window(window));
+						constraint = std::make_shared<ik_constraint_window>(window);
 						break;
 					}
 					case 1: { //Hinge
@@ -422,7 +422,7 @@ namespace animation {
 						required_string("+Axis:");
 						stuff_vec3d(&axis);
 						vm_vec_normalize(&axis);
-						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_hinge(axis));
+						constraint = std::make_shared<ik_constraint_hinge>(axis);
 						break;
 					}
 					default:
@@ -430,11 +430,11 @@ namespace animation {
 						break;
 				}
 			} else
-				constraint = std::shared_ptr<ik_constraint>(new ik_constraint());
+				constraint = std::make_shared<ik_constraint>();
 
 			chain.push_back({std::move(submodel), std::move(constraint), acceleration});
 		}
 		
-		return std::shared_ptr<ModelAnimationMoveable>(new ModelAnimationMoveableIK(std::move(chain), time));
+		return std::make_shared<ModelAnimationMoveableIK>(std::move(chain), time);
 	}
 }

--- a/code/model/animation/modelanimation_moveables.cpp
+++ b/code/model/animation/modelanimation_moveables.cpp
@@ -48,7 +48,7 @@ namespace animation {
 		if(submodel == nullptr)
 			error_display(1, "Could not create moveable! Moveable Orientation has no target submodel!");
 
-		return std::shared_ptr<ModelAnimationMoveableOrientation>(new ModelAnimationMoveableOrientation(submodel, angle));
+		return std::shared_ptr<ModelAnimationMoveableOrientation>(new ModelAnimationMoveableOrientation(std::move(submodel), angle));
 	}
 
 
@@ -101,7 +101,7 @@ namespace animation {
 		
 		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
 		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, orient, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentRotation(submodel, m_defaultPosOrient, m_velocity, std::nullopt, m_acceleration, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS)));
+		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentRotation(std::move(submodel), m_defaultPosOrient, m_velocity, std::nullopt, m_acceleration, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS)));
 		
 		anim->setAnimation(sequence);
 
@@ -128,7 +128,7 @@ namespace animation {
 		if(submodel == nullptr)
 			error_display(1, "Could not create moveable! Moveable Rotation has no target submodel!");
 
-		return std::shared_ptr<ModelAnimationMoveableRotation>(new ModelAnimationMoveableRotation(submodel, angle, velocity, acceleration));
+		return std::shared_ptr<ModelAnimationMoveableRotation>(new ModelAnimationMoveableRotation(std::move(submodel), angle, velocity, acceleration));
 	}
 
 
@@ -205,7 +205,7 @@ namespace animation {
 		if(submodel == nullptr)
 			error_display(1, "Could not create moveable! Moveable Translation has no target submodel!");
 
-		return std::shared_ptr<ModelAnimationMoveableTranslation>(new ModelAnimationMoveableTranslation(submodel, angle, velocity, acceleration));
+		return std::shared_ptr<ModelAnimationMoveableTranslation>(new ModelAnimationMoveableTranslation(std::move(submodel), angle, velocity, acceleration));
 	}
 
 
@@ -264,7 +264,7 @@ namespace animation {
 
 		auto sequence = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
 		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentSetOrientation(submodel, vmd_identity_matrix, ModelAnimationCoordinateRelation::RELATIVE_COORDS)));
-		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentAxisRotation(submodel, 0.0f, m_velocity, std::nullopt, m_acceleration, m_axis)));
+		sequence->addSegment(std::shared_ptr<ModelAnimationSegment>(new ModelAnimationSegmentAxisRotation(std::move(submodel), 0.0f, m_velocity, std::nullopt, m_acceleration, m_axis)));
 
 		anim->setAnimation(sequence);
 
@@ -292,7 +292,7 @@ namespace animation {
 		if(submodel == nullptr)
 			error_display(1, "Could not create moveable! Moveable Axis Rotation has no target submodel!");
 
-		return std::shared_ptr<ModelAnimationMoveableAxisRotation>(new ModelAnimationMoveableAxisRotation(submodel, velocity, acceleration, axis));
+		return std::shared_ptr<ModelAnimationMoveableAxisRotation>(new ModelAnimationMoveableAxisRotation(std::move(submodel), velocity, acceleration, axis));
 	}
 
 
@@ -432,9 +432,9 @@ namespace animation {
 			} else
 				constraint = std::shared_ptr<ik_constraint>(new ik_constraint());
 
-			chain.push_back({std::move(submodel), constraint, acceleration});
+			chain.push_back({std::move(submodel), std::move(constraint), acceleration});
 		}
 		
-		return std::shared_ptr<ModelAnimationMoveable>(new ModelAnimationMoveableIK(chain, time));
+		return std::shared_ptr<ModelAnimationMoveable>(new ModelAnimationMoveableIK(std::move(chain), time));
 	}
 }

--- a/code/model/animation/modelanimation_segments.cpp
+++ b/code/model/animation/modelanimation_segments.cpp
@@ -1504,7 +1504,7 @@ namespace animation {
 	};
 	
 	void ModelAnimationSegmentIK::recalculate(ModelAnimationSubmodelBuffer& base, ModelAnimationSubmodelBuffer& currentAnimDelta, polymodel_instance* pmi) {
-		auto ik = std::unique_ptr<ik_solver>(new ik_solver_fabrik());
+		auto ik = std::make_unique<ik_solver_fabrik>();
 
 		polymodel* pm = model_get(pmi->model_num);
 		bsp_info* lastSubmodel = nullptr;

--- a/code/model/animation/modelanimation_segments.cpp
+++ b/code/model/animation/modelanimation_segments.cpp
@@ -253,7 +253,7 @@ namespace animation {
 				error_display(1, "Set Orientation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSetOrientation>(new ModelAnimationSegmentSetOrientation(submodel, angle, relationType));
+		auto segment = std::shared_ptr<ModelAnimationSegmentSetOrientation>(new ModelAnimationSegmentSetOrientation(std::move(submodel), angle, relationType));
 
 		return segment;
 	}
@@ -308,7 +308,7 @@ namespace animation {
 				error_display(1, "Set Offset has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSetOffset>(new ModelAnimationSegmentSetOffset(submodel, target, relationType));
+		auto segment = std::shared_ptr<ModelAnimationSegmentSetOffset>(new ModelAnimationSegmentSetOffset(std::move(submodel), target, relationType));
 
 		return segment;
 	}
@@ -382,7 +382,7 @@ namespace animation {
 				error_display(1, "Set Angle has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(submodel, fl_radians(angle)));
+		auto segment = std::shared_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(std::move(submodel), fl_radians(angle)));
 
 		return segment;
 	}
@@ -667,7 +667,7 @@ namespace animation {
 				error_display(1, "Rotation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentRotation>(new ModelAnimationSegmentRotation(submodel, angle, velocity, time, acceleration, relationType));
+		auto segment = std::shared_ptr<ModelAnimationSegmentRotation>(new ModelAnimationSegmentRotation(std::move(submodel), angle, velocity, time, acceleration, relationType));
 
 		return segment;
 	}
@@ -916,7 +916,7 @@ namespace animation {
 				error_display(1, "Rotation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentAxisRotation>(new ModelAnimationSegmentAxisRotation(submodel, angle, velocity, time, acceleration, axis));
+		auto segment = std::shared_ptr<ModelAnimationSegmentAxisRotation>(new ModelAnimationSegmentAxisRotation(std::move(submodel), angle, velocity, time, acceleration, axis));
 
 		return segment;
 	}
@@ -1231,7 +1231,7 @@ namespace animation {
 				error_display(1, "Translation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentTranslation>(new ModelAnimationSegmentTranslation(submodel, offset, velocity, time, acceleration, coordSystem, relationType));
+		auto segment = std::shared_ptr<ModelAnimationSegmentTranslation>(new ModelAnimationSegmentTranslation(std::move(submodel), offset, velocity, time, acceleration, coordSystem, relationType));
 
 		return segment;
 	}
@@ -1381,7 +1381,7 @@ namespace animation {
 		bool flipIfReversed = optional_string("+Flip When Reversed");
 		bool abortSoundIfRunning = !optional_string("+Don't Interrupt Playing Sounds");
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSoundDuring>(new ModelAnimationSegmentSoundDuring(data->parseSegment(), start_sound, end_sound, loop_sound, flipIfReversed, abortSoundIfRunning, snd_rad, submodel, position));
+		auto segment = std::shared_ptr<ModelAnimationSegmentSoundDuring>(new ModelAnimationSegmentSoundDuring(data->parseSegment(), start_sound, end_sound, loop_sound, flipIfReversed, abortSoundIfRunning, snd_rad, std::move(submodel), std::move(position)));
 
 		return segment;
 	}
@@ -1619,7 +1619,7 @@ namespace animation {
 			
 			auto rotation = std::make_shared<ModelAnimationSegmentRotation>(submodel, std::optional<angles>({0,0,0}), std::optional<angles>(), time, acceleration, ModelAnimationCoordinateRelation::ABSOLUTE_COORDS);
 			parallel->addSegment(rotation);
-			segment->m_chain.push_back({submodel, constraint, rotation});
+			segment->m_chain.push_back({std::move(submodel), std::move(constraint), std::move(rotation)});
 		}
 		
 		return segment;

--- a/code/model/animation/modelanimation_segments.cpp
+++ b/code/model/animation/modelanimation_segments.cpp
@@ -79,7 +79,7 @@ namespace animation {
 		auto submodelOverride = ModelAnimationParseHelper::parseSubmodel();
 
 		ignore_white_space();
-		auto segment = std::shared_ptr<ModelAnimationSegmentSerial>(new ModelAnimationSegmentSerial());
+		auto segment = std::make_shared<ModelAnimationSegmentSerial>();
 
 		while (!optional_string("+End Segment")) {
 			if (submodelOverride)
@@ -153,7 +153,7 @@ namespace animation {
 		auto submodelOverride = ModelAnimationParseHelper::parseSubmodel();
 
 		ignore_white_space();
-		auto segment = std::shared_ptr<ModelAnimationSegmentParallel>(new ModelAnimationSegmentParallel());
+		auto segment = std::make_shared<ModelAnimationSegmentParallel>();
 
 		while (!optional_string("+End Segment")) {
 			if (submodelOverride)
@@ -181,7 +181,7 @@ namespace animation {
 		required_string("+Time:");
 		float time = 0.0f;
 		stuff_float(&time);
-		auto segment = std::shared_ptr<ModelAnimationSegmentWait>(new ModelAnimationSegmentWait(time));
+		auto segment = std::make_shared<ModelAnimationSegmentWait>(time);
 
 		return segment;
 	}
@@ -253,7 +253,7 @@ namespace animation {
 				error_display(1, "Set Orientation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSetOrientation>(new ModelAnimationSegmentSetOrientation(std::move(submodel), angle, relationType));
+		auto segment = std::make_shared<ModelAnimationSegmentSetOrientation>(std::move(submodel), angle, relationType);
 
 		return segment;
 	}
@@ -308,7 +308,7 @@ namespace animation {
 				error_display(1, "Set Offset has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSetOffset>(new ModelAnimationSegmentSetOffset(std::move(submodel), target, relationType));
+		auto segment = std::make_shared<ModelAnimationSegmentSetOffset>(std::move(submodel), target, relationType);
 
 		return segment;
 	}
@@ -382,7 +382,7 @@ namespace animation {
 				error_display(1, "Set Angle has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSetAngle>(new ModelAnimationSegmentSetAngle(std::move(submodel), fl_radians(angle)));
+		auto segment = std::make_shared<ModelAnimationSegmentSetAngle>(std::move(submodel), fl_radians(angle));
 
 		return segment;
 	}
@@ -667,7 +667,7 @@ namespace animation {
 				error_display(1, "Rotation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentRotation>(new ModelAnimationSegmentRotation(std::move(submodel), angle, velocity, time, acceleration, relationType));
+		auto segment = std::make_shared<ModelAnimationSegmentRotation>(std::move(submodel), angle, velocity, time, acceleration, relationType);
 
 		return segment;
 	}
@@ -916,7 +916,7 @@ namespace animation {
 				error_display(1, "Rotation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentAxisRotation>(new ModelAnimationSegmentAxisRotation(std::move(submodel), angle, velocity, time, acceleration, axis));
+		auto segment = std::make_shared<ModelAnimationSegmentAxisRotation>(std::move(submodel), angle, velocity, time, acceleration, axis);
 
 		return segment;
 	}
@@ -1231,7 +1231,7 @@ namespace animation {
 				error_display(1, "Translation has no target submodel!");
 		}
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentTranslation>(new ModelAnimationSegmentTranslation(std::move(submodel), offset, velocity, time, acceleration, coordSystem, relationType));
+		auto segment = std::make_shared<ModelAnimationSegmentTranslation>(std::move(submodel), offset, velocity, time, acceleration, coordSystem, relationType);
 
 		return segment;
 	}
@@ -1381,7 +1381,7 @@ namespace animation {
 		bool flipIfReversed = optional_string("+Flip When Reversed");
 		bool abortSoundIfRunning = !optional_string("+Don't Interrupt Playing Sounds");
 
-		auto segment = std::shared_ptr<ModelAnimationSegmentSoundDuring>(new ModelAnimationSegmentSoundDuring(data->parseSegment(), start_sound, end_sound, loop_sound, flipIfReversed, abortSoundIfRunning, snd_rad, std::move(submodel), std::move(position)));
+		auto segment = std::make_shared<ModelAnimationSegmentSoundDuring>(data->parseSegment(), start_sound, end_sound, loop_sound, flipIfReversed, abortSoundIfRunning, snd_rad, std::move(submodel), std::move(position));
 
 		return segment;
 	}
@@ -1568,8 +1568,8 @@ namespace animation {
 		float time;
 		stuff_float(&time);
 		
-		auto segment = std::shared_ptr<ModelAnimationSegmentIK>(new ModelAnimationSegmentIK(targetPosition, targetRotation));
-		auto parallel = std::shared_ptr<ModelAnimationSegmentParallel>(new ModelAnimationSegmentParallel());
+		auto segment = std::make_shared<ModelAnimationSegmentIK>(targetPosition, targetRotation);
+		auto parallel = std::make_shared<ModelAnimationSegmentParallel>();
 		segment->m_segment = parallel;
 		
 		while(optional_string("$Chain Link:")){
@@ -1597,7 +1597,7 @@ namespace animation {
 						required_string("Window");
 						required_string("+Window Size:");
 						stuff_angles_deg_phb(&window);
-						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_window(window));
+						constraint = std::make_shared<ik_constraint_window>(window);
 						break;
 					}
 					case 1: { //Hinge
@@ -1606,7 +1606,7 @@ namespace animation {
 						required_string("+Axis:");
 						stuff_vec3d(&axis);
 						vm_vec_normalize(&axis);
-						constraint = std::shared_ptr<ik_constraint>(new ik_constraint_hinge(axis));
+						constraint = std::make_shared<ik_constraint_hinge>(axis);
 						break;
 					}
 					default:

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3690,7 +3690,7 @@ void model_set_bay_path_nums(polymodel *pm)
 	*/
 
 	// malloc out storage for the path information
-	pm->ship_bay = make_shared<ship_bay_t>();
+	pm->ship_bay = std::make_shared<ship_bay_t>();
 
 	pm->ship_bay->num_paths = 0;
 	// TODO: determine if zeroing out here is affecting any earlier initializations

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -5339,7 +5339,7 @@ int model_create_bsp_collision_tree()
 	bsp_collision_tree tree{};
 
 	tree.used = true;
-	Bsp_collision_tree_list.push_back(tree);
+	Bsp_collision_tree_list.push_back(std::move(tree));
 
 	return (int)(Bsp_collision_tree_list.size() - 1);
 }

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -226,7 +226,7 @@ void model_render_params::set_replacement_textures(std::shared_ptr<const model_t
 
 void model_render_params::set_replacement_textures(int modelnum, const SCP_vector<texture_replace>& replacement_textures)
 {
-	auto textures = make_shared<model_texture_replace>();
+	auto textures = std::make_shared<model_texture_replace>();
 
 	polymodel* pm = model_get(modelnum);
 
@@ -3129,7 +3129,7 @@ void modelinstance_replace_active_texture(polymodel_instance* pmi, const char* o
 			texture = bm_load_either(new_name);
 
 		if (pmi->texture_replace == nullptr) {
-			pmi->texture_replace = make_shared<model_texture_replace>();
+			pmi->texture_replace = std::make_shared<model_texture_replace>();
 		}
 
 		(*pmi->texture_replace)[final_index] = texture;

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -250,7 +250,7 @@ int reallocate_and_copy_array(std::shared_ptr<T[]>& array, int& size, size_t to_
 //Generates one function for replacing data in a type, which is a map entry of which the key may be replaced. Takes an rvalue reference, used for making a copy and modifying the temporary to then assign it somewhere
 #define CHANGE_HELPER_MAP_KEY(name, intype, argtype) template<typename map_t> static typename std::enable_if<std::is_same<typename map_t::value_type, std::pair<const argtype, argtype>>::value, intype>::type name(intype&& pass, map_t replace){ \
 	const auto it = replace.find(pass.first); \
-	intype input = { (it == replace.end() ? pass.first : it->second), pass.second };
+	intype input = { (it == replace.end() ? pass.first : it->second), std::move(pass.second) };
 #define CHANGE_HELPER_MAP_KEY_END  return input; }
 
 //Generates two functions for replacing data in a type. One that takes an rvalue reference, used for making a copy and modifying the temporary to then assign it somewhere, and one which takes an lvalue reference for modifying in-place

--- a/code/model/modelreplace.cpp
+++ b/code/model/modelreplace.cpp
@@ -12,17 +12,17 @@
 
 static SCP_unordered_map<SCP_string, std::vector<VirtualPOFDefinition>, SCP_string_lcase_hash, SCP_string_lcase_equal_to> virtual_pofs;
 static SCP_unordered_map<SCP_string, std::function<std::unique_ptr<VirtualPOFOperation>()>> virtual_pof_operations = {
-	{"$Add Subobject:", &make_unique<VirtualPOFOperationAddSubmodel> },
-	{"$Add Turret:", &make_unique<VirtualPOFOperationAddTurret> },
-	{"$Add Engine:", &make_unique<VirtualPOFOperationAddEngine> },
-	{"$Add Glowpoint:", &make_unique<VirtualPOFOperationAddGlowpoint> },
-	{"$Add Weapon Bank:", &make_unique<VirtualPOFOperationAddWeapons> },
-	{"$Add Dock Point:", &make_unique<VirtualPOFOperationAddDockPoint> },
-	{"$Add Path:", &make_unique<VirtualPOFOperationAddPath> },
-	{"$Rename Subobjects:", &make_unique<VirtualPOFOperationRenameSubobjects> },
-	{"$Set Subsystem Data:", &make_unique<VirtualPOFOperationChangeSubsystemData> },
-	{"$Set Subobject Data:", &make_unique<VirtualPOFOperationChangeData> },
-	{"$Set Header Data:", &make_unique<VirtualPOFOperationHeaderData> }
+	{"$Add Subobject:", &std::make_unique<VirtualPOFOperationAddSubmodel> },
+	{"$Add Turret:", &std::make_unique<VirtualPOFOperationAddTurret> },
+	{"$Add Engine:", &std::make_unique<VirtualPOFOperationAddEngine> },
+	{"$Add Glowpoint:", &std::make_unique<VirtualPOFOperationAddGlowpoint> },
+	{"$Add Weapon Bank:", &std::make_unique<VirtualPOFOperationAddWeapons> },
+	{"$Add Dock Point:", &std::make_unique<VirtualPOFOperationAddDockPoint> },
+	{"$Add Path:", &std::make_unique<VirtualPOFOperationAddPath> },
+	{"$Rename Subobjects:", &std::make_unique<VirtualPOFOperationRenameSubobjects> },
+	{"$Set Subsystem Data:", &std::make_unique<VirtualPOFOperationChangeSubsystemData> },
+	{"$Set Subobject Data:", &std::make_unique<VirtualPOFOperationChangeData> },
+	{"$Set Header Data:", &std::make_unique<VirtualPOFOperationHeaderData> }
 };
 
 /*
@@ -86,7 +86,7 @@ public:
 		
 		//Don't load from cache if it's a virtual pof (always reload these) or we don't have it cached
 		if ((vp_it != virtual_pofs.end() && (int)vp_it->second.size() > depth[pof_name]) || it == cache.end()) {
-			auto pmh = ::make_shared<polymodel_holder>(pof_name, depth);
+			auto pmh = std::make_shared<polymodel_holder>(pof_name, depth);
 			if(pmh->needs_emplace)
 				cache.emplace(pof_name, pmh);
 			return pmh;
@@ -340,7 +340,7 @@ VirtualPOFOperationAddSubmodel::VirtualPOFOperationAddSubmodel() {
 	}
 
 	if (optional_string("$Rename Subobjects:")) {
-		rename = make_unique<VirtualPOFOperationRenameSubobjects>();
+		rename = std::make_unique<VirtualPOFOperationRenameSubobjects>();
 	}
 
 	required_string("+Destination Subobject:");

--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -1290,7 +1290,7 @@ bool multi_fs_tracker_validate_mission_list(SCP_vector<multi_create_info> &file_
 			cf_chksum_long(entry.filename, &item.crc);
 			item.name = entry.filename;
 
-			vdr.files.push_back(item);
+			vdr.files.push_back(std::move(item));
 			vdr.num_files++;
 
 			packet_size += len;
@@ -1375,7 +1375,7 @@ static int validate_table_list(const SCP_vector<SCP_string> &table_list, int &ga
 			cf_chksum_long(tbl.c_str(), &item.crc);
 			item.name = tbl;
 
-			vdr.files.push_back(item);
+			vdr.files.push_back(std::move(item));
 			vdr.num_files++;
 
 			packet_size += len;

--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -2726,8 +2726,8 @@ void multi_init_oo_and_ship_tracker()
 	temp_sent_to_player.subsystem_z.reserve(MAX_MODEL_SUBSYSTEMS);
 	temp_sent_to_player.subsystem_z.push_back(0.0f);
 
-	temp_netplayer_records.last_sent.push_back(temp_sent_to_player);
-	Oo_info.frame_info.push_back(temp_position_records);
+	temp_netplayer_records.last_sent.push_back(std::move(temp_sent_to_player));
+	Oo_info.frame_info.push_back(std::move(temp_position_records));
 	
 	for (int i = 0; i < MAX_PLAYERS; i++) {
 		Oo_info.player_frame_info.push_back(temp_netplayer_records);

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -2747,7 +2747,7 @@ void multi_pxo_clear_players()
 void multi_pxo_add_player(const char *name)
 {
 	SCP_string new_player = name;
-	Multi_pxo_players.push_back(new_player);
+	Multi_pxo_players.push_back(std::move(new_player));
 }
 
 /**

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -8783,7 +8783,7 @@ void process_flak_fired_packet(ubyte *data, header *hinfo)
 			//spawn particle effect
 			auto particleSource = particle::ParticleManager::get()->createSource(wip.muzzle_effect);
 			//This could potentially be attached to the ship, but might look weird if the spawn position of the weapon is ever interpolated away from the ship's barrel.
-			particleSource->setHost(make_unique<EffectHostVector>(pos, orient, objp->phys_info.vel));
+			particleSource->setHost(std::make_unique<EffectHostVector>(pos, orient, objp->phys_info.vel));
 			particleSource->setTriggerRadius(wp_obj.radius * radius_mult);
 			particleSource->setTriggerVelocity(vm_vec_mag_quick(&wp_obj.phys_info.vel));
 			particleSource->finishCreation();

--- a/code/network/psnet2.cpp
+++ b/code/network/psnet2.cpp
@@ -1085,13 +1085,13 @@ static bool psnet_explode_ip_string(const char *ip_string, SCP_string &host, SCP
 
 	// if it has no dots then assume it's just IPv6
 	if (dot == SCP_string::npos) {
-		host = ip;
+		host = std::move(ip);
 		return true;
 	}
 
 	// if colon before dots then it's likely mapped IPv4
 	if ( (colon != SCP_string::npos) && (dot != SCP_string::npos) && (colon < dot) ) {
-		host = ip;
+		host = std::move(ip);
 		return true;
 	}
 

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -702,7 +702,7 @@ static std::tuple<bool, bool, ship_weapon_collision_data> prop_weapon_check_coll
 			bool recheck = false;
 			// most of this data is irrevelant for props but let's match it to make it easy
 			ship_weapon_collision_data cd{mc, -1, postproc, -1, -1, ZERO_VECTOR, false, false};
-			return {postproc, recheck, cd};
+			return {postproc, recheck, std::move(cd)};
 		}
 	}
 
@@ -713,7 +713,7 @@ static std::tuple<bool, bool, ship_weapon_collision_data> prop_weapon_check_coll
 	// most of this data is irrevelant for props but let's match it to make it easy
 	ship_weapon_collision_data cd{(valid_hit_occurred ? mc : mc_info{}), -1, postproc, -1, -1, ZERO_VECTOR, false, false};
 
-	return{postproc, recheck, cd};
+	return{postproc, recheck, std::move(cd)};
 }
 
 static void prop_weapon_process_collision(obj_pair* pair, const ship_weapon_collision_data& cd)

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -1903,7 +1903,7 @@ void obj_queue_render(object* obj, model_draw_list* scene)
 
 		// Always execute the hook content
 		bool skip_render = scripting::hooks::OnObjectRender->isOverride(scripting::hooks::ObjectDrawConditions{ obj }, param_list);
-		scripting::hooks::OnObjectRender->run(scripting::hooks::ObjectDrawConditions{ obj }, param_list);
+		scripting::hooks::OnObjectRender->run(scripting::hooks::ObjectDrawConditions{ obj }, std::move(param_list));
 
 		// Clear the render scene context
 		scripting::api::Current_scene = nullptr;

--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -608,7 +608,7 @@ class OptionBuilder {
 			_instance.setPreset(val.first, json_dump_string_new(_instance.getSerializer()(val.second),
 			                                                    JSON_COMPACT | JSON_ENSURE_ASCII | JSON_ENCODE_ANY));
 		}
-		auto opt_ptr = make_shared<Option<T>>(_instance);
+		auto opt_ptr = std::make_shared<Option<T>>(_instance);
 
 		if (std::holds_alternative<std::pair<const char*, int>>(_title)) {
 			const auto& xstr_info = std::get<std::pair<const char*, int>>(_title);

--- a/code/options/Option.h
+++ b/code/options/Option.h
@@ -532,8 +532,8 @@ class OptionBuilder {
 			display_mapping.emplace(p.first, p.second);
 		}
 
-		_instance.setValueEnumerator(VectorEnumerator<T>(values));
-		_instance.setDisplayFunc(MapValueDisplay<T>(display_mapping));
+		_instance.setValueEnumerator(VectorEnumerator<T>(std::move(values)));
+		_instance.setDisplayFunc(MapValueDisplay<T>(std::move(display_mapping)));
 		return *this;
 	}
 	//The string to display for the option values, usually a function that returns a string

--- a/code/options/OptionsManager.cpp
+++ b/code/options/OptionsManager.cpp
@@ -265,7 +265,7 @@ void OptionsManager::set_ingame_binary_option(SCP_string key, bool value)
 		return;
 	}
 
-	const OptionBase* thisOpt = getOptionByKey(key);
+	const OptionBase* thisOpt = getOptionByKey(std::move(key));
 	if (thisOpt != nullptr) {
 		auto val = thisOpt->getCurrentValueDescription();
 		SCP_string newVal = value ? "true" : "false"; // OptionsManager stores values as serialized strings
@@ -281,7 +281,7 @@ void OptionsManager::set_ingame_multi_option(SCP_string key, int value)
 		return;
 	}
 
-	const OptionBase* thisOpt = getOptionByKey(key);
+	const OptionBase* thisOpt = getOptionByKey(std::move(key));
 	if (thisOpt != nullptr) {
 		auto values = thisOpt->getValidValues();
 		thisOpt->setValueDescription(values[value]);
@@ -296,7 +296,7 @@ void OptionsManager::set_ingame_range_option(SCP_string key, int value)
 		return;
 	}
 
-	const OptionBase* thisOpt = getOptionByKey(key);
+	const OptionBase* thisOpt = getOptionByKey(std::move(key));
 	if (thisOpt != nullptr) {
 		SCP_string newVal = std::to_string(value); // OptionsManager stores values as serialized strings
 		thisOpt->setValueDescription({newVal.c_str(), newVal.c_str()});
@@ -311,7 +311,7 @@ void OptionsManager::set_ingame_range_option(SCP_string key, float value)
 		return;
 	}
 
-	const OptionBase* thisOpt = getOptionByKey(key);
+	const OptionBase* thisOpt = getOptionByKey(std::move(key));
 	if (thisOpt != nullptr) {
 		SCP_string newVal = std::to_string(value); // OptionsManager stores values as serialized strings
 		thisOpt->setValueDescription({newVal.c_str(), newVal.c_str()});

--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -3649,7 +3649,7 @@ void pause_parse()
 	Mark.Warning_count = Warning_count;
 	Mark.Error_count = Error_count;
 
-	Bookmarks.push_back(Mark);
+	Bookmarks.push_back(std::move(Mark));
 }
 
 // unpause parsing to continue with previously parsing file

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -28106,7 +28106,7 @@ void add_to_event_log_buffer(int node, int op_num, int result)
 		}
 	}
 
-	Current_event_log_buffer->push_back(tmp);
+	Current_event_log_buffer->push_back(std::move(tmp));
 }
 
 /**

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -134,7 +134,7 @@ void LuaAISEXP::parseTable() {
 
 
 	if (optional_string("$Player Order:")) {
-		playerOrder = std::unique_ptr<player_order_lua>(new player_order_lua());
+		playerOrder = std::make_unique<player_order_lua>();
 		auto &order = *playerOrder;
 		if (_arg_type != OPF_SHIP && _arg_type != -1) {
 			error_display(1, "Player orders must have either no target or a ship-type target parameter!");

--- a/code/parse/sexp/LuaAISEXP.cpp
+++ b/code/parse/sexp/LuaAISEXP.cpp
@@ -265,10 +265,10 @@ void LuaAISEXP::parseTable() {
 		}
 
 		if (variable_arg_part) {
-			_varargs_type_pattern.push_back(type);
+			_varargs_type_pattern.push_back(std::move(type));
 		}
 		else {
-			_argument_types.push_back(type);
+			_argument_types.push_back(std::move(type));
 		}
 
 		if (optional_string("$Repeat")) {

--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -756,7 +756,7 @@ void LuaSEXP::parseTable() {
 				if (skip)
 					continue;
 
-				thisList.list.push_back(item);
+				thisList.list.push_back(std::move(item));
 			}
 
 			if (thisList.list.size() == 0) {
@@ -810,7 +810,7 @@ void LuaSEXP::parseTable() {
 				dyn_param.operator_name = _name;
 				dyn_param.parameter_map.push_back(param_map);
 
-				Dynamic_parameters.push_back(dyn_param);
+				Dynamic_parameters.push_back(std::move(dyn_param));
 			}
 		}
 		else if (parent_param_index >= 0)
@@ -832,14 +832,14 @@ void LuaSEXP::parseTable() {
 			if (optional_string("+Suffix:")) {
 				SCP_string suffix;
 				stuff_string(suffix, F_NAME);
-				Dynamic_enum_suffixes.push_back({_name, param_index, suffix});
+				Dynamic_enum_suffixes.push_back({_name, param_index, std::move(suffix)});
 			}
 		}
 
 		if (variable_arg_part) {
-			_varargs_type_pattern.push_back(type);
+			_varargs_type_pattern.push_back(std::move(type));
 		} else {
-			_argument_types.push_back(type);
+			_argument_types.push_back(std::move(type));
 		}
 
 		if (optional_string("$Repeat")) {

--- a/code/parse/sexp/sexp_lookup.cpp
+++ b/code/parse/sexp/sexp_lookup.cpp
@@ -88,7 +88,7 @@ void parse_sexp_table(const char* filename) {
 					if (skip)
 						continue;
 
-					thisList.list.push_back(item);
+					thisList.list.push_back(std::move(item));
 				}
 
 				if (thisList.list.size() > 0) {

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -587,7 +587,7 @@ namespace particle {
 				case ParticleEffectLegacyType::Sphere: {
 					parseParticleProperties(effect);
 
-					effect.m_velocityVolume = make_shared<SpheroidVolume>(1.f, 1.f, 1.f);
+					effect.m_velocityVolume = std::make_shared<SpheroidVolume>(1.f, 1.f, 1.f);
 
 					parseVelocityVolumeScale<false>(effect);
 					parseParticleNumber<false>(effect);
@@ -657,7 +657,7 @@ namespace particle {
 						}
 					}
 
-					effect.m_spawnVolume = make_shared<SpheroidVolume>(bias, stretch, radius);
+					effect.m_spawnVolume = std::make_shared<SpheroidVolume>(bias, stretch, radius);
 
 					parseVelocityInherit<false>(effect);
 					parseTiming<false>(effect);

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -895,7 +895,7 @@ void pilotfile::csg_read_redalert()
 
 			// this is quite likely a *bad* thing if it doesn't happen
 			if (ras.ship_class >= RED_ALERT_LOWEST_VALID_SHIP_CLASS) {
-				Red_alert_ship_status.push_back( ras );
+				Red_alert_ship_status.push_back( std::move(ras) );
 			}
 		}
 	}
@@ -924,7 +924,7 @@ void pilotfile::csg_read_redalert()
 			rws.total_destroyed = cfread_int(cfp);
 			rws.total_vanished = cfread_int(cfp);
 
-			Red_alert_wing_status.push_back(rws);
+			Red_alert_wing_status.push_back(std::move(rws));
 		}
 	}
 

--- a/code/pilotfile/csg_convert.cpp
+++ b/code/pilotfile/csg_convert.cpp
@@ -477,7 +477,7 @@ void pilotfile_convert::csg_import_red_alert()
 		}
 
 		// add to list
-		csg->wingman_status.push_back( ras );
+		csg->wingman_status.push_back( std::move(ras) );
 	}
 }
 

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -64,7 +64,7 @@ void read_multi_stats(pilot::FileHandler* handler, scoring_special_t* scoring) {
 		ilist.index = ship_info_lookup(ilist.name.c_str());
 		ilist.val = handler->readInt("val");
 
-		scoring->ship_kills.push_back(ilist);
+		scoring->ship_kills.push_back(std::move(ilist));
 	}
 	handler->endArrayRead();
 
@@ -78,7 +78,7 @@ void read_multi_stats(pilot::FileHandler* handler, scoring_special_t* scoring) {
 		ilist.index = medals_info_lookup(ilist.name.c_str());
 		ilist.val = handler->readInt("val");
 
-		scoring->medals_earned.push_back(ilist);
+		scoring->medals_earned.push_back(std::move(ilist));
 	}
 	handler->endArrayRead();
 }

--- a/code/prop/prop.cpp
+++ b/code/prop/prop.cpp
@@ -133,7 +133,7 @@ void parse_prop_table(const char* filename)
 			if (existing != Prop_categories.end()) {
 				*existing = pc; // Replace
 			} else {
-				Prop_categories.push_back(pc); // Add new
+				Prop_categories.push_back(std::move(pc)); // Add new
 			}
 		}
 	}
@@ -346,7 +346,7 @@ void parse_prop_table(const char* filename)
 				required_string("+String:");
 				stuff_string(cs.text, F_MULTITEXT);
 
-				pip->custom_strings.push_back(cs);
+				pip->custom_strings.push_back(std::move(cs));
 			}
 
 			required_string("$end_custom_strings");
@@ -378,7 +378,7 @@ void post_process_props()
 		prop_category pc;
 		pc.name = UnknownCategory;
 		gr_init_color(&pc.list_color, 128, 128, 128);
-		Prop_categories.push_back(pc);
+		Prop_categories.push_back(std::move(pc));
 	}
 
 	// Sort props by category order from Prop_categories, preserving internal order

--- a/code/scpui/RocketLuaSystemInterface.cpp
+++ b/code/scpui/RocketLuaSystemInterface.cpp
@@ -66,7 +66,7 @@ void RocketLuaSystemInterface::PrepareFunction(lua_State* L, int funcIdx, Rocket
 		static_cast<LuaTableReference*>(context->GetOwnerDocument()->GetUserValue(LuaEnvironmentIdentifier));
 
 	if (envTable == nullptr) {
-		auto reference = std::unique_ptr<LuaTableReference>(new LuaTableReference(createEnvironment(L)));
+		auto reference = std::make_unique<LuaTableReference>(createEnvironment(L));
 		envTable = reference.get();
 
 		context->GetOwnerDocument()->PutUserValue(LuaEnvironmentIdentifier, std::move(reference));

--- a/code/scpui/rocket_ui.cpp
+++ b/code/scpui/rocket_ui.cpp
@@ -678,7 +678,7 @@ void reloadContext(Rocket::Core::Context* context)
 		status.visible   = doc->IsVisible();
 		status.focus     = doc->GetFocusLeafNode() != nullptr;
 
-		documents.push_back(status);
+		documents.push_back(std::move(status));
 	}
 
 	Factory::ClearStyleSheetCache();

--- a/code/scripting/ade.cpp
+++ b/code/scripting/ade.cpp
@@ -582,7 +582,7 @@ std::unique_ptr<DocumentationElement> ade_table_entry::ToDocumentationElement(
 				overloadArgList.simple.assign(overload);
 			}
 
-			obj->overloads.push_back(overloadArgList);
+			obj->overloads.push_back(std::move(overloadArgList));
 		}
 
 		if (ReturnDescription != nullptr) {

--- a/code/scripting/api/libs/async.cpp
+++ b/code/scripting/api/libs/async.cpp
@@ -332,7 +332,7 @@ ADE_FUNC(yield,
 		explicit yield_resolve_context(executor::Executor* executor) : m_exec(executor) {}
 		void setResolver(Resolver resolver) override
 		{
-			m_exec->post([resolver]() {
+			m_exec->post([resolver = std::move(resolver)]() {
 				resolver(false, luacpp::LuaValueList());
 				return executor::Executor::CallbackResult::Done;
 			});

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -2893,7 +2893,7 @@ ADE_FUNC(addLuaEnum,
 		dynamic_sexp_enum_list this_list;
 		this_list.name = enum_name;
 
-		Dynamic_enums.push_back(this_list);
+		Dynamic_enums.push_back(std::move(this_list));
 
 		idx = get_dynamic_enum_position(enum_name);
 
@@ -3156,7 +3156,7 @@ ADE_FUNC(waitAsync,
 		{
 			// Keep checking the time until the timestamp is elapsed
 			auto self = shared_from_this();
-			auto cb = [this, self, resolver](
+			auto cb = [this, self, resolver = std::move(resolver)](
 						  executor::IExecutionContext::State contextState) {
 				if (contextState == executor::IExecutionContext::State::Invalid) {
 					mprintf(("waitAsync: Context is invalid, possibly due to a game state change (current state is %s).  Aborting asynchronous context %d.\n", GS_state_text[gameseq_get_state()], m_unique_id));

--- a/code/scripting/api/libs/options.cpp
+++ b/code/scripting/api/libs/options.cpp
@@ -134,7 +134,7 @@ ADE_FUNC(writeIPAddressTable, l_Options, "table", "Saves the table to the multip
 				// then carry on
 				try {
 					SCP_string ip = item.second.getValue<SCP_string>();
-					list.push_back(ip);
+					list.push_back(std::move(ip));
 				} catch (const luacpp::LuaException& /*e*/) {
 					// We were likely fed a userdata that was not an string.
 					// Since we can't actually tell whether that's the case before we try to get the value, and the

--- a/code/scripting/api/objs/executor.cpp
+++ b/code/scripting/api/objs/executor.cpp
@@ -40,7 +40,7 @@ ADE_FUNC(schedule,
 	}
 
 	// Post the function onto the executor with a wrapper to convert the Lua value to the proper enum
-	executor->getExecutor()->post([L, func]() {
+	executor->getExecutor()->post([L, func = std::move(func)]() {
 		const auto ret = func(L);
 
 		if (ret.empty()) {

--- a/code/scripting/api/objs/modelinstance.cpp
+++ b/code/scripting/api/objs/modelinstance.cpp
@@ -83,7 +83,7 @@ ADE_INDEXER(l_ModelInstanceTextures, "number/string IndexOrTextureFilename", "Ar
 
 	if (ADE_SETTING_VAR) {
 		if (pmi->texture_replace == nullptr) {
-			pmi->texture_replace = make_shared<model_texture_replace>();
+			pmi->texture_replace = std::make_shared<model_texture_replace>();
 		}
 
 		if (tdx != nullptr) {

--- a/code/scripting/api/objs/promise.cpp
+++ b/code/scripting/api/objs/promise.cpp
@@ -38,7 +38,7 @@ ADE_FUNC(continueWith,
 
 	return ade_set_args(L,
 		"o",
-		l_Promise.Set(promise->then([L, thenFunc](const luacpp::LuaValueList& val) { return thenFunc(L, val); })));
+		l_Promise.Set(promise->then([L, thenFunc = std::move(thenFunc)](const luacpp::LuaValueList& val) { return thenFunc(L, val); })));
 }
 
 ADE_FUNC(catch,
@@ -64,7 +64,7 @@ ADE_FUNC(catch,
 		return ADE_RETURN_NIL;
 	}
 
-	return ade_set_args(L, "o", l_Promise.Set(promise->catchError([L, thenFunc](const luacpp::LuaValueList& val) {
+	return ade_set_args(L, "o", l_Promise.Set(promise->catchError([L, thenFunc = std::move(thenFunc)](const luacpp::LuaValueList& val) {
 		return thenFunc(L, val);
 	})));
 }

--- a/code/scripting/api/objs/rpc.cpp
+++ b/code/scripting/api/objs/rpc.cpp
@@ -132,7 +132,7 @@ ADE_FUNC(waitRPC,
 		{
 			// Keep checking the time until the timestamp is elapsed
 			auto self = shared_from_this();
-			auto cb = [this, self, resolver](
+			auto cb = [this, self, resolver = std::move(resolver)](
 				executor::IExecutionContext::State contextState) {
 					if (contextState == executor::IExecutionContext::State::Invalid) {
 						mprintf(("waitRPC: Context is invalid, possibly due to a game state change (current state is %s). Aborting asynchronous context %d.\n", GS_state_text[gameseq_get_state()], m_unique_id));

--- a/code/scripting/doc_luastub.cpp
+++ b/code/scripting/doc_luastub.cpp
@@ -97,7 +97,7 @@ SCP_string create_function_alias(const ade_type_info& type_info, SCP_string alia
 		aliasName += "_" + std::to_string(dupCount++);
 	}
 
-	Aliases.emplace_back(aliasName, alias);
+	Aliases.emplace_back(aliasName, std::move(alias));
 
 	return aliasName;
 }

--- a/code/scripting/hook_conditions.cpp
+++ b/code/scripting/hook_conditions.cpp
@@ -16,7 +16,7 @@
 #define HOOK_CONDITIONS_END return build; \
 }();
 #define HOOK_CONDITION(conditionsClassName, conditionParseName, documentation, argument, argumentParse, argumentValid) \
-	build.emplace(conditionParseName, ::make_unique<ParseableConditionImpl<conditionsClassName, \
+	build.emplace(conditionParseName, std::make_unique<ParseableConditionImpl<conditionsClassName, \
 		decltype(std::declval<conditionsClassName>().argument), decltype(argumentParse(std::declval<SCP_string>()))>> \
 		(documentation, &conditionsClassName::argument, argumentParse, argumentValid))
 
@@ -36,7 +36,7 @@ class ParseableConditionImpl : public ParseableCondition {
 	template<typename _conditions_t, typename _operating_t, typename _cache_t> friend class EvaluatableConditionImpl;
 public:
 	std::unique_ptr<EvaluatableCondition> parse(const SCP_string& input) const override {
-		return ::make_unique<EvaluatableConditionImpl<conditions_t, operating_t, cache_t>>(*this, input);
+		return std::make_unique<EvaluatableConditionImpl<conditions_t, operating_t, cache_t>>(*this, input);
 	}
 
 	ParseableConditionImpl(SCP_string documentation_, const operating_t conditions_t::* object_, std::function<cache_t(const SCP_string&)> cache_, std::function<bool(operating_t, const cache_t&)> evaluate_) :

--- a/code/scripting/hook_conditions.h
+++ b/code/scripting/hook_conditions.h
@@ -27,7 +27,7 @@ public:
 	SCP_string documentation;
 
 	virtual std::unique_ptr<EvaluatableCondition> parse(const SCP_string& /*input*/) const {
-		return make_unique<EvaluatableCondition>();
+		return std::make_unique<EvaluatableCondition>();
 	};
 
 	ParseableCondition() : documentation("Invalid Condition. Will never evaluate.") { }

--- a/code/scripting/lua.cpp
+++ b/code/scripting/lua.cpp
@@ -314,7 +314,7 @@ void script_state::OutputLuaDocumentation(ScriptingDocumentation& doc,
 		e.name = Enumerations[i].name;
 		e.value = Enumerations[i].def;
 
-		doc.enumerations.push_back(e);
+		doc.enumerations.push_back(std::move(e));
 	}
 
 	auto& optionsList = options::OptionsManager::instance()->getOptions();
@@ -326,7 +326,7 @@ void script_state::OutputLuaDocumentation(ScriptingDocumentation& doc,
 		o.description = thisOpt->getDescription();
 		o.key = thisOpt->getConfigKey();
 
-		doc.options.push_back(o);
+		doc.options.push_back(std::move(o));
 	}
 }
 

--- a/code/scripting/lua/LuaThread.cpp
+++ b/code/scripting/lua/LuaThread.cpp
@@ -19,9 +19,9 @@ LuaThread LuaThread::create(lua_State* L, const LuaFunction& func)
 	//Usually we'd want to do this when the childs references are GC'd, but creating tables on child threads from C causes tests to fail for some reason.
 	auto threadRef = std::weak_ptr<UniqueLuaReference>(thread.getReference());
 	//These must be pointers to weak pointers, as we cannot know the weak pointers before creating the lambda.
-	auto delFuncRef = make_shared<std::weak_ptr<UniqueLuaReference>>();
-	auto delTabRef = make_shared<std::weak_ptr<UniqueLuaReference>>();
-	auto delUserdataRef = make_shared<std::weak_ptr<UniqueLuaReference>>();
+	auto delFuncRef = std::make_shared<std::weak_ptr<UniqueLuaReference>>();
+	auto delTabRef = std::make_shared<std::weak_ptr<UniqueLuaReference>>();
+	auto delUserdataRef = std::make_shared<std::weak_ptr<UniqueLuaReference>>();
 
 	int stack = lua_gettop(L);
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6939,7 +6939,7 @@ void ship_add_exited_ship( ship *sp, Ship::Exit_Flags reason )
 	if (ship_it != Ship_registry_map.end())
 		Ship_registry[ship_it->second].exited_index = static_cast<int>(Ships_exited.size());
 
-	Ships_exited.push_back(entry);
+	Ships_exited.push_back(std::move(entry));
 }
 
 /**
@@ -21118,7 +21118,7 @@ void parse_armor_type()
 		parse_string_flag_list(tat.flags, Armor_flags, Num_armor_flags);
 	
 	//Add it to global armor types
-	Armor_types.push_back(tat);
+	Armor_types.push_back(std::move(tat));
 }
 
 void armor_parse_table(const char *filename)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -2623,7 +2623,7 @@ particle::ParticleEffectHandle create_ship_legacy_particle_effect(LegacyShipPart
 		break;
 	}
 
-	auto velocity_volume = make_shared<particle::LegacyAACuboidVolume>(normal_variance, 1.f, true);
+	auto velocity_volume = std::make_shared<particle::LegacyAACuboidVolume>(normal_variance, 1.f, true);
 	if (variance_curve) {
 		velocity_volume->m_modular_curves.add_curve("Host Radius", particle::LegacyAACuboidVolume::VolumeModularCurveOutput::VARIANCE, *variance_curve);
 	}
@@ -5080,7 +5080,7 @@ static void parse_ship_values(ship_info* sip, const bool is_template, const bool
 				particle::ParticleEffect::ShapeDirection::ALIGNED, //Particle direction
 				::util::UniformFloatRange(1.f), //Velocity Inherit
 				true, //Velocity Inherit absolute?
-				make_unique<particle::LegacyAACuboidVolume>(variance, 1.f, true), //Velocity volume
+				std::make_unique<particle::LegacyAACuboidVolume>(variance, 1.f, true), //Velocity volume
 				::util::UniformFloatRange(0.75f, 1.25f), //Velocity volume multiplier
 				particle::ParticleEffect::VelocityScaling::NONE, //Velocity directional scaling
 				std::nullopt, //Orientation-based velocity
@@ -7434,7 +7434,7 @@ void ship::apply_replacement_textures(const SCP_vector<texture_replace> &replace
 
 	polymodel_instance* pmi = model_get_instance(model_instance_num);
 
-	pmi->texture_replace = make_shared<model_texture_replace>();
+	pmi->texture_replace = std::make_shared<model_texture_replace>();
 
 	auto pm = model_get(Ship_info[ship_info_index].model_num);
 
@@ -8675,7 +8675,7 @@ void ship_init_cockpit_displays(ship *shipp)
 	}
 
 	// ship's cockpit texture replacements haven't been setup yet, so do it.
-	Player_cockpit_textures = make_shared<model_texture_replace>();
+	Player_cockpit_textures = std::make_shared<model_texture_replace>();
 
 	for ( auto& display : sip->displays ) {
 		ship_add_cockpit_display(&display, cockpit_model_num);
@@ -11864,7 +11864,7 @@ static void ship_model_change(int n, int ship_type)
 	if ( !sip->replacement_textures.empty() ) {
 
 		// clear and reset replacement textures because the new positions may be different
-		pmi->texture_replace = make_shared<model_texture_replace>();
+		pmi->texture_replace = std::make_shared<model_texture_replace>();
 		auto& texture_replace_deref = *pmi->texture_replace;
 
 		// now fill them in according to texture name

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -542,7 +542,7 @@ void shipfx_warpin_start( object *objp )
 		auto params = scripting::hook_param_list(scripting::hook_param("Self", 'o', objp));
 		auto conditions = scripting::hooks::ShipSourceConditions{ shipp };
 		if (OnWarpInHook->isOverride(conditions, params)) {
-			OnWarpInHook->run(conditions, params);
+			OnWarpInHook->run(conditions, std::move(params));
 			return;
 		}
 	}
@@ -562,7 +562,7 @@ void shipfx_warpin_start( object *objp )
 	{
 		auto params = scripting::hook_param_list(scripting::hook_param("Self", 'o', objp));
 		auto conditions = scripting::hooks::ShipSourceConditions{ shipp };
-		OnWarpInHook->run(conditions, params);
+		OnWarpInHook->run(conditions, std::move(params));
 	}
 }
 
@@ -705,7 +705,7 @@ void shipfx_warpout_start( object *objp )
 		auto params = scripting::hook_param_list(scripting::hook_param("Self", 'o', objp));
 		auto conditions = scripting::hooks::ShipSourceConditions{ shipp };
 		if (OnWarpOutHook->isOverride(conditions, params)) {
-			OnWarpOutHook->run(conditions, params);
+			OnWarpOutHook->run(conditions, std::move(params));
 			return;
 		}
 	}
@@ -747,7 +747,7 @@ void shipfx_warpout_start( object *objp )
 	if (OnWarpOutHook->isActive()) {
 		auto params = scripting::hook_param_list(scripting::hook_param("Self", 'o', objp));
 		auto conditions = scripting::hooks::ShipSourceConditions{ shipp };
-		OnWarpOutHook->run(conditions, params);
+		OnWarpOutHook->run(conditions, std::move(params));
 	}
 }
 

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1097,7 +1097,7 @@ void shipfx_flash_create(object *objp, int model_num, vec3d *gun_pos, vec3d *gun
 				// spawn particle effect
 				auto particleSource = particle::ParticleManager::get()->createSource(Weapon_info[weapon_info_index].muzzle_effect);
 				//This should probably end up attached to the subobject, not the object, but it's not that much of a problem since primaries / secondaries rarely move.
-				particleSource->setHost(make_unique<EffectHostObject>(objp, *gun_pos, gunOrient, true));
+				particleSource->setHost(std::make_unique<EffectHostObject>(objp, *gun_pos, gunOrient, true));
 
 				auto *weapon_objp = &Objects[weapon_objnum];
 				auto *wp = &Weapons[weapon_objp->instance];

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -1917,7 +1917,7 @@ void ship_hit_kill(object *ship_objp, object *other_obj, const vec3d *hitpos, fl
 				hitpos != nullptr));
 
 		if (scripting::hooks::OnShipDeath->isOverride(scripting::hooks::ShipDeathConditions{ sp }, onDeathParamList)) {
-			scripting::hooks::OnShipDeath->run(scripting::hooks::ShipDeathConditions{ sp }, onDeathParamList);
+			scripting::hooks::OnShipDeath->run(scripting::hooks::ShipDeathConditions{ sp }, std::move(onDeathParamList));
 			return;
 		}
 	}

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -181,7 +181,7 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, const vec3d* 
 			vm_vec_normalize(&normalized_center_to_subsys);
 			// spawn particle effect
 			auto source = particle::ParticleManager::get()->createSource(death_effect);
-			source->setHost(make_unique<EffectHostObject>(ship_objp, subsys_local_pos, vmd_identity_matrix));
+			source->setHost(std::make_unique<EffectHostObject>(ship_objp, subsys_local_pos, vmd_identity_matrix));
 			source->setTriggerRadius(psub->radius);
 			source->setNormal(normalized_center_to_subsys);
 			source->finishCreation();

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -1751,7 +1751,7 @@ int ds_eax_get_prop(EFXREVERBPROPERTIES **props, const char *name, const char *t
 			n_prop.iDecayHFLimit = AL_TRUE;
 		}
 
-		EFX_presets.push_back( n_prop );
+		EFX_presets.push_back( std::move(n_prop) );
 
 		*props = &EFX_presets[id];
 	}

--- a/code/sound/openal.cpp
+++ b/code/sound/openal.cpp
@@ -300,7 +300,7 @@ static void find_playback_device(OpenALInformation* info)
 			new_device.type = OAL_DEVICE_DEFAULT;
 		}
 
-		PlaybackDevices.push_back( new_device );
+		PlaybackDevices.push_back( std::move(new_device) );
 	}
 
 	if ( PlaybackDevices.empty() ) {
@@ -412,7 +412,7 @@ static void find_capture_device(OpenALInformation* info)
 			new_device.type = OAL_DEVICE_DEFAULT;
 		}
 
-		CaptureDevices.push_back( new_device );
+		CaptureDevices.push_back( std::move(new_device) );
 	}
 
 	if ( CaptureDevices.empty() ) {

--- a/code/species_defs/species_defs.cpp
+++ b/code/species_defs/species_defs.cpp
@@ -366,7 +366,7 @@ void parse_species_tbl(const char *filename)
 
 			// don't add new entry if this is just a modified one
 			if (!no_create)
-				Species_info.push_back(new_species);
+				Species_info.push_back(std::move(new_species));
 		}
 
 		required_string("#END");

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -455,7 +455,7 @@ void parse_startbl(const char *filename)
 					}
 				}
 				else {
-					Starfield_bitmaps.push_back(sbm);
+					Starfield_bitmaps.push_back(std::move(sbm));
 				}
 			}
 
@@ -564,7 +564,7 @@ void parse_startbl(const char *filename)
 						Warning(LOCATION, "Sun bitmap '%s' listed more than once!!  Only using the first entry!", sbm.filename);
 				}
 				else {
-					Sun_bitmaps.push_back(sbm);
+					Sun_bitmaps.push_back(std::move(sbm));
 				}
 			}
 
@@ -594,7 +594,7 @@ void parse_startbl(const char *filename)
 					}
 				}
 				if (count == MAX_MOTION_DEBRIS_BITMAPS) {
-					Motion_debris_info.push_back(this_debris);
+					Motion_debris_info.push_back(std::move(this_debris));
 				} else {
 					error_display(0, "Not enough bitmaps defined for motion debris '%s'. Skipping!\n", this_debris.name.c_str());
 				}
@@ -624,7 +624,7 @@ void parse_startbl(const char *filename)
 					}
 				}
 				if (count == MAX_MOTION_DEBRIS_BITMAPS) {
-					Motion_debris_info.push_back(this_debris);
+					Motion_debris_info.push_back(std::move(this_debris));
 				} else {
 					error_display(0, "Not enough bitmaps defined for motion debris '%s'. Skipping!\n", this_debris.name.c_str());
 				}
@@ -654,7 +654,7 @@ void parse_startbl(const char *filename)
 						this_debris.bitmaps[i].name[0] = '\0';
 					}
 
-					Motion_debris_info.push_back(this_debris);
+					Motion_debris_info.push_back(std::move(this_debris));
 					check = static_cast<int>(Motion_debris_info.size()) - 1;
 				}
 

--- a/code/starfield/supernova.cpp
+++ b/code/starfield/supernova.cpp
@@ -54,7 +54,7 @@ static particle::ParticleEffectHandle supernova_init_particle() {
 			particle::ParticleEffect::ShapeDirection::ALIGNED, //Particle direction
 			::util::UniformFloatRange(1.f), //Velocity Inherit
 			false, //Velocity Inherit absolute?
-			make_unique<particle::LegacyAACuboidVolume>(0.75f, 1.f, true), //Velocity volume
+			std::make_unique<particle::LegacyAACuboidVolume>(0.75f, 1.f, true), //Velocity volume
 			::util::UniformFloatRange(25.f, 50.f), //Velocity volume multiplier
 			particle::ParticleEffect::VelocityScaling::NONE, //Velocity directional scaling
 			std::nullopt, //Orientation-based velocity
@@ -174,11 +174,11 @@ void supernova_do_particles()
 			vm_vec_add2(&b, &Player_obj->pos);
 
 			auto source = particle::ParticleManager::get()->createSource(Supernova_particle_effect);
-			source->setHost(make_unique<EffectHostVector>(a, orient, vel));
+			source->setHost(std::make_unique<EffectHostVector>(a, orient, vel));
 			source->finishCreation();
 
 			auto source2 = particle::ParticleManager::get()->createSource(Supernova_particle_effect);
-			source2->setHost(make_unique<EffectHostVector>(b, orient, vel));
+			source2->setHost(std::make_unique<EffectHostVector>(b, orient, vel));
 			source2->finishCreation();
 		}
 	}

--- a/code/stats/medals.cpp
+++ b/code/stats/medals.cpp
@@ -315,9 +315,9 @@ void parse_medals_table(const char* filename)
 					continue;
 				}
 
-				Medals.push_back(medal_t);
+				Medals.push_back(std::move(medal_t));
 				medal_p = &Medals[Medals.size() - 1];
-				Medal_display_info.push_back(display_t);
+				Medal_display_info.push_back(std::move(display_t));
 				display_p = &Medal_display_info[Medal_display_info.size() - 1];
 			}
 

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -145,7 +145,7 @@ void parse_rank_table(const char* filename)
 					}
 					continue;
 				}
-				Ranks.push_back(rank_t);
+				Ranks.push_back(std::move(rank_t));
 				rank_p = &Ranks.back();
 			}
 

--- a/code/tracing/FrameProfiler.cpp
+++ b/code/tracing/FrameProfiler.cpp
@@ -53,7 +53,7 @@ void process_begin(SCP_vector<profile_sample>& samples, const trace_event& evt) 
 	new_sample.parent = parent;
 	new_sample.num_parents = (parent >= 0) ? 1 : 0;
 
-	samples.push_back(new_sample);
+	samples.push_back(std::move(new_sample));
 }
 
 void process_end(SCP_vector<profile_sample>& samples, const trace_event& evt) {
@@ -227,7 +227,7 @@ void FrameProfiler::store_profile_in_history(SCP_string& name,
 	new_history.valid = true;
 	new_history.avg_micro_sec = new_history.min_micro_sec = new_history.max_micro_sec = time;
 
-	history.push_back(new_history);
+	history.push_back(std::move(new_history));
 }
 void FrameProfiler::dump_output(SCP_stringstream& out,
 								uint64_t  /*start_profile_time*/,

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -293,7 +293,7 @@ static void beam_set_state(weapon_info* wip, beam* bm, WeaponState state)
 	if ((map_entry != wip->state_effects.end()) && map_entry->second.isValid())
 	{
 		auto source = particle::ParticleManager::get()->createSource(map_entry->second);
-		source->setHost(make_unique<EffectHostBeam>(&Objects[bm->objnum]));
+		source->setHost(std::make_unique<EffectHostBeam>(&Objects[bm->objnum]));
 		source->finishCreation();
 	}
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -2363,7 +2363,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 					ParticleEffect::ShapeDirection::ALIGNED, //Particle direction
 					::util::UniformFloatRange(1.f), //Velocity Inherit
 					false, //Velocity Inherit absolute?
-					make_unique<LegacyAACuboidVolume>(variance, 1.f, true), //Velocity volume
+					std::make_unique<LegacyAACuboidVolume>(variance, 1.f, true), //Velocity volume
 					::util::UniformFloatRange(MIN(0.5f * velocity, 2.0f * velocity), MAX(0.5f * velocity, 2.0f * velocity)), //Velocity volume multiplier
 					ParticleEffect::VelocityScaling::NONE, //Velocity directional scaling
 					std::nullopt, //Orientation-based velocity
@@ -2395,7 +2395,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 						ParticleEffect::ShapeDirection::ALIGNED, //Particle direction
 						::util::UniformFloatRange(1.f), //Velocity Inherit
 						false, //Velocity Inherit absolute?
-						make_unique<LegacyAACuboidVolume>(variance, 1.f, true), //Velocity volume
+						std::make_unique<LegacyAACuboidVolume>(variance, 1.f, true), //Velocity volume
 						::util::UniformFloatRange(MIN(0.5f * back_velocity, 2.0f * back_velocity), MAX(0.5f * back_velocity, 2.0f * back_velocity)), //Velocity volume multiplier
 						ParticleEffect::VelocityScaling::NONE, //Velocity directional scaling
 						std::nullopt, //Orientation-based velocity
@@ -3268,7 +3268,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 						ParticleEffect::ShapeDirection::ALIGNED, //Particle direction
 						::util::UniformFloatRange(0.f), //Velocity Inherit
 						false, //Velocity Inherit absolute?
-						make_unique<SpheroidVolume>(1.f, 1.f, 1.f), //Velocity volume
+						std::make_unique<SpheroidVolume>(1.f, 1.f, 1.f), //Velocity volume
 						::util::UniformFloatRange(baseVelocity * variance), //Velocity volume multiplier
 						ParticleEffect::VelocityScaling::NONE, //Velocity directional scaling
 						::util::UniformFloatRange(MIN(baseVelocity, 2.0f * baseVelocity), MAX(baseVelocity, 2.0f * baseVelocity)), //Orientation-based velocity
@@ -3299,7 +3299,7 @@ int parse_weapon(int subtype, bool replace, const char *filename)
 						ParticleEffect::ShapeDirection::ALIGNED, //Particle direction
 						::util::UniformFloatRange(0.f), //Velocity Inherit
 						false, //Velocity Inherit absolute?
-						make_unique<SpheroidVolume>(1.f, 1.f, 1.f), //Velocity volume
+						std::make_unique<SpheroidVolume>(1.f, 1.f, 1.f), //Velocity volume
 						::util::UniformFloatRange(backVelocity * variance), //Velocity volume multiplier
 						ParticleEffect::VelocityScaling::NONE, //Velocity directional scaling
 						::util::UniformFloatRange(MIN(backVelocity, 2.0f * backVelocity), MAX(backVelocity, 2.0f * backVelocity)), //Orientation-based velocity
@@ -6130,7 +6130,7 @@ static void weapon_set_state(weapon_info* wip, weapon* wp, WeaponState state)
 	if ((map_entry != wip->state_effects.end()) && map_entry->second.isValid())
 	{
 		auto source = particle::ParticleManager::get()->createSource(map_entry->second);
-		source->setHost(make_unique<EffectHostObject>(&Objects[wp->objnum], vmd_zero_vector));
+		source->setHost(std::make_unique<EffectHostObject>(&Objects[wp->objnum], vmd_zero_vector));
 		source->finishCreation();
 	}
 
@@ -8809,7 +8809,7 @@ void shield_impact_explosion(const vec3d& hitpos, const vec3d& hitdir, const obj
 	vm_vec_unrotate(&hitdir_global, &hitdir, &objp->orient);
 
 	auto particleSource = particle::ParticleManager::get()->createSource(handle);
-	particleSource->setHost(make_unique<EffectHostObject>(objp, hitpos, localorient));
+	particleSource->setHost(std::make_unique<EffectHostObject>(objp, hitpos, localorient));
 	particleSource->setNormal(hitdir_global);
 	particleSource->setTriggerRadius(radius);
 	particleSource->setTriggerVelocity(vm_vec_mag_quick(&weapon_objp->phys_info.vel));

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -4123,7 +4123,7 @@ void game_do_full_frame(DEBUG_TIMER_SIG const vec3d* offset = nullptr, const mat
 			if (fov_override)
 				g3_set_fov(*fov_override);
 
-			scripting::hooks::OnHudDraw->run(scripting::hooks::ObjectDrawConditions{ Viewer_obj }, scripting_param_list);
+			scripting::hooks::OnHudDraw->run(scripting::hooks::ObjectDrawConditions{ Viewer_obj }, std::move(scripting_param_list));
 		}
 	}
 
@@ -5783,7 +5783,7 @@ void game_enter_state( int old_state, int new_state )
 
 	if(scripting::hooks::OnStateStart->isActive()) {
 		if (scripting::hooks::OnStateStart->isOverride(script_param_list)) {
-			scripting::hooks::OnStateStart->run(script_param_list);
+			scripting::hooks::OnStateStart->run(std::move(script_param_list));
 			return;
 		}
 	}


### PR DESCRIPTION
Addresses ~140 Coverity "Variable copied when it could be moved" defects across 74 files.  Every std::move() targets a local variable whose value is consumed by push_back, emplace, assignment, lambda capture, or a function call and is never read again afterward.

Also use `std::make_shared` and `std::make_unique`, per clang.