### PR TITLE
QtFRED align object dialog initialization

### DIFF
--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.cpp
@@ -8,6 +8,8 @@
 #include <model/model.h>
 #include <ship/ship.h>
 
+#include <QTimer>
+
 namespace fso::fred::dialogs {
 
 JumpNodeEditorDialogModel::JumpNodeEditorDialogModel(QObject* parent, EditorViewport* viewport)
@@ -445,16 +447,29 @@ void JumpNodeEditorDialogModel::selectPreviousNode() {
 	selectNodeFromObjectList(GET_PREV(&Objects[_selectedJumpNodes.front()]), false);
 }
 
+void JumpNodeEditorDialogModel::scheduleInitializeData() {
+	// Bulk selection changes fire one signal per object, so coalesce
+	// the burst into a single refresh once the event loop settles.
+	if (_initPending) {
+		return;
+	}
+	_initPending = true;
+	QTimer::singleShot(0, this, [this] {
+		_initPending = false;
+		initializeData();
+	});
+}
+
 void JumpNodeEditorDialogModel::onSelectedObjectChanged(int) {
-	initializeData();
+	scheduleInitializeData();
 }
 
 void JumpNodeEditorDialogModel::onSelectedObjectMarkingChanged(int, bool) {
-	initializeData();
+	scheduleInitializeData();
 }
 
 void JumpNodeEditorDialogModel::onMissionChanged() {
-	initializeData();
+	scheduleInitializeData();
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/JumpNodeEditorDialogModel.h
@@ -57,6 +57,7 @@ private slots:
 
 private: // NOLINT(readability-redundant-access-specifiers)
 	void initializeData();
+	void scheduleInitializeData();
 	void showErrorDialogNoCancel(const SCP_string& message);
 	bool validateName(const SCP_string& name);
 	void selectNodeFromObjectList(object* start, bool forward);
@@ -73,6 +74,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	bool _hiddenMixed = false;
 
 	bool _bypass_errors = false;
+	bool _initPending = false;
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/PropEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/PropEditorDialogModel.cpp
@@ -4,6 +4,8 @@
 #include <mission/object.h>
 #include <prop/prop.h>
 
+#include <QTimer>
+
 #include <unordered_set>
 
 namespace fso::fred::dialogs {
@@ -312,16 +314,29 @@ void PropEditorDialogModel::selectPreviousProp() {
 	selectPropFromObjectList(GET_PREV(&Objects[_selectedPropObjects.front()]), false);
 }
 
+void PropEditorDialogModel::scheduleInitializeData() {
+	// Bulk selection changes fire one signal per object, so coalesce
+	// the burst into a single refresh once the event loop settles.
+	if (_initPending) {
+		return;
+	}
+	_initPending = true;
+	QTimer::singleShot(0, this, [this] {
+		_initPending = false;
+		initializeData();
+	});
+}
+
 void PropEditorDialogModel::onSelectedObjectChanged(int) {
-	initializeData();
+	scheduleInitializeData();
 }
 
 void PropEditorDialogModel::onSelectedObjectMarkingChanged(int, bool) {
-	initializeData();
+	scheduleInitializeData();
 }
 
 void PropEditorDialogModel::onMissionChanged() {
-	initializeData();
+	scheduleInitializeData();
 }
 
 SCP_vector<std::pair<SCP_string, SCP_string>> PropEditorDialogModel::getPropFlagDescriptions()

--- a/qtfred/src/mission/dialogs/PropEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/PropEditorDialogModel.h
@@ -41,6 +41,7 @@ class PropEditorDialogModel : public AbstractDialogModel {
 
  private: // NOLINT(readability-redundant-access-specifiers)
 	void initializeData();
+	void scheduleInitializeData();
 	void showErrorDialogNoCancel(const SCP_string& message);
 	void selectPropFromObjectList(object* start, bool forward);
 	void selectFirstPropInMission();
@@ -53,6 +54,7 @@ class PropEditorDialogModel : public AbstractDialogModel {
 	SCP_vector<int> _flagState;
 	SCP_vector<int> _selectedPropObjects;
 	bool _bypass_errors = false;
+	bool _initPending = false;
 };
 
 }

--- a/qtfred/src/mission/dialogs/SceneBrowserModel.cpp
+++ b/qtfred/src/mission/dialogs/SceneBrowserModel.cpp
@@ -307,16 +307,30 @@ void SceneBrowserModel::setNameFilter(const QString& filter)
 // Signal handlers
 // ---------------------------------------------------------------------------
 
+void SceneBrowserModel::scheduleSelectionSync()
+{
+	// Bulk selection changes fire one signal per object, so coalesce
+	// the burst into a single refresh once the event loop settles.
+	if (_syncPending) {
+		return;
+	}
+	_syncPending = true;
+	QTimer::singleShot(0, this, [this] {
+		_syncPending = false;
+		modelChanged();
+	});
+}
+
 void SceneBrowserModel::onCurrentObjectChanged(int /*newObj*/)
 {
 	if (_updatingFromBrowser) return;
-	modelChanged();
+	scheduleSelectionSync();
 }
 
 void SceneBrowserModel::onObjectMarkingChanged(int /*obj*/, bool /*marked*/)
 {
 	if (_updatingFromBrowser) return;
-	modelChanged();
+	scheduleSelectionSync();
 }
 
 void SceneBrowserModel::onLayerVisibilityChanged()

--- a/qtfred/src/mission/dialogs/SceneBrowserModel.h
+++ b/qtfred/src/mission/dialogs/SceneBrowserModel.h
@@ -86,11 +86,13 @@ signals:
 
 private:
 	void buildTree();
+	void scheduleSelectionSync();
 
 	QVector<BrowserLayer> _tree;
 	QString _nameFilter;
 	QVector<bool> _filterIff;
 	bool _updatingFromBrowser = false;
+	bool _syncPending = false;
 	QTimer* _rebuildTimer = nullptr;
 
 	Q_SLOT void onCurrentObjectChanged(int newObj);

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.cpp
@@ -27,7 +27,37 @@ namespace fso::fred::dialogs {
 ShipEditorDialogModel::ShipEditorDialogModel(QObject* parent, EditorViewport* viewport)
 	: AbstractDialogModel(parent, viewport)
 {
+	connect(viewport->editor, &Editor::currentObjectChanged, this, &ShipEditorDialogModel::onSelectedObjectChanged);
+	connect(viewport->editor,
+		&Editor::objectMarkingChanged,
+		this,
+		&ShipEditorDialogModel::onSelectedObjectMarkingChanged);
+
 	initializeData();
+}
+
+void ShipEditorDialogModel::scheduleInitializeData()
+{
+	// Bulk selection changes fire one signal per object, so coalesce
+	// the burst into a single refresh once the event loop settles.
+	if (_initPending) {
+		return;
+	}
+	_initPending = true;
+	QTimer::singleShot(0, this, [this] {
+		_initPending = false;
+		initializeData();
+	});
+}
+
+void ShipEditorDialogModel::onSelectedObjectChanged(int)
+{
+	scheduleInitializeData();
+}
+
+void ShipEditorDialogModel::onSelectedObjectMarkingChanged(int, bool)
+{
+	scheduleInitializeData();
 }
 
 
@@ -546,7 +576,7 @@ void ShipEditorDialogModel::initializeData()
 		}
 	}
 
-	modelChanged();
+	Q_EMIT shipMarkingChanged();
 	_modified = false;
 }
 

--- a/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/ShipEditor/ShipEditorDialogModel.h
@@ -149,8 +149,18 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 
 	void initializeData();
 
+  signals:
+	// Emitted after the model has re-synced from the current selection; the view
+	// should do a full (overwrite) refresh in response.
+	void shipMarkingChanged();
+
+  private slots:
+	void onSelectedObjectChanged(int);
+	void onSelectedObjectMarkingChanged(int, bool);
+
   private: // NOLINT(readability-redundant-access-specifiers)
 	void setModified();
+	void scheduleInitializeData();
 	void shipAltNameClose(int baseShip);
 	void shipCallsignClose(int baseShip);
 	static int makeShipList(int* arr);
@@ -203,6 +213,7 @@ class ShipEditorDialogModel : public AbstractDialogModel {
 	int _respawnPriority;
 	SCP_vector<std::pair<SCP_string, bool>> _arrivalPaths;
 	SCP_vector<std::pair<SCP_string, bool>> _departurePaths;
+	bool _initPending = false;
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WaypointEditorDialogModel.cpp
@@ -5,6 +5,8 @@
 #include <unordered_set>
 #include "mission/dialogs/WaypointEditorDialogModel.h"
 
+#include <QTimer>
+
 namespace fso::fred::dialogs {
 
 namespace {
@@ -425,19 +427,32 @@ void WaypointEditorDialogModel::selectPreviousPath() {
 	selectWaypointPathByIndex(prev);
 }
 
+void WaypointEditorDialogModel::scheduleInitializeData() {
+	// Bulk selection changes fire one signal per object, so coalesce
+	// the burst into a single refresh once the event loop settles.tles.
+	if (_initPending) {
+		return;
+	}
+	_initPending = true;
+	QTimer::singleShot(0, this, [this] {
+		_initPending = false;
+		initializeData();
+	});
+}
+
 void WaypointEditorDialogModel::onSelectedObjectChanged(int) {
 	if (_suppressRefresh) return;
-	initializeData();
+	scheduleInitializeData();
 }
 
 void WaypointEditorDialogModel::onSelectedObjectMarkingChanged(int, bool) {
 	if (_suppressRefresh) return;
-	initializeData();
+	scheduleInitializeData();
 }
 
 void WaypointEditorDialogModel::onMissionChanged() {
 	if (_suppressRefresh) return;
-	initializeData();
+	scheduleInitializeData();
 }
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/WaypointEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/WaypointEditorDialogModel.h
@@ -58,6 +58,7 @@ private slots:
 
 private: // NOLINT(readability-redundant-access-specifiers)
 	void initializeData();
+	void scheduleInitializeData();
 	void showErrorDialogNoCancel(const SCP_string& message);
 	bool validateName(const SCP_string& name);
 
@@ -75,6 +76,7 @@ private: // NOLINT(readability-redundant-access-specifiers)
 	// Guards against re-entry into initializeData() from selection/marking/mission signals
 	// while we're already mutating mission state (e.g., setLayer fans out unmarks).
 	bool _suppressRefresh = false;
+	bool _initPending = false;
 };
 
 } // namespace fso::fred::dialogs

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.cpp
@@ -8,6 +8,7 @@
 #include "missioneditor/common.h"
 #include <QObject>
 #include <QMessageBox>
+#include <QTimer>
 
 namespace fso::fred::dialogs {
 WingEditorDialogModel::WingEditorDialogModel(QObject* parent, EditorViewport* viewport)
@@ -25,14 +26,28 @@ void WingEditorDialogModel::initializeData()
 	_modified = false;
 }
 
+void WingEditorDialogModel::scheduleReloadFromCurWing()
+{
+	// Bulk selection changes fire one signal per object, so coalesce
+	// the burst into a single refresh once the event loop settles.
+	if (_reloadPending) {
+		return;
+	}
+	_reloadPending = true;
+	QTimer::singleShot(0, this, [this] {
+		_reloadPending = false;
+		reloadFromCurWing();
+	});
+}
+
 void WingEditorDialogModel::onEditorSelectionChanged(int)
 {
-	reloadFromCurWing();
+	scheduleReloadFromCurWing();
 }
 
 void WingEditorDialogModel::onEditorMissionChanged()
 {
-	reloadFromCurWing();
+	scheduleReloadFromCurWing();
 }
 
 void WingEditorDialogModel::reloadFromCurWing()

--- a/qtfred/src/mission/dialogs/WingEditorDialogModel.h
+++ b/qtfred/src/mission/dialogs/WingEditorDialogModel.h
@@ -134,12 +134,14 @@ class WingEditorDialogModel : public AbstractDialogModel {
   private: // NOLINT(readability-redundant-access-specifiers)
 	void initializeData();
 	void reloadFromCurWing();
+	void scheduleReloadFromCurWing();
 	wing* getCurrentWing() const;
 	static SCP_vector<std::pair<SCP_string, bool>> getDockBayPathsForWingMask(uint32_t mask, int anchorShipnum);
 	void prepareSquadLogoList();
 
 	int _currentWingIndex = -1;
 	SCP_string _currentWingName;
+	bool _reloadPending = false;
 
 	SCP_vector<SCP_string> _squadLogoList;
 };

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.cpp
@@ -12,7 +12,6 @@
 #include <ui/util/SignalBlockers.h>
 #include <ui/util/menu.h>
 
-#include <QCloseEvent>
 #include <ui/dialogs/General/CheckBoxListDialog.h>
 #include <QVariant>
 
@@ -34,9 +33,14 @@ ShipEditorDialog::ShipEditorDialog(FredView* parent, EditorViewport* viewport)
 	ui->callsignCombo->lineEdit()->setMaxLength(CALLSIGN_LEN);
 	ui->cargoTitleEdit->setMaxLength(NAME_LENGTH - 1);
 
-	connect(_model.get(), &AbstractDialogModel::modelChanged, this, [this] { updateUi(false); });
-	connect(viewport->editor, &Editor::currentObjectChanged, this, &ShipEditorDialog::update);
-	connect(viewport->editor, &Editor::objectMarkingChanged, this, &ShipEditorDialog::update);
+	initializeUi();
+	updateUi();
+
+	connect(_model.get(), &AbstractDialogModel::modelChanged, this, [this] { initializeUi(); });
+	connect(_model.get(), &ShipEditorDialogModel::shipMarkingChanged, this, [this] {
+		initializeUi();
+		updateUi();
+	});
 
 	connect(ui->arrivalTree, &sexp_tree_view::modified, this, &ShipEditorDialog::on_arrivalTree_modified);
 	connect(ui->arrivalTree, &sexp_tree_view::helpChanged, this, &ShipEditorDialog::on_arrivalTree_helpChanged);
@@ -74,8 +78,6 @@ ShipEditorDialog::ShipEditorDialog(FredView* parent, EditorViewport* viewport)
 		},
 		tr("&Select Ship"));
 
-	updateUi(true);
-
 	// Resize the dialog to the minimum size
 	resize(QDialog::sizeHint());
 }
@@ -95,22 +97,6 @@ int ShipEditorDialog::getSingleShip() const
 bool ShipEditorDialog::getIfMultipleShips() const
 {
 	return _model->getIfMultipleShips();
-}
-
-void ShipEditorDialog::closeEvent(QCloseEvent* e)
-{
-	QDialog::closeEvent(e);
-}
-
-void ShipEditorDialog::hideEvent(QHideEvent* e)
-{
-	QDialog::hideEvent(e);
-}
-void ShipEditorDialog::showEvent(QShowEvent* e)
-{
-	_model->initializeData();
-	updateUi(true);
-	QDialog::showEvent(e);
 }
 
 void ShipEditorDialog::on_miscButton_clicked()
@@ -143,125 +129,24 @@ void ShipEditorDialog::on_tblInfoButton_clicked()
 	dialog->show();
 }
 
-void ShipEditorDialog::update()
-{
-	if (this->isVisible()) {
-		_model->initializeData();
-		updateUi(true);
-	}
-}
-
-void ShipEditorDialog::updateUi(bool overwrite)
+// Syncs selection-dependent structure: enabled states, window title, and the combos
+// whose contents depend on current mission state. Safe to run mid-edit — does not
+// overwrite user-editable values or reload the sexp trees.
+void ShipEditorDialog::initializeUi()
 {
 	util::SignalBlockers blockers(this);
+
 	enableDisable();
-	updateColumnOne(overwrite);
-	updateColumnTwo(overwrite);
-	updateArrival(overwrite);
-	updateDeparture(overwrite);
-}
-void ShipEditorDialog::updateColumnOne(bool overwrite)
-{
-	util::SignalBlockers blockers(this);
-	int idx;
-	if (overwrite) {
-		ui->shipNameEdit->setText(_model->getShipName().c_str());
-		ui->shipDisplayNameEdit->setText(_model->getShipDisplayName().c_str());
-		idx = _model->getShipClass();
-		ui->shipClassCombo->clear();
-		for (size_t i = 0; i < Ship_info.size(); i++) {
-			ui->shipClassCombo->addItem(Ship_info[i].name, QVariant(static_cast<int>(i)));
-		}
-		ui->shipClassCombo->setCurrentIndex(ui->shipClassCombo->findData(idx));
 
-		auto ai = _model->getAIClass();
-		ui->AIClassCombo->clear();
-		for (auto j = 0; j < Num_ai_classes; j++) {
-			ui->AIClassCombo->addItem(Ai_class_names[j], QVariant(j));
-		}
-		ui->AIClassCombo->setCurrentIndex(ui->AIClassCombo->findData(ai));
-	}
 	if (_model->getNumSelectedPlayers()) {
-		if (_model->getTeam() != -1) {
-			ui->teamCombo->setEnabled(true);
-		} else {
-			ui->teamCombo->setEnabled(false);
-		}
-		if (overwrite) {
-			ui->teamCombo->clear();
-			for (auto i = 0; i < MAX_TVT_TEAMS; i++) {
-				ui->teamCombo->addItem(Iff_info[i].iff_name, QVariant(static_cast<int>(i)));
-			}
-		}
+		ui->teamCombo->setEnabled(_model->getTeam() != -1);
 	} else {
 		ui->teamCombo->setEnabled(_model->getUIEnable());
-		if (overwrite) {
-			idx = _model->getTeam();
-			ui->teamCombo->clear();
-			for (size_t i = 0; i < Iff_info.size(); i++) {
-				ui->teamCombo->addItem(Iff_info[i].iff_name, QVariant(static_cast<int>(i)));
-			}
-			ui->teamCombo->setCurrentIndex(ui->teamCombo->findData(idx));
-		}
 	}
-	if (overwrite) {
-		auto cargo = _model->getCargo();
-		ui->cargoCombo->clear();
-		int j;
-		for (j = 0; j < Num_cargo; j++) {
-			ui->cargoCombo->addItem(Cargo_names[j]);
-		}
-		if (ui->cargoCombo->findText(QString(cargo.c_str()))) {
-			ui->cargoCombo->setCurrentIndex(ui->cargoCombo->findText(QString(cargo.c_str())));
-		} else {
-			ui->cargoCombo->addItem(cargo.c_str());
 
-			ui->cargoCombo->setCurrentIndex(ui->cargoCombo->findText(QString(cargo.c_str())));
-		}
-		ui->cargoTitleEdit->setText(_model->getCargoTitle().c_str());
-	}
 	if (_model->getNumSelectedObjects()) {
-		if (_model->getIfMultipleShips()) {
-			ui->altNameCombo->setEnabled(false);
-		} else {
-			auto altname = _model->getAltName();
-			ui->altNameCombo->setEnabled(true);
-			if (overwrite) {
-				ui->altNameCombo->clear();
-				ui->altNameCombo->addItem("<none>");
-				for (auto j = 0; j < Mission_alt_type_count; j++) {
-					ui->altNameCombo->addItem(Mission_alt_types[j]);
-				}
-				int altNameIdx = ui->altNameCombo->findText(QString(altname.c_str()));
-				if (altNameIdx >= 0) {
-					ui->altNameCombo->setCurrentIndex(altNameIdx);
-				} else {
-					ui->altNameCombo->setEditText("<none>");
-				}
-			}
-		}
-	}
-	if (_model->getNumSelectedObjects()) {
-		if (_model->getIfMultipleShips()) {
-			ui->callsignCombo->setEnabled(false);
-		} else {
-			auto callsign = _model->getCallsign();
-			ui->callsignCombo->setEnabled(true);
-			if (overwrite) {
-				ui->callsignCombo->clear();
-				ui->callsignCombo->addItem("<none>");
-				for (auto j = 0; j < Mission_callsign_count; j++) {
-					SCP_string current = Mission_callsigns[j];
-					ui->callsignCombo->addItem(Mission_callsigns[j], current.c_str());
-				}
-				int callsignIdx = ui->callsignCombo->findText(QString(callsign.c_str()));
-				if (callsignIdx >= 0) {
-					ui->callsignCombo->setCurrentIndex(callsignIdx);
-				} else {
-					ui->callsignCombo->setEditText("<none>");
-				}
-			}
-		}
+		ui->altNameCombo->setEnabled(!_model->getIfMultipleShips());
+		ui->callsignCombo->setEnabled(!_model->getIfMultipleShips());
 	}
 
 	// Layer combo — always rebuild so it reflects current mission layers
@@ -271,37 +156,8 @@ void ShipEditorDialog::updateColumnOne(bool overwrite)
 	}
 	ui->layerCombo->setCurrentIndex(ui->layerCombo->findData(QString::fromStdString(_model->getLayer())));
 	ui->layerCombo->setEnabled(_model->getNumSelectedObjects() > 0);
-}
-void ShipEditorDialog::updateColumnTwo(bool overwrite)
-{
-	util::SignalBlockers blockers(this);
-	if (overwrite) {
-		ui->wing->setText(_model->getWing().c_str());
 
-		auto idx = _model->getPersona();
-		ui->personaCombo->setCurrentIndex(ui->personaCombo->findData(idx));
-
-		ui->killScoreEdit->setValue(_model->getScore());
-
-		ui->assistEdit->setValue(_model->getAssist());
-
-		ui->playerShipCheckBox->setChecked(_model->getPlayer());
-		ui->respawnSpinBox->setValue(_model->getRespawn());
-		ui->hotkeyCombo->setCurrentIndex(_model->getHotkey());
-	}
-}
-void ShipEditorDialog::updateArrival(bool overwrite)
-{
-	util::SignalBlockers blockers(this);
-	if (overwrite) {
-		auto idx = _model->getArrivalLocationIndex();
-		int i;
-		ui->arrivalLocationCombo->clear();
-		for (i = 0; i < MAX_ARRIVAL_NAMES; i++) {
-			ui->arrivalLocationCombo->addItem(Arrival_location_names[i], QVariant(i));
-		}
-		ui->arrivalLocationCombo->setCurrentIndex(ui->arrivalLocationCombo->findData(idx));
-	}
+	// Arrival target combo — contents depend on which ships are currently marked
 	object* objp;
 	int restrict_to_players;
 	ui->arrivalTargetCombo->clear();
@@ -340,53 +196,8 @@ void ShipEditorDialog::updateArrival(bool overwrite)
 		}
 	}
 	ui->arrivalTargetCombo->setCurrentIndex(ui->arrivalTargetCombo->findData(_model->getArrivalTarget()));
-	if (overwrite) {
-		ui->arrivalDistanceEdit->clear();
-		ui->arrivalDistanceEdit->setValue(_model->getArrivalDistance());
-		ui->arrivalDelaySpinBox->setValue(_model->getArrivalDelay());
 
-		ui->updateArrivalCueCheckBox->setChecked(_model->getArrivalCue());
-
-		ui->arrivalTree->initializeEditor(_viewport->editor, this, _viewport);
-		if (_model->getNumSelectedShips()) {
-
-			if (_model->getIfMultipleShips()) {
-				ui->arrivalTree->clear_tree("");
-			}
-			if (_model->getUseCue()) {
-				ui->arrivalTree->load_tree(_model->getArrivalFormula());
-				ui->arrivalTree->expandAll();
-			} else {
-				ui->arrivalTree->clear_tree("");
-			}
-			if (!_model->getIfMultipleShips()) {
-				int j = ui->arrivalTree->select_sexp_node;
-				if (j != -1) {
-					ui->arrivalTree->hilite_item(j);
-				}
-			}
-		} else {
-			ui->arrivalTree->clear_tree("");
-		}
-
-		ui->noArrivalWarpCheckBox->setCheckState(Qt::CheckState(_model->getNoArrivalWarp()));
-		ui->dockWarpinCheckBox->setCheckState(Qt::CheckState(_model->getDockWarpinChange()));
-	}
-}
-void ShipEditorDialog::updateDeparture(bool overwrite)
-{
-	util::SignalBlockers blockers(this);
-	if (overwrite) {
-		auto idx = _model->getDepartureLocationIndex();
-		int i;
-		ui->departureLocationCombo->clear();
-		for (i = 0; i < MAX_DEPARTURE_NAMES; i++) {
-			ui->departureLocationCombo->addItem(Departure_location_names[i], QVariant(i));
-		}
-		ui->departureLocationCombo->setCurrentIndex(ui->departureLocationCombo->findData(idx));
-	}
-	object* objp;
-
+	// Departure target combo — only ships with docking bays
 	ui->departureTargetCombo->clear();
 	for (objp = GET_FIRST(&obj_used_list); objp != END_OF_LIST(&obj_used_list); objp = GET_NEXT(objp)) {
 		if (((objp->type == OBJ_SHIP) || (objp->type == OBJ_START)) && !(objp->flags[Object::Object_Flags::Marked])) {
@@ -402,37 +213,173 @@ void ShipEditorDialog::updateDeparture(bool overwrite)
 		}
 	}
 	ui->departureTargetCombo->setCurrentIndex(ui->departureTargetCombo->findData(_model->getDepartureTarget()));
-	if (overwrite) {
-		ui->departureDelaySpinBox->setValue(_model->getDepartureDelay());
+}
 
-		ui->departureTree->initializeEditor(_viewport->editor, this, _viewport);
-		if (_model->getNumSelectedShips()) {
+// Overwrites every editable value from the model, including rebuilding the static
+// combos and reloading the arrival/departure sexp trees.
+void ShipEditorDialog::updateUi()
+{
+	util::SignalBlockers blockers(this);
 
-			if (_model->getIfMultipleShips()) {
-				ui->departureTree->clear_tree("");
+	// Column one
+	ui->shipNameEdit->setText(_model->getShipName().c_str());
+	ui->shipDisplayNameEdit->setText(_model->getShipDisplayName().c_str());
+
+	auto shipClass = _model->getShipClass();
+	ui->shipClassCombo->clear();
+	for (size_t i = 0; i < Ship_info.size(); i++) {
+		ui->shipClassCombo->addItem(Ship_info[i].name, QVariant(static_cast<int>(i)));
+	}
+	ui->shipClassCombo->setCurrentIndex(ui->shipClassCombo->findData(shipClass));
+
+	auto ai = _model->getAIClass();
+	ui->AIClassCombo->clear();
+	for (auto j = 0; j < Num_ai_classes; j++) {
+		ui->AIClassCombo->addItem(Ai_class_names[j], QVariant(j));
+	}
+	ui->AIClassCombo->setCurrentIndex(ui->AIClassCombo->findData(ai));
+
+	ui->teamCombo->clear();
+	if (_model->getNumSelectedPlayers()) {
+		for (auto i = 0; i < MAX_TVT_TEAMS; i++) {
+			ui->teamCombo->addItem(Iff_info[i].iff_name, QVariant(static_cast<int>(i)));
+		}
+	} else {
+		auto team = _model->getTeam();
+		for (size_t i = 0; i < Iff_info.size(); i++) {
+			ui->teamCombo->addItem(Iff_info[i].iff_name, QVariant(static_cast<int>(i)));
+		}
+		ui->teamCombo->setCurrentIndex(ui->teamCombo->findData(team));
+	}
+
+	auto cargo = _model->getCargo();
+	ui->cargoCombo->clear();
+	for (int j = 0; j < Num_cargo; j++) {
+		ui->cargoCombo->addItem(Cargo_names[j]);
+	}
+	int cargoIdx = ui->cargoCombo->findText(QString(cargo.c_str()));
+	if (cargoIdx < 0) {
+		ui->cargoCombo->addItem(cargo.c_str());
+		cargoIdx = ui->cargoCombo->count() - 1;
+	}
+	ui->cargoCombo->setCurrentIndex(cargoIdx);
+	ui->cargoTitleEdit->setText(_model->getCargoTitle().c_str());
+
+	if (_model->getNumSelectedObjects() && !_model->getIfMultipleShips()) {
+		auto altname = _model->getAltName();
+		ui->altNameCombo->clear();
+		ui->altNameCombo->addItem("<none>");
+		for (auto j = 0; j < Mission_alt_type_count; j++) {
+			ui->altNameCombo->addItem(Mission_alt_types[j]);
+		}
+		int altNameIdx = ui->altNameCombo->findText(QString(altname.c_str()));
+		if (altNameIdx >= 0) {
+			ui->altNameCombo->setCurrentIndex(altNameIdx);
+		} else {
+			ui->altNameCombo->setEditText("<none>");
+		}
+
+		auto callsign = _model->getCallsign();
+		ui->callsignCombo->clear();
+		ui->callsignCombo->addItem("<none>");
+		for (auto j = 0; j < Mission_callsign_count; j++) {
+			SCP_string current = Mission_callsigns[j];
+			ui->callsignCombo->addItem(Mission_callsigns[j], current.c_str());
+		}
+		int callsignIdx = ui->callsignCombo->findText(QString(callsign.c_str()));
+		if (callsignIdx >= 0) {
+			ui->callsignCombo->setCurrentIndex(callsignIdx);
+		} else {
+			ui->callsignCombo->setEditText("<none>");
+		}
+	}
+
+	// Column two
+	ui->wing->setText(_model->getWing().c_str());
+
+	ui->personaCombo->setCurrentIndex(ui->personaCombo->findData(_model->getPersona()));
+
+	ui->killScoreEdit->setValue(_model->getScore());
+	ui->assistEdit->setValue(_model->getAssist());
+
+	ui->playerShipCheckBox->setChecked(_model->getPlayer());
+	ui->respawnSpinBox->setValue(_model->getRespawn());
+	ui->hotkeyCombo->setCurrentIndex(_model->getHotkey());
+
+	// Arrival
+	auto arrivalLocation = _model->getArrivalLocationIndex();
+	ui->arrivalLocationCombo->clear();
+	for (int i = 0; i < MAX_ARRIVAL_NAMES; i++) {
+		ui->arrivalLocationCombo->addItem(Arrival_location_names[i], QVariant(i));
+	}
+	ui->arrivalLocationCombo->setCurrentIndex(ui->arrivalLocationCombo->findData(arrivalLocation));
+
+	ui->arrivalDistanceEdit->clear();
+	ui->arrivalDistanceEdit->setValue(_model->getArrivalDistance());
+	ui->arrivalDelaySpinBox->setValue(_model->getArrivalDelay());
+
+	ui->updateArrivalCueCheckBox->setChecked(_model->getArrivalCue());
+
+	ui->arrivalTree->initializeEditor(_viewport->editor, this, _viewport);
+	if (_model->getNumSelectedShips()) {
+		if (_model->getIfMultipleShips()) {
+			ui->arrivalTree->clear_tree("");
+		}
+		if (_model->getUseCue()) {
+			ui->arrivalTree->load_tree(_model->getArrivalFormula());
+			ui->arrivalTree->expandAll();
+		} else {
+			ui->arrivalTree->clear_tree("");
+		}
+		if (!_model->getIfMultipleShips()) {
+			int j = ui->arrivalTree->select_sexp_node;
+			if (j != -1) {
+				ui->arrivalTree->hilite_item(j);
 			}
-			if (_model->getUseCue()) {
-				ui->departureTree->load_tree(_model->getDepartureFormula(), "false");
-				ui->departureTree->expandAll();
-			} else {
-				ui->departureTree->clear_tree("");
-			}
-			if (!_model->getIfMultipleShips()) {
-				auto i = ui->arrivalTree->select_sexp_node;
-				if (i != -1) {
-					i = ui->departureTree->select_sexp_node;
-					ui->departureTree->hilite_item(i);
-				}
-			}
+		}
+	} else {
+		ui->arrivalTree->clear_tree("");
+	}
+
+	ui->noArrivalWarpCheckBox->setCheckState(Qt::CheckState(_model->getNoArrivalWarp()));
+	ui->dockWarpinCheckBox->setCheckState(Qt::CheckState(_model->getDockWarpinChange()));
+
+	// Departure
+	auto departureLocation = _model->getDepartureLocationIndex();
+	ui->departureLocationCombo->clear();
+	for (int i = 0; i < MAX_DEPARTURE_NAMES; i++) {
+		ui->departureLocationCombo->addItem(Departure_location_names[i], QVariant(i));
+	}
+	ui->departureLocationCombo->setCurrentIndex(ui->departureLocationCombo->findData(departureLocation));
+
+	ui->departureDelaySpinBox->setValue(_model->getDepartureDelay());
+
+	ui->departureTree->initializeEditor(_viewport->editor, this, _viewport);
+	if (_model->getNumSelectedShips()) {
+		if (_model->getIfMultipleShips()) {
+			ui->departureTree->clear_tree("");
+		}
+		if (_model->getUseCue()) {
+			ui->departureTree->load_tree(_model->getDepartureFormula(), "false");
+			ui->departureTree->expandAll();
 		} else {
 			ui->departureTree->clear_tree("");
 		}
-
-		ui->noDepartureWarpCheckBox->setCheckState(Qt::CheckState(_model->getNoDepartureWarp()));
-		ui->dockWarpoutCheckBox->setCheckState(Qt::CheckState(_model->getDockWarpoutChange()));
-
-		ui->updateDepartureCueCheckBox->setChecked(_model->getDepartureCue());
+		if (!_model->getIfMultipleShips()) {
+			auto i = ui->arrivalTree->select_sexp_node;
+			if (i != -1) {
+				i = ui->departureTree->select_sexp_node;
+				ui->departureTree->hilite_item(i);
+			}
+		}
+	} else {
+		ui->departureTree->clear_tree("");
 	}
+
+	ui->noDepartureWarpCheckBox->setCheckState(Qt::CheckState(_model->getNoDepartureWarp()));
+	ui->dockWarpoutCheckBox->setCheckState(Qt::CheckState(_model->getDockWarpoutChange()));
+
+	ui->updateDepartureCueCheckBox->setChecked(_model->getDepartureCue());
 }
 // Enables disbales controls based on what is selected
 void ShipEditorDialog::enableDisable()

--- a/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
+++ b/qtfred/src/ui/dialogs/ShipEditor/ShipEditorDialog.h
@@ -32,10 +32,6 @@ class ShipEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	int getSingleShip() const;
 	bool getIfMultipleShips() const;
 
-  protected:
-	void closeEvent(QCloseEvent*) override;
-	void hideEvent(QHideEvent*) override;
-	void showEvent(QShowEvent*) override;
   private slots:
 
 	void on_textureReplacementButton_clicked();
@@ -103,13 +99,8 @@ class ShipEditorDialog : public QDialog, public SexpTreeEditorInterface {
 
 	bool _cues_hidden = false;
 
-	void update();
-
-	void updateUi(bool overwrite = false);
-	void updateColumnOne(bool overwrite = false);
-	void updateColumnTwo(bool ovewrite = false);
-	void updateArrival(bool overwrite = false);
-	void updateDeparture(bool overwrite = false);
+	void initializeUi();
+	void updateUi();
 	void enableDisable();
 
 	// column one

--- a/qtfred/src/ui/dialogs/WingEditorDialog.cpp
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.cpp
@@ -1,5 +1,4 @@
 #include "WingEditorDialog.h"
-#include <QCloseEvent>
 #include "General/CheckBoxListDialog.h"
 #include "General/ImagePickerDialog.h"
 #include "ShipEditor/ShipGoalsDialog.h"
@@ -34,7 +33,7 @@ WingEditorDialog::WingEditorDialog(FredView* parent, EditorViewport* viewport)
 	// Whenever the model reports changes, refresh the UI
 	connect(_model.get(), &AbstractDialogModel::modelChanged, this, &WingEditorDialog::updateUi);
 	connect(_model.get(), &WingEditorDialogModel::wingChanged, this, [this] {
-		refreshAllDynamicCombos();
+		initializeUi();
 		updateUi();
 	});
 
@@ -62,7 +61,7 @@ WingEditorDialog::WingEditorDialog(FredView* parent, EditorViewport* viewport)
 		[editor](int wing) { editor->mark_wing(wing); },
 		tr("&Select Wing"));
 
-	refreshAllDynamicCombos();
+	initializeUi();
 	updateUi();
 
 	// Resize the dialog to the minimum size
@@ -70,11 +69,6 @@ WingEditorDialog::WingEditorDialog(FredView* parent, EditorViewport* viewport)
 }
 
 WingEditorDialog::~WingEditorDialog() = default;
-
-void WingEditorDialog::closeEvent(QCloseEvent* e)
-{
-	QDialog::closeEvent(e);
-}
 
 void WingEditorDialog::updateUi()
 {
@@ -358,7 +352,7 @@ void WingEditorDialog::refreshDepartureTargetCombo()
 	}
 }
 
-void WingEditorDialog::refreshAllDynamicCombos()
+void WingEditorDialog::initializeUi()
 {
 	refreshLeaderCombo();
 	refreshHotkeyCombo();

--- a/qtfred/src/ui/dialogs/WingEditorDialog.h
+++ b/qtfred/src/ui/dialogs/WingEditorDialog.h
@@ -72,9 +72,6 @@ class WingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	void on_departureTree_helpChanged(const QString& help);
 	void on_departureTree_miniHelpChanged(const QString& help);
 
-  protected:
-	void closeEvent(QCloseEvent* e) override;
-
   private: // NOLINT(readability-redundant-access-specifiers)
 	std::unique_ptr<Ui::WingEditorDialog> ui;
 	std::unique_ptr<WingEditorDialogModel> _model;
@@ -82,6 +79,7 @@ class WingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 
 	bool _cues_hidden = false;
 
+	void initializeUi();
 	void updateUi();
 	void enableOrDisableControls();
 
@@ -96,7 +94,6 @@ class WingEditorDialog : public QDialog, public SexpTreeEditorInterface {
 	void refreshDepartureLocationCombo();
 	void refreshArrivalTargetCombo();
 	void refreshDepartureTargetCombo();
-	void refreshAllDynamicCombos();
 
 	void updateLogoPreview();
 };


### PR DESCRIPTION
This PR fixes a freeze when cycling wings with the Ship Editor open: bulk selection changes fire objectMarkingChanged once per object, and each signal triggered a full dialog rebuild. All selection-driven dialog models (Ship, Wing, Prop, JumpNode, Waypoint, Scene Browser) now coalesce these bursts into a single deferred refresh. 

This snowballed into making the Ship Editor aligned with the newer object-dialog architecture: the model owns the Editor subscriptions and emits shipMarkingChanged, while the dialog's legacy updateUi(bool overwrite) + updateColumn* methods were flattened into the canonical initializeUi()/updateUi() split used by the other object dialogs. Style cleanup removed the trivial closeEvent/hideEvent/showEvent overrides (which caused a redundant double-init on every open) and renamed the Wing Editor's refreshAllDynamicCombos() to initializeUi() to match.

Also fixed a latent cargo-combo bug where findText()'s index was tested as a boolean, leaving the combo blank for custom cargo and duplicating the first entry when the cargo matched it.