### PR TITLE
Qtfred generic fixes

### DIFF
--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -797,6 +797,8 @@ void FredRenderer::render_one_model_htl(object* objp,
 			render_info.set_debug_flags(debug_flags);
 			render_info.set_replacement_textures(model_get_instance(Ships[z].model_instance_num)->texture_replace);
 			render_info.set_flags(flags);
+			if (Ship_info[Ships[z].ship_info_index].uses_team_colors)
+				render_info.set_team_color(Ships[z].team_name, Ships[z].secondary_team_name, Ships[z].team_change_timestamp, Ships[z].team_change_time);
 			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 		}
 

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -952,9 +952,14 @@ void FredRenderer::render_frame(int cur_object_index,
 
 	g3_set_view_matrix(&_viewport->eye_pos, &_viewport->eye_orient, 0.5f);
 
+	// Force max star detail so the editor always shows the full Num_stars count
+	// regardless of the player's graphics quality setting (Detail.num_stars can be 0).
+	int saved_detail_stars = Detail.num_stars;
+	Detail.num_stars = MAX_DETAIL_VALUE;
 	enable_htl();
 	stars_draw(view().Show_stars, view().Show_stars, view().Show_stars, 0, 0);
 	disable_htl();
+	Detail.num_stars = saved_detail_stars;
 
 	if (view().Show_horizon) {
 		gr_set_color(128, 128, 64);

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -50,7 +50,6 @@ void BackgroundEditorDialogModel::refreshBackgroundPreview()
 	stars_load_background(Cur_background); // rebuild instances from Backgrounds[]
 	stars_set_background_model(The_mission.skybox_model, nullptr, The_mission.skybox_flags); // rebuild skybox
 	stars_set_background_orientation(&The_mission.skybox_orientation);
-	// TODO make this actually show the stars in the background
 	_editor->missionChanged();
 }
 

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -48,7 +48,14 @@ void BackgroundEditorDialogModel::reject()
 void BackgroundEditorDialogModel::refreshBackgroundPreview()
 {
 	stars_load_background(Cur_background); // rebuild instances from Backgrounds[]
-	stars_set_background_model(The_mission.skybox_model, nullptr, The_mission.skybox_flags); // rebuild skybox
+
+	// The mission stores the base model name (no extension); the save code adds .pof when writing.
+	// model_load needs the .pof extension to find the file, so append it if missing.
+	SCP_string skybox_model = The_mission.skybox_model;
+	if (!skybox_model.empty() && skybox_model.find('.') == SCP_string::npos)
+		skybox_model += ".pof";
+
+	stars_set_background_model(skybox_model.c_str(), nullptr, The_mission.skybox_flags); // rebuild skybox
 	stars_set_background_orientation(&The_mission.skybox_orientation);
 	_editor->missionChanged();
 }

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -422,18 +422,17 @@ bool MissionSpecDialogModel::getMissionFlag(Mission::Mission_Flags flag) const {
 }
 
 const SCP_vector<std::pair<SCP_string, bool>>& MissionSpecDialogModel::getMissionFlagsList() {
-	if (_m_flag_data.empty()) {
-		for (size_t i = 0; i < Num_parse_mission_flags; ++i) {
-			auto flagDef = Parse_mission_flags[i];
+	_m_flag_data.clear();
+	for (size_t i = 0; i < Num_parse_mission_flags; ++i) {
+		auto flagDef = Parse_mission_flags[i];
 
-			// Skip flags that have checkboxes elsewhere than the flag list or are inactive
-			if (flagDef.is_special || !flagDef.in_use) {
-				continue;
-			}
-
-			bool checked = _m_flags[flagDef.def];
-			_m_flag_data.emplace_back(flagDef.name, checked);
+		// Skip flags that have checkboxes elsewhere than the flag list or are inactive
+		if (flagDef.is_special || !flagDef.in_use) {
+			continue;
 		}
+
+		bool checked = _m_flags[flagDef.def];
+		_m_flag_data.emplace_back(flagDef.name, checked);
 	}
 	return _m_flag_data;
 }

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
@@ -554,8 +554,9 @@ std::vector<std::pair<SCP_string, bool>> ShipEditorDialogModel::getArrivalPaths(
 	auto m_path_mask = Ships[single_ship].arrival_path_mask;
 
 	for (int i = 0; i < m_num_paths; i++) {
-		SCP_string name("Path ");
-		name += i2ch(i + 1);
+		int path_id = m_model->ship_bay->path_indexes[i];
+		const char* raw_name = m_model->paths[path_id].name;
+		SCP_string name = (raw_name && raw_name[0]) ? SCP_string{raw_name} : SCP_string{"<unnamed path>"};
 		bool allowed;
 		if (m_path_mask == 0) {
 			allowed = true;
@@ -579,8 +580,9 @@ std::vector<std::pair<SCP_string, bool>> ShipEditorDialogModel::getDeparturePath
 	auto m_path_mask = Ships[single_ship].departure_path_mask;
 
 	for (int i = 0; i < m_num_paths; i++) {
-		SCP_string name("Path ");
-		name += i2ch(i + 1);
+		int path_id = m_model->ship_bay->path_indexes[i];
+		const char* raw_name = m_model->paths[path_id].name;
+		SCP_string name = (raw_name && raw_name[0]) ? SCP_string{raw_name} : SCP_string{"<unnamed path>"};
 		bool allowed;
 		if (m_path_mask == 0) {
 			allowed = true;

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
@@ -272,14 +272,9 @@ void ShipInitialStatusDialogModel::initializeData(bool multi)
 		}
 	}
 
-	if (objp != nullptr) {
-		if (objp->type == OBJ_SHIP || objp->type == OBJ_START) {
-			ship* shipp = &Ships[objp->instance];
-
-			if (Ship_info[shipp->ship_info_index].uses_team_colors) {
-				m_use_teams = true;
-			}
-		}
+	if (Ship_info[Ships[m_ship].ship_info_index].uses_team_colors) {
+		m_use_teams = true;
+		m_team_color_setting = Ships[m_ship].team_name;
 	}
 	change_subsys(0);
 
@@ -607,6 +602,7 @@ bool ShipInitialStatusDialogModel::apply()
 				handle_inconsistent_flag(shipp->flags, Ship::Ship_Flags::Secondaries_locked, m_secondaries_locked);
 				handle_inconsistent_flag(shipp->flags, Ship::Ship_Flags::Lock_all_turrets_initially, m_turrets_locked);
 				handle_inconsistent_flag(shipp->flags, Ship::Ship_Flags::Afterburner_locked, m_afterburner_locked);
+				shipp->team_name = m_team_color_setting;
 			}
 
 			objp = GET_NEXT(objp);
@@ -628,8 +624,8 @@ bool ShipInitialStatusDialogModel::apply()
 		handle_inconsistent_flag(Ships[m_ship].flags, Ship::Ship_Flags::Secondaries_locked, m_secondaries_locked);
 		handle_inconsistent_flag(Ships[m_ship].flags, Ship::Ship_Flags::Lock_all_turrets_initially, m_turrets_locked);
 		handle_inconsistent_flag(Ships[m_ship].flags, Ship::Ship_Flags::Afterburner_locked, m_afterburner_locked);
+		Ships[m_ship].team_name = m_team_color_setting;
 	}
-	Ships[m_ship].team_name = m_team_color_setting;
 	update_docking_info();
 	_editor->missionChanged();
 	return true;

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
@@ -771,7 +771,8 @@ void WingEditorDialogModel::setArrivalType(ArrivalLocation newArrivalType)
 	auto* w = getCurrentWing();
 	modify(w->arrival_location, newArrivalType);
 
-	// If the new arrival type is a dock bay, clear warp in parameters
+	// If the new arrival type is a dock bay, reset warp-in params to ship class defaults
+	// (dock bay arrivals don't use warp effects; -1 would crash the save code)
 	// else, clear arrival paths
 	if (newArrivalType == ArrivalLocation::FROM_DOCK_BAY) {
 		for (auto& ship : Ships) {
@@ -780,7 +781,7 @@ void WingEditorDialogModel::setArrivalType(ArrivalLocation newArrivalType)
 			if (ship.wingnum != _currentWingIndex)
 				continue;
 
-			ship.warpin_params_index = -1;
+			ship.warpin_params_index = Ship_info[ship.ship_info_index].warpin_params_index;
 		}
 	} else {
 		modify(w->arrival_path_mask, 0);
@@ -1104,7 +1105,8 @@ void WingEditorDialogModel::setDepartureType(DepartureLocation newDepartureType)
 	auto* w = getCurrentWing();
 	modify(w->departure_location, newDepartureType);
 
-	// If the new departure type is a dock bay,clear warp out parameters
+	// If the new departure type is a dock bay, reset warp-out params to ship class defaults
+	// (dock bay departures don't use warp effects; -1 would crash the save code)
 	// else, clear departure paths
 	if (newDepartureType == DepartureLocation::TO_DOCK_BAY) {
 		for (auto& ship : Ships) {
@@ -1113,7 +1115,7 @@ void WingEditorDialogModel::setDepartureType(DepartureLocation newDepartureType)
 			if (ship.wingnum != _currentWingIndex)
 				continue;
 
-			ship.warpout_params_index = -1;
+			ship.warpout_params_index = Ship_info[ship.ship_info_index].warpout_params_index;
 		}
 	} else {
 		modify(w->departure_path_mask, 0);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -2252,6 +2252,7 @@ void FredView::onPropClassSelected(int prop_class) {
 void FredView::on_actionAsteroid_Field_triggered(bool) {
 	auto asteroidFieldEditor = new dialogs::AsteroidEditorDialog(this, _viewport);
 	asteroidFieldEditor->setAttribute(Qt::WA_DeleteOnClose);
+	connect(asteroidFieldEditor, &QDialog::finished, this, [this]() { fred->updateAllViewports(); });
 	asteroidFieldEditor->show();
 }
 void FredView::on_actionVolumetric_Nebula_triggered(bool)

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.cpp
@@ -919,7 +919,7 @@ void BackgroundEditorDialog::on_noCullCheckBox_toggled(bool checked)
 	_model->setSkyboxNoCull(checked);
 }
 
-void BackgroundEditorDialog::on_noGlowmapsCheckBox_toggled(bool checked)
+void BackgroundEditorDialog::on_noGlowMapsCheckBox_toggled(bool checked)
 {
 	_model->setSkyboxNoGlowmaps(checked);
 }

--- a/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
+++ b/qtfred/src/ui/dialogs/BackgroundEditorDialog.h
@@ -92,7 +92,7 @@ private slots:
 	void on_forceClampCheckBox_toggled(bool checked);
 	void on_noZBufferCheckBox_toggled(bool checked);
 	void on_noCullCheckBox_toggled(bool checked);
-	void on_noGlowmapsCheckBox_toggled(bool checked);
+	void on_noGlowMapsCheckBox_toggled(bool checked);
 
 	// Misc
 	void on_numStarsSlider_valueChanged(int value);

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -145,7 +145,7 @@ void MissionSpecDialog::updateFlags()
 	toWidget.reserve(static_cast<int>(flags.size()));
 	for (const auto& p : flags) {
 		QString name = QString::fromUtf8(p.first.c_str());
-		toWidget.append({name, p.second});
+		toWidget.append({name, p.second ? Qt::Checked : Qt::Unchecked});
 	}
 
 	ui->flagList->setFlags(toWidget);

--- a/qtfred/src/ui/dialogs/WingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.cpp
@@ -365,7 +365,7 @@ void WingEditorDialog::on_wingLeaderCombo_currentIndexChanged(int index)
 	_model->setWingLeaderIndex(index);
 }
 
-void WingEditorDialog::on_numberOfWavesSpinBox_valueChanged(int value)
+void WingEditorDialog::on_numWavesSpinBox_valueChanged(int value)
 {
 	_model->setNumberOfWaves(value);
 	ui->waveThresholdSpinBox->setMaximum(_model->getMaxWaveThreshold());

--- a/qtfred/src/ui/dialogs/WingEditorDialog.h
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.h
@@ -24,7 +24,7 @@ class WingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 		// Top section, first column
 		void on_wingNameEdit_editingFinished();
 		void on_wingLeaderCombo_currentIndexChanged(int index);
-		void on_numberOfWavesSpinBox_valueChanged(int value);
+		void on_numWavesSpinBox_valueChanged(int value);
 		void on_waveThresholdSpinBox_valueChanged(int value);
 		void on_hotkeyCombo_currentIndexChanged(int /*index*/);
 

--- a/qtfred/src/ui/dialogs/WingFlagsDialog.cpp
+++ b/qtfred/src/ui/dialogs/WingFlagsDialog.cpp
@@ -8,13 +8,13 @@ namespace fso::fred::dialogs {
 
 WingFlagsDialog::WingFlagsDialog(QWidget* parent, const std::vector<std::pair<SCP_string, bool>>& flags,
                                  const std::vector<std::pair<SCP_string, SCP_string>>& descriptions)
-	: QDialog(parent), ui(new Ui::WingFlagsDialog()), _flags(flags)
+	: QDialog(parent), ui(new Ui::WingFlagsDialog())
 {
 	ui->setupUi(this);
 
 	QVector<std::pair<QString, int>> qtFlags;
-	qtFlags.reserve(static_cast<int>(_flags.size()));
-	for (const auto& f : _flags)
+	qtFlags.reserve(static_cast<int>(flags.size()));
+	for (const auto& f : flags)
 		qtFlags.append({QString::fromUtf8(f.first.c_str()), f.second ? Qt::Checked : Qt::Unchecked});
 	ui->flagList->setFlags(qtFlags);
 
@@ -26,15 +26,6 @@ WingFlagsDialog::WingFlagsDialog(QWidget* parent, const std::vector<std::pair<SC
 		ui->flagList->setFlagDescriptions(qtDescs);
 	}
 
-	connect(ui->flagList, &fso::fred::FlagListWidget::flagToggled, this, [this](const QString& name, int checked) {
-		for (auto& flag : _flags) {
-			if (flag.first == name.toUtf8().constData()) {
-				flag.second = (checked == Qt::Checked);
-				break;
-			}
-		}
-	});
-
 	resize(QDialog::sizeHint());
 }
 
@@ -42,7 +33,10 @@ WingFlagsDialog::~WingFlagsDialog() = default;
 
 std::vector<std::pair<SCP_string, bool>> WingFlagsDialog::getFlags() const
 {
-	return _flags;
+	std::vector<std::pair<SCP_string, bool>> result;
+	for (const auto& f : ui->flagList->getFlags())
+		result.emplace_back(f.first.toUtf8().constData(), f.second == Qt::Checked);
+	return result;
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/WingFlagsDialog.h
+++ b/qtfred/src/ui/dialogs/WingFlagsDialog.h
@@ -24,7 +24,6 @@ class WingFlagsDialog : public QDialog {
 
   private:
 	std::unique_ptr<Ui::WingFlagsDialog> ui;
-	std::vector<std::pair<SCP_string, bool>> _flags;
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/widgets/FlagList.cpp
+++ b/qtfred/src/ui/widgets/FlagList.cpp
@@ -212,11 +212,14 @@ void FlagListWidget::onSelectAll()
 {
 	_updating = true;
 	for (int r = 0; r < _model->rowCount(); ++r) {
-		if (auto* it = _model->item(r, 0)) {
+		if (auto* it = _model->item(r, 0))
 			it->setCheckState(Qt::Checked);
-		}
 	}
 	_updating = false;
+	for (int r = 0; r < _model->rowCount(); ++r) {
+		if (auto* it = _model->item(r, 0))
+			Q_EMIT flagToggled(it->data(KeyRole).toString(), Qt::Checked);
+	}
 	Q_EMIT flagsChanged(snapshot());
 }
 
@@ -224,11 +227,14 @@ void FlagListWidget::onClearAll()
 {
 	_updating = true;
 	for (int r = 0; r < _model->rowCount(); ++r) {
-		if (auto* it = _model->item(r, 0)) {
+		if (auto* it = _model->item(r, 0))
 			it->setCheckState(Qt::Unchecked);
-		}
 	}
 	_updating = false;
+	for (int r = 0; r < _model->rowCount(); ++r) {
+		if (auto* it = _model->item(r, 0))
+			Q_EMIT flagToggled(it->data(KeyRole).toString(), Qt::Unchecked);
+	}
 	Q_EMIT flagsChanged(snapshot());
 }
 

--- a/qtfred/ui/VariableDialog.ui
+++ b/qtfred/ui/VariableDialog.ui
@@ -32,7 +32,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">


### PR DESCRIPTION
Does a handful of little fixes to various dialogs

- Fix number of waves spin box not saving
- Fix wing flags all/none buttons not working
- Fix crash when setting wing arrival/departure to docking bay
- Fix ship bay paths dialog showing incorrect names
- Fix stars not rendering in the background
- Fix ship team colors not saving/loading and enable team colors in the viewport
- Force asteroid field editor to trigger a viewport refresh when closed
- Fix visual bug with variables tabs not being in sync with the actual tab shown
- Fix flag list in mission specs showing partially checked state and the all/none buttons not working
- Fix typo for skybox No Glowmaps checkbox that caused it not to save
- Force skyboxes to immediately load when the model name field edit completes