### PR TITLE
Qtfred prevent hiding toolbars

### DIFF
--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -269,6 +269,16 @@ void FredView::setEditor(Editor* editor, EditorViewport* viewport) {
 		restoreGeometry(savedGeometry);
 	enforceSideDockAreas();
 
+	// Keep the context bar on its own row below the primary toolbar.
+	// restoreState() can otherwise place or hide toolbars based on saved layout.
+	removeToolBar(ui->toolBar);
+	removeToolBar(ui->contextToolBar);
+	addToolBar(Qt::TopToolBarArea, ui->toolBar);
+	addToolBarBreak(Qt::TopToolBarArea);
+	addToolBar(Qt::TopToolBarArea, ui->contextToolBar);
+	ui->toolBar->setVisible(true);
+	ui->contextToolBar->setVisible(true);
+
 	// Lock the context toolbar to a fixed height so that adding/removing buttons
 	// doesn't resize the viewport. Use the primary toolbar's hint; fall back to 28px.
 	_contextToolBar->setFixedHeight(qMax(28, ui->toolBar->sizeHint().height()));
@@ -783,6 +793,8 @@ void FredView::initializeStatusBar() {
 
 void FredView::initializeContextToolbar() {
 	_contextToolBar = ui->contextToolBar;
+	_contextToolBar->setContextMenuPolicy(Qt::PreventContextMenu);
+	_contextToolBar->setVisible(true);
 
 	_contextLabel = new QLabel(tr("No Selection"), _contextToolBar);
 	_contextLabel->setContentsMargins(6, 0, 8, 0);
@@ -968,6 +980,8 @@ void FredView::quickRenameCurrentObject() {
 
 void FredView::initializeTransformBar() {
 	_transformToolBar = ui->transformToolBar;
+	_transformToolBar->setContextMenuPolicy(Qt::PreventContextMenu);
+	_transformToolBar->setVisible(true);
 
 	// Helper: add a fixed-width spacer widget to the toolbar.
 	auto addFixedSpacer = [this](int w) {


### PR DESCRIPTION
Depending on the state of the qtfred window when loading, the new toolbars can be placed incorrectly or entirely hidden. This PR enforces their original locations at startup and disables the default qtfred context menu that allows hiding them which would end up hiding them permanently.

This may just be caused by a bad saved window state during development but might as well fix it anyway.