### PR TITLE
remove empty destructors so waypoints can be moved

### DIFF
--- a/code/object/waypoint.cpp
+++ b/code/object/waypoint.cpp
@@ -38,11 +38,6 @@ waypoint::waypoint(const vec3d *position)
 	this->m_objnum = -1;
 }
 
-waypoint::~waypoint()
-{
-	// nothing to do
-}
-
 const vec3d *waypoint::get_pos() const
 {
 	if (m_objnum >= 0)
@@ -116,11 +111,6 @@ waypoint_list::waypoint_list(const char *name)
 	this->m_no_draw_lines = false;
 	this->m_has_custom_color = false;
 	this->m_color_r = this->m_color_g = this->m_color_b = 255;
-}
-
-waypoint_list::~waypoint_list()
-{
-	// nothing to do
 }
 
 const char *waypoint_list::get_name() const

--- a/code/object/waypoint.h
+++ b/code/object/waypoint.h
@@ -12,7 +12,6 @@ class waypoint
 	public:
 		waypoint();
 		waypoint(const vec3d *pos);
-		~waypoint();
 
 		// accessors
 		const vec3d *get_pos() const;
@@ -37,7 +36,6 @@ class waypoint_list
 	public:
 		waypoint_list();
 		waypoint_list(const char *name);
-		~waypoint_list();
 
 		// accessors
 		const char *get_name() const;


### PR DESCRIPTION
A user-declared destructor, even an empty one, suppresses the implicit move operations, so waypoint and waypoint_list were silently copy-only: every Waypoint_lists erase, insert, and reallocation deep-copied entire lists, and inserting a waypoint mid-path copied every shifted waypoint. Removing the destructors restores the implicit moves (correct and noexcept, since the members are vec3d/int and SCP_vector/SCP_string), turning those shifts into pointer steals.  The implicit deep copies remain available and unchanged.  Waypoint identity is index-encoded in Objects[].instance and renumbered on insert/erase, so relocation semantics are unaffected.