### PR TITLE
add missing libfontconfig dependency for PR test workflow

### DIFF
--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
+      - name: Install Qt dependencies
+        run: apt-get -yq update && apt-get -yq install libfontconfig1
       - uses: actions/checkout@v1
         name: Checkout
         with:


### PR DESCRIPTION
Fix issue with our Linux build image where libfontconfig1 isn't installed, but is needed by some Qt5 libs. Since aqt is used to install a more up-to-date Qt5 version than what's provided by the distro we don't have the usual dependency resolution needed to prevent this.

This is a stop-gap measure to fix testing of pull requests for QtFred, and only applies to that specifc workflow. The arm64 Linux image also has a broken Qt install so this workaround is useless with normal workflows. A proper fix will require updating the Linux build image to fix the Qt dependency problem and related issues.