### PR TITLE
remove redundant waypoint position by delegating to the game object

### DIFF
--- a/code/object/waypoint.cpp
+++ b/code/object/waypoint.cpp
@@ -20,9 +20,9 @@ const int INVALID_WAYPOINT_POSITION = INT_MAX;
 //********************CLASS MEMBERS********************
 waypoint::waypoint()
 {
-	this->m_position.xyz.x = 0.0f;
-	this->m_position.xyz.y = 0.0f;
-	this->m_position.xyz.z = 0.0f;
+	this->m_parsed_position.xyz.x = 0.0f;
+	this->m_parsed_position.xyz.y = 0.0f;
+	this->m_parsed_position.xyz.z = 0.0f;
 
 	this->m_objnum = -1;
 }
@@ -31,9 +31,9 @@ waypoint::waypoint(const vec3d *position)
 {
 	Assert(position != NULL);
 
-	this->m_position.xyz.x = position->xyz.x;
-	this->m_position.xyz.y = position->xyz.y;
-	this->m_position.xyz.z = position->xyz.z;
+	this->m_parsed_position.xyz.x = position->xyz.x;
+	this->m_parsed_position.xyz.y = position->xyz.y;
+	this->m_parsed_position.xyz.z = position->xyz.z;
 
 	this->m_objnum = -1;
 }
@@ -45,7 +45,10 @@ waypoint::~waypoint()
 
 const vec3d *waypoint::get_pos() const
 {
-	return &m_position;
+	if (m_objnum >= 0)
+		return &Objects[m_objnum].pos;
+
+	return &m_parsed_position;
 }
 
 int waypoint::get_objnum() const
@@ -90,7 +93,11 @@ int waypoint::get_index() const
 void waypoint::set_pos(const vec3d *pos)
 {
 	Assert(pos != NULL);
-	this->m_position = *pos;
+
+	if (m_objnum >= 0)
+		Objects[m_objnum].pos = *pos;
+	else
+		this->m_parsed_position = *pos;
 }
 
 waypoint_list::waypoint_list()

--- a/code/object/waypoint.h
+++ b/code/object/waypoint.h
@@ -26,7 +26,7 @@ class waypoint
 		void set_pos(const vec3d *pos);
 
 	private:
-		vec3d m_position;
+		vec3d m_parsed_position;	// only relevant until the game object is created, after which the waypoint delegates to the object position
 		int m_objnum;
 
 	friend void waypoint_create_game_object(waypoint *wpt, int list_index, int wpt_index);

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -9512,7 +9512,6 @@ void sexp_set_object_position(int n)
 
 		case OSWPT_TYPE_WAYPOINT:
 		{
-			oswpt.objp()->pos = target_vec;
 			oswpt.waypointp()->set_pos(&target_vec);
 			Current_sexp_network_packet.start_callback();
 			Current_sexp_network_packet.send_ushort(oswpt.objp()->net_signature);
@@ -9600,7 +9599,6 @@ void multi_sexp_set_object_position()
 	Current_sexp_network_packet.get_float(wp_vec.xyz.z);
 	objp = multi_get_network_object(obj_sig);
 	if (objp->type == OBJ_WAYPOINT) {
-		objp->pos = wp_vec;
 		waypoint *wpt = find_waypoint_with_instance(objp->instance);
 		wpt->set_pos(&wp_vec);
 	}

--- a/code/scripting/api/objs/object.cpp
+++ b/code/scripting/api/objs/object.cpp
@@ -175,10 +175,11 @@ ADE_VIRTVAR(Position, l_Object, "vector", "Object world position (World vector)"
 		return ade_set_error(L, "o", l_Vector.Set(vmd_zero_vector));
 
 	if(ADE_SETTING_VAR && v3 != NULL) {
-		objh->objp()->pos = *v3;
 		if (objh->objp()->type == OBJ_WAYPOINT) {
 			waypoint *wpt = find_waypoint_with_instance(objh->objp()->instance);
 			wpt->set_pos(v3);
+		} else {
+			objh->objp()->pos = *v3;
 		}
 
 		if (objh->objp()->flags[Object::Object_Flags::Collides])


### PR DESCRIPTION
The waypoint class stored its position in m_position separately from the game object's pos field, requiring callers to manually keep both in sync. Now get_pos() and set_pos() delegate to the object position when the game object exists, falling back to the parsed position only if the object does not exist.