### PR TITLE
Node v24 workflow update

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -51,7 +51,7 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         run: $GITHUB_WORKSPACE/ci/linux/generate_appimage.sh $GITHUB_WORKSPACE/build/install
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-${{ matrix.configuration }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/build/install/*.AppImage
@@ -59,23 +59,23 @@ jobs:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     strategy:
       matrix:
         arch: [x86_64, arm64]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
       - name: Download Release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-Release-${{ matrix.arch }}
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-FastDebug-${{ matrix.arch }}
           path: builds
@@ -106,7 +106,7 @@ jobs:
     name: Windows
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -179,7 +179,7 @@ jobs:
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
           path: ${{ github.workspace }}/build/install/*
@@ -187,24 +187,24 @@ jobs:
     name: Build Windows distribution zip
     needs: build_windows
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     strategy:
       matrix:
         arch: [Win32, x64]
         simd: [SSE2]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
       - name: Download Release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
@@ -249,7 +249,7 @@ jobs:
           # setup-python: 'false'
           # aqtversion: ==1.1.3
           # py7zrversion: '==0.19.*'
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -302,7 +302,7 @@ jobs:
         # Ref: https://github.com/actions/runner-images/issues/2619
         run: gtar -cvzf macos-build-${{ matrix.configuration }}-${{ matrix.arch }}.tgz *.app
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mac-${{ matrix.configuration }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}-${{ matrix.arch }}.tgz
@@ -310,24 +310,24 @@ jobs:
     name: Build Mac distribution zip
     needs: build_mac
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     strategy:
       matrix:
         arch: [x86_64, arm64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mac-Release-${{ matrix.arch }}
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mac-FastDebug-${{ matrix.arch }}
           path: builds

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -27,6 +27,9 @@ jobs:
         name: Checkout
         with:
           submodules: true
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
@@ -69,6 +72,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: '0'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
@@ -110,6 +116,9 @@ jobs:
         name: Checkout
         with:
           submodules: true
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       # - name: Cache Qt
         # id: cache-qt-win
         # uses: actions/cache@v1
@@ -198,6 +207,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: '0'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
@@ -254,6 +266,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Prepare Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
@@ -321,6 +336,9 @@ jobs:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         # checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.
         name: Checkout
         with:
@@ -82,7 +82,7 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         run: $GITHUB_WORKSPACE/ci/linux/generate_appimage.sh $GITHUB_WORKSPACE/build/install
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         # Upload the url file for use with other runners
         # upload-artifact.inputs:
         #   if-no-files-found=warn  What to do if path fails to find any files.
@@ -99,12 +99,12 @@ jobs:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     strategy:
       matrix:
         arch: [x86_64, arm64]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -112,13 +112,13 @@ jobs:
           ref: '${{ github.ref }}'
       - name: Download Release builds
         # Grab the release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-Release-${{ matrix.arch }}
           path: builds
       - name: Download FastDebug builds
         # Grab the debug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-FastDebug-${{ matrix.arch }}
           path: builds
@@ -135,7 +135,7 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Linux
       - name: Upload result package
         # Stash the result to artifact filespace
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.generate_package.outputs.package_name }}
           path: ${{ steps.generate_package.outputs.package_path }}
@@ -157,7 +157,7 @@ jobs:
     name: Windows
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         # Checkout repo
         name: Checkout
         with:
@@ -235,7 +235,7 @@ jobs:
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
           path: ${{ github.workspace }}/build/install/*
@@ -244,7 +244,7 @@ jobs:
     name: Build Windows distribution zip
     needs: build_windows
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     strategy:
       fail-fast: false  # Run the other jobs in the matrix instead of failing them
       matrix:
@@ -252,20 +252,20 @@ jobs:
         simd: [SSE2, AVX]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
 
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
@@ -280,13 +280,13 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Windows
 
       - name: Upload result package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.generate_package.outputs.package_name }}
           path: ${{ steps.generate_package.outputs.package_path }}
 
       - name: Upload debug package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.generate_package.outputs.debug_name }}
           path: ${{ steps.generate_package.outputs.debug_path }}
@@ -324,7 +324,7 @@ jobs:
           # cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
           # setup-python: 'false'
           # aqtversion: ==1.1.3
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -372,7 +372,7 @@ jobs:
         # Ref: https://github.com/actions/runner-images/issues/2619
         run: gtar -cvzf macos-build-${{ matrix.configuration }}-${{ matrix.arch }}.tgz *.app
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mac-${{ matrix.configuration }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}-${{ matrix.arch }}.tgz
@@ -380,24 +380,24 @@ jobs:
     name: Build Mac distribution zip
     needs: build_mac
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     strategy:
       matrix:
         arch: [x86_64, arm64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mac-Release-${{ matrix.arch }}
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mac-FastDebug-${{ matrix.arch }}
           path: builds
@@ -413,7 +413,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Mac
       - name: Upload result package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.generate_package.outputs.package_name }}
           path: ${{ steps.generate_package.outputs.package_path }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -58,6 +58,9 @@ jobs:
         with:
           submodules: true  # `true` to checkout submodules, `recursive` to recursively checkout submodules
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
@@ -110,6 +113,9 @@ jobs:
           submodules: true
           fetch-depth: '0'  # value 0 to fetch all history and tags for all branches
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         # Grab the release builds
         uses: actions/download-artifact@v8
@@ -163,6 +169,9 @@ jobs:
         with:
           submodules: true
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       # - name: Cache Qt
         # # Cache Qt
         # id: cache-qt-win
@@ -258,6 +267,9 @@ jobs:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
@@ -330,6 +342,9 @@ jobs:
           submodules: true
           fetch-depth: 0
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Prepare Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
@@ -391,6 +406,9 @@ jobs:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -21,6 +21,9 @@ jobs:
         name: Checkout
         with:
           submodules: true
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Set up test version
         shell: bash
         run: |
@@ -67,6 +70,9 @@ jobs:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
@@ -102,6 +108,9 @@ jobs:
         name: Checkout
         with:
           submodules: true
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Set up test version
         shell: bash
         run: |
@@ -197,6 +206,9 @@ jobs:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
@@ -253,6 +265,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Prepare Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.1
         with:
@@ -319,6 +334,9 @@ jobs:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -51,7 +51,7 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         run: $GITHUB_WORKSPACE/ci/linux/generate_appimage.sh $GITHUB_WORKSPACE/build/install
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-${{ matrix.configuration }}
           path: ${{ github.workspace }}/build/install/*.AppImage
@@ -59,21 +59,21 @@ jobs:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-Release
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-FastDebug
           path: builds
@@ -98,7 +98,7 @@ jobs:
     name: Windows
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -177,7 +177,7 @@ jobs:
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
           path: ${{ github.workspace }}/build/install/*
@@ -185,25 +185,25 @@ jobs:
     name: Build Windows distribution zip
     needs: build_windows
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     strategy:
       matrix:
         arch: [Win32, x64]
         simd: [SSE2]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
           path: builds
@@ -248,7 +248,7 @@ jobs:
           # setup-python: 'false'
           # aqtversion: ==1.1.3
           # py7zrversion: '==0.19.*'
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -300,7 +300,7 @@ jobs:
         # Ref: https://github.com/actions/runner-images/issues/2619
         run: gtar -cvzf macos-build-${{ matrix.configuration }}-${{ matrix.arch }}.tgz *.app
       - name: Upload build result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mac-${{ matrix.configuration }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/build/bin/macos-build-${{ matrix.configuration }}-${{ matrix.arch }}.tgz
@@ -308,24 +308,24 @@ jobs:
     name: Build Mac distribution zip
     needs: build_mac
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-748b19d
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
     strategy:
       matrix:
         arch: [x86_64, arm64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
           fetch-depth: '0'
           ref: '${{ github.ref }}'
       - name: Download Release builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mac-Release-${{ matrix.arch }}
           path: builds
       - name: Download FastDebug builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mac-FastDebug-${{ matrix.arch }}
           path: builds

--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -33,6 +33,9 @@ jobs:
         name: Checkout
         with:
           submodules: true
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:

--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Install Qt dependencies
         run: apt-get -yq update && apt-get -yq install libfontconfig1
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true

--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -49,7 +49,9 @@ jobs:
         with:
           fetch-depth: '0'
           ref: ${{ env.RELEASE_TAG }}
-
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install Python dependencies
         run: pip install -r ci/post/requirements.txt
 

--- a/.github/workflows/post-build-release.yaml
+++ b/.github/workflows/post-build-release.yaml
@@ -45,7 +45,7 @@ jobs:
         run: echo "github.event_name= ${{ github.event_name }}"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: '0'
           ref: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -37,6 +37,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
@@ -90,6 +93,9 @@ jobs:
         name: Checkout
         with:
           submodules: true
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       # - name: Cache Qt
         # id: cache-qt-win
         # uses: actions/cache@v1
@@ -204,6 +210,9 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
         with:

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Install Qt dependencies
         run: apt-get -yq update && apt-get -yq install libfontconfig1
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Prepare Environment
         run: choco install ninja
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true
@@ -199,7 +199,7 @@ jobs:
           # setup-python: 'false'
           # aqtversion: ==1.1.3
           # py7zrversion: '==0.19.*'
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: Checkout
         with:
           submodules: true

--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v7
         with:
           submodules: recursive # `true` to checkout submodules, `recursive` to recursively checkout submodules
 

--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -32,6 +32,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive # `true` to checkout submodules, `recursive` to recursively checkout submodules
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       # pipe results of wget to a log file because it's very verbose and rarely fails
       - name: Install Coverity


### PR DESCRIPTION
Update workflows to work properly with node v24, which is now default on Github runners. This required the follow changes:

- All action versions were bumped to the newest releases (Vulkan action is still built for v20, but appears to function on v24)
- Use a newer available version of sftp_upload container image
- Add workaround for safe.directory issue observed in tests