### PR TITLE
CI: stop running clang-tidy on QtFRED sources

### DIFF
--- a/ci/linux/clang_tidy.sh
+++ b/ci/linux/clang_tidy.sh
@@ -26,5 +26,5 @@ git diff -U0 --no-color "$BASE_COMMIT..$2" | \
     -extra-arg="-DWITH_VULKAN" \
     -extra-arg="-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1" \
     -extra-arg="-DVK_NO_PROTOTYPES" \
-    -regex '(code(?!((\/graphics\/shaders\/compiled)|(\/globalincs\/windebug)|(\/def_files\/data)))|freespace2|qtfred|test\/src|build|tools)\/.*\.(cpp|h)' \
+    -regex '(code(?!((\/graphics\/shaders\/compiled)|(\/globalincs\/windebug)|(\/def_files\/data)))|freespace2|test\/src|build|tools)\/.*\.(cpp|h)' \
     -clang-tidy-binary /usr/bin/clang-tidy-16 -j$(nproc) -export-fixes "$(pwd)/clang-fixes.yaml"


### PR DESCRIPTION
ENABLE_QTFRED=OFF, so QtFRED is no longer built. The clang-tidy regex still selected qtfred/ files, causing clang-tidy to parse them with no Qt include paths and fail on <QtCore/QObject>. Drop QtFRED from the regex so tidy only lints what CI builds.

We'll need to roll this back once QtFRED is part of workflows again.