### PR TITLE
Qtfred fix missing scene browser menu option

### DIFF
--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -150,7 +150,7 @@ FredView::FredView(QWidget* parent) : QMainWindow(parent), ui(new Ui::FredView()
 	bindThemeIcon(ui->actionConstrainXZ,   QStringLiteral("constxz"));
 	bindThemeIcon(ui->actionConstrainYZ,   QStringLiteral("constyz"));
 	bindThemeIcon(ui->actionConstrainXY,   QStringLiteral("constxy"));
-	bindThemeIcon(ui->actionSelectionList, QStringLiteral("selectlist"));
+	bindThemeIcon(ui->actionSceneBrowser, QStringLiteral("selectlist"));
 	bindThemeIcon(ui->actionSelectionLock, QStringLiteral("selectlock"));
 	bindThemeIcon(ui->actionWingForm,      QStringLiteral("wingform"));
 	bindThemeIcon(ui->actionWingDisband,   QStringLiteral("wingdisband"));
@@ -271,17 +271,14 @@ void FredView::setEditor(Editor* editor, EditorViewport* viewport) {
 	addDockWidget(Qt::LeftDockWidgetArea, _browserPanel);
 	enforceSideDockAreas();
 
-	// Reuse the existing toolbar/menu Selection List action as a Scene Browser toggle
-	ui->actionSelectionList->setCheckable(true);
-	ui->actionSelectionList->setText(tr("Scene Browser"));
-	ui->actionSelectionList->setToolTip(tr("Toggle Scene Browser (H)"));
-	ui->actionSelectionList->setChecked(_browserPanel->isVisible());
+	// Keep the Scene Browser toggle action in sync with the dock's visibility
+	ui->actionSceneBrowser->setChecked(_browserPanel->isVisible());
 	connect(_browserPanel, &QDockWidget::visibilityChanged, this, [this](bool visible) {
-		if (!ui || !ui->actionSelectionList) {
+		if (!ui || !ui->actionSceneBrowser) {
 			return;
 		}
-		QSignalBlocker blocker(ui->actionSelectionList);
-		ui->actionSelectionList->setChecked(visible);
+		QSignalBlocker blocker(ui->actionSceneBrowser);
+		ui->actionSceneBrowser->setChecked(visible);
 	});
 
 	// Restore dock/toolbar layout and window geometry from last session.
@@ -2769,7 +2766,7 @@ bool FredView::showModalDialog(IBaseDialog* dlg) {
 
 	return ret == QDialog::Accepted;
 }
-void FredView::on_actionSelectionList_triggered(bool checked) {
+void FredView::on_actionSceneBrowser_triggered(bool checked) {
 	if (_browserPanel != nullptr) {
 		_browserPanel->setVisible(checked);
 	}

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -140,7 +140,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void on_actionZoomSelected_triggered(bool);
 	void on_actionZoomExtents_triggered(bool);
 
-	void on_actionSelectionList_triggered(bool);
+	void on_actionSceneBrowser_triggered(bool);
 
 	void on_actionOrbitSelected_triggered(bool enabled);
 

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -100,6 +100,8 @@
      <addaction name="actionCamera"/>
      <addaction name="actionCurrent_Ship"/>
     </widget>
+    <addaction name="actionSceneBrowser"/>
+    <addaction name="separator"/>
     <addaction name="actionVisibility_Layers"/>
     <addaction name="menuOutline_LOD"/>
     <addaction name="separator"/>
@@ -308,7 +310,7 @@
    <addaction name="actionConstrainYZ"/>
    <addaction name="actionConstrainXY"/>
    <addaction name="separator"/>
-   <addaction name="actionSelectionList"/>
+   <addaction name="actionSceneBrowser"/>
    <addaction name="actionSelectionLock"/>
    <addaction name="separator"/>
    <addaction name="actionWingForm"/>
@@ -472,12 +474,15 @@
     <string>Constrain movement/rotation to XY plane</string>
    </property>
   </action>
-  <action name="actionSelectionList">
+  <action name="actionSceneBrowser">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
-    <string>SelectionList</string>
+    <string>Scene Browser</string>
    </property>
    <property name="toolTip">
-    <string>Selection List (H)</string>
+    <string>Toggle Scene Browser (H)</string>
    </property>
    <property name="shortcut">
     <string>H</string>


### PR DESCRIPTION
Scene Browser toggle was missing from the View menu in QtFred. This PR fixes it.

Scene Browser grew out of Selection List but I never renamed the methods. I suspect when I was cleaning I saw "Selection List" and removed it thinking it was the old dialog. So this PR also renames all the methods to Scene Browser.