### PR TITLE
External weapon model cleanup: consolidate duplicated logic, fix several longstanding bugs

### DIFF
--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -6781,25 +6781,16 @@ bool check_los(int objnum, int target_objnum, float threshold, int primary_bank,
 		vec3d pnt = is_primary ? pm->gun_banks[primary_bank].pnt[swp->primary_next_slot[primary_bank]] : pm->missile_banks[secondary_bank].pnt[swp->secondary_next_slot[secondary_bank]];
 		vec3d firing_point;
 
-		//Following Section taken from ship.cpp ship_fire_secondary()
 		polymodel* weapon_model = nullptr;
 		if (wip->external_model_num >= 0) {
 			weapon_model = model_get(wip->external_model_num);
 		}
 
-		if (weapon_model && weapon_model->n_guns) {
-			int external_bank = is_primary ? primary_bank : secondary_bank + MAX_SHIP_PRIMARY_BANKS;
-			if (wip->wi_flags[Weapon::Info_Flags::External_weapon_fp]) {
-				if ((weapon_model->n_guns <= swp->external_model_fp_counter[external_bank]) || (swp->external_model_fp_counter[external_bank] < 0))
-					swp->external_model_fp_counter[external_bank] = 0;
-				vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[swp->external_model_fp_counter[external_bank]]);
-				swp->external_model_fp_counter[external_bank]++;
-			}
-			else {
-				// make it use the 0 index slot
-				vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[0]);
-			}
-		}
+		// use the same firing point the next shot will use
+		int external_bank = is_primary ? primary_bank : secondary_bank + MAX_SHIP_PRIMARY_BANKS;
+		vec3d external_fp_offset = ship_get_external_model_fp_offset(swp, wip, weapon_model, external_bank, false);
+		vm_vec_add2(&pnt, &external_fp_offset);
+
 		vm_vec_unrotate(&firing_point, &pnt, &firing_ship->orient);
 		vm_vec_add(&start, &firing_point, &firing_ship->pos);
 	}

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7999,6 +7999,8 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 						renderCircle((int)draw_point.screen.xyw.x + position[0], (int)draw_point.screen.xyw.y + position[1], 10);
 				}
 			} else {
+				int external_model_instance = ship_get_external_weapon_model_instance(swp, i);
+
 				for ( k = 0; k < bank->num_slots; k++ ) {
 					model_render_params weapon_render_info;
 					weapon_render_info.set_detail_level_lock(detail_level_lock);
@@ -8016,7 +8018,7 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 					matrix model_orient;
 					vm_matrix_x_matrix(&model_orient, &object_orient, &slot_orient);
 
-					model_render_immediate(&weapon_render_info, wip->external_model_num, swp->primary_bank_external_model_instance[i], &model_orient, &world_position);
+					model_render_immediate(&weapon_render_info, wip->external_model_num, external_model_instance, &model_orient, &world_position);
 				}
 			}
 		}

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7905,9 +7905,11 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 		auto ship_pm = model_get(sip->model_num);
 
 		for (i = 0; i < swp->num_secondary_banks; i++) {
+			if (swp->secondary_bank_weapons[i] < 0)
+				continue;
 			auto wip = &Weapon_info[swp->secondary_bank_weapons[i]];
 
-			if (wip->external_model_num == -1 || !sip->draw_secondary_models[i])
+			if (wip->external_model_num < 0 || !sip->draw_secondary_models[i])
 				continue;
 
 			auto bank = &ship_pm->missile_banks[i];
@@ -7984,10 +7986,10 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 		auto ship_pm = model_get(sip->model_num);
 
 		for ( i = 0; i < swp->num_primary_banks; i++ ) {
-			auto wip = &Weapon_info[swp->primary_bank_weapons[i]];
 			auto bank = &ship_pm->gun_banks[i];
+			auto wip = (swp->primary_bank_weapons[i] >= 0) ? &Weapon_info[swp->primary_bank_weapons[i]] : nullptr;
 
-			if ( wip->external_model_num < 0 || !sip->draw_primary_models[i] ) {
+			if ( wip == nullptr || wip->external_model_num < 0 || !sip->draw_primary_models[i] ) {
 				// no model to draw, so just mark each firing point with a circle
 				for ( k = 0; k < bank->num_slots; k++ ) {
 					vm_vec_unrotate(&subobj_pos, &bank->pnt[k], &object_orient);

--- a/code/hud/hudtarget.cpp
+++ b/code/hud/hudtarget.cpp
@@ -7919,28 +7919,30 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 					weapon_render_info.set_detail_level_lock(detail_level_lock);
 					weapon_render_info.set_flags(render_flags);
 
+					vec3d slot_pnt;
+					matrix slot_orient;
+					ship_get_weapon_model_slot_transform(bank, k, 0.0f, &slot_pnt, &slot_orient);
+
 					// We need to transform the position local to the model to be in "world" space relative to the rendered outline
 					vec3d world_position;
-					vm_vec_unrotate(&world_position, &bank->pnt[k], &object_orient);
+					vm_vec_unrotate(&world_position, &slot_pnt, &object_orient);
 
-					// "Bank" the external model by the angle offset
-					angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
-					matrix model_orient = object_orient;
-					vm_rotate_matrix_by_angles(&model_orient, &angs);
+					matrix model_orient;
+					vm_matrix_x_matrix(&model_orient, &object_orient, &slot_orient);
 
-					model_render_immediate(&weapon_render_info, wip->external_model_num, &model_orient, &bank->pnt[k]);
+					model_render_immediate(&weapon_render_info, wip->external_model_num, &model_orient, &world_position);
 				}
 			} else {
+				auto weapon_pm = model_get(wip->external_model_num);
 				num_secondaries_rendered = 0;
 
 				for(k = 0; k < bank->num_slots; k++)
 				{
-					auto secondary_weapon_pos = bank->pnt[k];
-
 					if (num_secondaries_rendered >= sp->weapons.secondary_bank_ammo[i])
 						break;
 
-					if(sp->secondary_point_reload_pct.get(i, k) <= 0.0)
+					float reload_pct = sp->secondary_point_reload_pct.get(i, k);
+					if (reload_pct <= 0.0f)
 						continue;
 
 					model_render_params weapon_render_info;
@@ -7953,19 +7955,19 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 
 					num_secondaries_rendered++;
 
-					vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-sp->secondary_point_reload_pct.get(i, k)) * model_get(wip->external_model_num)->rad);
-
 					weapon_render_info.set_detail_level_lock(detail_level_lock);
 					weapon_render_info.set_flags(render_flags);
 
+					vec3d slot_pnt;
+					matrix slot_orient;
+					ship_get_weapon_model_slot_transform(bank, k, (1.0f - reload_pct) * weapon_pm->rad, &slot_pnt, &slot_orient);
+
 					// We need to transform the position local to the model to be in "world" space relative to the rendered outline
 					vec3d world_position;
-					vm_vec_unrotate(&world_position, &secondary_weapon_pos, &object_orient);
+					vm_vec_unrotate(&world_position, &slot_pnt, &object_orient);
 
-					// "Bank" the external model by the angle offset
-					angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
-					matrix model_orient = object_orient;
-					vm_rotate_matrix_by_angles(&model_orient, &angs);
+					matrix model_orient;
+					vm_matrix_x_matrix(&model_orient, &object_orient, &slot_orient);
 
 					model_render_immediate(&weapon_render_info, wip->external_model_num, &model_orient, &world_position);
 				}
@@ -7985,36 +7987,34 @@ void HudGaugeHardpoints::render(float /*frametime*/, bool config)
 			auto wip = &Weapon_info[swp->primary_bank_weapons[i]];
 			auto bank = &ship_pm->gun_banks[i];
 
-			for ( k = 0; k < bank->num_slots; k++ ) {
-				if ( wip->external_model_num < 0 || !sip->draw_primary_models[i] ) {
+			if ( wip->external_model_num < 0 || !sip->draw_primary_models[i] ) {
+				// no model to draw, so just mark each firing point with a circle
+				for ( k = 0; k < bank->num_slots; k++ ) {
 					vm_vec_unrotate(&subobj_pos, &bank->pnt[k], &object_orient);
-					//vm_vec_sub(&subobj_pos, &Eye_position, &subobj_pos);
-					//g3_rotate_vertex(&draw_point, &bank->pnt[k]);
 
 					g3_rotate_vertex(&draw_point, &subobj_pos);
 					g3_project_vertex(&draw_point);
 
-					//resize(&width, &height);
-
-					//unsize(&xc, &yc);
-					//unsize(&draw_point.screen.xyw.x, &draw_point.screen.xyw.y);
 					if (!(draw_point.flags & PF_OVERFLOW))
 						renderCircle((int)draw_point.screen.xyw.x + position[0], (int)draw_point.screen.xyw.y + position[1], 10);
-					//renderCircle(xc, yc, 25);
-				} else {
+				}
+			} else {
+				for ( k = 0; k < bank->num_slots; k++ ) {
 					model_render_params weapon_render_info;
 					weapon_render_info.set_detail_level_lock(detail_level_lock);
 					weapon_render_info.set_flags(render_flags);
 					weapon_render_info.set_alpha(alpha);
 
+					vec3d slot_pnt;
+					matrix slot_orient;
+					ship_get_weapon_model_slot_transform(bank, k, 0.0f, &slot_pnt, &slot_orient);
+
 					// We need to transform the position local to the model to be in "world" space relative to the rendered outline
 					vec3d world_position;
-					vm_vec_unrotate(&world_position, &bank->pnt[k], &object_orient);
+					vm_vec_unrotate(&world_position, &slot_pnt, &object_orient);
 
-					// "Bank" the external model by the angle offset
-					angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
-					matrix model_orient = object_orient;
-					vm_rotate_matrix_by_angles(&model_orient, &angs);
+					matrix model_orient;
+					vm_matrix_x_matrix(&model_orient, &object_orient, &slot_orient);
 
 					model_render_immediate(&weapon_render_info, wip->external_model_num, swp->primary_bank_external_model_instance[i], &model_orient, &world_position);
 				}

--- a/code/model/model.h
+++ b/code/model/model.h
@@ -1090,22 +1090,18 @@ void model_set_detail_level(int n);
 #define MR_SHOW_OUTLINE_PRESET		(1<<14)		// Draw the object in outline mode. Color assumed to be set already.	
 #define MR_SHOW_INVISIBLE_FACES		(1<<15)		// Show invisible faces as green...
 #define MR_AUTOCENTER				(1<<16)		// Always use the center of the hull bounding box as the center, instead of the pivot point
-#define MR_EMPTY_SLOT3				(1<<17)		// draw bay paths
-#define MR_ALL_XPARENT				(1<<18)		// render it fully transparent
-#define MR_NO_ZBUFFER				(1<<19)		// switch z-buffering off completely 
-#define MR_NO_CULL					(1<<20)		// don't cull backfacing poly's
-#define MR_EMPTY_SLOT4				(1<<21)		// force a given texture to always be used
-#define MR_NO_BATCH					(1<<22)		// don't use submodel batching when rendering
-#define MR_EDGE_ALPHA				(1<<23)		// makes norms that are faceing away from you render more transparent -Bobboau
-#define MR_CENTER_ALPHA				(1<<24)		// oposite of above -Bobboau
-#define MR_NO_FOGGING				(1<<25)		// Don't fog - taylor
-#define MR_SHOW_OUTLINE_HTL			(1<<26)		// Show outlines (wireframe view) using HTL method
-#define MR_NO_GLOWMAPS				(1<<27)		// disable rendering of glowmaps - taylor
-#define MR_FULL_DETAIL				(1<<28)		// render all valid objects, particularly ones that are otherwise in/out of render boxes - taylor
-#define MR_FORCE_CLAMP				(1<<29)		// force clamp - Hery
-#define MR_EMPTY_SLOT5				(1<<30)		// Use a animated Shader - Valathil
-constexpr uint64_t MR_ATTACHED_MODEL = static_cast<uint64_t>(1) << static_cast<uint64_t>(31); // Used for attached weapon model lodding
-constexpr uint64_t MR_NO_INSIGNIA = static_cast<uint64_t>(1) << static_cast<uint64_t>(32);	// Disable the insignias for ... reasons.  Also << more than 31 causes UB, so that's (1<<32)
+#define MR_ALL_XPARENT				(1<<17)		// render it fully transparent
+#define MR_NO_ZBUFFER				(1<<18)		// switch z-buffering off completely 
+#define MR_NO_CULL					(1<<19)		// don't cull backfacing poly's
+#define MR_NO_BATCH					(1<<20)		// don't use submodel batching when rendering
+#define MR_EDGE_ALPHA				(1<<21)		// makes norms that are faceing away from you render more transparent -Bobboau
+#define MR_CENTER_ALPHA				(1<<22)		// oposite of above -Bobboau
+#define MR_NO_FOGGING				(1<<23)		// Don't fog - taylor
+#define MR_SHOW_OUTLINE_HTL			(1<<24)		// Show outlines (wireframe view) using HTL method
+#define MR_NO_GLOWMAPS				(1<<25)		// disable rendering of glowmaps - taylor
+#define MR_FULL_DETAIL				(1<<26)		// render all valid objects, particularly ones that are otherwise in/out of render boxes - taylor
+#define MR_FORCE_CLAMP				(1<<27)		// force clamp - Hery
+#define MR_NO_INSIGNIA				(1<<28)		// Disable the insignias for ... reasons
 
 #define MR_DEBUG_PIVOTS				(1<<0)		// Show the pivot points
 #define MR_DEBUG_PATHS				(1<<1)		// Show the paths associated with a model

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -162,6 +162,7 @@ model_render_params::model_render_params() :
 	Objnum(-1),
 	Detail_level_locked(-1),
 	Depth_scale(1500.0f),
+	Attached_model_draw_distance(-1.0f),
 	Warp_bitmap(-1),
 	Warp_alpha(-1.0f),
 	Xparent_alpha(1.0f),
@@ -214,8 +215,13 @@ int model_render_params::get_detail_level_lock() const
 }
 
 float model_render_params::get_depth_scale() const
-{ 
-	return Depth_scale; 
+{
+	return Depth_scale;
+}
+
+float model_render_params::get_attached_model_draw_distance() const
+{
+	return Attached_model_draw_distance;
 }
 
 int model_render_params::get_warp_bitmap() const
@@ -380,6 +386,11 @@ void model_render_params::set_warp_params(int bitmap, float alpha, const vec3d &
 void model_render_params::set_depth_scale(float scale)
 {
 	Depth_scale = scale;
+}
+
+void model_render_params::set_attached_model_draw_distance(float distance)
+{
+	Attached_model_draw_distance = distance;
 }
 
 void model_render_params::set_debug_flags(uint flags)
@@ -906,10 +917,13 @@ void model_render_add_lightning(model_draw_list *scene, const model_render_param
 	}
 }
 
-float model_render_determine_depth(int obj_num, int model_num, const matrix* orient, const vec3d* pos, int detail_level_locked)
+float model_render_determine_depth(int obj_num, int model_num, const matrix* orient, const vec3d* pos, int detail_level_locked, const vec3d* eye_pos)
 {
+	if (eye_pos == nullptr)
+		eye_pos = &Eye_position;
+
 	vec3d closest_pos;
-	float depth = model_find_closest_point( &closest_pos, model_num, -1, orient, pos, &Eye_position );
+	float depth = model_find_closest_point( &closest_pos, model_num, -1, orient, pos, eye_pos );
 
 	if ( detail_level_locked < 0 ) {
 		switch (Detail.detail_distance) {
@@ -2761,22 +2775,28 @@ void model_render_queue(const model_render_params* interp, model_draw_list* scen
 	bool is_outlines_only = (model_flags & MR_NO_POLYS) && ((model_flags & MR_SHOW_OUTLINE_PRESET) || (model_flags & MR_SHOW_OUTLINE));
 	bool is_outlines_only_htl = (model_flags & MR_NO_POLYS) && (model_flags & MR_SHOW_OUTLINE_HTL);
 
+	float depth;
+	if (interp->get_attached_model_draw_distance() >= 0.0f) {
+		// this is an attached weapon model, rendered inside its parent's pushed transform, so pos
+		// is in the parent's frame; measure the depth from the eye position in that same frame
+		vec3d local_eye = scene->get_view_position();
+		depth = model_render_determine_depth(objnum, model_num, orient, pos, interp->get_detail_level_lock(), &local_eye);
+
+		// don't render weapon models beyond the ship's tabled Weapon Model Draw Distance (which defaults to 200)
+		if (depth > interp->get_attached_model_draw_distance()) {
+			return;
+		}
+	} else {
+		depth = model_render_determine_depth(objnum, model_num, orient, pos, interp->get_detail_level_lock());
+	}
+
 	scene->push_transform(pos, orient);
 
-	float depth = model_render_determine_depth(objnum, model_num, orient, pos, interp->get_detail_level_lock());
 	int detail_level = model_render_determine_detail(depth, model_num, interp->get_detail_level_lock());
 
 	// Send the detail level to the lab for displaying
 	if (gameseq_get_state() == GS_STATE_LAB) {
 		Lab_object_detail_level = detail_level;
-	}
-
-	// If we're rendering attached weapon models, check against the ships' tabled Weapon Model Draw Distance (which defaults to 200)
-	if ( model_flags & MR_ATTACHED_MODEL && shipp != NULL ) {
-		if (depth > Ship_info[shipp->ship_info_index].weapon_model_draw_distance) {
-			scene->pop_transform();
-			return;
-		}
 	}
 
 // #ifndef NDEBUG

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -76,6 +76,8 @@ class model_render_params
 
 	float Depth_scale;
 
+	float Attached_model_draw_distance;
+
 	int Warp_bitmap;
 	float Warp_alpha;
 	vec3d Warp_scale;
@@ -117,6 +119,7 @@ public:
 	void set_object_number(int num);
 	void set_detail_level_lock(int detail_level_lock);
 	void set_depth_scale(float scale);
+	void set_attached_model_draw_distance(float distance);
 	void set_warp_params(int bitmap, float alpha, const vec3d &scale);
 	void set_color(const color &clr);
 	void set_color(int r, int g, int b);
@@ -143,6 +146,7 @@ public:
 	int get_object_number() const;
 	int get_detail_level_lock() const;
 	float get_depth_scale() const;
+	float get_attached_model_draw_distance() const;
 	int get_warp_bitmap() const;
 	float get_warp_alpha() const;
 	const vec3d& get_warp_scale() const;
@@ -308,7 +312,7 @@ bool model_render_check_detail_box(const vec3d* view_pos, const polymodel* pm, i
 void model_render_arc(const vec3d* v1, const vec3d* v2, const SCP_vector<vec3d> *persistent_arc_points, const color* primary, const color* secondary, float arc_width, ubyte depth_limit);
 void model_render_insignias(const insignia_draw_data* insignia);
 void model_render_set_wireframe_color(const color* clr);
-float model_render_determine_depth(int obj_num, int model_num, const matrix* orient, const vec3d* pos, int detail_level_locked);
+float model_render_determine_depth(int obj_num, int model_num, const matrix* orient, const vec3d* pos, int detail_level_locked, const vec3d* eye_pos = nullptr);
 int model_render_determine_detail(float depth, int model_num, int detail_level_locked);
 bool render_tech_model(tech_render_type model_type, int x1, int y1, int x2, int y2, float zoom, bool lighting, int class_idx, const matrix* orient, const SCP_string& pof_filename = "", float closeup_zoom = 0, const vec3d* closeup_pos = &vmd_zero_vector, const SCP_string& tcolor = "", const SCP_vector<SCP_string>& destroyed_subsystems = SCP_vector<SCP_string>());
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -21864,7 +21864,23 @@ void ship_render_batch_thrusters(object *obj)
 	}
 }
 
-void ship_render_weapon_models(model_render_params *ship_render_info, model_draw_list *scene, object *obj, uint64_t render_flags)
+// Computes the position and orientation, in the ship model's frame, at which to render an
+// external weapon model on slot `slot` of weapon bank `bank`.  reload_slide_back is the
+// distance a partially reloaded missile is slid backward along the bank's -Z axis; pass
+// 0.0f for primaries and launcher-style secondaries, which don't slide.
+void ship_get_weapon_model_slot_transform(const w_bank *bank, int slot, float reload_slide_back, vec3d *outpnt, matrix *outorient)
+{
+	// "Bank" the external model by the angle offset
+	angles angs = { 0.0f, bank->external_model_angle_offset[slot], 0.0f };
+	vm_angles_2_matrix(outorient, &angs);
+
+	*outpnt = bank->pnt[slot];
+
+	if (reload_slide_back > 0.0f)
+		vm_vec_scale_add2(outpnt, &vmd_z_vector, -reload_slide_back);
+}
+
+void ship_render_weapon_models(model_render_params *ship_render_info, model_draw_list *scene, object *obj)
 {
 	int num = obj->instance;
 	ship *shipp = &Ships[num];
@@ -21881,8 +21897,7 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 	scene->push_transform(&obj->pos, &obj->orient);
 
 	auto ship_render_flags = ship_render_info->get_model_flags();
-	render_flags &= ~MR_SHOW_THRUSTERS;
-	ship_render_info->set_flags(render_flags);
+	ship_render_info->set_flags(ship_render_flags & ~MR_SHOW_THRUSTERS);
 
 	//primary weapons
 	for ( i = 0; i < swp->num_primary_banks; i++ ) {
@@ -21932,61 +21947,53 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 		}
 
 		for ( k = 0; k < bank->num_slots; k++ ) {
-			// "Bank" the external model by the angle offset
-			angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
-			matrix model_orient;
-			vm_angles_2_matrix(&model_orient, &angs);
+			vec3d slot_pnt;
+			matrix slot_orient;
+			ship_get_weapon_model_slot_transform(bank, k, 0.0f, &slot_pnt, &slot_orient);
 
-			model_render_queue(ship_render_info, scene, wip->external_model_num, swp->primary_bank_external_model_instance[i], &model_orient, &bank->pnt[k]);
+			model_render_queue(ship_render_info, scene, wip->external_model_num, swp->primary_bank_external_model_instance[i], &slot_orient, &slot_pnt);
 		}
 	}
 
 	//secondary weapons
-	int num_secondaries_rendered = 0;
-	vec3d secondary_weapon_pos;
-
 	for (i = 0; i < swp->num_secondary_banks; i++) {
 		auto wip = &Weapon_info[swp->secondary_bank_weapons[i]];
 
-		if ( wip->external_model_num == -1 || !sip->draw_secondary_models[i] ) {
+		if ( wip->external_model_num < 0 || !sip->draw_secondary_models[i] ) {
 			continue;
 		}
 
 		auto bank = &ship_pm->missile_banks[i];
 
-		if (wip->wi_flags[Weapon::Info_Flags::External_weapon_lnch]) {			
+		if (wip->wi_flags[Weapon::Info_Flags::External_weapon_lnch]) {
 			for(k = 0; k < bank->num_slots; k++) {
-				// "Bank" the external model by the angle offset
-				angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
-				matrix model_orient;
-				vm_angles_2_matrix(&model_orient, &angs);
+				vec3d slot_pnt;
+				matrix slot_orient;
+				ship_get_weapon_model_slot_transform(bank, k, 0.0f, &slot_pnt, &slot_orient);
 
-				model_render_queue(ship_render_info, scene, wip->external_model_num, &model_orient, &bank->pnt[k]);
+				model_render_queue(ship_render_info, scene, wip->external_model_num, &slot_orient, &slot_pnt);
 			}
 		} else {
-			num_secondaries_rendered = 0;
+			auto weapon_pm = model_get(wip->external_model_num);
+			int num_secondaries_rendered = 0;
 
 			for ( k = 0; k < bank->num_slots; k++ ) {
-				secondary_weapon_pos = bank->pnt[k];
-
 				if ( num_secondaries_rendered >= shipp->weapons.secondary_bank_ammo[i] ) {
 					break;
 				}
 
-				if ( shipp->secondary_point_reload_pct.get(i, k) <= 0.0 ) {
+				float reload_pct = shipp->secondary_point_reload_pct.get(i, k);
+				if ( reload_pct <= 0.0f ) {
 					continue;
 				}
 
 				num_secondaries_rendered++;
 
-				vm_vec_scale_add2(&secondary_weapon_pos, &vmd_z_vector, -(1.0f-shipp->secondary_point_reload_pct.get(i, k)) * model_get(wip->external_model_num)->rad);
+				vec3d slot_pnt;
+				matrix slot_orient;
+				ship_get_weapon_model_slot_transform(bank, k, (1.0f - reload_pct) * weapon_pm->rad, &slot_pnt, &slot_orient);
 
-				// "Bank" the external model by the angle offset
-				angles angs = { 0.0f, bank->external_model_angle_offset[k], 0.0f };
-				matrix model_orient;
-				vm_angles_2_matrix(&model_orient, &angs);
-
-				model_render_queue(ship_render_info, scene, wip->external_model_num, &model_orient, &secondary_weapon_pos);
+				model_render_queue(ship_render_info, scene, wip->external_model_num, &slot_orient, &slot_pnt);
 			}
 		}
 	}
@@ -22245,7 +22252,7 @@ void ship_render(object* obj, model_draw_list* scene)
 	render_info.set_debug_flags(debug_flags);
 
 	//draw weapon models
-	ship_render_weapon_models(&render_info, scene, obj, render_flags);
+	ship_render_weapon_models(&render_info, scene, obj);
 
 	render_info.set_object_number(OBJ_INDEX(obj));
 	render_info.set_replacement_textures(pmi->texture_replace);

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -7520,7 +7520,7 @@ void ship_weapon::clear()
         primary_bank_weapons[i] = -1;
 
 		primary_bank_external_model_instance[i] = -1;
-		primary_bank_model_instance_check[i] = false;
+		primary_bank_model_instance_weapon[i] = -1;
 
         next_primary_fire_stamp[i] = timestamp(0);
         last_primary_fire_stamp[i] = timestamp(-1);
@@ -21864,6 +21864,46 @@ void ship_render_batch_thrusters(object *obj)
 	}
 }
 
+// Lazily creates the model instance used to spin the Gun_rotation submodels of the external
+// weapon model in the given primary bank, recreating it if the bank's weapon has changed since
+// the last call (weapons can be swapped mid-mission by SEXPs, scripts, or rearming).  The ideal
+// place to create the instance would be in parse_object_create_sub, but the player can alter
+// the ship loadout after that function runs.
+// Returns the model instance number, or -1 if the bank's weapon doesn't need an instance.
+int ship_get_external_weapon_model_instance(ship_weapon *swp, int bank)
+{
+	int weapon_idx = swp->primary_bank_weapons[bank];
+
+	if (swp->primary_bank_model_instance_weapon[bank] != weapon_idx)
+	{
+		// the weapon changed, so any existing instance belongs to the old weapon's model
+		if (swp->primary_bank_external_model_instance[bank] >= 0)
+		{
+			model_delete_instance(swp->primary_bank_external_model_instance[bank]);
+			swp->primary_bank_external_model_instance[bank] = -1;
+		}
+
+		if (weapon_idx >= 0 && Weapon_info[weapon_idx].external_model_num >= 0)
+		{
+			auto pm = model_get(Weapon_info[weapon_idx].external_model_num);
+
+			// create a model instance only if at least one submodel has gun rotation
+			for (int mn = 0; mn < pm->n_models; mn++)
+			{
+				if (pm->submodel[mn].flags[Model::Submodel_flags::Gun_rotation])
+				{
+					swp->primary_bank_external_model_instance[bank] = model_create_instance(model_objnum_special::OBJNUM_NONE, Weapon_info[weapon_idx].external_model_num);
+					break;
+				}
+			}
+		}
+
+		swp->primary_bank_model_instance_weapon[bank] = weapon_idx;
+	}
+
+	return swp->primary_bank_external_model_instance[bank];
+}
+
 // Computes the position and orientation, in the ship model's frame, at which to render an
 // external weapon model on slot `slot` of weapon bank `bank`.  reload_slide_back is the
 // distance a partially reloaded missile is slid backward along the bank's -Z axis; pass
@@ -21907,31 +21947,13 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 			continue;
 		}
 
-		// Lazily create the model instance here, if we need to.  The ideal place to put this
-		// would be in parse_object_create_sub, but the player can alter the ship loadout
-		// after that function runs.
-		if (!swp->primary_bank_model_instance_check[i])
-		{
-			auto pm = model_get(wip->external_model_num);
-
-			// create a model instance only if at least one submodel has gun rotation
-			for (int mn = 0; mn < pm->n_models; mn++)
-			{
-				if (pm->submodel[mn].flags[Model::Submodel_flags::Gun_rotation])
-				{
-					swp->primary_bank_external_model_instance[i] = model_create_instance(model_objnum_special::OBJNUM_NONE, wip->external_model_num);
-					break;
-				}
-			}
-
-			swp->primary_bank_model_instance_check[i] = true;
-		}
+		int external_model_instance = ship_get_external_weapon_model_instance(swp, i);
 
 		auto bank = &ship_pm->gun_banks[i];
 
-		if ( swp->primary_bank_external_model_instance[i] >= 0 )
+		if ( external_model_instance >= 0 )
 		{
-			auto pmi = model_get_instance(swp->primary_bank_external_model_instance[i]);
+			auto pmi = model_get_instance(external_model_instance);
 			auto pm = model_get(pmi->model_num);
 
 			// spin the submodels by the gun rotation
@@ -21951,7 +21973,7 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 			matrix slot_orient;
 			ship_get_weapon_model_slot_transform(bank, k, 0.0f, &slot_pnt, &slot_orient);
 
-			model_render_queue(ship_render_info, scene, wip->external_model_num, swp->primary_bank_external_model_instance[i], &slot_orient, &slot_pnt);
+			model_render_queue(ship_render_info, scene, wip->external_model_num, external_model_instance, &slot_orient, &slot_pnt);
 		}
 	}
 

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -21939,6 +21939,10 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 	auto ship_render_flags = ship_render_info->get_model_flags();
 	ship_render_info->set_flags(ship_render_flags & ~MR_SHOW_THRUSTERS);
 
+	// weapon models aren't rendered beyond this distance, and they choose their detail
+	// level based on their own position rather than the ship's
+	ship_render_info->set_attached_model_draw_distance(sip->weapon_model_draw_distance);
+
 	//primary weapons
 	for ( i = 0; i < swp->num_primary_banks; i++ ) {
 		auto wip = &Weapon_info[swp->primary_bank_weapons[i]];
@@ -22021,6 +22025,7 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 	}
 
 	ship_render_info->set_flags(ship_render_flags);
+	ship_render_info->set_attached_model_draw_distance(-1.0f);
 
 	scene->pop_transform();
 }

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -12980,17 +12980,19 @@ static int ship_stop_fire_primary_bank(object * obj, int bank_to_stop)
 
 	shipp = &Ships[obj->instance];
 	swp = &shipp->weapons;
-	
-	if(shipp->primary_rotate_rate[bank_to_stop] > 0.0f)
-		shipp->primary_rotate_rate[bank_to_stop] -= Weapon_info[swp->primary_bank_weapons[bank_to_stop]].weapon_submodel_rotate_accell*flFrametime;
-	if(shipp->primary_rotate_rate[bank_to_stop] < 0.0f)
-		shipp->primary_rotate_rate[bank_to_stop] = 0.0f;
-	if(Ship_info[shipp->ship_info_index].draw_primary_models[bank_to_stop]){
-		shipp->primary_rotate_ang[bank_to_stop] += shipp->primary_rotate_rate[bank_to_stop]*flFrametime;
-		if(shipp->primary_rotate_ang[bank_to_stop] > PI2)
-			shipp->primary_rotate_ang[bank_to_stop] -= PI2;
-		if(shipp->primary_rotate_ang[bank_to_stop] < 0.0f)
-			shipp->primary_rotate_ang[bank_to_stop] += PI2;
+
+	if(swp->primary_bank_weapons[bank_to_stop] >= 0){
+		if(shipp->primary_rotate_rate[bank_to_stop] > 0.0f)
+			shipp->primary_rotate_rate[bank_to_stop] -= Weapon_info[swp->primary_bank_weapons[bank_to_stop]].weapon_submodel_rotate_accell*flFrametime;
+		if(shipp->primary_rotate_rate[bank_to_stop] < 0.0f)
+			shipp->primary_rotate_rate[bank_to_stop] = 0.0f;
+		if(Ship_info[shipp->ship_info_index].draw_primary_models[bank_to_stop]){
+			shipp->primary_rotate_ang[bank_to_stop] += shipp->primary_rotate_rate[bank_to_stop]*flFrametime;
+			if(shipp->primary_rotate_ang[bank_to_stop] > PI2)
+				shipp->primary_rotate_ang[bank_to_stop] -= PI2;
+			if(shipp->primary_rotate_ang[bank_to_stop] < 0.0f)
+				shipp->primary_rotate_ang[bank_to_stop] += PI2;
+		}
 	}
 	
 	if(shipp->was_firing_last_frame[bank_to_stop] == 0)
@@ -21945,6 +21947,9 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 
 	//primary weapons
 	for ( i = 0; i < swp->num_primary_banks; i++ ) {
+		if ( swp->primary_bank_weapons[i] < 0 ) {
+			continue;
+		}
 		auto wip = &Weapon_info[swp->primary_bank_weapons[i]];
 
 		if ( wip->external_model_num < 0 || !sip->draw_primary_models[i] ) {
@@ -21983,6 +21988,9 @@ void ship_render_weapon_models(model_render_params *ship_render_info, model_draw
 
 	//secondary weapons
 	for (i = 0; i < swp->num_secondary_banks; i++) {
+		if ( swp->secondary_bank_weapons[i] < 0 ) {
+			continue;
+		}
 		auto wip = &Weapon_info[swp->secondary_bank_weapons[i]];
 
 		if ( wip->external_model_num < 0 || !sip->draw_secondary_models[i] ) {

--- a/code/ship/ship.cpp
+++ b/code/ship/ship.cpp
@@ -13121,6 +13121,40 @@ bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj)
 }
 
 
+// Gets the offset, relative to the ship's firing point, of the firing point within an external
+// weapon model that the next shot should be fired from.  Handles the "chain external model fps"
+// weapon flag: chained weapons cycle through the external model's firing points using the bank's
+// chain counter; non-chained weapons use the sub_shot index directly.
+//
+// fp_counter_index indexes swp->external_model_fp_counter[]: the bank number for primaries, or
+// the bank number plus MAX_SHIP_PRIMARY_BANKS for secondaries.  advance_counter should be true
+// when actually firing a shot, and false for queries such as the AI's line-of-sight check.
+vec3d ship_get_external_model_fp_offset(ship_weapon *swp, const weapon_info *wip, const polymodel *weapon_model, int fp_counter_index, bool advance_counter, int sub_shot)
+{
+	if (weapon_model == nullptr || weapon_model->n_guns < 1 || weapon_model->gun_banks[0].num_slots < 1)
+		return vmd_zero_vector;
+
+	auto &bank = weapon_model->gun_banks[0];
+
+	if (wip->wi_flags[Weapon::Info_Flags::External_weapon_fp])
+	{
+		int &fp_counter = swp->external_model_fp_counter[fp_counter_index];
+
+		// the counter cycles through the firing points of the model's first gun bank
+		if (fp_counter < 0 || fp_counter >= bank.num_slots)
+			fp_counter = 0;
+
+		int fp = fp_counter;
+		if (advance_counter)
+			fp_counter++;
+
+		return bank.pnt[fp];
+	}
+
+	Assertion(sub_shot >= 0 && sub_shot < bank.num_slots, "sub_shot %d is out of range for the external model of weapon %s, which has %d firing points", sub_shot, wip->name, bank.num_slots);
+	return bank.pnt[sub_shot];
+}
+
 // fires a primary weapon for the given object.  It also handles multiplayer cases.
 // in multiplayer, the starting network signature, and number of banks fired are sent
 // to all the clients in the game. All the info is passed to send_primary at the end of
@@ -13796,28 +13830,19 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 					}
 
 					for (int j = 0; j < shot_count; j++) {
-						if (weapon_model)
-							if ((weapon_model->n_guns <= swp->external_model_fp_counter[bank_to_fire]) || (swp->external_model_fp_counter[bank_to_fire] < 0))
-								swp->external_model_fp_counter[bank_to_fire] = 0;
-
 						int sub_shots = 1;
-						// Use 0 instead of bank_to_fire as index when checking the number of external weapon model firingpoints
-						if (weapon_model && weapon_model->n_guns)
-							if (!(winfo_p->wi_flags[Weapon::Info_Flags::External_weapon_fp]))
-								sub_shots = weapon_model->gun_banks[0].num_slots;
+						// weapons that don't chain their external model firing points fire from all of them at once
+						// (note that external model firing points always come from the model's first gun bank)
+						if (weapon_model && weapon_model->n_guns && !(winfo_p->wi_flags[Weapon::Info_Flags::External_weapon_fp]))
+							sub_shots = weapon_model->gun_banks[0].num_slots;
 
 						for(int s = 0; s<sub_shots; s++){
 							pnt = pm->gun_banks[bank_to_fire].pnt[pt];
 							vec3d dir;
 							dir = pm->gun_banks[bank_to_fire].norm[pt];
-							// Use 0 instead of bank_to_fire as index to external weapon model firingpoints 
-							if (weapon_model && weapon_model->n_guns) {
-								if (winfo_p->wi_flags[Weapon::Info_Flags::External_weapon_fp]) {
-									vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[swp->external_model_fp_counter[bank_to_fire]]);
-								} else {
-									vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[s]);
-								}
-							}
+
+							vec3d external_fp_offset = ship_get_external_model_fp_offset(swp, winfo_p, weapon_model, bank_to_fire, true, s);
+							vm_vec_add2(&pnt, &external_fp_offset);
 
 							vm_vec_unrotate(&gun_point, &pnt, &obj->orient);
 							vm_vec_add(&firing_pos, &gun_point, &obj->pos);
@@ -13953,7 +13978,6 @@ int ship_fire_primary(object * obj, int force, bool rollback_shot)
 								multi_ship_record_add_rollback_wep(weapon_objnum);
 							}
 						}
-						swp->external_model_fp_counter[bank_to_fire]++;
 					}
 				}
 
@@ -14673,23 +14697,14 @@ int ship_fire_secondary( object *obj, int allow_swarm, bool rollback_shot )
 			vec3d dir;
 			dir = pm->missile_banks[bank].norm[pnt_index++];
 
-			polymodel *weapon_model = NULL;
+			polymodel *weapon_model = nullptr;
 			if(wip->external_model_num >= 0){
 				weapon_model = model_get(wip->external_model_num);
 			}
 
-			if (weapon_model && weapon_model->n_guns) {
-				int external_bank = bank + MAX_SHIP_PRIMARY_BANKS;
-				if (wip->wi_flags[Weapon::Info_Flags::External_weapon_fp]) {
-					if ((weapon_model->n_guns <= swp->external_model_fp_counter[external_bank]) || (swp->external_model_fp_counter[external_bank] < 0))
-						swp->external_model_fp_counter[external_bank] = 0;
-					vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[swp->external_model_fp_counter[external_bank]]);
-					swp->external_model_fp_counter[external_bank]++;
-				} else {
-					// make it use the 0 index slot
-					vm_vec_add2(&pnt, &weapon_model->gun_banks[0].pnt[0]);
-				}
-			}
+			// chained weapons cycle through the external model's firing points; other weapons use the 0 index slot
+			vec3d external_fp_offset = ship_get_external_model_fp_offset(swp, wip, weapon_model, bank + MAX_SHIP_PRIMARY_BANKS, true);
+			vm_vec_add2(&pnt, &external_fp_offset);
 			vm_vec_unrotate(&missile_point, &pnt, &obj->orient);
 			vm_vec_add(&firing_pos, &missile_point, &obj->pos);
 

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1734,6 +1734,7 @@ extern bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj);
 extern int ship_stop_fire_primary(object * obj);
 extern int ship_fire_primary(object * objp, int force = 0, bool rollback_shot = false);
 extern vec3d ship_get_external_model_fp_offset(ship_weapon *swp, const weapon_info *wip, const polymodel *weapon_model, int fp_counter_index, bool advance_counter, int sub_shot = 0);
+extern void ship_get_weapon_model_slot_transform(const w_bank *bank, int slot, float reload_slide_back, vec3d *outpnt, matrix *outorient);
 extern int ship_fire_secondary(object * objp, int allow_swarm = 0, bool rollback_shot = false );
 bool ship_start_secondary_fire(object* objp);
 bool ship_stop_secondary_fire(object* objp);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -102,7 +102,7 @@ public:
 	int secondary_bank_weapons[MAX_SHIP_SECONDARY_BANKS];		// Weapon_info[] index for the weapon in the bank
 
 	int primary_bank_external_model_instance[MAX_SHIP_PRIMARY_BANKS];
-	bool primary_bank_model_instance_check[MAX_SHIP_PRIMARY_BANKS];
+	int primary_bank_model_instance_weapon[MAX_SHIP_PRIMARY_BANKS];	// the weapon the model instance was created for, or -1 if not yet checked
 
 	int current_primary_bank;			// currently selected primary bank
 	int current_secondary_bank;		// currently selected secondary bank
@@ -1735,6 +1735,7 @@ extern int ship_stop_fire_primary(object * obj);
 extern int ship_fire_primary(object * objp, int force = 0, bool rollback_shot = false);
 extern vec3d ship_get_external_model_fp_offset(ship_weapon *swp, const weapon_info *wip, const polymodel *weapon_model, int fp_counter_index, bool advance_counter, int sub_shot = 0);
 extern void ship_get_weapon_model_slot_transform(const w_bank *bank, int slot, float reload_slide_back, vec3d *outpnt, matrix *outorient);
+extern int ship_get_external_weapon_model_instance(ship_weapon *swp, int bank);
 extern int ship_fire_secondary(object * objp, int allow_swarm = 0, bool rollback_shot = false );
 bool ship_start_secondary_fire(object* objp);
 bool ship_stop_secondary_fire(object* objp);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -1733,6 +1733,7 @@ extern void ship_actually_depart(int shipnum, int method = SHIP_DEPARTED_WARP);
 extern bool in_autoaim_fov(ship *shipp, int bank_to_fire, object *obj);
 extern int ship_stop_fire_primary(object * obj);
 extern int ship_fire_primary(object * objp, int force = 0, bool rollback_shot = false);
+extern vec3d ship_get_external_model_fp_offset(ship_weapon *swp, const weapon_info *wip, const polymodel *weapon_model, int fp_counter_index, bool advance_counter, int sub_shot = 0);
 extern int ship_fire_secondary(object * objp, int allow_swarm = 0, bool rollback_shot = false );
 bool ship_start_secondary_fire(object* objp);
 bool ship_stop_secondary_fire(object* objp);

--- a/code/weapon/weapons.cpp
+++ b/code/weapon/weapons.cpp
@@ -8787,6 +8787,95 @@ void weapon_mark_as_used(int weapon_type)
 	}
 }
 
+/**
+ * Pages in the model(s) and, optionally, all graphics for a single weapon.
+ *
+ * @param wip           Pointer to the weapon_info to page in.
+ * @param load_graphics When true, page in all textures/bitmaps (POF texture maps, laser
+ *                      bitmaps, trail/beam/thruster/decal graphics).  When false only the
+ *                      model geometry is loaded; non-model graphics will load lazily on
+ *                      first render (used by weapons_page_in_cheats).
+ */
+static void weapon_page_in_one(weapon_info *wip, bool load_graphics)
+{
+	wip->wi_flags.remove(Weapon::Info_Flags::Thruster);		// Assume no thrusters
+
+	switch (wip->render_type)
+	{
+		case WRT_POF:
+		{
+			wip->model_num = model_load(wip->pofbitmap_name);
+			polymodel *pm = model_get(wip->model_num);
+
+			// If it has a model, and the model pof has thrusters, then set
+			// the flags
+			if (pm->n_thrusters > 0)
+				wip->wi_flags.set(Weapon::Info_Flags::Thruster);
+
+			if (load_graphics)
+				for (int j = 0; j < pm->n_textures; j++)
+					pm->maps[j].PageIn();
+
+			break;
+		}
+
+		case WRT_LASER:
+		{
+			if (load_graphics)
+			{
+				bm_page_in_texture(wip->laser_bitmap.first_frame);
+				bm_page_in_texture(wip->laser_glow_bitmap.first_frame);
+				bm_page_in_texture(wip->laser_headon_bitmap.first_frame);
+				bm_page_in_texture(wip->laser_glow_headon_bitmap.first_frame);
+			}
+
+			break;
+		}
+
+		case WRT_NONE:
+			break;
+
+		default:
+			UNREACHABLE("Weapon %s has an invalid rendering type %d", wip->name, wip->render_type);
+	}
+
+	wip->external_model_num = -1;
+
+	if (VALID_FNAME(wip->external_model_name))
+		wip->external_model_num = model_load(wip->external_model_name);
+
+	if (wip->external_model_num == -1)
+		wip->external_model_num = wip->model_num;
+
+
+	//Load shockwaves
+	shockwave_create_info_load(&wip->shockwave);
+	shockwave_create_info_load(&wip->dinky_shockwave);
+
+	if (load_graphics)
+	{
+		// trail bitmaps
+		if ((wip->wi_flags[Weapon::Info_Flags::Trail]) && (wip->tr_info.texture.bitmap_id > -1))
+			bm_page_in_texture(wip->tr_info.texture.bitmap_id);
+
+		// if this is a beam weapon, page in its stuff
+		if (wip->wi_flags[Weapon::Info_Flags::Beam])
+		{
+			// all beam sections
+			for (int idx = 0; idx < wip->b_info.beam_num_sections; idx++)
+				bm_page_in_texture(wip->b_info.sections[idx].texture.first_frame);
+
+			// muzzle glow
+			bm_page_in_texture(wip->b_info.beam_glow.first_frame);
+		}
+
+		bm_page_in_texture(wip->thruster_flame.first_frame);
+		bm_page_in_texture(wip->thruster_glow.first_frame);
+
+		decals::pageInDecal(wip->impact_decal);
+	}
+}
+
 void weapons_page_in()
 {
 	TRACE_SCOPE(tracing::WeaponPageIn);
@@ -8833,75 +8922,7 @@ void weapons_page_in()
 
 		weapon_load_bitmaps(i);
 
-		weapon_info *wip = &Weapon_info[i];
-
-        wip->wi_flags.remove(Weapon::Info_Flags::Thruster);		// Assume no thrusters
-		
-		switch (wip->render_type)
-		{
-			case WRT_POF:
-			{
-				wip->model_num = model_load( wip->pofbitmap_name );
-
-				polymodel *pm = model_get( wip->model_num );
-
-				// If it has a model, and the model pof has thrusters, then set
-				// the flags
-				if (pm->n_thrusters > 0) {
-                    wip->wi_flags.set(Weapon::Info_Flags::Thruster);
-				}
-		
-				for (j = 0; j < pm->n_textures; j++)
-					pm->maps[j].PageIn();
-
-				break;
-			}
-
-			case WRT_LASER:
-			{
-				bm_page_in_texture( wip->laser_bitmap.first_frame );
-				bm_page_in_texture( wip->laser_glow_bitmap.first_frame );
-				bm_page_in_texture (wip->laser_headon_bitmap.first_frame );
-				bm_page_in_texture (wip->laser_glow_headon_bitmap.first_frame);
-
-				break;
-			}
-
-			default:
-				Assertion(wip->render_type != WRT_POF && wip->render_type != WRT_LASER, "Weapon %s does not have a valid rendering type. Type passed: %d\n", wip->name, wip->render_type);	// Invalid weapon rendering type.
-		}
-
-		wip->external_model_num = -1;
-
-		if (VALID_FNAME(wip->external_model_name))
-			wip->external_model_num = model_load( wip->external_model_name );
-
-		if (wip->external_model_num == -1)
-			wip->external_model_num = wip->model_num;
-
-
-		//Load shockwaves
-		shockwave_create_info_load(&wip->shockwave);
-		shockwave_create_info_load(&wip->dinky_shockwave);
-
-		// trail bitmaps
-		if ( (wip->wi_flags[Weapon::Info_Flags::Trail]) && (wip->tr_info.texture.bitmap_id > -1) )
-			bm_page_in_texture( wip->tr_info.texture.bitmap_id );
-
-		// if this is a beam weapon, page in its stuff
-		if (wip->wi_flags[Weapon::Info_Flags::Beam]) {
-			// all beam sections
-			for (idx = 0; idx < wip->b_info.beam_num_sections; idx++)
-				bm_page_in_texture(wip->b_info.sections[idx].texture.first_frame);
-
-			// muzzle glow
-			bm_page_in_texture(wip->b_info.beam_glow.first_frame);
-		}
-
-		bm_page_in_texture(wip->thruster_flame.first_frame);
-		bm_page_in_texture(wip->thruster_glow.first_frame);
-
-		decals::pageInDecal(wip->impact_decal);
+		weapon_page_in_one(&Weapon_info[i], true);
 	}
 }
 
@@ -8930,34 +8951,7 @@ void weapons_page_in_cheats()
 
 		weapon_load_bitmaps(i);
 
-		weapon_info *wip = &Weapon_info[i];
-		
-        wip->wi_flags.remove(Weapon::Info_Flags::Thruster);		// Assume no thrusters
-
-		if ( wip->render_type == WRT_POF ) {
-			wip->model_num = model_load( wip->pofbitmap_name );
-				
-			polymodel *pm = model_get( wip->model_num );
-				
-			// If it has a model, and the model pof has thrusters, then set
-			// the flags
-			if ( pm->n_thrusters > 0 )	{
-                wip->wi_flags.set(Weapon::Info_Flags::Thruster);
-			}
-		}
-		
-		wip->external_model_num = -1;
-		
-		if (VALID_FNAME(wip->external_model_name))
-			wip->external_model_num = model_load( wip->external_model_name );
-
-		if (wip->external_model_num == -1)
-			wip->external_model_num = wip->model_num;
-		
-		
-		//Load shockwaves
-		shockwave_create_info_load(&wip->shockwave);
-		shockwave_create_info_load(&wip->dinky_shockwave);
+		weapon_page_in_one(&Weapon_info[i], false);
 
 		used_weapons[i]++;
 	}
@@ -9006,76 +9000,7 @@ bool weapon_page_in(int weapon_type)
 		// Page in bitmaps for the weapon
 		weapon_load_bitmaps(page_in_weapons.at(k));
 
-		weapon_info *wip = &Weapon_info[page_in_weapons.at(k)];
-
-		wip->wi_flags.remove(Weapon::Info_Flags::Thruster);		// Assume no thrusters
-
-		switch (wip->render_type)
-		{
-		case WRT_POF:
-		{
-			wip->model_num = model_load(wip->pofbitmap_name);
-
-			polymodel *pm = model_get(wip->model_num);
-
-			// If it has a model, and the model pof has thrusters, then set
-			// the flags
-			if (pm->n_thrusters > 0) {
-				wip->wi_flags.set(Weapon::Info_Flags::Thruster);
-			}
-
-			for (int j = 0; j < pm->n_textures; j++)
-				pm->maps[j].PageIn();
-
-			break;
-		}
-
-		case WRT_LASER:
-		{
-			bm_page_in_texture(wip->laser_bitmap.first_frame);
-			bm_page_in_texture(wip->laser_glow_bitmap.first_frame);
-			bm_page_in_texture(wip->laser_headon_bitmap.first_frame);
-			bm_page_in_texture(wip->laser_glow_headon_bitmap.first_frame);
-
-			break;
-		}
-
-		default:
-			Assertion(wip->render_type != WRT_POF && wip->render_type != WRT_LASER, "Weapon %s does not have a valid rendering type. Type passed: %d\n", wip->name, wip->render_type);	// Invalid weapon rendering type.
-		}
-
-		wip->external_model_num = -1;
-
-		if (VALID_FNAME(wip->external_model_name))
-			wip->external_model_num = model_load(wip->external_model_name);
-
-		if (wip->external_model_num == -1)
-			wip->external_model_num = wip->model_num;
-
-
-		//Load shockwaves
-		shockwave_create_info_load(&wip->shockwave);
-		shockwave_create_info_load(&wip->dinky_shockwave);
-
-		// trail bitmaps
-		if ((wip->wi_flags[Weapon::Info_Flags::Trail]) && (wip->tr_info.texture.bitmap_id > -1))
-			bm_page_in_texture(wip->tr_info.texture.bitmap_id);
-
-		// if this is a beam weapon, page in its stuff
-		if (wip->wi_flags[Weapon::Info_Flags::Beam]) {
-			// all beam sections
-			for (int idx = 0; idx < wip->b_info.beam_num_sections; idx++)
-				bm_page_in_texture(wip->b_info.sections[idx].texture.first_frame);
-
-			// muzzle glow
-			bm_page_in_texture(wip->b_info.beam_glow.first_frame);
-		}
-
-		bm_page_in_texture(wip->thruster_flame.first_frame);
-		bm_page_in_texture(wip->thruster_glow.first_frame);
-
-		// Page in decal bitmaps
-		decals::pageInDecal(wip->impact_decal);
+		weapon_page_in_one(&Weapon_info[page_in_weapons.at(k)], true);
 
 		used_weapons[page_in_weapons.at(k)]++;	// Ensures weapon can be counted as used
 	}


### PR DESCRIPTION
This is a cleanup pass over the external weapon model code (`$Show Primary/Secondary Models:`), consolidating duplicated logic and fixing the bugs that were hiding in the copies.

### Consolidations

- **Weapon page-in** — `weapons_page_in()`, `weapons_page_in_cheats()`, and `weapon_page_in()` each duplicated the same ~60-line per-weapon block (model load, thruster flag, external model load, shockwaves, graphics paging). Extracted into `weapon_page_in_one()`; the cheats variant passes `load_graphics = false` to preserve its model-only behavior.
- **Firing point selection** — the "offset the shot by the external model's firing points" logic was copied in `ship_fire_primary()`, `ship_fire_secondary()`, and the AI line-of-sight check. Now shared as `ship_get_external_model_fp_offset()`.
- **Render slot placement** — the per-slot math (angle-offset yaw, missile reload slide-back) was duplicated four times across `ship_render_weapon_models()` and `HudGaugeHardpoints::render()`. Now shared as `ship_get_weapon_model_slot_transform()`.

### Bug fixes

- **"chain external model fps" never chained.** All three copies of the firing point logic reset the chain counter against `n_guns` (the number of gun *banks*) instead of the number of firing points in bank 0. For the typical one-bank model the counter reset after every shot, so chaining never advanced; models with several banks could read past the end of the point array.
- **The AI line-of-sight check advanced the chain counter**, even though it's only a query, desyncing it from the shots actually fired.
- **Gatling barrel-spin instances went stale after a mid-mission weapon swap.** The lazily created model instance was guarded by a once-per-bank flag that nothing reset, so after `set-primary-weapon`, a script swap, or a rearm-precedence swap, the old weapon's instance leaked and the new weapon's barrels never spun. The instance is now keyed to the weapon it was created for and recreated on change (`ship_get_external_weapon_model_instance()`), which self-heals after every swap path.
- **`$Weapon Model Draw Distance:` has been dead for years** — nothing set `MR_ATTACHED_MODEL` since 1ef7688fa1. The distance is now carried in `model_render_params` and enforced again. The old check also computed depth as if the weapon model's ship-local position were in world space; depth is now measured from the eye position in the parent's frame, which additionally fixes attached weapon models choosing their LOD from a garbage distance. `MR_ATTACHED_MODEL` is removed (nothing else referenced it).
- **Hardpoints gauge misplaced launcher models** — the `external model launcher` branch computed the view-rotated position but rendered at the untransformed local point.
- **Never-firing assertion** — the invalid-render-type assertion in the page-in code was a tautology inside its `default` case; it now asserts `render_type == WRT_NONE`.
- **Empty-bank hardening** — the render paths and `ship_stop_fire_primary_bank()` indexed `Weapon_info[]` without checking for an empty bank (-1), unlike other bank-iterating code.

### Notes for modders

- Weapons with "chain external model fps" will now actually cycle through the external model's firing points; previously every shot came from point 0.
- `$Weapon Model Draw Distance:` (default 200) is enforced again, and attached weapon models now LOD correctly with distance — missions far from the world origin previously got worst-case LODs regardless of camera distance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
