### PR TITLE
Fix shockwave damage bug

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -194,8 +194,7 @@ namespace AI {
 		Kamikaze_no_collision_avoidance,
 		Fix_big_ship_waypoint_completion,	// a) big ships complete a waypoint within their radius rather than sqrt(radius);
 											// b) completion no longer requires moving 0.1m in a single frame (framerate-dependent)
-		Fix_shockwave_damage_and_lifetime_bugs,	// a) fast shockwaves (whose lifetime is shorter than one frame) apply their area damage at least once before expiring (framerate-dependent)
-												// b) instant (speed <= 0) shockwave objects snap to full radius and expire, instead of dividing by zero and living forever at radius 1.0
+		Fix_shockwave_expire_before_do_damage,	// shockwaves whose lifetime is shorter than one frame apply their area damage at least once before expiring, so provide fix (framerate-dependent)
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -194,6 +194,8 @@ namespace AI {
 		Kamikaze_no_collision_avoidance,
 		Fix_big_ship_waypoint_completion,	// a) big ships complete a waypoint within their radius rather than sqrt(radius);
 											// b) completion no longer requires moving 0.1m in a single frame (framerate-dependent)
+		Fix_shockwave_damage_and_lifetime_bugs,	// a) fast shockwaves (whose lifetime is shorter than one frame) apply their area damage at least once before expiring (framerate-dependent)
+												// b) instant (speed <= 0) shockwave objects snap to full radius and expire, instead of dividing by zero and living forever at radius 1.0
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -194,7 +194,7 @@ namespace AI {
 		Kamikaze_no_collision_avoidance,
 		Fix_big_ship_waypoint_completion,	// a) big ships complete a waypoint within their radius rather than sqrt(radius);
 											// b) completion no longer requires moving 0.1m in a single frame (framerate-dependent)
-		Fix_shockwave_expire_before_do_damage,	// shockwaves whose lifetime is shorter than one frame apply their area damage at least once before expiring, so provide fix (framerate-dependent)
+		Fix_shockwave_expire_before_do_damage,	// shockwaves whose lifetime is shorter than one frame apply their area damage at least once before expiring
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -753,6 +753,8 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix big ship waypoint completion:", AI::Profile_Flags::Fix_big_ship_waypoint_completion);
 
+				set_flag(profile, "$fix shockwave damage and lifetime bugs:", AI::Profile_Flags::Fix_shockwave_damage_and_lifetime_bugs);
+
 
 				// end of options ----------------------------------------
 
@@ -982,5 +984,6 @@ void ai_profile_t::reset()
 	if (mod_supports_version(26, 2, 0)) {
 		flags.set(AI::Profile_Flags::Kamikaze_no_collision_avoidance);
 		flags.set(AI::Profile_Flags::Fix_big_ship_waypoint_completion);
+		flags.set(AI::Profile_Flags::Fix_shockwave_damage_and_lifetime_bugs);
 	}
 }

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -753,7 +753,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix big ship waypoint completion:", AI::Profile_Flags::Fix_big_ship_waypoint_completion);
 
-				set_flag(profile, "$fix shockwave damage and lifetime bugs:", AI::Profile_Flags::Fix_shockwave_damage_and_lifetime_bugs);
+				set_flag(profile, "$fix shockwave expiring before dealing damage:", AI::Profile_Flags::Fix_shockwave_expire_before_do_damage);
 
 
 				// end of options ----------------------------------------
@@ -984,6 +984,6 @@ void ai_profile_t::reset()
 	if (mod_supports_version(26, 2, 0)) {
 		flags.set(AI::Profile_Flags::Kamikaze_no_collision_avoidance);
 		flags.set(AI::Profile_Flags::Fix_big_ship_waypoint_completion);
-		flags.set(AI::Profile_Flags::Fix_shockwave_damage_and_lifetime_bugs);
+		flags.set(AI::Profile_Flags::Fix_shockwave_expire_before_do_damage);
 	}
 }

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -163,7 +163,16 @@ int shockwave_create(int parent_objnum, const vec3d* pos, const shockwave_create
 
 	sw->damage_type_idx = sci->damage_type_idx;
 
-	sw->total_time = sw->outer_radius / sw->speed;
+	// A shockwave speed <= 0 is an "instant" shockwave, but the speed is used as a denominator for total_time.
+	// Dividing by 0 that creates in infinite shockwave (frozen at its initial radius of 1.0).
+	// Thus, add a safeguard to protect against the infinite duration.
+	// Note, ship-death and sexp shockwave run shockwave straight to shockwave_create(), whereas weapon shockwaves run weapon_do_area_effect() if <= 0 speed.
+	if ( The_mission.ai_profile->flags[AI::Profile_Flags::Fix_shockwave_damage_and_lifetime_bugs] && sw->speed <= 0.0f ) {
+		sw->radius = sw->outer_radius;		// snap to full radius so the single damage pass covers the whole blast
+		sw->total_time = 0.001f;			// tiny but finite lifetime: applies damage once (see shockwave_move) then dies, is < 1/Framerate_cap
+	} else {
+		sw->total_time = sw->outer_radius / sw->speed;
+	}
 
 	if ( (parent_objnum != -1) && Objects[parent_objnum].type == OBJ_WEAPON ) {		// Goober5000: allow -1
 		sw->weapon_info_index = Weapons[Objects[parent_objnum].instance].weapon_info_index;
@@ -308,7 +317,13 @@ void shockwave_move(object *shockwave_objp, float frametime)
 		CLAMP(sw->radius, 0.0f, sw->outer_radius);
 	}
 
-	if ( sw->time_elapsed > sw->total_time ) {
+	// It is possible the shockwave may have lifetime shorter than one frame (e.g. high speed, small radius), 
+	// which by default results in shockwave applying no damage.
+	// Provide optional fix to ensure shockwave is not killed until after this frame's damage pass has run.
+	bool sw_expired = sw->time_elapsed > sw->total_time;
+	bool sw_expire_fix = The_mission.ai_profile->flags[AI::Profile_Flags::Fix_shockwave_damage_and_lifetime_bugs];
+
+	if ( sw_expired && !sw_expire_fix ) {
         shockwave_objp->flags.set(Object::Object_Flags::Should_be_dead);
 		return;
 	}
@@ -443,6 +458,12 @@ void shockwave_move(object *shockwave_objp, float frametime)
 		}
 
 	}	// end for
+
+	// See the sw_expired check above: shockwave has now applied its final damage pass this frame, so let it die.  
+	// With the flag off we already returned before the loop.
+	if ( sw_expired && sw_expire_fix ) {
+        shockwave_objp->flags.set(Object::Object_Flags::Should_be_dead);
+	}
 }
 
 /**

--- a/code/weapon/shockwave.cpp
+++ b/code/weapon/shockwave.cpp
@@ -163,16 +163,7 @@ int shockwave_create(int parent_objnum, const vec3d* pos, const shockwave_create
 
 	sw->damage_type_idx = sci->damage_type_idx;
 
-	// A shockwave speed <= 0 is an "instant" shockwave, but the speed is used as a denominator for total_time.
-	// Dividing by 0 that creates in infinite shockwave (frozen at its initial radius of 1.0).
-	// Thus, add a safeguard to protect against the infinite duration.
-	// Note, ship-death and sexp shockwave run shockwave straight to shockwave_create(), whereas weapon shockwaves run weapon_do_area_effect() if <= 0 speed.
-	if ( The_mission.ai_profile->flags[AI::Profile_Flags::Fix_shockwave_damage_and_lifetime_bugs] && sw->speed <= 0.0f ) {
-		sw->radius = sw->outer_radius;		// snap to full radius so the single damage pass covers the whole blast
-		sw->total_time = 0.001f;			// tiny but finite lifetime: applies damage once (see shockwave_move) then dies, is < 1/Framerate_cap
-	} else {
-		sw->total_time = sw->outer_radius / sw->speed;
-	}
+	sw->total_time = sw->outer_radius / sw->speed;
 
 	if ( (parent_objnum != -1) && Objects[parent_objnum].type == OBJ_WEAPON ) {		// Goober5000: allow -1
 		sw->weapon_info_index = Weapons[Objects[parent_objnum].instance].weapon_info_index;
@@ -321,7 +312,7 @@ void shockwave_move(object *shockwave_objp, float frametime)
 	// which by default results in shockwave applying no damage.
 	// Provide optional fix to ensure shockwave is not killed until after this frame's damage pass has run.
 	bool sw_expired = sw->time_elapsed > sw->total_time;
-	bool sw_expire_fix = The_mission.ai_profile->flags[AI::Profile_Flags::Fix_shockwave_damage_and_lifetime_bugs];
+	bool sw_expire_fix = The_mission.ai_profile->flags[AI::Profile_Flags::Fix_shockwave_expire_before_do_damage];
 
 	if ( sw_expired && !sw_expire_fix ) {
         shockwave_objp->flags.set(Object::Object_Flags::Should_be_dead);


### PR DESCRIPTION
Bug:
It is possible the shockwave may have lifetime shorter than one frame (e.g. high speed, small radius), which by default results in shockwave applying no damage.

Fix:
Provide optional fix to ensure shockwave is not killed until after this frame's damage pass has run.

Tested and work as expected.

~~Ship and SEXP created shockwaves with 0 speed last forever. A shockwave speed <= 0 is an "instant" shockwave, but the speed is used as a denominator for total_time. Dividing by 0 that creates in infinite shockwave (frozen at its initial radius of 1.0).Thus, add a safeguard to protect against the infinite duration. Note, ship-death and sexp shockwave run shockwave straight to shockwave_create(), whereas weapon shockwaves run weapon_do_area_effect() if <= 0 speed.~~