### PR TITLE
Fix Cross-Compile issues with inline static RandomRange seeder

### DIFF
--- a/code/utils/Random.cpp
+++ b/code/utils/Random.cpp
@@ -1,4 +1,5 @@
 #include "Random.h"
+#include "RandomRange.h"
 
 #include <limits>
 #include <random>
@@ -8,6 +9,9 @@
 #include "globalincs/pstypes.h"
 
 namespace util {
+
+thread_local std::mt19937 seeder {std::random_device()()};
+
 namespace {
 template <typename RngType>
 class RandomImpl {

--- a/code/utils/RandomRange.h
+++ b/code/utils/RandomRange.h
@@ -54,6 +54,10 @@ size_t parse_number_list(T (&list)[N])
 }
 } // namespace
 
+//Sampling a random_device is REALLY expensive.
+//Instead of sampling one for each seed, create a pseudorandom seeder which is initialized ONCE from a random_device.
+extern thread_local std::mt19937 seeder;
+
 /**
  * @brief Generic class for generating numbers in a specific range
  *
@@ -76,10 +80,6 @@ class RandomRange {
 	bool m_constant;
 	ValueType m_minValue;
 	ValueType m_maxValue;
-
-	//Sampling a random_device is REALLY expensive.
-	//Instead of sampling one for each seed, create a pseudorandom seeder which is initialized ONCE from a random_device.
-	inline static thread_local std::mt19937 seeder {std::random_device()()};
 
   public:
 	template <typename T, typename... Ts, typename = typename std::enable_if<(sizeof... (Ts) >=1 || !std::is_convertible<T, ValueType>::value) && !std::is_same_v<std::decay_t<T>, RandomRange>, int>::type>


### PR DESCRIPTION
Not sure exactly why, but our cross compile pipeline fails currently due to linkage issues with the inline static randomrange seeder. So just move that into an external scope (which has the added benefit of using one seeder, not one seeder per random range type).