### PR TITLE
Fix assert for flag list and player ships

### DIFF
--- a/qtfred/src/mission/dialogs/ShipEditor/ShipFlagsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipFlagsDialogModel.cpp
@@ -31,7 +31,15 @@ std::pair<SCP_string, int>* ShipFlagsDialogModel::getFlag(const SCP_string& flag
 			return &flag;
 		}
 	}
-	Assertion(false, "Illegal flag name \"[%s]\"", flag_name.c_str());
+	// Only assert if the name isn't a known flag at all; it may have been legitimately filtered out for ship starts
+	bool known = false;
+	for (size_t i = 0; i < Num_Parse_ship_flags && !known; ++i)
+		known = !stricmp(flag_name.c_str(), Parse_ship_flags[i].name);
+	for (size_t i = 0; i < Num_Parse_ship_ai_flags && !known; ++i)
+		known = !stricmp(flag_name.c_str(), Parse_ship_ai_flags[i].name);
+	for (size_t i = 0; i < Num_Parse_ship_object_flags && !known; ++i)
+		known = !stricmp(flag_name.c_str(), Parse_ship_object_flags[i].name);
+	Assertion(known, "Illegal flag name \"%s\"", flag_name.c_str());
 	return nullptr;
 }
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipFlagsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipFlagsDialog.cpp
@@ -96,16 +96,19 @@ void ShipFlagsDialog::updateUI()
 {
 	util::SignalBlockers blockers(this);
 	ui->destroySecondsSpinBox->setValue(_model->getDestroyTime());
-	ui->destroyedlabel->setVisible(_model->getFlag("Destroy before Mission")->second);
-	ui->destroySecondsSpinBox->setVisible(_model->getFlag("Destroy before Mission")->second);
-	ui->destroySecondsLabel->setVisible(_model->getFlag("Destroy before Mission")->second);
+	auto* destroyFlag = _model->getFlag("Destroy before Mission");
+	ui->destroyedlabel->setVisible(destroyFlag && destroyFlag->second);
+	ui->destroySecondsSpinBox->setVisible(destroyFlag && destroyFlag->second);
+	ui->destroySecondsLabel->setVisible(destroyFlag && destroyFlag->second);
 
+	auto* escortFlag = _model->getFlag("escort");
 	ui->escortPrioritySpinBox->setValue(_model->getEscortPriority());
-	ui->escortLabel->setVisible(_model->getFlag("escort")->second);
-	ui->escortPrioritySpinBox->setVisible(_model->getFlag("escort")->second);
+	ui->escortLabel->setVisible(escortFlag && escortFlag->second);
+	ui->escortPrioritySpinBox->setVisible(escortFlag && escortFlag->second);
 
+	auto* kamikazeFlag = _model->getFlag("kamikaze");
 	ui->kamikazeDamageSpinBox->setValue(_model->getKamikazeDamage());
-	ui->kamikazeLabel->setVisible(_model->getFlag("kamikaze")->second);
-	ui->kamikazeDamageSpinBox->setVisible(_model->getFlag("kamikaze")->second);
+	ui->kamikazeLabel->setVisible(kamikazeFlag && kamikazeFlag->second);
+	ui->kamikazeDamageSpinBox->setVisible(kamikazeFlag && kamikazeFlag->second);
 }
 } // namespace fso::fred::dialogs


### PR DESCRIPTION
In #7402 I set up the Ship Flag list to filter out some flags that aren't allowed or don't make sense for player ships. This included some flags that are checked on initialize for the flag dialog box. When the dialog box is opened for Player Ships this causes an assert because the flag isn't found.

So we make the assert a little smarter and we touch up the initialize code to only process flags that are valid for the current selection.

Fixes #7413 