### PR TITLE
fix cmake warning

### DIFF
--- a/cmake/toolchain-msvc.cmake
+++ b/cmake/toolchain-msvc.cmake
@@ -74,9 +74,9 @@ endif()
 IF(MSVC_USE_RUNTIME_DLL OR FSO_BUILD_QTFRED)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<NOT:$<CONFIG:Release>>:Debug>DLL")
 	add_compile_definitions(_AFXDLL)
-ELSE(MSVC_USE_RUNTIME_DLL)
+ELSE()
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<NOT:$<CONFIG:Release>>:Debug>")
-ENDIF(MSVC_USE_RUNTIME_DLL)
+ENDIF()
 
 # Debug
 set(CMAKE_C_FLAGS_DEBUG "/W4 /Gy /Zi /Od /RTC1 /Gd /Oy-")


### PR DESCRIPTION
Per Claude:
> The `IF` opens with `(MSVC_USE_RUNTIME_DLL OR FSO_BUILD_QTFRED)` but the `ELSE` and `ENDIF` only reference `(MSVC_USE_RUNTIME_DLL)`. CMake requires the argument in `ELSE`/`ENDIF` to match the `IF` exactly (or be omitted).