### PR TITLE
fix ship registry updating in FRED

### DIFF
--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -1820,6 +1820,15 @@ int rename_ship(int ship, const char *name)
 	if (i >= 0)
 		strcpy_s(Reinforcements[i].name, name);
 
+	// keep the ship registry in sync
+	auto reg_it = Ship_registry_map.find(Ships[ship].ship_name);
+	if (reg_it != Ship_registry_map.end()) {
+		int reg_idx = reg_it->second;
+		Ship_registry_map.erase(reg_it);
+		strcpy_s(Ship_registry[reg_idx].name, name);
+		Ship_registry_map[name] = reg_idx;
+	}
+
 	strcpy_s(Ships[ship].ship_name, name);
 	if (ship == cur_ship)
 		Ship_editor_dialog.m_ship_name = _T(name);

--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -1494,6 +1494,15 @@ int Editor::rename_ship(int ship, const char* name) {
 	if (i >= 0)
 		strcpy_s(Reinforcements[i].name, name);
 
+	// keep the ship registry in sync
+	auto reg_it = Ship_registry_map.find(Ships[ship].ship_name);
+	if (reg_it != Ship_registry_map.end()) {
+		int reg_idx = reg_it->second;
+		Ship_registry_map.erase(reg_it);
+		strcpy_s(Ship_registry[reg_idx].name, name);
+		Ship_registry_map[name] = reg_idx;
+	}
+
 	strcpy_s(Ships[ship].ship_name, name);
 
 	// if this name has a hash, create a default display name


### PR DESCRIPTION
When a ship is renamed in FRED/QtFRED, its ship registry information should be updated.