### PR TITLE
use std::exchange in move ctors/assignment operators

### DIFF
--- a/code/io/cursor.cpp
+++ b/code/io/cursor.cpp
@@ -78,14 +78,10 @@ namespace io
 
 			std::swap(this->mAnimationFrames, other.mAnimationFrames);
 			
-			this->mBitmapHandle = other.mBitmapHandle;
-			this->mBeginTimeStamp = other.mBeginTimeStamp;
-			this->mLastFrame = other.mLastFrame;
-			
-			other.mBitmapHandle = -1;
-			other.mBeginTimeStamp = UI_TIMESTAMP::invalid();
-			other.mLastFrame = static_cast<size_t>(-1);
-			
+			this->mBitmapHandle = std::exchange(other.mBitmapHandle, -1);
+			this->mBeginTimeStamp = std::exchange(other.mBeginTimeStamp, UI_TIMESTAMP::invalid());
+			this->mLastFrame = std::exchange(other.mLastFrame, static_cast<size_t>(-1));
+
 			return *this;
 		}
 

--- a/code/jumpnode/jumpnode.cpp
+++ b/code/jumpnode/jumpnode.cpp
@@ -71,15 +71,8 @@ CJumpNode::CJumpNode(const vec3d* position)
 }
 
 CJumpNode::CJumpNode(CJumpNode&& other) noexcept
-	: m_radius(other.m_radius), m_modelnum(other.m_modelnum), m_objnum(other.m_objnum), m_polymodel_instance_num(other.m_polymodel_instance_num), m_flags(other.m_flags), m_fred_layer(std::move(other.m_fred_layer))
+	: m_radius(std::exchange(other.m_radius, 0.0f)), m_modelnum(std::exchange(other.m_modelnum, -1)), m_objnum(std::exchange(other.m_objnum, -1)), m_polymodel_instance_num(std::exchange(other.m_polymodel_instance_num, -1)), m_flags(std::exchange(other.m_flags, 0)), m_fred_layer(std::exchange(other.m_fred_layer, "Default"))
 {
-	other.m_radius = 0.0f;
-	other.m_modelnum = -1;
-	other.m_objnum = -1;
-	other.m_polymodel_instance_num = -1;
-	other.m_flags = 0;
-	other.m_fred_layer = "Default";
-
 	m_display_color = other.m_display_color;
 	m_pos = other.m_pos;
 
@@ -91,19 +84,12 @@ CJumpNode& CJumpNode::operator=(CJumpNode&& other) noexcept
 {
 	if (this != &other)
 	{
-		m_radius = other.m_radius;
-		m_modelnum = other.m_modelnum;
-		m_objnum = other.m_objnum;
-		m_flags = other.m_flags;
-		m_polymodel_instance_num = other.m_polymodel_instance_num;
-		m_fred_layer = std::move(other.m_fred_layer);
-
-		other.m_radius = 0.0f;
-		other.m_modelnum = -1;
-		other.m_objnum = -1;
-		other.m_flags = 0;
-		other.m_polymodel_instance_num = -1;
-		other.m_fred_layer = "Default";
+		m_radius = std::exchange(other.m_radius, 0.0f);
+		m_modelnum = std::exchange(other.m_modelnum, -1);
+		m_objnum = std::exchange(other.m_objnum, -1);
+		m_flags = std::exchange(other.m_flags, 0);
+		m_polymodel_instance_num = std::exchange(other.m_polymodel_instance_num, -1);
+		m_fred_layer = std::exchange(other.m_fred_layer, "Default");
 
 		m_display_color = other.m_display_color;
 		m_pos = other.m_pos;

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -15,6 +15,7 @@
 #include "globalincs/globals.h" // for NAME_LENGTH
 #include "globalincs/pstypes.h"
 #include <array>
+#include <utility>
  
 #include "actions/Program.h"
 #include "gamesnd/gamesnd.h"
@@ -566,12 +567,9 @@ struct w_bank
 	w_bank& operator=(w_bank&& other) {
 		this->~w_bank();
 		num_slots = other.num_slots;
-		pnt = other.pnt;
-		norm = other.norm;
-		external_model_angle_offset = other.external_model_angle_offset;
-		other.pnt = nullptr;
-		other.norm = nullptr;
-		other.external_model_angle_offset = nullptr;
+		pnt = std::exchange(other.pnt, nullptr);
+		norm = std::exchange(other.norm, nullptr);
+		external_model_angle_offset = std::exchange(other.external_model_angle_offset, nullptr);
 		return *this;
 	}
 	w_bank(const w_bank& other) = default;

--- a/code/scripting/api/objs/player.cpp
+++ b/code/scripting/api/objs/player.cpp
@@ -40,11 +40,8 @@ player_h::~player_h()
 		delete _plr;
 }
 player_h::player_h(player_h&& other) noexcept
-	: _owned(other._owned), _plr(other._plr)
-{
-	other._owned = false;
-	other._plr = nullptr;
-}
+	: _owned(std::exchange(other._owned, false)), _plr(std::exchange(other._plr, nullptr))
+{}
 player_h& player_h::operator=(player_h&& other) noexcept
 {
 	if (this != &other)
@@ -52,11 +49,8 @@ player_h& player_h::operator=(player_h&& other) noexcept
 		if (_owned)
 			delete _plr;
 
-		_owned = other._owned;
-		_plr = other._plr;
-
-		other._owned = false;
-		other._plr = nullptr;
+		_owned = std::exchange(other._owned, false);
+		_plr = std::exchange(other._plr, nullptr);
 	}
 
 	return *this;


### PR DESCRIPTION
Replaces the copy-then-reset idiom with std::exchange in five steal-and-reset move constructors and assignment operators.