### PR TITLE
QtFred cleanup prefs dialog and persist more settings

### DIFF
--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -135,6 +135,8 @@ EditorViewport::EditorViewport(Editor* in_editor, std::unique_ptr<FredRenderer>&
 void EditorViewport::loadSettings() {
 	QSettings settings;
 	settings.beginGroup(SETTINGS_GROUP);
+	toolbar_icon_size                  = settings.value("toolbar_icon_size",                  toolbar_icon_size).toInt();
+	Offer_autosave_recovery            = settings.value("offer_autosave_recovery",            Offer_autosave_recovery).toBool();
 	Move_ships_when_undocking          = settings.value("move_ships_when_undocking",          Move_ships_when_undocking).toBool();
 	Always_save_display_names          = settings.value("always_save_display_names",          Always_save_display_names).toBool();
 	Error_checker_checks_potential_issues = settings.value("error_checker_checks_potential_issues", Error_checker_checks_potential_issues).toBool();
@@ -144,12 +146,37 @@ void EditorViewport::loadSettings() {
 	Show_sexp_help_ship_editor         = settings.value("show_sexp_help_ship_editor",         Show_sexp_help_ship_editor).toBool();
 	Show_sexp_help_wing_editor         = settings.value("show_sexp_help_wing_editor",         Show_sexp_help_wing_editor).toBool();
 	Dark_mode                          = settings.value("dark_mode",                          Dark_mode).toBool();
+
+	view.Universal_heading                 = settings.value("view_universal_heading",                 view.Universal_heading).toBool();
+	view.Show_stars                        = settings.value("view_show_stars",                        view.Show_stars).toBool();
+	view.Show_horizon                      = settings.value("view_show_horizon",                      view.Show_horizon).toBool();
+	view.Show_grid                         = settings.value("view_show_grid",                         view.Show_grid).toBool();
+	view.Show_distances                    = settings.value("view_show_distances",                    view.Show_distances).toBool();
+	view.Show_coordinates                  = settings.value("view_show_coordinates",                  view.Show_coordinates).toBool();
+	view.Show_outlines                     = settings.value("view_show_outlines",                     view.Show_outlines).toBool();
+	view.Draw_outlines_on_selected_ships   = settings.value("view_draw_outlines_on_selected_ships",   view.Draw_outlines_on_selected_ships).toBool();
+	view.Draw_outline_at_warpin_position   = settings.value("view_draw_outline_at_warpin_position",   view.Draw_outline_at_warpin_position).toBool();
+	view.Show_grid_positions               = settings.value("view_show_grid_positions",               view.Show_grid_positions).toBool();
+	view.Show_dock_points                  = settings.value("view_show_dock_points",                  view.Show_dock_points).toBool();
+	view.Show_bay_paths                    = settings.value("view_show_bay_paths",                    view.Show_bay_paths).toBool();
+	view.Show_starts                       = settings.value("view_show_starts",                       view.Show_starts).toBool();
+	view.Show_ships                        = settings.value("view_show_ships",                        view.Show_ships).toBool();
+	view.Show_ship_info                    = settings.value("view_show_ship_info",                    view.Show_ship_info).toBool();
+	view.Show_ship_models                  = settings.value("view_show_ship_models",                  view.Show_ship_models).toBool();
+	view.Show_paths_fred                   = settings.value("view_show_paths_fred",                   view.Show_paths_fred).toBool();
+	view.Lighting_on                       = settings.value("view_lighting_on",                       view.Lighting_on).toBool();
+	view.FullDetail                        = settings.value("view_full_detail",                       view.FullDetail).toBool();
+	view.Show_waypoints                    = settings.value("view_show_waypoints",                    view.Show_waypoints).toBool();
+	view.Show_compass                      = settings.value("view_show_compass",                      view.Show_compass).toBool();
+	view.Highlight_selectable_subsys       = settings.value("view_highlight_selectable_subsys",       view.Highlight_selectable_subsys).toBool();
 	settings.endGroup();
 }
 
 void EditorViewport::saveSettings() const {
 	QSettings settings;
 	settings.beginGroup(SETTINGS_GROUP);
+	settings.setValue("toolbar_icon_size",                   toolbar_icon_size);
+	settings.setValue("offer_autosave_recovery",             Offer_autosave_recovery);
 	settings.setValue("move_ships_when_undocking",           Move_ships_when_undocking);
 	settings.setValue("always_save_display_names",           Always_save_display_names);
 	settings.setValue("error_checker_checks_potential_issues", Error_checker_checks_potential_issues);
@@ -159,6 +186,29 @@ void EditorViewport::saveSettings() const {
 	settings.setValue("show_sexp_help_ship_editor",          Show_sexp_help_ship_editor);
 	settings.setValue("show_sexp_help_wing_editor",          Show_sexp_help_wing_editor);
 	settings.setValue("dark_mode",                           Dark_mode);
+
+	settings.setValue("view_universal_heading",                 view.Universal_heading);
+	settings.setValue("view_show_stars",                        view.Show_stars);
+	settings.setValue("view_show_horizon",                      view.Show_horizon);
+	settings.setValue("view_show_grid",                         view.Show_grid);
+	settings.setValue("view_show_distances",                    view.Show_distances);
+	settings.setValue("view_show_coordinates",                  view.Show_coordinates);
+	settings.setValue("view_show_outlines",                     view.Show_outlines);
+	settings.setValue("view_draw_outlines_on_selected_ships",   view.Draw_outlines_on_selected_ships);
+	settings.setValue("view_draw_outline_at_warpin_position",   view.Draw_outline_at_warpin_position);
+	settings.setValue("view_show_grid_positions",               view.Show_grid_positions);
+	settings.setValue("view_show_dock_points",                  view.Show_dock_points);
+	settings.setValue("view_show_bay_paths",                    view.Show_bay_paths);
+	settings.setValue("view_show_starts",                       view.Show_starts);
+	settings.setValue("view_show_ships",                        view.Show_ships);
+	settings.setValue("view_show_ship_info",                    view.Show_ship_info);
+	settings.setValue("view_show_ship_models",                  view.Show_ship_models);
+	settings.setValue("view_show_paths_fred",                   view.Show_paths_fred);
+	settings.setValue("view_lighting_on",                       view.Lighting_on);
+	settings.setValue("view_full_detail",                       view.FullDetail);
+	settings.setValue("view_show_waypoints",                    view.Show_waypoints);
+	settings.setValue("view_show_compass",                      view.Show_compass);
+	settings.setValue("view_highlight_selectable_subsys",       view.Highlight_selectable_subsys);
 	settings.endGroup();
 }
 void EditorViewport::needsUpdate() {

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -201,6 +201,8 @@ class EditorViewport {
 
 	bool Group_rotate = true;
 	bool Lookat_mode = false;
+	int  toolbar_icon_size = 24;  ///< Toolbar icon size in pixels (16, 24, or 32)
+	bool Offer_autosave_recovery = true;
 	bool Move_ships_when_undocking = true;
 	bool Always_save_display_names = false;
 	bool Error_checker_checks_potential_issues = true;

--- a/qtfred/src/mission/dialogs/PreferencesDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/PreferencesDialogModel.cpp
@@ -9,6 +9,7 @@ namespace fso::fred::dialogs {
 
 PreferencesDialogModel::PreferencesDialogModel(QObject* parent, EditorViewport* viewport)
 	: AbstractDialogModel(parent, viewport)
+	, _offerAutosaveRecovery(viewport->Offer_autosave_recovery)
 	, _moveShipsWhenUndocking(viewport->Move_ships_when_undocking)
 	, _alwaysSaveDisplayNames(viewport->Always_save_display_names)
 	, _errorCheckerChecksForPotentialIssues(viewport->Error_checker_checks_potential_issues)
@@ -18,6 +19,7 @@ PreferencesDialogModel::PreferencesDialogModel(QObject* parent, EditorViewport* 
 	, _showSexpHelpShipEditor(viewport->Show_sexp_help_ship_editor)
 	, _showSexpHelpWingEditor(viewport->Show_sexp_help_wing_editor)
 	, _darkMode(viewport->Dark_mode)
+	, _toolbarIconSize(viewport->toolbar_icon_size)
 	, _gridCenterX(static_cast<int>(viewport->The_grid->center.xyz.x))
 	, _gridCenterY(static_cast<int>(viewport->The_grid->center.xyz.y))
 	, _gridCenterZ(static_cast<int>(viewport->The_grid->center.xyz.z))
@@ -39,6 +41,7 @@ PreferencesDialogModel::PreferencesDialogModel(QObject* parent, EditorViewport* 
 }
 
 bool PreferencesDialogModel::apply() {
+	_viewport->Offer_autosave_recovery   = _offerAutosaveRecovery;
 	_viewport->Move_ships_when_undocking = _moveShipsWhenUndocking;
 	_viewport->Always_save_display_names = _alwaysSaveDisplayNames;
 	_viewport->Error_checker_checks_potential_issues = _errorCheckerChecksForPotentialIssues;
@@ -48,6 +51,7 @@ bool PreferencesDialogModel::apply() {
 	_viewport->Show_sexp_help_ship_editor       = _showSexpHelpShipEditor;
 	_viewport->Show_sexp_help_wing_editor       = _showSexpHelpWingEditor;
 	_viewport->Dark_mode                        = _darkMode;
+	_viewport->toolbar_icon_size                = _toolbarIconSize;
 
 	_viewport->saveSettings();
 	applyEditorTheme(_darkMode);
@@ -86,6 +90,9 @@ void PreferencesDialogModel::reject() {
 	// Nothing to do — data sources are not modified until apply()
 }
 
+bool PreferencesDialogModel::getOfferAutosaveRecovery() const { return _offerAutosaveRecovery; }
+void PreferencesDialogModel::setOfferAutosaveRecovery(bool value) { modify(_offerAutosaveRecovery, value); }
+
 bool PreferencesDialogModel::getMoveShipsWhenUndocking() const { return _moveShipsWhenUndocking; }
 void PreferencesDialogModel::setMoveShipsWhenUndocking(bool value) { modify(_moveShipsWhenUndocking, value); }
 
@@ -108,6 +115,9 @@ void PreferencesDialogModel::setShowSexpHelpWingEditor(bool value) { modify(_sho
 
 bool PreferencesDialogModel::getDarkMode() const { return _darkMode; }
 void PreferencesDialogModel::setDarkMode(bool value) { modify(_darkMode, value); }
+
+int  PreferencesDialogModel::getToolbarIconSize() const { return _toolbarIconSize; }
+void PreferencesDialogModel::setToolbarIconSize(int size) { modify(_toolbarIconSize, size); }
 
 QKeySequence PreferencesDialogModel::getControlKey(ControlAction action) const {
 	auto it = _controlKeys.find(action);

--- a/qtfred/src/mission/dialogs/PreferencesDialogModel.h
+++ b/qtfred/src/mission/dialogs/PreferencesDialogModel.h
@@ -18,6 +18,9 @@ public:
 	void reject() override;
 
 	// General
+	bool getOfferAutosaveRecovery() const;
+	void setOfferAutosaveRecovery(bool value);
+
 	bool getMoveShipsWhenUndocking() const;
 	void setMoveShipsWhenUndocking(bool value);
 
@@ -41,6 +44,9 @@ public:
 	bool getDarkMode() const;
 	void setDarkMode(bool value);
 
+	int  getToolbarIconSize() const;
+	void setToolbarIconSize(int size);
+
 	// Controls
 	QKeySequence getControlKey(ControlAction action) const;
 	void setControlKey(ControlAction action, const QKeySequence& sequence);
@@ -60,6 +66,7 @@ public:
 
 private:
 	// General
+	bool _offerAutosaveRecovery;
 	bool _moveShipsWhenUndocking;
 	bool _alwaysSaveDisplayNames;
 	bool _errorCheckerChecksForPotentialIssues;
@@ -69,6 +76,7 @@ private:
 	bool _showSexpHelpShipEditor;
 	bool _showSexpHelpWingEditor;
 	bool _darkMode;
+	int  _toolbarIconSize;
 
 	// Controls
 	std::map<ControlAction, QKeySequence> _controlKeys;

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -170,6 +170,8 @@ void FredView::setEditor(Editor* editor, EditorViewport* viewport) {
 	fred = editor;
 	_viewport = viewport;
 
+	setIconSize(QSize(_viewport->toolbar_icon_size, _viewport->toolbar_icon_size));
+
 	// Let the viewport use us for displaying dialogs
 	_viewport->dialogProvider = this;
 
@@ -241,7 +243,7 @@ void FredView::loadMissionFile(const QString& pathName, int flags) {
 		fred->clean_up_selections();
 
 		auto pathToLoad = pathName.toStdString();
-		if (!(flags & MPF_IS_TEMPLATE))
+		if (!(flags & MPF_IS_TEMPLATE) && _viewport->Offer_autosave_recovery)
 			fred->maybeUseAutosave(pathToLoad);
 
 		fred->loadMission(pathToLoad, flags);
@@ -795,6 +797,7 @@ void FredView::connectActionToViewSetting(QAction* option, bool* destination) {
 
 		// View settings have changed so we need to update the window
 		_viewport->needsUpdate();
+		_viewport->saveSettings();
 	});
 }
 void FredView::connectActionToViewSetting(QAction* option, std::vector<bool>* vector, size_t idx) {

--- a/qtfred/src/ui/dialogs/PreferencesDialog.cpp
+++ b/qtfred/src/ui/dialogs/PreferencesDialog.cpp
@@ -46,6 +46,8 @@ PreferencesDialog::PreferencesDialog(FredView* parent, EditorViewport* viewport)
 	: QDialog(parent)
 	, ui(new Ui::PreferencesDialog())
 	, _model(new PreferencesDialogModel(this, viewport))
+	, _fredView(parent)
+	, _viewport(viewport)
 {
 	ui->setupUi(this);
 
@@ -53,19 +55,15 @@ PreferencesDialog::PreferencesDialog(FredView* parent, EditorViewport* viewport)
 	updateUi();
 
 	connect(_model.get(), &PreferencesDialogModel::modelChanged, this, &PreferencesDialog::updateUi);
+	connect(_model.get(), &PreferencesDialogModel::modelChanged, this, &PreferencesDialog::applyChanges);
 }
 
 PreferencesDialog::~PreferencesDialog() = default;
 
-void PreferencesDialog::accept() {
-	if (_model->apply()) {
-		QDialog::accept();
-	}
-}
-
-void PreferencesDialog::reject() {
-	_model->reject();
-	QDialog::reject();
+void PreferencesDialog::applyChanges() {
+	_model->apply();
+	_fredView->setIconSize(QSize(_model->getToolbarIconSize(), _model->getToolbarIconSize()));
+	_viewport->needsUpdate();
 }
 
 void PreferencesDialog::initializeUi() {
@@ -86,10 +84,14 @@ void PreferencesDialog::updateUi() {
 	util::SignalBlockers blockers(this);
 
 	// General
+	ui->offerAutosaveRecovery->setChecked(_model->getOfferAutosaveRecovery());
 	ui->moveShipsWhenUndocking->setChecked(_model->getMoveShipsWhenUndocking());
 	ui->alwaysSaveDisplayNames->setChecked(_model->getAlwaysSaveDisplayNames());
 	ui->errorCheckerChecksForPotentialIssues->setChecked(_model->getErrorCheckerChecksForPotentialIssues());
-	ui->darkMode->setChecked(_model->getDarkMode());
+	ui->themeCombo->setCurrentIndex(_model->getDarkMode() ? 1 : 0);
+
+	const int iconSize = _model->getToolbarIconSize();
+	ui->toolbarIconSizeCombo->setCurrentIndex(iconSize <= 16 ? 0 : iconSize >= 32 ? 2 : 1);
 	ui->showSexpHelpMissionEvents->setChecked(_model->getShowSexpHelpMissionEvents());
 	ui->showSexpHelpMissionGoals->setChecked(_model->getShowSexpHelpMissionGoals());
 	ui->showSexpHelpMissionCutscenes->setChecked(_model->getShowSexpHelpMissionCutscenes());
@@ -117,6 +119,10 @@ void PreferencesDialog::updateUi() {
 	}
 }
 
+void PreferencesDialog::on_offerAutosaveRecovery_toggled(bool checked) {
+	_model->setOfferAutosaveRecovery(checked);
+}
+
 void PreferencesDialog::on_moveShipsWhenUndocking_toggled(bool checked) {
 	_model->setMoveShipsWhenUndocking(checked);
 }
@@ -129,8 +135,13 @@ void PreferencesDialog::on_errorCheckerChecksForPotentialIssues_toggled(bool che
 	_model->setErrorCheckerChecksForPotentialIssues(checked);
 }
 
-void PreferencesDialog::on_darkMode_toggled(bool checked) {
-	_model->setDarkMode(checked);
+void PreferencesDialog::on_toolbarIconSizeCombo_currentIndexChanged(int index) {
+	static constexpr int sizes[] = { 16, 24, 32 };
+	_model->setToolbarIconSize(sizes[index]);
+}
+
+void PreferencesDialog::on_themeCombo_currentIndexChanged(int index) {
+	_model->setDarkMode(index == 1);
 }
 
 void PreferencesDialog::on_showSexpHelpMissionEvents_toggled(bool checked) {

--- a/qtfred/src/ui/dialogs/PreferencesDialog.h
+++ b/qtfred/src/ui/dialogs/PreferencesDialog.h
@@ -20,15 +20,15 @@ public:
 	explicit PreferencesDialog(FredView* parent, EditorViewport* viewport);
 	~PreferencesDialog() override;
 
-	void accept() override;
-	void reject() override;
-
 private slots:
+	void applyChanges();
 	// General
+	void on_offerAutosaveRecovery_toggled(bool checked);
 	void on_moveShipsWhenUndocking_toggled(bool checked);
 	void on_alwaysSaveDisplayNames_toggled(bool checked);
 	void on_errorCheckerChecksForPotentialIssues_toggled(bool checked);
-	void on_darkMode_toggled(bool checked);
+	void on_toolbarIconSizeCombo_currentIndexChanged(int index);
+	void on_themeCombo_currentIndexChanged(int index);
 	void on_showSexpHelpMissionEvents_toggled(bool checked);
 	void on_showSexpHelpMissionGoals_toggled(bool checked);
 	void on_showSexpHelpMissionCutscenes_toggled(bool checked);
@@ -56,6 +56,8 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::PreferencesDialog> ui;
 	std::unique_ptr<PreferencesDialogModel> _model;
 	std::map<ControlAction, QKeySequenceEdit*> _controlEditors;
+	FredView* _fredView = nullptr;
+	EditorViewport* _viewport = nullptr;
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/ui/PreferencesDialog.ui
+++ b/qtfred/ui/PreferencesDialog.ui
@@ -25,31 +25,96 @@
       </attribute>
       <layout class="QVBoxLayout" name="generalLayout">
        <item>
-        <widget class="QCheckBox" name="moveShipsWhenUndocking">
-         <property name="text">
-          <string>Move Ships When Undocking</string>
+        <widget class="QGroupBox" name="appearanceGroup">
+         <property name="title">
+          <string>Appearance</string>
          </property>
+         <layout class="QFormLayout" name="appearanceLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="themeLabel">
+            <property name="text">
+             <string>Theme:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="themeCombo">
+            <item>
+             <property name="text">
+              <string>Light</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dark</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="toolbarIconSizeLabel">
+            <property name="text">
+             <string>Toolbar icon size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="toolbarIconSizeCombo">
+            <item>
+             <property name="text">
+              <string>Small (16px)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Medium (24px)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Large (32px)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="alwaysSaveDisplayNames">
-         <property name="text">
-          <string>Always save Display Names</string>
+        <widget class="QGroupBox" name="missionEditingGroup">
+         <property name="title">
+          <string>Mission Editing</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="errorCheckerChecksForPotentialIssues">
-         <property name="text">
-          <string>Error checker checks for potential issues</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="darkMode">
-         <property name="text">
-          <string>Dark mode</string>
-         </property>
+         <layout class="QVBoxLayout" name="missionEditingLayout">
+          <item>
+           <widget class="QCheckBox" name="offerAutosaveRecovery">
+            <property name="text">
+             <string>Offer to load backup file on mission open</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="moveShipsWhenUndocking">
+            <property name="text">
+             <string>Move Ships When Undocking</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="alwaysSaveDisplayNames">
+            <property name="text">
+             <string>Always save Display Names</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="errorCheckerChecksForPotentialIssues">
+            <property name="text">
+             <string>Error checker checks for potential issues</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
@@ -261,7 +326,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Close</set>
      </property>
     </widget>
    </item>
@@ -269,22 +334,6 @@
  </widget>
  <resources/>
  <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>fso::fred::dialogs::PreferencesDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>390</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>410</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>


### PR DESCRIPTION
A little visual cleanup pass on the preferences dialog and adds several settings to those that are persisted between app instances through QSettings.