### PR TITLE
Add safeguards for invalidated model instances

### DIFF
--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -3195,8 +3195,12 @@ void model_render_set_wireframe_color(const color* clr)
 
 void modelinstance_replace_active_texture(polymodel_instance* pmi, const char* old_name, const char* new_name)
 {
-	Assert(pmi != nullptr);
+	if (pmi == nullptr)
+		return;
+
 	polymodel* pm = model_get(pmi->model_num);
+	if (pm == nullptr)
+		return;
 
 	int final_index = -1;
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8986,6 +8986,7 @@ void ship_delete( object * obj )
 	ct_ship_delete(shipp);
 	
 	model_delete_instance(shipp->model_instance_num);
+	shipp->model_instance_num = -1;
 
 	// free up any weapon model instances
 	for (int i = 0; i < shipp->weapons.num_primary_banks; ++i)

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -19698,6 +19698,9 @@ void ship_page_out_textures(int ship_index, bool release)
 
 void ship_replace_active_texture(int ship_index, const char* old_name, const char* new_name)
 {
+	if (Ships[ship_index].model_instance_num < 0)
+		return;
+	
 	polymodel_instance* pmi = model_get_instance(Ships[ship_index].model_instance_num);
 	modelinstance_replace_active_texture(pmi, old_name, new_name);
 }


### PR DESCRIPTION
This fixes the crash for SF:EH that happens sometimes on mission exit.

Also, this is notably just a bandaid fix.
It'll stop the crash for now, but there's an underlying issue that needs resolving.
The Ship_registry will contain valid entries for ships, the objects of which have been deleted. This causes all sorts of trouble, and there's a few ways to mitigate this: Make Ship_registry accesses query for validity of the ships still inside, or make mission deallocation / obj_delete_all / ship_cleanup hard-nuke the entire registry. However, both of these are fairly deep-rooted changes, so they're not great for RCs, and I'd rather just go with the bandaid for now, and properly fix this early in the next nightly phase.