### PR TITLE
call object_moved() in the FRED and qtFRED wing Align handlers

### DIFF
--- a/fred2/wing_editor.cpp
+++ b/fred2/wing_editor.cpp
@@ -1475,6 +1475,9 @@ void wing_editor::OnWingFormationAlign()
 
 		get_absolute_wing_pos(&objp->pos, leader_objp, cur_wing, i, false);
 		objp->orient = leader_objp->orient;
+
+		// drag any docked partners along (no-op for undocked ships)
+		object_moved(objp);
 	}
 
 	// roll back temporary formation

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
@@ -4,6 +4,7 @@
 #include "iff_defs/iff_defs.h"
 #include "mission/missionhotkey.h"
 #include "mission/missionparse.h"
+#include "mission/object.h"
 #include "missioneditor/common.h"
 #include <QObject>
 #include <QMessageBox>
@@ -635,6 +636,9 @@ void WingEditorDialogModel::alignWingFormation()
 
 		get_absolute_wing_pos(&objp->pos, leader_objp, _currentWingIndex, i, false);
 		objp->orient = leader_objp->orient;
+
+		// drag any docked partners along (no-op for undocked ships)
+		object_moved(objp);
 	}
 
 	// roll back temporary formation


### PR DESCRIPTION
The Align button repositions wing members by assigning objp->pos and objp->orient directly, skipping the post-move bookkeeping that the viewport drag and orient editor paths perform.  A wing member with a docked partner (e.g. an attached support ship) would be moved to its formation slot while the partner stayed behind with broken dock geometry.

Fix by calling object_moved() for each repositioned member, which resets the Docked_already_handled flags and drags docked partners along.  No-op for undocked ships.

Verified in FRED by docking a ship to a wing member and pressing Align.