### PR TITLE
Qtfred minor fixes and tweaks

### DIFF
--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -14,6 +14,7 @@
 #include <QProcess>
 #include <QSignalBlocker>
 #include <QSettings>
+#include <QDateTime>
 
 #include <project.h>
 
@@ -448,6 +449,7 @@ bool FredView::saveMissionToCurrentPath() {
 
 	save.save_mission_file(saveName.replace('/', DIR_SEPARATOR_CHAR).toUtf8().constData());
 	_missionModified = false;
+	setLastSaved(QDateTime::currentDateTime());
 
 	if (fixCount > 0)
 		QMessageBox::information(this, tr("Auto-corrections Applied"),
@@ -488,6 +490,7 @@ bool FredView::saveMissionAs() {
 
 	save.save_mission_file(saveName.replace('/', DIR_SEPARATOR_CHAR).toUtf8().constData());
 	_missionModified = false;
+	setLastSaved(QDateTime::currentDateTime());
 
 	if (fixCount > 0)
 		QMessageBox::information(this, tr("Auto-corrections Applied"),
@@ -747,6 +750,9 @@ void FredView::on_mission_loaded(const std::string& filepath) {
 	// Clear browsed head ANIs so the new mission's message scan starts fresh.
 	fso::fred::dialogs::MissionEventsDialogModel::clearBrowsedHeadAnis();
 
+	// A freshly loaded or newly created mission has not been saved this session yet.
+	setLastSaved(QDateTime());
+
 	if (_errorCheckerDialog) {
 		_errorCheckerDialog->clearErrors();
 	}
@@ -903,6 +909,12 @@ void FredView::initializeStatusBar() {
 	_statusBarObjectCount->setAlignment(Qt::AlignCenter);
 	statusBar()->addWidget(_statusBarObjectCount, 1);
 
+	// Sits just right of the (centered, stretched) object count, near the middle.
+	_statusBarLastSaved = new QLabel();
+	_statusBarLastSaved->setContentsMargins(16, 0, 0, 0);
+	statusBar()->addWidget(_statusBarLastSaved);
+	setLastSaved(QDateTime());
+
 	_statusBarViewmode = new QLabel();
 	_statusBarViewmode->setContentsMargins(8, 0, 0, 0);
 	statusBar()->addPermanentWidget(_statusBarViewmode);
@@ -910,6 +922,17 @@ void FredView::initializeStatusBar() {
 	_statusBarUnitsLabel = new QLabel();
 	_statusBarUnitsLabel->setContentsMargins(16, 0, 0, 0);
 	statusBar()->addPermanentWidget(_statusBarUnitsLabel);
+}
+
+void FredView::setLastSaved(const QDateTime& when) {
+	if (!_statusBarLastSaved)
+		return;
+
+	if (when.isValid()) {
+		_statusBarLastSaved->setText(tr("Last Saved: %1").arg(when.toString(QStringLiteral("MMM d, yyyy h:mm:ss AP"))));
+	} else {
+		_statusBarLastSaved->setText(tr("Last Saved: Never"));
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -2507,6 +2507,7 @@ void FredView::on_actionLoadout_triggered(bool) {
 }
 void FredView::on_actionVariables_triggered(bool) {
 	auto editorDialog = new dialogs::VariableDialog(this, _viewport);
+	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
 	editorDialog->show();
 }
 

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -21,6 +21,7 @@
 #include <ui/widgets/ObjectComboBox.h>
 
 class waypoint_list;
+class QDateTime;
 
 namespace fso {
 namespace fred {
@@ -247,8 +248,12 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void onSetGroup(int group);
 
 	QLabel* _statusBarObjectCount = nullptr;
+	QLabel* _statusBarLastSaved   = nullptr;
 	QLabel* _statusBarViewmode    = nullptr;
 	QLabel* _statusBarUnitsLabel  = nullptr;
+
+	// Updates the "Last Saved" status bar label: pass an empty time to show "Never".
+	void setLastSaved(const QDateTime& when);
 
 	SceneBrowserPanel* _browserPanel = nullptr;
 

--- a/qtfred/src/ui/dialogs/AsteroidEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/AsteroidEditorDialog.cpp
@@ -68,7 +68,15 @@ void AsteroidEditorDialog::reject()
 void AsteroidEditorDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void AsteroidEditorDialog::initializeUi()

--- a/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/BriefingEditorDialog.cpp
@@ -135,7 +135,15 @@ void BriefingEditorDialog::reject()
 void BriefingEditorDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void BriefingEditorDialog::setupMapWidget()

--- a/qtfred/src/ui/dialogs/CommandBriefingDialog.cpp
+++ b/qtfred/src/ui/dialogs/CommandBriefingDialog.cpp
@@ -56,7 +56,15 @@ void CommandBriefingDialog::reject()
 void CommandBriefingDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void CommandBriefingDialog::initializeUi()

--- a/qtfred/src/ui/dialogs/DebriefingDialog.cpp
+++ b/qtfred/src/ui/dialogs/DebriefingDialog.cpp
@@ -60,7 +60,15 @@ void DebriefingDialog::reject()
 void DebriefingDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void DebriefingDialog::initializeUi()

--- a/qtfred/src/ui/dialogs/FictionViewerDialog.cpp
+++ b/qtfred/src/ui/dialogs/FictionViewerDialog.cpp
@@ -58,7 +58,15 @@ void FictionViewerDialog::reject()
 void FictionViewerDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void FictionViewerDialog::initializeUi()

--- a/qtfred/src/ui/dialogs/MissionCutscenesDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionCutscenesDialog.cpp
@@ -58,7 +58,15 @@ void MissionCutscenesDialog::reject()
 void MissionCutscenesDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void MissionCutscenesDialog::updateUi()

--- a/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
@@ -288,7 +288,15 @@ bool MissionEventsDialog::hasDefaultMessageParameter()
 void MissionEventsDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void MissionEventsDialog::initMessageWidgets() {

--- a/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
@@ -709,7 +709,7 @@ void MissionEventsDialog::on_chainedCheckBox_stateChanged(int state)
 	updateEventUi();
 }
 
-void MissionEventsDialog::on_chainedDelayBox_valueChanged(int value)
+void MissionEventsDialog::on_chainDelayBox_valueChanged(int value)
 {
 	_model->setChainDelay(value);
 }

--- a/qtfred/src/ui/dialogs/MissionEventsDialog.h
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.h
@@ -51,7 +51,7 @@ private slots:
 	void on_triggerCountBox_valueChanged(int value);
 	void on_intervalTimeBox_valueChanged(int value);
 	void on_chainedCheckBox_stateChanged(int state);
-	void on_chainedDelayBox_valueChanged(int value);
+	void on_chainDelayBox_valueChanged(int value);
 	void on_useMsecsCheckBox_stateChanged(int state);
 	void on_scoreBox_valueChanged(int value);
 	void on_teamCombo_currentIndexChanged(int index);

--- a/qtfred/src/ui/dialogs/MissionGoalsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionGoalsDialog.cpp
@@ -56,7 +56,15 @@ void MissionGoalsDialog::reject()
 void MissionGoalsDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void MissionGoalsDialog::updateUi()

--- a/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecDialog.cpp
@@ -62,7 +62,15 @@ void MissionSpecDialog::reject()
 
 void MissionSpecDialog::closeEvent(QCloseEvent* e) {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void MissionSpecDialog::initializeUi()

--- a/qtfred/src/ui/dialogs/MissionSpecs/CustomDataDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecs/CustomDataDialog.cpp
@@ -71,7 +71,15 @@ void CustomDataDialog::reject()
 void CustomDataDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void CustomDataDialog::setInitial(const SCP_map<SCP_string, SCP_string>& items)

--- a/qtfred/src/ui/dialogs/MissionSpecs/CustomStringsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecs/CustomStringsDialog.cpp
@@ -70,7 +70,15 @@ void CustomStringsDialog::reject()
 void CustomStringsDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void CustomStringsDialog::setInitial(const SCP_vector<custom_string>& items)

--- a/qtfred/src/ui/dialogs/MissionSpecs/CustomWingNamesDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecs/CustomWingNamesDialog.cpp
@@ -67,7 +67,15 @@ void CustomWingNamesDialog::reject()
 
 void CustomWingNamesDialog::closeEvent(QCloseEvent * e) {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void CustomWingNamesDialog::setInitialStartingWings(const std::array<SCP_string, MAX_STARTING_WINGS>& startingWings) {

--- a/qtfred/src/ui/dialogs/MissionSpecs/SoundEnvironmentDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecs/SoundEnvironmentDialog.cpp
@@ -78,7 +78,15 @@ void SoundEnvironmentDialog::closeEvent(QCloseEvent* e)
 	reject();
 	closeWave();
 	disableEnvPreview();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void SoundEnvironmentDialog::enableOrDisableFields()

--- a/qtfred/src/ui/dialogs/MissionSpecs/SupportRearmDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionSpecs/SupportRearmDialog.cpp
@@ -33,7 +33,15 @@ SupportRearmSettings SupportRearmDialog::settings() const
 void SupportRearmDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore();
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 QString SupportRearmDialog::weaponEntryText(int weaponClass) const

--- a/qtfred/src/ui/dialogs/ObjectOrientEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ObjectOrientEditorDialog.cpp
@@ -49,7 +49,15 @@ void ObjectOrientEditorDialog::reject()
 void ObjectOrientEditorDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void ObjectOrientEditorDialog::initializeUi()

--- a/qtfred/src/ui/dialogs/ReinforcementsEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ReinforcementsEditorDialog.cpp
@@ -53,7 +53,15 @@ void ReinforcementsDialog::reject()
 void ReinforcementsDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipAltShipClass.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipAltShipClass.cpp
@@ -46,7 +46,15 @@ void ShipAltShipClass::reject()
 void ShipAltShipClass::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void ShipAltShipClass::on_buttonBox_accepted()

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipCustomWarpDialog.cpp
@@ -144,7 +144,15 @@ void ShipCustomWarpDialog::reject()
 void ShipCustomWarpDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 void ShipCustomWarpDialog::updateUi(const bool firstrun)
 {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipFlagsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipFlagsDialog.cpp
@@ -73,7 +73,15 @@ void ShipFlagsDialog::reject() {
 void ShipFlagsDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 void ShipFlagsDialog::on_okAndCancelButtons_accepted()
 {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipGoalsDialog.cpp
@@ -87,7 +87,15 @@ void ShipGoalsDialog::reject()
 void ShipGoalsDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 void ShipGoalsDialog::on_okButton_clicked()
 {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipInitialStatusDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipInitialStatusDialog.cpp
@@ -55,7 +55,15 @@ void ShipInitialStatusDialog::reject()
 void ShipInitialStatusDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 void ShipInitialStatusDialog::on_velocitySpinBox_valueChanged(int value)
 {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipSpecialStatsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipSpecialStatsDialog.cpp
@@ -46,7 +46,15 @@ void ShipSpecialStatsDialog::reject()
 void ShipSpecialStatsDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void ShipSpecialStatsDialog::on_buttonBox_accepted()

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipTextureReplacementDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipTextureReplacementDialog.cpp
@@ -115,7 +115,15 @@ void ShipTextureReplacementDialog::reject()
 void ShipTextureReplacementDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 void ShipTextureReplacementDialog::on_buttonBox_accepted()
 {

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipWeaponsDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipWeaponsDialog.cpp
@@ -279,7 +279,15 @@ void ShipWeaponsDialog::reject()
 void ShipWeaponsDialog::closeEvent(QCloseEvent* event)
 {
 	reject();
-	event->ignore();
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		event->ignore();
+	} else {
+		event->accept();
+	}
 }
 
 void ShipWeaponsDialog::on_okAndCancelButtons_accepted()

--- a/qtfred/src/ui/dialogs/TeamLoadoutDialog.cpp
+++ b/qtfred/src/ui/dialogs/TeamLoadoutDialog.cpp
@@ -64,7 +64,15 @@ void TeamLoadoutDialog::reject()
 void TeamLoadoutDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void TeamLoadoutDialog::initializeUi()

--- a/qtfred/src/ui/dialogs/VariableDialog.cpp
+++ b/qtfred/src/ui/dialogs/VariableDialog.cpp
@@ -88,7 +88,15 @@ void VariableDialog::reject()
 void VariableDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void VariableDialog::initializeUi()

--- a/qtfred/src/ui/dialogs/VolumetricNebulaDialog.cpp
+++ b/qtfred/src/ui/dialogs/VolumetricNebulaDialog.cpp
@@ -51,7 +51,15 @@ void VolumetricNebulaDialog::reject()
 void VolumetricNebulaDialog::closeEvent(QCloseEvent* e)
 {
 	reject();
-	e->ignore(); // Don't let the base class close the window
+	// reject() hides the dialog when it actually closes. Let that close
+	// proceed (so a dialog created with WA_DeleteOnClose is destroyed),
+	// and only veto it when reject() decided to keep the dialog open (e.g.
+	// the user cancelled the unsaved-changes prompt).
+	if (isVisible()) {
+		e->ignore();
+	} else {
+		e->accept();
+	}
 }
 
 void VolumetricNebulaDialog::initializeUi()


### PR DESCRIPTION
First this fixes how the X close button works to make sure the modal dialog windows aren't leaking. Second this fixes chain delay's spinbox not auto-connecting because of a typo. Finally this adds a Last Saved timestamp to the status bar that resets on new mission or mission load.

Most of the changes here are duplicated across all the modal dialog files.