### PR TITLE
QtFRED Jump Node Dialog Upgrade

### DIFF
--- a/qtfred/help-src/doc/dialogs/JumpNodeEditorDialog.html
+++ b/qtfred/help-src/doc/dialogs/JumpNodeEditorDialog.html
@@ -10,24 +10,40 @@
 <h1>Jump Node Editor</h1>
 <p>Opens via <strong>Editors &rsaquo; Jump Node Editor</strong>.</p>
 <p>Creates and configures subspace jump nodes. Jump nodes are fixed points in space that
-ships can use to enter or exit subspace. They appear on the HUD radar and can be targeted.
-Select a node from the drop-down to edit its properties.</p>
+ships can use to enter or exit subspace. They appear on the HUD radar and can be
+targeted.</p>
+
+<p>The dialog tracks the viewport selection. Select jump node objects in the viewport
+to edit their properties. When multiple nodes are selected, color, layer, and hidden
+state changes apply to all selected nodes at once.</p>
+
+<h2>Navigation</h2>
+<table>
+    <tr><th>Button</th><th>Description</th></tr>
+    <tr><td>Prev / Next</td><td>Cycles the viewport selection to the previous or next
+        jump node in the mission, allowing sequential editing without switching back
+        to the viewport.</td></tr>
+</table>
 
 <h2>Key fields</h2>
 <table>
     <tr><th>Field</th><th>Description</th></tr>
-    <tr><td>Jump node</td><td>Selects which placed node to edit.</td></tr>
     <tr><td>Name</td><td>Internal identifier used in SEXPs and mission scripting.
-        Must be unique.</td></tr>
-    <tr><td>Layer</td><td>The layer the jump node is assigned to.</td></tr>
+        Must be unique. When multiple nodes are selected, shows the name of the first
+        selected node and renames only that node.</td></tr>
+    <tr><td>Layer</td><td>The layer the jump node is assigned to. Applied to all
+        selected nodes.</td></tr>
     <tr><td>Display name</td><td>Name shown to the player on the HUD and in targeting.
-        If left blank, the internal name is used instead.</td></tr>
+        If left blank, the internal name is used instead. When multiple nodes are
+        selected, applies only to the first selected node.</td></tr>
     <tr><td>Model file</td><td>POF model rendered at the node's position. Uses the
-        default jump node model if left blank.</td></tr>
+        default jump node model if left blank. When multiple nodes are selected,
+        applies only to the first selected node.</td></tr>
     <tr><td>Node color (RGB)</td><td>Color used to render the node model in the
-        mission.</td></tr>
-    <tr><td>Hidden by default</td><td>When checked, the node starts the mission hidden
-</td></tr>
+        mission. The color swatch next to the fields shows a live preview of the
+        current color. Applied to all selected nodes.</td></tr>
+    <tr><td>Hidden by default</td><td>When checked, the node starts the mission hidden.
+        Applied to all selected nodes.</td></tr>
 </table>
 
 </body>

--- a/qtfred/help-src/doc/dialogs/JumpNodeEditorDialog.html
+++ b/qtfred/help-src/doc/dialogs/JumpNodeEditorDialog.html
@@ -14,8 +14,10 @@ ships can use to enter or exit subspace. They appear on the HUD radar and can be
 targeted.</p>
 
 <p>The dialog tracks the viewport selection. Select jump node objects in the viewport
-to edit their properties. When multiple nodes are selected, color, layer, and hidden
-state changes apply to all selected nodes at once.</p>
+to edit their properties. When multiple nodes are selected, all edits except the
+node name apply to every selected node at once. Color channels and the hidden state
+display a mixed indicator when the selected nodes disagree, and editing one of them
+clears that mixed state.</p>
 
 <h2>Navigation</h2>
 <table>
@@ -34,16 +36,17 @@ state changes apply to all selected nodes at once.</p>
     <tr><td>Layer</td><td>The layer the jump node is assigned to. Applied to all
         selected nodes.</td></tr>
     <tr><td>Display name</td><td>Name shown to the player on the HUD and in targeting.
-        If left blank, the internal name is used instead. When multiple nodes are
-        selected, applies only to the first selected node.</td></tr>
-    <tr><td>Model file</td><td>POF model rendered at the node's position. Uses the
-        default jump node model if left blank. When multiple nodes are selected,
-        applies only to the first selected node.</td></tr>
-    <tr><td>Node color (RGB)</td><td>Color used to render the node model in the
+        Set to <code>&lt;none&gt;</code> to fall back to the internal name. Applied to
+        all selected nodes; when nodes disagree the field shows blank until edited.</td></tr>
+    <tr><td>Model file</td><td>POF model rendered at the node's position. Applied to
+        all selected nodes; when nodes disagree the field shows blank until edited.</td></tr>
+    <tr><td>Node color (RGBA)</td><td>Color used to render the node model in the
         mission. The color swatch next to the fields shows a live preview of the
-        current color. Applied to all selected nodes.</td></tr>
+        current color. Applied to all selected nodes. Channels that differ across the
+        selection show blank until edited, and the swatch shows a "?" indicator.</td></tr>
     <tr><td>Hidden by default</td><td>When checked, the node starts the mission hidden.
-        Applied to all selected nodes.</td></tr>
+        Applied to all selected nodes. Displays as a partially-checked tri-state when
+        nodes disagree, until the box is clicked.</td></tr>
 </table>
 
 </body>

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
@@ -107,7 +107,7 @@ bool JumpNodeEditorDialogModel::hasMultipleSelection() const {
 	return _selectedJumpNodes.size() > 1;
 }
 
-bool JumpNodeEditorDialogModel::hasAnyNodesInMission() const {
+bool JumpNodeEditorDialogModel::hasAnyNodesInMission() {
 	return !Jump_nodes.empty();
 }
 

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
@@ -29,6 +29,8 @@ void JumpNodeEditorDialogModel::reject() {}
 void JumpNodeEditorDialogModel::initializeData()
 {
 	_selectedJumpNodes.clear();
+	_redMixed = _greenMixed = _blueMixed = _alphaMixed = false;
+	_hiddenMixed = false;
 
 	// Collect all marked OBJ_JUMP_NODE objects
 	for (auto* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
@@ -83,6 +85,14 @@ void JumpNodeEditorDialogModel::initializeData()
 					otherModel = JN_DEFAULT_MODEL;
 				if (_modelFilename != otherModel)
 					modelConsistent = false;
+
+				const auto& oc = other->GetColor();
+				if (oc.red   != _red)   _redMixed   = true;
+				if (oc.green != _green) _greenMixed = true;
+				if (oc.blue  != _blue)  _blueMixed  = true;
+				if (oc.alpha != _alpha) _alphaMixed = true;
+
+				if (other->IsHidden() != _hidden) _hiddenMixed = true;
 			}
 			if (!displayConsistent) _display.clear();
 			if (!modelConsistent)   _modelFilename.clear();
@@ -237,6 +247,8 @@ bool JumpNodeEditorDialogModel::setModelFilename(const SCP_string& v) {
 		return true;
 	}
 
+	_bypass_errors = false;
+
 	if (!lcase_equal(v, JN_DEFAULT_MODEL) && !cf_exists_full(v.c_str(), CF_TYPE_MODELS)) {
 		showErrorDialogNoCancel("This jump node model file does not exist.");
 		return false;
@@ -260,15 +272,31 @@ bool JumpNodeEditorDialogModel::setModelFilename(const SCP_string& v) {
 
 const SCP_string& JumpNodeEditorDialogModel::getModelFilename() const { return _modelFilename; }
 
+// Writes one color channel to every selected node. Channels still flagged as mixed
+// keep their per-node values; the channel being set is cleared of its mixed flag.
+static void applyChannelToAll(const SCP_vector<int>& selected,
+    int red, int green, int blue, int alpha,
+    bool redMixed, bool greenMixed, bool blueMixed, bool alphaMixed)
+{
+	for (auto objnum : selected) {
+		auto* jnp = jumpnode_get_by_objnum(objnum);
+		if (!jnp) continue;
+		const auto& c = jnp->GetColor();
+		int r = redMixed   ? c.red   : red;
+		int g = greenMixed ? c.green : green;
+		int b = blueMixed  ? c.blue  : blue;
+		int a = alphaMixed ? c.alpha : alpha;
+		jnp->SetAlphaColor(r, g, b, a);
+	}
+}
+
 void JumpNodeEditorDialogModel::setColorR(int v) {
+	if (v < 0) return; // mixed-state sentinel from the dialog — no-op
 	CLAMP(v, 0, 255);
 	_red = v;
-	for (auto objnum : _selectedJumpNodes) {
-		auto* jnp = jumpnode_get_by_objnum(objnum);
-		if (jnp) {
-			jnp->SetAlphaColor(_red, _green, _blue, _alpha);
-		}
-	}
+	_redMixed = false;
+	applyChannelToAll(_selectedJumpNodes, _red, _green, _blue, _alpha,
+	    _redMixed, _greenMixed, _blueMixed, _alphaMixed);
 	set_modified();
 	_editor->missionChanged();
 }
@@ -276,14 +304,12 @@ void JumpNodeEditorDialogModel::setColorR(int v) {
 int JumpNodeEditorDialogModel::getColorR() const { return _red; }
 
 void JumpNodeEditorDialogModel::setColorG(int v) {
+	if (v < 0) return;
 	CLAMP(v, 0, 255);
 	_green = v;
-	for (auto objnum : _selectedJumpNodes) {
-		auto* jnp = jumpnode_get_by_objnum(objnum);
-		if (jnp) {
-			jnp->SetAlphaColor(_red, _green, _blue, _alpha);
-		}
-	}
+	_greenMixed = false;
+	applyChannelToAll(_selectedJumpNodes, _red, _green, _blue, _alpha,
+	    _redMixed, _greenMixed, _blueMixed, _alphaMixed);
 	set_modified();
 	_editor->missionChanged();
 }
@@ -291,14 +317,12 @@ void JumpNodeEditorDialogModel::setColorG(int v) {
 int JumpNodeEditorDialogModel::getColorG() const { return _green; }
 
 void JumpNodeEditorDialogModel::setColorB(int v) {
+	if (v < 0) return;
 	CLAMP(v, 0, 255);
 	_blue = v;
-	for (auto objnum : _selectedJumpNodes) {
-		auto* jnp = jumpnode_get_by_objnum(objnum);
-		if (jnp) {
-			jnp->SetAlphaColor(_red, _green, _blue, _alpha);
-		}
-	}
+	_blueMixed = false;
+	applyChannelToAll(_selectedJumpNodes, _red, _green, _blue, _alpha,
+	    _redMixed, _greenMixed, _blueMixed, _alphaMixed);
 	set_modified();
 	_editor->missionChanged();
 }
@@ -306,22 +330,29 @@ void JumpNodeEditorDialogModel::setColorB(int v) {
 int JumpNodeEditorDialogModel::getColorB() const { return _blue; }
 
 void JumpNodeEditorDialogModel::setColorA(int v) {
+	if (v < 0) return;
 	CLAMP(v, 0, 255);
 	_alpha = v;
-	for (auto objnum : _selectedJumpNodes) {
-		auto* jnp = jumpnode_get_by_objnum(objnum);
-		if (jnp) {
-			jnp->SetAlphaColor(_red, _green, _blue, _alpha);
-		}
-	}
+	_alphaMixed = false;
+	applyChannelToAll(_selectedJumpNodes, _red, _green, _blue, _alpha,
+	    _redMixed, _greenMixed, _blueMixed, _alphaMixed);
 	set_modified();
 	_editor->missionChanged();
 }
 
 int JumpNodeEditorDialogModel::getColorA() const { return _alpha; }
 
+bool JumpNodeEditorDialogModel::isColorRMixed() const { return _redMixed; }
+bool JumpNodeEditorDialogModel::isColorGMixed() const { return _greenMixed; }
+bool JumpNodeEditorDialogModel::isColorBMixed() const { return _blueMixed; }
+bool JumpNodeEditorDialogModel::isColorAMixed() const { return _alphaMixed; }
+bool JumpNodeEditorDialogModel::hasAnyColorMixed() const {
+	return _redMixed || _greenMixed || _blueMixed || _alphaMixed;
+}
+
 void JumpNodeEditorDialogModel::setHidden(bool v) {
 	_hidden = v;
+	_hiddenMixed = false;
 	for (auto objnum : _selectedJumpNodes) {
 		auto* jnp = jumpnode_get_by_objnum(objnum);
 		if (jnp) {
@@ -333,6 +364,11 @@ void JumpNodeEditorDialogModel::setHidden(bool v) {
 }
 
 bool JumpNodeEditorDialogModel::getHidden() const { return _hidden; }
+
+int JumpNodeEditorDialogModel::getHiddenState() const {
+	if (_hiddenMixed) return Qt::PartiallyChecked;
+	return _hidden ? Qt::Checked : Qt::Unchecked;
+}
 
 SCP_string JumpNodeEditorDialogModel::getLayer() const {
 	SCP_string result;

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
@@ -16,70 +16,36 @@ JumpNodeEditorDialogModel::JumpNodeEditorDialogModel(QObject* parent, EditorView
 	connect(viewport->editor, &Editor::currentObjectChanged, this, &JumpNodeEditorDialogModel::onSelectedObjectChanged);
 	connect(viewport->editor, &Editor::objectMarkingChanged, this, &JumpNodeEditorDialogModel::onSelectedObjectMarkingChanged);
 	connect(viewport->editor, &Editor::missionChanged, this, &JumpNodeEditorDialogModel::onMissionChanged);
-	
+
 	initializeData();
 }
 
-bool JumpNodeEditorDialogModel::apply()
-{
-	if (_currentlySelectedNodeIndex < 0) {
-		// Nothing to apply
-		return true;
-	}
-
-	// Validate
-	if (!validateData()) {
-		return false;
-	}
-
-	// Commit
-	auto* jnp = jumpnode_get_by_objnum(getSelectedJumpNodeObjnum(_currentlySelectedNodeIndex));
-	Assertion(jnp != nullptr, "Jump node not found during apply!");
-
-	char old_name_buf[NAME_LENGTH];
-	std::strncpy(old_name_buf, jnp->GetName(), NAME_LENGTH - 1);
-	old_name_buf[NAME_LENGTH - 1] = '\0';
-
-	lcl_fred_replace_stuff(_display);
-
-	jnp->SetName(_name.c_str());
-	jnp->SetDisplayName(lcase_equal(_display, "<none>") ? _name.c_str() : _display.c_str());
-
-	// Only set a non default model
-	if (!lcase_equal(_modelFilename, JN_DEFAULT_MODEL)) {
-		jnp->SetModel(_modelFilename.c_str());
-	}
-
-	jnp->SetAlphaColor(_red, _green, _blue, _alpha);
-	jnp->SetVisibility(!_hidden);
-
-	// Update sexp references when name changes
-	if (strcmp(old_name_buf, _name.c_str()) != 0) {
-		update_sexp_references(old_name_buf, _name.c_str());
-	}
-
-	_editor->missionChanged();
+bool JumpNodeEditorDialogModel::apply() {
 	return true;
 }
 
-void JumpNodeEditorDialogModel::reject()
-{
-	// do nothing
-}
+void JumpNodeEditorDialogModel::reject() {}
 
 void JumpNodeEditorDialogModel::initializeData()
 {
-	buildNodeList();
-	
-	// Find the currently selected object if it's a jump node
-	int objnum = -1;
-	if (query_valid_object(_editor->currentObject) && Objects[_editor->currentObject].type == OBJ_JUMP_NODE) {
-		objnum = _editor->currentObject;
+	_selectedJumpNodes.clear();
+
+	// Collect all marked OBJ_JUMP_NODE objects
+	for (auto* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
+		if (ptr->type == OBJ_JUMP_NODE && ptr->flags[Object::Object_Flags::Marked]) {
+			_selectedJumpNodes.push_back(OBJ_INDEX(ptr));
+		}
 	}
-	
-	if (objnum >= 0) {
-		auto* jnp = jumpnode_get_by_objnum(objnum);
-		Assertion(jnp != nullptr, "Jump node not found for current object!");
+
+	// Fall back to currentObject if nothing is marked
+	if (_selectedJumpNodes.empty() && query_valid_object(_editor->currentObject) &&
+	    Objects[_editor->currentObject].type == OBJ_JUMP_NODE) {
+		_selectedJumpNodes.push_back(_editor->currentObject);
+	}
+
+	if (!_selectedJumpNodes.empty()) {
+		auto* jnp = jumpnode_get_by_objnum(_selectedJumpNodes.front());
+		Assertion(jnp != nullptr, "Jump node not found for selected object!");
 
 		_name = jnp->GetName();
 		_display = jnp->HasDisplayName() ? jnp->GetDisplayName() : "<none>";
@@ -88,7 +54,7 @@ void JumpNodeEditorDialogModel::initializeData()
 		if (auto* pm = model_get(model_num)) {
 			_modelFilename = pm->filename;
 		} else {
-			_modelFilename.clear();
+			_modelFilename = JN_DEFAULT_MODEL;
 		}
 
 		const auto& c = jnp->GetColor();
@@ -99,12 +65,27 @@ void JumpNodeEditorDialogModel::initializeData()
 
 		_hidden = jnp->IsHidden();
 
-		// Find the index of the jump node in the local list
-		for (const auto& node : _nodes) {
-			if (!stricmp(node.first.c_str(), _name.c_str())) {
-				_currentlySelectedNodeIndex = node.second;
-				break;
+		if (hasMultipleSelection()) {
+			bool displayConsistent = true;
+			bool modelConsistent   = true;
+			for (size_t i = 1; i < _selectedJumpNodes.size(); ++i) {
+				auto* other = jumpnode_get_by_objnum(_selectedJumpNodes[i]);
+				if (!other) continue;
+
+				SCP_string otherDisplay = other->HasDisplayName() ? other->GetDisplayName() : "<none>";
+				if (_display != otherDisplay)
+					displayConsistent = false;
+
+				SCP_string otherModel;
+				if (auto* pm = model_get(other->GetModelNumber()))
+					otherModel = pm->filename;
+				else
+					otherModel = JN_DEFAULT_MODEL;
+				if (_modelFilename != otherModel)
+					modelConsistent = false;
 			}
+			if (!displayConsistent) _display.clear();
+			if (!modelConsistent)   _modelFilename.clear();
 		}
 	} else {
 		_name.clear();
@@ -112,42 +93,47 @@ void JumpNodeEditorDialogModel::initializeData()
 		_modelFilename.clear();
 		_red = _green = _blue = _alpha = 0;
 		_hidden = false;
-
-		_currentlySelectedNodeIndex = -1;
 	}
 
 	Q_EMIT jumpNodeMarkingChanged();
 	_modified = false;
 }
 
-void JumpNodeEditorDialogModel::buildNodeList()
-{
-	_nodes.clear();
-	int idx = 0;
-	for (auto& node : Jump_nodes) {
-		_nodes.emplace_back(node.GetName(), idx++);
-	}
+bool JumpNodeEditorDialogModel::hasValidSelection() const {
+	return !_selectedJumpNodes.empty();
 }
 
-bool JumpNodeEditorDialogModel::validateData()
-{
-	_bypass_errors = false;
+bool JumpNodeEditorDialogModel::hasMultipleSelection() const {
+	return _selectedJumpNodes.size() > 1;
+}
 
-	SCP_trim(_name);
+bool JumpNodeEditorDialogModel::hasAnyNodesInMission() const {
+	return !Jump_nodes.empty();
+}
 
-	const SCP_string name = _name;
+int JumpNodeEditorDialogModel::getSelectionCount() const {
+	return static_cast<int>(_selectedJumpNodes.size());
+}
+
+void JumpNodeEditorDialogModel::showErrorDialogNoCancel(const SCP_string& message) {
+	if (_bypass_errors) {
+		return;
+	}
+	_bypass_errors = true;
+	_viewport->dialogProvider->showButtonDialog(DialogType::Error, "Error", message, {DialogButton::Ok});
+}
+
+bool JumpNodeEditorDialogModel::validateName(const SCP_string& name) {
 	if (name.empty()) {
 		showErrorDialogNoCancel("A jump node name cannot be empty.");
 		return false;
 	}
 
-	// Disallow leading '<'
-	if (!name.empty() && name[0] == '<') {
+	if (name[0] == '<') {
 		showErrorDialogNoCancel("Jump node names are not allowed to begin with '<'.");
 		return false;
 	}
 
-	// Wing name collision
 	for (auto& wing : Wings) {
 		if (!stricmp(wing.name, name.c_str())) {
 			showErrorDialogNoCancel("This jump node name is already being used by a wing.");
@@ -155,7 +141,6 @@ bool JumpNodeEditorDialogModel::validateData()
 		}
 	}
 
-	// Ship/start name collision
 	for (auto* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
 		if (ptr->type == OBJ_SHIP || ptr->type == OBJ_START) {
 			if (!stricmp(name.c_str(), Ships[ptr->instance].ship_name)) {
@@ -165,7 +150,6 @@ bool JumpNodeEditorDialogModel::validateData()
 		}
 	}
 
-	// AI target priority group collision
 	for (auto& ai : Ai_tp_list) {
 		if (!stricmp(name.c_str(), ai.name)) {
 			showErrorDialogNoCancel("This jump node name is already being used by a target priority group.");
@@ -173,230 +157,268 @@ bool JumpNodeEditorDialogModel::validateData()
 		}
 	}
 
-	// Waypoint path collision
 	if (find_matching_waypoint_list(name.c_str()) != nullptr) {
 		showErrorDialogNoCancel("This jump node name is already being used by a waypoint path.");
 		return false;
 	}
 
-	// Another jump node with the same name (but not this one)
-	auto* jnp = jumpnode_get_by_objnum(getSelectedJumpNodeObjnum(_currentlySelectedNodeIndex));
+	auto* current_jnp = _selectedJumpNodes.empty() ? nullptr : jumpnode_get_by_objnum(_selectedJumpNodes.front());
 	auto* found = jumpnode_get_by_name(name.c_str());
-	if (found != nullptr && found != jnp) {
+	if (found != nullptr && found != current_jnp) {
 		showErrorDialogNoCancel("This jump node name is already being used by another jump node.");
-		return false;
-	}
-
-	if (!cf_exists_full(_modelFilename.c_str(), CF_TYPE_MODELS)) {
-		showErrorDialogNoCancel("This jump node model file does not exist.");
 		return false;
 	}
 
 	return true;
 }
 
-void JumpNodeEditorDialogModel::showErrorDialogNoCancel(const SCP_string& message)
-{
-	if (_bypass_errors) {
-		return;
+bool JumpNodeEditorDialogModel::setName(const SCP_string& v) {
+	if (hasMultipleSelection() || _selectedJumpNodes.empty()) {
+		return true;
 	}
 
-	_bypass_errors = true;
-	_viewport->dialogProvider->showButtonDialog(DialogType::Error, "Error", message, {DialogButton::Ok});
-}
+	_bypass_errors = false;
 
-int JumpNodeEditorDialogModel::getSelectedJumpNodeObjnum(int idx) const
-{
-	// Find the jump node and then mark it
-	for (const auto& node : Jump_nodes) {
-		if (!stricmp(node.GetName(), _nodes[idx].first.c_str())) {
-			return node.GetSCPObjectNumber();
-		}
+	SCP_string trimmed = v;
+	SCP_trim(trimmed);
+
+	if (!validateName(trimmed)) {
+		return false;
 	}
 
-	return -1;
-}
-
-void JumpNodeEditorDialogModel::onSelectedObjectChanged(int)
-{
-	initializeData();
-}
-
-void JumpNodeEditorDialogModel::onSelectedObjectMarkingChanged(int, bool)
-{
-	initializeData();
-}
-
-void JumpNodeEditorDialogModel::onMissionChanged()
-{
-	initializeData();
-}
-
-const SCP_vector<std::pair<SCP_string, int>>& JumpNodeEditorDialogModel::getJumpNodeList() const
-{
-	return _nodes;
-}
-
-void JumpNodeEditorDialogModel::selectJumpNodeByListIndex(int idx)
-{
-	if (_currentlySelectedNodeIndex == idx) {
-		// No change
-		return;
+	auto* jnp = jumpnode_get_by_objnum(_selectedJumpNodes.front());
+	if (!jnp) {
+		return false;
 	}
 
-	if (!SCP_vector_inbounds(_nodes, idx))
-		return;
+	char old_name[NAME_LENGTH];
+	std::strncpy(old_name, jnp->GetName(), NAME_LENGTH - 1);
+	old_name[NAME_LENGTH - 1] = '\0';
 
-	if (apply()) {
-		_editor->unmark_all();
+	jnp->SetName(trimmed.c_str());
 
-		int objnum = getSelectedJumpNodeObjnum(idx);
-
-		if (objnum < 0) {
-			_currentlySelectedNodeIndex = -1;
-			return;
-		}
-
-		_editor->markObject(objnum);
-		_currentlySelectedNodeIndex = idx;
+	if (strcmp(old_name, trimmed.c_str()) != 0) {
+		update_sexp_references(old_name, trimmed.c_str());
 	}
-}
 
-int JumpNodeEditorDialogModel::getCurrentJumpNodeIndex() const
-{
-	return _currentlySelectedNodeIndex;
-}
-bool JumpNodeEditorDialogModel::hasValidSelection() const
-{
-	return _currentlySelectedNodeIndex >= 0;
-}
-
-void JumpNodeEditorDialogModel::setName(const SCP_string& v)
-{
-	SCP_trim(_name);
-	
-	SCP_string current = _name;
-
-	_name = v;
-	if (apply()) {
-		set_modified();
-	} else {
-		_name = current; // restore the old name
-	}
-}
-
-const SCP_string& JumpNodeEditorDialogModel::getName() const
-{
-	return _name;
-}
-
-void JumpNodeEditorDialogModel::setDisplayName(const SCP_string& v)
-{
-	modify(_display, v);
-	apply(); // Apply changes immediately to update the display name
-}
-
-const SCP_string& JumpNodeEditorDialogModel::getDisplayName() const
-{
-	return _display;
-}
-
-void JumpNodeEditorDialogModel::setModelFilename(const SCP_string& v)
-{
-	SCP_string current = _modelFilename;
-
-	_modelFilename = v;
-	if (apply()) {
-		set_modified();
-	} else {
-		_modelFilename = current; // restore the old name
-	}
-}
-
-const SCP_string& JumpNodeEditorDialogModel::getModelFilename() const
-{
-	return _modelFilename;
-}
-
-void JumpNodeEditorDialogModel::setColorR(int v)
-{
-	CLAMP(v, 0, 255);
-	modify(_red, v);
-	apply(); // Apply changes immediately to update the model color
-}
-
-int JumpNodeEditorDialogModel::getColorR() const
-{
-	return _red;
-}
-
-void JumpNodeEditorDialogModel::setColorG(int v)
-{
-	CLAMP(v, 0, 255);
-	modify(_green, v);
-	apply(); // Apply changes immediately to update the model color
-}
-
-int JumpNodeEditorDialogModel::getColorG() const
-{
-	return _green;
-}
-
-void JumpNodeEditorDialogModel::setColorB(int v)
-{
-	CLAMP(v, 0, 255);
-	modify(_blue, v);
-	apply(); // Apply changes immediately to update the model color
-}
-
-int JumpNodeEditorDialogModel::getColorB() const
-{
-	return _blue;
-}
-
-void JumpNodeEditorDialogModel::setColorA(int v)
-{
-	CLAMP(v, 0, 255);
-	modify(_alpha, v);
-	apply(); // Apply changes immediately to update the model color
-}
-
-int JumpNodeEditorDialogModel::getColorA() const
-{
-	return _alpha;
-}
-
-void JumpNodeEditorDialogModel::setHidden(bool v)
-{
-	modify(_hidden, v);
-	apply(); // Apply changes immediately to update the visibility
-}
-
-bool JumpNodeEditorDialogModel::getHidden() const
-{
-	return _hidden;
-}
-
-SCP_string JumpNodeEditorDialogModel::getLayer() const
-{
-	if (_currentlySelectedNodeIndex < 0)
-		return "";
-	int objnum = getSelectedJumpNodeObjnum(_currentlySelectedNodeIndex);
-	if (objnum < 0)
-		return "";
-	return _viewport->getObjectLayerName(objnum);
-}
-
-void JumpNodeEditorDialogModel::setLayer(const SCP_string& v)
-{
-	if (_currentlySelectedNodeIndex < 0)
-		return;
-	int objnum = getSelectedJumpNodeObjnum(_currentlySelectedNodeIndex);
-	if (objnum < 0)
-		return;
-	_viewport->moveObjectToLayer(objnum, v);
+	_name = trimmed;
 	set_modified();
 	_editor->missionChanged();
+	return true;
+}
+
+const SCP_string& JumpNodeEditorDialogModel::getName() const { return _name; }
+
+bool JumpNodeEditorDialogModel::setDisplayName(const SCP_string& v) {
+	if (_selectedJumpNodes.empty() || v.empty()) {
+		return true;
+	}
+
+	SCP_string display = v;
+	lcl_fred_replace_stuff(display);
+	const bool useNodeName = lcase_equal(display, "<none>");
+
+	for (auto objnum : _selectedJumpNodes) {
+		auto* jnp = jumpnode_get_by_objnum(objnum);
+		if (!jnp) continue;
+		jnp->SetDisplayName(useNodeName ? jnp->GetName() : display.c_str());
+	}
+
+	_display = useNodeName ? "<none>" : display;
+	set_modified();
+	_editor->missionChanged();
+	return true;
+}
+
+const SCP_string& JumpNodeEditorDialogModel::getDisplayName() const { return _display; }
+
+bool JumpNodeEditorDialogModel::setModelFilename(const SCP_string& v) {
+	if (_selectedJumpNodes.empty() || v.empty()) {
+		return true;
+	}
+
+	if (!lcase_equal(v, JN_DEFAULT_MODEL) && !cf_exists_full(v.c_str(), CF_TYPE_MODELS)) {
+		showErrorDialogNoCancel("This jump node model file does not exist.");
+		return false;
+	}
+
+	_modelFilename = v;
+	const bool useDefault = lcase_equal(_modelFilename, JN_DEFAULT_MODEL);
+
+	for (auto objnum : _selectedJumpNodes) {
+		auto* jnp = jumpnode_get_by_objnum(objnum);
+		if (!jnp) continue;
+		if (!useDefault) {
+			jnp->SetModel(_modelFilename.c_str());
+		}
+	}
+
+	set_modified();
+	_editor->missionChanged();
+	return true;
+}
+
+const SCP_string& JumpNodeEditorDialogModel::getModelFilename() const { return _modelFilename; }
+
+void JumpNodeEditorDialogModel::setColorR(int v) {
+	CLAMP(v, 0, 255);
+	_red = v;
+	for (auto objnum : _selectedJumpNodes) {
+		auto* jnp = jumpnode_get_by_objnum(objnum);
+		if (jnp) {
+			jnp->SetAlphaColor(_red, _green, _blue, _alpha);
+		}
+	}
+	set_modified();
+	_editor->missionChanged();
+}
+
+int JumpNodeEditorDialogModel::getColorR() const { return _red; }
+
+void JumpNodeEditorDialogModel::setColorG(int v) {
+	CLAMP(v, 0, 255);
+	_green = v;
+	for (auto objnum : _selectedJumpNodes) {
+		auto* jnp = jumpnode_get_by_objnum(objnum);
+		if (jnp) {
+			jnp->SetAlphaColor(_red, _green, _blue, _alpha);
+		}
+	}
+	set_modified();
+	_editor->missionChanged();
+}
+
+int JumpNodeEditorDialogModel::getColorG() const { return _green; }
+
+void JumpNodeEditorDialogModel::setColorB(int v) {
+	CLAMP(v, 0, 255);
+	_blue = v;
+	for (auto objnum : _selectedJumpNodes) {
+		auto* jnp = jumpnode_get_by_objnum(objnum);
+		if (jnp) {
+			jnp->SetAlphaColor(_red, _green, _blue, _alpha);
+		}
+	}
+	set_modified();
+	_editor->missionChanged();
+}
+
+int JumpNodeEditorDialogModel::getColorB() const { return _blue; }
+
+void JumpNodeEditorDialogModel::setColorA(int v) {
+	CLAMP(v, 0, 255);
+	_alpha = v;
+	for (auto objnum : _selectedJumpNodes) {
+		auto* jnp = jumpnode_get_by_objnum(objnum);
+		if (jnp) {
+			jnp->SetAlphaColor(_red, _green, _blue, _alpha);
+		}
+	}
+	set_modified();
+	_editor->missionChanged();
+}
+
+int JumpNodeEditorDialogModel::getColorA() const { return _alpha; }
+
+void JumpNodeEditorDialogModel::setHidden(bool v) {
+	_hidden = v;
+	for (auto objnum : _selectedJumpNodes) {
+		auto* jnp = jumpnode_get_by_objnum(objnum);
+		if (jnp) {
+			jnp->SetVisibility(!v);
+		}
+	}
+	set_modified();
+	_editor->missionChanged();
+}
+
+bool JumpNodeEditorDialogModel::getHidden() const { return _hidden; }
+
+SCP_string JumpNodeEditorDialogModel::getLayer() const {
+	SCP_string result;
+	bool first = true;
+	for (auto objnum : _selectedJumpNodes) {
+		SCP_string layer = _viewport->getObjectLayerName(objnum);
+		if (first) {
+			result = layer;
+			first = false;
+		} else if (result != layer) {
+			return "";
+		}
+	}
+	return result;
+}
+
+void JumpNodeEditorDialogModel::setLayer(const SCP_string& v) {
+	for (auto objnum : _selectedJumpNodes) {
+		_viewport->moveObjectToLayer(objnum, v);
+	}
+	set_modified();
+	_editor->missionChanged();
+}
+
+void JumpNodeEditorDialogModel::selectNodeFromObjectList(object* start, bool forward) {
+	auto* ptr = start;
+	while (ptr != END_OF_LIST(&obj_used_list)) {
+		if (ptr->type == OBJ_JUMP_NODE) {
+			_editor->unmark_all();
+			_editor->markObject(OBJ_INDEX(ptr));
+			return;
+		}
+		ptr = forward ? GET_NEXT(ptr) : GET_PREV(ptr);
+	}
+	// Wrap around
+	ptr = forward ? GET_FIRST(&obj_used_list) : GET_LAST(&obj_used_list);
+	while (ptr != END_OF_LIST(&obj_used_list)) {
+		if (ptr->type == OBJ_JUMP_NODE) {
+			_editor->unmark_all();
+			_editor->markObject(OBJ_INDEX(ptr));
+			return;
+		}
+		ptr = forward ? GET_NEXT(ptr) : GET_PREV(ptr);
+	}
+}
+
+void JumpNodeEditorDialogModel::selectFirstNodeInMission() {
+	for (auto* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
+		if (ptr->type == OBJ_JUMP_NODE) {
+			_editor->unmark_all();
+			_editor->markObject(OBJ_INDEX(ptr));
+			return;
+		}
+	}
+}
+
+void JumpNodeEditorDialogModel::selectNextNode() {
+	if (!hasValidSelection()) {
+		if (hasAnyNodesInMission()) {
+			selectFirstNodeInMission();
+		}
+		return;
+	}
+	selectNodeFromObjectList(GET_NEXT(&Objects[_selectedJumpNodes.front()]), true);
+}
+
+void JumpNodeEditorDialogModel::selectPreviousNode() {
+	if (!hasValidSelection()) {
+		if (hasAnyNodesInMission()) {
+			selectFirstNodeInMission();
+		}
+		return;
+	}
+	selectNodeFromObjectList(GET_PREV(&Objects[_selectedJumpNodes.front()]), false);
+}
+
+void JumpNodeEditorDialogModel::onSelectedObjectChanged(int) {
+	initializeData();
+}
+
+void JumpNodeEditorDialogModel::onSelectedObjectMarkingChanged(int, bool) {
+	initializeData();
+}
+
+void JumpNodeEditorDialogModel::onMissionChanged() {
+	initializeData();
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.h
@@ -23,7 +23,7 @@ public:
 	bool setModelFilename(const SCP_string& v);
 	const SCP_string& getModelFilename() const;
 
-	void setColorR(int v);
+	void setColorR(int v); // pass -1 for no-op (mixed sentinel)
 	int getColorR() const;
 	void setColorG(int v);
 	int getColorG() const;
@@ -31,9 +31,15 @@ public:
 	int getColorB() const;
 	void setColorA(int v);
 	int getColorA() const;
+	bool isColorRMixed() const;
+	bool isColorGMixed() const;
+	bool isColorBMixed() const;
+	bool isColorAMixed() const;
+	bool hasAnyColorMixed() const;
 
 	void setHidden(bool v);
 	bool getHidden() const;
+	int getHiddenState() const; // returns Qt::CheckState as int (PartiallyChecked when mixed)
 
 	SCP_string getLayer() const;
 	void setLayer(const SCP_string& v);
@@ -62,7 +68,9 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	SCP_string _display;
 	SCP_string _modelFilename;
 	int _red = 0, _green = 0, _blue = 0, _alpha = 0;
+	bool _redMixed = false, _greenMixed = false, _blueMixed = false, _alphaMixed = false;
 	bool _hidden = false;
+	bool _hiddenMixed = false;
 
 	bool _bypass_errors = false;
 };

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.h
@@ -5,22 +5,22 @@ namespace fso::fred::dialogs {
 
 class JumpNodeEditorDialogModel : public AbstractDialogModel {
 	Q_OBJECT
-  public:
+public:
 	explicit JumpNodeEditorDialogModel(QObject* parent, EditorViewport* viewport);
 
 	bool apply() override;
 	void reject() override;
 
-	const SCP_vector<std::pair<SCP_string, int>>& getJumpNodeList() const;
-	void selectJumpNodeByListIndex(int idx);
-	int getCurrentJumpNodeIndex() const;
 	bool hasValidSelection() const;
+	bool hasMultipleSelection() const;
+	bool hasAnyNodesInMission() const;
+	int getSelectionCount() const;
 
-	void setName(const SCP_string& v);
+	bool setName(const SCP_string& v);
 	const SCP_string& getName() const;
-	void setDisplayName(const SCP_string& v); // "<none>" means use Name
+	bool setDisplayName(const SCP_string& v); // "<none>" means use Name
 	const SCP_string& getDisplayName() const;
-	void setModelFilename(const SCP_string& v);
+	bool setModelFilename(const SCP_string& v);
 	const SCP_string& getModelFilename() const;
 
 	void setColorR(int v);
@@ -38,30 +38,31 @@ class JumpNodeEditorDialogModel : public AbstractDialogModel {
 	SCP_string getLayer() const;
 	void setLayer(const SCP_string& v);
 
-  signals:
+	void selectNextNode();
+	void selectPreviousNode();
+
+signals:
 	void jumpNodeMarkingChanged();
 
-  private slots:
+private slots:
 	void onSelectedObjectChanged(int);
 	void onSelectedObjectMarkingChanged(int, bool);
 	void onMissionChanged();
 
-  private: // NOLINT(readability-redundant-access-specifiers)
+private:
 	void initializeData();
-	void buildNodeList();
-	bool validateData();
 	void showErrorDialogNoCancel(const SCP_string& message);
-	int getSelectedJumpNodeObjnum(int idx) const;
+	bool validateName(const SCP_string& name);
+	void selectNodeFromObjectList(object* start, bool forward);
+	void selectFirstNodeInMission();
 
-	int _currentlySelectedNodeIndex = -1;
+	SCP_vector<int> _selectedJumpNodes; // objnums of selected jump nodes
 
 	SCP_string _name;
 	SCP_string _display;
 	SCP_string _modelFilename;
 	int _red = 0, _green = 0, _blue = 0, _alpha = 0;
 	bool _hidden = false;
-
-	SCP_vector<std::pair<SCP_string, int>> _nodes;
 
 	bool _bypass_errors = false;
 };

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.h
@@ -13,7 +13,7 @@ public:
 
 	bool hasValidSelection() const;
 	bool hasMultipleSelection() const;
-	bool hasAnyNodesInMission() const;
+	static bool hasAnyNodesInMission();
 	int getSelectionCount() const;
 
 	bool setName(const SCP_string& v);
@@ -49,7 +49,7 @@ private slots:
 	void onSelectedObjectMarkingChanged(int, bool);
 	void onMissionChanged();
 
-private:
+private: // NOLINT(readability-redundant-access-specifiers)
 	void initializeData();
 	void showErrorDialogNoCancel(const SCP_string& message);
 	bool validateName(const SCP_string& name);

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -961,7 +961,7 @@ void FredView::onUpdateContextToolbar() {
 		}
 	} else if (effectiveType == OBJ_WAYPOINT && (numMarked <= 1 || multiSharedWaypointList != nullptr)) {
 		addBtn(tr("Edit Waypoint Path"),   &FredView::on_actionWaypoint_Paths_triggered);
-	} else if (numMarked <= 1 && effectiveType == OBJ_JUMP_NODE) {
+	} else if (effectiveType == OBJ_JUMP_NODE) {
 		addBtn(tr("Edit Jump Node"),       &FredView::on_actionJump_Nodes_triggered);
 	} else if (effectiveType == OBJ_PROP) {
 		addBtn(tr("Edit Prop"),            &FredView::on_actionProps_triggered);

--- a/qtfred/src/ui/dialogs/JumpNodeEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/JumpNodeEditorDialog.cpp
@@ -36,21 +36,32 @@ void JumpNodeEditorDialog::initializeUi()
 {
 	util::SignalBlockers blockers(this);
 
-	updateJumpNodeListComboBox();
-	enableOrDisableControls();
-}
-
-void JumpNodeEditorDialog::updateJumpNodeListComboBox()
-{
-	ui->selectJumpNodeComboBox->clear();
-
-	for (auto& wp : _model->getJumpNodeList()) {
-		ui->selectJumpNodeComboBox->addItem(QString::fromStdString(wp.first), wp.second);
+	ui->layerCombo->clear();
+	for (const auto& name : _viewport->getLayerNames()) {
+		ui->layerCombo->addItem(QString::fromStdString(name), QString::fromStdString(name));
 	}
 
-	ui->selectJumpNodeComboBox->setEnabled(!_model->getJumpNodeList().empty());
+	const bool enabled = _model->hasValidSelection();
+	const bool hasAny = _model->hasAnyNodesInMission();
+	const bool multiSelect = _model->hasMultipleSelection();
 
-	ui->selectJumpNodeComboBox->setCurrentIndex(_model->getCurrentJumpNodeIndex());
+	ui->nameLineEdit->setEnabled(enabled && !multiSelect);
+	ui->displayNameLineEdit->setEnabled(enabled);
+	ui->modelFileLineEdit->setEnabled(enabled);
+	ui->redSpinBox->setEnabled(enabled);
+	ui->greenSpinBox->setEnabled(enabled);
+	ui->blueSpinBox->setEnabled(enabled);
+	ui->alphaSpinBox->setEnabled(enabled);
+	ui->hiddenByDefaultCheckBox->setEnabled(enabled);
+	ui->layerCombo->setEnabled(enabled);
+	ui->prevNodeButton->setEnabled(hasAny);
+	ui->nextNodeButton->setEnabled(hasAny);
+
+	if (multiSelect) {
+		setWindowTitle(QString("Edit %1 Jump Nodes").arg(_model->getSelectionCount()));
+	} else {
+		setWindowTitle("Jump Node Editor");
+	}
 }
 
 void JumpNodeEditorDialog::updateUi()
@@ -68,69 +79,77 @@ void JumpNodeEditorDialog::updateUi()
 
 	ui->hiddenByDefaultCheckBox->setChecked(_model->getHidden());
 
-	ui->layerCombo->clear();
-	for (const auto& name : _viewport->getLayerNames()) {
-		ui->layerCombo->addItem(QString::fromStdString(name), QString::fromStdString(name));
-	}
 	ui->layerCombo->setCurrentIndex(ui->layerCombo->findData(QString::fromStdString(_model->getLayer())));
+
+	updateColorSwatch();
 }
 
-void JumpNodeEditorDialog::enableOrDisableControls()
+void JumpNodeEditorDialog::updateColorSwatch()
 {
-	const bool enable = _model->hasValidSelection();
-
-	ui->nameLineEdit->setEnabled(enable);
-	ui->displayNameLineEdit->setEnabled(enable);
-	ui->modelFileLineEdit->setEnabled(enable);
-	ui->redSpinBox->setEnabled(enable);
-	ui->greenSpinBox->setEnabled(enable);
-	ui->blueSpinBox->setEnabled(enable);
-	ui->alphaSpinBox->setEnabled(enable);
-	ui->hiddenByDefaultCheckBox->setEnabled(enable);
-	ui->layerCombo->setEnabled(enable);
+	ui->colorSwatch->setStyleSheet(QString("background: rgba(%1,%2,%3,%4);"
+	                                       "border: 1px solid #444; border-radius: 3px;")
+	        .arg(_model->getColorR())
+	        .arg(_model->getColorG())
+	        .arg(_model->getColorB())
+	        .arg(_model->getColorA()));
 }
 
-void JumpNodeEditorDialog::on_selectJumpNodeComboBox_currentIndexChanged(int index)
+void JumpNodeEditorDialog::on_prevNodeButton_clicked()
 {
-	auto itemId = ui->selectJumpNodeComboBox->itemData(index).value<int>();
-	_model->selectJumpNodeByListIndex(itemId);
+	_model->selectPreviousNode();
+}
+
+void JumpNodeEditorDialog::on_nextNodeButton_clicked()
+{
+	_model->selectNextNode();
 }
 
 void JumpNodeEditorDialog::on_nameLineEdit_editingFinished()
 {
-	_model->setName(ui->nameLineEdit->text().toUtf8().constData());
-	updateUi(); // Update immediately in case the name change is rejected
+	if (!_model->setName(ui->nameLineEdit->text().toUtf8().constData())) {
+		util::SignalBlockers blockers(this);
+		ui->nameLineEdit->setText(QString::fromStdString(_model->getName()));
+	}
 }
 
 void JumpNodeEditorDialog::on_displayNameLineEdit_editingFinished()
 {
-	_model->setDisplayName(ui->displayNameLineEdit->text().toUtf8().constData());
+	if (!_model->setDisplayName(ui->displayNameLineEdit->text().toUtf8().constData())) {
+		util::SignalBlockers blockers(this);
+		ui->displayNameLineEdit->setText(QString::fromStdString(_model->getDisplayName()));
+	}
 }
 
 void JumpNodeEditorDialog::on_modelFileLineEdit_editingFinished()
 {
-	_model->setModelFilename(ui->modelFileLineEdit->text().toUtf8().constData());
-	updateUi(); // Update immediately in case the name change is rejected
+	if (!_model->setModelFilename(ui->modelFileLineEdit->text().toUtf8().constData())) {
+		util::SignalBlockers blockers(this);
+		ui->modelFileLineEdit->setText(QString::fromStdString(_model->getModelFilename()));
+	}
 }
 
 void JumpNodeEditorDialog::on_redSpinBox_valueChanged(int value)
 {
 	_model->setColorR(value);
+	updateColorSwatch();
 }
 
 void JumpNodeEditorDialog::on_greenSpinBox_valueChanged(int value)
 {
 	_model->setColorG(value);
+	updateColorSwatch();
 }
 
 void JumpNodeEditorDialog::on_blueSpinBox_valueChanged(int value)
 {
 	_model->setColorB(value);
+	updateColorSwatch();
 }
 
 void JumpNodeEditorDialog::on_alphaSpinBox_valueChanged(int value)
 {
 	_model->setColorA(value);
+	updateColorSwatch();
 }
 
 void JumpNodeEditorDialog::on_hiddenByDefaultCheckBox_toggled(bool checked)

--- a/qtfred/src/ui/dialogs/JumpNodeEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/JumpNodeEditorDialog.cpp
@@ -18,6 +18,12 @@ JumpNodeEditorDialog::JumpNodeEditorDialog(FredView* parent, EditorViewport* vie
 	ui->displayNameLineEdit->setMaxLength(NAME_LENGTH - 1);
 	ui->modelFileLineEdit->setMaxLength(MAX_FILENAME_LEN - 1);
 
+	// -1 is the "mixed selection" sentinel... shown as blank via specialValueText.
+	for (auto* sb : {ui->redSpinBox, ui->greenSpinBox, ui->blueSpinBox, ui->alphaSpinBox}) {
+		sb->setMinimum(-1);
+		sb->setSpecialValueText(" ");
+	}
+
 	initializeUi();
 	updateUi();
 
@@ -72,12 +78,14 @@ void JumpNodeEditorDialog::updateUi()
 	ui->displayNameLineEdit->setText(QString::fromStdString(_model->getDisplayName()));
 	ui->modelFileLineEdit->setText(QString::fromStdString(_model->getModelFilename()));
 
-	ui->redSpinBox->setValue(_model->getColorR());
-	ui->greenSpinBox->setValue(_model->getColorG());
-	ui->blueSpinBox->setValue(_model->getColorB());
-	ui->alphaSpinBox->setValue(_model->getColorA());
+	ui->redSpinBox->setValue(_model->isColorRMixed() ? -1 : _model->getColorR());
+	ui->greenSpinBox->setValue(_model->isColorGMixed() ? -1 : _model->getColorG());
+	ui->blueSpinBox->setValue(_model->isColorBMixed() ? -1 : _model->getColorB());
+	ui->alphaSpinBox->setValue(_model->isColorAMixed() ? -1 : _model->getColorA());
 
-	ui->hiddenByDefaultCheckBox->setChecked(_model->getHidden());
+	const int hiddenState = _model->getHiddenState();
+	ui->hiddenByDefaultCheckBox->setTristate(hiddenState == Qt::PartiallyChecked);
+	ui->hiddenByDefaultCheckBox->setCheckState(static_cast<Qt::CheckState>(hiddenState));
 
 	ui->layerCombo->setCurrentIndex(ui->layerCombo->findData(QString::fromStdString(_model->getLayer())));
 
@@ -86,6 +94,15 @@ void JumpNodeEditorDialog::updateUi()
 
 void JumpNodeEditorDialog::updateColorSwatch()
 {
+	if (_model->hasAnyColorMixed()) {
+		// Mixed selection: render a neutral patterned swatch with a "?".
+		ui->colorSwatch->setText("?");
+		ui->colorSwatch->setAlignment(Qt::AlignCenter);
+		ui->colorSwatch->setStyleSheet("background: #888; color: white;"
+		                               "border: 1px solid #444; border-radius: 3px;");
+		return;
+	}
+	ui->colorSwatch->setText("");
 	ui->colorSwatch->setStyleSheet(QString("background: rgba(%1,%2,%3,%4);"
 	                                       "border: 1px solid #444; border-radius: 3px;")
 	        .arg(_model->getColorR())
@@ -152,9 +169,11 @@ void JumpNodeEditorDialog::on_alphaSpinBox_valueChanged(int value)
 	updateColorSwatch();
 }
 
-void JumpNodeEditorDialog::on_hiddenByDefaultCheckBox_toggled(bool checked)
+void JumpNodeEditorDialog::on_hiddenByDefaultCheckBox_clicked()
 {
-	_model->setHidden(checked);
+	// clicked() is used (not toggled()) so a click on a tri-state PartiallyChecked
+	// box still routes here. Read the post-click state from the widget itself.
+	_model->setHidden(ui->hiddenByDefaultCheckBox->isChecked());
 }
 
 void JumpNodeEditorDialog::on_layerCombo_currentIndexChanged(int index)

--- a/qtfred/src/ui/dialogs/JumpNodeEditorDialog.h
+++ b/qtfred/src/ui/dialogs/JumpNodeEditorDialog.h
@@ -12,12 +12,13 @@ class JumpNodeEditorDialog;
 
 class JumpNodeEditorDialog : public QDialog {
 	Q_OBJECT
-  public:
+public:
 	JumpNodeEditorDialog(FredView* parent, EditorViewport* viewport);
 	~JumpNodeEditorDialog() override;
 
-  private slots:
-	void on_selectJumpNodeComboBox_currentIndexChanged(int index);
+private slots:
+	void on_prevNodeButton_clicked();
+	void on_nextNodeButton_clicked();
 	void on_nameLineEdit_editingFinished();
 	void on_displayNameLineEdit_editingFinished();
 	void on_modelFileLineEdit_editingFinished();
@@ -28,15 +29,14 @@ class JumpNodeEditorDialog : public QDialog {
 	void on_hiddenByDefaultCheckBox_toggled(bool checked);
 	void on_layerCombo_currentIndexChanged(int index);
 
-  private: // NOLINT(readability-redundant-access-specifiers)
+private: // NOLINT(readability-redundant-access-specifiers)
 	EditorViewport* _viewport;
 	std::unique_ptr<Ui::JumpNodeEditorDialog> ui;
 	std::unique_ptr<JumpNodeEditorDialogModel> _model;
 
 	void initializeUi();
-	void updateJumpNodeListComboBox();
 	void updateUi();
-	void enableOrDisableControls();
+	void updateColorSwatch();
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/JumpNodeEditorDialog.h
+++ b/qtfred/src/ui/dialogs/JumpNodeEditorDialog.h
@@ -26,7 +26,7 @@ private slots:
 	void on_greenSpinBox_valueChanged(int value);
 	void on_blueSpinBox_valueChanged(int value);
 	void on_alphaSpinBox_valueChanged(int value);
-	void on_hiddenByDefaultCheckBox_toggled(bool checked);
+	void on_hiddenByDefaultCheckBox_clicked();
 	void on_layerCombo_currentIndexChanged(int index);
 
 private: // NOLINT(readability-redundant-access-specifiers)

--- a/qtfred/ui/JumpNodeEditorDialog.ui
+++ b/qtfred/ui/JumpNodeEditorDialog.ui
@@ -26,25 +26,22 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <layout class="QFormLayout" name="formLayout">
-       <item row="0" column="0">
-        <widget class="QLabel" name="selectJumpNodeLabel">
+      <layout class="QHBoxLayout" name="navigationLayout">
+       <item>
+        <widget class="QPushButton" name="prevNodeButton">
          <property name="text">
-          <string>Select Jump Node</string>
+          <string>&amp;Prev</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="selectJumpNodeComboBox"/>
+       <item>
+        <widget class="QPushButton" name="nextNodeButton">
+         <property name="text">
+          <string>&amp;Next</string>
+         </property>
+        </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
      </item>
      <item>
       <layout class="QFormLayout" name="formLayout_3">
@@ -188,6 +185,22 @@
           </property>
           <property name="value">
            <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="colorSwatch">
+          <property name="minimumSize">
+           <size>
+            <width>28</width>
+            <height>28</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::Box</enum>
+          </property>
+          <property name="text">
+           <string/>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The Jump Node dialog was mostly modal but now that Jump Points have more features it makes sense to upgrade this to match Ships/Wings. The dialog here is made to be multi-select aware and direct edit instead of modal. Also adds Prev/Next buttons.