### PR TITLE
QtFRED - Fix menubar on windows

### DIFF
--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -803,6 +803,14 @@ bool FredView::event(QEvent* event) {
 		return QMainWindow::event(event);
 	}
 }
+void FredView::changeEvent(QEvent* event) {
+	QMainWindow::changeEvent(event);
+	// Force menubar repaint when reenabled after a modal dialog closes.
+	// Without this, menu items stay grey until the user mouses over them.
+	if (event->type() == QEvent::EnabledChange && isEnabled()) {
+		menuBar()->update();
+	}
+}
 void FredView::closeEvent(QCloseEvent* event) {
 	if (!maybePromptToSaveMissionChanges(tr("closing QtFRED"))) {
 		event->ignore();
@@ -817,6 +825,7 @@ void FredView::windowActivated() {
 	// Track the last active viewport
 	fred->setActiveViewport(_viewport);
 
+	menuBar()->update();
 	viewWindowActivated();
 }
 void FredView::windowDeactivated() {

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -170,6 +170,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void viewWindowActivated();
  protected:
  bool event(QEvent* event) override;
+	void changeEvent(QEvent* event) override;
  	void closeEvent(QCloseEvent* event) override;
 
 	void keyPressEvent(QKeyEvent* event) override;


### PR DESCRIPTION
The menubar on Windows would grey out when modal dialogs were opened and then never return to normal color until a mouseover event occurred after those dialogs were closed. This fixes the issue by forcing a repaint at appropriate times.