### PR TITLE
Fix `targest nearest attacking ship` in multiplayer

### DIFF
--- a/code/network/multi_obj.cpp
+++ b/code/network/multi_obj.cpp
@@ -1490,22 +1490,18 @@ int multi_oo_pack_data(net_player *pl, object *objp, ushort oo_flags, ubyte *dat
 		auto submode = (short)(aip->submode);
 		ushort target_signature = 0;
 
-		// Either send out the waypoint they are trying to get to *or* their current target.
+		// either send out the waypoint they are trying to get to *or* their current target.
 		if (umode == AIM_WAYPOINTS) {
-			// If it's already started pointing to a waypoint, grab its net_signature and send that instead
+			// if it's already started pointing to a waypoint, grab its net_signature and send that instead
 			waypoint* wp;
 			if ((wp = find_waypoint_at_indexes(aip->wp_list_index, aip->wp_index)) != nullptr) {
 				target_signature = Objects[wp->get_objnum()].net_signature;
 			}
-		} // Pefer the live target_objnum so clients know who is actually being attacked b/c
-		  // goals[0].target_name only covers explicitly ordered goal targets and is empty for
-		  // spontaneous IFF-based engagements, which would leave target_signature 0 and break
-		  // TARGET_CLOSEST_SHIP_ATTACKING_SELF on clients.
-		else if (aip->target_objnum >= 0) {
+		} else if (aip->target_objnum >= 0) {
+			// prefer live target_objnum so clients can check both ordered goal targets and spontaneous targets
 			target_signature = Objects[aip->target_objnum].net_signature;
-		}  // As last check, send the target signature. 2021 Version!
-		else if ((aip->goals[0].target_name != nullptr) && strlen(aip->goals[0].target_name) != 0) {
-			
+		}  else if ((aip->goals[0].target_name != nullptr) && strlen(aip->goals[0].target_name) != 0) {
+			// send the target signature. 2021 Version!
 			int instance = ship_name_lookup(aip->goals[0].target_name);
 			if (instance > -1) {
 				target_signature = Objects[Ships[instance].objnum].net_signature;


### PR DESCRIPTION
Pressing 'Target Nearest Attacker` in multiplayer does not work when a ship has spontaneously targeted another ship. This is because within, `multi_oo_pack_data` `goals[0].target_name` only covers explicitly ordered goal targets and is empty for spontaneous IFF-based engagements, which means `target_signature` does not return the proper value. This PR adds an extra check for that to pefer the live target_objnum so clients know who is actually being attacked.

Tested and works as expected.