### PR TITLE
Fix standalone crash when client disconnects before mission loads

### DIFF
--- a/code/network/multi.cpp
+++ b/code/network/multi.cpp
@@ -1671,8 +1671,13 @@ void multi_standalone_reset_all()
 	// NETLOG
 	ml_string(NOX("Standalone resetting"));
 	
-	// shut all game stuff down
-	game_level_close();
+	// shut all game stuff down -- but only if a mission was actually in progress,
+	// otherwise scripting hooks in game_level_close() may fire into uninitialized
+	// subsystems (e.g. SEXP nodes never allocated because no mission was loaded)
+	if (Game_mode & GM_IN_MISSION) {
+		game_level_close();
+		Game_mode &= ~GM_IN_MISSION;
+	}
 
 	// reinitialize the gui
 	std_reset_standalone_gui();	

--- a/code/scripting/api/libs/mission.cpp
+++ b/code/scripting/api/libs/mission.cpp
@@ -201,6 +201,11 @@ ADE_FUNC(evaluateSEXP, l_Mission, "string", "Runs the defined SEXP script, and r
 	if(!ade_get_args(L, "s", &s))
 		return ADE_RETURN_FALSE;
 
+	if (Sexp_nodes == nullptr) {
+		Warning(LOCATION, "evaluateSEXP called before SEXP system initialized; returning false");
+		return ADE_RETURN_FALSE;
+	}
+
 	r_val = run_sexp(s);
 
 	if (r_val == SEXP_TRUE)
@@ -218,6 +223,11 @@ ADE_FUNC(evaluateNumericSEXP, l_Mission, "string", "Runs the defined SEXP script
 	if (!ade_get_args(L, "s", &s))
 		return ade_set_args(L, "i", 0);
 
+	if (Sexp_nodes == nullptr) {
+		Warning(LOCATION, "evaluateNumericSEXP called before SEXP system initialized; returning NaN");
+		return ade_set_args(L, "f", std::numeric_limits<float>::quiet_NaN());
+	}
+
 	r_val = run_sexp(s, true, &got_nan);
 
 	if (got_nan)
@@ -234,6 +244,11 @@ ADE_FUNC(runSEXP, l_Mission, "string", "Runs the defined SEXP script within a `w
 
 	if(!ade_get_args(L, "s", &s))
 		return ADE_RETURN_FALSE;
+
+	if (Sexp_nodes == nullptr) {
+		Warning(LOCATION, "runSEXP called before SEXP system initialized; returning false");
+		return ADE_RETURN_FALSE;
+	}
 
 	while (is_white_space(*s))
 		s++;


### PR DESCRIPTION
When a client connects to a standalone server and backs out before a mission is loaded, multi_standalone_reset_all() calls game_level_close() which fires OnMissionAboutToEnd/OnMissionEnd scripting hooks. If any mod script calls mn.evaluateSEXP() from those hooks, alloc_sexp() crashes because the SEXP system was never initialized (Locked_sexp_true/false are still -1, Sexp_nodes is nullptr).

Guard multi_standalone_reset_all() to only call game_level_close() when GM_IN_MISSION is set, and additionally guard game_level_close() to skip scripting hooks when Sexp_nodes is uninitialized.

Fixes #7353