### PR TITLE
QtFRED clean up preferences

### DIFF
--- a/qtfred/src/mission/CameraController.cpp
+++ b/qtfred/src/mission/CameraController.cpp
@@ -166,6 +166,10 @@ void CameraController::orbitCameraApply()
 void CameraController::orbitCameraRotate(int dx, int dy)
 {
 	float rot_scale = _physicsRot / 300.0f;
+	if (_invertOrbitX)
+		dx = -dx;
+	if (_invertOrbitY)
+		dy = -dy;
 	_orbitTheta += dx / 100.0f * rot_scale;
 	_orbitPhi += dy / 100.0f * rot_scale;
 
@@ -190,7 +194,10 @@ void CameraController::orbitCameraPan(int dx, int dy)
 
 void CameraController::orbitCameraZoom(float delta)
 {
-	float zoom_speed = 1.0f + (_physicsSpeed - 1) / 499.0f * 4.0f;
+	// Scale the per-notch zoom with the camera move speed: slow speeds give fine, precise
+	// zoom, fast speeds give coarse jumps for traversing large scenes. sqrt keeps the
+	// 1..100 move-speed range from exploding into absurd steps at the top end.
+	float zoom_speed = sqrtf(static_cast<float>(_physicsSpeed)) * 0.5f;
 	_orbitDistance *= powf(2.0f, delta * zoom_speed);
 
 	CLAMP(_orbitDistance, 1.0f, 10000000.0f);

--- a/qtfred/src/mission/CameraController.h
+++ b/qtfred/src/mission/CameraController.h
@@ -29,6 +29,9 @@ class CameraController {
 	float _orbitPhi = 1.24f;
 	float _orbitTheta = 2.25f;
 	bool _orbitActive = false;
+	// Default to inverted, matching the engine's F3 lab and POF Tools.
+	bool _invertOrbitX = true;
+	bool _invertOrbitY = true;
 
 	void orbitCameraApply();
 
@@ -71,6 +74,12 @@ public:
 
 	bool getLookatMode() const { return _lookatMode; }
 	void setLookatMode(bool mode) { _lookatMode = mode; }
+
+	bool getInvertOrbitX() const { return _invertOrbitX; }
+	void setInvertOrbitX(bool invert) { _invertOrbitX = invert; }
+
+	bool getInvertOrbitY() const { return _invertOrbitY; }
+	void setInvertOrbitY(bool invert) { _invertOrbitY = invert; }
 
 	void orbitCameraInitFromCurrentView(const vec3d* pivot, const matrix* grid_orient);
 	void orbitCameraRotate(int dx, int dy);

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -165,6 +165,9 @@ void EditorViewport::loadSettings() {
 	view.Show_waypoints                    = settings.value("view_show_waypoints",                    view.Show_waypoints).toBool();
 	view.Show_compass                      = settings.value("view_show_compass",                      view.Show_compass).toBool();
 	view.Highlight_selectable_subsys       = settings.value("view_highlight_selectable_subsys",       view.Highlight_selectable_subsys).toBool();
+	view.Outline_lod                       = settings.value("view_outline_lod",                       view.Outline_lod).toInt();
+	camera.setInvertOrbitX(settings.value("camera_invert_orbit_x", camera.getInvertOrbitX()).toBool());
+	camera.setInvertOrbitY(settings.value("camera_invert_orbit_y", camera.getInvertOrbitY()).toBool());
 	settings.endGroup();
 }
 
@@ -208,6 +211,9 @@ void EditorViewport::saveSettings() const {
 	settings.setValue("view_show_waypoints",                    view.Show_waypoints);
 	settings.setValue("view_show_compass",                      view.Show_compass);
 	settings.setValue("view_highlight_selectable_subsys",       view.Highlight_selectable_subsys);
+	settings.setValue("view_outline_lod",                       view.Outline_lod);
+	settings.setValue("camera_invert_orbit_x",                  camera.getInvertOrbitX());
+	settings.setValue("camera_invert_orbit_y",                  camera.getInvertOrbitY());
 	settings.endGroup();
 }
 void EditorViewport::needsUpdate() {

--- a/qtfred/src/mission/dialogs/PreferencesDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/PreferencesDialogModel.cpp
@@ -23,6 +23,9 @@ PreferencesDialogModel::PreferencesDialogModel(QObject* parent, EditorViewport* 
 	, _showSexpHelpWingEditor(viewport->Show_sexp_help_wing_editor)
 	, _darkMode(viewport->Dark_mode)
 	, _toolbarIconSize(viewport->toolbar_icon_size)
+	, _outlineLod(viewport->view.Outline_lod)
+	, _invertOrbitX(viewport->camera.getInvertOrbitX())
+	, _invertOrbitY(viewport->camera.getInvertOrbitY())
 	, _gridCenterX(static_cast<int>(viewport->The_grid->center.xyz.x))
 	, _gridCenterY(static_cast<int>(viewport->The_grid->center.xyz.y))
 	, _gridCenterZ(static_cast<int>(viewport->The_grid->center.xyz.z))
@@ -60,6 +63,9 @@ bool PreferencesDialogModel::apply() {
 	_viewport->Show_sexp_help_wing_editor       = _showSexpHelpWingEditor;
 	_viewport->Dark_mode                        = _darkMode;
 	_viewport->toolbar_icon_size                = _toolbarIconSize;
+	_viewport->view.Outline_lod                 = _outlineLod;
+	_viewport->camera.setInvertOrbitX(_invertOrbitX);
+	_viewport->camera.setInvertOrbitY(_invertOrbitY);
 
 	_viewport->saveSettings();
 	if (darkModeChanged) {
@@ -72,26 +78,49 @@ bool PreferencesDialogModel::apply() {
 	}
 	bindings.save();
 
-	_viewport->The_grid->center.xyz.x = static_cast<float>(_gridCenterX);
-	_viewport->The_grid->center.xyz.y = static_cast<float>(_gridCenterY);
-	_viewport->The_grid->center.xyz.z = static_cast<float>(_gridCenterZ);
-
-	switch (_gridPlane) {
-	case GridPlane::XY:
-		_viewport->The_grid->gmatrix.vec.fvec = vmd_x_vector;
-		_viewport->The_grid->gmatrix.vec.rvec = vmd_y_vector;
-		break;
-	case GridPlane::XZ:
-		_viewport->The_grid->gmatrix.vec.fvec = vmd_x_vector;
-		_viewport->The_grid->gmatrix.vec.rvec = vmd_z_vector;
-		break;
-	case GridPlane::YZ:
-		_viewport->The_grid->gmatrix.vec.fvec = vmd_y_vector;
-		_viewport->The_grid->gmatrix.vec.rvec = vmd_z_vector;
-		break;
+	// Only rebuild the grid when its settings actually changed. apply() runs on every
+	// preference change, and an unnecessary rebuild has visible side effects (e.g. it would
+	// re-derive the grid plane orientation each time).
+	const auto& curUvec = _viewport->The_grid->gmatrix.vec.uvec;
+	GridPlane curPlane;
+	if (curUvec.xyz.y != 0.0f) {
+		curPlane = GridPlane::XZ;
+	} else if (curUvec.xyz.z != 0.0f) {
+		curPlane = GridPlane::XY;
+	} else {
+		curPlane = GridPlane::YZ;
 	}
 
-	modify_grid(_viewport->The_grid);
+	const bool gridChanged = _gridPlane != curPlane
+		|| _gridCenterX != static_cast<int>(_viewport->The_grid->center.xyz.x)
+		|| _gridCenterY != static_cast<int>(_viewport->The_grid->center.xyz.y)
+		|| _gridCenterZ != static_cast<int>(_viewport->The_grid->center.xyz.z);
+
+	if (gridChanged) {
+		_viewport->The_grid->center.xyz.x = static_cast<float>(_gridCenterX);
+		_viewport->The_grid->center.xyz.y = static_cast<float>(_gridCenterY);
+		_viewport->The_grid->center.xyz.z = static_cast<float>(_gridCenterZ);
+
+		switch (_gridPlane) {
+		case GridPlane::XY:
+			_viewport->The_grid->gmatrix.vec.fvec = vmd_x_vector;
+			_viewport->The_grid->gmatrix.vec.rvec = vmd_y_vector;
+			break;
+		case GridPlane::XZ:
+			// fvec/rvec must be ordered so that uvec = fvec x rvec points +Y, matching
+			// create_default_grid(); the reverse (X, Z) yields a -Y normal that flips the
+			// grid plane and turns the orbit camera upside down.
+			_viewport->The_grid->gmatrix.vec.fvec = vmd_z_vector;
+			_viewport->The_grid->gmatrix.vec.rvec = vmd_x_vector;
+			break;
+		case GridPlane::YZ:
+			_viewport->The_grid->gmatrix.vec.fvec = vmd_y_vector;
+			_viewport->The_grid->gmatrix.vec.rvec = vmd_z_vector;
+			break;
+		}
+
+		modify_grid(_viewport->The_grid);
+	}
 
 	return true;
 }
@@ -138,6 +167,9 @@ void PreferencesDialogModel::setDarkMode(bool value) { modify(_darkMode, value);
 int  PreferencesDialogModel::getToolbarIconSize() const { return _toolbarIconSize; }
 void PreferencesDialogModel::setToolbarIconSize(int size) { modify(_toolbarIconSize, size); }
 
+int  PreferencesDialogModel::getOutlineLod() const { return _outlineLod; }
+void PreferencesDialogModel::setOutlineLod(int value) { modify(_outlineLod, value); }
+
 QKeySequence PreferencesDialogModel::getControlKey(ControlAction action) const {
 	auto it = _controlKeys.find(action);
 	Assertion(it != _controlKeys.end(), "Unknown control action!");
@@ -149,6 +181,12 @@ void PreferencesDialogModel::setControlKey(ControlAction action, const QKeySeque
 	Assertion(it != _controlKeys.end(), "Unknown control action!");
 	modify(it->second, sequence);
 }
+
+bool PreferencesDialogModel::getInvertOrbitX() const { return _invertOrbitX; }
+void PreferencesDialogModel::setInvertOrbitX(bool value) { modify(_invertOrbitX, value); }
+
+bool PreferencesDialogModel::getInvertOrbitY() const { return _invertOrbitY; }
+void PreferencesDialogModel::setInvertOrbitY(bool value) { modify(_invertOrbitY, value); }
 
 void PreferencesDialogModel::resetControlDefaults() {
 	auto& bindings = ControlBindings::instance();

--- a/qtfred/src/mission/dialogs/PreferencesDialogModel.h
+++ b/qtfred/src/mission/dialogs/PreferencesDialogModel.h
@@ -57,10 +57,18 @@ public:
 	int  getToolbarIconSize() const;
 	void setToolbarIconSize(int size);
 
+	int  getOutlineLod() const;
+	void setOutlineLod(int value);
+
 	// Controls
 	QKeySequence getControlKey(ControlAction action) const;
 	void setControlKey(ControlAction action, const QKeySequence& sequence);
 	void resetControlDefaults();
+
+	bool getInvertOrbitX() const;
+	void setInvertOrbitX(bool value);
+	bool getInvertOrbitY() const;
+	void setInvertOrbitY(bool value);
 
 	// Grid
 	int getGridCenterX() const;
@@ -90,9 +98,12 @@ private:
 	bool _showSexpHelpWingEditor;
 	bool _darkMode;
 	int  _toolbarIconSize;
+	int  _outlineLod;
 
 	// Controls
 	std::map<ControlAction, QKeySequence> _controlKeys;
+	bool _invertOrbitX;
+	bool _invertOrbitY;
 
 	// Grid
 	int _gridCenterX;

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -223,6 +223,8 @@ void FredView::setEditor(Editor* editor, EditorViewport* viewport) {
 		_tbLocalRotate = settings.value("FredView/transformLocalRotate", false).toBool();
 		_viewport->camera.setPhysicsSpeed(settings.value("FredView/cameraSpeedMove", 1).toInt());
 		_viewport->camera.setPhysicsRot(settings.value("FredView/cameraSpeedRot",  25).toInt());
+		_lastSavedCameraSpeedMove = _viewport->camera.getPhysicsSpeed();
+		_lastSavedCameraSpeedRot  = _viewport->camera.getPhysicsRot();
 	}
 
 	connect(fred, &Editor::missionLoaded, this, &FredView::on_mission_loaded);
@@ -892,22 +894,6 @@ void FredView::syncViewOptions() {
 	connectActionToViewSetting(ui->actionShowDistances, &_viewport->view.Show_distances);
 
 	connect(ui->actionVisibility_Layers, &QAction::triggered, this, [this]() { openLayerManagerDialog(); });
-
-	// Outline LOD submenu — mutually exclusive options
-	QAction* outlineLodActions[] = {
-		ui->actionOutline_LOD_0, ui->actionOutline_LOD_1, ui->actionOutline_LOD_2,
-		ui->actionOutline_LOD_3, ui->actionOutline_LOD_4
-	};
-	for (int i = 0; i < 5; i++) {
-		auto action = outlineLodActions[i];
-		connect(this, &FredView::viewIdle, this, [action, this, i]() {
-			action->setChecked(_viewport->view.Outline_lod == i);
-		});
-		connect(action, &QAction::triggered, this, [this, i]() {
-			_viewport->view.Outline_lod = i;
-			_viewport->needsUpdate();
-		});
-	}
 }
 void FredView::initializeStatusBar() {
 	statusBar()->setContentsMargins(8, 1, 8, 1);
@@ -2183,10 +2169,7 @@ void FredView::closeEvent(QCloseEvent* event) {
 	settings.setValue("FredView/geometry",             saveGeometry());
 	settings.setValue("FredView/transformLocalMove",   _tbLocalMove);
 	settings.setValue("FredView/transformLocalRotate", _tbLocalRotate);
-	if (_viewport) {
-		settings.setValue("FredView/cameraSpeedMove", _viewport->camera.getPhysicsSpeed());
-		settings.setValue("FredView/cameraSpeedRot",  _viewport->camera.getPhysicsRot());
-	}
+	// Camera speeds are persisted on change in onUpdateViewSpeeds(), so no need to save them here.
 
 	if (!maybePromptToSaveMissionChanges(tr("closing QtFRED"))) {
 		event->ignore();
@@ -2248,6 +2231,18 @@ void FredView::onUpdateViewSpeeds() {
 				break;
 			}
 		}
+	}
+
+	// Persist immediately when a speed changes (via toolbar, menu, or keyboard) so the choice
+	// survives even an unclean exit. Only writes on an actual change to avoid per-idle churn.
+	const int moveSpeed = _viewport->camera.getPhysicsSpeed();
+	const int rotSpeed  = _viewport->camera.getPhysicsRot();
+	if (moveSpeed != _lastSavedCameraSpeedMove || rotSpeed != _lastSavedCameraSpeedRot) {
+		QSettings settings;
+		settings.setValue("FredView/cameraSpeedMove", moveSpeed);
+		settings.setValue("FredView/cameraSpeedRot",  rotSpeed);
+		_lastSavedCameraSpeedMove = moveSpeed;
+		_lastSavedCameraSpeedRot  = rotSpeed;
 	}
 }
 void FredView::on_actionx1_triggered(bool enabled) {

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -331,6 +331,9 @@ class FredView: public QMainWindow, public IDialogProvider {
 	QDoubleSpinBox* _transformC          = nullptr;
 	QComboBox*      _transformMoveSpeedCombo = nullptr;
 	QComboBox*      _transformRotSpeedCombo  = nullptr;
+	// Last camera speeds written to QSettings; lets us persist on change instead of only on close.
+	int             _lastSavedCameraSpeedMove = -1;
+	int             _lastSavedCameraSpeedRot  = -1;
 	QComboBox*      _transformIffCombo   = nullptr;
 	QLabel*         _transformRadiusLabel = nullptr;
 	QToolButton*    _transformLocalBtn   = nullptr;

--- a/qtfred/src/ui/dialogs/PreferencesDialog.cpp
+++ b/qtfred/src/ui/dialogs/PreferencesDialog.cpp
@@ -96,6 +96,7 @@ void PreferencesDialog::updateUi() {
 
 	const int iconSize = _model->getToolbarIconSize();
 	ui->toolbarIconSizeCombo->setCurrentIndex(iconSize <= 16 ? 0 : iconSize >= 32 ? 2 : 1);
+	ui->outlineLodCombo->setCurrentIndex(_model->getOutlineLod());
 	ui->showSexpHelpMissionEvents->setChecked(_model->getShowSexpHelpMissionEvents());
 	ui->showSexpHelpMissionGoals->setChecked(_model->getShowSexpHelpMissionGoals());
 	ui->showSexpHelpMissionCutscenes->setChecked(_model->getShowSexpHelpMissionCutscenes());
@@ -118,6 +119,8 @@ void PreferencesDialog::updateUi() {
 	ui->gridCenterZ->setValue(_model->getGridCenterZ());
 
 	// Controls
+	ui->invertOrbitX->setChecked(_model->getInvertOrbitX());
+	ui->invertOrbitY->setChecked(_model->getInvertOrbitY());
 	for (const auto& entry : _controlEditors) {
 		entry.second->setKeySequence(_model->getControlKey(entry.first));
 	}
@@ -154,6 +157,10 @@ void PreferencesDialog::on_applyAutoCorrections_toggled(bool checked) {
 void PreferencesDialog::on_toolbarIconSizeCombo_currentIndexChanged(int index) {
 	static constexpr int sizes[] = { 16, 24, 32 };
 	_model->setToolbarIconSize(sizes[index]);
+}
+
+void PreferencesDialog::on_outlineLodCombo_currentIndexChanged(int index) {
+	_model->setOutlineLod(index);
 }
 
 void PreferencesDialog::on_themeCombo_currentIndexChanged(int index) {
@@ -208,6 +215,14 @@ void PreferencesDialog::on_gridCenterZ_valueChanged(int value) {
 
 void PreferencesDialog::on_resetGridButton_clicked() {
 	_model->resetGrid();
+}
+
+void PreferencesDialog::on_invertOrbitX_toggled(bool checked) {
+	_model->setInvertOrbitX(checked);
+}
+
+void PreferencesDialog::on_invertOrbitY_toggled(bool checked) {
+	_model->setInvertOrbitY(checked);
 }
 
 void PreferencesDialog::on_resetDefaultsButton_clicked() {

--- a/qtfred/src/ui/dialogs/PreferencesDialog.h
+++ b/qtfred/src/ui/dialogs/PreferencesDialog.h
@@ -31,6 +31,7 @@ private slots:
 	void on_checkPotentialIssues_toggled(bool checked);
 	void on_applyAutoCorrections_toggled(bool checked);
 	void on_toolbarIconSizeCombo_currentIndexChanged(int index);
+	void on_outlineLodCombo_currentIndexChanged(int index);
 	void on_themeCombo_currentIndexChanged(int index);
 	void on_showSexpHelpMissionEvents_toggled(bool checked);
 	void on_showSexpHelpMissionGoals_toggled(bool checked);
@@ -50,6 +51,8 @@ private slots:
 	void on_resetGridButton_clicked();
 
 	// Controls
+	void on_invertOrbitX_toggled(bool checked);
+	void on_invertOrbitY_toggled(bool checked);
 	void on_resetDefaultsButton_clicked();
 
 private: // NOLINT(readability-redundant-access-specifiers)

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -83,16 +83,6 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
-    <widget class="QMenu" name="menuOutline_LOD">
-     <property name="title">
-      <string>Outline LOD</string>
-     </property>
-     <addaction name="actionOutline_LOD_0"/>
-     <addaction name="actionOutline_LOD_1"/>
-     <addaction name="actionOutline_LOD_2"/>
-     <addaction name="actionOutline_LOD_3"/>
-     <addaction name="actionOutline_LOD_4"/>
-    </widget>
     <widget class="QMenu" name="menuViewpoint">
      <property name="title">
       <string>&amp;Viewpoint</string>
@@ -103,7 +93,6 @@
     <addaction name="actionSceneBrowser"/>
     <addaction name="separator"/>
     <addaction name="actionVisibility_Layers"/>
-    <addaction name="menuOutline_LOD"/>
     <addaction name="separator"/>
     <addaction name="actionShow_Background"/>
     <addaction name="actionShow_Ship_Models"/>
@@ -886,46 +875,6 @@
    </property>
    <property name="text">
     <string>Current &amp;Ship</string>
-   </property>
-  </action>
-  <action name="actionOutline_LOD_0">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>LOD 0 (highest detail)</string>
-   </property>
-  </action>
-  <action name="actionOutline_LOD_1">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>LOD 1</string>
-   </property>
-  </action>
-  <action name="actionOutline_LOD_2">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>LOD 2</string>
-   </property>
-  </action>
-  <action name="actionOutline_LOD_3">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>LOD 3</string>
-   </property>
-  </action>
-  <action name="actionOutline_LOD_4">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>LOD 4 (lowest detail)</string>
    </property>
   </action>
   <action name="actionx1">

--- a/qtfred/ui/PreferencesDialog.ui
+++ b/qtfred/ui/PreferencesDialog.ui
@@ -39,6 +39,9 @@
           </item>
           <item row="0" column="1">
            <widget class="QComboBox" name="themeCombo">
+            <property name="toolTip">
+             <string>Overall color theme for the QtFRED interface. Dark applies a dark palette to the editor UI.</string>
+            </property>
             <item>
              <property name="text">
               <string>Light</string>
@@ -60,6 +63,9 @@
           </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="toolbarIconSizeCombo">
+            <property name="toolTip">
+             <string>Size of the icons shown on the editor toolbars.</string>
+            </property>
             <item>
              <property name="text">
               <string>Small (16px)</string>
@@ -77,6 +83,45 @@
             </item>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="outlineLodLabel">
+            <property name="text">
+             <string>Outline detail:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="outlineLodCombo">
+            <property name="toolTip">
+             <string>Level of detail used when drawing model outlines in the viewport. Lower detail draws faster.</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>LOD 0 (highest detail)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LOD 1</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LOD 2</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LOD 3</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>LOD 4 (lowest detail)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -88,6 +133,9 @@
          <layout class="QFormLayout" name="missionEditingLayout">
           <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="offerAutosaveRecovery">
+            <property name="toolTip">
+             <string>When opening a mission, offer to restore a newer autosave if one is found.</string>
+            </property>
             <property name="text">
              <string>Offer to load autosave on mission open</string>
             </property>
@@ -102,6 +150,9 @@
           </item>
           <item row="1" column="1">
            <widget class="QSpinBox" name="autosaveIntervalSeconds">
+            <property name="toolTip">
+             <string>Time between automatic mission saves, in seconds. Set to 0 to disable autosave.</string>
+            </property>
             <property name="minimum">
              <number>0</number>
             </property>
@@ -118,6 +169,9 @@
           </item>
           <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="moveShipsWhenUndocking">
+            <property name="toolTip">
+             <string>When undocking ships, automatically move them apart so they no longer overlap.</string>
+            </property>
             <property name="text">
              <string>Move Ships When Undocking</string>
             </property>
@@ -125,6 +179,9 @@
           </item>
           <item row="3" column="0" colspan="2">
            <widget class="QCheckBox" name="alwaysSaveDisplayNames">
+            <property name="toolTip">
+             <string>Always write each object's $Display Name to the mission file, even when it matches the object's name.</string>
+            </property>
             <property name="text">
              <string>Always save Display Names</string>
             </property>
@@ -132,6 +189,9 @@
           </item>
           <item row="4" column="0" colspan="2">
            <widget class="QCheckBox" name="createBakOnSave">
+            <property name="toolTip">
+             <string>Keep a .bak backup copy of the previous mission file each time you save.</string>
+            </property>
             <property name="text">
              <string>Create .bak file when saving a mission</string>
             </property>
@@ -148,6 +208,9 @@
          <layout class="QVBoxLayout" name="errorCheckerLayout">
           <item>
            <widget class="QCheckBox" name="checkPotentialIssues">
+            <property name="toolTip">
+             <string>Include non-fatal potential issues (warnings) when running the mission error checker.</string>
+            </property>
             <property name="text">
              <string>Check potential issues</string>
             </property>
@@ -155,6 +218,9 @@
           </item>
           <item>
            <widget class="QCheckBox" name="applyAutoCorrections">
+            <property name="toolTip">
+             <string>Let the error checker automatically fix problems it is able to correct on its own.</string>
+            </property>
             <property name="text">
              <string>Apply auto-corrections</string>
             </property>
@@ -171,6 +237,9 @@
          <layout class="QVBoxLayout" name="sexpHelpLayout">
           <item>
            <widget class="QCheckBox" name="showSexpHelpMissionEvents">
+            <property name="toolTip">
+             <string>Show the SEXP operator help panel in the Mission Events editor.</string>
+            </property>
             <property name="text">
              <string>Mission Events</string>
             </property>
@@ -178,6 +247,9 @@
           </item>
           <item>
            <widget class="QCheckBox" name="showSexpHelpMissionGoals">
+            <property name="toolTip">
+             <string>Show the SEXP operator help panel in the Mission Goals editor.</string>
+            </property>
             <property name="text">
              <string>Mission Goals</string>
             </property>
@@ -185,6 +257,9 @@
           </item>
           <item>
            <widget class="QCheckBox" name="showSexpHelpMissionCutscenes">
+            <property name="toolTip">
+             <string>Show the SEXP operator help panel in the Mission Cutscenes editor.</string>
+            </property>
             <property name="text">
              <string>Mission Cutscenes</string>
             </property>
@@ -192,6 +267,9 @@
           </item>
           <item>
            <widget class="QCheckBox" name="showSexpHelpShipEditor">
+            <property name="toolTip">
+             <string>Show the SEXP operator help panel in the Ship editor.</string>
+            </property>
             <property name="text">
              <string>Ship Editor</string>
             </property>
@@ -199,6 +277,9 @@
           </item>
           <item>
            <widget class="QCheckBox" name="showSexpHelpWingEditor">
+            <property name="toolTip">
+             <string>Show the SEXP operator help panel in the Wing editor.</string>
+            </property>
             <property name="text">
              <string>Wing Editor</string>
             </property>
@@ -231,6 +312,9 @@
         <layout class="QHBoxLayout" name="planeLayout">
          <item>
           <widget class="QRadioButton" name="xyPlaneRadio">
+           <property name="toolTip">
+            <string>Orient the reference grid on the world XY plane.</string>
+           </property>
            <property name="text">
             <string>XY Plane</string>
            </property>
@@ -238,6 +322,9 @@
          </item>
          <item>
           <widget class="QRadioButton" name="xzPlaneRadio">
+           <property name="toolTip">
+            <string>Orient the reference grid on the world XZ plane (the default).</string>
+           </property>
            <property name="text">
             <string>XZ Plane</string>
            </property>
@@ -245,6 +332,9 @@
          </item>
          <item>
           <widget class="QRadioButton" name="yzPlaneRadio">
+           <property name="toolTip">
+            <string>Orient the reference grid on the world YZ plane.</string>
+           </property>
            <property name="text">
             <string>YZ Plane</string>
            </property>
@@ -280,6 +370,9 @@
           </item>
           <item row="0" column="1">
            <widget class="QSpinBox" name="gridCenterX">
+            <property name="toolTip">
+             <string>X coordinate of the grid's center point in the world.</string>
+            </property>
             <property name="minimum">
              <number>-32768</number>
             </property>
@@ -297,6 +390,9 @@
           </item>
           <item row="1" column="1">
            <widget class="QSpinBox" name="gridCenterY">
+            <property name="toolTip">
+             <string>Y coordinate of the grid's center point in the world.</string>
+            </property>
             <property name="minimum">
              <number>-32768</number>
             </property>
@@ -314,6 +410,9 @@
           </item>
           <item row="2" column="1">
            <widget class="QSpinBox" name="gridCenterZ">
+            <property name="toolTip">
+             <string>Z coordinate of the grid's center point in the world.</string>
+            </property>
             <property name="minimum">
              <number>-32768</number>
             </property>
@@ -327,6 +426,9 @@
        </item>
        <item>
         <widget class="QPushButton" name="resetGridButton">
+         <property name="toolTip">
+          <string>Reset the grid plane and center back to their defaults.</string>
+         </property>
          <property name="text">
           <string>Reset to Default</string>
          </property>
@@ -353,14 +455,59 @@
       </attribute>
       <layout class="QVBoxLayout" name="controlsLayout">
        <item>
+        <widget class="QGroupBox" name="mouseOrbitGroup">
+         <property name="title">
+          <string>Mouse Orbit Camera</string>
+         </property>
+         <layout class="QVBoxLayout" name="mouseOrbitLayout">
+          <item>
+           <widget class="QCheckBox" name="invertOrbitX">
+            <property name="toolTip">
+             <string>Invert the horizontal direction of mouse orbit rotation.</string>
+            </property>
+            <property name="text">
+             <string>Invert X axis (horizontal)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="invertOrbitY">
+            <property name="toolTip">
+             <string>Invert the vertical direction of mouse orbit rotation.</string>
+            </property>
+            <property name="text">
+             <string>Invert Y axis (vertical)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QWidget" name="controlsFormWidget" native="true"/>
        </item>
        <item>
         <widget class="QPushButton" name="resetDefaultsButton">
+         <property name="toolTip">
+          <string>Reset all control key bindings back to their defaults.</string>
+         </property>
          <property name="text">
           <string>Reset to Defaults</string>
          </property>
         </widget>
+       </item>
+       <item>
+        <spacer name="controlsSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Consolidates several viewport/camera options into the Preferences dialog and fixes a couple of apply-time issues in the process. Options that lived on the main menu are now proper, persisted preferences, and the orbit camera gains axis-inversion controls. Additionally it adds tooltips to all options.