### PR TITLE
Convert CSG/PLR fixed ship/weapon arrays to SCP_vector

### DIFF
--- a/code/mission/missioncampaign.cpp
+++ b/code/mission/missioncampaign.cpp
@@ -392,18 +392,16 @@ void mission_campaign_build_list(bool desc, bool sort, bool multiplayer)
  */
 void mission_campaign_get_sw_info()
 {
-    int i, count, ship_list[MAX_SHIP_CLASSES], weapon_list[MAX_WEAPON_TYPES];
+	if (optional_string("+Starting Ships:")) {
+		SCP_vector<int> ship_list;
+		stuff_int_list(ship_list, ParseLookupType::SHIP_INFO_TYPE);
 
-    if (optional_string("+Starting Ships:")) {
-        count = sz2i(stuff_int_list(ship_list, MAX_SHIP_CLASSES, ParseLookupType::SHIP_INFO_TYPE));
-
-        // now set the array elements stating which ships we are allowed
-        for (i = 0; i < count; i++) {
-            if (Ship_info[ship_list[i]].flags[Ship::Info_Flags::Player_ship])
-                Campaign.ships_allowed[ship_list[i]] = 1;
-        }
-	}
-	else {
+		// now set the array elements stating which ships we are allowed
+		for (int idx : ship_list) {
+			if (Ship_info[idx].flags[Ship::Info_Flags::Player_ship])
+				Campaign.ships_allowed[idx] = 1;
+		}
+	} else {
 		// set allowable ships to the SIF_PLAYER_SHIPs
 		for (auto it = Ship_info.cbegin(); it != Ship_info.cend(); ++it) {
 			if (it->flags[Ship::Info_Flags::Player_ship])
@@ -411,16 +409,16 @@ void mission_campaign_get_sw_info()
 		}
 	}
 
-    if (optional_string("+Starting Weapons:")) {
-        count = sz2i(stuff_int_list(weapon_list, MAX_WEAPON_TYPES, ParseLookupType::WEAPON_POOL_TYPE));
+	if (optional_string("+Starting Weapons:")) {
+		SCP_vector<int> weapon_list;
+		stuff_int_list(weapon_list, ParseLookupType::WEAPON_POOL_TYPE);
 
-        // now set the array elements stating which ships we are allowed
-		for (i = 0; i < count; i++) {
-			if (Weapon_info[weapon_list[i]].wi_flags[Weapon::Info_Flags::Player_allowed])
-				Campaign.weapons_allowed[weapon_list[i]] = 1;
+		// now set the array elements stating which weapons we are allowed
+		for (int idx : weapon_list) {
+			if (Weapon_info[idx].wi_flags[Weapon::Info_Flags::Player_allowed])
+				Campaign.weapons_allowed[idx] = 1;
 		}
-    }
-	else {
+	} else {
 		// set allowable weapons to the player-allowed ones
 		for (auto it = Weapon_info.cbegin(); it != Weapon_info.cend(); ++it) {
 			if (it->wi_flags[Weapon::Info_Flags::Player_allowed])
@@ -732,13 +730,8 @@ void player_loadout_init()
 	memset(Player_loadout.filename, 0, sizeof(Player_loadout.filename));
 	memset(Player_loadout.last_modified, 0, sizeof(Player_loadout.last_modified));
 
-	for ( i = 0; i < MAX_SHIP_CLASSES; i++ ) {
-		Player_loadout.ship_pool[i] = 0;
-	}
-
-	for ( i = 0; i < MAX_WEAPON_TYPES; i++ ) {
-		Player_loadout.weapon_pool[i] = 0;
-	}
+	Player_loadout.ship_pool.assign(ship_info_size(), 0);
+	Player_loadout.weapon_pool.assign(weapon_info_size(), 0);
 
 	for ( i = 0; i < MAX_WSS_SLOTS; i++ ) {
 		Player_loadout.unit_data[i].ship_class = -1;
@@ -1270,8 +1263,8 @@ void mission_campaign_clear()
 	Campaign.loop_reentry = 0;
 	Campaign.realign_required = 0;
 	Campaign.num_players = 0;
-	memset( Campaign.ships_allowed, 0, sizeof(Campaign.ships_allowed) );
-	memset( Campaign.weapons_allowed, 0, sizeof(Campaign.weapons_allowed) );
+	Campaign.ships_allowed.assign(ship_info_size(), 0);
+	Campaign.weapons_allowed.assign(weapon_info_size(), 0);
 	Campaign.persistent_variables.clear(); 
 	Campaign.red_alert_variables.clear();
 	Campaign.persistent_containers.clear();

--- a/code/mission/missioncampaign.h
+++ b/code/mission/missioncampaign.h
@@ -129,8 +129,8 @@ public:
 	int		loop_reentry;							// mission number to return to after loop is finished
 	int		realign_required;						// are any missions missing alignment info? (Fred)
 	int		num_players;							// valid in multiplayer campaigns -- number of players campaign supports.
-	ubyte	ships_allowed[MAX_SHIP_CLASSES];		// which ships the player can use
-	ubyte	weapons_allowed[MAX_WEAPON_TYPES];		// which weapons the player can use
+	SCP_vector<ubyte>	ships_allowed;					// which ships the player can use
+	SCP_vector<ubyte>	weapons_allowed;				// which weapons the player can use
 	cmission	missions[MAX_CAMPAIGN_MISSIONS];	// decription of the missions
 	SCP_vector<sexp_variable> persistent_variables;		// These variables will be saved at the end of a mission
 	SCP_vector<sexp_variable> red_alert_variables;		// state of the variables in the previous mission of a Red Alert scenario.

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1095,13 +1095,13 @@ void wss_save_loadout()
 	Assert( (Ss_pool != NULL) && (Wl_pool != NULL) && (Wss_slots != NULL) );
 
 	// save the ship pool
-	for ( i = 0; i < MAX_SHIP_CLASSES; i++ ) {
-		Player_loadout.ship_pool[i] = Ss_pool[i]; 
+	for ( i = 0; i < ship_info_size(); i++ ) {
+		Player_loadout.ship_pool[i] = Ss_pool[i];
 	}
 
 	// save the weapons pool
-	for ( i = 0; i < MAX_WEAPON_TYPES; i++ ) {
-		Player_loadout.weapon_pool[i] = Wl_pool[i]; 
+	for ( i = 0; i < weapon_info_size(); i++ ) {
+		Player_loadout.weapon_pool[i] = Wl_pool[i];
 	}
 
 	// save the ship class / weapons for each slot
@@ -1132,23 +1132,13 @@ void wss_maybe_restore_loadout()
 		return;
 	}
 
-	// first we generate a pool of ships and weapons used the last time this mission was played. We also generate a pool of what is 
+	// first we generate a pool of ships and weapons used the last time this mission was played. We also generate a pool of what is
 	// available in this mission.
-	int	last_loadout_ships[MAX_SHIP_CLASSES];
-	int	this_loadout_ships[MAX_SHIP_CLASSES];
+	SCP_vector<int> last_loadout_ships(ship_info_size(), 0);
+	SCP_vector<int> this_loadout_ships(ship_info_size(), 0);
 
-	int	last_loadout_weapons[MAX_WEAPON_TYPES];
-	int	this_loadout_weapons[MAX_WEAPON_TYPES];
-
-	// zero all pools
-	for (i = 0; i < MAX_SHIP_CLASSES; i++) {
-		last_loadout_ships[i] = 0; 
-		this_loadout_ships[i] = 0; 
-	}
-	for (i = 0; i < MAX_WEAPON_TYPES; i++) {
-		last_loadout_weapons[i] = 0; 
-		this_loadout_weapons[i] = 0; 
-	}
+	SCP_vector<int> last_loadout_weapons(weapon_info_size(), 0);
+	SCP_vector<int> this_loadout_weapons(weapon_info_size(), 0);
 
 	// record the ship classes / weapons used last time
 	for ( i = 0; i < MAX_WSS_SLOTS; i++ ) {

--- a/code/missionui/missionscreencommon.h
+++ b/code/missionui/missionscreencommon.h
@@ -207,8 +207,8 @@ typedef struct loadout_data
 	char				filename[MAX_FILENAME_LEN];				// mission filename
 	char				last_modified[DATE_TIME_LENGTH];	// when mission was last modified
 	wss_unit			unit_data[MAX_WSS_SLOTS];			// ship and weapon data
-	int				weapon_pool[MAX_WEAPON_TYPES];	// available weapons
-	int				ship_pool[MAX_SHIP_CLASSES];			// available ships
+	SCP_vector<int>	weapon_pool;						// available weapons
+	SCP_vector<int>	ship_pool;							// available ships
 } loadout_data;
 
 extern loadout_data Player_loadout;

--- a/code/network/multi_campaign.cpp
+++ b/code/network/multi_campaign.cpp
@@ -279,29 +279,29 @@ void multi_campaign_process_update(ubyte *data, header *hinfo)
 			}
 		} else {
 			// clear the ships and weapons allowed arrays
-			memset(Campaign.ships_allowed,0,MAX_SHIP_CLASSES);
-			memset(Campaign.weapons_allowed,0,MAX_WEAPON_TYPES);
+			Campaign.ships_allowed.assign(ship_info_size(), 0);
+			Campaign.weapons_allowed.assign(weapon_info_size(), 0);
 
 			// get all ship classes
 			GET_USHORT(spool_size);
 			for(idx=0;idx<spool_size;idx++){
 				GET_USHORT(s_val);
 
-				if (s_val < MAX_SHIP_CLASSES) {
+				if (Campaign.ships_allowed.in_bounds(s_val)) {
 					Campaign.ships_allowed[s_val] = 1;
 				}
-			} 
-	
+			}
+
 			// get all weapon classes
 			GET_USHORT(wpool_size);
 			for(idx=0;idx<wpool_size;idx++){
 				GET_USHORT(s_val);
 
-				if (s_val < MAX_WEAPON_TYPES) {
+				if (Campaign.weapons_allowed.in_bounds(s_val)) {
 					Campaign.weapons_allowed[s_val] = 1;
 				}
 			}
-		}	
+		}
 
 		// ack the server
 		Net_player->state = NETPLAYER_STATE_CPOOL_ACK;

--- a/code/network/multi_fstracker.cpp
+++ b/code/network/multi_fstracker.cpp
@@ -893,6 +893,11 @@ void multi_stats_fs_to_tracker(scoring_struct *fs, vmt_stats_struct *vmt, player
 	// find only up to last in array with at least 1 kill
 	vmt->num_ships = MAX_FS2OPEN_COUNTS - vmt->num_medals;
 
+	// can't transmit more ship classes than this mod actually has
+	if (static_cast<size_t>(vmt->num_ships) > fs->kills.size()) {
+		vmt->num_ships = static_cast<unsigned char>(fs->kills.size());
+	}
+
 	for (int idx = vmt->num_ships-1; idx >= 0; --idx) {
 		if (fs->kills[idx] > 0) {
 			break;
@@ -958,7 +963,11 @@ void multi_stats_tracker_to_fs(vmt_stats_struct *vmt,scoring_struct *fs)
 				fs->medal_counts[idx] = static_cast<int>(vmt->counts[idx]);
 			}
 		} else {
-			fs->kills[idx2++] = static_cast<int>(vmt->counts[idx]);
+			// tracker may have more ship slots than this mod's ship_info; drop excess
+			if (fs->kills.in_bounds(idx2)) {
+				fs->kills[idx2] = static_cast<int>(vmt->counts[idx]);
+			}
+			++idx2;
 		}
 	}
 }

--- a/code/network/multimsgs.cpp
+++ b/code/network/multimsgs.cpp
@@ -6564,11 +6564,13 @@ void send_player_stats_block_packet(net_player *pl, int stats_code, net_player *
 	
 	// kill information - alltime
 	switch(stats_code){
-	case STATS_ALLTIME:	
+	case STATS_ALLTIME:
 		// alltime kills
+		// Wire protocol packs offset/count as USHORT; bump to wider field if ship_info_size() ever exceeds USHRT_MAX.
+		Assertion(sc->kills.size() <= USHRT_MAX, "ship_info_size() exceeds STATS_ALLTIME_KILLS packet's USHORT field width");
 		idx = 0;
-		while (idx < MAX_SHIP_CLASSES) {
-			send_player_stats_block_packet(pl, STATS_ALLTIME_KILLS, target, idx, MAX_SHIP_CLASSES-idx);
+		while (idx < sz2i(sc->kills.size())) {
+			send_player_stats_block_packet(pl, STATS_ALLTIME_KILLS, target, idx, sz2i(sc->kills.size())-idx);
 			idx += MAX_SHIPS_PER_PACKET;
 		}
 
@@ -6600,11 +6602,12 @@ void send_player_stats_block_packet(net_player *pl, int stats_code, net_player *
 		ADD_INT(sc->last_backup);  // should be 32-bit value - taylor
 		break;
 
-	case STATS_MISSION:	
-		// mission OKkills	
+	case STATS_MISSION:
+		// mission OKkills
+		Assertion(sc->m_okKills.size() <= USHRT_MAX, "ship_info_size() exceeds STATS_MISSION_CLASS_KILLS packet's USHORT field width");
 		idx = 0;
-		while (idx < MAX_SHIP_CLASSES) {
-			send_player_stats_block_packet(pl, STATS_MISSION_CLASS_KILLS, target, idx, MAX_SHIP_CLASSES-idx);
+		while (idx < sz2i(sc->m_okKills.size())) {
+			send_player_stats_block_packet(pl, STATS_MISSION_CLASS_KILLS, target, idx, sz2i(sc->m_okKills.size())-idx);
 			idx += MAX_SHIPS_PER_PACKET;
 		}
 	
@@ -6720,7 +6723,7 @@ void process_player_stats_block_packet(ubyte *data, header *hinfo)
 		for (idx = si_offset; idx < si_offset+si_count; idx++) {
 			GET_INT(i_tmp);
 
-			if (idx < MAX_SHIP_CLASSES) {
+			if (sc->kills.in_bounds(idx)) {
 				sc->kills[idx] = i_tmp;
 			}
 		}
@@ -6733,7 +6736,7 @@ void process_player_stats_block_packet(ubyte *data, header *hinfo)
 		for (idx = si_offset; idx < si_offset+si_count; idx++) {
 			GET_INT(i_tmp);
 
-			if (idx < MAX_SHIP_CLASSES) {
+			if (sc->m_okKills.in_bounds(idx)) {
 				sc->m_okKills[idx] = i_tmp;
 			}
 		}

--- a/code/pilotfile/csg.cpp
+++ b/code/pilotfile/csg.cpp
@@ -1610,8 +1610,8 @@ void pilotfile::csg_reset_data(bool reset_ships_and_weapons)
 
 	// zero out allowed ships/weapons
 	if (reset_ships_and_weapons) {
-		memset(Campaign.ships_allowed, 0, sizeof(Campaign.ships_allowed));
-		memset(Campaign.weapons_allowed, 0, sizeof(Campaign.weapons_allowed));
+		Campaign.ships_allowed.assign(ship_info_size(), 0);
+		Campaign.weapons_allowed.assign(weapon_info_size(), 0);
 	}
 
 	// reset campaign status

--- a/code/pilotfile/pilotfile.cpp
+++ b/code/pilotfile/pilotfile.cpp
@@ -333,7 +333,7 @@ void pilotfile::set_multi_stats(const scoring_struct *stats)
 	multi_stats.ship_kills.clear();
 	multi_stats.ship_kills.shrink_to_fit();
 
-	auto kills_size = std::min(SDL_arraysize(stats->kills), Ship_info.size());
+	auto kills_size = stats->kills.size();
 
 	for (idx = 0; idx < kills_size; ++idx) {
 		if (stats->kills[idx] <= 0) {
@@ -446,7 +446,7 @@ bool pilotfile::export_stats(scoring_struct *stats)
 
 	// only export ships that this mod knows about (should already be index)
 	for (auto &item : p_stats->ship_kills) {
-		if ( (item.index >= 0) && (item.index < MAX_SHIP_CLASSES) ) {
+		if ( stats->kills.in_bounds(item.index) ) {
 			stats->kills[item.index] = item.val;
 		}
 	}

--- a/code/pilotfile/plr.cpp
+++ b/code/pilotfile/plr.cpp
@@ -568,7 +568,7 @@ void pilotfile::plr_read_stats()
 		for (size_t idx = 0; idx < list_size; idx++) {
 			auto j = all_time_stats.ship_kills[idx].index;
 
-			if (j >= 0) {
+			if (p->stats.kills.in_bounds(j)) {
 				p->stats.kills[j] = all_time_stats.ship_kills[idx].val;
 			}
 		}
@@ -665,7 +665,7 @@ void pilotfile::plr_read_stats_multi()
 		for (size_t idx = 0; idx < list_size; idx++) {
 			auto j = multi_stats.ship_kills[idx].index;
 
-			if (j >= 0) {
+			if (p->stats.kills.in_bounds(j)) {
 				p->stats.kills[j] = multi_stats.ship_kills[idx].val;
 			}
 		}

--- a/code/stats/scoring.cpp
+++ b/code/stats/scoring.cpp
@@ -408,6 +408,9 @@ void traitor_init()
 }
 
 // initialize a nice blank scoring element
+// Note: must be called after ship_init()/weapon_init() so ship_info_size() is final.
+// scoring_struct instances default-constructed before tables parse start with empty
+// kills vectors and must be re-initialized via init() (or replaced via assign()) before use.
 void scoring_struct::init()
 {
 	flags = 0;
@@ -416,7 +419,7 @@ void scoring_struct::init()
 
 	medal_counts.assign((int)Medals.size(), 0);
 
-	memset(kills, 0, sizeof(kills));
+	kills.assign(ship_info_size(), 0);
 	assists = 0;
 	kill_count = 0;
 	kill_count_ok = 0;
@@ -440,8 +443,8 @@ void scoring_struct::init()
 	m_badge_earned.clear();
 
 	m_score = 0;
-	memset(m_kills, 0, sizeof(m_kills));
-	memset(m_okKills, 0, sizeof(m_okKills));
+	m_kills.assign(ship_info_size(), 0);
+	m_okKills.assign(ship_info_size(), 0);
 	m_kill_count = 0;
 	m_kill_count_ok = 0;
 	m_assists = 0;
@@ -466,7 +469,7 @@ void scoring_struct::assign(const scoring_struct &s)
 
 	medal_counts.assign(s.medal_counts.begin(), s.medal_counts.end());
 
-	memcpy(kills, s.kills, MAX_SHIP_CLASSES * sizeof(int));
+	kills = s.kills;
 	assists = s.assists;
 	kill_count = s.kill_count;
 	kill_count_ok = s.kill_count_ok;
@@ -490,8 +493,8 @@ void scoring_struct::assign(const scoring_struct &s)
 	m_badge_earned = s.m_badge_earned;
 
 	m_score = s.m_score;
-	memcpy(m_kills, s.m_kills, MAX_SHIP_CLASSES * sizeof(int));
-	memcpy(m_okKills, s.m_okKills, MAX_SHIP_CLASSES * sizeof(int));
+	m_kills = s.m_kills;
+	m_okKills = s.m_okKills;
 	m_kill_count = s.m_kill_count;
 	m_kill_count_ok = s.m_kill_count_ok;
 	m_assists = s.m_assists;
@@ -524,7 +527,7 @@ bool array_compare(const T (&left)[N], const T (&right)[N]) {
 }
 bool scoring_struct::operator==(const scoring_struct& rhs) const {
 	return flags == rhs.flags && score == rhs.score && rank == rhs.rank && medal_counts == rhs.medal_counts
-		&& array_compare(kills, rhs.kills) && assists == rhs.assists && kill_count == rhs.kill_count
+		&& kills == rhs.kills && assists == rhs.assists && kill_count == rhs.kill_count
 		&& kill_count_ok == rhs.kill_count_ok && p_shots_fired == rhs.p_shots_fired
 		&& s_shots_fired == rhs.s_shots_fired && p_shots_hit == rhs.p_shots_hit && s_shots_hit == rhs.s_shots_hit
 		&& p_bonehead_hits == rhs.p_bonehead_hits && s_bonehead_hits == rhs.s_bonehead_hits
@@ -532,8 +535,8 @@ bool scoring_struct::operator==(const scoring_struct& rhs) const {
 		&& flight_time == rhs.flight_time && last_flown == rhs.last_flown && last_backup == rhs.last_backup
 		&& m_medal_earned == rhs.m_medal_earned && m_badge_earned == rhs.m_badge_earned
 		&& m_promotion_earned == rhs.m_promotion_earned && m_score == rhs.m_score
-		&& array_compare(m_kills, rhs.m_kills)
-		&& array_compare(m_okKills, rhs.m_okKills) && m_kill_count == rhs.m_kill_count
+		&& m_kills == rhs.m_kills
+		&& m_okKills == rhs.m_okKills && m_kill_count == rhs.m_kill_count
 		&& m_kill_count_ok == rhs.m_kill_count_ok && m_assists == rhs.m_assists && mp_shots_fired == rhs.mp_shots_fired
 		&& ms_shots_fired == rhs.ms_shots_fired && mp_shots_hit == rhs.mp_shots_hit && ms_shots_hit == rhs.ms_shots_hit
 		&& mp_bonehead_hits == rhs.mp_bonehead_hits && ms_bonehead_hits == rhs.ms_bonehead_hits
@@ -561,8 +564,8 @@ void scoring_level_init( scoring_struct *scp )
 	scp->ms_bonehead_hits=0;
 	scp->m_bonehead_kills=0;
 
-	memset(scp->m_kills, 0, MAX_SHIP_CLASSES * sizeof(int));
-	memset(scp->m_okKills, 0, MAX_SHIP_CLASSES * sizeof(int));
+	scp->m_kills.assign(ship_info_size(), 0);
+	scp->m_okKills.assign(ship_info_size(), 0);
 
 	scp->m_kill_count = 0;
 	scp->m_kill_count_ok = 0;
@@ -690,7 +693,7 @@ void scoring_do_accept(scoring_struct *score)
 	score->s_bonehead_hits += score->ms_bonehead_hits;
 	score->bonehead_kills += score->m_bonehead_kills;
 
-	for(idx=0;idx<MAX_SHIP_CLASSES;idx++){
+	for(idx=0;idx<sz2i(score->kills.size());idx++){
 		score->kills[idx] = (int)(score->kills[idx] + score->m_okKills[idx]);
 	}
 
@@ -735,7 +738,7 @@ void scoring_backout_accept( scoring_struct *score )
 	score->s_bonehead_hits -= score->ms_bonehead_hits;
 	score->bonehead_kills -= score->m_bonehead_kills;
 
-	for(idx=0;idx<MAX_SHIP_CLASSES;idx++){
+	for(idx=0;idx<sz2i(score->kills.size());idx++){
 		score->kills[idx] = (unsigned short)(score->kills[idx] - score->m_okKills[idx]);
 	}
 

--- a/code/stats/scoring.h
+++ b/code/stats/scoring.h
@@ -97,7 +97,7 @@ public:
 	int rank;								// all time rank
 	SCP_vector<int> medal_counts;			// all time medal counts
 
-	int kills[MAX_SHIP_CLASSES];		// only valid kills (i.e. not on friendlies).
+	SCP_vector<int> kills;					// only valid kills (i.e. not on friendlies). Sized to ship_info_size() after table parse.
 	int assists;							// alltime assists
 	int kill_count;						// total alltime kills
 	int kill_count_ok;					// total valid alltime kills (no friendlies)
@@ -122,8 +122,8 @@ public:
 	int m_promotion_earned;				// was a promotion earned.  Calculated after mission is over
 
 	int m_score;
-	int m_kills[MAX_SHIP_CLASSES];		// this will represent all kills in the mission (bonehead or not)
-	int m_okKills[MAX_SHIP_CLASSES];	// this will be only the "valid" kills the player made
+	SCP_vector<int> m_kills;				// this will represent all kills in the mission (bonehead or not). Sized to ship_info_size().
+	SCP_vector<int> m_okKills;				// this will be only the "valid" kills the player made. Sized to ship_info_size().
 	int m_kill_count;						// total kills for this mission
 	int m_kill_count_ok;             // total (non-friendly) kills for this mission
 	int m_assists;							// player assits for the mission

--- a/code/stats/stats.cpp
+++ b/code/stats/stats.cpp
@@ -262,7 +262,7 @@ void show_stats_numbers(const scoring_struct &stats, bool use_m_stats, int sx, i
 
 int stats_get_kills(const scoring_struct &stats, bool use_m_stats, int ship_class)
 {
-	Assertion(ship_class >= 0 && ship_class < MAX_SHIP_CLASSES, "ship_class is out of bounds!");
+	Assertion(stats.kills.in_bounds(ship_class), "ship_class is out of bounds!");
 
 	if (use_m_stats)
 		return stats.m_okKills[ship_class];

--- a/fred2/initialships.cpp
+++ b/fred2/initialships.cpp
@@ -88,9 +88,8 @@ BOOL InitialShips::OnInitDialog()
 	} else if ( m_initial_items == INITIAL_WEAPONS ) {
 		// get the list of initial weapons available by looking at all possible player ships, getting
 		// the weapon information for those ships, then putting those weapons onto the list
-		int allowed_weapons[MAX_WEAPON_TYPES];
+		SCP_vector<int> allowed_weapons(weapon_info_size(), 0);
 
-		memset( allowed_weapons, 0, sizeof(allowed_weapons) );
         for (auto it = Ship_info.cbegin(); it != Ship_info.cend(); ++it) {
             if (it->flags[Ship::Info_Flags::Player_ship]) {
                 for (int i = 0; i < weapon_info_size(); ++i) {
@@ -145,12 +144,9 @@ void InitialShips::OnOK()
 
 	// zero out whichever array we are setting
 	if ( m_initial_items == INITIAL_SHIPS ) {
-		for ( i = 0; i < MAX_SHIP_CLASSES; i++ ){
-			Campaign.ships_allowed[i] = 0;
-		}
+		Campaign.ships_allowed.assign(ship_info_size(), 0);
 	} else if ( m_initial_items == INITIAL_WEAPONS ) {
-		for (i = 0; i < MAX_WEAPON_TYPES; i++ )
-			Campaign.weapons_allowed[i] = 0;
+		Campaign.weapons_allowed.assign(weapon_info_size(), 0);
 	}
 
 	for ( i = 0; i < m_list_count; i++ ) {

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -100,8 +100,8 @@ void CampaignEditorDialogModel::initializeData(const char* filename)
 		}
 
 		// Copy ship and weapon permissions from the global Campaign struct
-		m_ships_allowed.assign(Campaign.ships_allowed, Campaign.ships_allowed + MAX_SHIP_CLASSES);
-		m_weapons_allowed.assign(Campaign.weapons_allowed, Campaign.weapons_allowed + MAX_WEAPON_TYPES);
+		m_ships_allowed.assign(Campaign.ships_allowed.begin(), Campaign.ships_allowed.end());
+		m_weapons_allowed.assign(Campaign.weapons_allowed.begin(), Campaign.weapons_allowed.end());
 
 	} else {
 		// CREATING A NEW CAMPAIGN
@@ -114,8 +114,8 @@ void CampaignEditorDialogModel::initializeData(const char* filename)
 		m_num_players = 0;
 		m_flags = CF_DEFAULT_VALUE;
 
-		m_ships_allowed.assign(MAX_SHIP_CLASSES, false);
-		m_weapons_allowed.assign(MAX_WEAPON_TYPES, false);
+		m_ships_allowed.assign(ship_info_size(), false);
+		m_weapons_allowed.assign(weapon_info_size(), false);
 	}
 
 	// Load the list of available mission files from the directory.
@@ -264,12 +264,8 @@ void CampaignEditorDialogModel::commitWorkingCopyToGlobal()
 	Campaign.custom_data = m_custom_data;
 
 	// Copy ship and weapon permissions
-	for (int i = 0; i < MAX_SHIP_CLASSES; ++i) {
-		Campaign.ships_allowed[i] = m_ships_allowed[i];
-	}
-	for (int i = 0; i < MAX_WEAPON_TYPES; ++i) {
-		Campaign.weapons_allowed[i] = m_weapons_allowed[i];
-	}
+	Campaign.ships_allowed.assign(m_ships_allowed.begin(), m_ships_allowed.end());
+	Campaign.weapons_allowed.assign(m_weapons_allowed.begin(), m_weapons_allowed.end());
 
 	// Copy mission data
 	for (int i = 0; i < Campaign.num_missions; ++i) {

--- a/test/src/pilotfile/plr.cpp
+++ b/test/src/pilotfile/plr.cpp
@@ -57,8 +57,7 @@ std::ostream& operator<<(std::ostream& out, const scoring_struct& data) {
 	out << "score:" << data.score << "\n";
 	out << "rank:" << data.rank << "\n";
 	out << "medal_counts:" << data.medal_counts << "\n";
-	out << "kills:";
-	array_print(out, data.kills) << "\n";
+	out << "kills:" << data.kills << "\n";
 	out << "assists:" << data.assists << "\n";
 	out << "kill_count:" << data.kill_count << "\n";
 	out << "kill_count_ok:" << data.kill_count_ok << "\n";
@@ -77,10 +76,8 @@ std::ostream& operator<<(std::ostream& out, const scoring_struct& data) {
 	out << "m_badge_earned:" << data.m_badge_earned << "\n";
 	out << "m_promotion_earned:" << data.m_promotion_earned << "\n";
 	out << "m_score:" << data.m_score << "\n";
-	out << "m_kills:";
-	array_print(out, data.m_kills) << "\n";
-	out << "m_okKills:";
-	array_print(out, data.m_okKills) << "\n";
+	out << "m_kills:" << data.m_kills << "\n";
+	out << "m_okKills:" << data.m_okKills << "\n";
 	out << "m_kill_count:" << data.m_kill_count << "\n";
 	out << "m_kill_count_ok:" << data.m_kill_count_ok << "\n";
 	out << "m_assists:" << data.m_assists << "\n";


### PR DESCRIPTION
Ship_info is already an SCP_vector but MAX_SHIP_CLASSES (500) is held in place by fixed-size structures throughout the engine and editors. This converts the seven file-format-adjacent arrays whose persistence touches the .csg campaign save and .plr pilot file formats:

  campaign::ships_allowed         [MAX_SHIP_CLASSES] -> SCP_vector<ubyte>
  campaign::weapons_allowed       [MAX_WEAPON_TYPES] -> SCP_vector<ubyte>
  loadout_data::ship_pool         [MAX_SHIP_CLASSES] -> SCP_vector<int>
  loadout_data::weapon_pool       [MAX_WEAPON_TYPES] -> SCP_vector<int>
  scoring_struct::kills           [MAX_SHIP_CLASSES] -> SCP_vector<int>
  scoring_struct::m_kills         [MAX_SHIP_CLASSES] -> SCP_vector<int>
  scoring_struct::m_okKills       [MAX_SHIP_CLASSES] -> SCP_vector<int>

The CSG and PLR file formats already store explicit counts and key by ship/weapon names, so no on-disk format change is needed. Existing read/write loops already iterated by ship_info_size() / weapon_info_size() and just compile through against the new vector types.

Vectors are sized to ship_info_size() / weapon_info_size() in scoring_struct::init(), mission_campaign_clear(), player_loadout_init(), and the campaign-pool reset paths in csg.cpp and multi_campaign.cpp. All of these run after weapon_init() / ship_init(), so the sizing invariant holds. scoring_struct globals constructed at static-init time start with empty vectors; first index access is always post-table-parse.

Multiplayer stats sync (multimsgs.cpp) now derives offsets and counts from the vector size; added USHRT_MAX assertions on the sender side since the wire protocol packs offset/count as USHORT. The FSTracker sync (multi_fstracker.cpp) clamps vmt->num_ships down to the local mod's kills.size() before transmission and guards the receive-side write so a tracker payload with more ship slots than this mod has won't overrun the vector.

The MAX_SHIP_CLASSES cap itself stays in place at ship.cpp:2327; this is one prerequisite toward lifting it. The other ~25 fixed-size ship-class-indexed structures (team_data, Ss_pool_teams, Wl_ships, FRED2 editor arrays, qtFRED Editor::_ship_usage, etc.) remain to be addressed in follow-up PRs.