### PR TITLE
QtFred fix volumetric related crash on mission load

### DIFF
--- a/qtfred/src/mission/Editor.cpp
+++ b/qtfred/src/mission/Editor.cpp
@@ -497,6 +497,12 @@ void Editor::unmarkObject(int obj) {
 }
 
 void Editor::clearMission(bool fast_reload) {
+	// drop cached model numbers while the models are still loaded; model_free_all() below invalidates
+	// them and the next mission reuses the slots, so a later unload would hit an unrelated model
+	for (auto& viewport : _viewports) {
+		viewport->renderer->freeVolumetricModel();
+	}
+
 	// clean up everything we need to before we reset back to defaults.
 	clean_up_selections();
 

--- a/qtfred/src/mission/FredRenderer.cpp
+++ b/qtfred/src/mission/FredRenderer.cpp
@@ -271,9 +271,6 @@ void FredRenderer::setViewport(EditorViewport* viewport) {
 	Assertion(viewport != nullptr, "Invalid viewport specified!");
 
 	_viewport = viewport;
-
-	connect(_viewport->editor, &Editor::missionLoaded, this,
-		[this](const std::string&) { freeVolumetricModel(); });
 }
 
 void FredRenderer::freeVolumetricModel() {


### PR DESCRIPTION
`FredRenderer` freed its cached volumetric nebula hull model on `missionLoaded`, by which point `clearMission()` had already called `model_free_all()` and the incoming mission's ships had reused the slot. Since `model_unload()` reduces a model id to a slot index without checking the generation, this destroyed an unrelated ship's model and reset its `Ship_info::model_num` to -1, tripping "Invalid model number -1 requested" as soon as the mouse moved in the viewport.

Fixed by freeing the volume model at the top of `clearMission()`, while the model id is still valid, instead of after the new mission has loaded.