### PR TITLE
Fix standalone web UI crash when polling player data before ship selection

### DIFF
--- a/code/network/stand_gui-unix.cpp
+++ b/code/network/stand_gui-unix.cpp
@@ -457,7 +457,11 @@ json_t* playerGet(ResourceContext * /*context*/) {
         json_object_set(obj, "host", (MULTI_HOST(p)) ? json_true() : json_false());
         json_object_set(obj, "observer", (MULTI_OBSERVER(p)) ? json_true() : json_false());
         json_object_set(obj, "callsign", json_string(p.m_player->callsign));
-        json_object_set(obj, "ship", json_string(Ship_info[p.p_info.ship_class].name));
+        if (p.p_info.ship_class >= 0 && p.p_info.ship_class < ship_info_size()) {
+            json_object_set(obj, "ship", json_string(Ship_info[p.p_info.ship_class].name));
+        } else {
+            json_object_set(obj, "ship", json_string(""));
+        }
 
         json_array_append(playerList, obj);
     }

--- a/code/network/stand_gui.cpp
+++ b/code/network/stand_gui.cpp
@@ -1067,7 +1067,7 @@ void std_pinfo_display_player_info(net_player *p)
 	txt[sizeof(txt)-1] = '\0';
 
 	// set his ship type -- Cyborg17, if it's valid!
-	if (p->p_info.ship_class >= 0 && p->p_info.ship_class < static_cast<int>(Ship_info.size())) {
+	if (p->p_info.ship_class >= 0 && p->p_info.ship_class < ship_info_size()) {
 		SetWindowText(Player_ship_type, Ship_info[p->p_info.ship_class].name);
 	}
 


### PR DESCRIPTION
playerGet() indexed Ship_info with ship_class without bounds checking. Before ship selection, ship_class is -1, which as an unsigned index causes an out-of-bounds access. Add the same bounds check that the Windows standalone GUI already has.

Fixes #7366