### PR TITLE
fix asteroid field undefined behavior

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -648,24 +648,30 @@ void asteroid_create_all()
 	int max_asteroids = Asteroid_field.num_initial_asteroids; // * (1.0f - 0.1f*(MAX_DETAIL_VALUE-Detail.asteroid_density)));
 
 	int num_debris_types = 0;
+	int num_valid = 0;	// count of valid (non-(-1)) entries written into shipDebrisOddsTable
 
 	// get number of debris types
 	if (Asteroid_field.debris_genre == DG_DEBRIS) {
 		num_debris_types = static_cast<int>(Asteroid_field.field_debris_type.size());
 
-		// Calculate the odds table
+		// Calculate the odds table; skip invalid entries (field_debris_type[idx] == -1 means
+		// missionparse invalidated the entry because the type no longer exists in Asteroid_info)
 		for (idx=0; idx<num_debris_types; idx++) {
+			if (Asteroid_field.field_debris_type[idx] == -1)
+				continue;
 			float debris_weight = Asteroid_info[Asteroid_field.field_debris_type[idx]].spawn_weight;
-			shipDebrisOddsTable[idx].random_threshold = max_weighted_range + debris_weight;
-			shipDebrisOddsTable[idx].debris_type = Asteroid_field.field_debris_type[idx];
+			shipDebrisOddsTable[num_valid].random_threshold = max_weighted_range + debris_weight;
+			shipDebrisOddsTable[num_valid].debris_type = Asteroid_field.field_debris_type[idx];
 			max_weighted_range += debris_weight;
+			num_valid++;
 		}
 	}
 
 	// Load Asteroid/debris models
 	if (Asteroid_field.debris_genre == DG_DEBRIS) {
 		for (idx=0; idx<num_debris_types; idx++) {
-			asteroid_load(Asteroid_field.field_debris_type[idx], 0);
+			if (Asteroid_field.field_debris_type[idx] != -1)
+				asteroid_load(Asteroid_field.field_debris_type[idx], 0);
 		}
 	} else {
 		for (const auto& subtype : Asteroid_field.field_asteroid_type) {
@@ -690,7 +696,7 @@ void asteroid_create_all()
 
 			float rand_choice = frand() * max_weighted_range;
 
-			for (idx = 0; idx < static_cast<int>(Asteroid_field.field_debris_type.size()); idx++) {
+			for (idx = 0; idx < num_valid; idx++) {
 				// for ship debris, choose type according to odds table
 				if (rand_choice < shipDebrisOddsTable[idx].random_threshold) {
 					asteroid_create(&Asteroid_field, shipDebrisOddsTable[idx].debris_type, 0);
@@ -2641,6 +2647,11 @@ static void verify_asteroid_list()
 		if (found)
 			continue;
 
+		if (asteroid_list.empty()) {
+			mprintf(("%s asteroid not found and no fallback available in asteroid_list.\n", asteroid_size[i].c_str()));
+			continue;
+		}
+
 		//Left this as a log print instead of a Warning because of retail-Mjn
 		mprintf(("%s asteroid not found. Using asteroid %s\n", asteroid_size[i].c_str(), asteroid_list[0].name));
 		asteroid_list[0].type = i;
@@ -2695,8 +2706,10 @@ void asteroid_init()
 	parse_modular_table("*-ast.tbm", asteroid_parse_tbl);
 
 	//No asteroids defined. Bail!
-	if (asteroid_list.empty())
+	if (asteroid_list.empty()) {
+		mprintf(("No asteroids defined in asteroid.tbl or any modular tables. Asteroid fields will not function.\n"));
 		return;
+	}
 
 	// now verify the asteroids were found and put them in the correct order
 	verify_asteroid_list();

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -6392,7 +6392,11 @@ void parse_asteroid_fields(mission *pm)
 				if (optional_string("+Field Debris Type:")) {
 					int subtype;
 					stuff_int(&subtype);
-					Asteroid_field.field_asteroid_type.push_back(colors[subtype]);
+					if (subtype >= 0 && subtype < NUM_ASTEROID_SIZES) {
+						Asteroid_field.field_asteroid_type.push_back(colors[subtype]);
+					} else {
+						WarningEx(LOCATION, "Invalid +Field Debris Type value %d in asteroid field (must be 0-%d); ignoring.", subtype, NUM_ASTEROID_SIZES - 1);
+					}
 				}
 			}
 


### PR DESCRIPTION
Three out-of-bounds/UB fixes for issue #6793:

- asteroid_create_all: skip field_debris_type[idx] == -1 entries when building the DG_DEBRIS odds table and loading models; iterate only over valid table slots during spawn. Matches the guard already present in asteroid_frame.
- missionparse: bounds-check subtype before indexing colors[] in the obsolete +Field Debris Type: parsing path.
- verify_asteroid_list: guard the asteroid_list[0] fallback access against an empty list.
- asteroid_init: emit an mprintf when no asteroids are defined instead of returning silently.