### PR TITLE
Fix various issues in SCPUI when using Vulkan

### DIFF
--- a/code/graphics/2d.cpp
+++ b/code/graphics/2d.cpp
@@ -2130,6 +2130,18 @@ bool gr_init(std::unique_ptr<os::GraphicsOperations>&& graphicsOps, GraphicsAPI 
 		Shadow_quality = ShadowQuality::Disabled;
 	}
 
+	// Drop options that have no meaning for the renderer we ended up with, so they don't
+	// appear in the options menu. HDR10 output is Vulkan-only; the raytraced-shadow options
+	// are gated on raytracing support (removed below). The bound globals keep their
+	// defaults, so nothing about the rendering path changes.
+	if (gr_screen.mode != GraphicsAPI::Vulkan) {
+		auto* options_mgr = options::OptionsManager::instance();
+		options_mgr->removeOption(HDROption);
+		options_mgr->removeOption(HDRPaperWhiteOption);
+		options_mgr->removeOption(HDRPeakOption);
+	}
+	shadows_remove_unsupported_options();
+
 	if(Cmdline_enable_vr)
 		openxr_init();
 

--- a/code/graphics/shadows.cpp
+++ b/code/graphics/shadows.cpp
@@ -227,6 +227,25 @@ bool shadows_raytracing_supported()
 	return gr_is_capable(gr_capability::CAPABILITY_RAYTRACED_SHADOWS);
 }
 
+void shadows_remove_unsupported_options()
+{
+	if (shadows_raytracing_supported()) {
+		return;
+	}
+
+	// No raytracing support (e.g. the OpenGL renderer): the render-method selector
+	// degenerates to a single value and every raytraced-shadow tuning option is inert, so
+	// drop them all. The bound globals keep their defaults, so shadow-map rendering is
+	// unaffected. Graphics.Shadows (base shadow quality) is deliberately kept.
+	auto* mgr = options::OptionsManager::instance();
+	mgr->removeOption(ShadowRenderMethodOption);
+	mgr->removeOption(MaxRtShadowLightsOption);
+	mgr->removeOption(RTShadowQualityOption);
+	mgr->removeOption(MaxRtShadowLocalLightsOption);
+	mgr->removeOption(RtShadowBiasMinOption);
+	mgr->removeOption(RtShadowBiasMaxOption);
+}
+
 bool shadows_use_raytracing()
 {
 	return Shadow_render_method == ShadowRenderMethod::Raytraced && shadows_raytracing_supported();

--- a/code/graphics/shadows.h
+++ b/code/graphics/shadows.h
@@ -70,6 +70,12 @@ extern float Rt_shadow_bias_max;
 // of which method is currently selected -- use this to decide whether to offer the choice.
 bool shadows_raytracing_supported();
 
+// Removes the raytraced-shadow options (method selector, light counts, bias) from the
+// options menu when the current renderer/hardware can't do raytraced shadows, so they don't
+// clutter the UI with settings that have no effect. Call once after the renderer is up
+// (gr_init), when shadows_raytracing_supported() is meaningful.
+void shadows_remove_unsupported_options();
+
 // Whether shading should actually sample the raytraced-shadow TLAS right now, i.e. both
 // the user has selected it AND the hardware supports it. This is the single source of
 // truth for that decision -- gate any new raytraced-shadow shader-flag or resource-binding

--- a/code/graphics/vulkan/VulkanRenderer.cpp
+++ b/code/graphics/vulkan/VulkanRenderer.cpp
@@ -613,6 +613,157 @@ bool VulkanRenderer::readbackFramebuffer(ubyte** outPixels, uint32_t* outWidth, 
 	return success;
 }
 
+bool VulkanRenderer::readbackRenderTarget(tcache_slot_vulkan* ts, ubyte** outPixels, uint32_t* outWidth,
+	uint32_t* outHeight)
+{
+	*outPixels = nullptr;
+	*outWidth = 0;
+	*outHeight = 0;
+
+	if (!ts || !ts->image || !ts->renderPassLoad || !ts->framebuffer) {
+		nprintf(("vulkan", "readbackRenderTarget - render target has no readable/resumable resources\n"));
+		return false;
+	}
+
+	if (!m_frameInProgress || !m_currentCommandBuffer) {
+		nprintf(("vulkan", "readbackRenderTarget - no frame in progress\n"));
+		return false;
+	}
+
+	const uint32_t w = ts->width;
+	const uint32_t h = ts->height;
+	if (w == 0 || h == 0) {
+		return false;
+	}
+
+	// The target's draws are in the current (not-yet-submitted) frame command buffer, so
+	// we can't read them via a side command buffer like readbackFramebuffer does. Instead
+	// we flush the frame command buffer mid-frame: end the active render-target pass,
+	// record the color image -> staging copy into the SAME buffer, submit it (segment 1)
+	// with a temporary fence, and host-wait so the pixels are ready. Rendering then
+	// resumes on a fresh command buffer (segment 2) that flip() ultimately submits.
+
+	const vk::DeviceSize bufferSize = static_cast<vk::DeviceSize>(w) * h * 4u; // R8G8B8A8
+
+	// Allocate the staging buffer BEFORE touching the render pass or image layout. If it
+	// fails we return with the render-target pass still active and the image untouched, so
+	// the frame carries on exactly as if the capture never happened.
+	vk::BufferCreateInfo bufferCreateInfo;
+	bufferCreateInfo.size = bufferSize;
+	bufferCreateInfo.usage = vk::BufferUsageFlagBits::eTransferDst;
+	bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
+	auto stagingBuffer = m_device->createBuffer(bufferCreateInfo);
+
+	VulkanAllocation stagingAlloc{};
+	if (!m_memoryManager->allocateBufferMemory(stagingBuffer, MemoryUsage::GpuToCpu, stagingAlloc)) {
+		nprintf(("vulkan", "readbackRenderTarget - failed to allocate staging buffer\n"));
+		m_device->destroyBuffer(stagingBuffer);
+		return false;
+	}
+
+	// End the active render-target pass; its finalLayout leaves the color image in
+	// eShaderReadOnlyOptimal.
+	m_currentCommandBuffer.endRenderPass();
+
+	// Transition color image eShaderReadOnlyOptimal -> eTransferSrcOptimal for the copy.
+	ImageBarrier2 preBarrier;
+	preBarrier.image = ts->image;
+	preBarrier.oldLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
+	preBarrier.newLayout = vk::ImageLayout::eTransferSrcOptimal;
+	preBarrier.srcStage = vk::PipelineStageFlagBits2::eColorAttachmentOutput;
+	preBarrier.srcAccess = vk::AccessFlagBits2::eColorAttachmentWrite;
+	preBarrier.dstStage = vk::PipelineStageFlagBits2::eCopy;
+	preBarrier.dstAccess = vk::AccessFlagBits2::eTransferRead;
+	cmdImageBarrier(m_currentCommandBuffer, preBarrier);
+
+	vk::BufferImageCopy region;
+	region.bufferOffset = 0;
+	region.bufferRowLength = 0;   // tightly packed
+	region.bufferImageHeight = 0; // tightly packed
+	region.imageSubresource = {vk::ImageAspectFlagBits::eColor, 0, 0, 1};
+	region.imageOffset = vk::Offset3D(0, 0, 0);
+	region.imageExtent = vk::Extent3D(w, h, 1);
+	m_currentCommandBuffer.copyImageToBuffer(ts->image, vk::ImageLayout::eTransferSrcOptimal, stagingBuffer, region);
+
+	// Transition color image back to eShaderReadOnlyOptimal (the load-variant resume pass
+	// expects this initial layout). The dst scope covers the loadOp=eLoad color read/write
+	// when rendering resumes.
+	ImageBarrier2 postBarrier;
+	postBarrier.image = ts->image;
+	postBarrier.oldLayout = vk::ImageLayout::eTransferSrcOptimal;
+	postBarrier.newLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
+	postBarrier.srcStage = vk::PipelineStageFlagBits2::eCopy;
+	postBarrier.srcAccess = vk::AccessFlagBits2::eTransferRead;
+	postBarrier.dstStage = vk::PipelineStageFlagBits2::eColorAttachmentOutput | vk::PipelineStageFlagBits2::eFragmentShader;
+	postBarrier.dstAccess = vk::AccessFlagBits2::eColorAttachmentRead | vk::AccessFlagBits2::eColorAttachmentWrite |
+	                        vk::AccessFlagBits2::eShaderSampledRead;
+	cmdImageBarrier(m_currentCommandBuffer, postBarrier);
+
+	// --- Submit segment 1 (RT draws + copy) and wait. No swap-chain image is touched here,
+	// so this submission carries no acquire/present semaphores -- just a throwaway fence. ---
+	m_currentCommandBuffer.end();
+
+	auto fence = m_device->createFence({});
+	vk::SubmitInfo submitInfo;
+	submitInfo.commandBufferCount = static_cast<uint32_t>(m_currentCommandBuffers.size());
+	submitInfo.pCommandBuffers = m_currentCommandBuffers.data();
+	m_graphicsQueue.submit(submitInfo, fence);
+
+	auto waitResult = m_device->waitForFences(fence, VK_TRUE, UINT64_MAX);
+	if (waitResult != vk::Result::eSuccess) {
+		nprintf(("vulkan", "readbackRenderTarget - fence wait failed\n"));
+	}
+	m_device->destroyFence(fence);
+
+	// Segment 1's command buffers are done executing (fence signaled), so free them now.
+	m_device->freeCommandBuffers(m_graphicsCommandPool.get(), m_currentCommandBuffers);
+	m_currentCommandBuffers.clear();
+	m_currentCommandBuffer = nullptr;
+
+	// Copy pixels out: R8G8B8A8_UNORM is already tightly-packed RGBA with real alpha, so no
+	// swizzle and no forced opacity (the icons rely on the transparent background).
+	bool success = false;
+	auto* mappedPtr = static_cast<ubyte*>(m_memoryManager->mapMemory(stagingAlloc));
+	if (mappedPtr) {
+		auto* pixels = static_cast<ubyte*>(vm_malloc(static_cast<int>(bufferSize)));
+		if (pixels) {
+			memcpy(pixels, mappedPtr, static_cast<size_t>(bufferSize));
+			*outPixels = pixels;
+			*outWidth = w;
+			*outHeight = h;
+			success = true;
+		}
+		m_memoryManager->unmapMemory(stagingAlloc);
+	}
+	m_device->destroyBuffer(stagingBuffer);
+	m_memoryManager->freeAllocation(stagingAlloc);
+
+	// --- Begin segment 2: a fresh frame command buffer that flip() will submit+present. ---
+	vk::CommandBufferAllocateInfo cmdAlloc;
+	cmdAlloc.commandPool = m_graphicsCommandPool.get();
+	cmdAlloc.level = vk::CommandBufferLevel::ePrimary;
+	cmdAlloc.commandBufferCount = 1;
+	auto cmdBufs = m_device->allocateCommandBuffers(cmdAlloc);
+	m_currentCommandBuffers.assign(cmdBufs.begin(), cmdBufs.end());
+	m_currentCommandBuffer = m_currentCommandBuffers.front();
+
+	vk::CommandBufferBeginInfo beginInfo;
+	beginInfo.flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit;
+	m_currentCommandBuffer.begin(beginInfo);
+
+	// A fresh command buffer starts with no Vulkan state, so re-point the state tracker at
+	// it and invalidate every cached binding/dynamic-state value. beginFrame() does exactly
+	// this (and touches nothing else), so the next tracked draw re-binds pipeline,
+	// descriptors, viewport, scissor, etc. Deliberately NOT resetting the descriptor pool
+	// mid-frame (segment 2 keeps allocating past segment 1's sets).
+	m_stateTracker->beginFrame(m_currentCommandBuffer);
+
+	// Resume drawing into the target (loadOp=eLoad) so content survives the flush.
+	resumeRenderTargetPass(ts);
+
+	return success;
+}
+
 uint32_t VulkanRenderer::getMinUniformBufferOffsetAlignment() const
 {
 	if (!m_physicalDevice) {

--- a/code/graphics/vulkan/VulkanRenderer.h
+++ b/code/graphics/vulkan/VulkanRenderer.h
@@ -124,6 +124,27 @@ class VulkanRenderer {
 	bool readbackFramebuffer(ubyte** outPixels, uint32_t* outWidth, uint32_t* outHeight);
 
 	/**
+	 * @brief Read back the currently-bound off-screen render target's color image.
+	 *
+	 * Unlike readbackFramebuffer (which reads the previous frame's on-screen image),
+	 * this captures the render target that is active right now via bm_set_render_target
+	 * — the path gr.screenToBlob uses to grab SCPUI-generated icons. Because the target's
+	 * draws live in the not-yet-submitted frame command buffer, this flushes that buffer
+	 * mid-frame (submit + host wait), copies the target's color image, then resumes
+	 * rendering into it with a loadOp=eLoad pass so already-drawn content survives.
+	 *
+	 * The target is R8G8B8A8_UNORM, so pixels come back as tightly-packed RGBA8 with
+	 * alpha preserved (no swizzle, no forced opacity). Caller must vm_free the buffer.
+	 *
+	 * @param ts         The active render target slot (must be non-cubemap, have a framebuffer)
+	 * @param[out] outPixels Receives the vm_malloc'd RGBA8 pixel buffer
+	 * @param[out] outWidth  Receives the target width
+	 * @param[out] outHeight Receives the target height
+	 * @return true on success, false on failure
+	 */
+	bool readbackRenderTarget(tcache_slot_vulkan* ts, ubyte** outPixels, uint32_t* outWidth, uint32_t* outHeight);
+
+	/**
 	 * @brief Get the minimum uniform buffer offset alignment requirement
 	 * @return The alignment in bytes (typically 64 or 256)
 	 */
@@ -269,6 +290,14 @@ class VulkanRenderer {
 	 * (render targets, irradiance map generation) to return to swap chain.
 	 */
 	void resumeSwapChainPass();
+
+	/**
+	 * @brief Resume rendering into a render target with loadOp=eLoad (preserving content)
+	 *
+	 * Used after a mid-frame render-target readback (readbackRenderTarget) to continue
+	 * drawing into the same target without clearing what was already rendered.
+	 */
+	void resumeRenderTargetPass(tcache_slot_vulkan* ts);
 
 	/**
 	 * @brief Check if we're currently rendering to an off-screen render target

--- a/code/graphics/vulkan/VulkanRenderer.h
+++ b/code/graphics/vulkan/VulkanRenderer.h
@@ -289,6 +289,15 @@ class VulkanRenderer {
 	 */
 	vk::SampleCountFlagBits getMsaaSampleCount() const { return m_msaaSampleCount; }
 
+	/**
+	 * @brief Get the depth/stencil format chosen at device init
+	 *
+	 * Used by render targets created with BMP_FLAG_RENDER_TARGET_DEPTH_ATTACHMENT so
+	 * their depth buffer matches the swap-chain depth format. Returns eUndefined if
+	 * depth resources have not been created yet.
+	 */
+	vk::Format getDepthFormat() const { return m_depthFormat; }
+
   private:
 	/**
 	 * @brief Begin a render pass on the frame command buffer with full state-tracker sync

--- a/code/graphics/vulkan/VulkanRendererLoop.cpp
+++ b/code/graphics/vulkan/VulkanRendererLoop.cpp
@@ -473,14 +473,18 @@ void VulkanRenderer::beginRenderTarget(tcache_slot_vulkan* ts, int face)
 	vk::Framebuffer fb = (ts->isCubemap && face >= 0 && face < 6)
 	                    ? ts->cubeFaceFramebuffers[face] : ts->framebuffer;
 
-	vk::ClearValue clearValue;
-	clearValue.color = m_stateTracker->getClearColor();
+	// Clear values must match the render pass attachments: color at index 0, and
+	// depth at index 1 when this target has a depth attachment.
+	std::array<vk::ClearValue, 2> clearValues;
+	clearValues[0].color = m_stateTracker->getClearColor();
+	clearValues[1].depthStencil = vk::ClearDepthStencilValue(1.0f, 0);
+	const bool hasDepth = static_cast<bool>(ts->depthImage);
 
 	PassBeginDesc pass;
 	pass.renderPass = ts->renderPass;
 	pass.framebuffer = fb;
 	pass.extent = vk::Extent2D(ts->width, ts->height);
-	pass.clearValues = ArrayView<vk::ClearValue>(&clearValue, 1);
+	pass.clearValues = ArrayView<vk::ClearValue>(clearValues.data(), hasDepth ? 2 : 1);
 	// The engine sets the RTT viewport itself via gr_set_viewport (positive
 	// height; the RTT projection matrix handles the Y-flip), so keep it.
 	pass.viewport = PassViewport::Keep;

--- a/code/graphics/vulkan/VulkanRendererLoop.cpp
+++ b/code/graphics/vulkan/VulkanRendererLoop.cpp
@@ -544,4 +544,26 @@ void VulkanRenderer::resumeSwapChainPass()
 	beginTrackedRenderPass(pass);
 }
 
+void VulkanRenderer::resumeRenderTargetPass(tcache_slot_vulkan* ts)
+{
+	// loadOp=eLoad on color keeps whatever was already drawn into the target; depth (if
+	// any) still clears. Only the depth clear value is consumed, but supply both so the
+	// index layout matches the pass attachments.
+	std::array<vk::ClearValue, 2> clearValues;
+	clearValues[0].color = m_stateTracker->getClearColor();
+	clearValues[1].depthStencil = vk::ClearDepthStencilValue(1.0f, 0);
+	const bool hasDepth = static_cast<bool>(ts->depthImage);
+
+	PassBeginDesc pass;
+	pass.renderPass = ts->renderPassLoad;
+	pass.framebuffer = ts->framebuffer;
+	pass.extent = vk::Extent2D(ts->width, ts->height);
+	pass.clearValues = ArrayView<vk::ClearValue>(clearValues.data(), hasDepth ? 2 : 1);
+	// Match beginRenderTarget: the engine drives the RTT viewport via gr_set_viewport.
+	pass.viewport = PassViewport::Keep;
+	beginTrackedRenderPass(pass);
+
+	m_renderTargetActive = true;
+}
+
 } // namespace graphics::vulkan

--- a/code/graphics/vulkan/VulkanState.h
+++ b/code/graphics/vulkan/VulkanState.h
@@ -181,6 +181,10 @@ class VulkanStateTracker {
 		float fr = static_cast<float>(gr_screen.current_clear_color.red) / 255.0f;
 		float fg = static_cast<float>(gr_screen.current_clear_color.green) / 255.0f;
 		float fb = static_cast<float>(gr_screen.current_clear_color.blue) / 255.0f;
+		// Honor the requested clear alpha rather than forcing opaque. Render-to-texture
+		// targets (e.g. SCPUI) clear with alpha 0 to get a transparent background;
+		// hardcoding 1.0 here left those targets pure black.
+		float fa = static_cast<float>(gr_screen.current_clear_color.alpha) / 255.0f;
 		// Apply HDR gamma if needed
 		if (High_dynamic_range) {
 			const float SRGB_GAMMA = 2.2f;
@@ -188,7 +192,7 @@ class VulkanStateTracker {
 			fg = powf(fg, SRGB_GAMMA);
 			fb = powf(fb, SRGB_GAMMA);
 		}
-		return {fr, fg, fb, 1.0f};
+		return {fr, fg, fb, fa};
 	}
 
 	// ========== Render State Tracking ==========

--- a/code/graphics/vulkan/VulkanTexture.cpp
+++ b/code/graphics/vulkan/VulkanTexture.cpp
@@ -121,6 +121,7 @@ void tcache_slot_vulkan::reset()
 	framebuffer = nullptr;
 	framebufferView = nullptr;
 	renderPass = nullptr;
+	renderPassLoad = nullptr;
 	isRenderTarget = false;
 	depthImage = nullptr;
 	depthImageView = nullptr;
@@ -466,6 +467,11 @@ void VulkanTextureManager::bm_free_data(bitmap_slot* slot, bool release) const
 	if (ts->renderPass) {
 		deletionQueue->queueRenderPass(ts->renderPass);
 		ts->renderPass = nullptr;
+	}
+
+	if (ts->renderPassLoad) {
+		deletionQueue->queueRenderPass(ts->renderPassLoad);
+		ts->renderPassLoad = nullptr;
 	}
 
 	if (ts->imageView) {
@@ -1444,6 +1450,43 @@ int VulkanTextureManager::bm_make_render_target(int handle, int* width, int* hei
 		return 0;
 	}
 
+	// Load-variant of the render pass (color loadOp=eLoad) so a mid-frame readback can
+	// resume rendering into this target without clearing what was already drawn. Only
+	// flat targets are read back via gr.screenToBlob, so skip it for cubemaps.
+	if (!isCubemapRT) {
+		vk::AttachmentDescription loadColorAttachment = colorAttachment;
+		loadColorAttachment.loadOp = vk::AttachmentLoadOp::eLoad;
+		std::array<vk::AttachmentDescription, 2> loadAttachments = {loadColorAttachment, depthAttachment};
+
+		vk::RenderPassCreateInfo loadPassInfo;
+		loadPassInfo.attachmentCount = hasDepth ? 2u : 1u;
+		loadPassInfo.pAttachments = loadAttachments.data();
+		loadPassInfo.subpassCount = 1;
+		loadPassInfo.pSubpasses = &subpass;
+
+		try {
+			ts->renderPassLoad = m_device.createRenderPass(loadPassInfo);
+		} catch (const vk::SystemError& e) {
+			nprintf(("vulkan", "Failed to create load-variant render pass: %s\n", e.what()));
+			m_device.destroyRenderPass(ts->renderPass);
+			ts->renderPass = nullptr;
+			if (hasDepth) {
+				m_device.destroyImageView(ts->depthImageView);
+				m_device.destroyImage(ts->depthImage);
+				ts->depthImageView = nullptr;
+				ts->depthImage = nullptr;
+				m_memoryManager->freeAllocation(ts->depthAllocation);
+				ts->depthAllocation = VulkanAllocation{};
+			}
+			m_device.destroyImageView(ts->imageView);
+			m_device.destroyImage(ts->image);
+			ts->image = nullptr;
+			ts->imageView = nullptr;
+			m_memoryManager->freeAllocation(ts->allocation);
+			return 0;
+		}
+	}
+
 	if (isCubemapRT) {
 		// Create per-face framebuffers
 		for (size_t face = 0; face < ts->cubeFaceFramebuffers.size(); face++) {
@@ -1492,6 +1535,10 @@ int VulkanTextureManager::bm_make_render_target(int handle, int* width, int* hei
 				ts->depthAllocation = VulkanAllocation{};
 			}
 			m_device.destroyRenderPass(ts->renderPass);
+			if (ts->renderPassLoad) {
+				m_device.destroyRenderPass(ts->renderPassLoad);
+				ts->renderPassLoad = nullptr;
+			}
 			m_device.destroyImageView(ts->imageView);
 			m_device.destroyImage(ts->image);
 			ts->image = nullptr;

--- a/code/graphics/vulkan/VulkanTexture.cpp
+++ b/code/graphics/vulkan/VulkanTexture.cpp
@@ -122,6 +122,9 @@ void tcache_slot_vulkan::reset()
 	framebufferView = nullptr;
 	renderPass = nullptr;
 	isRenderTarget = false;
+	depthImage = nullptr;
+	depthImageView = nullptr;
+	depthAllocation = VulkanAllocation();
 	is3D = false;
 	depth = 1;
 	isCubemap = false;
@@ -473,6 +476,17 @@ void VulkanTextureManager::bm_free_data(bitmap_slot* slot, bool release) const
 	if (ts->framebufferView) {
 		deletionQueue->queueImageView(ts->framebufferView);
 		ts->framebufferView = nullptr;
+	}
+
+	if (ts->depthImageView) {
+		deletionQueue->queueImageView(ts->depthImageView);
+		ts->depthImageView = nullptr;
+	}
+
+	if (ts->depthImage) {
+		deletionQueue->queueImage(ts->depthImage, ts->depthAllocation);
+		ts->depthImage = nullptr;
+		ts->depthAllocation = VulkanAllocation{};  // Clear to prevent double-free
 	}
 
 	if (ts->image) {
@@ -1329,6 +1343,38 @@ int VulkanTextureManager::bm_make_render_target(int handle, int* width, int* hei
 		}
 	}
 
+	// Optional depth/stencil attachment. Without it, models rendered into the target
+	// get no z-testing at all: the Vulkan spec ignores the pipeline's depth/stencil
+	// state when the subpass has no depth attachment, so depth-tested geometry draws
+	// in submission order. This mirrors the OpenGL FBO's depth renderbuffer. Cubemap
+	// render targets (env/irradiance maps) never request this.
+	const bool wantDepth = ((flags & BMP_FLAG_RENDER_TARGET_DEPTH_ATTACHMENT) != 0) && !isCubemapRT;
+	vk::Format depthFormat = vk::Format::eUndefined;
+	if (wantDepth) {
+		depthFormat = getRendererInstance()->getDepthFormat();
+		if (depthFormat == vk::Format::eUndefined) {
+			Warning(LOCATION, "Vulkan render target requested a depth attachment before the depth format "
+			                  "was initialized; z-buffering will be unavailable for this target.");
+		} else if (!createImage(w, h, 1, depthFormat, vk::ImageTiling::eOptimal,
+		                        vk::ImageUsageFlagBits::eDepthStencilAttachment, MemoryUsage::GpuOnly,
+		                        ts->depthImage, ts->depthAllocation, 1, false)) {
+			nprintf(("vulkan", "Failed to create render target depth image!\n"));
+			depthFormat = vk::Format::eUndefined;
+		} else {
+			// Array2D view with a single layer matches the color framebuffer attachment.
+			ts->depthImageView = createImageView(ts->depthImage, depthFormat,
+			                                     imageAspectFromFormat(depthFormat), 1, ImageViewType::Array2D);
+			if (!ts->depthImageView) {
+				m_device.destroyImage(ts->depthImage);
+				ts->depthImage = nullptr;
+				m_memoryManager->freeAllocation(ts->depthAllocation);
+				ts->depthAllocation = VulkanAllocation{};
+				depthFormat = vk::Format::eUndefined;
+			}
+		}
+	}
+	const bool hasDepth = (depthFormat != vk::Format::eUndefined) && static_cast<bool>(ts->depthImage);
+
 	// Create render pass for this target
 	vk::AttachmentDescription colorAttachment;
 	colorAttachment.format = format;
@@ -1344,14 +1390,37 @@ int VulkanTextureManager::bm_make_render_target(int handle, int* width, int* hei
 	colorAttachmentRef.attachment = 0;
 	colorAttachmentRef.layout = vk::ImageLayout::eColorAttachmentOptimal;
 
+	// Depth attachment: cleared at every pass begin (loadOp=eClear) so the target
+	// starts with a clean depth buffer regardless of what the caller does; contents
+	// are never sampled afterward (storeOp=eDontCare). Layout stays in
+	// eDepthStencilAttachmentOptimal across frames to avoid per-pass transitions.
+	vk::AttachmentDescription depthAttachment;
+	depthAttachment.format = depthFormat;
+	depthAttachment.samples = vk::SampleCountFlagBits::e1;
+	depthAttachment.loadOp = vk::AttachmentLoadOp::eClear;
+	depthAttachment.storeOp = vk::AttachmentStoreOp::eDontCare;
+	depthAttachment.stencilLoadOp = vk::AttachmentLoadOp::eDontCare;
+	depthAttachment.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
+	depthAttachment.initialLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
+	depthAttachment.finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
+
+	vk::AttachmentReference depthAttachmentRef;
+	depthAttachmentRef.attachment = 1;
+	depthAttachmentRef.layout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
+
+	std::array<vk::AttachmentDescription, 2> attachments = {colorAttachment, depthAttachment};
+
 	vk::SubpassDescription subpass;
 	subpass.pipelineBindPoint = vk::PipelineBindPoint::eGraphics;
 	subpass.colorAttachmentCount = 1;
 	subpass.pColorAttachments = &colorAttachmentRef;
+	if (hasDepth) {
+		subpass.pDepthStencilAttachment = &depthAttachmentRef;
+	}
 
 	vk::RenderPassCreateInfo renderPassInfo;
-	renderPassInfo.attachmentCount = 1;
-	renderPassInfo.pAttachments = &colorAttachment;
+	renderPassInfo.attachmentCount = hasDepth ? 2u : 1u;
+	renderPassInfo.pAttachments = attachments.data();
 	renderPassInfo.subpassCount = 1;
 	renderPassInfo.pSubpasses = &subpass;
 
@@ -1359,6 +1428,14 @@ int VulkanTextureManager::bm_make_render_target(int handle, int* width, int* hei
 		ts->renderPass = m_device.createRenderPass(renderPassInfo);
 	} catch (const vk::SystemError& e) {
 		nprintf(("vulkan", "Failed to create render pass: %s\n", e.what()));
+		if (hasDepth) {
+			m_device.destroyImageView(ts->depthImageView);
+			m_device.destroyImage(ts->depthImage);
+			ts->depthImageView = nullptr;
+			ts->depthImage = nullptr;
+			m_memoryManager->freeAllocation(ts->depthAllocation);
+			ts->depthAllocation = VulkanAllocation{};
+		}
 		m_device.destroyImageView(ts->imageView);
 		m_device.destroyImage(ts->image);
 		ts->image = nullptr;
@@ -1389,12 +1466,15 @@ int VulkanTextureManager::bm_make_render_target(int handle, int* width, int* hei
 		ts->framebuffer = ts->cubeFaceFramebuffers[0];
 	} else {
 		// Create framebuffer
-		// Use framebufferView (single-mip) if available, otherwise imageView
-		vk::ImageView fbAttachment = ts->framebufferView ? ts->framebufferView : ts->imageView;
+		// Use framebufferView (single-mip) if available, otherwise imageView.
+		// The depth view (when present) is attachment 1, matching the render pass.
+		std::array<vk::ImageView, 2> fbAttachments = {
+			ts->framebufferView ? ts->framebufferView : ts->imageView,
+			ts->depthImageView};
 		vk::FramebufferCreateInfo framebufferInfo;
 		framebufferInfo.renderPass = ts->renderPass;
-		framebufferInfo.attachmentCount = 1;
-		framebufferInfo.pAttachments = &fbAttachment;
+		framebufferInfo.attachmentCount = hasDepth ? 2u : 1u;
+		framebufferInfo.pAttachments = fbAttachments.data();
 		framebufferInfo.width = w;
 		framebufferInfo.height = h;
 		framebufferInfo.layers = 1;
@@ -1403,6 +1483,14 @@ int VulkanTextureManager::bm_make_render_target(int handle, int* width, int* hei
 			ts->framebuffer = m_device.createFramebuffer(framebufferInfo);
 		} catch (const vk::SystemError& e) {
 			nprintf(("vulkan", "Failed to create framebuffer: %s\n", e.what()));
+			if (hasDepth) {
+				m_device.destroyImageView(ts->depthImageView);
+				m_device.destroyImage(ts->depthImage);
+				ts->depthImageView = nullptr;
+				ts->depthImage = nullptr;
+				m_memoryManager->freeAllocation(ts->depthAllocation);
+				ts->depthAllocation = VulkanAllocation{};
+			}
 			m_device.destroyRenderPass(ts->renderPass);
 			m_device.destroyImageView(ts->imageView);
 			m_device.destroyImage(ts->image);
@@ -1418,6 +1506,13 @@ int VulkanTextureManager::bm_make_render_target(int handle, int* width, int* hei
 	// if sampled before being rendered into (render pass expects this initial layout)
 	transitionImageLayout(ts->image, format, vk::ImageLayout::eUndefined,
 	                      vk::ImageLayout::eShaderReadOnlyOptimal, mipLevels, arrayLayers);
+
+	// Put the depth image in the layout the render pass expects as its initial layout.
+	// It stays there across frames (finalLayout matches), so no per-pass transition.
+	if (hasDepth) {
+		transitionImageLayout(ts->depthImage, depthFormat, vk::ImageLayout::eUndefined,
+		                      vk::ImageLayout::eDepthStencilAttachmentOptimal, 1, 1);
+	}
 
 	// Update slot info
 	ts->width = w;

--- a/code/graphics/vulkan/VulkanTexture.h
+++ b/code/graphics/vulkan/VulkanTexture.h
@@ -42,6 +42,14 @@ public:
 	vk::RenderPass renderPass;  // Render pass compatible with this target
 	bool isRenderTarget = false;
 
+	// Optional depth/stencil attachment (BMP_FLAG_RENDER_TARGET_DEPTH_ATTACHMENT).
+	// Without this, models drawn into the target get no z-testing: the Vulkan spec
+	// ignores the pipeline's depth/stencil state when the subpass has no depth
+	// attachment, so depth-tested geometry renders in submission order.
+	vk::Image depthImage;
+	vk::ImageView depthImageView;
+	VulkanAllocation depthAllocation;
+
 	// 3D texture support
 	bool is3D = false;
 	uint32_t depth = 1;

--- a/code/graphics/vulkan/VulkanTexture.h
+++ b/code/graphics/vulkan/VulkanTexture.h
@@ -39,7 +39,11 @@ public:
 	// For render targets
 	vk::Framebuffer framebuffer;
 	vk::ImageView framebufferView;  // Single-mip view for framebuffer (when mipLevels > 1)
-	vk::RenderPass renderPass;  // Render pass compatible with this target
+	vk::RenderPass renderPass;  // Render pass compatible with this target (color loadOp=eClear)
+	// Load-variant render pass (color loadOp=eLoad) used to RESUME rendering into this
+	// target after a mid-frame readback (gr.screenToBlob) without wiping already-drawn
+	// content. Only meaningful for non-cubemap targets.
+	vk::RenderPass renderPassLoad;
 	bool isRenderTarget = false;
 
 	// Optional depth/stencil attachment (BMP_FLAG_RENDER_TARGET_DEPTH_ATTACHMENT).
@@ -189,6 +193,13 @@ public:
 	 * @brief Get texture slot data
 	 */
 	tcache_slot_vulkan* getTextureSlot(int handle);
+
+	/**
+	 * @brief Bitmap handle of the render target currently bound via bm_set_render_target,
+	 *        or -1 when rendering to the default framebuffer. Used by gr.screenToBlob so a
+	 *        capture reads the active render target instead of the on-screen framebuffer.
+	 */
+	int getCurrentRenderTarget() const { return m_currentRenderTarget; }
 
 	/**
 	 * @brief Create a static, single-mip, single-layer 2D texture from CPU pixel data

--- a/code/graphics/vulkan/gr_vulkan.cpp
+++ b/code/graphics/vulkan/gr_vulkan.cpp
@@ -346,6 +346,30 @@ SCP_string vulkan_blob_screen()
 {
 	ubyte* pixels = nullptr;
 	uint32_t w, h;
+
+	// If an off-screen render target is bound (e.g. SCPUI generating ship/weapon icons via
+	// gr.setTarget + gr.screenToBlob), capture that target rather than the on-screen frame.
+	// Its color image is R8G8B8A8_UNORM, already in RGBA order with real alpha, so it needs
+	// no BGRA swizzle. Reading the framebuffer here instead would grab whatever is currently
+	// on screen (and force it opaque), which is exactly the icon corruption bug.
+	auto* texManager = getTextureManager();
+	const int rtHandle = texManager ? texManager->getCurrentRenderTarget() : -1;
+	if (rtHandle >= 0) {
+		static bool logged_rt_capture = false;
+		if (!logged_rt_capture) {
+			logged_rt_capture = true;
+			mprintf(("Vulkan: gr.screenToBlob capturing active render target (handle %i) instead of the "
+			         "framebuffer (logged once).\n", rtHandle));
+		}
+		auto* ts = texManager->getTextureSlot(rtHandle);
+		if (ts && renderer_instance->readbackRenderTarget(ts, &pixels, &w, &h)) {
+			SCP_string result = png_b64_bitmap(w, h, false, pixels);
+			vm_free(pixels);
+			return "data:image/png;base64," + result;
+		}
+		return "";
+	}
+
 	if (!renderer_instance->readbackFramebuffer(&pixels, &w, &h)) {
 		return "";
 	}


### PR DESCRIPTION
Render targets did not have a depth/stencil buffer bound, leading to corrupted model rendering. In addition, when SCPUI tries to create icons, the function to read those icons and save them as png always grabbed from the main framebuffer instead of the current render target, leading to further wrongness.