### PR TITLE
Fix stencil attachment for RTT textures and enable depth/stencil for cockpit RTT

### DIFF
--- a/code/graphics/opengl/gropengltexture.cpp
+++ b/code/graphics/opengl/gropengltexture.cpp
@@ -1887,7 +1887,9 @@ int opengl_make_render_target( int handle, int *w, int *h, int *bpp, int *mm_lvl
 		glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, ts->texture_id, 0, 0);
 	}
 
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, new_fbo->renderbuffer_id);
+	if (flags & BMP_FLAG_RENDER_TARGET_DEPTH_ATTACHMENT) {
+		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, new_fbo->renderbuffer_id);
+	}
 
 	if ( opengl_check_framebuffer() ) {
 		// Oops!!  reset everything and then bail

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8702,7 +8702,7 @@ static void ship_add_cockpit_display(cockpit_display_info *display, int cockpit_
 	auto& glow_texture = (*Player_cockpit_textures)[glow_target];
 	if ( glow_texture == -1) {
 		bm_get_info(diffuse_handle, &w, &h);
-		glow_texture = bm_make_render_target(w, h, BMP_FLAG_RENDER_TARGET_DYNAMIC);
+		glow_texture = bm_make_render_target(w, h, BMP_FLAG_RENDER_TARGET_DYNAMIC | BMP_FLAG_RENDER_TARGET_DEPTH_ATTACHMENT);
 
 		// if no render target was made, bail
 		if ( glow_texture < 0 ) {


### PR DESCRIPTION
Should fix #1069, though a lack of test case makes this difficult to validate.