### PR TITLE
More Search UI/UX Enhancements

### DIFF
--- a/code/missioneditor/sexp_tree_model.cpp
+++ b/code/missioneditor/sexp_tree_model.cpp
@@ -28,6 +28,7 @@
 // Used by both FRED2 (MFC) and QtFRED (Qt) sexp tree implementations.
 
 constexpr int TREE_NODE_INCREMENT = 100;
+constexpr int MIN_SEXP_SEARCH_COST = 10;
 
 // -----------------------------------------------------------------------
 // sexp_list_item implementation
@@ -952,7 +953,7 @@ SCP_string SexpTreeModel::match_closest_operator(const SCP_string& str, int node
 	opf = query_operator_argument_type(op, arg_num);
 
 	// find the best operator
-	int best = sexp_match_closest_operator(str, opf, 10);
+	int best = sexp_match_closest_operator(str, opf, MIN_SEXP_SEARCH_COST);
 	if (best < 0) {
 		return str;
 	}

--- a/code/missioneditor/sexp_tree_model.cpp
+++ b/code/missioneditor/sexp_tree_model.cpp
@@ -952,9 +952,8 @@ SCP_string SexpTreeModel::match_closest_operator(const SCP_string& str, int node
 	opf = query_operator_argument_type(op, arg_num);
 
 	// find the best operator
-	int best = sexp_match_closest_operator(str, opf);
+	int best = sexp_match_closest_operator(str, opf, 10);
 	if (best < 0) {
-		Warning(LOCATION, "Unable to find an operator match for string '%s' and argument type %d", str.c_str(), opf);
 		return str;
 	}
 	return Operators[best].text;

--- a/code/parse/sexp.cpp
+++ b/code/parse/sexp.cpp
@@ -35315,12 +35315,15 @@ bool sexp_query_type_match(int opf, int opr)
  * Finds the operator that is the best textual match for the input string, given the required OPF type.  For equal matches,
  * the alphabetically earliest operator is returned.
  * 
+ * min defaults to SCP_string::npos, when specified to another value, this function will not always return a match  
+ *
  * Note: Returns the operator index, not the operator value.
  */
-int sexp_match_closest_operator(const SCP_string &str, int opf)
+int sexp_match_closest_operator(const SCP_string &str, int opf, size_t min)
 {
+	// Cyborg - This bool setup helps with readability
+	bool return_any = (min == SCP_string::npos);
 	int best = -1;
-	size_t min = SCP_string::npos;
 
 	for (int op_index : Sorted_operator_indexes)
 	{
@@ -35330,7 +35333,7 @@ int sexp_match_closest_operator(const SCP_string &str, int opf)
 		if (sexp_query_type_match(opf, opr))
 		{
 			size_t cost = stringcost(op_text, str, Max_operator_length, stringcost_tolower_equal);
-			if (best < 0 || cost < min)
+			if (cost < min || (return_any && best == -1) )
 			{
 				min = cost;
 				best = op_index;

--- a/code/parse/sexp.h
+++ b/code/parse/sexp.h
@@ -1494,7 +1494,7 @@ extern std::pair<int, sexp_src> query_referenced_in_sexp(sexp_ref_type type, con
 extern void stuff_sexp_text_string(SCP_string &dest, int node, int mode);
 extern int build_sexp_string(SCP_string &accumulator, int cur_node, int level, int mode);
 extern bool sexp_query_type_match(int opf, int opr);
-extern int sexp_match_closest_operator(const SCP_string &str, int opf);
+extern int sexp_match_closest_operator(const SCP_string &str, int opf, size_t min = SCP_string::npos);
 extern bool sexp_recoverable_error(int num);
 extern const char *sexp_error_message(int num);
 extern int count_free_sexp_nodes();

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -1151,7 +1151,6 @@ std::unique_ptr<QMenu> sexp_tree_view::buildContextMenu(QTreeWidgetItem* h) {
 	auto replace_op_menu = popup_menu->addMenu(tr("Replace Operator"));
 	
 	auto replace_data_menu = popup_menu->addMenu(tr("Replace Data"));
-	popup_menu->addAction(tr("Search for Replacement"), QKeySequence(Qt::CTRL | Qt::Key_S), this, [this]() { editActionHandlerHelper(); });
 
 	auto replace_number_act =
 		replace_data_menu->addAction(tr("Number"), this, [this]() { replaceNumberDataHandler(); });
@@ -1161,6 +1160,7 @@ std::unique_ptr<QMenu> sexp_tree_view::buildContextMenu(QTreeWidgetItem* h) {
 	replace_string_act->setEnabled(false);
 	replace_data_menu->addSeparator();
 
+	popup_menu->addAction(tr("Search for Replacement"), QKeySequence(Qt::CTRL | Qt::Key_S), this, [this]() { editActionHandlerHelper(); });
 	popup_menu->addSection("Variables");
 
 	auto modify_variable_act = popup_menu->addAction(tr("Add/Modify Variable"), this, [this]() {

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -2004,12 +2004,8 @@ void sexp_tree_view::editActionHandlerHelper(){
 	}
 
 	item_index = get_node(item);
-
-	if (_model.compute_context_menu_state().can_edit_text) {
-		editDataActionHandler();
-	} else {
-		openNodeEditor(currentItem());
-	}
+	// No longer gated to just certain types.
+	openNodeEditor(currentItem());
 }
 
 // Public entry point for deleting the currently selected item. Simply delegates to deleteActionHandler().

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -1144,9 +1144,9 @@ std::unique_ptr<QMenu> sexp_tree_view::buildContextMenu(QTreeWidgetItem* h) {
 
 	auto replace_op_menu = popup_menu->addMenu(tr("Replace Operator"));
 	
-	popup_menu->addAction(tr("Search Operators"), this, [this]() { editActionHandlerHelper(); });
-
 	auto replace_data_menu = popup_menu->addMenu(tr("Replace Data"));
+	popup_menu->addAction(tr("Search for Replacement"), QKeySequence(Qt::CTRL | Qt::Key_S), this, [this]() { editActionHandlerHelper(); });
+
 	auto replace_number_act =
 		replace_data_menu->addAction(tr("Number"), this, [this]() { replaceNumberDataHandler(); });
 	replace_number_act->setEnabled(false);

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -1622,12 +1622,14 @@ void sexp_tree_view::filterOperatorPopup(const QString& text)
 		_opList->addItems(_opAll);
 	} else {
 		for (const auto& s : _opAll) {
-			if (s.startsWith(text, Qt::CaseInsensitive))
+			if (s.startsWith(text, Qt::CaseInsensitive)){
 				_opList->addItem(s);
+				found_list.insert(s);
+			}
 		}
 
 		for (const auto& s : _opAll) {
-			if (s.contains(text, Qt::CaseInsensitive) && _opList->findItems(s, Qt::MatchExactly).isEmpty())
+			if (!found_list.insert(s).second && s.contains(text, Qt::CaseInsensitive))
 				_opList->addItem(s);
 		}
 	}
@@ -2011,7 +2013,7 @@ void sexp_tree_view::editActionHandlerHelper(){
 
 	item_index = get_node(item);
 	// No longer gated to just certain types.
-	openNodeEditor(currentItem());
+	openNodeEditor(item);
 }
 
 // Public entry point for deleting the currently selected item. Simply delegates to deleteActionHandler().

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -1608,11 +1608,18 @@ void sexp_tree_view::startOperatorQuickSearch(QTreeWidgetItem* item, const QStri
 void sexp_tree_view::filterOperatorPopup(const QString& text)
 {
 	_opList->clear();
+	SCP_set<QString> found_list;
+
 	if (text.isEmpty()) {
 		_opList->addItems(_opAll);
 	} else {
 		for (const auto& s : _opAll) {
-			if (s.contains(text, Qt::CaseInsensitive))
+			if (s.startsWith(text, Qt::CaseInsensitive))
+				_opList->addItem(s);
+		}
+
+		for (const auto& s : _opAll) {
+			if (s.contains(text, Qt::CaseInsensitive) && _opList->findItems(s, Qt::MatchExactly).isEmpty())
 				_opList->addItem(s);
 		}
 	}

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -1629,7 +1629,7 @@ void sexp_tree_view::filterOperatorPopup(const QString& text)
 		}
 
 		for (const auto& s : _opAll) {
-			if (!found_list.insert(s).second && s.contains(text, Qt::CaseInsensitive))
+			if (found_list.insert(s).second && s.contains(text, Qt::CaseInsensitive))
 				_opList->addItem(s);
 		}
 	}

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -260,6 +260,12 @@ sexp_tree_view::sexp_tree_view(QWidget* parent) : QTreeWidget(parent), _actions(
 	installShortcut(QKeySequence::Delete,
 		[](const SexpContextMenuState& s) { return s.can_delete; },
 		[this]() { deleteActionHandler(); });
+
+	// This keyboard shortcut does not need as much state checking because the helper 
+	// handles security checks and what to call, and any node should work here.
+	auto* shortcut = new QShortcut(QKeySequence(Qt::CTRL | Qt::Key_S), this);
+	shortcut->setContext(Qt::WidgetShortcut);
+	connect(shortcut, &QShortcut::activated, this, &sexp_tree_view::editActionHandlerHelper);
 }
 
 
@@ -1999,7 +2005,7 @@ void sexp_tree_view::editActionHandlerHelper(){
 	auto item = currentItem();
 	
 	// Just to be extra safe, early exit when an item is not selected
-	if (item == nullptr || !_interface) {
+	if (_currently_editing || _opPopupActive || item == nullptr || !_interface) {
 		return;
 	}
 

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -1143,6 +1143,8 @@ std::unique_ptr<QMenu> sexp_tree_view::buildContextMenu(QTreeWidgetItem* h) {
 	popup_menu->addSeparator();
 
 	auto replace_op_menu = popup_menu->addMenu(tr("Replace Operator"));
+	
+	popup_menu->addAction(tr("Search Operators"), this, [this]() { editActionHandlerHelper(); });
 
 	auto replace_data_menu = popup_menu->addMenu(tr("Replace Data"));
 	auto replace_number_act =

--- a/qtfred/src/ui/widgets/sexp_tree_view.cpp
+++ b/qtfred/src/ui/widgets/sexp_tree_view.cpp
@@ -1996,7 +1996,14 @@ void sexp_tree_view::handleDoubleClick() {
 
 // Helper function for making sure that search and edit are initiated consistently 
 void sexp_tree_view::editActionHandlerHelper(){
-	item_index = get_node(currentItem());
+	auto item = currentItem();
+	
+	// Just to be extra safe, early exit when an item is not selected
+	if (item == nullptr || !_interface) {
+		return;
+	}
+
+	item_index = get_node(item);
 
 	if (_model.compute_context_menu_state().can_edit_text) {
 		editDataActionHandler();


### PR DESCRIPTION
This has a few upgrades to the sexp search system, including:

- Adding "Search for Replacement" to context (right-click) menu
- Adding Ctrl+S as a shortcut to initiate search (and item edit)
- Re-enabling search for numeric sexps (which seems to have been disabled by accident, understandable from how big the original PR was)
- Keeps the search from picking results that have nothing to do with the searched string
- Search results will now show strings that *start* with the search string first.  More work would be required to further improve search, like sorting by how soon the search string appears in the text.
- Double click will *also* now initiate search or item edit, depending on the node type, if there are no children to expand.

Each feature was individually tested, and I'm open to feedback on adjustments.

Fixes #7604