### PR TITLE
QtFRED add object reorder dialog

### DIFF
--- a/code/missioneditor/common.cpp
+++ b/code/missioneditor/common.cpp
@@ -4,7 +4,10 @@
 #include "globalincs/linklist.h"
 #include "mission/missionparse.h"
 #include "iff_defs/iff_defs.h"
+#include "jumpnode/jumpnode.h"
 #include "object/object.h"
+#include "object/waypoint.h"
+#include "prop/prop.h"
 #include "ship/ship.h"
 
 #include <algorithm>
@@ -485,4 +488,96 @@ void resort_ships_in_obj_used_list()
 	resort_obj_used_list_subset(
 		[](int t) { return t == OBJ_SHIP || t == OBJ_START; },
 		[](const object* o) { return o->instance; });
+}
+
+void resort_props_in_obj_used_list()
+{
+	resort_obj_used_list_subset(
+		[](int t) { return t == OBJ_PROP; },
+		[](const object* o) { return o->instance; });
+}
+
+void rotate_prop_slots(const SCP_vector<int>& slots, int from_pos, int to_pos)
+{
+	Assertion(Fred_running, "rotate_prop_slots is FRED-only: it re-points object instances only, not any game-context state");
+	if (from_pos == to_pos)
+		return;
+
+	int count = (int)slots.size();
+	Assertion(from_pos >= 0 && from_pos < count, "rotate_prop_slots: 'from' position %d out of range", from_pos);
+	Assertion(to_pos >= 0 && to_pos < count, "rotate_prop_slots: 'to' position %d out of range", to_pos);
+
+	// Permute the prop occupants among the slot indices, leaving any empty
+	// holes where they are.  Park the mover, shift the rest over by one, then drop
+	// the mover into the slot vacated at the far end.
+	std::optional<prop> moving = std::move(Props[slots[from_pos]]);
+	int step = (to_pos > from_pos) ? 1 : -1;
+	for (int j = from_pos; j != to_pos; j += step)
+		Props[slots[j]] = std::move(Props[slots[j + step]]);
+	Props[slots[to_pos]] = std::move(moving);
+
+	// Re-point each moved prop's object instance to its new Props[] index.  Only
+	// the occupants between the two positions changed slots.
+	int lo = std::min(from_pos, to_pos);
+	int hi = std::max(from_pos, to_pos);
+	for (int j = lo; j <= hi; ++j)
+	{
+		if (Props[slots[j]].has_value())
+			Objects[Props[slots[j]]->objnum].instance = slots[j];
+	}
+
+	// Keep obj_used_list prop order in sync with Props[] index order, so
+	// the Scene Browser reflects the new order too.
+	resort_props_in_obj_used_list();
+}
+
+void rotate_waypoint_lists(int from_pos, int to_pos)
+{
+	Assertion(Fred_running, "rotate_waypoint_lists is FRED-only: it re-points object instances only, not any game-context state");
+	if (from_pos == to_pos)
+		return;
+
+	int count = (int)Waypoint_lists.size();
+	Assertion(from_pos >= 0 && from_pos < count, "rotate_waypoint_lists: 'from' position %d out of range", from_pos);
+	Assertion(to_pos >= 0 && to_pos < count, "rotate_waypoint_lists: 'to' position %d out of range", to_pos);
+
+	// Reorder the lists themselves, preserving the relative order of the rest.
+	if (from_pos < to_pos)
+		std::rotate(Waypoint_lists.begin() + from_pos, Waypoint_lists.begin() + from_pos + 1, Waypoint_lists.begin() + to_pos + 1);
+	else
+		std::rotate(Waypoint_lists.begin() + to_pos, Waypoint_lists.begin() + from_pos, Waypoint_lists.begin() + from_pos + 1);
+
+	// A waypoint object encodes its list index, point index in its instance, so
+	// every waypoint in the shifted lists now sits at a new list index.  Rebuild
+	// all instances from the lists' current positions.
+	for (int li = 0; li < (int)Waypoint_lists.size(); ++li)
+	{
+		auto& waypoints = Waypoint_lists[li].get_waypoints();
+		for (int wi = 0; wi < (int)waypoints.size(); ++wi)
+		{
+			int objnum = waypoints[wi].get_objnum();
+			if (objnum >= 0)
+				Objects[objnum].instance = calc_waypoint_instance(li, wi);
+		}
+	}
+}
+
+void rotate_jump_nodes(const SCP_vector<int>& slots, int from_pos, int to_pos)
+{
+	Assertion(Fred_running, "rotate_jump_nodes is FRED-only: it reorders the editor's jump-node list only");
+	if (from_pos == to_pos)
+		return;
+
+	int count = (int)slots.size();
+	Assertion(from_pos >= 0 && from_pos < count, "rotate_jump_nodes: 'from' position %d out of range", from_pos);
+	Assertion(to_pos >= 0 && to_pos < count, "rotate_jump_nodes: 'to' position %d out of range", to_pos);
+
+	// Permute the node occupants among the fixed slot indices, leaving any
+	// detached entries in place.  Park the mover, shift the rest over by one, then
+	// drop the mover into the slot vacated at the far end.
+	CJumpNode moving = std::move(Jump_nodes[slots[from_pos]]);
+	int step = (to_pos > from_pos) ? 1 : -1;
+	for (int j = from_pos; j != to_pos; j += step)
+		Jump_nodes[slots[j]] = std::move(Jump_nodes[slots[j + step]]);
+	Jump_nodes[slots[to_pos]] = std::move(moving);
 }

--- a/code/missioneditor/common.cpp
+++ b/code/missioneditor/common.cpp
@@ -360,7 +360,7 @@ static void rotate_slots(const SCP_vector<int>& slots, int from_pos, int to_pos,
 	if (from_pos == to_pos)
 		return;
 
-	int count = (int)slots.size();
+	int count = static_cast<int>(slots.size());
 	Assertion(from_pos >= 0 && from_pos < count, "%s: 'from' position %d out of range", caller, from_pos);
 	Assertion(to_pos >= 0 && to_pos < count, "%s: 'to' position %d out of range", caller, to_pos);
 
@@ -503,7 +503,7 @@ void rotate_prop_slots(const SCP_vector<int>& slots, int from_pos, int to_pos)
 	if (from_pos == to_pos)
 		return;
 
-	int count = (int)slots.size();
+	int count = static_cast<int>(slots.size());
 	Assertion(from_pos >= 0 && from_pos < count, "rotate_prop_slots: 'from' position %d out of range", from_pos);
 	Assertion(to_pos >= 0 && to_pos < count, "rotate_prop_slots: 'to' position %d out of range", to_pos);
 
@@ -537,7 +537,7 @@ void rotate_waypoint_lists(int from_pos, int to_pos)
 	if (from_pos == to_pos)
 		return;
 
-	int count = (int)Waypoint_lists.size();
+	int count = static_cast<int>(Waypoint_lists.size());
 	Assertion(from_pos >= 0 && from_pos < count, "rotate_waypoint_lists: 'from' position %d out of range", from_pos);
 	Assertion(to_pos >= 0 && to_pos < count, "rotate_waypoint_lists: 'to' position %d out of range", to_pos);
 
@@ -550,15 +550,18 @@ void rotate_waypoint_lists(int from_pos, int to_pos)
 	// A waypoint object encodes its list index, point index in its instance, so
 	// every waypoint in the shifted lists now sits at a new list index.  Rebuild
 	// all instances from the lists' current positions.
-	for (int li = 0; li < (int)Waypoint_lists.size(); ++li)
+	int li = 0;
+	for (auto& list : Waypoint_lists)
 	{
-		auto& waypoints = Waypoint_lists[li].get_waypoints();
-		for (int wi = 0; wi < (int)waypoints.size(); ++wi)
+		int wi = 0;
+		for (auto& wpt : list.get_waypoints())
 		{
-			int objnum = waypoints[wi].get_objnum();
+			int objnum = wpt.get_objnum();
 			if (objnum >= 0)
 				Objects[objnum].instance = calc_waypoint_instance(li, wi);
+			++wi;
 		}
+		++li;
 	}
 }
 
@@ -568,7 +571,7 @@ void rotate_jump_nodes(const SCP_vector<int>& slots, int from_pos, int to_pos)
 	if (from_pos == to_pos)
 		return;
 
-	int count = (int)slots.size();
+	int count = static_cast<int>(slots.size());
 	Assertion(from_pos >= 0 && from_pos < count, "rotate_jump_nodes: 'from' position %d out of range", from_pos);
 	Assertion(to_pos >= 0 && to_pos < count, "rotate_jump_nodes: 'to' position %d out of range", to_pos);
 

--- a/code/missioneditor/common.h
+++ b/code/missioneditor/common.h
@@ -115,3 +115,35 @@ void rotate_wing_slots(const SCP_vector<int>& slots, int from_pos, int to_pos, c
 // Restore the obj_used_list invariant for the OBJ_SHIP/OBJ_START subset:
 // among ship-type entries, list order matches Ships[] index order.
 void resort_ships_in_obj_used_list();
+
+// Same, for the OBJ_PROP subset: among prop entries, obj_used_list order matches
+// Props[] index order.  UI lists that walk obj_used_list, like the Scene Browser,
+// depend on this to show props in their reordered Props[] order.
+void resort_props_in_obj_used_list();
+
+// Props and waypoint paths live in SCP_vectors rather than the fixed
+// Ships[]/Wings[] arrays, and their only index-based back-reference is the
+// owning object's instance (everything else refers to them by name).  So unlike
+// the ship/wing slot helpers above, these reorder the elements directly and just
+// re-point the OBJ_PROP / OBJ_WAYPOINT object instances.
+
+// Move the prop at display position from_pos to to_pos within `slots` (the
+// occupied Props[] indices, in display order), shifting the props in between by
+// one and preserving their relative order.  Props[] may contain empty nullopt
+// holes; those stay put while the occupants are permuted among their slots.
+// Also resorts obj_used_list so Scene Browser matches.
+void rotate_prop_slots(const SCP_vector<int>& slots, int from_pos, int to_pos);
+
+// Move the waypoint list at index from_pos to to_pos within Waypoint_lists,
+// shifting the lists in between by one and preserving their relative order.
+// Waypoint_lists is kept compact, so positions are plain indices.
+void rotate_waypoint_lists(int from_pos, int to_pos);
+
+// Move the jump node at display position from_pos to to_pos within `slots` (the
+// live Jump_nodes[] indices, in display order), shifting the nodes in between by
+// one and preserving their relative order.  Unlike ships/props there is no
+// object-instance back-reference to re-point: a jump node links to its object via
+// CJumpNode::m_objnum, which travels with the node, and is looked up by
+// objnum/name, and the Scene Browser and mission save both iterate Jump_nodes
+// directly so permuting the occupants among their slots is all that is needed.
+void rotate_jump_nodes(const SCP_vector<int>& slots, int from_pos, int to_pos);

--- a/qtfred/help-src/doc/dialogs/ReorderDialog.html
+++ b/qtfred/help-src/doc/dialogs/ReorderDialog.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Reorder Objects - QtFRED Help</title>
+    <link rel="stylesheet" type="text/css" href="../css/help.css"/>
+</head>
+<body>
+<nav class="breadcrumb"><a href="../index.html">QtFRED Help</a> &rsaquo; Tools &rsaquo; Reorder Objects</nav>
+<h1>Reorder Objects</h1>
+<p>Opens via <strong>Tools &rsaquo; Reorder Objects</strong>.</p>
+<p>Changes the order in which ships, wings, props, waypoint lists, and jump nodes are
+stored. That order is what gets written to the mission file, and it controls how each
+type is listed in order-based UI such as the <a href="../general/SceneBrowserDialog.html">Scene
+Browser</a>. Reordering does not move anything in space, rename anything, or change any
+references. These objects are referred to by name everywhere else, so their references
+stay intact.</p>
+
+<div class="note">Moves apply immediately. There is no Apply or Cancel step: each
+move rewrites the stored order as soon as you make it, and closing the dialog keeps
+whatever order you have set.</div>
+
+<h2>Tabs</h2>
+<p>Each object type has its own tab. Switch tabs to reorder that type independently.</p>
+<table>
+    <tr><th>Tab</th><th>Reorders</th></tr>
+    <tr><td>Ships</td><td>The order of individual <a href="ShipEditorDialog.html">ships</a>,
+        including player starts.</td></tr>
+    <tr><td>Wings</td><td>The order of <a href="WingEditorDialog.html">wings</a>. Ships
+        remain assigned to their wings; only the wing order changes.</td></tr>
+    <tr><td>Props</td><td>The order of <a href="PropEditorDialog.html">props</a>.</td></tr>
+    <tr><td>Waypoint Lists</td><td>The order of <a href="WaypointEditorDialog.html">waypoint
+        paths</a>. The waypoints within each path keep their own order.</td></tr>
+    <tr><td>Jump Nodes</td><td>The order of <a href="JumpNodeEditorDialog.html">jump
+        nodes</a>.</td></tr>
+</table>
+
+<h2>Moving items</h2>
+<p>Select an item in the list, then use the buttons beside it to reposition it.
+The buttons act on the selected item and are disabled when a move would have no
+effect (for example, <strong>Move up</strong> on the top item).</p>
+<table>
+    <tr><th>Button</th><th>Action</th></tr>
+    <tr><td>Move to top</td><td>Moves the selected item to the first position.</td></tr>
+    <tr><td>Move up</td><td>Moves the selected item one position earlier.</td></tr>
+    <tr><td>Move down</td><td>Moves the selected item one position later.</td></tr>
+    <tr><td>Move to bottom</td><td>Moves the selected item to the last position.</td></tr>
+</table>
+</body>
+</html>

--- a/qtfred/help-src/doc/qtfred.qhp
+++ b/qtfred/help-src/doc/qtfred.qhp
@@ -79,6 +79,7 @@
                     <section title="Error Checker"                  ref="dialogs/ErrorCheckerDialog.html"/>
                     <section title="Global Ship Flags"              ref="dialogs/GlobalShipFlagsDialog.html"/>
                     <section title="Music Player"                   ref="dialogs/MusicPlayerDialog.html"/>
+                    <section title="Reorder Objects"                ref="dialogs/ReorderDialog.html"/>
                     <section title="Voice Acting Manager"           ref="dialogs/VoiceActingManager.html"/>
                     <section title="Waypoint Path Generator"        ref="dialogs/WaypointPathGeneratorDialog.html"/>
                 </section>
@@ -125,6 +126,7 @@
             <keyword name="Prop Editor"             id="PropEditorDialog"               ref="dialogs/PropEditorDialog.html"/>
             <keyword name="Calculate Relative Coordinates" id="RelativeCoordinatesDialog" ref="dialogs/RelativeCoordinatesDialog.html"/>
             <keyword name="Reinforcements"          id="ReinforcementsEditorDialog"     ref="dialogs/ReinforcementsEditorDialog.html"/>
+            <keyword name="Reorder Objects"         id="ReorderDialog"                  ref="dialogs/ReorderDialog.html"/>
             <keyword name="Shield System"           id="ShieldSystemDialog"             ref="dialogs/ShieldSystemDialog.html"/>
             <keyword name="Ship Editor"             id="ShipEditorDialog"               ref="dialogs/ShipEditorDialog.html"/>
             <keyword name="Ship Alt Class"          id="ShipAltShipClass"               ref="dialogs/ShipAltShipClass.html"/>
@@ -188,6 +190,7 @@
             <file>dialogs/PropEditorDialog.html</file>
             <file>dialogs/ReinforcementsEditorDialog.html</file>
             <file>dialogs/RelativeCoordinatesDialog.html</file>
+            <file>dialogs/ReorderDialog.html</file>
             <file>dialogs/ShieldSystemDialog.html</file>
             <file>dialogs/ShipEditorDialog.html</file>
             <file>dialogs/ShipAltShipClass.html</file>

--- a/qtfred/help-src/qtfred.qhp
+++ b/qtfred/help-src/qtfred.qhp
@@ -77,6 +77,7 @@
                     <section title="Error Checker"                  ref="doc/dialogs/ErrorCheckerDialog.html"/>
                     <section title="Global Ship Flags"              ref="doc/dialogs/GlobalShipFlagsDialog.html"/>
                     <section title="Music Player"                   ref="doc/dialogs/MusicPlayerDialog.html"/>
+                    <section title="Reorder Objects"                ref="doc/dialogs/ReorderDialog.html"/>
                     <section title="Voice Acting Manager"           ref="doc/dialogs/VoiceActingManager.html"/>
                     <section title="Waypoint Path Generator"        ref="doc/dialogs/WaypointPathGeneratorDialog.html"/>
                 </section>
@@ -121,6 +122,7 @@
             <keyword name="Prop Editor"             id="PropEditorDialog"               ref="doc/dialogs/PropEditorDialog.html"/>
             <keyword name="Calculate Relative Coordinates" id="RelativeCoordinatesDialog" ref="doc/dialogs/RelativeCoordinatesDialog.html"/>
             <keyword name="Reinforcements"          id="ReinforcementsEditorDialog"     ref="doc/dialogs/ReinforcementsEditorDialog.html"/>
+            <keyword name="Reorder Objects"         id="ReorderDialog"                  ref="doc/dialogs/ReorderDialog.html"/>
             <keyword name="Shield System"           id="ShieldSystemDialog"             ref="doc/dialogs/ShieldSystemDialog.html"/>
             <keyword name="Ship Editor"             id="ShipEditorDialog"               ref="doc/dialogs/ShipEditorDialog.html"/>
             <keyword name="Ship Alt Class"          id="ShipAltShipClass"               ref="doc/dialogs/ShipAltShipClass.html"/>
@@ -182,6 +184,7 @@
             <file>doc/dialogs/PropEditorDialog.html</file>
             <file>doc/dialogs/ReinforcementsEditorDialog.html</file>
             <file>doc/dialogs/RelativeCoordinatesDialog.html</file>
+            <file>doc/dialogs/ReorderDialog.html</file>
             <file>doc/dialogs/ShieldSystemDialog.html</file>
             <file>doc/dialogs/ShipEditorDialog.html</file>
             <file>doc/dialogs/ShipAltShipClass.html</file>

--- a/qtfred/source_groups.cmake
+++ b/qtfred/source_groups.cmake
@@ -86,8 +86,10 @@ add_file_folder("Source/Mission/Dialogs"
 	src/mission/dialogs/ObjectOrientEditorDialogModel.h
 	src/mission/dialogs/PropEditorDialogModel.cpp
 	src/mission/dialogs/PropEditorDialogModel.h
-	src/mission/dialogs/ReinforcementsEditorDialogModel.cpp	
+	src/mission/dialogs/ReinforcementsEditorDialogModel.cpp
 	src/mission/dialogs/ReinforcementsEditorDialogModel.h
+	src/mission/dialogs/ReorderDialogModel.cpp
+	src/mission/dialogs/ReorderDialogModel.h
 	src/mission/dialogs/RelativeCoordinatesDialogModel.cpp
 	src/mission/dialogs/RelativeCoordinatesDialogModel.h
 	src/mission/dialogs/ShieldSystemDialogModel.cpp
@@ -205,6 +207,8 @@ add_file_folder("Source/UI/Dialogs"
 	src/ui/dialogs/PropEditorDialog.h
 	src/ui/dialogs/ReinforcementsEditorDialog.cpp
 	src/ui/dialogs/ReinforcementsEditorDialog.h
+	src/ui/dialogs/ReorderDialog.cpp
+	src/ui/dialogs/ReorderDialog.h
 	src/ui/dialogs/RelativeCoordinatesDialog.cpp
 	src/ui/dialogs/RelativeCoordinatesDialog.h
 	src/ui/dialogs/SaveAsTemplateDialog.cpp
@@ -367,6 +371,7 @@ add_file_folder("UI"
 	ui/PreferencesDialog.ui
 	ui/PropEditorDialog.ui
 	ui/ReinforcementsDialog.ui
+	ui/ReorderDialog.ui
 	ui/RelativeCoordinatesDialog.ui
 	ui/ShieldSystemDialog.ui
 	ui/SoundEnvironmentDialog.ui

--- a/qtfred/src/mission/dialogs/ReorderDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ReorderDialogModel.cpp
@@ -60,7 +60,7 @@ SCP_vector<int> ReorderDialogModel::getSlots(Type type)
 	return slotList;
 }
 
-SCP_vector<SCP_string> ReorderDialogModel::getItemNames(Type type) const
+SCP_vector<SCP_string> ReorderDialogModel::getItemNames(Type type)
 {
 	SCP_vector<SCP_string> names;
 	for (int slot : getSlots(type)) {

--- a/qtfred/src/mission/dialogs/ReorderDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ReorderDialogModel.cpp
@@ -6,11 +6,8 @@
 #include "prop/prop.h"
 #include "ship/ship.h"
 
-// FRED-side parallel arrays that reassign_ship_slot keeps in sync (see
-// missioneditor/common.h).  Reached the same way the ship editor and
-// object-duplication code do.
-extern char Fred_alt_names[MAX_SHIPS][NAME_LENGTH + 1];
-extern char Fred_callsigns[MAX_SHIPS][NAME_LENGTH + 1];
+// Fred_alt_names[] / Fred_callsigns[] are the FRED-side parallel arrays that
+// reassign_ship_slot keeps in sync; they are declared extern in Editor.h.
 
 namespace fso::fred::dialogs {
 
@@ -31,7 +28,7 @@ void ReorderDialogModel::reject()
 	// Direct-edit dialog: nothing to roll back.
 }
 
-SCP_vector<int> ReorderDialogModel::getSlots(Type type) const
+SCP_vector<int> ReorderDialogModel::getSlots(Type type)
 {
 	SCP_vector<int> slotList;
 	switch (type) {

--- a/qtfred/src/mission/dialogs/ReorderDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ReorderDialogModel.cpp
@@ -1,0 +1,132 @@
+#include "mission/dialogs/ReorderDialogModel.h"
+
+#include "missioneditor/common.h"
+#include "jumpnode/jumpnode.h"
+#include "object/waypoint.h"
+#include "prop/prop.h"
+#include "ship/ship.h"
+
+// FRED-side parallel arrays that reassign_ship_slot keeps in sync (see
+// missioneditor/common.h).  Reached the same way the ship editor and
+// object-duplication code do.
+extern char Fred_alt_names[MAX_SHIPS][NAME_LENGTH + 1];
+extern char Fred_callsigns[MAX_SHIPS][NAME_LENGTH + 1];
+
+namespace fso::fred::dialogs {
+
+ReorderDialogModel::ReorderDialogModel(QObject* parent, EditorViewport* viewport) :
+	AbstractDialogModel(parent, viewport)
+{
+}
+
+bool ReorderDialogModel::apply()
+{
+	// Direct-edit dialog: moves are applied as they are made, so there is nothing
+	// to commit here.
+	return true;
+}
+
+void ReorderDialogModel::reject()
+{
+	// Direct-edit dialog: nothing to roll back.
+}
+
+SCP_vector<int> ReorderDialogModel::getSlots(Type type) const
+{
+	SCP_vector<int> slotList;
+	switch (type) {
+	case Type::Ships:
+		for (int i = 0; i < MAX_SHIPS; ++i)
+			if (Ships[i].objnum >= 0)
+				slotList.push_back(i);
+		break;
+	case Type::Wings:
+		for (int i = 0; i < MAX_WINGS; ++i)
+			if (Wings[i].wave_count > 0)
+				slotList.push_back(i);
+		break;
+	case Type::Props:
+		for (int i = 0; i < static_cast<int>(Props.size()); ++i)
+			if (Props[i].has_value())
+				slotList.push_back(i);
+		break;
+	case Type::WaypointLists:
+		for (int i = 0; i < static_cast<int>(Waypoint_lists.size()); ++i)
+			slotList.push_back(i);
+		break;
+	case Type::JumpNodes:
+		for (int i = 0; i < static_cast<int>(Jump_nodes.size()); ++i)
+			if (Jump_nodes[i].GetSCPObjectNumber() >= 0)
+				slotList.push_back(i);
+		break;
+	}
+	return slotList;
+}
+
+SCP_vector<SCP_string> ReorderDialogModel::getItemNames(Type type) const
+{
+	SCP_vector<SCP_string> names;
+	for (int slot : getSlots(type)) {
+		switch (type) {
+		case Type::Ships:
+			names.emplace_back(Ships[slot].ship_name);
+			break;
+		case Type::Wings:
+			names.emplace_back(Wings[slot].name);
+			break;
+		case Type::Props:
+			names.emplace_back(Props[slot]->prop_name);
+			break;
+		case Type::WaypointLists:
+			names.emplace_back(Waypoint_lists[slot].get_name());
+			break;
+		case Type::JumpNodes:
+			names.emplace_back(Jump_nodes[slot].GetName());
+			break;
+		}
+	}
+	return names;
+}
+
+void ReorderDialogModel::moveItem(Type type, int from_pos, int to_pos)
+{
+	if (from_pos == to_pos)
+		return;
+
+	SCP_vector<int> slotList = getSlots(type);
+	int count = static_cast<int>(slotList.size());
+	if (from_pos < 0 || from_pos >= count || to_pos < 0 || to_pos >= count)
+		return;
+
+	switch (type) {
+	case Type::Ships: {
+		FredShipSlotConfig cfg;
+		cfg.fred_alt_names = Fred_alt_names;
+		cfg.fred_callsigns = Fred_callsigns;
+		cfg.cur_ship = &_editor->cur_ship;
+		rotate_ship_slots(slotList, from_pos, to_pos, cfg);
+		break;
+	}
+	case Type::Wings: {
+		FredWingSlotConfig cfg;
+		cfg.wing_objects = _editor->wing_objects;
+		cfg.cur_wing = &_editor->cur_wing;
+		rotate_wing_slots(slotList, from_pos, to_pos, cfg);
+		break;
+	}
+	case Type::Props:
+		rotate_prop_slots(slotList, from_pos, to_pos);
+		break;
+	case Type::WaypointLists:
+		rotate_waypoint_lists(from_pos, to_pos);
+		break;
+	case Type::JumpNodes:
+		rotate_jump_nodes(slotList, from_pos, to_pos);
+		break;
+	}
+
+	set_modified();
+	_editor->missionChanged();
+}
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/ReorderDialogModel.h
+++ b/qtfred/src/mission/dialogs/ReorderDialogModel.h
@@ -24,7 +24,7 @@ public:
 	void reject() override;
 
 	// Display names for the given type, in current storage (mission-file) order.
-	SCP_vector<SCP_string> getItemNames(Type type) const;
+	static SCP_vector<SCP_string> getItemNames(Type type);
 
 	// Move the item at display position from_pos to to_pos for the given type,
 	// applying the reorder to the mission immediately.  No-op if from_pos == to_pos

--- a/qtfred/src/mission/dialogs/ReorderDialogModel.h
+++ b/qtfred/src/mission/dialogs/ReorderDialogModel.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "mission/dialogs/AbstractDialogModel.h"
+
+namespace fso::fred::dialogs {
+
+// Model for the Reorder dialog.  A direct-edit model: each move is applied to the
+// mission immediately, reordering how the object type is written to the mission file 
+// and shown in Scene Browser.
+class ReorderDialogModel : public AbstractDialogModel {
+	Q_OBJECT
+
+public:
+	enum class Type {
+		Ships,
+		Wings,
+		Props,
+		WaypointLists,
+		JumpNodes,
+	};
+
+	ReorderDialogModel(QObject* parent, EditorViewport* viewport);
+
+	bool apply() override;
+	void reject() override;
+
+	// Display names for the given type, in current storage (mission-file) order.
+	SCP_vector<SCP_string> getItemNames(Type type) const;
+
+	// Move the item at display position from_pos to to_pos for the given type,
+	// applying the reorder to the mission immediately.  No-op if from_pos == to_pos
+	// or either position is out of range.
+	void moveItem(Type type, int from_pos, int to_pos);
+
+private: // NOLINT(readability-redundant-access-specifiers)
+	// The occupied storage indices for the given type, in display order.  For
+	// ships/wings/props/jump nodes these are the live Ships[]/Wings[]/Props[]/
+	// Jump_nodes[] slots; for waypoint lists they are simply 0..N-1.
+	SCP_vector<int> getSlots(Type type) const;
+};
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/ReorderDialogModel.h
+++ b/qtfred/src/mission/dialogs/ReorderDialogModel.h
@@ -35,7 +35,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	// The occupied storage indices for the given type, in display order.  For
 	// ships/wings/props/jump nodes these are the live Ships[]/Wings[]/Props[]/
 	// Jump_nodes[] slots; for waypoint lists they are simply 0..N-1.
-	SCP_vector<int> getSlots(Type type) const;
+	static SCP_vector<int> getSlots(Type type);
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/ui/FredView.cpp
+++ b/qtfred/src/ui/FredView.cpp
@@ -33,6 +33,7 @@
 #include <ui/dialogs/VolumetricNebulaDialog.h>
 #include <ui/dialogs/BriefingEditorDialog.h>
 #include <ui/dialogs/WaypointEditorDialog.h>
+#include <ui/dialogs/ReorderDialog.h>
 #include <object/waypoint.h>
 #include <ui/dialogs/WaypointPathGeneratorDialog.h>
 #include <ui/dialogs/JumpNodeEditorDialog.h>
@@ -2526,6 +2527,9 @@ void FredView::on_actionMission_Specs_triggered(bool) {
 }
 void FredView::on_actionWaypoint_Paths_triggered(bool) {
 	showSingleInstanceDialog<dialogs::WaypointEditorDialog>(this, _viewport);
+}
+void FredView::on_actionReorder_Objects_triggered(bool) {
+	showSingleInstanceDialog<dialogs::ReorderDialog>(this, _viewport);
 }
 void FredView::on_actionJump_Nodes_triggered(bool)
 {

--- a/qtfred/src/ui/FredView.h
+++ b/qtfred/src/ui/FredView.h
@@ -179,6 +179,7 @@ class FredView: public QMainWindow, public IDialogProvider {
 	void on_actionMusic_Player_triggered(bool);
 	void on_actionCalculate_Relative_Coordinates_triggered(bool);
 	void on_actionWaypointPathGenerator_triggered(bool);
+	void on_actionReorder_Objects_triggered(bool);
  signals:
 	/**
 	 * @brief Special version of FredApplication::onIdle which is limited to the lifetime of this object

--- a/qtfred/src/ui/dialogs/ReorderDialog.cpp
+++ b/qtfred/src/ui/dialogs/ReorderDialog.cpp
@@ -45,7 +45,7 @@ void ReorderDialog::setupTab(const Tab& tab)
 	connect(tab.up, &QAbstractButton::clicked, this, [this, tab] { move(tab, true, false); });
 	connect(tab.down, &QAbstractButton::clicked, this, [this, tab] { move(tab, false, false); });
 	connect(tab.bottom, &QAbstractButton::clicked, this, [this, tab] { move(tab, false, true); });
-	connect(tab.list, &QListWidget::currentRowChanged, this, [this, tab] { updateButtons(tab); });
+	connect(tab.list, &QListWidget::currentRowChanged, this, [tab] { updateButtons(tab); });
 
 	rebuildList(tab);
 	// Select the first item so the move buttons start in a sensible state.

--- a/qtfred/src/ui/dialogs/ReorderDialog.cpp
+++ b/qtfred/src/ui/dialogs/ReorderDialog.cpp
@@ -1,0 +1,112 @@
+#include "ui/dialogs/ReorderDialog.h"
+#include "ui/Theme.h"
+#include "ui_ReorderDialog.h"
+
+#include <QListWidget>
+#include <QPushButton>
+#include <QSignalBlocker>
+
+#include <algorithm>
+
+namespace fso::fred::dialogs {
+
+ReorderDialog::ReorderDialog(FredView* parent, EditorViewport* viewport) :
+	QDialog(parent),
+	_viewport(viewport),
+	ui(new Ui::ReorderDialog()),
+	_model(new ReorderDialogModel(this, viewport))
+{
+	ui->setupUi(this);
+
+	using Type = ReorderDialogModel::Type;
+	_tabs = {
+		{Type::Ships, ui->shipList, ui->shipMoveTopBtn, ui->shipMoveUpBtn, ui->shipMoveDownBtn, ui->shipMoveBottomBtn},
+		{Type::Wings, ui->wingList, ui->wingMoveTopBtn, ui->wingMoveUpBtn, ui->wingMoveDownBtn, ui->wingMoveBottomBtn},
+		{Type::Props, ui->propList, ui->propMoveTopBtn, ui->propMoveUpBtn, ui->propMoveDownBtn, ui->propMoveBottomBtn},
+		{Type::WaypointLists, ui->waypointList, ui->waypointMoveTopBtn, ui->waypointMoveUpBtn, ui->waypointMoveDownBtn, ui->waypointMoveBottomBtn},
+		{Type::JumpNodes, ui->jumpNodeList, ui->jumpNodeMoveTopBtn, ui->jumpNodeMoveUpBtn, ui->jumpNodeMoveDownBtn, ui->jumpNodeMoveBottomBtn},
+	};
+
+	for (const auto& tab : _tabs) {
+		setupTab(tab);
+	}
+}
+
+ReorderDialog::~ReorderDialog() = default;
+
+void ReorderDialog::setupTab(const Tab& tab)
+{
+	fso::fred::bindCustomIcon(tab.top, CustomIcon::MoveToTop);
+	fso::fred::bindStandardIcon(tab.up, QStyle::SP_ArrowUp);
+	fso::fred::bindStandardIcon(tab.down, QStyle::SP_ArrowDown);
+	fso::fred::bindCustomIcon(tab.bottom, CustomIcon::MoveToBottom);
+
+	connect(tab.top, &QAbstractButton::clicked, this, [this, tab] { move(tab, true, true); });
+	connect(tab.up, &QAbstractButton::clicked, this, [this, tab] { move(tab, true, false); });
+	connect(tab.down, &QAbstractButton::clicked, this, [this, tab] { move(tab, false, false); });
+	connect(tab.bottom, &QAbstractButton::clicked, this, [this, tab] { move(tab, false, true); });
+	connect(tab.list, &QListWidget::currentRowChanged, this, [this, tab] { updateButtons(tab); });
+
+	rebuildList(tab);
+	// Select the first item so the move buttons start in a sensible state.
+	if (tab.list->count() > 0)
+		tab.list->setCurrentRow(0);
+	updateButtons(tab);
+}
+
+void ReorderDialog::rebuildList(const Tab& tab)
+{
+	QSignalBlocker blocker(tab.list);
+
+	const int prevRow = tab.list->currentRow();
+
+	tab.list->clear();
+	for (const auto& name : _model->getItemNames(tab.type)) {
+		tab.list->addItem(QString::fromStdString(name));
+	}
+
+	// Keep the previous row selected where possible (clamped to the new count).
+	const int count = tab.list->count();
+	if (count > 0 && prevRow >= 0)
+		tab.list->setCurrentRow(std::min(prevRow, count - 1));
+}
+
+void ReorderDialog::updateButtons(const Tab& tab)
+{
+	const int row = tab.list->currentRow();
+	const int count = tab.list->count();
+
+	const bool canUp = (row > 0);
+	const bool canDown = (row >= 0 && row < count - 1);
+
+	tab.top->setEnabled(canUp);
+	tab.up->setEnabled(canUp);
+	tab.down->setEnabled(canDown);
+	tab.bottom->setEnabled(canDown);
+}
+
+void ReorderDialog::move(const Tab& tab, bool up, bool all_the_way)
+{
+	const int from = tab.list->currentRow();
+	const int count = tab.list->count();
+	if (from < 0 || from >= count)
+		return;
+
+	int to;
+	if (up)
+		to = all_the_way ? 0 : from - 1;
+	else
+		to = all_the_way ? count - 1 : from + 1;
+
+	if (to < 0 || to >= count || to == from)
+		return;
+
+	_model->moveItem(tab.type, from, to);
+
+	rebuildList(tab);
+	tab.list->setCurrentRow(to);
+	tab.list->scrollToItem(tab.list->currentItem());
+	updateButtons(tab);
+}
+
+} // namespace fso::fred::dialogs

--- a/qtfred/src/ui/dialogs/ReorderDialog.h
+++ b/qtfred/src/ui/dialogs/ReorderDialog.h
@@ -36,7 +36,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 
 	void setupTab(const Tab& tab);
 	void rebuildList(const Tab& tab);
-	void updateButtons(const Tab& tab);
+	static void updateButtons(const Tab& tab);
 	void move(const Tab& tab, bool up, bool all_the_way);
 
 	EditorViewport* _viewport = nullptr;

--- a/qtfred/src/ui/dialogs/ReorderDialog.h
+++ b/qtfred/src/ui/dialogs/ReorderDialog.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QDialog>
+
+#include <mission/dialogs/ReorderDialogModel.h>
+#include <ui/FredView.h>
+
+class QListWidget;
+class QAbstractButton;
+
+namespace fso::fred::dialogs {
+
+namespace Ui {
+class ReorderDialog;
+}
+
+// Direct-edit dialog for reordering ships, wings, props, waypoint lists and jump
+// nodes.  Each tab is a plain list plus a move-to-top / up / down / to-bottom
+// button strip; every move is applied to the mission immediately.
+class ReorderDialog : public QDialog {
+	Q_OBJECT
+
+public:
+	ReorderDialog(FredView* parent, EditorViewport* viewport);
+	~ReorderDialog() override;
+
+private: // NOLINT(readability-redundant-access-specifiers)
+	struct Tab {
+		ReorderDialogModel::Type type;
+		QListWidget* list;
+		QAbstractButton* top;
+		QAbstractButton* up;
+		QAbstractButton* down;
+		QAbstractButton* bottom;
+	};
+
+	void setupTab(const Tab& tab);
+	void rebuildList(const Tab& tab);
+	void updateButtons(const Tab& tab);
+	void move(const Tab& tab, bool up, bool all_the_way);
+
+	EditorViewport* _viewport = nullptr;
+	std::unique_ptr<Ui::ReorderDialog> ui;
+	std::unique_ptr<ReorderDialogModel> _model;
+	SCP_vector<Tab> _tabs;
+};
+
+} // namespace fso::fred::dialogs

--- a/qtfred/ui/FredView.ui
+++ b/qtfred/ui/FredView.ui
@@ -250,6 +250,7 @@
      <string>Tools</string>
     </property>
     <addaction name="actionWaypointPathGenerator"/>
+    <addaction name="actionReorder_Objects"/>
     <addaction name="actionVoice_Acting_Manager"/>
     <addaction name="actionSet_Global_Ship_Flags"/>
     <addaction name="actionCalculate_Relative_Coordinates"/>
@@ -1055,6 +1056,11 @@
    </property>
    <property name="shortcut">
     <string>Shift+Y</string>
+   </property>
+  </action>
+  <action name="actionReorder_Objects">
+   <property name="text">
+    <string>&amp;Reorder Objects</string>
    </property>
   </action>
   <action name="actionMission_Events">

--- a/qtfred/ui/ReorderDialog.ui
+++ b/qtfred/ui/ReorderDialog.ui
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>fso::fred::dialogs::ReorderDialog</class>
+ <widget class="QDialog" name="ReorderDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>380</width>
+    <height>460</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Reorder Objects</string>
+  </property>
+  <layout class="QVBoxLayout" name="rootLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="shipsTab">
+      <attribute name="title">
+       <string>Ships</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="shipsLayout">
+       <item>
+        <widget class="QListWidget" name="shipList">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="shipButtonsLayout">
+         <item>
+          <widget class="QPushButton" name="shipMoveTopBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to top</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="shipMoveUpBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move up</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="shipMoveDownBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move down</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="shipMoveBottomBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to bottom</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="shipButtonsSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="wingsTab">
+      <attribute name="title">
+       <string>Wings</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="wingsLayout">
+       <item>
+        <widget class="QListWidget" name="wingList">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="wingButtonsLayout">
+         <item>
+          <widget class="QPushButton" name="wingMoveTopBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to top</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="wingMoveUpBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move up</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="wingMoveDownBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move down</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="wingMoveBottomBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to bottom</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="wingButtonsSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="propsTab">
+      <attribute name="title">
+       <string>Props</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="propsLayout">
+       <item>
+        <widget class="QListWidget" name="propList">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="propButtonsLayout">
+         <item>
+          <widget class="QPushButton" name="propMoveTopBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to top</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="propMoveUpBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move up</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="propMoveDownBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move down</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="propMoveBottomBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to bottom</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="propButtonsSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="waypointsTab">
+      <attribute name="title">
+       <string>Waypoint Lists</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="waypointsLayout">
+       <item>
+        <widget class="QListWidget" name="waypointList">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="waypointButtonsLayout">
+         <item>
+          <widget class="QPushButton" name="waypointMoveTopBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to top</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="waypointMoveUpBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move up</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="waypointMoveDownBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move down</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="waypointMoveBottomBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to bottom</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="waypointButtonsSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="jumpNodesTab">
+      <attribute name="title">
+       <string>Jump Nodes</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="jumpNodesLayout">
+       <item>
+        <widget class="QListWidget" name="jumpNodeList">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="jumpNodeButtonsLayout">
+         <item>
+          <widget class="QPushButton" name="jumpNodeMoveTopBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to top</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="jumpNodeMoveUpBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move up</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="jumpNodeMoveDownBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move down</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="jumpNodeMoveBottomBtn">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Move to bottom</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="jumpNodeButtonsSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Copies the object re-order dialog recently added to FRED2 into QtFRED while also supporting all object types in addition to Ships and Wings. In QtFRED, all primary object types get first class support. Help dialog text also added.