### PR TITLE
Fix various sexp tree issues

### DIFF
--- a/code/missioneditor/sexp_tree_actions.cpp
+++ b/code/missioneditor/sexp_tree_actions.cpp
@@ -420,11 +420,10 @@ void SexpTreeActions::add_or_replace_operator(int op, int replace_flag)
 // Returns 0 on success, -1 if no default value was available.
 int SexpTreeActions::add_default_operator(int op_index, int argnum)
 {
-	char buf[256];
 	sexp_list_item item;
 
 	int saved_index = _model.item_index;
-	if (_model._opf.get_default_value(&item, buf, op_index, argnum))
+	if (_model._opf.get_default_value(&item, op_index, argnum))
 		return -1;
 
 	if (item.type & SEXPT_OPERATOR) {
@@ -460,10 +459,9 @@ int SexpTreeActions::add_default_operator(int op_index, int argnum)
 		}
 		// modify-variable data type depends on type of variable being modified
 		else if (Operators[op_index].value == OP_MODIFY_VARIABLE) {
-			char buf2[256];
 			Assertion(argnum == 1, "Invalid argument number %d for modify-variable default (expected 1)", argnum);
 			sexp_list_item temp_item;
-			_model._opf.get_default_value(&temp_item, buf2, op_index, 0);
+			_model._opf.get_default_value(&temp_item, op_index, 0);
 			sexp_var_index = get_index_sexp_variable_name(temp_item.text);
 			Assertion(sexp_var_index != -1, "Invalid variable index for modify-variable default; lookup of '%s' failed", temp_item.text.c_str());
 

--- a/code/missioneditor/sexp_tree_actions.cpp
+++ b/code/missioneditor/sexp_tree_actions.cpp
@@ -427,7 +427,7 @@ int SexpTreeActions::add_default_operator(int op_index, int argnum)
 		return -1;
 
 	if (item.type & SEXPT_OPERATOR) {
-		Assertion(SCP_vector_inbounds(Operators, item.op), "Invalid operator index %d (Operators size %zu)", item.op, Operators.size());
+		Assertion(SCP_vector_inbounds(Operators, item.op), "Invalid operator index %d (Operators size " SIZE_T_ARG ")", item.op, Operators.size());
 		add_or_replace_operator(item.op);
 		_model.item_index = saved_index;
 
@@ -487,7 +487,7 @@ int SexpTreeActions::add_default_operator(int op_index, int argnum)
 
 int SexpTreeActions::insert_operator(int op, void* root_parent_handle)
 {
-	Assertion(SCP_vector_inbounds(Operators, op), "Invalid operator index %d (Operators size %zu)", op, Operators.size());
+	Assertion(SCP_vector_inbounds(Operators, op), "Invalid operator index %d (Operators size " SIZE_T_ARG ")", op, Operators.size());
 	Assertion(_model.item_index >= 0, "Invalid selected node index %d", _model.item_index);
 
 	const int wrapped_node = _model.item_index;

--- a/code/missioneditor/sexp_tree_actions.h
+++ b/code/missioneditor/sexp_tree_actions.h
@@ -14,6 +14,12 @@ public:
 	// The model provides tree node data; the UI interface updates the visual widget.
 	SexpTreeActions(SexpTreeModel& model, ISexpTreeUI& ui);
 
+	// Non-copyable and non-movable: permanently bound to its model and UI
+	SexpTreeActions(const SexpTreeActions&) = delete;
+	SexpTreeActions& operator=(const SexpTreeActions&) = delete;
+	SexpTreeActions(SexpTreeActions&&) = delete;
+	SexpTreeActions& operator=(SexpTreeActions&&) = delete;
+
 	// --- Replace operations (modify current item_index node) ---
 
 	// Replace the current node with plain data (number or string).

--- a/code/missioneditor/sexp_tree_model.cpp
+++ b/code/missioneditor/sexp_tree_model.cpp
@@ -601,7 +601,7 @@ void SexpTreeModel::move_branch_data(int source, int parent)
 	// link source as child of new parent
 	tree_nodes[source].parent = parent;
 	tree_nodes[source].next = -1;
-	if (parent != -1 && parent != 0) {
+	if (parent != -1) {
 		if (tree_nodes[parent].child == -1) {
 			tree_nodes[parent].child = source;
 		} else {

--- a/code/missioneditor/sexp_tree_model.h
+++ b/code/missioneditor/sexp_tree_model.h
@@ -428,6 +428,14 @@ public:
 	SexpTreeModel();
 	~SexpTreeModel();
 
+	// Non-copyable and non-movable: _opf holds a back-reference to this model,
+	// and UI layers keep long-lived pointers to it (views, dialog interfaces).
+	// A copy would silently leave the copy's _opf bound to the original model.
+	SexpTreeModel(const SexpTreeModel&) = delete;
+	SexpTreeModel& operator=(const SexpTreeModel&) = delete;
+	SexpTreeModel(SexpTreeModel&&) = delete;
+	SexpTreeModel& operator=(SexpTreeModel&&) = delete;
+
 	// Tree node storage
 	SCP_vector<sexp_tree_item> tree_nodes;
 	int total_nodes;

--- a/code/missioneditor/sexp_tree_opf.cpp
+++ b/code/missioneditor/sexp_tree_opf.cpp
@@ -2808,7 +2808,7 @@ int SexpTreeOPF::query_default_argument_available(int op, int i) const
 
 // Determine and return the default value for operator argument position i.
 // Returns 0 on success, -1 if no default available.
-int SexpTreeOPF::get_default_value(sexp_list_item* item, char* text_buf, int op, int i)
+int SexpTreeOPF::get_default_value(sexp_list_item* item, int op, int i)
 {
 	const char* str = nullptr;
 	int type, index;
@@ -3082,10 +3082,6 @@ int SexpTreeOPF::get_default_value(sexp_list_item* item, char* text_buf, int op,
 	{
 		// copy the information from the list to the passed-in item
 		*item = *list;
-
-		// but use the provided text buffer
-		strcpy(text_buf, list->text.c_str());
-		item->text = text_buf;
 
 		// get rid of the list, since we're done with it
 		list->destroy();

--- a/code/missioneditor/sexp_tree_opf.h
+++ b/code/missioneditor/sexp_tree_opf.h
@@ -26,6 +26,12 @@ class SexpTreeOPF {
 public:
 	explicit SexpTreeOPF(SexpTreeModel& model);
 
+	// Non-copyable and non-movable: permanently bound to its owning model
+	SexpTreeOPF(const SexpTreeOPF&) = delete;
+	SexpTreeOPF& operator=(const SexpTreeOPF&) = delete;
+	SexpTreeOPF(SexpTreeOPF&&) = delete;
+	SexpTreeOPF& operator=(SexpTreeOPF&&) = delete;
+
 	// Master dispatcher — routes to the appropriate get_listing_opf_* based on opf type
 	sexp_list_item* get_listing_opf(int opf, int parent_node, int arg_index);
 

--- a/code/missioneditor/sexp_tree_opf.h
+++ b/code/missioneditor/sexp_tree_opf.h
@@ -162,7 +162,7 @@ public:
 	int query_default_argument_available(int op, int i) const;
 	//! Determine and populate the default value for argument position i of operator op.
 	//! Returns 0 on success, -1 if no default available.
-	int get_default_value(sexp_list_item* item, char* text_buf, int op, int i);
+	int get_default_value(sexp_list_item* item, int op, int i);
 
 private:
 	SexpTreeModel& _model;

--- a/fred2/sexp_tree_view.cpp
+++ b/fred2/sexp_tree_view.cpp
@@ -58,8 +58,8 @@ sexp_tree_view::sexp_tree_view()
 	select_sexp_node = -1;
 	root_item = -1;
 	m_dragging = FALSE;
-	m_p_image_list = NULL;
-	help_box = NULL;
+	m_p_image_list = nullptr;
+	help_box = nullptr;
 	_model._interface = &m_default_interface;
 	clear_tree();
 
@@ -170,7 +170,7 @@ void sexp_tree_view::reset_handles()
 	uint i;
 
 	for (i=0; i<tree_nodes.size(); i++)
-		tree_nodes[i].handle = NULL;
+		tree_nodes[i].handle = nullptr;
 }
 
 // initializes and creates a tree from a given sexp startpoint.
@@ -255,11 +255,11 @@ void sexp_tree_view::right_clicked()
 	UINT _flags;
 	HTREEITEM h;
 	POINT click_point, mouse;
-	CMenu menu, *mptr, *popup_menu, *add_data_menu = NULL, *replace_data_menu = NULL;
+	CMenu menu, *mptr, *popup_menu, *add_data_menu = nullptr, *replace_data_menu = nullptr;
 	CMenu *add_op_menu, add_op_submenu[SEXP_TREE_MAX_OP_MENUS];
 	CMenu *replace_op_menu, replace_op_submenu[SEXP_TREE_MAX_OP_MENUS];
 	CMenu *insert_op_menu, insert_op_submenu[SEXP_TREE_MAX_OP_MENUS];
-	CMenu *replace_variable_menu = NULL;
+	CMenu *replace_variable_menu = nullptr;
 	CMenu *replace_container_name_menu = nullptr;
 	CMenu *replace_container_data_menu = nullptr;
 	CMenu add_op_subcategory_menu[SEXP_TREE_MAX_SUBMENUS];
@@ -277,10 +277,10 @@ void sexp_tree_view::right_clicked()
 	if (h && menu.LoadMenu(IDR_MENU_EDIT_SEXP_TREE)) {
 		update_help(h);
 		popup_menu = menu.GetSubMenu(0);
-		Assertion(popup_menu != NULL, "Invalid popup menu");
+		Assertion(popup_menu != nullptr, "Invalid popup menu");
 		//SelectDropTarget(h);  // WTF: Why was this here???
 
-		add_op_menu = replace_op_menu = insert_op_menu = NULL;
+		add_op_menu = replace_op_menu = insert_op_menu = nullptr;
 
 		// get pointers to several key popup menus we'll need to modify
 		i = popup_menu->GetMenuItemCount();
@@ -1463,12 +1463,12 @@ void sexp_tree_view::OnBegindrag(NMHDR* pNMHDR, LRESULT* pResult)
 
 	Assertion(!m_dragging, "Invalid drag state");
 	m_h_drag = HitTest(m_pt, &flags);
-	m_h_drop = NULL;
+	m_h_drop = nullptr;
 
 	if (!_model._interface || !_model._interface->getFlags()[TreeFlags::LabeledRoot] || GetParentItem(m_h_drag))
 		return;
 
-	Assertion(m_p_image_list == NULL, "Invalid image list");
+	Assertion(m_p_image_list == nullptr, "Invalid image list");
 	m_p_image_list = CreateDragImage(m_h_drag);  // get the image list for dragging
 	if (!m_p_image_list)
 		return;
@@ -1492,13 +1492,13 @@ void sexp_tree_view::OnLButtonDown(UINT nFlags, CPoint point)
 // Highlights potential drop-target root items during a drag operation.
 void sexp_tree_view::OnMouseMove(UINT nFlags, CPoint point)
 {
-	HTREEITEM hitem = NULL;
+	HTREEITEM hitem = nullptr;
 	UINT flags = 0;
 
 	if (m_dragging) {
-		Assertion(m_p_image_list != NULL, "Invalid image list");
+		Assertion(m_p_image_list != nullptr, "Invalid image list");
 		m_p_image_list->DragMove(point);
-		if ((hitem = HitTest(point, &flags)) != NULL)
+		if ((hitem = HitTest(point, &flags)) != nullptr)
 			if (!GetParentItem(hitem)) {
 				m_p_image_list->DragLeave(this);
 				SelectDropTarget(hitem);
@@ -1516,11 +1516,11 @@ void sexp_tree_view::OnLButtonUp(UINT nFlags, CPoint point)
 	int node1, node2;
 
 	if (m_dragging) {
-		Assertion(m_p_image_list != NULL, "Invalid image list");
+		Assertion(m_p_image_list != nullptr, "Invalid image list");
 		m_p_image_list->DragLeave(this);
 		m_p_image_list->EndDrag();
 		delete m_p_image_list;
-		m_p_image_list = NULL;
+		m_p_image_list = nullptr;
 
 		if (m_h_drop && m_h_drag != m_h_drop) {
 			Assertion(m_h_drag, "Invalid drag handle");
@@ -1552,7 +1552,7 @@ void sexp_tree_view::OnLButtonUp(UINT nFlags, CPoint point)
 
 		ReleaseCapture();
 		m_dragging = FALSE;
-		SelectDropTarget(NULL);
+		SelectDropTarget(nullptr);
 	}
 
 	CTreeCtrl::OnLButtonUp(nFlags, point);

--- a/fred2/sexp_tree_view.cpp
+++ b/fred2/sexp_tree_view.cpp
@@ -60,6 +60,7 @@ sexp_tree_view::sexp_tree_view()
 	m_dragging = FALSE;
 	m_p_image_list = NULL;
 	help_box = NULL;
+	_model._interface = &m_default_interface;
 	clear_tree();
 
 	m_operator_popup_active = false;

--- a/fred2/sexp_tree_view.cpp
+++ b/fred2/sexp_tree_view.cpp
@@ -1347,11 +1347,7 @@ void sexp_tree_view::move_branch(int source, int parent)
 	if (source != -1) {
 		Assertion(parent > -1, "move_branch called with negative parent index %d (source %d)", parent, source);
 		_model.move_branch_data(source, parent);
-		if (parent > 0) {
-			move_branch(tree_item_handle(tree_nodes[source]), tree_item_handle(tree_nodes[parent]));
-		} else {
-			move_branch(tree_item_handle(tree_nodes[source]));
-		}
+		move_branch(tree_item_handle(tree_nodes[source]), tree_item_handle(tree_nodes[parent]));
 	}
 }
 

--- a/fred2/sexp_tree_view.h
+++ b/fred2/sexp_tree_view.h
@@ -140,6 +140,12 @@ protected:
 
 	int& flag = _model.flag;
 	int*& modified = _model.modified;
+
+	// Fallback editor interface installed at construction so _model._interface is never
+	// null (shared model/OPF code dereferences it unconditionally).  Dialogs that provide
+	// editor context (events, goals, cutscenes, campaign) overwrite it with themselves.
+	SexpTreeEditorInterface m_default_interface;
+
 	bool m_operator_popup_active;
 	bool m_operator_popup_created;
 	int m_font_height;

--- a/fred2/sexp_tree_view.h
+++ b/fred2/sexp_tree_view.h
@@ -58,12 +58,12 @@ public:
 	HTREEITEM handle(int node);
 	int get_node(HTREEITEM h);
 	int get_type(HTREEITEM h);
-	void setup(CEdit *ptr = NULL);
+	void setup(CEdit *ptr = nullptr);
 	void move_root(HTREEITEM source, HTREEITEM dest, bool insert_before);
 	void move_branch(int source, int parent);
 	HTREEITEM move_branch(HTREEITEM source, HTREEITEM parent = TVI_ROOT, HTREEITEM after = TVI_LAST);
 	void copy_branch(HTREEITEM source, HTREEITEM parent = TVI_ROOT, HTREEITEM after = TVI_LAST);
-	void setup_selected(HTREEITEM h = NULL);
+	void setup_selected(HTREEITEM h = nullptr);
 	void ensure_visible(int node);
 	int node_error(int node, const char *msg, int *bypass);
 	void expand_branch(HTREEITEM h);
@@ -75,7 +75,7 @@ public:
 	void right_clicked();
 	int ctree_size;
 	virtual void build_tree();
-	void clear_tree(const char *op = NULL);
+	void clear_tree(const char *op = nullptr);
 	void reset_handles();
 	void load_tree(int index, const char *deflt = "true");
 	void add_operator(const char *op, HTREEITEM h = TVI_ROOT);

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -518,11 +518,7 @@ void sexp_tree_view::move_branch(int source, int parent) {
 	if (source != -1) {
 		Assertion(parent > -1, "move_branch called with negative parent index %d (source %d)", parent, source);
 		_model.move_branch_data(source, parent);
-		if (parent > 0) {
-			move_branch(tree_item_handle(tree_nodes[source]), tree_item_handle(tree_nodes[parent]));
-		} else {
-			move_branch(tree_item_handle(tree_nodes[source]));
-		}
+		move_branch(tree_item_handle(tree_nodes[source]), tree_item_handle(tree_nodes[parent]));
 	}
 }
 


### PR DESCRIPTION
Several follow-ups to #7301:

- **Fix a crash in FRED dialogs that don't install an editor interface.**
  The ship, wing, message, briefing, and debriefing editors leave
  `_model._interface` null, but the shared OPF code dereferences it
  unconditionally — e.g. right-clicking the event-name argument of
  `is-event-true-delay` in a ship's arrival cue crashed FRED.  The view now
  installs a fallback interface at construction, mirroring qtFRED; its base
  implementations match the old `m_mode == 0` behavior.

- **Fix wrong reparenting when insert-operator recycles node slot 0.**
  `move_branch()` treated parent index 0 as attach-at-tree-root (a
  pre-refactor quirk), visually reparenting the wrapped branch to the root
  and leaving node 0's child list unlinked.  Attach unconditionally, since
  0 is a valid recycled `tree_nodes` index.

- **Delete copy/move on `SexpTreeModel`, `SexpTreeOPF`, and `SexpTreeActions`.**
  They hold references to their owner, so an implicit copy compiled but
  stayed silently bound to the original model.

- **Remove the vestigial `text_buf` parameter from `get_default_value()`**,
  which also removes an unbounded `strcpy` into 256-byte stack buffers.

- **Convention fixes:** `nullptr` and `SIZE_T_ARG` in the new files.