### PR TITLE
Qtfred adjust tree controls

### DIFF
--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
@@ -300,6 +300,7 @@ void BriefingEditorDialog::updateUi()
 
 	// SEXP tree formula
 	ui->formulaTreeView->load_tree(_model->getFormula());
+	ui->formulaTreeView->expandAll();
 	if (ui->formulaTreeView->select_sexp_node != -1) {
 		ui->formulaTreeView->hilite_item(ui->formulaTreeView->select_sexp_node);
 	}

--- a/qtfred/src/ui/dialogs/DebriefingDialog.cpp
+++ b/qtfred/src/ui/dialogs/DebriefingDialog.cpp
@@ -109,6 +109,7 @@ void DebriefingDialog::updateUi()
 
 	// SEXP tree formula
 	ui->formulaTreeView->load_tree(_model->getFormula());
+	ui->formulaTreeView->expandAll();
 	if (ui->formulaTreeView->select_sexp_node != -1) {
 		ui->formulaTreeView->hilite_item(ui->formulaTreeView->select_sexp_node);
 	}

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -334,6 +334,7 @@ void ShipEditorDialog::updateArrival(bool overwrite)
 			}
 			if (_model->getUseCue()) {
 				ui->arrivalTree->load_tree(_model->getArrivalFormula());
+				ui->arrivalTree->expandAll();
 			} else {
 				ui->arrivalTree->clear_tree("");
 			}
@@ -390,6 +391,7 @@ void ShipEditorDialog::updateDeparture(bool overwrite)
 			}
 			if (_model->getUseCue()) {
 				ui->departureTree->load_tree(_model->getDepartureFormula(), "false");
+				ui->departureTree->expandAll();
 			} else {
 				ui->departureTree->clear_tree("");
 			}

--- a/qtfred/src/ui/dialogs/WingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.cpp
@@ -87,6 +87,7 @@ void WingEditorDialog::updateUi()
 
 	ui->arrivalTree->initializeEditor(_viewport->editor, this, _viewport);
 	ui->arrivalTree->load_tree(_model->getArrivalTree());
+	ui->arrivalTree->expandAll();
 	if (ui->arrivalTree->select_sexp_node != -1) {
 		ui->arrivalTree->hilite_item(ui->arrivalTree->select_sexp_node);
 	}
@@ -99,6 +100,7 @@ void WingEditorDialog::updateUi()
 	ui->departureTargetCombo->setCurrentIndex(ui->departureTargetCombo->findData(_model->getDepartureTarget()));
 	ui->departureTree->initializeEditor(_viewport->editor, this, _viewport);
 	ui->departureTree->load_tree(_model->getDepartureTree());
+	ui->departureTree->expandAll();
 	if (ui->departureTree->select_sexp_node != -1) {
 		ui->departureTree->hilite_item(ui->departureTree->select_sexp_node);
 	}

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -183,6 +183,14 @@ sexp_tree_view::sexp_tree_view(QWidget* parent) : QTreeWidget(parent), _actions(
 
 	setHeaderHidden(true);
 
+	// Editing is always initiated explicitly (Space or the context menu's Edit Data),
+	// so disable Qt's automatic edit triggers. Otherwise a double-click on an editable
+	// item would start an inline edit and fight with the expand-on-double-click below.
+	setEditTriggers(QAbstractItemView::NoEditTriggers);
+	// We toggle expansion ourselves in the itemDoubleClicked handler, so turn off Qt's
+	// built-in double-click expansion to avoid toggling twice.
+	setExpandsOnDoubleClick(false);
+
 	select_sexp_node = -1;
 	root_item = -1;
 	clear_tree();
@@ -190,7 +198,13 @@ sexp_tree_view::sexp_tree_view(QWidget* parent) : QTreeWidget(parent), _actions(
 	connect(this, &QWidget::customContextMenuRequested, this, &sexp_tree_view::customMenuHandler);
 	connect(this, &QTreeWidget::itemChanged, this, &sexp_tree_view::handleItemChange);
 	connect(this, &QTreeWidget::itemSelectionChanged, this, &sexp_tree_view::handleNewItemSelected);
-	connect(this, &QTreeWidget::itemDoubleClicked, this, [this](QTreeWidgetItem* item, int /*column*/) {openNodeEditor(item);});
+	// Double-clicking a node toggles its expansion when it has children; a leaf node
+	// has nothing to expand, so double-clicking it does nothing.
+	connect(this, &QTreeWidget::itemDoubleClicked, this, [](QTreeWidgetItem* item, int /*column*/) {
+		if (item && item->childCount() > 0) {
+			item->setExpanded(!item->isExpanded());
+		}
+	});
 
 	setItemDelegateForColumn(0, new NoteBadgeDelegate(this));
 
@@ -681,9 +695,16 @@ void sexp_tree_view::keyPressEvent(QKeyEvent* e)
 		}
 	}
 
-	// Space opens the editor for the selected node
+	// Space enters "Edit Data" mode on the selected node. For editable data nodes this
+	// starts inline text editing. Operator nodes have no editable data of their own, 
+	// so they fall back to the operator quick-search popup.
 	if (e->key() == Qt::Key_Space && currentItem()) {
-		openNodeEditor(currentItem());
+		item_index = get_node(currentItem());
+		if (_model.compute_context_menu_state().can_edit_text) {
+			editDataActionHandler();
+		} else {
+			openNodeEditor(currentItem());
+		}
 		return;
 	}
 

--- a/qtfred/src/ui/widgets/sexp_tree_view.h
+++ b/qtfred/src/ui/widgets/sexp_tree_view.h
@@ -256,6 +256,13 @@ class sexp_tree_view: public QTreeWidget, public ISexpTreeUI {
 					return;
 				if (currentItem() == nullptr)
 					return;
+				// Re-sync item_index to the currently selected item before computing
+				// menu state. Some mutations (like a paste that adds a child) move the
+				// model's item_index onto the newly created node without changing the
+				// visual selection, which would otherwise make a repeated hotkey act on
+				// the wrong node and fail its gate. The right-click menu re-derives
+				// item_index the same way, which is why the menu path can be repeated.
+				item_index = get_node(currentItem());
 				// item_index may be -1 in labeled-root mode (the user selected the
 				// label itself). compute_context_menu_state() handles that path and
 				// returns a state whose can_* flags already reflect what's legal


### PR DESCRIPTION
Adjusts Sexp Tree controls. Double click always expands. Spacebar always starts Edit Data mode. Fix paste via ctrl-v only working once. Automatically expand all nodes for ships, wings, briefings, and debriefings. The latter fixes #2973 .