### PR TITLE
Qtfred event/campaign editor enhancements

### DIFF
--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.cpp
@@ -1408,7 +1408,45 @@ void CampaignEditorDialogModel::moveBranchDown()
 	// Swap the selected branch with the one below it.
 	std::swap(mission.branches[m_current_branch_index], mission.branches[m_current_branch_index + 1]);
 	set_modified();
-	
+
+	m_current_branch_index = -1; // set no branch selected
+	// Rebuild the visual tree from the model's authoritative state
+	m_tree_ops.rebuildBranchTree(mission.branches, mission.filename);
+}
+
+void CampaignEditorDialogModel::moveBranchToTop()
+{
+	// Ensure a mission and a branch are currently selected.
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index) || m_current_branch_index == 0) {
+		return;
+	}
+	// Rotate the selected branch to the front, preserving the order of the rest.
+	std::rotate(mission.branches.begin(), mission.branches.begin() + m_current_branch_index, mission.branches.begin() + m_current_branch_index + 1);
+	set_modified();
+
+	m_current_branch_index = -1; // set no branch selected
+	// Rebuild the visual tree from the model's authoritative state
+	m_tree_ops.rebuildBranchTree(mission.branches, mission.filename);
+}
+
+void CampaignEditorDialogModel::moveBranchToBottom()
+{
+	// Ensure a mission and a branch are currently selected.
+	if (!SCP_vector_inbounds(m_missions, m_current_mission_index)) {
+		return;
+	}
+	auto& mission = m_missions[m_current_mission_index];
+	if (!SCP_vector_inbounds(mission.branches, m_current_branch_index) || m_current_branch_index == static_cast<int>(mission.branches.size()) - 1) {
+		return;
+	}
+	// Rotate the selected branch to the back, preserving the order of the rest.
+	std::rotate(mission.branches.begin() + m_current_branch_index, mission.branches.begin() + m_current_branch_index + 1, mission.branches.end());
+	set_modified();
+
 	m_current_branch_index = -1; // set no branch selected
 	// Rebuild the visual tree from the model's authoritative state
 	m_tree_ops.rebuildBranchTree(mission.branches, mission.filename);

--- a/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/CampaignEditorDialogModel.h
@@ -159,6 +159,8 @@ class CampaignEditorDialogModel : public AbstractDialogModel {
 	void removeBranch(int mission_index, int branch_index);
 	void moveBranchUp();
 	void moveBranchDown();
+	void moveBranchToTop();
+	void moveBranchToBottom();
 	bool getCurrentBranchIsSpecial() const;
 
 	void setModified() { set_modified(); }

--- a/qtfred/src/mission/dialogs/MissionEventsDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/MissionEventsDialogModel.cpp
@@ -1125,6 +1125,29 @@ void MissionEventsDialogModel::moveMessageDown()
 	set_modified();
 }
 
+void MissionEventsDialogModel::moveMessageToTop()
+{
+	if (!SCP_vector_inbounds(m_messages, m_cur_msg) || m_cur_msg == 0)
+		return;
+
+	// rotate the selected message to the front, preserving the order of the rest
+	std::rotate(m_messages.begin(), m_messages.begin() + m_cur_msg, m_messages.begin() + m_cur_msg + 1);
+	setCurrentlySelectedMessage(0);
+	set_modified();
+}
+
+void MissionEventsDialogModel::moveMessageToBottom()
+{
+	const int last = static_cast<int>(m_messages.size()) - 1;
+	if (!SCP_vector_inbounds(m_messages, m_cur_msg) || m_cur_msg >= last)
+		return;
+
+	// rotate the selected message to the back, preserving the order of the rest
+	std::rotate(m_messages.begin() + m_cur_msg, m_messages.begin() + m_cur_msg + 1, m_messages.end());
+	setCurrentlySelectedMessage(last);
+	set_modified();
+}
+
 
 SCP_string MissionEventsDialogModel::getMessageName() const
 {

--- a/qtfred/src/mission/dialogs/MissionEventsDialogModel.h
+++ b/qtfred/src/mission/dialogs/MissionEventsDialogModel.h
@@ -102,6 +102,8 @@ class MissionEventsDialogModel : public AbstractDialogModel {
 	void deleteMessage();
 	void moveMessageUp();
 	void moveMessageDown();
+	void moveMessageToTop();
+	void moveMessageToBottom();
 	SCP_string getMessageName() const;
 	void setMessageName(const SCP_string& name);
 	SCP_string getMessageText() const;

--- a/qtfred/src/ui/Theme.cpp
+++ b/qtfred/src/ui/Theme.cpp
@@ -454,6 +454,77 @@ void bindStandardIcon(QAbstractButton* btn, QStyle::StandardPixmap sp)
 	qApp->installEventFilter(filter);
 }
 
+QIcon makeThemedIcon(CustomIcon icon, const QColor& color, int size)
+{
+	QPixmap pm(size, size);
+	pm.fill(Qt::transparent);
+	QPainter p(&pm);
+	p.setRenderHint(QPainter::Antialiasing);
+	p.setPen(Qt::NoPen);
+	p.setBrush(color);
+
+	const qreal m = size * 0.15;
+	const QRectF full(m, m, size - 2 * m, size - 2 * m);
+
+	const qreal barH = full.height() * 0.16; // thickness of the top/bottom "end" bar
+	const qreal gap  = full.height() * 0.10; // space between the bar and the arrow
+
+	// Fill a shaft+head arrow (single polygon, no seam) inside the given sub-rect.
+	auto drawArrow = [&](const QRectF& r, bool up) {
+		const qreal shaftW   = full.width() * 0.38;
+		const qreal shaftOff = (r.width() - shaftW) / 2.0;
+		const qreal headLen  = r.height() * 0.55;
+		const qreal cx = r.center().x();
+		QPainterPath path;
+		if (up) {
+			const qreal headY = r.top() + headLen;
+			path.moveTo(cx,                            r.top());    // tip
+			path.lineTo(r.right(),                     headY);      // head right corner
+			path.lineTo(r.left() + shaftOff + shaftW,  headY);      // shoulder right
+			path.lineTo(r.left() + shaftOff + shaftW,  r.bottom()); // shaft bottom right
+			path.lineTo(r.left() + shaftOff,           r.bottom()); // shaft bottom left
+			path.lineTo(r.left() + shaftOff,           headY);      // shoulder left
+			path.lineTo(r.left(),                      headY);      // head left corner
+		} else {
+			const qreal headY = r.bottom() - headLen;
+			path.moveTo(r.left() + shaftOff,           r.top());    // shaft top left
+			path.lineTo(r.left() + shaftOff + shaftW,  r.top());    // shaft top right
+			path.lineTo(r.left() + shaftOff + shaftW,  headY);      // shoulder right
+			path.lineTo(r.right(),                     headY);      // head right corner
+			path.lineTo(cx,                            r.bottom()); // tip
+			path.lineTo(r.left(),                      headY);      // head left corner
+			path.lineTo(r.left() + shaftOff,           headY);      // shoulder left
+		}
+		path.closeSubpath();
+		p.drawPath(path);
+	};
+
+	switch (icon) {
+	case CustomIcon::MoveToTop:
+		p.drawRect(QRectF(full.left(), full.top(), full.width(), barH));
+		drawArrow(QRectF(full.left(), full.top() + barH + gap, full.width(), full.height() - barH - gap), true);
+		break;
+	case CustomIcon::MoveToBottom:
+		p.drawRect(QRectF(full.left(), full.bottom() - barH, full.width(), barH));
+		drawArrow(QRectF(full.left(), full.top(), full.width(), full.height() - barH - gap), false);
+		break;
+	}
+
+	p.end();
+	return {pm};
+}
+
+void bindCustomIcon(QAbstractButton* btn, CustomIcon icon)
+{
+	auto refresh = [btn, icon]() {
+		const QColor color = qApp->palette().color(QPalette::ButtonText);
+		btn->setIcon(makeThemedIcon(icon, color));
+	};
+	refresh();
+	auto* filter = new PaletteChangeFilter(btn, refresh);
+	qApp->installEventFilter(filter);
+}
+
 void bindThemeIcon(QAction* action, const QString& baseName)
 {
 	auto refresh = [action, baseName]() {

--- a/qtfred/src/ui/Theme.cpp
+++ b/qtfred/src/ui/Theme.cpp
@@ -466,11 +466,11 @@ QIcon makeThemedIcon(CustomIcon icon, const QColor& color, int size)
 	const qreal m = size * 0.15;
 	const QRectF full(m, m, size - 2 * m, size - 2 * m);
 
-	const qreal barH = full.height() * 0.16; // thickness of the top/bottom "end" bar
-	const qreal gap  = full.height() * 0.10; // space between the bar and the arrow
+	const qreal bar = full.width() * 0.16; // thickness of the "end" bar (full is square)
+	const qreal gap = full.width() * 0.10; // space between the bar and the arrow
 
-	// Fill a shaft+head arrow (single polygon, no seam) inside the given sub-rect.
-	auto drawArrow = [&](const QRectF& r, bool up) {
+	// Fill a vertical shaft+head arrow (single polygon, no seam) inside the sub-rect.
+	auto drawVArrow = [&](const QRectF& r, bool up) {
 		const qreal shaftW   = full.width() * 0.38;
 		const qreal shaftOff = (r.width() - shaftW) / 2.0;
 		const qreal headLen  = r.height() * 0.55;
@@ -499,14 +499,52 @@ QIcon makeThemedIcon(CustomIcon icon, const QColor& color, int size)
 		p.drawPath(path);
 	};
 
+	// Fill a horizontal shaft+head arrow (single polygon, no seam) inside the sub-rect.
+	auto drawHArrow = [&](const QRectF& r, bool left) {
+		const qreal shaftW   = full.height() * 0.38;
+		const qreal shaftOff = (r.height() - shaftW) / 2.0;
+		const qreal headLen  = r.width() * 0.55;
+		const qreal cy = r.center().y();
+		QPainterPath path;
+		if (left) {
+			const qreal headX = r.left() + headLen;
+			path.moveTo(r.left(),  cy);                          // tip
+			path.lineTo(headX,     r.top());                     // head top corner
+			path.lineTo(headX,     r.top() + shaftOff);          // shoulder top
+			path.lineTo(r.right(), r.top() + shaftOff);          // shaft right top
+			path.lineTo(r.right(), r.top() + shaftOff + shaftW); // shaft right bottom
+			path.lineTo(headX,     r.top() + shaftOff + shaftW); // shoulder bottom
+			path.lineTo(headX,     r.bottom());                  // head bottom corner
+		} else {
+			const qreal headX = r.right() - headLen;
+			path.moveTo(r.left(),  r.top() + shaftOff);          // shaft left top
+			path.lineTo(headX,     r.top() + shaftOff);          // shoulder top
+			path.lineTo(headX,     r.top());                     // head top corner
+			path.lineTo(r.right(), cy);                          // tip
+			path.lineTo(headX,     r.bottom());                  // head bottom corner
+			path.lineTo(headX,     r.top() + shaftOff + shaftW); // shoulder bottom
+			path.lineTo(r.left(),  r.top() + shaftOff + shaftW); // shaft left bottom
+		}
+		path.closeSubpath();
+		p.drawPath(path);
+	};
+
 	switch (icon) {
 	case CustomIcon::MoveToTop:
-		p.drawRect(QRectF(full.left(), full.top(), full.width(), barH));
-		drawArrow(QRectF(full.left(), full.top() + barH + gap, full.width(), full.height() - barH - gap), true);
+		p.drawRect(QRectF(full.left(), full.top(), full.width(), bar));
+		drawVArrow(QRectF(full.left(), full.top() + bar + gap, full.width(), full.height() - bar - gap), true);
 		break;
 	case CustomIcon::MoveToBottom:
-		p.drawRect(QRectF(full.left(), full.bottom() - barH, full.width(), barH));
-		drawArrow(QRectF(full.left(), full.top(), full.width(), full.height() - barH - gap), false);
+		p.drawRect(QRectF(full.left(), full.bottom() - bar, full.width(), bar));
+		drawVArrow(QRectF(full.left(), full.top(), full.width(), full.height() - bar - gap), false);
+		break;
+	case CustomIcon::MoveToLeft:
+		p.drawRect(QRectF(full.left(), full.top(), bar, full.height()));
+		drawHArrow(QRectF(full.left() + bar + gap, full.top(), full.width() - bar - gap, full.height()), true);
+		break;
+	case CustomIcon::MoveToRight:
+		p.drawRect(QRectF(full.right() - bar, full.top(), bar, full.height()));
+		drawHArrow(QRectF(full.left(), full.top(), full.width() - bar - gap, full.height()), false);
 		break;
 	}
 

--- a/qtfred/src/ui/Theme.h
+++ b/qtfred/src/ui/Theme.h
@@ -29,6 +29,19 @@ QIcon makeThemedIcon(QStyle::StandardPixmap sp, const QColor& color, int size = 
 // Bind a palette-aware icon to a button and refresh it when the theme changes.
 void bindStandardIcon(QAbstractButton* btn, QStyle::StandardPixmap sp);
 
+// Palette-aware icons drawn by QPainter that have no QStyle::StandardPixmap equivalent.
+// MoveToTop/MoveToBottom are the "jump to end" arrows (an up/down arrow with a bar).
+enum class CustomIcon {
+	MoveToTop,
+	MoveToBottom,
+};
+
+// Draw a palette-aware icon for a CustomIcon using QPainter.
+QIcon makeThemedIcon(CustomIcon icon, const QColor& color, int size = 16);
+
+// Bind a palette-aware CustomIcon to a button and refresh it when the theme changes.
+void bindCustomIcon(QAbstractButton* btn, CustomIcon icon);
+
 // Bind a theme-adaptive PNG icon to a toolbar action.
 // Loads :/images/toolbar/<baseName>-dark.png or <baseName>-light.png based on
 // the current palette, and refreshes automatically when the theme changes.

--- a/qtfred/src/ui/Theme.h
+++ b/qtfred/src/ui/Theme.h
@@ -30,10 +30,13 @@ QIcon makeThemedIcon(QStyle::StandardPixmap sp, const QColor& color, int size = 
 void bindStandardIcon(QAbstractButton* btn, QStyle::StandardPixmap sp);
 
 // Palette-aware icons drawn by QPainter that have no QStyle::StandardPixmap equivalent.
-// MoveToTop/MoveToBottom are the "jump to end" arrows (an up/down arrow with a bar).
+// The MoveTo* values are "jump to end" arrows: an arrow with a bar across the end it
+// points toward (e.g. MoveToTop is an up arrow with a bar along the top).
 enum class CustomIcon {
 	MoveToTop,
 	MoveToBottom,
+	MoveToLeft,
+	MoveToRight,
 };
 
 // Draw a palette-aware icon for a CustomIcon using QPainter.

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.cpp
@@ -244,8 +244,10 @@ void CampaignEditorDialog::initializeUi()
 {
 	util::SignalBlockers blocker(this);
 
-	fso::fred::bindStandardIcon(ui->moveBranchUpButton,   QStyle::SP_ArrowUp);
-	fso::fred::bindStandardIcon(ui->moveBranchDownButton, QStyle::SP_ArrowDown);
+	fso::fred::bindCustomIcon(ui->moveBranchTopButton,     CustomIcon::MoveToTop);
+	fso::fred::bindStandardIcon(ui->moveBranchUpButton,    QStyle::SP_ArrowUp);
+	fso::fred::bindStandardIcon(ui->moveBranchDownButton,  QStyle::SP_ArrowDown);
+	fso::fred::bindCustomIcon(ui->moveBranchBottomButton,  CustomIcon::MoveToBottom);
 	fso::fred::bindStandardIcon(ui->testVoiceButton,      QStyle::SP_MediaPlay);
 
 	// setup the types combo box
@@ -395,8 +397,12 @@ void CampaignEditorDialog::enableDisableControls()
 	ui->debriefingPersonaSpinBox->setEnabled(has_mission);
 
 	bool branch_selected = (_model->getCurrentBranchSelection() >= 0);
-	ui->moveBranchUpButton->setEnabled(branch_selected && _model->getCurrentBranchSelection() > 0);
-	ui->moveBranchDownButton->setEnabled(branch_selected && _model->getCurrentBranchSelection() < _model->getNumBranches() -1);
+	bool can_move_up = branch_selected && _model->getCurrentBranchSelection() > 0;
+	bool can_move_down = branch_selected && _model->getCurrentBranchSelection() < _model->getNumBranches() - 1;
+	ui->moveBranchTopButton->setEnabled(can_move_up);
+	ui->moveBranchUpButton->setEnabled(can_move_up);
+	ui->moveBranchDownButton->setEnabled(can_move_down);
+	ui->moveBranchBottomButton->setEnabled(can_move_down);
 
 	bool special_branch_selected = _model->getCurrentBranchIsSpecial();
 	ui->loopDescriptionPlainTextEdit->setEnabled(special_branch_selected);
@@ -776,6 +782,16 @@ void CampaignEditorDialog::on_substituteMainhallComboBox_currentIndexChanged(con
 	_model->setCurrentMissionSubstituteMainhall(arg1.toUtf8().constData());
 }
 
+void CampaignEditorDialog::on_moveBranchTopButton_clicked()
+{
+	int mission_selection = _model->getCurrentMissionSelection(); // save now because rebuild clears it
+
+	_model->moveBranchToTop();
+	ui->graphView->rebuildAll();
+
+	ui->graphView->setSelectedMission(mission_selection);
+}
+
 void CampaignEditorDialog::on_moveBranchUpButton_clicked()
 {
 	int mission_selection = _model->getCurrentMissionSelection(); // save now because rebuild clears it
@@ -791,6 +807,16 @@ void CampaignEditorDialog::on_moveBranchDownButton_clicked()
 	int mission_selection = _model->getCurrentMissionSelection(); // save now because rebuild clears it
 	
 	_model->moveBranchDown();
+	ui->graphView->rebuildAll();
+
+	ui->graphView->setSelectedMission(mission_selection);
+}
+
+void CampaignEditorDialog::on_moveBranchBottomButton_clicked()
+{
+	int mission_selection = _model->getCurrentMissionSelection(); // save now because rebuild clears it
+
+	_model->moveBranchToBottom();
 	ui->graphView->rebuildAll();
 
 	ui->graphView->setSelectedMission(mission_selection);

--- a/qtfred/src/ui/dialogs/CampaignEditorDialog.h
+++ b/qtfred/src/ui/dialogs/CampaignEditorDialog.h
@@ -74,8 +74,10 @@ class CampaignEditorDialog : public QMainWindow, public SexpTreeEditorInterface 
 	void on_mainhallComboBox_currentIndexChanged(const QString& arg1);
 	void on_substituteMainhallComboBox_currentIndexChanged(const QString& arg1);
 
+	void on_moveBranchTopButton_clicked();
 	void on_moveBranchUpButton_clicked();
 	void on_moveBranchDownButton_clicked();
+	void on_moveBranchBottomButton_clicked();
 
 	void on_loopDescriptionPlainTextEdit_textChanged();
 	void on_loopAnimLineEdit_textChanged(const QString& arg1);

--- a/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
@@ -371,6 +371,18 @@ void MissionEventsDialog::rebuildMessageList() {
 	}
 }
 
+// The log-state checkboxes only apply to a selected event, so gray them out (and
+// clear their stale state) when nothing is selected.
+void MissionEventsDialog::setEventLogEnabled(bool enable)
+{
+	for (auto* cb : {ui->checkLogTrue, ui->checkLogFalse, ui->checkLogPrevious, ui->checkLogAlwaysFalse,
+			ui->checkLogFirstRepeat, ui->checkLogLastRepeat, ui->checkLogFirstTrigger, ui->checkLogLastTrigger}) {
+		cb->setEnabled(enable);
+		if (!enable)
+			cb->setChecked(false);
+	}
+}
+
 void MissionEventsDialog::updateEventUi() {
 	util::SignalBlockers blockers(this);
 
@@ -394,6 +406,7 @@ void MissionEventsDialog::updateEventUi() {
 		ui->teamCombo->setEnabled(false);
 		ui->editDirectiveText->setEnabled(false);
 		ui->editDirectiveKeypressText->setEnabled(false);
+		setEventLogEnabled(false);
 		return;
 	}
 
@@ -436,6 +449,7 @@ void MissionEventsDialog::updateEventUi() {
 	ui->teamCombo->setEnabled(_model->getMissionIsMultiTeam());
 
 	// handle event log flags
+	setEventLogEnabled(true);
 	ui->checkLogTrue->setChecked(_model->getLogTrue());
 	ui->checkLogFalse->setChecked(_model->getLogFalse());
 	ui->checkLogPrevious->setChecked(_model->getLogLogPrevious());

--- a/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
@@ -59,11 +59,15 @@ MissionEventsDialog::MissionEventsDialog(QWidget* parent, EditorViewport* viewpo
 	ui->mainSplitter->setStretchFactor(1, 1);
 	ui->mainSplitter->setSizes({600, 350});
 
-	fso::fred::bindStandardIcon(ui->eventUpBtn,   QStyle::SP_ArrowUp);
-	fso::fred::bindStandardIcon(ui->eventDownBtn, QStyle::SP_ArrowDown);
-	fso::fred::bindStandardIcon(ui->msgUpBtn,     QStyle::SP_ArrowUp);
-	fso::fred::bindStandardIcon(ui->msgDownBtn,   QStyle::SP_ArrowDown);
-	fso::fred::bindStandardIcon(ui->btnWavePlay,  QStyle::SP_MediaPlay);
+	fso::fred::bindCustomIcon(ui->eventMoveTopBtn,    CustomIcon::MoveToTop);
+	fso::fred::bindStandardIcon(ui->eventUpBtn,       QStyle::SP_ArrowUp);
+	fso::fred::bindStandardIcon(ui->eventDownBtn,     QStyle::SP_ArrowDown);
+	fso::fred::bindCustomIcon(ui->eventMoveBottomBtn, CustomIcon::MoveToBottom);
+	fso::fred::bindCustomIcon(ui->msgMoveTopBtn,      CustomIcon::MoveToTop);
+	fso::fred::bindStandardIcon(ui->msgUpBtn,         QStyle::SP_ArrowUp);
+	fso::fred::bindStandardIcon(ui->msgDownBtn,       QStyle::SP_ArrowDown);
+	fso::fred::bindCustomIcon(ui->msgMoveBottomBtn,   CustomIcon::MoveToBottom);
+	fso::fred::bindStandardIcon(ui->btnWavePlay,      QStyle::SP_MediaPlay);
 
 	ui->editDirectiveText->setMaxLength(NAME_LENGTH - 1);
 	ui->editDirectiveKeypressText->setMaxLength(NAME_LENGTH - 1);
@@ -457,8 +461,10 @@ void MissionEventsDialog::updateEventMoveButtons()
 		canDown = (idx >= 0 && idx < count - 1);
 	}
 
+	ui->eventMoveTopBtn->setEnabled(canUp);
 	ui->eventUpBtn->setEnabled(canUp);
 	ui->eventDownBtn->setEnabled(canDown);
+	ui->eventMoveBottomBtn->setEnabled(canDown);
 }
 
 void MissionEventsDialog::initHeadCombo() {
@@ -565,8 +571,10 @@ void MissionEventsDialog::updateMessageMoveButtons()
 	const bool canUp = hasSel && row > 0;
 	const bool canDown = hasSel && row < count - 1;
 
+	ui->msgMoveTopBtn->setEnabled(canUp);
 	ui->msgUpBtn->setEnabled(canUp);
 	ui->msgDownBtn->setEnabled(canDown);
+	ui->msgMoveBottomBtn->setEnabled(canDown);
 }
 
 SCP_vector<int> MissionEventsDialog::read_root_formula_order(sexp_tree_view* tree)
@@ -641,6 +649,23 @@ void MissionEventsDialog::on_btnDeleteEvent_clicked()
 	updateEventUi();
 }
 
+void MissionEventsDialog::on_eventMoveTopBtn_clicked()
+{
+	auto* cur = ui->eventTree->currentItem();
+	if (!cur || cur->parent())
+		return; // roots only
+	const int idx = ui->eventTree->indexOfTopLevelItem(cur);
+	if (idx <= 0)
+		return; // already at top
+
+	QTreeWidgetItem* dest = ui->eventTree->topLevelItem(0);
+	ui->eventTree->move_root(cur, dest, /*insert_before=*/true); // visual move + modified()
+
+	ui->eventTree->setCurrentItem(cur);
+	ui->eventTree->scrollToItem(cur);
+	updateEventMoveButtons();
+}
+
 void MissionEventsDialog::on_eventUpBtn_clicked()
 {
 	auto* cur = ui->eventTree->currentItem();
@@ -670,6 +695,24 @@ void MissionEventsDialog::on_eventDownBtn_clicked()
 		return; // already at bottom
 
 	QTreeWidgetItem* dest = ui->eventTree->topLevelItem(idx + 1);
+	ui->eventTree->move_root(cur, dest, /*insert_before=*/false); // visual move + modified()
+
+	ui->eventTree->setCurrentItem(cur);
+	ui->eventTree->scrollToItem(cur);
+	updateEventMoveButtons();
+}
+
+void MissionEventsDialog::on_eventMoveBottomBtn_clicked()
+{
+	auto* cur = ui->eventTree->currentItem();
+	if (!cur || cur->parent())
+		return; // roots only
+	const int idx = ui->eventTree->indexOfTopLevelItem(cur);
+	const int last = ui->eventTree->topLevelItemCount() - 1;
+	if (idx < 0 || idx >= last)
+		return; // already at bottom
+
+	QTreeWidgetItem* dest = ui->eventTree->topLevelItem(last);
 	ui->eventTree->move_root(cur, dest, /*insert_before=*/false); // visual move + modified()
 
 	ui->eventTree->setCurrentItem(cur);
@@ -848,6 +891,19 @@ void MissionEventsDialog::on_btnDeleteMsg_clicked()
 	updateMessageUi();
 }
 
+void MissionEventsDialog::on_msgMoveTopBtn_clicked()
+{
+	_model->moveMessageToTop();
+	rebuildMessageList();
+	const int sel = _model->getCurrentlySelectedMessage();
+	if (auto* w = ui->messageList) {
+		w->setCurrentRow(sel);
+		if (auto* it = w->item(sel))
+			w->scrollToItem(it);
+	}
+	updateMessageUi();
+}
+
 void MissionEventsDialog::on_msgUpBtn_clicked()
 {
 	_model->moveMessageUp();
@@ -864,6 +920,19 @@ void MissionEventsDialog::on_msgUpBtn_clicked()
 void MissionEventsDialog::on_msgDownBtn_clicked()
 {
 	_model->moveMessageDown();
+	rebuildMessageList();
+	const int sel = _model->getCurrentlySelectedMessage();
+	if (auto* w = ui->messageList) {
+		w->setCurrentRow(sel);
+		if (auto* it = w->item(sel))
+			w->scrollToItem(it);
+	}
+	updateMessageUi();
+}
+
+void MissionEventsDialog::on_msgMoveBottomBtn_clicked()
+{
+	_model->moveMessageToBottom();
 	rebuildMessageList();
 	const int sel = _model->getCurrentlySelectedMessage();
 	if (auto* w = ui->messageList) {

--- a/qtfred/src/ui/dialogs/MissionEventsDialog.h
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.h
@@ -106,6 +106,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 
 	void updateEventUi();
 	void updateEventMoveButtons();
+	void setEventLogEnabled(bool enable);
 	void updateMessageUi();
 	void updateMessageMoveButtons();
 

--- a/qtfred/src/ui/dialogs/MissionEventsDialog.h
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.h
@@ -44,8 +44,10 @@ private slots:
 	void on_btnNewEvent_clicked();
     void on_btnInsertEvent_clicked();
 	void on_btnDeleteEvent_clicked();
+	void on_eventMoveTopBtn_clicked();
 	void on_eventUpBtn_clicked();
 	void on_eventDownBtn_clicked();
+	void on_eventMoveBottomBtn_clicked();
 
 	void on_repeatCountBox_valueChanged(int value);
 	void on_triggerCountBox_valueChanged(int value);
@@ -74,8 +76,10 @@ private slots:
 	void on_btnNewMsg_clicked();
 	void on_btnInsertMsg_clicked();
 	void on_btnDeleteMsg_clicked();
+	void on_msgMoveTopBtn_clicked();
 	void on_msgUpBtn_clicked();
 	void on_msgDownBtn_clicked();
+	void on_msgMoveBottomBtn_clicked();
 
 	void on_messageName_textChanged(const QString& text);
 	void on_messageContent_textChanged();

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -355,7 +355,20 @@
              <item>
               <layout class="QVBoxLayout" name="verticalLayout_3">
                <item>
+                <widget class="QPushButton" name="moveBranchTopButton">
+                 <property name="toolTip">
+                  <string>Move to top</string>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QPushButton" name="moveBranchUpButton">
+                 <property name="toolTip">
+                  <string>Move up</string>
+                 </property>
                  <property name="text">
                   <string/>
                  </property>
@@ -363,6 +376,19 @@
                </item>
                <item>
                 <widget class="QPushButton" name="moveBranchDownButton">
+                 <property name="toolTip">
+                  <string>Move down</string>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="moveBranchBottomButton">
+                 <property name="toolTip">
+                  <string>Move to bottom</string>
+                 </property>
                  <property name="text">
                   <string/>
                  </property>

--- a/qtfred/ui/MissionEventsDialog.ui
+++ b/qtfred/ui/MissionEventsDialog.ui
@@ -224,12 +224,31 @@
            <item>
             <layout class="QHBoxLayout" name="eventUpDownLayout">
              <item>
+              <widget class="QPushButton" name="eventMoveTopBtn">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Move to top</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="QPushButton" name="eventUpBtn">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Move up</string>
                </property>
                <property name="text">
                 <string/>
@@ -243,6 +262,25 @@
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Move down</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="eventMoveBottomBtn">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Move to bottom</string>
                </property>
                <property name="text">
                 <string/>
@@ -596,20 +634,42 @@ in Milliseconds</string>
             </item>
            </layout>
           </item>
-          <item row="1" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item row="1" column="0" colspan="2">
+           <layout class="QHBoxLayout" name="msgMoveButtonsLayout">
+            <property name="leftMargin">
+             <number>4</number>
+            </property>
+            <property name="rightMargin">
+             <number>4</number>
+            </property>
             <item>
-             <widget class="QLabel" name="label_9">
-              <property name="text">
-               <string>Name</string>
+             <spacer name="msgMoveButtonsSpacerLeft">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
               </property>
-              <property name="buddy">
-               <cstring>messageName</cstring>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
               </property>
-             </widget>
+             </spacer>
             </item>
             <item>
-             <widget class="QLineEdit" name="messageName"/>
+             <widget class="QPushButton" name="msgMoveTopBtn">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Move to top</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
             </item>
             <item>
              <widget class="QPushButton" name="msgUpBtn">
@@ -618,6 +678,9 @@ in Milliseconds</string>
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Move up</string>
               </property>
               <property name="text">
                <string/>
@@ -632,10 +695,59 @@ in Milliseconds</string>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
+              <property name="toolTip">
+               <string>Move down</string>
+              </property>
               <property name="text">
                <string/>
               </property>
              </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="msgMoveBottomBtn">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Move to bottom</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="msgMoveButtonsSpacerRight">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabel" name="label_9">
+              <property name="text">
+               <string>Name</string>
+              </property>
+              <property name="buddy">
+               <cstring>messageName</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="messageName"/>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
Adds the requested move-to-top and move-to-bottom buttons for Events and Messages. Adds the same controls to the branches editor in the Campaign Dialog. Finally it also fixes log-state checkboxes to enable/disable based on event selection.