### PR TITLE
Change Tab Orders

### DIFF
--- a/qtfred/ui/AsteroidEditorDialog.ui
+++ b/qtfred/ui/AsteroidEditorDialog.ui
@@ -429,6 +429,32 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>enabled</tabstop>
+  <tabstop>radioButtonActiveField</tabstop>
+  <tabstop>radioButtonPassiveField</tabstop>
+  <tabstop>radioButtonAsteroid</tabstop>
+  <tabstop>radioButtonDebris</tabstop>
+  <tabstop>asteroidSelectButton</tabstop>
+  <tabstop>debrisSelectButton</tabstop>
+  <tabstop>spinBoxNumber</tabstop>
+  <tabstop>lineEditAvgSpeed</tabstop>
+  <tabstop>lineEdit_obox_minX</tabstop>
+  <tabstop>lineEdit_obox_maxX</tabstop>
+  <tabstop>lineEdit_obox_minY</tabstop>
+  <tabstop>lineEdit_obox_maxY</tabstop>
+  <tabstop>lineEdit_obox_minZ</tabstop>
+  <tabstop>lineEdit_obox_maxZ</tabstop>
+  <tabstop>innerBoxEnabled</tabstop>
+  <tabstop>lineEdit_ibox_minX</tabstop>
+  <tabstop>lineEdit_ibox_maxX</tabstop>
+  <tabstop>lineEdit_ibox_minY</tabstop>
+  <tabstop>lineEdit_ibox_maxY</tabstop>
+  <tabstop>lineEdit_ibox_minZ</tabstop>
+  <tabstop>lineEdit_ibox_maxZ</tabstop>
+  <tabstop>shipSelectButton</tabstop>
+  <tabstop>enhancedFieldEnabled</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
  <buttongroups>

--- a/qtfred/ui/BackgroundEditor.ui
+++ b/qtfred/ui/BackgroundEditor.ui
@@ -1134,6 +1134,66 @@
    <header>ui/widgets/IntegerSnapDoubleSpinBox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>backgroundSelectionCombo</tabstop>
+  <tabstop>addButton</tabstop>
+  <tabstop>removeButton</tabstop>
+  <tabstop>importButton</tabstop>
+  <tabstop>swapWithButton</tabstop>
+  <tabstop>swapWithCombo</tabstop>
+  <tabstop>bitmapListWidget</tabstop>
+  <tabstop>addBitmapButton</tabstop>
+  <tabstop>changeBitmapButton</tabstop>
+  <tabstop>deleteBitmapButton</tabstop>
+  <tabstop>bitmapTypeCombo</tabstop>
+  <tabstop>bitmapScaleXDoubleSpinBox</tabstop>
+  <tabstop>bitmapScaleYDoubleSpinBox</tabstop>
+  <tabstop>bitmapDivXSpinBox</tabstop>
+  <tabstop>bitmapDivYSpinBox</tabstop>
+  <tabstop>sunListWidget</tabstop>
+  <tabstop>addSunButton</tabstop>
+  <tabstop>changeSunButton</tabstop>
+  <tabstop>deleteSunButton</tabstop>
+  <tabstop>sunSelectionCombo</tabstop>
+  <tabstop>sunScaleDoubleSpinBox</tabstop>
+  <tabstop>useCorrectAngleFormatCheckBox</tabstop>
+  <tabstop>fullNebulaCheckBox</tabstop>
+  <tabstop>poofsListWidget</tabstop>
+  <tabstop>rangeSpinBox</tabstop>
+  <tabstop>nebulaPatternCombo</tabstop>
+  <tabstop>nebulaLightningCombo</tabstop>
+  <tabstop>shipTrailsCheckBox</tabstop>
+  <tabstop>fog1000mVisDoubleSpinBox</tabstop>
+  <tabstop>fogNearDistanceDoubleSpinBox</tabstop>
+  <tabstop>fogSkyboxClipDoubleSpinBox</tabstop>
+  <tabstop>fogClipDoubleSpinBox</tabstop>
+  <tabstop>displayBgsInNebulaCheckbox</tabstop>
+  <tabstop>overrideFogPaletteCheckBox</tabstop>
+  <tabstop>fogOverrideRedSpinBox</tabstop>
+  <tabstop>fogOverrideGreenSpinBox</tabstop>
+  <tabstop>fogOverrideBlueSpinBox</tabstop>
+  <tabstop>ambientLightRedSlider</tabstop>
+  <tabstop>ambientLightGreenSlider</tabstop>
+  <tabstop>ambientLightBlueSlider</tabstop>
+  <tabstop>skyboxModelButton</tabstop>
+  <tabstop>skyboxEdit</tabstop>
+  <tabstop>noLightingCheckBox</tabstop>
+  <tabstop>transparentCheckBox</tabstop>
+  <tabstop>forceClampCheckBox</tabstop>
+  <tabstop>noZBufferCheckBox</tabstop>
+  <tabstop>noCullCheckBox</tabstop>
+  <tabstop>noGlowMapsCheckBox</tabstop>
+  <tabstop>numStarsSlider</tabstop>
+  <tabstop>subspaceCheckBox</tabstop>
+  <tabstop>envMapButton</tabstop>
+  <tabstop>envMapEdit</tabstop>
+  <tabstop>lightingProfileCombo</tabstop>
+  <tabstop>oldNebulaPatternCombo</tabstop>
+  <tabstop>oldNebulaColorCombo</tabstop>
+  <tabstop>oldNebulaPitchSpinBox</tabstop>
+  <tabstop>oldNebulaBankSpinBox</tabstop>
+  <tabstop>oldNebulaHeadingSpinBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/BriefingEditorDialog.ui
+++ b/qtfred/ui/BriefingEditorDialog.ui
@@ -778,6 +778,48 @@
    <header>ui/widgets/MusicComboWidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>prevStageButton</tabstop>
+  <tabstop>nextStageButton</tabstop>
+  <tabstop>addStageButton</tabstop>
+  <tabstop>deleteStageButton</tabstop>
+  <tabstop>insertStageButton</tabstop>
+  <tabstop>resetCameraButton</tabstop>
+  <tabstop>copyCameraButton</tabstop>
+  <tabstop>pasteCameraButton</tabstop>
+  <tabstop>cameraCoordinatesButton</tabstop>
+  <tabstop>cameraTransitionTimeSpinBox</tabstop>
+  <tabstop>cutToNextStageCheckBox</tabstop>
+  <tabstop>cutToPrevStageCheckBox</tabstop>
+  <tabstop>disableGridCheckBox</tabstop>
+  <tabstop>movementSpeedComboBox</tabstop>
+  <tabstop>rotationSpeedComboBox</tabstop>
+  <tabstop>makeIconButton</tabstop>
+  <tabstop>makeIconFromShipButton</tabstop>
+  <tabstop>iconIdSpinBox</tabstop>
+  <tabstop>iconLabelLineEdit</tabstop>
+  <tabstop>iconCloseupLabelLineEdit</tabstop>
+  <tabstop>iconImageComboBox</tabstop>
+  <tabstop>iconShipTypeComboBox</tabstop>
+  <tabstop>iconTeamComboBox</tabstop>
+  <tabstop>scaleDoubleSpinBox</tabstop>
+  <tabstop>drawLinesCheckBox</tabstop>
+  <tabstop>changeLocallyCheckBox</tabstop>
+  <tabstop>flipIconCheckBox</tabstop>
+  <tabstop>highlightCheckBox</tabstop>
+  <tabstop>useCargoIconCheckBox</tabstop>
+  <tabstop>useWingIconCheckBox</tabstop>
+  <tabstop>iconCoordinatesButton</tabstop>
+  <tabstop>deleteIconButton</tabstop>
+  <tabstop>propagateIconButton</tabstop>
+  <tabstop>formulaTreeView</tabstop>
+  <tabstop>voiceFileLineEdit</tabstop>
+  <tabstop>voiceFileBrowseButton</tabstop>
+  <tabstop>voiceFilePlayButton</tabstop>
+  <tabstop>stageTextPlainTextEdit</tabstop>
+  <tabstop>teamComboBox</tabstop>
+  <tabstop>copyToOtherTeamsButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/CampaignEditorDialog.ui
+++ b/qtfred/ui/CampaignEditorDialog.ui
@@ -609,6 +609,39 @@
    <header>ui/widgets/CampaignMissionGraph.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mainTabs</tabstop>
+  <tabstop>nameLineEdit</tabstop>
+  <tabstop>typeComboBox</tabstop>
+  <tabstop>descriptionPlainTextEdit</tabstop>
+  <tabstop>resetTechAtStartCheckBox</tabstop>
+  <tabstop>campaignCustomDataButton</tabstop>
+  <tabstop>shipsListWidget</tabstop>
+  <tabstop>weaponsListWidget</tabstop>
+  <tabstop>availableMissionsListWidget</tabstop>
+  <tabstop>fredMissionButton</tabstop>
+  <tabstop>missionNameLineEdit</tabstop>
+  <tabstop>missionDescriptionPlainTextEdit</tabstop>
+  <tabstop>briefCutsceneComboBox</tabstop>
+  <tabstop>debriefingPersonaSpinBox</tabstop>
+  <tabstop>mainhallComboBox</tabstop>
+  <tabstop>substituteMainhallComboBox</tabstop>
+  <tabstop>sxtBranches</tabstop>
+  <tabstop>moveBranchTopButton</tabstop>
+  <tabstop>moveBranchUpButton</tabstop>
+  <tabstop>moveBranchDownButton</tabstop>
+  <tabstop>moveBranchBottomButton</tabstop>
+  <tabstop>loopDescriptionPlainTextEdit</tabstop>
+  <tabstop>loopAnimLineEdit</tabstop>
+  <tabstop>loopAnimBrowseButton</tabstop>
+  <tabstop>loopVoiceLineEdit</tabstop>
+  <tabstop>loopVoiceBrowseButton</tabstop>
+  <tabstop>testVoiceButton</tabstop>
+  <tabstop>availableMissionsFilterLineEdit</tabstop>
+  <tabstop>graphView</tabstop>
+  <tabstop>retailFormatCheckbox</tabstop>
+  <tabstop>errorCheckerButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/CommandBriefingDialog.ui
+++ b/qtfred/ui/CommandBriefingDialog.ui
@@ -301,11 +301,10 @@
  </widget>
  <tabstops>
   <tabstop>actionAddStage</tabstop>
-  <tabstop>actionPrevStage</tabstop>
-  <tabstop>actionNextStage</tabstop>
   <tabstop>actionInsertStage</tabstop>
   <tabstop>actionDeleteStage</tabstop>
-  <tabstop>actionCopyToOtherTeams</tabstop>
+  <tabstop>actionPrevStage</tabstop>
+  <tabstop>actionNextStage</tabstop>
   <tabstop>actionBriefingTextEditor</tabstop>
   <tabstop>animationFilename</tabstop>
   <tabstop>actionBrowseAnimation</tabstop>
@@ -316,6 +315,8 @@
   <tabstop>actionLowResolutionBrowse</tabstop>
   <tabstop>actionHighResolutionFilenameEdit</tabstop>
   <tabstop>actionHighResolutionBrowse</tabstop>
+  <tabstop>actionChangeTeams</tabstop>
+  <tabstop>actionCopyToOtherTeams</tabstop>
  </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>

--- a/qtfred/ui/CustomDataDialog.ui
+++ b/qtfred/ui/CustomDataDialog.ui
@@ -168,6 +168,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>keyLineEdit</tabstop>
+  <tabstop>valueLineEdit</tabstop>
+  <tabstop>addButton</tabstop>
+  <tabstop>updateButton</tabstop>
+  <tabstop>removeButton</tabstop>
+  <tabstop>helpTextBrowser</tabstop>
+  <tabstop>stringsTableView</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/DebriefingDialog.ui
+++ b/qtfred/ui/DebriefingDialog.ui
@@ -277,12 +277,18 @@
  </customwidgets>
  <tabstops>
   <tabstop>actionAddStage</tabstop>
-  <tabstop>actionPrevStage</tabstop>
-  <tabstop>actionNextStage</tabstop>
   <tabstop>actionInsertStage</tabstop>
   <tabstop>actionDeleteStage</tabstop>
-  <tabstop>actionCopyToOtherTeams</tabstop>
+  <tabstop>actionPrevStage</tabstop>
+  <tabstop>actionNextStage</tabstop>
+  <tabstop>formulaTreeView</tabstop>
   <tabstop>debriefingTextEdit</tabstop>
+  <tabstop>voiceFileLineEdit</tabstop>
+  <tabstop>voiceFileBrowseButton</tabstop>
+  <tabstop>voiceFilePlayButton</tabstop>
+  <tabstop>recommendationTextEdit</tabstop>
+  <tabstop>actionChangeTeams</tabstop>
+  <tabstop>actionCopyToOtherTeams</tabstop>
  </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>

--- a/qtfred/ui/HelpTopicsDialog.ui
+++ b/qtfred/ui/HelpTopicsDialog.ui
@@ -137,6 +137,15 @@
    <header>ui/dialogs/HelpTopicsDialog.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>navigationTabs</tabstop>
+  <tabstop>findLineEdit</tabstop>
+  <tabstop>findPreviousButton</tabstop>
+  <tabstop>findNextButton</tabstop>
+  <tabstop>backButton</tabstop>
+  <tabstop>forwardButton</tabstop>
+  <tabstop>helpBrowser</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/LayerManagerDialog.ui
+++ b/qtfred/ui/LayerManagerDialog.ui
@@ -161,6 +161,19 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>layerList</tabstop>
+  <tabstop>addLayerButton</tabstop>
+  <tabstop>deleteLayerButton</tabstop>
+  <tabstop>showShipsCheck</tabstop>
+  <tabstop>showPropsCheck</tabstop>
+  <tabstop>showStartsCheck</tabstop>
+  <tabstop>showJumpNodesCheck</tabstop>
+  <tabstop>showWaypointsCheck</tabstop>
+  <tabstop>iffScrollArea</tabstop>
+ </tabstops>
+ <resources/>
  <connections>
   <connection>
    <sender>buttonBox</sender>

--- a/qtfred/ui/MissionCutscenesDialog.ui
+++ b/qtfred/ui/MissionCutscenesDialog.ui
@@ -200,6 +200,14 @@
    <header>ui/widgets/sexp_tree_view.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>newCutsceneBtn</tabstop>
+  <tabstop>cutsceneTypeCombo</tabstop>
+  <tabstop>cutsceneFilename</tabstop>
+  <tabstop>cutsceneEventTree</tabstop>
+  <tabstop>displayTypeCombo</tabstop>
+  <tabstop>helpTextBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/MissionEventsDialog.ui
+++ b/qtfred/ui/MissionEventsDialog.ui
@@ -798,6 +798,55 @@ in Milliseconds</string>
    <header>ui/widgets/sexp_tree_view.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>eventTree</tabstop>
+  <tabstop>btnNewEvent</tabstop>
+  <tabstop>btnInsertEvent</tabstop>
+  <tabstop>btnDeleteEvent</tabstop>
+  <tabstop>eventMoveTopBtn</tabstop>
+  <tabstop>eventUpBtn</tabstop>
+  <tabstop>eventDownBtn</tabstop>
+  <tabstop>eventMoveBottomBtn</tabstop>
+  <tabstop>repeatCountBox</tabstop>
+  <tabstop>triggerCountBox</tabstop>
+  <tabstop>intervalTimeBox</tabstop>
+  <tabstop>chainedCheckBox</tabstop>
+  <tabstop>chainDelayBox</tabstop>
+  <tabstop>useMsecsCheckBox</tabstop>
+  <tabstop>scoreBox</tabstop>
+  <tabstop>teamCombo</tabstop>
+  <tabstop>editDirectiveText</tabstop>
+  <tabstop>editDirectiveKeypressText</tabstop>
+  <tabstop>checkLogTrue</tabstop>
+  <tabstop>checkLogPrevious</tabstop>
+  <tabstop>checkLogFirstRepeat</tabstop>
+  <tabstop>checkLogFirstTrigger</tabstop>
+  <tabstop>checkLogFalse</tabstop>
+  <tabstop>checkLogAlwaysFalse</tabstop>
+  <tabstop>checkLogLastRepeat</tabstop>
+  <tabstop>checkLogLastTrigger</tabstop>
+  <tabstop>messageList</tabstop>
+  <tabstop>msgMoveTopBtn</tabstop>
+  <tabstop>msgUpBtn</tabstop>
+  <tabstop>msgDownBtn</tabstop>
+  <tabstop>msgMoveBottomBtn</tabstop>
+  <tabstop>messageName</tabstop>
+  <tabstop>messageContent</tabstop>
+  <tabstop>btnNewMsg</tabstop>
+  <tabstop>btnInsertMsg</tabstop>
+  <tabstop>btnDeleteMsg</tabstop>
+  <tabstop>btnMsgNote</tabstop>
+  <tabstop>aniCombo</tabstop>
+  <tabstop>btnAniBrowse</tabstop>
+  <tabstop>waveCombo</tabstop>
+  <tabstop>btnBrowseWave</tabstop>
+  <tabstop>btnWavePlay</tabstop>
+  <tabstop>personaCombo</tabstop>
+  <tabstop>btnUpdateStuff</tabstop>
+  <tabstop>messageTeamCombo</tabstop>
+  <tabstop>miniHelpBox</tabstop>
+  <tabstop>helpBox</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/MissionGoalsDialog.ui
+++ b/qtfred/ui/MissionGoalsDialog.ui
@@ -257,6 +257,19 @@
    <header>ui/widgets/sexp_tree_view.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>newObjectiveBtn</tabstop>
+  <tabstop>goalTypeCombo</tabstop>
+  <tabstop>goalName</tabstop>
+  <tabstop>goalDescription</tabstop>
+  <tabstop>goalScore</tabstop>
+  <tabstop>goalTeamCombo</tabstop>
+  <tabstop>objectiveInvalidCheck</tabstop>
+  <tabstop>noCompletionMusicCheck</tabstop>
+  <tabstop>displayTypeCombo</tabstop>
+  <tabstop>goalEventTree</tabstop>
+  <tabstop>helpTextBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/MusicPlayerDialog.ui
+++ b/qtfred/ui/MusicPlayerDialog.ui
@@ -87,6 +87,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>musicList</tabstop>
+  <tabstop>prevButton</tabstop>
+  <tabstop>playButton</tabstop>
+  <tabstop>nextButton</tabstop>
+  <tabstop>stopButton</tabstop>
+  <tabstop>autoplayCheck</tabstop>
+  <tabstop>musicTblButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/ReinforcementsDialog.ui
+++ b/qtfred/ui/ReinforcementsDialog.ui
@@ -376,6 +376,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>possibleShipsList</tabstop>
+  <tabstop>actionAddShip</tabstop>
+  <tabstop>chosenShipsList</tabstop>
+  <tabstop>moveSelectionUp</tabstop>
+  <tabstop>moveSelectionDown</tabstop>
+  <tabstop>useSpinBox</tabstop>
+  <tabstop>delaySpinBox</tabstop>
+  <tabstop>actionRemoveShip</tabstop>
+  <tabstop>poolMultiselectCheckbox</tabstop>
+  <tabstop>chosenMultiselectCheckbox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/ShipEditorDialog.ui
+++ b/qtfred/ui/ShipEditorDialog.ui
@@ -956,6 +956,60 @@
    <header>ui/widgets/PersonaColorComboBox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>prevButton</tabstop>
+  <tabstop>nextButton</tabstop>
+  <tabstop>shipNameEdit</tabstop>
+  <tabstop>shipDisplayNameEdit</tabstop>
+  <tabstop>shipClassCombo</tabstop>
+  <tabstop>callsignCombo</tabstop>
+  <tabstop>altNameCombo</tabstop>
+  <tabstop>AIClassCombo</tabstop>
+  <tabstop>teamCombo</tabstop>
+  <tabstop>cargoCombo</tabstop>
+  <tabstop>cargoTitleEdit</tabstop>
+  <tabstop>hotkeyCombo</tabstop>
+  <tabstop>personaCombo</tabstop>
+  <tabstop>killScoreEdit</tabstop>
+  <tabstop>assistEdit</tabstop>
+  <tabstop>respawnSpinBox</tabstop>
+  <tabstop>playerShipCheckBox</tabstop>
+  <tabstop>playerShipButton</tabstop>
+  <tabstop>altShipClassButton</tabstop>
+  <tabstop>textureReplacementButton</tabstop>
+  <tabstop>layerCombo</tabstop>
+  <tabstop>deleteButton</tabstop>
+  <tabstop>resetButton</tabstop>
+  <tabstop>weaponsButton</tabstop>
+  <tabstop>playerOrdersButton</tabstop>
+  <tabstop>specialStatsButton</tabstop>
+  <tabstop>miscButton</tabstop>
+  <tabstop>initialStatusButton</tabstop>
+  <tabstop>initialOrdersButton</tabstop>
+  <tabstop>tblInfoButton</tabstop>
+  <tabstop>hideCuesButton</tabstop>
+  <tabstop>arrivalLocationCombo</tabstop>
+  <tabstop>arrivalTargetCombo</tabstop>
+  <tabstop>arrivalDistanceEdit</tabstop>
+  <tabstop>arrivalDelaySpinBox</tabstop>
+  <tabstop>restrictArrivalPathsButton</tabstop>
+  <tabstop>customWarpinButton</tabstop>
+  <tabstop>updateArrivalCueCheckBox</tabstop>
+  <tabstop>arrivalTree</tabstop>
+  <tabstop>noArrivalWarpCheckBox</tabstop>
+  <tabstop>dockWarpinCheckBox</tabstop>
+  <tabstop>departureLocationCombo</tabstop>
+  <tabstop>departureTargetCombo</tabstop>
+  <tabstop>departureDelaySpinBox</tabstop>
+  <tabstop>restrictDeparturePathsButton</tabstop>
+  <tabstop>customWarpoutButton</tabstop>
+  <tabstop>updateDepartureCueCheckBox</tabstop>
+  <tabstop>departureTree</tabstop>
+  <tabstop>noDepartureWarpCheckBox</tabstop>
+  <tabstop>dockWarpoutCheckBox</tabstop>
+  <tabstop>HelpTitle</tabstop>
+  <tabstop>helpText</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/ShipInitialStatus.ui
+++ b/qtfred/ui/ShipInitialStatus.ui
@@ -458,6 +458,31 @@
    <header>ui/widgets/ShipFlagCheckbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>velocitySpinBox</tabstop>
+  <tabstop>hullSpinBox</tabstop>
+  <tabstop>guardianSpinBox</tabstop>
+  <tabstop>hasShieldCheckBox</tabstop>
+  <tabstop>forceShieldsCheckBox</tabstop>
+  <tabstop>shieldHullSpinBox</tabstop>
+  <tabstop>shipLockCheckBox</tabstop>
+  <tabstop>weaponLockCheckBox</tabstop>
+  <tabstop>primaryLockCheckBox</tabstop>
+  <tabstop>secondaryLockCheckBox</tabstop>
+  <tabstop>turretLockCheckBox</tabstop>
+  <tabstop>afterburnerLockCheckBox</tabstop>
+  <tabstop>dockpointList</tabstop>
+  <tabstop>dockeeComboBox</tabstop>
+  <tabstop>dockeePointComboBox</tabstop>
+  <tabstop>moveShipsCheckBox</tabstop>
+  <tabstop>subsystemList</tabstop>
+  <tabstop>subIntegritySpinBox</tabstop>
+  <tabstop>cargoEdit</tabstop>
+  <tabstop>cargoTitleEdit</tabstop>
+  <tabstop>colourComboBox</tabstop>
+  <tabstop>okPushButton</tabstop>
+  <tabstop>cancelPushButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/ShipWeaponsDialog.ui
+++ b/qtfred/ui/ShipWeaponsDialog.ui
@@ -315,6 +315,21 @@
    <header>ui/widgets/bankTree.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>primaryListWeapons</tabstop>
+  <tabstop>primarySetAllButton</tabstop>
+  <tabstop>primaryTreeBanks</tabstop>
+  <tabstop>primaryAiCombo</tabstop>
+  <tabstop>primaryAiButton</tabstop>
+  <tabstop>primaryTblButton</tabstop>
+  <tabstop>secondaryListWeapons</tabstop>
+  <tabstop>secondarySetAllButton</tabstop>
+  <tabstop>secondaryTreeBanks</tabstop>
+  <tabstop>secondaryAiCombo</tabstop>
+  <tabstop>secondaryAiButton</tabstop>
+  <tabstop>secondaryTblButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/TeamLoadoutDialog.ui
+++ b/qtfred/ui/TeamLoadoutDialog.ui
@@ -669,6 +669,32 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>currentTeamComboBox</tabstop>
+  <tabstop>weaponValidationCheckbox</tabstop>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>shipsFilterLineEdit</tabstop>
+  <tabstop>clearShipsListButton</tabstop>
+  <tabstop>selectAllShipsListButton</tabstop>
+  <tabstop>shipsMultiSelectCheckBox</tabstop>
+  <tabstop>weaponsFilterLineEdit</tabstop>
+  <tabstop>clearWeaponsListButton</tabstop>
+  <tabstop>selectAllWeaponsListButton</tabstop>
+  <tabstop>weaponsMultiSelectCheckBox</tabstop>
+  <tabstop>shipsList</tabstop>
+  <tabstop>weaponsList</tabstop>
+  <tabstop>shipsVarFilterLineEdit</tabstop>
+  <tabstop>clearShipsVarListButton</tabstop>
+  <tabstop>selectAllShipsVarListButton</tabstop>
+  <tabstop>shipsVarMultiSelectCheckBox</tabstop>
+  <tabstop>weaponsVarFilterLineEdit</tabstop>
+  <tabstop>clearWeaponsVarListButton</tabstop>
+  <tabstop>selectAllWeaponsVarListButton</tabstop>
+  <tabstop>weaponsVarMultiSelectCheckBox</tabstop>
+  <tabstop>shipVarsList</tabstop>
+  <tabstop>weaponVarsList</tabstop>
+  <tabstop>copyLoadoutToOtherTeamsButton</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>

--- a/qtfred/ui/VoiceActingManager.ui
+++ b/qtfred/ui/VoiceActingManager.ui
@@ -410,6 +410,33 @@ with that persona</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>abbrevCampaignLineEdit</tabstop>
+  <tabstop>abbrevMissionLineEdit</tabstop>
+  <tabstop>abbrevCommandBriefingLineEdit</tabstop>
+  <tabstop>abbrevBriefingLineEdit</tabstop>
+  <tabstop>abbrevDebriefingLineEdit</tabstop>
+  <tabstop>abbrevMessageLineEdit</tabstop>
+  <tabstop>suffixComboBox</tabstop>
+  <tabstop>exampleFilenameLabel</tabstop>
+  <tabstop>includeSenderCheckBox</tabstop>
+  <tabstop>noReplaceCheckBox</tabstop>
+  <tabstop>generateFilenamesButton</tabstop>
+  <tabstop>scriptEntryFormatPlainTextEdit</tabstop>
+  <tabstop>personaSyncComboBox</tabstop>
+  <tabstop>copyMsgToShipsButton</tabstop>
+  <tabstop>copyShipsToMsgsButton</tabstop>
+  <tabstop>clearNonSendersButton</tabstop>
+  <tabstop>setHeadAnisButton</tabstop>
+  <tabstop>checkAnyWingmanButton</tabstop>
+  <tabstop>exportAllRadio</tabstop>
+  <tabstop>exportCmdBriefingRadio</tabstop>
+  <tabstop>exportBriefingRadio</tabstop>
+  <tabstop>exportDebriefingRadio</tabstop>
+  <tabstop>exportMessageRadio</tabstop>
+  <tabstop>groupMessagesCheckBox</tabstop>
+  <tabstop>generateScriptButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
  <buttongroups>

--- a/qtfred/ui/VolumetricNebulaDialog.ui
+++ b/qtfred/ui/VolumetricNebulaDialog.ui
@@ -722,6 +722,39 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>enabled</tabstop>
+  <tabstop>setModelButton</tabstop>
+  <tabstop>setModelLineEdit</tabstop>
+  <tabstop>positionXSpinBox</tabstop>
+  <tabstop>positionYSpinBox</tabstop>
+  <tabstop>positionZSpinBox</tabstop>
+  <tabstop>colorRSpinBox</tabstop>
+  <tabstop>colorGSpinBox</tabstop>
+  <tabstop>colorBSpinBox</tabstop>
+  <tabstop>opacityDoubleSpinBox</tabstop>
+  <tabstop>opacityDistanceDoubleSpinBox</tabstop>
+  <tabstop>renderQualityStepsSpinBox</tabstop>
+  <tabstop>resolutionSpinBox</tabstop>
+  <tabstop>oversamplingSpinBox</tabstop>
+  <tabstop>smoothingDoubleSpinBox</tabstop>
+  <tabstop>henyeyGreensteinCoeffDoubleSpinBox</tabstop>
+  <tabstop>sunFalloffFactorDoubleSpinBox</tabstop>
+  <tabstop>sunQualityStepsSpinBox</tabstop>
+  <tabstop>emissiveLightDoubleSpinBox</tabstop>
+  <tabstop>emissiveLightIntensityDoubleSpinBox</tabstop>
+  <tabstop>emissiveLightFalloffDoubleSpinBox</tabstop>
+  <tabstop>enableNoiseCheckBox</tabstop>
+  <tabstop>noiseColorRSpinBox</tabstop>
+  <tabstop>noiseColorGSpinBox</tabstop>
+  <tabstop>noiseColorBSpinBox</tabstop>
+  <tabstop>noiseScaleBaseDoubleSpinBox</tabstop>
+  <tabstop>noiseScaleSubDoubleSpinBox</tabstop>
+  <tabstop>noiseIntensityDoubleSpinBox</tabstop>
+  <tabstop>noiseResolutionSpinBox</tabstop>
+  <tabstop>setBaseNoiseFunctionButton</tabstop>
+  <tabstop>setSubNoiseFunctionButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/WaypointPathGeneratorDialog.ui
+++ b/qtfred/ui/WaypointPathGeneratorDialog.ui
@@ -356,6 +356,23 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>pathNameLineEdit</tabstop>
+  <tabstop>manualCenterRadio</tabstop>
+  <tabstop>centerXSpinBox</tabstop>
+  <tabstop>centerYSpinBox</tabstop>
+  <tabstop>centerZSpinBox</tabstop>
+  <tabstop>objectCenterRadio</tabstop>
+  <tabstop>centerObjectCombo</tabstop>
+  <tabstop>axisComboBox</tabstop>
+  <tabstop>numPointsSpinBox</tabstop>
+  <tabstop>loopsSpinBox</tabstop>
+  <tabstop>radiusSpinBox</tabstop>
+  <tabstop>driftSpinBox</tabstop>
+  <tabstop>varianceXSpinBox</tabstop>
+  <tabstop>varianceYSpinBox</tabstop>
+  <tabstop>varianceZSpinBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qtfred/ui/WingEditorDialog.ui
+++ b/qtfred/ui/WingEditorDialog.ui
@@ -913,6 +913,46 @@
    <header>ui/widgets/sexp_tree_view.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>prevWingButton</tabstop>
+  <tabstop>nextWingButton</tabstop>
+  <tabstop>wingNameEdit</tabstop>
+  <tabstop>wingDisplayNameEdit</tabstop>
+  <tabstop>wingLeaderCombo</tabstop>
+  <tabstop>numWavesSpinBox</tabstop>
+  <tabstop>waveThresholdSpinBox</tabstop>
+  <tabstop>hotkeyCombo</tabstop>
+  <tabstop>formationCombo</tabstop>
+  <tabstop>formationScaleSpinBox</tabstop>
+  <tabstop>alignFormationButton</tabstop>
+  <tabstop>setSquadLogoButton</tabstop>
+  <tabstop>deleteWingButton</tabstop>
+  <tabstop>disbandWingButton</tabstop>
+  <tabstop>initialOrdersButton</tabstop>
+  <tabstop>wingFlagsButton</tabstop>
+  <tabstop>hideCuesButton</tabstop>
+  <tabstop>arrivalLocationCombo</tabstop>
+  <tabstop>arrivalTargetCombo</tabstop>
+  <tabstop>arrivalDistanceSpinBox</tabstop>
+  <tabstop>arrivalDelaySpinBox</tabstop>
+  <tabstop>minDelaySpinBox</tabstop>
+  <tabstop>maxDelaySpinBox</tabstop>
+  <tabstop>restrictArrivalPathsButton</tabstop>
+  <tabstop>customWarpinButton</tabstop>
+  <tabstop>arrivalTree</tabstop>
+  <tabstop>noArrivalWarpCheckBox</tabstop>
+  <tabstop>noArrivalWarpAdjustCheckbox</tabstop>
+  <tabstop>departureLocationCombo</tabstop>
+  <tabstop>departureTargetCombo</tabstop>
+  <tabstop>departureDelaySpinBox</tabstop>
+  <tabstop>restrictDeparturePathsButton</tabstop>
+  <tabstop>customWarpoutButton</tabstop>
+  <tabstop>departureTree</tabstop>
+  <tabstop>noDepartureWarpCheckBox</tabstop>
+  <tabstop>noDepartureWarpAdjustCheckbox</tabstop>
+  <tabstop>HelpTitle</tabstop>
+  <tabstop>helpText</tabstop>
+ </tabstops>
  <resources>
   <include location="../resources/resources.qrc"/>
  </resources>


### PR DESCRIPTION
Quick audit of tab orders to improve usability.  

Behavior in the Messages portion of the Events editor should allow users to hit tab after filling out a new message and getting back to the New Message button.

Most other dialogs work as expected.  Copy to teams controls are always last.