### PR TITLE
null out editor-dialog globals on DestroyWindow

### DIFF
--- a/fred2/bgbitmapdlg.cpp
+++ b/fred2/bgbitmapdlg.cpp
@@ -444,7 +444,13 @@ void bg_bitmap_dlg::OnCancel()
 	OnClose();
 }
 
-void bg_bitmap_dlg::OnClose() 
+BOOL bg_bitmap_dlg::DestroyWindow()
+{
+	Bg_bitmap_dialog = nullptr;
+	return CDialog::DestroyWindow();
+}
+
+void bg_bitmap_dlg::OnClose()
 {
 	UpdateData(TRUE);
 	Mission_palette = m_nebula_color;

--- a/fred2/bgbitmapdlg.h
+++ b/fred2/bgbitmapdlg.h
@@ -101,6 +101,8 @@ public:
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(bg_bitmap_dlg)
+	public:
+	virtual BOOL DestroyWindow();
 	protected:
 	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
 	//}}AFX_VIRTUAL

--- a/fred2/briefingeditordlg.cpp
+++ b/fred2/briefingeditordlg.cpp
@@ -1408,8 +1408,9 @@ void briefing_editor_dlg::OnEndlabeleditTree(NMHDR* pNMHDR, LRESULT* pResult)
 	*pResult = m_tree.end_label_edit(pTVDispInfo->item);
 }
 
-BOOL briefing_editor_dlg::DestroyWindow() 
+BOOL briefing_editor_dlg::DestroyWindow()
 {
+	Briefing_dialog = nullptr;
 	m_play_bm.DeleteObject();
 	audiostream_close_file(m_voice_id, 0);
 	return CDialog::DestroyWindow();

--- a/fred2/debriefingeditordlg.cpp
+++ b/fred2/debriefingeditordlg.cpp
@@ -498,8 +498,9 @@ BOOL debriefing_editor_dlg::OnCommand(WPARAM wParam, LPARAM lParam)
 	return CDialog::OnCommand(wParam, lParam);
 }
 
-BOOL debriefing_editor_dlg::DestroyWindow() 
+BOOL debriefing_editor_dlg::DestroyWindow()
 {
+	Debriefing_dialog = nullptr;
 	audiostream_close_file(m_voice_id, 0);
 	m_play_bm.DeleteObject();
 	return CDialog::DestroyWindow();

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -1520,8 +1520,10 @@ void event_editor::OnSelchangeWaveFilename()
 	update_persona();
 }
 
-BOOL event_editor::DestroyWindow() 
+BOOL event_editor::DestroyWindow()
 {
+	Event_editor_dlg = nullptr;
+
 	audiostream_close_file(m_wave_id, 0);
 	m_wave_id = -1;
 

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -5048,9 +5048,9 @@ void CFREDView::OnUpdateViewFullDetail(CCmdUI *pCmdUI)
 	pCmdUI->SetCheck(FullDetail);
 }
 
-BOOL CFREDView::DestroyWindow() 
+BOOL CFREDView::DestroyWindow()
 {
-	// TODO: Add your specialized code here and/or call the base class
+	Fred_view_wnd = nullptr;
 	return CView::DestroyWindow();
 }
 

--- a/fred2/messageeditordlg.cpp
+++ b/fred2/messageeditordlg.cpp
@@ -493,7 +493,13 @@ void CMessageEditorDlg::OnNew()
 	update_cur_message();
 }
 
-void CMessageEditorDlg::OnClose() 
+BOOL CMessageEditorDlg::DestroyWindow()
+{
+	Message_editor_dlg = nullptr;
+	return CDialog::DestroyWindow();
+}
+
+void CMessageEditorDlg::OnClose()
 {
 	int z;
 

--- a/fred2/messageeditordlg.h
+++ b/fred2/messageeditordlg.h
@@ -44,6 +44,8 @@ public:
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMessageEditorDlg)
+	public:
+	virtual BOOL DestroyWindow();
 	protected:
 	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
 	//}}AFX_VIRTUAL

--- a/fred2/missioncutscenesdlg.cpp
+++ b/fred2/missioncutscenesdlg.cpp
@@ -398,6 +398,12 @@ void CMissionCutscenesDlg::OnCancel()
 	CDialog::OnCancel();
 }
 
+BOOL CMissionCutscenesDlg::DestroyWindow()
+{
+	Cutscene_editor_dlg = nullptr;
+	return CDialog::DestroyWindow();
+}
+
 void CMissionCutscenesDlg::OnClose()
 {
 	if (query_modified()) {

--- a/fred2/missioncutscenesdlg.h
+++ b/fred2/missioncutscenesdlg.h
@@ -52,6 +52,8 @@ public:
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMissionCutscenesDlg)
+	public:
+	virtual BOOL DestroyWindow();
 	protected:
 	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
 	//}}AFX_VIRTUAL

--- a/fred2/missiongoalsdlg.cpp
+++ b/fred2/missiongoalsdlg.cpp
@@ -507,7 +507,13 @@ void CMissionGoalsDlg::OnCancel()
 	CDialog::OnCancel();
 }
 
-void CMissionGoalsDlg::OnClose() 
+BOOL CMissionGoalsDlg::DestroyWindow()
+{
+	Goal_editor_dlg = nullptr;
+	return CDialog::DestroyWindow();
+}
+
+void CMissionGoalsDlg::OnClose()
 {
 	int z;
 

--- a/fred2/missiongoalsdlg.h
+++ b/fred2/missiongoalsdlg.h
@@ -58,6 +58,8 @@ public:
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMissionGoalsDlg)
+	public:
+	virtual BOOL DestroyWindow();
 	protected:
 	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
 	//}}AFX_VIRTUAL


### PR DESCRIPTION
Several dialogs already null their global at the top of DestroyWindow, but a few do not: briefing, debriefing, event, background, message, cutscene, goal, and Fred_view_wnd.  OnClose nulls in those five cover the user-initiated close path, but any teardown that bypasses OnClose leaves a dangling pointer that could be dereferenced.