### PR TITLE
Move SDL joystick scanning off the main thread

### DIFF
--- a/code/io/joy-sdl.cpp
+++ b/code/io/joy-sdl.cpp
@@ -1036,6 +1036,13 @@ namespace joystick
 
 		mprintf(("Initializing Joystick...\n"));
 
+		// Run joystick polling and HID device-detection on a dedicated SDL thread
+		// instead of the main thread. Without this, WM_DEVICECHANGE broadcasts
+		// (caused by wireless HID peripherals waking/sleeping on the USB bus)
+		// trigger SDL to re-walk every HID device class via SetupAPI / cfgmgr32
+		// from inside SDL_PollEvent, stalling the frame loop for multiple seconds.
+		SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
+
 		if (SDL_InitSubSystem(SDL_INIT_JOYSTICK) < 0)
 		{
 			mprintf(("  Could not initialize joystick: %s\n", SDL_GetError()));


### PR DESCRIPTION
Setting SDL_HINT_JOYSTICK_THREAD=1 before SDL_InitSubSystem(SDL_INIT_JOYSTICK) tells SDL2 to run joystick polling and HID device-detection on a dedicated background thread, rather than processing them inline inside SDL_PollEvent on the main thread.

Without this hint, every WM_DEVICECHANGE broadcast (which Windows sends when *any* HID device wakes, sleeps, or pulses the USB bus) causes SDL to walk every HID device class via SetupAPI / cfgmgr32 from inside SDL_PollEvent, stalling the frame loop for multiple seconds on machines with many HID peripherals - especially wireless Logitech mice and keyboards that periodically pulse the bus. Diagnosed via ProcMon stack capture on one affected user's machine, with the slow frame's call chain ending in SDL2.dll -> SETUPAPI.dll -> cfgmgr32.dll -> kernel registry queries against HKLM\System\CurrentControlSet\Enum\HID\*.

With the hint enabled, that work happens on SDL's own thread and the main thread just dequeues already-collected events.

~~In draft pending confirmation via test.~~