### PR TITLE
QtFRED cleanup pass on dialog inits

### DIFF
--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -522,7 +522,7 @@ void Editor::unmark_all() {
 		numMarked = 0;
 		setupCurrentObjectIndices(-1);
 
-		missionChanged();
+		updateAllViewports();
 	}
 }
 void Editor::markObject(int obj) {
@@ -561,7 +561,7 @@ void Editor::unmarkObject(int obj) {
 			setupCurrentObjectIndices(-1);  // can't find one; nothing is marked.
 		}
 
-		missionChanged();
+		updateAllViewports();
 	}
 }
 
@@ -755,8 +755,6 @@ void Editor::selectObject(int objId) {
 	}
 
 	setupCurrentObjectIndices(objId);  // select the new object
-
-	missionChanged();
 }
 void Editor::updateAllViewports() {
 	// This takes all renderers and issues an update request for each of them. For now that is only one but this allows

--- a/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/AsteroidEditorDialogModel.cpp
@@ -95,7 +95,7 @@ void AsteroidEditorDialogModel::initializeData()
 			debrisOptions.emplace_back(std::make_pair(Asteroid_info[i].name, static_cast<int>(i)));
 		}
 	}
-
+	_modified = false;
 }
 
 void AsteroidEditorDialogModel::update_internal_field()

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.cpp
@@ -16,6 +16,11 @@ namespace fso::fred::dialogs {
 BackgroundEditorDialogModel::BackgroundEditorDialogModel(QObject* parent, EditorViewport* viewport)
 	: AbstractDialogModel(parent, viewport)
 {
+	initializeData();
+}
+
+void BackgroundEditorDialogModel::initializeData()
+{
 	auto& bg = getActiveBackground();
 	auto& bm_list = bg.bitmaps;
 	if (!bm_list.empty()) {
@@ -26,6 +31,7 @@ BackgroundEditorDialogModel::BackgroundEditorDialogModel(QObject* parent, Editor
 	if (!sun_list.empty()) {
 		_selectedSunIndex = 0;
 	}
+	_modified = false;
 }
 
 bool BackgroundEditorDialogModel::apply()

--- a/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/BackgroundEditorDialogModel.h
@@ -170,6 +170,7 @@ class BackgroundEditorDialogModel : public AbstractDialogModel {
 	void setLightingProfileName(const SCP_string& name);
 
   private:
+	void initializeData();
 	void refreshBackgroundPreview();
 	static background_t& getActiveBackground();
 	starfield_list_entry* getActiveBitmap() const;

--- a/qtfred/src/mission/dialogs/BriefingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/BriefingEditorDialogModel.cpp
@@ -126,6 +126,7 @@ void BriefingEditorDialogModel::initializeData()
 	_currentTeam = 0;
 	_currentStage = 0;
 	_currentIcon = -1;
+	_modified = false;
 }
 
 void BriefingEditorDialogModel::stopSpeech()

--- a/qtfred/src/mission/dialogs/CommandBriefingDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CommandBriefingDialogModel.cpp
@@ -39,6 +39,7 @@ void CommandBriefingDialogModel::initializeData()
 
 	_currentTeam = 0;  // default to the first team
 	_currentStage = 0; // default to the first stage
+	_modified = false;
 }
 
 void CommandBriefingDialogModel::gotoPreviousStage()

--- a/qtfred/src/mission/dialogs/DebriefingDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/DebriefingDialogModel.cpp
@@ -48,6 +48,7 @@ void DebriefingDialogModel::initializeData()
 
 	_currentTeam = 0;
 	_currentStage = 0;
+	_modified = false;
 }
 
 void DebriefingDialogModel::gotoPreviousStage()

--- a/qtfred/src/mission/dialogs/FictionViewerDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/FictionViewerDialogModel.cpp
@@ -19,7 +19,7 @@ bool FictionViewerDialogModel::apply() {
 		_fictionViewerStages.clear();
 		Mission_music[SCORE_FICTION_VIEWER] = -1;
 	} else {
-		// Keep whatever you’ve edited in _fictionViewerStages
+		// Keep whatever you've edited in _fictionViewerStages
 		Mission_music[SCORE_FICTION_VIEWER] = _fictionMusic; // -1 for none is valid
 	}
 
@@ -52,6 +52,7 @@ void FictionViewerDialogModel::initializeData() {
 
 	// music is managed through the mission
 	_fictionMusic = Mission_music[SCORE_FICTION_VIEWER];
+	_modified = false;
 }
 
 const SCP_vector<std::pair<SCP_string, int>>& FictionViewerDialogModel::getMusicOptions()

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
@@ -117,6 +117,7 @@ void JumpNodeEditorDialogModel::initializeData()
 	}
 
 	Q_EMIT jumpNodeMarkingChanged();
+	_modified = false;
 }
 
 void JumpNodeEditorDialogModel::buildNodeList()

--- a/qtfred/src/mission/dialogs/MissionCutscenesDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionCutscenesDialogModel.cpp
@@ -57,6 +57,7 @@ void MissionCutscenesDialogModel::initializeData()
 
 	cur_cutscene = -1;
 	modelChanged();
+	_modified = false;
 }
 SCP_vector<mission_cutscene>& MissionCutscenesDialogModel::getCutscenes()
 {

--- a/qtfred/src/mission/dialogs/MissionEventsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionEventsDialogModel.cpp
@@ -115,6 +115,7 @@ void MissionEventsDialogModel::initializeData()
 
 	initializeTeamList();
 	initializeEvents();
+	_modified = false;
 }
 
 void MissionEventsDialogModel::initializeEvents()

--- a/qtfred/src/mission/dialogs/MissionGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionGoalsDialogModel.cpp
@@ -85,6 +85,7 @@ void MissionGoalsDialogModel::initializeData() {
 
 	cur_goal = -1;
 	modelChanged();
+	_modified = false;
 }
 SCP_vector<mission_goal>& MissionGoalsDialogModel::getGoals() {
 	return m_goals;

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -91,6 +91,7 @@ void MissionSpecDialogModel::initializeData() {
 	}
 
 	modelChanged();
+	_modified = false;
 }
 
 void MissionSpecDialogModel::prepareSquadLogoList()

--- a/qtfred/src/mission/dialogs/ObjectOrientEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ObjectOrientEditorDialogModel.cpp
@@ -75,6 +75,7 @@ void ObjectOrientEditorDialogModel::initializeData()
 	}
 
 	modelChanged();
+	_modified = false;
 }
 
 void ObjectOrientEditorDialogModel::updateObject(object* ptr)

--- a/qtfred/src/mission/dialogs/PropEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/PropEditorDialogModel.cpp
@@ -106,6 +106,7 @@ void PropEditorDialogModel::initializeData() {
 	}
 
 	Q_EMIT modelDataChanged();
+	_modified = false;
 }
 
 bool PropEditorDialogModel::validateData() {

--- a/qtfred/src/mission/dialogs/ReinforcementsEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ReinforcementsEditorDialogModel.cpp
@@ -76,6 +76,7 @@ void ReinforcementsDialogModel::initializeData()
 
 	_selectedReinforcements.clear();
 	_selectedReinforcementIndices.clear();
+	_modified = false;
 }
 
 bool ReinforcementsDialogModel::apply() 

--- a/qtfred/src/mission/dialogs/ShieldSystemDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShieldSystemDialogModel.cpp
@@ -26,6 +26,7 @@ void ShieldSystemDialogModel::initializeData() {
 	for (const auto& iff : Iff_info) {
 		_teamOptions.emplace_back(iff.iff_name);
 	}
+	_modified = false;
 }
 
 bool ShieldSystemDialogModel::apply() {

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipAltShipClassModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipAltShipClassModel.cpp
@@ -115,6 +115,7 @@ void ShipAltShipClassModel::initializeData()
 		}
 		objp = GET_NEXT(objp);
 	}
+	_modified = false;
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipCustomWarpDialogModel.cpp
@@ -247,6 +247,7 @@ void ShipCustomWarpDialogModel::initializeData()
 			_m_player_warpout_speed = params->warpout_player_speed;
 		}
 	}
+	_modified = false;
 }
 
 void ShipCustomWarpDialogModel::setType(const int index)

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
@@ -534,6 +534,7 @@ void ShipEditorDialogModel::initializeData()
 	}
 
 	modelChanged();
+	_modified = false;
 }
 
 std::vector<std::pair<SCP_string, bool>> ShipEditorDialogModel::getArrivalPaths() const

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipFlagsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipFlagsDialogModel.cpp
@@ -361,5 +361,6 @@ void ShipFlagsDialogModel::initializeData()
 		objp = GET_NEXT(objp);
 	}
 	modelChanged();
+	_modified = false;
 }
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipGoalsDialogModel.cpp
@@ -471,6 +471,7 @@ namespace fso {
 					initialize_multi();
 				}
 				modelChanged();
+				_modified = false;
 			}
 			void ShipGoalsDialogModel::initialize(ai_goal* goals)
 			{

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipInitialStatusDialogModel.cpp
@@ -290,6 +290,7 @@ void ShipInitialStatusDialogModel::initializeData(bool multi)
 		m_velocity = BLANKFIELD;
 	}
 	modelChanged();
+	_modified = false;
 }
 
 void ShipInitialStatusDialogModel::update_docking_info()

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipSpecialStatsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipSpecialStatsDialogModel.cpp
@@ -96,6 +96,7 @@ namespace fso {
 					m_special_exp = true;
 				}
 				modelChanged();
+				_modified = false;
 			}
 
 			bool ShipSpecialStatsDialogModel::apply()

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipTextureReplacementDialogModel.cpp
@@ -184,6 +184,7 @@ namespace fso {
 					}
 				}
 				modelChanged();
+				_modified = false;
 			}
 			void ShipTextureReplacementDialogModel::initSubTypes(polymodel* model, int MapNum)
 			{

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipWeaponsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipWeaponsDialogModel.cpp
@@ -154,6 +154,7 @@ void ShipWeaponsDialogModel::initializeData(bool isMultiEdit)
 		initPrimary(m_ship, true);
 		initSecondary(m_ship, true);
 	}
+	_modified = false;
 }
 
 void ShipWeaponsDialogModel::initPrimary(int inst, bool first)

--- a/qtfred/src/mission/dialogs/TableViewerModel.cpp
+++ b/qtfred/src/mission/dialogs/TableViewerModel.cpp
@@ -36,6 +36,7 @@ void TableViewerModel::initializeData(const char* table_filename, const char* mo
 		_text = table_viewer::get_complete_table_text(table_filename, modular_pattern, msg.c_str());
 	}
 	modelChanged();
+	_modified = false;
 }
 
 SCP_string TableViewerModel::getText() const

--- a/qtfred/src/mission/dialogs/TeamLoadoutDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/TeamLoadoutDialogModel.cpp
@@ -327,6 +327,7 @@ void TeamLoadoutDialogModel::initializeData()
 			}
 		}
 	}
+	_modified = false;
 }
 
 void TeamLoadoutDialogModel::recalcShipCapacities(TeamLoadout& team)

--- a/qtfred/src/mission/dialogs/VariableDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/VariableDialogModel.cpp
@@ -167,6 +167,7 @@ void VariableDialogModel::initializeData()
 			}
 		}
 	}
+	_modified = false;
 }
 
 void VariableDialogModel::sortMap(int containerIndex)

--- a/qtfred/src/mission/dialogs/VoiceActingManagerModel.cpp
+++ b/qtfred/src/mission/dialogs/VoiceActingManagerModel.cpp
@@ -100,6 +100,7 @@ void VoiceActingManagerModel::initializeData()
 	_suffix = Suffix::WAV;
 	_includeSenderInFilename = false;
 	_whichPersonaToSync = 0;
+	_modified = false;
 }
 
 SCP_vector<SCP_string> VoiceActingManagerModel::personaChoices()

--- a/qtfred/src/mission/dialogs/VolumetricNebulaDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/VolumetricNebulaDialogModel.cpp
@@ -40,6 +40,7 @@ void VolumetricNebulaDialogModel::initializeData()
 		makeVolumetricsCopy(_volumetrics, volumetric_nebula{});
 		_volumetrics.enabled = false;
 	}
+	_modified = false;
 }
 
 bool VolumetricNebulaDialogModel::validate_data()

--- a/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
@@ -84,6 +84,7 @@ void WaypointEditorDialogModel::initializeData()
 	}
 
 	Q_EMIT waypointPathMarkingChanged();
+	_modified = false;
 }
 
 void WaypointEditorDialogModel::updateWaypointPathList()

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
@@ -12,11 +12,16 @@ namespace fso::fred::dialogs {
 WingEditorDialogModel::WingEditorDialogModel(QObject* parent, EditorViewport* viewport)
 	: AbstractDialogModel(parent, viewport)
 {
-	reloadFromCurWing();
-	prepareSquadLogoList();
-
+	initializeData();
 	connect(_editor, &Editor::currentObjectChanged, this, &WingEditorDialogModel::onEditorSelectionChanged);
 	connect(_editor, &Editor::missionChanged, this, &WingEditorDialogModel::onEditorMissionChanged);
+}
+
+void WingEditorDialogModel::initializeData()
+{
+	reloadFromCurWing();
+	prepareSquadLogoList();
+	_modified = false;
 }
 
 void WingEditorDialogModel::onEditorSelectionChanged(int)
@@ -39,15 +44,15 @@ void WingEditorDialogModel::reloadFromCurWing()
 	_currentWingIndex = w;
 
 	if (w < 0 || Wings[w].wave_count == 0) {
-		// No wing selected
-		modify(_currentWingIndex, -1);
-		modify(_currentWingName, SCP_string());
+		// No wing selected — track view state without dirtying the model
+		_currentWingIndex = -1;
+		_currentWingName = SCP_string();
+		Q_EMIT wingChanged();
 		return;
 	}
 
 	const auto& wing = Wings[w];
-	modify(_currentWingIndex, w);
-	modify(_currentWingName, SCP_string(wing.name));
+	_currentWingName = SCP_string(wing.name);
 
 	Q_EMIT wingChanged();
 }

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.h
@@ -133,6 +133,7 @@ class WingEditorDialogModel : public AbstractDialogModel {
 		void onEditorMissionChanged(); // missionChanged
 
 	private: // NOLINT(readability-redundant-access-specifiers)
+		void initializeData();
 		void reloadFromCurWing();
 		wing* getCurrentWing() const;
 		static std::vector<std::pair<SCP_string, bool>> getDockBayPathsForWingMask(uint32_t mask, int anchorShipnum);


### PR DESCRIPTION
Goes through the main editor and all dialogs to make sure `_modified` is not set to true after initializing data in the dialog. Mostly this is done with a defensive `_modified = false` at the end of each dialog's `initializeData()` call.

Fixes #7414 