### PR TITLE
Make showing 2D radar icons a toggle-able option

### DIFF
--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1917 // This is the next available ID
+// #define XSTR_SIZE	1918 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/code/localization/localize.cpp
+++ b/code/localization/localize.cpp
@@ -64,7 +64,7 @@ bool *Lcl_unexpected_tstring_check = nullptr;
 // NOTE: with map storage of XSTR strings, the indexes no longer need to be contiguous,
 // but internal strings should still increment XSTR_SIZE to avoid collisions.
 // retail XSTR_SIZE = 1570
-// #define XSTR_SIZE	1915 // This is the next available ID
+// #define XSTR_SIZE	1917 // This is the next available ID
 
 // struct to allow for strings.tbl-determined x offset
 // offset is 0 for english, by default

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -161,7 +161,7 @@ void HudGaugeRadarStd::drawBlips(int blip_type, int bright, int distort)
 		}
 		else
 		{
-			if (b->radar_image_2d == -1 && b->radar_color_image_2d == -1)
+			if (!Radar_show_2d_icons || (b->radar_image_2d == -1 && b->radar_color_image_2d == -1))
 				drawContactCircle(x, y, b->rad);
 			else
 				drawContactImage(x, y, b->rad, b->radar_image_2d, b->radar_color_image_2d, b->radar_image_size);

--- a/code/radar/radar.cpp
+++ b/code/radar/radar.cpp
@@ -161,7 +161,9 @@ void HudGaugeRadarStd::drawBlips(int blip_type, int bright, int distort)
 		}
 		else
 		{
-			if (!Radar_show_2d_icons || (b->radar_image_2d == -1 && b->radar_color_image_2d == -1))
+			bool show_icon = (Radar_2d_icon_mode == RadarIconMode::On ||
+			                  (Radar_2d_icon_mode == RadarIconMode::TargetOnly && (b->flags & BLIP_CURRENT_TARGET)));
+			if (!show_icon || (b->radar_image_2d == -1 && b->radar_color_image_2d == -1))
 				drawContactCircle(x, y, b->rad);
 			else
 				drawContactImage(x, y, b->rad, b->radar_image_2d, b->radar_color_image_2d, b->radar_image_size);

--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -319,7 +319,7 @@ void HudGaugeRadarDradis::drawBlips(int blip_type, int bright, int distort)
 		} else {
 			if (b->flags & BLIP_DRAW_DISTORTED) {
 				blipDrawFlicker(b, &pos, alpha);
-			} else if (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0) {
+			} else if (Radar_show_2d_icons && (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0)) {
 				drawContact(&pos, b->radar_image_2d, b->radar_color_image_2d, b->dist, alpha, scale_factor);
 			} else {
 				drawContact(&pos, -1, unknown_contact_icon, b->dist, alpha, scale_factor);

--- a/code/radar/radardradis.cpp
+++ b/code/radar/radardradis.cpp
@@ -319,10 +319,14 @@ void HudGaugeRadarDradis::drawBlips(int blip_type, int bright, int distort)
 		} else {
 			if (b->flags & BLIP_DRAW_DISTORTED) {
 				blipDrawFlicker(b, &pos, alpha);
-			} else if (Radar_show_2d_icons && (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0)) {
-				drawContact(&pos, b->radar_image_2d, b->radar_color_image_2d, b->dist, alpha, scale_factor);
 			} else {
-				drawContact(&pos, -1, unknown_contact_icon, b->dist, alpha, scale_factor);
+				bool show_icon = (Radar_2d_icon_mode == RadarIconMode::On ||
+				                  (Radar_2d_icon_mode == RadarIconMode::TargetOnly && (b->flags & BLIP_CURRENT_TARGET)));
+				if (show_icon && (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0)) {
+					drawContact(&pos, b->radar_image_2d, b->radar_color_image_2d, b->dist, alpha, scale_factor);
+				} else {
+					drawContact(&pos, -1, unknown_contact_icon, b->dist, alpha, scale_factor);
+				}
 			}
 		}
 	}

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -281,7 +281,7 @@ void HudGaugeRadarOrb::drawBlips(int blip_type, int bright, int distort)
 		}
 		else
 		{
-            if (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0)
+			if (Radar_show_2d_icons && (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0))
 			{
 				drawContactImage(&pos, b->rad, b->radar_image_2d, b->radar_color_image_2d, b->radar_projection_size);
 			}

--- a/code/radar/radarorb.cpp
+++ b/code/radar/radarorb.cpp
@@ -281,7 +281,9 @@ void HudGaugeRadarOrb::drawBlips(int blip_type, int bright, int distort)
 		}
 		else
 		{
-			if (Radar_show_2d_icons && (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0))
+			bool show_icon = (Radar_2d_icon_mode == RadarIconMode::On ||
+			                  (Radar_2d_icon_mode == RadarIconMode::TargetOnly && (b->flags & BLIP_CURRENT_TARGET)));
+			if (show_icon && (b->radar_image_2d >= 0 || b->radar_color_image_2d >= 0))
 			{
 				drawContactImage(&pos, b->rad, b->radar_image_2d, b->radar_color_image_2d, b->radar_projection_size);
 			}

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -89,14 +89,17 @@ int See_all = 0;
 
 DCF_BOOL(see_all, See_all);
 
-bool Radar_show_2d_icons = true;
+RadarIconMode Radar_2d_icon_mode = RadarIconMode::On;
 
-static auto RadarShow2dIconsOption __UNUSED = options::OptionBuilder<bool>("HUD.Radar2dIcons",
-	std::pair<const char*, int>{"Show Radar 2D Icons", 1915},
-	std::pair<const char*, int>{"Enables or disables the display of custom 2D ship icons on the radar", 1916})
+static auto RadarIconModeOption __UNUSED = options::OptionBuilder<RadarIconMode>("HUD.Radar2dIconMode",
+	std::pair<const char*, int>{"Radar 2D Icons", 1915},
+	std::pair<const char*, int>{"Controls how custom 2D ship icons are displayed on the radar", 1916})
 	.category(std::make_pair("Game", 1824))
-	.default_val(true)
-	.bind_to(&Radar_show_2d_icons)
+	.values({{RadarIconMode::Off,        {"Off", 1286}},
+	         {RadarIconMode::On,         {"On", 1285}},
+	         {RadarIconMode::TargetOnly, {"Target Only", 1917}}})
+	.default_val(RadarIconMode::On)
+	.bind_to(&Radar_2d_icon_mode)
 	.importance(56)
 	.finish();
 
@@ -107,7 +110,7 @@ void radar_check_2d_icon_options()
 	});
 
 	if (!has_icons) {
-		options::OptionsManager::instance()->removeOption(RadarShow2dIconsOption);
+		options::OptionsManager::instance()->removeOption(RadarIconModeOption);
 	}
 }
 

--- a/code/radar/radarsetup.cpp
+++ b/code/radar/radarsetup.cpp
@@ -21,6 +21,7 @@
 #include "localization/localize.h"
 #include "network/multi.h"
 #include "object/object.h"
+#include "options/Option.h"
 #include "playerman/player.h"
 #include "radar/radar.h"
 #include "radar/radarorb.h"
@@ -87,6 +88,28 @@ extern int radar_iff_color[5][2][4];
 int See_all = 0;
 
 DCF_BOOL(see_all, See_all);
+
+bool Radar_show_2d_icons = true;
+
+static auto RadarShow2dIconsOption __UNUSED = options::OptionBuilder<bool>("HUD.Radar2dIcons",
+	std::pair<const char*, int>{"Show Radar 2D Icons", 1915},
+	std::pair<const char*, int>{"Enables or disables the display of custom 2D ship icons on the radar", 1916})
+	.category(std::make_pair("Game", 1824))
+	.default_val(true)
+	.bind_to(&Radar_show_2d_icons)
+	.importance(56)
+	.finish();
+
+void radar_check_2d_icon_options()
+{
+	bool has_icons = std::any_of(Ship_info.begin(), Ship_info.end(), [](const ship_info& sip) {
+		return sip.radar_image_2d_idx >= 0 || sip.radar_color_image_2d_idx >= 0;
+	});
+
+	if (!has_icons) {
+		options::OptionsManager::instance()->removeOption(RadarShow2dIconsOption);
+	}
+}
 
 void radar_stuff_blip_info(object *objp, int is_bright, color **blip_color, int *blip_type)
 {

--- a/code/radar/radarsetup.h
+++ b/code/radar/radarsetup.h
@@ -89,10 +89,13 @@ enum RadarVisibility
 	DISTORTED //!< Visible but not fully
 };
 
+extern bool Radar_show_2d_icons;
+
 void radar_frame_init();
 void radar_mission_init();
 void radar_plot_object( object *objp );
 RadarVisibility radar_is_visible( object *objp );
+void radar_check_2d_icon_options();
 
 extern sound_handle Radar_static_looping;
 

--- a/code/radar/radarsetup.h
+++ b/code/radar/radarsetup.h
@@ -89,7 +89,12 @@ enum RadarVisibility
 	DISTORTED //!< Visible but not fully
 };
 
-extern bool Radar_show_2d_icons;
+enum class RadarIconMode {
+	Off = 0,
+	On = 1,
+	TargetOnly = 2
+};
+extern RadarIconMode Radar_2d_icon_mode;
 
 void radar_frame_init();
 void radar_mission_init();

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6752,6 +6752,8 @@ void ship_init()
 
 		// We shouldn't already have any subsystem pointers at this point.
 		Assertion(Ship_subsystems.empty(), "Some pre-allocated subsystems didn't get cleared out: " SIZE_T_ARG " batches present during ship_init(); get a coder!\n", Ship_subsystems.size());
+	
+		radar_check_2d_icon_options();
 	}
 }
 


### PR DESCRIPTION
As requested by Admiral Nelson, this makes the 2D radar icons an option in Options Builder. If no 2D icons are tabled then the option is automatically hidden. Tested and even works toggling it mid-mission. The best kind of option.