### PR TITLE
Fix edge case in switching from None AA to SMAA

### DIFF
--- a/code/graphics/opengl/gropenglpostprocessing.cpp
+++ b/code/graphics/opengl/gropenglpostprocessing.cpp
@@ -1111,9 +1111,11 @@ static bool opengl_post_init_framebuffer()
 
 	opengl_setup_bloom_textures();
 
-	if (Gr_aa_mode != AntiAliasMode::None) {
+	// Always set up SMAA resources so the user can switch to an SMAA preset
+	// at runtime even when starting with a non-SMAA AA mode, such as None.
+	//if (Gr_aa_mode != AntiAliasMode::None) {
 		setup_smaa_resources();
-	}
+	//}
 
 	GL_state.BindFrameBuffer(0);
 


### PR DESCRIPTION
If you set AA level to None, save, then close the game, then re-enter the game and switch the AA mode to an SMAA mode, then the screen will just be black until the game is restarted. This does not happen when switching from None to FXAA because FXAA works because its post-pass uses `Scene_luminance_texture` and `Scene_ldr_texture`, which are always created as part of standard scene setup.

There are two ways to fix this, either require AA mode to require a game restart (though that may complicate the lab) or allow resource allocation for SMAA always.

Honestly I like the idea of keeping the lower-end machines optimized and not allocating for SMAA but simply running it always but for this PR have just allowed it always run.

Happy to discuss whichever option folks think is best!