### PR TITLE
clean, fix, and update workflows

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'nightly_*'
 
-env:
-  QT_VERSION: 5.12.12
-
 jobs:
   build_linux:
     strategy:
@@ -21,7 +18,7 @@ jobs:
             arch: arm64
     name: Linux
     runs-on: ${{ matrix.os }}
-    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
+    container: ghcr.io/scp-fs2open/linux_build:sha-ab87451
     steps:
       - uses: actions/checkout@v7
         name: Checkout
@@ -40,8 +37,7 @@ jobs:
         working-directory: ./build
         env:
           CONFIGURATION: ${{ matrix.configuration }}
-        run: |
-          LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all
+        run: ninja -k 20 all
       - name: Run Tests
         working-directory: ./build
         env:
@@ -62,7 +58,7 @@ jobs:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
     strategy:
       matrix:
         arch: [x86_64, arm64]
@@ -107,10 +103,22 @@ jobs:
     strategy:
       matrix:
         configuration: [FastDebug, Release]
-        arch: [Win32, x64]
-        simd: [SSE2]
+        os: [windows-2022, windows-11-arm]
+        arch: [Win32, x64, ARM64]
+        simd: [SSE2, ""]
+        exclude:
+          - arch: Win32
+            os: windows-11-arm
+          - arch: x64
+            os: windows-11-arm
+          - arch: ARM64
+            os: windows-2022
+          - os: windows-2022
+            simd: ""
+          - os: windows-11-arm
+            simd: SSE2
     name: Windows
-    runs-on: windows-2022
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
         name: Checkout
@@ -119,36 +127,6 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      # - name: Cache Qt
-        # id: cache-qt-win
-        # uses: actions/cache@v1
-        # with:
-          # path: ${{ github.workspace }}/../Qt
-          # key: ${{ runner.os }}-${{ matrix.arch }}-QtCache-${{ env.QT_VERSION }}
-      # - name: Install Qt (32 bit)
-        # uses: jurplel/install-qt-action@v2
-        # if: ${{ matrix.arch == 'Win32' }}
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # arch: win32_msvc2017
-          # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
-          # aqtversion: ==0.8
-      # - name: Install Qt (64 bit)
-        # uses: jurplel/install-qt-action@v2
-        # if: ${{ matrix.arch == 'x64' }}
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # arch: win64_msvc2017_64
-          # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
-          # aqtversion: ==0.8
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.1
-        with:
-          vulkan-query-version: 1.4.304.1
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
@@ -158,20 +136,10 @@ jobs:
         run: |
           mkdir build
           cd build
-
-          if [ "$ARCHITECTURE" = "Win32" ]; then
-              cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
-                -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
-                -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
-                -DFSO_INSTALL_DEBUG_FILES="ON" -DFSO_BUILD_WITH_VULKAN="OFF" -A "$ARCHITECTURE" \
-                -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
-          else
-              cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
-                -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
-                -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
-                -DFSO_INSTALL_DEBUG_FILES="ON" -A "$ARCHITECTURE" \
-                -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
-          fi
+          cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH=ON \
+            -DFSO_USE_VOICEREC=ON -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
+            -DFSO_BUILD_TESTS=ON -DFSO_INSTALL_DEBUG_FILES=ON -A "$ARCHITECTURE" \
+            -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
       - name: Compile
         working-directory: ./build
         env:
@@ -187,20 +155,37 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
+      - name: Set artifact id
+        shell: bash
+        run: |
+          id=
+          if [ -n "${{ matrix.simd }}" ]; then
+            id="${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}"
+          else
+            id="${{ matrix.configuration }}-${{ matrix.arch }}"
+          fi
+          echo "artifact_id=${id}" >> $GITHUB_ENV
       - name: Upload build result
         uses: actions/upload-artifact@v7
         with:
-          name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-${{ env.artifact_id }}
           path: ${{ github.workspace }}/build/install/*
   windows_zip:
     name: Build Windows distribution zip
     needs: build_windows
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
     strategy:
       matrix:
-        arch: [Win32, x64]
-        simd: [SSE2]
+        arch: [Win32, x64, ARM64]
+        simd: [SSE2, ""]
+        exclude:
+          - arch: Win32
+            simd: ""
+          - arch: x64
+            simd: ""
+          - arch: ARM64
+            simd: SSE2
     steps:
       - uses: actions/checkout@v7
         name: Checkout
@@ -210,22 +195,31 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Set artifact id
+        shell: bash
+        run: |
+          id=
+          if [ -n "${{ matrix.simd }}" ]; then
+            id="${{ matrix.arch }}-${{ matrix.simd }}"
+          else
+            id="${{ matrix.arch }}"
+          fi
+          echo "artifact_id=${id}" >> $GITHUB_ENV
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
-          name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-Release-${{ env.artifact_id }}
           path: builds
       - name: Download FastDebug builds
         uses: actions/download-artifact@v8
         with:
-          name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-FastDebug-${{ env.artifact_id }}
           path: builds
       - name: Create Distribution package
         working-directory: ./builds
         shell: bash
         env:
-          ARCH: ${{ matrix.arch }}
-          SIMD: ${{ matrix.simd }}
+          ID: ${{ env.artifact_id }}
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Windows
       - name: Upload result package
         working-directory: ./builds
@@ -246,21 +240,6 @@ jobs:
     name: Mac
     runs-on: macos-latest
     steps:
-      # - name: Cache Qt
-        # id: cache-qt-mac
-        # uses: actions/cache@v1
-        # with:
-          # path: ${{ github.workspace }}/../Qt
-          # key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
-      # - name: Install Qt
-        # uses: jurplel/install-qt-action@v2
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
-          # setup-python: 'false'
-          # aqtversion: ==1.1.3
-          # py7zrversion: '==0.19.*'
       - uses: actions/checkout@v7
         name: Checkout
         with:
@@ -269,12 +248,6 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.1
-        with:
-          vulkan-query-version: 1.4.304.1
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Set up test version
         shell: bash
         run: |
@@ -291,7 +264,7 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build
-        run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja all
+        run: ninja all
       - name: Run Tests
         working-directory: ./build
         env:
@@ -325,7 +298,7 @@ jobs:
     name: Build Mac distribution zip
     needs: build_mac
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
     strategy:
       matrix:
         arch: [x86_64, arm64]

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'release_*'
 
-env:
-  QT_VERSION: 5.12.12
-
 jobs:
   create_release:
     name: Create GitHub release
@@ -50,7 +47,7 @@ jobs:
     name: Linux
     needs: create_release   # Don't run this job until create_release is done and successful
     runs-on: ${{ matrix.os }}
-    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
+    container: ghcr.io/scp-fs2open/linux_build:sha-ab87451
     steps:
       - uses: actions/checkout@v7
         # checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.
@@ -71,8 +68,7 @@ jobs:
         working-directory: ./build
         env:
           CONFIGURATION: ${{ matrix.configuration }}
-        run: |
-          LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all
+        run: ninja -k 20 all
       - name: Run Tests
         working-directory: ./build
         env:
@@ -102,7 +98,7 @@ jobs:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
     strategy:
       matrix:
         arch: [x86_64, arm64]
@@ -157,11 +153,25 @@ jobs:
     strategy:
       matrix:
         configuration: [FastDebug, Release]
-        arch: [Win32, x64]
-        simd: [SSE2, AVX]
+        os: [windows-2022, windows-11-arm]
+        arch: [Win32, x64, ARM64]
+        simd: [SSE2, AVX, ""]
+        exclude:
+          - arch: Win32
+            os: windows-11-arm
+          - arch: x64
+            os: windows-11-arm
+          - arch: ARM64
+            os: windows-2022
+          - os: windows-2022
+            simd: ""
+          - os: windows-11-arm
+            simd: SSE2
+          - os: windows-11-arm
+            simd: AVX
     needs: create_release
     name: Windows
-    runs-on: windows-2022
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
         # Checkout repo
@@ -172,39 +182,6 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      # - name: Cache Qt
-        # # Cache Qt
-        # id: cache-qt-win
-        # uses: actions/cache@v1
-        # with:
-          # path: ${{ github.workspace }}/../Qt
-          # key: ${{ runner.os }}-${{ matrix.arch }}-QtCache-${{ env.QT_VERSION }}
-      # - name: Install Qt (32 bit)
-        # # Install Qt 32bit if matrix.arch == Win32
-        # uses: jurplel/install-qt-action@v2
-        # if: ${{ matrix.arch == 'Win32' }}
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # arch: win32_msvc2017
-          # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
-          # aqtversion: ==0.8
-      # - name: Install Qt (64 bit)
-        # # Install Qt 64bit if matrix.arch == x64
-        # uses: jurplel/install-qt-action@v2
-        # if: ${{ matrix.arch == 'x64' }}
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # arch: win64_msvc2017_64
-          # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
-          # aqtversion: ==0.8
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.1
-        with:
-          vulkan-query-version: 1.4.304.1
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
@@ -214,20 +191,10 @@ jobs:
         run: |
           mkdir build
           cd build
-
-          if [ "$ARCHITECTURE" = "Win32" ]; then
-              cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
-                  -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
-                  -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
-                  -DFSO_INSTALL_DEBUG_FILES="ON" -DFSO_BUILD_WITH_VULKAN="OFF" -A "$ARCHITECTURE" \
-                  -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
-          else
-              cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
-                  -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
-                  -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
-                  -DFSO_INSTALL_DEBUG_FILES="ON" -A "$ARCHITECTURE" \
-                  -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
-          fi
+          cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH=ON \
+            -DFSO_USE_VOICEREC=ON -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
+            -DFSO_BUILD_TESTS=ON -DFSO_INSTALL_DEBUG_FILES=ON -A "$ARCHITECTURE" \
+            -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
       - name: Compile
         working-directory: ./build
         env:
@@ -243,22 +210,41 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
+      - name: Set artifact id
+        shell: bash
+        run: |
+          id=
+          if [ -n "${{ matrix.simd }}" ]; then
+            id="${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}"
+          else
+            id="${{ matrix.configuration }}-${{ matrix.arch }}"
+          fi
+          echo "artifact_id=${id}" >> $GITHUB_ENV
       - name: Upload build result
         uses: actions/upload-artifact@v7
         with:
-          name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-${{ env.artifact_id }}
           path: ${{ github.workspace }}/build/install/*
 
   windows_zip:
     name: Build Windows distribution zip
     needs: build_windows
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
     strategy:
       fail-fast: false  # Run the other jobs in the matrix instead of failing them
       matrix:
-        arch: [Win32, x64]
-        simd: [SSE2, AVX]
+        arch: [Win32, x64, ARM64]
+        simd: [SSE2, AVX, ""]
+        exclude:
+          - arch: Win32
+            simd: ""
+          - arch: x64
+            simd: ""
+          - arch: ARM64
+            simd: SSE2
+          - arch: ARM64
+            simd: AVX
 
     steps:
       - uses: actions/checkout@v7
@@ -270,16 +256,26 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Set artifact id
+        shell: bash
+        run: |
+          id=
+          if [ -n "${{ matrix.simd }}" ]; then
+            id="${{ matrix.arch }}-${{ matrix.simd }}"
+          else
+            id="${{ matrix.arch }}"
+          fi
+          echo "artifact_id=${id}" >> $GITHUB_ENV
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
-          name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-Release-${{ env.artifact_id }}
           path: builds
 
       - name: Download FastDebug builds
         uses: actions/download-artifact@v8
         with:
-          name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-FastDebug-${{ env.artifact_id }}
           path: builds
 
       - name: Create Distribution package
@@ -287,8 +283,7 @@ jobs:
         working-directory: ./builds
         shell: bash
         env:
-          ARCH: ${{ matrix.arch }}
-          SIMD: ${{ matrix.simd }}
+          ID: ${{ env.artifact_id }}
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Windows
 
       - name: Upload result package
@@ -322,20 +317,6 @@ jobs:
     needs: create_release
     runs-on: macos-latest
     steps:
-      # - name: Cache Qt
-        # id: cache-qt-mac
-        # uses: actions/cache@v1
-        # with:
-          # path: ${{ github.workspace }}/../Qt
-          # key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
-      # - name: Install Qt
-        # uses: jurplel/install-qt-action@v2
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
-          # setup-python: 'false'
-          # aqtversion: ==1.1.3
       - uses: actions/checkout@v7
         name: Checkout
         with:
@@ -345,12 +326,6 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.1
-        with:
-          vulkan-query-version: 1.4.304.1
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
@@ -361,7 +336,7 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build
-        run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja all
+        run: ninja all
       - name: Run Tests
         working-directory: ./build
         env:
@@ -395,7 +370,7 @@ jobs:
     name: Build Mac distribution zip
     needs: build_mac
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
     strategy:
       matrix:
         arch: [x86_64, arm64]

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -5,17 +5,20 @@ on:
     branches:
       - 'test/*'
 
-env:
-  QT_VERSION: 5.12.12
-
 jobs:
   build_linux:
     strategy:
       matrix:
         configuration: [FastDebug, Release]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: arm64
     name: Linux
-    runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
+    runs-on: ${{ matrix.os }}
+    container: ghcr.io/scp-fs2open/linux_build:sha-ab87451
     steps:
       - uses: actions/checkout@v7
         name: Checkout
@@ -40,8 +43,7 @@ jobs:
         working-directory: ./build
         env:
           CONFIGURATION: ${{ matrix.configuration }}
-        run: |
-          LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all
+        run: ninja -k 20 all
       - name: Run Tests
         working-directory: ./build
         env:
@@ -56,13 +58,16 @@ jobs:
       - name: Upload build result
         uses: actions/upload-artifact@v7
         with:
-          name: linux-${{ matrix.configuration }}
+          name: linux-${{ matrix.configuration }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/build/install/*.AppImage
   linux_zip:
     name: Build Linux distribution zip
     needs: build_linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
     steps:
       - uses: actions/checkout@v7
         name: Checkout
@@ -76,15 +81,21 @@ jobs:
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
-          name: linux-Release
+          name: linux-Release-${{ matrix.arch }}
           path: builds
       - name: Download FastDebug builds
         uses: actions/download-artifact@v8
         with:
-          name: linux-FastDebug
+          name: linux-FastDebug-${{ matrix.arch }}
           path: builds
+      - name: Fix permissions
+        working-directory: ./builds
+        shell: bash
+        run: chmod 755 *.AppImage
       - name: Create Distribution package
         working-directory: ./builds
+        env:
+          ARCH: ${{ matrix.arch }}
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Linux
       - name: Upload result package
         working-directory: ./builds
@@ -99,10 +110,22 @@ jobs:
     strategy:
       matrix:
         configuration: [FastDebug, Release]
-        arch: [Win32, x64]
-        simd: [SSE2]
+        os: [windows-2022, windows-11-arm]
+        arch: [Win32, x64, ARM64]
+        simd: [SSE2, ""]
+        exclude:
+          - arch: Win32
+            os: windows-11-arm
+          - arch: x64
+            os: windows-11-arm
+          - arch: ARM64
+            os: windows-2022
+          - os: windows-2022
+            simd: ""
+          - os: windows-11-arm
+            simd: SSE2
     name: Windows
-    runs-on: windows-2022
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
         name: Checkout
@@ -117,36 +140,6 @@ jobs:
           [[ "${{ github.ref }}" =~ ^refs\/heads\/test\/(.*)$ ]]
           # Override the revision string so that the builds are named correctly
           echo "set(FSO_VERSION_REVISION_STR ${BASH_REMATCH[1]})" > "version_override.cmake"
-      # - name: Cache Qt
-        # id: cache-qt-win
-        # uses: actions/cache@v1
-        # with:
-          # path: ${{ github.workspace }}/../Qt
-          # key: ${{ runner.os }}-${{ matrix.arch }}-QtCache-${{ env.QT_VERSION }}
-      # - name: Install Qt (32 bit)
-        # uses: jurplel/install-qt-action@v2
-        # if: ${{ matrix.arch == 'Win32' }}
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # arch: win32_msvc2017
-          # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
-          # aqtversion: ==0.8
-      # - name: Install Qt (64 bit)
-        # uses: jurplel/install-qt-action@v2
-        # if: ${{ matrix.arch == 'x64' }}
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # arch: win64_msvc2017_64
-          # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
-          # aqtversion: ==0.8
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.1
-        with:
-          vulkan-query-version: 1.4.304.1
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
@@ -156,20 +149,10 @@ jobs:
         run: |
           mkdir build
           cd build
-
-          if [ "$ARCHITECTURE" = "Win32" ]; then
-              cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
-                -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
-                -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
-                -DFSO_INSTALL_DEBUG_FILES="ON" -DFSO_BUILD_WITH_VULKAN="OFF" -A "$ARCHITECTURE" \
-                -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
-          else
-              cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH="ON" \
-                -DFSO_USE_VOICEREC="ON" -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
-                -DFSO_BUILD_QTFRED=OFF -DFSO_BUILD_TESTS=ON \
-                -DFSO_INSTALL_DEBUG_FILES="ON" -A "$ARCHITECTURE" \
-                -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
-          fi
+          cmake -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DFSO_USE_SPEECH=ON \
+            -DFSO_USE_VOICEREC=ON -DFORCED_SIMD_INSTRUCTIONS="$SIMD" \
+            -DFSO_BUILD_TESTS=ON -DFSO_INSTALL_DEBUG_FILES=ON -A "$ARCHITECTURE" \
+            -G "Visual Studio 17 2022" -T "v143" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
       - name: Compile
         working-directory: ./build
         env:
@@ -185,20 +168,37 @@ jobs:
           CONFIGURATION: ${{ matrix.configuration }}
         shell: bash
         run: ./bin/$CONFIGURATION/unittests --gtest_shuffle
+      - name: Set artifact id
+        shell: bash
+        run: |
+          id=
+          if [ -n "${{ matrix.simd }}" ]; then
+            id="${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}"
+          else
+            id="${{ matrix.configuration }}-${{ matrix.arch }}"
+          fi
+          echo "artifact_id=${id}" >> $GITHUB_ENV
       - name: Upload build result
         uses: actions/upload-artifact@v7
         with:
-          name: windows-${{ matrix.configuration }}-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-${{ env.artifact_id }}
           path: ${{ github.workspace }}/build/install/*
   windows_zip:
     name: Build Windows distribution zip
     needs: build_windows
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
     strategy:
       matrix:
-        arch: [Win32, x64]
-        simd: [SSE2]
+        arch: [Win32, x64, ARM64]
+        simd: [SSE2, ""]
+        exclude:
+          - arch: Win32
+            simd: ""
+          - arch: x64
+            simd: ""
+          - arch: ARM64
+            simd: SSE2
     steps:
       - uses: actions/checkout@v7
         name: Checkout
@@ -209,22 +209,31 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Set artifact id
+        shell: bash
+        run: |
+          id=
+          if [ -n "${{ matrix.simd }}" ]; then
+            id="${{ matrix.arch }}-${{ matrix.simd }}"
+          else
+            id="${{ matrix.arch }}"
+          fi
+          echo "artifact_id=${id}" >> $GITHUB_ENV
       - name: Download Release builds
         uses: actions/download-artifact@v8
         with:
-          name: windows-Release-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-Release-${{ env.artifact_id }}
           path: builds
       - name: Download FastDebug builds
         uses: actions/download-artifact@v8
         with:
-          name: windows-FastDebug-${{ matrix.arch }}-${{ matrix.simd }}
+          name: windows-FastDebug-${{ env.artifact_id }}
           path: builds
       - name: Create Distribution package
         working-directory: ./builds
         shell: bash
         env:
-          ARCH: ${{ matrix.arch }}
-          SIMD: ${{ matrix.simd }}
+          ID: ${{ env.artifact_id }}
         run: $GITHUB_WORKSPACE/ci/linux/create_dist_pack.sh Windows
       - name: Upload result package
         working-directory: ./builds
@@ -245,21 +254,6 @@ jobs:
     name: Mac
     runs-on: macos-latest
     steps:
-      # - name: Cache Qt
-        # id: cache-qt-mac
-        # uses: actions/cache@v1
-        # with:
-          # path: ${{ github.workspace }}/../Qt
-          # key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
-      # - name: Install Qt
-        # uses: jurplel/install-qt-action@v2
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
-          # setup-python: 'false'
-          # aqtversion: ==1.1.3
-          # py7zrversion: '==0.19.*'
       - uses: actions/checkout@v7
         name: Checkout
         with:
@@ -268,12 +262,6 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.1
-        with:
-          vulkan-query-version: 1.4.304.1
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Set up test version
         shell: bash
         run: |
@@ -289,7 +277,7 @@ jobs:
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build
-        run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja all
+        run: ninja all
       - name: Run Tests
         working-directory: ./build
         env:
@@ -323,7 +311,7 @@ jobs:
     name: Build Mac distribution zip
     needs: build_mac
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/sftp_upload:sha-844131c
+    container: ghcr.io/scp-fs2open/sftp_upload:sha-ab87451
     strategy:
       matrix:
         arch: [x86_64, arm64]

--- a/.github/workflows/cache-master.yaml
+++ b/.github/workflows/cache-master.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
 
-env:
-  QT_VERSION: 5.12.12
-
 jobs:
   build_linux:
     strategy:
@@ -25,10 +22,8 @@ jobs:
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
+    container: ghcr.io/scp-fs2open/linux_build:sha-ab87451
     steps:
-      - name: Install Qt dependencies
-        run: apt-get -yq update && apt-get -yq install libfontconfig1
       - uses: actions/checkout@v7
         name: Checkout
         with:
@@ -37,7 +32,7 @@ jobs:
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}
       - name: Configure ccache
@@ -51,11 +46,51 @@ jobs:
           COMPILER: ${{ matrix.compiler }}
           JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
           CCACHE_PATH: /usr/local/bin/ccache
-          ENABLE_QTFRED: ON
-          Qt5_DIR: /qt/${{ env.QT_VERSION }}/gcc_64/lib/cmake/Qt5
+          ENABLE_QTFRED: OFF
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build
-        run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all
+        run: ninja -k 20 all
+      - name: Show CCache statistics
+        run: ccache --show-stats
+
+
+  build_mac:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+        compiler: [clang]
+        arch: [x86_64, arm64]
+        cmake_options: [""]
+    name: Mac
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+        name: Checkout
+        with:
+          submodules: true
+      - name: Set workspace as safe
+        # This appears to be broken in current actions, so do it manually
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}
+      - name: Configure ccache
+        run: |
+          ccache --set-config=sloppiness=pch_defines,time_macros
+          ccache -p
+
+      - name: Configure CMake
+        env:
+          CONFIGURATION: ${{ matrix.configuration }}
+          COMPILER: ${{ matrix.compiler }}
+          JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
+          CCACHE_PATH: /usr/local/bin/ccache
+          ENABLE_QTFRED: OFF
+        run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
+      - name: Compile
+        working-directory: ./build
+        run: ninja -k 20 all
       - name: Show CCache statistics
         run: ccache --show-stats

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -2,9 +2,6 @@ name: Check a pull request
 
 on: [pull_request]
 
-env:
-  QT_VERSION: 5.12.12
-
 jobs:
   build_linux:
     strategy:
@@ -20,18 +17,16 @@ jobs:
           - configuration: Release
             compiler: gcc-13
             cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=OFF
-          - configuration: Debug
-            compiler: gcc-13
-            cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=ON
-          - configuration: Release
-            compiler: gcc-13
-            cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=ON
+          # - configuration: Debug
+          #   compiler: gcc-13
+          #   cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=ON
+          # - configuration: Release
+          #   compiler: gcc-13
+          #   cmake_options: -DFSO_BUILD_WITH_OPENGL=OFF -DFSO_BUILD_WITH_VULKAN=ON
     name: Linux
     runs-on: ubuntu-latest
-    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
+    container: ghcr.io/scp-fs2open/linux_build:sha-ab87451
     steps:
-      - name: Install Qt dependencies
-        run: apt-get -yq update && apt-get -yq install libfontconfig1
       - uses: actions/checkout@v7
         name: Checkout
         with:
@@ -41,7 +36,7 @@ jobs:
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}
           save: false # Caches are created by a separate job and only restored for PRs
@@ -55,11 +50,10 @@ jobs:
           JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
           CCACHE_PATH: /usr/local/bin/ccache
           ENABLE_QTFRED: ON
-          Qt5_DIR: /qt/${{ env.QT_VERSION }}/gcc_64/lib/cmake/Qt5
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build
-        run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja -k 20 all
+        run: ninja -k 20 all
       - name: Run Tests
         working-directory: ./build
         env:
@@ -96,36 +90,6 @@ jobs:
       - name: Set workspace as safe
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      # - name: Cache Qt
-        # id: cache-qt-win
-        # uses: actions/cache@v1
-        # with:
-          # path: ${{ github.workspace }}/../Qt
-          # key: ${{ runner.os }}-${{ matrix.arch }}-QtCache-${{ env.QT_VERSION }}
-      # - name: Install Qt (32 bit)
-        # uses: jurplel/install-qt-action@v2
-        # if: ${{ matrix.compiler  == 'MSVC' && matrix.arch == 'Win32' }}
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # arch: win32_msvc2017
-          # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
-          # aqtversion: ==0.8
-      # - name: Install Qt (64 bit)
-        # uses: jurplel/install-qt-action@v2
-        # if: ${{ matrix.compiler  == 'MSVC' && matrix.arch == 'x64' }}
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # arch: win64_msvc2017_64
-          # cached: ${{ steps.cache-qt-win.outputs.cache-hit }}
-          # aqtversion: ==0.8
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.1
-        with:
-          vulkan-query-version: 1.4.304.1
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
@@ -137,23 +101,12 @@ jobs:
           cd build
 
           if [ "$COMPILER" = "MinGW" ]; then
-              if [ "$ARCHITECTURE" = "Win32" ]; then
-                  cmake -DFSO_USE_SPEECH="OFF" -DFSO_FATAL_WARNINGS="ON" -DFSO_USE_VOICEREC="OFF" -DFSO_BUILD_TESTS="ON" \
-                      -DFSO_BUILD_FRED2="OFF" -DFSO_BUILD_WITH_VULKAN="OFF" -DCMAKE_BUILD_TYPE=$CONFIGURATION -G "Ninja" ..
-              else
-                  cmake -DFSO_USE_SPEECH="OFF" -DFSO_FATAL_WARNINGS="ON" -DFSO_USE_VOICEREC="OFF" -DFSO_BUILD_TESTS="ON" \
-                      -DFSO_BUILD_FRED2="OFF" -DCMAKE_BUILD_TYPE=$CONFIGURATION -G "Ninja" ..
-              fi
+              cmake -DFSO_USE_SPEECH=OFF -DFSO_FATAL_WARNINGS=ON -DFSO_USE_VOICEREC=OFF -DFSO_BUILD_TESTS=ON \
+                  -DFSO_BUILD_FRED2=OFF -DCMAKE_BUILD_TYPE=$CONFIGURATION -G "Ninja" ..
           else
-              if [ "$ARCHITECTURE" = "Win32" ]; then
-                  cmake -DFSO_USE_SPEECH="ON" -DFSO_FATAL_WARNINGS="ON" -DFSO_USE_VOICEREC="OFF" -DFSO_BUILD_TESTS="ON" \
-                      -DFORCED_SIMD_INSTRUCTIONS=SSE2 -DFSO_BUILD_FRED2="ON" -DFSO_BUILD_WITH_VULKAN="OFF" -G "Visual Studio 17 2022" \
-                      -DFSO_BUILD_QTFRED=OFF -T "v143" -A "$ARCHITECTURE" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
-              else
-                  cmake -DFSO_USE_SPEECH="ON" -DFSO_FATAL_WARNINGS="ON" -DFSO_USE_VOICEREC="OFF" -DFSO_BUILD_TESTS="ON" \
-                      -DFORCED_SIMD_INSTRUCTIONS=SSE2 -DFSO_BUILD_FRED2="ON" -G "Visual Studio 17 2022" \
-                      -DFSO_BUILD_QTFRED=OFF -T "v143" -A "$ARCHITECTURE" -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
-              fi
+              cmake -DFSO_USE_SPEECH=ON -DFSO_FATAL_WARNINGS=ON -DFSO_USE_VOICEREC=OFF -DFSO_BUILD_TESTS=ON \
+                  -DFORCED_SIMD_INSTRUCTIONS=SSE2 -G "Visual Studio 17 2022" -T "v143"  -A "$ARCHITECTURE" \
+                  -DCMAKE_BUILD_TYPE=$CONFIGURATION ..
           fi
       - name: Compile
         working-directory: ./build
@@ -190,21 +143,6 @@ jobs:
     name: Mac
     runs-on: macos-latest
     steps:
-      # - name: Cache Qt
-        # id: cache-qt-mac
-        # uses: actions/cache@v1
-        # with:
-          # path: ${{ github.workspace }}/../Qt
-          # key: ${{ runner.os }}-QtCache-${{ env.QT_VERSION }}
-      # - name: Install Qt
-        # uses: jurplel/install-qt-action@v2
-        # with:
-          # version: ${{ env.QT_VERSION }}
-          # dir: ${{ github.workspace }}/..
-          # cached: ${{ steps.cache-qt-mac.outputs.cache-hit }}
-          # setup-python: 'false'
-          # aqtversion: ==1.1.3
-          # py7zrversion: '==0.19.*'
       - uses: actions/checkout@v7
         name: Checkout
         with:
@@ -214,27 +152,24 @@ jobs:
         # This appears to be broken in current actions, so do it manually
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           key: ${{ runner.os }}-${{ matrix.configuration }}-${{ matrix.compiler }}-${{ matrix.arch }}
           save: false # Caches are created by a separate job and only restored for PRs
-      - name: Prepare Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.1
-        with:
-          vulkan-query-version: 1.4.304.1
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
+      - name: Configure ccache
+        run: ccache --set-config=sloppiness=pch_defines,time_macros
       - name: Configure CMake
         env:
           CONFIGURATION: ${{ matrix.configuration }}
           COMPILER: ${{ matrix.compiler }}
           ARCHITECTURE: ${{ matrix.arch }}
           JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
+          CCACHE_PATH: /usr/local/bin/ccache
           ENABLE_QTFRED: OFF
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build
-        run: LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH ninja all
+        run: ninja all
       - name: Run Tests
         working-directory: ./build
         env:
@@ -242,6 +177,8 @@ jobs:
           ARCH: ${{ matrix.arch }}
           XDG_RUNTIME_DIR: /root
         run: $GITHUB_WORKSPACE/ci/linux/run_tests.sh
+      - name: Show CCache statistics
+        run: ccache --show-stats
       - name: Run Clang Tidy
         # Clang-tidy reuses the precompiled headers so this only makes sense for the clang compilers
         if: startsWith(matrix.compiler, 'clang-')

--- a/.github/workflows/test-pull_request.yaml
+++ b/.github/workflows/test-pull_request.yaml
@@ -49,7 +49,7 @@ jobs:
           COMPILER: ${{ matrix.compiler }}
           JOB_CMAKE_OPTIONS: ${{ matrix.cmake_options }}
           CCACHE_PATH: /usr/local/bin/ccache
-          ENABLE_QTFRED: ON
+          ENABLE_QTFRED: OFF
         run: $GITHUB_WORKSPACE/ci/linux/configure_cmake.sh
       - name: Compile
         working-directory: ./build

--- a/.github/workflows/weekly-coverity-scan.yaml
+++ b/.github/workflows/weekly-coverity-scan.yaml
@@ -11,7 +11,6 @@ on:
     - cron: "5 0 * * 5" # Run once per a week on Friday morning (midnight UTC, 4 AM EST), to avoid Coverity's submission limits
 
 env:
-  QT_VERSION: 5.12.12
   coverity_email: SirKnightlySCP@gmail.com
   coverity_token: ${{ secrets.COVERITY_TOKEN }}
 
@@ -20,7 +19,7 @@ jobs:
     name: Build FSO With Coverity Wrapper
     if: github.repository == 'scp-fs2open/fs2open.github.com'
     runs-on: ${{ matrix.config.os }}
-    container: ghcr.io/scp-fs2open/linux_build:sha-71099c9
+    container: ghcr.io/scp-fs2open/linux_build:sha-ab87451
     strategy:
       fail-fast: false
       matrix:

--- a/ci/linux/configure_cmake.sh
+++ b/ci/linux/configure_cmake.sh
@@ -13,13 +13,15 @@ if [ "$COMPILER" = "clang-16" ]; then
     export CXX=clang++-16
 fi
 
-LD_LIBRARY_PATH=$Qt5_DIR/lib:$LD_LIBRARY_PATH
 if [ "$RUNNER_OS" = "macOS" ]; then
     CXXFLAGS="-mtune=generic -pipe -Wno-unknown-pragmas"
     CFLAGS="-mtune=generic -pipe -Wno-unknown-pragmas"
-    # TODO: Vulkan support is disabled on MacOS due to issues with the test suite not linking correctly
-    PLATFORM_CMAKE_OPTIONS="-DFSO_BUILD_WITH_VULKAN=OFF"
     export CMAKE_OSX_ARCHITECTURES="$ARCHITECTURE"
+    # the ccache-action should install via homebrew, which means that we can't
+    # hardcode the correct path in the workflow and must override it instead
+    if [ ! "$CCACHE_PATH" = "" ]; then
+        CCACHE_PATH="$(brew --prefix)/bin/ccache"
+    fi
 else
     PLATFORM_CMAKE_OPTIONS="-DFSO_BUILD_APPIMAGE=ON -DFORCED_SIMD_INSTRUCTIONS=SSE2 -DUSE_STATIC_LIBCXX=ON"
 fi
@@ -31,8 +33,12 @@ if [[ "$COMPILER" =~ ^clang.*$ ]]; then
 fi
 
 if [ ! "$CCACHE_PATH" = "" ]; then
-    echo "Using ccache at $CCACHE_PATH"
-    CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER_LAUNCHER=$CCACHE_PATH -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_PATH"
+    if [ -x "$CCACHE_PATH" ]; then
+        echo "Using ccache at $CCACHE_PATH"
+        CMAKE_OPTIONS="$CMAKE_OPTIONS -DCMAKE_C_COMPILER_LAUNCHER=$CCACHE_PATH -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_PATH"
+    else
+        echo "Invalid or missing ccache binary: $CCACHE_PATH"
+    fi
 fi
 
 mkdir build
@@ -51,5 +57,5 @@ fi
 
 cmake -G Ninja -DFSO_FATAL_WARNINGS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $CMAKE_OPTIONS $PLATFORM_CMAKE_OPTIONS \
     -DCMAKE_INSTALL_PREFIX="$(pwd)/install" -DCMAKE_BUILD_TYPE=$CONFIGURATION \
-    -DFFMPEG_USE_PRECOMPILED=ON -DFSO_BUILD_TESTS=ON -DFSO_BUILD_INCLUDED_LIBS=ON -DFSO_BUILD_QTFRED=${ENABLE_QTFRED:-OFF} \
-    -DSHADERS_ENABLE_COMPILATION=ON -DCMAKE_JOB_POOLS=link=1 -DCMAKE_JOB_POOL_LINK=link ..
+    -DFFMPEG_USE_PRECOMPILED=ON -DFSO_BUILD_TESTS=ON -DFSO_BUILD_INCLUDED_LIBS=ON \
+    -DFSO_BUILD_QTFRED=${ENABLE_QTFRED:-OFF} -DCMAKE_JOB_POOLS=link=1 -DCMAKE_JOB_POOL_LINK=link ..

--- a/ci/linux/create_dist_pack.sh
+++ b/ci/linux/create_dist_pack.sh
@@ -14,17 +14,17 @@ if [ "$OS" = "Linux" ]; then
     echo "package_name=$(get_package_name)-builds-Linux-$ARCH.tar.gz" >> $GITHUB_OUTPUT
     echo "package_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-Linux-$ARCH.tar.gz")" >> $GITHUB_OUTPUT
 elif [ "$OS" = "Windows" ]; then
-    7z a -xr'!*.pdb' "$(get_package_name)-builds-$ARCH-$SIMD.zip" "*"
+    7z a -xr'!*.pdb' "$(get_package_name)-builds-$ID.zip" "*"
 
-    echo "package_path=$(pwd)/$(get_package_name)-builds-$ARCH-$SIMD.zip" >> $GITHUB_OUTPUT
-    echo "package_name=$(get_package_name)-builds-$ARCH-$SIMD.zip" >> $GITHUB_OUTPUT
-    echo "package_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-$ARCH-$SIMD.zip")" >> $GITHUB_OUTPUT
+    echo "package_path=$(pwd)/$(get_package_name)-builds-$ID.zip" >> $GITHUB_OUTPUT
+    echo "package_name=$(get_package_name)-builds-$ID.zip" >> $GITHUB_OUTPUT
+    echo "package_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-builds-$ID.zip")" >> $GITHUB_OUTPUT
 
-    7z a "$(get_package_name)-debug-$ARCH-$SIMD.7z" "*.pdb"
+    7z a "$(get_package_name)-debug-$ID.7z" "*.pdb"
 
-    echo "debug_path=$(pwd)/$(get_package_name)-debug-$ARCH-$SIMD.7z" >> $GITHUB_OUTPUT
-    echo "debug_name=$(get_package_name)-debug-$ARCH-$SIMD.7z" >> $GITHUB_OUTPUT
-    echo "debug_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-debug-$ARCH-$SIMD.7z")" >> $GITHUB_OUTPUT
+    echo "debug_path=$(pwd)/$(get_package_name)-debug-$ID.7z" >> $GITHUB_OUTPUT
+    echo "debug_name=$(get_package_name)-debug-$ID.7z" >> $GITHUB_OUTPUT
+    echo "debug_mime=$(file -b --mime-type "$(pwd)/$(get_package_name)-debug-$ID.7z")" >> $GITHUB_OUTPUT
 elif [ "$OS" = "Mac" ]; then
     tar -cvzf "$(get_package_name)-builds-Mac-$ARCH.tar.gz" *.app
 

--- a/ci/post/file_list.py
+++ b/ci/post/file_list.py
@@ -149,6 +149,8 @@ def get_release_files(tag_name, config) -> Tuple[List[ReleaseFile], Dict[str, So
             # x64 is the Visual Studio name but for consistency we need Win64
             if platform == "x64":
                 platform = "Win64"
+            elif platform == "arm64":
+                platform = "WinARM64"
 
             binary_files.append(ReleaseFile(name, url, platform, group_match.group(3)))
         else:
@@ -213,6 +215,8 @@ def get_ftp_files(build_type, tag_name, config) -> List[ReleaseFile] :
         # x64 is the name Visual Studio uses but Win64 works better for us since that gets displayed in the nightly post
         if "x64" in group_match:
             group_match = group_match.replace("x64", "Win64")
+        elif "arm64" in group_match:
+            group_match = group_match.replace("arm64", "WinARM64")
 
         # construct the download URL list for all mirrors.  The first listed ftp location is taken as the Primary
         for mirror in config["ftp"]["mirrors"]:

--- a/ci/post/nebula.py
+++ b/ci/post/nebula.py
@@ -15,6 +15,7 @@ WIN32_SSE2_KEY = "Win32-SSE2"
 WIN64_SSE2_KEY = "Win64-SSE2"
 WIN32_AVX_KEY = "Win32-AVX"
 WIN64_AVX_KEY = "Win64-AVX"
+WINARM64_KEY = "WinARM64"
 
 metadata = {
     'type': 'engine',
@@ -42,7 +43,8 @@ platforms = {
     WIN32_SSE2_KEY: 'windows',
     WIN64_SSE2_KEY: 'windows',
     WIN32_AVX_KEY: 'windows',
-    WIN64_AVX_KEY: 'windows'
+    WIN64_AVX_KEY: 'windows',
+    WINARM64_KEY: 'windows',
 }
 
 envs = {
@@ -53,7 +55,8 @@ envs = {
     WIN32_SSE2_KEY: 'windows',
     WIN64_SSE2_KEY: 'windows && x86_64',
     WIN32_AVX_KEY: 'windows && avx',
-    WIN64_AVX_KEY: 'windows && avx && x86_64'
+    WIN64_AVX_KEY: 'windows && avx && x86_64',
+    WINARM64_KEY: 'windows && arm64'
 }
 
 subdirs = {
@@ -191,6 +194,7 @@ def render_nebula_release(version, stability, files, config):
                     "sse2": "SSE2" in fn or "AVX" in fn,  # AVX implies SSE2
                     "avx": "AVX" in fn,  # This conveniently also covers the AVX2 case since AVX2 implies AVX
                     "avx2": "AVX2" in fn,
+                    "arm64": "arm64" in fn,
                 }
 
                 pkg['executables'].append({

--- a/ci/post/release.mako
+++ b/ci/post/release.mako
@@ -22,13 +22,15 @@ Windows:  [url=http://scp.fsmods.net/builds/Launcher55g.zip]Launcher 5.5g[/url] 
 OS X:  Soulstorm's [url=https://www.hard-light.net/forums/index.php/topic,51391.0.html]OS X Launcher 3.0[/url]
 Linux:  [url=https://www.hard-light.net/forums/index.php/topic,53206.0.html]YAL[/url] or [url=https://www.hard-light.net/wiki/index.php/Fs2_open_on_Linux/Graphics_Settings]by hand[/url] or whatever you can figure out.[/hidden]
 
-[img]https://scp.indiegames.us/img/windows-icon.png[/img] [color=green][size=12pt]Windows (32/64-bit)[/size][/color]
+[img]https://scp.indiegames.us/img/windows-icon.png[/img] [color=green][size=12pt]Windows (32/64-bit/ARM64)[/size][/color]
 [size=8pt]Compiled using GitHub Actions on Windows Server 2019 (10.0.17763), Visual Studio Enterprise 2019[/size]
 
 [b]64-bit:[/b] ${build(groups["Win64"].mainFile)}
 
 [b]32-bit:[/b] ${build(groups["Win32"].mainFile)}
 [size=8pt]This one is based on the SSE2 Optimizations from the MSVC Compiler.[/size]
+
+[b]ARM64:[/b] ${build(groups["WinARM64"].mainFile)}
 
 [hidden=Alternative builds]
 


### PR DESCRIPTION
Add support for Windows ARM64 builds.

Try to rely on build defaults for various options so that workflow modifications aren't required for basic feature changes.

Remove Vulkan and Qt setup from workflow, instead relying on new prebuilt libs.

Update SFTP image and Linux build image to newer release.

Add ccache setup for macOS.

Update ccache action to a version compatible with Node v24.