### PR TITLE
QtFRED Trim The Fat

### DIFF
--- a/code/object/object.h
+++ b/code/object/object.h
@@ -43,7 +43,7 @@
 #define OBJ_DEBRIS          6	//a flying piece of ship debris
 //#define OBJ_CMEASURE      7	//a countermeasure, such as chaff
 #define OBJ_GHOST           8	//so far, just a placeholder for when a player dies.
-#define OBJ_POINT           9	//generic object type to display a point in Fred.
+#define OBJ_POINT           9	// FRED2 briefing icons only; not used by QtFRED.  Deprecate with FRED2.
 #define OBJ_SHOCKWAVE       10	// a shockwave
 #define OBJ_WING            11	// not really a type used anywhere, but I need it for Fred.
 #define OBJ_OBSERVER        12	// used for multiplayer observers (possibly single player later)

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -7,9 +7,7 @@
 
 #include <SDL.h>
 #include <ai/ai.h>
-#include <sound/audiostr.h>
 #include <parse/parselo.h>
-#include <missionui/fictionviewer.h>
 #include <mission/missiongoals.h>
 #include <mission/missionparse.h>
 #include <asteroid/asteroid.h>
@@ -490,11 +488,6 @@ bool Editor::loadMission(const std::string& mission_name, int flags) {
 	return true;
 }
 void Editor::clean_up_selections() {
-#if 0
-	if (Briefing_dialog)
-		Briefing_dialog->icon_select(-1);
-#endif
-
 	unmark_all();
 }
 void Editor::unmark_all() {
@@ -556,11 +549,6 @@ void Editor::unmarkObject(int obj) {
 void Editor::clearMission(bool fast_reload) {
 	// clean up everything we need to before we reset back to defaults.
 	clean_up_selections();
-#if 0
-    if (Briefing_dialog){
-        Briefing_dialog->reset_editor();
-    }
-#endif
 
 	allocate_parse_text(PARSE_TEXT_SIZE);
 
@@ -671,14 +659,6 @@ void Editor::setupCurrentObjectIndices(int selectedObj) {
 		if ((Objects[selectedObj].type == OBJ_SHIP) || (Objects[selectedObj].type == OBJ_START)) {
 			cur_ship = Objects[selectedObj].instance;
 			cur_wing = Ships[cur_ship].wingnum;
-			if (cur_wing >= 0) {
-				for (auto i = 0; i < Wings[cur_wing].wave_count; i++) {
-					if (wing_objects[cur_wing][i] == currentObject) {
-						cur_wing_index = i;
-						break;
-					}
-				}
-			}
 		} else if (Objects[selectedObj].type == OBJ_WAYPOINT) {
 			cur_waypoint = find_waypoint_with_instance(Objects[selectedObj].instance);
 			Assert(cur_waypoint != nullptr);
@@ -720,12 +700,6 @@ void Editor::setupCurrentObjectIndices(int selectedObj) {
 	if (ptr->type == OBJ_SHIP) {
 		cur_ship = ptr->instance;
 		cur_wing = Ships[cur_ship].wingnum;
-		for (auto i = 0; i < Wings[cur_wing].wave_count; i++) {
-			if (wing_objects[cur_wing][i] == currentObject) {
-				cur_wing_index = i;
-				break;
-			}
-		}
 	} else if (ptr->type == OBJ_WAYPOINT) {
 		cur_waypoint = find_waypoint_with_instance(ptr->instance);
 		Assert(cur_waypoint != nullptr);
@@ -1185,16 +1159,6 @@ int Editor::common_object_delete(int obj) {
 			ai_do_objects_undocked_stuff(&Objects[obj], dock_get_first_docked_object(&Objects[obj]));
 		}
 
-	} else if (type == OBJ_POINT) {
-		/*
-		 TODO: Implement briefing dialog
-
-		Assert(Briefing_dialog);
-		Briefing_dialog->delete_icon(Objects[obj].instance);
-		Update_window = 1;
-		 */
-		return 0;
-
 	} else if (type == OBJ_JUMP_NODE) {
 		for (jnp = Jump_nodes.begin(); jnp != Jump_nodes.end(); ++jnp) {
 			if (jnp->GetSCPObject() == &Objects[obj]) {
@@ -1320,7 +1284,6 @@ int Editor::reference_handler(const char* name, sexp_ref_type type, int obj) {
 			Warning(LOCATION, "\"%s\" referenced by an unknown sexp source!  "
 				"Run for the hills and let Hoffoss know right now!", name);
 
-			delete_flag = 1;
 			return 2;
 		}
 
@@ -1338,7 +1301,6 @@ int Editor::reference_handler(const char* name, sexp_ref_type type, int obj) {
 		}
 
 		if (r == 2) {
-			delete_flag = 1;
 			return 2;
 		}
 	}
@@ -1376,7 +1338,6 @@ int Editor::reference_handler(const char* name, sexp_ref_type type, int obj) {
 		}
 
 		if (r == 2) {
-			delete_flag = 1;
 			return 2;
 		}
 	}
@@ -1424,40 +1385,6 @@ int Editor::orders_reference_handler(sexp_src /*source*/, int /*source_index*/, 
 		return 0;
 	}
 
-	// TODO: add a generic dialog system for showing these dialogs
-	/*
-	ShipGoalsDlg dlg_goals;
-
-	switch (source) {
-	case sexp_src::SHIP_ORDER:
-		unmark_all();
-		mark_object(Ships[source_index].objnum);
-
-		dlg_goals.self_ship = source_index;
-		dlg_goals.DoModal();
-		if (!query_initial_orders_empty(Ai_info[Ships[source_index].ai_index].goals))
-			if ((Ships[source_index].wingnum >= 0) && (query_initial_orders_conflict(Ships[source_index].wingnum)))
-				Fred_main_wnd->MessageBox("This ship's wing also has initial orders", "Possible conflict");
-
-		break;
-
-	case sexp_src::WING_ORDER:
-		unmark_all();
-		mark_wing(source_index);
-
-		dlg_goals.self_wing = source_index;
-		dlg_goals.DoModal();
-		if (query_initial_orders_conflict(source_index))
-			Fred_main_wnd->MessageBox("One or more ships of this wing also has initial orders", "Possible conflict");
-
-		break;
-
-	default:  // very bad.  Someone added an sexp somewhere and didn't change this.
-		Error(LOCATION, "Unknown initial order reference source");
-	}
-	*/
-
-	delete_flag = 1;
 	return 2;
 }
 int Editor::sexp_reference_handler(int  /*node*/, sexp_src /*source*/, int /*source_index*/, const char* msg) {
@@ -1475,89 +1402,6 @@ int Editor::sexp_reference_handler(int  /*node*/, sexp_src /*source*/, int /*sou
 		return 0;
 	}
 
-	// TODO: add a generic dialog system for showing these dialogs
-	/*
-	int n = source_index;
-	switch (source) {
-	case sexp_src::SHIP_ARRIVAL:
-	case sexp_src::SHIP_DEPARTURE:
-		if (!Ship_editor_dialog.GetSafeHwnd())
-			Ship_editor_dialog.Create();
-
-		Ship_editor_dialog.SetWindowPos(&Fred_main_wnd->wndTop, 0, 0, 0, 0,
-										SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
-		Ship_editor_dialog.ShowWindow(SW_RESTORE);
-
-		Ship_editor_dialog.select_sexp_node = node;
-		unmark_all();
-		mark_object(Ships[n].objnum);
-		break;
-
-	case sexp_src::WING_ARRIVAL:
-	case sexp_src::WING_DEPARTURE:
-		if (!Wing_editor_dialog.GetSafeHwnd())
-			Wing_editor_dialog.Create();
-
-		Wing_editor_dialog.SetWindowPos(&Fred_main_wnd->wndTop, 0, 0, 0, 0,
-										SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
-		Wing_editor_dialog.ShowWindow(SW_RESTORE);
-
-		Wing_editor_dialog.select_sexp_node = node;
-		unmark_all();
-		mark_wing(n);
-		break;
-
-	case sexp_src::EVENT:
-		if (Message_editor_dlg) {
-			Fred_main_wnd->MessageBox("You must close the message editor before the event editor can be opened");
-			break;
-		}
-
-		if (!Event_editor_dlg) {
-			Event_editor_dlg = new event_editor;
-			Event_editor_dlg->select_sexp_node = node;
-			Event_editor_dlg->Create(event_editor::IDD);
-		}
-
-		Event_editor_dlg->SetWindowPos(&CWnd::wndTop, 0, 0, 0, 0, SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
-		Event_editor_dlg->ShowWindow(SW_RESTORE);
-		break;
-
-	case sexp_src::MISSION_GOAL: {
-		CMissionGoalsDlg dlg;
-
-		dlg.select_sexp_node = node;
-		dlg.DoModal();
-		break;
-	}
-
-	case sexp_src::DEBRIEFING: {
-		debriefing_editor_dlg dlg;
-
-		dlg.select_sexp_node = node;
-		dlg.DoModal();
-		break;
-	}
-
-	case sexp_src::BRIEFING: {
-		if (!Briefing_dialog) {
-			Briefing_dialog = new briefing_editor_dlg;
-			Briefing_dialog->create();
-		}
-
-		Briefing_dialog->SetWindowPos(&Briefing_dialog->wndTop, 0, 0, 0, 0,
-									  SWP_SHOWWINDOW | SWP_NOMOVE | SWP_NOSIZE);
-		Briefing_dialog->ShowWindow(SW_RESTORE);
-		Briefing_dialog->focus_sexp(node);
-		break;
-	}
-
-	default:  // very bad.  Someone added an sexp somewhere and didn't change this.
-		Error(LOCATION, "Unknown sexp reference source");
-	}
-	 */
-
-	delete_flag = 1;
 	return 2;
 }
 int Editor::delete_ship_from_wing(int ship) {
@@ -1570,10 +1414,6 @@ int Editor::delete_ship_from_wing(int ship) {
 			cur_wing = -1;
 			r = delete_wing(wing, 1);
 			if (r) {
-				if (r == 2) {
-					delete_flag = 1;
-				}
-
 				return r;
 			}
 
@@ -1892,13 +1732,14 @@ void Editor::updateStartingWingLoadoutUseCounts() {
 }
 void Editor::delete_marked() {
 	object* ptr, * next;
+	bool navigated_to_reference = false;
 
-	delete_flag = 0;
 	ptr = GET_FIRST(&obj_used_list);
 	while (ptr != END_OF_LIST(&obj_used_list)) {
 		next = GET_NEXT(ptr);
 		if (ptr->flags[Object::Object_Flags::Marked]) {
 			if (delete_object(OBJ_INDEX(ptr)) == 2) {  // user went to a reference, so don't get in the way.
+				navigated_to_reference = true;
 				break;
 			}
 		}
@@ -1906,7 +1747,7 @@ void Editor::delete_marked() {
 		ptr = next;
 	}
 
-	if (!delete_flag) {
+	if (!navigated_to_reference) {
 		setupCurrentObjectIndices(-1);
 	}
 
@@ -2215,15 +2056,6 @@ void Editor::pad_with_newline(SCP_string& str, size_t max_size) {
 	if (!len || (str.back() != '\n' && len < max_size)) {
 		str += "\n";
 	}
-}
-
-void Editor::lcl_fred_replace_stuff(QString& text)
-{
-	// this should be kept in sync with the function in localize.cpp
-	text.replace("\"", "$quote");
-	text.replace(";", "$semicolon");
-	text.replace("/", "$slash");
-	text.replace("\\", "$backslash");
 }
 
 SCP_string Editor::get_display_name_for_text_box(const SCP_string &orig_name)

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -199,8 +199,6 @@ class Editor : public QObject {
 	int cur_wing = -1;
 	int cur_ship = -1;
 
-	int cur_wing_index = -1;
-
 	waypoint* cur_waypoint = nullptr;
 	waypoint_list* cur_waypoint_list = nullptr;
 
@@ -273,7 +271,6 @@ class Editor : public QObject {
 
 	static void strip_quotation_marks(SCP_string& str);
 	static void pad_with_newline(SCP_string& str, size_t max_size);
-	static void lcl_fred_replace_stuff(QString& text);
 	static SCP_string get_display_name_for_text_box(const SCP_string &orig_name);
 
 	SCP_vector<int> getStartingWingLoadoutUseCounts();
@@ -302,8 +299,6 @@ class Editor : public QObject {
 
 	SCP_vector<GlobalShieldStatus> Shield_sys_teams;
 	SCP_vector<GlobalShieldStatus> Shield_sys_types;
-
-	int delete_flag;
 
 	bool already_deleting_wing = false;
 

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -256,7 +256,7 @@ bool EditorViewport::incMissionTime() {
 	return true;
 }
 void EditorViewport::select_objects(const Marking_box& box) {
-	int x, y, valid, icon_mode = 0;
+	int x, y, valid;
 	vertex v;
 	object* ptr;
 
@@ -335,26 +335,11 @@ void EditorViewport::select_objects(const Marking_box& box) {
 					} else {
 						editor->markObject(OBJ_INDEX(ptr));
 					}
-
-					if (ptr->type == OBJ_POINT) {
-						icon_mode = 1;
-					}
 				}
 			}
 		}
 
 		ptr = GET_NEXT(ptr);
-	}
-
-	if (icon_mode) {
-		ptr = GET_FIRST(&obj_used_list);
-		while (ptr != END_OF_LIST(&obj_used_list)) {
-			if ((ptr->flags[Object::Object_Flags::Marked]) && (ptr->type != OBJ_POINT)) {
-				editor->unmarkObject(OBJ_INDEX(ptr));
-			}
-
-			ptr = GET_NEXT(ptr);
-		}
 	}
 
 	needsUpdate();
@@ -660,7 +645,7 @@ void EditorViewport::level_object(matrix* orient) {
 int EditorViewport::object_check_collision(object* objp, vec3d* p0, vec3d* p1, vec3d* hitpos) {
 	mc_info mc;
 
-	if ((objp->type == OBJ_NONE) || (objp->type == OBJ_POINT)) {
+	if (objp->type == OBJ_NONE) {
 		return 0;
 	}
 

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -41,8 +41,6 @@ const float FRED_DEAFULT_HTL_DRAW_DIST = 300000.0f;
 const int FRED_COLOUR_WHITE = 0xffffff;
 const int FRED_COLOUR_YELLOW_GREEN = 0xc8ff00;
 
-const int BRIEFING_LOOKAT_POINT_ID = 99999;
-
 void enable_htl() {
 	gr_set_proj_matrix((4.0f / 9.0f) * PI * FRED_DEFAULT_HTL_FOV,
 					   gr_screen.aspect * static_cast<float>(gr_screen.clip_width)
@@ -473,11 +471,6 @@ void FredRenderer::display_ship_info(int cur_object_index) {
 							continue;
 						}
 						sprintf(buf, "%s\nWaypoint %d", wp_list->get_name(), idx + 1);
-					} else if (objp->type == OBJ_POINT) {
-						if (objp->instance == BRIEFING_LOOKAT_POINT_ID)
-							strcpy_s(buf, "Camera lookat point");
-						else
-							strcpy_s(buf, "Briefing icon");
 					} else if (objp->type == OBJ_JUMP_NODE) {
 						CJumpNode* jnp = jumpnode_get_by_objnum(OBJ_INDEX(objp));
 						sprintf(buf, "%s\n%s", jnp->GetName(), jnp->GetDisplayName());
@@ -654,6 +647,10 @@ void FredRenderer::render_one_model_htl(object* objp,
 	object* o2;
 
 	Assert(objp->type != OBJ_NONE);
+	// OBJ_POINT objects (briefing icons / camera lookat) are a FRED2-era construct.  QtFRED's
+	// briefing dialog renders its icons in its own widget and never adds them to the main
+	// object list, so encountering one here means something has gone very wrong.
+	Assertion(objp->type != OBJ_POINT, "OBJ_POINT object (instance %d) appeared in the main editor's render loop; QtFRED does not support OBJ_POINT objects.", objp->instance);
 
 	// if this object isn't fully created yet, don't render it
 	if (objp->type == OBJ_SHIP && Ships[objp->instance].create_time == 0)
@@ -849,16 +846,6 @@ void FredRenderer::render_one_model_htl(object* objp,
 				g = 0;
 				b = 112;
 			}
-		} else if (objp->type == OBJ_POINT) {
-			if (objp->instance != BRIEFING_LOOKAT_POINT_ID) {
-				///! \fixme Briefing stuff!
-				//Assert(Briefing_dialog);
-				return;
-			}
-
-			r = 196;
-			g = 32;
-			b = 196;
 		} else if (objp->type == OBJ_PROP) {
 			r = 255;
 			g = 255;
@@ -1021,8 +1008,6 @@ void FredRenderer::render_frame(int cur_object_index,
 						pos.xyz.y,
 						pos.xyz.z);
 			}
-		} else if (Objects[_viewport->Cursor_over].type == OBJ_POINT) {
-			sprintf(buf, "Briefing icon\n( %.1f , %.1f , %.1f ) ", pos.xyz.x, pos.xyz.y, pos.xyz.z);
 		} else {
 			sprintf(buf, "( %.1f , %.1f , %.1f ) ", pos.xyz.x, pos.xyz.y, pos.xyz.z);
 		}

--- a/qtfred/src/mission/dialogs/ObjectOrientEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ObjectOrientEditorDialogModel.cpp
@@ -56,8 +56,6 @@ void ObjectOrientEditorDialogModel::initializeData()
 					if (Props[ptr->instance].has_value())
 						_pointToObjectList.emplace_back(ObjectEntry(Props[ptr->instance]->prop_name, OBJ_INDEX(ptr)));
 					break;
-				case OBJ_POINT:
-					break;
 				default:
 					Assertion(false, "Unknown object type in Object Orient Dialog!"); // unknown object type
 			}

--- a/qtfred/src/mission/object.cpp
+++ b/qtfred/src/mission/object.cpp
@@ -65,9 +65,6 @@ const char* object_name(int obj) {
 		waypoint_stuff_name(text, Objects[obj].instance);
 		return text;
 
-	case OBJ_POINT:
-		return "Briefing icon";
-
 	case OBJ_JUMP_NODE: {
 		const CJumpNode* jnp = jumpnode_get_by_objnum(obj);
 		if (jnp != nullptr)

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -2555,8 +2555,6 @@ void FredView::handleObjectEditor(int objNum) {
 				// If this is a waypoint, we need to show the waypoint editor
 				on_actionWaypoint_Paths_triggered(false);
 			}
-		} else if (Objects[objNum].type == OBJ_POINT) {
-			return;
 		} else {
 			UNREACHABLE("Unhandled object type!");
 		}

--- a/qtfred/src/ui/util/ErrorChecker.cpp
+++ b/qtfred/src/ui/util/ErrorChecker.cpp
@@ -342,8 +342,6 @@ int ErrorChecker::checkObjectList() {
 			char buf[256];
 			waypoint_stuff_name(buf, i);
 			entry.name = buf;
-		} else if (ptr->type == OBJ_POINT) {
-			// Briefing icons are editor-only objects, not mission objects; nothing to validate here.
 		} else if (ptr->type == OBJ_JUMP_NODE || ptr->type == OBJ_PROP) {
 			// nothing needed
 		} else {


### PR DESCRIPTION
Removes a lot of dead code and FRED2 era cruft that QtFRED doesn't use, especially in editor.cpp. This was mostly briefing related code from before briefing dialog got it's own viewport and some other code that's been long commented out.

Some notes:

This does remove some commented out code intended to be used for a navigate to sexp usage upon obj delete feature. That is still on my todo list but I don't want to be beholden to past attempts. So yeet it all now and provide a clean slate.

`cur_wing_index` is removed entirely. It was copied from FRED2 where even there it is dead, only written to and never read. The loops that set this variable are also removed.

`Editor::lcl_fred_replace_stuff(QString&)` was also dead. It was added by Goober way back in 2023 and never used. All models run with SCP_string through the version in localize.cpp which is the preferred way anyway. Keeping this overload present and synced is just busy work. _Yeet_

`delete_flag` was really just a shadow of information that already flows naturally through the existing `delete_object() == 2` return value. All six original writes of this flag to 1 were just before those functions returned 2 so we just use that and simplify the whole thing.

`OBJ_POINT` is an object type exclusive to FRED2 now. It's used by FRED2's briefing editor for icons. QtFRED uses the in-mission briefing renderer, so icons are not objects here.. they're just icons. The only create calls for OBJ_POINT now are in the FRED2 project. Once FRED2 is deprecated, that whole object type can go with it.