### PR TITLE
fix compile error in shadow shader

### DIFF
--- a/code/def_files/data/effects/shadows.sdr
+++ b/code/def_files/data/effects/shadows.sdr
@@ -48,7 +48,7 @@ float samplePoissonPCSS(sampler2DArrayShadow shadow_map, vec4 shadowUV, float ma
 	for (int i=0; i<SAMPLES_PCSS; i++) {
 	    vec4 uv = shadowUV;
 	    uv.xy += poissonDisc[i] * maxUVOffset;
-		visibility += texture(shadow_map, uv).r;
+		visibility += texture(shadow_map, uv);
 	}
 	return visibility * (1.0f/float(SAMPLES_PCSS));
 }


### PR DESCRIPTION
A change introduced by #7529 caused a shader compile error on Mac due to an attempted swizzle of texture(sampler2DArrayShadow,...), which returns a single float value rather than a vector.