### PR TITLE
Fix FRED resetting the grid position after saving a mission

### DIFF
--- a/fred2/freddoc.cpp
+++ b/fred2/freddoc.cpp
@@ -36,6 +36,7 @@
 #include "localization/fhash.h"
 #include "localization/localize.h"
 #include "mission/missiongoals.h"
+#include "mission/missiongrid.h"
 #include "mission/missionparse.h"
 #include "object/object.h"
 #include "render/3d.h"
@@ -233,6 +234,14 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 	Parse_viewer_pos = view_pos;
 	Parse_viewer_orient = view_orient;
 
+	// preserve the editor grid across the reload; it's display state, not part of the mission,
+	// but clear_mission() recreates it via fred_render_init().  (See the view_pos/view_orient handling above and below.)
+	matrix grid_orient = The_grid->gmatrix;
+	vec3d grid_center = The_grid->center;
+	int grid_nrows = The_grid->nrows;
+	int grid_ncols = The_grid->ncols;
+	float grid_square_size = The_grid->square_size;
+
 	// activate the localizer hash table
 	fhash_flush();
 
@@ -392,6 +401,10 @@ bool CFREDDoc::load_mission(const char *pathname, int flags) {
 
 	view_pos = Parse_viewer_pos;
 	view_orient = Parse_viewer_orient;
+
+	// restore the editor grid that was preserved above
+	create_grid(The_grid, &grid_orient.vec.fvec, &grid_orient.vec.rvec, &grid_center, grid_nrows, grid_ncols, grid_square_size);
+
 	set_modified(0);
 	stars_post_level_init();
 


### PR DESCRIPTION
When FRED2 saves a mission, OnSaveDocument() reloads it via load_mission(MPF_FAST_RELOAD).  That reload calls clear_mission() -> fred_render_init() -> create_default_grid(), which rebuilds The_grid as the default origin-centered XZ plane, discarding any adjustments made in the Adjust Grid dialog (e.g. the X-Z Plane Y Level).  The grid is editor display state and is not stored in the mission file, so the reload had nothing to restore it from.

The camera (view_pos/view_orient) is already preserved across this reload; apply the same preserve-and-restore pattern to the grid by capturing its orientation, center, dimensions, and square size before clear_mission() and rebuilding it with create_grid() afterward.

qtfred is unaffected because its save path does not reload the mission.

Fixes #7548