### PR TITLE
port several QtFRED fixes to FRED

### DIFF
--- a/fred2/fredrender.cpp
+++ b/fred2/fredrender.cpp
@@ -2080,6 +2080,9 @@ void render_one_model_htl(object *objp) {
 		g3_done_instance(0);
 
 		if (Show_ship_models) {
+			if (Ship_info[Ships[z].ship_info_index].uses_team_colors)
+				render_info.set_team_color(Ships[z].team_name, Ships[z].secondary_team_name, Ships[z].team_change_timestamp, Ships[z].team_change_time);
+
 			render_info.set_flags(flags);
 			model_render_immediate(&render_info, Ship_info[Ships[z].ship_info_index].model_num, Ships[z].model_instance_num, &objp->orient, &objp->pos);
 		}

--- a/fred2/initialstatus.cpp
+++ b/fred2/initialstatus.cpp
@@ -492,10 +492,12 @@ void initial_status::OnOK()
 		handle_inconsistent_flag(Ships[m_ship].flags, Ship::Ship_Flags::Afterburner_locked, m_afterburner_locked);
 	}
 
-	if (m_team_color_setting.IsWindowEnabled() && m_team_color_setting.GetCurSel() > 0)
-		Ships[m_ship].team_name = Team_Names[m_team_color_setting.GetCurSel() - 1];
-	else
-		Ships[m_ship].team_name = "none";
+	if (m_team_color_setting.IsWindowEnabled()) {
+		if (m_team_color_setting.GetCurSel() > 0)
+			Ships[m_ship].team_name = Team_Names[m_team_color_setting.GetCurSel() - 1];
+		else
+			Ships[m_ship].team_name = "none";
+	}
 
 	update_docking_info();
 

--- a/fred2/orienteditor.cpp
+++ b/fred2/orienteditor.cpp
@@ -15,6 +15,7 @@
 #include "Management.h"
 #include "globalincs/linklist.h"
 #include "FREDView.h"
+#include "prop/prop.h"
 
 #ifdef _DEBUG
 #undef THIS_FILE
@@ -135,6 +136,12 @@ BOOL orient_editor::OnInitDialog()
 			} else if (ptr->type == OBJ_JUMP_NODE) {
 				box->AddString(jumpnode_get_by_objnum(objnum)->GetName());
 				index[total++] = objnum;
+
+			} else if (ptr->type == OBJ_PROP) {
+				if (Props[ptr->instance].has_value()) {
+					box->AddString(Props[ptr->instance].value().prop_name);
+					index[total++] = objnum;
+				}
 
 			} else if (ptr->type != OBJ_POINT)
 				Warning(LOCATION, "Unknown object type %d", ptr->type);

--- a/fred2/shipflagsdlg.cpp
+++ b/fred2/shipflagsdlg.cpp
@@ -429,9 +429,12 @@ void ship_flags_dlg::update_ship(int shipnum)
 	ship *shipp = &Ships[shipnum];
 	object *objp = &Objects[shipp->objnum];
 
-	if (m_reinforcement.GetCheck() != 2)
+	// skip this for player starts, which can be edited in a mixed multi-selection even though
+	// the checkbox is disabled when only players are selected; set_reinforcement would add a
+	// bogus reinforcement entry for the player, since ship_name_lookup skips player starts
+	if ((objp->type != OBJ_START) && (m_reinforcement.GetCheck() != 2))
 	{
-		set_reinforcement(shipp->ship_name, m_reinforcement.GetCheck());	
+		set_reinforcement(shipp->ship_name, m_reinforcement.GetCheck());
 	}
 
 	switch (m_cargo_known.GetCheck()) {
@@ -709,22 +712,26 @@ void ship_flags_dlg::update_ship(int shipnum)
 	}
 
 	// deal with updating the "destroy before the mission" stuff
-	switch (m_destroy.GetCheck()) {
-		case 0:  // this means no check in checkbox
-			if ( shipp->flags[Ship::Ship_Flags::Kill_before_mission] )
-				set_modified();
+	// (skip this for player starts, which can be edited in a mixed multi-selection even though
+	// the checkbox is disabled when only players are selected)
+	if (objp->type != OBJ_START) {
+		switch (m_destroy.GetCheck()) {
+			case 0:  // this means no check in checkbox
+				if ( shipp->flags[Ship::Ship_Flags::Kill_before_mission] )
+					set_modified();
 
-            shipp->flags.remove(Ship::Ship_Flags::Kill_before_mission);
-			break;
+				shipp->flags.remove(Ship::Ship_Flags::Kill_before_mission);
+				break;
 
-		case 1:  // this means checkbox is checked
-			if ( !(shipp->flags[Ship::Ship_Flags::Kill_before_mission]) )
-				set_modified();
+			case 1:  // this means checkbox is checked
+				if ( !(shipp->flags[Ship::Ship_Flags::Kill_before_mission]) )
+					set_modified();
 
-            shipp->flags.set(Ship::Ship_Flags::Kill_before_mission);
-			m_destroy_value.save(&shipp->final_death_time);
-			break;
-	}  // a mixed state is 2, and since it's not handled, it doesn't change
+				shipp->flags.set(Ship::Ship_Flags::Kill_before_mission);
+				m_destroy_value.save(&shipp->final_death_time);
+				break;
+		}  // a mixed state is 2, and since it's not handled, it doesn't change
+	}
 
 	switch (m_no_arrival_music.GetCheck()) {
 		case 0:


### PR DESCRIPTION
Any FRED fixes should be ported to QtFRED and vice versa.  This PR covers the QtFRED fixes from #7402 and #7403 that are applicable to FRED:
- Don't apply reinforcement or destroy-before-mission flags to player starting ships
- Don't wipe a ship's team color when the Initial Status combo is disabled
- Render team colors on ships in the FRED viewport
- Handle props in the Object Orientation editor