### PR TITLE
Qtfred cargo title and scanning fields

### DIFF
--- a/code/mission/mission_flags.h
+++ b/code/mission/mission_flags.h
@@ -113,6 +113,7 @@ namespace Mission {
 		SF_Cannot_perform_scan_hide_cargo,	// Goober5000 - ship cannot scan other ships, and cargo will not be shown on the HUD
 		SF_Cannot_perform_scan_show_cargo,	// Goober5000 - ship cannot scan other ships, but cargo will be shown on the HUD
 		SF_No_targeting_limits,			// MjnMixael - Ship is always targetable regardless of AWACS or targeting range limits
+		SF_No_scanned_cargo,			// MjnMixael - cargo is never revealed, only shows scanned/not scanned (requires unified scanning)
 		SF_From_player_wing,			// set for ships that are members of any player starting wing
 
 		NUM_VALUES

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -328,6 +328,7 @@ flag_def_list_new<Ship::Ship_Flags> Parse_ship_flags[] = {
 	{"cannot-perform-scan-hide-cargo", Ship::Ship_Flags::Cannot_perform_scan_hide_cargo, true, false},
 	{"cannot-perform-scan-show-cargo", Ship::Ship_Flags::Cannot_perform_scan_show_cargo, true, false},
 	{"no-targeting-limits", Ship::Ship_Flags::No_targeting_limits, true, false},
+	{"no-scanned-cargo", Ship::Ship_Flags::No_scanned_cargo, true, false},
 	{"force-shields-on", Ship::Ship_Flags::Force_shields_on, true, false},
 	{"Destroy before Mission", Ship::Ship_Flags::Kill_before_mission,true, false}, //Not Printed to misson so can use descriptive name
 }
@@ -499,6 +500,7 @@ flag_def_list_new<Mission::Parse_Object_Flags> Parse_object_flags[] = {
 	{ "cannot-perform-scan-hide-cargo",		Mission::Parse_Object_Flags::SF_Cannot_perform_scan_hide_cargo, true, false },
 	{ "cannot-perform-scan-show-cargo",		Mission::Parse_Object_Flags::SF_Cannot_perform_scan_show_cargo, true, false },
 	{ "no-targeting-limits",				Mission::Parse_Object_Flags::SF_No_targeting_limits, true, false},
+	{ "no-scanned-cargo",					Mission::Parse_Object_Flags::SF_No_scanned_cargo, true, false },
 };
 
 parse_object_flag_description<Mission::Parse_Object_Flags> Parse_object_flag_descriptions[] = {
@@ -566,6 +568,7 @@ parse_object_flag_description<Mission::Parse_Object_Flags> Parse_object_flag_des
 	{ Mission::Parse_Object_Flags::SF_Cannot_perform_scan_hide_cargo, "Ship cannot scan other ships, and the cargo line will not be shown on the HUD."},
 	{ Mission::Parse_Object_Flags::SF_Cannot_perform_scan_show_cargo, "Ship cannot scan other ships, but the cargo line will be shown on the HUD."},
 	{ Mission::Parse_Object_Flags::SF_No_targeting_limits,			"Ship is always targetable regardless of AWACS or targeting range limits."},
+	{ Mission::Parse_Object_Flags::SF_No_scanned_cargo,				"Cargo is never revealed; only shows 'Scanned' or 'Not Scanned'. Needs $Unify Scanning Behavior in game_settings.tbl."},
 };
 
 const size_t Num_parse_object_flags = sizeof(Parse_object_flags) / sizeof(flag_def_list_new<Mission::Parse_Object_Flags>);
@@ -3147,6 +3150,8 @@ void resolve_parse_flags(object *objp, flagset<Mission::Parse_Object_Flags> &par
 		shipp->flags.set(Ship::Ship_Flags::Cannot_perform_scan_hide_cargo);
 	if (parse_flags[Mission::Parse_Object_Flags::SF_Cannot_perform_scan_show_cargo])
 		shipp->flags.set(Ship::Ship_Flags::Cannot_perform_scan_show_cargo);
+	if (parse_flags[Mission::Parse_Object_Flags::SF_No_scanned_cargo])
+		shipp->flags.set(Ship::Ship_Flags::No_scanned_cargo);
 
 	if (parse_flags[Mission::Parse_Object_Flags::SF_No_targeting_limits])
 		shipp->flags.set(Ship::Ship_Flags::No_targeting_limits);

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -3843,6 +3843,8 @@ int Fred_mission_save::save_objects()
 				fout(" \"cannot-perform-scan-show-cargo\"");
 			if (shipp->flags[Ship::Ship_Flags::No_targeting_limits])
 				fout(" \"no-targeting-limits\"");
+			if (shipp->flags[Ship::Ship_Flags::No_scanned_cargo])
+				fout(" \"no-scanned-cargo\"");
 			fout(" )");
 		}
 		// -----------------------------------------------------------

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
@@ -370,6 +370,7 @@ void ShipEditorDialogModel::initializeData()
 							_m_ai_class = Ships[i].weapons.ai_class;
 							cargo = Ships[i].cargo1;
 							_m_cargo1 = Cargo_names[cargo];
+							_m_cargo_title = Ships[i].cargo_title;
 							_m_hotkey = Ships[i].hotkey + 1;
 							_m_score = Ships[i].score;
 							_m_assist_score = static_cast<int>(Ships[i].assist_score_pct * 100);
@@ -407,6 +408,10 @@ void ShipEditorDialogModel::initializeData()
 
 							if (Ships[i].cargo1 != cargo) {
 								_m_cargo1 = "";
+							}
+
+							if (_m_cargo_title != Ships[i].cargo_title) {
+								_m_cargo_title = "";
 							}
 
 							_m_score = Ships[i].score;
@@ -495,6 +500,7 @@ void ShipEditorDialogModel::initializeData()
 
 		_m_ai_class = -1;
 		_m_cargo1 = "";
+		_m_cargo_title = "";
 		_m_hotkey = 0;
 		_m_score = 0; // cause control to be blank
 		_m_assist_score = 0;
@@ -926,6 +932,24 @@ void ShipEditorDialogModel::setCargo(const SCP_string& m_cargo)
 SCP_string ShipEditorDialogModel::getCargo() const
 {
 	return _m_cargo1;
+}
+
+void ShipEditorDialogModel::setCargoTitle(const SCP_string& title)
+{
+	if (_m_cargo_title == title)
+		return;
+	_m_cargo_title = title;
+	for (auto* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
+		if (((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) && (ptr->flags[Object::Object_Flags::Marked])) {
+			strcpy_s(Ships[ptr->instance].cargo_title, title.c_str());
+		}
+	}
+	set_modified();
+}
+
+SCP_string ShipEditorDialogModel::getCargoTitle() const
+{
+	return _m_cargo_title;
 }
 
 void ShipEditorDialogModel::setAltName(const SCP_string& m_altName)

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.h
@@ -19,6 +19,7 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 	SCP_string _m_ship_name;
 	SCP_string _m_ship_display_name;
 	SCP_string _m_cargo1;
+	SCP_string _m_cargo_title;
 	SCP_string _m_alt_name;
 	SCP_string _m_callsign;
 	int _m_ship_class;
@@ -95,6 +96,9 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 
 	void setCargo(const SCP_string&);
 	SCP_string getCargo() const;
+
+	void setCargoTitle(const SCP_string&);
+	SCP_string getCargoTitle() const;
 
 	void setAltName(const SCP_string&);
 	SCP_string getAltName() const;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
@@ -912,7 +912,7 @@ bool ShipInitialStatusDialogModel::getToggleSubsystemScanning() const
 	return Ships[m_ship].flags[Ship::Ship_Flags::Toggle_subsystem_scanning];
 }
 
-bool ShipInitialStatusDialogModel::getUseNewScanningBehavior() const
+bool ShipInitialStatusDialogModel::getUseNewScanningBehavior()
 {
 	return Use_new_scanning_behavior;
 }

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
@@ -4,6 +4,7 @@
 
 #include <globalincs/linklist.h>
 #include <localization/localize.h>
+#include <mod_table/mod_table.h>
 
 #include <QtWidgets>
 #include <object/objectdock.cpp>
@@ -766,6 +767,16 @@ void ShipInitialStatusDialogModel::setCargo(const SCP_string& text)
 	modify(m_cargo_name, text);
 }
 
+SCP_string ShipInitialStatusDialogModel::getCargoTitle() const
+{
+	return m_cargo_title;
+}
+
+void ShipInitialStatusDialogModel::setCargoTitle(const SCP_string& text)
+{
+	modify(m_cargo_title, text);
+}
+
 SCP_string ShipInitialStatusDialogModel::getColour() const
 {
 	return m_team_color_setting;
@@ -817,6 +828,9 @@ void ShipInitialStatusDialogModel::change_subsys(const int new_subsys)
 				ptr->subsys_cargo_name = cargo_index;
 			}
 		}
+
+		// update cargo title
+		strcpy_s(ptr->subsys_cargo_title, m_cargo_title.c_str());
 	}
 
 	cur_subsys = z = new_subsys;
@@ -831,15 +845,12 @@ void ShipInitialStatusDialogModel::change_subsys(const int new_subsys)
 		}
 
 		m_damage = 100 - static_cast<int>(ptr->current_hits);
-		if (ship_has_scannable_subsystems) {
-			if (ptr->subsys_cargo_name > 0) {
-				m_cargo_name = Cargo_names[ptr->subsys_cargo_name];
-			} else {
-				m_cargo_name = "";
-			}
+		if (ptr->subsys_cargo_name > 0) {
+			m_cargo_name = Cargo_names[ptr->subsys_cargo_name];
 		} else {
 			m_cargo_name = "";
 		}
+		m_cargo_title = ptr->subsys_cargo_title;
 	}
 	set_modified();
 	modelChanged();
@@ -894,6 +905,16 @@ int ShipInitialStatusDialogModel::getGuardian() const
 void ShipInitialStatusDialogModel::setGuardian(int value)
 {
 	modify(guardian_threshold, value);
+}
+
+bool ShipInitialStatusDialogModel::getToggleSubsystemScanning() const
+{
+	return Ships[m_ship].flags[Ship::Ship_Flags::Toggle_subsystem_scanning];
+}
+
+bool ShipInitialStatusDialogModel::getUseNewScanningBehavior() const
+{
+	return Use_new_scanning_behavior;
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.h
@@ -33,6 +33,7 @@ class ShipInitialStatusDialogModel : public AbstractDialogModel {
 	int m_ship_locked;
 	int m_weapons_locked;
 	SCP_string m_cargo_name;
+	SCP_string m_cargo_title;
 	int m_primaries_locked;
 	int m_secondaries_locked;
 	int m_turrets_locked;
@@ -108,6 +109,9 @@ class ShipInitialStatusDialogModel : public AbstractDialogModel {
 	SCP_string getCargo() const;
 	void setCargo(const SCP_string&);
 
+	SCP_string getCargoTitle() const;
+	void setCargoTitle(const SCP_string&);
+
 	SCP_string getColour() const;
 	void setColour(const SCP_string&);
 
@@ -122,6 +126,9 @@ class ShipInitialStatusDialogModel : public AbstractDialogModel {
 
 	bool getUseTeamcolours() const;
 	bool getIfMultpleShips() const;
+
+	bool getToggleSubsystemScanning() const;
+	bool getUseNewScanningBehavior() const;
 
 	int getGuardian() const;
 	void setGuardian(int);

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.h
@@ -128,7 +128,7 @@ class ShipInitialStatusDialogModel : public AbstractDialogModel {
 	bool getIfMultpleShips() const;
 
 	bool getToggleSubsystemScanning() const;
-	bool getUseNewScanningBehavior() const;
+	static bool getUseNewScanningBehavior();
 
 	int getGuardian() const;
 	void setGuardian(int);

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -30,6 +30,7 @@ ShipEditorDialog::ShipEditorDialog(FredView* parent, EditorViewport* viewport)
 	ui->shipDisplayNameEdit->setMaxLength(NAME_LENGTH - 1);
 	ui->altNameCombo->lineEdit()->setMaxLength(NAME_LENGTH - 1);
 	ui->callsignCombo->lineEdit()->setMaxLength(CALLSIGN_LEN);
+	ui->cargoTitleEdit->setMaxLength(NAME_LENGTH - 1);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, [this] { updateUI(false); });
 	connect(viewport->editor, &Editor::currentObjectChanged, this, &ShipEditorDialog::update);
@@ -38,6 +39,7 @@ ShipEditorDialog::ShipEditorDialog(FredView* parent, EditorViewport* viewport)
 	// Column One
 
 	connect(ui->cargoCombo->lineEdit(), (&QLineEdit::editingFinished), this, &ShipEditorDialog::cargoChanged);
+	connect(ui->cargoTitleEdit, (&QLineEdit::editingFinished), this, &ShipEditorDialog::cargoTitleChanged);
 	connect(ui->altNameCombo->lineEdit(), (&QLineEdit::textEdited), this, &ShipEditorDialog::altNameChanged);
 	connect(ui->callsignCombo->lineEdit(), (&QLineEdit::textEdited), this, &ShipEditorDialog::callsignChanged);
 
@@ -187,6 +189,7 @@ void ShipEditorDialog::updateColumnOne(bool overwrite)
 
 			ui->cargoCombo->setCurrentIndex(ui->cargoCombo->findText(QString(cargo.c_str())));
 		}
+		ui->cargoTitleEdit->setText(_model->getCargoTitle().c_str());
 	}
 	if (_model->getNumSelectedObjects()) {
 		if (_model->getIfMultipleShips()) {
@@ -484,6 +487,7 @@ void ShipEditorDialog::enableDisable()
 
 	ui->AIClassCombo->setEnabled(_model->getUIEnable());
 	ui->cargoCombo->setEnabled(_model->getUIEnable());
+	ui->cargoTitleEdit->setEnabled(_model->getUIEnable());
 	ui->hotkeyCombo->setEnabled(_model->getUIEnable());
 	if ((_model->getShipClass() >= 0) && !(Ship_info[_model->getShipClass()].flags[Ship::Info_Flags::Cargo]) &&
 		!(Ship_info[_model->getShipClass()].flags[Ship::Info_Flags::No_ship_type]))
@@ -572,6 +576,14 @@ void ShipEditorDialog::cargoChanged()
 		const auto textBytes = entry.toUtf8();
 		const SCP_string NewCargo = textBytes.toStdString();
 		_model->setCargo(NewCargo);
+	}
+}
+void ShipEditorDialog::cargoTitleChanged()
+{
+	const QString entry = ui->cargoTitleEdit->text();
+	if (!entry.isEmpty() && entry != _model->getCargoTitle().c_str()) {
+		const SCP_string NewCargoTitle = entry.toUtf8().constData();
+		_model->setCargoTitle(NewCargoTitle);
 	}
 }
 void ShipEditorDialog::altNameChanged()

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
@@ -132,6 +132,7 @@ class ShipEditorDialog : public QDialog, public SexpTreeEditorInterface {
 
 	// column one
 	void cargoChanged();
+	void cargoTitleChanged();
 	void altNameChanged();
 	void callsignChanged();
 };

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipInitialStatusDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipInitialStatusDialog.cpp
@@ -22,6 +22,7 @@ ShipInitialStatusDialog::ShipInitialStatusDialog(QDialog* parent, EditorViewport
 	ui->setupUi(this);
 
 	ui->cargoEdit->setMaxLength(NAME_LENGTH - 1);
+	ui->cargoTitleEdit->setMaxLength(NAME_LENGTH - 1);
 
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &ShipInitialStatusDialog::updateUI);
 
@@ -129,6 +130,11 @@ void ShipInitialStatusDialog::on_cargoEdit_editingFinished()
 {
 	SCP_string cargo = ui->cargoEdit->text().toUtf8().constData();
 	_model->setCargo(cargo);
+}
+void ShipInitialStatusDialog::on_cargoTitleEdit_editingFinished()
+{
+	SCP_string title = ui->cargoTitleEdit->text().toUtf8().constData();
+	_model->setCargoTitle(title);
 }
 void ShipInitialStatusDialog::on_colourComboBox_currentIndexChanged(int index)
 {
@@ -363,12 +369,15 @@ void ShipInitialStatusDialog::updateSubsystems()
 	ship_subsys* ptr;
 	auto index = ui->subsystemList->currentIndex();
 	ui->subsystemList->clear();
-	if (!_model->getIfMultpleShips()) {
+
+	bool multiEdit = _model->getIfMultpleShips();
+	bool useNewScanning = _model->getUseNewScanningBehavior();
+	bool toggleSet = _model->getToggleSubsystemScanning();
+	bool scannable = _model->getShip_has_scannable_subsystems();
+
+	if (!multiEdit) {
 		ui->subsystemList->setEnabled(true);
 		ui->subIntegritySpinBox->setEnabled(true);
-		if (_model->getShip_has_scannable_subsystems()) {
-			ui->cargoEdit->setEnabled(true);
-		}
 		for (ptr = GET_FIRST(&Ships[_model->getShip()].subsys_list);
 			ptr != END_OF_LIST(&Ships[_model->getShip()].subsys_list);
 			ptr = GET_NEXT(ptr)) {
@@ -380,11 +389,30 @@ void ShipInitialStatusDialog::updateSubsystems()
 	} else {
 		ui->subsystemList->setEnabled(false);
 		ui->subIntegritySpinBox->setEnabled(false);
-		ui->cargoEdit->setEnabled(false);
 	}
+
+	// Determine whether subsystem cargo fields should be shown.
+	// Classic mode: ship must have scannable subsystems (huge ship, or non-huge with Toggle_subsystem_scanning).
+	// Unified mode: any ship with Toggle_subsystem_scanning can use subsystem cargo.
+	bool showCargo;
+	if (useNewScanning) {
+		showCargo = !multiEdit && toggleSet;
+	} else {
+		showCargo = !multiEdit && scannable;
+	}
+
+	ui->subsysCargoHelpLabel->setVisible(!showCargo && !multiEdit);
+	ui->cargoLabel->setVisible(showCargo);
+	ui->cargoEdit->setVisible(showCargo);
+	ui->cargoEdit->setEnabled(showCargo);
+	ui->cargoTitleLabel->setVisible(showCargo);
+	ui->cargoTitleEdit->setVisible(showCargo);
+	ui->cargoTitleEdit->setEnabled(showCargo);
+
 	auto value = _model->getDamage();
 	ui->subIntegritySpinBox->setValue(value);
 	auto cargovalue = _model->getCargo();
 	ui->cargoEdit->setText(cargovalue.c_str());
+	ui->cargoTitleEdit->setText(_model->getCargoTitle().c_str());
 }
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipInitialStatusDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipInitialStatusDialog.h
@@ -45,6 +45,7 @@ class ShipInitialStatusDialog : public QDialog {
 	void on_subsystemList_currentRowChanged(int);
 	void on_subIntegritySpinBox_valueChanged(int);
 	void on_cargoEdit_editingFinished();
+	void on_cargoTitleEdit_editingFinished();
 	void on_colourComboBox_currentIndexChanged(int);
 
   private: // NOLINT(readability-redundant-access-specifiers)

--- a/qtfred/ui/ShipEditorDialog.ui
+++ b/qtfred/ui/ShipEditorDialog.ui
@@ -158,6 +158,20 @@
              </property>
             </widget>
            </item>
+           <item row="8" column="0">
+            <widget class="QLabel" name="cargoTitleLabel">
+             <property name="text">
+              <string>Cargo Title</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="1">
+            <widget class="QLineEdit" name="cargoTitleEdit">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Overrides the HUD label shown before the cargo name (e.g. &quot;cargo&quot;). Use &quot;#&quot; as the first character to suppress the label entirely.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </item>
          <item>

--- a/qtfred/ui/ShipInitialStatus.ui
+++ b/qtfred/ui/ShipInitialStatus.ui
@@ -368,6 +368,16 @@
        </layout>
       </item>
       <item>
+       <widget class="QLabel" name="subsysCargoHelpLabel">
+        <property name="text">
+         <string>Enable &apos;Toggle Subsystem Scanning&apos; in the ship flags to edit subsystem cargo.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="cargoLayout">
         <item>
          <widget class="QLabel" name="cargoLabel">
@@ -380,6 +390,24 @@
          <widget class="QLineEdit" name="cargoEdit">
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the subsytems cargo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="cargoTitleLayout">
+        <item>
+         <widget class="QLabel" name="cargoTitleLabel">
+          <property name="text">
+           <string>Cargo Title</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="cargoTitleEdit">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Overrides the HUD label shown before this subsystem's cargo name. Use &quot;#&quot; as the first character to suppress the label entirely.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Adds the Cargo Title modifiable fields to the editor that were added in #6000 and upgrades the UI to help the user understand how to enable subsystem cargo scanning based on what the mod environment is.