### PR TITLE
Model surface particles

### DIFF
--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -578,7 +578,6 @@ public:
 	size_t stride;
 	size_t vertex_offset;
 	size_t vertex_num_offset;
-	size_t n_verts;
 
 	poly_list *model_list;
 

--- a/code/graphics/2d.h
+++ b/code/graphics/2d.h
@@ -578,6 +578,7 @@ public:
 	size_t stride;
 	size_t vertex_offset;
 	size_t vertex_num_offset;
+	size_t n_verts;
 
 	poly_list *model_list;
 

--- a/code/model/model_flags.h
+++ b/code/model/model_flags.h
@@ -10,6 +10,7 @@ namespace Model {
 		Is_live_debris,					// whether current submodel is a live debris model
 		Is_thruster,					// is an engine thruster submodel
 		Is_damaged,						// is a submodel that represents a damaged submodel (e.g. a -destroyed version of some other submodel)
+		Is_lod,							// is a submodel that is a lower LOD of a different submodel
 		Do_not_scale_detail_distances,	// if set should not scale boxes or spheres based on 'model detail' settings
 		Gun_rotation,					// for animated weapon models
 		Instant_rotate_accel,			// rotating submodels instantly reach their desired velocity

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -3457,6 +3457,7 @@ int model_load(const  char* filename, ship_info* sip, ErrorType error_type, bool
 					if (dl2 >= sm1->num_details ) sm1->num_details = dl2+1;
 					sm1->details[dl2] = j;
   				    mprintf(( "Submodel '%s' is detail level %d of '%s'\n", sm2->name, dl2 + 1, sm1->name ));
+					sm2->flags.set(Model::Submodel_flags::Is_lod);
 					lower_to_higher_detail_submodels.emplace(sm2->name, sm1->name);
 				}
 			}

--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -72,6 +72,10 @@ SCP_vector<bsp_collision_tree> Bsp_collision_tree_list;
 
 const ubyte* Macro_ubyte_bounds = nullptr;
 
+//If true, CPU-side vertex buffers are deleted once the model is on-GPU.
+//This is typically desired for memory reasons, but will prevent certain type of particles.
+bool Model_load_clear_CPU_buffers = true;
+
 static int model_initted = 0;
 
 #ifndef NDEBUG
@@ -1138,7 +1142,8 @@ void create_vertex_buffer(polymodel *pm, const model_read_deferred_tasks& deferr
 		interp_pack_vertex_buffers(pm, i);
 
 		// release temporary memory
-		pm->submodel[i].buffer.release();
+		if (Model_load_clear_CPU_buffers)
+			pm->submodel[i].buffer.release();
 		pm->submodel[i].trans_buffer.release();
 	}
 

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -29,6 +29,8 @@ extern color Wireframe_color;
 
 extern int Lab_object_detail_level;
 
+extern bool Model_load_clear_CPU_buffers;
+
 typedef enum {
 	TECH_SHIP,
 	TECH_WEAPON,

--- a/code/particle/EffectHost.h
+++ b/code/particle/EffectHost.h
@@ -27,6 +27,7 @@ public:
 	}
 
 	virtual std::pair<int, int> getParentObjAndSig() const { return {-1, -1}; }
+	virtual int getParentSubmodel() const { return -1; }
 
 	virtual float getLifetime() const { return -1.f; }
 

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -185,6 +185,28 @@ void ParticleEffect::sampleNoise(vec3d& noiseTarget, const matrix* orientation, 
 	vm_vec_unrotate(&noiseTarget, &noiseSampleLocal, orientation);
 }
 
+vec3d ParticleEffect::adaptPosition(const vec3d& pos, int parent) const {
+	if (parent < 0 || !m_local_position_scaling.has_value()) {
+		return pos;
+	}
+
+	vec3d pos_local = pos;
+
+	if (!m_parent_local) {
+		pos_local -= Objects[parent].pos;
+		vm_vec_rotate(&pos_local, &pos_local, &Objects[parent].orient);
+	}
+
+	pos_local *= m_local_position_scaling->next();
+
+	if (!m_parent_local) {
+		vm_vec_unrotate(&pos_local, &pos_local, &Objects[parent].orient);
+		vm_vec_add2(&pos_local, &Objects[parent].pos);
+	}
+
+	return pos_local;
+}
+
 /*
  * In persistent mode (should only ever be used by scripting, really), this function returns pointers to the persistent particles
  * In non-persistent mode, this function returns the multiplier for the next spawn time. This is because the source cannot know about the curve evaluation that is required to get this factor
@@ -213,7 +235,8 @@ auto ParticleEffect::processSourceInternal(float interp, const ParticleSource& s
 		}
 	}
 
-	const auto& [pos, hostOrientation] = source.m_host->getPositionAndOrientation(m_parent_local, interp, m_manual_offset);
+	const auto& [pos_hit, hostOrientation] = source.m_host->getPositionAndOrientation(m_parent_local, interp, m_manual_offset);
+	const vec3d& pos = adaptPosition(pos_hit, parent);
 
 	vec3d posGlobal = pos;
 	if (m_parent_local && parent >= 0) {

--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -290,11 +290,11 @@ auto ParticleEffect::processSourceInternal(float interp, const ParticleSource& s
 		vec3d localPos = posNoise;
 
 		if (m_spawnVolume != nullptr) {
-			localPos += m_spawnVolume->sampleRandomPoint(orientation, modularCurvesInput, particleFraction);
+			localPos += m_spawnVolume->sampleRandomPoint(orientation, modularCurvesInput, particleFraction, *source.m_host);
 		}
 
 		if (m_velocityVolume != nullptr) {
-			localVelocity += m_velocityVolume->sampleRandomPoint(orientation, modularCurvesInput, particleFraction) * (m_velocity_scaling.next() * velocityVolumeMultiplier);
+			localVelocity += m_velocityVolume->sampleRandomPoint(orientation, modularCurvesInput, particleFraction, *source.m_host) * (m_velocity_scaling.next() * velocityVolumeMultiplier);
 		}
 
 		if (m_manual_velocity_offset.has_value()) {

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -168,6 +168,7 @@ public:
 
 	std::optional<::util::ParsedRandomFloatRange> m_vel_inherit_from_orientation;
 	std::optional<::util::ParsedRandomFloatRange> m_vel_inherit_from_position;
+	std::optional<::util::ParsedRandomFloatRange> m_local_position_scaling;
 
 	std::shared_ptr<::particle::ParticleVolume> m_velocityVolume;
 	std::shared_ptr<::particle::ParticleVolume> m_spawnVolume;
@@ -186,6 +187,7 @@ public:
 	float m_distanceCulled; //Kinda deprecated. Only used by the oldest of legacy effects.
 
 	matrix getNewDirection(const matrix& hostOrientation, const std::optional<vec3d>& normal) const;
+	vec3d adaptPosition(const vec3d& pos, int parent) const;
 
 	template<bool isPersistent>
 	auto processSourceInternal(float interp, const ParticleSource& source, size_t effectNumber, const vec3d& velParent, int parent, int parent_sig, float parentLifetime, float parentRadius, float particle_percent) const;

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -7,6 +7,8 @@
 
 #include <anl.h>
 
+#include "volumes/ModelSurfaceVolume.h"
+
 namespace particle {
 
 	//
@@ -125,7 +127,7 @@ namespace particle {
 
 		static std::shared_ptr<ParticleVolume> parseVolume() {
 
-			int type = required_string_one_of(4, "Spheroid", "Cone", "Ring", "Point"); //... and future volumes
+			int type = required_string_one_of(5, "Spheroid", "Cone", "Ring", "Point", "ModelSurface"); //... and future volumes
 			std::shared_ptr<ParticleVolume> volume;
 
 			switch (type) {
@@ -144,6 +146,10 @@ namespace particle {
 				case 3:
 					required_string("Point");
 					volume = std::make_shared<PointVolume>();
+					break;
+				case 4:
+					required_string("ModelSurface");
+					volume = std::make_shared<ModelSurfaceVolume>();
 					break;
 				default:
 					UNREACHABLE("Invalid volume type specified!");

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -94,6 +94,12 @@ namespace particle {
 			}
 		}
 
+		static void parseLocalPositionScaling(ParticleEffect& effect) {
+			if (optional_string("+Local position scaling:")) {
+				effect.m_local_position_scaling = ::util::ParsedRandomFloatRange::parseRandomRange();
+			}
+		}
+
 		static void parseParentLocal(ParticleEffect& effect) {
 			if (optional_string("+Remain local to parent:")) {
 				stuff_boolean(&effect.m_parent_local);
@@ -378,6 +384,7 @@ namespace particle {
 			parseRadius(effect);
 			parseLength(effect);
 			parseLifetime(effect);
+			parseLocalPositionScaling(effect);
 			parseParentLocal(effect);
 			parseLightEmissionSettings(effect);
 

--- a/code/particle/ParticleVolume.h
+++ b/code/particle/ParticleVolume.h
@@ -2,6 +2,7 @@
 
 #include "globalincs/pstypes.h"
 #include "parse/parselo.h"
+#include "particle/EffectHost.h"
 
 #include <optional>
 
@@ -9,7 +10,7 @@ namespace particle {
 	class ParticleSource;
 	class ParticleVolume {
 	public:
-		virtual vec3d sampleRandomPoint(const matrix &orientation, const std::tuple<const ParticleSource&, const size_t&, const vec3d&>& source, float particlesFraction) = 0;
+		virtual vec3d sampleRandomPoint(const matrix &orientation, const std::tuple<const ParticleSource&, const size_t&, const vec3d&>& source, float particlesFraction, const EffectHost& host) = 0;
 
 		virtual void parse() = 0;
 

--- a/code/particle/hosts/EffectHostSubmodel.cpp
+++ b/code/particle/hosts/EffectHostSubmodel.cpp
@@ -60,6 +60,10 @@ std::pair<int, int> EffectHostSubmodel::getParentObjAndSig() const {
 	return { m_objnum, m_objsig };
 }
 
+int EffectHostSubmodel::getParentSubmodel() const {
+	return m_submodel;
+}
+
 float EffectHostSubmodel::getHostRadius() const {
 	return Objects[m_objnum].radius;
 }

--- a/code/particle/hosts/EffectHostSubmodel.cpp
+++ b/code/particle/hosts/EffectHostSubmodel.cpp
@@ -5,7 +5,7 @@
 #include "ship/ship.h"
 
 EffectHostSubmodel::EffectHostSubmodel(const object* objp, int submodel, vec3d offset, matrix orientationOverride, bool orientationOverrideRelative) :
-	EffectHost(orientationOverride, orientationOverrideRelative), m_offset(offset), m_objnum(OBJ_INDEX(objp)), m_objsig(objp->signature), m_submodel(submodel) {}
+	EffectHost(orientationOverride, orientationOverrideRelative), m_offset(offset), m_objnum(OBJ_INDEX(objp)), m_objsig(objp->signature), m_submodel(submodel), m_modelnum(object_get_model(&Objects[m_objnum])->id) {}
 
 std::pair<vec3d, matrix> EffectHostSubmodel::getPositionAndOrientation(bool relativeToParent, float interp, const std::optional<vec3d>& tabled_offset) const {
 	vec3d pos = m_offset;
@@ -69,5 +69,5 @@ float EffectHostSubmodel::getHostRadius() const {
 }
 
 bool EffectHostSubmodel::isValid() const {
-	return m_objnum >= 0 && m_submodel >= 0 && Objects[m_objnum].signature == m_objsig && object_get_model_num(&Objects[m_objnum]) >= 0 && object_get_model_instance_num(&Objects[m_objnum]) >= 0;
+	return m_objnum >= 0 && m_submodel >= 0 && Objects[m_objnum].signature == m_objsig && object_get_model_num(&Objects[m_objnum]) >= 0 && object_get_model_instance_num(&Objects[m_objnum]) >= 0 && object_get_model(&Objects[m_objnum])->id == m_modelnum;
 }

--- a/code/particle/hosts/EffectHostSubmodel.h
+++ b/code/particle/hosts/EffectHostSubmodel.h
@@ -7,7 +7,7 @@ class EffectHostSubmodel : public EffectHost {
 
 	vec3d m_offset;
 
-	int m_objnum, m_objsig, m_submodel;
+	int m_objnum, m_objsig, m_submodel, m_modelnum;
 public:
 	EffectHostSubmodel(const object* objp, int submodel, vec3d offset, matrix orientationOverride = vmd_identity_matrix, bool orientationOverrideRelative = true);
 

--- a/code/particle/hosts/EffectHostSubmodel.h
+++ b/code/particle/hosts/EffectHostSubmodel.h
@@ -16,6 +16,7 @@ public:
 	vec3d getVelocity() const override;
 
 	std::pair<int, int> getParentObjAndSig() const override;
+	int getParentSubmodel() const override;
 
 	float getHostRadius() const override;
 

--- a/code/particle/hosts/EffectHostTurret.cpp
+++ b/code/particle/hosts/EffectHostTurret.cpp
@@ -74,6 +74,10 @@ std::pair<int, int> EffectHostTurret::getParentObjAndSig() const {
 	return { m_objnum, m_objsig };
 }
 
+int EffectHostTurret::getParentSubmodel() const {
+	return m_submodel;
+}
+
 float EffectHostTurret::getHostRadius() const {
 	return Objects[m_objnum].radius;
 }

--- a/code/particle/hosts/EffectHostTurret.h
+++ b/code/particle/hosts/EffectHostTurret.h
@@ -15,6 +15,7 @@ public:
 	vec3d getVelocity() const override;
 
 	std::pair<int, int> getParentObjAndSig() const override;
+	int getParentSubmodel() const override;
 
 	float getHostRadius() const override;
 

--- a/code/particle/volumes/ConeVolume.cpp
+++ b/code/particle/volumes/ConeVolume.cpp
@@ -6,7 +6,7 @@ namespace particle {
 	ConeVolume::ConeVolume(::util::ParsedRandomFloatRange deviation, ::util::ParsedRandomFloatRange length) : m_deviation(deviation), m_length(length), m_modular_curve_instance(m_modular_curves.create_instance()) { }
 
 
-	vec3d ConeVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) {
+	vec3d ConeVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& /*host*/) {
 		auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
 
 		//It is surely possible to do this more efficiently.

--- a/code/particle/volumes/ConeVolume.h
+++ b/code/particle/volumes/ConeVolume.h
@@ -27,7 +27,7 @@ namespace particle {
 		explicit ConeVolume(::util::ParsedRandomFloatRange deviation, float length);
 		explicit ConeVolume(::util::ParsedRandomFloatRange deviation, ::util::ParsedRandomFloatRange length);
 
-		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) override;
+		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& host) override;
 		void parse() override;
 	};
 }

--- a/code/particle/volumes/LegacyAACuboidVolume.cpp
+++ b/code/particle/volumes/LegacyAACuboidVolume.cpp
@@ -5,7 +5,7 @@
 namespace particle {
 	LegacyAACuboidVolume::LegacyAACuboidVolume(float normalVariance, float size, bool normalize) : m_normalVariance(normalVariance), m_size(size), m_normalize(normalize), m_modular_curve_instance(m_modular_curves.create_instance()) {	}
 
-	vec3d LegacyAACuboidVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) {
+	vec3d LegacyAACuboidVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& /*host*/) {
 		auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
 		float variance = m_normalVariance * m_modular_curves.get_output(VolumeModularCurveOutput::VARIANCE, curveSource, &m_modular_curve_instance);
 

--- a/code/particle/volumes/LegacyAACuboidVolume.h
+++ b/code/particle/volumes/LegacyAACuboidVolume.h
@@ -28,7 +28,7 @@ namespace particle {
 	public:
 	  	explicit LegacyAACuboidVolume(float normalVariance, float size, bool normalize);
 
-		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) override;
+		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& host) override;
 		void parse() override {
 			UNREACHABLE("Cannot parse Legacy Particle Volume!");
 		};

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -18,7 +18,7 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 		if (pm != nullptr) {
 			if (submodel < 0) {
 				SCP_vector<int> eligible_submodels;
-				for (size_t i = 0; i < pm->n_models; ++i) {
+				for (size_t i = 0; i < static_cast<size_t>(pm->n_models); ++i) {
 					if (!pm->submodel[i].flags[Model::Submodel_flags::Is_lod, Model::Submodel_flags::Is_damaged, Model::Submodel_flags::Is_live_debris])
 						eligible_submodels.emplace_back(i);
 				}

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -3,7 +3,7 @@
 #include "math/vecmat.h"
 
 namespace particle {
-ModelSurfaceVolume::ModelSurfaceVolume() : m_modular_curve_instance(m_modular_curves.create_instance()) {
+ModelSurfaceVolume::ModelSurfaceVolume() : m_modelScale(::util::UniformFloatRange(1.f)), m_modular_curve_instance(m_modular_curves.create_instance()) {
 	Model_load_clear_CPU_buffers = false;
 };
 
@@ -12,6 +12,8 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 	int submodel = host.getParentSubmodel();
 
 	vec3d point = ZERO_VECTOR;
+
+	auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
 
 	if (obj_num >= 0) {
 		const polymodel* pm = object_get_model(&Objects[obj_num]);
@@ -31,10 +33,10 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 			
 			//This point is, despite its name, not in world space, but in model local space (NOT submodel local though!)
 			point = geometry_data.vert[target_vertex].world;
+
+			point *= m_modelScale.next() * m_modular_curves.get_output(VolumeModularCurveOutput::SCALE_MULT, curveSource, &m_modular_curve_instance);
 		}
 	}
-
-	auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
 
 	return pointCompensateForOffsetAndRotOffset(point, orientation,
 				m_modular_curves.get_output(VolumeModularCurveOutput::OFFSET_ROT, curveSource, &m_modular_curve_instance),
@@ -42,6 +44,10 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 }
 
 void ModelSurfaceVolume::parse() {
+	if (optional_string("+Scale:")) {
+		m_modelScale = ::util::ParsedRandomFloatRange::parseRandomRange();
+	}
+
 	ParticleVolume::parseCommon();
 
 	m_modular_curves.parse("$Volume Curve:");

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -27,7 +27,7 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 
 			const bsp_info* submodel_data = &pm->submodel[submodel];
 			const auto& geometry_data = *submodel_data->buffer.model_list;
-			size_t target_vertex = ::util::UniformUIntRange(0, geometry_data.n_verts - 1).next();
+			size_t target_vertex = ::util::UniformUIntRange(0, static_cast<size_t>(geometry_data.n_verts) - 1).next();
 			
 			//This point is, despite its name, not in world space, but in model local space (NOT submodel local though!)
 			point = geometry_data.vert[target_vertex].world;

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -1,0 +1,47 @@
+#include "ModelSurfaceVolume.h"
+
+#include "math/vecmat.h"
+
+namespace particle {
+ModelSurfaceVolume::ModelSurfaceVolume() : m_modular_curve_instance(m_modular_curves.create_instance()) { };
+
+vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& host) {
+	int obj_num = host.getParentObjAndSig().first;
+	int submodel = host.getParentSubmodel();
+
+	vec3d point = ZERO_VECTOR;
+
+	if (obj_num >= 0) {
+		const polymodel* pm = object_get_model(&Objects[obj_num]);
+		if (pm != nullptr) {
+			if (submodel < 0) {
+				SCP_vector<int> eligible_submodels;
+				for (size_t i = 0; i < pm->n_models; ++i) {
+					if (!pm->submodel[i].flags[Model::Submodel_flags::Is_lod, Model::Submodel_flags::Is_damaged, Model::Submodel_flags::Is_live_debris])
+						eligible_submodels.emplace_back(i);
+				}
+				submodel = eligible_submodels[::util::UniformUIntRange(0, eligible_submodels.size() - 1).next()];
+			}
+
+			const bsp_info* submodel_data = &pm->submodel[submodel];
+			const auto& geometry_data = *submodel_data->buffer.model_list;
+			size_t target_vertex = ::util::UniformUIntRange(0, geometry_data.n_verts - 1).next();
+			
+			//This point is, despite its name, not in world space, but in model local space (NOT submodel local though!)
+			point = geometry_data.vert[target_vertex].world;
+		}
+	}
+
+	auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
+
+	return pointCompensateForOffsetAndRotOffset(point, orientation,
+				m_modular_curves.get_output(VolumeModularCurveOutput::OFFSET_ROT, curveSource, &m_modular_curve_instance),
+				m_modular_curves.get_output(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, &m_modular_curve_instance));
+}
+
+void ModelSurfaceVolume::parse() {
+	ParticleVolume::parseCommon();
+
+	m_modular_curves.parse("$Volume Curve:");
+}
+}

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -22,12 +22,12 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 					if (!pm->submodel[i].flags[Model::Submodel_flags::Is_lod, Model::Submodel_flags::Is_damaged, Model::Submodel_flags::Is_live_debris])
 						eligible_submodels.emplace_back(i);
 				}
-				submodel = eligible_submodels[::util::UniformUIntRange(0, eligible_submodels.size() - 1).next()];
+				submodel = eligible_submodels[::util::UniformUIntRange(0U, eligible_submodels.size() - 1).next()];
 			}
 
 			const bsp_info* submodel_data = &pm->submodel[submodel];
 			const auto& geometry_data = *submodel_data->buffer.model_list;
-			size_t target_vertex = ::util::UniformUIntRange(0, static_cast<size_t>(geometry_data.n_verts) - 1).next();
+			size_t target_vertex = ::util::UniformUIntRange(0U, static_cast<size_t>(geometry_data.n_verts) - 1).next();
 			
 			//This point is, despite its name, not in world space, but in model local space (NOT submodel local though!)
 			point = geometry_data.vert[target_vertex].world;

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -24,17 +24,23 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 					if (!pm->submodel[i].flags[Model::Submodel_flags::Is_lod, Model::Submodel_flags::Is_damaged, Model::Submodel_flags::Is_live_debris])
 						eligible_submodels.emplace_back(i);
 				}
-				submodel = eligible_submodels[::util::UniformUIntRange(0U, static_cast<unsigned int>(eligible_submodels.size()) - 1).next()];
+
+				if (!eligible_submodels.empty())
+					submodel = eligible_submodels[::util::UniformUIntRange(0U, static_cast<unsigned int>(eligible_submodels.size()) - 1).next()];
 			}
 
-			const bsp_info* submodel_data = &pm->submodel[submodel];
-			const auto& geometry_data = *submodel_data->buffer.model_list;
-			size_t target_vertex = ::util::UniformUIntRange(0U, static_cast<unsigned int>(geometry_data.n_verts) - 1).next();
-			
-			//This point is, despite its name, not in world space, but in model local space (NOT submodel local though!)
-			point = geometry_data.vert[target_vertex].world;
+			if (submodel >= 0) {
+				const bsp_info* submodel_data = &pm->submodel[submodel];
+				const auto* geometry_data = submodel_data->buffer.model_list;
+				Assertion(geometry_data != nullptr, "ModelSurfaceVolume particles were spawned on a model with no data available!");
 
-			point *= m_modelScale.next() * m_modular_curves.get_output(VolumeModularCurveOutput::SCALE_MULT, curveSource, &m_modular_curve_instance);
+				size_t target_vertex = ::util::UniformUIntRange(0U, static_cast<unsigned int>(geometry_data->n_verts) - 1).next();
+
+				//This point is, despite its name, not in world space, but in model local space (NOT submodel local though!)
+				point = geometry_data->vert[target_vertex].world;
+
+				point *= m_modelScale.next() * m_modular_curves.get_output(VolumeModularCurveOutput::SCALE_MULT, curveSource, &m_modular_curve_instance);
+			}
 		}
 	}
 

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -3,7 +3,9 @@
 #include "math/vecmat.h"
 
 namespace particle {
-ModelSurfaceVolume::ModelSurfaceVolume() : m_modular_curve_instance(m_modular_curves.create_instance()) { };
+ModelSurfaceVolume::ModelSurfaceVolume() : m_modular_curve_instance(m_modular_curves.create_instance()) {
+	Model_load_clear_CPU_buffers = false;
+};
 
 vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& host) {
 	int obj_num = host.getParentObjAndSig().first;

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -22,12 +22,12 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 					if (!pm->submodel[i].flags[Model::Submodel_flags::Is_lod, Model::Submodel_flags::Is_damaged, Model::Submodel_flags::Is_live_debris])
 						eligible_submodels.emplace_back(i);
 				}
-				submodel = eligible_submodels[::util::UniformUIntRange(0U, eligible_submodels.size() - 1).next()];
+				submodel = eligible_submodels[::util::UniformUIntRange(0U, static_cast<unsigned int>(eligible_submodels.size()) - 1).next()];
 			}
 
 			const bsp_info* submodel_data = &pm->submodel[submodel];
 			const auto& geometry_data = *submodel_data->buffer.model_list;
-			size_t target_vertex = ::util::UniformUIntRange(0U, static_cast<size_t>(geometry_data.n_verts) - 1).next();
+			size_t target_vertex = ::util::UniformUIntRange(0U, static_cast<unsigned int>(geometry_data.n_verts) - 1).next();
 			
 			//This point is, despite its name, not in world space, but in model local space (NOT submodel local though!)
 			point = geometry_data.vert[target_vertex].world;

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -18,7 +18,7 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 		if (pm != nullptr) {
 			if (submodel < 0) {
 				SCP_vector<int> eligible_submodels;
-				for (size_t i = 0; i < static_cast<size_t>(pm->n_models); ++i) {
+				for (int i = 0; i < pm->n_models; ++i) {
 					if (!pm->submodel[i].flags[Model::Submodel_flags::Is_lod, Model::Submodel_flags::Is_damaged, Model::Submodel_flags::Is_live_debris])
 						eligible_submodels.emplace_back(i);
 				}

--- a/code/particle/volumes/ModelSurfaceVolume.h
+++ b/code/particle/volumes/ModelSurfaceVolume.h
@@ -5,12 +5,12 @@
 
 namespace particle {
 class ModelSurfaceVolume : public ParticleVolume {
-public:
-	enum class VolumeModularCurveOutput : uint8_t {OFFSET_ROT, POINT_TO_ROT, NUM_VALUES};
+	::util::ParsedRandomFloatRange m_modelScale;
+	enum class VolumeModularCurveOutput : uint8_t {SCALE_MULT, OFFSET_ROT, POINT_TO_ROT, NUM_VALUES};
 
-private:
 	constexpr static auto modular_curve_definition = ParticleEffect::modular_curves_definition.derive_modular_curves_subset<float, VolumeModularCurveOutput>(
 		std::array {
+			std::pair { "Scale Mult", VolumeModularCurveOutput::SCALE_MULT },
 			std::pair { "Offset Rotate Around Fvec", VolumeModularCurveOutput::OFFSET_ROT },
 			std::pair { "Point To Rotate Around Fvec", VolumeModularCurveOutput::POINT_TO_ROT }
 		},

--- a/code/particle/volumes/ModelSurfaceVolume.h
+++ b/code/particle/volumes/ModelSurfaceVolume.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "particle/ParticleVolume.h"
+#include "particle/ParticleEffect.h"
+
+namespace particle {
+class ModelSurfaceVolume : public ParticleVolume {
+public:
+	enum class VolumeModularCurveOutput : uint8_t {OFFSET_ROT, POINT_TO_ROT, NUM_VALUES};
+
+private:
+	constexpr static auto modular_curve_definition = ParticleEffect::modular_curves_definition.derive_modular_curves_subset<float, VolumeModularCurveOutput>(
+		std::array {
+			std::pair { "Offset Rotate Around Fvec", VolumeModularCurveOutput::OFFSET_ROT },
+			std::pair { "Point To Rotate Around Fvec", VolumeModularCurveOutput::POINT_TO_ROT }
+		},
+		std::pair { "Fraction Particles Spawned", modular_curves_self_input{}});
+
+public:
+	MODULAR_CURVE_SET(m_modular_curves, modular_curve_definition);
+
+private:
+	modular_curves_entry_instance m_modular_curve_instance;
+
+public:
+	explicit ModelSurfaceVolume();
+
+	vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& host) override;
+	void parse() override;
+};
+}

--- a/code/particle/volumes/PointVolume.cpp
+++ b/code/particle/volumes/PointVolume.cpp
@@ -5,7 +5,7 @@
 namespace particle {
 	PointVolume::PointVolume() : m_modular_curve_instance(m_modular_curves.create_instance()) { };
 
-	vec3d PointVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) {
+	vec3d PointVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& /*host*/) {
 		auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
 
 		return pointCompensateForOffsetAndRotOffset(ZERO_VECTOR, orientation,

--- a/code/particle/volumes/PointVolume.h
+++ b/code/particle/volumes/PointVolume.h
@@ -25,7 +25,7 @@ namespace particle {
 	public:
 		explicit PointVolume();
 
-		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) override;
+		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& host) override;
 		void parse() override;
 	};
 }

--- a/code/particle/volumes/RingVolume.cpp
+++ b/code/particle/volumes/RingVolume.cpp
@@ -6,7 +6,7 @@ namespace particle {
 	RingVolume::RingVolume() : m_radius(1.f), m_onEdge(false), m_modular_curve_instance(m_modular_curves.create_instance()) { };
 	RingVolume::RingVolume(float radius, bool onEdge) : m_radius(radius), m_onEdge(onEdge), m_modular_curve_instance(m_modular_curves.create_instance()) { };
 
-	vec3d RingVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) {
+	vec3d RingVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& /*host*/) {
 		auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
 		vec3d pos;
 		// get an unbiased random point in the sphere

--- a/code/particle/volumes/RingVolume.h
+++ b/code/particle/volumes/RingVolume.h
@@ -22,7 +22,7 @@ namespace particle {
 		explicit RingVolume();
 		explicit RingVolume(float radius, bool onEdge);
 
-		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) override;
+		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& host) override;
 		void parse() override;
 	};
 }

--- a/code/particle/volumes/SpheroidVolume.cpp
+++ b/code/particle/volumes/SpheroidVolume.cpp
@@ -6,7 +6,7 @@ namespace particle {
 	SpheroidVolume::SpheroidVolume() : m_bias(1.f), m_stretch(1.f), m_radius(1.f), m_modular_curve_instance(m_modular_curves.create_instance()) { };
 	SpheroidVolume::SpheroidVolume(float bias, float stretch, float radius) : m_bias(bias), m_stretch(stretch), m_radius(radius), m_modular_curve_instance(m_modular_curves.create_instance()) { };
 
-	vec3d SpheroidVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) {
+	vec3d SpheroidVolume::sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& /*host*/) {
 		auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
 		vec3d pos;
 		// get an unbiased random point in the sphere

--- a/code/particle/volumes/SpheroidVolume.h
+++ b/code/particle/volumes/SpheroidVolume.h
@@ -33,7 +33,7 @@ namespace particle {
 		explicit SpheroidVolume();
 		explicit SpheroidVolume(float bias, float stretch, float radius);
 
-		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction) override;
+		vec3d sampleRandomPoint(const matrix &orientation, decltype(ParticleEffect::modular_curves_definition)::input_type_t source, float particlesFraction, const EffectHost& host) override;
 		void parse() override;
 	};
 }

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -1154,6 +1154,8 @@ add_file_folder("Particle\\\\Volumes"
 	particle/volumes/ConeVolume.h
 	particle/volumes/LegacyAACuboidVolume.cpp
 	particle/volumes/LegacyAACuboidVolume.h
+	particle/volumes/ModelSurfaceVolume.cpp
+	particle/volumes/ModelSurfaceVolume.h
 	particle/volumes/PointVolume.cpp
 	particle/volumes/PointVolume.h
 	particle/volumes/RingVolume.cpp


### PR DESCRIPTION
Closes #7228.
Also implements a "local position scaling" in order to be able to center an effect on-hit on the center of the affected object, rather than the hitpos itself.

Here's a sample, where just one hit spawned a particle source with many particles and with the new ModelSurface mode.
<img width="1265" height="814" alt="image" src="https://github.com/user-attachments/assets/f89b784e-7a76-42a4-8799-56fa21726167" />

If a submodel is hit, just that submodel will be affected.
