### PR TITLE
Refactor player-set-target SEXP

### DIFF
--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13930,8 +13930,7 @@ void sexp_set_friendly_damage_caps(int n) {
  * Sets the player's target to the specified, either ship, and or the subsystem on said ship.
  */
 void sexp_set_player_target(int node)
-{
-	// int shipnum = ship_name_lookup(CTEXT(node), 1);
+{	
 	const ship_registry_entry *ship_entry = eval_ship(node);
 	if (ship_entry == nullptr)
 		return;
@@ -13950,10 +13949,6 @@ void sexp_set_player_target(int node)
 			new_subsys = ship_get_subsys(shipp, subsys_name);
 		}
 	}
-	
-    // set_target_objnum will call hud_restore_subsystem_target which reads last_targeted_subobject
-    shipp->last_targeted_subobject[Player_num] = new_subsys;
-
     set_target_objnum(Player_ai, objnum);
     set_targeted_subsys(Player_ai, new_subsys, objnum);
 }

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -13931,26 +13931,31 @@ void sexp_set_friendly_damage_caps(int n) {
  */
 void sexp_set_player_target(int node)
 {
-	int shipnum = ship_name_lookup(CTEXT(node), 1);
+	// int shipnum = ship_name_lookup(CTEXT(node), 1);
+	const ship_registry_entry *ship_entry = eval_ship(node);
+	if (ship_entry == nullptr)
+		return;
+
+	int shipnum = ship_entry->shipnum;
 	if (shipnum < 0)
 		return;
+
 	ship* shipp = &Ships[shipnum];
 	int objnum = shipp->objnum;
 	int n = CDR(node);
+	ship_subsys * new_subsys = nullptr;
 	if (n >= 0) {
 		const char* subsys_name = CTEXT(n);
 		if (stricmp(subsys_name, SEXP_NONE_STRING) != 0) {
-			ship_subsys* ss = ship_get_subsys(shipp, subsys_name);
-			// target ship regardless of whether subsystem is destroyed
-			shipp->last_targeted_subobject[Player_num] = ss;
-		} else {
-			shipp->last_targeted_subobject[Player_num] = nullptr;
+			new_subsys = ship_get_subsys(shipp, subsys_name);
 		}
-	} else {
-		shipp->last_targeted_subobject[Player_num] = nullptr;
 	}
-	// set_target_objnum will call hud_restore_subsystem_target which reads last_targeted_subobject
-	set_target_objnum(Player_ai, objnum);
+	
+    // set_target_objnum will call hud_restore_subsystem_target which reads last_targeted_subobject
+    shipp->last_targeted_subobject[Player_num] = new_subsys;
+
+    set_target_objnum(Player_ai, objnum);
+    set_targeted_subsys(Player_ai, new_subsys, objnum);
 }
 
 // Luytenky


### PR DESCRIPTION
Based on prior feedback from @Goober5000, I've revisited this feature to address the following:

1) the sexp implementation uses `ship_name_lookup`, but `eval_ship` would take advantage of the ship registry (faster lookup that comes with handling of non-present states) and would also cache the ship in the sexp node
2) `last_targeted_subobject` shouldn't be used; the sexp implementation should explicitly set the subsystem (as it does in the clearing sexp) without using hacks

However I should address the line:

```
    // set_target_objnum will call hud_restore_subsystem_target which reads last_targeted_subobject
    shipp->last_targeted_subobject[Player_num] = new_subsys;
```

HUD code still reads `ship::last_targeted_subobject` instead of `Player_ai->targeted_subsys` I think am not sure, so SEXPs have to write it as a hack. Needs HUD‑side fix so `hud_restore_subsystem_target` uses `targeted_subsys`; then `last_targeted_subobject` can be removed from SEXP logic. I'd have to say that this is an assumption.