### PR TITLE
Fix fighter/bomber AI remaining stationary if engines repaired

### DIFF
--- a/code/ai/ai_flags.h
+++ b/code/ai/ai_flags.h
@@ -195,6 +195,7 @@ namespace AI {
 		Fix_big_ship_waypoint_completion,	// a) big ships complete a waypoint within their radius rather than sqrt(radius);
 											// b) completion no longer requires moving 0.1m in a single frame (framerate-dependent)
 		Fix_shockwave_expire_before_do_damage,	// shockwaves whose lifetime is shorter than one frame apply their area damage at least once before expiring
+		Fix_small_ai_recover_after_engines_repaired, // ensure small ship AI can switch back to useful AI modes if engines get repaired
 
 		NUM_VALUES
 	};

--- a/code/ai/ai_profiles.cpp
+++ b/code/ai/ai_profiles.cpp
@@ -755,6 +755,7 @@ void parse_ai_profiles_tbl(const char *filename)
 
 				set_flag(profile, "$fix shockwave expiring before dealing damage:", AI::Profile_Flags::Fix_shockwave_expire_before_do_damage);
 
+				set_flag(profile, "$fix fighter/bomber AI recovers after engines repaired:", AI::Profile_Flags::Fix_small_ai_recover_after_engines_repaired);
 
 				// end of options ----------------------------------------
 
@@ -985,5 +986,6 @@ void ai_profile_t::reset()
 		flags.set(AI::Profile_Flags::Kamikaze_no_collision_avoidance);
 		flags.set(AI::Profile_Flags::Fix_big_ship_waypoint_completion);
 		flags.set(AI::Profile_Flags::Fix_shockwave_expire_before_do_damage);
+		flags.set(AI::Profile_Flags::Fix_small_ai_recover_after_engines_repaired);
 	}
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12445,7 +12445,7 @@ void ai_process_subobjects(int objnum)
 					aip->submode = SM_ATTACK_FOREVER;				//	Never leave attack submode, don't avoid, evade, etc.
 					aip->submode_start_time = Missiontime;
 				}
-			} 
+			}
 		}
 	} 	
 	// Goober5000 and wookieejedi - conversely, if the engines are no longer blown (e.g. after repair), resume normal chase behavior.

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12431,7 +12431,7 @@ void ai_process_subobjects(int objnum)
 	}
 
 	//	Deal with a ship with blown out engines.
-	if (ship_subsystems_blown(shipp, SUBSYSTEM_ENGINE)) {
+	if (!The_mission.ai_profile->flags[AI::Profile_Flags::Fix_small_ai_recover_after_engines_repaired] && ship_subsystems_blown(shipp, SUBSYSTEM_ENGINE)) {
 		// Karajorma - if Player_use_ai is ever fixed to work on multiplayer it should be checked that any player ships 
 		// aren't under AI control here
 		if ((!(objp->flags[Object::Object_Flags::Player_ship])) && (sip->is_fighter_bomber()) && !(shipp->flags[Ship::Ship_Flags::Dying])) {
@@ -12445,7 +12445,14 @@ void ai_process_subobjects(int objnum)
 					aip->submode = SM_ATTACK_FOREVER;				//	Never leave attack submode, don't avoid, evade, etc.
 					aip->submode_start_time = Missiontime;
 				}
-			}
+			} 
+		}
+		// Goober5000 - conversely, if the engines are no longer blown (e.g. after repair), resume normal chase behavior.
+		// The rest of the AI assumes SM_ATTACK_FOREVER implies blown engines, 
+		// so don't leave the submode set after the engines recover, or the ship will never evade and will ignore being hit.
+		else if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_small_ai_recover_after_engines_repaired] && ((aip->mode == AIM_CHASE) && (aip->submode == SM_ATTACK_FOREVER))) {
+			aip->submode = SM_ATTACK;
+			aip->submode_start_time = Missiontime;
 		}
 	}
 }

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12448,7 +12448,7 @@ void ai_process_subobjects(int objnum)
 			} 
 		}
 	} 	
-	// Goober5000 - conversely, if the engines are no longer blown (e.g. after repair), resume normal chase behavior.
+	// Goober5000 and wookieejedi - conversely, if the engines are no longer blown (e.g. after repair), resume normal chase behavior.
 	// The rest of the AI assumes SM_ATTACK_FOREVER implies blown engines, 
 	// so don't leave the submode set after the engines recover, or the ship will never evade and will ignore being hit.
 	else if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_small_ai_recover_after_engines_repaired] && ((aip->mode == AIM_CHASE) && (aip->submode == SM_ATTACK_FOREVER))) {

--- a/code/ai/aicode.cpp
+++ b/code/ai/aicode.cpp
@@ -12431,7 +12431,7 @@ void ai_process_subobjects(int objnum)
 	}
 
 	//	Deal with a ship with blown out engines.
-	if (!The_mission.ai_profile->flags[AI::Profile_Flags::Fix_small_ai_recover_after_engines_repaired] && ship_subsystems_blown(shipp, SUBSYSTEM_ENGINE)) {
+	if (ship_subsystems_blown(shipp, SUBSYSTEM_ENGINE)) {
 		// Karajorma - if Player_use_ai is ever fixed to work on multiplayer it should be checked that any player ships 
 		// aren't under AI control here
 		if ((!(objp->flags[Object::Object_Flags::Player_ship])) && (sip->is_fighter_bomber()) && !(shipp->flags[Ship::Ship_Flags::Dying])) {
@@ -12447,13 +12447,13 @@ void ai_process_subobjects(int objnum)
 				}
 			} 
 		}
-		// Goober5000 - conversely, if the engines are no longer blown (e.g. after repair), resume normal chase behavior.
-		// The rest of the AI assumes SM_ATTACK_FOREVER implies blown engines, 
-		// so don't leave the submode set after the engines recover, or the ship will never evade and will ignore being hit.
-		else if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_small_ai_recover_after_engines_repaired] && ((aip->mode == AIM_CHASE) && (aip->submode == SM_ATTACK_FOREVER))) {
-			aip->submode = SM_ATTACK;
-			aip->submode_start_time = Missiontime;
-		}
+	} 	
+	// Goober5000 - conversely, if the engines are no longer blown (e.g. after repair), resume normal chase behavior.
+	// The rest of the AI assumes SM_ATTACK_FOREVER implies blown engines, 
+	// so don't leave the submode set after the engines recover, or the ship will never evade and will ignore being hit.
+	else if (The_mission.ai_profile->flags[AI::Profile_Flags::Fix_small_ai_recover_after_engines_repaired] && ((aip->mode == AIM_CHASE) && (aip->submode == SM_ATTACK_FOREVER))) {
+		aip->submode = SM_ATTACK;
+		aip->submode_start_time = Missiontime;
 	}
 }
 


### PR DESCRIPTION
There is an FSO behavior that results in fighters/bombers just slowing down to 0 and remaining still--if their engines get temporarily disabled and then repaired and their current target dies/departs. This is b/c when the engines are blown they get set to AM_ATTACK_FOREVER mode, but if the target leaves they just end up remaining still. This becomes very obvious in mods where there is automatic subsystem repair. 

Thus, add a flag to enable the AI to stop that forever mode. 