### PR TITLE
fix CTD when LuaSEXP evaluates a subsystem on an absent ship

### DIFF
--- a/code/parse/sexp/LuaSEXP.cpp
+++ b/code/parse/sexp/LuaSEXP.cpp
@@ -304,13 +304,13 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum, int parent_node) const
 
 		auto ship_entry = eval_ship(this_node);
 
-		if (!ship_entry || !ship_entry->has_shipp()) {
-			// Name is invalid
-			return LuaValue::createValue(_action.getLuaState(), l_Ship.Set(object_h()));
+		if (!ship_entry || !ship_entry->has_objp()) {
+			// Ship is not present in the mission (never arrived, destroyed, or departed)
+			return LuaValue::createValue(_action.getLuaState(), l_Subsystem.Set(ship_subsys_h()));
 		}
 
 		ship_subsys* ss = ship_get_subsys(ship_entry->shipp(), name);
-		
+
 		return LuaValue::createValue(_action.getLuaState(), l_Subsystem.Set(ship_subsys_h(ship_entry->objp(), ss)));
 	}
 	case OPF_DOCKER_POINT: {
@@ -334,7 +334,7 @@ luacpp::LuaValue LuaSEXP::sexpToLua(int node, int argnum, int parent_node) const
 		auto ship_entry = eval_ship(this_node);
 		if (!ship_entry || !ship_entry->has_shipp()) {
 			// Name is invalid
-			return LuaValue::createValue(_action.getLuaState(), l_Ship.Set(object_h()));
+			return LuaValue::createValue(_action.getLuaState(), l_Dockingbay.Set(dockingbay_h()));
 		}
 
 		auto docker_pm = model_get(Ship_info[ship_entry->shipp()->ship_info_index].model_num);


### PR DESCRIPTION
The OPF_SUBSYSTEM argument-conversion path in LuaSEXP only verified has_shipp() before calling ship_entry->objp().  A ship registry entry retains its shipnum after the ship is destroyed or departed, but its objnum is reset to -1, so objp() either asserts (debug) or dereferences Objects[-1] (release) when the entry is looked up by Lua scripting during, for example, an OnMissionAboutToEnd hook.

Tighten the check to has_objp() so absent ships short-circuit to an empty handle, and correct the early-return type from l_Ship to l_Subsystem.  Apply the matching type correction to OPF_DOCKER_POINT, which has the same return-type mismatch but no CTD because it never dereferences objp().

Fixes #7206.