### PR TITLE
Qtfred fixes and tweaks

### DIFF
--- a/qtfred/src/mission/dialogs/MissionStatsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionStatsDialogModel.cpp
@@ -78,7 +78,7 @@ int MissionStatsDialogModel::getJumpNodeCount()
 
 int MissionStatsDialogModel::getMessageCount()
 {
-	return Num_messages;
+	return Num_messages - Num_builtin_messages;
 }
 
 int MissionStatsDialogModel::getEventCount()

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
@@ -2,6 +2,11 @@
 
 #include "mission/object.h"
 
+// Sub-texture type suffixes, mirroring the strcat_s calls in modelread.cpp.
+// Used both when detecting sub-texture slots in initSubTypes and when parsing
+// new_texture strings on dialog reload.
+static const SCP_string SUBTEXTURE_SUFFIXES[] = { "misc", "shine", "glow", "normal", "height", "ao", "reflect" };
+
 namespace fso {
 	namespace fred {
 		namespace dialogs {
@@ -76,24 +81,55 @@ namespace fso {
 					{
 						if (!stricmp(Ships[_editor->cur_ship].ship_name, Fred_texture_replacement.ship_name) && !(Fred_texture_replacement.from_table))
 						{
+							// old_texture is stored as the bare base name by this dialog (no type suffix).
+							// However, entries loaded from old mission files may have a type suffix
+							// (e.g. "fenris-body-misc"), so fall back to stripping if no direct match.
 							SCP_string pureName = Fred_texture_replacement.old_texture;
-							auto npos = pureName.find_last_of('-');
-							if (npos != SCP_string::npos) {
-								pureName = pureName.substr(0, pureName.find_last_of('-'));
+
+							// Find the matching default texture slot.
+							// Try direct match first; fall back to stripping the last '-' segment
+							// for old mission-file entries that stored old_texture with a type suffix.
+							size_t matchIdx = defaultTextures.size();
+							for (size_t i = 0; i < defaultTextures.size(); i++) {
+								if (lcase_equal(defaultTextures[i], pureName)) {
+									matchIdx = i;
+									break;
+								}
+							}
+							if (matchIdx == defaultTextures.size()) {
+								auto stripPos = pureName.find_last_of('-');
+								if (stripPos != SCP_string::npos) {
+									SCP_string stripped = pureName.substr(0, stripPos);
+									for (size_t i = 0; i < defaultTextures.size(); i++) {
+										if (lcase_equal(defaultTextures[i], stripped)) {
+											matchIdx = i;
+											break;
+										}
+									}
+								}
 							}
 
-							// look for corresponding old texture
-							for (size_t i = 0; i < defaultTextures.size(); i++)
+							if (matchIdx < defaultTextures.size())
 							{
-								// if match
-								if (lcase_equal(defaultTextures[i], pureName))
+								size_t i = matchIdx;
 								{
 									SCP_string newText = Fred_texture_replacement.new_texture;
-									npos = newText.find_last_of('-');
 									SCP_string type;
-									if (npos != SCP_string::npos) {
-										type = newText.substr(npos + 1);
-										newText = newText.substr(0, newText.find_last_of('-'));
+									{
+										auto npos = newText.find_last_of('-');
+										if (npos != SCP_string::npos) {
+											SCP_string possibleType = newText.substr(npos + 1);
+											// Only treat the suffix as a type if it's a known sub-texture type.
+											// Texture names themselves can contain hyphens (e.g. "fighter01-01a"),
+											// so we must not blindly strip the last segment.
+											for (const auto& kt : SUBTEXTURE_SUFFIXES) {
+												if (lcase_equal(possibleType, kt)) {
+													type = possibleType;
+													newText = newText.substr(0, npos);
+													break;
+												}
+											}
+										}
 									}
 									if (!type.empty()) {
 										if (type == "misc") {
@@ -142,8 +178,6 @@ namespace fso {
 										currentTextures[i]["main"] = newText;
 									}
 
-									// we found one, so no more to check
-									break;
 								}
 							}
 						}
@@ -206,30 +240,19 @@ namespace fso {
 					}
 					if (!type.empty()) {
 						if (type == "trans") {
-						}
-						else if (type == "misc") {
-							subTypesAvailable[MapNum]["misc"] = true;
-						}
-						else if (type == "shine") {
-							subTypesAvailable[MapNum]["shine"] = true;
-						}
-						else if (type == "glow") {
-							subTypesAvailable[MapNum]["glow"] = true;
-						}
-						else if (type == "normal") {
-							subTypesAvailable[MapNum]["normal"] = true;
-						}
-						else if (type == "height") {
-							subTypesAvailable[MapNum]["height"] = true;
-						}
-						else if (type == "ao") {
-							subTypesAvailable[MapNum]["ao"] = true;
-						}
-						else if (type == "reflect") {
-							subTypesAvailable[MapNum]["reflect"] = true;
-						}
-						else {
-							error_display(1, "Invalid Map type %s. Check your model's texture names or get a programmer", type.c_str());
+							// transparency map, not a replaceable subtype
+						} else {
+							bool known = false;
+							for (const auto& kt : SUBTEXTURE_SUFFIXES) {
+								if (lcase_equal(type, kt)) {
+									subTypesAvailable[MapNum][kt] = true;
+									known = true;
+									break;
+								}
+							}
+							if (!known) {
+								error_display(1, "Invalid Map type %s. Check your model's texture names or get a programmer", type.c_str());
+							}
 						}
 					}
 				}
@@ -564,7 +587,7 @@ namespace fso {
 					{
 						temp_bmp = bm_load_animation(fullName.c_str(), &temp_frames, &temp_fps, nullptr, nullptr, false, true);
 					}
-					return temp_bmp < 0;
+					return temp_bmp >= 0;
 				}
 			}
 

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -121,10 +121,6 @@ FredView::FredView(QWidget* parent) : QMainWindow(parent), ui(new Ui::FredView()
 
 	initializeGroupActions();
 
-	auto propsAction = new QAction(tr("Props"), this);
-	connect(propsAction, &QAction::triggered, this, &FredView::on_actionProps_triggered);
-	ui->menuObjects->insertAction(ui->actionWaypoint_Paths, propsAction);
-
 	connect(ui->actionPreferences, &QAction::triggered, this, [this]() {
 		dialogs::PreferencesDialog preferencesDialog(this, _viewport);
 		preferencesDialog.exec();

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -1438,7 +1438,7 @@ void FredView::on_actionCampaign_triggered(bool) {
 	editorCampaign->setAttribute(Qt::WA_DeleteOnClose);
 	editorCampaign->show();
 }
-void FredView::on_actionObjects_triggered(bool) {
+void FredView::on_actionObject_Orientation_triggered(bool) {
 	orientEditorTriggered();
 }
 void FredView::on_actionCommand_Briefing_triggered(bool) {
@@ -1583,7 +1583,7 @@ void FredView::orientEditorTriggered() {
 	dialog->exec();
 }
 void FredView::onUpdateEditorActions() {
-	ui->actionObjects->setEnabled(query_valid_object(fred->currentObject));
+	ui->actionObject_Orientation->setEnabled(query_valid_object(fred->currentObject));
 
 	const bool validObject = query_valid_object(fred->currentObject);
 	const bool hasMarked = fred->getNumMarked() > 0;
@@ -1596,7 +1596,7 @@ void FredView::onUpdateEditorActions() {
 	ui->actionDelete_Wing->setEnabled(fred->cur_wing >= 0);
 
 	// Objects editor — requires a selected object
-	ui->actionObjects->setEnabled(validObject);
+	ui->actionObject_Orientation->setEnabled(validObject);
 
 	// Level/Align — require something to be selected
 	ui->actionLevel_Object->setEnabled(validObject);

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -111,7 +111,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void on_actionMission_Specs_triggered(bool);
 	void on_actionWaypoint_Paths_triggered(bool);
 	void on_actionJump_Nodes_triggered(bool);
-	void on_actionObjects_triggered(bool);
+	void on_actionObject_Orientation_triggered(bool);
 	void on_actionShips_triggered(bool);
 	void on_actionWings_triggered(bool);
 	void on_actionProps_triggered(bool);

--- a/qtfred/src/ui/Theme.cpp
+++ b/qtfred/src/ui/Theme.cpp
@@ -102,6 +102,11 @@ QToolButton:checked:hover {
 QToolButton::menu-indicator {
     image: none;
 }
+QMenu::separator {
+    height: 1px;
+    background: #8f8f8f;
+    margin: 4px 8px;
+}
 )";
 
 } // anonymous namespace

--- a/qtfred/src/ui/dialogs/ReinforcementsEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ReinforcementsEditorDialog.cpp
@@ -1,5 +1,6 @@
 #include "ReinforcementsEditorDialog.h"
 #include "ui_ReinforcementsDialog.h"
+#include "ui/Theme.h"
 #include "mission/util.h"
 #include <globalincs/linklist.h>
 #include <ui/util/SignalBlockers.h>
@@ -15,6 +16,14 @@ ReinforcementsDialog::ReinforcementsDialog(FredView* parent, EditorViewport* vie
 {
 	this->setFocus();
 	ui->setupUi(this);		
+
+	fso::fred::bindStandardIcon(ui->moveSelectionUp, QStyle::SP_ArrowUp);
+	ui->moveSelectionUp->setText(QString());
+	ui->moveSelectionUp->setToolTip(tr("Move selected reinforcement up"));
+
+	fso::fred::bindStandardIcon(ui->moveSelectionDown, QStyle::SP_ArrowDown);
+	ui->moveSelectionDown->setText(QString());
+	ui->moveSelectionDown->setToolTip(tr("Move selected reinforcement down"));
 
 	updateUi();
 }

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipAltShipClass.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipAltShipClass.cpp
@@ -3,6 +3,7 @@
 #include "ui_ShipAltShipClass.h"
 
 #include <mission/util.h>
+#include <ui/Theme.h>
 #include <ui/util/SignalBlockers.h>
 
 #include <QCloseEvent>
@@ -204,6 +205,15 @@ void ShipAltShipClass::initUI()
 		variable_pool->appendRow(item);
 	}
 	ui->variableCombo->setModel(variable_pool);
+
+	fso::fred::bindStandardIcon(ui->upButton, QStyle::SP_ArrowUp);
+	ui->upButton->setText(QString());
+	ui->upButton->setToolTip(tr("Move selected class up"));
+
+	fso::fred::bindStandardIcon(ui->downButton, QStyle::SP_ArrowDown);
+	ui->downButton->setText(QString());
+	ui->downButton->setToolTip(tr("Move selected class down"));
+
 	updateUI();
 }
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipAltShipClass.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipAltShipClass.cpp
@@ -222,36 +222,46 @@ void ShipAltShipClass::updateUI()
 	if (ui->variableCombo->model()->rowCount() <= 1) {
 		dynamic_cast<InverseSortFilterProxyModel*>(ui->shipCombo->model())->setFilterFixedString("Set From Variable");
 	}
+	// Workaround: avoid model()->match() which returns a QModelIndexList that triggers a
+	// cross-heap free assert on Windows debug builds. Manually iterate instead.
 	{
-		QModelIndexList shipMatches =
-			ui->shipCombo->model()->match(ui->shipCombo->model()->index(0, 0), Qt::UserRole, ship_class);
-		if (!shipMatches.empty()) {
-			ui->shipCombo->setCurrentIndex(shipMatches.first().row());
-		} else {
-			if (ui->classList->model()->rowCount() != 0 && ship_class != -1) {
-				_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-					"Error",
-					"Illegal ship class.\n Resetting to -1",
-					{DialogButton::Ok});
+		int shipRow = 0;
+		bool found = false;
+		auto* shipModel = ui->shipCombo->model();
+		for (int i = 0; i < shipModel->rowCount(); ++i) {
+			if (shipModel->data(shipModel->index(i, 0), Qt::UserRole).toInt() == ship_class) {
+				shipRow = i;
+				found = true;
+				break;
 			}
-			ui->shipCombo->setCurrentIndex(0);
 		}
+		if (!found && ui->classList->model()->rowCount() != 0 && ship_class != -1) {
+			_viewport->dialogProvider->showButtonDialog(DialogType::Error,
+				"Error",
+				"Illegal ship class.\n Resetting to -1",
+				{DialogButton::Ok});
+		}
+		ui->shipCombo->setCurrentIndex(shipRow);
 	}
 
 	{
-		QModelIndexList varMatches =
-			ui->variableCombo->model()->match(ui->variableCombo->model()->index(0, 0), Qt::UserRole, variable);
-		if (!varMatches.empty()) {
-			ui->variableCombo->setCurrentIndex(varMatches.first().row());
-		} else {
-			if (ui->classList->model()->rowCount() != 0) {
-				_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-					"Error",
-					"Illegal variable index.\n Resetting to -1",
-					{DialogButton::Ok});
+		int varRow = 0;
+		bool found = false;
+		auto* varModel = ui->variableCombo->model();
+		for (int i = 0; i < varModel->rowCount(); ++i) {
+			if (varModel->data(varModel->index(i, 0), Qt::UserRole).toInt() == variable) {
+				varRow = i;
+				found = true;
+				break;
 			}
-			ui->variableCombo->setCurrentIndex(0);
 		}
+		if (!found && ui->classList->model()->rowCount() != 0) {
+			_viewport->dialogProvider->showButtonDialog(DialogType::Error,
+				"Error",
+				"Illegal variable index.\n Resetting to -1",
+				{DialogButton::Ok});
+		}
+		ui->variableCombo->setCurrentIndex(varRow);
 	}
 
 	if (ui->variableCombo->model()->rowCount() <= 1) {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -667,21 +667,18 @@ void ShipEditorDialog::on_specialStatsButton_clicked()
 }
 void ShipEditorDialog::on_hideCuesButton_clicked()
 {
-	if (ui->hideCuesButton->isChecked()) {
-		ui->arrivalGroupBox->setVisible(false);
-		ui->departureGroupBox->setVisible(false);
-		ui->HelpTitle->setVisible(false);
-		ui->helpText->setVisible(false);
-		QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-		resize(sizeHint());
-	} else {
-		ui->arrivalGroupBox->setVisible(true);
-		ui->departureGroupBox->setVisible(true);
-		ui->HelpTitle->setVisible(true);
-		ui->helpText->setVisible(true);
-		QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-		resize(sizeHint());
-	}
+	const auto showHelp = _viewport->Show_sexp_help_ship_editor;
+
+	_cues_hidden = !_cues_hidden;
+
+	ui->arrivalGroupBox->setVisible(!_cues_hidden);
+	ui->departureGroupBox->setVisible(!_cues_hidden);
+	ui->HelpTitle->setVisible(!_cues_hidden && showHelp);
+	ui->helpText->setVisible(!_cues_hidden && showHelp);
+	ui->hideCuesButton->setText(_cues_hidden ? "Show Cues" : "Hide Cues");
+
+	QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+	resize(sizeHint());
 }
 void ShipEditorDialog::on_restrictArrivalPathsButton_clicked()
 {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
@@ -116,10 +116,12 @@ class ShipEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	void on_departureTree_helpChanged(const QString&);
 	void on_departureTree_miniHelpChanged(const QString&);
 	void on_noDepartureWarpCheckBox_toggled(bool);
-  private:
+  private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::ShipEditorDialog> ui;
 	std::unique_ptr<ShipEditorDialogModel> _model;
 	EditorViewport* _viewport;
+
+	bool _cues_hidden = false;
 
 	void update();
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipTextureReplacementDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipTextureReplacementDialog.cpp
@@ -98,7 +98,7 @@ void ShipTextureReplacementDialog::on_newTextureLineEdit_editingFinished()
 {
 	SCP_string newText;
 	if (!ui->newTextureLineEdit->text().isEmpty()) {
-		newText = ui->newTextureLineEdit->text().toStdString();
+		newText = ui->newTextureLineEdit->text().toUtf8().constData();
 	}
 	_model->setMap(row, "main", newText);
 }
@@ -107,7 +107,7 @@ void ShipTextureReplacementDialog::on_MiscTextureLineEdit_editingFinished()
 {
 	SCP_string newText;
 	if (!ui->MiscTextureLineEdit->text().isEmpty()) {
-		newText = ui->MiscTextureLineEdit->text().toStdString();
+		newText = ui->MiscTextureLineEdit->text().toUtf8().constData();
 		_model->setMap(row, "misc", newText);
 	}
 }
@@ -116,7 +116,7 @@ void ShipTextureReplacementDialog::on_GlowTextureLineEdit_editingFinished()
 {
 	SCP_string newText;
 	if (!ui->GlowTextureLineEdit->text().isEmpty()) {
-		newText = ui->GlowTextureLineEdit->text().toStdString();
+		newText = ui->GlowTextureLineEdit->text().toUtf8().constData();
 		_model->setMap(row, "glow", newText);
 	}
 }
@@ -125,7 +125,7 @@ void ShipTextureReplacementDialog::on_ShineTextureLineEdit_editingFinished()
 {
 	SCP_string newText;
 	if (!ui->ShineTextureLineEdit->text().isEmpty()) {
-		newText = ui->ShineTextureLineEdit->text().toStdString();
+		newText = ui->ShineTextureLineEdit->text().toUtf8().constData();
 		_model->setMap(row, "shine", newText);
 	}
 }
@@ -134,7 +134,7 @@ void ShipTextureReplacementDialog::on_NormalTextureLineEdit_editingFinished()
 {
 	SCP_string newText;
 	if (!ui->NormalTextureLineEdit->text().isEmpty()) {
-		newText = ui->NormalTextureLineEdit->text().toStdString();
+		newText = ui->NormalTextureLineEdit->text().toUtf8().constData();
 		_model->setMap(row, "normal", newText);
 	}
 }
@@ -143,7 +143,7 @@ void ShipTextureReplacementDialog::on_HeightTextureLineEdit_editingFinished()
 {
 	SCP_string newText;
 	if (!ui->HeightTextureLineEdit->text().isEmpty()) {
-		newText = ui->HeightTextureLineEdit->text().toStdString();
+		newText = ui->HeightTextureLineEdit->text().toUtf8().constData();
 		_model->setMap(row, "height", newText);
 	}
 }
@@ -152,7 +152,7 @@ void ShipTextureReplacementDialog::on_AmbiantTextureLineEdit_editingFinished()
 {
 	SCP_string newText;
 	if (!ui->AmbiantTextureLineEdit->text().isEmpty()) {
-		newText = ui->AmbiantTextureLineEdit->text().toStdString();
+		newText = ui->AmbiantTextureLineEdit->text().toUtf8().constData();
 		_model->setMap(row, "ao", newText);
 	}
 }
@@ -161,7 +161,7 @@ void ShipTextureReplacementDialog::on_ReflectTextureLineEdit_editingFinished()
 {
 	SCP_string newText;
 	if (!ui->ReflectTextureLineEdit->text().isEmpty()) {
-		newText = ui->ReflectTextureLineEdit->text().toStdString();
+		newText = ui->ReflectTextureLineEdit->text().toUtf8().constData();
 		_model->setMap(row, "reflect", newText);
 	}
 }

--- a/qtfred/src/ui/dialogs/VariableDialog.cpp
+++ b/qtfred/src/ui/dialogs/VariableDialog.cpp
@@ -1,5 +1,6 @@
 #include "VariableDialog.h"
 #include "ui_VariableDialog.h"
+#include "ui/Theme.h"
 #include <ui/util/SignalBlockers.h>
 #include "ui/widgets/LineEditDelegate.h"
 #include <mission/util.h>
@@ -108,6 +109,14 @@ void VariableDialog::initializeUi()
 	ui->selectFormatCombobox->setVisible(false);
 
 	ui->tabWidget->setCurrentIndex(0);
+
+	fso::fred::bindStandardIcon(ui->shiftItemUpButton, QStyle::SP_ArrowUp);
+	ui->shiftItemUpButton->setText(QString());
+	ui->shiftItemUpButton->setToolTip(tr("Shift item up"));
+
+	fso::fred::bindStandardIcon(ui->shiftItemDownButton, QStyle::SP_ArrowDown);
+	ui->shiftItemDownButton->setText(QString());
+	ui->shiftItemDownButton->setToolTip(tr("Shift item down"));
 }
 
 void VariableDialog::updateUi()

--- a/qtfred/src/ui/dialogs/WingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.cpp
@@ -339,12 +339,14 @@ void WingEditorDialog::refreshAllDynamicCombos()
 
 void WingEditorDialog::on_hideCuesButton_clicked()
 {
+	const auto showHelp = _viewport->Show_sexp_help_wing_editor;
+	
 	_cues_hidden = !_cues_hidden;
 	
-	ui->arrivalGroupBox->setHidden(_cues_hidden);
-	ui->departureGroupBox->setHidden(_cues_hidden);
-	ui->helpText->setHidden(_cues_hidden);
-	ui->HelpTitle->setHidden(_cues_hidden);
+	ui->arrivalGroupBox->setVisible(!_cues_hidden);
+	ui->departureGroupBox->setVisible(!_cues_hidden);
+	ui->helpText->setVisible(!_cues_hidden && showHelp);
+	ui->HelpTitle->setVisible(!_cues_hidden && showHelp);
 	ui->hideCuesButton->setText(_cues_hidden ? "Show Cues" : "Hide Cues");
 
 	QApplication::processEvents(QEventLoop::ExcludeUserInputEvents);

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -194,10 +194,10 @@
     </property>
     <addaction name="actionShips"/>
     <addaction name="actionWings"/>
-    <addaction name="actionObjects"/>
     <addaction name="actionProps"/>
     <addaction name="actionWaypoint_Paths"/>
     <addaction name="actionJump_Nodes"/>
+    <addaction name="actionObject_Orientation"/>
     <addaction name="separator"/>
     <addaction name="actionControl_Object"/>
     <addaction name="actionNext_Object"/>
@@ -1023,9 +1023,9 @@
     <string>Shift+W</string>
    </property>
   </action>
-  <action name="actionObjects">
+  <action name="actionObject_Orientation">
    <property name="text">
-    <string>&amp;Objects</string>
+    <string>Object &amp;Orientation</string>
    </property>
    <property name="shortcut">
     <string>Shift+O</string>

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>926</width>
-     <height>26</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -195,6 +195,7 @@
     <addaction name="actionShips"/>
     <addaction name="actionWings"/>
     <addaction name="actionObjects"/>
+    <addaction name="actionProps"/>
     <addaction name="actionWaypoint_Paths"/>
     <addaction name="actionJump_Nodes"/>
     <addaction name="separator"/>
@@ -609,7 +610,7 @@
     <string>&amp;FS1 Mission</string>
    </property>
   </action>
-<action name="actionRun_FreeSpace_2_Open">
+  <action name="actionRun_FreeSpace_2_Open">
    <property name="text">
     <string>Run &amp;FreeSpace</string>
    </property>
@@ -1028,6 +1029,11 @@
    </property>
    <property name="shortcut">
     <string>Shift+O</string>
+   </property>
+  </action>
+  <action name="actionProps">
+   <property name="text">
+    <string>Props</string>
    </property>
   </action>
   <action name="actionWaypoint_Paths">

--- a/qtfred/ui/ReinforcementsDialog.ui
+++ b/qtfred/ui/ReinforcementsDialog.ui
@@ -150,7 +150,7 @@
           </size>
          </property>
          <property name="text">
-          <string>↓</string>
+          <string/>
          </property>
         </widget>
        </item>
@@ -179,7 +179,7 @@
           </size>
          </property>
          <property name="text">
-          <string>↑</string>
+          <string/>
          </property>
          <property name="autoDefault">
           <bool>false</bool>

--- a/qtfred/ui/ShipAltShipClass.ui
+++ b/qtfred/ui/ShipAltShipClass.ui
@@ -42,7 +42,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Up</string>
+            <string/>
            </property>
           </widget>
          </item>
@@ -55,7 +55,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string>Down</string>
+            <string/>
            </property>
           </widget>
          </item>

--- a/qtfred/ui/ShipEditorDialog.ui
+++ b/qtfred/ui/ShipEditorDialog.ui
@@ -472,7 +472,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set ship's flags (Add special Features)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
-          <string>Misc</string>
+          <string>Flags</string>
          </property>
         </widget>
        </item>

--- a/qtfred/ui/ShipInitialStatus.ui
+++ b/qtfred/ui/ShipInitialStatus.ui
@@ -393,7 +393,7 @@
      <item>
       <widget class="QLabel" name="colourLabel">
        <property name="text">
-        <string>Team Colour Setting</string>
+        <string>Team Color Setting</string>
        </property>
       </widget>
      </item>

--- a/qtfred/ui/VariableDialog.ui
+++ b/qtfred/ui/VariableDialog.ui
@@ -32,7 +32,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -574,14 +574,14 @@
             <item>
              <widget class="QPushButton" name="shiftItemUpButton">
               <property name="text">
-               <string>Shift Up</string>
+               <string/>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QPushButton" name="shiftItemDownButton">
               <property name="text">
-               <string>Shift Down</string>
+               <string/>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Fixes some things in QtFRED:

- Mission Stats message count was wrong
- Texture replace string algorithm was brittle
- Ship alt class heap issue crash on windows
- Match props menu item styling to the others
- Unify all up/down buttons to use the theme arrow icons
- Fix ship/wing dialog cues toggle buttons to obey they new settings
- Rename Objects to Object Orientation in the menu for clarity
- Fix menu separator color in dark mode