### PR TITLE
Add particles on death of particles

### DIFF
--- a/code/particle/ParticleEffect.cpp
+++ b/code/particle/ParticleEffect.cpp
@@ -49,6 +49,7 @@ ParticleEffect::ParticleEffect(SCP_string name)
 	  m_manual_velocity_offset(std::nullopt),
 	  m_light_source(std::nullopt),
 	  m_particleTrail(ParticleEffectHandle::invalid()),
+	  m_deathEffect(ParticleEffectHandle::invalid()),
 	  m_particleChance(1.f),
 	  m_distanceCulled(-1.f)
 	{}
@@ -119,6 +120,7 @@ ParticleEffect::ParticleEffect(SCP_string name,
 	  m_manual_velocity_offset(velocityOffsetLocal),
 	  m_light_source(std::nullopt),
 	  m_particleTrail(particleTrail),
+	  m_deathEffect(ParticleEffectHandle::invalid()),
 	  m_particleChance(particleChance),
 	  m_distanceCulled(distanceCulled) {}
 

--- a/code/particle/ParticleEffect.h
+++ b/code/particle/ParticleEffect.h
@@ -182,6 +182,7 @@ public:
 	std::optional<LightInformation> m_light_source;
 
 	ParticleEffectHandle m_particleTrail;
+	ParticleEffectHandle m_deathEffect;
 
 	float m_particleChance; //Deprecated. Use particle num random ranges instead.
 	float m_distanceCulled; //Kinda deprecated. Only used by the oldest of legacy effects.

--- a/code/particle/ParticleParse.cpp
+++ b/code/particle/ParticleParse.cpp
@@ -374,6 +374,25 @@ namespace particle {
 			}
 		}
 
+		static void parseModernDeathEffect(ParticleEffect& effect, bool top_layer) {
+			if (optional_string("$Death Effect:")) {
+				SCP_string name;
+				stuff_string(name, F_NAME);
+
+				effect.m_deathEffect = ParticleManager::get()->getEffectByName(name);
+			}
+			else if (top_layer && optional_string("$Death Inline Effect:")) {
+				SCP_string name;
+				stuff_string(name, F_NAME);
+
+				SCP_vector<ParticleEffect> death {constructModernEffect(name, false)};
+				while (optional_string("$Continue Death Effect:"))
+					death.emplace_back(constructModernEffect(name));
+
+				effect.m_deathEffect = ParticleManager::get()->addEffect(std::move(death));
+			}
+		}
+
 		static ParticleEffect constructModernEffect(const SCP_string& name, bool top_layer = true) {
 			ParticleEffect effect(name);
 
@@ -408,6 +427,7 @@ namespace particle {
 			parseModularCurvesSource(effect);
 
 			parseModernTrail(effect, top_layer);
+			parseModernDeathEffect(effect, top_layer);
 
 			return effect;
 		}

--- a/code/particle/particle.cpp
+++ b/code/particle/particle.cpp
@@ -13,6 +13,7 @@
 #include "particle/particle.h"
 #include "particle/ParticleManager.h"
 #include "particle/ParticleEffect.h"
+#include "particle/hosts/EffectHostVector.h"
 #include "debugconsole/console.h"
 #include "globalincs/systemvars.h"
 #include "graphics/2d.h"
@@ -250,12 +251,36 @@ namespace particle
 			}
 		}
 
+		const auto& source_effect = part->parent_effect.getParticleEffect();
+
 		if (remove_particle)
 		{
+			if (source_effect.m_deathEffect.isValid()) {
+				vec3d world_pos = part->pos;
+				vec3d world_vel = part->velocity;
+
+				// Convert from local to world space if attached to a valid parent
+				if (part->attached_objnum >= 0 &&
+					part->attached_objnum < MAX_OBJECTS &&
+					part->attached_sig == Objects[part->attached_objnum].signature) {
+					vec3d local_vel = part->velocity;
+					vm_vec_unrotate(&world_pos, &world_pos, &Objects[part->attached_objnum].orient);
+					vm_vec_add2(&world_pos, &Objects[part->attached_objnum].pos);
+					vm_vec_unrotate(&world_vel, &local_vel, &Objects[part->attached_objnum].orient);
+				}
+
+				matrix orient = vmd_identity_matrix;
+				if (vm_vec_mag_squared(&world_vel) > 0.0f) {
+					vm_vector_2_matrix(&orient, &world_vel);
+				}
+
+				auto deathSource = ParticleManager::get()->createSource(source_effect.m_deathEffect);
+				deathSource->setHost(std::make_unique<EffectHostVector>(world_pos, orient, world_vel));
+				deathSource->finishCreation();
+			}
+
 			return true;
 		}
-
-		const auto& source_effect = part->parent_effect.getParticleEffect();
 
 		float part_velocity =  vm_vec_mag_quick(&part->velocity);
 		float vel_scalar = source_effect.m_lifetime_curves.get_output(ParticleEffect::ParticleLifetimeCurvesOutput::VELOCITY_MULT, std::forward_as_tuple(*part, part_velocity) );


### PR DESCRIPTION
Implements and closes #3054.

With this, we can now have actual fireworks, where a particle (the lit firework) is moving along, spawning a trail, and then exploding into a bloom of colored particles that themselves also explode in more particles.