### PR TITLE
const-qualify read-only sexp tree methods

### DIFF
--- a/code/missioneditor/sexp_tree_model.cpp
+++ b/code/missioneditor/sexp_tree_model.cpp
@@ -1265,7 +1265,7 @@ bool SexpTreeModel::is_operator_hidden(int op_value)
 // which operators are enabled for add/replace/insert, and which variables and
 // containers can be used as replacements. The UI layers use this state to build
 // their context menus without needing to duplicate any of the enabling logic.
-SexpContextMenuState SexpTreeModel::compute_context_menu_state()
+SexpContextMenuState SexpTreeModel::compute_context_menu_state() const
 {
 	SexpContextMenuState state;
 
@@ -1491,7 +1491,7 @@ void SexpTreeModel::ctx_compute_variable_menus(SexpContextMenuState& state) cons
 // Sets add_type (OPR_* return type for operator filtering), populates
 // add_data_list with valid data items, and enables can_add_number/can_add_string.
 // Handles both container data nodes and regular operator nodes.
-void SexpTreeModel::ctx_compute_add_type(SexpContextMenuState& state)
+void SexpTreeModel::ctx_compute_add_type(SexpContextMenuState& state) const
 {
 	state.add_type = 0;
 
@@ -1576,7 +1576,7 @@ void SexpTreeModel::ctx_compute_add_type(SexpContextMenuState& state)
 // replace_data_list, enables can_replace_number/can_replace_string, and may
 // disable can_delete if this argument can't be removed. Returns the OPF_* type
 // for the replace position (needed by ctx_validate_clipboard).
-int SexpTreeModel::ctx_compute_replace_type(SexpContextMenuState& state)
+int SexpTreeModel::ctx_compute_replace_type(SexpContextMenuState& state) const
 {
 	state.replace_type = 0;
 	int parent = tree_nodes[item_index].parent;

--- a/code/missioneditor/sexp_tree_model.h
+++ b/code/missioneditor/sexp_tree_model.h
@@ -249,9 +249,9 @@ public:
 	// Update the icon of a tree item
 	virtual void ui_set_item_image(void* handle, NodeImage image) = 0;
 	// Return the first child handle of the given tree item, or nullptr if none
-	virtual void* ui_get_child_item(void* handle) = 0;
+	virtual void* ui_get_child_item(void* handle) const = 0;
 	// Return true if the tree item has any children
-	virtual bool ui_has_children(void* handle) = 0;
+	virtual bool ui_has_children(void* handle) const = 0;
 	// Expand a single tree item to show its children
 	virtual void ui_expand_item(void* handle) = 0;
 	// Set the tree's current selection to this item
@@ -588,7 +588,7 @@ public:
 	// Analyze the current selection and compute which context menu actions are available.
 	// The returned state includes operator enablement, variable/container menus, and
 	// clipboard paste validation. Returned state owns temporary lists and cleans them up automatically.
-	SexpContextMenuState compute_context_menu_state();
+	SexpContextMenuState compute_context_menu_state() const;
 	// Returns true if the given operator value should be hidden from menus (deprecated/hidden ops)
 	static bool is_operator_hidden(int op_value);
 
@@ -602,9 +602,9 @@ private:
 	// Build the variable and container replacement menu entries for the selected node
 	void ctx_compute_variable_menus(SexpContextMenuState& state) const;
 	// Determine what can be added as a new child of the selected node
-	void ctx_compute_add_type(SexpContextMenuState& state);
+	void ctx_compute_add_type(SexpContextMenuState& state) const;
 	// Determine what can replace the selected node; returns the OPF type for clipboard validation
-	int ctx_compute_replace_type(SexpContextMenuState& state);
+	int ctx_compute_replace_type(SexpContextMenuState& state) const;
 	// Determine the OPF type for inserting an operator before the selected node
 	void ctx_compute_insert_type(SexpContextMenuState& state) const;
 	// Pre-compute which operators are enabled for add/replace/insert

--- a/code/missioneditor/sexp_tree_opf.cpp
+++ b/code/missioneditor/sexp_tree_opf.cpp
@@ -72,7 +72,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_flexible_argument()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_bool(int parent_node)
+sexp_list_item *SexpTreeOPF::get_listing_opf_bool(int parent_node) const
 {
 	sexp_list_item head;
 
@@ -127,7 +127,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_number()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship(int parent_node)
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship(int parent_node) const
 {
 	sexp_list_item head;
 
@@ -357,7 +357,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_arrival_anchor_all()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ai_goal(int parent_node)
+sexp_list_item *SexpTreeOPF::get_listing_opf_ai_goal(int parent_node) const
 {
 	sexp_list_item head;
 
@@ -410,7 +410,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_message() const
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_docker_point(int parent_node, int arg_num)
+sexp_list_item *SexpTreeOPF::get_listing_opf_docker_point(int parent_node, int arg_num) const
 {
 	sexp_list_item head;
 
@@ -475,7 +475,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_docker_point(int parent_node, int a
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_dockee_point(int parent_node)
+sexp_list_item *SexpTreeOPF::get_listing_opf_dockee_point(int parent_node) const
 {
 	sexp_list_item head;
 
@@ -690,7 +690,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_waypoint_path()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship_point()
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship_point() const
 {
 	sexp_list_item head;
 
@@ -700,7 +700,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_ship_point()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_wholeteam()
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_wholeteam() const
 {
 	sexp_list_item head;
 
@@ -713,7 +713,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_wholeteam()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_shiponteam_point()
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_shiponteam_point() const
 {
 	sexp_list_item head;
 
@@ -729,7 +729,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_shiponteam_point()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_point()
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_point() const
 {
 	sexp_list_item head;
 
@@ -740,7 +740,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_point()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_point_or_none()
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing_point_or_none() const
 {
 	sexp_list_item head;
 
@@ -761,7 +761,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_mission_name() const
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_goal_name(int parent_node)
+sexp_list_item *SexpTreeOPF::get_listing_opf_goal_name(int parent_node) const
 {
 	sexp_list_item head;
 
@@ -778,7 +778,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_goal_name(int parent_node)
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing()
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing() const
 {
 	sexp_list_item head;
 
@@ -788,7 +788,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_ship_wing()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship_prop()
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship_prop() const
 {
 	sexp_list_item head;
 
@@ -798,7 +798,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_ship_prop()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_order_recipient()
+sexp_list_item *SexpTreeOPF::get_listing_opf_order_recipient() const
 {
 	sexp_list_item head;
 
@@ -839,7 +839,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_keypress()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_event_name(int parent_node)
+sexp_list_item *SexpTreeOPF::get_listing_opf_event_name(int parent_node) const
 {
 	sexp_list_item head;
 
@@ -981,7 +981,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_ship_not_player()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_ship_or_none()
+sexp_list_item *SexpTreeOPF::get_listing_opf_ship_or_none() const
 {
 	sexp_list_item head;
 
@@ -991,7 +991,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_ship_or_none()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_subsystem_or_none(int parent_node, int arg_index)
+sexp_list_item *SexpTreeOPF::get_listing_opf_subsystem_or_none(int parent_node, int arg_index) const
 {
 	sexp_list_item head;
 
@@ -1001,7 +1001,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_subsystem_or_none(int parent_node, 
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_subsys_or_generic(int parent_node, int arg_index)
+sexp_list_item *SexpTreeOPF::get_listing_opf_subsys_or_generic(int parent_node, int arg_index) const
 {
 	sexp_list_item head;
 	char buffer[NAME_LENGTH];
@@ -1363,7 +1363,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_fireball()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_species()	// NOLINT
+sexp_list_item *SexpTreeOPF::get_listing_opf_species()
 {
 	sexp_list_item head;
 
@@ -1373,7 +1373,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_species()	// NOLINT
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_language()	// NOLINT
+sexp_list_item *SexpTreeOPF::get_listing_opf_language()
 {
 	sexp_list_item head;
 
@@ -1383,7 +1383,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_language()	// NOLINT
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_functional_when_eval_type()	// NOLINT
+sexp_list_item *SexpTreeOPF::get_listing_opf_functional_when_eval_type()
 {
 	sexp_list_item head;
 
@@ -1393,7 +1393,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_functional_when_eval_type()	// NOLI
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_animation_name(int parent_node)
+sexp_list_item *SexpTreeOPF::get_listing_opf_animation_name(int parent_node) const
 {
 	sexp_list_item head;
 
@@ -1467,7 +1467,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_sexp_containers(ContainerType con_t
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_wing_formation()	// NOLINT
+sexp_list_item *SexpTreeOPF::get_listing_opf_wing_formation()
 {
 	sexp_list_item head;
 
@@ -1539,7 +1539,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_mission_custom_strings()
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_lua_enum(int parent_node, int arg_index)
+sexp_list_item *SexpTreeOPF::get_listing_opf_lua_enum(int parent_node, int arg_index) const
 {
 	// first child node
 	int child = _model.tree_nodes[parent_node].child;
@@ -1591,7 +1591,7 @@ enum : int {
 	OPS_ARMOR = 7,
 };
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_subsystem(int parent_node, int arg_index)
+sexp_list_item *SexpTreeOPF::get_listing_opf_subsystem(int parent_node, int arg_index) const
 {
 	sexp_list_item head;
 	
@@ -1834,7 +1834,7 @@ sexp_list_item *SexpTreeOPF::get_listing_opf_subsystem(int parent_node, int arg_
 	return head.next;
 }
 
-sexp_list_item *SexpTreeOPF::get_listing_opf_subsystem_type(int parent_node)
+sexp_list_item *SexpTreeOPF::get_listing_opf_subsystem_type(int parent_node) const
 {
 	sexp_list_item head;
 
@@ -2018,7 +2018,7 @@ bool SexpTreeOPF::is_container_name_opf_type(const int op_type)
 // Main OPF dispatch function
 // -----------------------------------------------------------------------
 
-sexp_list_item *SexpTreeOPF::get_listing_opf(int opf, int parent_node, int arg_index)
+sexp_list_item *SexpTreeOPF::get_listing_opf(int opf, int parent_node, int arg_index) const
 {
 	sexp_list_item head;
 	sexp_list_item *list = nullptr;
@@ -2808,7 +2808,7 @@ int SexpTreeOPF::query_default_argument_available(int op, int i) const
 
 // Determine and return the default value for operator argument position i.
 // Returns 0 on success, -1 if no default available.
-int SexpTreeOPF::get_default_value(sexp_list_item* item, int op, int i)
+int SexpTreeOPF::get_default_value(sexp_list_item* item, int op, int i) const
 {
 	const char* str = nullptr;
 	int type, index;

--- a/code/missioneditor/sexp_tree_opf.h
+++ b/code/missioneditor/sexp_tree_opf.h
@@ -33,18 +33,18 @@ public:
 	SexpTreeOPF& operator=(SexpTreeOPF&&) = delete;
 
 	// Master dispatcher — routes to the appropriate get_listing_opf_* based on opf type
-	sexp_list_item* get_listing_opf(int opf, int parent_node, int arg_index);
+	sexp_list_item* get_listing_opf(int opf, int parent_node, int arg_index) const;
 
 	static sexp_list_item* get_listing_opf_null();
 	static sexp_list_item* get_listing_opf_flexible_argument();
-	sexp_list_item* get_listing_opf_bool(int parent_node = -1);
+	sexp_list_item* get_listing_opf_bool(int parent_node = -1) const;
 	static sexp_list_item* get_listing_opf_positive();
 	static sexp_list_item* get_listing_opf_number();
-	sexp_list_item* get_listing_opf_ship(int parent_node = -1);
+	sexp_list_item* get_listing_opf_ship(int parent_node = -1) const;
 	static sexp_list_item* get_listing_opf_prop();
 	static sexp_list_item* get_listing_opf_wing();
-	sexp_list_item* get_listing_opf_subsystem(int parent_node, int arg_index);
-	sexp_list_item* get_listing_opf_subsystem_type(int parent_node);
+	sexp_list_item* get_listing_opf_subsystem(int parent_node, int arg_index) const;
+	sexp_list_item* get_listing_opf_subsystem_type(int parent_node) const;
 	static sexp_list_item* get_listing_opf_point();
 	static sexp_list_item* get_listing_opf_iff();
 	static sexp_list_item* get_listing_opf_ai_class();
@@ -55,9 +55,9 @@ public:
 	static sexp_list_item* get_listing_opf_arrival_location();
 	static sexp_list_item* get_listing_opf_departure_location();
 	static sexp_list_item* get_listing_opf_arrival_anchor_all();
-	sexp_list_item* get_listing_opf_ai_goal(int parent_node);
-	sexp_list_item* get_listing_opf_docker_point(int parent_node, int arg_index);
-	sexp_list_item* get_listing_opf_dockee_point(int parent_node);
+	sexp_list_item* get_listing_opf_ai_goal(int parent_node) const;
+	sexp_list_item* get_listing_opf_docker_point(int parent_node, int arg_index) const;
+	sexp_list_item* get_listing_opf_dockee_point(int parent_node) const;
 	sexp_list_item* get_listing_opf_message() const;
 	static sexp_list_item* get_listing_opf_persona();
 	static sexp_list_item* get_listing_opf_font();
@@ -72,19 +72,19 @@ public:
 	static sexp_list_item* get_listing_opf_ship_effect();
 	static sexp_list_item* get_listing_opf_explosion_option();
 	static sexp_list_item* get_listing_opf_waypoint_path();
-	sexp_list_item* get_listing_opf_ship_point();
-	sexp_list_item* get_listing_opf_ship_wing_wholeteam();
-	sexp_list_item* get_listing_opf_ship_wing_shiponteam_point();
-	sexp_list_item* get_listing_opf_ship_wing_point();
-	sexp_list_item* get_listing_opf_ship_wing_point_or_none();
+	sexp_list_item* get_listing_opf_ship_point() const;
+	sexp_list_item* get_listing_opf_ship_wing_wholeteam() const;
+	sexp_list_item* get_listing_opf_ship_wing_shiponteam_point() const;
+	sexp_list_item* get_listing_opf_ship_wing_point() const;
+	sexp_list_item* get_listing_opf_ship_wing_point_or_none() const;
 	sexp_list_item* get_listing_opf_mission_name() const;
-	sexp_list_item* get_listing_opf_goal_name(int parent_node);
-	sexp_list_item* get_listing_opf_ship_wing();
-	sexp_list_item* get_listing_opf_ship_prop();
-	sexp_list_item* get_listing_opf_order_recipient();
+	sexp_list_item* get_listing_opf_goal_name(int parent_node) const;
+	sexp_list_item* get_listing_opf_ship_wing() const;
+	sexp_list_item* get_listing_opf_ship_prop() const;
+	sexp_list_item* get_listing_opf_order_recipient() const;
 	static sexp_list_item* get_listing_opf_ship_type();
 	static sexp_list_item* get_listing_opf_keypress();
-	sexp_list_item* get_listing_opf_event_name(int parent_node);
+	sexp_list_item* get_listing_opf_event_name(int parent_node) const;
 	static sexp_list_item* get_listing_opf_ai_order();
 	static sexp_list_item* get_listing_opf_skill_level();
 	static sexp_list_item* get_listing_opf_cargo();
@@ -96,9 +96,9 @@ public:
 	static sexp_list_item* get_listing_opf_prop_class_name();
 	static sexp_list_item* get_listing_opf_huge_weapon();
 	static sexp_list_item* get_listing_opf_ship_not_player();
-	sexp_list_item* get_listing_opf_ship_or_none();
-	sexp_list_item* get_listing_opf_subsystem_or_none(int parent_node, int arg_index);
-	sexp_list_item* get_listing_opf_subsys_or_generic(int parent_node, int arg_index);
+	sexp_list_item* get_listing_opf_ship_or_none() const;
+	sexp_list_item* get_listing_opf_subsystem_or_none(int parent_node, int arg_index) const;
+	sexp_list_item* get_listing_opf_subsys_or_generic(int parent_node, int arg_index) const;
 	static sexp_list_item* get_listing_opf_jump_nodes();
 	static sexp_list_item* get_listing_opf_variable_names();
 	static sexp_list_item* get_listing_opf_skybox_model();
@@ -126,17 +126,17 @@ public:
 	static sexp_list_item* get_listing_opf_motion_debris();
 	static sexp_list_item* get_listing_opf_game_snds();
 	static sexp_list_item* get_listing_opf_fireball();
-	sexp_list_item* get_listing_opf_species();
-	sexp_list_item* get_listing_opf_language();
-	sexp_list_item* get_listing_opf_functional_when_eval_type();
-	sexp_list_item* get_listing_opf_animation_name(int parent_node);
+	static sexp_list_item* get_listing_opf_species();
+	static sexp_list_item* get_listing_opf_language();
+	static sexp_list_item* get_listing_opf_functional_when_eval_type();
+	sexp_list_item* get_listing_opf_animation_name(int parent_node) const;
 	static sexp_list_item* get_listing_opf_sexp_containers(ContainerType con_type);
-	sexp_list_item* get_listing_opf_wing_formation();
+	static sexp_list_item* get_listing_opf_wing_formation();
 	static sexp_list_item* get_listing_opf_bolt_types();
 	static sexp_list_item* get_listing_opf_traitor_overrides();
 	static sexp_list_item* get_listing_opf_lua_general_orders();
 	static sexp_list_item* get_listing_opf_message_types();
-	sexp_list_item* get_listing_opf_lua_enum(int parent_node, int arg_index);
+	sexp_list_item* get_listing_opf_lua_enum(int parent_node, int arg_index) const;
 	static sexp_list_item* get_listing_opf_mission_custom_strings();
 	static sexp_list_item* check_for_dynamic_sexp_enum(int opf);
 
@@ -162,7 +162,7 @@ public:
 	int query_default_argument_available(int op, int i) const;
 	//! Determine and populate the default value for argument position i of operator op.
 	//! Returns 0 on success, -1 if no default available.
-	int get_default_value(sexp_list_item* item, int op, int i);
+	int get_default_value(sexp_list_item* item, int op, int i) const;
 
 private:
 	SexpTreeModel& _model;

--- a/fred2/eventeditor.cpp
+++ b/fred2/eventeditor.cpp
@@ -29,7 +29,7 @@ static char THIS_FILE[] = __FILE__;
 #endif
 
 
-static int annotation_key_for_item(event_sexp_tree *tree, HTREEITEM h);
+static int annotation_key_for_item(const event_sexp_tree *tree, HTREEITEM h);
 
 BEGIN_MESSAGE_MAP(event_sexp_tree, sexp_tree_view)
 	//{{AFX_MSG_MAP(event_sexp_tree)
@@ -1657,7 +1657,7 @@ void event_editor::OnDblclkMessageList()
 // For regular nodes: their tree_nodes[] index (>= 0).
 // For root label nodes (event names): -(formula + 2), which is always <= -2,
 // avoiding collision with -1 (the default/unresolved sentinel).
-static int annotation_key_for_item(event_sexp_tree *tree, HTREEITEM h)
+static int annotation_key_for_item(const event_sexp_tree *tree, HTREEITEM h)
 {
 	int node = tree->get_node(h);
 	if (node >= 0)
@@ -1919,7 +1919,7 @@ SCP_string event_sexp_tree::get_node_comment(int node_index) const
 	return "";
 }
 
-SCP_string event_sexp_tree::get_item_comment(HTREEITEM h, int /*node_index*/)
+SCP_string event_sexp_tree::get_item_comment(HTREEITEM h, int /*node_index*/) const
 {
 	// resolves both regular nodes and root labels (which have no model node,
 	// so the base class's node_index would be -1 for them)

--- a/fred2/eventeditor.h
+++ b/fred2/eventeditor.h
@@ -28,7 +28,7 @@ public:
 	void edit_comment(HTREEITEM h);
 	void edit_bg_color(HTREEITEM h);
 	SCP_string get_node_comment(int node_index) const override;
-	SCP_string get_item_comment(HTREEITEM h, int node_index) override;
+	SCP_string get_item_comment(HTREEITEM h, int node_index) const override;
 
 	// Set by event_editor during initialization
 	SexpAnnotationModel* m_annotations = nullptr;

--- a/fred2/sexp_tree_view.cpp
+++ b/fred2/sexp_tree_view.cpp
@@ -95,12 +95,12 @@ void sexp_tree_view::ui_set_item_image(void* handle, NodeImage image)
 	SetItemImage(static_cast<HTREEITEM>(handle), img, img);
 }
 
-void* sexp_tree_view::ui_get_child_item(void* handle)
+void* sexp_tree_view::ui_get_child_item(void* handle) const
 {
 	return static_cast<void*>(GetChildItem(static_cast<HTREEITEM>(handle)));
 }
 
-bool sexp_tree_view::ui_has_children(void* handle)
+bool sexp_tree_view::ui_has_children(void* handle) const
 {
 	return ItemHasChildren(static_cast<HTREEITEM>(handle)) != 0;
 }
@@ -541,7 +541,7 @@ void sexp_tree_view::right_clicked()
 }
 
 // determine if an item should be editable.  This doesn't actually edit the label.
-int sexp_tree_view::edit_label(HTREEITEM h, bool *is_operator)
+int sexp_tree_view::edit_label(HTREEITEM h, bool *is_operator) const
 {
 	uint i;
 
@@ -619,7 +619,7 @@ SCP_string sexp_tree_view::get_node_comment(int /*node_index*/) const
 
 // Returns the comment for a tree item.  The base class only has comments on model
 // nodes; event_sexp_tree overrides this to also resolve labeled event roots.
-SCP_string sexp_tree_view::get_item_comment(HTREEITEM /*h*/, int node_index)
+SCP_string sexp_tree_view::get_item_comment(HTREEITEM /*h*/, int node_index) const
 {
 	return get_node_comment(node_index);
 }
@@ -1692,13 +1692,13 @@ void sexp_tree_view::OnDestroy()
 }
 
 // Returns the HTREEITEM handle for a given tree_nodes[] index.
-HTREEITEM sexp_tree_view::handle(int node)
+HTREEITEM sexp_tree_view::handle(int node) const
 {
 	return tree_item_handle(tree_nodes[node]);
 }
 
 // Returns the tree_nodes[] index for the node matching handle h, or -1 if not found.
-int sexp_tree_view::get_node(HTREEITEM h)
+int sexp_tree_view::get_node(HTREEITEM h) const
 {
 	for (int i = 0; i < static_cast<int>(tree_nodes.size()); i++) {
 		if (tree_nodes[i].handle == h)
@@ -1714,7 +1714,7 @@ const char *sexp_tree_view::help(int code)
 }
 
 // get type of item clicked on
-int sexp_tree_view::get_type(HTREEITEM h)
+int sexp_tree_view::get_type(HTREEITEM h) const
 {
 	uint i;
 

--- a/fred2/sexp_tree_view.h
+++ b/fred2/sexp_tree_view.h
@@ -55,9 +55,9 @@ public:
 	void update_help(HTREEITEM h);
 	static const char *help(int code);
 	HTREEITEM insert(LPCTSTR lpszItem, int image = BITMAP_ROOT, int sel_image = BITMAP_ROOT, HTREEITEM hParent = TVI_ROOT, HTREEITEM hInsertAfter = TVI_LAST);
-	HTREEITEM handle(int node);
-	int get_node(HTREEITEM h);
-	int get_type(HTREEITEM h);
+	HTREEITEM handle(int node) const;
+	int get_node(HTREEITEM h) const;
+	int get_type(HTREEITEM h) const;
 	void setup(CEdit *ptr = nullptr);
 	void move_root(HTREEITEM source, HTREEITEM dest, bool insert_before);
 	void move_branch(int source, int parent);
@@ -68,11 +68,11 @@ public:
 	int node_error(int node, const char *msg, int *bypass);
 	void expand_branch(HTREEITEM h);
 	int end_label_edit(TVITEMA &item);
-	int edit_label(HTREEITEM h, bool *is_operator = nullptr);
+	int edit_label(HTREEITEM h, bool *is_operator = nullptr) const;
 	virtual void edit_comment(HTREEITEM h);
 	virtual void edit_bg_color(HTREEITEM h);
 	virtual SCP_string get_node_comment(int node_index) const;
-	virtual SCP_string get_item_comment(HTREEITEM h, int node_index);
+	virtual SCP_string get_item_comment(HTREEITEM h, int node_index) const;
 	void right_clicked();
 	int ctree_size;
 	virtual void build_tree();
@@ -102,8 +102,8 @@ public:
 	void ui_delete_item(void* handle) override;
 	void ui_set_item_text(void* handle, const char* text) override;
 	void ui_set_item_image(void* handle, NodeImage image) override;
-	void* ui_get_child_item(void* handle) override;
-	bool ui_has_children(void* handle) override;
+	void* ui_get_child_item(void* handle) const override;
+	bool ui_has_children(void* handle) const override;
 	void ui_expand_item(void* handle) override;
 	void ui_select_item(void* handle) override;
 	void ui_ensure_visible(void* handle) override;

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -311,7 +311,7 @@ void sexp_tree_view::ui_set_item_image(void* handle, NodeImage image)
 }
 
 // Returns the first child QTreeWidgetItem, or nullptr. Called by _actions to traverse the tree.
-void* sexp_tree_view::ui_get_child_item(void* handle)
+void* sexp_tree_view::ui_get_child_item(void* handle) const
 {
 	auto* item = static_cast<QTreeWidgetItem*>(handle);
 	if (item->childCount() > 0)
@@ -320,7 +320,7 @@ void* sexp_tree_view::ui_get_child_item(void* handle)
 }
 
 // Returns true if the item has children. Called by _actions to check tree structure.
-bool sexp_tree_view::ui_has_children(void* handle)
+bool sexp_tree_view::ui_has_children(void* handle) const
 {
 	return static_cast<QTreeWidgetItem*>(handle)->childCount() > 0;
 }
@@ -939,7 +939,7 @@ QTreeWidgetItem* sexp_tree_view::insertWithIcon(const QString& lpszItem, const Q
 }
 
 // Returns the QTreeWidgetItem* handle for a given tree_nodes[] index.
-QTreeWidgetItem* sexp_tree_view::handle(int node) {
+QTreeWidgetItem* sexp_tree_view::handle(int node) const {
 	return tree_item_handle(tree_nodes[node]);
 }
 
@@ -950,7 +950,7 @@ const char* sexp_tree_view::help(int code) {
 
 // Returns the sexp type flags (SEXPT_OPERATOR, SEXPT_STRING, etc.) for the node matching
 // handle h. Performs a linear scan of tree_nodes[] to find the matching handle.
-int sexp_tree_view::get_type(QTreeWidgetItem* h) {
+int sexp_tree_view::get_type(QTreeWidgetItem* h) const {
 	uint i;
 
 	// get index into sexp_tree_view
@@ -970,7 +970,7 @@ int sexp_tree_view::get_type(QTreeWidgetItem* h) {
 
 // Returns the tree_nodes[] index for the node matching handle h.
 // Performs a linear scan of tree_nodes[]. Returns -1 if not found.
-int sexp_tree_view::get_node(QTreeWidgetItem* h) {
+int sexp_tree_view::get_node(QTreeWidgetItem* h) const {
 	uint i;
 
 	// get index into sexp_tree_view
@@ -989,7 +989,7 @@ int sexp_tree_view::get_node(QTreeWidgetItem* h) {
 }
 
 // Walks parent links from the given node up to find and return the root node index.
-int sexp_tree_view::get_root(int node) {
+int sexp_tree_view::get_root(int node) const {
 	while (tree_nodes[node].parent >= 0) {
 		node = tree_nodes[node].parent;
 	}
@@ -1454,7 +1454,7 @@ void sexp_tree_view::editDataActionHandler() {
 //   - _model._opf.query_default_argument_available() to filter operators that lack default args
 // Returns a sorted, deduplicated QStringList of operator names. Used by the operator
 // quick-search popup and openNodeEditor() to decide whether to show the popup.
-QStringList sexp_tree_view::validOperatorsForNode(int nodeIndex)
+QStringList sexp_tree_view::validOperatorsForNode(int nodeIndex) const
 {
 	QStringList out;
 	if (nodeIndex < 0 || nodeIndex >= static_cast<int>(tree_nodes.size()))

--- a/qtfred/src/ui/widgets/sexp_tree_view.h
+++ b/qtfred/src/ui/widgets/sexp_tree_view.h
@@ -92,19 +92,19 @@ class sexp_tree_view: public QTreeWidget, public ISexpTreeUI {
 	QTreeWidgetItem* insert(const QString& lpszItem, NodeImage image = NodeImage::ROOT, QTreeWidgetItem* hParent = nullptr, QTreeWidgetItem* hInsertAfter = nullptr);
 
 	//! Returns the QTreeWidgetItem* handle for a given tree_nodes[] index.
-	QTreeWidgetItem* handle(int node);
+	QTreeWidgetItem* handle(int node) const;
 
 	//! Looks up the sexp type (SEXPT_OPERATOR, SEXPT_STRING, etc.) for the node matching handle h.
 	//! Performs a linear scan of tree_nodes[].
-	int get_type(QTreeWidgetItem* h);
+	int get_type(QTreeWidgetItem* h) const;
 
 	//! Returns the tree_nodes[] index for the node matching handle h.
 	//! Performs a linear scan of tree_nodes[].
-	int get_node(QTreeWidgetItem* h);
+	int get_node(QTreeWidgetItem* h) const;
 
 	//! Walks parent links from node up to find the root node index.
 	//! Uses _model.tree_nodes[].parent.
-	int get_root(int node);
+	int get_root(int node) const;
 
 	//! Reorders top-level (root) items by removing source and reinserting relative to dest.
 	//! Emits rootOrderChanged() and modified(). Pure Qt widget operation.
@@ -195,8 +195,8 @@ class sexp_tree_view: public QTreeWidget, public ISexpTreeUI {
 	void ui_delete_item(void* handle) override;                  //!< Deletes a QTreeWidgetItem
 	void ui_set_item_text(void* handle, const char* text) override;   //!< Sets display text via setText()
 	void ui_set_item_image(void* handle, NodeImage image) override;   //!< Sets icon via setIcon()
-	void* ui_get_child_item(void* handle) override;              //!< Returns first child item, or nullptr
-	bool ui_has_children(void* handle) override;                 //!< Returns true if childCount() > 0
+	void* ui_get_child_item(void* handle) const override;        //!< Returns first child item, or nullptr
+	bool ui_has_children(void* handle) const override;           //!< Returns true if childCount() > 0
 	void ui_expand_item(void* handle) override;                  //!< Expands a single item via setExpanded()
 	void ui_select_item(void* handle) override;                  //!< Selects item via setCurrentItem()
 	void ui_ensure_visible(void* handle) override;               //!< Scrolls to item via scrollToItem()
@@ -357,7 +357,7 @@ class sexp_tree_view: public QTreeWidget, public ISexpTreeUI {
 	//! Computes the list of valid operator names for a given node position. Queries
 	//! _model.find_argument_number(), _model.query_node_argument_type(), _model._opf.get_listing_opf(),
 	//! and _model._opf.query_default_argument_available().
-	QStringList validOperatorsForNode(int nodeIndex);
+	QStringList validOperatorsForNode(int nodeIndex) const;
 
 	//! Slot for itemChanged. Handles inline edit completion. For root labels: emits rootNodeRenamed().
 	//! For operators: validates via _model.validate_label_edit() and commits via _actions.add_or_replace_operator().


### PR DESCRIPTION
Add const to query methods that the sexp_tree refactor left non-const:

- FRED2/qtFRED views: node, type, handle, and root lookups; label-edit
  eligibility; annotation key resolution and comment getters; qtFRED's
  validOperatorsForNode
- SexpTreeOPF: all instance get_listing_opf_* functions plus the
  dispatcher and get_default_value (the class holds only a reference
  to its model, so these are read-only by construction)
- SexpTreeModel: compute_context_menu_state and the two remaining
  ctx_* helpers, which write only their state out-parameter
- ISexpTreeUI: the two read-only navigation callbacks
  (ui_get_child_item, ui_has_children) in the interface and both
  frontend implementations

Also convert the four listing functions that use no editor state at all
(species, language, functional_when_eval_type, wing_formation) to
static, removing the NOLINT suppressions that had silenced clang-tidy's
convert-to-static warning since before the refactor.