### PR TITLE
fix mainhall music continuing to play during mission loop brief

### DIFF
--- a/code/missionui/missionloopbrief.cpp
+++ b/code/missionui/missionloopbrief.cpp
@@ -94,7 +94,7 @@ int Loop_brief_bitmap;
 
 generic_anim Loop_anim;
 
-int Loop_sound;
+int Loop_sound = -1;
 
 // ---------------------------------------------------------------------------------------------------------------------------------------
 // MISSION LOOP BRIEF FUNCTIONS
@@ -126,6 +126,9 @@ void loop_brief_init()
 {
 	int idx;
 	ui_button_info *b;
+
+	// init sound handle
+	Loop_sound = -1;
 
 	// load the background bitmap
 	Loop_brief_bitmap = bm_load(Loop_brief_fname[gr_screen.res]);

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -6293,6 +6293,10 @@ void mouse_force_pos(int x, int y);
 			break;		
 
 		case GS_STATE_LOOP_BRIEF:
+			if (old_state == GS_STATE_MAIN_MENU) {
+				main_hall_stop_music(true);
+				main_hall_stop_ambient();
+			}
 			loop_brief_init();
 			break;
 


### PR DESCRIPTION
When a player enters the mission loop screen from the main hall, there was no code to handle the stopping of main hall music and ambient sound.  Add code to handle this specific case.

Also fix `Loop_sound` not being initialized to -1 `in loop_brief_init()`, which caused an assert when closing the loop brief screen if no branch brief sound was defined for the mission.

Fixes #7330.