### PR TITLE
Follow-up fix to 7360

### DIFF
--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -761,7 +761,7 @@ void gr_opengl_post_process_save_zbuffer()
 	GR_DEBUG_SCOPE("Save z-Buffer");
 	if (Post_initialized)
 	{
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Cockpit_depth_texture, 0);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, Cockpit_depth_texture, 0);
 		gr_zbuffer_clear(TRUE);
 		zbuffer_saved = true;
 	}
@@ -777,7 +777,7 @@ void gr_opengl_post_process_restore_zbuffer()
 	GR_DEBUG_SCOPE("Restore z-Buffer");
 
 	if (zbuffer_saved) {
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, Scene_depth_texture, 0);
 
 		zbuffer_saved = false;
 	}


### PR DESCRIPTION
Turns out #7360 causes cockpits to not render. That PR had updated `GL_DEPTH_ATTACHMENT` to `GL_DEPTH_STENCIL_ATTACHMENT` but missed two spots. This PR fixes that and tests show cockpits now work.  (Root cause was the save/restore zbuffer swap using the old GL_DEPTH_ATTACHMENT point — once the scene texture became a combined depth-stencil, re-binding just the depth slot left stencil dangling and made the FBO incomplete.)