### PR TITLE
Fix center reticle firepoints swaying

### DIFF
--- a/code/hud/hudreticle.cpp
+++ b/code/hud/hudreticle.cpp
@@ -414,6 +414,12 @@ void HudGaugeReticle::getFirepointStatus() {
 				eye eyepoint = pm->view_positions[shipp->current_viewpoint];
 				vec2d ep = { eyepoint.pnt.xyz.x, eyepoint.pnt.xyz.y };
 
+				// Center reticle does not move if player is looking around, so ensure that firepoints also do not move.
+				// Use object_get_eye to get the needed eye values (do not use Eye_matrix b/c firepoints will sway if looking).
+				vec3d unused_eye_pos;
+				matrix eye_orient;
+				object_get_eye(&unused_eye_pos, &eye_orient, &Objects[Player->objnum], false, false, true);
+
 				for (int i = 0; i < pm->n_guns; i++) {
 					int bankactive = 0;
 					ship_weapon *swp = &shipp->weapons;
@@ -497,11 +503,6 @@ void HudGaugeReticle::getFirepointStatus() {
 						}
 
 						vec3d fpfromeye;
-
-						matrix eye_orient, player_transpose;
-
-						vm_copy_transpose(&player_transpose, &Objects[Player->objnum].orient);
-						vm_matrix_x_matrix(&eye_orient, &player_transpose, &Eye_matrix);
 						vm_vec_rotate(&fpfromeye, &pm->gun_banks[i].pnt[j], &eye_orient);
 
 						firepoint tmp = { { fpfromeye.xyz.x - ep.x, ep.y - fpfromeye.xyz.y }, fpactive };


### PR DESCRIPTION
Center reticle does not move if player is looking around, but there is a bug where the drawn firepoints of the center reticle do impromperly sway when the player is looking around. This is b/c the live global Eye_matrix, which has the free-look rotation baked into it by `object_get_eye()` then `compute_slew_matrix(eye_orient, &Viewer_slew_angles)`

Thus, do note use `Eye_matrix` b/c firepoints will sway if looking around, instead just use 'object_get_eye' with the properly set values.

Tested and fire-points work as normal but also fix the issue when looking around in free-look or TrackIR.