### PR TITLE
fix big ship waypoint completion (the "spinning Orion" bug)

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -192,6 +192,8 @@ namespace AI {
 		Cancel_future_waves_of_any_wing_launched_from_an_exited_ship,
 		Fix_ignore_if_dead_flag,
 		Kamikaze_no_collision_avoidance,
+		Fix_big_ship_waypoint_completion,	// a) big ships complete a waypoint within their radius rather than sqrt(radius);
+											// b) completion no longer requires moving 0.1m in a single frame (framerate-dependent)
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -751,6 +751,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$no collision avoidance for kamikaze fighters:", AI::Profile_Flags::Kamikaze_no_collision_avoidance);
 
+				set_flag(profile, "$fix big ship waypoint completion:", AI::Profile_Flags::Fix_big_ship_waypoint_completion);
+
 
 				// end of options ----------------------------------------
 
@@ -979,5 +981,6 @@ void ai_profile_t::reset()
 	}
 	if (mod_supports_version(26, 2, 0)) {
 		flags.set(AI::Profile_Flags::Kamikaze_no_collision_avoidance);
+		flags.set(AI::Profile_Flags::Fix_big_ship_waypoint_completion);
 	}
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -4936,14 +4936,24 @@ void ai_fly_to_target_position(const vec3d* target_pos, bool* pl_done_p=NULL, bo
 	}
 
 	float dist_to_cover_this_frame = (Pl_objp->phys_info.speed * flFrametime);
-	if ( (dist_to_goal < MIN_DIST_TO_WAYPOINT_GOAL) || dist_to_cover_this_frame > 0.1f ) {
+
+	// Retail's completion distance of sqrt(radius) is only ~32m for a capital ship with a 1000m radius --
+	// far smaller than such a ship's turning circle -- and retail also skipped the completion check
+	// entirely unless the ship covered 0.1m in a single frame, a framerate-dependent gate that excludes
+	// exactly the slow speeds at which a big ship could aim precisely.  Together these could trap a
+	// capital ship in an endless overshoot-turnaround-miss loop at its final waypoint.  With the flag
+	// set, big ships complete a waypoint anywhere within their own radius of it, and the check always runs.
+	bool fix_waypoint_completion = The_mission.ai_profile->flags[AI::Profile_Flags::Fix_big_ship_waypoint_completion];
+	float waypoint_tolerance = MIN_DIST_TO_WAYPOINT_GOAL + ((fix_waypoint_completion && sip->is_big_or_huge()) ? Pl_objp->radius : fl_sqrt(Pl_objp->radius));
+
+	if ( fix_waypoint_completion || (dist_to_goal < MIN_DIST_TO_WAYPOINT_GOAL) || dist_to_cover_this_frame > 0.1f ) {
 		vec3d	nearest_point;
 		float		r;
 
 		r = find_nearest_point_on_line(&nearest_point, &Pl_objp->last_pos, &Pl_objp->pos, target_pos);
 
-		if ( (dist_to_goal < (MIN_DIST_TO_WAYPOINT_GOAL + fl_sqrt(Pl_objp->radius) + dist_to_cover_this_frame))
-			|| (((r >= 0.0f) && (r <= 1.0f)) && (vm_vec_dist_quick(&nearest_point, target_pos) < (MIN_DIST_TO_WAYPOINT_GOAL + fl_sqrt(Pl_objp->radius)))))
+		if ( (dist_to_goal < (waypoint_tolerance + dist_to_cover_this_frame))
+			|| (((r >= 0.0f) && (r <= 1.0f)) && (vm_vec_dist_quick(&nearest_point, target_pos) < waypoint_tolerance)))
 		{
 				int treat_as_ship;
 


### PR DESCRIPTION
Since FS1 retail, a large ship could get permanently stuck circling its final waypoint.  Waypoint completion requires the ship center to pass within MIN_DIST_TO_WAYPOINT_GOAL + sqrt(radius) of the point (~37m for a 1000m-radius capital ship), and the check only runs when the ship covers 0.1m in a single frame (a framerate-dependent minimum speed). At any speed that passes that gate, a capital ship turning at 2PI/(3*rotation_time) has a turning circle of hundreds of meters, so once it overshoots a misaligned final leg it can never re-aim into the completion bubble: an endless overshoot-turnaround-miss loop.

Add ai_profiles flag "$fix big ship waypoint completion:" (Fix_big_ship_waypoint_completion), enabled by default for mods targeting 26.2.  With the flag set:

- big/huge ships complete a waypoint anywhere within their own radius of it (matching what the docking path code has always done), while small ships keep the retail sqrt(radius) tolerance; and
- the completion check runs every frame instead of requiring 0.1m of travel per frame, removing the framerate-dependent minimum speed (which at 240fps is 24 m/s, enough to affect fighters too).

With the flag unset, behavior is unchanged from retail.