### PR TITLE
fix copy-paste error

### DIFF
--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -514,7 +514,7 @@ int event_editor::query_modified()
 			return 1;
 		if (safe_stricmp(local.avi_info.name, ref.avi_info.name) != 0)
 			return 1;
-		if (safe_stricmp(local.wave_info.name, ref.avi_info.name) != 0)
+		if (safe_stricmp(local.wave_info.name, ref.wave_info.name) != 0)
 			return 1;
 	}
 


### PR DESCRIPTION
Due to a copy-paste error, the event editor would always be marked modified.  Fix the comparison.

This bug originally appeared in QtFRED also, but no longer does.

Follow-up to #6529.