### PR TITLE
QtFRED adjust message editor

### DIFF
--- a/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
+++ b/qtfred/src/ui/dialogs/MissionEventsDialog.cpp
@@ -886,6 +886,11 @@ void MissionEventsDialog::on_btnNewMsg_clicked()
 
 	rebuildMessageList();
 	updateMessageUi();
+
+	// Let the user name the new message right away: focus the name field and
+	// select its placeholder text so typing immediately replaces it.
+	ui->messageName->setFocus();
+	ui->messageName->selectAll();
 }
 
 void MissionEventsDialog::on_btnInsertMsg_clicked()
@@ -903,6 +908,11 @@ void MissionEventsDialog::on_btnInsertMsg_clicked()
 			w->scrollToItem(it);
 	}
 	updateMessageUi();
+
+	// Let the user name the new message right away: focus the name field and
+	// select its placeholder text so typing immediately replaces it.
+	ui->messageName->setFocus();
+	ui->messageName->selectAll();
 }
 
 void MissionEventsDialog::on_btnDeleteMsg_clicked()

--- a/qtfred/ui/MissionEventsDialog.ui
+++ b/qtfred/ui/MissionEventsDialog.ui
@@ -575,7 +575,7 @@ in Milliseconds</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="2">
+          <item row="4" column="0" colspan="2">
            <widget class="QPlainTextEdit" name="messageContent">
             <property name="statusTip">
              <string>Message Text</string>
@@ -588,7 +588,7 @@ in Milliseconds</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
+          <item row="2" column="0" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <property name="spacing">
              <number>0</number>
@@ -734,7 +734,7 @@ in Milliseconds</string>
             </item>
            </layout>
           </item>
-          <item row="2" column="0" colspan="2">
+          <item row="3" column="0" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
              <widget class="QLabel" name="label_9">


### PR DESCRIPTION
Move the New/Insert/Delete message buttons directly above the message name field so creating a message and naming it no longer requires travelling past the message text box.

Also focus and select the name field after New Msg and Insert Msg so the placeholder name can be replaced by typing immediately, without an extra click.