### PR TITLE
unlimited mission titles

### DIFF
--- a/code/controlconfig/controlsconfig.cpp
+++ b/code/controlconfig/controlsconfig.cpp
@@ -2724,8 +2724,7 @@ void control_config_do_frame(float frametime)
 			strcpy_s(buf, Control_config[i].text.c_str());
 		}
 
-		font::force_fit_string(buf, 255, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
-		gr_get_string_size(&w, NULL, buf);
+		w = font::force_fit_string(buf, 255, Conflict_wnd_coords[gr_screen.res][CONTROL_W_COORD]);
 		gr_printf_menu(x - w / 2, y, "%s", buf);
 
 	} else if (*bound_string) {

--- a/code/libs/discord/discord.cpp
+++ b/code/libs/discord/discord.cpp
@@ -68,7 +68,7 @@ SCP_string get_details()
 	}
 
 	if (has_campaign && in_mission) {
-		sprintf(res, "%s: %s", get_current_campaign_name().c_str(), The_mission.name);
+		sprintf(res, "%s: %s", get_current_campaign_name().c_str(), The_mission.name.c_str());
 	} else if (has_campaign) {
 		sprintf(res, "Campaign %s", get_current_campaign_name().c_str());
 	} else if (in_mission) {

--- a/code/menuui/readyroom.cpp
+++ b/code/menuui/readyroom.cpp
@@ -493,7 +493,7 @@ int build_standalone_mission_list_do_frame(bool API_Access)
 			Lcl_unexpected_tstring_check = nullptr;
 
 			if (condition) {
-				Standalone_mission_names[Num_standalone_missions_with_info] = vm_strdup(The_mission.name);
+				Standalone_mission_names[Num_standalone_missions_with_info] = vm_strdup(The_mission.name.c_str());
 				Standalone_mission_flags[Num_standalone_missions_with_info] = The_mission.game_type;
 				int y = Num_lines * (font_height + 2);
 
@@ -565,7 +565,7 @@ int build_campaign_mission_list_do_frame(bool API_Access)
 			auto filename = Campaign.missions[Num_campaign_missions_with_info].name;
 			
 			// add to list
-			Campaign_mission_names[Num_campaign_missions_with_info] = vm_strdup(The_mission.name);
+			Campaign_mission_names[Num_campaign_missions_with_info] = vm_strdup(The_mission.name.c_str());
 			Campaign_mission_flags[Num_campaign_missions_with_info] = The_mission.game_type;
 			int y = valid_missions_with_info * (font_height + 2);
 

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -787,7 +787,7 @@ void parse_mission_info(mission *pm, bool basic = false)
 		throw parse::VersionException("Mission requires version " + gameversion::format_version(pm->required_fso_version), pm->required_fso_version);
 
 	required_string("$Name:");
-	stuff_string(pm->name, F_NAME, NAME_LENGTH);
+	stuff_string(pm->name, F_NAME);
 
 	required_string("$Author:");
 	stuff_string(pm->author, F_NAME);
@@ -1050,7 +1050,7 @@ void parse_mission_info(mission *pm, bool basic = false)
 		if (index >= 0)
 			The_mission.ai_profile = &Ai_profiles[index];
 		else
-			WarningEx(LOCATION, "Mission: %s\nUnknown AI profile %s!", pm->name, temp );
+			WarningEx(LOCATION, "Mission: %s\nUnknown AI profile %s!", pm->name.c_str(), temp );
 	}
 
 	if (optional_string("$Lighting Profile:"))
@@ -1232,7 +1232,7 @@ void parse_player_info2(mission *pm)
 			stuff_string(str, F_NAME, NAME_LENGTH);
 			ptr->default_ship = ship_info_lookup(str);
 			if (-1 == ptr->default_ship) {
-				WarningEx(LOCATION, "Mission: %s\nUnknown default ship %s!  Defaulting to %s.", pm->name, str, Ship_info[ptr->ship_list[0]].name );
+				WarningEx(LOCATION, "Mission: %s\nUnknown default ship %s!  Defaulting to %s.", pm->name.c_str(), str, Ship_info[ptr->ship_list[0]].name );
 				ptr->default_ship = ptr->ship_list[0]; // default to 1st in list
 			}
 			// see if the player's default ship is an allowable ship (campaign only). If not, then what
@@ -1245,7 +1245,7 @@ void parse_player_info2(mission *pm)
 							break;
 						}
 					}
-					Assertion( i < ship_info_size(), "Mission: %s: Could not find a valid default ship.\n", pm->name );
+					Assertion( i < ship_info_size(), "Mission: %s: Could not find a valid default ship.\n", pm->name.c_str() );
 				}
 			}
 		}
@@ -3391,7 +3391,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 		// try and find the alternate name
 		p_objp->alt_type_index = mission_parse_lookup_alt(name);
 		if(p_objp->alt_type_index < 0)
-			WarningEx(LOCATION, "Mission %s\nError looking up alternate ship type name %s!\n", pm->name, name);
+			WarningEx(LOCATION, "Mission %s\nError looking up alternate ship type name %s!\n", pm->name.c_str(), name);
 		else
 			mprintf(("Using alternate ship type name: %s\n", name));
 	}
@@ -3405,7 +3405,7 @@ int parse_object(mission *pm, int  /*flag*/, p_object *p_objp)
 		// try and find the callsign
 		p_objp->callsign_index = mission_parse_lookup_callsign(name);
 		if(p_objp->callsign_index < 0)
-			WarningEx(LOCATION, "Mission %s\nError looking up callsign %s!\n", pm->name, name);
+			WarningEx(LOCATION, "Mission %s\nError looking up callsign %s!\n", pm->name.c_str(), name);
 		else
 			mprintf(("Using callsign: %s\n", name));
 	}
@@ -6310,7 +6310,7 @@ void parse_bitmaps(mission *pm)
 			}
 
 			if (z == NUM_NEBULAS)
-				WarningEx(LOCATION, "Mission %s\nUnknown nebula %s!", pm->name, str);
+				WarningEx(LOCATION, "Mission %s\nUnknown nebula %s!", pm->name.c_str(), str);
 
 			if (optional_string("+Color:")) {
 				stuff_string(str, F_NAME, MAX_FILENAME_LEN);
@@ -6323,7 +6323,7 @@ void parse_bitmaps(mission *pm)
 			}
 
 			if (z == NUM_NEBULA_COLORS)
-				WarningEx(LOCATION, "Mission %s\nUnknown nebula color %s!", pm->name, str);
+				WarningEx(LOCATION, "Mission %s\nUnknown nebula color %s!", pm->name.c_str(), str);
 
 			if (optional_string("+Pitch:")){
 				stuff_int(&Nebula_pitch);
@@ -6421,7 +6421,7 @@ void parse_asteroid_fields(mission *pm)
 				if (subtype >= 0) {
 					Asteroid_field.field_debris_type.push_back(subtype);
 				} else {
-					WarningEx(LOCATION, "Mission %s\n Invalid asteroid debris %s!", pm->name, ast_name.c_str());
+					WarningEx(LOCATION, "Mission %s\n Invalid asteroid debris %s!", pm->name.c_str(), ast_name.c_str());
 				}
 			}
 
@@ -6473,7 +6473,7 @@ void parse_asteroid_fields(mission *pm)
 				if (valid){
 					Asteroid_field.field_asteroid_type.push_back(std::move(ast_name));
 				} else {
-					WarningEx(LOCATION, "Mission %s\n Invalid asteroid %s!", pm->name, ast_name.c_str());
+					WarningEx(LOCATION, "Mission %s\n Invalid asteroid %s!", pm->name.c_str(), ast_name.c_str());
 				}
 			}
 		}
@@ -6853,7 +6853,7 @@ bool parse_mission(mission *pm, int flags)
 		popup(PF_TITLE_BIG | PF_TITLE_RED | PF_USE_AFFIRMATIVE_ICON | PF_NO_NETWORKING, 1, POPUP_OK, text);
 	}
 
-	log_printf(LOGFILE_EVENT_LOG, "Mission %s loaded.\n", pm->name); 
+	log_printf(LOGFILE_EVENT_LOG, "Mission %s loaded.\n", pm->name.c_str()); 
 
 	// success
 	return true;
@@ -7203,8 +7203,8 @@ int get_mission_info(const char *filename, mission *mission_p, bool basic, bool 
 
 void mission::Reset()
 {
-	name[ 0 ] = '\0';
-	author = "";
+	name.clear();
+	author.clear();
 	required_fso_version = LEGACY_MISSION_VERSION;
 	created[ 0 ] = '\0';
 	modified[ 0 ] = '\0';

--- a/code/mission/missionparse.h
+++ b/code/mission/missionparse.h
@@ -185,7 +185,7 @@ struct parse_object_flag_description {
 };
 
 typedef struct mission {
-	char	name[NAME_LENGTH];
+	SCP_string	name;
 	SCP_string	author;
 	gameversion::version	required_fso_version;
 	char	created[DATE_TIME_LENGTH];

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -2496,7 +2496,7 @@ int Fred_mission_save::save_mission_info()
 	// XSTR
 	required_string_fred("$Name:");
 	parse_comments();
-	fout_ext(" ", "%s", The_mission.name);
+	fout_ext(" ", "%s", The_mission.name.c_str());
 
 	required_string_fred("$Author:");
 	parse_comments();

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -290,9 +290,10 @@ UI_XSTR Brief_select_text[GR_NUM_RESOLUTIONS][BRIEF_SELECT_NUM_TEXT] = {
 };
 
 // coordinates for briefing title -- the x value is for the RIGHT side of the text
-static int Title_coords[GR_NUM_RESOLUTIONS][2] = {
-	{575, 117},		// GR_640
-	{918, 194}		// GR_1024
+// third coord is max width of area for it to fit into (it is force fit there)
+static int Title_coords[GR_NUM_RESOLUTIONS][3] = {
+	{575, 117, 370},	// GR_640
+	{918, 194, 588}		// GR_1024
 };
 
 // coordinates for briefing title in multiplayer briefings -- the x value is for the LEFT side of the text
@@ -1158,7 +1159,7 @@ void brief_render(float frametime, bool api_access)
 			gr_printf_menu((gr_screen.clip_width_unscaled - w) / 2,200,XSTR( "No Briefing exists for mission: %s", 430), Game_current_mission_filename);
 
 			#ifndef NDEBUG
-			gr_get_string_size(&w, &h, The_mission.name);
+			gr_get_string_size(&w, &h, The_mission.name.c_str());
 			gr_set_color_fast(&Color_normal);
 			SCP_string debugText;
 			sprintf(debugText, NOX("[filename: %s, last mod: %s]"), Mission_filename, The_mission.modified);
@@ -1211,17 +1212,20 @@ void brief_render(float frametime, bool api_access)
 		gr_printf_menu(Brief_bmap_coords[gr_screen.res][0], Brief_bmap_coords[gr_screen.res][1]-title_y_offset, NOX("[name: %s, mod: %s]"), Mission_filename, The_mission.modified);
 #endif
 
+		// force-fit mission title if necessary
+		const size_t max_buf_len = 255;
+		char buf[max_buf_len + 1];
+		strncpy(buf, The_mission.name.c_str(), max_buf_len);
+		buf[max_buf_len] = '\0';
+		const int max_coords_width = (Game_mode & GM_MULTIPLAYER) ? Title_coords_multi[gr_screen.res][2] : Title_coords[gr_screen.res][2];
+		w = font::force_fit_string(buf, max_buf_len, max_coords_width);
+
 		// output mission title
 		gr_set_color_fast(&Color_bright_white);
-
 		if (Game_mode & GM_MULTIPLAYER) {
-			char buf[256];
-			strncpy(buf, The_mission.name, 255);
-			font::force_fit_string(buf, 255, Title_coords_multi[gr_screen.res][2]);
 			gr_string(Title_coords_multi[gr_screen.res][0], Title_coords_multi[gr_screen.res][1], buf, GR_RESIZE_MENU);
 		} else {
-			gr_get_string_size(&w, nullptr, The_mission.name);
-			gr_string(Title_coords[gr_screen.res][0] - w, Title_coords[gr_screen.res][1], The_mission.name, GR_RESIZE_MENU);
+			gr_string(Title_coords[gr_screen.res][0] - w, Title_coords[gr_screen.res][1], buf, GR_RESIZE_MENU);
 		}
 
 		// maybe do objectives

--- a/code/missionui/missiondebrief.cpp
+++ b/code/missionui/missiondebrief.cpp
@@ -2277,7 +2277,8 @@ void debrief_do_frame(float frametime)
 {
 	int k=0, new_k=0;
 	const char *please_wait_str = XSTR("Please Wait", 1242);
-	char buf[256];
+	const size_t max_buf_len = 255;
+	char buf[max_buf_len+1];
 
 	Assert(Debrief_inited);	
 
@@ -2458,8 +2459,9 @@ void debrief_do_frame(float frametime)
 
 	// draw the title of the mission
 	gr_set_color_fast(&Color_bright_white);
-	strcpy_s(buf, The_mission.name);
-	font::force_fit_string(buf, 255, Debrief_title_coords[gr_screen.res][2]);
+	strncpy(buf, The_mission.name.c_str(), max_buf_len);
+	buf[max_buf_len] = '\0';
+	font::force_fit_string(buf, max_buf_len, Debrief_title_coords[gr_screen.res][2]);
 	gr_string(Debrief_title_coords[gr_screen.res][0], Debrief_title_coords[gr_screen.res][1], buf, GR_RESIZE_MENU);	
 
 #if !defined(NDEBUG)

--- a/code/network/multi_dogfight.cpp
+++ b/code/network/multi_dogfight.cpp
@@ -245,7 +245,8 @@ void multi_df_debrief_init(bool API_Access)
 void multi_df_debrief_do(bool API_Access)
 {
 	int k, new_k;
-	char buf[256];
+	const size_t max_buf_len = 255;
+	char buf[max_buf_len+1];
 	
 	k = chatbox_process();
 	if (!API_Access) {
@@ -285,8 +286,9 @@ void multi_df_debrief_do(bool API_Access)
 		chatbox_render();
 
 		// draw the mission title
-		strcpy_s(buf, The_mission.name);
-		font::force_fit_string(buf, 255, Kill_matrix_title_coords[gr_screen.res][2]);
+		strncpy(buf, The_mission.name.c_str(), max_buf_len);
+		buf[max_buf_len] = '\0';
+		font::force_fit_string(buf, max_buf_len, Kill_matrix_title_coords[gr_screen.res][2]);
 		gr_set_color_fast(&Color_bright_white);
 		gr_string(Kill_matrix_title_coords[gr_screen.res][0],
 			Kill_matrix_title_coords[gr_screen.res][1],
@@ -392,7 +394,7 @@ void multi_df_setup_kill_matrix()
 // blit the kill matrix
 void multi_df_blit_kill_matrix()
 {
-	int idx, s_idx, str_len;
+	int idx, s_idx;
 	int cx, cy;
 	char squashed_string[CALLSIGN_LEN+1] = "";
 	int dy = gr_get_font_height() + 1;
@@ -415,15 +417,14 @@ void multi_df_blit_kill_matrix()
 	for(idx=0; idx<Multi_df_score_count; idx++){		
 		// force the string to fit nicely
 		strcpy_s(squashed_string, Multi_df_score[idx].callsign);
-		font::force_fit_string(squashed_string, CALLSIGN_LEN, (int)max_text_width);
-		gr_get_string_size(&str_len, NULL, squashed_string);
+		int w = font::force_fit_string(squashed_string, CALLSIGN_LEN, (int)max_text_width);
 
 		// set color and blit the string		
 		Assert(Multi_df_score[idx].np_index >= 0);
 		if(Multi_df_score[idx].np_index >= 0){
 			gr_set_color_fast(Color_netplayer[Multi_df_score[idx].np_index]);
 		}
-		gr_string(cx + (int)((max_item_width - (float)str_len)/2.0f), cy, squashed_string, GR_RESIZE_MENU);
+		gr_string(cx + (int)((max_item_width - (float)w)/2.0f), cy, squashed_string, GR_RESIZE_MENU);
 
 		// next spot
 		cx += (int)max_item_width;
@@ -446,7 +447,6 @@ void multi_df_blit_kill_matrix()
 		cx = Multi_df_display_coords[gr_screen.res][0];
 		strcpy_s(squashed_string, Multi_df_score[idx].callsign);
 		font::force_fit_string(squashed_string, CALLSIGN_LEN, (int)max_text_width);
-		gr_get_string_size(&str_len, NULL, squashed_string);		
 		Assert(Multi_df_score[idx].np_index >= 0);
 		if(Multi_df_score[idx].np_index >= 0){
 			gr_set_color_fast(Color_netplayer[Multi_df_score[idx].np_index]);
@@ -469,9 +469,8 @@ void multi_df_blit_kill_matrix()
 			}						
 
 			// draw the string
-			font::force_fit_string(squashed_string, CALLSIGN_LEN, (int)max_text_width);
-			gr_get_string_size(&str_len, NULL, squashed_string);
-			gr_string(cx + (int)((max_item_width - (float)str_len)/2.0f), cy, squashed_string, GR_RESIZE_MENU);
+			int w = font::force_fit_string(squashed_string, CALLSIGN_LEN, (int)max_text_width);
+			gr_string(cx + (int)((max_item_width - (float)w)/2.0f), cy, squashed_string, GR_RESIZE_MENU);
 
 			// next spot
 			cx += (int)max_item_width;
@@ -480,8 +479,9 @@ void multi_df_blit_kill_matrix()
 		// draw the row total
 		gr_set_color_fast(Color_netplayer[Multi_df_score[idx].np_index]);
 		sprintf(squashed_string, "(%d)", row_total);
-		gr_get_string_size(&str_len, NULL, squashed_string);
-		gr_string(Multi_df_display_coords[gr_screen.res][0] + Multi_df_display_coords[gr_screen.res][2] - (MULTI_DF_TOTAL_ADJUST + str_len), cy, squashed_string, GR_RESIZE_MENU);
+		int w;
+		gr_get_string_size(&w, nullptr, squashed_string);
+		gr_string(Multi_df_display_coords[gr_screen.res][0] + Multi_df_display_coords[gr_screen.res][2] - (MULTI_DF_TOTAL_ADJUST + w), cy, squashed_string, GR_RESIZE_MENU);
 
 		cy += dy;
 	}

--- a/code/network/multi_pxo.cpp
+++ b/code/network/multi_pxo.cpp
@@ -3029,8 +3029,6 @@ void multi_pxo_chat_process_incoming(const char *txt,int mode)
  */
 void multi_pxo_chat_blit()
 {
-	int token_width;
-	
 	// blit the title line
 	char title[MAX_PXO_TEXT_LEN];
 	memset(title,0,MAX_PXO_TEXT_LEN);
@@ -3043,10 +3041,9 @@ void multi_pxo_chat_blit()
 	} else {
 		strcpy_s(title,XSTR("Parallax Online - No Channel", 956));
 	}	
-	font::force_fit_string(title, MAX_PXO_TEXT_LEN-1, Multi_pxo_chat_coords[gr_screen.res][2] - 10);
-	gr_get_string_size(&token_width,nullptr,title);
+	int title_width = font::force_fit_string(title, MAX_PXO_TEXT_LEN-1, Multi_pxo_chat_coords[gr_screen.res][2] - 10);
 	gr_set_color_fast(&Color_normal);
-	gr_string(Multi_pxo_chat_coords[gr_screen.res][0] + ((Multi_pxo_chat_coords[gr_screen.res][2] - token_width)/2), Multi_pxo_chat_title_y[gr_screen.res], title, GR_RESIZE_MENU);	
+	gr_string(Multi_pxo_chat_coords[gr_screen.res][0] + ((Multi_pxo_chat_coords[gr_screen.res][2] - title_width)/2), Multi_pxo_chat_title_y[gr_screen.res], title, GR_RESIZE_MENU);
 	
 	int disp_count, y_start;
 	int line_height = gr_get_font_height() + 1;
@@ -3078,12 +3075,13 @@ void multi_pxo_chat_blit()
 
 			// normal mode, just highlight the server
 			case CHAT_MODE_PRIVATE:
-			case CHAT_MODE_NORMAL:
+			case CHAT_MODE_NORMAL: {
 				char piece[MAX_CHAT_LINE_LEN + 1];
 				strcpy_s(piece, line->text);
 				tok = strtok(piece, " ");
 				if (tok != nullptr) {
 					// get the width of just the first "piece"
+					int token_width;
 					gr_get_string_size(&token_width, nullptr, tok);
 
 					// draw it brightly
@@ -3101,6 +3099,7 @@ void multi_pxo_chat_blit()
 					}
 				}
 				break;
+			}
 
 			// carry mode, display with no highlight
 			case CHAT_MODE_CARRY:

--- a/code/network/multiui.cpp
+++ b/code/network/multiui.cpp
@@ -4793,7 +4793,8 @@ void multi_create_list_set_item(int abs_index, int mode) {
 			ng->max_players = mission_parse_get_multi_mission_info(ng->mission_name);
 
 			Assert(ng->max_players > 0);
-			strcpy_s(ng->title, The_mission.name);
+			strncpy(ng->title, The_mission.name.c_str(), NAME_LENGTH);
+			ng->title[NAME_LENGTH] = '\0';
 
 			// set the information area text
 			Multi_netgame_common_description = The_mission.mission_desc;

--- a/code/playerman/managepilot.cpp
+++ b/code/playerman/managepilot.cpp
@@ -264,8 +264,7 @@ void pilot_set_short_callsign(player *p, int max_width)
 {
 	strcpy_s(p->short_callsign, p->callsign);
 	font::set_font(font::FONT1);
-	font::force_fit_string(p->short_callsign, CALLSIGN_LEN - 1, max_width);
-	gr_get_string_size( &(p->short_callsign_width), NULL, p->short_callsign );
+	p->short_callsign_width = font::force_fit_string(p->short_callsign, CALLSIGN_LEN - 1, max_width);
 }
 
 // pick a random image for the passed player

--- a/fred2/dumpstats.cpp
+++ b/fred2/dumpstats.cpp
@@ -132,7 +132,7 @@ void DumpStats::get_mission_stats(CString &buffer)
 	// Mission info
 	buffer += "\t MISSION INFO\r\n";
 
-	temp.Format("Title: %s\r\n", The_mission.name);
+	temp.Format("Title: %s\r\n", The_mission.name.c_str());
 	buffer += temp;
 
 	temp.Format("Filename: %s\r\n", Mission_filename);

--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -257,9 +257,9 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 	// message 2: unknown classes
 	if ((Num_unknown_ship_classes > 0) || (Num_unknown_prop_classes > 0) || (Num_unknown_weapon_classes > 0) || (Num_unknown_loadout_classes > 0)) {
 		if (flags & MPF_IMPORT_FSM) {
-			char msg[256];
-			sprintf(msg, "Fred encountered unknown ship/prop/weapon classes when importing \"%s\" (path \"%s\"). You will have to manually edit the converted mission to correct this.", The_mission.name, pathname);
-			Fred_view_wnd->MessageBox(msg);
+			SCP_string msg;
+			sprintf(msg, "Fred encountered unknown ship/prop/weapon classes when importing \"%s\" (path \"%s\"). You will have to manually edit the converted mission to correct this.", The_mission.name.c_str(), pathname);
+			Fred_view_wnd->MessageBox(msg.c_str());
 		} else {
 			Fred_view_wnd->MessageBox("Fred encountered unknown ship/prop/weapon classes when parsing the mission file. This may be due to mission disk data you do not have.");
 		}

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -2475,10 +2475,6 @@ int CFREDView::global_error_check()
 	if ( The_mission.game_type & MISSION_TYPE_MULTI )
 		multi = 1;
 
-//	if (!stricmp(The_mission.name, "Untitled"))
-//		if (error("You haven't given this mission a title yet.\nThis is done from the Mission Specs Editor (Shift-N)."))
-//			return 1;
-
 	// cycle though all the objects and verify every possible aspect of them
 	obj_count = t = 0;
 	ptr = GET_FIRST(&obj_used_list);

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -909,7 +909,7 @@ void clear_mission(bool fast_reload)
 	time(&currentTime);
 	auto timeinfo = localtime(&currentTime);
 
-	strcpy_s(The_mission.name, "Untitled");
+	The_mission.name = "Untitled";
 	The_mission.author = str;
 	time_to_mission_info_string(timeinfo, The_mission.created, DATE_TIME_LENGTH - 1);
 	strcpy_s(The_mission.modified, The_mission.created);

--- a/fred2/missionnotesdlg.cpp
+++ b/fred2/missionnotesdlg.cpp
@@ -320,7 +320,7 @@ void CMissionNotesDlg::OnOK()
 	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
 	pad_with_newline(m_mission_notes, NOTES_LENGTH - 1);
 
-	string_copy(The_mission.name, m_mission_title, NAME_LENGTH - 1, 1);
+	string_copy(The_mission.name, m_mission_title, true);
 	string_copy(The_mission.author, m_designer_name, true);
 	string_copy(The_mission.loading_screen[GR_640], m_loading_640, NAME_LENGTH - 1, 1);
 	string_copy(The_mission.loading_screen[GR_1024], m_loading_1024, NAME_LENGTH - 1, 1);
@@ -388,7 +388,7 @@ BOOL CMissionNotesDlg::OnInitDialog()
 	team = (CButton *)GetDlgItem(IDC_TEAMVTEAM);
 	dogfight = (CButton *)GetDlgItem(IDC_DOGFIGHT);
 
-	m_mission_title_orig = m_mission_title = _T(The_mission.name);
+	m_mission_title_orig = m_mission_title = _T(The_mission.name.c_str());
 	m_designer_name_orig = m_designer_name = _T(The_mission.author.c_str());
 	m_created = _T(The_mission.created);
 	m_modified = _T(The_mission.modified);

--- a/fred2/voiceactingmanager.cpp
+++ b/fred2/voiceactingmanager.cpp
@@ -408,7 +408,7 @@ void VoiceActingManager::OnGenerateScript()
 	}
 
 	fout("%s\n", Mission_filename);
-	fout("%s\n\n", The_mission.name);
+	fout("%s\n\n", The_mission.name.c_str());
 
 	if (m_export_everything || m_export_command_briefings)
 	{

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -308,7 +308,7 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 			SCP_string msg;
 			sprintf(msg,
 					"Fred encountered unknown ship/prop/weapon classes when importing \"%s\" (path \"%s\"). You will have to manually edit the converted mission to correct this.",
-					The_mission.name,
+					The_mission.name.c_str(),
 					filepath.c_str());
 
 			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Warning,
@@ -455,7 +455,7 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 
 	if (flags & MPF_IS_TEMPLATE) {
 		// reset fields that should not carry over from the template source
-		strcpy_s(The_mission.name, "Untitled");
+		The_mission.name = "Untitled";
 		The_mission.author = getUsername();
 
 		time_t currentTime;
@@ -592,7 +592,7 @@ void Editor::clearMission(bool fast_reload) {
 	time(&currentTime);
 	auto timeinfo = localtime(&currentTime);
 
-	strcpy_s(The_mission.name, "Untitled");
+	The_mission.name = "Untitled";
 	The_mission.author = userName;
 	time_to_mission_info_string(timeinfo, The_mission.created, DATE_TIME_LENGTH - 1);
 	strcpy_s(The_mission.modified, The_mission.created);

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -149,7 +149,7 @@ bool MissionSpecDialogModel::apply() {
 	// puts "$End Notes:" on a different line to ensure it's not interpreted as part of a comment
 	Editor::pad_with_newline(_m_mission_notes, NOTES_LENGTH - 1);
 
-	strncpy(The_mission.name, _m_mission_title.c_str(), NAME_LENGTH-1);
+	The_mission.name = _m_mission_title;
 	The_mission.author = _m_designer_name;
 	strncpy(The_mission.loading_screen[GR_640], _m_loading_640.c_str(), NAME_LENGTH-1);
 	strncpy(The_mission.loading_screen[GR_1024], _m_loading_1024.c_str(), NAME_LENGTH-1);

--- a/qtfred/src/mission/dialogs/VoiceActingManagerModel.cpp
+++ b/qtfred/src/mission/dialogs/VoiceActingManagerModel.cpp
@@ -353,7 +353,7 @@ bool VoiceActingManagerModel::generateScript(const SCP_string& absoluteFilePath)
 
 	// Mission metadata
 	fout(fp, "%s\n", Mission_filename);
-	fout(fp, "%s\n\n", The_mission.name);
+	fout(fp, "%s\n\n", The_mission.name.c_str());
 
 	auto writeMessageEntry = [&](const char* filename,
 								 const SCP_string& text,

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -529,8 +529,8 @@ void CampaignEditorDialog::on_availableMissionsListWidget_itemSelectionChanged()
 		return;
 	}
 
-	if (mission_info.name[0] != '\0') {
-		ui->missionNameLineEdit->setText(QString::fromUtf8(mission_info.name));
+	if (!mission_info.name.empty()) {
+		ui->missionNameLineEdit->setText(QString::fromStdString(mission_info.name));
 	} else {
 		ui->missionNameLineEdit->clear();
 	}
@@ -554,8 +554,8 @@ void CampaignEditorDialog::on_graphView_missionSelected(int missionIndex) {
 		return;
 	}
 
-	if (mission_info.name[0] != '\0') {
-		ui->missionNameLineEdit->setText(QString::fromUtf8(mission_info.name));
+	if (!mission_info.name.empty()) {
+		ui->missionNameLineEdit->setText(QString::fromStdString(mission_info.name));
 	} else {
 		ui->missionNameLineEdit->clear();
 	}

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -23,8 +23,6 @@ MissionSpecDialog::MissionSpecDialog(FredView* parent, EditorViewport* viewport)
 	_viewport(viewport) {
     ui->setupUi(this);
 
-	ui->missionTitle->setMaxLength(NAME_LENGTH - 1);
-	ui->missionDesigner->setMaxLength(NAME_LENGTH - 1);
 	ui->squadronName->setMaxLength(NAME_LENGTH - 1);
 	ui->squadronLogo->setMaxLength(MAX_FILENAME_LEN - 1);
 	ui->lowResScreen->setMaxLength(MAX_FILENAME_LEN - 1);


### PR DESCRIPTION
Some code refactoring to allow mission titles to be strings of any length.  Titles that are too long to actually display (based on string width) will be visibly truncated using `font::force_fit_string`, but the underlying title will not be affected.  Multiplayer is still subject to the 31-character length limit, so titles sent over the network will still have characters truncated.

Also removes some redundant calls to `gr_get_string_size`, since `font::force_fit_string` returns the fitted string width.