### PR TITLE
add missing fontconfig dependency for ccache workflow

### DIFF
--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
+      - name: Install Qt dependencies
+        run: apt-get -yq update && apt-get -yq install libfontconfig1
       - uses: actions/checkout@v1
         name: Checkout
         with:


### PR DESCRIPTION
Follow up to #7382 as the issue didn't appear in this workflow until #7380 was finally merged.