### PR TITLE
add orbit camera support to FRED2 and qtFRED

### DIFF
--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -53,6 +53,9 @@
 #include "starfield/starfield.h"
 #include "weapon/weapon.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -92,6 +95,14 @@ int Last_cursor_over = -1;
 int last_x = 0;
 int last_y = 0;
 int Lookat_mode = 0;
+
+// Orbit camera state
+vec3d Orbit_pivot = vmd_zero_vector;
+matrix Orbit_grid_orient = vmd_identity_matrix;
+float Orbit_distance = 200.0f;
+float Orbit_phi = 1.24f;
+float Orbit_theta = 2.25f;
+bool Orbit_active = false;
 int rendering_order[MAX_SHIPS];
 int render_count = 0;
 int Show_asteroid_field = 1;
@@ -1275,6 +1286,124 @@ void move_mouse(int btn, int mdx, int mdy) {
 	}
 }
 
+// ---------- Orbit camera functions ----------
+
+vec3d orbit_camera_get_pivot()
+{
+	vec3d pivot;
+
+	if (query_valid_object()) {
+		// Pivot on current object
+		pivot = Objects[cur_object_index].pos;
+	} else if (!The_grid) {
+		// Pivot on the origin, if no grid
+		pivot = ZERO_VECTOR;
+	} else {
+		// Intersect camera forward ray with the grid plane
+		vec3d *grid_normal = &The_grid->gmatrix.vec.uvec;
+		float denom = vm_vec_dot(grid_normal, &view_orient.vec.fvec);
+
+		if (fl_abs(denom) > 0.0001f) {
+			// t = -(dot(normal, view_pos) + planeD) / dot(normal, fvec)
+			float t = -(vm_vec_dot(grid_normal, &view_pos) + The_grid->planeD) / denom;
+			if (t > 0.0f) {
+				vm_vec_scale_add(&pivot, &view_pos, &view_orient.vec.fvec, t);
+			} else {
+				pivot = The_grid->center;
+			}
+		} else {
+			// Camera is parallel to grid plane; fall back to grid center
+			pivot = The_grid->center;
+		}
+	}
+	return pivot;
+}
+
+void orbit_camera_init_from_current_view(const vec3d *pivot, const matrix *grid_orient)
+{
+	Orbit_pivot = pivot ? *pivot : vmd_zero_vector;
+	Orbit_grid_orient = grid_orient ? *grid_orient : vmd_identity_matrix;
+
+	vec3d offset;
+	vm_vec_sub(&offset, &view_pos, &Orbit_pivot);
+
+	Orbit_distance = vm_vec_mag(&offset);
+	if (Orbit_distance < 1.0f)
+		Orbit_distance = 100.0f;
+
+	// Transform offset into grid-local frame for angle decomposition
+	// In local frame, Y is always "up" (the grid plane normal)
+	vec3d local_offset;
+	vm_vec_rotate(&local_offset, &offset, &Orbit_grid_orient);
+
+	Orbit_phi = acosf(std::clamp(local_offset.xyz.y / Orbit_distance, -1.0f, 1.0f));
+	Orbit_theta = atan2f(local_offset.xyz.z, local_offset.xyz.x);
+	Orbit_active = true;
+}
+
+void orbit_camera_apply()
+{
+	float sp = sinf(Orbit_phi);
+
+	// Build offset in grid-local coordinates (Y = up/normal)
+	vec3d local_pos;
+	local_pos.xyz.x = sp * cosf(Orbit_theta);
+	local_pos.xyz.y = cosf(Orbit_phi);
+	local_pos.xyz.z = sp * sinf(Orbit_theta);
+
+	// Transform back to world space
+	vec3d world_offset;
+	vm_vec_unrotate(&world_offset, &local_pos, &Orbit_grid_orient);
+
+	vm_vec_scale(&world_offset, Orbit_distance);
+	vm_vec_add(&view_pos, &Orbit_pivot, &world_offset);
+
+	// Point camera at pivot, using grid's up vector
+	vec3d look_dir;
+	vm_vec_sub(&look_dir, &Orbit_pivot, &view_pos);
+	if (vm_vec_mag(&look_dir) > 0.001f) {
+		vec3d grid_up = Orbit_grid_orient.vec.uvec;
+		vm_vector_2_matrix(&view_orient, &look_dir, &grid_up, nullptr);
+	}
+}
+
+void orbit_camera_rotate(int dx, int dy)
+{
+	float rot_scale = physics_rot / 300.0f;
+	Orbit_theta += dx / 100.0f * rot_scale;
+	Orbit_phi += dy / 100.0f * rot_scale;
+
+	CLAMP(Orbit_phi, 0.01f, PI - 0.01f);
+
+	orbit_camera_apply();
+}
+
+void orbit_camera_pan(int dx, int dy)
+{
+	float speed_factor = 1.0f + (physics_speed - 1) / 499.0f * 9.0f;
+	float pan_scale = Orbit_distance * 0.002f * speed_factor;
+
+	vec3d pan_delta;
+	vm_vec_copy_scale(&pan_delta, &view_orient.vec.rvec, -(float)dx * pan_scale);
+	vm_vec_scale_add2(&pan_delta, &view_orient.vec.uvec, (float)dy * pan_scale);
+
+	vm_vec_add2(&Orbit_pivot, &pan_delta);
+
+	orbit_camera_apply();
+}
+
+void orbit_camera_zoom(float delta)
+{
+	float zoom_speed = 1.0f + (physics_speed - 1) / 499.0f * 4.0f;
+	Orbit_distance *= powf(2.0f, delta * zoom_speed);
+
+	CLAMP(Orbit_distance, 1.0f, 10000000.0f);
+
+	orbit_camera_apply();
+}
+
+// ---------- End orbit camera functions ----------
+
 int object_check_collision(object *objp, vec3d *p0, vec3d *p1, vec3d *hitpos) {
 	mc_info mc;
 
@@ -1333,6 +1462,7 @@ int object_check_collision(object *objp, vec3d *p0, vec3d *p1, vec3d *hitpos) {
 
 void process_controls(vec3d *pos, matrix *orient, float frametime, int key, int mode) {
 	static std::unique_ptr<io::spacemouse::SpaceMouse> spacemouse = io::spacemouse::SpaceMouse::searchSpaceMice(0);
+	bool wantsUpdate = false;
 
 	if (Flying_controls_mode) {
 		grid_read_camera_controls(&view_controls, frametime);
@@ -1350,12 +1480,14 @@ void process_controls(vec3d *pos, matrix *orient, float frametime, int key, int 
 		if (key_get_shift_status())
 			memset(&view_controls, 0, sizeof(control_info));
 
-		if ((fabs(view_controls.pitch) > (frametime / 100)) &&
-			(fabs(view_controls.vertical) > (frametime / 100)) &&
-			(fabs(view_controls.heading) > (frametime / 100)) &&
-			(fabs(view_controls.sideways) > (frametime / 100)) &&
-			(fabs(view_controls.bank) > (frametime / 100)) &&
-			(fabs(view_controls.forward) > (frametime / 100)))
+		wantsUpdate = (fabs(view_controls.pitch) > (frametime / 100))
+		           || (fabs(view_controls.vertical) > (frametime / 100))
+		           || (fabs(view_controls.heading) > (frametime / 100))
+		           || (fabs(view_controls.sideways) > (frametime / 100))
+		           || (fabs(view_controls.bank) > (frametime / 100))
+		           || (fabs(view_controls.forward) > (frametime / 100));
+
+		if (wantsUpdate)
 			Update_window = 1;
 
 		flFrametime = frametime;
@@ -1388,7 +1520,16 @@ void process_controls(vec3d *pos, matrix *orient, float frametime, int key, int 
 		*orient = newmat;
 		if (rotangs.h && Universal_heading)
 			vm_transpose(orient);
+
+		wantsUpdate = !IS_VEC_NULL(&movement_vec)
+		           || rotangs.p != 0.0f
+		           || rotangs.h != 0.0f
+		           || rotangs.b != 0.0f;
 	}
+
+	// Invalidate orbit camera state when the user moves the camera another way
+	if (wantsUpdate)
+		Orbit_active = false;
 }
 
 void process_movement_keys(int key, vec3d *mvec, angles *angs) {

--- a/fred2/fredrender.h
+++ b/fred2/fredrender.h
@@ -36,6 +36,14 @@ extern int Flying_controls_mode;    //!< Bool. Unknown.
 extern int Group_rotate;            //!< Bool. If nonzero, each object rotates around the leader. If zero. rotate
 extern int Show_horizon;            //!< Bool. If nonzero, draw a line representing the horizon (XZ plane)
 extern int Lookat_mode;             //!< Bool. Unknown.
+
+// Orbit camera state
+extern vec3d Orbit_pivot;
+extern matrix Orbit_grid_orient;
+extern float Orbit_distance;
+extern float Orbit_phi;
+extern float Orbit_theta;
+extern bool Orbit_active;
 extern int True_rw;                 //!< Unsigned. The width of the render area
 extern int True_rh;                 //!< Unsigned. The height of the render area
 extern int Fixed_briefing_size;     //!< Bool. If nonzero then expand the briefing preview as much as we can, maintaining the aspect ratio.
@@ -94,3 +102,11 @@ void verticalize_controlled();
  * @return -1 if no object found
  */
 int select_object(int cx, int cy);
+
+// Orbit camera functions
+vec3d orbit_camera_get_pivot();
+void orbit_camera_init_from_current_view(const vec3d *pivot, const matrix *grid_orient);
+void orbit_camera_apply();
+void orbit_camera_rotate(int dx, int dy);
+void orbit_camera_pan(int dx, int dy);
+void orbit_camera_zoom(float delta);

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -158,6 +158,11 @@ BEGIN_MESSAGE_MAP(CFREDView, CView)
 	ON_WM_SIZE()
 	ON_WM_MOUSEMOVE()
 	ON_WM_LBUTTONUP()
+	ON_WM_MBUTTONDOWN()
+	ON_WM_MBUTTONUP()
+	ON_WM_RBUTTONDOWN()
+	ON_WM_RBUTTONUP()
+	ON_WM_MOUSEWHEEL()
 	ON_COMMAND(ID_MISCSTUFF_SHOWSHIPSASICONS, OnMiscstuffShowshipsasicons)
 	ON_WM_CONTEXTMENU()
 	ON_COMMAND(ID_EDIT_POPUP_SHOW_SHIP_ICONS, OnEditPopupShowShipIcons)
@@ -1048,7 +1053,7 @@ void CFREDView::OnLButtonDown(UINT nFlags, CPoint point)
 	CView::OnLButtonDown(nFlags, point);
 }
 
-void CFREDView::OnMouseMove(UINT nFlags, CPoint point) 
+void CFREDView::OnMouseMove(UINT nFlags, CPoint point)
 {
 	// RT point
 
@@ -1058,6 +1063,26 @@ void CFREDView::OnMouseMove(UINT nFlags, CPoint point)
 	last_mouse_y = marking_box.y2 = point.y;
 	Cursor_over = select_object(point.x, point.y);
 
+	// Orbit camera: middle button drag
+	if (m_orbit_dragging && (nFlags & MK_MBUTTON)) {
+		handle_orbit_drag(point, nFlags);
+		CView::OnMouseMove(nFlags, point);
+		return;
+	}
+
+	// Orbit camera: right button drag
+	if (m_rbutton_down && (nFlags & MK_RBUTTON) && viewpoint == 0 && Control_mode == 0) {
+		if (!m_rbutton_moved) {
+			if (abs(point.x - m_rbutton_down_point.x) > 2 || abs(point.y - m_rbutton_down_point.y) > 2)
+				m_rbutton_moved = true;
+		}
+		if (m_rbutton_moved) {
+			handle_orbit_drag(point, nFlags);
+			CView::OnMouseMove(nFlags, point);
+			return;
+		}
+	}
+
 	if (!(nFlags & MK_LBUTTON))
 		button_down = 0;
 
@@ -1066,7 +1091,7 @@ void CFREDView::OnMouseMove(UINT nFlags, CPoint point)
 	if (button_down && GetCapture() != this)
 		cancel_drag();
 
-	if (!button_down && GetCapture() == this)
+	if (!button_down && !m_orbit_dragging && !m_rbutton_down && GetCapture() == this)
 		ReleaseCapture();
 
 	if (button_down) {
@@ -1099,7 +1124,7 @@ void CFREDView::OnLButtonUp(UINT nFlags, CPoint point)
 	if (button_down && GetCapture() != this)
 		cancel_drag();
 
-	if (GetCapture() == this)
+	if (!m_orbit_dragging && !m_rbutton_down && GetCapture() == this)
 		ReleaseCapture();
 
 	if (button_down) {
@@ -1181,6 +1206,94 @@ void CFREDView::OnLButtonUp(UINT nFlags, CPoint point)
 
 	CView::OnLButtonUp(nFlags, point);
 }
+
+// ---------- Orbit camera mouse handlers ----------
+
+void CFREDView::handle_orbit_drag(CPoint point, UINT nFlags)
+{
+	int dx = point.x - m_orbit_last_mouse.x;
+	int dy = point.y - m_orbit_last_mouse.y;
+	m_orbit_last_mouse = point;
+
+	if (nFlags & MK_SHIFT)
+		orbit_camera_pan(dx, dy);
+	else
+		orbit_camera_rotate(dx, dy);
+	Update_window = 1;
+}
+
+void CFREDView::OnMButtonDown(UINT nFlags, CPoint point)
+{
+	if (viewpoint != 0 || Control_mode != 0)
+		return;
+
+	vec3d pivot = orbit_camera_get_pivot();
+	auto grid_orient = The_grid ? &The_grid->gmatrix : nullptr;
+	orbit_camera_init_from_current_view(&pivot, grid_orient);
+
+	m_orbit_dragging = true;
+	m_orbit_last_mouse = point;
+	SetCapture();
+}
+
+void CFREDView::OnMButtonUp(UINT nFlags, CPoint point)
+{
+	if (m_orbit_dragging) {
+		m_orbit_dragging = false;
+		if (GetCapture() == this && !m_rbutton_down)
+			ReleaseCapture();
+	}
+}
+
+void CFREDView::OnRButtonDown(UINT nFlags, CPoint point)
+{
+	m_rbutton_down = true;
+	m_rbutton_moved = false;
+	m_rbutton_down_point = point;
+	m_orbit_last_mouse = point;
+
+	if (viewpoint == 0 && Control_mode == 0) {
+		vec3d pivot = orbit_camera_get_pivot();
+		auto grid_orient = The_grid ? &The_grid->gmatrix : nullptr;
+		orbit_camera_init_from_current_view(&pivot, grid_orient);
+		SetCapture();
+	}
+}
+
+void CFREDView::OnRButtonUp(UINT nFlags, CPoint point)
+{
+	bool was_dragging = m_rbutton_moved;
+	m_rbutton_down = false;
+	m_rbutton_moved = false;
+
+	if (GetCapture() == this && !m_orbit_dragging)
+		ReleaseCapture();
+
+	if (!was_dragging) {
+		// No drag occurred — show context menu as normal
+		CPoint screen_point = point;
+		ClientToScreen(&screen_point);
+		OnContextMenu(this, screen_point);
+	}
+}
+
+BOOL CFREDView::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
+{
+	if (viewpoint != 0 || Control_mode != 0)
+		return CView::OnMouseWheel(nFlags, zDelta, pt);
+
+	if (!Orbit_active) {
+		vec3d pivot = orbit_camera_get_pivot();
+		auto grid_orient = The_grid ? &The_grid->gmatrix : nullptr;
+		orbit_camera_init_from_current_view(&pivot, grid_orient);
+	}
+
+	orbit_camera_zoom(zDelta / -200.0f);
+	Update_window = 1;
+	return TRUE;
+}
+
+// ---------- End orbit camera mouse handlers ----------
 
 //	This function never gets called because nothing causes
 //	the WM_GOODBYE event to occur.

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -36,6 +36,14 @@ private:
 	CGrid*		m_pGDlg;
 	int global_error_check_player_wings(int multi);
 
+	// Orbit camera drag state
+	bool m_orbit_dragging = false;
+	bool m_rbutton_down = false;
+	bool m_rbutton_moved = false;
+	CPoint m_orbit_last_mouse;
+	CPoint m_rbutton_down_point;
+	void handle_orbit_drag(CPoint point, UINT nFlags);
+
 protected: // create from serialization only
 	CFREDView();
 	DECLARE_DYNCREATE(CFREDView)
@@ -343,6 +351,11 @@ protected:
 	afx_msg void OnUpdateViewLighting(CCmdUI* pCmdUI);
 	afx_msg void OnViewFullDetail();
 	afx_msg void OnUpdateViewFullDetail(CCmdUI *pCmdUI);
+	afx_msg void OnMButtonDown(UINT nFlags, CPoint point);
+	afx_msg void OnMButtonUp(UINT nFlags, CPoint point);
+	afx_msg void OnRButtonDown(UINT nFlags, CPoint point);
+	afx_msg void OnRButtonUp(UINT nFlags, CPoint point);
+	afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
 	//}}AFX_MSG
 	afx_msg void OnGroup(UINT nID);
 	afx_msg void OnSetGroup(UINT nID);

--- a/qtfred/src/mission/CameraController.cpp
+++ b/qtfred/src/mission/CameraController.cpp
@@ -5,6 +5,9 @@
 #include <io/spacemouse.h>
 #include <mod_table/mod_table.h>
 
+#include <algorithm>
+#include <cmath>
+
 namespace fso::fred {
 
 void CameraController::resetView() {
@@ -102,7 +105,99 @@ bool CameraController::processControls(vec3d* pos, matrix* orient, float frameti
 	} else {
 		physics_sim(pos, orient, &view_physics, &vmd_zero_vector, frametime);
 	}
+
+	// Invalidate orbit camera state when the user moves the camera another way
+	if (wantsUpdate)
+		_orbitActive = false;
+
 	return wantsUpdate;
 }
+
+// ---------- Orbit camera functions ----------
+
+void CameraController::orbitCameraInitFromCurrentView(const vec3d *pivot, const matrix *grid_orient)
+{
+	_orbitPivot = pivot ? *pivot : vmd_zero_vector;
+	_orbitGridOrient = grid_orient ? *grid_orient : vmd_identity_matrix;
+
+	vec3d offset;
+	vm_vec_sub(&offset, &view_pos, &_orbitPivot);
+
+	_orbitDistance = vm_vec_mag(&offset);
+	if (_orbitDistance < 1.0f)
+		_orbitDistance = 100.0f;
+
+	// Transform offset into grid-local frame for angle decomposition
+	// In local frame, Y is always "up" (the grid plane normal)
+	vec3d local_offset;
+	vm_vec_rotate(&local_offset, &offset, &_orbitGridOrient);
+
+	_orbitPhi = acosf(std::clamp(local_offset.xyz.y / _orbitDistance, -1.0f, 1.0f));
+	_orbitTheta = atan2f(local_offset.xyz.z, local_offset.xyz.x);
+	_orbitActive = true;
+}
+
+void CameraController::orbitCameraApply()
+{
+	float sp = sinf(_orbitPhi);
+
+	// Build offset in grid-local coordinates (Y = up/normal)
+	vec3d local_pos;
+	local_pos.xyz.x = sp * cosf(_orbitTheta);
+	local_pos.xyz.y = cosf(_orbitPhi);
+	local_pos.xyz.z = sp * sinf(_orbitTheta);
+
+	// Transform back to world space
+	vec3d world_offset;
+	vm_vec_unrotate(&world_offset, &local_pos, &_orbitGridOrient);
+
+	vm_vec_scale(&world_offset, _orbitDistance);
+	vm_vec_add(&view_pos, &_orbitPivot, &world_offset);
+
+	// Point camera at pivot, using grid's up vector
+	vec3d look_dir;
+	vm_vec_sub(&look_dir, &_orbitPivot, &view_pos);
+	if (vm_vec_mag(&look_dir) > 0.001f) {
+		vec3d grid_up = _orbitGridOrient.vec.uvec;
+		vm_vector_2_matrix(&view_orient, &look_dir, &grid_up, nullptr);
+	}
+}
+
+void CameraController::orbitCameraRotate(int dx, int dy)
+{
+	float rot_scale = _physicsRot / 300.0f;
+	_orbitTheta += dx / 100.0f * rot_scale;
+	_orbitPhi += dy / 100.0f * rot_scale;
+
+	CLAMP(_orbitPhi, 0.01f, PI - 0.01f);
+
+	orbitCameraApply();
+}
+
+void CameraController::orbitCameraPan(int dx, int dy)
+{
+	float speed_factor = 1.0f + (_physicsSpeed - 1) / 499.0f * 9.0f;
+	float pan_scale = _orbitDistance * 0.002f * speed_factor;
+
+	vec3d pan_delta;
+	vm_vec_copy_scale(&pan_delta, &view_orient.vec.rvec, -(float)dx * pan_scale);
+	vm_vec_scale_add2(&pan_delta, &view_orient.vec.uvec, (float)dy * pan_scale);
+
+	vm_vec_add2(&_orbitPivot, &pan_delta);
+
+	orbitCameraApply();
+}
+
+void CameraController::orbitCameraZoom(float delta)
+{
+	float zoom_speed = 1.0f + (_physicsSpeed - 1) / 499.0f * 4.0f;
+	_orbitDistance *= powf(2.0f, delta * zoom_speed);
+
+	CLAMP(_orbitDistance, 1.0f, 10000000.0f);
+
+	orbitCameraApply();
+}
+
+// ---------- End orbit camera functions ----------
 
 } // namespace fso::fred

--- a/qtfred/src/mission/CameraController.h
+++ b/qtfred/src/mission/CameraController.h
@@ -22,6 +22,16 @@ class CameraController {
 	int _controlMode = 0;
 	bool _lookatMode = false;
 
+	// Orbit camera state
+	vec3d _orbitPivot = vmd_zero_vector;
+	matrix _orbitGridOrient = vmd_identity_matrix;
+	float _orbitDistance = 200.0f;
+	float _orbitPhi = 1.24f;
+	float _orbitTheta = 2.25f;
+	bool _orbitActive = false;
+
+	void orbitCameraApply();
+
 public:
 	vec3d eye_pos;
 	matrix eye_orient;
@@ -61,6 +71,13 @@ public:
 
 	bool getLookatMode() const { return _lookatMode; }
 	void setLookatMode(bool mode) { _lookatMode = mode; }
+
+	void orbitCameraInitFromCurrentView(const vec3d* pivot, const matrix* grid_orient);
+	void orbitCameraRotate(int dx, int dy);
+	void orbitCameraPan(int dx, int dy);
+	void orbitCameraZoom(float delta);
+
+	bool isOrbitActive() const { return _orbitActive; }
 };
 
 } // namespace fso::fred

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -642,6 +642,36 @@ void EditorViewport::level_object(matrix* orient) {
 	vm_fix_matrix(orient);
 }
 
+vec3d EditorViewport::orbitCameraGetPivot()
+{
+	vec3d pivot;
+
+	if (query_valid_object(editor->currentObject)) {
+		// Pivot on current object
+		pivot = Objects[editor->currentObject].pos;
+	} else if (!The_grid) {
+		// Pivot on the origin, if no grid
+		pivot = ZERO_VECTOR;
+	} else {
+		// Intersect camera forward ray with the grid plane
+		vec3d *grid_normal = &The_grid->gmatrix.vec.uvec;
+		float denom = vm_vec_dot(grid_normal, &camera.view_orient.vec.fvec);
+
+		if (fl_abs(denom) > 0.0001f) {
+			float t = -(vm_vec_dot(grid_normal, &camera.view_pos) + The_grid->planeD) / denom;
+			if (t > 0.0f) {
+				vm_vec_scale_add(&pivot, &camera.view_pos, &camera.view_orient.vec.fvec, t);
+			} else {
+				pivot = The_grid->center;
+			}
+		} else {
+			// Camera is parallel to grid plane; fall back to grid center
+			pivot = The_grid->center;
+		}
+	}
+	return pivot;
+}
+
 int EditorViewport::object_check_collision(object* objp, vec3d* p0, vec3d* p1, vec3d* hitpos) {
 	mc_info mc;
 

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -113,6 +113,8 @@ class EditorViewport {
 
 	void game_do_frame(const int cur_object_index);
 
+	vec3d orbitCameraGetPivot();
+
 	int object_check_collision(object* objp, vec3d* p0, vec3d* p1, vec3d* hitpos);
 
 	int select_object(int cx, int cy);

--- a/qtfred/src/ui/widgets/renderwidget.cpp
+++ b/qtfred/src/ui/widgets/renderwidget.cpp
@@ -56,27 +56,13 @@ void RenderWindow::paintGL() {
 bool RenderWindow::event(QEvent* evt) {
 	switch (evt->type()) {
 	case QEvent::MouseButtonRelease:
-	case QEvent::MouseButtonPress: {
-		auto mouseEvent = static_cast<QMouseEvent*>(evt);
-
-		if (mouseEvent->button() == Qt::RightButton) {
-			// Let the render widget consume right clicks for drag-cancel behavior first.
-			qGuiApp->sendEvent(_renderWidget, evt);
-			if (!evt->isAccepted()) {
-				// Not consumed by the render widget, forward for context menu handling.
-				qGuiApp->sendEvent(parent(), evt);
-			}
-		} else {
-			// The rest will be handled by the render widget
-			qGuiApp->sendEvent(_renderWidget, evt);
-		}
-		return true;
-	}
+	case QEvent::MouseButtonPress:
 	case QEvent::KeyPress:
 	case QEvent::KeyRelease:
 	case QEvent::ShortcutOverride:
 	case QEvent::MouseButtonDblClick:
-	case QEvent::MouseMove: {
+	case QEvent::MouseMove:
+	case QEvent::Wheel: {
 		// Redirect all the events to the render widget since we want to handle them in in the QtWidget related code
 		qGuiApp->sendEvent(_renderWidget, evt);
 		return true;
@@ -151,6 +137,12 @@ void RenderWidget::setSurfaceFormat(const QSurfaceFormat& fmt) {
 	_window->initializeGL(fmt);
 }
 void RenderWidget::contextMenuEvent(QContextMenuEvent* event) {
+	// Suppress context menu if right-button was used for orbit dragging
+	if (_rbuttonMoved) {
+		event->accept();
+		return;
+	}
+
 	event->accept();
 
 	auto parentView = static_cast<FredView*>(parentWidget());
@@ -197,19 +189,42 @@ void RenderWidget::mouseDoubleClickEvent(QMouseEvent* event) {
 	event->ignore();
 }
 void RenderWidget::mousePressEvent(QMouseEvent* event) {
+	// Orbit camera: middle button
+	if (event->button() == Qt::MiddleButton) {
+		if (_viewport != nullptr && _viewport->camera.getViewpoint() == 0 && _viewport->camera.getControlMode() == 0) {
+			vec3d pivot = _viewport->orbitCameraGetPivot();
+			auto grid_orient = _viewport->The_grid ? &_viewport->The_grid->gmatrix : nullptr;
+			_viewport->camera.orbitCameraInitFromCurrentView(&pivot, grid_orient);
+			_orbitDragging = true;
+			_orbitLastMouse = event->pos();
+		}
+		return;
+	}
+
+	// Orbit camera: right button
 	if (event->button() == Qt::RightButton) {
 		if (_viewport != nullptr && _viewport->button_down) {
 			_viewport->cancel_drag();
 			_usingMarkingBox = false;
 			event->accept();
-		} else {
-			event->ignore();
+			return;
+		}
+
+		_rbuttonDown = true;
+		_rbuttonMoved = false;
+		_rbuttonDownPoint = event->pos();
+		_orbitLastMouse = event->pos();
+
+		if (_viewport != nullptr && _viewport->camera.getViewpoint() == 0 && _viewport->camera.getControlMode() == 0) {
+			vec3d pivot = _viewport->orbitCameraGetPivot();
+			auto grid_orient = _viewport->The_grid ? &_viewport->The_grid->gmatrix : nullptr;
+			_viewport->camera.orbitCameraInitFromCurrentView(&pivot, grid_orient);
 		}
 		return;
 	}
 
 	if (event->button() != Qt::LeftButton) {
-		// Ignore everything that has nothing to to with the left button
+		// Ignore everything that has nothing to do with the left button
 		return QWidget::mousePressEvent(event);
 	}
 
@@ -278,9 +293,63 @@ void RenderWidget::mousePressEvent(QMouseEvent* event) {
 		_viewport->needsUpdate();
 	}
 }
+void RenderWidget::handleOrbitDrag(QPoint point, Qt::KeyboardModifiers modifiers)
+{
+	if (_viewport == nullptr || _viewport->camera.getViewpoint() != 0 || _viewport->camera.getControlMode() != 0)
+		return;
+
+	int dx = point.x() - _orbitLastMouse.x();
+	int dy = point.y() - _orbitLastMouse.y();
+	_orbitLastMouse = point;
+
+	if (modifiers & Qt::ShiftModifier)
+		_viewport->camera.orbitCameraPan(dx, dy);
+	else
+		_viewport->camera.orbitCameraRotate(dx, dy);
+	_viewport->needsUpdate();
+}
+
+void RenderWidget::wheelEvent(QWheelEvent* event)
+{
+	if (_viewport == nullptr || _viewport->camera.getViewpoint() != 0 || _viewport->camera.getControlMode() != 0) {
+		QWidget::wheelEvent(event);
+		return;
+	}
+
+	if (!_viewport->camera.isOrbitActive()) {
+		vec3d pivot = _viewport->orbitCameraGetPivot();
+		auto grid_orient = _viewport->The_grid ? &_viewport->The_grid->gmatrix : nullptr;
+		_viewport->camera.orbitCameraInitFromCurrentView(&pivot, grid_orient);
+	}
+
+	_viewport->camera.orbitCameraZoom(event->angleDelta().y() / -200.0f);
+	_viewport->needsUpdate();
+	event->accept();
+}
+
 void RenderWidget::mouseMoveEvent(QMouseEvent* event) {
 	auto mouseDX = event->pos() - _lastMouse;
 	_lastMouse = event->pos();
+
+	// Orbit camera: middle button drag
+	if (_orbitDragging && event->buttons().testFlag(Qt::MiddleButton)) {
+		handleOrbitDrag(event->pos(), event->modifiers());
+		return;
+	}
+
+	// Orbit camera: right button drag
+	if (_rbuttonDown && event->buttons().testFlag(Qt::RightButton) && _viewport != nullptr
+		&& _viewport->camera.getViewpoint() == 0 && _viewport->camera.getControlMode() == 0) {
+		if (!_rbuttonMoved) {
+			if (abs(event->pos().x() - _rbuttonDownPoint.x()) > 2
+				|| abs(event->pos().y() - _rbuttonDownPoint.y()) > 2)
+				_rbuttonMoved = true;
+		}
+		if (_rbuttonMoved) {
+			handleOrbitDrag(event->pos(), event->modifiers());
+			return;
+		}
+	}
 
 // Update marking box
 	_markingBox.x2 = event->x();
@@ -319,6 +388,25 @@ void RenderWidget::mouseMoveEvent(QMouseEvent* event) {
 	}
 }
 void RenderWidget::mouseReleaseEvent(QMouseEvent* event) {
+	if (event->button() == Qt::MiddleButton) {
+		_orbitDragging = false;
+		return;
+	}
+
+	if (event->button() == Qt::RightButton) {
+		bool wasDragging = _rbuttonMoved;
+		_rbuttonDown = false;
+		_rbuttonMoved = false;
+
+		if (!wasDragging) {
+			// No drag occurred — show context menu
+			auto parentView = static_cast<FredView*>(parentWidget());
+			Q_ASSERT(parentView);
+			parentView->showContextMenu(event->globalPos());
+		}
+		return;
+	}
+
 	if (event->button() != Qt::LeftButton) {
 		// Ignore everything that has nothing to do with the left button
 		return QWidget::mouseReleaseEvent(event);

--- a/qtfred/src/ui/widgets/renderwidget.h
+++ b/qtfred/src/ui/widgets/renderwidget.h
@@ -60,6 +60,15 @@ class RenderWidget: public QWidget {
 
 	QPoint _lastMouse;
 
+	// Orbit camera drag state
+	bool _orbitDragging = false;
+	bool _rbuttonDown = false;
+	bool _rbuttonMoved = false;
+	QPoint _orbitLastMouse;
+	QPoint _rbuttonDownPoint;
+
+	void handleOrbitDrag(QPoint point, Qt::KeyboardModifiers modifiers);
+
  public:
 	explicit RenderWidget(QWidget* parent);
 
@@ -81,6 +90,8 @@ class RenderWidget: public QWidget {
 
 	void mousePressEvent(QMouseEvent* event) override;
 	void mouseReleaseEvent(QMouseEvent*) override;
+
+	void wheelEvent(QWheelEvent* event) override;
 
 	void contextMenuEvent(QContextMenuEvent* event) override;
 	void updateCursor() const;


### PR DESCRIPTION
Implement a spherical-coordinate orbit camera for both the MFC (FRED2) and Qt (qtFRED) editors, providing intuitive 3D viewport navigation similar to other 3D editing tools.

Controls:
- Middle mouse drag: orbit rotate around pivot point
- Shift + middle mouse drag: pan the pivot point
- Right mouse drag: orbit rotate (alternative to middle mouse)
- Shift + right mouse drag: pan (alternative to shift + middle mouse)
- Mouse wheel: zoom in/out
- Right click without drag: context menu (preserving existing feature)

Camera pivot selection:
- If an object is selected, orbit around that object
- Otherwise, intersect the camera forward ray with the current grid plane to find a natural pivot point
- Falls back to grid center if the camera is parallel to the grid

Grid-plane awareness:
- Orbit axes are derived from The_grid->gmatrix using vm_vec_rotate and vm_vec_unrotate, so the camera orbits correctly on all three grid planes (XZ, XY, YZ), not just the default XZ plane
- The look-at matrix uses the grid's up vector (uvec) rather than a hardcoded world-up direction

Robust zoom/pan scaling:
- Zoom uses an exponential formula (powf) so the distance multiplier is always positive regardless of physics_speed setting (1-500)
- Pan uses a clamped speed factor to avoid excessive movement at high physics_speed values

State management:
- Keyboard camera movement (process_controls) invalidates orbit state, so the next mouse drag re-initializes from the current view
- Orbit state is per-viewport in qtFRED (EditorViewport members) and global in FRED2 (matching existing conventions in each codebase)

Implementation:
- FRED2: orbit math in fredrender.cpp, mouse handlers in fredview.cpp
- qtFRED: orbit math in EditorViewport.cpp, mouse/wheel handlers in renderwidget.cpp; RenderWindow::event() updated to forward middle button and wheel events to RenderWidget

Also fix an AND vs OR bug in FRED's process_controls().