### PR TITLE
fix ship select roster scroll-up getting stuck after list shrinks

### DIFF
--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1060,8 +1060,13 @@ int common_scroll_up_pressed(int *start, int size, int max_show)
 //
 int common_scroll_down_pressed(int *start, int size, int max_show)
 {
-	// check if we even need to scroll at all
+	// if the whole list fits on screen, the start offset must be 0;
+	// reset a stale non-zero offset so the up arrow doesn't get stuck
 	if ( size <= max_show ) {
+		if ( *start > 0 ) {
+			*start = 0;
+			return 1;
+		}
 		return 0;
 	}
 

--- a/code/missionui/missionshipchoice.cpp
+++ b/code/missionui/missionshipchoice.cpp
@@ -3307,9 +3307,17 @@ void ss_synch_interface()
 
 	init_active_list();	// build the list of pool ships
 
-	if ( old_list_start < SS_active_list_size ) {
-		SS_active_list_start = old_list_start;
+	// clamp the preserved scroll offset against the largest valid offset
+	// for the new list size, so the up arrow can still reach items at the
+	// top after a swap shrinks the active list (e.g., to <= MAX_ICONS_ON_SCREEN)
+	int max_start = SS_active_list_size - MAX_ICONS_ON_SCREEN;
+	if ( max_start < 0 ) {
+		max_start = 0;
 	}
+	if ( old_list_start > max_start ) {
+		old_list_start = max_start;
+	}
+	SS_active_list_start = old_list_start;
 
 	for ( i = 0; i < MAX_WSS_SLOTS; i++ ) {
 		slot = &Ss_wings[i/MAX_WING_SLOTS].ss_slots[i%MAX_WING_SLOTS];


### PR DESCRIPTION
After a drag-drop that consumed the last unit of a roster class, the active list could shrink while SS_active_list_start was non-zero, making items above the stuck offset (including default ships returned to the pool, such as Seth fighters) unreachable: the up-arrow handler short-circuits when size <= max_show without resetting the offset.

- Clamp the preserved scroll offset in ss_synch_interface() against SS_active_list_size - MAX_ICONS_ON_SCREEN.
- Harden common_scroll_down_pressed() to reset *start to 0 when the whole list fits on screen.

Fixes #6240.  Tested on the same Scroll mission from the stream, Thor's Hammer.