### PR TITLE
Fix shadow artifacts by employing hardware clamping

### DIFF
--- a/code/def_files/data/effects/main-g.sdr
+++ b/code/def_files/data/effects/main-g.sdr
@@ -163,9 +163,6 @@ out VertexOutput {
 				gl_Position = shadow_proj_matrix[instanceID] * gl_in[vert].gl_Position;
 			#prereplace ENDIF_FLAG //MODEL_SDR_FLAG_TRANSFORM
 
-			if(gl_Position.z < -1.0)
-			gl_Position.z = -1.0;
-
 			vertOut.position = gl_in[vert].gl_Position;
 			vertOut.normal = vertIn[vert].normal;
 			vertOut.texCoord = vertIn[vert].texCoord;

--- a/code/graphics/opengl/gropengltnl.cpp
+++ b/code/graphics/opengl/gropengltnl.cpp
@@ -697,6 +697,8 @@ void gr_opengl_shadow_map_start(matrix4 *shadow_view_matrix, const matrix *light
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
+	glEnable(GL_DEPTH_CLAMP);
+
 	Rendering_to_shadow_map = true;
 	Glowpoint_override_save = Glowpoint_override;
 	Glowpoint_override = true;
@@ -714,6 +716,8 @@ void gr_opengl_shadow_map_end()
 {
 	if(!Rendering_to_shadow_map)
 		return;
+
+	glDisable(GL_DEPTH_CLAMP);
 
 	gr_end_view_matrix();
 	Rendering_to_shadow_map = false;


### PR DESCRIPTION
Some models with long, unbroken faces experience geometry artifacts if their faces get partly clamped and "squished" by the shadow cascades. This can be fixed by using hardware clamping, causing shadows to no longer be wildly incorrect in certain cases and camera angles. Extracts the idea of the last commit f6e65d842be44fbd5e8e87e6863825febb4a7cb5 of #7529 and packages it as a bugfix that can go into the current RC.