### PR TITLE
Gate correct insignias behind flag / version

### DIFF
--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -1005,6 +1005,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Disable_all_noncustom_generic_debris);
 			}
 
+			if (optional_string("$Render insignias as decals:")) {
+				stuff_boolean(&Render_insignias_as_decals);
+			}
+
 			optional_string("#NETWORK SETTINGS");
 
 			if (optional_string("$FS2NetD port:")) {
@@ -1643,10 +1647,6 @@ void parse_mod_table(const char *filename)
 
 			if (optional_string("$Zero-radius explosions skip fireballs:")) {
 				stuff_boolean(&Zero_radius_explosions_skip_fireballs);
-			}
-
-			if (optional_string("$Render insignias as decals:")) {
-				stuff_boolean(&Render_insignias_as_decals);
 			}
 
 			// end of options ----------------------------------------

--- a/code/mod_table/mod_table.cpp
+++ b/code/mod_table/mod_table.cpp
@@ -183,6 +183,7 @@ bool Disable_expensive_turret_target_check;
 float Shield_percent_skips_damage;
 float Min_radius_for_persistent_debris;
 bool Zero_radius_explosions_skip_fireballs;
+bool Render_insignias_as_decals;
 
 
 #ifdef WITH_DISCORD
@@ -1644,6 +1645,10 @@ void parse_mod_table(const char *filename)
 				stuff_boolean(&Zero_radius_explosions_skip_fireballs);
 			}
 
+			if (optional_string("$Render insignias as decals:")) {
+				stuff_boolean(&Render_insignias_as_decals);
+			}
+
 			// end of options ----------------------------------------
 
 			// if we've been through once already and are at the same place, force a move
@@ -1891,6 +1896,7 @@ void mod_table_reset()
 	Shield_percent_skips_damage = 0.1f;
 	Min_radius_for_persistent_debris = 50.0f;
 	Zero_radius_explosions_skip_fireballs = false;
+	Render_insignias_as_decals = false;
 }
 
 void mod_table_set_version_flags()
@@ -1921,5 +1927,6 @@ void mod_table_set_version_flags()
 	}
 	if (mod_supports_version(26, 0, 0)) {
 		Zero_radius_explosions_skip_fireballs = true;
+		Render_insignias_as_decals = true;
 	}
 }

--- a/code/mod_table/mod_table.h
+++ b/code/mod_table/mod_table.h
@@ -205,6 +205,7 @@ extern bool Disable_expensive_turret_target_check;
 extern float Shield_percent_skips_damage;
 extern float Min_radius_for_persistent_debris;
 extern bool Zero_radius_explosions_skip_fireballs;
+extern bool Render_insignias_as_decals;
 
 void mod_table_init();
 void mod_table_post_process();

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -735,6 +735,11 @@ typedef struct insignia {
 	vec3d vecs[MAX_INS_VECS];								// vertex list	
 	vec3d offset;	// global position offset for this insignia
 	vec3d norm[MAX_INS_VECS]	;					//normal of the insignia-Bobboau
+
+	// Computed fields for decal rendering
+	vec3d position;
+	matrix orientation;
+	float diameter;
 } insignia;
 
 #define PM_FLAG_ALLOW_TILING			(1<<0)					// Allow texture tiling

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -2742,6 +2742,11 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 					// read in world offset
 					cfread_vector(&pm->ins[idx].offset, fp);
 
+					vec3d min = {{{FLT_MAX, FLT_MAX, FLT_MAX}}};
+					vec3d max = {{{-FLT_MAX, -FLT_MAX, -FLT_MAX}}};
+					vec3d avg_total = ZERO_VECTOR;
+					vec3d avg_normal = ZERO_VECTOR;
+
 					// read in all the faces
 					for(idx2=0; idx2<pm->ins[idx].num_faces; idx2++){
 						// read in 3 vertices
@@ -2753,18 +2758,37 @@ modelread_status read_model_file_no_subsys(polymodel * pm, const char* filename,
 						vec3d tempv;
 
 						//get three points (rotated) and compute normal
+						const vec3d& v1 = pm->ins[idx].vecs[pm->ins[idx].faces[idx2][0]];
+						const vec3d& v2 = pm->ins[idx].vecs[pm->ins[idx].faces[idx2][1]];
+						const vec3d& v3 = pm->ins[idx].vecs[pm->ins[idx].faces[idx2][2]];
 
 						vm_vec_perp(&tempv,
-							&pm->ins[idx].vecs[pm->ins[idx].faces[idx2][0]],
-							&pm->ins[idx].vecs[pm->ins[idx].faces[idx2][1]],
-							&pm->ins[idx].vecs[pm->ins[idx].faces[idx2][2]]);
+							&v1,
+							&v2,
+							&v3);
 
 						vm_vec_normalize_safe(&tempv);
 
 						pm->ins[idx].norm[idx2] = tempv;
-//						mprintf(("insignorm %.2f %.2f %.2f\n",pm->ins[idx].norm[idx2].xyz.x, pm->ins[idx].norm[idx2].xyz.y, pm->ins[idx].norm[idx2].xyz.z));
+	//					mprintf(("insignorm %.2f %.2f %.2f\n",pm->ins[idx].norm[idx2].xyz.x, pm->ins[idx].norm[idx2].xyz.y, pm->ins[idx].norm[idx2].xyz.z));
 
+
+						vm_vec_min(&min, &min, &v1);
+						vm_vec_min(&min, &min, &v2);
+						vm_vec_min(&min, &min, &v3);
+						vm_vec_max(&max, &max, &v1);
+						vm_vec_max(&max, &max, &v2);
+						vm_vec_max(&max, &max, &v3);
+
+						vec3d avg = (v1 + v2 + v3) * (1.0f / 3.0f);
+						avg_total += avg;
+						avg_normal += tempv;
 					}
+
+					pm->ins[idx].position = avg_total / static_cast<float>(num_faces) + pm->ins[idx].offset;
+					vec3d bb = max - min;
+					pm->ins[idx].diameter = std::max({bb.xyz.x, bb.xyz.y, bb.xyz.z});
+					vm_vector_2_matrix(&pm->ins[idx].orientation, &avg_normal, &vmd_z_vector);
 				}
 				break;
 

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -11,7 +11,10 @@
 
 #include "asteroid/asteroid.h"
 #include "cmdline/cmdline.h"
+#include "decals/decals.h"
 #include "gamesequence/gamesequence.h"
+#include "globalincs/systemvars.h"
+#include "math/floating.h"
 #include "graphics/light.h"
 #include "graphics/matrix.h"
 #include "graphics/shadows.h"
@@ -2984,7 +2987,30 @@ void model_render_queue(const model_render_params* interp, model_draw_list* scen
 
 	// MARKED!
 	if ( !( model_flags & MR_NO_TEXTURING ) && !( model_flags & MR_NO_INSIGNIA) ) {
-		scene->add_insignia(interp, pm, detail_level, interp->get_insignia_bitmap());
+		int bitmap_num = interp->get_insignia_bitmap();
+		if ( Render_insignias_as_decals && objnum >= 0 && (pm->num_ins > 0) && (bitmap_num >= 0) ) {
+			for (int ins_idx = 0; ins_idx < pm->num_ins; ins_idx++) {
+				const insignia& ins = pm->ins[ins_idx];
+				// skip insignias not on our detail level
+				if (ins.detail_level != detail_level) {
+					continue;
+				}
+
+				decals::Decal decal;
+				decal.object = &Objects[objnum];
+				decal.position = ins.position;
+				decal.submodel = -1;
+				decal.scale = vec3d{{{ins.diameter, ins.diameter, ins.diameter}}};
+				decal.orig_obj_type = OBJ_SHIP;
+				decal.creation_time = f2fl(Missiontime);
+				decal.lifetime = 1.0f;
+				decal.orientation = ins.orientation;
+				decal.definition_handle = std::make_tuple(bitmap_num, -1, -1);
+				decals::addSingleFrameDecal(std::move(decal));
+			}
+		} else {
+			scene->add_insignia(interp, pm, detail_level, bitmap_num);
+		}
 	}
 
 	if ( (model_flags & MR_AUTOCENTER) && (set_autocen) ) {


### PR DESCRIPTION
Closes #5674 and closes #1309.
Effectively reverts #7196, which means it restores #6849.
Except it's gated behind a flag / 26.0 now.