### PR TITLE
Fix misbehaviour of Volume Point Towards

### DIFF
--- a/code/particle/ParticleVolume.h
+++ b/code/particle/ParticleVolume.h
@@ -32,11 +32,13 @@ namespace particle {
 			vec3d outpnt = point;
 
 			if (rotOffset.has_value()) {
+				vm_vec_rotate(&outpnt, &outpnt, &orientation);
 				vec3d rot = *rotOffset;
 				vm_rot_point_around_line(&rot, &rot, rotOffsetRot, &vmd_zero_vector, &vmd_z_vector);
 				matrix orientUse;
 				vm_vector_2_matrix(&orientUse, &rot);
 				vm_vec_unrotate(&outpnt, &outpnt, &orientUse);
+				vm_vec_unrotate(&outpnt, &outpnt, &orientation);
 			}
 			if (posOffset.has_value()) {
 				vec3d pos = *posOffset;

--- a/code/particle/volumes/ConeVolume.cpp
+++ b/code/particle/volumes/ConeVolume.cpp
@@ -29,8 +29,8 @@ namespace particle {
 
 		//TODO
 		return pointCompensateForOffsetAndRotOffset(point, orientation,
-					m_modular_curves.get_output(VolumeModularCurveOutput::OFFSET_ROT, curveSource, &m_modular_curve_instance),
-					m_modular_curves.get_output(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, &m_modular_curve_instance));
+			m_modular_curves.get_output_or_default(VolumeModularCurveOutput::OFFSET_ROT, curveSource, 0.f, &m_modular_curve_instance),
+			m_modular_curves.get_output_or_default(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, 0.f, &m_modular_curve_instance));
 	}
 
 	void ConeVolume::parse() {

--- a/code/particle/volumes/ModelSurfaceVolume.cpp
+++ b/code/particle/volumes/ModelSurfaceVolume.cpp
@@ -45,8 +45,8 @@ vec3d ModelSurfaceVolume::sampleRandomPoint(const matrix &orientation, decltype(
 	}
 
 	return pointCompensateForOffsetAndRotOffset(point, orientation,
-				m_modular_curves.get_output(VolumeModularCurveOutput::OFFSET_ROT, curveSource, &m_modular_curve_instance),
-				m_modular_curves.get_output(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, &m_modular_curve_instance));
+		m_modular_curves.get_output_or_default(VolumeModularCurveOutput::OFFSET_ROT, curveSource, 0.f, &m_modular_curve_instance),
+		m_modular_curves.get_output_or_default(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, 0.f, &m_modular_curve_instance));
 }
 
 void ModelSurfaceVolume::parse() {

--- a/code/particle/volumes/PointVolume.cpp
+++ b/code/particle/volumes/PointVolume.cpp
@@ -9,8 +9,8 @@ namespace particle {
 		auto curveSource = std::tuple_cat(source, std::make_tuple(particlesFraction));
 
 		return pointCompensateForOffsetAndRotOffset(ZERO_VECTOR, orientation,
-					m_modular_curves.get_output(VolumeModularCurveOutput::OFFSET_ROT, curveSource, &m_modular_curve_instance),
-					m_modular_curves.get_output(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, &m_modular_curve_instance));
+			m_modular_curves.get_output_or_default(VolumeModularCurveOutput::OFFSET_ROT, curveSource, 0.f, &m_modular_curve_instance),
+			m_modular_curves.get_output_or_default(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, 0.f, &m_modular_curve_instance));
 	}
 
 	void PointVolume::parse() {

--- a/code/particle/volumes/RingVolume.cpp
+++ b/code/particle/volumes/RingVolume.cpp
@@ -13,8 +13,8 @@ namespace particle {
 		vm_vec_random_in_circle(&pos, &vmd_zero_vector, &orientation, m_radius * m_modular_curves.get_output(VolumeModularCurveOutput::RADIUS, curveSource, &m_modular_curve_instance), m_onEdge);
 
 		return pointCompensateForOffsetAndRotOffset(pos, orientation,
-					m_modular_curves.get_output(VolumeModularCurveOutput::OFFSET_ROT, curveSource, &m_modular_curve_instance),
-					m_modular_curves.get_output(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, &m_modular_curve_instance));
+			m_modular_curves.get_output_or_default(VolumeModularCurveOutput::OFFSET_ROT, curveSource, 0.f, &m_modular_curve_instance),
+			m_modular_curves.get_output_or_default(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, 0.f, &m_modular_curve_instance));
 	}
 
 	void RingVolume::parse() {

--- a/code/particle/volumes/SpheroidVolume.cpp
+++ b/code/particle/volumes/SpheroidVolume.cpp
@@ -43,8 +43,8 @@ namespace particle {
 		}
 
 		return pointCompensateForOffsetAndRotOffset(pos, orientation,
-					m_modular_curves.get_output(VolumeModularCurveOutput::OFFSET_ROT, curveSource, &m_modular_curve_instance),
-					m_modular_curves.get_output(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, &m_modular_curve_instance));
+			m_modular_curves.get_output_or_default(VolumeModularCurveOutput::OFFSET_ROT, curveSource, 0.f, &m_modular_curve_instance),
+			m_modular_curves.get_output_or_default(VolumeModularCurveOutput::POINT_TO_ROT, curveSource, 0.f, &m_modular_curve_instance));
 	}
 
 	void SpheroidVolume::parse() {

--- a/code/utils/modular_curves.h
+++ b/code/utils/modular_curves.h
@@ -647,6 +647,13 @@ public:
 		return result;
 	}
 
+	float get_output_or_default(output_enum output, const input_type& input, float default_val, const modular_curves_entry_instance* instance = nullptr) const {
+		if (has_curve(output))
+			return get_output(output, input, instance);
+		else
+			return default_val;
+	}
+
 	void reset() {
 		for (auto& curve_list : curves) {
 			curve_list.clear();


### PR DESCRIPTION
Particle's Volume Point Towards had two dormant issues:
1. it would cause incorrect rotations when not used with a spawner in an ident orientation
2. It would incorrectly rotate the volume by 1 rad if no curves were present
This fixes both