### PR TITLE
Allow double click to initiate search for sexp view items

### DIFF
--- a/qtfred/help-src/doc/dialogs/MissionEventsDialog.html
+++ b/qtfred/help-src/doc/dialogs/MissionEventsDialog.html
@@ -17,11 +17,15 @@ Events can repeat on a cooldown, depend on other events firing first, display ob
 on the HUD, trigger messages, and much more. The event list is the brain of a mission.</p>
 
 <h2>Event list and SEXP tree</h2>
-<p>The main area shows all events in the mission alongside their SEXP trees. Selecting an
-event expands its condition and action expressions for editing. Right-click any SEXP node
-to add, replace, or remove operators and arguments. See
+<p>The main area shows all events in the mission alongside their SEXP trees. 
+Clicking on the arrow of an event expands its condition and action expressions for editing.
+Right-click any SEXP node to add, replace, or remove operators and arguments. See
 <a href="../concepts/sexps.html">SEXPs</a> for a full overview of the expression
 language and the operators available.</p>
+<p>Several keyboard shortcuts are available for quick actions. Spacebar initiates edit
+or operator search. Double-clicking a leaf node (one that cannot be expanded) will do 
+the same. Double-clicking other nodes will only expand that part of the tree. Copy and
+pasting are also available.</p>
 <p>Events are evaluated in list order each frame. Order matters: events earlier in the
 list are processed first, which can affect timing when events interact.</p>
 

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -235,13 +235,7 @@ sexp_tree_view::sexp_tree_view(QWidget* parent) : QTreeWidget(parent), _actions(
 	connect(this, &QWidget::customContextMenuRequested, this, &sexp_tree_view::customMenuHandler);
 	connect(this, &QTreeWidget::itemChanged, this, &sexp_tree_view::handleItemChange);
 	connect(this, &QTreeWidget::itemSelectionChanged, this, &sexp_tree_view::handleNewItemSelected);
-	// Double-clicking a node toggles its expansion when it has children; a leaf node
-	// has nothing to expand, so double-clicking it does nothing.
-	connect(this, &QTreeWidget::itemDoubleClicked, this, [](QTreeWidgetItem* item, int /*column*/) {
-		if (item && item->childCount() > 0) {
-			item->setExpanded(!item->isExpanded());
-		}
-	});
+	connect(this, &QTreeWidget::itemDoubleClicked, this, &sexp_tree_view::handleDoubleClick);
 
 	setItemDelegateForColumn(0, new NoteBadgeDelegate(this));
 
@@ -782,12 +776,7 @@ void sexp_tree_view::keyPressEvent(QKeyEvent* e)
 	// starts inline text editing. Operator nodes have no editable data of their own, 
 	// so they fall back to the operator quick-search popup.
 	if (e->key() == Qt::Key_Space && currentItem()) {
-		item_index = get_node(currentItem());
-		if (_model.compute_context_menu_state().can_edit_text) {
-			editDataActionHandler();
-		} else {
-			openNodeEditor(currentItem());
-		}
+		editActionHandlerHelper();
 		return;
 	}
 
@@ -1980,6 +1969,31 @@ void sexp_tree_view::handleNewItemSelected() {
 	}
 
 	selectedRootChanged(item->data(0, FormulaDataRole).toInt());
+}
+
+// Slot connected to itemDoubleClicked. Allows the item to either be expanded or for an editable item
+// to go into edit view.
+void sexp_tree_view::handleDoubleClick() {
+	auto clickedItem = currentItem();
+
+	// expand when there is a child to expand
+	if (clickedItem && clickedItem->childCount() > 0) {
+		clickedItem->setExpanded(!clickedItem->isExpanded());
+	// edit otherwise
+	} else {
+		editActionHandlerHelper();	
+	}
+}
+
+// Helper function for making sure that search and edit are initiated consistently 
+void sexp_tree_view::editActionHandlerHelper(){
+	item_index = get_node(currentItem());
+
+	if (_model.compute_context_menu_state().can_edit_text) {
+		editDataActionHandler();
+	} else {
+		openNodeEditor(currentItem());
+	}
 }
 
 // Public entry point for deleting the currently selected item. Simply delegates to deleteActionHandler().

--- a/qtfred/src/ui/widgets/sexp_tree_view.h
+++ b/qtfred/src/ui/widgets/sexp_tree_view.h
@@ -304,6 +304,12 @@ class sexp_tree_view: public QTreeWidget, public ISexpTreeUI {
 	//! Slot for itemSelectionChanged. Updates help text, sets item_index, and emits selectedRootChanged().
 	void handleNewItemSelected();
 
+	//! Slot for double click which may either expand a tree or initiate edit mode
+	void handleDoubleClick();
+
+	//! Helper function to make sure search and editing is initiated consistently.
+	void editActionHandlerHelper();
+
 	//! Builds the full right-click context menu for a given item. Calls _model.compute_context_menu_state()
 	//! to determine all enabled/disabled states, then constructs menus for Delete, Edit, Cut/Copy/Paste,
 	//! Add/Replace/Insert Operator (categorized submenus), Add/Replace Data, Variables, and Containers.


### PR DESCRIPTION
This allows double click to initiate search and item editing when a non-parent item is double clicked.  Double clicking a parent will still expand/contract an item.  Spacebar will also still initiate edit.