### PR TITLE
Fix gauges not respecting table flags

### DIFF
--- a/code/hud/hudmessage.cpp
+++ b/code/hud/hudmessage.cpp
@@ -1342,6 +1342,18 @@ bool HudGaugeTalkingHead::canRender() const
 		return false;
 	}
 
+	if ((Viewer_mode & (VM_CHASE)) == 0 && only_render_in_chase_view) {
+		return false;
+	}
+
+	if (render_for_cockpit_toggle > 0) {
+		if (!(Viewer_mode & VM_CHASE) && Cockpit_active && (render_for_cockpit_toggle == 2)) {
+			return false;
+		} else if (!Cockpit_active && (render_for_cockpit_toggle == 1)) {
+			return false;
+		}
+	}
+
 	if(pop_up) {
 		if(!popUpActive()) {
 			return false;

--- a/code/hud/hudsquadmsg.cpp
+++ b/code/hud/hudsquadmsg.cpp
@@ -2860,6 +2860,18 @@ bool HudGaugeSquadMessage::canRender() const
 		return false;
 	}
 
+	if ((Viewer_mode & (VM_CHASE)) == 0 && only_render_in_chase_view) {
+		return false;
+	}
+
+	if (render_for_cockpit_toggle > 0) {
+		if (!(Viewer_mode & VM_CHASE) && Cockpit_active && (render_for_cockpit_toggle == 2)) {
+			return false;
+		} else if (!Cockpit_active && (render_for_cockpit_toggle == 1)) {
+			return false;
+		}
+	}
+
 	if (!( Player->flags & PLAYER_FLAGS_MSG_MODE )) {
 		return false;
 	}

--- a/code/mission/missiontraining.cpp
+++ b/code/mission/missiontraining.cpp
@@ -213,6 +213,18 @@ bool HudGaugeDirectives::canRender() const
 		return false;
 	}
 
+	if ((Viewer_mode & (VM_CHASE)) == 0 && only_render_in_chase_view) {
+		return false;
+	}
+
+	if (render_for_cockpit_toggle > 0) {
+		if (!(Viewer_mode & VM_CHASE) && Cockpit_active && (render_for_cockpit_toggle == 2)) {
+			return false;
+		} else if (!Cockpit_active && (render_for_cockpit_toggle == 1)) {
+			return false;
+		}
+	}
+
 	if(pop_up) {
 		if(!popUpActive()) {
 			return false;


### PR DESCRIPTION
These gauges override the base class canRender() call so these checks are needed here.

Fixes #5981