### PR TITLE
fix coerce_to_utf8

### DIFF
--- a/code/parse/parselo.cpp
+++ b/code/parse/parselo.cpp
@@ -2568,6 +2568,7 @@ void coerce_to_utf8(SCP_string &buffer, const char *str)
 	if (isLatin1)
 	{
 		unicode::convert_encoding(buffer, str, unicode::Encoding::Encoding_iso8859_1, unicode::Encoding::Encoding_utf8);
+		return;
 	}
 
 	// unknown encoding, so just truncate


### PR DESCRIPTION
Fix a bug that Claude caught: conversion from Latin-1 would fall through, truncate, and emit a spurious warning.