### PR TITLE
QtFred Render volumetric

### DIFF
--- a/code/mission/missionparse.cpp
+++ b/code/mission/missionparse.cpp
@@ -7104,7 +7104,10 @@ bool post_process_mission(mission *pm)
 	}
 	Last_file_checksum = Current_file_checksum;
 
-	if (pm->volumetrics)
+	// Skip the volumetric noise bake under FRED. Only the gameplay deferred
+	// pass and the Lab consume the baked 3D bitmap, and the bake can take
+	// minutes in a debug build for higher quality nebulae.
+	if (pm->volumetrics && !Fred_running)
 		pm->volumetrics->renderVolumeBitmap();
 
 	apply_default_custom_data(pm);

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -307,12 +307,24 @@ FredRenderer::FredRenderer(os::Viewport* targetView) : _targetView(targetView) {
 	init_fred_colors();
 }
 FredRenderer::~FredRenderer() {
+	freeVolumetricModel();
 }
 void FredRenderer::setViewport(EditorViewport* viewport) {
 	Assertion(_viewport == nullptr, "Resetting viewport is not supported");
 	Assertion(viewport != nullptr, "Invalid viewport specified!");
 
 	_viewport = viewport;
+
+	connect(_viewport->editor, &Editor::missionLoaded, this,
+		[this](const std::string&) { freeVolumetricModel(); });
+}
+
+void FredRenderer::freeVolumetricModel() {
+	if (_volumetric_model_num >= 0) {
+		model_unload(_volumetric_model_num);
+		_volumetric_model_num = -1;
+	}
+	_volumetric_cached_pof.clear();
 }
 
 void FredRenderer::render_grid(grid* gridp) {
@@ -899,6 +911,52 @@ void FredRenderer::render_one_model_htl(object* objp,
 	rendering_order.push_back(OBJ_INDEX(objp));
 }
 
+void FredRenderer::render_volumetric_overlay() {
+	if (!The_mission.volumetrics) {
+		return;
+	}
+
+	constexpr float alpha = 0.35f;
+
+	const volumetric_nebula& neb = *The_mission.volumetrics;
+	if (!neb.get_enabled() || neb.getHullPof().empty()) {
+		return;
+	}
+
+	const SCP_string& pof = neb.getHullPof();
+	if (pof != _volumetric_cached_pof) {
+		// Stamp the cache before model_load so a re-entrant paint (e.g. from
+		// an Error() dialog pumping events on a missing POF) sees the load
+		// as already attempted and bails out instead of re-loading.
+		freeVolumetricModel();
+		_volumetric_cached_pof = pof;
+		_volumetric_model_num = model_load(pof.c_str());
+	}
+
+	if (_volumetric_model_num < 0) {
+		return;
+	}
+
+	const auto& col = neb.getNebulaColor();
+	// Premultiply by alpha. MR_NO_TEXTURING + MR_ALL_XPARENT lands on
+	// ALPHA_BLEND_ADDITIVE (glBlendFunc(GL_ONE, GL_ONE)) which ignores
+	// src.alpha, so scaling RGB here is what actually controls intensity.
+	const int r = static_cast<int>(std::get<0>(col) * alpha * 255.0f);
+	const int g = static_cast<int>(std::get<1>(col) * alpha * 255.0f);
+	const int b = static_cast<int>(std::get<2>(col) * alpha * 255.0f);
+	const vec3d pos = neb.getPos();
+
+	enable_htl();
+
+	model_render_params fill;
+	fill.set_color(r, g, b);
+	fill.set_alpha(1.0f);
+	fill.set_flags(MR_NO_LIGHTING | MR_NO_TEXTURING | MR_NO_BATCH | MR_ALL_XPARENT);
+	model_render_immediate(&fill, _volumetric_model_num, &vmd_identity_matrix, &pos);
+
+	disable_htl();
+}
+
 void FredRenderer::render_models(int cur_object_index) {
 	gr_set_color_fast(&colour_white);
 
@@ -977,6 +1035,7 @@ void FredRenderer::render_frame(int cur_object_index,
 
 	gr_set_color(0, 0, 64);
 	render_models(cur_object_index);
+	render_volumetric_overlay();
 
 	if (view().Show_distances) {
 		display_distances();

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -26,6 +26,7 @@
 #include <math/fvi.h>
 #include <graphics/light.h>
 #include <mod_table/mod_table.h>
+#include <cfile/cfile.h>
 
 #include "mission/object.h"
 #include "prop/prop.h"
@@ -930,7 +931,20 @@ void FredRenderer::render_volumetric_overlay() {
 		// as already attempted and bails out instead of re-loading.
 		freeVolumetricModel();
 		_volumetric_cached_pof = pof;
-		_volumetric_model_num = model_load(pof.c_str());
+		if (cf_exists_full(pof.c_str(), CF_TYPE_MODELS)) {
+			_volumetric_model_num = model_load(pof.c_str());
+		} else {
+			mprintf(("Volumetric nebula hull POF '%s' not found; skipping editor overlay.\n", pof.c_str()));
+			if (_viewport->dialogProvider != nullptr) {
+				SCP_string msg = "Volumetric nebula hull POF '";
+				msg += pof;
+				msg += "' was not found. The nebula will render without an editor overlay until a valid POF is set in the Volumetric Nebula dialog.";
+				_viewport->dialogProvider->showButtonDialog(DialogType::Warning,
+															"Volumetric Nebula POF Missing",
+															msg,
+															{ DialogButton::Ok });
+			}
+		}
 	}
 
 	if (_volumetric_model_num < 0) {

--- a/qtfred/src/mission/FredRenderer.h
+++ b/qtfred/src/mission/FredRenderer.h
@@ -36,6 +36,9 @@ class FredRenderer: public QObject {
 	EditorViewport* _viewport = nullptr;
 	os::Viewport* _targetView = nullptr;
 
+	int _volumetric_model_num = -1;
+	SCP_string _volumetric_cached_pof;
+
 	FredRenderer(const FredRenderer& other) = delete;
 	FredRenderer& operator=(const FredRenderer& other) = delete;
 
@@ -61,6 +64,8 @@ class FredRenderer: public QObject {
 	void render_compass();
 	void render_one_model_htl(object* objp, int cur_object_index);
 	void render_models(int cur_object_index);
+	void render_volumetric_overlay();
+	void freeVolumetricModel();
 	void render_frame(int cur_object_index,
 					  subsys_to_render& Render_subsys,
 					  bool box_marking,


### PR DESCRIPTION
Renders the selected volumetric nebula POF with a flat fill at 0.35% color multiplier (since fill is rendered additively). This ends up looking really nice and provides a nice and simple way to visualize where a volume will be. As a bonus it renders the fill with the selected base RGB colors.
<img width="1897" height="1629" alt="image" src="https://github.com/user-attachments/assets/99270b4a-ac01-469b-8468-253682349f90" />
