### PR TITLE
Cache Animation submodel by model ID

### DIFF
--- a/code/model/animation/modelanimation.cpp
+++ b/code/model/animation/modelanimation.cpp
@@ -420,7 +420,8 @@ namespace animation {
 	}
 
 	void ModelAnimationSubmodel::reset(polymodel_instance* pmi) {
-		if(!m_submodel)
+		auto cache_it = m_submodel.find(pmi->model_num);
+		if (cache_it == m_submodel.end())
 			findSubmodel(pmi);
 
 		auto dataIt = m_initialData.find({ pmi->id });
@@ -515,8 +516,9 @@ namespace animation {
 		polymodel* pm = model_get(pmi->model_num);
 
 		//Do we have a submodel number already cached?
-		if (m_submodel)
-			submodelNumber = *m_submodel;
+		auto cache_it = m_submodel.find(pm->id);
+		if (cache_it != m_submodel.end())
+			submodelNumber = cache_it->second;
 		//We seem to have a submodel name
 		else {
 			for (int i = 0; i < pm->n_models; i++) {
@@ -526,7 +528,7 @@ namespace animation {
 				}
 			}
 
-			m_submodel = submodelNumber;
+			m_submodel.emplace(pm->id, submodelNumber);
 		}
 
 		//If the model does not exist, return null. The system is expected to just silently tolerate this,
@@ -559,11 +561,12 @@ namespace animation {
 		polymodel* pm = model_get(pmi->model_num);
 
 		//Do we have a submodel number already cached?
-		if (m_submodel)
-			submodelNumber = *m_submodel;
+		auto cache_it = m_submodel.find(pm->id);
+		if (cache_it != m_submodel.end())
+			submodelNumber = cache_it->second;
 		//Do we know if we were told to find the barrel submodel or not? This implies we have a subsystem name, not a submodel name
 		else {
-			ship_info* sip = nullptr;
+			const ship_info* sip = nullptr;
 			if (pmi->objnum >= 0) {
 				sip = &Ship_info[Ships[Objects[pmi->objnum].instance].ship_info_index];
 			}
@@ -579,7 +582,7 @@ namespace animation {
 
 			for (int i = 0; i < sip->n_subsystems; i++) {
 				if (!subsystem_stricmp(sip->subsystems[i].subobj_name, m_name.c_str())) {
-					if ((bool)m_findBarrel) {
+					if (m_findBarrel) {
 						//Check if the barrel subobj is a dedicated existing subobj or just the base turret.
 						if (sip->subsystems[i].turret_gun_sobj != sip->subsystems[i].subobj_num)
 							submodelNumber = sip->subsystems[i].turret_gun_sobj;
@@ -592,7 +595,7 @@ namespace animation {
 				}
 			}
 
-			m_submodel = submodelNumber;
+			m_submodel.emplace(pm->id, submodelNumber);
 		}
 
 		//If the model does not exist, return null. The system is expected to just silently tolerate this,
@@ -682,7 +685,7 @@ namespace animation {
 
 		for (const auto& submodel : other.m_submodels) {
 			auto newSubmodel = std::shared_ptr<ModelAnimationSubmodel>(submodel->copy());
-			newSubmodel->m_submodel = std::nullopt;
+			newSubmodel->m_submodel = {};
 			m_submodels.push_back(newSubmodel);
 		}
 

--- a/code/model/animation/modelanimation.h
+++ b/code/model/animation/modelanimation.h
@@ -127,7 +127,8 @@ namespace animation {
 	class ModelAnimationSubmodel {
 	protected:
 		SCP_string m_name;
-		std::optional<int> m_submodel;
+		//This maps from model id to submodel ID, as if an animation is reused on different models (such as with techroom models), IDs might differ per model
+		SCP_unordered_map<int, int> m_submodel;
 		bool is_turret = false;
 
 	private:


### PR DESCRIPTION
Fixes an issue where ships with techroom POFs in a different subsystem structure would break the animation systems submodel caching