### PR TITLE
Qtfred & FRED fix object cloning

### DIFF
--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -258,6 +258,16 @@ void CJumpNode::SetModel(const char *model_name, bool show_polys)
 	m_flags |= JN_SPECIAL_MODEL;
 	m_radius = model_get_radius(m_modelnum);
 
+	// keep the engine-side object radius in sync with the new model.  The
+	// in-game jump-into-subspace check uses model_get_radius() directly so it
+	// is unaffected, but render culling, HUD brackets and FRED selection all
+	// read Objects[].radius - leaving it at the default-model radius makes the
+	// node cull/bracket at the wrong size after a $Special Model parse or a
+	// set-jumpnode-model sexp.
+	if (m_objnum >= 0) {
+		Objects[m_objnum].radius = m_radius;
+	}
+
 	//Do we want to change poly showing?
 	if(show_polys)
 		m_flags |= JN_SHOW_POLYS;

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5931,6 +5931,10 @@ void parse_goals(mission *pm)
 		throw parse::ParseException("Number of goals is too high and breaks multi!");
 }
 
+// Per-waypoint-path field handling here MUST stay in sync with:
+//   Fred_mission_save::save_waypoints() (waypoint-list section) in missionsave.cpp
+//   clone_waypoint_path_instance_data() in missioneditor/objectduplication.cpp
+// When you add a new editable waypoint-path field, touch all three.
 void parse_waypoint_list(mission *pm)
 {
 	Assert(pm != NULL);

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -2280,6 +2280,11 @@ void parse_copy_wing_ai_to_ship(wing *wingp, ai_info *aip);
 /**
  * Given a stuffed p_object struct, create an object and fill in the necessary fields.
  * @return object number.
+ *
+ * Per-ship field handling here MUST stay in sync with:
+ *   Fred_mission_save::save_objects() / save_common_object_data() in missionsave.cpp
+ *   clone_ship_instance_data() in missioneditor/objectduplication.cpp
+ * When you add a new editable ship field, touch all three.
  */
 int parse_create_object_sub(p_object *p_objp, bool standalone_ship)
 {

--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -5251,6 +5251,10 @@ void parse_wing(mission *pm)
 	// Goober5000 - wing creation stuff moved to post_process_ships_wings
 }
 
+// Per-prop field handling here MUST stay in sync with:
+//   Fred_mission_save::save_props() in missionsave.cpp
+//   clone_prop_instance_data() in missioneditor/objectduplication.cpp
+// When you add a new editable prop field, touch all three.
 void parse_prop(mission* /*pm*/)
 {
 	parsed_prop p;
@@ -5978,6 +5982,10 @@ void parse_waypoint_list(mission *pm)
 	}
 }
 
+// The jump-node section of this function MUST stay in sync with:
+//   Fred_mission_save::save_waypoints() (jump-node section) in missionsave.cpp
+//   clone_jump_node_instance_data() in missioneditor/objectduplication.cpp
+// When you add a new editable jump-node field, touch all three.
 void parse_waypoints_and_jumpnodes(mission *pm)
 {
 	vec3d pos;

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -4940,6 +4940,10 @@ int Fred_mission_save::save_waypoints()
 		fso_comment_pop();
 	}
 
+	// Per-waypoint-path field handling here MUST stay in sync with:
+	//   parse_waypoint_list() in missionparse.cpp
+	//   clone_waypoint_path_instance_data() in missioneditor/objectduplication.cpp
+	// When you add a new editable waypoint-path field, touch all three.
 	bool first_wpt_list = true;
 	for (const auto& ii : Waypoint_lists) {
 		required_string_either_fred("$Name:", "#Messages");

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -4846,6 +4846,10 @@ int Fred_mission_save::save_vector(const vec3d& v)
 	return 0;
 }
 
+// The jump-node section of this function MUST stay in sync with:
+//   the "$Jump Node:" parse block in missionparse.cpp
+//   clone_jump_node_instance_data() in missioneditor/objectduplication.cpp
+// When you add a new editable jump-node field, touch all three.
 int Fred_mission_save::save_waypoints()
 {
 	// object *ptr;
@@ -5289,6 +5293,10 @@ int Fred_mission_save::save_wings()
 	return err;
 }
 
+// Per-prop field handling here MUST stay in sync with:
+//   parse_prop() in missionparse.cpp
+//   clone_prop_instance_data() in missioneditor/objectduplication.cpp
+// When you add a new editable prop field, touch all three.
 int Fred_mission_save::save_props()
 {
 	auto num_props = count_items_with_value(Props);

--- a/code/missioneditor/missionsave.cpp
+++ b/code/missioneditor/missionsave.cpp
@@ -1442,6 +1442,10 @@ void Fred_mission_save::fso_comment_pop(bool pop_all)
 	fso_ver_comment.pop_back();
 }
 
+// Per-ship field handling here MUST stay in sync with:
+//   parse_create_object_sub() in missionparse.cpp
+//   clone_ship_instance_data() in missioneditor/objectduplication.cpp
+// When you add a new editable ship field, touch all three.
 int Fred_mission_save::save_common_object_data(object* objp, ship* shipp)
 {
 	int j, z;
@@ -3474,6 +3478,10 @@ int Fred_mission_save::save_warp_params(WarpDirection direction, ship* shipp)
 	return err;
 }
 
+// Per-ship field handling here MUST stay in sync with:
+//   parse_create_object_sub() in missionparse.cpp
+//   clone_ship_instance_data() in missioneditor/objectduplication.cpp
+// When you add a new editable ship field, touch all three.
 int Fred_mission_save::save_objects()
 {
 	SCP_string sexp_out;

--- a/code/missioneditor/objectduplication.cpp
+++ b/code/missioneditor/objectduplication.cpp
@@ -9,6 +9,7 @@
 #include "mission/missionparse.h"
 #include "model/model.h"
 #include "object/object.h"
+#include "object/waypoint.h"
 #include "parse/sexp.h"
 #include "prop/prop.h"
 #include "ship/ship.h"
@@ -267,4 +268,24 @@ void clone_jump_node_instance_data(const CJumpNode& src, CJumpNode& dest)
 
 	// fred view layer
 	dest.SetFredLayer(src.GetFredLayer());
+}
+
+// Per-path field handling here MUST stay in sync with:
+//   Fred_mission_save::save_waypoints() (waypoint-list section) in missionsave.cpp
+//   parse_waypoint_list() in missionparse.cpp
+void clone_waypoint_path_instance_data(int src_list_index, int dest_list_index)
+{
+	waypoint_list* src = find_waypoint_list_at_index(src_list_index);
+	waypoint_list* dest = find_waypoint_list_at_index(dest_list_index);
+	if (src == nullptr || dest == nullptr || src == dest) {
+		return;
+	}
+
+	dest->set_no_draw_lines(src->get_no_draw_lines());
+	if (src->get_has_custom_color()) {
+		dest->set_color(src->get_color_r(), src->get_color_g(), src->get_color_b());
+	} else {
+		dest->clear_color();
+	}
+	dest->set_fred_layer(src->get_fred_layer());
 }

--- a/code/missioneditor/objectduplication.cpp
+++ b/code/missioneditor/objectduplication.cpp
@@ -5,9 +5,12 @@
 
 #include "ai/ai.h"
 #include "globalincs/linklist.h"
+#include "jumpnode/jumpnode.h"
 #include "mission/missionparse.h"
+#include "model/model.h"
 #include "object/object.h"
 #include "parse/sexp.h"
+#include "prop/prop.h"
 #include "ship/ship.h"
 
 // FRED/QtFRED each own their own copy of these arrays (defined in
@@ -210,4 +213,58 @@ void clone_ship_instance_data(int src_shipnum, int dest_shipnum)
 			Fred_texture_replacements.push_back(std::move(entry));
 		}
 	}
+}
+
+// Per-prop field handling here MUST stay in sync with:
+//   Fred_mission_save::save_props() in missionsave.cpp
+//   parse_prop() in missionparse.cpp
+void clone_prop_instance_data(int src_prop_id, int dest_prop_id)
+{
+	Assertion(src_prop_id != dest_prop_id, "clone_prop_instance_data: src and dest are the same prop");
+
+	prop* src = prop_id_lookup(src_prop_id);
+	prop* dest = prop_id_lookup(dest_prop_id);
+	Assertion(src && dest, "clone_prop_instance_data: invalid src or dest prop id");
+	Assertion(src->prop_info_index == dest->prop_info_index, "clone_prop_instance_data: dest must be the same prop class as src");
+
+	// fred view layer
+	dest->fred_layer = src->fred_layer;
+
+	// object flag the prop editor exposes (see save_props)
+	if (Objects[src->objnum].flags[Object::Object_Flags::Collides]) {
+		Objects[dest->objnum].flags.set(Object::Object_Flags::Collides);
+	} else {
+		Objects[dest->objnum].flags.remove(Object::Object_Flags::Collides);
+	}
+}
+
+// Per-jump-node field handling here MUST stay in sync with:
+//   Fred_mission_save::save_waypoints() jump-node section in missionsave.cpp
+//   the "$Jump Node:" parse block in missionparse.cpp
+void clone_jump_node_instance_data(const CJumpNode& src, CJumpNode& dest)
+{
+	// display name (the JN_HAS_DISPLAY_NAME flag is set by SetDisplayName)
+	if (src.HasDisplayName()) {
+		dest.SetDisplayName(src.GetDisplayName());
+	}
+
+	// special model - SetModel also sets m_radius and the JN_SPECIAL_MODEL flag.
+	// Parse uses default show_polys=false; JN_SHOW_POLYS isn't persisted, so we
+	// don't carry it across either.
+	if (src.IsSpecialModel()) {
+		polymodel* pm = model_get(src.GetModelNumber());
+		if (pm) {
+			dest.SetModel(pm->filename);
+		}
+	}
+
+	// color (SetAlphaColor manages the JN_USE_DISPLAY_COLOR flag)
+	const color& c = src.GetColor();
+	dest.SetAlphaColor(c.red, c.green, c.blue, c.alpha);
+
+	// hidden state
+	dest.SetVisibility(!src.IsHidden());
+
+	// fred view layer
+	dest.SetFredLayer(src.GetFredLayer());
 }

--- a/code/missioneditor/objectduplication.cpp
+++ b/code/missioneditor/objectduplication.cpp
@@ -1,0 +1,213 @@
+// Helpers for editor-side object duplication (Ctrl-drag, Clone Marked Objects).
+// Shared between FRED and QtFRED.
+
+#include "objectduplication.h"
+
+#include "ai/ai.h"
+#include "globalincs/linklist.h"
+#include "mission/missionparse.h"
+#include "object/object.h"
+#include "parse/sexp.h"
+#include "ship/ship.h"
+
+// FRED/QtFRED each own their own copy of these arrays (defined in
+// fred2/management.cpp and qtfred/src/mission/Editor.cpp)
+extern char Fred_alt_names[MAX_SHIPS][NAME_LENGTH + 1];
+extern char Fred_callsigns[MAX_SHIPS][NAME_LENGTH + 1];
+
+// Per-ship field handling here MUST stay in sync with:
+//   Fred_mission_save::save_objects() / save_common_object_data() in missionsave.cpp
+//   parse_create_object_sub() in missionparse.cpp
+// Field order below mirrors save_objects() so the two can be diffed.
+void clone_ship_instance_data(int src_shipnum, int dest_shipnum)
+{
+	Assertion(src_shipnum >= 0 && src_shipnum < MAX_SHIPS, "clone_ship_instance_data: bad src %d", src_shipnum);
+	Assertion(dest_shipnum >= 0 && dest_shipnum < MAX_SHIPS, "clone_ship_instance_data: bad dest %d", dest_shipnum);
+	Assertion(src_shipnum != dest_shipnum, "clone_ship_instance_data: src and dest are the same ship");
+
+	ship* src = &Ships[src_shipnum];
+	ship* dest = &Ships[dest_shipnum];
+	Assertion(src->ship_info_index == dest->ship_info_index, "clone_ship_instance_data: dest must be the same ship class as src");
+
+	object* src_obj = &Objects[src->objnum];
+	object* dest_obj = &Objects[dest->objnum];
+	ai_info* src_ai = &Ai_info[src->ai_index];
+	ai_info* dest_ai = &Ai_info[dest->ai_index];
+
+	// display name (the Has_display_name flag is carried via the bitset copy below)
+	dest->display_name = src->display_name;
+
+	// alt classes
+	dest->s_alt_classes = src->s_alt_classes;
+
+	// alt name / callsign
+	strcpy_s(Fred_alt_names[dest_shipnum], Fred_alt_names[src_shipnum]);
+	strcpy_s(Fred_callsigns[dest_shipnum], Fred_callsigns[src_shipnum]);
+	dest->alt_type_index = src->alt_type_index;
+	dest->callsign_index = src->callsign_index;
+
+	// team / team color
+	dest->team = src->team;
+	dest->team_name = src->team_name;
+	dest->ship_iff_color = src->ship_iff_color;
+
+	// AI class (lives both on the AI and mirrored on the ship's weapons struct;
+	// the weapons.ai_class part is included in the full weapons-struct copy below)
+	dest_ai->ai_class = src_ai->ai_class;
+
+	// AI goals
+	for (int i = 0; i < MAX_AI_GOALS; i++) {
+		dest_ai->goals[i] = src_ai->goals[i];
+	}
+
+	// cargo
+	dest->cargo1 = src->cargo1;
+	strcpy_s(dest->cargo_title, src->cargo_title);
+
+	// ===== begin save_common_object_data mirror =====
+
+	// initial velocity / hull / shields
+	dest_obj->phys_info.speed = src_obj->phys_info.speed;
+	dest_obj->phys_info.fspeed = src_obj->phys_info.fspeed;
+	dest_obj->hull_strength = src_obj->hull_strength;
+	dest_obj->shield_quadrant = src_obj->shield_quadrant;
+
+	// weapons (banks, ammo, ai_class... full struct, the assignment is a value copy)
+	dest->weapons = src->weapons;
+
+	// subsystems: walk the lists pairwise.  current_hits and max_hits both
+	// matter so that special-hitpoint scaling carries over; subsystem cargo
+	// and per-turret weapon loadout / ai_class are also editor-editable.
+	{
+		ship_subsys* sp_src = GET_FIRST(&src->subsys_list);
+		ship_subsys* sp_dest = GET_FIRST(&dest->subsys_list);
+		while (sp_dest != END_OF_LIST(&dest->subsys_list) && sp_src != END_OF_LIST(&src->subsys_list)) {
+			sp_dest->current_hits = sp_src->current_hits;
+			sp_dest->max_hits = sp_src->max_hits;
+			sp_dest->subsys_cargo_name = sp_src->subsys_cargo_name;
+			strcpy_s(sp_dest->subsys_cargo_title, sp_src->subsys_cargo_title);
+
+			if (sp_dest->system_info && sp_dest->system_info->type == SUBSYSTEM_TURRET) {
+				sp_dest->weapons = sp_src->weapons;
+			}
+
+			sp_src = GET_NEXT(sp_src);
+			sp_dest = GET_NEXT(sp_dest);
+		}
+	}
+
+	// ===== end save_common_object_data mirror =====
+
+	// arrival
+	dest->arrival_location = src->arrival_location;
+	dest->arrival_distance = src->arrival_distance;
+	dest->arrival_anchor = src->arrival_anchor;
+	dest->arrival_path_mask = src->arrival_path_mask;
+	dest->arrival_delay = src->arrival_delay;
+	dest->arrival_cue = dup_sexp_chain(src->arrival_cue);
+
+	// departure
+	dest->departure_location = src->departure_location;
+	dest->departure_anchor = src->departure_anchor;
+	dest->departure_path_mask = src->departure_path_mask;
+	dest->departure_delay = src->departure_delay;
+	dest->departure_cue = dup_sexp_chain(src->departure_cue);
+
+	// warp params
+	dest->warpin_params_index = src->warpin_params_index;
+	dest->warpout_params_index = src->warpout_params_index;
+
+	// ship flags
+	dest->flags = src->flags;
+	dest->flags.remove(Ship::Ship_Flags::Dying);
+	dest->flags.remove(Ship::Ship_Flags::Disabled);
+	dest->flags.remove(Ship::Ship_Flags::Depart_warp);
+	dest->flags.remove(Ship::Ship_Flags::Depart_dockbay);
+
+	// object flags (Explicit list of the editor-editable bits from save_objects)
+	const Object::Object_Flags editor_object_flags[] = {
+		Object::Object_Flags::Protected,
+		Object::Object_Flags::No_shields,
+		Object::Object_Flags::Invulnerable,
+		Object::Object_Flags::Beam_protected,
+		Object::Object_Flags::Flak_protected,
+		Object::Object_Flags::Laser_protected,
+		Object::Object_Flags::Missile_protected,
+		Object::Object_Flags::Special_warpin,
+		Object::Object_Flags::Targetable_as_bomb,
+		Object::Object_Flags::Dont_change_position,
+		Object::Object_Flags::Dont_change_orientation,
+		Object::Object_Flags::Collides,
+		Object::Object_Flags::Attackable_if_no_collide,
+	};
+	for (auto flag : editor_object_flags) {
+		if (src_obj->flags[flag]) {
+			dest_obj->flags.set(flag);
+		} else {
+			dest_obj->flags.remove(flag);
+		}
+	}
+
+	// AI flags
+	dest_ai->ai_flags = src_ai->ai_flags;
+	dest_ai->kamikaze_damage = src_ai->kamikaze_damage;
+
+	// respawn / escort / guardian
+	dest->respawn_priority = src->respawn_priority;
+	dest->escort_priority = src->escort_priority;
+	dest->ship_guardian_threshold = src->ship_guardian_threshold;
+
+	// special explosion
+	dest->use_special_explosion = src->use_special_explosion;
+	dest->special_exp_damage = src->special_exp_damage;
+	dest->special_exp_blast = src->special_exp_blast;
+	dest->special_exp_inner = src->special_exp_inner;
+	dest->special_exp_outer = src->special_exp_outer;
+	dest->use_shockwave = src->use_shockwave;
+	dest->special_exp_shockwave_speed = src->special_exp_shockwave_speed;
+	dest->special_exp_deathroll_time = src->special_exp_deathroll_time;
+
+	// special hitpoints / shield (and the derived max strengths the parse
+	// path sets at lines 2321-2326 of missionparse.cpp)
+	dest->special_hitpoints = src->special_hitpoints;
+	dest->special_shield = src->special_shield;
+	dest->ship_max_hull_strength = src->ship_max_hull_strength;
+	dest->ship_max_shield_strength = src->ship_max_shield_strength;
+	dest->max_shield_recharge = src->max_shield_recharge;
+	if (dest->special_hitpoints > 0) {
+		ship_recalc_subsys_strength(dest);
+	}
+
+	// hotkey
+	dest->hotkey = src->hotkey;
+
+	// destroy-at (Kill_before_mission flag already carried via shipp->flags)
+	dest->final_death_time = src->final_death_time;
+
+	// orders
+	dest->orders_accepted = src->orders_accepted;
+
+	// group / layer
+	dest->group = src->group;
+	dest->fred_layer = src->fred_layer;
+
+	// scoring / persona
+	dest->score = src->score;
+	dest->assist_score_pct = src->assist_score_pct;
+	dest->persona_index = src->persona_index;
+
+	// texture replacement... copy any entries whose ship_name matches src
+	{
+		SCP_vector<texture_replace> new_entries;
+		for (const auto& tr : Fred_texture_replacements) {
+			if (!stricmp(tr.ship_name, src->ship_name) && !(tr.from_table)) {
+				texture_replace copy = tr;
+				strcpy_s(copy.ship_name, dest->ship_name);
+				new_entries.push_back(copy);
+			}
+		}
+		for (auto& entry : new_entries) {
+			Fred_texture_replacements.push_back(std::move(entry));
+		}
+	}
+}

--- a/code/missioneditor/objectduplication.cpp
+++ b/code/missioneditor/objectduplication.cpp
@@ -38,9 +38,14 @@ void clone_ship_instance_data(int src_shipnum, int dest_shipnum)
 	ai_info* src_ai = &Ai_info[src->ai_index];
 	ai_info* dest_ai = &Ai_info[dest->ai_index];
 
-	// display name string only - the Has_display_name bit rides along on the
-	// shipp->flags assignment further down (search "ship flags" below).
+	// display name (the Has_display_name flag is NOT in Parse_ship_flags, so the
+	// flag-copy loop below doesn't carry it - mirror it here alongside the string).
 	dest->display_name = src->display_name;
+	if (src->flags[Ship::Ship_Flags::Has_display_name]) {
+		dest->flags.set(Ship::Ship_Flags::Has_display_name);
+	} else {
+		dest->flags.remove(Ship::Ship_Flags::Has_display_name);
+	}
 
 	// alt classes
 	dest->s_alt_classes = src->s_alt_classes;
@@ -103,49 +108,52 @@ void clone_ship_instance_data(int src_shipnum, int dest_shipnum)
 
 	// ===== end save_common_object_data mirror =====
 
-	// arrival
-	dest->arrival_location = src->arrival_location;
-	dest->arrival_distance = src->arrival_distance;
-	dest->arrival_anchor = src->arrival_anchor;
-	dest->arrival_path_mask = src->arrival_path_mask;
-	dest->arrival_delay = src->arrival_delay;
-	dest->arrival_cue = dup_sexp_chain(src->arrival_cue);
+	// arrival / departure - skip entirely for player starts: create_player has
+	// already locked arrival_cue to Locked_sexp_true and departure_cue to
+	// Locked_sexp_false, and player starts ignore the other arrival/departure
+	// fields.  Overwriting the cues here would break the locked-cue invariant.
+	if (!dest_obj->flags[Object::Object_Flags::Player_ship]) {
+		dest->arrival_location = src->arrival_location;
+		dest->arrival_distance = src->arrival_distance;
+		dest->arrival_anchor = src->arrival_anchor;
+		dest->arrival_path_mask = src->arrival_path_mask;
+		dest->arrival_delay = src->arrival_delay;
+		dest->arrival_cue = dup_sexp_chain(src->arrival_cue);
 
-	// departure
-	dest->departure_location = src->departure_location;
-	dest->departure_anchor = src->departure_anchor;
-	dest->departure_path_mask = src->departure_path_mask;
-	dest->departure_delay = src->departure_delay;
-	dest->departure_cue = dup_sexp_chain(src->departure_cue);
+		dest->departure_location = src->departure_location;
+		dest->departure_anchor = src->departure_anchor;
+		dest->departure_path_mask = src->departure_path_mask;
+		dest->departure_delay = src->departure_delay;
+		dest->departure_cue = dup_sexp_chain(src->departure_cue);
+	}
 
 	// warp params
 	dest->warpin_params_index = src->warpin_params_index;
 	dest->warpout_params_index = src->warpout_params_index;
 
-	// ship flags
-	dest->flags = src->flags;
-	dest->flags.remove(Ship::Ship_Flags::Dying);
-	dest->flags.remove(Ship::Ship_Flags::Disabled);
-	dest->flags.remove(Ship::Ship_Flags::Depart_warp);
-	dest->flags.remove(Ship::Ship_Flags::Depart_dockbay);
+	// ship flags - driven by Parse_ship_flags so duplication stays in sync with
+	// parse/save automatically when new editor-editable ship flags are added.
+	// Runtime/transient flags (Dying, Depart_warp, From_player_wing, ...) and
+	// instance-coupled flags (Dock_leader) are not in Parse_ship_flags and so
+	// are correctly NOT copied here.
+	for (size_t i = 0; i < Num_Parse_ship_flags; ++i) {
+		const auto flag = Parse_ship_flags[i].def;
+		if (src->flags[flag]) {
+			dest->flags.set(flag);
+		} else {
+			dest->flags.remove(flag);
+		}
+	}
 
-	// object flags (Explicit list of the editor-editable bits from save_objects)
-	const Object::Object_Flags editor_object_flags[] = {
-		Object::Object_Flags::Protected,
-		Object::Object_Flags::No_shields,
-		Object::Object_Flags::Invulnerable,
-		Object::Object_Flags::Beam_protected,
-		Object::Object_Flags::Flak_protected,
-		Object::Object_Flags::Laser_protected,
-		Object::Object_Flags::Missile_protected,
-		Object::Object_Flags::Special_warpin,
-		Object::Object_Flags::Targetable_as_bomb,
-		Object::Object_Flags::Dont_change_position,
-		Object::Object_Flags::Dont_change_orientation,
-		Object::Object_Flags::Collides,
-		Object::Object_Flags::Attackable_if_no_collide,
-	};
-	for (auto flag : editor_object_flags) {
+	// object flags - driven by Parse_ship_object_flags.  Skip Player_ship: that
+	// bit is managed by create_player/create_ship at the caller and copying it
+	// would either redundantly re-set it (player-start -> player-start) or
+	// wrongly promote a regular-ship dup to a player ship (demoted dup case).
+	for (size_t i = 0; i < Num_Parse_ship_object_flags; ++i) {
+		const auto flag = Parse_ship_object_flags[i].def;
+		if (flag == Object::Object_Flags::Player_ship) {
+			continue;
+		}
 		if (src_obj->flags[flag]) {
 			dest_obj->flags.set(flag);
 		} else {
@@ -153,8 +161,18 @@ void clone_ship_instance_data(int src_shipnum, int dest_shipnum)
 		}
 	}
 
-	// AI flags
-	dest_ai->ai_flags = src_ai->ai_flags;
+	// AI flags - driven by Parse_ship_ai_flags so duplication stays in sync with
+	// parse/save automatically when new editor-editable AI flags are added.
+	for (size_t i = 0; i < Num_Parse_ship_ai_flags; ++i) {
+		const auto flag = Parse_ship_ai_flags[i].def;
+		if (src_ai->ai_flags[flag]) {
+			dest_ai->ai_flags.set(flag);
+		} else {
+			dest_ai->ai_flags.remove(flag);
+		}
+	}
+	// kamikaze_damage is editor-editable independent of the Kamikaze flag (see
+	// ShipFlagsDialogModel), so copy unconditionally.
 	dest_ai->kamikaze_damage = src_ai->kamikaze_damage;
 
 	// respawn / escort / guardian
@@ -265,8 +283,10 @@ void clone_jump_node_instance_data(const CJumpNode& src, CJumpNode& dest)
 	}
 
 	// color (SetAlphaColor manages the JN_USE_DISPLAY_COLOR flag)
-	const color& c = src.GetColor();
-	dest.SetAlphaColor(c.red, c.green, c.blue, c.alpha);
+	if (src.IsColored()) {
+		const color& c = src.GetColor();
+		dest.SetAlphaColor(c.red, c.green, c.blue, c.alpha);
+	}
 
 	// hidden state
 	dest.SetVisibility(!src.IsHidden());

--- a/code/missioneditor/objectduplication.cpp
+++ b/code/missioneditor/objectduplication.cpp
@@ -38,7 +38,8 @@ void clone_ship_instance_data(int src_shipnum, int dest_shipnum)
 	ai_info* src_ai = &Ai_info[src->ai_index];
 	ai_info* dest_ai = &Ai_info[dest->ai_index];
 
-	// display name (the Has_display_name flag is carried via the bitset copy below)
+	// display name string only - the Has_display_name bit rides along on the
+	// shipp->flags assignment further down (search "ship flags" below).
 	dest->display_name = src->display_name;
 
 	// alt classes
@@ -200,7 +201,11 @@ void clone_ship_instance_data(int src_shipnum, int dest_shipnum)
 	dest->assist_score_pct = src->assist_score_pct;
 	dest->persona_index = src->persona_index;
 
-	// texture replacement... copy any entries whose ship_name matches src
+	// texture replacement... copy any entries whose ship_name matches src.
+	// Skip from_table entries: those came from the ship class's .tbl/.tbm and
+	// apply to every instance of the class automatically, so re-attaching one
+	// to the duplicate would create a duplicate override that save_objects
+	// wouldn't write anyway.
 	{
 		SCP_vector<texture_replace> new_entries;
 		for (const auto& tr : Fred_texture_replacements) {

--- a/code/missioneditor/objectduplication.h
+++ b/code/missioneditor/objectduplication.h
@@ -14,3 +14,26 @@
 //   parse_create_object_sub() in missionparse.cpp
 //   clone_ship_instance_data() in missioneditor/objectduplication.cpp
 void clone_ship_instance_data(int src_shipnum, int dest_shipnum);
+
+// Copy every per-instance prop field that the FRED/QtFRED prop editor
+// exposes, from src_prop_id -> dest_prop_id. dest_prop_id must already
+// be a freshly-created prop of the same prop class as the source.
+//
+// CANONICAL FIELD LIST - when you add a new editable prop field, update
+// all of:
+//   Fred_mission_save::save_props() in missionsave.cpp
+//   parse_prop() in missionparse.cpp
+//   clone_prop_instance_data() in missioneditor/objectduplication.cpp
+void clone_prop_instance_data(int src_prop_id, int dest_prop_id);
+
+// Copy every per-instance jump node field that the FRED/QtFRED jump node
+// editor exposes, from src to dest. The destination must already be a
+// freshly-constructed CJumpNode at its desired position.
+//
+// CANONICAL FIELD LIST - when you add a new editable jump node field,
+// update all of:
+//   Fred_mission_save::save_waypoints() (jump-node section) in missionsave.cpp
+//   jump node parse in missionparse.cpp (around the "$Jump Node:" handling)
+//   clone_jump_node_instance_data() in missioneditor/objectduplication.cpp
+class CJumpNode;
+void clone_jump_node_instance_data(const CJumpNode& src, CJumpNode& dest);

--- a/code/missioneditor/objectduplication.h
+++ b/code/missioneditor/objectduplication.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// Helpers for editor-side object duplication (Ctrl-drag, Clone Marked Objects).
+// Shared between FRED and QtFRED so both editors stay in sync.
+
+// Copy every per-instance ship field that the FRED/QtFRED ship-editor
+// dialogs expose, from src_shipnum -> dest_shipnum. dest_shipnum must
+// already be a freshly-created ship of the same class as the source.
+// Pure data copy: no UI, no popups, no editor-specific side effects.
+//
+// CANONICAL FIELD LIST - when you add a new editable ship field, update
+// all of:
+//   Fred_mission_save::save_objects() / save_common_object_data() in missionsave.cpp
+//   parse_create_object_sub() in missionparse.cpp
+//   clone_ship_instance_data() in missioneditor/objectduplication.cpp
+void clone_ship_instance_data(int src_shipnum, int dest_shipnum);

--- a/code/missioneditor/objectduplication.h
+++ b/code/missioneditor/objectduplication.h
@@ -37,3 +37,19 @@ void clone_prop_instance_data(int src_prop_id, int dest_prop_id);
 //   clone_jump_node_instance_data() in missioneditor/objectduplication.cpp
 class CJumpNode;
 void clone_jump_node_instance_data(const CJumpNode& src, CJumpNode& dest);
+
+// Individual waypoints have no editable per-instance fields beyond position
+// (which is already an argument to waypoint_add()).  Per-PATH editable fields
+// — no_draw_lines, custom color, fred_layer — do need to be carried across
+// when a duplicate operation creates a new path.
+//
+// Copy every editable per-path field from src_list_index -> dest_list_index.
+// The destination path's name is intentionally NOT copied (waypoint_add picks
+// a unique auto-generated name when a new path is created).
+//
+// CANONICAL FIELD LIST - when you add a new editable waypoint-path field,
+// update all of:
+//   Fred_mission_save::save_waypoints() (waypoint-list section) in missionsave.cpp
+//   parse_waypoint_list() in missionparse.cpp
+//   clone_waypoint_path_instance_data() in missioneditor/objectduplication.cpp
+void clone_waypoint_path_instance_data(int src_list_index, int dest_list_index);

--- a/code/source_groups.cmake
+++ b/code/source_groups.cmake
@@ -848,6 +848,8 @@ add_file_folder("MissionEditor"
 	missioneditor/campaignsave.h
 	missioneditor/missionsave.cpp
 	missioneditor/missionsave.h
+	missioneditor/objectduplication.cpp
+	missioneditor/objectduplication.h
 )
 
 # MissionUI files

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -27,6 +27,7 @@
 #include "mission/missiongoals.h"
 #include "mission/missionbriefcommon.h"
 #include "missioneditor/common.h"
+#include "missioneditor/objectduplication.h"
 #include "model/modelreplace.h"
 #include "Management.h"
 #include "cfile/cfile.h"
@@ -680,9 +681,6 @@ void copy_bits(int *dest, int src, int mask)
 int dup_object(object *objp)
 {
 	int i, n, inst, obj = -1;
-	ai_info *aip1, *aip2;
-	object *objp1, *objp2;
-	ship_subsys *subp1, *subp2;
 	static int waypoint_instance(-1);
 
 	if (!objp) {
@@ -692,55 +690,43 @@ int dup_object(object *objp)
 
 	inst = objp->instance;
 	if ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) {
-		obj = create_ship(&objp->orient, &objp->pos, Ships[inst].ship_info_index);
+		bool clone_as_player_start = false;
+		bool player_start_demoted = false;
+		if (objp->type == OBJ_START && (The_mission.game_type & MISSION_TYPE_MULTI)) {
+			if (Player_starts < MAX_PLAYERS) {
+				clone_as_player_start = true;
+			} else {
+				player_start_demoted = true;
+			}
+		}
+
+		if (clone_as_player_start) {
+			obj = create_player(&objp->pos, &objp->orient, Ships[inst].ship_info_index);
+		} else {
+			obj = create_ship(&objp->orient, &objp->pos, Ships[inst].ship_info_index);
+		}
 		if (obj == -1)
 			return -1;
 
 		n = Objects[obj].instance;
-		Ships[n].team = Ships[inst].team;
-		Ships[n].arrival_cue = dup_sexp_chain(Ships[inst].arrival_cue);
-		Ships[n].departure_cue = dup_sexp_chain(Ships[inst].departure_cue);
-		Ships[n].cargo1 = Ships[inst].cargo1;
-		Ships[n].arrival_location = Ships[inst].arrival_location;
-		Ships[n].departure_location = Ships[inst].departure_location;
-		Ships[n].arrival_delay = Ships[inst].arrival_delay;
-		Ships[n].departure_delay = Ships[inst].departure_delay;
-		Ships[n].weapons = Ships[inst].weapons;
-		Ships[n].hotkey = Ships[inst].hotkey;
 
-		aip1 = &Ai_info[Ships[n].ai_index];
-		aip2 = &Ai_info[Ships[inst].ai_index];
-		aip1->ai_class = aip2->ai_class;
-		for (i=0; i<MAX_AI_GOALS; i++)
-			aip1->goals[i] = aip2->goals[i];
+		// Copy every editable per-ship field.  See clone_ship_instance_data() in
+		// code/missioneditor/objectduplication.cpp for the canonical field list.
+		clone_ship_instance_data(inst, n);
 
-		if (aip2->ai_flags[AI::AI_Flags::Kamikaze])
-			aip1->ai_flags.set(AI::AI_Flags::Kamikaze);
-		if (aip2->ai_flags[AI::AI_Flags::No_dynamic])
-			aip2->ai_flags.set(AI::AI_Flags::No_dynamic);
-
-		aip1->kamikaze_damage = aip2->kamikaze_damage;
-
-		objp1 = &Objects[obj];
-		objp2 = &Objects[Ships[inst].objnum];
-		objp1->phys_info.speed = objp2->phys_info.speed;
-		objp1->phys_info.fspeed = objp2->phys_info.fspeed;
-		objp1->hull_strength = objp2->hull_strength;
-		objp1->shield_quadrant[0] = objp2->shield_quadrant[0];
-
-		subp1 = GET_FIRST(&Ships[n].subsys_list);
-		subp2 = GET_FIRST(&Ships[inst].subsys_list);
-		while (subp1 != END_OF_LIST(&Ships[n].subsys_list)) {
-			Assert(subp2 != END_OF_LIST(&Ships[inst].subsys_list));
-			subp1 -> current_hits = subp2 -> current_hits;
-			subp1 = GET_NEXT(subp1);
-			subp2 = GET_NEXT(subp2);
-		}
-
+		// Reinforcement-list propagation: if the source ship is listed as a
+		// reinforcement, add a new entry pointing at the duplicate.
 		i = find_item_with_string(Reinforcements, &reinforcements::name, Ships[inst].ship_name);
 		if (i >= 0) {
 			Reinforcements.push_back(Reinforcements[i]);
 			strcpy_s(Reinforcements.back().name, Ships[n].ship_name);
+		}
+
+		if (player_start_demoted) {
+			AfxMessageBox(
+				"Cannot create another player start. This mission already has the maximum of 12. "
+				"The duplicate has been created as a regular ship instead.",
+				MB_OK | MB_ICONINFORMATION);
 		}
 
 	} else if (objp->type == OBJ_WAYPOINT) {

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -680,7 +680,7 @@ void copy_bits(int *dest, int src, int mask)
 
 int dup_object(object *objp)
 {
-	int i, n, inst, obj = -1;
+	int inst, obj = -1;
 	static int waypoint_instance(-1);
 
 	if (!objp) {
@@ -708,7 +708,7 @@ int dup_object(object *objp)
 		if (obj == -1)
 			return -1;
 
-		n = Objects[obj].instance;
+		int n = Objects[obj].instance;
 
 		// Copy every editable per-ship field.  See clone_ship_instance_data() in
 		// code/missioneditor/objectduplication.cpp for the canonical field list.
@@ -716,17 +716,19 @@ int dup_object(object *objp)
 
 		// Reinforcement-list propagation: if the source ship is listed as a
 		// reinforcement, add a new entry pointing at the duplicate.
-		i = find_item_with_string(Reinforcements, &reinforcements::name, Ships[inst].ship_name);
+		int i = find_item_with_string(Reinforcements, &reinforcements::name, Ships[inst].ship_name);
 		if (i >= 0) {
 			Reinforcements.push_back(Reinforcements[i]);
 			strcpy_s(Reinforcements.back().name, Ships[n].ship_name);
 		}
 
 		if (player_start_demoted) {
-			AfxMessageBox(
-				"Cannot create another player start. This mission already has the maximum of 12. "
+			CString msg;
+			msg.Format(
+				"Cannot create another player start. This mission already has the maximum of %d. "
 				"The duplicate has been created as a regular ship instead.",
-				MB_OK | MB_ICONINFORMATION);
+				MAX_PLAYERS);
+			AfxMessageBox(msg, MB_OK | MB_ICONINFORMATION);
 		}
 
 	} else if (objp->type == OBJ_WAYPOINT) {

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -732,6 +732,22 @@ int dup_object(object *objp)
 	} else if (objp->type == OBJ_WAYPOINT) {
 		obj = create_waypoint(&objp->pos, waypoint_instance);
 		waypoint_instance = Objects[obj].instance;
+	} else if (objp->type == OBJ_JUMP_NODE) {
+		CJumpNode* src_jnp = jumpnode_get_by_objp(objp);
+		CJumpNode jnp(&objp->pos);
+		if (src_jnp) {
+			clone_jump_node_instance_data(*src_jnp, jnp);
+		}
+		obj = jnp.GetSCPObjectNumber();
+		Jump_nodes.push_back(std::move(jnp));
+	} else if (objp->type == OBJ_PROP) {
+		prop* propp = prop_id_lookup(inst);
+		if (propp != nullptr) {
+			obj = create_prop(&objp->orient, &objp->pos, propp->prop_info_index);
+			if (obj != -1) {
+				clone_prop_instance_data(inst, Objects[obj].instance);
+			}
+		}
 	}
 
 	if (obj == -1)

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -730,8 +730,17 @@ int dup_object(object *objp)
 		}
 
 	} else if (objp->type == OBJ_WAYPOINT) {
+		// waypoint_instance < 0 means waypoint_add() will create a fresh list;
+		// copy editable per-list properties from the source list in that case.
+		bool is_first_of_new_list = (waypoint_instance < 0);
+		int src_list_idx = calc_waypoint_list_index(objp->instance);
 		obj = create_waypoint(&objp->pos, waypoint_instance);
+		if (obj == -1)
+			return -1;
 		waypoint_instance = Objects[obj].instance;
+		if (is_first_of_new_list) {
+			clone_waypoint_path_instance_data(src_list_idx, calc_waypoint_list_index(waypoint_instance));
+		}
 	} else if (objp->type == OBJ_JUMP_NODE) {
 		CJumpNode* src_jnp = jumpnode_get_by_objp(objp);
 		CJumpNode jnp(&objp->pos);

--- a/qtfred/help-src/doc/general/Viewport.html
+++ b/qtfred/help-src/doc/general/Viewport.html
@@ -31,6 +31,19 @@ the viewport. Each dropdown is paired with its own modifier chord:</p>
 <h2>Moving objects</h2>
 <p><strong>Drag</strong> a selected object to reposition it in the mission.</p>
 
+<h2>Duplicating objects</h2>
+<ul>
+    <li><strong>Ctrl+drag</strong> a selected object to duplicate everything that is
+        currently marked. Ships, props, and jump nodes are cloned with all their
+        editable fields preserved. Marked waypoints are copied into a new path that
+        inherits the source path's color, layer, and line-drawing settings.</li>
+    <li><strong>Ctrl+Shift+drag</strong> behaves the same as Ctrl+drag except for
+        waypoints: each marked waypoint is inserted into its source path right after
+        the original, extending the path rather than creating a new one. Useful when
+        you want to add more points to an existing path without redrawing it. Other
+        object types in the marked set are duplicated normally.</li>
+</ul>
+
 <h2>Context menu</h2>
 <p><strong>Right-click</strong> anywhere in the viewport to open a context menu with
 options relevant to what was clicked. Available options vary depending on whether

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -17,6 +17,7 @@
 #include <mission/missionmessage.h>
 #include <missioneditor/common.h>
 #include <missioneditor/missionsave.h>
+#include <missioneditor/objectduplication.h>
 #include <gamesnd/eventmusic.h>
 #include <starfield/nebula.h>
 #include <object/objectdock.h>
@@ -918,9 +919,6 @@ int Editor::getNumMarked() {
 int Editor::dup_object(object* objp) {
 
 	int i, n, inst, obj = -1;
-	ai_info* aip1, * aip2;
-	object* objp1, * objp2;
-	ship_subsys* subp1, * subp2;
 	static int waypoint_instance(-1);
 
 	if (!objp) {
@@ -930,59 +928,45 @@ int Editor::dup_object(object* objp) {
 
 	inst = objp->instance;
 	if ((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) {
-		obj = create_ship(&objp->orient, &objp->pos, Ships[inst].ship_info_index);
+		bool clone_as_player_start = false;
+		bool player_start_demoted = false;
+		if (objp->type == OBJ_START && (The_mission.game_type & MISSION_TYPE_MULTI)) {
+			if (Player_starts < MAX_PLAYERS) {
+				clone_as_player_start = true;
+			} else {
+				player_start_demoted = true;
+			}
+		}
+
+		if (clone_as_player_start) {
+			obj = create_player(&objp->pos, &objp->orient, Ships[inst].ship_info_index);
+		} else {
+			obj = create_ship(&objp->orient, &objp->pos, Ships[inst].ship_info_index);
+		}
 		if (obj == -1) {
 			return -1;
 		}
 
 		n = Objects[obj].instance;
-		Ships[n].team = Ships[inst].team;
-		Ships[n].arrival_cue = dup_sexp_chain(Ships[inst].arrival_cue);
-		Ships[n].departure_cue = dup_sexp_chain(Ships[inst].departure_cue);
-		Ships[n].cargo1 = Ships[inst].cargo1;
-		Ships[n].arrival_location = Ships[inst].arrival_location;
-		Ships[n].departure_location = Ships[inst].departure_location;
-		Ships[n].arrival_delay = Ships[inst].arrival_delay;
-		Ships[n].departure_delay = Ships[inst].departure_delay;
-		Ships[n].weapons = Ships[inst].weapons;
-		Ships[n].hotkey = Ships[inst].hotkey;
 
-		aip1 = &Ai_info[Ships[n].ai_index];
-		aip2 = &Ai_info[Ships[inst].ai_index];
-		aip1->ai_class = aip2->ai_class;
-		for (i = 0; i < MAX_AI_GOALS; i++) {
-			aip1->goals[i] = aip2->goals[i];
-		}
+		// Copy every editable per-ship field.  See clone_ship_instance_data() in
+		// code/missioneditor/objectduplication.cpp for the canonical field list.
+		clone_ship_instance_data(inst, n);
 
-		if (aip2->ai_flags[AI::AI_Flags::Kamikaze]) {
-			aip1->ai_flags.set(AI::AI_Flags::Kamikaze);
-		}
-		if (aip2->ai_flags[AI::AI_Flags::No_dynamic]) {
-			aip2->ai_flags.set(AI::AI_Flags::No_dynamic);
-		}
-
-		aip1->kamikaze_damage = aip2->kamikaze_damage;
-
-		objp1 = &Objects[obj];
-		objp2 = &Objects[Ships[inst].objnum];
-		objp1->phys_info.speed = objp2->phys_info.speed;
-		objp1->phys_info.fspeed = objp2->phys_info.fspeed;
-		objp1->hull_strength = objp2->hull_strength;
-		objp1->shield_quadrant[0] = objp2->shield_quadrant[0];
-
-		subp1 = GET_FIRST(&Ships[n].subsys_list);
-		subp2 = GET_FIRST(&Ships[inst].subsys_list);
-		while (subp1 != END_OF_LIST(&Ships[n].subsys_list)) {
-			Assert(subp2 != END_OF_LIST(&Ships[inst].subsys_list));
-			subp1->current_hits = subp2->current_hits;
-			subp1 = GET_NEXT(subp1);
-			subp2 = GET_NEXT(subp2);
-		}
-
+		// Reinforcement-list propagation: if the source ship is listed as a
+		// reinforcement, add a new entry pointing at the duplicate.
 		i = find_item_with_string(Reinforcements, &reinforcements::name, Ships[inst].ship_name);
 		if (i >= 0) {
 			Reinforcements.push_back(Reinforcements[i]);
 			strcpy_s(Reinforcements.back().name, Ships[n].ship_name);
+		}
+
+		if (player_start_demoted && _lastActiveViewport) {
+			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Information,
+				"Player Starts",
+				"Cannot create another player start. This mission already has the maximum of 12. "
+				"The duplicate has been created as a regular ship instead.",
+				{ DialogButton::Ok });
 		}
 
 	} else if (objp->type == OBJ_WAYPOINT) {

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -973,13 +973,20 @@ int Editor::dup_object(object* objp) {
 		obj = create_waypoint(&objp->pos, waypoint_instance);
 		waypoint_instance = Objects[obj].instance;
 	} else if (objp->type == OBJ_JUMP_NODE) {
+		CJumpNode* src_jnp = jumpnode_get_by_objp(objp);
 		CJumpNode jnp(&objp->pos);
+		if (src_jnp) {
+			clone_jump_node_instance_data(*src_jnp, jnp);
+		}
 		obj = jnp.GetSCPObjectNumber();
 		Jump_nodes.push_back(std::move(jnp));
 	} else if (objp->type == OBJ_PROP) {
 		prop* propp = prop_id_lookup(inst);
 		if (propp != nullptr) {
 			obj = prop_create(&objp->orient, &objp->pos, propp->prop_info_index);
+			if (obj != -1) {
+				clone_prop_instance_data(inst, Objects[obj].instance);
+			}
 		}
 	}
 

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -918,7 +918,7 @@ int Editor::getNumMarked() {
 }
 int Editor::dup_object(object* objp) {
 
-	int i, n, inst, obj = -1;
+	int inst, obj = -1;
 	static int waypoint_instance(-1);
 
 	if (!objp) {
@@ -947,7 +947,7 @@ int Editor::dup_object(object* objp) {
 			return -1;
 		}
 
-		n = Objects[obj].instance;
+		int n = Objects[obj].instance;
 
 		// Copy every editable per-ship field.  See clone_ship_instance_data() in
 		// code/missioneditor/objectduplication.cpp for the canonical field list.
@@ -955,17 +955,21 @@ int Editor::dup_object(object* objp) {
 
 		// Reinforcement-list propagation: if the source ship is listed as a
 		// reinforcement, add a new entry pointing at the duplicate.
-		i = find_item_with_string(Reinforcements, &reinforcements::name, Ships[inst].ship_name);
+		int i = find_item_with_string(Reinforcements, &reinforcements::name, Ships[inst].ship_name);
 		if (i >= 0) {
 			Reinforcements.push_back(Reinforcements[i]);
 			strcpy_s(Reinforcements.back().name, Ships[n].ship_name);
 		}
 
 		if (player_start_demoted && _lastActiveViewport) {
+			SCP_string message;
+			sprintf(message,
+				"Cannot create another player start. This mission already has the maximum of %d. "
+				"The duplicate has been created as a regular ship instead.",
+				MAX_PLAYERS);
 			_lastActiveViewport->dialogProvider->showButtonDialog(DialogType::Information,
 				"Player Starts",
-				"Cannot create another player start. This mission already has the maximum of 12. "
-				"The duplicate has been created as a regular ship instead.",
+				message,
 				{ DialogButton::Ok });
 		}
 

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -997,6 +997,14 @@ int Editor::dup_object(object* objp) {
 	Objects[obj].pos = objp->pos;
 	Objects[obj].orient = objp->orient;
 	Objects[obj].flags.set(Object::Object_Flags::Temp_marked);
+
+	// Sync the viewport's layer-membership map for the new object so it shows
+	// up in the same layer as the source (per-object fred_layer was already
+	// copied by the clone_*_instance_data helpers).
+	if (_lastActiveViewport) {
+		_lastActiveViewport->registerObjectInLayer(obj);
+	}
+
 	return obj;
 }
 

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -970,8 +970,18 @@ int Editor::dup_object(object* objp) {
 		}
 
 	} else if (objp->type == OBJ_WAYPOINT) {
+		// waypoint_instance < 0 means create_waypoint() will create a fresh list;
+		// copy editable per-list properties from the source list in that case.
+		bool is_first_of_new_list = (waypoint_instance < 0);
+		int src_list_idx = calc_waypoint_list_index(objp->instance);
 		obj = create_waypoint(&objp->pos, waypoint_instance);
+		if (obj == -1) {
+			return -1;
+		}
 		waypoint_instance = Objects[obj].instance;
+		if (is_first_of_new_list) {
+			clone_waypoint_path_instance_data(src_list_idx, calc_waypoint_list_index(waypoint_instance));
+		}
 	} else if (objp->type == OBJ_JUMP_NODE) {
 		CJumpNode* src_jnp = jumpnode_get_by_objp(objp);
 		CJumpNode jnp(&objp->pos);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -1042,7 +1042,7 @@ int Editor::common_object_delete(int obj) {
 			return 1;
 		}
 
-		Assert((i >= 0) && (i < MAX_SHIPS));
+		Assertion((i >= 0) && (i < MAX_SHIPS), "Invalid ship index %d in player-start delete path", i); // NOLINT(readability-simplify-boolean-expr)
 		sprintf(msg, "Player %d", i + 1);
 		name = msg;
 		r = reference_handler(name, sexp_ref_type::PLAYER, obj);

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -1004,6 +1004,47 @@ void EditorViewport::reloadLayersFromMission() {
 	needsUpdate();
 }
 
+void EditorViewport::registerObjectInLayer(int objectIndex) {
+	if (objectIndex < 0 || objectIndex >= MAX_OBJECTS) {
+		return;
+	}
+	auto* objp = &Objects[objectIndex];
+	if (objp->type == OBJ_NONE) {
+		return;
+	}
+
+	SCP_string layerName;
+	switch (objp->type) {
+	case OBJ_SHIP:
+	case OBJ_START:
+		layerName = Ships[objp->instance].fred_layer;
+		break;
+	case OBJ_PROP:
+		if (auto* p = prop_id_lookup(objp->instance)) {
+			layerName = p->fred_layer;
+		}
+		break;
+	case OBJ_JUMP_NODE:
+		if (auto* jn = jumpnode_get_by_objnum(objectIndex)) {
+			layerName = jn->GetFredLayer();
+		}
+		break;
+	case OBJ_WAYPOINT:
+		if (auto* wl = find_waypoint_list_with_instance(objp->instance, nullptr)) {
+			layerName = wl->get_fred_layer();
+		}
+		break;
+	default:
+		return;
+	}
+
+	auto layerIndex = getLayerIndex(layerName);
+	if (layerIndex == static_cast<size_t>(-1)) {
+		layerIndex = 0;
+	}
+	_objectLayers[objectIndex] = layerIndex;
+}
+
 SCP_string EditorViewport::getObjectLayerName(int objectIndex) const {
 	const auto layerIndex = getObjectLayerIndex(objectIndex);
 	if (layerIndex >= _layerNames.size()) {

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -1270,7 +1270,7 @@ void EditorViewport::initialSetup() {
 	}
 }
 
-int EditorViewport::duplicate_marked_objects()
+int EditorViewport::duplicate_marked_objects(bool insert_waypoints)
 {
 	int z, cobj, flag;
 	object *objp, *ptr;
@@ -1295,24 +1295,41 @@ int EditorViewport::duplicate_marked_objects()
 				Duped_wing = -1;
 			}
 
-			// make sure we dup as many waypoint lists as we have
-			if (objp->type == OBJ_WAYPOINT) {
-				int this_list = calc_waypoint_list_index(objp->instance);
-				if (duping_waypoint_list != this_list) {
-					editor->dup_object(nullptr);  // reset waypoint list
-					duping_waypoint_list = this_list;
-				}
-			}
-
 			flag = 1;
-			z = editor->dup_object(objp);
-			if (z == -1) {
-				cobj = -1;
-				break;
-			}
 
-			if (editor->currentObject == OBJ_INDEX(objp) )
-				cobj = z;
+			if (insert_waypoints && objp->type == OBJ_WAYPOINT) {
+				// Insert a new waypoint into the source path right after this one.
+				// No new list is created, so no list-property copy is needed.
+				z = waypoint_add(&objp->pos, objp->instance, false);
+				if (z < 0) {
+					cobj = -1;
+					break;
+				}
+				Objects[z].pos = objp->pos;
+				Objects[z].orient = objp->orient;
+				Objects[z].flags.set(Object::Object_Flags::Temp_marked);
+				registerObjectInLayer(z);
+				if (editor->currentObject == OBJ_INDEX(objp))
+					cobj = z;
+			} else {
+				// make sure we dup as many waypoint lists as we have
+				if (objp->type == OBJ_WAYPOINT) {
+					int this_list = calc_waypoint_list_index(objp->instance);
+					if (duping_waypoint_list != this_list) {
+						editor->dup_object(nullptr);  // reset waypoint list
+						duping_waypoint_list = this_list;
+					}
+				}
+
+				z = editor->dup_object(objp);
+				if (z == -1) {
+					cobj = -1;
+					break;
+				}
+
+				if (editor->currentObject == OBJ_INDEX(objp))
+					cobj = z;
+			}
 		}
 
 		objp = GET_NEXT(objp);
@@ -1391,8 +1408,9 @@ int EditorViewport::drag_objects(int x, int y)
 	if (!query_valid_object(editor->currentObject) || camera.getLookatMode())
 		return -1;
 
-	if (Dup_drag == 1) {
-		if (duplicate_marked_objects() < 0)
+	if (Dup_drag == 1 || Dup_drag == DUP_DRAG_INSERT) {
+		const bool insert_waypoints = (Dup_drag == DUP_DRAG_INSERT);
+		if (duplicate_marked_objects(insert_waypoints) < 0)
 			return -1;
 
 		if (Duped_wing != -1)

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -1351,10 +1351,6 @@ int EditorViewport::drag_objects(int x, int y)
 		return -1;
 
 	if (Dup_drag == 1) {
-		Dup_drag = 0;
-	}
-
-	if (Dup_drag == 1) {
 		if (duplicate_marked_objects() < 0)
 			return -1;
 

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -130,6 +130,12 @@ class EditorViewport {
 	bool moveObjectToLayer(int objectIndex, const SCP_string& layerName, SCP_string* errorMessage = nullptr);
 	void moveMarkedObjectsToLayer(const SCP_string& layerName, SCP_string* errorMessage = nullptr);
 
+	// Sync the _objectLayers map for a freshly-created object by reading its
+	// per-object fred_layer string (or the parent waypoint list's, for waypoints).
+	// Call this after creating a new ship/prop/jump-node/waypoint outside of
+	// the normal mission-load path (e.g. when duplicating objects).
+	void registerObjectInLayer(int objectIndex);
+
 	bool isObjectVisibleInLayer(const object* objp) const;
 
 

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -98,7 +98,11 @@ class EditorViewport {
 	static const char* DefaultLayerName;
 
 	enum {
-		DUP_DRAG_OF_WING = 2
+		DUP_DRAG_OF_WING = 2,
+		// Ctrl+Shift+drag.  Same as a normal Ctrl+drag duplicate, except marked
+		// waypoints insert a copy into their source path rather than starting a
+		// new path.  Non-waypoint object types behave like a plain duplicate.
+		DUP_DRAG_INSERT = 3,
 	};
 
 	EditorViewport(Editor* in_editor, std::unique_ptr<FredRenderer>&& in_renderer);
@@ -157,7 +161,11 @@ class EditorViewport {
 	int createWaypointAtScreenPos(int x, int y, int waypoint_instance = -1);
 	int createJumpNodeAtScreenPos(int x, int y);
 
-	int duplicate_marked_objects();
+	// When `insert_waypoints` is true, marked waypoints get a new waypoint
+	// inserted into their source path (right after the source waypoint) instead
+	// of being duplicated into a fresh path.  Other object types are duplicated
+	// either way.  Triggered from Ctrl+Shift+drag in the viewport.
+	int duplicate_marked_objects(bool insert_waypoints = false);
 	int drag_objects(int x, int y);
 
 	int drag_rotate_objects(int mouse_dx, int mouse_dy);

--- a/qtfred/src/ui/widgets/renderwidget.cpp
+++ b/qtfred/src/ui/widgets/renderwidget.cpp
@@ -240,7 +240,12 @@ void RenderWidget::mousePressEvent(QMouseEvent* event) {
 			_viewport->on_object = _viewport->create_object_on_grid(event->x(), event->y(), waypoint_instance, kind);
 
 		} else {
-			_viewport->Dup_drag = 1;
+			// Ctrl+drag: duplicate marked objects (waypoints start a new path).
+			// Ctrl+Shift+drag: same, except marked waypoints insert into their
+			// source path instead of starting a new one.
+			_viewport->Dup_drag = event->modifiers().testFlag(Qt::ShiftModifier)
+				? EditorViewport::DUP_DRAG_INSERT
+				: 1;
 		}
 
 	} else if (!_viewport->Selection_lock) {


### PR DESCRIPTION
Fixes #6191 by creating a shared object duplication file with methods that mirror the parse/save fields and comments in each relevant place to help ensure they don't diverge again in the future. After doing this for ships it seemed prudent to do it for Jump Nodes, Waypoints, and Props as well. All cloneable object types should fully clone now instead of silently dropping field data.

I did sneak in a minor QtFRED feature here where shift-ctrl-drag allows inserting waypoints into a path rather than duplicating them into a new path. The code overhead is minor and related to the work here as I also had to fix ctrl-drag not working in QtFRED in the first place.