### PR TITLE
FIx shadow banding on cockpits

### DIFF
--- a/code/def_files/data/effects/z-compress.sdr
+++ b/code/def_files/data/effects/z-compress.sdr
@@ -6,9 +6,11 @@ float compress_depth_value(float linear) {
 	linear = max(-linear, 0.0);
 
 	if(linear < 10.0) {
-		linear_mult = 0.00000999908;
-		exponent_mult = 1.32878452580;
-		offset = 0.0;
+	    //Special handling for very close values. For smooth shadows at very close distances, equidistant steps get too inaccurate.
+	    //Scaling this down linearly will push more accuracy to closer distances. Due to the scaling, this does not lose accuracy
+	    //at any point over the worse of uncompressed / z-compress, but it does trade the gained accuracy from compression at 10m
+	    //distance for accuracy lost due to compression below 0.5m (roughly)
+		return linear * 0.01;
 	}
 	else if (linear < 100.0) {
 		linear_mult = 0.05550473078;
@@ -70,9 +72,7 @@ float uncompress_depth_value(float compressed) {
 		offset = 3000.0;
 	}
 	else if (compressed < 0.1) {
-		linear_mult = 0.00000999908;
-		exponent_mult = 1.32878452580;
-		offset = 0.0;
+		return compressed * -100.0;
 	}
 	else if (compressed < 20.0) {
 		linear_mult = 0.05550473078;


### PR DESCRIPTION
Followup to #7245.
Turns out "but no cockpit actually needs micrometer or even nanometer precision" was an incorrect assumption, as this level of precision is needed to avoid shadow banding at very shallow light angles.

Fortunately, this is a very easy fix.
We just switch to linear handling in the closest accuracy band (thanks to Wookiee for the idea and find).
This will reduce the accuracy at 10m compared to Z-compressed, but not below what the accuracy was before Z-compression was introduced.
This will also not increase the accuracy of very close geometry to / beyond of what it was originally, but it will increase it beyond what it was with Z-compression.
In effect, this will just reshuffle some 10m accuracy to the sub-meter range in a linear fashion instead of in an equidistant fashion. This should remove any shadow banding in the cockpit range, while not reducing visual fidelity beyond what it was before Z-compression.

Any other parts of Z-compression, like long-distance view support or increased accuracy in the main battle lighting resolution are untouched and continue to work.