### PR TITLE
Qtfred visual tweaks

### DIFF
--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -229,6 +229,18 @@ void EditorViewport::select_objects(const Marking_box& box) {
 			}
 
 			break;
+
+		case OBJ_PROP:
+			if (!view.Show_props) {
+				valid = 0;
+			}
+			break;
+
+		case OBJ_JUMP_NODE:
+			if (!view.Show_jump_nodes) {
+				valid = 0;
+			}
+			break;
 		}
 
 		g3_rotate_vertex(&v, &ptr->pos);
@@ -751,6 +763,14 @@ int EditorViewport::object_check_collision(object* objp, vec3d* p0, vec3d* p1, v
 		if (!view.Show_iff[Ships[objp->instance].team]) {
 			return 0;
 		}
+	}
+
+	if ((objp->type == OBJ_PROP) && !view.Show_props) {
+		return 0;
+	}
+
+	if ((objp->type == OBJ_JUMP_NODE) && !view.Show_jump_nodes) {
+		return 0;
 	}
 
 	if (objp->flags[Object::Object_Flags::Hidden, Object::Object_Flags::Locked_from_editing]) {

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -38,6 +38,8 @@ struct ViewSettings {
 	bool Lighting_on = false;
 	bool FullDetail = false;
 	bool Show_waypoints = true;
+	bool Show_props = true;
+	bool Show_jump_nodes = true;
 	bool Show_compass = true;
 	bool Highlight_selectable_subsys = false;
 

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -436,6 +436,14 @@ void FredRenderer::display_ship_info(int cur_object_index) {
 			}
 		}
 
+		if ((objp->type == OBJ_PROP) && !view().Show_props) {
+			render = 0;
+		}
+
+		if ((objp->type == OBJ_JUMP_NODE) && !view().Show_jump_nodes) {
+			render = 0;
+		}
+
 		if (objp->flags[Object::Object_Flags::Hidden]) {
 			render = 0;
 		}
@@ -654,7 +662,7 @@ void FredRenderer::render_one_model_htl(object* objp,
 		return;
 
 	if (objp->type == OBJ_JUMP_NODE) {
-		return;
+		return; // jump nodes have their own render loop in render_frame
 	}
 
 	if ((objp->type == OBJ_WAYPOINT) && !view().Show_waypoints) {
@@ -673,6 +681,10 @@ void FredRenderer::render_one_model_htl(object* objp,
 		if (!view().Show_iff[Ships[objp->instance].team]) {
 			return;
 		}
+	}
+
+	if ((objp->type == OBJ_PROP) && !view().Show_props) {
+		return;
 	}
 
 	if (objp->flags[Object::Object_Flags::Hidden]) {
@@ -1031,10 +1043,12 @@ void FredRenderer::render_frame(int cur_object_index,
 	gr_set_color(0, 160, 0);
 
 	enable_htl();
-	for (auto& jn : Jump_nodes) {
-		const object* jnObj = jn.GetSCPObject();
-		if (jnObj != nullptr && _viewport->isObjectVisibleInLayer(jnObj)) {
-			jn.Render(&jnObj->pos);
+	if (view().Show_jump_nodes) {
+		for (auto& jn : Jump_nodes) {
+			const object* jnObj = jn.GetSCPObject();
+			if (jnObj != nullptr && _viewport->isObjectVisibleInLayer(jnObj)) {
+				jn.Render(&jnObj->pos);
+			}
 		}
 	}
 	disable_htl();

--- a/qtfred/src/mission/dialogs/LayerManagerDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/LayerManagerDialogModel.cpp
@@ -65,9 +65,11 @@ bool LayerManagerDialogModel::isDefaultLayer(const SCP_string& name) {
 
 // --- Object type filters ---
 
-bool LayerManagerDialogModel::getShowShips() const    { return _viewport->view.Show_ships; }
-bool LayerManagerDialogModel::getShowStarts() const   { return _viewport->view.Show_starts; }
-bool LayerManagerDialogModel::getShowWaypoints() const { return _viewport->view.Show_waypoints; }
+bool LayerManagerDialogModel::getShowShips() const      { return _viewport->view.Show_ships; }
+bool LayerManagerDialogModel::getShowStarts() const     { return _viewport->view.Show_starts; }
+bool LayerManagerDialogModel::getShowWaypoints() const  { return _viewport->view.Show_waypoints; }
+bool LayerManagerDialogModel::getShowProps() const      { return _viewport->view.Show_props; }
+bool LayerManagerDialogModel::getShowJumpNodes() const  { return _viewport->view.Show_jump_nodes; }
 
 void LayerManagerDialogModel::setShowShips(bool value) {
 	if (_viewport->view.Show_ships != value) {
@@ -86,6 +88,20 @@ void LayerManagerDialogModel::setShowStarts(bool value) {
 void LayerManagerDialogModel::setShowWaypoints(bool value) {
 	if (_viewport->view.Show_waypoints != value) {
 		_viewport->view.Show_waypoints = value;
+		_viewport->needsUpdate();
+	}
+}
+
+void LayerManagerDialogModel::setShowProps(bool value) {
+	if (_viewport->view.Show_props != value) {
+		_viewport->view.Show_props = value;
+		_viewport->needsUpdate();
+	}
+}
+
+void LayerManagerDialogModel::setShowJumpNodes(bool value) {
+	if (_viewport->view.Show_jump_nodes != value) {
+		_viewport->view.Show_jump_nodes = value;
 		_viewport->needsUpdate();
 	}
 }

--- a/qtfred/src/mission/dialogs/LayerManagerDialogModel.h
+++ b/qtfred/src/mission/dialogs/LayerManagerDialogModel.h
@@ -29,6 +29,10 @@ public:
 	void setShowStarts(bool value);
 	bool getShowWaypoints() const;
 	void setShowWaypoints(bool value);
+	bool getShowProps() const;
+	void setShowProps(bool value);
+	bool getShowJumpNodes() const;
+	void setShowJumpNodes(bool value);
 
 	// IFF team filters
 	static int getIffCount();

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
@@ -472,7 +472,7 @@ namespace fso {
 				}
 				modelChanged();
 			}
-			void ShipGoalsDialogModel::initialize(ai_goal* goals, int ship)
+			void ShipGoalsDialogModel::initialize(ai_goal* goals)
 			{
 				int i, item, inst, flag;
 				ai_goal_mode mode;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
@@ -1,6 +1,7 @@
 #include "ShipGoalsDialogModel.h"
 #include <globalincs/linklist.h>
 #include <mission/object.h>
+#include <model/model.h>
 namespace fso {
 	namespace fred {
 		namespace dialogs {
@@ -134,7 +135,6 @@ namespace fso {
 
 			void ShipGoalsDialogModel::update_item(const int item)
 			{
-				char* docker, * dockee, * subsys;
 				ai_goal_mode mode;
 				char save[80]{};
 				SCP_string error_message;
@@ -179,13 +179,8 @@ namespace fso {
 				case AI_GOAL_CHASE_SHIP_CLASS:
 					break;
 
-				case AI_GOAL_DESTROY_SUBSYSTEM:
-					subsys = nullptr;
-					if (!m_multi_edit || (m_object[item] && (m_subsys[item].c_str() != nullptr)))
-						subsys = (char*)m_subsys[item].c_str();
-					//MODIFY(goalp[item].ai_submode, m_subsys[item] + 1);
-
-					if (!subsys) {
+				case AI_GOAL_DESTROY_SUBSYSTEM: {
+					if (m_subsys[item].empty()) {
 						sprintf(error_message, "Order #%d doesn't have valid subsystem name.  Order will be removed", item + 1);
 						_viewport->dialogProvider->showButtonDialog(DialogType::Information,
 							"Order Error",
@@ -193,16 +188,38 @@ namespace fso {
 							{ DialogButton::Ok });
 						modify(goalp[item].ai_mode, AI_GOAL_NONE);
 						return;
-
-					}
-					else {
-						if (!goalp[item].docker.name || (goalp[item].docker.name && !stricmp(goalp[item].docker.name, subsys)))
-							set_modified();
-
-						goalp[item].docker.name = subsys;
 					}
 
+					// Look up the subsystem in the target ship to get a persistent name pointer.
+					// Storing m_subsys[item].c_str() directly would dangle after the model is destroyed.
+					const char* persistent_name = nullptr;
+					int target_ship_idx = m_object[item] & DATA_MASK;
+					if (target_ship_idx >= 0 && target_ship_idx < MAX_SHIPS) {
+						ship_subsys* cur_ss = GET_FIRST(&Ships[target_ship_idx].subsys_list);
+						while (cur_ss != END_OF_LIST(&Ships[target_ship_idx].subsys_list)) {
+							if (!stricmp(cur_ss->system_info->subobj_name, m_subsys[item].c_str())) {
+								persistent_name = cur_ss->system_info->subobj_name;
+								break;
+							}
+							cur_ss = GET_NEXT(cur_ss);
+						}
+					}
+
+					if (!persistent_name) {
+						sprintf(error_message, "Order #%d doesn't have valid subsystem name.  Order will be removed", item + 1);
+						_viewport->dialogProvider->showButtonDialog(DialogType::Information,
+							"Order Error",
+							error_message,
+							{ DialogButton::Ok });
+						modify(goalp[item].ai_mode, AI_GOAL_NONE);
+						return;
+					}
+
+					if (!goalp[item].docker.name || stricmp(goalp[item].docker.name, persistent_name) != 0)
+						set_modified();
+					goalp[item].docker.name = persistent_name;
 					break;
+				}
 
 				case AI_GOAL_CHASE:
 				case AI_GOAL_CHASE_WING:
@@ -219,19 +236,37 @@ namespace fso {
 
 					break;
 
-				case AI_GOAL_DOCK:
-					docker = nullptr;
-					if (!m_multi_edit || (m_object[item] && (m_subsys[item].c_str() != nullptr)))
-						docker = (char*)m_subsys[item].c_str();
+				case AI_GOAL_DOCK: {
+					// Resolve persistent dock bay name pointers from the polymodel.
+					// Storing m_subsys[item].c_str() directly would dangle after the model is destroyed.
+					char* docker = nullptr;
+					char* dockee = nullptr;
 
-					dockee = nullptr;
-					if (!m_multi_edit || (m_object[item] && (m_dock2[item] >= 0)))
-						dockee = (char *)m_dock2[item];
+					if (!m_multi_edit || (m_object[item] && !m_subsys[item].empty())) {
+						if (self_ship >= 0) {
+							int model_num = Ship_info[Ships[self_ship].ship_info_index].model_num;
+							polymodel* pm = model_get(model_num);
+							if (pm) {
+								for (int b = 0; b < pm->n_docks; b++) {
+									if (!stricmp(pm->docking_bays[b].name, m_subsys[item].c_str())) {
+										docker = pm->docking_bays[b].name;
+										break;
+									}
+								}
+							}
+						}
+					}
 
-					if (docker == (char*)SIZE_MAX)
-						docker = nullptr;
-					if (dockee == (char*)SIZE_MAX)
-						dockee = nullptr;
+					if (!m_multi_edit || (m_object[item] && (m_dock2[item] >= 0))) {
+						int dockee_ship = m_object[item] & DATA_MASK;
+						if (dockee_ship >= 0 && dockee_ship < MAX_SHIPS && m_dock2[item] >= 0) {
+							int model_num = Ship_info[Ships[dockee_ship].ship_info_index].model_num;
+							polymodel* pm = model_get(model_num);
+							if (pm && m_dock2[item] < pm->n_docks) {
+								dockee = pm->docking_bays[m_dock2[item]].name;
+							}
+						}
+					}
 
 					if (!docker || !dockee) {
 						sprintf(error_message, "Order #%d doesn't have valid docking points.  Order will be removed", item + 1);
@@ -241,17 +276,10 @@ namespace fso {
 							{ DialogButton::Ok });
 						modify(goalp[item].ai_mode, AI_GOAL_NONE);
 						return;
-
-					}
-					else {
-						if (!goalp[item].docker.name)
+					} else {
+						if (!goalp[item].docker.name || stricmp(goalp[item].docker.name, docker) != 0)
 							set_modified();
-						else if (!stricmp(goalp[item].docker.name, docker))
-							set_modified();
-
-						if (!goalp[item].dockee.name)
-							set_modified();
-						else if (!stricmp(goalp[item].dockee.name, dockee))
+						if (!goalp[item].dockee.name || stricmp(goalp[item].dockee.name, dockee) != 0)
 							set_modified();
 
 						goalp[item].docker.name = docker;
@@ -259,6 +287,7 @@ namespace fso {
 					}
 
 					break;
+				}
 
 				case AI_GOAL_GUARD:
 				case AI_GOAL_GUARD_WING:
@@ -445,7 +474,7 @@ namespace fso {
 			}
 			void ShipGoalsDialogModel::initialize(ai_goal* goals, int ship)
 			{
-				int i, item, num, inst, flag;
+				int i, item, inst, flag;
 				ai_goal_mode mode;
 				object* ptr;
 				SCP_vector<SCP_string> docks;
@@ -522,22 +551,16 @@ namespace fso {
 						break;
 
 					case AI_GOAL_DESTROY_SUBSYSTEM:
-						num = ship_name_lookup(goalp[item].target_name, 1);
-						if (num != -1)
-							m_subsys[item] = ship_find_subsys(&Ships[num], goalp[item].docker.name);
-
+						// docker.name already holds the subsystem name string... copy it directly.
+						// (ship_find_subsys returns an int index, not the name, so don't use it here.)
+						if (goalp[item].docker.name != nullptr)
+							m_subsys[item] = goalp[item].docker.name;
 						break;
 
 					case AI_GOAL_DOCK:
-						m_subsys[item] = -1;
-						docks = _editor->get_docking_list(Ship_info[Ships[ship].ship_info_index].model_num);
-						for (i = 0; unsigned(i) < docks.size(); i++) {
-							if (!stricmp(goalp[item].docker.name, docks[i].c_str())) {
-								m_subsys[item] = i;
-								break;
-							}
-						}
-
+						// Store the docker bay name string directly; the persistent pointer lives in the polymodel.
+						if (goalp[item].docker.name != nullptr)
+							m_subsys[item] = goalp[item].docker.name;
 						break;
 
 					case AI_GOAL_CHASE_WING:

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
@@ -462,10 +462,10 @@ namespace fso {
 				init_combo_data();
 
 				if (self_ship >= 0) {
-					initialize(Ai_info[Ships[self_ship].ai_index].goals, self_ship);
+					initialize(Ai_info[Ships[self_ship].ai_index].goals);
 				}
 				else if (self_wing >= 0) {
-					initialize(Wings[self_wing].ai_goals, _editor->cur_ship);
+					initialize(Wings[self_wing].ai_goals);
 				}
 				else {
 					initialize_multi();
@@ -670,7 +670,7 @@ namespace fso {
 				ptr = GET_FIRST(&obj_used_list);
 				while (ptr != END_OF_LIST(&obj_used_list)) {
 					if (((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) && (ptr->flags[Object::Object_Flags::Marked])) {
-						initialize(Ai_info[Ships[ptr->instance].ai_index].goals, ptr->instance);
+						initialize(Ai_info[Ships[ptr->instance].ai_index].goals);
 						if (!flag) {
 							flag = 1;
 							for (i = 0; i < ED_MAX_GOALS; i++) {

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.h
@@ -2,12 +2,13 @@
 
 #include "../AbstractDialogModel.h"
 
+#include "ai/ai.h"
 #include "ai/aigoals.h"
 
 namespace fso {
 namespace fred {
 namespace dialogs {
-constexpr auto ED_MAX_GOALS = 10;
+constexpr auto ED_MAX_GOALS = MAX_AI_GOALS;
 constexpr auto MAX_EDITOR_GOAL_PRIORITY = 200;
 constexpr auto TYPE_PATH = 0x1000;
 constexpr auto TYPE_SHIP = 0x2000;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.h
@@ -23,7 +23,7 @@ constexpr auto MAX_VALID = 99;
 class ShipGoalsDialogModel : public AbstractDialogModel {
   private:
 	int Ai_goal_list_size = Editor::getAigoal_list_size();
-	void initialize(ai_goal* goals, int ship);
+	void initialize(ai_goal* goals);
 	void initialize_multi();
 	void init_combo_data();
 

--- a/qtfred/src/ui/dialogs/LayerManagerDialog.cpp
+++ b/qtfred/src/ui/dialogs/LayerManagerDialog.cpp
@@ -60,9 +60,13 @@ void LayerManagerDialog::updateUi() {
 		QSignalBlocker b1(ui->showShipsCheck);
 		QSignalBlocker b2(ui->showStartsCheck);
 		QSignalBlocker b3(ui->showWaypointsCheck);
+		QSignalBlocker b4(ui->showPropsCheck);
+		QSignalBlocker b5(ui->showJumpNodesCheck);
 		ui->showShipsCheck->setChecked(_model->getShowShips());
 		ui->showStartsCheck->setChecked(_model->getShowStarts());
 		ui->showWaypointsCheck->setChecked(_model->getShowWaypoints());
+		ui->showPropsCheck->setChecked(_model->getShowProps());
+		ui->showJumpNodesCheck->setChecked(_model->getShowJumpNodes());
 	}
 
 	// Sync IFF checkboxes
@@ -141,5 +145,7 @@ void LayerManagerDialog::on_layerList_itemChanged(QListWidgetItem* item) {
 void LayerManagerDialog::on_showShipsCheck_toggled(bool checked)     { _model->setShowShips(checked); }
 void LayerManagerDialog::on_showStartsCheck_toggled(bool checked)    { _model->setShowStarts(checked); }
 void LayerManagerDialog::on_showWaypointsCheck_toggled(bool checked) { _model->setShowWaypoints(checked); }
+void LayerManagerDialog::on_showPropsCheck_toggled(bool checked)     { _model->setShowProps(checked); }
+void LayerManagerDialog::on_showJumpNodesCheck_toggled(bool checked) { _model->setShowJumpNodes(checked); }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/LayerManagerDialog.h
+++ b/qtfred/src/ui/dialogs/LayerManagerDialog.h
@@ -29,6 +29,8 @@ private slots:
 	void on_showShipsCheck_toggled(bool checked);
 	void on_showStartsCheck_toggled(bool checked);
 	void on_showWaypointsCheck_toggled(bool checked);
+	void on_showPropsCheck_toggled(bool checked);
+	void on_showJumpNodesCheck_toggled(bool checked);
 
 private: // NOLINT(readability-redundant-access-specifiers)
 	void initializeUi();

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.cpp
@@ -16,60 +16,23 @@ ShipGoalsDialog::ShipGoalsDialog(QWidget* parent, EditorViewport* viewport, bool
 	  _model(new ShipGoalsDialogModel(this, viewport, editMultiple, shipID, wingID)), _viewport(viewport)
 {
 	ui->setupUi(this);
-	behaviors[0] = ui->comBehavior1;
-	behaviors[1] = ui->comBehavior2;
-	behaviors[2] = ui->comBehavior3;
-	behaviors[3] = ui->comBehavior4;
-	behaviors[4] = ui->comBehavior5;
-	behaviors[5] = ui->comBehavior6;
-	behaviors[6] = ui->comBehavior7;
-	behaviors[7] = ui->comBehavior8;
-	behaviors[8] = ui->comBehavior9;
-	behaviors[9] = ui->comBehavior10;
+	for (int i = 0; i < ED_MAX_GOALS; i++) {
+		const int row = i + 1; // row 0 is the header
 
-	objects[0] = ui->comObject1;
-	objects[1] = ui->comObject2;
-	objects[2] = ui->comObject3;
-	objects[3] = ui->comObject4;
-	objects[4] = ui->comObject5;
-	objects[5] = ui->comObject6;
-	objects[6] = ui->comObject7;
-	objects[7] = ui->comObject8;
-	objects[8] = ui->comObject9;
-	objects[9] = ui->comObject10;
+		auto* orderLabel = new QLabel(tr("Order %1").arg(i + 1), this);
+		behaviors[i] = new QComboBox(this);
+		objects[i]   = new QComboBox(this);
+		subsys[i]    = new QComboBox(this);
+		docks[i]     = new QComboBox(this);
+		priority[i]  = new QSpinBox(this);
 
-	subsys[0] = ui->comSub1;
-	subsys[1] = ui->comSub2;
-	subsys[2] = ui->comSub3;
-	subsys[3] = ui->comSub4;
-	subsys[4] = ui->comSub5;
-	subsys[5] = ui->comSub6;
-	subsys[6] = ui->comSub7;
-	subsys[7] = ui->comSub8;
-	subsys[8] = ui->comSub9;
-	subsys[9] = ui->comSub10;
-
-	docks[0] = ui->comDock1;
-	docks[1] = ui->comDock2;
-	docks[2] = ui->comDock3;
-	docks[3] = ui->comDock4;
-	docks[4] = ui->comDock5;
-	docks[5] = ui->comDock6;
-	docks[6] = ui->comDock7;
-	docks[7] = ui->comDock8;
-	docks[8] = ui->comDock9;
-	docks[9] = ui->comDock10;
-
-	priority[0] = ui->prioritySpinBox1;
-	priority[1] = ui->prioritySpinBox2;
-	priority[2] = ui->prioritySpinBox3;
-	priority[3] = ui->prioritySpinBox4;
-	priority[4] = ui->prioritySpinBox5;
-	priority[5] = ui->prioritySpinBox6;
-	priority[6] = ui->prioritySpinBox7;
-	priority[7] = ui->prioritySpinBox8;
-	priority[8] = ui->prioritySpinBox9;
-	priority[9] = ui->prioritySpinBox10;
+		ui->gridLayout->addWidget(orderLabel,   row, 0);
+		ui->gridLayout->addWidget(behaviors[i], row, 1);
+		ui->gridLayout->addWidget(objects[i],   row, 2);
+		ui->gridLayout->addWidget(subsys[i],    row, 3);
+		ui->gridLayout->addWidget(docks[i],     row, 4);
+		ui->gridLayout->addWidget(priority[i],  row, 5);
+	}
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &ShipGoalsDialog::updateUI);
 	for (int i = 0; i < ED_MAX_GOALS; i++) {
@@ -136,6 +99,9 @@ void ShipGoalsDialog::on_cancelButton_clicked()
 }
 void ShipGoalsDialog::updateUI()
 {
+	if (m_updating_ui)
+		return;
+	m_updating_ui = true;
 	util::SignalBlockers blockers(this);
 
 	for (int i = 0; i < ED_MAX_GOALS; i++) {
@@ -154,8 +120,6 @@ void ShipGoalsDialog::updateUI()
 		auto mode = _model->get_first_mode_from_combo_box(i);
 
 		SCP_vector<waypoint_list>::iterator ii;
-		if (i >= MAX_AI_GOALS)
-			behaviors[i]->setEnabled(false);
 		if (value < 1) {
 			objects[i]->setEnabled(false);
 			subsys[i]->setEnabled(false);
@@ -346,14 +310,14 @@ void ShipGoalsDialog::updateUI()
 				subsys[i]->setCurrentIndex(subsys[i]->findData(subsysvalue.c_str()));
 
 				docklist = _viewport->editor->get_docking_list(
-					Ship_info[Ships[_model->getDock(i) & DATA_MASK].ship_info_index].model_num);
+					Ship_info[Ships[_model->getObject(i) & DATA_MASK].ship_info_index].model_num);
 				docks[i]->setEnabled(true);
 				auto dockvalue = _model->getDock(i);
 				docks[i]->clear();
 				for (j = 0; unsigned(j) < docklist.size(); j++) {
 					docks[i]->addItem(docklist[j].c_str(), QVariant(QString(docklist[j].c_str())));
 				}
-				docks[i]->setCurrentIndex(docks[i]->findData(dockvalue));
+				docks[i]->setCurrentIndex(dockvalue);
 				priority[i]->setEnabled(true);
 				priority[i]->setValue(_model->getPriority(i));
 
@@ -368,5 +332,6 @@ void ShipGoalsDialog::updateUI()
 			}
 		}
 	}
+	m_updating_ui = false;
 }
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.h
@@ -38,6 +38,7 @@ class ShipGoalsDialog : public QDialog {
 	QSpinBox* priority[ED_MAX_GOALS];
 
 	void updateUI();
+	bool m_updating_ui = false;
 };
 } // namespace fso::fred::dialogs
 #endif // !SHIPGOALSDIALOG_H

--- a/qtfred/src/ui/dialogs/VariableDialog.cpp
+++ b/qtfred/src/ui/dialogs/VariableDialog.cpp
@@ -3,7 +3,10 @@
 #include <ui/util/SignalBlockers.h>
 #include "ui/widgets/LineEditDelegate.h"
 #include <mission/util.h>
+#include <QApplication>
+#include <QEvent>
 #include <QMessageBox>
+#include <QPalette>
 
 // Roles to store data for the line edit delegate
 const int IsStringRole = Qt::UserRole + 1;
@@ -37,6 +40,28 @@ VariableDialog::VariableDialog(FredView* parent, EditorViewport* viewport)
 }
 
 VariableDialog::~VariableDialog() = default;
+
+// Returns a subtle, theme-aware tint: blue for blue_type=true, orange for blue_type=false.
+// Detects dark/light mode via the application window-background lightness.
+QColor VariableDialog::rowTypeColor(bool blue_type)
+{
+	const bool dark_mode = QApplication::palette().color(QPalette::Window).lightness() < 128;
+	if (blue_type) {
+		return dark_mode ? QColor(50, 60, 80) : QColor(225, 235, 252);
+	} else {
+		return dark_mode ? QColor(75, 58, 42) : QColor(255, 240, 225);
+	}
+}
+
+void VariableDialog::changeEvent(QEvent* e)
+{
+	QDialog::changeEvent(e);
+	if (e->type() == QEvent::ApplicationPaletteChange || e->type() == QEvent::PaletteChange) {
+		// Re-apply row colors for the new theme
+		updateVariableList();
+		updateContainerList();
+	}
+}
 
 void VariableDialog::accept()
 {
@@ -91,7 +116,7 @@ void VariableDialog::initializeUi()
 
 	// Create one delegate to be reused for all container editing
 	auto* container_delegate = new LineEditDelegate(this);
-	ui->containersTable->setItemDelegateForColumn(ContName, container_delegate);
+	ui->containersTable->setItemDelegate(container_delegate); // covers ContName and ContType (for blended selection)
 	ui->containerContentsTable->setItemDelegate(container_delegate);
 
 	// Configure Items Table
@@ -144,6 +169,11 @@ void VariableDialog::updateVariableList()
 		if (is_string) {
 			valueItem->setData(MaxLength, TOKEN_LENGTH - 1);
 		}
+
+		// String rows tinted blue, number rows tinted orange
+		const QColor row_color = rowTypeColor(is_string);
+		nameItem->setBackground(row_color);
+		valueItem->setBackground(row_color);
 
 		ui->variablesTable->setItem(table_row, VarName, nameItem);
 		ui->variablesTable->setItem(table_row, VarValue, valueItem);
@@ -211,6 +241,11 @@ void VariableDialog::updateContainerList()
 		// Make the type column read-only
 		typeItem->setFlags(typeItem->flags() & ~Qt::ItemIsEditable);
 		ui->containersTable->setItem(table_row, ContType, typeItem);
+
+		// List rows tinted blue, map rows tinted orange
+		const QColor row_color = rowTypeColor(cont.is_list);
+		nameItem->setBackground(row_color);
+		typeItem->setBackground(row_color);
 
 		table_row++;
 	}

--- a/qtfred/src/ui/dialogs/VariableDialog.h
+++ b/qtfred/src/ui/dialogs/VariableDialog.h
@@ -3,6 +3,7 @@
 #include <mission/dialogs/VariableDialogModel.h>
 #include <ui/FredView.h>
 
+#include <QColor>
 #include <QDialog>
 
 namespace fso::fred::dialogs {
@@ -23,6 +24,7 @@ class VariableDialog : public QDialog {
 
   protected:
 	void closeEvent(QCloseEvent* e) override; // funnel all Window X presses through reject()
+	void changeEvent(QEvent* e) override;     // recolor rows on palette/theme change
 
   private slots:
 	// Dialog Controls
@@ -97,6 +99,9 @@ class VariableDialog : public QDialog {
 
 	void initializeUi();
 	void updateUi();
+
+	// Returns a theme-aware background color: blue-ish for blue_type=true, orange-ish for blue_type=false
+	static QColor rowTypeColor(bool blue_type);
 
 	// Granular update methods
 	void updateVariableList();

--- a/qtfred/src/ui/widgets/LineEditDelegate.cpp
+++ b/qtfred/src/ui/widgets/LineEditDelegate.cpp
@@ -1,7 +1,9 @@
 #include "LineEditDelegate.h"
 
+#include <QApplication>
 #include <QIntValidator>
 #include <QLineEdit>
+#include <QStyle>
 #include <limits>
 
 // A custom role to store our boolean flag
@@ -50,6 +52,36 @@ LineEditDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /*op
 	}
 
 	return editor;
+}
+
+void LineEditDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+	QStyleOptionViewItem opt = option;
+	initStyleOption(&opt, index); // fill opt from the index
+
+	if (opt.state & QStyle::State_Selected) {
+		QVariant bgData = index.data(Qt::BackgroundRole);
+		if (bgData.isValid()) {
+			// Determine blue vs orange from the row's background tint, then apply a
+			// proper saturated selection color for that type (theme-aware).
+			const QColor type_color = bgData.value<QBrush>().color();
+			const bool is_blue = type_color.blue() > type_color.red();
+			const bool dark_mode = opt.palette.color(QPalette::Window).lightness() < 128;
+			QColor sel;
+			if (is_blue) {
+				sel = dark_mode ? QColor(55, 95, 155) : QColor(70, 130, 200);
+			} else {
+				sel = dark_mode ? QColor(155, 90, 30) : QColor(200, 120, 40);
+			}
+			opt.palette.setColor(QPalette::Highlight, sel);
+		}
+	}
+
+	// Draw with our modified option directly bypassing QStyledItemDelegate::paint() which
+	// would call initStyleOption() again internally and overwrite the palette changes above.
+	const QWidget* widget = option.widget;
+	QStyle* style = widget ? widget->style() : QApplication::style();
+	style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, widget);
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/widgets/LineEditDelegate.h
+++ b/qtfred/src/ui/widgets/LineEditDelegate.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QPainter>
 #include <QStyledItemDelegate>
 
 namespace fso::fred::dialogs {
@@ -11,6 +12,8 @@ class LineEditDelegate : public QStyledItemDelegate {
 
 	QWidget*
 	createEditor(QWidget* parent, const QStyleOptionViewItem& /*option*/, const QModelIndex& index) const override;
+
+	void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/ui/LayerManagerDialog.ui
+++ b/qtfred/ui/LayerManagerDialog.ui
@@ -70,25 +70,39 @@
          <property name="title">
           <string>Object Types</string>
          </property>
-         <layout class="QVBoxLayout" name="objectTypesLayout">
-          <item>
+         <layout class="QGridLayout" name="objectTypesLayout">
+          <item row="0" column="0">
            <widget class="QCheckBox" name="showShipsCheck">
             <property name="text">
              <string>Ships</string>
             </property>
            </widget>
           </item>
-          <item>
+          <item row="1" column="0">
            <widget class="QCheckBox" name="showStartsCheck">
             <property name="text">
              <string>Player Starts</string>
             </property>
            </widget>
           </item>
-          <item>
+          <item row="2" column="0">
            <widget class="QCheckBox" name="showWaypointsCheck">
             <property name="text">
              <string>Waypoints</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="showPropsCheck">
+            <property name="text">
+             <string>Props</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="showJumpNodesCheck">
+            <property name="text">
+             <string>Jump Nodes</string>
             </property>
            </widget>
           </item>

--- a/qtfred/ui/ShipGoalsDialog.ui
+++ b/qtfred/ui/ShipGoalsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>597</width>
-    <height>374</height>
+    <height>230</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,38 +19,10 @@
   <layout class="QVBoxLayout" name="mainLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout" columnstretch="0,2,2,2,2,1">
-     <item row="10" column="0">
-      <widget class="QLabel" name="labelOrder10">
+     <item row="0" column="1">
+      <widget class="QLabel" name="behaviorLabel">
        <property name="text">
-        <string>Order 10</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="labelOrder2">
-       <property name="text">
-        <string>Order 2</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="4">
-      <widget class="QLabel" name="dockeeLabel">
-       <property name="text">
-        <string>Dockee's Bay</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="QLabel" name="subLabel">
-       <property name="text">
-        <string>Subsys/Docker's Bay</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="labelOrder8">
-       <property name="text">
-        <string>Order 8</string>
+        <string>Behavior</string>
        </property>
       </widget>
      </item>
@@ -61,59 +33,17 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="labelOrder3">
+     <item row="0" column="3">
+      <widget class="QLabel" name="subLabel">
        <property name="text">
-        <string>Order 3</string>
+        <string>Subsys/Docker's Bay</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="labelOrder5">
+     <item row="0" column="4">
+      <widget class="QLabel" name="dockeeLabel">
        <property name="text">
-        <string>Order 5</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="labelOrder9">
-       <property name="text">
-        <string>Order 9</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="labelOrder6">
-       <property name="text">
-        <string>Order 6</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="behaviorLabel">
-       <property name="text">
-        <string>Behavior</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelOrder1">
-       <property name="text">
-        <string>Order 1</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="labelOrder4">
-       <property name="text">
-        <string>Order 4</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="labelOrder7">
-       <property name="text">
-        <string>Order 7</string>
+        <string>Dockee's Bay</string>
        </property>
       </widget>
      </item>
@@ -123,156 +53,6 @@
         <string>Priority</string>
        </property>
       </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="comBehavior1"/>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="comBehavior2"/>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="comBehavior3"/>
-     </item>
-     <item row="4" column="1">
-      <widget class="QComboBox" name="comBehavior4"/>
-     </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="comBehavior5"/>
-     </item>
-     <item row="6" column="1">
-      <widget class="QComboBox" name="comBehavior6"/>
-     </item>
-     <item row="7" column="1">
-      <widget class="QComboBox" name="comBehavior7"/>
-     </item>
-     <item row="8" column="1">
-      <widget class="QComboBox" name="comBehavior8"/>
-     </item>
-     <item row="9" column="1">
-      <widget class="QComboBox" name="comBehavior9"/>
-     </item>
-     <item row="10" column="1">
-      <widget class="QComboBox" name="comBehavior10"/>
-     </item>
-     <item row="1" column="2">
-      <widget class="QComboBox" name="comObject1"/>
-     </item>
-     <item row="2" column="2">
-      <widget class="QComboBox" name="comObject2"/>
-     </item>
-     <item row="3" column="2">
-      <widget class="QComboBox" name="comObject3"/>
-     </item>
-     <item row="4" column="2">
-      <widget class="QComboBox" name="comObject4"/>
-     </item>
-     <item row="5" column="2">
-      <widget class="QComboBox" name="comObject5"/>
-     </item>
-     <item row="6" column="2">
-      <widget class="QComboBox" name="comObject6"/>
-     </item>
-     <item row="7" column="2">
-      <widget class="QComboBox" name="comObject7"/>
-     </item>
-     <item row="8" column="2">
-      <widget class="QComboBox" name="comObject8"/>
-     </item>
-     <item row="9" column="2">
-      <widget class="QComboBox" name="comObject9"/>
-     </item>
-     <item row="10" column="2">
-      <widget class="QComboBox" name="comObject10"/>
-     </item>
-     <item row="1" column="3">
-      <widget class="QComboBox" name="comSub1"/>
-     </item>
-     <item row="2" column="3">
-      <widget class="QComboBox" name="comSub2"/>
-     </item>
-     <item row="3" column="3">
-      <widget class="QComboBox" name="comSub3"/>
-     </item>
-     <item row="4" column="3">
-      <widget class="QComboBox" name="comSub4"/>
-     </item>
-     <item row="5" column="3">
-      <widget class="QComboBox" name="comSub5"/>
-     </item>
-     <item row="6" column="3">
-      <widget class="QComboBox" name="comSub6"/>
-     </item>
-     <item row="7" column="3">
-      <widget class="QComboBox" name="comSub7"/>
-     </item>
-     <item row="8" column="3">
-      <widget class="QComboBox" name="comSub8"/>
-     </item>
-     <item row="9" column="3">
-      <widget class="QComboBox" name="comSub9"/>
-     </item>
-     <item row="10" column="3">
-      <widget class="QComboBox" name="comSub10"/>
-     </item>
-     <item row="1" column="4">
-      <widget class="QComboBox" name="comDock1"/>
-     </item>
-     <item row="2" column="4">
-      <widget class="QComboBox" name="comDock2"/>
-     </item>
-     <item row="3" column="4">
-      <widget class="QComboBox" name="comDock3"/>
-     </item>
-     <item row="4" column="4">
-      <widget class="QComboBox" name="comDock4"/>
-     </item>
-     <item row="5" column="4">
-      <widget class="QComboBox" name="comDock5"/>
-     </item>
-     <item row="6" column="4">
-      <widget class="QComboBox" name="comDock6"/>
-     </item>
-     <item row="7" column="4">
-      <widget class="QComboBox" name="comDock7"/>
-     </item>
-     <item row="8" column="4">
-      <widget class="QComboBox" name="comDock8"/>
-     </item>
-     <item row="9" column="4">
-      <widget class="QComboBox" name="comDock9"/>
-     </item>
-     <item row="10" column="4">
-      <widget class="QComboBox" name="comDock10"/>
-     </item>
-     <item row="1" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox1"/>
-     </item>
-     <item row="2" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox2"/>
-     </item>
-     <item row="3" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox3"/>
-     </item>
-     <item row="4" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox4"/>
-     </item>
-     <item row="5" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox5"/>
-     </item>
-     <item row="6" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox6"/>
-     </item>
-     <item row="7" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox7"/>
-     </item>
-     <item row="8" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox8"/>
-     </item>
-     <item row="9" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox9"/>
-     </item>
-     <item row="10" column="5">
-      <widget class="QSpinBox" name="prioritySpinBox10"/>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Went in to make do some UI polish, ended up fixing a few things, too.

- Variables and Containers in their widget now color their rows based on type (string/number or list/map) to make it easier to tell at a glance what type each on in the list is.
- Props and Jump nodes were added to the visibility filters along with Ships, Waypoints, and Player Starts.
- The goals dialog was refactored to be dynamically built. The number of rows will now match `MAX_AI_GOALS` and in testing this I found a whole host of issues with saving/loading data for orders that I fixed up here, mostly regarding subsystems and docking bays being selected.