### PR TITLE
add a Reorder Ships and Wings editor to FRED

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1439,9 +1439,9 @@ int asteroid_check_collision(object *pasteroid, object *other_obj, vec3d *hitpos
 		// everything above was calculated relative to the heavy's position
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
 		if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr))
-			warp_effect = shipp->warpin_effect;
+			warp_effect = shipp->warpin_effect.get();
 		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr))
-			warp_effect = shipp->warpout_effect;
+			warp_effect = shipp->warpout_effect.get();
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect))
 			mc_ret_val = 0;

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -1152,9 +1152,9 @@ int debris_check_collision(object *pdebris, object *other_obj, vec3d *hitpos, co
 		// everything above was calculated relative to the heavy's position
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
 		if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr))
-			warp_effect = shipp->warpin_effect;
+			warp_effect = shipp->warpin_effect.get();
 		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr))
-			warp_effect = shipp->warpout_effect;
+			warp_effect = shipp->warpout_effect.get();
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect))
 			mc_ret_val = 0;

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -537,8 +537,8 @@ static bool shadow_obj_clip_plane(const object* objp, shadow_render_list::clip_p
 
 	if (dfi.maintained_variables.bool_value) {
 		auto* dship = &Ships[dfi.maintained_variables.objp_value->instance];
-		WarpEffect* warp_effect = dship->is_arriving(ship::warpstage::BOTH, true)
-			? dship->warpin_effect : dship->warpout_effect;
+		auto* warp_effect = (dship->is_arriving(ship::warpstage::BOTH, true)
+			? dship->warpin_effect : dship->warpout_effect).get();
 		model_render_params dummy;
 		if (warp_effect->warpShipClip(&dummy)) {
 			clip->normal = dummy.get_clip_plane_normal();

--- a/code/missioneditor/common.cpp
+++ b/code/missioneditor/common.cpp
@@ -97,6 +97,20 @@ anchor_t target_to_anchor(int target)
 		return anchor_t(target);
 }
 
+void update_custom_wing_indexes()
+{
+	int i;
+
+	for (i = 0; i < MAX_STARTING_WINGS; i++)
+		Starting_wings[i] = wing_name_lookup(Starting_wing_names[i], 1);
+
+	for (i = 0; i < MAX_SQUADRON_WINGS; i++)
+		Squadron_wings[i] = wing_name_lookup(Squadron_wing_names[i], 1);
+
+	for (i = 0; i < MAX_TVT_WINGS; i++)
+		TVT_wings[i] = wing_name_lookup(TVT_wing_names[i], 1);
+}
+
 void generate_weaponry_usage_list_team(int team, int* arr)
 {
 	int i;
@@ -294,6 +308,11 @@ static bool ship_slot_is_empty(int i)
 	return Ships[i].objnum < 0;
 }
 
+static bool wing_slot_is_empty(int i)
+{
+	return Wings[i].wave_count == 0;
+}
+
 static int find_free_slot(int max_slots, bool (*slot_is_empty)(int))
 {
 	for (int i = 0; i < max_slots; ++i)
@@ -370,6 +389,59 @@ void swap_ship_slots(int a, int b, const FredShipSlotConfig& cfg)
 void rotate_ship_slots(const SCP_vector<int>& slots, int from_pos, int to_pos, const FredShipSlotConfig& cfg)
 {
 	rotate_slots(slots, from_pos, to_pos, cfg, MAX_SHIPS, ship_slot_is_empty, reassign_ship_slot, "rotate_ship_slots");
+}
+
+void reassign_wing_slot(int from, int to, const FredWingSlotConfig& cfg, bool update_wing_indexes)
+{
+	Assertion(Fred_running, "reassign_wing_slot is FRED-only");
+	Assertion(from != to, "reassign_wing_slot: from == to (%d)", from);
+	Assertion(from >= 0 && from < MAX_WINGS, "reassign_wing_slot: 'from' slot %d out of range", from);
+	Assertion(to >= 0 && to < MAX_WINGS, "reassign_wing_slot: 'to' slot %d out of range", to);
+	Assertion(Wings[from].wave_count > 0, "reassign_wing_slot: source slot %d is empty", from);
+	Assertion(Wings[to].wave_count == 0, "reassign_wing_slot: destination slot %d is occupied", to);
+
+	// Move the wing struct itself; wave_count == 0 is the sentinel for an empty wing.
+	Wings[to] = std::move(Wings[from]);
+	Wings[from].wave_count = 0;
+
+	// Move FRED-side parallel array if the caller supplied it.
+	if (cfg.wing_objects != nullptr)
+	{
+		for (int k = 0; k < MAX_SHIPS_PER_WING; ++k)
+		{
+			cfg.wing_objects[to][k] = cfg.wing_objects[from][k];
+			cfg.wing_objects[from][k] = -1;
+		}
+	}
+
+	// Per-ship parent-wing back-reference.
+	for (auto &s: Ships)
+	{
+		if (s.objnum < 0)
+			continue;
+		if (s.wingnum == from)
+			s.wingnum = to;
+	}
+
+	// FRED's current-wing pointer, if the caller is tracking one.
+	if (cfg.cur_wing != nullptr && *cfg.cur_wing == from)
+		*cfg.cur_wing = to;
+
+	// Rebuild Starting/Squadron/TVT_wings caches from the parallel name arrays.
+	// The rebuild is total rather than incremental, so a caller making a batch
+	// of reassignments may defer it to the final call.
+	if (update_wing_indexes)
+		update_custom_wing_indexes();
+}
+
+void swap_wing_slots(int a, int b, const FredWingSlotConfig& cfg)
+{
+	swap_slots(a, b, cfg, MAX_WINGS, wing_slot_is_empty, reassign_wing_slot, "swap_wing_slots");
+}
+
+void rotate_wing_slots(const SCP_vector<int>& slots, int from_pos, int to_pos, const FredWingSlotConfig& cfg)
+{
+	rotate_slots(slots, from_pos, to_pos, cfg, MAX_WINGS, wing_slot_is_empty, reassign_wing_slot, "rotate_wing_slots");
 }
 
 // Bulk-re-sort one type's subset of obj_used_list while keeping non-matching

--- a/code/missioneditor/common.cpp
+++ b/code/missioneditor/common.cpp
@@ -1,10 +1,13 @@
 // methods and members common to any mission editor FSO may have
 #include "common.h"
+#include "ai/ai.h"
 #include "globalincs/linklist.h"
 #include "mission/missionparse.h"
 #include "iff_defs/iff_defs.h"
 #include "object/object.h"
 #include "ship/ship.h"
+
+#include <algorithm>
 
 // to keep track of data
 char Voice_abbrev_briefing[NAME_LENGTH];
@@ -213,4 +216,201 @@ bool set_single_player_start(int objnum)
 	ensure_valid_player_start_shipnum();
 
 	return changed;
+}
+
+void reassign_ship_slot(int from, int to, const FredShipSlotConfig& cfg, bool resort_obj_list)
+{
+	Assertion(Fred_running, "reassign_ship_slot is FRED-only: it does not fix up game-context references like Player_ship or runtime Ai_info shipnums");
+	Assertion(from != to, "reassign_ship_slot: from == to (%d)", from);
+	Assertion(from >= 0 && from < MAX_SHIPS, "reassign_ship_slot: 'from' slot %d out of range", from);
+	Assertion(to >= 0 && to < MAX_SHIPS, "reassign_ship_slot: 'to' slot %d out of range", to);
+	Assertion(Ships[from].objnum >= 0, "reassign_ship_slot: source slot %d is empty", from);
+	Assertion(Ships[to].objnum < 0, "reassign_ship_slot: destination slot %d is occupied", to);
+
+	// Move the ship struct itself.  Ship's move operations handle the members
+	// that need care (the subsys_list sentinel re-links its bookend nodes, and
+	// the owning pointers are unique_ptrs); this function's job is the external
+	// back-references.  Per the engine's convention, a slot with objnum < 0 is
+	// considered empty.
+	Ships[to] = std::move(Ships[from]);
+	Ships[from].objnum = -1;
+
+	// Move FRED-side parallel arrays if the caller supplied them.
+	if (cfg.fred_alt_names != nullptr)
+	{
+		strcpy_s(cfg.fred_alt_names[to], cfg.fred_alt_names[from]);
+		cfg.fred_alt_names[from][0] = '\0';
+	}
+	if (cfg.fred_callsigns != nullptr)
+	{
+		strcpy_s(cfg.fred_callsigns[to], cfg.fred_callsigns[from]);
+		cfg.fred_callsigns[from][0] = '\0';
+	}
+
+	// Object back-reference.
+	Objects[Ships[to].objnum].instance = to;
+
+	// Keep obj_used_list iteration order in sync with Ships[] slot order.  The
+	// re-sort is a total rebuild rather than an incremental fix, so a caller
+	// making a batch of reassignments may defer it to the final call.
+	if (resort_obj_list)
+		resort_ships_in_obj_used_list();
+
+	// AI back-reference (the one invariant codified by internal_integrity_check).
+	if (Ships[to].ai_index >= 0)
+		Ai_info[Ships[to].ai_index].shipnum = to;
+
+	// Wing membership: scan every wing and re-point any reference to the old slot.
+	// (wing.special_ship is wing-relative, NOT a Ships[] index, so it is intentionally
+	// not touched here.)
+	for (auto &w: Wings)
+	{
+		if (w.wave_count == 0)
+			continue;
+		for (int k = 0; k < w.wave_count; ++k)
+		{
+			if (w.ship_index[k] == from)
+				w.ship_index[k] = to;
+		}
+	}
+
+	// Single-player start.
+	if (Player_start_shipnum == from)
+		Player_start_shipnum = to;
+
+	// Ship_registry caches the shipnum on its entries (lookup is by name, but the
+	// cached integer would otherwise go stale).
+	int reg = ship_registry_get_index(Ships[to].ship_name);
+	if (reg >= 0)
+		Ship_registry[reg].shipnum = to;
+
+	// FRED's current-ship pointer, if the caller is tracking one.
+	if (cfg.cur_ship != nullptr && *cfg.cur_ship == from)
+		*cfg.cur_ship = to;
+}
+
+static bool ship_slot_is_empty(int i)
+{
+	return Ships[i].objnum < 0;
+}
+
+static int find_free_slot(int max_slots, bool (*slot_is_empty)(int))
+{
+	for (int i = 0; i < max_slots; ++i)
+	{
+		if (slot_is_empty(i))
+			return i;
+	}
+	return -1;
+}
+
+template <typename TConfig>
+static void swap_slots(int a, int b, const TConfig& cfg, int max_slots,
+	bool (*slot_is_empty)(int), void (*reassign)(int, int, const TConfig&, bool), const char* caller)
+{
+	if (a == b)
+		return;
+
+	Assertion(a >= 0 && a < max_slots, "%s: slot 'a' %d out of range", caller, a);
+	Assertion(b >= 0 && b < max_slots, "%s: slot 'b' %d out of range", caller, b);
+	Assertion(!slot_is_empty(a) && !slot_is_empty(b),
+		"%s: both slots must be valid (a=%d, b=%d)", caller, a, b);
+
+	// Find a free temporary slot.
+	int tmp = find_free_slot(max_slots, slot_is_empty);
+	if (tmp < 0)
+	{
+		ReleaseWarning(LOCATION, "%s: no free slot available for the temporary leg", caller);
+		return;
+	}
+
+	// Three-leg swap; each call's preconditions hold by construction.  The
+	// total-rebuild fixups are deferred to the final leg.
+	reassign(a, tmp, cfg, false);
+	reassign(b, a, cfg, false);
+	reassign(tmp, b, cfg, true);
+}
+
+template <typename TConfig>
+static void rotate_slots(const SCP_vector<int>& slots, int from_pos, int to_pos, const TConfig& cfg,
+	int max_slots, bool (*slot_is_empty)(int), void (*reassign)(int, int, const TConfig&, bool), const char* caller)
+{
+	if (from_pos == to_pos)
+		return;
+
+	int count = (int)slots.size();
+	Assertion(from_pos >= 0 && from_pos < count, "%s: 'from' position %d out of range", caller, from_pos);
+	Assertion(to_pos >= 0 && to_pos < count, "%s: 'to' position %d out of range", caller, to_pos);
+
+	// Find a free temporary slot.
+	int tmp = find_free_slot(max_slots, slot_is_empty);
+	if (tmp < 0)
+	{
+		ReleaseWarning(LOCATION, "%s: no free slot available for the temporary leg", caller);
+		return;
+	}
+
+	// Park the moving item in the free slot, shift everything between the two
+	// positions over by one, then drop the item into the slot vacated at the
+	// far end.  Preserves the relative order of everything else, in K+2
+	// reassignments for a move of K positions (vs 3K for a bubble of swaps).
+	// The total-rebuild fixups are deferred to the final leg.
+	int step = (to_pos > from_pos) ? 1 : -1;
+	reassign(slots[from_pos], tmp, cfg, false);
+	for (int j = from_pos; j != to_pos; j += step)
+		reassign(slots[j + step], slots[j], cfg, false);
+	reassign(tmp, slots[to_pos], cfg, true);
+}
+
+void swap_ship_slots(int a, int b, const FredShipSlotConfig& cfg)
+{
+	swap_slots(a, b, cfg, MAX_SHIPS, ship_slot_is_empty, reassign_ship_slot, "swap_ship_slots");
+}
+
+void rotate_ship_slots(const SCP_vector<int>& slots, int from_pos, int to_pos, const FredShipSlotConfig& cfg)
+{
+	rotate_slots(slots, from_pos, to_pos, cfg, MAX_SHIPS, ship_slot_is_empty, reassign_ship_slot, "rotate_ship_slots");
+}
+
+// Bulk-re-sort one type's subset of obj_used_list while keeping non-matching
+// entries in their original relative positions.  Each callsite supplies a
+// type matcher and a key function; the i-th matching slot (in original list
+// order) receives the i-th smallest matching node by key.
+static void resort_obj_used_list_subset(
+	bool (*matches_type)(int),
+	int (*key)(const object*))
+{
+	SCP_vector<object*> all;
+	SCP_vector<object*> matched;
+	for (auto o : list_range(&obj_used_list))
+	{
+		all.push_back(o);
+		if (matches_type(o->type))
+			matched.push_back(o);
+	}
+
+	std::sort(matched.begin(), matched.end(),
+		[&](const object* a, const object* b) { return key(a) < key(b); });
+
+	list_init(&obj_used_list);
+	auto it = matched.begin();
+	for (auto o : all)
+	{
+		if (matches_type(o->type))
+		{
+			list_append(&obj_used_list, *it);
+			++it;
+		}
+		else
+		{
+			list_append(&obj_used_list, o);
+		}
+	}
+}
+
+void resort_ships_in_obj_used_list()
+{
+	resort_obj_used_list_subset(
+		[](int t) { return t == OBJ_SHIP || t == OBJ_START; },
+		[](const object* o) { return o->instance; });
 }

--- a/code/missioneditor/common.h
+++ b/code/missioneditor/common.h
@@ -45,6 +45,11 @@ int anchor_to_target(anchor_t anchor);
 
 anchor_t target_to_anchor(int target);
 
+// Rebuild Starting_wings[], Squadron_wings[], TVT_wings[] from their parallel
+// name arrays via wing_name_lookup.  Consolidated from FRED's and qtFRED's
+// previously-duplicated copies.
+void update_custom_wing_indexes();
+
 void generate_weaponry_usage_list_team(int team, int* arr);
 
 void generate_weaponry_usage_list_wing(int wing_num, int* arr);
@@ -83,6 +88,29 @@ void swap_ship_slots(int a, int b, const FredShipSlotConfig& cfg);
 // Move the item at position from_pos in slots to position to_pos, shifting the
 // items in between by one position.
 void rotate_ship_slots(const SCP_vector<int>& slots, int from_pos, int to_pos, const FredShipSlotConfig& cfg);
+
+struct FredWingSlotConfig
+{
+	int (*wing_objects)[MAX_SHIPS_PER_WING] = nullptr;
+	int *cur_wing = nullptr;
+};
+
+// Move the wing currently in Wings[from] into Wings[to], updating every
+// back-reference (Ships[i].wingnum, Starting/Squadron/TVT_wings caches, and
+// editor-side fields supplied via cfg).  Leaves Wings[from] empty.
+// Preconditions: from != to, Wings[from].wave_count > 0, Wings[to].wave_count == 0.
+// No caller may hold a wing* to either slot across this call.
+// Fields in cfg whose pointers are nullptr are skipped.
+void reassign_wing_slot(int from, int to, const FredWingSlotConfig& cfg, bool update_wing_indexes = true);
+
+// Swap the contents of two slots.  Both must be valid (Wings[a].wave_count > 0
+// and Wings[b].wave_count > 0).  Implemented as three calls to
+// reassign_wing_slot via a temporary empty slot.
+void swap_wing_slots(int a, int b, const FredWingSlotConfig& cfg);
+
+// Move the item at position from_pos in slots to position to_pos, shifting the
+// items in between by one position.
+void rotate_wing_slots(const SCP_vector<int>& slots, int from_pos, int to_pos, const FredWingSlotConfig& cfg);
 
 // Restore the obj_used_list invariant for the OBJ_SHIP/OBJ_START subset:
 // among ship-type entries, list order matches Ships[] index order.

--- a/code/missioneditor/common.h
+++ b/code/missioneditor/common.h
@@ -58,3 +58,32 @@ void ensure_valid_player_start_shipnum();
 // OBJ_START, demote every other player start to OBJ_SHIP, adjust Player_starts to match,
 // and repoint Player_start_shipnum.  Returns true if anything changed.
 bool set_single_player_start(int objnum);
+
+struct FredShipSlotConfig
+{
+	char (*fred_alt_names)[NAME_LENGTH + 1] = nullptr;
+	char (*fred_callsigns)[NAME_LENGTH + 1] = nullptr;
+
+	int *cur_ship = nullptr;
+};
+
+// Move the ship currently in Ships[from] into Ships[to], updating every
+// back-reference (Objects, Ai_info, Wings, Player_start_shipnum, Ship_registry,
+// and editor-side fields supplied via cfg).  Leaves Ships[from] empty.
+// Preconditions: from != to, Ships[from].objnum >= 0, Ships[to].objnum < 0.
+// No caller may hold a ship* to either slot across this call.
+// Fields in cfg whose pointers are nullptr are skipped.
+void reassign_ship_slot(int from, int to, const FredShipSlotConfig& cfg, bool resort_obj_list = true);
+
+// Swap the contents of two slots.  Both must be valid (Ships[a].objnum >= 0
+// and Ships[b].objnum >= 0).  Implemented as three calls to reassign_ship_slot
+// via a temporary empty slot.
+void swap_ship_slots(int a, int b, const FredShipSlotConfig& cfg);
+
+// Move the item at position from_pos in slots to position to_pos, shifting the
+// items in between by one position.
+void rotate_ship_slots(const SCP_vector<int>& slots, int from_pos, int to_pos, const FredShipSlotConfig& cfg);
+
+// Restore the obj_used_list invariant for the OBJ_SHIP/OBJ_START subset:
+// among ship-type entries, list order matches Ships[] index order.
+void resort_ships_in_obj_used_list();

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -1662,11 +1662,11 @@ void model_render_glowpoint_bitmap(int point_num, const vec3d *pos, const matrix
 
 		if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr)
 			&& Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE) {
-			warp_effect = shipp->warpin_effect;
+			warp_effect = shipp->warpin_effect.get();
 		}
 		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr) 
 			&& Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE) {
-			warp_effect = shipp->warpout_effect;
+			warp_effect = shipp->warpout_effect.get();
 		}
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&world_pnt, warp_effect))
@@ -1821,10 +1821,10 @@ void model_render_glowpoint_add_light(int point_num, const vec3d *pos, const mat
 		WarpEffect* warp_effect = nullptr;
 
 		if ((shipp->is_arriving()) && Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE) {
-			warp_effect = shipp->warpin_effect;
+			warp_effect = shipp->warpin_effect.get();
 		}
 		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE) {
-			warp_effect = shipp->warpout_effect;
+			warp_effect = shipp->warpout_effect.get();
 		}
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&world_pnt, warp_effect))
@@ -2234,11 +2234,11 @@ void model_queue_render_thrusters(const model_render_params *interp, const polym
 
 				if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr)
 					&& Warp_params[shipp->warpin_params_index].warp_type != WT_HYPERSPACE) {
-					warp_effect = shipp->warpin_effect;
+					warp_effect = shipp->warpin_effect.get();
 				}
 				else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr)
 					&& Warp_params[shipp->warpout_params_index].warp_type != WT_HYPERSPACE) {
-					warp_effect = shipp->warpout_effect;
+					warp_effect = shipp->warpout_effect.get();
 				}
 
 				if (warp_effect != nullptr && point_is_clipped_by_warp(&world_pnt, warp_effect))

--- a/code/object/collideshipship.cpp
+++ b/code/object/collideshipship.cpp
@@ -358,9 +358,9 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
 
 		if (heavy_shipp->flags[Ship::Ship_Flags::Depart_warp] && heavy_shipp->warpout_effect != nullptr)
-			warp_effect = heavy_shipp->warpout_effect;
+			warp_effect = heavy_shipp->warpout_effect.get();
 		else if (heavy_shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && heavy_shipp->warpin_effect != nullptr)
-			warp_effect = heavy_shipp->warpin_effect;
+			warp_effect = heavy_shipp->warpin_effect.get();
 
 		bool heavy_warp_no_collide = false;
 		if (warp_effect != nullptr)
@@ -368,9 +368,9 @@ int ship_ship_check_collision(collision_info_struct *ship_ship_hit_info)
 
 		warp_effect = nullptr;
 		if (light_shipp->flags[Ship::Ship_Flags::Depart_warp] && light_shipp->warpout_effect != nullptr)
-			warp_effect = light_shipp->warpout_effect;
+			warp_effect = light_shipp->warpout_effect.get();
 		else if (light_shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && light_shipp->warpin_effect != nullptr)
-			warp_effect = light_shipp->warpin_effect;
+			warp_effect = light_shipp->warpin_effect.get();
 
 		bool light_warp_no_collide = false;
 		if (warp_effect != nullptr)

--- a/code/object/collideshipweapon.cpp
+++ b/code/object/collideshipweapon.cpp
@@ -435,9 +435,9 @@ static std::tuple<bool, bool, ship_weapon_collision_data> ship_weapon_check_coll
 		WarpEffect* warp_effect = nullptr;
 
 		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect != nullptr) 
-			warp_effect = shipp->warpout_effect;
+			warp_effect = shipp->warpout_effect.get();
 		else if (shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && shipp->warpin_effect != nullptr)
-			warp_effect = shipp->warpin_effect;
+			warp_effect = shipp->warpin_effect.get();
 
 		bool hull_no_collide, shield_no_collide;
 		hull_no_collide = shield_no_collide = false;

--- a/code/prop/prop.cpp
+++ b/code/prop/prop.cpp
@@ -1094,9 +1094,9 @@ int prop_check_collision(object* prop_obj, object* other_obj, vec3d* hitpos, col
 		// everything above was calculated relative to the heavy's position
 		vec3d actual_world_hit_pos = mc.hit_point_world + heavy_obj->pos;
 		if ((shipp->is_arriving()) && (shipp->warpin_effect != nullptr))
-			warp_effect = shipp->warpin_effect;
+			warp_effect = shipp->warpin_effect.get();
 		else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect != nullptr))
-			warp_effect = shipp->warpout_effect;
+			warp_effect = shipp->warpout_effect.get();
 
 		if (warp_effect != nullptr && point_is_clipped_by_warp(&actual_world_hit_pos, warp_effect))
 			mc_ret_val = 0;

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -6790,6 +6790,13 @@ vec3d get_submodel_offset(int model, int submodel){
 
 }
 
+// Defaulted here rather than in ship.h because the unique_ptr<WarpEffect>
+// members need the complete WarpEffect type at the point of definition.
+ship::ship() = default;
+ship::~ship() = default;
+ship::ship(ship &&) = default;				// NOLINT(performance-noexcept-move-constructor)
+ship &ship::operator=(ship &&) = default;	// NOLINT(performance-noexcept-move-constructor)
+
 // Reset all ship values to empty/unused.
 void ship::clear()
 {
@@ -6824,12 +6831,8 @@ void ship::clear()
 	really_final_death_time = timestamp(-1);
 	deathroll_rotvel = vmd_zero_vector;
 
-	if (warpin_effect != nullptr)
-		delete warpin_effect;
-	if (warpout_effect != nullptr)
-		delete warpout_effect;
-	warpin_effect = nullptr;
-	warpout_effect = nullptr;
+	warpin_effect.reset();
+	warpout_effect.reset();
 
 	warpin_params_index = -1;
 	warpout_params_index = -1;
@@ -16553,13 +16556,8 @@ void ship_close()
 	for (i=0; i<MAX_SHIPS; i++ )	{
 		ship *shipp = &Ships[i];
 
-		if(shipp->warpin_effect != NULL)
-			delete shipp->warpin_effect;
-		shipp->warpin_effect = NULL;
-
-		if(shipp->warpout_effect != NULL)
-			delete shipp->warpout_effect;
-		shipp->warpout_effect = NULL;
+		shipp->warpin_effect.reset();
+		shipp->warpout_effect.reset();
 	}
 
 	// free this too! -- Goober5000

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -450,6 +450,64 @@ public:
 	void clear();
 };
 
+// The head sentinel of a ship's intrusive subsystem list.  The sentinel's
+// address is meaningful: the first node's prev and the last node's next point
+// back at it, and an empty list is self-referential (after list_init) or
+// null-linked (after construction or ship::clear).  Moving a ship would
+// otherwise leave the bookend nodes pointing at the old sentinel address, so
+// the move operations re-link them.  Copying is deleted: a copied sentinel
+// would alias another list's nodes.
+struct ship_subsys_sentinel : public ship_subsys
+{
+	ship_subsys_sentinel() = default;
+
+	ship_subsys_sentinel(const ship_subsys_sentinel &) = delete;
+	ship_subsys_sentinel &operator=(const ship_subsys_sentinel &) = delete;
+
+	ship_subsys_sentinel(ship_subsys_sentinel &&other) noexcept
+	{
+		take_links_from(other);
+	}
+
+	ship_subsys_sentinel &operator=(ship_subsys_sentinel &&other) noexcept
+	{
+		if (this != &other)
+		{
+			Assertion(next == nullptr || next == this, "Move-assigning over a sentinel whose subsystem list is not empty!  The destination's subsystems would be orphaned.");
+			take_links_from(other);
+		}
+		return *this;
+	}
+
+private:
+	void take_links_from(ship_subsys_sentinel &other) noexcept
+	{
+		if (other.next == nullptr)
+		{
+			// other was never list_init'd; match that state
+			next = nullptr;
+			prev = nullptr;
+		}
+		else if (other.next == &other)
+		{
+			// other is an initialized empty list
+			next = this;
+			prev = this;
+		}
+		else
+		{
+			// take ownership of the chain and re-point the bookends
+			next = other.next;
+			prev = other.prev;
+			next->prev = this;
+			prev->next = this;
+		}
+		// leave other as an initialized empty list, which is safe to iterate
+		other.next = &other;
+		other.prev = &other;
+	}
+};
+
 // structure for subsystems which tells us the total count of a particular type of subsystem (i.e.
 // we might have 3 engines), and the relative strength of the subsystem.  The #defines in model.h
 // for SUBSYSTEM_xxx will be used as indices into this array.
@@ -592,8 +650,8 @@ public:
 	int	really_final_death_time;	// Time until ship breaks up and disappears
 	vec3d	deathroll_rotvel;			// Desired death rotational velocity
 
-	WarpEffect *warpin_effect;
-	WarpEffect *warpout_effect;
+	std::unique_ptr<WarpEffect> warpin_effect;
+	std::unique_ptr<WarpEffect> warpout_effect;
 
 	int warpin_params_index;
 	int warpout_params_index;
@@ -655,7 +713,7 @@ public:
 	// of a particular subsystem, like engines).  The subsys_info struct is information for particular
 	// types of subsystems.  (i.e. the list might contain 3 engines.  There will be one subsys_info entry
 	// describing the state of all engines combined) -- MWA 4/1/97
-	ship_subsys	subsys_list;									//	linked list of subsystems for this ship.
+	ship_subsys_sentinel	subsys_list;						//	linked list of subsystems for this ship.
 	std::unique_ptr<ship_subsys*[]> subsys_list_indexer;		//	provides random-access lookup to the linked list
 	ship_subsys	*last_targeted_subobject[MAX_PLAYERS];	// Last subobject that has been targeted.  NULL if none;(player specific)
 	ship_subsys_info	subsys_info[SUBSYSTEM_MAX];		// info on particular generic types of subsystems	
@@ -850,6 +908,28 @@ public:
 		STAGE2,
 		BOTH,
 	};
+
+	// Ships support moving but not copying.  The defaulted moves are correct
+	// because the members carry the smarts: the subsys_list sentinel re-links
+	// its bookend nodes, and the owning pointers are unique_ptrs.  Callers must
+	// still fix up external back-references (Objects[].instance,
+	// Ai_info[].shipnum, etc.) -- see reassign_ship_slot in
+	// missioneditor/common.cpp.
+	// All the defaulted special member functions are defaulted in ship.cpp
+	// rather than here because they need the complete WarpEffect type.
+	// The moves are not declared noexcept because the implicit exception
+	// specification differs by standard library: MSVC and clang compute
+	// nothrow, but libstdc++ computes potentially-throwing for some members,
+	// making an explicit noexcept ill-formed there (a defaulted redeclaration
+	// may not strengthen the implicit specification).  The NOLINTs suppress
+	// clang-tidy's performance-noexcept-move-constructor, which only sees
+	// clang's computation.
+	ship();
+	~ship();
+	ship(const ship &) = delete;
+	ship &operator=(const ship &) = delete;
+	ship(ship &&);				// NOLINT(performance-noexcept-move-constructor)
+	ship &operator=(ship &&);	// NOLINT(performance-noexcept-move-constructor)
 
 	// reset to a completely blank ship
 	void clear();

--- a/code/ship/shipfx.cpp
+++ b/code/ship/shipfx.cpp
@@ -1264,9 +1264,9 @@ void shipfx_emit_spark( int n, int sn )
 	WarpEffect* warp_effect = nullptr;
 
 	if ((shipp->is_arriving()) && (shipp->warpin_effect))
-		warp_effect = shipp->warpin_effect;
+		warp_effect = shipp->warpin_effect.get();
 	else if ((shipp->flags[Ship::Ship_Flags::Depart_warp]) && (shipp->warpout_effect))
-		warp_effect = shipp->warpout_effect;
+		warp_effect = shipp->warpout_effect.get();
 
 	if (warp_effect != nullptr && point_is_clipped_by_warp(&outpnt, warp_effect))
 		return;
@@ -2950,50 +2950,44 @@ void ship_set_warp_effects(object *objp)
 	if (warpout_type & WT_DEFAULT_WITH_FIREBALL)
 		warpout_type = WT_DEFAULT;
 
-	if (shipp->warpin_effect != nullptr)
-		delete shipp->warpin_effect;
-
 	switch (warpin_type)
 	{
 		case WT_DEFAULT:
 		case WT_KNOSSOS:
 		case WT_DEFAULT_THEN_KNOSSOS:
-			shipp->warpin_effect = new WE_Default(objnum, WarpDirection::WARP_IN);
+			shipp->warpin_effect = std::make_unique<WE_Default>(objnum, WarpDirection::WARP_IN);
 			break;
 		case WT_IN_PLACE_ANIM:
-			shipp->warpin_effect = new WE_BSG(objnum, WarpDirection::WARP_IN);
+			shipp->warpin_effect = std::make_unique<WE_BSG>(objnum, WarpDirection::WARP_IN);
 			break;
 		case WT_SWEEPER:
-			shipp->warpin_effect = new WE_Homeworld(objnum, WarpDirection::WARP_IN);
+			shipp->warpin_effect = std::make_unique<WE_Homeworld>(objnum, WarpDirection::WARP_IN);
 			break;
 		case WT_HYPERSPACE:
-			shipp->warpin_effect = new WE_Hyperspace(objnum, WarpDirection::WARP_IN);
+			shipp->warpin_effect = std::make_unique<WE_Hyperspace>(objnum, WarpDirection::WARP_IN);
 			break;
 		default:
-			shipp->warpin_effect = new WarpEffect();
+			shipp->warpin_effect = std::make_unique<WarpEffect>();
 	}
-
-	if (shipp->warpout_effect != nullptr)
-		delete shipp->warpout_effect;
 
 	switch (warpout_type)
 	{
 		case WT_DEFAULT:
 		case WT_KNOSSOS:
 		case WT_DEFAULT_THEN_KNOSSOS:
-			shipp->warpout_effect = new WE_Default(objnum, WarpDirection::WARP_OUT);
+			shipp->warpout_effect = std::make_unique<WE_Default>(objnum, WarpDirection::WARP_OUT);
 			break;
 		case WT_IN_PLACE_ANIM:
-			shipp->warpout_effect = new WE_BSG(objnum, WarpDirection::WARP_OUT);
+			shipp->warpout_effect = std::make_unique<WE_BSG>(objnum, WarpDirection::WARP_OUT);
 			break;
 		case WT_SWEEPER:
-			shipp->warpout_effect = new WE_Homeworld(objnum, WarpDirection::WARP_OUT);
+			shipp->warpout_effect = std::make_unique<WE_Homeworld>(objnum, WarpDirection::WARP_OUT);
 			break;
 		case WT_HYPERSPACE:
-			shipp->warpout_effect = new WE_Hyperspace(objnum, WarpDirection::WARP_OUT);
+			shipp->warpout_effect = std::make_unique<WE_Hyperspace>(objnum, WarpDirection::WARP_OUT);
 			break;
 		default:
-			shipp->warpout_effect = new WarpEffect();
+			shipp->warpout_effect = std::make_unique<WarpEffect>();
 	}
 }
 

--- a/code/weapon/beam.cpp
+++ b/code/weapon/beam.cpp
@@ -3216,9 +3216,9 @@ int beam_collide_ship(obj_pair *pair)
 		WarpEffect* warp_effect = nullptr;
 
 		if (shipp->flags[Ship::Ship_Flags::Depart_warp] && shipp->warpout_effect != nullptr)
-			warp_effect = shipp->warpout_effect;
+			warp_effect = shipp->warpout_effect.get();
 		else if (shipp->flags[Ship::Ship_Flags::Arriving_stage_2] && shipp->warpin_effect != nullptr)
-			warp_effect = shipp->warpin_effect;
+			warp_effect = shipp->warpin_effect.get();
 
 
 		bool hull_no_collide, shield_no_collide;

--- a/fred2/CMakeLists.txt
+++ b/fred2/CMakeLists.txt
@@ -105,6 +105,8 @@ set(FRED2_SOURCES
 	propdlg.h
 	reinforcementeditordlg.cpp
 	reinforcementeditordlg.h
+	reorderdlg.cpp
+	reorderdlg.h
 	resource.h
 	restrictpaths.cpp
 	restrictpaths.h

--- a/fred2/fred.rc
+++ b/fred2/fred.rc
@@ -412,6 +412,7 @@ BEGIN
     BEGIN
         MENUITEM "&Voice Acting Manager",       ID_EDITORS_VOICE
         MENUITEM "Set Global Ship Flags",       33073
+        MENUITEM "Reorder Ships and Wings",     ID_REORDER
         MENUITEM "Calculate Relative Coordinates", 33030
         MENUITEM "Music Player",                ID_MUSIC_PLAYER
         MENUITEM "Mission Statistics\tCtrl+Shift+D", 33067
@@ -2046,6 +2047,19 @@ BEGIN
     EDITTEXT        IDC_ORIENTATION_H,255,81,49,14,ES_READONLY
 END
 
+IDD_REORDER DIALOG 0, 0, 185, 191
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Reorder Ships and Wings"
+FONT 8, "MS Sans Serif"
+BEGIN
+    COMBOBOX        IDC_REORDER_TYPE,7,7,98,114,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LISTBOX         IDC_REORDER_LIST,7,25,98,159,LBS_NOINTEGRALHEIGHT | WS_VSCROLL | WS_TABSTOP
+    PUSHBUTTON      "Move to top",IDC_REORDER_MOVE_TO_TOP,112,25,66,14
+    PUSHBUTTON      "Move up",IDC_REORDER_MOVE_UP,112,43,66,14
+    PUSHBUTTON      "Move down",IDC_REORDER_MOVE_DOWN,112,61,66,14
+    PUSHBUTTON      "Move to bottom",IDC_REORDER_MOVE_TO_BOTTOM,112,79,66,14
+END
+
 IDD_SHIELD_SYS DIALOG 0, 0, 192, 106
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "Shield System Editor"
@@ -2945,6 +2959,14 @@ BEGIN
         BOTTOMMARGIN, 87
     END
 
+    IDD_REORDER, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 178
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 184
+    END
+
     IDD_SHIELD_SYS, DIALOG
     BEGIN
         LEFTMARGIN, 7
@@ -3815,6 +3837,7 @@ END
 STRINGTABLE
 BEGIN
     ID_CALC_RELATIVE_COORDS "Calculate orientation and distance relative to an origin object"
+    ID_REORDER              "Change the order in which ships and wings are stored in the mission"
     ID_EDITORS_ADJUST_GRID  "Adjust the orientation and level of the grid"
     ID_EDITORS_SHIELD_SYS   "Editor for availability of shield system for ships"
     ID_ALIGN_OBJ            "Align object (or camera if no objects are marked) X/Y/Z axes with the global axes that are closest"

--- a/fred2/fredview.cpp
+++ b/fred2/fredview.cpp
@@ -62,6 +62,7 @@
 #include "sound/audiostr.h"
 #include "mission/missiongrid.h"
 #include "calcrelativecoordsdlg.h"
+#include "reorderdlg.h"
 #include "musicplayerdlg.h"
 #include "volumetricsdlg.h"
 #include "customdatadlg.h"
@@ -342,6 +343,7 @@ BEGIN_MESSAGE_MAP(CFREDView, CView)
 	ON_UPDATE_COMMAND_UI(ID_LOOKAT_OBJ, OnUpdateLookatObj)
 	ON_COMMAND(ID_EDITORS_ADJUST_GRID, OnEditorsAdjustGrid)
 	ON_COMMAND(ID_CALC_RELATIVE_COORDS, OnCalcRelativeCoords)
+	ON_COMMAND(ID_REORDER, OnReorder)
 	ON_COMMAND(ID_MUSIC_PLAYER, OnMusicPlayer)
 	ON_COMMAND(ID_EDITORS_SHIELD_SYS, OnEditorsShieldSys)
 	ON_COMMAND(ID_LEVEL_OBJ, OnLevelObj)
@@ -4476,6 +4478,13 @@ void CFREDView::OnEditorsAdjustGrid()
 void CFREDView::OnCalcRelativeCoords()
 {
 	calc_relative_coords_dlg dlg;
+
+	dlg.DoModal();
+}
+
+void CFREDView::OnReorder()
+{
+	reorder_dlg dlg;
 
 	dlg.DoModal();
 }

--- a/fred2/fredview.h
+++ b/fred2/fredview.h
@@ -301,6 +301,7 @@ protected:
 	afx_msg void OnUpdateLookatObj(CCmdUI* pCmdUI);
 	afx_msg void OnEditorsAdjustGrid();
 	afx_msg void OnCalcRelativeCoords();
+	afx_msg void OnReorder();
 	afx_msg void OnMusicPlayer();
 	afx_msg void OnEditorsShieldSys();
 	afx_msg void OnLevelObj();

--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -2617,29 +2617,6 @@ int wing_is_player_wing(int wing)
 }
 
 // Goober5000
-// This must be done when either the wing name or the custom name is changed.
-// (It's also duplicated in FS2, in post_process_mission, for setting the indexes at mission load.)
-void update_custom_wing_indexes()
-{
-	int i;
-
-	for (i = 0; i < MAX_STARTING_WINGS; i++)
-	{
-		Starting_wings[i] = wing_name_lookup(Starting_wing_names[i], 1);
-	}
-
-	for (i = 0; i < MAX_SQUADRON_WINGS; i++)
-	{
-		Squadron_wings[i] = wing_name_lookup(Squadron_wing_names[i], 1);
-	}
-
-	for (i = 0; i < MAX_TVT_WINGS; i++)
-	{
-		TVT_wings[i] = wing_name_lookup(TVT_wing_names[i], 1);
-	}
-}
-
-// Goober5000
 void update_texture_replacements(const char *old_name, const char *new_name)
 {
 	for (SCP_vector<texture_replace>::iterator ii = Fred_texture_replacements.begin(); ii != Fred_texture_replacements.end(); ++ii)

--- a/fred2/management.h
+++ b/fred2/management.h
@@ -131,7 +131,6 @@ extern void management_add_ships_to_combo(CComboBox* box, int flags);
 
 // Goober5000
 extern int wing_is_player_wing(int wing);
-extern void update_custom_wing_indexes();
 extern void update_texture_replacements(const char* old_name, const char* new_name);
 
 // Load a button bitmap, remapping its background colors to system colors as needed.

--- a/fred2/reorderdlg.cpp
+++ b/fred2/reorderdlg.cpp
@@ -1,0 +1,176 @@
+// reorderdlg.cpp : implementation file
+//
+
+#include "stdafx.h"
+#include "FRED.h"
+#include "freddoc.h"
+#include "management.h"
+#include "reorderdlg.h"
+
+#include "missioneditor/common.h"
+#include "ship/ship.h"
+
+#ifdef _DEBUG
+#undef THIS_FILE
+static char THIS_FILE[] = __FILE__;
+#endif
+
+reorder_dlg::reorder_dlg(CWnd *pParent /*=nullptr*/)
+	: CDialog(reorder_dlg::IDD, pParent)
+{
+	//{{AFX_DATA_INIT(reorder_dlg)
+	//}}AFX_DATA_INIT
+}
+
+void reorder_dlg::DoDataExchange(CDataExchange *pDX)
+{
+	CDialog::DoDataExchange(pDX);
+	//{{AFX_DATA_MAP(reorder_dlg)
+	DDX_Control(pDX, IDC_REORDER_TYPE, m_type_combo);
+	DDX_Control(pDX, IDC_REORDER_LIST, m_list);
+	//}}AFX_DATA_MAP
+}
+
+BEGIN_MESSAGE_MAP(reorder_dlg, CDialog)
+	//{{AFX_MSG_MAP(reorder_dlg)
+	ON_CBN_SELCHANGE(IDC_REORDER_TYPE, OnSelchangeReorderType)
+	ON_LBN_SELCHANGE(IDC_REORDER_LIST, OnSelchangeReorderList)
+	ON_BN_CLICKED(IDC_REORDER_MOVE_TO_TOP, OnMoveToTop)
+	ON_BN_CLICKED(IDC_REORDER_MOVE_UP, OnMoveUp)
+	ON_BN_CLICKED(IDC_REORDER_MOVE_DOWN, OnMoveDown)
+	ON_BN_CLICKED(IDC_REORDER_MOVE_TO_BOTTOM, OnMoveToBottom)
+	//}}AFX_MSG_MAP
+END_MESSAGE_MAP()
+
+BOOL reorder_dlg::OnInitDialog()
+{
+	CDialog::OnInitDialog();
+
+	m_type_combo.AddString("Ships");
+	m_type_combo.AddString("Wings");
+	m_type_combo.SetCurSel(0);
+
+	populate_list();
+	update_buttons();
+
+	return TRUE;
+}
+
+bool reorder_dlg::ships_selected() const
+{
+	return m_type_combo.GetCurSel() == 0;
+}
+
+void reorder_dlg::populate_list()
+{
+	m_list.ResetContent();
+	m_slots.clear();
+
+	if (ships_selected())
+	{
+		for (int i = 0; i < MAX_SHIPS; ++i)
+		{
+			if (Ships[i].objnum >= 0)
+			{
+				m_list.AddString(Ships[i].ship_name);
+				m_slots.push_back(i);
+			}
+		}
+	}
+	else
+	{
+		for (int i = 0; i < MAX_WINGS; ++i)
+		{
+			if (Wings[i].wave_count > 0)
+			{
+				m_list.AddString(Wings[i].name);
+				m_slots.push_back(i);
+			}
+		}
+	}
+}
+
+void reorder_dlg::update_buttons()
+{
+	int pos = m_list.GetCurSel();
+	int count = (int)m_slots.size();
+	bool can_move_up = (pos > 0);
+	bool can_move_down = (pos >= 0 && pos < count - 1);
+
+	GetDlgItem(IDC_REORDER_MOVE_TO_TOP)->EnableWindow(can_move_up);
+	GetDlgItem(IDC_REORDER_MOVE_UP)->EnableWindow(can_move_up);
+	GetDlgItem(IDC_REORDER_MOVE_DOWN)->EnableWindow(can_move_down);
+	GetDlgItem(IDC_REORDER_MOVE_TO_BOTTOM)->EnableWindow(can_move_down);
+}
+
+void reorder_dlg::move_selected(bool up, bool all_the_way)
+{
+	int pos = m_list.GetCurSel();
+	int count = (int)m_slots.size();
+	if (pos < 0 || pos >= count)
+		return;
+
+	int target;
+	if (up)
+		target = all_the_way ? 0 : pos - 1;
+	else
+		target = all_the_way ? count - 1 : pos + 1;
+
+	if (target < 0 || target >= count || target == pos)
+		return;
+
+	// Rotate the item to the target position, which preserves the relative
+	// order of everything else in the list.
+	if (ships_selected())
+	{
+		FredShipSlotConfig cfg;
+		cfg.fred_alt_names = Fred_alt_names;
+		cfg.fred_callsigns = Fred_callsigns;
+		cfg.cur_ship = &cur_ship;
+		rotate_ship_slots(m_slots, pos, target, cfg);
+	}
+	else
+	{
+		FredWingSlotConfig cfg;
+		cfg.wing_objects = wing_objects;
+		cfg.cur_wing = &cur_wing;
+		rotate_wing_slots(m_slots, pos, target, cfg);
+	}
+
+	set_modified();
+
+	populate_list();
+	m_list.SetCurSel(target);
+	update_buttons();
+}
+
+void reorder_dlg::OnSelchangeReorderType()
+{
+	populate_list();
+	update_buttons();
+}
+
+void reorder_dlg::OnSelchangeReorderList()
+{
+	update_buttons();
+}
+
+void reorder_dlg::OnMoveToTop()
+{
+	move_selected(true, true);
+}
+
+void reorder_dlg::OnMoveUp()
+{
+	move_selected(true, false);
+}
+
+void reorder_dlg::OnMoveDown()
+{
+	move_selected(false, false);
+}
+
+void reorder_dlg::OnMoveToBottom()
+{
+	move_selected(false, true);
+}

--- a/fred2/reorderdlg.h
+++ b/fred2/reorderdlg.h
@@ -1,0 +1,40 @@
+// reorderdlg.h : header file
+
+#ifndef _REORDERDLG_H
+#define _REORDERDLG_H
+
+class reorder_dlg : public CDialog
+{
+public:
+	reorder_dlg(CWnd *pParent = nullptr);
+
+	// Dialog Data
+	//{{AFX_DATA(reorder_dlg)
+	enum { IDD = IDD_REORDER };
+	CComboBox	m_type_combo;
+	CListBox	m_list;
+	//}}AFX_DATA
+
+protected:
+	virtual void DoDataExchange(CDataExchange *pDX);    // DDX/DDV support
+
+	//{{AFX_MSG(reorder_dlg)
+	virtual BOOL OnInitDialog();
+	afx_msg void OnSelchangeReorderType();
+	afx_msg void OnSelchangeReorderList();
+	afx_msg void OnMoveToTop();
+	afx_msg void OnMoveUp();
+	afx_msg void OnMoveDown();
+	afx_msg void OnMoveToBottom();
+	//}}AFX_MSG
+	DECLARE_MESSAGE_MAP()
+
+	bool ships_selected() const;
+	void populate_list();
+	void update_buttons();
+	void move_selected(bool up, bool all_the_way);
+
+	// occupied Ships[] or Wings[] slot indexes, in list order
+	SCP_vector<int> m_slots;
+};
+#endif	// _REORDERDLG_H

--- a/fred2/resource.h
+++ b/fred2/resource.h
@@ -1491,14 +1491,6 @@
 #define ID_EDITORS_WAYPOINT             32979
 #define ID_VIEW_OUTLINES                32980
 #define ID_NEW_SHIP_TYPE                32981
-#define ID_NEW_PROP_TYPE                33104
-#define ID_STATIC_SHIP_LABEL            33105
-#define ID_STATIC_PROP_LABEL            33106
-#define ID_OUTLINE_LOD_0                33107
-#define ID_OUTLINE_LOD_1                33108
-#define ID_OUTLINE_LOD_2                33109
-#define ID_OUTLINE_LOD_3                33110
-#define ID_OUTLINE_LOD_4                33111
 #define ID_VIEW_OUTLINES_ON_SELECTED    32982
 #define ID_SHOW_STARFIELD               32983
 #define ID_ASTEROID_EDITOR              32984
@@ -1613,6 +1605,15 @@
 #define ID_MISC_POINTUSINGUVEC          33101
 #define ID_MUSIC_PLAYER                 33102
 #define ID_EDITORS_VOLUMETRICS          33103
+#define ID_NEW_PROP_TYPE                33104
+#define ID_STATIC_SHIP_LABEL            33105
+#define ID_STATIC_PROP_LABEL            33106
+#define ID_OUTLINE_LOD_0                33107
+#define ID_OUTLINE_LOD_1                33108
+#define ID_OUTLINE_LOD_2                33109
+#define ID_OUTLINE_LOD_3                33110
+#define ID_OUTLINE_LOD_4                33111
+#define ID_REORDER                      33112
 #define ID_INDICATOR_MODE               59142
 #define ID_INDICATOR_LEFT               59143
 #define ID_INDICATOR_RIGHT              59144
@@ -1626,7 +1627,7 @@
 #define _APS_3D_CONTROLS                     1
 #define _APS_NEXT_RESOURCE_VALUE        340
 #define _APS_NEXT_CONTROL_VALUE         1747
-#define _APS_NEXT_COMMAND_VALUE         33112
+#define _APS_NEXT_COMMAND_VALUE         33113
 #define _APS_NEXT_SYMED_VALUE           105
 #endif
 #endif

--- a/qtfred/src/mission/Editor.h
+++ b/qtfred/src/mission/Editor.h
@@ -188,11 +188,6 @@ class Editor : public QObject {
 
 	subsys_to_render Render_subsys;
 
-	// Goober5000
-	// This must be done when either the wing name or the custom name is changed.
-	// (It's also duplicated in FS2, in post_process_mission, for setting the indexes at mission load.)
-	static void update_custom_wing_indexes();
-
 	void ai_update_goal_references(sexp_ref_type type, const char* old_name, const char* new_name);
 
 	// Goober5000

--- a/qtfred/src/mission/EditorWing.cpp
+++ b/qtfred/src/mission/EditorWing.cpp
@@ -5,6 +5,7 @@
 
 #include <globalincs/linklist.h>
 #include <globalincs/utility.h>
+#include <missioneditor/common.h>
 #include <ship/ship.h>
 
 namespace {
@@ -68,22 +69,6 @@ void Editor::set_cur_wing(int wing)
 			Assert(cur_wing == Ships[Objects[cur_object_index].instance].wingnum);*/
 	updateAllViewports();
 	// TODO: Add notification for a changed selection
-}
-void Editor::update_custom_wing_indexes()
-{
-	int i;
-
-	for (i = 0; i < MAX_STARTING_WINGS; i++) {
-		Starting_wings[i] = wing_name_lookup(Starting_wing_names[i], 1);
-	}
-
-	for (i = 0; i < MAX_SQUADRON_WINGS; i++) {
-		Squadron_wings[i] = wing_name_lookup(Squadron_wing_names[i], 1);
-	}
-
-	for (i = 0; i < MAX_TVT_WINGS; i++) {
-		TVT_wings[i] = wing_name_lookup(TVT_wing_names[i], 1);
-	}
 }
 
 int Editor::create_wing()

--- a/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionSpecDialogModel.cpp
@@ -12,6 +12,7 @@
 
 #include "cfile/cfile.h"
 #include "localization/localize.h"
+#include "missioneditor/common.h"
 #include "mission/missionmessage.h"
 #include "mission/mission_flags.h"
 #include "scripting/global_hooks.h"
@@ -227,7 +228,7 @@ bool MissionSpecDialogModel::apply() {
 		strcpy_s(TVT_wing_names[i], _m_custom_tvt_wings[i].c_str());
 	}
 
-	Editor::update_custom_wing_indexes();
+	update_custom_wing_indexes();
 
 	// scripts may rebuild LuaEnums when custom data/strings change.
 	if (scripting::hooks::FredOnMissionSpecsSave->isActive()) {


### PR DESCRIPTION
Accessible from the Tools menu, this dialog lists all ships or all wings (selectable via a drop-down) and provides Move to top/up/down/bottom buttons.  Moves are applied immediately via the slot reassignment utilities in missioneditor/common.h, using adjacent swaps so the relative order of other entries is preserved.

(Fixes ship move operations in the process, as moving was broken in several ways.  This will also be beneficial for future conversion of ships to use SCP_vector.)

Currently FRED-only but could be extended to QtFRED easily.

~~In draft as it depends on #7578.~~