### PR TITLE
refactor CJumpNode to use SCP_vector

### DIFF
--- a/code/hud/hudtargetbox.cpp
+++ b/code/hud/hudtargetbox.cpp
@@ -1322,13 +1322,12 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 	matrix		camera_orient = IDENTITY_MATRIX;
 	float			factor, dist;
 	int			hx = 0, hy = 0, w, h;
-	SCP_list<CJumpNode>::iterator jnp;
-	
-	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
-		if(jnp->GetSCPObject() != target_objp)
+	int target_objnum = OBJ_INDEX(target_objp);
+	for (auto &jnp : Jump_nodes) {
+		if(jnp.GetSCPObjectNumber() != target_objnum)
 			continue;
-	
-		if ( jnp->IsHidden() ) {
+
+		if ( jnp.IsHidden() ) {
 			set_target_objnum( Player_ai, -1 );
 			return;
 		}
@@ -1357,7 +1356,7 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 				gr_stencil_set(GR_STENCIL_READ);
 			}
 
-			jnp->Render( &obj_pos );
+			jnp.Render( &obj_pos );
 
 			if ( Monitor_mask >= 0 ) {
 				gr_stencil_set(GR_STENCIL_NONE);
@@ -1370,7 +1369,7 @@ void HudGaugeTargetBox::renderTargetJumpNode(object *target_objp)
 		renderTargetIntegrity(1);
 		setGaugeColor();
 
-		renderString(position[0] + Name_offsets[0], position[1] + Name_offsets[1], EG_TBOX_NAME, jnp->GetDisplayName());
+		renderString(position[0] + Name_offsets[0], position[1] + Name_offsets[1], EG_TBOX_NAME, jnp.GetDisplayName());
 
 		dist = Player_ai->current_target_distance;
 		if ( Hud_unit_multiplier > 0.0f ) {	// use a different displayed distance scale

--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -13,7 +13,7 @@
 #include "model/model.h"
 #include "model/modelrender.h"
 
-SCP_list<CJumpNode> Jump_nodes;
+SCP_vector<CJumpNode> Jump_nodes;
 
 /**
  * Constructor for CJumpNode class, default
@@ -64,48 +64,21 @@ CJumpNode::CJumpNode(const vec3d* position)
 	}
 }
 
-CJumpNode::CJumpNode(CJumpNode&& other) noexcept
-	: m_radius(std::exchange(other.m_radius, 0.0f)), m_modelnum(std::exchange(other.m_modelnum, -1)), m_objnum(std::exchange(other.m_objnum, -1)), m_polymodel_instance_num(std::exchange(other.m_polymodel_instance_num, -1)), m_flags(std::exchange(other.m_flags, 0)), m_fred_layer(std::exchange(other.m_fred_layer, "Default"))
+/**
+ * Free the polymodel instance and unload the model, if applicable
+ */
+void CJumpNode::FreeModelResources()
 {
-	m_display_color = other.m_display_color;
-
-	strcpy_s(m_name, other.m_name);
-	strcpy_s(m_display, other.m_display);
-}
-
-CJumpNode& CJumpNode::operator=(CJumpNode&& other) noexcept
-{
-	if (this != &other)
+	if (m_polymodel_instance_num >= 0)
 	{
-		m_radius = std::exchange(other.m_radius, 0.0f);
-		m_modelnum = std::exchange(other.m_modelnum, -1);
-		m_objnum = std::exchange(other.m_objnum, -1);
-		m_flags = std::exchange(other.m_flags, 0);
-		m_polymodel_instance_num = std::exchange(other.m_polymodel_instance_num, -1);
-		m_fred_layer = std::exchange(other.m_fred_layer, "Default");
-
-		m_display_color = other.m_display_color;
-
-		strcpy_s(m_name, other.m_name);
-		strcpy_s(m_display, other.m_display);
+		model_delete_instance(m_polymodel_instance_num);
+		m_polymodel_instance_num = -1;
 	}
 
-	return *this;
-}
-
-/**
- * Destructor for CJumpNode class
- */
-CJumpNode::~CJumpNode()
-{
 	if (m_modelnum >= 0)
 	{
 		model_unload(m_modelnum);
-	}
-
-	if (m_objnum >= 0 && Objects[m_objnum].type != OBJ_NONE)
-	{
-		obj_delete(m_objnum);
+		m_modelnum = -1;
 	}
 }
 
@@ -159,8 +132,8 @@ int CJumpNode::GetSCPObjectNumber() const
  */
 const object *CJumpNode::GetSCPObject() const
 {
-	Assert(m_objnum != -1);
-    return &Objects[m_objnum];
+	Assertion(m_objnum >= 0, "jump node does not have an object number!");
+	return &Objects[m_objnum];
 }
 
 /**
@@ -235,10 +208,9 @@ void CJumpNode::SetModel(const char *model_name, bool show_polys)
 		Warning(LOCATION, "Couldn't load model file %s for jump node %s", model_name, m_name);
 		return;
 	}
-	
+
 	//If there's an old model, unload it
-	if(m_modelnum != -1)
-		model_unload(m_modelnum);
+	FreeModelResources();
 
 	//Now actually set stuff
 	m_modelnum = new_model;
@@ -260,6 +232,13 @@ void CJumpNode::SetModel(const char *model_name, bool show_polys)
 		m_flags |= JN_SHOW_POLYS;
 	else
 		m_flags &= ~JN_SHOW_POLYS;
+
+	// refresh the model instance
+	auto pm = model_get(m_modelnum);
+	if (pm->flags & PM_FLAG_HAS_INTRINSIC_MOTION)
+		m_polymodel_instance_num = model_create_instance(m_objnum, m_modelnum);
+	else
+		m_polymodel_instance_num = -1;
 }
 
 /**
@@ -470,15 +449,30 @@ void CJumpNode::Render(model_draw_list *scene, const vec3d *pos, const vec3d *vi
  */
 CJumpNode *jumpnode_get_by_name(const char* name)
 {
-	Assert(name != NULL);
-	SCP_list<CJumpNode>::iterator jnp;
+	Assert(name != nullptr);
 
-	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {	
-		if(!stricmp(jnp->GetName(), name)) 
-			return &(*jnp);
-	}
+	for (auto &jn : Jump_nodes)
+		if (!stricmp(jn.GetName(), name))
+			return &jn;
 
-	return NULL;
+	return nullptr;
+}
+
+/**
+ * Get jump node index by given name
+ *
+ * @param name Name of jump node
+ * @return Jump node index
+ */
+int jumpnode_lookup(const char *name)
+{
+	Assert(name != nullptr);
+
+	for (size_t i = 0; i < Jump_nodes.size(); i++)
+		if (!stricmp(Jump_nodes[i].GetName(), name))
+			return sz2i(i);
+
+	return -1;
 }
 
 /**
@@ -508,13 +502,8 @@ CJumpNode *jumpnode_get_by_objnum(int objnum)
 CJumpNode *jumpnode_get_by_objp(const object *objp)
 {
 	Assert(objp != nullptr);
-
-	for (CJumpNode &jnp : Jump_nodes) {
-		if (jnp.GetSCPObject() == objp)
-			return &(jnp);
-	}
-
-	return nullptr;
+	int objnum = OBJ_INDEX(objp);
+	return jumpnode_get_by_objnum(objnum);
 }
 
 /**
@@ -526,17 +515,15 @@ CJumpNode *jumpnode_get_by_objp(const object *objp)
 CJumpNode *jumpnode_get_which_in(const object *objp)
 {
 	Assert(objp != NULL);
-	SCP_list<CJumpNode>::iterator jnp;
-	float radius, dist;
 
-	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
-		if(jnp->GetModelNumber() < 0)
+	for (auto &jnp : Jump_nodes) {
+		if (jnp.GetModelNumber() < 0)
 			continue;
 
-		radius = jnp->GetRadius();
-		dist = vm_vec_dist( &objp->pos, &jnp->GetSCPObject()->pos );
+		float radius = jnp.GetRadius();
+		float dist = vm_vec_dist( &objp->pos, &jnp.GetSCPObject()->pos );
 		if ( dist <= radius ) {
-			return &(*jnp);
+			return &jnp;
 		}
 	}
 
@@ -550,11 +537,8 @@ CJumpNode *jumpnode_get_which_in(const object *objp)
  */
 void jumpnode_render_all()
 {
-	SCP_list<CJumpNode>::iterator jnp;
-	
-	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {	
-		jnp->Render(&jnp->GetSCPObject()->pos);
-	}
+	for (auto &jnp : Jump_nodes)
+		jnp.Render(&jnp.GetSCPObject()->pos);
 }
 
 /**
@@ -564,4 +548,25 @@ void jumpnode_level_close()
 {
 	// Clear all jump nodes.  Note that this can happen either before or after objects are cleaned up.
 	Jump_nodes.clear();
+}
+
+/**
+ * Delete the jump node corresponding to this object.  Since this is called from obj_delete(),
+ * it frees the node's resources and detaches it from the object, but it does not delete the
+ * object itself, nor does it remove the node from the Jump_nodes vector.
+ *
+ * @param objp Object pointer
+ */
+void jumpnode_delete(object *objp)
+{
+	Assert(objp != nullptr);
+	Assert(objp->type == OBJ_JUMP_NODE);
+
+	auto jn = jumpnode_get_by_objnum(OBJ_INDEX(objp));
+	Assertion(jn != nullptr, "Jump node object %d does not correspond to a CJumpNode!", OBJ_INDEX(objp));
+	if (jn == nullptr)
+		return;
+
+	jn->FreeModelResources();
+	jn->m_objnum = -1;
 }

--- a/code/jumpnode/jumpnode.h
+++ b/code/jumpnode/jumpnode.h
@@ -47,18 +47,22 @@ private:
 	color m_display_color;			// Color node will be shown in (Default:0/255/0/255)
 	SCP_string m_fred_layer = "Default";	// FRED view layer assignment
 
-	CJumpNode(const CJumpNode&);
-	CJumpNode& operator=(const CJumpNode&) = delete;
+	// jumpnode_delete() detaches the node from its object by resetting m_objnum
+	friend void jumpnode_delete(object *objp);
+
 public:
 	//Constructors
 	CJumpNode();
 	CJumpNode(const vec3d *position);
-	CJumpNode(CJumpNode&& other) noexcept;
 
-	CJumpNode& operator=(CJumpNode&&) noexcept;
+	// Following the pattern of other object types, a CJumpNode does not free its object or model
+	// resources on destruction; that is done by jumpnode_delete(), via obj_delete().  So jump nodes
+	// can be safely moved around, e.g. by SCP_vector operations.
+	CJumpNode(CJumpNode&&) noexcept = default;
+	CJumpNode& operator=(CJumpNode&&) noexcept = default;
 
-	//Destructor
-	~CJumpNode();
+	CJumpNode(const CJumpNode&) = delete;
+	CJumpNode& operator=(const CJumpNode&) = delete;
 
 	//Getting
 	const char *GetName() const;
@@ -78,6 +82,9 @@ public:
 	void SetDisplayName(const char* new_name);
 	void SetVisibility(bool enabled);
 
+	//Resource management
+	void FreeModelResources();
+
 	//Getting/Setting FRED layer
 	const SCP_string& GetFredLayer() const { return m_fred_layer; }
 	void SetFredLayer(const SCP_string& layer) { m_fred_layer = layer; }
@@ -94,15 +101,17 @@ public:
 };
 
 //-----Globals------
-extern SCP_list<CJumpNode> Jump_nodes;
+extern SCP_vector<CJumpNode> Jump_nodes;
 
 //-----Functions-----
 CJumpNode *jumpnode_get_by_name(const char *name);
+      int  jumpnode_lookup(const char *name);
 CJumpNode *jumpnode_get_by_objnum(int objnum);
 CJumpNode *jumpnode_get_by_objp(const object *objp);
 CJumpNode *jumpnode_get_which_in(const object *objp);
 
 void jumpnode_render_all();
 void jumpnode_level_close();
+void jumpnode_delete(object *objp);
 
 #endif

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -4920,57 +4920,59 @@ int Fred_mission_save::save_waypoints()
 	parse_comments(2);
 	fout("\t\t;! %d lists total\n", Waypoint_lists.size());
 
-	SCP_list<CJumpNode>::iterator jnp;
-	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
+	for (auto &jn : Jump_nodes) {
+		if (jn.GetSCPObjectNumber() < 0)
+			continue;
+
 		required_string_fred("$Jump Node:", "$Jump Node Name:");
 		parse_comments(2);
-		save_vector(jnp->GetSCPObject()->pos);
+		save_vector(jn.GetSCPObject()->pos);
 
 		required_string_fred("$Jump Node Name:", "$Jump Node:");
 		parse_comments();
-		fout(" %s", jnp->GetName());
+		fout(" %s", jn.GetName());
 
 		if (save_config.save_format != MissionFormat::RETAIL) {
 
 			// (If we are always saving display names, the "only/not written" comments do not apply)
 			// The display name is only written if it currently exists, to avoid introducing inconsistencies
-			if (save_config.always_save_display_names || jnp->HasDisplayName()) {
+			if (save_config.always_save_display_names || jn.HasDisplayName()) {
 				char truncated_name[NAME_LENGTH];
-				strcpy_s(truncated_name, jnp->GetName());
+				strcpy_s(truncated_name, jn.GetName());
 				end_string_at_first_hash_symbol(truncated_name);
 
 				// Also, the display name is not written if it's just the truncation of the name at the hash
-				if (save_config.always_save_display_names || strcmp(jnp->GetDisplayName(), truncated_name) != 0) {
+				if (save_config.always_save_display_names || strcmp(jn.GetDisplayName(), truncated_name) != 0) {
 					if (optional_string_fred("+Display Name:", "$Jump Node:")) {
 						parse_comments();
 					} else {
 						fout("\n+Display Name:");
 					}
 
-					fout_ext("", "%s", jnp->GetDisplayName());
+					fout_ext("", "%s", jn.GetDisplayName());
 				}
 			}
 
-			if (jnp->IsSpecialModel()) {
+			if (jn.IsSpecialModel()) {
 				if (optional_string_fred("+Model File:", "$Jump Node:")) {
 					parse_comments();
 				} else {
 					fout("\n+Model File:");
 				}
 
-				int model = jnp->GetModelNumber();
+				int model = jn.GetModelNumber();
 				polymodel* pm = model_get(model);
 				fout(" %s", pm->filename);
 			}
 
-			if (jnp->IsColored()) {
+			if (jn.IsColored()) {
 				if (optional_string_fred("+Alphacolor:", "$Jump Node:")) {
 					parse_comments();
 				} else {
 					fout("\n+Alphacolor:");
 				}
 
-				const auto& jn_color = jnp->GetColor();
+				const auto& jn_color = jn.GetColor();
 				fout(" %u %u %u %u", jn_color.red, jn_color.green, jn_color.blue, jn_color.alpha);
 			}
 
@@ -4978,17 +4980,17 @@ int Fred_mission_save::save_waypoints()
 			if (hidden_is_there)
 				parse_comments();
 
-			if (hidden_is_there || jnp->IsHidden()) {
+			if (hidden_is_there || jn.IsHidden()) {
 				if (!hidden_is_there)
 					fout("\n+Hidden:");
 
-				if (jnp->IsHidden())
+				if (jn.IsHidden())
 					fout(" %s", "true");
 				else
 					fout(" %s", "false");
 			}
 
-			const SCP_string& jn_layer = jnp->GetFredLayer();
+			const SCP_string& jn_layer = jn.GetFredLayer();
 			if (!jn_layer.empty() && !lcase_equal(jn_layer, "Default")) {
 				if (optional_string_fred("+Layer:", "$Jump Node:"))
 					parse_comments();

--- a/code/missioneditor/sexp_tree_opf.cpp
+++ b/code/missioneditor/sexp_tree_opf.cpp
@@ -1026,9 +1026,8 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_jump_nodes()
 {
 	sexp_list_item head;
 
-	SCP_list<CJumpNode>::iterator jnp;
-	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
-		head.add_data( jnp->GetName());
+	for (auto &jn : Jump_nodes) {
+		head.add_data(jn.GetName());
 	}
 
 	return head.next;

--- a/code/object/object.cpp
+++ b/code/object/object.cpp
@@ -735,7 +735,8 @@ void obj_delete(int objnum)
 	case OBJ_POINT:
 		break;  // requires no action, handled by the Fred code.
 	case OBJ_JUMP_NODE:
-		break;  // requires no further action, handled by jumpnode deconstructor.
+		jumpnode_delete(objp);
+		break;
 	case OBJ_DEBRIS:
 		debris_delete( objp );
 		break;
@@ -1940,15 +1941,17 @@ void obj_queue_render(object* obj, model_draw_list* scene)
 	case OBJ_ASTEROID:
 		asteroid_render(obj, scene);
 		break;
-	case OBJ_JUMP_NODE:
-		for ( SCP_list<CJumpNode>::iterator jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp ) {
-			if ( jnp->GetSCPObject() != obj ) {
+	case OBJ_JUMP_NODE: {
+		int objnum = OBJ_INDEX(obj);
+		for ( auto &jnp : Jump_nodes ) {
+			if ( jnp.GetSCPObjectNumber() != objnum ) {
 				continue;
 			}
 
-			jnp->Render(scene, &obj->pos, &Eye_position);
+			jnp.Render(scene, &obj->pos, &Eye_position);
 		}
 		break;
+	}
 	case OBJ_WAYPOINT:
 		// 		if (Show_waypoints)	{
 		// 			gr_set_color( 128, 128, 128 );

--- a/fred2/dumpstats.cpp
+++ b/fred2/dumpstats.cpp
@@ -395,9 +395,8 @@ void DumpStats::get_object_stats(CString &buffer)
 	// Jumpnodes
 	buffer += "\r\nJUMPNODES\r\n";
 
-	SCP_list<CJumpNode>::iterator jnp;
-	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
-		temp.Format("\tJumpnode: %s\r\n", jnp->GetName());
+	for (auto &jnp : Jump_nodes) {
+		temp.Format("\tJumpnode: %s\r\n", jnp.GetName());
 		buffer += temp;
 	}
 

--- a/fred2/jumpnodedlg.cpp
+++ b/fred2/jumpnodedlg.cpp
@@ -86,20 +86,18 @@ BOOL jumpnode_dlg::Create()
 void jumpnode_dlg::OnInitMenu(CMenu* pMenu)
 {
 	int i;
-	SCP_list<CJumpNode>::iterator jnp;
 	CMenu *m;
 
 	m = pMenu->GetSubMenu(0);
 	clear_menu(m);
 
-	i = 0; 
-	for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
-		m->AppendMenu(MF_ENABLED | MF_STRING, ID_JUMP_NODE_MENU + i, jnp->GetName());
-		if (jnp->GetSCPObjectNumber() == cur_object_index) {
+	i = 0;
+	for (auto &jnp : Jump_nodes) {
+		m->AppendMenu(MF_ENABLED | MF_STRING, ID_JUMP_NODE_MENU + i, jnp.GetName());
+		if (jnp.GetSCPObjectNumber() == cur_object_index) {
 			m->CheckMenuItem(ID_JUMP_NODE_MENU + i,  MF_BYCOMMAND | MF_CHECKED);
 		}
 		i++;
-
 	}
 
 	m->DeleteMenu(ID_PLACEHOLDER, MF_BYCOMMAND);

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -10,6 +10,7 @@
 
 
 #include "stdafx.h"
+#include <algorithm>
 #include "FRED.h"
 #include "MainFrm.h"
 #include "FREDDoc.h"
@@ -1245,7 +1246,7 @@ int common_object_delete(int obj)
 	char msg[255];
 	const char *name;
 	int i, z, r, type;
-	SCP_list<CJumpNode>::iterator jnp;
+	auto jnp = Jump_nodes.end();
 
 	type = Objects[obj].type;
 	if (type == OBJ_START) {
@@ -1360,6 +1361,7 @@ int common_object_delete(int obj)
 
 	} else if (type == OBJ_PROP) {
 		// Delete briefing icons maybe?
+
 	} else if (type == OBJ_POINT) {
 		Assert(Briefing_dialog);
 		Briefing_dialog->delete_icon(Objects[obj].instance);
@@ -1367,31 +1369,21 @@ int common_object_delete(int obj)
 		return 0;
 
 	} else if (type == OBJ_JUMP_NODE) {
-		for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
-			if(jnp->GetSCPObject() == &Objects[obj])
-				break;
-		}
-
-		// come on, WMC, we don't want to call obj_delete twice...
-		// fool the destructor into not calling obj_delete yet
-		Objects[obj].type = OBJ_NONE;
-		
-		// now call the destructor
-		if (jnp != Jump_nodes.end())
-			Jump_nodes.erase(jnp);
-
-		// now restore the jump node type so that the below unmark and obj_delete will work
-		Objects[obj].type = OBJ_JUMP_NODE;
+		// find the jump node while the object still exists; the defunct entry is removed below
+		jnp = std::find_if(Jump_nodes.begin(), Jump_nodes.end(),
+			[obj](const CJumpNode &jn) { return jn.GetSCPObjectNumber() == obj; });
 	}
 
 	unmark_object(obj);
 
-	//we need to call obj_delete() even if obj is a jump node
-	//the statement "delete Objects[obj].jnp" deletes the jnp object
-	//obj_delete() frees up the object slot where the node used to reside.
-	//if we don't call this then the node will still show up in fred and you can try to delete it twice
-	//this causes an ugly crash.
+	//obj_delete() handles all type-specific cleanup and frees up the object slot where the object used to reside
 	obj_delete(obj);
+
+	//for jump nodes, obj_delete() frees the node's resources via jumpnode_delete(), but the
+	//editor is responsible for removing the defunct entry from the Jump_nodes vector
+	if (jnp != Jump_nodes.end())
+		Jump_nodes.erase(jnp);
+
 	set_modified();
 	Update_window = 1;
 	return 0;

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -1,5 +1,6 @@
 #include "Editor.h"
 
+#include <algorithm>
 #include <array>
 #include <vector>
 #include <stdexcept>
@@ -990,7 +991,7 @@ int Editor::common_object_delete(int obj) {
 	char msg[255];
 	const char *name;
 	int i, z, r, type;
-	SCP_list<CJumpNode>::iterator jnp;
+	auto jnp = Jump_nodes.end();
 
 	type = Objects[obj].type;
 	if (type == OBJ_START) {
@@ -1112,32 +1113,20 @@ int Editor::common_object_delete(int obj) {
 		}
 
 	} else if (type == OBJ_JUMP_NODE) {
-		for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
-			if (jnp->GetSCPObject() == &Objects[obj]) {
-				break;
-			}
-		}
-
-		// come on, WMC, we don't want to call obj_delete twice...
-		// fool the destructor into not calling obj_delete yet
-		Objects[obj].type = OBJ_NONE;
-
-		// now call the destructor
-		if (jnp != Jump_nodes.end())
-			Jump_nodes.erase(jnp);
-
-		// now restore the jump node type so that the below unmark and obj_delete will work
-		Objects[obj].type = OBJ_JUMP_NODE;
+		// find the jump node while the object still exists; the defunct entry is removed below
+		jnp = std::find_if(Jump_nodes.begin(), Jump_nodes.end(),
+			[obj](const CJumpNode &jn) { return jn.GetSCPObjectNumber() == obj; });
 	}
 
 	unmarkObject(obj);
 
-	//we need to call obj_delete() even if obj is a jump node
-	//the statement "delete Objects[obj].jnp" deletes the jnp object
-	//obj_delete() frees up the object slot where the node used to reside.
-	//if we don't call this then the node will still show up in fred and you can try to delete it twice
-	//this causes an ugly crash.
+	//obj_delete() handles all type-specific cleanup and frees up the object slot where the object used to reside
 	obj_delete(obj);
+
+	//for jump nodes, obj_delete() frees the node's resources via jumpnode_delete(), but the
+	//editor is responsible for removing the defunct entry from the Jump_nodes vector
+	if (jnp != Jump_nodes.end())
+		Jump_nodes.erase(jnp);
 
 	return 0;
 }


### PR DESCRIPTION
Jump nodes previously used SCP_list; refactor to use SCP_vector.  Also improve resource handling and life cycle management.

Follow-up to, and depends on, #7431.  ~~In draft pending sexp_tree changes.~~