### PR TITLE
QtFRED Fix multiple dialog instances.

### DIFF
--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -2455,16 +2455,32 @@ void FredView::keyReleaseEvent(QKeyEvent* event) {
 
 	_inKeyReleaseHandler = false;
 }
+namespace {
+// Opens a single instance of a dialog parented to `parent`, wired for
+// delete-on-close.  If an instance is already open, it is raised and focused
+// rather than creating a second one.  Returns the newly-created dialog, or
+// nullptr if an existing instance was reused (so callers can do extra one-time
+// setup only on first open).
+template <typename DialogT>
+DialogT* showSingleInstanceDialog(FredView* parent, EditorViewport* viewport) {
+	if (auto* existing = parent->findChild<DialogT*>(QString(), Qt::FindDirectChildrenOnly)) {
+		existing->raise();
+		existing->activateWindow();
+		return nullptr;
+	}
+	auto* dialog = new DialogT(parent, viewport);
+	dialog->setAttribute(Qt::WA_DeleteOnClose);
+	dialog->show();
+	return dialog;
+}
+} // namespace
+
 void FredView::on_actionMission_Events_triggered(bool) {
-	auto eventEditor = new dialogs::MissionEventsDialog(this, _viewport);
-	eventEditor->setAttribute(Qt::WA_DeleteOnClose);
-	eventEditor->show();
+	showSingleInstanceDialog<dialogs::MissionEventsDialog>(this, _viewport);
 }
 void FredView::on_actionMission_Cutscenes_triggered(bool)
 {
-	auto cutsceneEditor = new dialogs::MissionCutscenesDialog(this, _viewport);
-	cutsceneEditor->setAttribute(Qt::WA_DeleteOnClose);
-	cutsceneEditor->show();
+	showSingleInstanceDialog<dialogs::MissionCutscenesDialog>(this, _viewport);
 }
 void FredView::on_actionSelectionLock_triggered(bool enabled) {
 	_viewport->Selection_lock = enabled;
@@ -2494,37 +2510,26 @@ void FredView::onOtherKindSelected(int other_kind) {
 	_viewport->cur_other_kind = static_cast<OtherKind>(other_kind);
 }
 void FredView::on_actionAsteroid_Field_triggered(bool) {
-	auto asteroidFieldEditor = new dialogs::AsteroidEditorDialog(this, _viewport);
-	asteroidFieldEditor->setAttribute(Qt::WA_DeleteOnClose);
-	connect(asteroidFieldEditor, &QDialog::finished, this, [this]() { fred->updateAllViewports(); });
-	asteroidFieldEditor->show();
+	if (auto* asteroidFieldEditor = showSingleInstanceDialog<dialogs::AsteroidEditorDialog>(this, _viewport)) {
+		connect(asteroidFieldEditor, &QDialog::finished, this, [this]() { fred->updateAllViewports(); });
+	}
 }
 void FredView::on_actionVolumetric_Nebula_triggered(bool)
 {
-	auto volumetricNebulaEditor = new dialogs::VolumetricNebulaDialog(this, _viewport);
-	volumetricNebulaEditor->setAttribute(Qt::WA_DeleteOnClose);
-	volumetricNebulaEditor->show();
+	showSingleInstanceDialog<dialogs::VolumetricNebulaDialog>(this, _viewport);
 }
 void FredView::on_actionBriefing_triggered(bool) {
-	auto eventEditor = new dialogs::BriefingEditorDialog(this, _viewport);
-	eventEditor->setAttribute(Qt::WA_DeleteOnClose);
-	eventEditor->show();
+	showSingleInstanceDialog<dialogs::BriefingEditorDialog>(this, _viewport);
 }
 void FredView::on_actionMission_Specs_triggered(bool) {
-	auto missionSpecEditor = new dialogs::MissionSpecDialog(this, _viewport);
-	missionSpecEditor->setAttribute(Qt::WA_DeleteOnClose);
-	missionSpecEditor->show();
+	showSingleInstanceDialog<dialogs::MissionSpecDialog>(this, _viewport);
 }
 void FredView::on_actionWaypoint_Paths_triggered(bool) {
-	auto editorDialog = new dialogs::WaypointEditorDialog(this, _viewport);
-	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
-	editorDialog->show();
+	showSingleInstanceDialog<dialogs::WaypointEditorDialog>(this, _viewport);
 }
 void FredView::on_actionJump_Nodes_triggered(bool)
 {
-	auto editorDialog = new dialogs::JumpNodeEditorDialog(this, _viewport);
-	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
-	editorDialog->show();
+	showSingleInstanceDialog<dialogs::JumpNodeEditorDialog>(this, _viewport);
 }
 void FredView::on_actionShips_triggered(bool)
 {
@@ -2569,38 +2574,26 @@ void FredView::on_actionProps_triggered(bool)
 }
 void FredView::on_actionCampaign_triggered(bool) {
 	//TODO: Save if Changes
-	auto editorCampaign = new dialogs::CampaignEditorDialog(this, _viewport);
-	editorCampaign->setAttribute(Qt::WA_DeleteOnClose);
-	editorCampaign->show();
+	showSingleInstanceDialog<dialogs::CampaignEditorDialog>(this, _viewport);
 }
 void FredView::on_actionObject_Orientation_triggered(bool) {
 	orientEditorTriggered();
 }
 void FredView::on_actionCommand_Briefing_triggered(bool) {
-	auto editorDialog = new dialogs::CommandBriefingDialog(this, _viewport);
-	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
-	editorDialog->show();
+	showSingleInstanceDialog<dialogs::CommandBriefingDialog>(this, _viewport);
 }
 void FredView::on_actionDebriefing_triggered(bool)
 {
-	auto editorDialog = new dialogs::DebriefingDialog(this, _viewport);
-	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
-	editorDialog->show();
+	showSingleInstanceDialog<dialogs::DebriefingDialog>(this, _viewport);
 }
 void FredView::on_actionReinforcements_triggered(bool) {
-	auto editorDialog = new dialogs::ReinforcementsDialog(this, _viewport);
-	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
-	editorDialog->show();
+	showSingleInstanceDialog<dialogs::ReinforcementsDialog>(this, _viewport);
 }
 void FredView::on_actionLoadout_triggered(bool) {
-	auto editorDialog = new dialogs::TeamLoadoutDialog(this, _viewport);
-	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
-	editorDialog->show();
+	showSingleInstanceDialog<dialogs::TeamLoadoutDialog>(this, _viewport);
 }
 void FredView::on_actionVariables_triggered(bool) {
-	auto editorDialog = new dialogs::VariableDialog(this, _viewport);
-	editorDialog->setAttribute(Qt::WA_DeleteOnClose);
-	editorDialog->show();
+	showSingleInstanceDialog<dialogs::VariableDialog>(this, _viewport);
 }
 
 DialogButton FredView::showButtonDialog(DialogType type,
@@ -3075,68 +3068,46 @@ void FredView::on_actionHelp_Topics_triggered(bool) {
 }
 
 void FredView::on_actionAbout_triggered(bool) {
-	auto dialog = new dialogs::AboutDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::AboutDialog>(this, _viewport);
 }
 void FredView::on_actionMission_Statistics_triggered(bool) {
-	auto dialog = new dialogs::MissionStatsDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::MissionStatsDialog>(this, _viewport);
 }
 
 void FredView::on_actionBackground_triggered(bool) {
-	auto dialog = new dialogs::BackgroundEditorDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::BackgroundEditorDialog>(this, _viewport);
 }
 
 void FredView::on_actionShield_System_triggered(bool) {
-	auto dialog = new dialogs::ShieldSystemDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::ShieldSystemDialog>(this, _viewport);
 }
 
 void FredView::on_actionSet_Global_Ship_Flags_triggered(bool) {
-	auto dialog = new dialogs::GlobalShipFlagsDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::GlobalShipFlagsDialog>(this, _viewport);
 }
 
 void FredView::on_actionVoice_Acting_Manager_triggered(bool) {
-	auto dialog = new dialogs::VoiceActingManager(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::VoiceActingManager>(this, _viewport);
 }
 void FredView::on_actionMission_Goals_triggered(bool) {
-	auto dialog = new dialogs::MissionGoalsDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::MissionGoalsDialog>(this, _viewport);
 }
 
 void FredView::on_actionMusic_Player_triggered(bool)
 {
-	auto dialog = new dialogs::MusicPlayerDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::MusicPlayerDialog>(this, _viewport);
 }
 
 void FredView::on_actionCalculate_Relative_Coordinates_triggered(bool) {
-	auto dialog = new dialogs::RelativeCoordinatesDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::RelativeCoordinatesDialog>(this, _viewport);
 }
 
 void FredView::on_actionFiction_Viewer_triggered(bool) {
-	auto dialog = new dialogs::FictionViewerDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::FictionViewerDialog>(this, _viewport);
 }
 
 void FredView::on_actionWaypointPathGenerator_triggered(bool) {
-	auto dialog = new dialogs::WaypointPathGeneratorDialog(this, _viewport);
-	dialog->setAttribute(Qt::WA_DeleteOnClose);
-	dialog->show();
+	showSingleInstanceDialog<dialogs::WaypointPathGeneratorDialog>(this, _viewport);
 }
 } // namespace fred
 } // namespace fso


### PR DESCRIPTION
Menubar entries and keyboard shortcuts created a new dialog instance on every activation. Route the non-modal dialog slots through a showSingleInstanceDialog() helper that raises and focuses an already-open instance instead of creating a second one.

Ship/Wing/Prop and the error checker keep their existing member-pointer guards since other code references those open instances.