### PR TITLE
Suppress Coverity GLOBAL_INIT_ORDER false positives for safe globals

### DIFF
--- a/code/camera/camera.cpp
+++ b/code/camera/camera.cpp
@@ -73,6 +73,7 @@ static void parse_fov_func()
 	fov_default = value;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto FovOption = options::OptionBuilder<float>("Graphics.FOV",
 					 std::pair<const char*, int>{"Field Of View", 1703},
 					 std::pair<const char*, int>{"The vertical field of view", 1704})
@@ -91,6 +92,7 @@ auto FovOption = options::OptionBuilder<float>("Graphics.FOV",
 
 bool Use_cockpit_fov = false;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto CockpitFOVToggleOption = options::OptionBuilder<bool>("Graphics.CockpitFOVToggle",
 					 std::pair<const char*, int>{"Cockpit FOV Toggle", 1838},
 					 std::pair<const char*, int>{"Whether or not to use a different FOV for cockpit rendering from normal rendering", 1839})
@@ -107,6 +109,7 @@ auto CockpitFOVToggleOption = options::OptionBuilder<bool>("Graphics.CockpitFOVT
 					 .importance(61)
 					 .finish();
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto CockpitFovOption = options::OptionBuilder<float>("Graphics.CockpitFOV",
 					 std::pair<const char*, int>{"Cockpit Field Of View", 1840},
 					 std::pair<const char*, int>{"The vertical field of view for cockpit rendering. Only works if cockpits are active and cockpit FOV toggle is turned on.", 1841})

--- a/code/controlconfig/controlsconfigcommon.cpp
+++ b/code/controlconfig/controlsconfigcommon.cpp
@@ -45,6 +45,7 @@ int Failed_key_index;
 // Joystick configuration
 int Joy_dead_zone_size = 10;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto DeadZoneOption = options::OptionBuilder<int>("Input.JoystickDeadZone",
                      std::pair<const char*, int>{"Deadzone", 1377},
                      std::pair<const char*, int>{"The deadzone used for all joysticks", 1744})
@@ -59,6 +60,7 @@ auto DeadZoneOption = options::OptionBuilder<int>("Input.JoystickDeadZone",
 
 int Joy_sensitivity = 9;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto SensitivityOption = options::OptionBuilder<int>("Input.JoystickSensitivity",
                      std::pair<const char*, int>{"Sensitivity", 1745},
                      std::pair<const char*, int>{"The sensitivity used for all joysticks", 1746})

--- a/code/gamesnd/eventmusic.cpp
+++ b/code/gamesnd/eventmusic.cpp
@@ -53,6 +53,7 @@ static void parse_music_volume_func()
 	Default_music_volume = volume;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto MusicVolumeOption __UNUSED = options::OptionBuilder<float>("Audio.Music",
                      std::pair<const char*, int>{"Music", 1371},
                      std::pair<const char*, int>{"Volume used for playing music", 1760})

--- a/code/globalincs/systemvars.cpp
+++ b/code/globalincs/systemvars.cpp
@@ -256,6 +256,7 @@ static void parse_model_detail_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 const auto ModelDetailOption __UNUSED = options::OptionBuilder<int>("Graphics.Detail",
                      std::pair<const char*, int>{"Model Detail", 1739},
                      std::pair<const char*, int>{"Detail level of models", 1740})
@@ -287,6 +288,7 @@ static void parse_texture_detail_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 const auto TexturesOption __UNUSED = options::OptionBuilder<int>("Graphics.Texture",
                      std::pair<const char*, int>{"3D Hardware Textures", 1362},
                      std::pair<const char*, int>{"Level of detail of textures", 1720})
@@ -318,6 +320,7 @@ static void parse_particles_detail_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 const auto ParticlesOption __UNUSED = options::OptionBuilder<int>("Graphics.Particles",
                      std::pair<const char*, int>{"Particles", 1363},
                      std::pair<const char*, int>{"Level of detail for particles", 1717})
@@ -349,7 +352,8 @@ static void parse_debris_detail_func()
 	}
 }
 
-const auto SmallDebrisOption __UNUSED = options::OptionBuilder<int>("Graphics.SmallDebris", 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
+const auto SmallDebrisOption __UNUSED = options::OptionBuilder<int>("Graphics.SmallDebris",
                      std::pair<const char*, int>{"Impact Effects", 1364}, 
                      std::pair<const char*, int>{"Level of detail of impact effects", 1743})
                      .category(std::make_pair("Graphics", 1825))
@@ -380,6 +384,7 @@ static void parse_shield_detail_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 const auto ShieldEffectsOption __UNUSED = options::OptionBuilder<int>("Graphics.ShieldEffects",
                      std::pair<const char*, int>{"Shield Hit Effects", 1718},
                      std::pair<const char*, int>{"Level of detail of shield impacts", 1719})
@@ -411,7 +416,8 @@ static void parse_stars_detail_func()
 	}
 }
 
-const auto StarsOption __UNUSED = options::OptionBuilder<int>("Graphics.Stars", 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
+const auto StarsOption __UNUSED = options::OptionBuilder<int>("Graphics.Stars",
                      std::pair<const char*, int>{"Stars", 1366}, 
                      std::pair<const char*, int>{"Number of stars in the mission", 1698})
                      .importance(2)

--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -165,6 +165,7 @@ static void parse_gamma_func()
 	error_display(0, "%f is not a valid gamma value! (Invalid increment)", value);
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto GammaOption __UNUSED = options::OptionBuilder<float>("Graphics.Gamma",
                      std::pair<const char*, int>{"Brightness", 1375},
                      std::pair<const char*, int>{"The brightness value used for the game window", 1738})
@@ -199,6 +200,7 @@ const SCP_vector<std::pair<int, std::pair<const char*, int>>> DetailLevelValues 
                                                                                    { 3, {"High", 1162}},
                                                                                    { 4, {"Ultra", 1721}}};
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 const auto LightingOption __UNUSED = options::OptionBuilder<int>("Graphics.Lighting",
                      std::pair<const char*, int>{"Lighting", 1367},
                      std::pair<const char*, int>{"Level of detail of the lighting", 1715})
@@ -252,6 +254,7 @@ static void parse_window_mode_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto WindowModeOption __UNUSED = options::OptionBuilder<os::ViewportState>("Graphics.WindowMode",
                      std::pair<const char*, int>{"Window Mode", 1772},
                      std::pair<const char*, int>{"Controls how the game window is created", 1773})
@@ -271,6 +274,7 @@ void removeWindowModeOption()
 	options::OptionsManager::instance()->removeOption(WindowModeOption);
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; Hook::Factory() uses Meyers singleton
 const std::shared_ptr<scripting::OverridableHook<>> OnFrameHook = scripting::OverridableHook<>::Factory(
 	"On Frame", "Called every frame as the last action before showing the frame result to the user.", {}, std::nullopt, CHA_ONFRAME);
 
@@ -354,6 +358,7 @@ static bool videodisplay_change(int display, bool initial)
 // Video display cannot support default settings because graphics have not been
 // initialized so we can't validate the setting. But also, this should probably
 // only ever be a user setting
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto VideoDisplayOption = options::OptionBuilder<int>("Graphics.Display",
                      std::pair<const char*, int>{"Primary display", 1741},
                      std::pair<const char*, int>{"The display used for rendering", 1742})
@@ -490,6 +495,7 @@ static bool resolution_vr_change(const ResolutionInfo& /*info*/, bool initial)
 // Resolution cannot support default settings because graphics have not been
 // initialized so we can't validate the setting. But also, this should probably
 // only ever be a user setting
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto ResolutionOption = options::OptionBuilder<ResolutionInfo>("Graphics.Resolution",
                      std::pair<const char*, int>{"Resolution", 1748},
                      std::pair<const char*, int>{"The rendering resolution", 1749})
@@ -509,6 +515,7 @@ void removeResolutionOption()
 	options::OptionsManager::instance()->removeOption(ResolutionOption);
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto ResolutionVROption = options::OptionBuilder<ResolutionInfo>("Graphics.ResolutionVR",
 	std::pair<const char*, int>{"VR Resolution", 1878},
 	std::pair<const char*, int>{"The rendering resolution when in VR mode", 1879})
@@ -537,6 +544,7 @@ static void parse_soft_particle_func() {
 	Gr_enable_soft_particles = value;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto SoftParticlesOption __UNUSED = options::OptionBuilder<bool>("Graphics.SoftParticles",
                      std::pair<const char*, int>{"Soft Particles", 1761},
                      std::pair<const char*, int>{"Enable or disable soft particle rendering", 1762})
@@ -577,6 +585,7 @@ static void parse_framebuffer_func() {
     }
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto FramebufferEffectsOption __UNUSED = options::OptionBuilder<flagset<FramebufferEffects>>("Graphics.FramebufferEffects",
                      std::pair<const char*, int>{"Framebuffer effects", 1732},
                      std::pair<const char*, int>{"Controls which framebuffer effects will be applied to the scene", 1733})
@@ -622,6 +631,7 @@ static void parse_anti_aliasing_func() {
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto AAOption __UNUSED = options::OptionBuilder<AntiAliasMode>("Graphics.AAMode",
                      std::pair<const char*, int>{"Anti Aliasing", 1752},
                      std::pair<const char*, int>{"Controls the anti aliasing mode of the engine.", 1753})
@@ -669,6 +679,7 @@ static void parse_msaa_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto MSAAOption __UNUSED = options::OptionBuilder<int>("Graphics.MSAASamples",
                      std::pair<const char*, int>{"Multisample Anti Aliasing", 1758},
                      std::pair<const char*, int>{"Controls whether multisample anti asliasing is enabled, and with how many samples", 1759})
@@ -701,6 +712,7 @@ static void parse_post_processing_func()
 
 bool Gr_post_processing_enabled = true;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto PostProcessOption __UNUSED = options::OptionBuilder<bool>("Graphics.PostProcessing",
                      std::pair<const char*, int>{"Post processing", 1726},
                      std::pair<const char*, int>{"Controls whether post processing is enabled in the engine.", 1727})
@@ -722,6 +734,7 @@ static void parse_vsync_func()
 	Gr_enable_vsync = value;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto VSyncOption __UNUSED = options::OptionBuilder<bool>("Graphics.VSync",
                      std::pair<const char*, int>{"Vertical Sync", 1766},
                      std::pair<const char*, int>{"Controls how the engine does vertical synchronization", 1767})

--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -72,6 +72,7 @@ static void parse_texture_filtering_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto TextureFilteringOption __UNUSED = options::OptionBuilder<int>("Graphics.TextureFilter",
                      std::pair<const char*, int>{"Texture Filtering", 1763},
                      std::pair<const char*, int>{"Texture filtering option", 1764})
@@ -125,6 +126,7 @@ static float anisotropic_default()
 	return max;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto AnisotropyOption = options::OptionBuilder<float>("Graphics.Anisotropy",
                      std::pair<const char*, int>{"Anistropic filtering", 1736},
                      std::pair<const char*, int>{"Controls the amount of anistropic filtering of the textures", 1737})

--- a/code/graphics/post_processing.cpp
+++ b/code/graphics/post_processing.cpp
@@ -65,6 +65,7 @@ void parse_sunglare_func()
 	Post_processing_enable_sunglare = enabled;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto LightshaftsOption = options::OptionBuilder<bool>("Graphics.Lightshafts",
                      std::pair<const char*, int>{"Lightshafts", 1724},
                      std::pair<const char*, int>{"Enables or disables lightshafts (requires post-processing)", 1725})
@@ -76,6 +77,7 @@ auto LightshaftsOption = options::OptionBuilder<bool>("Graphics.Lightshafts",
                      .parser(parse_lightshafts_func)
                      .finish();
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto SunglareOption = options::OptionBuilder<bool>("Graphics.Sunglare",
 					std::pair<const char*, int>{"Sunglare", 1880},
 					std::pair<const char*, int>{"Enables or disables glare from suns", 1881})
@@ -97,6 +99,7 @@ void parse_bloom_intensity_func()
 	Post_processing_bloom_intensity = value;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto BloomIntensityOption __UNUSED = options::OptionBuilder<int>("Graphics.BloomIntensity",
                      std::pair<const char*, int>{"Bloom intensity", 1701},
                      std::pair<const char*, int>{"Sets the bloom intensity (requires post-processing)", 1702})

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -59,6 +59,7 @@ static void parse_shadow_quality_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto ShadowQualityOption = options::OptionBuilder<ShadowQuality>("Graphics.Shadows",
                      std::pair<const char*, int>{"Shadow Quality", 1750},
                      std::pair<const char*, int>{"The quality of the shadows", 1751})

--- a/code/graphics/software/FSFont.cpp
+++ b/code/graphics/software/FSFont.cpp
@@ -3,6 +3,7 @@
 
 float Font_Scale_Factor = 1.0;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto FontScaleFactor __UNUSED = options::OptionBuilder<float>("Game.FontScaleFactor",
 	std::pair<const char*, int>{"Font Scale Factor", 1862},
 	std::pair<const char*, int>{

--- a/code/iff_defs/iff_defs.cpp
+++ b/code/iff_defs/iff_defs.cpp
@@ -46,6 +46,7 @@ static bool AccessiblitySupported = false;
 // used by In-Game Options menu
 static bool AccessibilityEnabled = false;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto AccessibilityOption = options::OptionBuilder<bool>("Game.IffAccessibility",
 	std::pair<const char*, int>{"Accessibility IFF Colors", 1855},
 	std::pair<const char*, int>{"Enables or disables IFF Accessibility color overrides", 1856})

--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -275,6 +275,7 @@ SCP_vector<Joystick*> joystick_enumerator()
  * Joystick options for the new menu system
  * These should be displayed as a dropdown box type widget
  */
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto JoystickOption = options::OptionBuilder<Joystick*>("Input.Joystick",
                      std::pair<const char*, int>{"Joystick 0", 1705},
                      std::pair<const char*, int>{"The current joystick 0", 1706})
@@ -293,6 +294,7 @@ auto JoystickOption = options::OptionBuilder<Joystick*>("Input.Joystick",
                      })
                      .finish();
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto JoystickOption1 = options::OptionBuilder<Joystick*>("Input.Joystick1",
                      std::pair<const char*, int>{"Joystick 1", 1707},
                      std::pair<const char*, int>{"The current joystick 1", 1708})
@@ -311,6 +313,7 @@ auto JoystickOption1 = options::OptionBuilder<Joystick*>("Input.Joystick1",
                      })
                      .finish();
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto JoystickOption2 = options::OptionBuilder<Joystick*>("Input.Joystick2",
                      std::pair<const char*, int>{"Joystick 2", 1709},
                      std::pair<const char*, int>{"The current joystick 2", 1710})
@@ -329,6 +332,7 @@ auto JoystickOption2 = options::OptionBuilder<Joystick*>("Input.Joystick2",
                      })
                      .finish();
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto JoystickOption3 = options::OptionBuilder<Joystick*>("Input.Joystick3",
                      std::pair<const char*, int>{"Joystick 3", 1711},
                      std::pair<const char*, int>{"The current joystick 3", 1712})

--- a/code/io/joy_ff-sdl.cpp
+++ b/code/io/joy_ff-sdl.cpp
@@ -53,6 +53,7 @@ static haptic_effect_t pSecShootEffect;
 static haptic_effect_t pSpring;
 static haptic_effect_t pDock;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto ForceFeedbackOption = options::OptionBuilder<bool>("Input.ForceFeedback",
                      std::pair<const char*, int>{"Force Feedback", 1728},
                      std::pair<const char*, int>{"Enable or disable force feedback", 1729})
@@ -61,6 +62,7 @@ static auto ForceFeedbackOption = options::OptionBuilder<bool>("Input.ForceFeedb
                      .default_val(false)
                      .finish();
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto HitEffectOption = options::OptionBuilder<bool>("Input.HitEffect",
                      std::pair<const char*, int>{"Directional Hit", 1730},
                      std::pair<const char*, int>{"Enable or disable the directional hit effect", 1731})
@@ -69,6 +71,7 @@ static auto HitEffectOption = options::OptionBuilder<bool>("Input.HitEffect",
                      .default_val(false)
                      .finish();
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto ForceFeedbackStrength = options::OptionBuilder<float>("Input.FFStrength",
                      std::pair<const char*, int>{"Force Feedback Strength", 1756},
                      std::pair<const char*, int>{"The realtive strength of Force Feedback effects", 1757})

--- a/code/io/mouse.cpp
+++ b/code/io/mouse.cpp
@@ -56,6 +56,7 @@ int Mouse_dz = 0;
 
 int Mouse_sensitivity = 4;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto MouseSensitivityOption __UNUSED = options::OptionBuilder<int>("Input.MouseSensitivity",
                      std::pair<const char*, int>{"Sensitivity", 1374},
                      std::pair<const char*, int>{"The sensitivity of the mouse input", 1747})
@@ -72,6 +73,7 @@ bool Use_mouse_to_fly = false;
 
 static SCP_string mouse_mode_display(bool mode) { return mode ? XSTR("Joy-0", 1699) : XSTR("Mouse", 1373); }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto UseMouseOption __UNUSED = options::OptionBuilder<bool>("Input.UseMouse",
                      std::pair<const char*, int>{"Mouse", 1373},
                      std::pair<const char*, int>{"Whether or not to use the mouse for flying", 1765})

--- a/code/lighting/lighting.cpp
+++ b/code/lighting/lighting.cpp
@@ -111,6 +111,7 @@ static void parse_deferred_lighting_func()
 	DeferredLightingEnabled = enabled;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto DeferredLightingOption = options::OptionBuilder<bool>("Graphics.DeferredLighting",
                   std::pair<const char*, int>{"Deferred Lighting", 1782},
                   std::pair<const char*, int>{"Enables or disables deferred lighting", 1783})
@@ -131,6 +132,7 @@ static void parse_deferredcockpit_lighting_func()
 	DeferredCockpitLightingEnabled = enabled;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto DeferredCockpitLightingOption = options::OptionBuilder<bool>("Graphics.DeferredCockpitLighting",
                   std::pair<const char*, int>{"Deferred Cockpit Lighting", 1864},
                   std::pair<const char*, int>{"Enables or disables deferred lighting in cockpits (requires Deferred Lighting to be enabled)", 1865})

--- a/code/mission/missionbriefcommon.cpp
+++ b/code/mission/missionbriefcommon.cpp
@@ -51,6 +51,7 @@ brief_screen bscreen;
 
 float Briefing_Icon_Scale_Factor = 1.0;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto IconScaleFactor __UNUSED = options::OptionBuilder<float>("Game.BriefIconScaleFactor",
                      std::pair<const char*, int>{"Briefing Icon Scale Factor", 1857},
                      std::pair<const char*, int>{"Scales the size of the briefing icons", 1858})
@@ -140,6 +141,7 @@ debriefing	*Debriefing;						// pointer to correct debriefing
 
 bool Briefing_voice_enabled = true; // flag which turn on/off voice playback of briefings/debriefings
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto BriefingVoiceOption __UNUSED = options::OptionBuilder<bool>("Audio.BriefingVoice",
                      std::pair<const char*, int>{"Briefing voice", 1368},
                      std::pair<const char*, int>{"Enable or disable voice playback in the briefing", 1716})

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -100,6 +100,7 @@ LOCAL struct {
 
 int Total_initially_docked;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; default-constructed, no cross-TU dependencies
 mission	The_mission;
 char Mission_filename[80];
 
@@ -123,6 +124,7 @@ ushort Current_file_checksum = 0;
 ushort Last_file_checksum = 0;
 int    Current_file_length   = 0;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; default-constructed, no cross-TU dependencies
 SCP_vector<mission_default_custom_data> Default_custom_data;
 
 // alternate ship type names
@@ -137,9 +139,11 @@ int Mission_callsign_count = 0;
 
 // the ship arrival list will contain a list of ships that are yet to arrive.  This
 // list could also include ships that are part of wings!
+// coverity[GLOBAL_INIT_ORDER] -- safe; default-constructed, no cross-TU dependencies
 p_object Ship_arrival_list;	// for linked list of ships to arrive later
 
 // all the ships that we parse
+// coverity[GLOBAL_INIT_ORDER] -- safe; default-constructed, no cross-TU dependencies
 SCP_vector<p_object> Parse_objects;
 
 // all the props that we parse
@@ -147,6 +151,7 @@ SCP_vector<parsed_prop> Parse_props;
 
 
 // list for arriving support ship
+// coverity[GLOBAL_INIT_ORDER] -- safe; default-constructed, no cross-TU dependencies
 p_object	Support_ship_pobj;
 p_object *Arriving_support_ship;
 char Arriving_repair_targets[MAX_AI_GOALS][NAME_LENGTH];

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -186,6 +186,7 @@ bool Zero_radius_explosions_skip_fireballs;
 
 
 #ifdef WITH_DISCORD
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto DiscordOption __UNUSED = options::OptionBuilder<bool>("Game.Discord",
                      std::pair<const char*, int>{"Discord Presence", 1754},
                      std::pair<const char*, int>{"Toggle Discord Rich Presence", 1755})

--- a/code/nebula/neb.cpp
+++ b/code/nebula/neb.cpp
@@ -151,6 +151,7 @@ static void parse_nebula_detail_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 const auto NebulaDetailOption __UNUSED = options::OptionBuilder<int>("Graphics.NebulaDetail",
                      std::pair<const char*, int>{"Nebula Detail", 1361},
                      std::pair<const char*, int>{"Detail level of nebulas", 1697})

--- a/code/network/multi_options.cpp
+++ b/code/network/multi_options.cpp
@@ -51,6 +51,7 @@ char Multi_options_proxy[512] = "";
 ushort Multi_options_proxy_port = 0;
 bool Multi_cfg_missing = true;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto TogglePXOOption __UNUSED = options::OptionBuilder<bool>("Multi.TogglePXO",
 									std::pair<const char*, int>{"PXO", 1383},
 									std::pair<const char*, int>{"Whether or not to play games on the local network or on PXO", 1809})
@@ -88,6 +89,7 @@ static bool local_broadcast_change(bool val, bool initial)
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto LocalBroadcastOption __UNUSED = options::OptionBuilder<bool>("Multi.LocalBroadcast",
 									std::pair<const char*, int>{"Broadcast Locally", 1387},
 									std::pair<const char*, int>{"Whether or not to broadcast games on the local network", 1808})
@@ -119,6 +121,7 @@ static bool flush_cache_change(bool val, bool initial)
 
 static SCP_string flush_cache_display(bool mode) { return mode ? XSTR("Before Game", 1401) : XSTR("Never", 1400); }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto FlushCacheOption __UNUSED = options::OptionBuilder<bool>("Multi.FlushCache",
 									std::pair<const char*, int>{"Flush Cache", 1399},
 									std::pair<const char*, int>{"Whether or not flush the multidata cache before games", 1810})
@@ -151,6 +154,7 @@ static bool transfer_missions_change(bool val, bool initial)
 
 static SCP_string transfer_missions_display(bool mode) { return mode ? XSTR("/multidata", 1397) : XSTR("/missions", 1398); }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto TransferMissionsOption __UNUSED = options::OptionBuilder<bool>("Multi.TransferMissions",
 									std::pair<const char*, int>{"Transfer Missions", 1396},
 									std::pair<const char*, int>{"What appdata folder to save missions to", 1811})

--- a/code/playerman/playercontrol.cpp
+++ b/code/playerman/playercontrol.cpp
@@ -91,6 +91,7 @@ static void parse_flight_mode_func()
 	}
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto FlightModeOption = options::OptionBuilder<FlightMode>("Game.FlightMode",
 	std::pair<const char*, int>{"Flight Mode", 1842},
 	std::pair<const char*, int>{"Choose the flying style to use during gameplay.", 1843})
@@ -123,6 +124,7 @@ static void parse_flight_cursor_extent_func()
 	Flight_cursor_extent = value;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto FlightCursorExtentOption = options::OptionBuilder<float>("Game.FlightCursorExtent",
 	std::pair<const char*, int>{"Flight Cursor Extent", 1846},
 	std::pair<const char*, int>{"How far from the center the cursor can go.", 1847})
@@ -146,6 +148,7 @@ static void parse_cursor_deadzone_func()
 	Flight_cursor_deadzone = value;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto FlightCursorDeadzoneOption = options::OptionBuilder<float>("Game.FlightCursorDeadzone",
 	std::pair<const char*, int>{"Flight Cursor Deadzone", 1848},
 	std::pair<const char*, int>{"How far from the center the cursor needs to go before registering.", 1849})

--- a/code/sound/ds.cpp
+++ b/code/sound/ds.cpp
@@ -177,6 +177,7 @@ static size_t Ds_active_env_idx = 0;
 
 bool Ingame_efx = false;
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto EnableEFXOption = options::OptionBuilder<bool>("Audio.EnableEFX",
                      std::pair<const char*, int>{"Use Audio EFX", 1832},
                      std::pair<const char*, int>{"Toggle whether OpenAL Audio EFX are used or not", 1833})

--- a/code/sound/openal.cpp
+++ b/code/sound/openal.cpp
@@ -115,6 +115,7 @@ static bool playbackdevice_change(int /*device*/, bool initial)
 
 	return false;
 }
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto PlaybackDeviceOption = options::OptionBuilder<int>("Audio.PlaybackDevice",
                      std::pair<const char*, int>{"Playback Device", 1834},
                      std::pair<const char*, int>{"The device used for audio playback", 1835})
@@ -190,6 +191,7 @@ static bool capturedevice_change(int /*device*/, bool initial)
 
 	return false;
 }
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto CaptureDeviceOption = options::OptionBuilder<int>("Audio.CaptureDevice",
                      std::pair<const char*, int>{"Capture Device", 1836},
                      std::pair<const char*, int>{"The device used for audio capture", 1837})

--- a/code/sound/sound.cpp
+++ b/code/sound/sound.cpp
@@ -70,6 +70,7 @@ static void parse_effect_volume_func()
 	Default_sound_volume = volume;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto EffectVolumeOption __UNUSED = options::OptionBuilder<float>("Audio.Effects",
                      std::pair<const char*, int>{"Effects", 1370},
                      std::pair<const char*, int>{"Volume used for playing in-game effects", 1734})
@@ -102,6 +103,7 @@ static void parse_voice_volume_func()
 	Default_voice_volume = volume;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto VoiceVolumeOption __UNUSED = options::OptionBuilder<float>("Audio.Voice",
                      std::pair<const char*, int>{"Voice", 1372},
                      std::pair<const char*, int>{"Volume used for playing voice audio", 1735})

--- a/code/starfield/starfield.cpp
+++ b/code/starfield/starfield.cpp
@@ -169,6 +169,7 @@ static void parse_motion_debris_func()
 	Motion_debris_enabled = enabled;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto MotionDebrisOption = options::OptionBuilder<bool>("Graphics.MotionDebris",
                      std::pair<const char*, int>{"Motion Debris", 1713},
                      std::pair<const char*, int>{"Enable or disable visible motion debris", 1714})

--- a/code/stats/stats.cpp
+++ b/code/stats/stats.cpp
@@ -18,6 +18,7 @@
 #include "stats/stats.h"
 
 static const scoring_struct *Player_stats;
+// coverity[GLOBAL_INIT_ORDER] -- safe; default-constructed, no cross-TU dependencies
 static scoring_struct All_time_ever_stats;
 
 void show_stats_init()

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -60,6 +60,7 @@ static void parse_shockwaves_func()
 	Use_3D_shockwaves = enabled;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto Shockwave3DMode = options::OptionBuilder<bool>("Graphics.3DShockwaves",
                      std::pair<const char*, int>{"Shockwaves", 1722},
                      std::pair<const char*, int>{"The way shockwaves are displayed. Changes will be reflected in the next loaded mission.", 1723})

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -273,6 +273,7 @@ static void parse_skill_func()
 	Game_skill_level = value;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 static auto GameSkillOption __UNUSED = options::OptionBuilder<int>("Game.SkillLevel",
                      std::pair<const char*, int>{"Skill Level", 1284},
                      std::pair<const char*, int>{"The skill level for the game.", 1700})
@@ -296,6 +297,7 @@ static void parse_screenshake_func()
 	Screenshake_enabled = enabled;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto ScreenShakeOption = options::OptionBuilder<bool>("Graphics.ScreenShake",
                      std::pair<const char*, int>{"Screen Shudder Effect", 1812}, // do xstr
                      std::pair<const char*, int>{"Toggles the screen shake effect for weapons, afterburners, and shockwaves", 1813})
@@ -318,6 +320,7 @@ static void parse_unfocused_pause_func()
 	Allow_unfocused_pause = enabled;
 }
 
+// coverity[GLOBAL_INIT_ORDER] -- safe; OptionBuilder::finish() uses Meyers singleton
 auto UnfocusedPauseOption = options::OptionBuilder<bool>("Game.UnfocusedPause",
                      std::pair<const char*, int>{"Pause If Unfocused", 1814}, // do xstr
                      std::pair<const char*, int>{"Whether or not the game automatically pauses if it loses focus", 1815})


### PR DESCRIPTION
Add coverity[GLOBAL_INIT_ORDER] annotations to ~50 global variables across 27 files. These were all analyzed and confirmed safe:

- ~48 OptionBuilder::finish() globals use a Meyers singleton (OptionsManager::instance()), which guarantees safe init order. Destruction is also safe due to shared_ptr ref-counting.
- 6 default-constructed container globals (vectors, maps) have no cross-TU dependencies at construction or destruction time.