### PR TITLE
invalidate UI render instance cache when freeing model instances

### DIFF
--- a/code/model/modelread.cpp
+++ b/code/model/modelread.cpp
@@ -31,6 +31,7 @@
 #include "math/fvi.h"
 #include "math/vecmat.h"
 #include "model/model.h"
+#include "model/modelrender.h"
 #include "model/modelreplace.h"
 #include "model/modelsinc.h"
 #include "parse/parselo.h"
@@ -337,6 +338,10 @@ void model_free_all()
 void model_instance_free_all()
 {
 	size_t i;
+
+	// invalidate the UI render instance cache first so it doesn't retain stale references
+	// into Polygon_model_instances after the loop below
+	model_clear_cached_ui_render_instances();
 
 	// free any outstanding model instances
 	for ( i = 0; i < Polygon_model_instances.size(); ++i ) {


### PR DESCRIPTION
Fixes a startup assertion failure in Star Fox: Event Horizon, where a Lua call to gr.freeAllModels() wiped Polygon_model_instances but left the UI render instance cache holding stale indices. The next state transition called model_clear_cached_ui_render_instances() which asserted in model_delete_instance().

Closes #7513