### PR TITLE
fix a few bugs in model loading

### DIFF
--- a/code/hud/hudshield.cpp
+++ b/code/hud/hudshield.cpp
@@ -697,7 +697,6 @@ void HudGaugeShield::showShields(const object *objp, ShieldGaugeType mode, bool 
 			model_render_params render_info;
 
 			// If this comment is here then I have not tested this
-			int model_num = sip->model_num;
 			int model_instance_number = -1;
 
 			if (!config) {
@@ -705,15 +704,15 @@ void HudGaugeShield::showShields(const object *objp, ShieldGaugeType mode, bool 
 				render_info.set_replacement_textures(model_get_instance(model_instance_number)->texture_replace);
 			}
 
-			if (model_num < 0 && config) {
-				model_num = model_load(sip, false);
+			if (sip->model_num < 0 && config) {
+				sip->model_num = model_load(sip, false);
 			}
 
 			render_info.set_flags(MR_NO_LIGHTING | MR_AUTOCENTER | MR_NO_FOGGING);
 			render_info.set_detail_level_lock(1);
 			render_info.set_object_number(OBJ_INDEX(objp));
 
-			model_render_immediate( &render_info, model_num, model_instance_number, &object_orient, &vmd_zero_vector );
+			model_render_immediate( &render_info, sip->model_num, model_instance_number, &object_orient, &vmd_zero_vector );
 		}
 
 		//We're done

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5347,6 +5347,7 @@ void resolve_path_masks(bool path_user_is_ship, const char *path_user, anchor_t 
 		// Load the anchor ship model with subsystems and all; it'll need to be done for this mission anyway
 		auto anchor_sip = anchor_ship_entry->sip();
 		modelnum = model_load(anchor_sip->pof_file, anchor_sip);
+		anchor_sip->model_num = modelnum;
 
 		// resolve names to indexes
 		*path_mask = 0;
@@ -7075,6 +7076,7 @@ bool post_process_mission(mission *pm)
 				if (valid) {
 					ship_info* sip = &Ship_info[icon.ship_class];
 					stage.icons[j].modelnum = model_load(sip->pof_file, sip);
+					sip->model_num = stage.icons[j].modelnum;
 				}
 			}
 		}
@@ -8944,6 +8946,7 @@ void check_anchor_for_hangar_bay(SCP_string &message, SCP_set<anchor_t> &anchors
 		// Load the anchor ship model with subsystems and all; it'll need to be done for this mission anyway
 		auto anchor_sip = anchor_ship_entry->sip();
 		int modelnum = model_load(anchor_sip->pof_file, anchor_sip);
+		anchor_sip->model_num = modelnum;
 
 		// Check if this model has a hangar bay
 		if (!model_has_hangar_bay(modelnum))

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5337,7 +5337,7 @@ void resolve_path_masks(bool path_user_is_ship, const char *path_user, anchor_t 
 	// uninitialized; compute the mask from scratch
 	if (prp->cached_mask & (1 << MAX_SHIP_BAY_PATHS))
 	{
-		int j, bay_path, modelnum;
+		int j, bay_path;
 
 		// get anchor ship
 		Assertion(anchor.isValid() && !(anchor.value() & ANCHOR_SPECIAL_ARRIVAL), "%s %s anchor %d is invalid or is a special arrival.  Get a coder!", path_user_is_ship ? "Ship" : "Wing", path_user, anchor.value());
@@ -5346,14 +5346,13 @@ void resolve_path_masks(bool path_user_is_ship, const char *path_user, anchor_t 
 
 		// Load the anchor ship model with subsystems and all; it'll need to be done for this mission anyway
 		auto anchor_sip = anchor_ship_entry->sip();
-		modelnum = model_load(anchor_sip->pof_file, anchor_sip);
-		anchor_sip->model_num = modelnum;
+		anchor_sip->model_num = model_load(anchor_sip->pof_file, anchor_sip);
 
 		// resolve names to indexes
 		*path_mask = 0;
 		for	(j = 0; j < prp->num_paths; j++)
 		{
-			bay_path = model_find_bay_path(modelnum, prp->path_names[j]);
+			bay_path = model_find_bay_path(anchor_sip->model_num, prp->path_names[j]);
 			if (bay_path < 0)
 				continue;
 
@@ -7075,8 +7074,9 @@ bool post_process_mission(mission *pm)
 
 				if (valid) {
 					ship_info* sip = &Ship_info[icon.ship_class];
-					stage.icons[j].modelnum = model_load(sip->pof_file, sip);
-					sip->model_num = stage.icons[j].modelnum;
+					int modelnum = model_load(sip->pof_file, sip);
+					stage.icons[j].modelnum = modelnum;
+					sip->model_num = modelnum;
 				}
 			}
 		}
@@ -8945,11 +8945,10 @@ void check_anchor_for_hangar_bay(SCP_string &message, SCP_set<anchor_t> &anchors
 	{
 		// Load the anchor ship model with subsystems and all; it'll need to be done for this mission anyway
 		auto anchor_sip = anchor_ship_entry->sip();
-		int modelnum = model_load(anchor_sip->pof_file, anchor_sip);
-		anchor_sip->model_num = modelnum;
+		anchor_sip->model_num = model_load(anchor_sip->pof_file, anchor_sip);
 
 		// Check if this model has a hangar bay
-		if (!model_has_hangar_bay(modelnum))
+		if (!model_has_hangar_bay(anchor_sip->model_num))
 		{
 			sprintf(message, "%s (%s) is used as a%s anchor by %s %s (and possibly elsewhere too), but it does not have a hangar bay!", anchor_ship_entry->name,
 				anchor_sip->name, is_arrival ? "n arrival" : " departure", other_is_ship ? "ship" : "wing", other_name);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1005,9 +1005,11 @@ void model_free_all();
 void model_instance_free_all();
 
 // Alias to model_load, checks if a pof tech model exists and loads it if specified, otherwise loads the default pof. --wookieejedi
+// NOTE: Each time model_load is called with a ship_info pointer, which causes it to load subsystems, the model number MUST be assigned to the ship_info.
 int model_load(ship_info* sip, bool prefer_tech_model);
 
 // Loads a model from disk and returns the model number it loaded into.
+// NOTE: Each time model_load is called with a ship_info pointer, which causes it to load subsystems, the model number MUST be assigned to the ship_info.
 int model_load(const char *filename, ship_info* sip = nullptr, ErrorType error_type = ErrorType::FATAL_ERROR, bool allow_redundant_load = false);
 
 int model_create_instance(int objnum, int model_num);

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1005,11 +1005,11 @@ void model_free_all();
 void model_instance_free_all();
 
 // Alias to model_load, checks if a pof tech model exists and loads it if specified, otherwise loads the default pof. --wookieejedi
-// NOTE: Each time model_load is called with a ship_info pointer, which causes it to load subsystems, the model number MUST be assigned to the ship_info.
+// NOTE: Each time model_load is called with a ship_info pointer, which causes it to load subsystems, the model number is also assigned to the ship_info.
 int model_load(ship_info* sip, bool prefer_tech_model);
 
 // Loads a model from disk and returns the model number it loaded into.
-// NOTE: Each time model_load is called with a ship_info pointer, which causes it to load subsystems, the model number MUST be assigned to the ship_info.
+// NOTE: Each time model_load is called with a ship_info pointer, which causes it to load subsystems, the model number is also assigned to the ship_info.
 int model_load(const char *filename, ship_info* sip = nullptr, ErrorType error_type = ErrorType::FATAL_ERROR, bool allow_redundant_load = false);
 
 int model_create_instance(int objnum, int model_num);

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3245,6 +3245,8 @@ int model_load(const  char* filename, ship_info* sip, ErrorType error_type, bool
 			if (!stricmp(filename , Polygon_models[i]->filename) && !allow_redundant_load) {
 				// Model already loaded; just return.
 				Polygon_models[i]->used_this_mission++;
+				if (sip != nullptr)
+					sip->model_num = Polygon_models[i]->id;
 				return Polygon_models[i]->id;
 			}
 		} else if ( num == -1 )	{
@@ -3519,6 +3521,8 @@ int model_load(const  char* filename, ship_info* sip, ErrorType error_type, bool
 	model_set_bay_path_nums(pm);
 
 	unpause_parse();
+	if (sip != nullptr)
+		sip->model_num = pm->id;
 	return pm->id;
 }
 

--- a/freespace2/freespace.cpp
+++ b/freespace2/freespace.cpp
@@ -7437,11 +7437,11 @@ void Do_model_timings_test()
 	int model_id[MAX_POLYGON_MODELS];
 
 	// Load them all
-	for (auto & sip : Ship_info) {
-		sip.model_num = model_load(sip.pof_file);
+	for (auto & si : Ship_info) {
+		si.model_num = model_load(&si, false);
 
-		model_used[sip.model_num % MAX_POLYGON_MODELS]++;
-		model_id[sip.model_num % MAX_POLYGON_MODELS] = sip.model_num;
+		model_used[si.model_num % MAX_POLYGON_MODELS]++;
+		model_id[si.model_num % MAX_POLYGON_MODELS] = si.model_num;
 	}
 
 	Texture_fp = fopen( NOX("ShipTextures.txt"), "wt" );


### PR DESCRIPTION
Each time `model_load` is called with a `ship_info` pointer, which causes it to load subsystems, the model number MUST be assigned to the ship_info.