### PR TITLE
Qtfred Fix Arrival Distance Checks

### DIFF
--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
@@ -1211,6 +1211,22 @@ ArrivalLocation ShipEditorDialogModel::getArrivalLocation() const
 	return static_cast<ArrivalLocation>(_arrivalLocation);
 }
 
+bool ShipEditorDialogModel::arrivalNeedsTarget() const
+{
+	return getArrivalLocation() != ArrivalLocation::AT_LOCATION;
+}
+
+bool ShipEditorDialogModel::arrivalNeedsDistance() const
+{
+	switch (getArrivalLocation()) {
+		case ArrivalLocation::AT_LOCATION:
+		case ArrivalLocation::FROM_DOCK_BAY:
+			return false;
+		default:
+			return true;
+	}
+}
+
 int ShipEditorDialogModel::computeArrivalMinDist() const
 {
 	// Validation only applies when arriving near a ship (not hyperspace or dock bay)

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.h
@@ -69,6 +69,9 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 	void setArrivalLocation(ArrivalLocation location);
 	ArrivalLocation getArrivalLocation() const;
 
+	bool arrivalNeedsTarget() const;
+	bool arrivalNeedsDistance() const;
+
 	void setArrivalTarget(int targetIndex);
 	int getArrivalTarget() const;
 

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
@@ -176,6 +176,22 @@ bool WingEditorDialogModel::arrivalNeedsTarget() const
 	}
 }
 
+bool WingEditorDialogModel::arrivalNeedsDistance() const
+{
+	const auto w = getCurrentWing();
+
+	if (!w)
+		return false;
+
+	switch (w->arrival_location) {
+		case ArrivalLocation::AT_LOCATION:
+		case ArrivalLocation::FROM_DOCK_BAY:
+			return false;
+		default:
+			return true;
+	}
+}
+
 
 bool WingEditorDialogModel::departureIsDockBay() const
 {

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.h
@@ -38,6 +38,7 @@ class WingEditorDialogModel : public AbstractDialogModel {
 
 	bool arrivalIsDockBay() const;
 	bool arrivalNeedsTarget() const;
+	bool arrivalNeedsDistance() const;
 	bool departureIsDockBay() const;
 	bool departureNeedsTarget() const;
 	int getMaxWaveThreshold() const;

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -422,13 +422,8 @@ void ShipEditorDialog::enableDisable()
 		ui->restrictDeparturePathsButton->setEnabled(false);
 	} else {
 		ui->arrivalLocationCombo->setEnabled(_model->getUIEnable());
-		if (_model->getArrivalLocationIndex()) {
-			ui->arrivalDistanceEdit->setEnabled(_model->getUIEnable());
-			ui->arrivalTargetCombo->setEnabled(_model->getUIEnable());
-		} else {
-			ui->arrivalDistanceEdit->setEnabled(false);
-			ui->arrivalTargetCombo->setEnabled(false);
-		}
+		ui->arrivalDistanceEdit->setEnabled(_model->getUIEnable() && _model->arrivalNeedsDistance());
+		ui->arrivalTargetCombo->setEnabled(_model->getUIEnable() && _model->arrivalNeedsTarget());
 		if (_model->getArrivalLocation() == ArrivalLocation::FROM_DOCK_BAY) {
 			if (_model->getArrivalTarget() >= 0) {
 				ui->restrictArrivalPathsButton->setEnabled(_model->getUIEnable());

--- a/qtfred/src/ui/dialogs/WingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.cpp
@@ -194,7 +194,7 @@ void WingEditorDialog::enableOrDisableControls()
 	const bool arrivalNeedsTarget = _model->arrivalNeedsTarget();
 
 	ui->arrivalTargetCombo->setEnabled(arrivalEditable && arrivalNeedsTarget);
-	ui->arrivalDistanceSpinBox->setEnabled(arrivalEditable && arrivalNeedsTarget);
+	ui->arrivalDistanceSpinBox->setEnabled(arrivalEditable && _model->arrivalNeedsDistance());
 	ui->restrictArrivalPathsButton->setEnabled(arrivalEditable && arrivalIsDockBay);
 	ui->customWarpinButton->setEnabled(arrivalEditable && !arrivalIsDockBay);
 

--- a/qtfred/src/ui/util/ErrorChecker.cpp
+++ b/qtfred/src/ui/util/ErrorChecker.cpp
@@ -433,7 +433,9 @@ int ErrorChecker::checkShips() {
 				error("Ship \"%s\" has a negative departure delay", Ships[i].ship_name);
 			}
 
-			if (Ships[i].arrival_location != ArrivalLocation::AT_LOCATION && Ships[i].arrival_distance <= 0) {
+			if (Ships[i].arrival_location != ArrivalLocation::AT_LOCATION &&
+				Ships[i].arrival_location != ArrivalLocation::FROM_DOCK_BAY &&
+				Ships[i].arrival_distance <= 0) {
 				error("Arrival distance for ship \"%s\" must be greater than 0", Ships[i].ship_name);
 			}
 
@@ -706,7 +708,9 @@ int ErrorChecker::checkWings() {
 				error("Wing \"%s\" has a negative departure delay", Wings[i].name);
 			}
 
-			if (Wings[i].arrival_location != ArrivalLocation::AT_LOCATION && Wings[i].arrival_distance <= 0) {
+			if (Wings[i].arrival_location != ArrivalLocation::AT_LOCATION &&
+				Wings[i].arrival_location != ArrivalLocation::FROM_DOCK_BAY &&
+				Wings[i].arrival_distance <= 0) {
 				error("Arrival distance for wing \"%s\" must be greater than 0", Wings[i].name);
 			}
 


### PR DESCRIPTION
Error checker should not warn about a 0 arrival distance if arrival is hyperspace or docking bay. This fixes that. Additionally let's go ahead and enable/disable the arrival distance field in the UI based on the arrival type.