### PR TITLE
fix FRED indexing of Props

### DIFF
--- a/fred2/management.cpp
+++ b/fred2/management.cpp
@@ -775,7 +775,7 @@ int create_object(vec3d *pos, int waypoint_instance, bool prop)
 	int obj, n;
 
 	if (prop) {
-		int prop_class = m_new_prop_type_combo_box.GetCurSel();
+		int prop_class = m_new_prop_type_combo_box.GetPropClass(m_new_prop_type_combo_box.GetCurSel());
 		if (prop_class < 0 || prop_class >= prop_info_size())
 			return -1;
 


### PR DESCRIPTION
Get the Prop class from the list, in the same way that a Ship class is gotten, which accounts for the no_fred flag.  Fixes #7545.