### PR TITLE
Remove redundant m_pos from CJumpNode; add GetRadius() accessor

### DIFF
--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -19,30 +19,28 @@ SCP_list<CJumpNode> Jump_nodes;
  * Constructor for CJumpNode class, default
  */
 CJumpNode::CJumpNode()
-{	
+{
     gr_init_alphacolor(&m_display_color, 0, 255, 0, 255);
 
 	m_name[0] = '\0';
 	m_display[0] = '\0';
-	
-    m_pos.xyz.x = 0.0f;
-    m_pos.xyz.y = 0.0f;
-    m_pos.xyz.z = 0.0f;
 }
 
 /**
  * Constructor for CJumpNode class, with world position argument
  */
 CJumpNode::CJumpNode(const vec3d* position)
-{	
-	Assert(position != NULL);
-	
+{
+	Assertion(position != nullptr, "Position should not be null!");
+	if (position == nullptr)
+		position = &vmd_zero_vector;
+
 	gr_init_alphacolor(&m_display_color, 0, 255, 0, 255);
-	
+
 	// Set m_name and m_display
 	sprintf(m_name, XSTR( "Jump Node %d", 632), Jump_nodes.size());
 	m_display[0] = '\0';
-	
+
 	// Set m_modelnum and m_radius
 	m_modelnum = model_load(NOX(JN_DEFAULT_MODEL), nullptr, ErrorType::WARNING);
 	if (m_modelnum == -1) {
@@ -50,15 +48,11 @@ CJumpNode::CJumpNode(const vec3d* position)
 	} else {
 		m_radius = model_get_radius(m_modelnum);
 	}
-	
-    m_pos.xyz.x = position->xyz.x;
-    m_pos.xyz.y = position->xyz.y;
-    m_pos.xyz.z = position->xyz.z;
-    
+
 	// Create the object
-    flagset<Object::Object_Flags> default_flags;
-    default_flags.set(Object::Object_Flags::Renders);
-    m_objnum = obj_create(OBJ_JUMP_NODE, -1, -1, NULL, &m_pos, m_radius, default_flags);
+	flagset<Object::Object_Flags> default_flags;
+	default_flags.set(Object::Object_Flags::Renders);
+	m_objnum = obj_create(OBJ_JUMP_NODE, -1, -1, nullptr, position, m_radius, default_flags);
 
 	if (m_modelnum >= 0) {
 		// set up animation in case of instrinsic_rotate
@@ -81,7 +75,6 @@ CJumpNode::CJumpNode(CJumpNode&& other) noexcept
 	other.m_fred_layer = "Default";
 
 	m_display_color = other.m_display_color;
-	m_pos = other.m_pos;
 
 	strcpy_s(m_name, other.m_name);
 	strcpy_s(m_display, other.m_display);
@@ -106,7 +99,6 @@ CJumpNode& CJumpNode::operator=(CJumpNode&& other) noexcept
 		other.m_fred_layer = "Default";
 
 		m_display_color = other.m_display_color;
-		m_pos = other.m_pos;
 
 		strcpy_s(m_name, other.m_name);
 		strcpy_s(m_display, other.m_display);
@@ -161,6 +153,14 @@ int CJumpNode::GetModelNumber() const
 }
 
 /**
+ * @return Radius of jump node model
+ */
+float CJumpNode::GetRadius() const
+{
+	return m_radius;
+}
+
+/**
  * @return Index into Objects[]
  */
 int CJumpNode::GetSCPObjectNumber() const
@@ -190,7 +190,8 @@ const color &CJumpNode::GetColor() const
  */
 const vec3d *CJumpNode::GetPosition() const
 {
-	return &m_pos;
+	Assert(m_objnum != -1);
+	return &Objects[m_objnum].pos;
 }
 
 /*
@@ -536,7 +537,7 @@ CJumpNode *jumpnode_get_which_in(const object *objp)
 		if(jnp->GetModelNumber() < 0)
 			continue;
 
-		radius = model_get_radius( jnp->GetModelNumber() );
+		radius = jnp->GetRadius();
 		dist = vm_vec_dist( &objp->pos, &jnp->GetSCPObject()->pos );
 		if ( dist <= radius ) {
 			return &(*jnp);

--- a/code/jumpnode/jumpnode.h
+++ b/code/jumpnode/jumpnode.h
@@ -45,7 +45,6 @@ private:
 
 	int m_flags {0};
 	color m_display_color;			// Color node will be shown in (Default:0/255/0/255)
-	vec3d m_pos;
 	SCP_string m_fred_layer = "Default";	// FRED view layer assignment
 
 	CJumpNode(const CJumpNode&);
@@ -65,6 +64,7 @@ public:
 	const char *GetName() const;
 	const char *GetDisplayName() const;
 	int GetModelNumber() const;
+	float GetRadius() const;
 	int GetSCPObjectNumber() const;
 	int GetPolymodelInstanceNum() const;
 	const object *GetSCPObject() const;


### PR DESCRIPTION
CJumpNode stored a private m_pos field that duplicated the position already held by its Objects[] entry.  The field was set once during construction and never updated afterward, so any subsequent movement (e.g. FRED dragging) would leave m_pos stale while Objects[m_objnum].pos held the authoritative value.  Every external caller already used GetSCPObject()->pos instead; GetPosition() had zero call sites.

- Remove the m_pos field and its initialization in both constructors, the move constructor, and the move-assignment operator.
- Pass the constructor's position argument directly to obj_create() instead of routing through m_pos.
- Repoint GetPosition() at Objects[m_objnum].pos so it always returns the live, up-to-date position.
- Add GetRadius() to expose the cached m_radius, and use it in jumpnode_get_which_in() instead of the redundant model_get_radius() call.