### PR TITLE
Fix crash in ai_manage_bay_doors from stale destroyed parent ship

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -13789,6 +13789,10 @@ void ai_manage_bay_doors(object *pl_objp, ai_info *aip, bool done)
 
 	ship *parent_ship = &Ships[shipp->bay_doors_parent_shipnum];
 
+	// the parent may have already been destroyed/departed, leaving stale bay door state behind
+	if (parent_ship->objnum < 0 || parent_ship->model_instance_num < 0)
+		return;
+
 	if (done)
 		parent_ship->bay_doors_wanting_open--;
 


### PR DESCRIPTION
## Summary
- Found via debugger: `ai_manage_bay_doors` (code/ai/aicode.cpp) can assert/crash calling `model_get_instance(-1)` when a departing fighter's bay-door "parent" carrier was already destroyed earlier in the mission.
- Root cause: the carrier's `Ships[]` entry retains stale bay door state (`bay_doors_status`, `bay_doors_wanting_open`) even after its `object` and model instance have been freed (`objnum == -1`, `model_instance_num == -1`). The existing guard only checked that a parent shipnum was assigned, not that the parent was still alive.
- Fix: after resolving `parent_ship`, return early if `parent_ship->objnum < 0 || parent_ship->model_instance_num < 0`, mirroring the validity checks used elsewhere in the codebase (e.g. `shiphit.cpp`, `object.cpp`) before touching a ship's model instance.

## Test plan
- [ ] Reproduce original crash scenario (fighter departing/being destroyed after its carrier was already destroyed) and confirm no crash/assert occurs with the fix.
- [ ] Sanity-check normal bay door open/close behavior (fighter launching/recovering to a live carrier) is unaffected.