### PR TITLE
QtFRED follow system theme mode

### DIFF
--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -151,6 +151,7 @@ add_file_folder("Source/UI"
     src/ui/FredView.h
     src/ui/Theme.cpp
     src/ui/Theme.h
+    src/ui/ThemeMode.h
     src/ui/QtGraphicsOperations.cpp
     src/ui/QtGraphicsOperations.h
 )

--- a/qtfred/src/main.cpp
+++ b/qtfred/src/main.cpp
@@ -4,7 +4,6 @@
 
 #include <QApplication>
 #include <QDir>
-#include <QSettings>
 #include <QSplashScreen>
 #include <QStyleFactory>
 #include <QTimer>
@@ -107,12 +106,7 @@ int main(int argc, char* argv[]) {
 
 	// Use Fusion style unconditionally — required for reliable dynamic palette switching
 	QApplication::setStyle(QStyleFactory::create("Fusion"));
-	{
-		QSettings startupSettings;
-		startupSettings.beginGroup("Preferences");
-		fso::fred::applyEditorTheme(startupSettings.value("dark_mode", false).toBool());
-		startupSettings.endGroup();
-	}
+	fso::fred::applyEditorTheme(fso::fred::readThemeModeSetting());
 
 	// Expect that the platform library is in the same directory
 	QCoreApplication::addLibraryPath(QCoreApplication::applicationDirPath());	

--- a/qtfred/src/mission/EditorViewport.cpp
+++ b/qtfred/src/mission/EditorViewport.cpp
@@ -5,6 +5,7 @@
 #include <render/3d.h>
 #include <ship/ship.h>
 #include "ui/ControlBindings.h"
+#include "ui/Theme.h"
 
 #include "object.h"
 
@@ -142,7 +143,8 @@ void EditorViewport::loadSettings() {
 	Show_sexp_help_mission_cutscenes   = settings.value("show_sexp_help_mission_cutscenes",   Show_sexp_help_mission_cutscenes).toBool();
 	Show_sexp_help_ship_editor         = settings.value("show_sexp_help_ship_editor",         Show_sexp_help_ship_editor).toBool();
 	Show_sexp_help_wing_editor         = settings.value("show_sexp_help_wing_editor",         Show_sexp_help_wing_editor).toBool();
-	Dark_mode                          = settings.value("dark_mode",                          Dark_mode).toBool();
+	// Handles its own group, since main.cpp reads it before the viewport exists.
+	Theme_mode                         = readThemeModeSetting();
 
 	view.Universal_heading                 = settings.value("view_universal_heading",                 view.Universal_heading).toBool();
 	view.Show_stars                        = settings.value("view_show_stars",                        view.Show_stars).toBool();
@@ -189,7 +191,7 @@ void EditorViewport::saveSettings() const {
 	settings.setValue("show_sexp_help_mission_cutscenes",    Show_sexp_help_mission_cutscenes);
 	settings.setValue("show_sexp_help_ship_editor",          Show_sexp_help_ship_editor);
 	settings.setValue("show_sexp_help_wing_editor",          Show_sexp_help_wing_editor);
-	settings.setValue("dark_mode",                           Dark_mode);
+	writeThemeModeSetting(Theme_mode);
 
 	settings.setValue("view_universal_heading",                 view.Universal_heading);
 	settings.setValue("view_show_stars",                        view.Show_stars);

--- a/qtfred/src/mission/EditorViewport.h
+++ b/qtfred/src/mission/EditorViewport.h
@@ -5,6 +5,7 @@
 #include "FredRenderer.h"
 #include "Editor.h"
 #include "IDialogProvider.h"
+#include "ui/ThemeMode.h"
 
 #include <object/object.h>
 
@@ -229,7 +230,7 @@ class EditorViewport {
 	bool Show_sexp_help_ship_editor = false;
 	bool Show_sexp_help_wing_editor = false;
 
-	bool Dark_mode = false;
+	ThemeMode Theme_mode = ThemeMode::System;
 
 	void saveSettings() const;
 

--- a/qtfred/src/mission/dialogs/PreferencesDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/PreferencesDialogModel.cpp
@@ -22,7 +22,7 @@ PreferencesDialogModel::PreferencesDialogModel(QObject* parent, EditorViewport* 
 	, _showSexpHelpMissionCutscenes(viewport->Show_sexp_help_mission_cutscenes)
 	, _showSexpHelpShipEditor(viewport->Show_sexp_help_ship_editor)
 	, _showSexpHelpWingEditor(viewport->Show_sexp_help_wing_editor)
-	, _darkMode(viewport->Dark_mode)
+	, _themeMode(viewport->Theme_mode)
 	, _toolbarIconSize(viewport->toolbar_icon_size)
 	, _outlineLod(viewport->view.Outline_lod)
 	, _invertOrbitX(viewport->camera.getInvertOrbitX())
@@ -48,7 +48,7 @@ PreferencesDialogModel::PreferencesDialogModel(QObject* parent, EditorViewport* 
 }
 
 bool PreferencesDialogModel::apply() {
-	const bool darkModeChanged = (_viewport->Dark_mode != _darkMode);
+	const bool themeModeChanged = (_viewport->Theme_mode != _themeMode);
 
 	_viewport->Offer_autosave_recovery   = _offerAutosaveRecovery;
 	_viewport->autosave_interval_seconds = _autosaveIntervalSeconds;
@@ -63,15 +63,15 @@ bool PreferencesDialogModel::apply() {
 	_viewport->Show_sexp_help_mission_cutscenes = _showSexpHelpMissionCutscenes;
 	_viewport->Show_sexp_help_ship_editor       = _showSexpHelpShipEditor;
 	_viewport->Show_sexp_help_wing_editor       = _showSexpHelpWingEditor;
-	_viewport->Dark_mode                        = _darkMode;
+	_viewport->Theme_mode                       = _themeMode;
 	_viewport->toolbar_icon_size                = _toolbarIconSize;
 	_viewport->view.Outline_lod                 = _outlineLod;
 	_viewport->camera.setInvertOrbitX(_invertOrbitX);
 	_viewport->camera.setInvertOrbitY(_invertOrbitY);
 
 	_viewport->saveSettings();
-	if (darkModeChanged) {
-		applyEditorTheme(_darkMode);
+	if (themeModeChanged) {
+		applyEditorTheme(_themeMode);
 	}
 
 	auto& bindings = ControlBindings::instance();
@@ -166,8 +166,8 @@ void PreferencesDialogModel::setShowSexpHelpShipEditor(bool value) { modify(_sho
 bool PreferencesDialogModel::getShowSexpHelpWingEditor() const { return _showSexpHelpWingEditor; }
 void PreferencesDialogModel::setShowSexpHelpWingEditor(bool value) { modify(_showSexpHelpWingEditor, value); }
 
-bool PreferencesDialogModel::getDarkMode() const { return _darkMode; }
-void PreferencesDialogModel::setDarkMode(bool value) { modify(_darkMode, value); }
+ThemeMode PreferencesDialogModel::getThemeMode() const { return _themeMode; }
+void PreferencesDialogModel::setThemeMode(ThemeMode value) { modify(_themeMode, value); }
 
 int  PreferencesDialogModel::getToolbarIconSize() const { return _toolbarIconSize; }
 void PreferencesDialogModel::setToolbarIconSize(int size) { modify(_toolbarIconSize, size); }

--- a/qtfred/src/mission/dialogs/PreferencesDialogModel.h
+++ b/qtfred/src/mission/dialogs/PreferencesDialogModel.h
@@ -2,6 +2,7 @@
 
 #include "mission/dialogs/AbstractDialogModel.h"
 #include "ui/ControlBindings.h"
+#include "ui/ThemeMode.h"
 
 namespace fso::fred::dialogs {
 
@@ -54,8 +55,8 @@ public:
 	bool getShowSexpHelpWingEditor() const;
 	void setShowSexpHelpWingEditor(bool value);
 
-	bool getDarkMode() const;
-	void setDarkMode(bool value);
+	ThemeMode getThemeMode() const;
+	void setThemeMode(ThemeMode value);
 
 	int  getToolbarIconSize() const;
 	void setToolbarIconSize(int size);
@@ -100,7 +101,7 @@ private:
 	bool _showSexpHelpMissionCutscenes;
 	bool _showSexpHelpShipEditor;
 	bool _showSexpHelpWingEditor;
-	bool _darkMode;
+	ThemeMode _themeMode;
 	int  _toolbarIconSize;
 	int  _outlineLod;
 

--- a/qtfred/src/ui/Theme.cpp
+++ b/qtfred/src/ui/Theme.cpp
@@ -8,6 +8,8 @@
 #include <QPainterPath>
 #include <QPalette>
 #include <QPixmap>
+#include <QSettings>
+#include <QStyleHints>
 
 namespace {
 class PaletteChangeFilter : public QObject {
@@ -187,7 +189,29 @@ QMenu::separator {
 
 namespace fso::fred {
 
-void applyEditorTheme(bool darkMode)
+namespace {
+
+constexpr auto SETTINGS_GROUP = "Preferences";
+constexpr auto THEME_MODE_KEY = "theme_mode";
+
+ThemeMode Current_mode = ThemeMode::System;
+bool System_hook_installed = false;
+
+bool resolveDark(ThemeMode mode)
+{
+	switch (mode) {
+	case ThemeMode::Light:
+		return false;
+	case ThemeMode::Dark:
+		return true;
+	case ThemeMode::System:
+		// Unknown when the OS reports no scheme which lands on light theme
+		return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+	}
+	return false;
+}
+
+void applyPalette(bool darkMode)
 {
 	if (darkMode) {
 		QPalette p;
@@ -239,6 +263,60 @@ void applyEditorTheme(bool darkMode)
 		p.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(160, 160, 160));
 		qApp->setPalette(p);
 		qApp->setStyleSheet(LIGHT_BUTTON_QSS);
+	}
+}
+
+} // namespace
+
+void applyEditorTheme(ThemeMode mode)
+{
+	Current_mode = mode;
+
+	// Installed once and left in place, since the mode can return to System later.
+	if (!System_hook_installed) {
+		QObject::connect(QGuiApplication::styleHints(),
+			&QStyleHints::colorSchemeChanged,
+			qApp,
+			[](Qt::ColorScheme) {
+				if (Current_mode == ThemeMode::System) {
+					applyPalette(resolveDark(ThemeMode::System));
+				}
+			});
+		System_hook_installed = true;
+	}
+
+	applyPalette(resolveDark(mode));
+}
+
+ThemeMode readThemeModeSetting()
+{
+	QSettings settings;
+	settings.beginGroup(SETTINGS_GROUP);
+
+	const auto value = settings.value(THEME_MODE_KEY).toString();
+	if (value == "light") {
+		return ThemeMode::Light;
+	}
+	if (value == "dark") {
+		return ThemeMode::Dark;
+	}
+	return ThemeMode::System;
+}
+
+void writeThemeModeSetting(ThemeMode mode)
+{
+	QSettings settings;
+	settings.beginGroup(SETTINGS_GROUP);
+	switch (mode) {
+	case ThemeMode::Light:
+		settings.setValue(THEME_MODE_KEY, "light");
+		break;
+	case ThemeMode::Dark:
+		settings.setValue(THEME_MODE_KEY, "dark");
+		break;
+	case ThemeMode::System:
+		settings.setValue(THEME_MODE_KEY, "system");
+		break;
 	}
 }
 

--- a/qtfred/src/ui/Theme.h
+++ b/qtfred/src/ui/Theme.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ui/ThemeMode.h"
+
 #include <QAbstractButton>
 #include <QAction>
 #include <QColor>
@@ -11,7 +13,14 @@
 namespace fso::fred {
 
 // Apply the Fusion-compatible light or dark palette and button stylesheet.
-void applyEditorTheme(bool darkMode);
+// System resolves against the OS color scheme, and the theme re-applies on its own
+// whenever the OS scheme changes while this mode is active.
+void applyEditorTheme(ThemeMode mode);
+
+// Read/write the theme mode preference. Both live here so the settings group and key
+// stay in one place: the startup path applies the theme before EditorViewport exists.
+ThemeMode readThemeModeSetting();
+void writeThemeModeSetting(ThemeMode mode);
 
 // Draw a palette-aware icon for a standard Qt pixmap using QPainter.
 // Falls back to the style's own icon for unhandled StandardPixmap values.

--- a/qtfred/src/ui/ThemeMode.h
+++ b/qtfred/src/ui/ThemeMode.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace fso::fred {
+
+// How the editor picks between the light and dark palette. System follows the OS
+// light/dark setting and re-applies whenever it changes.
+//
+// Kept apart from Theme.h so the mission layer can store the preference without
+// pulling QtWidgets into EditorViewport.h.
+enum class ThemeMode { System, Light, Dark };
+
+} // namespace fso::fred

--- a/qtfred/src/ui/dialogs/PreferencesDialog.cpp
+++ b/qtfred/src/ui/dialogs/PreferencesDialog.cpp
@@ -11,6 +11,31 @@
 namespace fso::fred::dialogs {
 namespace {
 
+int themeModeToIndex(ThemeMode mode)
+{
+	switch (mode) {
+	case ThemeMode::Light:
+		return 1;
+	case ThemeMode::Dark:
+		return 2;
+	case ThemeMode::System:
+		break;
+	}
+	return 0;
+}
+
+ThemeMode themeModeFromIndex(int index)
+{
+	switch (index) {
+	case 1:
+		return ThemeMode::Light;
+	case 2:
+		return ThemeMode::Dark;
+	default:
+		return ThemeMode::System;
+	}
+}
+
 class ControlKeySequenceEdit : public QKeySequenceEdit {
 public:
 	explicit ControlKeySequenceEdit(const QKeySequence& sequence, QWidget* parent)
@@ -94,7 +119,7 @@ void PreferencesDialog::updateUi() {
 	ui->alwaysSaveDisplayNames->setChecked(_model->getAlwaysSaveDisplayNames());
 	ui->checkPotentialIssues->setChecked(_model->getCheckPotentialIssues());
 	ui->applyAutoCorrections->setChecked(_model->getApplyAutoCorrections());
-	ui->themeCombo->setCurrentIndex(_model->getDarkMode() ? 1 : 0);
+	ui->themeCombo->setCurrentIndex(themeModeToIndex(_model->getThemeMode()));
 
 	const int iconSize = _model->getToolbarIconSize();
 	ui->toolbarIconSizeCombo->setCurrentIndex(iconSize <= 16 ? 0 : iconSize >= 32 ? 2 : 1);
@@ -173,7 +198,7 @@ void PreferencesDialog::on_outlineLodCombo_currentIndexChanged(int index) {
 }
 
 void PreferencesDialog::on_themeCombo_currentIndexChanged(int index) {
-	_model->setDarkMode(index == 1);
+	_model->setThemeMode(themeModeFromIndex(index));
 }
 
 void PreferencesDialog::on_showSexpHelpMissionEvents_toggled(bool checked) {

--- a/qtfred/ui/PreferencesDialog.ui
+++ b/qtfred/ui/PreferencesDialog.ui
@@ -40,8 +40,13 @@
           <item row="0" column="1">
            <widget class="QComboBox" name="themeCombo">
             <property name="toolTip">
-             <string>Overall color theme for the QtFRED interface. Dark applies a dark palette to the editor UI.</string>
+             <string>Overall color theme for the QtFRED interface. Follow system tracks your operating system's light/dark setting and switches automatically when it changes.</string>
             </property>
+            <item>
+             <property name="text">
+              <string>Follow system</string>
+             </property>
+            </item>
             <item>
              <property name="text">
               <string>Light</string>


### PR DESCRIPTION
Replaces the binary dark/light theme setting with an enumeration so we can have dark/light/system. System should change during runtime if the system theme changes. Tested and working on Windows. Not verified on Linux or Mac but the code should work identically.