### PR TITLE
fix wing name length checks

### DIFF
--- a/code/network/multiteamselect.cpp
+++ b/code/network/multiteamselect.cpp
@@ -1723,10 +1723,10 @@ void multi_ts_get_shipname( char *ship_name, int team, int slot_index )
 {
 	if ( Netgame.type_flags & NG_TYPE_TEAM ) {
 		Assert( (team >= 0) && (team < MULTI_TS_MAX_TVT_TEAMS) );
-		wing_bash_ship_name(ship_name, TVT_wing_names[team], slot_index);
+		wing_bash_ship_name(ship_name, TVT_wing_names[team], slot_index + 1);
 	} else {
 		Assert( team == 0 );
-		wing_bash_ship_name(ship_name, Starting_wing_names[slot_index / MULTI_TS_NUM_SHIP_SLOTS_TEAM], slot_index % MULTI_TS_NUM_SHIP_SLOTS_TEAM);
+		wing_bash_ship_name(ship_name, Starting_wing_names[slot_index / MULTI_TS_NUM_SHIP_SLOTS_TEAM], (slot_index % MULTI_TS_NUM_SHIP_SLOTS_TEAM) + 1);
 	}
 }
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15277,8 +15277,18 @@ void wing_bash_ship_name(ship *shipp, const wing *wingp, int ordinal, bool reset
 	//  This is unavoidable, because if we didn't overwrite display names, all waves would have the display name from the first wave.)
 	if (wingp->has_display_name())
 	{
-		wing_bash_ship_name(shipp->display_name, wingp->get_display_name(), ordinal);
-		shipp->flags.set(Ship::Ship_Flags::Has_display_name);
+		// in FRED, since the wing display name takes precedence, clear the ship display name
+		if (Fred_running)
+		{
+			shipp->display_name = "";
+			shipp->flags.remove(Ship::Ship_Flags::Has_display_name);
+		}
+		// in FS, set up the ship display name based on the wing display name
+		else
+		{
+			wing_bash_ship_name(shipp->display_name, wingp->get_display_name(), ordinal);
+			shipp->flags.set(Ship::Ship_Flags::Has_display_name);
+		}
 	}
 	else if (reset_display_name_if_normal)
 	{

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -15218,42 +15218,46 @@ int get_available_secondary_weapons(object *objp, int *outlist, int *outbanklist
 	return count;
 }
 
-void wing_bash_ship_name(SCP_string &ship_name, const char *wing_name, int index)
+void wing_bash_ship_name(SCP_string &ship_name, const char *wing_name, int ordinal)
 {
 	// always create the name this way; display names are handled in the p_object* and ship* functions
-	sprintf(ship_name, NOX("%s %d"), wing_name, index);
+	sprintf(ship_name, NOX("%s %d"), wing_name, ordinal);
 }
 
-void wing_bash_ship_name(char *ship_name, const char *wing_name, int index)
+void wing_bash_ship_name(char *ship_name, const char *wing_name, int ordinal)
 {
-	static_assert(MAX_SHIPS_PER_WING < 10, "If two-digit wingman indexes are possible, this function will need to be modified.");
-	constexpr size_t max_name_len = NAME_LENGTH - 3;
+	char ordinal_str[NAME_LENGTH];
+	sprintf(ordinal_str, "%d", ordinal);
+
+	size_t max_name_len = NAME_LENGTH - 2 - strlen(ordinal_str);
 
 	// truncate name if too long
 	if (strlen(wing_name) > max_name_len)
 	{
 		Warning(LOCATION, "Wing name %s is too long; truncating name for ship", wing_name);
 		strncpy(ship_name, wing_name, max_name_len);
-		sprintf(ship_name + max_name_len, NOX("%d"), index);
+		ship_name[max_name_len] = '\0';
 	}
 	else
-	{
-		// always create the name this way; display names are handled in the p_object* and ship* functions
-		sprintf(ship_name, NOX("%s %d"), wing_name, index);
-	}
+		strcpy(ship_name, wing_name);
+
+	// add the rest
+	// always create the name this way; display names are handled in the p_object* and ship* functions
+	strcat(ship_name, " ");
+	strcat(ship_name, ordinal_str);
 }
 
-void wing_bash_ship_name(p_object *p_objp, const wing *wingp, int index, bool reset_display_name_if_normal)
+void wing_bash_ship_name(p_object *p_objp, const wing *wingp, int ordinal, bool reset_display_name_if_normal)
 {
 	// always update the real name
-	wing_bash_ship_name(p_objp->name, wingp->name, index);
+	wing_bash_ship_name(p_objp->name, wingp->name, ordinal);
 
 	// also set up the display name if we have one
 	// (In the unlikely edge case where the ship already has a display name for some reason, it will be overwritten.
 	//  This is unavoidable, because if we didn't overwrite display names, all waves would have the display name from the first wave.)
 	if (wingp->has_display_name())
 	{
-		wing_bash_ship_name(p_objp->display_name, wingp->get_display_name(), index);
+		wing_bash_ship_name(p_objp->display_name, wingp->get_display_name(), ordinal);
 		p_objp->flags.set(Mission::Parse_Object_Flags::SF_Has_display_name);
 	}
 	else if (reset_display_name_if_normal)
@@ -15263,17 +15267,17 @@ void wing_bash_ship_name(p_object *p_objp, const wing *wingp, int index, bool re
 	}
 }
 
-void wing_bash_ship_name(ship *shipp, const wing *wingp, int index, bool reset_display_name_if_normal)
+void wing_bash_ship_name(ship *shipp, const wing *wingp, int ordinal, bool reset_display_name_if_normal)
 {
 	// always update the real name
-	wing_bash_ship_name(shipp->ship_name, wingp->name, index);
+	wing_bash_ship_name(shipp->ship_name, wingp->name, ordinal);
 
 	// also set up the display name if we have one
 	// (In the unlikely edge case where the ship already has a display name for some reason, it will be overwritten.
 	//  This is unavoidable, because if we didn't overwrite display names, all waves would have the display name from the first wave.)
 	if (wingp->has_display_name())
 	{
-		wing_bash_ship_name(shipp->display_name, wingp->get_display_name(), index);
+		wing_bash_ship_name(shipp->display_name, wingp->get_display_name(), ordinal);
 		shipp->flags.set(Ship::Ship_Flags::Has_display_name);
 	}
 	else if (reset_display_name_if_normal)

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1776,10 +1776,10 @@ extern int wing_name_lookup(const char *name, int ignore_count = 0);
 extern bool wing_has_yet_to_arrive(const wing *wingp);
 
 // for generating a ship name for arbitrary waves/indexes of that wing
-extern void wing_bash_ship_name(SCP_string &ship_name, const char *wing_name, int index);
-extern void wing_bash_ship_name(char *ship_name, const char *wing_name, int index);
-extern void wing_bash_ship_name(p_object *p_objp, const wing *wingp, int index, bool reset_display_name_if_normal = false);
-extern void wing_bash_ship_name(ship *shipp, const wing *wingp, int index, bool reset_display_name_if_normal = false);
+extern void wing_bash_ship_name(SCP_string &ship_name, const char *wing_name, int ordinal);
+extern void wing_bash_ship_name(char *ship_name, const char *wing_name, int ordinal);
+extern void wing_bash_ship_name(p_object *p_objp, const wing *wingp, int ordinal, bool reset_display_name_if_normal = false);
+extern void wing_bash_ship_name(ship *shipp, const wing *wingp, int ordinal, bool reset_display_name_if_normal = false);
 extern int Player_ship_class;
 
 //	Do the special effect for energy dissipating into the shield for a hit.


### PR DESCRIPTION
Handle wing names with any ordinal digit length.  Also fix a bug in `multi_ts_get_shipname` which passed a 0-based index instead of a 1-based index.

Follow-up to #7429 

Also a related fix: don't automatically give the ship a display name in FRED when the wing has a display name.