### PR TITLE
make brief_stage non-copyable and non-movable; provide swap() and reset()

### DIFF
--- a/code/mission/missionbriefcommon.h
+++ b/code/mission/missionbriefcommon.h
@@ -20,6 +20,8 @@
 #include "hud/hud.h"
 #include "utils/unicode.h"
 
+#include <utility>
+
 #define MAX_TEXT_STREAMS	2		// how many concurrent streams of text can be displayed
 
 // ------------------------------------------------------------------------
@@ -163,14 +165,53 @@ public:
 	bool		draw_grid;
 	color		grid_color;
 
-	brief_stage( ) 
-		: camera_time( 0 ), flags( 0 ), formula( -1 ), num_icons(0), icons(nullptr), num_lines(0), lines(nullptr),
-		  draw_grid(true)
-	{ 
+	brief_stage( )
+	{
+		reset();
+	}
+
+	// Restore this stage to its default-constructed state.  Does not free
+	// the icons/lines buffers; the caller is responsible for those.
+	void reset()
+	{
+		text.clear();
 		voice[ 0 ] = 0;
 		camera_pos = vmd_zero_vector;
 		camera_orient = vmd_identity_matrix;
+		camera_time = 0;
+		flags = 0;
+		formula = -1;
+		num_icons = 0;
+		icons = nullptr;
+		num_lines = 0;
+		lines = nullptr;
+		draw_grid = true;
 		grid_color = Color_briefing_grid;
+	}
+
+	// icons and lines are raw owning pointers, so the memberwise copy/move
+	// operations would alias those buffers across two stages; use swap() to
+	// rearrange stages, or copy the buffer contents explicitly
+	brief_stage(const brief_stage&) = delete;
+	brief_stage& operator=(const brief_stage&) = delete;
+	brief_stage(brief_stage&&) = delete;
+	brief_stage& operator=(brief_stage&&) = delete;
+
+	friend void swap(brief_stage& a, brief_stage& b)
+	{
+		std::swap(a.text, b.text);
+		std::swap(a.voice, b.voice);
+		std::swap(a.camera_pos, b.camera_pos);
+		std::swap(a.camera_orient, b.camera_orient);
+		std::swap(a.camera_time, b.camera_time);
+		std::swap(a.flags, b.flags);
+		std::swap(a.formula, b.formula);
+		std::swap(a.num_icons, b.num_icons);
+		std::swap(a.icons, b.icons);
+		std::swap(a.num_lines, b.num_lines);
+		std::swap(a.lines, b.lines);
+		std::swap(a.draw_grid, b.draw_grid);
+		std::swap(a.grid_color, b.grid_color);
 	}
 };
 

--- a/code/missionui/missionbrief.cpp
+++ b/code/missionui/missionbrief.cpp
@@ -821,7 +821,7 @@ void brief_compact_stages()
 
 			Briefing->stages[num].num_icons = 0;
 			for ( i = num+1; i < Briefing->num_stages; i++ ) {
-				Briefing->stages[i-1] = Briefing->stages[i];
+				swap(Briefing->stages[i-1], Briefing->stages[i]);
 			}
 			Briefing->num_stages--;
 			continue;
@@ -832,7 +832,7 @@ void brief_compact_stages()
 	// completely clear out the old entries (if any) so we don't access them by mistake - taylor
 	if ( before > Briefing->num_stages ) {
 		for ( i = Briefing->num_stages; i < before; i++ ) {
-			Briefing->stages[i] = brief_stage();
+			Briefing->stages[i].reset();
 		}
 	}
 }


### PR DESCRIPTION
brief_stage owns its icons and lines buffers through raw pointers, so the implicitly generated copy/move operations silently alias those buffers across two stages.  Delete them and provide a custom swap() that exchanges members (keeping each slot with a distinct buffer), plus a reset() that restores the default-constructed state.

Update brief_compact_stages, the only code that assigned brief_stage objects: shift stages down by swapping (equivalent, since the removed stage buffers were already freed and the tail is cleared afterward) and clear the tail entries with reset().