### PR TITLE
fix uniform type mismatch error in shadow_map shader

### DIFF
--- a/code/def_files/data/effects/shadow_map-g.sdr
+++ b/code/def_files/data/effects/shadow_map-g.sdr
@@ -10,6 +10,8 @@ layout(invocations = NUM_SHADOW_CASCADES) in;
 layout (std140) uniform shadowCascadeParams {
     int cascade_offset;
     int cascade_count;
+    float rtShadowBiasMin;
+    float rtShadowBiasMax;
 
 	mat4 shadow_mv_matrix;
 	mat4 shadow_proj_matrix[NUM_SHADOW_CASCADES];


### PR DESCRIPTION
Fixes error loading tech room on macOS in OpenGL mode. Vulkan mode didn't seem to care one way or the other.