### PR TITLE
Fix some issues with qtfred's ship list dialog

### DIFF
--- a/code/object/waypoint.cpp
+++ b/code/object/waypoint.cpp
@@ -433,7 +433,7 @@ void waypoint_stuff_name(SCP_string &dest, const char *waypoint_list_name, int w
 		return;
 	}
 
-	dest.assign(waypoint_list_name, name_max_len);
+	dest.assign(waypoint_list_name, std::min(strlen(waypoint_list_name), name_max_len));
 	dest += ":";
 	dest.append(std::to_string(waypoint_num));
 }

--- a/qtfred/src/mission/dialogs/SelectionDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/SelectionDialogModel.cpp
@@ -51,7 +51,7 @@ void SelectionDialogModel::initializeData() {
 		entry.id = i;
 		entry.selected = false;
 
-		_wing_list.push_back(entry);
+		_waypoint_list.push_back(entry);
 	}
 }
 void SelectionDialogModel::updateObjectList() {

--- a/qtfred/src/ui/dialogs/SelectionDialog.cpp
+++ b/qtfred/src/ui/dialogs/SelectionDialog.cpp
@@ -107,16 +107,13 @@ void SelectionDialog::objectSelectionChanged() {
 	auto current = _model->getObjectList(); // Copy the vector so we can change the selection
 
 	for (auto& entry : current) {
-		auto items =
-			ui->shipSelectionList->model()->match(ui->shipSelectionList->model()->index(0, 0), Qt::UserRole, entry.id);
-
-		Assertion(items.size() > 0, "No items for object index found!");
-		Assertion(items.size() <= 1, "Found multiple items for one object index!");
-
-		auto item = ui->shipSelectionList->item(items[0].row());
-
-		Assertion(item != nullptr, "Couldn't find item for index!");
-		entry.selected = item->isSelected();
+		for (int row = 0; row < ui->shipSelectionList->count(); ++row) {
+			auto* item = ui->shipSelectionList->item(row);
+			if (item->data(Qt::UserRole).value<int>() == entry.id) {
+				entry.selected = item->isSelected();
+				break;
+			}
+		}
 	}
 
 	_model->updateObjectSelection(current);


### PR DESCRIPTION
Fixes a few things here:

1. Waypoints in the list were having their name copied with characters past the null terminator causing junk characters to appear in the string.
2. Waypoints were being pushed to the wing list in a clear copy/paste error.
3. Fix a heap crash by changing it so that objectSelectionChanged() no longer uses model()->match() which returns a QList<QModelIndex>. These QModelIndex objects are heap-allocated inside Qt's DLL, but freed by the CRT causing an MSVC debug heap boundary violation.