### PR TITLE
fix FRED2 MFC linkage when building qtFRED

### DIFF
--- a/cmake/toolchain-msvc.cmake
+++ b/cmake/toolchain-msvc.cmake
@@ -71,6 +71,7 @@ if (MSVC_RELEASE_DEBUGGING)
 	endif()
 endif()
 
+# This should be kept in sync with the corresponding IF() in fred2/CMakeLists.txt
 IF(MSVC_USE_RUNTIME_DLL OR FSO_BUILD_QTFRED)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<NOT:$<CONFIG:Release>>:Debug>DLL")
 	add_compile_definitions(_AFXDLL)

--- a/fred2/CMakeLists.txt
+++ b/fred2/CMakeLists.txt
@@ -164,11 +164,12 @@ set_source_files_properties(fred.rc PROPERTIES
 	LANGUAGE RC
 )
 
-IF(MSVC_USE_RUNTIME_DLL)
+# This should be kept in sync with the corresponding IF() in cmake/toolchain-msvc.cmake
+IF(MSVC_USE_RUNTIME_DLL OR FSO_BUILD_QTFRED)
 	set(CMAKE_MFC_FLAG 2)
-ELSE(MSVC_USE_RUNTIME_DLL)
+ELSE()
 	set(CMAKE_MFC_FLAG 1)
-ENDIF(MSVC_USE_RUNTIME_DLL)
+ENDIF()
 
 IF(MSVC60)
 	link_directories(${STLPORT_INCLUDE_LIB_DIRS})
@@ -197,8 +198,15 @@ FIND_PACKAGE(OpenGL REQUIRED)
 target_link_libraries(FRED2 PUBLIC "${OPENGL_LIBRARY}")
 
 TARGET_LINK_LIBRARIES(FRED2 PUBLIC code) # This will also link all dependencies of code
-TARGET_LINK_LIBRARIES(FRED2 PUBLIC "$<$<NOT:$<CONFIG:Release>>:nafxcwd.lib>")
-TARGET_LINK_LIBRARIES(FRED2 PUBLIC "$<$<CONFIG:Release>:nafxcw.lib>")
+
+# When CMAKE_MFC_FLAG=2 (DLL MFC) MSBuild already links the DLL MFC stub libs (mfcs*.lib);
+# explicitly adding the static MFC libs (nafxcw*) on top causes IsDerivedFrom to be resolved
+# from the static MFC copy while CRuntimeClass structs are initialized in the DLL form,
+# crashing CDocTemplate's ctor on startup.
+IF(NOT (MSVC_USE_RUNTIME_DLL OR FSO_BUILD_QTFRED))
+	TARGET_LINK_LIBRARIES(FRED2 PUBLIC "$<$<NOT:$<CONFIG:Release>>:nafxcwd.lib>")
+	TARGET_LINK_LIBRARIES(FRED2 PUBLIC "$<$<CONFIG:Release>:nafxcw.lib>")
+ENDIF()
 
 target_link_libraries(FRED2 PUBLIC glad_wgl)
 


### PR DESCRIPTION
PR #7334 caused an unintended side effect when building both FRED and QtFRED.  With QtFRED enabled, FRED2 sources were compiled with _AFXDLL defined while still linking against static MFC, causing a crash on startup.  To fix this, keep the conditionals in sync between cmake/toolchain-msvc.cmake and fred2/CMakeLists.txt.

Also, do not explicitly add static MFC libraries if we are using dynamic linking.