### PR TITLE
Add intermediate framebuffer for gamma correction to prevent flickering

### DIFF
--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -121,7 +121,13 @@ void gr_opengl_flip()
 	if (Cmdline_window_res) {
 		GL_state.PopFramebufferState();
 
-		glViewport(0, 0, Cmdline_window_res->first, Cmdline_window_res->second);
+		// Gamma-correct Back_texture into an offscreen scratch texture. This is an FBO -> FBO
+		// draw, the same class of operation as every other post-process pass. Presenting straight
+		// into the window-system default framebuffer from a shader draw that samples a
+		// just-rendered texture caused flicker on some drivers, so the hand-off to the screen
+		// always goes through glBlitFramebuffer instead.
+		GL_state.BindFrameBuffer(GammaBlit_framebuffer);
+		glViewport(0, 0, gr_screen.max_w, gr_screen.max_h);
 
 		opengl_shader_set_current(gr_opengl_maybe_create_shader(SDR_TYPE_GAMMA_BLIT, 0));
 
@@ -137,6 +143,16 @@ void gr_opengl_flip()
 			});
 
 		opengl_draw_full_screen_textured(0.0f, 0.0f, 1.0f, 1.0f);
+
+		GL_state.BindFrameBuffer(0, GL_DRAW_FRAMEBUFFER);
+		GL_state.BindFrameBuffer(GammaBlit_framebuffer, GL_READ_FRAMEBUFFER);
+
+		glReadBuffer(GL_COLOR_ATTACHMENT0);
+		glDrawBuffer(GL_BACK);
+		glBlitFramebuffer(0, 0, gr_screen.max_w, gr_screen.max_h, 0, 0, Cmdline_window_res->first, Cmdline_window_res->second, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+		glDrawBuffer(GL_NONE);
+
+		GL_state.BindFrameBuffer(0, GL_READ_FRAMEBUFFER);
 	}
 
 	if (Cmdline_gl_finish)

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -136,6 +136,11 @@ void gr_opengl_flip()
 
 		GL_state.SetAlphaBlendMode(gr_alpha_blend::ALPHA_BLEND_NONE);
 		GL_state.SetZbufferType(ZBUFFER_TYPE_NONE);
+		// The last material of the frame may have left color writes disabled (e.g. a masked
+		// model pass in the briefing map render). The old blit-only present ignored the color
+		// mask, but this is a regular draw and needs color writes and no stencil to take effect.
+		GL_state.ColorMask(true, true, true, true);
+		GL_state.StencilTest(GL_FALSE);
 
 		opengl_set_generic_uniform_data<graphics::generic_data::gamma_blit_data>(
 			[](graphics::generic_data::gamma_blit_data* data) {

--- a/code/graphics/opengl/gropengl.cpp
+++ b/code/graphics/opengl/gropengl.cpp
@@ -121,36 +121,45 @@ void gr_opengl_flip()
 	if (Cmdline_window_res) {
 		GL_state.PopFramebufferState();
 
-		// Gamma-correct Back_texture into an offscreen scratch texture. This is an FBO -> FBO
-		// draw, the same class of operation as every other post-process pass. Presenting straight
-		// into the window-system default framebuffer from a shader draw that samples a
-		// just-rendered texture caused flicker on some drivers, so the hand-off to the screen
-		// always goes through glBlitFramebuffer instead.
-		GL_state.BindFrameBuffer(GammaBlit_framebuffer);
-		glViewport(0, 0, gr_screen.max_w, gr_screen.max_h);
+		const float gamma = Cmdline_no_set_gamma ? 1.0f : Gr_gamma;
+		GLuint present_source = Back_framebuffer;
 
-		opengl_shader_set_current(gr_opengl_maybe_create_shader(SDR_TYPE_GAMMA_BLIT, 0));
+		// At gamma 1.0 the correction shader is an identity transform, so skip the extra
+		// fullscreen pass and present Back_framebuffer directly.
+		if (gamma != 1.0f) {
+			// Gamma-correct Back_texture into an offscreen scratch texture. This is an FBO -> FBO
+			// draw, the same class of operation as every other post-process pass. Presenting straight
+			// into the window-system default framebuffer from a shader draw that samples a
+			// just-rendered texture caused flicker on some drivers, so the hand-off to the screen
+			// always goes through glBlitFramebuffer instead.
+			GL_state.BindFrameBuffer(GammaBlit_framebuffer);
+			glViewport(0, 0, gr_screen.max_w, gr_screen.max_h);
 
-		GL_state.Texture.Enable(0, GL_TEXTURE_2D, Back_texture);
-		Current_shader->program->Uniforms.setTextureUniform("tex", 0);
+			opengl_shader_set_current(gr_opengl_maybe_create_shader(SDR_TYPE_GAMMA_BLIT, 0));
 
-		GL_state.SetAlphaBlendMode(gr_alpha_blend::ALPHA_BLEND_NONE);
-		GL_state.SetZbufferType(ZBUFFER_TYPE_NONE);
-		// The last material of the frame may have left color writes disabled (e.g. a masked
-		// model pass in the briefing map render). The old blit-only present ignored the color
-		// mask, but this is a regular draw and needs color writes and no stencil to take effect.
-		GL_state.ColorMask(true, true, true, true);
-		GL_state.StencilTest(GL_FALSE);
+			GL_state.Texture.Enable(0, GL_TEXTURE_2D, Back_texture);
+			Current_shader->program->Uniforms.setTextureUniform("tex", 0);
 
-		opengl_set_generic_uniform_data<graphics::generic_data::gamma_blit_data>(
-			[](graphics::generic_data::gamma_blit_data* data) {
-				data->gamma = Cmdline_no_set_gamma ? 1.f : Gr_gamma;
-			});
+			GL_state.SetAlphaBlendMode(gr_alpha_blend::ALPHA_BLEND_NONE);
+			GL_state.SetZbufferType(ZBUFFER_TYPE_NONE);
+			// The last material of the frame may have left color writes disabled (e.g. a masked
+			// model pass in the briefing map render). The old blit-only present ignored the color
+			// mask, but this is a regular draw and needs color writes and no stencil to take effect.
+			GL_state.ColorMask(true, true, true, true);
+			GL_state.StencilTest(GL_FALSE);
 
-		opengl_draw_full_screen_textured(0.0f, 0.0f, 1.0f, 1.0f);
+			opengl_set_generic_uniform_data<graphics::generic_data::gamma_blit_data>(
+				[gamma](graphics::generic_data::gamma_blit_data* data) {
+					data->gamma = gamma;
+				});
+
+			opengl_draw_full_screen_textured(0.0f, 0.0f, 1.0f, 1.0f);
+
+			present_source = GammaBlit_framebuffer;
+		}
 
 		GL_state.BindFrameBuffer(0, GL_DRAW_FRAMEBUFFER);
-		GL_state.BindFrameBuffer(GammaBlit_framebuffer, GL_READ_FRAMEBUFFER);
+		GL_state.BindFrameBuffer(present_source, GL_READ_FRAMEBUFFER);
 
 		glReadBuffer(GL_COLOR_ATTACHMENT0);
 		glDrawBuffer(GL_BACK);

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -591,22 +591,32 @@ void opengl_setup_scene_textures()
 		GL_state.BindFrameBuffer(GammaBlit_framebuffer);
 		opengl_set_object_label(GL_FRAMEBUFFER, GammaBlit_framebuffer, "Gamma blit framebuffer");
 
-		glGenTextures(1, &GammaBlit_texture);
+		if (Scene_ldr_texture != 0 && Scene_texture_width == gr_screen.max_w && Scene_texture_height == gr_screen.max_h) {
+			// Scene_ldr_texture is dead scratch by flip time: its consumers (tonemap, AA, the final
+			// post pass) all write before reading within gr_opengl_post_process_end(), which completes
+			// before the flip. Reuse it as the gamma pass target instead of allocating another
+			// screen-sized texture. GammaBlit_texture stays 0 so shutdown won't delete it.
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, Scene_ldr_texture, 0);
+		} else {
+			// Scene textures are clamped to GL_max_renderbuffer_size and may not cover the screen;
+			// fall back to a dedicated texture in that case.
+			glGenTextures(1, &GammaBlit_texture);
 
-		GL_state.Texture.SetActiveUnit(0);
-		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
-		GL_state.Texture.Enable(GammaBlit_texture);
+			GL_state.Texture.SetActiveUnit(0);
+			GL_state.Texture.SetTarget(GL_TEXTURE_2D);
+			GL_state.Texture.Enable(GammaBlit_texture);
 
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
 
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, gr_screen.max_w, gr_screen.max_h, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, gr_screen.max_w, gr_screen.max_h, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
 
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, GammaBlit_texture, 0);
-		opengl_set_object_label(GL_TEXTURE, GammaBlit_texture, "Gamma blit texture");
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, GammaBlit_texture, 0);
+			opengl_set_object_label(GL_TEXTURE, GammaBlit_texture, "Gamma blit texture");
+		}
 
 		GL_state.BindFrameBuffer(Back_framebuffer);
 	}

--- a/code/graphics/opengl/gropengldraw.cpp
+++ b/code/graphics/opengl/gropengldraw.cpp
@@ -55,6 +55,9 @@ GLuint Back_framebuffer;
 GLuint Back_texture;
 GLuint Back_depth_texture;
 
+GLuint GammaBlit_framebuffer;
+GLuint GammaBlit_texture;
+
 GLuint Distortion_framebuffer = 0;
 GLuint Distortion_texture[2];
 int Distortion_switch = 0;
@@ -578,6 +581,34 @@ void opengl_setup_scene_textures()
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, Back_depth_texture, 0);
 		gr_zbuffer_set(GR_ZBUFF_FULL);
 		glClear(GL_DEPTH_BUFFER_BIT);
+
+		// Intermediate target for the gamma-correction pass. The gamma pass samples Back_texture and writes
+		// here (an offscreen FBO->FBO draw, same as every other post-process pass); the result is then
+		// presented to the window via glBlitFramebuffer. Some drivers show flicker when a shader draw that
+		// samples a just-rendered texture targets the window-system default framebuffer directly, so the
+		// final presentation step always goes through a blit instead.
+		glGenFramebuffers(1, &GammaBlit_framebuffer);
+		GL_state.BindFrameBuffer(GammaBlit_framebuffer);
+		opengl_set_object_label(GL_FRAMEBUFFER, GammaBlit_framebuffer, "Gamma blit framebuffer");
+
+		glGenTextures(1, &GammaBlit_texture);
+
+		GL_state.Texture.SetActiveUnit(0);
+		GL_state.Texture.SetTarget(GL_TEXTURE_2D);
+		GL_state.Texture.Enable(GammaBlit_texture);
+
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);
+
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, gr_screen.max_w, gr_screen.max_h, 0, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, nullptr);
+
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, GammaBlit_texture, 0);
+		opengl_set_object_label(GL_TEXTURE, GammaBlit_texture, "Gamma blit texture");
+
+		GL_state.BindFrameBuffer(Back_framebuffer);
 	}
 
 	//Setup thruster distortion framebuffer
@@ -695,7 +726,17 @@ void opengl_scene_texture_shutdown()
 		glDeleteFramebuffers(1, &Back_framebuffer);
 		Back_framebuffer = 0;
 	}
-	
+
+	if (GammaBlit_texture) {
+		glDeleteTextures(1, &GammaBlit_texture);
+		GammaBlit_texture = 0;
+	}
+
+	if (GammaBlit_framebuffer) {
+		glDeleteFramebuffers(1, &GammaBlit_framebuffer);
+		GammaBlit_framebuffer = 0;
+	}
+
 	glDeleteTextures(2, Distortion_texture);
 	Distortion_texture[0] = 0;
 	Distortion_texture[1] = 0;

--- a/code/graphics/opengl/gropengldraw.h
+++ b/code/graphics/opengl/gropengldraw.h
@@ -39,6 +39,9 @@ extern GLuint Cockpit_depth_texture;
 extern GLuint Back_framebuffer;
 extern GLuint Back_texture;
 
+extern GLuint GammaBlit_framebuffer;
+extern GLuint GammaBlit_texture;
+
 void gr_opengl_update_distortion();
 
 void gr_opengl_sphere(material *material_def, float rad);


### PR DESCRIPTION
## Summary

`cc63bfa7` ("Gamma by Shader (#7484)") introduced a shader-based gamma-correction pass that samples `Back_texture` (the just-rendered scene) and draws the corrected result directly into the window-system default framebuffer. This caused two SCPUI regressions, both fixed by this PR:

1. **Flicker on state transitions** (e.g. loading screen → briefing): on some drivers, presenting straight from a shader draw that samples a just-rendered texture isn't reliably synchronized with the swap chain, causing the screen to flicker between the outgoing and incoming screen's content for several frames.
2. **Frozen briefing screen** (#7590): the briefing stops visually updating (camera pan, stage text, map) except while hovering a briefing icon.

## Fixes

**Flicker**: Route the gamma pass through an intermediate offscreen framebuffer/texture (`GammaBlit_framebuffer` / `GammaBlit_texture`), matching how every other post-process pass in the renderer works (FBO → FBO draw). The corrected result is then handed to the screen via `glBlitFramebuffer`, the same mechanism used for presentation before the gamma shader was introduced. This keeps gamma correction intact while removing the flicker.

**Freeze**: A masked draw pass inside the briefing map render leaves `glColorMask` fully disabled, and the Rocket UI material path never restores it, so the mask stays disabled into `gr_opengl_flip`. Before `cc63bfa7` this was harmless — presentation was a pure `glBlitFramebuffer`, which ignores the color mask. The gamma pass turned presentation into a regular draw, which respects the mask, so every flip wrote nothing and the screen froze on stale swapchain content while the engine kept rendering correctly underneath. (Hovering a briefing icon appends draws whose materials re-enable color writes, which is why exactly those frames presented correctly.) The flip now neutralizes color mask and stencil state before the gamma draw, matching the blend/depth neutralization already done there. Full analysis in #7590.

## Changes

- `code/graphics/opengl/gropengldraw.cpp` / `.h`: add `GammaBlit_framebuffer`, created alongside the existing `Back_framebuffer` in `opengl_setup_scene_textures()` and torn down in `opengl_scene_texture_shutdown()`. It normally reuses `Scene_ldr_texture` as its color attachment (dead scratch by flip time — all its consumers write before reading within `gr_opengl_post_process_end()`), avoiding a new screen-sized allocation; a dedicated `GammaBlit_texture` is only allocated in the edge case where the scene textures were clamped to `GL_max_renderbuffer_size`.
- `code/graphics/opengl/gropengl.cpp`: `gr_opengl_flip()` now draws the gamma-correction shader into `GammaBlit_framebuffer` (sampling `Back_texture` as before), then presents via `glBlitFramebuffer` into `GL_BACK` instead of drawing directly to the default framebuffer; it also resets color mask and stencil state before the gamma draw. When the effective gamma is 1.0 the shader pass is an identity transform and is skipped entirely, blitting `Back_framebuffer` straight to `GL_BACK`.

## Testing

- Reproduced the flicker on loading screen → briefing and other state transitions before the fix; verified flicker-free transitions after, with gamma correction still visibly applied (gamma slider in options still affects brightness).
- Reproduced the briefing freeze and root-caused it with per-frame GL state/pixel probes (see #7590); verified after the fix that camera pans, stage text, and map animations update normally without hovering.
- Bisected to confirm `cc63bfa7` is the sole origin of both regressions; confirmed neither occurs on its parent commit.

Fixes #7590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

