### PR TITLE
more robust handling of modelinstance teardown

### DIFF
--- a/code/asteroid/asteroid.cpp
+++ b/code/asteroid/asteroid.cpp
@@ -1083,8 +1083,10 @@ void asteroid_delete( object * obj )
 
 	asp = &Asteroids[num];
 
-	if (asp->model_instance_num >= 0)
+	if (asp->model_instance_num >= 0) {
 		model_delete_instance(asp->model_instance_num);
+		asp->model_instance_num = -1;
+	}
 
 	if (asp->target_objnum >= 0) {
 		for (asteroid_target& target : Asteroid_targets) {

--- a/code/debris/debris.cpp
+++ b/code/debris/debris.cpp
@@ -248,6 +248,7 @@ void debris_delete( object * obj )
 
 	if (db->model_instance_num >= 0) {
 		model_delete_instance(db->model_instance_num);
+		db->model_instance_num = -1;
 	}
 
 	if ( db->is_hull ) {

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -3196,6 +3196,8 @@ void model_render_set_wireframe_color(const color* clr)
 void modelinstance_replace_active_texture(polymodel_instance* pmi, const char* old_name, const char* new_name)
 {
 	Assert(pmi != nullptr);
+	if (pmi == nullptr)
+		return;
 	polymodel* pm = model_get(pmi->model_num);
 
 	int final_index = -1;

--- a/code/prop/prop.cpp
+++ b/code/prop/prop.cpp
@@ -592,6 +592,7 @@ void prop_delete(object* obj)
 	propp.glow_point_bank_active.clear();
 
 	model_delete_instance(propp.model_instance_num);
+	propp.model_instance_num = -1;
 
 	// Leave the slot empty for the duration of the scene
 	// The Props array will be compacted at the end of the level

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -8986,12 +8986,16 @@ void ship_delete( object * obj )
 	ct_ship_delete(shipp);
 	
 	model_delete_instance(shipp->model_instance_num);
+	shipp->model_instance_num = -1;
 
 	// free up any weapon model instances
 	for (int i = 0; i < shipp->weapons.num_primary_banks; ++i)
 	{
 		if (shipp->weapons.primary_bank_external_model_instance[i] >= 0)
+		{
 			model_delete_instance(shipp->weapons.primary_bank_external_model_instance[i]);
+			shipp->weapons.primary_bank_external_model_instance[i] = -1;
+		}
 	}
 }
 

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -5336,8 +5336,10 @@ void weapon_delete(object *obj)
 	if (wp->hud_in_flight_snd_sig.isValid() && snd_is_playing(wp->hud_in_flight_snd_sig))
 		snd_stop(wp->hud_in_flight_snd_sig);
 
-	if (wp->model_instance_num >= 0)
+	if (wp->model_instance_num >= 0) {
 		model_delete_instance(wp->model_instance_num);
+		wp->model_instance_num = -1;
+	}
 
 	if (wp->cmeasure_ignore_list != nullptr) {
 		delete wp->cmeasure_ignore_list;


### PR DESCRIPTION
Set model instances to -1 when objects are deleted, and guard against null model instances in `modelinstance_replace_active_texture`.  This may fix a crash in Event Horizon.