### PR TITLE
small followup to 7327

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -196,7 +196,7 @@ void model_free(polymodel* pm)
 
 			if (pm->submodel[i].collision_tree_index >= 0) {
 				model_remove_bsp_collision_tree(pm->submodel[i].collision_tree_index);
-				pm->submodel[i].collision_tree_index = 0;
+				pm->submodel[i].collision_tree_index = -1;
 			}
 		}
 	}


### PR DESCRIPTION
Submodel `collision_tree_index` should be reset to -1 when removed, not 0.

Follow-up to #7327 