### PR TITLE
QtFred Combined spooled music selector/player widget

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -321,6 +321,8 @@ add_file_folder("Source/UI/Widgets"
 	src/ui/widgets/SimpleListSelectDialog.h
 	src/ui/widgets/weaponList.cpp
 	src/ui/widgets/weaponList.h
+	src/ui/widgets/MusicComboWidget.cpp
+	src/ui/widgets/MusicComboWidget.h
 )
 
 add_file_folder("UI"

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
@@ -284,7 +284,7 @@ void BriefingEditorDialog::updateUi()
 		const SCP_string& subName = _model->getSubstituteBriefingMusicName();
 		int smIdx = -1;
 		for (int i = 0; i < static_cast<int>(Spooled_music.size()); ++i) {
-			if (Spooled_music[i].name == subName) { smIdx = i; break; }
+			if (stricmp(Spooled_music[i].name, subName.c_str()) == 0) { smIdx = i; break; }
 		}
 		ui->musicPackWidget->setCurrentMusicIndex(smIdx);
 	}

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "mission/util.h"
 #include "ui/Theme.h"
+#include <gamesnd/eventmusic.h>
 #include "ui/widgets/BriefingMapWidget.h"
 #include "BriefingEditor/CameraCoordinatesDialog.h"
 #include "BriefingEditor/IconFromShipDialog.h"
@@ -111,6 +112,8 @@ void BriefingEditorDialog::accept()
 	// If apply() returns true, close the dialog
 	if (_model->apply()) {
 		_viewport->editor->autosave("briefing editor");
+		ui->defaultMusicWidget->stopPlayback();
+		ui->musicPackWidget->stopPlayback();
 		QDialog::accept();
 		create_default_grid(); // restore the grid back to the normal version
 	}
@@ -123,6 +126,8 @@ void BriefingEditorDialog::reject()
 	// If they do, it runs _model->apply() and returns the success value
 	// If they don't, it runs _model->reject() and returns true
 	if (rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		ui->defaultMusicWidget->stopPlayback();
+		ui->musicPackWidget->stopPlayback();
 		QDialog::reject(); // actually close
 		create_default_grid(); // restore the grid back to the normal version
 	}
@@ -218,6 +223,7 @@ void BriefingEditorDialog::applyMapWidgetAspectRatio()
 void BriefingEditorDialog::initializeUi()
 {
 	fso::fred::bindStandardIcon(ui->voiceFilePlayButton, QStyle::SP_MediaPlay);
+
 	util::SignalBlockers blockers(this);
 	ui->drawLinesCheckBox->setTristate(true);
 	ui->highlightCheckBox->setTristate(true);
@@ -248,12 +254,6 @@ void BriefingEditorDialog::initializeUi()
 		ui->iconTeamComboBox->addItem(iff.second.c_str(), iff.first);
 	}
 
-	auto musicList = _model->getMusicList();
-	for (const auto& m : musicList) {
-		ui->defaultMusicComboBox->addItem(m.c_str());
-		ui->musicPackComboBox->addItem(m.c_str());
-	}
-
 	// Initialize the formula tree editor
 	ui->formulaTreeView->initializeEditor(_viewport->editor, this);
 
@@ -276,8 +276,18 @@ void BriefingEditorDialog::updateUi()
 
 	ui->stageTextPlainTextEdit->setPlainText(QString::fromStdString(_model->getStageText()));
 	ui->voiceFileLineEdit->setText(QString::fromStdString(_model->getSpeechFilename()));
-	ui->defaultMusicComboBox->setCurrentIndex(_model->getBriefingMusicIndex());
-	ui->musicPackComboBox->setCurrentIndex(ui->musicPackComboBox->findText(_model->getSubstituteBriefingMusicName().c_str()));
+	// getBriefingMusicIndex() is 1-based (0 = None); widget uses Spooled_music index (-1 = None)
+	ui->defaultMusicWidget->setCurrentMusicIndex(_model->getBriefingMusicIndex() - 1);
+
+	// Substitute music is stored by name; find the corresponding Spooled_music index
+	{
+		const SCP_string& subName = _model->getSubstituteBriefingMusicName();
+		int smIdx = -1;
+		for (int i = 0; i < static_cast<int>(Spooled_music.size()); ++i) {
+			if (Spooled_music[i].name == subName) { smIdx = i; break; }
+		}
+		ui->musicPackWidget->setCurrentMusicIndex(smIdx);
+	}
 
 	SCP_string stages = "No Stages";
 	int total = _model->getTotalStages();
@@ -705,14 +715,28 @@ void BriefingEditorDialog::on_formulaTreeView_nodeChanged(int newTree)
 	_model->setFormula(newTree);
 }
 
-void BriefingEditorDialog::on_defaultMusicComboBox_currentIndexChanged(int index)
+void BriefingEditorDialog::on_defaultMusicWidget_currentIndexChanged(int spooledMusicIdx)
 {
-	_model->setBriefingMusicIndex(index);
+	// Model uses 1-based index (0 = None); widget uses Spooled_music index (-1 = None)
+	_model->setBriefingMusicIndex(spooledMusicIdx + 1);
 }
 
-void BriefingEditorDialog::on_musicPackComboBox_currentIndexChanged(int /*index*/)
+void BriefingEditorDialog::on_musicPackWidget_currentIndexChanged(int spooledMusicIdx)
 {
-	_model->setSubstituteBriefingMusicName(ui->musicPackComboBox->currentText().toUtf8().constData());
+	SCP_string name = (spooledMusicIdx >= 0 && spooledMusicIdx < static_cast<int>(Spooled_music.size()))
+	                      ? Spooled_music[spooledMusicIdx].name
+	                      : "";
+	_model->setSubstituteBriefingMusicName(name);
+}
+
+void BriefingEditorDialog::on_defaultMusicWidget_playbackStarted()
+{
+	ui->musicPackWidget->stopPlayback();
+}
+
+void BriefingEditorDialog::on_musicPackWidget_playbackStarted()
+{
+	ui->defaultMusicWidget->stopPlayback();
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.h
@@ -85,8 +85,10 @@ class BriefingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	void on_voiceFilePlayButton_clicked();
 	void on_formulaTreeView_nodeChanged(int newTree);
 
-	void on_defaultMusicComboBox_currentIndexChanged(int index);
-	void on_musicPackComboBox_currentIndexChanged(int /*index*/);
+	void on_defaultMusicWidget_currentIndexChanged(int spooledMusicIdx);
+	void on_musicPackWidget_currentIndexChanged(int spooledMusicIdx);
+	void on_defaultMusicWidget_playbackStarted();
+	void on_musicPackWidget_playbackStarted();
 
   private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::BriefingEditorDialog> ui;

--- a/qtfred/src/ui/dialogs/DebriefingDialog.cpp
+++ b/qtfred/src/ui/dialogs/DebriefingDialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_DebriefingDialog.h"
 #include "ui/Theme.h"
 #include "mission/util.h"
+#include <gamesnd/eventmusic.h>
 #include <globalincs/globals.h>
 #include <globalincs/linklist.h>
 #include <ui/util/default_dir.h>
@@ -35,6 +36,9 @@ void DebriefingDialog::accept()
 	// If apply() returns true, close the dialog
 	if (_model->apply()) {
 		_viewport->editor->autosave("debriefing editor");
+		ui->successMusicWidget->stopPlayback();
+		ui->averageMusicWidget->stopPlayback();
+		ui->failureMusicWidget->stopPlayback();
 		QDialog::accept();
 	}
 	// else: validation failed, don't close
@@ -46,6 +50,9 @@ void DebriefingDialog::reject()
 	// If they do, it runs _model->apply() and returns the success value
 	// If they don't, it runs _model->reject() and returns true
 	if (rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		ui->successMusicWidget->stopPlayback();
+		ui->averageMusicWidget->stopPlayback();
+		ui->failureMusicWidget->stopPlayback();
 		QDialog::reject(); // actually close
 	}
 	// else: do nothing, don't close
@@ -60,8 +67,9 @@ void DebriefingDialog::closeEvent(QCloseEvent* e)
 void DebriefingDialog::initializeUi()
 {
 	fso::fred::bindStandardIcon(ui->voiceFilePlayButton, QStyle::SP_MediaPlay);
+
 	util::SignalBlockers blockers(this);
-	
+
 	auto list = _model->getTeamList();
 
 	ui->actionChangeTeams->clear();
@@ -69,18 +77,6 @@ void DebriefingDialog::initializeUi()
 	for (const auto& team : list) {
 		ui->actionChangeTeams->addItem(QString::fromStdString(team.first), team.second);
 	}
-
-	auto musicList = _model->getMusicList();
-	QStringList qMusicList;
-	for (const auto& track : musicList) {
-		qMusicList << QString::fromStdString(track);
-	}
-	ui->successMusicComboBox->clear();
-	ui->successMusicComboBox->addItems(qMusicList);
-	ui->averageMusicComboBox->clear();
-	ui->averageMusicComboBox->addItems(qMusicList);
-	ui->failureMusicComboBox->clear();
-	ui->failureMusicComboBox->addItems(qMusicList);
 
 	// Initialize the formula tree editor
 	ui->formulaTreeView->initializeEditor(_viewport->editor, this);
@@ -114,10 +110,10 @@ void DebriefingDialog::updateUi()
 		ui->formulaTreeView->hilite_item(ui->formulaTreeView->select_sexp_node);
 	}
 
-	// Music tracks (data is index, UI is index + 1 to account for "None")
-	ui->successMusicComboBox->setCurrentIndex(_model->getSuccessMusicTrack() + 1);
-	ui->averageMusicComboBox->setCurrentIndex(_model->getAverageMusicTrack() + 1);
-	ui->failureMusicComboBox->setCurrentIndex(_model->getFailureMusicTrack() + 1);
+	// Music tracks: model uses Spooled_music index (-1 = None), widget uses the same convention
+	ui->successMusicWidget->setCurrentMusicIndex(_model->getSuccessMusicTrack());
+	ui->averageMusicWidget->setCurrentMusicIndex(_model->getAverageMusicTrack());
+	ui->failureMusicWidget->setCurrentMusicIndex(_model->getFailureMusicTrack());
 
 	enableDisableControls();
 }
@@ -240,19 +236,37 @@ void DebriefingDialog::on_formulaTreeView_nodeChanged(int newTree)
 	_model->setFormula(newTree);
 }
 
-void DebriefingDialog::on_successMusicComboBox_currentIndexChanged(int index)
+void DebriefingDialog::on_successMusicWidget_currentIndexChanged(int spooledMusicIdx)
 {
-	_model->setSuccessMusicTrack(index - 1); // -1 to account for "None"
+	_model->setSuccessMusicTrack(spooledMusicIdx);
 }
 
-void DebriefingDialog::on_averageMusicComboBox_currentIndexChanged(int index)
+void DebriefingDialog::on_averageMusicWidget_currentIndexChanged(int spooledMusicIdx)
 {
-	_model->setAverageMusicTrack(index - 1); // -1 to account for "None"
+	_model->setAverageMusicTrack(spooledMusicIdx);
 }
 
-void DebriefingDialog::on_failureMusicComboBox_currentIndexChanged(int index)
+void DebriefingDialog::on_failureMusicWidget_currentIndexChanged(int spooledMusicIdx)
 {
-	_model->setFailureMusicTrack(index - 1); // -1 to account for "None"
+	_model->setFailureMusicTrack(spooledMusicIdx);
+}
+
+void DebriefingDialog::on_successMusicWidget_playbackStarted()
+{
+	ui->averageMusicWidget->stopPlayback();
+	ui->failureMusicWidget->stopPlayback();
+}
+
+void DebriefingDialog::on_averageMusicWidget_playbackStarted()
+{
+	ui->successMusicWidget->stopPlayback();
+	ui->failureMusicWidget->stopPlayback();
+}
+
+void DebriefingDialog::on_failureMusicWidget_playbackStarted()
+{
+	ui->successMusicWidget->stopPlayback();
+	ui->averageMusicWidget->stopPlayback();
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/DebriefingDialog.h
+++ b/qtfred/src/ui/dialogs/DebriefingDialog.h
@@ -49,9 +49,12 @@ private slots:
 	void on_voiceFilePlayButton_clicked();
 	void on_formulaTreeView_nodeChanged(int newTree);
 
-	void on_successMusicComboBox_currentIndexChanged(int index);
-	void on_averageMusicComboBox_currentIndexChanged(int index);
-	void on_failureMusicComboBox_currentIndexChanged(int index);
+	void on_successMusicWidget_currentIndexChanged(int spooledMusicIdx);
+	void on_averageMusicWidget_currentIndexChanged(int spooledMusicIdx);
+	void on_failureMusicWidget_currentIndexChanged(int spooledMusicIdx);
+	void on_successMusicWidget_playbackStarted();
+	void on_averageMusicWidget_playbackStarted();
+	void on_failureMusicWidget_playbackStarted();
 
 private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::DebriefingDialog> ui;
@@ -61,6 +64,5 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	void initializeUi();
 	void updateUi();
 	void enableDisableControls();
-
 };
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/FictionViewerDialog.cpp
+++ b/qtfred/src/ui/dialogs/FictionViewerDialog.cpp
@@ -37,6 +37,7 @@ void FictionViewerDialog::accept()
 {
 	// If apply() returns true, close the dialog
 	if (_model->apply()) {
+		ui->musicWidget->stopPlayback();
 		QDialog::accept();
 	}
 	// else: validation failed, don't close
@@ -48,6 +49,7 @@ void FictionViewerDialog::reject()
 	// If they do, it runs _model->apply() and returns the success value
 	// If they don't, it runs _model->reject() and returns true
 	if (rejectOrCloseHandler(this, _model.get(), _viewport)) {
+		ui->musicWidget->stopPlayback();
 		QDialog::reject(); // actually close
 	}
 	// else: do nothing, don't close
@@ -65,35 +67,16 @@ void FictionViewerDialog::initializeUi()
 	ui->fontFileEdit->setMaxLength(_model->getMaxFontFileLength());
 	ui->voiceFileEdit->setMaxLength(_model->getMaxVoiceFileLength());
 
-	updateMusicComboBox();
 }
 
-void FictionViewerDialog::updateUi() {
+void FictionViewerDialog::updateUi()
+{
 	util::SignalBlockers blockers(this);
 
 	ui->storyFileEdit->setText(QString::fromStdString(_model->getStoryFile()));
 	ui->fontFileEdit->setText(QString::fromStdString(_model->getFontFile()));
 	ui->voiceFileEdit->setText(QString::fromStdString(_model->getVoiceFile()));
-	ui->musicComboBox->setCurrentIndex(ui->musicComboBox->findData(_model->getFictionMusic()));
-}
-
-void FictionViewerDialog::updateMusicComboBox()
-{
-	util::SignalBlockers blockers(this);
-	
-	ui->musicComboBox->clear();
-
-	const auto& musicOptions = _model->getMusicOptions();
-
-	if (musicOptions.empty()) {
-		ui->musicComboBox->setEnabled(false);
-		return;
-	}
-
-	ui->musicComboBox->setEnabled(true);
-	for (const auto& option : musicOptions) {
-		ui->musicComboBox->addItem(QString::fromStdString(option.first), option.second);
-	}
+	ui->musicWidget->setCurrentMusicIndex(_model->getFictionMusic());
 }
 
 void FictionViewerDialog::on_okAndCancelButtons_accepted()
@@ -121,9 +104,9 @@ void FictionViewerDialog::on_voiceFileEdit_textChanged(const QString& text)
 	_model->setVoiceFile(text.toUtf8().constData());
 }
 
-void FictionViewerDialog::on_musicComboBox_currentIndexChanged(int index)
+void FictionViewerDialog::on_musicWidget_currentIndexChanged(int spooledMusicIdx)
 {
-	_model->setFictionMusic(ui->musicComboBox->itemData(index).value<int>());
+	_model->setFictionMusic(spooledMusicIdx);
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/FictionViewerDialog.h
+++ b/qtfred/src/ui/dialogs/FictionViewerDialog.h
@@ -31,16 +31,13 @@ private slots:
 	void on_storyFileEdit_textChanged(const QString& text);
 	void on_fontFileEdit_textChanged(const QString& text);
 	void on_voiceFileEdit_textChanged(const QString& text);
-	void on_musicComboBox_currentIndexChanged(int index);
+
+	void on_musicWidget_currentIndexChanged(int spooledMusicIdx);
 
  private: // NOLINT(readability-redundant-access-specifiers)
 
 	void initializeUi();
 	void updateUi();
-
-	void updateMusicComboBox();
-
-	
 
 	EditorViewport* _viewport = nullptr;
 	std::unique_ptr<Ui::FictionViewerDialog> ui;

--- a/qtfred/src/ui/widgets/MusicComboWidget.cpp
+++ b/qtfred/src/ui/widgets/MusicComboWidget.cpp
@@ -1,0 +1,115 @@
+#include "ui/widgets/MusicComboWidget.h"
+#include "ui/Theme.h"
+
+#include <gamesnd/eventmusic.h>
+#include <sound/audiostr.h>
+
+#include <QComboBox>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QStyle>
+
+namespace fso::fred {
+
+MusicComboWidget::MusicComboWidget(QWidget* parent)
+	: QWidget(parent), _comboBox(new QComboBox(this)), _playButton(new QPushButton(this))
+{
+	auto* layout = new QHBoxLayout(this);
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->addWidget(_comboBox);
+	layout->addWidget(_playButton);
+
+	// Populate combo: "None" first, then all Spooled_music entries.
+	// Item data stores the Spooled_music index (-1 for None).
+	_comboBox->addItem(tr("None"), -1);
+	for (int i = 0; i < static_cast<int>(Spooled_music.size()); ++i) {
+		_comboBox->addItem(QString::fromStdString(Spooled_music[i].name), i);
+	}
+
+	fso::fred::bindStandardIcon(_playButton, QStyle::SP_MediaPlay);
+	_playButton->setEnabled(false); // disabled until a real track is selected
+
+	connect(_comboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, &MusicComboWidget::onComboChanged);
+	connect(_playButton, &QPushButton::clicked, this, &MusicComboWidget::onPlayButtonClicked);
+	connect(&_timer, &QTimer::timeout, this, &MusicComboWidget::onTimerTick);
+	_timer.start(250);
+}
+
+MusicComboWidget::~MusicComboWidget()
+{
+	stopPlayback();
+}
+
+int MusicComboWidget::currentMusicIndex() const
+{
+	return _comboBox->currentData().value<int>();
+}
+
+void MusicComboWidget::setCurrentMusicIndex(int spooledIdx)
+{
+	const int pos = _comboBox->findData(spooledIdx);
+	if (pos >= 0)
+		_comboBox->setCurrentIndex(pos);
+	// Signals may be blocked by the caller (e.g. SignalBlockers in updateUi), so
+	// update the button state directly rather than relying on onComboChanged firing.
+	_playButton->setEnabled(currentMusicIndex() >= 0);
+}
+
+void MusicComboWidget::stopPlayback()
+{
+	if (_streamId >= 0) {
+		audiostream_close_file(_streamId, false);
+		_streamId = -1;
+	}
+	fso::fred::bindStandardIcon(_playButton, QStyle::SP_MediaPlay);
+}
+
+void MusicComboWidget::onPlayButtonClicked()
+{
+	if (_streamId >= 0) {
+		// Already playing — stop.
+		stopPlayback();
+		return;
+	}
+
+	const int smIdx = currentMusicIndex();
+	if (smIdx < 0 || smIdx >= static_cast<int>(Spooled_music.size()))
+		return;
+
+	// Strip any extension already present in the filename before trying .wav then .ogg
+	SCP_string base = Spooled_music[smIdx].filename;
+	const auto dot = base.rfind('.');
+	if (dot != SCP_string::npos)
+		base = base.substr(0, dot);
+
+	int id = audiostream_open((base + ".wav").c_str(), ASF_EVENTMUSIC);
+	if (id < 0)
+		id = audiostream_open((base + ".ogg").c_str(), ASF_EVENTMUSIC);
+
+	if (id >= 0) {
+		audiostream_play(id, 1.0f, 0);
+		_streamId = id;
+		fso::fred::bindStandardIcon(_playButton, QStyle::SP_MediaStop);
+		Q_EMIT playbackStarted();
+	}
+}
+
+void MusicComboWidget::onComboChanged(int /*comboIdx*/)
+{
+	// Stop any active preview when the user changes the selection.
+	stopPlayback();
+
+	const int smIdx = currentMusicIndex();
+	_playButton->setEnabled(smIdx >= 0);
+	Q_EMIT currentIndexChanged(smIdx);
+}
+
+void MusicComboWidget::onTimerTick()
+{
+	if (_streamId >= 0 && !audiostream_is_playing(_streamId)) {
+		stopPlayback();
+	}
+}
+
+} // namespace fso::fred

--- a/qtfred/src/ui/widgets/MusicComboWidget.h
+++ b/qtfred/src/ui/widgets/MusicComboWidget.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QWidget>
+#include <QTimer>
+
+class QComboBox;
+class QPushButton;
+
+namespace fso::fred {
+
+// A combo box pre-populated with Spooled_music entries ("None" + all tracks)
+// combined with a play/stop toggle button for auditioning the selected track.
+// Place multiple instances in the same dialog and connect their playbackStarted()
+// signals to each other's stopPlayback() slots to enforce single-track playback.
+class MusicComboWidget : public QWidget {
+	Q_OBJECT
+
+  public:
+	explicit MusicComboWidget(QWidget* parent = nullptr);
+	~MusicComboWidget() override;
+
+	// Returns the Spooled_music index of the current selection, or -1 for "None".
+	int currentMusicIndex() const;
+
+	// Selects the entry matching the given Spooled_music index (-1 selects "None").
+	void setCurrentMusicIndex(int spooledIdx);
+
+  public slots:
+	// Stops any active playback and resets the button to its Play state.
+	void stopPlayback();
+
+  signals:
+	// Emitted when the user changes the combo selection.
+	// spooledMusicIdx is -1 for "None", or a valid index into Spooled_music.
+	void currentIndexChanged(int spooledMusicIdx);
+
+	// Emitted when playback starts, so sibling widgets can stop themselves.
+	void playbackStarted();
+
+  private slots:
+	void onPlayButtonClicked();
+	void onComboChanged(int comboIdx);
+	void onTimerTick();
+
+  private:
+	QComboBox* _comboBox;
+	QPushButton* _playButton;
+	QTimer _timer;
+	int _streamId = -1;
+};
+
+} // namespace fso::fred

--- a/qtfred/src/ui/widgets/MusicComboWidget.h
+++ b/qtfred/src/ui/widgets/MusicComboWidget.h
@@ -25,7 +25,6 @@ class MusicComboWidget : public QWidget {
 	// Selects the entry matching the given Spooled_music index (-1 selects "None").
 	void setCurrentMusicIndex(int spooledIdx);
 
-  public slots:
 	// Stops any active playback and resets the button to its Play state.
 	void stopPlayback();
 
@@ -42,7 +41,6 @@ class MusicComboWidget : public QWidget {
 	void onComboChanged(int comboIdx);
 	void onTimerTick();
 
-  private:
 	QComboBox* _comboBox;
 	QPushButton* _playButton;
 	QTimer _timer;

--- a/qtfred/src/ui/widgets/MusicComboWidget.h
+++ b/qtfred/src/ui/widgets/MusicComboWidget.h
@@ -41,6 +41,7 @@ class MusicComboWidget : public QWidget {
 	void onComboChanged(int comboIdx);
 	void onTimerTick();
 
+  private: // NOLINT(readability-redundant-access-specifiers)
 	QComboBox* _comboBox;
 	QPushButton* _playButton;
 	QTimer _timer;

--- a/qtfred/ui/BriefingEditorDialog.ui
+++ b/qtfred/ui/BriefingEditorDialog.ui
@@ -657,11 +657,7 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QComboBox" name="defaultMusicComboBox">
-              <property name="editable">
-               <bool>false</bool>
-              </property>
-             </widget>
+             <widget class="fso::fred::MusicComboWidget" name="defaultMusicWidget"/>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="musicPackLabel">
@@ -674,7 +670,7 @@
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QComboBox" name="musicPackComboBox"/>
+             <widget class="fso::fred::MusicComboWidget" name="musicPackWidget"/>
             </item>
            </layout>
           </widget>
@@ -775,6 +771,11 @@
    <class>fso::fred::sexp_tree</class>
    <extends>QTreeView</extends>
    <header>ui/widgets/sexp_tree.h</header>
+  </customwidget>
+  <customwidget>
+   <class>fso::fred::MusicComboWidget</class>
+   <extends>QWidget</extends>
+   <header>ui/widgets/MusicComboWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/qtfred/ui/DebriefingDialog.ui
+++ b/qtfred/ui/DebriefingDialog.ui
@@ -230,7 +230,7 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QComboBox" name="successMusicComboBox"/>
+             <widget class="fso::fred::MusicComboWidget" name="successMusicWidget"/>
             </item>
             <item row="1" column="0">
              <widget class="QLabel" name="averageMusicLabel">
@@ -240,7 +240,7 @@
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QComboBox" name="averageMusicComboBox"/>
+             <widget class="fso::fred::MusicComboWidget" name="averageMusicWidget"/>
             </item>
             <item row="2" column="0">
              <widget class="QLabel" name="failureMusicLabel">
@@ -250,7 +250,7 @@
              </widget>
             </item>
             <item row="2" column="1">
-             <widget class="QComboBox" name="failureMusicComboBox"/>
+             <widget class="fso::fred::MusicComboWidget" name="failureMusicWidget"/>
             </item>
            </layout>
           </widget>
@@ -268,6 +268,11 @@
    <class>fso::fred::sexp_tree</class>
    <extends>QTreeView</extends>
    <header>ui/widgets/sexp_tree.h</header>
+  </customwidget>
+  <customwidget>
+   <class>fso::fred::MusicComboWidget</class>
+   <extends>QWidget</extends>
+   <header>ui/widgets/MusicComboWidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qtfred/ui/FictionViewerDialog.ui
+++ b/qtfred/ui/FictionViewerDialog.ui
@@ -66,12 +66,12 @@
       <string>&amp;Music</string>
      </property>
      <property name="buddy">
-      <cstring>musicComboBox</cstring>
+      <cstring>musicWidget</cstring>
      </property>
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QComboBox" name="musicComboBox"/>
+    <widget class="fso::fred::MusicComboWidget" name="musicWidget"/>
    </item>
    <item row="4" column="1">
     <widget class="QDialogButtonBox" name="okAndCancelButtons">
@@ -82,23 +82,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>fso::fred::MusicComboWidget</class>
+   <extends>QWidget</extends>
+   <header>ui/widgets/MusicComboWidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>okAndCancelButtons</sender>
-   <signal>accepted()</signal>
-   <receiver>fso::fred::dialogs::FictionViewerDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>138</x>
-     <y>134</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>114</x>
-     <y>78</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
Creates a single widget shared across multiple dialogs that lists all spooled (briefing/debriefing) music and provides a playback toggle button to listen to the selected track. Uses this new widget in Fiction Viewer Dialog, Briefing Dialog, and Debriefing Dialog.