### PR TITLE
Fix 'ignore if dead' flag

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -190,6 +190,7 @@ namespace AI {
 		Do_not_set_override_when_assigning_form_on_wing,
 		Purge_player_issued_form_on_wing_after_subsequent_order,
 		Cancel_future_waves_of_any_wing_launched_from_an_exited_ship,
+		Fix_ignore_if_dead_flag,
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -747,6 +747,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$ships intercept mines:", AI::Profile_Flags::Ships_intercept_mines);
 
+				set_flag(profile, "$fix 'ignore if dead' flag:", AI::Profile_Flags::Fix_ignore_if_dead_flag);
+
 
 				// end of options ----------------------------------------
 
@@ -969,5 +971,8 @@ void ai_profile_t::reset()
 		flags.set(AI::Profile_Flags::Fix_avoid_shockwave_bugs);
 		flags.set(AI::Profile_Flags::Purge_player_issued_form_on_wing_after_subsequent_order);
 		flags.set(AI::Profile_Flags::Cancel_future_waves_of_any_wing_launched_from_an_exited_ship);
+	}
+	if (mod_supports_version(26, 0, 0)) {
+		flags.set(AI::Profile_Flags::Fix_ignore_if_dead_flag);
 	}
 }

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5834,8 +5834,14 @@ void weapon_home(object *obj, int num, float frame_time)
 	if (wp->homing_subsys != NULL) {
 		if (wp->homing_subsys->flags[Ship::Subsystem_Flags::Missiles_ignore_if_dead]) {
 			if ((wp->homing_subsys->max_hits > 0) && (wp->homing_subsys->current_hits <= 0)) {
-				wp->homing_object = &obj_used_list;
-				return;
+				if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_ignore_if_dead_flag]) {
+					// fixed way ensures an attack point on the target and proper homing
+					wp->homing_subsys = nullptr;
+				} else {
+					// old way resulted in weapon not homing
+					wp->homing_object = &obj_used_list;
+					return;
+				}
 			}
 		}
 	}

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5835,10 +5835,17 @@ void weapon_home(object *obj, int num, float frame_time)
 		if (wp->homing_subsys->flags[Ship::Subsystem_Flags::Missiles_ignore_if_dead]) {
 			if ((wp->homing_subsys->max_hits > 0) && (wp->homing_subsys->current_hits <= 0)) {
 				if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_ignore_if_dead_flag]) {
-					// fixed way ensures an attack point on the target and proper homing
+					// fixed way: clear dead subsys so the missile picks a hull attack point 
+					// or, for Javelins, re-acquire another engine
 					wp->homing_subsys = nullptr;
+					if (wip->wi_flags[Weapon::Info_Flags::Homing_javelin] && hobjp->type == OBJ_SHIP) {
+						int sindex = ship_get_by_signature(wp->target_sig);
+						if (sindex >= 0) {
+							wp->homing_subsys = ship_get_closest_subsys_in_sight(&Ships[sindex], SUBSYSTEM_ENGINE, &obj->pos);
+						}
+					}
 				} else {
-					// old way resulted in weapon not homing
+					// old way: resulted in weapon not homing
 					wp->homing_object = &obj_used_list;
 					return;
 				}


### PR DESCRIPTION
Fixes #7508.

The subsystem flag "ignore if dead" that many mods use is supposed to "prevent homing weapons from attempting to hit the now destroyed submodel and instead tells them to home on the main hull of the target."

Though, in actuality, the code makes the weapon dumb fire instead of home. This bug means if you destroy a subsystem with this flag, then lock onto it with an aspect weapon and fire the weapon, the weapon will just dumb fire.

With `wp->homing_subsys` cleared as this PR does, the homing code at `weapons.cpp`:5730 falls into its else branch and picks an attack point on the ship body (`ai_big_pick_attack_point / hobjp->pos`) — which is what the flag promises. Javelins, which can only home on engines, will still just drop lock if there's none though (edited for correction, previously stated javelins would acquire a new engine).

This fix is tested and now the flag works as expected.