### PR TITLE
QtFRED fix audio handle guards

### DIFF
--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -441,7 +441,7 @@ void CampaignEditorDialogModel::sortMissions()
 
 void CampaignEditorDialogModel::stopSpeech()
 {
-	if (_waveId >= -1) {
+	if (_waveId >= 0) {
 		audiostream_close_file(_waveId, false);
 		_waveId = -1;
 	}

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -198,7 +198,7 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	int m_current_mission_index = -1;
 	int m_current_branch_index = -1;
 
-	int _waveId;
+	int _waveId = -1;
 
 	CampaignFormat m_save_format = CampaignFormat::FSO;
 

--- a/qtfred/src/mission/dialogs/CommandBriefingDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CommandBriefingDialogModel.cpp
@@ -180,7 +180,7 @@ bool CommandBriefingDialogModel::getMissionIsMultiTeam()
 
 void CommandBriefingDialogModel::stopSpeech()
 {
-	if (_waveId >= -1) {
+	if (_waveId >= 0) {
 		audiostream_close_file(_waveId, false);
 		_waveId = -1;
 	}

--- a/qtfred/src/mission/dialogs/CommandBriefingDialogModel.h
+++ b/qtfred/src/mission/dialogs/CommandBriefingDialogModel.h
@@ -50,7 +50,7 @@ class CommandBriefingDialogModel: public AbstractDialogModel {
 	cmd_brief _wipCommandBrief[MAX_TVT_TEAMS];
 	int _currentTeam;
 	int _currentStage;
-	int _waveId;
+	int _waveId = -1;
 	SCP_vector<std::pair<SCP_string, int>> _teamList;
 };
 

--- a/qtfred/src/mission/dialogs/DebriefingDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/DebriefingDialogModel.cpp
@@ -289,7 +289,7 @@ bool DebriefingDialogModel::getMissionIsMultiTeam()
 
 void DebriefingDialogModel::stopSpeech()
 {
-	if (_waveId >= -1) {
+	if (_waveId >= 0) {
 		audiostream_close_file(_waveId, false);
 		_waveId = -1;
 	}

--- a/qtfred/src/mission/dialogs/DebriefingDialogModel.h
+++ b/qtfred/src/mission/dialogs/DebriefingDialogModel.h
@@ -66,7 +66,7 @@ class DebriefingDialogModel: public AbstractDialogModel {
 
 	int _currentTeam;
 	int _currentStage;
-	int _waveId;
+	int _waveId = -1;
 	SCP_vector<std::pair<SCP_string, int>> _teamList;
 };
 


### PR DESCRIPTION
The debriefing, command briefing, and campaign editor dialogs in QtFRED would crash if closed without interaction in release builds because the handle int is never initialized and then the later comparison guard is compared against junk data.

Follow the convention of other audio handles, initialize as -1 and compare >= 0 instead.