### PR TITLE
Fix flickering turrets in techroom

### DIFF
--- a/code/menuui/techmenu.cpp
+++ b/code/menuui/techmenu.cpp
@@ -600,8 +600,11 @@ void techroom_ships_render(float frametime)
 	render_info.set_detail_level_lock(0);
 
 	int model_instance = -1;
-	model_get_cached_ui_render_instance(Techroom_modelnum, &model_instance);
-	if (Tab == SHIPS_DATA_TAB) {
+	auto cache_result = model_get_cached_ui_render_instance(Techroom_modelnum, &model_instance);
+	// Only set up the instance when it was freshly created; the cached instance persists across
+	// frames, so re-running this every frame would re-apply initial animations on top of the
+	// already-animated pose and make animated submodels (e.g. turrets) flip/jitter.
+	if (Tab == SHIPS_DATA_TAB && cache_result == TriStateBool::TRUE_) {
 		model_set_up_techroom_instance(&Ship_info[Cur_entry_index], model_instance);
 	}
 

--- a/code/missionui/missionscreencommon.cpp
+++ b/code/missionui/missionscreencommon.cpp
@@ -1665,8 +1665,9 @@ void draw_model_icon(int model_id, uint64_t flags, int x, int y, int w, int h, s
 	Glowpoint_override = true;
 	model_clear_instance(model_id);
 	int model_instance = -1;
-	model_get_cached_ui_render_instance(model_id, &model_instance);
-	if (sip != nullptr) {
+	auto cache_result = model_get_cached_ui_render_instance(model_id, &model_instance);
+	// Only set up the instance when it was freshly created; the cached instance persists across frames.
+	if (sip != nullptr && cache_result == TriStateBool::TRUE_) {
 		model_set_up_techroom_instance(sip, model_instance);
 	}
 
@@ -1688,8 +1689,9 @@ void draw_model_rotating(model_render_params *render_info, int ship_class, int m
 		return;
 
 	int model_instance = -1;
-	model_get_cached_ui_render_instance(model_id, &model_instance);
-	if (!(flags & MR_IS_MISSILE) && SCP_vector_inbounds(Ship_info, ship_class)) {
+	auto cache_result = model_get_cached_ui_render_instance(model_id, &model_instance);
+	// Only set up the instance when it was freshly created; the cached instance persists across frames.
+	if (!(flags & MR_IS_MISSILE) && SCP_vector_inbounds(Ship_info, ship_class) && cache_result == TriStateBool::TRUE_) {
 		model_set_up_techroom_instance(&Ship_info[ship_class], model_instance);
 	}
 

--- a/code/missionui/missionweaponchoice.cpp
+++ b/code/missionui/missionweaponchoice.cpp
@@ -828,8 +828,11 @@ void draw_3d_overhead_view(int model_num,
 
 		model_clear_instance(model_num);
 		int model_instance = -1;
-		model_get_cached_ui_render_instance(model_num, &model_instance);
-		model_set_up_techroom_instance(sip, model_instance);
+		auto cache_result = model_get_cached_ui_render_instance(model_num, &model_instance);
+		// Only set up the instance when it was freshly created; the cached instance persists across frames.
+		if (cache_result == TriStateBool::TRUE_) {
+			model_set_up_techroom_instance(sip, model_instance);
+		}
 		polymodel* pm = model_get(model_num);
 
 		if (sip->replacement_textures.size() > 0) {


### PR DESCRIPTION
Turrets with initial animations flip animation angles every frame in the techroom.  The commit returns TriStateBool from model_get_cached_ui_render_instance specifically so callers can run setup only when a new instance is created, but only `render_tech_model` (the Lua path) actually checks it.

Since the instance is cached and persists across frames, every frame re-runs clearShipData + initial-animation start on an already-animated instance, re-applying the initial animations relative to the current (already-animated) pose. This is what seems to produces the per-frame flip/jitter.

This PR caches it to prevent this, and fixes #7526. Tests confirm it works as expected.

Happy to edit or use a different method if folks would prefer!