### PR TITLE
Extract common name conflict checker for FRED2 and qtFRED

### DIFF
--- a/code/missioneditor/common.cpp
+++ b/code/missioneditor/common.cpp
@@ -235,6 +235,89 @@ bool set_single_player_start(int objnum)
 	return changed;
 }
 
+SCP_string check_name_conflict(const char *entity_type, const char *name, int exclude_ship, int exclude_wing, int exclude_waypoint_list, int exclude_jump_node)
+{
+	SCP_string msg;
+
+	// Name must not be empty
+	if (name[0] == '\0') {
+		msg += "This ";
+		msg += entity_type;
+		msg += " name cannot be empty";
+		return msg;
+	}
+
+	// Check wings
+	for (int i = 0; i < MAX_WINGS; i++) {
+		if (Wings[i].wave_count && i != exclude_wing && !stricmp(Wings[i].name, name)) {
+			msg += "This ";
+			msg += entity_type;
+			msg += " name is already being used by ";
+			msg += (exclude_wing >= 0) ? "another wing" : "a wing";
+			return msg;
+		}
+	}
+
+	// Check ships
+	for (auto ptr: list_range(&obj_used_list)) {
+		if ((ptr->type == OBJ_SHIP || ptr->type == OBJ_START) && ptr->instance != exclude_ship) {
+			if (!stricmp(Ships[ptr->instance].ship_name, name)) {
+				msg += "This ";
+				msg += entity_type;
+				msg += " name is already being used by ";
+				msg += (exclude_ship >= 0) ? "another ship" : "a ship";
+				return msg;
+			}
+		}
+	}
+
+	// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
+
+	// Check target priority groups
+	for (const auto &ai_tp: Ai_tp_list) {
+		if (!stricmp(ai_tp.name, name)) {
+			msg += "This ";
+			msg += entity_type;
+			msg += " name is already being used by a target priority group";
+			return msg;
+		}
+	}
+
+	// Check waypoint lists
+	int wl_size = sz2i(Waypoint_lists.size());
+	for (int i = 0; i < wl_size; i++) {
+		if (i != exclude_waypoint_list && !stricmp(Waypoint_lists[i].get_name(), name)) {
+			msg += "This ";
+			msg += entity_type;
+			msg += " name is already being used by ";
+			msg += (exclude_waypoint_list >= 0) ? "another waypoint path" : "a waypoint path";
+			return msg;
+		}
+	}
+
+	// Check jump nodes
+	int jn_size = sz2i(Jump_nodes.size());
+	for (int i = 0; i < jn_size; i++) {
+		if (i != exclude_jump_node && !stricmp(Jump_nodes[i].GetName(), name)) {
+			msg += "This ";
+			msg += entity_type;
+			msg += " name is already being used by ";
+			msg += (exclude_jump_node >= 0) ? "another jump node" : "a jump node";
+			return msg;
+		}
+	}
+
+	// Name must not start with '<' (used for invalidated SEXP references)
+	if (name[0] == '<') {
+		msg += "This ";
+		msg += entity_type;
+		msg += " name is not allowed to begin with <";
+		return msg;
+	}
+
+	return "";	// no error
+}
+
 void reassign_ship_slot(int from, int to, const FredShipSlotConfig& cfg, bool resort_obj_list)
 {
 	Assertion(Fred_running, "reassign_ship_slot is FRED-only: it does not fix up game-context references like Player_ship or runtime Ai_info shipnums");

--- a/code/missioneditor/common.h
+++ b/code/missioneditor/common.h
@@ -64,6 +64,13 @@ void ensure_valid_player_start_shipnum();
 // and repoint Player_start_shipnum.  Returns true if anything changed.
 bool set_single_player_start(int objnum);
 
+// Check whether the given name is empty, starts with '<', or conflicts with an existing ship,
+// wing, waypoint path, jump node, or target priority group.
+// Returns an empty string if the name is valid, otherwise a self-contained reason string
+// (e.g. "The name is already being used by a wing").  The exclude parameters prevent matching
+// against the entity currently being renamed.
+SCP_string check_name_conflict(const char *entity_type, const char *name, int exclude_ship = -1, int exclude_wing = -1, int exclude_waypoint_list = -1, int exclude_jump_node = -1);
+
 struct FredShipSlotConfig
 {
 	char (*fred_alt_names)[NAME_LENGTH + 1] = nullptr;

--- a/fred2/jumpnodedlg.cpp
+++ b/fred2/jumpnodedlg.cpp
@@ -168,132 +168,28 @@ int jumpnode_dlg::update_data(int redraw)
 {
 	const char *str;
 	char old_name[255];
-	int i, z;
-	object *ptr;
+	int z;
 
 	if (!GetSafeHwnd())
 		return 0;
 
 	if (query_valid_object() && Objects[cur_object_index].type == OBJ_JUMP_NODE) {
 		auto jnp = jumpnode_get_by_objnum(cur_object_index);
+		Assertion(jnp != nullptr, "Jump node object not found in Jump_nodes vector?");
+		int jnp_index = static_cast<int>(jnp - Jump_nodes.data());
 
 		m_name.TrimLeft();
 		m_name.TrimRight();
-		if (m_name.IsEmpty())
-		{
+
+		SCP_string conflict = check_name_conflict("jump node", m_name, -1, -1, -1, jnp_index);
+		if (!conflict.empty()) {
 			if (bypass_errors)
 				return 1;
 
 			bypass_errors = 1;
-			z = MessageBox("A jump node name cannot be empty\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-				return -1;
-
-			m_name = _T(jnp->GetName());
-			UpdateData(FALSE);
-		}
-
-		for (i=0; i<MAX_WINGS; i++)
-		{
-			if (!stricmp(Wings[i].name, m_name)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This jump node name is already being used by a wing\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_name = _T(jnp->GetName());
-				UpdateData(FALSE);
-			}
-		}
-
-		ptr = GET_FIRST(&obj_used_list);
-		while (ptr != END_OF_LIST(&obj_used_list)) {
-			if ((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) {
-				if (!stricmp(m_name, Ships[ptr->instance].ship_name)) {
-					if (bypass_errors)
-						return 1;
-
-					bypass_errors = 1;
-					z = MessageBox("This jump node name is already being used by a ship\n"
-						"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-					if (z == IDCANCEL)
-						return -1;
-
-					m_name = _T(jnp->GetName());
-					UpdateData(FALSE);
-				}
-			}
-
-			ptr = GET_NEXT(ptr);
-		}
-
-		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
-
-		for ( i=0; i < (int)Ai_tp_list.size(); i++) {
-			if (!stricmp(m_name, Ai_tp_list[i].name)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This jump node name is already being used by a target priority group.\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_name = _T(jnp->GetName());
-				UpdateData(FALSE);
-			}
-		}
-
-		if (find_matching_waypoint_list((LPCSTR) m_name) != NULL)
-		{
-			if (bypass_errors)
-				return 1;
-
-			bypass_errors = 1;
-			z = MessageBox("This jump node name is already being used by a waypoint path\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-				return -1;
-
-			m_name = _T(jnp->GetName());
-			UpdateData(FALSE);
-		}
-
-		if (!stricmp(m_name.Left(1), "<")) {
-			if (bypass_errors)
-				return 1;
-
-			bypass_errors = 1;
-			z = MessageBox("Jump node names not allowed to begin with <\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-				return -1;
-
-			m_name = _T(jnp->GetName());
-			UpdateData(FALSE);
-		}
-
-		CJumpNode* found = jumpnode_get_by_name(m_name);
-		if(found != NULL && &(*jnp) != found)
-		{
-			if (bypass_errors)
-				return 1;
-
-			bypass_errors = 1;
-			z = MessageBox("This jump node name is already being used by another jump node\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
+			CString msg;
+			msg.Format("%s\nPress OK to restore old name", conflict.c_str());
+			z = MessageBox(msg, "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
 
 			if (z == IDCANCEL)
 				return -1;

--- a/fred2/shipeditordlg.cpp
+++ b/fred2/shipeditordlg.cpp
@@ -29,8 +29,6 @@
 #include "mission/missionparse.h"
 #include "missioneditor/common.h"
 #include "model/model.h"
-#include "starfield/starfield.h"
-#include "jumpnode/jumpnode.h"
 #include "ShipFlagsDlg.h"
 #include "mission/missionmessage.h"
 #include "ShipSpecialDamage.h"
@@ -1092,123 +1090,18 @@ int CShipEditorDlg::update_data(int redraw)
 		update_ship(player_ship);
 
 	} else if (single_ship >= 0) {  // editing a single ship
-		m_ship_name.TrimLeft(); 
+		m_ship_name.TrimLeft();
 		m_ship_name.TrimRight();
-		if (m_ship_name.IsEmpty()) {
+
+		SCP_string conflict = check_name_conflict("ship", m_ship_name, single_ship);
+		if (!conflict.empty()) {
 			if (bypass_errors)
 				return 1;
 
 			bypass_errors = 1;
-			z = MessageBox("A ship name cannot be empty\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-				return -1;
-
-			m_ship_name = _T(Ships[single_ship].ship_name);
-			UpdateData(FALSE);
-		}
-
-		ptr = GET_FIRST(&obj_used_list);
-		while (ptr != END_OF_LIST(&obj_used_list)) {
-			if (((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) && (single_ship != ptr->instance)) {
-				str = Ships[ptr->instance].ship_name;
-				if (!stricmp(m_ship_name, str)) {
-					if (bypass_errors)
-						return 1;
-
-					bypass_errors = 1;
-					z = MessageBox("This ship name is already being used by another ship\n"
-						"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-					if (z == IDCANCEL)
-						return -1;
-
-					m_ship_name = _T(Ships[single_ship].ship_name);
-					UpdateData(FALSE);
-				}
-			}
-
-			ptr = GET_NEXT(ptr);
-		}
-
-		for (i=0; i<MAX_WINGS; i++) {
-			if (Wings[i].wave_count && !stricmp(Wings[i].name, m_ship_name)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This ship name is already being used by a wing\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_ship_name = _T(Ships[single_ship].ship_name);
-				UpdateData(FALSE);
-			}
-		}
-
-		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
-
-		for ( i=0; i < (int)Ai_tp_list.size(); i++) {
-			if (!stricmp(m_ship_name, Ai_tp_list[i].name)) 
-			{
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This ship name is already being used by a target priority group.\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_ship_name = _T(Ships[single_ship].ship_name);
-				UpdateData(FALSE);
-			}
-		}
-
-		if (find_matching_waypoint_list((LPCSTR) m_ship_name) != NULL)
-		{
-			if (bypass_errors)
-				return 0;
-
-			bypass_errors = 1;
-			z = MessageBox("This ship name is already being used by a waypoint path\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-				return -1;
-
-			m_ship_name = _T(Ships[single_ship].ship_name);
-			UpdateData(FALSE);
-		}
-
-		if(jumpnode_get_by_name(m_ship_name) != NULL)
-		{
-			if (bypass_errors)
-				return 1;
-
-			bypass_errors = 1;
-
-			z = MessageBox("This ship name is already being used by a jump node\n"
-			"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-			return -1;
-
-			m_ship_name = _T(Ships[single_ship].ship_name);
-			UpdateData(FALSE);
-		}
-		
-		if (!stricmp(m_ship_name.Left(1), "<")) {
-			if (bypass_errors)
-				return 1;
-
-			bypass_errors = 1;
-			z = MessageBox("Ship names not allowed to begin with <\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
+			CString msg;
+			msg.Format("%s\nPress OK to restore old name", conflict.c_str());
+			z = MessageBox(msg, "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
 
 			if (z == IDCANCEL)
 				return -1;

--- a/fred2/waypointpathdlg.cpp
+++ b/fred2/waypointpathdlg.cpp
@@ -18,11 +18,7 @@
 #include "object/object.h"
 #include "object/waypoint.h"
 #include "globalincs/linklist.h"
-#include "ship/ship.h"
 #include "ai/aigoals.h"
-#include "starfield/starfield.h"
-#include "jumpnode/jumpnode.h"
-#include "iff_defs/iff_defs.h"
 
 #define ID_JUMP_NODE_MENU	8000
 #define ID_WAYPOINT_MENU	9000
@@ -138,8 +134,7 @@ void waypoint_path_dlg::initialize_data(int full_update)
 
 int waypoint_path_dlg::update_data(int redraw)
 {
-	int i, z;
-	object *ptr;
+	int z;
 
 	if (!GetSafeHwnd())
 		return 0;
@@ -147,97 +142,31 @@ int waypoint_path_dlg::update_data(int redraw)
 	UpdateData(TRUE);
 	UpdateData(TRUE);
 
+	int waypoint_list_index = -1;
 	if (query_valid_object() && Objects[cur_object_index].type == OBJ_WAYPOINT)
 	{
-		Assert(cur_waypoint_list == find_waypoint_list_with_instance(Objects[cur_object_index].instance));
+		waypoint_list_index = calc_waypoint_list_index(Objects[cur_object_index].instance);
+		Assert(cur_waypoint_list == &Waypoint_lists[waypoint_list_index]);
+	}
+	else if (cur_waypoint_list != nullptr)
+	{
+		Assertion(false, "inconsistent state in waypoint editor!");
+		return 0;
 	}
 
 	if (cur_waypoint_list != NULL) {
-		for (i=0; i<MAX_WINGS; i++)
-		{
-			if (!stricmp(Wings[i].name, m_name)) {
-				if (bypass_errors)
-					return 1;
+		m_name.TrimLeft();
+		m_name.TrimRight();
 
-				bypass_errors = 1;
-				z = MessageBox("This waypoint path name is already being used by a wing\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_name = _T(cur_waypoint_list->get_name());
-				UpdateData(FALSE);
-			}
-		}
-
-		ptr = GET_FIRST(&obj_used_list);
-		while (ptr != END_OF_LIST(&obj_used_list)) {
-			if ((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) {
-				if (!stricmp(m_name, Ships[ptr->instance].ship_name)) {
-					if (bypass_errors)
-						return 1;
-
-					bypass_errors = 1;
-					z = MessageBox("This waypoint path name is already being used by a ship\n"
-						"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-					if (z == IDCANCEL)
-						return -1;
-
-					m_name = _T(cur_waypoint_list->get_name());
-					UpdateData(FALSE);
-				}
-			}
-
-			ptr = GET_NEXT(ptr);
-		}
-
-		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
-
-		for ( i=0; i < (int)Ai_tp_list.size(); i++) {
-			if (!stricmp(m_name, Ai_tp_list[i].name)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This waypoint path name is already being used by a target priority group.\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_name = _T(cur_waypoint_list->get_name());
-				UpdateData(FALSE);
-			}
-		}
-
-		for (const auto &ii: Waypoint_lists)
-		{
-			if (!stricmp(ii.get_name(), m_name) && (&ii != cur_waypoint_list)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This waypoint path name is already being used by another waypoint path\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_name = _T(cur_waypoint_list->get_name());
-				UpdateData(FALSE);
-			}
-		}
-
-		if(jumpnode_get_by_name(m_name) != NULL)
-		{
+		SCP_string conflict = check_name_conflict("waypoint path", m_name, -1, -1, waypoint_list_index);
+		if (!conflict.empty()) {
 			if (bypass_errors)
 				return 1;
 
 			bypass_errors = 1;
-			z = MessageBox("This waypoint path name is already being used by a jump node\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
+			CString msg;
+			msg.Format("%s\nPress OK to restore old name", conflict.c_str());
+			z = MessageBox(msg, "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
 
 			if (z == IDCANCEL)
 				return -1;
@@ -245,22 +174,6 @@ int waypoint_path_dlg::update_data(int redraw)
 			m_name = _T(cur_waypoint_list->get_name());
 			UpdateData(FALSE);
 		}
-
-		if (!stricmp(m_name.Left(1), "<")) {
-			if (bypass_errors)
-				return 1;
-
-			bypass_errors = 1;
-			z = MessageBox("Waypoint names not allowed to begin with <\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-				return -1;
-
-			m_name = _T(cur_waypoint_list->get_name());
-			UpdateData(FALSE);
-		}
-
 
 		char old_name[NAME_LENGTH];
 		strcpy_s(old_name, cur_waypoint_list->get_name());

--- a/fred2/wing_editor.cpp
+++ b/fred2/wing_editor.cpp
@@ -15,15 +15,11 @@
 #include "FREDDoc.h"
 #include "Management.h"
 #include "wing.h"
-#include "globalincs/linklist.h"
 #include "ai/aigoals.h"
 #include "FREDView.h"
-#include "starfield/starfield.h"
-#include "jumpnode/jumpnode.h"
 #include "missioneditor/common.h"
 #include "cfile/cfile.h"
 #include "restrictpaths.h"
-#include "iff_defs/iff_defs.h"
 #include "warpparamsdlg.h"
 #include "ship/ship.h"
 
@@ -580,7 +576,6 @@ int wing_editor::update_data(int redraw)
 {
 	char *str, old_name[255], buf[512];
 	int i, z;
-	object *ptr;
 
 	nprintf(("Fred routing", "Wing dialog save\n"));
 	if (!GetSafeHwnd())
@@ -593,103 +588,15 @@ int wing_editor::update_data(int redraw)
 	m_wing_name.TrimRight(); 
 
 	if (cur_wing >= 0) {
-		for (i=0; i<MAX_WINGS; i++)
-			if (Wings[i].wave_count && !stricmp(Wings[i].name, m_wing_name) && (i != cur_wing)) {
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This wing name is already being used by another wing\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_wing_name = _T(Wings[cur_wing].name);
-				UpdateData(FALSE);
-			}
-
-		ptr = GET_FIRST(&obj_used_list);
-		while (ptr != END_OF_LIST(&obj_used_list)) {
-			if ((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) {
-				if (!stricmp(m_wing_name, Ships[ptr->instance].ship_name)) {
-					if (bypass_errors)
-						return 1;
-
-					bypass_errors = 1;
-					z = MessageBox("This wing name is already being used by a ship\n"
-						"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-					if (z == IDCANCEL)
-						return -1;
-
-					m_wing_name = _T(Wings[cur_wing].name);
-					UpdateData(FALSE);
-				}
-			}
-
-			ptr = GET_NEXT(ptr);
-		}
-
-		// We don't need to check teams.  "Unknown" is a valid name and also an IFF.
-
-		for ( i=0; i < (int)Ai_tp_list.size(); i++) {
-			if (!stricmp(m_wing_name, Ai_tp_list[i].name)) 
-			{
-				if (bypass_errors)
-					return 1;
-
-				bypass_errors = 1;
-				z = MessageBox("This wing name is already being used by a target priority group.\n"
-					"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-				if (z == IDCANCEL)
-					return -1;
-
-				m_wing_name = _T(Wings[cur_wing].name);
-				UpdateData(FALSE);
-			}
-		}
-
-		if (find_matching_waypoint_list((LPCSTR) m_wing_name) != NULL)
-		{
+		SCP_string conflict = check_name_conflict("wing", m_wing_name, -1, cur_wing);
+		if (!conflict.empty()) {
 			if (bypass_errors)
 				return 1;
 
 			bypass_errors = 1;
-			z = MessageBox("This wing name is already being used by a waypoint path\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-				return -1;
-
-			m_wing_name = _T(Wings[cur_wing].name);
-			UpdateData(FALSE);
-		}
-
-		if(jumpnode_get_by_name(m_wing_name) != NULL)
-		{
-			if (bypass_errors)
-				return 1;
-
-			bypass_errors = 1;
-			z = MessageBox("This wing name is already being used by a jump node\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
-
-			if (z == IDCANCEL)
-				return -1;
-
-			m_wing_name = _T(Wings[cur_wing].name);
-			UpdateData(FALSE);
-		}
-
-		if (!stricmp(m_wing_name.Left(1), "<")) {
-			if (bypass_errors)
-				return 1;
-
-			bypass_errors = 1;
-			z = MessageBox("Wing names not allowed to begin with <\n"
-				"Press OK to restore old name", "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
+			CString msg;
+			msg.Format("%s\nPress OK to restore old name", conflict.c_str());
+			z = MessageBox(msg, "Error", MB_ICONEXCLAMATION | MB_OKCANCEL);
 
 			if (z == IDCANCEL)
 				return -1;

--- a/qtfred/src/mission/EditorWing.cpp
+++ b/qtfred/src/mission/EditorWing.cpp
@@ -470,73 +470,24 @@ bool Editor::wing_contains_player_start(int wing)
 WingNameCheck Editor::validate_wing_name(const SCP_string& new_name, int ignore_wing)
 {
 	WingNameCheck r{false, WingNameError::None, {}};
-	if (new_name.empty()) {
-		r.error = WingNameError::Empty;
-		r.message = "Name is empty.";
-		return r;
-	}
 
-	if (new_name.empty()) {
-		r.error = WingNameError::Empty;
-		r.message = "Name is empty.";
-		return r;
-	}
 	if (new_name.size() >= NAME_LENGTH) {
 		r.error = WingNameError::TooLong;
 		r.message = "Name is too long.";
 		return r;
 	}
 
-	// Other wings
-	for (int i = 0; i < MAX_WINGS; ++i) {
-		if (i == ignore_wing)
-			continue;
-		if (Wings[i].wave_count <= 0)
-			continue;
-		if (!stricmp(new_name.c_str(), Wings[i].name)) {
-			r.error = WingNameError::DuplicateWing;
-			r.message = "This wing name is already used by another wing.";
-			return r;
-		}
-	}
-
-	// Ships
-	for (object* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
-		if (ptr->type == OBJ_SHIP || ptr->type == OBJ_START) {
-			const int si = get_ship_from_obj(ptr);
-			if (!stricmp(new_name.c_str(), Ships[si].ship_name)) {
-				r.error = WingNameError::DuplicateShip;
-				r.message = "This wing name is already used by a ship.";
-				return r;
-			}
-		}
-	}
-
-	// Target priority groups
-	for (auto& ai : Ai_tp_list) {
-		if (!stricmp(new_name.c_str(), ai.name)) {
-			r.error = WingNameError::DuplicateTargetPriority;
-			r.message = "This wing name is already used by a target priority group.";
-			return r;
-		}
-	}
-
-	// Waypoint paths
-	if (find_matching_waypoint_list(new_name.c_str()) != nullptr) {
-		r.error = WingNameError::DuplicateWaypointList;
-		r.message = "This wing name is already used by a waypoint path.";
-		return r;
-	}
-
-	// Jump nodes
-	if (jumpnode_get_by_name(new_name.c_str()) != nullptr) {
-		r.error = WingNameError::DuplicateJumpNode;
-		r.message = "This wing name is already used by a jump node.";
+	// check for an empty name, a name beginning with '<', or a conflict with an existing
+	// ship, wing, waypoint path, jump node, or target priority group
+	SCP_string reason = check_name_conflict("wing", new_name.c_str(), -1, ignore_wing);
+	if (!reason.empty()) {
+		// the enum is coarse now (only .ok is consumed), but the message is preserved
+		r.error = WingNameError::DuplicateWing;
+		r.message = reason;
 		return r;
 	}
 
 	r.ok = true;
-	r.message.clear();
 	return r;
 }
 

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
@@ -7,6 +7,7 @@
 #include <mission/object.h>
 #include <model/model.h>
 #include <ship/ship.h>
+#include "missioneditor/common.h"
 
 #include <QTimer>
 
@@ -136,51 +137,17 @@ void JumpNodeEditorDialogModel::showErrorDialogNoCancel(const SCP_string& messag
 }
 
 bool JumpNodeEditorDialogModel::validateName(const SCP_string& name) {
-	if (name.empty()) {
-		showErrorDialogNoCancel("A jump node name cannot be empty.");
+	int exclude_jn = -1;
+	if (!_selectedJumpNodes.empty()) {
+		auto* jnp = jumpnode_get_by_objnum(_selectedJumpNodes.front());
+		if (jnp)
+			exclude_jn = static_cast<int>(jnp - Jump_nodes.data());
+	}
+	SCP_string reason = check_name_conflict("jump node", name.c_str(), -1, -1, -1, exclude_jn);
+	if (!reason.empty()) {
+		showErrorDialogNoCancel(reason);
 		return false;
 	}
-
-	if (name[0] == '<') {
-		showErrorDialogNoCancel("Jump node names are not allowed to begin with '<'.");
-		return false;
-	}
-
-	for (auto& wing : Wings) {
-		if (!stricmp(wing.name, name.c_str())) {
-			showErrorDialogNoCancel("This jump node name is already being used by a wing.");
-			return false;
-		}
-	}
-
-	for (auto* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
-		if (ptr->type == OBJ_SHIP || ptr->type == OBJ_START) {
-			if (!stricmp(name.c_str(), Ships[ptr->instance].ship_name)) {
-				showErrorDialogNoCancel("This jump node name is already being used by a ship.");
-				return false;
-			}
-		}
-	}
-
-	for (auto& ai : Ai_tp_list) {
-		if (!stricmp(name.c_str(), ai.name)) {
-			showErrorDialogNoCancel("This jump node name is already being used by a target priority group.");
-			return false;
-		}
-	}
-
-	if (find_matching_waypoint_list(name.c_str()) != nullptr) {
-		showErrorDialogNoCancel("This jump node name is already being used by a waypoint path.");
-		return false;
-	}
-
-	auto* current_jnp = _selectedJumpNodes.empty() ? nullptr : jumpnode_get_by_objnum(_selectedJumpNodes.front());
-	auto* found = jumpnode_get_by_name(name.c_str());
-	if (found != nullptr && found != current_jnp) {
-		showErrorDialogNoCancel("This jump node name is already being used by another jump node.");
-		return false;
-	}
-
 	return true;
 }
 

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
@@ -738,83 +738,11 @@ void ShipEditorDialogModel::setShipName(const SCP_string& m_ship_name)
 	SCP_string new_name = m_ship_name;
 	drop_white_space(new_name);
 
-	if (new_name.empty()) {
+	SCP_string reason = check_name_conflict("ship", new_name.c_str(), _singleShip);
+	if (!reason.empty()) {
 		_viewport->dialogProvider->showButtonDialog(DialogType::Error,
 			"Ship Name Error",
-			"A ship name cannot be empty.",
-			{DialogButton::Ok});
-		_shipName = Ships[_singleShip].ship_name;
-		modelChanged();
-		return;
-	}
-
-	if (new_name[0] == '<') {
-		_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-			"Ship Name Error",
-			"Ship names not allowed to begin with <.",
-			{DialogButton::Ok});
-		_shipName = Ships[_singleShip].ship_name;
-		modelChanged();
-		return;
-	}
-
-	// Check for duplicate ship names
-	for (auto* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
-		if (((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) && (ptr->instance != _singleShip)) {
-			if (!stricmp(new_name.c_str(), Ships[ptr->instance].ship_name)) {
-				_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-					"Ship Name Error",
-					"This ship name is already being used by another ship.",
-					{DialogButton::Ok});
-				_shipName = Ships[_singleShip].ship_name;
-				modelChanged();
-				return;
-			}
-		}
-	}
-
-	// Check for conflict with wing names
-	for (auto& w : Wings) {
-		if (w.wave_count && !stricmp(w.name, new_name.c_str())) {
-			_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-				"Ship Name Error",
-				"This ship name is already being used by a wing.",
-				{DialogButton::Ok});
-			_shipName = Ships[_singleShip].ship_name;
-			modelChanged();
-			return;
-		}
-	}
-
-	// Check for conflict with AI target priority group names
-	for (auto& tp : Ai_tp_list) {
-		if (!stricmp(new_name.c_str(), tp.name)) {
-			_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-				"Ship Name Error",
-				"This ship name is already being used by a target priority group.",
-				{DialogButton::Ok});
-			_shipName = Ships[_singleShip].ship_name;
-			modelChanged();
-			return;
-		}
-	}
-
-	// Check for conflict with waypoint paths
-	if (find_matching_waypoint_list(new_name.c_str()) != nullptr) {
-		_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-			"Ship Name Error",
-			"This ship name is already being used by a waypoint path.",
-			{DialogButton::Ok});
-		_shipName = Ships[_singleShip].ship_name;
-		modelChanged();
-		return;
-	}
-
-	// Check for conflict with jump nodes
-	if (jumpnode_get_by_name(new_name.c_str()) != nullptr) {
-		_viewport->dialogProvider->showButtonDialog(DialogType::Error,
-			"Ship Name Error",
-			"This ship name is already being used by a jump node.",
+			reason,
 			{DialogButton::Ok});
 		_shipName = Ships[_singleShip].ship_name;
 		modelChanged();

--- a/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
@@ -4,6 +4,7 @@
 #include <iff_defs/iff_defs.h>
 #include <unordered_set>
 #include "mission/dialogs/WaypointEditorDialogModel.h"
+#include "missioneditor/common.h"
 
 #include <QTimer>
 
@@ -125,58 +126,12 @@ int WaypointEditorDialogModel::getSelectionCount() const {
 }
 
 bool WaypointEditorDialogModel::validateName(const SCP_string& name) {
-	if (name.empty()) {
-		showErrorDialogNoCancel("Waypoint path name cannot be empty.");
+	int exclude_wl = _selectedWaypointPaths.empty() ? -1 : static_cast<int>(_selectedWaypointPaths.front());
+	SCP_string reason = check_name_conflict("waypoint path", name.c_str(), -1, -1, exclude_wl);
+	if (!reason.empty()) {
+		showErrorDialogNoCancel(reason);
 		return false;
 	}
-
-	// wing name collision
-	for (auto& wing : Wings) {
-		if (!stricmp(wing.name, name.c_str())) {
-			showErrorDialogNoCancel("This waypoint path name is already being used by a wing");
-			return false;
-		}
-	}
-
-	// ship name collision
-	for (auto* ptr = GET_FIRST(&obj_used_list); ptr != END_OF_LIST(&obj_used_list); ptr = GET_NEXT(ptr)) {
-		if ((ptr->type == OBJ_SHIP) || (ptr->type == OBJ_START)) {
-			if (!stricmp(name.c_str(), Ships[ptr->instance].ship_name)) {
-				showErrorDialogNoCancel("This waypoint path name is already being used by a ship");
-				return false;
-			}
-		}
-	}
-
-	// target priority group name collision
-	for (auto& ai : Ai_tp_list) {
-		if (!stricmp(name.c_str(), ai.name)) {
-			showErrorDialogNoCancel("This waypoint path name is already being used by a target priority group");
-			return false;
-		}
-	}
-
-	// waypoint path name collision
-	const waypoint_list* current_path = &Waypoint_lists[_selectedWaypointPaths.front()];
-	for (const auto& ii : Waypoint_lists) {
-		if (!stricmp(ii.get_name(), name.c_str()) && (&ii != current_path)) {
-			showErrorDialogNoCancel("This waypoint path name is already being used by another waypoint path");
-			return false;
-		}
-	}
-
-	// jump node name collision
-	if (jumpnode_get_by_name(name.c_str()) != nullptr) {
-		showErrorDialogNoCancel("This waypoint path name is already being used by a jump node");
-		return false;
-	}
-
-	// formatting
-	if (name[0] == '<') {
-		showErrorDialogNoCancel("Waypoint names not allowed to begin with '<'");
-		return false;
-	}
-
 	return true;
 }
 


### PR DESCRIPTION
The ship editor, wing editor, waypoint path dialog, and jump node dialog all had near-identical code to check whether a new name conflicts with an existing ship, wing, waypoint path, jump node, or target priority group (or is empty, or begins with '<').  Both FRED2 and qtFRED carried their own copies of this logic.

Extract it into a single check_name_conflict() function in code/missioneditor/common.cpp, shared by both editors, and replace the duplicated validation at each call site with a one-line call:

  - FRED2:  shipeditordlg, wing_editor, waypointpathdlg, jumpnodedlg
  - qtFRED: ShipEditorDialogModel, WaypointEditorDialogModel, JumpNodeEditorDialogModel, and Editor::validate_wing_name

This also aligns a few small behavioral differences that had crept in between the two editors: the waypoint and jump node dialogs now skip empty wing slots (wave_count == 0) when checking for wing-name collisions, and the qtFRED wing editor now rejects names beginning with '<'.